### PR TITLE
Fix role LLM max async fallback

### DIFF
--- a/env.example
+++ b/env.example
@@ -413,6 +413,8 @@ OLLAMA_LLM_NUM_CTX=32768
 ### Optional role-specific LLM/VLM overrides
 ### If unset, each role falls back to the base LLM_* configuration above.
 ### Available roles: EXTRACT, KEYWORD, QUERY, VLM
+### Note: MAX_ASYNC_{ROLE}_LLM, when unset, inherits the base MAX_ASYNC
+### value at runtime (it is NOT capped at the commented default below).
 ###########################################################################
 ### Example: use a dedicated model/provider for entity extraction
 # EXTRACT_LLM_BINDING=openai

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -690,7 +690,9 @@ def create_app(args):
             or getattr(args, f"{attr}_llm_timeout", None)
             or llm_timeout
         )
-        role_max_async = getattr(args, f"{attr}_llm_max_async", None) or args.max_async
+        role_max_async = override_meta.get("max_async")
+        if role_max_async is None:
+            role_max_async = getattr(args, f"{attr}_llm_max_async", None)
         is_cross_provider = role_binding != args.llm_binding
 
         role_provider_options = override_meta.get("provider_options")
@@ -1465,9 +1467,14 @@ def create_app(args):
     logger.info(f"\n{'🎭 Role LLM Configuration:'}")
     for role in ["extract", "keyword", "query", "vlm"]:
         role_cfg = role_llm_configs[role]
+        effective_max_async = (
+            role_cfg["max_async"]
+            if role_cfg["max_async"] is not None
+            else args.max_async
+        )
         logger.info(
             f"    ├─ {role}: binding={role_cfg['binding']}, model={role_cfg['model']}, "
-            f"host={role_cfg['host']}, max_async={role_cfg['max_async']}"
+            f"host={role_cfg['host']}, max_async={effective_max_async}"
         )
 
     # Add routes
@@ -1678,8 +1685,7 @@ def create_app(args):
                             or args.llm_model,
                             "host": getattr(args, f"{role}_llm_binding_host", None)
                             or args.llm_binding_host,
-                            "max_async": getattr(args, f"{role}_llm_max_async", None)
-                            or args.max_async,
+                            "max_async": rag._get_effective_role_llm_max_async(role),
                         }
                         for role in ["extract", "keyword", "query", "vlm"]
                     },

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -372,6 +372,10 @@ def _default_addon_params() -> dict[str, Any]:
     }
 
 
