### PR TITLE
OpenSearch: Use version-aware sort tiebreaker for PIT search

### DIFF
--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -91,6 +91,17 @@ def _pit_sort_with_field(field: str, order: str = "asc") -> list[dict]:
     return [{field: {"order": order}}, {"_doc": "asc"}]
 
 
+def _pit_sort_with_composite_key(*fields: str) -> list[dict]:
+    """Return PIT sort clause with multiple fields forming a composite unique key.
+
+    >= 3.3.0: _shard_doc (most efficient, ignores the fields).
+    < 3.3.0:  field1 + field2 + ... + _doc (composite is unique, _doc for efficiency).
+    """
+    if _shard_doc_supported:
+        return [{"_shard_doc": "asc"}]
+    return [{f: {"order": "asc"}} for f in fields] + [{"_doc": "asc"}]
+
+
 async def _detect_shard_doc_support(client: AsyncOpenSearch) -> bool:
     """Check if the cluster supports _shard_doc (OpenSearch >= 3.3.0)."""
     try:
@@ -1359,7 +1370,9 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                         "_source": ["source_node_id", "target_node_id"],
                         "size": 10000,
                         "pit": {"id": pit_id, "keep_alive": "1m"},
-                        "sort": _pit_tiebreaker(),
+                        "sort": _pit_sort_with_composite_key(
+                            "source_node_id", "target_node_id"
+                        ),
                     }
                     if search_after:
                         body["search_after"] = search_after
@@ -1491,7 +1504,9 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                         "_source": ["source_node_id", "target_node_id"],
                         "size": 10000,
                         "pit": {"id": pit_id, "keep_alive": "1m"},
-                        "sort": _pit_tiebreaker(),
+                        "sort": _pit_sort_with_composite_key(
+                            "source_node_id", "target_node_id"
+                        ),
                     }
                     if search_after:
                         body["search_after"] = search_after
@@ -1960,7 +1975,9 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                     "query": edge_query,
                     "size": 10000,
                     "pit": {"id": pit_id, "keep_alive": "1m"},
-                    "sort": _pit_tiebreaker(),
+                    "sort": _pit_sort_with_composite_key(
+                        "source_node_id", "target_node_id"
+                    ),
                 }
                 if search_after:
                     edge_body["search_after"] = search_after
@@ -2391,7 +2408,9 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                         "query": {"match_all": {}},
                         "size": 10000,
                         "pit": {"id": pit_id, "keep_alive": "1m"},
-                        "sort": _pit_tiebreaker(),
+                        "sort": _pit_sort_with_composite_key(
+                            "source_node_id", "target_node_id"
+                        ),
                     }
                     if search_after:
                         body["search_after"] = search_after

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -69,25 +69,14 @@ def _sanitize_index_name(name: str) -> str:
 _shard_doc_supported: bool | None = None
 
 
-def _pit_tiebreaker() -> list[dict]:
-    """Return PIT sort tiebreaker based on detected OpenSearch version.
-
-    >= 3.3.0: _shard_doc (shard-local ordinal, most efficient).
-    < 3.3.0:  _doc + _id (_doc for efficiency, _id for cross-shard uniqueness).
-    """
-    if _shard_doc_supported:
-        return [{"_shard_doc": "asc"}]
-    return [{"_doc": "asc"}, {"_id": "asc"}]
-
-
 def _pit_sort_with_field(field: str, order: str = "asc") -> list[dict]:
     """Return PIT sort clause with a unique field as primary sort.
 
-    >= 3.3.0: field + _shard_doc.
-    < 3.3.0:  field + _doc (field is unique, so _doc suffices).
+    >= 3.3.0: _shard_doc only (most efficient, already unique within PIT).
+    < 3.3.0:  field + _doc (field is unique, _doc for efficiency).
     """
     if _shard_doc_supported:
-        return [{field: {"order": order}}, {"_shard_doc": "asc"}]
+        return [{"_shard_doc": "asc"}]
     return [{field: {"order": order}}, {"_doc": "asc"}]
 
 
@@ -114,7 +103,7 @@ async def _detect_shard_doc_support(client: AsyncOpenSearch) -> bool:
         supported = (major > 3) or (major == 3 and minor >= 3)
         logger.info(
             f"OpenSearch version {version_str}: "
-            f"_shard_doc {'supported' if supported else 'not supported, using _doc+_id fallback'}"
+            f"_shard_doc {'supported' if supported else 'not supported, using field+_doc fallback'}"
         )
         return supported
     except Exception as e:
@@ -291,7 +280,12 @@ class OpenSearchKVStorage(BaseKVStorage):
             if not await self.client.indices.exists(index=self._index_name):
                 # Use dynamic mapping so any namespace schema works
                 body = {
-                    "mappings": {"dynamic": True},
+                    "mappings": {
+                        "dynamic": True,
+                        "properties": {
+                            "doc_id": {"type": "keyword"},
+                        },
+                    },
                     "settings": {
                         "index": {
                             "number_of_shards": _get_index_number_of_shards(),
@@ -333,7 +327,7 @@ class OpenSearchKVStorage(BaseKVStorage):
                         "query": {"match_all": {}},
                         "size": batch_size,
                         "pit": {"id": pit_id, "keep_alive": "1m"},
-                        "sort": _pit_tiebreaker(),
+                        "sort": _pit_sort_with_field("doc_id"),
                     }
                     if search_after:
                         body["search_after"] = search_after
@@ -369,6 +363,7 @@ class OpenSearchKVStorage(BaseKVStorage):
             if response is None:
                 return None
             doc = response["_source"]
+            doc.pop("doc_id", None)
             doc["_id"] = response["_id"]
             doc.setdefault("create_time", 0)
             doc.setdefault("update_time", 0)
@@ -390,6 +385,7 @@ class OpenSearchKVStorage(BaseKVStorage):
             for doc in response["docs"]:
                 if doc.get("found"):
                     data = doc["_source"]
+                    data.pop("doc_id", None)
                     data["_id"] = doc["_id"]
                     data.setdefault("create_time", 0)
                     data.setdefault("update_time", 0)
@@ -432,12 +428,14 @@ class OpenSearchKVStorage(BaseKVStorage):
         for i, (doc_id, doc_data) in enumerate(data.items(), start=1):
             doc_data["update_time"] = current_time
             doc_data.setdefault("create_time", current_time)
+            source = {k: v for k, v in doc_data.items() if k != "_id"}
+            source["doc_id"] = doc_id
             actions.append(
                 {
                     "_op_type": "index",
                     "_index": self._index_name,
                     "_id": doc_id,
-                    "_source": {k: v for k, v in doc_data.items() if k != "_id"},
+                    "_source": source,
                 }
             )
             await _cooperative_yield(i)
@@ -556,6 +554,7 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
         """Normalize a raw OpenSearch document to DocProcessingStatus-compatible dict."""
         data = doc.copy()
         data.pop("_id", None)
+        data.pop("doc_id", None)
         if "file_path" not in data:
             data["file_path"] = "no-file-path"
         data.setdefault("metadata", {})
@@ -600,6 +599,7 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                     "mappings": {
                         "dynamic": True,
                         "properties": {
+                            "doc_id": {"type": "keyword"},
                             "status": {"type": "keyword"},
                             "file_path": {"type": "keyword"},
                             "track_id": {"type": "keyword"},
@@ -695,12 +695,14 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
         actions = []
         for i, (k, v) in enumerate(data.items(), start=1):
             v.setdefault("chunks_list", [])
+            source = {fk: fv for fk, fv in v.items() if fk != "_id"}
+            source["doc_id"] = k
             actions.append(
                 {
                     "_op_type": "index",
                     "_index": self._index_name,
                     "_id": k,
-                    "_source": {fk: fv for fk, fv in v.items() if fk != "_id"},
+                    "_source": source,
                 }
             )
             await _cooperative_yield(i)
@@ -752,7 +754,7 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                         "query": query,
                         "size": batch_size,
                         "pit": {"id": pit_id, "keep_alive": "1m"},
-                        "sort": _pit_tiebreaker(),
+                        "sort": _pit_sort_with_field("doc_id"),
                     }
                     if search_after:
                         body["search_after"] = search_after
@@ -842,7 +844,9 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
             if total_count == 0 or skip_count >= total_count:
                 return [], total_count
 
-            sort_clause = [{sort_field: {"order": sort_order}}] + _pit_tiebreaker()
+            sort_clause = [{sort_field: {"order": sort_order}}] + _pit_sort_with_field(
+                "doc_id"
+            )
 
             pit = await self.client.create_pit(
                 index=self._index_name, params={"keep_alive": "1m"}

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -65,6 +65,54 @@ def _sanitize_index_name(name: str) -> str:
     return sanitized
 
 
+# Detected at first connection; True when OpenSearch >= 3.3.0.
+_shard_doc_supported: bool | None = None
+
+
+def _pit_tiebreaker() -> list[dict]:
+    """Return PIT sort tiebreaker based on detected OpenSearch version.
+
+    >= 3.3.0: _shard_doc (shard-local ordinal, most efficient).
+    < 3.3.0:  _doc + _id (_doc for efficiency, _id for cross-shard uniqueness).
+    """
+    if _shard_doc_supported:
+        return [{"_shard_doc": "asc"}]
+    return [{"_doc": "asc"}, {"_id": "asc"}]
+
+
+def _pit_sort_with_field(field: str, order: str = "asc") -> list[dict]:
+    """Return PIT sort clause with a unique field as primary sort.
+
+    >= 3.3.0: field + _shard_doc.
+    < 3.3.0:  field + _doc (field is unique, so _doc suffices).
+    """
+    if _shard_doc_supported:
+        return [{field: {"order": order}}, {"_shard_doc": "asc"}]
+    return [{field: {"order": order}}, {"_doc": "asc"}]
+
+
+async def _detect_shard_doc_support(client: AsyncOpenSearch) -> bool:
+    """Check if the cluster supports _shard_doc (OpenSearch >= 3.3.0)."""
+    try:
+        info = await client.info()
+        version_str = info.get("version", {}).get("number", "0.0.0")
+        # Strip pre-release suffixes (e.g. "3.3.0-SNAPSHOT" → "3", "3", "0")
+        parts = [p.split("-")[0] for p in version_str.split(".")]
+        major = int(parts[0]) if parts[0].isdigit() else 0
+        minor = int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else 0
+        supported = (major > 3) or (major == 3 and minor >= 3)
+        logger.info(
+            f"OpenSearch version {version_str}: "
+            f"_shard_doc {'supported' if supported else 'not supported, using _doc+_id fallback'}"
+        )
+        return supported
+    except Exception as e:
+        logger.warning(
+            f"Failed to detect OpenSearch version, assuming _shard_doc not supported: {e}"
+        )
+        return False
+
+
 class ClientManager:
     """Singleton manager for OpenSearch client connections."""
 
@@ -74,6 +122,7 @@ class ClientManager:
     @classmethod
     async def get_client(cls) -> AsyncOpenSearch:
         """Get or create a shared AsyncOpenSearch client with reference counting."""
+        global _shard_doc_supported
         async with cls._lock:
             if cls._instances["client"] is None:
                 hosts_str = _get_opensearch_env("OPENSEARCH_HOSTS", "localhost:9200")
@@ -110,6 +159,7 @@ class ClientManager:
                 )
                 cls._instances["client"] = client
                 cls._instances["ref_count"] = 0
+                _shard_doc_supported = await _detect_shard_doc_support(client)
                 logger.info(f"OpenSearch client connected to {hosts}")
 
             cls._instances["ref_count"] += 1
@@ -118,6 +168,7 @@ class ClientManager:
     @classmethod
     async def release_client(cls, client: AsyncOpenSearch):
         """Release a client reference. Closes the connection when ref count reaches 0."""
+        global _shard_doc_supported
         async with cls._lock:
             if client is not None and client is cls._instances["client"]:
                 cls._instances["ref_count"] -= 1
@@ -128,6 +179,7 @@ class ClientManager:
                         pass
                     cls._instances["client"] = None
                     cls._instances["ref_count"] = 0
+                    _shard_doc_supported = None
                     logger.info("OpenSearch client connection closed")
 
 
@@ -270,7 +322,7 @@ class OpenSearchKVStorage(BaseKVStorage):
                         "query": {"match_all": {}},
                         "size": batch_size,
                         "pit": {"id": pit_id, "keep_alive": "1m"},
-                        "sort": [{"_shard_doc": "asc"}],
+                        "sort": _pit_tiebreaker(),
                     }
                     if search_after:
                         body["search_after"] = search_after
@@ -689,7 +741,7 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                         "query": query,
                         "size": batch_size,
                         "pit": {"id": pit_id, "keep_alive": "1m"},
-                        "sort": [{"_shard_doc": "asc"}],
+                        "sort": _pit_tiebreaker(),
                     }
                     if search_after:
                         body["search_after"] = search_after
@@ -779,7 +831,7 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
             if total_count == 0 or skip_count >= total_count:
                 return [], total_count
 
-            sort_clause = [{sort_field: {"order": sort_order}}, {"_shard_doc": "asc"}]
+            sort_clause = [{sort_field: {"order": sort_order}}] + _pit_tiebreaker()
 
             pit = await self.client.create_pit(
                 index=self._index_name, params={"keep_alive": "1m"}
@@ -1307,7 +1359,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                         "_source": ["source_node_id", "target_node_id"],
                         "size": 10000,
                         "pit": {"id": pit_id, "keep_alive": "1m"},
-                        "sort": [{"_shard_doc": "asc"}],
+                        "sort": _pit_tiebreaker(),
                     }
                     if search_after:
                         body["search_after"] = search_after
@@ -1439,7 +1491,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                         "_source": ["source_node_id", "target_node_id"],
                         "size": 10000,
                         "pit": {"id": pit_id, "keep_alive": "1m"},
-                        "sort": [{"_shard_doc": "asc"}],
+                        "sort": _pit_tiebreaker(),
                     }
                     if search_after:
                         body["search_after"] = search_after
