### PR TITLE
Improve LLM API failure diagnostics

### DIFF
--- a/lightrag/llm/anthropic.py
+++ b/lightrag/llm/anthropic.py
@@ -125,8 +125,19 @@ async def anthropic_complete_if_cache(
         logger.error(f"Anthropic API Timeout Error: {e}")
         raise
     except Exception as e:
+        body = getattr(e, "body", None)
+        request_id = getattr(e, "request_id", None)
+        req = getattr(e, "request", None)
+        extra_parts = []
+        if body:
+            extra_parts.append(f"Response body: {body}")
+        if request_id:
+            extra_parts.append(f"Request ID: {request_id}")
+        if req is not None:
+            extra_parts.append(f"Request URL: {req.url}")
+        extra = ("\n" + "\n".join(extra_parts)) if extra_parts else ""
         logger.error(
-            f"Anthropic API Call Failed,\nModel: {model},\nParams: {kwargs}, Got: {e}"
+            f"Anthropic API Call Failed,\nModel: {model},\nParams: {kwargs}, Got: {e}{extra}"
         )
         raise
 

--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -347,8 +347,19 @@ async def openai_complete_if_cache(
         await openai_async_client.close()  # Ensure client is closed
         raise
     except Exception as e:
+        body = getattr(e, "body", None)
+        request_id = getattr(e, "request_id", None)
+        req = getattr(e, "request", None)
+        extra_parts = []
+        if body:
+            extra_parts.append(f"Response body: {body}")
+        if request_id:
+            extra_parts.append(f"Request ID: {request_id}")
+        if req is not None:
+            extra_parts.append(f"Request URL: {req.url}")
+        extra = ("\n" + "\n".join(extra_parts)) if extra_parts else ""
         logger.error(
-            f"OpenAI API Call Failed,\nModel: {model},\nParams: {kwargs}, Got: {e}"
+            f"OpenAI API Call Failed,\nModel: {model},\nParams: {kwargs}, Got: {e}{extra}"
         )
         await openai_async_client.close()  # Ensure client is closed
         raise

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -3123,13 +3123,12 @@ def create_prefixed_exception(original_exception: Exception, prefix: str) -> Exc
         else:
             # Method 2: If no args, try single parameter construction.
             return type(original_exception)(f"{prefix}: {str(original_exception)}")
-    except (TypeError, ValueError, AttributeError) as construct_error:
+    except (TypeError, ValueError, AttributeError):
         # Method 3: If reconstruction fails, wrap it in a RuntimeError.
         # This is the safest fallback, as attempting to create the same type
         # with a single string can fail if the constructor requires multiple arguments.
         return RuntimeError(
-            f"{prefix}: {type(original_exception).__name__}: {str(original_exception)} "
-            f"(Original exception could not be reconstructed: {construct_error})"
+            f"{prefix}: {type(original_exception).__name__}: {str(original_exception)}"
         )
 
 


### PR DESCRIPTION
## Description

Improve OpenAI and Anthropic failure logging by including provider response metadata when available, and simplify the fallback `create_prefixed_exception` message when an exception type cannot be reconstructed.

## Related Issues

n/a

## Changes Made

- add optional response body, request ID, and request URL details to OpenAI API failure logs
- add optional response body, request ID, and request URL details to Anthropic API failure logs
- simplify the fallback `RuntimeError` message returned by `create_prefixed_exception`

## Checklist

- [ ] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

No local test suite was run for this change.
