### PR TITLE
Resolve the issue with making API calls to Azure OpenAI service

### DIFF
--- a/lightrag/llm/azure_openai.py
+++ b/lightrag/llm/azure_openai.py
@@ -55,6 +55,7 @@ async def azure_openai_complete_if_cache(
 
     openai_async_client = AsyncAzureOpenAI(
         azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
+        azure_deployment=model,
         api_key=os.getenv("AZURE_OPENAI_API_KEY"),
         api_version=os.getenv("AZURE_OPENAI_API_VERSION"),
     )
@@ -136,6 +137,7 @@ async def azure_openai_embed(
 
     openai_async_client = AsyncAzureOpenAI(
         azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
+        azure_deployment=model,
         api_key=os.getenv("AZURE_OPENAI_API_KEY"),
         api_version=os.getenv("AZURE_OPENAI_API_VERSION"),
     )


### PR DESCRIPTION
<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

Specify `azure_deployment` parameter when calling Azure OpenAI service. This parameter is mandatory; otherwise, the constructed URL will not function correctly due to the underlying logic in the `AsyncAzureOpenAI` constructor.

```python
if azure_deployment is not None:
    base_url = f"{azure_endpoint.rstrip('/')}/openai/deployments/{azure_deployment}"
else:
    base_url = f"{azure_endpoint.rstrip('/')}/openai"
```

## Related Issues

I have not see the exact errors in #680, but this fix might be useful for others.

## Changes Made

Specify azure_deployment parameter when calling Azure OpenAI service.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

[Add any additional notes or context for the reviewer(s).]
