### PR TITLE
Fix: Clean Residual Edges from VDB During Entity Deletion

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -3334,6 +3334,7 @@ class LightRAG:
                 if entities_to_delete:
                     try:
                         # Debug: Check and log all edges before deleting nodes
+                        edges_to_delete = set()
                         edges_still_exist = 0
                         for entity in entities_to_delete:
                             edges = (
@@ -3343,6 +3344,10 @@ class LightRAG:
                             )
                             if edges:
                                 for src, tgt in edges:
+                                    # Normalize edge representation (sorted for consistency)
+                                    edge_tuple = tuple(sorted((src, tgt)))
+                                    edges_to_delete.add(edge_tuple)
+
                                     if (
                                         src in entities_to_delete
                                         and tgt in entities_to_delete
@@ -3356,7 +3361,7 @@ class LightRAG:
                                         )
                                     else:
                                         logger.warning(
-                                            f"Edge still exists: {tgt} --> {src}"
+                                            f"Edge still exists: {src} <-- {tgt}"
                                         )
                                 edges_still_exist += 1
                         if edges_still_exist:
@@ -3364,7 +3369,32 @@ class LightRAG:
                                 f"⚠️ {edges_still_exist} entities still has edges before deletion"
                             )
 
-                        # Delete from graph
+                        # Clean residual edges from VDB and storage before deleting nodes
+                        if edges_to_delete:
+                            # Delete from relationships_vdb
+                            rel_ids_to_delete = []
+                            for src, tgt in edges_to_delete:
+                                rel_ids_to_delete.extend(
+                                    [
+                                        compute_mdhash_id(src + tgt, prefix="rel-"),
+                                        compute_mdhash_id(tgt + src, prefix="rel-"),
+                                    ]
+                                )
+                            await self.relationships_vdb.delete(rel_ids_to_delete)
+
+                            # Delete from relation_chunks storage
+                            if self.relation_chunks:
+                                relation_storage_keys = [
+                                    make_relation_chunk_key(src, tgt)
+                                    for src, tgt in edges_to_delete
+                                ]
+                                await self.relation_chunks.delete(relation_storage_keys)
+
+                            logger.info(
+                                f"Cleaned {len(edges_to_delete)} residual edges from VDB and chunk-tracking storage"
+                            )
+
+                        # Delete from graph (edges will be auto-deleted with nodes)
                         await self.chunk_entity_relation_graph.remove_nodes(
                             list(entities_to_delete)
                         )


### PR DESCRIPTION
## Fix: Clean Residual Edges from VDB During Entity Deletion

### 🐛 Problem

When deleting entities from the knowledge graph, the system was only removing nodes from the graph structure but not cleaning up associated edge data from, causing data inconsistencies between Graph DB and VDB.

- Vector database (`relationships_vdb`)
- Relation chunks storage (`relation_chunks`)

This resulted in orphaned edge is cause by manully editing entity name. 

### ✅ Solution

This PR adds comprehensive edge cleanup logic before node deletion:

1. **Edge Tracking**: Collect all edges connected to entities being deleted into a deduplicated set with normalized representation (sorted tuples for consistency)

2. **VDB Cleanup**: Delete edge vectors from `relationships_vdb` using computed relationship IDs for both directions (src→tgt and tgt→src)

3. **Storage Cleanup**: Remove relation chunk tracking data using `make_relation_chunk_key`

4. **Improved Logging**: 
   - Fixed edge direction in warning message (`{src} <-- {tgt}` instead of `{tgt} --> {src}`)
   - Added info log showing number of cleaned residual edges

### 📝 Changes

- **File**: `lightrag/lightrag.py`
- **Location**: Entity deletion logic in the cleanup process
- **Lines Modified**: ~30 lines added/modified

### 🧪 Testing

Tested with entity deletion scenarios to verify:

- All edge data is properly cleaned from VDB
- Relation chunk storage is correctly updated
- No orphaned data remains after deletion
- Log messages provide clear feedback
