### PR TITLE
Eliminate redundant chunk data fetching in naive and mix query mode

### DIFF
--- a/lightrag/api/__init__.py
+++ b/lightrag/api/__init__.py
@@ -1,1 +1,1 @@
-__api_version__ = "0166"
+__api_version__ = "0167"

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -390,6 +390,8 @@ class LightRAG:
             ),
             embedding_func=self.embedding_func,
         )
+
+        # TODO: deprecating, text_chunks is redundant with chunks_vdb
         self.text_chunks: BaseKVStorage = self.key_string_value_json_storage_cls(  # type: ignore
             namespace=make_namespace(
                 self.namespace_prefix, NameSpace.KV_STORE_TEXT_CHUNKS

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -2049,10 +2049,7 @@ async def naive_query(
     if not len(results):
         return PROMPTS["fail_response"]
 
-    # 直接从 chunks_vdb.query 结果中获取内容
-    valid_chunks = [
-        result for result in results if "content" in result
-    ]
+    valid_chunks = [result for result in results if "content" in result]
 
     if not valid_chunks:
         logger.warning("No valid chunks found after filtering")


### PR DESCRIPTION
Eliminate redundant chunk data fetching in naive and mix query mode. Use chunks fetched from vector db.

reslove #1535