### PR TITLE
fix: remove redundant file_path_placeholder lookup in _merge_edges_then_upsert

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -2188,9 +2188,6 @@ async def _merge_edges_then_upsert(
             limit_method = global_config.get(
                 "source_ids_limit_method", SOURCE_IDS_LIMIT_METHOD_KEEP
             )
-            file_path_placeholder = global_config.get(
-                "file_path_more_placeholder", DEFAULT_FILE_PATH_MORE_PLACEHOLDER
-            )
 
             # Add + sign to indicate actual file count is higher
             original_count_str = (


### PR DESCRIPTION
## Summary

Fixes #2635

In `_merge_edges_then_upsert` (lightrag/operate.py), `file_path_placeholder` was retrieved from `global_config` twice:

1. **First** at the top of the block (line ~2164), before iterating over `already_file_paths`
2. **Second** inside the `if len(file_paths_list) > max_file_paths:` branch (line ~2191), where the variable is already in scope from the first lookup

The second lookup is dead code — it shadows the already-defined variable with an identical value. This PR removes it.

## Changes

- `lightrag/operate.py`: Removed duplicate `global_config.get("file_path_more_placeholder", ...)` call inside `_merge_edges_then_upsert`

## Test plan

- [x] Ran full unit test suite (`pytest tests/` excluding infra-dependent tests): **217 passed, 0 failed**
- [x] No behaviour change — purely a dead code removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)