### PR TITLE
Add `search` interface to lightrag for retrieval structured response

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -4,7 +4,6 @@ from functools import partial
 import asyncio
 import json
 import re
-import os
 import json_repair
 from typing import Any, AsyncIterator
 from collections import Counter, defaultdict

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -2814,6 +2814,7 @@ async def kg_search(
         knowledge_graph_inst,
         entities_vdb,
         relationships_vdb,
+        text_chunks_db,
         query_param,
         chunks_vdb,
     )
@@ -3118,6 +3119,7 @@ async def _build_query_context(
         knowledge_graph_inst,
         entities_vdb,
         relationships_vdb,
+        text_chunks_db,
         query_param,
         chunks_vdb,
     )


### PR DESCRIPTION
<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

I have seen a lot of questions about how to get structured response from `lightrag.aquery` although there is already an existed query param `only_need_context`. With `only_need_context=True`, `lightrag.aquery` return context in text. There are two drawbacks:
1. it is complex to parse context in text. It will be hard to keep campatible in the future.
2. some important fields are missing in context, for example, `chunk_id`, which is important for downstream applications to do more process.

I added a new interface in lightrag called `search`/`asearch`. It reuses the previous logic to get entities, relations and chunks, but return them before converting to context string.

## Related Issues

#1892 

## Changes Made

1. operate.py
Divide `_build_query_context` into 4 parts: 1. Search -> 2. Truncate -> 3. Merge chunks -> 4. Build LLM context
Then reuse the part 1 and part 3 to perform search.

```
async def _build_query_context(...):
    # Stage 1: Pure search
    search_result = await _perform_kg_search(
        query,
        ll_keywords,
        hl_keywords,
        knowledge_graph_inst,
        entities_vdb,
        relationships_vdb,
        text_chunks_db,
        query_param,
        chunks_vdb,
    )

    # Stage 2: Apply token truncation for LLM efficiency
    truncation_result = await _apply_token_truncation(
        search_result,
        query_param,
        text_chunks_db.global_config,
    )

    # Stage 3: Merge chunks using filtered entities/relations
    merged_chunks = await _merge_all_chunks(
        search_result,
        filtered_entities=truncation_result["filtered_entities"],
        filtered_relations=truncation_result["filtered_relations"],
        query=query,
        knowledge_graph_inst=knowledge_graph_inst,
        text_chunks_db=text_chunks_db,
        query_param=query_param,
        chunks_vdb=chunks_vdb,
        chunk_tracking=search_result["chunk_tracking"],
    )

    # Stage 4: Build final LLM context with dynamic token processing
    context = await _build_llm_context(
        entities_context=truncation_result["entities_context"],
        relations_context=truncation_result["relations_context"],
        merged_chunks=merged_chunks,
        query=query,
        query_param=query_param,
        global_config=text_chunks_db.global_config,
        chunk_tracking=search_result["chunk_tracking"],
    )

    return context
```

Add `kg_search` function. Similar to `kg_query`. And some other help functions.

2. lightrag.py

Add `asearch` and `search` interface to lightrag.

## Checklist

- [ x] Changes tested locally
- [ x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

Help needed to test on the changes. Thanks for everyone!
