### PR TITLE
feat(embeddings): added embedding support for providers that don't support base64 encoding (e.g. Yandex Cloud)

### DIFF
--- a/env.example
+++ b/env.example
@@ -347,6 +347,9 @@ OLLAMA_LLM_NUM_CTX=32768
 ###    For OpenAI: Set EMBEDDING_SEND_DIM=true to enable dynamic dimension adjustment
 ###    For OpenAI: Set EMBEDDING_SEND_DIM=false (default) to disable sending dimension parameter
 ###    For Gemini: Allways set EMBEDDING_SEND_DIM=true
+### Control whether to use base64 encoding format for embeddings (improves performance for OpenAI)
+###    For OpenAI: Set EMBEDDING_USE_BASE64=true (default) to use base64 encoding
+###    For Yandex Cloud and other providers that don't support it: Set EMBEDDING_USE_BASE64=false
 #######################################################################################
 # EMBEDDING_TIMEOUT=30
 
@@ -358,6 +361,7 @@ EMBEDDING_MODEL=text-embedding-3-large
 EMBEDDING_DIM=3072
 EMBEDDING_TOKEN_LIMIT=8192
 EMBEDDING_SEND_DIM=false
+# EMBEDDING_USE_BASE64=true
 
 ### Optional for Azure Embedding
 ### Use deployment name as model name or set AZURE_EMBEDDING_DEPLOYMENT instead

--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -831,8 +831,13 @@ async def openai_embed(
         api_params = {
             "model": api_model,
             "input": texts,
-            "encoding_format": "base64",
         }
+
+        # Add encoding_format parameter (some providers like Yandex don't support base64)
+        # OpenAI client defaults to base64, so we must explicitly set it to "float" if disabled
+        use_base64_env = os.getenv("EMBEDDING_USE_BASE64", "true")
+        use_base64 = use_base64_env.lower() in ("true", "1", "yes")
+        api_params["encoding_format"] = "base64" if use_base64 else "float"
 
         # Add dimensions parameter only if embedding_dim is provided
         if embedding_dim is not None:


### PR DESCRIPTION
<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description
feat(embeddings): added embedding support for providers that don't support base64 encoding (e.g. Yandex Cloud)

## Changes Made
Add EMBEDDING_USE_BASE64 environment variable to support OpenAI-compatible embedding providers (like Yandex Cloud) that don't accept the encoding_format parameter set to "base64".

Changes:
- Add EMBEDDING_USE_BASE64 config option (defaults to "true" for backward compatibility)
- Set encoding_format to "float" when EMBEDDING_USE_BASE64=false
- Update env.example with documentation for the new option

The existing response handling code already supports both base64 and float formats, so no changes were needed there.

This fix allows LightRAG to work with Yandex Cloud Foundation Models and other OpenAI-compatible providers that reject base64-encoded embeddings.

## Checklist
- [ +] Changes tested locally
- [ +] Code reviewed
- [ +] Documentation updated (if necessary)
- [ -] Unit tests added (if applicable)