### PR TITLE
Fixed get_by_id type error in PSQL impl

### DIFF
--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -732,7 +732,7 @@ class PGDocStatusStorage(DocStatusStorage):
         if result is None or result == []:
             return None
         else:
-            return DocProcessingStatus(
+            return dict(
                 content=result[0]["content"],
                 content_length=result[0]["content_length"],
                 content_summary=result[0]["content_summary"],
@@ -1058,7 +1058,6 @@ class PGGraphStorage(BaseGraphStorage):
 
         Args:
             query (str): a cypher query to be executed
-            params (dict): parameters for the query
 
         Returns:
             list[dict[str, Any]]: a list of dictionaries containing the result set

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1473,8 +1473,7 @@ class LightRAG:
         """
         try:
             # 1. Get the document status and related data
-            doc_status = await self.doc_status.get_by_id(doc_id)
-            if not doc_status:
+            if not await self.doc_status.get_by_id(doc_id):
                 logger.warning(f"Document {doc_id} not found")
                 return
 


### PR DESCRIPTION
## Description
The baseclass 'DocStatusStorage' enforces the 'get_by_id' method to return a dict. However, the postgres implementation of that class returns a dataclass, which behaves differently.

## Related Issues

## Changes Made
- Changed return value from 'DocProcessingStatus' dataclass to a dict
- Some minor 'leave the place better behind' fixes

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes
I like the idea of returning an explicit type, rather than a dict. But since all the other implementations of 'DocStatusStorage' return a dict, I think we should adhere to the contract for now.
