### PR TITLE
fix: example llm_model_func unexpected keyword argument error

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,10 @@ print(rag.query("What are the top themes in this story?", param=QueryParam(mode=
 * LightRAG also supports Open AI-like chat/embeddings APIs:
 ```python
 async def llm_model_func(
-    prompt, system_prompt=None, history_messages=[], **kwargs
+    prompt, system_prompt=None, history_messages=[], keyword_extraction=False, **kwargs
 ) -> str:
+    if keyword_extraction:
+        kwargs["response_format"] = GPTKeywordExtractionFormat
     return await openai_complete_if_cache(
         "solar-mini",
         prompt,


### PR DESCRIPTION
- If the keyword_extraction argument is not passed explicitly, it is passed as kwargs to the `openai_async_client.chat.completions.create` function. Raised an error `TypeError: AsyncCompletions.create() got an unexpected keyword argument 'keyword_extraction'`.
- how to fix: add the `keyword_extraction` parameter just like implementations such as `gpt_4o_mini_complete`.