### PR TITLE
Remove graspologic pip installation that no longer seems to be used

### DIFF
--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -11,9 +11,6 @@ import pipmaster as pm
 if not pm.is_installed("networkx"):
     pm.install("networkx")
 
-if not pm.is_installed("graspologic"):
-    pm.install("graspologic")
-
 import networkx as nx
 from .shared_storage import (
     get_storage_lock,


### PR DESCRIPTION
## Description

As far as I can tell this is no longer actually used and its usage was removed in this commit: https://github.com/HKUDS/LightRAG/commit/83353ab9a619e921fb71a8b62070acfd6f773b49#diff-a346bcfb05aab0cc0c0baa6018976f4efab339e8cade9f6f8fb658fcbd54ae2e

Our systems are flagging this package as having a dependency on a package with a less permissive license so I would appreciate if it can be removed if its no longer needed.  Let me know if that is not the case.


## Changes Made

Removed pip installation of graspologic
