### PR TITLE
fix: preserve failed-doc chunk metadata for reliable deletion cleanup

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -126,6 +126,28 @@ config = configparser.ConfigParser()
 config.read("config.ini", "utf-8")
 
 
+def _chunk_fields_from_status_doc(
+    status_doc: "DocProcessingStatus",
+) -> tuple[list[str], int]:
+    """Return (chunks_list, chunks_count) preserved from a status document.
+
+    Filters out any non-string or empty chunk IDs.  When chunks_count is
+    absent or invalid, it is inferred from the length of chunks_list.
+    """
+    chunks_list: list[str] = []
+    if isinstance(status_doc.chunks_list, list):
+        chunks_list = [
+            chunk_id
+            for chunk_id in status_doc.chunks_list
+            if isinstance(chunk_id, str) and chunk_id
+        ]
+
+    if isinstance(status_doc.chunks_count, int) and status_doc.chunks_count >= 0:
+        return chunks_list, status_doc.chunks_count
+
+    return chunks_list, len(chunks_list)
+
+
 @final
 @dataclass
 class LightRAG:
@@ -1603,22 +1625,6 @@ class LightRAG:
         docs_to_reset = {}
         reset_count = 0
 
-        def get_preserved_chunk_fields(
-            status_doc: DocProcessingStatus,
-        ) -> tuple[list[str], int]:
-            preserved_chunks_list: list[str] = []
-            if isinstance(status_doc.chunks_list, list):
-                preserved_chunks_list = [
-                    chunk_id
-                    for chunk_id in status_doc.chunks_list
-                    if isinstance(chunk_id, str) and chunk_id
-                ]
-
-            if isinstance(status_doc.chunks_count, int) and status_doc.chunks_count >= 0:
-                return preserved_chunks_list, status_doc.chunks_count
-
-            return preserved_chunks_list, len(preserved_chunks_list)
-
         for doc_id, status_doc in to_process_docs.items():
             # Check if document has corresponding content in full_docs (consistency check)
             content_data = await self.full_docs.get_by_id(doc_id)
@@ -1629,7 +1635,7 @@ class LightRAG:
                     DocStatus.FAILED,
                 ]:
                     preserved_chunks_list, preserved_chunks_count = (
-                        get_preserved_chunk_fields(status_doc)
+                        _chunk_fields_from_status_doc(status_doc)
                     )
                     # Prepare document for status reset to PENDING
                     docs_to_reset[doc_id] = {
@@ -1824,22 +1830,7 @@ class LightRAG:
                         if chunks:
                             chunk_ids = list(chunks.keys())
                             return chunk_ids, len(chunk_ids)
-
-                        preserved_chunk_ids: list[str] = []
-                        if isinstance(status_doc.chunks_list, list):
-                            preserved_chunk_ids = [
-                                chunk_id
-                                for chunk_id in status_doc.chunks_list
-                                if isinstance(chunk_id, str) and chunk_id
-                            ]
-
-                        if (
-                            isinstance(status_doc.chunks_count, int)
-                            and status_doc.chunks_count >= 0
-                        ):
-                            return preserved_chunk_ids, status_doc.chunks_count
-
-                        return preserved_chunk_ids, len(preserved_chunk_ids)
+                        return _chunk_fields_from_status_doc(status_doc)
 
                     async with semaphore:
                         nonlocal processed_count

--- a/tests/test_doc_status_chunk_preservation.py
+++ b/tests/test_doc_status_chunk_preservation.py
@@ -133,7 +133,9 @@ async def test_extract_failure_preserves_chunks_and_allows_delete_with_cache_cle
 
         deleted_chunks = await rag.text_chunks.get_by_ids(chunk_ids)
         assert all(item is None for item in deleted_chunks)
-        deleted_cache = [await rag.llm_response_cache.get_by_id(cid) for cid in cache_ids]
+        deleted_cache = [
+            await rag.llm_response_cache.get_by_id(cid) for cid in cache_ids
+        ]
         assert all(item is None for item in deleted_cache)
         assert await rag.doc_status.get_by_id(doc_id) is None
     finally:
@@ -141,7 +143,9 @@ async def test_extract_failure_preserves_chunks_and_allows_delete_with_cache_cle
 
 
 @pytest.mark.asyncio
-async def test_extract_failure_before_chunking_preserves_previous_chunk_snapshot(tmp_path):
+async def test_extract_failure_before_chunking_preserves_previous_chunk_snapshot(
+    tmp_path,
+):
     rag = await _build_rag(tmp_path, "extract_failure_pre_chunking", _failing_chunking)
     try:
         content = "chunking failure document"
@@ -185,7 +189,9 @@ async def test_extract_failure_before_chunking_preserves_previous_chunk_snapshot
 async def test_merge_failure_preserves_chunks_and_skip_cache_cleanup_when_disabled(
     tmp_path, monkeypatch
 ):
-    rag = await _build_rag(tmp_path, "merge_failure_keep_cache", _deterministic_chunking)
+    rag = await _build_rag(
+        tmp_path, "merge_failure_keep_cache", _deterministic_chunking
+    )
     try:
         content = "merge failure document"
         file_path = "merge_failure.txt"
@@ -214,7 +220,9 @@ async def test_merge_failure_preserves_chunks_and_skip_cache_cleanup_when_disabl
         result = await rag.adelete_by_doc_id(doc_id, delete_llm_cache=False)
         assert result.status == "success"
 
-        remaining_cache = [await rag.llm_response_cache.get_by_id(cid) for cid in cache_ids]
+        remaining_cache = [
+            await rag.llm_response_cache.get_by_id(cid) for cid in cache_ids
+        ]
         assert all(item is not None for item in remaining_cache)
     finally:
         await rag.finalize_storages()


### PR DESCRIPTION
## Description

This PR fixes a document status regression where `chunks_list`/`chunks_count` could be overwritten during failure transitions, causing `adelete_by_doc_id` to miss chunk cleanup for failed documents.

The update ensures chunk metadata is preserved across extract/merge failure paths and when resetting `FAILED`/`PROCESSING` docs back to `PENDING` during consistency repair.

## Related Issues

Fix:  #2442

## Changes Made

- Preserve chunk metadata in failure status updates:
  - Add a failure snapshot helper in `process_document` that prefers current in-memory chunks, then falls back to existing `status_doc.chunks_list/chunks_count`.
  - Apply this logic to both extract-stage failure and merge-stage failure upserts.
- Preserve chunk metadata during status reset:
  - In `_validate_and_fix_document_consistency`, keep `chunks_list/chunks_count` when resetting `FAILED`/`PROCESSING` docs to `PENDING`.
  - Infer `chunks_count` from `chunks_list` when count is missing.
- Avoid adapter-default overwrite on failed synthetic docs:
  - Explicitly set `chunks_count=0` and `chunks_list=[]` for duplicate/error failed document records.
- Add offline unit tests (`tests/test_doc_status_chunk_preservation.py`) to verify:
  - Extract failure after chunk creation preserves chunk metadata and allows deletion + optional per-doc LLM cache cleanup.
  - Extract failure before chunk creation preserves previously recorded chunk metadata.
  - Merge failure preserves chunk metadata and respects `delete_llm_cache=False` behavior.
  - Consistency reset (`FAILED/PROCESSING -> PENDING`) preserves chunk metadata.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Local validation performed:

- `ruff check lightrag/lightrag.py tests/test_doc_status_chunk_preservation.py`
- `.venv/bin/python -m pytest tests/test_doc_status_chunk_preservation.py -q`

Both commands passed.
