### PR TITLE
fix: adjust the EMBEDDING_BINDING_HOST for openai in the env.example

### DIFF
--- a/env.example
+++ b/env.example
@@ -219,7 +219,7 @@ EMBEDDING_BINDING_HOST=http://localhost:11434
 # EMBEDDING_BINDING=openai
 # EMBEDDING_MODEL=text-embedding-3-large
 # EMBEDDING_DIM=3072
-# EMBEDDING_BINDING_HOST=https://api.openai.com
+# EMBEDDING_BINDING_HOST=https://api.openai.com/v1
 # EMBEDDING_BINDING_API_KEY=your_api_key
 
 ### Optional for Azure


### PR DESCRIPTION
<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

I simply tried to uncomment the OPENAI for embedding and it was missing the `/v1` to the openai endpoint. It took me a few to fix that.

## Related Issues

[Reference any related issues or tasks addressed by this pull request.]

## Changes Made

Simply added the `/v1` to the EMBEDDING_BINDING_HOST in the env.example.

## Checklist

- [ ] Changes tested locally
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

[Add any additional notes or context for the reviewer(s).]
