### PR TITLE
fix(postgres): remove duplicate SET clause in upsert_edge Cypher query

### DIFF
--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -5084,7 +5084,6 @@ class PGGraphStorage(BaseGraphStorage):
                      MATCH (target:base {{entity_id: "{tgt_label}"}})
                      MERGE (source)-[r:DIRECTED]-(target)
                      SET r += {edge_properties}
-                     SET r += {edge_properties}
                      RETURN r"""
 
         query = f"SELECT * FROM cypher({_dollar_quote(self.graph_name)}, {_dollar_quote(cypher_query)}) AS (r agtype)"

--- a/tests/test_postgres_upsert_edge_cypher.py
+++ b/tests/test_postgres_upsert_edge_cypher.py
@@ -1,0 +1,91 @@
+"""
+Unit tests for PGGraphStorage.upsert_edge Cypher query generation.
+
+Verifies the Cypher query sent to AGE contains exactly one SET clause
+(regression test for duplicate SET copy-paste bug).
+"""
+
+import re
+import pytest
+from unittest.mock import MagicMock, patch
+
+from lightrag.kg.postgres_impl import PGGraphStorage
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_graph_storage() -> PGGraphStorage:
+    """Construct a PGGraphStorage instance with a mocked _query method."""
+    storage = PGGraphStorage.__new__(PGGraphStorage)
+    storage.workspace = "test_ws"
+    storage.namespace = "test_graph"
+    storage.graph_name = "test_graph"
+    storage.db = MagicMock()
+    return storage
+
+
+# ---------------------------------------------------------------------------
+# upsert_edge: Cypher query correctness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_edge_single_set_clause():
+    """The Cypher query must contain exactly one SET clause, not a duplicate."""
+    storage = make_graph_storage()
+    captured_sql: list[str] = []
+
+    async def fake_query(sql, **kwargs):
+        captured_sql.append(sql)
+        return []
+
+    with patch.object(storage, "_query", side_effect=fake_query):
+        await storage.upsert_edge("NodeA", "NodeB", {"weight": "1.0", "description": "test edge"})
+
+    assert len(captured_sql) == 1
+    sql = captured_sql[0]
+
+    # Count occurrences of SET in the Cypher query
+    set_count = len(re.findall(r"\bSET\b", sql))
+    assert set_count == 1, f"Expected 1 SET clause, found {set_count} in: {sql}"
+
+
+@pytest.mark.asyncio
+async def test_upsert_edge_contains_merge_and_set():
+    """The Cypher query must contain MERGE and SET with edge properties."""
+    storage = make_graph_storage()
+    captured_sql: list[str] = []
+
+    async def fake_query(sql, **kwargs):
+        captured_sql.append(sql)
+        return []
+
+    with patch.object(storage, "_query", side_effect=fake_query):
+        await storage.upsert_edge("Alice", "Bob", {"weight": "0.5"})
+
+    sql = captured_sql[0]
+    assert "MERGE" in sql
+    assert "SET r +=" in sql
+    assert "RETURN r" in sql
+
+
+@pytest.mark.asyncio
+async def test_upsert_edge_uses_normalized_ids():
+    """Source and target IDs must be normalized in the Cypher query."""
+    storage = make_graph_storage()
+    captured_sql: list[str] = []
+
+    async def fake_query(sql, **kwargs):
+        captured_sql.append(sql)
+        return []
+
+    with patch.object(storage, "_query", side_effect=fake_query):
+        await storage.upsert_edge("Node A", "Node B", {"weight": "1.0"})
+
+    sql = captured_sql[0]
+    # The normalized IDs should appear in the MATCH clauses
+    assert 'entity_id: "Node A"' in sql
+    assert 'entity_id: "Node B"' in sql


### PR DESCRIPTION
## Summary
- Remove duplicated `SET r += {edge_properties}` line in `upsert_edge` Cypher query (line 5087 of `lightrag/kg/postgres_impl.py`)
- Add regression test verifying exactly one SET clause is generated

## Problem
The MERGE query in `PGGraphStorage.upsert_edge` applies `SET r += {edge_properties}` twice — a copy-paste artifact. While idempotent for AGE SET operations, it doubles the property assignment work on every edge upsert.

## Changes
- **`lightrag/kg/postgres_impl.py`**: Remove the duplicate SET line (was line 5087)
- **`tests/test_postgres_upsert_edge_cypher.py`**: New test file with 3 tests:
  - `test_upsert_edge_single_set_clause` — regression test counting SET occurrences
  - `test_upsert_edge_contains_merge_and_set` — structural correctness
  - `test_upsert_edge_uses_normalized_ids` — entity ID normalization

## Test plan
- [x] Verified single SET produces identical results to double SET (idempotent operation)
- [x] Scanned entire file for other consecutive duplicate lines — none found
- [x] Compared with `upsert_node` which correctly has a single SET
- [x] New unit tests mock `_query` and validate the generated Cypher string