### PR TITLE
feat(redis): add TTL support for Redis KV storage

### DIFF
--- a/env.example
+++ b/env.example
@@ -439,6 +439,7 @@ REDIS_SOCKET_TIMEOUT=30
 REDIS_CONNECT_TIMEOUT=10
 REDIS_MAX_CONNECTIONS=100
 REDIS_RETRY_ATTEMPTS=3
+REDIS_TTL=0
 ### DB specific workspace should not be set, keep for compatible only
 ### REDIS_WORKSPACE=forced_workspace_name
 


### PR DESCRIPTION
- Add REDIS_TTL environment variable (default: 0 = no expiration)
- Apply TTL to all set operations in RedisKVStorage and RedisDocStatusStorage
- TTL value is in seconds

## Description

Add configurable TTL (Time-To-Live) support for Redis storage implementations. This allows users to set an expiration time for cached data in Redis, which is useful for managing memory usage and ensuring stale data is automatically removed.

This is particularly useful for organizations that have internal data retention policies requiring cached data to expire after a specific period. By configuring the TTL, users can ensure compliance with their company's data governance requirements while also managing Redis memory usage more effectively.


## Changes Made

- Add `REDIS_TTL` environment variable to configure key expiration time (default: `0` = no expiration)
- Apply TTL to all `set` operations in `RedisKVStorage.upsert()` method
- Apply TTL to all `set` operations in `RedisDocStatusStorage.upsert()` method
- Apply TTL to cache migration operations in `RedisKVStorage._migrate_legacy_cache_structure()`
- TTL value is specified in seconds (e.g., `86400` for 24 hours, `604800` for 7 days)

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

### Usage

Set the `REDIS_TTL` environment variable to enable key expiration:

```bash
# No expiration (default)
export REDIS_TTL=0

# 24 hours
export REDIS_TTL=86400

# 7 days
export REDIS_TTL=604800
```

When `REDIS_TTL` is set to `0` (default), keys will never expire, maintaining backward compatibility with existing behavior.
