### PR TITLE
Prerequisites Poetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,14 @@ This repository hosts the code of LightRAG. The structure of this code is based 
 
 ## Install
 
+Prerequisites
+- Poetry must be installed (refer to the Poetry documentation for installation instructions).
+
 * Install from source (Recommend)
 
 ```bash
 cd LightRAG
+init poetry
 pip install -e .
 ```
 * Install from PyPI


### PR DESCRIPTION
When I started using the repository I didn't have poetry installed, which wasn't mentioned in the readme.

Basically I added this:

Prerequisites
Poetry must be installed (refer to the [Poetry documentation](https://python-poetry.org/docs/) for installation instructions).