### PR TITLE
refactor(bedrock): support default and custom endpoints

### DIFF
--- a/env.example
+++ b/env.example
@@ -285,7 +285,7 @@ MAX_PARALLEL_INSERT=2
 ###########################################################################
 ### LLM Configuration
 ### LLM_BINDING type: openai, ollama, lollms, azure_openai, aws_bedrock, gemini
-### LLM_BINDING_HOST: Service endpoint (left empty if using default endpoint provided by openai or gemini SDK)
+### LLM_BINDING_HOST: Service endpoint (left empty if using the provider SDK default endpoint)
 ### LLM_BINDING_API_KEY: api key
 ### If LightRAG deployed in Docker:
 ###    uses host.docker.internal instead of localhost in LLM_BINDING_HOST
@@ -379,6 +379,8 @@ OLLAMA_LLM_NUM_CTX=32768
 ### Bedrock uses AWS credentials from the environment / AWS credential chain.
 ### It does not use LLM_BINDING_API_KEY.
 # # LLM_BINDING=aws_bedrock
+# # LLM_BINDING_HOST=DEFAULT_BEDROCK_ENDPOINT
+# # Or set LLM_BINDING_HOST to a custom Bedrock-compatible proxy/gateway URL
 # # LLM_MODEL=anthropic.claude-3-5-sonnet-20241022-v2:0
 # AWS_ACCESS_KEY_ID=your_aws_access_key_id
 # AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
@@ -484,6 +486,8 @@ OLLAMA_EMBEDDING_NUM_CTX=8192
 ### Bedrock uses AWS credentials from the environment / AWS credential chain.
 ### It does not use EMBEDDING_BINDING_API_KEY.
 # # EMBEDDING_BINDING=aws_bedrock
+# # EMBEDDING_BINDING_HOST=DEFAULT_BEDROCK_ENDPOINT
+# # Or set EMBEDDING_BINDING_HOST to a custom Bedrock-compatible proxy/gateway URL
 # # EMBEDDING_MODEL=amazon.titan-embed-text-v2:0
 # # EMBEDDING_DIM=1024
 # AWS_ACCESS_KEY_ID=your_aws_access_key_id

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -66,6 +66,9 @@ def get_default_host(binding_type: str) -> str:
         "lollms": os.getenv("LLM_BINDING_HOST", "http://localhost:9600"),
         "azure_openai": os.getenv("AZURE_OPENAI_ENDPOINT", "https://api.openai.com/v1"),
         "openai": os.getenv("LLM_BINDING_HOST", "https://api.openai.com/v1"),
+        # Let boto3 select the regional Bedrock endpoint unless the user
+        # explicitly overrides LLM_BINDING_HOST / EMBEDDING_BINDING_HOST.
+        "aws_bedrock": os.getenv("LLM_BINDING_HOST", "DEFAULT_BEDROCK_ENDPOINT"),
         # Let google-genai pick the correct default endpoint/version unless the
         # user explicitly overrides LLM_BINDING_HOST / EMBEDDING_BINDING_HOST.
         "gemini": os.getenv("LLM_BINDING_HOST", "DEFAULT_GEMINI_ENDPOINT"),

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -1034,6 +1034,8 @@ def create_app(args):
                     )
                     # Pass model only if provided, let function use its default otherwise
                     kwargs = {"texts": texts}
+                    if host is not None:
+                        kwargs["endpoint_url"] = host
                     if model:
                         kwargs["model"] = model
                     return await actual_func(**kwargs)
@@ -1150,6 +1152,7 @@ def create_app(args):
             prompt,
             system_prompt=system_prompt,
             history_messages=history_messages,
+            endpoint_url=args.llm_binding_host,
             **kwargs,
         )
 

--- a/lightrag/llm/bedrock.py
+++ b/lightrag/llm/bedrock.py
@@ -17,14 +17,10 @@ from tenacity import (
     retry_if_exception_type,
 )
 
-import sys
-from lightrag.utils import wrap_embedding_func_with_attrs
-
-if sys.version_info < (3, 9):
-    from typing import AsyncIterator
-else:
-    from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator
 from typing import Union
