### PR TITLE
Fix parsed document artifact isolation

### DIFF
--- a/docs/FileProcessingConfiguration-zh.md
+++ b/docs/FileProcessingConfiguration-zh.md
@@ -129,18 +129,21 @@ DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
 | `format` | 内容格式：`pending_parse`, `raw`, `lightrag`。 |
 | `content` | `raw` 时保存抽取文本；`pending_parse` 时为空字符串；`lightrag` 时固定为 `{{stored-in-lightrag-doucment}}`。 |
 | `content_hash` | 内容 MD5，用于跨文件名查重。`format=raw` 取 `sanitize_text_for_encoding` 后文本的 hash；`format=lightrag` 取 `*.blocks.jsonl` 文件 hash；`format=pending_parse` 不写入，待抽取完成后补上。 |
-| `lightrag_document_path` | `format=lightrag` 时保存结构化 LightRAG Document 的路径；新记录优先保存为相对 `INPUT_DIR` 的路径，例如 `__parsed__/doc.blocks.jsonl`。 |
+| `lightrag_document_path` | `format=lightrag` 时保存结构化 LightRAG Document 的路径；新记录优先保存为相对 `INPUT_DIR` 的路径，例如 `__parsed__/report.docx.parsed/report.blocks.jsonl`。 |
 | `parsed_engine` | 实际完成抽取的引擎：`legacy`, `native`, `mineru`, `docling`。对于待抽取文件，也可暂存目标引擎。 |
 
 `pending_parse` 表示文件已经入队，但还没有完成抽取。抽取成功后会改写为 `raw` 或 `lightrag`，并补齐 `content_hash`。抽取失败时保留 `pending_parse` 和空 `content`，便于后续排查和重试。
 
 > `doc_status` 中也会同步保存 `file_path`（basename）与 `content_hash`，作为 `get_doc_by_file_basename` / `get_doc_by_content_hash` 的查重索引来源。
 
-## 原始文件归档
+## 分析结果目录结构
 
-- `legacy`：本地抽取成功并入队后，原文件会移动到同级 `__parsed__` 目录。
-- `native` / `mineru` / `docling`：文件先保留在原位置供 pipeline 解析；解析成功并写入 `full_docs` 后，原文件再移动到 `__parsed__`。
+`__parsed__` 是输入目录旁的归档与分析结果目录。它同时保存已经处理过的原始文档，以及结构化解析产生的 LightRAG Document 文件和图片等资源。
+
+- 原始文件归档：`legacy` 本地抽取成功并入队后，原文件会移动到同级 `__parsed__` 目录；`native` / `mineru` / `docling` 会先保留原文件供 pipeline 解析，解析成功并写入 `full_docs` 后再移动到 `__parsed__`。
+- 分析结果目录：结构化解析结果会写入以原始文件名加 `.parsed` 后缀命名的子目录，避免与归档原文件同名冲突。例如 `report.docx` 的分析结果目录为 `__parsed__/report.docx.parsed/`。
+- 分析结果文件：LightRAG Document blocks 文件使用原文件主干命名，例如 `__parsed__/report.docx.parsed/report.blocks.jsonl`；同一目录下还可能包含 `report.tables.json`、`report.drawings.json`、`report.equations.json` 和 `report.blocks.assets/` 图片资源目录。
 - 解析失败时，原文件不会移动，便于修复配置后重新处理。
 - `/documents/scan` 扫描到同名且已 `PROCESSED` 的文件时，该输入文件会被视为已处理并移动到 `__parsed__`，不会作为新文档入队。
 - 扫描或解析过程中发现内容 hash 重复时，该输入文件同样会移动到 `__parsed__`；本次 `doc_status` 保留为 `FAILED duplicate` 以便追踪。
-- 移动文件只作用于当前输入文件，不会覆盖或移动既有文档源文件。若目标目录已存在同名文件，系统会自动追加 `_001`、`_002` 等编号，例如 `report.pdf` 会依次归档为 `report_001.pdf`、`report_002.pdf`。
+- 移动文件只作用于当前输入文件，不会覆盖或移动既有文档源文件。若目标目录已存在同名文件，系统会自动追加 `_001`、`_002` 等编号，例如 `report.pdf` 会依次归档为 `report_001.pdf`、`report_002.pdf`。若分析结果目录名已被普通文件占用，也会追加编号，例如 `report.docx.parsed_001/`。

