### PR TITLE
[EVO] Add language configuration to environment and argument parsing

### DIFF
--- a/env.example
+++ b/env.example
@@ -47,7 +47,7 @@
 # CHUNK_OVERLAP_SIZE=100
 # MAX_TOKENS=32768             # Max tokens send to LLM for summarization
 # MAX_TOKEN_SUMMARY=500        # Max tokens for entity or relations summary
-# SUMMARY_LANGUAGE=English
+# LANGUAGE=English
 # MAX_EMBED_TOKENS=8192
 
 ### LLM Configuration (Use valid host. For local services installed with docker, you can use host.docker.internal)

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -331,6 +331,9 @@ def create_app(args):
             },
             log_level=args.log_level,
             namespace_prefix=args.namespace_prefix,
+            addon_params={
+                "language": args.language,
+            },
             auto_manage_storages_states=False,
         )
     else:  # azure_openai

--- a/lightrag/api/utils_api.py
+++ b/lightrag/api/utils_api.py
@@ -340,6 +340,7 @@ def parse_args(is_uvicorn_mode: bool = False) -> argparse.Namespace:
     # Inject chunk configuration
     args.chunk_size = get_env_value("CHUNK_SIZE", 1200, int)
     args.chunk_overlap_size = get_env_value("CHUNK_OVERLAP_SIZE", 100, int)
+    args.language = get_env_value("LANGUAGE", "English")
 
     ollama_server_infos.LIGHTRAG_MODEL = args.simulated_model_name
 


### PR DESCRIPTION
The language was not considered when using lightRAG_server. Even though the variable SUMMARY_LANGUAGE was defined in the env.example, it was not used anywhere.
I fixed that.