### PR TITLE
upgraded to use current folder's .env if present

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -43,12 +43,12 @@ from lightrag.kg.shared_storage import (
     initialize_pipeline_status,
 )
 from fastapi.security import OAuth2PasswordRequestForm
-from .auth import auth_handler
+from lightrag.api.auth import auth_handler
 
 # Load environment variables
 # Updated to use the .env that is inside the current folder
 # This update allows the user to put a different.env file for each lightrag folder
-load_dotenv()
+load_dotenv(".env")
 
 # Initialize config parser
 config = configparser.ConfigParser()

--- a/lightrag/api/run_with_gunicorn.py
+++ b/lightrag/api/run_with_gunicorn.py
@@ -13,7 +13,7 @@ from dotenv import load_dotenv
 
 # Updated to use the .env that is inside the current folder
 # This update allows the user to put a different.env file for each lightrag folder
-load_dotenv()
+load_dotenv(".env")
 
 
 def check_and_install_dependencies():


### PR DESCRIPTION
# Enhanced Environment Configuration for Multiple LightRAG Instances

## Overview
This PR enhances environment variable handling to support running multiple instances of LightRAG simultaneously.

## Key Changes
- Added support for using the `.env` file from the execution folder by default

## Use Case
This enables a powerful workflow where users can:
1. Create separate folders, each containing:
   - A custom `.env` configuration file
   - An `inputs` folder for instance-specific data

## Benefits
- Run multiple LightRAG instances (datalates) in parallel
- Configure each instance independently with different:
  - LLM models
  - Embedding models
  - Port numbers
  - OLLAMA simulated service names
  - Other environment-specific settings

## How to Use
Simply create a new folder structure, add your custom `.env` file, and launch the LightRAG server from that location.
