### PR TITLE
Remove config.ini from compose samples

### DIFF
--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -14,7 +14,6 @@ services:
     volumes:
       - ./data/rag_storage:/app/data/rag_storage
       - ./data/inputs:/app/data/inputs
-      - ./config.ini:/app/config.ini
       - ./.env:/app/.env
     deploy:
       restart_policy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
     volumes:
       - ./data/rag_storage:/app/data/rag_storage
       - ./data/inputs:/app/data/inputs
-      - ./config.ini:/app/config.ini
       - ./.env:/app/.env
     deploy:
       restart_policy:

--- a/tests/test_interactive_setup_outputs.py
+++ b/tests/test_interactive_setup_outputs.py
@@ -6574,6 +6574,87 @@ generate_docker_compose "$REPO_ROOT/docker-compose.generated.yml"
     assert lightrag_pos < override_pos < postgres_pos
 
 
+def test_generate_docker_compose_omits_config_ini_mount_from_base_template(
+    tmp_path: Path,
+) -> None:
+    compose_file = tmp_path / "docker-compose.yml"
+    compose_file.write_text(
+        "\n".join(
+            [
+                "services:",
+                "  lightrag:",
+                "    image: example/lightrag:test",
+                "    volumes:",
+                "      - ./data/rag_storage:/app/data/rag_storage",
+                "      - ./data/inputs:/app/data/inputs",
+                "      - ./.env:/app/.env",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_bash(
+        f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+reset_state
+
+generate_docker_compose "$REPO_ROOT/docker-compose.generated.yml"
+"""
+    )
+
+    generated_compose = (tmp_path / "docker-compose.generated.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "./config.ini:/app/config.ini" not in generated_compose
+    assert "./data/rag_storage:/app/data/rag_storage" in generated_compose
+    assert "./data/inputs:/app/data/inputs" in generated_compose
+    assert "./.env:/app/.env" in generated_compose
+
+
+def test_generate_docker_compose_preserves_existing_config_ini_mount(
+    tmp_path: Path,
+) -> None:
+    compose_file = tmp_path / "docker-compose.final.yml"
+    compose_file.write_text(
+        "\n".join(
+            [
+                "services:",
+                "  lightrag:",
+                "    image: example/lightrag:test",
+                "    volumes:",
+                "      - ./data/rag_storage:/app/data/rag_storage",
+                "      - ./data/inputs:/app/data/inputs",
+                "      - ./config.ini:/app/config.ini",
+                "      - ./.env:/app/.env",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_bash(
+        f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+reset_state
+
+generate_docker_compose "$REPO_ROOT/docker-compose.final.yml"
+"""
+    )
+
+    generated_compose = compose_file.read_text(encoding="utf-8")
+
+    assert "./config.ini:/app/config.ini" in generated_compose
+    assert "./data/rag_storage:/app/data/rag_storage" in generated_compose
+    assert "./data/inputs:/app/data/inputs" in generated_compose
+    assert "./.env:/app/.env" in generated_compose
+
+
 def test_finalize_server_setup_skips_embedded_milvus_sub_services(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Description

Remove the `config.ini` bind mount from the sample Compose files and add setup regression coverage for the expected compose-generation behavior.

## Related Issues

N/A

## Changes Made

- Remove `./config.ini:/app/config.ini` from `docker-compose.yml`
- Remove `./config.ini:/app/config.ini` from `docker-compose-full.yml`
- Add tests covering omission of the mount for fresh generated compose output
- Add tests covering preservation of the mount when it already exists in `docker-compose.final.yml`

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

- Targeting the `dev` branch as requested.
- Local verification: `./scripts/test.sh tests/test_interactive_setup_outputs.py -k 'config_ini_mount'`
