### PR TITLE
fix typo: "extrat" -> extract

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1006,7 +1006,7 @@ class LightRAG:
                         except Exception as e:
                             # Log error and update pipeline status
                             logger.error(traceback.format_exc())
-                            error_msg = f"Failed to extrat document {current_file_number}/{total_files}: {file_path}"
+                            error_msg = f"Failed to extract document {current_file_number}/{total_files}: {file_path}"
                             logger.error(error_msg)
                             async with pipeline_status_lock:
                                 pipeline_status["latest_message"] = error_msg


### PR DESCRIPTION
## Description

Just a small typo fix. A single character 😄 

## Related Issues

None

## Changes Made

Fixed a typo in logger error message, specifically "extrac" changed to "extract"

## Checklist

- [ x] Changes tested locally
- [ x] Code reviewed
