### PR TITLE
♻️ refactor(llm): unify keyword extraction across providers

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -37,7 +37,6 @@ from .config import (
 from lightrag.utils import get_env_value
 from lightrag import LightRAG, __version__ as core_version
 from lightrag.api import __api_version__
-from lightrag.types import GPTKeywordExtractionFormat
 from lightrag.utils import EmbeddingFunc
 from lightrag.constants import (
     DEFAULT_LOG_MAX_BYTES,
@@ -503,9 +502,6 @@ def create_app(args):
         ) -> str:
             from lightrag.llm.openai import openai_complete_if_cache
 
-            keyword_extraction = kwargs.pop("keyword_extraction", None)
-            if keyword_extraction:
-                kwargs["response_format"] = GPTKeywordExtractionFormat
             if history_messages is None:
                 history_messages = []
 
@@ -521,6 +517,7 @@ def create_app(args):
                 history_messages=history_messages,
                 base_url=args.llm_binding_host,
                 api_key=args.llm_binding_api_key,
+                keyword_extraction=keyword_extraction,
                 **kwargs,
             )
 
@@ -540,9 +537,6 @@ def create_app(args):
         ) -> str:
             from lightrag.llm.azure_openai import azure_openai_complete_if_cache
 
-            keyword_extraction = kwargs.pop("keyword_extraction", None)
-            if keyword_extraction:
-                kwargs["response_format"] = GPTKeywordExtractionFormat
             if history_messages is None:
                 history_messages = []
 
@@ -558,6 +552,7 @@ def create_app(args):
                 history_messages=history_messages,
                 base_url=args.llm_binding_host,
                 api_key=os.getenv("AZURE_OPENAI_API_KEY", args.llm_binding_api_key),
+                keyword_extraction=keyword_extraction,
                 api_version=os.getenv("AZURE_OPENAI_API_VERSION", "2024-08-01-preview"),
                 **kwargs,
             )
@@ -746,12 +741,8 @@ def create_app(args):
                     entity_extraction=False,
                     **kwargs,
                 ):
-                    keyword_extraction = kwargs.pop("keyword_extraction", None)
-                    entity_extraction = kwargs.pop(
-                        "entity_extraction", entity_extraction
-                    )
                     if keyword_extraction or entity_extraction:
-                        kwargs["format"] = "json"
+                        kwargs["response_format"] = {"type": "json_object"}
                     if history_messages is None:
                         history_messages = []
                     if role_provider_options:
@@ -781,8 +772,6 @@ def create_app(args):
                     entity_extraction=False,
                     **kwargs,
                 ):
-                    kwargs.pop("entity_extraction", entity_extraction)
-                    kwargs.pop("keyword_extraction", keyword_extraction)
                     if history_messages is None:
                         history_messages = []
                     if role_provider_options:
@@ -810,9 +799,6 @@ def create_app(args):
                     keyword_extraction=False,
                     **kwargs,
                 ) -> str:
-                    keyword_extraction = kwargs.pop("keyword_extraction", None)
-                    if keyword_extraction:
-                        kwargs["response_format"] = GPTKeywordExtractionFormat
                     if history_messages is None:
                         history_messages = []
                     kwargs["timeout"] = role_timeout
@@ -825,6 +811,7 @@ def create_app(args):
                         history_messages=history_messages,
                         base_url=role_host,
                         api_key=os.getenv("AZURE_OPENAI_API_KEY", role_apikey),
+                        keyword_extraction=keyword_extraction,
                         api_version=os.getenv(
                             "AZURE_OPENAI_API_VERSION", "2024-08-01-preview"
                         ),
@@ -869,9 +856,6 @@ def create_app(args):
                 keyword_extraction=False,
                 **kwargs,
             ) -> str:
-                keyword_extraction = kwargs.pop("keyword_extraction", None)
-                if keyword_extraction:
-                    kwargs["response_format"] = GPTKeywordExtractionFormat
                 if history_messages is None:
                     history_messages = []
                 kwargs["timeout"] = role_timeout
@@ -884,6 +868,7 @@ def create_app(args):
                     history_messages=history_messages,
                     base_url=role_host,
                     api_key=role_apikey,
+                    keyword_extraction=keyword_extraction,
                     **kwargs,
                 )
 
@@ -1160,9 +1145,6 @@ def create_app(args):
         # Lazy import
         from lightrag.llm.bedrock import bedrock_complete_if_cache
 
-        keyword_extraction = kwargs.pop("keyword_extraction", None)
-        if keyword_extraction:
-            kwargs["response_format"] = GPTKeywordExtractionFormat
         if history_messages is None:
             history_messages = []
 
@@ -1174,6 +1156,7 @@ def create_app(args):
             prompt,
             system_prompt=system_prompt,
             history_messages=history_messages,
+            keyword_extraction=keyword_extraction,
             **kwargs,
         )
 

