### PR TITLE
fix: Prevent KeyError when accessing history_messages during document insertion

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -1455,10 +1455,15 @@ def create_document_routes(
                 }
             )
             # Cleaning history_messages without breaking it as a shared list object
-            del pipeline_status["history_messages"][:]
-            pipeline_status["history_messages"].append(
-                "Starting document clearing process"
-            )
+            # Check if history_messages exists before trying to clear it
+            if "history_messages" in pipeline_status:
+                del pipeline_status["history_messages"][:]
+                pipeline_status["history_messages"].append(
+                    "Starting document clearing process"
+                )
+            else:
+                # Initialize history_messages if it doesn't exist
+                pipeline_status["history_messages"] = ["Starting document clearing process"]
 
         try:
             # Use drop method to clear all data

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1165,7 +1165,12 @@ class LightRAG:
                     }
                 )
                 # Cleaning history_messages without breaking it as a shared list object
-                del pipeline_status["history_messages"][:]
+                # Check if history_messages exists before trying to clear it
+                if "history_messages" in pipeline_status:
+                    del pipeline_status["history_messages"][:]
+                else:
+                    # Initialize history_messages if it doesn't exist
+                    pipeline_status["history_messages"] = []
             else:
                 # Another process is busy, just set request flag and return
                 pipeline_status["request_pending"] = True


### PR DESCRIPTION
## Description

This PR fixes the `KeyError: 'history_messages'` that occurs during document insertion in LightRAG. This is a common error that appears in the logs but doesn't affect functionality.

## Problem

When inserting documents, the system tries to clear `history_messages` without checking if it exists:

```python
# Line 1168 in lightrag.py
del pipeline_status["history_messages"][:]  # Raises KeyError if key doesn't exist
```

This causes the following error during first document insertion:
```
KeyError: 'history_messages'
File "lightrag/lightrag.py", line 1168
```

## Solution

Added defensive checks before accessing `history_messages`:

```python
# Check if history_messages exists before clearing
if "history_messages" in pipeline_status:
    del pipeline_status["history_messages"][:]
else:
    # Initialize if it doesn't exist
    pipeline_status["history_messages"] = []
```

### Files Modified

1. **lightrag/lightrag.py** (line 1168-1173)
   - Added check before clearing history_messages
   - Initialize as empty list if not present

2. **lightrag/api/routers/document_routes.py** (line 1458-1466)
   - Same defensive pattern applied
   - Ensures consistency across codebase

## Testing

✅ **Verified the fix with test script:**

```python
# Test shows no more KeyError
await rag.ainsert("Test document")  # Previously raised KeyError
# Now works without errors ✅
```

**Test results:**
- Document insertion works without KeyError
- All query modes function correctly
- No functional regression

## Impact

- **User Experience**: ✅ Improves - No more error messages in logs
- **Functionality**: ✅ No changes - System behavior unchanged
- **Performance**: ✅ No impact - Simple conditional check
- **Breaking Changes**: ❌ None

## Before/After

### Before (with error):
```
Inserting document...
KeyError: 'history_messages'
[Document still inserted but with error logged]
```

### After (fixed):
```
Inserting document...
✅ Document inserted successfully
[No errors in logs]
```

## Related Issues

While not formally reported as an issue, this error has been observed by multiple users during testing. This PR proactively fixes it.

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Tested locally
- [x] No breaking changes
- [x] Improves developer experience

## Additional Context

This is a quality-of-life improvement that eliminates confusing error messages without changing how LightRAG works. The error was non-critical but created unnecessary concern for developers seeing it in their logs.

## Note to Maintainers

This is my second contribution to LightRAG. My first PR (#1934) fixed the `storage_lock` initialization issue. This PR continues improving the developer experience by eliminating another common error.