### PR TITLE
Using keyed lock for max concurrency

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -20,3 +20,4 @@ user = your_username
 password = your_password
 database = your_database
 workspace = default  # 可选,默认为default
+max_connections = 12

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -54,7 +54,7 @@ class PostgreSQLDB:
         self.password = config.get("password", None)
         self.database = config.get("database", "postgres")
         self.workspace = config.get("workspace", "default")
-        self.max = 12
+        self.max = config.get("max_connections", 12)
         self.increment = 1
         self.pool: Pool | None = None
 
@@ -249,6 +249,10 @@ class ClientManager:
             "workspace": os.environ.get(
                 "POSTGRES_WORKSPACE",
                 config.get("postgres", "workspace", fallback="default"),
+            ),
+            "max_connections": os.environ.get(
+                "POSTGRES_MAX_CONNECTIONS",
+                config.get("postgres", "max_connections", fallback=12),
             ),
         }
 

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1024,73 +1024,73 @@ class LightRAG:
                                 }
                             )
 
-                    # Semphore was released here
+                        # Semphore is NOT released here, however, the profile context is
 
-                    if file_extraction_stage_ok:
-                        try:
-                            # Get chunk_results from entity_relation_task
-                            chunk_results = await entity_relation_task
-                            await merge_nodes_and_edges(
-                                chunk_results=chunk_results,  # result collected from entity_relation_task
-                                knowledge_graph_inst=self.chunk_entity_relation_graph,
-                                entity_vdb=self.entities_vdb,
-                                relationships_vdb=self.relationships_vdb,
-                                global_config=asdict(self),
-                                pipeline_status=pipeline_status,
-                                pipeline_status_lock=pipeline_status_lock,
-                                llm_response_cache=self.llm_response_cache,
-                                current_file_number=current_file_number,
-                                total_files=total_files,
-                                file_path=file_path,
-                            )
+                        if file_extraction_stage_ok:
+                            try:
+                                # Get chunk_results from entity_relation_task
+                                chunk_results = await entity_relation_task
+                                await merge_nodes_and_edges(
+                                    chunk_results=chunk_results,  # result collected from entity_relation_task
+                                    knowledge_graph_inst=self.chunk_entity_relation_graph,
+                                    entity_vdb=self.entities_vdb,
+                                    relationships_vdb=self.relationships_vdb,
+                                    global_config=asdict(self),
+                                    pipeline_status=pipeline_status,
+                                    pipeline_status_lock=pipeline_status_lock,
+                                    llm_response_cache=self.llm_response_cache,
+                                    current_file_number=current_file_number,
+                                    total_files=total_files,
+                                    file_path=file_path,
+                                )
 
