### PR TITLE
🐛 fix(kg): Correct omission of isolated nodes in `get_knowledge_graph` during full graph retrieval

### DIFF
--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -1268,6 +1268,19 @@ class MongoGraphStorage(BaseGraphStorage):
             },
         )
 
+    async def _fetch_nodes_by_ids(
+        self, node_ids: list[str], projection: dict[str, int] | None = None
+    ) -> list[dict[str, Any]]:
+        """Fetch nodes by ID while preserving the requested order."""
+        if not node_ids:
+            return []
+
+        cursor = self.collection.find({"_id": {"$in": node_ids}}, projection)
+        docs_by_id = {}
+        async for doc in cursor:
+            docs_by_id[str(doc["_id"])] = doc
+        return [docs_by_id[node_id] for node_id in node_ids if node_id in docs_by_id]
+
     async def get_knowledge_graph_all_by_degree(
         self, max_depth: int, max_nodes: int
     ) -> KnowledgeGraph:
@@ -1311,8 +1324,17 @@ class MongoGraphStorage(BaseGraphStorage):
                 node_id = str(doc["_id"])
                 node_ids.append(node_id)
 
-            cursor = self.collection.find({"_id": {"$in": node_ids}}, {"source_ids": 0})
-            async for doc in cursor:
+            if len(node_ids) < max_nodes:
+                remaining = max_nodes - len(node_ids)
+                cursor = self.collection.find(
+                    {"_id": {"$nin": node_ids}},
+                    {"source_ids": 0},
+                ).limit(remaining)
+                async for doc in cursor:
+                    node_ids.append(str(doc["_id"]))
+
+            docs = await self._fetch_nodes_by_ids(node_ids, {"source_ids": 0})
+            for doc in docs:
                 result.nodes.append(self._construct_graph_node(doc["_id"], doc))
 
             # As node count reaches the limit, only need to fetch the edges that directly connect to these nodes

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -1808,6 +1808,129 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 self._mark_indices_missing()
             return []
 
