### PR TITLE
feat: Add custom entity types support for document processing(upload/scan/retry per request)

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -1287,6 +1287,7 @@ def create_app(args):
                     "max_async": args.max_async,
                     "embedding_func_max_async": args.embedding_func_max_async,
                     "embedding_batch_num": args.embedding_batch_num,
+                    "entity_types": args.entity_types,
                 },
                 "auth_mode": auth_mode,
                 "pipeline_busy": pipeline_status.get("busy", False),

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -738,6 +738,8 @@ class DocProcessingStatus:
     """Error message if failed"""
     metadata: dict[str, Any] = field(default_factory=dict)
     """Additional metadata"""
+    entity_types: list[str] | None = None
+    """Custom entity types for extraction (optional, overrides default configuration)"""
     multimodal_processed: bool | None = field(default=None, repr=False)
     """Internal field: indicates if multimodal processing is complete. Not shown in repr() but accessible for debugging."""
 

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1260,6 +1260,7 @@ class LightRAG:
         ids: list[str] | None = None,
         file_paths: str | list[str] | None = None,
         track_id: str | None = None,
+        entity_types: list[str] | None = None,
     ) -> str:
         """
         Pipeline for Processing Documents
@@ -1274,6 +1275,7 @@ class LightRAG:
             ids: list of unique document IDs, if not provided, MD5 hash IDs will be generated
             file_paths: list of file paths corresponding to each document, used for citation
             track_id: tracking ID for monitoring processing status, if not provided, will be generated with "enqueue" prefix
+            entity_types: custom entity types for extraction, if not provided, will use default configuration
 
         Returns:
             str: tracking ID for monitoring processing status
@@ -1351,6 +1353,7 @@ class LightRAG:
                     "file_path"
                 ],  # Store file path in document status
                 "track_id": track_id,  # Store track_id in document status
+                "entity_types": entity_types,  # Store custom entity types if provided
             }
             for id_, content_data in contents.items()
         }
@@ -1386,6 +1389,7 @@ class LightRAG:
                     "content_length": new_docs.get(doc_id, {}).get("content_length", 0),
                     "created_at": datetime.now(timezone.utc).isoformat(),
                     "updated_at": datetime.now(timezone.utc).isoformat(),
+                    "entity_types": entity_types,
                     "file_path": file_path,
                     "track_id": track_id,  # Use current track_id for tracking
                     "error_msg": f"Content already exists. Original doc_id: {doc_id}, Status: {existing_status}",
@@ -1608,6 +1612,7 @@ class LightRAG:
                         "content_length": status_doc.content_length,
                         "created_at": status_doc.created_at,
                         "updated_at": datetime.now(timezone.utc).isoformat(),
+                        "entity_types": getattr(status_doc, "entity_types", None),
                         "file_path": getattr(status_doc, "file_path", "unknown_source"),
                         "track_id": getattr(status_doc, "track_id", ""),
                         # Clear any error messages and processing metadata
@@ -1635,6 +1640,7 @@ class LightRAG:
         self,
         split_by_character: str | None = None,
         split_by_character_only: bool = False,
+        entity_types: list[str] = None
     ) -> None:
         """
         Process pending documents by splitting them into chunks, processing
@@ -1670,7 +1676,10 @@ class LightRAG:
                 to_process_docs.update(processing_docs)
                 to_process_docs.update(failed_docs)
                 to_process_docs.update(pending_docs)
-
+                if entity_types:
+                    for processing_key in to_process_docs.keys():
+                        if getattr(to_process_docs[processing_key], "entity_types", None) != entity_types:
+                            to_process_docs[processing_key].entity_types = entity_types
                 if not to_process_docs:
                     logger.info("No documents to process")
                     return
@@ -1896,6 +1905,7 @@ class LightRAG:
                                             "updated_at": datetime.now(
                                                 timezone.utc
                                             ).isoformat(),
