### PR TITLE
fix(postgres_impl): added file_path to queries

### DIFF
--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -1648,7 +1648,7 @@ SQL_TEMPLATES = {
                                 FROM LIGHTRAG_DOC_FULL WHERE workspace=$1 AND id=$2
                             """,
     "get_by_id_text_chunks": """SELECT id, tokens, COALESCE(content, '') as content,
-                                chunk_order_index, full_doc_id
+                                chunk_order_index, full_doc_id, file_path
                                 FROM LIGHTRAG_DOC_CHUNKS WHERE workspace=$1 AND id=$2
                             """,
     "get_by_id_llm_response_cache": """SELECT id, original_prompt, COALESCE(return_value, '') as "return", mode
@@ -1661,7 +1661,7 @@ SQL_TEMPLATES = {
                                  FROM LIGHTRAG_DOC_FULL WHERE workspace=$1 AND id IN ({ids})
                             """,
     "get_by_ids_text_chunks": """SELECT id, tokens, COALESCE(content, '') as content,
-                                  chunk_order_index, full_doc_id
+                                  chunk_order_index, full_doc_id, file_path
                                    FROM LIGHTRAG_DOC_CHUNKS WHERE workspace=$1 AND id IN ({ids})
                                 """,
     "get_by_ids_llm_response_cache": """SELECT id, original_prompt, COALESCE(return_value, '') as "return", mode


### PR DESCRIPTION
## Description

Added 'file_path' to both get_by_id queries of the postgresql implementation, since they were still missing, which caused the new citation feature to not work when using postgres (and furthermore causes crashes when trying to query).

There is also another fix currently in PR, which adds at least a failsafe in case of doubt when not finding file paths. This fix provides the file paths when using postgres

## Related Issues

Related to PR #1264 
Fixes the same problem (at least partially since it would still crash if file_path is empty), but also adds support for acutally getting the file_paths

## Changes Made

- Modified postgres_impl.py and added 'file_path' to both get_by_id queries

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

No futher notes since all was covered in the previous texts