+    async def _collect_node_ids(
+        self, limit: int, exclude_ids: set[str] | None = None
+    ) -> list[str]:
+        """Collect up to `limit` node IDs, optionally skipping known IDs."""
+        if limit <= 0:
+            return []
+
+        excluded = exclude_ids or set()
+        if not excluded and limit <= 10000:
+            body = {
+                "query": {"match_all": {}},
+                "_source": False,
+                "size": limit,
+            }
+            resp = await self.client.search(index=self._nodes_index, body=body)
+            return [hit["_id"] for hit in resp["hits"]["hits"]]
+
+        node_ids: list[str] = []
+        pit = await self.client.create_pit(
+            index=self._nodes_index, params={"keep_alive": "1m"}
+        )
+        pit_id = pit["pit_id"]
+        try:
+            search_after = None
+            while len(node_ids) < limit:
+                body = {
+                    "query": {"match_all": {}},
+                    "_source": False,
+                    "size": 10000,
+                    "pit": {"id": pit_id, "keep_alive": "1m"},
+                    "sort": [{"_shard_doc": "asc"}],
+                }
+                if search_after:
+                    body["search_after"] = search_after
+                resp = await self.client.search(body=body)
+                hits = resp["hits"]["hits"]
+                if not hits:
+                    break
+                for hit in hits:
+                    node_id = hit["_id"]
+                    if node_id in excluded:
+                        continue
+                    node_ids.append(node_id)
+                    if len(node_ids) >= limit:
+                        break
+                search_after = hits[-1].get("sort")
+                if len(hits) < 10000:
+                    break
+        finally:
+            try:
+                await self.client.delete_pit(body={"pit_id": [pit_id]})
+            except Exception:
+                pass
+
+        return node_ids
+
+    @staticmethod
+    def _edge_rank_key(edge: dict[str, Any]) -> tuple[int, float]:
+        """Rank traversal edges by shallower depth first, then higher weight."""
+        depth = edge.get("_depth", edge.get("depth", 0))
+        try:
+            depth_value = int(depth)
+        except (TypeError, ValueError):
+            depth_value = 0
+
+        weight = edge.get("weight", 0)
+        try:
+            weight_value = float(weight)
+        except (TypeError, ValueError):
+            weight_value = 0.0
+
+        return (depth_value, -weight_value)
+
+    async def _append_edges_between_nodes(
+        self, node_ids: list[str], result: KnowledgeGraph
+    ) -> None:
+        """Append all edges whose source and target are both in `node_ids`."""
+        if not node_ids:
+            return
+
+        edge_query = {
+            "bool": {
+                "must": [
+                    {"terms": {"source_node_id": node_ids}},
+                    {"terms": {"target_node_id": node_ids}},
+                ]
+            }
+        }
+        seen_edges = set()
+        pit = await self.client.create_pit(
+            index=self._edges_index, params={"keep_alive": "1m"}
+        )
+        pit_id = pit["pit_id"]
+        try:
+            search_after = None
+            while True:
+                edge_body = {
+                    "query": edge_query,
+                    "size": 10000,
+                    "pit": {"id": pit_id, "keep_alive": "1m"},
+                    "sort": [{"_shard_doc": "asc"}],
+                }
+                if search_after:
+                    edge_body["search_after"] = search_after
+                edge_resp = await self.client.search(body=edge_body)
+                hits = edge_resp["hits"]["hits"]
+                if not hits:
+                    break
+                for hit in hits:
+                    e = hit["_source"]
+                    eid = f"{e['source_node_id']}-{e['target_node_id']}"
+                    if eid not in seen_edges:
+                        seen_edges.add(eid)
+                        result.edges.append(self._construct_graph_edge(eid, e))
+                search_after = hits[-1].get("sort")
+                if len(hits) < 10000:
+                    break
+        finally:
+            try:
+                await self.client.delete_pit(body={"pit_id": [pit_id]})
+            except Exception:
+                pass
+
     def _construct_graph_node(self, node_id, node_data: dict) -> KnowledgeGraphNode:
         return KnowledgeGraphNode(
             id=node_id,
@@ -1928,84 +2051,29 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 top_ids = sorted(degree_map, key=degree_map.get, reverse=True)[
                     :max_nodes
                 ]
-            else:
-                # Get all node IDs — use PIT scrolling if max_nodes > 10000
-                top_ids = []
-                if max_nodes <= 10000:
-                    body = {
-                        "query": {"match_all": {}},
-                        "_source": False,
-                        "size": max_nodes,
-                    }
-                    resp = await self.client.search(index=self._nodes_index, body=body)
-                    top_ids = [hit["_id"] for hit in resp["hits"]["hits"]]
-                else:
-                    pit = await self.client.create_pit(
-                        index=self._nodes_index, params={"keep_alive": "1m"}
+                if len(top_ids) < max_nodes:
+                    top_ids.extend(
+                        await self._collect_node_ids(
+                            max_nodes - len(top_ids), exclude_ids=set(top_ids)
+                        )
                     )
-                    pit_id = pit["pit_id"]
-                    try:
-                        search_after = None
-                        while len(top_ids) < max_nodes:
-                            body = {
-                                "query": {"match_all": {}},
-                                "_source": False,
-                                "size": 10000,
-                                "pit": {"id": pit_id, "keep_alive": "1m"},
-                                "sort": [{"_shard_doc": "asc"}],
-                            }
-                            if search_after:
-                                body["search_after"] = search_after
-                            resp = await self.client.search(body=body)
-                            hits = resp["hits"]["hits"]
-                            if not hits:
-                                break
-                            for hit in hits:
-                                top_ids.append(hit["_id"])
-                                if len(top_ids) >= max_nodes:
-                                    break
-                            search_after = hits[-1]["sort"]
-                            if len(hits) < 10000:
-                                break
-                    finally:
-                        try:
-                            await self.client.delete_pit(body={"pit_id": [pit_id]})
-                        except Exception:
-                            pass
+            else:
+                top_ids = await self._collect_node_ids(max_nodes)
 
             # Fetch node data
             if top_ids:
                 node_resp = await self.client.mget(
                     index=self._nodes_index, body={"ids": top_ids}
                 )
+                found_node_ids = []
                 for doc in node_resp["docs"]:
                     if doc.get("found"):
+                        found_node_ids.append(doc["_id"])
                         result.nodes.append(
                             self._construct_graph_node(doc["_id"], doc["_source"])
                         )
 
-                # Fetch edges between these nodes
-                edge_body = {
-                    "query": {
-                        "bool": {
-                            "must": [
-                                {"terms": {"source_node_id": top_ids}},
-                                {"terms": {"target_node_id": top_ids}},
-                            ]
-                        }
-                    },
-                    "size": 10000,
-                }
-                edge_resp = await self.client.search(
-                    index=self._edges_index, body=edge_body
-                )
-                seen_edges = set()
-                for hit in edge_resp["hits"]["hits"]:
-                    e = hit["_source"]
-                    eid = f"{e['source_node_id']}-{e['target_node_id']}"
-                    if eid not in seen_edges:
-                        seen_edges.add(eid)
-                        result.edges.append(self._construct_graph_edge(eid, e))
+                await self._append_edges_between_nodes(found_node_ids, result)
         except OpenSearchException as e:
             if _is_missing_index_error(e):
                 self._mark_indices_missing()
@@ -2029,7 +2097,6 @@ class OpenSearchGraphStorage(BaseGraphStorage):
         if not start_node:
             return result
 
-        seen_nodes = {start_label}
         result.nodes.append(self._construct_graph_node(start_label, start_node))
 
         if max_depth == 0:
@@ -2080,17 +2147,8 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             if not all_edge_rows:
                 return result
 
-            # Build field index map from the first edge row if it's a dict,
-            # otherwise fall back to known edge schema order
             if isinstance(all_edge_rows[0], dict):
-                # Dict-based response (ideal)
-                for edge_row in all_edge_rows:
-                    src = edge_row.get("source_node_id")
-                    tgt = edge_row.get("target_node_id")
-                    if src:
-                        seen_nodes.add(src)
-                    if tgt:
-                        seen_nodes.add(tgt)
+                sorted_edge_rows = sorted(all_edge_rows, key=self._edge_rank_key)
             else:
                 # Positional array — column positions are unknown, fall back to client BFS
                 logger.warning(
@@ -2104,12 +2162,23 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             )
             return await self._bfs_subgraph(start_label, max_depth, max_nodes)
 
-        # Limit to max_nodes
-        node_ids = list(seen_nodes)[:max_nodes]
-        result.is_truncated = len(seen_nodes) > max_nodes
+        ordered_node_ids = [start_label]
+        discovered_nodes = {start_label}
+        for edge_row in sorted_edge_rows:
+            for node_id in (
+                edge_row.get("source_node_id"),
+                edge_row.get("target_node_id"),
+            ):
+                if not node_id or node_id in discovered_nodes:
+                    continue
+                discovered_nodes.add(node_id)
+                if len(ordered_node_ids) < max_nodes:
+                    ordered_node_ids.append(node_id)
+
+        result.is_truncated = len(discovered_nodes) > max_nodes
 
         # Batch fetch node data (start node already added)
-        new_node_ids = [nid for nid in node_ids if nid != start_label]
+        new_node_ids = [nid for nid in ordered_node_ids if nid != start_label]
         if new_node_ids:
             node_resp = await self.client.mget(
                 index=self._nodes_index, body={"ids": new_node_ids}
@@ -2120,29 +2189,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                         self._construct_graph_node(doc["_id"], doc["_source"])
                     )
 
-        # Re-fetch full edge data between collected nodes for complete properties
-        if node_ids:
-            edge_body = {
-                "query": {
-                    "bool": {
-                        "must": [
-                            {"terms": {"source_node_id": node_ids}},
-                            {"terms": {"target_node_id": node_ids}},
-                        ]
-                    }
-                },
-                "size": 10000,
-            }
-            edge_resp = await self.client.search(
-                index=self._edges_index, body=edge_body
-            )
-            seen_edges = set()
-            for hit in edge_resp["hits"]["hits"]:
-                e = hit["_source"]
-                eid = f"{e['source_node_id']}-{e['target_node_id']}"
-                if eid not in seen_edges:
-                    seen_edges.add(eid)
-                    result.edges.append(self._construct_graph_edge(eid, e))
+        await self._append_edges_between_nodes(ordered_node_ids, result)
 
         return result
 
@@ -2222,49 +2269,8 @@ class OpenSearchGraphStorage(BaseGraphStorage):
         # Fetch all edges between seen nodes using PIT scrolling
         all_ids = list(seen_nodes)
         if all_ids:
-            edge_query = {
-                "bool": {
-                    "must": [
-                        {"terms": {"source_node_id": all_ids}},
-                        {"terms": {"target_node_id": all_ids}},
-                    ]
-                }
-            }
             try:
-                seen_edges = set()
-                pit = await self.client.create_pit(
-                    index=self._edges_index, params={"keep_alive": "1m"}
-                )
-                pit_id = pit["pit_id"]
-                try:
-                    search_after = None
-                    while True:
-                        edge_body = {
-                            "query": edge_query,
-                            "size": 10000,
-                            "pit": {"id": pit_id, "keep_alive": "1m"},
-                            "sort": [{"_shard_doc": "asc"}],
-                        }
-                        if search_after:
-                            edge_body["search_after"] = search_after
-                        edge_resp = await self.client.search(body=edge_body)
-                        hits = edge_resp["hits"]["hits"]
-                        if not hits:
-                            break
-                        for hit in hits:
-                            e = hit["_source"]
-                            eid = f"{e['source_node_id']}-{e['target_node_id']}"
-                            if eid not in seen_edges:
-                                seen_edges.add(eid)
-                                result.edges.append(self._construct_graph_edge(eid, e))
-                        search_after = hits[-1]["sort"]
-                        if len(hits) < 10000:
-                            break
-                finally:
-                    try:
-                        await self.client.delete_pit(body={"pit_id": [pit_id]})
-                    except Exception:
-                        pass
+                await self._append_edges_between_nodes(all_ids, result)
             except OpenSearchException:
                 pass
 

--- a/tests/test_mongo_storage.py
+++ b/tests/test_mongo_storage.py
@@ -1,0 +1,91 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+pytest.importorskip(
+    "pymongo",
+    reason="pymongo is required for Mongo storage tests",
+)
+
+from lightrag.kg.mongo_impl import MongoGraphStorage
+
+pytestmark = pytest.mark.offline
+
+
+class _AsyncCursor:
+    def __init__(self, docs):
+        self._docs = list(docs)
+
+    def limit(self, n: int):
+        self._docs = self._docs[:n]
+        return self
+
+    def __aiter__(self):
+        self._iter = iter(self._docs)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+class TestMongoGraphStorage:
+    def _make_storage(self):
+        storage = MongoGraphStorage.__new__(MongoGraphStorage)
+        storage.workspace = "test"
+        storage.global_config = {"max_graph_nodes": 1000}
+        storage._edge_collection_name = "test_edges"
+        storage.collection = SimpleNamespace()
+        storage.edge_collection = SimpleNamespace()
+        return storage
+
+    @pytest.mark.asyncio
+    async def test_get_knowledge_graph_all_backfills_isolated_nodes_when_truncated(self):
+        storage = self._make_storage()
+        storage.collection.count_documents = AsyncMock(return_value=5)
+        storage.edge_collection.aggregate = AsyncMock(
+            return_value=_AsyncCursor([{"_id": "A", "degree": 1}, {"_id": "B", "degree": 1}])
+        )
+
+        def collection_find_side_effect(query, projection=None):
+            if query == {"_id": {"$nin": ["A", "B"]}}:
+                return _AsyncCursor(
+                    [
+                        {"_id": "C", "entity_type": "person"},
+                        {"_id": "D", "entity_type": "person"},
+                        {"_id": "E", "entity_type": "person"},
+                    ]
+                )
+            if query == {"_id": {"$in": ["A", "B", "C", "D"]}}:
+                return _AsyncCursor(
+                    [
+                        {"_id": "B", "entity_type": "person"},
+                        {"_id": "D", "entity_type": "person"},
+                        {"_id": "A", "entity_type": "person"},
+                        {"_id": "C", "entity_type": "person"},
+                    ]
+                )
+            raise AssertionError(f"Unexpected node query: {query}")
+
+        storage.collection.find = Mock(side_effect=collection_find_side_effect)
+        storage.edge_collection.find = Mock(
+            return_value=_AsyncCursor(
+                [
+                    {
+                        "source_node_id": "A",
+                        "target_node_id": "B",
+                        "relationship": "knows",
+                    }
+                ]
+            )
+        )
+
+        result = await storage.get_knowledge_graph_all_by_degree(max_depth=2, max_nodes=4)
+
+        assert result.is_truncated is True
+        assert [node.id for node in result.nodes] == ["A", "B", "C", "D"]
+        assert len(result.edges) == 1
+        assert result.edges[0].source == "A"
+        assert result.edges[0].target == "B"

--- a/tests/test_mongo_storage.py
+++ b/tests/test_mongo_storage.py
@@ -42,11 +42,15 @@ class TestMongoGraphStorage:
         return storage
 
     @pytest.mark.asyncio
-    async def test_get_knowledge_graph_all_backfills_isolated_nodes_when_truncated(self):
+    async def test_get_knowledge_graph_all_backfills_isolated_nodes_when_truncated(
+        self,
+    ):
         storage = self._make_storage()
         storage.collection.count_documents = AsyncMock(return_value=5)
         storage.edge_collection.aggregate = AsyncMock(
-            return_value=_AsyncCursor([{"_id": "A", "degree": 1}, {"_id": "B", "degree": 1}])
+            return_value=_AsyncCursor(
+                [{"_id": "A", "degree": 1}, {"_id": "B", "degree": 1}]
+            )
         )
 
         def collection_find_side_effect(query, projection=None):
@@ -82,7 +86,9 @@ class TestMongoGraphStorage:
             )
         )
 
