### PR TITLE
feat(kg): support optional label property as display name for graph nodes

### DIFF
--- a/lightrag/kg/memgraph_impl.py
+++ b/lightrag/kg/memgraph_impl.py
@@ -333,7 +333,7 @@ class MemgraphStorage(BaseGraphStorage):
                 query = f"""
                 MATCH (n:`{workspace_label}`)
                 WHERE n.entity_id IS NOT NULL
-                RETURN DISTINCT n.entity_id AS label
+                RETURN DISTINCT COALESCE(n.label, n.entity_id) AS label
                 ORDER BY label
                 """
                 result = await session.run(query)
@@ -952,7 +952,7 @@ class MemgraphStorage(BaseGraphStorage):
                             result.nodes.append(
                                 KnowledgeGraphNode(
                                     id=f"{node_id}",
-                                    labels=[node.get("entity_id")],
+                                    labels=[node.get("label") or node.get("entity_id")],
                                     properties=dict(node),
                                 )
                             )
@@ -1066,7 +1066,7 @@ class MemgraphStorage(BaseGraphStorage):
                 MATCH (n:`{workspace_label}`)
                 WHERE n.entity_id IS NOT NULL
                 OPTIONAL MATCH (n)-[r]-()
-                WITH n.entity_id AS label, count(r) AS degree
+                WITH COALESCE(n.label, n.entity_id) AS label, count(r) AS degree
                 ORDER BY degree DESC, label ASC
                 LIMIT {limit}
                 RETURN label
@@ -1116,7 +1116,7 @@ class MemgraphStorage(BaseGraphStorage):
                 cypher_query = f"""
                 MATCH (n:`{workspace_label}`)
                 WHERE n.entity_id IS NOT NULL
-                WITH n.entity_id AS label, toLower(n.entity_id) AS label_lower
+                WITH COALESCE(n.label, n.entity_id) AS label, toLower(COALESCE(n.label, n.entity_id)) AS label_lower
                 WHERE label_lower CONTAINS $query_lower
                 WITH label, label_lower,
                      CASE

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -1118,11 +1118,14 @@ class MongoGraphStorage(BaseGraphStorage):
         """
 
         # Use aggregation with allowDiskUse for large datasets
-        pipeline = [{"$project": {"_id": 1}}, {"$sort": {"_id": 1}}]
+        pipeline = [
+            {"$project": {"label": {"$ifNull": ["$label", "$_id"]}}},
+            {"$sort": {"label": 1}},
+        ]
         cursor = await self.collection.aggregate(pipeline, allowDiskUse=True)
         labels = []
         async for doc in cursor:
-            labels.append(doc["_id"])
+            labels.append(doc["label"])
         return labels
 
     def _construct_graph_node(
@@ -1130,7 +1133,7 @@ class MongoGraphStorage(BaseGraphStorage):
     ) -> KnowledgeGraphNode:
         return KnowledgeGraphNode(
             id=node_id,
-            labels=[node_id],
+            labels=[node_data.get("label", node_id)],
             properties={
                 k: v
                 for k, v in node_data.items()
@@ -1655,13 +1658,33 @@ class MongoGraphStorage(BaseGraphStorage):
                 {"$limit": limit},
                 # Project only the label
                 {"$project": {"_id": 1}},
+                # Resolve display label from node collection
+                {
+                    "$lookup": {
+                        "from": self._collection_name,
+                        "localField": "_id",
+                        "foreignField": "_id",
+                        "pipeline": [{"$project": {"label": 1}}],
+                        "as": "node_info",
+                    }
+                },
+                {
+                    "$project": {
+                        "label": {
+                            "$ifNull": [
+                                {"$arrayElemAt": ["$node_info.label", 0]},
+                                "$_id",
+                            ]
+                        }
+                    }
+                },
             ]
 
             cursor = await self.edge_collection.aggregate(pipeline, allowDiskUse=True)
             labels = []
             async for doc in cursor:
-                if doc.get("_id"):
-                    labels.append(doc["_id"])
+                if doc.get("label"):
+                    labels.append(doc["label"])
 
             logger.debug(
                 f"[{self.workspace}] Retrieved {len(labels)} popular labels (limit: {limit})"
@@ -1681,11 +1704,13 @@ class MongoGraphStorage(BaseGraphStorage):
                         "text": {"query": query_strip, "path": "_id"},
                     }
                 },
