### PR TITLE
Hotfix: prevent premature lock cleanup in multiprocess mode

### DIFF
--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -422,7 +422,7 @@ def _get_or_create_shared_raw_mp_lock(
                     f"Shared-Data lock registry for {factory_name} is corrupted for key {key}"
                 )
             if (
-                count == 1 and combined_key in _lock_cleanup_data
+                count == 0 and combined_key in _lock_cleanup_data
             ):  # Reusing an key waiting for cleanup, remove it from cleanup list
                 _lock_cleanup_data.pop(combined_key)
         count += 1


### PR DESCRIPTION
### Prevent premature lock cleanup in multiprocess mode

- Change cleanup condition from count == 1 to count == 0 to properly remove reused locks from cleanup list
- This prevents locks from being accidentally cleaned up while still in use, resolving "RuntimeError: Attempting to release lock for xxxx more times than it was acquired"

