### PR TITLE
Add driver info to AsyncMongoClient instantiation

### DIFF
--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -64,7 +64,7 @@ class ClientManager:
                 )
                 client = AsyncMongoClient(
 					uri,
-					driver=DriverInfo(name="LightRAG", version=version("lightrag")),
+					driver=DriverInfo(name="LightRAG", version=version("lightrag-hku")),
 				)
                 db = client.get_database(database_name)
                 cls._instances["db"] = db


### PR DESCRIPTION
## Description

Pass `DriverInfo` identifying LightRAG to `AsyncMongoClient`

## Changes Made

This PR will pass [`pymongo.driver_info.DriverInfo`](https://pymongo.readthedocs.io/en/stable/api/pymongo/driver_info.html#pymongo.driver_info.DriverInfo) to the `AsyncMongoClient` instance to identify the connection as coming from LightRAG. This makes it easier to filter `mongod` logs for connections by integration.

For example:

> {"t":{"$date":"2026-03-23T16:10:26.686-04:00"},"s":"I","c":"NETWORK","id":51800,"ctx":"conn225","msg":"client metadata","attr":{"remote":"127.0.0.1:61857","client":"conn225","negotiatedCompressors":[],"doc":{"driver":{"name":"PyMongo|LightRAG","version":"3.11.4"},"os":{"type":"Darwin","name":"Darwin","architecture":"x86_64","version":"14.5"},"platform":"CPython 3.10.3.final.0"}}}

## Checklist

- [ ] Changes tested locally
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

[Add any additional notes or context for the reviewer(s).]
