### PR TITLE
feat(extraction): configurable per-response entity/relation limits

### DIFF
--- a/env.example
+++ b/env.example
@@ -203,6 +203,11 @@ SUMMARY_LANGUAGE=English
 ### Maximum token size allowed for entity extraction input context
 # MAX_EXTRACT_INPUT_TOKENS=20480
 
+### Per-response cap on total entity+relationship rows/records emitted by the LLM
+# MAX_EXTRACTION_RECORDS=100
+### Per-response cap on entity rows/objects emitted by the LLM
+# MAX_EXTRACTION_ENTITIES=40
+
 ### Use JSON structured output for entity extraction (false: default,  JSON is slower but more reliable)
 ENTITY_EXTRACTION_USE_JSON=true
 
@@ -307,7 +312,7 @@ LLM_MODEL=gpt-5-mini
 # OPENAI_LLM_TEMPERATURE=0.9
 ### Set the max_tokens to mitigate endless output of some LLM (less than LLM_TIMEOUT * llm_output_tokens/second, i.e. 9000 = 180s * 50 tokens/s)
 ### Typically, max_tokens does not include prompt content
-### For vLLM/SGLang deployed models, or most of OpenAI compatible API provider
+### For vLLM/SGLang and most of OpenAI compatible API provider
 # OPENAI_LLM_MAX_TOKENS=9000
 ### For OpenAI o1-mini or newer modles utilizes max_completion_tokens instead of max_tokens
 # OPENAI_LLM_MAX_COMPLETION_TOKENS=9000

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -15,6 +15,10 @@ DEFAULT_SUMMARY_LANGUAGE = "English"  # Default language for document processing
 DEFAULT_MAX_GLEANING = 1
 DEFAULT_ENTITY_NAME_MAX_LENGTH = 256
 
+# Per-response output limits for entity extraction prompts
+DEFAULT_MAX_EXTRACTION_RECORDS = 100
+DEFAULT_MAX_EXTRACTION_ENTITIES = 40
+
 # Number of description fragments to trigger LLM summary
 DEFAULT_FORCE_LLM_SUMMARY_ON_MERGE = 8
 # Max description token size to trigger LLM summary

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -41,6 +41,8 @@ from lightrag.prompt import PROMPTS
 from lightrag.exceptions import PipelineCancelledException
 from lightrag.constants import (
     DEFAULT_MAX_GLEANING,
+    DEFAULT_MAX_EXTRACTION_RECORDS,
+    DEFAULT_MAX_EXTRACTION_ENTITIES,
     DEFAULT_FORCE_LLM_SUMMARY_ON_MERGE,
     DEFAULT_TOP_K,
     DEFAULT_CHUNK_TOP_K,
@@ -442,6 +444,20 @@ class LightRAG:
         default=get_env_value("MAX_GLEANING", DEFAULT_MAX_GLEANING, int)
     )
     """Maximum number of entity extraction attempts for ambiguous content."""
