### PR TITLE
docs: deprecate config.ini in documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ LightRAG is an advanced Retrieval-Augmented Generation (RAG) framework designed 
 - For lightweight Python validation in fresh shells, prefer `python3` over `python` unless the active environment has already exposed `python`.
 
 ## Security & Configuration Tips
-- Copy `.env.example` and `config.ini.example`; never commit secrets or real connection strings.
+- Copy `.env.example`; never commit secrets or real connection strings.
 - Configure storage backends through `LIGHTRAG_*` variables and validate them with `docker-compose` services when needed.
 - Treat `lightrag.log*` as local artefacts; purge sensitive information before sharing logs or outputs.
 

--- a/config.ini.example
+++ b/config.ini.example
@@ -1,3 +1,8 @@
+; DEPRECATION WARNING:
+; `config.ini` support will be removed in a future release.
+; Please move your configuration to `.env` or environment variables.
+; This file is kept only as a temporary compatibility example.
+
 [neo4j]
 uri = neo4j+s://xxxxxxxx.databases.neo4j.io
 username = neo4j

--- a/docs/LightRAG-API-Server-zh.md
+++ b/docs/LightRAG-API-Server-zh.md
@@ -443,13 +443,12 @@ EMBEDDING_MODEL=your-embedding-deployment-name
 
 ## LightRAG 服务器详细配置
 
-API 服务器可以通过三种方式配置（优先级从高到低）：
+API 服务器可以通过两种方式配置（优先级从高到低）：
 
 * 命令行参数
 * 环境变量或 .env 文件
-* Config.ini（仅用于存储配置）
 
-大多数配置都有默认设置，详细信息请查看示例文件：`.env.example`。数据存储配置也可以通过 config.ini 设置。为方便起见，提供了示例文件 `config.ini.example`。
+大多数配置都有默认设置，详细信息请查看示例文件：`.env.example`。存储配置也应通过环境变量或 `.env` 文件设置。
 
 ### 支持的 LLM 和嵌入后端
 
@@ -514,7 +513,7 @@ LIGHTRAG_GRAPH_STORAGE=PGGraphStorage
 LIGHTRAG_DOC_STATUS_STORAGE=PGDocStatusStorage
 ```
 
-在向 LightRAG 添加文档后，您不能更改存储实现选择。目前尚不支持从一个存储实现迁移到另一个存储实现。更多配置信息请阅读示例 `env.exampl`e文件。
+在向 LightRAG 添加文档后，您不能更改存储实现选择。目前尚不支持从一个存储实现迁移到另一个存储实现。更多配置信息请阅读示例 `.env.example` 文件。
 
 ### 在不同存储类型之间迁移LLM缓存
 

--- a/docs/LightRAG-API-Server.md
+++ b/docs/LightRAG-API-Server.md
@@ -444,13 +444,12 @@ EMBEDDING_MODEL=your-embedding-deployment-name
 
 ## LightRAG Server Configuration in Detail
 
-The API Server can be configured in three ways (highest priority first):
+The API Server can be configured in two ways (highest priority first):
 
 * Command line arguments
 * Environment variables or .env file
-* Config.ini (Only for storage configuration)
 
-Most of the configurations come with default settings; check out the details in the sample file: `.env.example`. Data storage configuration can also be set by config.ini. A sample file `config.ini.example` is provided for your convenience.
+Most of the configurations come with default settings; check out the details in the sample file: `.env.example`. Storage configuration should also be set through environment variables or the `.env` file.
 
 ### LLM and Embedding Backend Supported
 
@@ -514,7 +513,7 @@ LIGHTRAG_GRAPH_STORAGE=PGGraphStorage
 LIGHTRAG_DOC_STATUS_STORAGE=PGDocStatusStorage
 ```
 
-You cannot change storage implementation selection after adding documents to LightRAG. Data migration from one storage implementation to another is not supported yet. For further information, please read the sample env file or config.ini file.
+You cannot change storage implementation selection after adding documents to LightRAG. Data migration from one storage implementation to another is not supported yet. For further information, please read the sample `.env.example` file.
 
 ### LLM Cache Migration Between Storage Types
 

