### PR TITLE
feat(gemini): Add Vertex AI support for Gemini LLM binding

### DIFF
--- a/env.example
+++ b/env.example
@@ -200,7 +200,7 @@ LLM_BINDING_API_KEY=your_api_key
 # LLM_BINDING_API_KEY=your_api_key
 # LLM_BINDING=openai
 
-### Gemini example
+### Google Gemini example (AI Studio)
 # LLM_BINDING=gemini
 # LLM_MODEL=gemini-flash-latest
 # LLM_BINDING_API_KEY=your_gemini_api_key
@@ -215,6 +215,19 @@ LLM_BINDING_API_KEY=your_api_key
 # GEMINI_LLM_THINKING_CONFIG='{"thinking_budget": -1, "include_thoughts": true}'
 ### Disable Thinking
 # GEMINI_LLM_THINKING_CONFIG='{"thinking_budget": 0, "include_thoughts": false}'
+
+### Google Vertex AI example
+### Vertex AI use GOOGLE_APPLICATION_CREDENTIALS instead of API-KEY for authentication
+### LLM_BINDING_HOST=DEFAULT_GEMINI_ENDPOINT means select endpoit based on project and location automatically
+# LLM_BINDING=gemini
+# LLM_BINDING_HOST=https://aiplatform.googleapis.com
+### or use DEFAULT_GEMINI_ENDPOINT to select endpoint based on project and location automatically
+# LLM_BINDING_HOST=DEFAULT_GEMINI_ENDPOINT
+# LLM_MODEL=gemini-2.5-flash
+# GOOGLE_GENAI_USE_VERTEXAI=true
+# GOOGLE_CLOUD_PROJECT='your-project-id'
+# GOOGLE_CLOUD_LOCATION='us-central1'
+# GOOGLE_APPLICATION_CREDENTIALS='/Users/xxxxx/your-service-account-credentials-file.json'
 
 ### use the following command to see all support options for OpenAI, azure_openai or OpenRouter
 ### lightrag-server --llm-binding openai --help


### PR DESCRIPTION
### feat(gemini): Add Vertex AI support for Gemini LLM binding

### Summary

This PR adds support for Google Cloud Vertex AI as an alternative authentication method for the Gemini LLM binding. Users can now choose between the standard Google AI Studio API (using API keys) and Vertex AI (using Google Cloud Application Default Credentials).

### Changes

**Modified file:** `lightrag/llm/gemini.py`

1. **`_get_gemini_client` function:**
   - Added detection for `GOOGLE_GENAI_USE_VERTEXAI` environment variable
   - In Vertex AI mode: initializes client with `vertexai=True`, `project`, and `location` parameters
   - In standard mode: uses `api_key` parameter as before
   - The two modes are mutually exclusive as per the google-genai SDK requirements
   - Fix baseUrl setting bugs: change option name from `api_endpoint` to `base_url`

2. **`_ensure_api_key` function:**
   - Added bypass for API key validation when in Vertex AI mode
   - Returns empty string in Vertex AI mode (since API key is not used)
   - Standard mode behavior remains unchanged

### Configuration

To enable Vertex AI mode, set the following environment variables:

```bash
### Google Vertex AI example (ydh.lily@gmail.com)
### Vertex AI use GOOGLE_APPLICATION_CREDENTIALS instead of API-KEY for API authentication
### LLM_BINDING_HOST=DEFAULT_GEMINI_ENDPOINT means select endpoit based on project and location automatically

LLM_BINDING=gemini
LLM_BINDING_HOST=https://aiplatform.googleapis.com
LLM_MODEL=gemini-3-flash-preview

GOOGLE_GENAI_USE_VERTEXAI=true
GOOGLE_CLOUD_PROJECT=your-project-id
GOOGLE_CLOUD_LOCATION=us-central1
GOOGLE_APPLICATION_CREDENTIALS='your-credential-file.json'
```

**Note:** Vertex AI uses Google Cloud Application Default Credentials (ADC) for authentication. Ensure you have configured `gcloud auth application-default login` or set up a service account.

### Backward Compatibility

- ✅ Fully backward compatible
- ✅ Existing configurations using `GEMINI_API_KEY` or `LLM_BINDING_API_KEY` continue to work
- ✅ `http_options` (base_url, timeout) remain compatible in both modes

### Testing

- Tested Vertex AI client initialization
- Verified API key and Vertex AI parameters are mutually exclusive
- Confirmed error handling for missing credentials
