### PR TITLE
Added import of OpenAILLMOptions when using azure_openai

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -248,6 +248,7 @@ def create_app(args):
             azure_openai_complete_if_cache,
             azure_openai_embed,
         )
+        from lightrag.llm.binding_options import OpenAILLMOptions
     if args.llm_binding == "aws_bedrock" or args.embedding_binding == "aws_bedrock":
         from lightrag.llm.bedrock import bedrock_complete_if_cache, bedrock_embed
     if args.embedding_binding == "ollama":


### PR DESCRIPTION
<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description
In LightRAG server, If I am using Azure OpenAI for the embeddings or as an LLM, I get the following error when uploading a document:

```
lightrag  | 
lightrag  | LightRAG log file: [REDACTED_PATH]/lightrag.log
lightrag  | 
lightrag  |     ╔══════════════════════════════════════════════════════════════╗
lightrag  |     ║                 LightRAG Server v1.4.7/0207                  ║
lightrag  |     ║         Fast, Lightweight RAG Server Implementation          ║
lightrag  |     ╚══════════════════════════════════════════════════════════════╝
lightrag  |     
lightrag  | 
lightrag  | 📡 Server Configuration:
lightrag  |     ├─ Host: 0.0.0.0
lightrag  |     ├─ Port: 9621
lightrag  |     ├─ Workers: 1
lightrag  |     ├─ Timeout: 150
lightrag  |     ├─ CORS Origins: *
lightrag  |     ├─ SSL Enabled: False
lightrag  |     ├─ Ollama Emulating Model: lightrag:latest
lightrag  |     ├─ Log Level: INFO
lightrag  |     ├─ Verbose Debug: True
lightrag  |     ├─ History Turns: 0
lightrag  |     ├─ API Key: Not Set
lightrag  |     └─ JWT Auth: Disabled
lightrag  | 
lightrag  | 📂 Directory Configuration:
lightrag  |     ├─ Working Directory: [REDACTED_PATH]/rag_storage
lightrag  |     └─ Input Directory: [REDACTED_PATH]/inputs
lightrag  | 
lightrag  | 🤖 LLM Configuration:
lightrag  |     ├─ Binding: azure_openai
lightrag  |     ├─ Host: [REDACTED_URL]
lightrag  |     ├─ Model: gpt-4o
lightrag  |     ├─ Max Async for LLM: 4
lightrag  |     ├─ Max Tokens: 30000
lightrag  |     ├─ LLM Cache Enabled: True
lightrag  |     └─ LLM Cache for Extraction Enabled: True
lightrag  | 
lightrag  | 📊 Embedding Configuration:
lightrag  |     ├─ Binding: azure_openai
lightrag  |     ├─ Host: [REDACTED_URL]/embeddings
lightrag  |     ├─ Model: text-embedding-3-small
lightrag  |     └─ Dimensions: 1536
lightrag  | 
lightrag  | ⚙️ RAG Configuration:
lightrag  |     ├─ Summary Language: English
lightrag  |     ├─ Entity Types: ["Book", "Author", "Topic", "Event"]
lightrag  |     ├─ Max Parallel Insert: 2
lightrag  |     ├─ Chunk Size: 1200
lightrag  |     ├─ Chunk Overlap Size: 100
lightrag  |     ├─ Cosine Threshold: 0.2
lightrag  |     ├─ Top-K: 40
lightrag  |     └─ Force LLM Summary on Merge: 4
lightrag  | 
lightrag  | 💾 Storage Configuration:
lightrag  |     ├─ KV Storage: JsonKVStorage
lightrag  |     ├─ Vector Storage: NanoVectorDBStorage
lightrag  |     ├─ Graph Storage: NetworkXStorage
lightrag  |     ├─ Document Status Storage: JsonDocStatusStorage
lightrag  |     └─ Workspace: -
lightrag  | 
lightrag  | ✨ Server starting up...
lightrag  | 
lightrag  | 
lightrag  | 🌐 Server Access Information:
lightrag  |     ├─ WebUI (local): http://localhost:9621
lightrag  |     ├─ Remote Access: http://<your-ip-address>:9621
lightrag  |     ├─ API Documentation (local): http://localhost:9621/docs
lightrag  |     └─ Alternative Documentation (local): http://localhost:9621/redoc
lightrag  | 
lightrag  | WARNING:root:In uvicorn mode, workers parameter was set to 2. Forcing workers=1
lightrag  | INFO: Reranking is disabled
lightrag  | INFO: [_] Created new empty graph file: [REDACTED_PATH]/graph_chunk_entity_relation.graphml
lightrag  | INFO: Started server process [1]
lightrag  | INFO: Waiting for application startup.
lightrag  | INFO: [_] Process 1 KV load full_docs with 0 records
lightrag  | INFO: [_] Process 1 KV load text_chunks with 0 records
lightrag  | INFO: [_] Process 1 KV load full_entities with 0 records
lightrag  | INFO: [_] Process 1 KV load full_relations with 0 records
lightrag  | INFO: [_] Process 1 KV load llm_response_cache with 0 records
lightrag  | INFO: [_] Process 1 doc status load doc_status with 0 records
lightrag  | INFO: Application startup complete.
lightrag  | INFO: Uvicorn running on http://0.0.0.0:9621 (Press CTRL+C to quit)
lightrag  | INFO: [_] Subgraph query successful | Node count: 0 | Edge count: 0
lightrag  | INFO: 172.20.0.1:59844 - "POST /documents/texts HTTP/1.1" 200
lightrag  | INFO: Processing 1 document(s)
lightrag  | INFO: Extracting stage 1/1: unknown_source
lightrag  | INFO: Processing d-id: [REDACTED_DOC_ID]
lightrag  | INFO: limit_async: 8 new workers initialized
lightrag  | INFO: limit_async: 4 new workers initialized
lightrag  | ERROR: limit_async: Error in decorated function: cannot access free variable 'OpenAILLMOptions' where it is not associated with a value in enclosing scope
lightrag  | ERROR: Failed to extract entities and relationships: cannot access free variable 'OpenAILLMOptions' where it is not associated with a value in enclosing scope
lightrag  | ERROR: Traceback (most recent call last):
lightrag  |   File "[REDACTED_PATH]/lightrag.py", line 1541, in process_document
lightrag  |     await entity_relation_task
lightrag  |   File "[REDACTED_PATH]/lightrag.py", line 1766, in _process_entity_relation_graph
lightrag  |     raise e
lightrag  |   File "[REDACTED_PATH]/lightrag.py", line 1751, in _process_entity_relation_graph
lightrag  |     chunk_results = await extract_entities(
lightrag  |                     ^^^^^^^^^^^^^^^^^^^^^^^
lightrag  |   File "[REDACTED_PATH]/operate.py", line 1710, in extract_entities
lightrag  |     raise task.exception()
lightrag  |   File "[REDACTED_PATH]/operate.py", line 1686, in _process_with_semaphore
lightrag  |     return await _process_single_content(chunk)
lightrag  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lightrag  |   File "[REDACTED_PATH]/operate.py", line 1595, in _process_single_content
lightrag  |     final_result = await use_llm_func_with_cache(
lightrag  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lightrag  |   File "[REDACTED_PATH]/utils.py", line 1473, in use_llm_func_with_cache
lightrag  |     res: str = await use_llm_func(safe_input_text, **kwargs)
lightrag  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lightrag  |   File "[REDACTED_PATH]/utils.py", line 602, in wait_func
lightrag  |     return await future
lightrag  |            ^^^^^^^^^^^^
lightrag  |   File "[REDACTED_PATH]/utils.py", line 386, in worker
lightrag  |     result = await func(*args, **kwargs)
lightrag  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
lightrag  |   File "[REDACTED_PATH]/api/lightrag_server.py", line 302, in azure_openai_model_complete
lightrag  |     openai_options = OpenAILLMOptions.options_dict(args)
lightrag  |                      ^^^^^^^^^^^^^^^^
lightrag  | NameError: cannot access free variable 'OpenAILLMOptions' where it is not associated with a value in enclosing scope
lightrag  | 
lightrag  | ERROR: Failed to extract document 1/1: unknown_source
lightrag  | INFO: Enqueued document processing pipeline stopped
```

The root causes seems to be that `OpenAILLMOptions` is only imported if the embedding or the llm is set to openai. 

## Related Issues
None

## Changes Made

I added the import statement `from lightrag.llm.binding_options import OpenAILLMOptions` also in the case where the embedding or the llm is azure_openai. 

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes
None
