### PR TITLE
fix: defer KG rebuild during batch document deletion

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -1854,6 +1854,9 @@ async def background_delete_documents(
     total_docs = len(doc_ids)
     successful_deletions = []
     failed_deletions = []
+    # Aggregate rebuild targets across all deletions so we only rebuild once
+    all_entities_to_rebuild: dict[str, list] = {}
+    all_relationships_to_rebuild: dict[tuple, list] = {}
 
     # Double-check pipeline status before proceeding
     async with pipeline_status_lock:
@@ -1906,13 +1909,22 @@ async def background_delete_documents(
             file_path = "#"
             try:
                 result = await rag.adelete_by_doc_id(
-                    doc_id, delete_llm_cache=delete_llm_cache
+                    doc_id,
+                    delete_llm_cache=delete_llm_cache,
+                    skip_rebuild=True,
                 )
                 file_path = (
                     getattr(result, "file_path", "-") if "result" in locals() else "-"
                 )
                 if result.status == "success":
                     successful_deletions.append(doc_id)
+                    # Collect deferred rebuild targets
+                    if result.entities_to_rebuild:
+                        all_entities_to_rebuild.update(result.entities_to_rebuild)
+                    if result.relationships_to_rebuild:
+                        all_relationships_to_rebuild.update(
+                            result.relationships_to_rebuild
+                        )
                     success_msg = (
                         f"Document deleted {i}/{total_docs}: {doc_id}[{file_path}]"
                     )
@@ -2048,6 +2060,44 @@ async def background_delete_documents(
                 async with pipeline_status_lock:
                     pipeline_status["latest_message"] = error_msg
                     pipeline_status["history_messages"].append(error_msg)
+
+        # Single deferred rebuild for all affected entities/relations
+        if all_entities_to_rebuild or all_relationships_to_rebuild:
+            from dataclasses import asdict
+
+            from lightrag.operate import rebuild_knowledge_from_chunks
+
+            rebuild_msg = (
+                f"Rebuilding knowledge graph: {len(all_entities_to_rebuild)} entities, "
+                f"{len(all_relationships_to_rebuild)} relations"
+            )
+            logger.info(rebuild_msg)
+            async with pipeline_status_lock:
+                pipeline_status["latest_message"] = rebuild_msg
+                pipeline_status["history_messages"].append(rebuild_msg)
+            try:
+                await rebuild_knowledge_from_chunks(
+                    entities_to_rebuild=all_entities_to_rebuild,
+                    relationships_to_rebuild=all_relationships_to_rebuild,
+                    knowledge_graph_inst=rag.chunk_entity_relation_graph,
+                    entities_vdb=rag.entities_vdb,
+                    relationships_vdb=rag.relationships_vdb,
+                    text_chunks_storage=rag.text_chunks,
+                    llm_response_cache=rag.llm_response_cache,
+                    global_config=asdict(rag),
+                    pipeline_status=pipeline_status,
+                    pipeline_status_lock=pipeline_status_lock,
+                    entity_chunks_storage=rag.entity_chunks,
+                    relation_chunks_storage=rag.relation_chunks,
+                )
+                await rag._insert_done()
+            except Exception as rebuild_err:
+                rebuild_error_msg = f"Failed to rebuild knowledge graph after batch deletion: {rebuild_err}"
+                logger.error(rebuild_error_msg)
+                logger.error(traceback.format_exc())
+                async with pipeline_status_lock:
+                    pipeline_status["latest_message"] = rebuild_error_msg
+                    pipeline_status["history_messages"].append(rebuild_error_msg)
 
     except Exception as e:
         error_msg = f"Critical error during batch deletion: {str(e)}"

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -2062,42 +2062,96 @@ async def background_delete_documents(
                     pipeline_status["history_messages"].append(error_msg)
 
         # Single deferred rebuild for all affected entities/relations
+        rebuild_ok = True
         if all_entities_to_rebuild or all_relationships_to_rebuild:
             from dataclasses import asdict
 
             from lightrag.operate import rebuild_knowledge_from_chunks
 
-            rebuild_msg = (
-                f"Rebuilding knowledge graph: {len(all_entities_to_rebuild)} entities, "
-                f"{len(all_relationships_to_rebuild)} relations"
-            )
-            logger.info(rebuild_msg)
-            async with pipeline_status_lock:
-                pipeline_status["latest_message"] = rebuild_msg
-                pipeline_status["history_messages"].append(rebuild_msg)
-            try:
-                await rebuild_knowledge_from_chunks(
-                    entities_to_rebuild=all_entities_to_rebuild,
-                    relationships_to_rebuild=all_relationships_to_rebuild,
-                    knowledge_graph_inst=rag.chunk_entity_relation_graph,
-                    entities_vdb=rag.entities_vdb,
-                    relationships_vdb=rag.relationships_vdb,
-                    text_chunks_storage=rag.text_chunks,
-                    llm_response_cache=rag.llm_response_cache,
-                    global_config=asdict(rag),
-                    pipeline_status=pipeline_status,
-                    pipeline_status_lock=pipeline_status_lock,
-                    entity_chunks_storage=rag.entity_chunks,
-                    relation_chunks_storage=rag.relation_chunks,
+            # --- Issue 1: filter out entities/relations that were already fully
+            # deleted by a later per-doc call.  When documents share entities,
+            # an earlier doc might tag an entity for "rebuild" while a later doc
+            # ends up deleting it entirely.  Trying to rebuild a deleted node is
+            # wasteful and may error out.
+            pruned_entities = 0
+            for ent_name in list(all_entities_to_rebuild):
+                if not await rag.chunk_entity_relation_graph.has_node(ent_name):
+                    del all_entities_to_rebuild[ent_name]
+                    pruned_entities += 1
+            pruned_relations = 0
+            for edge_key in list(all_relationships_to_rebuild):
+                src, tgt = edge_key
+                if not await rag.chunk_entity_relation_graph.has_edge(src, tgt):
+                    del all_relationships_to_rebuild[edge_key]
+                    pruned_relations += 1
+            if pruned_entities or pruned_relations:
+                prune_msg = (
+                    f"Pruned {pruned_entities} entities and {pruned_relations} "
+                    f"relations that were already deleted by overlapping docs"
                 )
-                await rag._insert_done()
-            except Exception as rebuild_err:
-                rebuild_error_msg = f"Failed to rebuild knowledge graph after batch deletion: {rebuild_err}"
-                logger.error(rebuild_error_msg)
-                logger.error(traceback.format_exc())
+                logger.info(prune_msg)
                 async with pipeline_status_lock:
-                    pipeline_status["latest_message"] = rebuild_error_msg
-                    pipeline_status["history_messages"].append(rebuild_error_msg)
+                    pipeline_status["history_messages"].append(prune_msg)
+
+            if all_entities_to_rebuild or all_relationships_to_rebuild:
+                rebuild_msg = (
+                    f"Rebuilding knowledge graph: {len(all_entities_to_rebuild)} entities, "
+                    f"{len(all_relationships_to_rebuild)} relations"
+                )
+                logger.info(rebuild_msg)
+                async with pipeline_status_lock:
+                    pipeline_status["latest_message"] = rebuild_msg
+                    pipeline_status["history_messages"].append(rebuild_msg)
+                try:
+                    await rebuild_knowledge_from_chunks(
+                        entities_to_rebuild=all_entities_to_rebuild,
+                        relationships_to_rebuild=all_relationships_to_rebuild,
+                        knowledge_graph_inst=rag.chunk_entity_relation_graph,
+                        entities_vdb=rag.entities_vdb,
+                        relationships_vdb=rag.relationships_vdb,
+                        text_chunks_storage=rag.text_chunks,
+                        llm_response_cache=rag.llm_response_cache,
+                        global_config=asdict(rag),
+                        pipeline_status=pipeline_status,
+                        pipeline_status_lock=pipeline_status_lock,
+                        entity_chunks_storage=rag.entity_chunks,
+                        relation_chunks_storage=rag.relation_chunks,
+                    )
+                    await rag._insert_done()
+                except Exception as rebuild_err:
+                    rebuild_ok = False
+                    rebuild_error_msg = (
+                        f"Failed to rebuild knowledge graph after batch deletion: {rebuild_err}"
+                    )
+                    logger.error(rebuild_error_msg)
+                    logger.error(traceback.format_exc())
+                    async with pipeline_status_lock:
+                        pipeline_status["latest_message"] = rebuild_error_msg
+                        pipeline_status["history_messages"].append(rebuild_error_msg)
+
+        # --- Issue 2: only finalize doc_status removal after rebuild succeeds.
+        # adelete_by_doc_id(skip_rebuild=True) intentionally keeps doc_status
+        # alive so a failed rebuild doesn't lose track of the documents.
+        if rebuild_ok and successful_deletions:
+            try:
+                await rag.doc_status.delete(successful_deletions)
+            except Exception as status_err:
+                logger.error(
+                    f"Failed to clean up doc_status for {len(successful_deletions)} docs: {status_err}"
+                )
+                async with pipeline_status_lock:
+                    pipeline_status["history_messages"].append(
+                        f"Warning: doc_status cleanup failed: {status_err}"
+                    )
+        elif not rebuild_ok:
+            keep_msg = (
+                f"Keeping doc_status for {len(successful_deletions)} docs "
+                f"because rebuild failed — re-trigger deletion to retry"
+            )
+            logger.warning(keep_msg)
+            async with pipeline_status_lock:
+                pipeline_status["latest_message"] = keep_msg
+                pipeline_status["history_messages"].append(keep_msg)
 
     except Exception as e:
         error_msg = f"Critical error during batch deletion: {str(e)}"

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -2120,9 +2120,7 @@ async def background_delete_documents(
                     await rag._insert_done()
                 except Exception as rebuild_err:
                     rebuild_ok = False
-                    rebuild_error_msg = (
-                        f"Failed to rebuild knowledge graph after batch deletion: {rebuild_err}"
-                    )
+                    rebuild_error_msg = f"Failed to rebuild knowledge graph after batch deletion: {rebuild_err}"
                     logger.error(rebuild_error_msg)
                     logger.error(traceback.format_exc())
                     async with pipeline_status_lock:

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -2603,7 +2603,7 @@ async def run_scanning_process(
                 ):
                     # File is already PROCESSED, skip it with warning and archive it.
                     processed_files.append(filename)
-                    warning = f"Skipping already processed file: " f"{filename}"
+                    warning = f"Skipping already processed file: {filename}"
                     await record_scan_warning(rag, warning)
                     try:
                         await move_file_to_parsed_dir(file_path)
@@ -2965,9 +2965,7 @@ async def background_delete_documents(
                     await rag._insert_done()
                 except Exception as rebuild_err:
                     rebuild_ok = False
-                    rebuild_error_msg = (
-                        f"Failed to rebuild knowledge graph after batch deletion: {rebuild_err}"
-                    )
+                    rebuild_error_msg = f"Failed to rebuild knowledge graph after batch deletion: {rebuild_err}"
                     logger.error(rebuild_error_msg)
                     logger.error(traceback.format_exc())
                     async with pipeline_status_lock:

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -2907,42 +2907,96 @@ async def background_delete_documents(
                     pipeline_status["history_messages"].append(error_msg)
 
         # Single deferred rebuild for all affected entities/relations
+        rebuild_ok = True
         if all_entities_to_rebuild or all_relationships_to_rebuild:
             from dataclasses import asdict
 
             from lightrag.operate import rebuild_knowledge_from_chunks
 
-            rebuild_msg = (
-                f"Rebuilding knowledge graph: {len(all_entities_to_rebuild)} entities, "
-                f"{len(all_relationships_to_rebuild)} relations"
-            )
-            logger.info(rebuild_msg)
-            async with pipeline_status_lock:
-                pipeline_status["latest_message"] = rebuild_msg
-                pipeline_status["history_messages"].append(rebuild_msg)
-            try:
-                await rebuild_knowledge_from_chunks(
-                    entities_to_rebuild=all_entities_to_rebuild,
-                    relationships_to_rebuild=all_relationships_to_rebuild,
-                    knowledge_graph_inst=rag.chunk_entity_relation_graph,
-                    entities_vdb=rag.entities_vdb,
-                    relationships_vdb=rag.relationships_vdb,
-                    text_chunks_storage=rag.text_chunks,
-                    llm_response_cache=rag.llm_response_cache,
-                    global_config=asdict(rag),
-                    pipeline_status=pipeline_status,
-                    pipeline_status_lock=pipeline_status_lock,
-                    entity_chunks_storage=rag.entity_chunks,
-                    relation_chunks_storage=rag.relation_chunks,
+            # --- Issue 1: filter out entities/relations that were already fully
+            # deleted by a later per-doc call.  When documents share entities,
+            # an earlier doc might tag an entity for "rebuild" while a later doc
+            # ends up deleting it entirely.  Trying to rebuild a deleted node is
+            # wasteful and may error out.
+            pruned_entities = 0
+            for ent_name in list(all_entities_to_rebuild):
+                if not await rag.chunk_entity_relation_graph.has_node(ent_name):
+                    del all_entities_to_rebuild[ent_name]
+                    pruned_entities += 1
+            pruned_relations = 0
+            for edge_key in list(all_relationships_to_rebuild):
+                src, tgt = edge_key
+                if not await rag.chunk_entity_relation_graph.has_edge(src, tgt):
+                    del all_relationships_to_rebuild[edge_key]
+                    pruned_relations += 1
+            if pruned_entities or pruned_relations:
+                prune_msg = (
+                    f"Pruned {pruned_entities} entities and {pruned_relations} "
+                    f"relations that were already deleted by overlapping docs"
                 )
-                await rag._insert_done()
-            except Exception as rebuild_err:
-                rebuild_error_msg = f"Failed to rebuild knowledge graph after batch deletion: {rebuild_err}"
-                logger.error(rebuild_error_msg)
-                logger.error(traceback.format_exc())
+                logger.info(prune_msg)
                 async with pipeline_status_lock:
-                    pipeline_status["latest_message"] = rebuild_error_msg
-                    pipeline_status["history_messages"].append(rebuild_error_msg)
+                    pipeline_status["history_messages"].append(prune_msg)
+
+            if all_entities_to_rebuild or all_relationships_to_rebuild:
+                rebuild_msg = (
+                    f"Rebuilding knowledge graph: {len(all_entities_to_rebuild)} entities, "
+                    f"{len(all_relationships_to_rebuild)} relations"
+                )
+                logger.info(rebuild_msg)
+                async with pipeline_status_lock:
+                    pipeline_status["latest_message"] = rebuild_msg
+                    pipeline_status["history_messages"].append(rebuild_msg)
+                try:
+                    await rebuild_knowledge_from_chunks(
+                        entities_to_rebuild=all_entities_to_rebuild,
+                        relationships_to_rebuild=all_relationships_to_rebuild,
+                        knowledge_graph_inst=rag.chunk_entity_relation_graph,
+                        entities_vdb=rag.entities_vdb,
+                        relationships_vdb=rag.relationships_vdb,
+                        text_chunks_storage=rag.text_chunks,
+                        llm_response_cache=rag.llm_response_cache,
+                        global_config=asdict(rag),
+                        pipeline_status=pipeline_status,
+                        pipeline_status_lock=pipeline_status_lock,
+                        entity_chunks_storage=rag.entity_chunks,
+                        relation_chunks_storage=rag.relation_chunks,
+                    )
+                    await rag._insert_done()
+                except Exception as rebuild_err:
+                    rebuild_ok = False
+                    rebuild_error_msg = (
+                        f"Failed to rebuild knowledge graph after batch deletion: {rebuild_err}"
+                    )
+                    logger.error(rebuild_error_msg)
+                    logger.error(traceback.format_exc())
+                    async with pipeline_status_lock:
+                        pipeline_status["latest_message"] = rebuild_error_msg
+                        pipeline_status["history_messages"].append(rebuild_error_msg)
+
+        # --- Issue 2: only finalize doc_status removal after rebuild succeeds.
+        # adelete_by_doc_id(skip_rebuild=True) intentionally keeps doc_status
+        # alive so a failed rebuild doesn't lose track of the documents.
+        if rebuild_ok and successful_deletions:
+            try:
+                await rag.doc_status.delete(successful_deletions)
+            except Exception as status_err:
+                logger.error(
+                    f"Failed to clean up doc_status for {len(successful_deletions)} docs: {status_err}"
+                )
+                async with pipeline_status_lock:
+                    pipeline_status["history_messages"].append(
+                        f"Warning: doc_status cleanup failed: {status_err}"
+                    )
+        elif not rebuild_ok:
+            keep_msg = (
+                f"Keeping doc_status for {len(successful_deletions)} docs "
+                f"because rebuild failed — re-trigger deletion to retry"
+            )
+            logger.warning(keep_msg)
+            async with pipeline_status_lock:
+                pipeline_status["latest_message"] = keep_msg
+                pipeline_status["history_messages"].append(keep_msg)
 
     except Exception as e:
         error_msg = f"Critical error during batch deletion: {str(e)}"

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -2749,6 +2749,9 @@ async def background_delete_documents(
     total_docs = len(doc_ids)
     successful_deletions = []
     failed_deletions = []
+    # Aggregate rebuild targets across all deletions so we only rebuild once
+    all_entities_to_rebuild: dict[str, list] = {}
+    all_relationships_to_rebuild: dict[tuple, list] = {}
 
     # The /documents/delete_document endpoint has already reserved the
     # destructive slot synchronously: ``busy=True`` and
@@ -2801,13 +2804,22 @@ async def background_delete_documents(
             file_path = "#"
             try:
                 result = await rag.adelete_by_doc_id(
-                    doc_id, delete_llm_cache=delete_llm_cache
+                    doc_id,
+                    delete_llm_cache=delete_llm_cache,
+                    skip_rebuild=True,
                 )
                 file_path = (
                     getattr(result, "file_path", "-") if "result" in locals() else "-"
                 )
                 if result.status == "success":
                     successful_deletions.append(doc_id)
+                    # Collect deferred rebuild targets
+                    if result.entities_to_rebuild:
+                        all_entities_to_rebuild.update(result.entities_to_rebuild)
+                    if result.relationships_to_rebuild:
+                        all_relationships_to_rebuild.update(
+                            result.relationships_to_rebuild
+                        )
                     success_msg = (
                         f"Document deleted {i}/{total_docs}: {doc_id}[{file_path}]"
                     )
@@ -2893,6 +2905,44 @@ async def background_delete_documents(
                 async with pipeline_status_lock:
                     pipeline_status["latest_message"] = error_msg
                     pipeline_status["history_messages"].append(error_msg)
+
+        # Single deferred rebuild for all affected entities/relations
+        if all_entities_to_rebuild or all_relationships_to_rebuild:
+            from dataclasses import asdict
+
+            from lightrag.operate import rebuild_knowledge_from_chunks
+
+            rebuild_msg = (
+                f"Rebuilding knowledge graph: {len(all_entities_to_rebuild)} entities, "
+                f"{len(all_relationships_to_rebuild)} relations"
+            )
+            logger.info(rebuild_msg)
+            async with pipeline_status_lock:
+                pipeline_status["latest_message"] = rebuild_msg
+                pipeline_status["history_messages"].append(rebuild_msg)
+            try:
+                await rebuild_knowledge_from_chunks(
+                    entities_to_rebuild=all_entities_to_rebuild,
+                    relationships_to_rebuild=all_relationships_to_rebuild,
+                    knowledge_graph_inst=rag.chunk_entity_relation_graph,
+                    entities_vdb=rag.entities_vdb,
+                    relationships_vdb=rag.relationships_vdb,
+                    text_chunks_storage=rag.text_chunks,
+                    llm_response_cache=rag.llm_response_cache,
+                    global_config=asdict(rag),
+                    pipeline_status=pipeline_status,
+                    pipeline_status_lock=pipeline_status_lock,
+                    entity_chunks_storage=rag.entity_chunks,
+                    relation_chunks_storage=rag.relation_chunks,
+                )
+                await rag._insert_done()
+            except Exception as rebuild_err:
+                rebuild_error_msg = f"Failed to rebuild knowledge graph after batch deletion: {rebuild_err}"
+                logger.error(rebuild_error_msg)
+                logger.error(traceback.format_exc())
+                async with pipeline_status_lock:
+                    pipeline_status["latest_message"] = rebuild_error_msg
+                    pipeline_status["history_messages"].append(rebuild_error_msg)
 
     except Exception as e:
         error_msg = f"Critical error during batch deletion: {str(e)}"

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -840,6 +840,9 @@ class DeletionResult:
     message: str
     status_code: int = 200
     file_path: str | None = None
+    # Populated when skip_rebuild=True so the caller can do a single deferred rebuild
+    entities_to_rebuild: Dict[str, list] | None = None
+    relationships_to_rebuild: Dict[Any, list] | None = None
 
 
 # Unified Query Result Data Structures for Reference List Support

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -997,6 +997,9 @@ class DeletionResult:
     message: str
     status_code: int = 200
     file_path: str | None = None
+    # Populated when skip_rebuild=True so the caller can do a single deferred rebuild
+    entities_to_rebuild: Dict[str, list] | None = None
+    relationships_to_rebuild: Dict[Any, list] | None = None
 
 
 # Unified Query Result Data Structures for Reference List Support

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -3137,7 +3137,10 @@ class LightRAG:
         return found_statuses
 
     async def adelete_by_doc_id(
-        self, doc_id: str, delete_llm_cache: bool = False
+        self,
+        doc_id: str,
+        delete_llm_cache: bool = False,
+        skip_rebuild: bool = False,
     ) -> DeletionResult:
         """Delete a document and all its related data, including chunks, graph elements.
 
@@ -3170,6 +3173,10 @@ class LightRAG:
             doc_id (str): The unique identifier of the document to be deleted.
             delete_llm_cache (bool): Whether to delete cached LLM extraction results
                 associated with the document. Defaults to False.
+            skip_rebuild (bool): When True, skip the per-document KG rebuild step.
+                The caller is responsible for performing a single deferred rebuild
+                using the entities/relationships returned in the DeletionResult.
+                Used by batch deletion to avoid N redundant rebuilds. Defaults to False.
 
         Returns:
             DeletionResult: An object containing the outcome of the deletion process.
@@ -3178,6 +3185,8 @@ class LightRAG:
                 - `message` (str): A summary of the operation's result.
                 - `status_code` (int): HTTP status code (e.g., 200, 404, 403, 500).
                 - `file_path` (str | None): The file path of the deleted document, if available.
+                - `entities_to_rebuild` (dict | None): Populated when skip_rebuild=True.
+                - `relationships_to_rebuild` (dict | None): Populated when skip_rebuild=True.
         """
         # Get pipeline status shared data and lock for validation
         pipeline_status = await get_namespace_data(
@@ -3860,27 +3869,39 @@ class LightRAG:
                 raise Exception(f"Failed to persist pre-rebuild changes: {e}") from e
 
             # 8. Rebuild entities and relationships from remaining chunks
+            #    When skip_rebuild is set (batch deletion), we hand the targets back
+            #    to the caller so it can do one combined rebuild at the end.
             if entities_to_rebuild or relationships_to_rebuild:
-                try:
-                    deletion_stage = "rebuild_knowledge_graph"
-                    await rebuild_knowledge_from_chunks(
-                        entities_to_rebuild=entities_to_rebuild,
-                        relationships_to_rebuild=relationships_to_rebuild,
-                        knowledge_graph_inst=self.chunk_entity_relation_graph,
-                        entities_vdb=self.entities_vdb,
-                        relationships_vdb=self.relationships_vdb,
-                        text_chunks_storage=self.text_chunks,
-                        llm_response_cache=self.llm_response_cache,
-                        global_config=asdict(self),
-                        pipeline_status=pipeline_status,
-                        pipeline_status_lock=pipeline_status_lock,
-                        entity_chunks_storage=self.entity_chunks,
-                        relation_chunks_storage=self.relation_chunks,
+                if skip_rebuild:
+                    logger.info(
+                        "Skipping per-doc rebuild (skip_rebuild=True), "
+                        "%d entities / %d relations deferred",
+                        len(entities_to_rebuild),
+                        len(relationships_to_rebuild),
                     )
+                else:
+                    try:
+                        deletion_stage = "rebuild_knowledge_graph"
+                        await rebuild_knowledge_from_chunks(
+                            entities_to_rebuild=entities_to_rebuild,
+                            relationships_to_rebuild=relationships_to_rebuild,
+                            knowledge_graph_inst=self.chunk_entity_relation_graph,
+                            entities_vdb=self.entities_vdb,
+                            relationships_vdb=self.relationships_vdb,
+                            text_chunks_storage=self.text_chunks,
+                            llm_response_cache=self.llm_response_cache,
+                            global_config=asdict(self),
+                            pipeline_status=pipeline_status,
+                            pipeline_status_lock=pipeline_status_lock,
+                            entity_chunks_storage=self.entity_chunks,
+                            relation_chunks_storage=self.relation_chunks,
+                        )
 
-                except Exception as e:
-                    logger.error(f"Failed to rebuild knowledge from chunks: {e}")
-                    raise Exception(f"Failed to rebuild knowledge graph: {e}") from e
+                    except Exception as e:
+                        logger.error(f"Failed to rebuild knowledge from chunks: {e}")
+                        raise Exception(
+                            f"Failed to rebuild knowledge graph: {e}"
+                        ) from e
 
             # 9. Delete LLM cache while the document status still exists so a failure
             # remains retryable via the same doc_id.
@@ -3953,13 +3974,18 @@ class LightRAG:
                 raise Exception(f"Failed to delete document and status: {e}") from e
 
             deletion_fully_completed = True
-            return DeletionResult(
+
+            result = DeletionResult(
                 status="success",
                 doc_id=doc_id,
                 message=log_message,
                 status_code=200,
                 file_path=file_path,
             )
+            if skip_rebuild:
+                result.entities_to_rebuild = entities_to_rebuild
+                result.relationships_to_rebuild = relationships_to_rebuild
+            return result
 
         except Exception as e:
             original_exception = e

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -3961,10 +3961,11 @@ class LightRAG:
                 ) from e
 
             # 11. Delete original document and status.
-            #     doc_status is deleted first so that if full_docs.delete fails, a retry
-            #     finds no doc_status record and treats the document as already gone.
-            #     When skip_rebuild is set the caller handles a deferred rebuild that may
-            #     fail -- keep doc_status alive so the user can re-trigger deletion later.
+            #     Normal mode: doc_status is deleted first so that if full_docs.delete
+            #     fails, a retry finds no doc_status record and treats the doc as gone.
+            #     Batch mode (skip_rebuild): doc_status stays alive because the caller
+            #     still needs to do a deferred rebuild that might fail. If it does fail,
+            #     having doc_status around means the user can just re-trigger deletion.
             try:
                 deletion_stage = "delete_doc_entries"
                 in_final_delete_stage = True

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -3961,13 +3961,15 @@ class LightRAG:
                 ) from e
 
             # 11. Delete original document and status.
-            # doc_status is deleted first so that if full_docs.delete fails, a retry
-            # finds no doc_status record and treats the document as already gone,
-            # rather than finding a doc_status that points to a missing full_docs entry.
+            #     doc_status is deleted first so that if full_docs.delete fails, a retry
+            #     finds no doc_status record and treats the document as already gone.
+            #     When skip_rebuild is set the caller handles a deferred rebuild that may
+            #     fail -- keep doc_status alive so the user can re-trigger deletion later.
             try:
                 deletion_stage = "delete_doc_entries"
                 in_final_delete_stage = True
-                await self.doc_status.delete([doc_id])
+                if not skip_rebuild:
+                    await self.doc_status.delete([doc_id])
                 await self.full_docs.delete([doc_id])
             except Exception as e:
                 logger.error(f"Failed to delete document and status: {e}")

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -3792,13 +3792,15 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 ) from e
 
             # 11. Delete original document and status.
-            # doc_status is deleted first so that if full_docs.delete fails, a retry
-            # finds no doc_status record and treats the document as already gone,
-            # rather than finding a doc_status that points to a missing full_docs entry.
+            #     doc_status is deleted first so that if full_docs.delete fails, a retry
+            #     finds no doc_status record and treats the document as already gone.
+            #     When skip_rebuild is set the caller handles a deferred rebuild that may
+            #     fail -- keep doc_status alive so the user can re-trigger deletion later.
             try:
                 deletion_stage = "delete_doc_entries"
                 in_final_delete_stage = True
-                await self.doc_status.delete([doc_id])
+                if not skip_rebuild:
+                    await self.doc_status.delete([doc_id])
                 await self.full_docs.delete([doc_id])
             except Exception as e:
                 logger.error(f"Failed to delete document and status: {e}")

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -2966,7 +2966,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             ) from e
 
     async def adelete_by_doc_id(
-        self, doc_id: str, delete_llm_cache: bool = False
+        self,
+        doc_id: str,
+        delete_llm_cache: bool = False,
+        skip_rebuild: bool = False,
     ) -> DeletionResult:
         """Delete a document and all its related data, including chunks, graph elements.
 
@@ -2999,6 +3002,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             doc_id (str): The unique identifier of the document to be deleted.
             delete_llm_cache (bool): Whether to delete cached LLM extraction results
                 associated with the document. Defaults to False.
+            skip_rebuild (bool): When True, skip the per-document KG rebuild step.
+                The caller is responsible for performing a single deferred rebuild
+                using the entities/relationships returned in the DeletionResult.
+                Used by batch deletion to avoid N redundant rebuilds. Defaults to False.
 
         Returns:
             DeletionResult: An object containing the outcome of the deletion process.
@@ -3007,6 +3014,8 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 - `message` (str): A summary of the operation's result.
                 - `status_code` (int): HTTP status code (e.g., 200, 404, 403, 500).
                 - `file_path` (str | None): The file path of the deleted document, if available.
+                - `entities_to_rebuild` (dict | None): Populated when skip_rebuild=True.
+                - `relationships_to_rebuild` (dict | None): Populated when skip_rebuild=True.
         """
         # Get pipeline status shared data and lock for validation
         pipeline_status = await get_namespace_data(
@@ -3691,27 +3700,39 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 raise Exception(f"Failed to persist pre-rebuild changes: {e}") from e
 
             # 8. Rebuild entities and relationships from remaining chunks
+            #    When skip_rebuild is set (batch deletion), we hand the targets back
+            #    to the caller so it can do one combined rebuild at the end.
             if entities_to_rebuild or relationships_to_rebuild:
-                try:
-                    deletion_stage = "rebuild_knowledge_graph"
-                    await rebuild_knowledge_from_chunks(
-                        entities_to_rebuild=entities_to_rebuild,
-                        relationships_to_rebuild=relationships_to_rebuild,
-                        knowledge_graph_inst=self.chunk_entity_relation_graph,
-                        entities_vdb=self.entities_vdb,
-                        relationships_vdb=self.relationships_vdb,
-                        text_chunks_storage=self.text_chunks,
-                        llm_response_cache=self.llm_response_cache,
-                        global_config=self._build_global_config(),
-                        pipeline_status=pipeline_status,
-                        pipeline_status_lock=pipeline_status_lock,
-                        entity_chunks_storage=self.entity_chunks,
-                        relation_chunks_storage=self.relation_chunks,
+                if skip_rebuild:
+                    logger.info(
+                        "Skipping per-doc rebuild (skip_rebuild=True), "
+                        "%d entities / %d relations deferred",
+                        len(entities_to_rebuild),
+                        len(relationships_to_rebuild),
                     )
+                else:
+                    try:
+                        deletion_stage = "rebuild_knowledge_graph"
+                        await rebuild_knowledge_from_chunks(
+                            entities_to_rebuild=entities_to_rebuild,
+                            relationships_to_rebuild=relationships_to_rebuild,
+                            knowledge_graph_inst=self.chunk_entity_relation_graph,
+                            entities_vdb=self.entities_vdb,
+                            relationships_vdb=self.relationships_vdb,
+                            text_chunks_storage=self.text_chunks,
+                            llm_response_cache=self.llm_response_cache,
+                            global_config=self._build_global_config(),
+                            pipeline_status=pipeline_status,
+                            pipeline_status_lock=pipeline_status_lock,
+                            entity_chunks_storage=self.entity_chunks,
+                            relation_chunks_storage=self.relation_chunks,
+                        )
 
-                except Exception as e:
-                    logger.error(f"Failed to rebuild knowledge from chunks: {e}")
-                    raise Exception(f"Failed to rebuild knowledge graph: {e}") from e
+                    except Exception as e:
+                        logger.error(f"Failed to rebuild knowledge from chunks: {e}")
+                        raise Exception(
+                            f"Failed to rebuild knowledge graph: {e}"
+                        ) from e
 
             # 9. Delete LLM cache while the document status still exists so a failure
             # remains retryable via the same doc_id.
@@ -3784,13 +3805,18 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 raise Exception(f"Failed to delete document and status: {e}") from e
 
             deletion_fully_completed = True
-            return DeletionResult(
+
+            result = DeletionResult(
                 status="success",
                 doc_id=doc_id,
                 message=log_message,
                 status_code=200,
                 file_path=file_path,
             )
+            if skip_rebuild:
+                result.entities_to_rebuild = entities_to_rebuild
+                result.relationships_to_rebuild = relationships_to_rebuild
+            return result
 
         except Exception as e:
             original_exception = e

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -3792,10 +3792,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 ) from e
 
             # 11. Delete original document and status.
-            #     doc_status is deleted first so that if full_docs.delete fails, a retry
-            #     finds no doc_status record and treats the document as already gone.
-            #     When skip_rebuild is set the caller handles a deferred rebuild that may
-            #     fail -- keep doc_status alive so the user can re-trigger deletion later.
+            #     Normal mode: doc_status is deleted first so that if full_docs.delete
+            #     fails, a retry finds no doc_status record and treats the doc as gone.
+            #     Batch mode (skip_rebuild): doc_status stays alive because the caller
+            #     still needs to do a deferred rebuild that might fail. If it does fail,
+            #     having doc_status around means the user can just re-trigger deletion.
             try:
                 deletion_stage = "delete_doc_entries"
                 in_final_delete_stage = True

--- a/tests/api/routes/test_document_routes_docx_archive.py
+++ b/tests/api/routes/test_document_routes_docx_archive.py
@@ -225,8 +225,10 @@ class _DeleteRag:
         self.workspace = f"delete-test-{uuid4().hex}"
         self.deleted_doc_ids = []
 
-    async def adelete_by_doc_id(self, doc_id, delete_llm_cache=False):
-        self.deleted_doc_ids.append((doc_id, delete_llm_cache))
+    async def adelete_by_doc_id(
+        self, doc_id, delete_llm_cache=False, skip_rebuild=False
+    ):
+        self.deleted_doc_ids.append((doc_id, delete_llm_cache, skip_rebuild))
         return self.result
 
     async def apipeline_process_enqueue_documents(self):
@@ -1787,7 +1789,7 @@ async def test_background_delete_removes_parser_hint_file_variants(tmp_path):
         delete_llm_cache=True,
     )
 
-    assert rag.deleted_doc_ids == [("doc-paper", True)]
+    assert rag.deleted_doc_ids == [("doc-paper", True, True)]
     assert not source_file.exists()
     assert not parsed_variant.exists()
     assert unrelated_file.exists()

--- a/tests/test_batch_delete_deferred_rebuild.py
+++ b/tests/test_batch_delete_deferred_rebuild.py
@@ -151,6 +151,15 @@ async def test_skip_rebuild_returns_targets():
     has_relations = bool(result.relationships_to_rebuild)
     assert has_entities or has_relations, "Expected deferred rebuild targets"
 
+    # doc_status should NOT be deleted when skip_rebuild=True — the caller
+    # is responsible for cleaning it up after a successful deferred rebuild.
+    doc_status_delete_calls = [
+        c for c in rag.doc_status.delete.call_args_list
+    ]
+    assert len(doc_status_delete_calls) == 0, (
+        "doc_status.delete should not be called with skip_rebuild=True"
+    )
+
 
 @pytest.mark.asyncio
 async def test_default_rebuild_still_runs():
@@ -188,3 +197,5 @@ async def test_default_rebuild_still_runs():
     # Default mode should NOT populate the rebuild fields
     assert result.entities_to_rebuild is None
     assert result.relationships_to_rebuild is None
+    # Default mode removes doc_status immediately
+    rag.doc_status.delete.assert_called()

--- a/tests/test_batch_delete_deferred_rebuild.py
+++ b/tests/test_batch_delete_deferred_rebuild.py
@@ -1,0 +1,190 @@
+"""Verify that skip_rebuild=True defers the KG rebuild and returns targets."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lightrag.base import DeletionResult, DocStatus
+
+pytestmark = pytest.mark.offline
+
+
+# -------------------------------------------------------------------
+# Unit: DeletionResult carries rebuild targets
+# -------------------------------------------------------------------
+
+
+def test_deletion_result_default_rebuild_fields():
+    """New fields default to None so existing callers aren't affected."""
+    r = DeletionResult(status="success", doc_id="d1", message="ok")
+    assert r.entities_to_rebuild is None
+    assert r.relationships_to_rebuild is None
+
+
+def test_deletion_result_with_rebuild_fields():
+    """Rebuild targets can be populated when skip_rebuild is used."""
+    entities = {"entity_a": ["chunk_1", "chunk_2"]}
+    relations = {("entity_a", "entity_b"): ["chunk_3"]}
+    r = DeletionResult(
+        status="success",
+        doc_id="d1",
+        message="ok",
+        entities_to_rebuild=entities,
+        relationships_to_rebuild=relations,
+    )
+    assert r.entities_to_rebuild == entities
+    assert r.relationships_to_rebuild == relations
+
+
+# -------------------------------------------------------------------
+# Integration: adelete_by_doc_id with skip_rebuild
+# -------------------------------------------------------------------
+
+
+def _make_rag_stub():
+    """Build a minimal mock that satisfies adelete_by_doc_id's storage calls."""
+    rag = MagicMock()
+    rag.workspace = "/tmp/test-workspace"
+
+    rag.doc_status = AsyncMock()
+    rag.doc_status.get_by_id = AsyncMock(
+        return_value={
+            "status": DocStatus.PROCESSED.value,
+            "file_path": "/fake/path.txt",
+            "chunks_list": ["chunk_a", "chunk_b"],
+        }
+    )
+
+    rag.full_entities = AsyncMock()
+    rag.full_entities.get_by_id = AsyncMock(
+        return_value={"entity_names": ["EntityX"]}
+    )
+    rag.full_entities.delete = AsyncMock()
+
+    rag.full_relations = AsyncMock()
+    rag.full_relations.get_by_id = AsyncMock(
+        return_value={"relation_pairs": [["EntityX", "EntityY"]]}
+    )
+    rag.full_relations.delete = AsyncMock()
+
+    rag.chunk_entity_relation_graph = AsyncMock()
+    rag.chunk_entity_relation_graph.get_nodes_batch = AsyncMock(
+        return_value={
+            "EntityX": {
+                "entity_id": "EntityX",
+                # chunk_a and chunk_b will be removed; chunk_c remains -> rebuild
+                "source_id": "chunk_a<SEP>chunk_b<SEP>chunk_c",
+            }
+        }
+    )
+    rag.chunk_entity_relation_graph.get_edges_batch = AsyncMock(
+        return_value={
+            ("EntityX", "EntityY"): {
+                "source": "EntityX",
+                "target": "EntityY",
+                "source_id": "chunk_a<SEP>chunk_d",
+            }
+        }
+    )
+    rag.chunk_entity_relation_graph.remove_edges = AsyncMock()
+    rag.chunk_entity_relation_graph.remove_nodes = AsyncMock()
+    rag.chunk_entity_relation_graph.get_nodes_edges_batch = AsyncMock(
+        return_value={}
+    )
+
+    rag.chunks_vdb = AsyncMock()
+    rag.entities_vdb = AsyncMock()
+    rag.relationships_vdb = AsyncMock()
+
+    rag.text_chunks = AsyncMock()
+    rag.full_docs = AsyncMock()
+    rag.llm_response_cache = None
+
+    rag.entity_chunks = AsyncMock()
+    rag.entity_chunks.get_by_id = AsyncMock(return_value=None)
+    rag.entity_chunks.upsert = AsyncMock()
+    rag.relation_chunks = AsyncMock()
+    rag.relation_chunks.get_by_id = AsyncMock(return_value=None)
+    rag.relation_chunks.upsert = AsyncMock()
+
+    rag._insert_done = AsyncMock()
+
+    return rag
+
+
+@pytest.mark.asyncio
+async def test_skip_rebuild_returns_targets():
+    """When skip_rebuild=True, rebuild should be skipped and targets returned."""
+    from lightrag.lightrag import LightRAG
+
+    rag = _make_rag_stub()
+
+    mock_pipeline_status = {"busy": False, "history_messages": []}
+    mock_lock = asyncio.Lock()
+
+    with (
+        patch(
+            "lightrag.lightrag.get_namespace_data",
+            new_callable=AsyncMock,
+            return_value=mock_pipeline_status,
+        ),
+        patch(
+            "lightrag.lightrag.get_namespace_lock",
+            return_value=mock_lock,
+        ),
+        patch(
+            "lightrag.lightrag.rebuild_knowledge_from_chunks",
+            new_callable=AsyncMock,
+        ) as mock_rebuild,
+    ):
+        # Call the unbound method on our mock
+        result = await LightRAG.adelete_by_doc_id(
+            rag, "test-doc-001", skip_rebuild=True
+        )
+
+    assert result.status == "success"
+    mock_rebuild.assert_not_called()
+
+    # At least one set of rebuild targets should have data
+    has_entities = bool(result.entities_to_rebuild)
+    has_relations = bool(result.relationships_to_rebuild)
+    assert has_entities or has_relations, "Expected deferred rebuild targets"
+
+
+@pytest.mark.asyncio
+async def test_default_rebuild_still_runs():
+    """Without skip_rebuild (default), rebuild_knowledge_from_chunks runs."""
+    from lightrag.lightrag import LightRAG
+
+    rag = _make_rag_stub()
+
+    mock_pipeline_status = {"busy": False, "history_messages": []}
+    mock_lock = asyncio.Lock()
+
+    with (
+        patch(
+            "lightrag.lightrag.get_namespace_data",
+            new_callable=AsyncMock,
+            return_value=mock_pipeline_status,
+        ),
+        patch(
+            "lightrag.lightrag.get_namespace_lock",
+            return_value=mock_lock,
+        ),
+        patch(
+            "lightrag.lightrag.rebuild_knowledge_from_chunks",
+            new_callable=AsyncMock,
+        ) as mock_rebuild,
+        patch(
+            "lightrag.lightrag.asdict",
+            return_value={},
+        ),
+    ):
+        result = await LightRAG.adelete_by_doc_id(rag, "test-doc-001")
+
+    assert result.status == "success"
+    mock_rebuild.assert_called_once()
+    # Default mode should NOT populate the rebuild fields
+    assert result.entities_to_rebuild is None
+    assert result.relationships_to_rebuild is None

--- a/tests/test_batch_delete_deferred_rebuild.py
+++ b/tests/test_batch_delete_deferred_rebuild.py
@@ -57,9 +57,7 @@ def _make_rag_stub():
     )
 
     rag.full_entities = AsyncMock()
-    rag.full_entities.get_by_id = AsyncMock(
-        return_value={"entity_names": ["EntityX"]}
-    )
+    rag.full_entities.get_by_id = AsyncMock(return_value={"entity_names": ["EntityX"]})
     rag.full_entities.delete = AsyncMock()
 
     rag.full_relations = AsyncMock()
@@ -89,9 +87,7 @@ def _make_rag_stub():
     )
     rag.chunk_entity_relation_graph.remove_edges = AsyncMock()
     rag.chunk_entity_relation_graph.remove_nodes = AsyncMock()
-    rag.chunk_entity_relation_graph.get_nodes_edges_batch = AsyncMock(
-        return_value={}
-    )
+    rag.chunk_entity_relation_graph.get_nodes_edges_batch = AsyncMock(return_value={})
 
     rag.chunks_vdb = AsyncMock()
     rag.entities_vdb = AsyncMock()
@@ -153,12 +149,10 @@ async def test_skip_rebuild_returns_targets():
 
     # doc_status should NOT be deleted when skip_rebuild=True — the caller
     # is responsible for cleaning it up after a successful deferred rebuild.
-    doc_status_delete_calls = [
-        c for c in rag.doc_status.delete.call_args_list
-    ]
-    assert len(doc_status_delete_calls) == 0, (
-        "doc_status.delete should not be called with skip_rebuild=True"
-    )
+    doc_status_delete_calls = [c for c in rag.doc_status.delete.call_args_list]
+    assert (
+        len(doc_status_delete_calls) == 0
+    ), "doc_status.delete should not be called with skip_rebuild=True"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

When deleting N documents via `background_delete_documents()`, each `adelete_by_doc_id()` call triggers a full `rebuild_knowledge_from_chunks()`. For entities shared across documents, this means the same summaries get recomputed N times. On an 85-document batch, the issue author measured ~75x redundant LLM calls.

This PR adds a `skip_rebuild` parameter to `adelete_by_doc_id()` (defaults to `False` for backwards compat). The batch deletion loop passes `skip_rebuild=True`, collects rebuild targets from each result, and does a single combined rebuild at the end.

**Changes:**
- `lightrag/base.py` — `DeletionResult` gains optional `entities_to_rebuild` / `relationships_to_rebuild` fields
- `lightrag/lightrag.py` — `adelete_by_doc_id()` conditionally skips rebuild when `skip_rebuild=True`, populates rebuild targets on the result
- `lightrag/api/routers/document_routes.py` — `background_delete_documents()` aggregates targets across loop, single `rebuild_knowledge_from_chunks()` call at the end
- `tests/test_batch_delete_deferred_rebuild.py` — 4 tests covering both modes

Single-doc deletion (direct `adelete_by_doc_id()` calls) is completely unaffected — same code path as before.

Closes #2795