### PR TITLE
fix: add opt-in allow_extra_vectors flag for vector count mismatch

### DIFF
--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -436,6 +436,9 @@ class EmbeddingFunc:
         max_token_size: Enable embedding token limit checking for description summarization(Set embedding_token_limit in LightRAG)
         send_dimensions: Whether to inject embedding_dim argument to underlying function
         model_name: Model name for implementing workspace data isolation in vector DB
+        allow_extra_vectors: When True, silently slice overflow vectors instead of raising.
+            Only enable this for providers known to safely append extra padding vectors
+            (e.g. multimodal parsers that split images into extra embeddings). Default False.
     """
 
     embedding_dim: int
@@ -445,6 +448,7 @@ class EmbeddingFunc:
     model_name: str | None = (
         None  # Model name for implementing workspace data isolation in vector DB
     )
+    allow_extra_vectors: bool = False
 
     def __post_init__(self):
         """Unwrap nested EmbeddingFunc to prevent double wrapping issues.
@@ -514,15 +518,29 @@ class EmbeddingFunc:
                 f"expected dimension ({expected_dim}). "
             )
 
-        # Optional: Verify vector count matches input text count
+        # Verify vector count matches input text count
         actual_vectors = total_elements // expected_dim
         if args and isinstance(args[0], (list, tuple)):
             expected_vectors = len(args[0])
             if actual_vectors != expected_vectors:
-                raise ValueError(
-                    f"Vector count mismatch: "
-                    f"expected {expected_vectors} vectors but got {actual_vectors} vectors (from embedding result)."
-                )
+                provider = self.model_name or "unknown"
+                if actual_vectors > expected_vectors and self.allow_extra_vectors:
+                    logger.warning(
+                        f"Vector count mismatch (provider={provider}): "
+                        f"expected {expected_vectors} vectors for "
+                        f"{expected_vectors} inputs but got {actual_vectors}. "
+                        f"Slicing to first {expected_vectors} vectors "
+                        f"(allow_extra_vectors=True)."
+                    )
+                    result = result.reshape(-1, expected_dim)[:expected_vectors]
+                else:
+                    raise ValueError(
+                        f"Vector count mismatch (provider={provider}): "
+                        f"expected {expected_vectors} vectors for "
+                        f"{expected_vectors} inputs but got {actual_vectors}. "
+                        f"If this provider is known to return extra padding "
+                        f"vectors, set allow_extra_vectors=True on EmbeddingFunc."
+                    )
 
         return result
 

--- a/tests/test_vector_count_mismatch.py
+++ b/tests/test_vector_count_mismatch.py
@@ -1,0 +1,94 @@
+"""
+Tests for vector count mismatch handling in EmbeddingFunc.
+
+Verifies that vector count mismatches raise ValueError by default,
+and that the opt-in allow_extra_vectors flag enables safe slicing
+for providers known to return extra padding vectors.
+"""
+
+import numpy as np
+import pytest
+
+from lightrag.utils import EmbeddingFunc
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_overflow_raises_by_default():
+    """Overflow raises ValueError when allow_extra_vectors is False (default)."""
+
+    async def mock_embed(texts, **kwargs):
+        dim = kwargs.get("embedding_dim", 128)
+        return np.random.rand(len(texts) * 2, dim).astype(np.float32)
+
+    func = EmbeddingFunc(embedding_dim=128, func=mock_embed, model_name="test-model")
+    with pytest.raises(ValueError, match="allow_extra_vectors"):
+        await func(["hello", "world"])
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_overflow_slices_with_opt_in():
+    """Overflow slices to expected count when allow_extra_vectors=True."""
+
+    async def mock_embed(texts, **kwargs):
+        dim = kwargs.get("embedding_dim", 128)
+        return np.random.rand(len(texts) * 2, dim).astype(np.float32)
+
+    func = EmbeddingFunc(
+        embedding_dim=128,
+        func=mock_embed,
+        model_name="test-model",
+        allow_extra_vectors=True,
+    )
+    result = await func(["hello", "world"])
+    assert result.shape == (2, 128)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_underflow_raises_even_with_opt_in():
+    """Underflow always raises ValueError, even with allow_extra_vectors=True."""
+
+    async def mock_embed(texts, **kwargs):
+        dim = kwargs.get("embedding_dim", 128)
+        return np.random.rand(1, dim).astype(np.float32)
+
+    func = EmbeddingFunc(
+        embedding_dim=128,
+        func=mock_embed,
+        model_name="test-model",
+        allow_extra_vectors=True,
+    )
+    with pytest.raises(ValueError, match="Vector count mismatch"):
+        await func(["hello", "world", "foo"])
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_vector_count_match_passes():
+    """When vector count matches, result is returned unchanged."""
+
+    async def mock_embed(texts, **kwargs):
+        dim = kwargs.get("embedding_dim", 128)
+        return np.random.rand(len(texts), dim).astype(np.float32)
+
+    func = EmbeddingFunc(embedding_dim=128, func=mock_embed, model_name="test-model")
+    result = await func(["hello", "world"])
+    assert result.shape == (2, 128)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_error_message_includes_provider_name():
+    """Error message includes provider name, batch size, and counts."""
+
+    async def mock_embed(texts, **kwargs):
+        dim = kwargs.get("embedding_dim", 128)
+        return np.random.rand(len(texts) * 3, dim).astype(np.float32)
+
+    func = EmbeddingFunc(embedding_dim=128, func=mock_embed, model_name="azure-openai")
+    with pytest.raises(ValueError, match="azure-openai") as exc_info:
+        await func(["a", "b"])
+    assert "expected 2" in str(exc_info.value)
+    assert "got 6" in str(exc_info.value)


### PR DESCRIPTION
## Description

When embedding functions return more vectors than expected (common with multimodal parsers like MinerU), the strict validation in `EmbeddingFunc.__call__` raises a `ValueError` that crashes the entire pipeline.

Instead of silently slicing (which risks silent data corruption if vectors are reordered/interleaved), this adds an explicit **opt-in flag** so the behavior is auditable:

- **Default** (`allow_extra_vectors=False`): raises `ValueError` with a detailed message naming the provider, batch size, and actual vs expected count. The error suggests setting `allow_extra_vectors=True` if appropriate.
- **Opt-in** (`allow_extra_vectors=True`): logs a warning and slices to expected count, for providers known to safely append extra padding vectors.

## Related Issues

Fixes #2549

## Changes Made

- **`lightrag/utils.py`**: Added `allow_extra_vectors: bool = False` field to `EmbeddingFunc`. Vector count mismatch now raises `ValueError` by default with detailed diagnostics. When opted in, reshapes to 2D and slices overflow vectors.
- **`tests/test_vector_count_mismatch.py`**: 5 tests covering default raise, opt-in slicing, underflow always raises, match passes, and error message content.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Addresses review feedback: the core approach is now **fail-fast by default** with an explicit opt-in escape hatch, rather than silently slicing at the shared `EmbeddingFunc.__call__` layer. This eliminates the silent data corruption risk across all six storage backends while still providing a documented path for providers known to return extra padding vectors.