### PR TITLE
fix: prevent None file_path from propagating as unknown_source

### DIFF
--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -113,8 +113,8 @@ class JsonDocStatusStorage(DocStatusStorage):
                         data = v.copy()
                         # Remove deprecated content field if it exists
                         data.pop("content", None)
-                        # If file_path is not in data, use document id as file path
-                        if "file_path" not in data:
+                        # Normalize missing or null file_path
+                        if not data.get("file_path"):
                             data["file_path"] = "no-file-path"
                         # Ensure new fields exist with default values
                         if "metadata" not in data:
@@ -142,8 +142,8 @@ class JsonDocStatusStorage(DocStatusStorage):
                         data = v.copy()
                         # Remove deprecated content field if it exists
                         data.pop("content", None)
-                        # If file_path is not in data, use document id as file path
-                        if "file_path" not in data:
+                        # Normalize missing or null file_path
+                        if not data.get("file_path"):
                             data["file_path"] = "no-file-path"
                         # Ensure new fields exist with default values
                         if "metadata" not in data:
@@ -274,7 +274,7 @@ class JsonDocStatusStorage(DocStatusStorage):
                     # Prepare document data
                     data = doc_data.copy()
                     data.pop("content", None)
-                    if "file_path" not in data:
+                    if not data.get("file_path"):
                         data["file_path"] = "no-file-path"
                     if "metadata" not in data:
                         data["metadata"] = {}

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1400,7 +1400,7 @@ class LightRAG:
         if ignored_ids:
             duplicate_docs: dict[str, Any] = {}
             for doc_id in ignored_ids:
-                file_path = new_docs.get(doc_id, {}).get("file_path", "unknown_source")
+                file_path = new_docs.get(doc_id, {}).get("file_path") or "unknown_source"
                 logger.warning(f"Duplicate document detected: {doc_id} ({file_path})")
 
                 # Get existing document info for reference
@@ -1592,7 +1592,7 @@ class LightRAG:
             for doc_id in inconsistent_docs:
                 try:
                     status_doc = to_process_docs[doc_id]
-                    file_path = getattr(status_doc, "file_path", "unknown_source")
+                    file_path = getattr(status_doc, "file_path", None) or "unknown_source"
 
                     # Delete doc_status entry
                     await self.doc_status.delete([doc_id])
@@ -1650,7 +1650,7 @@ class LightRAG:
                         "chunks_list": preserved_chunks_list,
                         "created_at": status_doc.created_at,
                         "updated_at": datetime.now(timezone.utc).isoformat(),
-                        "file_path": getattr(status_doc, "file_path", "unknown_source"),
+                        "file_path": getattr(status_doc, "file_path", None) or "unknown_source",
                         "track_id": getattr(status_doc, "track_id", ""),
                         # Clear any error messages and processing metadata
                         "error_msg": "",
@@ -1849,8 +1849,8 @@ class LightRAG:
 
                             # Get file path from status document
                             file_path = getattr(
-                                status_doc, "file_path", "unknown_source"
-                            )
+                                status_doc, "file_path", None
+                            ) or "unknown_source"
 
                             async with pipeline_status_lock:
                                 # Update processed file count and save current file number


### PR DESCRIPTION
## Summary

Fixes the root cause of #2764 where some documents show "unknown_source" instead of their actual filenames.

### Root Cause

`getattr(status_doc, "file_path", "unknown_source")` only returns the fallback when the **attribute doesn't exist**. When `file_path` is present but `None`, it returns `None` — which then permanently overwrites valid filenames during reprocessing or consistency validation.

Same pattern in `JsonDocStatusStorage`: `"file_path" not in data` passes when the key exists with a null value, creating `DocProcessingStatus(file_path=None)`.

### Changes

**`lightrag/lightrag.py`** (4 sites):
```python
# Before — returns None when file_path attribute is None
file_path = getattr(status_doc, "file_path", "unknown_source")

# After — catches both missing and None
file_path = getattr(status_doc, "file_path", None) or "unknown_source"
```

**`lightrag/kg/json_doc_status_impl.py`** (3 sites):
```python
# Before — only catches missing key, not null value
if "file_path" not in data:
    data["file_path"] = "no-file-path"

# After — catches missing, None, and empty string
if not data.get("file_path"):
    data["file_path"] = "no-file-path"
```

Complements #2793 which fixed the API input layer — this PR fixes the processing pipeline and storage layer.

## Test plan

- [x] 275 tests pass, 33 skipped (pre-existing skip/xfail)
- [x] 1 pre-existing failure in `test_interactive_setup_outputs.py` unrelated to this change