### PR TITLE
feat: Add SSL support for PostgreSQL database connections

### DIFF
--- a/env.example
+++ b/env.example
@@ -189,6 +189,13 @@ POSTGRES_DATABASE=your_database
 POSTGRES_MAX_CONNECTIONS=12
 # POSTGRES_WORKSPACE=forced_workspace_name
 
+### PostgreSQL SSL Configuration (Optional)
+# POSTGRES_SSL_MODE=require
+# POSTGRES_SSL_CERT=/path/to/client-cert.pem
+# POSTGRES_SSL_KEY=/path/to/client-key.pem
+# POSTGRES_SSL_ROOT_CERT=/path/to/ca-cert.pem
+# POSTGRES_SSL_CRL=/path/to/crl.pem
+
 ### Neo4j Configuration
 NEO4J_URI=neo4j+s://xxxxxxxx.databases.neo4j.io
 NEO4J_USERNAME=neo4j


### PR DESCRIPTION
### feat: Add SSL support for PostgreSQL database connections

- Add SSL configuration options (ssl_mode, ssl_cert, ssl_key, ssl_root_cert, ssl_crl)
- Support all PostgreSQL SSL modes (disable, allow, prefer, require, verify-ca, verify-full)
- Add SSL context creation with certificate validation
- Update initdb() method to handle SSL connection parameters
- Add SSL environment variables to env.example

fixed #1741 