### PR TITLE
Refact: Change DOCX extraction to use HTML tags for whitespace

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -1015,10 +1015,10 @@ def _extract_docx(file_bytes: bytes) -> str:
         # CRITICAL: Escape backslash first to avoid double-escaping
         return (
             text.replace("\\", "\\\\")  # Must be first: \ -> \\
-            .replace("\t", "\\t")  # Tab -> \t (visible)
-            .replace("\r\n", "\\n")  # Windows newline -> \n
-            .replace("\r", "\\n")  # Mac newline -> \n
-            .replace("\n", "\\n")  # Unix newline -> \n
+            .replace("\t", "&emsp;&emsp;")  # Tab -> \t (visible)
+            .replace("\r\n", "<br>")  # Windows newline -> \n
+            .replace("\r", "<br>")  # Mac newline -> \n
+            .replace("\n", "<br>")  # Unix newline -> \n
         )
 
     content_parts = []


### PR DESCRIPTION
## Refact: Change DOCX extraction to use HTML tags for whitespace

### Summary

This PR modifies the DOCX text extraction function to use HTML tags for representing whitespace instead of escaped string sequences. This change improves the visual representation of extracted document content when rendered in HTML contexts.

### Changes

- **File**: `lightrag/api/routers/document_routes.py`
- **Function**: `_extract_docx()`

#### Whitespace Conversion Updates:

| Before         | After                 | Purpose                                                      |
| -------------- | --------------------- | ------------------------------------------------------------ |
| `\t` → `\\t`   | `\t` → `&emsp;&emsp;` | Tabs rendered as HTML em spaces (double em space for visual tab width) |
| `\r\n` → `\\n` | `\r\n` → `<br>`       | Windows newlines rendered as HTML line breaks                |
| `\r` → `\\n`   | `\r` → `<br>`         | Mac (Classic) newlines rendered as HTML line breaks          |
| `\n` → `\\n`   | `\n` → `<br>`         | Unix newlines rendered as HTML line breaks                   |

### Motivation

The previous implementation escaped whitespace characters as literal string sequences (`\\t`, `\\n`), which displayed as raw text in HTML rendering contexts. The new approach uses proper HTML entities and tags:

- `&emsp;&emsp;` provides visual spacing equivalent to a tab character
- `<br>` creates proper line breaks when content is rendered in HTML

### Impact

- **Operational Impact**: DOCX document extraction will now produce HTML-compatible whitespace formatting
- **Backward Compatibility**: This affects how extracted text is formatted; consuming applications that expect escaped sequences may need adjustment
- **No API Changes**: The function signature and overall extraction logic remain unchanged

### Testing

- Verified DOCX extraction produces properly formatted HTML whitespace
- Line breaks and tabs render correctly in HTML display contexts
