### PR TITLE
perf: batch graph operations in ainsert_custom_kg for large-scale imports

### DIFF
--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -152,6 +152,42 @@ class NetworkXStorage(BaseGraphStorage):
         graph = await self._get_graph()
         graph.add_edge(source_node_id, target_node_id, **edge_data)
 
+    async def upsert_nodes_batch(
+        self, nodes: list[tuple[str, dict[str, str]]]
+    ) -> None:
+        """Batch insert/update multiple nodes in a single call.
+
+        Much faster than calling upsert_node() in a loop for large imports
+        because it avoids per-call async event loop overhead.
+
+        Args:
+            nodes: List of (node_id, node_data) tuples.
+        """
+        graph = await self._get_graph()
+        for node_id, node_data in nodes:
+            graph.add_node(node_id, **node_data)
+
+    async def has_nodes_batch(self, node_ids: list[str]) -> set[str]:
+        """Check existence of multiple nodes in a single call.
+
+        Returns:
+            Set of node_ids that exist in the graph.
+        """
+        graph = await self._get_graph()
+        return {nid for nid in node_ids if graph.has_node(nid)}
+
+    async def upsert_edges_batch(
+        self, edges: list[tuple[str, str, dict[str, str]]]
+    ) -> None:
+        """Batch insert/update multiple edges in a single call.
+
+        Args:
+            edges: List of (source_id, target_id, edge_data) tuples.
+        """
+        graph = await self._get_graph()
+        for src, tgt, edge_data in edges:
+            graph.add_edge(src, tgt, **edge_data)
+
     async def delete_node(self, node_id: str) -> None:
         """
         Importance notes:

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -2415,8 +2415,9 @@ class LightRAG:
                     self.text_chunks.upsert(all_chunks_data),
                 )
 
-            # Insert entities into knowledge graph
+            # Insert entities into knowledge graph (batch for performance)
             all_entities_data: list[dict[str, str]] = []
+            entity_nodes: list[tuple[str, dict[str, str]]] = []
             for entity_data in custom_kg.get("entities", []):
                 entity_name = entity_data["entity_name"]
                 entity_type = entity_data.get("entity_type", "UNKNOWN")
@@ -2425,13 +2426,11 @@ class LightRAG:
                 source_id = chunk_to_source_map.get(source_chunk_id, "UNKNOWN")
                 file_path = entity_data.get("file_path", "custom_kg")
 
-                # Log if source_id is UNKNOWN
                 if source_id == "UNKNOWN":
                     logger.warning(
                         f"Entity '{entity_name}' has an UNKNOWN source_id. Please check the source mapping."
                     )
 
-                # Prepare node data
                 node_data: dict[str, str] = {
                     "entity_id": entity_name,
                     "entity_type": entity_type,
@@ -2440,78 +2439,112 @@ class LightRAG:
                     "file_path": file_path,
                     "created_at": int(time.time()),
                 }
-                # Insert node data into the knowledge graph
-                await self.chunk_entity_relation_graph.upsert_node(
-                    entity_name, node_data=node_data
-                )
-                node_data["entity_name"] = entity_name
-                all_entities_data.append(node_data)
+                entity_nodes.append((entity_name, node_data))
+                node_data_copy = dict(node_data)
+                node_data_copy["entity_name"] = entity_name
+                all_entities_data.append(node_data_copy)
                 update_storage = True
 
-            # Insert relationships into knowledge graph
+            # Use batch operation if available (reduces N serial awaits to 1)
+            if entity_nodes:
+                if hasattr(self.chunk_entity_relation_graph, "upsert_nodes_batch"):
+                    await self.chunk_entity_relation_graph.upsert_nodes_batch(entity_nodes)
+                else:
+                    for node_id, node_data in entity_nodes:
+                        await self.chunk_entity_relation_graph.upsert_node(
+                            node_id, node_data=node_data
+                        )
+
+            # Insert relationships into knowledge graph (batch for performance)
             all_relationships_data: list[dict[str, str]] = []
+            edge_list: list[tuple[str, str, dict[str, str]]] = []
+
+            # Batch check which relationship endpoints exist (1 await instead of 2M)
+            needed_node_ids: set[str] = set()
+            for relationship_data in custom_kg.get("relationships", []):
+                needed_node_ids.add(relationship_data["src_id"])
+                needed_node_ids.add(relationship_data["tgt_id"])
+
+            if hasattr(self.chunk_entity_relation_graph, "has_nodes_batch"):
+                existing_nodes = await self.chunk_entity_relation_graph.has_nodes_batch(
+                    list(needed_node_ids)
+                )
+            else:
+                existing_nodes = set()
+                for nid in needed_node_ids:
+                    if await self.chunk_entity_relation_graph.has_node(nid):
+                        existing_nodes.add(nid)
+
+            # Create missing nodes in batch
+            missing_nodes: list[tuple[str, dict[str, str]]] = []
             for relationship_data in custom_kg.get("relationships", []):
                 src_id = relationship_data["src_id"]
                 tgt_id = relationship_data["tgt_id"]
-                description = relationship_data["description"]
-                keywords = relationship_data["keywords"]
-                weight = relationship_data.get("weight", 1.0)
                 source_chunk_id = relationship_data.get("source_id", "UNKNOWN")
                 source_id = chunk_to_source_map.get(source_chunk_id, "UNKNOWN")
                 file_path = relationship_data.get("file_path", "custom_kg")
 
-                # Log if source_id is UNKNOWN
                 if source_id == "UNKNOWN":
                     logger.warning(
                         f"Relationship from '{src_id}' to '{tgt_id}' has an UNKNOWN source_id. Please check the source mapping."
                     )
 
-                # Check if nodes exist in the knowledge graph
                 for need_insert_id in [src_id, tgt_id]:
-                    if not (
-                        await self.chunk_entity_relation_graph.has_node(need_insert_id)
-                    ):
-                        await self.chunk_entity_relation_graph.upsert_node(
-                            need_insert_id,
-                            node_data={
-                                "entity_id": need_insert_id,
-                                "source_id": source_id,
-                                "description": "UNKNOWN",
-                                "entity_type": "UNKNOWN",
-                                "file_path": file_path,
-                                "created_at": int(time.time()),
-                            },
-                        )
+                    if need_insert_id not in existing_nodes:
+                        missing_nodes.append((need_insert_id, {
+                            "entity_id": need_insert_id,
+                            "source_id": source_id,
+                            "description": "UNKNOWN",
+                            "entity_type": "UNKNOWN",
+                            "file_path": file_path,
+                            "created_at": int(time.time()),
+                        }))
+                        existing_nodes.add(need_insert_id)
 
-                # Insert edge into the knowledge graph
-                await self.chunk_entity_relation_graph.upsert_edge(
-                    src_id,
-                    tgt_id,
-                    edge_data={
-                        "weight": weight,
-                        "description": description,
-                        "keywords": keywords,
-                        "source_id": source_id,
-                        "file_path": file_path,
-                        "created_at": int(time.time()),
-                    },
-                )
-
-                edge_data: dict[str, str] = {
-                    "src_id": src_id,
-                    "tgt_id": tgt_id,
-                    "description": description,
-                    "keywords": keywords,
+                edge_data = {
+                    "weight": relationship_data.get("weight", 1.0),
+                    "description": relationship_data["description"],
+                    "keywords": relationship_data["keywords"],
                     "source_id": source_id,
-                    "weight": weight,
                     "file_path": file_path,
                     "created_at": int(time.time()),
                 }
-                all_relationships_data.append(edge_data)
+                edge_list.append((src_id, tgt_id, edge_data))
+
+                all_relationships_data.append({
+                    "src_id": src_id,
+                    "tgt_id": tgt_id,
+                    "description": relationship_data["description"],
+                    "keywords": relationship_data["keywords"],
+                    "source_id": source_id,
+                    "weight": relationship_data.get("weight", 1.0),
+                    "file_path": file_path,
+                    "created_at": int(time.time()),
+                })
                 update_storage = True
 
-            # Insert entities into vector storage with consistent format
-            data_for_vdb = {
+            # Batch insert missing nodes
+            if missing_nodes:
+                if hasattr(self.chunk_entity_relation_graph, "upsert_nodes_batch"):
+                    await self.chunk_entity_relation_graph.upsert_nodes_batch(missing_nodes)
+                else:
+                    for node_id, node_data in missing_nodes:
+                        await self.chunk_entity_relation_graph.upsert_node(
+                            node_id, node_data=node_data
+                        )
+
+            # Batch insert edges (1 await instead of M serial awaits)
+            if edge_list:
+                if hasattr(self.chunk_entity_relation_graph, "upsert_edges_batch"):
+                    await self.chunk_entity_relation_graph.upsert_edges_batch(edge_list)
+                else:
+                    for src, tgt, edata in edge_list:
+                        await self.chunk_entity_relation_graph.upsert_edge(
+                            src, tgt, edge_data=edata
+                        )
+
+            # Insert entities and relationships into vector storage (parallel)
+            data_for_entities_vdb = {
                 compute_mdhash_id(dp["entity_name"], prefix="ent-"): {
                     "content": dp["entity_name"] + "\n" + dp["description"],
                     "entity_name": dp["entity_name"],
@@ -2522,10 +2555,8 @@ class LightRAG:
                 }
                 for dp in all_entities_data
             }
-            await self.entities_vdb.upsert(data_for_vdb)
 
-            # Insert relationships into vector storage with consistent format
-            data_for_vdb = {
+            data_for_rels_vdb = {
                 compute_mdhash_id(dp["src_id"] + dp["tgt_id"], prefix="rel-"): {
                     "src_id": dp["src_id"],
                     "tgt_id": dp["tgt_id"],
@@ -2538,7 +2569,12 @@ class LightRAG:
                 }
                 for dp in all_relationships_data
             }
-            await self.relationships_vdb.upsert(data_for_vdb)
+
+            # Parallel VDB upserts (was serial in original)
+            await asyncio.gather(
+                self.entities_vdb.upsert(data_for_entities_vdb),
+                self.relationships_vdb.upsert(data_for_rels_vdb),
+            )
 
         except Exception as e:
             logger.error(f"Error in ainsert_custom_kg: {e}")


### PR DESCRIPTION
## Summary

Optimize `ainsert_custom_kg()` for large-scale knowledge graph imports by replacing serial per-entity/per-relationship async awaits with batch graph operations.

### Problem

When importing large custom KGs (e.g., 342K NVD CVE records → ~1M entities + ~2M relationships), `ainsert_custom_kg` generates **~64K serial async awaits** per batch of 2000 records. The accumulated async event loop overhead causes severe performance degradation as the graph grows, with insert times doubling every 6-8K records.

See #2909 for detailed benchmarks.

### Changes

**`lightrag/kg/networkx_impl.py`:**
- Add `upsert_nodes_batch(nodes)` — batch insert/update multiple nodes in 1 await
- Add `has_nodes_batch(node_ids)` — batch existence check in 1 await
- Add `upsert_edges_batch(edges)` — batch insert/update multiple edges in 1 await

**`lightrag/lightrag.py`:**
- Rewrite entity insertion: collect all nodes → single `upsert_nodes_batch()` call
- Rewrite relationship insertion: batch `has_nodes_batch()` for existence check → batch `upsert_nodes_batch()` for missing nodes → batch `upsert_edges_batch()` for all edges
- Parallelize entities and relationships VDB upserts via `asyncio.gather()`

### Backward Compatibility

All batch operations check `hasattr()` before use and fall back to the original serial operations if the storage backend does not implement the new batch methods. This means:
- NetworkX backend: uses batch methods (optimized)
- Other backends (Neo4j, PostgreSQL, etc.): falls back to serial (unchanged behavior)

Backend maintainers can add batch methods at their own pace.

### Before/After

For a batch of 2000 input records (~10K entities, ~18K relationships):

| Operation | Before | After |
|-----------|--------|-------|
| Entity graph inserts | N serial awaits | 1 batch await |
| Relationship node checks | 2M serial awaits | 1 batch await |
| Relationship edge inserts | M serial awaits | 1 batch await |
| VDB upserts | 2 serial | 2 parallel |
| **Total awaits** | **~64K** | **~6** |
