### PR TITLE
refactor(setup): use sentinel endpoints for Gemini and Bedrock defaults

### DIFF
--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -1894,12 +1894,12 @@ collect_llm_config() {
       api_key="$(prompt_secret_until_valid_with_default "Azure OpenAI API key: " "${ENV_VALUES[LLM_BINDING_API_KEY]:-}" validate_api_key azure_openai)"
       ;;
     gemini)
-      host_default="$(provider_default_or_existing "$binding" "$current_binding" "${ENV_VALUES[LLM_BINDING_HOST]:-}" "https://generativelanguage.googleapis.com")"
+      host_default="$(provider_default_or_existing "$binding" "$current_binding" "${ENV_VALUES[LLM_BINDING_HOST]:-}" "DEFAULT_GEMINI_ENDPOINT")"
       host="$(prompt_with_default "Gemini endpoint" "$host_default")"
       api_key="$(prompt_secret_until_valid_with_default "Gemini API key: " "${ENV_VALUES[LLM_BINDING_API_KEY]:-}" validate_api_key gemini)"
       ;;
     aws_bedrock)
-      host="$(provider_default_or_existing "$binding" "$current_binding" "${ENV_VALUES[LLM_BINDING_HOST]:-}" "https://bedrock.amazonaws.com")"
+      host="$(provider_default_or_existing "$binding" "$current_binding" "${ENV_VALUES[LLM_BINDING_HOST]:-}" "DEFAULT_BEDROCK_ENDPOINT")"
       api_key=""
       collect_bedrock_credentials
       ;;
@@ -1958,12 +1958,12 @@ collect_embedding_config() {
       api_key="$(prompt_secret_until_valid_with_default "Azure OpenAI API key: " "${ENV_VALUES[EMBEDDING_BINDING_API_KEY]:-$llm_api_key_default}" validate_api_key azure_openai)"
       ;;
     gemini)
-      host_default="$(provider_default_or_existing "$binding" "$current_binding" "${ENV_VALUES[EMBEDDING_BINDING_HOST]:-}" "${llm_host_fallback:-https://generativelanguage.googleapis.com}")"
+      host_default="$(provider_default_or_existing "$binding" "$current_binding" "${ENV_VALUES[EMBEDDING_BINDING_HOST]:-}" "${llm_host_fallback:-DEFAULT_GEMINI_ENDPOINT}")"
       host="$(prompt_with_default "Gemini endpoint" "$host_default")"
       api_key="$(prompt_secret_until_valid_with_default "Gemini API key: " "${ENV_VALUES[EMBEDDING_BINDING_API_KEY]:-$llm_api_key_default}" validate_api_key gemini)"
       ;;
     aws_bedrock)
-      host="$(provider_default_or_existing "$binding" "$current_binding" "${ENV_VALUES[EMBEDDING_BINDING_HOST]:-}" "${llm_host_fallback:-https://bedrock.amazonaws.com}")"
+      host="$(provider_default_or_existing "$binding" "$current_binding" "${ENV_VALUES[EMBEDDING_BINDING_HOST]:-}" "${llm_host_fallback:-DEFAULT_BEDROCK_ENDPOINT}")"
       api_key=""
       collect_bedrock_credentials
       ;;

--- a/tests/test_interactive_setup/test_collect.py
+++ b/tests/test_interactive_setup/test_collect.py
@@ -507,8 +507,67 @@ fi
             "2048",
             "set",
         ),
+        (
+            "collect_llm_config",
+            "LLM",
+            "gemini",
+            "prompt_secret_until_valid_with_default() { printf 'gemini-secret-key'; }",
+            "gemini",
+            "gemini-flash-latest",
+            "DEFAULT_GEMINI_ENDPOINT",
+            "",
+            "set",
+        ),
+        (
+            "collect_llm_config",
+            "LLM",
+            "aws_bedrock",
+            """
+prompt_clearable_with_default() { printf ''; }
+prompt_required_secret() { return 1; }
+confirm_default_yes() { return 1; }
+""",
+            "aws_bedrock",
+            "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "DEFAULT_BEDROCK_ENDPOINT",
+            "",
+            "",
+        ),
+        (
+            "collect_embedding_config",
+            "EMBEDDING",
+            "gemini",
+            "prompt_secret_until_valid_with_default() { printf 'gemini-secret-key'; }",
+            "gemini",
+            "gemini-embedding-001",
+            "DEFAULT_GEMINI_ENDPOINT",
+            "1536",
+            "set",
+        ),
+        (
+            "collect_embedding_config",
+            "EMBEDDING",
+            "aws_bedrock",
+            """
+prompt_clearable_with_default() { printf ''; }
+prompt_required_secret() { return 1; }
+confirm_default_yes() { return 1; }
+""",
+            "aws_bedrock",
+            "amazon.titan-embed-text-v2:0",
+            "DEFAULT_BEDROCK_ENDPOINT",
+            "1024",
+            "",
+        ),
     ],
