### PR TITLE
Allow users to provide keywords with QueryRequest

### DIFF
--- a/lightrag/api/routers/query_routes.py
+++ b/lightrag/api/routers/query_routes.py
@@ -73,6 +73,16 @@ class QueryRequest(BaseModel):
         ge=1,
     )
 
+    hl_keywords: list[str] = Field(
+        default_factory=list,
+        description="List of high-level keywords to prioritize in retrieval. Leave empty to use the LLM to generate the keywords.",
+    )
+
+    ll_keywords: list[str] = Field(
+        default_factory=list,
+        description="List of low-level keywords to refine retrieval focus. Leave empty to use the LLM to generate the keywords.",
+    )
+
     conversation_history: Optional[List[Dict[str, Any]]] = Field(
         default=None,
         description="Stores past conversation history to maintain context. Format: [{'role': 'user/assistant', 'content': 'message'}].",
@@ -294,6 +304,16 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
         }
         ```
 
+        Bypass initial LLM call by providing high-level and low-level keywords:
+        ```json
+        {
+            "query": "What is Retrieval-Augmented-Generation?",
+            "hl_keywords": ["machine learning", "information retrieval", "natural language processing"],
+            "ll_keywords": ["retrieval augmented generation", "RAG", "knowledge base"],
+            "mode": "mix"
+        }
+        ```
+
         Advanced query with references:
         ```json
         {
@@ -479,6 +499,16 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
             "mode": "mix",
             "stream": true,
             "include_references": true
+        }
+        ```
+
+        Bypass initial LLM call by providing high-level and low-level keywords:
+        ```json
+        {
+            "query": "What is Retrieval-Augmented-Generation?",
+            "hl_keywords": ["machine learning", "information retrieval", "natural language processing"],
+            "ll_keywords": ["retrieval augmented generation", "RAG", "knowledge base"],
+            "mode": "mix"
         }
         ```
 
@@ -965,6 +995,16 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
             "query": "neural network architectures",
             "mode": "naive",
             "chunk_top_k": 5
+        }
+        ```
+
+        Bypass initial LLM call by providing high-level and low-level keywords:
+        ```json
+        {
+            "query": "What is Retrieval-Augmented-Generation?",
+            "hl_keywords": ["machine learning", "information retrieval", "natural language processing"],
+            "ll_keywords": ["retrieval augmented generation", "RAG", "knowledge base"],
+            "mode": "mix"
         }
         ```
 


### PR DESCRIPTION
<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

This change allows API users to provide their own high-level and low-level keywords to the `/query` endpoints. This prevents the server from having the LLM generate the keywords.

This change allows users to fetch data from LightRAG with 0 LLM calls (by providing `hl_keywords`, `ll_keywords`, and setting `only_need_prompt` or `only_need_context` to True).

## Related Issues

The PR implements feature request #2249

## Changes Made

- add `hl_keywords` and `ll_keywords` to the `QueryRequest` class
- added usage examples in the endpoint docstrings

## Checklist

- [X] Changes tested locally
- [x] Code reviewed
- [X] Documentation updated (if necessary)
- [X] Unit tests added (if applicable)
