### PR TITLE
fix insert_custom_chunks skipping every new doc

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -524,7 +524,7 @@ class LightRAG:
             doc_key = compute_mdhash_id(full_text.strip(), prefix="doc-")
             new_docs = {doc_key: {"content": full_text.strip()}}
 
-            _add_doc_keys = await self.full_docs.filter_keys(set(doc_key))
+            _add_doc_keys = await self.full_docs.filter_keys({doc_key})
             new_docs = {k: v for k, v in new_docs.items() if k in _add_doc_keys}
             if not len(new_docs):
                 logger.warning("This document is already in the storage.")


### PR DESCRIPTION
fix insert_custom_chunks skipping every new doc and throwing warning "This document is already in the storage."

<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

Bug fix. set(doc_key) was creating a set of letters {a,b,c,...} instead of putting doc_key into a set as a single element.

## Related Issues

[Reference any related issues or tasks addressed by this pull request.]

## Changes Made

set(doc_key) -> {doc_key}

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

[Add any additional notes or context for the reviewer(s).]
