### PR TITLE
feat(rerank): add independent concurrency and timeout configuration

### DIFF
--- a/env.example
+++ b/env.example
@@ -130,8 +130,9 @@ RERANK_BINDING=null
 # RERANK_BY_DEFAULT=True
 
 ### Rerank concurrency and timeout (independent from base LLM settings)
-### When unset, MAX_ASYNC_RERANK_LLM falls back to MAX_ASYNC,
-### and RERANK_TIMEOUT falls back to LLM_TIMEOUT.
+### MAX_ASYNC_RERANK_LLM falls back to MAX_ASYNC when unset.
+### RERANK_TIMEOUT has its own default (30s) since reranker calls are
+### typically much shorter than full LLM generation.
 # MAX_ASYNC_RERANK_LLM=4
 # RERANK_TIMEOUT=30
 

--- a/env.example
+++ b/env.example
@@ -129,6 +129,12 @@ RERANK_BINDING=null
 ### Enable rerank by default in query params when RERANK_BINDING is not null
 # RERANK_BY_DEFAULT=True
 
+### Rerank concurrency and timeout (independent from base LLM settings)
+### When unset, MAX_ASYNC_RERANK_LLM falls back to MAX_ASYNC,
+### and RERANK_TIMEOUT falls back to LLM_TIMEOUT.
+# MAX_ASYNC_RERANK_LLM=4
+# RERANK_TIMEOUT=30
+
 ### Cohere AI
 # # RERANK_MODEL=rerank-v3.5
 # # RERANK_BINDING_HOST=https://api.cohere.com/v2/rerank

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -43,6 +43,7 @@ from lightrag.constants import (
     DEFAULT_OLLAMA_MODEL_NAME,
     DEFAULT_OLLAMA_MODEL_TAG,
     DEFAULT_RERANK_BINDING,
+    DEFAULT_LLM_TIMEOUT,
 )
 
 # use the .env that is inside the current folder
@@ -572,6 +573,17 @@ def parse_args() -> argparse.Namespace:
     # Min rerank score configuration
     args.min_rerank_score = get_env_value(
         "MIN_RERANK_SCORE", DEFAULT_MIN_RERANK_SCORE, float
+    )
+
+    # Rerank async/timeout configuration (independent from base LLM)
+    # When unset, falls back to MAX_ASYNC / LLM_TIMEOUT
+    args.rerank_max_async = get_env_value(
+        "MAX_ASYNC_RERANK_LLM", args.max_async, int
+    )
+    args.rerank_timeout = get_env_value(
+        "RERANK_TIMEOUT",
+        get_env_value("LLM_TIMEOUT", DEFAULT_LLM_TIMEOUT, int),
+        int,
     )
 
     # Query configuration

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -585,12 +585,8 @@ def parse_args() -> argparse.Namespace:
 
     # Rerank async/timeout configuration (independent from base LLM)
     # rerank_max_async falls back to MAX_ASYNC; rerank_timeout has its own default.
-    args.rerank_max_async = get_env_value(
-        "MAX_ASYNC_RERANK_LLM", args.max_async, int
-    )
-    args.rerank_timeout = get_env_value(
-        "RERANK_TIMEOUT", DEFAULT_RERANK_TIMEOUT, int
-    )
+    args.rerank_max_async = get_env_value("MAX_ASYNC_RERANK_LLM", args.max_async, int)
+    args.rerank_timeout = get_env_value("RERANK_TIMEOUT", DEFAULT_RERANK_TIMEOUT, int)
 
     # Query configuration
     args.history_turns = get_env_value("HISTORY_TURNS", DEFAULT_HISTORY_TURNS, int)

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -44,6 +44,7 @@ from lightrag.constants import (
     DEFAULT_OLLAMA_MODEL_TAG,
     DEFAULT_RERANK_BINDING,
     DEFAULT_LLM_TIMEOUT,
+    DEFAULT_EMBEDDING_TIMEOUT,
 )
 
 # use the .env that is inside the current folder
