### PR TITLE
add the missed `MAX_GLEANING` env variable

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -273,6 +273,7 @@ if __name__ == "__main__":
 | **llm_model_name** | `str` | 用于生成的LLM模型名称 | `meta-llama/Llama-3.2-1B-Instruct` |
 | **summary_context_size** | `int` | 合并实体关系摘要时送给LLM的最大令牌数 | `10000`（由环境变量 SUMMARY_MAX_CONTEXT 设置） |
 | **summary_max_tokens** | `int` | 合并实体关系描述的最大令牌数长度 | `500`（由环境变量 SUMMARY_MAX_TOKENS 设置） |
+| **max_gleaning** | `int` | 是否进行额外的重复提取，以纠正之前错失的提取结果 | `1`（由环境变量 MAX_GLEANING 设置） |
 | **llm_model_max_async** | `int` | 最大并发异步LLM进程数 | `4`（默认值由环境变量MAX_ASYNC更改） |
 | **llm_model_kwargs** | `dict` | LLM生成的附加参数 | |
 | **vector_db_storage_cls_kwargs** | `dict` | 向量数据库的附加参数，如设置节点和关系检索的阈值 | cosine_better_than_threshold: 0.2（默认值由环境变量COSINE_THRESHOLD更改） |

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ A full list of LightRAG init parameters:
 | **llm_model_name** | `str` | LLM model name for generation | `meta-llama/Llama-3.2-1B-Instruct` |
 | **summary_context_size** | `int` | Maximum tokens send to LLM to generate summaries for entity relation merging | `10000`（configured by env var SUMMARY_CONTEXT_SIZE) |
 | **summary_max_tokens** | `int` | Maximum token size for entity/relation description | `500`（configured by env var SUMMARY_MAX_TOKENS) |
+| **max_gleaning** | `int` | Whether process additional gleaning results to extract missed or incorrectly formatted entities | `1`（configured by env var MAX_GLEANING） |
 | **llm_model_max_async** | `int` | Maximum number of concurrent asynchronous LLM processes | `4`（default value changed by env var MAX_ASYNC) |
 | **llm_model_kwargs** | `dict` | Additional parameters for LLM generation | |
 | **vector_db_storage_cls_kwargs** | `dict` | Additional parameters for vector database, like setting the threshold for nodes and relations retrieval | cosine_better_than_threshold: 0.2（default value changed by env var COSINE_THRESHOLD) |

--- a/env.example
+++ b/env.example
@@ -139,6 +139,8 @@ SUMMARY_LANGUAGE=English
 # SUMMARY_LENGTH_RECOMMENDED_=600
 ### Maximum context size sent to LLM for description summary
 # SUMMARY_CONTEXT_SIZE=12000
+# Whether process additional gleaning results to extract missed or incorrectly formatted entities
+# MAX_GLEANING=1
 
 ###############################
 ### Concurrency Configuration


### PR DESCRIPTION
## Description

the environment variable `MAX_GLEANING` that corresponds to the config parameter `entity_extract_max_gleaning` is missed in the .env.example template. 

## Related Issues


## Changes Made

add the environment variable `MAX_GLEANING` to .env.example and describe it in readme files.

## Checklist

- [ x ] Changes tested locally
- [ x ] Code reviewed
- [ x ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

This variable is important because the default value `1` informs lightRAG to do gleaning extraction which consumes much more tokens and time. It also leads lightRAG to `llm request timeout` problem easily since using a longer context with previous extraction history.
