### PR TITLE
fix: neo4j MAX_CONNECTION_POOL_SIZE impl

### DIFF
--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -45,7 +45,10 @@ class Neo4JStorage(BaseGraphStorage):
         URI = os.environ["NEO4J_URI"]
         USERNAME = os.environ["NEO4J_USERNAME"]
         PASSWORD = os.environ["NEO4J_PASSWORD"]
-        MAX_CONNECTION_POOL_SIZE = os.environ.get("NEO4J_MAX_CONNECTION_POOL_SIZE", 800)
+        MAX_CONNECTION_POOL_SIZE = int(
+            os.environ.get("NEO4J_MAX_CONNECTION_POOL_SIZE", 800)
+        )
+
         DATABASE = os.environ.get(
             "NEO4J_DATABASE", re.sub(r"[^a-zA-Z0-9-]", "-", namespace)
         )


### PR DESCRIPTION
When `MAX_CONNECTION_POOL_SIZE` is specified in `.env`, the value of 

```python
MAX_CONNECTION_POOL_SIZE = os.environ.get("NEO4J_MAX_CONNECTION_POOL_SIZE", 800)
```

will be a string, which will cause an error in:

```python
infinite_pool_size = max_pool_size < 0 or max_pool_size == float("inf")
```