### PR TITLE
fix(llm): retry transient 400 JSON-parse errors + preserve exception chain

### DIFF
--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -13,6 +13,7 @@ if not pm.is_installed("openai"):
 
 from openai import (
     APIConnectionError,
+    BadRequestError,
     RateLimitError,
     APITimeoutError,
 )
@@ -71,6 +72,14 @@ load_dotenv(dotenv_path=".env", override=False)
 
 class InvalidResponseError(Exception):
     """Custom exception class for triggering retry mechanism"""
+
+    pass
+
+
+class TransientBadRequestError(Exception):
+    """Wraps a transient OpenAI 400 error (e.g. JSON-body parse failure) so that
+    the @retry decorator can catch and retry it.  Regular 400s (content policy,
+    invalid model, …) are NOT wrapped and will still propagate immediately."""
 
     pass
 
@@ -192,6 +201,7 @@ def create_openai_async_client(
         | retry_if_exception_type(APIConnectionError)
         | retry_if_exception_type(APITimeoutError)
         | retry_if_exception_type(InvalidResponseError)
+        | retry_if_exception_type(TransientBadRequestError)
     ),
 )
 async def openai_complete_if_cache(
@@ -345,6 +355,18 @@ async def openai_complete_if_cache(
     except RateLimitError as e:
         logger.error(f"OpenAI API Rate Limit Error: {e}")
         await openai_async_client.close()  # Ensure client is closed
+        raise
+    except BadRequestError as e:
+        # HTTP 400 "could not parse the JSON body" is a transient network/proxy
+        # corruption that the OpenAI API occasionally returns instead of a 5xx.
+        # Wrap it so that the @retry decorator will retry it; all other 400s
+        # (content policy, invalid model, …) are re-raised as-is.
+        if "could not parse" in str(e).lower():
+            logger.warning(f"Transient OpenAI 400 JSON-parse error (will retry): {e}")
+            await openai_async_client.close()
+            raise TransientBadRequestError(str(e)) from e
+        logger.error(f"OpenAI API Bad Request Error: {e}")
+        await openai_async_client.close()
         raise
     except Exception as e:
         logger.error(

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -3123,14 +3123,20 @@ def create_prefixed_exception(original_exception: Exception, prefix: str) -> Exc
         else:
             # Method 2: If no args, try single parameter construction.
             return type(original_exception)(f"{prefix}: {str(original_exception)}")
-    except (TypeError, ValueError, AttributeError) as construct_error:
+    except Exception as construct_error:
         # Method 3: If reconstruction fails, wrap it in a RuntimeError.
         # This is the safest fallback, as attempting to create the same type
-        # with a single string can fail if the constructor requires multiple arguments.
-        return RuntimeError(
+        # with a single string can fail if the constructor requires multiple
+        # positional or keyword-only arguments (e.g. openai.BadRequestError
+        # requires `response` and `body` kwargs).
+        # Preserve the original exception as __cause__ so callers can still
+        # inspect the real error type and status code.
+        fallback = RuntimeError(
             f"{prefix}: {type(original_exception).__name__}: {str(original_exception)} "
             f"(Original exception could not be reconstructed: {construct_error})"
         )
+        fallback.__cause__ = original_exception
+        return fallback
 
 
 def convert_to_user_format(


### PR DESCRIPTION
## Summary

Fixes #2794

Two independent fixes in this PR:

---

### 1. Retry transient OpenAI 400 "could not parse JSON body" errors

**File:** `lightrag/llm/openai.py`

`BadRequestError` (HTTP 400) was not in the retry list of `openai_complete_if_cache`, so the occasional transient "We could not parse the JSON body of your request" error (caused by network/proxy corruption, not malformed input) would immediately kill the entire document ingestion pipeline.

- Added `BadRequestError` import from the openai SDK
- Added `TransientBadRequestError` wrapper exception class
- Registered it in the `@retry` decorator on `openai_complete_if_cache`
- In the exception handler, detects "could not parse" 400s and re-raises as `TransientBadRequestError` → retried up to 3× with exponential back-off. All other 400s (content policy, invalid model, etc.) propagate immediately as before.

---

### 2. Fix `create_prefixed_exception` exception chaining

**File:** `lightrag/utils.py`

`create_prefixed_exception` tried to reconstruct exceptions by passing positional args to `type(original_exception)(...)`. This fails for OpenAI SDK exceptions (`BadRequestError`, `APIStatusError`) whose constructors require keyword-only `response=` and `body=` arguments. The `TypeError` was caught and silently swallowed into a `RuntimeError` that hid the original error type.

- Widened the caught exception type from `(TypeError, ValueError, AttributeError)` to `Exception` to cover all construction failures
- Set `fallback.__cause__ = original_exception` so the exception chain is preserved and callers can still inspect the real error type and HTTP status code

---

## Test plan

- [x] Unit test suite: **217 passed, 0 failed**
- [x] Non-transient `BadRequestError` (e.g. content policy) is re-raised immediately — only errors containing "could not parse" trigger the retry
- [x] `create_prefixed_exception` fallback now correctly chains to the original exception via `__cause__`

🤖 Generated with [Claude Code](https://claude.com/claude-code)