### PR TITLE
Fixed typo in log message when creating new graph file

### DIFF
--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -65,7 +65,7 @@ class NetworkXStorage(BaseGraphStorage):
             )
         else:
             logger.info(
-                f"[{self.workspace}] Created new empty graph fiel: {self._graphml_xml_file}"
+                f"[{self.workspace}] Created new empty graph file: {self._graphml_xml_file}"
             )
         self._graph = preloaded_graph or nx.Graph()
 


### PR DESCRIPTION
## Description

Fixed typo in log message when creating a new graph file.

## Changes Made

Before: `Created new empty graph fiel`
After: `Created new empty graph file`