--- a/lightrag/llm/bedrock.py
+++ b/lightrag/llm/bedrock.py
@@ -158,6 +158,11 @@ async def bedrock_complete_if_cache(
         logging.debug(
             "enable_cot=True is not supported for Bedrock and will be ignored."
         )
+
+    # Bedrock Converse API has no JSON mode; drop the flag and rely on the
+    # prompt template plus downstream tolerant JSON parsing.
+    kwargs.pop("keyword_extraction", None)
+
     # Respect existing env; only set if a non-empty value is available
     access_key = os.environ.get("AWS_ACCESS_KEY_ID") or aws_access_key_id
     secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY") or aws_secret_access_key
@@ -183,7 +188,6 @@ async def bedrock_complete_if_cache(
         "logprobs",
         "top_logprobs",
         "max_completion_tokens",
-        "response_format",
     ]:
         kwargs.pop(k, None)
     # Fix message history format
@@ -344,14 +348,16 @@ async def bedrock_complete(
     entity_extraction=False,
     **kwargs,
 ) -> Union[str, AsyncIterator[str]]:
-    kwargs.pop("keyword_extraction", None)
-    kwargs.pop("entity_extraction", None)
+    # entity_extraction is absorbed by the signature and intentionally unused:
+    # Bedrock Converse API has no JSON mode, so the flag has no effect here.
+    _ = entity_extraction
     model_name = kwargs["hashing_kv"].global_config["llm_model_name"]
     result = await bedrock_complete_if_cache(
         model_name,
         prompt,
         system_prompt=system_prompt,
         history_messages=history_messages,
+        keyword_extraction=keyword_extraction,
         **kwargs,
     )
     return result

--- a/lightrag/llm/lmdeploy.py
+++ b/lightrag/llm/lmdeploy.py
@@ -102,6 +102,7 @@ async def lmdeploy_model_if_cache(
     except Exception:
         raise ImportError("Please install lmdeploy before initialize lmdeploy backend.")
     kwargs.pop("hashing_kv", None)
+    kwargs.pop("keyword_extraction", None)
     kwargs.pop("response_format", None)
     kwargs.pop("entity_extraction", None)
     max_new_tokens = kwargs.pop("max_tokens", 512)

--- a/lightrag/llm/lollms.py
+++ b/lightrag/llm/lollms.py
@@ -117,18 +117,10 @@ async def lollms_model_complete(
 ) -> Union[str, AsyncIterator[str]]:
     """Complete function for lollms model generation."""
 
-    # Extract and remove keyword_extraction and entity_extraction from kwargs if present
-    keyword_extraction = kwargs.pop("keyword_extraction", None)
-    kwargs.pop("entity_extraction", None)
-
-    # Get model name from config
+    # lollms has no JSON mode; keyword_extraction/entity_extraction flags are
+    # absorbed by the signature and ignored — the shared prompt template plus
+    # downstream tolerant JSON parsing handle structured output.
     model_name = kwargs["hashing_kv"].global_config["llm_model_name"]
-
-    # If keyword extraction is needed, we might need to modify the prompt
-    # or add specific parameters for JSON output (if lollms supports it)
-    if keyword_extraction:
-        # Note: You might need to adjust this based on how lollms handles structured output
-        pass
 
     return await lollms_model_if_cache(
         model_name,

--- a/lightrag/llm/ollama.py
+++ b/lightrag/llm/ollama.py
@@ -51,6 +51,29 @@ def _coerce_host_for_cloud_model(host: Optional[str], model: object) -> Optional
     return host
 
 
+def _normalize_ollama_response_format(kwargs: dict) -> None:
+    """Translate OpenAI-style response_format into Ollama's native format field.
+
+    Precedence: an explicit ``format`` value (Ollama's native field) wins over
+    ``response_format`` — if ``format`` is already set, ``response_format`` is
+    dropped silently. Otherwise, ``{"type": "json_object"}`` maps to
+    ``format="json"`` and any other payload is passed through unchanged so
+    callers can supply JSON schemas directly.
+    """
+
+    response_format = kwargs.pop("response_format", None)
+    if kwargs.get("format") is not None or response_format is None:
+        return
+
+    if isinstance(response_format, dict):
+        if response_format.get("type") == "json_object":
+            kwargs["format"] = "json"
+            return
+
+    # Fall back to passing through schema-like payloads for native Ollama support.
+    kwargs["format"] = response_format
+
+
 @retry(
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=4, max=10),
@@ -71,7 +94,7 @@ async def _ollama_model_if_cache(
     stream = True if kwargs.get("stream") else False
 
     kwargs.pop("max_tokens", None)
-    # kwargs.pop("response_format", None) # allow json
+    _normalize_ollama_response_format(kwargs)
     host = kwargs.pop("host", None)
     timeout = kwargs.pop("timeout", None)
     if timeout == 0:
@@ -159,10 +182,8 @@ async def ollama_model_complete(
     entity_extraction=False,
     **kwargs,
 ) -> Union[str, AsyncIterator[str]]:
-    keyword_extraction = kwargs.pop("keyword_extraction", None)
-    entity_extraction = kwargs.pop("entity_extraction", entity_extraction)
     if keyword_extraction or entity_extraction:
-        kwargs["format"] = "json"
+        kwargs["response_format"] = {"type": "json_object"}
     model_name = kwargs["hashing_kv"].global_config["llm_model_name"]
     return await _ollama_model_if_cache(
         model_name,

--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -29,7 +29,6 @@ from lightrag.utils import (
     logger,
 )
 
-from lightrag.types import GPTKeywordExtractionFormat
 from lightrag.api import __api_version__
 
 import numpy as np
@@ -304,9 +303,9 @@ async def openai_complete_if_cache(
     if entity_extraction:
         kwargs["response_format"] = {"type": "json_object"}
 
-    # Handle keyword extraction mode
+    # Handle keyword extraction mode with json_object for broader compatibility
     if keyword_extraction:
-        kwargs["response_format"] = GPTKeywordExtractionFormat
+        kwargs["response_format"] = {"type": "json_object"}
 
     # Create the OpenAI client (supports both OpenAI and Azure)
     openai_async_client = create_openai_async_client(

--- a/lightrag/llm/zhipu.py
+++ b/lightrag/llm/zhipu.py
@@ -1,6 +1,4 @@
 import sys
-import re
-import json
 from ..utils import verbose_debug
 
 if sys.version_info < (3, 9):
@@ -29,8 +27,6 @@ from lightrag.utils import (
     wrap_embedding_func_with_attrs,
     logger,
 )
-
-from lightrag.types import GPTKeywordExtractionFormat
 
 import numpy as np
 from typing import Union, List, Optional, Dict
@@ -146,57 +142,18 @@ async def zhipu_complete(
             system_prompt = f"{system_prompt}\n\n{extraction_prompt}"
         else:
             system_prompt = extraction_prompt
+        # Reasoning text would corrupt the JSON payload expected by callers.
+        enable_cot = False
 
-        try:
-            response = await zhipu_complete_if_cache(
-                prompt=prompt,
-                system_prompt=system_prompt,
-                history_messages=history_messages,
-                enable_cot=enable_cot,
-                **kwargs,
-            )
-
-            # Try to parse as JSON
-            try:
-                data = json.loads(response)
-                return GPTKeywordExtractionFormat(
-                    high_level_keywords=data.get("high_level_keywords", []),
-                    low_level_keywords=data.get("low_level_keywords", []),
-                )
-            except json.JSONDecodeError:
-                # If direct JSON parsing fails, try to extract JSON from text
-                match = re.search(r"\{[\s\S]*\}", response)
-                if match:
-                    try:
-                        data = json.loads(match.group())
-                        return GPTKeywordExtractionFormat(
-                            high_level_keywords=data.get("high_level_keywords", []),
-                            low_level_keywords=data.get("low_level_keywords", []),
-                        )
-                    except json.JSONDecodeError:
-                        pass
-
-                # If all parsing fails, log warning and return empty format
-                logger.warning(
-                    f"Failed to parse keyword extraction response: {response}"
-                )
-                return GPTKeywordExtractionFormat(
-                    high_level_keywords=[], low_level_keywords=[]
-                )
-        except Exception as e:
-            logger.error(f"Error during keyword extraction: {str(e)}")
-            return GPTKeywordExtractionFormat(
-                high_level_keywords=[], low_level_keywords=[]
-            )
-    else:
-        # For non-keyword-extraction, just return the raw response string
-        return await zhipu_complete_if_cache(
-            prompt=prompt,
-            system_prompt=system_prompt,
-            history_messages=history_messages,
-            enable_cot=enable_cot,
-            **kwargs,
-        )
+    # For both keyword extraction and normal completion, return raw text and let
+    # the caller handle tolerant JSON parsing if needed.
+    return await zhipu_complete_if_cache(
+        prompt=prompt,
+        system_prompt=system_prompt,
+        history_messages=history_messages,
+        enable_cot=enable_cot,
+        **kwargs,
+    )
 
 
 @wrap_embedding_func_with_attrs(

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import asyncio
 import json
+import re
 import json_repair
 from typing import Any, AsyncIterator, overload, Literal
 from collections import Counter, defaultdict
@@ -3782,9 +3783,95 @@ async def get_keywords_from_query(
     if query_param.hl_keywords or query_param.ll_keywords:
         return query_param.hl_keywords, query_param.ll_keywords
 
-    # Extract keywords using extract_keywords_only function which already supports conversation history
+    # Extract keywords directly from the current query text.
     hl_keywords, ll_keywords = await extract_keywords_only(
         query, query_param, global_config, hashing_kv
+    )
+    return hl_keywords, ll_keywords
+
+
+def _normalize_keyword_list(raw_values: Any, field_name: str) -> list[str]:
+    """Normalize keyword payloads into a clean list of strings.
+
+    When the field is a plain string (e.g. LLM returned CSV), split on
+    newlines/commas/semicolons. List-shaped payloads are preserved per-item so
+    multi-word phrases that legitimately contain commas are not broken apart.
+    """
+
+    if raw_values is None:
+        return []
+
+    if isinstance(raw_values, str):
+        raw_values = [
+            part.strip()
+            for part in re.split(r"[\n,;]+", raw_values)
+            if part and part.strip()
+        ]
+
+    if not isinstance(raw_values, list):
+        logger.warning(
+            "Keyword extraction field '%s' is not a list: %r",
+            field_name,
+            raw_values,
+        )
+        return []
+
+    normalized: list[str] = []
+    for idx, value in enumerate(raw_values):
+        if isinstance(value, str):
+            cleaned = value.strip()
+            if cleaned:
+                normalized.append(cleaned)
+            continue
+
+        logger.warning(
+            "Keyword extraction field '%s' contains non-string element at index %d: %r",
+            field_name,
+            idx,
+            value,
+        )
+
+    return normalized
+
+
+def _parse_keywords_payload(result: Any) -> tuple[list[str], list[str]]:
+    """Parse keyword extraction responses from heterogeneous provider outputs."""
+
+    payload: Any
+
+    if result is None:
+        return [], []
+
+    if hasattr(result, "model_dump") and callable(result.model_dump):
+        payload = result.model_dump()
+    elif isinstance(result, dict):
+        payload = result
+    elif isinstance(result, str):
+        cleaned_result = remove_think_tags(result)
+        try:
+            payload = json_repair.loads(cleaned_result)
+        except Exception as e:
+            logger.error(f"JSON parsing error: {e}; response: {cleaned_result}")
+            return [], []
+    else:
+        logger.error(
+            "Unsupported keyword extraction response type: %s",
+            type(result).__name__,
+        )
+        return [], []
+
+    if not isinstance(payload, dict):
+        logger.error(
+            "Keyword extraction payload is not a JSON object: %s",
+            type(payload).__name__,
+        )
+        return [], []
+
+    hl_keywords = _normalize_keyword_list(
+        payload.get("high_level_keywords"), "high_level_keywords"
+    )
+    ll_keywords = _normalize_keyword_list(
+        payload.get("low_level_keywords"), "low_level_keywords"
     )
     return hl_keywords, ll_keywords
 
@@ -3817,12 +3904,10 @@ async def extract_keywords_only(
     )
     if cached_result is not None:
         cached_response, _ = cached_result  # Extract content, ignore timestamp
-        try:
-            keywords_data = json_repair.loads(cached_response)
-            return keywords_data.get("high_level_keywords", []), keywords_data.get(
-                "low_level_keywords", []
-            )
-        except (json.JSONDecodeError, KeyError):
+        hl_keywords, ll_keywords = _parse_keywords_payload(cached_response)
+        if hl_keywords or ll_keywords:
+            return hl_keywords, ll_keywords
+        else:
             logger.warning(
                 "Invalid cache format for keywords, proceeding with extraction"
             )
@@ -3853,20 +3938,8 @@ async def extract_keywords_only(
 
     result = await use_model_func(kw_prompt, keyword_extraction=True)
 
-    # 5. Parse out JSON from the LLM response
-    result = remove_think_tags(result)
-    try:
-        keywords_data = json_repair.loads(result)
-        if not keywords_data:
-            logger.error("No JSON-like structure found in the LLM respond.")
-            return [], []
-    except json.JSONDecodeError as e:
-        logger.error(f"JSON parsing error: {e}")
-        logger.error(f"LLM respond: {result}")
-        return [], []
-
-    hl_keywords = keywords_data.get("high_level_keywords", [])
-    ll_keywords = keywords_data.get("low_level_keywords", [])
+    # 5. Parse out JSON from the LLM response with tolerant provider normalization
+    hl_keywords, ll_keywords = _parse_keywords_payload(result)
 
     # 6. Cache only the processed keywords with cache type
     if hl_keywords or ll_keywords:
@@ -3874,7 +3947,7 @@ async def extract_keywords_only(
             "high_level_keywords": hl_keywords,
             "low_level_keywords": ll_keywords,
         }
-        if hashing_kv.global_config.get("enable_llm_cache"):
+        if hashing_kv and hashing_kv.global_config.get("enable_llm_cache"):
             # Save to cache with query parameters
             queryparam_dict = {
                 "mode": param.mode,

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -3834,13 +3834,13 @@ def _normalize_keyword_list(raw_values: Any, field_name: str) -> list[str]:
     return normalized
 
 
-def _parse_keywords_payload(result: Any) -> tuple[list[str], list[str]]:
+def _parse_keywords_payload(result: Any) -> tuple[bool, list[str], list[str]]:
     """Parse keyword extraction responses from heterogeneous provider outputs."""
 
     payload: Any
 
     if result is None:
-        return [], []
+        return False, [], []
 
     if hasattr(result, "model_dump") and callable(result.model_dump):
         payload = result.model_dump()
@@ -3849,23 +3849,36 @@ def _parse_keywords_payload(result: Any) -> tuple[list[str], list[str]]:
     elif isinstance(result, str):
         cleaned_result = remove_think_tags(result)
         try:
-            payload = json_repair.loads(cleaned_result)
-        except Exception as e:
-            logger.error(f"JSON parsing error: {e}; response: {cleaned_result}")
-            return [], []
+            payload = json.loads(cleaned_result)
+        except json.JSONDecodeError as strict_error:
+            try:
+                payload = json_repair.loads(cleaned_result)
+                logger.warning(
+                    "Keyword extraction response required JSON repair: %s; response: %r",
+                    strict_error,
+                    cleaned_result[:500],
+                )
+            except Exception as repair_error:
+                logger.error(
+                    "JSON parsing error: %s; repair failed: %s; response: %r",
+                    strict_error,
+                    repair_error,
+                    cleaned_result[:500],
+                )
+                return False, [], []
     else:
         logger.error(
             "Unsupported keyword extraction response type: %s",
             type(result).__name__,
         )
-        return [], []
+        return False, [], []
 
     if not isinstance(payload, dict):
         logger.error(
             "Keyword extraction payload is not a JSON object: %s",
             type(payload).__name__,
         )
-        return [], []
+        return False, [], []
 
     hl_keywords = _normalize_keyword_list(
         payload.get("high_level_keywords"), "high_level_keywords"
@@ -3873,7 +3886,7 @@ def _parse_keywords_payload(result: Any) -> tuple[list[str], list[str]]:
     ll_keywords = _normalize_keyword_list(
         payload.get("low_level_keywords"), "low_level_keywords"
     )
-    return hl_keywords, ll_keywords
+    return True, hl_keywords, ll_keywords
 
 
 async def extract_keywords_only(
@@ -3904,8 +3917,10 @@ async def extract_keywords_only(
     )
     if cached_result is not None:
         cached_response, _ = cached_result  # Extract content, ignore timestamp
-        hl_keywords, ll_keywords = _parse_keywords_payload(cached_response)
-        if hl_keywords or ll_keywords:
+        is_valid_payload, hl_keywords, ll_keywords = _parse_keywords_payload(
+            cached_response
+        )
+        if is_valid_payload:
             return hl_keywords, ll_keywords
         else:
             logger.warning(
@@ -3939,7 +3954,7 @@ async def extract_keywords_only(
     result = await use_model_func(kw_prompt, keyword_extraction=True)
 
     # 5. Parse out JSON from the LLM response with tolerant provider normalization
-    hl_keywords, ll_keywords = _parse_keywords_payload(result)
+    _, hl_keywords, ll_keywords = _parse_keywords_payload(result)
 
     # 6. Cache only the processed keywords with cache type
     if hl_keywords or ll_keywords:

--- a/lightrag/prompt.py
+++ b/lightrag/prompt.py
@@ -630,11 +630,17 @@ Given a user query, your task is to extract two distinct types of keywords:
 2. **low_level_keywords**: for specific entities or details, identifying the specific entities, proper nouns, technical jargon, product names, or concrete items.
 
 ---Instructions & Constraints---
-1. **Output Format**: Your output MUST be a valid JSON object and nothing else. Do not include any explanatory text, markdown code fences (like ```json), or any other text before or after the JSON. It will be parsed directly by a JSON parser.
-2. **Source of Truth**: All keywords must be explicitly derived from the user query, with both high-level and low-level keyword categories are required to contain content.
-3. **Concise & Meaningful**: Keywords should be concise words or meaningful phrases. Prioritize multi-word phrases when they represent a single concept. For example, from "latest financial report of Apple Inc.", you should extract "latest financial report" and "Apple Inc." rather than "latest", "financial", "report", and "Apple".
-4. **Handle Edge Cases**: For queries that are too simple, vague, or nonsensical (e.g., "hello", "ok", "asdfghjkl"), you must return a JSON object with empty lists for both keyword types.
-5. **Language**: All extracted keywords MUST be in {language}. Proper nouns (e.g., personal names, place names, organization names) should be kept in their original language.
+1. **Output Format**: Your output MUST be a valid JSON object and nothing else. Do not include any explanatory text, markdown code fences (like ```json), comments, or any other text before or after the JSON.
+2. **Exact JSON Shape**: The JSON object must contain exactly these two keys:
+   - `"high_level_keywords"`: an array of strings
+   - `"low_level_keywords"`: an array of strings
+3. **JSON Boundary**: The first character of your response must be `{{` and the last character must be `}}`.
+4. **Source of Truth**: All keywords must be explicitly derived from the user query. Do not infer unsupported facts. Do not invent entities, products, organizations, dates, or technical terms that are not grounded in the query.
+5. **Concise & Meaningful**: Keywords should be concise words or meaningful phrases. Prioritize multi-word phrases when they represent a single concept. For example, from "latest financial report of Apple Inc.", extract "latest financial report" and "Apple Inc." rather than "latest", "financial", "report", and "Apple".
+6. **Handle Edge Cases**: For queries that are too simple, vague, or nonsensical (e.g., "hello", "ok", "asdfghjkl"), return:
+   `{{"high_level_keywords": [], "low_level_keywords": []}}`
+7. **No Duplicates**: Do not repeat the same keyword within a list. Keep the lists short and high-signal.
+8. **Language**: All extracted keywords MUST be in {language}. Proper nouns (e.g., personal names, place names, organization names) should be kept in their original language.
 
 ---Examples---
 {examples}

--- a/lightrag/types.py
+++ b/lightrag/types.py
@@ -4,11 +4,6 @@ from pydantic import BaseModel, Field
 from typing import Any, Optional
 
 
-class GPTKeywordExtractionFormat(BaseModel):
-    high_level_keywords: list[str]
-    low_level_keywords: list[str]
-
-
 class ExtractedEntity(BaseModel):
     """A single entity extracted from text by the LLM."""
 

--- a/tests/test_bedrock_llm.py
+++ b/tests/test_bedrock_llm.py
@@ -1,0 +1,77 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from lightrag.llm.bedrock import bedrock_complete, bedrock_complete_if_cache
+
+
+class _FakeBedrockClient:
+    def __init__(self, captured_calls: list[dict]):
+        self._captured_calls = captured_calls
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def converse(self, **kwargs):
+        self._captured_calls.append(kwargs)
+        return {
+            "output": {
+                "message": {
+                    "content": [
+                        {
+                            "text": '{"high_level_keywords":["AI"],"low_level_keywords":["RAG"]}'
+                        }
+                    ]
+                }
+            }
+        }
+
+
+class _FakeSession:
+    def __init__(self, captured_calls: list[dict]):
+        self._captured_calls = captured_calls
+
+    def client(self, *_args, **_kwargs):
+        return _FakeBedrockClient(self._captured_calls)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_bedrock_complete_forwards_keyword_extraction_to_if_cache():
+    hashing_kv = SimpleNamespace(global_config={"llm_model_name": "bedrock-model"})
+
+    with patch(
+        "lightrag.llm.bedrock.bedrock_complete_if_cache",
+        AsyncMock(return_value="{}"),
+    ) as mocked_complete:
+        await bedrock_complete(
+            prompt="hello",
+            hashing_kv=hashing_kv,
+            keyword_extraction=True,
+        )
+
+    assert mocked_complete.await_args.kwargs["keyword_extraction"] is True
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_bedrock_keyword_extraction_does_not_inject_system_prompt():
+    captured_calls: list[dict] = []
+
+    with patch(
+        "lightrag.llm.bedrock.aioboto3.Session",
+        return_value=_FakeSession(captured_calls),
+    ):
+        result = await bedrock_complete_if_cache(
+            model="bedrock-model",
+            prompt="hello",
+            keyword_extraction=True,
+        )
+
+    assert result == '{"high_level_keywords":["AI"],"low_level_keywords":["RAG"]}'
+    assert len(captured_calls) == 1
+    assert "system" not in captured_calls[0]

--- a/tests/test_keyword_extraction_drivers.py
+++ b/tests/test_keyword_extraction_drivers.py
@@ -1,0 +1,111 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from lightrag.llm.lmdeploy import lmdeploy_model_if_cache
+from lightrag.llm.lollms import lollms_model_complete
+from lightrag.llm.ollama import _ollama_model_if_cache, ollama_model_complete
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_ollama_keyword_extraction_preserves_explicit_flag():
+    hashing_kv = SimpleNamespace(global_config={"llm_model_name": "ollama-model"})
+
+    with patch(
+        "lightrag.llm.ollama._ollama_model_if_cache",
+        AsyncMock(return_value="{}"),
+    ) as mocked_complete:
+        await ollama_model_complete(
+            prompt="hello",
+            hashing_kv=hashing_kv,
+            keyword_extraction=True,
+        )
+
+    assert mocked_complete.await_args.kwargs["response_format"] == {
+        "type": "json_object"
+    }
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_ollama_translates_json_object_response_format_to_native_format():
+    captured_kwargs = {}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            self._client = SimpleNamespace(aclose=AsyncMock())
+
+        async def chat(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            return {"message": {"content": "{}"}}
+
+    with patch("lightrag.llm.ollama.ollama.AsyncClient", FakeAsyncClient):
+        result = await _ollama_model_if_cache(
+            model="ollama-model",
+            prompt="hello",
+            response_format={"type": "json_object"},
+        )
+
+    assert result == "{}"
+    assert captured_kwargs["format"] == "json"
+    assert "response_format" not in captured_kwargs
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_lollms_keyword_extraction_preserves_explicit_flag():
+    hashing_kv = SimpleNamespace(global_config={"llm_model_name": "lollms-model"})
+
+    with patch(
+        "lightrag.llm.lollms.lollms_model_if_cache",
+        AsyncMock(return_value="{}"),
+    ) as mocked_complete:
+        await lollms_model_complete(
+            prompt="hello",
+            hashing_kv=hashing_kv,
+            keyword_extraction=True,
+        )
+
+    forwarded_kwargs = mocked_complete.await_args.kwargs
+    assert "keyword_extraction" not in forwarded_kwargs
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_lmdeploy_strips_keyword_extraction_before_generation_config(monkeypatch):
+    captured_gen_config_kwargs = {}
+
+    class FakeGenerationConfig:
+        def __init__(self, **kwargs):
+            captured_gen_config_kwargs.update(kwargs)
+
+    class FakeVersion:
+        def __lt__(self, other):
+            return False
+
+    async def fake_generate(*_args, **_kwargs):
+        yield SimpleNamespace(response="{}")
+
+    monkeypatch.setattr(
+        "lightrag.llm.lmdeploy.initialize_lmdeploy_pipeline",
+        lambda **_kwargs: SimpleNamespace(generate=fake_generate),
+    )
+
+    import sys
+
+    sys.modules["lmdeploy"] = SimpleNamespace(
+        __version__="0.6.0",
+        version_info=FakeVersion(),
+        GenerationConfig=FakeGenerationConfig,
+    )
+
+    result = await lmdeploy_model_if_cache(
+        model="lmdeploy-model",
+        prompt="hello",
+        keyword_extraction=True,
+    )
+
+    assert result == "{}"
+    assert "keyword_extraction" not in captured_gen_config_kwargs

--- a/tests/test_keyword_parsing.py
+++ b/tests/test_keyword_parsing.py
@@ -1,0 +1,33 @@
+import pytest
+
+from lightrag.operate import _parse_keywords_payload
+
+
+class _FakeKeywordModel:
+    def model_dump(self):
+        return {
+            "high_level_keywords": ["AI"],
+            "low_level_keywords": ["RAG", "Graph"],
+        }
+
+
+@pytest.mark.offline
+def test_parse_keywords_payload_accepts_model_like_objects():
+    hl_keywords, ll_keywords = _parse_keywords_payload(_FakeKeywordModel())
+
+    assert hl_keywords == ["AI"]
+    assert ll_keywords == ["RAG", "Graph"]
+
+
+@pytest.mark.offline
+def test_parse_keywords_payload_extracts_json_from_wrapped_text():
+    result = """
+    analysis first
+    {"high_level_keywords":"AI, Agents","low_level_keywords":["RAG","LightRAG"]}
+    trailing note
+    """
+
+    hl_keywords, ll_keywords = _parse_keywords_payload(result)
+
+    assert hl_keywords == ["AI", "Agents"]
+    assert ll_keywords == ["RAG", "LightRAG"]

--- a/tests/test_keyword_parsing.py
+++ b/tests/test_keyword_parsing.py
@@ -1,6 +1,8 @@
 import pytest
+from unittest.mock import patch
 
-from lightrag.operate import _parse_keywords_payload
+from lightrag.base import QueryParam
+from lightrag.operate import _parse_keywords_payload, extract_keywords_only
 
 
 class _FakeKeywordModel:
@@ -13,8 +15,9 @@ class _FakeKeywordModel:
 
 @pytest.mark.offline
 def test_parse_keywords_payload_accepts_model_like_objects():
-    hl_keywords, ll_keywords = _parse_keywords_payload(_FakeKeywordModel())
+    is_valid, hl_keywords, ll_keywords = _parse_keywords_payload(_FakeKeywordModel())
 
+    assert is_valid is True
     assert hl_keywords == ["AI"]
     assert ll_keywords == ["RAG", "Graph"]
 
@@ -27,7 +30,48 @@ def test_parse_keywords_payload_extracts_json_from_wrapped_text():
     trailing note
     """
 
-    hl_keywords, ll_keywords = _parse_keywords_payload(result)
+    is_valid, hl_keywords, ll_keywords = _parse_keywords_payload(result)
 
+    assert is_valid is True
     assert hl_keywords == ["AI", "Agents"]
     assert ll_keywords == ["RAG", "LightRAG"]
+
+
+@pytest.mark.offline
+def test_parse_keywords_payload_warns_when_json_repair_is_used():
+    broken_result = (
+        '{"high_level_keywords":"AI, Agents","low_level_keywords":["RAG","LightRAG"]'
+    )
+
+    with patch("lightrag.operate.logger.warning") as mocked_warning:
+        is_valid, hl_keywords, ll_keywords = _parse_keywords_payload(broken_result)
+
+    assert is_valid is True
+    assert hl_keywords == ["AI", "Agents"]
+    assert ll_keywords == ["RAG", "LightRAG"]
+    mocked_warning.assert_called_once()
+    assert "Keyword extraction response required JSON repair" in mocked_warning.call_args[0][0]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_extract_keywords_only_accepts_empty_keyword_cache_without_requery():
+    async def should_not_run(*_args, **_kwargs):
+        raise AssertionError("model_func should not be called on a valid empty cache hit")
+
+    param = QueryParam(model_func=should_not_run)
+    global_config = {"addon_params": {"language": "en"}}
+
+    with patch(
+        "lightrag.operate.handle_cache",
+        return_value=('{"high_level_keywords":[],"low_level_keywords":[]}', None),
+    ):
+        hl_keywords, ll_keywords = await extract_keywords_only(
+            "hello",
+            param,
+            global_config,
+            hashing_kv=None,
+        )
+
+    assert hl_keywords == []
+    assert ll_keywords == []

--- a/tests/test_keyword_prompt_template.py
+++ b/tests/test_keyword_prompt_template.py
@@ -1,0 +1,15 @@
+import pytest
+
+from lightrag.prompt import PROMPTS
+
+
+@pytest.mark.offline
+def test_keywords_extraction_prompt_template_formats_with_literal_json_braces():
+    rendered = PROMPTS["keywords_extraction"].format(
+        query="hello",
+        examples="example",
+        language="en",
+    )
+
+    assert "first character of your response must be `{`" in rendered
+    assert '{"high_level_keywords": [], "low_level_keywords": []}' in rendered

--- a/tests/test_openai_length_finish_reason.py
+++ b/tests/test_openai_length_finish_reason.py
@@ -59,3 +59,52 @@ async def test_length_finish_reason_falls_back_to_raw_content():
     fake_client.chat.completions.parse.assert_awaited_once()
     fake_client.chat.completions.create.assert_not_called()
     fake_client.close.assert_awaited_once()
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_keyword_extraction_uses_json_object_create_mode():
+    completion = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content='{"high_level_keywords":["AI"],"low_level_keywords":["RAG"]}',
+                    parsed=None,
+                    reasoning_content="",
+                )
+            )
+        ],
+        usage=SimpleNamespace(
+            prompt_tokens=5,
+            completion_tokens=6,
+            total_tokens=11,
+        ),
+    )
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                parse=AsyncMock(),
+                create=AsyncMock(return_value=completion),
+            )
+        ),
+        close=AsyncMock(),
+    )
+
+    with patch(
+        "lightrag.llm.openai.create_openai_async_client",
+        return_value=fake_client,
+    ):
+        result = await openai_complete_if_cache(
+            model="test-model",
+            prompt="Extract keywords",
+            keyword_extraction=True,
+        )
+
+    assert result == '{"high_level_keywords":["AI"],"low_level_keywords":["RAG"]}'
+    fake_client.chat.completions.parse.assert_not_called()
+    fake_client.chat.completions.create.assert_awaited_once()
+    assert fake_client.chat.completions.create.await_args.kwargs["response_format"] == {
+        "type": "json_object"
+    }
+    fake_client.close.assert_awaited_once()

--- a/tests/test_zhipu_llm.py
+++ b/tests/test_zhipu_llm.py
@@ -195,5 +195,4 @@ async def test_zhipu_keyword_extraction_ignores_reasoning_content(monkeypatch):
         enable_cot=True,
     )
 
-    assert result.high_level_keywords == ["AI"]
-    assert result.low_level_keywords == ["RAG"]
+    assert result == '{"high_level_keywords": ["AI"], "low_level_keywords": ["RAG"]}'


### PR DESCRIPTION
## Summary

- Decouple keyword extraction from the OpenAI-specific `GPTKeywordExtractionFormat` Pydantic schema and consolidate tolerant JSON parsing in `operate._parse_keywords_payload`. Providers now return raw strings; the caller handles JSON parsing, model-object unwrap, CSV fallbacks, and empty results uniformly.
- Standardize `response_format={"type": "json_object"}` where providers support JSON mode (OpenAI / Azure / Ollama), and drop the flag where they do not (Bedrock / Lollms / Lmdeploy). Added `_normalize_ollama_response_format` to translate OpenAI-style payloads into Ollama's native `format` field, preferring an explicit `format` when set.
- Tighten the keywords-extraction prompt template: require exact JSON shape, explicit response boundaries, and an empty-list response for edge cases.
- Remove redundant `kwargs.pop("keyword_extraction", keyword_extraction)` patterns — named parameters never leak into `**kwargs`, so those lines were no-ops.
- Remove the now-unused `GPTKeywordExtractionFormat` class from `lightrag/types.py`.

## Breaking Changes

- **`zhipu_complete(..., keyword_extraction=True)` return type**: previously returned a `GPTKeywordExtractionFormat` Pydantic object with `.high_level_keywords` / `.low_level_keywords` attributes; now returns the raw JSON string from the model. Callers routing through `LightRAG` are unaffected (parsing is handled by `operate._parse_keywords_payload`). External users calling `zhipu_complete` directly must parse the string themselves (e.g. via `json.loads` or `json_repair.loads`).
- **`lightrag.types.GPTKeywordExtractionFormat` removed**: any external import of this symbol will break. Replace with a local `dict`/`TypedDict` or parse the raw JSON string yourself.

## Test plan

- [x] `pytest tests` — 857 passed, 1 skipped, 31 deselected (offline suite green)
- [x] `ruff check .` clean on touched files
- [x] New tests cover:
  - Tolerant JSON parsing of model-like objects and wrapped text (`tests/test_keyword_parsing.py`)
  - Prompt template renders literal JSON braces after `.format()` (`tests/test_keyword_prompt_template.py`)
  - Ollama `response_format → format` translation and flag propagation (`tests/test_keyword_extraction_drivers.py`)
  - Bedrock keyword-extraction plumbing drops unsupported flags without injecting system prompt (`tests/test_bedrock_llm.py`)
  - OpenAI keyword extraction uses `json_object` create-mode (`tests/test_openai_length_finish_reason.py`)
  - Zhipu returns raw JSON string, with parsing delegated to `_parse_keywords_payload` (`tests/test_zhipu_llm.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
