### PR TITLE
docs: use Redoc in API tab instead of FastAPI docs for easier reading of endpoints

### DIFF
--- a/lightrag_webui/src/features/ApiSite.tsx
+++ b/lightrag_webui/src/features/ApiSite.tsx
@@ -21,16 +21,16 @@ export default function ApiSite() {
     <div className={`size-full ${isApiTabVisible ? '' : 'hidden'}`}>
       {iframeLoaded ? (
         <iframe
-          src={backendBaseUrl + '/docs'}
-          className="size-full w-full h-full"
+          src={backendBaseUrl + '/redoc'}
+          className="size-full h-full w-full"
           style={{ width: '100%', height: '100%', border: 'none' }}
           // Use key to ensure iframe doesn't reload
           key="api-docs-iframe"
         />
       ) : (
-        <div className="flex h-full w-full items-center justify-center bg-background">
+        <div className="bg-background flex h-full w-full items-center justify-center">
           <div className="text-center">
-            <div className="mb-2 h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
+            <div className="border-primary mb-2 h-8 w-8 animate-spin rounded-full border-4 border-t-transparent"></div>
             <p>{t('apiSite.loading')}</p>
           </div>
         </div>


### PR DESCRIPTION
… of endpoints

<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

This is only a suggestion, but I think it supplements LightRAG itself not having documentation, if a new user say this at first glance, it think it would be easier for them to get up and running.

### Example
<img width="1921" height="1081" alt="image" src="https://github.com/user-attachments/assets/2d4016a5-9322-4016-b6ee-32c678d438d3" />



## Checklist

- [x] Changes tested locally

## Additional Notes

[Add any additional notes or context for the reviewer(s).]
