### PR TITLE
Refactor file parser routing

### DIFF
--- a/docs/AdvancedFeatures.md
+++ b/docs/AdvancedFeatures.md
@@ -18,12 +18,12 @@ LightRAG Server includes a multimodal document pipeline for text, images, tables
 Configure parser routing and external parser service endpoints in `.env`:
 
 ```bash
-LIGHTRAG_PARSER=pdf:mineru,docx:docling,pptx:docling,*:native
+LIGHTRAG_PARSER=pdf:mineru,docx:docling,pptx:docling,xlsx:docling,*:legacy
 MINERU_ENDPOINT=http://localhost:8000/api/v1/task
 DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
 ```
 
-Then upload documents through LightRAG Server. Parsed multimodal sidecars are written by the pipeline and consumed by the normal indexing flow.
+Then upload documents through LightRAG Server. `LIGHTRAG_PARSER` rules match suffixes such as `pdf`, may be separated with commas or semicolons, and are evaluated from left to right. If a rule enables MinerU or Docling, the matching endpoint must be configured before server startup. Per-file hints such as `paper.[mineru].pdf` and `memo.[native].docx` override the default rules. Parsed multimodal sidecars are written by the pipeline and consumed by the normal indexing flow. See [File Processing Configuration](./FileProcessingConfiguration-zh.md) for detailed routing rules and examples.
 
 ---
 

--- a/docs/FileProcessingConfiguration-zh.md
+++ b/docs/FileProcessingConfiguration-zh.md
@@ -1,21 +1,21 @@
 # 文件处理方式配置指南
 
-LightRAG Server 支持按文件后缀或文件名为不同文件选择不同的内容抽取引擎。默认行为保持向后兼容：如果不配置 `LIGHTRAG_PARSER`，文件会走 `legacy` 本地抽取方式。
+从 LightRAG Server v1.5.0 开始，文件索引流水线支持使用外部的 MinerU 和 Docling 引擎进行文件内容的分析抽取，抽取内容将以 `LightRAG Document` 格式保存到`INPUT`输入目录下的 `__parsed__`子目录。`LightRAG Document`文件格式支持表格和图片等多模态数据，同时包含文章的章节段落元数据，方便日后进行内容溯源。LightRAG还提供了一个内置的 native 文件抽取引擎，可以高效地实现 docx 的智能内容抽取，支持章节标题、自动编号、表格和图片等内容的精确提取。
 
-## 抽取引擎
+## 支持的抽取引擎类型
 
-| 引擎 | 说明 | 默认支持后缀 |
+| 引擎 | 说明 | 支持的文件格式（后缀） |
 | --- | --- | --- |
-| `legacy` | 旧版兼容方式，在文件入队前由 API 进程本地抽取文本。 | Server 上传支持的全部后缀 |
-| `native` | LightRAG 内置结构化抽取器。当前仅支持 DOCX。 | `docx` |
-| `mineru` | 通过外部 MinerU 服务抽取文件内容。 | `pdf`, `docx`, `pptx`, `xlsx` |
-| `docling` | 通过外部 Docling 服务抽取文件内容。 | `pdf`, `docx`, `pptx`, `xlsx`, `md`, `html`, `xhtml`, `png`, `jpg`, `jpeg`, `tiff`, `webp`, `bmp` |
+| `legacy` | 旧版提取方式，在加入管线前集中提取内容 | `txt` `md` `mdx` `pdf` `docx` `pptx` `xlsx` `rtf` `odt` `tex` `epub` `html` `htm` `csv` `json` `xml` `yaml` `yml` `log` `conf` `ini` `properties` `sql` `bat` `sh` `c` `h` `cpp` `hpp` `py` `java` `js` `ts` `swift` `go` `rb` `php` `css` `scss` `less` |
+| `native` | 内置智能结构化内容抽取器 | `docx` |
+| `mineru` | 外部 MinerU 内容提取引擎 | `pdf`  `docx`  `pptx`  `xlsx` |
+| `docling` | 外部 Docling 内容提取引擎 | `pdf` `docx` `pptx` `xlsx` `md` `html` `xhtml` `png` `jpg` `jpeg` `tiff` `webp` `bmp` |
 
-外部引擎需要配置对应 endpoint。只要 `LIGHTRAG_PARSER` 中启用了 `mineru` 或 `docling`，服务启动时就会检查 `MINERU_ENDPOINT` 或 `DOCLING_ENDPOINT` 是否已配置；缺失时启动失败，避免文件静默回退到其他引擎。
+> 为了向后兼容，在未修改配置的情况下升级系统文件内容提取方式方式会维持原来的legacy不变。如需启用新的内容处理引擎，需要按照以下方式来配置
 
-## 默认路由规则
+## 修改默认内容抽取方式
 
-使用 `.env` 中的 `LIGHTRAG_PARSER` 配置默认文件处理方式：
+使用环境变量 `LIGHTRAG_PARSER`可以给不同的文件后最配资默认的文件内容提取方式：
 
 ```bash
 LIGHTRAG_PARSER=pdf:mineru,docx:docling,pptx:docling,xlsx:docling,*:legacy
@@ -34,12 +34,12 @@ DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
 
 - 左侧匹配的是文件后缀，不是完整文件名；应写 `pdf:mineru`，不要写 `*.pdf:mineru`。
 - 规则可以使用英文逗号 `,` 或分号 `;` 分隔。
-- 规则按从左到右的顺序检查；通配符规则应放在最后。
-- 启动时会严格校验规则：未知引擎、错误后缀写法、显式使用不支持的后缀、外部引擎缺少 endpoint 都会导致启动失败。
+- 规则按从左到右的顺序检查；优先规则放在前面；通配符规则应放在最后。
+- 启动时会严格校验规则：未知内容提取引擎、错误后缀写法、显式使用不支持的后缀、外部引擎缺少 endpoint 都会导致启动失败。
 - 通配符规则只会让引擎处理其能力表支持的后缀。例如 `*:mineru;html:docling` 中，MinerU 只接管 MinerU 支持的后缀，`html` 会继续匹配到后续 `docling` 规则。
-- 如果所有规则都不可用，最终回退到 `legacy`。
+- 如果所有规则都不可用，文件内容提取方式会回退到 `legacy`，如果legacy也不支持对应的文件后缀，会向系统加一个错误条目，上传文件保留在`INPUT`目录。
 
-## 单文件覆盖
+## 对单文件指定内容抽取方式
 
 可以在文件名中使用中括号临时指定单个文件的处理方式：
 
@@ -50,7 +50,7 @@ memo.[native].docx
 report.[legacy].pdf
 ```
 
-文件名 hint 的优先级高于 `LIGHTRAG_PARSER`。如果指定的引擎不支持该后缀，系统会回退到默认规则继续选择可用引擎。外部引擎仍需要配置对应 endpoint。
+文件名 hint 的优先级高于 `LIGHTRAG_PARSER`。如果指定的引擎不支持该后缀，系统会回退到默认规则继续选择可用引擎。如果所有规则都不可用，文件内容提取方式会回退到 `legacy`，如果legacy也不支持对应的文件后缀，会向系统加一个错误条目，上传文件保留在`INPUT`目录。
 
 ## 推荐配置
 
@@ -64,35 +64,27 @@ report.[legacy].pdf
 
 所有文件按旧版 `legacy` 本地抽取方式处理。
 
-### 使用 MinerU 处理 PDF，Docling 处理 Office
-
-```bash
-LIGHTRAG_PARSER=pdf:mineru,docx:docling,pptx:docling,xlsx:docling,*:legacy
-MINERU_ENDPOINT=http://localhost:8000/api/v1/task
-DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
-```
-
-适合包含复杂 PDF、PPTX、XLSX、DOCX 的场景。
-
-### 使用 LightRAG native DOCX 解析
+使用Native引擎处理docx文件，其余保持旧版行为：
 
 ```bash
 LIGHTRAG_PARSER=docx:native
 ```
 
-DOCX 会进入 LightRAG 内置 DOCX 解析流程，其余文件继续按旧版方式处理。
+### 梦幻组合
 
-### 使用通配符启用 MinerU，再指定 HTML 走 Docling
+* 使用Legacy处理md（写在最前面是为了避免用Docling处理md文件）
+* 使用Native处理docx文件（写在最前面是为了避免用MinerU处理docx文件）
+* 用MinerU 处理其自此的（自此的 PDF和其余Office)
+* 让Docling 处理其余它自此的文件格式（HTML和图片等）
+* 企业文件格式用Legacy
 
 ```bash
-LIGHTRAG_PARSER=*:mineru;html:docling
+LIGHTRAG_PARSER=md:legacy,docx:native,*:mineru,*:docling,*:legacy
 MINERU_ENDPOINT=http://localhost:8000/api/v1/task
 DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
 ```
 
-该配置是合法的。MinerU 只会处理其能力表支持的后缀；`html` 不在 MinerU 能力表内，因此会继续匹配到 `html:docling`。其他不被 MinerU 或 Docling 接管的后缀会回退到 `legacy`。
-
-## 处理状态和存储字段
+## `full_docs`存储存储说明
 
 文件入队和抽取结果会写入 `full_docs`：
 
@@ -110,15 +102,3 @@ DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
 - `legacy`：本地抽取成功并入队后，原文件会移动到同级 `__parsed__` 目录。
 - `native` / `mineru` / `docling`：文件先保留在原位置供 pipeline 解析；解析成功并写入 `full_docs` 后，原文件再移动到 `__parsed__`。
 - 解析失败时，原文件不会移动，便于修复配置后重新处理。
