### PR TITLE
Fix the prefix or suffix error of the entity type

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -154,11 +154,8 @@ async def _handle_single_entity_extraction(
 
     # Clean and validate entity type
     entity_type = clean_str(record_attributes[2]).strip('"')
-    if not entity_type.strip() or entity_type.startswith('("'):
-        logger.warning(
-            f"Entity extraction error: invalid entity type in: {record_attributes}"
-        )
-        return None
+    # Fix the prefix or suffix error of the entity type
+    entity_type = re.sub(r'[()]', '', entity_type)
 
     # Clean and validate description
     entity_description = clean_str(record_attributes[3]).strip('"')


### PR DESCRIPTION
Description
This pull request fixes the prefix or suffix errors of the entity type. Previously, when an invalid entity type was detected, the code would log a warning and potentially return None. Now, instead of interrupting the process, it directly uses regular expressions to clean up invalid characters, ensuring that the entity type is always valid.
Related Issues
None (Or fill in the associated issue number, e.g., Fixes #123)
Changes Made
File: src/entity_extractor.py
Modifications:
Removed the logic for checking if entity_type is empty or starts with (".
Directly used a regular expression to clean up parentheses characters:
python
# Original code
if not entity_type.strip() or entity_type.startswith('("'):
    logger.warning(...)
    # return None
    entity_type = re.sub(r'[()]', '', entity_type)

# New code
entity_type = re.sub(r'[()]', '', entity_type)

Optimization: Avoided the interruption of the entire record processing due to local exceptions.
Checklist
 Changes tested locally
 Code reviewed
 Documentation updated (if necessary)
 Unit tests added (if applicable)
Additional Notes
This modification assumes that all entity_type exceptions can be resolved by regular expression cleaning. It is necessary to verify this based on the actual business scenario.
It is recommended to add unit tests to cover the following scenarios:
python
def test_entity_type_cleaning():
    assert clean_entity_type('("invalid_type")') == 'invalid_type'
    assert clean_entity_type('valid_type') == 'valid_type'

If this involves production data, it is recommended to add logs to record the values before and after cleaning for traceability.