-                {"$project": {"_id": 1, "score": {"$meta": "searchScore"}}},
+                {"$project": {"_id": 1, "label": 1, "score": {"$meta": "searchScore"}}},
                 {"$limit": limit},
             ]
             cursor = await self.collection.aggregate(pipeline)
-            labels = [doc["_id"] async for doc in cursor if doc.get("_id")]
+            labels = [
+                doc.get("label") or doc["_id"] async for doc in cursor if doc.get("_id")
+            ]
             if labels:
                 logger.debug(
                     f"[{self.workspace}] Atlas text search returned {len(labels)} results"
@@ -1712,11 +1737,13 @@ class MongoGraphStorage(BaseGraphStorage):
                         },
                     }
                 },
-                {"$project": {"_id": 1, "score": {"$meta": "searchScore"}}},
+                {"$project": {"_id": 1, "label": 1, "score": {"$meta": "searchScore"}}},
                 {"$limit": limit},
             ]
             cursor = await self.collection.aggregate(pipeline)
-            labels = [doc["_id"] async for doc in cursor if doc.get("_id")]
+            labels = [
+                doc.get("label") or doc["_id"] async for doc in cursor if doc.get("_id")
+            ]
             if labels:
                 logger.debug(
                     f"[{self.workspace}] Atlas autocomplete search returned {len(labels)} results"
@@ -1765,12 +1792,14 @@ class MongoGraphStorage(BaseGraphStorage):
                         },
                     }
                 },
-                {"$project": {"_id": 1, "score": {"$meta": "searchScore"}}},
+                {"$project": {"_id": 1, "label": 1, "score": {"$meta": "searchScore"}}},
                 {"$sort": {"score": {"$meta": "searchScore"}}},
                 {"$limit": limit},
             ]
             cursor = await self.collection.aggregate(pipeline)
-            labels = [doc["_id"] async for doc in cursor if doc.get("_id")]
+            labels = [
+                doc.get("label") or doc["_id"] async for doc in cursor if doc.get("_id")
+            ]
             if labels:
                 logger.debug(
                     f"[{self.workspace}] Atlas compound search returned {len(labels)} results"
@@ -1789,16 +1818,23 @@ class MongoGraphStorage(BaseGraphStorage):
             )
 
             escaped_query = re.escape(query_strip)
-            regex_condition = {"_id": {"$regex": escaped_query, "$options": "i"}}
-            cursor = self.collection.find(regex_condition, {"_id": 1}).limit(limit * 2)
+            regex_condition = {
+                "$or": [
+                    {"_id": {"$regex": escaped_query, "$options": "i"}},
+                    {"label": {"$regex": escaped_query, "$options": "i"}},
+                ]
+            }
+            cursor = self.collection.find(
+                regex_condition, {"_id": 1, "label": 1}
+            ).limit(limit * 2)
             docs = await cursor.to_list(length=limit * 2)
 
-            # Extract labels
+            # Extract labels, preferring display label over _id
             labels = []
             for doc in docs:
-                doc_id = doc.get("_id")
-                if doc_id:
-                    labels.append(doc_id)
+                display_label = doc.get("label") or doc.get("_id")
+                if display_label:
+                    labels.append(display_label)
 
             # Sort results to prioritize exact matches and starts-with matches
             def sort_key(label):

--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -1303,7 +1303,7 @@ class Neo4JStorage(BaseGraphStorage):
                             result.nodes.append(
                                 KnowledgeGraphNode(
                                     id=f"{node_id}",
-                                    labels=[node.get("entity_id")],
+                                    labels=[node.get("label") or node.get("entity_id")],
                                     properties=dict(node),
                                 )
                             )
