### PR TITLE
refactor(gemini): improve default endpoint handling and sdk integration

### DIFF
--- a/env.example
+++ b/env.example
@@ -333,8 +333,8 @@ LLM_MODEL=gpt-5-mini
 
 ### Google Gemini example (AI Studio)
 # # LLM_BINDING=gemini
+# # LLM_BINDING_HOST=DEFAULT_GEMINI_ENDPOINT
 # # LLM_BINDING_API_KEY=your_gemini_api_key
-# # LLM_BINDING_HOST=https://generativelanguage.googleapis.com
 # # LLM_MODEL=gemini-flash-latest
 
 ### use the following command to see all support options for OpenAI, azure_openai or OpenRouter

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -66,9 +66,9 @@ def get_default_host(binding_type: str) -> str:
         "lollms": os.getenv("LLM_BINDING_HOST", "http://localhost:9600"),
         "azure_openai": os.getenv("AZURE_OPENAI_ENDPOINT", "https://api.openai.com/v1"),
         "openai": os.getenv("LLM_BINDING_HOST", "https://api.openai.com/v1"),
-        "gemini": os.getenv(
-            "LLM_BINDING_HOST", "https://generativelanguage.googleapis.com"
-        ),
+        # Let google-genai pick the correct default endpoint/version unless the
+        # user explicitly overrides LLM_BINDING_HOST / EMBEDDING_BINDING_HOST.
+        "gemini": os.getenv("LLM_BINDING_HOST", "DEFAULT_GEMINI_ENDPOINT"),
     }
     return default_hosts.get(
         binding_type, os.getenv("LLM_BINDING_HOST", "http://localhost:11434")

--- a/lightrag/llm/gemini.py
+++ b/lightrag/llm/gemini.py
@@ -49,6 +49,33 @@ class InvalidResponseError(Exception):
     pass
 
 
+_DEFAULT_GEMINI_BASE_URLS = {
+    "https://generativelanguage.googleapis.com",
+    "https://generativelanguage.googleapis.com/",
+    "https://generativelanguage.googleapis.com/v1beta",
+    "https://generativelanguage.googleapis.com/v1beta/",
+    "https://generativelanguage.googleapis.com/v1",
+    "https://generativelanguage.googleapis.com/v1/",
+}
+
+
+def _normalize_gemini_base_url(base_url: str | None) -> str | None:
+    """Treat Google's default Gemini API service roots as SDK defaults."""
+    if not base_url:
+        return None
+
+    normalized = base_url.strip()
+    if not normalized or normalized == "DEFAULT_GEMINI_ENDPOINT":
+        return None
+
+    if normalized.rstrip("/") in {
+        service_root.rstrip("/") for service_root in _DEFAULT_GEMINI_BASE_URLS
+    }:
+        return None
+
+    return normalized
+
+
 @lru_cache(maxsize=8)
 def _get_gemini_client(
     api_key: str, base_url: str | None, timeout: int | None = None
@@ -65,6 +92,7 @@ def _get_gemini_client(
         genai.Client: Configured Gemini client instance.
     """
     client_kwargs: dict[str, Any] = {}
+    normalized_base_url = _normalize_gemini_base_url(base_url)
 
     # Add Vertex AI support
     use_vertexai = os.getenv("GOOGLE_GENAI_USE_VERTEXAI", "").lower() == "true"
@@ -85,11 +113,11 @@ def _get_gemini_client(
         # Standard Gemini API mode: use api_key
         client_kwargs["api_key"] = api_key
 
-    if base_url and base_url != "DEFAULT_GEMINI_ENDPOINT" or timeout is not None:
+    if normalized_base_url is not None or timeout is not None:
         try:
             http_options_kwargs = {}
-            if base_url and base_url != "DEFAULT_GEMINI_ENDPOINT":
-                http_options_kwargs["base_url"] = base_url
+            if normalized_base_url is not None:
+                http_options_kwargs["base_url"] = normalized_base_url
             if timeout is not None:
                 http_options_kwargs["timeout"] = timeout
 

--- a/tests/test_api_config_gemini.py
+++ b/tests/test_api_config_gemini.py
@@ -1,0 +1,12 @@
+import pytest
+
+from lightrag.api.config import get_default_host
+
+
+pytestmark = pytest.mark.offline
+
+
+def test_gemini_default_host_uses_sdk_default_endpoint(monkeypatch):
+    monkeypatch.delenv("LLM_BINDING_HOST", raising=False)
+
+    assert get_default_host("gemini") == "DEFAULT_GEMINI_ENDPOINT"

--- a/tests/test_gemini_llm.py
+++ b/tests/test_gemini_llm.py
@@ -193,6 +193,7 @@ async def test_gemini_streaming_structured_output_disables_cot(monkeypatch):
         stream=True,
         enable_cot=True,
         response_format={"type": "json_object"},
+        api_key="test-key",
     )
     chunks = []
     async for chunk in stream:

--- a/tests/test_gemini_llm.py
+++ b/tests/test_gemini_llm.py
@@ -127,6 +127,41 @@ def test_gemini_rejects_typed_response_format(monkeypatch):
 
 
 @pytest.mark.offline
+def test_gemini_default_service_root_is_not_treated_as_custom_base_url(monkeypatch):
+    gemini_module = _load_gemini_module(monkeypatch)
+    gemini_module._get_gemini_client.cache_clear()
+    monkeypatch.delenv("GOOGLE_GENAI_USE_VERTEXAI", raising=False)
+
+    client = gemini_module._get_gemini_client(
+        "test-key",
+        "https://generativelanguage.googleapis.com",
+        1234,
+    )
+
+    assert client.kwargs["api_key"] == "test-key"
+    assert "http_options" in client.kwargs
+    assert client.kwargs["http_options"].kwargs == {"timeout": 1234}
+
+
+@pytest.mark.offline
+def test_gemini_custom_base_url_is_preserved(monkeypatch):
+    gemini_module = _load_gemini_module(monkeypatch)
+    gemini_module._get_gemini_client.cache_clear()
+    monkeypatch.delenv("GOOGLE_GENAI_USE_VERTEXAI", raising=False)
+
+    client = gemini_module._get_gemini_client(
+        "test-key",
+        "https://proxy.example.com",
+        1234,
+    )
+
+    assert client.kwargs["http_options"].kwargs == {
+        "base_url": "https://proxy.example.com",
+        "timeout": 1234,
+    }
+
+
+@pytest.mark.offline
 @pytest.mark.asyncio
 async def test_gemini_streaming_structured_output_disables_cot(monkeypatch):
     gemini_module = _load_gemini_module(monkeypatch)

--- a/tests/test_gemini_llm.py
+++ b/tests/test_gemini_llm.py
@@ -170,6 +170,7 @@ async def test_gemini_streaming_structured_output_disables_cot(monkeypatch):
         regular_text='{"answer":"ok"}',
         thought_text="this should not be included",
     )
+
     async def _single_chunk_stream(response):
         yield response
 


### PR DESCRIPTION
## Description

Improve Gemini endpoint handling so LightRAG uses the google-genai SDK defaults for official Gemini service roots instead of treating them as custom base URLs. This avoids 404 failures during query keyword extraction and keeps custom proxy endpoints working.

## Related Issues

N/A

## Changes Made

- normalize Gemini base URLs and treat `DEFAULT_GEMINI_ENDPOINT` plus official Google Gemini service roots as SDK-managed defaults
- change the default Gemini host in API config to `DEFAULT_GEMINI_ENDPOINT` instead of a hardcoded Google API URL
- update `env.example` Vertex AI guidance to prefer the SDK default endpoint selection path
- add offline regression tests for default Gemini host selection and custom base URL preservation

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Local validation run:
- `./scripts/test.sh tests/test_gemini_llm.py`
- `./scripts/test.sh tests/test_api_config_gemini.py`

This PR is intentionally based on `dev` as requested.
