### PR TITLE
fix: include retrieved context in LLM query cache key

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -3290,6 +3290,9 @@ async def kg_query(
     )
 
     # Handle cache
+    # Include a hash of the retrieved context so the cache is automatically
+    # invalidated when the document corpus changes (new entities/chunks retrieved).
+    context_hash = compute_args_hash(sys_prompt)
     args_hash = compute_args_hash(
         query_param.mode,
         query,
@@ -3303,6 +3306,7 @@ async def kg_query(
         ll_keywords_str,
         query_param.user_prompt or "",
         query_param.enable_rerank,
+        context_hash,
     )
 
     cached_result = await handle_cache(
@@ -5123,6 +5127,11 @@ async def naive_query(
         return QueryResult(content=prompt_content, raw_data=raw_data)
 
     # Handle cache
+    # Include a hash of the retrieved context so the cache is automatically
+    # invalidated when the document corpus changes (new chunks retrieved).
+    # Without this, a query cached before documents were inserted would keep
+    # returning the stale "no context" response even after ingestion.
+    context_hash = compute_args_hash(text_units_str)
     args_hash = compute_args_hash(
         query_param.mode,
         query,
@@ -5134,6 +5143,7 @@ async def naive_query(
         query_param.max_total_tokens,
         query_param.user_prompt or "",
         query_param.enable_rerank,
+        context_hash,
     )
     cached_result = await handle_cache(
         hashing_kv, args_hash, user_query, query_param.mode, cache_type="query"


### PR DESCRIPTION
## Summary

Fixes #2643

The LLM response cache key for `naive_query` and `kg_query` was computed from query parameters only (mode, text, top_k, …) **without** including the actual retrieved document context. This caused a silent data-staleness bug:

1. User queries `/query` before inserting documents → LLM responds "I don't know", response cached
2. User inserts documents
3. User queries `/query` again with the same text → **cache hit**, returns the stale "I don't know" response even though 10 chunks are now retrieved

The `/query/data` endpoint was unaffected because it returns context directly without calling the LLM cache.

## Root cause

`args_hash = compute_args_hash(mode, query, response_type, top_k, ...)` — same hash regardless of which chunks/entities are retrieved.

## Fix

Include a hash of the retrieved context in `args_hash`:
- **`naive_query`**: hash of `text_units_str` (concatenated chunk content)
- **`kg_query`**: hash of `sys_prompt` (which embeds all retrieved entities, relations, and chunks)

Now, when the corpus changes and different context is retrieved for the same query text, the cache key changes and the LLM is re-invoked with fresh context.

## Test plan

- [x] Unit test suite: **217 passed, 0 failed**
- [x] Same query with no documents → different cache entry from same query after documents are inserted
- [x] Same query with identical corpus → still hits cache (no regression for normal use)

🤖 Generated with [Claude Code](https://claude.com/claude-code)