### PR TITLE
fix(lightrag_siliconcloud_demo.py): max_token_size

### DIFF
--- a/examples/lightrag_siliconcloud_demo.py
+++ b/examples/lightrag_siliconcloud_demo.py
@@ -30,7 +30,7 @@ async def embedding_func(texts: list[str]) -> np.ndarray:
         texts,
         model="netease-youdao/bce-embedding-base_v1",
         api_key=os.getenv("UPSTAGE_API_KEY"),
-        max_token_size=int(512 * 1.5)
+        max_token_size=512
     )
 
 


### PR DESCRIPTION
bce 底层用的 512 token （转中文大约 1.5 倍）

参数 assign 错了，给太长会报错。