### PR TITLE
fix error when running caused by `global_args.timeout` being None

### DIFF
--- a/lightrag/api/run_with_gunicorn.py
+++ b/lightrag/api/run_with_gunicorn.py
@@ -147,8 +147,8 @@ def main():
 
             # Timeout configuration prioritizes command line arguments
             gunicorn_config.timeout = (
-                global_args.timeout
-                if global_args.timeout * 2
+                global_args.timeout * 2
+                if global_args.timeout is not None
                 else int(os.getenv("TIMEOUT", 150 * 2))
             )
 


### PR DESCRIPTION
<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

I received this error message `Error: unsupported operand type(s) for *: 'NoneType' and 'int'` when running `lightrag-gunicorn`.

## Related Issues

[Reference any related issues or tasks addressed by this pull request.]

## Changes Made

![image](https://github.com/user-attachments/assets/581d9174-5a51-4d74-88ce-aae17c949c98)

I made some small changes to ensure when `global_args.timeout` is `None`, it will not participate in any not-supported operations.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

[Add any additional notes or context for the reviewer(s).]
