### PR TITLE
Fix: docker build 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,15 @@ WORKDIR /app
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    curl \
+    pkg-config \
+    libssl-dev \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+    && . "$HOME/.cargo/env" \
+    && rustup default stable \
     && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Copy only requirements files first to leverage Docker cache
 COPY requirements.txt .


### PR DESCRIPTION
## What

To fix docker build failure, add rust toolchain

## Why

When we build container, it'll fail due to a lack of rust toolchain.

```
[+] Building 21.0s (10/17)                                                                                docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                      0.0s
 => => transferring dockerfile: 1.07kB                                                                                    0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)                                            0.0s
 => [internal] load metadata for docker.io/library/python:3.11-slim                                                       0.8s
 => [internal] load .dockerignore                                                                                         0.0s
 => => transferring context: 2B                                                                                           0.0s
 => [internal] load build context                                                                                         0.0s
 => => transferring context: 4.09kB                                                                                       0.0s
 => [builder 1/7] FROM docker.io/library/python:3.11-slim@sha256:6ed5bff4d7d377e2a27d9285553b8c21cfccc4f00881de1b24c9bc8  1.1s
 => => resolve docker.io/library/python:3.11-slim@sha256:6ed5bff4d7d377e2a27d9285553b8c21cfccc4f00881de1b24c9bc8d90016e8  0.0s
 => => sha256:8c2bfb64ec8eed5b02227a699c0eefcaf56f703acb33deecd0f389278c356b42 16.13MB / 16.13MB                          0.9s
 => => sha256:1c510bbba8451812391d414bbe2506eeb4b2c5bed5906900f20acc9b034c9df0 249B / 249B                                0.2s
 => => extracting sha256:8c2bfb64ec8eed5b02227a699c0eefcaf56f703acb33deecd0f389278c356b42                                 0.2s
 => => extracting sha256:1c510bbba8451812391d414bbe2506eeb4b2c5bed5906900f20acc9b034c9df0                                 0.0s
 => [builder 2/7] WORKDIR /app                                                                                            0.0s
 => [builder 3/7] RUN apt-get update && apt-get install -y --no-install-recommends     build-essential     && rm -rf /va  8.9s
 => [builder 4/7] COPY requirements.txt .                                                                                 0.0s
 => [builder 5/7] COPY lightrag/api/requirements.txt ./lightrag/api/                                                      0.0s
 => ERROR [builder 6/7] RUN pip install --user --no-cache-dir -r requirements.txt                                        10.2s
------
 > [builder 6/7] RUN pip install --user --no-cache-dir -r requirements.txt:
....
....
9.521   × Preparing metadata (pyproject.toml) did not run successfully.
9.521   │ exit code: 1
9.521   ╰─> [6 lines of output]
9.521
9.521       Cargo, the Rust package manager, is not installed or is not on PATH.
9.521       This package requires Rust and Cargo to compile extensions. Install it through
9.521       the system's package manager or via https://rustup.rs/
9.521
9.521       Checking for Rust toolchain....
9.521       [end of output]
```