### PR TITLE
fix: add embedding_func to graph storage initialization

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -186,7 +186,9 @@ class LightRAG:
             embedding_func=self.embedding_func,
         )
         self.chunk_entity_relation_graph = self.graph_storage_cls(
-            namespace="chunk_entity_relation", global_config=asdict(self)
+            namespace="chunk_entity_relation",
+            global_config=asdict(self),
+            embedding_func=self.embedding_func
         )
         ####
         # add embedding func by walter over


### PR DESCRIPTION
The Neo4JStorage backend requires an embedding_func parameter for initialization, but it was missing in the chunk_entity_relation_graph initialization. This caused a TypeError when using Neo4J as the graph storage backend:

TypeError: Neo4JStorage.__init__() missing 1 required positional
argument: 'embedding_func'

This commit adds the embedding_func parameter to ensure compatibility with Neo4J and other graph storage backends that may require vector operations on nodes or relationships.