### PR TITLE
remove deprecated dotenv package.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 dependencies = [
     "aiohttp",
     "configparser",
-    "dotenv",
     "future",
     "json_repair",
     "nano-vectordb",
@@ -45,7 +44,6 @@ api = [
     # Core dependencies
     "aiohttp",
     "configparser",
-    "dotenv",
     "future",
     "json_repair",
     "nano-vectordb",


### PR DESCRIPTION
## Description

Remove the deprecated/unnecessary dotenv package.
LightRAG already uses `python-dotenv`, so we can safely remove dotenv.

https://pypi.org/project/dotenv/

