### PR TITLE
refactor: unify role LLM config via ROLES registry + queue observability 

### DIFF
--- a/lightrag/__init__.py
+++ b/lightrag/__init__.py
@@ -2,17 +2,40 @@ from typing import TYPE_CHECKING, Any
 
 from ._version import __version__ as __version__
 
-__all__ = ["LightRAG", "QueryParam", "__version__"]
+__all__ = [
+    "LightRAG",
+    "QueryParam",
+    "RoleLLMConfig",
+    "RoleSpec",
+    "ROLES",
+    "__version__",
+]
 
 if TYPE_CHECKING:
-    from .lightrag import LightRAG as LightRAG, QueryParam as QueryParam
+    from .lightrag import (
+        LightRAG as LightRAG,
+        QueryParam as QueryParam,
+        ROLES as ROLES,
+        RoleLLMConfig as RoleLLMConfig,
+        RoleSpec as RoleSpec,
+    )
+
+
+_LAZY_EXPORTS = {"LightRAG", "QueryParam", "RoleLLMConfig", "RoleSpec", "ROLES"}
 
 
 def __getattr__(name: str) -> Any:
-    if name in {"LightRAG", "QueryParam"}:
-        from .lightrag import LightRAG, QueryParam
+    if name in _LAZY_EXPORTS:
+        from .lightrag import LightRAG, QueryParam, RoleLLMConfig, RoleSpec, ROLES
 
-        value = {"LightRAG": LightRAG, "QueryParam": QueryParam}[name]
+        values = {
+            "LightRAG": LightRAG,
+            "QueryParam": QueryParam,
+            "RoleLLMConfig": RoleLLMConfig,
+            "RoleSpec": RoleSpec,
+            "ROLES": ROLES,
+        }
+        value = values[name]
         globals()[name] = value
         return value
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -7,6 +7,7 @@ import re
 import argparse
 import logging
 from dotenv import load_dotenv
+from lightrag import ROLES
 from lightrag.utils import get_env_value
 from lightrag.llm.binding_options import (
     BedrockLLMOptions,
@@ -136,14 +137,14 @@ def validate_bedrock_auth_configuration(args: argparse.Namespace) -> None:
                 "Use SigV4 AWS_* variables or process-level AWS_BEARER_TOKEN_BEDROCK instead."
             )
 
-    for role in ("extract", "keyword", "query", "vlm"):
+    for spec in ROLES:
+        role = spec.name
         if getattr(
             args, f"{role}_llm_binding", None
         ) == "bedrock" and not has_valid_auth(role):
-            role_upper = role.upper()
             raise ValueError(
-                f"Bedrock role '{role}' requires {role_upper}_AWS_ACCESS_KEY_ID "
-                f"and {role_upper}_AWS_SECRET_ACCESS_KEY, global "
+                f"Bedrock role '{role}' requires {spec.env_prefix}_AWS_ACCESS_KEY_ID "
+                f"and {spec.env_prefix}_AWS_SECRET_ACCESS_KEY, global "
                 "AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, or process-level "
                 "AWS_BEARER_TOKEN_BEDROCK."
             )
@@ -479,15 +480,16 @@ def parse_args() -> argparse.Namespace:
     # PDF decryption password
     args.pdf_decrypt_password = get_env_value("PDF_DECRYPT_PASSWORD", None)
 
-    # --- Per-role LLM configuration (extract / keyword / query / vlm) ---
-    ROLE_PREFIXES = ["EXTRACT", "KEYWORD", "QUERY", "VLM"]
-    for role in ROLE_PREFIXES:
-        binding_key = f"{role}_LLM_BINDING"
-        model_key = f"{role}_LLM_MODEL"
-        host_key = f"{role}_LLM_BINDING_HOST"
-        apikey_key = f"{role}_LLM_BINDING_API_KEY"
-        max_async_key = f"MAX_ASYNC_{role}_LLM"
-        timeout_key = f"LLM_TIMEOUT_{role}_LLM"
+    # --- Per-role LLM configuration (driven by lightrag.ROLES registry) ---
+    for spec in ROLES:
+        prefix = spec.env_prefix
+        attr_prefix = spec.name
+        binding_key = f"{prefix}_LLM_BINDING"
+        model_key = f"{prefix}_LLM_MODEL"
+        host_key = f"{prefix}_LLM_BINDING_HOST"
+        apikey_key = f"{prefix}_LLM_BINDING_API_KEY"
+        max_async_key = f"MAX_ASYNC_{prefix}_LLM"
+        timeout_key = f"LLM_TIMEOUT_{prefix}_LLM"
 
         role_binding = normalize_binding_name(
             get_env_value(binding_key, None, special_none=True)
@@ -497,18 +499,17 @@ def parse_args() -> argparse.Namespace:
         role_apikey = get_env_value(apikey_key, None, special_none=True)
         role_max_async = get_env_value(max_async_key, None, int, special_none=True)
         role_timeout = get_env_value(timeout_key, None, int, special_none=True)
-        role_aws_region = get_env_value(f"{role}_AWS_REGION", None, special_none=True)
+        role_aws_region = get_env_value(f"{prefix}_AWS_REGION", None, special_none=True)
         role_aws_access_key_id = get_env_value(
-            f"{role}_AWS_ACCESS_KEY_ID", None, special_none=True
+            f"{prefix}_AWS_ACCESS_KEY_ID", None, special_none=True
         )
         role_aws_secret_access_key = get_env_value(
-            f"{role}_AWS_SECRET_ACCESS_KEY", None, special_none=True
+            f"{prefix}_AWS_SECRET_ACCESS_KEY", None, special_none=True
         )
         role_aws_session_token = get_env_value(
-            f"{role}_AWS_SESSION_TOKEN", None, special_none=True
+            f"{prefix}_AWS_SESSION_TOKEN", None, special_none=True
         )
 
-        attr_prefix = role.lower()
         setattr(args, f"{attr_prefix}_llm_binding", role_binding)
         setattr(args, f"{attr_prefix}_llm_model", role_model)
         setattr(args, f"{attr_prefix}_llm_binding_host", role_host)
@@ -524,7 +525,7 @@ def parse_args() -> argparse.Namespace:
 
         if role_binding == "bedrock" and role_apikey:
             raise SystemExit(
-                f"Bedrock role '{role}' does not support {apikey_key}; use "
+                f"Bedrock role '{spec.name}' does not support {apikey_key}; use "
                 "role-specific SigV4 AWS_* variables or process-level "
                 "AWS_BEARER_TOKEN_BEDROCK."
             )
@@ -541,7 +542,7 @@ def parse_args() -> argparse.Namespace:
                 missing.append(apikey_key)
             if missing:
                 raise SystemExit(
-                    f"Cross-provider error for role '{role}': "
+                    f"Cross-provider error for role '{spec.name}': "
                     f"binding={role_binding} differs from base={args.llm_binding}, "
                     f"but required env vars are missing: {', '.join(missing)}"
                 )

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -1693,6 +1693,7 @@ def create_app(args):
                 "auth_mode": auth_mode,
                 "pipeline_busy": pipeline_status.get("busy", False),
                 "keyed_locks": keyed_lock_info,
+                "llm_queue_status": await rag.get_llm_queue_status(include_base=True),
                 "core_version": core_version,
                 "api_version": api_version_display,
                 "webui_title": webui_title,

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -1671,20 +1671,7 @@ def create_app(args):
                     "max_async": args.max_async,
                     "embedding_func_max_async": args.embedding_func_max_async,
                     "embedding_batch_num": args.embedding_batch_num,
-                    "role_llm_config": {
-                        spec.name: {
-                            "binding": getattr(args, f"{spec.name}_llm_binding", None)
-                            or args.llm_binding,
-                            "model": getattr(args, f"{spec.name}_llm_model", None)
-                            or args.llm_model,
-                            "host": getattr(args, f"{spec.name}_llm_binding_host", None)
-                            or args.llm_binding_host,
-                            "max_async": rag._get_effective_role_llm_max_async(
-                                spec.name
-                            ),
-                        }
-                        for spec in ROLES
-                    },
+                    "role_llm_config": rag.get_llm_role_config(),
                 },
                 "auth_mode": auth_mode,
                 "pipeline_busy": pipeline_status.get("busy", False),

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -35,7 +35,7 @@ from .config import (
     get_default_host,
 )
 from lightrag.utils import get_env_value
-from lightrag import LightRAG, __version__ as core_version
+from lightrag import LightRAG, ROLES, RoleLLMConfig, __version__ as core_version
 from lightrag.api import __api_version__
 from lightrag.utils import EmbeddingFunc
 from lightrag.constants import (
@@ -1383,12 +1383,12 @@ def create_app(args):
     }
 
     role_llm_configs = {
-        role: {
-            **resolve_role_llm_settings(role),
-            "func": create_role_llm_func(role),
-            "kwargs": create_role_llm_model_kwargs(role),
+        spec.name: {
+            **resolve_role_llm_settings(spec.name),
+            "func": create_role_llm_func(spec.name),
+            "kwargs": create_role_llm_model_kwargs(spec.name),
         }
-        for role in ("extract", "keyword", "query", "vlm")
+        for spec in ROLES
     }
 
     # Initialize RAG with unified configuration
@@ -1423,22 +1423,15 @@ def create_app(args):
             max_graph_nodes=args.max_graph_nodes,
             addon_params=addon_params,
             ollama_server_infos=ollama_server_infos,
-            extract_llm_model_func=role_llm_configs["extract"]["func"],
-            extract_llm_model_kwargs=role_llm_configs["extract"]["kwargs"],
-            extract_llm_model_max_async=role_llm_configs["extract"]["max_async"],
-            extract_llm_timeout=role_llm_configs["extract"]["timeout"],
-            keyword_llm_model_func=role_llm_configs["keyword"]["func"],
-            keyword_llm_model_kwargs=role_llm_configs["keyword"]["kwargs"],
-            keyword_llm_model_max_async=role_llm_configs["keyword"]["max_async"],
-            keyword_llm_timeout=role_llm_configs["keyword"]["timeout"],
-            query_llm_model_func=role_llm_configs["query"]["func"],
-            query_llm_model_kwargs=role_llm_configs["query"]["kwargs"],
-            query_llm_model_max_async=role_llm_configs["query"]["max_async"],
-            query_llm_timeout=role_llm_configs["query"]["timeout"],
-            vlm_llm_model_func=role_llm_configs["vlm"]["func"],
-            vlm_llm_model_kwargs=role_llm_configs["vlm"]["kwargs"],
-            vlm_llm_model_max_async=role_llm_configs["vlm"]["max_async"],
-            vlm_llm_timeout=role_llm_configs["vlm"]["timeout"],
+            role_llm_configs={
+                spec.name: RoleLLMConfig(
+                    func=role_llm_configs[spec.name]["func"],
+                    kwargs=role_llm_configs[spec.name]["kwargs"],
+                    max_async=role_llm_configs[spec.name]["max_async"],
+                    timeout=role_llm_configs[spec.name]["timeout"],
+                )
+                for spec in ROLES
+            },
         )
     except Exception as e:
         logger.error(f"Failed to initialize LightRAG: {e}")
@@ -1450,30 +1443,31 @@ def create_app(args):
             create_role_llm_model_kwargs(role, meta),
         )
     )
-    for role in ("extract", "keyword", "query", "vlm"):
+    for spec in ROLES:
+        cfg = role_llm_configs[spec.name]
         rag.set_role_llm_metadata(
-            role,
+            spec.name,
             base_binding=args.llm_binding,
-            binding=role_llm_configs[role]["binding"],
-            model=role_llm_configs[role]["model"],
-            host=role_llm_configs[role]["host"],
-            api_key=role_llm_configs[role]["api_key"],
-            provider_options=role_llm_configs[role]["provider_options"],
-            bedrock_aws_options=role_llm_configs[role]["bedrock_aws_options"],
-            is_cross_provider=role_llm_configs[role]["is_cross_provider"],
+            binding=cfg["binding"],
+            model=cfg["model"],
+            host=cfg["host"],
+            api_key=cfg["api_key"],
+            provider_options=cfg["provider_options"],
+            bedrock_aws_options=cfg["bedrock_aws_options"],
+            is_cross_provider=cfg["is_cross_provider"],
         )
 
     # Print role LLM configuration
     logger.info(f"\n{'🎭 Role LLM Configuration:'}")
-    for role in ["extract", "keyword", "query", "vlm"]:
-        role_cfg = role_llm_configs[role]
+    for spec in ROLES:
+        role_cfg = role_llm_configs[spec.name]
         effective_max_async = (
             role_cfg["max_async"]
             if role_cfg["max_async"] is not None
             else args.max_async
         )
         logger.info(
-            f"    ├─ {role}: binding={role_cfg['binding']}, model={role_cfg['model']}, "
+            f"    ├─ {spec.name}: binding={role_cfg['binding']}, model={role_cfg['model']}, "
             f"host={role_cfg['host']}, max_async={effective_max_async}"
         )
 
@@ -1678,16 +1672,18 @@ def create_app(args):
                     "embedding_func_max_async": args.embedding_func_max_async,
                     "embedding_batch_num": args.embedding_batch_num,
                     "role_llm_config": {
-                        role: {
-                            "binding": getattr(args, f"{role}_llm_binding", None)
+                        spec.name: {
+                            "binding": getattr(args, f"{spec.name}_llm_binding", None)
                             or args.llm_binding,
-                            "model": getattr(args, f"{role}_llm_model", None)
+                            "model": getattr(args, f"{spec.name}_llm_model", None)
                             or args.llm_model,
-                            "host": getattr(args, f"{role}_llm_binding_host", None)
+                            "host": getattr(args, f"{spec.name}_llm_binding_host", None)
                             or args.llm_binding_host,
-                            "max_async": rag._get_effective_role_llm_max_async(role),
+                            "max_async": rag._get_effective_role_llm_max_async(
+                                spec.name
+                            ),
                         }
-                        for role in ["extract", "keyword", "query", "vlm"]
+                        for spec in ROLES
                     },
                 },
                 "auth_mode": auth_mode,

--- a/lightrag/api/routers/ollama_api.py
+++ b/lightrag/api/routers/ollama_api.py
@@ -300,17 +300,17 @@ class OllamaAPI:
                 prompt_tokens = estimate_tokens(query)
 
                 role_kwargs = (
-                    dict(self.rag.query_llm_model_kwargs)
-                    if self.rag.query_llm_model_kwargs is not None
+                    dict(self.rag.role_llm_kwargs["query"])
+                    if self.rag.role_llm_kwargs["query"] is not None
                     else dict(self.rag.llm_model_kwargs)
                 )
                 if request.system:
                     role_kwargs["system_prompt"] = request.system
 
                 if request.stream:
-                    response = await (
-                        self.rag.query_llm_model_func or self.rag.llm_model_func
-                    )(query, stream=True, **role_kwargs)
+                    response = await (self.rag.role_llm_funcs["query"])(
+                        query, stream=True, **role_kwargs
+                    )
 
                     async def stream_generator():
                         first_chunk_time = None
@@ -433,9 +433,9 @@ class OllamaAPI:
                     )
                 else:
                     first_chunk_time = time.time_ns()
-                    response_text = await (
-                        self.rag.query_llm_model_func or self.rag.llm_model_func
-                    )(query, stream=False, **role_kwargs)
+                    response_text = await (self.rag.role_llm_funcs["query"])(
+                        query, stream=False, **role_kwargs
+                    )
                     last_chunk_time = time.time_ns()
 
                     if not response_text:
