### PR TITLE
docs(config): fix typo in .env comments

### DIFF
--- a/env.example
+++ b/env.example
@@ -121,7 +121,7 @@ RERANK_BINDING=null
 ########################################
 ENABLE_LLM_CACHE_FOR_EXTRACT=true
 
-### Document processing outpu language: English, Chinese, French, German ...
+### Document processing output language: English, Chinese, French, German ...
 SUMMARY_LANGUAGE=English
 
 ### Entity types that the LLM will attempt to recognize


### PR DESCRIPTION
<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

Fixed a typo in the config file comments by correcting `outpu` to `output`, ensuring semantic accuracy and professionalism in configuration descriptions.

## Related Issues

This fix is unrelated to any specific issue and falls under ​​code robustness maintenance​​ (non-functional defect correction).

## Changes Made

Modified file: [env.example#L124](https://github.com/HKUDS/LightRAG/blob/main/env.example#L124)

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

[Add any additional notes or context for the reviewer(s).]
