### PR TITLE
fix(operate,utils): correct typos in log messages and remove dead code

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -385,7 +385,7 @@ async def _handle_single_entity_extraction(
     if len(record_attributes) != 4 or "entity" not in record_attributes[0]:
         if len(record_attributes) > 1 and "entity" in record_attributes[0]:
             logger.warning(
-                f"{chunk_key}: LLM output format error; found {len(record_attributes)}/4 feilds on ENTITY `{record_attributes[1]}` @ `{record_attributes[2] if len(record_attributes) > 2 else 'N/A'}`"
+                f"{chunk_key}: LLM output format error; found {len(record_attributes)}/4 fields on ENTITY `{record_attributes[1]}` @ `{record_attributes[2] if len(record_attributes) > 2 else 'N/A'}`"
             )
             logger.debug(record_attributes)
         return None
@@ -474,7 +474,7 @@ async def _handle_single_relationship_extraction(
     ):  # treat "relationship" and "relation" interchangeable
         if len(record_attributes) > 1 and "relation" in record_attributes[0]:
             logger.warning(
-                f"{chunk_key}: LLM output format error; found {len(record_attributes)}/5 fields on REALTION `{record_attributes[1]}`~`{record_attributes[2] if len(record_attributes) > 2 else 'N/A'}`"
+                f"{chunk_key}: LLM output format error; found {len(record_attributes)}/5 fields on RELATION `{record_attributes[1]}`~`{record_attributes[2] if len(record_attributes) > 2 else 'N/A'}`"
             )
             logger.debug(record_attributes)
         return None

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -2238,8 +2238,6 @@ def normalize_extracted_info(name: str, remove_inner_quotes=False) -> str:
         return all(c.isdigit() or c == "." for c in text) and "." in text
 
     if len(name) < 6 and should_filter_by_dots(name):
-        # Filter out mixed numeric and dot content with length < 6
-        return ""
         # Filter out mixed numeric and dot content with length < 6, requiring at least one dot
         return ""
 


### PR DESCRIPTION
## Summary

This PR fixes typos in error log messages and removes unreachable dead code to improve code quality and debugging experience.

## Changes Made

### 1. Fixed Typos in Error Messages (`lightrag/operate.py`)

**Line 388:** `feilds` → `fields`
```python
# Before
f"{chunk_key}: LLM output format error; found {len(record_attributes)}/4 feilds on ENTITY..."

# After
f"{chunk_key}: LLM output format error; found {len(record_attributes)}/4 fields on ENTITY..."
```

**Line 477:** `REALTION` → `RELATION`
```python
# Before
f"{chunk_key}: LLM output format error; found {len(record_attributes)}/5 fields on REALTION..."

# After
f"{chunk_key}: LLM output format error; found {len(record_attributes)}/5 fields on RELATION..."
```

### 2. Removed Dead Code (`lightrag/utils.py`)

**Lines 2241-2242:** Removed unreachable return statement
```python
# Before
if len(name) < 6 and should_filter_by_dots(name):
    # Filter out mixed numeric and dot content with length < 6
    return ""
    # Filter out mixed numeric and dot content with length < 6, requiring at least one dot
    return ""  # ← This line is unreachable

# After
if len(name) < 6 and should_filter_by_dots(name):
    # Filter out mixed numeric and dot content with length < 6, requiring at least one dot
    return ""
```

## Impact

- **User Experience:** Error messages are now correctly spelled, improving professionalism
- **Debugging:** Developers won't be distracted by typos when troubleshooting
- **Code Quality:** Removes dead code that could confuse maintainers
- **Risk:** Zero - these are purely cosmetic changes to strings and unreachable code

## Testing

- Verified the changes compile without errors
- Confirmed no functional logic was modified
- Only string literals and dead code were changed

## Related Issues

None - these are code quality improvements discovered during code review.