### PR TITLE
support async chunking func to improve processing performance when a heavy `chunking_func` is passed in by user

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from inspect import iscoroutinefunction
 import traceback
 import asyncio
 import configparser
@@ -1758,24 +1757,17 @@ class LightRAG:
                             content = content_data["content"]
 
                             # Generate chunks from document
-                            if iscoroutinefunction(self.chunking_func):
-                                chunks = await self.chunking_func(
-                                    self.tokenizer,
-                                    content,
-                                    split_by_character,
-                                    split_by_character_only,
-                                    self.chunk_overlap_token_size,
-                                    self.chunk_token_size,
-                                )
-                            else:
-                                chunks = self.chunking_func(
-                                    self.tokenizer,
-                                    content,
-                                    split_by_character,
-                                    split_by_character_only,
-                                    self.chunk_overlap_token_size,
-                                    self.chunk_token_size,
-                                )
+                            chunks = self.chunking_func(
+                                self.tokenizer,
+                                content,
+                                split_by_character,
+                                split_by_character_only,
+                                self.chunk_overlap_token_size,
+                                self.chunk_token_size,
+                            )
+                            # 判断chunks是否是异步异步函数的返回
+                            if asyncio.iscoroutine(chunks):
+                                chunks = await chunks
                             chunks: dict[str, Any] = {
                                 compute_mdhash_id(dp["content"], prefix="chunk-"): {
                                     **dp,


### PR DESCRIPTION
## Description

Current implementation call the `chunking_func` as synchronized function. If the `chunking_func` has heavy operations such as calling LLMs, the calling will block the main loop for a long time.

I add support of async implementation of `chunking_func` so that it will not block the main loop. If the `chunking_func` is a normal function, the code will run as before.

## Related Issues

-

## Changes Made

I simply add a condition check before calling `chunking_func`. If it is an async function, call await, else call as before.

lightrag.py:apipeline_process_enqueue_documents:1761

```
if iscoroutinefunction(self.chunking_func):
  chunks = await self.chunking_func(
      self.tokenizer,
      content,
      split_by_character,
      split_by_character_only,
      self.chunk_overlap_token_size,
      self.chunk_token_size,
  )
else:
  chunks = self.chunking_func(
      self.tokenizer,
      content,
      split_by_character,
      split_by_character_only,
      self.chunk_overlap_token_size,
      self.chunk_token_size,
  )
chunks: dict[str, Any] = {
  compute_mdhash_id(dp["content"], prefix="chunk-"): {
      **dp,
      "full_doc_id": doc_id,
      "file_path": file_path,  # Add file path to each chunk
      "llm_cache_list": [],  # Initialize empty LLM cache list for each chunk
  }
  for dp in chunks
}
```

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

[Add any additional notes or context for the reviewer(s).]
