### PR TITLE
fix(api): allow deleting non-processing documents while pipeline is busy

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -2855,11 +2855,19 @@ def create_document_routes(
             # Check if pipeline is busy with proper lock
             async with pipeline_status_lock:
                 if pipeline_status.get("busy", False):
-                    return DeleteDocByIdResponse(
-                        status="busy",
-                        message="Cannot delete documents while pipeline is busy",
-                        doc_id=", ".join(doc_ids),
-                    )
+                    # Allow deletion of documents not currently being processed
+                    docs = await rag.doc_status.get_by_ids(doc_ids)
+                    processing_ids = [
+                        d["doc_id"]
+                        for d in docs
+                        if d and d.get("status") == DocStatus.PROCESSING
+                    ]
+                    if processing_ids:
+                        return DeleteDocByIdResponse(
+                            status="busy",
+                            message=f"Cannot delete documents currently being processed: {', '.join(processing_ids)}",
+                            doc_id=", ".join(processing_ids),
+                        )
 
             # Add deletion task to background tasks
             background_tasks.add_task(


### PR DESCRIPTION
## Description

The `DELETE /documents/delete_document` endpoint unconditionally rejects all deletion requests when `pipeline_busy` is `True`. This blocks deletion of documents with `status: "failed"` or `status: "processed"` that are not actively being processed.

## Related Issues

Fixes #2690

## Changes Made

- **`lightrag/api/routers/document_routes.py`**: In the `delete_document` endpoint, when the pipeline is busy, check each requested document's status via `rag.doc_status.get_by_ids()`. Only block deletion for documents with `status == DocStatus.PROCESSING`. Documents with failed/processed/pending status can be deleted regardless of pipeline state.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

The bulk `DELETE /documents` (clear all) endpoint is left unchanged — it still requires the pipeline to be idle. This change only affects individual document deletion via `/delete_document`.