### PR TITLE
Fix local setup device prompt defaults and ordering

### DIFF
--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -23,17 +23,17 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
-      MILVUS_URI: "http://milvus:19530"
-      NEO4J_URI: "neo4j://neo4j:7687"
-      POSTGRES_HOST: "postgres"
-      POSTGRES_PORT: "5432"
-      EMBEDDING_BINDING_HOST: "http://vllm-embed:8001/v1"
-      RERANK_BINDING_HOST: "http://vllm-rerank:8000/rerank"
-      WORKING_DIR: "/app/data/rag_storage"
-      INPUT_DIR: "/app/data/inputs"
-      MEMGRAPH_URI: "bolt://host.docker.internal:7687"
       HOST: "0.0.0.0"
       PORT: "9621"
+      EMBEDDING_BINDING_HOST: "http://vllm-embed:8001/v1"
+      RERANK_BINDING_HOST: "http://vllm-rerank:8000/rerank"
+      POSTGRES_HOST: "postgres"
+      POSTGRES_PORT: "5432"
+      NEO4J_URI: "neo4j://neo4j:7687"
+      WORKING_DIR: "/app/data/rag_storage"
+      MILVUS_URI: "http://milvus:19530"
+      INPUT_DIR: "/app/data/inputs"
+      MEMGRAPH_URI: "bolt://host.docker.internal:7687"
     depends_on:
       vllm-embed:
         condition: service_healthy
@@ -45,6 +45,115 @@ services:
         condition: service_healthy
       milvus:
         condition: service_healthy
+
+  vllm-embed:
+    image: vllm/vllm-openai:latest
+    runtime: nvidia
+    command: >
+      --model ${VLLM_EMBED_MODEL:-BAAI/bge-m3}
+      --port ${VLLM_EMBED_PORT:-8001}
+      --dtype float16
+      --api-key ${VLLM_EMBED_API_KEY}
+      ${VLLM_EMBED_EXTRA_ARGS:-}
+    environment:
+      NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
+      NVIDIA_DRIVER_CAPABILITIES: ${NVIDIA_DRIVER_CAPABILITIES:-compute,utility}
+    ports:
+      - "${VLLM_EMBED_PORT:-8001}:${VLLM_EMBED_PORT:-8001}"
+    volumes:
+      - vllm_embed_cache:/root/.cache/huggingface
+    ipc: host
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - 'PORT_HEX="$(printf ''%04X'' ${VLLM_EMBED_PORT:-8001})"; cat /proc/net/tcp /proc/net/tcp6 2>/dev/null | grep -q ":$${PORT_HEX} "'
+      interval: 5s
+      timeout: 3s
+      retries: 120
+      start_period: 10s
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    restart: unless-stopped
+
+  vllm-rerank:
+    image: vllm/vllm-openai:latest
+    runtime: nvidia
+    command: >
+      --model ${VLLM_RERANK_MODEL:-BAAI/bge-reranker-v2-m3}
+      --port ${VLLM_RERANK_PORT:-8000}
+      --dtype float16
+      --api-key ${VLLM_RERANK_API_KEY}
+      ${VLLM_RERANK_EXTRA_ARGS:-}
+    environment:
+      NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
+      NVIDIA_DRIVER_CAPABILITIES: ${NVIDIA_DRIVER_CAPABILITIES:-compute,utility}
+    ports:
+      - "${VLLM_RERANK_PORT:-8000}:${VLLM_RERANK_PORT:-8000}"
+    volumes:
+      - vllm_rerank_cache:/root/.cache/huggingface
+    ipc: host
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - 'PORT_HEX="$(printf ''%04X'' ${VLLM_RERANK_PORT:-8000})"; cat /proc/net/tcp /proc/net/tcp6 2>/dev/null | grep -q ":$${PORT_HEX} "'
+      interval: 5s
+      timeout: 3s
+      retries: 120
+      start_period: 10s
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    restart: unless-stopped
+
+  postgres:
+    # this image does not support PGGraphStorage
+    image: pgvector/pgvector:pg18
+    # ports:
+    #   - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - 'PORT_HEX="$(printf ''%04X'' 5432)"; cat /proc/net/tcp /proc/net/tcp6 2>/dev/null | grep -q ":$${PORT_HEX} "'
+      interval: 5s
+      timeout: 3s
+      retries: 120
+      start_period: 10s
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: "rag"
+      POSTGRES_PASSWORD: "rag"
+      POSTGRES_DB: "rag"
+
+  neo4j:
+    image: neo4j:5-community
+    # ports:
+    #   - "7474:7474"
+    #   - "${NEO4J_BOLT_PORT:-7687}:7687"
+    volumes:
+      - neo4j_data:/data
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - 'PORT_HEX="$(printf ''%04X'' 7687)"; cat /proc/net/tcp /proc/net/tcp6 2>/dev/null | grep -q ":$${PORT_HEX} "'
+      interval: 10s
+      timeout: 3s
+      retries: 120
+      start_period: 10s
+    restart: unless-stopped
+    environment:
+      NEO4J_AUTH: ${NEO4J_USERNAME:?missing}/${NEO4J_PASSWORD:?missing}
+      NEO4J_dbms_default__database: "neo4j"
 
   milvus:
     image: milvusdb/milvus:v2.6.11-gpu
@@ -118,121 +227,11 @@ services:
       retries: 3
     restart: unless-stopped
 
-  neo4j:
-    image: neo4j:5-community
-    # ports:
-    #   - "7474:7474"
-    #   - "${NEO4J_BOLT_PORT:-7687}:7687"
-    volumes:
-      - neo4j_data:/data
-    healthcheck:
-      test:
-        - CMD-SHELL
-        - 'PORT_HEX="$(printf ''%04X'' 7687)"; cat /proc/net/tcp /proc/net/tcp6 2>/dev/null | grep -q ":$${PORT_HEX} "'
-      interval: 10s
-      timeout: 3s
-      retries: 120
-      start_period: 10s
-    restart: unless-stopped
-    environment:
-      NEO4J_AUTH: ${NEO4J_USERNAME:?missing}/${NEO4J_PASSWORD:?missing}
-      NEO4J_dbms_default__database: "neo4j"
-
-  postgres:
-    image: gzdaniel/postgres-for-rag:16.6
-    command: ["sh", "-c", "service postgresql start && sleep infinity"]
-    # ports:
-    #   - "5432:5432"
-    volumes:
-      - postgres_data:/var/lib/postgresql
-    healthcheck:
-      test:
-        - CMD-SHELL
-        - 'PORT_HEX="$(printf ''%04X'' 5432)"; cat /proc/net/tcp /proc/net/tcp6 2>/dev/null | grep -q ":$${PORT_HEX} "'
-      interval: 5s
-      timeout: 3s
-      retries: 120
-      start_period: 10s
-    restart: unless-stopped
-    environment:
-      # The custom image featuring pre-installed AGE and pgvector extensions, including a pre-configured administrator account
-      POSTGRES_USER: "rag"
-      POSTGRES_PASSWORD: "rag"
-      POSTGRES_DB: "rag"
-
-  vllm-embed:
-    image: vllm/vllm-openai:latest
-    runtime: nvidia
-    command: >
-      --model ${VLLM_EMBED_MODEL:-BAAI/bge-m3}
-      --port ${VLLM_EMBED_PORT:-8001}
-      --dtype float16
-      --api-key ${VLLM_EMBED_API_KEY}
-      ${VLLM_EMBED_EXTRA_ARGS:-}
-    environment:
-      NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
-      NVIDIA_DRIVER_CAPABILITIES: ${NVIDIA_DRIVER_CAPABILITIES:-compute,utility}
-    ports:
-      - "${VLLM_EMBED_PORT:-8001}:${VLLM_EMBED_PORT:-8001}"
-    volumes:
-      - vllm_embed_cache:/root/.cache/huggingface
-    ipc: host
-    healthcheck:
-      test:
-        - CMD-SHELL
-        - 'PORT_HEX="$(printf ''%04X'' ${VLLM_EMBED_PORT:-8001})"; cat /proc/net/tcp /proc/net/tcp6 2>/dev/null | grep -q ":$${PORT_HEX} "'
-      interval: 5s
-      timeout: 3s
-      retries: 120
-      start_period: 10s
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
-    restart: unless-stopped
-
-  vllm-rerank:
-    image: vllm/vllm-openai:latest
-    runtime: nvidia
-    command: >
-      --model ${VLLM_RERANK_MODEL:-BAAI/bge-reranker-v2-m3}
-      --port ${VLLM_RERANK_PORT:-8000}
-      --dtype float16
-      --api-key ${VLLM_RERANK_API_KEY}
-      ${VLLM_RERANK_EXTRA_ARGS:-}
-    environment:
-      NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
-      NVIDIA_DRIVER_CAPABILITIES: ${NVIDIA_DRIVER_CAPABILITIES:-compute,utility}
-    ports:
-      - "${VLLM_RERANK_PORT:-8000}:${VLLM_RERANK_PORT:-8000}"
-    volumes:
-      - vllm_rerank_cache:/root/.cache/huggingface
-    ipc: host
-    healthcheck:
-      test:
-        - CMD-SHELL
-        - 'PORT_HEX="$(printf ''%04X'' ${VLLM_RERANK_PORT:-8000})"; cat /proc/net/tcp /proc/net/tcp6 2>/dev/null | grep -q ":$${PORT_HEX} "'
-      interval: 5s
-      timeout: 3s
-      retries: 120
-      start_period: 10s
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
-    restart: unless-stopped
-
 volumes:
