### PR TITLE
feat: separate LLM functions by role (extract/keyword/query)

### DIFF
--- a/env.example
+++ b/env.example
@@ -234,7 +234,7 @@ SUMMARY_LANGUAGE=English
 ###############################
 ### Concurrency Configuration
 ###############################
-### Max concurrency requests of LLM (for both query and document processing)
+### Max concurrency requests of LLM (default for all roles; override per role with MAX_ASYNC_EXTRACT_LLM, MAX_ASYNC_KEYWORD_LLM, MAX_ASYNC_QUERY_LLM)
 MAX_ASYNC=4
 ### Number of parallel processing documents(between 2~10, MAX_ASYNC/3 is recommended)
 MAX_PARALLEL_INSERT=2
@@ -258,6 +258,57 @@ LLM_BINDING=openai
 LLM_BINDING_HOST=https://api.openai.com/v1
 LLM_BINDING_API_KEY=your_api_key
 LLM_MODEL=gpt-5-mini
+
+###############################
+### Per-Role LLM Configuration
+### Separate LLM functions for extract (entity extraction), keyword (keyword extraction), and query (answer generation).
+### Each role inherits from the base LLM config above. Only set overrides as needed.
+### Each role gets its own independent concurrency queue.
+###############################
+
+### Extract role (entity/relation extraction + description summarization)
+# EXTRACT_LLM_BINDING=openai
+# EXTRACT_LLM_MODEL=gpt-4o
+# EXTRACT_LLM_BINDING_HOST=https://api.openai.com/v1
+# EXTRACT_LLM_BINDING_API_KEY=your_api_key
+# MAX_ASYNC_EXTRACT_LLM=8
+# LLM_TIMEOUT_EXTRACT_LLM=240
+
+### Keyword role (query keyword extraction)
+# KEYWORD_LLM_BINDING=openai
+# KEYWORD_LLM_MODEL=gpt-4o-mini
+# KEYWORD_LLM_BINDING_HOST=https://api.openai.com/v1
+# KEYWORD_LLM_BINDING_API_KEY=your_api_key
+# MAX_ASYNC_KEYWORD_LLM=4
+# LLM_TIMEOUT_KEYWORD_LLM=60
+
+### Query role (final answer generation, bypass mode, Ollama API direct calls)
+# QUERY_LLM_BINDING=openai
+# QUERY_LLM_MODEL=gpt-4o
+# QUERY_LLM_BINDING_HOST=https://api.openai.com/v1
+# QUERY_LLM_BINDING_API_KEY=your_api_key
+# MAX_ASYNC_QUERY_LLM=12
+# LLM_TIMEOUT_QUERY_LLM=300
+
+### Per-role provider options
+### Override provider-specific parameters per role. Format: {ROLE}_{PROVIDER_PREFIX}_{FIELD}
+### Same provider: inherits from base options, only set overrides.
+### Cross provider: starts from provider defaults, set all needed options.
+###
+### OpenAI examples (applies to openai and azure_openai bindings):
+# EXTRACT_OPENAI_LLM_TEMPERATURE=0.1
+# EXTRACT_OPENAI_LLM_MAX_COMPLETION_TOKENS=6000
+# KEYWORD_OPENAI_LLM_TEMPERATURE=0.0
+# QUERY_OPENAI_LLM_REASONING_EFFORT=high
+###
+### Ollama examples:
+# EXTRACT_OLLAMA_LLM_NUM_CTX=65536
+# EXTRACT_OLLAMA_LLM_TEMPERATURE=0.1
+# KEYWORD_OLLAMA_LLM_NUM_CTX=16384
+###
+### Gemini examples:
+# EXTRACT_GEMINI_LLM_TEMPERATURE=0.1
+# QUERY_GEMINI_LLM_MAX_OUTPUT_TOKENS=8192
 
 ### use the following command to see all support options for OpenAI, azure_openai or OpenRouter
 ### lightrag-server --llm-binding openai --help

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -582,6 +582,48 @@ def parse_args() -> argparse.Namespace:
             args.workspace = sanitized
 
     validate_auth_configuration(args)
+
+    # Per-role LLM configuration
+    # Extract role
+    args.extract_llm_binding = get_env_value("EXTRACT_LLM_BINDING", None)
+    args.extract_llm_model = get_env_value("EXTRACT_LLM_MODEL", None)
+    args.extract_llm_binding_host = get_env_value("EXTRACT_LLM_BINDING_HOST", None)
+    args.extract_llm_binding_api_key = get_env_value(
+        "EXTRACT_LLM_BINDING_API_KEY", None
+    )
+    args.max_async_extract_llm = get_env_value(
+        "MAX_ASYNC_EXTRACT_LLM", None, int, special_none=True
+    )
+    args.llm_timeout_extract_llm = get_env_value(
+        "LLM_TIMEOUT_EXTRACT_LLM", None, int, special_none=True
+    )
+
+    # Keyword role
+    args.keyword_llm_binding = get_env_value("KEYWORD_LLM_BINDING", None)
+    args.keyword_llm_model = get_env_value("KEYWORD_LLM_MODEL", None)
+    args.keyword_llm_binding_host = get_env_value("KEYWORD_LLM_BINDING_HOST", None)
+    args.keyword_llm_binding_api_key = get_env_value(
+        "KEYWORD_LLM_BINDING_API_KEY", None
+    )
+    args.max_async_keyword_llm = get_env_value(
+        "MAX_ASYNC_KEYWORD_LLM", None, int, special_none=True
+    )
+    args.llm_timeout_keyword_llm = get_env_value(
+        "LLM_TIMEOUT_KEYWORD_LLM", None, int, special_none=True
+    )
+
+    # Query role
+    args.query_llm_binding = get_env_value("QUERY_LLM_BINDING", None)
+    args.query_llm_model = get_env_value("QUERY_LLM_MODEL", None)
+    args.query_llm_binding_host = get_env_value("QUERY_LLM_BINDING_HOST", None)
+    args.query_llm_binding_api_key = get_env_value("QUERY_LLM_BINDING_API_KEY", None)
+    args.max_async_query_llm = get_env_value(
+        "MAX_ASYNC_QUERY_LLM", None, int, special_none=True
+    )
+    args.llm_timeout_query_llm = get_env_value(
+        "LLM_TIMEOUT_QUERY_LLM", None, int, special_none=True
+    )
+
     return args
 
 

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -661,6 +661,200 @@ def create_app(args):
         except ImportError as e:
             raise Exception(f"Failed to import {binding} LLM binding: {e}")
 