+                                            "entity_types": status_doc.entity_types,
                                             "file_path": file_path,
                                             "track_id": status_doc.track_id,  # Preserve existing track_id
                                             "metadata": {
@@ -1924,9 +1934,11 @@ class LightRAG:
                             await asyncio.gather(*first_stage_tasks)
 
                             # Stage 2: Process entity relation graph (after text_chunks are saved)
+                            # Check if document has custom entity_types
+                            doc_entity_types = getattr(status_doc, 'entity_types', None)
                             entity_relation_task = asyncio.create_task(
                                 self._process_extract_entities(
-                                    chunks, pipeline_status, pipeline_status_lock
+                                    chunks, pipeline_status, pipeline_status_lock, doc_entity_types
                                 )
                             )
                             chunk_results = await entity_relation_task
@@ -1989,6 +2001,7 @@ class LightRAG:
                                         "updated_at": datetime.now(
                                             timezone.utc
                                         ).isoformat(),
+                                        "entity_types": status_doc.entity_types,
                                         "file_path": file_path,
                                         "track_id": status_doc.track_id,  # Preserve existing track_id
                                         "metadata": {
@@ -2046,6 +2059,7 @@ class LightRAG:
                                             "updated_at": datetime.now(
                                                 timezone.utc
                                             ).isoformat(),
+                                            "entity_types": status_doc.entity_types,
                                             "file_path": file_path,
                                             "track_id": status_doc.track_id,  # Preserve existing track_id
                                             "metadata": {
@@ -2114,6 +2128,7 @@ class LightRAG:
                                             "content_length": status_doc.content_length,
                                             "created_at": status_doc.created_at,
                                             "updated_at": datetime.now().isoformat(),
+                                            "entity_types": status_doc.entity_types,
                                             "file_path": file_path,
                                             "track_id": status_doc.track_id,  # Preserve existing track_id
                                             "metadata": {
@@ -2195,12 +2210,24 @@ class LightRAG:
                 pipeline_status["history_messages"].append(log_message)
 
     async def _process_extract_entities(
-        self, chunk: dict[str, Any], pipeline_status=None, pipeline_status_lock=None
+        self, chunk: dict[str, Any], pipeline_status=None, pipeline_status_lock=None, entity_types: list[str] = None
     ) -> list:
         try:
+            # Prepare global config
+            global_config = asdict(self)
+
+            # If custom entity_types are provided, override addon_params
+            if entity_types is not None:
+                if "addon_params" not in global_config:
+                    global_config["addon_params"] = {}
+                global_config["addon_params"]["entity_types"] = entity_types
+                logger.info(f"Using custom entity_types for extraction: {entity_types}")
+            else:
+                logger.debug(f"Using default entity_types from addon_params")
+
             chunk_results = await extract_entities(
                 chunk,
-                global_config=asdict(self),
+                global_config=global_config,
                 pipeline_status=pipeline_status,
                 pipeline_status_lock=pipeline_status_lock,
                 llm_response_cache=self.llm_response_cache,

--- a/lightrag_webui/src/api/lightrag.ts
+++ b/lightrag_webui/src/api/lightrag.ts
@@ -493,8 +493,8 @@ export const getDocuments = async (): Promise<DocsStatusesResponse> => {
   return response.data
 }
 
-export const scanNewDocuments = async (): Promise<ScanResponse> => {
-  const response = await axiosInstance.post('/documents/scan')
+export const scanNewDocuments = async (entityTypes?: string[]): Promise<ScanResponse> => {
+  const response = await axiosInstance.post('/documents/scan', entityTypes || null)
   return response.data
 }
 
@@ -791,10 +791,16 @@ export const insertTexts = async (texts: string[]): Promise<DocActionResponse> =
 
 export const uploadDocument = async (
   file: File,
-  onUploadProgress?: (percentCompleted: number) => void
+  onUploadProgress?: (percentCompleted: number) => void,
+  entityTypes?: string[]
 ): Promise<DocActionResponse> => {
   const formData = new FormData()
   formData.append('file', file)
+
+  // Add entity_types if provided
+  if (entityTypes && entityTypes.length > 0) {
+    formData.append('entity_types', JSON.stringify(entityTypes))
+  }
 
   const response = await axiosInstance.post('/documents/upload', formData, {
     headers: {

--- a/lightrag_webui/src/components/documents/EntityTypeConfig.tsx
+++ b/lightrag_webui/src/components/documents/EntityTypeConfig.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react'
+import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+interface EntityTypeConfigProps {
+  entityTypes: string[]
+  onEntityTypesChange: (types: string[]) => void
+  defaultEntityTypes: string[]
+}
+
+export default function EntityTypeConfig({
+  entityTypes,
+  onEntityTypesChange,
+  defaultEntityTypes
+}: EntityTypeConfigProps) {
+  const { t } = useTranslation()
+  const [isExpanded, setIsExpanded] = useState(false)
+  const [useDefault, setUseDefault] = useState(true)
+  const [textInput, setTextInput] = useState('')
+
+  const handleUseDefaultToggle = (checked: boolean) => {
+    setUseDefault(checked)
+    if (checked) {
+      onEntityTypesChange([])
+      setTextInput('')
+    }
+  }
+
+  const handleTextInputChange = (value: string) => {
+    setTextInput(value)
+    const lines = value
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line.length > 0)
+    onEntityTypesChange(lines)
+    // 只在用户明确点击复选框时才使用默认配置，不在输入为空时自动切换
+    // 这样用户可以清空输入框重新输入，而不会导致输入框消失
+  }
+
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="flex items-center gap-2 text-sm font-medium text-foreground/80 hover:text-foreground transition-colors"
+      >
+        {isExpanded ? (
+          <ChevronUpIcon className="w-4 h-4" />
+        ) : (
+          <ChevronDownIcon className="w-4 h-4" />
+        )}
+        {t('documentPanel.entityTypeConfig.advancedSettings')}
+      </button>
+
+      {isExpanded && (
+        <div className="pl-6 space-y-3">
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="use-default-entity-types"
+              checked={useDefault}
+              onChange={e => handleUseDefaultToggle(e.target.checked)}
+              className="w-4 h-4 rounded border-gray-300 text-primary focus:ring-primary"
+            />
+            <label
+              htmlFor="use-default-entity-types"
+              className="text-sm text-foreground/70"
+            >
+              {t('documentPanel.entityTypeConfig.useDefaultForUpload')}
+            </label>
+          </div>
+
+          {!useDefault && (
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground/80">
+                {t('documentPanel.entityTypeConfig.customTypes')}
+              </label>
+              <textarea
+                value={textInput}
+                onChange={e => handleTextInputChange(e.target.value)}
+                placeholder={t('documentPanel.entityTypeConfig.placeholder')}
+                rows={6}
+                className="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent resize-y"
+              />
+              <div className="flex items-center justify-between text-xs text-foreground/60">
+                <span>
+                  {t('documentPanel.entityTypeConfig.count', {
+                    count: entityTypes.length
+                  })}
+                </span>
+                <span>{t('documentPanel.entityTypeConfig.hint')}</span>
+              </div>
+
+              {defaultEntityTypes.length > 0 && (
+                <div className="mt-2 p-2 bg-muted/50 rounded text-xs">
+                  <div className="font-medium text-foreground/70 mb-1">
+                    {t('documentPanel.entityTypeConfig.defaultLabel')}
+                  </div>
+                  <div className="text-foreground/60">
+                    {defaultEntityTypes.join(', ')}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lightrag_webui/src/components/documents/ScanConfigDialog.tsx
+++ b/lightrag_webui/src/components/documents/ScanConfigDialog.tsx
@@ -1,0 +1,162 @@
+import { useState } from 'react'
+import Button from '@/components/ui/Button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/Dialog'
+import { useTranslation } from 'react-i18next'
+
+interface ScanConfigDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: (entityTypes: string[] | undefined) => void
+  defaultEntityTypes: string[]
+  isScanning?: boolean
+}
+
+export default function ScanConfigDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  defaultEntityTypes,
+  isScanning = false
+}: ScanConfigDialogProps) {
+  const { t } = useTranslation()
+  const [useDefault, setUseDefault] = useState<boolean>(true)
+  const [customEntityTypes, setCustomEntityTypes] = useState<string[]>([])
+  const [textInput, setTextInput] = useState<string>('')
+
+  const handleConfirm = () => {
+    // 如果使用默认类型，传递 undefined
+    // 否则传递自定义的类型
+    const entityTypesToUse = useDefault ? undefined : customEntityTypes
+    onConfirm(entityTypesToUse)
+    // 关闭弹窗
+    onOpenChange(false)
+  }
+
+  const handleCancel = () => {
+    onOpenChange(false)
+    // 重置状态
+    setUseDefault(true)
+    setCustomEntityTypes([])
+    setTextInput('')
+  }
+
+  // 当对话框关闭时重置状态
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen) {
+      setUseDefault(true)
+      setCustomEntityTypes([])
+      setTextInput('')
+    }
+    onOpenChange(newOpen)
+  }
+
+  const handleCheckboxChange = (checked: boolean) => {
+    setUseDefault(checked)
+    if (checked) {
+      setTextInput('')
+      setCustomEntityTypes([])
+    }
+  }
+
+  const handleTextInputChange = (value: string) => {
+    setTextInput(value)
+    const lines = value
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line.length > 0)
+    setCustomEntityTypes(lines)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-lg overflow-hidden">
+        <DialogHeader>
+          <DialogTitle>{t('documentPanel.documentManager.scanButton')}</DialogTitle>
+          <DialogDescription>
+            {t('documentPanel.documentManager.scanConfig.description')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                id="use-default-entity-types-scan"
+                checked={useDefault}
+                onChange={e => handleCheckboxChange(e.target.checked)}
+                className="w-4 h-4 rounded border-gray-300 text-primary focus:ring-primary"
+              />
+              <label
+                htmlFor="use-default-entity-types-scan"
+                className="text-sm text-foreground/70"
+              >
+                {t('documentPanel.entityTypeConfig.useDefaultForScan')}
+              </label>
+            </div>
+
+            {useDefault && defaultEntityTypes.length > 0 && (
+              <div className="pl-6 p-2 bg-muted/50 rounded text-xs">
+                <div className="font-medium text-foreground/70 mb-1">
+                  {t('documentPanel.entityTypeConfig.defaultLabel')}
+                </div>
+                <div className="text-foreground/60">
+                  {defaultEntityTypes.join(', ')}
+                </div>
+              </div>
+            )}
+
+            {!useDefault && (
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground/80">
+                  {t('documentPanel.entityTypeConfig.customTypes')}
+                </label>
+                <textarea
+                  value={textInput}
+                  onChange={e => handleTextInputChange(e.target.value)}
+                  placeholder={t('documentPanel.entityTypeConfig.placeholder')}
+                  rows={6}
+                  className="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent resize-y"
+                />
+                <div className="flex items-center justify-between text-xs text-foreground/60">
+                  <span>
+                    {t('documentPanel.entityTypeConfig.count', {
+                      count: customEntityTypes.length
+                    })}
+                  </span>
+                  <span>{t('documentPanel.entityTypeConfig.hint')}</span>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleCancel}
+            disabled={isScanning}
+          >
+            {t('documentPanel.documentManager.scanConfig.cancel')}
+          </Button>
+          <Button
+            type="button"
+            variant="default"
+            onClick={handleConfirm}
+            disabled={isScanning}
+          >
+            {isScanning ? t('documentPanel.documentManager.scanConfig.scanning') : '启动'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/lightrag_webui/src/components/documents/ScanEntityTypeConfig.tsx
+++ b/lightrag_webui/src/components/documents/ScanEntityTypeConfig.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react'
+import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+interface ScanEntityTypeConfigProps {
+  entityTypes: string[]
+  onEntityTypesChange: (types: string[]) => void
+  defaultEntityTypes: string[]
+}
+
+export default function ScanEntityTypeConfig({
+  entityTypes,
+  onEntityTypesChange,
+  defaultEntityTypes
+}: ScanEntityTypeConfigProps) {
+  const { t } = useTranslation()
+  const [isExpanded, setIsExpanded] = useState(false)  // 默认折叠
+  const [useDefault, setUseDefault] = useState(true)
+  const [textInput, setTextInput] = useState('')
+
+  const handleUseDefaultToggle = (checked: boolean) => {
+    setUseDefault(checked)
+    if (checked) {
+      onEntityTypesChange([])
+      setTextInput('')
+    }
+  }
+
+  const handleTextInputChange = (value: string) => {
+    setTextInput(value)
+    const lines = value
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line.length > 0)
+    onEntityTypesChange(lines)
+    // 只在用户明确点击复选框时才使用默认配置，不在输入为空时自动切换
+    // 这样用户可以清空输入框重新输入，而不会导致输入框消失
+  }
+
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="flex items-center gap-2 text-sm font-medium text-foreground/80 hover:text-foreground transition-colors"
+      >
+        {isExpanded ? (
+          <ChevronUpIcon className="w-4 h-4" />
+        ) : (
+          <ChevronDownIcon className="w-4 h-4" />
+        )}
+        {t('documentPanel.entityTypeConfig.advancedSettings')}
+      </button>
+
+      {isExpanded && (
+        <div className="pl-6 space-y-3">
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="use-default-entity-types-scan"
+              checked={useDefault}
+              onChange={e => handleUseDefaultToggle(e.target.checked)}
+              className="w-4 h-4 rounded border-gray-300 text-primary focus:ring-primary"
+            />
+            <label
+              htmlFor="use-default-entity-types-scan"
+              className="text-sm text-foreground/70"
+            >
+              {t('documentPanel.entityTypeConfig.useDefault')}
+            </label>
+          </div>
+
+          {!useDefault && (
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground/80">
+                {t('documentPanel.entityTypeConfig.customTypes')}
+              </label>
+              <textarea
+                value={textInput}
+                onChange={e => handleTextInputChange(e.target.value)}
+                placeholder={t('documentPanel.entityTypeConfig.placeholder')}
+                rows={6}
+                className="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent resize-y"
+              />
+              <div className="flex items-center justify-between text-xs text-foreground/60">
+                <span>
+                  {t('documentPanel.entityTypeConfig.count', {
+                    count: entityTypes.length
+                  })}
+                </span>
+                <span>{t('documentPanel.entityTypeConfig.hint')}</span>
+              </div>
+
+              {defaultEntityTypes.length > 0 && (
+                <div className="mt-2 p-2 bg-muted/50 rounded text-xs">
+                  <div className="font-medium text-foreground/70 mb-1">
+                    {t('documentPanel.entityTypeConfig.defaultLabel')}
+                  </div>
+                  <div className="text-foreground/60">
+                    {defaultEntityTypes.join(', ')}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lightrag_webui/src/components/ui/FileUploader.tsx
+++ b/lightrag_webui/src/components/ui/FileUploader.tsx
@@ -146,8 +146,9 @@ function FileUploader(props: FileUploaderProps) {
     ...dropzoneProps
   } = props
 
-  const [files, setFiles] = useControllableState({
+  const [files, setFiles] = useControllableState<File[]>({
     prop: valueProp,
+    defaultProp: [],
     onChange: onValueChange
   })
 

--- a/lightrag_webui/src/locales/ar.json
+++ b/lightrag_webui/src/locales/ar.json
@@ -111,7 +111,10 @@
         "removeFile": "إزالة الملف",
         "uploadDescription": "يمكنك رفع {{isMultiple ? 'عدة' : count}} ملفات (حتى {{maxSize}} لكل منها)",
         "duplicateFile": "اسم الملف موجود بالفعل في ذاكرة التخزين المؤقت للخادم"
-      }
+      },
+      "startUpload": "بدء الرفع",
+      "uploading": "جاري الرفع...",
+      "cancel": "مسح"
     },
     "documentManager": {
       "title": "إدارة المستندات",
@@ -153,7 +156,14 @@
       "showButton": "عرض",
       "hideButton": "إخفاء",
       "showFileNameTooltip": "عرض اسم الملف",
-      "hideFileNameTooltip": "إخفاء اسم الملف"
+      "hideFileNameTooltip": "إخفاء اسم الملف",
+      "scanConfig": {
+        "title": "تكوين أنواع الكيانات",
+        "description": "اختر تكوين أنواع الكيانات لمسح المستندات",
+        "cancel": "إلغاء",
+        "confirm": "بدء المسح",
+        "scanning": "جاري المسح..."
+      }
     },
     "pipelineStatus": {
       "title": "حالة خط الأنابيب",
@@ -178,6 +188,17 @@
       "errors": {
         "fetchFailed": "فشل في جلب حالة خط الأنابيب\n{{error}}"
       }
+    },
+    "entityTypeConfig": {
+      "advancedSettings": "إعدادات متقدمة",
+      "useDefaultForUpload": "استخدام أنواع الكيانات الافتراضية",
+      "useDefaultForScan": "استخدام أنواع الكيانات الأصلية",
+      "customTypes": "أنواع كيانات مخصصة",
+      "fillDefault": "ملء الأنواع الافتراضية",
+      "placeholder": "أدخل نوع كيان واحد لكل سطر، مثلاً:\\nشخص\\nمنظمة\\nموقع\\nحدث",
+      "count": "{{count}} أنواع",
+      "hint": "نوع واحد لكل سطر",
+      "defaultLabel": "أنواع الكيانات الافتراضية:"
     }
   },
   "graphPanel": {

--- a/lightrag_webui/src/locales/de.json
+++ b/lightrag_webui/src/locales/de.json
@@ -111,7 +111,10 @@
         "removeFile": "Datei entfernen",
         "uploadDescription": "Sie können {{isMultiple ? 'mehrere' : count}} Dateien hochladen (bis zu {{maxSize}} pro Datei)",
         "duplicateFile": "Dateiname existiert bereits im Server-Cache"
-      }
+      },
+      "startUpload": "Upload starten",
+      "uploading": "Wird hochgeladen...",
+      "cancel": "Löschen"
     },
     "documentManager": {
       "title": "Dokumentenverwaltung",
@@ -153,7 +156,14 @@
       "showButton": "Anzeigen",
       "hideButton": "Ausblenden",
       "showFileNameTooltip": "Dateiname anzeigen",
-      "hideFileNameTooltip": "Dateiname ausblenden"
+      "hideFileNameTooltip": "Dateiname ausblenden",
+      "scanConfig": {
+        "title": "Entitätstypen konfigurieren",
+        "description": "Entitätstyp-Konfiguration für das Scannen von Dokumenten auswählen",
+        "cancel": "Abbrechen",
+        "confirm": "Scannen starten",
+        "scanning": "Wird gescannt..."
+      }
     },
     "pipelineStatus": {
       "title": "Pipeline-Status",
@@ -178,6 +188,17 @@
       "errors": {
         "fetchFailed": "Pipeline-Status konnte nicht abgerufen werden\n{{error}}"
       }
+    },
+    "entityTypeConfig": {
+      "advancedSettings": "Erweiterte Einstellungen",
+      "useDefaultForUpload": "Standard-Entitätstypen verwenden",
+      "useDefaultForScan": "Ursprüngliche Entitätstypen verwenden",
+      "customTypes": "Benutzerdefinierte Entitätstypen",
+      "fillDefault": "Standardtypen ausfüllen",
+      "placeholder": "Geben Sie einen Entitätstyp pro Zeile ein, z. B.:\nPerson\nOrganisation\nOrt\nEreignis",
+      "count": "{{count}} Typen",
+      "hint": "Ein Typ pro Zeile",
+      "defaultLabel": "Standard-Entitätstypen:"
     }
   },
   "graphPanel": {

--- a/lightrag_webui/src/locales/en.json
+++ b/lightrag_webui/src/locales/en.json
@@ -99,6 +99,9 @@
         "error": "Some files failed to upload"
       },
       "generalError": "Upload Failed\n{{error}}",
+      "startUpload": "Start Upload",
+      "uploading": "Uploading...",
+      "cancel": "Clear",
       "fileTypes": "Supported types: TXT, MD, MDX, DOCX, PDF, PPTX, XLSX, RTF, ODT, EPUB, HTML, HTM, TEX, JSON, XML, YAML, YML, CSV, LOG, CONF, INI, PROPERTIES, SQL, BAT, SH, C, H, CPP, HPP, PY, JAVA, JS, TS, SWIFT, GO, RB, PHP, CSS, SCSS, LESS",
       "fileUploader": {
         "singleFileLimit": "Cannot upload more than 1 file at a time",
@@ -113,11 +116,29 @@
         "duplicateFile": "File name already exists in server cache"
       }
     },
+    "entityTypeConfig": {
+      "advancedSettings": "Advanced Settings",
+      "useDefaultForUpload": "Use default entity types",
+      "useDefaultForScan": "Use original entity types",
+      "customTypes": "Custom entity types",
+      "fillDefault": "Fill default types",
+      "placeholder": "Enter one entity type per line, e.g.:\nPerson\nOrganization\nLocation\nEvent",
+      "count": "{{count}} types",
+      "hint": "One type per line",
+      "defaultLabel": "Default entity types:"
+    },
     "documentManager": {
       "title": "Document Management",
       "scanButton": "Scan/Retry",
       "scanTooltip": "Scan and process documents in input folder, and also reprocess all failed documents",
       "refreshTooltip": "Reset document list",
+      "scanConfig": {
+        "title": "Configure Entity Types",
+        "description": "Select entity type configuration for scanning documents",
+        "cancel": "Cancel",
+        "confirm": "Start Scan",
+        "scanning": "Scanning..."
+      },
       "pipelineStatusButton": "Pipeline",
       "pipelineStatusTooltip": "View document processing pipeline status",
       "uploadedTitle": "Uploaded Documents",

--- a/lightrag_webui/src/locales/fr.json
+++ b/lightrag_webui/src/locales/fr.json
@@ -111,7 +111,10 @@
         "removeFile": "Supprimer le fichier",
         "uploadDescription": "Vous pouvez télécharger {{isMultiple ? 'plusieurs' : count}} fichiers (jusqu'à {{maxSize}} chacun)",
         "duplicateFile": "Le nom du fichier existe déjà dans le cache du serveur"
-      }
+      },
+      "startUpload": "Démarrer le téléchargement",
+      "uploading": "Téléchargement...",
+      "cancel": "Effacer"
     },
     "documentManager": {
       "title": "Gestion des documents",
@@ -153,7 +156,14 @@
       "showButton": "Afficher",
       "hideButton": "Masquer",
       "showFileNameTooltip": "Afficher le nom du fichier",
-      "hideFileNameTooltip": "Masquer le nom du fichier"
+      "hideFileNameTooltip": "Masquer le nom du fichier",
+      "scanConfig": {
+        "title": "Configurer les types d'entités",
+        "description": "Sélectionner la configuration des types d'entités pour l'analyse des documents",
+        "cancel": "Annuler",
+        "confirm": "Démarrer l'analyse",
+        "scanning": "Analyse..."
+      }
     },
     "pipelineStatus": {
       "title": "État du Pipeline",
@@ -178,6 +188,17 @@
       "errors": {
         "fetchFailed": "Échec de la récupération de l'état du pipeline\n{{error}}"
       }
+    },
+    "entityTypeConfig": {
+      "advancedSettings": "Paramètres avancés",
+      "useDefaultForUpload": "Utiliser les types d'entités par défaut",
+      "useDefaultForScan": "Utiliser les types d'entités d'origine",
+      "customTypes": "Types d'entités personnalisés",
+      "fillDefault": "Remplir les types par défaut",
+      "placeholder": "Entrez un type d'entité par ligne, ex :\nPersonne\nOrganisation\nLieu\nÉvénement",
+      "count": "{{count}} types",
+      "hint": "Un type par ligne",
+      "defaultLabel": "Types d'entités par défaut :"
     }
   },
   "graphPanel": {

--- a/lightrag_webui/src/locales/ja.json
+++ b/lightrag_webui/src/locales/ja.json
@@ -111,7 +111,10 @@
         "removeFile": "ファイルを削除",
         "uploadDescription": "{{isMultiple ? '複数' : count}}個のファイルをアップロードできます（それぞれ最大{{maxSize}}まで）",
         "duplicateFile": "ファイル名がサーバーキャッシュに既に存在します"
-      }
+      },
+      "startUpload": "アップロード開始",
+      "uploading": "アップロード中...",
+      "cancel": "クリア"
     },
     "documentManager": {
       "title": "ドキュメント管理",
@@ -153,7 +156,14 @@
       "showButton": "表示",
       "hideButton": "非表示",
       "showFileNameTooltip": "ファイル名を表示",
-      "hideFileNameTooltip": "ファイル名を非表示"
+      "hideFileNameTooltip": "ファイル名を非表示",
+      "scanConfig": {
+        "title": "エンティティタイプの設定",
+        "description": "ドキュメントスキャン用のエンティティタイプ設定を選択",
+        "cancel": "キャンセル",
+        "confirm": "スキャン開始",
+        "scanning": "スキャン中..."
+      }
     },
     "pipelineStatus": {
       "title": "パイプラインステータス",
@@ -178,6 +188,17 @@
       "errors": {
         "fetchFailed": "パイプラインステータスの取得に失敗しました\n{{error}}"
       }
+    },
+    "entityTypeConfig": {
+      "advancedSettings": "詳細設定",
+      "useDefaultForUpload": "デフォルトのエンティティタイプを使用",
+      "useDefaultForScan": "元のエンティティタイプを使用",
+      "customTypes": "カスタムエンティティタイプ",
+      "fillDefault": "デフォルトタイプを入力",
+      "placeholder": "1行に1つのエンティティタイプを入力してください（例）:\n人物\n組織\n場所\nイベント",
+      "count": "{{count}}タイプ",
+      "hint": "1行に1タイプ",
+      "defaultLabel": "デフォルトのエンティティタイプ："
     }
   },
   "graphPanel": {

--- a/lightrag_webui/src/locales/ko.json
+++ b/lightrag_webui/src/locales/ko.json
@@ -111,7 +111,10 @@
         "removeFile": "파일 제거",
         "uploadDescription": "{{isMultiple ? '여러' : count}}개의 파일을 업로드할 수 있습니다 (각 최대 {{maxSize}})",
         "duplicateFile": "파일 이름이 서버 캐시에 이미 존재합니다"
-      }
+      },
+      "startUpload": "업로드 시작",
+      "uploading": "업로드 중...",
+      "cancel": "지우기"
     },
     "documentManager": {
       "title": "문서 관리",
@@ -153,7 +156,14 @@
       "showButton": "표시",
       "hideButton": "숨기기",
       "showFileNameTooltip": "파일명 표시",
-      "hideFileNameTooltip": "파일명 숨기기"
+      "hideFileNameTooltip": "파일명 숨기기",
+      "scanConfig": {
+        "title": "엔티티 유형 구성",
+        "description": "문서 스캔을 위한 엔티티 유형 구성 선택",
+        "cancel": "취소",
+        "confirm": "스캔 시작",
+        "scanning": "스캔 중..."
+      }
     },
     "pipelineStatus": {
       "title": "파이프라인 상태",
@@ -178,6 +188,17 @@
       "errors": {
         "fetchFailed": "파이프라인 상태 가져오기 실패\n{{error}}"
       }
+    },
+    "entityTypeConfig": {
+      "advancedSettings": "고급 설정",
+      "useDefaultForUpload": "기본 엔티티 유형 사용",
+      "useDefaultForScan": "원본 엔티티 유형 사용",
+      "customTypes": "사용자 정의 엔티티 유형",
+      "fillDefault": "기본 유형 채우기",
+      "placeholder": "줄당 하나의 엔티티 유형을 입력하세요 (예):\\n사람\\n조직\\n장소\\n이벤트",
+      "count": "{{count}}개 유형",
+      "hint": "줄당 하나의 유형",
+      "defaultLabel": "기본 엔티티 유형:"
     }
   },
   "graphPanel": {

--- a/lightrag_webui/src/locales/ru.json
+++ b/lightrag_webui/src/locales/ru.json
@@ -111,7 +111,10 @@
         "removeFile": "Удалить файл",
         "uploadDescription": "Вы можете загрузить {{isMultiple ? 'несколько' : count}} файлов (до {{maxSize}} каждый)",
         "duplicateFile": "Имя файла уже существует в кэше сервера"
-      }
+      },
+      "startUpload": "Начать загрузку",
+      "uploading": "Загрузка...",
+      "cancel": "Очистить"
     },
     "documentManager": {
       "title": "Управление документами",
@@ -153,7 +156,14 @@
       "showButton": "Показать",
       "hideButton": "Скрыть",
       "showFileNameTooltip": "Показать имя файла",
-      "hideFileNameTooltip": "Скрыть имя файла"
+      "hideFileNameTooltip": "Скрыть имя файла",
+      "scanConfig": {
+        "title": "Настроить типы сущностей",
+        "description": "Выберите конфигурацию типов сущностей для сканирования документов",
+        "cancel": "Отмена",
+        "confirm": "Начать сканирование",
+        "scanning": "Сканирование..."
+      }
     },
     "pipelineStatus": {
       "title": "Статус конвейера",
@@ -178,6 +188,17 @@
       "errors": {
         "fetchFailed": "Не удалось получить статус конвейера\n{{error}}"
       }
+    },
+    "entityTypeConfig": {
+      "advancedSettings": "Расширенные настройки",
+      "useDefaultForUpload": "Использовать типы сущностей по умолчанию",
+      "useDefaultForScan": "Использовать исходные типы сущностей",
+      "customTypes": "Пользовательские типы сущностей",
+      "fillDefault": "Заполнить типы по умолчанию",
+      "placeholder": "Введите один тип сущности на строку, например:\\nЧеловек\\nОрганизация\\nМестоположение\\nСобытие",
+      "count": "{{count}} типов",
+      "hint": "Один тип на строку",
+      "defaultLabel": "Типы сущностей по умолчанию:"
     }
   },
   "graphPanel": {

--- a/lightrag_webui/src/locales/uk.json
+++ b/lightrag_webui/src/locales/uk.json
@@ -111,7 +111,10 @@
         "removeFile": "Видалити файл",
         "uploadDescription": "Ви можете завантажити {{isMultiple ? 'кілька' : count}} файлів (до {{maxSize}} кожен)",
         "duplicateFile": "Ім'я файлу вже існує в кеші сервера"
-      }
+      },
+      "startUpload": "Почати завантаження",
+      "uploading": "Завантаження...",
+      "cancel": "Очистити"
     },
     "documentManager": {
       "title": "Управління документами",
@@ -153,7 +156,14 @@
       "showButton": "Показати",
       "hideButton": "Приховати",
       "showFileNameTooltip": "Показати ім'я файлу",
-      "hideFileNameTooltip": "Приховати ім'я файлу"
+      "hideFileNameTooltip": "Приховати ім'я файлу",
+      "scanConfig": {
+        "title": "Налаштувати типи сутностей",
+        "description": "Виберіть конфігурацію типів сутностей для сканування документів",
+        "cancel": "Скасувати",
+        "confirm": "Почати сканування",
+        "scanning": "Сканування..."
+      }
     },
     "pipelineStatus": {
       "title": "Статус пайплайну",
@@ -178,6 +188,17 @@
       "errors": {
         "fetchFailed": "Не вдалося отримати статус пайплайну\n{{error}}"
       }
+    },
+    "entityTypeConfig": {
+      "advancedSettings": "Розширені налаштування",
+      "useDefaultForUpload": "Використовувати типи сутностей за замовчуванням",
+      "useDefaultForScan": "Використовувати початкові типи сутностей",
+      "customTypes": "Користувацькі типи сутностей",
+      "fillDefault": "Заповнити типи за замовчуванням",
+      "placeholder": "Введіть один тип сутності на рядок, наприклад:\\nОсоба\\nОрганізація\\nМісце\\nПодія",
+      "count": "{{count}} типів",
+      "hint": "Один тип на рядок",
+      "defaultLabel": "Типи сутностей за замовчуванням:"
     }
   },
   "graphPanel": {

--- a/lightrag_webui/src/locales/zh.json
+++ b/lightrag_webui/src/locales/zh.json
@@ -99,6 +99,9 @@
         "error": "部分文件上传失败"
       },
       "generalError": "上传失败\n{{error}}",