+  vllm_embed_cache:
+  vllm_rerank_cache:
+  postgres_data:
+  neo4j_data:
   milvus_data:
   milvus-etcd_data:
   milvus-minio_data:
-  neo4j_data:
-  postgres_data:
-  vllm_embed_cache:
-  vllm_rerank_cache:

--- a/docs/DockerDeployment.md
+++ b/docs/DockerDeployment.md
@@ -231,8 +231,9 @@ This keeps generated host mounts under the same `./data` root used by the defaul
 
 ### PostgreSQL image
 
-The interactive setup defaults PostgreSQL to `gzdaniel/postgres-for-rag:16.6`.
-That image bundles both Apache AGE and pgvector so the generated stack works with `PGGraphStorage` and `PGVectorStorage` without extra extension setup.
+The interactive setup defaults PostgreSQL to `gzdaniel/postgres-for-rag:16.6`. This image bundles both Apache AGE and pgvector so the generated stack works with `PGGraphStorage` and `PGVectorStorage` without extra extension setup.
+
+**Important Note**: If PGGraphStorage is not required for vector storage, you may replace the upper docker image with the latest official pgvector image `pgvector/pgvector:pg18`. Please note that data file formats are incompatible across different PostgreSQL major versions; once this Docker image is deployed, it cannot be rolled back to a previous version.
 
 ### Updates
 