+    def create_role_llm_func(
+        role: str,
+        role_binding: str | None,
+        role_model: str | None,
+        role_host: str | None,
+        role_api_key: str | None,
+        role_timeout: int | None,
+    ):
+        """
+        Create a role-specific LLM function.
+
+        If role_binding differs from the base binding (cross-provider), creates a
+        standalone function with the role's own provider settings.
+        If same provider, creates a function that uses the role's model/host/api_key
+        with the base provider's configuration.
+
+        Returns None if no role-specific config is set (caller should fall back to base).
+        """
+        # If no role-specific binding or model, no custom function needed
+        if not role_binding and not role_model:
+            return None
+
+        effective_binding = role_binding or args.llm_binding
+        effective_model = role_model or args.llm_model
+        effective_host = role_host or (
+            get_default_host(effective_binding)
+            if role_binding
+            else args.llm_binding_host
+        )
+        effective_api_key = (
+            role_api_key if role_api_key is not None else args.llm_binding_api_key
+        )
+        effective_timeout = role_timeout or llm_timeout
+
+        is_cross_provider = role_binding and role_binding != args.llm_binding
+
+        if is_cross_provider:
+            # Cross-provider: validate required fields
+            if not role_model:
+                raise ValueError(
+                    f"{role.upper()}_LLM_MODEL is required when using cross-provider binding "
+                    f"({role.upper()}_LLM_BINDING={role_binding} differs from base LLM_BINDING={args.llm_binding})"
+                )
+            # Validate api_key for providers that require one
+            providers_requiring_key = {
+                "openai",
+                "azure_openai",
+                "gemini",
+                "aws_bedrock",
+            }
+            if effective_binding in providers_requiring_key and not effective_api_key:
+                raise ValueError(
+                    f"{role.upper()}_LLM_BINDING_API_KEY is required when using cross-provider binding "
+                    f"({role.upper()}_LLM_BINDING={role_binding}) with provider '{effective_binding}'"
+                )
+
+        # Build role-specific provider options
+        role_provider_options = None
+        try:
+            if effective_binding in ["openai", "azure_openai"]:
+                from lightrag.llm.binding_options import OpenAILLMOptions
+
+                role_provider_options = OpenAILLMOptions.options_dict_for_role(
+                    args, role, is_cross_provider
+                )
+            elif effective_binding == "gemini":
+                from lightrag.llm.binding_options import GeminiLLMOptions
+
+                role_provider_options = GeminiLLMOptions.options_dict_for_role(
+                    args, role, is_cross_provider
+                )
+            elif effective_binding == "ollama":
+                from lightrag.llm.binding_options import OllamaLLMOptions
+
+                role_provider_options = OllamaLLMOptions.options_dict_for_role(
+                    args, role, is_cross_provider
+                )
+        except ImportError:
+            pass
+
+        # Create the function based on the effective binding
+        try:
+            if effective_binding == "lollms":
+                from lightrag.llm.lollms import lollms_model_complete
+
+                return lollms_model_complete
+            elif effective_binding == "ollama":
+                from lightrag.llm.ollama import ollama_model_complete
+
+                return ollama_model_complete
+            elif effective_binding == "aws_bedrock":
+                return bedrock_model_complete
+            elif effective_binding == "azure_openai":
+                from lightrag.llm.azure_openai import azure_openai_complete_if_cache
+
+                _role_openai_opts = role_provider_options
+
+                async def role_azure_openai_complete(
+                    prompt,
+                    system_prompt=None,
+                    history_messages=None,
+                    keyword_extraction=False,
+                    **kwargs,
+                ) -> str:
+                    keyword_extraction = kwargs.pop("keyword_extraction", None)
+                    if keyword_extraction:
+                        kwargs["response_format"] = GPTKeywordExtractionFormat
+                    if history_messages is None:
+                        history_messages = []
+                    kwargs["timeout"] = effective_timeout
+                    if _role_openai_opts:
+                        kwargs.update(_role_openai_opts)
+                    return await azure_openai_complete_if_cache(
+                        effective_model,
+                        prompt,
+                        system_prompt=system_prompt,
+                        history_messages=history_messages,
+                        base_url=effective_host,
+                        api_key=os.getenv("AZURE_OPENAI_API_KEY", effective_api_key),
+                        api_version=os.getenv(
+                            "AZURE_OPENAI_API_VERSION", "2024-08-01-preview"
+                        ),
+                        **kwargs,
+                    )
+
+                return role_azure_openai_complete
+            elif effective_binding == "gemini":
+                from lightrag.llm.gemini import gemini_complete_if_cache
+
+                _role_gemini_opts = role_provider_options
+
+                async def role_gemini_complete(
+                    prompt,
+                    system_prompt=None,
+                    history_messages=None,
+                    keyword_extraction=False,
+                    **kwargs,
+                ) -> str:
+                    if history_messages is None:
+                        history_messages = []
+                    kwargs["timeout"] = effective_timeout
+                    if (
+                        _role_gemini_opts is not None
+                        and "generation_config" not in kwargs
+                    ):
+                        kwargs["generation_config"] = dict(_role_gemini_opts)
+                    return await gemini_complete_if_cache(
+                        effective_model,
+                        prompt,
+                        system_prompt=system_prompt,
+                        history_messages=history_messages,
+                        api_key=effective_api_key,
+                        base_url=effective_host,
+                        keyword_extraction=keyword_extraction,
+                        **kwargs,
+                    )
+
+                return role_gemini_complete
+            else:  # openai and compatible
+                from lightrag.llm.openai import openai_complete_if_cache
+
+                _role_oai_opts = role_provider_options
+
+                async def role_openai_complete(
+                    prompt,
+                    system_prompt=None,
+                    history_messages=None,
+                    keyword_extraction=False,
+                    **kwargs,
+                ) -> str:
+                    keyword_extraction = kwargs.pop("keyword_extraction", None)
+                    if keyword_extraction:
+                        kwargs["response_format"] = GPTKeywordExtractionFormat
+                    if history_messages is None:
+                        history_messages = []
+                    kwargs["timeout"] = effective_timeout
+                    if _role_oai_opts:
+                        kwargs.update(_role_oai_opts)
+                    return await openai_complete_if_cache(
+                        effective_model,
+                        prompt,
+                        system_prompt=system_prompt,
+                        history_messages=history_messages,
+                        base_url=effective_host,
+                        api_key=effective_api_key,
+                        **kwargs,
+                    )
+
+                return role_openai_complete
+        except ImportError as e:
+            raise Exception(
+                f"Failed to import {effective_binding} LLM binding for {role} role: {e}"
+            )
+
     def create_llm_model_kwargs(binding: str, args, llm_timeout: int) -> dict:
         """
         Create LLM model kwargs based on binding type.
@@ -679,6 +873,38 @@ def create_app(args):
             except ImportError as e:
                 raise Exception(f"Failed to import {binding} options: {e}")
         return {}
+
+    def create_role_llm_model_kwargs(
+        role: str,
+        role_binding: str | None,
+        role_host: str | None,
+        role_api_key: str | None,
+        role_timeout: int | None,
+    ) -> dict | None:
+        """
+        Create role-specific LLM model kwargs for ollama/lollms bindings.
+        Uses role-specific provider options with proper inheritance.
+        Returns None if no role-specific config warrants separate kwargs.
+        """
+        effective_binding = role_binding or args.llm_binding
+        is_cross_provider = role_binding and role_binding != args.llm_binding
+        if effective_binding in ["lollms", "ollama"]:
+            try:
+                from lightrag.llm.binding_options import OllamaLLMOptions
+
+                return {
+                    "host": role_host or args.llm_binding_host,
+                    "timeout": role_timeout or llm_timeout,
+                    "options": OllamaLLMOptions.options_dict_for_role(
+                        args, role, is_cross_provider
+                    ),
+                    "api_key": role_api_key
+                    if role_api_key is not None
+                    else args.llm_binding_api_key,
+                }
+            except ImportError:
+                pass
+        return None
 
     def create_optimized_embedding_function(
         config_cache: LLMConfigCache,
@@ -1163,6 +1389,44 @@ def create_app(args):
         name=args.simulated_model_name, tag=args.simulated_model_tag
     )
 
+    # Create per-role LLM functions
+    role_llm_configs = {}
+    for role, prefix in [
+        ("extract", "extract"),
+        ("keyword", "keyword"),
+        ("query", "query"),
+    ]:
+        role_binding = getattr(args, f"{prefix}_llm_binding", None)
+        role_model = getattr(args, f"{prefix}_llm_model", None)
+        role_host = getattr(args, f"{prefix}_llm_binding_host", None)
+        role_api_key = getattr(args, f"{prefix}_llm_binding_api_key", None)
+        role_max_async = getattr(args, f"max_async_{prefix}_llm", None)
+        role_timeout_val = getattr(args, f"llm_timeout_{prefix}_llm", None)
+
+        role_func = create_role_llm_func(
+            role, role_binding, role_model, role_host, role_api_key, role_timeout_val
+        )
+        role_kwargs = create_role_llm_model_kwargs(
+            role, role_binding, role_host, role_api_key, role_timeout_val
+        )
+
+        role_llm_configs[role] = {
+            "func": role_func,
+            "kwargs": role_kwargs,
+            "max_async": role_max_async,
+            "timeout": role_timeout_val,
+            "binding": role_binding or args.llm_binding,
+            "model": role_model or args.llm_model,
+        }
+
+        if role_func or role_max_async or role_timeout_val:
+            logger.info(
+                f"LLM role '{role}': binding={role_binding or args.llm_binding}, "
+                f"model={role_model or args.llm_model}, "
+                f"max_async={role_max_async or args.max_async}, "
+                f"timeout={role_timeout_val or llm_timeout}"
+            )
+
     # Initialize RAG with unified configuration
     try:
         rag = LightRAG(
@@ -1198,6 +1462,19 @@ def create_app(args):
                 "entity_types": args.entity_types,
             },
             ollama_server_infos=ollama_server_infos,
+            # Per-role LLM configuration
+            extract_llm_model_func=role_llm_configs["extract"]["func"],
+            extract_llm_model_max_async=role_llm_configs["extract"]["max_async"],
+            extract_llm_timeout=role_llm_configs["extract"]["timeout"],
+            extract_llm_model_kwargs=role_llm_configs["extract"]["kwargs"],
+            keyword_llm_model_func=role_llm_configs["keyword"]["func"],
+            keyword_llm_model_max_async=role_llm_configs["keyword"]["max_async"],
+            keyword_llm_timeout=role_llm_configs["keyword"]["timeout"],
+            keyword_llm_model_kwargs=role_llm_configs["keyword"]["kwargs"],
+            query_llm_model_func=role_llm_configs["query"]["func"],
+            query_llm_model_max_async=role_llm_configs["query"]["max_async"],
+            query_llm_timeout=role_llm_configs["query"]["timeout"],
+            query_llm_model_kwargs=role_llm_configs["query"]["kwargs"],
         )
     except Exception as e:
         logger.error(f"Failed to initialize LightRAG: {e}")
@@ -1405,6 +1682,16 @@ def create_app(args):
                     "max_async": args.max_async,
                     "embedding_func_max_async": args.embedding_func_max_async,
                     "embedding_batch_num": args.embedding_batch_num,
+                    # Per-role LLM configuration
+                    "role_llm_config": {
+                        role: {
+                            "binding": cfg["binding"],
+                            "model": cfg["model"],
+                            "max_async": cfg["max_async"] or args.max_async,
+                            "timeout": cfg["timeout"] or llm_timeout,
+                        }
+                        for role, cfg in role_llm_configs.items()
+                    },
                 },
                 "auth_mode": auth_mode,
                 "pipeline_busy": pipeline_status.get("busy", False),

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -748,9 +748,34 @@ def create_app(args):
 
                 return lollms_model_complete
             elif effective_binding == "ollama":
-                from lightrag.llm.ollama import ollama_model_complete
+                from lightrag.llm.ollama import _ollama_model_if_cache
 
-                return ollama_model_complete
+                _role_ollama_opts = role_provider_options
+
+                async def role_ollama_complete(
+                    prompt,
+                    system_prompt=None,
+                    history_messages=None,
+                    keyword_extraction=False,
+                    **kwargs,
+                ):
+                    keyword_extraction = kwargs.pop("keyword_extraction", None)
+                    if keyword_extraction:
+                        kwargs["format"] = "json"
+                    if _role_ollama_opts:
+                        kwargs.update(_role_ollama_opts)
+                    if history_messages is None:
+                        history_messages = []
+                    return await _ollama_model_if_cache(
+                        effective_model,
+                        prompt,
+                        system_prompt=system_prompt,
+                        history_messages=history_messages,
+                        host=effective_host,
+                        **kwargs,
+                    )
+
+                return role_ollama_complete
             elif effective_binding == "aws_bedrock":
                 return bedrock_model_complete
             elif effective_binding == "azure_openai":

--- a/lightrag/api/routers/ollama_api.py
+++ b/lightrag/api/routers/ollama_api.py
@@ -303,7 +303,7 @@ class OllamaAPI:
                     self.rag.llm_model_kwargs["system_prompt"] = request.system
 
                 if request.stream:
-                    response = await self.rag.llm_model_func(
+                    response = await self.rag.query_llm_model_func(
                         query, stream=True, **self.rag.llm_model_kwargs
                     )
 
@@ -428,7 +428,7 @@ class OllamaAPI:
                     )
                 else:
                     first_chunk_time = time.time_ns()
-                    response_text = await self.rag.llm_model_func(
+                    response_text = await self.rag.query_llm_model_func(
                         query, stream=False, **self.rag.llm_model_kwargs
                     )
                     last_chunk_time = time.time_ns()
@@ -517,7 +517,7 @@ class OllamaAPI:
                     if mode == SearchMode.bypass:
                         if request.system:
                             self.rag.llm_model_kwargs["system_prompt"] = request.system
-                        response = await self.rag.llm_model_func(
+                        response = await self.rag.query_llm_model_func(
                             cleaned_query,
                             stream=True,
                             history_messages=conversation_history,
@@ -680,7 +680,7 @@ class OllamaAPI:
                         if request.system:
                             self.rag.llm_model_kwargs["system_prompt"] = request.system
 
-                        response_text = await self.rag.llm_model_func(
+                        response_text = await self.rag.query_llm_model_func(
                             cleaned_query,
                             stream=False,
                             history_messages=conversation_history,

--- a/lightrag/api/routers/ollama_api.py
+++ b/lightrag/api/routers/ollama_api.py
@@ -303,8 +303,9 @@ class OllamaAPI:
                     self.rag.llm_model_kwargs["system_prompt"] = request.system
 
                 if request.stream:
+                    role_kwargs = self.rag.query_llm_model_kwargs if self.rag.query_llm_model_kwargs is not None else self.rag.llm_model_kwargs
                     response = await self.rag.query_llm_model_func(
-                        query, stream=True, **self.rag.llm_model_kwargs
+                        query, stream=True, **role_kwargs
                     )
 
                     async def stream_generator():
@@ -428,8 +429,9 @@ class OllamaAPI:
                     )
                 else:
                     first_chunk_time = time.time_ns()
+                    role_kwargs = self.rag.query_llm_model_kwargs if self.rag.query_llm_model_kwargs is not None else self.rag.llm_model_kwargs
                     response_text = await self.rag.query_llm_model_func(
-                        query, stream=False, **self.rag.llm_model_kwargs
+                        query, stream=False, **role_kwargs
                     )
                     last_chunk_time = time.time_ns()
 

--- a/lightrag/api/routers/ollama_api.py
+++ b/lightrag/api/routers/ollama_api.py
@@ -303,7 +303,11 @@ class OllamaAPI:
                     self.rag.llm_model_kwargs["system_prompt"] = request.system
 
                 if request.stream:
-                    role_kwargs = self.rag.query_llm_model_kwargs if self.rag.query_llm_model_kwargs is not None else self.rag.llm_model_kwargs
+                    role_kwargs = (
+                        self.rag.query_llm_model_kwargs
+                        if self.rag.query_llm_model_kwargs is not None
+                        else self.rag.llm_model_kwargs
+                    )
                     response = await self.rag.query_llm_model_func(
                         query, stream=True, **role_kwargs
                     )
@@ -429,7 +433,11 @@ class OllamaAPI:
                     )
                 else:
                     first_chunk_time = time.time_ns()
-                    role_kwargs = self.rag.query_llm_model_kwargs if self.rag.query_llm_model_kwargs is not None else self.rag.llm_model_kwargs
+                    role_kwargs = (
+                        self.rag.query_llm_model_kwargs
+                        if self.rag.query_llm_model_kwargs is not None
+                        else self.rag.llm_model_kwargs
+                    )
                     response_text = await self.rag.query_llm_model_func(
                         query, stream=False, **role_kwargs
                     )
@@ -517,13 +525,18 @@ class OllamaAPI:
                 if request.stream:
                     # Determine if the request is prefix with "/bypass"
                     if mode == SearchMode.bypass:
+                        role_kwargs = (
+                            self.rag.query_llm_model_kwargs
+                            if self.rag.query_llm_model_kwargs is not None
+                            else self.rag.llm_model_kwargs
+                        )
                         if request.system:
-                            self.rag.llm_model_kwargs["system_prompt"] = request.system
+                            role_kwargs["system_prompt"] = request.system
                         response = await self.rag.query_llm_model_func(
                             cleaned_query,
                             stream=True,
                             history_messages=conversation_history,
-                            **self.rag.llm_model_kwargs,
+                            **role_kwargs,
                         )
                     else:
                         response = await self.rag.aquery(
@@ -679,14 +692,19 @@ class OllamaAPI:
                         r"\n<chat_history>\nUSER:", cleaned_query, re.MULTILINE
                     )
                     if match_result or mode == SearchMode.bypass:
+                        role_kwargs = (
+                            self.rag.query_llm_model_kwargs
+                            if self.rag.query_llm_model_kwargs is not None
+                            else self.rag.llm_model_kwargs
+                        )
                         if request.system:
-                            self.rag.llm_model_kwargs["system_prompt"] = request.system
+                            role_kwargs["system_prompt"] = request.system
 
                         response_text = await self.rag.query_llm_model_func(
                             cleaned_query,
                             stream=False,
                             history_messages=conversation_history,
-                            **self.rag.llm_model_kwargs,
+                            **role_kwargs,
                         )
                     else:
                         response_text = await self.rag.aquery(

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -957,19 +957,25 @@ class LightRAG:
                 effective_max_async = max_async
             else:
                 stored = getattr(self, max_async_attr)
-                effective_max_async = stored if stored is not None else self.llm_model_max_async
+                effective_max_async = (
+                    stored if stored is not None else self.llm_model_max_async
+                )
 
             if timeout is not None:
                 effective_timeout = timeout
             else:
                 stored = getattr(self, timeout_attr)
-                effective_timeout = stored if stored is not None else self.default_llm_timeout
+                effective_timeout = (
+                    stored if stored is not None else self.default_llm_timeout
+                )
 
             if model_kwargs is not None:
                 effective_kwargs = model_kwargs
             else:
                 stored = getattr(self, kwargs_attr)
-                effective_kwargs = stored if stored is not None else self.llm_model_kwargs
+                effective_kwargs = (
+                    stored if stored is not None else self.llm_model_kwargs
+                )
 
             # Rebuild the wrapped function with independent queue
             hashing_kv = self.llm_response_cache

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -432,6 +432,45 @@ class LightRAG:
         default=int(os.getenv("LLM_TIMEOUT", DEFAULT_LLM_TIMEOUT))
     )
 
+    # Per-role LLM Configuration
+    # ---
+
+    extract_llm_model_func: Callable[..., object] | None = field(default=None)
+    """Optional LLM function for entity/relation extraction. Falls back to llm_model_func if None."""
+
+    keyword_llm_model_func: Callable[..., object] | None = field(default=None)
+    """Optional LLM function for keyword extraction. Falls back to llm_model_func if None."""
+
+    query_llm_model_func: Callable[..., object] | None = field(default=None)
+    """Optional LLM function for query answering. Falls back to llm_model_func if None."""
+
+    extract_llm_model_max_async: int | None = field(default=None)
+    """Max concurrent calls for extract role. Falls back to llm_model_max_async if None."""
+
+    keyword_llm_model_max_async: int | None = field(default=None)
+    """Max concurrent calls for keyword role. Falls back to llm_model_max_async if None."""
+
+    query_llm_model_max_async: int | None = field(default=None)
+    """Max concurrent calls for query role. Falls back to llm_model_max_async if None."""
+
+    extract_llm_timeout: int | None = field(default=None)
+    """Timeout for extract role. Falls back to default_llm_timeout if None."""
+
+    keyword_llm_timeout: int | None = field(default=None)
+    """Timeout for keyword role. Falls back to default_llm_timeout if None."""
+
+    query_llm_timeout: int | None = field(default=None)
+    """Timeout for query role. Falls back to default_llm_timeout if None."""
+
+    extract_llm_model_kwargs: dict[str, Any] | None = field(default=None)
+    """Additional kwargs for extract role LLM. Falls back to llm_model_kwargs if None."""
+
+    keyword_llm_model_kwargs: dict[str, Any] | None = field(default=None)
+    """Additional kwargs for keyword role LLM. Falls back to llm_model_kwargs if None."""
+
+    query_llm_model_kwargs: dict[str, Any] | None = field(default=None)
+    """Additional kwargs for query role LLM. Falls back to llm_model_kwargs if None."""
+
     # Rerank Configuration
     # ---
 
@@ -739,6 +778,9 @@ class LightRAG:
         # Directly use llm_response_cache, don't create a new object
         hashing_kv = self.llm_response_cache
 
+        # Save raw base LLM func before wrapping
+        _raw_llm_func = self.llm_model_func
+
         # Get timeout from LLM model kwargs for dynamic timeout calculation
         self.llm_model_func = priority_limit_async_func_call(
             self.llm_model_max_async,
@@ -750,6 +792,49 @@ class LightRAG:
                 hashing_kv=hashing_kv,
                 **self.llm_model_kwargs,
             )
+        )
+
+        # Wrap per-role LLM functions with independent concurrency queues
+        # Store raw (unwrapped) functions for later use by update_llm_role_config
+        self._raw_role_llm_funcs: dict[str, Callable] = {}
+        # Store role metadata for introspection (health endpoint, logging)
+        self._role_llm_metadata: dict[str, dict[str, Any]] = {}
+        for role in ("extract", "keyword", "query"):
+            role_func_attr = f"{role}_llm_model_func"
+            role_max_async_attr = f"{role}_llm_model_max_async"
+            role_timeout_attr = f"{role}_llm_timeout"
+            role_kwargs_attr = f"{role}_llm_model_kwargs"
+
+            # Determine the raw function for this role
+            role_raw_func = getattr(self, role_func_attr) or _raw_llm_func
+            self._raw_role_llm_funcs[role] = role_raw_func
+
+            # Determine max_async and timeout (fall back to base values)
+            role_max_async = (
+                getattr(self, role_max_async_attr) or self.llm_model_max_async
+            )
+            role_timeout = getattr(self, role_timeout_attr) or self.default_llm_timeout
+            role_kwargs = getattr(self, role_kwargs_attr) or self.llm_model_kwargs
+
+            # Create independently wrapped function with its own queue
+            wrapped_role_func = priority_limit_async_func_call(
+                role_max_async,
+                llm_timeout=role_timeout,
+                queue_name=f"LLM func ({role})",
+            )(
+                partial(
+                    role_raw_func,  # type: ignore
+                    hashing_kv=hashing_kv,
+                    **role_kwargs,
+                )
+            )
+            setattr(self, role_func_attr, wrapped_role_func)
+
+        logger.info(
+            f"LLM role functions initialized - "
+            f"extract: max_async={self.extract_llm_model_max_async or self.llm_model_max_async}, "
+            f"keyword: max_async={self.keyword_llm_model_max_async or self.llm_model_max_async}, "
+            f"query: max_async={self.query_llm_model_max_async or self.llm_model_max_async}"
         )
 
         self._storages_status = StoragesStatus.CREATED
@@ -793,6 +878,126 @@ class LightRAG:
 
             self._storages_status = StoragesStatus.INITIALIZED
             logger.debug("All storage types initialized")
+
+    def update_llm_role_config(
+        self,
+        role: str,
+        *,
+        binding: str | None = None,
+        model: str | None = None,
+        host: str | None = None,
+        api_key: str | None = None,
+        provider_options: dict[str, Any] | None = None,
+        max_async: int | None = None,
+        timeout: int | None = None,
+        model_func: Callable[..., object] | None = None,
+        model_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        """Update role LLM config at runtime.
+
+        Args:
+            role: One of "extract", "keyword", "query".
+            binding: Provider binding name (e.g., "openai", "ollama"). Stored as metadata.
+            model: Model name (e.g., "gpt-4o"). Stored as metadata.
+            host: Provider host URL. Stored as metadata.
+            api_key: Provider API key. Stored as metadata.
+            provider_options: Provider-specific options (e.g., temperature). Stored as metadata.
+            model_func: If provided, used as the raw callable for this role.
+            model_kwargs: Additional kwargs baked into the role function.
+            max_async: Concurrency limit for this role's queue.
+            timeout: Timeout for this role's LLM calls.
+
+        If model_func is provided, it is treated as a fully configured callable.
+        The binding/model/host/api_key/provider_options parameters are stored as
+        metadata for introspection (e.g., health endpoint) and are available via
+        the ``_role_llm_metadata`` dict.
+
+        The updated function takes effect on the next aquery()/ainsert() call.
+        On failure, the previous config remains intact.
+        """
+        if role not in ("extract", "keyword", "query"):
+            raise ValueError(
+                f"Invalid role: {role}. Must be 'extract', 'keyword', or 'query'."
+            )
+
+        func_attr = f"{role}_llm_model_func"
+        max_async_attr = f"{role}_llm_model_max_async"
+        timeout_attr = f"{role}_llm_timeout"
+        kwargs_attr = f"{role}_llm_model_kwargs"
+
+        # Save previous state for rollback
+        prev_func = getattr(self, func_attr)
+        prev_metadata = self._role_llm_metadata.get(role, {}).copy()
+
+        try:
+            # Determine effective values - use stored raw function to avoid double-wrapping
+            raw_func = model_func or self._raw_role_llm_funcs.get(role)
+            if raw_func is None:
+                raise ValueError(f"No raw function available for role '{role}'")
+            # Update stored raw function if a new one is provided
+            if model_func is not None:
+                self._raw_role_llm_funcs[role] = model_func
+            effective_max_async = (
+                max_async or getattr(self, max_async_attr) or self.llm_model_max_async
+            )
+            effective_timeout = (
+                timeout or getattr(self, timeout_attr) or self.default_llm_timeout
+            )
+            effective_kwargs = (
+                model_kwargs
+                if model_kwargs is not None
+                else (getattr(self, kwargs_attr) or self.llm_model_kwargs)
+            )
+
+            # Rebuild the wrapped function with independent queue
+            hashing_kv = self.llm_response_cache
+            wrapped_func = priority_limit_async_func_call(
+                effective_max_async,
+                llm_timeout=effective_timeout,
+                queue_name=f"LLM func ({role})",
+            )(
+                partial(
+                    raw_func,
+                    hashing_kv=hashing_kv,
+                    **effective_kwargs,
+                )
+            )
+
+            # Atomic update — function and attributes
+            if max_async is not None:
+                setattr(self, max_async_attr, max_async)
+            if timeout is not None:
+                setattr(self, timeout_attr, timeout)
+            if model_kwargs is not None:
+                setattr(self, kwargs_attr, model_kwargs)
+            setattr(self, func_attr, wrapped_func)
+
+            # Update metadata for introspection
+            metadata = self._role_llm_metadata.get(role, {})
+            if binding is not None:
+                metadata["binding"] = binding
+            if model is not None:
+                metadata["model"] = model
+            if host is not None:
+                metadata["host"] = host
+            if api_key is not None:
+                metadata["api_key"] = "***"  # Never store raw key
+            if provider_options is not None:
+                metadata["provider_options"] = provider_options
+            self._role_llm_metadata[role] = metadata
+
+            logger.info(
+                f"Updated LLM role config for '{role}': "
+                f"max_async={effective_max_async}, timeout={effective_timeout}"
+                + (f", binding={binding}" if binding else "")
+                + (f", model={model}" if model else "")
+            )
+        except Exception as e:
+            # Rollback on failure
+            setattr(self, func_attr, prev_func)
+            self._role_llm_metadata[role] = prev_metadata
+            logger.error(f"Failed to update LLM role config for '{role}': {e}")
+            raise
 
     async def finalize_storages(self):
         """Asynchronously finalize the storages with improved error handling"""
@@ -2932,8 +3137,8 @@ class LightRAG:
                 )
             elif param.mode == "bypass":
                 # Bypass mode: directly use LLM without knowledge retrieval
-                use_llm_func = param.model_func or global_config["llm_model_func"]
-                # Apply higher priority (8) to entity/relation summary tasks
+                use_llm_func = param.model_func or global_config["query_llm_model_func"]
+                # Apply higher priority (8) to bypass tasks
                 use_llm_func = partial(use_llm_func, _priority=8)
 
                 param.stream = True if param.stream is None else param.stream

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -810,11 +810,25 @@ class LightRAG:
             self._raw_role_llm_funcs[role] = role_raw_func
 
             # Determine max_async and timeout (fall back to base values)
+            # Use `is not None` to allow explicit 0/{} overrides
+            role_max_async_value = getattr(self, role_max_async_attr)
             role_max_async = (
-                getattr(self, role_max_async_attr) or self.llm_model_max_async
+                role_max_async_value
+                if role_max_async_value is not None
+                else self.llm_model_max_async
             )
-            role_timeout = getattr(self, role_timeout_attr) or self.default_llm_timeout
-            role_kwargs = getattr(self, role_kwargs_attr) or self.llm_model_kwargs
+            role_timeout_value = getattr(self, role_timeout_attr)
+            role_timeout = (
+                role_timeout_value
+                if role_timeout_value is not None
+                else self.default_llm_timeout
+            )
+            role_kwargs_value = getattr(self, role_kwargs_attr)
+            role_kwargs = (
+                role_kwargs_value
+                if role_kwargs_value is not None
+                else self.llm_model_kwargs
+            )
 
             # Create independently wrapped function with its own queue
             wrapped_role_func = priority_limit_async_func_call(
@@ -928,6 +942,7 @@ class LightRAG:
         # Save previous state for rollback
         prev_func = getattr(self, func_attr)
         prev_metadata = self._role_llm_metadata.get(role, {}).copy()
+        prev_raw_func = self._raw_role_llm_funcs.get(role)
 
         try:
             # Determine effective values - use stored raw function to avoid double-wrapping
@@ -937,17 +952,24 @@ class LightRAG:
             # Update stored raw function if a new one is provided
             if model_func is not None:
                 self._raw_role_llm_funcs[role] = model_func
-            effective_max_async = (
-                max_async or getattr(self, max_async_attr) or self.llm_model_max_async
-            )
-            effective_timeout = (
-                timeout or getattr(self, timeout_attr) or self.default_llm_timeout
-            )
-            effective_kwargs = (
-                model_kwargs
-                if model_kwargs is not None
-                else (getattr(self, kwargs_attr) or self.llm_model_kwargs)
-            )
+            # Use `is not None` to allow explicit 0/{} overrides
+            if max_async is not None:
+                effective_max_async = max_async
+            else:
+                stored = getattr(self, max_async_attr)
+                effective_max_async = stored if stored is not None else self.llm_model_max_async
+
+            if timeout is not None:
+                effective_timeout = timeout
+            else:
+                stored = getattr(self, timeout_attr)
+                effective_timeout = stored if stored is not None else self.default_llm_timeout
+
+            if model_kwargs is not None:
+                effective_kwargs = model_kwargs
+            else:
+                stored = getattr(self, kwargs_attr)
+                effective_kwargs = stored if stored is not None else self.llm_model_kwargs
 
             # Rebuild the wrapped function with independent queue
             hashing_kv = self.llm_response_cache
@@ -993,8 +1015,10 @@ class LightRAG:
                 + (f", model={model}" if model else "")
             )
         except Exception as e:
-            # Rollback on failure
+            # Rollback on failure (including raw function)
             setattr(self, func_attr, prev_func)
+            if prev_raw_func is not None:
+                self._raw_role_llm_funcs[role] = prev_raw_func
             self._role_llm_metadata[role] = prev_metadata
             logger.error(f"Failed to update LLM role config for '{role}': {e}")
             raise

--- a/lightrag/llm/binding_options.py
+++ b/lightrag/llm/binding_options.py
@@ -342,6 +342,80 @@ class BindingOptions:
 
         return options
 
+    @classmethod
+    def options_dict_for_role(
+        cls, args: Namespace, role: str, is_cross_provider: bool = False
+    ) -> dict[str, Any]:
+        """
+        Extract role-specific provider options with proper inheritance.
+
+        Same provider: inherit base options from args, overlay role-specific env vars.
+        Cross provider: start from provider defaults, overlay role-specific env vars.
+
+        Role env vars follow the pattern: {ROLE}_{BINDING_PREFIX}_{FIELD}
+        e.g., EXTRACT_OPENAI_LLM_TEMPERATURE, KEYWORD_OLLAMA_LLM_NUM_CTX
+
+        Args:
+            args: Parsed command-line arguments containing base binding options
+            role: Role name ("extract", "keyword", or "query")
+            is_cross_provider: True when the role uses a different provider than base
+
+        Returns:
+            dict[str, Any]: Options dict with role-specific overrides applied
+        """
+        import dataclasses
+        import os
+
+        if is_cross_provider:
+            # Cross-provider: start from provider defaults
+            if dataclasses.is_dataclass(cls):
+                base = {}
+                for f in dataclasses.fields(cls):
+                    if f.name.startswith("_"):
+                        continue
+                    if f.default is not dataclasses.MISSING:
+                        base[f.name] = f.default
+                    elif f.default_factory is not dataclasses.MISSING:
+                        base[f.name] = f.default_factory()
+            else:
+                base = dict(cls._all_class_vars(cls))
+        else:
+            # Same provider: inherit base options
+            base = cls.options_dict(args)
+
+        # Overlay role-specific env var overrides
+        role_upper = role.upper()
+        env_prefix = cls._binding_name.upper() + "_"  # e.g., "OPENAI_LLM_"
+
+        for arg_item in cls.args_env_name_type_value():
+            original_env = arg_item["env_name"]  # e.g., "OPENAI_LLM_TEMPERATURE"
+            role_env = (
+                f"{role_upper}_{original_env}"  # e.g., "EXTRACT_OPENAI_LLM_TEMPERATURE"
+            )
+            field_name = original_env[len(env_prefix) :].lower()  # e.g., "temperature"
+
+            env_raw = os.getenv(role_env)
+            if env_raw is not None:
+                # Type-convert the value
+                field_type = _resolve_optional_type(arg_item["type"])
+                try:
+                    if field_type is bool:
+                        base[field_name] = env_raw.lower() in ("true", "1", "yes")
+                    elif field_type in (list, List[str]):
+                        base[field_name] = json.loads(env_raw)
+                    elif field_type is dict:
+                        base[field_name] = json.loads(env_raw)
+                    elif field_type is int:
+                        base[field_name] = int(env_raw)
+                    elif field_type is float:
+                        base[field_name] = float(env_raw)
+                    else:
+                        base[field_name] = env_raw
+                except (ValueError, json.JSONDecodeError):
+                    base[field_name] = env_raw
+
+        return base
+
     def asdict(self) -> dict[str, Any]:
         """
         Convert an instance of binding options to a dictionary.

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -319,7 +319,7 @@ async def _summarize_descriptions(
     Returns:
         Summarized description string
     """
-    use_llm_func: callable = global_config["llm_model_func"]
+    use_llm_func: callable = global_config["extract_llm_model_func"]
     # Apply higher priority (8) to entity/relation summary tasks
     use_llm_func = partial(use_llm_func, _priority=8)
 
@@ -2896,7 +2896,7 @@ async def extract_entities(
                     "User cancelled during entity extraction"
                 )
 
-    use_llm_func: callable = global_config["llm_model_func"]
+    use_llm_func: callable = global_config["extract_llm_model_func"]
     entity_extract_max_gleaning = global_config["entity_extract_max_gleaning"]
 
     ordered_chunks = list(chunks.items())
@@ -3209,7 +3209,7 @@ async def kg_query(
     if query_param.model_func:
         use_model_func = query_param.model_func
     else:
-        use_model_func = global_config["llm_model_func"]
+        use_model_func = global_config["query_llm_model_func"]
         # Apply higher priority (5) to query relation LLM function
         use_model_func = partial(use_model_func, _priority=5)
 
@@ -3458,8 +3458,8 @@ async def extract_keywords_only(
     if param.model_func:
         use_model_func = param.model_func
     else:
-        use_model_func = global_config["llm_model_func"]
-        # Apply higher priority (5) to query relation LLM function
+        use_model_func = global_config["keyword_llm_model_func"]
+        # Apply higher priority (5) to keyword extraction LLM function
         use_model_func = partial(use_model_func, _priority=5)
 
     result = await use_model_func(kw_prompt, keyword_extraction=True)
@@ -4985,7 +4985,7 @@ async def naive_query(
     if query_param.model_func:
         use_model_func = query_param.model_func
     else:
-        use_model_func = global_config["llm_model_func"]
+        use_model_func = global_config["query_llm_model_func"]
         # Apply higher priority (5) to query relation LLM function
         use_model_func = partial(use_model_func, _priority=5)
 

--- a/tests/test_extract_entities.py
+++ b/tests/test_extract_entities.py
@@ -23,8 +23,12 @@ def _make_global_config(
 ) -> dict:
     """Build a minimal global_config dict for extract_entities."""
     tokenizer = Tokenizer("dummy", DummyTokenizer())
+    llm_mock = AsyncMock(return_value="")
     return {
-        "llm_model_func": AsyncMock(return_value=""),
+        "llm_model_func": llm_mock,
+        "extract_llm_model_func": llm_mock,
+        "keyword_llm_model_func": llm_mock,
+        "query_llm_model_func": llm_mock,
         "entity_extract_max_gleaning": entity_extract_max_gleaning,
         "addon_params": {},
         "tokenizer": tokenizer,
@@ -62,7 +66,7 @@ async def test_gleaning_skipped_when_tokens_exceed_limit():
         entity_extract_max_gleaning=1,
     )
 
-    llm_func = global_config["llm_model_func"]
+    llm_func = global_config["extract_llm_model_func"]
     llm_func.return_value = _EXTRACTION_RESULT
 
     with patch("lightrag.operate.logger") as mock_logger:
@@ -92,7 +96,7 @@ async def test_gleaning_proceeds_when_tokens_within_limit():
         entity_extract_max_gleaning=1,
     )
 
-    llm_func = global_config["llm_model_func"]
+    llm_func = global_config["extract_llm_model_func"]
     llm_func.return_value = _EXTRACTION_RESULT
 
     with patch("lightrag.operate.logger"):
@@ -116,7 +120,7 @@ async def test_no_gleaning_when_max_gleaning_zero():
         entity_extract_max_gleaning=0,
     )
 
-    llm_func = global_config["llm_model_func"]
+    llm_func = global_config["extract_llm_model_func"]
     llm_func.return_value = _EXTRACTION_RESULT
 
     with patch("lightrag.operate.logger"):

--- a/tests/test_llm_role_separation.py
+++ b/tests/test_llm_role_separation.py
@@ -655,6 +655,119 @@ class TestOperateRouting:
         assert mocks["keyword"].await_count == 0
         assert mocks["base"].await_count == 0
 
+    @pytest.mark.asyncio
+    async def test_kg_query_uses_query_func(self):
+        """kg_query() should call query_llm_model_func, not base."""
+        from lightrag.operate import kg_query
+        from lightrag.base import QueryParam
+
+        global_config, mocks = _make_global_config_with_roles()
+
+        # Mock storage dependencies — kg_query returns None when no context
+        mock_graph = MagicMock()
+        mock_entities_vdb = MagicMock()
+        mock_relationships_vdb = MagicMock()
+        mock_text_chunks_db = MagicMock()
+        mock_chunks_vdb = MagicMock()
+
+        # Make vector search return empty so kg_query exits early (no context)
+        mock_entities_vdb.query = AsyncMock(return_value=[])
+        mock_relationships_vdb.query = AsyncMock(return_value=[])
+        mock_chunks_vdb.query = AsyncMock(return_value=[])
+        mock_graph.get_node = AsyncMock(return_value=None)
+
+        mock_hashing_kv = MagicMock()
+        mock_hashing_kv.global_config = {"enable_llm_cache": False}
+
+        # kg_query returns None when no context is built (no entities/relations found)
+        await kg_query(
+            query="What is machine learning?",
+            knowledge_graph_inst=mock_graph,
+            entities_vdb=mock_entities_vdb,
+            relationships_vdb=mock_relationships_vdb,
+            text_chunks_db=mock_text_chunks_db,
+            query_param=QueryParam(mode="hybrid"),
+            global_config=global_config,
+            hashing_kv=mock_hashing_kv,
+            chunks_vdb=mock_chunks_vdb,
+        )
+
+        # With no context, kg_query returns None without calling LLM
+        # But the keyword extraction (for context building) uses keyword role
+        assert mocks["keyword"].await_count >= 1, (
+            "keyword_llm_model_func should be called for keyword extraction in kg_query"
+        )
+        # Base should never be called
+        assert mocks["base"].await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_naive_query_uses_query_func(self):
+        """naive_query() should call query_llm_model_func, not base."""
+        from lightrag.operate import naive_query
+        from lightrag.base import QueryParam
+
+        global_config, mocks = _make_global_config_with_roles()
+
+        # Mock chunks_vdb to return empty (no matching chunks)
+        mock_chunks_vdb = MagicMock()
+        mock_chunks_vdb.query = AsyncMock(return_value=[])
+
+        mock_hashing_kv = MagicMock()
+        mock_hashing_kv.global_config = {"enable_llm_cache": False}
+
+        # naive_query returns None when no chunks are found
+        result = await naive_query(
+            query="What is AI?",
+            chunks_vdb=mock_chunks_vdb,
+            query_param=QueryParam(mode="naive"),
+            global_config=global_config,
+            hashing_kv=mock_hashing_kv,
+        )
+
+        # With no chunks, naive_query returns None without calling query LLM
+        assert result is None
+        # Neither base nor query should be called (no context to query about)
+        assert mocks["base"].await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_naive_query_calls_query_func_with_chunks(self):
+        """naive_query() should use query_llm_model_func when chunks are available."""
+        from lightrag.operate import naive_query
+        from lightrag.base import QueryParam
+
+        global_config, mocks = _make_global_config_with_roles()
+
+        # Mock chunks_vdb to return matching chunks (must include 'content' key)
+        mock_chunks_vdb = MagicMock()
+        mock_chunks_vdb.cosine_better_than_threshold = 0.2
+        mock_chunks_vdb.query = AsyncMock(
+            return_value=[
+                {
+                    "id": "chunk-1",
+                    "distance": 0.9,
+                    "content": "Machine learning is a branch of AI.",
+                    "file_path": "test.txt",
+                }
+            ]
+        )
+
+        mock_hashing_kv = MagicMock()
+        mock_hashing_kv.global_config = {"enable_llm_cache": False}
+
+        await naive_query(
+            query="What is machine learning?",
+            chunks_vdb=mock_chunks_vdb,
+            query_param=QueryParam(mode="naive"),
+            global_config=global_config,
+            hashing_kv=mock_hashing_kv,
+        )
+
+        # query_llm_model_func should be called (not base)
+        assert mocks["query"].await_count >= 1, (
+            "query_llm_model_func should be called by naive_query"
+        )
+        assert mocks["base"].await_count == 0
+
 
 # ---------------------------------------------------------------------------
 # 8. asdict Snapshot Tests
@@ -889,14 +1002,15 @@ class TestEndToEndIntegration:
 class TestEdgeCases:
     """Test edge cases and boundary conditions."""
 
-    def test_zero_max_async_falls_back(self, tmp_path):
-        """max_async=0 is falsy, should fall back to base max_async."""
+    def test_zero_max_async_is_respected(self, tmp_path):
+        """max_async=0 is an explicit override and should be preserved (not fall back)."""
         rag = _make_rag(
             tmp_path,
             llm_model_max_async=4,
             extract_llm_model_max_async=0,
         )
-        # 0 is falsy so should fall back to base value of 4
+        # 0 is explicitly set, so it should be preserved (not fall back to base)
+        assert rag.extract_llm_model_max_async == 0
         # The function should still be created successfully
         assert rag.extract_llm_model_func is not None
         assert callable(rag.extract_llm_model_func)

--- a/tests/test_llm_role_separation.py
+++ b/tests/test_llm_role_separation.py
@@ -1,0 +1,1410 @@
+"""
+Tests for per-role LLM function separation (extract, keyword, query).
+
+Covers:
+- Backward compatibility (no role config → same behavior as before)
+- Role function isolation (each role gets its own wrapped function and queue)
+- Role fallback to base when not configured
+- Custom per-role functions
+- Per-role max_async and timeout
+- Per-role kwargs
+- asdict() snapshot includes role functions for operate.py
+- update_llm_role_config() runtime updates
+- update_llm_role_config() rollback on failure
+- update_llm_role_config() invalid role rejection
+- Operate.py routing: extract_entities uses extract role
+- Operate.py routing: extract summary uses extract role
+- Operate.py routing: keyword extraction uses keyword role
+- Operate.py routing: kg_query uses query role
+- Operate.py routing: naive_query uses query role
+- Operate.py routing: bypass mode uses query role
+- Cross-role isolation under concurrent load
+"""
+
+import asyncio
+import sys
+from dataclasses import asdict
+from unittest.mock import AsyncMock, MagicMock
+
+import numpy as np
+import pytest
+
+from lightrag.lightrag import LightRAG
+from lightrag.utils import EmbeddingFunc, Tokenizer
+
+pytestmark = pytest.mark.offline
+
+
+@pytest.fixture(autouse=False)
+def _restore_config_module():
+    """Ensure lightrag.api.config is the real module, not a Mock.
+
+    test_token_auto_renewal.py replaces it with Mock() at import time,
+    which poisons the module cache for all subsequent tests in the suite.
+    """
+    key = "lightrag.api.config"
+    prev = sys.modules.get(key)
+    if prev is not None and not hasattr(prev, "__file__"):
+        # It's a Mock — remove it so importlib.import_module reloads the real one
+        del sys.modules[key]
+    yield
+    # Restore whatever was there before (including the Mock), so we don't
+    # break test_token_auto_renewal if it runs later.
+    if prev is not None:
+        sys.modules[key] = prev
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _SimpleTokenizer:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _dummy_embedding(texts: list[str]) -> np.ndarray:
+    return np.ones((len(texts), 8), dtype=float)
+
+
+async def _dummy_llm(*args, **kwargs) -> str:
+    return "base_response"
+
+
+async def _extract_llm(*args, **kwargs) -> str:
+    return "extract_response"
+
+
+async def _keyword_llm(*args, **kwargs) -> str:
+    return "keyword_response"
+
+
+async def _query_llm(*args, **kwargs) -> str:
+    return "query_response"
+
+
+def _make_rag(tmp_path, **overrides) -> LightRAG:
+    """Create a LightRAG instance with minimal config for testing."""
+    defaults = dict(
+        working_dir=str(tmp_path / "test_rag"),
+        llm_model_func=_dummy_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8,
+            max_token_size=8192,
+            func=_dummy_embedding,
+        ),
+        tokenizer=Tokenizer("test", _SimpleTokenizer()),
+    )
+    defaults.update(overrides)
+    return LightRAG(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# 1. Backward Compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompatibility:
+    """When no role-specific config is set, behavior matches the old single-LLM pattern."""
+
+    def test_role_funcs_exist_after_init(self, tmp_path):
+        """All three role functions should be set even with no role config."""
+        rag = _make_rag(tmp_path)
+        assert rag.extract_llm_model_func is not None
+        assert rag.keyword_llm_model_func is not None
+        assert rag.query_llm_model_func is not None
+
+    def test_role_funcs_are_callable(self, tmp_path):
+        """Role functions must be callable after wrapping."""
+        rag = _make_rag(tmp_path)
+        assert callable(rag.extract_llm_model_func)
+        assert callable(rag.keyword_llm_model_func)
+        assert callable(rag.query_llm_model_func)
+
+    def test_base_func_still_wrapped(self, tmp_path):
+        """The base llm_model_func should still be wrapped as before."""
+        rag = _make_rag(tmp_path)
+        assert rag.llm_model_func is not None
+        assert callable(rag.llm_model_func)
+
+    def test_asdict_includes_role_funcs(self, tmp_path):
+        """asdict(rag) must include role function keys for operate.py."""
+        rag = _make_rag(tmp_path)
+        config = asdict(rag)
+        assert "extract_llm_model_func" in config
+        assert "keyword_llm_model_func" in config
+        assert "query_llm_model_func" in config
+        # They should be the wrapped callables
+        assert callable(config["extract_llm_model_func"])
+        assert callable(config["keyword_llm_model_func"])
+        assert callable(config["query_llm_model_func"])
+
+
+# ---------------------------------------------------------------------------
+# 2. Role Function Isolation
+# ---------------------------------------------------------------------------
+
+
+class TestRoleFunctionIsolation:
+    """Each role gets its own independent function object, never sharing the base."""
+
+    def test_role_funcs_are_distinct_objects(self, tmp_path):
+        """All three role functions should be distinct from each other and from base."""
+        rag = _make_rag(tmp_path)
+        funcs = [
+            rag.llm_model_func,
+            rag.extract_llm_model_func,
+            rag.keyword_llm_model_func,
+            rag.query_llm_model_func,
+        ]
+        # All should be distinct objects (no shared reference)
+        for i in range(len(funcs)):
+            for j in range(i + 1, len(funcs)):
+                assert funcs[i] is not funcs[j], (
+                    f"Function {i} and {j} should be distinct objects"
+                )
+
+    def test_role_funcs_independent_even_with_same_config(self, tmp_path):
+        """Even when role config matches base exactly, functions must be independent."""
+        rag = _make_rag(
+            tmp_path,
+            llm_model_max_async=4,
+            default_llm_timeout=180,
+        )
+        assert rag.extract_llm_model_func is not rag.llm_model_func
+        assert rag.keyword_llm_model_func is not rag.llm_model_func
+        assert rag.query_llm_model_func is not rag.llm_model_func
+        assert rag.extract_llm_model_func is not rag.keyword_llm_model_func
+
+
+# ---------------------------------------------------------------------------
+# 3. Custom Per-Role Functions
+# ---------------------------------------------------------------------------
+
+
+class TestCustomRoleFunctions:
+    """Test that custom per-role functions are used when provided."""
+
+    @pytest.mark.asyncio
+    async def test_custom_extract_func_is_used(self, tmp_path):
+        """A custom extract function should be wrapped and usable."""
+        call_log = []
+
+        async def custom_extract(*args, **kwargs):
+            call_log.append("extract_called")
+            return "custom_extract_result"
+
+        rag = _make_rag(tmp_path, extract_llm_model_func=custom_extract)
+
+        # The wrapped function should call our custom func
+        await rag.extract_llm_model_func("test prompt")
+        assert "extract_called" in call_log
+
+    @pytest.mark.asyncio
+    async def test_custom_keyword_func_is_used(self, tmp_path):
+        """A custom keyword function should be wrapped and usable."""
+        call_log = []
+
+        async def custom_keyword(*args, **kwargs):
+            call_log.append("keyword_called")
+            return "custom_keyword_result"
+
+        rag = _make_rag(tmp_path, keyword_llm_model_func=custom_keyword)
+        await rag.keyword_llm_model_func("test prompt")
+        assert "keyword_called" in call_log
+
+    @pytest.mark.asyncio
+    async def test_custom_query_func_is_used(self, tmp_path):
+        """A custom query function should be wrapped and usable."""
+        call_log = []
+
+        async def custom_query(*args, **kwargs):
+            call_log.append("query_called")
+            return "custom_query_result"
+
+        rag = _make_rag(tmp_path, query_llm_model_func=custom_query)
+        await rag.query_llm_model_func("test prompt")
+        assert "query_called" in call_log
+
+    def test_mixed_custom_and_default(self, tmp_path):
+        """Can set one role custom while others fall back to base."""
+
+        async def custom_extract(*args, **kwargs):
+            return "custom"
+
+        rag = _make_rag(tmp_path, extract_llm_model_func=custom_extract)
+
+        # Extract should use custom func (different underlying func)
+        # Keyword and query should fall back to base
+        # All should be distinct objects regardless
+        assert rag.extract_llm_model_func is not rag.keyword_llm_model_func
+        assert rag.keyword_llm_model_func is not rag.query_llm_model_func
+
+
+# ---------------------------------------------------------------------------
+# 4. Per-Role Max Async and Timeout
+# ---------------------------------------------------------------------------
+
+
+class TestPerRoleConcurrencyAndTimeout:
+    """Test that per-role max_async and timeout override base values."""
+
+    def test_role_max_async_stored(self, tmp_path):
+        """Per-role max_async values should be preserved on the instance."""
+        rag = _make_rag(
+            tmp_path,
+            llm_model_max_async=4,
+            extract_llm_model_max_async=8,
+            keyword_llm_model_max_async=2,
+            query_llm_model_max_async=16,
+        )
+        assert rag.extract_llm_model_max_async == 8
+        assert rag.keyword_llm_model_max_async == 2
+        assert rag.query_llm_model_max_async == 16
+
+    def test_role_timeout_stored(self, tmp_path):
+        """Per-role timeout values should be preserved on the instance."""
+        rag = _make_rag(
+            tmp_path,
+            default_llm_timeout=180,
+            extract_llm_timeout=240,
+            keyword_llm_timeout=60,
+            query_llm_timeout=300,
+        )
+        assert rag.extract_llm_timeout == 240
+        assert rag.keyword_llm_timeout == 60
+        assert rag.query_llm_timeout == 300
+
+    def test_none_role_values_fallback_to_base(self, tmp_path):
+        """When role max_async/timeout is None, base values are used."""
+        rag = _make_rag(
+            tmp_path,
+            llm_model_max_async=4,
+            default_llm_timeout=180,
+        )
+        assert rag.extract_llm_model_max_async is None
+        assert rag.keyword_llm_model_max_async is None
+        assert rag.query_llm_model_max_async is None
+        assert rag.extract_llm_timeout is None
+        assert rag.keyword_llm_timeout is None
+        assert rag.query_llm_timeout is None
+
+
+# ---------------------------------------------------------------------------
+# 5. Per-Role Kwargs
+# ---------------------------------------------------------------------------
+
+
+class TestPerRoleKwargs:
+    """Test that per-role kwargs are correctly applied."""
+
+    @pytest.mark.asyncio
+    async def test_role_kwargs_passed_to_function(self, tmp_path):
+        """Role-specific kwargs should be baked into the wrapped function."""
+        received_kwargs = {}
+
+        async def tracking_llm(*args, **kwargs):
+            received_kwargs.update(kwargs)
+            return "ok"
+
+        rag = _make_rag(
+            tmp_path,
+            extract_llm_model_func=tracking_llm,
+            extract_llm_model_kwargs={
+                "host": "http://extract-host:11434",
+                "custom_param": "extract_val",
+            },
+        )
+
+        await rag.extract_llm_model_func("test")
+        assert received_kwargs.get("host") == "http://extract-host:11434"
+        assert received_kwargs.get("custom_param") == "extract_val"
+
+    @pytest.mark.asyncio
+    async def test_default_kwargs_when_role_kwargs_none(self, tmp_path):
+        """When role kwargs is None, base llm_model_kwargs should be used."""
+        received_kwargs = {}
+
+        async def tracking_llm(*args, **kwargs):
+            received_kwargs.update(kwargs)
+            return "ok"
+
+        rag = _make_rag(
+            tmp_path,
+            llm_model_func=tracking_llm,
+            llm_model_kwargs={"host": "http://base-host:11434"},
+        )
+
+        await rag.extract_llm_model_func("test")
+        assert received_kwargs.get("host") == "http://base-host:11434"
+
+
+# ---------------------------------------------------------------------------
+# 6. update_llm_role_config()
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateLLMRoleConfig:
+    """Test runtime dynamic updates to role LLM configurations."""
+
+    def test_invalid_role_raises_error(self, tmp_path):
+        """Invalid role name should raise ValueError."""
+        rag = _make_rag(tmp_path)
+        with pytest.raises(ValueError, match="Invalid role"):
+            rag.update_llm_role_config("invalid_role")
+
+    def test_valid_roles_accepted(self, tmp_path):
+        """All three valid role names should be accepted."""
+        rag = _make_rag(tmp_path)
+        for role in ("extract", "keyword", "query"):
+            # Should not raise
+            rag.update_llm_role_config(role, max_async=8)
+
+    @pytest.mark.asyncio
+    async def test_update_model_func(self, tmp_path):
+        """Updating model_func should replace the role's function."""
+        call_log = []
+
+        async def new_func(*args, **kwargs):
+            call_log.append("new_func")
+            return "new_result"
+
+        rag = _make_rag(tmp_path)
+        old_func = rag.extract_llm_model_func
+
+        rag.update_llm_role_config("extract", model_func=new_func)
+
+        assert rag.extract_llm_model_func is not old_func
+        await rag.extract_llm_model_func("test")
+        assert "new_func" in call_log
+
+    def test_update_max_async(self, tmp_path):
+        """Updating max_async should persist on the instance."""
+        rag = _make_rag(tmp_path, llm_model_max_async=4)
+        rag.update_llm_role_config("keyword", max_async=20)
+        assert rag.keyword_llm_model_max_async == 20
+
+    def test_update_timeout(self, tmp_path):
+        """Updating timeout should persist on the instance."""
+        rag = _make_rag(tmp_path, default_llm_timeout=180)
+        rag.update_llm_role_config("query", timeout=600)
+        assert rag.query_llm_timeout == 600
+
+    def test_update_kwargs(self, tmp_path):
+        """Updating model_kwargs should persist on the instance."""
+        rag = _make_rag(tmp_path)
+        new_kwargs = {"host": "http://new-host:8080"}
+        rag.update_llm_role_config("extract", model_kwargs=new_kwargs)
+        assert rag.extract_llm_model_kwargs == new_kwargs
+
+    def test_rollback_on_failure(self, tmp_path):
+        """If update fails, the previous function should be preserved."""
+        rag = _make_rag(tmp_path)
+        original_func = rag.extract_llm_model_func
+
+        # Force a failure by passing a non-callable as model_func
+        # The priority_limit_async_func_call will raise because partial(non_callable) fails
+        with pytest.raises(Exception):
+            rag.update_llm_role_config("extract", model_func="not_a_function")
+
+        # Original function should be preserved
+        assert rag.extract_llm_model_func is original_func
+
+    def test_update_creates_new_function_object(self, tmp_path):
+        """Each update should create a fresh wrapped function."""
+        rag = _make_rag(tmp_path)
+        func_before = rag.query_llm_model_func
+
+        rag.update_llm_role_config("query", max_async=10)
+        func_after = rag.query_llm_model_func
+
+        assert func_before is not func_after
+
+    def test_multiple_updates_accumulate(self, tmp_path):
+        """Multiple updates to the same role should each take effect."""
+        rag = _make_rag(tmp_path)
+
+        rag.update_llm_role_config("extract", max_async=10)
+        assert rag.extract_llm_model_max_async == 10
+
+        rag.update_llm_role_config("extract", timeout=500)
+        assert rag.extract_llm_timeout == 500
+        # Previous max_async should be retained
+        assert rag.extract_llm_model_max_async == 10
+
+    @pytest.mark.asyncio
+    async def test_no_double_wrapping_on_update(self, tmp_path):
+        """Updating without model_func should not double-wrap the function."""
+        received_kwargs_list = []
+
+        async def tracking_llm(*args, **kwargs):
+            received_kwargs_list.append(dict(kwargs))
+            return "ok"
+
+        rag = _make_rag(
+            tmp_path,
+            extract_llm_model_func=tracking_llm,
+            extract_llm_model_kwargs={"custom_key": "val1"},
+        )
+
+        # Update max_async only (no new model_func) — this was the bug trigger
+        rag.update_llm_role_config("extract", max_async=10)
+
+        await rag.extract_llm_model_func("test prompt")
+        assert len(received_kwargs_list) == 1
+
+        kw = received_kwargs_list[0]
+        # hashing_kv should appear exactly once (not doubled)
+        assert "hashing_kv" in kw
+        # custom_key should appear exactly once (not doubled)
+        assert kw.get("custom_key") == "val1"
+
+    @pytest.mark.asyncio
+    async def test_repeated_updates_no_nesting(self, tmp_path):
+        """Calling update_llm_role_config multiple times should not nest wrappers."""
+        call_count = []
+
+        async def counting_llm(*args, **kwargs):
+            call_count.append(1)
+            return "result"
+
+        rag = _make_rag(tmp_path, extract_llm_model_func=counting_llm)
+
+        # Update 5 times without providing a new model_func
+        for i in range(5):
+            rag.update_llm_role_config("extract", max_async=i + 2)
+
+        # Call the function — it should invoke the underlying func exactly once
+        await rag.extract_llm_model_func("test")
+        assert len(call_count) == 1, (
+            f"Expected 1 call but got {len(call_count)} — function is nested/double-wrapped"
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_with_new_func_replaces_raw(self, tmp_path):
+        """Providing a new model_func to update should replace the raw function."""
+        log = []
+
+        async def func_v1(*args, **kwargs):
+            log.append("v1")
+            return "v1"
+
+        async def func_v2(*args, **kwargs):
+            log.append("v2")
+            return "v2"
+
+        rag = _make_rag(tmp_path, extract_llm_model_func=func_v1)
+
+        # Replace with v2
+        rag.update_llm_role_config("extract", model_func=func_v2)
+        await rag.extract_llm_model_func("test")
+        assert log == ["v2"]
+
+        # Update max_async only — should still use v2 (not fall back to v1 or double-wrap)
+        log.clear()
+        rag.update_llm_role_config("extract", max_async=20)
+        await rag.extract_llm_model_func("test")
+        assert log == ["v2"]
+
+
+# ---------------------------------------------------------------------------
+# 7. Operate.py Routing Tests
+# ---------------------------------------------------------------------------
+
+
+def _make_global_config_with_roles():
+    """Build a global_config dict with separate mock LLM funcs per role."""
+    extract_mock = AsyncMock(
+        return_value="(entity<|#|>TEST<|#|>CONCEPT<|#|>desc)<|COMPLETE|>"
+    )
+    keyword_mock = AsyncMock(
+        return_value='{"high_level_keywords": ["test"], "low_level_keywords": ["item"]}'
+    )
+    query_mock = AsyncMock(return_value="query answer")
+    base_mock = AsyncMock(return_value="base answer")
+
+    tokenizer = Tokenizer("test", _SimpleTokenizer())
+
+    return {
+        "llm_model_func": base_mock,
+        "extract_llm_model_func": extract_mock,
+        "keyword_llm_model_func": keyword_mock,
+        "query_llm_model_func": query_mock,
+        "entity_extract_max_gleaning": 0,
+        "addon_params": {},
+        "tokenizer": tokenizer,
+        "max_extract_input_tokens": 20480,
+        "llm_model_max_async": 4,
+        "summary_length_recommended": 200,
+        "summary_context_size": 4000,
+        "embedding_token_limit": None,
+        "max_total_tokens": 30000,
+    }, {
+        "base": base_mock,
+        "extract": extract_mock,
+        "keyword": keyword_mock,
+        "query": query_mock,
+    }
+
+
+class TestOperateRouting:
+    """Verify that operate.py functions use the correct role-specific LLM function."""
+
+    @pytest.mark.asyncio
+    async def test_extract_entities_uses_extract_func(self):
+        """extract_entities() should call extract_llm_model_func, not base."""
+        from lightrag.operate import extract_entities
+
+        global_config, mocks = _make_global_config_with_roles()
+
+        chunks = {
+            "chunk-001": {
+                "tokens": 10,
+                "content": "Test entity content.",
+                "full_doc_id": "doc-001",
+                "chunk_order_index": 0,
+            }
+        }
+
+        await extract_entities(chunks=chunks, global_config=global_config)
+
+        # Extract mock should have been called
+        assert mocks["extract"].await_count >= 1, (
+            "extract_llm_model_func should be called by extract_entities"
+        )
+        # Base mock should NOT have been called
+        assert mocks["base"].await_count == 0, (
+            "base llm_model_func should not be called directly by extract_entities"
+        )
+
+    @pytest.mark.asyncio
+    async def test_summarize_descriptions_uses_extract_func(self):
+        """_summarize_descriptions() should use extract_llm_model_func."""
+        from lightrag.operate import _summarize_descriptions
+
+        global_config, mocks = _make_global_config_with_roles()
+        mocks["extract"].return_value = "summarized description"
+
+        await _summarize_descriptions(
+            description_type="entity",
+            description_name="TEST_ENTITY",
+            description_list=["desc1", "desc2", "desc3"],
+            global_config=global_config,
+        )
+
+        assert mocks["extract"].await_count >= 1, (
+            "extract_llm_model_func should be called by _summarize_descriptions"
+        )
+        assert mocks["base"].await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_extract_keywords_uses_keyword_func(self):
+        """extract_keywords_only() should use keyword_llm_model_func."""
+        from lightrag.operate import extract_keywords_only
+        from lightrag.base import QueryParam
+
+        global_config, mocks = _make_global_config_with_roles()
+
+        # Provide a mock hashing_kv that extract_keywords_only needs for caching
+        mock_hashing_kv = MagicMock()
+        mock_hashing_kv.global_config = {"enable_llm_cache": False}
+
+        hl, ll = await extract_keywords_only(
+            text="What is machine learning?",
+            param=QueryParam(mode="hybrid"),
+            global_config=global_config,
+            hashing_kv=mock_hashing_kv,
+        )
+
+        assert mocks["keyword"].await_count >= 1, (
+            "keyword_llm_model_func should be called by extract_keywords_only"
+        )
+        assert mocks["base"].await_count == 0
+        assert mocks["extract"].await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_extract_keywords_respects_model_func_override(self):
+        """When QueryParam.model_func is set, it should override the keyword role func."""
+        from lightrag.operate import extract_keywords_only
+        from lightrag.base import QueryParam
+
+        global_config, mocks = _make_global_config_with_roles()
+
+        custom_mock = AsyncMock(
+            return_value='{"high_level_keywords": ["custom"], "low_level_keywords": ["override"]}'
+        )
+        param = QueryParam(mode="hybrid", model_func=custom_mock)
+
+        # Provide a mock hashing_kv that extract_keywords_only needs for caching
+        mock_hashing_kv = MagicMock()
+        mock_hashing_kv.global_config = {"enable_llm_cache": False}
+
+        hl, ll = await extract_keywords_only(
+            text="What is AI?",
+            param=param,
+            global_config=global_config,
+            hashing_kv=mock_hashing_kv,
+        )
+
+        # Custom model_func should be used instead
+        assert custom_mock.await_count >= 1
+        assert mocks["keyword"].await_count == 0
+        assert mocks["base"].await_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 8. asdict Snapshot Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsDictSnapshot:
+    """Test that asdict(rag) produces correct snapshots for operate.py consumption."""
+
+    def test_snapshot_has_all_role_keys(self, tmp_path):
+        """The asdict snapshot should include all role function keys."""
+        rag = _make_rag(tmp_path)
+        config = asdict(rag)
+
+        required_keys = [
+            "llm_model_func",
+            "extract_llm_model_func",
+            "keyword_llm_model_func",
+            "query_llm_model_func",
+            "extract_llm_model_max_async",
+            "keyword_llm_model_max_async",
+            "query_llm_model_max_async",
+            "extract_llm_timeout",
+            "keyword_llm_timeout",
+            "query_llm_timeout",
+            "extract_llm_model_kwargs",
+            "keyword_llm_model_kwargs",
+            "query_llm_model_kwargs",
+        ]
+        for key in required_keys:
+            assert key in config, f"Missing key '{key}' in asdict snapshot"
+
+    def test_snapshot_role_funcs_are_callable(self, tmp_path):
+        """Role functions in the snapshot should be the wrapped callables."""
+        rag = _make_rag(tmp_path)
+        config = asdict(rag)
+        for role in ("extract", "keyword", "query"):
+            func = config[f"{role}_llm_model_func"]
+            assert callable(func), (
+                f"{role}_llm_model_func in snapshot should be callable"
+            )
+
+    def test_snapshot_reflects_updates(self, tmp_path):
+        """After update_llm_role_config, the next asdict should reflect the change."""
+        rag = _make_rag(tmp_path)
+
+        async def new_extract(*a, **kw):
+            return "updated"
+
+        rag.update_llm_role_config("extract", model_func=new_extract)
+
+        config = asdict(rag)
+        # The function should be a newly wrapped version
+        assert callable(config["extract_llm_model_func"])
+
+    def test_snapshot_preserves_max_async_and_timeout(self, tmp_path):
+        """Per-role max_async and timeout should be in the snapshot."""
+        rag = _make_rag(
+            tmp_path,
+            extract_llm_model_max_async=10,
+            keyword_llm_timeout=60,
+        )
+        config = asdict(rag)
+        assert config["extract_llm_model_max_async"] == 10
+        assert config["keyword_llm_timeout"] == 60
+
+
+# ---------------------------------------------------------------------------
+# 9. Concurrency Isolation Test
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrencyIsolation:
+    """Test that role queues operate independently under concurrent load."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_role_calls_dont_interfere(self, tmp_path):
+        """Multiple concurrent calls to different roles should not block each other."""
+        extract_events = []
+        keyword_events = []
+        query_events = []
+
+        async def slow_extract(*args, **kwargs):
+            extract_events.append("start")
+            await asyncio.sleep(0.05)
+            extract_events.append("end")
+            return "extract"
+
+        async def slow_keyword(*args, **kwargs):
+            keyword_events.append("start")
+            await asyncio.sleep(0.05)
+            keyword_events.append("end")
+            return "keyword"
+
+        async def slow_query(*args, **kwargs):
+            query_events.append("start")
+            await asyncio.sleep(0.05)
+            query_events.append("end")
+            return "query"
+
+        rag = _make_rag(
+            tmp_path,
+            extract_llm_model_func=slow_extract,
+            keyword_llm_model_func=slow_keyword,
+            query_llm_model_func=slow_query,
+            # Each role gets only 1 concurrent slot
+            extract_llm_model_max_async=1,
+            keyword_llm_model_max_async=1,
+            query_llm_model_max_async=1,
+        )
+
+        # Run all three roles concurrently
+        await asyncio.gather(
+            rag.extract_llm_model_func("test"),
+            rag.keyword_llm_model_func("test"),
+            rag.query_llm_model_func("test"),
+        )
+
+        # All should have completed
+        assert len(extract_events) == 2
+        assert len(keyword_events) == 2
+        assert len(query_events) == 2
+
+    @pytest.mark.asyncio
+    async def test_same_role_respects_max_async(self, tmp_path):
+        """Within a single role, max_async=1 should serialize calls."""
+        execution_order = []
+
+        async def tracking_llm(*args, **kwargs):
+            call_id = kwargs.get("_call_id", "unknown")
+            execution_order.append(f"start_{call_id}")
+            await asyncio.sleep(0.02)
+            execution_order.append(f"end_{call_id}")
+            return "ok"
+
+        rag = _make_rag(
+            tmp_path,
+            extract_llm_model_func=tracking_llm,
+            extract_llm_model_max_async=1,
+        )
+
+        # Launch 3 concurrent calls to the same role
+        await asyncio.gather(
+            rag.extract_llm_model_func("a", _call_id="1"),
+            rag.extract_llm_model_func("b", _call_id="2"),
+            rag.extract_llm_model_func("c", _call_id="3"),
+        )
+
+        # All 6 events should have occurred (3 starts + 3 ends)
+        assert len(execution_order) == 6
+
+        # With max_async=1, calls should be serialized:
+        # Each "start" should be followed by its "end" before the next "start"
+        # (This is guaranteed by the priority queue semaphore)
+        starts = [i for i, e in enumerate(execution_order) if e.startswith("start")]
+        ends = [i for i, e in enumerate(execution_order) if e.startswith("end")]
+        # Each start should have an end before the next start (serialized)
+        for i in range(len(starts) - 1):
+            # Find the end that corresponds to this start
+            assert any(
+                ends[j] > starts[i] and ends[j] < starts[i + 1]
+                for j in range(len(ends))
+            ), "Calls should be serialized with max_async=1"
+
+
+# ---------------------------------------------------------------------------
+# 10. End-to-End Integration with LightRAG Instance
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndIntegration:
+    """Test the full flow through LightRAG methods that use role functions."""
+
+    @pytest.mark.asyncio
+    async def test_ainsert_uses_extract_func(self, tmp_path):
+        """Document insertion should route through extract_llm_model_func."""
+        extract_called = []
+
+        async def tracking_extract(*args, **kwargs):
+            extract_called.append(True)
+            return "(entity<|#|>TEST<|#|>CONCEPT<|#|>description)<|COMPLETE|>"
+
+        rag = _make_rag(
+            tmp_path,
+            extract_llm_model_func=tracking_extract,
+        )
+        await rag.initialize_storages()
+
+        try:
+            await rag.ainsert("This is a test document about machine learning.")
+            # The extract function should have been invoked during entity extraction
+            assert len(extract_called) >= 1, (
+                "extract_llm_model_func should be called during ainsert"
+            )
+        finally:
+            await rag.finalize_storages()
+
+    @pytest.mark.asyncio
+    async def test_bypass_query_uses_query_func(self, tmp_path):
+        """Bypass mode should use query_llm_model_func."""
+        query_called = []
+
+        async def tracking_query(*args, **kwargs):
+            query_called.append(True)
+            return "bypass response"
+
+        rag = _make_rag(
+            tmp_path,
+            query_llm_model_func=tracking_query,
+        )
+        await rag.initialize_storages()
+
+        try:
+            from lightrag.base import QueryParam
+
+            await rag.aquery_llm(
+                "What is AI?",
+                param=QueryParam(mode="bypass"),
+            )
+            assert len(query_called) >= 1, (
+                "query_llm_model_func should be called in bypass mode"
+            )
+        finally:
+            await rag.finalize_storages()
+
+
+# ---------------------------------------------------------------------------
+# 11. Edge Cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Test edge cases and boundary conditions."""
+
+    def test_zero_max_async_falls_back(self, tmp_path):
+        """max_async=0 is falsy, should fall back to base max_async."""
+        rag = _make_rag(
+            tmp_path,
+            llm_model_max_async=4,
+            extract_llm_model_max_async=0,
+        )
+        # 0 is falsy so should fall back to base value of 4
+        # The function should still be created successfully
+        assert rag.extract_llm_model_func is not None
+        assert callable(rag.extract_llm_model_func)
+
+    def test_empty_kwargs_dict(self, tmp_path):
+        """Empty dict for role kwargs should work (not fall back to base)."""
+        rag = _make_rag(
+            tmp_path,
+            llm_model_kwargs={"host": "http://base:11434"},
+            extract_llm_model_kwargs={},  # Empty but not None
+        )
+        # Should not fall back to base kwargs since it's explicitly set to empty dict
+        # (empty dict is falsy, so currently falls back - this is a known behavior)
+        assert rag.extract_llm_model_func is not None
+
+    def test_all_roles_with_different_configs(self, tmp_path):
+        """All three roles with completely different configs should work."""
+
+        async def e(*a, **kw):
+            return "e"
+
+        async def k(*a, **kw):
+            return "k"
+
+        async def q(*a, **kw):
+            return "q"
+
+        rag = _make_rag(
+            tmp_path,
+            extract_llm_model_func=e,
+            extract_llm_model_max_async=2,
+            extract_llm_timeout=100,
+            extract_llm_model_kwargs={"mode": "extract"},
+            keyword_llm_model_func=k,
+            keyword_llm_model_max_async=4,
+            keyword_llm_timeout=200,
+            keyword_llm_model_kwargs={"mode": "keyword"},
+            query_llm_model_func=q,
+            query_llm_model_max_async=8,
+            query_llm_timeout=300,
+            query_llm_model_kwargs={"mode": "query"},
+        )
+
+        assert rag.extract_llm_model_max_async == 2
+        assert rag.keyword_llm_model_max_async == 4
+        assert rag.query_llm_model_max_async == 8
+        assert rag.extract_llm_timeout == 100
+        assert rag.keyword_llm_timeout == 200
+        assert rag.query_llm_timeout == 300
+
+    def test_update_all_roles_sequentially(self, tmp_path):
+        """Updating all three roles sequentially should not cause issues."""
+        rag = _make_rag(tmp_path)
+
+        for role in ("extract", "keyword", "query"):
+            old_func = getattr(rag, f"{role}_llm_model_func")
+            rag.update_llm_role_config(role, max_async=10, timeout=500)
+            new_func = getattr(rag, f"{role}_llm_model_func")
+            assert old_func is not new_func
+
+        assert rag.extract_llm_model_max_async == 10
+        assert rag.keyword_llm_model_max_async == 10
+        assert rag.query_llm_model_max_async == 10
+
+
+# ---------------------------------------------------------------------------
+# 12. API Config Parsing Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_restore_config_module")
+class TestAPIConfigParsing:
+    """Test that per-role environment variables are correctly parsed in config.py."""
+
+    def test_role_env_vars_parsed(self, monkeypatch):
+        """Per-role env vars should be parsed into the args namespace."""
+        monkeypatch.setenv("EXTRACT_LLM_BINDING", "openai")
+        monkeypatch.setenv("EXTRACT_LLM_MODEL", "gpt-4o")
+        monkeypatch.setenv("EXTRACT_LLM_BINDING_HOST", "https://api.openai.com/v1")
+        monkeypatch.setenv("EXTRACT_LLM_BINDING_API_KEY", "sk-extract")
+        monkeypatch.setenv("MAX_ASYNC_EXTRACT_LLM", "10")
+        monkeypatch.setenv("LLM_TIMEOUT_EXTRACT_LLM", "240")
+
+        monkeypatch.setenv("KEYWORD_LLM_BINDING", "gemini")
+        monkeypatch.setenv("KEYWORD_LLM_MODEL", "gemini-2.0-flash-lite")
+        monkeypatch.setenv("MAX_ASYNC_KEYWORD_LLM", "3")
+        monkeypatch.setenv("LLM_TIMEOUT_KEYWORD_LLM", "60")
+
+        monkeypatch.setenv("QUERY_LLM_BINDING", "ollama")
+        monkeypatch.setenv("QUERY_LLM_MODEL", "llama3:8b")
+        monkeypatch.setenv("QUERY_LLM_BINDING_HOST", "http://localhost:11434")
+        monkeypatch.setenv("MAX_ASYNC_QUERY_LLM", "16")
+        monkeypatch.setenv("LLM_TIMEOUT_QUERY_LLM", "300")
+
+        # Mock sys.argv to prevent argparse from parsing pytest args
+        import sys
+
+        monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+
+        from lightrag.api.config import initialize_config
+
+        args = initialize_config(force=True)
+
+        assert args.extract_llm_binding == "openai"
+        assert args.extract_llm_model == "gpt-4o"
+        assert args.extract_llm_binding_host == "https://api.openai.com/v1"
+        assert args.extract_llm_binding_api_key == "sk-extract"
+        assert args.max_async_extract_llm == 10
+        assert args.llm_timeout_extract_llm == 240
+
+        assert args.keyword_llm_binding == "gemini"
+        assert args.keyword_llm_model == "gemini-2.0-flash-lite"
+        assert args.max_async_keyword_llm == 3
+        assert args.llm_timeout_keyword_llm == 60
+
+        assert args.query_llm_binding == "ollama"
+        assert args.query_llm_model == "llama3:8b"
+        assert args.query_llm_binding_host == "http://localhost:11434"
+        assert args.max_async_query_llm == 16
+        assert args.llm_timeout_query_llm == 300
+
+    def test_role_env_vars_default_none(self, monkeypatch):
+        """When no role env vars are set, values should default to None."""
+        import sys
+
+        monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+
+        # Clear any role env vars that might be set
+        for var in [
+            "EXTRACT_LLM_BINDING",
+            "EXTRACT_LLM_MODEL",
+            "EXTRACT_LLM_BINDING_HOST",
+            "EXTRACT_LLM_BINDING_API_KEY",
+            "MAX_ASYNC_EXTRACT_LLM",
+            "LLM_TIMEOUT_EXTRACT_LLM",
+            "KEYWORD_LLM_BINDING",
+            "KEYWORD_LLM_MODEL",
+            "KEYWORD_LLM_BINDING_HOST",
+            "KEYWORD_LLM_BINDING_API_KEY",
+            "MAX_ASYNC_KEYWORD_LLM",
+            "LLM_TIMEOUT_KEYWORD_LLM",
+            "QUERY_LLM_BINDING",
+            "QUERY_LLM_MODEL",
+            "QUERY_LLM_BINDING_HOST",
+            "QUERY_LLM_BINDING_API_KEY",
+            "MAX_ASYNC_QUERY_LLM",
+            "LLM_TIMEOUT_QUERY_LLM",
+        ]:
+            monkeypatch.delenv(var, raising=False)
+
+        from lightrag.api.config import initialize_config
+
+        args = initialize_config(force=True)
+
+        assert args.extract_llm_binding is None
+        assert args.extract_llm_model is None
+        assert args.extract_llm_binding_host is None
+        assert args.extract_llm_binding_api_key is None
+        assert args.max_async_extract_llm is None
+        assert args.llm_timeout_extract_llm is None
+
+        assert args.keyword_llm_binding is None
+        assert args.keyword_llm_model is None
+        assert args.max_async_keyword_llm is None
+
+        assert args.query_llm_binding is None
+        assert args.query_llm_model is None
+        assert args.max_async_query_llm is None
+
+    def test_partial_role_config(self, monkeypatch):
+        """Setting only some role vars should work; others remain None."""
+        import sys
+
+        monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+
+        # Clear all role env vars
+        for prefix in ["EXTRACT", "KEYWORD", "QUERY"]:
+            for suffix in [
+                "_LLM_BINDING",
+                "_LLM_MODEL",
+                "_LLM_BINDING_HOST",
+                "_LLM_BINDING_API_KEY",
+            ]:
+                monkeypatch.delenv(f"{prefix}{suffix}", raising=False)
+            monkeypatch.delenv(f"MAX_ASYNC_{prefix}_LLM", raising=False)
+            monkeypatch.delenv(f"LLM_TIMEOUT_{prefix}_LLM", raising=False)
+
+        # Only set keyword model
+        monkeypatch.setenv("KEYWORD_LLM_MODEL", "gpt-4o-mini")
+
+        from lightrag.api.config import initialize_config
+
+        args = initialize_config(force=True)
+
+        assert args.extract_llm_model is None
+        assert args.keyword_llm_model == "gpt-4o-mini"
+        assert args.query_llm_model is None
+
+
+# ---------------------------------------------------------------------------
+# 13. Per-Role Provider Options (binding_options.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_restore_config_module")
+class TestPerRoleProviderOptions:
+    """Test options_dict_for_role for per-role provider option overrides."""
+
+    def test_same_provider_inherits_base_options(self, monkeypatch):
+        """Same provider: role options should inherit from base, overlay role-specific."""
+        import sys
+
+        monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+        monkeypatch.setenv("LLM_BINDING", "openai")
+
+        # Set base OpenAI options
+        monkeypatch.setenv("OPENAI_LLM_TEMPERATURE", "0.7")
+        monkeypatch.setenv("OPENAI_LLM_TOP_P", "0.9")
+
+        # Set role-specific override for extract only
+        monkeypatch.setenv("EXTRACT_OPENAI_LLM_TEMPERATURE", "0.1")
+
+        from lightrag.api.config import initialize_config
+
+        args = initialize_config(force=True)
+
+        from lightrag.llm.binding_options import OpenAILLMOptions
+
+        role_opts = OpenAILLMOptions.options_dict_for_role(
+            args, "extract", is_cross_provider=False
+        )
+
+        # Temperature should be overridden for extract
+        assert role_opts["temperature"] == 0.1
+        # top_p should be inherited from base
+        assert role_opts["top_p"] == 0.9
+
+    def test_cross_provider_starts_from_defaults(self, monkeypatch):
+        """Cross provider: role options should start from provider defaults, not base."""
+        import sys
+
+        monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+        monkeypatch.setenv("LLM_BINDING", "ollama")
+
+        # Set base Ollama options (should NOT be inherited by cross-provider role)
+        monkeypatch.setenv("OLLAMA_LLM_NUM_CTX", "65536")
+
+        # Set role-specific OpenAI option
+        monkeypatch.setenv("EXTRACT_OPENAI_LLM_TEMPERATURE", "0.2")
+
+        from lightrag.api.config import initialize_config
+
+        args = initialize_config(force=True)
+
+        from lightrag.llm.binding_options import OpenAILLMOptions
+
+        role_opts = OpenAILLMOptions.options_dict_for_role(
+            args, "extract", is_cross_provider=True
+        )
+
+        # Temperature should be the role-specific override
+        assert role_opts["temperature"] == 0.2
+        # top_p should be the OpenAI default (1.0), not inherited from ollama
+        assert role_opts["top_p"] == 1.0
+
+    def test_no_role_overrides_returns_base(self, monkeypatch):
+        """No role env vars: should return base options unchanged."""
+        import sys
+
+        monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+        monkeypatch.setenv("LLM_BINDING", "openai")
+        monkeypatch.setenv("OPENAI_LLM_TEMPERATURE", "0.5")
+
+        # Clear any role-specific env vars
+        monkeypatch.delenv("EXTRACT_OPENAI_LLM_TEMPERATURE", raising=False)
+
+        from lightrag.api.config import initialize_config
+
+        args = initialize_config(force=True)
+
+        from lightrag.llm.binding_options import OpenAILLMOptions
+
+        base_opts = OpenAILLMOptions.options_dict(args)
+        role_opts = OpenAILLMOptions.options_dict_for_role(
+            args, "extract", is_cross_provider=False
+        )
+
+        assert role_opts["temperature"] == base_opts["temperature"]
+
+    def test_ollama_role_options(self, monkeypatch):
+        """Ollama per-role options should work with role env var prefix."""
+        import sys
+
+        monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+        monkeypatch.setenv("LLM_BINDING", "ollama")
+        monkeypatch.setenv("OLLAMA_LLM_NUM_CTX", "32768")
+
+        # Set role-specific ollama option
+        monkeypatch.setenv("EXTRACT_OLLAMA_LLM_NUM_CTX", "65536")
+        monkeypatch.setenv("EXTRACT_OLLAMA_LLM_TEMPERATURE", "0.1")
+
+        from lightrag.api.config import initialize_config
+
+        args = initialize_config(force=True)
+
+        from lightrag.llm.binding_options import OllamaLLMOptions
+
+        role_opts = OllamaLLMOptions.options_dict_for_role(
+            args, "extract", is_cross_provider=False
+        )
+
+        assert role_opts["num_ctx"] == 65536
+        assert role_opts["temperature"] == 0.1
+
+    def test_gemini_role_options(self, monkeypatch):
+        """Gemini per-role options should work with role env var prefix."""
+        import sys
+
+        monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+        monkeypatch.setenv("LLM_BINDING", "gemini")
+
+        monkeypatch.setenv("QUERY_GEMINI_LLM_TEMPERATURE", "0.8")
+        monkeypatch.setenv("QUERY_GEMINI_LLM_MAX_OUTPUT_TOKENS", "4096")
+
+        from lightrag.api.config import initialize_config
+
+        args = initialize_config(force=True)
+
+        from lightrag.llm.binding_options import GeminiLLMOptions
+
+        role_opts = GeminiLLMOptions.options_dict_for_role(
+            args, "query", is_cross_provider=False
+        )
+
+        assert role_opts["temperature"] == 0.8
+        assert role_opts["max_output_tokens"] == 4096
+
+    def test_multiple_roles_different_options(self, monkeypatch):
+        """Different roles can have different provider option overrides."""
+        import sys
+
+        monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+        monkeypatch.setenv("LLM_BINDING", "openai")
+        monkeypatch.setenv("OPENAI_LLM_TEMPERATURE", "0.7")
+
+        monkeypatch.setenv("EXTRACT_OPENAI_LLM_TEMPERATURE", "0.1")
+        monkeypatch.setenv("KEYWORD_OPENAI_LLM_TEMPERATURE", "0.0")
+        monkeypatch.setenv("QUERY_OPENAI_LLM_TEMPERATURE", "0.9")
+
+        from lightrag.api.config import initialize_config
+
+        args = initialize_config(force=True)
+
+        from lightrag.llm.binding_options import OpenAILLMOptions
+
+        extract_opts = OpenAILLMOptions.options_dict_for_role(args, "extract")
+        keyword_opts = OpenAILLMOptions.options_dict_for_role(args, "keyword")
+        query_opts = OpenAILLMOptions.options_dict_for_role(args, "query")
+
+        assert extract_opts["temperature"] == 0.1
+        assert keyword_opts["temperature"] == 0.0
+        assert query_opts["temperature"] == 0.9
+
+
+# ---------------------------------------------------------------------------
+# 14. update_llm_role_config Extended Params
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateLLMRoleConfigExtended:
+    """Test extended update_llm_role_config with binding/model/host/api_key/provider_options."""
+
+    def test_metadata_stored_on_update(self, tmp_path):
+        """Binding metadata should be stored when provided."""
+        rag = _make_rag(tmp_path)
+        rag.update_llm_role_config(
+            "extract",
+            binding="openai",
+            model="gpt-4o",
+            host="https://api.openai.com/v1",
+            api_key="sk-test",
+            provider_options={"temperature": 0.1},
+        )
+
+        metadata = rag._role_llm_metadata["extract"]
+        assert metadata["binding"] == "openai"
+        assert metadata["model"] == "gpt-4o"
+        assert metadata["host"] == "https://api.openai.com/v1"
+        assert metadata["api_key"] == "***"  # Should be masked
+        assert metadata["provider_options"] == {"temperature": 0.1}
+
+    def test_metadata_partial_update(self, tmp_path):
+        """Partial metadata updates should only change specified fields."""
+        rag = _make_rag(tmp_path)
+        rag.update_llm_role_config("query", binding="openai", model="gpt-4o")
+        rag.update_llm_role_config("query", model="gpt-4o-mini")
+
+        metadata = rag._role_llm_metadata["query"]
+        assert metadata["binding"] == "openai"  # Preserved from first update
+        assert metadata["model"] == "gpt-4o-mini"  # Updated
+
+    def test_metadata_rollback_on_failure(self, tmp_path):
+        """Metadata should be rolled back if function wrapping fails."""
+        rag = _make_rag(tmp_path)
+        rag.update_llm_role_config("extract", binding="openai", model="gpt-4o")
+
+        with pytest.raises(Exception):
+            rag.update_llm_role_config(
+                "extract",
+                model_func="not_callable",
+                binding="gemini",
+                model="gemini-pro",
+            )
+
+        # Metadata should be rolled back to pre-failure state
+        metadata = rag._role_llm_metadata["extract"]
+        assert metadata["binding"] == "openai"
+        assert metadata["model"] == "gpt-4o"
+
+    def test_metadata_empty_initially(self, tmp_path):
+        """Metadata should be empty after initial construction."""
+        rag = _make_rag(tmp_path)
+        assert rag._role_llm_metadata == {}
+
+    @pytest.mark.asyncio
+    async def test_update_with_all_extended_params(self, tmp_path):
+        """Update with all params including model_func should work end-to-end."""
+        call_log = []
+
+        async def new_func(*args, **kwargs):
+            call_log.append("called")
+            return "result"
+
+        rag = _make_rag(tmp_path)
+        rag.update_llm_role_config(
+            "query",
+            binding="openai",
+            model="gpt-4o",
+            host="https://api.openai.com/v1",
+            api_key="sk-test",
+            provider_options={"temperature": 0.5},
+            model_func=new_func,
+            max_async=20,
+            timeout=600,
+        )
+
+        # Function should work
+        await rag.query_llm_model_func("test")
+        assert "called" in call_log
+
+        # Metadata and attributes should be set
+        assert rag._role_llm_metadata["query"]["binding"] == "openai"
+        assert rag.query_llm_model_max_async == 20
+        assert rag.query_llm_timeout == 600
+
+
+# ---------------------------------------------------------------------------
+# 15. Cross-Provider Validation Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_restore_config_module")
+class TestCrossProviderValidation:
+    """Test cross-provider validation in create_role_llm_func."""
+
+    def test_cross_provider_missing_model_raises(self, monkeypatch):
+        """Cross-provider without model should raise ValueError."""
+        import sys
+
+        monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+        monkeypatch.setenv("LLM_BINDING", "ollama")
+        monkeypatch.setenv("LLM_MODEL", "qwen2.5:7b")
+        monkeypatch.setenv("LLM_BINDING_HOST", "http://localhost:11434")
+
+        # Set cross-provider binding but no model
+        monkeypatch.setenv("EXTRACT_LLM_BINDING", "openai")
+        monkeypatch.delenv("EXTRACT_LLM_MODEL", raising=False)
+        monkeypatch.setenv("EXTRACT_LLM_BINDING_API_KEY", "sk-test")
+
+        from lightrag.api.config import initialize_config
+
+        args = initialize_config(force=True)
+
+        # The validation happens at server startup in create_role_llm_func
+        # We can't easily test the full server flow here, but we can verify
+        # that the config is parsed correctly and the validation would trigger
+        assert args.extract_llm_binding == "openai"
+        assert args.extract_llm_model is None  # Missing - would cause validation error
+
+    def test_cross_provider_with_all_required_fields(self, monkeypatch):
+        """Cross-provider with all required fields should parse correctly."""
+        import sys
+
+        monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+        monkeypatch.setenv("LLM_BINDING", "ollama")
+        monkeypatch.setenv("LLM_MODEL", "qwen2.5:7b")
+        monkeypatch.setenv("LLM_BINDING_HOST", "http://localhost:11434")
+
+        monkeypatch.setenv("EXTRACT_LLM_BINDING", "openai")
+        monkeypatch.setenv("EXTRACT_LLM_MODEL", "gpt-4o")
+        monkeypatch.setenv("EXTRACT_LLM_BINDING_API_KEY", "sk-test")
+        monkeypatch.setenv("EXTRACT_LLM_BINDING_HOST", "https://api.openai.com/v1")
+
+        from lightrag.api.config import initialize_config
+
+        args = initialize_config(force=True)
+
+        assert args.extract_llm_binding == "openai"
+        assert args.extract_llm_model == "gpt-4o"
+        assert args.extract_llm_binding_api_key == "sk-test"
+        assert args.extract_llm_binding_host == "https://api.openai.com/v1"


### PR DESCRIPTION
Implement per-role LLM function separation as specified in #2741 
Each role (extract, keyword, query) gets its own independently wrapped
LLM function with a dedicated concurrency queue, enabling fine-grained
control over model selection, concurrency limits, timeouts, and
provider-specific options per task type.

Closes #2741 

Key changes:

- lightrag.py: Add 12 dataclass fields for per-role config, wrap each
  role function independently in __post_init__, store raw functions to
  prevent double-wrapping on runtime updates, add update_llm_role_config()
  with binding/model/host/api_key/provider_options metadata support and
  atomic rollback on failure.

- operate.py: Route extract_entities and _summarize_descriptions through
  extract_llm_model_func, extract_keywords_only through
  keyword_llm_model_func, and kg_query/naive_query through
  query_llm_model_func.

- api/config.py: Parse 18 per-role environment variables
  (EXTRACT_LLM_BINDING, KEYWORD_LLM_MODEL, MAX_ASYNC_QUERY_LLM, etc.).

- api/lightrag_server.py: Build role-specific LLM functions at startup
  with cross-provider validation (model and api_key required when binding
  differs from base), role-specific provider options via
  options_dict_for_role(), and /health endpoint role config exposure.

- llm/binding_options.py: Add options_dict_for_role() supporting
  per-role provider option env vars ({ROLE}_{PROVIDER}_{FIELD}, e.g.
  EXTRACT_OPENAI_LLM_TEMPERATURE) with same-provider inheritance and
  cross-provider default reset.

- api/routers/ollama_api.py: Route Ollama emulation calls through
  query_llm_model_func.