### PR TITLE
feat: change default query mode from hybrid to mix

### DIFF
--- a/lightrag/api/routers/ollama_api.py
+++ b/lightrag/api/routers/ollama_api.py
@@ -199,7 +199,7 @@ def parse_query_mode(query: str) -> tuple[str, SearchMode, bool, Optional[str]]:
         "/mix ": (SearchMode.mix, False),
         "/bypass ": (SearchMode.bypass, False),
         "/context": (
-            SearchMode.hybrid,
+            SearchMode.mix,
             True,
         ),
         "/localcontext": (SearchMode.local, True),
@@ -215,7 +215,7 @@ def parse_query_mode(query: str) -> tuple[str, SearchMode, bool, Optional[str]]:
             cleaned_query = query[len(prefix) :].lstrip()
             return cleaned_query, mode, only_need_context, user_prompt
 
-    return query, SearchMode.hybrid, False, user_prompt
+    return query, SearchMode.mix, False, user_prompt
 
 
 class OllamaAPI:

--- a/lightrag/api/routers/query_routes.py
+++ b/lightrag/api/routers/query_routes.py
@@ -23,7 +23,7 @@ class QueryRequest(BaseModel):
     )
 
     mode: Literal["local", "global", "hybrid", "naive", "mix", "bypass"] = Field(
-        default="hybrid",
+        default="mix",
         description="Query mode",
     )
 


### PR DESCRIPTION
### Change default query mode from hybrid to mix

- Update default mode for Ollama chat endpoint
- Update default mode for query endpoint of LightRAG
