### PR TITLE
feat(setup): support Atlas Local for Mongo vector storage

### DIFF
--- a/docs/InteractiveSetup.md
+++ b/docs/InteractiveSetup.md
@@ -144,7 +144,10 @@ make env-storage
 
 **Important rule**
 
-- If you choose `MongoVectorDBStorage` for vector storage, the wizard does not offer the bundled local Docker MongoDB service. You must provide a MongoDB deployment that supports Atlas Search / Vector Search.
+- `MongoVectorDBStorage` requires Atlas Search / Vector Search support.
+- If you choose the wizard-managed Docker MongoDB service, the wizard now provisions MongoDB Atlas Local, so `MongoVectorDBStorage` can run against the local Docker deployment. The generated host-side `MONGO_URI` uses `?directConnection=true`.
+- If you do not use the wizard-managed Docker MongoDB service, provide an external Atlas-capable MongoDB endpoint for `MONGO_URI`, such as a `mongodb+srv://` Atlas cluster URI or an Atlas Local `mongodb://...?...directConnection=true` URI.
+- For external `mongodb://...?...directConnection=true` URIs, the wizard can only validate the URI format. It cannot determine statically whether the target deployment actually provides Atlas Search / Vector Search support.
 
 **What gets written**
 
@@ -245,6 +248,8 @@ In practice, this means:
 The wizard creates or updates `docker-compose.final.yml` only when you choose wizard-managed Docker services or when an existing wizard-generated compose setup needs to stay aligned with new server settings.
 
 When one of the setup flows is about to replace or remove an existing generated compose file, it automatically creates a timestamped backup first.
+
+For MongoDB-backed storage, the wizard-managed Docker path uses MongoDB Atlas Local rather than MongoDB Community Edition so local Atlas Search / Vector Search workflows are available.
 
 Use this file when starting the generated Docker stack:
 

--- a/scripts/setup/lib/file_ops.sh
+++ b/scripts/setup/lib/file_ops.sh
@@ -441,7 +441,7 @@ _managed_volume_root_name() {
     neo4j_data)
       printf 'neo4j'
       ;;
-    mongo_data)
+    mongo_data|mongo_config_data)
       printf 'mongodb'
       ;;
     redis_data)

--- a/scripts/setup/lib/file_ops.sh
+++ b/scripts/setup/lib/file_ops.sh
@@ -441,7 +441,7 @@ _managed_volume_root_name() {
     neo4j_data)
       printf 'neo4j'
       ;;
-    mongo_data|mongo_config_data)
+    mongo_data|mongo_config_data|mongo_mongot_data)
       printf 'mongodb'
       ;;
     redis_data)

