### PR TITLE
Add Podman-compatible compose file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ venv/
 
 # Generated Docker Compose files (output of setup wizard)
 docker-compose.*.yml
+!docker-compose.podman.yml
 
 # Build / Distribution
 dist/

--- a/docker-compose.podman.yml
+++ b/docker-compose.podman.yml
@@ -1,0 +1,35 @@
+# Podman-compatible compose file for LightRAG
+#
+# Usage:
+#   podman-compose -f docker-compose.podman.yml up -d
+#
+# Key differences from docker-compose.yml:
+#   - Uses top-level `restart` instead of `deploy.restart_policy`
+#     (Podman does not support the deploy block for restart policies)
+#   - No `extra_hosts` with `host-gateway` (Podman fails on this special
+#     value; Podman auto-provides host.containers.internal for host access)
+#   - When connecting to host services (e.g. LLM, embedding, rerank),
+#     use `host.containers.internal` instead of `host.docker.internal`
+#     in your .env binding host configuration
+
+services:
+  lightrag:
+    image: ghcr.io/hkuds/lightrag:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+      tags:
+        - ghcr.io/hkuds/lightrag:latest
+    ports:
+      - "${HOST:-0.0.0.0}:${PORT:-9621}:9621"
+    volumes:
+      - ./data/rag_storage:/app/data/rag_storage
+      - ./data/inputs:/app/data/inputs
+      - ./config.ini:/app/config.ini
+      - ./.env:/app/.env
+    restart: on-failure:10
+    environment:
+      WORKING_DIR: "/app/data/rag_storage"
+      INPUT_DIR: "/app/data/inputs"
+      HOST: "0.0.0.0"
+      PORT: "9621"


### PR DESCRIPTION
## Summary
Add a standalone `docker-compose.podman.yml` for Podman users. The existing `docker-compose.yml` and `docker-compose-full.yml` remain unchanged — Docker users are unaffected.

## Problem
Podman fails on `docker-compose.yml` with two errors:
1. `deploy.restart_policy` — Podman does not support the `deploy` block for restart policies
2. `extra_hosts: host.docker.internal:host-gateway` — Podman cannot resolve the `host-gateway` special value, producing: `unable to replace "host-gateway" of host entry: host containers internal IP address is empty`

## Changes
- **New file: `docker-compose.podman.yml`** — standalone compose file for Podman with two fixes:
  - Uses top-level `restart: on-failure:10` instead of `deploy.restart_policy`
  - Omits `extra_hosts` with `host-gateway` (Podman auto-provides `host.containers.internal` for host access)
- **`.gitignore`** — Added `!docker-compose.podman.yml` exclusion so the new file is tracked despite the `docker-compose.*.yml` pattern that ignores setup-wizard-generated files

## Usage
```bash
podman-compose -f docker-compose.podman.yml up -d
```

When connecting to host services (LLM, embedding, rerank), use `host.containers.internal` instead of `host.docker.internal` in your `.env` binding host configuration.

## Testing
- `podman-compose -f docker-compose.podman.yml up -d` — container starts successfully
- Health check returns `{"status":"healthy"}`

## Operational Impact
No changes to existing Docker Compose workflow. This PR only adds a new file.