### PR TITLE
Resolved issue with upsert of PG entity and relation

### DIFF
--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -8,7 +8,7 @@ import numpy as np
 import configparser
 
 from lightrag.types import KnowledgeGraph, KnowledgeGraphNode, KnowledgeGraphEdge
-from prompt import GRAPH_FIELD_SEP
+from lightrag.prompt import GRAPH_FIELD_SEP
 
 import sys
 from tenacity import (

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -223,11 +223,12 @@ async def _merge_nodes_then_upsert(
         already_source_ids.extend(
             split_string_by_multi_markers(already_node["source_id"], [GRAPH_FIELD_SEP])
         )
-        already_file_paths.extend(
-            split_string_by_multi_markers(
-                already_node["metadata"]["file_path"], [GRAPH_FIELD_SEP]
+        if "metadata" in already_node and "file_path" in already_node["metadata"]:
+            already_file_paths.extend(
+                split_string_by_multi_markers(
+                    already_node["metadata"]["file_path"], [GRAPH_FIELD_SEP]
+                )
             )
-        )
         already_description.append(already_node["description"])
 
     entity_type = sorted(
@@ -295,7 +296,7 @@ async def _merge_edges_then_upsert(
                 )
 
             # Get file_path with empty string default if missing or None
-            if already_edge.get("file_path") is not None:
+            if already_edge.get("file_path") is not None and "metadata" in already_edge:
                 already_file_paths.extend(
                     split_string_by_multi_markers(
                         already_edge["metadata"]["file_path"], [GRAPH_FIELD_SEP]


### PR DESCRIPTION
## Description
This PR complements [PR #1120 "fix: correct chunk_ids as array type and remove incorrect filepath type conversion"](https://github.com/HKUDS/LightRAG/pull/1120) with a few additional improvements

## Related Issues
Addresses the "entity and relation upsert error" as well as missing "metadata" key errors encountered during the insertion of entities and relationships into the PostgreSQL database.

## Changes Made
- Fixed SQL template for entity upsert by adding CURRENT_TIMESTAMP for update_time column
- Added conditional check for metadata and file_path keys in graph node extraction
- Fixed parameter type casting for content_vector in relationship insertion query
- Ensured proper alignment between SQL parameter placeholders and data dictionary values

## Checklist
- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes
The fix ensures data integrity during entity and relationship extraction operations by resolving SQL syntax errors that were preventing proper document processing.
