### PR TITLE
Refac: Generalize keyed lock with namespace support

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -1016,25 +1016,12 @@ async def _merge_edges_then_upsert(
     )
 
     for need_insert_id in [src_id, tgt_id]:
-        if await knowledge_graph_inst.has_node(need_insert_id):
-            # This is so that the initial check for the existence of the node need not be locked
-            continue
         workspace = global_config.get("workspace", "")
         namespace = f"{workspace}:GraphDB" if workspace else "GraphDB"
         async with get_storage_keyed_lock(
             [need_insert_id], namespace=namespace, enable_logging=False
         ):
             if not (await knowledge_graph_inst.has_node(need_insert_id)):
-                # # Discard this edge if the node does not exist
-                # if need_insert_id == src_id:
-                #     logger.warning(
-                #         f"Discard edge: {src_id} - {tgt_id} | Source node missing"
-                #     )
-                # else:
-                #     logger.warning(
-                #         f"Discard edge: {src_id} - {tgt_id} | Target node missing"
-                #     )
-                # return None
                 await knowledge_graph_inst.upsert_node(
                     need_insert_id,
                     node_data={


### PR DESCRIPTION
### Generalize keyed lock with namespace support

Refactored the KeyedUnifiedLock to be generic and support dynamic namespaces. This decouples the locking mechanism from a specific "GraphDB" implementation, allowing it to be reused across different components and workspaces safely.
Move node existence check inside lock to prevent race condition and prevent duplicate node creation during concurrent updates.

Key changes:
- KeyedUnifiedLock now takes a namespace parameter on lock acquisition.
- Renamed _graph_db_lock_keyed to a more generic _storage_keyed_lock`
- Replaced get_graph_db_lock_keyed with get_storage_keyed_lock` to support namespaces
- Move knowledge_graph_inst.has_node check inside get_storage_keyed_lock
in _merge_edges_then_upsert to ensure atomic check-then-act operations