-    ids=["llm-provider-defaults", "embedding-provider-defaults"],
+    ids=[
+        "llm-provider-defaults",
+        "embedding-provider-defaults",
+        "llm-gemini-sentinel-default",
+        "llm-bedrock-sentinel-default",
+        "embedding-gemini-sentinel-default",
+        "embedding-bedrock-sentinel-default",
+    ],
 )
 def test_collect_provider_config_uses_provider_specific_defaults(
     collector_name: str,
@@ -545,6 +604,79 @@ printf 'API_KEY_SET=%s\\n' "${{ENV_VALUES[{binding_prefix}_BINDING_API_KEY]+set}
     assert values["HOST"] == expected_host
     assert values["DIM"] == expected_dim
     assert values["API_KEY_SET"] == expected_api_key_set
+
+
+@pytest.mark.parametrize(
+    (
+        "collector_name",
+        "binding_prefix",
+        "env_lines",
+        "expected_host",
+        "expected_api_key",
+    ),
+    [
+        (
+            "collect_llm_config",
+            "LLM",
+            [
+                "LLM_BINDING=gemini",
+                "LLM_MODEL=gemini-flash-latest",
+                "LLM_BINDING_HOST=https://generativelanguage.googleapis.com",
+                "LLM_BINDING_API_KEY=gemini-existing-key",
+            ],
+            "https://generativelanguage.googleapis.com",
+            "gemini-existing-key",
+        ),
+        (
+            "collect_embedding_config",
+            "EMBEDDING",
+            [
+                "EMBEDDING_BINDING=aws_bedrock",
+                "EMBEDDING_MODEL=amazon.titan-embed-text-v2:0",
+                "EMBEDDING_DIM=1024",
+                "EMBEDDING_BINDING_HOST=https://bedrock.amazonaws.com",
+            ],
+            "https://bedrock.amazonaws.com",
+            "",
+        ),
+    ],
+    ids=[
+        "llm-rerun-preserves-explicit-gemini-host",
+        "embedding-rerun-preserves-explicit-bedrock-host",
+    ],
+)
+def test_collect_provider_config_preserves_explicit_host_on_rerun(
+    tmp_path: Path,
+    collector_name: str,
+    binding_prefix: str,
+    env_lines: list[str],
+    expected_host: str,
+    expected_api_key: str,
+) -> None:
+    """Reruns should keep saved explicit provider hosts instead of swapping to sentinels."""
+    write_text_lines(tmp_path / ".env", env_lines)
+    output = run_bash(f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+reset_state
+load_existing_env_if_present
+
+prompt_choice() {{ printf '%s' "$2"; }}
+prompt_with_default() {{ printf '%s' "$2"; }}
+prompt_secret_until_valid_with_default() {{ printf '%s' "$2"; }}
+prompt_clearable_with_default() {{ printf ''; }}
+prompt_required_secret() {{ return 1; }}
+confirm_default_yes() {{ return 1; }}
+
+{collector_name}
+
+printf 'HOST=%s\\n' "${{ENV_VALUES[{binding_prefix}_BINDING_HOST]}}"
+printf 'API_KEY=%s\\n' "${{ENV_VALUES[{binding_prefix}_BINDING_API_KEY]:-}}\"
+""")
+    values = parse_lines(output)
+    assert values["HOST"] == expected_host
+    assert values["API_KEY"] == expected_api_key
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Update the setup wizard to use SDK sentinel endpoints as the default host values for Gemini and Bedrock instead of hardcoded provider URLs.

## Related Issues

N/A

## Changes Made

- changed Gemini setup defaults to `DEFAULT_GEMINI_ENDPOINT` for both LLM and embedding configuration
- changed Bedrock setup defaults to `DEFAULT_BEDROCK_ENDPOINT` for both LLM and embedding configuration
- added interactive setup tests covering the new sentinel defaults
- added rerun tests to confirm existing explicit Gemini and Bedrock hosts are preserved without migration

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Existing `.env` values that already use explicit Gemini or Bedrock URLs are intentionally preserved on rerun; this change only affects new default values offered by the setup wizard.
