### PR TITLE
feat: add MiniMax as a supported LLM and embedding provider

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -802,6 +802,65 @@ rag = LightRAG(
 
 </details>
 
+<details>
+<summary> <b>使用 MiniMax 模型</b> </summary>
+
+[MiniMax](https://www.minimax.io/) 提供 OpenAI 兼容的 API，模型支持最多 204K 的上下文长度。您可以按如下方式在 LightRAG 中使用 MiniMax 模型：
+
+```python
+import os
+import numpy as np
+from lightrag.utils import wrap_embedding_func_with_attrs
+from lightrag.llm.openai import openai_complete_if_cache, openai_embed
+
+async def llm_model_func(
+    prompt, system_prompt=None, history_messages=[], keyword_extraction=False, **kwargs
+) -> str:
+    return await openai_complete_if_cache(
+        "MiniMax-M2.5",
+        prompt,
+        system_prompt=system_prompt,
+        history_messages=history_messages,
+        api_key=os.getenv("MINIMAX_API_KEY"),
+        base_url="https://api.minimax.io/v1",
+        **kwargs
+    )
+
+@wrap_embedding_func_with_attrs(
+    embedding_dim=1536,
+    max_token_size=8192,
+    model_name="text-embedding-3-small"
+)
+async def embedding_func(texts: list[str]) -> np.ndarray:
+    return await openai_embed.func(
+        texts,
+        api_key=os.getenv("MINIMAX_API_KEY"),
+        base_url="https://api.minimax.io/v1",
+        model="text-embedding-3-small"
+    )
+
+rag = LightRAG(
+    working_dir=WORKING_DIR,
+    llm_model_func=llm_model_func,
+    llm_model_name="MiniMax-M2.5",
+    embedding_func=embedding_func
+)
+```
+
+对于 API 服务器，设置以下环境变量：
+
+```bash
+LLM_BINDING=minimax
+LLM_BINDING_HOST=https://api.minimax.io/v1
+LLM_BINDING_API_KEY=your_minimax_api_key
+LLM_MODEL=MiniMax-M2.5
+```
+
+可用模型包括 `MiniMax-M2.5` 和 `MiniMax-M2.5-highspeed`（204K 上下文）。
+注意：MiniMax 的 temperature 参数范围为 (0.0, 1.0]。
+
+</details>
+
 ### Rerank 函数注入
 
 为了提升检索质量，可以基于更有效的相关性评分模型对文档进行重新排序。`rerank.py` 文件提供了三个 Reranker 服务商的驱动函数：

--- a/README.md
+++ b/README.md
@@ -802,6 +802,65 @@ rag = LightRAG(
 
 </details>
 
+<details>
+<summary> <b>Using MiniMax Models</b> </summary>
+
+[MiniMax](https://www.minimax.io/) provides OpenAI-compatible API with models supporting up to 204K context length. You can use MiniMax models with LightRAG as follows:
+
+```python
+import os
+import numpy as np
+from lightrag.utils import wrap_embedding_func_with_attrs
+from lightrag.llm.openai import openai_complete_if_cache, openai_embed
+
+async def llm_model_func(
+    prompt, system_prompt=None, history_messages=[], keyword_extraction=False, **kwargs
+) -> str:
+    return await openai_complete_if_cache(
+        "MiniMax-M2.5",
+        prompt,
+        system_prompt=system_prompt,
+        history_messages=history_messages,
+        api_key=os.getenv("MINIMAX_API_KEY"),
+        base_url="https://api.minimax.io/v1",
+        **kwargs
+    )
+
+@wrap_embedding_func_with_attrs(
+    embedding_dim=1536,
+    max_token_size=8192,
+    model_name="text-embedding-3-small"
+)
+async def embedding_func(texts: list[str]) -> np.ndarray:
+    return await openai_embed.func(
+        texts,
+        api_key=os.getenv("MINIMAX_API_KEY"),
+        base_url="https://api.minimax.io/v1",
+        model="text-embedding-3-small"
+    )
+
+rag = LightRAG(
+    working_dir=WORKING_DIR,
+    llm_model_func=llm_model_func,
+    llm_model_name="MiniMax-M2.5",
+    embedding_func=embedding_func
+)
+```
+
+For the API server, set the following environment variables:
+
+```bash
+LLM_BINDING=minimax
+LLM_BINDING_HOST=https://api.minimax.io/v1
+LLM_BINDING_API_KEY=your_minimax_api_key
+LLM_MODEL=MiniMax-M2.5
+```
+
+Available models include `MiniMax-M2.5` and `MiniMax-M2.5-highspeed` (204K context).
+Note: MiniMax temperature must be in the range (0.0, 1.0].
+
+</details>
+
 ### Rerank Function Injection
 
 To enhance retrieval quality, documents can be re-ranked based on a more effective relevance scoring model. The `rerank.py` file provides three Reranker provider driver functions:

--- a/env.example
+++ b/env.example
@@ -235,7 +235,7 @@ MAX_PARALLEL_INSERT=2
 
 ###########################################################################
 ### LLM Configuration
-### LLM_BINDING type: openai, ollama, lollms, azure_openai, aws_bedrock, gemini
+### LLM_BINDING type: openai, ollama, lollms, azure_openai, aws_bedrock, gemini, minimax
 ### LLM_BINDING_HOST: Service endpoint (left empty if using default endpoint provided by openai or gemini SDK)
 ### LLM_BINDING_API_KEY: api key
 ### If LightRAG deployed in Docker:
@@ -337,9 +337,18 @@ OLLAMA_LLM_NUM_CTX=32768
 # AWS_REGION=us-east-1
 # BEDROCK_LLM_TEMPERATURE=1.0
 
+### MiniMax example (OpenAI-compatible)
+### MiniMax provides models with up to 204K context length
+# # LLM_BINDING=minimax
+# # LLM_BINDING_HOST=https://api.minimax.io/v1
+# # LLM_BINDING_API_KEY=your_minimax_api_key
+# # LLM_MODEL=MiniMax-M2.5
+### MiniMax temperature must be in (0.0, 1.0]
+# OPENAI_LLM_TEMPERATURE=0.7
+
 #######################################################################################
 ### Embedding Configuration (Should not be changed after the first file processed)
-### EMBEDDING_BINDING: ollama, openai, azure_openai, jina, lollms, aws_bedrock
+### EMBEDDING_BINDING: ollama, openai, azure_openai, jina, lollms, aws_bedrock, minimax
 ### EMBEDDING_BINDING_HOST: Service endpoint (left empty if using default endpoint provided by openai or gemini SDK)
 ### EMBEDDING_BINDING_API_KEY: api key
 ### If LightRAG deployed in Docker:

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -65,6 +65,7 @@ def get_default_host(binding_type: str) -> str:
         "lollms": os.getenv("LLM_BINDING_HOST", "http://localhost:9600"),
         "azure_openai": os.getenv("AZURE_OPENAI_ENDPOINT", "https://api.openai.com/v1"),
         "openai": os.getenv("LLM_BINDING_HOST", "https://api.openai.com/v1"),
+        "minimax": os.getenv("LLM_BINDING_HOST", "https://api.minimax.io/v1"),
         "gemini": os.getenv(
             "LLM_BINDING_HOST", "https://generativelanguage.googleapis.com"
         ),
@@ -232,6 +233,7 @@ def parse_args() -> argparse.Namespace:
             "azure_openai",
             "aws_bedrock",
             "gemini",
+            "minimax",
         ],
         help="LLM binding type (default: from env or ollama)",
     )
@@ -247,6 +249,7 @@ def parse_args() -> argparse.Namespace:
             "aws_bedrock",
             "jina",
             "gemini",
+            "minimax",
         ],
         help="Embedding binding type (default: from env or ollama)",
     )
