### PR TITLE
Fix: Initialize first_stage_tasks and entity_relation_task to prevent empty-task cancel errors

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1229,6 +1229,7 @@ class LightRAG:
                     async with semaphore:
                         nonlocal processed_count
                         current_file_number = 0
+                        # Initialize to prevent UnboundLocalError in error handling
                         first_stage_tasks = []
                         entity_relation_task = None
                         try:
@@ -1352,9 +1353,7 @@ class LightRAG:
 
                             # Cancel tasks that are not yet completed
                             all_tasks = first_stage_tasks + (
-                                [entity_relation_task]
-                                if entity_relation_task
-                                else []
+                                [entity_relation_task] if entity_relation_task else []
                             )
                             for task in all_tasks:
                                 if task and not task.done():

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1229,6 +1229,8 @@ class LightRAG:
                     async with semaphore:
                         nonlocal processed_count
                         current_file_number = 0
+                        first_stage_tasks = []
+                        entity_relation_task = None
                         try:
                             # Get file path from status document
                             file_path = getattr(
@@ -1348,15 +1350,15 @@ class LightRAG:
                                 )
                                 pipeline_status["history_messages"].append(error_msg)
 
-                                # Cancel tasks that are not yet completed
-                                all_tasks = first_stage_tasks + (
-                                    [entity_relation_task]
-                                    if entity_relation_task
-                                    else []
-                                )
-                                for task in all_tasks:
-                                    if task and not task.done():
-                                        task.cancel()
+                            # Cancel tasks that are not yet completed
+                            all_tasks = first_stage_tasks + (
+                                [entity_relation_task]
+                                if entity_relation_task
+                                else []
+                            )
+                            for task in all_tasks:
+                                if task and not task.done():
+                                    task.cancel()
 
                             # Persistent llm cache
                             if self.llm_response_cache:


### PR DESCRIPTION
### Fix: Initialize first_stage_tasks and entity_relation_task to prevent empty-task cancel errors

- Initialize first_stage_tasks = [] and entity_relation_task = None at coroutine start
- Ensure cancel block safely handles no-op when tasks lists are empty