### PR TITLE
Fix the async issue while running on Windows

### DIFF
--- a/lightrag/kg/age_impl.py
+++ b/lightrag/kg/age_impl.py
@@ -1,7 +1,7 @@
 import asyncio
 import inspect
 import json
-import os
+import os, sys
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
@@ -20,6 +20,9 @@ from lightrag.utils import logger
 
 from ..base import BaseGraphStorage
 
+if sys.platform.startswith("win"):
+    import asyncio.windows_events
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 class AGEQueryException(Exception):
     """Exception for the AGE queries."""


### PR DESCRIPTION
When running with Apache AGE impl on Windows (with psycopg), it will got async loop error, the fix is to register asyncio with WindowsSelectorEventLoopPolicy. Only effect on Windows. Tested okay.