### PR TITLE
fix: handle OpenAI length finish reason fallback

### DIFF
--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -15,6 +15,7 @@ from openai import (
     APIConnectionError,
     RateLimitError,
     APITimeoutError,
+    LengthFinishReasonError,
 )
 from tenacity import (
     retry,
@@ -334,18 +335,43 @@ async def openai_complete_if_cache(
 
     try:
         # Don't use async with context manager, use client directly
-        # Use parse() for Pydantic schema-based structured output (e.g., keyword_extraction)
-        # Use create() for simple JSON mode {"type": "json_object"} (e.g., entity_extraction)
+        # Use parse() for structured output whenever available so truncated responses can
+        # still surface raw content via LengthFinishReasonError.completion.
+        # For JSON object mode we keep a fallback to create() for broader compatibility
+        # with OpenAI-compatible providers that may not implement parse().
         response_format = kwargs.get("response_format")
         use_parse = (
             "response_format" in kwargs
             and response_format is not None
-            and not isinstance(response_format, dict)
+            and (entity_extraction or not isinstance(response_format, dict))
         )
         if use_parse:
-            response = await openai_async_client.chat.completions.parse(
-                model=api_model, messages=messages, **kwargs
-            )
+            try:
+                response = await openai_async_client.chat.completions.parse(
+                    model=api_model, messages=messages, **kwargs
+                )
+            except (AttributeError, TypeError) as e:
+                if not entity_extraction:
+                    raise
+                logger.debug(
+                    "OpenAI-compatible client does not support parse() for JSON mode; "
+                    "falling back to create(). Model: %s, error: %s",
+                    model,
+                    e,
+                )
+                response = await openai_async_client.chat.completions.create(
+                    model=api_model, messages=messages, **kwargs
+                )
+            except LengthFinishReasonError as e:
+                response = getattr(e, "completion", None)
+                if response is None:
+                    raise
+                logger.warning(
+                    "Structured OpenAI-compatible response hit the length limit; "
+                    "falling back to raw content. Model: %s, max_completion_tokens: %s",
+                    model,
+                    kwargs.get("max_completion_tokens") or kwargs.get("max_tokens"),
+                )
         else:
             response = await openai_async_client.chat.completions.create(
                 model=api_model, messages=messages, **kwargs

--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -185,6 +185,7 @@ def create_openai_async_client(
         return AsyncOpenAI(**merged_configs)
 
 
+# TODO LengthFinishReasonError should not persist into LLM cache
 @retry(
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=4, max=10),
@@ -217,6 +218,13 @@ async def openai_complete_if_cache(
     This function supports automatic integration of reasoning content from models that provide
     Chain of Thought capabilities. The reasoning content is seamlessly integrated into the response
     using <think>...</think> tags.
+
+    Note on truncated structured output: when the OpenAI SDK raises
+    `LengthFinishReasonError`, callers may still receive partial raw JSON from
+    `completion.choices[0].message.content`. That payload should be treated as
+    best-effort recovery only. If the JSON was truncated or repaired after
+    truncation, it is safer not to persist it into the LLM cache because later
+    runs with a higher token budget could otherwise keep reusing incomplete data.
 
     Note on `reasoning_content`: This feature relies on a Deepseek Style `reasoning_content`
     in the API response, which may be provided by OpenAI-compatible endpoints that support

--- a/tests/test_openai_length_finish_reason.py
+++ b/tests/test_openai_length_finish_reason.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from openai import LengthFinishReasonError
+
+from lightrag.llm.openai import openai_complete_if_cache
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_length_finish_reason_falls_back_to_raw_content():
+    raw_json = (
+        '{"entities":[{"entity_name":"Alice","entity_type":"Person",'
+        '"entity_description":"Founder"}],"relationships":[]}'
+    )
+    completion = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="length",
+                message=SimpleNamespace(
+                    content=raw_json,
+                    parsed=None,
+                    reasoning_content="",
+                ),
+            )
+        ],
+        usage=SimpleNamespace(
+            prompt_tokens=10,
+            completion_tokens=20,
+            total_tokens=30,
+        ),
+    )
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                parse=AsyncMock(
+                    side_effect=LengthFinishReasonError(completion=completion)
+                ),
+                create=AsyncMock(),
+            )
+        ),
+        close=AsyncMock(),
+    )
+
+    with patch(
+        "lightrag.llm.openai.create_openai_async_client",
+        return_value=fake_client,
+    ):
+        result = await openai_complete_if_cache(
+            model="test-model",
+            prompt="Extract entities",
+            entity_extraction=True,
+            max_completion_tokens=128,
+        )
+
+    assert result == raw_json
+    fake_client.chat.completions.parse.assert_awaited_once()
+    fake_client.chat.completions.create.assert_not_called()
+    fake_client.close.assert_awaited_once()


### PR DESCRIPTION
## Description

Handle `LengthFinishReasonError` in the OpenAI adapter so JSON/entity extraction can fall back to raw content instead of failing immediately, while preserving compatibility with OpenAI-compatible providers that do not support `parse()` for JSON mode.

## Related Issues

n/a

## Changes Made

- catch `LengthFinishReasonError` from `chat.completions.parse()` and reuse the raw completion payload
- fall back to `chat.completions.create()` for JSON-mode entity extraction when an OpenAI-compatible client does not support `parse()`
- add an offline regression test covering the length-finish-reason fallback path

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

- Local verification: `./scripts/test.sh tests/test_openai_length_finish_reason.py -q`
- This PR targets `dev` as requested.
