### PR TITLE
Fix performance bottleneck in document deletion

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -3333,15 +3333,16 @@ class LightRAG:
                 # 7. Delete entities that have no remaining sources
                 if entities_to_delete:
                     try:
+                        # Batch get all edges for entities to avoid N+1 query problem
+                        nodes_edges_dict = await self.chunk_entity_relation_graph.get_nodes_edges_batch(
+                            list(entities_to_delete)
+                        )
+
                         # Debug: Check and log all edges before deleting nodes
                         edges_to_delete = set()
                         edges_still_exist = 0
-                        for entity in entities_to_delete:
-                            edges = (
-                                await self.chunk_entity_relation_graph.get_node_edges(
-                                    entity
-                                )
-                            )
+
+                        for entity, edges in nodes_edges_dict.items():
                             if edges:
                                 for src, tgt in edges:
                                     # Normalize edge representation (sorted for consistency)
@@ -3364,6 +3365,7 @@ class LightRAG:
                                             f"Edge still exists: {src} <-- {tgt}"
                                         )
                                 edges_still_exist += 1
+
                         if edges_still_exist:
                             logger.warning(
                                 f"⚠️ {edges_still_exist} entities still has edges before deletion"


### PR DESCRIPTION
## Fix performance bottleneck in document deletion

### 🎯 Summary

**Optimize `adelete_by_doc_id` to fix N+1 query performance bottleneck in step 7 (Delete entities with no remaining sources)**

This PR resolves a critical performance issue in the document deletion process, particularly noticeable when using PostgreSQL storage. The optimization reduces database queries from O(N) to O(1) by using batch operations.

### 🐛 Problem

In `adelete_by_doc_id` function's step 7, the code was iterating through all entities to delete and calling `get_node_edges()` individually for each entity to check for residual edges:

```python
for entity in entities_to_delete:
    edges = await self.chunk_entity_relation_graph.get_node_edges(entity)
    # Process edges...
```

**Impact:**

- **N+1 Query Problem:** For N entities, this triggered N separate database queries
- **Severe Performance Degradation:** Each query required database round-trip, connection pool access, and Cypher query execution
- **PostgreSQL Especially Slow:** AGE (Apache AGE) graph queries are particularly expensive when executed repeatedly

**Example Scenario:**

- Deleting 100 entities = 100 separate database queries
- Each query ~10-50ms = 1-5 seconds total overhead
- For PostgreSQL users, deletion operations became prohibitively slow

### ✅ Solution

Replace the N individual queries with a single batch operation using the existing `get_nodes_edges_batch()` method:

```python
# Batch get all edges for entities to avoid N+1 query problem
nodes_edges_dict = await self.chunk_entity_relation_graph.get_nodes_edges_batch(
    list(entities_to_delete)
)

for entity, edges in nodes_edges_dict.items():
    # Process edges...
```

### 📊 Performance Impact

**Query Count:**

- **Before:** N queries (one per entity)
- **After:** 1-2 queries (with batching, default batch_size=500)

**Execution Time (estimated for 100 entities):**

- **Before:** 1-5 seconds (100 × 10-50ms)
- **After:** 20-100ms (1-2 batch queries)
- **Improvement:** **10-50x faster**

### ✨ Compatibility

This optimization works seamlessly with all Graph Storage implementations:

- ✅ **PostgreSQL (AGE)** - Primary beneficiary, massive speedup
- ✅ **Neo4j** - Also benefits from reduced query overhead
- ✅ **NetworkX** - In-memory operations, minimal overhead reduction
- ✅ **Memgraph** - Benefits from batch query optimization
