### PR TITLE
add "azure_openai" in llm_binding and embedding_binding

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -551,10 +551,10 @@ def get_api_key_dependency(api_key: Optional[str]):
 
 def create_app(args):
     # Verify that bindings arer correctly setup
-    if args.llm_binding not in ["lollms", "ollama", "openai"]:
+    if args.llm_binding not in ["lollms", "ollama", "openai", "azure_openai"]:
         raise Exception("llm binding not supported")
 
-    if args.embedding_binding not in ["lollms", "ollama", "openai"]:
+    if args.embedding_binding not in ["lollms", "ollama", "openai", "azure_openai"]:
         raise Exception("embedding binding not supported")
 
     # Add SSL validation


### PR DESCRIPTION
LightRAG support `llm_binding.azure_openai` but due to incorrect condition, we cant use AzureOpenAI currently.
This PR fix it.