### PR TITLE
Deduplicate documents by filename

### DIFF
--- a/docs/FileProcessingConfiguration-zh.md
+++ b/docs/FileProcessingConfiguration-zh.md
@@ -109,20 +109,23 @@ MINERU_ENDPOINT=http://localhost:8000/api/v1/task
 DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
 ```
 
-## `full_docs`存储存储说明
+## `full_docs` 存储说明
 
 文件入队和抽取结果会写入 `full_docs`：
 
 | 字段 | 说明 |
 | --- | --- |
-| `parsed_engine` | 实际完成抽取的引擎：`legacy`, `native`, `mineru`, `docling`。对于待抽取文件，也可暂存目标引擎。 |
+| `file_path` | 文件名 basename（不含目录），文件名重复判定与内容溯源都基于该字段。 |
+| `source_path` | 入队时提供的原始路径（仅当与 `file_path` 不同才会写入），供 `native` / `mineru` / `docling` 解析器定位真实文件位置。 |
 | `format` | 内容格式：`pending_parse`, `raw`, `lightrag`。 |
 | `content` | `raw` 时保存抽取文本；`pending_parse` 时为空字符串；`lightrag` 时固定为 `{{stored-in-lightrag-doucment}}`。 |
+| `content_hash` | 内容 MD5，用于跨文件名查重。`format=raw` 取 `sanitize_text_for_encoding` 后文本的 hash；`format=lightrag` 取 `*.blocks.jsonl` 文件 hash；`format=pending_parse` 不写入，待抽取完成后补上。 |
 | `lightrag_document_path` | `format=lightrag` 时保存结构化 LightRAG Document 的相对路径。 |
+| `parsed_engine` | 实际完成抽取的引擎：`legacy`, `native`, `mineru`, `docling`。对于待抽取文件，也可暂存目标引擎。 |
 
-其中 `file_path` 是文件名重复判定和内容溯源的关键字段，建议保持稳定、可读的文件名来源。
+`pending_parse` 表示文件已经入队，但还没有完成抽取。抽取成功后会改写为 `raw` 或 `lightrag`，并补齐 `content_hash`。抽取失败时保留 `pending_parse` 和空 `content`，便于后续排查和重试。
 
-`pending_parse` 表示文件已经入队，但还没有完成抽取。抽取成功后会改写为 `raw` 或 `lightrag`。抽取失败时保留 `pending_parse` 和空 `content`，便于后续排查和重试。
+> `doc_status` 中也会同步保存 `file_path`（basename）与 `content_hash`，作为 `get_doc_by_file_basename` / `get_doc_by_content_hash` 的查重索引来源。
 
 ## 原始文件归档
 

--- a/docs/FileProcessingConfiguration-zh.md
+++ b/docs/FileProcessingConfiguration-zh.md
@@ -52,15 +52,30 @@ report.[legacy].pdf
 
 文件名 hint 的优先级高于 `LIGHTRAG_PARSER`。如果指定的引擎不支持该后缀，系统会回退到默认规则继续选择可用引擎。如果所有规则都不可用，文件内容提取方式会回退到 `legacy`，如果legacy也不支持对应的文件后缀，会向系统加一个错误条目，上传文件保留在`INPUT`目录。
 
-## 文件重复判定规则
+## 文档重复判定规则
 
-文件上传、目录扫描、文件解析入队和文本接口都会按照文件名判断文档是否已经存在，不再依赖内容 hash 判断重复。
+文件上传、目录扫描、文件解析入队和文本接口在入队前会按照「文件名 + 内容 hash」两道关卡来判断是否重复，命中任一即视为重复并写入一条 `FAILED` 记录，不会覆盖已有的 `full_docs`。
+
+### 1) 文件名（basename）查重
 
 - 判断粒度为 basename，不包含目录路径和 workspace 路径。例如 `/data/a.pdf`、`inputs/a.pdf` 和 `a.pdf` 都视为同一个文件名 `a.pdf`。
-- 只要 `doc_status` 中已经存在同名文件记录，无论该记录当前处于 `PENDING`、`PARSING`、`ANALYZING`、`PROCESSING`、`FAILED` 还是 `PROCESSED`，同名文件都会被视为重复，不会覆盖已有 `full_docs`。
+- 只要 `doc_status` 中已经存在同名文件记录，无论该记录当前处于 `PENDING`、`PARSING`、`ANALYZING`、`PROCESSING`、`FAILED` 还是 `PROCESSED`，同名文件都会被视为重复。
 - 同名文件即使内容已经变化，也需要先删除旧文档记录后再重新上传或入队。
-- 不同文件名即使内容完全相同，也允许作为不同文档入队。
-- 文本接口必须提供有效的 `file_source`，并按 `file_source` 的 basename 判断重复；缺少有效 `file_source` 时不再使用内容 hash 兜底。
+- 文本接口必须提供有效的 `file_source`，并按 `file_source` 的 basename 判断重复；缺少有效 `file_source` 时直接返回 400。
+
+存储后端通过 `get_doc_by_file_basename` 提供 basename 直查能力。`JsonDocStatusStorage` 已经实现了内存级遍历；其它后端目前回落到默认实现（扫描全部状态后比对 basename），将在后续 PR 中补齐原生索引。
+
+### 2) 内容 hash 查重
+
+- 文件名不同但内容完全相同的文档同样视为重复，不会再次入队。
+- `full_docs` 与 `doc_status` 在入队时都会写入 `content_hash` 字段：
+  - `format=raw`：取经过 `sanitize_text_for_encoding` 之后的文本 MD5。
+  - `format=lightrag`：取 `lightrag_document_path` 解析出的 `*.blocks.jsonl` 文件 MD5（与 `_load_lightrag_document_content` 的解析规则一致）。
+  - `format=pending_parse`：暂不写入 hash，等到真正完成解析后由后续步骤补上（避免按空内容误判）。
+- 重复记录会在 `metadata.duplicate_kind` 中标记为 `filename` 或 `content_hash`，便于排查。
+- 存储后端通过 `get_doc_by_content_hash` 进行 hash 直查；命名约定与 `get_doc_by_file_basename` 一致。
+
+> 入队批次内（同一次 `apipeline_enqueue_documents` 调用）也会做 basename 与 content_hash 去重，命中时把后续条目直接写为 `FAILED` 并标记 `existing_status=batch_duplicate`。
 
 ## 推荐配置
 

--- a/docs/FileProcessingConfiguration-zh.md
+++ b/docs/FileProcessingConfiguration-zh.md
@@ -73,7 +73,7 @@ report.[legacy].pdf
 - 文件名不同但内容完全相同的文档同样视为重复，不会再次入队。
 - `full_docs` 与 `doc_status` 在入队时都会写入 `content_hash` 字段：
   - `format=raw`：取经过 `sanitize_text_for_encoding` 之后的文本 MD5。
-  - `format=lightrag`：取 `lightrag_document_path` 解析出的 `*.blocks.jsonl` 文件 MD5（与 `_load_lightrag_document_content` 的解析规则一致）。
+  - `format=lightrag`：取 `lightrag_document_path` 解析出的 `*.blocks.jsonl` 文件 MD5。相对路径按 `INPUT_DIR` 解析。
   - `format=pending_parse`：暂不写入 hash，等到真正完成解析后由后续步骤补上（避免按空内容误判）。
 - 重复记录会在 `metadata.duplicate_kind` 中标记为 `filename` 或 `content_hash`，便于排查。
 - 存储后端通过 `get_doc_by_content_hash` 进行 hash 直查；命名约定与 `get_doc_by_file_basename` 一致。
@@ -123,7 +123,7 @@ DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
 | `format` | 内容格式：`pending_parse`, `raw`, `lightrag`。 |
 | `content` | `raw` 时保存抽取文本；`pending_parse` 时为空字符串；`lightrag` 时固定为 `{{stored-in-lightrag-doucment}}`。 |
 | `content_hash` | 内容 MD5，用于跨文件名查重。`format=raw` 取 `sanitize_text_for_encoding` 后文本的 hash；`format=lightrag` 取 `*.blocks.jsonl` 文件 hash；`format=pending_parse` 不写入，待抽取完成后补上。 |
-| `lightrag_document_path` | `format=lightrag` 时保存结构化 LightRAG Document 的相对路径。 |
+| `lightrag_document_path` | `format=lightrag` 时保存结构化 LightRAG Document 的路径；新记录优先保存为相对 `INPUT_DIR` 的路径，例如 `__parsed__/doc.blocks.jsonl`。 |
 | `parsed_engine` | 实际完成抽取的引擎：`legacy`, `native`, `mineru`, `docling`。对于待抽取文件，也可暂存目标引擎。 |
 
 `pending_parse` 表示文件已经入队，但还没有完成抽取。抽取成功后会改写为 `raw` 或 `lightrag`，并补齐 `content_hash`。抽取失败时保留 `pending_parse` 和空 `content`，便于后续排查和重试。

--- a/docs/FileProcessingConfiguration-zh.md
+++ b/docs/FileProcessingConfiguration-zh.md
@@ -62,6 +62,9 @@ report.[legacy].pdf
 - 只要 `doc_status` 中已经存在同名文件记录，无论该记录当前处于 `PENDING`、`PARSING`、`ANALYZING`、`PROCESSING`、`FAILED` 还是 `PROCESSED`，同名文件都会被视为重复。
 - 同名文件即使内容已经变化，也需要先删除旧文档记录后再重新上传或入队。
 - 文本接口必须提供有效的 `file_source`，并按 `file_source` 的 basename 判断重复；缺少有效 `file_source` 时直接返回 400。
+- 核心 API `insert` / `ainsert` / `apipeline_enqueue_documents` 仍兼容未传 `file_paths` 的调用；这类文档的 `file_path` 会保存为 `unknown_source`，不会参与文件名查重，文档 ID 继续按文本内容生成。
+- 为兼容遗留数据，空字符串、`no-file-path` 和 `unknown_source` 都会被视为未知来源；它们不会阻止新的无来源文本入队，也不会作为同名文件互相去重。
+- 遗留数据中如果存在多个有效 basename 相同的 `file_path`，系统不会自动合并或清理；后续再次入队同名文件时会命中第一条匹配记录并按重复处理，建议先删除或修正旧记录。
 
 存储后端通过 `get_doc_by_file_basename` 提供 basename 直查能力。`JsonDocStatusStorage` 已经实现了内存级遍历；其它后端目前回落到默认实现（扫描全部状态后比对 basename），将在后续 PR 中补齐原生索引。
 
@@ -75,7 +78,7 @@ report.[legacy].pdf
 - 重复记录会在 `metadata.duplicate_kind` 中标记为 `filename` 或 `content_hash`，便于排查。
 - 存储后端通过 `get_doc_by_content_hash` 进行 hash 直查；命名约定与 `get_doc_by_file_basename` 一致。
 
-> 入队批次内（同一次 `apipeline_enqueue_documents` 调用）也会做 basename 与 content_hash 去重，命中时把后续条目直接写为 `FAILED` 并标记 `existing_status=batch_duplicate`。
+> 入队批次内（同一次 `apipeline_enqueue_documents` 调用）也会做 basename 与 content_hash 去重，命中时把后续条目直接写为 `FAILED` 并标记 `existing_status=batch_duplicate`。其中 basename 去重只对有效文件名生效；`unknown_source`、`no-file-path` 和空来源只参与内容 hash 去重。
 
 ## 推荐配置
 
@@ -115,7 +118,7 @@ DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
 
 | 字段 | 说明 |
 | --- | --- |
-| `file_path` | 文件名 basename（不含目录），文件名重复判定与内容溯源都基于该字段。 |
+| `file_path` | 文件名 basename（不含目录）。未提供有效来源时保存为 `unknown_source`；有效文件名的重复判定与内容溯源都基于该字段。 |
 | `source_path` | 入队时提供的原始路径（仅当与 `file_path` 不同才会写入），供 `native` / `mineru` / `docling` 解析器定位真实文件位置。 |
 | `format` | 内容格式：`pending_parse`, `raw`, `lightrag`。 |
 | `content` | `raw` 时保存抽取文本；`pending_parse` 时为空字符串；`lightrag` 时固定为 `{{stored-in-lightrag-doucment}}`。 |

--- a/docs/FileProcessingConfiguration-zh.md
+++ b/docs/FileProcessingConfiguration-zh.md
@@ -52,6 +52,16 @@ report.[legacy].pdf
 
 文件名 hint 的优先级高于 `LIGHTRAG_PARSER`。如果指定的引擎不支持该后缀，系统会回退到默认规则继续选择可用引擎。如果所有规则都不可用，文件内容提取方式会回退到 `legacy`，如果legacy也不支持对应的文件后缀，会向系统加一个错误条目，上传文件保留在`INPUT`目录。
 
+## 文件重复判定规则
+
+文件上传、目录扫描、文件解析入队和文本接口都会按照文件名判断文档是否已经存在，不再依赖内容 hash 判断重复。
+
+- 判断粒度为 basename，不包含目录路径和 workspace 路径。例如 `/data/a.pdf`、`inputs/a.pdf` 和 `a.pdf` 都视为同一个文件名 `a.pdf`。
+- 只要 `doc_status` 中已经存在同名文件记录，无论该记录当前处于 `PENDING`、`PARSING`、`ANALYZING`、`PROCESSING`、`FAILED` 还是 `PROCESSED`，同名文件都会被视为重复，不会覆盖已有 `full_docs`。
+- 同名文件即使内容已经变化，也需要先删除旧文档记录后再重新上传或入队。
+- 不同文件名即使内容完全相同，也允许作为不同文档入队。
+- 文本接口必须提供有效的 `file_source`，并按 `file_source` 的 basename 判断重复；缺少有效 `file_source` 时不再使用内容 hash 兜底。
+
 ## 推荐配置
 
 ### 保持旧版行为
@@ -95,6 +105,8 @@ DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
 | `content` | `raw` 时保存抽取文本；`pending_parse` 时为空字符串；`lightrag` 时固定为 `{{stored-in-lightrag-doucment}}`。 |
 | `lightrag_document_path` | `format=lightrag` 时保存结构化 LightRAG Document 的相对路径。 |
 
+其中 `file_path` 是文件名重复判定和内容溯源的关键字段，建议保持稳定、可读的文件名来源。
+
 `pending_parse` 表示文件已经入队，但还没有完成抽取。抽取成功后会改写为 `raw` 或 `lightrag`。抽取失败时保留 `pending_parse` 和空 `content`，便于后续排查和重试。
 
 ## 原始文件归档
@@ -102,3 +114,4 @@ DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
 - `legacy`：本地抽取成功并入队后，原文件会移动到同级 `__parsed__` 目录。
 - `native` / `mineru` / `docling`：文件先保留在原位置供 pipeline 解析；解析成功并写入 `full_docs` 后，原文件再移动到 `__parsed__`。
 - 解析失败时，原文件不会移动，便于修复配置后重新处理。
+- 同名重复文件不会作为新文档入队，也不应为了重复判定而覆盖或移动既有文档源文件。

--- a/docs/FileProcessingConfiguration-zh.md
+++ b/docs/FileProcessingConfiguration-zh.md
@@ -54,13 +54,16 @@ report.[legacy].pdf
 
 ## 文档重复判定规则
 
-文件上传、目录扫描、文件解析入队和文本接口在入队前会按照「文件名 + 内容 hash」两道关卡来判断是否重复，命中任一即视为重复并写入一条 `FAILED` 记录，不会覆盖已有的 `full_docs`。
+文件上传、文件解析入队和文本接口会按照「文件名 + 内容 hash」两道关卡判断是否重复，命中任一即视为重复并写入一条 `FAILED` 记录，不会覆盖已有的 `full_docs`。`/documents/scan` 目录扫描也使用同一套索引，但为了便于自动重试未完成文件，对文件名重复有单独的归档与重处理规则。
 
 ### 1) 文件名（basename）查重
 
 - 判断粒度为 basename，不包含目录路径和 workspace 路径。例如 `/data/a.pdf`、`inputs/a.pdf` 和 `a.pdf` 都视为同一个文件名 `a.pdf`。
-- 只要 `doc_status` 中已经存在同名文件记录，无论该记录当前处于 `PENDING`、`PARSING`、`ANALYZING`、`PROCESSING`、`FAILED` 还是 `PROCESSED`，同名文件都会被视为重复。
-- 同名文件即使内容已经变化，也需要先删除旧文档记录后再重新上传或入队。
+- 对普通上传、文本接口和核心入队 API，只要 `doc_status` 中已经存在同名文件记录，无论该记录当前处于 `PENDING`、`PARSING`、`ANALYZING`、`PROCESSING`、`FAILED` 还是 `PROCESSED`，同名文件都会被视为重复。
+- 对 `/documents/scan` 目录扫描：
+  - 如果同名记录已经是 `PROCESSED`，当前扫描到的文件视为已处理文件，系统会输出 warning，将该输入文件移动到同级 `__parsed__` 目录，并跳过入队。
+  - 如果同名记录不是 `PROCESSED`，当前扫描文件不会仅因文件名相同而跳过；系统会按新的扫描文件从头提取、入队并覆盖/重置未完成的同名状态。
+- 普通上传和核心入队 API 中，同名文件即使内容已经变化，也需要先删除旧文档记录后再重新上传或入队；扫描路径的非 `PROCESSED` 同名重处理只用于目录扫描自动恢复。
 - 文本接口必须提供有效的 `file_source`，并按 `file_source` 的 basename 判断重复；缺少有效 `file_source` 时直接返回 400。
 - 核心 API `insert` / `ainsert` / `apipeline_enqueue_documents` 仍兼容未传 `file_paths` 的调用；这类文档的 `file_path` 会保存为 `unknown_source`，不会参与文件名查重，文档 ID 继续按文本内容生成。
 - 为兼容遗留数据，空字符串、`no-file-path` 和 `unknown_source` 都会被视为未知来源；它们不会阻止新的无来源文本入队，也不会作为同名文件互相去重。
@@ -70,12 +73,15 @@ report.[legacy].pdf
 
 ### 2) 内容 hash 查重
 
-- 文件名不同但内容完全相同的文档同样视为重复，不会再次入队。
-- `full_docs` 与 `doc_status` 在入队时都会写入 `content_hash` 字段：
+- 文件名不同但抽取后的内容完全相同的文档同样视为重复。这里的 hash 是按配置的抽取引擎得到最终文本或 LightRAG Document 后计算的内容 hash，不是原始文件字节 hash。
+- `full_docs` 与 `doc_status` 会按内容格式写入或补齐 `content_hash` 字段：
   - `format=raw`：取经过 `sanitize_text_for_encoding` 之后的文本 MD5。
   - `format=lightrag`：取 `lightrag_document_path` 解析出的 `*.blocks.jsonl` 文件 MD5。相对路径按 `INPUT_DIR` 解析。
   - `format=pending_parse`：暂不写入 hash，等到真正完成解析后由后续步骤补上（避免按空内容误判）。
-- 重复记录会在 `metadata.duplicate_kind` 中标记为 `filename` 或 `content_hash`，便于排查。
+- `legacy` 路径会在本地提取文本后、入队时进行内容 hash 查重；命中重复时，本次记录写为 `FAILED duplicate`，不会生成新的 `full_docs`、chunks 或图数据。
+- `native` / `mineru` / `docling` 路径会先以 `pending_parse` 入队；真正完成解析并补齐 `content_hash` 后，如果发现其它文档已有相同 hash，本次记录会在进入分析、切块、实体抽取和图写入前停止。
+- 重复记录会在 `metadata.duplicate_kind` 中标记为 `filename` 或 `content_hash`，便于排查。内容 hash 重复还会记录 `metadata.is_duplicate=true`、`metadata.original_doc_id` 和 `metadata.original_track_id`；解析后才发现的重复会删除本次临时写入的 `full_docs`。
+- 相关 warning 会尽量减少重复噪音：扫描发现已 `PROCESSED` 的同名文件时会写入日志和 pipeline status；入队阶段重复使用 LightRAG 层的 `Duplicate document detected (...)` 日志；解析完成后才发现的内容重复使用 `Duplicate content skipped after parsing`，并写入 pipeline status。扫描归档不会额外输出 `[File Extraction]Duplicate skipped`。
 - 存储后端通过 `get_doc_by_content_hash` 进行 hash 直查；命名约定与 `get_doc_by_file_basename` 一致。
 
 > 入队批次内（同一次 `apipeline_enqueue_documents` 调用）也会做 basename 与 content_hash 去重，命中时把后续条目直接写为 `FAILED` 并标记 `existing_status=batch_duplicate`。其中 basename 去重只对有效文件名生效；`unknown_source`、`no-file-path` 和空来源只参与内容 hash 去重。
@@ -135,4 +141,6 @@ DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
 - `legacy`：本地抽取成功并入队后，原文件会移动到同级 `__parsed__` 目录。
 - `native` / `mineru` / `docling`：文件先保留在原位置供 pipeline 解析；解析成功并写入 `full_docs` 后，原文件再移动到 `__parsed__`。
 - 解析失败时，原文件不会移动，便于修复配置后重新处理。
-- 同名重复文件不会作为新文档入队，也不应为了重复判定而覆盖或移动既有文档源文件。
+- `/documents/scan` 扫描到同名且已 `PROCESSED` 的文件时，该输入文件会被视为已处理并移动到 `__parsed__`，不会作为新文档入队。
+- 扫描或解析过程中发现内容 hash 重复时，该输入文件同样会移动到 `__parsed__`；本次 `doc_status` 保留为 `FAILED duplicate` 以便追踪。
+- 移动文件只作用于当前输入文件，不会覆盖或移动既有文档源文件。若目标目录已存在同名文件，系统会自动追加 `_001`、`_002` 等编号，例如 `report.pdf` 会依次归档为 `report_001.pdf`、`report_002.pdf`。

--- a/env.example
+++ b/env.example
@@ -233,7 +233,8 @@ ENTITY_EXTRACTION_USE_JSON=true
 ### (pdf), not full names (*.pdf), and are checked left-to-right.
 ### If mineru/docling appears in LIGHTRAG_PARSER, the corresponding endpoint
 ### below must be configured before server startup.
-# LIGHTRAG_PARSER=
+# LIGHTRAG_PARSER=docx:native
+
 ### Retry count for multimodal VLM analysis JSON normalization/writeback
 # VLM_ANALYZE_RETRIES=2
 ### Maximum image bytes sent to VLM per multimodal item

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -964,6 +964,28 @@ async def get_existing_doc_by_file_path_candidates(
     return existing_doc_data
 
 
+async def record_scan_warning(rag: LightRAG, message: str) -> None:
+    logger.warning(message)
+    try:
+        from lightrag.kg import shared_storage
+
+        if not getattr(shared_storage, "_initialized", False):
+            return
+
+        workspace = getattr(rag, "workspace", "")
+        pipeline_status = await shared_storage.get_namespace_data(
+            "pipeline_status", workspace=workspace
+        )
+        pipeline_status_lock = shared_storage.get_namespace_lock(
+            "pipeline_status", workspace=workspace
+        )
+        async with pipeline_status_lock:
+            pipeline_status["latest_message"] = message
+            pipeline_status["history_messages"].append(message)
+    except Exception:
+        pass
+
+
 # Document processing helper functions (synchronous)
 # These functions run in thread pool via asyncio.to_thread() to avoid blocking the event loop
 
@@ -1214,7 +1236,10 @@ def _extract_xlsx(file_bytes: bytes) -> str:
 
 
 async def pipeline_enqueue_file(
-    rag: LightRAG, file_path: Path, track_id: str = None
+    rag: LightRAG,
+    file_path: Path,
+    track_id: str = None,
+    reprocess_existing_non_processed: bool = False,
 ) -> tuple[bool, str]:
     """Add a file to the queue for processing
 
@@ -1245,13 +1270,25 @@ async def pipeline_enqueue_file(
         extraction_engine = resolve_file_parser_engine(file_path)
         if extraction_engine != PARSER_ENGINE_LEGACY:
             try:
-                await rag.apipeline_enqueue_documents(
-                    "",
-                    file_paths=str(file_path),
-                    track_id=track_id,
-                    docs_format=FULL_DOCS_FORMAT_PENDING_PARSE,
-                    parsed_engine=extraction_engine,
+                enqueue_kwargs = {
+                    "file_paths": str(file_path),
+                    "track_id": track_id,
+                    "docs_format": FULL_DOCS_FORMAT_PENDING_PARSE,
+                    "parsed_engine": extraction_engine,
+                }
+                if reprocess_existing_non_processed:
+                    enqueue_kwargs["reprocess_existing_non_processed"] = True
+                enqueue_result = await rag.apipeline_enqueue_documents(
+                    "", **enqueue_kwargs
                 )
+                if enqueue_result is None:
+                    try:
+                        await move_file_to_parsed_dir(file_path)
+                    except Exception as move_error:
+                        logger.error(
+                            f"Failed to move duplicate file {file_path.name} to {PARSED_DIR_NAME} directory: {move_error}"
+                        )
+                    return False, track_id
                 logger.info(
                     f"[File Extraction]Deferred {file_path.name} to {extraction_engine} parser"
                 )
@@ -1547,12 +1584,24 @@ async def pipeline_enqueue_file(
                 return False, track_id
 
             try:
-                await rag.apipeline_enqueue_documents(
-                    content,
-                    file_paths=file_path.name,
-                    track_id=track_id,
-                    parsed_engine=PARSER_ENGINE_LEGACY,
+                enqueue_kwargs = {
+                    "file_paths": file_path.name,
+                    "track_id": track_id,
+                    "parsed_engine": PARSER_ENGINE_LEGACY,
+                }
+                if reprocess_existing_non_processed:
+                    enqueue_kwargs["reprocess_existing_non_processed"] = True
+                enqueue_result = await rag.apipeline_enqueue_documents(
+                    content, **enqueue_kwargs
                 )
+                if enqueue_result is None:
+                    try:
+                        await move_file_to_parsed_dir(file_path)
+                    except Exception as move_error:
+                        logger.error(
+                            f"Failed to move duplicate file {file_path.name} to {PARSED_DIR_NAME} directory: {move_error}"
+                        )
+                    return False, track_id
 
                 logger.info(
                     f"Successfully extracted and enqueued file: {file_path.name}"
@@ -1640,7 +1689,10 @@ async def pipeline_index_file(rag: LightRAG, file_path: Path, track_id: str = No
 
 
 async def pipeline_index_files(
-    rag: LightRAG, file_paths: List[Path], track_id: str = None
+    rag: LightRAG,
+    file_paths: List[Path],
+    track_id: str = None,
+    reprocess_existing_non_processed: bool = False,
 ):
     """Index multiple files sequentially to avoid high CPU load
 
@@ -1661,7 +1713,12 @@ async def pipeline_index_files(
 
         # Process files sequentially with track_id
         for file_path in sorted_file_paths:
-            success, _ = await pipeline_enqueue_file(rag, file_path, track_id)
+            success, _ = await pipeline_enqueue_file(
+                rag,
+                file_path,
+                track_id,
+                reprocess_existing_non_processed=reprocess_existing_non_processed,
+            )
             if success:
                 enqueued = True
 
@@ -1724,7 +1781,6 @@ async def run_scanning_process(
             # Check for files with PROCESSED status and filter them out
             valid_files = []
             processed_files = []
-            queued_existing_files = []
 
             for file_path in new_files:
                 filename = file_path.name
@@ -1737,21 +1793,37 @@ async def run_scanning_process(
                     and get_doc_status_value(existing_doc_data)
                     == DocStatus.PROCESSED.value
                 ):
-                    # File is already PROCESSED, skip it with warning
+                    # File is already PROCESSED, skip it with warning and archive it.
                     processed_files.append(filename)
-                    logger.warning(f"Skipping already processed file: {filename}")
-                elif existing_doc_data:
-                    queued_existing_files.append(filename)
-                    logger.info(
-                        f"Skipping already enqueued file and continuing existing pipeline state: {filename}"
+                    warning = (
+                        f"Skipping already processed file: "
+                        f"{filename}"
                     )
+                    await record_scan_warning(rag, warning)
+                    try:
+                        await move_file_to_parsed_dir(file_path)
+                    except Exception as move_error:
+                        logger.error(
+                            f"Failed to move already processed file {filename} to {PARSED_DIR_NAME}: {move_error}"
+                        )
+                elif existing_doc_data:
+                    logger.info(
+                        "Reprocessing previously unfinished file from scan: "
+                        f"{filename} (Status: {get_doc_status_value(existing_doc_data)})"
+                    )
+                    valid_files.append(file_path)
                 else:
                     # File is new or in non-PROCESSED status, add to processing list
                     valid_files.append(file_path)
 
             # Process valid files (new files + non-PROCESSED status files)
             if valid_files:
-                await pipeline_index_files(rag, valid_files, track_id)
+                await pipeline_index_files(
+                    rag,
+                    valid_files,
+                    track_id,
+                    reprocess_existing_non_processed=True,
+                )
                 if processed_files:
                     logger.info(
                         f"Scanning process completed: {len(valid_files)} files Processed {len(processed_files)} skipped."
@@ -1764,8 +1836,6 @@ async def run_scanning_process(
                 logger.info(
                     "No files to process after filtering already processed files."
                 )
-                if queued_existing_files:
-                    await rag.apipeline_process_enqueue_documents()
         else:
             # No new files to index, check if there are any documents in the queue
             logger.info(

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -950,46 +950,18 @@ def get_doc_track_id(doc_status: Any) -> str:
     return str(track_id or "")
 
 
-def build_file_path_lookup_candidates(file_path: Path | str) -> list[str]:
-    """Build compatible file_path keys for legacy name/full-path records."""
-    path = Path(file_path)
-    candidates = [path.name, str(path)]
-    try:
-        candidates.append(str(path.resolve()))
-    except Exception:
-        pass
-
-    seen: set[str] = set()
-    unique: list[str] = []
-    for candidate in candidates:
-        if candidate and candidate not in seen:
-            seen.add(candidate)
-            unique.append(candidate)
-    return unique
-
-
 async def get_existing_doc_by_file_path_candidates(
     doc_status: Any, file_path: Path | str
 ) -> dict[str, Any] | None:
-    """Find an existing document using filename and full-path variants."""
-    target_name = normalize_file_path(str(file_path))
-    for candidate in build_file_path_lookup_candidates(file_path):
-        existing_doc_data = await doc_status.get_doc_by_file_path(candidate)
-        if existing_doc_data:
-            return existing_doc_data
-    try:
-        docs = await doc_status.get_docs_by_statuses(list(DocStatus))
-    except Exception:
+    """Find an existing document by file basename via the storage backend."""
+    basename = normalize_file_path(str(file_path))
+    if basename == UNKNOWN_FILE_SOURCE:
         return None
-    for existing_doc_data in docs.values():
-        existing_path = (
-            existing_doc_data.get("file_path")
-            if isinstance(existing_doc_data, dict)
-            else getattr(existing_doc_data, "file_path", None)
-        )
-        if normalize_file_path(existing_path) == target_name:
-            return existing_doc_data
-    return None
+    match = await doc_status.get_doc_by_file_basename(basename)
+    if not match:
+        return None
+    _, existing_doc_data = match
+    return existing_doc_data
 
 
 # Document processing helper functions (synchronous)

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -1795,10 +1795,7 @@ async def run_scanning_process(
                 ):
                     # File is already PROCESSED, skip it with warning and archive it.
                     processed_files.append(filename)
-                    warning = (
-                        f"Skipping already processed file: "
-                        f"{filename}"
-                    )
+                    warning = f"Skipping already processed file: " f"{filename}"
                     await record_scan_warning(rag, warning)
                     try:
                         await move_file_to_parsed_dir(file_path)

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -32,8 +32,6 @@ from lightrag.constants import (
 from lightrag.parser_routing import resolve_file_parser_engine
 from lightrag.utils import (
     generate_track_id,
-    compute_mdhash_id,
-    sanitize_text_for_encoding,
     move_file_to_parsed_dir,
 )
 from lightrag.api.utils_api import get_combined_auth_dependency
@@ -85,7 +83,13 @@ def normalize_file_path(file_path: str | None) -> str:
     if normalized in LEGACY_EMPTY_FILE_PATH_SENTINELS:
         return UNKNOWN_FILE_SOURCE
 
-    return normalized
+    return Path(normalized).name or UNKNOWN_FILE_SOURCE
+
+
+def is_valid_file_source(file_source: str | None) -> bool:
+    if file_source is None:
+        return False
+    return normalize_file_path(file_source) != UNKNOWN_FILE_SOURCE
 
 
 def sanitize_filename(filename: str, input_dir: Path) -> str:
@@ -968,9 +972,22 @@ async def get_existing_doc_by_file_path_candidates(
     doc_status: Any, file_path: Path | str
 ) -> dict[str, Any] | None:
     """Find an existing document using filename and full-path variants."""
+    target_name = normalize_file_path(str(file_path))
     for candidate in build_file_path_lookup_candidates(file_path):
         existing_doc_data = await doc_status.get_doc_by_file_path(candidate)
         if existing_doc_data:
+            return existing_doc_data
+    try:
+        docs = await doc_status.get_docs_by_statuses(list(DocStatus))
+    except Exception:
+        return None
+    for existing_doc_data in docs.values():
+        existing_path = (
+            existing_doc_data.get("file_path")
+            if isinstance(existing_doc_data, dict)
+            else getattr(existing_doc_data, "file_path", None)
+        )
+        if normalize_file_path(existing_path) == target_name:
             return existing_doc_data
     return None
 
@@ -1701,17 +1718,14 @@ async def pipeline_index_texts(
     if not texts:
         return
 
-    normalized_file_sources: list[str] | None = None
-    if file_sources:
-        normalized_file_sources = [
-            normalize_file_path(source) for source in file_sources
-        ]
-        if len(normalized_file_sources) > len(texts):
-            raise ValueError("Number of file sources must not exceed number of texts")
-        if len(normalized_file_sources) < len(texts):
-            normalized_file_sources.extend(
-                [UNKNOWN_FILE_SOURCE] * (len(texts) - len(normalized_file_sources))
-            )
+    if not file_sources or len(file_sources) != len(texts):
+        raise ValueError("A valid file source is required for each text")
+
+    normalized_file_sources = [normalize_file_path(source) for source in file_sources]
+    if any(source == UNKNOWN_FILE_SOURCE for source in normalized_file_sources):
+        raise ValueError("A valid file source is required for each text")
+    if len(set(normalized_file_sources)) != len(normalized_file_sources):
+        raise ValueError("File sources must be unique by filename")
 
     await rag.apipeline_enqueue_documents(
         input=texts, file_paths=normalized_file_sources, track_id=track_id
@@ -2270,36 +2284,24 @@ def create_document_routes(
         """
         try:
             # Check if file_source already exists in doc_status storage
-            if (
-                request.file_source
-                and request.file_source.strip()
-                and request.file_source != "unknown_source"
-            ):
-                existing_doc_data = await rag.doc_status.get_doc_by_file_path(
-                    request.file_source
+            if not is_valid_file_source(request.file_source):
+                raise HTTPException(
+                    status_code=400,
+                    detail="A valid file_source is required for text insertion",
                 )
-                if existing_doc_data:
-                    # Get document status and track_id from existing document
-                    status = existing_doc_data.get("status", "unknown")
-                    # Use `or ""` to handle both missing key and None value (e.g., legacy rows without track_id)
-                    existing_track_id = existing_doc_data.get("track_id") or ""
-                    return InsertResponse(
-                        status="duplicated",
-                        message=f"File source '{request.file_source}' already exists in document storage (Status: {status}).",
-                        track_id=existing_track_id,
-                    )
 
-            # Check if content already exists by computing content hash (doc_id)
-            sanitized_text = sanitize_text_for_encoding(request.text)
-            content_doc_id = compute_mdhash_id(sanitized_text, prefix="doc-")
-            existing_doc = await rag.doc_status.get_by_id(content_doc_id)
-            if existing_doc:
-                # Content already exists, return duplicated with existing track_id
-                status = existing_doc.get("status", "unknown")
-                existing_track_id = existing_doc.get("track_id") or ""
+            normalized_file_source = normalize_file_path(request.file_source)
+            existing_doc_data = await get_existing_doc_by_file_path_candidates(
+                rag.doc_status, normalized_file_source
+            )
+            if existing_doc_data:
+                # Get document status and track_id from existing document
+                status = get_doc_status_value(existing_doc_data) or "unknown"
+                # Use `or ""` to handle both missing key and None value (e.g., legacy rows without track_id)
+                existing_track_id = get_doc_track_id(existing_doc_data)
                 return InsertResponse(
                     status="duplicated",
-                    message=f"Identical content already exists in document storage (doc_id: {content_doc_id}, Status: {status}).",
+                    message=f"File source '{normalized_file_source}' already exists in document storage (Status: {status}).",
                     track_id=existing_track_id,
                 )
 
@@ -2310,7 +2312,7 @@ def create_document_routes(
                 pipeline_index_texts,
                 rag,
                 [request.text],
-                file_sources=[request.file_source],
+                file_sources=[normalized_file_source],
                 track_id=track_id,
             )
 
@@ -2319,6 +2321,8 @@ def create_document_routes(
                 message="Text successfully received. Processing will continue in background.",
                 track_id=track_id,
             )
+        except HTTPException:
+            raise
         except Exception as e:
             logger.error(f"Error /documents/text: {str(e)}")
             logger.error(traceback.format_exc())
@@ -2350,39 +2354,43 @@ def create_document_routes(
         """
         try:
             # Check if any file_sources already exist in doc_status storage
-            if request.file_sources:
-                for file_source in request.file_sources:
-                    if (
-                        file_source
-                        and file_source.strip()
-                        and file_source != "unknown_source"
-                    ):
-                        existing_doc_data = await rag.doc_status.get_doc_by_file_path(
-                            file_source
-                        )
-                        if existing_doc_data:
-                            # Get document status and track_id from existing document
-                            status = existing_doc_data.get("status", "unknown")
-                            # Use `or ""` to handle both missing key and None value (e.g., legacy rows without track_id)
-                            existing_track_id = existing_doc_data.get("track_id") or ""
-                            return InsertResponse(
-                                status="duplicated",
-                                message=f"File source '{file_source}' already exists in document storage (Status: {status}).",
-                                track_id=existing_track_id,
-                            )
+            if not request.file_sources or len(request.file_sources) != len(
+                request.texts
+            ):
+                raise HTTPException(
+                    status_code=400,
+                    detail="A valid file_source is required for each text",
+                )
 
-            # Check if any content already exists by computing content hash (doc_id)
-            for text in request.texts:
-                sanitized_text = sanitize_text_for_encoding(text)
-                content_doc_id = compute_mdhash_id(sanitized_text, prefix="doc-")
-                existing_doc = await rag.doc_status.get_by_id(content_doc_id)
-                if existing_doc:
-                    # Content already exists, return duplicated with existing track_id
-                    status = existing_doc.get("status", "unknown")
-                    existing_track_id = existing_doc.get("track_id") or ""
+            normalized_file_sources = [
+                normalize_file_path(file_source) for file_source in request.file_sources
+            ]
+            if any(
+                file_source == UNKNOWN_FILE_SOURCE
+                for file_source in normalized_file_sources
+            ):
+                raise HTTPException(
+                    status_code=400,
+                    detail="A valid file_source is required for each text",
+                )
+            if len(set(normalized_file_sources)) != len(normalized_file_sources):
+                raise HTTPException(
+                    status_code=400,
+                    detail="file_sources must be unique by filename",
+                )
+
+            for file_source in normalized_file_sources:
+                existing_doc_data = await get_existing_doc_by_file_path_candidates(
+                    rag.doc_status, file_source
+                )
+                if existing_doc_data:
+                    # Get document status and track_id from existing document
+                    status = get_doc_status_value(existing_doc_data) or "unknown"
+                    # Use `or ""` to handle both missing key and None value (e.g., legacy rows without track_id)
+                    existing_track_id = get_doc_track_id(existing_doc_data)
                     return InsertResponse(
                         status="duplicated",
-                        message=f"Identical content already exists in document storage (doc_id: {content_doc_id}, Status: {status}).",
+                        message=f"File source '{file_source}' already exists in document storage (Status: {status}).",
                         track_id=existing_track_id,
                     )
 
@@ -2393,7 +2401,7 @@ def create_document_routes(
                 pipeline_index_texts,
                 rag,
                 request.texts,
-                file_sources=request.file_sources,
+                file_sources=normalized_file_sources,
                 track_id=track_id,
             )
 
@@ -2402,6 +2410,8 @@ def create_document_routes(
                 message="Texts successfully received. Processing will continue in background.",
                 track_id=track_id,
             )
+        except HTTPException:
+            raise
         except Exception as e:
             logger.error(f"Error /documents/texts: {str(e)}")
             logger.error(traceback.format_exc())

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -4,7 +4,8 @@ from abc import ABC, abstractmethod
 from enum import Enum
 import os
 from dotenv import load_dotenv
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
 from typing import (
     Any,
     Literal,
@@ -799,6 +800,12 @@ class DocProcessingStatus:
     metadata: dict[str, Any] = field(default_factory=dict)
     """Additional metadata"""
     multimodal_processed: bool | None = field(default=None, repr=False)
+    content_hash: str | None = None
+    """MD5 hash of the underlying document content (raw text or source file).
+
+    Used together with file_path basename for duplicate detection. Empty for
+    pending_parse records whose content has not been extracted yet.
+    """
     """Internal field: indicates if multimodal processing is complete. Not shown in repr() but accessible for debugging."""
 
     def __post_init__(self):
@@ -904,6 +911,74 @@ class DocStatusStorage(BaseKVStorage, ABC):
             dict[str, Any] | None: Document data if found, None otherwise
             Returns the same format as get_by_ids method
         """
+
+    async def get_doc_by_file_basename(
+        self, basename: str
+    ) -> tuple[str, dict[str, Any]] | None:
+        """Get document by file basename (filename without directory).
+
+        Used for filename-based deduplication. Backends that can index by
+        basename should override this for efficiency. The default implementation
+        scans all documents via get_docs_by_statuses().
+
+        Args:
+            basename: The filename basename to search for (e.g. "report.pdf").
+
+        Returns:
+            (doc_id, doc_data) when a matching record exists, otherwise None.
+        """
+        if not basename:
+            return None
+        try:
+            docs = await self.get_docs_by_statuses(list(DocStatus))
+        except NotImplementedError:
+            raise
+        except Exception:
+            return None
+        for doc_id, doc in docs.items():
+            existing_path = (
+                doc.get("file_path")
+                if isinstance(doc, dict)
+                else getattr(doc, "file_path", None)
+            )
+            if not existing_path:
+                continue
+            if Path(str(existing_path)).name == basename:
+                return doc_id, (doc if isinstance(doc, dict) else asdict(doc))
+        return None
+
+    async def get_doc_by_content_hash(
+        self, content_hash: str
+    ) -> tuple[str, dict[str, Any]] | None:
+        """Get document by content_hash field.
+
+        Used for content-hash deduplication of full documents. Backends that
+        can index by content_hash should override this for efficiency. The
+        default implementation scans all documents via get_docs_by_statuses().
+
+        Args:
+            content_hash: The content hash value to search for.
+
+        Returns:
+            (doc_id, doc_data) when a matching record exists, otherwise None.
+        """
+        if not content_hash:
+            return None
+        try:
+            docs = await self.get_docs_by_statuses(list(DocStatus))
+        except NotImplementedError:
+            raise
+        except Exception:
+            return None
+        for doc_id, doc in docs.items():
+            existing_hash = (
+                doc.get("content_hash")
+                if isinstance(doc, dict)
+                else getattr(doc, "content_hash", None)
+            )
+            if existing_hash and existing_hash == content_hash:
+                return doc_id, (doc if isinstance(doc, dict) else asdict(doc))
+        return None
 
 
 class StoragesStatus(str, Enum):

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 import os
+from pathlib import Path
 from typing import Any, Union, final
 
 from lightrag.base import (
@@ -398,6 +399,44 @@ class JsonDocStatusStorage(DocStatusStorage):
                     # Return complete document data, consistent with get_by_ids method
                     return doc_data
 
+        return None
+
+    async def get_doc_by_file_basename(
+        self, basename: str
+    ) -> Union[tuple[str, dict[str, Any]], None]:
+        """Find an existing record whose file_path basename matches.
+
+        Compares against the stored file_path's basename so legacy records
+        that still hold a full path are matched the same way as new records
+        whose file_path is already a basename.
+        """
+        if not basename:
+            return None
+        if self._storage_lock is None:
+            raise StorageNotInitializedError("JsonDocStatusStorage")
+
+        async with self._storage_lock:
+            for doc_id, doc_data in self._data.items():
+                stored_path = doc_data.get("file_path")
+                if not stored_path:
+                    continue
+                if Path(str(stored_path)).name == basename:
+                    return doc_id, doc_data
+        return None
+
+    async def get_doc_by_content_hash(
+        self, content_hash: str
+    ) -> Union[tuple[str, dict[str, Any]], None]:
+        """Find an existing record whose content_hash field matches."""
+        if not content_hash:
+            return None
+        if self._storage_lock is None:
+            raise StorageNotInitializedError("JsonDocStatusStorage")
+
+        async with self._storage_lock:
+            for doc_id, doc_data in self._data.items():
+                if doc_data.get("content_hash") == content_hash:
+                    return doc_id, doc_data
         return None
 
     async def drop(self) -> dict[str, str]:

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -215,6 +215,63 @@ def _resolve_doc_file_path(
     return "unknown_source"
 
 
+def _document_source_key(file_path: Any) -> str:
+    """Return the filename-level key used for document uniqueness."""
+    source = str(file_path or "").strip()
+    filename = Path(source).name.strip()
+    return filename or "unknown_source"
+
+
+def _file_path_lookup_candidates(file_path: Any, source_path: Any = None) -> list[str]:
+    candidates = [
+        _document_source_key(file_path),
+        str(file_path or "").strip(),
+        str(source_path or "").strip(),
+    ]
+    for raw_path in [file_path, source_path]:
+        try:
+            resolved = str(Path(str(raw_path)).resolve())
+        except Exception:
+            resolved = ""
+        candidates.append(resolved)
+
+    seen: set[str] = set()
+    unique: list[str] = []
+    for candidate in candidates:
+        if candidate and candidate not in seen:
+            seen.add(candidate)
+            unique.append(candidate)
+    return unique
+
+
+def _doc_status_field(doc: Any, field: str, default: Any = "") -> Any:
+    if isinstance(doc, dict):
+        return doc.get(field, default)
+    return getattr(doc, field, default)
+
+
+async def _get_existing_doc_by_file_path_candidates(
+    doc_status: DocStatusStorage, file_path: Any, source_path: Any = None
+) -> Any | None:
+    """Find an existing doc_status record by filename, including legacy paths."""
+    target_name = _document_source_key(file_path)
+    for candidate in _file_path_lookup_candidates(file_path, source_path):
+        existing_doc = await doc_status.get_doc_by_file_path(candidate)
+        if existing_doc:
+            return existing_doc
+
+    try:
+        docs = await doc_status.get_docs_by_statuses(list(DocStatus))
+    except Exception:
+        return None
+
+    for existing_doc in docs.values():
+        existing_path = _doc_status_field(existing_doc, "file_path", "")
+        if _document_source_key(existing_path) == target_name:
+            return existing_doc
+    return None
+
+
 def _normalize_string_list(raw_values: Any, context: str = "") -> list[str]:
     """Return a list of non-empty strings from raw_values.
 
@@ -2463,77 +2520,85 @@ class LightRAG:
             if len(ids) != len(set(ids)):
                 raise ValueError("IDs must be unique")
 
+        source_keys = [_document_source_key(path) for path in file_paths]
+        contents: dict[str, dict[str, Any]] = {}
+        source_to_doc_id: dict[str, str] = {}
+        duplicate_attempts: list[dict[str, Any]] = []
+
+        def _add_content(
+            index: int,
+            content: str,
+            doc_format: str,
+            *,
+            lightrag_document_path: str | None = None,
+        ) -> None:
+            source_key = source_keys[index]
+            source_path = file_paths[index]
+            doc_id = (
+                ids[index]
+                if ids is not None
+                else compute_mdhash_id(source_key, prefix="doc-")
+            )
+
+            if source_key in source_to_doc_id:
+                duplicate_attempts.append(
+                    {
+                        "doc_id": doc_id,
+                        "original_doc_id": source_to_doc_id[source_key],
+                        "file_path": source_key,
+                        "content_length": len(content or ""),
+                        "existing_status": "batch_duplicate",
+                        "existing_track_id": "",
+                    }
+                )
+                return
+
+            source_to_doc_id[source_key] = doc_id
+            content_data = {
+                "content": content,
+                "file_path": source_key,
+                "format": doc_format,
+            }
+            if str(source_path).strip() and str(source_path).strip() != source_key:
+                content_data["source_path"] = source_path
+            if lightrag_document_path:
+                content_data["lightrag_document_path"] = lightrag_document_path
+            if engine := _parsed_engine_at(index):
+                content_data["parsed_engine"] = engine
+            contents[doc_id] = content_data
+
         if is_lightrag_format:
             # LightRAG Document: no content hash dedup; content may be empty
-            contents = {}
             for i in range(len(file_paths)):
                 path = file_paths[i]
-                doc_id = (
-                    ids[i]
-                    if ids is not None
-                    else compute_mdhash_id(path, prefix="doc-")
-                )
                 lightrag_path = (
                     lightrag_document_paths[i] if lightrag_document_paths else ""
                 ) or path
-                contents[doc_id] = {
-                    "content": FULL_DOCS_CONTENT_STORED_IN_LIGHTRAG_DOCUMENT,
-                    "file_path": path,
-                    "format": FULL_DOCS_FORMAT_LIGHTRAG,
-                    "lightrag_document_path": lightrag_path,
-                }
-                if engine := _parsed_engine_at(i):
-                    contents[doc_id]["parsed_engine"] = engine
-        elif ids is not None:
-            # Generate contents dict and remove duplicates in one pass
-            unique_contents = {}
-            for id_, doc, path in zip(ids, input, file_paths):
-                cleaned_content = sanitize_text_for_encoding(doc)
-                if cleaned_content not in unique_contents:
-                    unique_contents[cleaned_content] = (id_, path)
-
-            contents = {}
-            for i, (content, (id_, file_path)) in enumerate(unique_contents.items()):
-                contents[id_] = {
-                    "content": content,
-                    "file_path": file_path,
-                    "format": FULL_DOCS_FORMAT_RAW,
-                }
-                if engine := _parsed_engine_at(i):
-                    contents[id_]["parsed_engine"] = engine
-        elif docs_format == FULL_DOCS_FORMAT_PENDING_PARSE:
-            contents = {}
-            for i, (doc, path) in enumerate(zip(input, file_paths)):
-                doc_id = (
-                    ids[i]
-                    if ids is not None
-                    else compute_mdhash_id(path, prefix="doc-")
+                _add_content(
+                    i,
+                    FULL_DOCS_CONTENT_STORED_IN_LIGHTRAG_DOCUMENT,
+                    FULL_DOCS_FORMAT_LIGHTRAG,
+                    lightrag_document_path=lightrag_path,
                 )
-                contents[doc_id] = {
-                    "content": doc or "",
-                    "file_path": path,
-                    "format": FULL_DOCS_FORMAT_PENDING_PARSE,
-                }
-                if engine := _parsed_engine_at(i):
-                    contents[doc_id]["parsed_engine"] = engine
-        else:
-            # Clean input text and remove duplicates in one pass
-            unique_content_with_paths = {}
-            for doc, path in zip(input, file_paths):
+        elif ids is not None:
+            for i, doc in enumerate(input):
                 cleaned_content = sanitize_text_for_encoding(doc)
-                if cleaned_content not in unique_content_with_paths:
-                    unique_content_with_paths[cleaned_content] = path
-
-            contents = {}
-            for i, (content, path) in enumerate(unique_content_with_paths.items()):
-                doc_id = compute_mdhash_id(content, prefix="doc-")
-                contents[doc_id] = {
-                    "content": content,
-                    "file_path": path,
-                    "format": FULL_DOCS_FORMAT_RAW,
-                }
-                if engine := _parsed_engine_at(i):
-                    contents[doc_id]["parsed_engine"] = engine
+                _add_content(
+                    i,
+                    cleaned_content,
+                    FULL_DOCS_FORMAT_RAW,
+                )
+        elif docs_format == FULL_DOCS_FORMAT_PENDING_PARSE:
+            for i, doc in enumerate(input):
+                _add_content(
+                    i,
+                    doc or "",
+                    FULL_DOCS_FORMAT_PENDING_PARSE,
+                )
+        else:
+            for i, doc in enumerate(input):
+                cleaned_content = sanitize_text_for_encoding(doc)
+                _add_content(i, cleaned_content, FULL_DOCS_FORMAT_RAW)
 
         # 2. Generate document initial status (without content)
         new_docs: dict[str, Any] = {
@@ -2555,42 +2620,94 @@ class LightRAG:
         # Exclude IDs of documents that are already enqueued
         unique_new_doc_ids = await self.doc_status.filter_keys(all_new_doc_ids)
 
+        for doc_id in list(unique_new_doc_ids):
+            content_data = contents[doc_id]
+            existing_doc = await _get_existing_doc_by_file_path_candidates(
+                self.doc_status,
+                content_data["file_path"],
+                content_data.get("source_path"),
+            )
+            if existing_doc:
+                unique_new_doc_ids.discard(doc_id)
+                duplicate_attempts.append(
+                    {
+                        "doc_id": doc_id,
+                        "original_doc_id": _doc_status_field(
+                            existing_doc, "_id", doc_id
+                        ),
+                        "file_path": content_data["file_path"],
+                        "content_length": new_docs.get(doc_id, {}).get(
+                            "content_length", 0
+                        ),
+                        "existing_status": _doc_status_field(
+                            existing_doc, "status", "unknown"
+                        ),
+                        "existing_track_id": _doc_status_field(
+                            existing_doc, "track_id", ""
+                        ),
+                    }
+                )
+
         # Handle duplicate documents - create trackable records with current track_id
         ignored_ids = list(all_new_doc_ids - unique_new_doc_ids)
-        if ignored_ids:
+        for doc_id in ignored_ids:
+            if any(attempt.get("doc_id") == doc_id for attempt in duplicate_attempts):
+                continue
+            existing_doc = await self.doc_status.get_by_id(doc_id)
+            duplicate_attempts.append(
+                {
+                    "doc_id": doc_id,
+                    "original_doc_id": doc_id,
+                    "file_path": new_docs.get(doc_id, {}).get(
+                        "file_path", "unknown_source"
+                    ),
+                    "content_length": new_docs.get(doc_id, {}).get(
+                        "content_length", 0
+                    ),
+                    "existing_status": (
+                        existing_doc.get("status", "unknown")
+                        if existing_doc
+                        else "unknown"
+                    ),
+                    "existing_track_id": (
+                        existing_doc.get("track_id", "") if existing_doc else ""
+                    ),
+                }
+            )
+
+        if duplicate_attempts:
             duplicate_docs: dict[str, Any] = {}
-            for doc_id in ignored_ids:
-                file_path = (
-                    new_docs.get(doc_id, {}).get("file_path") or "unknown_source"
-                )
+            for index, attempt in enumerate(duplicate_attempts):
+                doc_id = attempt["doc_id"]
+                file_path = attempt.get("file_path") or "unknown_source"
                 logger.warning(f"Duplicate document detected: {doc_id} ({file_path})")
 
-                # Get existing document info for reference
-                existing_doc = await self.doc_status.get_by_id(doc_id)
-                existing_status = (
-                    existing_doc.get("status", "unknown") if existing_doc else "unknown"
-                )
-                existing_track_id = (
-                    existing_doc.get("track_id", "") if existing_doc else ""
-                )
-
                 # Create a new record with unique ID for this duplicate attempt
-                dup_record_id = compute_mdhash_id(f"{doc_id}-{track_id}", prefix="dup-")
+                dup_record_id = compute_mdhash_id(
+                    f"{doc_id}-{track_id}-{index}-{file_path}", prefix="dup-"
+                )
                 duplicate_docs[dup_record_id] = {
                     "status": DocStatus.FAILED,
-                    "content_summary": f"[DUPLICATE] Original document: {doc_id}",
-                    "content_length": new_docs.get(doc_id, {}).get("content_length", 0),
+                    "content_summary": (
+                        f"[DUPLICATE] Original document: "
+                        f"{attempt.get('original_doc_id', doc_id)}"
+                    ),
+                    "content_length": attempt.get("content_length", 0),
                     "chunks_count": 0,
                     "chunks_list": [],
                     "created_at": datetime.now(timezone.utc).isoformat(),
                     "updated_at": datetime.now(timezone.utc).isoformat(),
                     "file_path": file_path,
                     "track_id": track_id,  # Use current track_id for tracking
-                    "error_msg": f"Content already exists. Original doc_id: {doc_id}, Status: {existing_status}",
+                    "error_msg": (
+                        "File name already exists. "
+                        f"Original doc_id: {attempt.get('original_doc_id', doc_id)}, "
+                        f"Status: {attempt.get('existing_status', 'unknown')}"
+                    ),
                     "metadata": {
                         "is_duplicate": True,
-                        "original_doc_id": doc_id,
-                        "original_track_id": existing_track_id,
+                        "original_doc_id": attempt.get("original_doc_id", doc_id),
+                        "original_track_id": attempt.get("existing_track_id", ""),
                     },
                 }
 
@@ -2622,6 +2739,10 @@ class LightRAG:
             for doc_id in new_docs.keys()
         }
         for doc_id in new_docs.keys():
+            if contents[doc_id].get("source_path"):
+                full_docs_data[doc_id]["source_path"] = contents[doc_id][
+                    "source_path"
+                ]
             if contents[doc_id].get("lightrag_document_path"):
                 full_docs_data[doc_id]["lightrag_document_path"] = contents[doc_id][
                     "lightrag_document_path"
@@ -4839,7 +4960,9 @@ class LightRAG:
             }
 
         if doc_format == FULL_DOCS_FORMAT_PENDING_PARSE:
-            source_path = self._resolve_source_file_for_parser(file_path)
+            source_path = self._resolve_source_file_for_parser(
+                str(content_data.get("source_path") or file_path)
+            )
             p = Path(source_path)
             if p.exists() and p.is_file() and p.suffix.lower() == ".docx":
                 from lightrag.extraction.parse_document import (
@@ -4924,7 +5047,9 @@ class LightRAG:
             ),
             "max_polls": int(os.getenv("MINERU_MAX_POLLS", "180")),
         }
-        source_file_path = self._resolve_source_file_for_parser(file_path)
+        source_file_path = self._resolve_source_file_for_parser(
+            str(content_data.get("source_path") or file_path)
+        )
         result_text = await self._call_protocol_parse_service(
             protocol=protocol,
             file_path=source_file_path,
@@ -4989,7 +5114,9 @@ class LightRAG:
             ),
             "max_polls": int(os.getenv("DOCLING_MAX_POLLS", "180")),
         }
-        source_file_path = self._resolve_source_file_for_parser(file_path)
+        source_file_path = self._resolve_source_file_for_parser(
+            str(content_data.get("source_path") or file_path)
+        )
         result_text = await self._call_protocol_parse_service(
             protocol=protocol,
             file_path=source_file_path,

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -215,11 +215,22 @@ def _resolve_doc_file_path(
     return "unknown_source"
 
 
+PLACEHOLDER_DOCUMENT_SOURCES = {"", "no-file-path", "unknown_source"}
+
+
 def _document_source_key(file_path: Any) -> str:
     """Return the filename-level key used for document uniqueness."""
     source = str(file_path or "").strip()
+    if source in PLACEHOLDER_DOCUMENT_SOURCES:
+        return "unknown_source"
     filename = Path(source).name.strip()
+    if filename in PLACEHOLDER_DOCUMENT_SOURCES:
+        return "unknown_source"
     return filename or "unknown_source"
+
+
+def _has_known_document_source(source_key: str) -> bool:
+    return source_key not in PLACEHOLDER_DOCUMENT_SOURCES
 
 
 def _doc_status_field(doc: Any, field: str, default: Any = "") -> Any:
@@ -2553,13 +2564,29 @@ class LightRAG:
         ) -> None:
             source_key = source_keys[index]
             source_path = file_paths[index]
-            doc_id = (
-                ids[index]
-                if ids is not None
-                else compute_mdhash_id(source_key, prefix="doc-")
-            )
 
-            if source_key in source_to_doc_id:
+            # Compute content hash: skip for pending_parse (content extracted later).
+            content_hash: str | None = None
+            if doc_format == FULL_DOCS_FORMAT_RAW:
+                content_hash = _compute_text_content_hash(content or "")
+            elif doc_format == FULL_DOCS_FORMAT_LIGHTRAG and lightrag_document_path:
+                content_hash = _compute_file_content_hash(lightrag_document_path)
+
+            known_source = _has_known_document_source(source_key)
+            if ids is not None:
+                doc_id = ids[index]
+            elif known_source:
+                doc_id = compute_mdhash_id(source_key, prefix="doc-")
+            elif doc_format == FULL_DOCS_FORMAT_RAW:
+                doc_id = compute_mdhash_id(content or "", prefix="doc-")
+            elif content_hash:
+                doc_id = compute_mdhash_id(content_hash, prefix="doc-")
+            else:
+                doc_id = compute_mdhash_id(
+                    f"{source_key}-{track_id}-{index}", prefix="doc-"
+                )
+
+            if known_source and source_key in source_to_doc_id:
                 duplicate_attempts.append(
                     {
                         "doc_id": doc_id,
@@ -2572,13 +2599,6 @@ class LightRAG:
                     }
                 )
                 return
-
-            # Compute content hash: skip for pending_parse (content extracted later).
-            content_hash: str | None = None
-            if doc_format == FULL_DOCS_FORMAT_RAW:
-                content_hash = _compute_text_content_hash(content or "")
-            elif doc_format == FULL_DOCS_FORMAT_LIGHTRAG and lightrag_document_path:
-                content_hash = _compute_file_content_hash(lightrag_document_path)
 
             if content_hash and content_hash in content_hash_to_doc_id:
                 duplicate_attempts.append(
@@ -2594,7 +2614,8 @@ class LightRAG:
                 )
                 return
 
-            source_to_doc_id[source_key] = doc_id
+            if known_source:
+                source_to_doc_id[source_key] = doc_id
             if content_hash:
                 content_hash_to_doc_id[content_hash] = doc_id
 

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -3042,6 +3042,7 @@ class LightRAG:
                         "updated_at": datetime.now(timezone.utc).isoformat(),
                         "file_path": resolved_file_path,
                         "track_id": getattr(status_doc, "track_id", ""),
+                        "content_hash": getattr(status_doc, "content_hash", None),
                         # Clear any error messages and processing metadata
                         "error_msg": "",
                         "metadata": {},
@@ -3296,6 +3297,7 @@ class LightRAG:
                                             ).isoformat(),
                                             "file_path": file_path,
                                             "track_id": status_doc.track_id,
+                                            "content_hash": status_doc.content_hash,
                                         }
                                     }
                                 )
@@ -3323,6 +3325,24 @@ class LightRAG:
 
                                 content = parsed_data.get("content", "")
 
+                                # parse_* may have patched doc_status with the
+                                # content_hash that was missing for pending_parse.
+                                # Refresh the in-memory dataclass so subsequent
+                                # state-machine upserts preserve it.
+                                refreshed_status = await self.doc_status.get_by_id(
+                                    doc_id
+                                )
+                                if refreshed_status:
+                                    refreshed_hash = (
+                                        refreshed_status.get("content_hash")
+                                        if isinstance(refreshed_status, dict)
+                                        else getattr(
+                                            refreshed_status, "content_hash", None
+                                        )
+                                    )
+                                    if refreshed_hash:
+                                        status_doc.content_hash = refreshed_hash
+
                                 # ---- Phase 2: ANALYZING ----
                                 await self.doc_status.upsert(
                                     {
@@ -3336,6 +3356,7 @@ class LightRAG:
                                             ).isoformat(),
                                             "file_path": file_path,
                                             "track_id": status_doc.track_id,
+                                            "content_hash": status_doc.content_hash,
                                         }
                                     }
                                 )
@@ -3531,6 +3552,7 @@ class LightRAG:
                                             ).isoformat(),
                                             "file_path": file_path,
                                             "track_id": status_doc.track_id,  # Preserve existing track_id
+                                            "content_hash": status_doc.content_hash,
                                             "metadata": {
                                                 "processing_start_time": processing_start_time,
                                                 **extraction_meta,
@@ -3637,6 +3659,7 @@ class LightRAG:
                                         ).isoformat(),
                                         "file_path": file_path,
                                         "track_id": status_doc.track_id,  # Preserve existing track_id
+                                        "content_hash": status_doc.content_hash,
                                         "metadata": {
                                             "processing_start_time": processing_start_time,
                                             "processing_end_time": processing_end_time,
@@ -3694,6 +3717,7 @@ class LightRAG:
                                             ).isoformat(),
                                             "file_path": file_path,
                                             "track_id": status_doc.track_id,  # Preserve existing track_id
+                                            "content_hash": status_doc.content_hash,
                                             "metadata": {
                                                 "processing_start_time": processing_start_time,
                                                 "processing_end_time": processing_end_time,
@@ -3770,6 +3794,7 @@ class LightRAG:
                                             ).isoformat(),
                                             "file_path": file_path,
                                             "track_id": status_doc.track_id,  # Preserve existing track_id
+                                            "content_hash": status_doc.content_hash,
                                             "metadata": {
                                                 "processing_start_time": processing_start_time,
                                                 "processing_end_time": processing_end_time,
@@ -3818,6 +3843,7 @@ class LightRAG:
                                         ).isoformat(),
                                         "file_path": file_path_w,
                                         "track_id": status_doc_w.track_id,
+                                        "content_hash": status_doc_w.content_hash,
                                     }
                                 }
                             )
@@ -3833,6 +3859,19 @@ class LightRAG:
                                 parsed_data_w = await self.parse_native(
                                     doc_id_w, file_path_w, content_data_w
                                 )
+
+                            # parse_* may have patched content_hash for
+                            # pending_parse → raw transitions.
+                            refreshed = await self.doc_status.get_by_id(doc_id_w)
+                            if refreshed:
+                                refreshed_hash = (
+                                    refreshed.get("content_hash")
+                                    if isinstance(refreshed, dict)
+                                    else getattr(refreshed, "content_hash", None)
+                                )
+                                if refreshed_hash:
+                                    status_doc_w.content_hash = refreshed_hash
+
                             await q_analyze.put((doc_id_w, status_doc_w, parsed_data_w))
                         except Exception as e:
                             logger.error(f"Parse worker failed ({engine}): {e}")
@@ -3854,6 +3893,7 @@ class LightRAG:
                                                 "unknown_source",
                                             ),
                                             "track_id": status_doc_w.track_id,
+                                            "content_hash": status_doc_w.content_hash,
                                         }
                                     }
                                 )
@@ -3884,6 +3924,7 @@ class LightRAG:
                                         ).isoformat(),
                                         "file_path": file_path_w,
                                         "track_id": status_doc_w.track_id,
+                                        "content_hash": status_doc_w.content_hash,
                                     }
                                 }
                             )
@@ -4537,6 +4578,48 @@ class LightRAG:
         except Exception:
             return None
 
+    async def _persist_parsed_full_docs(
+        self,
+        doc_id: str,
+        record: dict[str, Any],
+    ) -> str | None:
+        """Write a parse-result record to ``full_docs`` and sync ``content_hash``.
+
+        Computes ``content_hash`` from the actual extracted body so subsequent
+        ``get_doc_by_content_hash`` lookups can dedupe across pending_parse
+        records that did not have a hash at enqueue time. Also patches the
+        existing ``doc_status`` row so both storages stay aligned.
+        """
+        fmt = record.get("format")
+        content_hash: str | None = None
+        if fmt == FULL_DOCS_FORMAT_RAW:
+            content_hash = _compute_text_content_hash(record.get("content") or "")
+        elif fmt == FULL_DOCS_FORMAT_LIGHTRAG:
+            blocks_path = record.get("lightrag_document_path") or ""
+            if blocks_path:
+                absolute = (
+                    blocks_path
+                    if Path(blocks_path).is_absolute()
+                    else str(Path(self.working_dir) / blocks_path)
+                )
+                content_hash = _compute_file_content_hash(absolute)
+
+        payload = dict(record)
+        if content_hash:
+            payload["content_hash"] = content_hash
+
+        await self.full_docs.upsert({doc_id: payload})
+        await self.full_docs.index_done_callback()
+
+        if content_hash:
+            existing_status = await self.doc_status.get_by_id(doc_id)
+            if existing_status:
+                patched = dict(existing_status)
+                patched["content_hash"] = content_hash
+                patched["updated_at"] = datetime.now(timezone.utc).isoformat()
+                await self.doc_status.upsert({doc_id: patched})
+        return content_hash
+
     def _resolve_source_file_for_parser(self, file_path: str) -> str:
         """Resolve a readable source file path for parser upload."""
         p = Path(file_path)
@@ -4987,19 +5070,17 @@ class LightRAG:
             stored_blocks_path = str(blocks_path.relative_to(Path(self.working_dir)))
         except ValueError:
             pass
-        await self.full_docs.upsert(
+        await self._persist_parsed_full_docs(
+            doc_id,
             {
-                doc_id: {
-                    "content": FULL_DOCS_CONTENT_STORED_IN_LIGHTRAG_DOCUMENT,
-                    "file_path": file_path,
-                    "format": FULL_DOCS_FORMAT_LIGHTRAG,
-                    "lightrag_document_path": stored_blocks_path,
-                    "parsed_engine": engine,
-                    "update_time": int(time.time()),
-                }
-            }
+                "content": FULL_DOCS_CONTENT_STORED_IN_LIGHTRAG_DOCUMENT,
+                "file_path": file_path,
+                "format": FULL_DOCS_FORMAT_LIGHTRAG,
+                "lightrag_document_path": stored_blocks_path,
+                "parsed_engine": engine,
+                "update_time": int(time.time()),
+            },
         )
-        await self.full_docs.index_done_callback()
         await self._archive_docx_source_after_full_docs_sync(
             source_path or self._resolve_source_file_for_parser(file_path)
         )
@@ -5077,18 +5158,16 @@ class LightRAG:
                         f"DOCX parser returned empty content for {file_path}"
                     )
 
-                await self.full_docs.upsert(
+                await self._persist_parsed_full_docs(
+                    doc_id,
                     {
-                        doc_id: {
-                            "content": interchange_text,
-                            "file_path": file_path,
-                            "format": FULL_DOCS_FORMAT_RAW,
-                            "parsed_engine": PARSER_ENGINE_NATIVE,
-                            "update_time": int(time.time()),
-                        }
-                    }
+                        "content": interchange_text,
+                        "file_path": file_path,
+                        "format": FULL_DOCS_FORMAT_RAW,
+                        "parsed_engine": PARSER_ENGINE_NATIVE,
+                        "update_time": int(time.time()),
+                    },
                 )
-                await self.full_docs.index_done_callback()
                 await self._archive_docx_source_after_full_docs_sync(str(p))
                 logger.info(
                     f"[parse_native] pending_parse completed for {file_path} via interchange JSONL"
@@ -5158,18 +5237,16 @@ class LightRAG:
         if not result_text:
             raise ValueError(f"MinerU parser returned empty content for {file_path}")
 
-        await self.full_docs.upsert(
+        await self._persist_parsed_full_docs(
+            doc_id,
             {
-                doc_id: {
-                    "content": str(result_text),
-                    "file_path": file_path,
-                    "format": FULL_DOCS_FORMAT_RAW,
-                    "parsed_engine": PARSER_ENGINE_MINERU,
-                    "update_time": int(time.time()),
-                }
-            }
+                "content": str(result_text),
+                "file_path": file_path,
+                "format": FULL_DOCS_FORMAT_RAW,
+                "parsed_engine": PARSER_ENGINE_MINERU,
+                "update_time": int(time.time()),
+            },
         )
-        await self.full_docs.index_done_callback()
         await self._archive_docx_source_after_full_docs_sync(source_file_path)
         return {
             "doc_id": doc_id,
@@ -5225,18 +5302,16 @@ class LightRAG:
         if not result_text:
             raise ValueError(f"Docling parser returned empty content for {file_path}")
 
-        await self.full_docs.upsert(
+        await self._persist_parsed_full_docs(
+            doc_id,
             {
-                doc_id: {
-                    "content": str(result_text),
-                    "file_path": file_path,
-                    "format": FULL_DOCS_FORMAT_RAW,
-                    "parsed_engine": PARSER_ENGINE_DOCLING,
-                    "update_time": int(time.time()),
-                }
-            }
+                "content": str(result_text),
+                "file_path": file_path,
+                "format": FULL_DOCS_FORMAT_RAW,
+                "parsed_engine": PARSER_ENGINE_DOCLING,
+                "update_time": int(time.time()),
+            },
         )
-        await self.full_docs.index_done_callback()
         await self._archive_docx_source_after_full_docs_sync(source_file_path)
         return {
             "doc_id": doc_id,

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -239,6 +239,13 @@ def _doc_status_field(doc: Any, field: str, default: Any = "") -> Any:
     return getattr(doc, field, default)
 
 
+def _doc_status_value(doc: Any) -> str:
+    status = _doc_status_field(doc, "status", "")
+    if isinstance(status, DocStatus):
+        return status.value
+    return str(status or "")
+
+
 def _compute_text_content_hash(content: str) -> str:
     """MD5 hex digest of text content used for cross-filename dedup."""
     return compute_mdhash_id(content, prefix="")
@@ -304,6 +311,29 @@ async def _get_existing_doc_by_content_hash(
     if not content_hash:
         return None
     return await doc_status.get_doc_by_content_hash(content_hash)
+
+
+async def _get_duplicate_doc_by_content_hash(
+    doc_status: DocStatusStorage, content_hash: str, current_doc_id: str
+) -> tuple[str, Any] | None:
+    """Find another doc_status record with the same content hash."""
+    if not content_hash:
+        return None
+
+    match = await doc_status.get_doc_by_content_hash(content_hash)
+    if match and match[0] != current_doc_id:
+        return match
+
+    try:
+        docs = await doc_status.get_docs_by_statuses(list(DocStatus))
+    except Exception:
+        return None
+    for doc_id, doc in docs.items():
+        if doc_id == current_doc_id:
+            continue
+        if _doc_status_field(doc, "content_hash", "") == content_hash:
+            return doc_id, doc
+    return None
 
 
 def _normalize_string_list(raw_values: Any, context: str = "") -> list[str]:
@@ -2478,6 +2508,7 @@ class LightRAG:
         docs_format: str = FULL_DOCS_FORMAT_RAW,
         lightrag_document_paths: str | list[str] | None = None,
         parsed_engine: str | list[str] | None = None,
+        reprocess_existing_non_processed: bool = False,
     ) -> str:
         """
         Pipeline for Processing Documents
@@ -2495,6 +2526,8 @@ class LightRAG:
             docs_format: "raw" (default) or "lightrag"; when "lightrag" content may be empty and content-dedup is skipped
             lightrag_document_paths: paths to LightRAG Document (e.g. .blocks.jsonl dir or base path), when docs_format is lightrag
             parsed_engine: file extraction engine already used or target engine for pending_parse
+            reprocess_existing_non_processed: allow scan retries to overwrite
+                existing same-name records that have not reached PROCESSED.
 
         Returns:
             str: tracking ID for monitoring processing status
@@ -2698,6 +2731,16 @@ class LightRAG:
         all_new_doc_ids = set(new_docs.keys())
         # Exclude IDs of documents that are already enqueued
         unique_new_doc_ids = await self.doc_status.filter_keys(all_new_doc_ids)
+        reprocess_doc_ids: set[str] = set()
+        if reprocess_existing_non_processed:
+            for doc_id in all_new_doc_ids - unique_new_doc_ids:
+                existing_doc = await self.doc_status.get_by_id(doc_id)
+                if (
+                    existing_doc
+                    and _doc_status_value(existing_doc) != DocStatus.PROCESSED.value
+                ):
+                    unique_new_doc_ids.add(doc_id)
+                    reprocess_doc_ids.add(doc_id)
 
         for doc_id in list(unique_new_doc_ids):
             content_data = contents[doc_id]
@@ -2708,6 +2751,18 @@ class LightRAG:
             )
             if match:
                 existing_doc_id, existing_doc = match
+                if (
+                    reprocess_existing_non_processed
+                    and _doc_status_value(existing_doc) != DocStatus.PROCESSED.value
+                ):
+                    reprocess_doc_ids.add(doc_id)
+                    if existing_doc_id != doc_id:
+                        await self.doc_status.delete([existing_doc_id])
+                        try:
+                            await self.full_docs.delete([existing_doc_id])
+                        except Exception:
+                            pass
+                    continue
                 unique_new_doc_ids.discard(doc_id)
                 duplicate_attempts.append(
                     {
@@ -2737,6 +2792,8 @@ class LightRAG:
             )
             if hash_match:
                 existing_doc_id, existing_doc = hash_match
+                if existing_doc_id == doc_id and doc_id in reprocess_doc_ids:
+                    continue
                 unique_new_doc_ids.discard(doc_id)
                 duplicate_attempts.append(
                     {
@@ -2760,6 +2817,8 @@ class LightRAG:
         ignored_ids = list(all_new_doc_ids - unique_new_doc_ids)
         for doc_id in ignored_ids:
             if any(attempt.get("doc_id") == doc_id for attempt in duplicate_attempts):
+                continue
+            if doc_id in reprocess_doc_ids:
                 continue
             existing_doc = await self.doc_status.get_by_id(doc_id)
             duplicate_attempts.append(
@@ -3371,6 +3430,18 @@ class LightRAG:
                                     if refreshed_hash:
                                         status_doc.content_hash = refreshed_hash
 
+                                if await self._mark_duplicate_after_parse(
+                                    doc_id=doc_id,
+                                    status_doc=status_doc,
+                                    file_path=file_path,
+                                    content_hash=status_doc.content_hash,
+                                    content_length=len(content),
+                                    content_data=content_data,
+                                    pipeline_status=pipeline_status,
+                                    pipeline_status_lock=pipeline_status_lock,
+                                ):
+                                    return
+
                                 # ---- Phase 2: ANALYZING ----
                                 await self.doc_status.upsert(
                                     {
@@ -3899,6 +3970,18 @@ class LightRAG:
                                 )
                                 if refreshed_hash:
                                     status_doc_w.content_hash = refreshed_hash
+
+                            if await self._mark_duplicate_after_parse(
+                                doc_id=doc_id_w,
+                                status_doc=status_doc_w,
+                                file_path=file_path_w,
+                                content_hash=status_doc_w.content_hash,
+                                content_length=len(parsed_data_w.get("content", "")),
+                                content_data=content_data_w,
+                                pipeline_status=pipeline_status,
+                                pipeline_status_lock=pipeline_status_lock,
+                            ):
+                                continue
 
                             await q_analyze.put((doc_id_w, status_doc_w, parsed_data_w))
                         except Exception as e:
@@ -4644,6 +4727,78 @@ class LightRAG:
                 patched["updated_at"] = datetime.now(timezone.utc).isoformat()
                 await self.doc_status.upsert({doc_id: patched})
         return content_hash
+
+    async def _mark_duplicate_after_parse(
+        self,
+        doc_id: str,
+        status_doc: DocProcessingStatus,
+        file_path: str,
+        content_hash: str | None,
+        content_length: int,
+        content_data: dict[str, Any] | None = None,
+        pipeline_status: dict | None = None,
+        pipeline_status_lock: asyncio.Lock | None = None,
+    ) -> bool:
+        """Mark post-parse content duplicates and stop further processing."""
+        if not content_hash:
+            return False
+
+        match = await _get_duplicate_doc_by_content_hash(
+            self.doc_status, content_hash, doc_id
+        )
+        if not match:
+            return False
+
+        original_doc_id, original_doc = match
+        original_track_id = _doc_status_field(original_doc, "track_id", "")
+        original_status = _doc_status_field(original_doc, "status", "unknown")
+        now = datetime.now(timezone.utc).isoformat()
+        message = (
+            "Identical content already exists under another filename. "
+            f"Original doc_id: {original_doc_id}, Status: {original_status}"
+        )
+
+        await self.doc_status.upsert(
+            {
+                doc_id: {
+                    "status": DocStatus.FAILED,
+                    "content_summary": (
+                        f"[DUPLICATE:content_hash] Original document: {original_doc_id}"
+                    ),
+                    "content_length": content_length,
+                    "chunks_count": 0,
+                    "chunks_list": [],
+                    "created_at": status_doc.created_at,
+                    "updated_at": now,
+                    "file_path": file_path,
+                    "track_id": status_doc.track_id,
+                    "content_hash": content_hash,
+                    "error_msg": message,
+                    "metadata": {
+                        "is_duplicate": True,
+                        "duplicate_kind": "content_hash",
+                        "original_doc_id": original_doc_id,
+                        "original_track_id": original_track_id,
+                    },
+                }
+            }
+        )
+        try:
+            await self.full_docs.delete([doc_id])
+            await self.full_docs.index_done_callback()
+        except Exception as e:
+            logger.warning(f"Failed to remove duplicate full_docs entry {doc_id}: {e}")
+
+        source_path = str((content_data or {}).get("source_path") or file_path)
+        archived = await self._archive_source_after_full_docs_sync(source_path)
+        archive_msg = f"; archived to {archived}" if archived else ""
+        warning = f"Duplicate content skipped after parsing: {file_path}{archive_msg}"
+        logger.warning(warning)
+        if pipeline_status is not None and pipeline_status_lock is not None:
+            async with pipeline_status_lock:
+                pipeline_status["latest_message"] = warning
+                pipeline_status["history_messages"].append(warning)
+        return True
 
     def _input_dir_path(self) -> Path:
         return _configured_input_dir()

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -277,6 +277,11 @@ def _compute_file_content_hash(path_str: str) -> str | None:
         return None
 
 
+def _configured_input_dir() -> Path:
+    input_dir = os.getenv("INPUT_DIR", "").strip()
+    return Path(input_dir) if input_dir else Path.cwd() / "inputs"
+
+
 async def _get_existing_doc_by_file_basename(
     doc_status: DocStatusStorage, file_path: Any
 ) -> tuple[str, Any] | None:
@@ -2570,7 +2575,9 @@ class LightRAG:
             if doc_format == FULL_DOCS_FORMAT_RAW:
                 content_hash = _compute_text_content_hash(content or "")
             elif doc_format == FULL_DOCS_FORMAT_LIGHTRAG and lightrag_document_path:
-                content_hash = _compute_file_content_hash(lightrag_document_path)
+                content_hash = _compute_file_content_hash(
+                    self._resolve_lightrag_document_path(lightrag_document_path)
+                )
 
             known_source = _has_known_document_source(source_key)
             if ids is not None:
@@ -4618,12 +4625,9 @@ class LightRAG:
         elif fmt == FULL_DOCS_FORMAT_LIGHTRAG:
             blocks_path = record.get("lightrag_document_path") or ""
             if blocks_path:
-                absolute = (
-                    blocks_path
-                    if Path(blocks_path).is_absolute()
-                    else str(Path(self.working_dir) / blocks_path)
+                content_hash = _compute_file_content_hash(
+                    self._resolve_lightrag_document_path(blocks_path)
                 )
-                content_hash = _compute_file_content_hash(absolute)
 
         payload = dict(record)
         if content_hash:
@@ -4641,6 +4645,29 @@ class LightRAG:
                 await self.doc_status.upsert({doc_id: patched})
         return content_hash
 
+    def _input_dir_path(self) -> Path:
+        return _configured_input_dir()
+
+    def _parsed_dir_for_source(self, source_path: str | None = None) -> Path:
+        if not source_path:
+            return self._input_dir_path() / PARSED_DIR_NAME
+
+        source = Path(source_path)
+        if source.is_absolute():
+            return source.parent / PARSED_DIR_NAME
+
+        source_parent = source.parent
+        if str(source_parent) == ".":
+            return self._input_dir_path() / PARSED_DIR_NAME
+        return self._input_dir_path() / source_parent / PARSED_DIR_NAME
+
+    def _resolve_lightrag_document_path(self, document_path: str) -> str:
+        path = Path(document_path)
+        if path.is_absolute():
+            return str(path)
+
+        return str(self._input_dir_path() / path)
+
     def _resolve_source_file_for_parser(self, file_path: str) -> str:
         """Resolve a readable source file path for parser upload."""
         p = Path(file_path)
@@ -4649,11 +4676,9 @@ class LightRAG:
 
         name = p.name
         candidates: list[Path] = []
-        input_dir = os.getenv("INPUT_DIR", "").strip()
-        if input_dir:
-            input_path = Path(input_dir)
-            candidates.append(input_path / name)
-            candidates.append(input_path / PARSED_DIR_NAME / name)
+        input_path = self._input_dir_path()
+        candidates.append(input_path / name)
+        candidates.append(input_path / PARSED_DIR_NAME / name)
 
         # Common local defaults used by API server.
         cwd = Path.cwd()
@@ -4703,7 +4728,7 @@ class LightRAG:
         source_path: str | None = None,
     ) -> dict[str, Any]:
         """Convert parser content list to LightRAG Document files and return parsed_data."""
-        parsed_dir = Path(self.working_dir) / PARSED_DIR_NAME
+        parsed_dir = self._parsed_dir_for_source(source_path)
         parsed_dir.mkdir(parents=True, exist_ok=True)
 
         source_name = Path(file_path).name or f"{doc_id}.bin"
@@ -5088,7 +5113,7 @@ class LightRAG:
         # Keep full_docs in sync so restart/reprocess can directly use LightRAG Document.
         stored_blocks_path = str(blocks_path)
         try:
-            stored_blocks_path = str(blocks_path.relative_to(Path(self.working_dir)))
+            stored_blocks_path = str(blocks_path.relative_to(self._input_dir_path()))
         except ValueError:
             pass
         await self._persist_parsed_full_docs(
@@ -5139,9 +5164,7 @@ class LightRAG:
         doc_format = content_data.get("format", FULL_DOCS_FORMAT_RAW)
         if doc_format == FULL_DOCS_FORMAT_LIGHTRAG:
             doc_path = content_data.get("lightrag_document_path") or file_path
-            doc_path = Path(str(doc_path))
-            if not doc_path.is_absolute():
-                doc_path = Path(self.working_dir) / doc_path
+            doc_path = Path(self._resolve_lightrag_document_path(str(doc_path)))
             merged_text, blocks_path = await self._load_lightrag_document_content(
                 str(doc_path)
             )
@@ -5164,7 +5187,7 @@ class LightRAG:
                 )
 
                 file_bytes = await asyncio.to_thread(p.read_bytes)
-                parsed_dir = Path(self.working_dir) / PARSED_DIR_NAME
+                parsed_dir = self._parsed_dir_for_source(str(p))
                 parsed_dir.mkdir(parents=True, exist_ok=True)
                 output_dir = str(parsed_dir)
                 interchange_text = await asyncio.to_thread(

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -2661,9 +2661,7 @@ class LightRAG:
                     "file_path": new_docs.get(doc_id, {}).get(
                         "file_path", "unknown_source"
                     ),
-                    "content_length": new_docs.get(doc_id, {}).get(
-                        "content_length", 0
-                    ),
+                    "content_length": new_docs.get(doc_id, {}).get("content_length", 0),
                     "existing_status": (
                         existing_doc.get("status", "unknown")
                         if existing_doc
@@ -2740,9 +2738,7 @@ class LightRAG:
         }
         for doc_id in new_docs.keys():
             if contents[doc_id].get("source_path"):
-                full_docs_data[doc_id]["source_path"] = contents[doc_id][
-                    "source_path"
-                ]
+                full_docs_data[doc_id]["source_path"] = contents[doc_id]["source_path"]
             if contents[doc_id].get("lightrag_document_path"):
                 full_docs_data[doc_id]["lightrag_document_path"] = contents[doc_id][
                     "lightrag_document_path"

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -222,54 +222,72 @@ def _document_source_key(file_path: Any) -> str:
     return filename or "unknown_source"
 
 
-def _file_path_lookup_candidates(file_path: Any, source_path: Any = None) -> list[str]:
-    candidates = [
-        _document_source_key(file_path),
-        str(file_path or "").strip(),
-        str(source_path or "").strip(),
-    ]
-    for raw_path in [file_path, source_path]:
-        try:
-            resolved = str(Path(str(raw_path)).resolve())
-        except Exception:
-            resolved = ""
-        candidates.append(resolved)
-
-    seen: set[str] = set()
-    unique: list[str] = []
-    for candidate in candidates:
-        if candidate and candidate not in seen:
-            seen.add(candidate)
-            unique.append(candidate)
-    return unique
-
-
 def _doc_status_field(doc: Any, field: str, default: Any = "") -> Any:
     if isinstance(doc, dict):
         return doc.get(field, default)
     return getattr(doc, field, default)
 
 
-async def _get_existing_doc_by_file_path_candidates(
-    doc_status: DocStatusStorage, file_path: Any, source_path: Any = None
-) -> Any | None:
-    """Find an existing doc_status record by filename, including legacy paths."""
-    target_name = _document_source_key(file_path)
-    for candidate in _file_path_lookup_candidates(file_path, source_path):
-        existing_doc = await doc_status.get_doc_by_file_path(candidate)
-        if existing_doc:
-            return existing_doc
+def _compute_text_content_hash(content: str) -> str:
+    """MD5 hex digest of text content used for cross-filename dedup."""
+    return compute_mdhash_id(content, prefix="")
 
+
+def _compute_file_content_hash(path_str: str) -> str | None:
+    """Stream-compute MD5 of a file's bytes; returns None if unreadable.
+
+    Resolves the LightRAG ``*.blocks.jsonl`` conventions used by
+    ``_load_lightrag_document_content`` so the hash matches the actual
+    document body regardless of whether ``path_str`` points at the blocks
+    file directly or its parent directory/base name.
+    """
+    if not path_str:
+        return None
     try:
-        docs = await doc_status.get_docs_by_statuses(list(DocStatus))
-    except Exception:
+        path = Path(path_str)
+        if path.is_dir():
+            candidates = sorted(path.glob("*.blocks.jsonl"))
+            if not candidates:
+                return None
+            path = candidates[0]
+        elif not (path.exists() and path.is_file()):
+            blocks_path = Path(path_str + ".blocks.jsonl")
+            if blocks_path.exists() and blocks_path.is_file():
+                path = blocks_path
+            else:
+                return None
+        h = hashlib.md5()
+        with path.open("rb") as f:
+            for chunk in iter(lambda: f.read(65536), b""):
+                h.update(chunk)
+        return h.hexdigest()
+    except Exception as e:
+        logger.warning(f"Failed to compute file content hash for {path_str}: {e}")
         return None
 
-    for existing_doc in docs.values():
-        existing_path = _doc_status_field(existing_doc, "file_path", "")
-        if _document_source_key(existing_path) == target_name:
-            return existing_doc
-    return None
+
+async def _get_existing_doc_by_file_basename(
+    doc_status: DocStatusStorage, file_path: Any
+) -> tuple[str, Any] | None:
+    """Find an existing doc_status record by file basename.
+
+    Delegates to the storage backend's basename index when available so the
+    lookup avoids scanning every record. Backends without a native index fall
+    back to the default scan implemented in DocStatusStorage.
+    """
+    basename = _document_source_key(file_path)
+    if basename == "unknown_source":
+        return None
+    return await doc_status.get_doc_by_file_basename(basename)
+
+
+async def _get_existing_doc_by_content_hash(
+    doc_status: DocStatusStorage, content_hash: str
+) -> tuple[str, Any] | None:
+    """Find an existing doc_status record by content hash."""
+    if not content_hash:
+        return None
+    return await doc_status.get_doc_by_content_hash(content_hash)
 
 
 def _normalize_string_list(raw_values: Any, context: str = "") -> list[str]:
@@ -2523,6 +2541,7 @@ class LightRAG:
         source_keys = [_document_source_key(path) for path in file_paths]
         contents: dict[str, dict[str, Any]] = {}
         source_to_doc_id: dict[str, str] = {}
+        content_hash_to_doc_id: dict[str, str] = {}
         duplicate_attempts: list[dict[str, Any]] = []
 
         def _add_content(
@@ -2549,16 +2568,43 @@ class LightRAG:
                         "content_length": len(content or ""),
                         "existing_status": "batch_duplicate",
                         "existing_track_id": "",
+                        "duplicate_kind": "filename",
+                    }
+                )
+                return
+
+            # Compute content hash: skip for pending_parse (content extracted later).
+            content_hash: str | None = None
+            if doc_format == FULL_DOCS_FORMAT_RAW:
+                content_hash = _compute_text_content_hash(content or "")
+            elif doc_format == FULL_DOCS_FORMAT_LIGHTRAG and lightrag_document_path:
+                content_hash = _compute_file_content_hash(lightrag_document_path)
+
+            if content_hash and content_hash in content_hash_to_doc_id:
+                duplicate_attempts.append(
+                    {
+                        "doc_id": doc_id,
+                        "original_doc_id": content_hash_to_doc_id[content_hash],
+                        "file_path": source_key,
+                        "content_length": len(content or ""),
+                        "existing_status": "batch_duplicate",
+                        "existing_track_id": "",
+                        "duplicate_kind": "content_hash",
                     }
                 )
                 return
 
             source_to_doc_id[source_key] = doc_id
+            if content_hash:
+                content_hash_to_doc_id[content_hash] = doc_id
+
             content_data = {
                 "content": content,
                 "file_path": source_key,
                 "format": doc_format,
             }
+            if content_hash:
+                content_data["content_hash"] = content_hash
             if str(source_path).strip() and str(source_path).strip() != source_key:
                 content_data["source_path"] = source_path
             if lightrag_document_path:
@@ -2610,6 +2656,11 @@ class LightRAG:
                 "updated_at": datetime.now(timezone.utc).isoformat(),
                 "file_path": content_data["file_path"],
                 "track_id": track_id,
+                **(
+                    {"content_hash": content_data["content_hash"]}
+                    if content_data.get("content_hash")
+                    else {}
+                ),
             }
             for id_, content_data in contents.items()
         }
@@ -2622,19 +2673,18 @@ class LightRAG:
 
         for doc_id in list(unique_new_doc_ids):
             content_data = contents[doc_id]
-            existing_doc = await _get_existing_doc_by_file_path_candidates(
-                self.doc_status,
-                content_data["file_path"],
-                content_data.get("source_path"),
+
+            # 3a. Filename-based dedup: same basename always treated as duplicate.
+            match = await _get_existing_doc_by_file_basename(
+                self.doc_status, content_data["file_path"]
             )
-            if existing_doc:
+            if match:
+                existing_doc_id, existing_doc = match
                 unique_new_doc_ids.discard(doc_id)
                 duplicate_attempts.append(
                     {
                         "doc_id": doc_id,
-                        "original_doc_id": _doc_status_field(
-                            existing_doc, "_id", doc_id
-                        ),
+                        "original_doc_id": existing_doc_id,
                         "file_path": content_data["file_path"],
                         "content_length": new_docs.get(doc_id, {}).get(
                             "content_length", 0
@@ -2645,6 +2695,36 @@ class LightRAG:
                         "existing_track_id": _doc_status_field(
                             existing_doc, "track_id", ""
                         ),
+                        "duplicate_kind": "filename",
+                    }
+                )
+                continue
+
+            # 3b. Content-hash dedup: different filename but same body still dupes.
+            content_hash = content_data.get("content_hash")
+            if not content_hash:
+                continue
+            hash_match = await _get_existing_doc_by_content_hash(
+                self.doc_status, content_hash
+            )
+            if hash_match:
+                existing_doc_id, existing_doc = hash_match
+                unique_new_doc_ids.discard(doc_id)
+                duplicate_attempts.append(
+                    {
+                        "doc_id": doc_id,
+                        "original_doc_id": existing_doc_id,
+                        "file_path": content_data["file_path"],
+                        "content_length": new_docs.get(doc_id, {}).get(
+                            "content_length", 0
+                        ),
+                        "existing_status": _doc_status_field(
+                            existing_doc, "status", "unknown"
+                        ),
+                        "existing_track_id": _doc_status_field(
+                            existing_doc, "track_id", ""
+                        ),
+                        "duplicate_kind": "content_hash",
                     }
                 )
 
@@ -2670,6 +2750,7 @@ class LightRAG:
                     "existing_track_id": (
                         existing_doc.get("track_id", "") if existing_doc else ""
                     ),
+                    "duplicate_kind": "filename",
                 }
             )
 
@@ -2678,16 +2759,26 @@ class LightRAG:
             for index, attempt in enumerate(duplicate_attempts):
                 doc_id = attempt["doc_id"]
                 file_path = attempt.get("file_path") or "unknown_source"
-                logger.warning(f"Duplicate document detected: {doc_id} ({file_path})")
+                duplicate_kind = attempt.get("duplicate_kind") or "filename"
+                logger.warning(
+                    f"Duplicate document detected ({duplicate_kind}): "
+                    f"{doc_id} ({file_path})"
+                )
 
                 # Create a new record with unique ID for this duplicate attempt
                 dup_record_id = compute_mdhash_id(
                     f"{doc_id}-{track_id}-{index}-{file_path}", prefix="dup-"
                 )
+                if duplicate_kind == "content_hash":
+                    error_prefix = (
+                        "Identical content already exists under another filename."
+                    )
+                else:
+                    error_prefix = "File name already exists."
                 duplicate_docs[dup_record_id] = {
                     "status": DocStatus.FAILED,
                     "content_summary": (
-                        f"[DUPLICATE] Original document: "
+                        f"[DUPLICATE:{duplicate_kind}] Original document: "
                         f"{attempt.get('original_doc_id', doc_id)}"
                     ),
                     "content_length": attempt.get("content_length", 0),
@@ -2698,12 +2789,13 @@ class LightRAG:
                     "file_path": file_path,
                     "track_id": track_id,  # Use current track_id for tracking
                     "error_msg": (
-                        "File name already exists. "
+                        f"{error_prefix} "
                         f"Original doc_id: {attempt.get('original_doc_id', doc_id)}, "
                         f"Status: {attempt.get('existing_status', 'unknown')}"
                     ),
                     "metadata": {
                         "is_duplicate": True,
+                        "duplicate_kind": duplicate_kind,
                         "original_doc_id": attempt.get("original_doc_id", doc_id),
                         "original_track_id": attempt.get("existing_track_id", ""),
                     },
@@ -2737,6 +2829,10 @@ class LightRAG:
             for doc_id in new_docs.keys()
         }
         for doc_id in new_docs.keys():
+            if contents[doc_id].get("content_hash"):
+                full_docs_data[doc_id]["content_hash"] = contents[doc_id][
+                    "content_hash"
+                ]
             if contents[doc_id].get("source_path"):
                 full_docs_data[doc_id]["source_path"] = contents[doc_id]["source_path"]
             if contents[doc_id].get("lightrag_document_path"):

--- a/tests/test_doc_status_chunk_preservation.py
+++ b/tests/test_doc_status_chunk_preservation.py
@@ -319,7 +319,7 @@ async def test_extract_failure_preserves_chunks_and_allows_delete_with_cache_cle
     try:
         content = "extract failure document"
         file_path = "extract_failure.txt"
-        doc_id = compute_mdhash_id(content, prefix="doc-")
+        doc_id = compute_mdhash_id(file_path, prefix="doc-")
         await rag.apipeline_enqueue_documents(input=content, file_paths=file_path)
 
         async def fail_extract(self, chunks, pipeline_status, pipeline_status_lock):
@@ -360,7 +360,7 @@ async def test_extract_failure_before_chunking_preserves_previous_chunk_snapshot
     try:
         content = "chunking failure document"
         file_path = "chunking_failure.txt"
-        doc_id = compute_mdhash_id(content, prefix="doc-")
+        doc_id = compute_mdhash_id(file_path, prefix="doc-")
         await rag.apipeline_enqueue_documents(input=content, file_paths=file_path)
 
         previous_chunks = ["chunk-old-1", "chunk-old-2", "chunk-old-3"]
@@ -405,7 +405,7 @@ async def test_merge_failure_preserves_chunks_and_skip_cache_cleanup_when_disabl
     try:
         content = "merge failure document"
         file_path = "merge_failure.txt"
-        doc_id = compute_mdhash_id(content, prefix="doc-")
+        doc_id = compute_mdhash_id(file_path, prefix="doc-")
         await rag.apipeline_enqueue_documents(input=content, file_paths=file_path)
 
         async def ok_extract(self, chunks, pipeline_status, pipeline_status_lock):
@@ -1207,7 +1207,7 @@ async def test_pipeline_cancellation_preserves_file_path_for_queued_docs(
         release_first_doc.set()
         await asyncio.wait_for(pipeline_task, timeout=5)
 
-        second_doc_id = compute_mdhash_id(contents[1], prefix="doc-")
+        second_doc_id = compute_mdhash_id(file_paths[1], prefix="doc-")
         second_status = await rag.doc_status.get_by_id(second_doc_id)
         assert second_status is not None
         assert _status_to_text(second_status["status"]) == "failed"
@@ -1232,7 +1232,7 @@ async def test_pipeline_cancellation_repairs_placeholder_file_path_for_queued_do
         file_paths = ["first.md", "second.md"]
         await rag.apipeline_enqueue_documents(input=contents, file_paths=file_paths)
 
-        second_doc_id = compute_mdhash_id(contents[1], prefix="doc-")
+        second_doc_id = compute_mdhash_id(file_paths[1], prefix="doc-")
         second_status = await rag.doc_status.get_by_id(second_doc_id)
         assert second_status is not None
         second_status["file_path"] = "unknown_source"

--- a/tests/test_document_file_path_normalization.py
+++ b/tests/test_document_file_path_normalization.py
@@ -27,22 +27,34 @@ class DummyRAG:
 
 
 @pytest.mark.asyncio
-async def test_pipeline_index_texts_normalizes_missing_file_sources():
+async def test_pipeline_index_texts_rejects_missing_file_sources():
+    rag = DummyRAG()
+
+    with pytest.raises(ValueError, match="valid file source"):
+        await pipeline_index_texts(
+            rag,
+            texts=["alpha"],
+            file_sources=[None],
+            track_id="track-1",
+        )
+
+    assert rag.enqueued_calls == []
+    assert rag.processed is False
+
+
+@pytest.mark.asyncio
+async def test_pipeline_index_texts_normalizes_file_sources_to_basename():
     rag = DummyRAG()
 
     await pipeline_index_texts(
         rag,
         texts=["alpha"],
-        file_sources=[None],
+        file_sources=["/tmp/source/alpha.txt"],
         track_id="track-1",
     )
 
     assert rag.enqueued_calls == [
-        {
-            "input": ["alpha"],
-            "file_paths": ["unknown_source"],
-            "track_id": "track-1",
-        }
+        {"input": ["alpha"], "file_paths": ["alpha.txt"], "track_id": "track-1"}
     ]
     assert rag.processed is True
 

--- a/tests/test_document_routes_docx_archive.py
+++ b/tests/test_document_routes_docx_archive.py
@@ -150,6 +150,9 @@ class _ParseRag:
         LightRAG._archive_docx_source_after_full_docs_sync
     )
     _persist_parsed_full_docs = LightRAG._persist_parsed_full_docs
+    _input_dir_path = LightRAG._input_dir_path
+    _parsed_dir_for_source = LightRAG._parsed_dir_for_source
+    _resolve_lightrag_document_path = LightRAG._resolve_lightrag_document_path
 
     def __init__(self, working_dir, source_path):
         self.working_dir = str(working_dir)

--- a/tests/test_document_routes_docx_archive.py
+++ b/tests/test_document_routes_docx_archive.py
@@ -86,6 +86,14 @@ class _ScanDocStatus:
     async def get_doc_by_file_path(self, file_path):
         return self.docs_by_path.get(file_path)
 
+    async def get_doc_by_file_basename(self, basename):
+        from pathlib import Path as _Path
+
+        for stored_path, doc in self.docs_by_path.items():
+            if _Path(stored_path).name == basename:
+                return stored_path, doc
+        return None
+
 
 class _ScanRag:
     def __init__(self, docs_by_path):

--- a/tests/test_document_routes_docx_archive.py
+++ b/tests/test_document_routes_docx_archive.py
@@ -53,16 +53,18 @@ class _FakeRag:
         track_id=None,
         docs_format=None,
         parsed_engine=None,
+        reprocess_existing_non_processed=False,
     ):
-        self.enqueued.append(
-            {
-                "input": input,
-                "file_path": file_paths,
-                "track_id": track_id,
-                "docs_format": docs_format,
-                "parsed_engine": parsed_engine,
-            }
-        )
+        item = {
+            "input": input,
+            "file_path": file_paths,
+            "track_id": track_id,
+            "docs_format": docs_format,
+            "parsed_engine": parsed_engine,
+        }
+        if reprocess_existing_non_processed:
+            item["reprocess_existing_non_processed"] = True
+        self.enqueued.append(item)
         return track_id
 
     async def apipeline_process_enqueue_documents(self):
@@ -77,6 +79,12 @@ class _FakeRag:
 
     async def apipeline_enqueue_error_documents(self, error_files, track_id=None):
         self.errors.append((error_files, track_id))
+
+
+class _DuplicateEnqueueRag(_FakeRag):
+    async def apipeline_enqueue_documents(self, *args, **kwargs):
+        self.enqueued.append({"args": args, "kwargs": kwargs})
+        return None
 
 
 class _ScanDocStatus:
@@ -99,6 +107,7 @@ class _ScanRag:
     def __init__(self, docs_by_path):
         self.doc_status = _ScanDocStatus(docs_by_path)
         self.process_calls = 0
+        self.workspace = "scan-test"
 
     async def apipeline_process_enqueue_documents(self):
         self.process_calls += 1
@@ -254,6 +263,30 @@ async def test_pipeline_enqueue_md_moves_after_enqueue(tmp_path, monkeypatch):
     assert (tmp_path / PARSED_DIR_NAME / file_path.name).exists()
 
 
+async def test_pipeline_enqueue_legacy_duplicate_archives_with_unique_name(
+    tmp_path, monkeypatch
+):
+    monkeypatch.delenv("LIGHTRAG_PARSER", raising=False)
+    file_path = tmp_path / "duplicate.md"
+    file_path.write_text("duplicate content", encoding="utf-8")
+    parsed_dir = tmp_path / PARSED_DIR_NAME
+    parsed_dir.mkdir()
+    (parsed_dir / file_path.name).write_text("existing", encoding="utf-8")
+    rag = _DuplicateEnqueueRag()
+
+    success, returned_track_id = await pipeline_enqueue_file(
+        rag, file_path, "track-dup"
+    )
+
+    assert success is False
+    assert returned_track_id == "track-dup"
+    assert not file_path.exists()
+    assert (parsed_dir / file_path.name).read_text(encoding="utf-8") == "existing"
+    assert (parsed_dir / "duplicate_001.md").read_text(
+        encoding="utf-8"
+    ) == "duplicate content"
+
+
 async def test_pipeline_enqueue_parser_routed_pdf_defers_without_extraction(
     tmp_path, monkeypatch
 ):
@@ -308,14 +341,19 @@ async def test_pipeline_index_files_leaves_lightrag_document_docx_batch(
     assert all(item["parsed_engine"] == "native" for item in rag.enqueued)
 
 
-async def test_scan_existing_full_path_docx_does_not_reenqueue(tmp_path, monkeypatch):
+async def test_scan_processed_same_name_archives_with_unique_name(
+    tmp_path, monkeypatch
+):
     file_path = tmp_path / "already-parsed.docx"
     file_path.write_bytes(b"docx bytes")
+    parsed_dir = tmp_path / PARSED_DIR_NAME
+    parsed_dir.mkdir()
+    (parsed_dir / file_path.name).write_bytes(b"previous parsed file")
     doc_manager = DocumentManager(str(tmp_path))
     rag = _ScanRag(
         {
             str(file_path): {
-                "status": DocStatus.PARSING.value,
+                "status": DocStatus.PROCESSED.value,
                 "file_path": str(file_path),
                 "track_id": "track-existing",
             }
@@ -329,7 +367,49 @@ async def test_scan_existing_full_path_docx_does_not_reenqueue(tmp_path, monkeyp
 
     await run_scanning_process(rag, doc_manager, "track-scan")
 
-    assert rag.process_calls == 1
+    assert not file_path.exists()
+    assert (parsed_dir / file_path.name).read_bytes() == b"previous parsed file"
+    assert (parsed_dir / "already-parsed_001.docx").read_bytes() == b"docx bytes"
+
+
+async def test_scan_existing_non_processed_reprocesses_file(tmp_path, monkeypatch):
+    file_path = tmp_path / "retry.docx"
+    file_path.write_bytes(b"docx bytes")
+    doc_manager = DocumentManager(str(tmp_path))
+    rag = _ScanRag(
+        {
+            str(file_path): {
+                "status": DocStatus.PARSING.value,
+                "file_path": str(file_path),
+                "track_id": "track-existing",
+            }
+        }
+    )
+    calls = []
+
+    async def capture_pipeline(rag_arg, file_paths, track_id, **kwargs):
+        calls.append(
+            {
+                "rag": rag_arg,
+                "file_paths": file_paths,
+                "track_id": track_id,
+                "kwargs": kwargs,
+            }
+        )
+
+    monkeypatch.setattr(_document_routes, "pipeline_index_files", capture_pipeline)
+
+    await run_scanning_process(rag, doc_manager, "track-scan")
+
+    assert calls == [
+        {
+            "rag": rag,
+            "file_paths": [file_path],
+            "track_id": "track-scan",
+            "kwargs": {"reprocess_existing_non_processed": True},
+        }
+    ]
+    assert file_path.exists()
 
 
 async def test_upload_rejects_same_name_failed_doc_status_without_full_docs(

--- a/tests/test_document_routes_docx_archive.py
+++ b/tests/test_document_routes_docx_archive.py
@@ -130,14 +130,31 @@ class _ParseFullDocs:
         assert self.source_path.exists()
 
 
+class _ParseDocStatus:
+    """Minimal doc_status double for the parse_* archive tests.
+
+    ``_persist_parsed_full_docs`` reads the existing record and patches its
+    ``content_hash``; with no record present the helper short-circuits, which
+    is what these tests want — they only assert on full_docs side effects.
+    """
+
+    async def get_by_id(self, doc_id):
+        return None
+
+    async def upsert(self, data):
+        return None
+
+
 class _ParseRag:
     _archive_docx_source_after_full_docs_sync = (
         LightRAG._archive_docx_source_after_full_docs_sync
     )
+    _persist_parsed_full_docs = LightRAG._persist_parsed_full_docs
 
     def __init__(self, working_dir, source_path):
         self.working_dir = str(working_dir)
         self.full_docs = _ParseFullDocs(source_path)
+        self.doc_status = _ParseDocStatus()
 
     def _resolve_source_file_for_parser(self, file_path):
         return file_path

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -274,6 +274,104 @@ def test_lightrag_format_uses_blocks_file_hash(tmp_path):
 
 
 @pytest.mark.offline
+def test_persist_parsed_full_docs_syncs_hash_to_doc_status(tmp_path):
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+        try:
+            # Enqueue a pending_parse record: no content_hash should exist yet.
+            await rag.apipeline_enqueue_documents(
+                "",
+                file_paths="pending.txt",
+                docs_format="pending_parse",
+                track_id="track-pending",
+            )
+            doc_id = compute_mdhash_id("pending.txt", prefix="doc-")
+            full_doc = await rag.full_docs.get_by_id(doc_id)
+            assert full_doc is not None
+            assert full_doc.get("content_hash") in (None, "")
+            status_pre = await rag.doc_status.get_by_id(doc_id)
+            assert (status_pre or {}).get("content_hash") in (None, "")
+
+            # Simulate a parse_* completion that converts the record to RAW.
+            content = "extracted body text"
+            await rag._persist_parsed_full_docs(
+                doc_id,
+                {
+                    "content": content,
+                    "file_path": "pending.txt",
+                    "format": "raw",
+                    "parsed_engine": "native",
+                },
+            )
+
+            full_doc = await rag.full_docs.get_by_id(doc_id)
+            status_post = await rag.doc_status.get_by_id(doc_id)
+            expected_hash = compute_mdhash_id(content, prefix="")
+            assert full_doc["content_hash"] == expected_hash
+            assert (status_post or {}).get("content_hash") == expected_hash
+
+            # The hash should be queryable via the storage index.
+            match = await rag.doc_status.get_doc_by_content_hash(expected_hash)
+            assert match is not None
+            assert match[0] == doc_id
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_state_machine_upsert_preserves_content_hash(tmp_path):
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+        try:
+            await rag.apipeline_enqueue_documents(
+                "raw body",
+                file_paths="alpha.txt",
+                track_id="track-state",
+            )
+            doc_id = compute_mdhash_id("alpha.txt", prefix="doc-")
+            initial_hash = (await rag.doc_status.get_by_id(doc_id))["content_hash"]
+            assert initial_hash
+
+            # Simulate the production state-machine upsert pattern: read
+            # status_doc, then write a new payload that includes content_hash.
+            status_doc = (await rag.doc_status.get_docs_by_status(DocStatus.PENDING))[
+                doc_id
+            ]
+            for next_status in (
+                DocStatus.PARSING,
+                DocStatus.ANALYZING,
+                DocStatus.PROCESSED,
+            ):
+                await rag.doc_status.upsert(
+                    {
+                        doc_id: {
+                            "status": next_status,
+                            "content_summary": status_doc.content_summary,
+                            "content_length": status_doc.content_length,
+                            "created_at": status_doc.created_at,
+                            "updated_at": "now",
+                            "file_path": status_doc.file_path,
+                            "track_id": status_doc.track_id,
+                            "content_hash": status_doc.content_hash,
+                        }
+                    }
+                )
+                current = await rag.doc_status.get_by_id(doc_id)
+                assert current.get("content_hash") == initial_hash
+                # And the index lookup must still return this doc.
+                match = await rag.doc_status.get_doc_by_content_hash(initial_hash)
+                assert match is not None and match[0] == doc_id
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
 def test_parser_routing_accepts_semicolon_rules(monkeypatch):
     monkeypatch.setenv("MINERU_ENDPOINT", "http://fake-mineru")
     monkeypatch.setenv("DOCLING_ENDPOINT", "http://fake-docling")

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -103,36 +103,170 @@ def test_parse_engine_rule_fallback_and_default_legacy(tmp_path, monkeypatch):
 
 
 @pytest.mark.offline
-def test_enqueue_uses_filename_for_document_identity(tmp_path):
+def test_enqueue_dedupes_by_filename_and_content_hash(tmp_path):
     async def _run():
         rag = _new_rag(tmp_path)
         await rag.initialize_storages()
         try:
+            # Distinct filenames with distinct content both get enqueued.
             await rag.apipeline_enqueue_documents(
-                ["same content", "same content"],
+                ["alpha body", "beta body"],
                 file_paths=["first.txt", "second.txt"],
                 track_id="track-a",
             )
-
             first_id = compute_mdhash_id("first.txt", prefix="doc-")
             second_id = compute_mdhash_id("second.txt", prefix="doc-")
-            assert await rag.full_docs.get_by_id(first_id) is not None
-            assert await rag.full_docs.get_by_id(second_id) is not None
+            first_doc = await rag.full_docs.get_by_id(first_id)
+            second_doc = await rag.full_docs.get_by_id(second_id)
+            assert first_doc is not None
+            assert second_doc is not None
+            assert first_doc.get("content_hash")
+            assert second_doc.get("content_hash")
+            assert first_doc["content_hash"] != second_doc["content_hash"]
 
+            # Same filename basename with new content is rejected (filename dedup).
             await rag.apipeline_enqueue_documents(
                 "changed content",
                 file_paths="/tmp/first.txt",
                 track_id="track-b",
             )
-
             first_doc = await rag.full_docs.get_by_id(first_id)
-            assert first_doc["content"] == "same content"
-            failed_docs = await rag.doc_status.get_docs_by_status(DocStatus.FAILED)
-            assert any(
-                getattr(doc, "metadata", {}).get("is_duplicate")
-                and getattr(doc, "file_path", "") == "first.txt"
-                for doc in failed_docs.values()
+            assert first_doc["content"] == "alpha body"
+
+            # New filename but same content as an existing doc is rejected
+            # (content_hash dedup).
+            await rag.apipeline_enqueue_documents(
+                "alpha body",
+                file_paths="third.txt",
+                track_id="track-c",
             )
+            third_id = compute_mdhash_id("third.txt", prefix="doc-")
+            assert await rag.full_docs.get_by_id(third_id) is None
+
+            failed_docs = await rag.doc_status.get_docs_by_status(DocStatus.FAILED)
+            kinds = {
+                getattr(doc, "metadata", {}).get("duplicate_kind")
+                for doc in failed_docs.values()
+                if getattr(doc, "metadata", {}).get("is_duplicate")
+            }
+            assert {"filename", "content_hash"}.issubset(kinds)
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_basename_lookup_finds_legacy_full_path_records(tmp_path):
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+        try:
+            # Simulate a legacy doc_status row whose file_path still holds a
+            # full path; the new basename lookup should still resolve it.
+            legacy_id = "doc-legacy-1"
+            await rag.doc_status.upsert(
+                {
+                    legacy_id: {
+                        "status": DocStatus.PROCESSED,
+                        "content_summary": "legacy",
+                        "content_length": 7,
+                        "file_path": "/inputs/legacy.txt",
+                        "track_id": "legacy-track",
+                        "created_at": "2025-01-01T00:00:00+00:00",
+                        "updated_at": "2025-01-01T00:00:00+00:00",
+                        "chunks_list": [],
+                    }
+                }
+            )
+
+            match = await rag.doc_status.get_doc_by_file_basename("legacy.txt")
+            assert match is not None
+            doc_id, doc = match
+            assert doc_id == legacy_id
+            assert doc["file_path"] == "/inputs/legacy.txt"
+
+            # Re-enqueueing the same basename hits the filename guard.
+            await rag.apipeline_enqueue_documents(
+                "fresh body",
+                file_paths="legacy.txt",
+                track_id="track-x",
+            )
+            new_id = compute_mdhash_id("legacy.txt", prefix="doc-")
+            assert await rag.full_docs.get_by_id(new_id) is None
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_content_hash_lookup_via_storage(tmp_path):
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+        try:
+            await rag.apipeline_enqueue_documents(
+                "shared body",
+                file_paths="alpha.txt",
+                track_id="track-a",
+            )
+            alpha_id = compute_mdhash_id("alpha.txt", prefix="doc-")
+            alpha_full = await rag.full_docs.get_by_id(alpha_id)
+            assert alpha_full is not None
+            content_hash = alpha_full["content_hash"]
+
+            match = await rag.doc_status.get_doc_by_content_hash(content_hash)
+            assert match is not None
+            doc_id, _ = match
+            assert doc_id == alpha_id
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_lightrag_format_uses_blocks_file_hash(tmp_path):
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+        try:
+            blocks_path = tmp_path / "doc.blocks.jsonl"
+            blocks_path.write_text(
+                json.dumps({"type": "header"})
+                + "\n"
+                + json.dumps({"type": "content", "text": "hello"})
+                + "\n",
+                encoding="utf-8",
+            )
+
+            # Enqueue twice with different filenames pointing at the same
+            # blocks file: the second one must be rejected as content_hash dup.
+            await rag.apipeline_enqueue_documents(
+                FULL_DOCS_CONTENT_STORED_IN_LIGHTRAG_DOCUMENT,
+                file_paths="first.lightrag",
+                docs_format="lightrag",
+                lightrag_document_paths=str(blocks_path),
+                track_id="track-a",
+            )
+            await rag.apipeline_enqueue_documents(
+                FULL_DOCS_CONTENT_STORED_IN_LIGHTRAG_DOCUMENT,
+                file_paths="second.lightrag",
+                docs_format="lightrag",
+                lightrag_document_paths=str(blocks_path),
+                track_id="track-b",
+            )
+            second_id = compute_mdhash_id("second.lightrag", prefix="doc-")
+            assert await rag.full_docs.get_by_id(second_id) is None
+
+            failed = await rag.doc_status.get_docs_by_status(DocStatus.FAILED)
+            kinds = {
+                getattr(doc, "metadata", {}).get("duplicate_kind")
+                for doc in failed.values()
+                if getattr(doc, "metadata", {}).get("is_duplicate")
+            }
+            assert "content_hash" in kinds
         finally:
             await rag.finalize_storages()
 

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -7,7 +7,12 @@ import pytest
 
 from lightrag import LightRAG, ROLES, RoleLLMConfig
 from lightrag.base import DocStatus
-from lightrag.constants import FULL_DOCS_CONTENT_STORED_IN_LIGHTRAG_DOCUMENT
+from lightrag.constants import (
+    FULL_DOCS_CONTENT_STORED_IN_LIGHTRAG_DOCUMENT,
+    FULL_DOCS_FORMAT_PENDING_PARSE,
+    PARSED_DIR_NAME,
+    PARSER_ENGINE_NATIVE,
+)
 from lightrag.operate import _get_relationship_vdb_timeout_seconds
 from lightrag.parser_routing import (
     ParserRoutingConfigError,
@@ -61,7 +66,7 @@ def _new_rag(tmp_path: Path, **kwargs) -> LightRAG:
 
     return LightRAG(
         working_dir=str(tmp_path),
-        workspace="test-release-closure",
+        workspace=f"test-release-closure-{tmp_path.name}",
         llm_model_func=_mock_llm,
         embedding_func=EmbeddingFunc(
             embedding_dim=32,
@@ -316,6 +321,7 @@ def test_lightrag_format_uses_blocks_file_hash(tmp_path, monkeypatch):
         monkeypatch.setenv("INPUT_DIR", str(input_dir))
 
         rag = _new_rag(tmp_path / "work")
+        rag.workspace = "test-pending-parse-duplicate"
         await rag.initialize_storages()
         try:
             blocks_path = parsed_dir / "doc.blocks.jsonl"
@@ -451,6 +457,66 @@ def test_state_machine_upsert_preserves_content_hash(tmp_path):
                 # And the index lookup must still return this doc.
                 match = await rag.doc_status.get_doc_by_content_hash(initial_hash)
                 assert match is not None and match[0] == doc_id
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_pending_parse_duplicate_hash_fails_and_archives_source(tmp_path, monkeypatch):
+    async def _run():
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+        monkeypatch.setenv("INPUT_DIR", str(input_dir))
+        rag = _new_rag(tmp_path / "work")
+        await rag.initialize_storages()
+        try:
+            content = "same extracted body"
+            await rag.apipeline_enqueue_documents(
+                content,
+                file_paths="existing.txt",
+                track_id="track-original",
+            )
+            original_id = compute_mdhash_id("existing.txt", prefix="doc-")
+            original_status = await rag.doc_status.get_by_id(original_id)
+            original_status["status"] = DocStatus.PROCESSED
+            await rag.doc_status.upsert({original_id: original_status})
+
+            source_path = input_dir / "duplicate.docx"
+            source_path.write_bytes(b"docx bytes")
+            parse_document = __import__(
+                "lightrag.extraction.parse_document",
+                fromlist=["parse_docx_to_interchange_jsonl"],
+            )
+            monkeypatch.setattr(
+                parse_document,
+                "parse_docx_to_interchange_jsonl",
+                lambda file_bytes, source_file, doc_id, output_dir: content,
+            )
+
+            async def _fail_extract(*args, **kwargs):
+                raise AssertionError("duplicate document should not reach extraction")
+
+            monkeypatch.setattr(rag, "_process_extract_entities", _fail_extract)
+
+            await rag.apipeline_enqueue_documents(
+                "",
+                file_paths=str(source_path),
+                docs_format=FULL_DOCS_FORMAT_PENDING_PARSE,
+                parsed_engine=PARSER_ENGINE_NATIVE,
+                track_id="track-dup",
+            )
+            await rag.apipeline_process_enqueue_documents()
+
+            duplicate_id = compute_mdhash_id("duplicate.docx", prefix="doc-")
+            duplicate_status = await rag.doc_status.get_by_id(duplicate_id)
+            assert duplicate_status["status"] == DocStatus.FAILED
+            assert duplicate_status["metadata"]["is_duplicate"] is True
+            assert duplicate_status["metadata"]["duplicate_kind"] == "content_hash"
+            assert duplicate_status["metadata"]["original_doc_id"] == original_id
+            assert not source_path.exists()
+            assert (input_dir / PARSED_DIR_NAME / source_path.name).exists()
         finally:
             await rag.finalize_storages()
 

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 from lightrag import LightRAG, ROLES, RoleLLMConfig
+from lightrag.base import DocStatus
 from lightrag.constants import FULL_DOCS_CONTENT_STORED_IN_LIGHTRAG_DOCUMENT
 from lightrag.operate import _get_relationship_vdb_timeout_seconds
 from lightrag.parser_routing import (
@@ -13,7 +14,12 @@ from lightrag.parser_routing import (
     resolve_file_parser_engine,
     validate_parser_routing_config,
 )
-from lightrag.utils import EmbeddingFunc, Tokenizer, safe_vdb_operation_with_exception
+from lightrag.utils import (
+    EmbeddingFunc,
+    Tokenizer,
+    compute_mdhash_id,
+    safe_vdb_operation_with_exception,
+)
 
 
 class _SimpleTokenizerImpl:
@@ -94,6 +100,43 @@ def test_parse_engine_rule_fallback_and_default_legacy(tmp_path, monkeypatch):
     monkeypatch.delenv("LIGHTRAG_PARSER", raising=False)
     monkeypatch.setenv("MINERU_ENDPOINT", "")
     assert rag._resolve_parser_engine("slides.pptx", {}) == "legacy"
+
+
+@pytest.mark.offline
+def test_enqueue_uses_filename_for_document_identity(tmp_path):
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+        try:
+            await rag.apipeline_enqueue_documents(
+                ["same content", "same content"],
+                file_paths=["first.txt", "second.txt"],
+                track_id="track-a",
+            )
+
+            first_id = compute_mdhash_id("first.txt", prefix="doc-")
+            second_id = compute_mdhash_id("second.txt", prefix="doc-")
+            assert await rag.full_docs.get_by_id(first_id) is not None
+            assert await rag.full_docs.get_by_id(second_id) is not None
+
+            await rag.apipeline_enqueue_documents(
+                "changed content",
+                file_paths="/tmp/first.txt",
+                track_id="track-b",
+            )
+
+            first_doc = await rag.full_docs.get_by_id(first_id)
+            assert first_doc["content"] == "same content"
+            failed_docs = await rag.doc_status.get_docs_by_status(DocStatus.FAILED)
+            assert any(
+                getattr(doc, "metadata", {}).get("is_duplicate")
+                and getattr(doc, "file_path", "") == "first.txt"
+                for doc in failed_docs.values()
+            )
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
 
 
 @pytest.mark.offline

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -157,6 +157,87 @@ def test_enqueue_dedupes_by_filename_and_content_hash(tmp_path):
 
 
 @pytest.mark.offline
+def test_enqueue_without_file_paths_uses_content_ids(tmp_path):
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+        try:
+            docs = ["alpha without source", "beta without source"]
+            await rag.apipeline_enqueue_documents(docs, track_id="track-no-source")
+
+            for content in docs:
+                doc_id = compute_mdhash_id(content, prefix="doc-")
+                full_doc = await rag.full_docs.get_by_id(doc_id)
+                status = await rag.doc_status.get_by_id(doc_id)
+                assert full_doc is not None
+                assert status is not None
+                assert full_doc["content"] == content
+                assert full_doc["file_path"] == "unknown_source"
+                assert status["file_path"] == "unknown_source"
+                assert full_doc.get("content_hash")
+                assert status.get("content_hash") == full_doc.get("content_hash")
+
+            failed_docs = await rag.doc_status.get_docs_by_status(DocStatus.FAILED)
+            duplicate_failures = [
+                doc
+                for doc in failed_docs.values()
+                if getattr(doc, "track_id", "") == "track-no-source"
+                and getattr(doc, "metadata", {}).get("is_duplicate")
+            ]
+            assert duplicate_failures == []
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_legacy_empty_file_paths_do_not_block_unsourced_insert(tmp_path):
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+        try:
+            await rag.doc_status.upsert(
+                {
+                    "legacy-empty": {
+                        "status": DocStatus.PROCESSED,
+                        "content_summary": "legacy empty",
+                        "content_length": 0,
+                        "file_path": "",
+                        "track_id": "legacy",
+                        "created_at": "2025-01-01T00:00:00+00:00",
+                        "updated_at": "2025-01-01T00:00:00+00:00",
+                        "chunks_list": [],
+                    },
+                    "legacy-no-file": {
+                        "status": DocStatus.PROCESSED,
+                        "content_summary": "legacy no-file",
+                        "content_length": 0,
+                        "file_path": "no-file-path",
+                        "track_id": "legacy",
+                        "created_at": "2025-01-01T00:00:00+00:00",
+                        "updated_at": "2025-01-01T00:00:00+00:00",
+                        "chunks_list": [],
+                    },
+                }
+            )
+
+            content = "fresh unsourced body"
+            await rag.apipeline_enqueue_documents(content, track_id="track-fresh")
+            doc_id = compute_mdhash_id(content, prefix="doc-")
+            full_doc = await rag.full_docs.get_by_id(doc_id)
+            status = await rag.doc_status.get_by_id(doc_id)
+            assert full_doc is not None
+            assert status is not None
+            assert full_doc["file_path"] == "unknown_source"
+            assert status["file_path"] == "unknown_source"
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
 def test_basename_lookup_finds_legacy_full_path_records(tmp_path):
     async def _run():
         rag = _new_rag(tmp_path)

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -308,12 +308,17 @@ def test_content_hash_lookup_via_storage(tmp_path):
 
 
 @pytest.mark.offline
-def test_lightrag_format_uses_blocks_file_hash(tmp_path):
+def test_lightrag_format_uses_blocks_file_hash(tmp_path, monkeypatch):
     async def _run():
-        rag = _new_rag(tmp_path)
+        input_dir = tmp_path / "input"
+        parsed_dir = input_dir / "__parsed__"
+        parsed_dir.mkdir(parents=True)
+        monkeypatch.setenv("INPUT_DIR", str(input_dir))
+
+        rag = _new_rag(tmp_path / "work")
         await rag.initialize_storages()
         try:
-            blocks_path = tmp_path / "doc.blocks.jsonl"
+            blocks_path = parsed_dir / "doc.blocks.jsonl"
             blocks_path.write_text(
                 json.dumps({"type": "header"})
                 + "\n"
@@ -328,14 +333,14 @@ def test_lightrag_format_uses_blocks_file_hash(tmp_path):
                 FULL_DOCS_CONTENT_STORED_IN_LIGHTRAG_DOCUMENT,
                 file_paths="first.lightrag",
                 docs_format="lightrag",
-                lightrag_document_paths=str(blocks_path),
+                lightrag_document_paths="__parsed__/doc.blocks.jsonl",
                 track_id="track-a",
             )
             await rag.apipeline_enqueue_documents(
                 FULL_DOCS_CONTENT_STORED_IN_LIGHTRAG_DOCUMENT,
                 file_paths="second.lightrag",
                 docs_format="lightrag",
-                lightrag_document_paths=str(blocks_path),
+                lightrag_document_paths="__parsed__/doc.blocks.jsonl",
                 track_id="track-b",
             )
             second_id = compute_mdhash_id("second.lightrag", prefix="doc-")
@@ -950,10 +955,14 @@ def test_analyze_multimodal_table_without_image_uses_textual_analysis(tmp_path):
 @pytest.mark.offline
 def test_parse_mineru_to_lightrag_document(tmp_path, monkeypatch):
     async def _run():
-        rag = _new_rag(tmp_path)
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+        monkeypatch.setenv("INPUT_DIR", str(input_dir))
+
+        rag = _new_rag(tmp_path / "work")
         await rag.initialize_storages()
 
-        src_file = tmp_path / "demo.pdf"
+        src_file = input_dir / "demo.pdf"
         src_file.write_bytes(b"fake-pdf")
 
         async def _fake_service(protocol, file_path):
@@ -1019,7 +1028,7 @@ def test_parse_mineru_to_lightrag_document(tmp_path, monkeypatch):
         assert full_doc["format"] == "lightrag"
         assert full_doc["content"] == FULL_DOCS_CONTENT_STORED_IN_LIGHTRAG_DOCUMENT
         assert full_doc["lightrag_document_path"] == str(
-            blocks_path.relative_to(Path(rag.working_dir))
+            blocks_path.relative_to(input_dir)
         )
 
         await rag.finalize_storages()


### PR DESCRIPTION
## Description

Deduplicate document ingestion by filename basename instead of extracted content hash. This keeps same-name uploads from overwriting existing `full_docs` content while allowing identical content under different filenames to be indexed as separate documents.

## Related Issues

n/a

## Changes Made

- Generate default document IDs from normalized filename basename during pipeline enqueue.
- Preserve parser-readable source paths separately from the basename `file_path`.
- Require valid `file_source` values for text ingestion and remove content-hash duplicate checks.
- Document the filename-based duplicate policy in the file processing configuration guide.
- Update tests for filename identity, text source validation, and existing pipeline status behavior.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Local validation:

- `./scripts/test.sh tests/test_document_file_path_normalization.py tests/test_pipeline_release_closure.py tests/test_document_routes_docx_archive.py tests/test_doc_status_chunk_preservation.py -q`
- `ruff check lightrag/lightrag.py lightrag/api/routers/document_routes.py tests/test_document_file_path_normalization.py tests/test_pipeline_release_closure.py tests/test_doc_status_chunk_preservation.py`