@@ -1520,7 +1520,7 @@ class Neo4JStorage(BaseGraphStorage):
             query = f"""
             MATCH (n:`{workspace_label}`)
             WHERE n.entity_id IS NOT NULL
-            RETURN DISTINCT n.entity_id AS label
+            RETURN DISTINCT COALESCE(n.label, n.entity_id) AS label
             ORDER BY label
             """
             result = await session.run(query)
@@ -1709,7 +1709,7 @@ class Neo4JStorage(BaseGraphStorage):
                 MATCH (n:`{workspace_label}`)
                 WHERE n.entity_id IS NOT NULL
                 OPTIONAL MATCH (n)-[r]-()
-                WITH n.entity_id AS label, count(r) AS degree
+                WITH COALESCE(n.label, n.entity_id) AS label, count(r) AS degree
                 ORDER BY degree DESC, label ASC
                 LIMIT $limit
                 RETURN label
@@ -1758,7 +1758,7 @@ class Neo4JStorage(BaseGraphStorage):
                     CALL db.index.fulltext.queryNodes($index_name, $search_query) YIELD node, score
                     WITH node, score
                     WHERE node:`{workspace_label}`
-                    WITH node.entity_id AS label, score
+                    WITH COALESCE(node.label, node.entity_id) AS label, score
                     WITH label, score,
                          CASE
                              WHEN label = $query_strip THEN score + 1000
@@ -1777,7 +1777,7 @@ class Neo4JStorage(BaseGraphStorage):
                     CALL db.index.fulltext.queryNodes($index_name, $search_query) YIELD node, score
                     WITH node, score
                     WHERE node:`{workspace_label}`
-                    WITH node.entity_id AS label, toLower(node.entity_id) AS label_lower, score
+                    WITH COALESCE(node.label, node.entity_id) AS label, toLower(COALESCE(node.label, node.entity_id)) AS label_lower, score
                     WITH label, label_lower, score,
                          CASE
                              WHEN label_lower = $query_lower THEN score + 1000
@@ -1823,7 +1823,7 @@ class Neo4JStorage(BaseGraphStorage):
                     cypher_query = f"""
                     MATCH (n:`{workspace_label}`)
                     WHERE n.entity_id IS NOT NULL
-                    WITH n.entity_id AS label
+                    WITH COALESCE(n.label, n.entity_id) AS label
                     WHERE label CONTAINS $query_strip
                     WITH label,
                          CASE
@@ -1843,7 +1843,7 @@ class Neo4JStorage(BaseGraphStorage):
                     cypher_query = f"""
                     MATCH (n:`{workspace_label}`)
                     WHERE n.entity_id IS NOT NULL
-                    WITH n.entity_id AS label, toLower(n.entity_id) AS label_lower
+                    WITH COALESCE(n.label, n.entity_id) AS label, toLower(COALESCE(n.label, n.entity_id)) AS label_lower
                     WHERE label_lower CONTAINS $query_lower
                     WITH label, label_lower,
                          CASE

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -209,7 +209,7 @@ class NetworkXStorage(BaseGraphStorage):
         graph = await self._get_graph()
         labels = set()
         for node in graph.nodes():
-            labels.add(str(node))  # Add node id as a label
+            labels.add(graph.nodes[node].get("label", str(node)))
 
         # Return sorted list
         return sorted(list(labels))
@@ -231,7 +231,10 @@ class NetworkXStorage(BaseGraphStorage):
         sorted_nodes = sorted(degrees.items(), key=lambda x: x[1], reverse=True)
 
         # Return top labels limited by the specified limit