@@ -1783,7 +1835,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                         "_source": False,
                         "size": 10000,
                         "pit": {"id": pit_id, "keep_alive": "1m"},
-                        "sort": [{"_shard_doc": "asc"}],
+                        "sort": _pit_sort_with_field("entity_id"),
                     }
                     if search_after:
                         body["search_after"] = search_after
@@ -1838,7 +1890,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                     "_source": False,
                     "size": 10000,
                     "pit": {"id": pit_id, "keep_alive": "1m"},
-                    "sort": [{"_shard_doc": "asc"}],
+                    "sort": _pit_sort_with_field("entity_id"),
                 }
                 if search_after:
                     body["search_after"] = search_after
@@ -1908,7 +1960,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                     "query": edge_query,
                     "size": 10000,
                     "pit": {"id": pit_id, "keep_alive": "1m"},
-                    "sort": [{"_shard_doc": "asc"}],
+                    "sort": _pit_tiebreaker(),
                 }
                 if search_after:
                     edge_body["search_after"] = search_after
@@ -2295,7 +2347,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                         "query": {"match_all": {}},
                         "size": 10000,
                         "pit": {"id": pit_id, "keep_alive": "1m"},
-                        "sort": [{"_shard_doc": "asc"}],
+                        "sort": _pit_sort_with_field("entity_id"),
                     }
                     if search_after:
                         body["search_after"] = search_after
