### PR TITLE
fix: 修改了local search中的relation_counts计数规则

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -578,24 +578,20 @@ async def _find_most_related_text_unit_from_entities(
     all_text_units_lookup = {}
     for index, (this_text_units, this_edges) in enumerate(zip(text_units, edges)):
         for c_id in this_text_units:
-            if c_id in all_text_units_lookup:
-                continue
-            relation_counts = 0
-            if this_edges:  # Add check for None edges
+            if c_id not in all_text_units_lookup:
+                all_text_units_lookup[c_id] = {
+                    "data": await text_chunks_db.get_by_id(c_id),
+                    "order": index,
+                    "relation_counts": 0,
+                }
+
+            if this_edges:
                 for e in this_edges:
                     if (
                         e[1] in all_one_hop_text_units_lookup
                         and c_id in all_one_hop_text_units_lookup[e[1]]
                     ):
-                        relation_counts += 1
-
-            chunk_data = await text_chunks_db.get_by_id(c_id)
-            if chunk_data is not None and "content" in chunk_data:  # Add content check
-                all_text_units_lookup[c_id] = {
-                    "data": chunk_data,
-                    "order": index,
-                    "relation_counts": relation_counts,
-                }
+                        all_text_units_lookup[c_id]["relation_counts"] += 1
 
     # Filter out None values and ensure data has content
     all_text_units = [


### PR DESCRIPTION
您好，看到您的项目对我很有启发。但我在使用 local search 时，发现源码中`/LightRAG/lightrag/operate.py`  在召回实体最相关文本单元`_find_most_related_text_unit_from_entities`函数的时候，为了对文本单元重要性进行排序所使用到了relation_counts。
但在现有的逻辑中，如果一个文本单元c_id与多个实体节点相关联，且这些实体节点的一跳相邻节点数量不同，那么先遍历到一跳相邻节点少的实体节点时，relation_counts可能会被低估。
所以我修改为：在每次遍历时更新relation_counts，而不是跳过已经存在的文本单元。