-        popular_labels = [str(node) for node, _ in sorted_nodes[:limit]]
+        popular_labels = [
+            graph.nodes[node].get("label", str(node))
+            for node, _ in sorted_nodes[:limit]
+        ]
 
         logger.debug(
             f"[{self.workspace}] Retrieved {len(popular_labels)} popular labels (limit: {limit})"
@@ -259,7 +262,7 @@ class NetworkXStorage(BaseGraphStorage):
         # Collect matching nodes with relevance scores
         matches = []
         for node in graph.nodes():
-            node_str = str(node)
+            node_str = graph.nodes[node].get("label", str(node))
             node_lower = node_str.lower()
 
             # Skip if no match
@@ -438,7 +441,9 @@ class NetworkXStorage(BaseGraphStorage):
 
             result.nodes.append(
                 KnowledgeGraphNode(
-                    id=str(node), labels=[str(node)], properties=node_properties
+                    id=str(node),
+                    labels=[node_data.get("label", str(node))],
+                    properties=node_properties,
                 )
             )
             seen_nodes.add(str(node))

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -4846,8 +4846,8 @@ class PGGraphStorage(BaseGraphStorage):
             """SELECT * FROM cypher('%s', $$
                      MATCH (n:base)
                      WHERE n.entity_id IS NOT NULL
-                     RETURN DISTINCT n.entity_id AS label
-                     ORDER BY n.entity_id
+                     RETURN DISTINCT COALESCE(n.label, n.entity_id) AS label
+                     ORDER BY label
                    $$) AS (label text)"""
             % self.graph_name
         )
@@ -4903,7 +4903,7 @@ class PGGraphStorage(BaseGraphStorage):
 
         start_node = KnowledgeGraphNode(
             id=internal_id,
-            labels=[entity_id],
+            labels=[start_node_data["properties"].get("label") or entity_id],
             properties=start_node_data["properties"],
         )
 
@@ -5018,7 +5018,7 @@ class PGGraphStorage(BaseGraphStorage):
                 # Create neighbor node object
                 neighbor_node = KnowledgeGraphNode(
                     id=neighbor_internal_id,
-                    labels=[neighbor_entity_id],
+                    labels=[b_node["properties"].get("label") or neighbor_entity_id],
                     properties=b_node["properties"],
                 )
 
@@ -5145,7 +5145,10 @@ class PGGraphStorage(BaseGraphStorage):
                         if node_id not in nodes_dict and "properties" in node_a:
                             nodes_dict[node_id] = KnowledgeGraphNode(
                                 id=node_id,
-                                labels=[node_a["properties"]["entity_id"]],
+                                labels=[
+                                    node_a["properties"].get("label")
+                                    or node_a["properties"]["entity_id"]
+                                ],
                                 properties=node_a["properties"],
                             )
 
@@ -5156,7 +5159,10 @@ class PGGraphStorage(BaseGraphStorage):
                         if node_id not in nodes_dict and "properties" in node_b:
                             nodes_dict[node_id] = KnowledgeGraphNode(
                                 id=node_id,
-                                labels=[node_b["properties"]["entity_id"]],
+                                labels=[
+                                    node_b["properties"].get("label")
+                                    or node_b["properties"]["entity_id"]
+                                ],
                                 properties=node_b["properties"],
                             )
 
@@ -5288,7 +5294,10 @@ class PGGraphStorage(BaseGraphStorage):
                 GROUP BY node_id
             )
             SELECT
-                (ag_catalog.agtype_access_operator(VARIADIC ARRAY[v.properties, '"entity_id"'::agtype]))::text AS label
+                COALESCE(
+                    (ag_catalog.agtype_access_operator(VARIADIC ARRAY[v.properties, '"label"'::agtype]))::text,
+                    (ag_catalog.agtype_access_operator(VARIADIC ARRAY[v.properties, '"entity_id"'::agtype]))::text
+                ) AS label
             FROM
                 node_degrees d
             JOIN
