### PR TITLE
Feat: Add PDF Decryption Support for Password-Protected Files

### DIFF
--- a/env.example
+++ b/env.example
@@ -119,6 +119,9 @@ ENABLE_LLM_CACHE_FOR_EXTRACT=true
 ### Document processing output language: English, Chinese, French, German ...
 SUMMARY_LANGUAGE=English
 
+### PDF decryption password for protected PDF files
+# PDF_DECRYPT_PASSWORD=your_pdf_password_here
+
 ### Entity types that the LLM will attempt to recognize
 # ENTITY_TYPES='["Person", "Creature", "Organization", "Location", "Event", "Concept", "Method", "Content", "Data", "Artifact", "NaturalObject"]'
 

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -342,6 +342,9 @@ def parse_args() -> argparse.Namespace:
     # Select Document loading tool (DOCLING, DEFAULT)
     args.document_loading_engine = get_env_value("DOCUMENT_LOADING_ENGINE", "DEFAULT")
 
+    # PDF decryption password
+    args.pdf_decrypt_password = get_env_value("PDF_DECRYPT_PASSWORD", None)
+
     # Add environment variables that were previously read directly
     args.cors_origins = get_env_value("CORS_ORIGINS", "*")
     args.summary_language = get_env_value("SUMMARY_LANGUAGE", DEFAULT_SUMMARY_LANGUAGE)

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -1090,6 +1090,67 @@ async def pipeline_enqueue_file(
 
                             pdf_file = BytesIO(file)
                             reader = PdfReader(pdf_file)
+
+                            # Check if PDF is encrypted
+                            if reader.is_encrypted:
+                                pdf_password = global_args.pdf_decrypt_password
+                                if not pdf_password:
+                                    # PDF is encrypted but no password provided
+                                    error_files = [
+                                        {
+                                            "file_path": str(file_path.name),
+                                            "error_description": "[File Extraction]PDF is encrypted but no password provided",
+                                            "original_error": "Please set PDF_DECRYPT_PASSWORD environment variable to decrypt this PDF file",
+                                            "file_size": file_size,
+                                        }
+                                    ]
+                                    await rag.apipeline_enqueue_error_documents(
+                                        error_files, track_id
+                                    )
+                                    logger.error(
+                                        f"[File Extraction]PDF is encrypted but no password provided: {file_path.name}"
+                                    )
+                                    return False, track_id
+
+                                # Try to decrypt with password
+                                try:
+                                    decrypt_result = reader.decrypt(pdf_password)
+                                    if decrypt_result == 0:
+                                        # Password is incorrect
+                                        error_files = [
+                                            {
+                                                "file_path": str(file_path.name),
+                                                "error_description": "[File Extraction]Failed to decrypt PDF - incorrect password",
+                                                "original_error": "The provided PDF_DECRYPT_PASSWORD is incorrect for this file",
+                                                "file_size": file_size,
+                                            }
+                                        ]
+                                        await rag.apipeline_enqueue_error_documents(
+                                            error_files, track_id
+                                        )
+                                        logger.error(
+                                            f"[File Extraction]Incorrect PDF password: {file_path.name}"
+                                        )
+                                        return False, track_id
+                                except Exception as decrypt_error:
+                                    # Decryption process error
+                                    error_files = [
+                                        {
+                                            "file_path": str(file_path.name),
+                                            "error_description": "[File Extraction]PDF decryption failed",
+                                            "original_error": f"Error during PDF decryption: {str(decrypt_error)}",
+                                            "file_size": file_size,
+                                        }
+                                    ]
+                                    await rag.apipeline_enqueue_error_documents(
+                                        error_files, track_id
+                                    )
+                                    logger.error(
+                                        f"[File Extraction]PDF decryption error for {file_path.name}: {str(decrypt_error)}"
+                                    )
+                                    return False, track_id
+
+                            # Extract text from PDF (encrypted PDFs are now decrypted, unencrypted PDFs proceed directly)
                             for page in reader.pages:
                                 content += page.extract_text() + "\n"
                     except Exception as e:


### PR DESCRIPTION
# Feat: Add PDF Decryption Support for Password-Protected Files

## Summary

This PR adds support for processing password-protected PDF files in the document processing pipeline. Users can now decrypt and process encrypted PDFs by setting a password in the environment configuration.

## Motivation

Previously, the system would fail to process encrypted PDF files without any clear indication of what went wrong. This enhancement allows users to work with password-protected documents, which is common in enterprise and academic environments where sensitive documents are often encrypted.

## Changes Made

### 1. Configuration Management (`lightrag/api/config.py`)

- Added `pdf_decrypt_password` parameter to `global_args`
- Reads from `PDF_DECRYPT_PASSWORD` environment variable
- Defaults to `None` if not set

### 2. Document Processing (`lightrag/api/routers/document_routes.py`)

- Modified `pipeline_enqueue_file` function to detect encrypted PDFs
- Implemented decryption logic using PyPDF2's `decrypt()` method
- Added comprehensive error handling for three scenarios:
  - **No password provided**: Clear error message directing users to set `PDF_DECRYPT_PASSWORD`
  - **Incorrect password**: Friendly error indicating the password is wrong
  - **Decryption failure**: Detailed error with exception information

### 3. Documentation (`env.example`)

- Added `PDF_DECRYPT_PASSWORD` configuration example
- Included clear comments explaining the feature

## Usage

### Configuration

Add to your `.env` file:

```env
# PDF decryption password for protected PDF files
PDF_DECRYPT_PASSWORD=your_password_here
```

### Behavior

- **Unencrypted PDFs**: Process normally (no change in behavior)
- **Encrypted PDFs with password set**: Automatically decrypt and process
- **Encrypted PDFs without password**: Fail gracefully with helpful error message
- **Encrypted PDFs with wrong password**: Fail with clear indication of incorrect password

## Error Messages

All error messages are user-friendly and appear in English:

- `"PDF is encrypted but no password provided - Please set PDF_DECRYPT_PASSWORD environment variable"`
- `"Failed to decrypt PDF - incorrect password - The provided PDF_DECRYPT_PASSWORD is incorrect for this file"`
- `"PDF decryption failed - Error during PDF decryption: [details]"`

## Technical Notes

- Only affects PyPDF2 processing engine (DEFAULT mode)
- DOCLING mode is unchanged
- Password is accessed via `global_args.pdf_decrypt_password` for consistency with other configuration
- Backward compatible - no breaking changes for existing deployments

## Testing Recommendations

1. Test with unencrypted PDF - should work as before
2. Test with encrypted PDF without password set - should show friendly error
3. Test with encrypted PDF and correct password - should decrypt and process successfully
4. Test with encrypted PDF and incorrect password - should show password error

## Checklist

- [x] Code follows project style guidelines
- [x] Comments are in English
- [x] Environment variable documented in `env.example`
- [x] Error handling is comprehensive and user-friendly
- [x] Backward compatible with existing functionality
- [x] Configuration managed through `global_args` pattern
