### PR TITLE
fix Azure deployment

### DIFF
--- a/lightrag/llm/azure_openai.py
+++ b/lightrag/llm/azure_openai.py
@@ -47,7 +47,7 @@ async def azure_openai_complete_if_cache(
     api_version: str | None = None,
     **kwargs,
 ):
-    model = model or os.getenv("AZURE_OPENAI_DEPLOYMENT") or os.getenv("LLM_MODEL")
+    deployment = os.getenv("AZURE_OPENAI_DEPLOYMENT") or model or os.getenv("LLM_MODEL")
     base_url = (
         base_url or os.getenv("AZURE_OPENAI_ENDPOINT") or os.getenv("LLM_BINDING_HOST")
     )
@@ -62,7 +62,7 @@ async def azure_openai_complete_if_cache(
 
     openai_async_client = AsyncAzureOpenAI(
         azure_endpoint=base_url,
-        azure_deployment=model,
+        azure_deployment=deployment,
         api_key=api_key,
         api_version=api_version,
     )
@@ -136,9 +136,9 @@ async def azure_openai_embed(
     api_key: str | None = None,
     api_version: str | None = None,
 ) -> np.ndarray:
-    model = (
-        model
-        or os.getenv("AZURE_EMBEDDING_DEPLOYMENT")
+    deployment = (
+        os.getenv("AZURE_EMBEDDING_DEPLOYMENT")
+        or model
         or os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
     )
     base_url = (
@@ -159,7 +159,7 @@ async def azure_openai_embed(
 
     openai_async_client = AsyncAzureOpenAI(
         azure_endpoint=base_url,
-        azure_deployment=model,
+        azure_deployment=deployment,
         api_key=api_key,
         api_version=api_version,
     )


### PR DESCRIPTION
## Description

###Purpose of the Change
The update introduced in the commit ensures proper handling of the distinction between model and azure_deployment when using Azure OpenAI APIs for embeddings.
###Why This Change Was Needed
Azure OpenAI requires both the model name (e.g., "text-embedding-3-small") and the deployment name (the name of the configured deployment resource in Azure). These two values can differ: the deployment is an alias defined in Azure that points to a specific model and is used to build the API endpoint.
###Previous Issue
In the earlier implementation, if a model value was provided, it was also used as the deployment. This caused errors when the deployment name in Azure differed from the model name. As a result, the deployment variable could be incorrectly set, leading to failed or misrouted API calls.
###Impact on AsyncAzureOpenAI
The AsyncAzureOpenAI class now accepts both model and azure_deployment as separate parameters. If not handled correctly, the API call may fail or use the wrong model.

## Related Issues

[#1800](https://github.com/HKUDS/LightRAG/issues/1800)

## Changes Made

By prioritizing the AZURE_EMBEDDING_DEPLOYMENT or AZURE_OPENAI_DEPLOYMENT environment variables, the update ensures correct override and disambiguation between model and deployment names—especially when they are identical—while the renaming of the variable improves clarity and intent.

## Checklist

- [ x] Changes tested locally
- [x ] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

The fix is actually logical: the explicit value comes first, then the fallbacks.