### PR TITLE
Fix(opensearch): ensure consistent by lazy index refresh and real-time edge lookups

### DIFF
--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -975,6 +975,8 @@ class OpenSearchGraphStorage(BaseGraphStorage):
     _nodes_index: str = field(default="", init=False)
     _edges_index: str = field(default="", init=False)
     _indices_ready: bool = field(default=False, init=False)
+    _nodes_dirty: bool = field(default=False, init=False)
+    _edges_dirty: bool = field(default=False, init=False)
     _ppl_graphlookup_available: bool = field(default=False, init=False)
 
     def __init__(self, namespace, global_config, embedding_func, workspace=None):
@@ -1000,6 +1002,8 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 self.client = await ClientManager.get_client()
             await self._create_indices_if_not_exist()
             self._indices_ready = True
+            self._nodes_dirty = False
+            self._edges_dirty = False
             await self._detect_ppl_graphlookup()
             logger.debug(
                 f"[{self.workspace}] OpenSearch Graph storage initialized: "
@@ -1021,6 +1025,34 @@ class OpenSearchGraphStorage(BaseGraphStorage):
     def _mark_indices_missing(self):
         """Mark graph indices as unavailable for subsequent read short-circuiting."""
         self._indices_ready = False
+        self._nodes_dirty = False
+        self._edges_dirty = False
+
+    async def _refresh_graph_indices_if_dirty(
+        self, *, refresh_nodes: bool = False, refresh_edges: bool = False
+    ) -> None:
+        """Refresh graph indices only when prior writes made search views stale."""
+        if not self._indices_ready:
+            return
+        if not (
+            (refresh_nodes and self._nodes_dirty)
+            or (refresh_edges and self._edges_dirty)
+        ):
+            return
+
+        try:
+            async with get_data_init_lock():
+                if refresh_nodes and self._nodes_dirty:
+                    await self.client.indices.refresh(index=self._nodes_index)
+                    self._nodes_dirty = False
+                if refresh_edges and self._edges_dirty:
+                    await self.client.indices.refresh(index=self._edges_index)
+                    self._edges_dirty = False
+        except OpenSearchException as e:
+            if _is_missing_index_error(e):
+                self._mark_indices_missing()
+                return
+            raise
 
     async def _detect_ppl_graphlookup(self):
         """Detect whether PPL graphlookup command is available on this cluster."""
@@ -1145,37 +1177,25 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             return False
 
     async def has_edge(self, source_node_id: str, target_node_id: str) -> bool:
-        """Check whether an edge exists between two nodes (bidirectional)."""
+        """Check whether an edge exists between two nodes (bidirectional).
+
+        Uses mget with the two candidate edge IDs so the check is real-time
+        (translog-backed), consistent with has_node() and independent of the
+        index refresh cycle.
+        """
         if not self._indices_ready:
             return False
         try:
-            body = {
-                "query": {
-                    "bool": {
-                        "should": [
-                            {
-                                "bool": {
-                                    "must": [
-                                        {"term": {"source_node_id": source_node_id}},
-                                        {"term": {"target_node_id": target_node_id}},
-                                    ]
-                                }
-                            },
-                            {
-                                "bool": {
-                                    "must": [
-                                        {"term": {"source_node_id": target_node_id}},
-                                        {"term": {"target_node_id": source_node_id}},
-                                    ]
-                                }
-                            },
-                        ]
-                    }
-                },
-                "size": 0,
-            }
-            response = await self.client.search(index=self._edges_index, body=body)
-            return response["hits"]["total"]["value"] > 0
+            forward_id = compute_mdhash_id(
+                f"{source_node_id}-{target_node_id}", prefix="edge-"
+            )
+            reverse_id = compute_mdhash_id(
+                f"{target_node_id}-{source_node_id}", prefix="edge-"
+            )
+            response = await self.client.mget(
+                index=self._edges_index, body={"ids": [forward_id, reverse_id]}
+            )
+            return any(doc.get("found") for doc in response.get("docs", []))
         except OpenSearchException as e:
             if _is_missing_index_error(e):
                 self._mark_indices_missing()
@@ -1186,6 +1206,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
         if not self._indices_ready:
             return 0
         try:
+            await self._refresh_graph_indices_if_dirty(refresh_edges=True)
             response = await self.client.count(
                 index=self._edges_index,
                 body={
@@ -1230,41 +1251,29 @@ class OpenSearchGraphStorage(BaseGraphStorage):
     async def get_edge(
         self, source_node_id: str, target_node_id: str
     ) -> dict[str, str] | None:
-        """Get an edge between two nodes (bidirectional), or None."""
+        """Get an edge between two nodes (bidirectional), or None.
+
+        Uses mget with the two candidate edge IDs so the read is real-time
+        (translog-backed), consistent with get_node() and independent of the
+        index refresh cycle.
+        """
         if not self._indices_ready:
             return None
         try:
-            body = {
-                "query": {
-                    "bool": {
-                        "should": [
-                            {
-                                "bool": {
-                                    "must": [
-                                        {"term": {"source_node_id": source_node_id}},
-                                        {"term": {"target_node_id": target_node_id}},
-                                    ]
-                                }
-                            },
-                            {
-                                "bool": {
-                                    "must": [
-                                        {"term": {"source_node_id": target_node_id}},
-                                        {"term": {"target_node_id": source_node_id}},
-                                    ]
-                                }
-                            },
-                        ]
-                    }
-                },
-                "size": 1,
-            }
-            response = await self.client.search(index=self._edges_index, body=body)
-            hits = response["hits"]["hits"]
-            if hits:
-                doc = hits[0]["_source"]
-                doc["_id"] = hits[0]["_id"]
-                return doc
+            forward_id = compute_mdhash_id(
+                f"{source_node_id}-{target_node_id}", prefix="edge-"
+            )
+            reverse_id = compute_mdhash_id(
+                f"{target_node_id}-{source_node_id}", prefix="edge-"
+            )
+            response = await self.client.mget(
+                index=self._edges_index, body={"ids": [forward_id, reverse_id]}
+            )
+            for doc in response.get("docs", []):
+                if doc.get("found"):
+                    result = doc["_source"]
+                    result["_id"] = doc["_id"]
+                    return result
             return None
         except OpenSearchException as e:
             if _is_missing_index_error(e):
@@ -1276,6 +1285,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
         if not self._indices_ready:
             return None
         try:
+            await self._refresh_graph_indices_if_dirty(refresh_edges=True)
             query = {
                 "bool": {
                     "should": [
@@ -1355,6 +1365,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
         if not self._indices_ready:
             return {}
         try:
+            await self._refresh_graph_indices_if_dirty(refresh_edges=True)
             # Use a single query with aggregations for both source and target
             body = {
                 "size": 0,
@@ -1407,6 +1418,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
         if not self._indices_ready:
             return result
         try:
+            await self._refresh_graph_indices_if_dirty(refresh_edges=True)
             query = {
                 "bool": {
                     "should": [
@@ -1469,6 +1481,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             # No per-operation refresh: node reads use ID-based mget/exists
             # (translog, real-time). Search visibility after index_done_callback().
             await self.client.index(index=self._nodes_index, id=node_id, body=doc)
+            self._nodes_dirty = True
         except OpenSearchException as e:
             logger.error(f"[{self.workspace}] Error upserting node {node_id}: {e}")
 
@@ -1503,11 +1516,8 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             except OpenSearchException:
                 pass
 
-            # No per-operation refresh: the reverse-edge check above uses
-            # client.exists() which reads from the translog (real-time).
-            # Note: has_edge() and get_edge() use the search API, so they may
-            # not see this write until the next index_done_callback() refresh.
             await self.client.index(index=self._edges_index, id=edge_id, body=doc)
+            self._edges_dirty = True
         except OpenSearchException as e:
             logger.error(
                 f"[{self.workspace}] Error upserting edge {source_node_id}->{target_node_id}: {e}"
@@ -1538,6 +1548,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                     }
                 )
             await helpers.async_bulk(self.client, actions)
+            self._nodes_dirty = True
         except OpenSearchException as e:
             logger.error(f"[{self.workspace}] Error during batch node upsert: {e}")
 
@@ -1634,6 +1645,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                     }
                 )
             await helpers.async_bulk(self.client, actions)
+            self._edges_dirty = True
         except OpenSearchException as e:
             logger.error(f"[{self.workspace}] Error during batch edge upsert: {e}")
 
@@ -1642,12 +1654,13 @@ class OpenSearchGraphStorage(BaseGraphStorage):
     async def delete_node(self, node_id: str) -> None:
         """Delete a node and all its connected edges.
 
-        No per-operation refresh: delete_node is called from document deletion
-        pipelines that invoke index_done_callback() afterward.
-        Uses conflicts="proceed" to tolerate stale search views when prior
-        delete_by_query calls have already removed some edges.
+        Marks node and edge search views dirty so refresh happens lazily on the
+        next search/count-based graph read. Uses conflicts="proceed" to
+        tolerate already-deleted matches.
         """
         try:
+            # Refresh edge search view so delete_by_query sees all un-flushed writes.
+            await self._refresh_graph_indices_if_dirty(refresh_edges=True)
             # Delete all edges referencing this node
             body = {
                 "query": {
@@ -1660,27 +1673,33 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 }
             }
             await self.client.delete_by_query(
-                index=self._edges_index, body=body, params={"conflicts": "proceed"}
+                index=self._edges_index,
+                body=body,
+                params={"conflicts": "proceed"},
             )
             # Delete the node
             try:
                 await self.client.delete(index=self._nodes_index, id=node_id)
             except NotFoundError:
                 pass
+            self._nodes_dirty = True
+            self._edges_dirty = True
         except OpenSearchException as e:
             logger.error(f"[{self.workspace}] Error deleting node {node_id}: {e}")
 
     async def remove_nodes(self, nodes: list[str]) -> None:
         """Batch-delete multiple nodes and their connected edges.
 
-        No per-operation refresh: callers invoke index_done_callback() afterward.
-        Uses conflicts="proceed" to tolerate stale search views when prior
-        remove_edges() calls have already removed some edges without refresh.
+        Marks node and edge search views dirty so refresh happens lazily on the
+        next search/count-based graph read. Uses conflicts="proceed" to
+        tolerate already-deleted matches.
         """
         if not nodes:
             return
         logger.info(f"[{self.workspace}] Deleting {len(nodes)} nodes")
         try:
+            # Refresh edge search view so delete_by_query sees all un-flushed writes.
+            await self._refresh_graph_indices_if_dirty(refresh_edges=True)
             # Delete edges
             body = {
                 "query": {
@@ -1693,7 +1712,9 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 }
             }
             await self.client.delete_by_query(
-                index=self._edges_index, body=body, params={"conflicts": "proceed"}
+                index=self._edges_index,
+                body=body,
+                params={"conflicts": "proceed"},
             )
             # Delete nodes
             actions = [
@@ -1701,46 +1722,43 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 for nid in nodes
             ]
             await helpers.async_bulk(self.client, actions, raise_on_error=False)
+            self._nodes_dirty = True
+            self._edges_dirty = True
         except OpenSearchException as e:
             logger.error(f"[{self.workspace}] Error removing nodes: {e}")
 
     async def remove_edges(self, edges: list[tuple[str, str]]) -> None:
-        """Batch-delete multiple edges (bidirectional matching).
+        """Batch-delete multiple edges by deterministic ID (real-time).
 
-        No per-operation refresh: callers invoke index_done_callback() afterward.
-        Uses conflicts="proceed" to tolerate stale search views when
-        subsequent remove_nodes() may target already-deleted edges.
+        Each edge is stored under one of two candidate IDs:
+          forward  = compute_mdhash_id("src-tgt", prefix="edge-")
+          reverse  = compute_mdhash_id("tgt-src", prefix="edge-")
+        We delete both candidates for every requested edge so the deletion
+        is effective regardless of which direction was stored.
+
+        Marks edge search views dirty so refresh happens lazily on the next
+        search/count-based graph read.
         """
         if not edges:
             return
         logger.info(f"[{self.workspace}] Deleting {len(edges)} edges")
         try:
-            should_clauses = []
+            operations = []
             for src, tgt in edges:
-                should_clauses.append(
-                    {
-                        "bool": {
-                            "must": [
-                                {"term": {"source_node_id": src}},
-                                {"term": {"target_node_id": tgt}},
-                            ]
+                for edge_id in (
+                    compute_mdhash_id(f"{src}-{tgt}", prefix="edge-"),
+                    compute_mdhash_id(f"{tgt}-{src}", prefix="edge-"),
+                ):
+                    operations.append(
+                        {
+                            "delete": {
+                                "_index": self._edges_index,
+                                "_id": edge_id,
+                            }
                         }
-                    }
-                )
-                should_clauses.append(
-                    {
-                        "bool": {
-                            "must": [
-                                {"term": {"source_node_id": tgt}},
-                                {"term": {"target_node_id": src}},
-                            ]
-                        }
-                    }
-                )
-            body = {"query": {"bool": {"should": should_clauses}}}
-            await self.client.delete_by_query(
-                index=self._edges_index, body=body, params={"conflicts": "proceed"}
-            )
+                    )
+            await self.client.bulk(body=operations)
+            self._edges_dirty = True
         except OpenSearchException as e:
             logger.error(f"[{self.workspace}] Error removing edges: {e}")
 
@@ -1751,6 +1769,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
         if not self._indices_ready:
             return []
         try:
+            await self._refresh_graph_indices_if_dirty(refresh_nodes=True)
             labels = []
             pit = await self.client.create_pit(
                 index=self._nodes_index, params={"keep_alive": "1m"}
@@ -1845,6 +1864,9 @@ class OpenSearchGraphStorage(BaseGraphStorage):
         start = time.perf_counter()
 
         try:
+            await self._refresh_graph_indices_if_dirty(
+                refresh_nodes=True, refresh_edges=True
+            )
             if node_label == "*":
                 result = await self._get_knowledge_graph_all(max_nodes)
             elif self._ppl_graphlookup_available:
@@ -2254,6 +2276,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
         if not self._indices_ready:
             return []
         try:
+            await self._refresh_graph_indices_if_dirty(refresh_nodes=True)
             nodes = []
             pit = await self.client.create_pit(
                 index=self._nodes_index, params={"keep_alive": "1m"}
@@ -2297,6 +2320,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
         if not self._indices_ready:
             return []
         try:
+            await self._refresh_graph_indices_if_dirty(refresh_edges=True)
             edges = []
             pit = await self.client.create_pit(
                 index=self._edges_index, params={"keep_alive": "1m"}
@@ -2341,6 +2365,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
         if not self._indices_ready:
             return []
         try:
+            await self._refresh_graph_indices_if_dirty(refresh_edges=True)
             body = {
                 "size": 0,
                 "aggs": {
@@ -2373,6 +2398,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
         if not self._indices_ready:
             return []
         try:
+            await self._refresh_graph_indices_if_dirty(refresh_nodes=True)
             body = {
                 "query": {
                     "bool": {
@@ -2410,8 +2436,9 @@ class OpenSearchGraphStorage(BaseGraphStorage):
         if not self._indices_ready:
             return
         try:
-            await self.client.indices.refresh(index=self._nodes_index)
-            await self.client.indices.refresh(index=self._edges_index)
+            await self._refresh_graph_indices_if_dirty(
+                refresh_nodes=True, refresh_edges=True
+            )
         except OpenSearchException as e:
             if _is_missing_index_error(e):
                 self._mark_indices_missing()

--- a/tests/test_opensearch_storage.py
+++ b/tests/test_opensearch_storage.py
@@ -1080,28 +1080,24 @@ class TestGraphStorage:
 
     @pytest.mark.asyncio
     async def test_get_edge(self, global_config, embed_func, mock_client):
-        mock_client.search = AsyncMock(
+        # get_edge now uses mget (translog real-time) instead of search.
+        mock_client.mget = AsyncMock(
             return_value={
-                "hits": {
-                    "hits": [
-                        {
-                            "_id": "e1",
-                            "_source": {
-                                "source_node_id": "A",
-                                "target_node_id": "B",
-                                "weight": 1.0,
-                            },
+                "docs": [
+                    {
+                        "_id": "e1",
+                        "found": True,
+                        "_source": {
+                            "source_node_id": "A",
+                            "target_node_id": "B",
+                            "weight": 1.0,
                         },
-                    ],
-                    "total": {"value": 1},
-                },
-                "aggregations": {
-                    "status_counts": {"buckets": []},
-                    "src": {"buckets": []},
-                    "tgt": {"buckets": []},
-                    "source_degrees": {"buckets": []},
-                    "target_degrees": {"buckets": []},
-                },
+                    },
+                    {
+                        "_id": "e2",
+                        "found": False,
+                    },
+                ]
             }
         )
         with patch.object(ClientManager, "get_client", return_value=mock_client):
@@ -1329,11 +1325,17 @@ class TestGraphStorage:
 
     @pytest.mark.asyncio
     async def test_remove_edges(self, global_config, embed_func, mock_client):
+        # remove_edges now uses bulk delete with deterministic IDs instead of
+        # delete_by_query, so mock bulk as AsyncMock.
+        mock_client.bulk = AsyncMock(return_value={"errors": False, "items": []})
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()
             await s.remove_edges([("A", "B"), ("C", "D")])
-            mock_client.delete_by_query.assert_awaited_once()
+            # 2 edges × 2 candidate directions = 4 delete actions in one bulk call
+            mock_client.bulk.assert_awaited_once()
+            call_body = mock_client.bulk.call_args.kwargs["body"]
+            assert len(call_body) == 4
 
     @pytest.mark.asyncio
     async def test_get_all_labels(self, global_config, embed_func, mock_client):


### PR DESCRIPTION
## Description

Enhance OpenSearch graph storage efficiency by implementing lazy index refresh and real-time edge lookups to minimize overhead during bulk writes, while **ensuring data consistency for read operations following modify actions**.

## Related Issues

N/A

## Changes Made

**Lazy refresh with dirty tracking** (`opensearch_impl.py`):
- Added `_nodes_dirty` / `_edges_dirty` boolean flags to track whether prior writes have made search views stale
- New `_refresh_graph_indices_if_dirty()` helper — refreshes only when the corresponding dirty flag is set, called before each search/count/scan-based read
- `index_done_callback()` becomes a no-op when nothing is dirty, eliminating redundant refreshes

**Real-time edge point lookups**:
- `has_edge()` / `get_edge()`: replaced search query (requires refresh) with `mget` on two candidate edge IDs (`forward` + `reverse`). `mget` reads from the translog directly so results are immediately consistent regardless of refresh cycle

**Bulk edge deletion**:
- `remove_edges()`: replaced `delete_by_query` (search-based, refresh-dependent) with `bulk` delete on deterministic edge IDs — faster and immediately effective

**Fix: orphan edges on node deletion**:
- `delete_node()` / `remove_nodes()`: now call `_refresh_graph_indices_if_dirty(refresh_edges=True)` before `delete_by_query` so un-flushed edge writes are visible and not missed

**Test updates** (`test_opensearch_storage.py`):
- `test_get_edge`: updated mock from `client.search` to `client.mget` with correct response structure
- `test_remove_edges`: updated mock from `client.delete_by_query` to `client.bulk` (`AsyncMock`); added assertion that 4 delete actions are sent (2 edges × 2 candidate directions)

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

OpenSearch's near-real-time model means writes go to the translog first and are only visible in search after a refresh (default 1 s, or explicit `indices.refresh`). Point-lookup APIs (`mget`, `get`, `exists`) read from the translog directly and are always up to date. This PR exploits that distinction to minimize explicit refresh calls while preserving correctness.
