### PR TITLE
fix(webui): make build runtime-agnostic by fixing Bun-only imports in…

### DIFF
--- a/docs/FrontendBuildGuide.md
+++ b/docs/FrontendBuildGuide.md
@@ -8,7 +8,7 @@ The LightRAG project includes a React-based WebUI frontend. This guide explains 
 
 - **Git Repository**: Frontend build results are **NOT** included (kept clean)
 - **PyPI Package**: Frontend build results **ARE** included (ready to use)
-- **Build Tool**: Uses **Bun** (not npm/yarn)
+- **Build Tool**: **Bun** is recommended, but **Node.js/npm** is fully supported as a fallback
 
 ## Installation Scenarios
 
@@ -193,7 +193,16 @@ cd lightrag_webui && bun run build
 
 ### Q: Can I use npm or yarn instead of Bun?
 
-**A:** The project is configured for Bun. While npm/yarn might work, Bun is recommended per project standards.
+**A:** Yes. The build scripts (`dev`, `build`, `preview`, `lint`) are runtime-agnostic and work with both Bun and Node.js/npm:
+```bash
+npm install
+npm run build
+```
+Bun is recommended for speed, but npm is fully supported. Tests (`bun test`) still require Bun.
+
+### Q: Build fails with `Cannot find package '@/lib'`
+
+**A:** This was caused by `vite.config.ts` using a TypeScript path alias (`@/`) that only Bun could resolve at config load time. Update to the latest version where this is fixed with a relative import.
 
 ---
 

--- a/lightrag_webui/README.md
+++ b/lightrag_webui/README.md
@@ -4,6 +4,8 @@ LightRAG WebUI is a React-based web interface for interacting with the LightRAG 
 
 ## Installation
 
+### Using Bun (recommended)
+
 1. **Install Bun:**
 
     If you haven't already installed Bun, follow the official documentation: [https://bun.sh/docs/installation](https://bun.sh/docs/installation)
@@ -26,21 +28,53 @@ LightRAG WebUI is a React-based web interface for interacting with the LightRAG 
 
     This command will bundle the project and output the built files to the `lightrag/api/webui` directory.
 
+### Using Node.js / npm (alternative)
+
+If Bun is unavailable or the Bun build fails in your environment (e.g., older Linux distributions, restricted environments, or Bun version incompatibilities), you can use Node.js instead:
+
+```bash
+npm install
+npm run build
+```
+
+> **Note:** Tests (`bun test`) still require Bun. All other scripts (`dev`, `build`, `preview`, `lint`) work with both Bun and Node.js/npm.
+
 ## Development
 
 - **Start the Development Server:**
 
-  If you want to run the WebUI in development mode, use the following command:
-
   ```bash
+  # With Bun
   bun run dev
+
+  # With Node.js/npm
+  npm run dev
   ```
 
 ## Script Commands
 
 The following are some commonly used script commands defined in `package.json`:
 
-- `bun install`: Installs project dependencies.
-- `bun run dev`: Starts the development server.
-- `bun run build`: Builds the project.
-- `bun run lint`: Runs the linter.
+| Command | Description |
+|---------|-------------|
+| `bun run dev` / `npm run dev` | Starts the development server |
+| `bun run build` / `npm run build` | Builds the project for production |
+| `bun run lint` / `npm run lint` | Runs the linter |
+| `bun run preview` / `npm run preview` | Previews the production build |
+| `bun run build:bun` | Builds using Bun runtime explicitly |
+| `bun test` | Runs tests (Bun only) |
+
+## Troubleshooting
+
+### `bun run build` fails silently or with exit code 1
+
+This can happen due to Bun version incompatibilities or restricted environments. Try:
+
+```bash
+npm install
+npm run build
+```
+
+### `Cannot find package '@/lib'`
+
+This error occurred in older versions when the Vite config used a TypeScript path alias (`@/`) that only Bun could resolve at config load time. This has been fixed by using a relative import in `vite.config.ts`.

--- a/lightrag_webui/package.json
+++ b/lightrag_webui/package.json
@@ -4,16 +4,16 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "bunx --bun vite",
-    "build": "bunx --bun vite build",
+    "dev": "vite",
+    "build": "vite build",
     "lint": "eslint .",
-    "preview": "bunx --bun vite preview",
+    "preview": "vite preview",
     "test": "bun test",
     "test:watch": "bun test --watch",
     "test:coverage": "bun test --coverage",
