### PR TITLE
fix(llm): 移除 openai_complete_if_cache 调用中的 keyword_extraction 参数

### DIFF
--- a/lightrag/llm.py
+++ b/lightrag/llm.py
@@ -59,6 +59,9 @@ async def openai_complete_if_cache(
         AsyncOpenAI() if base_url is None else AsyncOpenAI(base_url=base_url)
     )
     hashing_kv: BaseKVStorage = kwargs.pop("hashing_kv", None)
+    # 从kwargs中移除keyword_extraction参数，对于使用openai_complete_if_cache来调用openai接口风格自定义的模型，
+    # 如果调用时指定了keyword_extraction=True，则会导致openai的模型无法正常工作
+    kwargs.pop("keyword_extraction", None)
     messages = []
     if system_prompt:
         messages.append({"role": "system", "content": system_prompt})


### PR DESCRIPTION
- 从 kwargs 中移除 keyword_extraction 参数，以解决在使用 openai 接口风格自定义模型时指定 keyword_extraction=True 导致的 openai 模型无法正常工作的问题