-
-## DOCX 配置
-
-DOCX 处理方式统一使用 `LIGHTRAG_PARSER` 控制：
-
-```bash
-# 使用旧版本地文本抽取
-LIGHTRAG_PARSER=docx:legacy
-
-# 使用 LightRAG native DOCX 解析
-LIGHTRAG_PARSER=docx:native
-```

--- a/docs/FileProcessingConfiguration-zh.md
+++ b/docs/FileProcessingConfiguration-zh.md
@@ -1,0 +1,124 @@
+# 文件处理方式配置指南
+
+LightRAG Server 支持按文件后缀或文件名为不同文件选择不同的内容抽取引擎。默认行为保持向后兼容：如果不配置 `LIGHTRAG_PARSER`，文件会走 `legacy` 本地抽取方式。
+
+## 抽取引擎
+
+| 引擎 | 说明 | 默认支持后缀 |
+| --- | --- | --- |
+| `legacy` | 旧版兼容方式，在文件入队前由 API 进程本地抽取文本。 | Server 上传支持的全部后缀 |
+| `native` | LightRAG 内置结构化抽取器。当前仅支持 DOCX。 | `docx` |
+| `mineru` | 通过外部 MinerU 服务抽取文件内容。 | `pdf`, `docx`, `pptx`, `xlsx` |
+| `docling` | 通过外部 Docling 服务抽取文件内容。 | `pdf`, `docx`, `pptx`, `xlsx`, `md`, `html`, `xhtml`, `png`, `jpg`, `jpeg`, `tiff`, `webp`, `bmp` |
+
+外部引擎需要配置对应 endpoint。只要 `LIGHTRAG_PARSER` 中启用了 `mineru` 或 `docling`，服务启动时就会检查 `MINERU_ENDPOINT` 或 `DOCLING_ENDPOINT` 是否已配置；缺失时启动失败，避免文件静默回退到其他引擎。
+
+## 默认路由规则
+
+使用 `.env` 中的 `LIGHTRAG_PARSER` 配置默认文件处理方式：
+
+```bash
+LIGHTRAG_PARSER=pdf:mineru,docx:docling,pptx:docling,xlsx:docling,*:legacy
+MINERU_ENDPOINT=http://localhost:8000/api/v1/task
+DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
+```
+
+规则格式：
+
+```text
+后缀:引擎,后缀:引擎,*:legacy
+后缀:引擎;后缀:引擎;*:legacy
+```
+
+注意事项：
+
+- 左侧匹配的是文件后缀，不是完整文件名；应写 `pdf:mineru`，不要写 `*.pdf:mineru`。
+- 规则可以使用英文逗号 `,` 或分号 `;` 分隔。
+- 规则按从左到右的顺序检查；通配符规则应放在最后。
+- 启动时会严格校验规则：未知引擎、错误后缀写法、显式使用不支持的后缀、外部引擎缺少 endpoint 都会导致启动失败。
+- 通配符规则只会让引擎处理其能力表支持的后缀。例如 `*:mineru;html:docling` 中，MinerU 只接管 MinerU 支持的后缀，`html` 会继续匹配到后续 `docling` 规则。
+- 如果所有规则都不可用，最终回退到 `legacy`。
+
+## 单文件覆盖
+
+可以在文件名中使用中括号临时指定单个文件的处理方式：
+
+```text
+paper.[mineru].pdf
+slides.[docling].pptx
+memo.[native].docx
+report.[legacy].pdf
+```
+
+文件名 hint 的优先级高于 `LIGHTRAG_PARSER`。如果指定的引擎不支持该后缀，系统会回退到默认规则继续选择可用引擎。外部引擎仍需要配置对应 endpoint。
+
+## 推荐配置
+
+### 保持旧版行为
+
+不配置 `LIGHTRAG_PARSER`：
+
+```bash
+# LIGHTRAG_PARSER=
+```
+
+所有文件按旧版 `legacy` 本地抽取方式处理。
+
+### 使用 MinerU 处理 PDF，Docling 处理 Office
+
+```bash
+LIGHTRAG_PARSER=pdf:mineru,docx:docling,pptx:docling,xlsx:docling,*:legacy
+MINERU_ENDPOINT=http://localhost:8000/api/v1/task
+DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
+```
+
+适合包含复杂 PDF、PPTX、XLSX、DOCX 的场景。
+
+### 使用 LightRAG native DOCX 解析
+
+```bash
+LIGHTRAG_PARSER=docx:native
+```
+
+DOCX 会进入 LightRAG 内置 DOCX 解析流程，其余文件继续按旧版方式处理。
+
+### 使用通配符启用 MinerU，再指定 HTML 走 Docling
+
+```bash
+LIGHTRAG_PARSER=*:mineru;html:docling
+MINERU_ENDPOINT=http://localhost:8000/api/v1/task
+DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
+```
+
+该配置是合法的。MinerU 只会处理其能力表支持的后缀；`html` 不在 MinerU 能力表内，因此会继续匹配到 `html:docling`。其他不被 MinerU 或 Docling 接管的后缀会回退到 `legacy`。
+
+## 处理状态和存储字段
+
+文件入队和抽取结果会写入 `full_docs`：
+
+| 字段 | 说明 |
+| --- | --- |
+| `parsed_engine` | 实际完成抽取的引擎：`legacy`, `native`, `mineru`, `docling`。对于待抽取文件，也可暂存目标引擎。 |
+| `format` | 内容格式：`pending_parse`, `raw`, `lightrag`。 |
+| `content` | `raw` 时保存抽取文本；`pending_parse` 时为空字符串；`lightrag` 时固定为 `{{stored-in-lightrag-doucment}}`。 |
+| `lightrag_document_path` | `format=lightrag` 时保存结构化 LightRAG Document 的相对路径。 |
+
+`pending_parse` 表示文件已经入队，但还没有完成抽取。抽取成功后会改写为 `raw` 或 `lightrag`。抽取失败时保留 `pending_parse` 和空 `content`，便于后续排查和重试。
+
+## 原始文件归档
+
+- `legacy`：本地抽取成功并入队后，原文件会移动到同级 `__parsed__` 目录。
+- `native` / `mineru` / `docling`：文件先保留在原位置供 pipeline 解析；解析成功并写入 `full_docs` 后，原文件再移动到 `__parsed__`。
+- 解析失败时，原文件不会移动，便于修复配置后重新处理。
+
+## DOCX 配置
+
+DOCX 处理方式统一使用 `LIGHTRAG_PARSER` 控制：
+
+```bash
+# 使用旧版本地文本抽取
+LIGHTRAG_PARSER=docx:legacy
+
+# 使用 LightRAG native DOCX 解析
+LIGHTRAG_PARSER=docx:native
+```

--- a/env.docker-compose-full
+++ b/env.docker-compose-full
@@ -229,7 +229,11 @@ ENTITY_EXTRACTION_USE_JSON=true
 
 ### Multimodal parsing/analyze integration
 ### Optional parser routing rules, for example:
-###   pdf:mineru-iet,docx:docling,pptx:docling,*:native
+###   pdf:mineru,docx:docling,pptx:docling,xlsx:docling,*:legacy
+### Rules may be separated with commas or semicolons. Rules match file suffixes
+### (pdf), not full names (*.pdf), and are checked left-to-right.
+### If mineru/docling appears in LIGHTRAG_PARSER, the corresponding endpoint
+### below must be configured before server startup.
 # LIGHTRAG_PARSER=
 ### Retry count for multimodal VLM analysis JSON normalization/writeback
 # VLM_ANALYZE_RETRIES=2

--- a/env.example
+++ b/env.example
@@ -226,13 +226,13 @@ ENTITY_EXTRACTION_USE_JSON=true
 ###   addon_params={"entity_types_guidance": "- CustomType: description..."}
 # ENTITY_TYPE_PROMPT_FILE=entity_type_prompt.yml
 
-### DOCX parsing method: plain_text (legacy) or lightrag_document (structured)
-### Default: plain_text
-# DOCX_PARSING_DEFAULT_METHOD=plain_text
-
 ### Multimodal parsing/analyze integration
 ### Optional parser routing rules, for example:
-###   pdf:mineru-iet,docx:docling,pptx:docling,*:native
+###   pdf:mineru,docx:docling,pptx:docling,xlsx:docling,*:legacy
+### Rules may be separated with commas or semicolons. Rules match file suffixes
+### (pdf), not full names (*.pdf), and are checked left-to-right.
+### If mineru/docling appears in LIGHTRAG_PARSER, the corresponding endpoint
+### below must be configured before server startup.
 # LIGHTRAG_PARSER=
 ### Retry count for multimodal VLM analysis JSON normalization/writeback
 # VLM_ANALYZE_RETRIES=2

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -49,6 +49,7 @@ from lightrag.api.routers.document_routes import (
     DocumentManager,
     create_document_routes,
 )
+from lightrag.parser_routing import validate_parser_routing_config
 from lightrag.api.routers.query_routes import create_query_routes
 from lightrag.api.routers.graph_routes import create_graph_routes
 from lightrag.api.routers.ollama_api import OllamaAPI
@@ -385,6 +386,7 @@ def create_app(args):
     # Setup logging
     logger.setLevel(args.log_level)
     set_verbose_debug(args.verbose)