--- a/lightrag/extraction/parse_document.py
+++ b/lightrag/extraction/parse_document.py
@@ -107,10 +107,10 @@ def parse_docx_to_interchange_jsonl(
 
     asset_dir_created = False
     if output_dir and images:
-        prefix = (
+        asset_base = Path(source_file).stem or (
             doc_id.strip() if doc_id and doc_id.strip() else f"doc-{source_hash[:12]}"
         )
-        assets_dir = Path(output_dir) / f"{prefix}.{source_file}.blocks.assets"
+        assets_dir = Path(output_dir) / f"{asset_base}.blocks.assets"
         try:
             assets_dir.mkdir(parents=True, exist_ok=True)
             for _rel_id, (filename, blob) in images.items():

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -4809,12 +4809,33 @@ class LightRAG:
 
         source = Path(source_path)
         if source.is_absolute():
+            if source.parent.name == PARSED_DIR_NAME:
+                return source.parent
             return source.parent / PARSED_DIR_NAME
 
         source_parent = source.parent
         if str(source_parent) == ".":
             return self._input_dir_path() / PARSED_DIR_NAME
+        if source_parent.name == PARSED_DIR_NAME:
+            return self._input_dir_path() / source_parent
         return self._input_dir_path() / source_parent / PARSED_DIR_NAME
+
+    def _parsed_artifact_dir_for_source(
+        self, source_path: str | None = None, file_path: str | None = None
+    ) -> Path:
+        parsed_dir = self._parsed_dir_for_source(source_path)
+        source_name = Path(source_path or file_path or "document").name or "document"
+        artifact_name = f"{source_name}.parsed"
+        artifact_dir = parsed_dir / artifact_name
+        if not artifact_dir.exists() or artifact_dir.is_dir():
+            return artifact_dir
+
+        for i in range(1, 1000):
+            candidate = parsed_dir / f"{artifact_name}_{i:03d}"
+            if not candidate.exists() or candidate.is_dir():
+                return candidate
+
+        return parsed_dir / f"{artifact_name}_{int(time.time())}"
 
     def _resolve_lightrag_document_path(self, document_path: str) -> str:
         path = Path(document_path)
@@ -4883,11 +4904,11 @@ class LightRAG:
         source_path: str | None = None,
     ) -> dict[str, Any]:
         """Convert parser content list to LightRAG Document files and return parsed_data."""
-        parsed_dir = self._parsed_dir_for_source(source_path)
+        parsed_dir = self._parsed_artifact_dir_for_source(source_path, file_path)
         parsed_dir.mkdir(parents=True, exist_ok=True)
 
         source_name = Path(file_path).name or f"{doc_id}.bin"
-        base_name = f"{doc_id}.{source_name}"
+        base_name = Path(source_name).stem or source_name
         blocks_path = parsed_dir / f"{base_name}.blocks.jsonl"
         tables_path = parsed_dir / f"{base_name}.tables.json"
         drawings_path = parsed_dir / f"{base_name}.drawings.json"
@@ -5342,7 +5363,7 @@ class LightRAG:
                 )
 
                 file_bytes = await asyncio.to_thread(p.read_bytes)
