### PR TITLE
fix neo4j bug

### DIFF
--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -214,6 +214,7 @@ class Neo4JStorage(BaseGraphStorage):
                 neo4jExceptions.ServiceUnavailable,
                 neo4jExceptions.TransientError,
                 neo4jExceptions.WriteServiceUnavailable,
+                neo4jExceptions.ClientError
             )
         ),
     )

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -174,8 +174,7 @@ class LightRAG:
         )
         self.chunk_entity_relation_graph = self.graph_storage_cls(
             namespace="chunk_entity_relation",
-            global_config=asdict(self),
-            embedding_func=self.embedding_func,
+            global_config=asdict(self)
         )
         ####
         # add embedding func by walter over


### PR DESCRIPTION
fix the bug which describe in issue #269, and I found neo4j would threw ClientError when thread pool is overload. so I add a retry Exception by the way.

修复了#269 问题，然后我发现当线程池不够用的时候，neo4j会抛出ClientError，所以顺手加了一个重试的异常