### PR TITLE
Fix: Unify  document chunks context format in only_need_context query

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -3105,7 +3105,7 @@ async def naive_query(
     text_units_str = json.dumps(text_units_context, ensure_ascii=False)
     if query_param.only_need_context:
         return f"""
----Document Chunks---
+---Document Chunks(DC)---
 
 ```json
 {text_units_str}


### PR DESCRIPTION
### Unify  document chunks context format in only_need_context query

- Update Document Chunks label to include (DC) abbreviation

fix #1919 