### PR TITLE
Fix: move OllamaServerInfos class to base module

### DIFF
--- a/lightrag/__init__.py
+++ b/lightrag/__init__.py
@@ -1,5 +1,5 @@
 from .lightrag import LightRAG as LightRAG, QueryParam as QueryParam
 
-__version__ = "1.4.5"
+__version__ = "1.4.6"
 __author__ = "Zirui Guo"
 __url__ = "https://github.com/HKUDS/LightRAG"

--- a/lightrag/api/__init__.py
+++ b/lightrag/api/__init__.py
@@ -1,1 +1,1 @@
-__api_version__ = "0195"
+__api_version__ = "0196"

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -8,6 +8,7 @@ import logging
 from dotenv import load_dotenv
 from lightrag.utils import get_env_value
 from lightrag.llm.binding_options import OllamaEmbeddingOptions, OllamaLLMOptions
+from lightrag.base import OllamaServerInfos
 import sys
 
 from lightrag.constants import (
@@ -30,9 +31,6 @@ from lightrag.constants import (
     DEFAULT_EMBEDDING_BATCH_NUM,
     DEFAULT_OLLAMA_MODEL_NAME,
     DEFAULT_OLLAMA_MODEL_TAG,
-    DEFAULT_OLLAMA_MODEL_SIZE,
-    DEFAULT_OLLAMA_CREATED_AT,
-    DEFAULT_OLLAMA_DIGEST,
     DEFAULT_TEMPERATURE,
 )
 
@@ -40,39 +38,6 @@ from lightrag.constants import (
 # allows to use different .env file for each lightrag instance
 # the OS environment variables take precedence over the .env file
 load_dotenv(dotenv_path=".env", override=False)
-
-
-class OllamaServerInfos:
-    def __init__(self, name=None, tag=None):
-        self._lightrag_name = name or os.getenv(
-            "OLLAMA_EMULATING_MODEL_NAME", DEFAULT_OLLAMA_MODEL_NAME
-        )
-        self._lightrag_tag = tag or os.getenv(
-            "OLLAMA_EMULATING_MODEL_TAG", DEFAULT_OLLAMA_MODEL_TAG
-        )
-        self.LIGHTRAG_SIZE = DEFAULT_OLLAMA_MODEL_SIZE
-        self.LIGHTRAG_CREATED_AT = DEFAULT_OLLAMA_CREATED_AT
-        self.LIGHTRAG_DIGEST = DEFAULT_OLLAMA_DIGEST
-
-    @property
-    def LIGHTRAG_NAME(self):
-        return self._lightrag_name
-
-    @LIGHTRAG_NAME.setter
-    def LIGHTRAG_NAME(self, value):
-        self._lightrag_name = value
-
-    @property
-    def LIGHTRAG_TAG(self):
-        return self._lightrag_tag
-
-    @LIGHTRAG_TAG.setter
-    def LIGHTRAG_TAG(self, value):
-        self._lightrag_tag = value
-
-    @property
-    def LIGHTRAG_MODEL(self):
-        return f"{self._lightrag_name}:{self._lightrag_tag}"
 
 
 ollama_server_infos = OllamaServerInfos()

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -23,12 +23,50 @@ from .constants import (
     DEFAULT_MAX_TOTAL_TOKENS,
     DEFAULT_HISTORY_TURNS,
     DEFAULT_ENABLE_RERANK,
+    DEFAULT_OLLAMA_MODEL_NAME,
+    DEFAULT_OLLAMA_MODEL_TAG,
+    DEFAULT_OLLAMA_MODEL_SIZE,
+    DEFAULT_OLLAMA_CREATED_AT,
+    DEFAULT_OLLAMA_DIGEST,
 )
 
 # use the .env that is inside the current folder
 # allows to use different .env file for each lightrag instance
 # the OS environment variables take precedence over the .env file
 load_dotenv(dotenv_path=".env", override=False)
+
+
+class OllamaServerInfos:
+    def __init__(self, name=None, tag=None):
+        self._lightrag_name = name or os.getenv(
+            "OLLAMA_EMULATING_MODEL_NAME", DEFAULT_OLLAMA_MODEL_NAME
+        )
+        self._lightrag_tag = tag or os.getenv(
+            "OLLAMA_EMULATING_MODEL_TAG", DEFAULT_OLLAMA_MODEL_TAG
+        )
+        self.LIGHTRAG_SIZE = DEFAULT_OLLAMA_MODEL_SIZE
+        self.LIGHTRAG_CREATED_AT = DEFAULT_OLLAMA_CREATED_AT
+        self.LIGHTRAG_DIGEST = DEFAULT_OLLAMA_DIGEST
+
+    @property
+    def LIGHTRAG_NAME(self):
+        return self._lightrag_name
+
+    @LIGHTRAG_NAME.setter
+    def LIGHTRAG_NAME(self, value):
+        self._lightrag_name = value
+
+    @property
+    def LIGHTRAG_TAG(self):
+        return self._lightrag_tag
+
+    @LIGHTRAG_TAG.setter
+    def LIGHTRAG_TAG(self, value):
+        self._lightrag_tag = value
+
+    @property
+    def LIGHTRAG_MODEL(self):
+        return f"{self._lightrag_name}:{self._lightrag_tag}"
 
 
 class TextChunkSchema(TypedDict):

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -44,11 +44,6 @@ from lightrag.kg import (
     verify_storage_implementation,
 )
 
-# Import for type annotation
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from lightrag.api.config import OllamaServerInfos
 
 from lightrag.kg.shared_storage import (
     get_namespace_data,
@@ -67,6 +62,7 @@ from .base import (
     StorageNameSpace,
     StoragesStatus,
     DeletionResult,
+    OllamaServerInfos,
 )
 from .namespace import NameSpace
 from .operate import (
@@ -358,7 +354,7 @@ class LightRAG:
         default=float(os.getenv("COSINE_THRESHOLD", 0.2))
     )
 
-    ollama_server_infos: Optional["OllamaServerInfos"] = field(default=None)
+    ollama_server_infos: Optional[OllamaServerInfos] = field(default=None)
     """Configuration for Ollama server information."""
 
     _storages_status: StoragesStatus = field(default=StoragesStatus.NOT_CREATED)
@@ -424,8 +420,6 @@ class LightRAG:
 
         # Initialize ollama_server_infos if not provided
         if self.ollama_server_infos is None:
-            from lightrag.api.config import OllamaServerInfos
-
             self.ollama_server_infos = OllamaServerInfos()
 
         # Fix global_config now


### PR DESCRIPTION
Move OllamaServerInfos class to base module to eliminate dependency of the core module on the API module.

Fixed #1887