### PR TITLE
feat: Add token tracking support to openai_embed function

### DIFF
--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -610,14 +610,14 @@ async def openai_embed(
         response = await openai_async_client.embeddings.create(
             model=model, input=texts, encoding_format="base64"
         )
-        
+
         if token_tracker and hasattr(response, "usage"):
             token_counts = {
                 "prompt_tokens": getattr(response.usage, "prompt_tokens", 0),
                 "total_tokens": getattr(response.usage, "total_tokens", 0),
             }
             token_tracker.add_usage(token_counts)
-        
+
         return np.array(
             [
                 np.array(dp.embedding, dtype=np.float32)


### PR DESCRIPTION
## Description

This PR adds optional token tracking support to the [openai_embed()](cci:1://file:///Users/yash/Developer/LightRAG/lightrag/llm/openai.py:565:0-627:9) function, enabling comprehensive monitoring of embedding token usage alongside existing LLM token tracking capabilities.

## Related Issues

N/A - Enhancement to improve observability of API token usage for embeddings.

## Changes Made

- Add optional `token_tracker` parameter to [openai_embed()](cci:1://file:///Users/yash/Developer/LightRAG/lightrag/llm/openai.py:565:0-627:9) function in [lightrag/llm/openai.py](cci:7://file:///Users/yash/Developer/LightRAG/lightrag/llm/openai.py:0:0-0:0)
- Track `prompt_tokens` and `total_tokens` for embedding API calls
- Update function docstring to document the new `token_tracker` parameter
- Enables monitoring of embedding token usage alongside LLM calls
- Maintains backward compatibility with existing code (parameter is optional)

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated

## Additional Notes

**Implementation Details:**
- Follows the same pattern used in [openai_complete_if_cache()](cci:1://file:///Users/yash/Developer/LightRAG/lightrag/llm/openai.py:95:0-471:45) for consistency
- Token tracking only occurs when `token_tracker` is provided and response contains usage data
- No breaking changes - existing code continues to work without modifications

**Usage Example:**
```python
from lightrag.utils import TokenTracker
from lightrag.llm.openai import openai_embed

token_tracker = TokenTracker()
embeddings = await openai_embed(
    texts=["example text"],
    token_tracker=token_tracker
)
print(token_tracker)  # Shows token usage statistics