@@ -575,15 +576,19 @@ def parse_args() -> argparse.Namespace:
         "MIN_RERANK_SCORE", DEFAULT_MIN_RERANK_SCORE, float
     )
 
+    # LLM / Embedding request timeouts
+    args.llm_timeout = get_env_value("LLM_TIMEOUT", DEFAULT_LLM_TIMEOUT, int)
+    args.embedding_timeout = get_env_value(
+        "EMBEDDING_TIMEOUT", DEFAULT_EMBEDDING_TIMEOUT, int
+    )
+
     # Rerank async/timeout configuration (independent from base LLM)
     # When unset, falls back to MAX_ASYNC / LLM_TIMEOUT
     args.rerank_max_async = get_env_value(
         "MAX_ASYNC_RERANK_LLM", args.max_async, int
     )
     args.rerank_timeout = get_env_value(
-        "RERANK_TIMEOUT",
-        get_env_value("LLM_TIMEOUT", DEFAULT_LLM_TIMEOUT, int),
-        int,
+        "RERANK_TIMEOUT", args.llm_timeout, int
     )
 
     # Query configuration

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -45,6 +45,7 @@ from lightrag.constants import (
     DEFAULT_RERANK_BINDING,
     DEFAULT_LLM_TIMEOUT,
     DEFAULT_EMBEDDING_TIMEOUT,
+    DEFAULT_RERANK_TIMEOUT,
 )
 
 # use the .env that is inside the current folder
@@ -583,12 +584,12 @@ def parse_args() -> argparse.Namespace:
     )
 
     # Rerank async/timeout configuration (independent from base LLM)
