### PR TITLE
Fix get_by_id DB query ressult is empty array

### DIFF
--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -447,7 +447,7 @@ class PGDocStatusStorage(DocStatusStorage):
         sql = "select * from LIGHTRAG_DOC_STATUS where workspace=$1 and id=$2"
         params = {"workspace": self.db.workspace, "id": id}
         result = await self.db.query(sql, params, True)
-        if result is None:
+        if result is None or result == []:
             return None
         else:
             return DocProcessingStatus(


### PR DESCRIPTION
The get_by_id function returns an empty array