### PR TITLE
Fix deletion cleanup for failed documents

### DIFF
--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -400,6 +400,19 @@ class BaseKVStorage(StorageNameSpace, ABC):
             bool: True if storage contains no data, False otherwise
         """
 
+    async def get_ids_by_doc_id(self, doc_id: str) -> list[str]:
+        """Get record IDs associated with a document.
+
+        This is an optional capability used by deletion cleanup to discover chunk
+        IDs when a document status record does not contain `chunks_list`.
+
+        Implementations are expected to return IDs where the stored record has
+        `full_doc_id == doc_id` (commonly for `text_chunks` storage).
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support get_ids_by_doc_id"
+        )
+
 
 @dataclass
 class BaseGraphStorage(StorageNameSpace, ABC):

--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -134,6 +134,14 @@ class JsonKVStorage(BaseKVStorage):
                     results.append(None)
             return results
 
+    async def get_ids_by_doc_id(self, doc_id: str) -> list[str]:
+        async with self._storage_lock:
+            return [
+                record_id
+                for record_id, record in self._data.items()
+                if isinstance(record, dict) and record.get("full_doc_id") == doc_id
+            ]
+
     async def filter_keys(self, keys: set[str]) -> set[str]:
         async with self._storage_lock:
             return set(keys) - set(self._data.keys())

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -169,6 +169,10 @@ class MongoKVStorage(BaseKVStorage):
             ordered_results.append(doc_map.get(str(id_value)))
         return ordered_results
 
+    async def get_ids_by_doc_id(self, doc_id: str) -> list[str]:
+        cursor = self._data.find({"full_doc_id": doc_id}, {"_id": 1})
+        return [str(item["_id"]) async for item in cursor]
+
     async def filter_keys(self, keys: set[str]) -> set[str]:
         cursor = self._data.find({"_id": {"$in": list(keys)}}, {"_id": 1})
         existing_ids = {str(x["_id"]) async for x in cursor}

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1786,6 +1786,7 @@ class LightRAG:
                     processing_start_time = int(time.time())
                     first_stage_tasks = []
                     entity_relation_task = None
+                    chunks: dict[str, Any] = {}
 
                     async with semaphore:
                         nonlocal processed_count
