### PR TITLE
Fixed workspace matching in oracle_impl.py

### DIFF
--- a/lightrag/kg/oracle_impl.py
+++ b/lightrag/kg/oracle_impl.py
@@ -769,7 +769,7 @@ SQL_TEMPLATES = {
         COLUMNS (e.source_name,e.target_name)  )""",
     "node_degree": """SELECT count(1) as degree FROM GRAPH_TABLE (lightrag_graph
         MATCH (a)-[e]->(b)
-        WHERE a.workspace=:workspace and a.workspace=:workspace and b.workspace=:workspace
+        WHERE e.workspace=:workspace and a.workspace=:workspace and b.workspace=:workspace
         AND a.name=:node_id or b.name = :node_id
         COLUMNS (a.name))""",
     "get_node": """SELECT t1.name,t2.entity_type,t2.source_chunk_id as source_id,NVL(t2.description,'') AS description


### PR DESCRIPTION
In the query for `node_degree`, there was a typo that did not match the workspace of the edges, but only of the nodes. The condition `a.workspace = :workspace` was therefore checked twice.