### PR TITLE
Fix mongo doc status

### DIFF
--- a/env.example
+++ b/env.example
@@ -142,9 +142,16 @@ NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD='your_password'
 
 ### MongoDB Configuration
-MONGODB_URI=mongodb://root:root@localhost:27017/
-MONGODB_DATABASE=LightRAG
+MONGO_URI=mongodb://root:root@localhost:27017/
+MONGO_DATABASE=LightRAG
 MONGODB_GRAPH=false # deprecated (keep for backward compatibility)
+
+### Milvus Configuration
+MILVUS_URI=http://localhost:19530
+MILVUS_DB_NAME=lightrag
+# MILVUS_USER=root
+# MILVUS_PASSWORD=your_password
+# MILVUS_TOKEN=your_token
 
 ### Qdrant
 QDRANT_URL=http://localhost:16333

--- a/lightrag/api/README.md
+++ b/lightrag/api/README.md
@@ -267,7 +267,7 @@ OracleGraphStorage   Postgres
 
 ```
 NanoVectorDBStorage         NanoVector(default)
-MilvusVectorDBStorge        Milvus
+MilvusVectorDBStorage       Milvus
 ChromaVectorDBStorage       Chroma
 TiDBVectorDBStorage         TiDB
 PGVectorStorage             Postgres

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -221,6 +221,7 @@ class MongoDocStatusStorage(DocStatusStorage):
                 created_at=doc.get("created_at"),
                 updated_at=doc.get("updated_at"),
                 chunks_count=doc.get("chunks_count", -1),
+                file_path=doc.get("file_path", doc["_id"])
             )
             for doc in result
         }


### PR DESCRIPTION
## Description

The MongoDocStatusStorage's get_docs_by_status() method constructs DocProcessingStatus without required `file_path` attribute, this will cause error when insert documents into lightrag.

## Related Issues

#843 

## Changes Made

Add the missing file_path attribute and use `_id` as default value.

```python
async def get_docs_by_status(
    self, status: DocStatus
) -> dict[str, DocProcessingStatus]:
    """Get all documents with a specific status"""
    cursor = self._data.find({"status": status.value})
    result = await cursor.to_list()
    return {
        doc["_id"]: DocProcessingStatus(
            content=doc["content"],
            content_summary=doc.get("content_summary"),
            content_length=doc["content_length"],
            status=doc["status"],
            created_at=doc.get("created_at"),
            updated_at=doc.get("updated_at"),
            chunks_count=doc.get("chunks_count", -1),
            file_path=doc.get("file_path", doc["_id"])
        )
        for doc in result
    }
```

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (also fixed some Milvus configuration)
- [ ] Unit tests added