@@ -5324,13 +5333,22 @@ class PGGraphStorage(BaseGraphStorage):
             sql_query = f"""
             WITH ranked_labels AS (
                 SELECT
-                    (ag_catalog.agtype_access_operator(VARIADIC ARRAY[properties, '"entity_id"'::agtype]))::text AS label,
-                    LOWER((ag_catalog.agtype_access_operator(VARIADIC ARRAY[properties, '"entity_id"'::agtype]))::text) AS label_lower
+                    COALESCE(
+                        (ag_catalog.agtype_access_operator(VARIADIC ARRAY[properties, '"label"'::agtype]))::text,
+                        (ag_catalog.agtype_access_operator(VARIADIC ARRAY[properties, '"entity_id"'::agtype]))::text
+                    ) AS label,
+                    LOWER(COALESCE(
+                        (ag_catalog.agtype_access_operator(VARIADIC ARRAY[properties, '"label"'::agtype]))::text,
+                        (ag_catalog.agtype_access_operator(VARIADIC ARRAY[properties, '"entity_id"'::agtype]))::text
+                    )) AS label_lower
                 FROM
                     {self.graph_name}._ag_label_vertex
                 WHERE
                     ag_catalog.agtype_access_operator(VARIADIC ARRAY[properties, '"entity_id"'::agtype]) IS NOT NULL
-                    AND LOWER((ag_catalog.agtype_access_operator(VARIADIC ARRAY[properties, '"entity_id"'::agtype]))::text) ILIKE $1
+                    AND LOWER(COALESCE(
+                        (ag_catalog.agtype_access_operator(VARIADIC ARRAY[properties, '"label"'::agtype]))::text,
+                        (ag_catalog.agtype_access_operator(VARIADIC ARRAY[properties, '"entity_id"'::agtype]))::text
+                    )) ILIKE $1
             )
             SELECT
                 label

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -966,6 +966,10 @@ async def acreate_entity(
                 "created_at": int(time.time()),
             }
 
+            # Pass through optional label property for display name
+            if "label" in entity_data:
+                node_data["label"] = entity_data["label"]
+
             # Add entity to knowledge graph
             await chunk_entity_relation_graph.upsert_node(entity_name, node_data)
 

--- a/tests/test_graph_label_property.py
+++ b/tests/test_graph_label_property.py
@@ -1,0 +1,140 @@
+"""
+Tests for the optional `label` property on graph nodes.
+
+When a node has a `label` property, it should be used as the display name
+instead of the raw node ID (entity_id). This is useful when node IDs are
+UUIDs or hashes rather than human-readable strings.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from lightrag.kg.networkx_impl import NetworkXStorage
+from lightrag.kg.shared_storage import initialize_share_data
+from lightrag.base import EmbeddingFunc
+
+
+async def _mock_embed(texts: list[str]) -> np.ndarray:
+    return np.random.rand(len(texts), 10)
+
+
+@pytest.fixture
+def storage(tmp_path):
+    """Create a NetworkXStorage instance with a temp working directory."""
+    initialize_share_data()
+    embed = EmbeddingFunc(embedding_dim=10, max_token_size=512, func=_mock_embed)
+    s = NetworkXStorage(
+        namespace="test_ns",
+        workspace="test",
+        global_config={"working_dir": str(tmp_path), "addon_params": {}},
+        embedding_func=embed,
+    )
+    return s
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_get_all_labels_without_label_property(storage):
+    """Nodes without a label property should return their node ID."""
+    await storage.initialize()
+    graph = await storage._get_graph()
+    graph.add_node("ELON MUSK", entity_type="person")
+    graph.add_node("SPACEX", entity_type="organization")
+
+    labels = await storage.get_all_labels()
+    assert labels == ["ELON MUSK", "SPACEX"]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_get_all_labels_with_label_property(storage):
+    """Nodes with a label property should return the label, not the node ID."""
+    await storage.initialize()
+    graph = await storage._get_graph()
+    graph.add_node("uuid-123", entity_type="person", label="Elon Musk")
+    graph.add_node("uuid-456", entity_type="organization", label="SpaceX")
+
+    labels = await storage.get_all_labels()
+    assert labels == ["Elon Musk", "SpaceX"]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_get_all_labels_mixed(storage):
+    """Mix of nodes with and without label property."""
+    await storage.initialize()
+    graph = await storage._get_graph()
+    graph.add_node("HUMAN_READABLE", entity_type="person")
+    graph.add_node("uuid-789", entity_type="organization", label="Some Org")
+
+    labels = await storage.get_all_labels()
+    assert "HUMAN_READABLE" in labels
+    assert "Some Org" in labels
+    assert "uuid-789" not in labels
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_get_popular_labels_with_label_property(storage):
+    """Popular labels should return display labels, not node IDs."""
+    await storage.initialize()
+    graph = await storage._get_graph()
+    graph.add_node("uuid-a", entity_type="person", label="Alice")
+    graph.add_node("uuid-b", entity_type="person", label="Bob")
+    graph.add_node("uuid-c", entity_type="person")  # no label
+    # Add edges to make uuid-a most popular
+    graph.add_edge("uuid-a", "uuid-b", weight=1.0)
+    graph.add_edge("uuid-a", "uuid-c", weight=1.0)
+
+    labels = await storage.get_popular_labels(limit=10)
+    assert labels[0] == "Alice"  # Most connected
+    assert "Bob" in labels
+    assert "uuid-c" in labels  # No label, falls back to node ID
+    assert "uuid-a" not in labels  # Should show "Alice" instead
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_search_labels_with_label_property(storage):
+    """Search should match against label property, not node IDs."""
+    await storage.initialize()
+    graph = await storage._get_graph()
+    graph.add_node("uuid-100", entity_type="person", label="Elon Musk")
+    graph.add_node("uuid-200", entity_type="organization", label="Tesla Inc")
+    graph.add_node("VISIBLE_NAME", entity_type="person")
+
+    # Search for "elon" should find the labeled node
+    results = await storage.search_labels("elon")
+    assert "Elon Musk" in results
+    assert "uuid-100" not in results
+
+    # Search for "VISIBLE" should find the unlabeled node by its ID
+    results = await storage.search_labels("VISIBLE")
+    assert "VISIBLE_NAME" in results
+
+    # Search for "uuid" should NOT match (label takes precedence)
+    results = await storage.search_labels("uuid-100")
+    assert len(results) == 0
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_get_knowledge_graph_labels(storage):
+    """KnowledgeGraphNode.labels should use label property when available."""
+    await storage.initialize()
+    graph = await storage._get_graph()
+    graph.add_node("uuid-x", entity_type="person", label="Jane Doe")
+    graph.add_node("PLAIN_NODE", entity_type="organization")
+    graph.add_edge("uuid-x", "PLAIN_NODE", weight=1.0, description="works at")
+
+    kg = await storage.get_knowledge_graph("uuid-x", max_depth=1)
+
+    # Find the nodes in the result
+    node_labels = {n.id: n.labels[0] for n in kg.nodes}
+    assert node_labels["uuid-x"] == "Jane Doe"
+    assert node_labels["PLAIN_NODE"] == "PLAIN_NODE"

