### PR TITLE
Fix/anthropic api compatibility

### DIFF
--- a/lightrag/llm/anthropic.py
+++ b/lightrag/llm/anthropic.py
@@ -100,8 +100,6 @@ async def anthropic_complete_if_cache(
     )
 
     messages: list[dict[str, Any]] = []
-    if system_prompt:
-        messages.append({"role": "system", "content": system_prompt})
     messages.extend(history_messages)
     messages.append({"role": "user", "content": prompt})
 
@@ -112,9 +110,16 @@ async def anthropic_complete_if_cache(
     verbose_debug(f"System prompt: {system_prompt}")
 
     try:
-        response = await anthropic_async_client.messages.create(
-            model=model, messages=messages, stream=True, **kwargs
-        )
+        create_params = {
+            'model': model,
+            'messages': messages,
+            'stream': True,
+            **kwargs
+        }
+        if system_prompt:
+            create_params['system'] = system_prompt
+        response = await anthropic_async_client.messages.create(**create_params)
+
     except APIConnectionError as e:
         logger.error(f"Anthropic API Connection Error: {e}")
         raise


### PR DESCRIPTION
## Description

Fixes Anthropic Claude API compatibility issues in the anthropic.py LLM adapter.

  This PR addresses two bugs that prevent proper usage of Anthropic Claude models:
  1. System prompt handling - Anthropic API requires system prompts as top-level parameter, not in messages array
  2. Streaming response Delta attribute checking - prevents AttributeError on events without text attribute

## Changes Made

 1. **System prompt parameter fix** (lines 103-126):
     - Removed code that adds system prompt to messages array with "system" role
     - Added logic to pass system prompt as top-level `system` parameter to `messages.create()`
     - Anthropic API only accepts "user" and "assistant" roles in messages array
     - Fixes: `Error code: 400 - messages: Unexpected role "system"`

  2. **Delta attribute checking fix** (line 138):
     - Added `hasattr(event.delta, "text")` check before accessing `event.delta.text`
     - Not all streaming event types have a `text` attribute on their delta object
     - Fixes: `AttributeError: 'Delta' object has no attribute 'text'`

## Checklist

- [X] Changes tested locally
- [X ] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

  **Testing performed:**
  - Tested with `claude-sonnet-4-5-20250929` model
  - Verified entity extraction and knowledge graph construction work correctly
  - Confirmed streaming responses are properly consumed
  - Tested with both empty and non-empty system prompts

  **API Documentation Reference:**
  - Anthropic Messages API: https://docs.anthropic.com/en/api/messages
  - System parameter documentation: https://docs.anthropic.com/en/api/messages#system

  **Breaking Changes:** None - this is a bug fix that makes the adapter work as intended.

  **Compatibility:** Compatible with all current Anthropic Claude models (Claude 3, Claude 3.5, Claude Opus 4.5, etc.)