-                            await self.doc_status.upsert(
-                                {
-                                    doc_id: {
-                                        "status": DocStatus.PROCESSED,
-                                        "chunks_count": len(chunks),
-                                        "content": status_doc.content,
-                                        "content_summary": status_doc.content_summary,
-                                        "content_length": status_doc.content_length,
-                                        "created_at": status_doc.created_at,
-                                        "updated_at": datetime.now().isoformat(),
-                                        "file_path": file_path,
+                                await self.doc_status.upsert(
+                                    {
+                                        doc_id: {
+                                            "status": DocStatus.PROCESSED,
+                                            "chunks_count": len(chunks),
+                                            "content": status_doc.content,
+                                            "content_summary": status_doc.content_summary,
+                                            "content_length": status_doc.content_length,
+                                            "created_at": status_doc.created_at,
+                                            "updated_at": datetime.now().isoformat(),
+                                            "file_path": file_path,
+                                        }
                                     }
-                                }
-                            )
+                                )
 
-                            # Call _insert_done after processing each file
-                            await self._insert_done()
+                                # Call _insert_done after processing each file
+                                await self._insert_done()
 
-                            async with pipeline_status_lock:
-                                log_message = f"Completed processing file {current_file_number}/{total_files}: {file_path}"
-                                logger.info(log_message)
-                                pipeline_status["latest_message"] = log_message
-                                pipeline_status["history_messages"].append(log_message)
+                                async with pipeline_status_lock:
+                                    log_message = f"Completed processing file {current_file_number}/{total_files}: {file_path}"
+                                    logger.info(log_message)
+                                    pipeline_status["latest_message"] = log_message
+                                    pipeline_status["history_messages"].append(log_message)
 
-                        except Exception as e:
-                            # Log error and update pipeline status
-                            error_msg = f"Merging stage failed in document {doc_id}: {traceback.format_exc()}"
-                            logger.error(error_msg)
-                            async with pipeline_status_lock:
-                                pipeline_status["latest_message"] = error_msg
-                                pipeline_status["history_messages"].append(error_msg)
+                            except Exception as e:
+                                # Log error and update pipeline status
+                                error_msg = f"Merging stage failed in document {doc_id}: {traceback.format_exc()}"
+                                logger.error(error_msg)
+                                async with pipeline_status_lock:
+                                    pipeline_status["latest_message"] = error_msg
+                                    pipeline_status["history_messages"].append(error_msg)
 
-                            # Update document status to failed
-                            await self.doc_status.upsert(
-                                {
-                                    doc_id: {
-                                        "status": DocStatus.FAILED,
-                                        "error": str(e),
-                                        "content": status_doc.content,
-                                        "content_summary": status_doc.content_summary,
-                                        "content_length": status_doc.content_length,
-                                        "created_at": status_doc.created_at,
-                                        "updated_at": datetime.now().isoformat(),
-                                        "file_path": file_path,
+                                # Update document status to failed
+                                await self.doc_status.upsert(
+                                    {
+                                        doc_id: {
+                                            "status": DocStatus.FAILED,
+                                            "error": str(e),
+                                            "content": status_doc.content,
+                                            "content_summary": status_doc.content_summary,
+                                            "content_length": status_doc.content_length,
+                                            "created_at": status_doc.created_at,
+                                            "updated_at": datetime.now().isoformat(),
+                                            "file_path": file_path,
+                                        }
                                     }
-                                }
-                            )
+                                )
 
                 # Create processing tasks for all documents
                 doc_tasks = []

--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -177,14 +177,15 @@ async def openai_complete_if_cache(
     logger.debug("===== Sending Query to LLM =====")
 
     try:
-        if "response_format" in kwargs:
-            response = await openai_async_client.beta.chat.completions.parse(
-                model=model, messages=messages, **kwargs
-            )
-        else:
-            response = await openai_async_client.chat.completions.create(
-                model=model, messages=messages, **kwargs
-            )
+        async with openai_async_client:
+            if "response_format" in kwargs:
+                response = await openai_async_client.beta.chat.completions.parse(
+                    model=model, messages=messages, **kwargs
+                )
+            else:
+                response = await openai_async_client.chat.completions.create(
+                    model=model, messages=messages, **kwargs
+                )
     except APIConnectionError as e:
         logger.error(f"OpenAI API Connection Error: {e}")
         raise
@@ -421,7 +422,8 @@ async def openai_embed(
         api_key=api_key, base_url=base_url, client_configs=client_configs
     )
 
-    response = await openai_async_client.embeddings.create(
-        model=model, input=texts, encoding_format="float"
-    )
-    return np.array([dp.embedding for dp in response.data])
+    async with openai_async_client:
+        response = await openai_async_client.embeddings.create(
+            model=model, input=texts, encoding_format="float"
+        )
+        return np.array([dp.embedding for dp in response.data])

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -9,6 +9,8 @@ import os
 from typing import Any, AsyncIterator
 from collections import Counter, defaultdict
 
+from .kg.shared_storage import get_graph_db_lock_keyed
+
 from .utils import (
     logger,
     clean_str,
@@ -403,27 +405,31 @@ async def _merge_edges_then_upsert(
     )
 
     for need_insert_id in [src_id, tgt_id]:
-        if not (await knowledge_graph_inst.has_node(need_insert_id)):
-            # # Discard this edge if the node does not exist
-            # if need_insert_id == src_id:
-            #     logger.warning(
-            #         f"Discard edge: {src_id} - {tgt_id} | Source node missing"
-            #     )
-            # else:
-            #     logger.warning(
-            #         f"Discard edge: {src_id} - {tgt_id} | Target node missing"
-            #     )
-            # return None
-            await knowledge_graph_inst.upsert_node(
-                need_insert_id,
-                node_data={
-                    "entity_id": need_insert_id,
-                    "source_id": source_id,
-                    "description": description,
-                    "entity_type": "UNKNOWN",
-                    "file_path": file_path,
-                },
-            )
+        if (await knowledge_graph_inst.has_node(need_insert_id)):
+            # This is so that the initial check for the existence of the node need not be locked
+            continue
+        async with get_graph_db_lock_keyed([need_insert_id], enable_logging=False):
+            if not (await knowledge_graph_inst.has_node(need_insert_id)):
+                # # Discard this edge if the node does not exist
+                # if need_insert_id == src_id:
+                #     logger.warning(
+                #         f"Discard edge: {src_id} - {tgt_id} | Source node missing"
+                #     )
+                # else:
+                #     logger.warning(
+                #         f"Discard edge: {src_id} - {tgt_id} | Target node missing"
+                #     )
+                # return None
+                await knowledge_graph_inst.upsert_node(
+                    need_insert_id,
+                    node_data={
+                        "entity_id": need_insert_id,
+                        "source_id": source_id,
+                        "description": description,
+                        "entity_type": "UNKNOWN",
+                        "file_path": file_path,
+                    },
+                )
 
     force_llm_summary_on_merge = global_config["force_llm_summary_on_merge"]
 
@@ -523,23 +529,30 @@ async def merge_nodes_and_edges(
             all_edges[sorted_edge_key].extend(edges)
 
     # Centralized processing of all nodes and edges
-    entities_data = []
-    relationships_data = []
+    total_entities_count = len(all_nodes)
+    total_relations_count = len(all_edges)
 
     # Merge nodes and edges
     # Use graph database lock to ensure atomic merges and updates
     graph_db_lock = get_graph_db_lock(enable_logging=False)
-    async with graph_db_lock:
+    async with pipeline_status_lock:
+        log_message = (
+            f"Merging stage {current_file_number}/{total_files}: {file_path}"
+        )
+        logger.info(log_message)
+        pipeline_status["latest_message"] = log_message
+        pipeline_status["history_messages"].append(log_message)
+
+    # Process and update all entities at once
+    log_message = f"Updating {total_entities_count} entities  {current_file_number}/{total_files}: {file_path}"
+    logger.info(log_message)
+    if pipeline_status is not None:
         async with pipeline_status_lock:
-            log_message = (
-                f"Merging stage {current_file_number}/{total_files}: {file_path}"
-            )
-            logger.info(log_message)
             pipeline_status["latest_message"] = log_message
             pipeline_status["history_messages"].append(log_message)
 
-        # Process and update all entities at once
-        for entity_name, entities in all_nodes.items():
+    async def _locked_process_entity_name(entity_name, entities):
+        async with get_graph_db_lock_keyed([entity_name], enable_logging=False):
             entity_data = await _merge_nodes_then_upsert(
                 entity_name,
                 entities,
@@ -549,10 +562,34 @@ async def merge_nodes_and_edges(
                 pipeline_status_lock,
                 llm_response_cache,
             )
-            entities_data.append(entity_data)
+            if entity_vdb is not None:
+                data_for_vdb = {
+                    compute_mdhash_id(entity_data["entity_name"], prefix="ent-"): {
+                        "entity_name": entity_data["entity_name"],
+                        "entity_type": entity_data["entity_type"],
+                        "content": f"{entity_data['entity_name']}\n{entity_data['description']}",
+                        "source_id": entity_data["source_id"],
+                        "file_path": entity_data.get("file_path", "unknown_source"),
+                    }
+                }
+                await entity_vdb.upsert(data_for_vdb)
+            return entity_data
 
-        # Process and update all relationships at once
-        for edge_key, edges in all_edges.items():
+    tasks = []
+    for entity_name, entities in all_nodes.items():
+        tasks.append(asyncio.create_task(_locked_process_entity_name(entity_name, entities)))
+    await asyncio.gather(*tasks)
+
+    # Process and update all relationships at once
+    log_message = f"Updating {total_relations_count} relations {current_file_number}/{total_files}: {file_path}"
+    logger.info(log_message)
+    if pipeline_status is not None:
+        async with pipeline_status_lock:
+            pipeline_status["latest_message"] = log_message
+            pipeline_status["history_messages"].append(log_message)
+
+    async def _locked_process_edges(edge_key, edges):
+        async with get_graph_db_lock_keyed(f"{edge_key[0]}-{edge_key[1]}", enable_logging=False):
             edge_data = await _merge_edges_then_upsert(
                 edge_key[0],
                 edge_key[1],
@@ -563,55 +600,27 @@ async def merge_nodes_and_edges(
                 pipeline_status_lock,
                 llm_response_cache,
             )
-            if edge_data is not None:
-                relationships_data.append(edge_data)
+            if edge_data is None:
+                return None
 
-        # Update total counts
-        total_entities_count = len(entities_data)
-        total_relations_count = len(relationships_data)
-
-        log_message = f"Updating {total_entities_count} entities  {current_file_number}/{total_files}: {file_path}"
-        logger.info(log_message)
-        if pipeline_status is not None:
-            async with pipeline_status_lock:
-                pipeline_status["latest_message"] = log_message
-                pipeline_status["history_messages"].append(log_message)
-
-        # Update vector databases with all collected data
-        if entity_vdb is not None and entities_data:
-            data_for_vdb = {
-                compute_mdhash_id(dp["entity_name"], prefix="ent-"): {
-                    "entity_name": dp["entity_name"],
-                    "entity_type": dp["entity_type"],
-                    "content": f"{dp['entity_name']}\n{dp['description']}",
-                    "source_id": dp["source_id"],
-                    "file_path": dp.get("file_path", "unknown_source"),
+            if relationships_vdb is not None:
+                data_for_vdb = {
+                    compute_mdhash_id(edge_data["src_id"] + edge_data["tgt_id"], prefix="rel-"): {
+                        "src_id": edge_data["src_id"],
+                        "tgt_id": edge_data["tgt_id"],
+                        "keywords": edge_data["keywords"],
+                        "content": f"{edge_data['src_id']}\t{edge_data['tgt_id']}\n{edge_data['keywords']}\n{edge_data['description']}",
+                        "source_id": edge_data["source_id"],
+                        "file_path": edge_data.get("file_path", "unknown_source"),
+                    }
                 }
-                for dp in entities_data
-            }
-            await entity_vdb.upsert(data_for_vdb)
+                await relationships_vdb.upsert(data_for_vdb)
+            return edge_data
 
-        log_message = f"Updating {total_relations_count} relations {current_file_number}/{total_files}: {file_path}"
-        logger.info(log_message)
-        if pipeline_status is not None:
-            async with pipeline_status_lock:
-                pipeline_status["latest_message"] = log_message
-                pipeline_status["history_messages"].append(log_message)
-
-        if relationships_vdb is not None and relationships_data:
-            data_for_vdb = {
-                compute_mdhash_id(dp["src_id"] + dp["tgt_id"], prefix="rel-"): {
-                    "src_id": dp["src_id"],
-                    "tgt_id": dp["tgt_id"],
-                    "keywords": dp["keywords"],
-                    "content": f"{dp['src_id']}\t{dp['tgt_id']}\n{dp['keywords']}\n{dp['description']}",
-                    "source_id": dp["source_id"],
-                    "file_path": dp.get("file_path", "unknown_source"),
-                }
-                for dp in relationships_data
-            }
-            await relationships_vdb.upsert(data_for_vdb)
-
+    tasks = []
+    for edge_key, edges in all_edges.items():
+        tasks.append(asyncio.create_task(_locked_process_edges(edge_key, edges)))
+    await asyncio.gather(*tasks)
 
 async def extract_entities(
     chunks: dict[str, TextChunkSchema],


### PR DESCRIPTION
## Description

This pull request introduces a keyed locking mechanism for entity and relationship processing in LightRAG. The aim is to ensure atomic and mutually exclusive operations on individual entities or relationships, while allowing concurrent processing of different entities and relationships.

This locking mechanism is designed with multi-processing environments in mind, although this specific compatibility has not yet been tested.

## Key motivation
It turns out that when trying to run massively parallel insertion, namely hundreds of documents at once (max_parallel_insert = 100 for instance), we run into the issue that the hard lock that is taken on the database during the merging phase becomes a significant bottleneck, especially if we're doing LLM summarization on merge. However, from my initial observation of the logic, the processing of any single entity depends only on the entries that correspond to that entity, the processing of any relation depends on only entries corresponding to that relation and possibly entries corresponding to the related entries.

The changes I have made in this pull request essentially allow for this operation to no longer require a lock of the entire database, but only a lock specific to the entity name or relation name that it seeks to modify. This allows for massively parallel document insertion that allows for full use of GPU / API capacity.

## Key Changes

1.  **Keyed Locking for Granular Control**:
    *   Introduced `get_graph_db_lock_keyed(key)`: a function/method that returns an asynchronous lock context manager specific to the provided `key` (e.g., an `entity_name` or a unique `src_id_tgt_id` string for relationships).
    *   **Mutual Exclusion**: If multiple coroutines attempt to acquire a lock for the *same* key via `get_graph_db_lock_keyed(key)`, they will operate sequentially on that specific item. One coroutine must release the lock before another can acquire it for that same key.
    *   **Concurrency**: Operations using locks for *different* keys can proceed in parallel without blocking each other.

2.  **Atomic Operations**:
    *   All operations related to a single entity (e.g., graph updates, vector DB upserts) are grouped and executed atomically under the lock obtained for that entity's key.
    *   Similarly, all operations for a single relationship are performed atomically under the lock obtained for that relationship's key.
    *   This ensures that an entity or relationship is always in a consistent state post-operation, preventing partial updates during concurrent execution.

3.  **Concurrent Processing Logic**:
    *   Utilizes `asyncio.gather()` to process merging of different entities in parallel.
    *   Utilizes `asyncio.gather()` to process merging of different relationships in parallel.
    *   The keyed locking mechanism, accessed via `get_graph_db_lock_keyed(key)`, integrates with this concurrent execution to manage access.

## Additional Changes
Introduced semaphore for merging portion because now that this portion is massively parallel it needs to be appropriately resource controlled. It is in-fact significantly more parallel than the initial portion since each entity and relation is processed in parallel potentially. In-fact in practice I have found it beneficial to increase the llm_model_max_async and embedding_func_max_async to 3x of max_parallel_insert.

## Illustrative Examples of Locking

Let's assume `self.get_graph_db_lock_keyed` is the method providing access to the new locking mechanism.

**Entity Processing**:
```python
# self.get_graph_db_lock_keyed(key) returns an async lock
# context manager specific to the 'entity_name'.
async with self.get_graph_db_lock_keyed(entity_name):
    # Any other coroutine attempting to lock the *same* entity_name
    # (i.e., calling self.get_graph_db_lock_keyed(entity_name))
    # will block here until this critical section is exited.
    # Operations within this block are atomic for this entity.
    await self.chunk_entity_relation_graph.upsert_node(...)
    await self.entities_vdb.upsert(...)
```

**Relationship Processing**:
```python
# Generate a unique key for the relationship.
relationship_key = f"{src_id}_{tgt_id}"
async with self.get_graph_db_lock_keyed(relationship_key):
    # Any other coroutine attempting to lock the *same* relationship_key
    # will block here until this critical section is exited.
    # Operations within this block are atomic for this relationship.
    await self.chunk_entity_relation_graph.upsert_edge(...)
    await self.relationships_vdb.upsert(...)
```

## Related Issues

-   Implements atomic operations for entities/relationships.
-   Addresses potential race conditions during concurrent updates to the same items.
-   Contributes to data consistency during parallel processing.

## Checklist

-   [x] Changes tested locally (for asyncio concurrency)
-   [ ] Code reviewed
-   [ ] Internal behavior, no documentation present AFAIK (maybe theres some developer docs somewhere?)
-   [ ] Unit tests added (I think this should be tested against existing tests for correctness)
-   [ ] Multi-processing compatibility tested [I have added multi-processing keyed locks, but haven't had the opportunity to test it]

## Summary

The locking strategy is fine-grained to individual data items (entities/relationships), identified by unique keys. This allows for concurrent processing of unrelated items while enforcing serial, atomic access for operations on the same item.