### PR TITLE
adding full_doc_id to insert

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -839,7 +839,7 @@ class LightRAG:
         loop = always_get_an_event_loop()
         loop.run_until_complete(self.ainsert_custom_kg(custom_kg, full_doc_id))
 
-    async def ainsert_custom_kg(self, custom_kg: dict[str, Any], full_doc_id: str | None) -> None:
+    async def ainsert_custom_kg(self, custom_kg: dict[str, Any], full_doc_id: str = None) -> None:
         update_storage = False
         try:
             # Insert chunks into vector storage

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -835,11 +835,11 @@ class LightRAG:
         await asyncio.gather(*tasks)
         logger.info("All Insert done")
 
-    def insert_custom_kg(self, custom_kg: dict[str, Any]) -> None:
+    def insert_custom_kg(self, custom_kg: dict[str, Any], full_doc_id: str = None) -> None:
         loop = always_get_an_event_loop()
-        loop.run_until_complete(self.ainsert_custom_kg(custom_kg))
+        loop.run_until_complete(self.ainsert_custom_kg(custom_kg, full_doc_id))
 
-    async def ainsert_custom_kg(self, custom_kg: dict[str, Any]) -> None:
+    async def ainsert_custom_kg(self, custom_kg: dict[str, Any], full_doc_id: str | None) -> None:
         update_storage = False
         try:
             # Insert chunks into vector storage
@@ -865,7 +865,7 @@ class LightRAG:
                     "source_id": source_id,
                     "tokens": tokens,
                     "chunk_order_index": chunk_order_index,
-                    "full_doc_id": source_id,
+                    "full_doc_id": full_doc_id if full_doc_id is not None else source_id,
                     "status": DocStatus.PROCESSED,
                 }
                 all_chunks_data[chunk_id] = chunk_entry


### PR DESCRIPTION

## Description

In certain use cases we would like to provide a full doc_id instead of using the source id

## Related Issues


## Changes Made

Added an optional parameter to the insert function of the LightRAG

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)


