### PR TITLE
Remove deprecated response_type parameter from query settings UI

### DIFF
--- a/lightrag/api/__init__.py
+++ b/lightrag/api/__init__.py
@@ -1,1 +1,1 @@
-__api_version__ = "0253"
+__api_version__ = "0254"

--- a/lightrag_webui/src/components/retrieval/QuerySettings.tsx
+++ b/lightrag_webui/src/components/retrieval/QuerySettings.tsx
@@ -40,7 +40,6 @@ export default function QuerySettings() {
   // Default values for reset functionality
   const defaultValues = useMemo(() => ({
     mode: 'mix' as QueryMode,
-    response_type: 'Multiple Paragraphs',
     top_k: 40,
     chunk_top_k: 20,
     max_entity_tokens: 6000,
@@ -149,46 +148,6 @@ export default function QuerySettings() {
                 <ResetButton
                   onClick={() => handleReset('mode')}
                   title="Reset to default (Mix)"
-                />
-              </div>
-            </>
-
-            {/* Response Format */}
-            <>
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <label htmlFor="response_format_select" className="ml-1 cursor-help">
-                      {t('retrievePanel.querySettings.responseFormat')}
-                    </label>
-                  </TooltipTrigger>
-                  <TooltipContent side="left">
-                    <p>{t('retrievePanel.querySettings.responseFormatTooltip')}</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-              <div className="flex items-center gap-1">
-                <Select
-                  value={querySettings.response_type}
-                  onValueChange={(v) => handleChange('response_type', v)}
-                >
-                  <SelectTrigger
-                    id="response_format_select"
-                    className="hover:bg-primary/5 h-9 cursor-pointer focus:ring-0 focus:ring-offset-0 focus:outline-0 active:right-0 flex-1 text-left [&>span]:break-all [&>span]:line-clamp-1"
-                  >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      <SelectItem value="Multiple Paragraphs">{t('retrievePanel.querySettings.responseFormatOptions.multipleParagraphs')}</SelectItem>
-                      <SelectItem value="Single Paragraph">{t('retrievePanel.querySettings.responseFormatOptions.singleParagraph')}</SelectItem>
-                      <SelectItem value="Bullet Points">{t('retrievePanel.querySettings.responseFormatOptions.bulletPoints')}</SelectItem>
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
-                <ResetButton
-                  onClick={() => handleReset('response_type')}
-                  title="Reset to default (Multiple Paragraphs)"
                 />
               </div>
             </>

--- a/lightrag_webui/src/features/RetrievalTesting.tsx
+++ b/lightrag_webui/src/features/RetrievalTesting.tsx
@@ -357,6 +357,7 @@ export default function RetrievalTesting() {
       const queryParams = {
         ...state.querySettings,
         query: actualQuery,
+        response_type: 'Multiple Paragraphs',
         conversation_history: effectiveHistoryTurns > 0
           ? prevMessages
             .filter((m) => m.isError !== true)

--- a/lightrag_webui/src/stores/settings.ts
+++ b/lightrag_webui/src/stores/settings.ts
@@ -123,7 +123,6 @@ const useSettingsStoreBase = create<SettingsState>()(
 
       querySettings: {
         mode: 'global',
-        response_type: 'Multiple Paragraphs',
         top_k: 40,
         chunk_top_k: 20,
         max_entity_tokens: 6000,
@@ -239,7 +238,7 @@ const useSettingsStoreBase = create<SettingsState>()(
     {
       name: 'settings-storage',
       storage: createJSONStorage(() => localStorage),
-      version: 18,
+      version: 19,
       migrate: (state: any, version: number) => {
         if (version < 2) {
           state.showEdgeLabel = false
@@ -335,6 +334,12 @@ const useSettingsStoreBase = create<SettingsState>()(
         if (version < 18) {
           // Add userPromptHistory field for older versions
           state.userPromptHistory = []
+        }
+        if (version < 19) {
+          // Remove deprecated response_type parameter
+          if (state.querySettings) {
+            delete state.querySettings.response_type
+          }
         }
         return state
       }


### PR DESCRIPTION
## Remove `response_type` Parameter from Query Settings UI

### Summary

The query parameter `response_type` is deprecated, as it can no longer effectively control the query output. Output behavior can now be guided through the `user_prompt`. In the future, full output customization will be achieved by modifying the prompt templates.

This PR removes the `response_type` parameter from the query settings interface and fixes it to "Multiple Paragraphs" for all queries. The parameter is no longer configurable by users through the UI.

### Changes Made

#### 1. **Frontend UI** (`lightrag_webui/src/components/retrieval/QuerySettings.tsx`)

- Removed the entire "Response Format" section including:
  - Select dropdown for choosing response format
  - Reset button for response_type
  - Tooltip and label components
- Removed `response_type` from `defaultValues` object

#### 2. **Query Execution** (`lightrag_webui/src/features/RetrievalTesting.tsx`)

- Hardcoded `response_type: 'Multiple Paragraphs'` in the `queryParams` object
- All queries now consistently use "Multiple Paragraphs" format regardless of stored settings

#### 3. **Settings Store** (`lightrag_webui/src/stores/settings.ts`)

- Removed `response_type: 'Multiple Paragraphs'` from initial `querySettings` state
- Incremented storage version from `18` to `19`
- Added migration for version 19 that automatically removes deprecated `response_type` from localStorage

### Migration Strategy

The implementation includes automatic migration for existing users:

- Users with `response_type` in localStorage will have it automatically removed on next app load
- Storage version bump ensures migration runs exactly once
- No manual intervention required from users

### Testing

- ✅ Frontend builds successfully with no compilation errors
- ✅ Linting passes with no warnings or errors
- ✅ All queries will use "Multiple Paragraphs" format consistently
- ✅ No breaking changes to the API (response_type remains optional in QueryRequest interface)

### Breaking Changes

**None** - This is a UI-only change. The backend API still accepts `response_type` as an optional parameter, ensuring backward compatibility with other clients.
