### PR TITLE
Fix: Add file_path field to full_docs storage

### DIFF
--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -1750,6 +1750,7 @@ class PGKVStorage(BaseKVStorage):
                 _data = {
                     "id": k,
                     "content": v["content"],
+                    "doc_name": v.get("file_path", ""),  # Map file_path to doc_name
                     "workspace": self.workspace,
                 }
                 await self.db.execute(upsert_sql, _data)
@@ -4588,7 +4589,8 @@ TABLES = {
 
 SQL_TEMPLATES = {
     # SQL for KVStorage
-    "get_by_id_full_docs": """SELECT id, COALESCE(content, '') as content
+    "get_by_id_full_docs": """SELECT id, COALESCE(content, '') as content,
+                                COALESCE(doc_name, '') as file_path
                                 FROM LIGHTRAG_DOC_FULL WHERE workspace=$1 AND id=$2
                             """,
     "get_by_id_text_chunks": """SELECT id, tokens, COALESCE(content, '') as content,
@@ -4603,7 +4605,8 @@ SQL_TEMPLATES = {
                                 EXTRACT(EPOCH FROM update_time)::BIGINT as update_time
                                 FROM LIGHTRAG_LLM_CACHE WHERE workspace=$1 AND id=$2
                                """,
-    "get_by_ids_full_docs": """SELECT id, COALESCE(content, '') as content
+    "get_by_ids_full_docs": """SELECT id, COALESCE(content, '') as content,
+                                 COALESCE(doc_name, '') as file_path
                                  FROM LIGHTRAG_DOC_FULL WHERE workspace=$1 AND id IN ({ids})
                             """,
     "get_by_ids_text_chunks": """SELECT id, tokens, COALESCE(content, '') as content,
@@ -4639,10 +4642,12 @@ SQL_TEMPLATES = {
                                  FROM LIGHTRAG_FULL_RELATIONS WHERE workspace=$1 AND id IN ({ids})
                                 """,
     "filter_keys": "SELECT id FROM {table_name} WHERE workspace=$1 AND id IN ({ids})",
-    "upsert_doc_full": """INSERT INTO LIGHTRAG_DOC_FULL (id, content, workspace)
-                        VALUES ($1, $2, $3)
+    "upsert_doc_full": """INSERT INTO LIGHTRAG_DOC_FULL (id, content, doc_name, workspace)
+                        VALUES ($1, $2, $3, $4)
                         ON CONFLICT (workspace,id) DO UPDATE
-                           SET content = $2, update_time = CURRENT_TIMESTAMP
+                           SET content = $2,
+                               doc_name = $3,
+                               update_time = CURRENT_TIMESTAMP
                        """,
     "upsert_llm_response_cache": """INSERT INTO LIGHTRAG_LLM_CACHE(workspace,id,original_prompt,return_value,chunk_id,cache_type,queryparam)
                                       VALUES ($1, $2, $3, $4, $5, $6, $7)

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -961,7 +961,7 @@ class LightRAG:
                 doc_key = compute_mdhash_id(full_text, prefix="doc-")
             else:
                 doc_key = doc_id
-            new_docs = {doc_key: {"content": full_text}}
+            new_docs = {doc_key: {"content": full_text, "file_path": file_path}}
 
             _add_doc_keys = await self.full_docs.filter_keys({doc_key})
             new_docs = {k: v for k, v in new_docs.items() if k in _add_doc_keys}
@@ -1139,7 +1139,10 @@ class LightRAG:
         # 4. Store document content in full_docs and status in doc_status
         #    Store full document content separately
         full_docs_data = {
-            doc_id: {"content": contents[doc_id]["content"]}
+            doc_id: {
+                "content": contents[doc_id]["content"],
+                "file_path": contents[doc_id]["file_path"],
+            }
             for doc_id in new_docs.keys()
         }
         await self.full_docs.upsert(full_docs_data)


### PR DESCRIPTION
## Fix: Add `file_path` field to `full_docs` storage

## Summary

This PR adds a `file_path` field to the `full_docs` storage layer, enabling better document tracking and citation capabilities. The implementation ensures compatibility across all storage backends (JSON, Redis, MongoDB, PostgreSQL) with special handling for PostgreSQL's existing `doc_name` column.

Relalted Issue: #2167

## Changes Made

### 1. Core Pipeline (`lightrag/lightrag.py`)

**Modified `apipeline_enqueue_documents` function:**

```python
full_docs_data = {
    doc_id: {
        "content": contents[doc_id]["content"],
        "file_path": contents[doc_id]["file_path"]  # Added
    }
    for doc_id in new_docs.keys()
}
```

**Modified `ainsert_custom_chunks` function:**

```python
new_docs = {doc_key: {"content": full_text, "file_path": file_path}}
```

### 2. PostgreSQL Storage (`lightrag/kg/postgres_impl.py`)

**SQL Template Updates:**

- `upsert_doc_full`: Maps `file_path` → `doc_name` for INSERT/UPDATE operations
- `get_by_id_full_docs`: Returns `doc_name` as `file_path` for consistency
- `get_by_ids_full_docs`: Returns `doc_name` as `file_path` for batch operations

**PGKVStorage.upsert() method:**

```python
elif is_namespace(self.namespace, NameSpace.KV_STORE_FULL_DOCS):
    _data = {
        "id": k,
        "content": v["content"],
        "doc_name": v.get("file_path", ""),  # Field mapping
        "workspace": self.workspace,
    }
```

### 3. Other Storage Implementations

**No changes required for:**

- **JsonKVStorage**: JSON serialization automatically handles new fields
- **RedisKVStorage**: JSON serialization in Redis automatically stores new fields
- **MongoKVStorage**: Document-based storage automatically accommodates new fields

## Technical Details

### Field Mapping Strategy

PostgreSQL uses a **bidirectional mapping** approach:

- **Application → Database**: `file_path` → `doc_name`
- **Database → Application**: `doc_name` → `file_path`

This preserves the existing PostgreSQL schema while maintaining a consistent application-layer interface.

### Backward Compatibility

✅ **Fully backward compatible:**

- Existing documents without `file_path` will return empty string (`""`)
- PostgreSQL query uses `COALESCE(doc_name, '') as file_path` to handle NULL values
- No database migration required
- All storage backends gracefully handle missing fields

## Impact

- **Breaking Changes**: None
- **API Changes**: None (internal storage only)
- **Performance Impact**: Negligible (one additional field per document)
- **Database Schema**: No migration needed (uses existing PostgreSQL `doc_name` column)
