### PR TITLE
perf: batch OpenSearch graph/KV/vector operations to reduce HTTP roundtrips

### DIFF
--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -332,29 +332,54 @@ class OpenSearchKVStorage(BaseKVStorage):
             return None
 
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
-        """Get multiple documents by IDs, preserving input order."""
-        if not self._index_ready:
-            return [None] * len(ids)
-        try:
-            response = await self.client.mget(index=self._index_name, body={"ids": ids})
-            doc_map = {}
-            for doc in response["docs"]:
-                if doc.get("found"):
-                    data = doc["_source"]
-                    data["_id"] = doc["_id"]
-                    data.setdefault("create_time", 0)
-                    data.setdefault("update_time", 0)
-                    doc_map[doc["_id"]] = data
-            return [doc_map.get(id) for id in ids]
-        except OpenSearchException as e:
-            if _is_missing_index_error(e):
-                self._mark_index_missing()
-                return [None] * len(ids)
-            logger.error(f"[{self.workspace}] Error getting documents: {e}")
-            return [None] * len(ids)
+        """Get multiple documents by IDs, preserving input order.
+
+        Checks the pending write buffer first so callers see documents
+        that have been upserted but not yet flushed.
+        """
+        # Collect any buffered docs, then fetch the rest from OpenSearch
+        buffered = {}
+        remaining_ids = []
+        for id in ids:
+            if id in self._pending_upserts:
+                doc = self._pending_upserts[id].copy()
+                doc["_id"] = id
+                doc.setdefault("create_time", 0)
+                doc.setdefault("update_time", 0)
+                buffered[id] = doc
+            else:
+                remaining_ids.append(id)
+
+        doc_map = dict(buffered)
+        if remaining_ids and self._index_ready:
+            try:
+                response = await self.client.mget(
+                    index=self._index_name, body={"ids": remaining_ids}
+                )
+                for doc in response["docs"]:
+                    if doc.get("found"):
+                        data = doc["_source"]
+                        data["_id"] = doc["_id"]
+                        data.setdefault("create_time", 0)
+                        data.setdefault("update_time", 0)
+                        doc_map[doc["_id"]] = data
+            except OpenSearchException as e:
+                if _is_missing_index_error(e):
+                    self._mark_index_missing()
+                else:
+                    logger.error(f"[{self.workspace}] Error getting documents: {e}")
+
+        return [doc_map.get(id) for id in ids]
 
     async def filter_keys(self, keys: set[str]) -> set[str]:
-        """Return the subset of keys that do not exist in storage."""
+        """Return the subset of keys that do not exist in storage.
+
+        Also excludes keys already buffered in _pending_upserts so we
+        don't trigger duplicate processing for docs queued in this batch.
+        """
+        keys = keys - set(self._pending_upserts.keys())
+        if not keys:
+            return keys
         if not self._index_ready:
             return keys
         try:
@@ -405,11 +430,11 @@ class OpenSearchKVStorage(BaseKVStorage):
             }
             for doc_id, doc in self._pending_upserts.items()
         ]
-        self._pending_upserts.clear()
         try:
             success, failed = await helpers.async_bulk(
                 self.client, actions, raise_on_error=False
             )
+            self._pending_upserts.clear()
             if failed:
                 logger.warning(
                     f"[{self.workspace}] {len(failed)} documents failed to upsert"
@@ -418,6 +443,7 @@ class OpenSearchKVStorage(BaseKVStorage):
                 f"[{self.workspace}] Flushed {success} KV docs via bulk"
             )
         except OpenSearchException as e:
+            # Buffer is preserved so next index_done_callback() or finalize() retries
             logger.error(f"[{self.workspace}] Error flushing KV upserts: {e}")
             raise
 
@@ -2510,7 +2536,6 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                         "_source": doc,
                     }
                 )
-            self._pending_nodes.clear()
 
         if self._pending_edges:
             for edge_id, doc in self._pending_edges.items():
@@ -2522,7 +2547,6 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                         "_source": doc,
                     }
                 )
-            self._pending_edges.clear()
 
         if not actions:
             return
@@ -2531,6 +2555,8 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             success, failed = await helpers.async_bulk(
                 self.client, actions, raise_on_error=False
             )
+            self._pending_nodes.clear()
+            self._pending_edges.clear()
             if failed:
                 logger.warning(
                     f"[{self.workspace}] {len(failed)} graph ops failed during bulk flush"
@@ -2539,7 +2565,9 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 f"[{self.workspace}] Flushed {success} graph ops via bulk"
             )
         except OpenSearchException as e:
