### PR TITLE
Fix: Increase Ollama timeout values to prevent ReadTimeout errors

### DIFF
--- a/lightrag/llm/ollama.py
+++ b/lightrag/llm/ollama.py
@@ -50,7 +50,7 @@ async def _ollama_model_if_cache(
     kwargs.pop("max_tokens", None)
     # kwargs.pop("response_format", None) # allow json
     host = kwargs.pop("host", None)
-    timeout = kwargs.pop("timeout", None) or 300  # Default timeout 300s
+    timeout = kwargs.pop("timeout", None) or 600  # Default timeout 600s (10분으로 증가)
     kwargs.pop("hashing_kv", None)
     api_key = kwargs.pop("api_key", None)
     headers = {
@@ -146,7 +146,7 @@ async def ollama_embed(texts: list[str], embed_model, **kwargs) -> np.ndarray:
         headers["Authorization"] = f"Bearer {api_key}"
 
     host = kwargs.pop("host", None)
-    timeout = kwargs.pop("timeout", None) or 90  # Default time out 90s
+    timeout = kwargs.pop("timeout", None) or 300  # Default time out 300s (5분으로 증가)
 
     ollama_client = ollama.AsyncClient(host=host, timeout=timeout, headers=headers)
 


### PR DESCRIPTION

resolve:  #1640


## 🐛 Problem
Users are experiencing `httpx.ReadTimeout` errors when using Ollama models, especially during entity extraction processes. The current timeout values (300s for completion, 90s for embedding) are insufficient for larger documents or slower models.

**Related Issue:** #1640

## 🔧 Solution
Increased default timeout values in `lightrag/llm/ollama.py`:
- **LLM completion timeout**: `300s` → `600s` (10 minutes)
- **Embedding timeout**: `90s` → `300s` (5 minutes)