### PR TITLE
Add vector index support for PostgreSQL KG

### DIFF
--- a/env.example
+++ b/env.example
@@ -234,6 +234,14 @@ POSTGRES_DATABASE=your_database
 POSTGRES_MAX_CONNECTIONS=12
 # POSTGRES_WORKSPACE=forced_workspace_name
 
+### PostgreSQL Vector Storage Configuration
+### Vector storage type: HNSW, IVFFlat, FLAT
+
+VECTOR_INDEX=FLAT
+POSTGRES_HNSW_M=16
+POSTGRES_HNSW_EF=200
+POSTGRES_IVFFLAT_LISTS=100
+
 ### PostgreSQL SSL Configuration (Optional)
 # POSTGRES_SSL_MODE=require
 # POSTGRES_SSL_CERT=/path/to/client-cert.pem


### PR DESCRIPTION
## Summary

This PR introduces support for multiple PostgreSQL vector index types (`IVFFLAT`, `HNSW`, and `FLAT`) for vector-based retrieval in LightRAG.

It:

- Adds index creation logic for the three vector index types
- Enables auto-indexing for three key VDB tables 
  - `LIGHTRAG_VDB_CHUNKS`
  - `LIGHTRAG_VDB_ENTITY`
  - `LIGHTRAG_VDB_RELATION`
- Makes index type configurable via `.env`
- Updates SQL templates to ensure vector indexes are used effectively via `<=>` operator

These enhancements make LightRAG's vector storage more efficient, flexible, and production-ready.

------

## Changes

### 1. Vector Index Creation Methods

Added three async methods for vector index creation:

- `_create_ivfflat_vector_indexes(lists: int = 100)`
- `_create_hnsw_vector_indexes(m: int = 16, ef_construction: int = 256)`
- `_create_flat_vector_indexes()`

Each method automatically applies the selected index to the following tables:

- `LIGHTRAG_VDB_CHUNKS`
- `LIGHTRAG_VDB_ENTITY`
- `LIGHTRAG_VDB_RELATION`

Each index is created only if it doesn't already exist. Example log output is added, and `ANALYZE` is executed after index creation to optimize query planning.

------

### 2. Environment Configuration (`.env`)

Added the following `.env` configuration options:

```env
### PostgreSQL Vector Storage Configuration
### Vector storage type: HNSW, IVFFLAT, FLAT
VECTOR_INDEX=FLAT
POSTGRES_HNSW_M=16
POSTGRES_HNSW_EF=200
POSTGRES_IVFFLAT_LISTS=100
```

These settings control the type and parameters of vector index creation during setup/migration.

------

### 3. Query SQL Modifications

Updated the SQL query templates in vector retrieval logic (`relationships`, `entities`, `chunks`) to explicitly use the `<=>` operator, ensuring the PostgreSQL query planner leverages vector indexes (e.g., HNSW or IVFFLAT).

#### Relationships Query

```sql
WITH relevant_chunks AS (
    SELECT id as chunk_id
    FROM LIGHTRAG_VDB_CHUNKS
    WHERE $2::varchar[] IS NULL OR full_doc_id = ANY($2::varchar[])
)
SELECT r.source_id as src_id, r.target_id as tgt_id,
       EXTRACT(EPOCH FROM r.create_time)::BIGINT as created_at
FROM LIGHTRAG_VDB_RELATION r
JOIN relevant_chunks c ON c.chunk_id = ANY(r.chunk_ids)
WHERE r.workspace = $1
  AND r.content_vector <=> '[{embedding_string}]'::vector < $3
ORDER BY r.content_vector <=> '[{embedding_string}]'::vector
LIMIT $4
```

---

## Motivation

Previously, LightRAG lacked configurable support for different vector index types, and query performance would degrade with large datasets.

This PR improves vector search performance, introduces flexibility in index configuration, and helps LightRAG scale to production workloads with large embeddings.

------

## Compatibility

- Requires PostgreSQL ≥ 13 with `pgvector` extension installed
- Fully backward compatible
- Only active when configured via `.env`

------

##  Notes

- Default distance metric is `vector_cosine_ops`, but this can be modified as needed (`vector_l2_ops`, `vector_ip_ops`, etc.)
- No schema-breaking changes; this is an additive, optional enhancement
- Optionally extendable to support auto-sync or reindexing pipelines later