### PR TITLE
Allow max_connections to be configured in postgres

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -20,3 +20,4 @@ user = your_username
 password = your_password
 database = your_database
 workspace = default  # 可选,默认为default
+max_connections = 12

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -54,7 +54,7 @@ class PostgreSQLDB:
         self.password = config.get("password", None)
         self.database = config.get("database", "postgres")
         self.workspace = config.get("workspace", "default")
-        self.max = 12
+        self.max = config.get("max_connections", 12)
         self.increment = 1
         self.pool: Pool | None = None
 
@@ -249,6 +249,10 @@ class ClientManager:
             "workspace": os.environ.get(
                 "POSTGRES_WORKSPACE",
                 config.get("postgres", "workspace", fallback="default"),
+            ),
+            "max_connections": os.environ.get(
+                "POSTGRES_MAX_CONNECTIONS",
+                config.get("postgres", "max_connections", fallback=12),
             ),
         }
 

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -54,7 +54,7 @@ class PostgreSQLDB:
         self.password = config.get("password", None)
         self.database = config.get("database", "postgres")
         self.workspace = config.get("workspace", "default")
-        self.max = config.get("max_connections", 12)
+        self.max = int(config.get("max_connections", 12))
         self.increment = 1
         self.pool: Pool | None = None
 


### PR DESCRIPTION
## Description

This PR adds configurable PostgreSQL connection pool size support through both configuration file and environment variables. This enhancement allows users to fine-tune the database connection pool based on their specific needs and system resources.

## Related Issues

N/A

## Changes Made

1. Added `max_connections` parameter to `config.ini.example` with a default value of 12
2. Modified `PostgreSQLDB` class to read the max connections from config instead of hardcoding it
3. Updated `ClientManager` to support `POSTGRES_MAX_CONNECTIONS` environment variable

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [x] Documentation update is separate PR. For now since this behavior is backward compatible, it does not invalidate existing docs [along with other changes I suggested in #1495 ]
- [x] No new unit tests needed as this is a configuration change

## Additional Notes

This change maintains backward compatibility by:
- Using 12 as the default value if not specified in config
- Supporting both config file and environment variable configuration
- Preserving existing behavior for users who don't specify the parameter

The change allows for better resource management and scalability by letting users adjust the connection pool size according to their needs. This is part of a series of updates I have planned to allow for efficient massive concurrent insertion (i.e. 100s in parallel)