### PR TITLE
perf: defer KG rebuild in batch deletion to a single pass

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -1857,6 +1857,10 @@ async def background_delete_documents(
     total_docs = len(doc_ids)
     successful_deletions = []
     failed_deletions = []
+    # Aggregated rebuild targets collected across all per-doc deletions.
+    # A single rebuild pass is performed after the loop instead of N rebuilds.
+    all_entities_to_rebuild: dict = {}
+    all_relationships_to_rebuild: dict = {}
 
     # Double-check pipeline status before proceeding
     async with pipeline_status_lock:
@@ -1909,12 +1913,19 @@ async def background_delete_documents(
             file_path = "#"
             try:
                 result = await rag.adelete_by_doc_id(
-                    doc_id, delete_llm_cache=delete_llm_cache
+                    doc_id,
+                    delete_llm_cache=delete_llm_cache,
+                    skip_rebuild=True,
                 )
                 file_path = (
                     getattr(result, "file_path", "-") if "result" in locals() else "-"
                 )
                 if result.status == "success":
+                    # Merge this document's rebuild targets into the batch accumulator
+                    all_entities_to_rebuild.update(result.entities_to_rebuild)
+                    all_relationships_to_rebuild.update(
+                        result.relationships_to_rebuild
+                    )
                     successful_deletions.append(doc_id)
                     success_msg = (
                         f"Document deleted {i}/{total_docs}: {doc_id}[{file_path}]"
@@ -2051,6 +2062,32 @@ async def background_delete_documents(
                 async with pipeline_status_lock:
                     pipeline_status["latest_message"] = error_msg
                     pipeline_status["history_messages"].append(error_msg)
+
+        # Single consolidated knowledge-graph rebuild for all successfully deleted docs.
+        # This replaces the N per-document rebuilds that would otherwise be triggered.
+        if all_entities_to_rebuild or all_relationships_to_rebuild:
+            rebuild_msg = (
+                f"Rebuilding knowledge graph for {len(all_entities_to_rebuild)} entities "
+                f"and {len(all_relationships_to_rebuild)} relationships "
+                f"(deferred from {len(successful_deletions)} deletions)"
+            )
+            logger.info(rebuild_msg)
+            async with pipeline_status_lock:
+                pipeline_status["latest_message"] = rebuild_msg
+                pipeline_status["history_messages"].append(rebuild_msg)
+            try:
+                await rag._arebuild_knowledge(
+                    entities_to_rebuild=all_entities_to_rebuild,
+                    relationships_to_rebuild=all_relationships_to_rebuild,
+                    pipeline_status=pipeline_status,
+                    pipeline_status_lock=pipeline_status_lock,
+                )
+            except Exception as rebuild_error:
+                rebuild_error_msg = f"Knowledge graph rebuild failed after batch deletion: {rebuild_error}"
+                logger.error(rebuild_error_msg)
+                logger.error(traceback.format_exc())
+                async with pipeline_status_lock:
+                    pipeline_status["history_messages"].append(rebuild_error_msg)
 
     except Exception as e:
         error_msg = f"Critical error during batch deletion: {str(e)}"

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -846,6 +846,9 @@ class DeletionResult:
     message: str
     status_code: int = 200
     file_path: str | None = None
+    # Populated when skip_rebuild=True so callers can aggregate and rebuild once
+    entities_to_rebuild: dict = field(default_factory=dict)
+    relationships_to_rebuild: dict = field(default_factory=dict)
 
 
 # Unified Query Result Data Structures for Reference List Support

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -3175,7 +3175,10 @@ class LightRAG:
         return found_statuses
 
     async def adelete_by_doc_id(
-        self, doc_id: str, delete_llm_cache: bool = False
+        self,
+        doc_id: str,
+        delete_llm_cache: bool = False,
+        skip_rebuild: bool = False,
     ) -> DeletionResult:
         """Delete a document and all its related data, including chunks, graph elements.
 
@@ -3208,6 +3211,12 @@ class LightRAG:
             doc_id (str): The unique identifier of the document to be deleted.
             delete_llm_cache (bool): Whether to delete cached LLM extraction results
                 associated with the document. Defaults to False.
+            skip_rebuild (bool): When True, skip the knowledge-graph rebuild step and
+                instead return the rebuild targets in ``DeletionResult.entities_to_rebuild``
+                and ``DeletionResult.relationships_to_rebuild``.  The caller is then
+                responsible for performing a single consolidated rebuild via
+                ``_arebuild_knowledge()``.  Useful for batch deletions where rebuilding
+                after every document would repeat the same work N times.  Defaults to False.
 
         Returns:
             DeletionResult: An object containing the outcome of the deletion process.
@@ -3216,6 +3225,8 @@ class LightRAG:
                 - `message` (str): A summary of the operation's result.
                 - `status_code` (int): HTTP status code (e.g., 200, 404, 403, 500).
                 - `file_path` (str | None): The file path of the deleted document, if available.
+                - `entities_to_rebuild` (dict): Populated when skip_rebuild=True.
+                - `relationships_to_rebuild` (dict): Populated when skip_rebuild=True.
         """
         # Get pipeline status shared data and lock for validation
         pipeline_status = await get_namespace_data(
@@ -3897,8 +3908,10 @@ class LightRAG:
                 logger.error(f"Failed to persist pre-rebuild changes: {e}")
                 raise Exception(f"Failed to persist pre-rebuild changes: {e}") from e
 
-            # 8. Rebuild entities and relationships from remaining chunks
-            if entities_to_rebuild or relationships_to_rebuild:
+            # 8. Rebuild entities and relationships from remaining chunks.
+            # When skip_rebuild=True the caller (e.g. background_delete_documents)
+            # will aggregate targets across all documents and do a single rebuild.
+            if not skip_rebuild and (entities_to_rebuild or relationships_to_rebuild):
                 try:
                     deletion_stage = "rebuild_knowledge_graph"
                     await rebuild_knowledge_from_chunks(
@@ -3997,6 +4010,8 @@ class LightRAG:
                 message=log_message,
                 status_code=200,
                 file_path=file_path,
+                entities_to_rebuild=entities_to_rebuild if skip_rebuild else {},
+                relationships_to_rebuild=relationships_to_rebuild if skip_rebuild else {},
             )
 
         except Exception as e:
@@ -4084,6 +4099,35 @@ class LightRAG:
                     pipeline_status["latest_message"] = completion_msg
                     pipeline_status["history_messages"].append(completion_msg)
                     logger.info(completion_msg)
+
+    async def _arebuild_knowledge(
+        self,
+        entities_to_rebuild: dict,
+        relationships_to_rebuild: dict,
+        pipeline_status: dict,
+        pipeline_status_lock,
+    ) -> None:
+        """Run a single knowledge-graph rebuild pass for the given targets.
+
+        Intended to be called once after a batch deletion where individual
+        ``adelete_by_doc_id(skip_rebuild=True)`` calls deferred their rebuilds.
+        """
+        if not entities_to_rebuild and not relationships_to_rebuild:
+            return
+        await rebuild_knowledge_from_chunks(
+            entities_to_rebuild=entities_to_rebuild,
+            relationships_to_rebuild=relationships_to_rebuild,
+            knowledge_graph_inst=self.chunk_entity_relation_graph,
+            entities_vdb=self.entities_vdb,
+            relationships_vdb=self.relationships_vdb,
+            text_chunks_storage=self.text_chunks,
+            llm_response_cache=self.llm_response_cache,
+            global_config=asdict(self),
+            pipeline_status=pipeline_status,
+            pipeline_status_lock=pipeline_status_lock,
+            entity_chunks_storage=self.entity_chunks,
+            relation_chunks_storage=self.relation_chunks,
+        )
 
     async def adelete_by_entity(self, entity_name: str) -> DeletionResult:
         """Asynchronously delete an entity and all its relationships.


### PR DESCRIPTION
## Summary

Fixes #2795

When `background_delete_documents` deleted N documents it called `adelete_by_doc_id` in a loop, and each call ran `rebuild_knowledge_from_chunks` independently. For shared entities/relationships this meant the same LLM summary work was repeated N times — up to **75× waste** in practice (per the issue's benchmarks on an 85-doc batch).

## Changes

- **`lightrag/base.py`**: Add `entities_to_rebuild` and `relationships_to_rebuild` fields to `DeletionResult` (populated when `skip_rebuild=True`).
- **`lightrag/lightrag.py`**:
  - Add `skip_rebuild: bool = False` parameter to `adelete_by_doc_id`. When True, the rebuild step is skipped and targets are stored in the result instead.
  - Add `_arebuild_knowledge()` helper that wraps `rebuild_knowledge_from_chunks` for callers that accumulate targets across multiple deletions.
- **`lightrag/api/routers/document_routes.py`**: Pass `skip_rebuild=True` in the per-document loop, aggregate all targets, then call `rag._arebuild_knowledge()` once after the loop completes.

## Before / After

| | Before | After |
|---|---|---|
| Rebuild operations (N=85) | 85 | **1** |
| LLM summary calls | ~1,593 | ~21 |
| Cached chunk re-parses | ~135,987 | ~1,800 |

## Test plan

- [x] Unit test suite: **217 passed, 0 failed**
- [x] `skip_rebuild=True` only skips the rebuild step — document cleanup (LLM cache, doc_status, full_docs) still runs normally
- [x] `skip_rebuild` defaults to `False` so single-document deletion behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)