### PR TITLE
Fix nested EmbeddingFunc wrapping and improve embedding function safety

### DIFF
--- a/lightrag/api/__init__.py
+++ b/lightrag/api/__init__.py
@@ -1,1 +1,1 @@
-__api_version__ = "0261"
+__api_version__ = "0262"


### PR DESCRIPTION
## Fix nested EmbeddingFunc wrapping and improve embedding function safety

---

## Summary

This PR addresses a critical issue where `EmbeddingFunc` wrappers could be nested multiple times, causing configuration conflicts where inner wrapper settings would override outer wrapper settings. The fix introduces automatic unwrapping detection and improved documentation for best practices.

---

## Key Changes

### 🔧 Core Fix (`lightrag/utils.py`)

- **Added `__post_init__` method to `EmbeddingFunc`** that automatically detects and unwraps nested `EmbeddingFunc` instances
- Implements safety limit (max depth of 3) to prevent infinite loops from circular references
- Emits warning log when auto-unwrapping occurs, guiding users to use `.func` directly
- Updated class docstring with comprehensive usage examples showing correct patterns

### 📝 Example Updates

Updated multiple demo files to use the correct pattern with `functools.partial`:

- `examples/lightrag_ollama_demo.py`
- `examples/lightrag_openai_compatible_demo.py`  
- `examples/lightrag_openai_mongodb_graph_demo.py`

**Before (problematic):**

```python
func=lambda texts: ollama_embed(texts, embed_model="bge-m3:latest", host="...")
```

**After (correct):**

```python
func=partial(ollama_embed.func, embed_model="bge-m3:latest", host="...")
```

### 📚 Documentation Updates (`README.md` & `README-zh.md`)

- Added examples for **Azure OpenAI** and **Google Gemini** model configurations
- Updated Hugging Face and LlamaIndex integration examples with correct patterns
- Improved code formatting and fixed minor typos
- Synced Chinese README with English version (major update)

---

## Why This Matters

When embedding functions decorated with `@wrap_embedding_func_with_attrs` (like `openai_embed`, `ollama_embed`) are passed directly to `EmbeddingFunc`, double wrapping occurs. This causes:

1. The inner wrapper's `embedding_dim`, `max_token_size`, and other settings override the outer wrapper's configuration
2. Unexpected behavior and hard-to-debug issues

The fix ensures that only the outermost `EmbeddingFunc` configuration is applied.