@@ -287,7 +290,7 @@ def parse_args() -> argparse.Namespace:
     # Add LLM binding options based on determined value
     if llm_binding_value == "ollama":
         OllamaLLMOptions.add_args(parser)
-    elif llm_binding_value in ["openai", "azure_openai"]:
+    elif llm_binding_value in ["openai", "azure_openai", "minimax"]:
         OpenAILLMOptions.add_args(parser)
     elif llm_binding_value == "gemini":
         GeminiLLMOptions.add_args(parser)

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -95,7 +95,7 @@ class LLMConfigCache:
         self.ollama_embedding_options = None
 
         # Only initialize and log OpenAI options when using OpenAI-related bindings
-        if args.llm_binding in ["openai", "azure_openai"]:
+        if args.llm_binding in ["openai", "azure_openai", "minimax"]:
             from lightrag.llm.binding_options import OpenAILLMOptions
 
             self.openai_llm_options = OpenAILLMOptions.options_dict(args)


### PR DESCRIPTION
## Summary

Add [MiniMax](https://www.minimax.io/) as a first-class LLM and embedding binding option for LightRAG.

- Register `minimax` as a valid choice for `--llm-binding` and `--embedding-binding`
- Set default API endpoint to `https://api.minimax.io/v1`
- Reuse OpenAI-compatible client — **no new dependencies required**
- Add MiniMax configuration example in `env.example`
- Add usage documentation in both `README.md` and `README-zh.md`

### Why MiniMax?

MiniMax provides an OpenAI-compatible API with models supporting up to **204K context length**, which is well suited for RAG workloads:

| Model | Context Length | Notes |
|-------|---------------|-------|
| `MiniMax-M2.5` | 204K | Full-featured model |
| `MiniMax-M2.5-highspeed` | 204K | Optimized for speed |

### Configuration

For the API server, users simply set:

```bash
LLM_BINDING=minimax
LLM_BINDING_HOST=https://api.minimax.io/v1
LLM_BINDING_API_KEY=your_minimax_api_key
LLM_MODEL=MiniMax-M2.5
```

> **Note**: MiniMax temperature must be in the range (0.0, 1.0].

### Implementation Details

Since MiniMax provides an OpenAI-compatible API, this PR reuses the existing OpenAI client infrastructure. The changes are minimal and focused:

1. **`lightrag/api/config.py`**: Added `minimax` to binding choices, default host, and OpenAI options registration
2. **`lightrag/api/lightrag_server.py`**: Added `minimax` to OpenAI-related bindings in LLMConfigCache
3. **`env.example`**: Added MiniMax configuration example
4. **`README.md` / `README-zh.md`**: Added usage documentation with code examples

## Test plan

- [x] Verified `minimax` binding is accepted by argparse for both LLM and embedding
- [x] Verified default host resolves to `https://api.minimax.io/v1`
- [x] Verified OpenAI LLM options are registered when using minimax binding
- [x] Existing tests unaffected (pre-existing import errors in some tests are unrelated)
