### PR TITLE
fix(llm): tighten client and stream cleanup across LLM bindings

### DIFF
--- a/lightrag/llm/bedrock.py
+++ b/lightrag/llm/bedrock.py
@@ -1,4 +1,5 @@
 import copy
+import inspect
 import json
 import logging
 import warnings
@@ -303,7 +304,6 @@ async def bedrock_complete_if_cache(
     if stream:
         # Create a session that will be used throughout the streaming process
         session = aioboto3.Session()
-        client = None
         client_kwargs = _bedrock_client_kwargs(
             region,
             endpoint_url,
@@ -314,77 +314,52 @@ async def bedrock_complete_if_cache(
 
         # Define the generator function that will manage the client lifecycle
         async def stream_generator():
-            nonlocal client
+            # async with ensures the aioboto3 client is closed even under
+            # task cancellation, avoiding aiohttp "Unclosed connection" warnings.
+            async with session.client("bedrock-runtime", **client_kwargs) as client:
+                event_stream = None
+                try:
+                    # Make the API call
+                    response = await client.converse_stream(**args, **kwargs)
+                    event_stream = response.get("stream")
 
-            # Create the client outside the generator to ensure it stays open
-            client = await session.client(
-                "bedrock-runtime", **client_kwargs
-            ).__aenter__()
-            event_stream = None
-            iteration_started = False
+                    # Process the stream
+                    async for event in event_stream:
+                        # Validate event structure
+                        if not event or not isinstance(event, dict):
+                            continue
 
-            try:
-                # Make the API call
-                response = await client.converse_stream(**args, **kwargs)
-                event_stream = response.get("stream")
-                iteration_started = True
+                        if "contentBlockDelta" in event:
+                            delta = event["contentBlockDelta"].get("delta", {})
+                            text = delta.get("text")
+                            if text:
+                                yield text
+                        # Handle other event types that might indicate stream end
+                        elif "messageStop" in event:
+                            break
 
-                # Process the stream
-                async for event in event_stream:
-                    # Validate event structure
-                    if not event or not isinstance(event, dict):
-                        continue
+                except Exception as e:
+                    # Convert to appropriate exception type
+                    _handle_bedrock_exception(e, "Bedrock streaming")
 
-                    if "contentBlockDelta" in event:
-                        delta = event["contentBlockDelta"].get("delta", {})
-                        text = delta.get("text")
-                        if text:
-                            yield text
-                    # Handle other event types that might indicate stream end
-                    elif "messageStop" in event:
-                        break
-
-            except Exception as e:
-                # Try to clean up resources if possible
-                if (
-                    iteration_started
-                    and event_stream
-                    and hasattr(event_stream, "aclose")
-                    and callable(getattr(event_stream, "aclose", None))
-                ):
-                    try:
-                        await event_stream.aclose()
-                    except Exception as close_error:
-                        logging.warning(
-                            f"Failed to close Bedrock event stream: {close_error}"
+                finally:
+                    # Close the event stream once; client cleanup is handled by async with.
+                    # aiobotocore's EventStream exposes sync `close()`, while generic
+                    # async iterators expose async `aclose()` — handle both and dispatch
+                    # awaitable results accordingly.
+                    if event_stream is not None:
+                        close_fn = getattr(event_stream, "close", None) or getattr(
+                            event_stream, "aclose", None
                         )
-
-                # Convert to appropriate exception type
-                _handle_bedrock_exception(e, "Bedrock streaming")
-
-            finally:
-                # Clean up the event stream
-                if (
-                    iteration_started
-                    and event_stream
-                    and hasattr(event_stream, "aclose")
-                    and callable(getattr(event_stream, "aclose", None))
-                ):
-                    try:
-                        await event_stream.aclose()
-                    except Exception as close_error:
-                        logging.warning(
-                            f"Failed to close Bedrock event stream in finally block: {close_error}"
-                        )
-
-                # Clean up the client
-                if client:
-                    try:
-                        await client.__aexit__(None, None, None)
-                    except Exception as client_close_error:
-                        logging.warning(
-                            f"Failed to close Bedrock client: {client_close_error}"
-                        )
+                        if callable(close_fn):
+                            try:
+                                result = close_fn()
+                                if inspect.isawaitable(result):
+                                    await result
+                            except Exception as close_error:
+                                logging.warning(
+                                    f"Failed to close Bedrock event stream: {close_error}"
+                                )
 
         # Return the generator that manages its own lifecycle
         return stream_generator()

--- a/lightrag/llm/gemini.py
+++ b/lightrag/llm/gemini.py
@@ -411,10 +411,10 @@ async def gemini_complete_if_cache(
             try:
                 # Use native async streaming from genai SDK
                 # Note: generate_content_stream returns Awaitable[AsyncIterator], need to await first
-                stream = await client.aio.models.generate_content_stream(
+                stream_iter = await client.aio.models.generate_content_stream(
                     **request_kwargs
                 )
-                async for chunk in stream:
+                async for chunk in stream_iter:
                     usage = getattr(chunk, "usage_metadata", None)
                     if usage is not None:
                         usage_metadata = usage
@@ -471,14 +471,14 @@ async def gemini_complete_if_cache(
                     yield "</think>"
                     cot_active = False
 
-            except Exception as exc:
+            except Exception:
                 # Try to close COT tag before re-raising
                 if cot_active:
                     try:
                         yield "</think>"
                     except Exception:
                         pass
-                raise exc
+                raise
             finally:
                 # Track token usage after streaming completes
                 if token_tracker and usage_metadata:

--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -398,15 +398,24 @@ async def openai_complete_if_cache(
         )
     except APITimeoutError as e:
         logger.error(f"OpenAI API Timeout Error: {e}")
-        await openai_async_client.close()  # Ensure client is closed
+        try:
+            await openai_async_client.close()
+        except Exception as close_error:
+            logger.warning(f"Failed to close OpenAI client: {close_error}")
         raise
     except APIConnectionError as e:
         logger.error(f"OpenAI API Connection Error: {e}")
-        await openai_async_client.close()  # Ensure client is closed
+        try:
+            await openai_async_client.close()
+        except Exception as close_error:
+            logger.warning(f"Failed to close OpenAI client: {close_error}")
         raise
     except RateLimitError as e:
         logger.error(f"OpenAI API Rate Limit Error: {e}")
-        await openai_async_client.close()  # Ensure client is closed
+        try:
+            await openai_async_client.close()
+        except Exception as close_error:
+            logger.warning(f"Failed to close OpenAI client: {close_error}")
         raise
     except Exception as e:
         body = getattr(e, "body", None)
@@ -423,7 +432,10 @@ async def openai_complete_if_cache(
         logger.error(
             f"OpenAI API Call Failed,\nModel: {model},\nParams: {kwargs}, Got: {e}{extra}"
         )
-        await openai_async_client.close()  # Ensure client is closed
+        try:
+            await openai_async_client.close()
+        except Exception as close_error:
+            logger.warning(f"Failed to close OpenAI client: {close_error}")
         raise
 
     if hasattr(response, "__aiter__"):
@@ -558,7 +570,12 @@ async def openai_complete_if_cache(
                             f"Failed to close stream response: {close_error}"
                         )
                 # Ensure client is closed in case of exception
-                await openai_async_client.close()
+                try:
+                    await openai_async_client.close()
+                except Exception as client_close_error:
+                    logger.warning(
+                        f"Failed to close OpenAI client after stream error: {client_close_error}"
+                    )
                 raise
             finally:
                 # Final safety check for unclosed COT tags
@@ -611,7 +628,10 @@ async def openai_complete_if_cache(
                 or not hasattr(response.choices[0], "message")
             ):
                 logger.error("Invalid response from OpenAI API")
-                await openai_async_client.close()  # Ensure client is closed
+                try:
+                    await openai_async_client.close()
+                except Exception as close_error:
+                    logger.warning(f"Failed to close OpenAI client: {close_error}")
                 raise InvalidResponseError("Invalid response from OpenAI API")
 
             message = response.choices[0].message
@@ -664,7 +684,10 @@ async def openai_complete_if_cache(
                 # Validate final content
                 if not final_content or final_content.strip() == "":
                     logger.error("Received empty content from OpenAI API")
-                    await openai_async_client.close()  # Ensure client is closed
+                    try:
+                        await openai_async_client.close()
+                    except Exception as close_error:
+                        logger.warning(f"Failed to close OpenAI client: {close_error}")
                     raise InvalidResponseError("Received empty content from OpenAI API")
 
             # Apply Unicode decoding to final content if needed
@@ -687,7 +710,12 @@ async def openai_complete_if_cache(
             return final_content
         finally:
             # Ensure client is closed in all cases for non-streaming responses
-            await openai_async_client.close()
+            try:
+                await openai_async_client.close()
+            except Exception as close_error:
+                logger.warning(
+                    f"Failed to close OpenAI client in non-streaming finally block: {close_error}"
+                )
 
 
 async def openai_complete(


### PR DESCRIPTION
## Summary

Three related fixes around LLM-client resource cleanup surfaced while investigating occasional `ERROR:asyncio:Unclosed connection` warnings from `bedrock-runtime`:

- **bedrock.py**: root-caused the persistent *Unclosed connection* warnings. The previous `finally` block guarded on `hasattr(event_stream, \"aclose\")`, but aiobotocore's `AioEventStream` only exposes a **sync** `close()` method — so the cleanup branch silently never ran, leaving the underlying aiohttp `StreamReader` open whenever the `async for` exited via `break`, exception, or cancellation. Also replaced the manual `__aenter__`/`__aexit__` pattern with `async with` to remove a cancellation window, and dropped a duplicated `event_stream.aclose()` from the except branch.
- **openai.py**: wrapped every bare `openai_async_client.close()` in `try/except` so a failure during cleanup can no longer replace the original exception being raised.
- **gemini.py**: `raise exc` → bare `raise` (preserves traceback); renamed a local `stream` variable that was shadowing the outer parameter.

## Test plan

- [x] `ruff check lightrag/llm/{bedrock,openai,gemini}.py` passes
- [x] `python -c \"import lightrag.llm.{bedrock,openai,gemini}\"` smoke-imports all three modules
- [x] Verified via `inspect` that aiobotocore's `AioEventStream` exposes only sync `close()` (no `aclose`), confirming the old guard never matched
- [ ] Run in production with Bedrock streaming and watch for reduction in `Unclosed connection` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)