### PR TITLE
fix(api): add missing metadata field in /query/data error response

### DIFF
--- a/lightrag/api/routers/query_routes.py
+++ b/lightrag/api/routers/query_routes.py
@@ -1151,6 +1151,7 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
                     status="failure",
                     message="Invalid response type",
                     data={},
+                    metadata={},
                 )
         except Exception as e:
             logger.error(f"Error processing data query: {str(e)}", exc_info=True)


### PR DESCRIPTION
## Description

The `/query/data` endpoint has a fallback branch that constructs a `QueryDataResponse` without the required `metadata` field. Since `QueryDataResponse` is a Pydantic model with `metadata` as a non-optional field, this raises a `ValidationError` instead of returning the intended error response — turning a graceful fallback into a 500.

## Related Issues

Found via code review — the error fallback at `query_routes.py:1150` is the only `QueryDataResponse` construction that omits `metadata`. All sibling paths (the happy path at line 1147, and the equivalent returns in `lightrag.py`) include it.

## Changes Made

Added the missing `metadata={}` to the fallback `QueryDataResponse` constructor (1 line).

**Before:** Pydantic raises `ValidationError: 1 validation error for QueryDataResponse — metadata: Field required`
**After:** Returns a proper `{"status": "failure", "message": "Invalid response type", "data": {}, "metadata": {}}` response.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

Reproduction:

```python
from pydantic import BaseModel, Field
from typing import Any, Dict

class QueryDataResponse(BaseModel):
    status: str = Field(description="Query execution status")
    message: str = Field(description="Status message")
    data: Dict[str, Any] = Field(description="Query result data")
    metadata: Dict[str, Any] = Field(description="Query metadata")

# Bug: missing metadata raises ValidationError
QueryDataResponse(status="failure", message="Invalid response type", data={})
# pydantic.ValidationError: 1 validation error for QueryDataResponse
# metadata
#   Field required [type=missing, ...]
```