+      "startUpload": "开始上传",
+      "uploading": "上传中...",
+      "cancel": "清空",
       "fileTypes": "支持的文件类型：TXT, MD, MDX, DOCX, PDF, PPTX, XLSX, RTF, ODT, EPUB, HTML, HTM, TEX, JSON, XML, YAML, YML, CSV, LOG, CONF, INI, PROPERTIES, SQL, BAT, SH, C, CPP, H, HPP, PY, JAVA, JS, TS, SWIFT, GO, RB, PHP, CSS, SCSS, LESS",
       "fileUploader": {
         "singleFileLimit": "一次只能上传一个文件",
@@ -113,11 +116,29 @@
         "duplicateFile": "文件名与服务器上的缓存重复"
       }
     },
+    "entityTypeConfig": {
+      "advancedSettings": "高级设置",
+      "useDefaultForUpload": "使用默认实体类型",
+      "useDefaultForScan": "使用原实体类型",
+      "customTypes": "自定义实体类型",
+      "fillDefault": "填充默认类型",
+      "placeholder": "每行输入一个实体类型，例如：\n人物\n组织\n地点\n事件",
+      "count": "{{count}} 个类型",
+      "hint": "每行一个类型",
+      "defaultLabel": "默认实体类型："
+    },
     "documentManager": {
       "title": "文档管理",
       "scanButton": "扫描/重试",
       "scanTooltip": "扫描处理输入目录中的文档，同时重新处理所有失败的文档",
       "refreshTooltip": "复位文档清单",
+      "scanConfig": {
+        "title": "配置实体类型",
+        "description": "选择用于扫描文档的实体类型配置",
+        "cancel": "取消",
+        "confirm": "开始扫描",
+        "scanning": "扫描中..."
+      },
       "pipelineStatusButton": "流水线",
       "pipelineStatusTooltip": "查看文档处理流水线状态",
       "uploadedTitle": "已上传文档",

--- a/lightrag_webui/src/locales/zh_TW.json
+++ b/lightrag_webui/src/locales/zh_TW.json
@@ -111,7 +111,10 @@
         "removeFile": "移除檔案",
         "uploadDescription": "您可以上傳{{isMultiple ? '多個' : count}}個檔案（每個檔案最大{{maxSize}}）",
         "duplicateFile": "檔案名稱與伺服器上的快取重複"
-      }
+      },
+      "startUpload": "開始上傳",
+      "uploading": "上傳中...",
+      "cancel": "清除"
     },
     "documentManager": {
       "title": "文件管理",
@@ -153,7 +156,14 @@
       "showButton": "顯示",
       "hideButton": "隱藏",
       "showFileNameTooltip": "顯示檔案名稱",
-      "hideFileNameTooltip": "隱藏檔案名稱"
+      "hideFileNameTooltip": "隱藏檔案名稱",
+      "scanConfig": {
+        "title": "配置實體類型",
+        "description": "選擇用於掃描文檔的實體類型配置",
+        "cancel": "取消",
+        "confirm": "開始掃描",
+        "scanning": "掃描中..."
+      }
     },
     "pipelineStatus": {
       "title": "流水線狀態",
@@ -178,6 +188,17 @@
       "errors": {
         "fetchFailed": "獲取流水線狀態失敗\n{{error}}"
       }
+    },
+    "entityTypeConfig": {
+      "advancedSettings": "高級設置",
+      "useDefaultForUpload": "使用預設實體類型",
+      "useDefaultForScan": "使用原實體類型",
+      "customTypes": "自訂實體類型",
+      "fillDefault": "填入預設類型",
+      "placeholder": "每行輸入一個實體類型，例如：\\n人物\\n組織\\n地點\\n事件",
+      "count": "{{count}} 個類型",
+      "hint": "每行一個類型",
+      "defaultLabel": "預設實體類型："
     }
   },
   "graphPanel": {


### PR DESCRIPTION
feat: Add custom entity types support for document processing(upload/scan/retry) when the user requests

### Features
- Add custom entity types configuration for document upload and scan/retry operations
- Distinguish between "use default entity types" (upload) and "use original entity types" (scan/retry)
- Support user-defined entity types in text format (one type per line)

### Backend Changes
- Add `entity_types` field to `DocProcessingStatus` dataclass
- Update `/documents/upload` endpoint to accept `entity_types` form parameter
- Update `/documents/scan` endpoint to accept `entity_types` body parameter
- Modify `pipeline_index_files()` to pass `entity_types` through the processing chain
- Update all `doc_status.upsert()` calls to include `entity_types` field
- Add PostgreSQL migration for `entity_types` JSONB column
- Update DDL to include `entity_types` column in LIGHTRAG_DOC_STATUS table
- Add entity_types serialization/deserialization in all query methods

### Frontend Changes
- Create `ScanConfigDialog` component for scan/retry configuration
- Update `EntityTypeConfig` component to support custom entity types input
- Integrate scan config dialog into `DocumentManager` component
- Add textarea input for custom entity types to extract
- Add button for upload or scan contexts

功能：添加“上传和扫描文档时，支持自定义提取实体类型”

### 新功能
- 为文档上传和扫描/重试操作添加自定义实体类型配置
- 区分"使用默认实体类型"（上传）和"使用原实体类型"（扫描/重试）
- 支持用户以文本格式自定义实体类型（每行一个类型）

### 后端变更
- 在 DocProcessingStatus 数据类中添加 entity_types 字段
- 更新 /documents/upload 接口以接受 entity_types 表单参数
- 更新 /documents/scan 接口以接受 entity_types body 参数
- 修改 pipeline_index_files() 在处理链中传递 entity_types 参数
- 更新所有 doc_status.upsert() 调用以包含 entity_types 字段
- 为 PostgreSQL 添加 entity_types JSONB 字段的数据库迁移
- 更新 DDL 在 LIGHTRAG_DOC_STATUS 表中包含 entity_types 列
- 在所有查询方法中添加 entity_types 序列化/反序列化

### 前端变更
- 创建 ScanConfigDialog 组件用于扫描/重试配置
- 更新 EntityTypeConfig 组件以支持自定义实体类型输入
- 将扫描配置对话框集成到 DocumentManager 组件
- 添加自定义待提取实体类型的文本输入框
- 为上传与扫描上下文添加单独按键

<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

Add custom entity types support for document processing(upload/scan/retry) when the user requests

### Features
- Add custom entity types configuration for document upload and scan/retry operations
- Distinguish between "use default entity types" (upload) and "use original entity types" (scan/retry)
- Support user-defined entity types in text format (one type per line)

功能：添加“上传和扫描文档时，支持自定义提取实体类型”

### 新功能
- 为文档上传和扫描/重试操作添加自定义实体类型配置
- 区分"使用默认实体类型"（上传）和"使用原实体类型"（扫描/重试）
- 支持用户以文本格式自定义实体类型（每行一个类型）

## Related Issues
N/A - This is a new feature to improve extraction experience.

## Changes Made

### Backend Changes
- Add `entity_types` field to `DocProcessingStatus` dataclass
- Update `/documents/upload` endpoint to accept `entity_types` form parameter
- Update `/documents/scan` endpoint to accept `entity_types` body parameter
- Modify `pipeline_index_files()` to pass `entity_types` through the processing chain
- Update all `doc_status.upsert()` calls to include `entity_types` field
- Add PostgreSQL migration for `entity_types` JSONB column
- Update DDL to include `entity_types` column in LIGHTRAG_DOC_STATUS table
- Add entity_types serialization/deserialization in all query methods

### Frontend Changes
- Create `ScanConfigDialog` component for scan/retry configuration
- Update `EntityTypeConfig` component to support custom entity types input
- Integrate scan config dialog into `DocumentManager` component
- Add textarea input for custom entity types to extract
- Add button for upload or scan contexts

### 后端变更
- 在 DocProcessingStatus 数据类中添加 entity_types 字段
- 更新 /documents/upload 接口以接受 entity_types 表单参数
- 更新 /documents/scan 接口以接受 entity_types body 参数
- 修改 pipeline_index_files() 在处理链中传递 entity_types 参数
- 更新所有 doc_status.upsert() 调用以包含 entity_types 字段
- 为 PostgreSQL 添加 entity_types JSONB 字段的数据库迁移
- 更新 DDL 在 LIGHTRAG_DOC_STATUS 表中包含 entity_types 列
- 在所有查询方法中添加 entity_types 序列化/反序列化

### 前端变更
- 创建 ScanConfigDialog 组件用于扫描/重试配置
- 更新 EntityTypeConfig 组件以支持自定义实体类型输入
- 将扫描配置对话框集成到 DocumentManager 组件
- 添加自定义待提取实体类型的文本输入框
- 为上传与扫描上下文添加单独按键

## Checklist

[✓] Changes tested locally
[✓] Code reviewed
[ ] Documentation updated (if necessary)
[ ] Unit tests added (if applicable)

## Additional Notes
N/A
