### PR TITLE
fix apipeline_enqueue_documents

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -568,7 +568,7 @@ class LightRAG:
                 await self._insert_done()
 
     async def apipeline_enqueue_documents(
-        self, input: str | list[str], ids: list[str] | None
+        self, input: str | list[str], ids: list[str] | None = None
     ) -> None:
         """
         Pipeline for Processing Documents


### PR DESCRIPTION
## Description

This PR fixes a missing argument issue in `apipeline_enqueue_documents` by making the `ids` parameter optional. If `ids` is not provided, the function now automatically generates unique MD5-based document IDs. This prevents runtime errors when the function is called without explicit IDs. 

I tested it with neo4j as backend system for graph db

## Related Issues

- Fixes missing argument errors in API calls such as `pipeline_index_texts`.
- Ensures backward compatibility while improving robustness.

Error received without fix:
```bash
lightrag    | INFO:     172.25.0.1:54700 - "POST /documents/upload HTTP/1.1" 200 OK
lightrag    | ERROR:Error processing or enqueueing file testfile.md: LightRAG.apipeline_enqueue_documents() missing 1 required positional argument: 'ids'
lightrag    | ERROR:Traceback (most recent call last):
lightrag    |   File "/app/lightrag/api/routers/document_routes.py", line 297, in pipeline_enqueue_file
lightrag    |     await rag.apipeline_enqueue_documents(content)
lightrag    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lightrag    | TypeError: LightRAG.apipeline_enqueue_documents() missing 1 required positional argument: 'ids'
´´´

## Changes Made

- Set `ids=None` as the default argument in `apipeline_enqueue_documents`.
- If `ids` is `None`, generate unique MD5-based IDs for each document.
- Ensured that all existing function calls remain unchanged.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

I tested with both webui and api rest.