### PR TITLE
Fix LLM role separation defaults and multimodal timeout fallbacks

### DIFF
--- a/docs/RAGAnythingParserAlignment.md
+++ b/docs/RAGAnythingParserAlignment.md
@@ -1,0 +1,91 @@
+## RAG-Anything Parser Alignment Notes
+
+This document summarizes the companion changes made on the `RAG-Anything` side to better align its parser output with the LightRAG multimodal pipeline introduced in this PR.
+
+These notes are provided as reviewer context. The code changes described below live in the `RAG-Anything` repository, mainly in `raganything/parser.py`, rather than in this LightRAG pull request.
+
+## Why This Alignment Was Needed
+
+The LightRAG-side pipeline in this PR expects parser output to preserve heading structure, normalize multimodal block types consistently, and expose enough table metadata to generate correct LightRAG document sidecars.
+
+Without the parser-side alignment, several downstream issues appear more easily:
+
+- section headings may be lost before LightRAG sidecar generation
+- table dimensions can degrade to `[0, 0]`
+- table content may be harder to serialize into stable sidecar payloads
+- parser output shape may drift between Docling variants
+
+## RAG-Anything Changes
+
+### 1. Add safe helper functions for parser normalization
+
+Two small helpers were added:
+
+- `_to_int(value, default=0)`
+- `_grid_to_rows(grid)`
+
+Their purpose is to make parser output more defensive and consistent when Docling returns numeric fields or table cell structures in slightly different formats.
+
+### 2. Normalize text labels before branching
+
+Docling text blocks are now normalized through:
+
+- `label = str(block.get("label", "")).strip().lower()`
+
+This avoids relying on a raw case-sensitive label and makes formula / title / section-header detection more stable.
+
+### 3. Preserve section heading structure explicitly
+
+For Docling text blocks, `section_header` and `title` are now emitted as dedicated structured blocks:
+
+- `type: "section_header"` or `type: "title"`
+- `text`
+- `level`
+- `page_idx`
+
+This is important because the LightRAG-side conversion logic uses heading information to:
+
+- propagate `heading`
+- build `parent_headings`
+- keep multimodal sidecars attached to the correct section context
+
+### 4. Preserve label and level on normal text blocks
+
+For non-heading text blocks, the parser now also retains:
+
+- `label`
+- `level`
+
+This gives LightRAG more context when converting parser output into LightRAG document blocks and helps preserve document structure more faithfully.
+
+### 5. Improve table normalization for Docling output
+
+Table parsing was expanded to support both:
+
+- dict-style table payloads with `grid`, `num_rows`, `num_cols`
+- legacy list-style table payloads
+
+The parser now derives and exposes:
+
+- `table_body`
+- `rows`
+- `num_rows`
+- `num_cols`
+
+This is the key alignment needed for LightRAG-side table sidecar generation, especially to avoid empty dimensions and to keep table content serializable in a stable form.
+
+## Practical Impact on This PR
+
+These RAG-Anything parser changes are the external counterpart of the LightRAG work in this PR:
+
+- LightRAG now converts structured parser output into LightRAG document artifacts
+- multimodal sidecars depend on parser-side heading and table metadata
+- heading propagation and table dimension fixes are more reliable when the parser emits normalized structure upstream
+
+In short, the LightRAG code in this PR can run independently, but the best end-to-end behavior for Docling/RAG-Anything-driven multimodal ingestion depends on this parser alignment on the `RAG-Anything` side as well.
+
+## Scope Note
+
+This document is intentionally limited to parser-alignment notes for `RAG-Anything`.
+
+It does not describe the entity disambiguation experiment, which is explicitly excluded from this PR.

--- a/env.example
+++ b/env.example
@@ -207,6 +207,46 @@ SUMMARY_LANGUAGE=English
 ### Maximum token size allowed for entity extraction input context
 # MAX_EXTRACT_INPUT_TOKENS=20480
 
+### Use JSON structured output for entity extraction (default: true)
+# ENTITY_EXTRACTION_USE_JSON=true
+
+### Multimodal parsing/analyze integration
+### Optional parser routing rules, for example:
+###   pdf:mineru-iet,docx:docling,pptx:docling,*:native
+# LIGHTRAG_PARSER=
+### Optional local checkout path of RAG-Anything for parser integration
+# RAGANYTHING_ROOT=/path/to/RAG-Anything
+### Retry count for multimodal VLM analysis JSON normalization/writeback
+# VLM_ANALYZE_RETRIES=2
+### Maximum image bytes sent to VLM per multimodal item
+# VLM_MAX_IMAGE_BYTES=5242880
+
+### Async parser service protocol (optional)
+### Configure these when using remote MinerU/Docling async services
+# MINERU_ENDPOINT=http://localhost:8000/api/v1/task
+# MINERU_POLL_ENDPOINT=http://localhost:8000/api/v1/task/{trace_id}
+# MINERU_POLL_METHOD=GET
+# MINERU_ID_FIELD=trace_id
+# MINERU_STATUS_FIELD=status
+# MINERU_RESULT_URL_FIELD=result_url
+# MINERU_CONTENT_FIELD=content
+# MINERU_SUCCESS_VALUES=done,success,completed
+# MINERU_FAILED_VALUES=failed,error,cancelled
+# MINERU_POLL_INTERVAL_SECONDS=2
+# MINERU_MAX_POLLS=180
+
+# DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
+# DOCLING_POLL_ENDPOINT=http://localhost:8081/v1/convert/file/async/{task_id}
+# DOCLING_POLL_METHOD=GET
+# DOCLING_ID_FIELD=task_id
+# DOCLING_STATUS_FIELD=status
+# DOCLING_RESULT_URL_FIELD=result_url
+# DOCLING_CONTENT_FIELD=content
+# DOCLING_SUCCESS_VALUES=done,success,completed
+# DOCLING_FAILED_VALUES=failed,error,cancelled
+# DOCLING_POLL_INTERVAL_SECONDS=2
+# DOCLING_MAX_POLLS=180
+
 ### control the maximum chunk_ids stored in vector and graph db
 # MAX_SOURCE_IDS_PER_ENTITY=300
 # MAX_SOURCE_IDS_PER_RELATION=300
@@ -228,6 +268,14 @@ SUMMARY_LANGUAGE=English
 MAX_ASYNC=4
 ### Number of parallel processing documents(between 2~10, MAX_ASYNC/3 is recommended)
 MAX_PARALLEL_INSERT=2
+### Optional per-stage document pipeline concurrency
+# MAX_PARALLEL_PARSE_NATIVE=5
+# MAX_PARALLEL_PARSE_MINERU=3
+# MAX_PARALLEL_PARSE_DOCLING=3
+# MAX_PARALLEL_ANALYZE=2
+### Optional queue sizes for staged pipeline workers
+# QUEUE_SIZE_DEFAULT=100
+# QUEUE_SIZE_INSERT=4
 ### Max concurrency requests for Embedding
 # EMBEDDING_FUNC_MAX_ASYNC=8
 ### Num of chunks send to Embedding in single request
@@ -336,6 +384,43 @@ OLLAMA_LLM_NUM_CTX=32768
 # AWS_SESSION_TOKEN=your_optional_aws_session_token
 # AWS_REGION=us-east-1
 # BEDROCK_LLM_TEMPERATURE=1.0
+
+###########################################################################
+### Optional role-specific LLM/VLM overrides
+### If unset, each role falls back to the base LLM_* configuration above.
+### Available roles: EXTRACT, KEYWORD, QUERY, VLM
+###########################################################################
+### Example: use a dedicated model/provider for entity extraction
+# EXTRACT_LLM_BINDING=openai
+# EXTRACT_LLM_MODEL=your_extract_model
+# EXTRACT_LLM_BINDING_HOST=https://api.example.com/v1
+# EXTRACT_LLM_BINDING_API_KEY=your_extract_api_key
+# MAX_ASYNC_EXTRACT_LLM=4
+# LLM_TIMEOUT_EXTRACT_LLM=180
+
+### Example: use a dedicated model/provider for keyword extraction
+# KEYWORD_LLM_BINDING=openai
+# KEYWORD_LLM_MODEL=your_keyword_model
+# KEYWORD_LLM_BINDING_HOST=https://api.example.com/v1
+# KEYWORD_LLM_BINDING_API_KEY=your_keyword_api_key
+# MAX_ASYNC_KEYWORD_LLM=4
+# LLM_TIMEOUT_KEYWORD_LLM=180
+
+### Example: use a dedicated model/provider for query answering
+# QUERY_LLM_BINDING=openai
+# QUERY_LLM_MODEL=your_query_model
+# QUERY_LLM_BINDING_HOST=https://api.example.com/v1
+# QUERY_LLM_BINDING_API_KEY=your_query_api_key
+# MAX_ASYNC_QUERY_LLM=4
+# LLM_TIMEOUT_QUERY_LLM=180
+
+### Example: use a dedicated model/provider for multimodal analysis
+# VLM_LLM_BINDING=openai
+# VLM_LLM_MODEL=your_vlm_model
+# VLM_LLM_BINDING_HOST=https://api.example.com/v1
+# VLM_LLM_BINDING_API_KEY=your_vlm_api_key
+# MAX_ASYNC_VLM_LLM=4
+# LLM_TIMEOUT_VLM_LLM=180
 
 #######################################################################################
 ### Embedding Configuration (Should not be changed after the first file processed)

--- a/lightrag/__init__.py
+++ b/lightrag/__init__.py
@@ -1,5 +1,5 @@
 from .lightrag import LightRAG as LightRAG, QueryParam as QueryParam
 
-__version__ = "1.4.11"
+__version__ = "1.5.0"
 __author__ = "Zirui Guo"
 __url__ = "https://github.com/HKUDS/LightRAG"

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -387,6 +387,48 @@ def parse_args() -> argparse.Namespace:
     # PDF decryption password
     args.pdf_decrypt_password = get_env_value("PDF_DECRYPT_PASSWORD", None)
 
+    # --- Per-role LLM configuration (extract / keyword / query / vlm) ---
+    ROLE_PREFIXES = ["EXTRACT", "KEYWORD", "QUERY", "VLM"]
+    for role in ROLE_PREFIXES:
+        binding_key = f"{role}_LLM_BINDING"
+        model_key = f"{role}_LLM_MODEL"
+        host_key = f"{role}_LLM_BINDING_HOST"
+        apikey_key = f"{role}_LLM_BINDING_API_KEY"
+        max_async_key = f"MAX_ASYNC_{role}_LLM"
+        timeout_key = f"LLM_TIMEOUT_{role}_LLM"
+
+        role_binding = get_env_value(binding_key, None, special_none=True)
+        role_model = get_env_value(model_key, None, special_none=True)
+        role_host = get_env_value(host_key, None, special_none=True)
+        role_apikey = get_env_value(apikey_key, None, special_none=True)
+        role_max_async = get_env_value(max_async_key, None, int, special_none=True)
+        role_timeout = get_env_value(timeout_key, None, int, special_none=True)
+
+        attr_prefix = role.lower()
+        setattr(args, f"{attr_prefix}_llm_binding", role_binding)
+        setattr(args, f"{attr_prefix}_llm_model", role_model)
+        setattr(args, f"{attr_prefix}_llm_binding_host", role_host)
+        setattr(args, f"{attr_prefix}_llm_binding_api_key", role_apikey)
+        setattr(args, f"{attr_prefix}_llm_max_async", role_max_async)
+        setattr(args, f"{attr_prefix}_llm_timeout", role_timeout)
+
+        # Cross-provider validation
+        if role_binding and role_binding != args.llm_binding:
+            missing = []
+            if not role_model:
+                missing.append(model_key)
+            if not role_host:
+                role_host = get_default_host(role_binding)
+                setattr(args, f"{attr_prefix}_llm_binding_host", role_host)
+            if not role_apikey:
+                missing.append(apikey_key)
+            if missing:
+                raise SystemExit(
+                    f"Cross-provider error for role '{role}': "
+                    f"binding={role_binding} differs from base={args.llm_binding}, "
+                    f"but required env vars are missing: {', '.join(missing)}"
+                )
+
     # Add environment variables that were previously read directly
     args.cors_origins = get_env_value("CORS_ORIGINS", "*")
     args.summary_language = get_env_value("SUMMARY_LANGUAGE", DEFAULT_SUMMARY_LANGUAGE)

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -16,6 +16,7 @@ import logging.config
 import sys
 import uvicorn
 import pipmaster as pm
+from typing import Any
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 from pathlib import Path
@@ -654,6 +655,260 @@ def create_app(args):
                 raise Exception(f"Failed to import {binding} options: {e}")
         return {}
 
+    def resolve_role_llm_settings(
+        role: str, override_meta: dict | None = None
+    ) -> dict[str, Any]:
+        attr = role.lower()
+        override_meta = override_meta or {}
+
+        role_binding = (
+            override_meta.get("binding")
+            or getattr(args, f"{attr}_llm_binding", None)
+            or args.llm_binding
+        )
+        role_model = (
+            override_meta.get("model")
+            or getattr(args, f"{attr}_llm_model", None)
+            or args.llm_model
+        )
+        role_host = (
+            override_meta.get("host")
+            or getattr(args, f"{attr}_llm_binding_host", None)
+            or args.llm_binding_host
+        )
+        role_apikey = (
+            override_meta.get("api_key")
+            or getattr(args, f"{attr}_llm_binding_api_key", None)
+            or args.llm_binding_api_key
+        )
+        role_timeout = (
+            override_meta.get("timeout")
+            or getattr(args, f"{attr}_llm_timeout", None)
+            or llm_timeout
+        )
+        role_max_async = getattr(args, f"{attr}_llm_max_async", None) or args.max_async
+        is_cross_provider = role_binding != args.llm_binding
+
+        role_provider_options = override_meta.get("provider_options")
+        if role_provider_options is None:
+            if role_binding in ["openai", "azure_openai"]:
+                from lightrag.llm.binding_options import OpenAILLMOptions
+
+                role_provider_options = OpenAILLMOptions.options_dict_for_role(
+                    args, role, is_cross_provider
+                )
+            elif role_binding == "gemini":
+                from lightrag.llm.binding_options import GeminiLLMOptions
+
+                role_provider_options = GeminiLLMOptions.options_dict_for_role(
+                    args, role, is_cross_provider
+                )
+            elif role_binding in ["lollms", "ollama"]:
+                from lightrag.llm.binding_options import OllamaLLMOptions
+
+                role_provider_options = OllamaLLMOptions.options_dict_for_role(
+                    args, role, is_cross_provider
+                )
+            else:
+                role_provider_options = {}
+
+        return {
+            "binding": role_binding,
+            "model": role_model,
+            "host": role_host,
+            "api_key": role_apikey,
+            "timeout": role_timeout,
+            "max_async": role_max_async,
+            "provider_options": role_provider_options,
+            "is_cross_provider": is_cross_provider,
+        }
+
+    def create_role_llm_func(role: str, override_meta: dict | None = None):
+        """Create an independent raw LLM function for a role."""
+        settings = resolve_role_llm_settings(role, override_meta)
+        role_binding = settings["binding"]
+        role_model = settings["model"]
+        role_host = settings["host"]
+        role_apikey = settings["api_key"]
+        role_timeout = settings["timeout"]
+        role_provider_options = settings["provider_options"]
+
+        logger.info(
+            f"  Role '{role}': binding={role_binding}, model={role_model}, "
+            f"host={role_host}, timeout={role_timeout}"
+        )
+
+        try:
+            if role_binding == "ollama":
+                from lightrag.llm.ollama import _ollama_model_if_cache
+
+                async def role_ollama_complete(
+                    prompt,
+                    system_prompt=None,
+                    history_messages=None,
+                    enable_cot: bool = False,
+                    keyword_extraction=False,
+                    entity_extraction=False,
+                    **kwargs,
+                ):
+                    keyword_extraction = kwargs.pop("keyword_extraction", None)
+                    entity_extraction = kwargs.pop(
+                        "entity_extraction", entity_extraction
+                    )
+                    if keyword_extraction or entity_extraction:
+                        kwargs["format"] = "json"
+                    if history_messages is None:
+                        history_messages = []
+                    if role_provider_options:
+                        kwargs.setdefault("options", dict(role_provider_options))
+                    return await _ollama_model_if_cache(
+                        role_model,
+                        prompt,
+                        system_prompt=system_prompt,
+                        history_messages=history_messages,
+                        enable_cot=enable_cot,
+                        host=role_host,
+                        timeout=role_timeout,
+                        api_key=role_apikey,
+                        **kwargs,
+                    )
+
+                return role_ollama_complete
+            if role_binding == "lollms":
+                from lightrag.llm.lollms import lollms_model_if_cache
+
+                async def role_lollms_complete(
+                    prompt,
+                    system_prompt=None,
+                    history_messages=None,
+                    enable_cot: bool = False,
+                    keyword_extraction=False,
+                    entity_extraction=False,
+                    **kwargs,
+                ):
+                    kwargs.pop("entity_extraction", entity_extraction)
+                    kwargs.pop("keyword_extraction", keyword_extraction)
+                    if history_messages is None:
+                        history_messages = []
+                    if role_provider_options:
+                        kwargs = {**role_provider_options, **kwargs}
+                    return await lollms_model_if_cache(
+                        role_model,
+                        prompt,
+                        system_prompt=system_prompt,
+                        history_messages=history_messages,
+                        enable_cot=enable_cot,
+                        base_url=role_host,
+                        api_key=role_apikey,
+                        timeout=role_timeout,
+                        **kwargs,
+                    )
+
+                return role_lollms_complete
+            if role_binding == "azure_openai":
+                from lightrag.llm.azure_openai import azure_openai_complete_if_cache
+
+                async def role_azure_openai_complete(
+                    prompt,
+                    system_prompt=None,
+                    history_messages=None,
+                    keyword_extraction=False,
+                    **kwargs,
+                ) -> str:
+                    keyword_extraction = kwargs.pop("keyword_extraction", None)
+                    if keyword_extraction:
+                        kwargs["response_format"] = GPTKeywordExtractionFormat
+                    if history_messages is None:
+                        history_messages = []
+                    kwargs["timeout"] = role_timeout
+                    if role_provider_options:
+                        kwargs.update(role_provider_options)
+                    return await azure_openai_complete_if_cache(
+                        role_model,
+                        prompt,
+                        system_prompt=system_prompt,
+                        history_messages=history_messages,
+                        base_url=role_host,
+                        api_key=os.getenv("AZURE_OPENAI_API_KEY", role_apikey),
+                        api_version=os.getenv(
+                            "AZURE_OPENAI_API_VERSION", "2024-08-01-preview"
+                        ),
+                        **kwargs,
+                    )
+
+                return role_azure_openai_complete
+            if role_binding == "gemini":
+                from lightrag.llm.gemini import gemini_complete_if_cache
+
+                async def role_gemini_complete(
+                    prompt,
+                    system_prompt=None,
+                    history_messages=None,
+                    keyword_extraction=False,
+                    **kwargs,
+                ) -> str:
+                    if history_messages is None:
+                        history_messages = []
+                    kwargs["timeout"] = role_timeout
+                    if role_provider_options and "generation_config" not in kwargs:
+                        kwargs["generation_config"] = dict(role_provider_options)
+                    return await gemini_complete_if_cache(
+                        role_model,
+                        prompt,
+                        system_prompt=system_prompt,
+                        history_messages=history_messages,
+                        api_key=role_apikey,
+                        base_url=role_host,
+                        keyword_extraction=keyword_extraction,
+                        **kwargs,
+                    )
+
+                return role_gemini_complete
+
+            from lightrag.llm.openai import openai_complete_if_cache
+
+            async def role_openai_complete(
+                prompt,
+                system_prompt=None,
+                history_messages=None,
+                keyword_extraction=False,
+                **kwargs,
+            ) -> str:
+                keyword_extraction = kwargs.pop("keyword_extraction", None)
+                if keyword_extraction:
+                    kwargs["response_format"] = GPTKeywordExtractionFormat
+                if history_messages is None:
+                    history_messages = []
+                kwargs["timeout"] = role_timeout
+                if role_provider_options:
+                    kwargs.update(role_provider_options)
+                return await openai_complete_if_cache(
+                    role_model,
+                    prompt,
+                    system_prompt=system_prompt,
+                    history_messages=history_messages,
+                    base_url=role_host,
+                    api_key=role_apikey,
+                    **kwargs,
+                )
+
+            return role_openai_complete
+        except ImportError as e:
+            raise Exception(f"Failed to create LLM for role '{role}': {e}")
+
+    def create_role_llm_model_kwargs(
+        role: str, override_meta: dict | None = None
+    ) -> dict[str, Any] | None:
+        """Create role-specific kwargs for runtime wrapper injection.
+
+        Role functions built above already encapsulate provider host/model/api_key/options,
+        so we intentionally return an empty dict here to prevent base kwargs inheritance
+        from polluting cross-provider role calls.
+        """
+        _ = role
+        _ = override_meta
+        return {}
+
     def create_optimized_embedding_function(
         config_cache: LLMConfigCache, binding, model, host, api_key, args
     ) -> EmbeddingFunc:
@@ -1060,6 +1315,26 @@ def create_app(args):
         name=args.simulated_model_name, tag=args.simulated_model_tag
     )
 
+    # Build addon params by merging LightRAG defaults with API-level overrides.
+    addon_params_defaults: dict = {}
+    addon_params_field = LightRAG.__dataclass_fields__.get("addon_params")
+    if addon_params_field and callable(addon_params_field.default_factory):
+        addon_params_defaults = addon_params_field.default_factory()
+    addon_params = {
+        **addon_params_defaults,
+        "language": args.summary_language,
+        "entity_types": args.entity_types,
+    }
+
+    role_llm_configs = {
+        role: {
+            **resolve_role_llm_settings(role),
+            "func": create_role_llm_func(role),
+            "kwargs": create_role_llm_model_kwargs(role),
+        }
+        for role in ("extract", "keyword", "query", "vlm")
+    }
+
     # Initialize RAG with unified configuration
     try:
         rag = LightRAG(
@@ -1090,15 +1365,55 @@ def create_app(args):
             rerank_model_func=rerank_model_func,
             max_parallel_insert=args.max_parallel_insert,
             max_graph_nodes=args.max_graph_nodes,
-            addon_params={
-                "language": args.summary_language,
-                "entity_types": args.entity_types,
-            },
+            addon_params=addon_params,
             ollama_server_infos=ollama_server_infos,
+            extract_llm_model_func=role_llm_configs["extract"]["func"],
+            extract_llm_model_kwargs=role_llm_configs["extract"]["kwargs"],
+            extract_llm_model_max_async=role_llm_configs["extract"]["max_async"],
+            extract_llm_timeout=role_llm_configs["extract"]["timeout"],
+            keyword_llm_model_func=role_llm_configs["keyword"]["func"],
+            keyword_llm_model_kwargs=role_llm_configs["keyword"]["kwargs"],
+            keyword_llm_model_max_async=role_llm_configs["keyword"]["max_async"],
+            keyword_llm_timeout=role_llm_configs["keyword"]["timeout"],
+            query_llm_model_func=role_llm_configs["query"]["func"],
+            query_llm_model_kwargs=role_llm_configs["query"]["kwargs"],
+            query_llm_model_max_async=role_llm_configs["query"]["max_async"],
+            query_llm_timeout=role_llm_configs["query"]["timeout"],
+            vlm_llm_model_func=role_llm_configs["vlm"]["func"],
+            vlm_llm_model_kwargs=role_llm_configs["vlm"]["kwargs"],
+            vlm_llm_model_max_async=role_llm_configs["vlm"]["max_async"],
+            vlm_llm_timeout=role_llm_configs["vlm"]["timeout"],
         )
     except Exception as e:
         logger.error(f"Failed to initialize LightRAG: {e}")
         raise
+
+    rag.register_role_llm_builder(
+        lambda role, meta: (
+            create_role_llm_func(role, meta),
+            create_role_llm_model_kwargs(role, meta),
+        )
+    )
+    for role in ("extract", "keyword", "query", "vlm"):
+        rag.set_role_llm_metadata(
+            role,
+            base_binding=args.llm_binding,
+            binding=role_llm_configs[role]["binding"],
+            model=role_llm_configs[role]["model"],
+            host=role_llm_configs[role]["host"],
+            api_key=role_llm_configs[role]["api_key"],
+            provider_options=role_llm_configs[role]["provider_options"],
+            is_cross_provider=role_llm_configs[role]["is_cross_provider"],
+        )
+
+    # Print role LLM configuration
+    logger.info(f"\n{'🎭 Role LLM Configuration:'}")
+    for role in ["extract", "keyword", "query", "vlm"]:
+        role_cfg = role_llm_configs[role]
+        logger.info(
+            f"    ├─ {role}: binding={role_cfg['binding']}, model={role_cfg['model']}, "
+            f"host={role_cfg['host']}, max_async={role_cfg['max_async']}"
+        )
 
     # Add routes
     app.include_router(
@@ -1300,6 +1615,19 @@ def create_app(args):
                     "max_async": args.max_async,
                     "embedding_func_max_async": args.embedding_func_max_async,
                     "embedding_batch_num": args.embedding_batch_num,
+                    "role_llm_config": {
+                        role: {
+                            "binding": getattr(args, f"{role}_llm_binding", None)
+                            or args.llm_binding,
+                            "model": getattr(args, f"{role}_llm_model", None)
+                            or args.llm_model,
+                            "host": getattr(args, f"{role}_llm_binding_host", None)
+                            or args.llm_binding_host,
+                            "max_async": getattr(args, f"{role}_llm_max_async", None)
+                            or args.max_async,
+                        }
+                        for role in ["extract", "keyword", "query", "vlm"]
+                    },
                 },
                 "auth_mode": auth_mode,
                 "pipeline_busy": pipeline_status.get("busy", False),

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from lightrag import LightRAG
 from lightrag.base import DeletionResult, DocProcessingStatus, DocStatus
