### PR TITLE
Feature: Implemented an option to use DeepSeek Reasoner for intelligent semantic node re-ranking and retrieval

### DIFF
--- a/examples/lightrag_reasoning_deepseek_rerank_demo.py
+++ b/examples/lightrag_reasoning_deepseek_rerank_demo.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+import os
+import asyncio
+import logging
+import sys
+
+from lightrag import LightRAG, QueryParam
+from lightrag.llm.openai import openai_embed, gpt_4o_mini_complete
+from lightrag.kg.shared_storage import initialize_pipeline_status
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+
+# Set LightRAG logger to DEBUG level
+lightrag_logger = logging.getLogger("lightrag")
+lightrag_logger.setLevel(logging.DEBUG)
+
+# Set API credentials
+if "DEEPSEEK_API_KEY" not in os.environ:
+    os.environ["DEEPSEEK_API_KEY"] = "YOUR DEEPSEEK API KEY FOR REASONING"
+if "DEEPSEEK_API_BASE" not in os.environ:
+    os.environ["DEEPSEEK_API_BASE"] = "https://api.deepseek.com/v1"
+if "OPENAI_API_KEY" not in os.environ:
+    os.environ["OPENAI_API_KEY"] = "YOUR OPENAI API KEY FOR EMBEDDING"
+
+WORKING_DIR = "./YOUR WORKING DIRECTORY"
+
+if not os.path.exists(WORKING_DIR):
+    os.makedirs(WORKING_DIR)
+
+
+async def initialize_rag():
+    """Initialize LightRAG with the necessary configuration."""
+    rag = LightRAG(
+        working_dir=WORKING_DIR,
+        embedding_func=openai_embed,
+        llm_model_func=gpt_4o_mini_complete,
+    )
+
+    await rag.initialize_storages()
+    await initialize_pipeline_status()
+    return rag
+
+
+def main():
+    # Initialize LightRAG
+    rag = asyncio.run(initialize_rag())
+
+    print("\n===== LIGHTRAG REASONING RE-RANKING DEMO =====")
+    print("This demo shows the step-by-step reasoning process for re-ranking nodes")
+    print(
+        "You'll see: 1) Original node ranking, 2) Reasoning chain of thought, 3) Re-ranked nodes"
+    )
+
+    print("\n===== STANDARD RANKING (NO REASONING) =====")
+    query = "Why does Scrooge manage to have a happy ending?"
+    standard_result = rag.query(query, param=QueryParam(mode="local"))
+    print(f"\n{standard_result}")
+
+    print("\n===== WITH REASONING RE-RANKING =====")
+    print("Now the same query but with reasoning-based re-ranking of nodes:")
+    print(
+        "Watch for the ORIGINAL NODE RANKING, CHAIN OF THOUGHT REASONING, and RE-RANKED NODE ORDER"
+    )
+    reasoning_result = rag.query(
+        query,
+        param=QueryParam(
+            mode="local",
+            use_reasoning_reranking=True,
+            reasoning_model_name="deepseek_r1",
+        ),
+    )
+    print("\n===== FINAL ANSWER WITH REASONING RE-RANKING =====")
+    print(f"{reasoning_result}")
+
+    print("\n===== HYBRID MODE WITH REASONING RE-RANKING =====")
+    complex_query = "How does Scrooge make a lot of money in the end of the story?"
+    print("Using a different query in hybrid mode with reasoning re-ranking:")
+    hybrid_result = rag.query(
+        complex_query,
+        param=QueryParam(
+            mode="hybrid",
+            use_reasoning_reranking=True,
+            reasoning_model_name="deepseek_r1",
+        ),
+    )
+    print("\n===== FINAL ANSWER =====")
+    print(f"{hybrid_result}")
+
+
+if __name__ == "__main__":
+    main()

--- a/lightrag/api/routers/query_routes.py
+++ b/lightrag/api/routers/query_routes.py
@@ -88,6 +88,16 @@ class QueryRequest(BaseModel):
         description="Number of complete conversation turns (user-assistant pairs) to consider in the response context.",
     )
 
+    use_reasoning_reranking: Optional[bool] = Field(
+        default=None,
+        description="Whether to use reasoning model-based re-ranking for nodes. When enabled, a reasoning model will evaluate query-node relevance beyond vector similarity.",
+    )
+
+    reasoning_model_name: Optional[str] = Field(
+        default=None,
+        description="The name of the reasoning model to use for node re-ranking. Options: 'deepseek_r1', 'gpt_4o', 'gpt_4o_mini', or any other model supported by the system.",
+    )
+
     @field_validator("query", mode="after")
     @classmethod
     def query_strip_after(cls, query: str) -> str:

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -93,6 +93,16 @@ class QueryParam:
     This allows using different models for different query modes.
     """
 
+    use_reasoning_reranking: bool = False
+    """Whether to use reasoning model-based re-ranking for nodes.
+    When enabled, a reasoning model will evaluate query-node relevance beyond vector similarity.
+    """
+
+    reasoning_model_name: str = "deepseek_r1"
+    """The name of the reasoning model to use for node re-ranking.
+    Options: "deepseek_r1", "gpt_4o", "gpt_4o_mini", or any other model supported by the system.
+    """
+
 
 @dataclass
 class StorageNameSpace(ABC):

--- a/lightrag/prompt.py
+++ b/lightrag/prompt.py
@@ -385,3 +385,28 @@ When handling information with timestamps:
 - List up to 5 most important reference sources at the end under "References" section. Clearly indicating whether each source is from Knowledge Graph (KG) or Vector Data (DC), and include the file path if available, in the following format: [KG/DC] file_path
 - If you don't know the answer, just say so. Do not make anything up.
 - Do not include information not provided by the Data Sources."""
