### PR TITLE
feat: Add POSTGRES_ENABLE_VECTOR option to conditionally disable pgvector extension

### DIFF
--- a/env.example
+++ b/env.example
@@ -405,6 +405,10 @@ POSTGRES_MAX_CONNECTIONS=12
 ### POSTGRES_WORKSPACE=forced_workspace_name
 
 ### PostgreSQL Vector Storage Configuration
+### Enable/disable vector features (default: true for backward compatibility)
+### Set to false to disable pgvector extension and vector operations when using PostgreSQL
+### only for KV/Graph/DocStatus storage with a different vector backend (e.g., Milvus, Qdrant)
+POSTGRES_ENABLE_VECTOR=true
 ### Vector storage type: HNSW, IVFFlat, VCHORDRQ
 POSTGRES_VECTOR_INDEX_TYPE=HNSW
 POSTGRES_HNSW_M=16


### PR DESCRIPTION
## Description

Adds a new `POSTGRES_ENABLE_VECTOR` configuration option to explicitly disable pgvector extension and vector operations when using PostgreSQL only for KV, Graph and DocStatus storage with an alternative vector backend (e.g., Milvus, Qdrant and etc.)

## Related Issues

LightRAG currently fails to initialize if PostgreSQL doesn't have pgvector extension installed, even when PGVectorStorage isn't being used (e.g., when using Milvus/Qdrant for vectors and PostgreSQL only for KV/Graph/DocStatus storage)

## Changes Made

- Added `POSTGRES_ENABLE_VECTOR` environment variable (defaults to `true` for backward compatibility)
- Added skip for bootstrap connection and extension creation when disabled when `POSTGRES_ENABLE_VECTOR` is set to `true`
- `register_vector()` only called when `POSTGRES_ENABLE_VECTOR` is set to `true`
- `PGVectorStorage.__post_init__()` raises `ValueError` if instantiated with vectors disabled
- Updated `env.example`

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)