### PR TITLE
fix: add miss key for ainsert_custom_chunks

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -582,6 +582,7 @@ class LightRAG:
             # Clean input texts
             full_text = clean_text(full_text)
             text_chunks = [clean_text(chunk) for chunk in text_chunks]
+            file_path = ""
 
             # Process cleaned texts
             if doc_id is None:
@@ -600,12 +601,19 @@ class LightRAG:
             logger.info(f"Inserting {len(new_docs)} docs")
 
             inserting_chunks: dict[str, Any] = {}
-            for chunk_text in text_chunks:
+            for index, chunk_text in enumerate(text_chunks):
                 chunk_key = compute_mdhash_id(chunk_text, prefix="chunk-")
-
+                tokens = len(
+                    encode_string_by_tiktoken(
+                        chunk_text, model_name=self.tiktoken_model_name
+                    )
+                )
                 inserting_chunks[chunk_key] = {
                     "content": chunk_text,
                     "full_doc_id": doc_key,
+                    "tokens": tokens,
+                    "chunk_order_index": index,
+                    "file_path": file_path,
                 }
 
             doc_ids = set(inserting_chunks.keys())


### PR DESCRIPTION
<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

When using the current `ainsert_custom_chunks` API, an error occurs with `self.chunks_vdb.upsert`. Specifically, during the execution of `PGKVStorage._upsert_chunks`, the fields `tokens`, `chunk_order_index`, and `file_path` are missing, which causes the insertion of custom chunks to fail.

## Related Issues

This bug is similar to #745 

## Changes Made

Add miss key for ainsert_custom_chunks

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

[Add any additional notes or context for the reviewer(s).]