+    validate_parser_routing_config()
 
     # Create configuration cache (this will output configuration logs)
     config_cache = LLMConfigCache(args)

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -3,7 +3,6 @@ This module contains all document-related routes for the LightRAG API.
 """
 
 import asyncio
-import os
 import time
 from uuid import uuid4
 from lightrag.utils import logger, get_pinyin_sort_key, performance_timing_log
@@ -26,12 +25,11 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from lightrag import LightRAG
 from lightrag.base import DeletionResult, DocProcessingStatus, DocStatus
 from lightrag.constants import (
-    DEFAULT_DOCX_PARSING_METHOD,
-    DOCX_PARSING_METHOD_LIGHTRAG_DOCUMENT,
-    DOCX_PARSING_METHOD_PLAIN_TEXT,
     FULL_DOCS_FORMAT_PENDING_PARSE,
+    PARSER_ENGINE_LEGACY,
     PARSED_DIR_NAME,
 )
+from lightrag.parser_routing import resolve_file_parser_engine
 from lightrag.utils import (
     generate_track_id,
     compute_mdhash_id,
@@ -40,26 +38,6 @@ from lightrag.utils import (
 )
 from lightrag.api.utils_api import get_combined_auth_dependency
 from ..config import global_args
-
-
-def _get_docx_parsing_default_method() -> str:
-    method = (
-        os.getenv("DOCX_PARSING_DEFAULT_METHOD", DEFAULT_DOCX_PARSING_METHOD)
-        .strip()
-        .lower()
-    )
-    if method in {
-        DOCX_PARSING_METHOD_PLAIN_TEXT,
-        DOCX_PARSING_METHOD_LIGHTRAG_DOCUMENT,
-    }:
-        return method
-
-    logger.warning(
-        "Invalid DOCX_PARSING_DEFAULT_METHOD=%r. Falling back to %s.",
-        method,
-        DOCX_PARSING_METHOD_PLAIN_TEXT,
-    )
-    return DOCX_PARSING_METHOD_PLAIN_TEXT
 
 
 # Function to format datetime to ISO format string with timezone information
@@ -1275,6 +1253,35 @@ async def pipeline_enqueue_file(
         except Exception:
             file_size = 0
 
+        extraction_engine = resolve_file_parser_engine(file_path)
+        if extraction_engine != PARSER_ENGINE_LEGACY:
+            try:
+                await rag.apipeline_enqueue_documents(
+                    "",
+                    file_paths=str(file_path),
+                    track_id=track_id,
+                    docs_format=FULL_DOCS_FORMAT_PENDING_PARSE,
+                    parsed_engine=extraction_engine,
+                )
+                logger.info(
+                    f"[File Extraction]Deferred {file_path.name} to {extraction_engine} parser"
+                )
+                return True, track_id
+            except Exception as e:
+                error_files = [
+                    {
+                        "file_path": str(file_path.name),
+                        "error_description": "[File Extraction]Parser enqueue error",
+                        "original_error": f"Failed to enqueue file for parser: {str(e)}",
+                        "file_size": file_size,
+                    }
+                ]
+                await rag.apipeline_enqueue_error_documents(error_files, track_id)
+                logger.error(
+                    f"[File Extraction]Error enqueuing {file_path.name} for {extraction_engine}: {str(e)}"
+                )
+                return False, track_id
+
         file = None
         try:
             async with aiofiles.open(file_path, "rb") as f:
@@ -1443,39 +1450,6 @@ async def pipeline_enqueue_file(
                         return False, track_id
 
                 case ".docx":
-                    docx_parsing_method = _get_docx_parsing_default_method()
-                    if docx_parsing_method == DOCX_PARSING_METHOD_LIGHTRAG_DOCUMENT:
-                        logger.info(
-                            f"[File Extraction]DOCX deferred to pipeline: {file_path.name}"
-                        )
-                        try:
-                            await rag.apipeline_enqueue_documents(
-                                "",
-                                file_paths=str(file_path),
-                                track_id=track_id,
-                                docs_format=FULL_DOCS_FORMAT_PENDING_PARSE,
-                            )
-                            logger.info(
-                                f"Successfully enqueued DOCX for pipeline parsing: {file_path.name}"
-                            )
-                            return True, track_id
-                        except Exception as e:
-                            error_files = [
-                                {
-                                    "file_path": str(file_path.name),
-                                    "error_description": "[File Extraction]DOCX enqueue error",
-                                    "original_error": f"Failed to enqueue DOCX for pipeline: {str(e)}",
-                                    "file_size": file_size,
-                                }
-                            ]
-                            await rag.apipeline_enqueue_error_documents(
-                                error_files, track_id
-                            )
-                            logger.error(
-                                f"[File Extraction]Error enqueuing DOCX {file_path.name}: {str(e)}"
-                            )
-                            return False, track_id
-
                     try:
                         content = await asyncio.to_thread(_extract_docx, file)
                     except Exception as e:
@@ -1585,7 +1559,10 @@ async def pipeline_enqueue_file(
 
             try:
                 await rag.apipeline_enqueue_documents(
-                    content, file_paths=file_path.name, track_id=track_id
+                    content,
+                    file_paths=file_path.name,
+                    track_id=track_id,
+                    parsed_engine=PARSER_ENGINE_LEGACY,
                 )
 
                 logger.info(

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -84,9 +84,84 @@ FULL_DOCS_FORMAT_LIGHTRAG = "lightrag"  # content in LightRAG Document files
 FULL_DOCS_FORMAT_PENDING_PARSE = (
     "pending_parse"  # file saved but not yet parsed; parse_native will read from disk
 )
-DOCX_PARSING_METHOD_PLAIN_TEXT = "plain_text"
-DOCX_PARSING_METHOD_LIGHTRAG_DOCUMENT = "lightrag_document"
-DEFAULT_DOCX_PARSING_METHOD = DOCX_PARSING_METHOD_PLAIN_TEXT
+FULL_DOCS_CONTENT_STORED_IN_LIGHTRAG_DOCUMENT = "{{stored-in-lightrag-doucment}}"
+PARSER_ENGINE_LEGACY = "legacy"
+PARSER_ENGINE_NATIVE = "native"
+PARSER_ENGINE_MINERU = "mineru"
+PARSER_ENGINE_DOCLING = "docling"
+SUPPORTED_PARSER_ENGINES = frozenset(
+    {
+        PARSER_ENGINE_LEGACY,
+        PARSER_ENGINE_NATIVE,
+        PARSER_ENGINE_MINERU,
+        PARSER_ENGINE_DOCLING,
+    }
+)
+PARSER_ENGINE_SUFFIX_CAPABILITIES = {
+    PARSER_ENGINE_LEGACY: frozenset(
+        {
+            "txt",
+            "md",
+            "mdx",
+            "pdf",
+            "docx",
+            "pptx",
+            "xlsx",
+            "rtf",
+            "odt",
+            "tex",
+            "epub",
+            "html",
+            "htm",
+            "csv",
+            "json",
+            "xml",
+            "yaml",
+            "yml",
+            "log",
+            "conf",
+            "ini",
+            "properties",
+            "sql",
+            "bat",
+            "sh",
+            "c",
+            "h",
+            "cpp",
+            "hpp",
+            "py",
+            "java",
+            "js",
+            "ts",
+            "swift",
+            "go",
+            "rb",
+            "php",
+            "css",
+            "scss",
+            "less",
+        }
+    ),
+    PARSER_ENGINE_NATIVE: frozenset({"docx"}),
+    PARSER_ENGINE_MINERU: frozenset({"pdf", "docx", "pptx", "xlsx"}),
+    PARSER_ENGINE_DOCLING: frozenset(
+        {
+            "pdf",
+            "docx",
+            "pptx",
+            "xlsx",
+            "md",
+            "html",
+            "xhtml",
+            "png",
+            "jpg",
+            "jpeg",
+            "tiff",
+            "webp",
+            "bmp",
+        }
+    ),
+}
 PARSED_DIR_NAME = "__parsed__"  # Dir for parsed files (renamed from __enqueued__)
 
 DEFAULT_MAX_PARALLEL_ANALYZE = 2  # Multimodal analysis (VLM) concurrency

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -6,7 +6,6 @@ import inspect
 import os
 import json
 import re
-import fnmatch
 import hashlib
 import base64
 import mimetypes
@@ -75,9 +74,13 @@ from lightrag.constants import (
     FULL_DOCS_FORMAT_RAW,
     FULL_DOCS_FORMAT_LIGHTRAG,
     FULL_DOCS_FORMAT_PENDING_PARSE,
+    FULL_DOCS_CONTENT_STORED_IN_LIGHTRAG_DOCUMENT,
     PARSED_DIR_NAME,
     DEFAULT_MAX_PARALLEL_ANALYZE,
     DEFAULT_FILE_PATH_MORE_PLACEHOLDER,
+    PARSER_ENGINE_DOCLING,
+    PARSER_ENGINE_MINERU,
+    PARSER_ENGINE_NATIVE,
 )
 from lightrag.utils import get_env_value
 
@@ -143,6 +146,7 @@ from lightrag.utils import (
 from lightrag.types import KnowledgeGraph
 from dotenv import load_dotenv
 from lightrag.extraction.interchange import parse_interchange_jsonl
+from lightrag.parser_routing import resolve_stored_document_parser_engine
 
 # use the .env that is inside the current folder
 # allows to use different .env file for each lightrag instance
@@ -2382,6 +2386,7 @@ class LightRAG:
         track_id: str | None = None,
         docs_format: str = FULL_DOCS_FORMAT_RAW,
         lightrag_document_paths: str | list[str] | None = None,
+        parsed_engine: str | list[str] | None = None,
     ) -> str:
         """
         Pipeline for Processing Documents
