### PR TITLE
Fix custom prompts for "mix" mode queries

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -921,10 +921,8 @@ async def mix_kg_vector_query(
         return {"kg_context": kg_context, "vector_context": vector_context}
 
     # 5. Construct hybrid prompt
-    sys_prompt = (
-        system_prompt
-        if system_prompt
-        else PROMPTS["mix_rag_response"].format(
+    sys_prompt_temp = system_prompt if system_prompt else PROMPTS["mix_rag_response"]
+    sys_prompt = (sys_prompt_temp.format(
             kg_context=kg_context
             if kg_context
             else "No relevant knowledge graph information found",


### PR DESCRIPTION
## Description

Enables custom prompts for mix mode queries to use `{vector_context}` and `{kg_context}`. 

Note: Available context should probably be standardized across prompts (sometimes its `context_data`, sometimes it `kg_context`, etc.)

## Related Issues

Fixes #863 

## Changes Made

I follow the pattern used for other mode's custom prompts. If a system prompt is provided, use that otherwise fall back to the default prompt. Then format whatever that result is, instead of only formatting if default prompt is used.

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

N/A