-    "dev-no-bun": "vite",
-    "build-no-bun": "vite build --emptyOutDir",
-    "preview-no-bun": "vite preview"
+    "dev:bun": "bunx --bun vite",
+    "build:bun": "bunx --bun vite build",
+    "preview:bun": "bunx --bun vite preview"
   },
   "dependencies": {
     "@faker-js/faker": "^10.2.0",

--- a/lightrag_webui/vite.config.ts
+++ b/lightrag_webui/vite.config.ts
@@ -1,52 +1,63 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import path from 'path'
-import { webuiPrefix } from '@/lib/constants'
 import react from '@vitejs/plugin-react-swc'
 import tailwindcss from '@tailwindcss/vite'
 
+// Use relative import instead of '@/lib/constants' path alias.
+// The '@' alias is configured in this file's resolve.alias and only takes effect
+// during bundling — Node.js cannot resolve it when loading vite.config.ts itself.
+// Bun resolves tsconfig paths natively, masking the issue, but Node.js does not.
+import { webuiPrefix } from './src/lib/constants'
+
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src')
+// Use functional config form so we can call loadEnv(). import.meta.env is only
+// available inside Bun's runtime; Node.js leaves it undefined, crashing the build.
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+
+  return {
+    plugins: [react(), tailwindcss()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src')
+      },
+      // Force all modules to use the same katex instance
+      // This ensures mhchem extension registered in main.tsx is available to rehype-katex
+      dedupe: ['katex']
     },
-    // Force all modules to use the same katex instance
-    // This ensures mhchem extension registered in main.tsx is available to rehype-katex
-    dedupe: ['katex']
-  },
-  // base: import.meta.env.VITE_BASE_URL || '/webui/',
-  base: webuiPrefix,
-  build: {
-    outDir: path.resolve(__dirname, '../lightrag/api/webui'),
-    emptyOutDir: true,
-    chunkSizeWarningLimit: 3800,
-    rollupOptions: {
-      // Let Vite handle chunking automatically to avoid circular dependency issues
-      output: {
-        // Ensure consistent chunk naming format
-        chunkFileNames: 'assets/[name]-[hash].js',
-        // Entry file naming format
-        entryFileNames: 'assets/[name]-[hash].js',
-        // Asset file naming format
-        assetFileNames: 'assets/[name]-[hash].[ext]'
+    // base: env.VITE_BASE_URL || '/webui/',
+    base: webuiPrefix,
+    build: {
+      outDir: path.resolve(__dirname, '../lightrag/api/webui'),
+      emptyOutDir: true,
+      chunkSizeWarningLimit: 3800,
+      rollupOptions: {
+        // Let Vite handle chunking automatically to avoid circular dependency issues
+        output: {
+          // Ensure consistent chunk naming format
+          chunkFileNames: 'assets/[name]-[hash].js',
+          // Entry file naming format
+          entryFileNames: 'assets/[name]-[hash].js',
+          // Asset file naming format
+          assetFileNames: 'assets/[name]-[hash].[ext]'
+        }
       }
+    },
+    server: {
+      proxy: env.VITE_API_PROXY === 'true' && env.VITE_API_ENDPOINTS ?
+        Object.fromEntries(
+          env.VITE_API_ENDPOINTS.split(',').map(endpoint => [
+            endpoint,
+            {
+              target: env.VITE_BACKEND_URL || 'http://localhost:9621',
+              changeOrigin: true,
+              rewrite: endpoint === '/api' ?
+                (p: string) => p.replace(/^\/api/, '') :
+                endpoint === '/docs' || endpoint === '/redoc' || endpoint === '/openapi.json' || endpoint === '/static' ?
+                  (p: string) => p : undefined
+            }
+          ])
+        ) : {}
     }
-  },
-  server: {
-    proxy: import.meta.env.VITE_API_PROXY === 'true' && import.meta.env.VITE_API_ENDPOINTS ?
-      Object.fromEntries(
-        import.meta.env.VITE_API_ENDPOINTS.split(',').map(endpoint => [
-          endpoint,
-          {
-            target: import.meta.env.VITE_BACKEND_URL || 'http://localhost:9621',
-            changeOrigin: true,
-            rewrite: endpoint === '/api' ?
-              (path) => path.replace(/^\/api/, '') :
-              endpoint === '/docs' || endpoint === '/redoc' || endpoint === '/openapi.json' || endpoint === '/static' ?
-                (path) => path : undefined
-          }
-        ])
-      ) : {}
   }
 })


### PR DESCRIPTION
Description

WebUI build fails silently (exit code 1 or 127) in environments where Bun is unavailable, incompatible, or not on PATH. Two root causes in vite.config.ts make the build Bun-only despite Vite itself being runtime-agnostic:
	•	@/lib/constants path alias import — Node.js cannot resolve tsconfig path aliases at config load time; Bun masks this by resolving them natively
	•	import.meta.env usage — only populated inside Bun’s runtime; Node.js leaves it undefined, crashing the config

This PR fixes both issues and makes the default build scripts runtime-agnostic so npm run build works out of the box.

Related Issues

Fixes: [Bug]: bun run build error: script “build” exited with code 1 (Nov 2025)
Affects users on CentOS/older Linux, restricted temp dir permissions, or environments where Bun is not installed

Changes Made

vite.config.ts
	•	Replace import { webuiPrefix } from '@/lib/constants' with relative import './src/lib/constants' — the @ alias is defined inside this config, so it can’t resolve itself
	•	Replace import.meta.env references with Vite’s official loadEnv() API using functional defineConfig(({ mode }) => ...) form
	•	Import loadEnv from vite

package.json
	•	Make default scripts runtime-agnostic: "build": "vite build" instead of "build": "bunx --bun vite build"
	•	Rename old *-no-bun scripts to *:bun variants (build:bun, dev:bun, preview:bun) for explicit Bun runtime usage
	•	dev, build, preview, lint now work with both bun run and npm run

README.md
	•	Add Using Node.js / npm (alternative) installation section
	•	Add troubleshooting section for common build failures
	•	Update script commands table to show both bun and npm usage

FrontendBuildGuide.md
	•	Update “Key Principle” to note npm is fully supported as fallback
	•	Expand FAQ: Can I use npm? → Yes, with instructions
	•	Add FAQ entry for Cannot find package '@/lib' error

Checklist
	•	Changes tested locally
	•	Code reviewed
	•	Documentation updated (if necessary)
	•	Unit tests added (if applicable)

Additional Notes

Verified all three build paths succeed after changes: bun run build, npm run build, npx vite build
No new lint errors introduced (pre-existing lint warnings are unrelated)
Tests (bun test) still require Bun — only build/dev/preview scripts are made agnostic
Zero architecture risk: only config-level changes, no application code modified