### PR TITLE
Update NanoVectorDBStorage upsert to use hash values for IDs

### DIFF
--- a/lightrag/storage.py
+++ b/lightrag/storage.py
@@ -86,7 +86,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
             return []
         list_data = [
             {
-                "__id__": k,
+                "__id__": compute_mdhash_id(k, prefix="ent-"),
                 **{k1: v1 for k1, v1 in v.items() if k1 in self.meta_fields},
             }
             for k, v in data.items()


### PR DESCRIPTION
- In the delete_entity method, a hash value is calculated when deleting an entity.
- On the other hand, in the upsert method, the index was used directly as the ID when adding an entity.
- Therefore, I modified the upsert method to also calculate a hash value.