### PR TITLE
fix(build): pyproject.toml setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,8 +82,10 @@ Documentation = "https://github.com/HKUDS/LightRAG"
 Repository = "https://github.com/HKUDS/LightRAG"
 "Bug Tracker" = "https://github.com/HKUDS/LightRAG/issues"
 
+[tool.setuptools.packages.find]
+include = ["lightrag*"]
+
 [tool.setuptools]
-packages = ["lightrag"]
 include-package-data = true
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
## Description
In the changes introduced from tag `1.3.9` to `1.3.10`, the setup of the package was changed from using `setup.py` to using  `pyproject.toml`. Within the pyproject.toml, there's a config error leading to only the `lightrag.api' package being installed.

## Related Issues
Installing any version of LightRAG >= 1.3.10 would only install lightrag.api, but not lightrag.kg, lightrag.llm and lightrag.tools.
<img width="596" height="38" alt="image" src="https://github.com/user-attachments/assets/4d9c067b-24df-43b9-8840-1786c76878be" />

This would in a regular use case crash the service:
<img width="1051" height="111" alt="image" src="https://github.com/user-attachments/assets/953d29bc-7251-434b-88bb-c9d732fc2104" />

## Changes Made
This change makes sure the automatic discovery functionality originally within `setup.py` also works in the `pyproject.toml` file.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