@@ -2339,7 +2391,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                         "query": {"match_all": {}},
                         "size": 10000,
                         "pit": {"id": pit_id, "keep_alive": "1m"},
-                        "sort": [{"_shard_doc": "asc"}],
+                        "sort": _pit_tiebreaker(),
                     }
                     if search_after:
                         body["search_after"] = search_after

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -69,15 +69,18 @@ def _sanitize_index_name(name: str) -> str:
 _shard_doc_supported: bool | None = None
 
 
-def _pit_sort_with_field(field: str, order: str = "asc") -> list[dict]:
+def _pit_sort_with_field(field: str) -> list[dict]:
     """Return PIT sort clause with a unique field as primary sort.
+
+    Used purely as a pagination tiebreaker — order is fixed to asc since the
+    business sort (when present) is applied separately by the caller.
 
     >= 3.3.0: _shard_doc only (most efficient, already unique within PIT).
     < 3.3.0:  field + _doc (field is unique, _doc for efficiency).
     """
     if _shard_doc_supported:
         return [{"_shard_doc": "asc"}]
-    return [{field: {"order": order}}, {"_doc": "asc"}]
+    return [{field: {"order": "asc"}}, {"_doc": "asc"}]
 
 
 def _pit_sort_with_composite_key(*fields: str) -> list[dict]:
