### PR TITLE
feat(config): add ENABLE_CITATIONS environment variable

### DIFF
--- a/env.example
+++ b/env.example
@@ -81,6 +81,7 @@ OLLAMA_EMULATING_MODEL_TAG=latest
 ######################################################################################
 # LLM response cache for query (Not valid for streaming response)
 ENABLE_LLM_CACHE=true
+# ENABLE_CITATIONS=true
 # COSINE_THRESHOLD=0.2
 ### Number of entities or relations retrieved from KG
 # TOP_K=40

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -374,6 +374,7 @@ def parse_args() -> argparse.Namespace:
         "ENABLE_LLM_CACHE_FOR_EXTRACT", True, bool
     )
     args.enable_llm_cache = get_env_value("ENABLE_LLM_CACHE", True, bool)
+    args.enable_citations = get_env_value("ENABLE_CITATIONS", True, bool)
 
     # Set document_loading_engine from --docling flag
     if args.docling:

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -1078,6 +1078,7 @@ def create_app(args):
             },
             enable_llm_cache_for_entity_extract=args.enable_llm_cache_for_extract,
             enable_llm_cache=args.enable_llm_cache,
+            enable_citations=args.enable_citations,
             rerank_model_func=rerank_model_func,
             max_parallel_insert=args.max_parallel_insert,
             max_graph_nodes=args.max_graph_nodes,
@@ -1272,6 +1273,7 @@ def create_app(args):
                     "vector_storage": args.vector_storage,
                     "enable_llm_cache_for_extract": args.enable_llm_cache_for_extract,
                     "enable_llm_cache": args.enable_llm_cache,
+                    "enable_citations": args.enable_citations,
                     "workspace": default_workspace,
                     "max_graph_nodes": args.max_graph_nodes,
                     # Rerank configuration

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -376,6 +376,9 @@ class LightRAG:
     enable_llm_cache_for_entity_extract: bool = field(default=True)
     """If True, enables caching for entity extraction steps to reduce LLM costs."""
 
+    enable_citations: bool = field(default=True)
+    """If True, includes citation references in query responses."""
+
     # Extensions
     # ---
 

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -4032,25 +4032,28 @@ async def _build_context_str(
         truncated_chunks
     )
 
+    enable_citations = global_config.get("enable_citations", True)
+
     # Rebuild chunks_context with truncated chunks
     # The actual tokens may be slightly less than available_chunk_tokens due to deduplication logic
     chunks_context = []
     for i, chunk in enumerate(truncated_chunks):
-        chunks_context.append(
-            {
-                "reference_id": chunk["reference_id"],
-                "content": chunk["content"],
-            }
-        )
+        entry = {"content": chunk["content"]}
+        if enable_citations:
+            entry["reference_id"] = chunk["reference_id"]
+        chunks_context.append(entry)
 
     text_units_str = "\n".join(
         json.dumps(text_unit, ensure_ascii=False) for text_unit in chunks_context
     )
-    reference_list_str = "\n".join(
-        f"[{ref['reference_id']}] {ref['file_path']}"
-        for ref in reference_list
-        if ref["reference_id"]
-    )
+    if enable_citations:
+        reference_list_str = "\n".join(
+            f"[{ref['reference_id']}] {ref['file_path']}"
+            for ref in reference_list
+            if ref["reference_id"]
+        )
+    else:
+        reference_list_str = ""
 
     logger.info(
         f"Final context: {len(entities_context)} entities, {len(relations_context)} relations, {len(chunks_context)} chunks"
@@ -4953,24 +4956,27 @@ async def naive_query(
         "final_chunks_count": len(processed_chunks_with_ref_ids),
     }
 
+    enable_citations = global_config.get("enable_citations", True)
+
     # Build chunks_context from processed chunks with reference IDs
     chunks_context = []
     for i, chunk in enumerate(processed_chunks_with_ref_ids):
-        chunks_context.append(
-            {
-                "reference_id": chunk["reference_id"],
-                "content": chunk["content"],
-            }
-        )
+        entry = {"content": chunk["content"]}
+        if enable_citations:
+            entry["reference_id"] = chunk["reference_id"]
+        chunks_context.append(entry)
 
     text_units_str = "\n".join(
         json.dumps(text_unit, ensure_ascii=False) for text_unit in chunks_context
     )
-    reference_list_str = "\n".join(
-        f"[{ref['reference_id']}] {ref['file_path']}"
-        for ref in reference_list
-        if ref["reference_id"]
-    )
+    if enable_citations:
+        reference_list_str = "\n".join(
+            f"[{ref['reference_id']}] {ref['file_path']}"
+            for ref in reference_list
+            if ref["reference_id"]
+        )
+    else:
+        reference_list_str = ""
 
     naive_context_template = PROMPTS["naive_query_context"]
     context_content = naive_context_template.format(


### PR DESCRIPTION
## Description

Add an `ENABLE_CITATIONS` environment variable (default `true`) that controls whether citation references are included in query responses. When set to `false`, the reference list and `reference_id` fields are omitted from the LLM context, producing cleaner answers without source citations. Useful for Docker-based deployments where only `.env` configuration is available.

## Related Issues

Fixes #2097

## Changes Made

- **`lightrag/lightrag.py`**: Added `enable_citations: bool` field (default `True`) to the `LightRAG` dataclass
- **`lightrag/api/config.py`**: Parse `ENABLE_CITATIONS` env var via `get_env_value()`
- **`lightrag/api/lightrag_server.py`**: Wire `enable_citations` through to the `LightRAG` instance and debug log
- **`lightrag/operate.py`**: Conditionally skip reference list generation and `reference_id` in chunk context for both KG and naive query paths when citations are disabled
- **`env.example`**: Added commented `ENABLE_CITATIONS` entry

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Follows the same pattern as the existing `ENABLE_LLM_CACHE` / `ENABLE_LLM_CACHE_FOR_EXTRACT` configuration flags. Default is `true` so existing behavior is unchanged.