### PR TITLE
Fix qdrant payload id

### DIFF
--- a/lightrag/kg/qdrant_impl.py
+++ b/lightrag/kg/qdrant_impl.py
@@ -135,7 +135,7 @@ class QdrantVectorDBStorage(BaseVectorStorage):
 
         logger.debug(f"query result: {results}")
 
-        return [{**dp.payload, "id": dp.id, "distance": dp.score} for dp in results]
+        return [{**dp.payload, "distance": dp.score} for dp in results]
 
     async def index_done_callback(self) -> None:
         # Qdrant handles persistence automatically
@@ -264,7 +264,7 @@ class QdrantVectorDBStorage(BaseVectorStorage):
 
             # Format the results to match expected return format
             formatted_results = [
-                {**point.payload, "id": point.id} for point in matching_records
+                {**point.payload} for point in matching_records
             ]
 
             logger.debug(


### PR DESCRIPTION

## Description

Qdrant now is using `PointStruct.payload["id"]`, not `PointStruct.id` UUID. This will fix id overwrite

## Related Issues

```python
# some imports, configs here

async def initialize_rag():
    rag = LightRAG(
        working_dir=WORKING_DIR,
        embedding_func=azure_openai_embed,
        llm_model_func=azure_openai_complete,
        kv_storage="RedisKVStorage",
        graph_storage="Neo4JStorage",
        vector_storage="QdrantVectorDBStorage", # Milvus is ok
        doc_status_storage="MongoDocStatusStorage",
    )

    await rag.initialize_storages()
    await initialize_pipeline_status()

    return rag

def main():
    # Initialize RAG instance
    rag = asyncio.run(initialize_rag())

    with open(os.path.join(ROOT_DIR, "some.md"), "r", encoding="utf-8") as f:
        rag.insert(f.read())

    # Perform naive search
    print("naive search")
    print(
        rag.query(
            "请用中文回答: 介绍下向量内积?", param=QueryParam(mode="naive")
        )
    )
```

When using `QdrantVectorDBStorage`, it errors:

```text
No valid chunks found after filtering
```

## Changes Made

removed duplicated id key in qdrant query method

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

Maybe there's better way to fix this? like a new `Data.get_id()` method?
