### PR TITLE
Fix local setup device prompt defaults and ordering

### DIFF
--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -1513,9 +1513,7 @@ collect_milvus_config() {
     if [[ "$milvus_device" == "cuda" ]] && ! host_cuda_available; then
       log_warn "CUDA device selected for Milvus but no NVIDIA driver detected on host."
     fi
-  fi
-  uri="$(prompt_until_valid "Milvus URI" "$uri" validate_uri milvus)"
-  if [[ "$use_docker" == "yes" ]]; then
+    uri="$(prompt_until_valid "Milvus URI" "$uri" validate_uri milvus)"
     uri="$(normalize_milvus_uri_for_local_service "$uri")"
     if [[ -z "${ENV_VALUES[MINIO_ACCESS_KEY_ID]:-}" ]]; then
       ENV_VALUES["MINIO_ACCESS_KEY_ID"]="minioadmin"
@@ -1523,6 +1521,8 @@ collect_milvus_config() {
     if [[ -z "${ENV_VALUES[MINIO_SECRET_ACCESS_KEY]:-}" ]]; then
       ENV_VALUES["MINIO_SECRET_ACCESS_KEY"]="minioadmin"
     fi
+  else
+    uri="$(prompt_until_valid "Milvus URI" "$uri" validate_uri milvus)"
   fi
   db_name="$(prompt_with_default "Milvus database name" "${existing_db_name:-lightrag}")"
 
@@ -1568,10 +1568,10 @@ collect_qdrant_config() {
     if [[ "$qdrant_device" == "cuda" ]] && ! host_cuda_available; then
       log_warn "CUDA device selected for Qdrant but no NVIDIA driver detected on host."
     fi
-  fi
-  url="$(prompt_until_valid "Qdrant URL" "$url" validate_uri qdrant)"
-  if [[ "$use_docker" == "yes" ]]; then
+    url="$(prompt_until_valid "Qdrant URL" "$url" validate_uri qdrant)"
     url="$(normalize_qdrant_uri_for_local_service "$url")"
+  else
+    url="$(prompt_until_valid "Qdrant URL" "$url" validate_uri qdrant)"
   fi
   ENV_VALUES["QDRANT_URL"]="$url"
   if [[ -n "$qdrant_device" ]]; then

--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -1505,7 +1505,6 @@ collect_milvus_config() {
     uri="${ENV_VALUES[MILVUS_URI]:-http://localhost:19530}"
   fi
 
-  uri="$(prompt_until_valid "Milvus URI" "$uri" validate_uri milvus)"
   existing_db_name="${ORIGINAL_ENV_VALUES[MILVUS_DB_NAME]-${ENV_VALUES[MILVUS_DB_NAME]:-}}"
   existing_device="${ORIGINAL_ENV_VALUES[MILVUS_DEVICE]-${ENV_VALUES[MILVUS_DEVICE]:-}}"
   if [[ "$use_docker" == "yes" ]]; then
@@ -1514,6 +1513,9 @@ collect_milvus_config() {
     if [[ "$milvus_device" == "cuda" ]] && ! host_cuda_available; then
       log_warn "CUDA device selected for Milvus but no NVIDIA driver detected on host."
     fi
+  fi
+  uri="$(prompt_until_valid "Milvus URI" "$uri" validate_uri milvus)"
+  if [[ "$use_docker" == "yes" ]]; then
     uri="$(normalize_milvus_uri_for_local_service "$uri")"
     if [[ -z "${ENV_VALUES[MINIO_ACCESS_KEY_ID]:-}" ]]; then
       ENV_VALUES["MINIO_ACCESS_KEY_ID"]="minioadmin"
@@ -1559,7 +1561,6 @@ collect_qdrant_config() {
     url="${ENV_VALUES[QDRANT_URL]:-http://localhost:6333}"
   fi
 
-  url="$(prompt_until_valid "Qdrant URL" "$url" validate_uri qdrant)"
   existing_device="${ORIGINAL_ENV_VALUES[QDRANT_DEVICE]-${ENV_VALUES[QDRANT_DEVICE]:-}}"
   if [[ "$use_docker" == "yes" ]]; then
     qdrant_device="$(resolve_local_device_default "$existing_device")"
@@ -1567,6 +1568,9 @@ collect_qdrant_config() {
     if [[ "$qdrant_device" == "cuda" ]] && ! host_cuda_available; then
       log_warn "CUDA device selected for Qdrant but no NVIDIA driver detected on host."
     fi
+  fi
+  url="$(prompt_until_valid "Qdrant URL" "$url" validate_uri qdrant)"
+  if [[ "$use_docker" == "yes" ]]; then
     url="$(normalize_qdrant_uri_for_local_service "$url")"
   fi
   ENV_VALUES["QDRANT_URL"]="$url"
@@ -2369,12 +2373,18 @@ env_base_flow() {
   fi
 
   if [[ "$use_docker_embed" == "yes" ]]; then
-    existing_vllm_embed_model="${ENV_VALUES[VLLM_EMBED_MODEL]:-}"
-    existing_embedding_dim="${ENV_VALUES[EMBEDDING_DIM]:-}"
-    existing_vllm_embed_port="${ENV_VALUES[VLLM_EMBED_PORT]:-}"
-    existing_vllm_embed_host="${ENV_VALUES[EMBEDDING_BINDING_HOST]:-}"
-    existing_vllm_embed_device="${ENV_VALUES[VLLM_EMBED_DEVICE]:-}"
+    existing_vllm_embed_model="${ORIGINAL_ENV_VALUES[VLLM_EMBED_MODEL]-${ENV_VALUES[VLLM_EMBED_MODEL]:-}}"
+    existing_embedding_dim="${ORIGINAL_ENV_VALUES[EMBEDDING_DIM]-${ENV_VALUES[EMBEDDING_DIM]:-}}"
+    existing_vllm_embed_port="${ORIGINAL_ENV_VALUES[VLLM_EMBED_PORT]-${ENV_VALUES[VLLM_EMBED_PORT]:-}}"
+    existing_vllm_embed_host="${ORIGINAL_ENV_VALUES[EMBEDDING_BINDING_HOST]-${ENV_VALUES[EMBEDDING_BINDING_HOST]:-}}"
+    existing_vllm_embed_device="${ORIGINAL_ENV_VALUES[VLLM_EMBED_DEVICE]-${ENV_VALUES[VLLM_EMBED_DEVICE]:-}}"
     apply_preset_overwrite "${PRESET_VLLM_EMBEDDING[@]}"
+    local vllm_embed_device
+    vllm_embed_device="$(resolve_local_device_default "$existing_vllm_embed_device")"
+    vllm_embed_device="$(prompt_choice "Embedding device" "$vllm_embed_device" "cpu" "cuda")"
+    if [[ "$vllm_embed_device" == "cuda" ]] && ! host_cuda_available; then
+      log_warn "CUDA device selected for vLLM embedding but no NVIDIA driver detected on host."
+    fi
     if [[ -n "$existing_vllm_embed_port" ]]; then
       ENV_VALUES["VLLM_EMBED_PORT"]="$existing_vllm_embed_port"
     fi
@@ -2390,9 +2400,6 @@ env_base_flow() {
     embed_model="$(prompt_with_default "Embedding model" "${existing_vllm_embed_model:-${ENV_VALUES[VLLM_EMBED_MODEL]:-BAAI/bge-m3}}")"
     ENV_VALUES["VLLM_EMBED_MODEL"]="$embed_model"
     ENV_VALUES["EMBEDDING_MODEL"]="$embed_model"
-
-    local vllm_embed_device
-    vllm_embed_device="$(resolve_local_device_default "$existing_vllm_embed_device")"
     ENV_VALUES["VLLM_EMBED_DEVICE"]="$vllm_embed_device"
     ENV_VALUES["LIGHTRAG_SETUP_EMBEDDING_PROVIDER"]="vllm"
 
@@ -2439,11 +2446,17 @@ env_base_flow() {
     fi
 
     if [[ "$use_docker_rerank" == "yes" ]]; then
-      existing_vllm_rerank_model="${ENV_VALUES[VLLM_RERANK_MODEL]:-}"
-      existing_vllm_rerank_port="${ENV_VALUES[VLLM_RERANK_PORT]:-}"
-      existing_vllm_rerank_host="${ENV_VALUES[RERANK_BINDING_HOST]:-}"
-      existing_vllm_rerank_device="${ENV_VALUES[VLLM_RERANK_DEVICE]:-}"
+      existing_vllm_rerank_model="${ORIGINAL_ENV_VALUES[VLLM_RERANK_MODEL]-${ENV_VALUES[VLLM_RERANK_MODEL]:-}}"
+      existing_vllm_rerank_port="${ORIGINAL_ENV_VALUES[VLLM_RERANK_PORT]-${ENV_VALUES[VLLM_RERANK_PORT]:-}}"
+      existing_vllm_rerank_host="${ORIGINAL_ENV_VALUES[RERANK_BINDING_HOST]-${ENV_VALUES[RERANK_BINDING_HOST]:-}}"
+      existing_vllm_rerank_device="${ORIGINAL_ENV_VALUES[VLLM_RERANK_DEVICE]-${ENV_VALUES[VLLM_RERANK_DEVICE]:-}}"
       apply_preset_overwrite "${PRESET_VLLM_RERANKER[@]}"
+      local vllm_rerank_device
+      vllm_rerank_device="$(resolve_local_device_default "$existing_vllm_rerank_device")"
+      vllm_rerank_device="$(prompt_choice "Rerank device" "$vllm_rerank_device" "cpu" "cuda")"
+      if [[ "$vllm_rerank_device" == "cuda" ]] && ! host_cuda_available; then
+        log_warn "CUDA device selected for vLLM rerank but no NVIDIA driver detected on host."
+      fi
       local rerank_model rerank_port
       if [[ -n "$existing_vllm_rerank_port" ]]; then
         ENV_VALUES["VLLM_RERANK_PORT"]="$existing_vllm_rerank_port"
@@ -2458,9 +2471,6 @@ env_base_flow() {
       ENV_VALUES["VLLM_RERANK_MODEL"]="$rerank_model"
       ENV_VALUES["RERANK_MODEL"]="$rerank_model"
       ENV_VALUES["VLLM_RERANK_PORT"]="$rerank_port"
-
-      local vllm_rerank_device
-      vllm_rerank_device="$(resolve_local_device_default "$existing_vllm_rerank_device")"
       ENV_VALUES["VLLM_RERANK_DEVICE"]="$vllm_rerank_device"
       ENV_VALUES["LIGHTRAG_SETUP_RERANK_PROVIDER"]="vllm"
 

--- a/tests/test_interactive_setup/test_collect.py
+++ b/tests/test_interactive_setup/test_collect.py
@@ -942,6 +942,46 @@ printf 'MILVUS_DEVICE=%s\\n' "${{ENV_VALUES[MILVUS_DEVICE]}}\"
     assert values["MILVUS_DEVICE"] == expected_device
 
 
+@pytest.mark.parametrize(
+    ("collector_call", "device_prompt", "endpoint_prompt"),
+    [
+        ("collect_milvus_config yes", "Milvus device", "Milvus URI"),
+        ("collect_qdrant_config yes", "Qdrant device", "Qdrant URL"),
+    ],
+)
+def test_local_vector_db_device_prompt_is_first_follow_up_after_docker_choice(
+    collector_call: str, device_prompt: str, endpoint_prompt: str
+) -> None:
+    """GPU/CPU selection should be the first prompt after choosing local Docker deployment."""
+    values = run_bash_lines(f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+reset_state
+
+PROMPT_LOG_FILE="$(mktemp)"
+: > "$PROMPT_LOG_FILE"
+
+confirm_default_yes() {{ return 0; }}
+prompt_choice() {{
+  printf '%s\\n' "$1" >> "$PROMPT_LOG_FILE"
+  printf '%s' "$2"
+}}
+prompt_with_default() {{
+  printf '%s\\n' "$1" >> "$PROMPT_LOG_FILE"
+  printf '%s' "$2"
+}}
+prompt_until_valid() {{
+  printf '%s\\n' "$1" >> "$PROMPT_LOG_FILE"
+  printf '%s' "$2"
+}}
+
+{collector_call}
+
+printf 'PROMPT_LOG=%s\\n' "$(paste -sd '|' "$PROMPT_LOG_FILE")"
+""")
+    assert values["PROMPT_LOG"].startswith(f"{device_prompt}|{endpoint_prompt}")
+
+
 def test_collect_mongodb_config_local_service_strips_stale_credentials_on_rerun() -> (
     None
 ):

--- a/tests/test_interactive_setup/test_env.py
+++ b/tests/test_interactive_setup/test_env.py
@@ -389,6 +389,208 @@ env_base_flow
     assert values["VLLM_EMBED_DEVICE"] == "cuda"
 
 
+def test_env_base_flow_forced_vllm_cuda_selection_writes_cuda_devices_to_env(
+    tmp_path: Path,
+) -> None:
+    """Forced CUDA selection should drive both .env devices and GPU compose templates."""
+    write_text_lines(
+        tmp_path / "env.example",
+        (REPO_ROOT / "env.example").read_text(encoding="utf-8").splitlines(),
+    )
+    write_text_lines(
+        tmp_path / "docker-compose.yml",
+        (REPO_ROOT / "docker-compose.yml").read_text(encoding="utf-8").splitlines(),
+    )
+
+    result = run_bash_process(
+        f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+
+host_cuda_available() {{ return 1; }}
+prompt_choice() {{
+  case "$1" in
+    "LLM provider") printf 'ollama' ;;
+    "Embedding device"|"Rerank device") printf 'cuda' ;;
+    *) printf '%s' "$2" ;;
+  esac
+}}
+prompt_with_default() {{ printf '%s' "$2"; }}
+prompt_until_valid() {{ printf '%s' "$2"; }}
+prompt_secret_with_default() {{ printf '%s' "$2"; }}
+prompt_secret_until_valid_with_default() {{ printf '%s' "$2"; }}
+confirm_default_no() {{
+  case "$1" in
+    "Run embedding model locally via Docker (vLLM)?") return 0 ;;
+    "Enable reranking?") return 0 ;;
+    "Run rerank service locally via Docker?") return 0 ;;
+    *) return 1 ;;
+  esac
+}}
+confirm_default_yes() {{
+  case "$1" in
+    *"The compose file will be created/updated. Continue?"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}}
+confirm_required_yes_no() {{ return 0; }}
+
+env_base_flow
+""",
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    generated_env = (tmp_path / ".env").read_text(encoding="utf-8")
+    generated_compose = (tmp_path / "docker-compose.final.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "VLLM_EMBED_DEVICE=cuda" in generated_env
+    assert "VLLM_RERANK_DEVICE=cuda" in generated_env
+    assert generated_compose.count("capabilities: [gpu]") >= 2
+    assert (
+        "CUDA device selected for vLLM embedding but no NVIDIA driver detected on host."
+        in result.stdout
+    )
+    assert (
+        "CUDA device selected for vLLM rerank but no NVIDIA driver detected on host."
+        in result.stdout
+    )
+
+
+def test_env_base_flow_vllm_defaults_prefer_original_env_values_on_rerun(
+    tmp_path: Path,
+) -> None:
+    """vLLM prompt defaults should prefer the loaded `.env` snapshot over later mutations."""
+    write_text_lines(
+        tmp_path / ".env",
+        [
+            "LLM_BINDING=openai",
+            "LLM_MODEL=gpt-4o-mini",
+            "LLM_BINDING_HOST=https://api.openai.com/v1",
+            "LLM_BINDING_API_KEY=sk-existing",
+            "EMBEDDING_BINDING=openai",
+            "EMBEDDING_MODEL=BAAI/original-embed",
+            "EMBEDDING_DIM=1024",
+            "EMBEDDING_BINDING_HOST=http://localhost:9101/v1",
+            "EMBEDDING_BINDING_API_KEY=embed-key",
+            "LIGHTRAG_SETUP_EMBEDDING_PROVIDER=vllm",
+            "VLLM_EMBED_MODEL=BAAI/original-embed",
+            "VLLM_EMBED_PORT=9101",
+            "VLLM_EMBED_DEVICE=cpu",
+            "RERANK_BINDING=cohere",
+            "RERANK_MODEL=BAAI/original-rerank",
+            "RERANK_BINDING_HOST=http://localhost:9200/rerank",
+            "RERANK_BINDING_API_KEY=rerank-key",
+            "LIGHTRAG_SETUP_RERANK_PROVIDER=vllm",
+            "VLLM_RERANK_MODEL=BAAI/original-rerank",
+            "VLLM_RERANK_PORT=9200",
+            "VLLM_RERANK_DEVICE=cpu",
+        ],
+    )
+    values = run_bash_lines(f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+
+nvidia-smi() {{ return 0; }}
+collect_llm_config() {{
+  ENV_VALUES[VLLM_EMBED_MODEL]="BAAI/mutated-embed"
+  ENV_VALUES[EMBEDDING_DIM]="2048"
+  ENV_VALUES[VLLM_EMBED_PORT]="9991"
+  ENV_VALUES[EMBEDDING_BINDING_HOST]="http://localhost:9991/v1"
+  ENV_VALUES[VLLM_EMBED_DEVICE]="cuda"
+  ENV_VALUES[VLLM_RERANK_MODEL]="BAAI/mutated-rerank"
+  ENV_VALUES[VLLM_RERANK_PORT]="9990"
+  ENV_VALUES[RERANK_BINDING_HOST]="http://localhost:9990/rerank"
+  ENV_VALUES[VLLM_RERANK_DEVICE]="cuda"
+}}
+prompt_choice() {{ printf '%s' "$2"; }}
+prompt_with_default() {{ printf '%s' "$2"; }}
+prompt_until_valid() {{ printf '%s' "$2"; }}
+prompt_secret_with_default() {{ printf '%s' "$2"; }}
+prompt_secret_until_valid_with_default() {{ printf '%s' "$2"; }}
+confirm_default_no() {{ return 1; }}
+confirm_default_yes() {{
+  case "$1" in
+    "Enable reranking?") return 0 ;;
+    "Run embedding model locally via Docker (vLLM)?") return 0 ;;
+    "Run rerank service locally via Docker?") return 0 ;;
+    *) return 1 ;;
+  esac
+}}
+
+finalize_base_setup() {{
+  printf 'VLLM_EMBED_MODEL=%s\\n' "${{ENV_VALUES[VLLM_EMBED_MODEL]}}"
+  printf 'EMBEDDING_DIM=%s\\n' "${{ENV_VALUES[EMBEDDING_DIM]}}"
+  printf 'VLLM_EMBED_PORT=%s\\n' "${{ENV_VALUES[VLLM_EMBED_PORT]}}"
+  printf 'EMBEDDING_BINDING_HOST=%s\\n' "${{ENV_VALUES[EMBEDDING_BINDING_HOST]}}"
+  printf 'VLLM_EMBED_DEVICE=%s\\n' "${{ENV_VALUES[VLLM_EMBED_DEVICE]}}"
+  printf 'VLLM_RERANK_MODEL=%s\\n' "${{ENV_VALUES[VLLM_RERANK_MODEL]}}"
+  printf 'VLLM_RERANK_PORT=%s\\n' "${{ENV_VALUES[VLLM_RERANK_PORT]}}"
+  printf 'RERANK_BINDING_HOST=%s\\n' "${{ENV_VALUES[RERANK_BINDING_HOST]}}"
+  printf 'VLLM_RERANK_DEVICE=%s\\n' "${{ENV_VALUES[VLLM_RERANK_DEVICE]}}"
+}}
+
+env_base_flow
+""")
+    assert values["VLLM_EMBED_MODEL"] == "BAAI/original-embed"
+    assert values["EMBEDDING_DIM"] == "1024"
+    assert values["VLLM_EMBED_PORT"] == "9101"
+    assert values["EMBEDDING_BINDING_HOST"] == "http://localhost:9101/v1"
+    assert values["VLLM_EMBED_DEVICE"] == "cpu"
+    assert values["VLLM_RERANK_MODEL"] == "BAAI/original-rerank"
+    assert values["VLLM_RERANK_PORT"] == "9200"
+    assert values["RERANK_BINDING_HOST"] == "http://localhost:9200/rerank"
+    assert values["VLLM_RERANK_DEVICE"] == "cpu"
+
+
+def test_env_base_flow_vllm_device_prompt_is_first_after_docker_choice(
+    tmp_path: Path,
+) -> None:
+    """vLLM should ask for device before model-specific prompts once Docker is selected."""
+    values = run_bash_lines(f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+
+PROMPT_LOG_FILE="$(mktemp)"
+: > "$PROMPT_LOG_FILE"
+
+prompt_choice() {{
+  printf '%s\\n' "$1" >> "$PROMPT_LOG_FILE"
+  printf '%s' "$2"
+}}
+prompt_with_default() {{
+  printf '%s\\n' "$1" >> "$PROMPT_LOG_FILE"
+  printf '%s' "$2"
+}}
+prompt_until_valid() {{ printf '%s' "$2"; }}
+prompt_secret_with_default() {{ printf '%s' "$2"; }}
+prompt_secret_until_valid_with_default() {{ printf '%s' "$2"; }}
+confirm_default_no() {{
+  case "$1" in
+    "Run embedding model locally via Docker (vLLM)?") return 0 ;;
+    "Enable reranking?") return 0 ;;
+    "Run rerank service locally via Docker?") return 0 ;;
+    *) return 1 ;;
+  esac
+}}
+confirm_default_yes() {{
+  return 1
+}}
+finalize_base_setup() {{ :; }}
+
+env_base_flow
+
+printf 'PROMPT_LOG=%s\\n' "$(paste -sd '|' "$PROMPT_LOG_FILE")"
+""")
+    prompt_log = values["PROMPT_LOG"]
+    assert prompt_log.index("Embedding device") < prompt_log.index("Embedding model")
+    assert prompt_log.index("Rerank device") < prompt_log.index("Rerank model")
+
+
 def test_env_base_flow_preserves_ssl_config_on_rerun(tmp_path: Path) -> None:
     """env-base should preserve SSL config on rerun, even when old paths are stale."""
     cases = {


### PR DESCRIPTION
## Description

Fix local setup prompt handling for vLLM, Milvus, and Qdrant so device defaults continue to respect the previously saved `.env` values, and GPU/CPU selection is asked immediately after choosing Docker deployment.

## Related Issues

N/A

## Changes Made

- preserve vLLM embed/rerank prompt defaults from the original `.env` snapshot instead of mutable in-memory values
- move the device selection prompt to be the first follow-up after choosing local Docker deployment for vLLM, Milvus, and Qdrant
- add regression tests for device default preservation and prompt ordering across setup flows

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Validated with:
`./scripts/test.sh tests/test_interactive_setup/test_collect.py tests/test_interactive_setup/test_env.py -k 'device_prompt_is_first or local_vector_db_device_prompt_is_first or env_base_flow and vllm'`