+def _optional_env_int(env_key: str) -> int | None:
+    return get_env_value(env_key, None, int, special_none=True)
+
+
 class ObservableAddonParams(dict[str, Any]):
     def __init__(
         self,
@@ -649,23 +653,23 @@ class LightRAG:
     """VLM (vision-language) model for multimodal analysis (images/tables/equations).
     Used in analyze_multimodal phase. When Ray-Anything merges, bind here as the VLM role."""
 
-    vlm_llm_model_max_async: int = field(
-        default=int(os.getenv("MAX_ASYNC_VLM_LLM", str(DEFAULT_MAX_ASYNC)))
+    vlm_llm_model_max_async: int | None = field(
+        default_factory=partial(_optional_env_int, "MAX_ASYNC_VLM_LLM")
     )
     """Max concurrent VLM calls in analyze_multimodal."""
 
-    extract_llm_model_max_async: int = field(
-        default=int(os.getenv("MAX_ASYNC_EXTRACT_LLM", str(DEFAULT_MAX_ASYNC)))
+    extract_llm_model_max_async: int | None = field(
+        default_factory=partial(_optional_env_int, "MAX_ASYNC_EXTRACT_LLM")
     )
     """Max concurrent LLM calls for entity/relation extraction."""
 
-    keyword_llm_model_max_async: int = field(
-        default=int(os.getenv("MAX_ASYNC_KEYWORD_LLM", str(DEFAULT_MAX_ASYNC)))
+    keyword_llm_model_max_async: int | None = field(
+        default_factory=partial(_optional_env_int, "MAX_ASYNC_KEYWORD_LLM")
     )
     """Max concurrent LLM calls for keyword extraction."""
 
-    query_llm_model_max_async: int = field(
-        default=int(os.getenv("MAX_ASYNC_QUERY_LLM", str(DEFAULT_MAX_ASYNC)))
+    query_llm_model_max_async: int | None = field(
+        default_factory=partial(_optional_env_int, "MAX_ASYNC_QUERY_LLM")
     )
     """Max concurrent LLM calls for query/answer generation."""
 
@@ -3409,7 +3413,8 @@ class LightRAG:
 
             # Analyze sidecar multimodal items by VLM model role.
             use_vlm_func = self.vlm_llm_model_func or self.llm_model_func
-            sem = asyncio.Semaphore(max(1, self.vlm_llm_model_max_async))
+            effective_vlm_max_async = self._get_effective_role_llm_max_async("vlm")
+            sem = asyncio.Semaphore(max(1, effective_vlm_max_async))
             analyze_retries = max(0, int(os.getenv("VLM_ANALYZE_RETRIES", "2")))
             max_image_bytes = max(
                 256 * 1024, int(os.getenv("VLM_MAX_IMAGE_BYTES", str(5 * 1024 * 1024)))

--- a/tests/test_api_config_role_max_async.py
+++ b/tests/test_api_config_role_max_async.py
@@ -1,0 +1,63 @@
+import sys
+
+import pytest
+
+from lightrag.api.config import parse_args
+
+
+pytestmark = pytest.mark.offline
+
+
+ROLE_MAX_ASYNC_ENV_KEYS = (
+    "MAX_ASYNC",
+    "MAX_ASYNC_EXTRACT_LLM",
+    "MAX_ASYNC_KEYWORD_LLM",
+    "MAX_ASYNC_QUERY_LLM",
+    "MAX_ASYNC_VLM_LLM",
+)
+
+
+def _clear_max_async_env(monkeypatch):
+    for key in ROLE_MAX_ASYNC_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_role_max_async_defaults_none_when_env_unset(monkeypatch):
+    _clear_max_async_env(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+    monkeypatch.setenv("MAX_ASYNC", "10")
+
+    args = parse_args()
+
+    assert args.max_async == 10
+    assert args.extract_llm_max_async is None
+    assert args.keyword_llm_max_async is None
+    assert args.query_llm_max_async is None
+    assert args.vlm_llm_max_async is None
+
+
+def test_role_max_async_env_override_keeps_other_roles_none(monkeypatch):
+    _clear_max_async_env(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+    monkeypatch.setenv("MAX_ASYNC", "10")
+    monkeypatch.setenv("MAX_ASYNC_EXTRACT_LLM", "7")
+
+    args = parse_args()
+
+    assert args.max_async == 10
+    assert args.extract_llm_max_async == 7
+    assert args.keyword_llm_max_async is None
+    assert args.query_llm_max_async is None
+    assert args.vlm_llm_max_async is None
+
+
+def test_role_max_async_literal_none_string_is_preserved(monkeypatch):
+    _clear_max_async_env(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+    monkeypatch.setenv("MAX_ASYNC", "10")
+    monkeypatch.setenv("MAX_ASYNC_QUERY_LLM", "None")
+
+    args = parse_args()
+
+    assert args.max_async == 10
+    assert args.query_llm_max_async is None

--- a/tests/test_llm_role_runtime.py
+++ b/tests/test_llm_role_runtime.py
@@ -44,6 +44,47 @@ def _make_rag(tmp_path, **kwargs) -> LightRAG:
     )
 
 
+ROLE_MAX_ASYNC_ENV_KEYS = (
+    "MAX_ASYNC_EXTRACT_LLM",
+    "MAX_ASYNC_KEYWORD_LLM",
+    "MAX_ASYNC_QUERY_LLM",
+    "MAX_ASYNC_VLM_LLM",
+)
+
+
+def test_role_max_async_defaults_inherit_base(tmp_path, monkeypatch):
+    for env_key in ROLE_MAX_ASYNC_ENV_KEYS:
+        monkeypatch.delenv(env_key, raising=False)
+
+    rag = _make_rag(tmp_path, llm_model_max_async=10)
+
+    assert rag.extract_llm_model_max_async is None
+    assert rag.keyword_llm_model_max_async is None
+    assert rag.query_llm_model_max_async is None
+    assert rag.vlm_llm_model_max_async is None
+    assert rag._get_effective_role_llm_max_async("extract") == 10
+    assert rag._get_effective_role_llm_max_async("keyword") == 10
+    assert rag._get_effective_role_llm_max_async("query") == 10
+    assert rag._get_effective_role_llm_max_async("vlm") == 10
+
+
+def test_role_max_async_env_override_keeps_other_roles_inherited(tmp_path, monkeypatch):
+    for env_key in ROLE_MAX_ASYNC_ENV_KEYS:
+        monkeypatch.delenv(env_key, raising=False)
+    monkeypatch.setenv("MAX_ASYNC_EXTRACT_LLM", "7")
+
+    rag = _make_rag(tmp_path, llm_model_max_async=10)
+
+    assert rag.extract_llm_model_max_async == 7
+    assert rag.keyword_llm_model_max_async is None
+    assert rag.query_llm_model_max_async is None
+    assert rag.vlm_llm_model_max_async is None
+    assert rag._get_effective_role_llm_max_async("extract") == 7
+    assert rag._get_effective_role_llm_max_async("keyword") == 10
+    assert rag._get_effective_role_llm_max_async("query") == 10
+    assert rag._get_effective_role_llm_max_async("vlm") == 10
+
+
 @pytest.mark.asyncio
 async def test_role_functions_are_isolated_and_vlm_present(tmp_path):
     rag = _make_rag(tmp_path)

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -197,6 +197,36 @@ def test_analyze_multimodal_json_retry_and_writeback(tmp_path):
 
 
 @pytest.mark.offline
+def test_analyze_multimodal_uses_effective_vlm_max_async_when_role_none(tmp_path):
+    async def _run():
+        rag = _new_rag(
+            tmp_path,
+            llm_model_max_async=3,
+            vlm_llm_model_max_async=None,
+        )
+        blocks = tmp_path / "demo.blocks.jsonl"
+        blocks.write_text(
+            json.dumps({"type": "meta", "format_version": "1.0"}) + "\n",
+            encoding="utf-8",
+        )
+
+        parsed = {
+            "doc_id": "doc-1",
+            "file_path": "demo.pdf",
+            "blocks_path": str(blocks),
+            "content": "body",
+        }
+        result = await rag.analyze_multimodal("doc-1", "demo.pdf", parsed)
+
+        meta = json.loads(blocks.read_text(encoding="utf-8").splitlines()[0])
+        assert meta.get("analyze_time")
+        assert result["analyze_time"]
+        assert result["multimodal_processed"] is True
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
 def test_safe_vdb_operation_times_out_with_context():
     async def _run():
         async def _hang():


### PR DESCRIPTION
## Description

Fix role-specific LLM max async fallback so unset per-role concurrency values inherit the base `llm_model_max_async`, and prevent VLM multimodal analysis from aborting when the VLM role max async value is `None`.

## Related Issues

No linked issue.

## Changes Made

- Preserve `None` for unset `MAX_ASYNC_*_LLM` role overrides so runtime fallback uses `llm_model_max_async`.
- Use the effective VLM role max async value when creating the `analyze_multimodal` semaphore.
- Keep API initialization pass-through semantics aligned with the Python API while displaying effective role concurrency in status/log output.
- Add regression tests for inherited role concurrency, env overrides, and the VLM `None` semaphore path.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Local validation:

- `ruff check lightrag/lightrag.py lightrag/api/lightrag_server.py tests/test_llm_role_runtime.py tests/test_pipeline_release_closure.py`
- `PYTHON=.venv/bin/python ./scripts/test.sh tests/test_llm_role_runtime.py tests/test_pipeline_release_closure.py -m offline`
