### PR TITLE
Add role LLM provider options logging and change role provider options to start from empty not default

### DIFF
--- a/docs/RoleSpecificLLMConfiguration-zh.md
+++ b/docs/RoleSpecificLLMConfiguration-zh.md
@@ -133,7 +133,7 @@ QUERY_LLM_MODEL=gpt-5
 - 必须设置 `{ROLE}_LLM_MODEL`。
 - 非 Bedrock provider 必须设置 `{ROLE}_LLM_BINDING_API_KEY`。
 - 如果没有设置 `{ROLE}_LLM_BINDING_HOST`，LightRAG 会尝试使用该 provider 的默认 host。
-- provider 参数不继承基础 provider options，而是从目标 provider 默认值开始，再叠加角色专属 provider options。
+- provider 参数不继承基础 provider options，而是从空配置开始，只叠加角色专属 provider options。
 
 示例：基础使用 Ollama，本地抽取；最终回答改用 OpenAI：
 
@@ -365,7 +365,7 @@ QUERY_BEDROCK_LLM_TEMPERATURE=0.2
 ## 注意事项
 
 - 同 provider 下，`OPENAI_LLM_REASONING_EFFORT`、`OPENAI_LLM_MAX_TOKENS`、`OLLAMA_LLM_NUM_CTX`、`GEMINI_LLM_THINKING_CONFIG` 等 provider 参数会自动继承。
-- 当前没有干净的角色级“取消继承某个 provider 参数”的语义。如果某个同 provider 角色模型不支持基础参数，需要为该角色显式覆盖为可用值，或将它配置成跨 provider 并使用目标 provider 默认参数。
+- 当前没有干净的角色级“取消继承某个 provider 参数”的语义。如果某个同 provider 角色模型不支持基础参数，需要为该角色显式覆盖为可用值，或将它配置成跨 provider，并且只设置该角色支持的 provider 参数。
 - `azure_openai` 的 `AZURE_OPENAI_DEPLOYMENT` 和 `AZURE_OPENAI_API_VERSION` 是全局环境变量。若设置了 `AZURE_OPENAI_DEPLOYMENT`，它可能优先于角色模型名。
 - Gemini Vertex AI 模式由进程级 Google 环境变量控制，不能在同一个 LightRAG 进程里让某些角色使用 Vertex AI、另一些角色使用 AI Studio API key。
 - `LLM_BINDING_HOST` 在 Docker/Compose 中通常需要使用容器可访问地址，例如 `host.docker.internal`，角色级 host 也遵循相同原则。

--- a/docs/RoleSpecificLLMConfiguration.md
+++ b/docs/RoleSpecificLLMConfiguration.md
@@ -133,7 +133,7 @@ If a role's `{ROLE}_LLM_BINDING` differs from the base `LLM_BINDING`, it is a cr
 - `{ROLE}_LLM_MODEL` must be set.
 - Non-Bedrock providers must set `{ROLE}_LLM_BINDING_API_KEY`.
 - If `{ROLE}_LLM_BINDING_HOST` is not set, LightRAG tries to use that provider's default host.
-- Provider options do not inherit base provider options. They start from the target provider defaults, then apply role-specific provider options.
+- Provider options do not inherit base provider options. They start empty and only apply role-specific provider options.
 
 Example: use Ollama as the base for local extraction, then use OpenAI for final answers:
 
@@ -365,7 +365,7 @@ Do not set `QUERY_LLM_BINDING_API_KEY`; Bedrock rejects that configuration.
 ## Caveats
 
 - Within the same provider, provider options such as `OPENAI_LLM_REASONING_EFFORT`, `OPENAI_LLM_MAX_TOKENS`, `OLLAMA_LLM_NUM_CTX`, and `GEMINI_LLM_THINKING_CONFIG` are inherited automatically.
-- There is currently no clean role-level semantic for "unsetting an inherited provider option". If a model in a same-provider role does not support a base option, explicitly override that option for the role with a supported value, or configure the role as cross-provider and use the target provider defaults.
+- There is currently no clean role-level semantic for "unsetting an inherited provider option". If a model in a same-provider role does not support a base option, explicitly override that option for the role with a supported value, or configure the role as cross-provider and set only the role-specific provider options it supports.
 - `AZURE_OPENAI_DEPLOYMENT` and `AZURE_OPENAI_API_VERSION` for `azure_openai` are global environment variables. If `AZURE_OPENAI_DEPLOYMENT` is set, it may take precedence over the role model name.
 - Gemini Vertex AI mode is controlled by process-level Google environment variables. In the same LightRAG process, some roles cannot use Vertex AI while others use AI Studio API keys.
 - In Docker/Compose, `LLM_BINDING_HOST` usually needs to use a container-reachable address such as `host.docker.internal`; role-level hosts follow the same principle.

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -196,6 +196,52 @@ class LLMConfigCache:
                 self.gemini_embedding_options = {}
 
 
