### PR TITLE
Fix typo: "Oputput" -> output 

### DIFF
--- a/lightrag/prompt.py
+++ b/lightrag/prompt.py
@@ -75,7 +75,7 @@ Extract entities and relationships from the input text to be processed.
 1.  **Strict Adherence to Format:** Strictly adhere to all format requirements for entity and relationship lists, including output order, field delimiters, and proper noun handling, as specified in the system prompt.
 2.  **Output Content Only:** Output *only* the extracted list of entities and relationships. Do not include any introductory or concluding remarks, explanations, or additional text before or after the list.
 3.  **Completion Signal:** Output `{completion_delimiter}` as the final line after all relevant entities and relationships have been extracted and presented.
-4.  **Oputput Language:** Ensure the output language is {language}. Proper nouns (e.g., personal names, place names, organization names) must be kept in their original language and not translated.
+4.  **Output Language:** Ensure the output language is {language}. Proper nouns (e.g., personal names, place names, organization names) must be kept in their original language and not translated.
 
 <Output>
 """


### PR DESCRIPTION

## Description

Just a small typo fix. A single character :)
from Oputput to Output in prompt.

## Related Issues

None

## Changes Made

Fixed a typo in system prompt, specifically "Oputput" changed to "output"
***

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed

