### PR TITLE
chore: remove dead OLLAMA_NUM_CTX / args.ollama_num_ctx assignment

### DIFF
--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -356,9 +356,6 @@ def parse_args() -> argparse.Namespace:
         args.llm_binding = "openai"
         args.embedding_binding = "ollama"
 
-    # Ollama ctx_num
-    args.ollama_num_ctx = get_env_value("OLLAMA_NUM_CTX", 32768, int)
-
     args.llm_binding_host = get_env_value(
         "LLM_BINDING_HOST", get_default_host(args.llm_binding)
     )


### PR DESCRIPTION
## Summary

`config.py` line 360 reads the `OLLAMA_NUM_CTX` environment variable and stores it in `args.ollama_num_ctx`, but that attribute is **never read** anywhere else in the codebase:

```python
# Ollama ctx_num
args.ollama_num_ctx = get_env_value("OLLAMA_NUM_CTX", 32768, int)
```

The actual Ollama context-window size is handled entirely by the typed `BindingOptions` system:

| Option class | Env var | CLI arg |
|---|---|---|
| `OllamaLLMOptions` | `OLLAMA_LLM_NUM_CTX` | `--ollama-llm-num_ctx` |
| `OllamaEmbeddingOptions` | `OLLAMA_EMBEDDING_NUM_CTX` | `--ollama-embedding-num_ctx` |

`env.example` and the API READMEs already document the correct names (`OLLAMA_LLM_NUM_CTX` / `OLLAMA_EMBEDDING_NUM_CTX`).  The dead `OLLAMA_NUM_CTX` assignment just creates confusion for anyone tracing why that variable has no effect.

## Tests

```
317 passed, 34 skipped
```