### PR TITLE
Fix: AttributeError in NanoVectorDB Initialization

### DIFF
--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -54,6 +54,10 @@ from tqdm.asyncio import tqdm as tqdm_async
 from dataclasses import dataclass
 import numpy as np
 import pipmaster as pm
+from lightrag.base import EmbeddingFunc
+from lightrag.llm.openai import gpt_4o_mini_complete
+
+
 
 if not pm.is_installed("nano-vectordb"):
     pm.install("nano-vectordb")
@@ -88,6 +92,10 @@ class NanoVectorDBStorage(BaseVectorStorage):
             self.global_config["working_dir"], f"vdb_{self.namespace}.json"
         )
         self._max_batch_size = self.global_config["embedding_batch_num"]
+
+        self.embedding_func=EmbeddingFunc(
+        embedding_dim=4096, max_token_size=8192, func=gpt_4o_mini_complete
+    )
         self._client = NanoVectorDB(
             self.embedding_func.embedding_dim, storage_file=self._client_file_name
         )
@@ -137,6 +145,11 @@ class NanoVectorDBStorage(BaseVectorStorage):
             )
 
     async def query(self, query: str, top_k=5):
+
+        self.embedding_func=EmbeddingFunc(
+        embedding_dim=4096, max_token_size=8192, func=gpt_4o_mini_complete
+        )
+
         embedding = await self.embedding_func([query])
         embedding = embedding[0]
         logger.info(


### PR DESCRIPTION
Issue
The following error occurred during the initialization of NanoVectorDB in nano_vector_db_impl.py:

File ".../LightRAG/LightRAG/lightrag/kg/nano_vector_db_impl.py", line 92, in __post_init__
    self.embedding_func.embedding_dim, storage_file=self._client_file_name
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'function' object has no attribute 'embedding_dim'

Root Cause
The embedding_func variable was declared locally instead of being assigned to self.embedding_func.
As a result, self.embedding_func was referring to a function instead of an instance of EmbeddingFunc, causing the AttributeError.

Changes Made
1. Explicitly Initialized self.embedding_func in __post_init__ and query using:

self.embedding_func = EmbeddingFunc(
    embedding_dim=4096, max_token_size=8192, func=gpt_4o_mini_complete
)

2. Imported EmbeddingFunc and gpt_4o_mini_complete to avoid reference errors.