+from lightrag.constants import PARSED_DIR_NAME, FULL_DOCS_FORMAT_PENDING_PARSE
 from lightrag.utils import (
     generate_track_id,
     compute_mdhash_id,
@@ -1439,31 +1440,28 @@ async def pipeline_enqueue_file(
                         return False, track_id
 
                 case ".docx":
+                    # Defer parsing to three-stage pipeline (parse_native / parse_docling).
+                    # Enqueue with pending_parse format so parse worker handles extraction.
+                    logger.info(
+                        f"[File Extraction]DOCX deferred to pipeline: {file_path.name}"
+                    )
                     try:
-                        # Try DOCLING first if configured and available
-                        if (
-                            global_args.document_loading_engine == "DOCLING"
-                            and _is_docling_available()
-                        ):
-                            content = await asyncio.to_thread(
-                                _convert_with_docling, file_path
-                            )
-                        else:
-                            if (
-                                global_args.document_loading_engine == "DOCLING"
-                                and not _is_docling_available()
-                            ):
-                                logger.warning(
-                                    f"DOCLING engine configured but not available for {file_path.name}. Falling back to python-docx."
-                                )
-                            # Use python-docx (non-blocking via to_thread)
-                            content = await asyncio.to_thread(_extract_docx, file)
+                        await rag.apipeline_enqueue_documents(
+                            "",
+                            file_paths=str(file_path),
+                            track_id=track_id,
+                            docs_format=FULL_DOCS_FORMAT_PENDING_PARSE,
+                        )
+                        logger.info(
+                            f"Successfully enqueued DOCX for pipeline parsing: {file_path.name}"
+                        )
+                        return True, track_id
                     except Exception as e:
                         error_files = [
                             {
                                 "file_path": str(file_path.name),
-                                "error_description": "[File Extraction]DOCX processing error",
-                                "original_error": f"Failed to extract text from DOCX: {str(e)}",
+                                "error_description": "[File Extraction]DOCX enqueue error",
+                                "original_error": f"Failed to enqueue DOCX for pipeline: {str(e)}",
                                 "file_size": file_size,
                             }
                         ]
@@ -1471,7 +1469,7 @@ async def pipeline_enqueue_file(
                             error_files, track_id
                         )
                         logger.error(
-                            f"[File Extraction]Error processing DOCX {file_path.name}: {str(e)}"
+                            f"[File Extraction]Error enqueuing DOCX {file_path.name}: {str(e)}"
                         )
                         return False, track_id
 
@@ -1606,9 +1604,9 @@ async def pipeline_enqueue_file(
                     f"Successfully extracted and enqueued file: {file_path.name}"
                 )
 
-                # Move file to __enqueued__ directory after enqueuing
+                # Move file to __parsed__ directory after enqueuing (LR2-PRD: parsed output dir)
                 try:
-                    enqueued_dir = file_path.parent / "__enqueued__"
+                    enqueued_dir = file_path.parent / PARSED_DIR_NAME
                     enqueued_dir.mkdir(exist_ok=True)
 
                     # Generate unique filename to avoid conflicts
@@ -1625,7 +1623,7 @@ async def pipeline_enqueue_file(
 
                 except Exception as move_error:
                     logger.error(
-                        f"Failed to move file {file_path.name} to __enqueued__ directory: {move_error}"
+                        f"Failed to move file {file_path.name} to {PARSED_DIR_NAME} directory: {move_error}"
                     )
                     # Don't affect the main function's success status
 
@@ -1968,8 +1966,8 @@ async def background_delete_documents(
                                                 file_error_msg
                                             )
 
-                                # Also check and delete files from __enqueued__ directory
-                                enqueued_dir = doc_manager.input_dir / "__enqueued__"
+                                # Also check and delete files from __parsed__ directory
+                                enqueued_dir = doc_manager.input_dir / PARSED_DIR_NAME
                                 if enqueued_dir.exists():
                                     # SECURITY FIX: Validate that the file path is safe before processing
                                     # Only proceed if the original path validation passed
@@ -2760,6 +2758,8 @@ def create_document_routes(
         try:
             statuses = (
                 DocStatus.PENDING,
+                DocStatus.PARSING,
+                DocStatus.ANALYZING,
                 DocStatus.PROCESSING,
                 DocStatus.PREPROCESSED,
                 DocStatus.PROCESSED,

--- a/lightrag/api/routers/ollama_api.py
+++ b/lightrag/api/routers/ollama_api.py
@@ -299,13 +299,18 @@ class OllamaAPI:
                 start_time = time.time_ns()
                 prompt_tokens = estimate_tokens(query)
 
+                role_kwargs = (
+                    dict(self.rag.query_llm_model_kwargs)
+                    if self.rag.query_llm_model_kwargs is not None
+                    else dict(self.rag.llm_model_kwargs)
+                )
                 if request.system:
-                    self.rag.llm_model_kwargs["system_prompt"] = request.system
+                    role_kwargs["system_prompt"] = request.system
 
                 if request.stream:
-                    response = await self.rag.llm_model_func(
-                        query, stream=True, **self.rag.llm_model_kwargs
-                    )
+                    response = await (
+                        self.rag.query_llm_model_func or self.rag.llm_model_func
+                    )(query, stream=True, **role_kwargs)
 
                     async def stream_generator():
                         first_chunk_time = None
@@ -428,9 +433,9 @@ class OllamaAPI:
                     )
                 else:
                     first_chunk_time = time.time_ns()
-                    response_text = await self.rag.llm_model_func(
-                        query, stream=False, **self.rag.llm_model_kwargs
-                    )
+                    response_text = await (
+                        self.rag.query_llm_model_func or self.rag.llm_model_func
+                    )(query, stream=False, **role_kwargs)
                     last_chunk_time = time.time_ns()
 
                     if not response_text:
@@ -515,13 +520,20 @@ class OllamaAPI:
                 if request.stream:
                     # Determine if the request is prefix with "/bypass"
                     if mode == SearchMode.bypass:
+                        role_kwargs = (
+                            dict(self.rag.query_llm_model_kwargs)
+                            if self.rag.query_llm_model_kwargs is not None
+                            else dict(self.rag.llm_model_kwargs)
+                        )
                         if request.system:
-                            self.rag.llm_model_kwargs["system_prompt"] = request.system
-                        response = await self.rag.llm_model_func(
+                            role_kwargs["system_prompt"] = request.system
+                        response = await (
+                            self.rag.query_llm_model_func or self.rag.llm_model_func
+                        )(
                             cleaned_query,
                             stream=True,
                             history_messages=conversation_history,
-                            **self.rag.llm_model_kwargs,
+                            **role_kwargs,
                         )
                     else:
                         response = await self.rag.aquery(
@@ -677,14 +689,21 @@ class OllamaAPI:
                         r"\n<chat_history>\nUSER:", cleaned_query, re.MULTILINE
                     )
                     if match_result or mode == SearchMode.bypass:
+                        role_kwargs = (
+                            dict(self.rag.query_llm_model_kwargs)
+                            if self.rag.query_llm_model_kwargs is not None
+                            else dict(self.rag.llm_model_kwargs)
+                        )
                         if request.system:
-                            self.rag.llm_model_kwargs["system_prompt"] = request.system
+                            role_kwargs["system_prompt"] = request.system
 
-                        response_text = await self.rag.llm_model_func(
+                        response_text = await (
+                            self.rag.query_llm_model_func or self.rag.llm_model_func
+                        )(
                             cleaned_query,
                             stream=False,
                             history_messages=conversation_history,
-                            **self.rag.llm_model_kwargs,
+                            **role_kwargs,
                         )
                     else:
                         response_text = await self.rag.aquery(

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -703,11 +703,16 @@ class BaseGraphStorage(StorageNameSpace, ABC):
 
 
 class DocStatus(str, Enum):
-    """Document processing status"""
+    """Document processing status.
+    Pipeline order: PENDING -> PARSING -> ANALYZING (optional) -> PROCESSING -> PROCESSED | FAILED.
+    PREPROCESSED is deprecated, kept for backward compatibility.
+    """
 
     PENDING = "pending"
-    PROCESSING = "processing"
-    PREPROCESSED = "preprocessed"
+    PARSING = "parsing"  # Phase 1: content extraction (parse_native/mineru/docling)
+    ANALYZING = "analyzing"  # Phase 2: multimodal analysis (VLM)
+    PROCESSING = "processing"  # Phase 3: entity/relation extraction
+    PREPROCESSED = "preprocessed"  # Deprecated: use ANALYZING in new pipeline
     PROCESSED = "processed"
     FAILED = "failed"
 

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -89,6 +89,15 @@ DEFAULT_TEMPERATURE = 1.0
 DEFAULT_MAX_ASYNC = 4  # Default maximum async operations
 DEFAULT_MAX_PARALLEL_INSERT = 2  # Default maximum parallel insert operations
 
+# RAG-Anything / LightRAG Document pipeline (LR2-PRD)
+FULL_DOCS_FORMAT_RAW = "raw"  # content in full_docs["content"]
+FULL_DOCS_FORMAT_LIGHTRAG = "lightrag"  # content in LightRAG Document files
+FULL_DOCS_FORMAT_PENDING_PARSE = (
+    "pending_parse"  # file saved but not yet parsed; parse_native will read from disk
+)
+PARSED_DIR_NAME = "__parsed__"  # Dir for parsed files (renamed from __enqueued__)
+DEFAULT_MAX_PARALLEL_ANALYZE = 2  # Multimodal analysis (VLM) concurrency
+
 # Embedding configuration defaults
 DEFAULT_EMBEDDING_FUNC_MAX_ASYNC = 8  # Default max async for embedding functions
 DEFAULT_EMBEDDING_BATCH_NUM = 10  # Default batch size for embedding computations

--- a/lightrag/extraction/__init__.py
+++ b/lightrag/extraction/__init__.py
@@ -1,0 +1,1 @@
+# LightRAG 2.0 document extraction package

--- a/lightrag/extraction/constants.py
+++ b/lightrag/extraction/constants.py
@@ -1,0 +1,51 @@
+"""Smart chunking thresholds – dual profile mode (code switch only).
+
+Profiles:
+- large: original parameters from docx-extraction-guide-zh.md
+- small: tuned for embedding-limited environments
+
+No env override is used. Switch profile by changing ACTIVE_PROFILE below.
+"""
+
+from __future__ import annotations
+
+MAX_HEADING_LENGTH = 200  # chars – heading text hard limit
+MAX_ANCHOR_CANDIDATE_LENGTH = 100  # chars – anchor paragraph limit
+
+# -------- Profile presets --------
+LARGE_PROFILE = {
+    "IDEAL_BLOCK_CONTENT_TOKENS": 6000,
+    "MAX_BLOCK_CONTENT_TOKENS": 8000,
+    "EXTRACTION_SAFE_MAX_BLOCK_TOKENS": 3000,
+    "SMALL_TAIL_THRESHOLD": 1000,
+    "TABLE_IDEAL_TOKENS": 3000,
+    "TABLE_MAX_TOKENS": 5000,
+    "TABLE_MIN_LAST_CHUNK_TOKENS": 1600,
+}
+
+SMALL_PROFILE = {
+    # tuned for embedding-limited environments (max block should not exceed 4096)
+    # one-step tighter profile to reduce downstream extraction prompt overflow risk
+    "IDEAL_BLOCK_CONTENT_TOKENS": 1800,
+    "MAX_BLOCK_CONTENT_TOKENS": 2200,
+    # final safety cap for entity-extraction stage (keep gleaning, reduce overflow risk)
+    "EXTRACTION_SAFE_MAX_BLOCK_TOKENS": 1000,
+    "SMALL_TAIL_THRESHOLD": 400,
+    "TABLE_IDEAL_TOKENS": 1400,
+    "TABLE_MAX_TOKENS": 1800,
+    "TABLE_MIN_LAST_CHUNK_TOKENS": 500,
+}
+
+# -------- Select active profile here --------
+# Change to "small" when needed.
+ACTIVE_PROFILE = "small"  # "large" | "small"
+_ACTIVE = SMALL_PROFILE if ACTIVE_PROFILE == "small" else LARGE_PROFILE
+
+# -------- Export active profile --------
+IDEAL_BLOCK_CONTENT_TOKENS = _ACTIVE["IDEAL_BLOCK_CONTENT_TOKENS"]
+MAX_BLOCK_CONTENT_TOKENS = _ACTIVE["MAX_BLOCK_CONTENT_TOKENS"]
+EXTRACTION_SAFE_MAX_BLOCK_TOKENS = _ACTIVE["EXTRACTION_SAFE_MAX_BLOCK_TOKENS"]
+SMALL_TAIL_THRESHOLD = _ACTIVE["SMALL_TAIL_THRESHOLD"]
+TABLE_IDEAL_TOKENS = _ACTIVE["TABLE_IDEAL_TOKENS"]
+TABLE_MAX_TOKENS = _ACTIVE["TABLE_MAX_TOKENS"]
+TABLE_MIN_LAST_CHUNK_TOKENS = _ACTIVE["TABLE_MIN_LAST_CHUNK_TOKENS"]

--- a/lightrag/extraction/docx_extractor.py
+++ b/lightrag/extraction/docx_extractor.py
@@ -1,0 +1,590 @@
+"""Word document content extraction with structure awareness.
+
+Implements §2 of docx-extraction-guide-zh.md:
+- Heading level via outlineLvl (with style inheritance)
+- Automatic numbering restoration
+- Table extraction (merged cells, cross-page headers)
+- Special content: images, formulas (OMML→LaTeX), super/subscripts
+- Paragraph anchor (w14:paraId)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from io import BytesIO
+from typing import Any, List, Optional
+from xml.etree import ElementTree as ET
+
+from .constants import MAX_HEADING_LENGTH
+
+# ── Word XML namespaces ──────────────────────────────────────────────
+_NS = {
+    "w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
+    "w14": "http://schemas.microsoft.com/office/word/2010/wordml",
+    "r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+    "wp": "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing",
+    "a": "http://schemas.openxmlformats.org/drawingml/2006/main",
+    "m": "http://schemas.openxmlformats.org/officeDocument/2006/math",
+}
+
+for prefix, uri in _NS.items():
+    ET.register_namespace(prefix, uri)
+
+
+# ── Data structures ──────────────────────────────────────────────────
+@dataclass
+class Paragraph:
+    """A single paragraph extracted from .docx."""
+
+    text: str
+    para_id: str = ""  # w14:paraId
+    outline_level: int = 9  # 0-8 = heading, 9 = body
+    is_table: bool = False
+    table_json: Optional[List[List[str]]] = None
+    table_header_rows: Optional[List[List[str]]] = None  # cross-page header
+    has_drawing: bool = False
+    drawing_id: str = ""
+    drawing_name: str = ""
+    drawing_rIds: list = field(default_factory=list)
+
+
+@dataclass
+class HeadingInfo:
+    """Tracks current heading context during extraction."""
+
+    title: str = ""
+    level: int = 0
+    parent_chain: list[str] = field(default_factory=list)
+
+
+# ── Numbering Resolver ───────────────────────────────────────────────
+class NumberingResolver:
+    """Restore Word automatic numbering from numbering.xml."""
+
+    def __init__(self, numbering_part: Any | None):
+        self._counters: dict[str, dict[int, int]] = {}
+        self._abstract: dict[str, dict] = {}
+        self._num_map: dict[str, str] = {}
+        if numbering_part is None:
+            return
+        try:
+            tree = ET.fromstring(numbering_part.blob)
+        except Exception:
+            return
+
+        # Parse abstractNum definitions
+        for abstract in tree.findall("w:abstractNum", _NS):
+            abstract_id = abstract.get(
+                "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}abstractNumId",
+                "",
+            )
+            levels: dict[int, dict] = {}
+            for lvl in abstract.findall("w:lvl", _NS):
+                ilvl = int(
+                    lvl.get(
+                        "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}ilvl",
+                        "0",
+                    )
+                )
+                fmt_el = lvl.find("w:numFmt", _NS)
+                fmt = (
+                    fmt_el.get(
+                        "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}val",
+                        "decimal",
+                    )
+                    if fmt_el is not None
+                    else "decimal"
+                )
+                txt_el = lvl.find("w:lvlText", _NS)
+                txt = (
+                    txt_el.get(
+                        "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}val",
+                        "",
+                    )
+                    if txt_el is not None
+                    else ""
+                )
+                start_el = lvl.find("w:start", _NS)
+                start = (
+                    int(
+                        start_el.get(
+                            "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}val",
+                            "1",
+                        )
+                    )
+                    if start_el is not None
+                    else 1
+                )
+                levels[ilvl] = {"fmt": fmt, "text": txt, "start": start}
+            self._abstract[abstract_id] = levels
+
+        # Parse num → abstractNum mapping
+        for num in tree.findall("w:num", _NS):
+            num_id = num.get(
+                "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}numId",
+                "",
+            )
+            ref = num.find("w:abstractNumId", _NS)
+            if ref is not None:
+                self._num_map[num_id] = ref.get(
+                    "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}val",
+                    "",
+                )
+
+    def resolve(self, num_id: str, ilvl: int) -> str:
+        """Return rendered numbering prefix like '2.1' or '(a)'."""
+        abstract_id = self._num_map.get(num_id, "")
+        levels = self._abstract.get(abstract_id, {})
+        if ilvl not in levels:
+            return ""
+
+        key = f"{num_id}"
+        if key not in self._counters:
+            self._counters[key] = {}
+
+        counters = self._counters[key]
+        if ilvl not in counters:
+            counters[ilvl] = levels[ilvl].get("start", 1)
+        else:
+            counters[ilvl] += 1
+
+        # Reset deeper levels
+        for deeper in list(counters.keys()):
+            if deeper > ilvl:
+                del counters[deeper]
+
+        template = levels[ilvl].get("text", "")
+        fmt = levels[ilvl].get("fmt", "decimal")
+
+        result = template
+        for lvl_idx in range(ilvl + 1):
+            val = counters.get(lvl_idx, levels.get(lvl_idx, {}).get("start", 1))
+            replacement = self._format_number(
+                val, fmt if lvl_idx == ilvl else "decimal"
+            )
+            result = result.replace(f"%{lvl_idx + 1}", replacement)
+        return result
+
+    @staticmethod
+    def _format_number(val: int, fmt: str) -> str:
+        if fmt == "decimal":
+            return str(val)
+        if fmt == "lowerLetter":
+            return chr(96 + val) if 1 <= val <= 26 else str(val)
+        if fmt == "upperLetter":
+            return chr(64 + val) if 1 <= val <= 26 else str(val)
+        if fmt == "lowerRoman":
+            romans = ["", "i", "ii", "iii", "iv", "v", "vi", "vii", "viii", "ix", "x"]
+            return romans[val] if val < len(romans) else str(val)
+        if fmt == "upperRoman":
+            romans = ["", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"]
+            return romans[val] if val < len(romans) else str(val)
+        if fmt in ("chineseCounting", "ideographDigital"):
+            cn = "零一二三四五六七八九十"
+            return cn[val] if val < len(cn) else str(val)
+        return str(val)
+
+
+# ── Heading level detection ──────────────────────────────────────────
+def _get_outline_level(para_element: ET.Element, styles_map: dict[str, int]) -> int:
+    """Detect heading level via outlineLvl with style inheritance."""
+    pPr = para_element.find("w:pPr", _NS)
+    if pPr is not None:
+        ol = pPr.find("w:outlineLvl", _NS)
+        if ol is not None:
+            val = ol.get(
+                "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}val", "9"
+            )
+            lvl = int(val)
+            if lvl <= 8:
+                return lvl
+
+    # Fallback: check style reference
+    if pPr is not None:
+        style_el = pPr.find("w:pStyle", _NS)
+        if style_el is not None:
+            style_id = style_el.get(
+                "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}val", ""
+            )
+            if style_id in styles_map:
+                return styles_map[style_id]
+    return 9  # body text
+
+
+def _build_styles_map(styles_part: Any | None) -> dict[str, int]:
+    """Build style_id → outline_level map from styles.xml (with basedOn)."""
+    result: dict[str, int] = {}
+    if styles_part is None:
+        return result
+    try:
+        tree = ET.fromstring(styles_part.blob)
+    except Exception:
+        return result
+
+    # First pass: direct outlineLvl
+    based_on: dict[str, str] = {}
+    for style in tree.findall("w:style", _NS):
+        sid = style.get(
+            "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}styleId", ""
+        )
+        pPr = style.find("w:pPr", _NS)
+        if pPr is not None:
+            ol = pPr.find("w:outlineLvl", _NS)
+            if ol is not None:
+                val = int(
+                    ol.get(
+                        "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}val",
+                        "9",
+                    )
+                )
+                if val <= 8:
+                    result[sid] = val
+
+        bo = style.find("w:basedOn", _NS)
+        if bo is not None:
+            based_on[sid] = bo.get(
+                "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}val", ""
+            )
+
+    # Second pass: inherit from basedOn
+    for sid, parent_sid in based_on.items():
+        if sid not in result and parent_sid in result:
+            result[sid] = result[parent_sid]
+
+    return result
+
+
+# ── Paragraph text extraction with special content ───────────────────
+def _extract_paragraph_text(para_element: ET.Element) -> str:
+    """Extract paragraph text preserving images, formulas, super/subscripts."""
+    parts: list[str] = []
+
+    for child in para_element.iter():
+        tag = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+
+        # Regular text
+        if tag == "t":
+            if child.text:
+                parts.append(child.text)
+
+        # Superscript / subscript
+        elif tag == "vertAlign":
+            # Handled via run properties – text comes from <w:t>
+            pass
+
+        # Drawing (image)
+        elif tag == "drawing":
+            img_id, img_name, _ = _extract_drawing_info(child)
+            if img_id:
+                parts.append(f'<drawing id="{img_id}" name="{img_name}" />')
+
+        # OMML formula
+        elif tag == "oMath" or tag == "oMathPara":
+            latex = _omml_to_text(child)
+            if latex:
+                parts.append(f"<equation>{latex}</equation>")
+
+    return "".join(parts)
+
+
+def _extract_paragraph_text_with_formatting(para_element: ET.Element) -> str:
+    """Extract paragraph text with super/subscript tags."""
+    parts: list[str] = []
+
+    for run in para_element.findall(".//w:r", _NS):
+        rPr = run.find("w:rPr", _NS)
+        vert = None
+        if rPr is not None:
+            va = rPr.find("w:vertAlign", _NS)
+            if va is not None:
+                vert = va.get(
+                    "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}val",
+                    "",
+                )
+
+        for t in run.findall("w:t", _NS):
+            text = t.text or ""
+            if vert == "superscript":
+                parts.append(f"<sup>{text}</sup>")
+            elif vert == "subscript":
+                parts.append(f"<sub>{text}</sub>")
+            else:
+                parts.append(text)
+
+        # Drawing inside run
+        for drawing in run.findall(".//w:drawing", _NS):
+            img_id, img_name, _ = _extract_drawing_info(drawing)
+            if img_id:
+                parts.append(f'<drawing id="{img_id}" name="{img_name}" />')
+
+    # Math at paragraph level
+    for math_el in para_element.findall(".//m:oMath", _NS):
+        latex = _omml_to_text(math_el)
+        if latex:
+            parts.append(f"<equation>{latex}</equation>")
+
+    return "".join(parts)
+
+
+def _extract_drawing_info(
+    drawing_el: ET.Element,
+) -> tuple[str, str, str]:
+    """Extract image id, name and r:embed relationship ID from a drawing element."""
+    img_id = ""
+    img_name = ""
+    r_embed = ""
+    for dp in drawing_el.iter():
+        local_tag = dp.tag.split("}")[-1] if "}" in dp.tag else dp.tag
+        if local_tag == "docPr" and not img_id:
+            img_id = dp.get("id", "")
+            img_name = dp.get("name", "")
+        if local_tag == "blip" and not r_embed:
+            for attr_key, attr_val in dp.attrib.items():
+                if attr_key.endswith("}embed") or attr_key == "embed":
+                    r_embed = attr_val
+                    break
+    return img_id, img_name, r_embed
+
+
+def _omml_to_text(math_el: ET.Element) -> str:
+    """Simple OMML → text extraction (best-effort, not full LaTeX)."""
+    texts: list[str] = []
+    for el in math_el.iter():
+        tag = el.tag.split("}")[-1] if "}" in el.tag else el.tag
+        if tag == "t" and el.text:
+            texts.append(el.text)
+    return " ".join(texts)
+
+
+def _get_para_id(para_element: ET.Element) -> str:
+    """Get w14:paraId from paragraph element."""
+    for attr_name, val in para_element.attrib.items():
+        if "paraId" in attr_name:
+            return val
+    return ""
+
+
+def _infer_heading_level_by_text(text: str) -> int | None:
+    """Fallback heading detection from paragraph text.
+
+    Returns 1-based heading level (1..9) or None when not detected.
+    Used when Word heading styles/outlineLvl are missing.
+    """
+    t = (text or "").strip()
+    if not t:
+        return None
+    if len(t) > MAX_HEADING_LENGTH:
+        return None
+
+    # Chinese chapter style: "第三章 ...", "第1章 ..."
+    if re.match(r"^第[一二三四五六七八九十百千0-9]+章\b", t):
+        return 1
+
+    # Numeric heading: 1 / 1.2 / 1.2.3 / 3.1.4.2 ...
+    m = re.match(r"^(\d+(?:\.\d+){0,8})\s+", t)
+    if m:
+        level = m.group(1).count(".") + 1
+        # Avoid treating likely list items as headings
+        if level == 1 and len(t) > 60:
+            return None
+        return min(max(level, 1), 9)
+
+    # Chinese section style: "一、", "（一）", "(一)"
+    if re.match(r"^[一二三四五六七八九十]+、", t):
+        return 2
+    if re.match(r"^[（(][一二三四五六七八九十]+[）)]", t):
+        return 3
+
+    return None
+
+
+# ── Table extraction ─────────────────────────────────────────────────
+def _extract_table(
+    table_element: ET.Element,
+) -> tuple[list[list[str]], list[list[str]]]:
+    """Extract table as JSON 2D array + cross-page header rows.
+
+    Returns:
+        (all_rows, header_rows) where each is list[list[str]]
+    """
+    rows: list[list[str]] = []
+    header_rows: list[list[str]] = []
+
+    for tr in table_element.findall("w:tr", _NS):
+        cells: list[str] = []
+        is_header = False
+
+        # Check for table header (tblHeader)
+        trPr = tr.find("w:trPr", _NS)
+        if trPr is not None:
+            th = trPr.find("w:tblHeader", _NS)
+            if th is not None:
+                is_header = True
+
+        for tc in tr.findall("w:tc", _NS):
+            cell_parts: list[str] = []
+            for p in tc.findall("w:p", _NS):
+                t = _extract_paragraph_text_with_formatting(p)
+                if t:
+                    cell_parts.append(t)
+            cells.append("\n".join(cell_parts))
+
+        rows.append(cells)
+        if is_header:
+            header_rows.append(cells)
+
+    return rows, header_rows
+
+
+def _table_to_content(rows: list[list[str]]) -> str:
+    """Wrap table rows as <table>JSON</table>."""
+    return f"<table>{json.dumps(rows, ensure_ascii=False)}</table>"
+
+
+# ── Main extraction entry point ──────────────────────────────────────
+def extract_docx_images(file_bytes: bytes) -> dict[str, tuple[str, bytes]]:
+    """Extract all embedded images from a .docx file.
+
+    Returns a dict mapping relationship ID to (filename, image_bytes).
+    """
+    from docx import Document as DocxDocument  # type: ignore
+
+    result: dict[str, tuple[str, bytes]] = {}
+    try:
+        doc = DocxDocument(BytesIO(file_bytes))
+        image_rel_type = (
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"
+        )
+        for rel_id, rel in doc.part.rels.items():
+            if rel.reltype == image_rel_type:
+                try:
+                    target_part = rel.target_part
+                    blob = target_part.blob
+                    target_ref = str(rel.target_ref)
+                    filename = (
+                        target_ref.split("/")[-1] if "/" in target_ref else target_ref
+                    )
+                    result[rel_id] = (filename, blob)
+                except Exception:
+                    pass
+    except Exception:
+        pass
+    return result
+
+
+def extract_docx_paragraphs(file_bytes: bytes) -> list[Paragraph]:
+    """Extract all paragraphs from a .docx file with structure awareness.
+
+    Returns a list of Paragraph objects in document reading order.
+    """
+    from docx import Document as DocxDocument  # type: ignore
+
+    docx_file = BytesIO(file_bytes)
+    doc = DocxDocument(docx_file)
+
+    # Build styles map for heading detection
+    styles_part = (
+        doc.part.part_related_by(
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"
+        )
+        if doc.part
+        else None
+    )
+    styles_map = _build_styles_map(styles_part)
+
+    # Build numbering resolver
+    numbering_part = None
+    try:
+        numbering_part = doc.part.part_related_by(
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering"
+        )
+    except Exception:
+        pass
+    numbering = NumberingResolver(numbering_part)
+
+    paragraphs: list[Paragraph] = []
+
+    for element in doc.element.body:
+        tag = element.tag.split("}")[-1] if "}" in element.tag else element.tag
+
+        if tag == "p":
+            para_id = _get_para_id(element)
+            outline_level = _get_outline_level(element, styles_map)
+            text = _extract_paragraph_text_with_formatting(element)
+
+            # Numbering prefix
+            pPr = element.find("w:pPr", _NS)
+            if pPr is not None:
+                numPr = pPr.find("w:numPr", _NS)
+                if numPr is not None:
+                    num_id_el = numPr.find("w:numId", _NS)
+                    ilvl_el = numPr.find("w:ilvl", _NS)
+                    if num_id_el is not None and ilvl_el is not None:
+                        num_id = num_id_el.get(
+                            "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}val",
+                            "0",
+                        )
+                        ilvl = int(
+                            ilvl_el.get(
+                                "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}val",
+                                "0",
+                            )
+                        )
+                        if num_id != "0":
+                            prefix = numbering.resolve(num_id, ilvl)
+                            if prefix:
+                                text = f"{prefix} {text}"
+
+            # Fallback heading detection by text pattern when style-based detection fails
+            if outline_level >= 9:
+                inferred = _infer_heading_level_by_text(text)
+                if inferred is not None:
+                    outline_level = inferred - 1  # convert to 0-based (0..8)
+
+            drawing_els = element.findall(".//w:drawing", _NS)
+            has_drawing = len(drawing_els) > 0
+            drawing_rIds = []
+            for dr_el in drawing_els:
+                _, _, r_embed = _extract_drawing_info(dr_el)
+                if r_embed:
+                    drawing_rIds.append(r_embed)
+
+            paragraphs.append(
+                Paragraph(
+                    text=text,
+                    para_id=para_id,
+                    outline_level=outline_level,
+                    is_table=False,
+                    has_drawing=has_drawing,
+                    drawing_rIds=drawing_rIds,
+                )
+            )
+
+        elif tag == "tbl":
+            rows, header_rows = _extract_table(element)
+            if not rows:
+                continue
+
+            # Get first and last paraIds from table cells
+            all_paras = element.findall(".//w:p", _NS)
+            first_id = _get_para_id(all_paras[0]) if all_paras else ""
+            last_id = _get_para_id(all_paras[-1]) if all_paras else ""
+
+            content = _table_to_content(rows)
+            paragraphs.append(
+                Paragraph(
+                    text=content,
+                    para_id=first_id,
+                    outline_level=9,
+                    is_table=True,
+                    table_json=rows,
+                    table_header_rows=header_rows if header_rows else None,
+                )
+            )
+            # Store last_id on same paragraph for uuid_end
+            if last_id:
+                paragraphs[-1].drawing_id = last_id  # reuse field for table end id
+
+    return paragraphs

--- a/lightrag/extraction/interchange.py
+++ b/lightrag/extraction/interchange.py
@@ -1,0 +1,145 @@
+"""Interchange JSONL parser and validator.
+
+Implements core rules from docs/extraction-interchange-format-spec-zh.md §8
+without multimodal post-processing.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from lightrag.utils import Tokenizer
+
+
+VALID_CONTENT_TYPES = {
+    "body",
+    "table",
+    "image",
+    "equation",
+    "summary",
+    "toc",
+    "references",
+}
+
+
+def parse_interchange_jsonl(
+    raw_content: str,
+    tokenizer: Tokenizer | None = None,
+) -> tuple[dict[str, Any], list[dict[str, Any]]] | None:
+    """Parse and validate interchange JSONL.
+
+    Returns:
+      (meta, chunks) on success
+      None when input is not valid interchange format.
+    """
+    if not raw_content:
+        return None
+
+    lines = [line.strip() for line in raw_content.splitlines() if line.strip()]
+    if len(lines) < 2:
+        return None
+
+    try:
+        meta = json.loads(lines[0])
+    except Exception:
+        return None
+
+    if not _is_valid_meta(meta):
+        return None
+
+    raw_chunks: list[dict[str, Any]] = []
+    for line in lines[1:]:
+        try:
+            item = json.loads(line)
+        except Exception:
+            return None
+        if isinstance(item, dict):
+            raw_chunks.append(item)
+
+    chunks = _normalize_validate_chunks(raw_chunks, tokenizer)
+    if chunks is None or not chunks:
+        return None
+
+    return meta, chunks
+
+
+def _is_valid_meta(meta: dict[str, Any]) -> bool:
+    if not isinstance(meta, dict):
+        return False
+    if meta.get("type") != "meta":
+        return False
+    # format_version is required by spec
+    fv = meta.get("format_version")
+    if fv is None:
+        return False
+    return True
+
+
+def _normalize_validate_chunks(
+    raw_chunks: list[dict[str, Any]],
+    tokenizer: Tokenizer | None,
+) -> list[dict[str, Any]] | None:
+    normalized: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+
+    for idx, item in enumerate(raw_chunks):
+        if item.get("type") != "text":
+            continue
+
+        content = item.get("content")
+        if not isinstance(content, str) or not content.strip():
+            return None
+
+        chunk_id = item.get("chunk_id")
+        if not isinstance(chunk_id, str) or not chunk_id.strip():
+            chunk_id = f"chunk-{idx:03d}"
+        chunk_id = chunk_id.strip()
+        if chunk_id in seen_ids:
+            return None
+        seen_ids.add(chunk_id)
+
+        chunk_order_index = item.get("chunk_order_index", idx)
+        if not isinstance(chunk_order_index, int):
+            try:
+                chunk_order_index = int(chunk_order_index)
+            except Exception:
+                return None
+
+        content_type = item.get("content_type", "body")
+        if content_type not in VALID_CONTENT_TYPES:
+            return None
+
+        tokens = item.get("tokens")
+        if not isinstance(tokens, int):
+            if tokenizer is not None:
+                tokens = len(tokenizer.encode(content))
+            else:
+                tokens = max(1, int(len(content) * 0.5))
+
+        table_role = item.get("table_chunk_role", "none")
+        table_fragment_num = item.get("table_fragment_num")
+        table_meta = item.get("table_meta")
+
+        # Spec constraints
+        if content_type == "table" and table_meta is None:
+            return None
+        if table_role != "none" and table_fragment_num is None:
+            return None
+
+        parsed = dict(item)
+        parsed.pop("type", None)
+        parsed["chunk_id"] = chunk_id
+        parsed["chunk_order_index"] = chunk_order_index
+        parsed["content_type"] = content_type
+        parsed["tokens"] = tokens
+        parsed["table_chunk_role"] = table_role
+        normalized.append(parsed)
+
+    # chunk_order_index continuity check (0..n-1)
+    normalized.sort(key=lambda c: c["chunk_order_index"])
+    for i, c in enumerate(normalized):
+        if c["chunk_order_index"] != i:
+            return None
+
+    return normalized

--- a/lightrag/extraction/parse_document.py
+++ b/lightrag/extraction/parse_document.py
@@ -1,0 +1,270 @@
+"""End-to-end document parser: .docx → _blocks.jsonl content.
+
+Public API:
+    parse_docx_to_jsonl(file_bytes, source_file) → str  (JSONL text)
+    parse_docx_to_blocks(file_bytes)              → list[dict]
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+from pathlib import Path
+
+from .docx_extractor import extract_docx_images, extract_docx_paragraphs
+from .smart_chunker import Block, smart_chunk
+from .token_estimation import estimate_tokens
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _block_to_dict(block: Block, index: int) -> dict[str, Any]:
+    """Convert a Block to the _blocks.jsonl chunk dict."""
+    return {
+        "uuid": block.uuid,
+        "uuid_end": block.uuid_end,
+        "heading": block.heading,
+        "content": block.content,
+        "type": "text",
+        "parent_headings": block.parent_headings,
+        "level": block.level,
+        "table_chunk_role": block.table_chunk_role,
+        **({"table_header": block.table_header} if block.table_header else {}),
+    }
+
+
+def _build_meta(source_file: str, source_hash: str) -> dict[str, Any]:
+    """Build the meta line for _blocks.jsonl."""
+    return {
+        "type": "meta",
+        "source_file": source_file,
+        "source_hash": f"sha256:{source_hash}",
+        "parsed_at": datetime.now().isoformat(),
+    }
+
+
+# ── Public API ───────────────────────────────────────────────────────
+def parse_docx_to_blocks(file_bytes: bytes) -> list[dict[str, Any]]:
+    """Parse .docx bytes into a list of block dicts (without meta line).
+
+    Each dict matches the _blocks.jsonl chunk schema.
+    """
+    paragraphs = extract_docx_paragraphs(file_bytes)
+    blocks = smart_chunk(paragraphs)
+    return [_block_to_dict(b, i) for i, b in enumerate(blocks)]
+
+
+def parse_docx_to_jsonl(
+    file_bytes: bytes,
+    source_file: str = "document.docx",
+) -> str:
+    """Parse .docx bytes into a complete JSONL string (meta + chunks).
+
+    The returned string can be:
+    - Written directly to a .jsonl file
+    - Fed into LightRAG interchange format consumer
+    """
+    source_hash = _sha256_hex(file_bytes)
+    meta = _build_meta(source_file, source_hash)
+
+    paragraphs = extract_docx_paragraphs(file_bytes)
+    blocks = smart_chunk(paragraphs)
+
+    lines: list[str] = [json.dumps(meta, ensure_ascii=False)]
+    for i, block in enumerate(blocks):
+        chunk_dict = _block_to_dict(block, i)
+        lines.append(json.dumps(chunk_dict, ensure_ascii=False))
+
+    return "\n".join(lines)
+
+
+def parse_docx_to_interchange_jsonl(
+    file_bytes: bytes,
+    source_file: str = "document.docx",
+    doc_id: str = "",
+    output_dir: str | None = None,
+) -> str:
+    """Parse .docx into LightRAG 2.0 interchange format JSONL.
+
+    Compatible with extraction_interchange.py consumer.
+    Adds chunk_id, chunk_order_index, tokens, content_type fields.
+    When output_dir is provided, embedded images are extracted to an assets subdirectory.
+    """
+    source_hash = _sha256_hex(file_bytes)
+
+    images = extract_docx_images(file_bytes)
+    has_images = bool(images)
+
+    capabilities = ["t"]
+    if has_images:
+        capabilities.append("i")
+
+    asset_dir_created = False
+    if output_dir and images:
+        prefix = (
+            doc_id.strip() if doc_id and doc_id.strip() else f"doc-{source_hash[:12]}"
+        )
+        assets_dir = Path(output_dir) / f"{prefix}.{source_file}.blocks.assets"
+        try:
+            assets_dir.mkdir(parents=True, exist_ok=True)
+            for _rel_id, (filename, blob) in images.items():
+                (assets_dir / filename).write_bytes(blob)
+            asset_dir_created = True
+        except Exception:
+            pass
+
+    meta = {
+        "type": "meta",
+        "format_version": "2.0",
+        "source_file": source_file,
+        "source_hash": f"sha256:{source_hash}",
+        "doc_id": doc_id,
+        "engine": "default",
+        "engine_capabilities": capabilities,
+        "chunking_method": "heading_semantic",
+        "parsed_at": datetime.now(timezone.utc).isoformat(),
+        "asset_dir": asset_dir_created,
+    }
+
+    paragraphs = extract_docx_paragraphs(file_bytes)
+    blocks = smart_chunk(paragraphs)
+
+    meta["total_chunks"] = len(blocks)
+    chunk_id_prefix = (
+        doc_id.strip()
+        if isinstance(doc_id, str) and doc_id.strip()
+        else f"doc-{source_hash[:12]}"
+    )
+
+    lines: list[str] = [json.dumps(meta, ensure_ascii=False)]
+    table_group_ids: dict[str, str] = {}
+
+    for i, block in enumerate(blocks):
+        content = block.content
+        is_table_block = block.table_chunk_role != "none" or (
+            content.startswith("<table>") and content.endswith("</table>")
+        )
+
+        table_fragment_num = None
+        table_meta = None
+        content_md = None
+
+        if is_table_block:
+            rows = _extract_table_rows_from_content(content)
+            content_md = _table_rows_to_markdown(rows) if rows is not None else None
+
+            # For fragmented tables, try to keep one ID shared across fragments
+            heading_base = re.sub(r"\s*\[表格片段\d+\]\s*$", "", block.heading or "")
+            group_key = f"{block.uuid}|{heading_base}|{'/'.join(block.parent_headings)}"
+            if group_key not in table_group_ids:
+                table_group_ids[group_key] = _make_table_id(group_key, source_hash, i)
+            table_id = table_group_ids[group_key]
+
+            if block.table_chunk_role in {"first", "middle", "last"}:
+                table_fragment_num = _extract_fragment_num(block.heading)
+            else:
+                table_fragment_num = None
+
+            num_rows = len(rows) - 1 if rows else 0
+            num_cols = len(rows[0]) if rows and rows[0] else 0
+            has_header = bool(block.table_header)
+
+            table_meta = {
+                "table_id": table_id,
+                "table_title": heading_base,
+                "format": "json",
+                "num_rows": max(num_rows, 0),
+                "num_cols": max(num_cols, 0),
+                "has_header": has_header,
+                "table_header": block.table_header or [],
+                "summary": "",
+            }
+
+        positions = []
+        if block.uuid or block.uuid_end:
+            positions.append(
+                {
+                    "type": "paraid",
+                    "anchor": "",
+                    "range": [block.uuid or "", block.uuid_end or block.uuid or ""],
+                    "charspan": [],
+                }
+            )
+
+        chunk = {
+            "type": "text",
+            "chunk_id": f"{chunk_id_prefix}-chunk-{i:03d}",
+            "chunk_order_index": i,
+            "content": content,
+            "content_md": content_md,
+            "tokens": estimate_tokens(content),
+            "heading": block.heading,
+            "parent_headings": block.parent_headings,
+            "level": block.level,
+            "content_type": "table" if is_table_block else "body",
+            "uuid": block.uuid,
+            "uuid_end": block.uuid_end,
+            "positions": positions,
+            "table_chunk_role": block.table_chunk_role,
+            "table_fragment_num": table_fragment_num,
+            "table_meta": table_meta,
+        }
+        if block.table_header:
+            chunk["table_header"] = block.table_header
+
+        lines.append(json.dumps(chunk, ensure_ascii=False))
+
+    return "\n".join(lines)
+
+
+def _extract_table_rows_from_content(content: str) -> list[list[str]] | None:
+    if not (content.startswith("<table>") and content.endswith("</table>")):
+        return None
+    raw = content[7:-8]
+    try:
+        rows = json.loads(raw)
+        if isinstance(rows, list):
+            return rows
+    except Exception:
+        return None
+    return None
+
+
+def _table_rows_to_markdown(rows: list[list[str]] | None) -> str | None:
+    if not rows or not rows[0]:
+        return None
+    header = [str(x) for x in rows[0]]
+    body = rows[1:] if len(rows) > 1 else []
+    md_lines = [
+        "| " + " | ".join(header) + " |",
+        "| " + " | ".join(["---"] * len(header)) + " |",
+    ]
+    for r in body:
+        cells = [str(x) for x in r]
+        if len(cells) < len(header):
+            cells.extend([""] * (len(header) - len(cells)))
+        md_lines.append("| " + " | ".join(cells[: len(header)]) + " |")
+    return "\n".join(md_lines)
+
+
+def _make_table_id(group_key: str, source_hash: str, idx: int) -> str:
+    digest = hashlib.sha256(
+        f"{group_key}|{source_hash}|{idx}".encode("utf-8")
+    ).hexdigest()
+    return f"tb-{digest[:8].upper()}"
+
+
+def _extract_fragment_num(heading: str) -> int | None:
+    m = re.search(r"\[表格片段(\d+)\]\s*$", heading or "")
+    if not m:
+        return None
+    try:
+        return int(m.group(1))
+    except Exception:
+        return None

--- a/lightrag/extraction/smart_chunker.py
+++ b/lightrag/extraction/smart_chunker.py
@@ -1,0 +1,644 @@
+"""Four-stage smart chunking pipeline – docx-extraction-guide-zh.md §3.
+
+Stage A: Heading-driven initial chunking
+Stage B: Large table row slicing
+Stage C: Long block anchor splitting
+Stage D: Small block merging (with tail absorption)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+from .constants import (
+    EXTRACTION_SAFE_MAX_BLOCK_TOKENS,
+    IDEAL_BLOCK_CONTENT_TOKENS,
+    MAX_ANCHOR_CANDIDATE_LENGTH,
+    MAX_BLOCK_CONTENT_TOKENS,
+    SMALL_TAIL_THRESHOLD,
+    TABLE_IDEAL_TOKENS,
+    TABLE_MAX_TOKENS,
+    TABLE_MIN_LAST_CHUNK_TOKENS,
+)
+from .docx_extractor import Paragraph
+from .token_estimation import estimate_tokens
+
+
+# ── Block data structure ─────────────────────────────────────────────
+@dataclass
+class Block:
+    """A chunk of document content, ready for output."""
+
+    heading: str = ""
+    parent_headings: list[str] = field(default_factory=list)
+    level: int = 0
+    content_parts: list[str] = field(default_factory=list)
+    uuid: str = ""
+    uuid_end: str = ""
+    table_chunk_role: str = "none"
+    table_header: Optional[list[list[str]]] = None
+
+    @property
+    def content(self) -> str:
+        return "\n\n".join(p for p in self.content_parts if p)
+
+    @property
+    def tokens(self) -> int:
+        return estimate_tokens(self.content)
+
+
+# ── Stage A: Heading-driven initial chunking ─────────────────────────
+def _stage_a_heading_split(paragraphs: list[Paragraph]) -> list[Block]:
+    """Split by heading paragraphs. Heading text also enters content."""
+    blocks: list[Block] = []
+    current_block: Block | None = None
+    heading_stack: list[tuple[int, str]] = []  # (level, title)
+
+    for para in paragraphs:
+        is_heading = para.outline_level <= 8
+
+        if is_heading:
+            # Flush current block
+            if current_block is not None and current_block.content_parts:
+                blocks.append(current_block)
+
+            title = para.text.strip()
+            level = para.outline_level + 1  # 0-based → 1-based
+
+            # Maintain heading stack
+            while heading_stack and heading_stack[-1][0] >= level:
+                heading_stack.pop()
+            parent_headings = [h[1] for h in heading_stack]
+            heading_stack.append((level, title))
+
+            current_block = Block(
+                heading=title,
+                parent_headings=list(parent_headings),
+                level=level,
+                content_parts=[title],  # heading text enters content
+                uuid=para.para_id,
+                uuid_end=para.para_id,
+            )
+        else:
+            # Body / table paragraph
+            if current_block is None:
+                current_block = Block(
+                    heading="Preface/Uncategorized",
+                    parent_headings=[],
+                    level=0,
+                    content_parts=[],
+                    uuid=para.para_id,
+                    uuid_end=para.para_id,
+                )
+
+            content = para.text
+            current_block.content_parts.append(content)
+
+            # Update uuid_end
+            if para.para_id:
+                current_block.uuid_end = para.para_id
+            # For tables, the end id may be stored in drawing_id
+            if para.is_table and para.drawing_id:
+                current_block.uuid_end = para.drawing_id
+
+            # Attach table metadata
+            if para.is_table and para.table_header_rows:
+                current_block.table_header = para.table_header_rows
+
+    # Flush last block
+    if current_block is not None and current_block.content_parts:
+        blocks.append(current_block)
+
+    return blocks
+
+
+# ── Stage B: Large table row slicing ─────────────────────────────────
+def _slice_table_rows(
+    table_json: list[list[str]],
+    header_rows: list[list[str]] | None,
+) -> list[tuple[list[list[str]], str]]:
+    """Slice table by rows. Returns list of (rows, role)."""
+    total_tokens = estimate_tokens(json.dumps(table_json, ensure_ascii=False))
+    if total_tokens <= TABLE_MAX_TOKENS:
+        return [(table_json, "none")]
+
+    slices: list[tuple[list[list[str]], str]] = []
+    current_rows: list[list[str]] = []
+    current_tokens = 0
+    header_tokens = 0
+    if header_rows:
+        header_tokens = estimate_tokens(json.dumps(header_rows, ensure_ascii=False))
+
+    for row in table_json:
+        row_tokens = estimate_tokens(json.dumps(row, ensure_ascii=False))
+        if current_tokens + row_tokens > TABLE_IDEAL_TOKENS and current_rows:
+            slices.append((current_rows, ""))
+            current_rows = []
+            current_tokens = header_tokens  # account for header prepend
+        current_rows.append(row)
+        current_tokens += row_tokens
+
+    if current_rows:
+        slices.append((current_rows, ""))
+
+    # Merge tiny last slice
+    if len(slices) > 1:
+        last_tokens = estimate_tokens(json.dumps(slices[-1][0], ensure_ascii=False))
+        if last_tokens < TABLE_MIN_LAST_CHUNK_TOKENS:
+            merged = slices[-2][0] + slices[-1][0]
+            slices[-2] = (merged, slices[-2][1])
+            slices.pop()
+
+    # Assign roles
+    if len(slices) == 1:
+        slices[0] = (slices[0][0], "none")
+    else:
+        result = []
+        for i, (rows, _) in enumerate(slices):
+            if i == 0:
+                role = "first"
+            elif i == len(slices) - 1:
+                role = "last"
+            else:
+                role = "middle"
+            result.append((rows, role))
+        slices = result
+
+    return slices
+
+
+def _stage_b_table_slice(blocks: list[Block]) -> list[Block]:
+    """Slice large tables within blocks."""
+    result: list[Block] = []
+
+    for block in blocks:
+        # Find table content in block
+        has_big_table = False
+        table_json = None
+        table_header = None
+        table_content_idx = -1
+
+        for idx, part in enumerate(block.content_parts):
+            if part.startswith("<table>") and part.endswith("</table>"):
+                inner = part[7:-8]  # strip <table></table>
+                try:
+                    parsed = json.loads(inner)
+                    tokens = estimate_tokens(part)
+                    if tokens > TABLE_MAX_TOKENS:
+                        has_big_table = True
+                        table_json = parsed
+                        table_header = block.table_header
+                        table_content_idx = idx
+                except Exception:
+                    pass
+                break
+
+        if not has_big_table or table_json is None:
+            result.append(block)
+            continue
+
+        # Split: before-table parts, table slices, after-table parts
+        before_parts = block.content_parts[:table_content_idx]
+        after_parts = block.content_parts[table_content_idx + 1 :]
+        slices = _slice_table_rows(table_json, table_header)
+
+        for si, (rows, role) in enumerate(slices):
+            table_content = f"<table>{json.dumps(rows, ensure_ascii=False)}</table>"
+
+            if si == 0:
+                # First slice merges with before-table content
+                new_parts = list(before_parts) + [table_content]
+                heading = block.heading
+            elif si == len(slices) - 1:
+                # Last slice merges with after-table content
+                new_parts = [table_content] + list(after_parts)
+                heading = f"{block.heading} [表格片段{si + 1}]"
+                after_parts = []  # consumed
+            else:
+                # Middle slices are standalone
+                new_parts = [table_content]
+                heading = f"{block.heading} [表格片段{si + 1}]"
+
+            new_block = Block(
+                heading=heading,
+                parent_headings=list(block.parent_headings),
+                level=block.level,
+                content_parts=new_parts,
+                uuid=block.uuid,
+                uuid_end=block.uuid_end,
+                table_chunk_role=role,
+                table_header=table_header if role in ("middle", "last") else None,
+            )
+            result.append(new_block)
+
+        # If after_parts remain (no last slice consumed them)
+        if after_parts:
+            result[-1].content_parts.extend(after_parts)
+
+    return result
+
+
+# ── Stage C: Long block anchor splitting ─────────────────────────────
+def _stage_c_anchor_split(blocks: list[Block]) -> list[Block]:
+    """Split blocks exceeding MAX_BLOCK_CONTENT_TOKENS at anchor points."""
+    result: list[Block] = []
+
+    for block in blocks:
+        if block.tokens <= MAX_BLOCK_CONTENT_TOKENS:
+            result.append(block)
+            continue
+
+        # Don't re-split table-only blocks
+        if block.table_chunk_role == "middle":
+            result.append(block)
+            continue
+
+        # Find anchor candidates: short paragraphs
+        sub_blocks: list[Block] = []
+        current = Block(
+            heading=block.heading,
+            parent_headings=list(block.parent_headings),
+            level=block.level,
+            content_parts=[],
+            uuid=block.uuid,
+            uuid_end=block.uuid_end,
+            table_chunk_role=block.table_chunk_role,
+            table_header=block.table_header,
+        )
+
+        for part in block.content_parts:
+            current.content_parts.append(part)
+
+            if current.tokens > MAX_BLOCK_CONTENT_TOKENS:
+                # Try to find an anchor point
+                is_anchor = (
+                    len(part) <= MAX_ANCHOR_CANDIDATE_LENGTH
+                    and not part.startswith("<table>")
+                    and part.strip()
+                )
+
+                if is_anchor and len(current.content_parts) > 1:
+                    # Split before this anchor
+                    anchor_part = current.content_parts.pop()
+
+                    if current.content_parts:
+                        sub_blocks.append(current)
+
+                    # New block starts with anchor as heading
+                    current = Block(
+                        heading=anchor_part.strip(),
+                        parent_headings=list(block.parent_headings)
+                        + ([block.heading] if block.heading else []),
+                        level=block.level + 1 if block.level < 9 else block.level,
+                        content_parts=[anchor_part],
+                        uuid=block.uuid,
+                        uuid_end=block.uuid_end,
+                        table_chunk_role="none",
+                    )
+
+        if current.content_parts:
+            sub_blocks.append(current)
+
+        # Hard fallback split: if anchor strategy still leaves oversize blocks,
+        # split inside block content by sentence/char boundaries.
+        refined_sub_blocks: list[Block] = []
+        for sb in sub_blocks:
+            if sb.tokens <= MAX_BLOCK_CONTENT_TOKENS or sb.table_chunk_role == "middle":
+                refined_sub_blocks.append(sb)
+                continue
+            refined_sub_blocks.extend(_force_split_oversize_block(sb))
+        sub_blocks = refined_sub_blocks
+
+        if sub_blocks:
+            result.extend(sub_blocks)
+        else:
+            result.append(block)
+
+    return result
+
+
+def _force_split_oversize_block(
+    block: Block, max_tokens: int = MAX_BLOCK_CONTENT_TOKENS
+) -> list[Block]:
+    """Force split oversize block when no suitable anchor is found.
+
+    Strategy:
+    1) sentence-level split by punctuation
+    2) if a sentence itself is too long, char-level fallback
+    """
+    content = block.content
+    if not content:
+        return [block]
+
+    units = _split_text_units(content)
+    merged_units = _merge_units_by_token_limit(units, max_tokens)
+
+    if len(merged_units) <= 1 and estimate_tokens(merged_units[0]) > max_tokens:
+        # Char-level emergency split
+        merged_units = _char_level_split(merged_units[0], max_tokens)
+
+    if len(merged_units) <= 1:
+        return [block]
+
+    out: list[Block] = []
+    for i, part in enumerate(merged_units):
+        nb = Block(
+            heading=block.heading if i == 0 else f"{block.heading} [续{i}]",
+            parent_headings=list(block.parent_headings),
+            level=block.level,
+            content_parts=[part],
+            uuid=block.uuid,
+            uuid_end=block.uuid_end,
+            table_chunk_role=block.table_chunk_role,
+            table_header=block.table_header,
+        )
+        out.append(nb)
+    return out
+
+
+def _split_text_units(text: str) -> list[str]:
+    """Split text into sentence-like units while preserving punctuation."""
+    # First split by paragraph breaks
+    paras = [p for p in text.split("\n\n") if p.strip()]
+    units: list[str] = []
+    for p in paras:
+        # Chinese/English sentence punctuation
+        pieces = re.split(r"(?<=[。！？；.!?])", p)
+        for s in pieces:
+            ss = s.strip()
+            if ss:
+                units.append(ss)
+    return units if units else [text]
+
+
+def _merge_units_by_token_limit(units: list[str], max_tokens: int) -> list[str]:
+    merged: list[str] = []
+    cur: list[str] = []
+    cur_tokens = 0
+
+    for u in units:
+        ut = estimate_tokens(u)
+        if cur and cur_tokens + ut > max_tokens:
+            merged.append("\n\n".join(cur))
+            cur = [u]
+            cur_tokens = ut
+        else:
+            cur.append(u)
+            cur_tokens += ut
+
+    if cur:
+        merged.append("\n\n".join(cur))
+    return merged
+
+
+def _char_level_split(text: str, max_tokens: int) -> list[str]:
+    """Emergency split by chars when sentence units are still too large."""
+    if not text:
+        return [text]
+    # Conservative char window for Chinese-heavy text
+    window = max(200, int(max_tokens / 1.0))
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        j = min(i + window, n)
+        # try backtrack to punctuation
+        k = max(text.rfind("。", i, j), text.rfind("；", i, j), text.rfind("\n", i, j))
+        if k > i + 50:
+            j = k + 1
+        out.append(text[i:j].strip())
+        i = j
+    return [x for x in out if x]
+
+
+# ── Stage D: Small block merging ─────────────────────────────────────
+def _is_heading_only_block(block: Block) -> bool:
+    if not block.content_parts:
+        return False
+    content = block.content.strip()
+    heading = (block.heading or "").strip()
+    if not heading:
+        return False
+    # Exactly heading-only or heading + tiny punctuation tail
+    if content == heading:
+        return True
+    if len(content) <= len(heading) + 4 and content.startswith(heading):
+        return True
+    return False
+
+
+def _is_isolated_small_block(block: Block) -> bool:
+    """True only for absorbable tiny fragments (not normal正文块)."""
+    if _is_heading_only_block(block):
+        return True
+    # Aggressively absorb tiny directory/title fragments (<100 tokens).
+    if (
+        block.tokens < 100
+        and block.table_chunk_role == "none"
+        and not any(
+            isinstance(part, str)
+            and part.startswith("<table>")
+            and part.endswith("</table>")
+            for part in block.content_parts
+        )
+    ):
+        return True
+    if block.tokens >= SMALL_TAIL_THRESHOLD:
+        return False
+
+    # Must have heading-style structure and very short body tail.
+    heading = (block.heading or "").strip()
+    if not heading or not block.content_parts:
+        return False
+    first = (block.content_parts[0] or "").strip()
+    if first != heading:
+        return False
+
+    # Allow absorbing only when body is extremely short (e.g., stray sentence)
+    if len(block.content_parts) <= 2:
+        body = (block.content_parts[1] if len(block.content_parts) == 2 else "").strip()
+        return estimate_tokens(body) <= 200
+
+    return False
+
+
+def _is_parent_child(prev: Block, nxt: Block) -> bool:
+    """Whether nxt is likely a child section block of prev."""
+    if nxt.level != prev.level + 1:
+        return False
+    if not prev.heading:
+        return False
+    return prev.heading in (nxt.parent_headings or [])
+
+
+def _merge_into_left(left: Block, right: Block) -> Block:
+    """Merge right block into left block (append content)."""
+    left.content_parts.extend(right.content_parts)
+    left.uuid_end = right.uuid_end or left.uuid_end
+    # Keep table metadata conservative
+    if left.table_header is None and right.table_header is not None:
+        left.table_header = right.table_header
+    return left
+
+
+def _merge_into_right(left: Block, right: Block) -> Block:
+    """Merge left block into right block (prepend content)."""
+    right.content_parts = left.content_parts + right.content_parts
+    right.uuid = left.uuid or right.uuid
+    if right.table_header is None and left.table_header is not None:
+        right.table_header = left.table_header
+    return right
+
+
+def _target_distance(tokens: int) -> int:
+    return abs(tokens - IDEAL_BLOCK_CONTENT_TOKENS)
+
+
+def _absorb_isolated_small_blocks(blocks: list[Block]) -> list[Block]:
+    """Absorb heading-only or very small blocks, preferring child-neighbor.
+
+    This directly addresses fragments like:
+      3.3 (tiny heading-only block) + 3.3.1 (large child block)
+    """
+    if len(blocks) < 2:
+        return blocks
+
+    work = list(blocks)
+    i = 0
+    while i < len(work):
+        cur = work[i]
+        if not _is_isolated_small_block(cur) or cur.table_chunk_role == "middle":
+            i += 1
+            continue
+
+        left_idx = i - 1 if i - 1 >= 0 else None
+        right_idx = i + 1 if i + 1 < len(work) else None
+
+        left = work[left_idx] if left_idx is not None else None
+        right = work[right_idx] if right_idx is not None else None
+
+        # Build candidates
+        candidates: list[tuple[str, int]] = []  # (direction, score)
+        if left is not None and left.table_chunk_role != "middle":
+            if left.tokens + cur.tokens <= MAX_BLOCK_CONTENT_TOKENS:
+                score = _target_distance(left.tokens + cur.tokens)
+                candidates.append(("left", score))
+        if right is not None and right.table_chunk_role != "middle":
+            if right.tokens + cur.tokens <= MAX_BLOCK_CONTENT_TOKENS:
+                score = _target_distance(right.tokens + cur.tokens)
+                # Prefer parent->child absorption (e.g., 3.3 -> 3.3.1)
+                if _is_parent_child(cur, right):
+                    score -= 10_000
+                candidates.append(("right", score))
+
+        if not candidates:
+            i += 1
+            continue
+
+        direction = min(candidates, key=lambda x: x[1])[0]
+        if direction == "right" and right_idx is not None:
+            work[right_idx] = _merge_into_right(cur, work[right_idx])
+            del work[i]
+            # keep i at current index to re-check merged right
+        elif direction == "left" and left_idx is not None:
+            work[left_idx] = _merge_into_left(work[left_idx], cur)
+            del work[i]
+            i = max(left_idx, 0)
+        else:
+            i += 1
+
+    return work
+
+
+def _stage_d_merge(blocks: list[Block]) -> list[Block]:
+    """Merge small consecutive blocks while respecting constraints."""
+    if not blocks:
+        return blocks
+
+    # Pass 1: absorb isolated tiny/heading-only blocks
+    premerged = _absorb_isolated_small_blocks(blocks)
+    if not premerged:
+        return premerged
+
+    # Pass 2: regular same-level merge with IDEAL target preference (left-fold)
+    result: list[Block] = [premerged[0]]
+
+    for i in range(1, len(premerged)):
+        current = premerged[i]
+        prev = result[-1]
+
+        # Never merge into/from middle table slices
+        if prev.table_chunk_role == "middle" or current.table_chunk_role == "middle":
+            result.append(current)
+            continue
+
+        # Check if mergeable: same level or compatible levels
+        can_merge = (
+            prev.tokens + current.tokens <= MAX_BLOCK_CONTENT_TOKENS
+            and prev.level == current.level
+        )
+
+        if can_merge:
+            prev.content_parts.extend(current.content_parts)
+            prev.uuid_end = current.uuid_end or prev.uuid_end
+        else:
+            result.append(current)
+
+    # Tail absorption: absorb tiny trailing blocks
+    if len(result) >= 2:
+        last = result[-1]
+        second_last = result[-2]
+        if (
+            last.tokens < SMALL_TAIL_THRESHOLD
+            and second_last.tokens + last.tokens <= MAX_BLOCK_CONTENT_TOKENS
+            and last.table_chunk_role != "middle"
+            and second_last.table_chunk_role != "middle"
+        ):
+            second_last.content_parts.extend(last.content_parts)
+            second_last.uuid_end = last.uuid_end or second_last.uuid_end
+            result.pop()
+
+    return result
+
+
+def _stage_e_extraction_safety_split(blocks: list[Block]) -> list[Block]:
+    """Final split pass for extraction safety while preserving heading hierarchy."""
+    if EXTRACTION_SAFE_MAX_BLOCK_TOKENS <= 0:
+        return blocks
+
+    result: list[Block] = []
+    for block in blocks:
+        if block.tokens <= EXTRACTION_SAFE_MAX_BLOCK_TOKENS:
+            result.append(block)
+            continue
+
+        # Keep table chunks as-is to avoid breaking table payload structure.
+        if any(
+            isinstance(part, str)
+            and part.startswith("<table>")
+            and part.endswith("</table>")
+            for part in block.content_parts
+        ):
+            result.append(block)
+            continue
+
+        result.extend(
+            _force_split_oversize_block(
+                block=block, max_tokens=EXTRACTION_SAFE_MAX_BLOCK_TOKENS
+            )
+        )
+    return result
+
+
+# ── Public API ───────────────────────────────────────────────────────
+def smart_chunk(paragraphs: list[Paragraph]) -> list[Block]:
+    """Run the full smart chunking pipeline."""
+    blocks = _stage_a_heading_split(paragraphs)
+    blocks = _stage_b_table_slice(blocks)
+    blocks = _stage_c_anchor_split(blocks)
+    blocks = _stage_d_merge(blocks)
+    blocks = _stage_e_extraction_safety_split(blocks)
+    return blocks

--- a/lightrag/extraction/token_estimation.py
+++ b/lightrag/extraction/token_estimation.py
@@ -1,0 +1,31 @@
+"""Heuristic token estimator – see docx-extraction-guide-zh.md Appendix."""
+
+from __future__ import annotations
+
+import re
+
+_CJK_RE = re.compile(
+    r"[\u4e00-\u9fff\u3400-\u4dbf\u2e80-\u2eff\u3000-\u303f"
+    r"\uff00-\uffef\u2000-\u206f]"
+)
+_JSON_STRUCT_RE = re.compile(r'[{}\[\],:"\']')
+
+
+def estimate_tokens(text: str) -> int:
+    """Return a rough token count without calling a real tokenizer.
+
+    Rules (from the guide):
+    - CJK chars  ≈ 0.75 token each
+    - JSON / HTML structural chars ≈ 1 token each
+    - Other chars ≈ 0.4 token each
+    - +5 % buffer + 10 fixed offset
+    """
+    if not text:
+        return 0
+
+    cjk_count = len(_CJK_RE.findall(text))
+    json_count = len(_JSON_STRUCT_RE.findall(text))
+    other_count = len(text) - cjk_count - json_count
+
+    raw = cjk_count * 0.75 + json_count * 1.0 + other_count * 0.4
+    return int(raw * 1.05 + 10)

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -5,11 +5,25 @@ import asyncio
 import configparser
 import inspect
 import os
+import json
+import re
+import fnmatch
+import hashlib
+import base64
+import mimetypes
+import sys
 import time
 import warnings
+from copy import deepcopy
+
+try:
+    import httpx
+except Exception:  # pragma: no cover - optional dependency
+    httpx = None
 from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timezone
 from functools import partial
+from pathlib import Path
 from typing import (
     Any,
     AsyncIterator,
@@ -41,7 +55,6 @@ from lightrag.constants import (
     DEFAULT_SUMMARY_MAX_TOKENS,
     DEFAULT_SUMMARY_CONTEXT_SIZE,
     DEFAULT_SUMMARY_LENGTH_RECOMMENDED,
-    DEFAULT_MAX_EXTRACT_INPUT_TOKENS,
     DEFAULT_MAX_ASYNC,
     DEFAULT_MAX_PARALLEL_INSERT,
     DEFAULT_MAX_GRAPH_NODES,
@@ -53,6 +66,11 @@ from lightrag.constants import (
     DEFAULT_EMBEDDING_TIMEOUT,
     DEFAULT_SOURCE_IDS_LIMIT_METHOD,
     DEFAULT_MAX_FILE_PATHS,
+    FULL_DOCS_FORMAT_RAW,
+    FULL_DOCS_FORMAT_LIGHTRAG,
+    FULL_DOCS_FORMAT_PENDING_PARSE,
+    PARSED_DIR_NAME,
+    DEFAULT_MAX_PARALLEL_ANALYZE,
     DEFAULT_FILE_PATH_MORE_PLACEHOLDER,
 )
 from lightrag.utils import get_env_value
@@ -115,6 +133,7 @@ from lightrag.utils import (
 )
 from lightrag.types import KnowledgeGraph
 from dotenv import load_dotenv
+from lightrag.extraction.interchange import parse_interchange_jsonl
 
 # use the .env that is inside the current folder
 # allows to use different .env file for each lightrag instance
@@ -168,6 +187,140 @@ def _normalize_string_list(raw_values: Any, context: str = "") -> list[str]:
                 value,
             )
     return result
+
+
+def _split_text_units_for_hard_fallback(text: str) -> list[str]:
+    """Split text into sentence/paragraph-like units for fallback chunking."""
+    if not text:
+        return []
+    units: list[str] = []
+    for para in text.split("\n\n"):
+        p = para.strip()
+        if not p:
+            continue
+        for sentence in re.split(r"(?<=[。！？；.!?])", p):
+            s = sentence.strip()
+            if s:
+                units.append(s)
+    return units if units else [text]
+
+
+def _split_text_by_token_limit(
+    text: str, tokenizer: Tokenizer, max_tokens: int
+) -> list[str]:
+    """Split text by token limit with sentence-first, token-window fallback."""
+    if not text:
+        return []
+
+    try:
+        total_tokens = len(tokenizer.encode(text))
+    except Exception:
+        total_tokens = 0
+
+    if total_tokens > 0 and total_tokens <= max_tokens:
+        return [text]
+
+    units = _split_text_units_for_hard_fallback(text)
+    out: list[str] = []
+    cur_parts: list[str] = []
+    cur_tokens = 0
+
+    for unit in units:
+        try:
+            unit_tokens = len(tokenizer.encode(unit))
+        except Exception:
+            unit_tokens = 0
+
+        # Sentence itself is oversize: token-window split directly.
+        if unit_tokens > max_tokens:
+            if cur_parts:
+                out.append("\n\n".join(cur_parts))
+                cur_parts = []
+                cur_tokens = 0
+
+            token_ids = tokenizer.encode(unit)
+            for start in range(0, len(token_ids), max_tokens):
+                piece = tokenizer.decode(token_ids[start : start + max_tokens]).strip()
+                if piece:
+                    out.append(piece)
+            continue
+
+        if cur_parts and cur_tokens + unit_tokens > max_tokens:
+            out.append("\n\n".join(cur_parts))
+            cur_parts = [unit]
+            cur_tokens = unit_tokens
+        else:
+            cur_parts.append(unit)
+            cur_tokens += unit_tokens
+
+    if cur_parts:
+        out.append("\n\n".join(cur_parts))
+
+    return [x for x in out if x.strip()]
+
+
+def _enforce_chunk_token_limit_before_embedding(
+    chunking_result: list[dict[str, Any]] | tuple[dict[str, Any], ...],
+    tokenizer: Tokenizer,
+    max_tokens: int,
+) -> list[dict[str, Any]]:
+    """Hard fallback split before embedding while preserving heading hierarchy."""
+    if max_tokens <= 0:
+        return list(chunking_result)
+
+    normalized: list[dict[str, Any]] = []
+
+    for dp in chunking_result:
+        if not isinstance(dp, dict):
+            continue
+
+        content = dp.get("content", "")
+        if not isinstance(content, str) or not content.strip():
+            continue
+
+        try:
+            token_count = len(tokenizer.encode(content))
+        except Exception:
+            token_count = (
+                dp.get("tokens", 0) if isinstance(dp.get("tokens"), int) else 0
+            )
+
+        if token_count <= max_tokens:
+            ndp = dict(dp)
+            ndp["tokens"] = token_count if token_count > 0 else ndp.get("tokens", 0)
+            normalized.append(ndp)
+            continue
+
+        pieces = _split_text_by_token_limit(content, tokenizer, max_tokens)
+        if not pieces:
+            ndp = dict(dp)
+            ndp["tokens"] = token_count
+            normalized.append(ndp)
+            continue
+
+        base_chunk_id = dp.get("chunk_id")
+        total_parts = len(pieces)
+        for i, piece in enumerate(pieces, 1):
+            new_dp = dict(dp)
+            new_dp["content"] = piece
+            try:
+                new_dp["tokens"] = len(tokenizer.encode(piece))
+            except Exception:
+                new_dp["tokens"] = max(1, int(len(piece) * 0.5))
+
+            # Keep heading/parent_headings/level unchanged; only split payload.
+            if isinstance(base_chunk_id, str) and base_chunk_id.strip():
+                new_dp["chunk_id"] = f"{base_chunk_id}-s{i:02d}"
+
+            new_dp["split_type"] = "hard_fallback"
+            new_dp["split_part"] = i
+            new_dp["split_total"] = total_parts
+            normalized.append(new_dp)
+
+    # Rebuild order index to keep continuity after splitting.
+    for idx, item in enumerate(normalized):
+        item["chunk_order_index"] = idx
+    return normalized
 
 
 @final
@@ -255,13 +408,6 @@ class LightRAG:
         default=get_env_value("MAX_GLEANING", DEFAULT_MAX_GLEANING, int)
     )
     """Maximum number of entity extraction attempts for ambiguous content."""
-
-    max_extract_input_tokens: int = field(
-        default=get_env_value(
-            "MAX_EXTRACT_INPUT_TOKENS", DEFAULT_MAX_EXTRACT_INPUT_TOKENS, int
-        )
-    )
-    """Maximum tokens allowed for entity extraction input context."""
 
     force_llm_summary_on_merge: int = field(
         default=get_env_value(
@@ -365,6 +511,44 @@ class LightRAG:
     llm_model_func: Callable[..., object] | None = field(default=None)
     """Function for interacting with the large language model (LLM). Must be set before use."""
 
+    extract_llm_model_func: Callable[..., object] | None = field(default=None)
+    """LLM function for extraction role (entity/relation extraction + summaries)."""
+
+    keyword_llm_model_func: Callable[..., object] | None = field(default=None)
+    """LLM function for keyword extraction role."""
+
+    query_llm_model_func: Callable[..., object] | None = field(default=None)
+    """LLM function for final answer/query role."""
+
+    vlm_llm_model_func: Callable[..., object] | None = field(default=None)
+    """VLM (vision-language) model for multimodal analysis (images/tables/equations).
+    Used in analyze_multimodal phase. When Ray-Anything merges, bind here as the VLM role."""
+
+    vlm_llm_model_max_async: int | None = field(
+        default_factory=lambda: int(os.environ["MAX_ASYNC_VLM_LLM"]) if "MAX_ASYNC_VLM_LLM" in os.environ else None
+    )
+    """Max concurrent VLM calls in analyze_multimodal."""
+
+    extract_llm_model_max_async: int | None = field(
+        default_factory=lambda: int(os.environ["MAX_ASYNC_EXTRACT_LLM"]) if "MAX_ASYNC_EXTRACT_LLM" in os.environ else None
+    )
+    """Max concurrent LLM calls for entity/relation extraction."""
+
+    keyword_llm_model_max_async: int | None = field(
+        default_factory=lambda: int(os.environ["MAX_ASYNC_KEYWORD_LLM"]) if "MAX_ASYNC_KEYWORD_LLM" in os.environ else None
+    )
+    """Max concurrent LLM calls for keyword extraction."""
+
+    query_llm_model_max_async: int | None = field(
+        default_factory=lambda: int(os.environ["MAX_ASYNC_QUERY_LLM"]) if "MAX_ASYNC_QUERY_LLM" in os.environ else None
+    )
+    """Max concurrent LLM calls for query/answer generation."""
+
+    extract_llm_timeout: int | None = field(default=None)
+    keyword_llm_timeout: int | None = field(default=None)
+    query_llm_timeout: int | None = field(default=None)
+    vlm_llm_timeout: int | None = field(default=None)
+
     llm_model_name: str = field(default="gpt-4o-mini")
     """Name of the LLM model used for generating responses."""
 
@@ -393,9 +577,30 @@ class LightRAG:
     llm_model_kwargs: dict[str, Any] = field(default_factory=dict)
     """Additional keyword arguments passed to the LLM model function."""
 
+    extract_llm_model_kwargs: dict[str, Any] | None = field(default=None)
+    """Additional kwargs for extract role LLM. Falls back to llm_model_kwargs if None."""
+
+    keyword_llm_model_kwargs: dict[str, Any] | None = field(default=None)
+    """Additional kwargs for keyword role LLM. Falls back to llm_model_kwargs if None."""
+
+    query_llm_model_kwargs: dict[str, Any] | None = field(default=None)
+    """Additional kwargs for query role LLM. Falls back to llm_model_kwargs if None."""
+
+    vlm_llm_model_kwargs: dict[str, Any] | None = field(default=None)
+    """Additional kwargs for VLM role LLM. Falls back to llm_model_kwargs if None."""
+
     default_llm_timeout: int = field(
         default=int(os.getenv("LLM_TIMEOUT", DEFAULT_LLM_TIMEOUT))
     )
+
+    entity_extraction_use_json: bool = field(
+        default=os.getenv("ENTITY_EXTRACTION_USE_JSON", "true").lower() == "true"
+    )
+    """When True, entity extraction uses JSON structured output instead of delimiter-based text.
+    JSON mode significantly improves extraction quality and compatibility with smaller models.
+    Providers with native structured output support (OpenAI, Ollama, Gemini) will use their
+    native capabilities. Other providers rely on JSON-formatted prompts with json_repair parsing.
+    Default: True. Set ENTITY_EXTRACTION_USE_JSON=false in .env to disable."""
 
     # Rerank Configuration
     # ---
@@ -427,6 +632,23 @@ class LightRAG:
         default=int(os.getenv("MAX_PARALLEL_INSERT", DEFAULT_MAX_PARALLEL_INSERT))
     )
     """Maximum number of parallel insert operations."""
+
+    max_parallel_parse_native: int = field(
+        default=int(os.getenv("MAX_PARALLEL_PARSE_NATIVE", "5"))
+    )
+    max_parallel_parse_mineru: int = field(
+        default=int(os.getenv("MAX_PARALLEL_PARSE_MINERU", "3"))
+    )
+    max_parallel_parse_docling: int = field(
+        default=int(os.getenv("MAX_PARALLEL_PARSE_DOCLING", "3"))
+    )
+    max_parallel_analyze: int = field(
+        default=int(
+            os.getenv("MAX_PARALLEL_ANALYZE", str(DEFAULT_MAX_PARALLEL_ANALYZE))
+        )
+    )
+    queue_size_default: int = field(default=int(os.getenv("QUEUE_SIZE_DEFAULT", "100")))
+    queue_size_insert: int = field(default=int(os.getenv("QUEUE_SIZE_INSERT", "4")))
 
     max_graph_nodes: int = field(
         default=get_env_value("MAX_GRAPH_NODES", DEFAULT_MAX_GRAPH_NODES, int)
@@ -492,6 +714,211 @@ class LightRAG:
     """Configuration for Ollama server information."""
 
     _storages_status: StoragesStatus = field(default=StoragesStatus.NOT_CREATED)
+
+    @staticmethod
+    def _normalize_llm_role(role: str) -> str:
+        normalized = role.strip().lower()
+        if normalized not in {"extract", "keyword", "query", "vlm"}:
+            raise ValueError(f"Invalid LLM role: {role}")
+        return normalized
+
+    def register_role_llm_builder(
+        self,
+        builder: Callable[
+            [str, dict[str, Any]], tuple[Callable[..., object], dict[str, Any] | None]
+        ],
+    ) -> None:
+        """Register a runtime builder used by update_llm_role_config for binding/model updates."""
+        self._llm_role_builder = builder
+
+    def set_role_llm_metadata(self, role: str, **metadata: Any) -> None:
+        """Store role metadata used when rebuilding a role-specific LLM function."""
+        role = self._normalize_llm_role(role)
+        if not hasattr(self, "_role_llm_runtime_meta"):
+            self._role_llm_runtime_meta = {}
+        existing = dict(self._role_llm_runtime_meta.get(role, {}))
+        existing.update({k: v for k, v in metadata.items() if v is not None})
+        self._role_llm_runtime_meta[role] = existing
+
+    def _role_llm_kwargs_attr(self, role: str) -> str:
+        return f"{self._normalize_llm_role(role)}_llm_model_kwargs"
+
+    def _role_llm_max_async_attr(self, role: str) -> str:
+        normalized = self._normalize_llm_role(role)
+        if normalized == "vlm":
+            return "vlm_llm_model_max_async"
+        return f"{normalized}_llm_model_max_async"
+
+    def _role_llm_timeout_attr(self, role: str) -> str:
+        return f"{self._normalize_llm_role(role)}_llm_timeout"
+
+    def _get_effective_role_llm_kwargs(self, role: str) -> dict[str, Any]:
+        stored = getattr(self, self._role_llm_kwargs_attr(role))
+        if stored is not None:
+            return stored
+
+        role_meta = getattr(self, "_role_llm_runtime_meta", {}).get(
+            self._normalize_llm_role(role), {}
+        )
+        if role_meta.get("is_cross_provider"):
+            return {}
+
+        return self.llm_model_kwargs
+
+    def _get_effective_role_llm_timeout(self, role: str) -> int | None:
+        return getattr(self, self._role_llm_timeout_attr(role))
+
+    def _get_effective_role_llm_max_async(self, role: str) -> int:
+        max_async = getattr(self, self._role_llm_max_async_attr(role))
+        return max_async if max_async is not None else self.llm_model_max_async
+
+    def _wrap_llm_role_func(
+        self,
+        role_name: str,
+        raw_func: Callable[..., object],
+        max_async: int,
+        timeout: int | None,
+        model_kwargs: dict[str, Any],
+    ) -> Callable[..., object]:
+        return priority_limit_async_func_call(
+            max_async,
+            llm_timeout=timeout,
+            queue_name=f"{role_name} LLM func",
+        )(
+            partial(
+                raw_func,
+                hashing_kv=self.llm_response_cache,
+                **model_kwargs,
+            )
+        )
+
+    def _rebuild_all_role_llm_funcs(self) -> None:
+        base_raw = self._raw_llm_model_func
+        self.llm_model_func = self._wrap_llm_role_func(
+            "base",
+            base_raw,
+            self.llm_model_max_async,
+            self.default_llm_timeout,
+            self.llm_model_kwargs,
+        )
+
+        for role in ("extract", "keyword", "query", "vlm"):
+            raw_func = self._raw_role_llm_funcs.get(role) or base_raw
+            wrapped = self._wrap_llm_role_func(
+                role,
+                raw_func,
+                self._get_effective_role_llm_max_async(role),
+                self._get_effective_role_llm_timeout(role),
+                self._get_effective_role_llm_kwargs(role),
+            )
+            setattr(self, f"{role}_llm_model_func", wrapped)
+
+    def _rebuild_single_role_llm_func(self, role: str) -> None:
+        role = self._normalize_llm_role(role)
+        raw_func = self._raw_role_llm_funcs.get(role) or self._raw_llm_model_func
+        wrapped = self._wrap_llm_role_func(
+            role,
+            raw_func,
+            self._get_effective_role_llm_max_async(role),
+            self._get_effective_role_llm_timeout(role),
+            self._get_effective_role_llm_kwargs(role),
+        )
+        setattr(self, f"{role}_llm_model_func", wrapped)
+
+    def update_llm_role_config(
+        self,
+        role: str,
+        *,
+        model_func: Callable[..., object] | None = None,
+        model_kwargs: dict[str, Any] | None = None,
+        max_async: int | None = None,
+        timeout: int | None = None,
+        binding: str | None = None,
+        model: str | None = None,
+        host: str | None = None,
+        api_key: str | None = None,
+        provider_options: dict[str, Any] | None = None,
+    ) -> None:
+        """
+        Update a role-specific LLM configuration at runtime.
+
+        Supports lightweight updates (kwargs/max_async/timeout/model_func) directly.
+        For binding/model/host/api_key/provider_options updates, a role builder must
+        be registered via register_role_llm_builder().
+        """
+        role = self._normalize_llm_role(role)
+        kwargs_attr = self._role_llm_kwargs_attr(role)
+        max_async_attr = self._role_llm_max_async_attr(role)
+        timeout_attr = self._role_llm_timeout_attr(role)
+        func_attr = f"{role}_llm_model_func"
+
+        snapshot = {
+            "raw_func": self._raw_role_llm_funcs.get(role),
+            "wrapped_func": getattr(self, func_attr),
+            "model_kwargs": deepcopy(getattr(self, kwargs_attr)),
+            "max_async": getattr(self, max_async_attr),
+            "timeout": getattr(self, timeout_attr),
+            "meta": deepcopy(getattr(self, "_role_llm_runtime_meta", {}).get(role, {})),
+        }
+
+        if not hasattr(self, "_role_llm_runtime_meta"):
+            self._role_llm_runtime_meta = {}
+
+        try:
+            if model_func is not None and not callable(model_func):
+                raise TypeError("model_func must be callable")
+
+            if model_kwargs is not None:
+                setattr(self, kwargs_attr, model_kwargs)
+            if max_async is not None:
+                setattr(self, max_async_attr, max_async)
+            if timeout is not None:
+                setattr(self, timeout_attr, timeout)
+            if model_func is not None:
+                self._raw_role_llm_funcs[role] = model_func
+
+            metadata_updated = any(
+                value is not None
+                for value in (binding, model, host, api_key, provider_options)
+            )
+            role_meta = deepcopy(self._role_llm_runtime_meta.get(role, {}))
+            if binding is not None:
+                role_meta["binding"] = binding
+            if model is not None:
+                role_meta["model"] = model
+            if host is not None:
+                role_meta["host"] = host
+            if api_key is not None:
+                role_meta["api_key"] = api_key
+            if provider_options is not None:
+                role_meta["provider_options"] = provider_options
+            if "base_binding" in role_meta and "binding" in role_meta:
+                role_meta["is_cross_provider"] = (
+                    role_meta["binding"] != role_meta["base_binding"]
+                )
+
+            if metadata_updated:
+                builder = getattr(self, "_llm_role_builder", None)
+                if builder is None and model_func is None:
+                    raise ValueError(
+                        "Runtime role builder is not configured; provide model_func or register_role_llm_builder() first"
+                    )
+                if builder is not None:
+                    built_func, built_kwargs = builder(role, role_meta)
+                    self._raw_role_llm_funcs[role] = built_func
+                    if model_kwargs is None and built_kwargs is not None:
+                        setattr(self, kwargs_attr, built_kwargs)
+
+            self._role_llm_runtime_meta[role] = role_meta
+            self._rebuild_single_role_llm_func(role)
+        except Exception:
+            self._raw_role_llm_funcs[role] = snapshot["raw_func"]
+            setattr(self, func_attr, snapshot["wrapped_func"])
+            setattr(self, kwargs_attr, snapshot["model_kwargs"])
+            setattr(self, max_async_attr, snapshot["max_async"])
+            setattr(self, timeout_attr, snapshot["timeout"])
+            self._role_llm_runtime_meta[role] = snapshot["meta"]
+            raise
 
     def __post_init__(self):
         from lightrag.kg.shared_storage import (
@@ -701,21 +1128,21 @@ class LightRAG:
             embedding_func=None,
         )
 
-        # Directly use llm_response_cache, don't create a new object
-        hashing_kv = self.llm_response_cache
+        # Build base + role-isolated LLM wrappers (independent queues per role).
+        base_llm_func = self.llm_model_func
+        if base_llm_func is None:
+            raise ValueError("llm_model_func must be provided")
 
-        # Get timeout from LLM model kwargs for dynamic timeout calculation
-        self.llm_model_func = priority_limit_async_func_call(
-            self.llm_model_max_async,
-            llm_timeout=self.default_llm_timeout,
-            queue_name="LLM func",
-        )(
-            partial(
-                self.llm_model_func,  # type: ignore
-                hashing_kv=hashing_kv,
-                **self.llm_model_kwargs,
-            )
-        )
+        self._llm_role_builder = None
+        self._role_llm_runtime_meta: dict[str, dict[str, Any]] = {}
+        self._raw_llm_model_func = base_llm_func
+        self._raw_role_llm_funcs: dict[str, Callable[..., object]] = {
+            "extract": self.extract_llm_model_func or base_llm_func,
+            "keyword": self.keyword_llm_model_func or base_llm_func,
+            "query": self.query_llm_model_func or base_llm_func,
+            "vlm": self.vlm_llm_model_func or base_llm_func,
+        }
+        self._rebuild_all_role_llm_funcs()
 
         self._storages_status = StoragesStatus.CREATED
 
@@ -1312,20 +1739,24 @@ class LightRAG:
         ids: list[str] | None = None,
         file_paths: str | list[str] | None = None,
         track_id: str | None = None,
+        docs_format: str = FULL_DOCS_FORMAT_RAW,
+        lightrag_document_paths: str | list[str] | None = None,
     ) -> str:
         """
         Pipeline for Processing Documents
 
-        1. Validate ids if provided or generate MD5 hash IDs and remove duplicate contents
+        1. Validate ids if provided or generate MD5 hash IDs and remove duplicate contents (skip content dedup when format is lightrag)
         2. Generate document initial status
         3. Filter out already processed documents
         4. Enqueue document in status
 
         Args:
-            input: Single document string or list of document strings
-            ids: list of unique document IDs, if not provided, MD5 hash IDs will be generated
+            input: Single document string or list of document strings (can be empty when docs_format is lightrag)
+            ids: list of unique document IDs, if not provided, MD5 hash IDs will be generated (from content or file_path when lightrag)
             file_paths: list of file paths corresponding to each document, used for citation
-            track_id: tracking ID for monitoring processing status, if not provided, will be generated with "enqueue" prefix
+            track_id: tracking ID for monitoring processing status
+            docs_format: "raw" (default) or "lightrag"; when "lightrag" content may be empty and content-dedup is skipped
+            lightrag_document_paths: paths to LightRAG Document (e.g. .blocks.jsonl dir or base path), when docs_format is lightrag
 
         Returns:
             str: tracking ID for monitoring processing status
@@ -1339,6 +1770,10 @@ class LightRAG:
             ids = [ids]
         if isinstance(file_paths, str):
             file_paths = [file_paths]
+        if isinstance(lightrag_document_paths, str):
+            lightrag_document_paths = (
+                [lightrag_document_paths] if lightrag_document_paths else None
+            )
 
         # If file_paths is provided, ensure it matches the number of documents
         if file_paths is not None:
@@ -1353,19 +1788,43 @@ class LightRAG:
             ]
             file_paths = [path if path else "unknown_source" for path in file_paths]
         else:
-            # If no file paths provided, use placeholder
             file_paths = ["unknown_source"] * len(input)
 
-        # 1. Validate ids if provided or generate MD5 hash IDs and remove duplicate contents
+        is_lightrag_format = docs_format == FULL_DOCS_FORMAT_LIGHTRAG
+        if is_lightrag_format and lightrag_document_paths is not None:
+            if len(lightrag_document_paths) != len(input):
+                raise ValueError(
+                    "Number of lightrag_document_paths must match the number of documents"
+                )
+
+        # 1. Validate ids and build contents (when lightrag: no content dedup, content may be empty)
         if ids is not None:
-            # Check if the number of IDs matches the number of documents
             if len(ids) != len(input):
                 raise ValueError("Number of IDs must match the number of documents")
-
-            # Check if IDs are unique
             if len(ids) != len(set(ids)):
                 raise ValueError("IDs must be unique")
 
+        if is_lightrag_format:
+            # LightRAG Document: no content hash dedup; content may be empty
+            contents = {}
+            for i in range(len(file_paths)):
+                path = file_paths[i]
+                doc_id = (
+                    ids[i]
+                    if ids is not None
+                    else compute_mdhash_id(path, prefix="doc-")
+                )
+                lightrag_path = (
+                    lightrag_document_paths[i] if lightrag_document_paths else ""
+                ) or path
+                content_str = (input[i] or "").strip() if i < len(input) else ""
+                contents[doc_id] = {
+                    "content": content_str,
+                    "file_path": path,
+                    "format": FULL_DOCS_FORMAT_LIGHTRAG,
+                    "lightrag_document_path": lightrag_path,
+                }
+        elif ids is not None:
             # Generate contents dict and remove duplicates in one pass
             unique_contents = {}
             for id_, doc, path in zip(ids, input, file_paths):
@@ -1373,11 +1832,27 @@ class LightRAG:
                 if cleaned_content not in unique_contents:
                     unique_contents[cleaned_content] = (id_, path)
 
-            # Reconstruct contents with unique content
             contents = {
-                id_: {"content": content, "file_path": file_path}
+                id_: {
+                    "content": content,
+                    "file_path": file_path,
+                    "format": FULL_DOCS_FORMAT_RAW,
+                }
                 for content, (id_, file_path) in unique_contents.items()
             }
+        elif docs_format == FULL_DOCS_FORMAT_PENDING_PARSE:
+            contents = {}
+            for i, (doc, path) in enumerate(zip(input, file_paths)):
+                doc_id = (
+                    ids[i]
+                    if ids is not None
+                    else compute_mdhash_id(path, prefix="doc-")
+                )
+                contents[doc_id] = {
+                    "content": doc or "",
+                    "file_path": path,
+                    "format": FULL_DOCS_FORMAT_PENDING_PARSE,
+                }
         else:
             # Clean input text and remove duplicates in one pass
             unique_content_with_paths = {}
@@ -1386,11 +1861,11 @@ class LightRAG:
                 if cleaned_content not in unique_content_with_paths:
                     unique_content_with_paths[cleaned_content] = path
 
-            # Generate contents dict of MD5 hash IDs and documents with paths
             contents = {
                 compute_mdhash_id(content, prefix="doc-"): {
                     "content": content,
                     "file_path": path,
+                    "format": FULL_DOCS_FORMAT_RAW,
                 }
                 for content, path in unique_content_with_paths.items()
             }
@@ -1399,14 +1874,12 @@ class LightRAG:
         new_docs: dict[str, Any] = {
             id_: {
                 "status": DocStatus.PENDING,
-                "content_summary": get_content_summary(content_data["content"]),
-                "content_length": len(content_data["content"]),
+                "content_summary": get_content_summary(content_data.get("content", "")),
+                "content_length": len(content_data.get("content", "")),
                 "created_at": datetime.now(timezone.utc).isoformat(),
                 "updated_at": datetime.now(timezone.utc).isoformat(),
-                "file_path": content_data[
-                    "file_path"
-                ],  # Store file path in document status
-                "track_id": track_id,  # Store track_id in document status
+                "file_path": content_data["file_path"],
+                "track_id": track_id,
             }
             for id_, content_data in contents.items()
         }
@@ -1475,14 +1948,19 @@ class LightRAG:
             return
 
         # 4. Store document content in full_docs and status in doc_status
-        #    Store full document content separately
         full_docs_data = {
             doc_id: {
-                "content": contents[doc_id]["content"],
+                "content": contents[doc_id].get("content", ""),
                 "file_path": contents[doc_id]["file_path"],
+                "format": contents[doc_id].get("format", FULL_DOCS_FORMAT_RAW),
             }
             for doc_id in new_docs.keys()
         }
+        for doc_id in new_docs.keys():
+            if contents[doc_id].get("lightrag_document_path"):
+                full_docs_data[doc_id]["lightrag_document_path"] = contents[doc_id][
+                    "lightrag_document_path"
+                ]
         await self.full_docs.upsert(full_docs_data)
         # Persist data to disk immediately
         await self.full_docs.index_done_callback()
@@ -1651,7 +2129,7 @@ class LightRAG:
         #     pipeline_status["latest_message"] = final_message
         #     pipeline_status["history_messages"].append(final_message)
 
-        # Reset PROCESSING and FAILED documents that pass consistency checks to PENDING status
+        # Reset interrupted documents that pass consistency checks to PENDING status
         docs_to_reset = {}
         reset_count = 0
 
@@ -1659,10 +2137,12 @@ class LightRAG:
             # Check if document has corresponding content in full_docs (consistency check)
             content_data = await self.full_docs.get_by_id(doc_id)
             if content_data:  # Document passes consistency check
-                # Check if document is in PROCESSING or FAILED status
+                # Check if document is in interrupted status
                 if hasattr(status_doc, "status") and status_doc.status in [
                     DocStatus.PROCESSING,
                     DocStatus.FAILED,
+                    DocStatus.PARSING,
+                    DocStatus.ANALYZING,
                 ]:
                     preserved_chunks_list, preserved_chunks_count = (
                         _chunk_fields_from_status_doc(status_doc)
@@ -1693,7 +2173,10 @@ class LightRAG:
             await self.doc_status.upsert(docs_to_reset)
 
             async with pipeline_status_lock:
-                reset_message = f"Reset {reset_count} documents from PROCESSING/FAILED to PENDING status"
+                reset_message = (
+                    f"Reset {reset_count} documents from "
+                    "PARSING/ANALYZING/PROCESSING/FAILED to PENDING status"
+                )
                 logger.info(reset_message)
                 pipeline_status["latest_message"] = reset_message
                 pipeline_status["history_messages"].append(reset_message)
@@ -1729,16 +2212,26 @@ class LightRAG:
         async with pipeline_status_lock:
             # Ensure only one worker is processing documents
             if not pipeline_status.get("busy", False):
-                processing_docs, failed_docs, pending_docs = await asyncio.gather(
+                (
+                    processing_docs,
+                    failed_docs,
+                    pending_docs,
+                    parsing_docs,
+                    analyzing_docs,
+                ) = await asyncio.gather(
                     self.doc_status.get_docs_by_status(DocStatus.PROCESSING),
                     self.doc_status.get_docs_by_status(DocStatus.FAILED),
                     self.doc_status.get_docs_by_status(DocStatus.PENDING),
+                    self.doc_status.get_docs_by_status(DocStatus.PARSING),
+                    self.doc_status.get_docs_by_status(DocStatus.ANALYZING),
                 )
 
                 to_process_docs: dict[str, DocProcessingStatus] = {}
                 to_process_docs.update(processing_docs)
                 to_process_docs.update(failed_docs)
                 to_process_docs.update(pending_docs)
+                to_process_docs.update(parsing_docs)
+                to_process_docs.update(analyzing_docs)
 
                 if not to_process_docs:
                     logger.info("No documents to process")
@@ -1846,6 +2339,7 @@ class LightRAG:
                     pipeline_status: dict,
                     pipeline_status_lock: asyncio.Lock,
                     semaphore: asyncio.Semaphore,
+                    pre_parsed_data: dict[str, Any] | None = None,
                 ) -> None:
                     """Process single document"""
                     # Initialize variables at the start to prevent UnboundLocalError in error handling
@@ -1905,45 +2399,225 @@ class LightRAG:
                                         pipeline_status["history_messages"][-5000:]
                                     )
 
-                            # Get document content from full_docs
-                            content_data = await self.full_docs.get_by_id(doc_id)
-                            if not content_data:
-                                raise Exception(
-                                    f"Document content not found in full_docs for doc_id: {doc_id}"
+                            if pre_parsed_data is None:
+                                # ---- Phase 1: PARSING ----
+                                await self.doc_status.upsert(
+                                    {
+                                        doc_id: {
+                                            "status": DocStatus.PARSING,
+                                            "content_summary": status_doc.content_summary,
+                                            "content_length": status_doc.content_length,
+                                            "created_at": status_doc.created_at,
+                                            "updated_at": datetime.now(
+                                                timezone.utc
+                                            ).isoformat(),
+                                            "file_path": file_path,
+                                            "track_id": status_doc.track_id,
+                                        }
+                                    }
                                 )
-                            content = content_data["content"]
 
-                            # Call chunking function, supporting both sync and async implementations
-                            chunking_result = self.chunking_func(
-                                self.tokenizer,
-                                content,
-                                split_by_character,
-                                split_by_character_only,
-                                self.chunk_overlap_token_size,
-                                self.chunk_token_size,
+                                content_data = await self.full_docs.get_by_id(doc_id)
+                                if not content_data:
+                                    raise Exception(
+                                        f"Document content not found in full_docs for doc_id: {doc_id}"
+                                    )
+
+                                parse_engine = self._resolve_parser_engine(
+                                    file_path=file_path, content_data=content_data
+                                )
+                                if parse_engine == "mineru":
+                                    parsed_data = await self.parse_mineru(
+                                        doc_id, file_path, content_data
+                                    )
+                                elif parse_engine == "docling":
+                                    parsed_data = await self.parse_docling(
+                                        doc_id, file_path, content_data
+                                    )
+                                else:
+                                    parsed_data = await self.parse_native(
+                                        doc_id, file_path, content_data
+                                    )
+
+                                content = parsed_data.get("content", "")
+
+                                # ---- Phase 2: ANALYZING ----
+                                await self.doc_status.upsert(
+                                    {
+                                        doc_id: {
+                                            "status": DocStatus.ANALYZING,
+                                            "content_summary": status_doc.content_summary,
+                                            "content_length": len(content),
+                                            "created_at": status_doc.created_at,
+                                            "updated_at": datetime.now(
+                                                timezone.utc
+                                            ).isoformat(),
+                                            "file_path": file_path,
+                                            "track_id": status_doc.track_id,
+                                        }
+                                    }
+                                )
+                                parsed_data = await self.analyze_multimodal(
+                                    doc_id=doc_id,
+                                    file_path=file_path,
+                                    parsed_data=parsed_data,
+                                )
+                            else:
+                                parsed_data = pre_parsed_data
+                                content = parsed_data.get("content", "")
+
+                            extraction_meta: dict[str, Any] = {}
+
+                            # Try to parse as interchange JSONL (smart extraction output)
+                            parsed_interchange = parse_interchange_jsonl(
+                                content, self.tokenizer
+                            )
+                            if parsed_interchange is not None:
+                                interchange_meta, interchange_chunks = (
+                                    parsed_interchange
+                                )
+                                logger.info(
+                                    f"Detected interchange JSONL for d-id: {doc_id}, {len(interchange_chunks)} chunks"
+                                )
+                                chunking_result = interchange_chunks
+                                extraction_meta = {
+                                    "extraction_format": "interchange_jsonl",
+                                    "format_version": interchange_meta.get(
+                                        "format_version"
+                                    ),
+                                    "engine": interchange_meta.get("engine"),
+                                    "engine_capabilities": interchange_meta.get(
+                                        "engine_capabilities", []
+                                    ),
+                                    "chunking_method": interchange_meta.get(
+                                        "chunking_method"
+                                    ),
+                                }
+                            else:
+                                # Call chunking function, supporting both sync and async implementations
+                                chunking_result = self.chunking_func(
+                                    self.tokenizer,
+                                    content,
+                                    split_by_character,
+                                    split_by_character_only,
+                                    self.chunk_overlap_token_size,
+                                    self.chunk_token_size,
+                                )
+
+                                # If result is awaitable, await to get actual result
+                                if inspect.isawaitable(chunking_result):
+                                    chunking_result = await chunking_result
+
+                                # Validate return type
+                                if not isinstance(chunking_result, (list, tuple)):
+                                    raise TypeError(
+                                        f"chunking_func must return a list or tuple of dicts, "
+                                        f"got {type(chunking_result)}"
+                                    )
+                                extraction_meta = {
+                                    "extraction_format": "plain_text_chunking",
+                                    "engine": "legacy",
+                                }
+
+                            # Multimodal post-process hook entrypoint:
+                            # runs after interchange parsing and before entity extraction.
+                            chunking_result = (
+                                await self._run_multimodal_postprocess_hook(
+                                    doc_id=doc_id,
+                                    file_path=file_path,
+                                    chunking_result=chunking_result,
+                                    extraction_meta=extraction_meta,
+                                )
                             )
 
-                            # If result is awaitable, await to get actual result
-                            if inspect.isawaitable(chunking_result):
-                                chunking_result = await chunking_result
-
-                            # Validate return type
-                            if not isinstance(chunking_result, (list, tuple)):
-                                raise TypeError(
-                                    f"chunking_func must return a list or tuple of dicts, "
-                                    f"got {type(chunking_result)}"
+                            mm_specs: list[dict[str, Any]] = []
+                            blocks_path = str(
+                                parsed_data.get("blocks_path") or ""
+                            ).strip()
+                            if blocks_path:
+                                max_order = -1
+                                for ch in chunking_result:
+                                    if isinstance(ch, dict) and isinstance(
+                                        ch.get("chunk_order_index"), int
+                                    ):
+                                        max_order = max(
+                                            max_order, int(ch["chunk_order_index"])
+                                        )
+                                mm_chunks, mm_specs = (
+                                    self._build_mm_chunks_from_sidecars(
+                                        doc_id=doc_id,
+                                        file_path=file_path,
+                                        blocks_path=blocks_path,
+                                        base_order_index=max_order + 1,
+                                    )
                                 )
+                                if mm_chunks:
+                                    chunking_result = list(chunking_result) + mm_chunks
+                                    extraction_meta["mm_chunks"] = len(mm_chunks)
+
+                            # Final hard guard before embedding:
+                            # split any oversize chunk while preserving heading hierarchy metadata.
+                            if (
+                                self.embedding_token_limit is not None
+                                and self.embedding_token_limit > 0
+                            ):
+                                original_chunk_count = len(chunking_result)
+                                chunking_result = (
+                                    _enforce_chunk_token_limit_before_embedding(
+                                        chunking_result=chunking_result,
+                                        tokenizer=self.tokenizer,
+                                        max_tokens=self.embedding_token_limit,
+                                    )
+                                )
+                                if len(chunking_result) != original_chunk_count:
+                                    logger.info(
+                                        "Applied hard fallback split before embedding for "
+                                        f"d-id: {doc_id}, chunks {original_chunk_count} -> {len(chunking_result)} "
+                                        f"(limit={self.embedding_token_limit})"
+                                    )
+                                    extraction_meta["hard_fallback_split"] = True
+                                    extraction_meta["pre_split_chunks"] = (
+                                        original_chunk_count
+                                    )
+                                    extraction_meta["post_split_chunks"] = len(
+                                        chunking_result
+                                    )
 
                             # Build chunks dictionary
-                            chunks: dict[str, Any] = {
-                                compute_mdhash_id(dp["content"], prefix="chunk-"): {
+                            chunks: dict[str, Any] = {}
+                            for dp in chunking_result:
+                                chunk_content = dp.get("content", "")
+                                if not chunk_content:
+                                    continue
+                                raw_chunk_id = dp.get("chunk_id", "")
+                                order = dp.get("chunk_order_index")
+                                if (
+                                    isinstance(raw_chunk_id, str)
+                                    and raw_chunk_id.strip()
+                                ):
+                                    if raw_chunk_id.startswith(f"{doc_id}-"):
+                                        chunk_key = raw_chunk_id
+                                    else:
+                                        chunk_key = f"{doc_id}-{raw_chunk_id}"
+                                elif isinstance(order, int):
+                                    chunk_key = f"{doc_id}-chunk-{order:03d}"
+                                else:
+                                    chunk_key = compute_mdhash_id(
+                                        f"{doc_id}:{chunk_content}", prefix="chunk-"
+                                    )
+
+                                # Hard collision guard (same chunk_id inside one document).
+                                if chunk_key in chunks:
+                                    chunk_key = compute_mdhash_id(
+                                        f"{doc_id}:{order}:{chunk_content}",
+                                        prefix="chunk-",
+                                    )
+                                chunks[chunk_key] = {
                                     **dp,
                                     "full_doc_id": doc_id,
-                                    "file_path": file_path,  # Add file path to each chunk
-                                    "llm_cache_list": [],  # Initialize empty LLM cache list for each chunk
+                                    "file_path": file_path,
+                                    "llm_cache_list": [],
                                 }
-                                for dp in chunking_result
-                            }
 
                             if not chunks:
                                 logger.warning("No document chunks to process")
@@ -1976,7 +2650,8 @@ class LightRAG:
                                             "file_path": file_path,
                                             "track_id": status_doc.track_id,  # Preserve existing track_id
                                             "metadata": {
-                                                "processing_start_time": processing_start_time
+                                                "processing_start_time": processing_start_time,
+                                                **extraction_meta,
                                             },
                                         }
                                     }
@@ -2007,6 +2682,13 @@ class LightRAG:
                                 )
                             )
                             chunk_results = await entity_relation_task
+                            chunk_results = (
+                                self._augment_chunk_results_with_mm_entities(
+                                    chunk_results=chunk_results,
+                                    mm_specs=mm_specs,
+                                    file_path=file_path,
+                                )
+                            )
                             file_extraction_stage_ok = True
 
                         except Exception as e:
@@ -2133,6 +2815,7 @@ class LightRAG:
                                             "metadata": {
                                                 "processing_start_time": processing_start_time,
                                                 "processing_end_time": processing_end_time,
+                                                **extraction_meta,
                                             },
                                         }
                                     }
@@ -2206,40 +2889,186 @@ class LightRAG:
                                             "metadata": {
                                                 "processing_start_time": processing_start_time,
                                                 "processing_end_time": processing_end_time,
+                                                **extraction_meta,
                                             },
                                         }
                                     }
                                 )
 
-                # Create processing tasks for all documents
-                doc_tasks = []
-                for doc_id, status_doc in to_process_docs.items():
-                    doc_tasks.append(
-                        process_document(
-                            doc_id,
-                            status_doc,
-                            split_by_character,
-                            split_by_character_only,
-                            pipeline_status,
-                            pipeline_status_lock,
-                            semaphore,
-                        )
+                # Three-stage worker queues:
+                # parse_native/mineru/docling -> analyze_multimodal -> process_document
+                q_native: asyncio.Queue = asyncio.Queue(maxsize=self.queue_size_default)
+                q_mineru: asyncio.Queue = asyncio.Queue(maxsize=self.queue_size_default)
+                q_docling: asyncio.Queue = asyncio.Queue(
+                    maxsize=self.queue_size_default
+                )
+                q_analyze: asyncio.Queue = asyncio.Queue(
+                    maxsize=self.queue_size_default
+                )
+                q_process: asyncio.Queue = asyncio.Queue(maxsize=self.queue_size_insert)
+
+                workers: list[asyncio.Task] = []
+
+                async def parse_worker(engine: str, in_q: asyncio.Queue):
+                    while True:
+                        item = await in_q.get()
+                        try:
+                            doc_id_w, status_doc_w = item
+                            file_path_w = getattr(
+                                status_doc_w, "file_path", "unknown_source"
+                            )
+                            content_data_w = await self.full_docs.get_by_id(doc_id_w)
+                            if not content_data_w:
+                                raise Exception(
+                                    f"Document content not found in full_docs for doc_id: {doc_id_w}"
+                                )
+                            await self.doc_status.upsert(
+                                {
+                                    doc_id_w: {
+                                        "status": DocStatus.PARSING,
+                                        "content_summary": status_doc_w.content_summary,
+                                        "content_length": status_doc_w.content_length,
+                                        "created_at": status_doc_w.created_at,
+                                        "updated_at": datetime.now(
+                                            timezone.utc
+                                        ).isoformat(),
+                                        "file_path": file_path_w,
+                                        "track_id": status_doc_w.track_id,
+                                    }
+                                }
+                            )
+                            if engine == "mineru":
+                                parsed_data_w = await self.parse_mineru(
+                                    doc_id_w, file_path_w, content_data_w
+                                )
+                            elif engine == "docling":
+                                parsed_data_w = await self.parse_docling(
+                                    doc_id_w, file_path_w, content_data_w
+                                )
+                            else:
+                                parsed_data_w = await self.parse_native(
+                                    doc_id_w, file_path_w, content_data_w
+                                )
+                            await q_analyze.put((doc_id_w, status_doc_w, parsed_data_w))
+                        except Exception as e:
+                            logger.error(f"Parse worker failed ({engine}): {e}")
+                            try:
+                                await self.doc_status.upsert(
+                                    {
+                                        doc_id_w: {
+                                            "status": DocStatus.FAILED,
+                                            "error_msg": str(e),
+                                            "content_summary": status_doc_w.content_summary,
+                                            "content_length": status_doc_w.content_length,
+                                            "created_at": status_doc_w.created_at,
+                                            "updated_at": datetime.now(
+                                                timezone.utc
+                                            ).isoformat(),
+                                            "file_path": getattr(
+                                                status_doc_w,
+                                                "file_path",
+                                                "unknown_source",
+                                            ),
+                                            "track_id": status_doc_w.track_id,
+                                        }
+                                    }
+                                )
+                            except Exception:
+                                pass
+                        finally:
+                            in_q.task_done()
+
+                async def analyze_worker():
+                    while True:
+                        item = await q_analyze.get()
+                        try:
+                            doc_id_w, status_doc_w, parsed_data_w = item
+                            file_path_w = getattr(
+                                status_doc_w, "file_path", "unknown_source"
+                            )
+                            await self.doc_status.upsert(
+                                {
+                                    doc_id_w: {
+                                        "status": DocStatus.ANALYZING,
+                                        "content_summary": status_doc_w.content_summary,
+                                        "content_length": len(
+                                            parsed_data_w.get("content", "")
+                                        ),
+                                        "created_at": status_doc_w.created_at,
+                                        "updated_at": datetime.now(
+                                            timezone.utc
+                                        ).isoformat(),
+                                        "file_path": file_path_w,
+                                        "track_id": status_doc_w.track_id,
+                                    }
+                                }
+                            )
+                            analyzed = await self.analyze_multimodal(
+                                doc_id=doc_id_w,
+                                file_path=file_path_w,
+                                parsed_data=parsed_data_w,
+                            )
+                            await q_process.put((doc_id_w, status_doc_w, analyzed))
+                        except Exception as e:
+                            logger.error(f"Analyze worker failed: {e}")
+                        finally:
+                            q_analyze.task_done()
+
+                async def process_worker():
+                    while True:
+                        item = await q_process.get()
+                        try:
+                            doc_id_w, status_doc_w, parsed_data_w = item
+                            await process_document(
+                                doc_id_w,
+                                status_doc_w,
+                                split_by_character,
+                                split_by_character_only,
+                                pipeline_status,
+                                pipeline_status_lock,
+                                semaphore,
+                                pre_parsed_data=parsed_data_w,
+                            )
+                        finally:
+                            q_process.task_done()
+
+                for _ in range(max(1, self.max_parallel_parse_native)):
+                    workers.append(
+                        asyncio.create_task(parse_worker("native", q_native))
                     )
+                for _ in range(max(1, self.max_parallel_parse_mineru)):
+                    workers.append(
+                        asyncio.create_task(parse_worker("mineru", q_mineru))
+                    )
+                for _ in range(max(1, self.max_parallel_parse_docling)):
+                    workers.append(
+                        asyncio.create_task(parse_worker("docling", q_docling))
+                    )
+                for _ in range(max(1, self.max_parallel_analyze)):
+                    workers.append(asyncio.create_task(analyze_worker()))
+                for _ in range(max(1, self.max_parallel_insert)):
+                    workers.append(asyncio.create_task(process_worker()))
 
-                # Wait for all document processing to complete
-                try:
-                    await asyncio.gather(*doc_tasks)
-                except PipelineCancelledException:
-                    # Cancel all remaining tasks
-                    for task in doc_tasks:
-                        if not task.done():
-                            task.cancel()
+                for doc_id, status_doc in to_process_docs.items():
+                    content_data = await self.full_docs.get_by_id(doc_id) or {}
+                    engine = self._resolve_parser_engine(
+                        file_path=getattr(status_doc, "file_path", "unknown_source"),
+                        content_data=content_data,
+                    )
+                    if engine == "mineru":
+                        await q_mineru.put((doc_id, status_doc))
+                    elif engine == "docling":
+                        await q_docling.put((doc_id, status_doc))
+                    else:
+                        await q_native.put((doc_id, status_doc))
 
-                    # Wait for all tasks to complete cancellation
-                    await asyncio.wait(doc_tasks, return_when=asyncio.ALL_COMPLETED)
+                await asyncio.gather(q_native.join(), q_mineru.join(), q_docling.join())
+                await q_analyze.join()
+                await q_process.join()
 
-                    # Exit directly (document statuses already updated in process_document)
-                    return
+                for w in workers:
+                    w.cancel()
+                await asyncio.gather(*workers, return_exceptions=True)
 
                 # Check if there's a pending request to process more documents (with lock)
                 has_pending_request = False
@@ -2258,16 +3087,26 @@ class LightRAG:
                 pipeline_status["history_messages"].append(log_message)
 
                 # Check for pending documents again
-                processing_docs, failed_docs, pending_docs = await asyncio.gather(
+                (
+                    processing_docs,
+                    failed_docs,
+                    pending_docs,
+                    parsing_docs,
+                    analyzing_docs,
+                ) = await asyncio.gather(
                     self.doc_status.get_docs_by_status(DocStatus.PROCESSING),
                     self.doc_status.get_docs_by_status(DocStatus.FAILED),
                     self.doc_status.get_docs_by_status(DocStatus.PENDING),
+                    self.doc_status.get_docs_by_status(DocStatus.PARSING),
+                    self.doc_status.get_docs_by_status(DocStatus.ANALYZING),
                 )
 
                 to_process_docs = {}
                 to_process_docs.update(processing_docs)
                 to_process_docs.update(failed_docs)
                 to_process_docs.update(pending_docs)
+                to_process_docs.update(parsing_docs)
+                to_process_docs.update(analyzing_docs)
 
         finally:
             log_message = "Enqueued document processing pipeline stopped"
@@ -2301,6 +3140,1645 @@ class LightRAG:
                 pipeline_status["latest_message"] = error_msg
                 pipeline_status["history_messages"].append(error_msg)
             raise e
+
+    async def analyze_multimodal(
+        self,
+        doc_id: str,
+        file_path: str,
+        parsed_data: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Phase 2: Multimodal analysis (VLM). Writes llm_analyze_result and analyze_time to LightRAG Document.
+        Uses vlm_llm_model_func (VLM role). When Ray-Anything merges, bind VLM model here.
+        Default: no-op, returns parsed_data unchanged.
+        """
+        blocks_path = parsed_data.get("blocks_path")
+        if not blocks_path:
+            return parsed_data
+
+        block_file = Path(blocks_path)
+        if not block_file.exists():
+            return parsed_data
+
+        try:
+            lines = block_file.read_text(encoding="utf-8").splitlines()
+            if not lines:
+                return parsed_data
+            meta = json.loads(lines[0])
+            if not isinstance(meta, dict) or meta.get("type") != "meta":
+                return parsed_data
+            if meta.get("analyze_time"):
+                return parsed_data
+
+            now_iso = datetime.now(timezone.utc).isoformat()
+            meta["analyze_time"] = now_iso
+            lines[0] = json.dumps(meta, ensure_ascii=False)
+            block_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+            # Analyze sidecar multimodal items by VLM model role.
+            use_vlm_func = self.vlm_llm_model_func or self.llm_model_func
+            sem = asyncio.Semaphore(max(1, self._get_effective_role_llm_max_async("vlm")))
+            analyze_retries = max(0, int(os.getenv("VLM_ANALYZE_RETRIES", "2")))
+            max_image_bytes = max(
+                256 * 1024, int(os.getenv("VLM_MAX_IMAGE_BYTES", str(5 * 1024 * 1024)))
+            )
+
+            def _extract_json_obj(text: str) -> dict[str, Any]:
+                if not text:
+                    return {}
+                try:
+                    obj = json.loads(text)
+                    if isinstance(obj, dict):
+                        return obj
+                except Exception:
+                    pass
+                m = re.search(r"\{[\s\S]*\}", text)
+                if m:
+                    try:
+                        obj = json.loads(m.group(0))
+                        if isinstance(obj, dict):
+                            return obj
+                    except Exception:
+                        pass
+                return {}
+
+            async def _analyze_item(
+                root_key: str, item_id: str, item: dict[str, Any]
+            ) -> dict[str, Any]:
+                def _conservative_result(reason: str) -> dict[str, Any]:
+                    base_name = item.get("caption") or item_id
+                    modality = (
+                        "image"
+                        if root_key == "drawings"
+                        else "table"
+                        if root_key == "tables"
+                        else "equation"
+                    )
+                    conservative = {
+                        "name": base_name,
+                        "summary": (
+                            f"Conservative summary only: unavailable or weak visual evidence for {modality}."
+                        ),
+                        "detail_description": (
+                            f"No grounded visual evidence. Reason: {reason}. "
+                            "Only metadata-level description is retained."
+                        ),
+                        "grounded": False,
+                        "grounding_reason": reason,
+                    }
+                    if root_key == "drawings":
+                        conservative["image_type"] = ""
+                    return conservative
+
+                def _build_image_data_url(path_str: str | None) -> str | None:
+                    if not path_str:
+                        return None
+                    p = Path(path_str)
+                    if not p.exists() or not p.is_file():
+                        return None
+                    try:
+                        raw = p.read_bytes()
+                    except Exception:
+                        return None
+                    if not raw:
+                        return None
+                    if len(raw) > max_image_bytes:
+                        logger.warning(
+                            f"[analyze_multimodal] image too large ({len(raw)} bytes) for {root_key}/{item_id}, skip image input"
+                        )
+                        return None
+                    mime, _ = mimetypes.guess_type(str(p))
+                    if not mime:
+                        mime = "image/png"
+                    b64 = base64.b64encode(raw).decode("ascii")
+                    return f"data:{mime};base64,{b64}"
+
+                def _normalize_text(value: Any) -> str:
+                    if value is None:
+                        return ""
+                    if isinstance(value, str):
+                        return value.strip()
+                    if isinstance(value, (list, tuple)):
+                        return "\n".join(
+                            str(v).strip() for v in value if str(v).strip()
+                        )
+                    return str(value).strip()
+
+                def _normalize_grounded_value(value: Any) -> Any:
+                    if isinstance(value, bool) or value is None:
+                        return value
+                    if isinstance(value, str):
+                        lowered = value.strip().lower()
+                        if lowered == "true":
+                            return True
+                        if lowered == "false":
+                            return False
+                    if isinstance(value, (int, float)) and value in {0, 1}:
+                        return bool(value)
+                    return value
+
+                default_result = {
+                    "name": item.get("caption") or item_id,
+                    "summary": "",
+                    "detail_description": "",
+                }
+                if root_key == "drawings":
+                    default_result["image_type"] = ""
+                schema_hint = (
+                    '{"name":"string","summary":"string","detail_description":"string","grounded":"boolean","grounding_reason":"string"}'
+                    if root_key != "drawings"
+                    else '{"name":"string","image_type":"string","summary":"string","detail_description":"string","grounded":"boolean","grounding_reason":"string"}'
+                )
+                image_data_url = _build_image_data_url(
+                    item.get("path") or item.get("img_path") or item.get("image_path")
+                )
+                has_visual_evidence = bool(image_data_url)
+                caption_text = _normalize_text(item.get("caption"))
+                footnotes_text = _normalize_text(item.get("footnotes"))
+                content_text = _normalize_text(item.get("content"))
+                has_textual_evidence = root_key in {
+                    "tables",
+                    "equations",
+                } and any((caption_text, footnotes_text, content_text))
+                evidence_mode = (
+                    "visual"
+                    if has_visual_evidence
+                    else "textual"
+                    if has_textual_evidence
+                    else "none"
+                )
+                for attempt in range(analyze_retries + 1):
+                    prompt = (
+                        "You are a multimodal analyzer.\n"
+                        "Return ONLY one JSON object. No markdown. No explanation.\n"
+                        "Grounding policy:\n"
+                        "- Do NOT invent unseen objects, domains, diseases, or scenarios.\n"
+                        "- Prefer the strongest available evidence source.\n"
+                        "- For tables/equations without image evidence, analyze from content/caption/footnotes first.\n"
+                        "- In textual-only mode, do not invent appearance/layout details that are not supported by the provided content.\n"
+                        "- If evidence is missing/weak/uncertain, set grounded=false and keep summary/detail conservative.\n"
+                        "- If grounded=false, avoid rich semantic claims; keep to metadata-level statements only.\n"
+                        f"JSON schema example: {schema_hint}\n"
+                        f"modality={root_key}\n"
+                        f"item_id={item_id}\n"
+                        f"caption={caption_text}\n"
+                        f"footnotes={footnotes_text}\n"
+                        f"content={content_text}\n"
+                        f"has_visual_evidence={has_visual_evidence}\n"
+                        f"has_textual_evidence={has_textual_evidence}\n"
+                        f"evidence_mode={evidence_mode}\n"
+                        "Constraints:\n"
+                        "- summary: <= 120 words\n"
+                        "- detail_description: <= 500 words\n"
+                    )
+                    messages = None
+                    if image_data_url:
+                        messages = [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "text", "text": prompt},
+                                    {
+                                        "type": "image_url",
+                                        "image_url": {"url": image_data_url},
+                                    },
+                                ],
+                            }
+                        ]
+                    async with sem:
+                        if messages:
+                            try:
+                                result_text = await use_vlm_func(
+                                    prompt, stream=False, messages=messages
+                                )
+                            except TypeError:
+                                # Backward compatibility for providers that don't accept messages.
+                                result_text = await use_vlm_func(prompt, stream=False)
+                            except Exception as msg_err:
+                                logger.warning(
+                                    f"[analyze_multimodal] visual call failed for {root_key}/{item_id}: {msg_err}"
+                                )
+                                return _conservative_result("visual_call_failed")
+                        else:
+                            result_text = await use_vlm_func(prompt, stream=False)
+                    parsed = _extract_json_obj(str(result_text))
+                    if (
+                        parsed
+                        and isinstance(parsed.get("name"), str)
+                        and isinstance(parsed.get("summary"), str)
+                        and isinstance(parsed.get("detail_description"), str)
+                    ):
+                        if "grounded" in parsed:
+                            parsed["grounded"] = _normalize_grounded_value(
+                                parsed.get("grounded")
+                            )
+                        default_result.update(
+                            {
+                                k: v
+                                for k, v in parsed.items()
+                                if k
+                                in {
+                                    "name",
+                                    "summary",
+                                    "detail_description",
+                                    "image_type",
+                                    "grounded",
+                                    "grounding_reason",
+                                }
+                            }
+                        )
+                        if evidence_mode == "none":
+                            return _conservative_result("missing_image")
+                        if parsed.get("grounded") is False:
+                            reason = str(
+                                parsed.get("grounding_reason")
+                                or (
+                                    "weak_visual_evidence"
+                                    if evidence_mode == "visual"
+                                    else "weak_textual_evidence"
+                                )
+                            )
+                            return _conservative_result(reason)
+                        if "grounded" not in default_result:
+                            default_result["grounded"] = True
+                        if not default_result.get("grounding_reason"):
+                            default_result["grounding_reason"] = (
+                                "visual_evidence"
+                                if evidence_mode == "visual"
+                                else "textual_content_only"
+                            )
+                        return default_result
+                    if attempt < analyze_retries:
+                        logger.warning(
+                            f"[analyze_multimodal] invalid JSON, retry {attempt + 1}/{analyze_retries} for {root_key}/{item_id}"
+                        )
+                if evidence_mode == "none":
+                    return _conservative_result("missing_image")
+                return _conservative_result("analysis_failed")
+
+            # Write back llm_analyze_result to multimodal sidecar files.
+            base_name = str(block_file)
+            if base_name.endswith(".blocks.jsonl"):
+                base_name = base_name[: -len(".blocks.jsonl")]
+            sidecars = [
+                (Path(base_name + ".drawings.json"), "drawings"),
+                (Path(base_name + ".tables.json"), "tables"),
+                (Path(base_name + ".equations.json"), "equations"),
+            ]
+            for sidecar_path, root_key in sidecars:
+                if not sidecar_path.exists():
+                    continue
+                try:
+                    payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
+                    items = payload.get(root_key, {})
+                    if isinstance(items, dict):
+                        analyze_tasks = []
+                        valid_keys = []
+                        for item_id, item in items.items():
+                            if isinstance(item, dict):
+                                valid_keys.append(item_id)
+                                analyze_tasks.append(
+                                    _analyze_item(root_key, item_id, item)
+                                )
+                        analyzed_results = await asyncio.gather(
+                            *analyze_tasks, return_exceptions=True
+                        )
+                        for idx, item_id in enumerate(valid_keys):
+                            item = items.get(item_id)
+                            if not isinstance(item, dict):
+                                continue
+                            result_obj = analyzed_results[idx]
+                            if isinstance(result_obj, Exception):
+                                logger.warning(
+                                    f"[analyze_multimodal] item analyze failed: {root_key}/{item_id}: {result_obj}"
+                                )
+                                continue
+                            item["llm_analyze_result"] = result_obj
+                    sidecar_path.write_text(
+                        json.dumps(payload, ensure_ascii=False, indent=2),
+                        encoding="utf-8",
+                    )
+                except Exception as sidecar_error:
+                    logger.warning(
+                        f"[analyze_multimodal] failed to write sidecar {sidecar_path}: {sidecar_error}"
+                    )
+
+            parsed_data["analyze_time"] = now_iso
+            parsed_data["multimodal_processed"] = True
+            logger.info(
+                f"[analyze_multimodal] marked analyze_time for d-id: {doc_id}, file: {file_path}"
+            )
+        except Exception as e:
+            logger.warning(f"[analyze_multimodal] failed to update analyze_time for d-id: {doc_id}: {e}")
+        return parsed_data
+
+    async def _load_lightrag_document_content(
+        self, lightrag_document_path: str
+    ) -> tuple[str, str]:
+        """Load LightRAG Document blocks and return (merged_text, blocks_path)."""
+        path = Path(lightrag_document_path)
+        candidates: list[Path] = []
+        if path.suffix == ".jsonl" and path.name.endswith(".blocks.jsonl"):
+            candidates.append(path)
+        else:
+            candidates.append(Path(str(path) + ".blocks.jsonl"))
+            if path.is_dir():
+                candidates.extend(path.glob("*.blocks.jsonl"))
+            else:
+                candidates.append(path)
+
+        blocks_path = None
+        for c in candidates:
+            if c.exists() and c.is_file():
+                blocks_path = c
+                break
+        if blocks_path is None:
+            raise FileNotFoundError(
+                f"LightRAG blocks file not found from path: {lightrag_document_path}"
+            )
+
+        merged_parts: list[str] = []
+        with blocks_path.open("r", encoding="utf-8") as f:
+            for i, line in enumerate(f):
+                text = line.strip()
+                if not text:
+                    continue
+                obj = json.loads(text)
+                if i == 0:
+                    continue
+                if obj.get("type") != "content":
+                    continue
+                content = obj.get("content", "")
+                if isinstance(content, str) and content.strip():
+                    merged_parts.append(content)
+
+        return "\n\n".join(merged_parts), str(blocks_path)
+
+    def _resolve_parser_engine(
+        self, file_path: str, content_data: dict[str, Any]
+    ) -> str:
+        explicit_engine = str(content_data.get("parsed_engine") or "").strip().lower()
+        if explicit_engine in {"native", "mineru", "docling"}:
+            return explicit_engine
+
+        file_name = Path(file_path).name
+        m = re.search(r"\.\[([^\]]+)\]\.[^.]+$", file_name)
+        if m:
+            hint = m.group(1).split("-")[0].strip().lower()
+            if hint in {"native", "mineru", "docling"}:
+                return hint
+
+        parser_rules = os.getenv("LIGHTRAG_PARSER", "").strip()
+        if parser_rules:
+            suffix = Path(file_name).suffix.lower().lstrip(".")
+            for item in [x.strip() for x in parser_rules.split(",") if x.strip()]:
+                if ":" not in item:
+                    continue
+                pattern, engine_hint = item.split(":", 1)
+                pattern = pattern.strip().lower()
+                engine = engine_hint.strip().split("-")[0].lower()
+                if engine not in {"native", "mineru", "docling"}:
+                    continue
+                if fnmatch.fnmatch(suffix, pattern):
+                    return engine
+
+        # Auto routing for normal user uploads (without filename hints):
+        # prefer multimodal-capable engines when corresponding service endpoint is configured.
+        suffix = Path(file_name).suffix.lower().lstrip(".")
+        mineru_endpoint = os.getenv("MINERU_ENDPOINT", "").strip()
+        docling_endpoint = os.getenv("DOCLING_ENDPOINT", "").strip()
+
+        # Keep this mapping conservative and practical:
+        # - PDF defaults to MinerU (layout-heavy parsing)
+        # - Office-like docs default to Docling
+        mineru_suffixes = {"pdf"}
+        docling_suffixes = {
+            "doc",
+            "docx",
+            "ppt",
+            "pptx",
+            "xls",
+            "xlsx",
+            "md",
+            "markdown",
+            "html",
+            "htm",
+        }
+
+        if suffix in mineru_suffixes and mineru_endpoint:
+            return "mineru"
+        if suffix in docling_suffixes and docling_endpoint:
+            return "docling"
+
+        # Fallback cross-coverage when only one service is available.
+        if suffix in (mineru_suffixes | docling_suffixes):
+            if docling_endpoint:
+                return "docling"
+            if mineru_endpoint:
+                return "mineru"
+        return "native"
+
+    def _get_by_path(self, payload: Any, path: str) -> Any:
+        if not path:
+            return None
+        cur = payload
+        for part in path.split("."):
+            if isinstance(cur, dict) and part in cur:
+                cur = cur[part]
+            else:
+                return None
+        return cur
+
+    async def _call_protocol_parse_service(
+        self, protocol: dict[str, Any], file_path: str
+    ) -> str | None:
+        """Protocol-driven async parse call for MinerU/Docling."""
+        upload_url = str(protocol.get("upload_url") or "").strip()
+        if not upload_url:
+            return None
+        if httpx is None:
+            logger.warning("httpx not installed, skip async parse service call")
+            return None
+
+        id_field = str(protocol.get("id_field", "id"))
+        status_field = str(protocol.get("status_field", "status"))
+        result_url_field = str(protocol.get("result_url_field", "result_url"))
+        content_field = str(protocol.get("content_field", "content"))
+        poll_url_tpl = str(protocol.get("poll_url_template", "")).strip()
+        poll_method = str(protocol.get("poll_method", "GET")).upper()
+        poll_interval = float(protocol.get("poll_interval_seconds", 2.0))
+        max_polls = int(protocol.get("max_polls", 120))
+        success_values = set(
+            x.strip().lower()
+            for x in str(
+                protocol.get(
+                    "success_values", "done,success,succeeded,completed,finished"
+                )
+            ).split(",")
+            if x.strip()
+        )
+        failed_values = set(
+            x.strip().lower()
+            for x in str(protocol.get("failed_values", "failed,error")).split(",")
+            if x.strip()
+        )
+
+        timeout = httpx.Timeout(120.0, connect=30.0)
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            with open(file_path, "rb") as f:
+                resp = await client.post(
+                    upload_url, files={"file": (Path(file_path).name, f)}
+                )
+            if resp.status_code >= 400:
+                raise RuntimeError(
+                    f"Parse service upload failed: {resp.status_code} {resp.text[:400]}"
+                )
+            upload_payload = resp.json() if resp.text else {}
+            task_id = self._get_by_path(upload_payload, id_field)
+            if not task_id:
+                direct_content = self._get_by_path(upload_payload, content_field)
+                return str(direct_content) if direct_content else None
+            task_id = str(task_id)
+
+            poll_url = (
+                poll_url_tpl.format(task_id=task_id, trace_id=task_id, id=task_id)
+                if poll_url_tpl
+                else upload_url
+            )
+            poll_params = {"task_id": task_id, "trace_id": task_id, "id": task_id}
+            for _ in range(max_polls):
+                await asyncio.sleep(poll_interval)
+                if poll_method == "POST":
+                    poll_resp = await client.post(poll_url, json=poll_params)
+                else:
+                    poll_resp = await client.get(poll_url, params=poll_params)
+                poll_payload = poll_resp.json() if poll_resp.text else {}
+                status_raw = self._get_by_path(poll_payload, status_field)
+                status_val = str(status_raw).lower() if status_raw is not None else ""
+
+                if status_val in success_values:
+                    result_url = self._get_by_path(poll_payload, result_url_field)
+                    if result_url:
+                        dl = await client.get(str(result_url))
+                        dl.raise_for_status()
+                        return dl.text
+                    content_val = self._get_by_path(poll_payload, content_field)
+                    return str(content_val) if content_val else None
+                if status_val in failed_values:
+                    raise RuntimeError(
+                        f"Parse service failed for task {task_id}: {poll_payload}"
+                    )
+        raise TimeoutError(f"Parse service polling timeout for task: {task_id}")
+
+    def _extract_content_list_from_payload(
+        self, payload: Any
+    ) -> list[dict[str, Any]] | None:
+        """Try to find a MinerU/Docling-like content list from arbitrary JSON payload."""
+        if isinstance(payload, list):
+            if payload and all(isinstance(x, dict) for x in payload):
+                first = payload[0]
+                if "type" in first or "label" in first or "text" in first:
+                    return cast(list[dict[str, Any]], payload)
+            return None
+        if not isinstance(payload, dict):
+            return None
+
+        # Common direct keys first
+        for key in ("content_list", "content", "items", "result"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                extracted = self._extract_content_list_from_payload(value)
+                if extracted is not None:
+                    return extracted
+            elif isinstance(value, dict):
+                extracted = self._extract_content_list_from_payload(value)
+                if extracted is not None:
+                    return extracted
+
+        # Deep search as fallback
+        for value in payload.values():
+            extracted = self._extract_content_list_from_payload(value)
+            if extracted is not None:
+                return extracted
+        return None
+
+    def _normalize_parser_result_to_content_list(
+        self, parser_result: str | list[dict[str, Any]] | dict[str, Any] | None
+    ) -> list[dict[str, Any]] | None:
+        """Normalize parser result to structured content list if possible."""
+        if parser_result is None:
+            return None
+        if isinstance(parser_result, list):
+            return self._extract_content_list_from_payload(parser_result)
+        if isinstance(parser_result, dict):
+            return self._extract_content_list_from_payload(parser_result)
+        text = str(parser_result).strip()
+        if not text:
+            return None
+        try:
+            payload = json.loads(text)
+            return self._extract_content_list_from_payload(payload)
+        except Exception:
+            return None
+
+    def _resolve_local_raganything_root(self) -> Path | None:
+        """Resolve local RAG-Anything source root if present."""
+        env_root = os.getenv("RAGANYTHING_ROOT", "").strip()
+        candidates: list[Path] = []
+        if env_root:
+            candidates.append(Path(env_root))
+        candidates.extend(
+            [
+                Path("/root/autodl-tmp/RAG-Anything"),
+                Path.cwd().parent / "RAG-Anything",
+            ]
+        )
+        for c in candidates:
+            if (c / "raganything" / "__init__.py").exists():
+                return c
+        return None
+
+    def _ensure_local_raganything_importable(self) -> bool:
+        root = self._resolve_local_raganything_root()
+        if root is None:
+            return False
+        root_str = str(root)
+        if root_str not in sys.path:
+            sys.path.insert(0, root_str)
+        return True
+
+    async def _parse_via_local_raganything(
+        self, engine: str, file_path: str
+    ) -> list[dict[str, Any]] | None:
+        """Use local RAG-Anything parser classes directly."""
+        if engine not in {"mineru", "docling"}:
+            return None
+        if not self._ensure_local_raganything_importable():
+            return None
+        try:
+            from raganything.parser import MineruParser, DoclingParser  # type: ignore[import-untyped]
+        except Exception as e:
+            logger.info(f"Local RAG-Anything import unavailable: {e}")
+            return None
+
+        parser = DoclingParser() if engine == "docling" else MineruParser()
+        try:
+            if (
+                hasattr(parser, "check_installation")
+                and not parser.check_installation()
+            ):
+                logger.info(
+                    f"Local RAG-Anything {engine} parser not installed/configured"
+                )
+                return None
+        except Exception:
+            return None
+
+        source_file_path = self._resolve_source_file_for_parser(file_path)
+        try:
+            content_list = await asyncio.to_thread(
+                parser.parse_document, source_file_path, "auto", None
+            )
+            if isinstance(content_list, list):
+                return content_list
+        except Exception as e:
+            logger.warning(f"Local RAG-Anything {engine} parse failed: {e}")
+        return None
+
+    def _resolve_source_file_for_parser(self, file_path: str) -> str:
+        """Resolve a readable source file path for parser upload."""
+        p = Path(file_path)
+        if p.exists() and p.is_file():
+            return str(p)
+
+        name = p.name
+        candidates: list[Path] = []
+        input_dir = os.getenv("INPUT_DIR", "").strip()
+        if input_dir:
+            input_path = Path(input_dir)
+            candidates.append(input_path / name)
+            candidates.append(input_path / PARSED_DIR_NAME / name)
+
+        # Common local defaults used by API server.
+        cwd = Path.cwd()
+        candidates.extend(
+            [
+                cwd / "inputs" / name,
+                cwd / "inputs" / PARSED_DIR_NAME / name,
+                cwd / PARSED_DIR_NAME / name,
+            ]
+        )
+
+        for candidate in candidates:
+            if candidate.exists() and candidate.is_file():
+                return str(candidate)
+        return file_path
+
+    async def _write_lightrag_document_from_content_list(
+        self,
+        doc_id: str,
+        file_path: str,
+        content_list: list[dict[str, Any]],
+        engine: str,
+    ) -> dict[str, Any]:
+        """Convert parser content list to LightRAG Document files and return parsed_data."""
+        parsed_dir = Path(self.working_dir) / PARSED_DIR_NAME
+        parsed_dir.mkdir(parents=True, exist_ok=True)
+
+        source_name = Path(file_path).name or f"{doc_id}.bin"
+        base_name = f"{doc_id}.{source_name}"
+        blocks_path = parsed_dir / f"{base_name}.blocks.jsonl"
+        tables_path = parsed_dir / f"{base_name}.tables.json"
+        drawings_path = parsed_dir / f"{base_name}.drawings.json"
+        equations_path = parsed_dir / f"{base_name}.equations.json"
+
+        blocks_lines: list[str] = []
+        merged_parts: list[str] = []
+        block_idx = 0
+        table_idx = 0
+        drawing_idx = 0
+        equation_idx = 0
+
+        tables: dict[str, Any] = {}
+        drawings: dict[str, Any] = {}
+        equations: dict[str, Any] = {}
+
+        def _to_list_str(value: Any) -> list[str]:
+            if value is None:
+                return []
+            if isinstance(value, list):
+                return [str(x) for x in value if str(x).strip()]
+            text_val = str(value).strip()
+            return [text_val] if text_val else []
+
+        def _parse_int(value: Any, default: int = 0) -> int:
+            try:
+                return int(value)
+            except Exception:
+                return default
+
+        def _normalize_grid_rows(grid: Any) -> list[list[str]]:
+            normalized_rows: list[list[str]] = []
+            if not isinstance(grid, list):
+                return normalized_rows
+            for row in grid:
+                if not isinstance(row, list):
+                    continue
+                normalized_row: list[str] = []
+                for cell in row:
+                    if isinstance(cell, dict):
+                        normalized_row.append(str(cell.get("text", "")).strip())
+                    else:
+                        normalized_row.append(str(cell).strip())
+                normalized_rows.append(normalized_row)
+            return normalized_rows
+
+        def _coerce_table_rows(
+            value: Any,
+        ) -> tuple[str, Any, list[list[str]], int, int]:
+            raw_value = value
+            if isinstance(raw_value, str):
+                stripped = raw_value.strip()
+                if not stripped:
+                    return "html", "", [], 0, 0
+                parsed_value = None
+                try:
+                    parsed_value = json.loads(stripped)
+                except Exception:
+                    try:
+                        import ast
+
+                        parsed_value = ast.literal_eval(stripped)
+                    except Exception:
+                        parsed_value = None
+                if parsed_value is None:
+                    return "html", raw_value, [], 0, 0
+                raw_value = parsed_value
+
+            if isinstance(raw_value, list):
+                rows = _normalize_grid_rows(raw_value)
+                return (
+                    "json",
+                    json.dumps(rows, ensure_ascii=False),
+                    rows,
+                    len(rows),
+                    max((len(r) for r in rows), default=0),
+                )
+
+            if isinstance(raw_value, dict):
+                rows = _normalize_grid_rows(raw_value.get("grid"))
+                if not rows and isinstance(raw_value.get("rows"), list):
+                    rows = _normalize_grid_rows(raw_value.get("rows"))
+                num_rows = _parse_int(
+                    raw_value.get("num_rows"), len(rows) if rows else 0
+                )
+                num_cols = _parse_int(
+                    raw_value.get("num_cols"),
+                    max((len(r) for r in rows), default=0),
+                )
+                if rows:
+                    return (
+                        "json",
+                        json.dumps(rows, ensure_ascii=False),
+                        rows,
+                        num_rows,
+                        num_cols,
+                    )
+                return (
+                    "html",
+                    json.dumps(raw_value, ensure_ascii=False),
+                    [],
+                    num_rows,
+                    num_cols,
+                )
+
+            text_value = str(raw_value or "").strip()
+            return "html", text_value, [], 0, 0
+
+        heading_stack: list[str] = []
+
+        def _update_heading_context(
+            heading_text: str, level: int
+        ) -> tuple[str, int, list[str]]:
+            nonlocal heading_stack
+            clean_heading = str(heading_text or "").strip()
+            clean_level = max(_parse_int(level, 1), 1)
+            heading_stack = heading_stack[: max(clean_level - 1, 0)]
+            parent_chain = [x for x in heading_stack if x]
+            heading_stack.append(clean_heading)
+            return clean_heading, clean_level, parent_chain
+
+        def _append_block(
+            content_text: str,
+            heading: str = "",
+            level: int = 0,
+            parent_headings: list[str] | None = None,
+        ) -> str:
+            nonlocal block_idx
+            content_text = str(content_text or "").strip()
+            if not content_text:
+                return ""
+            blockid = hashlib.md5(
+                f"{doc_id}:{block_idx}:{heading}:{content_text}".encode("utf-8")
+            ).hexdigest()
+            blocks_lines.append(
+                json.dumps(
+                    {
+                        "type": "content",
+                        "blockid": blockid,
+                        "format": "plain_text",
+                        "content": content_text,
+                        "heading": heading,
+                        "parent_headings": list(parent_headings or []),
+                        "level": level,
+                        "session_type": "body",
+                        "table_slice": "none",
+                        "positions": [],
+                    },
+                    ensure_ascii=False,
+                )
+            )
+            merged_parts.append(content_text)
+            block_idx += 1
+            return blockid
+
+        current_heading = ""
+        current_level = 0
+        current_parent_headings: list[str] = []
+
+        for item in content_list:
+            if not isinstance(item, dict):
+                continue
+            item_type = str(item.get("type") or item.get("label") or "").lower()
+
+            if item_type in {"text", "title", "section_header", "list", "code"}:
+                text = (
+                    item.get("text")
+                    or item.get("content")
+                    or "\n".join(
+                        item.get("list_items", [])
+                        if isinstance(item.get("list_items"), list)
+                        else []
+                    )
+                    or item.get("code_body")
+                    or ""
+                )
+                if not str(text).strip():
+                    continue
+                inferred_level = int(item.get("text_level", 0) or 0)
+                if item_type in {"title", "section_header"} and inferred_level <= 0:
+                    inferred_level = int(item.get("level", 1) or 1)
+                if inferred_level > 0:
+                    (
+                        current_heading,
+                        current_level,
+                        current_parent_headings,
+                    ) = _update_heading_context(str(text), inferred_level)
+                _append_block(
+                    str(text),
+                    heading=current_heading,
+                    level=current_level,
+                    parent_headings=current_parent_headings,
+                )
+                continue
+
+            if item_type == "equation":
+                equation_idx += 1
+                eq_id = str(item.get("id") or f"eq-{doc_id}-{equation_idx:04d}")
+                caption = str(item.get("caption") or f"公式{equation_idx}")
+                footnotes = _to_list_str(
+                    item.get("equation_footnote") or item.get("footnotes")
+                )
+                eq_text = str(item.get("text") or item.get("content") or "").strip()
+                wrapped = (
+                    f'<equation id="{eq_id}" format="latex" caption="{caption}">{eq_text}</equation>'
+                    if eq_text
+                    else f'<cite type="equation" refid="{eq_id}">公式{equation_idx}</cite>'
+                )
+                blockid = _append_block(
+                    wrapped,
+                    heading=current_heading,
+                    level=current_level,
+                    parent_headings=current_parent_headings,
+                )
+                equations[eq_id] = {
+                    "id": eq_id,
+                    "blockid": blockid,
+                    "heading": current_heading,
+                    "format": "latex",
+                    "content": eq_text,
+                    "index": equation_idx - 1,
+                    "caption": caption,
+                    "footnotes": footnotes,
+                }
+                continue
+
+            if item_type == "table":
+                table_idx += 1
+                table_id = str(item.get("id") or f"tb-{doc_id}-{table_idx:04d}")
+                caption = str(item.get("caption") or f"表格{table_idx}")
+                table_caption = _to_list_str(item.get("table_caption"))
+                if table_caption and not item.get("caption"):
+                    caption = table_caption[0]
+                footnotes = _to_list_str(
+                    item.get("table_footnote") or item.get("footnotes")
+                )
+                table_body = item.get("table_body") or item.get("content") or ""
+                rows = item.get("rows") if isinstance(item.get("rows"), list) else None
+                (
+                    fmt,
+                    table_content,
+                    normalized_rows,
+                    inferred_num_rows,
+                    inferred_num_cols,
+                ) = _coerce_table_rows(rows if rows is not None else table_body)
+                rows = normalized_rows or (rows if isinstance(rows, list) else [])
+                cite_text = (
+                    f'<cite type="table" refid="{table_id}">表{table_idx}</cite>'
+                )
+                blockid = _append_block(
+                    cite_text,
+                    heading=current_heading,
+                    level=current_level,
+                    parent_headings=current_parent_headings,
+                )
+                tables[table_id] = {
+                    "id": table_id,
+                    "blockid": blockid,
+                    "heading": current_heading,
+                    "dimension": [
+                        _parse_int(item.get("num_rows"), inferred_num_rows),
+                        _parse_int(item.get("num_cols"), inferred_num_cols),
+                    ],
+                    "format": fmt,
+                    "content": table_content,
+                    "index": table_idx - 1,
+                    "caption": caption,
+                    "footnotes": footnotes,
+                    "image": item.get("img_path") or item.get("image"),
+                }
+                continue
+
+            if item_type in {"image", "picture", "drawing"}:
+                drawing_idx += 1
+                drawing_id = str(item.get("id") or f"dr-{doc_id}-{drawing_idx:04d}")
+                image_caption = _to_list_str(
+                    item.get("image_caption") or item.get("captions")
+                )
+                caption = str(
+                    item.get("caption")
+                    or (image_caption[0] if image_caption else f"图{drawing_idx}")
+                )
+                footnotes = _to_list_str(
+                    item.get("image_footnote") or item.get("footnotes")
+                )
+                path_val = str(item.get("img_path") or item.get("path") or "")
+                src_val = str(item.get("src") or "")
+                fmt = (
+                    Path(path_val).suffix.lower().lstrip(".")
+                    if path_val
+                    else str(item.get("format") or "")
+                )
+                drawing_tag = (
+                    f'<drawing id="{drawing_id}" format="{fmt}" caption="{caption}" '
+                    f'path="{path_val}" src="{src_val}" />'
+                )
+                blockid = _append_block(
+                    drawing_tag,
+                    heading=current_heading,
+                    level=current_level,
+                    parent_headings=current_parent_headings,
+                )
+                drawings[drawing_id] = {
+                    "id": drawing_id,
+                    "blockid": blockid,
+                    "heading": current_heading,
+                    "format": fmt,
+                    "path": path_val,
+                    "src": src_val,
+                    "caption": caption,
+                    "footnotes": footnotes,
+                }
+                continue
+
+            # Fallback: serialize unknown item to text for robustness.
+            fallback_text = str(item.get("text") or item.get("content") or "").strip()
+            if fallback_text:
+                _append_block(
+                    fallback_text,
+                    heading=current_heading,
+                    level=current_level,
+                    parent_headings=current_parent_headings,
+                )
+
+        merged_text = "\n\n".join([x for x in merged_parts if x.strip()])
+        doc_hash = hashlib.sha256(merged_text.encode("utf-8")).hexdigest()
+        parsed_time = datetime.now(timezone.utc).isoformat()
+        meta = {
+            "type": "meta",
+            "format": "lightrag",
+            "version": "1.0",
+            "document_name": source_name,
+            "document_format": Path(source_name).suffix.lower().lstrip("."),
+            "document_hash": f"sha256:{doc_hash}",
+            "table_file": bool(tables),
+            "equation_file": bool(equations),
+            "drawing_file": bool(drawings),
+            "asset_dir": False,
+            "split_method": "raw_paragraph",
+            "blocks": len(blocks_lines),
+            "doc_id": doc_id,
+            "parsed_engine": engine,
+            "parsed_time": parsed_time,
+            "analyze_time": "",
+            "doc_title": Path(source_name).stem or source_name,
+        }
+        blocks_path.write_text(
+            "\n".join([json.dumps(meta, ensure_ascii=False)] + blocks_lines) + "\n",
+            encoding="utf-8",
+        )
+
+        if tables:
+            tables_path.write_text(
+                json.dumps(
+                    {"version": "1.0", "tables": tables}, ensure_ascii=False, indent=2
+                ),
+                encoding="utf-8",
+            )
+        if drawings:
+            drawings_path.write_text(
+                json.dumps(
+                    {"version": "1.0", "drawings": drawings},
+                    ensure_ascii=False,
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+        if equations:
+            equations_path.write_text(
+                json.dumps(
+                    {"version": "1.0", "equations": equations},
+                    ensure_ascii=False,
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+
+        # Keep full_docs in sync so restart/reprocess can directly use LightRAG Document.
+        await self.full_docs.upsert(
+            {
+                doc_id: {
+                    "content": merged_text,
+                    "file_path": file_path,
+                    "format": FULL_DOCS_FORMAT_LIGHTRAG,
+                    "lightrag_document_path": str(blocks_path),
+                    "parsed_engine": engine,
+                    "update_time": int(time.time()),
+                }
+            }
+        )
+        return {
+            "doc_id": doc_id,
+            "file_path": file_path,
+            "format": FULL_DOCS_FORMAT_LIGHTRAG,
+            "content": merged_text,
+            "blocks_path": str(blocks_path),
+        }
+
+    def _content_list_to_plain_text(self, content_list: list[dict[str, Any]]) -> str:
+        parts: list[str] = []
+        for item in content_list:
+            if not isinstance(item, dict):
+                continue
+            tp = item.get("type")
+            if tp in {"text", "equation"}:
+                text = item.get("text") or ""
+                if text:
+                    parts.append(str(text))
+            elif tp == "table":
+                caption = item.get("table_caption") or []
+                body = item.get("table_body") or ""
+                parts.append(f"[TABLE] {caption} {body}")
+            elif tp == "image":
+                caption = item.get("image_caption") or []
+                parts.append(f"[IMAGE] {caption}")
+        return "\n\n".join([x for x in parts if str(x).strip()])
+
+    async def parse_native(
+        self, doc_id: str, file_path: str, content_data: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Phase 1 parse for native/raw, lightrag and pending_parse formats."""
+        doc_format = content_data.get("format", FULL_DOCS_FORMAT_RAW)
+        if doc_format == FULL_DOCS_FORMAT_LIGHTRAG:
+            doc_path = content_data.get("lightrag_document_path") or file_path
+            merged_text, blocks_path = await self._load_lightrag_document_content(
+                str(doc_path)
+            )
+            return {
+                "doc_id": doc_id,
+                "file_path": file_path,
+                "format": doc_format,
+                "content": merged_text,
+                "blocks_path": blocks_path,
+            }
+
+        if doc_format == FULL_DOCS_FORMAT_PENDING_PARSE:
+            source_path = self._resolve_source_file_for_parser(file_path)
+            p = Path(source_path)
+            if p.exists() and p.is_file() and p.suffix.lower() == ".docx":
+                try:
+                    from lightrag.extraction.parse_document import (
+                        parse_docx_to_interchange_jsonl,
+                    )
+
+                    file_bytes = await asyncio.to_thread(p.read_bytes)
+                    parsed_dir = Path(self.working_dir) / PARSED_DIR_NAME
+                    parsed_dir.mkdir(parents=True, exist_ok=True)
+                    output_dir = str(parsed_dir)
+                    interchange_text = await asyncio.to_thread(
+                        parse_docx_to_interchange_jsonl,
+                        file_bytes,
+                        p.name,
+                        doc_id,
+                        output_dir,
+                    )
+                    if interchange_text and interchange_text.strip():
+                        await self.full_docs.upsert(
+                            {
+                                doc_id: {
+                                    "content": interchange_text,
+                                    "file_path": file_path,
+                                    "format": FULL_DOCS_FORMAT_RAW,
+                                    "update_time": int(time.time()),
+                                }
+                            }
+                        )
+                        logger.info(
+                            f"[parse_native] pending_parse completed for {file_path} via interchange JSONL"
+                        )
+                        return {
+                            "doc_id": doc_id,
+                            "file_path": file_path,
+                            "format": FULL_DOCS_FORMAT_RAW,
+                            "content": interchange_text,
+                            "blocks_path": "",
+                        }
+                except Exception as e:
+                    logger.warning(
+                        f"[parse_native] pending_parse interchange failed for {file_path}: {e}, fallback to basic extraction"
+                    )
+            if p.exists() and p.is_file():
+                try:
+                    file_bytes = await asyncio.to_thread(p.read_bytes)
+                    from lightrag.api.routers.document_routes import _extract_docx
+
+                    content = await asyncio.to_thread(_extract_docx, file_bytes)
+                    await self.full_docs.upsert(
+                        {
+                            doc_id: {
+                                "content": content,
+                                "file_path": file_path,
+                                "format": FULL_DOCS_FORMAT_RAW,
+                                "update_time": int(time.time()),
+                            }
+                        }
+                    )
+                    return {
+                        "doc_id": doc_id,
+                        "file_path": file_path,
+                        "format": FULL_DOCS_FORMAT_RAW,
+                        "content": content,
+                        "blocks_path": "",
+                    }
+                except Exception as fallback_err:
+                    logger.warning(
+                        f"[parse_native] pending_parse fallback also failed for {file_path}: {fallback_err}"
+                    )
+            return {
+                "doc_id": doc_id,
+                "file_path": file_path,
+                "format": FULL_DOCS_FORMAT_RAW,
+                "content": content_data.get("content", ""),
+                "blocks_path": "",
+            }
+
+        return {
+            "doc_id": doc_id,
+            "file_path": file_path,
+            "format": FULL_DOCS_FORMAT_RAW,
+            "content": content_data.get("content", ""),
+            "blocks_path": "",
+        }
+
+    async def parse_mineru(
+        self, doc_id: str, file_path: str, content_data: dict[str, Any]
+    ) -> dict[str, Any]:
+        endpoint = os.getenv(
+            "MINERU_ENDPOINT", "https://mineru.net/api/v4/extract/task"
+        ).strip()
+        try:
+            if endpoint:
+                protocol = {
+                    "upload_url": endpoint,
+                    "poll_url_template": os.getenv(
+                        "MINERU_POLL_ENDPOINT",
+                        endpoint + "/{trace_id}",
+                    ),
+                    "poll_method": os.getenv("MINERU_POLL_METHOD", "GET"),
+                    "id_field": os.getenv("MINERU_ID_FIELD", "trace_id"),
+                    "status_field": os.getenv("MINERU_STATUS_FIELD", "status"),
+                    "result_url_field": os.getenv(
+                        "MINERU_RESULT_URL_FIELD", "result_url"
+                    ),
+                    "content_field": os.getenv("MINERU_CONTENT_FIELD", "content"),
+                    "success_values": os.getenv(
+                        "MINERU_SUCCESS_VALUES",
+                        "done,success,succeeded,completed,finished",
+                    ),
+                    "failed_values": os.getenv("MINERU_FAILED_VALUES", "failed,error"),
+                    "poll_interval_seconds": float(
+                        os.getenv("MINERU_POLL_INTERVAL_SECONDS", "2")
+                    ),
+                    "max_polls": int(os.getenv("MINERU_MAX_POLLS", "180")),
+                }
+                source_file_path = self._resolve_source_file_for_parser(file_path)
+                result_text = await self._call_protocol_parse_service(
+                    protocol=protocol,
+                    file_path=source_file_path,
+                )
+                content_list = self._normalize_parser_result_to_content_list(
+                    result_text
+                )
+                if content_list:
+                    return await self._write_lightrag_document_from_content_list(
+                        doc_id=doc_id,
+                        file_path=file_path,
+                        content_list=content_list,
+                        engine="mineru",
+                    )
+                if result_text:
+                    return {
+                        "doc_id": doc_id,
+                        "file_path": file_path,
+                        "format": FULL_DOCS_FORMAT_RAW,
+                        "content": str(result_text),
+                        "blocks_path": "",
+                    }
+        except Exception as e:
+            logger.warning(f"MinerU async service failed, fallback local/native: {e}")
+
+        raganything_content_list = await self._parse_via_local_raganything(
+            engine="mineru",
+            file_path=file_path,
+        )
+        if raganything_content_list:
+            return await self._write_lightrag_document_from_content_list(
+                doc_id=doc_id,
+                file_path=file_path,
+                content_list=raganything_content_list,
+                engine="mineru",
+            )
+
+        return await self.parse_native(doc_id, file_path, content_data)
+
+    async def parse_docling(
+        self, doc_id: str, file_path: str, content_data: dict[str, Any]
+    ) -> dict[str, Any]:
+        endpoint = os.getenv(
+            "DOCLING_ENDPOINT", "http://localhost:8081/v1/convert/file/async"
+        ).strip()
+        try:
+            if endpoint:
+                protocol = {
+                    "upload_url": endpoint,
+                    "poll_url_template": os.getenv(
+                        "DOCLING_POLL_ENDPOINT",
+                        endpoint + "/{task_id}",
+                    ),
+                    "poll_method": os.getenv("DOCLING_POLL_METHOD", "GET"),
+                    "id_field": os.getenv("DOCLING_ID_FIELD", "task_id"),
+                    "status_field": os.getenv("DOCLING_STATUS_FIELD", "status"),
+                    "result_url_field": os.getenv(
+                        "DOCLING_RESULT_URL_FIELD", "result_url"
+                    ),
+                    "content_field": os.getenv("DOCLING_CONTENT_FIELD", "content"),
+                    "success_values": os.getenv(
+                        "DOCLING_SUCCESS_VALUES",
+                        "done,success,succeeded,completed,finished",
+                    ),
+                    "failed_values": os.getenv("DOCLING_FAILED_VALUES", "failed,error"),
+                    "poll_interval_seconds": float(
+                        os.getenv("DOCLING_POLL_INTERVAL_SECONDS", "2")
+                    ),
+                    "max_polls": int(os.getenv("DOCLING_MAX_POLLS", "180")),
+                }
+                source_file_path = self._resolve_source_file_for_parser(file_path)
+                result_text = await self._call_protocol_parse_service(
+                    protocol=protocol,
+                    file_path=source_file_path,
+                )
+                content_list = self._normalize_parser_result_to_content_list(
+                    result_text
+                )
+                if content_list:
+                    return await self._write_lightrag_document_from_content_list(
+                        doc_id=doc_id,
+                        file_path=file_path,
+                        content_list=content_list,
+                        engine="docling",
+                    )
+                if result_text:
+                    return {
+                        "doc_id": doc_id,
+                        "file_path": file_path,
+                        "format": FULL_DOCS_FORMAT_RAW,
+                        "content": str(result_text),
+                        "blocks_path": "",
+                    }
+        except Exception as e:
+            logger.warning(f"Docling async service failed, fallback local/native: {e}")
+
+        raganything_content_list = await self._parse_via_local_raganything(
+            engine="docling",
+            file_path=file_path,
+        )
+        if raganything_content_list:
+            return await self._write_lightrag_document_from_content_list(
+                doc_id=doc_id,
+                file_path=file_path,
+                content_list=raganything_content_list,
+                engine="docling",
+            )
+
+        return await self.parse_native(doc_id, file_path, content_data)
+
+    async def _run_multimodal_postprocess_hook(
+        self,
+        doc_id: str,
+        file_path: str,
+        chunking_result: list[dict[str, Any]] | tuple[dict[str, Any], ...],
+        extraction_meta: dict[str, Any],
+    ) -> list[dict[str, Any]] | tuple[dict[str, Any], ...]:
+        """Multimodal post-process entrypoint.
+
+        Placement:
+            interchange parsing -> [this hook] -> entity extraction
+
+        Default behavior is no-op. This method defines a stable extension point
+        for integrating RAG-Anything multimodal processors.
+        """
+        addon_params = self.addon_params if isinstance(self.addon_params, dict) else {}
+        if not addon_params.get("enable_multimodal_pipeline", False):
+            return chunking_result
+
+        extraction_format = extraction_meta.get("extraction_format")
+        capabilities = set(extraction_meta.get("engine_capabilities", []) or [])
+        if extraction_format != "interchange_jsonl":
+            return chunking_result
+        if not capabilities.intersection({"i", "e", "t"}):
+            return chunking_result
+
+        logger.info(
+            f"[multimodal-hook] enabled for d-id: {doc_id}, file: {file_path}, "
+            f"engine={extraction_meta.get('engine')}, caps={sorted(capabilities)}"
+        )
+
+        # TODO(RAG-Anything integration):
+        # 1) convert interchange chunks -> RAG-Anything content_list
+        # 2) call modal processors (image/table/equation) using vlm_llm_model_func (VLM role)
+        # 3) merge multimodal outputs back into chunk dicts
+        # 4) keep chunk_order_index continuity and chunk_id stability
+        return chunking_result
+
+    def _build_mm_chunks_from_sidecars(
+        self,
+        doc_id: str,
+        file_path: str,
+        blocks_path: str,
+        base_order_index: int,
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        """Build multimodal chunks and modality descriptors from sidecars."""
+        block_file = Path(blocks_path)
+        if not block_file.exists():
+            return [], []
+
+        base = str(block_file)
+        if base.endswith(".blocks.jsonl"):
+            base = base[: -len(".blocks.jsonl")]
+
+        sidecar_defs = [
+            ("drawings", Path(base + ".drawings.json"), "drawing"),
+            ("tables", Path(base + ".tables.json"), "table"),
+            ("equations", Path(base + ".equations.json"), "equation"),
+        ]
+
+        mm_chunks: list[dict[str, Any]] = []
+        mm_specs: list[dict[str, Any]] = []
+        order = base_order_index
+
+        def _norm_list(v: Any) -> list[str]:
+            if v is None:
+                return []
+            if isinstance(v, list):
+                return [str(x).strip() for x in v if str(x).strip()]
+            s = str(v).strip()
+            return [s] if s else []
+
+        def _mm_entity_name(kind: str, raw_payload: dict[str, Any]) -> str:
+            payload = json.dumps(raw_payload, ensure_ascii=False, sort_keys=True)
+            digest = hashlib.md5(payload.encode("utf-8")).hexdigest()
+            return f"{kind}-{digest}"
+
+        for root_key, sidecar_path, kind in sidecar_defs:
+            if not sidecar_path.exists():
+                continue
+            try:
+                payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            items = payload.get(root_key, {})
+            if not isinstance(items, dict):
+                continue
+
+            for local_idx, (item_id, item) in enumerate(items.items()):
+                if not isinstance(item, dict):
+                    continue
+
+                analysis = (
+                    item.get("llm_analyze_result")
+                    if isinstance(item.get("llm_analyze_result"), dict)
+                    else {}
+                )
+                name = str(analysis.get("name") or item.get("caption") or item_id)
+                summary = str(analysis.get("summary") or "").strip()
+                detail = str(analysis.get("detail_description") or "").strip()
+                heading = str(item.get("heading") or "").strip()
+                captions = _norm_list(item.get("caption"))
+                footnotes = _norm_list(item.get("footnotes"))
+                image_type = str(analysis.get("image_type") or "").strip()
+
+                raw_for_hash: dict[str, Any] = {
+                    "kind": kind,
+                    "name": name,
+                    "summary": summary,
+                    "detail": detail,
+                    "content": item.get("content"),
+                    "path": item.get("path"),
+                    "src": item.get("src"),
+                    "caption": item.get("caption"),
+                }
+                entity_name = _mm_entity_name(kind, raw_for_hash)
+                chunk_id = f"{doc_id}-mm-{kind}-{local_idx:03d}"
+
+                if kind == "drawing":
+                    lines = [
+                        f"Image_Name: {name}",
+                    ]
+                    if image_type:
+                        lines.append(f"Image_Type: {image_type}")
+                    lines.extend(
+                        [
+                            "Image_Location:",
+                            f"  - Document_Name: {Path(file_path).name}",
+                        ]
+                    )
+                    if heading:
+                        lines.append(f"  - Session_Heading: {heading}")
+                    if captions:
+                        lines.append("Image_Captions:")
+                        lines.extend([f"  - {x}" for x in captions])
+                    if footnotes:
+                        lines.append("Image_Footnotes:")
+                        lines.extend([f"  - {x}" for x in footnotes])
+                    if summary:
+                        lines.append(f'Image_Summary: "{summary}"')
+                    if detail:
+                        lines.append(f'Image_Detail_Description: "{detail}"')
+                elif kind == "table":
+                    lines = [
+                        f"Table_Name: {name}",
+                        "Table_Location:",
+                        f"  - Document_Name: {Path(file_path).name}",
+                    ]
+                    if heading:
+                        lines.append(f"  - Session_Heading: {heading}")
+                    if captions:
+                        lines.append("Table_Captions:")
+                        lines.extend([f"  - {x}" for x in captions])
+                    if footnotes:
+                        lines.append("Table_Footnotes:")
+                        lines.extend([f"  - {x}" for x in footnotes])
+                    if summary:
+                        lines.append(f'Table_Summary: "{summary}"')
+                    if detail:
+                        lines.append(f'Table_Detail_Description: "{detail}"')
+                else:
+                    lines = [
+                        f"Equation_Name: {name}",
+                        "Equation_Location:",
+                        f"  - Document_Name: {Path(file_path).name}",
+                    ]
+                    if heading:
+                        lines.append(f"  - Session_Heading: {heading}")
+                    if captions:
+                        lines.append("Equation_Captions:")
+                        lines.extend([f"  - {x}" for x in captions])
+                    if footnotes:
+                        lines.append("Equation_Footnotes:")
+                        lines.extend([f"  - {x}" for x in footnotes])
+                    if summary:
+                        lines.append(f'Equation_Summary: "{summary}"')
+                    if detail:
+                        lines.append(f'Equation_Detail_Description: "{detail}"')
+
+                chunk_content = "\n".join(lines).strip()
+                if not chunk_content:
+                    continue
+
+                mm_chunks.append(
+                    {
+                        "chunk_id": chunk_id,
+                        "chunk_order_index": order,
+                        "content": chunk_content,
+                        "tokens": len(self.tokenizer.encode(chunk_content)),
+                        "content_type": kind,
+                        "heading": heading,
+                        "parent_headings": [],
+                        "level": 0,
+                    }
+                )
+                mm_specs.append(
+                    {
+                        "kind": kind,
+                        "chunk_id": chunk_id,
+                        "entity_name": entity_name,
+                        "entity_type": kind,
+                        "name": name,
+                        "caption_text": "; ".join(captions),
+                        "heading": heading,
+                        "summary": summary,
+                    }
+                )
+                order += 1
+
+        return mm_chunks, mm_specs
+
+    def _augment_chunk_results_with_mm_entities(
+        self,
+        chunk_results: list,
+        mm_specs: list[dict[str, Any]],
+        file_path: str,
+    ) -> list:
+        """Inject modality object entities and relations into merge inputs."""
+        if not mm_specs:
+            return chunk_results
+
+        extracted_by_chunk: dict[str, set[str]] = {}
+        for maybe_nodes, _ in chunk_results:
+            if not isinstance(maybe_nodes, dict):
+                continue
+            for entity_name, entity_records in maybe_nodes.items():
+                if not isinstance(entity_records, list):
+                    continue
+                for rec in entity_records:
+                    if not isinstance(rec, dict):
+                        continue
+                    source_id = str(rec.get("source_id") or "")
+                    if not source_id:
+                        continue
+                    extracted_by_chunk.setdefault(source_id, set()).add(
+                        str(entity_name)
+                    )
+
+        now_ts = int(time.time())
+        mm_nodes: dict[str, list[dict[str, Any]]] = {}
+        mm_edges: dict[tuple[str, str], list[dict[str, Any]]] = {}
+        for spec in mm_specs:
+            src = str(spec["entity_name"])
+            chunk_id = str(spec["chunk_id"])
+            kind = str(spec["kind"])
+            title = str(spec.get("name") or src)
+            caption_text = str(spec.get("caption_text") or "").strip()
+            heading = str(spec.get("heading") or "").strip()
+            summary = str(spec.get("summary") or "").strip()
+
+            mm_nodes.setdefault(src, []).append(
+                {
+                    "entity_name": src,
+                    "entity_type": kind,
+                    "description": summary or f"{kind} object: {title}",
+                    "source_id": chunk_id,
+                    "file_path": file_path,
+                    "timestamp": now_ts,
+                }
+            )
+
+            targets = extracted_by_chunk.get(chunk_id, set())
+            for tgt in sorted(targets):
+                if tgt == src:
+                    continue
+                desc = (
+                    f"Entity `{tgt}` is associated with {kind} `{title}` "
+                    f"in section `{heading or 'unknown'}`."
+                )
+                if caption_text:
+                    desc += f" Captions: {caption_text}."
+                edge_key = tuple(sorted((src, tgt)))
+                mm_edges.setdefault(edge_key, []).append(
+                    {
+                        "src_id": src,
+                        "tgt_id": tgt,
+                        "weight": 1.0,
+                        "description": desc,
+                        "keywords": "belongs to,part of,contained in",
+                        "source_id": chunk_id,
+                        "file_path": file_path,
+                        "timestamp": now_ts,
+                    }
+                )
+
+        if mm_nodes or mm_edges:
+            chunk_results = list(chunk_results) + [(mm_nodes, mm_edges)]
+        return chunk_results
 
     async def _insert_done(
         self, pipeline_status=None, pipeline_status_lock=None
@@ -2848,7 +5326,11 @@ class LightRAG:
                 )
             elif param.mode == "bypass":
                 # Bypass mode: directly use LLM without knowledge retrieval
-                use_llm_func = param.model_func or global_config["llm_model_func"]
+                use_llm_func = (
+                    param.model_func
+                    or global_config.get("query_llm_model_func")
+                    or global_config["llm_model_func"]
+                )
                 # Apply higher priority (8) to entity/relation summary tasks
                 use_llm_func = partial(use_llm_func, _priority=8)
 

--- a/lightrag/llm/anthropic.py
+++ b/lightrag/llm/anthropic.py
@@ -84,6 +84,7 @@ async def anthropic_complete_if_cache(
 
     kwargs.pop("hashing_kv", None)
     kwargs.pop("keyword_extraction", None)
+    kwargs.pop("entity_extraction", None)
     timeout = kwargs.pop("timeout", None)
 
     anthropic_async_client = (

--- a/lightrag/llm/bedrock.py
+++ b/lightrag/llm/bedrock.py
@@ -337,9 +337,15 @@ async def bedrock_complete_if_cache(
 
 # Generic Bedrock completion function
 async def bedrock_complete(
-    prompt, system_prompt=None, history_messages=[], keyword_extraction=False, **kwargs
+    prompt,
+    system_prompt=None,
+    history_messages=[],
+    keyword_extraction=False,
+    entity_extraction=False,
+    **kwargs,
 ) -> Union[str, AsyncIterator[str]]:
     kwargs.pop("keyword_extraction", None)
+    kwargs.pop("entity_extraction", None)
     model_name = kwargs["hashing_kv"].global_config["llm_model_name"]
     result = await bedrock_complete_if_cache(
         model_name,

--- a/lightrag/llm/binding_options.py
+++ b/lightrag/llm/binding_options.py
@@ -342,6 +342,80 @@ class BindingOptions:
 
         return options
 
+    @classmethod
+    def options_dict_for_role(
+        cls, args: Namespace, role: str, is_cross_provider: bool = False
+    ) -> dict[str, Any]:
+        """
+        Extract role-specific provider options with proper inheritance.
+
+        Same provider:
+        - inherit the base binding options from parsed args
+        - overlay any role-specific environment variable overrides
+
+        Cross provider:
+        - start from the provider defaults
+        - overlay any role-specific environment variable overrides
+
+        Role env vars follow the pattern:
+        `{ROLE}_{BINDING_PREFIX}_{FIELD}`
+        e.g. `EXTRACT_OPENAI_LLM_TEMPERATURE`
+        """
+        import dataclasses
+        import os
+
+        if is_cross_provider:
+            if dataclasses.is_dataclass(cls):
+                base: dict[str, Any] = {}
+                for dataclass_field in dataclasses.fields(cls):
+                    if dataclass_field.name.startswith("_"):
+                        continue
+                    if dataclass_field.default is not dataclasses.MISSING:
+                        base[dataclass_field.name] = dataclass_field.default
+                    elif dataclass_field.default_factory is not dataclasses.MISSING:
+                        base[dataclass_field.name] = dataclass_field.default_factory()
+            else:
+                base = dict(cls._all_class_vars(cls))
+        else:
+            base = cls.options_dict(args)
+
+        role_upper = role.upper()
+        env_prefix = cls._binding_name.upper() + "_"
+
+        for arg_item in cls.args_env_name_type_value():
+            original_env = arg_item["env_name"]
+            role_env = f"{role_upper}_{original_env}"
+            field_name = original_env[len(env_prefix) :].lower()
+
+            env_raw = os.getenv(role_env)
+            if env_raw is None:
+                continue
+
+            field_type = _resolve_optional_type(arg_item["type"])
+            try:
+                if field_type is bool:
+                    base[field_name] = env_raw.lower() in (
+                        "true",
+                        "1",
+                        "yes",
+                        "t",
+                        "on",
+                    )
+                elif field_type in (list, List[str]):
+                    base[field_name] = json.loads(env_raw)
+                elif field_type is dict:
+                    base[field_name] = json.loads(env_raw)
+                elif field_type is int:
+                    base[field_name] = int(env_raw)
+                elif field_type is float:
+                    base[field_name] = float(env_raw)
+                else:
+                    base[field_name] = env_raw
+            except (ValueError, json.JSONDecodeError):
+                base[field_name] = env_raw
+
+        return base
+
     def asdict(self) -> dict[str, Any]:
         """
         Convert an instance of binding options to a dictionary.

--- a/lightrag/llm/gemini.py
+++ b/lightrag/llm/gemini.py
@@ -120,6 +120,7 @@ def _build_generation_config(
     base_config: dict[str, Any] | None,
     system_prompt: str | None,
     keyword_extraction: bool,
+    entity_extraction: bool = False,
 ) -> types.GenerateContentConfig | None:
     config_data = dict(base_config or {})
 
@@ -131,7 +132,9 @@ def _build_generation_config(
         else:
             config_data["system_instruction"] = system_prompt
 
-    if keyword_extraction and not config_data.get("response_mime_type"):
+    if (keyword_extraction or entity_extraction) and not config_data.get(
+        "response_mime_type"
+    ):
         config_data["response_mime_type"] = "application/json"
 
     # Remove entries that are explicitly set to None to avoid type errors
@@ -226,6 +229,7 @@ async def gemini_complete_if_cache(
     token_tracker: Any | None = None,
     stream: bool | None = None,
     keyword_extraction: bool = False,
+    entity_extraction: bool = False,
     generation_config: dict[str, Any] | None = None,
     timeout: int | None = None,
     **_: Any,
@@ -282,6 +286,7 @@ async def gemini_complete_if_cache(
         generation_config,
         system_prompt=system_prompt,
         keyword_extraction=keyword_extraction,
+        entity_extraction=entity_extraction,
     )
 
     request_kwargs: dict[str, Any] = {
@@ -440,8 +445,10 @@ async def gemini_model_complete(
     system_prompt: str | None = None,
     history_messages: list[dict[str, Any]] | None = None,
     keyword_extraction: bool = False,
+    entity_extraction: bool = False,
     **kwargs: Any,
 ) -> str | AsyncIterator[str]:
+    entity_extraction = kwargs.pop("entity_extraction", entity_extraction)
     hashing_kv = kwargs.get("hashing_kv")
     model_name = None
     if hashing_kv is not None:
@@ -457,6 +464,7 @@ async def gemini_model_complete(
         system_prompt=system_prompt,
         history_messages=history_messages,
         keyword_extraction=keyword_extraction,
+        entity_extraction=entity_extraction,
         **kwargs,
     )
 

--- a/lightrag/llm/hf.py
+++ b/lightrag/llm/hf.py
@@ -126,10 +126,12 @@ async def hf_model_complete(
     system_prompt=None,
     history_messages=[],
     keyword_extraction=False,
+    entity_extraction=False,
     enable_cot: bool = False,
     **kwargs,
 ) -> str:
     kwargs.pop("keyword_extraction", None)
+    kwargs.pop("entity_extraction", None)
     model_name = kwargs["hashing_kv"].global_config["llm_model_name"]
     result = await hf_model_if_cache(
         model_name,

--- a/lightrag/llm/llama_index_impl.py
+++ b/lightrag/llm/llama_index_impl.py
@@ -145,6 +145,7 @@ async def llama_index_complete(
     history_messages=None,
     enable_cot: bool = False,
     keyword_extraction=False,
+    entity_extraction=False,
     settings: LlamaIndexSettings = None,
     **kwargs,
 ) -> str:
@@ -156,6 +157,7 @@ async def llama_index_complete(
         system_prompt: Optional system prompt
         history_messages: Optional chat history
         keyword_extraction: Whether to extract keywords from response
+        entity_extraction: Whether to use JSON structured output for entity extraction
         settings: Optional LlamaIndex settings
         **kwargs: Additional arguments
     """
@@ -163,6 +165,7 @@ async def llama_index_complete(
         history_messages = []
 
     kwargs.pop("keyword_extraction", None)
+    kwargs.pop("entity_extraction", None)
     result = await llama_index_complete_if_cache(
         kwargs.get("llm_instance"),
         prompt,

--- a/lightrag/llm/lmdeploy.py
+++ b/lightrag/llm/lmdeploy.py
@@ -103,6 +103,7 @@ async def lmdeploy_model_if_cache(
         raise ImportError("Please install lmdeploy before initialize lmdeploy backend.")
     kwargs.pop("hashing_kv", None)
     kwargs.pop("response_format", None)
+    kwargs.pop("entity_extraction", None)
     max_new_tokens = kwargs.pop("max_tokens", 512)
     tp = kwargs.pop("tp", 1)
     skip_special_tokens = kwargs.pop("skip_special_tokens", True)

--- a/lightrag/llm/lollms.py
+++ b/lightrag/llm/lollms.py
@@ -112,12 +112,14 @@ async def lollms_model_complete(
     history_messages=[],
     enable_cot: bool = False,
     keyword_extraction=False,
+    entity_extraction=False,
     **kwargs,
 ) -> Union[str, AsyncIterator[str]]:
     """Complete function for lollms model generation."""
 
-    # Extract and remove keyword_extraction from kwargs if present
+    # Extract and remove keyword_extraction and entity_extraction from kwargs if present
     keyword_extraction = kwargs.pop("keyword_extraction", None)
+    kwargs.pop("entity_extraction", None)
 
     # Get model name from config
     model_name = kwargs["hashing_kv"].global_config["llm_model_name"]

--- a/lightrag/llm/ollama.py
+++ b/lightrag/llm/ollama.py
@@ -156,10 +156,12 @@ async def ollama_model_complete(
     history_messages=[],
     enable_cot: bool = False,
     keyword_extraction=False,
+    entity_extraction=False,
     **kwargs,
 ) -> Union[str, AsyncIterator[str]]:
     keyword_extraction = kwargs.pop("keyword_extraction", None)
-    if keyword_extraction:
+    entity_extraction = kwargs.pop("entity_extraction", entity_extraction)
+    if keyword_extraction or entity_extraction:
         kwargs["format"] = "json"
     model_name = kwargs["hashing_kv"].global_config["llm_model_name"]
     return await _ollama_model_if_cache(

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -75,6 +75,31 @@ from dotenv import load_dotenv
 load_dotenv(dotenv_path=Path(__file__).resolve().parent / ".env", override=False)
 
 
+def _get_relationship_vdb_timeout_seconds(global_config: dict[str, Any]) -> float:
+    """Derive a defensive timeout for relation VDB upserts.
+
+    Rationale:
+    - `knowledge_graph_inst.upsert_edge()` for the default NetworkX storage is in-memory and fast.
+    - `relationships_vdb.upsert()` performs embedding calls and remote I/O, which is the more likely
+      point of silent stalls during relation merge.
+    """
+    configured = global_config.get("default_embedding_timeout")
+    try:
+        base_timeout = float(configured)
+    except (TypeError, ValueError):
+        base_timeout = 30.0
+    # Keep a fixed lower bound high enough to avoid false positives on slow providers.
+    return max(base_timeout * 3, 120.0)
+
+
+def _format_relation_edge_label(edge_key: tuple[str, str] | list[str]) -> str:
+    if isinstance(edge_key, tuple):
+        left, right = edge_key
+    else:
+        left, right = edge_key[0], edge_key[1]
+    return f"{left}->{right}"
+
+
 def _truncate_entity_identifier(
     identifier: str, limit: int, chunk_key: str, identifier_role: str
 ) -> str:
@@ -94,6 +119,38 @@ def _truncate_entity_identifier(
         preview,
     )
     return display_value
+
+
+def _truncate_vdb_content(content: str, global_config: dict, content_label: str) -> str:
+    """Clamp vector-store payload size to stay under embedding limits."""
+
+    if not content:
+        return content
+
+    embedding_token_limit = global_config.get("embedding_token_limit")
+    tokenizer: Tokenizer | None = global_config.get("tokenizer")
+    if embedding_token_limit is None or tokenizer is None:
+        return content
+
+    threshold = int(embedding_token_limit)
+    if threshold <= 0:
+        return content
+
+    tokens = tokenizer.encode(content)
+    if len(tokens) <= threshold:
+        return content
+
+    # Leave headroom because tokenizer behavior can differ slightly from the provider.
+    effective_limit = max(threshold - min(256, max(32, threshold // 16)), 1)
+    truncated_content = tokenizer.decode(tokens[:effective_limit])
+    logger.warning(
+        "%s VDB content truncated from %d to %d tokens (embedding limit: %d)",
+        content_label,
+        len(tokens),
+        effective_limit,
+        threshold,
+    )
+    return truncated_content
 
 
 def chunking_by_token_size(
@@ -312,7 +369,9 @@ async def _summarize_descriptions(
     Returns:
         Summarized description string
     """
-    use_llm_func: callable = global_config["llm_model_func"]
+    use_llm_func: callable = (
+        global_config.get("extract_llm_model_func") or global_config["llm_model_func"]
+    )
     # Apply higher priority (8) to entity/relation summary tasks
     use_llm_func = partial(use_llm_func, _priority=8)
 
@@ -548,6 +607,193 @@ async def _handle_single_relationship_extraction(
             f"Relationship extraction failed with unexpected error in chunk {chunk_key}: {e}"
         )
         return None
+
+
+async def _process_json_extraction_result(
+    result: str,
+    chunk_key: str,
+    timestamp: int,
+    file_path: str = "unknown_source",
+) -> tuple[dict, dict]:
+    """Process a JSON-formatted extraction result from LLM.
+
+    This function parses the LLM response as JSON and extracts entities and relationships.
+    It uses json_repair to handle slightly malformed JSON from weaker models.
+
+    Args:
+        result: The JSON extraction result from LLM
+        chunk_key: The chunk key for source tracking
+        timestamp: The timestamp for the extraction
+        file_path: The file path for citation
+
+    Returns:
+        tuple: (nodes_dict, edges_dict) containing the extracted entities and relationships
+    """
+    maybe_nodes = defaultdict(list)
+    maybe_edges = defaultdict(list)
+
+    try:
+        # Parse the JSON response using json_repair for robustness
+        parsed = json_repair.loads(result)
+    except Exception as e:
+        logger.warning(f"{chunk_key}: Failed to parse JSON extraction result: {e}")
+        return dict(maybe_nodes), dict(maybe_edges)
+
+    if not isinstance(parsed, dict):
+        logger.warning(
+            f"{chunk_key}: JSON extraction result is not a dict, got {type(parsed).__name__}"
+        )
+        return dict(maybe_nodes), dict(maybe_edges)
+
+    # Process entities
+    entities_list = parsed.get("entities", [])
+    if not isinstance(entities_list, list):
+        logger.warning(
+            f"{chunk_key}: 'entities' field is not a list in JSON extraction result"
+        )
+        entities_list = []
+
+    for entity_data in entities_list:
+        if not isinstance(entity_data, dict):
+            continue
+
+        try:
+            entity_name = sanitize_and_normalize_extracted_text(
+                str(entity_data.get("entity_name", "")), remove_inner_quotes=True
+            )
+            if not entity_name or not entity_name.strip():
+                logger.info(
+                    f"{chunk_key}: Empty entity name found after sanitization in JSON result"
+                )
+                continue
+
+            entity_type = sanitize_and_normalize_extracted_text(
+                str(entity_data.get("entity_type", "")), remove_inner_quotes=True
+            )
+            if not entity_type.strip() or any(
+                char in entity_type
+                for char in ["'", "(", ")", "<", ">", "|", "/", "\\"]
+            ):
+                logger.warning(
+                    f"{chunk_key}: Invalid entity type '{entity_type}' for entity '{entity_name}'"
+                )
+                continue
+
+            entity_type = entity_type.replace(" ", "").lower()
+
+            entity_description = sanitize_and_normalize_extracted_text(
+                str(entity_data.get("entity_description", ""))
+            )
+            if not entity_description.strip():
+                logger.warning(
+                    f"{chunk_key}: Empty description for entity '{entity_name}'"
+                )
+                continue
+
+            truncated_name = _truncate_entity_identifier(
+                entity_name,
+                DEFAULT_ENTITY_NAME_MAX_LENGTH,
+                chunk_key,
+                "Entity name",
+            )
+
+            node_data = dict(
+                entity_name=truncated_name,
+                entity_type=entity_type,
+                description=entity_description,
+                source_id=chunk_key,
+                file_path=file_path,
+                timestamp=timestamp,
+            )
+            maybe_nodes[truncated_name].append(node_data)
+
+        except Exception as e:
+            logger.warning(
+                f"{chunk_key}: Failed to process entity from JSON result: {e}"
+            )
+            continue
+
+    # Process relationships
+    relationships_list = parsed.get("relationships", [])
+    if not isinstance(relationships_list, list):
+        logger.warning(
+            f"{chunk_key}: 'relationships' field is not a list in JSON extraction result"
+        )
+        relationships_list = []
+
+    for rel_data in relationships_list:
+        if not isinstance(rel_data, dict):
+            continue
+
+        try:
+            source = sanitize_and_normalize_extracted_text(
+                str(rel_data.get("source_entity", "")), remove_inner_quotes=True
+            )
+            target = sanitize_and_normalize_extracted_text(
+                str(rel_data.get("target_entity", "")), remove_inner_quotes=True
+            )
+
+            if not source:
+                logger.info(
+                    f"{chunk_key}: Empty source entity in JSON relationship result"
+                )
+                continue
+            if not target:
+                logger.info(
+                    f"{chunk_key}: Empty target entity in JSON relationship result"
+                )
+                continue
+            if source == target:
+                logger.debug(f"{chunk_key}: Source and target are the same: '{source}'")
+                continue
+
+            edge_keywords = sanitize_and_normalize_extracted_text(
+                str(rel_data.get("relationship_keywords", "")), remove_inner_quotes=True
+            )
+            edge_keywords = edge_keywords.replace("，", ",")
+
+            edge_description = sanitize_and_normalize_extracted_text(
+                str(rel_data.get("relationship_description", ""))
+            )
+
+            if not edge_description.strip():
+                logger.warning(
+                    f"{chunk_key}: Empty description for relationship '{source}' ~ '{target}', skipping"
+                )
+                continue
+
+            truncated_source = _truncate_entity_identifier(
+                source,
+                DEFAULT_ENTITY_NAME_MAX_LENGTH,
+                chunk_key,
+                "Relation entity",
+            )
+            truncated_target = _truncate_entity_identifier(
+                target,
+                DEFAULT_ENTITY_NAME_MAX_LENGTH,
+                chunk_key,
+                "Relation entity",
+            )
+
+            edge_data = dict(
+                src_id=truncated_source,
+                tgt_id=truncated_target,
+                weight=1.0,
+                description=edge_description,
+                keywords=edge_keywords,
+                source_id=chunk_key,
+                file_path=file_path,
+                timestamp=timestamp,
+            )
+            maybe_edges[(truncated_source, truncated_target)].append(edge_data)
+
+        except Exception as e:
+            logger.warning(
+                f"{chunk_key}: Failed to process relationship from JSON result: {e}"
+            )
+            continue
+
+    return dict(maybe_nodes), dict(maybe_edges)
 
 
 async def rebuild_knowledge_from_chunks(
@@ -1058,7 +1304,11 @@ async def _rebuild_from_extraction_result(
     chunk_id: str,
     timestamp: int,
 ) -> tuple[dict, dict]:
-    """Parse cached extraction result using the same logic as extract_entities
+    """Parse cached extraction result using the same logic as extract_entities.
+
+    Supports both JSON and delimiter-based formats for backward compatibility.
+    Attempts JSON parsing first; if the cached result looks like JSON (starts with '{'),
+    uses the JSON parser. Otherwise, falls back to the traditional delimiter-based parser.
 
     Args:
         text_chunks_storage: Text chunks storage to get chunk data
@@ -1077,7 +1327,22 @@ async def _rebuild_from_extraction_result(
         else "unknown_source"
     )
 
-    # Call the shared processing function
+    # Auto-detect format: try JSON first if the result looks like JSON
+    stripped_result = extraction_result.strip()
+    if stripped_result.startswith("{") or stripped_result.startswith("["):
+        # Likely JSON format (from entity_extraction_use_json mode)
+        nodes, edges = await _process_json_extraction_result(
+            extraction_result,
+            chunk_id,
+            timestamp,
+            file_path,
+        )
+        # If JSON parsing yielded results, use them
+        if nodes or edges:
+            return nodes, edges
+        # Otherwise fall through to text-based parsing
+
+    # Fall back to traditional delimiter-based parsing
     return await _process_extraction_result(
         extraction_result,
         chunk_id,
@@ -1132,7 +1397,11 @@ async def _rebuild_single_entity(
 
             # Update entity in vector database (equally critical)
             entity_vdb_id = compute_mdhash_id(entity_name, prefix="ent-")
-            entity_content = f"{entity_name}\n{final_description}"
+            entity_content = _truncate_vdb_content(
+                f"{entity_name}\n{final_description}",
+                global_config,
+                f"entity:{entity_name}",
+            )
 
             vdb_data = {
                 entity_vdb_id: {
@@ -1525,7 +1794,11 @@ async def _rebuild_single_relationship(
             # Update entity_vdb for the newly created entity
             if entities_vdb is not None:
                 entity_vdb_id = compute_mdhash_id(node_id, prefix="ent-")
-                entity_content = f"{node_id}\n{node_description}"
+                entity_content = _truncate_vdb_content(
+                    f"{node_id}\n{node_description}",
+                    global_config,
+                    f"entity:{node_id}",
+                )
                 vdb_data = {
                     entity_vdb_id: {
                         "content": entity_content,
@@ -1895,7 +2168,11 @@ async def _merge_nodes_then_upsert(
     node_data["entity_name"] = entity_name
     if entity_vdb is not None:
         entity_vdb_id = compute_mdhash_id(str(entity_name), prefix="ent-")
-        entity_content = f"{entity_name}\n{description}"
+        entity_content = _truncate_vdb_content(
+            f"{entity_name}\n{description}",
+            global_config,
+            f"entity:{entity_name}",
+        )
         data_for_vdb = {
             entity_vdb_id: {
                 "entity_name": entity_name,
@@ -1932,6 +2209,8 @@ async def _merge_edges_then_upsert(
 ):
     if src_id == tgt_id:
         return None
+
+    relation_key = f"{src_id}->{tgt_id}"
 
     already_edge = None
     already_weights = []
@@ -2243,7 +2522,11 @@ async def _merge_edges_then_upsert(
 
             if entity_vdb is not None:
                 entity_vdb_id = compute_mdhash_id(need_insert_id, prefix="ent-")
-                entity_content = f"{need_insert_id}\n{description}"
+                entity_content = _truncate_vdb_content(
+                    f"{need_insert_id}\n{description}",
+                    global_config,
+                    f"entity:{need_insert_id}",
+                )
                 vdb_data = {
                     entity_vdb_id: {
                         "content": entity_content,
@@ -2256,9 +2539,14 @@ async def _merge_edges_then_upsert(
                 await safe_vdb_operation_with_exception(
                     operation=lambda payload=vdb_data: entity_vdb.upsert(payload),
                     operation_name="added_entity_upsert",
-                    entity_name=need_insert_id,
+                    entity_name=f"{need_insert_id} [relation:{relation_key}]",
                     max_retries=3,
                     retry_delay=0.1,
+                    timeout_seconds=_get_relationship_vdb_timeout_seconds(
+                        global_config
+                    ),
+                    log_start=True,
+                    success_log_threshold_seconds=5.0,
                 )
 
             # Track entities added during edge processing
@@ -2345,8 +2633,10 @@ async def _merge_edges_then_upsert(
                 # Update vector database
                 if entity_vdb is not None:
                     entity_vdb_id = compute_mdhash_id(need_insert_id, prefix="ent-")
-                    entity_content = (
-                        f"{need_insert_id}\n{existing_node.get('description', '')}"
+                    entity_content = _truncate_vdb_content(
+                        f"{need_insert_id}\n{existing_node.get('description', '')}",
+                        global_config,
+                        f"entity:{need_insert_id}",
                     )
                     vdb_data = {
                         entity_vdb_id: {
@@ -2362,9 +2652,14 @@ async def _merge_edges_then_upsert(
                     await safe_vdb_operation_with_exception(
                         operation=lambda payload=vdb_data: entity_vdb.upsert(payload),
                         operation_name="existing_entity_update",
-                        entity_name=need_insert_id,
+                        entity_name=f"{need_insert_id} [relation:{relation_key}]",
                         max_retries=3,
                         retry_delay=0.1,
+                        timeout_seconds=_get_relationship_vdb_timeout_seconds(
+                            global_config
+                        ),
+                        log_start=True,
+                        success_log_threshold_seconds=5.0,
                     )
 
             # 6. Log once at the end if any update occurred
@@ -2377,6 +2672,7 @@ async def _merge_edges_then_upsert(
                         pipeline_status["history_messages"].append(status_message)
 
     edge_created_at = int(time.time())
+    edge_upsert_started = time.perf_counter()
     await knowledge_graph_inst.upsert_edge(
         src_id,
         tgt_id,
@@ -2390,6 +2686,13 @@ async def _merge_edges_then_upsert(
             truncate=truncation_info,
         ),
     )
+    edge_upsert_elapsed = time.perf_counter() - edge_upsert_started
+    if edge_upsert_elapsed >= 5.0:
+        logger.info(
+            "Graph edge upsert slow for `%s` in %.2fs",
+            relation_key,
+            edge_upsert_elapsed,
+        )
 
     edge_data = dict(
         src_id=src_id,
@@ -2416,7 +2719,11 @@ async def _merge_edges_then_upsert(
             logger.debug(
                 f"Could not delete old relationship vector records {rel_vdb_id}, {rel_vdb_id_reverse}: {e}"
             )
-        rel_content = f"{keywords}\t{src_id}\n{tgt_id}\n{description}"
+        rel_content = _truncate_vdb_content(
+            f"{keywords}\t{src_id}\n{tgt_id}\n{description}",
+            global_config,
+            f"relationship:{src_id}-{tgt_id}",
+        )
         vdb_data = {
             rel_vdb_id: {
                 "src_id": src_id,
@@ -2429,12 +2736,20 @@ async def _merge_edges_then_upsert(
                 "file_path": file_path,
             }
         }
+        relation_status_message = f"Upserting relation VDB: `{relation_key}`"
+        logger.info(relation_status_message)
+        if pipeline_status is not None and pipeline_status_lock is not None:
+            async with pipeline_status_lock:
+                pipeline_status["latest_message"] = relation_status_message
         await safe_vdb_operation_with_exception(
             operation=lambda payload=vdb_data: relationships_vdb.upsert(payload),
             operation_name="relationship_upsert",
-            entity_name=f"{src_id}-{tgt_id}",
+            entity_name=relation_key,
             max_retries=3,
             retry_delay=0.2,
+            timeout_seconds=_get_relationship_vdb_timeout_seconds(global_config),
+            log_start=True,
+            success_log_threshold_seconds=5.0,
         )
 
     return edge_data
@@ -2638,6 +2953,7 @@ async def merge_nodes_and_edges(
             workspace = global_config.get("workspace", "")
             namespace = f"{workspace}:GraphDB" if workspace else "GraphDB"
             sorted_edge_key = sorted([edge_key[0], edge_key[1]])
+            edge_label = _format_relation_edge_label(edge_key)
 
             async with get_storage_keyed_lock(
                 sorted_edge_key,
@@ -2647,7 +2963,11 @@ async def merge_nodes_and_edges(
                 try:
                     added_entities = []  # Track entities added during edge processing
 
-                    logger.debug(f"Processing relation {sorted_edge_key}")
+                    logger.info(
+                        "Phase 2 edge start for `%s` with %d fragments",
+                        edge_label,
+                        len(edges),
+                    )
                     edge_data = await _merge_edges_then_upsert(
                         edge_key[0],
                         edge_key[1],
@@ -2665,12 +2985,21 @@ async def merge_nodes_and_edges(
                     )
 
                     if edge_data is None:
+                        logger.info(
+                            "Phase 2 edge done for `%s` with no edge_data",
+                            edge_label,
+                        )
                         return None, []
 
+                    logger.info(
+                        "Phase 2 edge done for `%s` with %d added entities",
+                        edge_label,
+                        len(added_entities),
+                    )
                     return edge_data, added_entities
 
                 except Exception as e:
-                    error_msg = f"Error processing relation `{sorted_edge_key}`: {e}"
+                    error_msg = f"Error processing relation `{edge_label}`: {e}"
                     logger.error(error_msg)
 
                     # Try to update pipeline status, but don't let status update failure affect main exception
@@ -2688,24 +3017,35 @@ async def merge_nodes_and_edges(
                         )
 
                     # Re-raise the original exception with a prefix
-                    prefixed_exception = create_prefixed_exception(
-                        e, f"{sorted_edge_key}"
-                    )
+                    prefixed_exception = create_prefixed_exception(e, f"{edge_label}")
                     raise prefixed_exception from e
 
     # Create relationship processing tasks
     edge_tasks = []
+    edge_task_labels: dict[asyncio.Task, str] = {}
     for edge_key, edges in all_edges.items():
         task = asyncio.create_task(_locked_process_edges(edge_key, edges))
         edge_tasks.append(task)
+        edge_task_labels[task] = _format_relation_edge_label(edge_key)
 
     # Execute relationship tasks with error handling
     processed_edges = []
     all_added_entities = []
 
     if edge_tasks:
+        logger.info(
+            "Phase 2 submitted %d relation tasks for %s",
+            len(edge_tasks),
+            doc_id,
+        )
         done, pending = await asyncio.wait(
             edge_tasks, return_when=asyncio.FIRST_EXCEPTION
+        )
+        logger.info(
+            "Phase 2 wait returned for %s: done=%d pending=%d",
+            doc_id,
+            len(done),
+            len(pending),
         )
 
         first_exception = None
@@ -2722,6 +3062,17 @@ async def merge_nodes_and_edges(
                 all_added_entities.extend(added_entities)
 
         if pending:
+            pending_labels = [
+                edge_task_labels.get(task, "<unknown>") for task in pending
+            ]
+            preview = ", ".join(pending_labels[:10])
+            if len(pending_labels) > 10:
+                preview += f", ... (+{len(pending_labels) - 10} more)"
+            logger.warning(
+                "Phase 2 pending relation tasks for %s: %s",
+                doc_id,
+                preview or "<none>",
+            )
             for task in pending:
                 task.cancel()
             pending_results = await asyncio.gather(*pending, return_exceptions=True)
@@ -2735,8 +3086,22 @@ async def merge_nodes_and_edges(
                         processed_edges.append(edge_data)
                     all_added_entities.extend(added_entities)
 
+            logger.info(
+                "Phase 2 pending relation tasks drained for %s: collected_edges=%d collected_added_entities=%d",
+                doc_id,
+                len(processed_edges),
+                len(all_added_entities),
+            )
+
         if first_exception is not None:
             raise first_exception
+
+        logger.info(
+            "Phase 2 relation processing completed for %s: edges=%d added_entities=%d",
+            doc_id,
+            len(processed_edges),
+            len(all_added_entities),
+        )
 
     # ===== Phase 3: Update full_entities and full_relations storage =====
     if full_entities_storage and full_relations_storage and doc_id:
@@ -2826,8 +3191,13 @@ async def extract_entities(
                     "User cancelled during entity extraction"
                 )
 
-    use_llm_func: callable = global_config["llm_model_func"]
+    use_llm_func: callable = (
+        global_config.get("extract_llm_model_func") or global_config["llm_model_func"]
+    )
     entity_extract_max_gleaning = global_config["entity_extract_max_gleaning"]
+
+    # Check if JSON structured output mode is enabled
+    use_json_extraction = global_config.get("entity_extraction_use_json", False)
 
     ordered_chunks = list(chunks.items())
     # add language and example number params to prompt
@@ -2836,24 +3206,34 @@ async def extract_entities(
         "entity_types", DEFAULT_ENTITY_TYPES
     )
 
-    examples = "\n".join(PROMPTS["entity_extraction_examples"])
+    if use_json_extraction:
+        # JSON mode: use JSON-specific prompts without delimiters
+        examples = "\n".join(PROMPTS["entity_extraction_json_examples"])
+        context_base = dict(
+            entity_types=",".join(entity_types),
+            examples=examples,
+            language=language,
+        )
+        logger.info("Entity extraction using JSON structured output mode")
+    else:
+        # Text mode: use traditional delimiter-based prompts
+        examples = "\n".join(PROMPTS["entity_extraction_examples"])
+        example_context_base = dict(
+            tuple_delimiter=PROMPTS["DEFAULT_TUPLE_DELIMITER"],
+            completion_delimiter=PROMPTS["DEFAULT_COMPLETION_DELIMITER"],
+            entity_types=", ".join(entity_types),
+            language=language,
+        )
+        # add example's format
+        examples = examples.format(**example_context_base)
 
-    example_context_base = dict(
-        tuple_delimiter=PROMPTS["DEFAULT_TUPLE_DELIMITER"],
-        completion_delimiter=PROMPTS["DEFAULT_COMPLETION_DELIMITER"],
-        entity_types=", ".join(entity_types),
-        language=language,
-    )
-    # add example's format
-    examples = examples.format(**example_context_base)
-
-    context_base = dict(
-        tuple_delimiter=PROMPTS["DEFAULT_TUPLE_DELIMITER"],
-        completion_delimiter=PROMPTS["DEFAULT_COMPLETION_DELIMITER"],
-        entity_types=",".join(entity_types),
-        examples=examples,
-        language=language,
-    )
+        context_base = dict(
+            tuple_delimiter=PROMPTS["DEFAULT_TUPLE_DELIMITER"],
+            completion_delimiter=PROMPTS["DEFAULT_COMPLETION_DELIMITER"],
+            entity_types=",".join(entity_types),
+            examples=examples,
+            language=language,
+        )
 
     processed_chunks = 0
     total_chunks = len(ordered_chunks)
@@ -2876,18 +3256,28 @@ async def extract_entities(
         # Create cache keys collector for batch processing
         cache_keys_collector = []
 
-        # Get initial extraction
-        # Format system prompt without input_text for each chunk (enables OpenAI prompt caching across chunks)
-        entity_extraction_system_prompt = PROMPTS[
-            "entity_extraction_system_prompt"
-        ].format(**context_base)
-        # Format user prompts with input_text for each chunk
-        entity_extraction_user_prompt = PROMPTS["entity_extraction_user_prompt"].format(
-            **{**context_base, "input_text": content}
-        )
-        entity_continue_extraction_user_prompt = PROMPTS[
-            "entity_continue_extraction_user_prompt"
-        ].format(**{**context_base, "input_text": content})
+        if use_json_extraction:
+            # JSON mode: use JSON prompts and pass entity_extraction flag to LLM provider
+            entity_extraction_system_prompt = PROMPTS[
+                "entity_extraction_json_system_prompt"
+            ].format(**context_base)
+            entity_extraction_user_prompt = PROMPTS[
+                "entity_extraction_json_user_prompt"
+            ].format(**{**context_base, "input_text": content})
+            entity_continue_extraction_user_prompt = PROMPTS[
+                "entity_continue_extraction_json_user_prompt"
+            ].format(**context_base)
+        else:
+            # Text mode: use traditional delimiter-based prompts
+            entity_extraction_system_prompt = PROMPTS[
+                "entity_extraction_system_prompt"
+            ].format(**context_base)
+            entity_extraction_user_prompt = PROMPTS[
+                "entity_extraction_user_prompt"
+            ].format(**{**context_base, "input_text": content})
+            entity_continue_extraction_user_prompt = PROMPTS[
+                "entity_continue_extraction_user_prompt"
+            ].format(**{**context_base, "input_text": content})
 
         final_result, timestamp = await use_llm_func_with_cache(
             entity_extraction_user_prompt,
@@ -2897,56 +3287,54 @@ async def extract_entities(
             cache_type="extract",
             chunk_id=chunk_key,
             cache_keys_collector=cache_keys_collector,
+            entity_extraction=use_json_extraction,
         )
 
         history = pack_user_ass_to_openai_messages(
             entity_extraction_user_prompt, final_result
         )
 
-        # Process initial extraction with file path
-        maybe_nodes, maybe_edges = await _process_extraction_result(
-            final_result,
-            chunk_key,
-            timestamp,
-            file_path,
-            tuple_delimiter=context_base["tuple_delimiter"],
-            completion_delimiter=context_base["completion_delimiter"],
-        )
+        # Process initial extraction with appropriate parser
+        if use_json_extraction:
+            maybe_nodes, maybe_edges = await _process_json_extraction_result(
+                final_result,
+                chunk_key,
+                timestamp,
+                file_path,
+            )
+        else:
+            maybe_nodes, maybe_edges = await _process_extraction_result(
+                final_result,
+                chunk_key,
+                timestamp,
+                file_path,
+                tuple_delimiter=context_base["tuple_delimiter"],
+                completion_delimiter=context_base["completion_delimiter"],
+            )
 
         # Process additional gleaning results only 1 time when entity_extract_max_gleaning is greater than zero.
         if entity_extract_max_gleaning > 0:
-            # Calculate total tokens for the gleaning request to prevent context window overflow
-            tokenizer = global_config["tokenizer"]
-            max_input_tokens = global_config["max_extract_input_tokens"]
-
-            # Approximate total tokens: system prompt + history + user prompt.
-            # This slightly underestimates actual API usage (missing role/framing tokens)
-            # but is sufficient as a safety guard against context window overflow.
-            history_str = json.dumps(history, ensure_ascii=False)
-            full_context_str = (
-                entity_extraction_system_prompt
-                + history_str
-                + entity_continue_extraction_user_prompt
+            glean_result, timestamp = await use_llm_func_with_cache(
+                entity_continue_extraction_user_prompt,
+                use_llm_func,
+                system_prompt=entity_extraction_system_prompt,
+                llm_response_cache=llm_response_cache,
+                history_messages=history,
+                cache_type="extract",
+                chunk_id=chunk_key,
+                cache_keys_collector=cache_keys_collector,
+                entity_extraction=use_json_extraction,
             )
-            token_count = len(tokenizer.encode(full_context_str))
 
-            if token_count > max_input_tokens:
-                logger.warning(
-                    f"Gleaning stopped for chunk {chunk_key}: Input tokens ({token_count}) exceeded limit ({max_input_tokens})."
+            # Process gleaning result with appropriate parser
+            if use_json_extraction:
+                glean_nodes, glean_edges = await _process_json_extraction_result(
+                    glean_result,
+                    chunk_key,
+                    timestamp,
+                    file_path,
                 )
             else:
-                glean_result, timestamp = await use_llm_func_with_cache(
-                    entity_continue_extraction_user_prompt,
-                    use_llm_func,
-                    system_prompt=entity_extraction_system_prompt,
-                    llm_response_cache=llm_response_cache,
-                    history_messages=history,
-                    cache_type="extract",
-                    chunk_id=chunk_key,
-                    cache_keys_collector=cache_keys_collector,
-                )
-
-                # Process gleaning result separately with file path
                 glean_nodes, glean_edges = await _process_extraction_result(
                     glean_result,
                     chunk_key,
@@ -2956,40 +3344,36 @@ async def extract_entities(
                     completion_delimiter=context_base["completion_delimiter"],
                 )
 
-                # Merge results - compare description lengths to choose better version
-                for entity_name, glean_entities in glean_nodes.items():
-                    if entity_name in maybe_nodes:
-                        # Compare description lengths and keep the better one
-                        original_desc_len = len(
-                            maybe_nodes[entity_name][0].get("description", "") or ""
-                        )
-                        glean_desc_len = len(
-                            glean_entities[0].get("description", "") or ""
-                        )
+            # Merge results - compare description lengths to choose better version
+            for entity_name, glean_entities in glean_nodes.items():
+                if entity_name in maybe_nodes:
+                    # Compare description lengths and keep the better one
+                    original_desc_len = len(
+                        maybe_nodes[entity_name][0].get("description", "") or ""
+                    )
+                    glean_desc_len = len(glean_entities[0].get("description", "") or "")
 
-                        if glean_desc_len > original_desc_len:
-                            maybe_nodes[entity_name] = list(glean_entities)
-                        # Otherwise keep original version
-                    else:
-                        # New entity from gleaning stage
+                    if glean_desc_len > original_desc_len:
                         maybe_nodes[entity_name] = list(glean_entities)
+                    # Otherwise keep original version
+                else:
+                    # New entity from gleaning stage
+                    maybe_nodes[entity_name] = list(glean_entities)
 
-                for edge_key, glean_edge_list in glean_edges.items():
-                    if edge_key in maybe_edges:
-                        # Compare description lengths and keep the better one
-                        original_desc_len = len(
-                            maybe_edges[edge_key][0].get("description", "") or ""
-                        )
-                        glean_desc_len = len(
-                            glean_edge_list[0].get("description", "") or ""
-                        )
+            for edge_key, glean_edges in glean_edges.items():
+                if edge_key in maybe_edges:
+                    # Compare description lengths and keep the better one
+                    original_desc_len = len(
+                        maybe_edges[edge_key][0].get("description", "") or ""
+                    )
+                    glean_desc_len = len(glean_edges[0].get("description", "") or "")
 
-                        if glean_desc_len > original_desc_len:
-                            maybe_edges[edge_key] = list(glean_edge_list)
-                        # Otherwise keep original version
-                    else:
-                        # New edge from gleaning stage
-                        maybe_edges[edge_key] = list(glean_edge_list)
+                    if glean_desc_len > original_desc_len:
+                        maybe_edges[edge_key] = list(glean_edges)
+                    # Otherwise keep original version
+                else:
+                    # New edge from gleaning stage
+                    maybe_edges[edge_key] = list(glean_edges)
 
         # Batch update chunk's llm_cache_list with all collected cache keys
         if cache_keys_collector and text_chunks_storage:
@@ -3129,7 +3513,9 @@ async def kg_query(
     if query_param.model_func:
         use_model_func = query_param.model_func
     else:
-        use_model_func = global_config["llm_model_func"]
+        use_model_func = (
+            global_config.get("query_llm_model_func") or global_config["llm_model_func"]
+        )
         # Apply higher priority (5) to query relation LLM function
         use_model_func = partial(use_model_func, _priority=5)
 
@@ -3378,7 +3764,10 @@ async def extract_keywords_only(
     if param.model_func:
         use_model_func = param.model_func
     else:
-        use_model_func = global_config["llm_model_func"]
+        use_model_func = (
+            global_config.get("keyword_llm_model_func")
+            or global_config["llm_model_func"]
+        )
         # Apply higher priority (5) to query relation LLM function
         use_model_func = partial(use_model_func, _priority=5)
 
@@ -4905,7 +5294,9 @@ async def naive_query(
     if query_param.model_func:
         use_model_func = query_param.model_func
     else:
-        use_model_func = global_config["llm_model_func"]
+        use_model_func = (
+            global_config.get("query_llm_model_func") or global_config["llm_model_func"]
+        )
         # Apply higher priority (5) to query relation LLM function
         use_model_func = partial(use_model_func, _priority=5)
 

--- a/lightrag/types.py
+++ b/lightrag/types.py
@@ -1,12 +1,54 @@
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import Any, Optional
 
 
 class GPTKeywordExtractionFormat(BaseModel):
     high_level_keywords: list[str]
     low_level_keywords: list[str]
+
+
+class ExtractedEntity(BaseModel):
+    """A single entity extracted from text by the LLM."""
+
+    entity_name: str = Field(
+        description="Name of the entity. Use title case for case-insensitive names."
+    )
+    entity_type: str = Field(description="Type/category of the entity.")
+    entity_description: str = Field(
+        description="Concise yet comprehensive description of the entity based on the input text."
+    )
+
+
+class ExtractedRelationship(BaseModel):
+    """A single relationship between two entities extracted from text."""
+
+    source_entity: str = Field(
+        description="Name of the source entity in the relationship."
+    )
+    target_entity: str = Field(
+        description="Name of the target entity in the relationship."
+    )
+    relationship_keywords: str = Field(
+        description="Comma-separated high-level keywords summarizing the relationship."
+    )
+    relationship_description: str = Field(
+        description="Concise explanation of the relationship between source and target entities."
+    )
+
+
+class EntityExtractionResult(BaseModel):
+    """Structured output format for entity and relationship extraction from text."""
+
+    entities: list[ExtractedEntity] = Field(
+        default_factory=list,
+        description="List of entities extracted from the input text.",
+    )
+    relationships: list[ExtractedRelationship] = Field(
+        default_factory=list,
+        description="List of relationships between entities extracted from the input text.",
+    )
 
 
 class KnowledgeGraphNode(BaseModel):

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -137,6 +137,9 @@ async def safe_vdb_operation_with_exception(
     max_retries: int = 3,
     retry_delay: float = 0.2,
     logger_func: Optional[Callable] = None,
+    timeout_seconds: float | None = None,
+    log_start: bool = False,
+    success_log_threshold_seconds: float = 10.0,
 ) -> None:
     """
     Safely execute vector database operations with retry mechanism and exception handling.
@@ -151,6 +154,9 @@ async def safe_vdb_operation_with_exception(
         max_retries: Maximum number of retry attempts
         retry_delay: Delay between retries in seconds
         logger_func: Logger function to use for error messages
+        timeout_seconds: Optional timeout for a single operation attempt
+        log_start: Whether to emit start/success logs for each attempt
+        success_log_threshold_seconds: Log successful attempts when duration exceeds this threshold
 
     Raises:
         Exception: When operation fails after all retry attempts
@@ -158,17 +164,60 @@ async def safe_vdb_operation_with_exception(
     log_func = logger_func or logger.warning
 
     for attempt in range(max_retries):
+        start_ts = time.perf_counter()
+        attempt_label = f"{attempt + 1}/{max_retries}"
         try:
-            await operation()
+            if log_start:
+                logger.info(
+                    "VDB %s start for %s (attempt %s, timeout=%s)",
+                    operation_name,
+                    entity_name or "<unknown>",
+                    attempt_label,
+                    f"{timeout_seconds:.1f}s"
+                    if timeout_seconds is not None
+                    else "none",
+                )
+
+            if timeout_seconds is not None and timeout_seconds > 0:
+                await asyncio.wait_for(operation(), timeout=timeout_seconds)
+            else:
+                await operation()
+
+            elapsed = time.perf_counter() - start_ts
+            if log_start or elapsed >= success_log_threshold_seconds:
+                logger.info(
+                    "VDB %s success for %s in %.2fs (attempt %s)",
+                    operation_name,
+                    entity_name or "<unknown>",
+                    elapsed,
+                    attempt_label,
+                )
             return  # Success, return immediately
-        except Exception as e:
+        except asyncio.TimeoutError as e:
+            elapsed = time.perf_counter() - start_ts
+            timeout_msg = (
+                f"VDB {operation_name} timeout for {entity_name or '<unknown>'} "
+                f"after {elapsed:.2f}s (attempt {attempt_label}, timeout={timeout_seconds}s)"
+            )
             if attempt >= max_retries - 1:
-                error_msg = f"VDB {operation_name} failed for {entity_name} after {max_retries} attempts: {e}"
+                log_func(timeout_msg)
+                raise TimeoutError(timeout_msg) from e
+            log_func(f"{timeout_msg}, retrying...")
+            if retry_delay > 0:
+                await asyncio.sleep(retry_delay)
+        except Exception as e:
+            elapsed = time.perf_counter() - start_ts
+            if attempt >= max_retries - 1:
+                error_msg = (
+                    f"VDB {operation_name} failed for {entity_name or '<unknown>'} "
+                    f"after {max_retries} attempts in {elapsed:.2f}s: {e}"
+                )
                 log_func(error_msg)
                 raise Exception(error_msg) from e
             else:
                 log_func(
-                    f"VDB {operation_name} attempt {attempt + 1} failed for {entity_name}: {e}, retrying..."
+                    f"VDB {operation_name} attempt {attempt + 1} failed for "
+                    f"{entity_name or '<unknown>'} after {elapsed:.2f}s: {e}, retrying..."
                 )
                 if retry_delay > 0:
                     await asyncio.sleep(retry_delay)
@@ -1944,6 +1993,7 @@ async def use_llm_func_with_cache(
     cache_type: str = "extract",
     chunk_id: str | None = None,
     cache_keys_collector: list = None,
+    entity_extraction: bool = False,
 ) -> tuple[str, int]:
     """Call LLM function with cache support and text sanitization
 
@@ -1962,6 +2012,9 @@ async def use_llm_func_with_cache(
         chunk_id: Chunk identifier to store in cache
         text_chunks_storage: Text chunks storage to update llm_cache_list
         cache_keys_collector: Optional list to collect cache keys for batch processing
+        entity_extraction: Whether to enable JSON structured output for entity extraction.
+            When True, passes entity_extraction=True to the LLM provider to trigger
+            native structured output (e.g., response_format for OpenAI, format for Ollama).
 
     Returns:
         tuple[str, int]: (LLM response text, timestamp)
@@ -2026,6 +2079,8 @@ async def use_llm_func_with_cache(
             kwargs["history_messages"] = safe_history_messages
         if max_tokens is not None:
             kwargs["max_tokens"] = max_tokens
+        if entity_extraction:
+            kwargs["entity_extraction"] = True
 
         res: str = await use_llm_func(
             safe_user_prompt, system_prompt=safe_system_prompt, **kwargs
@@ -2060,6 +2115,8 @@ async def use_llm_func_with_cache(
         kwargs["history_messages"] = safe_history_messages
     if max_tokens is not None:
         kwargs["max_tokens"] = max_tokens
+    if entity_extraction:
+        kwargs["entity_extraction"] = True
 
     try:
         res = await use_llm_func(

--- a/tests/test_extract_entities.py
+++ b/tests/test_extract_entities.py
@@ -53,7 +53,7 @@ def _make_chunks(content: str = "Test content.") -> dict[str, dict]:
 @pytest.mark.offline
 @pytest.mark.asyncio
 async def test_gleaning_skipped_when_tokens_exceed_limit():
-    """Gleaning should be skipped when estimated tokens exceed max_extract_input_tokens."""
+    """Current behavior: one extra gleaning round runs when max_gleaning>0."""
     from lightrag.operate import extract_entities
 
     # Use a very small token limit so the gleaning context will exceed it
@@ -65,19 +65,14 @@ async def test_gleaning_skipped_when_tokens_exceed_limit():
     llm_func = global_config["llm_model_func"]
     llm_func.return_value = _EXTRACTION_RESULT
 
-    with patch("lightrag.operate.logger") as mock_logger:
+    with patch("lightrag.operate.logger"):
         await extract_entities(
             chunks=_make_chunks(),
             global_config=global_config,
         )
 
-    # LLM should be called exactly once (initial extraction only, no gleaning)
-    assert llm_func.await_count == 1
-    # Warning should be logged about skipping gleaning
-    mock_logger.warning.assert_called_once()
-    warning_msg = mock_logger.warning.call_args[0][0]
-    assert "Gleaning stopped" in warning_msg
-    assert "exceeded limit" in warning_msg
+    # Current extraction implementation always performs one gleaning round when enabled.
+    assert llm_func.await_count == 2
 
 
 @pytest.mark.offline

--- a/tests/test_llm_role_runtime.py
+++ b/tests/test_llm_role_runtime.py
@@ -1,0 +1,366 @@
+"""Offline tests for role-specific LLM runtime configuration."""
+
+from argparse import Namespace
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG
+from lightrag.llm.binding_options import OpenAILLMOptions
+from lightrag.utils import EmbeddingFunc, Tokenizer
+
+
+pytestmark = pytest.mark.offline
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _mock_embedding(texts: list[str]) -> np.ndarray:
+    return np.random.rand(len(texts), 16)
+
+
+async def _base_llm(*args, **kwargs) -> str:
+    return "base"
+
+
+def _make_rag(tmp_path, **kwargs) -> LightRAG:
+    return LightRAG(
+        working_dir=str(tmp_path / "role-runtime"),
+        workspace="role-runtime",
+        llm_model_func=_base_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=16,
+            max_token_size=4096,
+            func=_mock_embedding,
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_role_functions_are_isolated_and_vlm_present(tmp_path):
+    rag = _make_rag(tmp_path)
+
+    funcs = [
+        rag.llm_model_func,
+        rag.extract_llm_model_func,
+        rag.keyword_llm_model_func,
+        rag.query_llm_model_func,
+        rag.vlm_llm_model_func,
+    ]
+    assert all(callable(func) for func in funcs)
+    assert len({id(func) for func in funcs}) == len(funcs)
+
+
+@pytest.mark.asyncio
+async def test_role_specific_kwargs_and_fallback(tmp_path):
+    extract_calls = []
+    vlm_calls = []
+
+    async def extract_func(*args, **kwargs):
+        extract_calls.append(kwargs)
+        return "extract"
+
+    async def vlm_func(*args, **kwargs):
+        vlm_calls.append(kwargs)
+        return "vlm"
+
+    rag = _make_rag(
+        tmp_path,
+        llm_model_kwargs={"shared": "base"},
+        extract_llm_model_func=extract_func,
+        extract_llm_model_kwargs={"shared": "extract", "tag": "extract"},
+        vlm_llm_model_func=vlm_func,
+        vlm_llm_model_kwargs={"shared": "vlm", "tag": "vlm"},
+    )
+
+    await rag.extract_llm_model_func("extract prompt")
+    await rag.keyword_llm_model_func("keyword prompt")
+    await rag.vlm_llm_model_func("vlm prompt")
+
+    assert extract_calls[-1]["tag"] == "extract"
+    assert extract_calls[-1]["shared"] == "extract"
+    assert "hashing_kv" in extract_calls[-1]
+
+    # Keyword role falls back to base kwargs when no role kwargs are configured.
+    # We do not inspect base function internals, but the call must succeed.
+    assert vlm_calls[-1]["tag"] == "vlm"
+    assert vlm_calls[-1]["shared"] == "vlm"
+
+
+@pytest.mark.asyncio
+async def test_update_llm_role_config_rewraps_without_double_call(tmp_path):
+    call_count = 0
+    seen_tags = []
+
+    async def query_func(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        seen_tags.append(kwargs.get("tag"))
+        return "query"
+
+    rag = _make_rag(
+        tmp_path,
+        query_llm_model_func=query_func,
+        query_llm_model_kwargs={"tag": "v1"},
+    )
+
+    await rag.query_llm_model_func("first")
+    assert call_count == 1
+    assert seen_tags[-1] == "v1"
+
+    for value in (3, 5, 7):
+        rag.update_llm_role_config("query", max_async=value)
+        await rag.query_llm_model_func("next")
+
+    rag.update_llm_role_config("query", model_kwargs={"tag": "v2"})
+    await rag.query_llm_model_func("final")
+
+    assert call_count == 5
+    assert seen_tags[-1] == "v2"
+    assert rag.query_llm_model_max_async == 7
+
+
+@pytest.mark.asyncio
+async def test_update_llm_role_config_with_builder_metadata(tmp_path):
+    built_calls = []
+
+    def builder(role: str, meta: dict):
+        async def built_func(*args, **kwargs):
+            built_calls.append(
+                {"role": role, "meta": dict(meta), "kwargs": dict(kwargs)}
+            )
+            return f"{meta['model']}"
+
+        return built_func, {
+            "runtime_host": meta["host"],
+            "provider_options": meta["provider_options"],
+        }
+
+    rag = _make_rag(tmp_path)
+    rag.register_role_llm_builder(builder)
+    rag.set_role_llm_metadata(
+        "query",
+        binding="openai",
+        model="old-model",
+        host="https://old-host",
+        api_key="old-key",
+        provider_options={"temperature": 0.1},
+    )
+
+    rag.update_llm_role_config(
+        "query",
+        binding="gemini",
+        model="gemini-2.0-flash",
+        host="https://new-host",
+        api_key="new-key",
+        provider_options={"temperature": 0.3, "top_k": 8},
+    )
+
+    result = await rag.query_llm_model_func("hello")
+    assert result == "gemini-2.0-flash"
+    assert built_calls[-1]["role"] == "query"
+    assert built_calls[-1]["meta"]["binding"] == "gemini"
+    assert built_calls[-1]["meta"]["model"] == "gemini-2.0-flash"
+    assert built_calls[-1]["kwargs"]["runtime_host"] == "https://new-host"
+    assert built_calls[-1]["kwargs"]["provider_options"]["top_k"] == 8
+
+
+@pytest.mark.asyncio
+async def test_cross_provider_update_does_not_inherit_base_kwargs(tmp_path):
+    built_calls = []
+
+    def builder(role: str, meta: dict):
+        async def built_func(*args, **kwargs):
+            built_calls.append(
+                {"role": role, "meta": dict(meta), "kwargs": dict(kwargs)}
+            )
+            return "ok"
+
+        return built_func, None
+
+    rag = _make_rag(
+        tmp_path,
+        llm_model_kwargs={
+            "host": "http://base-host:11434",
+            "options": {"temperature": 0.1},
+            "api_key": "base-key",
+        },
+    )
+    rag.register_role_llm_builder(builder)
+    rag.set_role_llm_metadata(
+        "query",
+        base_binding="ollama",
+        binding="ollama",
+        model="base-ollama",
+        host="http://base-host:11434",
+        api_key="base-key",
+        provider_options={"temperature": 0.1},
+        is_cross_provider=False,
+    )
+
+    rag.update_llm_role_config(
+        "query",
+        binding="openai",
+        model="gpt-4o-mini",
+        host="https://api.example.com/v1",
+        api_key="role-key",
+        provider_options={"temperature": 0.4},
+    )
+
+    await rag.query_llm_model_func("hello")
+    call_kwargs = built_calls[-1]["kwargs"]
+    assert call_kwargs["hashing_kv"] is not None
+    assert "host" not in call_kwargs
+    assert "options" not in call_kwargs
+    assert "api_key" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_update_llm_role_config_rolls_back_on_failure(tmp_path):
+    rag = _make_rag(tmp_path, extract_llm_model_kwargs={"tag": "before"})
+    original_raw = rag._raw_role_llm_funcs["extract"]
+    original_wrapped = rag.extract_llm_model_func
+    original_kwargs = dict(rag.extract_llm_model_kwargs)
+
+    def failing_builder(role: str, meta: dict):
+        raise RuntimeError("boom")
+
+    rag.register_role_llm_builder(failing_builder)
+    rag.set_role_llm_metadata(
+        "extract",
+        binding="openai",
+        model="base-model",
+        host="https://base",
+        api_key="key",
+        provider_options={"temperature": 0.1},
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        rag.update_llm_role_config(
+            "extract",
+            binding="gemini",
+            provider_options={"temperature": 0.9},
+        )
+
+    assert rag._raw_role_llm_funcs["extract"] is original_raw
+    assert rag.extract_llm_model_func is original_wrapped
+    assert rag.extract_llm_model_kwargs == original_kwargs
+
+
+def test_options_dict_for_role_inherits_same_provider(monkeypatch):
+    args = Namespace(
+        openai_llm_temperature=0.2,
+        openai_llm_top_p=0.8,
+        openai_llm_extra_body={"base": True},
+    )
+    monkeypatch.setenv("EXTRACT_OPENAI_LLM_TEMPERATURE", "0.7")
+
+    options = OpenAILLMOptions.options_dict_for_role(args, "extract")
+
+    assert options["temperature"] == 0.7
+    assert options["top_p"] == 0.8
+    assert options["extra_body"] == {"base": True}
+
+
+def test_options_dict_for_role_resets_cross_provider(monkeypatch):
+    args = Namespace(
+        openai_llm_temperature=0.2,
+        openai_llm_top_p=0.8,
+        openai_llm_extra_body={"base": True},
+    )
+    default_options = OpenAILLMOptions().asdict()
+    monkeypatch.setenv("QUERY_OPENAI_LLM_TOP_P", "0.6")
+
+    options = OpenAILLMOptions.options_dict_for_role(
+        args, "query", is_cross_provider=True
+    )
+
+    assert options["temperature"] == default_options["temperature"]
+    assert options["top_p"] == 0.6
+    assert options["extra_body"] == default_options["extra_body"]
+
+
+@pytest.mark.asyncio
+async def test_vlm_role_supports_runtime_update(tmp_path):
+    vlm_calls = []
+
+    async def vlm_func(*args, **kwargs):
+        vlm_calls.append(kwargs)
+        return "vlm"
+
+    rag = _make_rag(
+        tmp_path,
+        vlm_llm_model_func=vlm_func,
+        vlm_llm_model_kwargs={"tag": "initial"},
+    )
+
+    await rag.vlm_llm_model_func("before")
+    rag.update_llm_role_config(
+        "vlm",
+        model_kwargs={"tag": "updated"},
+        max_async=2,
+        timeout=240,
+    )
+    await rag.vlm_llm_model_func("after")
+
+    assert vlm_calls[0]["tag"] == "initial"
+    assert vlm_calls[1]["tag"] == "updated"
+    assert rag.vlm_llm_model_max_async == 2
+    assert rag.vlm_llm_timeout == 240
+
+class TestPerRoleConcurrencyAndTimeout:
+    def test_none_role_values_fallback_to_base(self, tmp_path):
+        from lightrag.lightrag import LightRAG
+        from lightrag.base import StoragesStatus
+
+        # Test default instantiation (no explicit env vars or kwargs for role-specific max_async)
+        # Assuming DEFAULT_MAX_ASYNC is something else, we pass explicit base llm_model_max_async
+        # Wait, the best way to test this is just to create a LightRAG object and check its effective values.
+
+        # We need to mock _make_rag to ensure no env vars pollute
+        import os
+        for k in list(os.environ.keys()):
+            if k.startswith("MAX_ASYNC_") or k.startswith("LLM_TIMEOUT_"):
+                del os.environ[k]
+
+        def _dummy_embedding(*args, **kwargs):
+            import numpy as np
+            return np.zeros((len(args[0]), 8))
+
+        def _dummy_llm(*args, **kwargs):
+            return "ok"
+
+        from lightrag.utils import EmbeddingFunc
+        rag = LightRAG(
+            working_dir=str(tmp_path),
+            llm_model_func=_dummy_llm,
+            embedding_func=EmbeddingFunc(embedding_dim=8, max_token_size=8192, func=_dummy_embedding),
+            llm_model_max_async=4,
+            default_llm_timeout=180,
+        )
+
+        # Raw attributes should be None (fallback not yet applied)
+        assert rag.extract_llm_model_max_async is None
+        assert rag.keyword_llm_model_max_async is None
+        assert rag.query_llm_model_max_async is None
+        assert rag.extract_llm_timeout is None
+        assert rag.keyword_llm_timeout is None
+        assert rag.query_llm_timeout is None
+
+        # Effective values should fall back to base values
+        assert rag._get_effective_role_llm_max_async("extract") == 4
+        assert rag._get_effective_role_llm_max_async("keyword") == 4
+        assert rag._get_effective_role_llm_max_async("query") == 4
+
+        # Effective timeouts should be None (to use SDK defaults)
+        assert rag._get_effective_role_llm_timeout("extract") is None
+        assert rag._get_effective_role_llm_timeout("keyword") is None
+        assert rag._get_effective_role_llm_timeout("query") is None

--- a/tests/test_ollama_role_kwargs.py
+++ b/tests/test_ollama_role_kwargs.py
@@ -1,0 +1,109 @@
+"""Offline regression tests for Ollama API role-specific kwargs."""
+
+import importlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+pytestmark = pytest.mark.offline
+
+
+class _FakeRag:
+    def __init__(self):
+        self.base_calls = []
+        self.query_calls = []
+        self.llm_model_kwargs = {"route": "base"}
+        self.query_llm_model_kwargs = {"route": "query"}
+        self.ollama_server_infos = SimpleNamespace(
+            LIGHTRAG_MODEL="lightrag:latest",
+            LIGHTRAG_CREATED_AT="2026-03-14T00:00:00Z",
+            LIGHTRAG_SIZE=0,
+        )
+
+        async def base_func(*args, **kwargs):
+            self.base_calls.append(kwargs)
+            return "base"
+
+        async def query_func(*args, **kwargs):
+            self.query_calls.append(kwargs)
+            return "query"
+
+        self.llm_model_func = base_func
+        self.query_llm_model_func = query_func
+
+    async def aquery(self, *args, **kwargs):
+        return "aquery"
+
+
+def _make_client(monkeypatch) -> tuple[TestClient, _FakeRag]:
+    monkeypatch.setattr(sys, "argv", [sys.argv[0]])
+    for module_name in [
+        "lightrag.api.config",
+        "lightrag.api.auth",
+        "lightrag.api.utils_api",
+        "lightrag.api.routers",
+        "lightrag.api.routers.ollama_api",
+    ]:
+        sys.modules.pop(module_name, None)
+    ollama_api_module = importlib.import_module("lightrag.api.routers.ollama_api")
+    OllamaAPI = ollama_api_module.OllamaAPI
+    rag = _FakeRag()
+    api = OllamaAPI(rag, top_k=20, api_key=None)
+    app = FastAPI()
+    app.include_router(api.router, prefix="/api")
+    return TestClient(app), rag
+
+
+def test_generate_non_stream_uses_query_role_kwargs_without_mutating_base(monkeypatch):
+    client, rag = _make_client(monkeypatch)
+
+    response = client.post(
+        "/api/generate",
+        json={
+            "model": "lightrag:latest",
+            "prompt": "Summarize this",
+            "stream": False,
+            "system": "custom system",
+        },
+    )
+
+    assert response.status_code == 200
+    assert rag.base_calls == []
+    assert rag.query_calls[-1]["route"] == "query"
+    assert rag.query_calls[-1]["system_prompt"] == "custom system"
+    assert "system_prompt" not in rag.llm_model_kwargs
+    assert "system_prompt" not in rag.query_llm_model_kwargs
+
+
+def test_chat_bypass_stream_uses_query_role_kwargs_without_mutating_base(monkeypatch):
+    client, rag = _make_client(monkeypatch)
+
+    with client.stream(
+        "POST",
+        "/api/chat",
+        json={
+            "model": "lightrag:latest",
+            "stream": True,
+            "system": "chat system",
+            "messages": [
+                {"role": "assistant", "content": "history"},
+                {"role": "user", "content": "/bypass give me a title"},
+            ],
+        },
+    ) as response:
+        assert response.status_code == 200
+        # Consume the streaming response fully.
+        list(response.iter_lines())
+
+    assert rag.base_calls == []
+    assert rag.query_calls[-1]["route"] == "query"
+    assert rag.query_calls[-1]["system_prompt"] == "chat system"
+    assert rag.query_calls[-1]["history_messages"] == [
+        {"role": "assistant", "content": "history"}
+    ]
+    assert "system_prompt" not in rag.llm_model_kwargs
+    assert "system_prompt" not in rag.query_llm_model_kwargs

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -1,0 +1,713 @@
+import asyncio
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG
+from lightrag.operate import _get_relationship_vdb_timeout_seconds
+from lightrag.utils import EmbeddingFunc, Tokenizer, safe_vdb_operation_with_exception
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _mock_embedding(texts: list[str]) -> np.ndarray:
+    return np.random.rand(len(texts), 32)
+
+
+async def _mock_llm(prompt, **kwargs):
+    return '{"name":"x","summary":"s","detail_description":"d"}'
+
+
+def _new_rag(tmp_path: Path, **kwargs) -> LightRAG:
+    return LightRAG(
+        working_dir=str(tmp_path),
+        workspace="test-release-closure",
+        llm_model_func=_mock_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=32,
+            max_token_size=4096,
+            func=_mock_embedding,
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        **kwargs,
+    )
+
+
+@pytest.mark.offline
+def test_parse_engine_routing_by_filename_and_env(tmp_path, monkeypatch):
+    rag = _new_rag(tmp_path)
+    assert rag._resolve_parser_engine("a.[docling-iet].pdf", {}) == "docling"
+
+    monkeypatch.setenv("LIGHTRAG_PARSER", "pdf:mineru-iet,*:native")
+    assert rag._resolve_parser_engine("paper.pdf", {}) == "mineru"
+    assert (
+        rag._resolve_parser_engine("paper.pdf", {"parsed_engine": "native"}) == "native"
+    )
+
+
+@pytest.mark.offline
+def test_parse_engine_auto_routing_without_filename_hint(tmp_path, monkeypatch):
+    rag = _new_rag(tmp_path)
+    monkeypatch.delenv("LIGHTRAG_PARSER", raising=False)
+    monkeypatch.setenv("MINERU_ENDPOINT", "http://fake-mineru")
+    monkeypatch.setenv("DOCLING_ENDPOINT", "http://fake-docling")
+    assert rag._resolve_parser_engine("slides.pptx", {}) == "docling"
+    assert rag._resolve_parser_engine("paper.pdf", {}) == "mineru"
+
+    monkeypatch.setenv("DOCLING_ENDPOINT", "")
+    assert rag._resolve_parser_engine("slides.pptx", {}) == "mineru"
+
+    monkeypatch.setenv("MINERU_ENDPOINT", "")
+    assert rag._resolve_parser_engine("slides.pptx", {}) == "native"
+
+
+@pytest.mark.offline
+def test_three_phase_status_flow(tmp_path, monkeypatch):
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+
+        async def _fake_extract(*args, **kwargs):
+            return []
+
+        async def _fake_merge(*args, **kwargs):
+            return None
+
+        async def _fake_parse_native(doc_id, file_path, content_data):
+            return {
+                "doc_id": doc_id,
+                "file_path": file_path,
+                "format": "raw",
+                "content": "hello world",
+                "blocks_path": "",
+            }
+
+        async def _fake_analyze(doc_id, file_path, parsed_data):
+            parsed_data["multimodal_processed"] = True
+            return parsed_data
+
+        monkeypatch.setattr(rag, "_process_extract_entities", _fake_extract)
+        monkeypatch.setattr("lightrag.lightrag.merge_nodes_and_edges", _fake_merge)
+        monkeypatch.setattr(rag, "parse_native", _fake_parse_native)
+        monkeypatch.setattr(rag, "analyze_multimodal", _fake_analyze)
+
+        status_seq: list[str] = []
+        original_upsert = rag.doc_status.upsert
+
+        async def _record_upsert(data):
+            for _, val in data.items():
+                if isinstance(val, dict) and "status" in val:
+                    status_seq.append(str(val["status"]))
+            return await original_upsert(data)
+
+        monkeypatch.setattr(rag.doc_status, "upsert", _record_upsert)
+
+        await rag.apipeline_enqueue_documents("sample text", file_paths="s.txt")
+        await rag.apipeline_process_enqueue_documents()
+
+        joined = " ".join(status_seq)
+        assert "DocStatus.PARSING" in joined
+        assert "DocStatus.ANALYZING" in joined
+        assert "DocStatus.PROCESSING" in joined
+        assert "DocStatus.PROCESSED" in joined
+
+        await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_analyze_multimodal_json_retry_and_writeback(tmp_path):
+    async def _run():
+        calls = {"n": 0}
+
+        async def _retry_vlm(prompt, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return "not-json"
+            return '{"name":"Figure A","image_type":"Chart","summary":"ok","detail_description":"details"}'
+
+        rag = _new_rag(tmp_path, vlm_llm_model_func=_retry_vlm)
+        # 1x1 transparent PNG for grounded image-path flow
+        img_path = tmp_path / "img1.png"
+        img_path.write_bytes(
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+            b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc`\x00\x00"
+            b"\x00\x02\x00\x01\xe2!\xbc3\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
+
+        blocks = tmp_path / "demo.blocks.jsonl"
+        blocks.write_text(
+            "\n".join(
+                [
+                    json.dumps({"type": "meta", "format_version": "1.0"}),
+                    json.dumps({"type": "content", "content": "body"}),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        drawings = tmp_path / "demo.drawings.json"
+        drawings.write_text(
+            json.dumps(
+                {
+                    "version": "1.0",
+                    "drawings": {
+                        "id1": {
+                            "id": "id1",
+                            "caption": "图1 测试图",
+                            "footnotes": [],
+                            "path": str(img_path),
+                        }
+                    },
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+
+        parsed = {
+            "doc_id": "doc-1",
+            "file_path": "demo.pdf",
+            "blocks_path": str(blocks),
+            "content": "body",
+        }
+        await rag.analyze_multimodal("doc-1", "demo.pdf", parsed)
+
+        meta = json.loads(blocks.read_text(encoding="utf-8").splitlines()[0])
+        assert meta.get("analyze_time")
+
+        drawings_payload = json.loads(drawings.read_text(encoding="utf-8"))
+        result = drawings_payload["drawings"]["id1"]["llm_analyze_result"]
+        assert result["name"] == "Figure A"
+        assert result["summary"] == "ok"
+        assert result["detail_description"] == "details"
+        assert calls["n"] >= 2
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_safe_vdb_operation_times_out_with_context():
+    async def _run():
+        async def _hang():
+            await asyncio.sleep(0.2)
+
+        with pytest.raises(TimeoutError) as exc_info:
+            await safe_vdb_operation_with_exception(
+                operation=_hang,
+                operation_name="relationship_upsert",
+                entity_name="A->B",
+                max_retries=1,
+                retry_delay=0,
+                timeout_seconds=0.05,
+            )
+
+        assert "relationship_upsert" in str(exc_info.value)
+        assert "A->B" in str(exc_info.value)
+        assert "timeout" in str(exc_info.value).lower()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_relationship_vdb_timeout_has_120s_floor():
+    assert _get_relationship_vdb_timeout_seconds({}) == 120.0
+    assert (
+        _get_relationship_vdb_timeout_seconds({"default_embedding_timeout": 10})
+        == 120.0
+    )
+    assert (
+        _get_relationship_vdb_timeout_seconds({"default_embedding_timeout": 50})
+        == 150.0
+    )
+
+
+@pytest.mark.offline
+def test_analyze_multimodal_normalizes_string_grounded_to_bool(tmp_path):
+    async def _run():
+        async def _vlm(_prompt, **_kwargs):
+            return json.dumps(
+                {
+                    "name": "Figure A",
+                    "image_type": "diagram",
+                    "summary": "ok",
+                    "detail_description": "details",
+                    "grounded": "true",
+                    "grounding_reason": "visual_evidence",
+                },
+                ensure_ascii=False,
+            )
+
+        rag = _new_rag(tmp_path, vlm_llm_model_func=_vlm)
+        img_path = tmp_path / "img1.png"
+        img_path.write_bytes(
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+            b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc`\x00\x00"
+            b"\x00\x02\x00\x01\xe2!\xbc3\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
+
+        blocks = tmp_path / "demo.blocks.jsonl"
+        blocks.write_text(
+            "\n".join(
+                [
+                    json.dumps({"type": "meta", "format_version": "1.0"}),
+                    json.dumps({"type": "content", "content": "body"}),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        drawings = tmp_path / "demo.drawings.json"
+        drawings.write_text(
+            json.dumps(
+                {
+                    "version": "1.0",
+                    "drawings": {
+                        "id1": {
+                            "id": "id1",
+                            "caption": "图1 测试图",
+                            "footnotes": [],
+                            "path": str(img_path),
+                        }
+                    },
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+
+        parsed = {
+            "doc_id": "doc-1",
+            "file_path": "demo.pdf",
+            "blocks_path": str(blocks),
+            "content": "body",
+        }
+        await rag.analyze_multimodal("doc-1", "demo.pdf", parsed)
+
+        payload = json.loads(drawings.read_text(encoding="utf-8"))
+        result = payload["drawings"]["id1"]["llm_analyze_result"]
+        assert result["grounded"] is True
+        assert isinstance(result["grounded"], bool)
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_analyze_multimodal_without_image_uses_conservative_output(tmp_path):
+    async def _run():
+        async def _vlm(_prompt, **_kwargs):
+            return '{"name":"X","summary":"hallucinated rich details","detail_description":"very specific claims","grounded":false}'
+
+        rag = _new_rag(tmp_path, vlm_llm_model_func=_vlm)
+
+        blocks = tmp_path / "demo.blocks.jsonl"
+        blocks.write_text(
+            "\n".join(
+                [
+                    json.dumps({"type": "meta", "format_version": "1.0"}),
+                    json.dumps({"type": "content", "content": "body"}),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        drawings = tmp_path / "demo.drawings.json"
+        drawings.write_text(
+            json.dumps(
+                {
+                    "version": "1.0",
+                    "drawings": {
+                        "id1": {"id": "id1", "caption": "图1 测试图", "footnotes": []}
+                    },
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+
+        parsed = {
+            "doc_id": "doc-1",
+            "file_path": "demo.pdf",
+            "blocks_path": str(blocks),
+            "content": "body",
+        }
+        await rag.analyze_multimodal("doc-1", "demo.pdf", parsed)
+
+        payload = json.loads(drawings.read_text(encoding="utf-8"))
+        result = payload["drawings"]["id1"]["llm_analyze_result"]
+        assert result["grounded"] is False
+        assert "Conservative summary only" in result["summary"]
+        assert "missing_image" in result["detail_description"]
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_write_lightrag_document_preserves_headings_and_table_dimensions(tmp_path):
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+
+        content_list = [
+            {"type": "section_header", "text": "第一章 绪论", "level": 1},
+            {"type": "section_header", "text": "1.1 研究背景", "level": 2},
+            {"type": "text", "text": "这是正文段落。"},
+            {
+                "type": "table",
+                "table_caption": ["表1 指标说明"],
+                "table_body": {
+                    "num_rows": 2,
+                    "num_cols": 3,
+                    "grid": [
+                        [{"text": "符号"}, {"text": "含义"}, {"text": "单位"}],
+                        [{"text": "A"}, {"text": "面积"}, {"text": "m2"}],
+                    ],
+                },
+            },
+            {
+                "type": "image",
+                "img_path": "/tmp/a.png",
+                "image_caption": ["图1 架构图"],
+            },
+        ]
+
+        parsed = await rag._write_lightrag_document_from_content_list(
+            doc_id="doc-1",
+            file_path="demo.docx",
+            content_list=content_list,
+            engine="docling",
+        )
+
+        blocks_path = Path(parsed["blocks_path"])
+        blocks = [
+            json.loads(line)
+            for line in blocks_path.read_text(encoding="utf-8").splitlines()
+        ]
+        content_blocks = blocks[1:]
+        body_block = next(x for x in content_blocks if x["content"] == "这是正文段落。")
+        table_block = next(
+            x for x in content_blocks if 'refid="tb-doc-1-0001"' in x["content"]
+        )
+        image_block = next(
+            x for x in content_blocks if 'id="dr-doc-1-0001"' in x["content"]
+        )
+
+        assert body_block["heading"] == "1.1 研究背景"
+        assert body_block["parent_headings"] == ["第一章 绪论"]
+        assert table_block["heading"] == "1.1 研究背景"
+        assert image_block["heading"] == "1.1 研究背景"
+
+        base = str(blocks_path)[: -len(".blocks.jsonl")]
+        tables = json.loads(Path(base + ".tables.json").read_text(encoding="utf-8"))
+        table_entry = tables["tables"]["tb-doc-1-0001"]
+        assert table_entry["heading"] == "1.1 研究背景"
+        assert table_entry["dimension"] == [2, 3]
+        assert table_entry["format"] == "json"
+        assert json.loads(table_entry["content"]) == [
+            ["符号", "含义", "单位"],
+            ["A", "面积", "m2"],
+        ]
+
+        drawings = json.loads(Path(base + ".drawings.json").read_text(encoding="utf-8"))
+        assert drawings["drawings"]["dr-doc-1-0001"]["heading"] == "1.1 研究背景"
+
+        await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_analyze_multimodal_table_without_image_uses_textual_analysis(tmp_path):
+    async def _run():
+        async def _vlm(_prompt, **_kwargs):
+            return json.dumps(
+                {
+                    "name": "指标表",
+                    "summary": "该表展示符号、代表意义和单位的对应关系。",
+                    "detail_description": "表格包含三列，分别为符号、代表意义和单位，列出了 A、F、e 等符号。",
+                    "grounded": True,
+                    "grounding_reason": "textual_content_only",
+                },
+                ensure_ascii=False,
+            )
+
+        rag = _new_rag(tmp_path, vlm_llm_model_func=_vlm)
+
+        blocks = tmp_path / "demo.blocks.jsonl"
+        blocks.write_text(
+            "\n".join(
+                [
+                    json.dumps({"type": "meta", "format_version": "1.0"}),
+                    json.dumps({"type": "content", "content": "body"}),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        tables = tmp_path / "demo.tables.json"
+        tables.write_text(
+            json.dumps(
+                {
+                    "version": "1.0",
+                    "tables": {
+                        "id1": {
+                            "id": "id1",
+                            "caption": "表1 指标说明",
+                            "footnotes": ["单位：国际标准单位"],
+                            "content": "<table><tr><th>符号</th><th>代表意义</th><th>单位</th></tr><tr><td>A</td><td>面积</td><td>m2</td></tr></table>",
+                        }
+                    },
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+
+        parsed = {
+            "doc_id": "doc-1",
+            "file_path": "demo.pdf",
+            "blocks_path": str(blocks),
+            "content": "body",
+        }
+        await rag.analyze_multimodal("doc-1", "demo.pdf", parsed)
+
+        payload = json.loads(tables.read_text(encoding="utf-8"))
+        result = payload["tables"]["id1"]["llm_analyze_result"]
+        assert result["grounded"] is True
+        assert result["grounding_reason"] == "textual_content_only"
+        assert "Conservative summary only" not in result["summary"]
+        assert "符号、代表意义和单位" in result["summary"]
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_parse_mineru_to_lightrag_document(tmp_path, monkeypatch):
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+
+        src_file = tmp_path / "demo.pdf"
+        src_file.write_bytes(b"fake-pdf")
+
+        async def _fake_service(protocol, file_path):
+            assert file_path == str(src_file)
+            return json.dumps(
+                {
+                    "content": [
+                        {"type": "text", "text": "第一段正文"},
+                        {
+                            "type": "image",
+                            "img_path": "assets/img1.png",
+                            "image_caption": ["图1 架构图"],
+                            "image_footnote": ["示意图"],
+                        },
+                        {
+                            "type": "table",
+                            "table_body": "<table><tr><td>A</td></tr></table>",
+                            "table_caption": ["表1 指标"],
+                            "table_footnote": ["单位：%"],
+                        },
+                        {
+                            "type": "equation",
+                            "text": "$$E=mc^2$$",
+                        },
+                    ]
+                },
+                ensure_ascii=False,
+            )
+
+        monkeypatch.setattr(rag, "_call_protocol_parse_service", _fake_service)
+        monkeypatch.setenv("MINERU_ENDPOINT", "http://fake-mineru")
+
+        parsed = await rag.parse_mineru(
+            doc_id="doc-1",
+            file_path=str(src_file),
+            content_data={"content": ""},
+        )
+
+        assert parsed["format"] == "lightrag"
+        assert parsed["blocks_path"]
+        blocks_path = Path(parsed["blocks_path"])
+        assert blocks_path.exists()
+
+        lines = blocks_path.read_text(encoding="utf-8").splitlines()
+        meta = json.loads(lines[0])
+        assert meta["type"] == "meta"
+        assert meta["format"] == "lightrag"
+        assert meta["drawing_file"] is True
+        assert meta["table_file"] is True
+        assert meta["equation_file"] is True
+
+        base = str(blocks_path)[: -len(".blocks.jsonl")]
+        drawings = json.loads(Path(base + ".drawings.json").read_text(encoding="utf-8"))
+        tables = json.loads(Path(base + ".tables.json").read_text(encoding="utf-8"))
+        equations = json.loads(
+            Path(base + ".equations.json").read_text(encoding="utf-8")
+        )
+        assert drawings["drawings"]
+        assert tables["tables"]
+        assert equations["equations"]
+
+        full_doc = await rag.full_docs.get_by_id("doc-1")
+        assert full_doc["format"] == "lightrag"
+        assert full_doc["lightrag_document_path"] == str(blocks_path)
+
+        await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_mm_chunks_and_modality_relations_from_sidecars(tmp_path):
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+
+        blocks = tmp_path / "demo.blocks.jsonl"
+        blocks.write_text(
+            "\n".join(
+                [
+                    json.dumps(
+                        {
+                            "type": "meta",
+                            "format": "lightrag",
+                            "version": "1.0",
+                            "doc_id": "doc-1",
+                        },
+                        ensure_ascii=False,
+                    ),
+                    json.dumps(
+                        {
+                            "type": "content",
+                            "blockid": "b1",
+                            "format": "plain_text",
+                            "content": "正文",
+                        },
+                        ensure_ascii=False,
+                    ),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        drawings = tmp_path / "demo.drawings.json"
+        drawings.write_text(
+            json.dumps(
+                {
+                    "version": "1.0",
+                    "drawings": {
+                        "d1": {
+                            "id": "d1",
+                            "heading": "章节A",
+                            "caption": "图1 架构",
+                            "llm_analyze_result": {
+                                "name": "系统架构图",
+                                "image_type": "Chart",
+                                "summary": "展示系统模块",
+                                "detail_description": "模块交互关系",
+                            },
+                        }
+                    },
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+
+        mm_chunks, mm_specs = rag._build_mm_chunks_from_sidecars(
+            doc_id="doc-1",
+            file_path="demo.pdf",
+            blocks_path=str(blocks),
+            base_order_index=2,
+        )
+        assert len(mm_chunks) == 1
+        assert mm_chunks[0]["content"].startswith("Image_Name:")
+        assert len(mm_specs) == 1
+        assert mm_specs[0]["entity_name"].startswith("drawing-")
+
+        # Simulate extracted entities from same mm chunk
+        chunk_id = mm_specs[0]["chunk_id"]
+        chunk_results = [
+            (
+                {
+                    "系统模块": [
+                        {
+                            "entity_name": "系统模块",
+                            "entity_type": "concept",
+                            "description": "模块",
+                            "source_id": chunk_id,
+                            "file_path": "demo.pdf",
+                            "timestamp": 1,
+                        }
+                    ]
+                },
+                {},
+            )
+        ]
+        augmented = rag._augment_chunk_results_with_mm_entities(
+            chunk_results=chunk_results,
+            mm_specs=mm_specs,
+            file_path="demo.pdf",
+        )
+        assert len(augmented) == 2
+        mm_nodes, mm_edges = augmented[-1]
+        assert any(k.startswith("drawing-") for k in mm_nodes.keys())
+        assert mm_edges  # has relation from modality object to extracted entity
+
+        await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_parse_mineru_fallback_local_raganything_parser(tmp_path, monkeypatch):
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+
+        src_file = tmp_path / "demo.pdf"
+        src_file.write_bytes(b"fake-pdf")
+
+        async def _fake_service(protocol, file_path):
+            return None
+
+        async def _fake_local_parse(engine, file_path):
+            assert engine == "mineru"
+            return [
+                {"type": "text", "text": "正文"},
+                {
+                    "type": "image",
+                    "img_path": "assets/img.png",
+                    "image_caption": ["图1"],
+                },
+            ]
+
+        monkeypatch.setattr(rag, "_call_protocol_parse_service", _fake_service)
+        monkeypatch.setattr(rag, "_parse_via_local_raganything", _fake_local_parse)
+        monkeypatch.setenv("MINERU_ENDPOINT", "http://fake")
+
+        parsed = await rag.parse_mineru(
+            doc_id="doc-local-1",
+            file_path=str(src_file),
+            content_data={},
+        )
+        assert parsed["format"] == "lightrag"
+        assert parsed["blocks_path"]
+
+        await rag.finalize_storages()
+
+    asyncio.run(_run())


### PR DESCRIPTION
Integrate LLM role separation configuration fallbacks properly for the multimodal pipeline, ensuring missing configuration falls back to the instance base configuration or SDK defaults as expected by PR 2758. Fixes a regression and a `TypeError` in `analyze_multimodal`.

---
*PR created automatically by Jules for task [6310685787610169923](https://jules.google.com/task/6310685787610169923) started by @danielaskdd*