### PR TITLE
Fix Milvus DataNotMatchException

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -457,13 +457,13 @@ class LightRAG:
             namespace=NameSpace.VECTOR_STORE_ENTITIES,
             workspace=self.workspace,
             embedding_func=self.embedding_func,
-            meta_fields={"entity_name", "source_id", "content", "file_path", "entity_type"},
+            meta_fields={"entity_name", "source_id", "content", "file_path"},
         )
         self.relationships_vdb: BaseVectorStorage = self.vector_db_storage_cls(  # type: ignore
             namespace=NameSpace.VECTOR_STORE_RELATIONSHIPS,
             workspace=self.workspace,
             embedding_func=self.embedding_func,
-            meta_fields={"src_id", "tgt_id", "source_id", "content", "file_path", "weight"},
+            meta_fields={"src_id", "tgt_id", "source_id", "content", "file_path"},
         )
         self.chunks_vdb: BaseVectorStorage = self.vector_db_storage_cls(  # type: ignore
             namespace=NameSpace.VECTOR_STORE_CHUNKS,


### PR DESCRIPTION
## Description

Milvus向量存储保存失败
向量集合entities中，entity_type字段为空，报错：entity_type不能为空
向量集合relationships中，weight字段为空，报错：weight不能为空

## Related Issues

https://github.com/HKUDS/LightRAG/issues/1785

## Changes Made

1、meta_fields 添加"entity_type"
方法
lightrag.lightrag.LightRAG.__post_init__ 
字段
self.entities_vdb

2、meta_fields 添加"weight"
方法
lightrag.lightrag.LightRAG.__post_init__ 
字段
self.relationships_vdb

3、添加"weight"默认值
文件
lightrag/operate.py
位置
relationships_vdb.upsert

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

### 报错
报错信息:Milvus Fails: DataNotMatchException ('entity_type' required even when nullable) 
可能原因:由于Mivlus服务版本和Mivlus-SDK版本问题，导致允许可空的配置无效(nullable=True、milvus_impl.py)
触发位置:lightrag.kg.milvus_impl.MilvusVectorDBStorage.upsert
相关属性:meta_fields
复现场景:项目从零开始导入文件(没有存量数据)

### 分支
## 修复分支:tag=v1.4.0