### PR TITLE
fix(memgraph): preserve start node in knowledge graph query

### DIFF
--- a/lightrag/kg/memgraph_impl.py
+++ b/lightrag/kg/memgraph_impl.py
@@ -925,24 +925,25 @@ class MemgraphStorage(BaseGraphStorage):
                     MATCH (start:`{workspace_label}`)
                     WHERE start.entity_id = $entity_id
 
-                    MATCH path = (start)-[*BFS 0..{max_depth}]-(end:`{workspace_label}`)
-                    WHERE ALL(n IN nodes(path) WHERE '{workspace_label}' IN labels(n))
-                    WITH collect(DISTINCT end) + start AS all_nodes_unlimited
+                    OPTIONAL MATCH path = (start)-[*BFS 0..{max_depth}]-(end:`{workspace_label}`)
+                    WHERE path IS NULL OR ALL(n IN nodes(path) WHERE '{workspace_label}' IN labels(n))
+                    WITH start, collect(DISTINCT end) AS discovered_nodes
+                    WITH start, [node IN discovered_nodes WHERE node IS NOT NULL AND node <> start] AS other_nodes
                     WITH
                     CASE
-                        WHEN size(all_nodes_unlimited) <= $max_nodes THEN all_nodes_unlimited
-                        ELSE all_nodes_unlimited[0..$max_nodes]
+                        WHEN 1 + size(other_nodes) <= $max_nodes THEN [start] + other_nodes
+                        ELSE [start] + other_nodes[0..$max_other_nodes]
                     END AS limited_nodes,
-                    size(all_nodes_unlimited) > $max_nodes AS is_truncated
+                    1 + size(other_nodes) > $max_nodes AS is_truncated
 
                     UNWIND limited_nodes AS n
-                    MATCH (n)-[r]-(m)
+                    OPTIONAL MATCH (n)-[r]-(m)
                     WHERE m IN limited_nodes
-                    WITH collect(DISTINCT n) AS limited_nodes, collect(DISTINCT r) AS relationships, is_truncated
+                    WITH limited_nodes, collect(DISTINCT r) AS relationships, is_truncated
 
                     RETURN
                     [node IN limited_nodes | {{node: node}}] AS node_info,
-                    relationships,
+                    [rel IN relationships WHERE rel IS NOT NULL] AS relationships,
                     is_truncated
                     """
 
@@ -953,6 +954,7 @@ class MemgraphStorage(BaseGraphStorage):
                             {
                                 "entity_id": node_label,
                                 "max_nodes": max_nodes,
+                                "max_other_nodes": max(max_nodes - 1, 0),
                             },
                         )
                         record = await result_set.single()

--- a/tests/test_memgraph_storage.py
+++ b/tests/test_memgraph_storage.py
@@ -1,0 +1,113 @@
+import pytest
+
+from lightrag.kg.memgraph_impl import MemgraphStorage
+
+
+pytestmark = pytest.mark.offline
+
+
+class _FakeNode(dict):
+    def __init__(self, node_id: int, entity_id: str, **properties):
+        super().__init__(entity_id=entity_id, **properties)
+        self.id = node_id
+
+
+class _FakeResult:
+    def __init__(self, record):
+        self._record = record
+
+    async def single(self):
+        return self._record
+
+    async def consume(self):
+        return None
+
+
+class _FakeSession:
+    def __init__(self, record, calls):
+        self._record = record
+        self._calls = calls
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def run(self, query, parameters=None, **kwargs):
+        if parameters is None:
+            parameters = kwargs
+        self._calls.append((query, parameters))
+        return _FakeResult(self._record)
+
+
+class _FakeDriver:
+    def __init__(self, record, calls):
+        self._record = record
+        self._calls = calls
+
+    def session(self, **kwargs):
+        return _FakeSession(self._record, self._calls)
+
+
+def _make_storage(record):
+    calls = []
+    storage = MemgraphStorage(
+        namespace="chunk_entity_relation",
+        global_config={"max_graph_nodes": 1000},
+        embedding_func=None,
+        workspace="test",
+    )
+    storage._driver = _FakeDriver(record, calls)
+    storage._DATABASE = "memgraph"
+    return storage, calls
+
+
+@pytest.mark.asyncio
+async def test_get_knowledge_graph_preserves_isolated_start_node():
+    start_node = _FakeNode(1, "Start", description="isolated")
+    storage, calls = _make_storage(
+        {
+            "node_info": [{"node": start_node}],
+            "relationships": [],
+            "is_truncated": False,
+        }
+    )
+
+    result = await storage.get_knowledge_graph("Start", max_depth=0, max_nodes=1)
+
+    assert len(result.nodes) == 1
+    assert result.nodes[0].labels == ["Start"]
+    assert result.nodes[0].properties["entity_id"] == "Start"
+    assert result.edges == []
+
+    assert len(calls) == 1
+    query, params = calls[0]
+    assert "OPTIONAL MATCH path = (start)-[*BFS 0..0]-(end:`test`)" in query
+    assert "THEN [start] + other_nodes" in query
+    assert "OPTIONAL MATCH (n)-[r]-(m)" in query
+    assert "[rel IN relationships WHERE rel IS NOT NULL] AS relationships" in query
+    assert params["entity_id"] == "Start"
+    assert params["max_nodes"] == 1
+    assert params["max_other_nodes"] == 0
+
+
+@pytest.mark.asyncio
+async def test_get_knowledge_graph_reserves_capacity_for_start_node_when_truncating():
+    start_node = _FakeNode(1, "Start")
+    storage, calls = _make_storage(
+        {
+            "node_info": [{"node": start_node}],
+            "relationships": [],
+            "is_truncated": True,
+        }
+    )
+
+    result = await storage.get_knowledge_graph("Start", max_depth=2, max_nodes=2)
+
+    assert result.is_truncated is True
+    assert len(calls) == 1
+    query, params = calls[0]
+    assert "other_nodes[0..$max_other_nodes]" in query
+    assert "1 + size(other_nodes) > $max_nodes AS is_truncated" in query
+    assert params["max_other_nodes"] == 1


### PR DESCRIPTION
## Description

Preserve the queried start node in Memgraph knowledge graph retrieval so non-wildcard subgraph results keep the `node_label` node even when it is isolated or the traversal result is truncated.

## Related Issues

N/A

## Changes Made

- Updated `MemgraphStorage.get_knowledge_graph()` to reserve capacity for the start node before truncating BFS results.
- Switched the retained-node edge expansion to `OPTIONAL MATCH` and filtered null relationships so isolated retained nodes are not dropped from the response.
- Added focused offline regression tests covering isolated start-node retention and truncation behavior.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Local verification run:
- `./scripts/test.sh tests/test_memgraph_storage.py -q`
