### PR TITLE
Improve Logging Configuration

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -794,10 +794,12 @@ class LightRAG:
                         "cur_batch": 0,
                         "request_pending": False,  # Clear any previous request
                         "latest_message": "",
+                        "history_messages": [],  # Initialize empty history_messages list
                     }
                 )
                 # Cleaning history_messages without breaking it as a shared list object
-                del pipeline_status["history_messages"][:]
+                if "history_messages" in pipeline_status:
+                    del pipeline_status["history_messages"][:]
             else:
                 # Another process is busy, just set request flag and return
                 pipeline_status["request_pending"] = True

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -794,12 +794,9 @@ class LightRAG:
                         "cur_batch": 0,
                         "request_pending": False,  # Clear any previous request
                         "latest_message": "",
-                        "history_messages": [],  # Initialize empty history_messages list
                     }
                 )
-                # Cleaning history_messages without breaking it as a shared list object
-                if "history_messages" in pipeline_status:
-                    del pipeline_status["history_messages"][:]
+                del pipeline_status["history_messages"][:]
             else:
                 # Another process is busy, just set request flag and return
                 pipeline_status["request_pending"] = True


### PR DESCRIPTION
Problem: The logging configuration currently lacks flexibility incase you want to run it in a container and want to only log to STDOUT.

The change adds an `enable_file_logging` parameter to `setup_logger` which:

- When `True` (default): Sets up both console and file logging
- When `False`: Sets up console logging only, skipping all file-related operations

The change also adds better error handling for file permission issues, allowing the logger to fall back to console-only logging if it can't create log files, rather than crashing.

This makes the logging system more flexible and resilient, especially in restricted environments where file writing might not be possible or desired.