--- a/scripts/setup/lib/validation.sh
+++ b/scripts/setup/lib/validation.sh
@@ -104,7 +104,7 @@ check_storage_compatibility() {
   local warnings=()
 
   if [[ "$vector_storage" == "MongoVectorDBStorage" ]]; then
-    warnings+=("MongoDB vector storage requires an Atlas-capable deployment with Atlas Search / Vector Search support.")
+    warnings+=("MongoDB vector storage requires Atlas Search / Vector Search support, such as an Atlas cluster or Atlas Local deployment.")
   fi
 
   if [[ "$graph_storage" == "Neo4JStorage" && "$kv_storage" == "JsonKVStorage" ]]; then
@@ -335,13 +335,6 @@ validate_mongo_vector_storage_config() {
     return 0
   fi
 
-  if [[ "$mongo_deployment" == "docker" ]]; then
-    format_error \
-      "MongoVectorDBStorage cannot use the local Docker MongoDB service managed by this setup wizard." \
-      "That service is MongoDB Community Edition without Atlas Search / Vector Search support. Use an Atlas-capable MongoDB endpoint instead."
-    return 1
-  fi
-
   if ! validate_uri "$mongo_uri" mongodb; then
     format_error \
       "MongoVectorDBStorage requires a valid MongoDB URI." \
@@ -349,14 +342,35 @@ validate_mongo_vector_storage_config() {
     return 1
   fi
 
-  if [[ ! "$mongo_uri" =~ ^mongodb\+srv:// ]]; then
+  if [[ "$mongo_deployment" == "docker" ]]; then
+    if [[ ! "$mongo_uri" =~ ^mongodb://([^/?#]+@)?(mongodb|localhost|127\.0\.0\.1|0\.0\.0\.0):27017([/?#].*)?$ ]] || ! _mongo_uri_has_direct_connection_true "$mongo_uri"; then
+      format_error \
+        "MongoVectorDBStorage requires the bundled Atlas Local endpoint when LIGHTRAG_SETUP_MONGODB_DEPLOYMENT=docker." \
+        "Set MONGO_URI to the wizard-managed local MongoDB URI, or remove the docker deployment marker and use a mongodb+srv:// Atlas cluster URI."
+      return 1
+    fi
+    return 0
+  fi
+
+  if [[ "$mongo_uri" =~ ^mongodb\+srv:// ]]; then
+    return 0
+  fi
+
+  if ! _mongo_uri_has_direct_connection_true "$mongo_uri"; then
     format_error \
-      "MongoVectorDBStorage requires a MongoDB Atlas URI." \
-      "Set MONGO_URI to a mongodb+srv:// endpoint backed by Atlas Search / Vector Search."
+      "MongoVectorDBStorage requires an Atlas-capable MongoDB URI." \
+      "Use a mongodb+srv:// Atlas cluster URI, a mongodb:// Atlas Local URI with ?directConnection=true, or rerun the wizard with the bundled Atlas Local Docker MongoDB service."
     return 1
   fi
 
   return 0
+}
+
+_mongo_uri_has_direct_connection_true() {
+  local uri="$1"
+  local direct_connection_pattern='[?&]directConnection=true([&#]|$)'
+
+  [[ "$uri" =~ ^mongodb:// ]] && [[ "$uri" =~ $direct_connection_pattern ]]
 }
 
 validate_auth_accounts_format() {

--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -228,11 +228,73 @@ normalize_loopback_uri_for_compose() {
   printf '%s' "$uri"
 }
 
-normalize_mongodb_uri_for_local_service() {
+ensure_mongodb_direct_connection_suffix() {
+  local suffix="${1:-}"
+  local path query fragment filtered_query=""
+  local part
+  local -a query_parts=()
+
+  if [[ "$suffix" == *"#"* ]]; then
+    fragment="#${suffix#*#}"
+    suffix="${suffix%%#*}"
+  else
+    fragment=""
+  fi
+
+  if [[ "$suffix" == *"?"* ]]; then
+    path="${suffix%%\?*}"
+    query="${suffix#*\?}"
+  else
+    path="$suffix"
+    query=""
+  fi
+
+  if [[ -z "$path" ]]; then
+    path="/"
+  fi
+
+  if [[ -n "$query" ]]; then
+    IFS='&' read -r -a query_parts <<< "$query"
+    for part in "${query_parts[@]}"; do
+      if [[ -z "$part" || "$part" == directConnection=* ]]; then
+        continue
+      fi
+      if [[ -n "$filtered_query" ]]; then
+        filtered_query="${filtered_query}&${part}"
+      else
+        filtered_query="$part"
+      fi
+    done
+  fi
+
+  if [[ -n "$filtered_query" ]]; then
+    printf '%s?%s&directConnection=true%s' "$path" "$filtered_query" "$fragment"
+  else
+    printf '%s?directConnection=true%s' "$path" "$fragment"
+  fi
+}
+
+mongodb_uri_has_direct_connection_true() {
+  local uri="$1"
+  local direct_connection_pattern='[?&]directConnection=true([&#]|$)'
+
+  [[ "$uri" =~ ^mongodb:// ]] && [[ "$uri" =~ $direct_connection_pattern ]]
+}
+
+is_wizard_managed_local_mongodb_uri() {
   local uri="$1"
 
+  [[ "$uri" =~ ^mongodb://([^/?#]+@)?(mongodb|localhost|127\.0\.0\.1|0\.0\.0\.0):27017([/?#].*)?$ ]] && \
+    mongodb_uri_has_direct_connection_true "$uri"
+}
+
+normalize_mongodb_uri_for_local_service() {
+  local uri="$1"
+  local suffix
+
   if [[ "$uri" =~ ^mongodb://([^/?#]+@)?(mongodb|localhost|127\.0\.0\.1|0\.0\.0\.0)(:[0-9]+)?([/?#].*)?$ ]]; then
-    printf 'mongodb://localhost:27017%s' "${BASH_REMATCH[4]:-/}"
+    suffix="$(ensure_mongodb_direct_connection_suffix "${BASH_REMATCH[4]:-/}")"
+    printf 'mongodb://localhost:27017%s' "$suffix"
     return 0
   fi
 
@@ -455,7 +517,7 @@ set_managed_service_compose_overrides() {
       ;;
     mongodb)
       if [[ -z "${COMPOSE_ENV_OVERRIDES[MONGO_URI]+set}" ]]; then
-        set_compose_override "MONGO_URI" "mongodb://mongodb:27017/"
+        set_compose_override "MONGO_URI" "mongodb://mongodb:27017/?directConnection=true"
       fi
       ;;
     redis)
@@ -793,6 +855,66 @@ existing_managed_root_service_present() {
   local root_service="$1"
 
   [[ -n "${EXISTING_MANAGED_ROOT_SERVICE_SET[$root_service]+set}" ]]
+}
+
+compose_service_block_contains_literal() {
+  local compose_file="$1"
+  local service_name="$2"
+  local literal="$3"
+
+  if [[ -z "$compose_file" || ! -f "$compose_file" ]]; then
+    return 1
+  fi
+
+  awk -v header="  ${service_name}:" -v literal="$literal" '
+    $0 == header { in_service = 1; next }
+    in_service && $0 ~ /^  [^[:space:]]/ { exit found ? 0 : 1 }
+    in_service && index($0, literal) { found = 1; exit 0 }
+    END { exit found ? 0 : 1 }
+  ' "$compose_file"
+}
+
+mongodb_service_requires_atlas_local_rewrite() {
+  local compose_file="${1:-}"
+
+  if [[ -z "$compose_file" ]]; then
+    return 1
+  fi
+
+  if [[ "${ENV_VALUES[LIGHTRAG_VECTOR_STORAGE]:-}" != "MongoVectorDBStorage" ]]; then
+    return 1
+  fi
+
+  if [[ "${ENV_VALUES[LIGHTRAG_SETUP_MONGODB_DEPLOYMENT]:-}" != "docker" ]]; then
+    return 1
+  fi
+
+  if [[ -z "${DOCKER_SERVICE_SET[mongodb]+set}" ]] || \
+    ! existing_managed_root_service_present "mongodb"; then
+    return 1
+  fi
+
+  if ! compose_service_block_contains_literal "$compose_file" "mongodb" "image: mongodb/mongodb-atlas-local:"; then
+    return 0
+  fi
+
+  if ! compose_service_block_contains_literal "$compose_file" "mongodb" "mongo_config_data:/data/configdb"; then
+    return 0
+  fi
+
+  return 1
+}
+
+configure_mongodb_compose_migration_rewrite() {
+  local existing_compose="${1:-}"
+
+  if [[ "$FORCE_REWRITE_COMPOSE" == "yes" ]]; then
+    return 0
+  fi
+
+  if mongodb_service_requires_atlas_local_rewrite "$existing_compose"; then
+    mark_compose_service_for_rewrite "mongodb"
+  fi
 }
 
 env_value_changed_from_original() {
@@ -1247,28 +1369,29 @@ collect_mongodb_config() {
     vector_search_required="yes"
   fi
 
-  if [[ "$vector_search_required" == "yes" ]]; then
-    log_warn "MongoVectorDBStorage cannot use the local Docker MongoDB service from this setup wizard."
-    log_warn "Reason: the bundled local Docker MongoDB service is MongoDB Community Edition, but MongoVectorDBStorage requires Atlas Search / Vector Search support."
-    log_warn "Provide a MongoDB endpoint that supports Atlas Search / Vector Search, such as MongoDB Atlas or Atlas local."
-    uri="${ENV_VALUES[MONGO_URI]:-mongodb+srv://cluster.example.mongodb.net/}"
+  if [[ "$default_docker" == "yes" ]]; then
+    if confirm_default_yes "Run MongoDB locally via Docker?"; then
+      use_docker="yes"
+    fi
   else
-    if [[ "$default_docker" == "yes" ]]; then
-      if confirm_default_yes "Run MongoDB locally via Docker?"; then
-        use_docker="yes"
-      fi
-    else
-      if confirm_default_no "Run MongoDB locally via Docker?"; then
-        use_docker="yes"
-      fi
+    if confirm_default_no "Run MongoDB locally via Docker?"; then
+      use_docker="yes"
     fi
+  fi
 
-    if [[ "$use_docker" == "yes" ]]; then
-      add_docker_service "mongodb"
-      uri="$(prefer_local_service_uri "${ENV_VALUES[MONGO_URI]:-}" "mongodb://localhost:27017/" "mongodb" "localhost" "127.0.0.1" "0.0.0.0")"
-    else
-      uri="${ENV_VALUES[MONGO_URI]:-mongodb://localhost:27017/}"
+  if [[ "$use_docker" == "yes" ]]; then
+    if [[ "$vector_search_required" == "yes" ]]; then
+      log_info "Docker MongoDB uses Atlas Local, so MongoVectorDBStorage can use Atlas Search / Vector Search locally."
     fi
+    add_docker_service "mongodb"
+    uri="$(prefer_local_service_uri "${ENV_VALUES[MONGO_URI]:-}" "mongodb://localhost:27017/?directConnection=true" "mongodb" "localhost" "127.0.0.1" "0.0.0.0")"
+  elif [[ "$vector_search_required" == "yes" ]]; then
+    uri="${ENV_VALUES[MONGO_URI]:-}"
+    if [[ -z "$uri" ]] || is_wizard_managed_local_mongodb_uri "$uri"; then
+      uri="mongodb+srv://cluster.example.mongodb.net/"
+    fi
+  else
+    uri="${ENV_VALUES[MONGO_URI]:-mongodb://localhost:27017/}"
   fi
 
   if [[ "$vector_search_required" == "yes" ]]; then
@@ -1285,7 +1408,7 @@ collect_mongodb_config() {
   ENV_VALUES["MONGO_URI"]="$uri"
   ENV_VALUES["MONGO_DATABASE"]="$database"
   if [[ "$use_docker" == "yes" ]]; then
-    set_compose_override "MONGO_URI" "mongodb://mongodb:27017/"
+    set_compose_override "MONGO_URI" "mongodb://mongodb:27017/?directConnection=true"
   else
     set_compose_override "MONGO_URI" ""
   fi
@@ -2351,6 +2474,13 @@ finalize_base_setup() {
     return 1
   fi
 
+  if ! validate_mongo_vector_storage_config \
+    "${ENV_VALUES[LIGHTRAG_VECTOR_STORAGE]:-}" \
+    "${ENV_VALUES[MONGO_URI]:-}" \
+    "${ENV_VALUES[LIGHTRAG_SETUP_MONGODB_DEPLOYMENT]:-}"; then
+    return 1
+  fi
+
   show_summary
 
   if ! confirm_required_yes_no "${COLOR_YELLOW}Ready to proceed and write .env${COLOR_RESET}"; then
@@ -2362,6 +2492,7 @@ finalize_base_setup() {
   compose_file="${REPO_ROOT}/docker-compose.final.yml"
   record_existing_managed_root_services "$existing_compose"
   restore_storage_docker_services_from_env
+  configure_mongodb_compose_migration_rewrite "$existing_compose"
 
   configure_base_compose_rewrites
 
@@ -2507,6 +2638,7 @@ finalize_storage_setup() {
   record_existing_managed_root_services "$existing_compose"
   restore_vllm_docker_services_from_env
   configure_storage_compose_rewrites
+  configure_mongodb_compose_migration_rewrite "$existing_compose"
   resolve_compose_output_action \
     "$existing_compose" \
     compose_action \
@@ -2607,6 +2739,13 @@ finalize_server_setup() {
     return 1
   fi
 
+  if ! validate_mongo_vector_storage_config \
+    "${ENV_VALUES[LIGHTRAG_VECTOR_STORAGE]:-}" \
+    "${ENV_VALUES[MONGO_URI]:-}" \
+    "${ENV_VALUES[LIGHTRAG_SETUP_MONGODB_DEPLOYMENT]:-}"; then
+    return 1
+  fi
+
   show_summary
 
   if ! confirm_required_yes_no "${COLOR_YELLOW}Ready to proceed and write .env${COLOR_RESET}"; then
@@ -2619,6 +2758,7 @@ finalize_server_setup() {
   record_existing_managed_root_services "$existing_compose"
   restore_storage_docker_services_from_env
   restore_vllm_docker_services_from_env
+  configure_mongodb_compose_migration_rewrite "$existing_compose"
   resolve_compose_output_action \
     "$existing_compose" \
     compose_action \

--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -902,6 +902,10 @@ mongodb_service_requires_atlas_local_rewrite() {
     return 0
   fi
 
+  if ! compose_service_block_contains_literal "$compose_file" "mongodb" "mongo_mongot_data:/data/mongot"; then
+    return 0
+  fi
+
   return 1
 }
 

--- a/scripts/setup/templates/mongodb.yml
+++ b/scripts/setup/templates/mongodb.yml
@@ -6,5 +6,6 @@
     volumes:
       - mongo_data:/data/db
       - mongo_config_data:/data/configdb
+      - mongo_mongot_data:/data/mongot
     stop_grace_period: 30s
     restart: unless-stopped

--- a/scripts/setup/templates/mongodb.yml
+++ b/scripts/setup/templates/mongodb.yml
@@ -1,16 +1,10 @@
   mongodb:
-    image: mongo:8.2.4
+    hostname: mongodb
+    image: mongodb/mongodb-atlas-local:8
     # ports:
     #   - "27017:27017"
     volumes:
       - mongo_data:/data/db
-    healthcheck:
-      test:
-        - CMD-SHELL
-        - 'PORT_HEX="$(printf ''%04X'' 27017)"; cat /proc/net/tcp /proc/net/tcp6 2>/dev/null | grep -q ":$${PORT_HEX} "'
-      interval: 5s
-      timeout: 3s
-      retries: 20
-      start_period: 10s
+      - mongo_config_data:/data/configdb
     stop_grace_period: 30s
     restart: unless-stopped

--- a/tests/test_interactive_setup_outputs.py
+++ b/tests/test_interactive_setup_outputs.py
@@ -360,7 +360,7 @@ printf 'PROMPT_LOG=%s\\n' "$(paste -sd '|' "$PROMPT_LOG_FILE")"
             ['ENV_VALUES[MONGO_URI]="mongodb://mongo.example.com:27018/"'],
             "collect_mongodb_config yes",
             "MONGO_URI",
-            "mongodb://localhost:27017/",
+            "mongodb://localhost:27017/?directConnection=true",
         ),
         (
             ['ENV_VALUES[REDIS_URI]="redis://cache.example.com:6380/1"'],
@@ -768,7 +768,7 @@ generate_docker_compose "$REPO_ROOT/docker-compose.final.yml"
             in lightrag_block
         )
 
-    assert generated_compose.count("    healthcheck:") == 11
+    assert generated_compose.count("    healthcheck:") == 10
     assert "  milvus-etcd:" in generated_compose
     assert "  milvus-minio:" in generated_compose
     assert "      milvus-etcd:\n        condition: service_healthy" in generated_compose
@@ -3924,6 +3924,128 @@ finalize_base_setup
     assert "      milvus-minio:\n        condition: service_healthy" not in result
 
 
+def test_finalize_base_setup_migrates_mongodb_to_atlas_local_for_mongo_vector_storage(
+    tmp_path: Path,
+) -> None:
+    """Base reruns should upgrade docker-managed MongoDB to Atlas Local when Mongo vector storage needs it."""
+
+    write_text_lines(
+        tmp_path / ".env",
+        [
+            "LIGHTRAG_RUNTIME_TARGET=compose",
+            "LIGHTRAG_SETUP_MONGODB_DEPLOYMENT=docker",
+            "LIGHTRAG_KV_STORAGE=MongoKVStorage",
+            "LIGHTRAG_VECTOR_STORAGE=MongoVectorDBStorage",
+            "LIGHTRAG_GRAPH_STORAGE=MongoGraphStorage",
+            "LIGHTRAG_DOC_STATUS_STORAGE=MongoDocStatusStorage",
+            "MONGO_URI=mongodb://localhost:27017/?directConnection=true",
+            "MONGO_DATABASE=LightRAG",
+        ],
+    )
+    write_text_lines(
+        tmp_path / "env.example",
+        (REPO_ROOT / "env.example").read_text(encoding="utf-8").splitlines(),
+    )
+    write_text_lines(
+        tmp_path / "docker-compose.final.yml",
+        [
+            "services:",
+            "  lightrag:",
+            "    image: example/lightrag:test",
+            "  mongodb:",
+            "    image: mongo:8.2.4",
+            "    volumes:",
+            "      - mongo_data:/data/db",
+            "volumes:",
+            "  mongo_data:",
+        ],
+    )
+
+    run_bash(
+        f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+reset_state
+load_existing_env_if_present
+show_summary() {{ :; }}
+confirm_required_yes_no() {{ return 0; }}
+confirm_default_yes() {{ return 0; }}
+validate_sensitive_env_literals() {{ return 0; }}
+finalize_base_setup
+"""
+    )
+
+    result = (tmp_path / "docker-compose.final.yml").read_text(encoding="utf-8")
+
+    assert "image: mongodb/mongodb-atlas-local:" in result
+    assert "mongo_config_data:/data/configdb" in result
+    assert "image: mongo:8.2.4" not in result
+
+
+def test_finalize_base_setup_rejects_invalid_preserved_mongo_vector_config(
+    tmp_path: Path,
+) -> None:
+    """Base reruns should fail before writing when preserved Mongo vector config is invalid."""
+
+    write_text_lines(
+        tmp_path / ".env",
+        [
+            "LIGHTRAG_RUNTIME_TARGET=compose",
+            "LIGHTRAG_SETUP_MONGODB_DEPLOYMENT=docker",
+            "LIGHTRAG_KV_STORAGE=MongoKVStorage",
+            "LIGHTRAG_VECTOR_STORAGE=MongoVectorDBStorage",
+            "LIGHTRAG_GRAPH_STORAGE=MongoGraphStorage",
+            "LIGHTRAG_DOC_STATUS_STORAGE=MongoDocStatusStorage",
+            "MONGO_URI=mongodb://mongo.example.com:27017/?directConnection=true",
+            "MONGO_DATABASE=LightRAG",
+        ],
+    )
+    write_text_lines(
+        tmp_path / "env.example",
+        (REPO_ROOT / "env.example").read_text(encoding="utf-8").splitlines(),
+    )
+    write_text_lines(
+        tmp_path / "docker-compose.final.yml",
+        [
+            "services:",
+            "  lightrag:",
+            "    image: example/lightrag:test",
+            "  mongodb:",
+            "    image: mongo:8.2.4",
+            "    volumes:",
+            "      - mongo_data:/data/db",
+            "volumes:",
+            "  mongo_data:",
+        ],
+    )
+
+    result = run_bash_process(
+        f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+reset_state
+load_existing_env_if_present
+show_summary() {{ :; }}
+confirm_required_yes_no() {{ return 0; }}
+confirm_default_yes() {{ return 0; }}
+validate_sensitive_env_literals() {{ return 0; }}
+finalize_base_setup
+""",
+        cwd=tmp_path,
+    )
+
+    assert result.returncode != 0
+    assert (
+        "MongoVectorDBStorage requires the bundled Atlas Local endpoint"
+        in result.stderr
+    )
+    assert "image: mongo:8.2.4" in (
+        tmp_path / "docker-compose.final.yml"
+    ).read_text(encoding="utf-8")
+
+
 def test_finalize_base_setup_drops_stale_storage_services_missing_from_env_markers(
     tmp_path: Path,
 ) -> None:
@@ -5415,6 +5537,67 @@ fi
     assert values["REWRITE"] == expected_rewrite
 
 
+@pytest.mark.parametrize(
+    ("vector_storage", "deployment_marker", "expected_rewrite"),
+    [
+        ("MongoVectorDBStorage", "docker", "yes"),
+        ("NanoVectorDBStorage", "docker", "no"),
+        ("MongoVectorDBStorage", "", "no"),
+    ],
+    ids=[
+        "mongo-vector-with-docker-rewrites",
+        "non-mongo-vector-does-not-rewrite",
+        "mongo-vector-without-docker-does-not-rewrite",
+    ],
+)
+def test_configure_mongodb_compose_migration_rewrite_only_runs_for_atlas_local_vector_path(
+    tmp_path: Path,
+    vector_storage: str,
+    deployment_marker: str,
+    expected_rewrite: str,
+) -> None:
+    """Atlas Local migration should only run for docker-managed MongoDB vector storage."""
+
+    write_text_lines(
+        tmp_path / "docker-compose.final.yml",
+        [
+            "services:",
+            "  lightrag:",
+            "    image: example/lightrag:test",
+            "  mongodb:",
+            "    image: mongo:8.2.4",
+            "    volumes:",
+            "      - mongo_data:/data/db",
+            "volumes:",
+            "  mongo_data:",
+        ],
+    )
+
+    values = run_bash_lines(
+        f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+reset_state
+
+ENV_VALUES[LIGHTRAG_VECTOR_STORAGE]="{vector_storage}"
+ENV_VALUES[LIGHTRAG_SETUP_MONGODB_DEPLOYMENT]="{deployment_marker}"
+EXISTING_MANAGED_ROOT_SERVICE_SET[mongodb]=1
+DOCKER_SERVICE_SET[mongodb]=1
+
+configure_mongodb_compose_migration_rewrite "$REPO_ROOT/docker-compose.final.yml"
+
+if [[ -n "${{COMPOSE_REWRITE_SERVICE_SET[mongodb]+set}}" ]]; then
+  printf 'REWRITE=yes\\n'
+else
+  printf 'REWRITE=no\\n'
+fi
+"""
+    )
+
+    assert values["REWRITE"] == expected_rewrite
+
+
 def test_env_storage_flow_backs_up_existing_compose_before_rewrite(
     tmp_path: Path,
 ) -> None:
@@ -5553,10 +5736,10 @@ env_storage_flow
     assert "LIGHTRAG_RUNTIME_TARGET=compose" in generated_env
 
 
-def test_env_storage_flow_clears_mongodb_docker_marker_for_atlas_vector_storage(
+def test_env_storage_flow_preserves_mongodb_docker_marker_for_atlas_local_vector_storage(
     tmp_path: Path,
 ) -> None:
-    """MongoDB Atlas-only vector storage should not preserve a local Docker deployment marker."""
+    """MongoDB Atlas Local vector storage should preserve the bundled Docker deployment marker."""
 
     write_text_lines(
         tmp_path / ".env",
@@ -5600,11 +5783,8 @@ env_storage_flow
     )
 
     generated_env = (tmp_path / ".env").read_text(encoding="utf-8")
-    assert not any(
-        line.startswith("LIGHTRAG_SETUP_MONGODB_DEPLOYMENT=")
-        for line in generated_env.splitlines()
-    )
-    assert "MONGO_URI=mongodb+srv://cluster.example.mongodb.net/" in generated_env
+    assert "LIGHTRAG_SETUP_MONGODB_DEPLOYMENT=docker" in generated_env
+    assert "MONGO_URI=mongodb://localhost:27017/?directConnection=true" in generated_env
 
 
 def test_env_storage_flow_preserves_existing_compose_ssl_when_env_paths_are_stale(
@@ -6191,6 +6371,37 @@ generate_docker_compose "$REPO_ROOT/docker-compose.final.yml"
     assert "\n  source:\n" not in result
 
 
+def test_generate_docker_compose_includes_all_atlas_local_mongodb_volumes(
+    tmp_path: Path,
+) -> None:
+    """MongoDB Atlas Local should emit both data and config named volumes."""
+
+    write_text_lines(
+        tmp_path / "env.example",
+        (REPO_ROOT / "env.example").read_text(encoding="utf-8").splitlines(),
+    )
+
+    run_bash(
+        f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+reset_state
+add_docker_service mongodb
+generate_docker_compose "$REPO_ROOT/docker-compose.final.yml"
+"""
+    )
+
+    result = (tmp_path / "docker-compose.final.yml").read_text(encoding="utf-8")
+
+    assert "hostname: mongodb" in result
+    assert "image: mongodb/mongodb-atlas-local:" in result
+    assert "mongo_data:/data/db" in result
+    assert "mongo_config_data:/data/configdb" in result
+    assert "healthcheck:" not in result
+    assert "\nvolumes:\n  mongo_data:\n  mongo_config_data:\n" in result
+
+
 def test_collect_milvus_config_defaults_to_existing_database_name() -> None:
     """Milvus database prompt should preserve the documented default database."""
 
@@ -6403,9 +6614,72 @@ printf 'DOCKER_SERVICE=%s\\n' "${{DOCKER_SERVICES[0]}}"
 """
     )
 
-    assert values["MONGO_URI"] == "mongodb://localhost:27017/"
-    assert values["COMPOSE_MONGO_URI"] == "mongodb://mongodb:27017/"
+    assert values["MONGO_URI"] == "mongodb://localhost:27017/?directConnection=true"
+    assert (
+        values["COMPOSE_MONGO_URI"] == "mongodb://mongodb:27017/?directConnection=true"
+    )
     assert values["DOCKER_SERVICE"] == "mongodb"
+
+
+def test_collect_mongodb_config_resets_wizard_managed_local_uri_when_switching_off_docker() -> (
+    None
+):
+    """Switching off bundled MongoDB should not preserve the old wizard-managed local URI."""
+
+    values = run_bash_lines(
+        f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+reset_state
+
+ENV_VALUES[LIGHTRAG_VECTOR_STORAGE]="MongoVectorDBStorage"
+ENV_VALUES[MONGO_URI]="mongodb://localhost:27017/?directConnection=true"
+
+confirm_default_yes() {{ return 1; }}
+prompt_until_valid() {{ printf '%s' "$2"; }}
+prompt_with_default() {{ printf '%s' "$2"; }}
+
+collect_mongodb_config yes
+
+printf 'MONGO_URI=%s\\n' "${{ENV_VALUES[MONGO_URI]}}"
+printf 'COMPOSE_MONGO_URI=%s\\n' "${{COMPOSE_ENV_OVERRIDES[MONGO_URI]-}}"
+"""
+    )
+
+    assert values["MONGO_URI"] == "mongodb+srv://cluster.example.mongodb.net/"
+    assert values["COMPOSE_MONGO_URI"] == ""
+
+
+def test_collect_mongodb_config_preserves_external_atlas_local_uri_when_switching_off_docker() -> (
+    None
+):
+    """Switching off bundled MongoDB should keep an explicitly configured external Atlas Local URI."""
+
+    values = run_bash_lines(
+        f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+reset_state
+
+ENV_VALUES[LIGHTRAG_VECTOR_STORAGE]="MongoVectorDBStorage"
+ENV_VALUES[MONGO_URI]="mongodb://atlas-local.example.com:27017/LightRAG?replicaSet=rs0&directConnection=true"
+
+confirm_default_yes() {{ return 1; }}
+prompt_until_valid() {{ printf '%s' "$2"; }}
+prompt_with_default() {{ printf '%s' "$2"; }}
+
+collect_mongodb_config yes
+
+printf 'MONGO_URI=%s\\n' "${{ENV_VALUES[MONGO_URI]}}"
+printf 'COMPOSE_MONGO_URI=%s\\n' "${{COMPOSE_ENV_OVERRIDES[MONGO_URI]-}}"
+"""
+    )
+
+    assert (
+        values["MONGO_URI"]
+        == "mongodb://atlas-local.example.com:27017/LightRAG?replicaSet=rs0&directConnection=true"
+    )
+    assert values["COMPOSE_MONGO_URI"] == ""
 
 
 def test_collect_redis_config_local_service_normalizes_custom_host_port() -> None:
@@ -6685,6 +6959,132 @@ finalize_server_setup
 
     assert 'NEO4J_URI: "neo4j://neo4j:7687"' in result
     assert 'NEO4J_URI: "neo4j://host.docker.internal:7687"' not in result
+
+
+def test_finalize_server_setup_migrates_mongodb_to_atlas_local_for_mongo_vector_storage(
+    tmp_path: Path,
+) -> None:
+    """Server reruns should upgrade docker-managed MongoDB to Atlas Local when Mongo vector storage needs it."""
+
+    write_text_lines(
+        tmp_path / ".env",
+        [
+            "LIGHTRAG_RUNTIME_TARGET=compose",
+            "LIGHTRAG_SETUP_MONGODB_DEPLOYMENT=docker",
+            "LIGHTRAG_KV_STORAGE=MongoKVStorage",
+            "LIGHTRAG_VECTOR_STORAGE=MongoVectorDBStorage",
+            "LIGHTRAG_GRAPH_STORAGE=MongoGraphStorage",
+            "LIGHTRAG_DOC_STATUS_STORAGE=MongoDocStatusStorage",
+            "MONGO_URI=mongodb://localhost:27017/?directConnection=true",
+            "MONGO_DATABASE=LightRAG",
+            "HOST=0.0.0.0",
+            "PORT=9621",
+        ],
+    )
+    write_text_lines(
+        tmp_path / "env.example",
+        (REPO_ROOT / "env.example").read_text(encoding="utf-8").splitlines(),
+    )
+    write_text_lines(
+        tmp_path / "docker-compose.final.yml",
+        [
+            "services:",
+            "  lightrag:",
+            "    image: example/lightrag:test",
+            "  mongodb:",
+            "    image: mongo:8.2.4",
+            "    volumes:",
+            "      - mongo_data:/data/db",
+            "volumes:",
+            "  mongo_data:",
+        ],
+    )
+
+    run_bash(
+        f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+reset_state
+load_existing_env_if_present
+show_summary() {{ :; }}
+confirm_required_yes_no() {{ return 0; }}
+validate_sensitive_env_literals() {{ return 0; }}
+validate_security_config() {{ return 0; }}
+finalize_server_setup
+"""
+    )
+
+    result = (tmp_path / "docker-compose.final.yml").read_text(encoding="utf-8")
+
+    assert "image: mongodb/mongodb-atlas-local:" in result
+    assert "mongo_config_data:/data/configdb" in result
+    assert "image: mongo:8.2.4" not in result
+
+
+def test_finalize_server_setup_rejects_invalid_preserved_mongo_vector_config(
+    tmp_path: Path,
+) -> None:
+    """Server reruns should fail before writing when preserved Mongo vector config is invalid."""
+
+    write_text_lines(
+        tmp_path / ".env",
+        [
+            "LIGHTRAG_RUNTIME_TARGET=compose",
+            "LIGHTRAG_SETUP_MONGODB_DEPLOYMENT=docker",
+            "LIGHTRAG_KV_STORAGE=MongoKVStorage",
+            "LIGHTRAG_VECTOR_STORAGE=MongoVectorDBStorage",
+            "LIGHTRAG_GRAPH_STORAGE=MongoGraphStorage",
+            "LIGHTRAG_DOC_STATUS_STORAGE=MongoDocStatusStorage",
+            "MONGO_URI=mongodb://mongo.example.com:27017/?directConnection=true",
+            "MONGO_DATABASE=LightRAG",
+            "HOST=0.0.0.0",
+            "PORT=9621",
+        ],
+    )
+    write_text_lines(
+        tmp_path / "env.example",
+        (REPO_ROOT / "env.example").read_text(encoding="utf-8").splitlines(),
+    )
+    write_text_lines(
+        tmp_path / "docker-compose.final.yml",
+        [
+            "services:",
+            "  lightrag:",
+            "    image: example/lightrag:test",
+            "  mongodb:",
+            "    image: mongo:8.2.4",
+            "    volumes:",
+            "      - mongo_data:/data/db",
+            "volumes:",
+            "  mongo_data:",
+        ],
+    )
+
+    result = run_bash_process(
+        f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+reset_state
+load_existing_env_if_present
+show_summary() {{ :; }}
+confirm_required_yes_no() {{ return 0; }}
+validate_sensitive_env_literals() {{ return 0; }}
+validate_security_config() {{ return 0; }}
+finalize_server_setup
+""",
+        cwd=tmp_path,
+    )
+
+    assert result.returncode != 0
+    assert (
+        "MongoVectorDBStorage requires the bundled Atlas Local endpoint"
+        in result.stderr
+    )
+    assert "image: mongo:8.2.4" in (
+        tmp_path / "docker-compose.final.yml"
+    ).read_text(encoding="utf-8")
 
 
 def test_finalize_server_setup_drops_stale_managed_services_missing_from_env_markers(
@@ -8859,10 +9259,10 @@ fi
     assert values["REPLICAS"] == "valid"
 
 
-def test_validate_env_file_rejects_mongo_vector_storage_without_atlas_uri(
+def test_validate_env_file_rejects_mongo_vector_storage_without_atlas_capable_uri(
     tmp_path: Path,
 ) -> None:
-    """validate_env_file must reject MongoVectorDBStorage when MONGO_URI is not Atlas (mongodb+srv://)."""
+    """validate_env_file must reject MongoVectorDBStorage when the URI is not an Atlas cluster and no Atlas Local marker is set."""
 
     env_file = tmp_path / ".env"
     env_file.write_text(
@@ -8905,7 +9305,268 @@ fi
 
     values = parse_lines(result.stdout)
     assert values["VALID"] == "no"
-    assert "MongoVectorDBStorage requires a MongoDB Atlas URI" in result.stderr
+    assert "MongoVectorDBStorage requires an Atlas-capable MongoDB URI" in result.stderr
+
+
+def test_validate_env_file_allows_mongo_vector_storage_with_wizard_managed_atlas_local(
+    tmp_path: Path,
+) -> None:
+    """validate_env_file should allow MongoVectorDBStorage with the bundled Atlas Local deployment."""
+
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "LIGHTRAG_SETUP_MONGODB_DEPLOYMENT=docker",
+                "LIGHTRAG_KV_STORAGE=MongoKVStorage",
+                "LIGHTRAG_VECTOR_STORAGE=MongoVectorDBStorage",
+                "LIGHTRAG_GRAPH_STORAGE=MongoGraphStorage",
+                "LIGHTRAG_DOC_STATUS_STORAGE=MongoDocStatusStorage",
+                "MONGO_URI=mongodb://localhost:27017/?directConnection=true",
+                "MONGO_DATABASE=LightRAG",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "env.example").write_text("LLM_BINDING=openai\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            "bash",
+            "--norc",
+            "--noprofile",
+            "-c",
+            f"""
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+reset_state
+if validate_env_file; then
+  printf 'VALID=yes\\n'
+else
+  printf 'VALID=no\\n'
+fi
+""",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    values = parse_lines(result.stdout)
+    assert values["VALID"] == "yes"
+
+
+def test_validate_env_file_allows_external_atlas_local_for_mongo_vector_storage(
+    tmp_path: Path,
+) -> None:
+    """validate_env_file should allow Atlas Local URIs outside the wizard-managed docker path."""
+
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "LIGHTRAG_KV_STORAGE=MongoKVStorage",
+                "LIGHTRAG_VECTOR_STORAGE=MongoVectorDBStorage",
+                "LIGHTRAG_GRAPH_STORAGE=MongoGraphStorage",
+                "LIGHTRAG_DOC_STATUS_STORAGE=MongoDocStatusStorage",
+                "MONGO_URI=mongodb://atlas-local.example.com:27017/LightRAG?replicaSet=rs0&directConnection=true",
+                "MONGO_DATABASE=LightRAG",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "env.example").write_text("LLM_BINDING=openai\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            "bash",
+            "--norc",
+            "--noprofile",
+            "-c",
+            f"""
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+reset_state
+if validate_env_file; then
+  printf 'VALID=yes\\n'
+else
+  printf 'VALID=no\\n'
+fi
+""",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    values = parse_lines(result.stdout)
+    assert values["VALID"] == "yes"
+
+
+def test_validate_env_file_rejects_remote_mongo_uri_with_docker_marker(
+    tmp_path: Path,
+) -> None:
+    """validate_env_file should reject remote mongodb:// URIs when the docker marker is set."""
+
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "LIGHTRAG_SETUP_MONGODB_DEPLOYMENT=docker",
+                "LIGHTRAG_KV_STORAGE=MongoKVStorage",
+                "LIGHTRAG_VECTOR_STORAGE=MongoVectorDBStorage",
+                "LIGHTRAG_GRAPH_STORAGE=MongoGraphStorage",
+                "LIGHTRAG_DOC_STATUS_STORAGE=MongoDocStatusStorage",
+                "MONGO_URI=mongodb://mongo.example.com:27017/?directConnection=true",
+                "MONGO_DATABASE=LightRAG",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "env.example").write_text("LLM_BINDING=openai\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            "bash",
+            "--norc",
+            "--noprofile",
+            "-c",
+            f"""
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+reset_state
+if validate_env_file; then
+  printf 'VALID=yes\\n'
+else
+  printf 'VALID=no\\n'
+fi
+""",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    values = parse_lines(result.stdout)
+    assert values["VALID"] == "no"
+    assert (
+        "MongoVectorDBStorage requires the bundled Atlas Local endpoint"
+        in result.stderr
+    )
+
+
+def test_validate_env_file_rejects_stale_local_mongo_uri_without_direct_connection(
+    tmp_path: Path,
+) -> None:
+    """validate_env_file should reject the old local MongoDB URI format when the docker marker is set."""
+
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "LIGHTRAG_SETUP_MONGODB_DEPLOYMENT=docker",
+                "LIGHTRAG_KV_STORAGE=MongoKVStorage",
+                "LIGHTRAG_VECTOR_STORAGE=MongoVectorDBStorage",
+                "LIGHTRAG_GRAPH_STORAGE=MongoGraphStorage",
+                "LIGHTRAG_DOC_STATUS_STORAGE=MongoDocStatusStorage",
+                "MONGO_URI=mongodb://localhost:27017/",
+                "MONGO_DATABASE=LightRAG",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "env.example").write_text("LLM_BINDING=openai\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            "bash",
+            "--norc",
+            "--noprofile",
+            "-c",
+            f"""
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+reset_state
+if validate_env_file; then
+  printf 'VALID=yes\\n'
+else
+  printf 'VALID=no\\n'
+fi
+""",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    values = parse_lines(result.stdout)
+    assert values["VALID"] == "no"
+    assert (
+        "MongoVectorDBStorage requires the bundled Atlas Local endpoint"
+        in result.stderr
+    )
+
+
+def test_validate_env_file_rejects_wrong_local_mongo_port_with_docker_marker(
+    tmp_path: Path,
+) -> None:
+    """validate_env_file should reject local MongoDB URIs that do not use the managed Atlas Local port."""
+
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "LIGHTRAG_SETUP_MONGODB_DEPLOYMENT=docker",
+                "LIGHTRAG_KV_STORAGE=MongoKVStorage",
+                "LIGHTRAG_VECTOR_STORAGE=MongoVectorDBStorage",
+                "LIGHTRAG_GRAPH_STORAGE=MongoGraphStorage",
+                "LIGHTRAG_DOC_STATUS_STORAGE=MongoDocStatusStorage",
+                "MONGO_URI=mongodb://localhost:9999/?directConnection=true",
+                "MONGO_DATABASE=LightRAG",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "env.example").write_text("LLM_BINDING=openai\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            "bash",
+            "--norc",
+            "--noprofile",
+            "-c",
+            f"""
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+reset_state
+if validate_env_file; then
+  printf 'VALID=yes\\n'
+else
+  printf 'VALID=no\\n'
+fi
+""",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    values = parse_lines(result.stdout)
+    assert values["VALID"] == "no"
+    assert (
+        "MongoVectorDBStorage requires the bundled Atlas Local endpoint"
+        in result.stderr
+    )
 
 
 def test_validate_env_file_rejects_empty_opensearch_hosts(tmp_path: Path) -> None:

--- a/tests/test_interactive_setup_outputs.py
+++ b/tests/test_interactive_setup_outputs.py
@@ -3980,6 +3980,7 @@ finalize_base_setup
 
     assert "image: mongodb/mongodb-atlas-local:" in result
     assert "mongo_config_data:/data/configdb" in result
+    assert "mongo_mongot_data:/data/mongot" in result
     assert "image: mongo:8.2.4" not in result
 
 
@@ -5598,6 +5599,53 @@ fi
     assert values["REWRITE"] == expected_rewrite
 
 
+def test_configure_mongodb_compose_migration_rewrite_repairs_missing_mongot_volume(
+    tmp_path: Path,
+) -> None:
+    """Atlas Local compose rewrites should repair stale MongoDB services missing mongot persistence."""
+
+    write_text_lines(
+        tmp_path / "docker-compose.final.yml",
+        [
+            "services:",
+            "  lightrag:",
+            "    image: example/lightrag:test",
+            "  mongodb:",
+            "    image: mongodb/mongodb-atlas-local:8",
+            "    volumes:",
+            "      - mongo_data:/data/db",
+            "      - mongo_config_data:/data/configdb",
+            "volumes:",
+            "  mongo_data:",
+            "  mongo_config_data:",
+        ],
+    )
+
+    values = run_bash_lines(
+        f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+reset_state
+
+ENV_VALUES[LIGHTRAG_VECTOR_STORAGE]="MongoVectorDBStorage"
+ENV_VALUES[LIGHTRAG_SETUP_MONGODB_DEPLOYMENT]="docker"
+EXISTING_MANAGED_ROOT_SERVICE_SET[mongodb]=1
+DOCKER_SERVICE_SET[mongodb]=1
+
+configure_mongodb_compose_migration_rewrite "$REPO_ROOT/docker-compose.final.yml"
+
+if [[ -n "${{COMPOSE_REWRITE_SERVICE_SET[mongodb]+set}}" ]]; then
+  printf 'REWRITE=yes\\n'
+else
+  printf 'REWRITE=no\\n'
+fi
+"""
+    )
+
+    assert values["REWRITE"] == "yes"
+
+
 def test_env_storage_flow_backs_up_existing_compose_before_rewrite(
     tmp_path: Path,
 ) -> None:
@@ -6374,7 +6422,7 @@ generate_docker_compose "$REPO_ROOT/docker-compose.final.yml"
 def test_generate_docker_compose_includes_all_atlas_local_mongodb_volumes(
     tmp_path: Path,
 ) -> None:
-    """MongoDB Atlas Local should emit both data and config named volumes."""
+    """MongoDB Atlas Local should emit data, config, and mongot named volumes."""
 
     write_text_lines(
         tmp_path / "env.example",
@@ -6398,8 +6446,12 @@ generate_docker_compose "$REPO_ROOT/docker-compose.final.yml"
     assert "image: mongodb/mongodb-atlas-local:" in result
     assert "mongo_data:/data/db" in result
     assert "mongo_config_data:/data/configdb" in result
+    assert "mongo_mongot_data:/data/mongot" in result
     assert "healthcheck:" not in result
-    assert "\nvolumes:\n  mongo_data:\n  mongo_config_data:\n" in result
+    assert (
+        "\nvolumes:\n  mongo_data:\n  mongo_config_data:\n  mongo_mongot_data:\n"
+        in result
+    )
 
 
 def test_collect_milvus_config_defaults_to_existing_database_name() -> None:
@@ -7019,6 +7071,7 @@ finalize_server_setup
 
     assert "image: mongodb/mongodb-atlas-local:" in result
     assert "mongo_config_data:/data/configdb" in result
+    assert "mongo_mongot_data:/data/mongot" in result
     assert "image: mongo:8.2.4" not in result
 
 

--- a/tests/test_interactive_setup_outputs.py
+++ b/tests/test_interactive_setup_outputs.py
@@ -4042,9 +4042,9 @@ finalize_base_setup
         "MongoVectorDBStorage requires the bundled Atlas Local endpoint"
         in result.stderr
     )
-    assert "image: mongo:8.2.4" in (
-        tmp_path / "docker-compose.final.yml"
-    ).read_text(encoding="utf-8")
+    assert "image: mongo:8.2.4" in (tmp_path / "docker-compose.final.yml").read_text(
+        encoding="utf-8"
+    )
 
 
 def test_finalize_base_setup_drops_stale_storage_services_missing_from_env_markers(
@@ -7135,9 +7135,9 @@ finalize_server_setup
         "MongoVectorDBStorage requires the bundled Atlas Local endpoint"
         in result.stderr
     )
-    assert "image: mongo:8.2.4" in (
-        tmp_path / "docker-compose.final.yml"
-    ).read_text(encoding="utf-8")
+    assert "image: mongo:8.2.4" in (tmp_path / "docker-compose.final.yml").read_text(
+        encoding="utf-8"
+    )
 
 
 def test_finalize_server_setup_drops_stale_managed_services_missing_from_env_markers(


### PR DESCRIPTION
## Description

Enable the setup wizard to support MongoDB Atlas Local for `MongoVectorDBStorage` while keeping compose rewrites and preserved `.env` state consistent across base, storage, and server flows.

## Related Issues

n/a

## Changes Made

- switch the wizard-managed Docker MongoDB template from Community Edition to MongoDB Atlas Local and add the extra config volume
- normalize wizard-managed local MongoDB URIs to include `?directConnection=true` and update compose overrides accordingly
- allow Atlas-capable external MongoDB URIs for `MongoVectorDBStorage`, while keeping stricter validation for the wizard-managed Docker endpoint
- migrate old `mongo:8.2.4` compose services to Atlas Local only when `MongoVectorDBStorage` is configured with docker-managed MongoDB
- prevent base and server reruns from writing `.env` files that fail Mongo vector validation, and update interactive setup docs/tests for the new Atlas Local behavior

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Targeted validation run locally:
- `./scripts/test.sh tests/test_interactive_setup_outputs.py -k 'mongodb_compose_migration_rewrite or atlas_local or finalize_base_setup_migrates_mongodb or finalize_server_setup_migrates_mongodb or mongodb_config or mongo_vector_storage'`
- `./scripts/test.sh tests/test_interactive_setup_outputs.py -k 'finalize_base_setup_migrates_mongodb or finalize_server_setup_migrates_mongodb or finalize_base_setup_rejects_invalid_preserved_mongo_vector_config or finalize_server_setup_rejects_invalid_preserved_mongo_vector_config or mongo_vector_storage'`
