### PR TITLE
fix(pdf): handle permission-only encrypted PDFs without password

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -1001,12 +1001,13 @@ def _extract_pdf_pypdf(file_bytes: bytes, password: str = None) -> str:
 
     # Check if PDF is encrypted
     if reader.is_encrypted:
-        if not password:
-            raise Exception("PDF is encrypted but no password provided")
-
-        decrypt_result = reader.decrypt(password)
+        # Try empty password first (covers permission-only encrypted PDFs)
+        decrypt_result = reader.decrypt(password or "")
         if decrypt_result == 0:
-            raise Exception("Incorrect PDF password")
+            if password:
+                raise Exception("Incorrect PDF password")
+            else:
+                raise Exception("PDF is encrypted but no password provided")
 
     # Extract text from all pages
     content = ""


### PR DESCRIPTION
## Description

Fix false "PDF is encrypted but no password provided" error for PDFs that use permission-only encryption (e.g., no-copy, no-print restrictions). These PDFs have `is_encrypted=True` in pypdf but can be opened with an empty password — they do not require a real password from the user.

## Related Issues

N/A

## Changes Made

- In `_extract_pdf_sync`, when `reader.is_encrypted` is `True` and no password is provided, attempt decryption with an empty string before raising an error.
- If decryption with the empty string succeeds (return value ≠ 0), proceed with text extraction normally.
- Error messages remain accurate: "Incorrect PDF password" when a wrong password is supplied, "PDF is encrypted but no password provided" only when an actual password is truly required but missing.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

This is a common PDF quirk: the PDF spec allows setting permission restrictions (preventing copying, printing, etc.) via encryption with an empty user password. Adobe Acrobat and most PDF readers open these files without prompting for a password. pypdf's `is_encrypted` property returns `True` for both cases, so we must attempt a decrypt call to distinguish them.
