### PR TITLE
Add ollama dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ api = [
     "xlsxwriter>=3.1.0",
     "google-api-core>=2.0.0,<3.0.0",
     "google-genai>=1.0.0,<2.0.0",
+    "ollama>=0.1.0,<1.0.0",
     # API-specific dependencies
     "aiofiles",
     "ascii_colors",


### PR DESCRIPTION
## Description

When using the LightRAG source code for a local installation and configuring the Ollama model, I encountered an error while starting lightrag-server: `Exception: Failed to import ollama LLM binding: No module named 'ollama'`. It appears this dependency needs to be installed.

## Related Issues

None.

## Changes Made

Add ollama to dependency.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

None.
