### PR TITLE
friendly implementation of entity extraction and relationship weight extract for Low-Capability LLMs

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -18,6 +18,7 @@ from .utils import (
     normalize_extracted_info,
     pack_user_ass_to_openai_messages,
     split_string_by_multi_markers,
+    extract_fixed_parenthesized_content,
     truncate_list_by_token_size,
     process_combine_contexts,
     compute_args_hash,
@@ -215,7 +216,7 @@ async def _handle_single_relationship_extraction(
     edge_source_id = chunk_key
     weight = (
         float(record_attributes[-1].strip('"').strip("'"))
-        if is_float_regex(record_attributes[-1])
+        if is_float_regex(record_attributes[-1].strip('"').strip("'"))
         else 1.0
     )
     return dict(
@@ -548,6 +549,8 @@ async def extract_entities(
             result,
             [context_base["record_delimiter"], context_base["completion_delimiter"]],
         )
+
+        records = extract_fixed_parenthesized_content(records)
 
         for record in records:
             record = re.search(r"\((.*)\)", record)

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -18,7 +18,6 @@ from .utils import (
     normalize_extracted_info,
     pack_user_ass_to_openai_messages,
     split_string_by_multi_markers,
-    extract_fixed_parenthesized_content,
     truncate_list_by_token_size,
     process_combine_contexts,
     compute_args_hash,
@@ -153,7 +152,7 @@ async def _handle_single_entity_extraction(
     chunk_key: str,
     file_path: str = "unknown_source",
 ):
-    if len(record_attributes) < 4 or record_attributes[0] != '"entity"':
+    if len(record_attributes) < 4 or '"entity"' not in record_attributes[0]:
         return None
 
     # Clean and validate entity name
@@ -199,7 +198,7 @@ async def _handle_single_relationship_extraction(
     chunk_key: str,
     file_path: str = "unknown_source",
 ):
-    if len(record_attributes) < 5 or record_attributes[0] != '"relationship"':
+    if len(record_attributes) < 5 or '"relationship"' not in record_attributes[0]:
         return None
     # add this record as edge
     source = clean_str(record_attributes[1])
@@ -549,8 +548,6 @@ async def extract_entities(
             result,
             [context_base["record_delimiter"], context_base["completion_delimiter"]],
         )
-
-        records = extract_fixed_parenthesized_content(records)
 
         for record in records:
             record = re.search(r"\((.*)\)", record)

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -408,33 +408,6 @@ def split_string_by_multi_markers(content: str, markers: list[str]) -> list[str]
     return [r.strip() for r in results if r.strip()]
 
 
-def extract_fixed_parenthesized_content(records: list[str]) -> list[str]:
-    """
-    Extract content that should be in parentheses from each record.
-    Ensures each extracted item has both opening and closing parentheses.
-    """
-    result = []
-
-    for record in records:
-        # First, extract properly matched pairs
-        balanced_matches = re.findall(r"\((.*?)\)", record)
-        for match in balanced_matches:
-            result.append(f"({match})")
-
-        # Process string to handle unbalanced parentheses
-        # For opening without closing
-        open_matches = re.findall(r"\(([^()]*?)$", record)
-        for match in open_matches:
-            result.append(f"({match})")
-
-        # For closing without opening
-        close_matches = re.findall(r"^([^()]*?)\)", record)
-        for match in close_matches:
-            result.append(f"({match})")
-
-    return result
-
-
 # Refer the utils functions of the official GraphRAG implementation:
 # https://github.com/microsoft/graphrag
 def clean_str(input: Any) -> str:

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -417,21 +417,21 @@ def extract_fixed_parenthesized_content(records: list[str]) -> list[str]:
 
     for record in records:
         # First, extract properly matched pairs
-        balanced_matches = re.findall(r'\((.*?)\)', record)
+        balanced_matches = re.findall(r"\((.*?)\)", record)
         for match in balanced_matches:
             result.append(f"({match})")
-        
+
         # Process string to handle unbalanced parentheses
         # For opening without closing
-        open_matches = re.findall(r'\(([^()]*?)$', record)
+        open_matches = re.findall(r"\(([^()]*?)$", record)
         for match in open_matches:
             result.append(f"({match})")
-        
+
         # For closing without opening
-        close_matches = re.findall(r'^([^()]*?)\)', record)
+        close_matches = re.findall(r"^([^()]*?)\)", record)
         for match in close_matches:
             result.append(f"({match})")
-    
+
     return result
 
 

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -408,6 +408,33 @@ def split_string_by_multi_markers(content: str, markers: list[str]) -> list[str]
     return [r.strip() for r in results if r.strip()]
 
 
+def extract_fixed_parenthesized_content(records: list[str]) -> list[str]:
+    """
+    Extract content that should be in parentheses from each record.
+    Ensures each extracted item has both opening and closing parentheses.
+    """
+    result = []
+
+    for record in records:
+        # First, extract properly matched pairs
+        balanced_matches = re.findall(r'\((.*?)\)', record)
+        for match in balanced_matches:
+            result.append(f"({match})")
+        
+        # Process string to handle unbalanced parentheses
+        # For opening without closing
+        open_matches = re.findall(r'\(([^()]*?)$', record)
+        for match in open_matches:
+            result.append(f"({match})")
+        
+        # For closing without opening
+        close_matches = re.findall(r'^([^()]*?)\)', record)
+        for match in close_matches:
+            result.append(f"({match})")
+    
+    return result
+
+
 # Refer the utils functions of the official GraphRAG implementation:
 # https://github.com/microsoft/graphrag
 def clean_str(input: Any) -> str:


### PR DESCRIPTION
friendly implementation of entity extraction and relationship weight extract for Low-Capability LLMs

## Description
This PR addresses two critical issues when processing output from smaller LLMs:
1. These models often produce malformed entity outputs, such as:
- Missing or incorrectly placing record delimiters (e.g., placing them inside parentheses)
- Omitting opening or closing parentheses.
- Since the current entity extraction logic relies on regex, these issues lead to many valid entities being ignored, resulting in a low entity count.
2. Relationship weights are sometimes returned wrapped in quotes (e.g., "1.0" or '0.8'). The current regex does not handle this properly and defaults to returning a weight of 1.0.

## Changes Made
1. Introduces a `new extract_fixed_parenthesized_content` function that runs after `split_string_by_multi_markers`, to clean and correct malformed records caused by issue 1
2. Adds a strip() call before passing relationship weight values to is_float_regex, ensuring that quoted numeric strings are properly parsed.


## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)
