### PR TITLE
perf: use deque for BFS queue in get_knowledge_subgraph()

### DIFF
--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -1,4 +1,5 @@
 import os
+from collections import deque
 from dataclasses import dataclass
 from typing import final
 
@@ -352,7 +353,7 @@ class NetworkXStorage(BaseGraphStorage):
             bfs_nodes = []
             visited = set()
             # Store (node, depth, degree) in the queue
-            queue = [(node_label, 0, graph.degree(node_label))]
+            queue = deque([(node_label, 0, graph.degree(node_label))])
 
             # Flag to track if there are unexplored neighbors due to depth limit
             has_unexplored_neighbors = False
@@ -365,7 +366,7 @@ class NetworkXStorage(BaseGraphStorage):
                 # Collect all nodes at the current depth
                 current_level_nodes = []
                 while queue and queue[0][1] == current_depth:
-                    current_level_nodes.append(queue.pop(0))
+                    current_level_nodes.append(queue.popleft())
 
                 # Sort nodes at current depth by degree (highest first)
                 current_level_nodes.sort(key=lambda x: x[2], reverse=True)


### PR DESCRIPTION
## Problem

`get_knowledge_subgraph()` in `NetworkXStorage` uses `list.pop(0)` to drain the BFS queue, which is **O(n)** per removal. For large knowledge graphs with many nodes, the traversal becomes **O(n²)**.

## Solution

Switch to `collections.deque` with `.popleft()` for **O(1)** front removal while keeping identical `.append()` semantics.

## Changes

- `lightrag/kg/networkx_impl.py`:
  - Import `deque` from `collections`
  - Initialize queue as `deque([...])` instead of list
  - `.pop(0)` → `.popleft()`

## Testing

- Module imports cleanly
- Syntax verified via `ast.parse()`