### PR TITLE
Fix Module Import Bug of PostgresSQL Demo

### DIFF
--- a/examples/lightrag_zhipu_postgres_demo.py
+++ b/examples/lightrag_zhipu_postgres_demo.py
@@ -6,7 +6,8 @@ from dotenv import load_dotenv
 
 from lightrag import LightRAG, QueryParam
 from lightrag.kg.postgres_impl import PostgreSQLDB
-from lightrag.llm.zhipu import ollama_embedding, zhipu_complete
+from lightrag.llm.zhipu import zhipu_complete
+from lightrag.llm.ollama import ollama_embedding
 from lightrag.utils import EmbeddingFunc
 
 load_dotenv()


### PR DESCRIPTION
This PR fix the module import bugs in the [Postgres Demo](https://github.com/HKUDS/LightRAG/blob/main/examples/lightrag_zhipu_postgres_demo.py#L9)
```python
from lightrag.llm.zhipu import ollama_embedding, zhipu_complete
from lightrag.utils import EmbeddingFunc
```
Here `ollama_embedding` should be imported from `lightrag.llm.ollama`.
