### PR TITLE
Explicitly set API docs and schema URLs.

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -177,6 +177,9 @@ def create_app(args):
         if api_key
         else "",
         version=__api_version__,
+        openapi_url="/openapi.json",  # Explicitly set OpenAPI schema URL
+        docs_url="/docs",  # Explicitly set docs URL
+        redoc_url="/redoc",  # Explicitly set redoc URL
         openapi_tags=[{"name": "api"}],
         lifespan=lifespan,
     )

--- a/lightrag_webui/vite.config.ts
+++ b/lightrag_webui/vite.config.ts
@@ -26,7 +26,9 @@ export default defineConfig({
             target: import.meta.env.VITE_BACKEND_URL || 'http://localhost:9621',
             changeOrigin: true,
             rewrite: endpoint === '/api' ?
-              (path) => path.replace(/^\/api/, '') : undefined
+              (path) => path.replace(/^\/api/, '') :
+              endpoint === '/docs' || endpoint === '/openapi.json' ?
+                (path) => path : undefined
           }
         ])
       ) : {}


### PR DESCRIPTION
Make backend support frontend local proxy for dev mod

- Set OpenAPI schema URL to `/openapi.json`
- Set docs URL to `/docs`
- Set redoc URL to `/redoc`
- Update Vite config for API docs routing
- Ensure proper path handling for docs endpoints