### PR TITLE
fix continue prompt format error

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -404,7 +404,7 @@ async def extract_entities(
         language=language,
     )
 
-    continue_prompt = PROMPTS["entity_continue_extraction"]
+    continue_prompt = PROMPTS["entity_continue_extraction"].format(**context_base)
     if_loop_prompt = PROMPTS["entity_if_loop_extraction"]
 
     processed_chunks = 0


### PR DESCRIPTION
<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

Fixed a bug in the entity extraction process where placeholder variables in the `continue_prompt` were not being properly formatted with context values, potentially causing incorrect entity extraction results.

## Related Issues

Addresses an issue where entity extraction might fail or produce unexpected results due to unformatted placeholders in prompts.

## Changes Made

Modified the `extract_entities` function to properly format the `continue_prompt` with the context_base dictionary, ensuring all placeholders like {entity_types}, {tuple_delimiter}, etc. are correctly replaced with their actual values.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

N/A
