### PR TITLE
Fix: history_turns variable name in kg_query function

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -633,9 +633,7 @@ async def kg_query(
     # Process conversation history
     history_context = ""
     if query_param.conversation_history:
-        recent_history = query_param.conversation_history[
-            -query_param.history_window_size :
-        ]
+        recent_history = query_param.conversation_history[-query_param.history_turns :]
         history_context = "\n".join(
             [f"{turn['role']}: {turn['content']}" for turn in recent_history]
         )


### PR DESCRIPTION
## Description
Fixed an AttributeError in `kg_query` function where it was trying to access `history_window_size` when the `QueryParam` class uses `history_turns` as the variable name.

## Issue
When using the RAG query functionality with chat history, the following error occurs:

```python
AttributeError: 'QueryParam' object has no attribute 'history_window_size'
```

## Fix
Updated the variable reference in `lightrag/operate.py` to use `history_turn` instead of `history_window_size` to match the `QueryParam` class implementation.

## Testing
- Tested the chat functionality with conversation history
- Verified that the query parameter correctly processes the history turns