### PR TITLE
Hot Fix AttributeError in Neo4JStorage and MemgraphStorage when using storage specified workspace env var

### DIFF
--- a/lightrag/kg/memgraph_impl.py
+++ b/lightrag/kg/memgraph_impl.py
@@ -36,10 +36,8 @@ class MemgraphStorage(BaseGraphStorage):
     def __init__(self, namespace, global_config, embedding_func, workspace=None):
         # Priority: 1) MEMGRAPH_WORKSPACE env 2) user arg 3) default 'base'
         memgraph_workspace = os.environ.get("MEMGRAPH_WORKSPACE")
+        original_workspace = workspace  # Save original value for logging
         if memgraph_workspace and memgraph_workspace.strip():
-            logger.info(
-                f"Using MEMGRAPH_WORKSPACE environment variable: '{memgraph_workspace}' (overriding '{self.workspace}/{self.namespace}')"
-            )
             workspace = memgraph_workspace
 
         if not workspace or not str(workspace).strip():
@@ -51,6 +49,13 @@ class MemgraphStorage(BaseGraphStorage):
             global_config=global_config,
             embedding_func=embedding_func,
         )
+
+        # Log after super().__init__() to ensure self.workspace is initialized
+        if memgraph_workspace and memgraph_workspace.strip():
+            logger.info(
+                f"Using MEMGRAPH_WORKSPACE environment variable: '{memgraph_workspace}' (overriding '{original_workspace}/{namespace}')"
+            )
+
         self._driver = None
 
     def _get_workspace_label(self) -> str:

--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -67,10 +67,8 @@ class Neo4JStorage(BaseGraphStorage):
     def __init__(self, namespace, global_config, embedding_func, workspace=None):
         # Read env and override the arg if present
         neo4j_workspace = os.environ.get("NEO4J_WORKSPACE")
+        original_workspace = workspace  # Save original value for logging
         if neo4j_workspace and neo4j_workspace.strip():
-            logger.info(
-                f"Using NEO4J_WORKSPACE environment variable: '{neo4j_workspace}' (overriding '{self.workspace}/{self.namespace}')"
-            )
             workspace = neo4j_workspace
 
         # Default to 'base' when both arg and env are empty
@@ -83,6 +81,13 @@ class Neo4JStorage(BaseGraphStorage):
             global_config=global_config,
             embedding_func=embedding_func,
         )
+
+        # Log after super().__init__() to ensure self.workspace is initialized
+        if neo4j_workspace and neo4j_workspace.strip():
+            logger.info(
+                f"Using NEO4J_WORKSPACE environment variable: '{neo4j_workspace}' (overriding '{original_workspace}/{namespace}')"
+            )
+
         self._driver = None
 
     def _get_workspace_label(self) -> str:


### PR DESCRIPTION
### Hot Fix AttributeError in Neo4JStorage and MemgraphStorage when using storage specified workspace env var

---

### Summary

This PR fixes a critical bug in `Neo4JStorage` and `MemgraphStorage` that causes an `AttributeError` when the `NEO4J_WORKSPACE` or `MEMGRAPH_WORKSPACE` environment variables are set.

### Problem

When initializing LightRAG with Neo4J or Memgraph graph storage and the workspace environment variable is set, the application crashes with:

```
AttributeError: 'Neo4JStorage' object has no attribute 'workspace'
```

or

```
AttributeError: 'MemgraphStorage' object has no attribute 'workspace'
```

### Root Cause

Both `Neo4JStorage` and `MemgraphStorage` use custom `__init__` methods that attempt to access `self.workspace` and `self.namespace` attributes **before** calling `super().__init__()`. Since these attributes are defined in the parent `BaseGraphStorage` dataclass and initialized by the parent's `__init__`, they don't exist until `super().__init__()` is called.

The problematic code pattern was:

```python
def __init__(self, namespace, global_config, embedding_func, workspace=None):
    neo4j_workspace = os.environ.get("NEO4J_WORKSPACE")
    if neo4j_workspace and neo4j_workspace.strip():
        logger.info(
            f"Using NEO4J_WORKSPACE environment variable: '{neo4j_workspace}' (overriding '{self.workspace}/{self.namespace}')"
            # ↑ BUG: self.workspace and self.namespace don't exist yet!
        )
        workspace = neo4j_workspace

    super().__init__(...)  # Attributes are initialized here
```

### Solution

Move the logging statement to **after** `super().__init__()` is called, and use parameter values instead of `self` attributes in the log message:

```python
def __init__(self, namespace, global_config, embedding_func, workspace=None):
    neo4j_workspace = os.environ.get("NEO4J_WORKSPACE")
    original_workspace = workspace  # Save original value for logging
    if neo4j_workspace and neo4j_workspace.strip():
        workspace = neo4j_workspace

    super().__init__(
        namespace=namespace,
        workspace=workspace,
        global_config=global_config,
        embedding_func=embedding_func,
    )
    
    # Log after super().__init__() to ensure self.workspace is initialized
    if neo4j_workspace and neo4j_workspace.strip():
        logger.info(
            f"Using NEO4J_WORKSPACE environment variable: '{neo4j_workspace}' (overriding '{original_workspace}/{namespace}')"
        )
```

### Changes

- **`lightrag/kg/neo4j_impl.py`**: Fixed `Neo4JStorage.__init__()` to access attributes only after parent initialization
- **`lightrag/kg/memgraph_impl.py`**: Fixed `MemgraphStorage.__init__()` to access attributes only after parent initialization

### Why Other Storage Implementations Are Not Affected

Other storage implementations (Redis, Milvus, PostgreSQL, MongoDB, Qdrant, etc.) use dataclass `__post_init__` methods instead of custom `__init__` methods. With `__post_init__`, the dataclass framework automatically initializes all fields (including `workspace` and `namespace`) **before** `__post_init__` is called, so there is no issue.

### Testing

1. Set `NEO4J_WORKSPACE` environment variable
2. Initialize LightRAG with Neo4J graph storage
3. Verify no `AttributeError` is raised
4. Confirm Neo4J storage initializes correctly with the specified workspace

### Breaking Changes

None. This is a pure bug fix with no API changes.

### Related Issues

Fixes the error:

```
ERROR: Failed to initialize LightRAG: 'Neo4JStorage' object has no attribute 'workspace'
```