@@ -226,6 +229,30 @@ def _is_missing_index_error(exc: Exception) -> bool:
     return "index_not_found_exception" in str(exc)
 
 
+async def _verify_mirrored_id_mapping(client: AsyncOpenSearch, index_name: str) -> None:
+    """Fail-fast when an existing index lacks the __mirrored_id keyword mapping.
+
+    Only enforced on OpenSearch < 3.3.0, where __mirrored_id serves as the
+    cross-shard pagination tiebreaker. Indices created by older LightRAG
+    releases will be missing this mapping; sorting by a missing field on a
+    multi-shard index can drop or duplicate documents during PIT pagination.
+    """
+    if _shard_doc_supported:
+        return
+    try:
+        mapping = await client.indices.get_mapping(index=index_name)
+    except OpenSearchException:
+        return
+    props = mapping.get(index_name, {}).get("mappings", {}).get("properties", {})
+    if "__mirrored_id" not in props:
+        raise RuntimeError(
+            f"Index '{index_name}' lacks the '__mirrored_id' keyword mapping "
+            f"required for stable PIT pagination on OpenSearch < 3.3.0. "
+            f"This index was likely created by an older LightRAG release. "
+            f"Please reindex the data, or upgrade the cluster to OpenSearch >= 3.3.0."
+        )
+
+
 @final
 @dataclass
 class OpenSearchKVStorage(BaseKVStorage):
@@ -283,7 +310,7 @@ class OpenSearchKVStorage(BaseKVStorage):
                     "mappings": {
                         "dynamic": True,
                         "properties": {
-                            "doc_id": {"type": "keyword"},
+                            "__mirrored_id": {"type": "keyword"},
                         },
                     },
                     "settings": {
@@ -295,6 +322,8 @@ class OpenSearchKVStorage(BaseKVStorage):
                 }
                 await self.client.indices.create(index=self._index_name, body=body)
                 logger.info(f"[{self.workspace}] Created index: {self._index_name}")
+            else:
+                await _verify_mirrored_id_mapping(self.client, self._index_name)
         except RequestError as e:
             if "resource_already_exists_exception" not in str(e):
                 raise
@@ -327,7 +356,7 @@ class OpenSearchKVStorage(BaseKVStorage):
                         "query": {"match_all": {}},
                         "size": batch_size,
                         "pit": {"id": pit_id, "keep_alive": "1m"},
-                        "sort": _pit_sort_with_field("doc_id"),
+                        "sort": _pit_sort_with_field("__mirrored_id"),
                     }
                     if search_after:
                         body["search_after"] = search_after
