### PR TITLE
fix: resolve dark mode text visibility issue in knowledge graph view

### DIFF
--- a/lightrag_webui/src/features/GraphViewer.tsx
+++ b/lightrag_webui/src/features/GraphViewer.tsx
@@ -23,12 +23,13 @@ import LegendButton from '@/components/graph/LegendButton'
 
 import { useSettingsStore } from '@/stores/settings'
 import { useGraphStore } from '@/stores/graph'
+import { labelColorDarkTheme } from '@/lib/constants'
 
 import '@react-sigma/core/lib/style.css'
 import '@react-sigma/graph-search/lib/style.css'
 
-// Sigma settings
-const defaultSigmaSettings: Partial<SigmaSettings> = {
+// Function to create sigma settings based on theme
+const createSigmaSettings = (isDarkTheme: boolean): Partial<SigmaSettings> => ({
   allowInvalidContainer: true,
   defaultNodeType: 'default',
   defaultEdgeType: 'curvedNoArrow',
@@ -47,18 +48,18 @@ const defaultSigmaSettings: Partial<SigmaSettings> = {
   labelRenderedSizeThreshold: 12,
   enableEdgeEvents: true,
   labelColor: {
-    color: '#000',
+    color: isDarkTheme ? labelColorDarkTheme : '#000',
     attribute: 'labelColor'
   },
   edgeLabelColor: {
-    color: '#000',
+    color: isDarkTheme ? labelColorDarkTheme : '#000',
     attribute: 'labelColor'
   },
   edgeLabelSize: 8,
   labelSize: 12
   // minEdgeThickness: 2
   // labelFont: 'Lato, sans-serif'
-}
+})
 
 const GraphEvents = () => {
   const registerEvents = useRegisterEvents()
@@ -107,7 +108,7 @@ const GraphEvents = () => {
 }
 
 const GraphViewer = () => {
-  const [sigmaSettings, setSigmaSettings] = useState(defaultSigmaSettings)
+  const [sigmaSettings, setSigmaSettings] = useState<Partial<SigmaSettings>>({})
   const sigmaRef = useRef<any>(null)
 
   const selectedNode = useGraphStore.use.selectedNode()
@@ -119,13 +120,15 @@ const GraphViewer = () => {
   const showNodeSearchBar = useSettingsStore.use.showNodeSearchBar()
   const enableNodeDrag = useSettingsStore.use.enableNodeDrag()
   const showLegend = useSettingsStore.use.showLegend()
+  const theme = useSettingsStore.use.theme()
 
-  // Initialize sigma settings once on component mount
-  // All dynamic settings will be updated in GraphControl using useSetSettings
+  // Initialize sigma settings based on theme
   useEffect(() => {
-    setSigmaSettings(defaultSigmaSettings)
-    console.log('Initialized sigma settings')
-  }, [])
+    const isDarkTheme = theme === 'dark'
+    const settings = createSigmaSettings(isDarkTheme)
+    setSigmaSettings(settings)
+    console.log('Initialized sigma settings for theme:', theme)
+  }, [theme])
 
   // Clean up sigma instance when component unmounts
   useEffect(() => {


### PR DESCRIPTION
## Description

This PR fixes a dark mode text visibility issue in the knowledge graph view where node and edge labels were rendered in hardcoded black color (#000), making them nearly invisible against the dark background.

## Related Issues

Fixes dark mode text visibility in knowledge graph visualization where labels were invisible due to hardcoded black text colors.

## Changes Made

- Replace hardcoded black text colors (#000) with dynamic theme-based colors
- Add createSigmaSettings function to generate settings based on theme
- Use labelColorDarkTheme (#B2EBF2) for dark mode and black (#000) for light mode
- Update GraphViewer component to react to theme changes
- Fixes issue where node and edge labels were invisible in dark mode

## Checklist

- [x] Changes tested locally
- [x] Code reviewed

## Additional Notes

The fix ensures that both node labels and edge labels properly adapt to the current theme:
- **Light mode**: Uses black text (#000) for good contrast against light background
- **Dark mode**: Uses light cyan text (#B2EBF2) for visibility against dark background
- **Dynamic switching**: Labels update automatically when theme changes

This improves the overall user experience in dark mode by making the knowledge graph labels readable and accessible.