+_PROVIDER_LOG_LABELS = {
+    "azure_openai": "Azure OpenAI",
+    "bedrock": "Bedrock",
+    "gemini": "Gemini",
+    "lollms": "Lollms",
+    "ollama": "Ollama",
+    "openai": "OpenAI",
+}
+
+
+def _provider_log_label(binding: Any) -> str:
+    binding_name = str(binding)
+    return _PROVIDER_LOG_LABELS.get(
+        binding_name, binding_name.replace("_", " ").title()
+    )
+
+
+def _log_role_provider_options(rag: Any) -> None:
+    """Log sanitized provider options for every role LLM."""
+    try:
+        role_configs = rag.get_llm_role_config()
+    except Exception as e:
+        logger.warning(f"Failed to read role LLM configuration for logging: {e}")
+        return
+
+    logger.info("Role LLM Option:")
+
+    for spec in ROLES:
+        role_config = role_configs.get(spec.name)
+        if not isinstance(role_config, dict):
+            continue
+
+        metadata = role_config.get("metadata") or {}
+        binding = role_config.get("binding") or metadata.get("binding")
+        if not binding:
+            continue
+
+        provider_options = metadata.get("provider_options") or {}
+        logger.info(
+            " - %s: %s %s",
+            spec.name,
+            _provider_log_label(binding),
+            provider_options,
+        )
+
+
 def check_frontend_build():
     """Check if frontend is built and optionally check if source is up-to-date
 
@@ -1485,6 +1531,8 @@ def create_app(args):
     except Exception as e:
         logger.error(f"Failed to initialize LightRAG: {e}")
         raise
+
+    _log_role_provider_options(rag)
 
     rag.register_role_llm_builder(
         lambda role, meta: (

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1300,7 +1300,7 @@ class LightRAG:
         for role_name in role_names:
             cfg = configs[role_name]
             logger.info(
-                " - %s: binding=%s, model=%s, host=%s, max_async=%s, timeout=%s",
+                " - %s: %s/%s, host=%s, max_async=%s, timeout=%s",
                 role_name,
                 cfg["binding"],
                 cfg["model"],

--- a/lightrag/llm/binding_options.py
+++ b/lightrag/llm/binding_options.py
@@ -354,28 +354,17 @@ class BindingOptions:
         - overlay any role-specific environment variable overrides
 
         Cross provider:
-        - start from the provider defaults
+        - start from empty provider options
         - overlay any role-specific environment variable overrides
 
         Role env vars follow the pattern:
         `{ROLE}_{BINDING_PREFIX}_{FIELD}`
         e.g. `EXTRACT_OPENAI_LLM_TEMPERATURE`
         """
-        import dataclasses
         import os
 
         if is_cross_provider:
-            if dataclasses.is_dataclass(cls):
-                base: dict[str, Any] = {}
-                for dataclass_field in dataclasses.fields(cls):
-                    if dataclass_field.name.startswith("_"):
-                        continue
-                    if dataclass_field.default is not dataclasses.MISSING:
-                        base[dataclass_field.name] = dataclass_field.default
-                    elif dataclass_field.default_factory is not dataclasses.MISSING:
-                        base[dataclass_field.name] = dataclass_field.default_factory()
-            else:
-                base = dict(cls._all_class_vars(cls))
+            base: dict[str, Any] = {}
         else:
             base = cls.options_dict(args)
 

--- a/tests/test_bedrock_llm.py
+++ b/tests/test_bedrock_llm.py
@@ -1,4 +1,5 @@
 import importlib
+import logging
 import os
 import sys
 from types import SimpleNamespace
@@ -450,6 +451,18 @@ class _FakeLightRAG:
         type(self).last_init_kwargs = dict(kwargs)
         type(self).last_instance = self
         self.role_config_snapshot = {}
