### PR TITLE
Fix: WebUI Auth

### DIFF
--- a/lightrag/api/static/index.html
+++ b/lightrag/api/static/index.html
@@ -486,7 +486,7 @@
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${localStorage.getItem('apiKey') || ''}`
+                    'X-API-Key': `${localStorage.getItem('apiKey') || ''}`
                 },
                 body: JSON.stringify({ query })
             });

--- a/lightrag/api/static/index.html
+++ b/lightrag/api/static/index.html
@@ -679,7 +679,7 @@
           const response = await fetch('/documents/upload', {
             method: 'POST',
             headers: {
-              'Authorization': `Bearer ${localStorage.getItem('apiKey')}`
+              'X-API-Key': `${localStorage.getItem('apiKey')}`
             },
             body: formData
           });

--- a/lightrag/api/static/index.html
+++ b/lightrag/api/static/index.html
@@ -614,7 +614,7 @@
       try {
         const response = await fetch('/health', {
           headers: {
-            'Authorization': `Bearer ${localStorage.getItem('apiKey')}`
+            'X-API-Key': `${localStorage.getItem('apiKey')}`
           }
         });
 

--- a/lightrag/api/static/index.html
+++ b/lightrag/api/static/index.html
@@ -342,7 +342,7 @@
                     const response = await fetch('/documents/upload', {
                         method: 'POST',
                         headers: {
-                            'Authorization': `Bearer ${localStorage.getItem('apiKey') || ''}`
+                            'X-API-Key': `${localStorage.getItem('apiKey') || ''}`
                         },
                         body: formData
                     });


### PR DESCRIPTION
this PR fixes auth of webui.
`X-API-Key`: `api-key`   (without Bearer)
is expected form of apikey auth