### PR TITLE
fix(setup): preserve storage images on compose rewrites

### DIFF
--- a/scripts/setup/lib/file_ops.sh
+++ b/scripts/setup/lib/file_ops.sh
@@ -905,6 +905,8 @@ read_service_environment_value() {
   return 1
 }
 
+# Parse the image: value for a named service from a compose file.
+# Assumes wizard-standard indentation: services at 2 spaces, properties at 4 spaces.
 read_service_image_value() {
   local compose_file="$1"
   local service_name="$2"

--- a/scripts/setup/lib/file_ops.sh
+++ b/scripts/setup/lib/file_ops.sh
@@ -905,6 +905,39 @@ read_service_environment_value() {
   return 1
 }
 
+read_service_image_value() {
+  local compose_file="$1"
+  local service_name="$2"
+  local line
+  local service_header="  ${service_name}:"
+  local in_service="no"
+
+  if [[ ! -f "$compose_file" ]]; then
+    return 1
+  fi
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$in_service" == "yes" ]]; then
+      if [[ "$line" =~ ^[[:space:]]{4}image:[[:space:]]*(.+)$ ]]; then
+        printf '%s' "${BASH_REMATCH[1]}"
+        return 0
+      fi
+
+      if [[ "$line" =~ ^[[:space:]]{2}[^[:space:]] && "$line" != "$service_header" ]]; then
+        in_service="no"
+      elif [[ "$line" =~ ^[^[:space:]] ]]; then
+        in_service="no"
+      fi
+    fi
+
+    if [[ "$line" == "$service_header" ]]; then
+      in_service="yes"
+    fi
+  done < "$compose_file"
+
+  return 1
+}
+
 _extract_named_volume_name() {
   local mount_spec="$1"
   local source=""
@@ -1263,6 +1296,13 @@ generate_docker_compose() {
       vllm-embed)
         ;;
     esac
+
+    if [[ -n "${COMPOSE_SERVICE_IMAGE_OVERRIDES[$service]+set}" ]]; then
+      inject_service_image_override \
+        "$service_blocks_file" \
+        "$service" \
+        "${COMPOSE_SERVICE_IMAGE_OVERRIDES[$service]}"
+    fi
   done
 
   _merge_managed_service_blocks "$tmp_file" "$service_blocks_file"
@@ -1565,6 +1605,65 @@ inject_service_environment_overrides() {
       printf '    environment:\n' >> "$tmp_file"
     fi
     _write_service_environment_entries "$tmp_file" "$environment_style" "${entries[@]}"
+  fi
+
+  mv "$tmp_file" "$compose_file"
+}
+
+inject_service_image_override() {
+  local compose_file="$1"
+  local service_name="$2"
+  local image_value="$3"
+  local tmp_file="${compose_file}.${service_name}.image"
+  _FILE_OPS_CLEANUP_TMP+=("$tmp_file")
+  local line
+  local in_service="no"
+  local inserted="no"
+  local service_header="  ${service_name}:"
+
+  if [[ -z "$image_value" || ! -f "$compose_file" ]]; then
+    return 0
+  fi
+
+  : > "$tmp_file"
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$in_service" == "yes" ]]; then
+      if [[ "$line" =~ ^[[:space:]]{4}image:[[:space:]]*.+$ ]]; then
+        printf '    image: %s\n' "$image_value" >> "$tmp_file"
+        inserted="yes"
+        continue
+      fi
+
+      if [[ "$inserted" == "no" && "$line" =~ ^[[:space:]]{4}[^[:space:]] ]]; then
+        printf '    image: %s\n' "$image_value" >> "$tmp_file"
+        inserted="yes"
+      fi
+
+      if [[ "$line" =~ ^[[:space:]]{2}[^[:space:]] && "$line" != "$service_header" ]]; then
+        if [[ "$inserted" == "no" ]]; then
+          printf '    image: %s\n' "$image_value" >> "$tmp_file"
+          inserted="yes"
+        fi
+        in_service="no"
+      elif [[ "$line" =~ ^[^[:space:]] ]]; then
+        if [[ "$inserted" == "no" ]]; then
+          printf '    image: %s\n' "$image_value" >> "$tmp_file"
+          inserted="yes"
+        fi
+        in_service="no"
+      fi
+    fi
+
+    printf '%s\n' "$line" >> "$tmp_file"
+
+    if [[ "$line" == "$service_header" ]]; then
+      in_service="yes"
+    fi
+  done < "$compose_file"
+
+  if [[ "$in_service" == "yes" && "$inserted" == "no" ]]; then
+    printf '    image: %s\n' "$image_value" >> "$tmp_file"
   fi
 
   mv "$tmp_file" "$compose_file"

--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -814,6 +814,9 @@ collect_preserved_storage_service_images() {
     return 0
   fi
 
+  # Only postgres and neo4j are wizard-managed Docker storage services that users
+  # commonly pin to custom registry images. If new storage backends are added as
+  # wizard-managed Docker services, extend this list accordingly.
   for service_name in postgres neo4j; do
     if [[ -z "${COMPOSE_REWRITE_SERVICE_SET[$service_name]+set}" ]] || \
       [[ -z "${DOCKER_SERVICE_SET[$service_name]+set}" ]] || \
@@ -2803,6 +2806,7 @@ finalize_server_setup() {
     if ! prepare_managed_service_assets_for_compose "$existing_compose"; then
       return 1
     fi
+    collect_preserved_storage_service_images "$existing_compose"
     prepare_compose_env_overrides
   elif [[ "$compose_action" == "delete_compose_and_switch_host" ]]; then
     backup_existing_compose_for_action "$compose_action" "$existing_compose" || return 1

--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -17,6 +17,7 @@ declare -A ENV_VALUES
 declare -A ORIGINAL_ENV_VALUES
 declare -A COMPOSE_ENV_OVERRIDES
 declare -A COMPOSE_REWRITE_SERVICE_SET
+declare -A COMPOSE_SERVICE_IMAGE_OVERRIDES
 declare -A REQUIRED_DB_TYPES
 declare -A DOCKER_SERVICE_SET
 declare -A EXISTING_MANAGED_ROOT_SERVICE_SET
@@ -102,6 +103,7 @@ reset_state() {
   ORIGINAL_ENV_VALUES=()
   COMPOSE_ENV_OVERRIDES=()
   COMPOSE_REWRITE_SERVICE_SET=()
+  COMPOSE_SERVICE_IMAGE_OVERRIDES=()
   REQUIRED_DB_TYPES=()
   DOCKER_SERVICE_SET=()
   EXISTING_MANAGED_ROOT_SERVICE_SET=()
@@ -799,6 +801,31 @@ record_existing_managed_root_services() {
       EXISTING_MANAGED_ROOT_SERVICE_SET["$root_service"]=1
     fi
   done < <(detect_managed_root_services "$compose_file")
+}
+
+collect_preserved_storage_service_images() {
+  local compose_file="${1:-}"
+  local service_name=""
+  local image_value=""
+
+  COMPOSE_SERVICE_IMAGE_OVERRIDES=()
+
+  if [[ "$FORCE_REWRITE_COMPOSE" == "yes" || -z "$compose_file" || ! -f "$compose_file" ]]; then
+    return 0
+  fi
+
+  for service_name in postgres neo4j; do
+    if [[ -z "${COMPOSE_REWRITE_SERVICE_SET[$service_name]+set}" ]] || \
+      [[ -z "${DOCKER_SERVICE_SET[$service_name]+set}" ]] || \
+      ! existing_managed_root_service_present "$service_name"; then
+      continue
+    fi
+
+    image_value="$(read_service_image_value "$compose_file" "$service_name" || true)"
+    if [[ -n "$image_value" ]]; then
+      COMPOSE_SERVICE_IMAGE_OVERRIDES["$service_name"]="$image_value"
+    fi
+  done
 }
 
 backup_existing_compose_if_generating() {
@@ -2524,6 +2551,7 @@ finalize_base_setup() {
     if ! prepare_managed_service_assets_for_compose "$existing_compose"; then
       return 1
     fi
+    collect_preserved_storage_service_images "$existing_compose"
     prepare_compose_env_overrides
   elif [[ "$compose_action" == "delete_compose_and_switch_host" ]]; then
     backup_existing_compose_for_action "$compose_action" "$existing_compose" || return 1
@@ -2654,6 +2682,7 @@ finalize_storage_setup() {
     if ! prepare_managed_service_assets_for_compose "$existing_compose"; then
       return 1
     fi
+    collect_preserved_storage_service_images "$existing_compose"
     prepare_compose_env_overrides
   elif [[ "$compose_action" == "delete_compose_and_switch_host" ]]; then
     backup_existing_compose_for_action "$compose_action" "$existing_compose" || return 1

--- a/tests/test_interactive_setup_outputs.py
+++ b/tests/test_interactive_setup_outputs.py
@@ -3937,6 +3937,60 @@ finalize_base_setup
     assert "      milvus-minio:\n        condition: service_healthy" not in result
 
 
+def test_env_base_flow_preserves_existing_storage_images_on_rerun(
+    tmp_path: Path,
+) -> None:
+    """env-base should preserve postgres and neo4j images from an existing compose rerun."""
+
+    write_storage_setup_files(
+        tmp_path,
+        [
+            "LLM_BINDING=openai",
+            "EMBEDDING_BINDING=openai",
+            "LIGHTRAG_SETUP_POSTGRES_DEPLOYMENT=docker",
+            "LIGHTRAG_SETUP_NEO4J_DEPLOYMENT=docker",
+        ],
+        [
+            "services:",
+            "  lightrag:",
+            "    image: example/lightrag:test",
+            "  postgres:",
+            "    image: registry.example.com/postgres-for-rag:patched",
+            "  neo4j:",
+            "    image: registry.example.com/neo4j:custom",
+        ],
+    )
+
+    run_bash(
+        f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+
+host_cuda_available() {{ return 1; }}
+collect_llm_config() {{ :; }}
+collect_embedding_config() {{ :; }}
+confirm_default_no() {{ return 1; }}
+confirm_default_yes() {{
+  case "$1" in
+    *"The compose file will be created/updated. Continue?"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}}
+confirm_required_yes_no() {{ return 0; }}
+validate_sensitive_env_literals() {{ return 0; }}
+validate_mongo_vector_storage_config() {{ return 0; }}
+
+env_base_flow
+"""
+    )
+
+    result = (tmp_path / "docker-compose.final.yml").read_text(encoding="utf-8")
+
+    assert "image: registry.example.com/postgres-for-rag:patched" in result
+    assert "image: registry.example.com/neo4j:custom" in result
+
+
 def test_finalize_base_setup_migrates_mongodb_to_atlas_local_for_mongo_vector_storage(
     tmp_path: Path,
 ) -> None:
@@ -7340,6 +7394,54 @@ finalize_server_setup
 
     assert 'NEO4J_URI: "neo4j://neo4j:7687"' in result
     assert 'NEO4J_URI: "neo4j://host.docker.internal:7687"' not in result
+
+
+def test_env_server_flow_preserves_existing_storage_images_on_rerun(
+    tmp_path: Path,
+) -> None:
+    """env-server should preserve postgres and neo4j images from an existing compose rerun."""
+
+    write_storage_setup_files(
+        tmp_path,
+        [
+            "LLM_BINDING=openai",
+            "EMBEDDING_BINDING=openai",
+            "LIGHTRAG_SETUP_POSTGRES_DEPLOYMENT=docker",
+            "LIGHTRAG_SETUP_NEO4J_DEPLOYMENT=docker",
+        ],
+        [
+            "services:",
+            "  lightrag:",
+            "    image: example/lightrag:test",
+            "  postgres:",
+            "    image: registry.example.com/postgres-for-rag:patched",
+            "  neo4j:",
+            "    image: registry.example.com/neo4j:custom",
+        ],
+    )
+
+    run_bash(
+        f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+
+collect_server_config() {{ :; }}
+collect_security_config() {{ :; }}
+collect_ssl_config() {{ :; }}
+confirm_required_yes_no() {{ return 0; }}
+validate_sensitive_env_literals() {{ return 0; }}
+validate_auth_accounts_runtime_config() {{ return 0; }}
+validate_mongo_vector_storage_config() {{ return 0; }}
+
+env_server_flow
+"""
+    )
+
+    result = (tmp_path / "docker-compose.final.yml").read_text(encoding="utf-8")
+
+    assert "image: registry.example.com/postgres-for-rag:patched" in result
+    assert "image: registry.example.com/neo4j:custom" in result
 
 
 def test_finalize_server_setup_migrates_mongodb_to_atlas_local_for_mongo_vector_storage(

--- a/tests/test_interactive_setup_outputs.py
+++ b/tests/test_interactive_setup_outputs.py
@@ -7396,10 +7396,78 @@ finalize_server_setup
     assert 'NEO4J_URI: "neo4j://host.docker.internal:7687"' not in result
 
 
-def test_env_server_flow_preserves_existing_storage_images_on_rerun(
+def test_env_server_flow_preserves_existing_storage_images_on_compose_rewrite(
     tmp_path: Path,
 ) -> None:
-    """env-server should preserve postgres and neo4j images from an existing compose rerun."""
+    """env-server should preserve postgres and neo4j images when a compose rewrite is triggered."""
+
+    # Changing PORT causes resolve_compose_output_action to return rewrite_compose,
+    # exercising the collect_preserved_storage_service_images call in finalize_server_setup.
+    original_compose_lines = [
+        "services:",
+        "  lightrag:",
+        "    image: example/lightrag:test",
+        "    environment:",
+        '      PORT: "9621"',
+        "  postgres:",
+        "    image: registry.example.com/postgres-for-rag:patched",
+        "  neo4j:",
+        "    image: registry.example.com/neo4j:custom",
+    ]
+    original_compose_content = "\n".join(original_compose_lines) + "\n"
+
+    write_storage_setup_files(
+        tmp_path,
+        [
+            "LLM_BINDING=openai",
+            "EMBEDDING_BINDING=openai",
+            "HOST=0.0.0.0",
+            "PORT=9621",
+            "LIGHTRAG_SETUP_POSTGRES_DEPLOYMENT=docker",
+            "LIGHTRAG_SETUP_NEO4J_DEPLOYMENT=docker",
+        ],
+        original_compose_lines,
+    )
+
+    run_bash(
+        f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+
+collect_server_config() {{
+  ENV_VALUES[HOST]="0.0.0.0"
+  ENV_VALUES[PORT]="8080"
+}}
+collect_security_config() {{ :; }}
+collect_ssl_config() {{ :; }}
+confirm_default_yes() {{
+  case "$1" in
+    "All wizard-managed services have been removed. Remove LightRAG from Docker and switch to host mode?") return 1 ;;
+    *) return 0 ;;
+  esac
+}}
+confirm_required_yes_no() {{ return 0; }}
+validate_sensitive_env_literals() {{ return 0; }}
+validate_auth_accounts_runtime_config() {{ return 0; }}
+validate_mongo_vector_storage_config() {{ return 0; }}
+
+env_server_flow
+"""
+    )
+
+    result = (tmp_path / "docker-compose.final.yml").read_text(encoding="utf-8")
+
+    # Confirm the compose rewrite path was taken (a backup of the original must exist).
+    assert_single_compose_backup(tmp_path, expected_content=original_compose_content)
+    assert "image: registry.example.com/postgres-for-rag:patched" in result
+    assert "image: registry.example.com/neo4j:custom" in result
+
+
+def test_env_server_flow_preserves_existing_storage_images_on_env_only_rerun(
+    tmp_path: Path,
+) -> None:
+    """env-server write_env_only path should leave custom storage images untouched."""
 
     write_storage_setup_files(
         tmp_path,

--- a/tests/test_interactive_setup_outputs.py
+++ b/tests/test_interactive_setup_outputs.py
@@ -82,6 +82,19 @@ def assert_single_compose_backup(tmp_path: Path, expected_content: str) -> Path:
     return backups[0]
 
 
+def write_storage_setup_files(
+    tmp_path: Path, env_lines: list[str], compose_lines: list[str]
+) -> None:
+    """Write the minimal env/example/compose fixtures used by storage-flow tests."""
+
+    write_text_lines(tmp_path / ".env", env_lines)
+    write_text_lines(
+        tmp_path / "env.example",
+        (REPO_ROOT / "env.example").read_text(encoding="utf-8").splitlines(),
+    )
+    write_text_lines(tmp_path / "docker-compose.final.yml", compose_lines)
+
+
 def test_collect_postgres_config_uses_fixed_bundled_port_and_compose_overrides() -> (
     None
 ):
@@ -5536,6 +5549,322 @@ fi
     values = parse_lines(output)
 
     assert values["REWRITE"] == expected_rewrite
+
+
+def test_env_storage_flow_preserves_existing_postgres_image_during_rewrite(
+    tmp_path: Path,
+) -> None:
+    """Postgres env rewrites should keep an existing custom image."""
+
+    write_storage_setup_files(
+        tmp_path,
+        [
+            "LLM_BINDING=openai",
+            "EMBEDDING_BINDING=openai",
+            "POSTGRES_USER=rag",
+            "POSTGRES_PASSWORD=rag",
+            "POSTGRES_DATABASE=rag",
+        ],
+        [
+            "services:",
+            "  lightrag:",
+            "    image: example/lightrag:test",
+            "  postgres:",
+            "    image: registry.example.com/postgres-for-rag:patched",
+        ],
+    )
+
+    run_bash(
+        f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+
+select_storage_backends() {{
+  REQUIRED_DB_TYPES[postgresql]=1
+  ENV_VALUES[LIGHTRAG_KV_STORAGE]="PGKVStorage"
+  ENV_VALUES[LIGHTRAG_VECTOR_STORAGE]="PGVectorStorage"
+  ENV_VALUES[LIGHTRAG_GRAPH_STORAGE]="PGGraphStorage"
+  ENV_VALUES[LIGHTRAG_DOC_STATUS_STORAGE]="PGDocStatusStorage"
+}}
+collect_database_config() {{
+  if [[ "$1" == "postgresql" ]]; then
+    add_docker_service "postgres"
+    ENV_VALUES[POSTGRES_USER]="updated-user"
+  fi
+}}
+validate_required_variables() {{ return 0; }}
+validate_mongo_vector_storage_config() {{ return 0; }}
+validate_sensitive_env_literals() {{ return 0; }}
+confirm_required_yes_no() {{ return 0; }}
+
+env_storage_flow
+"""
+    )
+
+    result = (tmp_path / "docker-compose.final.yml").read_text(encoding="utf-8")
+
+    assert "image: registry.example.com/postgres-for-rag:patched" in result
+    assert 'POSTGRES_USER: "updated-user"' in result
+    assert 'POSTGRES_DB: "rag"' in result
+
+
+def test_env_storage_flow_preserves_existing_neo4j_image_during_rewrite(
+    tmp_path: Path,
+) -> None:
+    """Neo4j database rewrites should keep an existing custom image."""
+
+    write_storage_setup_files(
+        tmp_path,
+        [
+            "LLM_BINDING=openai",
+            "EMBEDDING_BINDING=openai",
+            "NEO4J_USERNAME=neo4j",
+            "NEO4J_PASSWORD=neo4j-password",
+            "NEO4J_DATABASE=neo4j",
+        ],
+        [
+            "services:",
+            "  lightrag:",
+            "    image: example/lightrag:test",
+            "  neo4j:",
+            "    image: registry.example.com/neo4j:custom",
+        ],
+    )
+
+    run_bash(
+        f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+
+select_storage_backends() {{
+  REQUIRED_DB_TYPES[neo4j]=1
+  ENV_VALUES[LIGHTRAG_KV_STORAGE]="JsonKVStorage"
+  ENV_VALUES[LIGHTRAG_VECTOR_STORAGE]="NanoVectorDBStorage"
+  ENV_VALUES[LIGHTRAG_GRAPH_STORAGE]="Neo4JStorage"
+  ENV_VALUES[LIGHTRAG_DOC_STATUS_STORAGE]="JsonDocStatusStorage"
+}}
+collect_database_config() {{
+  if [[ "$1" == "neo4j" ]]; then
+    add_docker_service "neo4j"
+    ENV_VALUES[NEO4J_DATABASE]="updated-database"
+  fi
+}}
+validate_required_variables() {{ return 0; }}
+validate_mongo_vector_storage_config() {{ return 0; }}
+validate_sensitive_env_literals() {{ return 0; }}
+confirm_required_yes_no() {{ return 0; }}
+
+env_storage_flow
+"""
+    )
+
+    result = (tmp_path / "docker-compose.final.yml").read_text(encoding="utf-8")
+
+    assert "image: registry.example.com/neo4j:custom" in result
+    assert 'NEO4J_dbms_default__database: "updated-database"' in result
+
+
+def test_env_storage_flow_preserves_existing_postgres_and_neo4j_images_on_rewrite(
+    tmp_path: Path,
+) -> None:
+    """Concurrent postgres and neo4j rewrites should preserve both custom images."""
+
+    write_storage_setup_files(
+        tmp_path,
+        [
+            "LLM_BINDING=openai",
+            "EMBEDDING_BINDING=openai",
+            "POSTGRES_USER=rag",
+            "POSTGRES_PASSWORD=rag",
+            "POSTGRES_DATABASE=rag",
+            "NEO4J_USERNAME=neo4j",
+            "NEO4J_PASSWORD=neo4j-password",
+            "NEO4J_DATABASE=neo4j",
+        ],
+        [
+            "services:",
+            "  lightrag:",
+            "    image: example/lightrag:test",
+            "  postgres:",
+            "    image: registry.example.com/postgres-for-rag:patched",
+            "  neo4j:",
+            "    image: registry.example.com/neo4j:custom",
+        ],
+    )
+
+    run_bash(
+        f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+
+select_storage_backends() {{
+  REQUIRED_DB_TYPES[postgresql]=1
+  REQUIRED_DB_TYPES[neo4j]=1
+  ENV_VALUES[LIGHTRAG_KV_STORAGE]="PGKVStorage"
+  ENV_VALUES[LIGHTRAG_VECTOR_STORAGE]="PGVectorStorage"
+  ENV_VALUES[LIGHTRAG_GRAPH_STORAGE]="Neo4JStorage"
+  ENV_VALUES[LIGHTRAG_DOC_STATUS_STORAGE]="PGDocStatusStorage"
+}}
+collect_database_config() {{
+  case "$1" in
+    postgresql)
+      add_docker_service "postgres"
+      ENV_VALUES[POSTGRES_USER]="updated-user"
+      ;;
+    neo4j)
+      add_docker_service "neo4j"
+      ENV_VALUES[NEO4J_DATABASE]="updated-database"
+      ;;
+  esac
+}}
+validate_required_variables() {{ return 0; }}
+validate_mongo_vector_storage_config() {{ return 0; }}
+validate_sensitive_env_literals() {{ return 0; }}
+confirm_required_yes_no() {{ return 0; }}
+
+env_storage_flow
+"""
+    )
+
+    result = (tmp_path / "docker-compose.final.yml").read_text(encoding="utf-8")
+
+    assert "image: registry.example.com/postgres-for-rag:patched" in result
+    assert "image: registry.example.com/neo4j:custom" in result
+    assert 'POSTGRES_USER: "updated-user"' in result
+    assert 'NEO4J_dbms_default__database: "updated-database"' in result
+
+
+def test_env_storage_flow_uses_template_image_when_existing_service_has_no_image(
+    tmp_path: Path,
+) -> None:
+    """A rewritten service without an existing image should fall back to the template image."""
+
+    write_storage_setup_files(
+        tmp_path,
+        [
+            "LLM_BINDING=openai",
+            "EMBEDDING_BINDING=openai",
+            "POSTGRES_USER=rag",
+            "POSTGRES_PASSWORD=rag",
+            "POSTGRES_DATABASE=rag",
+        ],
+        [
+            "services:",
+            "  lightrag:",
+            "    image: example/lightrag:test",
+            "  postgres:",
+            "    environment:",
+            '      LEGACY_SETTING: "1"',
+        ],
+    )
+
+    run_bash(
+        f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+
+select_storage_backends() {{
+  REQUIRED_DB_TYPES[postgresql]=1
+  ENV_VALUES[LIGHTRAG_KV_STORAGE]="PGKVStorage"
+  ENV_VALUES[LIGHTRAG_VECTOR_STORAGE]="PGVectorStorage"
+  ENV_VALUES[LIGHTRAG_GRAPH_STORAGE]="PGGraphStorage"
+  ENV_VALUES[LIGHTRAG_DOC_STATUS_STORAGE]="PGDocStatusStorage"
+}}
+collect_database_config() {{
+  if [[ "$1" == "postgresql" ]]; then
+    add_docker_service "postgres"
+    ENV_VALUES[POSTGRES_USER]="updated-user"
+  fi
+}}
+validate_required_variables() {{ return 0; }}
+validate_mongo_vector_storage_config() {{ return 0; }}
+validate_sensitive_env_literals() {{ return 0; }}
+confirm_required_yes_no() {{ return 0; }}
+
+env_storage_flow
+"""
+    )
+
+    result = (tmp_path / "docker-compose.final.yml").read_text(encoding="utf-8")
+
+    assert "image: gzdaniel/postgres-for-rag:16.6" in result
+    assert 'POSTGRES_USER: "updated-user"' in result
+
+
+def test_env_storage_flow_force_rewrite_drops_preserved_storage_images(
+    tmp_path: Path,
+) -> None:
+    """FORCE_REWRITE_COMPOSE should bypass preserved postgres and neo4j images."""
+
+    write_storage_setup_files(
+        tmp_path,
+        [
+            "LLM_BINDING=openai",
+            "EMBEDDING_BINDING=openai",
+            "POSTGRES_USER=rag",
+            "POSTGRES_PASSWORD=rag",
+            "POSTGRES_DATABASE=rag",
+            "NEO4J_USERNAME=neo4j",
+            "NEO4J_PASSWORD=neo4j-password",
+            "NEO4J_DATABASE=neo4j",
+        ],
+        [
+            "services:",
+            "  lightrag:",
+            "    image: example/lightrag:test",
+            "  postgres:",
+            "    image: registry.example.com/postgres-for-rag:patched",
+            "  neo4j:",
+            "    image: registry.example.com/neo4j:custom",
+        ],
+    )
+
+    run_bash(
+        f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+FORCE_REWRITE_COMPOSE="yes"
+
+select_storage_backends() {{
+  REQUIRED_DB_TYPES[postgresql]=1
+  REQUIRED_DB_TYPES[neo4j]=1
+  ENV_VALUES[LIGHTRAG_KV_STORAGE]="PGKVStorage"
+  ENV_VALUES[LIGHTRAG_VECTOR_STORAGE]="PGVectorStorage"
+  ENV_VALUES[LIGHTRAG_GRAPH_STORAGE]="Neo4JStorage"
+  ENV_VALUES[LIGHTRAG_DOC_STATUS_STORAGE]="PGDocStatusStorage"
+}}
+collect_database_config() {{
+  case "$1" in
+    postgresql)
+      add_docker_service "postgres"
+      ENV_VALUES[POSTGRES_USER]="updated-user"
+      ;;
+    neo4j)
+      add_docker_service "neo4j"
+      ENV_VALUES[NEO4J_DATABASE]="updated-database"
+      ;;
+  esac
+}}
+validate_required_variables() {{ return 0; }}
+validate_mongo_vector_storage_config() {{ return 0; }}
+validate_sensitive_env_literals() {{ return 0; }}
+confirm_required_yes_no() {{ return 0; }}
+
+env_storage_flow
+"""
+    )
+
+    result = (tmp_path / "docker-compose.final.yml").read_text(encoding="utf-8")
+
+    assert "image: gzdaniel/postgres-for-rag:16.6" in result
+    assert "image: neo4j:5-community" in result
+    assert "registry.example.com/postgres-for-rag:patched" not in result
+    assert "registry.example.com/neo4j:custom" not in result
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Preserve existing `postgres` and `neo4j` image values when `env_storage_flow` rewrites those services due to storage credential or database changes.

## Related Issues

n/a

## Changes Made

- preserve custom `image:` values for rewritten `postgres` and `neo4j` service blocks during storage setup reruns
- keep `FORCE_REWRITE_COMPOSE=yes` as a full overwrite path with no image preservation
- add regression coverage for postgres-only, neo4j-only, combined rewrite, template fallback, and force-rewrite behavior

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Local validation:
- `./scripts/test.sh tests/test_interactive_setup_outputs.py -k 'preserves_existing_postgres_image_during_rewrite or preserves_existing_neo4j_image_during_rewrite or preserves_existing_postgres_and_neo4j_images_on_rewrite or uses_template_image_when_existing_service_has_no_image or force_rewrite_drops_preserved_storage_images or configure_storage_compose_rewrites_only_rewrites_neo4j_on_database_change or configure_storage_compose_rewrites_only_rewrites_postgres_for_service_env_changes'`
- `bash -n scripts/setup/setup.sh && bash -n scripts/setup/lib/file_ops.sh`
- `python3 -m py_compile tests/test_interactive_setup_outputs.py`
