### PR TITLE
Feat(webui): Prevent LaTeX Parsing Errors During Streaming

### DIFF
--- a/lightrag_webui/src/components/retrieval/ChatMessage.tsx
+++ b/lightrag_webui/src/components/retrieval/ChatMessage.tsx
@@ -27,6 +27,11 @@ export type MessageWithError = Message & {
    * Used to persist the rendering state across updates and prevent flickering.
    */
   mermaidRendered?: boolean
+  /**
+   * Indicates if the LaTeX formulas in this message are complete and ready for rendering.
+   * Used to prevent red error text during streaming of incomplete LaTeX formulas.
+   */
+  latexRendered?: boolean
 }
 
 // Restore original component definition and export
@@ -138,7 +143,7 @@ export const ChatMessage = ({ message }: { message: MessageWithError }) => { // 
                 remarkPlugins={[remarkGfm, remarkFootnotes, remarkMath]}
                 rehypePlugins={[
                   rehypeRaw,
-                  ...(katexPlugin ? [[katexPlugin, {
+                  ...((katexPlugin && (message.latexRendered ?? true)) ? [[katexPlugin, {
                     errorColor: theme === 'dark' ? '#ef4444' : '#dc2626',
                     throwOnError: false,
                     displayMode: false,
@@ -168,7 +173,7 @@ export const ChatMessage = ({ message }: { message: MessageWithError }) => { // 
             remarkPlugins={[remarkGfm, remarkFootnotes, remarkMath]}
             rehypePlugins={[
               rehypeRaw,
-              ...(katexPlugin ? [[
+              ...((katexPlugin && (message.latexRendered ?? true)) ? [[
                 katexPlugin,
                 {
                   errorColor: theme === 'dark' ? '#ef4444' : '#dc2626',


### PR DESCRIPTION
## Feat(webui): Prevent LaTeX Parsing Errors During Streaming

### Problem

LaTeX formulas displayed red error text during streaming due to KaTeX attempting to parse incomplete formulas, while Mermaid diagrams correctly showed black text during streaming. This created an inconsistent and confusing user experience.

### Root Cause

- **Mermaid**: Used `renderAsDiagram` flag to conditionally render as diagram vs. plain text
- **LaTeX**: Always applied KaTeX plugin, causing parsing errors on incomplete formulas during streaming

### Solution

Implemented LaTeX completeness detection following the same pattern as Mermaid diagrams:

#### 1. Added Conditional KaTeX Rendering

- Extended `MessageWithError` type with `latexRendered?: boolean` field
- Made KaTeX plugin application conditional: `(katexPlugin && (message.latexRendered ?? true))`

#### 2. LaTeX Completeness Detection

```typescript
const detectLatexCompleteness = (content: string): boolean => {
  // Check for unclosed block-level LaTeX formulas ($$...$$)
  const blockLatexMatches = content.match(/\$\$/g) || []
  const hasUnclosedBlock = blockLatexMatches.length % 2 !== 0
  
  // Check for unclosed inline LaTeX formulas ($...$, but not $$)
  const contentWithoutBlocks = content.replace(/\$\$[\s\S]*?\$\$/g, '')
  const inlineLatexMatches = contentWithoutBlocks.match(/(?<!\$)\$(?!\$)/g) || []
  const hasUnclosedInline = inlineLatexMatches.length % 2 !== 0
  
  return !hasUnclosedBlock && !hasUnclosedInline
}
```

#### 3. Streaming Integration

- Added LaTeX detection to message update flow
- Initialize new messages with `latexRendered: false`
- Historical messages default to `latexRendered: true` for backward compatibility

### Expected Behavior

- **During streaming**: Incomplete LaTeX formulas display as plain text (no red errors)
- **After completion**: Complete LaTeX formulas render properly with KaTeX
- **Syntax errors**: Still show red errors for genuinely invalid LaTeX (intentional UX)
- **Consistent**: Matches Mermaid diagram behavior exactly
