### PR TITLE
feat: env var overrides for extraction and query prompts

### DIFF
--- a/env.example
+++ b/env.example
@@ -191,6 +191,21 @@ SUMMARY_LANGUAGE=English
 ### Entity types that the LLM will attempt to recognize
 # ENTITY_TYPES='["Person", "Creature", "Organization", "Location", "Event", "Concept", "Method", "Content", "Data", "Artifact", "NaturalObject"]'
 
+### Prompt overrides (optional, env vars)
+### Override extraction/query prompts without modifying source code.
+### String prompts: set the env var to the full prompt text.
+### List prompts (examples): set the env var to a JSON array of strings.
+### If not set, built-in defaults are used. See lightrag/prompt.py for defaults.
+### Note: this is a lightweight bridge until the full prompt template system (#2623) lands.
+# ENTITY_EXTRACTION_SYSTEM_PROMPT=<your custom extraction system prompt>
+# ENTITY_EXTRACTION_USER_PROMPT=<your custom extraction user prompt>
+# ENTITY_EXTRACTION_EXAMPLES=<JSON array of example strings>
+# SUMMARIZE_ENTITY_DESCRIPTIONS_PROMPT=<your custom summarization prompt>
+# RAG_RESPONSE_PROMPT=<your custom RAG response prompt>
+# NAIVE_RAG_RESPONSE_PROMPT=<your custom naive RAG response prompt>
+# KEYWORDS_EXTRACTION_PROMPT=<your custom keywords extraction prompt>
+# KEYWORDS_EXTRACTION_EXAMPLES=<JSON array of example strings>
+
 ### Chunk size for document splitting, 500~1500 is recommended
 # CHUNK_SIZE=1200
 # CHUNK_OVERLAP_SIZE=100

--- a/lightrag/prompt.py
+++ b/lightrag/prompt.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import json
+import os
 from typing import Any
 
 
@@ -430,3 +432,43 @@ Output:
 
 """,
 ]
+
+# ── Environment variable overrides ───────────────────────────────────
+# Allow users to customize prompts via environment variables without
+# modifying this file. Each override is optional — if the env var is
+# not set, the hardcoded default above is used.
+#
+# This is a lightweight bridge until the full prompt template management
+# system (see #2623 / #2652) is available.
+#
+# String prompts: set the env var to the full prompt text.
+# List prompts (examples): set the env var to a JSON array of strings.
+
+_PROMPT_ENV_OVERRIDES: dict[str, str] = {
+    "entity_extraction_system_prompt": "ENTITY_EXTRACTION_SYSTEM_PROMPT",
+    "entity_extraction_user_prompt": "ENTITY_EXTRACTION_USER_PROMPT",
+    "summarize_entity_descriptions": "SUMMARIZE_ENTITY_DESCRIPTIONS_PROMPT",
+    "rag_response": "RAG_RESPONSE_PROMPT",
+    "naive_rag_response": "NAIVE_RAG_RESPONSE_PROMPT",
+    "keywords_extraction": "KEYWORDS_EXTRACTION_PROMPT",
+}
+
+_LIST_PROMPT_ENV_OVERRIDES: dict[str, str] = {
+    "entity_extraction_examples": "ENTITY_EXTRACTION_EXAMPLES",
+    "keywords_extraction_examples": "KEYWORDS_EXTRACTION_EXAMPLES",
+}
+
+for _key, _env_var in _PROMPT_ENV_OVERRIDES.items():
+    _val = os.environ.get(_env_var)
+    if _val is not None:
+        PROMPTS[_key] = _val
+
+for _key, _env_var in _LIST_PROMPT_ENV_OVERRIDES.items():
+    _val = os.environ.get(_env_var)
+    if _val is not None:
+        try:
+            parsed = json.loads(_val)
+            if isinstance(parsed, list):
+                PROMPTS[_key] = parsed
+        except (json.JSONDecodeError, TypeError):
+            pass  # Ignore malformed JSON — keep the default


### PR DESCRIPTION
## Description

Add environment variable overrides for the key prompts in `lightrag/prompt.py`, allowing users to customize entity extraction, summarization, and query prompts **without modifying source code**.

This is a minimal, non-breaking bridge until the full prompt template management system (#2652) lands. It follows the same pattern LightRAG already uses for `ENTITY_TYPES` and `SUMMARY_LANGUAGE`.

## Related Issues

- Closes #308 — Custom Entity Types and Prompts
- Closes #1672 — Custom prompt for entity extraction
- Related to #2623 — Prompt Template Management (this PR is a lightweight stopgap)
- Related to #2652 — Full prompt template system (this PR complements, not competes)

## Changes Made

**`lightrag/prompt.py`** (42 lines added):
- Added `import os, json` 
- Added env var override loop at module bottom: if an env var is set, it replaces the corresponding `PROMPTS` entry; otherwise the hardcoded default is preserved
- 6 string prompt overrides: `ENTITY_EXTRACTION_SYSTEM_PROMPT`, `ENTITY_EXTRACTION_USER_PROMPT`, `SUMMARIZE_ENTITY_DESCRIPTIONS_PROMPT`, `RAG_RESPONSE_PROMPT`, `NAIVE_RAG_RESPONSE_PROMPT`, `KEYWORDS_EXTRACTION_PROMPT`
- 2 list prompt overrides (JSON arrays): `ENTITY_EXTRACTION_EXAMPLES`, `KEYWORDS_EXTRACTION_EXAMPLES`

**`env.example`** (15 lines added):
- Documented all new env vars with usage notes, placed next to `ENTITY_TYPES`

## Why This Matters

Domain-specific use cases — code analysis, legal, medical, DevOps — need different extraction prompts. For example, the default prompt title-cases all entity names (`Split And Save Layers`), which is wrong for code identifiers that must preserve `snake_case`. Currently the only options are editing `prompt.py` directly or monkey-patching at runtime.

This PR lets users set `ENTITY_EXTRACTION_SYSTEM_PROMPT` in `.env` and get custom extraction behavior with zero code changes, zero new dependencies, and zero risk to existing users.

## Example Usage

```env
# In .env — customize for code analysis
ENTITY_TYPES='["Function", "Class", "Module", "ConfigKey", "Service", "Concept"]'
ENTITY_EXTRACTION_SYSTEM_PROMPT='---Role---\nYou are a Code Knowledge Graph Specialist...\n(custom prompt preserving snake_case identifiers)'
```

## Checklist

- [x] Changes tested locally
- [x] Pre-commit checks pass (`pre-commit run --all-files`)
- [x] Documentation updated (env.example)
- [x] Zero breaking changes — all overrides are optional with existing defaults
- [x] No new dependencies

## Additional Notes

This is intentionally minimal. The full prompt template system in #2652 (Jinja2, git-backed, WebUI editor) is the right long-term solution. This PR is a 57-line bridge that unblocks the community today — it can be deprecated when #2652 merges.