### PR TITLE
fix(api): make DocStatusResponse.file_path optional for text ingestion

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -447,7 +447,9 @@ class DocStatusResponse(BaseModel):
     metadata: Optional[dict[str, Any]] = Field(
         default=None, description="Additional metadata about the document"
     )
-    file_path: str = Field(description="Path to the document file")
+    file_path: Optional[str] = Field(
+        default=None, description="Path to the document file"
+    )
 
     class Config:
         json_schema_extra = {


### PR DESCRIPTION
Fixes #2762

## Problem
`/documents/text` ingestion does not provide a `file_path` — documents inserted this way have `file_path = NULL` in the database.

However, `DocStatusResponse` declared `file_path: str` (required), causing **Pydantic validation errors** when `/documents/paginated` attempts to serialize text-ingested documents.

**Error:**
```
ERROR: Error getting paginated documents: 1 validation error for DocStatusResponse
file_path
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
```

**Result**: `POST /documents/paginated` returns HTTP 500.

## Root Cause
The field was introduced in commit `d54bda8d` as a required `str`, but text ingestion legitimately produces documents with no file path.

## Solution
Changed `file_path` from required `str` to `Optional[str]` with `default=None`, aligning it with other optional fields in the model:
- `track_id: Optional[str] = None`
- `chunks_count: Optional[int] = None`
- `error_msg: Optional[str] = None`
- `metadata: Optional[dict[str, Any]] = None`

## Changes
- `lightrag/api/routers/document_routes.py`: Updated `DocStatusResponse.file_path` from `str` to `Optional[str]` with `default=None`

## Testing
This fix allows `/documents/paginated` to successfully serialize documents created via `/documents/text` endpoint without causing validation errors.

- DocStatusResponse BEFORE Fix - Bug
<img width="1786" height="892" alt="image" src="https://github.com/user-attachments/assets/41c385ef-1346-430c-809b-64eff8e566e8" />

- DocStatusResponse Fix
<img width="1776" height="1029" alt="image" src="https://github.com/user-attachments/assets/94d69382-ccda-4254-808c-364c709a8ee2" />
