### PR TITLE
fix(postgres): handle ssl_mode="allow" in _create_ssl_context

### DIFF
--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -80,7 +80,7 @@ class PostgreSQLDB:
         if ssl_mode in ["disable", "allow", "prefer", "require"]:
             if ssl_mode == "disable":
                 return None
-            elif ssl_mode in ["require", "prefer"]:
+            elif ssl_mode in ["require", "prefer", "allow"]:
                 # Return None for simple SSL requirement, handled in initdb
                 return None
 


### PR DESCRIPTION
### fix(postgres): handle ssl_mode="allow" in _create_ssl_context

Add "allow" to the list of recognized SSL modes in PostgreSQL connection helper. Previously, ssl_mode="allow" would fall through to "Unknown SSL mode" warning. Now it's properly handled alongside "require" and "prefer" modes.

fix #1850