### PR TITLE
feat(core): implement safety check for embedding dimension mismatch

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -118,6 +118,7 @@ from dotenv import load_dotenv
 
 # use the .env that is inside the current folder
 # allows to use different .env file for each lightrag instance
+
 # the OS environment variables take precedence over the .env file
 load_dotenv(dotenv_path=".env", override=False)
 
@@ -535,6 +536,11 @@ class LightRAG:
             )
         self.embedding_token_limit = embedding_max_token_size
 
+        # Capture embedding model name before decoration so we don't lose it to wrappers
+        self.embedding_model_name = (
+            self.embedding_func.__class__.__name__ if self.embedding_func else "unknown"
+        )
+
         # --- CAPTURE EMBEDDING DIMENSION (NEW) ---
         self.embedding_dim = None
         if self.embedding_func and hasattr(self.embedding_func, "embedding_dim"):
@@ -698,11 +704,10 @@ class LightRAG:
             # First run: Save the metadata
             meta_data = {
                 "embedding_dim": self.embedding_dim,
-                "embedding_model_func": self.embedding_func.__class__.__name__
-                if self.embedding_func
-                else "unknown",
-                "created_at": str(os.path.abspath(self.working_dir)),
+                "embedding_model_func": self.embedding_model_name,
+                "created_at": datetime.now(timezone.utc).isoformat(),
             }
+
             # Ensure directory exists
             if not os.path.exists(self.working_dir):
                 os.makedirs(self.working_dir)


### PR DESCRIPTION
Currently, switching embedding models (e.g., from OpenAI to BGE-M3) without clearing the working_dir causes silent failures or dimension mismatch errors deep in the vector store logic.

This PR introduces a _check_embedding_config method that acts as a handshake protocol during initialization:

Persists Metadata: Saves a lightrag_meta.json file upon the first successful initialization.

Validates Configuration: Compares the currently configured embedding_dim against the persisted metadata on subsequent runs.

Prevents Corruption: Raises a clear, actionable ValueError if a mismatch is detected, halting execution before any write operations occur.

Architecture Logic

The following diagram illustrates the new initialization flow introduced in this PR:

```mermaid
graph TD
    A[Start: LightRAG Initialization] --> B{Metadata File Exists?}
    
    %% Path 1: First Run
    B -- No --> C[Create lightrag_meta.json]
    C --> D[Save Current Model Name & Dimension]
    D --> E[Proceed to Initialize Storage]

    %% Path 2: Subsequent Run
    B -- Yes --> F[Load Saved Metadata]
    F --> G{Compare Dimensions}
    
    %% Logic Branch
    G -- Match --> E
    G -- Mismatch --> H[Raise ValueError]
    H --> I[Stop Execution]
    
    style H fill:#f9f,stroke:#333,stroke-width:2px
    style I fill:#bbf,stroke:#333,stroke-width:2px
```
I created a reproduction script using mock embeddings to simulate a user switching models between runs.

Phase 1 (Initial Setup): System correctly initializes and saves metadata.

Phase 2 (The Crash Test): System correctly BLOCKS an invalid model switch (768 vs 1536) and raises the new error message.

Phase 3 (Regression Test): System correctly loads when the valid model is restored.

Test Logs:

--- PHASE 1: Initial Setup (Model A) ---
Initializing LightRAG with 'OpenAI_Mock' (Dimension: 1536)...
SUCCESS: 'lightrag_meta.json' created successfully.

--- PHASE 2: The Safety Check (Model B) ---
Attempting to re-initialize with 'BGE_Mock' (Dimension: 768)...
SUCCESS: The system caught the error.
Captured Error Message:
--> Embedding dimension mismatch! Existing data uses dimension 1536, but current configuration uses 768. Please clear the directory.

--- PHASE 3: Regression Test (Model A again) ---
Re-initializing with correct model (Dimension: 1536)...
SUCCESS: The system allowed the correct model to proceed.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Captures embedding model info/dimension, persists it to `lightrag_meta.json`, and validates on init to block runs with mismatched embedding dimensions.
> 
> - **Core initialization (LightRAG)**:
>   - Capture `embedding_model_name` and `embedding_dim` from `embedding_func` before wrapping.
>   - New `_check_embedding_config`:
>     - On first run, writes `working_dir/lightrag_meta.json` with `embedding_dim`, `embedding_model_func`, and timestamp.
>     - On subsequent runs, loads metadata and raises `ValueError` if current `embedding_dim` differs.
>     - Ensures `working_dir` exists before writing.
>   - Invoke `_check_embedding_config()` at start of `initialize_storages()` to prevent corrupting data when switching embedding models.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14b648e10f682150adb4c30b92165a046459b07c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->