### PR TITLE
Refactor: Standardize .env loading behavior across modules

### DIFF
--- a/lightrag/api/auth.py
+++ b/lightrag/api/auth.py
@@ -5,7 +5,10 @@ from fastapi import HTTPException, status
 from pydantic import BaseModel
 from dotenv import load_dotenv
 
-load_dotenv()
+# use the .env that is inside the current folder
+# allows to use different .env file for each lightrag instance
+# the OS environment variables take precedence over the .env file
+load_dotenv(dotenv_path=".env", override=False)
 
 
 class TokenPayload(BaseModel):

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -47,10 +47,10 @@ from lightrag.kg.shared_storage import (
 from fastapi.security import OAuth2PasswordRequestForm
 from lightrag.api.auth import auth_handler
 
-# Load environment variables
-# Updated to use the .env that is inside the current folder
-# This update allows the user to put a different.env file for each lightrag folder
-load_dotenv(".env")
+# use the .env that is inside the current folder
+# allows to use different .env file for each lightrag instance
+# the OS environment variables take precedence over the .env file
+load_dotenv(dotenv_path=".env", override=False)
 
 # Initialize config parser
 config = configparser.ConfigParser()

--- a/lightrag/api/run_with_gunicorn.py
+++ b/lightrag/api/run_with_gunicorn.py
@@ -11,9 +11,10 @@ from lightrag.api.utils_api import parse_args, display_splash_screen, check_env_
 from lightrag.kg.shared_storage import initialize_share_data, finalize_share_data
 from dotenv import load_dotenv
 
-# Updated to use the .env that is inside the current folder
-# This update allows the user to put a different.env file for each lightrag folder
-load_dotenv(".env")
+# use the .env that is inside the current folder
+# allows to use different .env file for each lightrag instance
+# the OS environment variables take precedence over the .env file
+load_dotenv(dotenv_path=".env", override=False)
 
 
 def check_and_install_dependencies():

--- a/lightrag/api/utils_api.py
+++ b/lightrag/api/utils_api.py
@@ -38,8 +38,10 @@ def check_env_file():
     return True
 
 
-# Load environment variables
-load_dotenv()
+# use the .env that is inside the current folder
+# allows to use different .env file for each lightrag instance
+# the OS environment variables take precedence over the .env file
+load_dotenv(dotenv_path=".env", override=False)
 
 global_args = {"main_args": None}
 

--- a/lightrag/api/utils_api.py
+++ b/lightrag/api/utils_api.py
@@ -25,7 +25,7 @@ def check_env_file():
     """
     if not os.path.exists(".env"):
         warning_msg = (
-            "Warning: .env file not found. Some features may not work properly."
+            "Warning: Startup directory must contain .env file for multi-instance support."
         )
         ASCIIColors.yellow(warning_msg)
 

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -19,9 +19,10 @@ import tiktoken
 from lightrag.prompt import PROMPTS
 from dotenv import load_dotenv
 
-# Load environment variables
-load_dotenv(override=True)
-
+# use the .env that is inside the current folder
+# allows to use different .env file for each lightrag instance
+# the OS environment variables take precedence over the .env file
+load_dotenv(dotenv_path=".env", override=False)
 
 VERBOSE_DEBUG = os.getenv("VERBOSE", "false").lower() == "true"
 


### PR DESCRIPTION
refactor: standardize .env loading behavior across modules

- Use .env from current folder for each lightrag instance
- Allow different .env files for different instances
- Make OS env vars take precedence over .env file