@@ -2398,6 +2403,7 @@ class LightRAG:
             track_id: tracking ID for monitoring processing status
             docs_format: "raw" (default) or "lightrag"; when "lightrag" content may be empty and content-dedup is skipped
             lightrag_document_paths: paths to LightRAG Document (e.g. .blocks.jsonl dir or base path), when docs_format is lightrag
+            parsed_engine: file extraction engine already used or target engine for pending_parse
 
         Returns:
             str: tracking ID for monitoring processing status
@@ -2415,6 +2421,8 @@ class LightRAG:
             lightrag_document_paths = (
                 [lightrag_document_paths] if lightrag_document_paths else None
             )
+        if isinstance(parsed_engine, str):
+            parsed_engine = [parsed_engine] * len(input)
 
         # If file_paths is provided, ensure it matches the number of documents
         if file_paths is not None:
@@ -2437,6 +2445,16 @@ class LightRAG:
                 raise ValueError(
                     "Number of lightrag_document_paths must match the number of documents"
                 )
+        if parsed_engine is not None and len(parsed_engine) != len(input):
+            raise ValueError(
+                "Number of parsed engines must match the number of documents"
+            )
+
+        def _parsed_engine_at(index: int) -> str | None:
+            if parsed_engine is None:
+                return None
+            engine = str(parsed_engine[index] or "").strip().lower()
+            return engine or None
 
         # 1. Validate ids and build contents (when lightrag: no content dedup, content may be empty)
         if ids is not None:
@@ -2458,13 +2476,14 @@ class LightRAG:
                 lightrag_path = (
                     lightrag_document_paths[i] if lightrag_document_paths else ""
                 ) or path
-                content_str = (input[i] or "").strip() if i < len(input) else ""
                 contents[doc_id] = {
-                    "content": content_str,
+                    "content": FULL_DOCS_CONTENT_STORED_IN_LIGHTRAG_DOCUMENT,
                     "file_path": path,
                     "format": FULL_DOCS_FORMAT_LIGHTRAG,
                     "lightrag_document_path": lightrag_path,
                 }
+                if engine := _parsed_engine_at(i):
+                    contents[doc_id]["parsed_engine"] = engine
         elif ids is not None:
             # Generate contents dict and remove duplicates in one pass
             unique_contents = {}
@@ -2473,14 +2492,15 @@ class LightRAG:
                 if cleaned_content not in unique_contents:
                     unique_contents[cleaned_content] = (id_, path)
 
-            contents = {
-                id_: {
+            contents = {}
+            for i, (content, (id_, file_path)) in enumerate(unique_contents.items()):
+                contents[id_] = {
                     "content": content,
                     "file_path": file_path,
                     "format": FULL_DOCS_FORMAT_RAW,
                 }
-                for content, (id_, file_path) in unique_contents.items()
-            }
+                if engine := _parsed_engine_at(i):
+                    contents[id_]["parsed_engine"] = engine
         elif docs_format == FULL_DOCS_FORMAT_PENDING_PARSE:
             contents = {}
             for i, (doc, path) in enumerate(zip(input, file_paths)):
@@ -2494,6 +2514,8 @@ class LightRAG:
                     "file_path": path,
                     "format": FULL_DOCS_FORMAT_PENDING_PARSE,
                 }
+                if engine := _parsed_engine_at(i):
+                    contents[doc_id]["parsed_engine"] = engine
         else:
             # Clean input text and remove duplicates in one pass
             unique_content_with_paths = {}
@@ -2502,14 +2524,16 @@ class LightRAG:
                 if cleaned_content not in unique_content_with_paths:
                     unique_content_with_paths[cleaned_content] = path
 
-            contents = {
-                compute_mdhash_id(content, prefix="doc-"): {
+            contents = {}
+            for i, (content, path) in enumerate(unique_content_with_paths.items()):
+                doc_id = compute_mdhash_id(content, prefix="doc-")
+                contents[doc_id] = {
                     "content": content,
                     "file_path": path,
                     "format": FULL_DOCS_FORMAT_RAW,
                 }
-                for content, path in unique_content_with_paths.items()
-            }
+                if engine := _parsed_engine_at(i):
+                    contents[doc_id]["parsed_engine"] = engine
 
         # 2. Generate document initial status (without content)
         new_docs: dict[str, Any] = {
@@ -2601,6 +2625,10 @@ class LightRAG:
             if contents[doc_id].get("lightrag_document_path"):
                 full_docs_data[doc_id]["lightrag_document_path"] = contents[doc_id][
                     "lightrag_document_path"
+                ]
+            if contents[doc_id].get("parsed_engine"):
+                full_docs_data[doc_id]["parsed_engine"] = contents[doc_id][
+                    "parsed_engine"
                 ]
         await self.full_docs.upsert(full_docs_data)
         # Persist data to disk immediately
@@ -4151,72 +4179,7 @@ class LightRAG:
     def _resolve_parser_engine(
         self, file_path: str, content_data: dict[str, Any]
     ) -> str:
-        doc_format = content_data.get("format", FULL_DOCS_FORMAT_RAW)
-        if doc_format == FULL_DOCS_FORMAT_LIGHTRAG and content_data.get(
-            "lightrag_document_path"
-        ):
-            return "native"
-
-        explicit_engine = str(content_data.get("parsed_engine") or "").strip().lower()
-        if explicit_engine in {"native", "mineru", "docling"}:
-            return explicit_engine
-
-        file_name = Path(file_path).name
-        m = re.search(r"\.\[([^\]]+)\]\.[^.]+$", file_name)
-        if m:
-            hint = m.group(1).split("-")[0].strip().lower()
-            if hint in {"native", "mineru", "docling"}:
-                return hint
-
-        parser_rules = os.getenv("LIGHTRAG_PARSER", "").strip()
-        if parser_rules:
-            suffix = Path(file_name).suffix.lower().lstrip(".")
-            for item in [x.strip() for x in parser_rules.split(",") if x.strip()]:
-                if ":" not in item:
-                    continue
-                pattern, engine_hint = item.split(":", 1)
-                pattern = pattern.strip().lower()
-                engine = engine_hint.strip().split("-")[0].lower()
-                if engine not in {"native", "mineru", "docling"}:
-                    continue
-                if fnmatch.fnmatch(suffix, pattern):
-                    return engine
-
-        # Auto routing for normal user uploads (without filename hints):
-        # prefer multimodal-capable engines when corresponding service endpoint is configured.
-        suffix = Path(file_name).suffix.lower().lstrip(".")
-        mineru_endpoint = os.getenv("MINERU_ENDPOINT", "").strip()
-        docling_endpoint = os.getenv("DOCLING_ENDPOINT", "").strip()
-
-        # Keep this mapping conservative and practical:
-        # - PDF defaults to MinerU (layout-heavy parsing)
-        # - Office-like docs default to Docling
-        mineru_suffixes = {"pdf"}
-        docling_suffixes = {
-            "doc",
-            "docx",
-            "ppt",
-            "pptx",
-            "xls",
-            "xlsx",
-            "md",
-            "markdown",
-            "html",
-            "htm",
-        }
-
-        if suffix in mineru_suffixes and mineru_endpoint:
-            return "mineru"
-        if suffix in docling_suffixes and docling_endpoint:
-            return "docling"
-
-        # Fallback cross-coverage when only one service is available.
-        if suffix in (mineru_suffixes | docling_suffixes):
-            if docling_endpoint:
-                return "docling"
-            if mineru_endpoint:
-                return "mineru"
-        return "native"
+        return resolve_stored_document_parser_engine(file_path, content_data)
 
     def _get_by_path(self, payload: Any, path: str) -> Any:
         if not path:
@@ -4394,13 +4357,11 @@ class LightRAG:
         self, source_path: str
     ) -> str | None:
         source = Path(source_path)
-        if source.suffix.lower() != ".docx":
-            return None
         try:
             target = await move_file_to_parsed_dir(source, skip_if_already_parsed=True)
         except Exception as e:
             logger.warning(
-                f"[parse] DOCX source archive skipped after full_docs sync: {source_path}: {e}"
+                f"[parse] Source archive skipped after full_docs sync: {source_path}: {e}"
             )
             return None
         if target is None:
@@ -4410,6 +4371,11 @@ class LightRAG:
                 f"[parse] Archived DOCX source after full_docs sync: {source} -> {target}"
             )
         return str(target)
+
+    async def _archive_source_after_full_docs_sync(
+        self, source_path: str
+    ) -> str | None:
+        return await self._archive_docx_source_after_full_docs_sync(source_path)
 
     async def _write_lightrag_document_from_content_list(
         self,
@@ -4803,13 +4769,18 @@ class LightRAG:
             )
 
         # Keep full_docs in sync so restart/reprocess can directly use LightRAG Document.
+        stored_blocks_path = str(blocks_path)
+        try:
+            stored_blocks_path = str(blocks_path.relative_to(Path(self.working_dir)))
+        except ValueError:
+            pass
         await self.full_docs.upsert(
             {
                 doc_id: {
-                    "content": merged_text,
+                    "content": FULL_DOCS_CONTENT_STORED_IN_LIGHTRAG_DOCUMENT,
                     "file_path": file_path,
                     "format": FULL_DOCS_FORMAT_LIGHTRAG,
-                    "lightrag_document_path": str(blocks_path),
+                    "lightrag_document_path": stored_blocks_path,
                     "parsed_engine": engine,
                     "update_time": int(time.time()),
                 }
@@ -4853,6 +4824,9 @@ class LightRAG:
         doc_format = content_data.get("format", FULL_DOCS_FORMAT_RAW)
         if doc_format == FULL_DOCS_FORMAT_LIGHTRAG:
             doc_path = content_data.get("lightrag_document_path") or file_path
+            doc_path = Path(str(doc_path))
+            if not doc_path.is_absolute():
+                doc_path = Path(self.working_dir) / doc_path
             merged_text, blocks_path = await self._load_lightrag_document_content(
                 str(doc_path)
             )
@@ -4894,7 +4868,7 @@ class LightRAG:
                             "content": interchange_text,
                             "file_path": file_path,
                             "format": FULL_DOCS_FORMAT_RAW,
-                            "parsed_engine": "native",
+                            "parsed_engine": PARSER_ENGINE_NATIVE,
                             "update_time": int(time.time()),
                         }
                     }
