### PR TITLE
[FIX] fix hf output bug (current output contain user prompt which cause logical error in entity extraction phase)

### DIFF
--- a/lightrag/llm.py
+++ b/lightrag/llm.py
@@ -266,10 +266,11 @@ async def hf_model_if_cache(
     input_ids = hf_tokenizer(
         input_prompt, return_tensors="pt", padding=True, truncation=True
     ).to("cuda")
+    inputs = {k: v.to(hf_model.device) for k, v in input_ids.items()}
     output = hf_model.generate(
         **input_ids, max_new_tokens=200, num_return_sequences=1, early_stopping=True
     )
-    response_text = hf_tokenizer.decode(output[0], skip_special_tokens=True)
+    response_text = hf_tokenizer.decode(output[0][len(inputs["input_ids"][0]):], skip_special_tokens=True)
     if hashing_kv is not None:
         await hashing_kv.upsert({args_hash: {"return": response_text, "model": model}})
     return response_text

--- a/lightrag/llm.py
+++ b/lightrag/llm.py
@@ -268,7 +268,7 @@ async def hf_model_if_cache(
     ).to("cuda")
     inputs = {k: v.to(hf_model.device) for k, v in input_ids.items()}
     output = hf_model.generate(
-        **input_ids, max_new_tokens=200, num_return_sequences=1, early_stopping=True
+        **input_ids, max_new_tokens=512, num_return_sequences=1, early_stopping=True
     )
     response_text = hf_tokenizer.decode(output[0][len(inputs["input_ids"][0]):], skip_special_tokens=True)
     if hashing_kv is not None:


### PR DESCRIPTION
- the current `response_text` in `hf_model_if_cache` will contain user prompt as shown as follows:
![image](https://github.com/user-attachments/assets/1f8b04a5-8f4f-4d6d-9a4f-e557e90a0253)

-  even though the response_text is being stripped in `operate.py` which make the final response look like normally, but in the process of creating the knowledge graph and vector databse (entity extraction phase), the user prompt is not strip, which will result the prompt `PROMPTS["entity_extraction"]` in `prompt.py` will also consider as assitant response as well and causes the entity in example prompt is being extracted, but these entity is not actually in the text file (pure text database), instead, it just an example entity.

- what does thir pr do: remove user prompt in response as shown as follows:
![8933b3a26fef0bed0bab6ae8ad2c5ef](https://github.com/user-attachments/assets/4f69a86e-128c-4f49-81fd-78612a7cb0ee)