--- a/tests/test_pg_graph_label_property.py
+++ b/tests/test_pg_graph_label_property.py
@@ -1,0 +1,236 @@
+"""
+Integration tests for the optional `label` property on PGGraphStorage nodes.
+
+Requires a PostgreSQL instance with Apache AGE extension.
+Configure via environment variables:
+  POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DATABASE
+
+Run with: pytest tests/test_pg_graph_label_property.py -v --run-integration
+"""
+
+import os
+import sys
+import uuid
+
+import numpy as np
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from lightrag.base import EmbeddingFunc
+from lightrag.kg.shared_storage import initialize_share_data
+
+
+async def _mock_embed(texts: list[str]) -> np.ndarray:
+    return np.random.rand(len(texts), 10)
+
+
+def _pg_env_configured() -> bool:
+    return bool(os.environ.get("POSTGRES_PASSWORD"))
+
+
+@pytest.fixture
+async def storage(tmp_path):
+    """Create and initialize a PGGraphStorage instance for testing."""
+    from lightrag.kg.postgres_impl import PGGraphStorage, ClientManager
+
+    initialize_share_data()
+    embed = EmbeddingFunc(embedding_dim=10, max_token_size=512, func=_mock_embed)
+
+    # Use a unique namespace to avoid collisions between test runs
+    test_ns = f"test_label_{uuid.uuid4().hex[:8]}"
+
+    s = PGGraphStorage(
+        namespace=test_ns,
+        workspace="test",
+        global_config={
+            "working_dir": str(tmp_path),
+            "addon_params": {},
+        },
+        embedding_func=embed,
+    )
+    await s.initialize()
+    yield s
+
+    # Cleanup: drop the test graph
+    try:
+        await s.drop()
+    except Exception:
+        pass
+
+    # Reset the client manager singleton so other tests aren't affected
+    ClientManager._instances = {"db": None, "ref_count": 0}
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.skipif(not _pg_env_configured(), reason="POSTGRES_PASSWORD not set")
+async def test_upsert_and_get_node_with_label(storage):
+    """Nodes can be upserted with a label property and retrieved."""
+    node_id = "uuid-node-1"
+    await storage.upsert_node(
+        node_id,
+        {
+            "entity_id": node_id,
+            "entity_type": "person",
+            "label": "Elon Musk",
+            "description": "CEO of SpaceX",
+        },
+    )
+
+    props = await storage.get_node(node_id)
+    assert props is not None
+    assert props["entity_id"] == node_id
+    assert props["label"] == "Elon Musk"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.skipif(not _pg_env_configured(), reason="POSTGRES_PASSWORD not set")
+async def test_get_all_labels_uses_label_property(storage):
+    """get_all_labels should return label property when present, entity_id otherwise."""
+    await storage.upsert_node(
+        "uuid-a",
+        {
+            "entity_id": "uuid-a",
+            "entity_type": "person",
+            "label": "Alice",
+        },
+    )
+    await storage.upsert_node(
+        "HUMAN_READABLE",
+        {
+            "entity_id": "HUMAN_READABLE",
+            "entity_type": "organization",
+        },
+    )
+
+    labels = await storage.get_all_labels()
+    assert "Alice" in labels, f"Expected 'Alice' in labels, got {labels}"
+    assert (
+        "HUMAN_READABLE" in labels
+    ), f"Expected 'HUMAN_READABLE' in labels, got {labels}"
+    assert (
+        "uuid-a" not in labels
+    ), f"'uuid-a' should not appear when label exists, got {labels}"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.skipif(not _pg_env_configured(), reason="POSTGRES_PASSWORD not set")
+async def test_get_knowledge_graph_uses_label_property(storage):
+    """KnowledgeGraphNode.labels should use label property when available."""
+    await storage.upsert_node(
+        "uuid-x",
+        {
+            "entity_id": "uuid-x",
+            "entity_type": "person",
+            "label": "Jane Doe",
+        },
+    )
+    await storage.upsert_node(
+        "PLAIN_NODE",
+        {
+            "entity_id": "PLAIN_NODE",
+            "entity_type": "organization",
+        },
+    )
+    await storage.upsert_edge(
+        "uuid-x",
+        "PLAIN_NODE",
+        {
+            "weight": 1.0,
+            "description": "works at",
+        },
+    )
+
+    kg = await storage.get_knowledge_graph("uuid-x", max_depth=1)
+
+    # PGGraphStorage uses AGE internal IDs as node.id, not entity_id.
+    # So we check labels by looking up via entity_id in properties.
+    node_labels = {n.properties["entity_id"]: n.labels[0] for n in kg.nodes}
+    assert (
+        node_labels.get("uuid-x") == "Jane Doe"
+    ), f"Expected 'Jane Doe', got {node_labels}"
+    # PLAIN_NODE may or may not appear depending on BFS depth traversal;
+    # the key assertion is that the labeled node uses its label property.
+    if "PLAIN_NODE" in node_labels:
+        assert (
+            node_labels["PLAIN_NODE"] == "PLAIN_NODE"
+        ), f"Expected 'PLAIN_NODE', got {node_labels}"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.skipif(not _pg_env_configured(), reason="POSTGRES_PASSWORD not set")
+async def test_search_labels_matches_label_property(storage):
+    """search_labels should search against label property, not entity_id."""
+    await storage.upsert_node(
+        "uuid-100",
+        {
+            "entity_id": "uuid-100",
+            "entity_type": "person",
+            "label": "Elon Musk",
+        },
+    )
+    await storage.upsert_node(
+        "VISIBLE_NAME",
+        {
+            "entity_id": "VISIBLE_NAME",
+            "entity_type": "person",
+        },
+    )
+
+    results = await storage.search_labels("elon")
+    assert (
+        "Elon Musk" in results
+    ), f"Expected 'Elon Musk' in search results, got {results}"
+    assert "uuid-100" not in results, f"'uuid-100' should not appear, got {results}"
+
+    results = await storage.search_labels("VISIBLE")
+    assert (
+        "VISIBLE_NAME" in results
+    ), f"Expected 'VISIBLE_NAME' in search results, got {results}"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.skipif(not _pg_env_configured(), reason="POSTGRES_PASSWORD not set")
+async def test_get_popular_labels_uses_label_property(storage):
+    """Popular labels should return display labels, not node IDs."""
+    await storage.upsert_node(
+        "uuid-p1",
+        {
+            "entity_id": "uuid-p1",
+            "entity_type": "person",
+            "label": "Alice",
+        },
+    )
+    await storage.upsert_node(
+        "uuid-p2",
+        {
+            "entity_id": "uuid-p2",
+            "entity_type": "person",
+            "label": "Bob",
+        },
+    )
+    await storage.upsert_node(
+        "uuid-p3",
+        {
+            "entity_id": "uuid-p3",
+            "entity_type": "person",
+            # No label - should fall back to entity_id
+        },
+    )
+    # Make uuid-p1 most popular
+    await storage.upsert_edge(
+        "uuid-p1", "uuid-p2", {"weight": 1.0, "description": "knows"}
+    )
+    await storage.upsert_edge(
+        "uuid-p1", "uuid-p3", {"weight": 1.0, "description": "knows"}
+    )
+
+    labels = await storage.get_popular_labels(limit=10)
+    assert "Alice" in labels, f"Expected 'Alice' in popular labels, got {labels}"
+    assert "Bob" in labels, f"Expected 'Bob' in popular labels, got {labels}"
+    assert "uuid-p1" not in labels, f"'uuid-p1' should not appear, got {labels}"


