### PR TITLE
Add /context query prefix to Ollama model simulation for LightRAG Server

### DIFF
--- a/lightrag/api/routers/ollama_api.py
+++ b/lightrag/api/routers/ollama_api.py
@@ -23,6 +23,7 @@ class SearchMode(str, Enum):
     hybrid = "hybrid"
     mix = "mix"
     bypass = "bypass"
+    context = "context"
 
 
 class OllamaMessage(BaseModel):
@@ -111,6 +112,7 @@ def parse_query_mode(query: str) -> tuple[str, SearchMode]:
         "/hybrid ": SearchMode.hybrid,
         "/mix ": SearchMode.mix,
         "/bypass ": SearchMode.bypass,
+        "/context": SearchMode.context,
     }
 
     for prefix, mode in mode_map.items():
@@ -336,6 +338,26 @@ class OllamaAPI:
             Detects and forwards OpenWebUI session-related requests (for meta data generation task) directly to LLM.
             """
             try:
+                if True:
+                    # 打印完整请求体
+                    request_body = await raw_request.body()
+                    try:
+                        request_json = json.loads(request_body.decode("utf-8"))
+                        logging.info(
+                            f"Full chat request body: {json.dumps(request_json, indent=2, ensure_ascii=False)}"
+                        )
+                    except json.JSONDecodeError:
+                        logging.warning(
+                            f"Could not decode request body: {request_body}"
+                        )
+
+                    # 获取所有消息
+                    messages = request.messages
+                    if not messages:
+                        raise HTTPException(
+                            status_code=400, detail="No messages provided"
+                        )
+
                 # Get all messages
                 messages = request.messages
                 if not messages:

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1337,7 +1337,7 @@ class LightRAG:
         # If a custom model is provided in param, temporarily update global config
         global_config = asdict(self)
 
-        if param.mode in ["local", "global", "hybrid"]:
+        if param.mode in ["local", "global", "hybrid", "context"]:
             response = await kg_query(
                 query.strip(),
                 self.chunk_entity_relation_graph,

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -736,6 +736,9 @@ async def kg_query(
         query_param,
     )
 
+    if query_param.mode == "context":
+        return context
+
     if query_param.only_need_context:
         return context
     if context is None:
@@ -766,6 +769,7 @@ async def kg_query(
         system_prompt=sys_prompt,
         stream=query_param.stream,
     )
+
     if isinstance(response, str) and len(response) > len(sys_prompt):
         response = (
             response.replace(sys_prompt, "")


### PR DESCRIPTION
## Description

When you use LightRAG as an Ollama module and prepend your message with /context, LightRAG now will return only the knowledge and documents, without processing them through LLMs.


![Dify Test](https://github.com/user-attachments/assets/94dd723f-5037-44c5-9ecc-46925e4cc5dd)

## Related Issues
Add /context query prefix to Ollama model simulation for LightRAG Server #1287
[[Reference any related issues or tasks addressed by this pull request.]](https://github.com/HKUDS/LightRAG/issues/1287)

## Changes Made

`operate.py`
`lightrag.py`
`ollama_api.py`

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes
