### PR TITLE
Fix: Handle NoneType error when processing documents without a file path

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -900,9 +900,15 @@ class LightRAG:
                 # Get first document's file path and total count for job name
                 first_doc_id, first_doc = next(iter(to_process_docs.items()))
                 first_doc_path = first_doc.file_path
-                path_prefix = first_doc_path[:20] + (
-                    "..." if len(first_doc_path) > 20 else ""
-                )
+
+                # Handle cases where first_doc_path is None
+                if first_doc_path:
+                    path_prefix = first_doc_path[:20] + (
+                        "..." if len(first_doc_path) > 20 else ""
+                    )
+                else:
+                    path_prefix = "unknown_source"
+
                 total_files = len(to_process_docs)
                 job_name = f"{path_prefix}[{total_files} files]"
                 pipeline_status["job_name"] = job_name


### PR DESCRIPTION

### Description

This pull request addresses a `TypeError` crash that occurs in the document processing pipeline. When a document is submitted as raw text (e.g., via the `/documents/text` API endpoint), the `file_path` attribute is `None`. The existing code did not handle this case and attempted to perform a string slice on the `None` value, causing the background processing task to crash and preventing the document from being indexed.

This change introduces a simple check to handle a `None` `file_path` gracefully by providing a default string, which resolves the crash and ensures that text-based documents can be successfully processed and indexed.

### Related Issues

*   This PR fixes a bug that causes a `TypeError: 'NoneType' object is not subscriptable` in `lightrag/lightrag.py` during document processing. While there is no open issue for this yet, it directly resolves the error observed in the user-provided logs.

### Changes Made

*   **Modified `lightrag/lightrag.py`:**
    *   In the `apipeline_process_enqueue_documents` method, added a conditional check to verify if `first_doc_path` is not `None` before attempting to slice it.
    *   If `first_doc_path` is `None`, a default value of `"unknown_source"` is used for the log message prefix, preventing the `TypeError`.

### Checklist

- [x] Changes tested locally (by simulating the API call that previously caused the crash)
- [ ] Code reviewed
- [x] Documentation updated (if necessary) - *No documentation changes were required for this fix.*
- [ ] Unit tests added (if applicable) - *No new unit tests were added, as this is a minor fix.*

### Additional Notes

This is a critical fix for users who interact with the LightRAG server primarily through its API by submitting raw text, as it unblocks a core functionality of the indexing pipeline. The fix is minimal and has no side effects on document processing for file-based inputs.