### PR TITLE
Refactoring Neo4j implementation and fixing storage init problem for Gunicorn

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -323,7 +323,7 @@ def create_app(args):
             vector_db_storage_cls_kwargs={
                 "cosine_better_than_threshold": args.cosine_threshold
             },
-            enable_llm_cache_for_entity_extract=args.enable_llm_cache,  # Read from args
+            enable_llm_cache_for_entity_extract=args.enable_llm_cache_for_extract,
             embedding_cache_config={
                 "enabled": True,
                 "similarity_threshold": 0.95,
@@ -352,7 +352,7 @@ def create_app(args):
             vector_db_storage_cls_kwargs={
                 "cosine_better_than_threshold": args.cosine_threshold
             },
-            enable_llm_cache_for_entity_extract=args.enable_llm_cache,  # Read from args
+            enable_llm_cache_for_entity_extract=args.enable_llm_cache_for_extract,
             embedding_cache_config={
                 "enabled": True,
                 "similarity_threshold": 0.95,
@@ -416,7 +416,7 @@ def create_app(args):
                 "doc_status_storage": args.doc_status_storage,
                 "graph_storage": args.graph_storage,
                 "vector_storage": args.vector_storage,
-                "enable_llm_cache": args.enable_llm_cache,
+                "enable_llm_cache_for_extract": args.enable_llm_cache_for_extract,
             },
             "update_status": update_status,
         }

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -50,9 +50,6 @@ from .auth import auth_handler
 # This update allows the user to put a different.env file for each lightrag folder
 load_dotenv(".env", override=True)
 
-# Read entity extraction cache config
-enable_llm_cache = os.getenv("ENABLE_LLM_CACHE_FOR_EXTRACT", "false").lower() == "true"
-
 # Initialize config parser
 config = configparser.ConfigParser()
 config.read("config.ini")
@@ -326,7 +323,7 @@ def create_app(args):
             vector_db_storage_cls_kwargs={
                 "cosine_better_than_threshold": args.cosine_threshold
             },
-            enable_llm_cache_for_entity_extract=enable_llm_cache,  # Read from environment variable
+            enable_llm_cache_for_entity_extract=args.enable_llm_cache,  # Read from args
             embedding_cache_config={
                 "enabled": True,
                 "similarity_threshold": 0.95,
@@ -355,7 +352,7 @@ def create_app(args):
             vector_db_storage_cls_kwargs={
                 "cosine_better_than_threshold": args.cosine_threshold
             },
-            enable_llm_cache_for_entity_extract=enable_llm_cache,  # Read from environment variable
+            enable_llm_cache_for_entity_extract=args.enable_llm_cache,  # Read from args
             embedding_cache_config={
                 "enabled": True,
                 "similarity_threshold": 0.95,
@@ -419,6 +416,7 @@ def create_app(args):
                 "doc_status_storage": args.doc_status_storage,
                 "graph_storage": args.graph_storage,
                 "vector_storage": args.vector_storage,
+                "enable_llm_cache": args.enable_llm_cache,
             },
             "update_status": update_status,
         }

--- a/lightrag/api/utils_api.py
+++ b/lightrag/api/utils_api.py
@@ -359,6 +359,13 @@ def parse_args(is_uvicorn_mode: bool = False) -> argparse.Namespace:
     # Inject chunk configuration
     args.chunk_size = get_env_value("CHUNK_SIZE", 1200, int)
     args.chunk_overlap_size = get_env_value("CHUNK_OVERLAP_SIZE", 100, int)
+    
+    # Inject LLM cache configuration
+    args.enable_llm_cache = get_env_value(
+        "ENABLE_LLM_CACHE_FOR_EXTRACT", 
+        False, 
+        bool
+    )
 
     ollama_server_infos.LIGHTRAG_MODEL = args.simulated_model_name
 
@@ -451,8 +458,10 @@ def display_splash_screen(args: argparse.Namespace) -> None:
     ASCIIColors.yellow(f"{args.history_turns}")
     ASCIIColors.white("    ├─ Cosine Threshold: ", end="")
     ASCIIColors.yellow(f"{args.cosine_threshold}")
-    ASCIIColors.white("    └─ Top-K: ", end="")
+    ASCIIColors.white("    ├─ Top-K: ", end="")
     ASCIIColors.yellow(f"{args.top_k}")
+    ASCIIColors.white("    └─ LLM Cache Enabled: ", end="")
+    ASCIIColors.yellow(f"{args.enable_llm_cache}")
 
     # System Configuration
     ASCIIColors.magenta("\n💾 Storage Configuration:")

--- a/lightrag/api/utils_api.py
+++ b/lightrag/api/utils_api.py
@@ -359,12 +359,10 @@ def parse_args(is_uvicorn_mode: bool = False) -> argparse.Namespace:
     # Inject chunk configuration
     args.chunk_size = get_env_value("CHUNK_SIZE", 1200, int)
     args.chunk_overlap_size = get_env_value("CHUNK_OVERLAP_SIZE", 100, int)
-    
+
     # Inject LLM cache configuration
     args.enable_llm_cache_for_extract = get_env_value(
-        "ENABLE_LLM_CACHE_FOR_EXTRACT", 
-        False, 
-        bool
+        "ENABLE_LLM_CACHE_FOR_EXTRACT", False, bool
     )
 
     ollama_server_infos.LIGHTRAG_MODEL = args.simulated_model_name

--- a/lightrag/api/utils_api.py
+++ b/lightrag/api/utils_api.py
@@ -361,7 +361,7 @@ def parse_args(is_uvicorn_mode: bool = False) -> argparse.Namespace:
     args.chunk_overlap_size = get_env_value("CHUNK_OVERLAP_SIZE", 100, int)
     
     # Inject LLM cache configuration
