### PR TITLE
Fix ImportError by Removing Redundant Try-Except Block

### DIFF
--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -23,18 +23,13 @@ import pipmaster as pm
 if not pm.is_installed("neo4j"):
     pm.install("neo4j")
 
-try:
-    from neo4j import (
-        AsyncGraphDatabase,
-        exceptions as neo4jExceptions,
-        AsyncDriver,
-        AsyncManagedTransaction,
-        GraphDatabase,
-    )
-except ImportError as e:
-    raise ImportError(
-        "`neo4j` library is not installed. Please install it via pip: `pip install neo4j`."
-    ) from e
+from neo4j import (
+    AsyncGraphDatabase,
+    exceptions as neo4jExceptions,
+    AsyncDriver,
+    AsyncManagedTransaction,
+    GraphDatabase,
+)
 
 config = configparser.ConfigParser()
 config.read("config.ini", "utf-8")

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -20,13 +20,8 @@ if not pm.is_installed("networkx"):
 if not pm.is_installed("graspologic"):
     pm.install("graspologic")
 
-try:
-    from graspologic import embed
-    import networkx as nx
-except ImportError as e:
-    raise ImportError(
-        "`networkx` library is not installed. Please install it via pip: `pip install networkx`."
-    ) from e
+from graspologic import embed
+import networkx as nx
 
 
 @final


### PR DESCRIPTION
This PR addresses an issue where an ImportError for the networkx library was incorrectly raised due to a try-except block that masked the real problem. The actual issue was a ModuleNotFoundError for the past module, which is part of the future package.

Since pipmaster is used to verify that the module is already installed, no need to use that extra try except especially that it hides the real error.

This fixes issue: #871