-        result = await storage.get_knowledge_graph_all_by_degree(max_depth=2, max_nodes=4)
+        result = await storage.get_knowledge_graph_all_by_degree(
+            max_depth=2, max_nodes=4
+        )
 
         assert result.is_truncated is True
         assert [node.id for node in result.nodes] == ["A", "B", "C", "D"]

--- a/tests/test_opensearch_storage.py
+++ b/tests/test_opensearch_storage.py
@@ -1380,6 +1380,144 @@ class TestGraphStorage:
             assert labels[0] == "A"  # degree 8 > B degree 2
 
     @pytest.mark.asyncio
+    async def test_get_knowledge_graph_all_backfills_isolated_nodes_when_truncated(
+        self, global_config, embed_func, mock_client
+    ):
+        mock_client.count = AsyncMock(return_value={"count": 5})
+        mock_client.search = AsyncMock(
+            side_effect=[
+                {
+                    "hits": {"hits": [], "total": {"value": 1}},
+                    "aggregations": {
+                        "src": {"buckets": [{"key": "A", "doc_count": 1}]},
+                        "tgt": {"buckets": [{"key": "B", "doc_count": 1}]},
+                        "status_counts": {"buckets": []},
+                    },
+                },
+                {
+                    "hits": {
+                        "hits": [
+                            {"_id": "A", "sort": [1]},
+                            {"_id": "B", "sort": [2]},
+                            {"_id": "C", "sort": [3]},
+                            {"_id": "D", "sort": [4]},
+                            {"_id": "E", "sort": [5]},
+                        ],
+                        "total": {"value": 5},
+                    }
+                },
+                {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_id": "edge-ab",
+                                "_source": {
+                                    "source_node_id": "A",
+                                    "target_node_id": "B",
+                                    "relationship": "knows",
+                                },
+                            }
+                        ],
+                        "total": {"value": 1},
+                    }
+                },
+            ]
+        )
+        mock_client.mget = AsyncMock(
+            return_value={
+                "docs": [
+                    {"_id": "A", "found": True, "_source": {"entity_type": "person"}},
+                    {"_id": "B", "found": True, "_source": {"entity_type": "person"}},
+                    {"_id": "C", "found": True, "_source": {"entity_type": "person"}},
+                    {"_id": "D", "found": True, "_source": {"entity_type": "person"}},
+                ]
+            }
+        )
+
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+
+            result = await s.get_knowledge_graph("*", max_nodes=4)
+
+            assert result.is_truncated is True
+            assert [node.id for node in result.nodes] == ["A", "B", "C", "D"]
+            assert len(result.edges) == 1
+            assert result.edges[0].source == "A"
+            assert result.edges[0].target == "B"
+            assert mock_client.create_pit.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_get_knowledge_graph_all_paginates_edges_between_selected_nodes(
+        self, global_config, embed_func, mock_client
+    ):
+        mock_client.count = AsyncMock(return_value={"count": 2})
+        first_edge_page = [
+            {
+                "_id": f"edge-{i}",
+                "_source": {
+                    "source_node_id": "A",
+                    "target_node_id": "B",
+                    "relationship": "knows",
+                },
+                "sort": [i],
+            }
+            for i in range(10000)
+        ]
+        mock_client.search = AsyncMock(
+            side_effect=[
+                {
+                    "hits": {
+                        "hits": [
+                            {"_id": "A"},
+                            {"_id": "B"},
+                        ],
+                        "total": {"value": 2},
+                    }
+                },
+                {"hits": {"hits": first_edge_page, "total": {"value": 10001}}},
+                {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_id": "edge-last",
+                                "_source": {
+                                    "source_node_id": "B",
+                                    "target_node_id": "A",
+                                    "relationship": "knows",
+                                },
+                                "sort": [10000],
+                            }
+                        ],
+                        "total": {"value": 10001},
+                    }
+                },
+            ]
+        )
+        mock_client.mget = AsyncMock(
+            return_value={
+                "docs": [
+                    {"_id": "A", "found": True, "_source": {"entity_type": "person"}},
+                    {"_id": "B", "found": True, "_source": {"entity_type": "person"}},
+                ]
+            }
+        )
+
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+
+            result = await s.get_knowledge_graph("*", max_nodes=2)
+
+            assert len(result.nodes) == 2
+            assert len(result.edges) == 2
+            assert {(edge.source, edge.target) for edge in result.edges} == {
+                ("A", "B"),
+                ("B", "A"),
+            }
+            assert mock_client.search.await_count == 3
+
+    @pytest.mark.asyncio
     async def test_search_labels_empty_query(
         self, global_config, embed_func, mock_client
     ):