--- a/env.docker-compose-full
+++ b/env.docker-compose-full
@@ -1,0 +1,710 @@
+### All configurable environment variable must show up in this sample file in active or comment out status
+### Setup tool `make env-*` uses this file to generate final .env file
+### These are placeholders and setup tool should not be substituted with actual values in this lines.
+
+### Target environment of this env file: host/compose (compose is for Dokcer or Kubernetes)
+LIGHTRAG_RUNTIME_TARGET=compose
+
+###########################
+### Server Configuration
+###########################
+HOST=0.0.0.0
+PORT=9621
+WEBUI_TITLE='My Graph KB'
+WEBUI_DESCRIPTION='Simple and Fast Graph Based RAG System'
+# WORKERS=2
+### gunicorn worker timeout(as default LLM request timeout if LLM_TIMEOUT is not set)
+# TIMEOUT=150
+# CORS_ORIGINS=http://localhost:3000,http://localhost:8080
+
+### Optional SSL Configuration
+### Docker note: generated compose files mount staged certs at /app/data/certs/ inside the container
+# SSL=true
+# SSL_CERTFILE=/path/to/cert.pem
+# SSL_KEYFILE=/path/to/key.pem
+
+### Directory Configuration (defaults to current working directory)
+### Default value is ./inputs and ./rag_storage
+# INPUT_DIR=<absolute_path_for_doc_input_dir>
+# WORKING_DIR=<absolute_path_for_working_dir>
+
+### Tiktoken cache directory (Store cached files in this folder for offline deployment)
+# TIKTOKEN_CACHE_DIR=/app/data/tiktoken
+
+### Ollama Emulating Model and Tag
+# OLLAMA_EMULATING_MODEL_NAME=lightrag
+OLLAMA_EMULATING_MODEL_TAG=latest
+
+### Max nodes for graph retrieval (Ensure WebUI local settings are also updated, which is limited to this value)
+# MAX_GRAPH_NODES=1000
+
+### Logging level
+# LOG_LEVEL=INFO
+# VERBOSE=False
+# LOG_MAX_BYTES=10485760
+# LOG_BACKUP_COUNT=5
+### Logfile location (defaults to current working directory)
+# LOG_DIR=/path/to/log/directory
+# LIGHTRAG_PERFORMANCE_TIMING_LOGS=false
+
+#####################################
+### Login and API-Key Configuration
+#####################################
+# AUTH_ACCOUNTS='admin:admin123,user1:{bcrypt}$2b$12$S8Yu.gCbuAbNTJFB.231gegTwr5pgrFxc8H9kXQ4/sduFBHkhM8Ka'
+# TOKEN_SECRET=lightrag-jwt-default-secret-key!
+# JWT_ALGORITHM=HS256
+# TOKEN_EXPIRE_HOURS=48
+# GUEST_TOKEN_EXPIRE_HOURS=24
+
+### Token Auto-Renewal Configuration (Sliding Window Expiration)
+### Enable automatic token renewal to prevent active users from being logged out
+### When enabled, tokens will be automatically renewed when remaining time < threshold
+# TOKEN_AUTO_RENEW=true
+### Token renewal threshold (0.0 - 1.0)
+### Renew token when remaining time < (total time * threshold)
+### Default: 0.5 (renew when 50% time remaining)
+### Examples:
+###   0.5 = renew when 24h token has 12h left
+###   0.25 = renew when 24h token has 6h left
+# TOKEN_RENEW_THRESHOLD=0.5
+### Note: Token renewal is automatically skipped for certain endpoints:
+###   - /health: Health check endpoint (no authentication required)
+###   - /documents/paginated: Frequently polled by client (5-30s interval)
+###   - /documents/pipeline_status: Very frequently polled by client (2s interval)
+###   - Rate limit: Minimum 60 seconds between renewals for same user
+
+### API-Key to access LightRAG Server API
+### Use this key in HTTP requests with the 'X-API-Key' header
+### Example: curl -H "X-API-Key: your-secure-api-key-here" http://localhost:9621/query
+# LIGHTRAG_API_KEY=your-secure-api-key-here
+# WHITELIST_PATHS=/health,/api/*
+
+######################################################################################
+### Query Configuration
+###
+### How to control the context length sent to LLM:
+###    MAX_ENTITY_TOKENS + MAX_RELATION_TOKENS < MAX_TOTAL_TOKENS
+###    Chunk_Tokens = MAX_TOTAL_TOKENS - Actual_Entity_Tokens - Actual_Relation_Tokens
+######################################################################################
+# LLM response cache for query (Not valid for streaming response)
+# ENABLE_LLM_CACHE=true
+# COSINE_THRESHOLD=0.2
+### Number of entities or relations retrieved from KG
+# TOP_K=40
+### Maximum number or chunks for naive vector search
+# CHUNK_TOP_K=20
+### control the actual entities send to LLM
+# MAX_ENTITY_TOKENS=6000
+### control the actual relations send to LLM
+# MAX_RELATION_TOKENS=8000
+### control the maximum tokens send to LLM (include entities, relations and chunks)
+# MAX_TOTAL_TOKENS=30000
+
+### chunk selection strategies
+###     VECTOR: Pick KG chunks by vector similarity, delivered chunks to the LLM aligning more closely with naive retrieval
+###     WEIGHT: Pick KG chunks by entity and chunk weight, delivered more solely KG related chunks to the LLM
+###     If reranking is enabled, the impact of chunk selection strategies will be diminished.
+# KG_CHUNK_PICK_METHOD=VECTOR
+
+### maximum number of related chunks per source entity or relation
+###     The chunk picker uses this value to determine the total number of chunks selected from KG(knowledge graph)
+###     Higher values increase re-ranking time
+# RELATED_CHUNK_NUMBER=5
+
+#########################################################
+### Reranking configuration
+### RERANK_BINDING type: null, cohere, jina, aliyun
+### For rerank model deployed by vLLM use cohere binding
+### If LightRAG deployed in Docker:
+###    uses host.docker.internal instead of localhost in RERANK_BINDING_HOST
+#########################################################
+RERANK_BINDING=cohere
+# RERANK_BINDING=null
+RERANK_MODEL=BAAI/bge-reranker-v2-m3
+RERANK_BINDING_HOST=http://localhost:8000/rerank
+RERANK_BINDING_API_KEY=sk-your_rerank_api_key_here
+
+### rerank score chunk filter(set to 0.0 to keep all chunks, 0.6 or above if LLM is not strong enough)
+# MIN_RERANK_SCORE=0.0
+### Enable rerank by default in query params when RERANK_BINDING is not null
+# RERANK_BY_DEFAULT=True
+
+### Cohere AI
+# # RERANK_MODEL=rerank-v3.5
+# # RERANK_BINDING_HOST=https://api.cohere.com/v2/rerank
+# # RERANK_BINDING_API_KEY=your_rerank_api_key_here
+### Cohere rerank chunking configuration (useful for models with token limits like ColBERT)
+# RERANK_ENABLE_CHUNKING=true
+# RERANK_MAX_TOKENS_PER_DOC=480
+
+### Aliyun Dashscope
+# # RERANK_MODEL=gte-rerank-v2
+# # RERANK_BINDING_HOST=https://dashscope.aliyuncs.com/api/v1/services/rerank/text-rerank/text-rerank
+# # RERANK_BINDING_API_KEY=your_rerank_api_key_here
+
+### Jina AI
+# # RERANK_MODEL=jina-reranker-v2-base-multilingual
+# # RERANK_BINDING_HOST=https://api.jina.ai/v1/rerank
+# # RERANK_BINDING_API_KEY=your_rerank_api_key_here
+
+### For local deployment Embedding and Reranker with vLLM (OpenAI-compatible API)
+### Wizard metadata used to preserve the chosen deployment provider across setup reruns
+LIGHTRAG_SETUP_EMBEDDING_PROVIDER=vllm
+LIGHTRAG_SETUP_RERANK_PROVIDER=vllm
+VLLM_EMBED_MODEL=BAAI/bge-m3
+VLLM_EMBED_PORT=8001
+VLLM_EMBED_DEVICE=cuda
+### VLLM_EMBED_API_KEY is passed as --api-key to vLLM; synced to EMBEDDING_BINDING_API_KEY; auto-generated if blank
+VLLM_EMBED_API_KEY=sk-your_rerank_api_key_here
+# VLLM_EMBED_EXTRA_ARGS=
+VLLM_RERANK_MODEL=BAAI/bge-reranker-v2-m3
+VLLM_RERANK_PORT=8000
+VLLM_RERANK_DEVICE=cuda
+### VLLM_RERANK_API_KEY is passed as --api-key to vLLM; synced to RERANK_BINDING_API_KEY; auto-generated if blank
+VLLM_RERANK_API_KEY=sk-your_rerank_api_key_here
+### Use float16 for GPU mode. CPU mode uses the official vLLM CPU image.
+# VLLM_USE_CPU=1
+### Set to 1 for CPU mode, unset for GPU mode
+# CUDA_VISIBLE_DEVICES=-1
+### Set to -1 to disable CUDA (CPU mode), or specific GPU IDs for GPU mode
+# NVIDIA_VISIBLE_DEVICES=0
+### Optional Docker runtime equivalent; generated GPU compose honors either variable.
+# VLLM_RERANK_EXTRA_ARGS=
+
+########################################
+### Document processing configuration
+########################################
+ENABLE_LLM_CACHE_FOR_EXTRACT=true
+
+### Document processing output language: English, Chinese, French, German ...
+SUMMARY_LANGUAGE=English
+
+### File upload size limit (in bytes)
+### Default: 104857600 (100MB)
+### Set to 0 or None for unlimited upload size
+### Examples:
+###   52428800  = 50MB
+###   104857600 = 100MB (default)
+###   209715200 = 200MB
+### Note: If using Nginx as reverse proxy, also configure client_max_body_size
+# MAX_UPLOAD_SIZE=104857600
+
+### Entity types that the LLM will attempt to recognize
+# ENTITY_TYPES='["Person", "Creature", "Organization", "Location", "Event", "Concept", "Method", "Content", "Data", "Artifact", "NaturalObject"]'
+
+### Chunk size for document splitting, 500~1500 is recommended
+# CHUNK_SIZE=1200
+# CHUNK_OVERLAP_SIZE=100
+
+### Number of summary segments or tokens to trigger LLM summary on entity/relation merge (at least 3 is recommended)
+# FORCE_LLM_SUMMARY_ON_MERGE=8
+### Max description token size to trigger LLM summary
+# SUMMARY_MAX_TOKENS = 1200
+### Recommended LLM summary output length in tokens
+# SUMMARY_LENGTH_RECOMMENDED=600
+### Maximum context size sent to LLM for description summary
+# SUMMARY_CONTEXT_SIZE=12000
+### Maximum token size allowed for entity extraction input context
+# MAX_EXTRACT_INPUT_TOKENS=20480
+
+### control the maximum chunk_ids stored in vector and graph db
+# MAX_SOURCE_IDS_PER_ENTITY=300
+# MAX_SOURCE_IDS_PER_RELATION=300
+### control chunk_ids limitation method: FIFO, KEEP
+###    FIFO: First in first out
+###    KEEP: Keep oldest (less merge action and faster)
+# SOURCE_IDS_LIMIT_METHOD=FIFO
+
+# Maximum number of file paths stored in entity/relation file_path field (For displayed only, does not affect query performance)
+# MAX_FILE_PATHS=100
+
+### PDF decryption password for protected PDF files
+# PDF_DECRYPT_PASSWORD=your_pdf_password_here
+
+###############################
+### Concurrency Configuration
+###############################
+### Max concurrency requests of LLM (for both query and document processing)
+MAX_ASYNC=8
+# MAX_ASYNC=4
+### Number of parallel processing documents(between 2~10, MAX_ASYNC/3 is recommended)
+MAX_PARALLEL_INSERT=3
+# MAX_PARALLEL_INSERT=2
+### Max concurrency requests for Embedding
+# EMBEDDING_FUNC_MAX_ASYNC=8
+### Num of chunks send to Embedding in single request
+# EMBEDDING_BATCH_NUM=10
+
+###########################################################################
+### LLM Configuration
+### LLM_BINDING type: openai, ollama, lollms, azure_openai, aws_bedrock, gemini
+### LLM_BINDING_HOST: Service endpoint (left empty if using default endpoint provided by openai or gemini SDK)
+### LLM_BINDING_API_KEY: api key
+### If LightRAG deployed in Docker:
+###    uses host.docker.internal instead of localhost in LLM_BINDING_HOST
+###########################################################################
+### LLM request timeout setting for all llm (0 means no timeout for Ollma)
+# LLM_TIMEOUT=180
+
+LLM_BINDING=openai
+LLM_BINDING_HOST=https://api.openai.com/v1
+LLM_BINDING_API_KEY=your_api_key
+LLM_MODEL=gpt-5-mini
+
+### use the following command to see all support options for OpenAI, azure_openai or OpenRouter
+### lightrag-server --llm-binding openai --help
+### OpenAI Specific Parameters
+# OPENAI_LLM_REASONING_EFFORT=minimal
+### OpenRouter Specific Parameters
+# OPENAI_LLM_EXTRA_BODY='{"reasoning": {"enabled": false}}'
+### Qwen3 Specific Parameters deploy by vLLM
+# OPENAI_LLM_EXTRA_BODY='{"chat_template_kwargs": {"enable_thinking": false}}'
+
+### OpenAI Compatible API Specific Parameters
+### Increased temperature values may mitigate infinite inference loops in certain LLM, such as Qwen3-30B.
+# OPENAI_LLM_TEMPERATURE=0.9
+### Set the max_tokens to mitigate endless output of some LLM (less than LLM_TIMEOUT * llm_output_tokens/second, i.e. 9000 = 180s * 50 tokens/s)
+### Typically, max_tokens does not include prompt content
+### For vLLM/SGLang deployed models, or most of OpenAI compatible API provider
+# OPENAI_LLM_MAX_TOKENS=9000
+### For OpenAI o1-mini or newer modles utilizes max_completion_tokens instead of max_tokens
+# OPENAI_LLM_MAX_COMPLETION_TOKENS=9000
+
+### Azure OpenAI example
+### Use deployment name as model name or set AZURE_OPENAI_DEPLOYMENT instead
+# AZURE_OPENAI_API_VERSION=2024-08-01-preview
+# # LLM_BINDING=azure_openai
+# # LLM_BINDING_HOST=https://xxxx.openai.azure.com/
+# # LLM_BINDING_API_KEY=your_api_key
+# # LLM_MODEL=my-gpt-mini-deployment
+
+### Openrouter example
+# # LLM_BINDING=openai
+# # LLM_BINDING_HOST=https://openrouter.ai/api/v1
+# # LLM_BINDING_API_KEY=your_api_key
+# # LLM_MODEL=google/gemini-2.5-flash
+
+### Google Gemini example (AI Studio)
+# # LLM_BINDING=gemini
+# # LLM_BINDING_API_KEY=your_gemini_api_key
+# # LLM_BINDING_HOST=https://generativelanguage.googleapis.com
+# # LLM_MODEL=gemini-flash-latest
+
+### use the following command to see all support options for OpenAI, azure_openai or OpenRouter
+### lightrag-server --llm-binding gemini --help
+### Gemini Specific Parameters
+# GEMINI_LLM_MAX_OUTPUT_TOKENS=9000
+# GEMINI_LLM_TEMPERATURE=0.7
+### Enable or disable thinking
+# GEMINI_LLM_THINKING_CONFIG='{"thinking_budget": -1, "include_thoughts": true}'
+# # GEMINI_LLM_THINKING_CONFIG='{"thinking_budget": 0, "include_thoughts": false}'
+
+### Google Vertex AI example
+### Vertex AI use GOOGLE_APPLICATION_CREDENTIALS instead of API-KEY for authentication
+### LLM_BINDING_HOST=DEFAULT_GEMINI_ENDPOINT means select endpoit based on project and location automatically
+# # LLM_BINDING=gemini
+# # LM_BINDING_HOST=https://aiplatform.googleapis.com
+### or use DEFAULT_GEMINI_ENDPOINT to select endpoint based on project and location automatically
+# # LLM_BINDING_HOST=DEFAULT_GEMINI_ENDPOINT
+# # LLM_MODEL=gemini-2.5-flash
+# GOOGLE_GENAI_USE_VERTEXAI=true
+# GOOGLE_CLOUD_PROJECT='your-project-id'
+# GOOGLE_CLOUD_LOCATION='us-central1'
+# GOOGLE_APPLICATION_CREDENTIALS='/Users/xxxxx/your-service-account-credentials-file.json'
+
+### Ollama example
+# # LLM_BINDING=ollama
+# # LLM_BINDING_HOST=http://localhost:11434
+# # LLM_MODEL=qwen3.5:9b
+
+### use the following command to see all support options for Ollama LLM
+### lightrag-server --llm-binding ollama --help
+### Ollama Server Specific Parameters
+### OLLAMA_LLM_NUM_CTX must be provided, and should at least larger than MAX_TOTAL_TOKENS + 2000
+OLLAMA_LLM_NUM_CTX=32768
+### Set the max_output_tokens to mitigate endless output of some LLM (less than LLM_TIMEOUT * llm_output_tokens/second, i.e. 9000 = 180s * 50 tokens/s)
+# OLLAMA_LLM_NUM_PREDICT=9000
+# OLLAMA_LLM_TEMPERATURE=0.85
+### Stop sequences for Ollama LLM
+# OLLAMA_LLM_STOP='["</s>", "<|EOT|>"]'
+
+### Bedrock Specific Parameters
+### Bedrock uses AWS credentials from the environment / AWS credential chain.
+### It does not use LLM_BINDING_API_KEY.
+# # LLM_BINDING=aws_bedrock
+# # LLM_MODEL=anthropic.claude-3-5-sonnet-20241022-v2:0
+# AWS_ACCESS_KEY_ID=your_aws_access_key_id
+# AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
+# AWS_SESSION_TOKEN=your_optional_aws_session_token
+# AWS_REGION=us-east-1
+# BEDROCK_LLM_TEMPERATURE=1.0
+
+#######################################################################################
+### Embedding Configuration (Should not be changed after the first file processed)
+### EMBEDDING_BINDING: ollama, openai, azure_openai, jina, lollms, aws_bedrock
+### EMBEDDING_BINDING_HOST: Service endpoint (left empty if using default endpoint provided by openai or gemini SDK)
+### EMBEDDING_BINDING_API_KEY: api key
+### If LightRAG deployed in Docker:
+###    uses host.docker.internal instead of localhost in EMBEDDING_BINDING_HOST
+### Control whether to send embedding_dim parameter to embedding API
+###    For OpenAI: Set EMBEDDING_SEND_DIM=true to enable dynamic dimension adjustment
+###    For OpenAI: Set EMBEDDING_SEND_DIM=false (default) to disable sending dimension parameter
+###    For Gemini: Allways set EMBEDDING_SEND_DIM=true
+#######################################################################################
+# EMBEDDING_TIMEOUT=30
+
+### OpenAI compatible embedding
+EMBEDDING_BINDING=openai
+EMBEDDING_BINDING_HOST=http://localhost:8001/v1
+# EMBEDDING_BINDING_HOST=https://api.openai.com/v1
+EMBEDDING_BINDING_API_KEY=sk-your_api_key
+# EMBEDDING_BINDING_API_KEY=your_api_key
+EMBEDDING_MODEL=BAAI/bge-m3
+# EMBEDDING_MODEL=text-embedding-3-large
+EMBEDDING_DIM=1024
+# EMBEDDING_DIM=3072
+EMBEDDING_TOKEN_LIMIT=8192
+EMBEDDING_SEND_DIM=false
+
+### Optional for Azure Embedding
+### Use deployment name as model name or set AZURE_EMBEDDING_DEPLOYMENT instead
+# # EMBEDDING_BINDING=azure_openai
+# # EMBEDDING_BINDING_HOST=https://xxxx.openai.azure.com/
+# # EMBEDDING_API_KEY=your_api_key
+# # EMBEDDING_MODEL==my-text-embedding-3-large-deployment
+# # EMBEDDING_DIM=3072
+# AZURE_EMBEDDING_API_VERSION=2024-08-01-preview
+
+### Gemini embedding
+# # EMBEDDING_BINDING=gemini
+# # EMBEDDING_MODEL=gemini-embedding-001
+# # EMBEDDING_DIM=1536
+# # EMBEDDING_TOKEN_LIMIT=2048
+# # EMBEDDING_BINDING_HOST=https://generativelanguage.googleapis.com
+# # EMBEDDING_BINDING_API_KEY=your_api_key
+### Gemini embedding requires sending dimension to server
+# # EMBEDDING_SEND_DIM=true
+
+### Ollama embedding
+# # EMBEDDING_BINDING=ollama
+# # EMBEDDING_BINDING_HOST=http://localhost:11434
+# # EMBEDDING_BINDING_API_KEY=your_api_key
+# # EMBEDDING_MODEL=qwen3-embedding:4b
+# # EMBEDDING_DIM=2560
+### Optional for Ollama embedding
+OLLAMA_EMBEDDING_NUM_CTX=8192
+### use the following command to see all support options for Ollama embedding
+### lightrag-server --embedding-binding ollama --help
+
+### Bedrock embedding
+### Bedrock uses AWS credentials from the environment / AWS credential chain.
+### It does not use EMBEDDING_BINDING_API_KEY.
+# # EMBEDDING_BINDING=aws_bedrock
+# # EMBEDDING_MODEL=amazon.titan-embed-text-v2:0
+# # EMBEDDING_DIM=1024
+# AWS_ACCESS_KEY_ID=your_aws_access_key_id
+# AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
+# AWS_SESSION_TOKEN=your_optional_aws_session_token
+# AWS_REGION=us-east-1
+
+### Jina AI Embedding
+# # EMBEDDING_BINDING=jina
+# # EMBEDDING_BINDING_HOST=https://api.jina.ai/v1/embeddings
+# # EMBEDDING_MODEL=jina-embeddings-v4
+# # EMBEDDING_DIM=2048
+# # EMBEDDING_BINDING_API_KEY=your_api_key
+
+####################################################################
+### WORKSPACE sets workspace name for all storage types
+### for the purpose of isolating data from LightRAG instances.
+### Valid workspace name constraints: a-z, A-Z, 0-9, and _
+####################################################################
+WORKSPACE=space1
+
+############################
+### Data storage selection
+############################
+### Default storage: JSON/Nano/NetworkX (Recommended for test deployment)
+LIGHTRAG_KV_STORAGE=PGKVStorage
+# LIGHTRAG_KV_STORAGE=JsonKVStorage
+LIGHTRAG_DOC_STATUS_STORAGE=PGDocStatusStorage
+# LIGHTRAG_DOC_STATUS_STORAGE=JsonDocStatusStorage
+LIGHTRAG_GRAPH_STORAGE=Neo4JStorage
+# LIGHTRAG_GRAPH_STORAGE=NetworkXStorage
+LIGHTRAG_VECTOR_STORAGE=MilvusVectorDBStorage
+# LIGHTRAG_VECTOR_STORAGE=NanoVectorDBStorage
+
+### Wizard metadata used to preserve env-storage Docker deployment defaults across setup reruns
+LIGHTRAG_SETUP_POSTGRES_DEPLOYMENT=docker
+LIGHTRAG_SETUP_NEO4J_DEPLOYMENT=docker
+# LIGHTRAG_SETUP_MONGODB_DEPLOYMENT=docker
+# LIGHTRAG_SETUP_MONGODB_DEPLOYMENT=atlas-capable
+# LIGHTRAG_SETUP_REDIS_DEPLOYMENT=docker
+LIGHTRAG_SETUP_MILVUS_DEPLOYMENT=docker
+# LIGHTRAG_SETUP_QDRANT_DEPLOYMENT=docker
+# LIGHTRAG_SETUP_MEMGRAPH_DEPLOYMENT=docker
+# LIGHTRAG_SETUP_OPENSEARCH_DEPLOYMENT=docker
+
+### PostgreSQL Configuration
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+POSTGRES_USER=rag
+# POSTGRES_USER=your_username
+POSTGRES_PASSWORD=rag
+# POSTGRES_PASSWORD='your_password'
+POSTGRES_DATABASE=rag
+POSTGRES_MAX_CONNECTIONS=25
+### DB specific workspace should not be set, keep for compatible only
+# POSTGRES_WORKSPACE=forced_workspace_name
+
+### Use HNSW_HALFVEC for large embeddings (2000+ dim).
+### Requires pgvector extension >= 0.7.0.
+### Vector storage type: HNSW, HNSW_HALFVEC, IVFFlat, VCHORDRQ
+POSTGRES_VECTOR_INDEX_TYPE=HNSW
+POSTGRES_HNSW_M=16
+POSTGRES_HNSW_EF=200
+POSTGRES_IVFFLAT_LISTS=100
+POSTGRES_VCHORDRQ_BUILD_OPTIONS=
+POSTGRES_VCHORDRQ_PROBES=
+POSTGRES_VCHORDRQ_EPSILON=1.9
+
+### PostgreSQL Connection Retry Configuration (Network Robustness)
+### NEW DEFAULTS (v1.4.10+): Optimized for HA deployments with ~30s switchover time
+### These defaults provide out-of-the-box support for PostgreSQL High Availability setups
+###
+### Number of retry attempts (1-100, default: 10)
+###   - Default 10 attempts allows ~225s total retry time (sufficient for most HA scenarios)
+###   - For extreme cases: increase up to 20-50
+### Initial retry backoff in seconds (0.1-300.0, default: 3.0)
+###   - Default 3.0s provides reasonable initial delay for switchover detection
+###   - For faster recovery: decrease to 1.0-2.0
+### Maximum retry backoff in seconds (must be >= backoff, max: 600.0, default: 30.0)
+###   - Default 30.0s matches typical switchover completion time
+###   - For longer switchovers: increase to 60-90
+### Connection pool close timeout in seconds (1.0-30.0, default: 5.0)
+# POSTGRES_CONNECTION_RETRIES=10
+# POSTGRES_CONNECTION_RETRY_BACKOFF=3.0
+# POSTGRES_CONNECTION_RETRY_BACKOFF_MAX=30.0
+# POSTGRES_POOL_CLOSE_TIMEOUT=5.0
+
+### PostgreSQL SSL Configuration (Optional)
+# POSTGRES_SSL_MODE=require
+# POSTGRES_SSL_CERT=/path/to/client-cert.pem
+# POSTGRES_SSL_KEY=/path/to/client-key.pem
+# POSTGRES_SSL_ROOT_CERT=/path/to/ca-cert.pem
+# POSTGRES_SSL_CRL=/path/to/crl.pem
+
+### PostgreSQL Server Settings (for Supabase Supavisor)
+# Use this to pass extra options to the PostgreSQL connection string.
+# For Supabase, you might need to set it like this:
+# POSTGRES_SERVER_SETTINGS='options=reference%3D[project-ref]'
+
+# Default is 100 set to 0 to disable
+# POSTGRES_STATEMENT_CACHE_SIZE=100
+
+### Neo4j Configuration
+NEO4J_URI=neo4j://localhost:7687
+# NEO4J_URI=neo4j+s://xxxxxxxx.databases.neo4j.io
+NEO4J_USERNAME=neo4j
+NEO4J_PASSWORD=neo4j@lightrag
+# NEO4J_PASSWORD='your_password'
+NEO4J_DATABASE=neo4j
+NEO4J_MAX_CONNECTION_POOL_SIZE=100
+NEO4J_CONNECTION_TIMEOUT=30
+NEO4J_CONNECTION_ACQUISITION_TIMEOUT=30
+NEO4J_MAX_TRANSACTION_RETRY_TIME=30
+NEO4J_MAX_CONNECTION_LIFETIME=300
+NEO4J_LIVENESS_CHECK_TIMEOUT=30
+NEO4J_KEEP_ALIVE=true
+### DB specific workspace should not be set, keep for compatible only
+# NEO4J_WORKSPACE=forced_workspace_name
+
+### MongoDB Configuration
+# For MongoVectorDBStorage, MONGO_URI must point to a MongoDB endpoint with
+# Atlas Search / Vector Search support, such as MongoDB Atlas or Atlas local.
+MONGO_URI=mongodb://localhost:27017/
+MONGO_DATABASE=LightRAG
+### DB specific workspace should not be set, keep for compatible only
+# MONGODB_WORKSPACE=forced_workspace_name
+
+# Community/local Docker MongoDB example for KV, graph, or doc-status storage only:
+# MONGO_URI=mongodb://localhost:27017/
+
+### OpenSearch Configuration
+### OpenSearch can be used for all storage types: KV, Vector, Graph, DocStatus
+### Connection settings (comma-separated host:port entries; do not include http:// or https://)
+### This setup wizard supports authenticated OpenSearch clusters only.
+### OPENSEARCH_USE_SSL controls whether those hosts are reached over TLS.
+OPENSEARCH_HOSTS=localhost:9200
+OPENSEARCH_USER=admin
+OPENSEARCH_PASSWORD=LightRAG2026_!@
+OPENSEARCH_USE_SSL=true
+OPENSEARCH_VERIFY_CERTS=false
+# OPENSEARCH_TIMEOUT=30
+# OPENSEARCH_MAX_RETRIES=3
+### Index Settings (for 3-AZ Amazon OpenSearch Service, set replicas to 2)
+# OPENSEARCH_NUMBER_OF_SHARDS=1
+# OPENSEARCH_NUMBER_OF_REPLICAS=0
+### k-NN Settings for Vector Storage (HNSW algorithm)
+# OPENSEARCH_KNN_EF_CONSTRUCTION=200
+# OPENSEARCH_KNN_M=16
+# OPENSEARCH_KNN_EF_SEARCH=100
+### PPL graphlookup for server-side graph traversal (auto-detected if not set)
+# OPENSEARCH_USE_PPL_GRAPHLOOKUP=true
+### DB specific workspace should not be set, keep for compatible only
+# OPENSEARCH_WORKSPACE=forced_workspace_name
+
+### Milvus Configuration
+MILVUS_URI=http://localhost:19530
+MILVUS_DB_NAME=default
+# MILVUS_DB_NAME=lightrag
+MILVUS_DEVICE=cuda
+# MILVUS_USER=root
+# MILVUS_PASSWORD=your_password
+# MILVUS_TOKEN=your_token
+# Required for the bundled Docker Milvus stack; may come from .env or exported shell variables.
+MINIO_ACCESS_KEY_ID=minioadmin
+MINIO_SECRET_ACCESS_KEY=minioadmin
+### DB specific workspace should not be set, keep for compatible only
+# MILVUS_WORKSPACE=forced_workspace_name
+
+### Milvus Vector Index Configuration
+### Index type: AUTOINDEX (default), HNSW, HNSW_SQ, HNSW_PQ, IVF_FLAT, IVF_SQ8, DISKANN
+# MILVUS_INDEX_TYPE=AUTOINDEX
+
+### Metric type: COSINE (default), L2, IP
+# MILVUS_METRIC_TYPE=COSINE
+
+### HNSW / HNSW_SQ / HNSW_PQ Parameters (aligned with Milvus 2.4+ defaults)
+### M: Maximum number of connections per node [2-2048], default 16
+# MILVUS_HNSW_M=16
+### efConstruction: Size of dynamic candidate list during build [8-512], default 360
+# MILVUS_HNSW_EF_CONSTRUCTION=360
+### ef: Size of dynamic candidate list during search, default 200
+# MILVUS_HNSW_EF=200
+
+### HNSW_SQ Specific Parameters (requires Milvus 2.6.8+)
+### sq_type: Scalar quantization type - SQ4U, SQ6, SQ8 (default), BF16, FP16
+# MILVUS_HNSW_SQ_TYPE=SQ8
+### refine: Enable refinement step for higher precision, default false
+# MILVUS_HNSW_SQ_REFINE=false
+### refine_type: Refinement precision (must be higher than sq_type) - SQ6, SQ8, BF16, FP16, FP32
+# MILVUS_HNSW_SQ_REFINE_TYPE=FP32
+### refine_k: Refinement expansion factor, default 10
+# MILVUS_HNSW_SQ_REFINE_K=10
+
+### IVF_FLAT / IVF_SQ8 Parameters
+### nlist: Number of cluster units [1-65536], recommended sqrt(n) for n>1M, default 1024
+# MILVUS_IVF_NLIST=1024
+### nprobe: Number of units to query [1-nlist], default 16
+# MILVUS_IVF_NPROBE=16
+
+### Qdrant
+QDRANT_URL=http://localhost:6333
+# QDRANT_DEVICE=cpu
+# QDRANT_API_KEY=your-api-key
+### Qdrant upsert batching (enabled by default)
+### Split large upserts by estimated JSON payload size and point count
+### Default 16MB keeps safe headroom below common 32MB gateway/request limits
+# QDRANT_UPSERT_MAX_PAYLOAD_BYTES=16777216
+# QDRANT_UPSERT_MAX_POINTS_PER_BATCH=128
+### DB specific workspace should not be set, keep for compatible only
+# QDRANT_WORKSPACE=forced_workspace_name
+
+### Redis
+REDIS_URI=redis://localhost:6379
+REDIS_SOCKET_TIMEOUT=30
+REDIS_CONNECT_TIMEOUT=10
+REDIS_MAX_CONNECTIONS=100
+REDIS_RETRY_ATTEMPTS=3
+### DB specific workspace should not be set, keep for compatible only
+# REDIS_WORKSPACE=forced_workspace_name
+
+### Memgraph Configuration
+MEMGRAPH_URI=bolt://localhost:7687
+MEMGRAPH_USERNAME=
+MEMGRAPH_PASSWORD=
+MEMGRAPH_DATABASE=memgraph
+### DB specific workspace should not be set, keep for compatible only
+# MEMGRAPH_WORKSPACE=forced_workspace_name
+
+###########################################################
+### Langfuse Observability Configuration
+### Only works with LLM provided by OpenAI compatible API
+### Install with: pip install lightrag-hku[observability]
+### Sign up at: https://cloud.langfuse.com or self-host
+###########################################################
+# LANGFUSE_SECRET_KEY=''
+# LANGFUSE_PUBLIC_KEY=''
+# LANGFUSE_HOST='https://cloud.langfuse.com'
+# LANGFUSE_ENABLE_TRACE=true
+
+############################
+### Evaluation Configuration
+############################
+### RAGAS evaluation models (used for RAG quality assessment)
+### ⚠️ IMPORTANT: Both LLM and Embedding endpoints MUST be OpenAI-compatible
+### Default uses OpenAI models for evaluation
+
+### LLM Configuration for Evaluation
+# EVAL_LLM_MODEL=gpt-4o-mini
+### API key for LLM evaluation (fallback to OPENAI_API_KEY if not set)
+# EVAL_LLM_BINDING_API_KEY=your_api_key
+### Custom OpenAI-compatible endpoint for LLM evaluation (optional)
+# EVAL_LLM_BINDING_HOST=https://api.openai.com/v1
+
+### Embedding Configuration for Evaluation
+# EVAL_EMBEDDING_MODEL=text-embedding-3-large
+### API key for embeddings (fallback: EVAL_LLM_BINDING_API_KEY -> OPENAI_API_KEY)
+# EVAL_EMBEDDING_BINDING_API_KEY=your_embedding_api_key
+### Custom OpenAI-compatible endpoint for embeddings (fallback: EVAL_LLM_BINDING_HOST)
+# EVAL_EMBEDDING_BINDING_HOST=https://api.openai.com/v1
+
+### Performance Tuning
+### Number of concurrent test case evaluations
+### Lower values reduce API rate limit issues but increase evaluation time
+# EVAL_MAX_CONCURRENT=2
+### TOP_K query parameter of LightRAG (default: 10)
+### Number of entities or relations retrieved from KG
+# EVAL_QUERY_TOP_K=10
+### LLM request retry and timeout settings for evaluation
+# EVAL_LLM_MAX_RETRIES=5
+# EVAL_LLM_TIMEOUT=180
+
+##########################################################################
+### ----- Preserved custom environment variables from previous .env  -----
+### ----- Comments in this session will persist across regenerations -----
+### (This must be the final session; ensure the preceding lines unchanged)
+##########################################################################
+
+### Default Storage (Recommended for test deployment)
+# LIGHTRAG_KV_STORAGE=JsonKVStorage
+# LIGHTRAG_DOC_STATUS_STORAGE=JsonDocStatusStorage
+# LIGHTRAG_GRAPH_STORAGE=NetworkXStorage
+# LIGHTRAG_VECTOR_STORAGE=NanoVectorDBStorage
+
+### Production Storage
+# LIGHTRAG_KV_STORAGE=RedisKVStorage
+# LIGHTRAG_DOC_STATUS_STORAGE=RedisDocStatusStorage
+# LIGHTRAG_VECTOR_STORAGE=QdrantVectorDBStorage
+# LIGHTRAG_GRAPH_STORAGE=MemgraphStorage
+
+### Select OpenSearch for all storages
+# LIGHTRAG_KV_STORAGE=OpenSearchKVStorage
+# LIGHTRAG_DOC_STATUS_STORAGE=OpenSearchDocStatusStorage
+# LIGHTRAG_GRAPH_STORAGE=OpenSearchGraphStorage
+# LIGHTRAG_VECTOR_STORAGE=OpenSearchVectorDBStorage
+
+### Select PostgreSQL for all storages
+# LIGHTRAG_KV_STORAGE=PGKVStorage
+# LIGHTRAG_DOC_STATUS_STORAGE=PGDocStatusStorage
+# LIGHTRAG_GRAPH_STORAGE=PGGraphStorage
+# LIGHTRAG_VECTOR_STORAGE=PGVectorStorage
+
+### Select MongoDB for all storage (Vector storage requires an Atlas-capable deployment)
+# LIGHTRAG_KV_STORAGE=MongoKVStorage
+# LIGHTRAG_DOC_STATUS_STORAGE=MongoDocStatusStorage
+# LIGHTRAG_GRAPH_STORAGE=MongoGraphStorage
+# LIGHTRAG_VECTOR_STORAGE=MongoVectorDBStorage
+
+### ----- Extra setting from previous .env -----

