### PR TITLE
fix examples' prompt bug

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -264,6 +264,16 @@ async def extract_entities(
     else:
         examples = "\n".join(PROMPTS["entity_extraction_examples"])
 
+    example_context_base = dict(
+        tuple_delimiter=PROMPTS["DEFAULT_TUPLE_DELIMITER"],
+        record_delimiter=PROMPTS["DEFAULT_RECORD_DELIMITER"],
+        completion_delimiter=PROMPTS["DEFAULT_COMPLETION_DELIMITER"],
+        entity_types=",".join(PROMPTS["DEFAULT_ENTITY_TYPES"]),
+        language=language,
+    )
+    # add example's format
+    examples = examples.format(**example_context_base)
+
     entity_extract_prompt = PROMPTS["entity_extraction"]
     context_base = dict(
         tuple_delimiter=PROMPTS["DEFAULT_TUPLE_DELIMITER"],

--- a/lightrag/prompt.py
+++ b/lightrag/prompt.py
@@ -19,7 +19,7 @@ Use {language} as output language.
 - entity_name: Name of the entity, use same language as input text. If English, capitalized the name.
 - entity_type: One of the following types: [{entity_types}]
 - entity_description: Comprehensive description of the entity's attributes and activities
-Format each entity as ("entity"{tuple_delimiter}<entity_name>{tuple_delimiter}<entity_type>{tuple_delimiter}<entity_description>
+Format each entity as ("entity"{tuple_delimiter}<entity_name>{tuple_delimiter}<entity_type>{tuple_delimiter}<entity_description>)
 
 2. From the entities identified in step 1, identify all pairs of (source_entity, target_entity) that are *clearly related* to each other.
 For each pair of related entities, extract the following information:


### PR DESCRIPTION
1. examples in the latest main branch was changed to be cutomizable, but a bug was introduced, that the string literal format is missing for the `PROMPTS["entity_extraction_examples"` in `lightrag/prompt.py` . It is directly used in the line 265 of `lightrag/operate.py` without formating.
2. fixed a typo (missing right bracket) in the system prompt for entity extraction.

