### PR TITLE
perf(postgres): optimize KV storage upsert using executemany

### DIFF
--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -2324,9 +2324,14 @@ class PGKVStorage(BaseKVStorage):
 
         # upsert_sql is always set here; unknown namespace raises ValueError above
         if batch_values:
-            await self.db.executemany(upsert_sql, batch_values)
+            # Chunking batch_values into smaller sub-batches to prevent database overload
+            for i in range(0, len(batch_values), self._max_batch_size):
+                sub_batch = batch_values[i : i + self._max_batch_size]
+                await self.db.executemany(upsert_sql, sub_batch)
+
             logger.debug(
-                f"[{self.workspace}] Batch upserted {len(batch_values)} records to {self.namespace}"
+                f"[{self.workspace}] Batch upserted {len(batch_values)} records to {self.namespace} "
+                f"in {-(len(batch_values) // -self._max_batch_size)} sub-batches"
             )
 
     async def index_done_callback(self) -> None:


### PR DESCRIPTION
## Description

This PR optimizes the document ingestion performance for Postgres-based storage by introducing batch processing
for Key-Value (KV) storage operations. By replacing individual INSERT calls in a loop with executemany and implementing a robust sub-batching mechanism.

it addresses performance bottlenecks where small documents (e.g., <300kB) took several minutes to process.

## Changes

 - `PostgreSQLDB.executemany` Implementation: Added a dedicated method to the PostgreSQLDB class to support asyncpg's batch execution, ensuring efficient data transmission to Postgres.
 - Refactored `PGKVStorage.upsert`: Updated the upsert logic for all namespaces (TEXT_CHUNKS, FULL_DOCS, LLM_CACHE, etc.) to collect data into tuples and execute them in a single batch.
 - Sub-batching (Chunking) Logic: Introduced a mechanism to split large data sets into smaller sub-batches (defined by _max_batch_size). This prevents memory spikes and database transaction timeouts when processing massive documents.

## Checklist

 - [x] Changes tested locally
 - [x] Code reviewed
 - [ ] Documentation updated (if necessary)
 - [ ] Unit tests added (if applicable)

## Additional Notes

The sub-batching unit is currently synchronized with the embedding_batch_num (default 10-50), which provides a balanced load for both the LLM embedding phase and the subsequent database write phase.

This PR and PR summary were created with the help of Gemini, with some additional modifications.