+            # Buffer is preserved so next index_done_callback() or finalize() retries
             logger.error(f"[{self.workspace}] Error flushing graph ops: {e}")
+            raise
 
     async def index_done_callback(self) -> None:
         """Flush pending writes and refresh both node and edge indices."""
@@ -2870,7 +2898,6 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
             return
         # Deduplicate — same ID might be queued more than once
         unique_ids = list(dict.fromkeys(self._pending_deletes))
-        self._pending_deletes.clear()
         actions = [
             {"_op_type": "delete", "_index": self._index_name, "_id": doc_id}
             for doc_id in unique_ids
@@ -2879,6 +2906,7 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
             success, _ = await helpers.async_bulk(
                 self.client, actions, raise_on_error=False
             )
+            self._pending_deletes.clear()
             logger.debug(
                 f"[{self.workspace}] Flushed {success} vector deletes via bulk"
             )
@@ -2886,7 +2914,9 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
             if _is_missing_index_error(e):
                 self._mark_index_missing()
                 return
+            # Buffer is preserved so next index_done_callback() or finalize() retries
             logger.error(f"[{self.workspace}] Error flushing vector deletes: {e}")
+            raise
 
     async def index_done_callback(self) -> None:
         """Flush pending deletes and refresh index for search visibility."""

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -439,9 +439,7 @@ class OpenSearchKVStorage(BaseKVStorage):
                 logger.warning(
                     f"[{self.workspace}] {len(failed)} documents failed to upsert"
                 )
-            logger.debug(
-                f"[{self.workspace}] Flushed {success} KV docs via bulk"
-            )
+            logger.debug(f"[{self.workspace}] Flushed {success} KV docs via bulk")
         except OpenSearchException as e:
             # Buffer is preserved so next index_done_callback() or finalize() retries
             logger.error(f"[{self.workspace}] Error flushing KV upserts: {e}")
@@ -1596,9 +1594,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 edge_id = reverse_id
             else:
                 try:
-                    if await self.client.exists(
-                        index=self._edges_index, id=reverse_id
-                    ):
+                    if await self.client.exists(index=self._edges_index, id=reverse_id):
                         edge_id = reverse_id
                 except OpenSearchException:
                     pass
@@ -2561,9 +2557,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 logger.warning(
                     f"[{self.workspace}] {len(failed)} graph ops failed during bulk flush"
                 )
-            logger.debug(
-                f"[{self.workspace}] Flushed {success} graph ops via bulk"
-            )
+            logger.debug(f"[{self.workspace}] Flushed {success} graph ops via bulk")
         except OpenSearchException as e:
             # Buffer is preserved so next index_done_callback() or finalize() retries
             logger.error(f"[{self.workspace}] Error flushing graph ops: {e}")

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -182,6 +182,8 @@ class OpenSearchKVStorage(BaseKVStorage):
     client: AsyncOpenSearch = field(default=None)
     _index_name: str = field(default="", init=False)
     _index_ready: bool = field(default=False, init=False)
+    # Write buffer — accumulated by upsert(), flushed in index_done_callback().
+    _pending_upserts: dict = field(default_factory=dict, init=False)
 
     def __init__(self, namespace, global_config, embedding_func, workspace=None):
         super().__init__(
@@ -196,6 +198,7 @@ class OpenSearchKVStorage(BaseKVStorage):
         self.workspace, self.final_namespace, self._index_name = _build_index_name(
             self.workspace, self.namespace
         )
+        self._pending_upserts = {}
 
     async def initialize(self):
         """Initialize client connection and create index if needed."""
@@ -246,8 +249,9 @@ class OpenSearchKVStorage(BaseKVStorage):
             raise
 
     async def finalize(self):
-        """Release the OpenSearch client connection."""
+        """Flush pending writes and release the OpenSearch client connection."""
         if self.client is not None:
+            await self._flush_pending_upserts()
             await ClientManager.release_client(self.client)
             self.client = None
 
@@ -298,7 +302,17 @@ class OpenSearchKVStorage(BaseKVStorage):
             raise
 
     async def get_by_id(self, id: str) -> dict[str, Any] | None:
-        """Get a document by its ID, or None if not found."""
+        """Get a document by its ID, or None if not found.
+
+        Checks the pending write buffer first so callers see documents
+        that have been upserted but not yet flushed.
+        """
+        if id in self._pending_upserts:
+            doc = self._pending_upserts[id].copy()
+            doc["_id"] = id
+            doc.setdefault("create_time", 0)
+            doc.setdefault("update_time", 0)
+            return doc
         if not self._index_ready:
             return None
         try:
@@ -357,30 +371,42 @@ class OpenSearchKVStorage(BaseKVStorage):
             return keys
 
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
-        """Insert or update documents with automatic timestamping."""
+        """Buffer documents for bulk indexing during index_done_callback().
+
+        Timestamps are applied immediately so ordering is preserved.
+        Reads via get_by_id/get_by_ids still work because mget hits the
+        translog once the batch is flushed.
+        """
         if not data:
             return
         await self._ensure_index_ready()
         logger.debug(
-            f"[{self.workspace}] Upserting {len(data)} documents to {self.namespace}"
+            f"[{self.workspace}] Buffering {len(data)} documents for {self.namespace}"
         )
         current_time = int(time.time())
-        actions = []
         for i, (doc_id, doc_data) in enumerate(data.items(), start=1):
             doc_data["update_time"] = current_time
             doc_data.setdefault("create_time", current_time)
-            actions.append(
-                {
-                    "_op_type": "index",
-                    "_index": self._index_name,
-                    "_id": doc_id,
-                    "_source": {k: v for k, v in doc_data.items() if k != "_id"},
-                }
-            )
+            self._pending_upserts[doc_id] = {
+                k: v for k, v in doc_data.items() if k != "_id"
+            }
             await _cooperative_yield(i)
+
+    async def _flush_pending_upserts(self) -> None:
+        """Flush buffered upserts to OpenSearch via a single async_bulk call."""
+        if not self._pending_upserts:
+            return
+        actions = [
+            {
+                "_op_type": "index",
+                "_index": self._index_name,
+                "_id": doc_id,
+                "_source": doc,
+            }
+            for doc_id, doc in self._pending_upserts.items()
+        ]
+        self._pending_upserts.clear()
         try:
-            # No per-operation refresh: immediate reads use ID-based mget (translog),
-            # search visibility is guaranteed after index_done_callback() batch refresh.
             success, failed = await helpers.async_bulk(
                 self.client, actions, raise_on_error=False
             )
@@ -388,14 +414,18 @@ class OpenSearchKVStorage(BaseKVStorage):
                 logger.warning(
                     f"[{self.workspace}] {len(failed)} documents failed to upsert"
                 )
+            logger.debug(
+                f"[{self.workspace}] Flushed {success} KV docs via bulk"
+            )
         except OpenSearchException as e:
-            logger.error(f"[{self.workspace}] Error upserting documents: {e}")
+            logger.error(f"[{self.workspace}] Error flushing KV upserts: {e}")
             raise
 
     async def index_done_callback(self) -> None:
-        """Refresh index to make recently indexed documents searchable."""
+        """Flush pending writes and refresh index for search visibility."""
         if not self._index_ready:
             return
+        await self._flush_pending_upserts()
         try:
             await self.client.indices.refresh(index=self._index_name)
         except OpenSearchException as e:
@@ -446,6 +476,7 @@ class OpenSearchKVStorage(BaseKVStorage):
 
     async def drop(self) -> dict[str, str]:
         """Delete the entire index."""
+        self._pending_upserts.clear()
         try:
             try:
                 await self.client.indices.delete(index=self._index_name)
@@ -978,6 +1009,10 @@ class OpenSearchGraphStorage(BaseGraphStorage):
     _nodes_dirty: bool = field(default=False, init=False)
     _edges_dirty: bool = field(default=False, init=False)
     _ppl_graphlookup_available: bool = field(default=False, init=False)
+    # Write buffers — accumulated by upsert_node/upsert_edge, flushed in
+    # index_done_callback() via async_bulk to avoid per-operation HTTP roundtrips.
+    _pending_nodes: dict = field(default_factory=dict, init=False)
+    _pending_edges: dict = field(default_factory=dict, init=False)
 
     def __init__(self, namespace, global_config, embedding_func, workspace=None):
         super().__init__(
@@ -994,6 +1029,8 @@ class OpenSearchGraphStorage(BaseGraphStorage):
         )
         self._nodes_index = f"{base_name}-nodes"
         self._edges_index = f"{base_name}-edges"
+        self._pending_nodes = {}
+        self._pending_edges = {}
 
     async def initialize(self):
         """Initialize client, create indices, and detect PPL graphlookup support."""
@@ -1158,15 +1195,18 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 raise
 
     async def finalize(self):
-        """Release the OpenSearch client connection."""
+        """Flush pending writes and release the OpenSearch client connection."""
         if self.client is not None:
+            await self._flush_pending_ops()
             await ClientManager.release_client(self.client)
             self.client = None
 
     # --- Basic queries ---
 
     async def has_node(self, node_id: str) -> bool:
-        """Check whether a node exists in the graph."""
+        """Check whether a node exists in the graph (including pending buffer)."""
+        if node_id in self._pending_nodes:
+            return True
         if not self._indices_ready:
             return False
         try:
@@ -1233,7 +1273,15 @@ class OpenSearchGraphStorage(BaseGraphStorage):
         return src_degree + tgt_degree
 
     async def get_node(self, node_id: str) -> dict[str, str] | None:
-        """Get a node document by ID, or None if not found."""
+        """Get a node document by ID, or None if not found.
+
+        Checks the pending write buffer first so callers see nodes that
+        have been upserted but not yet flushed to OpenSearch.
+        """
+        if node_id in self._pending_nodes:
+            doc = self._pending_nodes[node_id].copy()
+            doc["_id"] = node_id
+            return doc
         if not self._indices_ready:
             return None
         try:
@@ -1471,28 +1519,36 @@ class OpenSearchGraphStorage(BaseGraphStorage):
     # --- Upsert operations ---
 
     async def upsert_node(self, node_id: str, node_data: dict[str, str]) -> None:
-        """Insert or update a node. Adds entity_id for PPL compatibility."""
+        """Insert or update a node. Adds entity_id for PPL compatibility.
+
+        The write is buffered and flushed in bulk during index_done_callback()
+        to avoid one HTTP roundtrip per node.
+        """
         try:
             await self._ensure_indices_ready()
             doc = {k: v for k, v in node_data.items() if k != "_id"}
             doc["entity_id"] = node_id
             if node_data.get("source_id", ""):
                 doc["source_ids"] = node_data["source_id"].split(GRAPH_FIELD_SEP)
-            # No per-operation refresh: node reads use ID-based mget/exists
-            # (translog, real-time). Search visibility after index_done_callback().
-            await self.client.index(index=self._nodes_index, id=node_id, body=doc)
-            self._nodes_dirty = True
+            self._pending_nodes[node_id] = doc
         except OpenSearchException as e:
             logger.error(f"[{self.workspace}] Error upserting node {node_id}: {e}")
 
     async def upsert_edge(
         self, source_node_id: str, target_node_id: str, edge_data: dict[str, str]
     ) -> None:
-        """Insert or update an edge with deterministic ID for bidirectional handling."""
+        """Insert or update an edge with deterministic ID for bidirectional handling.
+
+        The write is buffered and flushed in bulk during index_done_callback()
+        to avoid one HTTP roundtrip per edge.
+        """
         try:
             await self._ensure_indices_ready()
-            # Ensure source node exists (don't overwrite if it already has data)
-            if not await self.has_node(source_node_id):
+            # Ensure source node exists — check both the pending buffer and the
+            # persisted index so we don't create a redundant empty node.
+            if source_node_id not in self._pending_nodes and not await self.has_node(
+                source_node_id
+            ):
                 await self.upsert_node(source_node_id, {})
 
             doc = {k: v for k, v in edge_data.items() if k != "_id"}
@@ -1501,23 +1557,27 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             if edge_data.get("source_id", ""):
                 doc["source_ids"] = edge_data["source_id"].split(GRAPH_FIELD_SEP)
 
-            # Use a deterministic ID for the edge so upserts work
+            # Deterministic edge ID for upsert semantics
             edge_id = compute_mdhash_id(
                 f"{source_node_id}-{target_node_id}", prefix="edge-"
             )
 
-            # Check if reverse edge exists
+            # Check if reverse edge already exists (in buffer or persisted)
             reverse_id = compute_mdhash_id(
                 f"{target_node_id}-{source_node_id}", prefix="edge-"
             )
-            try:
-                if await self.client.exists(index=self._edges_index, id=reverse_id):
-                    edge_id = reverse_id
-            except OpenSearchException:
-                pass
+            if reverse_id in self._pending_edges:
+                edge_id = reverse_id
+            else:
+                try:
+                    if await self.client.exists(
+                        index=self._edges_index, id=reverse_id
+                    ):
+                        edge_id = reverse_id
+                except OpenSearchException:
+                    pass
 
-            await self.client.index(index=self._edges_index, id=edge_id, body=doc)
-            self._edges_dirty = True
+            self._pending_edges[edge_id] = doc
         except OpenSearchException as e:
             logger.error(
                 f"[{self.workspace}] Error upserting edge {source_node_id}->{target_node_id}: {e}"
@@ -2437,10 +2497,55 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 self._mark_indices_missing()
             return []
 
+    async def _flush_pending_ops(self) -> None:
+        """Flush buffered node/edge upserts to OpenSearch via async_bulk."""
+        actions = []
+        if self._pending_nodes:
+            for node_id, doc in self._pending_nodes.items():
+                actions.append(
+                    {
+                        "_op_type": "index",
+                        "_index": self._nodes_index,
+                        "_id": node_id,
+                        "_source": doc,
+                    }
+                )
+            self._pending_nodes.clear()
+
+        if self._pending_edges:
+            for edge_id, doc in self._pending_edges.items():
+                actions.append(
+                    {
+                        "_op_type": "index",
+                        "_index": self._edges_index,
+                        "_id": edge_id,
+                        "_source": doc,
+                    }
+                )
+            self._pending_edges.clear()
+
+        if not actions:
+            return
+
+        try:
+            success, failed = await helpers.async_bulk(
+                self.client, actions, raise_on_error=False
+            )
+            if failed:
+                logger.warning(
+                    f"[{self.workspace}] {len(failed)} graph ops failed during bulk flush"
+                )
+            logger.debug(
+                f"[{self.workspace}] Flushed {success} graph ops via bulk"
+            )
+        except OpenSearchException as e:
+            logger.error(f"[{self.workspace}] Error flushing graph ops: {e}")
+
     async def index_done_callback(self) -> None:
-        """Refresh both node and edge indices."""
+        """Flush pending writes and refresh both node and edge indices."""
         if not self._indices_ready:
             return
+        await self._flush_pending_ops()
         try:
             await self._refresh_graph_indices_if_dirty(
                 refresh_nodes=True, refresh_edges=True
@@ -2454,6 +2559,9 @@ class OpenSearchGraphStorage(BaseGraphStorage):
 
     async def drop(self) -> dict[str, str]:
         """Delete both node and edge indices."""
+        # Discard buffered writes — the indices are being deleted anyway
+        self._pending_nodes.clear()
+        self._pending_edges.clear()
         errors = []
         for idx in (self._nodes_index, self._edges_index):
             try:
@@ -2498,6 +2606,8 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
     client: AsyncOpenSearch = field(default=None)
     _index_name: str = field(default="", init=False)
     _index_ready: bool = field(default=False, init=False)
+    # Delete buffer — accumulated by delete(), flushed in index_done_callback().
+    _pending_deletes: list = field(default_factory=list, init=False)
 
     def __init__(
         self, namespace, global_config, embedding_func, workspace=None, meta_fields=None
@@ -2524,6 +2634,7 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
             )
         self.cosine_better_than_threshold = cosine_threshold
         self._max_batch_size = self.global_config["embedding_batch_num"]
+        self._pending_deletes = []
 
     async def initialize(self):
         """Initialize client and create k-NN vector index."""
@@ -2633,8 +2744,9 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
             raise
 
     async def finalize(self):
-        """Release the OpenSearch client connection."""
+        """Flush pending deletes and release the OpenSearch client connection."""
         if self.client is not None:
+            await self._flush_pending_deletes()
             await ClientManager.release_client(self.client)
             self.client = None
 
@@ -2752,10 +2864,35 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
             logger.error(f"[{self.workspace}] Error querying vectors: {e}")
             return []
 
+    async def _flush_pending_deletes(self) -> None:
+        """Flush buffered delete IDs to OpenSearch via a single async_bulk call."""
+        if not self._pending_deletes:
+            return
+        # Deduplicate — same ID might be queued more than once
+        unique_ids = list(dict.fromkeys(self._pending_deletes))
+        self._pending_deletes.clear()
+        actions = [
+            {"_op_type": "delete", "_index": self._index_name, "_id": doc_id}
+            for doc_id in unique_ids
+        ]
+        try:
+            success, _ = await helpers.async_bulk(
+                self.client, actions, raise_on_error=False
+            )
+            logger.debug(
+                f"[{self.workspace}] Flushed {success} vector deletes via bulk"
+            )
+        except OpenSearchException as e:
+            if _is_missing_index_error(e):
+                self._mark_index_missing()
+                return
+            logger.error(f"[{self.workspace}] Error flushing vector deletes: {e}")
+
     async def index_done_callback(self) -> None:
-        """Refresh index to make recently indexed vectors searchable."""
+        """Flush pending deletes and refresh index for search visibility."""
         if not self._index_ready:
             return
+        await self._flush_pending_deletes()
         try:
             await self.client.indices.refresh(index=self._index_name)
         except OpenSearchException as e:
@@ -2828,30 +2965,14 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
             return {}
 
     async def delete(self, ids: list[str]) -> None:
-        """Delete vectors by their IDs."""
+        """Buffer vector IDs for bulk deletion during index_done_callback()."""
         if not ids:
             return
         if not self._index_ready:
             return
         if isinstance(ids, set):
             ids = list(ids)
-        try:
-            # No per-operation refresh: search visibility after index_done_callback().
-            actions = [
-                {"_op_type": "delete", "_index": self._index_name, "_id": doc_id}
-                for doc_id in ids
-            ]
-            result = await helpers.async_bulk(
-                self.client, actions, raise_on_error=False
-            )
-            logger.debug(
-                f"[{self.workspace}] Deleted {result[0]} vectors from {self.namespace}"
-            )
-        except OpenSearchException as e:
-            if _is_missing_index_error(e):
-                self._mark_index_missing()
-                return
-            logger.error(f"[{self.workspace}] Error deleting vectors: {e}")
+        self._pending_deletes.extend(ids)
 
     async def delete_entity(self, entity_name: str) -> None:
         """Delete an entity vector by computing its hash ID."""
@@ -2907,6 +3028,7 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
 
     async def drop(self) -> dict[str, str]:
         """Delete and recreate the vector index."""
+        self._pending_deletes.clear()
         try:
             try:
                 await self.client.indices.delete(index=self._index_name)

--- a/tests/test_opensearch_storage.py
+++ b/tests/test_opensearch_storage.py
@@ -338,6 +338,8 @@ class TestKVStorage:
                 s = self._make(global_config, embed_func)
                 await s.initialize()
                 await s.upsert({"k1": {"content": "v1"}})
+                # upsert buffers docs; flush happens in index_done_callback
+                await s.index_done_callback()
                 _, kwargs = mock_bulk.call_args
                 assert "refresh" not in kwargs
 
@@ -351,6 +353,8 @@ class TestKVStorage:
                 s = self._make(global_config, embed_func)
                 await s.initialize()
                 await s.upsert({"k1": {"content": "v1"}})
+                # upsert buffers docs; flush happens in index_done_callback
+                await s.index_done_callback()
                 actions = mock_bulk.call_args[0][1]
                 src = actions[0]["_source"]
                 assert "create_time" in src
@@ -1186,10 +1190,9 @@ class TestGraphStorage:
             await s.upsert_node(
                 "Alice", {"entity_type": "person", "source_id": "c1<SEP>c2"}
             )
-            mock_client.index.assert_awaited()
-            call_kwargs = mock_client.index.call_args
-            assert call_kwargs.kwargs["id"] == "Alice"
-            body = call_kwargs.kwargs["body"]
+            # upsert_node buffers; verify the buffer content directly
+            assert "Alice" in s._pending_nodes
+            body = s._pending_nodes["Alice"]
             assert body["source_ids"] == ["c1", "c2"]
             assert body["entity_id"] == "Alice"
 
@@ -1200,8 +1203,10 @@ class TestGraphStorage:
             s = self._make(global_config, embed_func)
             await s.initialize()
             await s.upsert_edge("A", "B", {"weight": "1.0", "description": "knows"})
-            # Should call index twice: once for ensuring source node, once for edge
-            assert mock_client.index.await_count == 2
+            # Source node "A" should be buffered (since has_node returned False)
+            assert "A" in s._pending_nodes
+            # Edge should also be buffered
+            assert len(s._pending_edges) == 1
 
     @pytest.mark.asyncio
     async def test_upsert_edges_batch_reuses_id_for_reciprocal_edges(
@@ -1254,7 +1259,9 @@ class TestGraphStorage:
                 await s.drop()
                 await s.upsert_edge("A", "B", {"weight": "1.0"})
                 mock_create.assert_awaited_once()
-                assert mock_client.index.await_count == 2
+                # Buffered, not flushed yet
+                assert "A" in s._pending_nodes
+                assert len(s._pending_edges) == 1
 
     @pytest.mark.asyncio
     async def test_reads_short_circuit_after_drop(
@@ -1619,6 +1626,188 @@ class TestGraphStorage:
             assert len(result.edges) == 0
 
 
+# ---------------------------------------------------------------------------
+# Batch flush tests
+# ---------------------------------------------------------------------------
+
+
+class TestBatchFlush:
+    """Tests for write-buffering and flush behavior across all storage classes."""
+
+    @pytest.mark.asyncio
+    async def test_graph_flush_via_index_done_callback(
+        self, global_config, embed_func, mock_client
+    ):
+        """Buffered node/edge writes should be flushed as a single async_bulk call."""
+        mock_client.exists = AsyncMock(return_value=False)
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch(
+                "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
+            ) as mock_bulk:
+                mock_bulk.return_value = (5, [])
+                s = OpenSearchGraphStorage(
+                    namespace="chunk_entity_relation",
+                    global_config=global_config,
+                    embedding_func=embed_func,
+                    workspace="test",
+                )
+                await s.initialize()
+
+                # Buffer several nodes and edges
+                await s.upsert_node("A", {"entity_type": "person"})
+                await s.upsert_node("B", {"entity_type": "place"})
+                await s.upsert_edge("A", "B", {"weight": "1.0"})
+
+                # Nothing flushed yet
+                mock_bulk.assert_not_awaited()
+
+                await s.index_done_callback()
+
+                # Now everything should be flushed in one bulk call
+                mock_bulk.assert_awaited_once()
+                actions = mock_bulk.call_args[0][1]
+                # A, B (nodes), source node C from edge (if not in buffer), edge
+                node_actions = [a for a in actions if a["_index"].endswith("-nodes")]
+                edge_actions = [a for a in actions if a["_index"].endswith("-edges")]
+                assert len(node_actions) >= 2
+                assert len(edge_actions) == 1
+
+    @pytest.mark.asyncio
+    async def test_graph_has_node_sees_buffered_nodes(
+        self, global_config, embed_func, mock_client
+    ):
+        """has_node should return True for nodes in the pending buffer."""
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = OpenSearchGraphStorage(
+                namespace="chunk_entity_relation",
+                global_config=global_config,
+                embedding_func=embed_func,
+                workspace="test",
+            )
+            await s.initialize()
+            await s.upsert_node("X", {"entity_type": "thing"})
+            assert await s.has_node("X") is True
+            # Should not have hit the server
+            mock_client.exists.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_graph_get_node_sees_buffered_nodes(
+        self, global_config, embed_func, mock_client
+    ):
+        """get_node should return data from the pending buffer."""
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = OpenSearchGraphStorage(
+                namespace="chunk_entity_relation",
+                global_config=global_config,
+                embedding_func=embed_func,
+                workspace="test",
+            )
+            await s.initialize()
+            await s.upsert_node("Y", {"entity_type": "org", "description": "test"})
+            node = await s.get_node("Y")
+            assert node is not None
+            assert node["entity_type"] == "org"
+            assert node["_id"] == "Y"
+
+    @pytest.mark.asyncio
+    async def test_kv_flush_via_index_done_callback(
+        self, global_config, embed_func, mock_client
+    ):
+        """KV upserts should be buffered and flushed via index_done_callback."""
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch(
+                "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
+            ) as mock_bulk:
+                mock_bulk.return_value = (3, [])
+                s = OpenSearchKVStorage(
+                    namespace="text_chunks",
+                    global_config=global_config,
+                    embedding_func=embed_func,
+                    workspace="test",
+                )
+                await s.initialize()
+
+                await s.upsert({"k1": {"content": "v1"}})
+                await s.upsert({"k2": {"content": "v2"}})
+                await s.upsert({"k3": {"content": "v3"}})
+
+                # Nothing flushed yet
+                mock_bulk.assert_not_awaited()
+
+                await s.index_done_callback()
+
+                # All 3 docs flushed in one bulk call
+                mock_bulk.assert_awaited_once()
+                actions = mock_bulk.call_args[0][1]
+                assert len(actions) == 3
+
+    @pytest.mark.asyncio
+    async def test_kv_get_by_id_sees_buffered_docs(
+        self, global_config, embed_func, mock_client
+    ):
+        """get_by_id should return data from the pending buffer."""
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = OpenSearchKVStorage(
+                namespace="text_chunks",
+                global_config=global_config,
+                embedding_func=embed_func,
+                workspace="test",
+            )
+            await s.initialize()
+            await s.upsert({"doc1": {"content": "buffered"}})
+            doc = await s.get_by_id("doc1")
+            assert doc is not None
+            assert doc["content"] == "buffered"
+            assert doc["_id"] == "doc1"
+
+    @pytest.mark.asyncio
+    async def test_vector_delete_flush(self, global_config, embed_func, mock_client):
+        """Vector deletes should be buffered and flushed via index_done_callback."""
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch(
+                "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
+            ) as mock_bulk:
+                mock_bulk.return_value = (5, [])
+                s = OpenSearchVectorDBStorage(
+                    namespace="entities",
+                    global_config=global_config,
+                    embedding_func=embed_func,
+                    workspace="test",
+                )
+                await s.initialize()
+
+                await s.delete(["v1", "v2"])
+                await s.delete(["v3"])
+
+                mock_bulk.assert_not_awaited()
+
+                await s.index_done_callback()
+
+                mock_bulk.assert_awaited_once()
+                actions = mock_bulk.call_args[0][1]
+                assert len(actions) == 3
+                assert all(a["_op_type"] == "delete" for a in actions)
+
+    @pytest.mark.asyncio
+    async def test_graph_drop_clears_pending_buffer(
+        self, global_config, embed_func, mock_client
+    ):
+        """drop() should discard pending writes since the indices are deleted."""
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = OpenSearchGraphStorage(
+                namespace="chunk_entity_relation",
+                global_config=global_config,
+                embedding_func=embed_func,
+                workspace="test",
+            )
+            await s.initialize()
+            await s.upsert_node("Z", {"entity_type": "person"})
+            assert len(s._pending_nodes) == 1
+            await s.drop()
+            assert len(s._pending_nodes) == 0
+            assert len(s._pending_edges) == 0
+
+
 class TestGraphPPLDetection:
     """Tests for PPL graphlookup detection and server-side BFS."""
 
@@ -1978,7 +2167,7 @@ class TestGraphPPLDetection:
             s = self._make(global_config, embed_func)
             await s.initialize()
             await s.upsert_node("TestNode", {"description": "test"})
-            body = mock_client.index.call_args.kwargs["body"]
+            body = s._pending_nodes["TestNode"]
             assert body["entity_id"] == "TestNode"
             assert body["description"] == "test"
 
@@ -2239,6 +2428,8 @@ class TestVectorStorage:
                 s = self._make(global_config, embed_func)
                 await s.initialize()
                 await s.delete(["v1", "v2"])
+                # delete buffers; flush via index_done_callback
+                await s.index_done_callback()
                 actions = mock_bulk.call_args[0][1]
                 assert len(actions) == 2
                 assert all(a["_op_type"] == "delete" for a in actions)


### PR DESCRIPTION
## Summary

Fixes #2785

The profiling data in #2785 shows that individual HTTP roundtrips dominate OpenSearch wall time compared to Neo4j:

- **Graph**: `upsert_node` (252s / 266 calls) and `upsert_edge` (224s / 244 calls) each did individual `client.index()` calls
- **KV**: `upsert` called 651 times with small payloads (429s total), each triggering a separate `async_bulk`
- **Vector**: `delete` called 244 times (128s total), same per-call overhead

This PR buffers write operations in memory and flushes them in a single `async_bulk` call during `index_done_callback()`, which is already called at the end of each processing stage.

## What changed

**Graph storage (`OpenSearchGraphStorage`)**
- `upsert_node()` and `upsert_edge()` now buffer docs to `_pending_nodes` / `_pending_edges` dicts instead of calling `client.index()` per operation
- `_flush_pending_ops()` flushes both buffers via one `async_bulk` call
- `has_node()` and `get_node()` check the pending buffer first, so callers see buffered-but-unflushed data (read-your-writes consistency)
- `upsert_edge()` checks the buffer for reverse edge IDs too, avoiding a server roundtrip when both directions are written in the same batch

**KV storage (`OpenSearchKVStorage`)**
- `upsert()` buffers docs to `_pending_upserts` dict
- `_flush_pending_upserts()` flushes via one `async_bulk` call
- `get_by_id()` checks the pending buffer first

**Vector storage (`OpenSearchVectorDBStorage`)**
- `delete()` buffers IDs to `_pending_deletes` list
- `_flush_pending_deletes()` deduplicates and flushes via one `async_bulk` call

**Safety**
- `finalize()` flushes pending ops before releasing the client connection
- `drop()` discards pending buffers (no point writing to indices being deleted)
- Error handling preserved -- `async_bulk(raise_on_error=False)` logs partial failures

## Backwards compatibility

No API changes. The public interface (`upsert_node`, `upsert_edge`, `upsert`, `delete`, `index_done_callback`) is unchanged. The only behavioral difference is that writes are deferred until the next `index_done_callback()` or `finalize()` call, which matches how all other LightRAG storage backends work (the base class docstrings explicitly state "changes will be persisted during the next index_done_callback").

## Test plan

- [x] All 109 existing OpenSearch tests pass
- [x] Added 7 new tests covering buffer/flush behavior, read-your-writes consistency, and drop-clears-buffer
- [ ] Integration test with a real OpenSearch cluster (needs docker-compose)