### PR TITLE
chore: remove dead config.ini / configparser code

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import traceback
 import asyncio
-import configparser
 import inspect
 import os
 import time
@@ -120,10 +119,6 @@ from dotenv import load_dotenv
 # allows to use different .env file for each lightrag instance
 # the OS environment variables take precedence over the .env file
 load_dotenv(dotenv_path=".env", override=False)
-
-# TODO: TO REMOVE @Yannick
-config = configparser.ConfigParser()
-config.read("config.ini", "utf-8")
 
 
 def _chunk_fields_from_status_doc(


### PR DESCRIPTION
## Summary

Removes two lines of dead code that have been annotated `# TODO: TO REMOVE @Yannick` since they were added:

```python
# TODO: TO REMOVE @Yannick
config = configparser.ConfigParser()
config.read("config.ini", "utf-8")
```

The `config` variable is never read anywhere else in `lightrag.py`, so the block is pure noise.  Removing it also lets us drop the `import configparser` line at the top of the file.

## Tests

```
317 passed, 34 skipped
```