### PR TITLE
Update PostgreSQL demo script reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -973,7 +973,7 @@ For production level scenarios you will most likely want to leverage an enterpri
 
 * PostgreSQL is lightweight,the whole binary distribution including all necessary plugins can be zipped to 40MB: Ref to [Windows Release](https://github.com/ShanGor/apache-age-windows/releases/tag/PG17%2Fv1.5.0-rc0) as it is easy to install for Linux/Mac.
 * If you prefer docker, please start with this image if you are a beginner to avoid hiccups (Default user password:rag/rag): https://hub.docker.com/r/gzdaniel/postgres-for-rag
-* How to start? Ref to: [examples/lightrag_zhipu_postgres_demo.py](https://github.com/HKUDS/LightRAG/blob/main/examples/lightrag_zhipu_postgres_demo.py)
+* How to start? Ref to: [examples/lightrag_gemini_postgres_demo.py](https://github.com/HKUDS/LightRAG/blob/main/examples/lightrag_gemini_postgres_demo.py)
 * For high-performance graph database requirements, Neo4j is recommended as Apache AGE's performance is not as competitive.
 
 </details>


### PR DESCRIPTION
### Description

This PR updates the `README.md` to reference the correct PostgreSQL + Gemini demo script.

The README previously pointed to an outdated or incorrect example. It now correctly links to:

* `examples/lightrag_gemini_postgres_demo.py`

This ensures users can easily find and run the intended demo when setting up LightRAG with **Gemini** and **PostgreSQL**.

### Changes

* Updated README.md to reference the correct PostgreSQL Gemini demo file
* No code logic changes; documentation-only update

### Motivation

Several users may follow the README as the primary entry point. Correcting this reference avoids confusion and improves the onboarding experience for users experimenting with PostgreSQL-backed LightRAG setups.

### Impact

* Improves documentation accuracy
* Reduces setup friction for new users
* No breaking changes
