### PR TITLE
fix: align zhipu adapter with official thinking and dimensions api

### DIFF
--- a/lightrag/llm/zhipu.py
+++ b/lightrag/llm/zhipu.py
@@ -50,7 +50,9 @@ async def zhipu_complete_if_cache(
     system_prompt: Optional[str] = None,
     history_messages: List[Dict[str, str]] = [],
     enable_cot: bool = False,  # LightRAG output switch: include reasoning_content as <think>...</think>
-    thinking: Optional[Dict[str, object]] = None,  # Zhipu request param: use {"type": "enabled"} to enable thinking
+    thinking: Optional[
+        Dict[str, object]
+    ] = None,  # Zhipu request param: use {"type": "enabled"} to enable thinking
     **kwargs,
 ) -> str:
     """Call Zhipu chat completions with optional official thinking support.

--- a/tests/test_zhipu_llm.py
+++ b/tests/test_zhipu_llm.py
@@ -52,7 +52,9 @@ async def test_zhipu_embedding_sends_dimensions_when_embedding_dim_provided(
 
         def create(self, **kwargs):
             captured_calls.append(kwargs)
-            return SimpleNamespace(data=[SimpleNamespace(embedding=_fake_embedding_vector())])
+            return SimpleNamespace(
+                data=[SimpleNamespace(embedding=_fake_embedding_vector())]
+            )
 
     zhipu_module = _load_zhipu_module(monkeypatch, FakeClient)
 
@@ -83,7 +85,9 @@ async def test_zhipu_embedding_omits_dimensions_when_embedding_dim_not_provided(
 
         def create(self, **kwargs):
             captured_calls.append(kwargs)
-            return SimpleNamespace(data=[SimpleNamespace(embedding=_fake_embedding_vector())])
+            return SimpleNamespace(
+                data=[SimpleNamespace(embedding=_fake_embedding_vector())]
+            )
 
     zhipu_module = _load_zhipu_module(monkeypatch, FakeClient)
 
@@ -100,9 +104,7 @@ async def test_zhipu_complete_forwards_official_thinking(monkeypatch):
     class FakeClient:
         def __init__(self, api_key=None):
             self.api_key = api_key
-            self.chat = SimpleNamespace(
-                completions=SimpleNamespace(create=self.create)
-            )
+            self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
 
         def create(self, **kwargs):
             captured_calls.append(kwargs)
@@ -126,9 +128,7 @@ async def test_zhipu_complete_filters_reasoning_when_cot_disabled(monkeypatch):
     class FakeClient:
         def __init__(self, api_key=None):
             self.api_key = api_key
-            self.chat = SimpleNamespace(
-                completions=SimpleNamespace(create=self.create)
-            )
+            self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
 
         def create(self, **kwargs):
             return _fake_chat_response(
@@ -153,9 +153,7 @@ async def test_zhipu_complete_includes_reasoning_when_cot_enabled(monkeypatch):
     class FakeClient:
         def __init__(self, api_key=None):
             self.api_key = api_key
-            self.chat = SimpleNamespace(
-                completions=SimpleNamespace(create=self.create)
-            )
+            self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
 
         def create(self, **kwargs):
             return _fake_chat_response(
@@ -180,9 +178,7 @@ async def test_zhipu_keyword_extraction_ignores_reasoning_content(monkeypatch):
     class FakeClient:
         def __init__(self, api_key=None):
             self.api_key = api_key
-            self.chat = SimpleNamespace(
-                completions=SimpleNamespace(create=self.create)
-            )
+            self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
 
         def create(self, **kwargs):
             return _fake_chat_response(


### PR DESCRIPTION
  ## Description

  This pull request improves the standalone Zhipu adapter in LightRAG with official API alignment and better reasoning support.

  It adds support for Zhipu's official `thinking` request parameter in chat completion, enables configurable embedding dimensions through the official `dimensions` field, and fixes keyword
  extraction behavior when `keyword_extraction=True` is passed explicitly.

  ## Related Issues

  N/A

  ## Changes Made

  - Added official `thinking` parameter support to `lightrag/llm/zhipu.py`
  - Clarified the distinction between `thinking` (Zhipu request parameter) and `enable_cot` (LightRAG output formatting switch)
  - Added docstring and inline comments explaining how to enable thinking with `{"type": "enabled"}`
  - Added support for configurable embedding dimensions by mapping `embedding_dim` to Zhipu's official `dimensions` field
  - Preserved reasoning output as `<think>...</think>` when `enable_cot=True` and `reasoning_content` is returned
  - Fixed `keyword_extraction=True` being overwritten inside `zhipu_complete`
  - Added focused unit tests for embedding dimension passthrough, official thinking passthrough, reasoning formatting, and keyword extraction safety

  ## Checklist

  - [x] Changes tested locally
  - [x] Code reviewed
  - [ ] Documentation updated (if necessary)
  - [x] Unit tests added (if applicable)

  ## Additional Notes

  Local verification completed with:

  - `./.venv/bin/python -m pytest tests/test_zhipu_llm.py -v`
  - `./.venv/bin/ruff check lightrag/llm/zhipu.py tests/test_zhipu_llm.py`

  Live smoke tests were also run against the Zhipu API:

  - Embedding request confirmed that `dimensions` works correctly
  - `glm-4.7` completion confirmed that `thinking={"type": "enabled"}` is accepted and reasoning content can be returned