@@ -4911,13 +4885,9 @@ class LightRAG:
                     "content": interchange_text,
                     "blocks_path": "",
                 }
-            return {
-                "doc_id": doc_id,
-                "file_path": file_path,
-                "format": FULL_DOCS_FORMAT_RAW,
-                "content": content_data.get("content", ""),
-                "blocks_path": "",
-            }
+            raise ValueError(
+                f"Native parser does not support pending file: {file_path}"
+            )
 
         return {
             "doc_id": doc_id,
@@ -4930,162 +4900,132 @@ class LightRAG:
     async def parse_mineru(
         self, doc_id: str, file_path: str, content_data: dict[str, Any]
     ) -> dict[str, Any]:
-        endpoint = os.getenv(
-            "MINERU_ENDPOINT", "https://mineru.net/api/v4/extract/task"
-        ).strip()
-        try:
-            if endpoint:
-                protocol = {
-                    "upload_url": endpoint,
-                    "poll_url_template": os.getenv(
-                        "MINERU_POLL_ENDPOINT",
-                        endpoint + "/{trace_id}",
-                    ),
-                    "poll_method": os.getenv("MINERU_POLL_METHOD", "GET"),
-                    "id_field": os.getenv("MINERU_ID_FIELD", "trace_id"),
-                    "status_field": os.getenv("MINERU_STATUS_FIELD", "status"),
-                    "result_url_field": os.getenv(
-                        "MINERU_RESULT_URL_FIELD", "result_url"
-                    ),
-                    "content_field": os.getenv("MINERU_CONTENT_FIELD", "content"),
-                    "success_values": os.getenv(
-                        "MINERU_SUCCESS_VALUES",
-                        "done,success,succeeded,completed,finished",
-                    ),
-                    "failed_values": os.getenv("MINERU_FAILED_VALUES", "failed,error"),
-                    "poll_interval_seconds": float(
-                        os.getenv("MINERU_POLL_INTERVAL_SECONDS", "2")
-                    ),
-                    "max_polls": int(os.getenv("MINERU_MAX_POLLS", "180")),
-                }
-                source_file_path = self._resolve_source_file_for_parser(file_path)
-                result_text = await self._call_protocol_parse_service(
-                    protocol=protocol,
-                    file_path=source_file_path,
-                )
-                content_list = self._normalize_parser_result_to_content_list(
-                    result_text
-                )
-                if content_list:
-                    return await self._write_lightrag_document_from_content_list(
-                        doc_id=doc_id,
-                        file_path=file_path,
-                        content_list=content_list,
-                        engine="mineru",
-                        source_path=source_file_path,
-                    )
-                if result_text:
-                    # Content is already extracted as raw text and persisted; mark
-                    # parsed_engine="native" so retries skip the remote MinerU call
-                    # via _resolve_parser_engine. The original engine is kept in
-                    # source_parsed_engine for audit.
-                    await self.full_docs.upsert(
-                        {
-                            doc_id: {
-                                "content": str(result_text),
-                                "file_path": file_path,
-                                "format": FULL_DOCS_FORMAT_RAW,
-                                "parsed_engine": "native",
-                                "source_parsed_engine": "mineru",
-                                "update_time": int(time.time()),
-                            }
-                        }
-                    )
-                    await self.full_docs.index_done_callback()
-                    await self._archive_docx_source_after_full_docs_sync(
-                        source_file_path
-                    )
-                    return {
-                        "doc_id": doc_id,
-                        "file_path": file_path,
-                        "format": FULL_DOCS_FORMAT_RAW,
-                        "content": str(result_text),
-                        "blocks_path": "",
-                    }
-        except Exception as e:
-            logger.warning(f"MinerU async service failed, fallback native: {e}")
+        endpoint = os.getenv("MINERU_ENDPOINT", "").strip()
+        if not endpoint:
+            raise ValueError("MINERU_ENDPOINT is required for MinerU parsing")
+        protocol = {
+            "upload_url": endpoint,
+            "poll_url_template": os.getenv(
+                "MINERU_POLL_ENDPOINT",
+                endpoint + "/{trace_id}",
+            ),
+            "poll_method": os.getenv("MINERU_POLL_METHOD", "GET"),
+            "id_field": os.getenv("MINERU_ID_FIELD", "trace_id"),
+            "status_field": os.getenv("MINERU_STATUS_FIELD", "status"),
+            "result_url_field": os.getenv("MINERU_RESULT_URL_FIELD", "result_url"),
+            "content_field": os.getenv("MINERU_CONTENT_FIELD", "content"),
+            "success_values": os.getenv(
+                "MINERU_SUCCESS_VALUES",
+                "done,success,succeeded,completed,finished",
+            ),
+            "failed_values": os.getenv("MINERU_FAILED_VALUES", "failed,error"),
+            "poll_interval_seconds": float(
+                os.getenv("MINERU_POLL_INTERVAL_SECONDS", "2")
+            ),
+            "max_polls": int(os.getenv("MINERU_MAX_POLLS", "180")),
+        }
+        source_file_path = self._resolve_source_file_for_parser(file_path)
+        result_text = await self._call_protocol_parse_service(
+            protocol=protocol,
+            file_path=source_file_path,
+        )
+        content_list = self._normalize_parser_result_to_content_list(result_text)
+        if content_list:
+            return await self._write_lightrag_document_from_content_list(
+                doc_id=doc_id,
+                file_path=file_path,
+                content_list=content_list,
+                engine=PARSER_ENGINE_MINERU,
+                source_path=source_file_path,
+            )
+        if not result_text:
+            raise ValueError(f"MinerU parser returned empty content for {file_path}")
 
-        return await self.parse_native(doc_id, file_path, content_data)
+        await self.full_docs.upsert(
+            {
+                doc_id: {
+                    "content": str(result_text),
+                    "file_path": file_path,
+                    "format": FULL_DOCS_FORMAT_RAW,
+                    "parsed_engine": PARSER_ENGINE_MINERU,
+                    "update_time": int(time.time()),
+                }
+            }
+        )
+        await self.full_docs.index_done_callback()
+        await self._archive_docx_source_after_full_docs_sync(source_file_path)
+        return {
+            "doc_id": doc_id,
+            "file_path": file_path,
+            "format": FULL_DOCS_FORMAT_RAW,
+            "content": str(result_text),
+            "blocks_path": "",
+        }
 
     async def parse_docling(
         self, doc_id: str, file_path: str, content_data: dict[str, Any]
     ) -> dict[str, Any]:
-        endpoint = os.getenv(
-            "DOCLING_ENDPOINT", "http://localhost:8081/v1/convert/file/async"
-        ).strip()
-        try:
-            if endpoint:
-                protocol = {
-                    "upload_url": endpoint,
-                    "poll_url_template": os.getenv(
-                        "DOCLING_POLL_ENDPOINT",
-                        endpoint + "/{task_id}",
-                    ),
-                    "poll_method": os.getenv("DOCLING_POLL_METHOD", "GET"),
-                    "id_field": os.getenv("DOCLING_ID_FIELD", "task_id"),
-                    "status_field": os.getenv("DOCLING_STATUS_FIELD", "status"),
-                    "result_url_field": os.getenv(
-                        "DOCLING_RESULT_URL_FIELD", "result_url"
-                    ),
-                    "content_field": os.getenv("DOCLING_CONTENT_FIELD", "content"),
-                    "success_values": os.getenv(
-                        "DOCLING_SUCCESS_VALUES",
-                        "done,success,succeeded,completed,finished",
-                    ),
-                    "failed_values": os.getenv("DOCLING_FAILED_VALUES", "failed,error"),
-                    "poll_interval_seconds": float(
-                        os.getenv("DOCLING_POLL_INTERVAL_SECONDS", "2")
-                    ),
-                    "max_polls": int(os.getenv("DOCLING_MAX_POLLS", "180")),
-                }
-                source_file_path = self._resolve_source_file_for_parser(file_path)
-                result_text = await self._call_protocol_parse_service(
-                    protocol=protocol,
-                    file_path=source_file_path,
-                )
-                content_list = self._normalize_parser_result_to_content_list(
-                    result_text
-                )
-                if content_list:
-                    return await self._write_lightrag_document_from_content_list(
-                        doc_id=doc_id,
-                        file_path=file_path,
-                        content_list=content_list,
-                        engine="docling",
-                        source_path=source_file_path,
-                    )
-                if result_text:
-                    # Same retry-skip rationale as in parse_mineru: parsed_engine
-                    # is normalized to "native" because the raw content is already
-                    # in full_docs; the real upstream engine is kept in
-                    # source_parsed_engine for audit.
-                    await self.full_docs.upsert(
-                        {
-                            doc_id: {
-                                "content": str(result_text),
-                                "file_path": file_path,
-                                "format": FULL_DOCS_FORMAT_RAW,
-                                "parsed_engine": "native",
-                                "source_parsed_engine": "docling",
-                                "update_time": int(time.time()),
-                            }
-                        }
-                    )
-                    await self.full_docs.index_done_callback()
-                    await self._archive_docx_source_after_full_docs_sync(
-                        source_file_path
-                    )
-                    return {
-                        "doc_id": doc_id,
-                        "file_path": file_path,
-                        "format": FULL_DOCS_FORMAT_RAW,
-                        "content": str(result_text),
-                        "blocks_path": "",
-                    }
-        except Exception as e:
-            logger.warning(f"Docling async service failed, fallback native: {e}")
+        endpoint = os.getenv("DOCLING_ENDPOINT", "").strip()
+        if not endpoint:
+            raise ValueError("DOCLING_ENDPOINT is required for Docling parsing")
+        protocol = {
+            "upload_url": endpoint,
+            "poll_url_template": os.getenv(
+                "DOCLING_POLL_ENDPOINT",
+                endpoint + "/{task_id}",
+            ),
+            "poll_method": os.getenv("DOCLING_POLL_METHOD", "GET"),
+            "id_field": os.getenv("DOCLING_ID_FIELD", "task_id"),
+            "status_field": os.getenv("DOCLING_STATUS_FIELD", "status"),
+            "result_url_field": os.getenv("DOCLING_RESULT_URL_FIELD", "result_url"),
+            "content_field": os.getenv("DOCLING_CONTENT_FIELD", "content"),
+            "success_values": os.getenv(
+                "DOCLING_SUCCESS_VALUES",
+                "done,success,succeeded,completed,finished",
+            ),
+            "failed_values": os.getenv("DOCLING_FAILED_VALUES", "failed,error"),
+            "poll_interval_seconds": float(
+                os.getenv("DOCLING_POLL_INTERVAL_SECONDS", "2")
+            ),
+            "max_polls": int(os.getenv("DOCLING_MAX_POLLS", "180")),
+        }
+        source_file_path = self._resolve_source_file_for_parser(file_path)
+        result_text = await self._call_protocol_parse_service(
+            protocol=protocol,
+            file_path=source_file_path,
+        )
+        content_list = self._normalize_parser_result_to_content_list(result_text)
+        if content_list:
+            return await self._write_lightrag_document_from_content_list(
+                doc_id=doc_id,
+                file_path=file_path,
+                content_list=content_list,
+                engine=PARSER_ENGINE_DOCLING,
+                source_path=source_file_path,
+            )
+        if not result_text:
+            raise ValueError(f"Docling parser returned empty content for {file_path}")
 
-        return await self.parse_native(doc_id, file_path, content_data)
+        await self.full_docs.upsert(
+            {
+                doc_id: {
+                    "content": str(result_text),
+                    "file_path": file_path,
+                    "format": FULL_DOCS_FORMAT_RAW,
+                    "parsed_engine": PARSER_ENGINE_DOCLING,
+                    "update_time": int(time.time()),
+                }
+            }
+        )
+        await self.full_docs.index_done_callback()
+        await self._archive_docx_source_after_full_docs_sync(source_file_path)
+        return {
+            "doc_id": doc_id,
+            "file_path": file_path,
+            "format": FULL_DOCS_FORMAT_RAW,
+            "content": str(result_text),
+            "blocks_path": "",
+        }
 
     async def _run_multimodal_postprocess_hook(
         self,

--- a/lightrag/parser_routing.py
+++ b/lightrag/parser_routing.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import fnmatch
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from lightrag.constants import (
+    FULL_DOCS_FORMAT_LIGHTRAG,
+    FULL_DOCS_FORMAT_PENDING_PARSE,
+    FULL_DOCS_FORMAT_RAW,
+    PARSER_ENGINE_DOCLING,
+    PARSER_ENGINE_LEGACY,
+    PARSER_ENGINE_MINERU,
+    PARSER_ENGINE_NATIVE,
+    PARSER_ENGINE_SUFFIX_CAPABILITIES,
+    SUPPORTED_PARSER_ENGINES,
+)
+
+_PARSER_RULE_SPLIT_RE = re.compile(r"[;,]")
+_PARSER_ENGINE_ENDPOINT_ENV = {
+    PARSER_ENGINE_MINERU: "MINERU_ENDPOINT",
+    PARSER_ENGINE_DOCLING: "DOCLING_ENDPOINT",
+}
+
+
+class ParserRoutingConfigError(ValueError):
+    """Raised when LIGHTRAG_PARSER contains an invalid routing rule."""
+
+
+def normalize_parser_engine(engine: Any) -> str:
+    """Normalize engine hints such as mineru-iet to mineru."""
+    return str(engine or "").strip().split("-", 1)[0].lower()
+
+
+def parser_suffix(file_path: str | Path) -> str:
+    return Path(file_path).suffix.lower().lstrip(".")
+
+
+def parser_engine_supports_suffix(engine: str, suffix: str) -> bool:
+    return suffix.lower().lstrip(".") in PARSER_ENGINE_SUFFIX_CAPABILITIES.get(
+        engine, frozenset()
+    )
+
+
+def parser_engine_endpoint_configured(engine: str) -> bool:
+    endpoint_env = _PARSER_ENGINE_ENDPOINT_ENV.get(engine)
+    if endpoint_env:
+        return bool(os.getenv(endpoint_env, "").strip())
+    return True
+
+
+def _engine_is_usable(
+    engine: str,
+    suffix: str,
+    *,
+    require_external_endpoint: bool,
+) -> bool:
+    if engine not in SUPPORTED_PARSER_ENGINES:
+        return False
+    if not parser_engine_supports_suffix(engine, suffix):
+        return False
+    if require_external_endpoint and not parser_engine_endpoint_configured(engine):
+        return False
+    return True
+
+
+def filename_parser_hint(file_path: str | Path) -> str | None:
+    m = re.search(r"\.\[([^\]]+)\]\.[^.]+$", Path(file_path).name)
+    if not m:
+        return None
+    engine = normalize_parser_engine(m.group(1))
+    return engine if engine in SUPPORTED_PARSER_ENGINES else None
+
+
+def parser_rules_from_env() -> str:
+    return os.getenv("LIGHTRAG_PARSER", "").strip()
+
+
+def _iter_parser_rule_items(rules: str) -> list[tuple[int, str]]:
+    return [
+        (index, item.strip())
+        for index, item in enumerate(_PARSER_RULE_SPLIT_RE.split(rules), start=1)
+        if item.strip()
+    ]
+
+
+def _rule_pattern_matches_engine_capability(pattern: str, engine: str) -> bool:
+    supported_suffixes = PARSER_ENGINE_SUFFIX_CAPABILITIES.get(engine, frozenset())
+    return any(fnmatch.fnmatch(suffix, pattern) for suffix in supported_suffixes)
+
+
+def validate_parser_routing_config(parser_rules: str | None = None) -> None:
+    """Validate LIGHTRAG_PARSER syntax and required external parser endpoints."""
+    rules = parser_rules_from_env() if parser_rules is None else parser_rules.strip()
+    if not rules:
+        return
+
+    errors: list[str] = []
+    for index, item in _iter_parser_rule_items(rules):
+        label = f"rule {index} ({item!r})"
+        if ":" not in item:
+            errors.append(f"{label} must use '<suffix-pattern>:<engine>'")
+            continue
+
+        pattern, engine_hint = item.split(":", 1)
+        pattern = pattern.strip().lower()
+        engine_hint = engine_hint.strip()
+        engine = normalize_parser_engine(engine_hint)
+
+        if not pattern:
+            errors.append(f"{label} has an empty suffix pattern")
+            continue
+        if "." in pattern:
+            errors.append(
+                f"{label} matches suffixes without dots; use 'pdf', not '*.pdf'"
+            )
+            continue
+        if not engine_hint:
+            errors.append(f"{label} has an empty parser engine")
+            continue
+        if engine not in SUPPORTED_PARSER_ENGINES:
+            supported = ", ".join(sorted(SUPPORTED_PARSER_ENGINES))
+            errors.append(
+                f"{label} uses unsupported parser engine {engine_hint!r}; "
+                f"supported engines: {supported}"
+            )
+            continue
+        if not _rule_pattern_matches_engine_capability(pattern, engine):
+            supported_suffixes = ", ".join(
+                sorted(PARSER_ENGINE_SUFFIX_CAPABILITIES.get(engine, frozenset()))
+            )
+            errors.append(
+                f"{label} does not match any suffix supported by {engine}; "
+                f"supported suffixes: {supported_suffixes}"
+            )
+        endpoint_env = _PARSER_ENGINE_ENDPOINT_ENV.get(engine)
+        if endpoint_env and not parser_engine_endpoint_configured(engine):
+            errors.append(f"{label} requires {endpoint_env} to be configured")
+
+    if errors:
+        raise ParserRoutingConfigError(
+            "Invalid LIGHTRAG_PARSER configuration: " + "; ".join(errors)
+        )
+
+
+def resolve_file_parser_engine(
+    file_path: str | Path,
+    *,
+    parser_rules: str | None = None,
+    require_external_endpoint: bool = True,
+) -> str:
+    """Resolve the extraction engine for a source file before content extraction."""
+    suffix = parser_suffix(file_path)
+
+    hint = filename_parser_hint(file_path)
+    if hint and _engine_is_usable(
+        hint, suffix, require_external_endpoint=require_external_endpoint
+    ):
+        return hint
+
+    rules = parser_rules_from_env() if parser_rules is None else parser_rules.strip()
+    if rules:
+        for _, item in _iter_parser_rule_items(rules):
+            if ":" not in item:
+                continue
+            pattern, engine_hint = item.split(":", 1)
+            pattern = pattern.strip().lower()
+            engine = normalize_parser_engine(engine_hint)
+            if not fnmatch.fnmatch(suffix, pattern):
+                continue
+            if _engine_is_usable(
+                engine,
+                suffix,
+                require_external_endpoint=require_external_endpoint,
+            ):
+                return engine
+
+    return PARSER_ENGINE_LEGACY
+
+
+def resolve_stored_document_parser_engine(
+    file_path: str | Path,
+    content_data: dict[str, Any] | None,
+) -> str:
+    """Resolve parser engine for a full_docs row during pipeline processing."""
+    if content_data:
+        doc_format = content_data.get("format", FULL_DOCS_FORMAT_RAW)
+        if doc_format == FULL_DOCS_FORMAT_LIGHTRAG and content_data.get(
+            "lightrag_document_path"
+        ):
+            return PARSER_ENGINE_NATIVE
+        if doc_format != FULL_DOCS_FORMAT_PENDING_PARSE:
+            return PARSER_ENGINE_LEGACY
+
+        suffix = parser_suffix(file_path)
+        pending_engine = normalize_parser_engine(content_data.get("parsed_engine"))
+        if pending_engine in SUPPORTED_PARSER_ENGINES and parser_engine_supports_suffix(
+            pending_engine, suffix
+        ):
+            return pending_engine
+
+    return resolve_file_parser_engine(file_path)

--- a/tests/test_document_routes_docx_archive.py
+++ b/tests/test_document_routes_docx_archive.py
@@ -46,7 +46,13 @@ class _FakeRag:
         self.errors = []
 
     async def apipeline_enqueue_documents(
-        self, input, ids=None, file_paths=None, track_id=None, docs_format=None
+        self,
+        input,
+        ids=None,
+        file_paths=None,
+        track_id=None,
+        docs_format=None,
+        parsed_engine=None,
     ):
         self.enqueued.append(
             {
@@ -54,6 +60,7 @@ class _FakeRag:
                 "file_path": file_paths,
                 "track_id": track_id,
                 "docs_format": docs_format,
+                "parsed_engine": parsed_engine,
             }
         )
         return track_id
@@ -131,7 +138,7 @@ class _ParseRag:
 async def test_pipeline_index_file_leaves_lightrag_document_docx_for_parser_archive(
     tmp_path, monkeypatch
 ):
-    monkeypatch.setenv("DOCX_PARSING_DEFAULT_METHOD", "lightrag_document")
+    monkeypatch.setenv("LIGHTRAG_PARSER", "docx:native")
     file_path = tmp_path / "sample.[docling].docx"
     file_path.write_bytes(b"docx bytes")
     rag = _FakeRag()
@@ -142,12 +149,13 @@ async def test_pipeline_index_file_leaves_lightrag_document_docx_for_parser_arch
     assert not (tmp_path / PARSED_DIR_NAME / file_path.name).exists()
     assert rag.enqueued[0]["file_path"] == str(file_path)
     assert rag.enqueued[0]["docs_format"] == FULL_DOCS_FORMAT_PENDING_PARSE
+    assert rag.enqueued[0]["parsed_engine"] == "native"
 
 
 async def test_pipeline_enqueue_lightrag_document_docx_does_not_move_source(
     tmp_path, monkeypatch
 ):
-    monkeypatch.setenv("DOCX_PARSING_DEFAULT_METHOD", "lightrag_document")
+    monkeypatch.setenv("LIGHTRAG_PARSER", "docx:native")
     file_path = tmp_path / "pending.docx"
     file_path.write_bytes(b"docx bytes")
     rag = _FakeRag()
@@ -162,12 +170,13 @@ async def test_pipeline_enqueue_lightrag_document_docx_does_not_move_source(
     assert not (tmp_path / PARSED_DIR_NAME / file_path.name).exists()
     assert rag.enqueued[0]["file_path"] == str(file_path)
     assert rag.enqueued[0]["docs_format"] == FULL_DOCS_FORMAT_PENDING_PARSE
+    assert rag.enqueued[0]["parsed_engine"] == "native"
 
 
 async def test_pipeline_enqueue_docx_plain_text_extracts_before_enqueue(
     tmp_path, monkeypatch
 ):
-    monkeypatch.setenv("DOCX_PARSING_DEFAULT_METHOD", "plain_text")
+    monkeypatch.setenv("LIGHTRAG_PARSER", "docx:legacy")
     monkeypatch.setattr(
         _document_routes, "_extract_docx", lambda file_bytes: "plain docx content"
     )
@@ -187,6 +196,7 @@ async def test_pipeline_enqueue_docx_plain_text_extracts_before_enqueue(
             "file_path": file_path.name,
             "track_id": "track-docx",
             "docs_format": None,
+            "parsed_engine": "legacy",
         }
     ]
     assert not file_path.exists()
@@ -194,7 +204,7 @@ async def test_pipeline_enqueue_docx_plain_text_extracts_before_enqueue(
 
 
 async def test_pipeline_enqueue_md_moves_after_enqueue(tmp_path, monkeypatch):
-    monkeypatch.setenv("DOCX_PARSING_DEFAULT_METHOD", "plain_text")
+    monkeypatch.delenv("LIGHTRAG_PARSER", raising=False)
     file_path = tmp_path / "notes.md"
     file_path.write_text("# Notes\n\nmarkdown content", encoding="utf-8")
     rag = _FakeRag()
@@ -209,16 +219,49 @@ async def test_pipeline_enqueue_md_moves_after_enqueue(tmp_path, monkeypatch):
             "file_path": file_path.name,
             "track_id": "track-md",
             "docs_format": None,
+            "parsed_engine": "legacy",
         }
     ]
     assert not file_path.exists()
     assert (tmp_path / PARSED_DIR_NAME / file_path.name).exists()
 
 
+async def test_pipeline_enqueue_parser_routed_pdf_defers_without_extraction(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("LIGHTRAG_PARSER", "pdf:mineru,*:legacy")
+    monkeypatch.setenv("MINERU_ENDPOINT", "http://fake-mineru")
+
+    def _fail_pdf_extract(*args, **kwargs):
+        raise AssertionError("parser-routed PDF should not be extracted before enqueue")
+
+    monkeypatch.setattr(_document_routes, "_extract_pdf_pypdf", _fail_pdf_extract)
+    file_path = tmp_path / "paper.pdf"
+    file_path.write_bytes(b"fake-pdf")
+    rag = _FakeRag()
+
+    success, returned_track_id = await pipeline_enqueue_file(
+        rag, file_path, "track-pdf"
+    )
+
+    assert success is True
+    assert returned_track_id == "track-pdf"
+    assert file_path.exists()
+    assert rag.enqueued == [
+        {
+            "input": "",
+            "file_path": str(file_path),
+            "track_id": "track-pdf",
+            "docs_format": FULL_DOCS_FORMAT_PENDING_PARSE,
+            "parsed_engine": "mineru",
+        }
+    ]
+
+
 async def test_pipeline_index_files_leaves_lightrag_document_docx_batch(
     tmp_path, monkeypatch
 ):
-    monkeypatch.setenv("DOCX_PARSING_DEFAULT_METHOD", "lightrag_document")
+    monkeypatch.setenv("LIGHTRAG_PARSER", "docx:native")
     first = tmp_path / "first.docx"
     second = tmp_path / "second.[mineru].docx"
     first.write_bytes(b"first docx bytes")
@@ -234,6 +277,7 @@ async def test_pipeline_index_files_leaves_lightrag_document_docx_batch(
     assert all(
         item["docs_format"] == FULL_DOCS_FORMAT_PENDING_PARSE for item in rag.enqueued
     )
+    assert all(item["parsed_engine"] == "native" for item in rag.enqueued)
 
 
 async def test_scan_existing_full_path_docx_does_not_reenqueue(tmp_path, monkeypatch):

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -6,7 +6,13 @@ import numpy as np
 import pytest
 
 from lightrag import LightRAG, ROLES, RoleLLMConfig
+from lightrag.constants import FULL_DOCS_CONTENT_STORED_IN_LIGHTRAG_DOCUMENT
 from lightrag.operate import _get_relationship_vdb_timeout_seconds
+from lightrag.parser_routing import (
+    ParserRoutingConfigError,
+    resolve_file_parser_engine,
+    validate_parser_routing_config,
+)
 from lightrag.utils import EmbeddingFunc, Tokenizer, safe_vdb_operation_with_exception
 
 
@@ -64,29 +70,70 @@ def _new_rag(tmp_path: Path, **kwargs) -> LightRAG:
 @pytest.mark.offline
 def test_parse_engine_routing_by_filename_and_env(tmp_path, monkeypatch):
     rag = _new_rag(tmp_path)
-    assert rag._resolve_parser_engine("a.[docling-iet].pdf", {}) == "docling"
+    monkeypatch.setenv("DOCLING_ENDPOINT", "http://fake-docling")
+    assert rag._resolve_parser_engine("a.[docling-iet].docx", {}) == "docling"
 
+    monkeypatch.setenv("MINERU_ENDPOINT", "http://fake-mineru")
     monkeypatch.setenv("LIGHTRAG_PARSER", "pdf:mineru-iet,*:native")
     assert rag._resolve_parser_engine("paper.pdf", {}) == "mineru"
     assert (
-        rag._resolve_parser_engine("paper.pdf", {"parsed_engine": "native"}) == "native"
+        rag._resolve_parser_engine("paper.pdf", {"parsed_engine": "native"}) == "legacy"
     )
 
 
 @pytest.mark.offline
-def test_parse_engine_auto_routing_without_filename_hint(tmp_path, monkeypatch):
+def test_parse_engine_rule_fallback_and_default_legacy(tmp_path, monkeypatch):
     rag = _new_rag(tmp_path)
+    monkeypatch.setenv("LIGHTRAG_PARSER", "pdf:native,*:legacy")
+    assert rag._resolve_parser_engine("paper.pdf", {}) == "legacy"
+
+    monkeypatch.setenv("LIGHTRAG_PARSER", "pptx:docling,*:legacy")
+    monkeypatch.delenv("DOCLING_ENDPOINT", raising=False)
+    assert rag._resolve_parser_engine("slides.pptx", {}) == "legacy"
+
     monkeypatch.delenv("LIGHTRAG_PARSER", raising=False)
+    monkeypatch.setenv("MINERU_ENDPOINT", "")
+    assert rag._resolve_parser_engine("slides.pptx", {}) == "legacy"
+
+
+@pytest.mark.offline
+def test_parser_routing_accepts_semicolon_rules(monkeypatch):
     monkeypatch.setenv("MINERU_ENDPOINT", "http://fake-mineru")
     monkeypatch.setenv("DOCLING_ENDPOINT", "http://fake-docling")
-    assert rag._resolve_parser_engine("slides.pptx", {}) == "docling"
-    assert rag._resolve_parser_engine("paper.pdf", {}) == "mineru"
 
-    monkeypatch.setenv("DOCLING_ENDPOINT", "")
-    assert rag._resolve_parser_engine("slides.pptx", {}) == "mineru"
+    rules = "*:mineru;html:docling"
+    validate_parser_routing_config(rules)
+    assert resolve_file_parser_engine("paper.pdf", parser_rules=rules) == "mineru"
+    assert resolve_file_parser_engine("index.html", parser_rules=rules) == "docling"
+    assert resolve_file_parser_engine("notes.txt", parser_rules=rules) == "legacy"
 
-    monkeypatch.setenv("MINERU_ENDPOINT", "")
-    assert rag._resolve_parser_engine("slides.pptx", {}) == "native"
+
+@pytest.mark.offline
+def test_parser_routing_validation_requires_external_endpoints(monkeypatch):
+    monkeypatch.delenv("MINERU_ENDPOINT", raising=False)
+    monkeypatch.setenv("DOCLING_ENDPOINT", "http://fake-docling")
+
+    with pytest.raises(ParserRoutingConfigError, match="MINERU_ENDPOINT"):
+        validate_parser_routing_config("*:mineru;html:docling")
+
+    monkeypatch.setenv("MINERU_ENDPOINT", "http://fake-mineru")
+    monkeypatch.delenv("DOCLING_ENDPOINT", raising=False)
+    with pytest.raises(ParserRoutingConfigError, match="DOCLING_ENDPOINT"):
+        validate_parser_routing_config("*:mineru;html:docling")
+
+
+@pytest.mark.offline
+def test_parser_routing_validation_rejects_invalid_rules(monkeypatch):
+    monkeypatch.setenv("MINERU_ENDPOINT", "http://fake-mineru")
+
+    with pytest.raises(ParserRoutingConfigError, match=r"\*\.pdf"):
+        validate_parser_routing_config("*.pdf:mineru")
+
+    with pytest.raises(ParserRoutingConfigError, match="unsupported parser engine"):
+        validate_parser_routing_config("pdf:unknown")
+
+    with pytest.raises(ParserRoutingConfigError, match="does not match any suffix"):
+        validate_parser_routing_config("pdf:native")
 
 
 @pytest.mark.offline
@@ -614,7 +661,10 @@ def test_parse_mineru_to_lightrag_document(tmp_path, monkeypatch):
 
         full_doc = await rag.full_docs.get_by_id("doc-1")
         assert full_doc["format"] == "lightrag"
-        assert full_doc["lightrag_document_path"] == str(blocks_path)
+        assert full_doc["content"] == FULL_DOCS_CONTENT_STORED_IN_LIGHTRAG_DOCUMENT
+        assert full_doc["lightrag_document_path"] == str(
+            blocks_path.relative_to(Path(rag.working_dir))
+        )
 
         await rag.finalize_storages()
 
@@ -724,7 +774,9 @@ def test_mm_chunks_and_modality_relations_from_sidecars(tmp_path):
 
 
 @pytest.mark.offline
-def test_parse_mineru_empty_service_result_falls_back_native(tmp_path, monkeypatch):
+def test_parse_mineru_empty_service_result_raises_without_fallback(
+    tmp_path, monkeypatch
+):
     async def _run():
         rag = _new_rag(tmp_path)
         await rag.initialize_storages()
@@ -738,14 +790,12 @@ def test_parse_mineru_empty_service_result_falls_back_native(tmp_path, monkeypat
         monkeypatch.setattr(rag, "_call_protocol_parse_service", _fake_service)
         monkeypatch.setenv("MINERU_ENDPOINT", "http://fake")
 
-        parsed = await rag.parse_mineru(
-            doc_id="doc-local-1",
-            file_path=str(src_file),
-            content_data={"content": "native fallback content"},
-        )
-        assert parsed["format"] == "raw"
-        assert parsed["content"] == "native fallback content"
-        assert parsed["blocks_path"] == ""
+        with pytest.raises(ValueError, match="empty content"):
+            await rag.parse_mineru(
+                doc_id="doc-local-1",
+                file_path=str(src_file),
+                content_data={"content": "native fallback content"},
+            )
 
         await rag.finalize_storages()
 
@@ -753,7 +803,9 @@ def test_parse_mineru_empty_service_result_falls_back_native(tmp_path, monkeypat
 
 
 @pytest.mark.offline
-def test_parse_docling_empty_service_result_falls_back_native(tmp_path, monkeypatch):
+def test_parse_docling_empty_service_result_raises_without_fallback(
+    tmp_path, monkeypatch
+):
     async def _run():
         rag = _new_rag(tmp_path)
         await rag.initialize_storages()
@@ -767,14 +819,12 @@ def test_parse_docling_empty_service_result_falls_back_native(tmp_path, monkeypa
         monkeypatch.setattr(rag, "_call_protocol_parse_service", _fake_service)
         monkeypatch.setenv("DOCLING_ENDPOINT", "http://fake")
 
-        parsed = await rag.parse_docling(
-            doc_id="doc-local-2",
-            file_path=str(src_file),
-            content_data={"content": "native fallback content"},
-        )
-        assert parsed["format"] == "raw"
-        assert parsed["content"] == "native fallback content"
-        assert parsed["blocks_path"] == ""
+        with pytest.raises(ValueError, match="empty content"):
+            await rag.parse_docling(
+                doc_id="doc-local-2",
+                file_path=str(src_file),
+                content_data={"content": "native fallback content"},
+            )
 
         await rag.finalize_storages()
 


### PR DESCRIPTION
## Description

This PR refactors LightRAG Server file ingestion so parser selection happens before upload-time extraction instead of after legacy extraction has already run. The previous flow mixed legacy local extractors, DOCX-specific switches, filename hints, and pipeline parser decisions. As a result, configurations such as `LIGHTRAG_PARSER=pdf:mineru,...` could be bypassed by the API upload path, which extracted PDFs locally first and enqueued raw text without enough parser context for the pipeline to route the original file to MinerU or Docling.

The new flow introduces a single parser routing layer for `legacy`, `native`, `mineru`, and `docling`, with explicit engine capability checks and startup-time configuration validation. Parser-routed files are stored as `pending_parse` records and keep their original file paths until the pipeline parser succeeds, while legacy files preserve the existing local extraction behavior.

## Related Issues

n/a

## Changes Made

- Added a shared `lightrag.parser_routing` module for filename hints, `LIGHTRAG_PARSER` parsing, engine capability checks, endpoint checks, and strict startup validation.
- Added parser engine constants and suffix capability tables for `legacy`, `native`, `mineru`, and `docling`.
- Moved parser selection into the API upload enqueue path so non-legacy files are deferred before local extraction and written to `full_docs` as `format=pending_parse` with the target parser engine.
- Standardized `full_docs` writeback semantics for `pending_parse`, `raw`, and `lightrag`, including placeholder content for structured LightRAG document storage and relative `lightrag_document_path` values.
- Removed `DOCX_PARSING_DEFAULT_METHOD` handling and replaced it with explicit `LIGHTRAG_PARSER=docx:legacy` or `LIGHTRAG_PARSER=docx:native` configuration.
- Made MinerU/Docling parsing fail clearly when endpoints are missing or parser services return empty content instead of silently falling back to native/raw behavior.
- Added support for both comma and semicolon parser rule separators, e.g. `pdf:mineru,html:docling` and `*:mineru;html:docling`.
- Added a Chinese file processing configuration guide under `docs/` and updated examples in `env.example`, `env.docker-compose-full`, and `docs/AdvancedFeatures.md`.
- Expanded tests for parser routing, pending-parse enqueue behavior, structured writeback, external endpoint validation, and DOCX routing without the deprecated config variable.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Local validation performed:

- `ruff check lightrag/parser_routing.py lightrag/constants.py lightrag/api/routers/document_routes.py tests/test_document_routes_docx_archive.py`
- `ruff check lightrag/parser_routing.py lightrag/api/lightrag_server.py tests/test_pipeline_release_closure.py`
- `./scripts/test.sh tests/test_document_routes_docx_archive.py tests/test_pipeline_release_closure.py`
- `git diff --check`
