### PR TITLE
fix(graph): return 0 for missing node/edge degree instead of None

### DIFF
--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -110,7 +110,9 @@ class NetworkXStorage(BaseGraphStorage):
 
     async def node_degree(self, node_id: str) -> int:
         graph = await self._get_graph()
-        return graph.degree(node_id)
+        if graph.has_node(node_id):
+            return graph.degree(node_id)
+        return 0
 
     async def edge_degree(self, src_id: str, tgt_id: str) -> int:
         graph = await self._get_graph()

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -4950,11 +4950,13 @@ class PGGraphStorage(BaseGraphStorage):
         result = await self.node_degrees_batch(node_ids=[node_id])
         if result and node_id in result:
             return result[node_id]
+        return 0
 
     async def edge_degree(self, src_id: str, tgt_id: str) -> int:
         result = await self.edge_degrees_batch(edges=[(src_id, tgt_id)])
         if result and (src_id, tgt_id) in result:
             return result[(src_id, tgt_id)]
+        return 0
 
     async def get_edge(
         self, source_node_id: str, target_node_id: str

--- a/tests/test_degree_return_type.py
+++ b/tests/test_degree_return_type.py
@@ -4,58 +4,42 @@ Every graph storage backend must return ``int`` from ``node_degree`` and
 ``edge_degree``, even when the requested node or edge does not exist.
 The expected default for missing entries is ``0``.
 
-These tests mock the batch helpers so they run without a database or
-heavy import dependencies.
+These tests exercise the *real* methods on ``PGGraphStorage`` and
+``NetworkXStorage`` (from ``lightrag/kg/``) with mocked backing stores
+so they run without a database or heavy import dependencies.
 """
 
 import asyncio
-import types
 from unittest.mock import AsyncMock
 
+import networkx as nx
 import pytest
 
+from lightrag.kg.postgres_impl import PGGraphStorage
+from lightrag.kg.networkx_impl import NetworkXStorage
+
 
 # ---------------------------------------------------------------------------
-# Helpers — extract the unbound coroutine functions from source to avoid
-# importing modules that require Python 3.10+ syntax or heavy deps.
+# Helpers — build storage instances without triggering __post_init__
 # ---------------------------------------------------------------------------
 
 
-async def _pg_node_degree(self, node_id: str) -> int:
-    """Copied logic from PGGraphStorage.node_degree"""
-    result = await self.node_degrees_batch(node_ids=[node_id])
-    if result and node_id in result:
-        return result[node_id]
-    return 0
+def _make_pg_storage(**attrs) -> PGGraphStorage:
+    """Create a PGGraphStorage instance bypassing __post_init__, then
+    attach mock attributes needed for the methods under test."""
+    instance = object.__new__(PGGraphStorage)
+    for k, v in attrs.items():
+        setattr(instance, k, v)
+    return instance
 
 
-async def _pg_edge_degree(self, src_id: str, tgt_id: str) -> int:
-    """Copied logic from PGGraphStorage.edge_degree"""
-    result = await self.edge_degrees_batch(edges=[(src_id, tgt_id)])
-    if result and (src_id, tgt_id) in result:
-        return result[(src_id, tgt_id)]
-    return 0
-
-
-async def _nx_node_degree(self, node_id: str) -> int:
-    """Copied logic from NetworkXStorage.node_degree"""
-    graph = await self._get_graph()
-    if graph.has_node(node_id):
-        return graph.degree(node_id)
-    return 0
-
-
-async def _nx_edge_degree(self, src_id: str, tgt_id: str) -> int:
-    """Copied logic from NetworkXStorage.edge_degree"""
-    graph = await self._get_graph()
-    src_degree = graph.degree(src_id) if graph.has_node(src_id) else 0
-    tgt_degree = graph.degree(tgt_id) if graph.has_node(tgt_id) else 0
-    return src_degree + tgt_degree
-
-
-def _make_stub(**attrs):
-    """Create a simple namespace object with the given attributes."""
-    return types.SimpleNamespace(**attrs)
+def _make_nx_storage(**attrs) -> NetworkXStorage:
+    """Create a NetworkXStorage instance bypassing __post_init__, then
+    attach mock attributes needed for the methods under test."""
+    instance = object.__new__(NetworkXStorage)
+    for k, v in attrs.items():
+        setattr(instance, k, v)
+    return instance
 
 
 # ---------------------------------------------------------------------------
@@ -68,45 +52,55 @@ class TestPGGraphStorageDegree:
 
     @pytest.mark.asyncio
     async def test_node_degree_missing_returns_zero(self):
-        stub = _make_stub(node_degrees_batch=AsyncMock(return_value={}))
-        result = await _pg_node_degree(stub, "nonexistent_node")
+        storage = _make_pg_storage(
+            node_degrees_batch=AsyncMock(return_value={})
+        )
+        result = await storage.node_degree("nonexistent_node")
         assert result == 0
         assert isinstance(result, int)
 
     @pytest.mark.asyncio
     async def test_node_degree_existing_returns_value(self):
-        stub = _make_stub(node_degrees_batch=AsyncMock(return_value={"node_a": 5}))
-        result = await _pg_node_degree(stub, "node_a")
+        storage = _make_pg_storage(
+            node_degrees_batch=AsyncMock(return_value={"node_a": 5})
+        )
+        result = await storage.node_degree("node_a")
         assert result == 5
         assert isinstance(result, int)
 
     @pytest.mark.asyncio
     async def test_edge_degree_missing_returns_zero(self):
-        stub = _make_stub(edge_degrees_batch=AsyncMock(return_value={}))
-        result = await _pg_edge_degree(stub, "src", "tgt")
+        storage = _make_pg_storage(
+            edge_degrees_batch=AsyncMock(return_value={})
+        )
+        result = await storage.edge_degree("src", "tgt")
         assert result == 0
         assert isinstance(result, int)
 
     @pytest.mark.asyncio
     async def test_edge_degree_existing_returns_value(self):
-        stub = _make_stub(
+        storage = _make_pg_storage(
             edge_degrees_batch=AsyncMock(return_value={("src", "tgt"): 7})
         )
-        result = await _pg_edge_degree(stub, "src", "tgt")
+        result = await storage.edge_degree("src", "tgt")
         assert result == 7
         assert isinstance(result, int)
 
     @pytest.mark.asyncio
     async def test_node_degree_none_result_returns_zero(self):
-        stub = _make_stub(node_degrees_batch=AsyncMock(return_value=None))
-        result = await _pg_node_degree(stub, "any")
+        storage = _make_pg_storage(
+            node_degrees_batch=AsyncMock(return_value=None)
+        )
+        result = await storage.node_degree("any")
         assert result == 0
         assert isinstance(result, int)
 
     @pytest.mark.asyncio
     async def test_edge_degree_none_result_returns_zero(self):
-        stub = _make_stub(edge_degrees_batch=AsyncMock(return_value=None))
-        result = await _pg_edge_degree(stub, "src", "tgt")
+        storage = _make_pg_storage(
+            edge_degrees_batch=AsyncMock(return_value=None)
+        )
+        result = await storage.edge_degree("src", "tgt")
         assert result == 0
         assert isinstance(result, int)
 
@@ -121,46 +115,38 @@ class TestNetworkXStorageDegree:
 
     @pytest.mark.asyncio
     async def test_node_degree_missing_returns_zero(self):
-        import networkx as nx
-
         graph = nx.Graph()
-        stub = _make_stub(_get_graph=AsyncMock(return_value=graph))
-        result = await _nx_node_degree(stub, "nonexistent")
+        storage = _make_nx_storage(_get_graph=AsyncMock(return_value=graph))
+        result = await storage.node_degree("nonexistent")
         assert result == 0
         assert isinstance(result, int)
 
     @pytest.mark.asyncio
     async def test_node_degree_existing_returns_value(self):
-        import networkx as nx
-
         graph = nx.Graph()
         graph.add_edge("a", "b")
         graph.add_edge("a", "c")
-        stub = _make_stub(_get_graph=AsyncMock(return_value=graph))
-        result = await _nx_node_degree(stub, "a")
+        storage = _make_nx_storage(_get_graph=AsyncMock(return_value=graph))
+        result = await storage.node_degree("a")
         assert result == 2
         assert isinstance(result, int)
 
     @pytest.mark.asyncio
     async def test_edge_degree_missing_returns_zero(self):
-        import networkx as nx
-
         graph = nx.Graph()
-        stub = _make_stub(_get_graph=AsyncMock(return_value=graph))
-        result = await _nx_edge_degree(stub, "x", "y")
+        storage = _make_nx_storage(_get_graph=AsyncMock(return_value=graph))
+        result = await storage.edge_degree("x", "y")
         assert result == 0
         assert isinstance(result, int)
 
     @pytest.mark.asyncio
     async def test_edge_degree_existing_returns_value(self):
-        import networkx as nx
-
         graph = nx.Graph()
         graph.add_edge("a", "b")
         graph.add_edge("a", "c")
         graph.add_edge("b", "d")
-        stub = _make_stub(_get_graph=AsyncMock(return_value=graph))
+        storage = _make_nx_storage(_get_graph=AsyncMock(return_value=graph))
         # edge_degree("a", "b") = degree(a) + degree(b) = 2 + 2 = 4
-        result = await _nx_edge_degree(stub, "a", "b")
+        result = await storage.edge_degree("a", "b")
         assert result == 4
         assert isinstance(result, int)

--- a/tests/test_degree_return_type.py
+++ b/tests/test_degree_return_type.py
@@ -1,0 +1,166 @@
+"""Tests for node_degree and edge_degree return type contract.
+
+Every graph storage backend must return ``int`` from ``node_degree`` and
+``edge_degree``, even when the requested node or edge does not exist.
+The expected default for missing entries is ``0``.
+
+These tests mock the batch helpers so they run without a database or
+heavy import dependencies.
+"""
+
+import asyncio
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers — extract the unbound coroutine functions from source to avoid
+# importing modules that require Python 3.10+ syntax or heavy deps.
+# ---------------------------------------------------------------------------
+
+
+async def _pg_node_degree(self, node_id: str) -> int:
+    """Copied logic from PGGraphStorage.node_degree"""
+    result = await self.node_degrees_batch(node_ids=[node_id])
+    if result and node_id in result:
+        return result[node_id]
+    return 0
+
+
+async def _pg_edge_degree(self, src_id: str, tgt_id: str) -> int:
+    """Copied logic from PGGraphStorage.edge_degree"""
+    result = await self.edge_degrees_batch(edges=[(src_id, tgt_id)])
+    if result and (src_id, tgt_id) in result:
+        return result[(src_id, tgt_id)]
+    return 0
+
+
+async def _nx_node_degree(self, node_id: str) -> int:
+    """Copied logic from NetworkXStorage.node_degree"""
+    graph = await self._get_graph()
+    if graph.has_node(node_id):
+        return graph.degree(node_id)
+    return 0
+
+
+async def _nx_edge_degree(self, src_id: str, tgt_id: str) -> int:
+    """Copied logic from NetworkXStorage.edge_degree"""
+    graph = await self._get_graph()
+    src_degree = graph.degree(src_id) if graph.has_node(src_id) else 0
+    tgt_degree = graph.degree(tgt_id) if graph.has_node(tgt_id) else 0
+    return src_degree + tgt_degree
+
+
+def _make_stub(**attrs):
+    """Create a simple namespace object with the given attributes."""
+    return types.SimpleNamespace(**attrs)
+
+
+# ---------------------------------------------------------------------------
+# PostgreSQL (PGGraphStorage)
+# ---------------------------------------------------------------------------
+
+
+class TestPGGraphStorageDegree:
+    """Verify PGGraphStorage.node_degree / edge_degree return 0 for missing entries."""
+
+    @pytest.mark.asyncio
+    async def test_node_degree_missing_returns_zero(self):
+        stub = _make_stub(node_degrees_batch=AsyncMock(return_value={}))
+        result = await _pg_node_degree(stub, "nonexistent_node")
+        assert result == 0
+        assert isinstance(result, int)
+
+    @pytest.mark.asyncio
+    async def test_node_degree_existing_returns_value(self):
+        stub = _make_stub(node_degrees_batch=AsyncMock(return_value={"node_a": 5}))
+        result = await _pg_node_degree(stub, "node_a")
+        assert result == 5
+        assert isinstance(result, int)
+
+    @pytest.mark.asyncio
+    async def test_edge_degree_missing_returns_zero(self):
+        stub = _make_stub(edge_degrees_batch=AsyncMock(return_value={}))
+        result = await _pg_edge_degree(stub, "src", "tgt")
+        assert result == 0
+        assert isinstance(result, int)
+
+    @pytest.mark.asyncio
+    async def test_edge_degree_existing_returns_value(self):
+        stub = _make_stub(
+            edge_degrees_batch=AsyncMock(return_value={("src", "tgt"): 7})
+        )
+        result = await _pg_edge_degree(stub, "src", "tgt")
+        assert result == 7
+        assert isinstance(result, int)
+
+    @pytest.mark.asyncio
+    async def test_node_degree_none_result_returns_zero(self):
+        stub = _make_stub(node_degrees_batch=AsyncMock(return_value=None))
+        result = await _pg_node_degree(stub, "any")
+        assert result == 0
+        assert isinstance(result, int)
+
+    @pytest.mark.asyncio
+    async def test_edge_degree_none_result_returns_zero(self):
+        stub = _make_stub(edge_degrees_batch=AsyncMock(return_value=None))
+        result = await _pg_edge_degree(stub, "src", "tgt")
+        assert result == 0
+        assert isinstance(result, int)
+
+
+# ---------------------------------------------------------------------------
+# NetworkX
+# ---------------------------------------------------------------------------
+
+
+class TestNetworkXStorageDegree:
+    """Verify NetworkXStorage.node_degree returns 0 for missing nodes."""
+
+    @pytest.mark.asyncio
+    async def test_node_degree_missing_returns_zero(self):
+        import networkx as nx
+
+        graph = nx.Graph()
+        stub = _make_stub(_get_graph=AsyncMock(return_value=graph))
+        result = await _nx_node_degree(stub, "nonexistent")
+        assert result == 0
+        assert isinstance(result, int)
+
+    @pytest.mark.asyncio
+    async def test_node_degree_existing_returns_value(self):
+        import networkx as nx
+
+        graph = nx.Graph()
+        graph.add_edge("a", "b")
+        graph.add_edge("a", "c")
+        stub = _make_stub(_get_graph=AsyncMock(return_value=graph))
+        result = await _nx_node_degree(stub, "a")
+        assert result == 2
+        assert isinstance(result, int)
+
+    @pytest.mark.asyncio
+    async def test_edge_degree_missing_returns_zero(self):
+        import networkx as nx
+
+        graph = nx.Graph()
+        stub = _make_stub(_get_graph=AsyncMock(return_value=graph))
+        result = await _nx_edge_degree(stub, "x", "y")
+        assert result == 0
+        assert isinstance(result, int)
+
+    @pytest.mark.asyncio
+    async def test_edge_degree_existing_returns_value(self):
+        import networkx as nx
+
+        graph = nx.Graph()
+        graph.add_edge("a", "b")
+        graph.add_edge("a", "c")
+        graph.add_edge("b", "d")
+        stub = _make_stub(_get_graph=AsyncMock(return_value=graph))
+        # edge_degree("a", "b") = degree(a) + degree(b) = 2 + 2 = 4
+        result = await _nx_edge_degree(stub, "a", "b")
+        assert result == 4
+        assert isinstance(result, int)


### PR DESCRIPTION
## Summary
- Fix `node_degree` and `edge_degree` in `PGGraphStorage` to return `0` instead of `None` when the node/edge is not found
- Fix `node_degree` in `NetworkXStorage` to return `0` instead of raising `NetworkXError` for missing nodes
- Add unit tests covering both backends for missing and existing node/edge degree

## Problem
Both methods in `PGGraphStorage` have return type annotation `-> int` but implicitly return `None` when the lookup misses. Callers doing arithmetic (e.g., ranking by degree in `operate.py`) crash with `TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'`.

Similarly, `NetworkXStorage.node_degree` calls `graph.degree(node_id)` without checking node existence, raising `NetworkXError` for missing nodes — inconsistent with its own `edge_degree` which already guards with `has_node()`.

The base class `BaseGraphStorage` contract and other backends (Neo4j, Memgraph, MongoDB, OpenSearch) all return `0` for nonexistent nodes.

## Changes
- `lightrag/kg/postgres_impl.py`: Add `return 0` default in `node_degree` and `edge_degree`
- `lightrag/kg/networkx_impl.py`: Add `has_node` guard in `node_degree`
- `tests/test_degree_return_type.py`: 10 unit tests covering missing/existing node and edge degrees for both backends

## Test plan
- [x] Missing node returns `0` (not `None`)
- [x] Missing edge returns `0` (not `None`)
- [x] Existing nodes/edges return correct degree
- [x] Return type is always `int`
- [x] `None` batch result handled gracefully
- [x] All 10 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)