+
+# Node re-ranking with reasoning model
+PROMPTS["node_reasoning_system_prompt"] = (
+    "You are a reasoning assistant that analyzes and ranks knowledge graph nodes based on their relevance to a query. Your responses must be in valid JSON format."
+)
+
+PROMPTS["node_reasoning_rerank"] = """
+Query: {query}
+
+I need to determine which of the following knowledge graph nodes are most relevant and important
+for answering this query. Please analyze each node and re-rank them from most to least relevant,
+considering:
+
+1. Semantic relevance to the query
+2. Information richness and completeness
+3. How central this node is to addressing the query's needs
+4. The node's relationships (higher degree nodes may contain more useful context)
+
+Nodes:
+{nodes}
+
+YOUR RESPONSE MUST BE VALID JSON. Return an array of entity_name strings, ordered from most to least relevant.
+Format your entire response as a valid JSON array like this: ["most_relevant_entity", "second_most_relevant", ...].
+Do not include any explanations or text outside the JSON array.
+"""


### PR DESCRIPTION
## Description

*Note: This feature could be extended to use other reasoning models as well down the line.*

I've added an option to use reasoning-based node re-ranking feature to LightRAG if the user wants that improves retrieval quality by using the **DeepSeek Reasoner R1** model to re-rank knowledge graph nodes based on relevance to the query. This goes beyond simple vector similarity by incorporating deep semantic understanding and multi-hop reasoning when selecting nodes.

Unlike traditional cosine similarity currently which only measures proximity in embedding space, this reasoning-based approach considers factors like information richness, contextual relevance, and centrality to the query's needs. This is particularly valuable for complex queries where the most similar embedding doesn't always contain the most useful information.


**Current Flow (Vector Similarity Only):**
1. User submits a query
2. System retrieves nodes from vector database based on embedding similarity
3. Nodes are ranked purely by cosine similarity score
4. Top-ranked nodes are used to generate the response

**New Implementation (With Reasoning Re-ranking):**
1. User submits a query
2. System retrieves nodes from vector database based on embedding similarity (initial retrieval)
3. The retrieved nodes are analyzed by the DeepSeek Reasoner model
4. The reasoner evaluates each node based on:
   - Semantic relevance to the query
   - Information richness and completeness
   - How central the node is to answering the query
   - The node's relationships with other nodes
5. Nodes are re-ranked according to the reasoner's evaluation
6. The re-ranked nodes are used to generate a more relevant response

Unlike traditional cosine similarity which only measures proximity in embedding space, this reasoning-based approach considers factors like information richness, contextual relevance, and centrality to the query's needs. This is particularly valuable for complex queries where the most similar embedding doesn't always contain the most useful information.

*Note: This feature is currently only available for `local` and `hybrid` modes.*


## Related Issues

No specific issue - this enhancement came from observing limitations in pure vector similarity retrieval when handling complex analytical queries.

## Changes Made

- Added `use_reasoning_reranking` boolean flag to `QueryParam` to enable/disable reasoning-based re-ranking
- Added `reasoning_model_name` parameter to `QueryParam` to specify which reasoning model to use
- Implemented `_rerank_nodes_with_reasoning` function in `operate.py` to handle the reasoning-based re-ranking logic
- Added prompts for reasoning re-ranking to `prompt.py`
- Enhanced `deepseek_r1_complete` function to capture and return reasoning chain of thought
- Created comprehensive logging to display the re-ranking process, including original ranking, chain of thought, and final re-ranked order
- Added a demo script (`lightrag_reasoning_rerank_demo.py`) showing the feature in action

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (comments in code and demo file)
- [ ] Unit tests added (if applicable)

## Additional Notes

This feature addresses several practical use cases:

1. **Complex analytical queries** - Traditional vector similarity can miss important semantic relationships that reasoning models can identify
2. **Multi-faceted questions** - Questions requiring synthesis of multiple knowledge pieces benefit from smarter node prioritization
3. **Reasoning transparency** - The chain-of-thought logging provides visibility into why certain nodes were prioritized
4. **Improved answer quality** - By prioritizing the most semantically relevant nodes, final answers show improved coherence and depth

Usage is straightforward:

```python
# Standard query with vector similarity ranking
result = rag.query("What are the main themes?", param=QueryParam(mode="local"))

# Same query with reasoning-based re-ranking
result = rag.query(
    "What are the main themes?", 
    param=QueryParam(
        mode="local",  # Also works with hybrid mode
        use_reasoning_reranking=True,
        reasoning_model_name="deepseek_r1"  # Optional, defaults to deepseek_r1
    )
)
```
```