### PR TITLE
Fix node retrieval fail with special characters in IDs for Postgres AGE GraphStorage

### DIFF
--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -3844,7 +3844,9 @@ class PGGraphStorage(BaseGraphStorage):
                     node_key = result["node_id"]
                     original_key = lookup.get(node_key)
                     if original_key is None:
-                        logger.warning(f"[{self.workspace}] Node {node_key} not found in lookup map")
+                        logger.warning(
+                            f"[{self.workspace}] Node {node_key} not found in lookup map"
+                        )
                         original_key = node_key
                     if original_key in requested:
                         nodes_dict[original_key] = node_dict
@@ -3935,7 +3937,9 @@ class PGGraphStorage(BaseGraphStorage):
                 node_key = node_id
                 original_key = lookup.get(node_key)
                 if original_key is None:
-                    logger.warning(f"[{self.workspace}] Node {node_key} not found in lookup map")
+                    logger.warning(
+                        f"[{self.workspace}] Node {node_key} not found in lookup map"
+                    )
                     original_key = node_key
                 if original_key in requested:
                     out_degrees[original_key] = int(row.get("out_degree", 0) or 0)


### PR DESCRIPTION
## Fix node retrieval fail with special characters in IDs for Postgres AGE GraphStorage

### Problem Statement

Nodes or edges with special characters (particularly **double quotes**) in their IDs were failing to be retrieved, causing the error.

**Root Cause:**  
Node ID normalization was happening too early in single-node query methods (`get_node`, `node_degree`, `get_edge`). When a node ID like `Node with "double quotes"` was normalized before being passed to batch operations, it created key mismatches during result lookup, leading to:

- ❌ Failed lookups for nodes with special characters (quotes, backslashes, etc.)
- ❌ "Failed to read node properties" errors
- ❌ Inconsistent behavior between direct queries and batch queries
- ❌ Potential data integrity issues in graph operations

### Solution

This PR refactors the normalization logic to ensure node IDs with special characters are correctly handled throughout the query pipeline:

**Key Changes:**

1. **Remove premature ID normalization**: Single-node methods now pass original IDs directly to batch operations
2. **Add bidirectional lookup mapping**: Batch methods maintain mapping between original and normalized IDs
   - `{original_id → original_id, normalized_id → original_id}`
3. **Filter results by requested nodes**: Only return data for explicitly requested node IDs
4. **Improve error logging**: Add workspace context for better debugging

**Technical Implementation:**

- `get_nodes_batch()` and `node_degrees_batch()` now handle normalization internally
- Results are consistently keyed by the caller's original request IDs (not normalized IDs)
- Added defensive checks with warnings when lookup keys are missing

**Example Fix:**

```python
# Before (❌ BROKEN):
node_id = 'Node with "double quotes"'
label = self._normalize_node_id(node_id)  # → 'Node with \\"double quotes\\"'
result = await self.get_nodes_batch([label])
return result[node_id]  # ❌ KeyError - looking for wrong key!

# After (✅ FIXED):
node_id = 'Node with "double quotes"'
result = await self.get_nodes_batch([node_id])  # Pass original ID
return result[node_id]  # ✅ Works - result keyed by original ID
```
