### PR TITLE
Add query prefix "/bypass" for ollama api

### DIFF
--- a/lightrag/api/README.md
+++ b/lightrag/api/README.md
@@ -82,13 +82,18 @@ We provide an Ollama-compatible interfaces for LightRAG, aiming to emulate Light
 
 A query prefix in the query string can determines which LightRAG query mode is used to generate the respond for the query. The supported prefixes include:
 
+```
 /local
 /global
 /hybrid
 /naive
 /mix
+/bypass
+```
 
 For example, chat message "/mix 唐僧有几个徒弟" will trigger a mix mode query for LighRAG. A chat message without query prefix will trigger a hybrid mode query by default。
+
+"/bypass" is not a LightRAG query mode, it will tell API Server to pass the query directly to the underlying LLM with chat history. So user can use LLM to answer question base on the LightRAG query results. (If you are using Open WebUI as front end, you can just switch the model to a normal LLM instead of using /bypass prefix)
 
 #### Connect Open WebUI to LightRAG
 

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -1477,7 +1477,7 @@ def create_app(args):
 
     @app.get("/api/tags")
     async def get_tags():
-        """Get available models"""
+        """Retrun available models acting as an Ollama server"""
         return OllamaTagResponse(
             models=[
                 {
@@ -1521,7 +1521,7 @@ def create_app(args):
 
     @app.post("/api/generate")
     async def generate(raw_request: Request, request: OllamaGenerateRequest):
-        """Handle generate completion requests
+        """Handle generate completion requests acting as an Ollama model
         For compatiblity purpuse, the request is not processed by LightRAG,
         and will be handled by underlying LLM model.
         """
@@ -1663,7 +1663,7 @@ def create_app(args):
 
     @app.post("/api/chat")
     async def chat(raw_request: Request, request: OllamaChatRequest):
-        """Process chat completion requests.
+        """Process chat completion requests acting as an Ollama model
         Routes user queries through LightRAG by selecting query mode based on prefix indicators.
         Detects and forwards OpenWebUI session-related requests (for meta data generation task) directly to LLM.
         """

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -1707,10 +1707,10 @@ def create_app(args):
                     if request.system:
                         rag.llm_model_kwargs["system_prompt"] = request.system
                     response = await rag.llm_model_func(
-                        cleaned_query, 
+                        cleaned_query,
                         stream=True,
                         history_messages=conversation_history,
-                        **rag.llm_model_kwargs
+                        **rag.llm_model_kwargs,
                     )
                 else:
                     response = await rag.aquery(  # Need await to get async generator
@@ -1826,10 +1826,10 @@ def create_app(args):
                         rag.llm_model_kwargs["system_prompt"] = request.system
 
                     response_text = await rag.llm_model_func(
-                        cleaned_query, 
+                        cleaned_query,
                         stream=False,
                         history_messages=conversation_history,
-                        **rag.llm_model_kwargs
+                        **rag.llm_model_kwargs,
                     )
                 else:
                     response_text = await rag.aquery(cleaned_query, param=query_param)


### PR DESCRIPTION
Add "/bypass" query prefix skip context retrieval from LightRAG, and pass the query directly the underlying  LLM.