### PR TITLE
Fix incorrect file path (404 Not Found)

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -30,7 +30,7 @@
       <a href="https://github.com/HKUDS/LightRAG/issues/285"><img src="https://img.shields.io/badge/💬微信群-交流-07c160?style=for-the-badge&logo=wechat&logoColor=white&labelColor=1a1a2e"></a>
     </p>
     <p>
-      <a href="README_zh.md"><img src="https://img.shields.io/badge/🇨🇳中文版-1a1a2e?style=for-the-badge"></a>
+      <a href="README-zh.md"><img src="https://img.shields.io/badge/🇨🇳中文版-1a1a2e?style=for-the-badge"></a>
       <a href="README.md"><img src="https://img.shields.io/badge/🇺🇸English-1a1a2e?style=for-the-badge"></a>
     </p>
   </div>


### PR DESCRIPTION
## Description

![image](https://github.com/user-attachments/assets/a1e1aa7f-f8ae-4e43-9303-8da56130a42a)

This pull request fixes a broken link to the Chinese README file in the repository. The original link referenced README_zh.md, which caused a 404 error. It has been corrected to point to the correct file README-zh.md.


## Related Issues

N/A

## Changes Made

Replaced incorrect reference README_zh.md with README-zh.md in documentation links.

## Checklist

- [x] Changes tested locally

- [x] Code reviewed

- [x] Documentation updated

## Additional Notes

The broken link previously prevented users from accessing the Chinese documentation. This fix ensures the README can be properly opened via browser, improving accessibility for Chinese-speaking users.
