### PR TITLE
fix mongo impl

### DIFF
--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -2,10 +2,13 @@ import os
 from tqdm.asyncio import tqdm as tqdm_async
 from dataclasses import dataclass
 import pipmaster as pm
-import np
+import numpy as np
 
 if not pm.is_installed("pymongo"):
     pm.install("pymongo")
+
+if not pm.is_installed("motor"):
+    pm.install("motor")
 
 from pymongo import MongoClient
 from motor.motor_asyncio import AsyncIOMotorClient


### PR DESCRIPTION
This change fixes two minor issues in `lightrag/kg/mongo_impl.py`:

1. **Numpy Import Correction**  
   - Changed `import np` to `import numpy as np` to fix the module import error.

2. **Motor Dependency Handling**  
   - Added a check to install the `motor` package if it's not already installed, ensuring asynchronous MongoDB operations work correctly.