### PR TITLE
feat: Add output_dimension support for Voyage AI embeddings

### DIFF
--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -825,7 +825,12 @@ async def openai_embed(
 
         # Add dimensions parameter only if embedding_dim is provided
         if embedding_dim is not None:
-            api_params["dimensions"] = embedding_dim
+            # Voyage AI requires 'output_dimension' via extra_body, not 'dimensions'
+            is_voyage_ai = base_url and "voyageai.com" in base_url
+            if is_voyage_ai:
+                api_params["extra_body"] = {"output_dimension": embedding_dim}
+            else:
+                api_params["dimensions"] = embedding_dim
 
         # Make API call
         response = await openai_async_client.embeddings.create(**api_params)


### PR DESCRIPTION
## Summary

This PR adds support for custom embedding dimensions when using Voyage AI's embedding models through the OpenAI-compatible API.

## Problem

LightRAG's OpenAI embedding binding passes the `dimensions` parameter directly to the API. However, Voyage AI's OpenAI-compatible endpoint requires the dimension parameter to be passed as `output_dimension` via the `extra_body` parameter.

Without this fix:
- `embedding_dim` is configured (e.g., 2048)
- Voyage AI ignores the `dimensions` parameter
- Voyage AI returns 1024-dimensional vectors (default)
- Dimension mismatch errors occur with vector stores

Related issues: #2233, #2230, #2119

## Solution

Detect Voyage AI by checking if `base_url` contains "voyageai.com" and route the dimension parameter appropriately:
- For Voyage AI: pass `output_dimension` via `extra_body` parameter
- For OpenAI and others: pass `dimensions` directly (existing behavior)

## Changes

### `lightrag/llm/openai.py`

```python
# Add dimensions parameter only if embedding_dim is provided
if embedding_dim is not None:
    # Voyage AI requires 'output_dimension' via extra_body, not 'dimensions'
    is_voyage_ai = base_url and "voyageai.com" in base_url
    if is_voyage_ai:
        api_params["extra_body"] = {"output_dimension": embedding_dim}
    else:
        api_params["dimensions"] = embedding_dim
```

## Testing

Tested with:
- Voyage AI `voyage-3-large` model
- `embedding_dim=2048`
- Qdrant vector store

Verified embeddings are correctly 2048-dimensional.

## Backwards Compatibility

- No breaking changes
- Existing OpenAI configurations work unchanged
- Only affects Voyage AI when `embedding_dim` is explicitly set