@@ -1983,6 +1984,8 @@ class LightRAG:
                                     doc_id: {
                                         "status": DocStatus.FAILED,
                                         "error_msg": str(e),
+                                        "chunks_count": len(chunks),
+                                        "chunks_list": list(chunks.keys()),
                                         "content_summary": status_doc.content_summary,
                                         "content_length": status_doc.content_length,
                                         "created_at": status_doc.created_at,
@@ -2110,6 +2113,8 @@ class LightRAG:
                                         doc_id: {
                                             "status": DocStatus.FAILED,
                                             "error_msg": str(e),
+                                            "chunks_count": len(chunks),
+                                            "chunks_list": list(chunks.keys()),
                                             "content_summary": status_doc.content_summary,
                                             "content_length": status_doc.content_length,
                                             "created_at": status_doc.created_at,
@@ -3428,8 +3433,9 @@ class LightRAG:
             # 5. Delete chunks from storage
             if chunk_ids:
                 try:
-                    await self.chunks_vdb.delete(chunk_ids)
-                    await self.text_chunks.delete(chunk_ids)
+                    chunk_id_list = list(chunk_ids)
+                    await self.chunks_vdb.delete(chunk_id_list)
+                    await self.text_chunks.delete(chunk_id_list)
 
                     async with pipeline_status_lock:
                         log_message = (

--- a/tests/test_document_deletion_cleanup.py
+++ b/tests/test_document_deletion_cleanup.py
@@ -116,7 +116,9 @@ async def test_failed_doc_preserves_chunks_list_on_extraction_error(
 async def test_failed_doc_preserves_chunks_list_on_merge_error(tmp_path, monkeypatch):
     rag = await _make_rag(str(tmp_path), workspace="ws_merge_fail")
     try:
-        monkeypatch.setattr(rag, "_process_extract_entities", AsyncMock(return_value=[]))
+        monkeypatch.setattr(
+            rag, "_process_extract_entities", AsyncMock(return_value=[])
+        )
         monkeypatch.setattr(
             lightrag_module,
             "merge_nodes_and_edges",

--- a/tests/test_document_deletion_cleanup.py
+++ b/tests/test_document_deletion_cleanup.py
@@ -1,0 +1,139 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import numpy as np
+import pytest
+
+import lightrag.lightrag as lightrag_module
+from lightrag import LightRAG
+from lightrag.base import DocStatus
+from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+def _single_chunking_func(
+    tokenizer: Tokenizer,
+    content: str,
+    split_by_character: str | None,
+    split_by_character_only: bool,
+    chunk_overlap_token_size: int,
+    chunk_token_size: int,
+):
+    return [
+        {
+            "content": content,
+            "tokens": len(content),
+            "chunk_order_index": 0,
+        }
+    ]
+
+
+async def _dummy_llm(*args, **kwargs) -> str:
+    return "<|COMPLETE|>"
+
+
+async def _dummy_embed(texts: list[str], **kwargs) -> np.ndarray:
+    await asyncio.sleep(0)
+    return np.ones((len(texts), 4), dtype=np.float32)
+
+
+async def _make_rag(tmp_path: str, workspace: str) -> LightRAG:
+    tokenizer = Tokenizer("test-tokenizer", _SimpleTokenizerImpl())
+    rag = LightRAG(
+        working_dir=tmp_path,
+        workspace=workspace,
+        llm_model_func=_dummy_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=4,
+            max_token_size=8192,
+            func=_dummy_embed,
+            model_name="test-embedding",
+        ),
+        tokenizer=tokenizer,
+        chunking_func=_single_chunking_func,
+        max_parallel_insert=1,
+    )
+    await rag.initialize_storages()
+    return rag
+
+
+@pytest.mark.offline
+async def test_failed_doc_preserves_chunks_list_on_extraction_error(
+    tmp_path, monkeypatch
+):
+    rag = await _make_rag(str(tmp_path), workspace="ws_extract_fail")
+    try:
+        monkeypatch.setattr(
+            rag,
+            "_process_extract_entities",
+            AsyncMock(side_effect=RuntimeError("extract failed")),
+        )
+
+        content = "doc content that will fail during extraction stage"
+        await rag.ainsert(content)
+
+        doc_id = compute_mdhash_id(content, prefix="doc-")
+        doc_status = await rag.doc_status.get_by_id(doc_id)
+        assert doc_status is not None
+        assert doc_status["status"] == DocStatus.FAILED
+
+        chunk_ids = doc_status.get("chunks_list")
+        assert isinstance(chunk_ids, list)
+        assert chunk_ids, "FAILED doc should keep chunks_list for deletion cleanup"
+        assert doc_status.get("chunks_count") == len(chunk_ids)
+
+        first_chunk_id = chunk_ids[0]
+        assert await rag.text_chunks.get_by_id(first_chunk_id) is not None
+        assert await rag.chunks_vdb.get_by_id(first_chunk_id) is not None
+
+        cache_id = "cache-test-1"
+        chunk_data = await rag.text_chunks.get_by_id(first_chunk_id)
+        assert chunk_data is not None
+        chunk_data["llm_cache_list"] = [cache_id]
+        await rag.text_chunks.upsert({first_chunk_id: chunk_data})
+        await rag.llm_response_cache.upsert({cache_id: {"content": "cached"}})
+
+        result = await rag.adelete_by_doc_id(doc_id, delete_llm_cache=True)
+        assert result.status == "success"
+
+        assert await rag.text_chunks.get_by_id(first_chunk_id) is None
+        assert await rag.chunks_vdb.get_by_id(first_chunk_id) is None
+        assert await rag.llm_response_cache.get_by_id(cache_id) is None
+        assert await rag.doc_status.get_by_id(doc_id) is None
+        assert await rag.full_docs.get_by_id(doc_id) is None
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.offline
+async def test_failed_doc_preserves_chunks_list_on_merge_error(tmp_path, monkeypatch):
+    rag = await _make_rag(str(tmp_path), workspace="ws_merge_fail")
+    try:
+        monkeypatch.setattr(rag, "_process_extract_entities", AsyncMock(return_value=[]))
+        monkeypatch.setattr(
+            lightrag_module,
+            "merge_nodes_and_edges",
+            AsyncMock(side_effect=RuntimeError("merge failed")),
+        )
+
+        content = "doc content that will fail during merge stage"
+        await rag.ainsert(content)
+
+        doc_id = compute_mdhash_id(content, prefix="doc-")
+        doc_status = await rag.doc_status.get_by_id(doc_id)
+        assert doc_status is not None
+        assert doc_status["status"] == DocStatus.FAILED
+
+        chunk_ids = doc_status.get("chunks_list")
+        assert isinstance(chunk_ids, list)
+        assert chunk_ids, "FAILED doc should keep chunks_list for deletion cleanup"
+        assert doc_status.get("chunks_count") == len(chunk_ids)
+    finally:
+        await rag.finalize_storages()


### PR DESCRIPTION
Fixes #2442

### What
- Preserve doc_status.chunks_list/chunks_count when a document fails during extract or merge, so later deletion can remove associated chunks.
- Add offline regression tests covering extract-failure and merge-failure deletion + optional per-doc LLM cache cleanup.

### Why
Some DocStatusStorage adapters default missing chunks_list to an empty list on upsert. When a doc fails, the FAILED status update previously omitted chunks_list, which could overwrite a previously-recorded chunk list. Deletion then saw no chunks and skipped chunk cleanup.

### Tests
- uv run ruff check lightrag/lightrag.py tests/test_document_deletion_cleanup.py
- uv run pytest -m offline tests/test_document_deletion_cleanup.py