### PR TITLE
修改日志文件路径

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -133,7 +133,7 @@ class LightRAG:
     convert_response_to_json_func: callable = convert_response_to_json
 
     def __post_init__(self):
-        log_file = os.path.join(self.working_dir, "lightrag.log")
+        log_file = os.path.join("lightrag.log")
         set_logger(log_file)
         logger.setLevel(self.log_level)
 


### PR DESCRIPTION
- 因为LightRAG的几乎都是导入的utils中的全局logger对象，当多个rag实例的时候并无法完全把日志记录到对应的working_dir,并且应用中删除working_dir时会由于logger的句柄无法删除
- 此修改简化了日志文件的路径，不再依赖于 working_dir 属性，日志文件独立于working_dir
- 这样实际使用中可以多个不同主题的文件集可以按照working_dir来分开构建知识图谱避免互相影响。