-                parsed_dir = self._parsed_dir_for_source(str(p))
+                parsed_dir = self._parsed_artifact_dir_for_source(str(p), file_path)
                 parsed_dir.mkdir(parents=True, exist_ok=True)
                 output_dir = str(parsed_dir)
                 interchange_text = await asyncio.to_thread(

--- a/tests/test_document_routes_docx_archive.py
+++ b/tests/test_document_routes_docx_archive.py
@@ -161,6 +161,7 @@ class _ParseRag:
     _persist_parsed_full_docs = LightRAG._persist_parsed_full_docs
     _input_dir_path = LightRAG._input_dir_path
     _parsed_dir_for_source = LightRAG._parsed_dir_for_source
+    _parsed_artifact_dir_for_source = LightRAG._parsed_artifact_dir_for_source
     _resolve_lightrag_document_path = LightRAG._resolve_lightrag_document_path
 
     def __init__(self, working_dir, source_path):
@@ -472,15 +473,16 @@ async def test_parse_native_archives_docx_after_full_docs_sync(tmp_path, monkeyp
     source_path = tmp_path / "parsed-after-sync.docx"
     source_path.write_bytes(b"docx bytes")
     rag = _ParseRag(tmp_path / "work", source_path)
+    observed_output_dirs = []
 
     parse_document = importlib.import_module("lightrag.extraction.parse_document")
+
+    def _fake_parse_docx(file_bytes, source_file, doc_id, output_dir):
+        observed_output_dirs.append(output_dir)
+        return '{"type":"meta"}\n{"type":"content","content":"parsed"}'
+
     monkeypatch.setattr(
-        parse_document,
-        "parse_docx_to_interchange_jsonl",
-        lambda file_bytes,
-        source_file,
-        doc_id,
-        output_dir: '{"type":"meta"}\n{"type":"content","content":"parsed"}',
+        parse_document, "parse_docx_to_interchange_jsonl", _fake_parse_docx
     )
 
     result = await LightRAG.parse_native(
@@ -494,7 +496,64 @@ async def test_parse_native_archives_docx_after_full_docs_sync(tmp_path, monkeyp
     assert rag.full_docs.events == ["upsert", "index_done"]
     assert not source_path.exists()
     assert (tmp_path / PARSED_DIR_NAME / source_path.name).exists()
+    assert observed_output_dirs == [
+        str(tmp_path / PARSED_DIR_NAME / f"{source_path.name}.parsed")
+    ]
+    assert (tmp_path / PARSED_DIR_NAME / f"{source_path.name}.parsed").is_dir()
     assert rag.full_docs.data["doc-test"]["parsed_engine"] == "native"
+
+
+def test_docx_interchange_assets_use_source_stem_under_output_dir(
+    tmp_path, monkeypatch
+):
+    parse_document = importlib.import_module("lightrag.extraction.parse_document")
+    output_dir = tmp_path / "demo.docx.parsed"
+
+    monkeypatch.setattr(
+        parse_document,
+        "extract_docx_images",
+        lambda _file_bytes: {"rId1": ("image1.png", b"image bytes")},
+    )
+    monkeypatch.setattr(
+        parse_document, "extract_docx_paragraphs", lambda _file_bytes: []
+    )
+    monkeypatch.setattr(parse_document, "smart_chunk", lambda _paragraphs: [])
+
+    result = parse_document.parse_docx_to_interchange_jsonl(
+        b"docx bytes",
+        source_file="demo.docx",
+        doc_id="doc-test",
+        output_dir=str(output_dir),
+    )
+
+    assert result
+    assert (output_dir / "demo.blocks.assets" / "image1.png").read_bytes() == (
+        b"image bytes"
+    )
+
+
+def test_parsed_artifact_dir_uses_unique_suffix_when_path_is_file(tmp_path):
+    source_path = tmp_path / "demo.docx"
+    parsed_dir = tmp_path / PARSED_DIR_NAME
+    parsed_dir.mkdir()
+    (parsed_dir / "demo.docx.parsed").write_text("legacy file", encoding="utf-8")
+    rag = _ParseRag(tmp_path / "work", source_path)
+
+    artifact_dir = LightRAG._parsed_artifact_dir_for_source(rag, str(source_path))
+
+    assert artifact_dir == parsed_dir / "demo.docx.parsed_001"
+
+
+def test_parsed_artifact_dir_reuses_existing_parsed_parent(tmp_path):
+    parsed_dir = tmp_path / PARSED_DIR_NAME
+    parsed_dir.mkdir()
+    source_path = parsed_dir / "demo.docx"
+    source_path.write_bytes(b"docx bytes")
+    rag = _ParseRag(tmp_path / "work", source_path)
+
+    artifact_dir = LightRAG._parsed_artifact_dir_for_source(rag, str(source_path))
+
+    assert artifact_dir == parsed_dir / "demo.docx.parsed"
 
 
 async def test_parse_native_docx_interchange_failure_raises_without_fallback(

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -879,10 +879,15 @@ def test_analyze_multimodal_without_image_uses_conservative_output(tmp_path):
 
 
 @pytest.mark.offline
-def test_write_lightrag_document_preserves_headings_and_table_dimensions(tmp_path):
+def test_write_lightrag_document_preserves_headings_and_table_dimensions(
+    tmp_path, monkeypatch
+):
     async def _run():
+        monkeypatch.setenv("INPUT_DIR", str(tmp_path))
         rag = _new_rag(tmp_path)
         await rag.initialize_storages()
+        source_path = tmp_path / "demo.docx"
+        source_path.write_bytes(b"docx bytes")
 
         content_list = [
             {"type": "section_header", "text": "第一章 绪论", "level": 1},
@@ -912,9 +917,15 @@ def test_write_lightrag_document_preserves_headings_and_table_dimensions(tmp_pat
             file_path="demo.docx",
             content_list=content_list,
             engine="docling",
+            source_path=str(source_path),
         )
 
         blocks_path = Path(parsed["blocks_path"])
+        assert blocks_path == (
+            tmp_path / PARSED_DIR_NAME / "demo.docx.parsed" / "demo.blocks.jsonl"
+        )
+        assert not source_path.exists()
+        assert (tmp_path / PARSED_DIR_NAME / source_path.name).exists()
         blocks = [
             json.loads(line)
             for line in blocks_path.read_text(encoding="utf-8").splitlines()
@@ -946,6 +957,11 @@ def test_write_lightrag_document_preserves_headings_and_table_dimensions(tmp_pat
 
         drawings = json.loads(Path(base + ".drawings.json").read_text(encoding="utf-8"))
         assert drawings["drawings"]["dr-doc-1-0001"]["heading"] == "1.1 研究背景"
+
+        full_doc = await rag.full_docs.get_by_id("doc-1")
+        assert full_doc["lightrag_document_path"] == (
+            "__parsed__/demo.docx.parsed/demo.blocks.jsonl"
+        )
 
         await rag.finalize_storages()
 


### PR DESCRIPTION
## Description

Isolate parsed LightRAG document artifacts into per-source `.parsed` directories so archived source files and generated blocks/assets do not collide under `__parsed__`.

## Related Issues

#XXXX

## Changes Made

- Write structured parser outputs to `__parsed__/<source-name>.parsed/`.
- Use source stems for generated block and DOCX asset names.
- Preserve existing parsed-directory behavior when source files already live under `__parsed__`.
- Add tests for DOCX archive output directories, asset paths, parsed directory suffixing, and stored relative document paths.
- Update Chinese file processing documentation for the parsed output layout.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Tested with:

```bash
./scripts/test.sh tests/test_document_routes_docx_archive.py tests/test_pipeline_release_closure.py
```
