### PR TITLE
fix(RetrievalTesting): Limit the length of conversation history records

### DIFF
--- a/lightrag_webui/src/features/RetrievalTesting.tsx
+++ b/lightrag_webui/src/features/RetrievalTesting.tsx
@@ -69,6 +69,7 @@ export default function RetrievalTesting() {
         query: userMessage.content,
         conversation_history: prevMessages
           .filter((m) => m.isError !== true)
+          .slice(-(state.querySettings.history_turns || 0) * 2)
           .map((m) => ({ role: m.role, content: m.content }))
       }
 


### PR DESCRIPTION

## Description

History_turns in webui is not effective

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)
