### PR TITLE
Fix LLM cache role identity isolation

### DIFF
--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -149,9 +149,10 @@ class QueryParam:
     """
 
     model_func: Callable[..., object] | None = None
-    """Optional override for the LLM model function to use for this specific query.
-    If provided, this will be used instead of the global model function.
-    This allows using different models for different query modes.
+    """Deprecated optional override for the LLM model function.
+    Use role-specific LLM configuration at initialization or
+    await rag.aupdate_llm_role_config("query" | "keyword", ...) for runtime
+    LLM changes instead. Kept for backward compatibility with direct Python callers.
     """
 
     user_prompt: str | None = None

--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -153,6 +153,10 @@ class QueryParam:
     Use role-specific LLM configuration at initialization or
     await rag.aupdate_llm_role_config("query" | "keyword", ...) for runtime
     LLM changes instead. Kept for backward compatibility with direct Python callers.
+
+    Note: when set, the LLM cache key collapses to a single "override" identity,
+    so swapping the override across calls will reuse stale cached responses.
+    Use aupdate_llm_role_config() for cache-correct model swaps.
     """
 
     user_prompt: str | None = None

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -145,10 +145,12 @@ class QueryParam:
     history_turns: int = int(os.getenv("HISTORY_TURNS", str(DEFAULT_HISTORY_TURNS)))
     """Number of complete conversation turns (user-assistant pairs) to consider in the response context."""
 
+    # TODO: deprecated
     model_func: Callable[..., object] | None = None
-    """Optional override for the LLM model function to use for this specific query.
-    If provided, this will be used instead of the global model function.
-    This allows using different models for different query modes.
+    """Deprecated optional override for the LLM model function.
+    Use role_llm_configs at initialization or LightRAG.aupdate_llm_role_config() /
+    LightRAG.update_llm_role_config() for runtime role LLM changes instead.
+    Kept for backward compatibility with direct Python callers.
     """
 
     user_prompt: str | None = None

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -145,12 +145,18 @@ class QueryParam:
     history_turns: int = int(os.getenv("HISTORY_TURNS", str(DEFAULT_HISTORY_TURNS)))
     """Number of complete conversation turns (user-assistant pairs) to consider in the response context."""
 
-    # TODO: deprecated
+    # TODO(v1.5.0): remove model_func together with the override branches in
+    # operate.py (_warn_deprecated_query_model_func call sites) and the
+    # `model_func_override` path in utils.get_llm_cache_identity.
     model_func: Callable[..., object] | None = None
     """Deprecated optional override for the LLM model function.
     Use role_llm_configs at initialization or LightRAG.aupdate_llm_role_config() /
     LightRAG.update_llm_role_config() for runtime role LLM changes instead.
     Kept for backward compatibility with direct Python callers.
+
+    Note: when set, the LLM cache key collapses to a single "override" identity,
+    so swapping the override across calls will reuse stale cached responses.
+    Use aupdate_llm_role_config() for cache-correct model swaps.
     """
 
     user_prompt: str | None = None

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -118,6 +118,7 @@ from lightrag.operate import (
     kg_query,
     naive_query,
     rebuild_knowledge_from_chunks,
+    _warn_deprecated_query_model_func,
 )
 from lightrag.constants import GRAPH_FIELD_SEP
 from lightrag.utils import (
@@ -1447,7 +1448,24 @@ class LightRAG:
             spec.name: states[spec.name].wrapped if spec.name in states else None
             for spec in ROLES
         }
+        global_config["llm_cache_identities"] = {
+            spec.name: self._build_role_llm_cache_identity(
+                spec.name, states.get(spec.name)
+            )
+            for spec in ROLES
+        }
         return global_config
+
+    def _build_role_llm_cache_identity(
+        self, role: str, state: _RoleLLMState | None
+    ) -> dict[str, Any]:
+        metadata = state.metadata if state is not None else {}
+        return {
+            "role": role,
+            "binding": metadata.get("binding"),
+            "model": metadata.get("model") or self.llm_model_name,
+            "host": metadata.get("host"),
+        }
 
     def __post_init__(self, addon_params: dict[str, Any] | None):
         from lightrag.kg.shared_storage import (
@@ -5966,6 +5984,8 @@ class LightRAG:
                 )
             elif param.mode == "bypass":
                 # Bypass mode: directly use LLM without knowledge retrieval
+                if param.model_func:
+                    _warn_deprecated_query_model_func("bypass query generation")
                 use_llm_func = (
                     param.model_func or global_config["role_llm_funcs"]["query"]
                 )

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1459,6 +1459,10 @@ class LightRAG:
     def _build_role_llm_cache_identity(
         self, role: str, state: _RoleLLMState | None
     ) -> dict[str, Any]:
+        # `state` is None during the first _build_global_config() call from
+        # __post_init__ — role builders have not run yet, so metadata is empty
+        # and we fall back to self.llm_model_name. Once roles are initialized
+        # or aupdate_llm_role_config() runs, metadata always carries `model`.
         metadata = state.metadata if state is not None else {}
         return {
             "role": role,

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import asyncio
 import json
 import re
+import warnings
 import json_repair
 from typing import Any, AsyncIterator, overload, Literal
 from collections import Counter, defaultdict
@@ -27,6 +28,8 @@ from lightrag.utils import (
     save_to_cache,
     CacheData,
     use_llm_func_with_cache,
+    get_llm_cache_identity,
+    serialize_llm_cache_identity,
     update_chunk_cache_list,
     remove_think_tags,
     pick_by_weighted_polling,
@@ -75,6 +78,16 @@ from dotenv import load_dotenv
 # allows to use different .env file for each lightrag instance
 # the OS environment variables take precedence over the .env file
 load_dotenv(dotenv_path=Path(__file__).resolve().parent / ".env", override=False)
+
+
+def _warn_deprecated_query_model_func(context: str) -> None:
+    warnings.warn(
+        "QueryParam.model_func is deprecated and will be removed at v1.5.0. "
+        "Use LightRAG.aupdate_llm_role_config() instead. "
+        f"Deprecated override used for {context}.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
 
 
 def _get_relationship_vdb_timeout_seconds(global_config: dict[str, Any]) -> float:
@@ -425,6 +438,7 @@ async def _summarize_descriptions(
         use_llm_func,
         llm_response_cache=llm_response_cache,
         cache_type="summary",
+        llm_cache_identity=get_llm_cache_identity(global_config, "extract"),
     )
 
     # Check summary token length against embedding limit
@@ -3366,6 +3380,7 @@ async def extract_entities(
             chunk_id=chunk_key,
             cache_keys_collector=cache_keys_collector,
             response_format=({"type": "json_object"} if use_json_extraction else None),
+            llm_cache_identity=get_llm_cache_identity(global_config, "extract"),
         )
 
         history = pack_user_ass_to_openai_messages(
@@ -3404,6 +3419,7 @@ async def extract_entities(
                 response_format=(
                     {"type": "json_object"} if use_json_extraction else None
                 ),
+                llm_cache_identity=get_llm_cache_identity(global_config, "extract"),
             )
 
             # Process gleaning result with appropriate parser
@@ -3608,6 +3624,9 @@ async def kg_query(
         use_model_func = global_config["role_llm_funcs"]["query"]
         # Apply higher priority (5) to query relation LLM function
         use_model_func = partial(use_model_func, _priority=5)
+    llm_cache_identity = get_llm_cache_identity(
+        global_config, "query", query_param.model_func
+    )
 
     hl_keywords, ll_keywords = await get_keywords_from_query(
         query, query_param, global_config, hashing_kv
@@ -3696,6 +3715,8 @@ async def kg_query(
         ll_keywords_str,
         query_param.user_prompt or "",
         query_param.enable_rerank,
+        "\n<llm_identity>\n",
+        serialize_llm_cache_identity(llm_cache_identity),
     )
 
     cached_result = await handle_cache(
@@ -3709,6 +3730,8 @@ async def kg_query(
         )
         response = cached_response
     else:
+        if query_param.model_func:
+            _warn_deprecated_query_model_func("KG query generation")
         response = await use_model_func(
             user_query,
             system_prompt=sys_prompt,
@@ -3943,10 +3966,15 @@ async def extract_keywords_only(
         language = addon_params.get("language", DEFAULT_SUMMARY_LANGUAGE)
 
     # 2. Handle cache if needed - add cache type for keywords
+    llm_cache_identity = get_llm_cache_identity(
+        global_config, "keyword", param.model_func
+    )
     args_hash = compute_args_hash(
         param.mode,
         text,
         language,
+        "\n<llm_identity>\n",
+        serialize_llm_cache_identity(llm_cache_identity),
     )
     cached_result = await handle_cache(
         hashing_kv, args_hash, text, param.mode, cache_type="keywords"
@@ -3978,6 +4006,7 @@ async def extract_keywords_only(
 
     # 4. Call the LLM for keyword extraction
     if param.model_func:
+        _warn_deprecated_query_model_func("keyword extraction")
         use_model_func = param.model_func
     else:
         use_model_func = global_config["role_llm_funcs"]["keyword"]
@@ -5498,6 +5527,9 @@ async def naive_query(
         use_model_func = global_config["role_llm_funcs"]["query"]
         # Apply higher priority (5) to query relation LLM function
         use_model_func = partial(use_model_func, _priority=5)
+    llm_cache_identity = get_llm_cache_identity(
+        global_config, "query", query_param.model_func
+    )
 
     tokenizer: Tokenizer = global_config["tokenizer"]
     if not tokenizer:
@@ -5641,6 +5673,8 @@ async def naive_query(
         query_param.max_total_tokens,
         query_param.user_prompt or "",
         query_param.enable_rerank,
+        "\n<llm_identity>\n",
+        serialize_llm_cache_identity(llm_cache_identity),
     )
     cached_result = await handle_cache(
         hashing_kv, args_hash, user_query, query_param.mode, cache_type="query"
@@ -5652,6 +5686,8 @@ async def naive_query(
         )
         response = cached_response
     else:
+        if query_param.model_func:
+            _warn_deprecated_query_model_func("naive query generation")
         response = await use_model_func(
             user_query,
             system_prompt=sys_prompt,

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -639,7 +639,17 @@ def get_llm_cache_identity(
     role: str,
     model_func_override: Callable[..., Any] | None = None,
 ) -> dict[str, Any]:
-    """Get the non-secret LLM identity used to partition LLM cache keys."""
+    """Get the non-secret LLM identity used to partition LLM cache keys.
+
+    Includes ``role``, ``binding``, ``model``, and ``host``. Deliberately excludes
+    ``api_key`` and ``provider_options`` so cache keys remain non-secret and safe
+    to persist.
+
+    When ``model_func_override`` is set (the deprecated ``QueryParam.model_func``
+    path), the identity collapses to ``{role, override}`` and does not partition
+    by the underlying model — callers swapping overrides will hit shared cache
+    entries. Use ``LightRAG.aupdate_llm_role_config()`` for cache-correct swaps.
+    """
     if model_func_override is not None:
         return {
             "role": role,

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -634,6 +634,38 @@ def _serialize_cache_variant(value: Any) -> str:
         return repr(value)
 
 
+def get_llm_cache_identity(
+    global_config: dict[str, Any] | None,
+    role: str,
+    model_func_override: Callable[..., Any] | None = None,
+) -> dict[str, Any]:
+    """Get the non-secret LLM identity used to partition LLM cache keys."""
+    if model_func_override is not None:
+        return {
+            "role": role,
+            "override": "query_param.model_func",
+        }
+
+    config = global_config or {}
+    identities = config.get("llm_cache_identities")
+    if isinstance(identities, dict):
+        identity = identities.get(role)
+        if isinstance(identity, dict):
+            return dict(identity)
+
+    return {
+        "role": role,
+        "binding": None,
+        "model": config.get("llm_model_name"),
+        "host": None,
+    }
+
+
+def serialize_llm_cache_identity(identity: Any) -> str:
+    """Serialize an LLM cache identity for inclusion in hash inputs."""
+    return _serialize_cache_variant(identity)
+
+
 def _validate_cached_response_format(response_format: Any | None) -> None:
     """Reject structured-output modes that the cache wrapper does not support."""
     if response_format is None:
@@ -2168,6 +2200,7 @@ async def use_llm_func_with_cache(
     cache_keys_collector: list = None,
     response_format: Any | None = None,
     entity_extraction: bool = False,
+    llm_cache_identity: Any | None = None,
 ) -> tuple[str, int]:
     """Call LLM function with cache support and text sanitization
 
@@ -2196,6 +2229,8 @@ async def use_llm_func_with_cache(
         entity_extraction: Deprecated. When True and ``response_format`` is not
             provided, maps to ``{"type": "json_object"}``. Prefer passing
             ``response_format`` directly.
+        llm_cache_identity: Non-secret model/provider identity used to partition
+            cache entries across role model, binding, or host changes.
 
     Returns:
         tuple[str, int]: (LLM response text, timestamp)
@@ -2241,8 +2276,13 @@ async def use_llm_func_with_cache(
         _prompt = "\n".join(prompt_parts)
 
         response_format_key = _serialize_cache_variant(response_format)
+        llm_identity_key = serialize_llm_cache_identity(llm_cache_identity)
         arg_hash = compute_args_hash(
-            _prompt, "\n<response_format>\n", response_format_key
+            _prompt,
+            "\n<response_format>\n",
+            response_format_key,
+            "\n<llm_identity>\n",
+            llm_identity_key,
         )
         # Generate cache key for this LLM call
         cache_key = generate_cache_key("default", cache_type, arg_hash)

--- a/tests/test_api_config_bedrock.py
+++ b/tests/test_api_config_bedrock.py
@@ -13,6 +13,7 @@ def _clear_bedrock_auth_env(monkeypatch):
         "LLM_BINDING",
         "EMBEDDING_BINDING",
         "QUERY_LLM_BINDING",
+        "QUERY_LLM_BINDING_API_KEY",
         "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY",
         "AWS_SESSION_TOKEN",

--- a/tests/test_keyword_parsing.py
+++ b/tests/test_keyword_parsing.py
@@ -13,6 +13,41 @@ class _FakeKeywordModel:
         }
 
 
+class _FakeTokenizer:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+
+class _FakeKVStorage:
+    def __init__(self):
+        self.global_config = {"enable_llm_cache": True}
+        self._store = {}
+
+    async def get_by_id(self, key):
+        return self._store.get(key)
+
+    async def upsert(self, entries):
+        self._store.update(entries)
+
+
+def _keyword_global_config(
+    model: str, binding: str = "openai", keyword_func=None
+) -> dict:
+    return {
+        "addon_params": {"language": "en"},
+        "tokenizer": _FakeTokenizer(),
+        "role_llm_funcs": {"keyword": keyword_func} if keyword_func else {},
+        "llm_cache_identities": {
+            "keyword": {
+                "role": "keyword",
+                "binding": binding,
+                "model": model,
+                "host": "https://api.example.com/v1",
+            }
+        },
+    }
+
+
 @pytest.mark.offline
 def test_parse_keywords_payload_accepts_model_like_objects():
     is_valid, hl_keywords, ll_keywords = _parse_keywords_payload(_FakeKeywordModel())
@@ -80,3 +115,64 @@ async def test_extract_keywords_only_accepts_empty_keyword_cache_without_requery
 
     assert hl_keywords == []
     assert ll_keywords == []
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_extract_keywords_only_partitions_cache_by_keyword_llm_identity():
+    cache = _FakeKVStorage()
+    calls = 0
+
+    async def keyword_model(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        return (
+            '{"high_level_keywords":["model-'
+            + str(calls)
+            + '"],"low_level_keywords":["rag"]}'
+        )
+
+    param = QueryParam()
+
+    first_hl, first_ll = await extract_keywords_only(
+        "same query",
+        param,
+        _keyword_global_config("model-a", keyword_func=keyword_model),
+        hashing_kv=cache,
+    )
+    second_hl, second_ll = await extract_keywords_only(
+        "same query",
+        param,
+        _keyword_global_config("model-b", keyword_func=keyword_model),
+        hashing_kv=cache,
+    )
+
+    assert first_hl == ["model-1"]
+    assert first_ll == ["rag"]
+    assert second_hl == ["model-2"]
+    assert second_ll == ["rag"]
+    assert calls == 2
+    assert len(cache._store) == 2
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_extract_keywords_only_warns_for_deprecated_model_func():
+    calls = 0
+
+    async def keyword_model(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        return '{"high_level_keywords":["ai"],"low_level_keywords":["rag"]}'
+
+    with pytest.warns(DeprecationWarning, match="QueryParam.model_func"):
+        hl_keywords, ll_keywords = await extract_keywords_only(
+            "hello",
+            QueryParam(model_func=keyword_model),
+            _keyword_global_config("model-a"),
+            hashing_kv=None,
+        )
+
+    assert hl_keywords == ["ai"]
+    assert ll_keywords == ["rag"]
+    assert calls == 1

--- a/tests/test_llm_cache_identity.py
+++ b/tests/test_llm_cache_identity.py
@@ -1,0 +1,89 @@
+import pytest
+
+from lightrag.base import QueryParam
+from lightrag.operate import naive_query
+
+
+class _FakeTokenizer:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(token) for token in tokens)
+
+
+class _FakeKVStorage:
+    def __init__(self):
+        self.global_config = {"enable_llm_cache": True}
+        self._store = {}
+
+    async def get_by_id(self, key):
+        return self._store.get(key)
+
+    async def upsert(self, entries):
+        self._store.update(entries)
+
+
+class _FakeChunksVDB:
+    cosine_better_than_threshold = 0.0
+
+    async def query(self, *_args, **_kwargs):
+        return [
+            {
+                "id": "chunk-1",
+                "content": "LightRAG cache identity test chunk.",
+                "file_path": "test.md",
+            }
+        ]
+
+
+def _query_global_config(model: str, llm_func) -> dict:
+    return {
+        "tokenizer": _FakeTokenizer(),
+        "role_llm_funcs": {"query": llm_func},
+        "llm_cache_identities": {
+            "query": {
+                "role": "query",
+                "binding": "openai",
+                "model": model,
+                "host": "https://api.example.com/v1",
+            }
+        },
+        "min_rerank_score": 0.0,
+        "max_total_tokens": 4096,
+    }
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_naive_query_partitions_query_cache_by_llm_identity():
+    cache = _FakeKVStorage()
+    chunks_vdb = _FakeChunksVDB()
+    calls = 0
+
+    async def query_model(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        return f"answer-{calls}"
+
+    param = QueryParam(mode="naive", enable_rerank=False)
+
+    first = await naive_query(
+        "same query",
+        chunks_vdb,
+        param,
+        _query_global_config("model-a", query_model),
+        hashing_kv=cache,
+    )
+    second = await naive_query(
+        "same query",
+        chunks_vdb,
+        param,
+        _query_global_config("model-b", query_model),
+        hashing_kv=cache,
+    )
+
+    assert first.content == "answer-1"
+    assert second.content == "answer-2"
+    assert calls == 2
+    assert len(cache._store) == 2

--- a/tests/test_llm_role_runtime.py
+++ b/tests/test_llm_role_runtime.py
@@ -545,6 +545,32 @@ async def test_aupdate_llm_role_config_with_builder_drains_old_queue(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_aupdate_llm_role_config_updates_cache_identity(tmp_path):
+    async def query_func(*_args, **_kwargs):
+        return "query"
+
+    rag = _make_rag(tmp_path)
+    rag.register_role_llm_builder(lambda _role, _meta: (query_func, {}))
+
+    await rag.aupdate_llm_role_config(
+        "query",
+        binding="openai",
+        model="gpt-cache-test",
+        host="https://api.example.com/v1",
+    )
+
+    identity = rag._build_global_config()["llm_cache_identities"]["query"]
+
+    assert identity == {
+        "role": "query",
+        "binding": "openai",
+        "model": "gpt-cache-test",
+        "host": "https://api.example.com/v1",
+    }
+    await rag.wait_for_retired_llm_queues()
+
+
+@pytest.mark.asyncio
 async def test_update_llm_role_config_with_builder_metadata(tmp_path):
     built_calls = []
 

--- a/tests/test_utils_llm_cache.py
+++ b/tests/test_utils_llm_cache.py
@@ -43,6 +43,41 @@ async def test_use_llm_func_with_cache_partitions_cache_by_response_format():
 
 @pytest.mark.offline
 @pytest.mark.asyncio
+async def test_use_llm_func_with_cache_partitions_cache_by_llm_identity():
+    cache = _FakeKVStorage()
+    llm_func = AsyncMock(side_effect=["model-a", "model-b"])
+
+    first_result, _ = await use_llm_func_with_cache(
+        "same prompt",
+        llm_func,
+        llm_response_cache=cache,
+        llm_cache_identity={
+            "role": "query",
+            "binding": "openai",
+            "model": "model-a",
+            "host": "https://api.example.com/v1",
+        },
+    )
+    second_result, _ = await use_llm_func_with_cache(
+        "same prompt",
+        llm_func,
+        llm_response_cache=cache,
+        llm_cache_identity={
+            "role": "query",
+            "binding": "openai",
+            "model": "model-b",
+            "host": "https://api.example.com/v1",
+        },
+    )
+
+    assert first_result == "model-a"
+    assert second_result == "model-b"
+    assert llm_func.await_count == 2
+    assert len(cache._store) == 2
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
 async def test_use_llm_func_with_cache_rejects_json_schema_response_format():
     llm_func = AsyncMock()
 


### PR DESCRIPTION
## Description

Partition LLM response cache entries by the active role LLM identity so model, binding, or host changes no longer reuse stale cached responses. This also marks the per-query `QueryParam.model_func` override as deprecated in favor of role LLM configuration and runtime role updates.

## Related Issues

n/a

## Changes Made

- Add non-secret per-role LLM cache identities (`role`, `binding`, `model`, `host`) to LightRAG global config.
- Include serialized LLM identity in keyword, query, entity extraction, and summary cache hash inputs.
- Keep deprecated `QueryParam.model_func` functional while warning when it is selected.
- Update programming docs and add regression tests for cache identity partitioning and Bedrock env isolation.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Local validation:
- `./scripts/test.sh tests/test_utils_llm_cache.py tests/test_keyword_parsing.py tests/test_llm_cache_identity.py tests/test_api_config_bedrock.py`
- `ruff check tests/test_api_config_bedrock.py lightrag/utils.py`
