### PR TITLE
fix keywords_extraction_examples format error

### DIFF
--- a/lightrag/prompt.py
+++ b/lightrag/prompt.py
@@ -211,30 +211,30 @@ PROMPTS["keywords_extraction_examples"] = [
 Query: "How does international trade influence global economic stability?"
 ################
 Output:
-{{
+{
   "high_level_keywords": ["International trade", "Global economic stability", "Economic impact"],
   "low_level_keywords": ["Trade agreements", "Tariffs", "Currency exchange", "Imports", "Exports"]
-}}
+}
 #############################""",
     """Example 2:
 
 Query: "What are the environmental consequences of deforestation on biodiversity?"
 ################
 Output:
-{{
+{
   "high_level_keywords": ["Environmental consequences", "Deforestation", "Biodiversity loss"],
   "low_level_keywords": ["Species extinction", "Habitat destruction", "Carbon emissions", "Rainforest", "Ecosystem"]
-}}
+}
 #############################""",
     """Example 3:
 
 Query: "What is the role of education in reducing poverty?"
 ################
 Output:
-{{
+{
   "high_level_keywords": ["Education", "Poverty reduction", "Socioeconomic development"],
   "low_level_keywords": ["School access", "Literacy rates", "Job training", "Income inequality"]
-}}
+}
 #############################""",
 ]
 


### PR DESCRIPTION
hi, thanks for your great work. 
when I ran lightrag_azure_openai_demo.py, 
I found that there were some problems with the format of ‘keywords_extraction_examples’. 
```
{{
"high_level_keywords": ["International trade", "Global economic stability", "Economic impact"],
"low_level_keywords": ["Trade agreements", "Tariffs", "Currency exchange", "Imports", "Exports"]
}}
```
 it  caused unexpected output.
![image](https://github.com/user-attachments/assets/a7697cae-88ba-496a-8ed9-8ca555c2c3b2)

I fixed the format of keywords_extraction_examples and it seems to work well now.
![image](https://github.com/user-attachments/assets/6a149e0b-6b74-4b8d-9151-3a724f10d8e3)
