### PR TITLE
fix(useLightragGraph): Change the label of the edge from type to keyword

### DIFF
--- a/lightrag_webui/src/hooks/useLightragGraph.tsx
+++ b/lightrag_webui/src/hooks/useLightragGraph.tsx
@@ -205,7 +205,7 @@ const createSigmaGraph = (rawGraph: RawGraph | null) => {
   // Add edges from raw graph data
   for (const rawEdge of rawGraph?.edges ?? []) {
     rawEdge.dynamicId = graph.addDirectedEdge(rawEdge.source, rawEdge.target, {
-      label: rawEdge.type || undefined
+      label: rawEdge.properties?.keywords || undefined
     })
   }
 
@@ -660,7 +660,7 @@ const useLightrangeGraph = () => {
 
           // Add the edge to the sigma graph
           newEdge.dynamicId = sigmaGraph.addDirectedEdge(newEdge.source, newEdge.target, {
-            label: newEdge.type || undefined
+            label: newEdge.properties?.keywords || undefined
           });
 
           // Add the edge to the raw graph


### PR DESCRIPTION
## Description

At present, all edge labels display the hard coded 'Directed', and it is unclear how they were designed and considered. Do you feel like changing it to properties Keywords are more meaningful？

Also, can we associate the weights of edge with their thickness? If so, I will develop this area

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)