+
+    entity_extract_max_records: int = field(
+        default=get_env_value(
+            "MAX_EXTRACTION_RECORDS", DEFAULT_MAX_EXTRACTION_RECORDS, int
+        )
+    )
+    """Per-response cap on total entity+relationship rows/records."""
+
+    entity_extract_max_entities: int = field(
+        default=get_env_value(
+            "MAX_EXTRACTION_ENTITIES", DEFAULT_MAX_EXTRACTION_ENTITIES, int
+        )
+    )
+    """Per-response cap on entity rows/objects."""
 
     force_llm_summary_on_merge: int = field(
         default=get_env_value(

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -3276,7 +3276,6 @@ async def extract_entities(
             examples=examples,
             language=language,
         )
-        logger.info("Entity extraction using JSON structured output mode")
     else:
         # Text mode: use traditional delimiter-based prompts
         examples = "\n".join(PROMPTS["entity_extraction_examples"])

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -3268,6 +3268,9 @@ async def extract_entities(
         "entity_types_guidance", PROMPTS["default_entity_types_guidance"]
     )
 
+    max_total_records = global_config["entity_extract_max_records"]
+    max_entity_records = global_config["entity_extract_max_entities"]
+
     if use_json_extraction:
         # JSON mode: use JSON-specific prompts without delimiters
         examples = "\n".join(PROMPTS["entity_extraction_json_examples"])
@@ -3275,6 +3278,8 @@ async def extract_entities(
             entity_types_guidance=entity_types_guidance,
             examples=examples,
             language=language,
+            max_total_records=max_total_records,
+            max_entity_records=max_entity_records,
         )
     else:
         # Text mode: use traditional delimiter-based prompts
@@ -3294,6 +3299,8 @@ async def extract_entities(
             entity_types_guidance=entity_types_guidance,
             examples=examples,
             language=language,
+            max_total_records=max_total_records,
+            max_entity_records=max_entity_records,
         )
 
     processed_chunks = 0

--- a/lightrag/prompt.py
+++ b/lightrag/prompt.py
@@ -66,6 +66,11 @@ You are a Knowledge Graph Specialist responsible for extracting entities and rel
 
 6. **Output Order & Deduplication:**
   - Output all extracted entities first, followed by all extracted relationships.
+  - Output at most {max_total_records} total rows across entities and relationships in this response.
+  - Output at most {max_entity_records} entity rows in this response.
+  - Output fewer rows if fewer high-value items are present. Do not try to fill the limit.
+  - Only output relationship rows whose source and target entities are both included in the selected entity rows for this response.
+  - If the limit is reached, stop adding new rows immediately and output `{completion_delimiter}`.
   - Treat all relationships as **undirected** unless explicitly stated otherwise. Swapping the source and target entities for an undirected relationship does not constitute a new relationship.
   - Avoid outputting duplicate relationships.
   - Within the list of relationships, output the relationships that are **most significant** to the core meaning of the input text first.
@@ -90,9 +95,10 @@ Extract entities and relationships from the `---Input Text---` session below.
 
 ---Instructions---
 1. **Strict Adherence to Format:** Strictly adhere to all format requirements for entity and relationship lists, including output order, field delimiters, and proper noun handling, as specified in the system prompt.
-2. **Output Content Only:** Output *only* the extracted list of entities and relationships. Do not include any introductory or concluding remarks, explanations, or additional text before or after the list.
-3. **Completion Signal:** Output `{completion_delimiter}` as the final line after all relevant entities and relationships have been extracted and presented.
-4. **Output Language:** Ensure the output language is {language}. Proper nouns (e.g., personal names, place names, organization names) must be kept in their original language and not translated.
+2. **Quantity Limits:** In this response, output at most {max_total_records} total rows and at most {max_entity_records} entity rows. Output fewer rows if fewer high-value items are present. Only output relationship rows whose source and target entities are both included in this response.
+3. **Output Content Only:** Output *only* the extracted list of entities and relationships. Do not include any introductory or concluding remarks, explanations, or additional text before or after the list.
+4. **Completion Signal:** Output `{completion_delimiter}` as the final line after all relevant entities and relationships have been extracted and presented. If the row limit is reached, output `{completion_delimiter}` immediately after the last allowed row.
+5. **Output Language:** Ensure the output language is {language}. Proper nouns (e.g., personal names, place names, organization names) must be kept in their original language and not translated.
 
 ---Input Text---
 ```
@@ -112,9 +118,10 @@ Based on the last extraction task, identify and extract any missed or incorrectl
   - If an entity or relationship was **missed** in the last task, extract and output it now according to the system format.
   - If an entity or relationship was **truncated, had missing fields, or was otherwise incorrectly formatted** in the last task, re-output the *corrected and complete* version in the specified format.
   - Any corrected relationship row must be emitted with the literal `relation` prefix, never `entity`.
-3. **Output Content Only:** Output *only* the extracted list of entities and relationships. Do not include any introductory or concluding remarks, explanations, or additional text before or after the list.
-4. **Completion Signal:** Output `{completion_delimiter}` as the final line after all relevant missing or corrected entities and relationships have been extracted and presented.
-5. **Output Language:** Ensure the output language is {language}. Proper nouns (e.g., personal names, place names, organization names) must be kept in their original language and not translated.
+3. **Quantity Limits:** In this response, output at most {max_total_records} total rows and at most {max_entity_records} entity rows. Output fewer rows if fewer high-value corrections or additions remain. Only output relationship rows whose source and target entities are both included in this response.
+4. **Output Content Only:** Output *only* the extracted list of entities and relationships. Do not include any introductory or concluding remarks, explanations, or additional text before or after the list.
+5. **Completion Signal:** Output `{completion_delimiter}` as the final line after all relevant missing or corrected entities and relationships have been extracted and presented. If the row limit is reached, output `{completion_delimiter}` immediately after the last allowed row.
+6. **Output Language:** Ensure the output language is {language}. Proper nouns (e.g., personal names, place names, organization names) must be kept in their original language and not translated.
 
 ---Output---
 """
@@ -249,7 +256,11 @@ You are a Knowledge Graph Specialist responsible for extracting entities and rel
   - Treat all relationships as **undirected** unless explicitly stated otherwise. Swapping the source and target entities for an undirected relationship does not constitute a new relationship.
   - Avoid outputting duplicate relationships.
 
-4. **Prioritization:**
+4. **Output Limits & Prioritization:**
+  - Output at most {max_total_records} total records across `entities` and `relationships` in this response.
+  - Output at most {max_entity_records} entity objects in this response.
+  - Output fewer records if fewer high-value items are present. Do not try to fill the limit.
+  - Only output relationship objects whose `source` and `target` are both included in the selected `entities` list for this response.
   - Within the list of relationships, prioritize and output those relationships that are **most significant** to the core meaning of the input text first.
 
 5. **Context & Objectivity:**
@@ -259,6 +270,10 @@ You are a Knowledge Graph Specialist responsible for extracting entities and rel
 6. **Language & Proper Nouns:**
   - The entire output (entity names, keywords, and descriptions) must be written in `{language}`.
   - Proper nouns (e.g., personal names, place names, organization names) should be retained in their original language if a proper, widely accepted translation is not available or would cause ambiguity.
+
+7. **JSON Contract:**
+  - Return one valid JSON object with `entities` and `relationships` arrays only.
+  - If the record limit is reached, stop adding new objects immediately and return the JSON object with the allowed items only.
 
 ---Entity Types---
 {entity_types_guidance}
@@ -272,7 +287,8 @@ Extract entities and relationships from the `---Input Text---` session below.
 
 ---Instructions---
 1. **Strict Adherence to JSON Format:** Your output MUST be a valid JSON object with `entities` and `relationships` arrays. Do not include any introductory or concluding remarks, explanations, markdown code fences, or any other text before or after the JSON.
-2. **Output Language:** Ensure the output language is {language}. Proper nouns (e.g., personal names, place names, organization names) must be kept in their original language and not translated.
+2. **Quantity Limits:** In this response, output at most {max_total_records} total records and at most {max_entity_records} entity objects. Output fewer records if fewer high-value items are present. Only output relationship objects whose `source` and `target` are both included in this response.
+3. **Output Language:** Ensure the output language is {language}. Proper nouns (e.g., personal names, place names, organization names) must be kept in their original language and not translated.
 
 ---Entity Types---
 {entity_types_guidance}
@@ -294,8 +310,9 @@ Based on the last extraction task, identify and extract any **missed or incorrec
   - If an entity or relationship was **missed** in the last task, extract and output it now.
   - If an entity or relationship was **incorrectly described** in the last task, re-output the *corrected and complete* version.
 2. **Strict Adherence to JSON Format:** Your output MUST be a valid JSON object with `entities` and `relationships` arrays. Do not include any introductory or concluding remarks, explanations, markdown code fences, or any other text before or after the JSON.
-3. **Output Language:** Ensure the output language is {language}. Proper nouns (e.g., personal names, place names, organization names) must be kept in their original language and not translated.
-4. **If nothing was missed or needs correction**, output: `{{"entities": [], "relationships": []}}`
+3. **Quantity Limits:** In this response, output at most {max_total_records} total records and at most {max_entity_records} entity objects. Output fewer records if fewer high-value corrections or additions remain. Only output relationship objects whose `source` and `target` are both included in this response.
+4. **Output Language:** Ensure the output language is {language}. Proper nouns (e.g., personal names, place names, organization names) must be kept in their original language and not translated.
+5. **If nothing was missed or needs correction**, output: `{{"entities": [], "relationships": []}}`
 
 ---Output---
 """

--- a/lightrag/prompt.py
+++ b/lightrag/prompt.py
@@ -118,7 +118,7 @@ Based on the last extraction task, identify and extract any missed or incorrectl
   - If an entity or relationship was **missed** in the last task, extract and output it now according to the system format.
   - If an entity or relationship was **truncated, had missing fields, or was otherwise incorrectly formatted** in the last task, re-output the *corrected and complete* version in the specified format.
   - Any corrected relationship row must be emitted with the literal `relation` prefix, never `entity`.
-3. **Quantity Limits:** In this response, output at most {max_total_records} total rows and at most {max_entity_records} entity rows. Output fewer rows if fewer high-value corrections or additions remain. Only output relationship rows whose source and target entities are both included in this response.
+3. **Quantity Limits:** In this response, output at most {max_total_records} total rows and at most {max_entity_records} entity rows. Output fewer rows if fewer high-value corrections or additions remain. A relationship row may reference entities that were already extracted correctly in the previous response. Do not re-output those entities unless they were missing or need correction.
 4. **Output Content Only:** Output *only* the extracted list of entities and relationships. Do not include any introductory or concluding remarks, explanations, or additional text before or after the list.
 5. **Completion Signal:** Output `{completion_delimiter}` as the final line after all relevant missing or corrected entities and relationships have been extracted and presented. If the row limit is reached, output `{completion_delimiter}` immediately after the last allowed row.
 6. **Output Language:** Ensure the output language is {language}. Proper nouns (e.g., personal names, place names, organization names) must be kept in their original language and not translated.
@@ -310,7 +310,7 @@ Based on the last extraction task, identify and extract any **missed or incorrec
   - If an entity or relationship was **missed** in the last task, extract and output it now.
   - If an entity or relationship was **incorrectly described** in the last task, re-output the *corrected and complete* version.
 2. **Strict Adherence to JSON Format:** Your output MUST be a valid JSON object with `entities` and `relationships` arrays. Do not include any introductory or concluding remarks, explanations, markdown code fences, or any other text before or after the JSON.
-3. **Quantity Limits:** In this response, output at most {max_total_records} total records and at most {max_entity_records} entity objects. Output fewer records if fewer high-value corrections or additions remain. Only output relationship objects whose `source` and `target` are both included in this response.
+3. **Quantity Limits:** In this response, output at most {max_total_records} total records and at most {max_entity_records} entity objects. Output fewer records if fewer high-value corrections or additions remain. A relationship object may reference entities already extracted correctly in the previous response. Do not repeat those entity objects unless they were missing or need correction.
 4. **Output Language:** Ensure the output language is {language}. Proper nouns (e.g., personal names, place names, organization names) must be kept in their original language and not translated.
 5. **If nothing was missed or needs correction**, output: `{{"entities": [], "relationships": []}}`
 

--- a/tests/test_entity_extraction_stability.py
+++ b/tests/test_entity_extraction_stability.py
@@ -78,6 +78,12 @@ _TEXT_MODE_GLEANED_RELATION_RESPONSES = [
     "\nrelation<|#|>Alice<|#|>Acme Corp<|#|>founded<|#|>Alice founded Acme Corp.\n<|COMPLETE|>",
 ]
 
+_TEXT_MODE_CROSS_PASS_RELATION_RESPONSES = [
+    "entity<|#|>Alice<|#|>Person<|#|>Alice founded a company.\n<|COMPLETE|>",
+    "entity<|#|>Acme Corp<|#|>Organization<|#|>Acme Corp was founded by Alice."
+    "\nrelation<|#|>Alice<|#|>Acme Corp<|#|>founded<|#|>Alice founded Acme Corp.\n<|COMPLETE|>",
+]
+
 _JSON_MODE_RESPONSE = json.dumps(
     {
         "entities": [
@@ -269,6 +275,14 @@ def test_text_continue_prompt_requires_relation_prefix_for_corrections():
         "output at most {max_total_records} total rows and at most {max_entity_records} entity rows"
         in prompt
     )
+    assert (
+        "may reference entities that were already extracted correctly in the previous response"
+        in prompt
+    )
+    assert (
+        "whose source and target entities are both included in this response"
+        not in prompt
+    )
 
 
 @pytest.mark.offline
@@ -387,7 +401,7 @@ def test_json_continue_prompt_includes_quantity_limits():
         in prompt
     )
     assert (
-        "Only output relationship objects whose `source` and `target` are both included"
+        "may reference entities already extracted correctly in the previous response"
         in prompt
     )
 
@@ -455,6 +469,29 @@ async def test_text_mode_gleaned_relation_merges_cleanly_after_recovery():
 
     entities, relationships = chunk_results[0]
     assert len(entities) == 2
+    assert len(relationships) == 1
+    relation_data = next(iter(relationships.values()))[0]
+    assert relation_data["src_id"] == "Alice"
+    assert relation_data["tgt_id"] == "Acme Corp"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_text_mode_gleaned_relation_can_reference_prior_entity():
+    from lightrag.operate import extract_entities
+
+    global_config = _make_global_config(use_json=False, max_gleaning=1)
+    llm_func = global_config["llm_model_func"]
+    llm_func.side_effect = _TEXT_MODE_CROSS_PASS_RELATION_RESPONSES
+
+    with patch("lightrag.operate.logger"):
+        chunk_results = await extract_entities(
+            chunks=_make_chunks(),
+            global_config=global_config,
+        )
+
+    entities, relationships = chunk_results[0]
+    assert set(entities.keys()) == {"Alice", "Acme Corp"}
     assert len(relationships) == 1
     relation_data = next(iter(relationships.values()))[0]
     assert relation_data["src_id"] == "Alice"

--- a/tests/test_entity_extraction_stability.py
+++ b/tests/test_entity_extraction_stability.py
@@ -36,6 +36,8 @@ def _make_global_config(
     return {
         "llm_model_func": AsyncMock(return_value=""),
         "entity_extract_max_gleaning": max_gleaning,
+        "entity_extract_max_records": 100,
+        "entity_extract_max_entities": 40,
         "addon_params": addon_params if addon_params is not None else {},
         "tokenizer": tokenizer,
         "max_extract_input_tokens": 20480,
@@ -225,6 +227,8 @@ async def test_text_mode_default_guidance_injected_into_prompt():
     assert PROMPTS["default_entity_types_guidance"] in system_prompt
     assert "must start with `relation`, never `entity`" in system_prompt
     assert "After the last entity row, switch prefixes to `relation`" in system_prompt
+    assert "Output at most 100 total rows" in system_prompt
+    assert "Output at most 40 entity rows" in system_prompt
 
 
 @pytest.mark.offline
@@ -261,6 +265,25 @@ def test_text_continue_prompt_requires_relation_prefix_for_corrections():
         "Any corrected relationship row must be emitted with the literal `relation` prefix"
         in prompt
     )
+    assert (
+        "output at most {max_total_records} total rows and at most {max_entity_records} entity rows"
+        in prompt
+    )
+
+
+@pytest.mark.offline
+def test_text_user_prompt_includes_quantity_limits():
+    from lightrag.prompt import PROMPTS
+
+    prompt = PROMPTS["entity_extraction_user_prompt"]
+    assert (
+        "output at most {max_total_records} total rows and at most {max_entity_records} entity rows"
+        in prompt
+    )
+    assert (
+        "If the row limit is reached, output `{completion_delimiter}` immediately"
+        in prompt
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -289,6 +312,8 @@ async def test_json_mode_default_guidance_injected_into_prompt():
     call_kwargs = llm_func.call_args_list[0][1]
     system_prompt = call_kwargs.get("system_prompt", "")
     assert PROMPTS["default_entity_types_guidance"] in system_prompt
+    assert "Output at most 100 total records" in system_prompt
+    assert "Output at most 40 entity objects" in system_prompt
 
 
 @pytest.mark.offline
@@ -335,6 +360,36 @@ async def test_json_mode_custom_guidance_overrides_default():
     call_kwargs = llm_func.call_args_list[0][1]
     system_prompt = call_kwargs.get("system_prompt", "")
     assert custom_guidance in system_prompt
+
+
+@pytest.mark.offline
+def test_json_user_prompt_includes_quantity_limits():
+    from lightrag.prompt import PROMPTS
+
+    prompt = PROMPTS["entity_extraction_json_user_prompt"]
+    assert (
+        "output at most {max_total_records} total records and at most {max_entity_records} entity objects"
+        in prompt
+    )
+    assert (
+        "Only output relationship objects whose `source` and `target` are both included"
+        in prompt
+    )
+
+
+@pytest.mark.offline
+def test_json_continue_prompt_includes_quantity_limits():
+    from lightrag.prompt import PROMPTS
+
+    prompt = PROMPTS["entity_continue_extraction_json_user_prompt"]
+    assert (
+        "output at most {max_total_records} total records and at most {max_entity_records} entity objects"
+        in prompt
+    )
+    assert (
+        "Only output relationship objects whose `source` and `target` are both included"
+        in prompt
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_extract_entities.py
+++ b/tests/test_extract_entities.py
@@ -26,6 +26,8 @@ def _make_global_config(
     return {
         "llm_model_func": AsyncMock(return_value=""),
         "entity_extract_max_gleaning": entity_extract_max_gleaning,
+        "entity_extract_max_records": 100,
+        "entity_extract_max_entities": 40,
         "addon_params": {},
         "tokenizer": tokenizer,
         "max_extract_input_tokens": max_extract_input_tokens,


### PR DESCRIPTION
## Summary
- Cap per-response LLM output in entity extraction at 100 total rows / 40 entity rows by default, with a matching `{completion_delimiter}` early-stop instruction for text mode
- Expose the caps as `MAX_EXTRACTION_RECORDS` and `MAX_EXTRACTION_ENTITIES` env vars (plumbed through `constants.py` → `LightRAG` dataclass → `global_config` → prompt placeholders)
- Applies consistently across text + JSON modes and the corresponding continue/gleaning prompts

## Test plan
- [x] `pytest tests` — 846 passed, 1 skipped
- [x] `pytest tests/test_entity_extraction_stability.py tests/test_extract_entities.py` — 20 passed
- [x] `ruff check` on all touched files — clean
- [ ] Manual: set `MAX_EXTRACTION_RECORDS=50` in `.env` and confirm the rendered prompt reflects the override

🤖 Generated with [Claude Code](https://claude.com/claude-code)