### PR TITLE
Hotfix: Fix missing __post_init__ calls in storage implementations

### DIFF
--- a/lightrag/kg/deprecated/chroma_impl.py
+++ b/lightrag/kg/deprecated/chroma_impl.py
@@ -21,6 +21,7 @@ class ChromaVectorDBStorage(BaseVectorStorage):
     """ChromaDB vector storage implementation."""
 
     def __post_init__(self):
+        super().__post_init__()
         try:
             config = self.global_config.get("vector_db_storage_cls_kwargs", {})
             cosine_threshold = config.get("cosine_better_than_threshold")

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -89,7 +89,8 @@ class MongoKVStorage(BaseKVStorage):
             global_config=global_config,
             embedding_func=embedding_func,
         )
-        # __post_init__() is automatically called by super().__init__()
+        # Explicitly call __post_init__ because dataclass doesn't do it when __init__ is overridden.
+        self.__post_init__()
 
     def __post_init__(self):
         # Check for MONGODB_WORKSPACE environment variable first (higher priority)
@@ -317,7 +318,8 @@ class MongoDocStatusStorage(DocStatusStorage):
             global_config=global_config,
             embedding_func=embedding_func,
         )
-        # __post_init__() is automatically called by super().__init__()
+        # Explicitly call __post_init__ because dataclass doesn't do it when __init__ is overridden.
+        self.__post_init__()
 
     def __post_init__(self):
         # Check for MONGODB_WORKSPACE environment variable first (higher priority)
@@ -2052,7 +2054,8 @@ class MongoVectorDBStorage(BaseVectorStorage):
             embedding_func=embedding_func,
             meta_fields=meta_fields or set(),
         )
-        # __post_init__() is automatically called by super().__init__()
+        # Explicitly call __post_init__ because dataclass doesn't do it when __init__ is overridden.
+        self.__post_init__()
 
     def __post_init__(self):
         # Call parent class __post_init__ to validate embedding_func

--- a/lightrag/kg/qdrant_impl.py
+++ b/lightrag/kg/qdrant_impl.py
@@ -124,7 +124,8 @@ class QdrantVectorDBStorage(BaseVectorStorage):
             embedding_func=embedding_func,
             meta_fields=meta_fields or set(),
         )
-        # __post_init__() is automatically called by super().__init__()
+        # Explicitly call __post_init__ because dataclass doesn't do it when __init__ is overridden.
+        self.__post_init__()
 
     @staticmethod
     def setup_collection(


### PR DESCRIPTION
### Fix missing __post_init__ calls in storage implementations

- Add super call in Chroma storage
- Call __post_init__ in Mongo classes
- Call __post_init__ in Qdrant storage
