### PR TITLE
Improve DOCX parsing idempotency

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -2210,6 +2210,8 @@ def create_document_routes(
 
         1. **Filename Duplicate (Synchronous Detection)**:
            - Detected immediately before file processing
+           - File name is treated as the unique document key; an existing
+             document storage row rejects the upload regardless of status
            - Returns `status="duplicated"` with the existing document's track_id
            - Two cases:
              - If filename exists in document storage: returns existing track_id

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -30,6 +30,7 @@ from lightrag.utils import (
     generate_track_id,
     compute_mdhash_id,
     sanitize_text_for_encoding,
+    move_file_to_parsed_dir,
 )
 from lightrag.api.utils_api import get_combined_auth_dependency
 from ..config import global_args
@@ -937,56 +938,6 @@ def validate_file_path_security(file_path_str: str, base_dir: Path) -> Optional[
         return None
 
 
-def get_unique_filename_in_enqueued(target_dir: Path, original_name: str) -> str:
-    """Generate a unique filename in the target directory by adding numeric suffixes if needed
-
-    Args:
-        target_dir: Target directory path
-        original_name: Original filename
-
-    Returns:
-        str: Unique filename (may have numeric suffix added)
-    """
-    import time
-
-    original_path = Path(original_name)
-    base_name = original_path.stem
-    extension = original_path.suffix
-
-    # Try original name first
-    if not (target_dir / original_name).exists():
-        return original_name
-
-    # Try with numeric suffixes 001-999
-    for i in range(1, 1000):
-        suffix = f"{i:03d}"
-        new_name = f"{base_name}_{suffix}{extension}"
-        if not (target_dir / new_name).exists():
-            return new_name
-
-    # Fallback with timestamp if all 999 slots are taken
-    timestamp = int(time.time())
-    return f"{base_name}_{timestamp}{extension}"
-
-
-async def move_file_to_parsed_dir(file_path: Path) -> Path | None:
-    """Move a processed source file into its sibling __parsed__ directory."""
-    if not file_path.exists():
-        return None
-
-    parsed_dir = file_path.parent / PARSED_DIR_NAME
-    await asyncio.to_thread(parsed_dir.mkdir, exist_ok=True)
-
-    unique_filename = get_unique_filename_in_enqueued(parsed_dir, file_path.name)
-    target_path = parsed_dir / unique_filename
-
-    await asyncio.to_thread(file_path.rename, target_path)
-    logger.debug(
-        f"Moved file to parsed directory: {file_path.name} -> {unique_filename}"
-    )
-    return target_path
-
-
 def get_doc_status_value(doc_status: Any) -> str:
     """Read status from dict or DocProcessingStatus-like objects."""
     status = (
@@ -1019,11 +970,12 @@ def build_file_path_lookup_candidates(file_path: Path | str) -> list[str]:
         pass
 
     seen: set[str] = set()
-    return [
-        candidate
-        for candidate in candidates
-        if candidate and not (candidate in seen or seen.add(candidate))
-    ]
+    unique: list[str] = []
+    for candidate in candidates:
+        if candidate and candidate not in seen:
+            seen.add(candidate)
+            unique.append(candidate)
+    return unique
 
 
 async def get_existing_doc_by_file_path_candidates(

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -969,6 +969,82 @@ def get_unique_filename_in_enqueued(target_dir: Path, original_name: str) -> str
     return f"{base_name}_{timestamp}{extension}"
 
 
+async def move_file_to_parsed_dir(file_path: Path) -> Path | None:
+    """Move a processed source file into its sibling __parsed__ directory."""
+    if not file_path.exists():
+        return None
+
+    parsed_dir = file_path.parent / PARSED_DIR_NAME
+    await asyncio.to_thread(parsed_dir.mkdir, exist_ok=True)
+
+    unique_filename = get_unique_filename_in_enqueued(parsed_dir, file_path.name)
+    target_path = parsed_dir / unique_filename
+
+    await asyncio.to_thread(file_path.rename, target_path)
+    logger.debug(
+        f"Moved file to parsed directory: {file_path.name} -> {unique_filename}"
+    )
+    return target_path
+
+
+def get_doc_status_value(doc_status: Any) -> str:
+    """Read status from dict or DocProcessingStatus-like objects."""
+    status = (
+        doc_status.get("status")
+        if isinstance(doc_status, dict)
+        else getattr(doc_status, "status", None)
+    )
+    if isinstance(status, DocStatus):
+        return status.value
+    return str(status or "")
+
+
+def get_doc_track_id(doc_status: Any) -> str:
+    """Read track_id from dict or DocProcessingStatus-like objects."""
+    track_id = (
+        doc_status.get("track_id")
+        if isinstance(doc_status, dict)
+        else getattr(doc_status, "track_id", None)
+    )
+    return str(track_id or "")
+
+
+async def move_docx_to_parsed_after_processing(
+    rag: LightRAG, file_path: Path, track_id: str | None
+) -> None:
+    """Archive a DOCX source file only after this pipeline run processed it."""
+    if file_path.suffix.lower() != ".docx":
+        return
+
+    doc_id = compute_mdhash_id(str(file_path), prefix="doc-")
+    doc_status = await rag.doc_status.get_by_id(doc_id)
+    if not doc_status:
+        logger.debug(
+            f"Skipping DOCX archive for {file_path.name}: no document status found"
+        )
+        return
+
+    status = get_doc_status_value(doc_status)
+    status_track_id = get_doc_track_id(doc_status)
+    if status != DocStatus.PROCESSED.value:
+        logger.debug(
+            f"Skipping DOCX archive for {file_path.name}: document status is {status}"
+        )
+        return
+    if track_id and status_track_id and status_track_id != track_id:
+        logger.debug(
+            f"Skipping DOCX archive for {file_path.name}: track_id does not match current run"
+        )
+        return
+
+    try:
+        await move_file_to_parsed_dir(file_path)
+    except Exception as move_error:
+        logger.error(
+            f"Failed to move file {file_path.name} to {PARSED_DIR_NAME} directory: {move_error}"
+        )
+
+
 # Document processing helper functions (synchronous)
 # These functions run in thread pool via asyncio.to_thread() to avoid blocking the event loop
 
@@ -1614,21 +1690,7 @@ async def pipeline_enqueue_file(
 
                 # Move file to __parsed__ directory after enqueuing (LR2-PRD: parsed output dir)
                 try:
-                    enqueued_dir = file_path.parent / PARSED_DIR_NAME
-                    await asyncio.to_thread(enqueued_dir.mkdir, exist_ok=True)
-
-                    # Generate unique filename to avoid conflicts
-                    unique_filename = get_unique_filename_in_enqueued(
-                        enqueued_dir, file_path.name
-                    )
-                    target_path = enqueued_dir / unique_filename
-
-                    # Move the file
-                    await asyncio.to_thread(file_path.rename, target_path)
-                    logger.debug(
-                        f"Moved file to enqueued directory: {file_path.name} -> {unique_filename}"
-                    )
-
+                    await move_file_to_parsed_dir(file_path)
                 except Exception as move_error:
                     logger.error(
                         f"Failed to move file {file_path.name} to {PARSED_DIR_NAME} directory: {move_error}"
@@ -1703,6 +1765,9 @@ async def pipeline_index_file(rag: LightRAG, file_path: Path, track_id: str = No
         )
         if success:
             await rag.apipeline_process_enqueue_documents()
+            await move_docx_to_parsed_after_processing(
+                rag, file_path, returned_track_id
+            )
 
     except Exception as e:
         logger.error(f"Error indexing file {file_path.name}: {str(e)}")
@@ -1723,6 +1788,7 @@ async def pipeline_index_files(
         return
     try:
         enqueued = False
+        enqueued_docx_files: list[tuple[Path, str]] = []
 
         # Use get_pinyin_sort_key for Chinese pinyin sorting
         sorted_file_paths = sorted(
@@ -1731,13 +1797,21 @@ async def pipeline_index_files(
 
         # Process files sequentially with track_id
         for file_path in sorted_file_paths:
-            success, _ = await pipeline_enqueue_file(rag, file_path, track_id)
+            success, returned_track_id = await pipeline_enqueue_file(
+                rag, file_path, track_id
+            )
             if success:
                 enqueued = True
+                if file_path.suffix.lower() == ".docx":
+                    enqueued_docx_files.append((file_path, returned_track_id))
 
         # Process the queue only if at least one file was successfully enqueued
         if enqueued:
             await rag.apipeline_process_enqueue_documents()
+            for docx_file_path, returned_track_id in enqueued_docx_files:
+                await move_docx_to_parsed_after_processing(
+                    rag, docx_file_path, returned_track_id
+                )
     except Exception as e:
         logger.error(f"Error indexing files: {str(e)}")
         logger.error(traceback.format_exc())

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -1009,6 +1009,34 @@ def get_doc_track_id(doc_status: Any) -> str:
     return str(track_id or "")
 
 
+def build_file_path_lookup_candidates(file_path: Path | str) -> list[str]:
+    """Build compatible file_path keys for legacy name/full-path records."""
+    path = Path(file_path)
+    candidates = [path.name, str(path)]
+    try:
+        candidates.append(str(path.resolve()))
+    except Exception:
+        pass
+
+    seen: set[str] = set()
+    return [
+        candidate
+        for candidate in candidates
+        if candidate and not (candidate in seen or seen.add(candidate))
+    ]
+
+
+async def get_existing_doc_by_file_path_candidates(
+    doc_status: Any, file_path: Path | str
+) -> dict[str, Any] | None:
+    """Find an existing document using filename and full-path variants."""
+    for candidate in build_file_path_lookup_candidates(file_path):
+        existing_doc_data = await doc_status.get_doc_by_file_path(candidate)
+        if existing_doc_data:
+            return existing_doc_data
+    return None
+
+
 async def move_docx_to_parsed_after_processing(
     rag: LightRAG, file_path: Path, track_id: str | None
 ) -> None:
@@ -1871,15 +1899,27 @@ async def run_scanning_process(
             # Check for files with PROCESSED status and filter them out
             valid_files = []
             processed_files = []
+            queued_existing_files = []
 
             for file_path in new_files:
                 filename = file_path.name
-                existing_doc_data = await rag.doc_status.get_doc_by_file_path(filename)
+                existing_doc_data = await get_existing_doc_by_file_path_candidates(
+                    rag.doc_status, file_path
+                )
 
-                if existing_doc_data and existing_doc_data.get("status") == "processed":
+                if (
+                    existing_doc_data
+                    and get_doc_status_value(existing_doc_data)
+                    == DocStatus.PROCESSED.value
+                ):
                     # File is already PROCESSED, skip it with warning
                     processed_files.append(filename)
                     logger.warning(f"Skipping already processed file: {filename}")
+                elif existing_doc_data:
+                    queued_existing_files.append(filename)
+                    logger.info(
+                        f"Skipping already enqueued file and continuing existing pipeline state: {filename}"
+                    )
                 else:
                     # File is new or in non-PROCESSED status, add to processing list
                     valid_files.append(file_path)
@@ -1899,6 +1939,8 @@ async def run_scanning_process(
                 logger.info(
                     "No files to process after filtering already processed files."
                 )
+                if queued_existing_files:
+                    await rag.apipeline_process_enqueue_documents()
         else:
             # No new files to index, check if there are any documents in the queue
             logger.info(
@@ -2280,20 +2322,23 @@ def create_document_routes(
                         f"File size not available in UploadFile for {safe_filename}, will check during streaming"
                     )
 
+            file_path = doc_manager.input_dir / safe_filename
+
             # Check if filename already exists in doc_status storage
-            existing_doc_data = await rag.doc_status.get_doc_by_file_path(safe_filename)
+            existing_doc_data = await get_existing_doc_by_file_path_candidates(
+                rag.doc_status, file_path
+            )
             if existing_doc_data:
                 # Get document status and track_id from existing document
-                status = existing_doc_data.get("status", "unknown")
+                status = get_doc_status_value(existing_doc_data) or "unknown"
                 # Use `or ""` to handle both missing key and None value (e.g., legacy rows without track_id)
-                existing_track_id = existing_doc_data.get("track_id") or ""
+                existing_track_id = get_doc_track_id(existing_doc_data)
                 return InsertResponse(
                     status="duplicated",
                     message=f"File '{safe_filename}' already exists in document storage (Status: {status}).",
                     track_id=existing_track_id,
                 )
 
-            file_path = doc_manager.input_dir / safe_filename
             # Check if file already exists in file system
             if file_path.exists():
                 return InsertResponse(

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -4462,9 +4462,7 @@ class LightRAG:
         if source.suffix.lower() != ".docx":
             return None
         try:
-            target = await move_file_to_parsed_dir(
-                source, skip_if_already_parsed=True
-            )
+            target = await move_file_to_parsed_dir(source, skip_if_already_parsed=True)
         except Exception as e:
             logger.warning(
                 f"[parse] DOCX source archive skipped after full_docs sync: {source_path}: {e}"

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -4151,6 +4151,12 @@ class LightRAG:
     def _resolve_parser_engine(
         self, file_path: str, content_data: dict[str, Any]
     ) -> str:
+        doc_format = content_data.get("format", FULL_DOCS_FORMAT_RAW)
+        if doc_format == FULL_DOCS_FORMAT_LIGHTRAG and content_data.get(
+            "lightrag_document_path"
+        ):
+            return "native"
+
         explicit_engine = str(content_data.get("parsed_engine") or "").strip().lower()
         if explicit_engine in {"native", "mineru", "docling"}:
             return explicit_engine
@@ -4448,12 +4454,54 @@ class LightRAG:
                 return str(candidate)
         return file_path
 
+    def _get_unique_filename_in_parsed_dir(
+        self, target_dir: Path, original_name: str
+    ) -> str:
+        original_path = Path(original_name)
+        base_name = original_path.stem
+        extension = original_path.suffix
+
+        if not (target_dir / original_name).exists():
+            return original_name
+
+        for i in range(1, 1000):
+            suffix = f"{i:03d}"
+            new_name = f"{base_name}_{suffix}{extension}"
+            if not (target_dir / new_name).exists():
+                return new_name
+
+        timestamp = int(time.time())
+        return f"{base_name}_{timestamp}{extension}"
+
+    async def _archive_docx_source_after_full_docs_sync(
+        self, source_path: str
+    ) -> str | None:
+        source = Path(source_path)
+        if source.suffix.lower() != ".docx":
+            return None
+        if not source.exists() or not source.is_file():
+            return None
+        if source.parent.name == PARSED_DIR_NAME:
+            return str(source)
+
+        parsed_dir = source.parent / PARSED_DIR_NAME
+        await asyncio.to_thread(parsed_dir.mkdir, parents=True, exist_ok=True)
+
+        target_name = self._get_unique_filename_in_parsed_dir(parsed_dir, source.name)
+        target_path = parsed_dir / target_name
+        await asyncio.to_thread(source.rename, target_path)
+        logger.debug(
+            f"[parse] Archived DOCX source after full_docs sync: {source} -> {target_path}"
+        )
+        return str(target_path)
+
     async def _write_lightrag_document_from_content_list(
         self,
         doc_id: str,
         file_path: str,
         content_list: list[dict[str, Any]],
         engine: str,
+        source_path: str | None = None,
     ) -> dict[str, Any]:
         """Convert parser content list to LightRAG Document files and return parsed_data."""
         parsed_dir = Path(self.working_dir) / PARSED_DIR_NAME
@@ -4851,6 +4899,10 @@ class LightRAG:
                 }
             }
         )
+        await self.full_docs.index_done_callback()
+        await self._archive_docx_source_after_full_docs_sync(
+            source_path or self._resolve_source_file_for_parser(file_path)
+        )
         return {
             "doc_id": doc_id,
             "file_path": file_path,
@@ -4923,10 +4975,13 @@ class LightRAG:
                                     "content": interchange_text,
                                     "file_path": file_path,
                                     "format": FULL_DOCS_FORMAT_RAW,
+                                    "parsed_engine": "native",
                                     "update_time": int(time.time()),
                                 }
                             }
                         )
+                        await self.full_docs.index_done_callback()
+                        await self._archive_docx_source_after_full_docs_sync(str(p))
                         logger.info(
                             f"[parse_native] pending_parse completed for {file_path} via interchange JSONL"
                         )
@@ -4953,10 +5008,13 @@ class LightRAG:
                                 "content": content,
                                 "file_path": file_path,
                                 "format": FULL_DOCS_FORMAT_RAW,
+                                "parsed_engine": "native",
                                 "update_time": int(time.time()),
                             }
                         }
                     )
+                    await self.full_docs.index_done_callback()
+                    await self._archive_docx_source_after_full_docs_sync(str(p))
                     return {
                         "doc_id": doc_id,
                         "file_path": file_path,
@@ -5029,8 +5087,25 @@ class LightRAG:
                         file_path=file_path,
                         content_list=content_list,
                         engine="mineru",
+                        source_path=source_file_path,
                     )
                 if result_text:
+                    await self.full_docs.upsert(
+                        {
+                            doc_id: {
+                                "content": str(result_text),
+                                "file_path": file_path,
+                                "format": FULL_DOCS_FORMAT_RAW,
+                                "parsed_engine": "native",
+                                "source_parsed_engine": "mineru",
+                                "update_time": int(time.time()),
+                            }
+                        }
+                    )
+                    await self.full_docs.index_done_callback()
+                    await self._archive_docx_source_after_full_docs_sync(
+                        source_file_path
+                    )
                     return {
                         "doc_id": doc_id,
                         "file_path": file_path,
@@ -5051,6 +5126,7 @@ class LightRAG:
                 file_path=file_path,
                 content_list=raganything_content_list,
                 engine="mineru",
+                source_path=self._resolve_source_file_for_parser(file_path),
             )
 
         return await self.parse_native(doc_id, file_path, content_data)
@@ -5100,8 +5176,25 @@ class LightRAG:
                         file_path=file_path,
                         content_list=content_list,
                         engine="docling",
+                        source_path=source_file_path,
                     )
                 if result_text:
+                    await self.full_docs.upsert(
+                        {
+                            doc_id: {
+                                "content": str(result_text),
+                                "file_path": file_path,
+                                "format": FULL_DOCS_FORMAT_RAW,
+                                "parsed_engine": "native",
+                                "source_parsed_engine": "docling",
+                                "update_time": int(time.time()),
+                            }
+                        }
+                    )
+                    await self.full_docs.index_done_callback()
+                    await self._archive_docx_source_after_full_docs_sync(
+                        source_file_path
+                    )
                     return {
                         "doc_id": doc_id,
                         "file_path": file_path,
@@ -5122,6 +5215,7 @@ class LightRAG:
                 file_path=file_path,
                 content_list=raganything_content_list,
                 engine="docling",
+                source_path=self._resolve_source_file_for_parser(file_path),
             )
 
         return await self.parse_native(doc_id, file_path, content_data)

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -139,6 +139,7 @@ from lightrag.utils import (
     subtract_source_ids,
     make_relation_chunk_key,
     normalize_source_ids_limit_method,
+    move_file_to_parsed_dir,
 )
 from lightrag.types import KnowledgeGraph
 from dotenv import load_dotenv
@@ -4454,54 +4455,28 @@ class LightRAG:
                 return str(candidate)
         return file_path
 
-    def _get_unique_filename_in_parsed_dir(
-        self, target_dir: Path, original_name: str
-    ) -> str:
-        original_path = Path(original_name)
-        base_name = original_path.stem
-        extension = original_path.suffix
-
-        if not (target_dir / original_name).exists():
-            return original_name
-
-        for i in range(1, 1000):
-            suffix = f"{i:03d}"
-            new_name = f"{base_name}_{suffix}{extension}"
-            if not (target_dir / new_name).exists():
-                return new_name
-
-        timestamp = int(time.time())
-        return f"{base_name}_{timestamp}{extension}"
-
     async def _archive_docx_source_after_full_docs_sync(
         self, source_path: str
     ) -> str | None:
+        source = Path(source_path)
+        if source.suffix.lower() != ".docx":
+            return None
         try:
-            source = Path(source_path)
-            if source.suffix.lower() != ".docx":
-                return None
-            if not source.exists() or not source.is_file():
-                return None
-            if source.parent.name == PARSED_DIR_NAME:
-                return str(source)
-
-            parsed_dir = source.parent / PARSED_DIR_NAME
-            await asyncio.to_thread(parsed_dir.mkdir, parents=True, exist_ok=True)
-
-            target_name = self._get_unique_filename_in_parsed_dir(
-                parsed_dir, source.name
+            target = await move_file_to_parsed_dir(
+                source, skip_if_already_parsed=True
             )
-            target_path = parsed_dir / target_name
-            await asyncio.to_thread(source.rename, target_path)
-            logger.debug(
-                f"[parse] Archived DOCX source after full_docs sync: {source} -> {target_path}"
-            )
-            return str(target_path)
         except Exception as e:
             logger.warning(
                 f"[parse] DOCX source archive skipped after full_docs sync: {source_path}: {e}"
             )
             return None
+        if target is None:
+            return None
+        if target != source:
+            logger.debug(
+                f"[parse] Archived DOCX source after full_docs sync: {source} -> {target}"
+            )
+        return str(target)
 
     async def _write_lightrag_document_from_content_list(
         self,
@@ -5098,6 +5073,10 @@ class LightRAG:
                         source_path=source_file_path,
                     )
                 if result_text:
+                    # Content is already extracted as raw text and persisted; mark
+                    # parsed_engine="native" so retries skip the remote MinerU call
+                    # via _resolve_parser_engine. The original engine is kept in
+                    # source_parsed_engine for audit.
                     await self.full_docs.upsert(
                         {
                             doc_id: {
@@ -5187,6 +5166,10 @@ class LightRAG:
                         source_path=source_file_path,
                     )
                 if result_text:
+                    # Same retry-skip rationale as in parse_mineru: parsed_engine
+                    # is normalized to "native" because the raw content is already
+                    # in full_docs; the real upstream engine is kept in
+                    # source_parsed_engine for audit.
                     await self.full_docs.upsert(
                         {
                             doc_id: {

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -4476,24 +4476,32 @@ class LightRAG:
     async def _archive_docx_source_after_full_docs_sync(
         self, source_path: str
     ) -> str | None:
-        source = Path(source_path)
-        if source.suffix.lower() != ".docx":
-            return None
-        if not source.exists() or not source.is_file():
-            return None
-        if source.parent.name == PARSED_DIR_NAME:
-            return str(source)
+        try:
+            source = Path(source_path)
+            if source.suffix.lower() != ".docx":
+                return None
+            if not source.exists() or not source.is_file():
+                return None
+            if source.parent.name == PARSED_DIR_NAME:
+                return str(source)
 
-        parsed_dir = source.parent / PARSED_DIR_NAME
-        await asyncio.to_thread(parsed_dir.mkdir, parents=True, exist_ok=True)
+            parsed_dir = source.parent / PARSED_DIR_NAME
+            await asyncio.to_thread(parsed_dir.mkdir, parents=True, exist_ok=True)
 
-        target_name = self._get_unique_filename_in_parsed_dir(parsed_dir, source.name)
-        target_path = parsed_dir / target_name
-        await asyncio.to_thread(source.rename, target_path)
-        logger.debug(
-            f"[parse] Archived DOCX source after full_docs sync: {source} -> {target_path}"
-        )
-        return str(target_path)
+            target_name = self._get_unique_filename_in_parsed_dir(
+                parsed_dir, source.name
+            )
+            target_path = parsed_dir / target_name
+            await asyncio.to_thread(source.rename, target_path)
+            logger.debug(
+                f"[parse] Archived DOCX source after full_docs sync: {source} -> {target_path}"
+            )
+            return str(target_path)
+        except Exception as e:
+            logger.warning(
+                f"[parse] DOCX source archive skipped after full_docs sync: {source_path}: {e}"
+            )
+            return None
 
     async def _write_lightrag_document_from_content_list(
         self,

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from functools import wraps
 from hashlib import md5
+from pathlib import Path
 from typing import (
     Any,
     Protocol,
@@ -42,6 +43,7 @@ from lightrag.constants import (
     DEFAULT_SOURCE_IDS_LIMIT_METHOD,
     VALID_SOURCE_IDS_LIMIT_METHODS,
     SOURCE_IDS_LIMIT_METHOD_FIFO,
+    PARSED_DIR_NAME,
 )
 
 # Precompile regex pattern for JSON sanitization (module-level, compiled once)
@@ -721,6 +723,55 @@ def compute_mdhash_id(content: str, prefix: str = "") -> str:
     The ID is a combination of the given prefix and the MD5 hash of the content string.
     """
     return prefix + compute_args_hash(content)
+
+
+def get_unique_filename_in_parsed(target_dir: Path, original_name: str) -> str:
+    """Generate a unique filename in target_dir, adding numeric suffixes on conflict.
+
+    Tries the original name first, then `{stem}_001{ext}` ... `{stem}_999{ext}`,
+    falling back to a timestamp-suffixed name if all numeric slots are taken.
+    """
+    original_path = Path(original_name)
+    base_name = original_path.stem
+    extension = original_path.suffix
+
+    if not (target_dir / original_name).exists():
+        return original_name
+
+    for i in range(1, 1000):
+        new_name = f"{base_name}_{i:03d}{extension}"
+        if not (target_dir / new_name).exists():
+            return new_name
+
+    return f"{base_name}_{int(time.time())}{extension}"
+
+
+async def move_file_to_parsed_dir(
+    file_path: Path,
+    *,
+    skip_if_already_parsed: bool = False,
+) -> Path | None:
+    """Move a processed source file into its sibling __parsed__ directory.
+
+    Returns the new path on success, the input path if `skip_if_already_parsed`
+    is set and the file already lives in a `__parsed__` directory, or None if
+    the source no longer exists.
+    """
+    if not file_path.exists() or not file_path.is_file():
+        return None
+    if skip_if_already_parsed and file_path.parent.name == PARSED_DIR_NAME:
+        return file_path
+
+    parsed_dir = file_path.parent / PARSED_DIR_NAME
+    await asyncio.to_thread(parsed_dir.mkdir, parents=True, exist_ok=True)
+
+    unique_filename = get_unique_filename_in_parsed(parsed_dir, file_path.name)
+    target_path = parsed_dir / unique_filename
+    await asyncio.to_thread(file_path.rename, target_path)
+    logger.debug(
+        f"Moved file to parsed directory: {file_path.name} -> {unique_filename}"
+    )
+    return target_path
 
 
 def make_relation_vdb_ids(src_entity: str, tgt_entity: str) -> list[str]:

--- a/tests/test_document_routes_docx_archive.py
+++ b/tests/test_document_routes_docx_archive.py
@@ -90,9 +90,6 @@ class _ArchiveFailureRag:
         LightRAG._archive_docx_source_after_full_docs_sync
     )
 
-    def _get_unique_filename_in_parsed_dir(self, target_dir, original_name):
-        raise OSError("simulated archive failure")
-
 
 class _ParseFullDocs:
     def __init__(self, source_path):
@@ -113,7 +110,6 @@ class _ParseRag:
     _archive_docx_source_after_full_docs_sync = (
         LightRAG._archive_docx_source_after_full_docs_sync
     )
-    _get_unique_filename_in_parsed_dir = LightRAG._get_unique_filename_in_parsed_dir
 
     def __init__(self, working_dir, source_path):
         self.working_dir = str(working_dir)
@@ -188,10 +184,17 @@ async def test_scan_existing_full_path_docx_does_not_reenqueue(
     assert rag.process_calls == 1
 
 
-async def test_docx_archive_failure_is_best_effort(tmp_path):
+async def test_docx_archive_failure_is_best_effort(tmp_path, monkeypatch):
     file_path = tmp_path / "archive-failure.docx"
     file_path.write_bytes(b"docx bytes")
     rag = _ArchiveFailureRag()
+
+    async def _raise_archive_failure(*args, **kwargs):
+        raise OSError("simulated archive failure")
+
+    monkeypatch.setattr(
+        _lightrag, "move_file_to_parsed_dir", _raise_archive_failure
+    )
 
     archived_path = await LightRAG._archive_docx_source_after_full_docs_sync(
         rag, str(file_path)

--- a/tests/test_document_routes_docx_archive.py
+++ b/tests/test_document_routes_docx_archive.py
@@ -1,5 +1,6 @@
 import importlib
 import sys
+from io import BytesIO
 
 import pytest
 
@@ -22,6 +23,7 @@ pipeline_index_file = _document_routes.pipeline_index_file
 pipeline_index_files = _document_routes.pipeline_index_files
 run_scanning_process = _document_routes.run_scanning_process
 DocumentManager = _document_routes.DocumentManager
+create_document_routes = _document_routes.create_document_routes
 
 pytestmark = pytest.mark.offline
 
@@ -83,6 +85,11 @@ class _ScanRag:
 
     async def apipeline_process_enqueue_documents(self):
         self.process_calls += 1
+
+
+class _DuplicateUploadRag:
+    def __init__(self, docs_by_path):
+        self.doc_status = _ScanDocStatus(docs_by_path)
 
 
 class _ArchiveFailureRag:
@@ -182,6 +189,37 @@ async def test_scan_existing_full_path_docx_does_not_reenqueue(
     await run_scanning_process(rag, doc_manager, "track-scan")
 
     assert rag.process_calls == 1
+
+
+async def test_upload_rejects_same_name_failed_doc_status_without_full_docs(tmp_path):
+    doc_manager = DocumentManager(str(tmp_path))
+    rag = _DuplicateUploadRag(
+        {
+            "failed.docx": {
+                "status": DocStatus.FAILED.value,
+                "file_path": "failed.docx",
+                "track_id": "track-failed",
+                "metadata": {"error_type": "file_extraction_error"},
+            }
+        }
+    )
+    router = create_document_routes(rag, doc_manager)
+    upload_endpoint = [
+        route.endpoint
+        for route in router.routes
+        if getattr(route, "name", "") == "upload_to_input_dir"
+    ][-1]
+    upload_file = _document_routes.UploadFile(
+        filename="failed.docx",
+        file=BytesIO(b"replacement docx bytes"),
+    )
+
+    response = await upload_endpoint(_document_routes.BackgroundTasks(), upload_file)
+
+    assert response.status == "duplicated"
+    assert response.track_id == "track-failed"
+    assert "Status: failed" in response.message
+    assert not (tmp_path / "failed.docx").exists()
 
 
 async def test_docx_archive_failure_is_best_effort(tmp_path, monkeypatch):

--- a/tests/test_document_routes_docx_archive.py
+++ b/tests/test_document_routes_docx_archive.py
@@ -20,6 +20,8 @@ compute_mdhash_id = _utils.compute_mdhash_id
 LightRAG = _lightrag.LightRAG
 pipeline_index_file = _document_routes.pipeline_index_file
 pipeline_index_files = _document_routes.pipeline_index_files
+run_scanning_process = _document_routes.run_scanning_process
+DocumentManager = _document_routes.DocumentManager
 
 pytestmark = pytest.mark.offline
 
@@ -64,6 +66,32 @@ class _FakeRag:
 
     async def apipeline_enqueue_error_documents(self, error_files, track_id=None):
         self.errors.append((error_files, track_id))
+
+
+class _ScanDocStatus:
+    def __init__(self, docs_by_path):
+        self.docs_by_path = docs_by_path
+
+    async def get_doc_by_file_path(self, file_path):
+        return self.docs_by_path.get(file_path)
+
+
+class _ScanRag:
+    def __init__(self, docs_by_path):
+        self.doc_status = _ScanDocStatus(docs_by_path)
+        self.process_calls = 0
+
+    async def apipeline_process_enqueue_documents(self):
+        self.process_calls += 1
+
+
+class _ArchiveFailureRag:
+    _archive_docx_source_after_full_docs_sync = (
+        LightRAG._archive_docx_source_after_full_docs_sync
+    )
+
+    def _get_unique_filename_in_parsed_dir(self, target_dir, original_name):
+        raise OSError("simulated archive failure")
 
 
 class _ParseFullDocs:
@@ -132,6 +160,45 @@ async def test_pipeline_index_files_moves_processed_docx_batch(tmp_path):
     assert not second.exists()
     assert (tmp_path / PARSED_DIR_NAME / first.name).exists()
     assert (tmp_path / PARSED_DIR_NAME / second.name).exists()
+
+
+async def test_scan_existing_full_path_docx_does_not_reenqueue(
+    tmp_path, monkeypatch
+):
+    file_path = tmp_path / "already-parsed.docx"
+    file_path.write_bytes(b"docx bytes")
+    doc_manager = DocumentManager(str(tmp_path))
+    rag = _ScanRag(
+        {
+            str(file_path): {
+                "status": DocStatus.PARSING.value,
+                "file_path": str(file_path),
+                "track_id": "track-existing",
+            }
+        }
+    )
+
+    async def fail_if_reenqueue(*args, **kwargs):
+        raise AssertionError("existing docx should not be re-enqueued")
+
+    monkeypatch.setattr(_document_routes, "pipeline_index_files", fail_if_reenqueue)
+
+    await run_scanning_process(rag, doc_manager, "track-scan")
+
+    assert rag.process_calls == 1
+
+
+async def test_docx_archive_failure_is_best_effort(tmp_path):
+    file_path = tmp_path / "archive-failure.docx"
+    file_path.write_bytes(b"docx bytes")
+    rag = _ArchiveFailureRag()
+
+    archived_path = await LightRAG._archive_docx_source_after_full_docs_sync(
+        rag, str(file_path)
+    )
+
+    assert archived_path is None
+    assert file_path.exists()
 
 
 async def test_parse_native_archives_docx_after_full_docs_sync(tmp_path, monkeypatch):

--- a/tests/test_document_routes_docx_archive.py
+++ b/tests/test_document_routes_docx_archive.py
@@ -1,6 +1,7 @@
 import importlib
 import sys
 from io import BytesIO
+from types import SimpleNamespace
 
 import pytest
 
@@ -189,7 +190,14 @@ async def test_scan_existing_full_path_docx_does_not_reenqueue(tmp_path, monkeyp
     assert rag.process_calls == 1
 
 
-async def test_upload_rejects_same_name_failed_doc_status_without_full_docs(tmp_path):
+async def test_upload_rejects_same_name_failed_doc_status_without_full_docs(
+    tmp_path, monkeypatch
+):
+    # Other tests (e.g. test_auth.py) may replace global_args with a SimpleNamespace
+    # that lacks max_upload_size; pin a known state so the upload endpoint runs.
+    monkeypatch.setattr(
+        _document_routes, "global_args", SimpleNamespace(max_upload_size=None)
+    )
     doc_manager = DocumentManager(str(tmp_path))
     rag = _DuplicateUploadRag(
         {

--- a/tests/test_document_routes_docx_archive.py
+++ b/tests/test_document_routes_docx_archive.py
@@ -1,0 +1,174 @@
+import importlib
+import sys
+
+import pytest
+
+_original_argv = sys.argv[:]
+sys.argv = [sys.argv[0]]
+_document_routes = importlib.import_module("lightrag.api.routers.document_routes")
+_lightrag = importlib.import_module("lightrag.lightrag")
+_base = importlib.import_module("lightrag.base")
+_constants = importlib.import_module("lightrag.constants")
+_utils = importlib.import_module("lightrag.utils")
+sys.argv = _original_argv
+
+DocStatus = _base.DocStatus
+FULL_DOCS_FORMAT_LIGHTRAG = _constants.FULL_DOCS_FORMAT_LIGHTRAG
+FULL_DOCS_FORMAT_PENDING_PARSE = _constants.FULL_DOCS_FORMAT_PENDING_PARSE
+PARSED_DIR_NAME = _constants.PARSED_DIR_NAME
+compute_mdhash_id = _utils.compute_mdhash_id
+LightRAG = _lightrag.LightRAG
+pipeline_index_file = _document_routes.pipeline_index_file
+pipeline_index_files = _document_routes.pipeline_index_files
+
+pytestmark = pytest.mark.offline
+
+
+class _FakeDocStatus:
+    def __init__(self):
+        self.docs = {}
+
+    async def get_by_id(self, doc_id):
+        return self.docs.get(doc_id)
+
+
+class _FakeRag:
+    def __init__(self, final_status=DocStatus.PROCESSED):
+        self.doc_status = _FakeDocStatus()
+        self.final_status = final_status
+        self.enqueued = []
+        self.errors = []
+
+    async def apipeline_enqueue_documents(
+        self, input, ids=None, file_paths=None, track_id=None, docs_format=None
+    ):
+        self.enqueued.append(
+            {
+                "input": input,
+                "file_path": file_paths,
+                "track_id": track_id,
+                "docs_format": docs_format,
+            }
+        )
+        return track_id
+
+    async def apipeline_process_enqueue_documents(self):
+        for item in self.enqueued:
+            file_path = item["file_path"]
+            doc_id = compute_mdhash_id(file_path, prefix="doc-")
+            self.doc_status.docs[doc_id] = {
+                "status": self.final_status,
+                "file_path": file_path,
+                "track_id": item["track_id"],
+            }
+
+    async def apipeline_enqueue_error_documents(self, error_files, track_id=None):
+        self.errors.append((error_files, track_id))
+
+
+class _ParseFullDocs:
+    def __init__(self, source_path):
+        self.source_path = source_path
+        self.events = []
+        self.data = {}
+
+    async def upsert(self, data):
+        self.events.append("upsert")
+        self.data.update(data)
+
+    async def index_done_callback(self):
+        self.events.append("index_done")
+        assert self.source_path.exists()
+
+
+class _ParseRag:
+    _archive_docx_source_after_full_docs_sync = (
+        LightRAG._archive_docx_source_after_full_docs_sync
+    )
+    _get_unique_filename_in_parsed_dir = LightRAG._get_unique_filename_in_parsed_dir
+
+    def __init__(self, working_dir, source_path):
+        self.working_dir = str(working_dir)
+        self.full_docs = _ParseFullDocs(source_path)
+
+    def _resolve_source_file_for_parser(self, file_path):
+        return file_path
+
+
+async def test_pipeline_index_file_moves_processed_docx_to_parsed(tmp_path):
+    file_path = tmp_path / "sample.[docling].docx"
+    file_path.write_bytes(b"docx bytes")
+    rag = _FakeRag()
+
+    await pipeline_index_file(rag, file_path, "track-docx")
+
+    assert not file_path.exists()
+    assert (tmp_path / PARSED_DIR_NAME / file_path.name).exists()
+    assert rag.enqueued[0]["file_path"] == str(file_path)
+    assert rag.enqueued[0]["docs_format"] == FULL_DOCS_FORMAT_PENDING_PARSE
+
+
+async def test_pipeline_index_file_keeps_failed_docx_in_input_dir(tmp_path):
+    file_path = tmp_path / "failed.docx"
+    file_path.write_bytes(b"docx bytes")
+    rag = _FakeRag(final_status=DocStatus.FAILED)
+
+    await pipeline_index_file(rag, file_path, "track-docx")
+
+    assert file_path.exists()
+    assert not (tmp_path / PARSED_DIR_NAME / file_path.name).exists()
+
+
+async def test_pipeline_index_files_moves_processed_docx_batch(tmp_path):
+    first = tmp_path / "first.docx"
+    second = tmp_path / "second.[mineru].docx"
+    first.write_bytes(b"first docx bytes")
+    second.write_bytes(b"second docx bytes")
+    rag = _FakeRag()
+
+    await pipeline_index_files(rag, [second, first], "track-scan")
+
+    assert not first.exists()
+    assert not second.exists()
+    assert (tmp_path / PARSED_DIR_NAME / first.name).exists()
+    assert (tmp_path / PARSED_DIR_NAME / second.name).exists()
+
+
+async def test_parse_native_archives_docx_after_full_docs_sync(tmp_path, monkeypatch):
+    source_path = tmp_path / "parsed-after-sync.docx"
+    source_path.write_bytes(b"docx bytes")
+    rag = _ParseRag(tmp_path / "work", source_path)
+
+    parse_document = importlib.import_module("lightrag.extraction.parse_document")
+    monkeypatch.setattr(
+        parse_document,
+        "parse_docx_to_interchange_jsonl",
+        lambda file_bytes, source_file, doc_id, output_dir: '{"type":"meta"}\n{"type":"content","content":"parsed"}',
+    )
+
+    result = await LightRAG.parse_native(
+        rag,
+        "doc-test",
+        str(source_path),
+        {"format": FULL_DOCS_FORMAT_PENDING_PARSE, "content": ""},
+    )
+
+    assert result["content"]
+    assert rag.full_docs.events == ["upsert", "index_done"]
+    assert not source_path.exists()
+    assert (tmp_path / PARSED_DIR_NAME / source_path.name).exists()
+    assert rag.full_docs.data["doc-test"]["parsed_engine"] == "native"
+
+
+def test_lightrag_document_reprocess_uses_full_docs_without_reparse():
+    engine = LightRAG._resolve_parser_engine(
+        object(),
+        "report.[mineru].docx",
+        {
+            "format": FULL_DOCS_FORMAT_LIGHTRAG,
+            "lightrag_document_path": "report.blocks.jsonl",
+            "parsed_engine": "mineru",
+        },
+    )
+
+    assert engine == "native"

--- a/tests/test_document_routes_docx_archive.py
+++ b/tests/test_document_routes_docx_archive.py
@@ -165,9 +165,7 @@ async def test_pipeline_index_files_moves_processed_docx_batch(tmp_path):
     assert (tmp_path / PARSED_DIR_NAME / second.name).exists()
 
 
-async def test_scan_existing_full_path_docx_does_not_reenqueue(
-    tmp_path, monkeypatch
-):
+async def test_scan_existing_full_path_docx_does_not_reenqueue(tmp_path, monkeypatch):
     file_path = tmp_path / "already-parsed.docx"
     file_path.write_bytes(b"docx bytes")
     doc_manager = DocumentManager(str(tmp_path))
@@ -230,9 +228,7 @@ async def test_docx_archive_failure_is_best_effort(tmp_path, monkeypatch):
     async def _raise_archive_failure(*args, **kwargs):
         raise OSError("simulated archive failure")
 
-    monkeypatch.setattr(
-        _lightrag, "move_file_to_parsed_dir", _raise_archive_failure
-    )
+    monkeypatch.setattr(_lightrag, "move_file_to_parsed_dir", _raise_archive_failure)
 
     archived_path = await LightRAG._archive_docx_source_after_full_docs_sync(
         rag, str(file_path)
@@ -251,7 +247,10 @@ async def test_parse_native_archives_docx_after_full_docs_sync(tmp_path, monkeyp
     monkeypatch.setattr(
         parse_document,
         "parse_docx_to_interchange_jsonl",
-        lambda file_bytes, source_file, doc_id, output_dir: '{"type":"meta"}\n{"type":"content","content":"parsed"}',
+        lambda file_bytes,
+        source_file,
+        doc_id,
+        output_dir: '{"type":"meta"}\n{"type":"content","content":"parsed"}',
     )
 
     result = await LightRAG.parse_native(


### PR DESCRIPTION
## Description

Improve DOCX processing idempotency and source-file archiving across native, MinerU, and Docling parsing paths.

## Related Issues

n/a

## Changes Made

- Archive DOCX source files after parsed content is persisted to `full_docs`, instead of waiting for the full entity extraction pipeline to complete.
- Reuse persisted LightRAG/raw parsed content on retry so MinerU and Docling are not called again after successful parsing.
- Add compatible file path lookup for filename, full path, and resolved path variants to avoid duplicate DOCX enqueueing.
- Make DOCX source archiving best-effort after `full_docs` persistence so archive failures do not invalidate parsed content.
- Add offline tests for DOCX archiving, retry behavior, scan idempotency, and archive failure handling.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Validated with:

- `ruff check lightrag/api/routers/document_routes.py lightrag/lightrag.py tests/test_document_routes_docx_archive.py`
- `./scripts/test.sh tests/test_document_routes_docx_archive.py tests/test_document_routes_paginated.py`