@@ -363,7 +392,7 @@ class OpenSearchKVStorage(BaseKVStorage):
             if response is None:
                 return None
             doc = response["_source"]
-            doc.pop("doc_id", None)
+            doc.pop("__mirrored_id", None)
             doc["_id"] = response["_id"]
             doc.setdefault("create_time", 0)
             doc.setdefault("update_time", 0)
@@ -385,7 +414,7 @@ class OpenSearchKVStorage(BaseKVStorage):
             for doc in response["docs"]:
                 if doc.get("found"):
                     data = doc["_source"]
-                    data.pop("doc_id", None)
+                    data.pop("__mirrored_id", None)
                     data["_id"] = doc["_id"]
                     data.setdefault("create_time", 0)
                     data.setdefault("update_time", 0)
@@ -429,7 +458,7 @@ class OpenSearchKVStorage(BaseKVStorage):
             doc_data["update_time"] = current_time
             doc_data.setdefault("create_time", current_time)
             source = {k: v for k, v in doc_data.items() if k != "_id"}
-            source["doc_id"] = doc_id
+            source["__mirrored_id"] = doc_id
             actions.append(
                 {
                     "_op_type": "index",
@@ -554,7 +583,7 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
         """Normalize a raw OpenSearch document to DocProcessingStatus-compatible dict."""
         data = doc.copy()
         data.pop("_id", None)
-        data.pop("doc_id", None)
+        data.pop("__mirrored_id", None)
         if "file_path" not in data:
             data["file_path"] = "no-file-path"
         data.setdefault("metadata", {})
@@ -599,7 +628,7 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                     "mappings": {
                         "dynamic": True,
                         "properties": {
-                            "doc_id": {"type": "keyword"},
+                            "__mirrored_id": {"type": "keyword"},
                             "status": {"type": "keyword"},
                             "file_path": {"type": "keyword"},
                             "track_id": {"type": "keyword"},
@@ -618,6 +647,8 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                 logger.info(
                     f"[{self.workspace}] Created doc status index: {self._index_name}"
                 )
+            else:
+                await _verify_mirrored_id_mapping(self.client, self._index_name)
         except RequestError as e:
             if "resource_already_exists_exception" not in str(e):
                 raise
@@ -696,7 +727,7 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
         for i, (k, v) in enumerate(data.items(), start=1):
             v.setdefault("chunks_list", [])
             source = {fk: fv for fk, fv in v.items() if fk != "_id"}
-            source["doc_id"] = k
+            source["__mirrored_id"] = k
             actions.append(
                 {
                     "_op_type": "index",
@@ -754,7 +785,7 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                         "query": query,
                         "size": batch_size,
                         "pit": {"id": pit_id, "keep_alive": "1m"},
-                        "sort": _pit_sort_with_field("doc_id"),
+                        "sort": _pit_sort_with_field("__mirrored_id"),
                     }
                     if search_after:
                         body["search_after"] = search_after
@@ -845,7 +876,7 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                 return [], total_count
 
             sort_clause = [{sort_field: {"order": sort_order}}] + _pit_sort_with_field(
-                "doc_id"
+                "__mirrored_id"
             )
 
             pit = await self.client.create_pit(

--- a/tests/test_opensearch_storage.py
+++ b/tests/test_opensearch_storage.py
@@ -25,6 +25,7 @@ from lightrag.kg.opensearch_impl import (
     _build_index_name,
     _resolve_workspace,
     _sanitize_index_name,
+    _verify_mirrored_id_mapping,
 )
 from lightrag.base import DocStatus, DocProcessingStatus
 
@@ -55,6 +56,16 @@ def patch_data_init_lock():
     with patch(
         "lightrag.kg.opensearch_impl.get_data_init_lock", side_effect=_mock_lock_factory
     ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def patch_shard_doc_supported():
+    """Default tests to OpenSearch >= 3.3.0 so the __mirrored_id verification is a no-op.
+
+    Tests covering the < 3.3.0 fallback should override this with their own patch.
+    """
+    with patch("lightrag.kg.opensearch_impl._shard_doc_supported", True):
         yield
 
 
@@ -193,11 +204,22 @@ class TestHelpers:
 class TestClientManager:
     """Tests for ClientManager singleton pattern and reference counting."""
 
+    @staticmethod
+    def _stub_client(version: str = "3.3.0") -> AsyncMock:
+        """Build an AsyncMock client with a concrete .info() payload.
+
+        Without this stub, _detect_shard_doc_support's chained .get(...) calls
+        on an AsyncMock would leak un-awaited coroutines.
+        """
+        client = AsyncMock()
+        client.info = AsyncMock(return_value={"version": {"number": version}})
+        return client
+
     @pytest.mark.asyncio
     async def test_singleton_and_refcount(self):
         ClientManager._instances = {"client": None, "ref_count": 0}
         with patch("lightrag.kg.opensearch_impl.AsyncOpenSearch") as mock_cls:
-            mock_cls.return_value = AsyncMock()
+            mock_cls.return_value = self._stub_client()
             c1 = await ClientManager.get_client()
             c2 = await ClientManager.get_client()
             assert c1 is c2
@@ -212,11 +234,65 @@ class TestClientManager:
     async def test_close_called_on_last_release(self):
         ClientManager._instances = {"client": None, "ref_count": 0}
         with patch("lightrag.kg.opensearch_impl.AsyncOpenSearch") as mock_cls:
-            inner = AsyncMock()
+            inner = self._stub_client()
             mock_cls.return_value = inner
             c = await ClientManager.get_client()
             await ClientManager.release_client(c)
             inner.close.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# _verify_mirrored_id_mapping helper
+# ---------------------------------------------------------------------------
+
+
+class TestMirroredIdVerification:
+    """Tests for the _verify_mirrored_id_mapping fail-fast helper."""
+
+    @pytest.mark.asyncio
+    async def test_skipped_on_modern_cluster(self, mock_client):
+        """On OpenSearch >= 3.3.0 the mapping check is short-circuited."""
+        # _shard_doc_supported is True via autouse fixture.
+        await _verify_mirrored_id_mapping(mock_client, "any_index")
+        mock_client.indices.get_mapping.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_passes_when_mapping_present(self, mock_client):
+        """On OpenSearch < 3.3.0 a mapping containing __mirrored_id is accepted."""
+        mock_client.indices.get_mapping = AsyncMock(
+            return_value={
+                "my_index": {
+                    "mappings": {
+                        "properties": {"__mirrored_id": {"type": "keyword"}}
+                    }
+                }
+            }
+        )
+        with patch("lightrag.kg.opensearch_impl._shard_doc_supported", False):
+            await _verify_mirrored_id_mapping(mock_client, "my_index")
+
+    @pytest.mark.asyncio
+    async def test_fails_fast_when_mapping_missing(self, mock_client):
+        """On OpenSearch < 3.3.0 a legacy index without __mirrored_id raises."""
+        mock_client.indices.get_mapping = AsyncMock(
+            return_value={
+                "my_index": {
+                    "mappings": {"properties": {"other_field": {"type": "text"}}}
+                }
+            }
+        )
+        with patch("lightrag.kg.opensearch_impl._shard_doc_supported", False):
+            with pytest.raises(RuntimeError, match="__mirrored_id"):
+                await _verify_mirrored_id_mapping(mock_client, "my_index")
+
+    @pytest.mark.asyncio
+    async def test_swallows_get_mapping_error(self, mock_client):
+        """Mapping-fetch failures should not block initialization."""
+        mock_client.indices.get_mapping = AsyncMock(
+            side_effect=OpenSearchException("transport error")
+        )
+        with patch("lightrag.kg.opensearch_impl._shard_doc_supported", False):
+            await _verify_mirrored_id_mapping(mock_client, "my_index")
 
 
 # ---------------------------------------------------------------------------
@@ -258,6 +334,28 @@ class TestKVStorage:
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()
+            mock_client.indices.create.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_initialize_fails_on_legacy_index_without_mirrored_id(
+        self, global_config, embed_func, mock_client
+    ):
+        """On OpenSearch < 3.3.0, an existing index lacking __mirrored_id must fail-fast."""
+        mock_client.indices.exists = AsyncMock(return_value=True)
+        mock_client.indices.get_mapping = AsyncMock(
+            return_value={
+                "test_text_chunks": {
+                    "mappings": {"properties": {"content": {"type": "text"}}}
+                }
+            }
+        )
+        with (
+            patch.object(ClientManager, "get_client", return_value=mock_client),
+            patch("lightrag.kg.opensearch_impl._shard_doc_supported", False),
+        ):
+            s = self._make(global_config, embed_func)
+            with pytest.raises(RuntimeError, match="__mirrored_id"):
+                await s.initialize()
             mock_client.indices.create.assert_not_awaited()
 
     @pytest.mark.asyncio

--- a/tests/test_opensearch_storage.py
+++ b/tests/test_opensearch_storage.py
@@ -262,9 +262,7 @@ class TestMirroredIdVerification:
         mock_client.indices.get_mapping = AsyncMock(
             return_value={
                 "my_index": {
-                    "mappings": {
-                        "properties": {"__mirrored_id": {"type": "keyword"}}
-                    }
+                    "mappings": {"properties": {"__mirrored_id": {"type": "keyword"}}}
                 }
             }
         )


### PR DESCRIPTION
<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

Use version-aware sort tiebreaker for PIT search:
```
  ┌──────────────────────────────────────────────────────────────────┬───────────────────┬─────────────┬────────────────────────────────────────┐
  │                          Sort function                           │     Locations     │ On >= 3.3.0 │               On < 3.3.0               │
  ├──────────────────────────────────────────────────────────────────┼───────────────────┼─────────────┼────────────────────────────────────────┤
  │ _pit_sort_with_field("doc_id")                                   │ 3 (KV, DocStatus) │ _shard_doc  │ doc_id + _doc                          │
  ├──────────────────────────────────────────────────────────────────┼───────────────────┼─────────────┼────────────────────────────────────────┤
  │ _pit_sort_with_field("entity_id")                                │ 3 (Graph nodes)   │ _shard_doc  │ entity_id + _doc                       │
  ├──────────────────────────────────────────────────────────────────┼───────────────────┼─────────────┼────────────────────────────────────────┤
  │ _pit_sort_with_composite_key("source_node_id", "target_node_id") │ 4 (Graph edges)   │ _shard_doc  │ source_node_id + target_node_id + _doc │
  └──────────────────────────────────────────────────────────────────┴───────────────────┴─────────────┴────────────────────────────────────────┘
```

It's a breaking change for existing deployments on OpenSearch < 3.3.0.

### Who is affected

```

  ┌──────────────────────────────────────────┬───────────────────────────────────────┐
  │                 Scenario                 │               Affected?               │
  ├──────────────────────────────────────────┼───────────────────────────────────────┤
  │ New deployment (any version)             │ No — mapping includes doc_id          │
  ├──────────────────────────────────────────┼───────────────────────────────────────┤
  │ Existing deployment, OpenSearch >= 3.3.0 │ No — uses _shard_doc                  │
  ├──────────────────────────────────────────┼───────────────────────────────────────┤
  │ Existing deployment, OpenSearch < 3.3.0  │ Yes — old indices lack doc_id mapping │
  └──────────────────────────────────────────┴───────────────────────────────────────┘
```
## Related Issues

https://github.com/HKUDS/LightRAG/issues/2975

## Changes Made

- lightrag/kg/opensearch_impl.py

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

[Add any additional notes or context for the reviewer(s).]