-    # When unset, falls back to MAX_ASYNC / LLM_TIMEOUT
+    # rerank_max_async falls back to MAX_ASYNC; rerank_timeout has its own default.
     args.rerank_max_async = get_env_value(
         "MAX_ASYNC_RERANK_LLM", args.max_async, int
     )
     args.rerank_timeout = get_env_value(
-        "RERANK_TIMEOUT", args.llm_timeout, int
+        "RERANK_TIMEOUT", DEFAULT_RERANK_TIMEOUT, int
     )
 
     # Query configuration

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -42,8 +42,6 @@ from lightrag.constants import (
     DEFAULT_LOG_MAX_BYTES,
     DEFAULT_LOG_BACKUP_COUNT,
     DEFAULT_LOG_FILENAME,
-    DEFAULT_LLM_TIMEOUT,
-    DEFAULT_EMBEDDING_TIMEOUT,
 )
 from lightrag.api.routers.document_routes import (
     DocumentManager,
@@ -1239,10 +1237,8 @@ def create_app(args):
 
         return embedding_func_instance
 
-    llm_timeout = get_env_value("LLM_TIMEOUT", DEFAULT_LLM_TIMEOUT, int)
-    embedding_timeout = get_env_value(
-        "EMBEDDING_TIMEOUT", DEFAULT_EMBEDDING_TIMEOUT, int
-    )
+    llm_timeout = args.llm_timeout
+    embedding_timeout = args.embedding_timeout
 
     async def bedrock_model_complete(
         prompt,
@@ -1704,8 +1700,10 @@ def create_app(args):
                     "min_rerank_score": args.min_rerank_score,
                     "related_chunk_number": args.related_chunk_number,
                     "max_async": args.max_async,
+                    "llm_timeout": args.llm_timeout,
                     "embedding_func_max_async": args.embedding_func_max_async,
                     "embedding_batch_num": args.embedding_batch_num,
+                    "embedding_timeout": args.embedding_timeout,
                     "role_llm_config": rag.get_llm_role_config(),
                 },
                 "auth_mode": auth_mode,

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -1454,6 +1454,8 @@ def create_app(args):
             enable_llm_cache_for_entity_extract=args.enable_llm_cache_for_extract,
             enable_llm_cache=args.enable_llm_cache,
             rerank_model_func=rerank_model_func,
+            rerank_model_max_async=args.rerank_max_async,
+            default_rerank_timeout=args.rerank_timeout,
             max_parallel_insert=args.max_parallel_insert,
             max_graph_nodes=args.max_graph_nodes,
             addon_params=addon_params,
@@ -1692,6 +1694,8 @@ def create_app(args):
                     "rerank_binding_host": args.rerank_binding_host
                     if rerank_model_func
                     else None,
+                    "rerank_max_async": args.rerank_max_async,
+                    "rerank_timeout": args.rerank_timeout,
                     # Environment variable status (requested configuration)
                     "summary_language": args.summary_language,
                     "force_llm_summary_on_merge": args.force_llm_summary_on_merge,

--- a/lightrag/api/utils_api.py
+++ b/lightrag/api/utils_api.py
@@ -336,24 +336,6 @@ def display_splash_screen(args: argparse.Namespace) -> None:
     ASCIIColors.yellow(f"{args.working_dir}")
     ASCIIColors.white("    └─ Input Directory: ", end="")
     ASCIIColors.yellow(f"{args.input_dir}")
-
-    # LLM Configuration
-    ASCIIColors.magenta("\n🤖 LLM Configuration:")
-    ASCIIColors.white("    ├─ Binding: ", end="")
-    ASCIIColors.yellow(f"{args.llm_binding}")
-    ASCIIColors.white("    ├─ Host: ", end="")
-    ASCIIColors.yellow(f"{args.llm_binding_host}")
-    ASCIIColors.white("    ├─ Model: ", end="")
-    ASCIIColors.yellow(f"{args.llm_model}")
-    ASCIIColors.white("    ├─ Max Async for LLM: ", end="")
-    ASCIIColors.yellow(f"{args.max_async}")
-    ASCIIColors.white("    ├─ Summary Context Size: ", end="")
-    ASCIIColors.yellow(f"{args.summary_context_size}")
-    ASCIIColors.white("    ├─ LLM Cache Enabled: ", end="")
-    ASCIIColors.yellow(f"{args.enable_llm_cache}")
-    ASCIIColors.white("    └─ LLM Cache for Extraction Enabled: ", end="")
-    ASCIIColors.yellow(f"{args.enable_llm_cache_for_extract}")
-
     # Embedding Configuration
     ASCIIColors.magenta("\n📊 Embedding Configuration:")
     ASCIIColors.white("    ├─ Binding: ", end="")

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -98,9 +98,11 @@ DEFAULT_TIMEOUT = 300
 DEFAULT_LLM_TIMEOUT = 180
 DEFAULT_EMBEDDING_TIMEOUT = 30
 
-# Rerank async / timeout defaults (fall back to base LLM defaults when env unset)
+# Rerank async / timeout defaults
+# Concurrency falls back to base MAX_ASYNC when env unset; timeout has its own
+# default since reranker calls are typically much faster than full LLM generation.
 DEFAULT_RERANK_MAX_ASYNC = DEFAULT_MAX_ASYNC
-DEFAULT_RERANK_TIMEOUT = DEFAULT_LLM_TIMEOUT
+DEFAULT_RERANK_TIMEOUT = 30
 
 # Logging configuration defaults
 DEFAULT_LOG_MAX_BYTES = 10485760  # Default 10MB

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -98,6 +98,10 @@ DEFAULT_TIMEOUT = 300
 DEFAULT_LLM_TIMEOUT = 180
 DEFAULT_EMBEDDING_TIMEOUT = 30
 
+# Rerank async / timeout defaults (fall back to base LLM defaults when env unset)
+DEFAULT_RERANK_MAX_ASYNC = DEFAULT_MAX_ASYNC
+DEFAULT_RERANK_TIMEOUT = DEFAULT_LLM_TIMEOUT
+
 # Logging configuration defaults
 DEFAULT_LOG_MAX_BYTES = 10485760  # Default 10MB
 DEFAULT_LOG_BACKUP_COUNT = 5  # Default 5 backups

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -760,6 +760,28 @@ class LightRAG:
     rerank_model_func: Callable[..., object] | None = field(default=None)
     """Function for reranking retrieved documents. All rerank configurations (model name, API keys, top_k, etc.) should be included in this function. Optional."""
 
+    rerank_model_max_async: int = field(
+        default=int(
+            os.getenv(
+                "MAX_ASYNC_RERANK_LLM",
+                os.getenv("MAX_ASYNC", DEFAULT_MAX_ASYNC),
+            )
+        )
+    )
+    """Maximum number of concurrent rerank calls.
+    Falls back to MAX_ASYNC when MAX_ASYNC_RERANK_LLM is unset."""
+
+    default_rerank_timeout: int = field(
+        default=int(
+            os.getenv(
+                "RERANK_TIMEOUT",
+                os.getenv("LLM_TIMEOUT", DEFAULT_LLM_TIMEOUT),
+            )
+        )
+    )
+    """Rerank request timeout in seconds.
+    Falls back to LLM_TIMEOUT when RERANK_TIMEOUT is unset."""
+
     min_rerank_score: float = field(
         default=get_env_value("MIN_RERANK_SCORE", DEFAULT_MIN_RERANK_SCORE, float)
     )
@@ -1520,8 +1542,8 @@ class LightRAG:
 
         if self.rerank_model_func is not None:
             self.rerank_model_func = priority_limit_async_func_call(
-                self.llm_model_max_async,
-                llm_timeout=self.default_llm_timeout,
+                self.rerank_model_max_async,
+                llm_timeout=self.default_rerank_timeout,
                 queue_name="Rerank func",
             )(self.rerank_model_func)
 

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -70,6 +70,7 @@ from lightrag.constants import (
     DEFAULT_SUMMARY_LANGUAGE,
     DEFAULT_LLM_TIMEOUT,
     DEFAULT_EMBEDDING_TIMEOUT,
+    DEFAULT_RERANK_TIMEOUT,
     DEFAULT_SOURCE_IDS_LIMIT_METHOD,
     DEFAULT_MAX_FILE_PATHS,
     FULL_DOCS_FORMAT_RAW,
@@ -772,15 +773,11 @@ class LightRAG:
     Falls back to MAX_ASYNC when MAX_ASYNC_RERANK_LLM is unset."""
 
     default_rerank_timeout: int = field(
-        default=int(
-            os.getenv(
-                "RERANK_TIMEOUT",
-                os.getenv("LLM_TIMEOUT", DEFAULT_LLM_TIMEOUT),
-            )
-        )
+        default=int(os.getenv("RERANK_TIMEOUT", DEFAULT_RERANK_TIMEOUT))
     )
     """Rerank request timeout in seconds.
-    Falls back to LLM_TIMEOUT when RERANK_TIMEOUT is unset."""
+    Independent from LLM_TIMEOUT since reranker calls are much shorter
+    than full LLM generation."""
 
     min_rerank_score: float = field(
         default=get_env_value("MIN_RERANK_SCORE", DEFAULT_MIN_RERANK_SCORE, float)

--- a/lightrag_webui/src/api/lightrag.ts
+++ b/lightrag_webui/src/api/lightrag.ts
@@ -909,7 +909,8 @@ export const getAuthStatus = async (): Promise<AuthStatusResponse> => {
     });
 
     // Check if response is HTML (which indicates a redirect or wrong endpoint)
-    const contentType = response.headers['content-type'] || '';
+    const contentTypeHeader = response.headers['content-type'];
+    const contentType = typeof contentTypeHeader === 'string' ? contentTypeHeader : '';
     if (contentType.includes('text/html')) {
       console.warn('Received HTML response instead of JSON for auth-status endpoint');
       return {

--- a/lightrag_webui/src/api/lightrag.ts
+++ b/lightrag_webui/src/api/lightrag.ts
@@ -79,12 +79,16 @@ export type LightragStatus = {
     rerank_binding?: string | null
     rerank_model?: string | null
     rerank_binding_host?: string | null
+    rerank_max_async?: number
+    rerank_timeout?: number
     summary_language: string
     force_llm_summary_on_merge: boolean
     max_parallel_insert: number
     max_async: number
+    llm_timeout?: number
     embedding_func_max_async: number
     embedding_batch_num: number
+    embedding_timeout?: number
     cosine_threshold: number
     min_rerank_score: number
     related_chunk_number: number

--- a/tests/test_bedrock_llm.py
+++ b/tests/test_bedrock_llm.py
@@ -546,6 +546,10 @@ def _make_args(tmp_path) -> SimpleNamespace:
         min_rerank_score=0.0,
         related_chunk_number=5,
         top_k=10,
+        llm_timeout=180,
+        embedding_timeout=30,
+        rerank_max_async=4,
+        rerank_timeout=30,
     )
 
 

--- a/tests/test_llm_role_runtime.py
+++ b/tests/test_llm_role_runtime.py
@@ -710,7 +710,7 @@ async def test_embedding_and_rerank_queue_status_are_observable(tmp_path):
     async def rerank_func(*args, **kwargs):
         return []
 
-    rag = _make_rag(tmp_path, rerank_model_func=rerank_func, llm_model_max_async=3)
+    rag = _make_rag(tmp_path, rerank_model_func=rerank_func)
 
     embedding_status = await rag.get_embedding_queue_status()
     rerank_status = await rag.get_rerank_queue_status()
@@ -720,7 +720,7 @@ async def test_embedding_and_rerank_queue_status_are_observable(tmp_path):
     assert embedding_status["max_async"] == rag.embedding_func_max_async
     assert rerank_status["available"] is True
     assert rerank_status["queue_name"] == "Rerank func"
-    assert rerank_status["max_async"] == 3
+    assert rerank_status["max_async"] == rag.rerank_model_max_async
 
 
 def test_get_llm_role_config_strips_bedrock_and_password_fields(tmp_path):


### PR DESCRIPTION
## Summary

- Decouple rerank concurrency and timeout from the base LLM settings via two new env vars: `MAX_ASYNC_RERANK` (falls back to `MAX_ASYNC`) and `RERANK_TIMEOUT` (independent default of `30s`, since reranker calls are typically much shorter than full LLM generation).
- Surface `llm_timeout`, `embedding_timeout`, `rerank_max_async`, and `rerank_timeout` on the `/health` status endpoint, and sync the `LightragStatus` type in the WebUI so the new fields can be displayed.
- Centralize timeout parsing in `api/config.py` (previously duplicated in `lightrag_server.py`) and wire the new defaults through `LightRAG` (`rerank_model_max_async`, `default_rerank_timeout`).
- Fix a TypeScript error in `getAuthStatus`: `response.headers['content-type']` is `string | number | true | string[] | AxiosHeaders`, so guard with a `typeof` check before calling `.includes`.

## Test plan

- [ ] Start the API server with defaults and verify `/health` reports the new timeout / rerank-async fields.
- [ ] Override `MAX_ASYNC_RERANK` and `RERANK_TIMEOUT` via `.env`, restart, and confirm the values flow through to `/health` and the rerank queue.
- [ ] Run a query with reranking enabled and confirm the rerank task uses the configured concurrency / timeout limits.
- [ ] Run `bunx tsc --noEmit` in `lightrag_webui` and confirm `lightrag.ts:913` no longer reports a type error.
- [ ] Open the WebUI status panel and confirm the new timeout / rerank fields render correctly.