### PR TITLE
refactor(lightrag): hashing_kv初始化

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -252,7 +252,10 @@ class LightRAG:
         self.llm_model_func = limit_async_func_call(self.llm_model_max_async)(
             partial(
                 self.llm_model_func,
-                hashing_kv=self.llm_response_cache,
+                hashing_kv=self.llm_response_cache if self.llm_response_cache and hasattr(self.llm_response_cache,
+                                                                                          'global_config') else self.key_string_value_json_storage_cls(
+                    global_config=asdict(self),
+                ),
                 **self.llm_model_kwargs,
             )
         )
@@ -515,7 +518,10 @@ class LightRAG:
                 self.text_chunks,
                 param,
                 asdict(self),
-                hashing_kv=self.llm_response_cache,
+                hashing_kv=self.llm_response_cache if self.llm_response_cache and hasattr(self.llm_response_cache,
+                                                                                          'global_config') else self.key_string_value_json_storage_cls(
+                    global_config=asdict(self),
+                ),
             )
         elif param.mode == "naive":
             response = await naive_query(
@@ -524,7 +530,10 @@ class LightRAG:
                 self.text_chunks,
                 param,
                 asdict(self),
-                hashing_kv=self.llm_response_cache,
+                hashing_kv=self.llm_response_cache if self.llm_response_cache and hasattr(self.llm_response_cache,
+                                                                                          'global_config') else self.key_string_value_json_storage_cls(
+                    global_config=asdict(self),
+                ),
             )
         else:
             raise ValueError(f"Unknown mode {param.mode}")


### PR DESCRIPTION
修改背景：enable_llm_cache=False时，lightRag.py 的 llm_response_cache 赋值None
但是，所有query的hashing_kv初始化依赖于 llm_response_cache ，所有查询函数的参数传递依赖于hashing_kv，
最终报错点位于 llm.py 中所有 xxx_model_complete 方法需要依赖hashing_kv获取model_name。
考虑到项目对hashing_kv的使用，最终选择优化hashing_kv初始化逻辑

- 修改了 llm_model_func 和 query 方法中的hashing_kv初始化逻辑
- 当 self.llm_response_cache 不存在或没有 global_config 属性时，会创建一个新的hashing_kv实例
- 所有基于hashing_kv获取global_config属性的对象可以正常运行

Background: When enable_llm_cache=False, llm_response_cache of lightRag.py is set to None
However, the hashing_kv initialization of all queries depends on llm_response_cache, and the parameter passing of all query functions depends on hashing_kv.
The final error point is located in llm.py. All xxx_model_complete methods rely on hashing_kv to get model_name.
Considering the project's use of hashing_kv, the final choice was to optimize the hashing_kv initialization logic

- Changed the hashing_kv initialization logic in the llm_model_func and query methods
- When self.llm_response_cache does not exist or there is no global_config attribute, a new hashing_kv instance is created
- All objects that obtain the global_config attribute based on hashing_kv can run properly