### PR TITLE
fix(merge_entities): handle long descriptions, embedder failures, and storage wrappers

### DIFF
--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -1239,22 +1239,42 @@ async def _merge_entities_impl(
         }
     target_entity_data = {} if target_entity_data is None else target_entity_data
 
+    # Helper: coerce a value returned by `get_node` into a plain dict.
+    # Some graph backends (notably PostgreSQL+Apache AGE through asyncpg)
+    # return a wrapper object whose `.get()` method returns None for every
+    # key — feeding that straight into `_merge_attributes` below silently
+    # produces an empty dict because every value is filtered out as falsy,
+    # and then `upsert_node(target_entity, merged_entity_data)` overwrites
+    # the existing target's description with empty. We saw this in
+    # production: after a merge attempt aborted on a downstream embedder
+    # failure, a hub entity was left with description="" in the graph
+    # store even though the VDB row still had the old description.
+    def _coerce_node(obj):
+        if obj is None or isinstance(obj, dict):
+            return obj or {}
+        try:
+            return dict(obj)
+        except Exception:
+            try:
+                return vars(obj)
+            except Exception:
+                return {}
+
     # 1. Check if all source entities exist
     source_entities_data = {}
     for entity_name in source_entities:
         node_exists = await chunk_entity_relation_graph.has_node(entity_name)
         if not node_exists:
             raise ValueError(f"Source entity '{entity_name}' does not exist")
-        node_data = await chunk_entity_relation_graph.get_node(entity_name)
-        source_entities_data[entity_name] = node_data
+        raw_node_data = await chunk_entity_relation_graph.get_node(entity_name)
+        source_entities_data[entity_name] = _coerce_node(raw_node_data)
 
     # 2. Check if target entity exists and get its data if it does
     target_exists = await chunk_entity_relation_graph.has_node(target_entity)
     existing_target_entity_data = {}
     if target_exists:
