### PR TITLE
fix this event loop is already running

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -418,7 +418,7 @@ class LightRAG:
             if loop.is_running():
                 task = loop.create_task(async_func())
                 task.add_done_callback(
-                    lambda t: logger.info(f"✅ {action_name} completed!")
+                    lambda t: logger.info(f"{action_name} completed!")
                 )
             else:
                 loop.run_until_complete(async_func())


### PR DESCRIPTION
## Description

This pull request improves the asynchronous management of storage initialization and finalization in the LightRAG class.

It introduces the _run_async_safely() method to handle asynchronous execution safely, preventing event loop conflicts.
Storage initialization is now automatically managed upon object creation (self.initialize_storages).
Storage finalization is triggered when the object is deleted (self.finalize_storages).

## Related Issues

This PR addresses potential issues with event loop conflicts when running asynchronous functions within synchronous contexts.

## Changes Made

Added _run_async_safely() method to execute async functions safely without blocking the event loop.
Ensured that storage initialization (initialize_storages) runs when auto_manage_storages_states is enabled.
Automatically finalizes storage (finalize_storages) when the object is deleted.
Improved error handling for missing event loops to prevent runtime errors

## Checklist

- [x ] Changes tested locally
- [x ] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes
This change helps improve performance and prevents blocking issues in environments like FastAPI or Jupyter Notebook.
