### PR TITLE
fix(graph): preserve custom properties in acreate_entity

### DIFF
--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -970,6 +970,7 @@ async def acreate_entity(
             # GraphML compatibility (NetworkX write_graphml requires scalar attrs)
             _reserved_keys = {
                 "entity_name",
+                "entity_id",
                 "entity_type",
                 "description",
                 "source_id",

--- a/tests/test_entity_custom_props.py
+++ b/tests/test_entity_custom_props.py
@@ -110,3 +110,24 @@ async def test_reserved_keys_not_overwritten(storage):
         )
     node = graph._nodes["TestEntity3"]
     assert node["created_at"] != 999  # computed timestamp, not the input
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_entity_id_not_overwritten(storage):
+    """entity_id is reserved and cannot be overridden by custom payload."""
+    graph, entities_vdb, relationships_vdb = storage
+    entity_data = {
+        "entity_type": "PERSON",
+        "description": "Trying to override entity_id",
+        "entity_id": "MALICIOUS_ID",
+    }
+    with (
+        patch("lightrag.utils_graph.get_storage_keyed_lock", _noop_lock),
+        patch("lightrag.utils_graph.get_entity_info", new_callable=AsyncMock),
+    ):
+        await acreate_entity(
+            graph, entities_vdb, relationships_vdb, "TestEntity4", entity_data
+        )
+    node = graph._nodes["TestEntity4"]
+    assert node["entity_id"] == "TestEntity4"  # canonical ID, not the payload


### PR DESCRIPTION
## Description

When creating entities via the REST API (`acreate_entity`), user-supplied custom properties beyond the reserved keys (`entity_type`, `description`, `source_id`, `file_path`, `created_at`) were silently dropped. This PR passes them through to the graph node data, with JSON serialization for complex types (list, dict) to maintain GraphML compatibility.

## Related Issues

Fixes #2101

## Changes Made

- **`lightrag/utils_graph.py`**: After building the default `node_data` dict in `acreate_entity()`, iterate over `entity_data` and copy any non-reserved keys into `node_data`. Lists and dicts are JSON-serialized to satisfy NetworkX `write_graphml` scalar-attribute requirement.
- **`tests/test_entity_custom_props.py`**: Added 3 offline tests covering scalar pass-through, complex type serialization, and reserved-key protection.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

This is consistent with how `ainsert_custom_kg()` already handles custom fields for both entities and relationships.