### PR TITLE
feat: parameter‑based storage configuration (decouple from env vars / config.ini)

### DIFF
--- a/examples/lightrag_storage_config_demo.py
+++ b/examples/lightrag_storage_config_demo.py
@@ -1,0 +1,109 @@
+import asyncio
+import logging
+import os
+from dotenv import load_dotenv
+
+from lightrag import LightRAG, QueryParam
+from lightrag.llm.zhipu import zhipu_complete
+from lightrag.llm.ollama import ollama_embedding
+from lightrag.utils import EmbeddingFunc
+from lightrag.kg.shared_storage import initialize_pipeline_status
+
+load_dotenv()
+ROOT_DIR = os.environ.get("ROOT_DIR")
+WORKING_DIR = f"{ROOT_DIR}/dickens-pg"
+
+logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.INFO)
+
+if not os.path.exists(WORKING_DIR):
+    os.mkdir(WORKING_DIR)
+
+# AGE
+os.environ["AGE_GRAPH_NAME"] = "dickens"
+
+os.environ["POSTGRES_HOST"] = "localhost"
+os.environ["POSTGRES_PORT"] = "15432"
+os.environ["POSTGRES_USER"] = "rag"
+os.environ["POSTGRES_PASSWORD"] = "rag"
+os.environ["POSTGRES_DATABASE"] = "rag"
+
+
+async def initialize_rag():
+    rag = LightRAG(
+        working_dir=WORKING_DIR,
+        llm_model_func=zhipu_complete,
+        llm_model_name="glm-4-flashx",
+        llm_model_max_async=4,
+        llm_model_max_token_size=32768,
+        enable_llm_cache_for_entity_extract=True,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=1024,
+            max_token_size=8192,
+            func=lambda texts: ollama_embedding(
+                texts, embed_model="bge-m3", host="http://localhost:11434"
+            ),
+        ),
+        kv_storage="PGKVStorage",
+        kv_db_storage_cls_kwargs={
+            "POSTGRES_HOST": "localhost",
+            "POSTGRES_PORT": "15432",
+            "POSTGRES_USER": "rag",
+            "POSTGRES_PASSWORD": "rag",
+            "POSTGRES_DATABASE": "rag",
+            "POSTGRES_WORKSPACE": "kv",
+        },
+        doc_status_storage="PGDocStatusStorage",
+        doc_status_db_storage_cls_kwargs={
+            "POSTGRES_HOST": "localhost",
+            "POSTGRES_PORT": "15432",
+            "POSTGRES_USER": "rag",
+            "POSTGRES_PASSWORD": "rag",
+            "POSTGRES_DATABASE": "rag",
+            "POSTGRES_WORKSPACE": "doc_status",
+        },
+        graph_storage="PGGraphStorage",
+        graph_status_db_storage_cls_kwargs={
+            "POSTGRES_HOST": "localhost",
+            "POSTGRES_PORT": "15432",
+            "POSTGRES_USER": "rag",
+            "POSTGRES_PASSWORD": "rag",
+            "POSTGRES_DATABASE": "rag",
+            "POSTGRES_WORKSPACE": "graph",
+        },
+        vector_storage="PGVectorStorage",
+        vector_status_db_storage_cls_kwargs={
+            "POSTGRES_HOST": "localhost",
+            "POSTGRES_PORT": "15432",
+            "POSTGRES_USER": "rag",
+            "POSTGRES_PASSWORD": "rag",
+            "POSTGRES_DATABASE": "rag",
+            "POSTGRES_WORKSPACE": "vector",
+        },
+        auto_manage_storages_states=False,
+    )
+
+    await rag.initialize_storages()
+    await initialize_pipeline_status()
+
+    return rag
+
+
+async def main():
+    # Initialize RAG instance
+    rag = await initialize_rag()
+
+    # add embedding_func for graph database, it's deleted in commit 5661d76860436f7bf5aef2e50d9ee4a59660146c
+    rag.chunk_entity_relation_graph.embedding_func = rag.embedding_func
+
+    with open(f"{ROOT_DIR}/book.txt", "r", encoding="utf-8") as f:
+        await rag.ainsert(f.read())
+
+    print(
+        await rag.aquery(
+            "What are the top themes in this story?", param=QueryParam(mode="naive")
+        )
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -226,6 +226,15 @@ class LightRAG:
     vector_db_storage_cls_kwargs: dict[str, Any] = field(default_factory=dict)
     """Additional parameters for vector database storage."""
 
+    kv_db_storage_cls_kwargs: dict[str, Any] = field(default_factory=dict)
+    """Additional parameters for kv database storage."""
+
+    graph_db_storage_cls_kwargs: dict[str, Any] = field(default_factory=dict)
+    """Additional parameters for graph database storage."""
+
+    doc_status_db_storage_cls_kwargs: dict[str, Any] = field(default_factory=dict)
+    """Additional parameters for doc status database storage."""
+
     # TODO：deprecated, remove in the future, use WORKSPACE instead
     namespace_prefix: str = field(default="")
     """Prefix for namespacing stored data across different environments."""


### PR DESCRIPTION
> ⚠️  **Work‑in‑Progress / RFC**  
> This PR only patches the PostgreSQL and MongoDB back‑ends for now.  
> I’m opening it early to discuss the approach with the maintainers; once the design is approved I’ll finish the remaining storages, tests and docs to avoid wasting effort. 🙏

### 1. Motivation

`LightRAG` currently initializes every Storage by reading  
1. environment variables, or  
2. `config.ini`.  

This causes two major issues:

* **Instance interference** – In a single Python process, creating two `LightRAG` objects that should talk to different databases requires mutating global env vars, so they override each other.
* **Lack of per‑Storage flexibility** – Within one `LightRAG`, if I want one PG instance for `KVStorage` and a different PG instance for `VectorStorage`, it’s impossible.

### 2. Goals

1. Allow multiple `LightRAG` instances to coexist in the same process without touching global state.  
2. Allow one `LightRAG` to connect each storage type to a different DB or workspace.  
3. Remain 100 % backward‑compatible with the existing env‑var / config.ini flow.

### 3. Design & Implementation

Four optional kwargs are added to the `LightRAG` dataclass:

```python
vector_db_storage_cls_kwargs: dict[str, Any] = field(default_factory=dict)
kv_db_storage_cls_kwargs: dict[str, Any] = field(default_factory=dict)
graph_db_storage_cls_kwargs: dict[str, Any] = field(default_factory=dict)
doc_status_db_storage_cls_kwargs: dict[str, Any] = field(default_factory=dict)
```

Key points:

1. **No change to Storage base classes.**  
2. Concrete storages (PG / Mongo so far) now read `self.global_config[...]` first; if a key is missing they fall back to env vars or `config.ini`.  
3. A demo script `lightrag_storage_config_demo.py` shows two `LightRAG` objects running side‑by‑side on different ports/workspaces.

### 4. Usage Example

```python
rag1 = LightRAG(
    …,
    kv_storage="PGKVStorage",
    kv_db_storage_cls_kwargs={"POSTGRES_HOST":"localhost", "POSTGRES_PORT":"1111", "POSTGRES_WORKSPACE":"ws1"},
    graph_storage="PGGraphStorage",
    graph_db_storage_cls_kwargs={"POSTGRES_HOST":"localhost", "POSTGRES_PORT":"2222", "POSTGRES_WORKSPACE":"ws1"},
    vector_storage="PGVectorStorage",
    vector_db_storage_cls_kwargs={"POSTGRES_HOST":"localhost", "POSTGRES_PORT":"3333", "POSTGRES_WORKSPACE":"ws1"},
)

rag2 = LightRAG(
    …,
    kv_storage="PGKVStorage",
    kv_db_storage_cls_kwargs={"POSTGRES_HOST":"localhost", "POSTGRES_PORT":"1111", "POSTGRES_WORKSPACE":"ws2"},
    # …same pattern for the other storages
)
```

No environment variables need to be (re)exported, and both RAGs can run concurrently.

### 5. Compatibility

* Existing code that relies solely on env vars or `config.ini` keeps working unchanged.  
* All new fields are optional and default to `{}`.  
* No APIs were removed or renamed.

### 6. Next Steps (after design approval)

- [ ] Patch the remaining storage back‑ends (SQLite, Redis, Elasticsearch, …).  
- [ ] Update docs / README / type hints.  
- [ ] Add unit tests 

### 7. Open Questions

1. Should we unify the four dicts into a single `storage_configs: dict[str, dict]`?  
2. `ClientManager` remains a singleton; if we ever need completely separate connection pools, should we move to a keyed‑singleton?

### 8. Conclusion

This PR makes `LightRAG`’s storage layer **more flexible, composable and notebook‑friendly** while staying fully backward‑compatible.

Looking forward to your feedback! 🤝