### PR TITLE
Fix error  'history messages'

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1054,6 +1054,10 @@ class LightRAG:
         if pipeline_status is not None and pipeline_status_lock is not None:
             async with pipeline_status_lock:
                 pipeline_status["latest_message"] = log_message
+                # BEL: history_messages is missing
+                history_messages_available = pipeline_status.get('history_messages', False)
+                if not history_messages_available:
+                    pipeline_status['history_messages'] = ['BEL: initial history entry']
                 pipeline_status["history_messages"].append(log_message)
 
     def insert_custom_kg(

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -813,6 +813,9 @@ class LightRAG:
                     log_message = "All documents have been processed or are duplicates"
                     logger.info(log_message)
                     pipeline_status["latest_message"] = log_message
+                    history_messages_available = pipeline_status.get('history_messages', False)
+                    if not history_messages_available:
+                        pipeline_status['history_messages'] = ['BEL: initial history entry']
                     pipeline_status["history_messages"].append(log_message)
                     break
 
@@ -829,6 +832,9 @@ class LightRAG:
                 pipeline_status["docs"] += len(to_process_docs)
                 pipeline_status["batchs"] += len(docs_batches)
                 pipeline_status["latest_message"] = log_message
+                history_messages_available = pipeline_status.get('history_messages', False)
+                if not history_messages_available:
+                    pipeline_status['history_messages'] = ['BEL: initial history entry']
                 pipeline_status["history_messages"].append(log_message)
 
                 async def process_document(
@@ -915,6 +921,9 @@ class LightRAG:
                         logger.error(error_msg)
                         async with pipeline_status_lock:
                             pipeline_status["latest_message"] = error_msg
+                            history_messages_available = pipeline_status.get('history_messages', False)
+                            if not history_messages_available:
+                                pipeline_status['history_messages'] = ['BEL: initial history entry']
                             pipeline_status["history_messages"].append(error_msg)
 
                             # Cancel other tasks as they are no longer meaningful
@@ -951,6 +960,9 @@ class LightRAG:
                     logger.info(log_message)
                     pipeline_status["cur_batch"] = current_batch
                     pipeline_status["latest_message"] = log_message
+                    history_messages_available = pipeline_status.get('history_messages', False)
+                    if not history_messages_available:
+                        pipeline_status['history_messages'] = ['BEL: initial history entry']
                     pipeline_status["history_messages"].append(log_message)
 
                     doc_tasks = []
@@ -973,6 +985,9 @@ class LightRAG:
                     log_message = f"Completed batch {current_batch} of {total_batches}."
                     logger.info(log_message)
                     pipeline_status["latest_message"] = log_message
+                    history_messages_available = pipeline_status.get('history_messages', False)
+                    if not history_messages_available:
+                        pipeline_status['history_messages'] = ['BEL: initial history entry']
                     pipeline_status["history_messages"].append(log_message)
 
                 # Check if there's a pending request to process more documents (with lock)
@@ -989,6 +1004,9 @@ class LightRAG:
                 log_message = "Processing additional documents due to pending request"
                 logger.info(log_message)
                 pipeline_status["latest_message"] = log_message
+                history_messages_available = pipeline_status.get('history_messages', False)
+                if not history_messages_available:
+                    pipeline_status['history_messages'] = ['BEL: initial history entry']
                 pipeline_status["history_messages"].append(log_message)
 
                 # Check for pending documents again
@@ -1010,6 +1028,9 @@ class LightRAG:
             async with pipeline_status_lock:
                 pipeline_status["busy"] = False
                 pipeline_status["latest_message"] = log_message
+                history_messages_available = pipeline_status.get('history_messages', False)
+                if not history_messages_available:
+                    pipeline_status['history_messages'] = ['BEL: initial history entry']
                 pipeline_status["history_messages"].append(log_message)
 
     async def _process_entity_relation_graph(


### PR DESCRIPTION
<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

Using kotaemon with lightrag, I get this error message, when adding files to lightrag:

Indexing [1/1]: AMF-Imagebroschuere.pdf
 => Converting AMF-Imagebroschuere.pdf to text
 => Converted AMF-Imagebroschuere.pdf to text
 => [AMF-Imagebroschuere.pdf] Processed 28 chunks
 => Finished indexing AMF-Imagebroschuere.pdf
[GraphRAG] Creating/Updating index... This can take a long time.
[GraphRAG] Creating index: 0 / 14 documents.
Error: 'history_messages'


## Related Issues

When 
light_rag.insert_custom_chunks(doc, chunks)
is used, it seems to happen under specific circumstances.

## Changes Made

        #REPLACED
        pipeline_status["history_messages"].append(log_message)

        #by:
        
        # BEL: history_messages is missing
        history_messages_available = pipeline_status.get('history_messages', False)
        if not history_messages_available:
           pipeline_status['history_messages'] = ['BEL: initial history entry'] 
        pipeline_status["history_messages"].append(log_message)
        
        # in lightrag.py
        
## Checklist

- [?] Changes tested locally: Do not know how
- [?] Code reviewed: Nobody there to do
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

It seems to NOT BE IDEAL, because it is not getting to the root. But I want to use it.
I may thank anybody who is more into it to fix it at the root.

