### PR TITLE
Fix: Content Duplicate Detection for Document Upload Now Trackable

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -2080,13 +2080,41 @@ def create_document_routes(
         uploaded file is of a supported type, saves it in the specified input directory,
         indexes it for retrieval, and returns a success status with relevant details.
 
+        **Duplicate Detection Behavior:**
+
+        This endpoint handles two types of duplicate scenarios differently:
+
+        1. **Filename Duplicate (Synchronous Detection)**:
+           - Detected immediately before file processing
+           - Returns `status="duplicated"` with the existing document's track_id
+           - Two cases:
+             - If filename exists in document storage: returns existing track_id
+             - If filename exists in file system only: returns empty track_id ("")
+
+        2. **Content Duplicate (Asynchronous Detection)**:
+           - Detected during background processing after content extraction
+           - Returns `status="success"` with a new track_id immediately
+           - The duplicate is detected later when processing the file content
+           - Use `/documents/track_status/{track_id}` to check the final result:
+             - Document will have `status="FAILED"`
+             - `error_msg` contains "Content already exists. Original doc_id: xxx"
+             - `metadata.is_duplicate=true` with reference to original document
+             - `metadata.original_doc_id` points to the existing document
+             - `metadata.original_track_id` shows the original upload's track_id
+
+        **Why Different Behavior?**
+        - Filename check is fast (simple lookup), done synchronously
+        - Content extraction is expensive (PDF/DOCX parsing), done asynchronously
+        - This design prevents blocking the client during expensive operations
+
         Args:
             background_tasks: FastAPI BackgroundTasks for async processing
             file (UploadFile): The file to be uploaded. It must have an allowed extension.
 
         Returns:
             InsertResponse: A response object containing the upload status and a message.
-                status can be "success", "duplicated", or error is thrown.
+                - status="success": File accepted and queued for processing
+                - status="duplicated": Filename already exists (see track_id for existing document)
 
         Raises:
             HTTPException: If the file type is not supported (400) or other errors occur (500).

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1361,17 +1361,46 @@ class LightRAG:
         # Exclude IDs of documents that are already enqueued
         unique_new_doc_ids = await self.doc_status.filter_keys(all_new_doc_ids)
 
-        # Log ignored document IDs (documents that were filtered out because they already exist)
+        # Handle duplicate documents - create trackable records with current track_id
         ignored_ids = list(all_new_doc_ids - unique_new_doc_ids)
         if ignored_ids:
+            duplicate_docs: dict[str, Any] = {}
             for doc_id in ignored_ids:
                 file_path = new_docs.get(doc_id, {}).get("file_path", "unknown_source")
-                logger.warning(
-                    f"Ignoring document ID (already exists): {doc_id} ({file_path})"
+                logger.warning(f"Duplicate document detected: {doc_id} ({file_path})")
+
+                # Get existing document info for reference
+                existing_doc = await self.doc_status.get_by_id(doc_id)
+                existing_status = (
+                    existing_doc.get("status", "unknown") if existing_doc else "unknown"
                 )
-            if len(ignored_ids) > 3:
-                logger.warning(
-                    f"Total Ignoring {len(ignored_ids)} document IDs that already exist in storage"
+                existing_track_id = (
+                    existing_doc.get("track_id", "") if existing_doc else ""
+                )
+
+                # Create a new record with unique ID for this duplicate attempt
+                dup_record_id = compute_mdhash_id(f"{doc_id}-{track_id}", prefix="dup-")
+                duplicate_docs[dup_record_id] = {
+                    "status": DocStatus.FAILED,
+                    "content_summary": f"[DUPLICATE] Original document: {doc_id}",
+                    "content_length": new_docs.get(doc_id, {}).get("content_length", 0),
+                    "created_at": datetime.now(timezone.utc).isoformat(),
+                    "updated_at": datetime.now(timezone.utc).isoformat(),
+                    "file_path": file_path,
+                    "track_id": track_id,  # Use current track_id for tracking
+                    "error_msg": f"Content already exists. Original doc_id: {doc_id}, Status: {existing_status}",
+                    "metadata": {
+                        "is_duplicate": True,
+                        "original_doc_id": doc_id,
+                        "original_track_id": existing_track_id,
+                    },
+                }
+
+            # Store duplicate records in doc_status
+            if duplicate_docs:
+                await self.doc_status.upsert(duplicate_docs)
+                logger.info(
+                    f"Created {len(duplicate_docs)} duplicate document records with track_id: {track_id}"
                 )
 
         # Filter new_docs to only include documents with unique IDs


### PR DESCRIPTION
# Fix: Content Duplicate Detection for Document Upload Now Trackable

## 🔍 Problem

When uploading a document via `/documents/upload` with **same content but different filename**, the API returned:

- `status: "success"` with a new `track_id`
- But querying `/documents/track_status/{track_id}` returned **0 documents**

This made it impossible for clients to understand what happened to their uploaded file.

### Root Cause

- **Filename duplicate**: Detected synchronously before file processing → works correctly
- **Content duplicate**: Detected asynchronously during background processing → was silently ignored without creating any trackable record

## ✅ Solution

### Design Philosophy

Content extraction (PDF, DOCX, XLSX parsing) is expensive and should NOT block the upload endpoint. Instead of synchronous content checking, we create **trackable FAILED records** for duplicate content.

### Changes Made

#### 1. `lightrag/lightrag.py` - Core Fix

Added content duplicate handling in `apipeline_enqueue_documents()`:

- When duplicate content is detected, create a trackable record with:
  - `status="FAILED"`
  - `track_id` from the current upload operation
  - `error_msg` containing original document reference
  - `metadata.is_duplicate=true`
  - `metadata.original_doc_id` pointing to existing document
  - `metadata.original_track_id` for cross-reference

#### 2. `lightrag/api/routers/document_routes.py` - Documentation

Updated Swagger documentation for `/documents/upload` endpoint to clearly explain the two duplicate scenarios.

## 📖 Usage Scenarios

### Scenario 1: Filename Duplicate (Synchronous)

```
POST /documents/upload → paper.pdf
Response: {
  "status": "duplicated",
  "message": "File 'paper.pdf' already exists in document storage (Status: processed)",
  "track_id": "upload_20250115_120000_abc123"  // existing track_id
}
```

**Client Action**: Can immediately use the returned `track_id` to find the existing document.

### Scenario 2: Content Duplicate (Asynchronous)

```
POST /documents/upload → paper_v2.pdf (same content as paper.pdf)
Response: {
  "status": "success",
  "message": "File 'paper_v2.pdf' uploaded successfully...",
  "track_id": "upload_20250115_130000_xyz789"  // new track_id
}

GET /documents/track_status/upload_20250115_130000_xyz789
Response: {
  "track_id": "upload_20250115_130000_xyz789",
  "documents": [{
    "id": "dup-abc123def456",
    "status": "FAILED",
    "error_msg": "Content already exists. Original doc_id: doc-xxx, Status: processed",
    "metadata": {
      "is_duplicate": true,
      "original_doc_id": "doc-xxx",
      "original_track_id": "upload_20250115_120000_abc123"
    },
    "file_path": "paper_v2.pdf"
  }],
  "total_count": 1,
  "status_summary": {"FAILED": 1}
}
```

**Client Action**: 

1. Poll `/documents/track_status/{track_id}` to check processing result
2. When seeing `status="FAILED"` with `metadata.is_duplicate=true`, understand it's a duplicate
3. Use `metadata.original_doc_id` or `metadata.original_track_id` to find the original document

### Scenario 3: Normal Upload (No Duplicate)

```
POST /documents/upload → unique_paper.pdf
Response: {"status": "success", "track_id": "upload_xxx"}

GET /documents/track_status/upload_xxx
Response: {
  "documents": [{"status": "PROCESSED", ...}],
  "status_summary": {"PROCESSED": 1}
}
```

## 🔄 API Behavior Changes

| Scenario                             | Before                             | After                                                     |
| ------------------------------------ | ---------------------------------- | --------------------------------------------------------- |
| Filename duplicate                   | `status="duplicated"` ✅            | No change                                                 |
| Content duplicate                    | `status="success"`, track_id empty | `status="success"`, track_id trackable with FAILED record |
| `/documents/text` content duplicate  | N/A                                | Already implemented (synchronous check) ✅                 |
| `/documents/texts` content duplicate | N/A                                | Already implemented (synchronous check) ✅                 |

## 📁 Files Changed

- `lightrag/lightrag.py` - Added duplicate document tracking logic
- `lightrag/api/routers/document_routes.py` - Updated API documentation

## ⚠️ Breaking Changes

None. The API response format remains the same. Clients polling `track_status` will now receive meaningful results for content duplicates instead of empty responses.

## 🧪 Testing

Tested scenarios:

1. Upload file A → Success, PROCESSED
2. Upload file A again (same filename) → Immediately returns `duplicated`
3. Upload file B with same content as A → Returns `success`, track_status shows FAILED with duplicate metadata
4. POST `/documents/text` with duplicate content → Immediately returns `duplicated`
5. POST `/documents/texts` with duplicate content → Immediately returns `duplicated`
