### PR TITLE
Refactor DOCX archive handling

### DIFF
--- a/env.example
+++ b/env.example
@@ -226,6 +226,10 @@ ENTITY_EXTRACTION_USE_JSON=true
 ###   addon_params={"entity_types_guidance": "- CustomType: description..."}
 # ENTITY_TYPE_PROMPT_FILE=entity_type_prompt.yml
 
+### DOCX parsing method: plain_text (legacy) or lightrag_document (structured)
+### Default: plain_text
+# DOCX_PARSING_DEFAULT_METHOD=plain_text
+
 ### Multimodal parsing/analyze integration
 ### Optional parser routing rules, for example:
 ###   pdf:mineru-iet,docx:docling,pptx:docling,*:native

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -3,6 +3,7 @@ This module contains all document-related routes for the LightRAG API.
 """
 
 import asyncio
+import os
 import time
 from uuid import uuid4
 from functools import lru_cache
@@ -25,7 +26,13 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from lightrag import LightRAG
 from lightrag.base import DeletionResult, DocProcessingStatus, DocStatus
-from lightrag.constants import PARSED_DIR_NAME, FULL_DOCS_FORMAT_PENDING_PARSE
+from lightrag.constants import (
+    DEFAULT_DOCX_PARSING_METHOD,
+    DOCX_PARSING_METHOD_LIGHTRAG_DOCUMENT,
+    DOCX_PARSING_METHOD_PLAIN_TEXT,
+    FULL_DOCS_FORMAT_PENDING_PARSE,
+    PARSED_DIR_NAME,
+)
 from lightrag.utils import (
     generate_track_id,
     compute_mdhash_id,
@@ -52,6 +59,26 @@ def _is_docling_available() -> bool:
         return True
     except ImportError:
         return False
+
+
+def _get_docx_parsing_default_method() -> str:
+    method = (
+        os.getenv("DOCX_PARSING_DEFAULT_METHOD", DEFAULT_DOCX_PARSING_METHOD)
+        .strip()
+        .lower()
+    )
+    if method in {
+        DOCX_PARSING_METHOD_PLAIN_TEXT,
+        DOCX_PARSING_METHOD_LIGHTRAG_DOCUMENT,
+    }:
+        return method
+
+    logger.warning(
+        "Invalid DOCX_PARSING_DEFAULT_METHOD=%r. Falling back to %s.",
+        method,
+        DOCX_PARSING_METHOD_PLAIN_TEXT,
+    )
+    return DOCX_PARSING_METHOD_PLAIN_TEXT
 
 
 # Function to format datetime to ISO format string with timezone information
@@ -1504,28 +1531,47 @@ async def pipeline_enqueue_file(
                         return False, track_id
 
                 case ".docx":
-                    # Defer parsing to three-stage pipeline (parse_native / parse_docling).
-                    # Enqueue with pending_parse format so parse worker handles extraction.
-                    logger.info(
-                        f"[File Extraction]DOCX deferred to pipeline: {file_path.name}"
-                    )
-                    try:
-                        await rag.apipeline_enqueue_documents(
-                            "",
-                            file_paths=str(file_path),
-                            track_id=track_id,
-                            docs_format=FULL_DOCS_FORMAT_PENDING_PARSE,
-                        )
+                    docx_parsing_method = _get_docx_parsing_default_method()
+                    if docx_parsing_method == DOCX_PARSING_METHOD_LIGHTRAG_DOCUMENT:
                         logger.info(
-                            f"Successfully enqueued DOCX for pipeline parsing: {file_path.name}"
+                            f"[File Extraction]DOCX deferred to pipeline: {file_path.name}"
                         )
-                        return True, track_id
+                        try:
+                            await rag.apipeline_enqueue_documents(
+                                "",
+                                file_paths=str(file_path),
+                                track_id=track_id,
+                                docs_format=FULL_DOCS_FORMAT_PENDING_PARSE,
+                            )
+                            logger.info(
+                                f"Successfully enqueued DOCX for pipeline parsing: {file_path.name}"
+                            )
+                            return True, track_id
+                        except Exception as e:
+                            error_files = [
+                                {
+                                    "file_path": str(file_path.name),
+                                    "error_description": "[File Extraction]DOCX enqueue error",
+                                    "original_error": f"Failed to enqueue DOCX for pipeline: {str(e)}",
+                                    "file_size": file_size,
+                                }
+                            ]
+                            await rag.apipeline_enqueue_error_documents(
+                                error_files, track_id
+                            )
+                            logger.error(
+                                f"[File Extraction]Error enqueuing DOCX {file_path.name}: {str(e)}"
+                            )
+                            return False, track_id
+
+                    try:
+                        content = await asyncio.to_thread(_extract_docx, file)
                     except Exception as e:
                         error_files = [
                             {
                                 "file_path": str(file_path.name),
-                                "error_description": "[File Extraction]DOCX enqueue error",
-                                "original_error": f"Failed to enqueue DOCX for pipeline: {str(e)}",
+                                "error_description": "[File Extraction]DOCX processing error",
+                                "original_error": f"Failed to extract text from DOCX: {str(e)}",
                                 "file_size": file_size,
                             }
                         ]
@@ -1533,7 +1579,7 @@ async def pipeline_enqueue_file(
                             error_files, track_id
                         )
                         logger.error(
-                            f"[File Extraction]Error enqueuing DOCX {file_path.name}: {str(e)}"
+                            f"[File Extraction]Error processing DOCX {file_path.name}: {str(e)}"
                         )
                         return False, track_id
 

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -1016,42 +1016,6 @@ async def get_existing_doc_by_file_path_candidates(
     return None
 
 
-async def move_docx_to_parsed_after_processing(
-    rag: LightRAG, file_path: Path, track_id: str | None
-) -> None:
-    """Archive a DOCX source file only after this pipeline run processed it."""
-    if file_path.suffix.lower() != ".docx":
-        return
-
-    doc_id = compute_mdhash_id(str(file_path), prefix="doc-")
-    doc_status = await rag.doc_status.get_by_id(doc_id)
-    if not doc_status:
-        logger.debug(
-            f"Skipping DOCX archive for {file_path.name}: no document status found"
-        )
-        return
-
-    status = get_doc_status_value(doc_status)
-    status_track_id = get_doc_track_id(doc_status)
-    if status != DocStatus.PROCESSED.value:
-        logger.debug(
-            f"Skipping DOCX archive for {file_path.name}: document status is {status}"
-        )
-        return
-    if track_id and status_track_id and status_track_id != track_id:
-        logger.debug(
-            f"Skipping DOCX archive for {file_path.name}: track_id does not match current run"
-        )
-        return
-
-    try:
-        await move_file_to_parsed_dir(file_path)
-    except Exception as move_error:
-        logger.error(
-            f"Failed to move file {file_path.name} to {PARSED_DIR_NAME} directory: {move_error}"
-        )
-
-
 # Document processing helper functions (synchronous)
 # These functions run in thread pool via asyncio.to_thread() to avoid blocking the event loop
 
@@ -1786,14 +1750,9 @@ async def pipeline_index_file(rag: LightRAG, file_path: Path, track_id: str = No
         track_id: Optional tracking ID
     """
     try:
-        success, returned_track_id = await pipeline_enqueue_file(
-            rag, file_path, track_id
-        )
+        success, _ = await pipeline_enqueue_file(rag, file_path, track_id)
         if success:
             await rag.apipeline_process_enqueue_documents()
-            await move_docx_to_parsed_after_processing(
-                rag, file_path, returned_track_id
-            )
 
     except Exception as e:
         logger.error(f"Error indexing file {file_path.name}: {str(e)}")
@@ -1814,7 +1773,6 @@ async def pipeline_index_files(
         return
     try:
         enqueued = False
-        enqueued_docx_files: list[tuple[Path, str]] = []
 
         # Use get_pinyin_sort_key for Chinese pinyin sorting
         sorted_file_paths = sorted(
@@ -1823,21 +1781,13 @@ async def pipeline_index_files(
 
         # Process files sequentially with track_id
         for file_path in sorted_file_paths:
-            success, returned_track_id = await pipeline_enqueue_file(
-                rag, file_path, track_id
-            )
+            success, _ = await pipeline_enqueue_file(rag, file_path, track_id)
             if success:
                 enqueued = True
-                if file_path.suffix.lower() == ".docx":
-                    enqueued_docx_files.append((file_path, returned_track_id))
 
         # Process the queue only if at least one file was successfully enqueued
         if enqueued:
             await rag.apipeline_process_enqueue_documents()
-            for docx_file_path, returned_track_id in enqueued_docx_files:
-                await move_docx_to_parsed_after_processing(
-                    rag, docx_file_path, returned_track_id
-                )
     except Exception as e:
         logger.error(f"Error indexing files: {str(e)}")
         logger.error(traceback.format_exc())

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -84,7 +84,11 @@ FULL_DOCS_FORMAT_LIGHTRAG = "lightrag"  # content in LightRAG Document files
 FULL_DOCS_FORMAT_PENDING_PARSE = (
     "pending_parse"  # file saved but not yet parsed; parse_native will read from disk
 )
+DOCX_PARSING_METHOD_PLAIN_TEXT = "plain_text"
+DOCX_PARSING_METHOD_LIGHTRAG_DOCUMENT = "lightrag_document"
+DEFAULT_DOCX_PARSING_METHOD = DOCX_PARSING_METHOD_PLAIN_TEXT
 PARSED_DIR_NAME = "__parsed__"  # Dir for parsed files (renamed from __enqueued__)
+
 DEFAULT_MAX_PARALLEL_ANALYZE = 2  # Multimodal analysis (VLM) concurrency
 
 # Embedding configuration defaults

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -4933,80 +4933,49 @@ class LightRAG:
             source_path = self._resolve_source_file_for_parser(file_path)
             p = Path(source_path)
             if p.exists() and p.is_file() and p.suffix.lower() == ".docx":
-                try:
-                    from lightrag.extraction.parse_document import (
-                        parse_docx_to_interchange_jsonl,
+                from lightrag.extraction.parse_document import (
+                    parse_docx_to_interchange_jsonl,
+                )
+
+                file_bytes = await asyncio.to_thread(p.read_bytes)
+                parsed_dir = Path(self.working_dir) / PARSED_DIR_NAME
+                parsed_dir.mkdir(parents=True, exist_ok=True)
+                output_dir = str(parsed_dir)
+                interchange_text = await asyncio.to_thread(
+                    parse_docx_to_interchange_jsonl,
+                    file_bytes,
+                    p.name,
+                    doc_id,
+                    output_dir,
+                )
+                if not interchange_text or not interchange_text.strip():
+                    raise ValueError(
+                        f"DOCX parser returned empty content for {file_path}"
                     )
 
-                    file_bytes = await asyncio.to_thread(p.read_bytes)
-                    parsed_dir = Path(self.working_dir) / PARSED_DIR_NAME
-                    parsed_dir.mkdir(parents=True, exist_ok=True)
-                    output_dir = str(parsed_dir)
-                    interchange_text = await asyncio.to_thread(
-                        parse_docx_to_interchange_jsonl,
-                        file_bytes,
-                        p.name,
-                        doc_id,
-                        output_dir,
-                    )
-                    if interchange_text and interchange_text.strip():
-                        await self.full_docs.upsert(
-                            {
-                                doc_id: {
-                                    "content": interchange_text,
-                                    "file_path": file_path,
-                                    "format": FULL_DOCS_FORMAT_RAW,
-                                    "parsed_engine": "native",
-                                    "update_time": int(time.time()),
-                                }
-                            }
-                        )
-                        await self.full_docs.index_done_callback()
-                        await self._archive_docx_source_after_full_docs_sync(str(p))
-                        logger.info(
-                            f"[parse_native] pending_parse completed for {file_path} via interchange JSONL"
-                        )
-                        return {
-                            "doc_id": doc_id,
+                await self.full_docs.upsert(
+                    {
+                        doc_id: {
+                            "content": interchange_text,
                             "file_path": file_path,
                             "format": FULL_DOCS_FORMAT_RAW,
-                            "content": interchange_text,
-                            "blocks_path": "",
+                            "parsed_engine": "native",
+                            "update_time": int(time.time()),
                         }
-                except Exception as e:
-                    logger.warning(
-                        f"[parse_native] pending_parse interchange failed for {file_path}: {e}, fallback to basic extraction"
-                    )
-            if p.exists() and p.is_file():
-                try:
-                    file_bytes = await asyncio.to_thread(p.read_bytes)
-                    from lightrag.api.routers.document_routes import _extract_docx
-
-                    content = await asyncio.to_thread(_extract_docx, file_bytes)
-                    await self.full_docs.upsert(
-                        {
-                            doc_id: {
-                                "content": content,
-                                "file_path": file_path,
-                                "format": FULL_DOCS_FORMAT_RAW,
-                                "parsed_engine": "native",
-                                "update_time": int(time.time()),
-                            }
-                        }
-                    )
-                    await self.full_docs.index_done_callback()
-                    await self._archive_docx_source_after_full_docs_sync(str(p))
-                    return {
-                        "doc_id": doc_id,
-                        "file_path": file_path,
-                        "format": FULL_DOCS_FORMAT_RAW,
-                        "content": content,
-                        "blocks_path": "",
                     }
-                except Exception as fallback_err:
-                    logger.warning(
-                        f"[parse_native] pending_parse fallback also failed for {file_path}: {fallback_err}"
-                    )
+                )
+                await self.full_docs.index_done_callback()
+                await self._archive_docx_source_after_full_docs_sync(str(p))
+                logger.info(
+                    f"[parse_native] pending_parse completed for {file_path} via interchange JSONL"
+                )
+                return {
+                    "doc_id": doc_id,
+                    "file_path": file_path,
+                    "format": FULL_DOCS_FORMAT_RAW,
+                    "content": interchange_text,
+                    "blocks_path": "",
+                }
             return {
                 "doc_id": doc_id,
                 "file_path": file_path,

--- a/tests/test_document_routes_docx_archive.py
+++ b/tests/test_document_routes_docx_archive.py
@@ -128,7 +128,7 @@ class _ParseRag:
         return file_path
 
 
-async def test_pipeline_index_file_moves_processed_docx_to_parsed(
+async def test_pipeline_index_file_leaves_lightrag_document_docx_for_parser_archive(
     tmp_path, monkeypatch
 ):
     monkeypatch.setenv("DOCX_PARSING_DEFAULT_METHOD", "lightrag_document")
@@ -138,24 +138,30 @@ async def test_pipeline_index_file_moves_processed_docx_to_parsed(
 
     await pipeline_index_file(rag, file_path, "track-docx")
 
-    assert not file_path.exists()
-    assert (tmp_path / PARSED_DIR_NAME / file_path.name).exists()
+    assert file_path.exists()
+    assert not (tmp_path / PARSED_DIR_NAME / file_path.name).exists()
     assert rag.enqueued[0]["file_path"] == str(file_path)
     assert rag.enqueued[0]["docs_format"] == FULL_DOCS_FORMAT_PENDING_PARSE
 
 
-async def test_pipeline_index_file_keeps_failed_docx_in_input_dir(
+async def test_pipeline_enqueue_lightrag_document_docx_does_not_move_source(
     tmp_path, monkeypatch
 ):
     monkeypatch.setenv("DOCX_PARSING_DEFAULT_METHOD", "lightrag_document")
-    file_path = tmp_path / "failed.docx"
+    file_path = tmp_path / "pending.docx"
     file_path.write_bytes(b"docx bytes")
-    rag = _FakeRag(final_status=DocStatus.FAILED)
+    rag = _FakeRag()
 
-    await pipeline_index_file(rag, file_path, "track-docx")
+    success, returned_track_id = await pipeline_enqueue_file(
+        rag, file_path, "track-docx"
+    )
 
+    assert success is True
+    assert returned_track_id == "track-docx"
     assert file_path.exists()
     assert not (tmp_path / PARSED_DIR_NAME / file_path.name).exists()
+    assert rag.enqueued[0]["file_path"] == str(file_path)
+    assert rag.enqueued[0]["docs_format"] == FULL_DOCS_FORMAT_PENDING_PARSE
 
 
 async def test_pipeline_enqueue_docx_plain_text_extracts_before_enqueue(
@@ -187,7 +193,31 @@ async def test_pipeline_enqueue_docx_plain_text_extracts_before_enqueue(
     assert (tmp_path / PARSED_DIR_NAME / file_path.name).exists()
 
 
-async def test_pipeline_index_files_moves_processed_docx_batch(tmp_path, monkeypatch):
+async def test_pipeline_enqueue_md_moves_after_enqueue(tmp_path, monkeypatch):
+    monkeypatch.setenv("DOCX_PARSING_DEFAULT_METHOD", "plain_text")
+    file_path = tmp_path / "notes.md"
+    file_path.write_text("# Notes\n\nmarkdown content", encoding="utf-8")
+    rag = _FakeRag()
+
+    success, returned_track_id = await pipeline_enqueue_file(rag, file_path, "track-md")
+
+    assert success is True
+    assert returned_track_id == "track-md"
+    assert rag.enqueued == [
+        {
+            "input": "# Notes\n\nmarkdown content",
+            "file_path": file_path.name,
+            "track_id": "track-md",
+            "docs_format": None,
+        }
+    ]
+    assert not file_path.exists()
+    assert (tmp_path / PARSED_DIR_NAME / file_path.name).exists()
+
+
+async def test_pipeline_index_files_leaves_lightrag_document_docx_batch(
+    tmp_path, monkeypatch
+):
     monkeypatch.setenv("DOCX_PARSING_DEFAULT_METHOD", "lightrag_document")
     first = tmp_path / "first.docx"
     second = tmp_path / "second.[mineru].docx"
@@ -197,10 +227,13 @@ async def test_pipeline_index_files_moves_processed_docx_batch(tmp_path, monkeyp
 
     await pipeline_index_files(rag, [second, first], "track-scan")
 
-    assert not first.exists()
-    assert not second.exists()
-    assert (tmp_path / PARSED_DIR_NAME / first.name).exists()
-    assert (tmp_path / PARSED_DIR_NAME / second.name).exists()
+    assert first.exists()
+    assert second.exists()
+    assert not (tmp_path / PARSED_DIR_NAME / first.name).exists()
+    assert not (tmp_path / PARSED_DIR_NAME / second.name).exists()
+    assert all(
+        item["docs_format"] == FULL_DOCS_FORMAT_PENDING_PARSE for item in rag.enqueued
+    )
 
 
 async def test_scan_existing_full_path_docx_does_not_reenqueue(tmp_path, monkeypatch):

--- a/tests/test_document_routes_docx_archive.py
+++ b/tests/test_document_routes_docx_archive.py
@@ -22,6 +22,7 @@ compute_mdhash_id = _utils.compute_mdhash_id
 LightRAG = _lightrag.LightRAG
 pipeline_index_file = _document_routes.pipeline_index_file
 pipeline_index_files = _document_routes.pipeline_index_files
+pipeline_enqueue_file = _document_routes.pipeline_enqueue_file
 run_scanning_process = _document_routes.run_scanning_process
 DocumentManager = _document_routes.DocumentManager
 create_document_routes = _document_routes.create_document_routes
@@ -127,7 +128,10 @@ class _ParseRag:
         return file_path
 
 
-async def test_pipeline_index_file_moves_processed_docx_to_parsed(tmp_path):
+async def test_pipeline_index_file_moves_processed_docx_to_parsed(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DOCX_PARSING_DEFAULT_METHOD", "lightrag_document")
     file_path = tmp_path / "sample.[docling].docx"
     file_path.write_bytes(b"docx bytes")
     rag = _FakeRag()
@@ -140,7 +144,10 @@ async def test_pipeline_index_file_moves_processed_docx_to_parsed(tmp_path):
     assert rag.enqueued[0]["docs_format"] == FULL_DOCS_FORMAT_PENDING_PARSE
 
 
-async def test_pipeline_index_file_keeps_failed_docx_in_input_dir(tmp_path):
+async def test_pipeline_index_file_keeps_failed_docx_in_input_dir(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DOCX_PARSING_DEFAULT_METHOD", "lightrag_document")
     file_path = tmp_path / "failed.docx"
     file_path.write_bytes(b"docx bytes")
     rag = _FakeRag(final_status=DocStatus.FAILED)
@@ -151,7 +158,37 @@ async def test_pipeline_index_file_keeps_failed_docx_in_input_dir(tmp_path):
     assert not (tmp_path / PARSED_DIR_NAME / file_path.name).exists()
 
 
-async def test_pipeline_index_files_moves_processed_docx_batch(tmp_path):
+async def test_pipeline_enqueue_docx_plain_text_extracts_before_enqueue(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DOCX_PARSING_DEFAULT_METHOD", "plain_text")
+    monkeypatch.setattr(
+        _document_routes, "_extract_docx", lambda file_bytes: "plain docx content"
+    )
+    file_path = tmp_path / "plain.docx"
+    file_path.write_bytes(b"docx bytes")
+    rag = _FakeRag()
+
+    success, returned_track_id = await pipeline_enqueue_file(
+        rag, file_path, "track-docx"
+    )
+
+    assert success is True
+    assert returned_track_id == "track-docx"
+    assert rag.enqueued == [
+        {
+            "input": "plain docx content",
+            "file_path": file_path.name,
+            "track_id": "track-docx",
+            "docs_format": None,
+        }
+    ]
+    assert not file_path.exists()
+    assert (tmp_path / PARSED_DIR_NAME / file_path.name).exists()
+
+
+async def test_pipeline_index_files_moves_processed_docx_batch(tmp_path, monkeypatch):
+    monkeypatch.setenv("DOCX_PARSING_DEFAULT_METHOD", "lightrag_document")
     first = tmp_path / "first.docx"
     second = tmp_path / "second.[mineru].docx"
     first.write_bytes(b"first docx bytes")
@@ -273,6 +310,65 @@ async def test_parse_native_archives_docx_after_full_docs_sync(tmp_path, monkeyp
     assert not source_path.exists()
     assert (tmp_path / PARSED_DIR_NAME / source_path.name).exists()
     assert rag.full_docs.data["doc-test"]["parsed_engine"] == "native"
+
+
+async def test_parse_native_docx_interchange_failure_raises_without_fallback(
+    tmp_path, monkeypatch
+):
+    source_path = tmp_path / "interchange-failure.docx"
+    source_path.write_bytes(b"docx bytes")
+    rag = _ParseRag(tmp_path / "work", source_path)
+    parse_document = importlib.import_module("lightrag.extraction.parse_document")
+
+    def _raise_parser(file_bytes, source_file, doc_id, output_dir):
+        raise RuntimeError("interchange boom")
+
+    def _fail_fallback(file_bytes):
+        raise AssertionError("plain text fallback should not run")
+
+    monkeypatch.setattr(
+        parse_document, "parse_docx_to_interchange_jsonl", _raise_parser
+    )
+    monkeypatch.setattr(_document_routes, "_extract_docx", _fail_fallback)
+
+    with pytest.raises(RuntimeError, match="interchange boom"):
+        await LightRAG.parse_native(
+            rag,
+            "doc-test",
+            str(source_path),
+            {"format": FULL_DOCS_FORMAT_PENDING_PARSE, "content": ""},
+        )
+
+    assert source_path.exists()
+    assert rag.full_docs.events == []
+
+
+async def test_parse_native_docx_empty_interchange_result_raises_without_fallback(
+    tmp_path, monkeypatch
+):
+    source_path = tmp_path / "empty-interchange.docx"
+    source_path.write_bytes(b"docx bytes")
+    rag = _ParseRag(tmp_path / "work", source_path)
+    parse_document = importlib.import_module("lightrag.extraction.parse_document")
+
+    def _fail_fallback(file_bytes):
+        raise AssertionError("plain text fallback should not run")
+
+    monkeypatch.setattr(
+        parse_document, "parse_docx_to_interchange_jsonl", lambda *args: " \n\t"
+    )
+    monkeypatch.setattr(_document_routes, "_extract_docx", _fail_fallback)
+
+    with pytest.raises(ValueError, match="empty content"):
+        await LightRAG.parse_native(
+            rag,
+            "doc-test",
+            str(source_path),
+            {"format": FULL_DOCS_FORMAT_PENDING_PARSE, "content": ""},
+        )
+
+    assert source_path.exists()
+    assert rag.full_docs.events == []
 
 
 def test_lightrag_document_reprocess_uses_full_docs_without_reparse():


### PR DESCRIPTION
## Description

Refactor DOCX parsing archive behavior so plain-text DOCX files follow the same immediate post-enqueue archive flow as other non-deferred files, while deferred LightRAG Document DOCX parsing archives the source only after parser output is persisted.

## Related Issues

n/a

## Changes Made

- Add a configurable `DOCX_PARSING_DEFAULT_METHOD` with `plain_text` as the default and `lightrag_document` for deferred structured DOCX parsing.
- Route `plain_text` DOCX files through the same extraction/enqueue/archive path used by Markdown and other non-deferred files.
- Persist `parse_docx_to_interchange_jsonl` output before archiving deferred DOCX sources, and fail without falling back to plain text when structured parsing fails.
- Remove the route-level DOCX post-processing archive fallback and update archive timing tests for the new ownership model.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Local validation:

- `./scripts/test.sh tests/test_document_routes_docx_archive.py`
- `ruff check lightrag/api/routers/document_routes.py tests/test_document_routes_docx_archive.py`