--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -1505,7 +1505,6 @@ collect_milvus_config() {
     uri="${ENV_VALUES[MILVUS_URI]:-http://localhost:19530}"
   fi
 
-  uri="$(prompt_until_valid "Milvus URI" "$uri" validate_uri milvus)"
   existing_db_name="${ORIGINAL_ENV_VALUES[MILVUS_DB_NAME]-${ENV_VALUES[MILVUS_DB_NAME]:-}}"
   existing_device="${ORIGINAL_ENV_VALUES[MILVUS_DEVICE]-${ENV_VALUES[MILVUS_DEVICE]:-}}"
   if [[ "$use_docker" == "yes" ]]; then
@@ -1514,6 +1513,9 @@ collect_milvus_config() {
     if [[ "$milvus_device" == "cuda" ]] && ! host_cuda_available; then
       log_warn "CUDA device selected for Milvus but no NVIDIA driver detected on host."
     fi
+  fi
+  uri="$(prompt_until_valid "Milvus URI" "$uri" validate_uri milvus)"
+  if [[ "$use_docker" == "yes" ]]; then
     uri="$(normalize_milvus_uri_for_local_service "$uri")"
     if [[ -z "${ENV_VALUES[MINIO_ACCESS_KEY_ID]:-}" ]]; then
       ENV_VALUES["MINIO_ACCESS_KEY_ID"]="minioadmin"
@@ -1559,7 +1561,6 @@ collect_qdrant_config() {
     url="${ENV_VALUES[QDRANT_URL]:-http://localhost:6333}"
   fi
 
-  url="$(prompt_until_valid "Qdrant URL" "$url" validate_uri qdrant)"
   existing_device="${ORIGINAL_ENV_VALUES[QDRANT_DEVICE]-${ENV_VALUES[QDRANT_DEVICE]:-}}"
   if [[ "$use_docker" == "yes" ]]; then
     qdrant_device="$(resolve_local_device_default "$existing_device")"
@@ -1567,6 +1568,9 @@ collect_qdrant_config() {
     if [[ "$qdrant_device" == "cuda" ]] && ! host_cuda_available; then
       log_warn "CUDA device selected for Qdrant but no NVIDIA driver detected on host."
     fi
+  fi
+  url="$(prompt_until_valid "Qdrant URL" "$url" validate_uri qdrant)"
+  if [[ "$use_docker" == "yes" ]]; then
     url="$(normalize_qdrant_uri_for_local_service "$url")"
   fi
   ENV_VALUES["QDRANT_URL"]="$url"
@@ -2369,12 +2373,18 @@ env_base_flow() {
   fi
 
   if [[ "$use_docker_embed" == "yes" ]]; then
-    existing_vllm_embed_model="${ENV_VALUES[VLLM_EMBED_MODEL]:-}"
-    existing_embedding_dim="${ENV_VALUES[EMBEDDING_DIM]:-}"
-    existing_vllm_embed_port="${ENV_VALUES[VLLM_EMBED_PORT]:-}"
-    existing_vllm_embed_host="${ENV_VALUES[EMBEDDING_BINDING_HOST]:-}"
-    existing_vllm_embed_device="${ENV_VALUES[VLLM_EMBED_DEVICE]:-}"
+    existing_vllm_embed_model="${ORIGINAL_ENV_VALUES[VLLM_EMBED_MODEL]-${ENV_VALUES[VLLM_EMBED_MODEL]:-}}"
+    existing_embedding_dim="${ORIGINAL_ENV_VALUES[EMBEDDING_DIM]-${ENV_VALUES[EMBEDDING_DIM]:-}}"
+    existing_vllm_embed_port="${ORIGINAL_ENV_VALUES[VLLM_EMBED_PORT]-${ENV_VALUES[VLLM_EMBED_PORT]:-}}"
+    existing_vllm_embed_host="${ORIGINAL_ENV_VALUES[EMBEDDING_BINDING_HOST]-${ENV_VALUES[EMBEDDING_BINDING_HOST]:-}}"
+    existing_vllm_embed_device="${ORIGINAL_ENV_VALUES[VLLM_EMBED_DEVICE]-${ENV_VALUES[VLLM_EMBED_DEVICE]:-}}"
     apply_preset_overwrite "${PRESET_VLLM_EMBEDDING[@]}"
+    local vllm_embed_device
+    vllm_embed_device="$(resolve_local_device_default "$existing_vllm_embed_device")"
+    vllm_embed_device="$(prompt_choice "Embedding device" "$vllm_embed_device" "cpu" "cuda")"
+    if [[ "$vllm_embed_device" == "cuda" ]] && ! host_cuda_available; then
+      log_warn "CUDA device selected for vLLM embedding but no NVIDIA driver detected on host."
+    fi
     if [[ -n "$existing_vllm_embed_port" ]]; then
       ENV_VALUES["VLLM_EMBED_PORT"]="$existing_vllm_embed_port"
     fi
@@ -2390,9 +2400,6 @@ env_base_flow() {
     embed_model="$(prompt_with_default "Embedding model" "${existing_vllm_embed_model:-${ENV_VALUES[VLLM_EMBED_MODEL]:-BAAI/bge-m3}}")"
     ENV_VALUES["VLLM_EMBED_MODEL"]="$embed_model"
     ENV_VALUES["EMBEDDING_MODEL"]="$embed_model"
-
-    local vllm_embed_device
-    vllm_embed_device="$(resolve_local_device_default "$existing_vllm_embed_device")"
     ENV_VALUES["VLLM_EMBED_DEVICE"]="$vllm_embed_device"
     ENV_VALUES["LIGHTRAG_SETUP_EMBEDDING_PROVIDER"]="vllm"
 
@@ -2439,11 +2446,17 @@ env_base_flow() {
     fi
 
     if [[ "$use_docker_rerank" == "yes" ]]; then
-      existing_vllm_rerank_model="${ENV_VALUES[VLLM_RERANK_MODEL]:-}"
-      existing_vllm_rerank_port="${ENV_VALUES[VLLM_RERANK_PORT]:-}"
-      existing_vllm_rerank_host="${ENV_VALUES[RERANK_BINDING_HOST]:-}"
-      existing_vllm_rerank_device="${ENV_VALUES[VLLM_RERANK_DEVICE]:-}"
+      existing_vllm_rerank_model="${ORIGINAL_ENV_VALUES[VLLM_RERANK_MODEL]-${ENV_VALUES[VLLM_RERANK_MODEL]:-}}"
+      existing_vllm_rerank_port="${ORIGINAL_ENV_VALUES[VLLM_RERANK_PORT]-${ENV_VALUES[VLLM_RERANK_PORT]:-}}"
+      existing_vllm_rerank_host="${ORIGINAL_ENV_VALUES[RERANK_BINDING_HOST]-${ENV_VALUES[RERANK_BINDING_HOST]:-}}"
+      existing_vllm_rerank_device="${ORIGINAL_ENV_VALUES[VLLM_RERANK_DEVICE]-${ENV_VALUES[VLLM_RERANK_DEVICE]:-}}"
       apply_preset_overwrite "${PRESET_VLLM_RERANKER[@]}"
+      local vllm_rerank_device
+      vllm_rerank_device="$(resolve_local_device_default "$existing_vllm_rerank_device")"
+      vllm_rerank_device="$(prompt_choice "Rerank device" "$vllm_rerank_device" "cpu" "cuda")"
+      if [[ "$vllm_rerank_device" == "cuda" ]] && ! host_cuda_available; then
+        log_warn "CUDA device selected for vLLM rerank but no NVIDIA driver detected on host."
+      fi
       local rerank_model rerank_port
       if [[ -n "$existing_vllm_rerank_port" ]]; then
         ENV_VALUES["VLLM_RERANK_PORT"]="$existing_vllm_rerank_port"
@@ -2458,9 +2471,6 @@ env_base_flow() {
       ENV_VALUES["VLLM_RERANK_MODEL"]="$rerank_model"
       ENV_VALUES["RERANK_MODEL"]="$rerank_model"
       ENV_VALUES["VLLM_RERANK_PORT"]="$rerank_port"
-
-      local vllm_rerank_device
-      vllm_rerank_device="$(resolve_local_device_default "$existing_vllm_rerank_device")"
       ENV_VALUES["VLLM_RERANK_DEVICE"]="$vllm_rerank_device"
       ENV_VALUES["LIGHTRAG_SETUP_RERANK_PROVIDER"]="vllm"
 

--- a/scripts/setup/templates/postgres.yml
+++ b/scripts/setup/templates/postgres.yml
@@ -1,6 +1,5 @@
   postgres:
     image: gzdaniel/postgres-for-rag:16.6
-    command: ["sh", "-c", "service postgresql start && sleep infinity"]
     # ports:
     #   - "5432:5432"
     volumes:

--- a/tests/test_interactive_setup/test_collect.py
+++ b/tests/test_interactive_setup/test_collect.py
@@ -942,6 +942,46 @@ printf 'MILVUS_DEVICE=%s\\n' "${{ENV_VALUES[MILVUS_DEVICE]}}\"
     assert values["MILVUS_DEVICE"] == expected_device
 
 
+@pytest.mark.parametrize(
+    ("collector_call", "device_prompt", "endpoint_prompt"),
+    [
+        ("collect_milvus_config yes", "Milvus device", "Milvus URI"),
+        ("collect_qdrant_config yes", "Qdrant device", "Qdrant URL"),
+    ],
+)
+def test_local_vector_db_device_prompt_is_first_follow_up_after_docker_choice(
+    collector_call: str, device_prompt: str, endpoint_prompt: str
+) -> None:
+    """GPU/CPU selection should be the first prompt after choosing local Docker deployment."""
+    values = run_bash_lines(f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+reset_state
+
+PROMPT_LOG_FILE="$(mktemp)"
+: > "$PROMPT_LOG_FILE"
+
+confirm_default_yes() {{ return 0; }}
+prompt_choice() {{
+  printf '%s\\n' "$1" >> "$PROMPT_LOG_FILE"
+  printf '%s' "$2"
+}}
+prompt_with_default() {{
+  printf '%s\\n' "$1" >> "$PROMPT_LOG_FILE"
+  printf '%s' "$2"
+}}
+prompt_until_valid() {{
+  printf '%s\\n' "$1" >> "$PROMPT_LOG_FILE"
+  printf '%s' "$2"
+}}
+
+{collector_call}
+
+printf 'PROMPT_LOG=%s\\n' "$(paste -sd '|' "$PROMPT_LOG_FILE")"
+""")
+    assert values["PROMPT_LOG"].startswith(f"{device_prompt}|{endpoint_prompt}")
+
+
 def test_collect_mongodb_config_local_service_strips_stale_credentials_on_rerun() -> (
     None
 ):

--- a/tests/test_interactive_setup/test_env.py
+++ b/tests/test_interactive_setup/test_env.py
@@ -389,6 +389,208 @@ env_base_flow
     assert values["VLLM_EMBED_DEVICE"] == "cuda"
 
 
+def test_env_base_flow_forced_vllm_cuda_selection_writes_cuda_devices_to_env(
+    tmp_path: Path,
+) -> None:
+    """Forced CUDA selection should drive both .env devices and GPU compose templates."""
+    write_text_lines(
+        tmp_path / "env.example",
+        (REPO_ROOT / "env.example").read_text(encoding="utf-8").splitlines(),
+    )
+    write_text_lines(
+        tmp_path / "docker-compose.yml",
+        (REPO_ROOT / "docker-compose.yml").read_text(encoding="utf-8").splitlines(),
+    )
+
+    result = run_bash_process(
+        f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+
+host_cuda_available() {{ return 1; }}
+prompt_choice() {{
+  case "$1" in
+    "LLM provider") printf 'ollama' ;;
+    "Embedding device"|"Rerank device") printf 'cuda' ;;
+    *) printf '%s' "$2" ;;
+  esac
+}}
+prompt_with_default() {{ printf '%s' "$2"; }}
+prompt_until_valid() {{ printf '%s' "$2"; }}
+prompt_secret_with_default() {{ printf '%s' "$2"; }}
+prompt_secret_until_valid_with_default() {{ printf '%s' "$2"; }}
+confirm_default_no() {{
+  case "$1" in
+    "Run embedding model locally via Docker (vLLM)?") return 0 ;;
+    "Enable reranking?") return 0 ;;
+    "Run rerank service locally via Docker?") return 0 ;;
+    *) return 1 ;;
+  esac
+}}
+confirm_default_yes() {{
+  case "$1" in
+    *"The compose file will be created/updated. Continue?"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}}
+confirm_required_yes_no() {{ return 0; }}
+
+env_base_flow
+""",
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    generated_env = (tmp_path / ".env").read_text(encoding="utf-8")
+    generated_compose = (tmp_path / "docker-compose.final.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "VLLM_EMBED_DEVICE=cuda" in generated_env
+    assert "VLLM_RERANK_DEVICE=cuda" in generated_env
+    assert generated_compose.count("capabilities: [gpu]") >= 2
+    assert (
+        "CUDA device selected for vLLM embedding but no NVIDIA driver detected on host."
+        in result.stdout
+    )
+    assert (
+        "CUDA device selected for vLLM rerank but no NVIDIA driver detected on host."
+        in result.stdout
+    )
+
+
+def test_env_base_flow_vllm_defaults_prefer_original_env_values_on_rerun(
+    tmp_path: Path,
+) -> None:
+    """vLLM prompt defaults should prefer the loaded `.env` snapshot over later mutations."""
+    write_text_lines(
+        tmp_path / ".env",
+        [
+            "LLM_BINDING=openai",
+            "LLM_MODEL=gpt-4o-mini",
+            "LLM_BINDING_HOST=https://api.openai.com/v1",
+            "LLM_BINDING_API_KEY=sk-existing",
+            "EMBEDDING_BINDING=openai",
+            "EMBEDDING_MODEL=BAAI/original-embed",
+            "EMBEDDING_DIM=1024",
+            "EMBEDDING_BINDING_HOST=http://localhost:9101/v1",
+            "EMBEDDING_BINDING_API_KEY=embed-key",
+            "LIGHTRAG_SETUP_EMBEDDING_PROVIDER=vllm",
+            "VLLM_EMBED_MODEL=BAAI/original-embed",
+            "VLLM_EMBED_PORT=9101",
+            "VLLM_EMBED_DEVICE=cpu",
+            "RERANK_BINDING=cohere",
+            "RERANK_MODEL=BAAI/original-rerank",
+            "RERANK_BINDING_HOST=http://localhost:9200/rerank",
+            "RERANK_BINDING_API_KEY=rerank-key",
+            "LIGHTRAG_SETUP_RERANK_PROVIDER=vllm",
+            "VLLM_RERANK_MODEL=BAAI/original-rerank",
+            "VLLM_RERANK_PORT=9200",
+            "VLLM_RERANK_DEVICE=cpu",
+        ],
+    )
+    values = run_bash_lines(f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+
+nvidia-smi() {{ return 0; }}
+collect_llm_config() {{
+  ENV_VALUES[VLLM_EMBED_MODEL]="BAAI/mutated-embed"
+  ENV_VALUES[EMBEDDING_DIM]="2048"
+  ENV_VALUES[VLLM_EMBED_PORT]="9991"
+  ENV_VALUES[EMBEDDING_BINDING_HOST]="http://localhost:9991/v1"
+  ENV_VALUES[VLLM_EMBED_DEVICE]="cuda"
+  ENV_VALUES[VLLM_RERANK_MODEL]="BAAI/mutated-rerank"
+  ENV_VALUES[VLLM_RERANK_PORT]="9990"
+  ENV_VALUES[RERANK_BINDING_HOST]="http://localhost:9990/rerank"
+  ENV_VALUES[VLLM_RERANK_DEVICE]="cuda"
+}}
+prompt_choice() {{ printf '%s' "$2"; }}
+prompt_with_default() {{ printf '%s' "$2"; }}
+prompt_until_valid() {{ printf '%s' "$2"; }}
+prompt_secret_with_default() {{ printf '%s' "$2"; }}
+prompt_secret_until_valid_with_default() {{ printf '%s' "$2"; }}
+confirm_default_no() {{ return 1; }}
+confirm_default_yes() {{
+  case "$1" in
+    "Enable reranking?") return 0 ;;
+    "Run embedding model locally via Docker (vLLM)?") return 0 ;;
+    "Run rerank service locally via Docker?") return 0 ;;
+    *) return 1 ;;
+  esac
+}}
+
+finalize_base_setup() {{
+  printf 'VLLM_EMBED_MODEL=%s\\n' "${{ENV_VALUES[VLLM_EMBED_MODEL]}}"
+  printf 'EMBEDDING_DIM=%s\\n' "${{ENV_VALUES[EMBEDDING_DIM]}}"
+  printf 'VLLM_EMBED_PORT=%s\\n' "${{ENV_VALUES[VLLM_EMBED_PORT]}}"
+  printf 'EMBEDDING_BINDING_HOST=%s\\n' "${{ENV_VALUES[EMBEDDING_BINDING_HOST]}}"
+  printf 'VLLM_EMBED_DEVICE=%s\\n' "${{ENV_VALUES[VLLM_EMBED_DEVICE]}}"
+  printf 'VLLM_RERANK_MODEL=%s\\n' "${{ENV_VALUES[VLLM_RERANK_MODEL]}}"
+  printf 'VLLM_RERANK_PORT=%s\\n' "${{ENV_VALUES[VLLM_RERANK_PORT]}}"
+  printf 'RERANK_BINDING_HOST=%s\\n' "${{ENV_VALUES[RERANK_BINDING_HOST]}}"
+  printf 'VLLM_RERANK_DEVICE=%s\\n' "${{ENV_VALUES[VLLM_RERANK_DEVICE]}}"
+}}
+
+env_base_flow
+""")
+    assert values["VLLM_EMBED_MODEL"] == "BAAI/original-embed"
+    assert values["EMBEDDING_DIM"] == "1024"
+    assert values["VLLM_EMBED_PORT"] == "9101"
+    assert values["EMBEDDING_BINDING_HOST"] == "http://localhost:9101/v1"
+    assert values["VLLM_EMBED_DEVICE"] == "cpu"
+    assert values["VLLM_RERANK_MODEL"] == "BAAI/original-rerank"
+    assert values["VLLM_RERANK_PORT"] == "9200"
+    assert values["RERANK_BINDING_HOST"] == "http://localhost:9200/rerank"
+    assert values["VLLM_RERANK_DEVICE"] == "cpu"
+
+
+def test_env_base_flow_vllm_device_prompt_is_first_after_docker_choice(
+    tmp_path: Path,
+) -> None:
+    """vLLM should ask for device before model-specific prompts once Docker is selected."""
+    values = run_bash_lines(f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+
+PROMPT_LOG_FILE="$(mktemp)"
+: > "$PROMPT_LOG_FILE"
+
+prompt_choice() {{
+  printf '%s\\n' "$1" >> "$PROMPT_LOG_FILE"
+  printf '%s' "$2"
+}}
+prompt_with_default() {{
+  printf '%s\\n' "$1" >> "$PROMPT_LOG_FILE"
+  printf '%s' "$2"
+}}
+prompt_until_valid() {{ printf '%s' "$2"; }}
+prompt_secret_with_default() {{ printf '%s' "$2"; }}
+prompt_secret_until_valid_with_default() {{ printf '%s' "$2"; }}
+confirm_default_no() {{
+  case "$1" in
+    "Run embedding model locally via Docker (vLLM)?") return 0 ;;
+    "Enable reranking?") return 0 ;;
+    "Run rerank service locally via Docker?") return 0 ;;
+    *) return 1 ;;
+  esac
+}}
+confirm_default_yes() {{
+  return 1
+}}
+finalize_base_setup() {{ :; }}
+
+env_base_flow
+
+printf 'PROMPT_LOG=%s\\n' "$(paste -sd '|' "$PROMPT_LOG_FILE")"
+""")
+    prompt_log = values["PROMPT_LOG"]
+    assert prompt_log.index("Embedding device") < prompt_log.index("Embedding model")
+    assert prompt_log.index("Rerank device") < prompt_log.index("Rerank model")
+
+
 def test_env_base_flow_preserves_ssl_config_on_rerun(tmp_path: Path) -> None:
     """env-base should preserve SSL config on rerun, even when old paths are stale."""
     cases = {


### PR DESCRIPTION
## Description

Fix local setup prompt handling for vLLM, Milvus, and Qdrant so device defaults continue to respect the previously saved `.env` values, and GPU/CPU selection is asked immediately after choosing Docker deployment.

## Related Issues

N/A

## Changes Made

- preserve vLLM embed/rerank prompt defaults from the original `.env` snapshot instead of mutable in-memory values
- move the device selection prompt to be the first follow-up after choosing local Docker deployment for vLLM, Milvus, and Qdrant
- add regression tests for device default preservation and prompt ordering across setup flows

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Validated with:
`./scripts/test.sh tests/test_interactive_setup/test_collect.py tests/test_interactive_setup/test_env.py -k 'device_prompt_is_first or local_vector_db_device_prompt_is_first or env_base_flow and vllm'`
