### PR TITLE
bugfix: Corrected exception handling for LLM API timeouts where the subclass incorrectly passes keyword args

### DIFF
--- a/lightrag/exceptions.py
+++ b/lightrag/exceptions.py
@@ -14,7 +14,9 @@ class APIStatusError(Exception):
     def __init__(
         self, message: str, *, response: httpx.Response, body: object | None
     ) -> None:
-        super().__init__(message, response.request, body=body)
+        super().__init__(message)
+        self.request = response.request
+        self.body = body
         self.response = response
         self.status_code = response.status_code
         self.request_id = response.headers.get("x-request-id")
@@ -22,9 +24,10 @@ class APIStatusError(Exception):
 
 class APIConnectionError(Exception):
     def __init__(
-        self, *, message: str = "Connection error.", request: httpx.Request
+        self, *, message: str = "Connection error.", request: httpx.Request | None
     ) -> None:
-        super().__init__(message, request, body=None)
+        super().__init__(message)
+        self.request = request
 
 
 class BadRequestError(APIStatusError):
@@ -56,7 +59,7 @@ class RateLimitError(APIStatusError):
 
 
 class APITimeoutError(APIConnectionError):
-    def __init__(self, request: httpx.Request) -> None:
+    def __init__(self, request: httpx.Request | None) -> None:
         super().__init__(message="Request timed out.", request=request)
 
 


### PR DESCRIPTION
## Description

Durring 24 hour burn-in tests related to https://github.com/HKUDS/LightRAG/pull/2898 an exception handling bug was discovered, wherein if an LLM API timeout occurred,  an error was thrown but instead of logging the failure, the timeout error subclass incorrectly handled arguments causing a further failure, and stacktrace. Further the error related to the cause of the document ingestion failure is incorrectly logged, to indicate the error handler fault instead of the actual timeout error. An example stacktrace follows:

```
Failed to extract entities and relationships: C[25/50]: chunk-3997405144786221bd7fe560c304d5c8: APITimeoutError() takes no keyword arguments                             
   Traceback (most recent call last):                                                                                                                                       
     File "/app/.venv/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions                                                      
       yield                                                                                                                                                                
     File "/app/.venv/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request                                                         
       resp = await self._pool.handle_async_request(req)                                                                                                                    
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                    
     File "/app/.venv/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request                                                   
       raise exc from None                                                                                                                                                  
     File "/app/.venv/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request                                                   
       response = await connection.handle_async_request(                                                                                                                    
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                    
     File "/app/.venv/lib/python3.12/site-packages/httpcore/_async/connection.py", line 103, in handle_async_request                                                        
       return await self._connection.handle_async_request(request)                                                                                                          
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                          
     File "/app/.venv/lib/python3.12/site-packages/httpcore/_async/http11.py", line 136, in handle_async_request                                                            
       raise exc                                                                                                                                                            
     File "/app/.venv/lib/python3.12/site-packages/httpcore/_async/http11.py", line 106, in handle_async_request                                                            
       ) = await self._receive_response_headers(**kwargs)                                                                                                                   
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                   
     File "/app/.venv/lib/python3.12/site-packages/httpcore/_async/http11.py", line 177, in _receive_response_headers                                                       
       event = await self._receive_event(timeout=timeout)                                                                                                                   
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                   
     File "/app/.venv/lib/python3.12/site-packages/httpcore/_async/http11.py", line 217, in _receive_event                                                                  
       data = await self._network_stream.read(                                                                                                                              
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                              
     File "/app/.venv/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 32, in read                                                                           
       with map_exceptions(exc_map):                                                                                                                                        
            ^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                         
     File "/usr/local/lib/python3.12/contextlib.py", line 158, in __exit__                                                                                                  
       self.gen.throw(value)                                                                                                                                                
     File "/app/.venv/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions                                                                     
       raise to_exc(exc) from exc                                                                                                                                           
   httpcore.ReadTimeout                                                                                                                                                     
                                                                                                                                                                            
   The above exception was the direct cause of the following exception:                                                                                                     
                                                                                                                                                                            
   Traceback (most recent call last):                                                                                                                                       
     File "/app/lightrag/llm/ollama.py", line 119, in _ollama_model_if_cache                                                                                                
       response = await ollama_client.chat(model=model, messages=messages, **kwargs)                                                                                        
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                        
     File "/app/.venv/lib/python3.12/site-packages/ollama/_client.py", line 953, in chat                                                                                    
       return await self._request(                                                                                                                                          
              ^^^^^^^^^^^^^^^^^^^^                                                                                                                                          
     File "/app/.venv/lib/python3.12/site-packages/ollama/_client.py", line 751, in _request                                                                                
       return cls(**(await self._request_raw(*args, **kwargs)).json())                                                                                                      
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                               
     File "/app/.venv/lib/python3.12/site-packages/ollama/_client.py", line 691, in _request_raw                                                                            
       r = await self._client.request(*args, **kwargs)                                                                                                                      
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                      
     File "/app/.venv/lib/python3.12/site-packages/httpx/_client.py", line 1540, in request                                                                                 
       return await self.send(request, auth=auth, follow_redirects=follow_redirects)                                                                                        
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                        
     File "/app/.venv/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send                                                                                    
       response = await self._send_handling_auth(                                                                                                                           
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                           
     File "/app/.venv/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth                                                                     
       response = await self._send_handling_redirects(                                                                                                                      
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                      
     File "/app/.venv/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects                                                                
       response = await self._send_single_request(request)                                                                                                                  
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                  
     File "/app/.venv/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request                                                                    
       response = await transport.handle_async_request(request)                                                                                                             
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                             
     File "/app/.venv/lib/python3.12/site-packages/httpx/_transports/default.py", line 393, in handle_async_request                                                         
       with map_httpcore_exceptions():                                                                                                                                      
            ^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                       
     File "/usr/local/lib/python3.12/contextlib.py", line 158, in __exit__                                                                                                  
       self.gen.throw(value)                                                                                                                                                
     File "/app/.venv/lib/python3.12/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions                                                      
       raise mapped_exc(message) from exc                                                                                                                                   
   httpx.ReadTimeout                                                                                                                                                        
                                                                                                                                                                            
   During handling of the above exception, another exception occurred:                                                                                                      
                                                                                                                                                                            
   Traceback (most recent call last):                                                                                                                                       
     File "/app/lightrag/operate.py", line 3107, in _process_with_semaphore                                                                                                 
       result = await _process_single_content(chunk)                                                                                                                        
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                        
     File "/app/lightrag/operate.py", line 2962, in _process_single_content                                                                                                 
       final_result, timestamp = await use_llm_func_with_cache(                                                                                                             
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                             
     File "/app/lightrag/utils.py", line 2049, in use_llm_func_with_cache                                                                                                   
       res: str = await use_llm_func(                                                                                                                                       
                  ^^^^^^^^^^^^^^^^^^^                                                                                                                                       
     File "/app/lightrag/utils.py", line 1026, in wait_func                                                                                                                 
       return await future                                                                                                                                                  
              ^^^^^^^^^^^^                                                                                                                                                  
     File "/app/lightrag/utils.py", line 730, in worker                                                                                                                     
       result = await asyncio.wait_for(                                                                                                                                     
                ^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                     
     File "/usr/local/lib/python3.12/asyncio/tasks.py", line 520, in wait_for                                                                                               
       return await fut                                                                                                                                                     
              ^^^^^^^^^                                                                                                                                                     
     File "/app/lightrag/llm/ollama.py", line 190, in ollama_model_complete                                                                                                 
       return await _ollama_model_if_cache(                                                                                                                                 
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                 
     File "/app/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped                                                                
       return await copy(fn, *args, **kwargs)                                                                                                                               
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                               
     File "/app/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__                                                                     
       do = await self.iter(retry_state=retry_state)                                                                                                                        
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                        
     File "/app/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 153, in iter                                                                         
       result = await action(retry_state)                                                                                                                                   
                ^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                   
     File "/app/.venv/lib/python3.12/site-packages/tenacity/_utils.py", line 99, in inner                                                                                   
       return call(*args, **kwargs)                                                                                                                                         
              ^^^^^^^^^^^^^^^^^^^^^                                                                                                                                         
     File "/app/.venv/lib/python3.12/site-packages/tenacity/__init__.py", line 400, in <lambda>                                                                             
       self._add_action_func(lambda rs: rs.outcome.result())                                                                                                                
                                        ^^^^^^^^^^^^^^^^^^^                                                                                                                 
     File "/usr/local/lib/python3.12/concurrent/futures/_base.py", line 449, in result                                                                                      
       return self.__get_result()                                                                                                                                           
              ^^^^^^^^^^^^^^^^^^^                                                                                                                                           
     File "/usr/local/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result                                                                                
       raise self._exception                                                                                                                                                
     File "/app/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__                                                                     
       result = await fn(*args, **kwargs)                                                                                                                                   
                ^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                   
     File "/app/lightrag/llm/ollama.py", line 152, in _ollama_model_if_cache                                                                                                
       raise APITimeoutError(request=None) from e                                                                                                                           
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                  
     File "/app/lightrag/exceptions.py", line 60, in __init__                                                                                                               
       super().__init__(message="Request timed out.", request=request)                                                                                                      
     File "/app/lightrag/exceptions.py", line 27, in __init__                                                                                                               
       super().__init__(message, request, body=None)                                                                                                                        
   TypeError: APITimeoutError() takes no keyword arguments                                                                                                                  
                                                                                                                                                                            
   The above exception was the direct cause of the following exception:                                                                                                     
                                                                                                                                                                            
   Traceback (most recent call last):                                                                                                                                       
     File "/app/lightrag/operate.py", line 3115, in _process_with_semaphore                                                                                                 
       raise prefixed_exception from e                                                                                                                                      
   TypeError: chunk-3997405144786221bd7fe560c304d5c8: APITimeoutError() takes no keyword arguments                                                                          
                                                                                                                                                                            
   The above exception was the direct cause of the following exception:                                                                                                     
                                                                                                                                                                            
   Traceback (most recent call last):                                                                                                                                       
     File "/app/lightrag/lightrag.py", line 2047, in process_document                                                                                                       
       chunk_results = await entity_relation_task                                                                                                                           
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                           
     File "/app/lightrag/lightrag.py", line 2336, in _process_extract_entities                                                                                              
       raise e                                                                                                                                                              
     File "/app/lightrag/lightrag.py", line 2321, in _process_extract_entities                                                                                              
       chunk_results = await extract_entities(                                                                                                                              
                       ^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                              
     File "/app/lightrag/operate.py", line 3157, in extract_entities                                                                                                        
       raise prefixed_exception from first_exception                                                                                                                        
   TypeError: C[25/50]: chunk-3997405144786221bd7fe560c304d5c8: APITimeoutError() takes no keyword arguments                                                                
   Failed to extract document 1/20: 2412.14135v1.pdf 
```

## Related Issues

This bug was discovered in the course of burn-in testing related to https://github.com/HKUDS/LightRAG/pull/2898 however the bug itself presents whenever a less capable model enters any kind of loop that exceeds the LLLM API timeout. 

## Changes Made

Corrected lightrag/exceptions.py to properly handle keyword arguments

## Checklist

- [X] Changes tested locally
- [X] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

[Add any additional notes or context for the reviewer(s).]
