### PR TITLE
fix: sanitize entity_type in Memgraph upsert_node to prevent Cypher injection (CWE-89)

### DIFF
--- a/lightrag/kg/memgraph_impl.py
+++ b/lightrag/kg/memgraph_impl.py
@@ -510,6 +510,27 @@ class MemgraphStorage(BaseGraphStorage):
                 "Memgraph: node properties must contain an 'entity_id' field"
             )
 
+        # Coerce to str first so membership checks below never raise TypeError
+        # regardless of what upstream callers (e.g. API payloads) pass in.
+        entity_type = (
+            str(entity_type) if not isinstance(entity_type, str) else entity_type
+        )
+
+        # Sanitize entity_type: strip backticks and handle comma-separated values.
+        # This guards against dirty data from LLM extraction or database read-back.
+        if "`" in entity_type or "," in entity_type or not entity_type.strip():
+            original = entity_type
+            entity_type = entity_type.replace("`", "").strip()
+            if "," in entity_type:
+                entity_type = entity_type.split(",")[0].strip()
+            if not entity_type:
+                entity_type = "UNKNOWN"
+            logger.warning(
+                f"[{self.workspace}] Entity type sanitized in upsert_node: '{original}' -> '{entity_type}'"
+            )
+            properties = dict(properties)
+            properties["entity_type"] = entity_type
+
         # Manual transaction-level retry following official Memgraph documentation
         max_retries = 100
         initial_wait_time = 0.2


### PR DESCRIPTION
## Vulnerability Summary

**CWE-89 — Improper Neutralization of Special Elements used in a Query (Cypher Injection)**
**Severity: High**
**File:** `lightrag/kg/memgraph_impl.py` — `upsert_node()` method

### Data Flow

User-controlled `entity_type` reaches the Cypher query without sanitization:

1. **API entry points:**
   - `POST /graph/entity/create` → `rag.acreate_entity()` → `utils_graph.acreate_entity()` → `upsert_node()`
   - `POST /graph/entity/edit` → `_edit_entity_impl()` → `upsert_node()`
2. **In `upsert_node()`**, `entity_type` is interpolated directly into a backtick-quoted Cypher label via f-string: `` SET n:`{entity_type}` ``
3. An attacker can break out of the backtick-quoted label by including a backtick in `entity_type`, injecting arbitrary Cypher statements.

### Exploit Example

```http
POST /graph/entity/create HTTP/1.1
Content-Type: application/json

{
  "entity_name": "test_entity",
  "entity_data": {
    "description": "A test entity",
    "entity_type": "x` SET n.admin = true //"
  }
}
```

**Resulting Cypher (before fix):**
```cypher
MERGE (n:`workspace` {entity_id: $entity_id})
SET n += $properties
SET n:`x` SET n.admin = true //`
```

This allows arbitrary property manipulation. A destructive payload like `x\` WITH n MATCH (m) DETACH DELETE m //` could delete all nodes in the database.

### Preconditions

1. LightRAG deployed with Memgraph storage backend
2. Attacker has network access to the API server (default: binds `0.0.0.0`, internet-facing)
3. Either no API key configured (default — `LIGHTRAG_API_KEY` defaults to `None`) or attacker possesses a valid API key/OAuth token
4. Alternatively: attacker can inject content into documents processed by LightRAG (prompt injection path — harder but possible since backticks are not in the sanitization filter for LLM-extracted text)

---

## Fix Description

**Single-file change:** `lightrag/kg/memgraph_impl.py` (+21 lines)

The fix adds input sanitization for `entity_type` in `upsert_node()`, before the value is interpolated into the Cypher query:

1. **Coerce to string** — prevents `TypeError` from non-string values passed by upstream callers.
2. **Strip backticks** — eliminates the escape character that enables breakout from the backtick-quoted label identifier.
3. **Handle comma-separated values** — takes only the first value when LLM extraction produces comma-delimited types (e.g. `"PERSON, ORGANIZATION"`).
4. **Fallback to `UNKNOWN`** — if sanitization empties the string, a safe default is used.
5. **Logging** — warns when sanitization modifies a value, for audit traceability.
6. **Properties dict updated** — ensures the sanitized value is persisted, not just used in the query label.

### Rationale

This is the **exact same pattern** already applied in `neo4j_impl.py` (lines 1035–1054 on `main`). The Memgraph implementation was missing this defense. This fix brings `memgraph_impl.py` to parity with the already-secured Neo4j backend.

The `workspace_label` parameter is already sanitized separately by `_get_workspace_label()` (which doubles backticks). `entity_type` was the **only remaining unsanitized user-controlled variable** interpolated into Cypher queries.

---

## Test Results

### Verification

- **Diff is minimal:** Only `lightrag/kg/memgraph_impl.py` is modified (1 file, +21 lines of sanitization logic).
- **No functional changes:** The fix only strips dangerous characters from `entity_type`; legitimate values without backticks or commas pass through unchanged.
- **Consistent with existing pattern:** Mirrors the identical sanitization already present in `neo4j_impl.py`.
- **No new dependencies** added.

### Sanitization Behavior

| Input | Output | Notes |
|---|---|---|
| `"PERSON"` | `"PERSON"` | Clean input — no change |
| `` "x` SET n.admin=true //" `` | `"x SET n.admin=true //"` | Backtick stripped, injection neutralized |
| `"PERSON, ORGANIZATION"` | `"PERSON"` | Comma-separated → first value |
| `` "`" `` | `"UNKNOWN"` | Only backtick → fallback |
| `"  "` | `"UNKNOWN"` | Whitespace-only → fallback |

---

## Disprove Analysis

We systematically attempted to disprove this finding:

### Authentication Check
No auth decorators in `memgraph_impl.py` (storage layer). API routes use `combined_auth` dependency, but `LIGHTRAG_API_KEY` **defaults to `None`** — auth is disabled by default.

### Network Exposure Check
- Server binds to `0.0.0.0` by default
- CORS origins default to `"*"` (wildcard)
- Dockerfile/docker-compose expose port `9621` directly — no reverse proxy or service mesh

**Result:** API is internet-facing by default with no CORS restrictions.

### Caller Trace Verification
`entity_type` reaches `upsert_node` via:
1. **Direct API path** (`POST /graph/entity/create`, `POST /graph/entity/edit`) — fully user-controlled, no sanitization
2. **LLM extraction path** — `sanitize_and_normalize_extracted_text()` removes spaces but **does not filter backticks**; exploitation harder but theoretically possible via prompt injection

### Existing Mitigations Assessment
- `_get_workspace_label()` sanitizes workspace labels (separate concern, already handled)
- **No equivalent sanitization existed** for `entity_type` before this fix
- LLM extraction filter strips spaces (hinders but does not prevent Cypher injection syntax)

### Prior Art
- `neo4j_impl.py` had the **identical vulnerability** and was **already fixed** on `main` — this fix brings Memgraph to parity
- No other storage backends (PostgreSQL, OpenSearch, MongoDB, NetworkX) use Cypher
- No prior issues, PRs, or CVEs found for this specific vulnerability

### Verdict
**CONFIRMED_VALID** — High confidence. The vulnerability is concretely exploitable via the API create/edit entity endpoints with a straightforward backtick breakout payload, against a default internet-facing deployment with no authentication.

---

*Found via automated security analysis. This is a responsible disclosure following the project's SECURITY.md guidelines.*