+
+from lightrag.utils import wrap_embedding_func_with_attrs
 
 # Import botocore exceptions for proper exception handling
 try:
@@ -66,6 +62,14 @@ def _normalize_bedrock_endpoint_url(endpoint_url: str | None) -> str | None:
         return None
 
     return normalized
+
+
+def _bedrock_client_kwargs(region: str | None, endpoint_url: str | None) -> dict:
+    """Build kwargs for aioboto3 ``session.client("bedrock-runtime", ...)``."""
+    client_kwargs: dict = {"region_name": region}
+    if endpoint_url is not None:
+        client_kwargs["endpoint_url"] = endpoint_url
+    return client_kwargs
 
 
 def _set_env_if_present(key: str, value):
@@ -173,6 +177,11 @@ async def bedrock_complete_if_cache(
     - If callers pass ``response_format``, it is stripped before the request.
     - Deprecated ``keyword_extraction`` and ``entity_extraction`` booleans are
       accepted only as compatibility shims; they emit warnings and are ignored.
+
+    Endpoint note:
+    - ``endpoint_url`` overrides the default regional Bedrock endpoint. Pass
+      ``None``, an empty string, or the sentinel ``DEFAULT_BEDROCK_ENDPOINT``
+      to let the AWS SDK select its default endpoint.
     """
     if enable_cot:
         import logging
@@ -210,9 +219,7 @@ async def bedrock_complete_if_cache(
     _set_env_if_present("AWS_SESSION_TOKEN", session_token)
     # Region handling: prefer env, else kwarg (optional)
     region = os.environ.get("AWS_REGION") or kwargs.pop("aws_region", None)
-    endpoint_url = _normalize_bedrock_endpoint_url(
-        endpoint_url or kwargs.pop("base_url", None)
-    )
+    endpoint_url = _normalize_bedrock_endpoint_url(endpoint_url)
     kwargs.pop("hashing_kv", None)
     # Capture stream flag (if provided) and remove from kwargs since it's not a Bedrock API parameter
     # We'll use this to determine whether to call converse_stream or converse
@@ -271,9 +278,7 @@ async def bedrock_complete_if_cache(
         # Create a session that will be used throughout the streaming process
         session = aioboto3.Session()
         client = None
-        client_kwargs = {"region_name": region}
-        if endpoint_url is not None:
-            client_kwargs["endpoint_url"] = endpoint_url
+        client_kwargs = _bedrock_client_kwargs(region, endpoint_url)
 
         # Define the generator function that will manage the client lifecycle
         async def stream_generator():
@@ -354,11 +359,8 @@ async def bedrock_complete_if_cache(
 
     # For non-streaming responses, use the standard async context manager pattern
     session = aioboto3.Session()
-    client_kwargs = {"region_name": region}
-    if endpoint_url is not None:
-        client_kwargs["endpoint_url"] = endpoint_url
     async with session.client(
-        "bedrock-runtime", **client_kwargs
+        "bedrock-runtime", **_bedrock_client_kwargs(region, endpoint_url)
     ) as bedrock_async_client:
         try:
             # Use converse for non-streaming responses
@@ -444,11 +446,8 @@ async def bedrock_embed(
     endpoint_url = _normalize_bedrock_endpoint_url(endpoint_url)
 
     session = aioboto3.Session()
-    client_kwargs = {"region_name": region}
-    if endpoint_url is not None:
-        client_kwargs["endpoint_url"] = endpoint_url
     async with session.client(
-        "bedrock-runtime", **client_kwargs
+        "bedrock-runtime", **_bedrock_client_kwargs(region, endpoint_url)
     ) as bedrock_async_client:
         try:
             if (model_provider := model.split(".")[0]) == "amazon":

--- a/lightrag/llm/bedrock.py
+++ b/lightrag/llm/bedrock.py
@@ -56,6 +56,18 @@ class BedrockTimeoutError(BedrockError):
     """Error for timeout issues"""
 
 
+def _normalize_bedrock_endpoint_url(endpoint_url: str | None) -> str | None:
+    """Return a usable Bedrock endpoint override or None for SDK defaults."""
+    if endpoint_url is None:
+        return None
+
+    normalized = endpoint_url.strip()
+    if not normalized or normalized == "DEFAULT_BEDROCK_ENDPOINT":
+        return None
+
+    return normalized
+
+
 def _set_env_if_present(key: str, value):
     """Set environment variable only if a non-empty value is provided."""
     if value is not None and value != "":
@@ -151,6 +163,7 @@ async def bedrock_complete_if_cache(
     aws_access_key_id=None,
     aws_secret_access_key=None,
     aws_session_token=None,
+    endpoint_url: str | None = None,
     **kwargs,
 ) -> Union[str, AsyncIterator[str]]:
     """Call Amazon Bedrock Converse API with LightRAG-compatible shims.
@@ -197,6 +210,9 @@ async def bedrock_complete_if_cache(
     _set_env_if_present("AWS_SESSION_TOKEN", session_token)
     # Region handling: prefer env, else kwarg (optional)
     region = os.environ.get("AWS_REGION") or kwargs.pop("aws_region", None)
+    endpoint_url = _normalize_bedrock_endpoint_url(
+        endpoint_url or kwargs.pop("base_url", None)
+    )
     kwargs.pop("hashing_kv", None)
     # Capture stream flag (if provided) and remove from kwargs since it's not a Bedrock API parameter
     # We'll use this to determine whether to call converse_stream or converse
@@ -255,6 +271,9 @@ async def bedrock_complete_if_cache(
         # Create a session that will be used throughout the streaming process
         session = aioboto3.Session()
         client = None
+        client_kwargs = {"region_name": region}
+        if endpoint_url is not None:
+            client_kwargs["endpoint_url"] = endpoint_url
 
         # Define the generator function that will manage the client lifecycle
         async def stream_generator():
@@ -262,7 +281,7 @@ async def bedrock_complete_if_cache(
 
             # Create the client outside the generator to ensure it stays open
             client = await session.client(
-                "bedrock-runtime", region_name=region
+                "bedrock-runtime", **client_kwargs
             ).__aenter__()
             event_stream = None
             iteration_started = False
@@ -335,8 +354,11 @@ async def bedrock_complete_if_cache(
 
     # For non-streaming responses, use the standard async context manager pattern
     session = aioboto3.Session()
+    client_kwargs = {"region_name": region}
+    if endpoint_url is not None:
+        client_kwargs["endpoint_url"] = endpoint_url
     async with session.client(
-        "bedrock-runtime", region_name=region
+        "bedrock-runtime", **client_kwargs
     ) as bedrock_async_client:
         try:
             # Use converse for non-streaming responses
@@ -407,6 +429,7 @@ async def bedrock_embed(
     aws_access_key_id=None,
     aws_secret_access_key=None,
     aws_session_token=None,
+    endpoint_url: str | None = None,
 ) -> np.ndarray:
     # Respect existing env; only set if a non-empty value is available
     access_key = os.environ.get("AWS_ACCESS_KEY_ID") or aws_access_key_id
@@ -418,10 +441,14 @@ async def bedrock_embed(
 
     # Region handling: prefer env
     region = os.environ.get("AWS_REGION")
+    endpoint_url = _normalize_bedrock_endpoint_url(endpoint_url)
 
     session = aioboto3.Session()
+    client_kwargs = {"region_name": region}
+    if endpoint_url is not None:
+        client_kwargs["endpoint_url"] = endpoint_url
     async with session.client(
-        "bedrock-runtime", region_name=region
+        "bedrock-runtime", **client_kwargs
     ) as bedrock_async_client:
         try:
             if (model_provider := model.split(".")[0]) == "amazon":

--- a/tests/test_api_config_bedrock.py
+++ b/tests/test_api_config_bedrock.py
@@ -1,0 +1,12 @@
+import pytest
+
+from lightrag.api.config import get_default_host
+
+
+pytestmark = pytest.mark.offline
+
+
+def test_bedrock_default_host_uses_sdk_default_endpoint(monkeypatch):
+    monkeypatch.delenv("LLM_BINDING_HOST", raising=False)
+
+    assert get_default_host("aws_bedrock") == "DEFAULT_BEDROCK_ENDPOINT"

--- a/tests/test_api_config_bedrock.py
+++ b/tests/test_api_config_bedrock.py
@@ -10,3 +10,9 @@ def test_bedrock_default_host_uses_sdk_default_endpoint(monkeypatch):
     monkeypatch.delenv("LLM_BINDING_HOST", raising=False)
 
     assert get_default_host("aws_bedrock") == "DEFAULT_BEDROCK_ENDPOINT"
+
+
+def test_bedrock_custom_host_is_returned(monkeypatch):
+    monkeypatch.setenv("LLM_BINDING_HOST", "https://proxy.example.com")
+
+    assert get_default_host("aws_bedrock") == "https://proxy.example.com"

--- a/tests/test_bedrock_llm.py
+++ b/tests/test_bedrock_llm.py
@@ -187,3 +187,41 @@ async def test_bedrock_embed_custom_endpoint_url_is_forwarded(monkeypatch):
         "region_name": None,
         "endpoint_url": "https://proxy.example.com",
     }
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_bedrock_embed_default_endpoint_sentinel_uses_sdk_default(monkeypatch):
+    captured_calls: list[dict] = []
+    client_kwargs_calls: list[dict] = []
+    monkeypatch.delenv("AWS_REGION", raising=False)
+
+    with patch(
+        "lightrag.llm.bedrock.aioboto3.Session",
+        return_value=_FakeEmbeddingSession(captured_calls, client_kwargs_calls),
+    ):
+        await bedrock_embed(
+            texts=["hello"],
+            endpoint_url="DEFAULT_BEDROCK_ENDPOINT",
+        )
+
+    assert client_kwargs_calls[-1] == {"region_name": None}
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_bedrock_embed_empty_endpoint_url_uses_sdk_default(monkeypatch):
+    captured_calls: list[dict] = []
+    client_kwargs_calls: list[dict] = []
+    monkeypatch.delenv("AWS_REGION", raising=False)
+
+    with patch(
+        "lightrag.llm.bedrock.aioboto3.Session",
+        return_value=_FakeEmbeddingSession(captured_calls, client_kwargs_calls),
+    ):
+        await bedrock_embed(
+            texts=["hello"],
+            endpoint_url="",
+        )
+
+    assert client_kwargs_calls[-1] == {"region_name": None}

--- a/tests/test_bedrock_llm.py
+++ b/tests/test_bedrock_llm.py
@@ -3,7 +3,11 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from lightrag.llm.bedrock import bedrock_complete, bedrock_complete_if_cache
+from lightrag.llm.bedrock import (
+    bedrock_complete,
+    bedrock_complete_if_cache,
+    bedrock_embed,
+)
 
 
 class _FakeBedrockClient:
@@ -32,10 +36,12 @@ class _FakeBedrockClient:
 
 
 class _FakeSession:
-    def __init__(self, captured_calls: list[dict]):
+    def __init__(self, captured_calls: list[dict], client_kwargs_calls: list[dict]):
         self._captured_calls = captured_calls
+        self._client_kwargs_calls = client_kwargs_calls
 
-    def client(self, *_args, **_kwargs):
+    def client(self, *_args, **kwargs):
+        self._client_kwargs_calls.append(dict(kwargs))
         return _FakeBedrockClient(self._captured_calls)
 
 
@@ -61,10 +67,11 @@ async def test_bedrock_complete_forwards_keyword_extraction_to_if_cache():
 @pytest.mark.asyncio
 async def test_bedrock_keyword_extraction_does_not_inject_system_prompt():
     captured_calls: list[dict] = []
+    client_kwargs_calls: list[dict] = []
 
     with patch(
         "lightrag.llm.bedrock.aioboto3.Session",
-        return_value=_FakeSession(captured_calls),
+        return_value=_FakeSession(captured_calls, client_kwargs_calls),
     ):
         result = await bedrock_complete_if_cache(
             model="bedrock-model",
@@ -75,3 +82,108 @@ async def test_bedrock_keyword_extraction_does_not_inject_system_prompt():
     assert result == '{"high_level_keywords":["AI"],"low_level_keywords":["RAG"]}'
     assert len(captured_calls) == 1
     assert "system" not in captured_calls[0]
+    assert client_kwargs_calls[-1] == {"region_name": None}
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_bedrock_default_endpoint_sentinel_uses_sdk_default():
+    captured_calls: list[dict] = []
+    client_kwargs_calls: list[dict] = []
+
+    with patch(
+        "lightrag.llm.bedrock.aioboto3.Session",
+        return_value=_FakeSession(captured_calls, client_kwargs_calls),
+    ):
+        await bedrock_complete_if_cache(
+            model="bedrock-model",
+            prompt="hello",
+            endpoint_url="DEFAULT_BEDROCK_ENDPOINT",
+        )
+
+    assert client_kwargs_calls[-1] == {"region_name": None}
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_bedrock_empty_endpoint_url_uses_sdk_default():
+    captured_calls: list[dict] = []
+    client_kwargs_calls: list[dict] = []
+
+    with patch(
+        "lightrag.llm.bedrock.aioboto3.Session",
+        return_value=_FakeSession(captured_calls, client_kwargs_calls),
+    ):
+        await bedrock_complete_if_cache(
+            model="bedrock-model",
+            prompt="hello",
+            endpoint_url="",
+        )
+
+    assert client_kwargs_calls[-1] == {"region_name": None}
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_bedrock_custom_endpoint_url_is_forwarded():
+    captured_calls: list[dict] = []
+    client_kwargs_calls: list[dict] = []
+
+    with patch(
+        "lightrag.llm.bedrock.aioboto3.Session",
+        return_value=_FakeSession(captured_calls, client_kwargs_calls),
+    ):
+        await bedrock_complete_if_cache(
+            model="bedrock-model",
+            prompt="hello",
+            endpoint_url="https://proxy.example.com",
+        )
+
+    assert client_kwargs_calls[-1] == {
+        "region_name": None,
+        "endpoint_url": "https://proxy.example.com",
+    }
+
+
+class _FakeEmbeddingBody:
+    async def json(self):
+        return {"embedding": [0.1] * 1024}
+
+
+class _FakeEmbeddingResponse:
+    def get(self, key):
+        assert key == "body"
+        return _FakeEmbeddingBody()
+
+
+class _FakeEmbeddingClient(_FakeBedrockClient):
+    async def invoke_model(self, **_kwargs):
+        return _FakeEmbeddingResponse()
+
+
+class _FakeEmbeddingSession(_FakeSession):
+    def client(self, *_args, **kwargs):
+        self._client_kwargs_calls.append(dict(kwargs))
+        return _FakeEmbeddingClient(self._captured_calls)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_bedrock_embed_custom_endpoint_url_is_forwarded(monkeypatch):
+    captured_calls: list[dict] = []
+    client_kwargs_calls: list[dict] = []
+    monkeypatch.delenv("AWS_REGION", raising=False)
+
+    with patch(
+        "lightrag.llm.bedrock.aioboto3.Session",
+        return_value=_FakeEmbeddingSession(captured_calls, client_kwargs_calls),
+    ):
+        await bedrock_embed(
+            texts=["hello"],
+            endpoint_url="https://proxy.example.com",
+        )
+
+    assert client_kwargs_calls[-1] == {
+        "region_name": None,
+        "endpoint_url": "https://proxy.example.com",
+    }


### PR DESCRIPTION
## Description

Add Bedrock endpoint normalization and proxy endpoint support while keeping SDK-default endpoint behavior consistent with the recent Gemini handling.

## Related Issues

N/A

## Changes Made

- add Bedrock endpoint normalization so `DEFAULT_BEDROCK_ENDPOINT` and empty host values use the AWS SDK default regional endpoint
- forward custom Bedrock `LLM_BINDING_HOST` and `EMBEDDING_BINDING_HOST` values to boto3 as `endpoint_url`
- set the default Bedrock host config sentinel to `DEFAULT_BEDROCK_ENDPOINT`
- update `env.example` to document Bedrock default endpoint and custom proxy/gateway usage
- add offline tests for Bedrock endpoint normalization, custom endpoint forwarding, and default config behavior

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Local validation run:
- `./scripts/test.sh tests/test_bedrock_llm.py`
- `./scripts/test.sh tests/test_api_config_bedrock.py`
