### PR TITLE
Fix empty context validation bug and improve naming consistency in query context building

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -3832,7 +3832,7 @@ async def _merge_all_chunks(
     return merged_chunks
 
 
-async def _build_llm_context(
+async def _build_context_str(
     entities_context: list[dict],
     relations_context: list[dict],
     merged_chunks: list[dict],
@@ -3932,23 +3932,32 @@ async def _build_llm_context(
         truncated_chunks
     )
 
-    # Rebuild text_units_context with truncated chunks
+    # Rebuild chunks_context with truncated chunks
     # The actual tokens may be slightly less than available_chunk_tokens due to deduplication logic
-    text_units_context = []
+    chunks_context = []
     for i, chunk in enumerate(truncated_chunks):
-        text_units_context.append(
+        chunks_context.append(
             {
                 "reference_id": chunk["reference_id"],
                 "content": chunk["content"],
             }
         )
 
+    text_units_str = "\n".join(
+        json.dumps(text_unit, ensure_ascii=False) for text_unit in chunks_context
+    )
+    reference_list_str = "\n".join(
+        f"[{ref['reference_id']}] {ref['file_path']}"
+        for ref in reference_list
+        if ref["reference_id"]
+    )
+
     logger.info(
-        f"Final context: {len(entities_context)} entities, {len(relations_context)} relations, {len(text_units_context)} chunks"
+        f"Final context: {len(entities_context)} entities, {len(relations_context)} relations, {len(chunks_context)} chunks"
     )
 
     # not necessary to use LLM to generate a response
-    if not entities_context and not relations_context:
+    if not entities_context and not relations_context and not chunks_context:
         # Return empty raw data structure when no entities/relations
         empty_raw_data = convert_to_user_format(
             [],
@@ -3979,15 +3988,6 @@ async def _build_llm_context(
         if chunk_tracking_log:
             logger.info(f"Final chunks S+F/O: {' '.join(chunk_tracking_log)}")
 
-    text_units_str = "\n".join(
-        json.dumps(text_unit, ensure_ascii=False) for text_unit in text_units_context
-    )
-    reference_list_str = "\n".join(
-        f"[{ref['reference_id']}] {ref['file_path']}"
-        for ref in reference_list
-        if ref["reference_id"]
-    )
-
     result = kg_context_template.format(
         entities_str=entities_str,
         relations_str=relations_str,
@@ -3997,7 +3997,7 @@ async def _build_llm_context(
 
     # Always return both context and complete data structure (unified approach)
     logger.debug(
-        f"[_build_llm_context] Converting to user format: {len(entities_context)} entities, {len(relations_context)} relations, {len(truncated_chunks)} chunks"
+        f"[_build_context_str] Converting to user format: {len(entities_context)} entities, {len(relations_context)} relations, {len(truncated_chunks)} chunks"
     )
     final_data = convert_to_user_format(
         entities_context,
@@ -4009,7 +4009,7 @@ async def _build_llm_context(
         relation_id_to_original,
     )
     logger.debug(
-        f"[_build_llm_context] Final data after conversion: {len(final_data.get('entities', []))} entities, {len(final_data.get('relationships', []))} relationships, {len(final_data.get('chunks', []))} chunks"
+        f"[_build_context_str] Final data after conversion: {len(final_data.get('entities', []))} entities, {len(final_data.get('relationships', []))} relationships, {len(final_data.get('chunks', []))} chunks"
     )
     return result, final_data
 
@@ -4086,8 +4086,8 @@ async def _build_query_context(
         return None
 
     # Stage 4: Build final LLM context with dynamic token processing
-    # _build_llm_context now always returns tuple[str, dict]
-    context, raw_data = await _build_llm_context(
+    # _build_context_str now always returns tuple[str, dict]
+    context, raw_data = await _build_context_str(
         entities_context=truncation_result["entities_context"],
         relations_context=truncation_result["relations_context"],
         merged_chunks=merged_chunks,
@@ -4860,10 +4860,10 @@ async def naive_query(
         "final_chunks_count": len(processed_chunks_with_ref_ids),
     }
 
-    # Build text_units_context from processed chunks with reference IDs
-    text_units_context = []
+    # Build chunks_context from processed chunks with reference IDs
+    chunks_context = []
     for i, chunk in enumerate(processed_chunks_with_ref_ids):
-        text_units_context.append(
+        chunks_context.append(
             {
                 "reference_id": chunk["reference_id"],
                 "content": chunk["content"],
@@ -4871,7 +4871,7 @@ async def naive_query(
         )
 
     text_units_str = "\n".join(
-        json.dumps(text_unit, ensure_ascii=False) for text_unit in text_units_context
+        json.dumps(text_unit, ensure_ascii=False) for text_unit in chunks_context
     )
     reference_list_str = "\n".join(
         f"[{ref['reference_id']}] {ref['file_path']}"


### PR DESCRIPTION
# Fix empty context validation bug and improve naming consistency in query context building

This change ensures that any valid context source (entities, relations, or chunks) can independently contribute to the query response, which is essential for multi-modal RAG operations.

* Related Issues: Fix #2293

## Problem Statement

The `_build_llm_context` function had a critical logic flaw in its empty context validation:

**Bug**: When only chunks were present (entities and relations empty), the function would incorrectly return an empty result, discarding valid chunk-based context. This affected scenarios like:

- Mix mode queries with only vector search results
- Naive mode operations where no knowledge graph data exists
- Edge cases where entity/relation extraction returned empty but chunks were retrieved

**Code Quality**: Inconsistent naming between `text_units_context` and the broader codebase terminology which uses "chunks" throughout.

## Changes Made

### 1. 🔴 Critical Bug Fix

**File**: `lightrag/operate.py`  
**Function**: `_build_context_str` (formerly `_build_llm_context`)  
**Line**: 3960

```python
# Before (Bug)
if not entities_context and not relations_context:
    return "", empty_raw_data

# After (Fixed)
if not entities_context and not relations_context and not chunks_context:
    return "", empty_raw_data
```

**Impact**: The validation now correctly checks all three context sources. The function only returns empty when ALL THREE are empty, not just when entities and relations are empty.

### 2. 📝 Function Rename

- `_build_llm_context` → `_build_context_str`
- Updated all 4 references throughout the codebase
- More descriptive name that accurately reflects the function's purpose

### 3. 🎯 Variable Naming Consistency

- `text_units_context` → `chunks_context`
- Aligns with project-wide terminology
- Affects two locations in the codebase (lines 3937-3950, 4863-4874)

### 4. 🔄 Code Organization

Improved logical flow by building `text_units_str` and `reference_list_str` immediately after creating `chunks_context`, grouping related operations together.

---

## Behavior Comparison

| Scenario        | Entities | Relations | Chunks | Before (Bug)       | After (Fixed)    |
| --------------- | -------- | --------- | ------ | ------------------ | ---------------- |
| Normal KG query | ✓        | ✓         | ✓      | ✅ Continue         | ✅ Continue       |
| Entity-only     | ✓        | ✗         | ✗      | ✅ Continue         | ✅ Continue       |
| Relation-only   | ✗        | ✓         | ✗      | ✅ Continue         | ✅ Continue       |
| **Chunks-only** | ✗        | ✗         | ✓      | ❌ **Empty return** | ✅ **Continue** ⭐ |
| All empty       | ✗        | ✗         | ✗      | ❌ Empty return     | ❌ Empty return   |

---

## Impact Assessment

### Affected Query Modes

- ✅ **Mix mode**: Now correctly processes vector-only results
- ✅ **Naive mode**: Continues to work correctly (already handled chunks-only)
- ✅ **Local/Global/Hybrid modes**: No impact (always have entities or relations)

### Breaking Changes

- ❌ None - This fix only corrects broken behavior

---

## Testing Recommendations

### Critical Test Cases

1. **Mix mode with empty KG results**
   - Query that returns chunks but no entities/relations
   - Expected: Valid context with chunks should be built

2. **Edge case: All empty**
   - Query with no results from any source
   - Expected: Empty result returned

3. **Existing modes**
   - Verify local, global, hybrid, naive modes still work
   - Expected: No regression

### Manual Verification

```python
# Test scenario: chunks-only context
entities_context = []
relations_context = []  
chunks_context = [{"content": "test chunk"}]

# Before fix: Would return ("", empty_raw_data)
# After fix: Should build valid context with chunks
```
