### PR TITLE
Add the ability to specify a path for saving lightrag.log

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -126,9 +126,11 @@ class LightRAG:
     vector_storage: str = field(default="NanoVectorDBStorage")
     graph_storage: str = field(default="NetworkXStorage")
 
+    # logging
     current_log_level = logger.level
     log_level: str = field(default=current_log_level)
-
+    log_folder: str = field(default="./")
+    
     # text chunking
     chunk_token_size: int = 1200
     chunk_overlap_token_size: int = 100
@@ -180,9 +182,12 @@ class LightRAG:
     # Custom Chunking Function
     chunking_func: callable = chunking_by_token_size
     chunking_func_kwargs: dict = field(default_factory=dict)
+        
 
     def __post_init__(self):
-        log_file = os.path.join("lightrag.log")
+        log_dir = os.path.join(os.getcwd(), "logs")
+        os.makedirs(log_dir, exist_ok=True)
+        log_file = os.path.join(log_dir, "lightrag.log")
         set_logger(log_file)
         logger.setLevel(self.log_level)
 

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -129,8 +129,8 @@ class LightRAG:
     # logging
     current_log_level = logger.level
     log_level: str = field(default=current_log_level)
-    log_folder: str = field(default="./")
-    
+    log_folder: str = field(default="")
+
     # text chunking
     chunk_token_size: int = 1200
     chunk_overlap_token_size: int = 100
@@ -182,10 +182,9 @@ class LightRAG:
     # Custom Chunking Function
     chunking_func: callable = chunking_by_token_size
     chunking_func_kwargs: dict = field(default_factory=dict)
-        
 
     def __post_init__(self):
-        log_dir = os.path.join(os.getcwd(), "logs")
+        log_dir = os.path.join(os.getcwd(), self.log_folder)
         os.makedirs(log_dir, exist_ok=True)
         log_file = os.path.join(log_dir, "lightrag.log")
         set_logger(log_file)


### PR DESCRIPTION
When initializing LightRAG, you can specify `log_folder`, where `lightrag.log` will be saved.
The default value is the project’s root directory.

This can be useful if the project contains other log files that should be stored in a dedicated directory.