### PR TITLE
Fix the merge bug with Neo4j

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -2622,6 +2622,12 @@ class LightRAG:
 
             # 9. Delete source entities
             for entity_name in source_entities:
+                if entity_name == target_entity:
+                    logger.info(
+                        f"Skipping deletion of '{entity_name}' as it's also the target entity"
+                    )
+                    continue
+
                 # Delete entity node from knowledge graph
                 await self.chunk_entity_relation_graph.delete_node(entity_name)
 


### PR DESCRIPTION
<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

Fixed a bug where merging nodes in Neo4j as a graph database caused all nodes to be deleted when a merged node had the same name as one of the pre-merged nodes.

## Related Issues

Merging nodes in Neo4j as a graph database caused all nodes to be deleted when a merged node had the same name as one of the pre-merged nodes.

## Changes Made

Skipped deleting nodes with duplicate names during the deletion process.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

N/A
