### PR TITLE
fix(auth): prevent JWT algorithm confusion attack (GHSA-8ffj-4hx4-9pgf)

### DIFF
--- a/lightrag/api/auth.py
+++ b/lightrag/api/auth.py
@@ -160,4 +160,10 @@ class AuthHandler:
             )
 
 
-auth_handler = AuthHandler()
+try:
+    auth_handler = AuthHandler()
+except ValueError as e:
+    import sys
+
+    print(f"\n[Configuration Error] {e}\n", file=sys.stderr)
+    sys.exit(1)

--- a/lightrag/api/auth.py
+++ b/lightrag/api/auth.py
@@ -36,7 +36,13 @@ class AuthHandler:
                 "TOKEN_SECRET not set and AUTH_ACCOUNTS is not configured. "
                 "Falling back to the default guest-mode JWT secret. "
             )
-        self.algorithm = global_args.jwt_algorithm
+        algorithm = global_args.jwt_algorithm
+        if not algorithm or algorithm.lower() == "none":
+            raise ValueError(
+                "JWT_ALGORITHM must be set to a secure algorithm (e.g. HS256). "
+                "The 'none' algorithm is not permitted."
+            )
+        self.algorithm = algorithm
         self.expire_hours = global_args.token_expire_hours
         self.guest_expire_hours = global_args.guest_token_expire_hours
         self.accounts = {}
@@ -125,7 +131,14 @@ class AuthHandler:
             HTTPException: If token is invalid or expired
         """
         try:
-            payload = jwt.decode(token, self.secret, algorithms=[self.algorithm])
+            # Explicitly exclude 'none' to prevent algorithm confusion attacks
+            allowed_algorithms = [self.algorithm]
+            if "none" in (a.lower() for a in allowed_algorithms):
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="Insecure JWT algorithm configuration",
+                )
+            payload = jwt.decode(token, self.secret, algorithms=allowed_algorithms)
             expire_timestamp = payload["exp"]
             expire_time = datetime.fromtimestamp(expire_timestamp, timezone.utc)
 


### PR DESCRIPTION
## Description

Fix JWT algorithm confusion vulnerability (GHSA-8ffj-4hx4-9pgf) in `lightrag/api/auth.py`. The `validate_token` method did not guard against `JWT_ALGORITHM=none` misconfiguration, which would cause `jwt.decode()` to accept unsigned tokens and allow attackers to impersonate any user including admins.

## Related Issues

Security advisory: GHSA-8ffj-4hx4-9pgf (JWT Algorithm Confusion Vulnerability, HIGH severity, CVSS 7.5)

## Changes Made

- **`lightrag/api/auth.py` — `AuthHandler.__init__`**: Validate that `jwt_algorithm` is not empty or `"none"` at startup. Raises `ValueError` immediately so a misconfigured server fails fast rather than silently accepting forged tokens.
- **`lightrag/api/auth.py` — `validate_token`**: Added runtime guard that explicitly rejects `"none"` from the allowed algorithms list, providing defense-in-depth in case the initialization check is bypassed.

**Root cause**: When `JWT_ALGORITHM=none` is set in the environment, the original code passed `algorithms=["none"]` to `jwt.decode()`, which PyJWT 2.x honours — allowing unsigned tokens to be accepted as valid.

**Note**: Under the default configuration (`JWT_ALGORITHM=HS256`), PyJWT 2.x already rejects `alg: none` tokens because the algorithms list acts as a strict whitelist. This fix closes the residual risk from explicit misconfiguration.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

Reported via GitHub Security Advisories. The fix is minimal and backward-compatible: no behaviour changes for correctly configured deployments.
