### PR TITLE
Fix: Add MAX_EXTRACT_INPUT_TOKENS to prevent gleaning context overflow (#2472)

### DIFF
--- a/env.example
+++ b/env.example
@@ -159,6 +159,8 @@ SUMMARY_LANGUAGE=English
 # SUMMARY_LENGTH_RECOMMENDED_=600
 ### Maximum context size sent to LLM for description summary
 # SUMMARY_CONTEXT_SIZE=12000
+### Maximum token size allowed for entity extraction input context
+# MAX_EXTRACT_INPUT_TOKENS=20480
 
 ### control the maximum chunk_ids stored in vector and graph db
 # MAX_SOURCE_IDS_PER_ENTITY=300

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -23,6 +23,8 @@ DEFAULT_SUMMARY_MAX_TOKENS = 1200
 DEFAULT_SUMMARY_LENGTH_RECOMMENDED = 600
 # Maximum token size sent to LLM for summary
 DEFAULT_SUMMARY_CONTEXT_SIZE = 12000
+# Maximum token size allowed for entity extraction input context
+DEFAULT_MAX_EXTRACT_INPUT_TOKENS = 20480
 # Default entities to extract if ENTITY_TYPES is not specified in .env
 DEFAULT_ENTITY_TYPES = [
     "Person",

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -41,6 +41,7 @@ from lightrag.constants import (
     DEFAULT_SUMMARY_MAX_TOKENS,
     DEFAULT_SUMMARY_CONTEXT_SIZE,
     DEFAULT_SUMMARY_LENGTH_RECOMMENDED,
+    DEFAULT_MAX_EXTRACT_INPUT_TOKENS,
     DEFAULT_MAX_ASYNC,
     DEFAULT_MAX_PARALLEL_INSERT,
     DEFAULT_MAX_GRAPH_NODES,
@@ -210,6 +211,13 @@ class LightRAG:
         default=get_env_value("MAX_GLEANING", DEFAULT_MAX_GLEANING, int)
     )
     """Maximum number of entity extraction attempts for ambiguous content."""
+
+    max_extract_input_tokens: int = field(
+        default=get_env_value(
+            "MAX_EXTRACT_INPUT_TOKENS", DEFAULT_MAX_EXTRACT_INPUT_TOKENS, int
+        )
+    )
+    """Maximum tokens allowed for entity extraction input context."""
 
     force_llm_summary_on_merge: int = field(
         default=get_env_value(

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -8,8 +8,6 @@ import json_repair
 from typing import Any, AsyncIterator, overload, Literal
 from collections import Counter, defaultdict
 
-import os
-
 from lightrag.exceptions import (
     PipelineCancelledException,
     ChunkTokenLimitExceededError,
@@ -2874,7 +2872,7 @@ async def extract_entities(
         if entity_extract_max_gleaning > 0:
             # Calculate total tokens for the gleaning request to prevent context window overflow
             tokenizer = global_config["tokenizer"]
-            max_input_tokens = int(os.environ.get("MAX_EXTRACT_INPUT_TOKENS", 20480))
+            max_input_tokens = global_config["max_extract_input_tokens"]
 
             # Estimate total tokens: System Prompt + History (Previous Round) + Current User Prompt
             history_str = json.dumps(history, ensure_ascii=False)


### PR DESCRIPTION
## Description

This PR addresses issue #2472.

During the "Process additional gleaning results" stage, if the content returned by the LLM in the first extraction is too large, the combined history and prompt for the second extraction (gleaning) might exceed the LLM's context window limit, causing the pipeline to crash.

This PR introduces a check mechanism to skip the gleaning step if the estimated input token count exceeds a configurable limit.

## Related Issues

Fixes #2472

## Changes Made

- **`lightrag/operate.py`**:
    - Imported `os` module (fixed `NameError` issue).
    - Added logic to retrieve `MAX_EXTRACT_INPUT_TOKENS` from environment variables (default: 20480).
    - Implemented a pre-check before the gleaning loop: calculates the total tokens of `system_prompt + history + user_prompt`.
    - If the token count exceeds the limit, it logs a warning and skips the gleaning process to ensure pipeline stability.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

I have verified the fix locally with two scenarios:
1. **Trigger Warning**: Set `MAX_EXTRACT_INPUT_TOKENS=50`, confirmed that gleaning was skipped with a warning log.
2. **Normal Flow**: Set default limit, confirmed that standard extraction works without issues.