### PR TITLE
feat: skip LLM summary for entities with unchanged descriptions

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -1770,6 +1770,31 @@ async def _merge_nodes_then_upsert(
         )
         description_list = [fallback_description]
 
+    # Skip LLM summary if no new descriptions were added (re-ingestion optimisation)
+    if already_node and already_description:
+        existing_descriptions = set(
+            d.strip()
+            for d in already_description
+            if d.strip()
+        )
+        incoming_descriptions = set(
+            d.strip()
+            for d in sorted_descriptions
+            if d.strip()
+        )
+        if incoming_descriptions and incoming_descriptions.issubset(existing_descriptions):
+            logger.debug(
+                f"Entity '{entity_name}': no new descriptions, skipping LLM summary"
+            )
+            node_data = dict(already_node)
+            node_data["source_id"] = source_id
+            node_data["file_path"] = GRAPH_FIELD_SEP.join(
+                list(dict.fromkeys(already_file_paths + [dp.get("file_path") for dp in nodes_data if dp.get("file_path")]))
+            )
+            await knowledge_graph_inst.upsert_node(entity_name, node_data=node_data)
+            node_data["entity_name"] = entity_name
+            return node_data
+
     # Check for cancellation before LLM summary
     if pipeline_status is not None and pipeline_status_lock is not None:
         async with pipeline_status_lock:

--- a/tests/test_skip_unchanged_summary.py
+++ b/tests/test_skip_unchanged_summary.py
@@ -1,0 +1,144 @@
+# test_skip_unchanged_summary.py
+
+import pytest
+from unittest.mock import AsyncMock, patch
+from lightrag.utils import GRAPH_FIELD_SEP
+
+
+def _make_global_config(**overrides):
+    cfg = {
+        "source_ids_limit_method": "FIFO",
+        "max_source_ids_per_entity": 100,
+        "max_file_paths": 50,
+        "file_path_more_placeholder": "more",
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+@pytest.fixture
+def mock_kg_with_existing_person():
+    kg = AsyncMock()
+    kg.get_node = AsyncMock(return_value={
+        "entity_type": "PERSON",
+        "source_id": "doc1",
+        "file_path": "file1.pdf",
+        "description": f"Alice is a person{GRAPH_FIELD_SEP}Alice works at Acme",
+    })
+    kg.upsert_node = AsyncMock()
+    return kg
+
+
+@pytest.mark.asyncio
+async def test_skip_summary_when_no_new_descriptions(mock_kg_with_existing_person):
+    from lightrag.operate import _merge_nodes_then_upsert
+
+    nodes_data = [
+        {
+            "entity_type": "PERSON",
+            "source_id": "doc1",
+            "file_path": "file1.pdf",
+            "description": "Alice is a person",
+        },
+        {
+            "entity_type": "PERSON",
+            "source_id": "doc1",
+            "file_path": "file1.pdf",
+            "description": "Alice works at Acme",
+        },
+    ]
+
+    with patch("lightrag.operate._handle_entity_relation_summary") as mock_summary:
+        await _merge_nodes_then_upsert(
+            entity_name="Alice",
+            nodes_data=nodes_data,
+            knowledge_graph_inst=mock_kg_with_existing_person,
+            entity_vdb=None,
+            global_config=_make_global_config(),
+        )
+        mock_summary.assert_not_called()
+
+    mock_kg_with_existing_person.upsert_node.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_calls_summary_when_new_descriptions(mock_kg_with_existing_person):
+    from lightrag.operate import _merge_nodes_then_upsert
+
+    nodes_data = [
+        {
+            "entity_type": "PERSON",
+            "source_id": "doc2",
+            "file_path": "file2.pdf",
+            "description": "Alice is the CEO of Acme",
+        },
+    ]
+
+    with patch("lightrag.operate._handle_entity_relation_summary") as mock_summary:
+        mock_summary.return_value = ("Alice is a person and CEO of Acme", True)
+        await _merge_nodes_then_upsert(
+            entity_name="Alice",
+            nodes_data=nodes_data,
+            knowledge_graph_inst=mock_kg_with_existing_person,
+            entity_vdb=None,
+            global_config=_make_global_config(),
+        )
+        mock_summary.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_calls_summary_for_new_entity():
+    from lightrag.operate import _merge_nodes_then_upsert
+
+    mock_kg = AsyncMock()
+    mock_kg.get_node = AsyncMock(return_value=None)
+    mock_kg.upsert_node = AsyncMock()
+
+    nodes_data = [
+        {
+            "entity_type": "ORG",
+            "source_id": "doc1",
+            "file_path": "file1.pdf",
+            "description": "Acme Corp makes widgets",
+        },
+    ]
+
+    with patch("lightrag.operate._handle_entity_relation_summary") as mock_summary:
+        mock_summary.return_value = ("Acme Corp makes widgets", True)
+        await _merge_nodes_then_upsert(
+            entity_name="Acme",
+            nodes_data=nodes_data,
+            knowledge_graph_inst=mock_kg,
+            entity_vdb=None,
+            global_config=_make_global_config(),
+        )
+        mock_summary.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_skip_preserves_existing_description(mock_kg_with_existing_person):
+    from lightrag.operate import _merge_nodes_then_upsert
+
+    existing_desc = f"Alice is a person{GRAPH_FIELD_SEP}Alice works at Acme"
+
+    nodes_data = [
+        {
+            "entity_type": "PERSON",
+            "source_id": "doc1",
+            "file_path": "file1.pdf",
+            "description": "Alice is a person",
+        },
+    ]
+
+    with patch("lightrag.operate._handle_entity_relation_summary"):
+        await _merge_nodes_then_upsert(
+            entity_name="Alice",
+            nodes_data=nodes_data,
+            knowledge_graph_inst=mock_kg_with_existing_person,
+            entity_vdb=None,
+            global_config=_make_global_config(),
+        )
+
+    call_kwargs = mock_kg_with_existing_person.upsert_node.call_args
+    upserted_data = call_kwargs.kwargs.get("node_data", call_kwargs[1].get("node_data"))
+    assert upserted_data["description"] == existing_desc


### PR DESCRIPTION
When re-ingesting a document or doing incremental updates, most entities already have the same descriptions. Right now we still call the LLM to re-summarize them every time, which is wasteful.

This adds an early return in _merge_nodes_then_upsert — if all incoming descriptions are already present on the existing node, we skip the summary call and just update source tracking.