### PR TITLE
fix: remove `stream` parameter from `.parse()` call when `response_format` is present

### DIFF
--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -336,8 +336,9 @@ async def openai_complete_if_cache(
     try:
         # Don't use async with context manager, use client directly
         if "response_format" in kwargs:
+            parse_kwargs = {k: v for k, v in kwargs.items() if k != "stream"}
             response = await openai_async_client.chat.completions.parse(
-                model=api_model, messages=messages, **kwargs
+                model=api_model, messages=messages, **parse_kwargs
             )
         else:
             response = await openai_async_client.chat.completions.create(


### PR DESCRIPTION
…rmat` is present

<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

When `response_format` is present in kwargs, the `stream` parameter is incorrectly passed to `client.beta.chat.completions.parse()`, which does not accept `stream`. This causes a runtime error when using OpenAI-compatible providers (DeepSeek) during keyword extraction.

## Related Issues
No existing issue. This bug occurs when using DeepSeek with LightRAG v1.4.14.

## Changes Made
In `lightrag/llm/openai.py`, filtered out `stream` from kwargs before 
passing to `.parse()`:

Before:
    `if "response_format" in kwargs:
        response = await openai_async_client.chat.completions.parse(
            model=api_model, messages=messages, **kwargs
        )`

After:
    `if "response_format" in kwargs:
        parse_kwargs = {k: v for k, v in kwargs.items() if k != "stream"}
        response = await openai_async_client.chat.completions.parse(
            model=api_model, messages=messages, **parse_kwargs
        )`

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary) — no docs change needed
- [ ] Unit tests added (if applicable)

## Additional Notes

Tested with DeepSeek (deepseek-chat) via OpenAI-compatible endpoint on 
LightRAG v1.4.14. The error message before fix:    `AsyncCompletions.parse() got an unexpected keyword argument 'stream'` This fix only affects the `.parse()` call path. The `.create()` path is unchanged and `stream` still works normally for non-structured responses.
