### PR TITLE
Enable LiteLLM proxy with embedding_binding_host

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -1021,8 +1021,8 @@ def create_app(args):
         if args.embedding_binding == "azure_openai"
         else openai_embed(
             texts,
-            model=args.embedding_model,  
-            base_url=args.embedding_binding_host, # If you decide to use litellm as a proxy for azure openai, this is relevant
+            model=args.embedding_model,
+            base_url=args.embedding_binding_host,
             api_key=args.embedding_binding_api_key,
         ),
     )

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -101,6 +101,7 @@ def estimate_tokens(text: str) -> int:
 
     return int(tokens)
 
+
 def get_default_host(binding_type: str) -> str:
     default_hosts = {
         "ollama": os.getenv("LLM_BINDING_HOST", "http://localhost:11434"),

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -1021,7 +1021,8 @@ def create_app(args):
         if args.embedding_binding == "azure_openai"
         else openai_embed(
             texts,
-            model=args.embedding_model,  # no host is used for openai,
+            model=args.embedding_model,  
+            base_url=args.embedding_binding_host, # If you decide to use litellm as a proxy for azure openai, this is relevant
             api_key=args.embedding_binding_api_key,
         ),
     )


### PR DESCRIPTION
This pull request fixes a bug that occurs when using Azure OpenAI through the  [LiteLLM](https://github.com/BerriAI/litellm) 
 proxy to manage and track the api calls. The issue arises because the embedding_binding_host was not being properly specified, causing the system to default to OpenAI's API endpoint instead of routing requests through LiteLLM.

# Changes Made
- Updated the  openai_embed  call to explicitly use embedding_binding_host when LiteLLM is used as a proxy.
- Ensured that args.embedding_binding_host is correctly propagated and used when configuring the embedding function.

Confirmed the fix allows embedding requests to route through LiteLLM instead of OpenAI default binding host

# Bug Context
Without this fix:
- Requests intended to use Azure OpenAI through LiteLLM would default to the OpenAI endpoint (https://api.openai.com/v1/embeddings), resulting in 401 Unauthorized errors if a valid API key for OpenAI is not provided.

With this fix:
- Embedding requests are correctly routed through LiteLLM with the specified embedding_binding_host, enabling the use of Azure OpenAI as expected.

# Testing Instructions
Ensure that EMBEDDING_BINDING_HOST is correctly set in the .env file, pointing to http://litellm:4000/v1.
Restart the server and test embedding operations.
Confirm that embedding API calls are routed to LiteLLM (http://litellm:4000/v1/embeddings) instead of OpenAI's default endpoint.
Impact
This change specifically affects users who want to use Azure OpenAI through the LiteLLM proxy. No impact is expected for other LLM configurations or direct OpenAI usage.

# Sample environment: 
The following environment assumes you have a [LiteLLM](https://github.com/BerriAI/litellm) service up and running listening at http://litellm:4000

```yaml
environment:
      - LLM_BINDING=openai
      - LLM_MODEL=${AZURE_OPENAI_DEPLOYMENT}
      - LLM_BINDING_HOST=http://litellm:4000/v1
      - LLM_BINDING_API_KEY=dummy_key
      - OPENAI_API_KEY=dummy_key
      - EMBEDDING_BINDING=openai
      - EMBEDDING_MODEL=${EMBEDDING_MODEL}
      - EMBEDDING_BINDING_HOST=http://litellm:4000/v1
```
