### PR TITLE
Fix typo on readme: utils.jpeg -> utils.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ def extract_queries(file_path):
 │   ├── operate.py
 │   ├── prompt.py
 │   ├── storage.py
-│   └── utils.jpeg
+│   └── utils.py
 ├── reproduce
 │   ├── Step_0.py
 │   ├── Step_1.py


### PR DESCRIPTION
In the readme for the repository, there is a reference to the utils.jpeg file, but the correct file extension is .py

Edit:
Fixes #5 