### PR TITLE
fix(postgres): Add CASCADE to AGE extension creation for automatic dependency resolution

### DIFF
--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -383,7 +383,7 @@ class PostgreSQLDB:
     async def configure_age_extension(connection: asyncpg.Connection) -> None:
         """Create AGE extension if it doesn't exist for graph operations."""
         try:
-            await connection.execute("CREATE EXTENSION IF NOT EXISTS age")  # type: ignore
+            await connection.execute("CREATE EXTENSION IF NOT EXISTS AGE CASCADE")  # type: ignore
             logger.info("PostgreSQL, AGE extension enabled")
         except Exception as e:
             logger.warning(f"Could not create AGE extension: {e}")


### PR DESCRIPTION
## fix(postgres): Add CASCADE to AGE extension creation for automatic dependency resolution

### Description

**Problem**

When initializing PostgreSQL graph storage, the AGE (Apache Graph Extension) creation could fail if any dependent extensions were not pre-installed on the PostgreSQL server. This resulted in the error:

```
asyncpg.exceptions.UndefinedFunctionError: function create_graph(unknown) does not exist
```

**Solution**

Added `CASCADE` keyword to the `CREATE EXTENSION` statement for Apache AGE. This ensures that any required dependent extensions are automatically installed when AGE is created.

**Changes**

- Modified `configure_age_extension()` in `lightrag/kg/postgres_impl.py`
- Changed from: `CREATE EXTENSION IF NOT EXISTS age`
- Changed to: `CREATE EXTENSION IF NOT EXISTS AGE CASCADE`

**Impact**

- Improves compatibility across different PostgreSQL deployments
- Reduces manual configuration requirements for users
- No breaking changes to existing functionality

### Testing

- Verified that AGE extension is created successfully with CASCADE option
- Confirmed backward compatibility with existing PostgreSQL deployments
