### PR TITLE
Refact: Auto-refresh of Popular Labels When Pipeline Completes

### DIFF
--- a/lightrag_webui/src/components/ui/AsyncSelect.tsx
+++ b/lightrag_webui/src/components/ui/AsyncSelect.tsx
@@ -43,6 +43,8 @@ export interface AsyncSelectProps<T> {
   value: string
   /** Callback when selection changes */
   onChange: (value: string) => void
+  /** Callback before opening the dropdown (async supported) */
+  onBeforeOpen?: () => void | Promise<void>
   /** Accessibility label for the select field */
   ariaLabel?: string
   /** Placeholder text when no selection */
@@ -83,6 +85,7 @@ export function AsyncSelect<T>({
   searchPlaceholder,
   value,
   onChange,
+  onBeforeOpen,
   disabled = false,
   className,
   triggerClassName,
@@ -196,8 +199,18 @@ export function AsyncSelect<T>({
     [selectedValue, onChange, clearable, options, getOptionValue]
   )
 
+  const handleOpenChange = useCallback(
+    async (newOpen: boolean) => {
+      if (newOpen && onBeforeOpen) {
+        await onBeforeOpen()
+      }
+      setOpen(newOpen)
+    },
+    [onBeforeOpen]
+  )
+
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button
           variant="outline"


### PR DESCRIPTION
### Refact: Auto-refresh of Popular Labels When Pipeline Completes

#### Summary

This PR implements automatic refresh of popular labels in the graph viewer when the document processing pipeline transitions from busy to idle state. This ensures users always see the most up-to-date entity labels without manual intervention.

#### Problem Statement

Previously, after uploading and processing new documents, the popular labels dropdown would still show outdated labels until users manually refreshed. This created a disconnect between the newly processed knowledge graph and the available label suggestions.

#### Solution

Implemented pipeline state monitoring with automatic label refresh:

1. **Pipeline State Monitoring**: Added monitoring of `pipelineBusy` state using refs to detect transitions from busy → idle
2. **Smart Refresh Flag**: Introduced `shouldRefreshPopularLabelsRef` to mark when refresh is needed
3. **Multiple Trigger Points**: 
   - Auto-refresh when dropdown opens (if no specific label selected)
   - Auto-refresh during manual refresh operations
4. **AsyncSelect Enhancement**: Added `onBeforeOpen` callback support for async operations before dropdown opens

#### Technical Details

**GraphLabels.tsx Changes:**

- Added `useBackendState` hook to monitor pipeline status
- Implemented `reloadPopularLabels()` helper function
- Added `handleDropdownBeforeOpen()` callback for pre-open refresh
- Enhanced existing refresh logic to respect the refresh flag
- Proper error handling with fallback labels

**AsyncSelect.tsx Changes:**

- Added `onBeforeOpen?: () => void | Promise<void>` prop
- Implemented `handleOpenChange()` to trigger callback before opening
- Maintains backward compatibility (callback is optional)

#### Benefits

- ✅ Improved UX: Popular labels automatically update after document processing
- ✅ Reduced manual intervention: No need to manually refresh after uploads
- ✅ Consistent state: Dropdown always reflects current knowledge graph
- ✅ Error resilience: Fallback labels ensure dropdown always works
- ✅ Performance: Only refreshes when actually needed (flag-based)

#### Testing Suggestions

1. Upload a document and wait for processing to complete
2. Open the labels dropdown → should show new entities
3. Select a specific label and refresh → should work as before
4. Manually refresh with `*` label → should reload popular labels