@@ -1725,6 +1863,111 @@ class TestGraphPPLDetection:
             result = await s.get_knowledge_graph("A", max_depth=2)
             assert len(result.nodes) == 1
             assert result.nodes[0].id == "A"
+
+    @pytest.mark.asyncio
+    async def test_ppl_bfs_truncates_nodes_by_depth_then_weight(
+        self, global_config, embed_func, mock_client
+    ):
+        mock_client.transport = AsyncMock()
+        ppl_response = {
+            "schema": [
+                {"name": "entity_id", "type": "string"},
+                {"name": "connected_edges", "type": "struct"},
+            ],
+            "datarows": [
+                [
+                    "A",
+                    [
+                        {
+                            "source_node_id": "A",
+                            "target_node_id": "C",
+                            "weight": 1.0,
+                            "_depth": 1,
+                        },
+                        {
+                            "source_node_id": "B",
+                            "target_node_id": "D",
+                            "weight": 10.0,
+                            "_depth": 1,
+                        },
+                        {
+                            "source_node_id": "A",
+                            "target_node_id": "B",
+                            "weight": 1.0,
+                            "_depth": 0,
+                        },
+                    ],
+                ]
+            ],
+        }
+        mock_client.transport.perform_request = AsyncMock(return_value=ppl_response)
+        mock_client.mget = AsyncMock(
+            side_effect=[
+                {
+                    "docs": [
+                        {
+                            "_id": "A",
+                            "found": True,
+                            "_source": {"entity_type": "person"},
+                        }
+                    ]
+                },
+                {
+                    "docs": [
+                        {
+                            "_id": "B",
+                            "found": True,
+                            "_source": {"entity_type": "person"},
+                        },
+                        {
+                            "_id": "D",
+                            "found": True,
+                            "_source": {"entity_type": "person"},
+                        },
+                    ]
+                },
+            ]
+        )
+        mock_client.search = AsyncMock(
+            return_value={
+                "hits": {
+                    "hits": [
+                        {
+                            "_id": "e1",
+                            "_source": {
+                                "source_node_id": "A",
+                                "target_node_id": "B",
+                                "relationship": "knows",
+                            },
+                            "sort": [1],
+                        },
+                        {
+                            "_id": "e2",
+                            "_source": {
+                                "source_node_id": "B",
+                                "target_node_id": "D",
+                                "relationship": "knows",
+                            },
+                            "sort": [2],
+                        },
+                    ],
+                    "total": {"value": 2},
+                }
+            }
+        )
+
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+
+            result = await s.get_knowledge_graph("A", max_depth=2, max_nodes=3)
+
+            assert [node.id for node in result.nodes] == ["A", "B", "D"]
+            assert result.is_truncated is True
+            assert {(edge.source, edge.target) for edge in result.edges} == {
+                ("A", "B"),
+                ("B", "D"),
+            }
 
     @pytest.mark.asyncio
     async def test_upsert_node_adds_entity_id(


### PR DESCRIPTION
## Description

Fix knowledge graph retrieval to include isolated nodes (nodes not connected by any edges) that were previously excluded from results. Also refactors repetitive PIT (Point-in-Time) scrolling code in the OpenSearch implementation into reusable helper methods.

## Related Issues

Related to #2926 (follow-up improvement)

## Changes Made

**`lightrag/kg/mongo_impl.py`**
- Add `_fetch_nodes_by_ids()` helper that preserves insertion order when fetching nodes by ID (MongoDB `$in` does not guarantee order)
- Backfill isolated nodes in `get_knowledge_graph_all_by_degree()` when the degree-sorted set is smaller than `max_nodes`

**`lightrag/kg/opensearch_impl.py`**
- Extract `_collect_node_ids()` helper to consolidate 3 copies of repeated PIT scrolling logic for node collection; includes a fast path for small result sets without exclusions
- Extract `_append_edges_between_nodes()` helper to eliminate 3 copies of identical edge PIT pagination code
- Add `_edge_rank_key()` static method for deterministic BFS truncation (shallower depth first, then higher weight)
- Use `ordered_node_ids` in BFS traversal to guarantee the start node is always included first
- Backfill isolated nodes in `get_knowledge_graph_all_by_degree()` to match MongoDB behavior

**`tests/test_mongo_storage.py`** *(new file)*
- Unit tests for MongoGraphStorage isolated-node backfill and order preservation

**`tests/test_opensearch_storage.py`**
- `test_get_knowledge_graph_all_backfills_isolated_nodes_when_truncated`: verifies isolated nodes are included and PIT is used correctly
- `test_get_knowledge_graph_all_paginates_edges_between_selected_nodes`: verifies edge pagination handles 10000+ edges across multiple pages
- `test_ppl_bfs_truncates_nodes_by_depth_then_weight`: verifies BFS truncation prioritizes shallow, high-weight edges

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

The root cause was that nodes with no edges never appear in degree aggregation results, so they were silently dropped when `degree_map` had fewer entries than `max_nodes`. The fix adds a supplemental query to fill the remaining slots with any nodes not already selected.