### PR DESCRIPTION
## Summary

- When a graph node has a `label` property, all graph query endpoints (`get_all_labels`, `search_labels`, `get_popular_labels`, `get_knowledge_graph`) now use it as the display name instead of the raw `entity_id`
- Nodes without a `label` property fall back to `entity_id` — fully backward-compatible, zero behavior change for existing users
- Covers all 5 storage backends: NetworkX, Neo4j, PostgreSQL/AGE, MongoDB, Memgraph

## Motivation

Currently `KnowledgeGraphNode(labels=[str(node)])` uses the raw node ID as display text. This works when IDs are human-readable strings like `"ELON MUSK"`, but breaks for workflows that use UUIDs, hashes, or other non-human-readable node keys. Adding an optional `label` property decouples display name from graph identity.

## Changes

| File | Change |
|------|--------|
| `networkx_impl.py` | `.get("label", entity_id)` fallback in 4 query methods |
| `neo4j_impl.py` | `COALESCE(n.label, n.entity_id)` in 7 Cypher queries |
| `postgres_impl.py` | `COALESCE` in Cypher + agtype access + Python `.get()` fallbacks |
| `mongo_impl.py` | `$ifNull` in aggregation pipelines, `$or` regex for search, `$lookup` for popular labels |
| `memgraph_impl.py` | `COALESCE(n.label, n.entity_id)` in 4 Cypher queries |
| `utils_graph.py` | `acreate_entity()` forwards `label` from entity_data to node properties |

## Test plan

- [x] 6 offline tests (NetworkX): insert nodes with/without label, verify all 4 query endpoints return correct display names
- [x] 5 integration tests (PostgreSQL/AGE): same coverage against live AGE database
- [x] Backward compatibility: nodes without label property behave identically to before