### PR TITLE
fix: skip reference instructions in LLM prompt when include_references=false

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -3225,6 +3225,7 @@ async def kg_query(
         ll_keywords_str,
         query_param.user_prompt or "",
         query_param.enable_rerank,
+        query_param.include_references,
     )
 
     cached_result = await handle_cache(
@@ -5073,6 +5074,7 @@ async def naive_query(
         query_param.max_total_tokens,
         query_param.user_prompt or "",
         query_param.enable_rerank,
+        query_param.include_references,
     )
     cached_result = await handle_cache(
         hashing_kv, args_hash, user_query, query_param.mode, cache_type="query"

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -3186,7 +3186,12 @@ async def kg_query(
     )
 
     # Build system prompt
-    sys_prompt_temp = system_prompt if system_prompt else PROMPTS["rag_response"]
+    if system_prompt:
+        sys_prompt_temp = system_prompt
+    elif not query_param.include_references:
+        sys_prompt_temp = PROMPTS["rag_response_no_ref"]
+    else:
+        sys_prompt_temp = PROMPTS["rag_response"]
     sys_prompt = sys_prompt_temp.format(
         response_type=response_type,
         user_prompt=user_prompt,
@@ -4011,11 +4016,18 @@ async def _build_context_str(
     )
 
     # Get the system prompt template from PROMPTS or global_config
-    sys_prompt_template = global_config.get(
-        "system_prompt_template", PROMPTS["rag_response"]
-    )
+    custom_sys_prompt = global_config.get("system_prompt_template")
+    if custom_sys_prompt:
+        sys_prompt_template = custom_sys_prompt
+    elif not query_param.include_references:
+        sys_prompt_template = PROMPTS["rag_response_no_ref"]
+    else:
+        sys_prompt_template = PROMPTS["rag_response"]
 
-    kg_context_template = PROMPTS["kg_query_context"]
+    if not query_param.include_references:
+        kg_context_template = PROMPTS["kg_query_context_no_ref"]
+    else:
+        kg_context_template = PROMPTS["kg_query_context"]
     user_prompt = query_param.user_prompt if query_param.user_prompt else ""
     response_type = (
         query_param.response_type
@@ -4087,11 +4099,14 @@ async def _build_context_str(
     text_units_str = "\n".join(
         json.dumps(text_unit, ensure_ascii=False) for text_unit in chunks_context
     )
-    reference_list_str = "\n".join(
-        f"[{ref['reference_id']}] {ref['file_path']}"
-        for ref in reference_list
-        if ref["reference_id"]
-    )
+    if query_param.include_references:
+        reference_list_str = "\n".join(
+            f"[{ref['reference_id']}] {ref['file_path']}"
+            for ref in reference_list
+            if ref["reference_id"]
+        )
+    else:
+        reference_list_str = ""
 
     logger.info(
         f"Final context: {len(entities_context)} entities, {len(relations_context)} relations, {len(chunks_context)} chunks"
@@ -4938,9 +4953,12 @@ async def naive_query(
     )
 
     # Use the provided system prompt or default
-    sys_prompt_template = (
-        system_prompt if system_prompt else PROMPTS["naive_rag_response"]
-    )
+    if system_prompt:
+        sys_prompt_template = system_prompt
+    elif not query_param.include_references:
+        sys_prompt_template = PROMPTS["naive_rag_response_no_ref"]
+    else:
+        sys_prompt_template = PROMPTS["naive_rag_response"]
 
     # Create a preliminary system prompt with empty content_data to calculate overhead
     pre_sys_prompt = sys_prompt_template.format(
@@ -5012,13 +5030,17 @@ async def naive_query(
     text_units_str = "\n".join(
         json.dumps(text_unit, ensure_ascii=False) for text_unit in chunks_context
     )
-    reference_list_str = "\n".join(
-        f"[{ref['reference_id']}] {ref['file_path']}"
-        for ref in reference_list
-        if ref["reference_id"]
-    )
+    if query_param.include_references:
+        reference_list_str = "\n".join(
+            f"[{ref['reference_id']}] {ref['file_path']}"
+            for ref in reference_list
+            if ref["reference_id"]
+        )
+        naive_context_template = PROMPTS["naive_query_context"]
+    else:
+        reference_list_str = ""
+        naive_context_template = PROMPTS["naive_query_context_no_ref"]
 
-    naive_context_template = PROMPTS["naive_query_context"]
     context_content = naive_context_template.format(
         text_chunks_str=text_units_str,
         reference_list_str=reference_list_str,

--- a/lightrag/prompt.py
+++ b/lightrag/prompt.py
@@ -329,6 +329,76 @@ Consider the conversation history if provided to maintain conversational flow an
 {content_data}
 """
 
+PROMPTS["rag_response_no_ref"] = """---Role---
+
+You are an expert AI assistant specializing in synthesizing information from a provided knowledge base. Your primary function is to answer user queries accurately by ONLY using the information within the provided **Context**.
+
+---Goal---
+
+Generate a comprehensive, well-structured answer to the user query.
+The answer must integrate relevant facts from the Knowledge Graph and Document Chunks found in the **Context**.
+Consider the conversation history if provided to maintain conversational flow and avoid repeating information.
+
+---Instructions---
+
+1. Step-by-Step Instruction:
+  - Carefully determine the user's query intent in the context of the conversation history to fully understand the user's information need.
+  - Scrutinize both `Knowledge Graph Data` and `Document Chunks` in the **Context**. Identify and extract all pieces of information that are directly relevant to answering the user query.
+  - Weave the extracted facts into a coherent and logical response. Your own knowledge must ONLY be used to formulate fluent sentences and connect ideas, NOT to introduce any external information.
+
+2. Content & Grounding:
+  - Strictly adhere to the provided context from the **Context**; DO NOT invent, assume, or infer any information not explicitly stated.
+  - If the answer cannot be found in the **Context**, state that you do not have enough information to answer. Do not attempt to guess.
+
+3. Formatting & Language:
+  - The response MUST be in the same language as the user query.
+  - The response MUST utilize Markdown formatting for enhanced clarity and structure (e.g., headings, bold text, bullet points).
+  - The response should be presented in {response_type}.
+  - Do not include a references or citations section in the response.
+
+4. Additional Instructions: {user_prompt}
+
+
+---Context---
+
+{context_data}
+"""
+
+PROMPTS["naive_rag_response_no_ref"] = """---Role---
+
+You are an expert AI assistant specializing in synthesizing information from a provided knowledge base. Your primary function is to answer user queries accurately by ONLY using the information within the provided **Context**.
+
+---Goal---
+
+Generate a comprehensive, well-structured answer to the user query.
+The answer must integrate relevant facts from the Document Chunks found in the **Context**.
+Consider the conversation history if provided to maintain conversational flow and avoid repeating information.
+
+---Instructions---
+
+1. Step-by-Step Instruction:
+  - Carefully determine the user's query intent in the context of the conversation history to fully understand the user's information need.
+  - Scrutinize `Document Chunks` in the **Context**. Identify and extract all pieces of information that are directly relevant to answering the user query.
+  - Weave the extracted facts into a coherent and logical response. Your own knowledge must ONLY be used to formulate fluent sentences and connect ideas, NOT to introduce any external information.
+
+2. Content & Grounding:
+  - Strictly adhere to the provided context from the **Context**; DO NOT invent, assume, or infer any information not explicitly stated.
+  - If the answer cannot be found in the **Context**, state that you do not have enough information to answer. Do not attempt to guess.
+
+3. Formatting & Language:
+  - The response MUST be in the same language as the user query.
+  - The response MUST utilize Markdown formatting for enhanced clarity and structure (e.g., headings, bold text, bullet points).
+  - The response should be presented in {response_type}.
+  - Do not include a references or citations section in the response.
+
+4. Additional Instructions: {user_prompt}
+
+
+---Context---
+
+{content_data}
+"""
+
 PROMPTS["kg_query_context"] = """
 Knowledge Graph Data (Entity):
 
@@ -367,6 +437,36 @@ Reference Document List (Each entry starts with a [reference_id] that correspond
 
 ```
 {reference_list_str}
+```
+
+"""
+
+PROMPTS["kg_query_context_no_ref"] = """
+Knowledge Graph Data (Entity):
+
+```json
+{entities_str}
+```
+
+Knowledge Graph Data (Relationship):
+
+```json
+{relations_str}
+```
+
+Document Chunks:
+
+```json
+{text_chunks_str}
+```
+
+"""
+
+PROMPTS["naive_query_context_no_ref"] = """
+Document Chunks:
+
+```json
+{text_chunks_str}
 ```
 
 """

--- a/tests/test_include_references_prompt.py
+++ b/tests/test_include_references_prompt.py
@@ -1,0 +1,73 @@
+"""Tests that include_references=False removes reference instructions from LLM prompts."""
+
+import pytest
+
+from lightrag.prompt import PROMPTS
+
+pytestmark = pytest.mark.offline
+
+
+class TestRagResponsePromptVariants:
+    """Verify rag_response and rag_response_no_ref prompt templates."""
+
+    def test_rag_response_contains_reference_instructions(self):
+        prompt = PROMPTS["rag_response"]
+        assert "References Section Format" in prompt
+        assert "reference_id" in prompt
+        assert "Reference Document List" in prompt
+
+    def test_rag_response_no_ref_omits_reference_instructions(self):
+        prompt = PROMPTS["rag_response_no_ref"]
+        assert "References Section Format" not in prompt
+        assert "reference_id" not in prompt
+        assert "Reference Document List" not in prompt
+
+    def test_rag_response_no_ref_has_required_placeholders(self):
+        prompt = PROMPTS["rag_response_no_ref"]
+        assert "{response_type}" in prompt
+        assert "{user_prompt}" in prompt
+        assert "{context_data}" in prompt
+
+
+class TestNaiveRagResponsePromptVariants:
+    """Verify naive_rag_response and naive_rag_response_no_ref prompt templates."""
+
+    def test_naive_rag_response_contains_reference_instructions(self):
+        prompt = PROMPTS["naive_rag_response"]
+        assert "References Section Format" in prompt
+        assert "reference_id" in prompt
+
+    def test_naive_rag_response_no_ref_omits_reference_instructions(self):
+        prompt = PROMPTS["naive_rag_response_no_ref"]
+        assert "References Section Format" not in prompt
+        assert "reference_id" not in prompt
+
+    def test_naive_rag_response_no_ref_has_required_placeholders(self):
+        prompt = PROMPTS["naive_rag_response_no_ref"]
+        assert "{response_type}" in prompt
+        assert "{user_prompt}" in prompt
+        assert "{content_data}" in prompt
+
+
+class TestContextTemplateVariants:
+    """Verify context templates with and without reference sections."""
+
+    def test_kg_context_contains_reference_list(self):
+        template = PROMPTS["kg_query_context"]
+        assert "Reference Document List" in template
+        assert "{reference_list_str}" in template
+
+    def test_kg_context_no_ref_omits_reference_list(self):
+        template = PROMPTS["kg_query_context_no_ref"]
+        assert "Reference Document List" not in template
+        assert "{reference_list_str}" not in template
+
+    def test_naive_context_contains_reference_list(self):
+        template = PROMPTS["naive_query_context"]
+        assert "Reference Document List" in template
+        assert "{reference_list_str}" in template
+
+    def test_naive_context_no_ref_omits_reference_list(self):
+        template = PROMPTS["naive_query_context_no_ref"]
+        assert "Reference Document List" not in template
+        assert "{reference_list_str}" not in template


### PR DESCRIPTION
## Description

When `include_references=False`, the structured `references` field is correctly nulled, but the LLM system prompt still contains reference formatting instructions (steps 1.4-1.6, section 4, section 5) and the context still includes the "Reference Document List" section. This causes the LLM to generate reference markers in the response text even though the API strips the structured references field.

## Related Issues

Fixes #2832

## Changes Made

1. **`lightrag/prompt.py`** — Added no-reference variants of prompt templates:
   - `rag_response_no_ref`: `rag_response` without reference tracking instructions, References Section Format, and Reference Section Example
   - `naive_rag_response_no_ref`: Same treatment for `naive_rag_response`
   - `kg_query_context_no_ref`: `kg_query_context` without "Reference Document List" block and reference_id mentions in Document Chunks header
   - `naive_query_context_no_ref`: Same treatment for `naive_query_context`

2. **`lightrag/operate.py`** — Conditional prompt selection:
   - `_build_context_str`: Selects no-ref system prompt and context template when `include_references=False`; skips building `reference_list_str`
   - `kg_query`: Selects no-ref system prompt when `include_references=False` and no custom `system_prompt` provided
   - `naive_rag`: Same treatment for naive query mode

3. **`tests/test_include_references_prompt.py`** — 10 offline tests verifying:
   - No-ref prompt variants omit reference instructions
   - Default prompts retain reference instructions
   - Template placeholders are valid

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

All 10 new tests pass. Pre-existing test failures in `test_postgres_index_name.py` are unrelated (postgres-specific tests that fail without asyncpg installed).