### PR TITLE
Fix Retrieval Page Parameter Options: Enforce Mutual Exclusivity Between "Only Need Context" and "Only Need Prompt"

### DIFF
--- a/lightrag_webui/src/components/retrieval/QuerySettings.tsx
+++ b/lightrag_webui/src/components/retrieval/QuerySettings.tsx
@@ -419,7 +419,12 @@ export default function QuerySettings() {
                   className="mr-1 cursor-pointer"
                   id="only_need_context"
                   checked={querySettings.only_need_context}
-                  onCheckedChange={(checked) => handleChange('only_need_context', checked)}
+                  onCheckedChange={(checked) => { 
+                    handleChange('only_need_context', checked)
+                    if (checked) {
+                      handleChange('only_need_prompt', false)
+                    }
+                  }}
                 />
               </div>
 
@@ -440,7 +445,12 @@ export default function QuerySettings() {
                   className="mr-1 cursor-pointer"
                   id="only_need_prompt"
                   checked={querySettings.only_need_prompt}
-                  onCheckedChange={(checked) => handleChange('only_need_prompt', checked)}
+                  onCheckedChange={(checked) => {
+                    handleChange('only_need_prompt', checked)
+                    if (checked) {
+                      handleChange('only_need_context', false)
+                    }
+                  }}
                 />
               </div>
 


### PR DESCRIPTION
PR Description:
This PR fixes an issue in the Retrieval page where the "Only Need Context" and "Only Need Prompt" checkboxes could both be selected at the same time, leading to incorrect or confusing response behavior.

Changes Made
    •	Updated checkbox logic in QuerySettings:
             o Selecting "Only Need Context" automatically disables "Only Need Prompt".
             o Selecting "Only Need Prompt" automatically disables "Only Need Context".
   •	Removed redundant onCheckedChange handlers and consolidated into a single handler for each checkbox.
   •	Ensured consistent response behavior:
             o	Only Need Context → returns only the context.
             o	Only Need Prompt → returns prompt with context included, without separating context.

Impact
  •	Prevents conflicting selections on the Retrieval page.
  •	Simplifies user interaction with clear and predictable behavior.
  •	Fixes previously confusing responses when both checkboxes were active.

Checklist
  •	Changes tested locally
  •	Code reviewed
