### PR TITLE
fix: neo4j MAX_CONNECTION_POOL_SIZE impl

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -101,6 +101,7 @@ def estimate_tokens(text: str) -> int:
 
     return int(tokens)
 
+
 def get_default_host(binding_type: str) -> str:
     default_hosts = {
         "ollama": os.getenv("LLM_BINDING_HOST", "http://localhost:11434"),

--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -52,7 +52,7 @@ class Neo4JStorage(BaseGraphStorage):
         USERNAME = os.environ.get(
             "NEO4J_USERNAME", config.get("neo4j", "username", fallback=None)
         )
-        PASSWORD = os.environ(
+        PASSWORD = os.environ.get(
             "NEO4J_PASSWORD", config.get("neo4j", "password", fallback=None)
         )
         MAX_CONNECTION_POOL_SIZE = int(

--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -55,9 +55,11 @@ class Neo4JStorage(BaseGraphStorage):
         PASSWORD = os.environ[
             "NEO4J_PASSWORD", config.get("neo4j", "password", fallback=None)
         ]
-        MAX_CONNECTION_POOL_SIZE = os.environ.get(
-            "NEO4J_MAX_CONNECTION_POOL_SIZE",
-            config.get("neo4j", "connection_pool_size", fallback=800),
+        MAX_CONNECTION_POOL_SIZE = int(
+            os.environ.get(
+                "NEO4J_MAX_CONNECTION_POOL_SIZE",
+                config.get("neo4j", "connection_pool_size", fallback=800),
+            )
         )
         DATABASE = os.environ.get(
             "NEO4J_DATABASE", re.sub(r"[^a-zA-Z0-9-]", "-", namespace)

--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -48,13 +48,13 @@ class Neo4JStorage(BaseGraphStorage):
         self._driver = None
         self._driver_lock = asyncio.Lock()
 
-        URI = os.environ["NEO4J_URI", config.get("neo4j", "uri", fallback=None)]
-        USERNAME = os.environ[
+        URI = os.environ.get("NEO4J_URI", config.get("neo4j", "uri", fallback=None))
+        USERNAME = os.environ.get(
             "NEO4J_USERNAME", config.get("neo4j", "username", fallback=None)
-        ]
-        PASSWORD = os.environ[
+        )
+        PASSWORD = os.environ(
             "NEO4J_PASSWORD", config.get("neo4j", "password", fallback=None)
-        ]
+        )
         MAX_CONNECTION_POOL_SIZE = int(
             os.environ.get(
                 "NEO4J_MAX_CONNECTION_POOL_SIZE",


### PR DESCRIPTION
When `MAX_CONNECTION_POOL_SIZE` is specified in `.env`, the value of 

```python
MAX_CONNECTION_POOL_SIZE = os.environ.get("NEO4J_MAX_CONNECTION_POOL_SIZE", 800)
```

will be a string, which will cause an error in:

```python
infinite_pool_size = max_pool_size < 0 or max_pool_size == float("inf")
```