### PR TITLE
Fix bedrock/gemini host leak from env.example on make server/storage

### DIFF
--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -151,6 +151,28 @@ normalize_vllm_rerank_binding_state() {
   fi
 }
 
+# Backfill sentinel hosts for bedrock/gemini bindings when LLM_BINDING_HOST or
+# EMBEDDING_BINDING_HOST is missing or empty. Flows that skip collect_llm_config /
+# collect_embedding_config (--server, --storage) would otherwise let the openai URL
+# hardcoded in env.example leak into the regenerated .env.
+normalize_provider_binding_hosts() {
+  local llm_sentinel="" embedding_sentinel=""
+  case "${ENV_VALUES[LLM_BINDING]:-}" in
+    bedrock) llm_sentinel="DEFAULT_BEDROCK_ENDPOINT" ;;
+    gemini) llm_sentinel="DEFAULT_GEMINI_ENDPOINT" ;;
+  esac
+  case "${ENV_VALUES[EMBEDDING_BINDING]:-}" in
+    bedrock) embedding_sentinel="DEFAULT_BEDROCK_ENDPOINT" ;;
+    gemini) embedding_sentinel="DEFAULT_GEMINI_ENDPOINT" ;;
+  esac
+  if [[ -n "$llm_sentinel" && -z "${ENV_VALUES[LLM_BINDING_HOST]:-}" ]]; then
+    ENV_VALUES["LLM_BINDING_HOST"]="$llm_sentinel"
+  fi
+  if [[ -n "$embedding_sentinel" && -z "${ENV_VALUES[EMBEDDING_BINDING_HOST]:-}" ]]; then
+    ENV_VALUES["EMBEDDING_BINDING_HOST"]="$embedding_sentinel"
+  fi
+}
+
 load_existing_env_if_present() {
   local env_file="${REPO_ROOT}/.env"
 
@@ -159,6 +181,7 @@ load_existing_env_if_present() {
     load_env_file "$env_file"
     clear_deprecated_vllm_dtype_state
     normalize_vllm_rerank_binding_state
+    normalize_provider_binding_hosts
     if [[ "${ENV_VALUES[SSL]:-false}" == "true" ]]; then
       SSL_CERT_SOURCE_PATH="${ENV_VALUES[SSL_CERTFILE]:-}"
       SSL_KEY_SOURCE_PATH="${ENV_VALUES[SSL_KEYFILE]:-}"

--- a/tests/test_interactive_setup/test_misc.py
+++ b/tests/test_interactive_setup/test_misc.py
@@ -357,6 +357,63 @@ printf 'LIGHTRAG_SETUP_RERANK_PROVIDER=%s\\n' "${{ENV_VALUES[LIGHTRAG_SETUP_RERA
     assert values["LIGHTRAG_SETUP_RERANK_PROVIDER"] == "vllm"
 
 
+@pytest.mark.parametrize(
+    ("llm_binding", "embedding_binding", "expected_llm_host", "expected_embed_host"),
+    [
+        ("bedrock", "bedrock", "DEFAULT_BEDROCK_ENDPOINT", "DEFAULT_BEDROCK_ENDPOINT"),
+        ("gemini", "gemini", "DEFAULT_GEMINI_ENDPOINT", "DEFAULT_GEMINI_ENDPOINT"),
+        ("bedrock", "openai", "DEFAULT_BEDROCK_ENDPOINT", ""),
+    ],
+    ids=["bedrock-both", "gemini-both", "bedrock-llm-only"],
+)
+def test_load_existing_env_backfills_sentinel_hosts_for_bedrock_and_gemini(
+    tmp_path: Path,
+    llm_binding: str,
+    embedding_binding: str,
+    expected_llm_host: str,
+    expected_embed_host: str,
+) -> None:
+    """Flows that skip collect_*_config (--server, --storage) must not let env.example's openai URL leak through for sentinel-based providers."""
+    write_text_lines(
+        tmp_path / ".env",
+        [
+            f"LLM_BINDING={llm_binding}",
+            f"EMBEDDING_BINDING={embedding_binding}",
+        ],
+    )
+    write_text_lines(
+        tmp_path / "env.example",
+        (REPO_ROOT / "env.example").read_text(encoding="utf-8").splitlines(),
+    )
+    values = run_bash_lines(f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+reset_state
+load_existing_env_if_present
+generate_env_file "$REPO_ROOT/env.example" "$REPO_ROOT/.env.generated"
+
+printf 'LOADED_LLM_HOST=%s\\n' "${{ENV_VALUES[LLM_BINDING_HOST]:-}}"
+printf 'LOADED_EMBED_HOST=%s\\n' "${{ENV_VALUES[EMBEDDING_BINDING_HOST]:-}}\"
+""")
+    assert values["LOADED_LLM_HOST"] == expected_llm_host
+    generated_lines = (
+        (tmp_path / ".env.generated").read_text(encoding="utf-8").splitlines()
+    )
+    llm_host_line = next(
+        line for line in generated_lines if line.startswith("LLM_BINDING_HOST=")
+    )
+    assert llm_host_line == f"LLM_BINDING_HOST={expected_llm_host}"
+    if expected_embed_host:
+        assert values["LOADED_EMBED_HOST"] == expected_embed_host
+        embed_host_line = next(
+            line
+            for line in generated_lines
+            if line.startswith("EMBEDDING_BINDING_HOST=")
+        )
+        assert embed_host_line == f"EMBEDDING_BINDING_HOST={expected_embed_host}"
+
+
 def test_finalize_base_setup_uses_compose_native_storage_endpoints_on_rerun(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- `make server` / `make storage` reload the existing `.env` and run `generate_env_file` against `env.example`, but **skip** `collect_llm_config` / `collect_embedding_config`. When an existing `.env` had `LLM_BINDING=bedrock` (or `gemini`) without an `LLM_BINDING_HOST` line, `ENV_VALUES[LLM_BINDING_HOST]` stayed unset and `generate_env_file` preserved the template's uncommented `LLM_BINDING_HOST=https://api.openai.com/v1` line — leaking the OpenAI URL into a Bedrock/Gemini configuration.
- Fix: add `normalize_provider_binding_hosts` and call it from `load_existing_env_if_present` to backfill `DEFAULT_BEDROCK_ENDPOINT` / `DEFAULT_GEMINI_ENDPOINT` when the binding is sentinel-based and the host is missing/empty. Same pattern for `EMBEDDING_BINDING_HOST`.
- The base flow (`collect_llm_config` / `collect_embedding_config`) is unaffected: `provider_default_or_existing` already preserves an explicit user-set host when the binding is unchanged, and treats the sentinel as a valid existing value.

## Test plan

- [x] New parametrized regression test `test_load_existing_env_backfills_sentinel_hosts_for_bedrock_and_gemini` covers bedrock-both, gemini-both, and bedrock-LLM-only scenarios. Verifies both `ENV_VALUES` after load and the regenerated `.env` line.
- [x] Full `tests/test_interactive_setup/` suite passes (254 tests).
- [x] Manual repro on `make server` flow with `LLM_BINDING=bedrock` and missing `LLM_BINDING_HOST` now writes `LLM_BINDING_HOST=DEFAULT_BEDROCK_ENDPOINT` (was `https://api.openai.com/v1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)