@@ -521,15 +521,13 @@ class OllamaAPI:
                     # Determine if the request is prefix with "/bypass"
                     if mode == SearchMode.bypass:
                         role_kwargs = (
-                            dict(self.rag.query_llm_model_kwargs)
-                            if self.rag.query_llm_model_kwargs is not None
+                            dict(self.rag.role_llm_kwargs["query"])
+                            if self.rag.role_llm_kwargs["query"] is not None
                             else dict(self.rag.llm_model_kwargs)
                         )
                         if request.system:
                             role_kwargs["system_prompt"] = request.system
-                        response = await (
-                            self.rag.query_llm_model_func or self.rag.llm_model_func
-                        )(
+                        response = await (self.rag.role_llm_funcs["query"])(
                             cleaned_query,
                             stream=True,
                             history_messages=conversation_history,
@@ -690,16 +688,14 @@ class OllamaAPI:
                     )
                     if match_result or mode == SearchMode.bypass:
                         role_kwargs = (
-                            dict(self.rag.query_llm_model_kwargs)
-                            if self.rag.query_llm_model_kwargs is not None
+                            dict(self.rag.role_llm_kwargs["query"])
+                            if self.rag.role_llm_kwargs["query"] is not None
                             else dict(self.rag.llm_model_kwargs)
                         )
                         if request.system:
                             role_kwargs["system_prompt"] = request.system
 
-                        response_text = await (
-                            self.rag.query_llm_model_func or self.rag.llm_model_func
-                        )(
+                        response_text = await (self.rag.role_llm_funcs["query"])(
                             cleaned_query,
                             stream=False,
                             history_messages=conversation_history,

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -376,6 +376,66 @@ def _optional_env_int(env_key: str) -> int | None:
     return get_env_value(env_key, None, int, special_none=True)
 
 
+@dataclass(frozen=True)
+class RoleSpec:
+    """Static descriptor for a known LLM role.
+
+    Adding a new role anywhere in LightRAG is a single-line edit: append a
+    ``RoleSpec`` to :data:`ROLES`. Every other component (env var loop in
+    ``api/config.py``, queue observability, role config update flow) iterates
+    this registry rather than hard-coding role names.
+    """
+
+    name: str
+    """Canonical lowercase role key (used in ``role_llm_configs`` dict and CLI/log output)."""
+
+    env_prefix: str
+    """Uppercase prefix used by the API env-var layer, e.g. ``"EXTRACT"`` for
+    ``EXTRACT_LLM_BINDING`` / ``MAX_ASYNC_EXTRACT_LLM`` / ``LLM_TIMEOUT_EXTRACT_LLM``."""
+
+    queue_name: str
+    """Display name passed to ``priority_limit_async_func_call`` for log lines."""
+
+
+ROLES: tuple[RoleSpec, ...] = (
+    RoleSpec("extract", "EXTRACT", "extract LLM func"),
+    RoleSpec("keyword", "KEYWORD", "keyword LLM func"),
+    RoleSpec("query", "QUERY", "query LLM func"),
+    RoleSpec("vlm", "VLM", "vlm LLM func"),
+)
+ROLE_NAMES: frozenset[str] = frozenset(spec.name for spec in ROLES)
+ROLES_BY_NAME: dict[str, RoleSpec] = {spec.name: spec for spec in ROLES}
+
+
+@dataclass
+class RoleLLMConfig:
+    """Per-role LLM override accepted at :class:`LightRAG` init time.
+
+    Any field left as ``None`` falls back to the corresponding base LLM
+    setting (``llm_model_func`` / ``llm_model_kwargs`` / ``llm_model_max_async``
+    / ``default_llm_timeout``). When ``max_async`` is None at init and the
+    user did not pass a ``role_llm_configs`` entry for the role, the value is
+    additionally seeded from ``MAX_ASYNC_{ROLE_PREFIX}_LLM``.
+    """
+
+    func: Callable[..., object] | None = None
+    kwargs: dict[str, Any] | None = None
+    max_async: int | None = None
+    timeout: int | None = None
+
+
+@dataclass
+class _RoleLLMState:
+    """Runtime state for one role. Internal — not part of the public API."""
+
+    raw_func: Callable[..., object]
+    kwargs: dict[str, Any] | None
+    max_async: int | None
+    timeout: int | None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    wrapped: Callable[..., object] | None = None
+
+
 class ObservableAddonParams(dict[str, Any]):
     def __init__(
         self,
@@ -640,43 +700,16 @@ class LightRAG:
     llm_model_func: Callable[..., object] | None = field(default=None)
     """Function for interacting with the large language model (LLM). Must be set before use."""
 
-    extract_llm_model_func: Callable[..., object] | None = field(default=None)
-    """LLM function for extraction role (entity/relation extraction + summaries)."""
-
-    keyword_llm_model_func: Callable[..., object] | None = field(default=None)
-    """LLM function for keyword extraction role."""
-
-    query_llm_model_func: Callable[..., object] | None = field(default=None)
-    """LLM function for final answer/query role."""
-
-    vlm_llm_model_func: Callable[..., object] | None = field(default=None)
-    """VLM (vision-language) model for multimodal analysis (images/tables/equations).
-    Used in analyze_multimodal phase. When Ray-Anything merges, bind here as the VLM role."""
-
-    vlm_llm_model_max_async: int | None = field(
-        default_factory=partial(_optional_env_int, "MAX_ASYNC_VLM_LLM")
+    role_llm_configs: dict[str, RoleLLMConfig | dict[str, Any]] | None = field(
+        default=None
     )
-    """Max concurrent VLM calls in analyze_multimodal."""
+    """Per-role LLM overrides keyed by role name (see :data:`ROLES`).
 
-    extract_llm_model_max_async: int | None = field(
-        default_factory=partial(_optional_env_int, "MAX_ASYNC_EXTRACT_LLM")
-    )
-    """Max concurrent LLM calls for entity/relation extraction."""
-
-    keyword_llm_model_max_async: int | None = field(
-        default_factory=partial(_optional_env_int, "MAX_ASYNC_KEYWORD_LLM")
-    )
-    """Max concurrent LLM calls for keyword extraction."""
-
-    query_llm_model_max_async: int | None = field(
-        default_factory=partial(_optional_env_int, "MAX_ASYNC_QUERY_LLM")
-    )
-    """Max concurrent LLM calls for query/answer generation."""
-
-    extract_llm_timeout: int | None = field(default=None)
-    keyword_llm_timeout: int | None = field(default=None)
-    query_llm_timeout: int | None = field(default=None)
-    vlm_llm_timeout: int | None = field(default=None)
+    Each entry is a :class:`RoleLLMConfig` (or a plain dict with the same
+    keys ``func`` / ``kwargs`` / ``max_async`` / ``timeout``). Any field left
+    as ``None`` falls back to the corresponding base LLM setting. Roles not
+    present in the dict are wrapped from the base ``llm_model_func`` and
+    pick up ``MAX_ASYNC_{ROLE_PREFIX}_LLM`` env defaults."""
 
     llm_model_name: str = field(default="gpt-4o-mini")
     """Name of the LLM model used for generating responses."""
@@ -705,18 +738,6 @@ class LightRAG:
 
     llm_model_kwargs: dict[str, Any] = field(default_factory=dict)
     """Additional keyword arguments passed to the LLM model function."""
-
-    extract_llm_model_kwargs: dict[str, Any] | None = field(default=None)
-    """Additional kwargs for extract role LLM. Falls back to llm_model_kwargs if None."""
-
-    keyword_llm_model_kwargs: dict[str, Any] | None = field(default=None)
-    """Additional kwargs for keyword role LLM. Falls back to llm_model_kwargs if None."""
-
-    query_llm_model_kwargs: dict[str, Any] | None = field(default=None)
-    """Additional kwargs for query role LLM. Falls back to llm_model_kwargs if None."""
-
-    vlm_llm_model_kwargs: dict[str, Any] | None = field(default=None)
-    """Additional kwargs for VLM role LLM. Falls back to llm_model_kwargs if None."""
 
     default_llm_timeout: int = field(
         default=int(os.getenv("LLM_TIMEOUT", DEFAULT_LLM_TIMEOUT))
@@ -861,7 +882,7 @@ class LightRAG:
     @staticmethod
     def _normalize_llm_role(role: str) -> str:
         normalized = role.strip().lower()
-        if normalized not in {"extract", "keyword", "query", "vlm"}:
+        if normalized not in ROLE_NAMES:
             raise ValueError(f"Invalid LLM role: {role}")
         return normalized
 
@@ -877,44 +898,43 @@ class LightRAG:
     def set_role_llm_metadata(self, role: str, **metadata: Any) -> None:
         """Store role metadata used when rebuilding a role-specific LLM function."""
         role = self._normalize_llm_role(role)
-        if not hasattr(self, "_role_llm_runtime_meta"):
-            self._role_llm_runtime_meta = {}
-        existing = dict(self._role_llm_runtime_meta.get(role, {}))
-        existing.update({k: v for k, v in metadata.items() if v is not None})
-        self._role_llm_runtime_meta[role] = existing
+        state = self._role_llm_states[role]
+        for key, value in metadata.items():
+            if value is None:
+                continue
+            state.metadata[key] = value
 
-    def _role_llm_kwargs_attr(self, role: str) -> str:
-        return f"{self._normalize_llm_role(role)}_llm_model_kwargs"
+    @property
+    def role_llm_funcs(self) -> Mapping[str, Callable[..., object]]:
+        """Read-only mapping of role name → wrapped (queue-managed) LLM func."""
+        return {
+            name: state.wrapped
+            for name, state in self._role_llm_states.items()
+            if state.wrapped is not None
+        }
 
-    def _role_llm_max_async_attr(self, role: str) -> str:
-        normalized = self._normalize_llm_role(role)
-        if normalized == "vlm":
-            return "vlm_llm_model_max_async"
-        return f"{normalized}_llm_model_max_async"
-
-    def _role_llm_timeout_attr(self, role: str) -> str:
-        return f"{self._normalize_llm_role(role)}_llm_timeout"
+    @property
+    def role_llm_kwargs(self) -> Mapping[str, dict[str, Any] | None]:
+        """Read-only mapping of role name → effective LLM kwargs (None means inherit base)."""
+        return {name: state.kwargs for name, state in self._role_llm_states.items()}
 
     def _get_effective_role_llm_kwargs(self, role: str) -> dict[str, Any]:
-        stored = getattr(self, self._role_llm_kwargs_attr(role))
-        if stored is not None:
-            return stored
-
-        role_meta = getattr(self, "_role_llm_runtime_meta", {}).get(
-            self._normalize_llm_role(role), {}
-        )
-        if role_meta.get("is_cross_provider"):
+        state = self._role_llm_states[self._normalize_llm_role(role)]
+        if state.kwargs is not None:
+            return state.kwargs
+        if state.metadata.get("is_cross_provider"):
             return {}
-
         return self.llm_model_kwargs
 
     def _get_effective_role_llm_timeout(self, role: str) -> int:
-        timeout = getattr(self, self._role_llm_timeout_attr(role))
-        return timeout if timeout is not None else self.default_llm_timeout
+        state = self._role_llm_states[self._normalize_llm_role(role)]
+        return state.timeout if state.timeout is not None else self.default_llm_timeout
 
     def _get_effective_role_llm_max_async(self, role: str) -> int:
-        max_async = getattr(self, self._role_llm_max_async_attr(role))
-        return max_async if max_async is not None else self.llm_model_max_async
+        state = self._role_llm_states[self._normalize_llm_role(role)]
+        return (
+            state.max_async if state.max_async is not None else self.llm_model_max_async
+        )
 
     def _wrap_llm_role_func(
         self,
@@ -924,10 +944,11 @@ class LightRAG:
         timeout: int,
         model_kwargs: dict[str, Any],
     ) -> Callable[..., object]:
+        spec = ROLES_BY_NAME[role_name]
         return priority_limit_async_func_call(
             max_async,
             llm_timeout=timeout,
-            queue_name=f"{role_name} LLM func",
+            queue_name=spec.queue_name,
         )(
             partial(
                 raw_func,
@@ -936,38 +957,26 @@ class LightRAG:
             )
         )
 
-    def _rebuild_all_role_llm_funcs(self) -> None:
-        base_raw = self._raw_llm_model_func
-        self.llm_model_func = self._wrap_llm_role_func(
-            "base",
-            base_raw,
-            self.llm_model_max_async,
-            self.default_llm_timeout,
-            self.llm_model_kwargs,
-        )
+    def _rebuild_role_llm_funcs(self) -> None:
+        """Wrap each role's raw_func with its own priority queue.
 
-        for role in ("extract", "keyword", "query", "vlm"):
-            raw_func = self._raw_role_llm_funcs.get(role) or base_raw
-            wrapped = self._wrap_llm_role_func(
-                role,
-                raw_func,
-                self._get_effective_role_llm_max_async(role),
-                self._get_effective_role_llm_timeout(role),
-                self._get_effective_role_llm_kwargs(role),
-            )
-            setattr(self, f"{role}_llm_model_func", wrapped)
+        Base ``llm_model_func`` is intentionally NOT wrapped — concurrency
+        for the base function is enforced at the role layer (every code path
+        that calls an LLM goes through a role wrapper).
+        """
+        for spec in ROLES:
+            self._rebuild_single_role_llm_func(spec.name)
 
     def _rebuild_single_role_llm_func(self, role: str) -> None:
         role = self._normalize_llm_role(role)
-        raw_func = self._raw_role_llm_funcs.get(role) or self._raw_llm_model_func
-        wrapped = self._wrap_llm_role_func(
+        state = self._role_llm_states[role]
+        state.wrapped = self._wrap_llm_role_func(
             role,
-            raw_func,
+            state.raw_func,
             self._get_effective_role_llm_max_async(role),
             self._get_effective_role_llm_timeout(role),
             self._get_effective_role_llm_kwargs(role),
         )
-        setattr(self, f"{role}_llm_model_func", wrapped)
 
     async def _shutdown_llm_wrapper(self, wrapped_func: Callable[..., object]) -> None:
         shutdown = getattr(wrapped_func, "shutdown", None)
@@ -977,7 +986,9 @@ class LightRAG:
     def _schedule_retired_llm_queue_cleanup(
         self, wrapped_func: Callable[..., object] | None
     ) -> None:
-        if wrapped_func is None or not callable(getattr(wrapped_func, "shutdown", None)):
+        if wrapped_func is None or not callable(
+            getattr(wrapped_func, "shutdown", None)
+        ):
             return
 
         try:
@@ -1035,51 +1046,48 @@ class LightRAG:
         provider_options: dict[str, Any] | None = None,
     ) -> Callable[..., object] | None:
         role = self._normalize_llm_role(role)
-        kwargs_attr = self._role_llm_kwargs_attr(role)
-        max_async_attr = self._role_llm_max_async_attr(role)
-        timeout_attr = self._role_llm_timeout_attr(role)
-        func_attr = f"{role}_llm_model_func"
+        state = self._role_llm_states[role]
+        old_wrapped = state.wrapped
 
-        snapshot = {
-            "raw_func": self._raw_role_llm_funcs.get(role),
-            "wrapped_func": getattr(self, func_attr),
-            "model_kwargs": deepcopy(getattr(self, kwargs_attr)),
-            "max_async": getattr(self, max_async_attr),
-            "timeout": getattr(self, timeout_attr),
-            "meta": deepcopy(self._role_llm_runtime_meta.get(role, {})),
-        }
+        snapshot = _RoleLLMState(
+            raw_func=state.raw_func,
+            kwargs=deepcopy(state.kwargs),
+            max_async=state.max_async,
+            timeout=state.timeout,
+            metadata=deepcopy(state.metadata),
+            wrapped=state.wrapped,
+        )
 
         try:
             if model_func is not None and not callable(model_func):
                 raise TypeError("model_func must be callable")
 
             if model_kwargs is not None:
-                setattr(self, kwargs_attr, model_kwargs)
+                state.kwargs = model_kwargs
             if max_async is not None:
-                setattr(self, max_async_attr, max_async)
+                state.max_async = max_async
             if timeout is not None:
-                setattr(self, timeout_attr, timeout)
+                state.timeout = timeout
             if model_func is not None:
-                self._raw_role_llm_funcs[role] = model_func
+                state.raw_func = model_func
 
             metadata_updated = any(
                 value is not None
                 for value in (binding, model, host, api_key, provider_options)
             )
-            role_meta = deepcopy(self._role_llm_runtime_meta.get(role, {}))
             if binding is not None:
-                role_meta["binding"] = binding
+                state.metadata["binding"] = binding
             if model is not None:
-                role_meta["model"] = model
+                state.metadata["model"] = model
             if host is not None:
-                role_meta["host"] = host
+                state.metadata["host"] = host
             if api_key is not None:
-                role_meta["api_key"] = api_key
+                state.metadata["api_key"] = api_key
             if provider_options is not None:
-                role_meta["provider_options"] = provider_options
-            if "base_binding" in role_meta and "binding" in role_meta:
-                role_meta["is_cross_provider"] = (
-                    role_meta["binding"] != role_meta["base_binding"]
+                state.metadata["provider_options"] = provider_options
+            if "base_binding" in state.metadata and "binding" in state.metadata:
+                state.metadata["is_cross_provider"] = (
+                    state.metadata["binding"] != state.metadata["base_binding"]
                 )
 
             if metadata_updated:
@@ -1089,21 +1097,20 @@ class LightRAG:
                         "Runtime role builder is not configured; provide model_func or register_role_llm_builder() first"
                     )
                 if builder is not None:
-                    built_func, built_kwargs = builder(role, role_meta)
-                    self._raw_role_llm_funcs[role] = built_func
+                    built_func, built_kwargs = builder(role, state.metadata)
+                    state.raw_func = built_func
                     if model_kwargs is None and built_kwargs is not None:
-                        setattr(self, kwargs_attr, built_kwargs)
+                        state.kwargs = built_kwargs
 
-            self._role_llm_runtime_meta[role] = role_meta
             self._rebuild_single_role_llm_func(role)
-            return snapshot["wrapped_func"]
+            return old_wrapped
         except Exception:
-            self._raw_role_llm_funcs[role] = snapshot["raw_func"]
-            setattr(self, func_attr, snapshot["wrapped_func"])
-            setattr(self, kwargs_attr, snapshot["model_kwargs"])
-            setattr(self, max_async_attr, snapshot["max_async"])
-            setattr(self, timeout_attr, snapshot["timeout"])
-            self._role_llm_runtime_meta[role] = snapshot["meta"]
+            state.raw_func = snapshot.raw_func
+            state.kwargs = snapshot.kwargs
+            state.max_async = snapshot.max_async
+            state.timeout = snapshot.timeout
+            state.metadata = snapshot.metadata
+            state.wrapped = snapshot.wrapped
             raise
 
     def update_llm_role_config(
@@ -1171,57 +1178,65 @@ class LightRAG:
         if old_wrapped is not None:
             await self._shutdown_llm_wrapper(old_wrapped)
 
-    @staticmethod
-    def _mask_secret_value(value: Any) -> Any:
-        if isinstance(value, str) and value:
-            return "***"
-        return value
+    _SECRET_MARKERS = (
+        "api_key",
+        "access_key",
+        "secret",
+        "token",
+        "credential",
+        "password",
+        "passphrase",
+        "pwd",
+        "auth",
+        "session",
+    )
 
-    def _masked_llm_metadata(
-        self, metadata: dict[str, Any], include_secrets: bool
-    ) -> dict[str, Any]:
-        masked = deepcopy(metadata)
-        if include_secrets:
-            return masked
+    @classmethod
+    def _is_secret_key(cls, key: str) -> bool:
+        lowered = key.lower()
+        return any(marker in lowered for marker in cls._SECRET_MARKERS)
 
-        secret_markers = (
-            "api_key",
-            "access_key",
-            "secret",
-            "token",
-            "credential",
-            "password",
-            "passphrase",
-            "pwd",
-        )
-        for key in list(masked.keys()):
-            if any(marker in key.lower() for marker in secret_markers):
-                masked[key] = self._mask_secret_value(masked[key])
-        bedrock_options = masked.get("bedrock_aws_options")
+    def _scrubbed_llm_metadata(self, metadata: dict[str, Any]) -> dict[str, Any]:
+        """Return a deep copy of ``metadata`` with auth-bearing fields removed.
+
+        Auth-bearing fields are stripped entirely — not masked — because a
+        masked ``"***"`` carries no information for an external consumer
+        (operators already see ``binding`` / ``host`` to confirm a role is
+        configured). Stripping makes the invariant simple: anything that
+        appears in this output is safe to log, cache, ship over the wire.
+
+        Components that legitimately need the raw secret (the role builder,
+        provider clients) read it directly off the private
+        ``_role_llm_states[role].metadata`` dict.
+        """
+        scrubbed = deepcopy(metadata)
+        for key in list(scrubbed.keys()):
+            if self._is_secret_key(key):
+                del scrubbed[key]
+        bedrock_options = scrubbed.get("bedrock_aws_options")
         if isinstance(bedrock_options, dict):
             for key in list(bedrock_options.keys()):
-                if any(marker in key.lower() for marker in secret_markers):
-                    bedrock_options[key] = self._mask_secret_value(
-                        bedrock_options[key]
-                    )
-        return masked
+                if self._is_secret_key(key):
+                    del bedrock_options[key]
+        return scrubbed
 
-    def get_llm_role_config(
-        self, role: str | None = None, include_secrets: bool = False
-    ) -> dict[str, Any]:
-        """Return effective role LLM runtime configuration.
+    def get_llm_role_config(self, role: str | None = None) -> dict[str, Any]:
+        """Return effective role LLM runtime configuration (observability snapshot).
 
         Each role entry exposes ``binding`` / ``model`` / ``host`` at the top
         level for convenience and again inside ``metadata`` as part of the
         full runtime snapshot (which may contain extra builder-specific
-        keys). Secret-bearing fields in ``metadata`` are masked unless
-        ``include_secrets=True``.
+        keys). Auth-bearing fields (``api_key``, ``aws_secret_access_key``,
+        ``password``, …) are **stripped entirely** from ``metadata`` — this
+        method is intended for ``/health`` / WebUI / audit output and must
+        never leak credentials. There is no escape hatch; runtime components
+        that legitimately need the raw value read it from
+        ``_role_llm_states[role].metadata`` directly.
         """
 
         def role_config(role_name: str) -> dict[str, Any]:
-            role_meta = self._role_llm_runtime_meta.get(role_name, {})
-            metadata = self._masked_llm_metadata(role_meta, include_secrets)
-            kwargs_value = getattr(self, self._role_llm_kwargs_attr(role_name))
+            state = self._role_llm_states[role_name]
+            metadata = self._scrubbed_llm_metadata(state.metadata)
             return {
                 "binding": metadata.get("binding"),
                 "model": metadata.get("model"),
@@ -1229,21 +1244,23 @@ class LightRAG:
                 "is_cross_provider": metadata.get("is_cross_provider", False),
                 "max_async": self._get_effective_role_llm_max_async(role_name),
                 "timeout": self._get_effective_role_llm_timeout(role_name),
-                "has_model_kwargs": kwargs_value is not None,
+                "has_model_kwargs": state.kwargs is not None,
                 "metadata": metadata,
             }
 
         if role is not None:
-            normalized = self._normalize_llm_role(role)
-            return role_config(normalized)
+            return role_config(self._normalize_llm_role(role))
 
-        return {
-            role_name: role_config(role_name)
-            for role_name in ("extract", "keyword", "query", "vlm")
-        }
+        return {spec.name: role_config(spec.name) for spec in ROLES}
 
     async def get_llm_queue_status(self, include_base: bool = True) -> dict[str, Any]:
-        """Return queue status for base and role LLM wrappers."""
+        """Return queue status for each role's wrapped LLM func.
+
+        The base ``llm_model_func`` is no longer queue-wrapped, so it is not
+        reported here. ``include_base`` is kept for signature compatibility
+        but has no effect.
+        """
+        del include_base  # base is unwrapped — see docstring
 
         async def stats_for(func: Callable[..., object] | None) -> dict[str, Any]:
             if func is None:
@@ -1258,13 +1275,9 @@ class LightRAG:
             return stats
 
         result: dict[str, Any] = {}
-        if include_base:
-            result["base"] = await stats_for(self.llm_model_func)
-
-        for role_name in ("extract", "keyword", "query", "vlm"):
-            result[role_name] = await stats_for(
-                getattr(self, f"{role_name}_llm_model_func", None)
-            )
+        for spec in ROLES:
+            state = self._role_llm_states.get(spec.name)
+            result[spec.name] = await stats_for(state.wrapped if state else None)
         return result
 
     def _mark_addon_params_dirty(self) -> None:
@@ -1356,6 +1369,15 @@ class LightRAG:
         global_config.pop("_addon_params_dirty", None)
         global_config.pop("_cached_entity_extraction_use_json", None)
         global_config["addon_params"] = dict(self._addon_params)
+        # Inject runtime per-role wrapped LLM funcs (callable; not part of asdict
+        # because they live in the private _role_llm_states map). The first
+        # _build_global_config() call from __post_init__ runs before the role
+        # state is built, so fall back to an empty dict in that case.
+        states = getattr(self, "_role_llm_states", None) or {}
+        global_config["role_llm_funcs"] = {
+            spec.name: states[spec.name].wrapped if spec.name in states else None
+            for spec in ROLES
+        }
         return global_config
 
     def __post_init__(self, addon_params: dict[str, Any] | None):
@@ -1577,22 +1599,45 @@ class LightRAG:
             embedding_func=None,
         )
 
-        # Build base + role-isolated LLM wrappers (independent queues per role).
+        # Per-role isolated LLM wrappers (independent queues per role).
+        # The base ``self.llm_model_func`` is intentionally NOT queue-wrapped:
+        # every code path that calls an LLM goes through one of the role
+        # wrappers built below, so concurrency is enforced at the role layer.
         base_llm_func = self.llm_model_func
         if base_llm_func is None:
             raise ValueError("llm_model_func must be provided")
 
         self._llm_role_builder = None
-        self._role_llm_runtime_meta: dict[str, dict[str, Any]] = {}
         self._retired_llm_queue_cleanup_tasks: set[asyncio.Task] = set()
-        self._raw_llm_model_func = base_llm_func
-        self._raw_role_llm_funcs: dict[str, Callable[..., object]] = {
-            "extract": self.extract_llm_model_func or base_llm_func,
-            "keyword": self.keyword_llm_model_func or base_llm_func,
-            "query": self.query_llm_model_func or base_llm_func,
-            "vlm": self.vlm_llm_model_func or base_llm_func,
-        }
-        self._rebuild_all_role_llm_funcs()
+
+        user_role_configs = self.role_llm_configs or {}
+        self._role_llm_states: dict[str, _RoleLLMState] = {}
+        for spec in ROLES:
+            override = user_role_configs.get(spec.name)
+            if override is None:
+                cfg = RoleLLMConfig()
+            elif isinstance(override, RoleLLMConfig):
+                cfg = override
+            elif isinstance(override, Mapping):
+                cfg = RoleLLMConfig(**dict(override))
+            else:
+                raise TypeError(
+                    f"role_llm_configs[{spec.name!r}] must be RoleLLMConfig or "
+                    f"a dict, got {type(override).__name__}"
+                )
+
+            max_async = cfg.max_async
+            if max_async is None:
+                max_async = _optional_env_int(f"MAX_ASYNC_{spec.env_prefix}_LLM")
+
+            self._role_llm_states[spec.name] = _RoleLLMState(
+                raw_func=cfg.func or base_llm_func,
+                kwargs=cfg.kwargs,
+                max_async=max_async,
+                timeout=cfg.timeout,
+            )
+
+        self._rebuild_role_llm_funcs()
 
         self._storages_status = StoragesStatus.CREATED
 
@@ -3616,7 +3661,7 @@ class LightRAG:
             block_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
             # Analyze sidecar multimodal items by VLM model role.
-            use_vlm_func = self.vlm_llm_model_func or self.llm_model_func
+            use_vlm_func = self.role_llm_funcs["vlm"]
             effective_vlm_max_async = self._get_effective_role_llm_max_async("vlm")
             sem = asyncio.Semaphore(max(1, effective_vlm_max_async))
             analyze_retries = max(0, int(os.getenv("VLM_ANALYZE_RETRIES", "2")))
@@ -5821,9 +5866,7 @@ class LightRAG:
             elif param.mode == "bypass":
                 # Bypass mode: directly use LLM without knowledge retrieval
                 use_llm_func = (
-                    param.model_func
-                    or global_config.get("query_llm_model_func")
-                    or global_config["llm_model_func"]
+                    param.model_func or global_config["role_llm_funcs"]["query"]
                 )
                 # Apply higher priority (8) to entity/relation summary tasks
                 use_llm_func = partial(use_llm_func, _priority=8)

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -969,7 +969,50 @@ class LightRAG:
         )
         setattr(self, f"{role}_llm_model_func", wrapped)
 
-    def update_llm_role_config(
+    async def _shutdown_llm_wrapper(self, wrapped_func: Callable[..., object]) -> None:
+        shutdown = getattr(wrapped_func, "shutdown", None)
+        if callable(shutdown):
+            await shutdown(graceful=True)
+
+    def _schedule_retired_llm_queue_cleanup(
+        self, wrapped_func: Callable[..., object] | None
+    ) -> None:
+        if wrapped_func is None or not callable(getattr(wrapped_func, "shutdown", None)):
+            return
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            try:
+                asyncio.run(self._shutdown_llm_wrapper(wrapped_func))
+            except RuntimeError as e:
+                logger.warning(
+                    f"Failed to clean up retired LLM queue synchronously: {e}"
+                )
+            return
+
+        task = loop.create_task(self._shutdown_llm_wrapper(wrapped_func))
+        if not hasattr(self, "_retired_llm_queue_cleanup_tasks"):
+            self._retired_llm_queue_cleanup_tasks = set()
+        self._retired_llm_queue_cleanup_tasks.add(task)
+        task.add_done_callback(self._finalize_retired_llm_queue_cleanup)
+
+    def _finalize_retired_llm_queue_cleanup(self, task: asyncio.Task) -> None:
+        self._retired_llm_queue_cleanup_tasks.discard(task)
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            logger.warning(f"Retired LLM queue cleanup failed: {e}")
+
+    async def wait_for_retired_llm_queues(self) -> None:
+        """Wait until all retired role LLM queues have drained and shut down."""
+        while getattr(self, "_retired_llm_queue_cleanup_tasks", None):
+            tasks = list(self._retired_llm_queue_cleanup_tasks)
+            await asyncio.gather(*tasks, return_exceptions=False)
+
+    def _apply_llm_role_config_update(
         self,
         role: str,
         *,
@@ -982,14 +1025,7 @@ class LightRAG:
         host: str | None = None,
         api_key: str | None = None,
         provider_options: dict[str, Any] | None = None,
-    ) -> None:
-        """
-        Update a role-specific LLM configuration at runtime.
-
-        Supports lightweight updates (kwargs/max_async/timeout/model_func) directly.
-        For binding/model/host/api_key/provider_options updates, a role builder must
-        be registered via register_role_llm_builder().
-        """
+    ) -> Callable[..., object] | None:
         role = self._normalize_llm_role(role)
         kwargs_attr = self._role_llm_kwargs_attr(role)
         max_async_attr = self._role_llm_max_async_attr(role)
@@ -1055,6 +1091,7 @@ class LightRAG:
 
             self._role_llm_runtime_meta[role] = role_meta
             self._rebuild_single_role_llm_func(role)
+            return snapshot["wrapped_func"]
         except Exception:
             self._raw_role_llm_funcs[role] = snapshot["raw_func"]
             setattr(self, func_attr, snapshot["wrapped_func"])
@@ -1063,6 +1100,151 @@ class LightRAG:
             setattr(self, timeout_attr, snapshot["timeout"])
             self._role_llm_runtime_meta[role] = snapshot["meta"]
             raise
+
+    def update_llm_role_config(
+        self,
+        role: str,
+        *,
+        model_func: Callable[..., object] | None = None,
+        model_kwargs: dict[str, Any] | None = None,
+        max_async: int | None = None,
+        timeout: int | None = None,
+        binding: str | None = None,
+        model: str | None = None,
+        host: str | None = None,
+        api_key: str | None = None,
+        provider_options: dict[str, Any] | None = None,
+    ) -> None:
+        """
+        Update a role-specific LLM configuration at runtime.
+
+        Supports lightweight updates (kwargs/max_async/timeout/model_func) directly.
+        For binding/model/host/api_key/provider_options updates, a role builder must
+        be registered via register_role_llm_builder().
+        """
+        old_wrapped = self._apply_llm_role_config_update(
+            role,
+            model_func=model_func,
+            model_kwargs=model_kwargs,
+            max_async=max_async,
+            timeout=timeout,
+            binding=binding,
+            model=model,
+            host=host,
+            api_key=api_key,
+            provider_options=provider_options,
+        )
+        self._schedule_retired_llm_queue_cleanup(old_wrapped)
+
+    async def aupdate_llm_role_config(
+        self,
+        role: str,
+        *,
+        model_func: Callable[..., object] | None = None,
+        model_kwargs: dict[str, Any] | None = None,
+        max_async: int | None = None,
+        timeout: int | None = None,
+        binding: str | None = None,
+        model: str | None = None,
+        host: str | None = None,
+        api_key: str | None = None,
+        provider_options: dict[str, Any] | None = None,
+    ) -> None:
+        """Async variant of update_llm_role_config that waits for queue cleanup."""
+        old_wrapped = self._apply_llm_role_config_update(
+            role,
+            model_func=model_func,
+            model_kwargs=model_kwargs,
+            max_async=max_async,
+            timeout=timeout,
+            binding=binding,
+            model=model,
+            host=host,
+            api_key=api_key,
+            provider_options=provider_options,
+        )
+        if old_wrapped is not None:
+            await self._shutdown_llm_wrapper(old_wrapped)
+
+    @staticmethod
+    def _mask_secret_value(value: Any) -> Any:
+        if isinstance(value, str) and value:
+            return "***"
+        return value
+
+    def _masked_llm_metadata(
+        self, metadata: dict[str, Any], include_secrets: bool
+    ) -> dict[str, Any]:
+        masked = deepcopy(metadata)
+        if include_secrets:
+            return masked
+
+        secret_markers = ("api_key", "access_key", "secret", "token", "credential")
+        for key in list(masked.keys()):
+            if any(marker in key.lower() for marker in secret_markers):
+                masked[key] = self._mask_secret_value(masked[key])
+        bedrock_options = masked.get("bedrock_aws_options")
+        if isinstance(bedrock_options, dict):
+            for key in list(bedrock_options.keys()):
+                if any(marker in key.lower() for marker in secret_markers):
+                    bedrock_options[key] = self._mask_secret_value(
+                        bedrock_options[key]
+                    )
+        return masked
+
+    def get_llm_role_config(
+        self, role: str | None = None, include_secrets: bool = False
+    ) -> dict[str, Any]:
+        """Return effective role LLM runtime configuration."""
+
+        def role_config(role_name: str) -> dict[str, Any]:
+            role_meta = getattr(self, "_role_llm_runtime_meta", {}).get(role_name, {})
+            metadata = self._masked_llm_metadata(role_meta, include_secrets)
+            kwargs_value = getattr(self, self._role_llm_kwargs_attr(role_name))
+            return {
+                "binding": metadata.get("binding"),
+                "model": metadata.get("model"),
+                "host": metadata.get("host"),
+                "is_cross_provider": metadata.get("is_cross_provider", False),
+                "max_async": self._get_effective_role_llm_max_async(role_name),
+                "timeout": self._get_effective_role_llm_timeout(role_name),
+                "has_model_kwargs": kwargs_value is not None,
+                "metadata": metadata,
+            }
+
+        if role is not None:
+            normalized = self._normalize_llm_role(role)
+            return role_config(normalized)
+
+        return {
+            role_name: role_config(role_name)
+            for role_name in ("extract", "keyword", "query", "vlm")
+        }
+
+    async def get_llm_queue_status(self, include_base: bool = True) -> dict[str, Any]:
+        """Return queue status for base and role LLM wrappers."""
+
+        async def stats_for(func: Callable[..., object] | None) -> dict[str, Any]:
+            if func is None:
+                return {"available": False}
+            get_stats = getattr(func, "get_queue_stats", None)
+            if not callable(get_stats):
+                return {"available": False}
+            stats = get_stats()
+            if inspect.isawaitable(stats):
+                stats = await stats
+            stats["available"] = True
+            return stats
+
+        result: dict[str, Any] = {}
+        if include_base:
+            result["base"] = await stats_for(self.llm_model_func)
+
+        for role_name in ("extract", "keyword", "query", "vlm"):
+            result[role_name] = await stats_for(
+                getattr(self, f"{role_name}_llm_model_func", None)
+            )
+        return result
 
     def _mark_addon_params_dirty(self) -> None:
         self._addon_params_dirty = True
@@ -1381,6 +1563,7 @@ class LightRAG:
 
         self._llm_role_builder = None
         self._role_llm_runtime_meta: dict[str, dict[str, Any]] = {}
+        self._retired_llm_queue_cleanup_tasks: set[asyncio.Task] = set()
         self._raw_llm_model_func = base_llm_func
         self._raw_role_llm_funcs: dict[str, Callable[..., object]] = {
             "extract": self.extract_llm_model_func or base_llm_func,

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -983,17 +983,20 @@ class LightRAG:
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
-            try:
-                asyncio.run(self._shutdown_llm_wrapper(wrapped_func))
-            except RuntimeError as e:
-                logger.warning(
-                    f"Failed to clean up retired LLM queue synchronously: {e}"
-                )
+            # The retired wrapper's queue and worker tasks are tied to the
+            # event loop that first used them. Spinning up a fresh loop via
+            # asyncio.run would either hang on queue.join() or touch
+            # primitives bound to a closed loop. Skip cleanup with a warning
+            # — call aupdate_llm_role_config() from an async context for
+            # deterministic shutdown.
+            logger.warning(
+                "update_llm_role_config: skipping retired LLM queue cleanup "
+                "because no event loop is running; call aupdate_llm_role_config() "
+                "from an async context for deterministic shutdown"
+            )
             return
 
         task = loop.create_task(self._shutdown_llm_wrapper(wrapped_func))
-        if not hasattr(self, "_retired_llm_queue_cleanup_tasks"):
-            self._retired_llm_queue_cleanup_tasks = set()
         self._retired_llm_queue_cleanup_tasks.add(task)
         task.add_done_callback(self._finalize_retired_llm_queue_cleanup)
 
@@ -1007,10 +1010,15 @@ class LightRAG:
             logger.warning(f"Retired LLM queue cleanup failed: {e}")
 
     async def wait_for_retired_llm_queues(self) -> None:
-        """Wait until all retired role LLM queues have drained and shut down."""
-        while getattr(self, "_retired_llm_queue_cleanup_tasks", None):
+        """Wait until all retired role LLM queues have drained and shut down.
+
+        Cleanup failures are logged by ``_finalize_retired_llm_queue_cleanup``
+        and intentionally swallowed here so callers can rely on this method
+        always returning once every retired wrapper has finished.
+        """
+        while self._retired_llm_queue_cleanup_tasks:
             tasks = list(self._retired_llm_queue_cleanup_tasks)
-            await asyncio.gather(*tasks, return_exceptions=False)
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     def _apply_llm_role_config_update(
         self,
@@ -1038,11 +1046,8 @@ class LightRAG:
             "model_kwargs": deepcopy(getattr(self, kwargs_attr)),
             "max_async": getattr(self, max_async_attr),
             "timeout": getattr(self, timeout_attr),
-            "meta": deepcopy(getattr(self, "_role_llm_runtime_meta", {}).get(role, {})),
+            "meta": deepcopy(self._role_llm_runtime_meta.get(role, {})),
         }
-
-        if not hasattr(self, "_role_llm_runtime_meta"):
-            self._role_llm_runtime_meta = {}
 
         try:
             if model_func is not None and not callable(model_func):
@@ -1179,7 +1184,16 @@ class LightRAG:
         if include_secrets:
             return masked
 
-        secret_markers = ("api_key", "access_key", "secret", "token", "credential")
+        secret_markers = (
+            "api_key",
+            "access_key",
+            "secret",
+            "token",
+            "credential",
+            "password",
+            "passphrase",
+            "pwd",
+        )
         for key in list(masked.keys()):
             if any(marker in key.lower() for marker in secret_markers):
                 masked[key] = self._mask_secret_value(masked[key])
@@ -1195,10 +1209,17 @@ class LightRAG:
     def get_llm_role_config(
         self, role: str | None = None, include_secrets: bool = False
     ) -> dict[str, Any]:
-        """Return effective role LLM runtime configuration."""
+        """Return effective role LLM runtime configuration.
+
+        Each role entry exposes ``binding`` / ``model`` / ``host`` at the top
+        level for convenience and again inside ``metadata`` as part of the
+        full runtime snapshot (which may contain extra builder-specific
+        keys). Secret-bearing fields in ``metadata`` are masked unless
+        ``include_secrets=True``.
+        """
 
         def role_config(role_name: str) -> dict[str, Any]:
-            role_meta = getattr(self, "_role_llm_runtime_meta", {}).get(role_name, {})
+            role_meta = self._role_llm_runtime_meta.get(role_name, {})
             metadata = self._masked_llm_metadata(role_meta, include_secrets)
             kwargs_value = getattr(self, self._role_llm_kwargs_attr(role_name))
             return {

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1180,7 +1180,10 @@ class LightRAG:
 
     _SECRET_MARKERS = (
         "api_key",
+        "api-key",
+        "apikey",
         "access_key",
+        "access-key",
         "secret",
         "token",
         "credential",
@@ -1209,16 +1212,21 @@ class LightRAG:
         provider clients) read it directly off the private
         ``_role_llm_states[role].metadata`` dict.
         """
-        scrubbed = deepcopy(metadata)
-        for key in list(scrubbed.keys()):
-            if self._is_secret_key(key):
-                del scrubbed[key]
-        bedrock_options = scrubbed.get("bedrock_aws_options")
-        if isinstance(bedrock_options, dict):
-            for key in list(bedrock_options.keys()):
-                if self._is_secret_key(key):
-                    del bedrock_options[key]
-        return scrubbed
+
+        def scrub_value(value: Any) -> Any:
+            if isinstance(value, Mapping):
+                return {
+                    key: scrub_value(inner_value)
+                    for key, inner_value in value.items()
+                    if not self._is_secret_key(str(key))
+                }
+            if isinstance(value, list):
+                return [scrub_value(item) for item in value]
+            if isinstance(value, tuple):
+                return tuple(scrub_value(item) for item in value)
+            return deepcopy(value)
+
+        return scrub_value(metadata)
 
     def get_llm_role_config(self, role: str | None = None) -> dict[str, Any]:
         """Return effective role LLM runtime configuration (observability snapshot).
@@ -1611,6 +1619,20 @@ class LightRAG:
         self._retired_llm_queue_cleanup_tasks: set[asyncio.Task] = set()
 
         user_role_configs = self.role_llm_configs or {}
+        if not isinstance(user_role_configs, Mapping):
+            raise TypeError(
+                "role_llm_configs must be a Mapping or None, got "
+                f"{type(user_role_configs).__name__}"
+            )
+        unknown_roles = [role for role in user_role_configs if role not in ROLE_NAMES]
+        if unknown_roles:
+            valid_roles = ", ".join(sorted(ROLE_NAMES))
+            unknown = ", ".join(repr(role) for role in unknown_roles)
+            raise ValueError(
+                f"Unknown role_llm_configs key(s): {unknown}. "
+                f"Valid roles are: {valid_roles}"
+            )
+
         self._role_llm_states: dict[str, _RoleLLMState] = {}
         for spec in ROLES:
             override = user_role_configs.get(spec.name)

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -376,9 +376,7 @@ async def _summarize_descriptions(
     Returns:
         Summarized description string
     """
-    use_llm_func: callable = (
-        global_config.get("extract_llm_model_func") or global_config["llm_model_func"]
-    )
+    use_llm_func: callable = global_config["role_llm_funcs"]["extract"]
     # Apply higher priority (8) to entity/relation summary tasks
     use_llm_func = partial(use_llm_func, _priority=8)
 
@@ -3257,9 +3255,7 @@ async def extract_entities(
                     "User cancelled during entity extraction"
                 )
 
-    use_llm_func: callable = (
-        global_config.get("extract_llm_model_func") or global_config["llm_model_func"]
-    )
+    use_llm_func: callable = global_config["role_llm_funcs"]["extract"]
     entity_extract_max_gleaning = global_config["entity_extract_max_gleaning"]
 
     # Check if JSON structured output mode is enabled
@@ -3609,9 +3605,7 @@ async def kg_query(
     if query_param.model_func:
         use_model_func = query_param.model_func
     else:
-        use_model_func = (
-            global_config.get("query_llm_model_func") or global_config["llm_model_func"]
-        )
+        use_model_func = global_config["role_llm_funcs"]["query"]
         # Apply higher priority (5) to query relation LLM function
         use_model_func = partial(use_model_func, _priority=5)
 
@@ -3986,10 +3980,7 @@ async def extract_keywords_only(
     if param.model_func:
         use_model_func = param.model_func
     else:
-        use_model_func = (
-            global_config.get("keyword_llm_model_func")
-            or global_config["llm_model_func"]
-        )
+        use_model_func = global_config["role_llm_funcs"]["keyword"]
         # Apply higher priority (5) to query relation LLM function
         use_model_func = partial(use_model_func, _priority=5)
 
@@ -5504,9 +5495,7 @@ async def naive_query(
     if query_param.model_func:
         use_model_func = query_param.model_func
     else:
-        use_model_func = (
-            global_config.get("query_llm_model_func") or global_config["llm_model_func"]
-        )
+        use_model_func = global_config["role_llm_funcs"]["query"]
         # Apply higher priority (5) to query relation LLM function
         use_model_func = partial(use_model_func, _priority=5)
 

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -799,6 +799,7 @@ def priority_limit_async_func_call(
         completed_total = 0
         failed_total = 0
         cancelled_total = 0
+        rejected_total = 0
 
         async def worker():
             """Enhanced worker that processes tasks with proper timeout and state management"""
@@ -1043,30 +1044,39 @@ def priority_limit_async_func_call(
                 "completed_total": completed_total,
                 "failed_total": failed_total,
                 "cancelled_total": cancelled_total,
+                "rejected_total": rejected_total,
             }
 
         async def shutdown(graceful: bool = True, timeout: float | None = None):
             """Shut down workers and cleanup resources.
 
-            Graceful mode stops new submissions, drains queued/running work,
-            then cancels idle workers. Force mode cancels pending work.
+            Graceful mode stops new submissions and drains queued/running
+            work; if the drain exceeds ``timeout`` (defaulting to
+            ``max_task_duration`` or 30s), it falls through to forced
+            cancellation so shutdown never blocks indefinitely.
             """
             nonlocal accepting_new_tasks, initialized, worker_health_check_task
             logger.info(f"{queue_name}: Shutting down priority queue workers")
 
             accepting_new_tasks = False
 
+            drain_timed_out = False
             if graceful:
-                try:
-                    if timeout is None:
-                        await queue.join()
-                    else:
-                        await asyncio.wait_for(queue.join(), timeout=timeout)
-                except asyncio.TimeoutError:
-                    logger.warning(
-                        f"{queue_name}: Timeout waiting for queue to empty during shutdown"
+                effective_timeout = timeout
+                if effective_timeout is None:
+                    effective_timeout = (
+                        max_task_duration if max_task_duration is not None else 30.0
                     )
-            else:
+                try:
+                    await asyncio.wait_for(queue.join(), timeout=effective_timeout)
+                except asyncio.TimeoutError:
+                    drain_timed_out = True
+                    logger.warning(
+                        f"{queue_name}: Graceful drain timed out after "
+                        f"{effective_timeout}s; cancelling pending work"
+                    )
+
+            if not graceful or drain_timed_out:
                 # Cancel all active futures
                 for future in list(active_futures):
                     if not future.done():
@@ -1132,7 +1142,9 @@ def priority_limit_async_func_call(
                 Any exception raised by the decorated function
             """
             nonlocal submitted_total, completed_total, cancelled_total, failed_total
+            nonlocal rejected_total
             if not accepting_new_tasks:
+                rejected_total += 1
                 raise RuntimeError(f"{queue_name}: Queue is shutting down")
 
             await ensure_workers()
@@ -1162,6 +1174,7 @@ def priority_limit_async_func_call(
                 # Queue the task with timeout handling
                 try:
                     if not accepting_new_tasks:
+                        rejected_total += 1
                         raise RuntimeError(f"{queue_name}: Queue is shutting down")
                     if _queue_timeout is not None:
                         await asyncio.wait_for(

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -787,6 +787,7 @@ def priority_limit_async_func_call(
         counter = 0
         shutdown_event = asyncio.Event()
         initialized = False
+        accepting_new_tasks = True
         worker_health_check_task = None
 
         # Enhanced task state management
@@ -794,6 +795,10 @@ def priority_limit_async_func_call(
         task_states_lock = asyncio.Lock()
         active_futures = weakref.WeakSet()
         reinit_count = 0
+        submitted_total = 0
+        completed_total = 0
+        failed_total = 0
+        cancelled_total = 0
 
         async def worker():
             """Enhanced worker that processes tasks with proper timeout and state management"""
@@ -1014,31 +1019,74 @@ def priority_limit_async_func_call(
                     f"{queue_name}: {workers_needed} new workers initialized {timeout_str}"
                 )
 
-        async def shutdown():
-            """Gracefully shut down all workers and cleanup resources"""
+        async def get_queue_stats():
+            """Return a best-effort snapshot of queue and worker state."""
+            async with task_states_lock:
+                running = sum(
+                    1
+                    for task_state in task_states.values()
+                    if task_state.worker_started and not task_state.future.done()
+                )
+                in_flight = len(task_states)
+
+            active_workers = len([task for task in tasks if not task.done()])
+            return {
+                "queue_name": queue_name,
+                "max_async": max_size,
+                "max_queue_size": max_queue_size,
+                "queued": queue.qsize(),
+                "running": running,
+                "in_flight": in_flight,
+                "worker_count": active_workers,
+                "initialized": initialized,
+                "submitted_total": submitted_total,
+                "completed_total": completed_total,
+                "failed_total": failed_total,
+                "cancelled_total": cancelled_total,
+            }
+
+        async def shutdown(graceful: bool = True, timeout: float | None = None):
+            """Shut down workers and cleanup resources.
+
+            Graceful mode stops new submissions, drains queued/running work,
+            then cancels idle workers. Force mode cancels pending work.
+            """
+            nonlocal accepting_new_tasks, initialized, worker_health_check_task
             logger.info(f"{queue_name}: Shutting down priority queue workers")
 
+            accepting_new_tasks = False
+
+            if graceful:
+                try:
+                    if timeout is None:
+                        await queue.join()
+                    else:
+                        await asyncio.wait_for(queue.join(), timeout=timeout)
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        f"{queue_name}: Timeout waiting for queue to empty during shutdown"
+                    )
+            else:
+                # Cancel all active futures
+                for future in list(active_futures):
+                    if not future.done():
+                        future.cancel()
+
+                # Cancel all pending tasks
+                async with task_states_lock:
+                    for task_id, task_state in list(task_states.items()):
+                        if not task_state.future.done():
+                            task_state.future.cancel()
+                    task_states.clear()
+
+                while True:
+                    try:
+                        queue.get_nowait()
+                        queue.task_done()
+                    except asyncio.QueueEmpty:
+                        break
+
             shutdown_event.set()
-
-            # Cancel all active futures
-            for future in list(active_futures):
-                if not future.done():
-                    future.cancel()
-
-            # Cancel all pending tasks
-            async with task_states_lock:
-                for task_id, task_state in list(task_states.items()):
-                    if not task_state.future.done():
-                        task_state.future.cancel()
-                task_states.clear()
-
-            # Wait for queue to empty with timeout
-            try:
-                await asyncio.wait_for(queue.join(), timeout=5.0)
-            except asyncio.TimeoutError:
-                logger.warning(
-                    f"{queue_name}: Timeout waiting for queue to empty during shutdown"
-                )
 
             # Cancel worker tasks
             for task in list(tasks):
@@ -1056,6 +1104,8 @@ def priority_limit_async_func_call(
                     await worker_health_check_task
                 except asyncio.CancelledError:
                     pass
+            worker_health_check_task = None
+            initialized = False
 
             logger.info(f"{queue_name}: Priority queue workers shutdown complete")
 
@@ -1081,6 +1131,10 @@ def priority_limit_async_func_call(
                 QueueFullError: If the queue is full and waiting times out
                 Any exception raised by the decorated function
             """
+            nonlocal submitted_total, completed_total, cancelled_total, failed_total
+            if not accepting_new_tasks:
+                raise RuntimeError(f"{queue_name}: Queue is shutting down")
+
             await ensure_workers()
 
             # Generate unique task ID
@@ -1107,6 +1161,8 @@ def priority_limit_async_func_call(
 
                 # Queue the task with timeout handling
                 try:
+                    if not accepting_new_tasks:
+                        raise RuntimeError(f"{queue_name}: Queue is shutting down")
                     if _queue_timeout is not None:
                         await asyncio.wait_for(
                             queue.put(
@@ -1118,6 +1174,7 @@ def priority_limit_async_func_call(
                         await queue.put(
                             (_priority, current_count, task_id, args, kwargs)
                         )
+                    submitted_total += 1
                 except asyncio.TimeoutError:
                     raise QueueFullError(
                         f"{queue_name}: Queue full, timeout after {_queue_timeout} seconds"
@@ -1131,9 +1188,11 @@ def priority_limit_async_func_call(
                 # Wait for result with timeout handling
                 try:
                     if _timeout is not None:
-                        return await asyncio.wait_for(future, _timeout)
+                        result = await asyncio.wait_for(future, _timeout)
                     else:
-                        return await future
+                        result = await future
+                    completed_total += 1
+                    return result
                 except asyncio.TimeoutError:
                     # This is user-level timeout (asyncio.wait_for caused)
                     # Mark cancellation request
@@ -1154,15 +1213,24 @@ def priority_limit_async_func_call(
                     ):
                         await asyncio.sleep(0.1)
 
+                    cancelled_total += 1
                     raise TimeoutError(
                         f"{queue_name}: User timeout after {_timeout} seconds"
                     )
                 except WorkerTimeoutError as e:
                     # This is Worker-level timeout, directly propagate exception information
+                    failed_total += 1
                     raise TimeoutError(f"{queue_name}: {str(e)}")
                 except HealthCheckTimeoutError as e:
                     # This is Health Check-level timeout, directly propagate exception information
+                    failed_total += 1
                     raise TimeoutError(f"{queue_name}: {str(e)}")
+                except asyncio.CancelledError:
+                    cancelled_total += 1
+                    raise
+                except Exception:
+                    failed_total += 1
+                    raise
 
             finally:
                 # Ensure cleanup
@@ -1172,6 +1240,7 @@ def priority_limit_async_func_call(
 
         # Add shutdown method to decorated function
         wait_func.shutdown = shutdown
+        wait_func.get_queue_stats = get_queue_stats
 
         return wait_func
 

--- a/lightrag_webui/src/api/lightrag.ts
+++ b/lightrag_webui/src/api/lightrag.ts
@@ -39,6 +39,7 @@ export type LightragQueueStatus = {
   completed_total?: number
   failed_total?: number
   cancelled_total?: number
+  rejected_total?: number
 }
 
 export type LightragStatus = {

--- a/lightrag_webui/src/api/lightrag.ts
+++ b/lightrag_webui/src/api/lightrag.ts
@@ -25,6 +25,22 @@ export type LightragGraphType = {
   edges: LightragEdgeType[]
 }
 
+export type LightragQueueStatus = {
+  available: boolean
+  queue_name?: string
+  max_async?: number
+  max_queue_size?: number
+  queued?: number
+  running?: number
+  in_flight?: number
+  worker_count?: number
+  initialized?: boolean
+  submitted_total?: number
+  completed_total?: number
+  failed_total?: number
+  cancelled_total?: number
+}
+
 export type LightragStatus = {
   status: 'healthy'
   working_directory: string
@@ -61,6 +77,7 @@ export type LightragStatus = {
   api_version?: string
   auth_mode?: 'enabled' | 'disabled'
   pipeline_busy: boolean
+  llm_queue_status?: Record<string, LightragQueueStatus>
   keyed_locks?: {
     process_id: number
     cleanup_performed: {

--- a/tests/test_bedrock_llm.py
+++ b/tests/test_bedrock_llm.py
@@ -559,7 +559,7 @@ async def test_create_app_query_role_uses_bedrock_binding(tmp_path, monkeypatch)
         ) as mocked_openai,
     ):
         lightrag_server.create_app(args)
-        query_func = _FakeLightRAG.last_init_kwargs["query_llm_model_func"]
+        query_func = _FakeLightRAG.last_init_kwargs["role_llm_configs"]["query"].func
         result = await query_func("hello")
 
     assert result == "bedrock-ok"
@@ -608,7 +608,7 @@ async def test_create_app_bedrock_query_role_uses_role_sigv4_credentials(
         AsyncMock(return_value="bedrock-ok"),
     ) as mocked_bedrock:
         lightrag_server.create_app(args)
-        query_func = _FakeLightRAG.last_init_kwargs["query_llm_model_func"]
+        query_func = _FakeLightRAG.last_init_kwargs["role_llm_configs"]["query"].func
         await query_func("hello")
 
     assert mocked_bedrock.await_args.kwargs["aws_region"] == "us-west-2"

--- a/tests/test_bedrock_llm.py
+++ b/tests/test_bedrock_llm.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from fastapi import APIRouter
+from fastapi.testclient import TestClient
 
 from lightrag.llm.bedrock import (
     bedrock_complete,
@@ -443,15 +444,25 @@ def test_bedrock_auth_docstrings_describe_generic_api_key_behavior():
 
 class _FakeLightRAG:
     last_init_kwargs = None
+    last_instance = None
 
     def __init__(self, **kwargs):
         type(self).last_init_kwargs = dict(kwargs)
+        type(self).last_instance = self
+        self.role_config_snapshot = {}
+        self.queue_status_snapshot = {}
 
     def register_role_llm_builder(self, _builder) -> None:
         return None
 
     def set_role_llm_metadata(self, _role: str, **_metadata) -> None:
         return None
+
+    def get_llm_role_config(self):
+        return self.role_config_snapshot
+
+    async def get_llm_queue_status(self, include_base=True):
+        return self.queue_status_snapshot
 
 
 class _FakeOllamaAPI:
@@ -503,6 +514,7 @@ def _make_args(tmp_path) -> SimpleNamespace:
         max_async=4,
         summary_max_tokens=512,
         summary_context_size=4096,
+        force_llm_summary_on_merge=8,
         chunk_size=1200,
         chunk_overlap_size=100,
         kv_storage="JsonKVStorage",
@@ -521,6 +533,10 @@ def _make_args(tmp_path) -> SimpleNamespace:
         rerank_model=None,
         rerank_binding_host=None,
         rerank_binding_api_key=None,
+        embedding_func_max_async=8,
+        embedding_batch_num=10,
+        min_rerank_score=0.0,
+        related_chunk_number=5,
         top_k=10,
     )
 
@@ -631,3 +647,61 @@ def test_create_app_rejects_bedrock_role_api_key(tmp_path, monkeypatch):
 
     with pytest.raises(ValueError, match="does not support role-specific"):
         lightrag_server.create_app(args)
+
+
+@pytest.mark.offline
+def test_health_role_llm_config_uses_runtime_snapshot(tmp_path, monkeypatch):
+    _reload_api_modules_if_mocked()
+    monkeypatch.setattr(sys, "argv", ["pytest"])
+    config = importlib.import_module("lightrag.api.config")
+    config.initialize_config(_make_args(tmp_path), force=True)
+    lightrag_server = importlib.import_module("lightrag.api.lightrag_server")
+    monkeypatch.setattr(lightrag_server, "LightRAG", _FakeLightRAG)
+    monkeypatch.setattr(lightrag_server, "check_frontend_build", lambda: (True, False))
+    monkeypatch.setattr(
+        lightrag_server, "create_document_routes", lambda *_args, **_kwargs: APIRouter()
+    )
+    monkeypatch.setattr(
+        lightrag_server, "create_query_routes", lambda *_args, **_kwargs: APIRouter()
+    )
+    monkeypatch.setattr(
+        lightrag_server, "create_graph_routes", lambda *_args, **_kwargs: APIRouter()
+    )
+    monkeypatch.setattr(lightrag_server, "OllamaAPI", _FakeOllamaAPI)
+    monkeypatch.setattr(
+        lightrag_server,
+        "get_namespace_data",
+        AsyncMock(return_value={"busy": False}),
+    )
+    monkeypatch.setattr(lightrag_server, "get_default_workspace", lambda: "default")
+    monkeypatch.setattr(
+        lightrag_server,
+        "cleanup_keyed_lock",
+        lambda: {"cleanup_performed": {}, "current_status": {}},
+    )
+
+    app = lightrag_server.create_app(_make_args(tmp_path))
+    _FakeLightRAG.last_instance.role_config_snapshot = {
+        "query": {
+            "binding": "runtime-binding",
+            "model": "runtime-model",
+            "host": "https://runtime.example/v1",
+            "max_async": 9,
+            "metadata": {"binding": "runtime-binding"},
+        }
+    }
+    _FakeLightRAG.last_instance.queue_status_snapshot = {
+        "query": {"available": True, "rejected_total": 2}
+    }
+
+    response = TestClient(app).get("/health")
+
+    assert response.status_code == 200
+    body = response.json()
+    role_cfg = body["configuration"]["role_llm_config"]["query"]
+    assert role_cfg["binding"] == "runtime-binding"
+    assert role_cfg["model"] == "runtime-model"
+    assert role_cfg["host"] == "https://runtime.example/v1"
+    assert role_cfg["max_async"] == 9
+    assert role_cfg["model"] != "us.amazon.nova-lite-v1:0"
+    assert body["llm_queue_status"]["query"]["rejected_total"] == 2

--- a/tests/test_entity_extraction_stability.py
+++ b/tests/test_entity_extraction_stability.py
@@ -35,8 +35,15 @@ def _make_global_config(
     prompt_profile: dict | None = None,
 ) -> dict:
     tokenizer = Tokenizer("dummy", DummyTokenizer())
+    extract_func = AsyncMock(return_value="")
     return {
-        "llm_model_func": AsyncMock(return_value=""),
+        "llm_model_func": extract_func,
+        "role_llm_funcs": {
+            "extract": extract_func,
+            "keyword": extract_func,
+            "query": extract_func,
+            "vlm": extract_func,
+        },
         "entity_extract_max_gleaning": max_gleaning,
         "entity_extract_max_records": 100,
         "entity_extract_max_entities": 40,

--- a/tests/test_extract_entities.py
+++ b/tests/test_extract_entities.py
@@ -23,8 +23,15 @@ def _make_global_config(
 ) -> dict:
     """Build a minimal global_config dict for extract_entities."""
     tokenizer = Tokenizer("dummy", DummyTokenizer())
+    extract_func = AsyncMock(return_value="")
     return {
-        "llm_model_func": AsyncMock(return_value=""),
+        "llm_model_func": extract_func,
+        "role_llm_funcs": {
+            "extract": extract_func,
+            "keyword": extract_func,
+            "query": extract_func,
+            "vlm": extract_func,
+        },
         "entity_extract_max_gleaning": entity_extract_max_gleaning,
         "entity_extract_max_records": 100,
         "entity_extract_max_entities": 40,

--- a/tests/test_llm_role_runtime.py
+++ b/tests/test_llm_role_runtime.py
@@ -287,6 +287,11 @@ async def test_role_llm_configs_accepts_dict_form(tmp_path):
     assert await rag.role_llm_funcs["query"]("ping") == "query-via-dict"
 
 
+def test_role_llm_configs_rejects_unknown_role_keys(tmp_path):
+    with pytest.raises(ValueError, match="qurey"):
+        _make_rag(tmp_path, role_llm_configs={"qurey": {}})
+
+
 @pytest.mark.asyncio
 async def test_role_specific_kwargs_and_fallback(tmp_path):
     extract_calls = []
@@ -564,6 +569,21 @@ def test_get_llm_role_config_strips_bedrock_and_password_fields(tmp_path):
         binding="bedrock",
         model="claude-3",
         password="proxy-password",
+        provider_options={
+            "temperature": 0.1,
+            "extra_body": {
+                "safe_option": True,
+                "api_key": "nested-api-key",
+                "headers": {
+                    "Authorization": "Bearer nested-token",
+                    "X-API-Key": "nested-api-key",
+                    "Accept": "application/json",
+                },
+                "tools": [
+                    {"name": "safe-tool", "token": "nested-token"},
+                ],
+            },
+        },
         bedrock_aws_options={
             "region_name": "us-east-1",
             "aws_access_key_id": "AKIA-secret",
@@ -574,6 +594,13 @@ def test_get_llm_role_config_strips_bedrock_and_password_fields(tmp_path):
 
     snapshot = rag.get_llm_role_config("query")
     assert "password" not in snapshot["metadata"]
+    provider_options = snapshot["metadata"]["provider_options"]
+    assert provider_options["temperature"] == 0.1
+    extra_body = provider_options["extra_body"]
+    assert extra_body["safe_option"] is True
+    assert "api_key" not in extra_body
+    assert extra_body["headers"] == {"Accept": "application/json"}
+    assert extra_body["tools"] == [{"name": "safe-tool"}]
     bedrock = snapshot["metadata"]["bedrock_aws_options"]
     # Non-secret fields stay; auth-bearing fields are removed entirely.
     assert bedrock["region_name"] == "us-east-1"

--- a/tests/test_llm_role_runtime.py
+++ b/tests/test_llm_role_runtime.py
@@ -7,7 +7,7 @@ from argparse import Namespace
 import numpy as np
 import pytest
 
-from lightrag import LightRAG
+from lightrag import LightRAG, ROLES, RoleLLMConfig
 from lightrag.llm.binding_options import OpenAILLMOptions
 from lightrag.utils import EmbeddingFunc, Tokenizer, priority_limit_async_func_call
 
@@ -37,7 +37,48 @@ async def _base_llm(*args, **kwargs) -> str:
     return "base"
 
 
+_ROLE_FIELD_SUFFIXES = (
+    ("_llm_model_func", "func"),
+    ("_llm_model_kwargs", "kwargs"),
+    ("_llm_model_max_async", "max_async"),
+    ("_llm_timeout", "timeout"),
+)
+
+
 def _make_rag(tmp_path, **kwargs) -> LightRAG:
+    """Create a LightRAG for role tests.
+
+    Accepts both the canonical ``role_llm_configs={...}`` style and shorthand
+    ``{role}_llm_model_func`` / ``{role}_llm_model_kwargs`` etc. keyword
+    arguments. Shorthand kwargs are folded into ``role_llm_configs`` so the
+    body of each test reads clearly.
+    """
+    role_configs: dict[str, RoleLLMConfig] = {}
+    explicit = kwargs.pop("role_llm_configs", None)
+    if explicit is not None:
+        for name, cfg in explicit.items():
+            role_configs[name] = (
+                cfg if isinstance(cfg, RoleLLMConfig) else RoleLLMConfig(**dict(cfg))
+            )
+
+    for spec in ROLES:
+        bucket = {}
+        for suffix, target in _ROLE_FIELD_SUFFIXES:
+            key = f"{spec.name}{suffix}"
+            if key in kwargs:
+                bucket[target] = kwargs.pop(key)
+        if bucket:
+            existing = role_configs.get(spec.name)
+            if existing is not None:
+                for target, value in bucket.items():
+                    if getattr(existing, target) is None:
+                        setattr(existing, target, value)
+            else:
+                role_configs[spec.name] = RoleLLMConfig(**bucket)
+
+    if role_configs:
+        kwargs["role_llm_configs"] = role_configs
+
     return LightRAG(
         working_dir=str(tmp_path / "role-runtime"),
         workspace="role-runtime",
@@ -108,9 +149,7 @@ async def test_priority_queue_graceful_shutdown_timeout_falls_back_to_force(
         await asyncio.sleep(60)
         return value
 
-    wrapped = priority_limit_async_func_call(1, queue_name="stuck LLM func")(
-        stuck_func
-    )
+    wrapped = priority_limit_async_func_call(1, queue_name="stuck LLM func")(stuck_func)
 
     in_flight = asyncio.create_task(wrapped("hold"))
     await started.wait()
@@ -119,8 +158,7 @@ async def test_priority_queue_graceful_shutdown_timeout_falls_back_to_force(
         await wrapped.shutdown(graceful=True, timeout=0.1)
 
     assert any(
-        "Graceful drain timed out" in record.getMessage()
-        for record in caplog.records
+        "Graceful drain timed out" in record.getMessage() for record in caplog.records
     )
 
     with pytest.raises(asyncio.CancelledError):
@@ -135,9 +173,7 @@ async def test_priority_queue_rejects_submissions_after_shutdown():
     async def fast_func(value: str, **_kwargs):
         return value
 
-    wrapped = priority_limit_async_func_call(1, queue_name="reject LLM func")(
-        fast_func
-    )
+    wrapped = priority_limit_async_func_call(1, queue_name="reject LLM func")(fast_func)
 
     assert await wrapped("warmup") == "warmup"
     await wrapped.shutdown()
@@ -155,10 +191,10 @@ def test_role_max_async_defaults_inherit_base(tmp_path, monkeypatch):
 
     rag = _make_rag(tmp_path, llm_model_max_async=10)
 
-    assert rag.extract_llm_model_max_async is None
-    assert rag.keyword_llm_model_max_async is None
-    assert rag.query_llm_model_max_async is None
-    assert rag.vlm_llm_model_max_async is None
+    assert rag._role_llm_states["extract"].max_async is None
+    assert rag._role_llm_states["keyword"].max_async is None
+    assert rag._role_llm_states["query"].max_async is None
+    assert rag._role_llm_states["vlm"].max_async is None
     assert rag._get_effective_role_llm_max_async("extract") == 10
     assert rag._get_effective_role_llm_max_async("keyword") == 10
     assert rag._get_effective_role_llm_max_async("query") == 10
@@ -172,10 +208,10 @@ def test_role_max_async_env_override_keeps_other_roles_inherited(tmp_path, monke
 
     rag = _make_rag(tmp_path, llm_model_max_async=10)
 
-    assert rag.extract_llm_model_max_async == 7
-    assert rag.keyword_llm_model_max_async is None
-    assert rag.query_llm_model_max_async is None
-    assert rag.vlm_llm_model_max_async is None
+    assert rag._role_llm_states["extract"].max_async == 7
+    assert rag._role_llm_states["keyword"].max_async is None
+    assert rag._role_llm_states["query"].max_async is None
+    assert rag._role_llm_states["vlm"].max_async is None
     assert rag._get_effective_role_llm_max_async("extract") == 7
     assert rag._get_effective_role_llm_max_async("keyword") == 10
     assert rag._get_effective_role_llm_max_async("query") == 10
@@ -188,13 +224,67 @@ async def test_role_functions_are_isolated_and_vlm_present(tmp_path):
 
     funcs = [
         rag.llm_model_func,
-        rag.extract_llm_model_func,
-        rag.keyword_llm_model_func,
-        rag.query_llm_model_func,
-        rag.vlm_llm_model_func,
+        rag.role_llm_funcs["extract"],
+        rag.role_llm_funcs["keyword"],
+        rag.role_llm_funcs["query"],
+        rag.role_llm_funcs["vlm"],
     ]
     assert all(callable(func) for func in funcs)
     assert len({id(func) for func in funcs}) == len(funcs)
+
+
+@pytest.mark.asyncio
+async def test_no_role_configs_keeps_base_raw_and_wraps_each_role(tmp_path):
+    """Regression: base llm_model_func must stay raw; each role still gets
+    its own queue wrapper around the base func when no override is given."""
+    rag = _make_rag(tmp_path)
+
+    # Base is the user-provided callable, untouched by any wrapper.
+    assert rag.llm_model_func is _base_llm
+
+    # Every role has a wrapped (queue-managed) func that's distinct from base.
+    for spec in ROLES:
+        wrapped = rag.role_llm_funcs[spec.name]
+        assert callable(wrapped)
+        assert wrapped is not _base_llm
+
+    # All four role wrappers are independent (separate queues).
+    wrappers = [rag.role_llm_funcs[spec.name] for spec in ROLES]
+    assert len({id(w) for w in wrappers}) == len(wrappers)
+
+    # Calling any role wrapper hits the base function.
+    assert await rag.role_llm_funcs["extract"]("p") == "base"
+    assert await rag.role_llm_funcs["vlm"]("p") == "base"
+
+    # get_llm_queue_status no longer reports a 'base' entry.
+    status = await rag.get_llm_queue_status()
+    assert "base" not in status
+    assert set(status) == {spec.name for spec in ROLES}
+
+
+@pytest.mark.asyncio
+async def test_role_llm_configs_accepts_dict_form(tmp_path):
+    """Init accepts plain dicts in role_llm_configs (auto-normalized to RoleLLMConfig)."""
+
+    async def query_fn(*args, **kwargs):
+        return "query-via-dict"
+
+    rag = LightRAG(
+        working_dir=str(tmp_path / "dict-form"),
+        workspace="dict-form",
+        llm_model_func=_base_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=16, max_token_size=4096, func=_mock_embedding
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        role_llm_configs={"query": {"func": query_fn, "max_async": 5}},
+    )
+
+    assert rag._role_llm_states["query"].raw_func is query_fn
+    assert rag._role_llm_states["query"].max_async == 5
+    # Roles not present in the dict still wrap the base function.
+    assert rag._role_llm_states["extract"].raw_func is _base_llm
+    assert await rag.role_llm_funcs["query"]("ping") == "query-via-dict"
 
 
 @pytest.mark.asyncio
@@ -219,9 +309,9 @@ async def test_role_specific_kwargs_and_fallback(tmp_path):
         vlm_llm_model_kwargs={"shared": "vlm", "tag": "vlm"},
     )
 
-    await rag.extract_llm_model_func("extract prompt")
-    await rag.keyword_llm_model_func("keyword prompt")
-    await rag.vlm_llm_model_func("vlm prompt")
+    await rag.role_llm_funcs["extract"]("extract prompt")
+    await rag.role_llm_funcs["keyword"]("keyword prompt")
+    await rag.role_llm_funcs["vlm"]("vlm prompt")
 
     assert extract_calls[-1]["tag"] == "extract"
     assert extract_calls[-1]["shared"] == "extract"
@@ -250,20 +340,20 @@ async def test_update_llm_role_config_rewraps_without_double_call(tmp_path):
         query_llm_model_kwargs={"tag": "v1"},
     )
 
-    await rag.query_llm_model_func("first")
+    await rag.role_llm_funcs["query"]("first")
     assert call_count == 1
     assert seen_tags[-1] == "v1"
 
     for value in (3, 5, 7):
         rag.update_llm_role_config("query", max_async=value)
-        await rag.query_llm_model_func("next")
+        await rag.role_llm_funcs["query"]("next")
 
     rag.update_llm_role_config("query", model_kwargs={"tag": "v2"})
-    await rag.query_llm_model_func("final")
+    await rag.role_llm_funcs["query"]("final")
 
     assert call_count == 5
     assert seen_tags[-1] == "v2"
-    assert rag.query_llm_model_max_async == 7
+    assert rag._role_llm_states["query"].max_async == 7
     await rag.wait_for_retired_llm_queues()
 
 
@@ -282,7 +372,7 @@ async def test_aupdate_llm_role_config_drains_old_queue(tmp_path):
 
     rag = _make_rag(tmp_path, query_llm_model_func=old_query_func)
 
-    old_call = asyncio.create_task(rag.query_llm_model_func("old"))
+    old_call = asyncio.create_task(rag.role_llm_funcs["query"]("old"))
     await started.wait()
 
     update_call = asyncio.create_task(
@@ -290,7 +380,7 @@ async def test_aupdate_llm_role_config_drains_old_queue(tmp_path):
     )
     await asyncio.sleep(0.05)
     assert not update_call.done()
-    assert await rag.query_llm_model_func("new") == "new"
+    assert await rag.role_llm_funcs["query"]("new") == "new"
 
     release.set()
     assert await old_call == "old"
@@ -307,9 +397,9 @@ async def test_sync_update_tracks_retired_queue_cleanup(tmp_path):
 
     rag = _make_rag(tmp_path, query_llm_model_func=query_func)
 
-    assert await rag.query_llm_model_func("before") == "old"
+    assert await rag.role_llm_funcs["query"]("before") == "old"
     rag.update_llm_role_config("query", model_func=new_query_func)
-    assert await rag.query_llm_model_func("after") == "new"
+    assert await rag.role_llm_funcs["query"]("after") == "new"
 
     await rag.wait_for_retired_llm_queues()
     assert not rag._retired_llm_queue_cleanup_tasks
@@ -331,12 +421,11 @@ def test_sync_update_without_event_loop_skips_cleanup(
 
     assert not rag._retired_llm_queue_cleanup_tasks
     assert any(
-        "no event loop is running" in record.getMessage()
-        for record in caplog.records
+        "no event loop is running" in record.getMessage() for record in caplog.records
     )
 
     async def call_new() -> str:
-        return await rag.query_llm_model_func("after")
+        return await rag.role_llm_funcs["query"]("after")
 
     assert asyncio.run(call_new()) == "new"
 
@@ -350,11 +439,13 @@ async def test_aupdate_llm_role_config_with_builder_drains_old_queue(tmp_path):
         model_name = meta["model"]
 
         if model_name == "old-model":
+
             async def built_func(*args, **kwargs):
                 started.set()
                 await release.wait()
                 return model_name
         else:
+
             async def built_func(*args, **kwargs):
                 return model_name
 
@@ -373,7 +464,7 @@ async def test_aupdate_llm_role_config_with_builder_drains_old_queue(tmp_path):
     rag.update_llm_role_config("query", binding="openai", model="old-model")
     await rag.wait_for_retired_llm_queues()
 
-    in_flight = asyncio.create_task(rag.query_llm_model_func("hold"))
+    in_flight = asyncio.create_task(rag.role_llm_funcs["query"]("hold"))
     await started.wait()
 
     update_call = asyncio.create_task(
@@ -381,7 +472,7 @@ async def test_aupdate_llm_role_config_with_builder_drains_old_queue(tmp_path):
     )
     await asyncio.sleep(0.05)
     assert not update_call.done()
-    assert await rag.query_llm_model_func("hello") == "new-model"
+    assert await rag.role_llm_funcs["query"]("hello") == "new-model"
 
     release.set()
     assert await in_flight == "old-model"
@@ -425,7 +516,7 @@ async def test_update_llm_role_config_with_builder_metadata(tmp_path):
         provider_options={"temperature": 0.3, "top_k": 8},
     )
 
-    result = await rag.query_llm_model_func("hello")
+    result = await rag.role_llm_funcs["query"]("hello")
     assert result == "gemini-2.0-flash"
     assert built_calls[-1]["role"] == "query"
     assert built_calls[-1]["meta"]["binding"] == "gemini"
@@ -450,19 +541,23 @@ async def test_llm_role_config_and_queue_status_are_observable(tmp_path):
     assert set(all_configs) == {"extract", "keyword", "query", "vlm"}
     assert all_configs["query"]["binding"] == "openai"
     assert all_configs["query"]["model"] == "gpt-test"
-    assert all_configs["query"]["metadata"]["api_key"] == "***"
+    # Auth-bearing fields are dropped from the observability snapshot,
+    # not masked — there is no "***" placeholder to confuse consumers.
+    assert "api_key" not in all_configs["query"]["metadata"]
     assert all_configs["query"]["has_model_kwargs"] is True
 
-    query_config = rag.get_llm_role_config("query", include_secrets=True)
-    assert query_config["metadata"]["api_key"] == "secret-key"
+    # Raw secrets remain accessible to in-process components that legitimately
+    # need them (role builder, provider clients), but are not exposed via the
+    # public observability method.
+    assert rag._role_llm_states["query"].metadata["api_key"] == "secret-key"
 
     queue_status = await rag.get_llm_queue_status()
-    assert set(queue_status) == {"base", "extract", "keyword", "query", "vlm"}
+    assert set(queue_status) == {"extract", "keyword", "query", "vlm"}
     assert queue_status["query"]["available"] is True
     assert queue_status["query"]["queue_name"] == "query LLM func"
 
 
-def test_get_llm_role_config_masks_bedrock_and_password_fields(tmp_path):
+def test_get_llm_role_config_strips_bedrock_and_password_fields(tmp_path):
     rag = _make_rag(tmp_path)
     rag.set_role_llm_metadata(
         "query",
@@ -473,21 +568,38 @@ def test_get_llm_role_config_masks_bedrock_and_password_fields(tmp_path):
             "region_name": "us-east-1",
             "aws_access_key_id": "AKIA-secret",
             "aws_secret_access_key": "TOPSECRET",
+            "aws_session_token": "SESSION",
         },
     )
 
-    masked = rag.get_llm_role_config("query")
-    assert masked["metadata"]["password"] == "***"
-    masked_bedrock = masked["metadata"]["bedrock_aws_options"]
-    assert masked_bedrock["region_name"] == "us-east-1"
-    assert masked_bedrock["aws_access_key_id"] == "***"
-    assert masked_bedrock["aws_secret_access_key"] == "***"
+    snapshot = rag.get_llm_role_config("query")
+    assert "password" not in snapshot["metadata"]
+    bedrock = snapshot["metadata"]["bedrock_aws_options"]
+    # Non-secret fields stay; auth-bearing fields are removed entirely.
+    assert bedrock["region_name"] == "us-east-1"
+    assert "aws_access_key_id" not in bedrock
+    assert "aws_secret_access_key" not in bedrock
+    assert "aws_session_token" not in bedrock
 
-    revealed = rag.get_llm_role_config("query", include_secrets=True)
-    assert revealed["metadata"]["password"] == "proxy-password"
-    revealed_bedrock = revealed["metadata"]["bedrock_aws_options"]
-    assert revealed_bedrock["aws_access_key_id"] == "AKIA-secret"
-    assert revealed_bedrock["aws_secret_access_key"] == "TOPSECRET"
+    # Mutating the returned snapshot must not affect the live state.
+    snapshot["metadata"]["bedrock_aws_options"]["region_name"] = "tampered"
+    assert (
+        rag._role_llm_states["query"].metadata["bedrock_aws_options"]["region_name"]
+        == "us-east-1"
+    )
+
+
+def test_get_llm_role_config_has_no_secret_escape_hatch(tmp_path):
+    """Security guarantee: no parameter on get_llm_role_config can flip
+    secret stripping off. This pins down the public-API contract so a future
+    change can't accidentally re-introduce an ``include_secrets`` knob."""
+    rag = _make_rag(tmp_path)
+    rag.set_role_llm_metadata("query", api_key="super-secret")
+
+    with pytest.raises(TypeError):
+        rag.get_llm_role_config("query", include_secrets=True)  # type: ignore[call-arg]
+
+    assert "api_key" not in rag.get_llm_role_config("query")["metadata"]
 
 
 @pytest.mark.asyncio
@@ -532,7 +644,7 @@ async def test_cross_provider_update_does_not_inherit_base_kwargs(tmp_path):
         provider_options={"temperature": 0.4},
     )
 
-    await rag.query_llm_model_func("hello")
+    await rag.role_llm_funcs["query"]("hello")
     call_kwargs = built_calls[-1]["kwargs"]
     assert call_kwargs["hashing_kv"] is not None
     assert "host" not in call_kwargs
@@ -543,9 +655,9 @@ async def test_cross_provider_update_does_not_inherit_base_kwargs(tmp_path):
 @pytest.mark.asyncio
 async def test_update_llm_role_config_rolls_back_on_failure(tmp_path):
     rag = _make_rag(tmp_path, extract_llm_model_kwargs={"tag": "before"})
-    original_raw = rag._raw_role_llm_funcs["extract"]
-    original_wrapped = rag.extract_llm_model_func
-    original_kwargs = dict(rag.extract_llm_model_kwargs)
+    original_raw = rag._role_llm_states["extract"].raw_func
+    original_wrapped = rag.role_llm_funcs["extract"]
+    original_kwargs = dict(rag.role_llm_kwargs["extract"])
 
     def failing_builder(role: str, meta: dict):
         raise RuntimeError("boom")
@@ -567,9 +679,9 @@ async def test_update_llm_role_config_rolls_back_on_failure(tmp_path):
             provider_options={"temperature": 0.9},
         )
 
-    assert rag._raw_role_llm_funcs["extract"] is original_raw
-    assert rag.extract_llm_model_func is original_wrapped
-    assert rag.extract_llm_model_kwargs == original_kwargs
+    assert rag._role_llm_states["extract"].raw_func is original_raw
+    assert rag.role_llm_funcs["extract"] is original_wrapped
+    assert rag.role_llm_kwargs["extract"] == original_kwargs
 
 
 def test_options_dict_for_role_inherits_same_provider(monkeypatch):
@@ -619,16 +731,16 @@ async def test_vlm_role_supports_runtime_update(tmp_path):
         vlm_llm_model_kwargs={"tag": "initial"},
     )
 
-    await rag.vlm_llm_model_func("before")
+    await rag.role_llm_funcs["vlm"]("before")
     rag.update_llm_role_config(
         "vlm",
         model_kwargs={"tag": "updated"},
         max_async=2,
         timeout=240,
     )
-    await rag.vlm_llm_model_func("after")
+    await rag.role_llm_funcs["vlm"]("after")
 
     assert vlm_calls[0]["tag"] == "initial"
     assert vlm_calls[1]["tag"] == "updated"
-    assert rag.vlm_llm_model_max_async == 2
-    assert rag.vlm_llm_timeout == 240
+    assert rag._role_llm_states["vlm"].max_async == 2
+    assert rag._role_llm_states["vlm"].timeout == 240

--- a/tests/test_llm_role_runtime.py
+++ b/tests/test_llm_role_runtime.py
@@ -1,6 +1,7 @@
 """Offline tests for role-specific LLM runtime configuration."""
 
 import asyncio
+import logging
 from argparse import Namespace
 
 import numpy as np
@@ -12,6 +13,12 @@ from lightrag.utils import EmbeddingFunc, Tokenizer, priority_limit_async_func_c
 
 
 pytestmark = pytest.mark.offline
+
+
+@pytest.fixture
+def lightrag_logger_propagating(monkeypatch):
+    """Force the lightrag logger to propagate so caplog can capture records."""
+    monkeypatch.setattr(logging.getLogger("lightrag"), "propagate", True)
 
 
 class _SimpleTokenizerImpl:
@@ -85,8 +92,61 @@ async def test_priority_queue_stats_track_running_and_queued():
     assert stats["running"] == 0
     assert stats["queued"] == 0
     assert stats["completed_total"] == 2
+    assert stats["rejected_total"] == 0
 
     await wrapped.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_priority_queue_graceful_shutdown_timeout_falls_back_to_force(
+    caplog, lightrag_logger_propagating
+):
+    started = asyncio.Event()
+
+    async def stuck_func(value: str, **_kwargs):
+        started.set()
+        await asyncio.sleep(60)
+        return value
+
+    wrapped = priority_limit_async_func_call(1, queue_name="stuck LLM func")(
+        stuck_func
+    )
+
+    in_flight = asyncio.create_task(wrapped("hold"))
+    await started.wait()
+
+    with caplog.at_level("WARNING", logger="lightrag"):
+        await wrapped.shutdown(graceful=True, timeout=0.1)
+
+    assert any(
+        "Graceful drain timed out" in record.getMessage()
+        for record in caplog.records
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await in_flight
+
+    stats = await wrapped.get_queue_stats()
+    assert stats["cancelled_total"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_priority_queue_rejects_submissions_after_shutdown():
+    async def fast_func(value: str, **_kwargs):
+        return value
+
+    wrapped = priority_limit_async_func_call(1, queue_name="reject LLM func")(
+        fast_func
+    )
+
+    assert await wrapped("warmup") == "warmup"
+    await wrapped.shutdown()
+
+    with pytest.raises(RuntimeError, match="Queue is shutting down"):
+        await wrapped("rejected")
+
+    stats = await wrapped.get_queue_stats()
+    assert stats["rejected_total"] == 1
 
 
 def test_role_max_async_defaults_inherit_base(tmp_path, monkeypatch):
@@ -255,6 +315,80 @@ async def test_sync_update_tracks_retired_queue_cleanup(tmp_path):
     assert not rag._retired_llm_queue_cleanup_tasks
 
 
+def test_sync_update_without_event_loop_skips_cleanup(
+    tmp_path, caplog, lightrag_logger_propagating
+):
+    async def query_func(*args, **kwargs):
+        return "old"
+
+    async def new_query_func(*args, **kwargs):
+        return "new"
+
+    rag = _make_rag(tmp_path, query_llm_model_func=query_func)
+
+    with caplog.at_level("WARNING", logger="lightrag"):
+        rag.update_llm_role_config("query", model_func=new_query_func)
+
+    assert not rag._retired_llm_queue_cleanup_tasks
+    assert any(
+        "no event loop is running" in record.getMessage()
+        for record in caplog.records
+    )
+
+    async def call_new() -> str:
+        return await rag.query_llm_model_func("after")
+
+    assert asyncio.run(call_new()) == "new"
+
+
+@pytest.mark.asyncio
+async def test_aupdate_llm_role_config_with_builder_drains_old_queue(tmp_path):
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    def builder(role, meta):
+        model_name = meta["model"]
+
+        if model_name == "old-model":
+            async def built_func(*args, **kwargs):
+                started.set()
+                await release.wait()
+                return model_name
+        else:
+            async def built_func(*args, **kwargs):
+                return model_name
+
+        return built_func, None
+
+    rag = _make_rag(tmp_path)
+    rag.register_role_llm_builder(builder)
+    rag.set_role_llm_metadata(
+        "query",
+        binding="openai",
+        model="seed",
+        host="https://seed",
+        api_key="seed-key",
+    )
+
+    rag.update_llm_role_config("query", binding="openai", model="old-model")
+    await rag.wait_for_retired_llm_queues()
+
+    in_flight = asyncio.create_task(rag.query_llm_model_func("hold"))
+    await started.wait()
+
+    update_call = asyncio.create_task(
+        rag.aupdate_llm_role_config("query", binding="openai", model="new-model")
+    )
+    await asyncio.sleep(0.05)
+    assert not update_call.done()
+    assert await rag.query_llm_model_func("hello") == "new-model"
+
+    release.set()
+    assert await in_flight == "old-model"
+    await update_call
+    assert not rag._retired_llm_queue_cleanup_tasks
+
+
 @pytest.mark.asyncio
 async def test_update_llm_role_config_with_builder_metadata(tmp_path):
     built_calls = []
@@ -326,6 +460,34 @@ async def test_llm_role_config_and_queue_status_are_observable(tmp_path):
     assert set(queue_status) == {"base", "extract", "keyword", "query", "vlm"}
     assert queue_status["query"]["available"] is True
     assert queue_status["query"]["queue_name"] == "query LLM func"
+
+
+def test_get_llm_role_config_masks_bedrock_and_password_fields(tmp_path):
+    rag = _make_rag(tmp_path)
+    rag.set_role_llm_metadata(
+        "query",
+        binding="bedrock",
+        model="claude-3",
+        password="proxy-password",
+        bedrock_aws_options={
+            "region_name": "us-east-1",
+            "aws_access_key_id": "AKIA-secret",
+            "aws_secret_access_key": "TOPSECRET",
+        },
+    )
+
+    masked = rag.get_llm_role_config("query")
+    assert masked["metadata"]["password"] == "***"
+    masked_bedrock = masked["metadata"]["bedrock_aws_options"]
+    assert masked_bedrock["region_name"] == "us-east-1"
+    assert masked_bedrock["aws_access_key_id"] == "***"
+    assert masked_bedrock["aws_secret_access_key"] == "***"
+
+    revealed = rag.get_llm_role_config("query", include_secrets=True)
+    assert revealed["metadata"]["password"] == "proxy-password"
+    revealed_bedrock = revealed["metadata"]["bedrock_aws_options"]
+    assert revealed_bedrock["aws_access_key_id"] == "AKIA-secret"
+    assert revealed_bedrock["aws_secret_access_key"] == "TOPSECRET"
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm_role_runtime.py
+++ b/tests/test_llm_role_runtime.py
@@ -1,5 +1,6 @@
 """Offline tests for role-specific LLM runtime configuration."""
 
+import asyncio
 from argparse import Namespace
 
 import numpy as np
@@ -7,7 +8,7 @@ import pytest
 
 from lightrag import LightRAG
 from lightrag.llm.binding_options import OpenAILLMOptions
-from lightrag.utils import EmbeddingFunc, Tokenizer
+from lightrag.utils import EmbeddingFunc, Tokenizer, priority_limit_async_func_call
 
 
 pytestmark = pytest.mark.offline
@@ -50,6 +51,42 @@ ROLE_MAX_ASYNC_ENV_KEYS = (
     "MAX_ASYNC_QUERY_LLM",
     "MAX_ASYNC_VLM_LLM",
 )
+
+
+@pytest.mark.asyncio
+async def test_priority_queue_stats_track_running_and_queued():
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_func(value: str, **_kwargs):
+        started.set()
+        await release.wait()
+        return value
+
+    wrapped = priority_limit_async_func_call(1, queue_name="test LLM func")(slow_func)
+
+    first = asyncio.create_task(wrapped("first"))
+    await started.wait()
+    second = asyncio.create_task(wrapped("second"))
+    await asyncio.sleep(0.05)
+
+    stats = await wrapped.get_queue_stats()
+    assert stats["max_async"] == 1
+    assert stats["running"] == 1
+    assert stats["queued"] == 1
+    assert stats["in_flight"] == 2
+    assert stats["submitted_total"] == 2
+
+    release.set()
+    assert await asyncio.gather(first, second) == ["first", "second"]
+    await asyncio.sleep(0)
+
+    stats = await wrapped.get_queue_stats()
+    assert stats["running"] == 0
+    assert stats["queued"] == 0
+    assert stats["completed_total"] == 2
+
+    await wrapped.shutdown()
 
 
 def test_role_max_async_defaults_inherit_base(tmp_path, monkeypatch):
@@ -167,6 +204,55 @@ async def test_update_llm_role_config_rewraps_without_double_call(tmp_path):
     assert call_count == 5
     assert seen_tags[-1] == "v2"
     assert rag.query_llm_model_max_async == 7
+    await rag.wait_for_retired_llm_queues()
+
+
+@pytest.mark.asyncio
+async def test_aupdate_llm_role_config_drains_old_queue(tmp_path):
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def old_query_func(*args, **kwargs):
+        started.set()
+        await release.wait()
+        return "old"
+
+    async def new_query_func(*args, **kwargs):
+        return "new"
+
+    rag = _make_rag(tmp_path, query_llm_model_func=old_query_func)
+
+    old_call = asyncio.create_task(rag.query_llm_model_func("old"))
+    await started.wait()
+
+    update_call = asyncio.create_task(
+        rag.aupdate_llm_role_config("query", model_func=new_query_func)
+    )
+    await asyncio.sleep(0.05)
+    assert not update_call.done()
+    assert await rag.query_llm_model_func("new") == "new"
+
+    release.set()
+    assert await old_call == "old"
+    await update_call
+
+
+@pytest.mark.asyncio
+async def test_sync_update_tracks_retired_queue_cleanup(tmp_path):
+    async def query_func(*args, **kwargs):
+        return "old"
+
+    async def new_query_func(*args, **kwargs):
+        return "new"
+
+    rag = _make_rag(tmp_path, query_llm_model_func=query_func)
+
+    assert await rag.query_llm_model_func("before") == "old"
+    rag.update_llm_role_config("query", model_func=new_query_func)
+    assert await rag.query_llm_model_func("after") == "new"
+
+    await rag.wait_for_retired_llm_queues()
+    assert not rag._retired_llm_queue_cleanup_tasks
 
 
 @pytest.mark.asyncio
@@ -212,6 +298,34 @@ async def test_update_llm_role_config_with_builder_metadata(tmp_path):
     assert built_calls[-1]["meta"]["model"] == "gemini-2.0-flash"
     assert built_calls[-1]["kwargs"]["runtime_host"] == "https://new-host"
     assert built_calls[-1]["kwargs"]["provider_options"]["top_k"] == 8
+
+
+@pytest.mark.asyncio
+async def test_llm_role_config_and_queue_status_are_observable(tmp_path):
+    rag = _make_rag(tmp_path, query_llm_model_kwargs={"tag": "query"})
+    rag.set_role_llm_metadata(
+        "query",
+        binding="openai",
+        model="gpt-test",
+        host="https://api.example.com/v1",
+        api_key="secret-key",
+        provider_options={"temperature": 0.1},
+    )
+
+    all_configs = rag.get_llm_role_config()
+    assert set(all_configs) == {"extract", "keyword", "query", "vlm"}
+    assert all_configs["query"]["binding"] == "openai"
+    assert all_configs["query"]["model"] == "gpt-test"
+    assert all_configs["query"]["metadata"]["api_key"] == "***"
+    assert all_configs["query"]["has_model_kwargs"] is True
+
+    query_config = rag.get_llm_role_config("query", include_secrets=True)
+    assert query_config["metadata"]["api_key"] == "secret-key"
+
+    queue_status = await rag.get_llm_queue_status()
+    assert set(queue_status) == {"base", "extract", "keyword", "query", "vlm"}
+    assert queue_status["query"]["available"] is True
+    assert queue_status["query"]["queue_name"] == "query LLM func"
 
 
 @pytest.mark.asyncio

--- a/tests/test_ollama_role_kwargs.py
+++ b/tests/test_ollama_role_kwargs.py
@@ -17,7 +17,7 @@ class _FakeRag:
         self.base_calls = []
         self.query_calls = []
         self.llm_model_kwargs = {"route": "base"}
-        self.query_llm_model_kwargs = {"route": "query"}
+        self._query_kwargs = {"route": "query"}
         self.ollama_server_infos = SimpleNamespace(
             LIGHTRAG_MODEL="lightrag:latest",
             LIGHTRAG_CREATED_AT="2026-03-14T00:00:00Z",
@@ -33,7 +33,10 @@ class _FakeRag:
             return "query"
 
         self.llm_model_func = base_func
-        self.query_llm_model_func = query_func
+        # ollama_api.py reads `rag.role_llm_funcs[role]` and
+        # `rag.role_llm_kwargs[role]`; expose them as plain dict mappings here.
+        self.role_llm_funcs = {"query": query_func}
+        self.role_llm_kwargs = {"query": self._query_kwargs}
 
     async def aquery(self, *args, **kwargs):
         return "aquery"
@@ -76,7 +79,7 @@ def test_generate_non_stream_uses_query_role_kwargs_without_mutating_base(monkey
     assert rag.query_calls[-1]["route"] == "query"
     assert rag.query_calls[-1]["system_prompt"] == "custom system"
     assert "system_prompt" not in rag.llm_model_kwargs
-    assert "system_prompt" not in rag.query_llm_model_kwargs
+    assert "system_prompt" not in rag.role_llm_kwargs["query"]
 
 
 def test_chat_bypass_stream_uses_query_role_kwargs_without_mutating_base(monkeypatch):
@@ -106,4 +109,4 @@ def test_chat_bypass_stream_uses_query_role_kwargs_without_mutating_base(monkeyp
         {"role": "assistant", "content": "history"}
     ]
     assert "system_prompt" not in rag.llm_model_kwargs
-    assert "system_prompt" not in rag.query_llm_model_kwargs
+    assert "system_prompt" not in rag.role_llm_kwargs["query"]

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from lightrag import LightRAG
+from lightrag import LightRAG, ROLES, RoleLLMConfig
 from lightrag.operate import _get_relationship_vdb_timeout_seconds
 from lightrag.utils import EmbeddingFunc, Tokenizer, safe_vdb_operation_with_exception
 
@@ -26,7 +26,27 @@ async def _mock_llm(prompt, **kwargs):
     return '{"name":"x","summary":"s","detail_description":"d"}'
 
 
+_ROLE_FIELD_SUFFIXES = (
+    ("_llm_model_func", "func"),
+    ("_llm_model_kwargs", "kwargs"),
+    ("_llm_model_max_async", "max_async"),
+    ("_llm_timeout", "timeout"),
+)
+
+
 def _new_rag(tmp_path: Path, **kwargs) -> LightRAG:
+    role_configs: dict[str, RoleLLMConfig] = {}
+    for spec in ROLES:
+        bucket = {}
+        for suffix, target in _ROLE_FIELD_SUFFIXES:
+            key = f"{spec.name}{suffix}"
+            if key in kwargs:
+                bucket[target] = kwargs.pop(key)
+        if bucket:
+            role_configs[spec.name] = RoleLLMConfig(**bucket)
+    if role_configs:
+        kwargs["role_llm_configs"] = role_configs
+
     return LightRAG(
         working_dir=str(tmp_path),
         workspace="test-release-closure",


### PR DESCRIPTION
## Description

This PR consolidates per-role LLM configuration behind a single `ROLES` registry and a dict-based `role_llm_configs` argument on `LightRAG`, adds runtime queue observability for each role, and locks down credential exposure on the public observability method. **Adding a new role is now a one-line edit** to the `ROLES` tuple — the env-var loop in `api/config.py`, queue observability, role builder, `operate.py` / `ollama_api.py` consumers, and `/health` output all iterate this single source of truth.

## Related Issues

n/a

## Public API

### Role configuration

```python
from lightrag import LightRAG, RoleLLMConfig

rag = LightRAG(
    llm_model_func=base_llm,
    role_llm_configs={
        "extract": RoleLLMConfig(func=extract_llm, max_async=4),
        "query":   RoleLLMConfig(kwargs={"temperature": 0.2}),
        # roles not present inherit base llm_model_func with their own queue
    },
)
```

- `role_llm_configs` is the only init kwarg for per-role overrides. Each entry is a `RoleLLMConfig(func, kwargs, max_async, timeout)`; plain dicts are also accepted and auto-normalized.
- The base `LightRAG(llm_model_func=..., llm_model_kwargs=..., llm_model_max_async=..., default_llm_timeout=...)` interface is unchanged. Code that does not configure per-role overrides is untouched.
- `.env` variable names (`EXTRACT_LLM_BINDING`, `MAX_ASYNC_QUERY_LLM`, `LLM_TIMEOUT_VLM_LLM`, …) are unchanged.

### Read-only accessors

- `rag.role_llm_funcs[role]` — wrapped, queue-managed callable for the role (used by `operate.py`, `ollama_api.py`, etc.).
- `rag.role_llm_kwargs[role]` — effective kwargs dict for the role, or `None` to inherit base.
- `global_config["role_llm_funcs"]` — same mapping injected into `_build_global_config()` for `operate.py` consumers.

### Runtime updates and observability

- `rag.update_llm_role_config(role, ...)` (sync) and `rag.aupdate_llm_role_config(role, ...)` (async) hot-swap a role's wrapper. The retired wrapper drains gracefully via `priority_limit_async_func_call.shutdown(graceful=True, timeout=...)`, falling through to forced cancellation if the drain exceeds `max_task_duration` (or 30 s by default) so retirement never blocks indefinitely.
- The sync variant schedules cleanup on the running event loop; called without a running loop it logs a warning and skips cleanup. Use `aupdate_llm_role_config` from an async context for deterministic shutdown.
- `await rag.wait_for_retired_llm_queues()` joins all in-flight cleanup tasks; cleanup failures are absorbed (already logged) so the wait always returns.
- `rag.get_llm_queue_status()` returns per-role queue stats (`queued` / `running` / `in_flight` / `worker_count` / `submitted_total` / `completed_total` / `failed_total` / `cancelled_total` / `rejected_total`) for each role in `ROLES`.
- `/health` exposes `llm_queue_status` for the WebUI status panel; matching `LightragQueueStatus` typings added to `lightrag_webui/src/api/lightrag.ts`.

### `get_llm_role_config` — credential-safe by construction

`rag.get_llm_role_config(role=None)` returns an observability snapshot of role configuration. Auth-bearing fields (`api_key`, `aws_secret_access_key`, `aws_session_token`, `password`, `passphrase`, `token`, `credential`, `auth*`, `session*`, …) are **stripped entirely** from the returned `metadata` — not masked with `"***"`. The invariant is simple: anything that appears in the snapshot is safe to log, cache, or send over the wire. There is no parameter that can flip this off; in-process components that legitimately need a raw secret (the role builder, provider clients) read `_role_llm_states[role].metadata` directly.

## Behavioural notes

- The base `llm_model_func` is no longer queue-wrapped. Concurrency is enforced at the role layer: every code path that calls an LLM goes through one of the role wrappers, and each role still gets its own `priority_limit_async_func_call` wrapper — including the four built-in roles when no override is supplied.
- `get_llm_queue_status` therefore does not report a `base` entry; the `include_base` parameter is kept for signature stability but has no effect.

## Migration

Code that used the old per-role kwargs / instance attributes needs to update:

| Old | New |
|---|---|
| `LightRAG(extract_llm_model_func=fn, ...)` | `LightRAG(role_llm_configs={"extract": RoleLLMConfig(func=fn)})` |
| `LightRAG(query_llm_model_kwargs={...}, query_llm_timeout=120)` | `RoleLLMConfig(kwargs={...}, timeout=120)` in `role_llm_configs["query"]` |
| `rag.query_llm_model_func(...)` | `rag.role_llm_funcs["query"](...)` |
| `rag.query_llm_model_kwargs` | `rag.role_llm_kwargs["query"]` |
| `global_config["extract_llm_model_func"]` | `global_config["role_llm_funcs"]["extract"]` |
| `rag.get_llm_role_config(role, include_secrets=True)` | Use `_role_llm_states[role].metadata` (in-process only); the public method no longer exposes secrets |

`register_role_llm_builder` / `set_role_llm_metadata` / `update_llm_role_config` / `aupdate_llm_role_config` / `wait_for_retired_llm_queues` signatures are unchanged.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Validation

- `./scripts/test.sh tests` — 952 passed, 1 skipped, 31 deselected.
- `ruff check lightrag/`
- `bun run lint`
- `git diff --check`
