### PR TITLE
Add /context query prefix to Ollama model simulation for LightRAG Server

### DIFF
--- a/lightrag/api/routers/ollama_api.py
+++ b/lightrag/api/routers/ollama_api.py
@@ -23,6 +23,7 @@ class SearchMode(str, Enum):
     hybrid = "hybrid"
     mix = "mix"
     bypass = "bypass"
+    context = "context"
 
 
 class OllamaMessage(BaseModel):
@@ -111,6 +112,7 @@ def parse_query_mode(query: str) -> tuple[str, SearchMode]:
         "/hybrid ": SearchMode.hybrid,
         "/mix ": SearchMode.mix,
         "/bypass ": SearchMode.bypass,
+        "/context": SearchMode.context,
     }
 
     for prefix, mode in mode_map.items():
@@ -354,10 +356,16 @@ class OllamaAPI:
                 start_time = time.time_ns()
                 prompt_tokens = estimate_tokens(cleaned_query)
 
+                if mode == SearchMode.context:
+                    mode = SearchMode.hybrid
+                    only_need_context = True
+                else:
+                    only_need_context = False
+
                 param_dict = {
                     "mode": mode,
                     "stream": request.stream,
-                    "only_need_context": False,
+                    "only_need_context": only_need_context,
                     "conversation_history": conversation_history,
                     "top_k": self.top_k,
                 }


### PR DESCRIPTION
## Description
When you use LightRAG as an Ollama module and prepend your message with /context, LightRAG now will return only the knowledge and documents, without processing them through LLMs.
![image](https://github.com/user-attachments/assets/4b7ae139-5839-42e9-88cd-18677d25784d)

## Related Issues
Add /context query prefix to Ollama model simulation for LightRAG Server #1287
[[Reference any related issues or tasks addressed by this pull request.]](https://github.com/HKUDS/LightRAG/issues/1287)

## Changes Made
ollama_api.py:
A /context mode has been added. Knowledge is extracted in hybrid mode (because I didn't make changes to other files, and they are not compatible with context mode).

## Checklist
- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes