### PR TITLE
A more robust approach for result to json.

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -418,7 +418,7 @@ async def local_query(
                 .replace("model", "")
                 .strip()
             )
-            result = "{" + result.split("{")[1].split("}")[0] + "}"
+            result = "{" + result.split("{")[-1].split("}")[0] + "}"
 
             keywords_data = json.loads(result)
             keywords = keywords_data.get("low_level_keywords", [])
@@ -691,7 +691,7 @@ async def global_query(
                 .replace("model", "")
                 .strip()
             )
-            result = "{" + result.split("{")[1].split("}")[0] + "}"
+            result = "{" + result.split("{")[-1].split("}")[0] + "}"
 
             keywords_data = json.loads(result)
             keywords = keywords_data.get("high_level_keywords", [])
@@ -940,7 +940,7 @@ async def hybrid_query(
                 .replace("model", "")
                 .strip()
             )
-            result = "{" + result.split("{")[1].split("}")[0] + "}"
+            result = "{" + result.split("{")[-1].split("}")[0] + "}"
             keywords_data = json.loads(result)
             hl_keywords = keywords_data.get("high_level_keywords", [])
             ll_keywords = keywords_data.get("low_level_keywords", [])


### PR DESCRIPTION
When I using LightRAG, my model will generate **text below** for keyword extraction, it contains two `"{"`, when using `"{" + result.split("{")[1].split("}")[0] + "}"`, it fails, but using `"{" + result.split("{")[-1].split("}")[0] + "}"` is ok, and the original expectation still achieved.

### Keyword Extraction

To extract high-level and low-level keywords from the given query, we will use Natural Language Processing (NLP) techniques.

```python
import json
import re

def extract_keywords(query):
    # Convert query to lowercase
    query = query.lower()

    # Tokenize the query
    tokens = re.findall(r'\b\w+\b', query)

    # Identify high-level keywords
    high_level_keywords = []
    low_level_keywords = []
    stop_words = ['the', 'and', 'a', 'an', 'in', 'on', 'at', 'by', 'with']

    for token in tokens:
        if token not in stop_words:
            if len(token.split()) > 1:
                high_level_keywords.append(token)
            else:
                low_level_keywords.append(token)

    # Remove duplicates from high-level and low-level keywords
    high_level_keywords = list(set(high_level_keywords))
    low_level_keywords = list(set(low_level_keywords))

    # Return the keywords in JSON format
    return {
        "high_level_keywords": high_level_keywords,
        "low_level_keywords": low_level_keywords
    }

query = "How did urbanization influence the average household size in Bhubaneswar?"
result = extract_keywords(query)

print(json.dumps(result, indent=4))
```

### Output:

```json
{
    "high_level_keywords": ["Urbanization", "Average household size"],
    "low_level_keywords": ["Influence", "Bhubaneswar"]
}
```

This script first tokenizes the query into individual words and then identifies high-level and low-level keywords. High-level keywords are phrases with multiple words, while low-level keywords are single words. The `stop_words` list is used to exclude common words like "the", "and", etc. that do not add much value to the query. The output is in JSON format, with two keys: `high_level_keywords` and `low_level_keywords`.