+        for role, cfg in (kwargs.get("role_llm_configs") or {}).items():
+            metadata = dict(getattr(cfg, "metadata", None) or {})
+            self.role_config_snapshot[role] = {
+                "binding": metadata.get("binding"),
+                "model": metadata.get("model"),
+                "host": metadata.get("host"),
+                "is_cross_provider": metadata.get("is_cross_provider", False),
+                "max_async": getattr(cfg, "max_async", None),
+                "timeout": getattr(cfg, "timeout", None),
+                "has_model_kwargs": getattr(cfg, "kwargs", None) is not None,
+                "metadata": metadata,
+            }
         self.queue_status_snapshot = {}
         self.embedding_queue_status_snapshot = {}
         self.rerank_queue_status_snapshot = {}
@@ -649,6 +662,84 @@ async def test_create_app_bedrock_query_role_uses_role_sigv4_credentials(
     assert mocked_bedrock.await_args.kwargs["aws_access_key_id"] == "query-akid"
     assert mocked_bedrock.await_args.kwargs["aws_secret_access_key"] == "query-secret"
     assert mocked_bedrock.await_args.kwargs["aws_session_token"] == "query-session"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_create_app_keyword_openai_role_forwards_nested_extra_body(
+    tmp_path, monkeypatch, caplog
+):
+    _reload_api_modules_if_mocked()
+    monkeypatch.setattr(sys, "argv", ["pytest"])
+    monkeypatch.setattr(logging.getLogger("lightrag"), "propagate", True)
+    monkeypatch.setenv(
+        "KEYWORD_OPENAI_LLM_EXTRA_BODY",
+        '{"chat_template_kwargs": {"enable_thinking": false}}',
+    )
+
+    config = importlib.import_module("lightrag.api.config")
+    config.initialize_config(_make_args(tmp_path), force=True)
+    lightrag_server = importlib.import_module("lightrag.api.lightrag_server")
+    monkeypatch.setattr(lightrag_server, "LightRAG", _FakeLightRAG)
+    monkeypatch.setattr(lightrag_server, "check_frontend_build", lambda: (True, False))
+    monkeypatch.setattr(
+        lightrag_server, "create_document_routes", lambda *_args, **_kwargs: APIRouter()
+    )
+    monkeypatch.setattr(
+        lightrag_server, "create_query_routes", lambda *_args, **_kwargs: APIRouter()
+    )
+    monkeypatch.setattr(
+        lightrag_server, "create_graph_routes", lambda *_args, **_kwargs: APIRouter()
+    )
+    monkeypatch.setattr(lightrag_server, "OllamaAPI", _FakeOllamaAPI)
+
+    args = _make_args(tmp_path)
+    args.keyword_llm_binding = "openai"
+    args.keyword_llm_model = "xhd/Qwen3.5-35B-A3B"
+    args.keyword_llm_binding_host = "https://keyword.example/v1"
+    args.keyword_llm_binding_api_key = "keyword-secret"
+
+    with (
+        caplog.at_level("INFO", logger="lightrag"),
+        patch(
+            "lightrag.llm.openai.openai_complete_if_cache",
+            AsyncMock(
+                return_value='{"high_level_keywords":[],"low_level_keywords":[]}'
+            ),
+        ) as mocked_openai,
+    ):
+        lightrag_server.create_app(args)
+        keyword_cfg = _FakeLightRAG.last_init_kwargs["role_llm_configs"]["keyword"]
+        result = await keyword_cfg.func(
+            "keyword prompt", response_format={"type": "json_object"}
+        )
+
+    assert result == '{"high_level_keywords":[],"low_level_keywords":[]}'
+    assert keyword_cfg.metadata["binding"] == "openai"
+    assert keyword_cfg.metadata["provider_options"]["extra_body"] == {
+        "chat_template_kwargs": {"enable_thinking": False}
+    }
+    assert mocked_openai.await_count == 1
+    assert mocked_openai.await_args.args[:2] == (
+        "xhd/Qwen3.5-35B-A3B",
+        "keyword prompt",
+    )
+    kwargs = mocked_openai.await_args.kwargs
+    assert kwargs["base_url"] == "https://keyword.example/v1"
+    assert kwargs["api_key"] == "keyword-secret"
+    assert kwargs["response_format"] == {"type": "json_object"}
+    assert kwargs["extra_body"] == {"chat_template_kwargs": {"enable_thinking": False}}
+
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "Role LLM Option:" in messages
+    assert " - extract: Bedrock {}" in messages
+    assert " - keyword: OpenAI {'extra_body':" in messages
+    assert " - query: Bedrock {}" in messages
+    assert " - vlm: Bedrock {}" in messages
+    assert "chat_template_kwargs" in messages
+    assert "reasoning_effort" not in messages
+    assert "frequency_penalty" not in messages
+    assert "keyword-secret" not in messages
 
 
 @pytest.mark.offline

--- a/tests/test_llm_role_runtime.py
+++ b/tests/test_llm_role_runtime.py
@@ -105,6 +105,11 @@ def _role_config_headers(caplog) -> list[str]:
     ]
 
 