-        existing_target_entity_data = await chunk_entity_relation_graph.get_node(
-            target_entity
-        )
+        raw_target_data = await chunk_entity_relation_graph.get_node(target_entity)
+        existing_target_entity_data = _coerce_node(raw_target_data)
 
     # 3. Merge entity data
     merged_entity_data = _merge_attributes(
@@ -1422,8 +1442,27 @@ async def _merge_entities_impl(
         source_id = edge_data.get("source_id", "")
         weight = float(edge_data.get("weight", 1.0))
 
+        # Truncate description for relation embedder content to fit the
+        # embedder's context window. When merging a hub entity with many
+        # neighbours, individual relations may already have descriptions
+        # accumulated from prior merges that exceed the embedder's context
+        # (e.g. Ollama nomic-embed-text default 2048 tokens), and the
+        # whole merge then aborts on a single relation embedding.
+        # The full description is preserved in `edge_data["description"]`
+        # and in the VDB row metadata below — only the embedded `content`
+        # is shortened.
+        description_for_embed = (
+            description[:1500] + "..." if len(description) > 1500 else description
+        )
+        keywords_for_embed = (
+            keywords[:200] + "..." if len(keywords) > 200 else keywords
+        )
+
         # Use normalized order for content and relation ID
-        content = f"{keywords}\t{normalized_src}\n{normalized_tgt}\n{description}"
+        content = (
+            f"{keywords_for_embed}\t{normalized_src}\n{normalized_tgt}\n"
+            f"{description_for_embed}"
+        )
         relation_id = compute_mdhash_id(normalized_src + normalized_tgt, prefix="rel-")
 
         relation_data_for_vdb = {
@@ -1438,10 +1477,23 @@ async def _merge_entities_impl(
                 "file_path": edge_data.get("file_path", ""),
             }
         }
-        await relationships_vdb.upsert(relation_data_for_vdb)
-        logger.debug(
-            f"Entity Merge: updating vdb `{normalized_src}`~`{normalized_tgt}`"
-        )
+        # Wrap individual relation VDB upsert in try/except so that one bad
+        # embedding (transient embedder error, residual context-length issue
+        # on a single relation) does not abort the whole merge and leave
+        # the graph in a half-migrated state. We log the failure and keep
+        # going — relation chunk tracking is still updated below, so the
+        # graph stays consistent even if a single VDB upsert is missed.
+        try:
+            await relationships_vdb.upsert(relation_data_for_vdb)
+            logger.debug(
+                f"Entity Merge: updating vdb `{normalized_src}`~`{normalized_tgt}`"
+            )
+        except Exception as _rel_upsert_exc:
+            logger.warning(
+                f"Entity Merge: skipping vdb upsert for "
+                f"`{normalized_src}`~`{normalized_tgt}` due to "
+                f"{type(_rel_upsert_exc).__name__}: {_rel_upsert_exc}"
+            )
 
     logger.info(f"Entity Merge: {len(relation_updates)} relations in vdb updated")
 
@@ -1478,8 +1530,20 @@ async def _merge_entities_impl(
             "file_path": merged_entity_data.get("file_path", ""),
         }
     }
-    await entities_vdb.upsert(entity_data_for_vdb)
-    logger.info(f"Entity Merge: updating vdb `{target_entity}`")
+    # Protect entity vdb upsert with try/except for the same reason as the
+    # relation upsert above: a transient embedder failure should not abort
+    # the merge mid-flight and leave source entities undeleted. We log and
+    # continue: source entity delete (step 10 below) still happens, and the
+    # next merge attempt or a subsequent reprocess will recreate the VDB row.
+    try:
+        await entities_vdb.upsert(entity_data_for_vdb)
+        logger.info(f"Entity Merge: updating vdb `{target_entity}`")
+    except Exception as _ent_upsert_exc:
+        logger.warning(
+            f"Entity Merge: skipping entity vdb upsert for "
+            f"`{target_entity}` due to {type(_ent_upsert_exc).__name__}: "
+            f"{_ent_upsert_exc}"
+        )
 
     # 9. Merge entity chunk tracking (source entities first, then target entity)
     if entity_chunks_storage is not None:

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -1449,7 +1449,23 @@ async def _merge_entities_impl(
     description = merged_entity_data.get("description", "")
     source_id = merged_entity_data.get("source_id", "")
     entity_type = merged_entity_data.get("entity_type", "")
-    content = target_entity + "\n" + description
+    # When merging "central" entities the default `concatenate` strategy
+    # produces a description that is the join of every source entity's
+    # description. For graph hubs this routinely exceeds the embedder
+    # context window (e.g. Ollama nomic-embed-text defaults to 2048
+    # tokens), and the embedding call fails with HTTP 400
+    # "input length exceeds the context length", which aborts the merge.
+    #
+    # Truncate the description that is fed into the embedder to a safe
+    # length. The full, untruncated description is still preserved in
+    # `merged_entity_data["description"]` (and therefore in the graph
+    # node properties below); only the `content` string used for
+    # embedding is shortened. ~1500 characters ≈ 500 tokens, leaving
+    # comfortable headroom for the entity name on top.
+    description_for_embed = (
+        description[:1500] + "..." if len(description) > 1500 else description
+    )
+    content = target_entity + "\n" + description_for_embed
 
     entity_id = compute_mdhash_id(target_entity, prefix="ent-")
     entity_data_for_vdb = {


### PR DESCRIPTION
## Summary

This PR addresses three closely related failure modes in `_merge_entities_impl` that all surface as the same user-visible bug: a merge of a graph hub entity (one with many neighbours) goes through partway, then aborts, leaving the graph in a half-migrated state.

> **Update:** the original PR only had the description-truncate fix from the title. After deploying it I hit two more failure modes while merging hubs at scale and pushed an additional commit (8f0aea7) addressing them. Title and description rewritten to match the wider scope.

## 1. Truncate relation embed content (extends the original fix)

The original fix in this PR truncated `description` only for the **entity** vdb upsert at the end of `_merge_entities_impl`. But the loop that re-embeds each migrated relation right above (around line 1426) builds a `content` string from the relation's own description, which can also exceed the embedder's context window — relations that have been merged before may have descriptions accumulated from prior merges.

When merging Иисин (a hub with ~270 neighbours) the merge would crash mid-loop on a single relation whose accumulated description was too long:
\`\`\`
ollama._types.ResponseError: the input length exceeds the context length (status code: 400)
File \".../lightrag/utils_graph.py\", line 1441, in _merge_entities_impl
    await relationships_vdb.upsert(relation_data_for_vdb)
\`\`\`

This commit applies the same truncate (1500 chars for description, 200 for keywords) to the embedded `content` for each relation. The full description and full keywords are still stored in the VDB row metadata; only the string fed to the embedder is shortened.

## 2. Wrap entity and relation embed calls in try/except

Even with the truncate, embedders can fail for other transient reasons (network blip, model context drift, an unusually pathological character sequence). Without the try/except, **one** failed embedding aborts the **whole** merge, leaving the graph in a partially-migrated state where the target has been updated but the source entities have not been deleted (because we never reach the delete loop further down).

Wrap the entity vdb upsert and the per-relation vdb upsert in try/except. We log a warning and keep going. Relation chunk tracking is already updated separately above the upsert, so the graph stays consistent even if a single VDB row is missed; the next merge attempt or a subsequent reprocess will fix it.

## 3. Coerce raw node_data through dict() before _merge_attributes

This is the most subtle of the three. Some graph backends (notably PostgreSQL + Apache AGE through asyncpg) return a wrapper object from `get_node` whose `.get()` method returns `None` for every key — the attribute access protocol is implemented but `dict.get` semantics are not. When we feed that wrapper straight into `_merge_attributes` below:

\`\`\`python
values = [data.get(key) for data in data_list if data.get(key)]
if not values:
    continue  # ← key is dropped!
\`\`\`

…every value comes back falsy, the loop drops every key, and `merged_entity_data` ends up as an empty dict. Then on the line `await chunk_entity_relation_graph.upsert_node(target_entity, merged_entity_data)` we **overwrite** the existing target's description with empty.

We hit this in production: after a merge attempt aborted on a downstream embedder failure (#2 above), a hub entity was left with `description=\"\"` in the graph store while the VDB row still had the old 2.9KB description. We had to write a one-shot recovery script that read the VDB content back and called `edit_entity` to restore the graph node. The fix here prevents the regression entirely: coerce the wrapper into a plain dict before `_merge_attributes` sees it.

## Verification

Tested against LightRAG v1.4.13 with PGGraphStorage (Apache AGE 1.5.0) and Ollama nomic-embed-text. Smoke merges before and after this commit:

- `Vault Refs ← Vault Ref` (small, 2 sources): worked before, still works.
- `OpenClaw ← Openclaw` (medium, 53 relations): worked before, still works.
- `Иисин ← Iisin/main` (hub, 271 relations): **previously aborted** with `the input length exceeds the context length`, **now succeeds** in ~20 minutes (slow only because of the embedder rebuild for that many edges), with no errors in the server log.

After the merge, `Иисин` graph node still has the full description and all the relations are correctly migrated.

## Notes

- One-file change. Two commits in this PR — happy to squash if maintainers prefer.
- All three sub-fixes are in `_merge_entities_impl`. They are tightly coupled (the embedder failures and the silent description nuking are two halves of the same incident) and easier to review together than as three separate PRs.
- No public API or schema changes.
- Independent of #2915 (`vars()` TypeError on storage wrapper) — those are completely different code paths and either PR can be merged first.