### PR TITLE
Un-center README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@
 </tr>
 </table>
 
-
 <img src="./README.assets/b2aaf634151b4706892693ffb43d9093.png" width="800" alt="LightRAG Diagram">
+
+</div>
 
 ## 🎉 News
 


### PR DESCRIPTION
README.md seems to have a missed close </div>, causing the entire page to get centered -- it makes the code examples especially hard to read :)
