### PR TITLE
Fix node names with JSON formatting were mistakenly interpreted as JSON objects for PostgreSQL AGE graph storage

### DIFF
--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -1252,15 +1252,7 @@ class PGGraphStorage(BaseGraphStorage):
                     elif dtype == "edge":
                         d[k] = json.loads(v)
             else:
-                try:
-                    d[k] = (
-                        json.loads(v)
-                        if isinstance(v, str)
-                        and (v.startswith("{") or v.startswith("["))
-                        else v
-                    )
-                except json.JSONDecodeError:
-                    d[k] = v
+                d[k] = v  # Keep as string
 
         return d
 


### PR DESCRIPTION
Resolved an issue where string values were being incorrectly parsed as JSON in PostgreSQL AGE graph storage, which caused errors when processing node names containing JSON-formatted text.