### PR TITLE
Restore backwards compatibility for LightRAG's ainsert method

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -320,7 +320,7 @@ class LightRAG:
             self.ainsert(string_or_strings, split_by_character)
         )
 
-    async def ainsert(self, string_or_strings, split_by_character):
+    async def ainsert(self, string_or_strings, split_by_character=None):
         """Insert documents with checkpoint support
 
         Args:


### PR DESCRIPTION
Makes the split_by_character parameter optional in ainsert method to maintain backwards compatibility with existing code.

Details:

The ainsert method in LightRAG class was recently modified to include a new split_by_character parameter
This change broke backwards compatibility for code using the previous method signature
Fixed by making split_by_character parameter optional with a default value of None
Impact:

Restores compatibility with existing code using the old method signature
Maintains new functionality for users who want to use character splitting
No breaking changes