### PR TITLE
Fix GRAPH_FIELD_SEP import typo

### DIFF
--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 
 from .base import DeletionResult
 from .kg.shared_storage import get_graph_db_lock
-from .prompt import GRAPH_FIELD_SEP
+from .constants import GRAPH_FIELD_SEP
 from .utils import compute_mdhash_id, logger
 from .base import StorageNameSpace
 


### PR DESCRIPTION
## Description

Fix `GRAPH_FIELD_SEP` import typo from the wrong module.

## Related Issues

#1697

## Changes Made

Change import path for `GRAPH_FIELD_SEP` from `prompt.py` to `constants.py` in `utils_graph.py`.

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes


