### PR TITLE
fix: suppress reference list from LLM prompt when include_references=False

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -4170,11 +4170,18 @@ async def _build_context_str(
     text_units_str = "\n".join(
         json.dumps(text_unit, ensure_ascii=False) for text_unit in chunks_context
     )
-    reference_list_str = "\n".join(
-        f"[{ref['reference_id']}] {ref['file_path']}"
-        for ref in reference_list
-        if ref["reference_id"]
-    )
+    # Only expose the reference list to the LLM when the caller wants references
+    # included in the response.  When include_references=False the reference block
+    # is omitted from the prompt so the model does not append a "### References"
+    # section to its answer (fixes #2832).
+    if query_param.include_references:
+        reference_list_str = "\n".join(
+            f"[{ref['reference_id']}] {ref['file_path']}"
+            for ref in reference_list
+            if ref["reference_id"]
+        )
+    else:
+        reference_list_str = ""
 
     logger.info(
         f"Final context: {len(entities_context)} entities, {len(relations_context)} relations, {len(chunks_context)} chunks"
@@ -5095,11 +5102,17 @@ async def naive_query(
     text_units_str = "\n".join(
         json.dumps(text_unit, ensure_ascii=False) for text_unit in chunks_context
     )
-    reference_list_str = "\n".join(
-        f"[{ref['reference_id']}] {ref['file_path']}"
-        for ref in reference_list
-        if ref["reference_id"]
-    )
+    # Omit the reference list from the LLM prompt when the caller has disabled
+    # references, so the model does not append a "### References" section to its
+    # answer (fixes #2832).
+    if query_param.include_references:
+        reference_list_str = "\n".join(
+            f"[{ref['reference_id']}] {ref['file_path']}"
+            for ref in reference_list
+            if ref["reference_id"]
+        )
+    else:
+        reference_list_str = ""
 
     naive_context_template = PROMPTS["naive_query_context"]
     context_content = naive_context_template.format(


### PR DESCRIPTION
## Problem

When a caller sets `include_references=False` in `QueryParam`, LightRAG correctly
omits the `references` field from the API response — but the LLM still receives
the full `Reference Document List` block in its context and naturally appends a
`### References` section to the response text.

Closes #2832

## Root cause

`_build_context_str` (kg path) and `naive_query` always build `reference_list_str`
and inject it into the prompt template regardless of `query_param.include_references`.

## Fix

Conditionally build `reference_list_str` based on `query_param.include_references`:

```python
# kg path (_build_context_str) and naive_query
if query_param.include_references:
    reference_list_str = "\n".join(
        f"[{ref['reference_id']}] {ref['file_path']}"
        for ref in reference_list
        if ref["reference_id"]
    )
else:
    reference_list_str = ""
```

When the string is empty the prompt template already handles it gracefully —
the `Reference Document List` section simply renders as an empty block, giving
the LLM no citation information to parrot back.

## Impact

- `include_references=False` (the default): model no longer appends `### References` to answers.
- `include_references=True`: behaviour unchanged.

## Tests

```
317 passed, 34 skipped
```