### PR TITLE
fix: defer KG rebuild during batch document deletion

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from lightrag import LightRAG
 from lightrag.base import DeletionResult, DocProcessingStatus, DocStatus
+from lightrag.operate import rebuild_knowledge_from_chunks
 from lightrag.utils import (
     generate_track_id,
     compute_mdhash_id,
@@ -1853,6 +1854,9 @@ async def background_delete_documents(
     total_docs = len(doc_ids)
     successful_deletions = []
     failed_deletions = []
+    # Aggregate rebuild targets across all deletions so we only rebuild once
+    all_entities_to_rebuild: dict[str, list] = {}
+    all_relationships_to_rebuild: dict[tuple, list] = {}
 
     # Double-check pipeline status before proceeding
     async with pipeline_status_lock:
@@ -1905,13 +1909,31 @@ async def background_delete_documents(
             file_path = "#"
             try:
                 result = await rag.adelete_by_doc_id(
-                    doc_id, delete_llm_cache=delete_llm_cache
+                    doc_id,
+                    delete_llm_cache=delete_llm_cache,
+                    skip_rebuild=True,
                 )
                 file_path = (
                     getattr(result, "file_path", "-") if "result" in locals() else "-"
                 )
                 if result.status == "success":
                     successful_deletions.append(doc_id)
+                    # Collect deferred rebuild targets
+                    if result.entities_to_rebuild:
+                        all_entities_to_rebuild.update(result.entities_to_rebuild)
+                    if result.relationships_to_rebuild:
+                        all_relationships_to_rebuild.update(
+                            result.relationships_to_rebuild
+                        )
+                    # Remove completely deleted entities and relationships from rebuild targets
+                    if getattr(result, "deleted_entities", None):
+                        for entity in result.deleted_entities:
+                            all_entities_to_rebuild.pop(entity, None)
+                    if getattr(result, "deleted_relationships", None):
+                        for relation in result.deleted_relationships:
+                            # Try both orders of the tuple since relationships are undirected in rebuilding logic
+                            all_relationships_to_rebuild.pop(relation, None)
+                            all_relationships_to_rebuild.pop((relation[1], relation[0]), None)
                     success_msg = (
                         f"Document deleted {i}/{total_docs}: {doc_id}[{file_path}]"
                     )
@@ -2047,6 +2069,42 @@ async def background_delete_documents(
                 async with pipeline_status_lock:
                     pipeline_status["latest_message"] = error_msg
                     pipeline_status["history_messages"].append(error_msg)
+
+        # Single deferred rebuild for all affected entities/relations
+        if all_entities_to_rebuild or all_relationships_to_rebuild:
+            from dataclasses import asdict
+
+            rebuild_msg = (
+                f"Rebuilding knowledge graph: {len(all_entities_to_rebuild)} entities, "
+                f"{len(all_relationships_to_rebuild)} relations"
+            )
+            logger.info(rebuild_msg)
+            async with pipeline_status_lock:
+                pipeline_status["latest_message"] = rebuild_msg
+                pipeline_status["history_messages"].append(rebuild_msg)
+            try:
+                await rebuild_knowledge_from_chunks(
+                    entities_to_rebuild=all_entities_to_rebuild,
+                    relationships_to_rebuild=all_relationships_to_rebuild,
+                    knowledge_graph_inst=rag.chunk_entity_relation_graph,
+                    entities_vdb=rag.entities_vdb,
+                    relationships_vdb=rag.relationships_vdb,
+                    text_chunks_storage=rag.text_chunks,
+                    llm_response_cache=rag.llm_response_cache,
+                    global_config=asdict(rag),
+                    pipeline_status=pipeline_status,
+                    pipeline_status_lock=pipeline_status_lock,
+                    entity_chunks_storage=rag.entity_chunks,
+                    relation_chunks_storage=rag.relation_chunks,
+                )
+                await rag._insert_done()
+            except Exception as rebuild_err:
+                rebuild_error_msg = f"Failed to rebuild knowledge graph after batch deletion: {rebuild_err}"
+                logger.error(rebuild_error_msg)
+                logger.error(traceback.format_exc())
+                async with pipeline_status_lock:
+                    pipeline_status["latest_message"] = rebuild_error_msg
+                    pipeline_status["history_messages"].append(rebuild_error_msg)
 
     except Exception as e:
         error_msg = f"Critical error during batch deletion: {str(e)}"

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -840,6 +840,12 @@ class DeletionResult:
     message: str
     status_code: int = 200
     file_path: str | None = None
+    # Populated when skip_rebuild=True so the caller can do a single deferred rebuild
+    entities_to_rebuild: Dict[str, list] | None = None
+    relationships_to_rebuild: Dict[Any, list] | None = None
+    # Track fully deleted entities/relationships that should NOT be rebuilt
+    deleted_entities: list[str] | None = None
+    deleted_relationships: list[tuple[str, str]] | None = None
 
 
 # Unified Query Result Data Structures for Reference List Support

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -3044,7 +3044,10 @@ class LightRAG:
         return found_statuses
 
     async def adelete_by_doc_id(
-        self, doc_id: str, delete_llm_cache: bool = False
+        self,
+        doc_id: str,
+        delete_llm_cache: bool = False,
+        skip_rebuild: bool = False,
     ) -> DeletionResult:
         """Delete a document and all its related data, including chunks, graph elements.
 
@@ -3077,6 +3080,10 @@ class LightRAG:
             doc_id (str): The unique identifier of the document to be deleted.
             delete_llm_cache (bool): Whether to delete cached LLM extraction results
                 associated with the document. Defaults to False.
+            skip_rebuild (bool): When True, skip the per-document KG rebuild step.
+                The caller is responsible for performing a single deferred rebuild
+                using the entities/relationships returned in the DeletionResult.
+                Used by batch deletion to avoid N redundant rebuilds. Defaults to False.
 
         Returns:
             DeletionResult: An object containing the outcome of the deletion process.
@@ -3085,6 +3092,8 @@ class LightRAG:
                 - `message` (str): A summary of the operation's result.
                 - `status_code` (int): HTTP status code (e.g., 200, 404, 403, 500).
                 - `file_path` (str | None): The file path of the deleted document, if available.
+                - `entities_to_rebuild` (dict | None): Populated when skip_rebuild=True.
+                - `relationships_to_rebuild` (dict | None): Populated when skip_rebuild=True.
         """
         # Get pipeline status shared data and lock for validation
         pipeline_status = await get_namespace_data(
@@ -3645,26 +3654,38 @@ class LightRAG:
             await self._insert_done()
 
             # 8. Rebuild entities and relationships from remaining chunks
+            #    When skip_rebuild is set (batch deletion), we hand the targets back
+            #    to the caller so it can do one combined rebuild at the end.
             if entities_to_rebuild or relationships_to_rebuild:
-                try:
-                    await rebuild_knowledge_from_chunks(
-                        entities_to_rebuild=entities_to_rebuild,
-                        relationships_to_rebuild=relationships_to_rebuild,
-                        knowledge_graph_inst=self.chunk_entity_relation_graph,
-                        entities_vdb=self.entities_vdb,
-                        relationships_vdb=self.relationships_vdb,
-                        text_chunks_storage=self.text_chunks,
-                        llm_response_cache=self.llm_response_cache,
-                        global_config=asdict(self),
-                        pipeline_status=pipeline_status,
-                        pipeline_status_lock=pipeline_status_lock,
-                        entity_chunks_storage=self.entity_chunks,
-                        relation_chunks_storage=self.relation_chunks,
+                if skip_rebuild:
+                    logger.info(
+                        "Skipping per-doc rebuild (skip_rebuild=True), "
+                        "%d entities / %d relations deferred",
+                        len(entities_to_rebuild),
+                        len(relationships_to_rebuild),
                     )
+                else:
+                    try:
+                        await rebuild_knowledge_from_chunks(
+                            entities_to_rebuild=entities_to_rebuild,
+                            relationships_to_rebuild=relationships_to_rebuild,
+                            knowledge_graph_inst=self.chunk_entity_relation_graph,
+                            entities_vdb=self.entities_vdb,
+                            relationships_vdb=self.relationships_vdb,
+                            text_chunks_storage=self.text_chunks,
+                            llm_response_cache=self.llm_response_cache,
+                            global_config=asdict(self),
+                            pipeline_status=pipeline_status,
+                            pipeline_status_lock=pipeline_status_lock,
+                            entity_chunks_storage=self.entity_chunks,
+                            relation_chunks_storage=self.relation_chunks,
+                        )
 
-                except Exception as e:
-                    logger.error(f"Failed to rebuild knowledge from chunks: {e}")
-                    raise Exception(f"Failed to rebuild knowledge graph: {e}") from e
+                    except Exception as e:
+                        logger.error(f"Failed to rebuild knowledge from chunks: {e}")
+                        raise Exception(
+                            f"Failed to rebuild knowledge graph: {e}"
+                        ) from e
 
             # 9. Delete from full_entities and full_relations storage
             try:
@@ -3701,13 +3722,19 @@ class LightRAG:
                         pipeline_status["latest_message"] = log_message
                         pipeline_status["history_messages"].append(log_message)
 
-            return DeletionResult(
+            result = DeletionResult(
                 status="success",
                 doc_id=doc_id,
                 message=log_message,
                 status_code=200,
                 file_path=file_path,
             )
+            if skip_rebuild:
+                result.entities_to_rebuild = entities_to_rebuild
+                result.relationships_to_rebuild = relationships_to_rebuild
+                result.deleted_entities = list(entities_to_delete)
+                result.deleted_relationships = list(relationships_to_delete)
+            return result
 
         except Exception as e:
             original_exception = e

--- a/tests/test_batch_delete_deferred_rebuild.py
+++ b/tests/test_batch_delete_deferred_rebuild.py
@@ -1,0 +1,249 @@
+"""Verify that skip_rebuild=True defers the KG rebuild and returns targets."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lightrag.base import DeletionResult, DocStatus
+
+pytestmark = pytest.mark.offline
+
+
+# -------------------------------------------------------------------
+# Router Integration: Test stale entity bug via dict.update()
+# -------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_batch_delete_aggregates_targets_and_removes_deleted():
+    """Verify that the router logic properly aggregates targets and removes fully deleted ones."""
+    # We simulate the loop inside `background_delete_documents`
+    # Mock return for Doc A (deleted first, shares entity X and Y)
+    result_a = DeletionResult(
+        status="success",
+        doc_id="docA",
+        message="ok",
+        entities_to_rebuild={"EntityX": ["chunkB"], "EntityY": ["chunkC"]},
+        relationships_to_rebuild={("EntityX", "EntityY"): ["chunkB"]},
+        deleted_entities=[],
+        deleted_relationships=[]
+    )
+
+    # Mock return for Doc B (deleted second, deletes the rest of Entity X)
+    result_b = DeletionResult(
+        status="success",
+        doc_id="docB",
+        message="ok",
+        entities_to_rebuild={"EntityY": ["chunkC_other"]}, # Y is updated
+        relationships_to_rebuild={},
+        deleted_entities=["EntityX"], # X is fully deleted now
+        deleted_relationships=[("EntityX", "EntityY")]
+    )
+
+    all_entities_to_rebuild = {}
+    all_relationships_to_rebuild = {}
+
+    for result in [result_a, result_b]:
+        if result.entities_to_rebuild:
+            all_entities_to_rebuild.update(result.entities_to_rebuild)
+        if result.relationships_to_rebuild:
+            all_relationships_to_rebuild.update(result.relationships_to_rebuild)
+
+        # Simulated fix logic from the router
+        if result.deleted_entities:
+            for entity in result.deleted_entities:
+                all_entities_to_rebuild.pop(entity, None)
+        if result.deleted_relationships:
+            for relation in result.deleted_relationships:
+                all_relationships_to_rebuild.pop(relation, None)
+                all_relationships_to_rebuild.pop((relation[1], relation[0]), None)
+
+    # Assertions
+    # Entity X was added by Doc A, but fully deleted by Doc B. It must NOT be in rebuild dict.
+    assert "EntityX" not in all_entities_to_rebuild
+    # Entity Y was updated by Doc B
+    assert "EntityY" in all_entities_to_rebuild
+    assert all_entities_to_rebuild["EntityY"] == ["chunkC_other"]
+
+    # Relationship X-Y was added by Doc A, but fully deleted by Doc B.
+    assert ("EntityX", "EntityY") not in all_relationships_to_rebuild
+
+
+# -------------------------------------------------------------------
+# Unit: DeletionResult carries rebuild targets
+# -------------------------------------------------------------------
+
+
+def test_deletion_result_default_rebuild_fields():
+    """New fields default to None so existing callers aren't affected."""
+    r = DeletionResult(status="success", doc_id="d1", message="ok")
+    assert r.entities_to_rebuild is None
+    assert r.relationships_to_rebuild is None
+
+
+def test_deletion_result_with_rebuild_fields():
+    """Rebuild targets can be populated when skip_rebuild is used."""
+    entities = {"entity_a": ["chunk_1", "chunk_2"]}
+    relations = {("entity_a", "entity_b"): ["chunk_3"]}
+    r = DeletionResult(
+        status="success",
+        doc_id="d1",
+        message="ok",
+        entities_to_rebuild=entities,
+        relationships_to_rebuild=relations,
+    )
+    assert r.entities_to_rebuild == entities
+    assert r.relationships_to_rebuild == relations
+
+
+# -------------------------------------------------------------------
+# Integration: adelete_by_doc_id with skip_rebuild
+# -------------------------------------------------------------------
+
+
+def _make_rag_stub():
+    """Build a minimal mock that satisfies adelete_by_doc_id's storage calls."""
+    rag = MagicMock()
+    rag.workspace = "/tmp/test-workspace"
+
+    rag.doc_status = AsyncMock()
+    rag.doc_status.get_by_id = AsyncMock(
+        return_value={
+            "status": DocStatus.PROCESSED.value,
+            "file_path": "/fake/path.txt",
+            "chunks_list": ["chunk_a", "chunk_b"],
+        }
+    )
+
+    rag.full_entities = AsyncMock()
+    rag.full_entities.get_by_id = AsyncMock(
+        return_value={"entity_names": ["EntityX"]}
+    )
+    rag.full_entities.delete = AsyncMock()
+
+    rag.full_relations = AsyncMock()
+    rag.full_relations.get_by_id = AsyncMock(
+        return_value={"relation_pairs": [["EntityX", "EntityY"]]}
+    )
+    rag.full_relations.delete = AsyncMock()
+
+    rag.chunk_entity_relation_graph = AsyncMock()
+    rag.chunk_entity_relation_graph.get_nodes_batch = AsyncMock(
+        return_value={
+            "EntityX": {
+                "entity_id": "EntityX",
+                # chunk_a and chunk_b will be removed; chunk_c remains -> rebuild
+                "source_id": "chunk_a<SEP>chunk_b<SEP>chunk_c",
+            }
+        }
+    )
+    rag.chunk_entity_relation_graph.get_edges_batch = AsyncMock(
+        return_value={
+            ("EntityX", "EntityY"): {
+                "source": "EntityX",
+                "target": "EntityY",
+                "source_id": "chunk_a<SEP>chunk_d",
+            }
+        }
+    )
+    rag.chunk_entity_relation_graph.remove_edges = AsyncMock()
+    rag.chunk_entity_relation_graph.remove_nodes = AsyncMock()
+    rag.chunk_entity_relation_graph.get_nodes_edges_batch = AsyncMock(
+        return_value={}
+    )
+
+    rag.chunks_vdb = AsyncMock()
+    rag.entities_vdb = AsyncMock()
+    rag.relationships_vdb = AsyncMock()
+
+    rag.text_chunks = AsyncMock()
+    rag.full_docs = AsyncMock()
+    rag.llm_response_cache = None
+
+    rag.entity_chunks = AsyncMock()
+    rag.entity_chunks.get_by_id = AsyncMock(return_value=None)
+    rag.entity_chunks.upsert = AsyncMock()
+    rag.relation_chunks = AsyncMock()
+    rag.relation_chunks.get_by_id = AsyncMock(return_value=None)
+    rag.relation_chunks.upsert = AsyncMock()
+
+    rag._insert_done = AsyncMock()
+
+    return rag
+
+
+@pytest.mark.asyncio
+async def test_skip_rebuild_returns_targets():
+    """When skip_rebuild=True, rebuild should be skipped and targets returned."""
+    from lightrag.lightrag import LightRAG
+
+    rag = _make_rag_stub()
+
+    mock_pipeline_status = {"busy": False, "history_messages": []}
+    mock_lock = asyncio.Lock()
+
+    with (
+        patch(
+            "lightrag.lightrag.get_namespace_data",
+            new_callable=AsyncMock,
+            return_value=mock_pipeline_status,
+        ),
+        patch(
+            "lightrag.lightrag.get_namespace_lock",
+            return_value=mock_lock,
+        ),
+        patch(
+            "lightrag.lightrag.rebuild_knowledge_from_chunks",
+            new_callable=AsyncMock,
+        ) as mock_rebuild,
+    ):
+        # Call the unbound method on our mock
+        result = await LightRAG.adelete_by_doc_id(
+            rag, "test-doc-001", skip_rebuild=True
+        )
+
+    assert result.status == "success"
+    mock_rebuild.assert_not_called()
+
+    # At least one set of rebuild targets should have data
+    has_entities = bool(result.entities_to_rebuild)
+    has_relations = bool(result.relationships_to_rebuild)
+    assert has_entities or has_relations, "Expected deferred rebuild targets"
+
+
+@pytest.mark.asyncio
+async def test_default_rebuild_still_runs():
+    """Without skip_rebuild (default), rebuild_knowledge_from_chunks runs."""
+    from lightrag.lightrag import LightRAG
+
+    rag = _make_rag_stub()
+
+    mock_pipeline_status = {"busy": False, "history_messages": []}
+    mock_lock = asyncio.Lock()
+
+    with (
+        patch(
+            "lightrag.lightrag.get_namespace_data",
+            new_callable=AsyncMock,
+            return_value=mock_pipeline_status,
+        ),
+        patch(
+            "lightrag.lightrag.get_namespace_lock",
+            return_value=mock_lock,
+        ),
+        patch(
+            "lightrag.lightrag.rebuild_knowledge_from_chunks",
+            new_callable=AsyncMock,
+        ) as mock_rebuild,
+        patch(
+            "lightrag.lightrag.asdict",
+            return_value={},
+        ),
+    ):
+        result = await LightRAG.adelete_by_doc_id(rag, "test-doc-001")
+
+    assert result.status == "success"
+    mock_rebuild.assert_called_once()
+    # Default mode should NOT populate the rebuild fields
+    assert result.entities_to_rebuild is None
+    assert result.relationships_to_rebuild is None


### PR DESCRIPTION
Fixes an issue where batch document deletion causes redundant N Knowledge Graph rebuilds. It introduces a `skip_rebuild` flag to `adelete_by_doc_id()`, allowing batch deletion processes to defer per-document KG rebuilds. Rebuild data (entities, relationships) is returned from deletion and aggregated by the caller. It incorporates the logic from PR 2819 and includes additional checks to ensure fully deleted entities and relationships are not rebuilt with stale data. Adds tests to cover this optimization and its edge cases.

---
*PR created automatically by Jules for task [16849260015452852282](https://jules.google.com/task/16849260015452852282) started by @danielaskdd*