-    args.enable_llm_cache = get_env_value(
+    args.enable_llm_cache_for_extract = get_env_value(
         "ENABLE_LLM_CACHE_FOR_EXTRACT", 
         False, 
         bool
@@ -460,8 +460,8 @@ def display_splash_screen(args: argparse.Namespace) -> None:
     ASCIIColors.yellow(f"{args.cosine_threshold}")
     ASCIIColors.white("    ├─ Top-K: ", end="")
     ASCIIColors.yellow(f"{args.top_k}")
-    ASCIIColors.white("    └─ LLM Cache Enabled: ", end="")
-    ASCIIColors.yellow(f"{args.enable_llm_cache}")
+    ASCIIColors.white("    └─ LLM Cache for Extraction Enabled: ", end="")
+    ASCIIColors.yellow(f"{args.enable_llm_cache_for_extract}")
 
     # System Configuration
     ASCIIColors.magenta("\n💾 Storage Configuration:")

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -20,6 +20,7 @@ from .shared_storage import (
     set_all_update_flags,
     clear_all_update_flags,
     try_initialize_namespace,
+    is_multiprocess,
 )
 
 
@@ -95,7 +96,7 @@ class JsonDocStatusStorage(DocStatusStorage):
 
     async def index_done_callback(self) -> None:
         async with self._storage_lock:
-            if self.storage_updated:
+            if (is_multiprocess and self.storage_updated.value) or (not is_multiprocess and self.storage_updated):
                 data_dict = (
                     dict(self._data) if hasattr(self._data, "_getvalue") else self._data
                 )

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -96,12 +96,12 @@ class JsonDocStatusStorage(DocStatusStorage):
             write_json(data_dict, self._file_name)
 
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
-        logger.info(f"Inserting {len(data)} to {self.namespace}")
         if not data:
             return
-
+        logger.info(f"Inserting {len(data)} to {self.namespace}")
         async with self._storage_lock:
             self._data.update(data)
+
         await self.index_done_callback()
 
     async def get_by_id(self, id: str) -> Union[dict[str, Any], None]:

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -107,7 +107,7 @@ class JsonDocStatusStorage(DocStatusStorage):
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
         if not data:
             return
-        logger.info(f"Inserting {len(data)} to {self.namespace}")
+        logger.info(f"Inserting {len(data)} records to {self.namespace}")
         async with self._storage_lock:
             self._data.update(data)
             await set_all_update_flags(self.namespace)

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -40,7 +40,7 @@ class JsonDocStatusStorage(DocStatusStorage):
             async with self._storage_lock:
                 self._data.update(loaded_data)
                 logger.info(
-                    f"Loaded document status storage with {len(loaded_data)} records"
+                    f"Process {os.getpid()} doc status load {self.namespace} with {len(loaded_data)} records"
                 )
 
     async def filter_keys(self, keys: set[str]) -> set[str]:
@@ -90,6 +90,7 @@ class JsonDocStatusStorage(DocStatusStorage):
             data_dict = (
                 dict(self._data) if hasattr(self._data, "_getvalue") else self._data
             )
+            logger.info(f"Process {os.getpid()} doc status writting {len(data_dict)} records to {self.namespace}")
             write_json(data_dict, self._file_name)
 
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -33,7 +33,7 @@ class JsonDocStatusStorage(DocStatusStorage):
     async def initialize(self):
         """Initialize storage data"""
         # check need_init must before get_namespace_data
-        need_init = try_initialize_namespace(self.namespace)
+        need_init = await try_initialize_namespace(self.namespace)
         self._data = await get_namespace_data(self.namespace)
         if need_init:
             loaded_data = load_json(self._file_name) or {}

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -33,10 +33,10 @@ class JsonDocStatusStorage(DocStatusStorage):
     async def initialize(self):
         """Initialize storage data"""
         self._storage_lock = get_storage_lock()
-        self._data = await get_namespace_data(self.namespace)
         async with get_data_init_lock():
             # check need_init must before get_namespace_data
             need_init = await try_initialize_namespace(self.namespace)
+            self._data = await get_namespace_data(self.namespace)
             if need_init:
                 loaded_data = load_json(self._file_name) or {}
                 async with self._storage_lock:

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -20,7 +20,6 @@ from .shared_storage import (
     set_all_update_flags,
     clear_all_update_flags,
     try_initialize_namespace,
-    is_multiprocess,
 )
 
 
@@ -96,9 +95,7 @@ class JsonDocStatusStorage(DocStatusStorage):
 
     async def index_done_callback(self) -> None:
         async with self._storage_lock:
-            if (is_multiprocess and self.storage_updated.value) or (
-                not is_multiprocess and self.storage_updated
-            ):
+            if self.storage_updated.value:
                 data_dict = (
                     dict(self._data) if hasattr(self._data, "_getvalue") else self._data
                 )

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -16,6 +16,9 @@ from .shared_storage import (
     get_namespace_data,
     get_storage_lock,
     get_data_init_lock,
+    get_update_flag,
+    set_all_update_flags,
+    clear_all_update_flags,
     try_initialize_namespace,
 )
 
@@ -29,10 +32,13 @@ class JsonDocStatusStorage(DocStatusStorage):
         working_dir = self.global_config["working_dir"]
         self._file_name = os.path.join(working_dir, f"kv_store_{self.namespace}.json")
         self._data = None
+        self._storage_lock = None
+        self.storage_updated = None
 
     async def initialize(self):
         """Initialize storage data"""
         self._storage_lock = get_storage_lock()
+        self.storage_updated = await get_update_flag(self.namespace)
         async with get_data_init_lock():
             # check need_init must before get_namespace_data
             need_init = await try_initialize_namespace(self.namespace)
@@ -89,11 +95,13 @@ class JsonDocStatusStorage(DocStatusStorage):
 
     async def index_done_callback(self) -> None:
         async with self._storage_lock:
-            data_dict = (
-                dict(self._data) if hasattr(self._data, "_getvalue") else self._data
-            )
-            logger.info(f"Process {os.getpid()} doc status writting {len(data_dict)} records to {self.namespace}")
-            write_json(data_dict, self._file_name)
+            if self.storage_updated:
+                data_dict = (
+                    dict(self._data) if hasattr(self._data, "_getvalue") else self._data
+                )
+                logger.info(f"Process {os.getpid()} doc status writting {len(data_dict)} records to {self.namespace}")
+                write_json(data_dict, self._file_name)
+                await clear_all_update_flags(self.namespace)
 
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
         if not data:
@@ -101,6 +109,7 @@ class JsonDocStatusStorage(DocStatusStorage):
         logger.info(f"Inserting {len(data)} to {self.namespace}")
         async with self._storage_lock:
             self._data.update(data)
+            await set_all_update_flags(self.namespace)
 
         await self.index_done_callback()
 
@@ -112,9 +121,12 @@ class JsonDocStatusStorage(DocStatusStorage):
         async with self._storage_lock:
             for doc_id in doc_ids:
                 self._data.pop(doc_id, None)
+            await set_all_update_flags(self.namespace)
         await self.index_done_callback()
 
     async def drop(self) -> None:
         """Drop the storage"""
         async with self._storage_lock:
             self._data.clear()
+            await set_all_update_flags(self.namespace)
+        await self.index_done_callback()

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -96,11 +96,15 @@ class JsonDocStatusStorage(DocStatusStorage):
 
     async def index_done_callback(self) -> None:
         async with self._storage_lock:
-            if (is_multiprocess and self.storage_updated.value) or (not is_multiprocess and self.storage_updated):
+            if (is_multiprocess and self.storage_updated.value) or (
+                not is_multiprocess and self.storage_updated
+            ):
                 data_dict = (
                     dict(self._data) if hasattr(self._data, "_getvalue") else self._data
                 )
-                logger.info(f"Process {os.getpid()} doc status writting {len(data_dict)} records to {self.namespace}")
+                logger.info(
+                    f"Process {os.getpid()} doc status writting {len(data_dict)} records to {self.namespace}"
+                )
                 write_json(data_dict, self._file_name)
                 await clear_all_update_flags(self.namespace)
 

--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -108,7 +108,7 @@ class JsonKVStorage(BaseKVStorage):
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
         if not data:
             return
-        logger.info(f"Inserting {len(data)} to {self.namespace}")
+        logger.info(f"Inserting {len(data)} records to {self.namespace}")
         async with self._storage_lock:
             self._data.update(data)
             await set_all_update_flags(self.namespace)

--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -18,7 +18,6 @@ from .shared_storage import (
     set_all_update_flags,
     clear_all_update_flags,
     try_initialize_namespace,
-    is_multiprocess,
 )
 
 
@@ -63,9 +62,7 @@ class JsonKVStorage(BaseKVStorage):
 
     async def index_done_callback(self) -> None:
         async with self._storage_lock:
-            if (is_multiprocess and self.storage_updated.value) or (
-                not is_multiprocess and self.storage_updated
-            ):
+            if self.storage_updated.value:
                 data_dict = (
                     dict(self._data) if hasattr(self._data, "_getvalue") else self._data
                 )

--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -98,11 +98,9 @@ class JsonKVStorage(BaseKVStorage):
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
         if not data:
             return
+        logger.info(f"Inserting {len(data)} to {self.namespace}")
         async with self._storage_lock:
-            left_data = {k: v for k, v in data.items() if k not in self._data}
-            if left_data:
-                logger.info(f"Process {os.getpid()} KV inserting {len(left_data)} to {self.namespace}")
-                self._data.update(left_data)
+            self._data.update(data)
 
     async def delete(self, ids: list[str]) -> None:
         async with self._storage_lock:

--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -18,6 +18,7 @@ from .shared_storage import (
     set_all_update_flags,
     clear_all_update_flags,
     try_initialize_namespace,
+    is_multiprocess,
 )
 
 
@@ -57,7 +58,7 @@ class JsonKVStorage(BaseKVStorage):
 
     async def index_done_callback(self) -> None:
         async with self._storage_lock:
-            if self.storage_updated:
+            if (is_multiprocess and self.storage_updated.value) or (not is_multiprocess and self.storage_updated):
                 data_dict = (
                     dict(self._data) if hasattr(self._data, "_getvalue") else self._data
                 )

--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -29,10 +29,10 @@ class JsonKVStorage(BaseKVStorage):
     async def initialize(self):
         """Initialize storage data"""
         self._storage_lock = get_storage_lock()
-        self._data = await get_namespace_data(self.namespace)
         async with get_data_init_lock():
             # check need_init must before get_namespace_data
             need_init = await try_initialize_namespace(self.namespace)
+            self._data = await get_namespace_data(self.namespace)
             if need_init:
                 loaded_data = load_json(self._file_name) or {}
                 async with self._storage_lock:

--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -44,21 +44,28 @@ class JsonKVStorage(BaseKVStorage):
                 loaded_data = load_json(self._file_name) or {}
                 async with self._storage_lock:
                     self._data.update(loaded_data)
-                    
+
                     # Calculate data count based on namespace
                     if self.namespace.endswith("cache"):
                         # For cache namespaces, sum the cache entries across all cache types
-                        data_count = sum(len(first_level_dict) for first_level_dict in loaded_data.values() 
-                                        if isinstance(first_level_dict, dict))
+                        data_count = sum(
+                            len(first_level_dict)
+                            for first_level_dict in loaded_data.values()
+                            if isinstance(first_level_dict, dict)
+                        )
                     else:
                         # For non-cache namespaces, use the original count method
                         data_count = len(loaded_data)
-                    
-                    logger.info(f"Process {os.getpid()} KV load {self.namespace} with {data_count} records")
+
+                    logger.info(
+                        f"Process {os.getpid()} KV load {self.namespace} with {data_count} records"
+                    )
 
     async def index_done_callback(self) -> None:
         async with self._storage_lock:
-            if (is_multiprocess and self.storage_updated.value) or (not is_multiprocess and self.storage_updated):
+            if (is_multiprocess and self.storage_updated.value) or (
+                not is_multiprocess and self.storage_updated
+            ):
                 data_dict = (
                     dict(self._data) if hasattr(self._data, "_getvalue") else self._data
                 )
@@ -66,16 +73,20 @@ class JsonKVStorage(BaseKVStorage):
                 # Calculate data count based on namespace
                 if self.namespace.endswith("cache"):
                     # # For cache namespaces, sum the cache entries across all cache types
-                    data_count = sum(len(first_level_dict) for first_level_dict in data_dict.values() 
-                                    if isinstance(first_level_dict, dict))
+                    data_count = sum(
+                        len(first_level_dict)
+                        for first_level_dict in data_dict.values()
+                        if isinstance(first_level_dict, dict)
+                    )
                 else:
                     # For non-cache namespaces, use the original count method
                     data_count = len(data_dict)
-                    
-                logger.info(f"Process {os.getpid()} KV writting {data_count} records to {self.namespace}")
+
+                logger.info(
+                    f"Process {os.getpid()} KV writting {data_count} records to {self.namespace}"
+                )
                 write_json(data_dict, self._file_name)
                 await clear_all_update_flags(self.namespace)
-
 
     async def get_all(self) -> dict[str, Any]:
         """Get all data from storage

--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -29,7 +29,7 @@ class JsonKVStorage(BaseKVStorage):
     async def initialize(self):
         """Initialize storage data"""
         # check need_init must before get_namespace_data
-        need_init = try_initialize_namespace(self.namespace)
+        need_init = await try_initialize_namespace(self.namespace)
         self._data = await get_namespace_data(self.namespace)
         if need_init:
             loaded_data = load_json(self._file_name) or {}

--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -15,6 +15,7 @@ from tenacity import (
     retry_if_exception_type,
 )
 
+import logging
 from ..utils import logger
 from ..base import BaseGraphStorage
 from ..types import KnowledgeGraph, KnowledgeGraphNode, KnowledgeGraphEdge
@@ -37,6 +38,8 @@ config.read("config.ini", "utf-8")
 # Get maximum number of graph nodes from environment variable, default is 1000
 MAX_GRAPH_NODES = int(os.getenv("MAX_GRAPH_NODES", 1000))
 
+# Set neo4j logger level to ERROR to suppress warning logs
+logging.getLogger("neo4j").setLevel(logging.ERROR)
 
 @final
 @dataclass

--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -865,17 +865,17 @@ class Neo4JStorage(BaseGraphStorage):
                         if b_node.labels:  # Only process if target node has labels
                             # Create KnowledgeGraphNode for target
                             target_node = KnowledgeGraphNode(
-                                id=target_id,
+                                id=f"{target_id}",
                                 labels=list(b_node.labels),
                                 properties=dict(b_node),
                             )
 
                             # Create KnowledgeGraphEdge
                             target_edge = KnowledgeGraphEdge(
-                                id=edge_id,
+                                id=f"{edge_id}",
                                 type=rel.type,
-                                source=node.id,
-                                target=target_id,
+                                source=f"{node.id}",
+                                target=f"{target_id}",
                                 properties=dict(rel),
                             )
 
@@ -905,7 +905,7 @@ class Neo4JStorage(BaseGraphStorage):
 
                 # Create initial KnowledgeGraphNode
                 start_node = KnowledgeGraphNode(
-                    id=str(node_record["node_id"]),
+                    id=f"{node_record['node_id']}",
                     labels=list(node_record["n"].labels),
                     properties=dict(node_record["n"]),
                 )

--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -520,7 +520,7 @@ class Neo4JStorage(BaseGraphStorage):
                             edges.append((source_label, target_label))
 
                     await results.consume()  # Ensure results are consumed
-                    return edges if edges else None
+                    return edges
                 except Exception as e:
                     logger.error(f"Error getting edges for node {node_label}: {str(e)}")
                     await results.consume()  # Ensure results are consumed even on error

--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -176,11 +176,17 @@ class Neo4JStorage(BaseGraphStorage):
         # Noe4J handles persistence automatically
         pass
 
-    async def _ensure_label(self, label: str) -> str:
+    def _ensure_label(self, label: str) -> str:
         """Ensure a label is valid
 
         Args:
             label: The label to validate
+            
+        Returns:
+            str: The cleaned label
+            
+        Raises:
+            ValueError: If label is empty after cleaning
         """
         clean_label = label.strip('"')
         if not clean_label:
@@ -201,7 +207,7 @@ class Neo4JStorage(BaseGraphStorage):
             ValueError: If node_id is invalid
             Exception: If there is an error executing the query
         """
-        entity_name_label = await self._ensure_label(node_id)
+        entity_name_label = self._ensure_label(node_id)
         async with self._driver.session(
             database=self._DATABASE, default_access_mode="READ"
         ) as session:
@@ -233,8 +239,8 @@ class Neo4JStorage(BaseGraphStorage):
             ValueError: If either node_id is invalid
             Exception: If there is an error executing the query
         """
-        entity_name_label_source = await self._ensure_label(source_node_id)
-        entity_name_label_target = await self._ensure_label(target_node_id)
+        entity_name_label_source = self._ensure_label(source_node_id)
+        entity_name_label_target = self._ensure_label(target_node_id)
 
         async with self._driver.session(
             database=self._DATABASE, default_access_mode="READ"
@@ -269,7 +275,7 @@ class Neo4JStorage(BaseGraphStorage):
             ValueError: If node_id is invalid
             Exception: If there is an error executing the query
         """
-        entity_name_label = await self._ensure_label(node_id)
+        entity_name_label = self._ensure_label(node_id)
         async with self._driver.session(
             database=self._DATABASE, default_access_mode="READ"
         ) as session:
@@ -314,7 +320,7 @@ class Neo4JStorage(BaseGraphStorage):
             ValueError: If node_id is invalid
             Exception: If there is an error executing the query
         """
-        entity_name_label = await self._ensure_label(node_id)
+        entity_name_label = self._ensure_label(node_id)
 
         async with self._driver.session(
             database=self._DATABASE, default_access_mode="READ"
@@ -363,8 +369,8 @@ class Neo4JStorage(BaseGraphStorage):
         Returns:
             int: Sum of the degrees of both nodes
         """
-        entity_name_label_source = await self._ensure_label(src_id)
-        entity_name_label_target = await self._ensure_label(tgt_id)
+        entity_name_label_source = self._ensure_label(src_id)
+        entity_name_label_target = self._ensure_label(tgt_id)
 
         src_degree = await self.node_degree(entity_name_label_source)
         trg_degree = await self.node_degree(entity_name_label_target)
@@ -393,8 +399,8 @@ class Neo4JStorage(BaseGraphStorage):
             Exception: If there is an error executing the query
         """
         try:
-            entity_name_label_source = await self._ensure_label(source_node_id)
-            entity_name_label_target = await self._ensure_label(target_node_id)
+            entity_name_label_source = self._ensure_label(source_node_id)
+            entity_name_label_target = self._ensure_label(target_node_id)
 
             async with self._driver.session(
                 database=self._DATABASE, default_access_mode="READ"
@@ -484,7 +490,7 @@ class Neo4JStorage(BaseGraphStorage):
             Exception: If there is an error executing the query
         """
         try:
-            node_label = await self._ensure_label(source_node_id)
+            node_label = self._ensure_label(source_node_id)
 
             query = f"""MATCH (n:`{node_label}`)
                     OPTIONAL MATCH (n)-[r]-(connected)
@@ -543,7 +549,7 @@ class Neo4JStorage(BaseGraphStorage):
             node_id: The unique identifier for the node (used as label)
             node_data: Dictionary of node properties
         """
-        label = await self._ensure_label(node_id)
+        label = self._ensure_label(node_id)
         properties = node_data
 
         async def _do_upsert(tx: AsyncManagedTransaction):
@@ -591,8 +597,8 @@ class Neo4JStorage(BaseGraphStorage):
         Raises:
             ValueError: If either source or target node does not exist
         """
-        source_label = await self._ensure_label(source_node_id)
-        target_label = await self._ensure_label(target_node_id)
+        source_label = self._ensure_label(source_node_id)
+        target_label = self._ensure_label(target_node_id)
         edge_properties = edge_data
 
         # Check if both nodes exist
@@ -966,7 +972,7 @@ class Neo4JStorage(BaseGraphStorage):
         Args:
             node_id: The label of the node to delete
         """
-        label = await self._ensure_label(node_id)
+        label = self._ensure_label(node_id)
 
         async def _do_delete(tx: AsyncManagedTransaction):
             query = f"""
@@ -1024,8 +1030,8 @@ class Neo4JStorage(BaseGraphStorage):
             edges: List of edges to be deleted, each edge is a (source, target) tuple
         """
         for source, target in edges:
-            source_label = await self._ensure_label(source)
-            target_label = await self._ensure_label(target)
+            source_label = self._ensure_label(source)
+            target_label = self._ensure_label(target)
 
             async def _do_delete_edge(tx: AsyncManagedTransaction):
                 query = f"""

--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -842,7 +842,7 @@ class Neo4JStorage(BaseGraphStorage):
                                 seen_edges.add(edge_id)
 
                         logger.info(
-                            f"Subgraph query successful | Node count: {len(result.nodes)} | Edge count: {len(result.edges)}"
+                            f"Process {os.getpid()} graph query return: {len(result.nodes)} nodes, {len(result.edges)} edges"
                         )
                 finally:
                     await result_set.consume()  # Ensure result set is consumed

--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -843,7 +843,7 @@ class Neo4JStorage(BaseGraphStorage):
                 results = await session.run(query, {"node_id": node.id})
 
                 # Get all records and release database connection
-                records = await results.fetch()
+                records = await results.fetch(1000)  # Max neighbour nodes we can handled
                 await results.consume()  # Ensure results are consumed
 
                 # Nodes not connected to start node need to check degree

--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -181,10 +181,10 @@ class Neo4JStorage(BaseGraphStorage):
 
         Args:
             label: The label to validate
-            
+
         Returns:
             str: The cleaned label
-            
+
         Raises:
             ValueError: If label is empty after cleaning
         """
@@ -283,7 +283,9 @@ class Neo4JStorage(BaseGraphStorage):
                 query = f"MATCH (n:`{entity_name_label}` {{entity_id: $entity_id}}) RETURN n"
                 result = await session.run(query, entity_id=entity_name_label)
                 try:
-                    records = await result.fetch(2)  # Get 2 records for duplication check
+                    records = await result.fetch(
+                        2
+                    )  # Get 2 records for duplication check
 
                     if len(records) > 1:
                         logger.warning(
@@ -552,6 +554,7 @@ class Neo4JStorage(BaseGraphStorage):
 
         try:
             async with self._driver.session(database=self._DATABASE) as session:
+
                 async def execute_upsert(tx: AsyncManagedTransaction):
                     query = f"""
                     MERGE (n:`{label}` {{entity_id: $properties.entity_id}})
@@ -562,7 +565,7 @@ class Neo4JStorage(BaseGraphStorage):
                         f"Upserted node with label '{label}' and properties: {properties}"
                     )
                     await result.consume()  # Ensure result is fully consumed
-                
+
                 await session.execute_write(execute_upsert)
         except Exception as e:
             logger.error(f"Error during upsert: {str(e)}")
@@ -602,18 +605,26 @@ class Neo4JStorage(BaseGraphStorage):
             """
             result = await session.run(query)
             try:
-                records = await result.fetch(2)  # We only need to know if there are 0, 1, or >1 nodes
-                
+                records = await result.fetch(
+                    2
+                )  # We only need to know if there are 0, 1, or >1 nodes
+
                 if not records or records[0]["node_count"] == 0:
-                    raise ValueError(f"Neo4j: node with label '{node_label}' does not exist")
-                
+                    raise ValueError(
+                        f"Neo4j: node with label '{node_label}' does not exist"
+                    )
+
                 if records[0]["node_count"] > 1:
-                    raise ValueError(f"Neo4j: multiple nodes found with label '{node_label}', cannot determine unique node")
-                
+                    raise ValueError(
+                        f"Neo4j: multiple nodes found with label '{node_label}', cannot determine unique node"
+                    )
+
                 node = records[0]["n"]
                 if "entity_id" not in node:
-                    raise ValueError(f"Neo4j: node with label '{node_label}' does not have an entity_id property")
-                
+                    raise ValueError(
+                        f"Neo4j: node with label '{node_label}' does not have an entity_id property"
+                    )
+
                 return node["entity_id"]
             finally:
                 await result.consume()  # Ensure result is fully consumed
@@ -656,6 +667,7 @@ class Neo4JStorage(BaseGraphStorage):
 
         try:
             async with self._driver.session(database=self._DATABASE) as session:
+
                 async def execute_upsert(tx: AsyncManagedTransaction):
                     query = f"""
                     MATCH (source:`{source_label}` {{entity_id: $source_entity_id}})
@@ -666,10 +678,10 @@ class Neo4JStorage(BaseGraphStorage):
                     RETURN r, source, target
                     """
                     result = await tx.run(
-                        query, 
+                        query,
                         source_entity_id=source_entity_id,
                         target_entity_id=target_entity_id,
-                        properties=edge_properties
+                        properties=edge_properties,
                     )
                     try:
                         records = await result.fetch(100)
@@ -681,7 +693,7 @@ class Neo4JStorage(BaseGraphStorage):
                             )
                     finally:
                         await result.consume()  # Ensure result is consumed
-                
+
                 await session.execute_write(execute_upsert)
         except Exception as e:
             logger.error(f"Error during edge upsert: {str(e)}")
@@ -891,7 +903,9 @@ class Neo4JStorage(BaseGraphStorage):
                 results = await session.run(query, {"node_id": node.id})
 
                 # Get all records and release database connection
-                records = await results.fetch(1000)  # Max neighbour nodes we can handled
+                records = await results.fetch(
+                    1000
+                )  # Max neighbour nodes we can handled
                 await results.consume()  # Ensure results are consumed
 
                 # Nodes not connected to start node need to check degree

--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -164,23 +164,13 @@ class Neo4JStorage(BaseGraphStorage):
         # Noe4J handles persistence automatically
         pass
 
-    async def _label_exists(self, label: str) -> bool:
-        """Check if a label exists in the Neo4j database."""
-        query = "CALL db.labels() YIELD label RETURN label"
-        try:
-            async with self._driver.session(database=self._DATABASE) as session:
-                result = await session.run(query)
-                labels = [record["label"] for record in await result.data()]
-                return label in labels
-        except Exception as e:
-            logger.error(f"Error checking label existence: {e}")
-            return False
-
     async def _ensure_label(self, label: str) -> str:
-        """Ensure a label exists by validating it."""
+        """Ensure a label is valid
+        
+        Args:
+            label: The label to validate
+        """
         clean_label = label.strip('"')
-        if not await self._label_exists(clean_label):
-            logger.warning(f"Label '{clean_label}' does not exist in Neo4j")
         return clean_label
 
     async def has_node(self, node_id: str) -> bool:
@@ -290,7 +280,7 @@ class Neo4JStorage(BaseGraphStorage):
                 if record:
                     try:
                         result = dict(record["edge_properties"])
-                        logger.info(f"Result: {result}")
+                        logger.debug(f"Result: {result}")
                         # Ensure required keys exist with defaults
                         required_keys = {
                             "weight": 0.0,

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -344,6 +344,7 @@ async def set_all_update_flags(namespace: str):
             else:
                 _update_flags[namespace][i] = True
 
+
 async def clear_all_update_flags(namespace: str):
     """Clear all update flag of namespace indicating all workers need to reload data from files"""
     global _update_flags
@@ -359,6 +360,7 @@ async def clear_all_update_flags(namespace: str):
                 _update_flags[namespace][i].value = False
             else:
                 _update_flags[namespace][i] = False
+
 
 async def get_all_update_flags_status() -> Dict[str, list]:
     """

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -326,7 +326,7 @@ async def get_update_flag(namespace: str):
             class MutableBoolean:
                 def __init__(self, initial_value=False):
                     self.value = initial_value
-            
+
             new_update_flag = MutableBoolean(False)
 
         _update_flags[namespace].append(new_update_flag)

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -322,7 +322,12 @@ async def get_update_flag(namespace: str):
         if is_multiprocess and _manager is not None:
             new_update_flag = _manager.Value("b", False)
         else:
-            new_update_flag = False
+            # Create a simple mutable object to store boolean value for compatibility with mutiprocess
+            class MutableBoolean:
+                def __init__(self, initial_value=False):
+                    self.value = initial_value
+            
+            new_update_flag = MutableBoolean(False)
 
         _update_flags[namespace].append(new_update_flag)
         return new_update_flag
@@ -342,7 +347,8 @@ async def set_all_update_flags(namespace: str):
             if is_multiprocess:
                 _update_flags[namespace][i].value = True
             else:
-                _update_flags[namespace][i] = True
+                # Use .value attribute instead of direct assignment
+                _update_flags[namespace][i].value = True
 
 
 async def clear_all_update_flags(namespace: str):
@@ -359,7 +365,8 @@ async def clear_all_update_flags(namespace: str):
             if is_multiprocess:
                 _update_flags[namespace][i].value = False
             else:
-                _update_flags[namespace][i] = False
+                # Use .value attribute instead of direct assignment
+                _update_flags[namespace][i].value = False
 
 
 async def get_all_update_flags_status() -> Dict[str, list]:

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -286,6 +286,7 @@ async def initialize_pipeline_status():
         history_messages = _manager.list() if is_multiprocess else []
         pipeline_namespace.update(
             {
+                "autoscanned": False,  # Auto-scan started
                 "busy": False,  # Control concurrent processes
                 "job_name": "Default Job",  # Current job name (indexing files/indexing texts)
                 "job_start": None,  # Job start time

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -344,6 +344,21 @@ async def set_all_update_flags(namespace: str):
             else:
                 _update_flags[namespace][i] = True
 
+async def clear_all_update_flags(namespace: str):
+    """Clear all update flag of namespace indicating all workers need to reload data from files"""
+    global _update_flags
+    if _update_flags is None:
+        raise ValueError("Try to create namespace before Shared-Data is initialized")
+
+    async with get_internal_lock():
+        if namespace not in _update_flags:
+            raise ValueError(f"Namespace {namespace} not found in update flags")
+        # Update flags for both modes
+        for i in range(len(_update_flags[namespace])):
+            if is_multiprocess:
+                _update_flags[namespace][i].value = False
+            else:
+                _update_flags[namespace][i] = False
 
 async def get_all_update_flags_status() -> Dict[str, list]:
     """

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -7,12 +7,18 @@ from typing import Any, Dict, Optional, Union, TypeVar, Generic
 
 
 # Define a direct print function for critical logs that must be visible in all processes
-def direct_log(message, level="INFO"):
+def direct_log(message, level="INFO", enable_output: bool = True):
     """
     Log a message directly to stderr to ensure visibility in all processes,
     including the Gunicorn master process.
+    
+    Args:
+        message: The message to log
+        level: Log level (default: "INFO")
+        enable_output: Whether to actually output the log (default: True)
     """
-    print(f"{level}: {message}", file=sys.stderr, flush=True)
+    if enable_output:
+        print(f"{level}: {message}", file=sys.stderr, flush=True)
 
 
 T = TypeVar("T")
@@ -32,55 +38,88 @@ _update_flags: Optional[Dict[str, bool]] = None  # namespace -> updated
 _storage_lock: Optional[LockType] = None
 _internal_lock: Optional[LockType] = None
 _pipeline_status_lock: Optional[LockType] = None
+_graph_db_lock: Optional[LockType] = None
 
 
 class UnifiedLock(Generic[T]):
     """Provide a unified lock interface type for asyncio.Lock and multiprocessing.Lock"""
 
-    def __init__(self, lock: Union[ProcessLock, asyncio.Lock], is_async: bool):
+    def __init__(self, lock: Union[ProcessLock, asyncio.Lock], is_async: bool, name: str = "unnamed", enable_logging: bool = True):
         self._lock = lock
         self._is_async = is_async
+        self._pid = os.getpid()  # for debug only
+        self._name = name  # for debug only
+        self._enable_logging = enable_logging  # for debug only
 
     async def __aenter__(self) -> "UnifiedLock[T]":
-        if self._is_async:
-            await self._lock.acquire()
-        else:
-            self._lock.acquire()
-        return self
+        try:
+            direct_log(f"== Lock == Process {self._pid}: Acquiring lock '{self._name}' (async={self._is_async})", enable_output=self._enable_logging)
+            if self._is_async:
+                await self._lock.acquire()
+            else:
+                self._lock.acquire()
+            direct_log(f"== Lock == Process {self._pid}: Lock '{self._name}' acquired (async={self._is_async})", enable_output=self._enable_logging)
+            return self
+        except Exception as e:
+            direct_log(f"== Lock == Process {self._pid}: Failed to acquire lock '{self._name}': {e}", level="ERROR", enable_output=self._enable_logging)
+            raise
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        if self._is_async:
-            self._lock.release()
-        else:
-            self._lock.release()
+        try:
+            direct_log(f"== Lock == Process {self._pid}: Releasing lock '{self._name}' (async={self._is_async})", enable_output=self._enable_logging)
+            if self._is_async:
+                self._lock.release()
+            else:
+                self._lock.release()
+            direct_log(f"== Lock == Process {self._pid}: Lock '{self._name}' released (async={self._is_async})", enable_output=self._enable_logging)
+        except Exception as e:
+            direct_log(f"== Lock == Process {self._pid}: Failed to release lock '{self._name}': {e}", level="ERROR", enable_output=self._enable_logging)
+            raise
 
     def __enter__(self) -> "UnifiedLock[T]":
         """For backward compatibility"""
-        if self._is_async:
-            raise RuntimeError("Use 'async with' for shared_storage lock")
-        self._lock.acquire()
-        return self
+        try:
+            if self._is_async:
+                raise RuntimeError("Use 'async with' for shared_storage lock")
+            direct_log(f"== Lock == Process {self._pid}: Acquiring lock '{self._name}' (sync)", enable_output=self._enable_logging)
+            self._lock.acquire()
+            direct_log(f"== Lock == Process {self._pid}: Lock '{self._name}' acquired (sync)", enable_output=self._enable_logging)
+            return self
+        except Exception as e:
+            direct_log(f"== Lock == Process {self._pid}: Failed to acquire lock '{self._name}' (sync): {e}", level="ERROR", enable_output=self._enable_logging)
+            raise
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """For backward compatibility"""
-        if self._is_async:
-            raise RuntimeError("Use 'async with' for shared_storage lock")
-        self._lock.release()
+        try:
+            if self._is_async:
+                raise RuntimeError("Use 'async with' for shared_storage lock")
+            direct_log(f"== Lock == Process {self._pid}: Releasing lock '{self._name}' (sync)", enable_output=self._enable_logging)
+            self._lock.release()
+            direct_log(f"== Lock == Process {self._pid}: Lock '{self._name}' released (sync)", enable_output=self._enable_logging)
+        except Exception as e:
+            direct_log(f"== Lock == Process {self._pid}: Failed to release lock '{self._name}' (sync): {e}", level="ERROR", enable_output=self._enable_logging)
+            raise
 
 
-def get_internal_lock() -> UnifiedLock:
+def get_internal_lock(enable_logging: bool = False) -> UnifiedLock:
     """return unified storage lock for data consistency"""
-    return UnifiedLock(lock=_internal_lock, is_async=not is_multiprocess)
+    return UnifiedLock(lock=_internal_lock, is_async=not is_multiprocess, name="internal_lock", enable_logging=enable_logging)
 
 
-def get_storage_lock() -> UnifiedLock:
+def get_storage_lock(enable_logging: bool = False) -> UnifiedLock:
     """return unified storage lock for data consistency"""
-    return UnifiedLock(lock=_storage_lock, is_async=not is_multiprocess)
+    return UnifiedLock(lock=_storage_lock, is_async=not is_multiprocess, name="storage_lock", enable_logging=enable_logging)
 
 
-def get_pipeline_status_lock() -> UnifiedLock:
+def get_pipeline_status_lock(enable_logging: bool = False) -> UnifiedLock:
     """return unified storage lock for data consistency"""
-    return UnifiedLock(lock=_pipeline_status_lock, is_async=not is_multiprocess)
+    return UnifiedLock(lock=_pipeline_status_lock, is_async=not is_multiprocess, name="pipeline_status_lock", enable_logging=enable_logging)
+
+
+def get_graph_db_lock(enable_logging: bool = False) -> UnifiedLock:
+    """return unified graph database lock for ensuring atomic operations"""
+    return UnifiedLock(lock=_graph_db_lock, is_async=not is_multiprocess, name="graph_db_lock", enable_logging=enable_logging)
 
 
 def initialize_share_data(workers: int = 1):
@@ -108,6 +147,7 @@ def initialize_share_data(workers: int = 1):
         _storage_lock, \
         _internal_lock, \
         _pipeline_status_lock, \
+        _graph_db_lock, \
         _shared_dicts, \
         _init_flags, \
         _initialized, \
@@ -128,6 +168,7 @@ def initialize_share_data(workers: int = 1):
         _internal_lock = _manager.Lock()
         _storage_lock = _manager.Lock()
         _pipeline_status_lock = _manager.Lock()
+        _graph_db_lock = _manager.Lock()
         _shared_dicts = _manager.dict()
         _init_flags = _manager.dict()
         _update_flags = _manager.dict()
@@ -139,6 +180,7 @@ def initialize_share_data(workers: int = 1):
         _internal_lock = asyncio.Lock()
         _storage_lock = asyncio.Lock()
         _pipeline_status_lock = asyncio.Lock()
+        _graph_db_lock = asyncio.Lock()
         _shared_dicts = {}
         _init_flags = {}
         _update_flags = {}
@@ -304,6 +346,7 @@ def finalize_share_data():
         _storage_lock, \
         _internal_lock, \
         _pipeline_status_lock, \
+        _graph_db_lock, \
         _shared_dicts, \
         _init_flags, \
         _initialized, \
@@ -369,6 +412,7 @@ def finalize_share_data():
     _storage_lock = None
     _internal_lock = None
     _pipeline_status_lock = None
+    _graph_db_lock = None
     _update_flags = None
 
     direct_log(f"Process {os.getpid()} storage data finalization complete")

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -887,7 +887,9 @@ class LightRAG:
                                 self.chunks_vdb.upsert(chunks)
                             )
                             entity_relation_task = asyncio.create_task(
-                                self._process_entity_relation_graph(chunks, pipeline_status, pipeline_status_lock)
+                                self._process_entity_relation_graph(
+                                    chunks, pipeline_status, pipeline_status_lock
+                                )
                             )
                             full_docs_task = asyncio.create_task(
                                 self.full_docs.upsert(
@@ -1002,7 +1004,9 @@ class LightRAG:
                 pipeline_status["latest_message"] = log_message
                 pipeline_status["history_messages"].append(log_message)
 
-    async def _process_entity_relation_graph(self, chunk: dict[str, Any], pipeline_status=None, pipeline_status_lock=None) -> None:
+    async def _process_entity_relation_graph(
+        self, chunk: dict[str, Any], pipeline_status=None, pipeline_status_lock=None
+    ) -> None:
         try:
             await extract_entities(
                 chunk,
@@ -1018,7 +1022,9 @@ class LightRAG:
             logger.error("Failed to extract entities and relationships")
             raise e
 
-    async def _insert_done(self, pipeline_status=None, pipeline_status_lock=None) -> None:
+    async def _insert_done(
+        self, pipeline_status=None, pipeline_status_lock=None
+    ) -> None:
         tasks = [
             cast(StorageNameSpace, storage_inst).index_done_callback()
             for storage_inst in [  # type: ignore

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -354,7 +354,9 @@ class LightRAG:
             namespace=make_namespace(
                 self.namespace_prefix, NameSpace.KV_STORE_LLM_RESPONSE_CACHE
             ),
-            global_config=asdict(self),  # Add global_config to ensure cache works properly
+            global_config=asdict(
+                self
+            ),  # Add global_config to ensure cache works properly
             embedding_func=self.embedding_func,
         )
 

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -354,6 +354,7 @@ class LightRAG:
             namespace=make_namespace(
                 self.namespace_prefix, NameSpace.KV_STORE_LLM_RESPONSE_CACHE
             ),
+            global_config=asdict(self),  # Add global_config to ensure cache works properly
             embedding_func=self.embedding_func,
         )
 
@@ -404,18 +405,8 @@ class LightRAG:
             embedding_func=None,
         )
 
-        if self.llm_response_cache and hasattr(
-            self.llm_response_cache, "global_config"
-        ):
-            hashing_kv = self.llm_response_cache
-        else:
-            hashing_kv = self.key_string_value_json_storage_cls(  # type: ignore
-                namespace=make_namespace(
-                    self.namespace_prefix, NameSpace.KV_STORE_LLM_RESPONSE_CACHE
-                ),
-                global_config=asdict(self),
-                embedding_func=self.embedding_func,
-            )
+        # Directly use llm_response_cache, don't create a new object
+        hashing_kv = self.llm_response_cache
 
         self.llm_model_func = limit_async_func_call(self.llm_model_max_async)(
             partial(
@@ -1260,16 +1251,7 @@ class LightRAG:
                 self.text_chunks,
                 param,
                 asdict(self),
-                hashing_kv=self.llm_response_cache
-                if self.llm_response_cache
-                and hasattr(self.llm_response_cache, "global_config")
-                else self.key_string_value_json_storage_cls(
-                    namespace=make_namespace(
-                        self.namespace_prefix, NameSpace.KV_STORE_LLM_RESPONSE_CACHE
-                    ),
-                    global_config=asdict(self),
-                    embedding_func=self.embedding_func,
-                ),
+                hashing_kv=self.llm_response_cache,  # Directly use llm_response_cache
                 system_prompt=system_prompt,
             )
         elif param.mode == "naive":
@@ -1279,16 +1261,7 @@ class LightRAG:
                 self.text_chunks,
                 param,
                 asdict(self),
-                hashing_kv=self.llm_response_cache
-                if self.llm_response_cache
-                and hasattr(self.llm_response_cache, "global_config")
-                else self.key_string_value_json_storage_cls(
-                    namespace=make_namespace(
-                        self.namespace_prefix, NameSpace.KV_STORE_LLM_RESPONSE_CACHE
-                    ),
-                    global_config=asdict(self),
-                    embedding_func=self.embedding_func,
-                ),
+                hashing_kv=self.llm_response_cache,  # Directly use llm_response_cache
                 system_prompt=system_prompt,
             )
         elif param.mode == "mix":
@@ -1301,16 +1274,7 @@ class LightRAG:
                 self.text_chunks,
                 param,
                 asdict(self),
-                hashing_kv=self.llm_response_cache
-                if self.llm_response_cache
-                and hasattr(self.llm_response_cache, "global_config")
-                else self.key_string_value_json_storage_cls(
-                    namespace=make_namespace(
-                        self.namespace_prefix, NameSpace.KV_STORE_LLM_RESPONSE_CACHE
-                    ),
-                    global_config=asdict(self),
-                    embedding_func=self.embedding_func,
-                ),
+                hashing_kv=self.llm_response_cache,  # Directly use llm_response_cache
                 system_prompt=system_prompt,
             )
         else:
@@ -1344,14 +1308,7 @@ class LightRAG:
             text=query,
             param=param,
             global_config=asdict(self),
-            hashing_kv=self.llm_response_cache
-            or self.key_string_value_json_storage_cls(
-                namespace=make_namespace(
-                    self.namespace_prefix, NameSpace.KV_STORE_LLM_RESPONSE_CACHE
-                ),
-                global_config=asdict(self),
-                embedding_func=self.embedding_func,
-            ),
+            hashing_kv=self.llm_response_cache,  # Directly use llm_response_cache
         )
 
         param.hl_keywords = hl_keywords
@@ -1375,16 +1332,7 @@ class LightRAG:
                 self.text_chunks,
                 param,
                 asdict(self),
-                hashing_kv=self.llm_response_cache
-                if self.llm_response_cache
-                and hasattr(self.llm_response_cache, "global_config")
-                else self.key_string_value_json_storage_cls(
-                    namespace=make_namespace(
-                        self.namespace_prefix, NameSpace.KV_STORE_LLM_RESPONSE_CACHE
-                    ),
-                    global_config=asdict(self),
-                    embedding_func=self.embedding_func,
-                ),
+                hashing_kv=self.llm_response_cache,  # Directly use llm_response_cache
             )
         elif param.mode == "naive":
             response = await naive_query(
@@ -1393,16 +1341,7 @@ class LightRAG:
                 self.text_chunks,
                 param,
                 asdict(self),
-                hashing_kv=self.llm_response_cache
-                if self.llm_response_cache
-                and hasattr(self.llm_response_cache, "global_config")
-                else self.key_string_value_json_storage_cls(
-                    namespace=make_namespace(
-                        self.namespace_prefix, NameSpace.KV_STORE_LLM_RESPONSE_CACHE
-                    ),
-                    global_config=asdict(self),
-                    embedding_func=self.embedding_func,
-                ),
+                hashing_kv=self.llm_response_cache,  # Directly use llm_response_cache
             )
         elif param.mode == "mix":
             response = await mix_kg_vector_query(
@@ -1414,16 +1353,7 @@ class LightRAG:
                 self.text_chunks,
                 param,
                 asdict(self),
-                hashing_kv=self.llm_response_cache
-                if self.llm_response_cache
-                and hasattr(self.llm_response_cache, "global_config")
-                else self.key_string_value_json_storage_cls(
-                    namespace=make_namespace(
-                        self.namespace_prefix, NameSpace.KV_STORE_LLM_RESPONSE_CACHE
-                    ),
-                    global_config=asdict(self),
-                    embedding_func=self.embedding_func,
-                ),
+                hashing_kv=self.llm_response_cache,  # Directly use llm_response_cache
             )
         else:
             raise ValueError(f"Unknown mode {param.mode}")

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -341,7 +341,7 @@ async def extract_entities(
     relationships_vdb: BaseVectorStorage,
     global_config: dict[str, str],
     pipeline_status: dict = None,
-    pipeline_status_lock = None,
+    pipeline_status_lock=None,
     llm_response_cache: BaseKVStorage | None = None,
 ) -> None:
     use_llm_func: callable = global_config["llm_model_func"]

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -220,6 +220,7 @@ async def _merge_nodes_then_upsert(
         entity_name, description, global_config
     )
     node_data = dict(
+        entity_id=entity_name,
         entity_type=entity_type,
         description=description,
         source_id=source_id,
@@ -301,6 +302,7 @@ async def _merge_edges_then_upsert(
             await knowledge_graph_inst.upsert_node(
                 need_insert_id,
                 node_data={
+                    "entity_id": need_insert_id,
                     "source_id": source_id,
                     "description": description,
                     "entity_type": "UNKNOWN",

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -410,7 +410,6 @@ async def extract_entities(
                 _prompt,
                 "default",
                 cache_type="extract",
-                force_llm_cache=True,
             )
             if cached_return:
                 logger.debug(f"Found cache for {arg_hash}")
@@ -432,6 +431,7 @@ async def extract_entities(
                     cache_type="extract",
                 ),
             )
+            logger.info(f"Extract: saved cache for {arg_hash}")
             return res
 
         if history_messages:

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -403,6 +403,7 @@ async def extract_entities(
             else:
                 _prompt = input_text
 
+            # TODO： add cache_type="extract"
             arg_hash = compute_args_hash(_prompt)
             cached_return, _1, _2, _3 = await handle_cache(
                 llm_response_cache,
@@ -431,7 +432,6 @@ async def extract_entities(
                     cache_type="extract",
                 ),
             )
-            logger.info(f"Extract: saved cache for {arg_hash}")
             return res
 
         if history_messages:

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -522,8 +522,9 @@ async def extract_entities(
             maybe_edges[tuple(sorted(k))].extend(v)
 
     from .kg.shared_storage import get_graph_db_lock
-    graph_db_lock = get_graph_db_lock(enable_logging = True)
-    
+
+    graph_db_lock = get_graph_db_lock(enable_logging=True)
+
     # Ensure that nodes and edges are merged and upserted atomically
     async with graph_db_lock:
         all_entities_data = await asyncio.gather(
@@ -535,7 +536,9 @@ async def extract_entities(
 
         all_relationships_data = await asyncio.gather(
             *[
-                _merge_edges_then_upsert(k[0], k[1], v, knowledge_graph_inst, global_config)
+                _merge_edges_then_upsert(
+                    k[0], k[1], v, knowledge_graph_inst, global_config
+                )
                 for k, v in maybe_edges.items()
             ]
         )

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -523,7 +523,7 @@ async def extract_entities(
 
     from .kg.shared_storage import get_graph_db_lock
 
-    graph_db_lock = get_graph_db_lock(enable_logging=True)
+    graph_db_lock = get_graph_db_lock(enable_logging=False)
 
     # Ensure that nodes and edges are merged and upserted atomically
     async with graph_db_lock:

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+import os
 from typing import Any, AsyncIterator
 from collections import Counter, defaultdict
 
@@ -1027,6 +1028,7 @@ async def _build_query_context(
     text_chunks_db: BaseKVStorage,
     query_param: QueryParam,
 ):
+    logger.info(f"Process {os.getpid()} buidling query context...")
     if query_param.mode == "local":
         entities_context, relations_context, text_units_context = await _get_node_data(
             ll_keywords,

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -667,11 +667,11 @@ async def handle_cache(
                 cache_type=cache_type,
             )
             if best_cached_response is not None:
-                logger.info(f"Embedding cached hit(mode:{mode} type:{cache_type})")
+                logger.debug(f"Embedding cached hit(mode:{mode} type:{cache_type})")
                 return best_cached_response, None, None, None
             else:
                 # if caching keyword embedding is enabled, return the quantized embedding for saving it latter
-                logger.info(f"Embedding cached missed(mode:{mode} type:{cache_type})")
+                logger.debug(f"Embedding cached missed(mode:{mode} type:{cache_type})")
                 return None, quantized, min_val, max_val
 
     # For default mode or is_embedding_cache_enabled is False, use regular cache
@@ -681,10 +681,10 @@ async def handle_cache(
     else:
         mode_cache = await hashing_kv.get_by_id(mode) or {}
     if args_hash in mode_cache:
-        logger.info(f"Non-embedding cached hit(mode:{mode} type:{cache_type})")
+        logger.debug(f"Non-embedding cached hit(mode:{mode} type:{cache_type})")
         return mode_cache[args_hash]["return"], None, None, None
 
-    logger.info(f"Non-embedding cached missed(mode:{mode} type:{cache_type})")
+    logger.debug(f"Non-embedding cached missed(mode:{mode} type:{cache_type})")
     return None, None, None, None
 
 

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -706,7 +706,7 @@ class CacheData:
 
 async def save_to_cache(hashing_kv, cache_data: CacheData):
     """Save data to cache, with improved handling for streaming responses and duplicate content.
-    
+
     Args:
         hashing_kv: The key-value storage for caching
         cache_data: The cache data to save
@@ -714,12 +714,12 @@ async def save_to_cache(hashing_kv, cache_data: CacheData):
     # Skip if storage is None or content is a streaming response
     if hashing_kv is None or not cache_data.content:
         return
-    
+
     # If content is a streaming response, don't cache it
     if hasattr(cache_data.content, "__aiter__"):
         logger.debug("Streaming response detected, skipping cache")
         return
-    
+
     # Get existing cache data
     if exists_func(hashing_kv, "get_by_mode_and_id"):
         mode_cache = (
@@ -728,14 +728,16 @@ async def save_to_cache(hashing_kv, cache_data: CacheData):
         )
     else:
         mode_cache = await hashing_kv.get_by_id(cache_data.mode) or {}
-    
+
     # Check if we already have identical content cached
     if cache_data.args_hash in mode_cache:
         existing_content = mode_cache[cache_data.args_hash].get("return")
         if existing_content == cache_data.content:
-            logger.info(f"Cache content unchanged for {cache_data.args_hash}, skipping update")
+            logger.info(
+                f"Cache content unchanged for {cache_data.args_hash}, skipping update"
+            )
             return
-    
+
     # Update cache with new content
     mode_cache[cache_data.args_hash] = {
         "return": cache_data.content,
@@ -750,7 +752,7 @@ async def save_to_cache(hashing_kv, cache_data: CacheData):
         "embedding_max": cache_data.max_val,
         "original_prompt": cache_data.prompt,
     }
-    
+
     # Only upsert if there's actual new content
     await hashing_kv.upsert({cache_data.mode: mode_cache})
 

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -705,9 +705,22 @@ class CacheData:
 
 
 async def save_to_cache(hashing_kv, cache_data: CacheData):
-    if hashing_kv is None or hasattr(cache_data.content, "__aiter__"):
+    """Save data to cache, with improved handling for streaming responses and duplicate content.
+    
+    Args:
+        hashing_kv: The key-value storage for caching
+        cache_data: The cache data to save
+    """
+    # Skip if storage is None or content is a streaming response
+    if hashing_kv is None or not cache_data.content:
         return
-
+    
+    # If content is a streaming response, don't cache it
+    if hasattr(cache_data.content, "__aiter__"):
+        logger.debug("Streaming response detected, skipping cache")
+        return
+    
+    # Get existing cache data
     if exists_func(hashing_kv, "get_by_mode_and_id"):
         mode_cache = (
             await hashing_kv.get_by_mode_and_id(cache_data.mode, cache_data.args_hash)
@@ -715,7 +728,15 @@ async def save_to_cache(hashing_kv, cache_data: CacheData):
         )
     else:
         mode_cache = await hashing_kv.get_by_id(cache_data.mode) or {}
-
+    
+    # Check if we already have identical content cached
+    if cache_data.args_hash in mode_cache:
+        existing_content = mode_cache[cache_data.args_hash].get("return")
+        if existing_content == cache_data.content:
+            logger.info(f"Cache content unchanged for {cache_data.args_hash}, skipping update")
+            return
+    
+    # Update cache with new content
     mode_cache[cache_data.args_hash] = {
         "return": cache_data.content,
         "cache_type": cache_data.cache_type,
@@ -729,7 +750,8 @@ async def save_to_cache(hashing_kv, cache_data: CacheData):
         "embedding_max": cache_data.max_val,
         "original_prompt": cache_data.prompt,
     }
-
+    
+    # Only upsert if there's actual new content
     await hashing_kv.upsert({cache_data.mode: mode_cache})
 
 


### PR DESCRIPTION
## Description

Refactoring Neo4j implementation and fixing storage cache handling problem.

## Changes Made

### Neo4j Refactoring
- Fix duplicate nodes for same entity(label)  problem in Neo4j, by adding entity_id field as the key of node in Neo4j. Update MERGE query to use entity_id as key
- Change Neo4j graph relationships to undirected.
- Close Neo4j DB session properly and ensure all result is consumed
- Reduce the connection pool size from 800 to 50
- Suppress no lablel warning from DBMS
- 
### Bug fixed or improment on graph and storage operation
- Add async lock for atomic graph database operations, ensured atomic node/edge merge and insert operation
- Fix async namespace init problem for Gunicorn startup mode
- Fix KV storage persistance problem for LLM cache
- Unified llm_response_cache and hashing_kv, prevent creating new storage instance for hashing_kv
- Added update flag to avoid redundant llm cache updates
- Refactor pipeline status updates and entity extraction, let all parallel jobs using one pipe_status objects, mproved thread safety with pipeline_status_lock
- Marked insert_custom_chunks as deprecated

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

The Neo4j implementation still occasionally generates duplicate nodes and edges, and a resolution for this issue is currently pending.