--- a/lightrag/tools/README_CLEAN_LLM_QUERY_CACHE.md
+++ b/lightrag/tools/README_CLEAN_LLM_QUERY_CACHE.md
@@ -41,7 +41,7 @@ Examples:
 
 ## Prerequisites
 
-- The tool reads storage configuration from environment variables or `config.ini`
+- The tool reads storage configuration from environment variables
 - Ensure the target storage is properly configured and accessible
 - Backup important data before running cleanup operations
 
@@ -428,8 +428,7 @@ After cleanup completes, a detailed report includes:
 The tool supports multiple configuration methods with the following priority:
 
 1. **Environment variables** (highest priority)
-2. **config.ini file** (medium priority)
-3. **Default values** (lowest priority)
+2. **Default values** (lowest priority)
 
 ### Environment Variable Configuration
 
@@ -485,30 +484,7 @@ OPENSEARCH_HOSTS=localhost:9200
 OPENSEARCH_WORKSPACE=search_space
 ```
 
-### config.ini Configuration
-
-Alternatively, create a `config.ini` file in the project root:
-
-```ini
-[redis]
-uri = redis://localhost:6379
-
-[postgres]
-host = localhost
-port = 5432
-user = postgres
-password = yourpassword
-database = lightrag
-
-[mongodb]
-uri = mongodb://root:root@localhost:27017/
-database = LightRAG
-
-[opensearch]
-hosts = localhost:9200
-```
-
-**Note**: Environment variables take precedence over config.ini settings.
+If environment variables are not provided, the tool falls back to built-in defaults where available.
 
 ## Troubleshooting
 
@@ -516,7 +492,7 @@ hosts = localhost:9200
 ```
 ⚠️  Warning: Missing environment variables: POSTGRES_USER, POSTGRES_PASSWORD
 ```
-**Solution**: Add missing variables to your `.env` file or configure in `config.ini`
+**Solution**: Add missing variables to your `.env` file
 
 ### Connection Failed
 ```

--- a/lightrag/tools/README_MIGRATE_LLM_CACHE.md
+++ b/lightrag/tools/README_MIGRATE_LLM_CACHE.md
@@ -300,8 +300,7 @@ After migration completes, a detailed report includes:
 The tool supports multiple configuration methods with the following priority:
 
 1. **Environment variables** (highest priority)
-2. **config.ini file** (medium priority)
-3. **Default values** (lowest priority)
+2. **Default values** (lowest priority)
 
 #### Option A: Environment Variable Configuration
 
@@ -358,30 +357,7 @@ OPENSEARCH_HOSTS=localhost:9200
 OPENSEARCH_WORKSPACE=os_space
 ```
 
-#### Option B: config.ini Configuration
-
-Alternatively, create a `config.ini` file in the project root:
-
-```ini
-[redis]
-uri = redis://localhost:6379
-
-[postgres]
-host = localhost
-port = 5432
-user = postgres
-password = yourpassword
-database = lightrag
-
-[mongodb]
-uri = mongodb://root:root@localhost:27017/
-database = LightRAG
-
-[opensearch]
-hosts = localhost:9200
-```
-
-**Note**: Environment variables take precedence over config.ini settings. JsonKVStorage uses `WORKING_DIR` environment variable or defaults to `./rag_storage`.
+If environment variables are not provided, the tool falls back to built-in defaults where available. JsonKVStorage uses `WORKING_DIR` or defaults to `./rag_storage`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Description

Deprecates `config.ini` in the project documentation and updates the sample `config.ini.example` file with a warning that users should migrate to `.env` or environment variables.

## Related Issues

N/A

## Changes Made

- Removed `config.ini` usage guidance from Markdown documentation and replaced it with `.env` / environment variable guidance
- Added a deprecation warning at the top of `config.ini.example`
- Kept runtime `config.ini` compatibility unchanged; this PR only updates docs and the sample file

## Checklist

- [ ] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

This is a documentation-only change. Runtime support for `config.ini` remains in place for now as a transition path.
