### PR TITLE
docs: fix TokenTracker usage documentation (#2325)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1701,45 +1701,52 @@ For detailed documentation and advanced usage, please refer to the [RAG-Anything
 
 LightRAG provides a TokenTracker tool to monitor and manage token consumption by large language models. This feature is particularly useful for controlling API costs and optimizing performance.
 
+**Important:** The `token_tracker` must be passed to the LLM function via `llm_model_kwargs` when creating the LightRAG instance. Simply wrapping calls in a `with token_tracker:` block will not work, because the tracker needs to be injected into the actual LLM API calls.
+
 ### Usage
 
 ```python
 from lightrag.utils import TokenTracker
+from lightrag.llm.openai import openai_complete, openai_embed
 
 # Create TokenTracker instance
 token_tracker = TokenTracker()
 
-# Method 1: Using context manager (Recommended)
-# Suitable for scenarios requiring automatic token usage tracking
-with token_tracker:
-    result1 = await llm_model_func("your question 1")
-    result2 = await llm_model_func("your question 2")
+# Pass token_tracker via llm_model_kwargs so it reaches the LLM function
+rag = LightRAG(
+    working_dir="./rag_storage",
+    llm_model_func=openai_complete,
+    llm_model_kwargs={"token_tracker": token_tracker},
+    embedding_model_func=openai_embed,
+)
 
-# Method 2: Manually adding token usage records
-# Suitable for scenarios requiring more granular control over token statistics
-token_tracker.reset()
-
-rag.insert()
+# All LLM calls through this rag instance will now track token usage
+rag.insert("Your document text here")
 
 rag.query("your question 1", param=QueryParam(mode="naive"))
 rag.query("your question 2", param=QueryParam(mode="mix"))
 
 # Display total token usage (including insert and query operations)
 print("Token usage:", token_tracker.get_usage())
+
+# Reset tracker for a new tracking session
+token_tracker.reset()
 ```
 
+### Supported LLM Backends
+
+Token tracking is supported for the following LLM backends:
+- **OpenAI** (`openai_complete`, `openai_embed`)
+- **Azure OpenAI** (`azure_openai_complete`, `azure_openai_embed`)
+- **Google Gemini** (`gemini_complete`, `gemini_embed`)
+
+Other backends (Ollama, HuggingFace, etc.) do not currently support token tracking.
+
 ### Usage Tips
-- Use context managers for long sessions or batch operations to automatically track all token consumption
-- For scenarios requiring segmented statistics, use manual mode and call reset() when appropriate
+- Pass `token_tracker` via `llm_model_kwargs` when creating the LightRAG instance
+- Use `token_tracker.reset()` to start a new tracking session
+- Use `token_tracker.get_usage()` to retrieve current statistics
 - Regular checking of token usage helps detect abnormal consumption early
-- Actively use this feature during development and testing to optimize production costs
-
-### Practical Examples
-You can refer to these examples for implementing token tracking:
-- `examples/lightrag_gemini_track_token_demo.py`: Token tracking example using Google Gemini model
-- `examples/lightrag_siliconcloud_track_token_demo.py`: Token tracking example using SiliconCloud model
-
-These examples demonstrate how to effectively use the TokenTracker feature with different models and scenarios.
 
 </details>
 


### PR DESCRIPTION
## Summary
Fixes #2325 - TokenTracker always returns 0 because the README documents incorrect usage.

## Problem
The README suggests using TokenTracker with a context manager:
```python
with token_tracker:
    result = await llm_model_func("question")
```

This doesn't work because:
1. The context manager only resets and prints statistics
2. It doesn't inject `token_tracker` into the LLM function calls
3. LightRAG wraps LLM functions with `partial()` at initialization, not at call time

## Solution
Update README to document the correct usage:
```python
token_tracker = TokenTracker()
rag = LightRAG(
    llm_model_func=openai_complete,
    llm_model_kwargs={"token_tracker": token_tracker},
)
```

This works because:
1. `token_tracker` is passed via `llm_model_kwargs`
2. LightRAG includes it in the `partial()` wrapper at `lightrag.py:686-696`
3. The tracker is then available to all LLM function calls

## Changes
- ✅ Removed incorrect context manager example
- ✅ Added correct usage via `llm_model_kwargs`
- ✅ Added explanation of why context manager doesn't work
- ✅ Added list of supported LLM backends
- ✅ Removed references to non-existent example files

## Verification
Created comprehensive tests that verify:
1. `token_tracker` survives `partial()` wrapping ✅
2. `token_tracker` survives `priority_limit_async_func_call()` wrapping ✅
3. Token usage is correctly tracked ✅

Test files:
- `reproduce_2325.py` - Reproduces the bug
- `test_token_tracker_fix.py` - Verifies the fix

## Impact
- Documentation now accurately reflects how TokenTracker actually works
- Users can successfully track token usage
- No code changes required - the functionality already works correctly