+def _clear_role_provider_env(monkeypatch, role: str, options_cls) -> None:
+    for arg_item in options_cls.args_env_name_type_value():
+        monkeypatch.delenv(f"{role.upper()}_{arg_item['env_name']}", raising=False)
+
+
 ROLE_MAX_ASYNC_ENV_KEYS = (
     "MAX_ASYNC_EXTRACT_LLM",
     "MAX_ASYNC_KEYWORD_LLM",
@@ -343,7 +348,7 @@ def test_role_llm_config_logs_once_on_init_with_metadata(
     assert len(headers) == 1
     assert "initialized" in headers[0]
     messages = "\n".join(_captured_messages(caplog))
-    assert " - query: binding=openai, model=gpt-test" in messages
+    assert " - query: openai/gpt-test" in messages
     assert "max_async=7" in messages
     assert "timeout=42" in messages
     assert "secret-key" not in messages
@@ -654,7 +659,7 @@ def test_update_llm_role_config_logs_after_success(
     assert len(headers) == 1
     assert "updated: query" in headers[0]
     messages = "\n".join(_captured_messages(caplog))
-    assert " - query: binding=gemini, model=gemini-2.0-flash" in messages
+    assert " - query: gemini/gemini-2.0-flash" in messages
     assert "host=https://gemini.example/v1" in messages
     assert "is_cross_provider" not in messages
     assert "new-secret" not in messages
@@ -694,7 +699,7 @@ async def test_aupdate_llm_role_config_logs_after_success(
     assert len(headers) == 1
     assert "updated: query" in headers[0]
     messages = "\n".join(_captured_messages(caplog))
-    assert " - query: binding=openai, model=old-model" in messages
+    assert " - query: openai/old-model" in messages
     assert "max_async=2" in messages
     assert "timeout=180" in messages
 
@@ -909,6 +914,7 @@ def test_options_dict_for_role_inherits_same_provider(monkeypatch):
         openai_llm_top_p=0.8,
         openai_llm_extra_body={"base": True},
     )
+    _clear_role_provider_env(monkeypatch, "extract", OpenAILLMOptions)
     monkeypatch.setenv("EXTRACT_OPENAI_LLM_TEMPERATURE", "0.7")
 
     options = OpenAILLMOptions.options_dict_for_role(args, "extract")
@@ -924,16 +930,29 @@ def test_options_dict_for_role_resets_cross_provider(monkeypatch):
         openai_llm_top_p=0.8,
         openai_llm_extra_body={"base": True},
     )
-    default_options = OpenAILLMOptions().asdict()
+    _clear_role_provider_env(monkeypatch, "query", OpenAILLMOptions)
     monkeypatch.setenv("QUERY_OPENAI_LLM_TOP_P", "0.6")
 
     options = OpenAILLMOptions.options_dict_for_role(
         args, "query", is_cross_provider=True
     )
 
-    assert options["temperature"] == default_options["temperature"]
-    assert options["top_p"] == 0.6
-    assert options["extra_body"] == default_options["extra_body"]
+    assert options == {"top_p": 0.6}
+
+
+def test_options_dict_for_role_parses_nested_extra_body_cross_provider(monkeypatch):
+    args = Namespace(openai_llm_extra_body={"base": True})
+    _clear_role_provider_env(monkeypatch, "keyword", OpenAILLMOptions)
+    monkeypatch.setenv(
+        "KEYWORD_OPENAI_LLM_EXTRA_BODY",
+        '{"chat_template_kwargs": {"enable_thinking": false}}',
+    )
+
+    options = OpenAILLMOptions.options_dict_for_role(
+        args, "keyword", is_cross_provider=True
+    )
+
+    assert options["extra_body"] == {"chat_template_kwargs": {"enable_thinking": False}}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Add role-level provider options logging and align cross-provider role option handling so only explicitly configured role options are forwarded.

## Related Issues

n/a

## Changes Made

- Add sanitized role LLM provider option logging after LightRAG initialization.
- Change cross-provider role provider options to start empty instead of injecting provider dataclass defaults.
- Update role-specific LLM configuration docs in English and Chinese.
- Add regression tests for nested OpenAI `extra_body` forwarding and role env isolation.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Validated with targeted role runtime and API initialization tests, plus ruff checks for the changed Python files.
