### PR TITLE
fix(webui): graph settings not persisting when popover closes

### DIFF
--- a/lightrag_webui/src/components/graph/Settings.tsx
+++ b/lightrag_webui/src/components/graph/Settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect} from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/Popover'
 import Checkbox from '@/components/ui/Checkbox'
 import Button from '@/components/ui/Button'
@@ -64,9 +64,27 @@ const LabeledNumberInput = ({
   // Create unique ID using the label text converted to lowercase with spaces removed
   const id = `input-${label.toLowerCase().replace(/\s+/g, '-')}`;
 
+  // Keep refs in sync so the unmount effect can read the latest values
+  const currentValueRef = useRef(currentValue)
+  const valueRef = useRef(value)
+  const onEditFinishedRef = useRef(onEditFinished)
+  currentValueRef.current = currentValue
+  valueRef.current = value
+  onEditFinishedRef.current = onEditFinished
+
   useEffect(() => {
     setCurrentValue(value)
   }, [value])
+
+  // Commit any pending change when the component unmounts (e.g. popover closes)
+  useEffect(() => {
+    return () => {
+      const cur = currentValueRef.current
+      if (cur !== null && cur !== valueRef.current) {
+        onEditFinishedRef.current(cur)
+      }
+    }
+  }, [])
 
   const onValueChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -215,11 +233,7 @@ export default function Settings() {
   const setGraphQueryMaxDepth = useCallback((depth: number) => {
     if (depth < 1) return
     useSettingsStore.setState({ graphQueryMaxDepth: depth })
-    const currentLabel = useSettingsStore.getState().queryLabel
-    useSettingsStore.getState().setQueryLabel('')
-    setTimeout(() => {
-      useSettingsStore.getState().setQueryLabel(currentLabel)
-    }, 300)
+    useGraphStore.getState().setGraphDataFetchAttempted(false)
   }, [])
 
   const setGraphMaxNodes = useCallback((nodes: number) => {

--- a/lightrag_webui/src/components/graph/Settings.tsx
+++ b/lightrag_webui/src/components/graph/Settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react'
+import { useState, useCallback, useEffect, useLayoutEffect, useRef } from 'react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/Popover'
 import Checkbox from '@/components/ui/Checkbox'
 import Button from '@/components/ui/Button'
@@ -68,9 +68,11 @@ const LabeledNumberInput = ({
   const currentValueRef = useRef(currentValue)
   const valueRef = useRef(value)
   const onEditFinishedRef = useRef(onEditFinished)
-  currentValueRef.current = currentValue
-  valueRef.current = value
-  onEditFinishedRef.current = onEditFinished
+  useLayoutEffect(() => {
+    currentValueRef.current = currentValue
+    valueRef.current = value
+    onEditFinishedRef.current = onEditFinished
+  })
 
   useEffect(() => {
     setCurrentValue(value)


### PR DESCRIPTION
## Description

Graph settings (Max Query Depth, Max Nodes, Max Layout Iterations) appeared to update in the UI but silently reverted to their previous values when the settings popover was closed. For example, setting Max Query Depth to 1 would immediately revert to 3 after closing.

## Related Issues

No existing issue — discovered during local testing of the graph view.

## Changes Made

- **`LabeledNumberInput` (Settings.tsx):** Added a cleanup `useEffect` that commits any pending dirty value when the component unmounts. Uses refs (`currentValueRef`, `valueRef`, `onEditFinishedRef`) to capture the latest state without adding them as effect dependencies, avoiding stale closure issues. Refs are synced via `useLayoutEffect` to satisfy the `react-hooks/refs` lint rule.
- **`setGraphQueryMaxDepth` (Settings.tsx):** Removed an unnecessary query-label clear/restore workaround (`setQueryLabel('')` + `setTimeout`). Since `maxQueryDepth` is already in the fetch effect's dependency array in `useLightragGraph`, resetting `graphDataFetchAttempted` is sufficient to trigger a re-fetch with the new depth.

**Root cause:** React does not fire `onBlur` when a component is unmounted. The Popover closing unmounts `LabeledNumberInput` before blur fires, so `onEditFinished` was never called with the new value.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

This fix applies to all three `LabeledNumberInput` instances in the graph settings popover (Max Query Depth, Max Nodes, Max Layout Iterations), not just Max Query Depth.

## Test Plan

Frontend-only change (no Python code modified):

- `bun run lint` — clean (0 errors, 0 warnings)
- `bun test` — 3 passed, 0 failed
- `bun run build` — success (built in ~18s, no errors)