### PR TITLE
Better prompt for entity description extraction to avoid hallucinations

### DIFF
--- a/lightrag/prompt.py
+++ b/lightrag/prompt.py
@@ -21,7 +21,7 @@ Use {language} as output language.
 1. Identify all entities. For each identified entity, extract the following information:
 - entity_name: Name of the entity, use same language as input text. If English, capitalized the name.
 - entity_type: One of the following types: [{entity_types}]
-- entity_description: Comprehensive description of the entity's attributes and activities
+- entity_description: Provide a comprehensive description of the entity's attributes and activities *based solely on the information present in the input text*. **Do not infer or hallucinate information not explicitly stated.** If the text provides insufficient information to create a comprehensive description, state "Description not available in text."
 Format each entity as ("entity"{tuple_delimiter}<entity_name>{tuple_delimiter}<entity_type>{tuple_delimiter}<entity_description>)
 
 2. From the entities identified in step 1, identify all pairs of (source_entity, target_entity) that are *clearly related* to each other.


### PR DESCRIPTION
## Description
Noticed that during entity extraction the LLM (o4-mini) was making up things under some circumstances for the description. For example given the abbreviation of an organization, the description sometimes contained bogus full name. Ran the original prompt multiple times, and definitely reproducible, LLMs can be pretty creative :)

## Changes Made
Extended the instruction to use only the information in the text for the description.

## Additional Notes
There might be a better prompt, but this seems to be working for me, and wanted to let you know the issue.