### PR TITLE
Fixed null value handling and ensure exceptions are avoided

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -1363,6 +1363,7 @@ async def _find_most_related_text_unit_from_entities(
     text_units = [
         split_string_by_multi_markers(dp["source_id"], [GRAPH_FIELD_SEP])
         for dp in node_datas
+        if dp["source_id"] is not None
     ]
     edges = await asyncio.gather(
         *[knowledge_graph_inst.get_node_edges(dp["entity_name"]) for dp in node_datas]
@@ -1657,6 +1658,7 @@ async def _find_most_related_entities_from_relationships(
     node_datas = [
         {**n, "entity_name": k, "rank": d}
         for k, n, d in zip(entity_names, node_datas, node_degrees)
+        if n is not None
     ]
 
     len_node_datas = len(node_datas)
@@ -1681,6 +1683,7 @@ async def _find_related_text_unit_from_relationships(
     text_units = [
         split_string_by_multi_markers(dp["source_id"], [GRAPH_FIELD_SEP])
         for dp in edge_datas
+        if dp["source_id"] is not None
     ]
     all_text_units_lookup = {}
 

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -334,6 +334,7 @@ def split_string_by_multi_markers(content: str, markers: list[str]) -> list[str]
     """Split a string by multiple markers"""
     if not markers:
         return [content]
+    content = content if content is not None else ""
     results = re.split("|".join(re.escape(marker) for marker in markers), content)
     return [r.strip() for r in results if r.strip()]
 


### PR DESCRIPTION
<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

Recently when I'm testing LightRAG with neo4j, an error occurred like this:

```text
[ERROR][2025-04-07 16:29:24] Traceback (most recent call last):
  File "/home/admin/LightRAG/lightrag/api/routers/query_routes.py", line 193, in query_text_stream
    response = await rag.aquery(request.query, param=param)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/admin/LightRAG/lightrag/lightrag.py", line 1353, in aquery
    response = await kg_query(
               ^^^^^^^^^^^^^^^
  File "/home/admin/LightRAG/lightrag/operate.py", line 749, in kg_query
    context = await _build_query_context(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/admin/LightRAG/lightrag/operate.py", line 1144, in _build_query_context
    entities_context, relations_context, text_units_context = await _get_edge_data(
                                                              ^^^^^^^^^^^^^^^^^^^^^
  File "/home/admin/LightRAG/lightrag/operate.py", line 1526, in _get_edge_data
    use_entities, use_text_units = await asyncio.gather(
                                   ^^^^^^^^^^^^^^^^^^^^^
  File "/home/admin/LightRAG/lightrag/operate.py", line 1661, in _find_related_text_unit_from_relationships
    text_units = [
                 ^
  File "/home/admin/LightRAG/lightrag/operate.py", line 1662, in <listcomp>
    split_string_by_multi_markers(dp["source_id"], [GRAPH_FIELD_SEP])
  File "/home/admin/LightRAG/lightrag/utils.py", line 336, in split_string_by_multi_markers
    results = re.split("|".join(re.escape(marker) for marker in markers), content)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/lib/python3.11/re/__init__.py", line 206, in split
    return _compile(pattern, flags).split(string, maxsplit)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'NoneType'
```

Also, another error like this:

```text
[ERROR][2025-04-07 16:45:33] Traceback (most recent call last):
  File "/home/admin/LightRAG/lightrag/api/routers/query_routes.py", line 193, in query_text_stream
    response = await rag.aquery(request.query, param=param)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/admin/LightRAG/lightrag/lightrag.py", line 1353, in aquery
    response = await kg_query(
               ^^^^^^^^^^^^^^^
  File "/home/admin/LightRAG/lightrag/operate.py", line 749, in kg_query
    context = await _build_query_context(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/admin/LightRAG/lightrag/operate.py", line 1152, in _build_query_context
    ll_data, hl_data = await asyncio.gather(
                       ^^^^^^^^^^^^^^^^^^^^^
  File "/home/admin/LightRAG/lightrag/operate.py", line 1526, in _get_edge_data
    use_entities, use_text_units = await asyncio.gather(
                                   ^^^^^^^^^^^^^^^^^^^^^
  File "/home/admin/LightRAG/lightrag/operate.py", line 1637, in _find_most_related_entities_from_relationships
    node_datas = [
                 ^
  File "/home/admin/LightRAG/lightrag/operate.py", line 1638, in <listcomp>
    {**n, "entity_name": k, "rank": d}
TypeError: 'NoneType' object is not a mapping
```

## Changes Made

I checked the source code and it seems that `dp["source_id"]` might not be a valid string value, so I added some safety check to it.

There are also several similar codes pieces in `operate.py`, so I modified them together.

Just to be safe, I modified `split_string_by_multi_markers()`  in `utils.py` to handle `None` value.

## Checklist

- [X] Changes tested locally
- [X] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)