### PR TITLE
Fix parser-hinted filename dedup

### DIFF
--- a/docs/FileProcessingConfiguration-zh.md
+++ b/docs/FileProcessingConfiguration-zh.md
@@ -90,8 +90,8 @@ DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
 
 | 字段 | 说明 |
 | --- | --- |
-| `file_path` | 文件名 basename（不含目录）。未提供有效来源时保存为 `unknown_source`；有效文件名的重复判定与内容溯源都基于该字段。 |
-| `source_path` | 入队时提供的原始路径（仅当与 `file_path` 不同才会写入），供 `native` / `mineru` / `docling` 解析器定位真实文件位置。 |
+| `file_path` | 文件名 basename（不含目录）。如果文件名带有支持的处理指引 hint，例如 `abc.[native].docx`，会先规范化为 `abc.docx` 后保存。未提供有效来源时保存为 `unknown_source`；有效文件名的重复判定与内容溯源都基于该字段。 |
+| `source_path` | 入队时提供的原始路径（仅当与规范化后的 `file_path` 不同才会写入），供 `native` / `mineru` / `docling` 解析器定位真实文件位置。 |
 | `format` | 内容格式：`pending_parse`, `raw`, `lightrag`。 |
 | `content` | `raw` 时保存抽取文本；`pending_parse` 时为空字符串；`lightrag` 时固定为以 `{{LRdoc}}`开头的一段内容摘要。 |
 | `content_hash` | 内容 MD5，用于跨文件名查重。`format=raw` 取 `sanitize_text_for_encoding` 后文本的 hash；`format=lightrag` 取 `*.blocks.jsonl` 文件 hash；`format=pending_parse` 不写入，待抽取完成后补上。 |
@@ -100,17 +100,18 @@ DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
 
 `pending_parse` 表示文件已经入队，但还没有完成抽取。抽取成功后会改写为 `raw` 或 `lightrag`，并补齐 `content_hash`。抽取失败时保留 `pending_parse` 和空 `content`，便于后续排查和重试。
 
-> `doc_status` 中也会同步保存 `file_path`（basename）与 `content_hash`，作为 `get_doc_by_file_basename` / `get_doc_by_content_hash` 的查重索引来源。
+> `doc_status` 中也会同步保存规范化后的 `file_path`（basename）与 `content_hash`，作为 `get_doc_by_file_basename` / `get_doc_by_content_hash` 的查重索引来源。
 
-## 分析结果目录结构
+## 内容提取结果目录结构
 
 `__parsed__` 是输入目录旁的归档与分析结果目录。它同时保存已经处理过的原始文档，以及结构化解析产生的 LightRAG Document 文件和图片等资源。
 
 - 原始文件归档：`legacy` 本地抽取成功并入队后，原文件会移动到同级 `__parsed__` 目录；`native` / `mineru` / `docling` 会先保留原文件供 pipeline 解析，解析成功并写入 `full_docs` 后再移动到 `__parsed__`。
-- 分析结果目录：结构化解析结果会写入以原始文件名加 `.parsed` 后缀命名的子目录，避免与归档原文件同名冲突。例如 `report.docx` 的分析结果目录为 `__parsed__/report.docx.parsed/`。
-- 分析结果文件：LightRAG Document blocks 文件使用原文件主干命名，例如 `__parsed__/report.docx.parsed/report.blocks.jsonl`；同一目录下还可能包含 `report.tables.json`、`report.drawings.json`、`report.equations.json` 和 `report.blocks.assets/` 图片资源目录。
+- 分析结果目录：结构化解析结果会写入以规范化文件名加 `.parsed` 后缀命名的子目录，避免与归档原文件同名冲突。例如 `report.docx` 的分析结果目录为 `__parsed__/report.docx.parsed/`；`report.[native].docx` 也会写入 `__parsed__/report.docx.parsed/`。
+- 分析结果文件：LightRAG Document blocks 文件使用规范化文件名的主干命名，例如 `__parsed__/report.docx.parsed/report.blocks.jsonl`；同一目录下还可能包含 `report.tables.json`、`report.drawings.json`、`report.equations.json` 和 `report.blocks.assets/` 图片资源目录。
 - 解析失败时，原文件不会移动，便于修复配置后重新处理。
 - `/documents/scan` 扫描到同名且已 `PROCESSED` 的文件时，该输入文件会被视为已处理并移动到 `__parsed__`，不会作为新文档入队。
+- `/documents/scan` 同一次扫描中发现多个规范化后同名的文件时，只会按排序处理第一个文件，其余文件会输出 warning 并移动到 `__parsed__`，避免同批文件互相覆盖。例如 `abc.docx` 和 `abc.[native].docx` 同时存在时只处理其中一个。
 - 扫描或解析过程中发现内容 hash 重复时，该输入文件同样会移动到 `__parsed__`；本次 `doc_status` 保留为 `FAILED duplicate` 以便追踪。
 - 移动文件只作用于当前输入文件，不会覆盖或移动既有文档源文件。若目标目录已存在同名文件，系统会自动追加 `_001`、`_002` 等编号，例如 `report.pdf` 会依次归档为 `report_001.pdf`、`report_002.pdf`。若分析结果目录名已被普通文件占用，也会追加编号，例如 `report.docx.parsed_001/`。
 
@@ -121,16 +122,16 @@ DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
 ### 1) 文件名（basename）查重
 
 - 判断粒度为 basename，不包含目录路径和 workspace 路径。例如 `/data/a.pdf`、`inputs/a.pdf` 和 `a.pdf` 都视为同一个文件名 `a.pdf`。
-- 文件名查重需要把文件名中的处理指引部分去掉，即认为 `abc.docx` 与 `abc.[native].docx` 是文件名重复。
+- 文件名查重会去掉文件名末尾的支持引擎处理指引 hint，即认为 `abc.docx` 与 `abc.[native].docx` 是文件名重复；不支持的 hint 不会被剥离，例如 `abc.[draft].docx` 仍按原文件名处理。
 - 对普通上传、文本接口和核心入队 API，只要 `doc_status` 中已经存在同名文件记录，无论该记录当前处于 `PENDING`、`PARSING`、`ANALYZING`、`PROCESSING`、`FAILED` 还是 `PROCESSED`，同名文件都会被视为重复。
 - 对 `/documents/scan` 目录扫描：
+  - 同一次扫描中如果有多个文件规范化后同名，只处理排序后的第一个文件，其余文件会归档到 `__parsed__` 并跳过。
   - 如果同名记录已经是 `PROCESSED`，当前扫描到的文件视为已处理文件，系统会输出 warning，将该输入文件移动到同级 `__parsed__` 目录，并跳过入队。
   - 如果同名记录不是 `PROCESSED`，当前扫描文件不会仅因文件名相同而跳过；系统会按新的扫描文件从头提取、入队并覆盖/重置未完成的同名状态。
 - 普通上传和核心入队 API 中，同名文件即使内容已经变化，也需要先删除旧文档记录后再重新上传或入队；扫描路径的非 `PROCESSED` 同名重处理只用于目录扫描自动恢复。
 - 文本接口必须提供有效的 `file_source`，并按 `file_source` 的 basename 判断重复；缺少有效 `file_source` 时直接返回 400。
 - 核心 API `insert` / `ainsert` / `apipeline_enqueue_documents` 仍兼容未传 `file_paths` 的调用；这类文档的 `file_path` 会保存为 `unknown_source`，不会参与文件名查重，文档 ID 继续按文本内容生成。
-- 为兼容遗留数据，空字符串、`no-file-path` 和 `unknown_source` 都会被视为未知来源；它们不会阻止新的无来源文本入队，也不会作为同名文件互相去重。
-- 遗留数据中如果存在多个有效 basename 相同的 `file_path`，系统不会自动合并或清理；后续再次入队同名文件时会命中第一条匹配记录并按重复处理，建议先删除或修正旧记录。
+- 空字符串、`no-file-path` 和 `unknown_source` 都会被视为未知来源；它们不会阻止新的无来源文本入队，也不会作为同名文件互相去重。
 
 存储后端通过 `get_doc_by_file_basename` 提供 basename 直查能力。`JsonDocStatusStorage` 已经实现了内存级遍历；其它后端目前回落到默认实现（扫描全部状态后比对 basename），将在后续 PR 中补齐原生索引。
 
@@ -148,4 +149,3 @@ DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
 - 存储后端通过 `get_doc_by_content_hash` 进行 hash 直查；命名约定与 `get_doc_by_file_basename` 一致。
 
 > 入队批次内（同一次 `apipeline_enqueue_documents` 调用）也会做 basename 与 content_hash 去重，命中时把后续条目直接写为 `FAILED` 并标记 `existing_status=batch_duplicate`。其中 basename 去重只对有效文件名生效；`unknown_source`、`no-file-path` 和空来源只参与内容 hash 去重。
-

--- a/docs/FileProcessingConfiguration-zh.md
+++ b/docs/FileProcessingConfiguration-zh.md
@@ -111,7 +111,7 @@ DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
 - 分析结果文件：LightRAG Document blocks 文件使用规范化文件名的主干命名，例如 `__parsed__/report.docx.parsed/report.blocks.jsonl`；同一目录下还可能包含 `report.tables.json`、`report.drawings.json`、`report.equations.json` 和 `report.blocks.assets/` 图片资源目录。
 - 解析失败时，原文件不会移动，便于修复配置后重新处理。
 - `/documents/scan` 扫描到同名且已 `PROCESSED` 的文件时，该输入文件会被视为已处理并移动到 `__parsed__`，不会作为新文档入队。
-- `/documents/scan` 同一次扫描中发现多个规范化后同名的文件时，只会按排序处理第一个文件，其余文件会输出 warning 并移动到 `__parsed__`，避免同批文件互相覆盖。例如 `abc.docx` 和 `abc.[native].docx` 同时存在时只处理其中一个。
+- `/documents/scan` 同一次扫描中发现多个规范化后同名的文件时，会优先保留带支持引擎 hint 的文件以尊重用户的引擎选择；如果没有任何变体带 hint，则按排序处理第一个文件。其余变体会输出 warning 并移动到 `__parsed__`，避免同批文件互相覆盖。例如 `abc.docx` 和 `abc.[native].docx` 同时存在时只会处理 `abc.[native].docx`。
 - 扫描或解析过程中发现内容 hash 重复时，该输入文件同样会移动到 `__parsed__`；本次 `doc_status` 保留为 `FAILED duplicate` 以便追踪。
 - 移动文件只作用于当前输入文件，不会覆盖或移动既有文档源文件。若目标目录已存在同名文件，系统会自动追加 `_001`、`_002` 等编号，例如 `report.pdf` 会依次归档为 `report_001.pdf`、`report_002.pdf`。若分析结果目录名已被普通文件占用，也会追加编号，例如 `report.docx.parsed_001/`。
 
@@ -125,7 +125,7 @@ DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
 - 文件名查重会去掉文件名末尾的支持引擎处理指引 hint，即认为 `abc.docx` 与 `abc.[native].docx` 是文件名重复；不支持的 hint 不会被剥离，例如 `abc.[draft].docx` 仍按原文件名处理。
 - 对普通上传、文本接口和核心入队 API，只要 `doc_status` 中已经存在同名文件记录，无论该记录当前处于 `PENDING`、`PARSING`、`ANALYZING`、`PROCESSING`、`FAILED` 还是 `PROCESSED`，同名文件都会被视为重复。
 - 对 `/documents/scan` 目录扫描：
-  - 同一次扫描中如果有多个文件规范化后同名，只处理排序后的第一个文件，其余文件会归档到 `__parsed__` 并跳过。
+  - 同一次扫描中如果有多个文件规范化后同名，优先处理带支持引擎 hint 的文件；若无任何 hint 变体，则处理排序后的第一个文件，其余文件会归档到 `__parsed__` 并跳过。
   - 如果同名记录已经是 `PROCESSED`，当前扫描到的文件视为已处理文件，系统会输出 warning，将该输入文件移动到同级 `__parsed__` 目录，并跳过入队。
   - 如果同名记录不是 `PROCESSED`，当前扫描文件不会仅因文件名相同而跳过；系统会按新的扫描文件从头提取、入队并覆盖/重置未完成的同名状态。
 - 普通上传和核心入队 API 中，同名文件即使内容已经变化，也需要先删除旧文档记录后再重新上传或入队；扫描路径的非 `PROCESSED` 同名重处理只用于目录扫描自动恢复。

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -4,6 +4,7 @@ This module contains all document-related routes for the LightRAG API.
 
 import asyncio
 import re
+import shutil
 import time
 from uuid import uuid4
 from lightrag.utils import logger, get_pinyin_sort_key, performance_timing_log
@@ -1000,6 +1001,17 @@ def canonicalize_archived_file_variant_basename(
     return normalize_file_path(f"{stem}{path.suffix}")
 
 
+def _canonical_basename_for_parsed_artifact_dir(dir_name: str) -> str | None:
+    """Return the canonical source basename for a `<basename>.parsed[_NNN]` dir."""
+    stripped = ARCHIVED_FILE_SUFFIX_RE.sub("", dir_name)
+    if not stripped.endswith(".parsed"):
+        return None
+    basename = stripped[: -len(".parsed")]
+    if not basename:
+        return None
+    return normalize_file_path(basename)
+
+
 def delete_file_variants_by_canonical_basename(
     input_dir: Path,
     file_path: str | None,
@@ -1030,33 +1042,60 @@ def delete_file_variants_by_canonical_basename(
             errors.append(f"Failed to scan {candidate_dir}: {e}")
             continue
 
+        in_parsed_dir = candidate_dir.name == PARSED_DIR_NAME
         for candidate in candidates:
-            if not candidate.is_file():
-                continue
             if candidate in seen_paths:
                 continue
-            if (
-                canonicalize_archived_file_variant_basename(
-                    candidate.name,
-                    strip_archive_suffix=candidate_dir.name == PARSED_DIR_NAME,
+
+            if candidate.is_file():
+                if (
+                    canonicalize_archived_file_variant_basename(
+                        candidate.name,
+                        strip_archive_suffix=in_parsed_dir,
+                    )
+                    not in canonical_names
+                ):
+                    continue
+
+                safe_candidate = validate_file_path_security(
+                    candidate.name, candidate_dir
                 )
-                not in canonical_names
-            ):
+                if safe_candidate is None:
+                    errors.append(f"Unsafe file path skipped: {candidate.name}")
+                    continue
+
+                try:
+                    safe_candidate.unlink()
+                    seen_paths.add(candidate)
+                    deleted_files.append(
+                        str(safe_candidate.relative_to(input_dir_resolved))
+                    )
+                except Exception as e:
+                    errors.append(f"Failed to delete {candidate.name}: {e}")
                 continue
 
-            safe_candidate = validate_file_path_security(candidate.name, candidate_dir)
-            if safe_candidate is None:
-                errors.append(f"Unsafe file path skipped: {candidate.name}")
-                continue
-
-            try:
-                safe_candidate.unlink()
-                seen_paths.add(candidate)
-                deleted_files.append(
-                    str(safe_candidate.relative_to(input_dir_resolved))
+            if in_parsed_dir and candidate.is_dir():
+                canonical_for_dir = _canonical_basename_for_parsed_artifact_dir(
+                    candidate.name
                 )
-            except Exception as e:
-                errors.append(f"Failed to delete {candidate.name}: {e}")
+                if canonical_for_dir is None or canonical_for_dir not in canonical_names:
+                    continue
+
+                safe_candidate = validate_file_path_security(
+                    candidate.name, candidate_dir
+                )
+                if safe_candidate is None:
+                    errors.append(f"Unsafe artifact dir skipped: {candidate.name}")
+                    continue
+
+                try:
+                    shutil.rmtree(safe_candidate)
+                    seen_paths.add(candidate)
+                    deleted_files.append(
+                        str(safe_candidate.relative_to(input_dir_resolved))
+                    )
+                except Exception as e:
+                    errors.append(f"Failed to delete artifact dir {candidate.name}: {e}")
 
     return deleted_files, errors
 

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -3,6 +3,7 @@ This module contains all document-related routes for the LightRAG API.
 """
 
 import asyncio
+import re
 import time
 from uuid import uuid4
 from lightrag.utils import logger, get_pinyin_sort_key, performance_timing_log
@@ -75,6 +76,7 @@ router = APIRouter(
 temp_prefix = "__tmp__"
 UNKNOWN_FILE_SOURCE = "unknown_source"
 LEGACY_EMPTY_FILE_PATH_SENTINELS = {"", "no-file-path"}
+ARCHIVED_FILE_SUFFIX_RE = re.compile(r"_(?:\d{3}|\d{10,})$")
 
 
 def normalize_file_path(file_path: str | None) -> str:
@@ -982,6 +984,81 @@ def find_existing_file_by_canonical_basename(
     except FileNotFoundError:
         return None
     return None
+
+
+def canonicalize_archived_file_variant_basename(
+    file_path: Path | str, *, strip_archive_suffix: bool = False
+) -> str:
+    """Canonical basename for original files and numbered archive variants."""
+    name = Path(file_path).name
+    path = Path(name)
+    stem = (
+        ARCHIVED_FILE_SUFFIX_RE.sub("", path.stem)
+        if strip_archive_suffix
+        else path.stem
+    )
+    return normalize_file_path(f"{stem}{path.suffix}")
+
+
+def delete_file_variants_by_canonical_basename(
+    input_dir: Path,
+    file_path: str | None,
+    source_path: str | None = None,
+) -> tuple[list[str], list[str]]:
+    """Delete input/__parsed__ source files matching a canonical basename."""
+    source_names = [source_path, file_path]
+    canonical_names = {
+        normalize_file_path(source)
+        for source in source_names
+        if source and normalize_file_path(source) != UNKNOWN_FILE_SOURCE
+    }
+    if not canonical_names:
+        return [], []
+
+    deleted_files: list[str] = []
+    errors: list[str] = []
+    seen_paths: set[Path] = set()
+    candidate_dirs = [input_dir, input_dir / PARSED_DIR_NAME]
+    input_dir_resolved = input_dir.resolve()
+
+    for candidate_dir in candidate_dirs:
+        try:
+            candidates = list(candidate_dir.iterdir())
+        except FileNotFoundError:
+            continue
+        except Exception as e:
+            errors.append(f"Failed to scan {candidate_dir}: {e}")
+            continue
+
+        for candidate in candidates:
+            if not candidate.is_file():
+                continue
+            if candidate in seen_paths:
+                continue
+            if (
+                canonicalize_archived_file_variant_basename(
+                    candidate.name,
+                    strip_archive_suffix=candidate_dir.name == PARSED_DIR_NAME,
+                )
+                not in canonical_names
+            ):
+                continue
+
+            safe_candidate = validate_file_path_security(candidate.name, candidate_dir)
+            if safe_candidate is None:
+                errors.append(f"Unsafe file path skipped: {candidate.name}")
+                continue
+
+            try:
+                safe_candidate.unlink()
+                seen_paths.add(candidate)
+                deleted_files.append(
+                    str(safe_candidate.relative_to(input_dir_resolved))
+                )
+            except Exception as e:
+                errors.append(f"Failed to delete {candidate.name}: {e}")
+
+    return deleted_files, errors
 
 
 async def record_scan_warning(rag: LightRAG, message: str) -> None:
@@ -1979,95 +2056,46 @@ async def background_delete_documents(
                     async with pipeline_status_lock:
                         pipeline_status["history_messages"].append(success_msg)
 
-                    # Handle file deletion if requested and file_path is available
-                    if (
-                        delete_file
-                        and result.file_path
-                        and result.file_path != "unknown_source"
+                    # Handle file deletion if requested and source information is available
+                    result_source_path = getattr(result, "source_path", None)
+                    if delete_file and (
+                        (result.file_path and result.file_path != UNKNOWN_FILE_SOURCE)
+                        or result_source_path
                     ):
                         try:
-                            deleted_files = []
-                            # SECURITY FIX: Use secure path validation to prevent arbitrary file deletion
-                            safe_file_path = validate_file_path_security(
-                                result.file_path, doc_manager.input_dir
+                            deleted_files, file_delete_errors = (
+                                delete_file_variants_by_canonical_basename(
+                                    doc_manager.input_dir,
+                                    result.file_path,
+                                    result_source_path,
+                                )
                             )
-
-                            if safe_file_path is None:
-                                # Security violation detected - log and skip file deletion
-                                security_msg = f"Security violation: Unsafe file path detected for deletion - {result.file_path}"
-                                logger.warning(security_msg)
+                            for file_delete_error in file_delete_errors:
+                                logger.warning(file_delete_error)
                                 async with pipeline_status_lock:
-                                    pipeline_status["latest_message"] = security_msg
+                                    pipeline_status["latest_message"] = (
+                                        file_delete_error
+                                    )
                                     pipeline_status["history_messages"].append(
-                                        security_msg
+                                        file_delete_error
+                                    )
+
+                            if deleted_files:
+                                file_delete_msg = (
+                                    "Successfully deleted source files: "
+                                    + ", ".join(deleted_files)
+                                )
+                                logger.info(file_delete_msg)
+                                async with pipeline_status_lock:
+                                    pipeline_status["latest_message"] = file_delete_msg
+                                    pipeline_status["history_messages"].append(
+                                        file_delete_msg
                                     )
                             else:
-                                # check and delete files from input_dir directory
-                                if safe_file_path.exists():
-                                    try:
-                                        safe_file_path.unlink()
-                                        deleted_files.append(safe_file_path.name)
-                                        file_delete_msg = f"Successfully deleted input_dir file: {result.file_path}"
-                                        logger.info(file_delete_msg)
-                                        async with pipeline_status_lock:
-                                            pipeline_status["latest_message"] = (
-                                                file_delete_msg
-                                            )
-                                            pipeline_status["history_messages"].append(
-                                                file_delete_msg
-                                            )
-                                    except Exception as file_error:
-                                        file_error_msg = f"Failed to delete input_dir file {result.file_path}: {str(file_error)}"
-                                        logger.debug(file_error_msg)
-                                        async with pipeline_status_lock:
-                                            pipeline_status["latest_message"] = (
-                                                file_error_msg
-                                            )
-                                            pipeline_status["history_messages"].append(
-                                                file_error_msg
-                                            )
-
-                                # Also check and delete files from __parsed__ directory
-                                enqueued_dir = doc_manager.input_dir / PARSED_DIR_NAME
-                                if enqueued_dir.exists():
-                                    # SECURITY FIX: Validate that the file path is safe before processing
-                                    # Only proceed if the original path validation passed
-                                    base_name = Path(result.file_path).stem
-                                    extension = Path(result.file_path).suffix
-
-                                    # Search for exact match and files with numeric suffixes
-                                    for enqueued_file in enqueued_dir.glob(
-                                        f"{base_name}*{extension}"
-                                    ):
-                                        # Additional security check: ensure enqueued file is within enqueued directory
-                                        safe_enqueued_path = (
-                                            validate_file_path_security(
-                                                enqueued_file.name, enqueued_dir
-                                            )
-                                        )
-                                        if safe_enqueued_path is not None:
-                                            try:
-                                                enqueued_file.unlink()
-                                                deleted_files.append(enqueued_file.name)
-                                                logger.info(
-                                                    f"Successfully deleted enqueued file: {enqueued_file.name}"
-                                                )
-                                            except Exception as enqueued_error:
-                                                file_error_msg = f"Failed to delete enqueued file {enqueued_file.name}: {str(enqueued_error)}"
-                                                logger.debug(file_error_msg)
-                                                async with pipeline_status_lock:
-                                                    pipeline_status[
-                                                        "latest_message"
-                                                    ] = file_error_msg
-                                                    pipeline_status[
-                                                        "history_messages"
-                                                    ].append(file_error_msg)
-                                        else:
-                                            security_msg = f"Security violation: Unsafe enqueued file path detected - {enqueued_file.name}"
-                                            logger.warning(security_msg)
-
-                            if deleted_files == []:
-                                file_error_msg = f"File deletion skipped, missing or unsafe file: {result.file_path}"
+                                file_error_msg = (
+                                    "File deletion skipped, missing or unsafe file: "
+                                    f"{result.file_path or result_source_path}"
+                                )
                                 logger.warning(file_error_msg)
                                 async with pipeline_status_lock:
                                     pipeline_status["latest_message"] = file_error_msg

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -33,6 +33,7 @@ from lightrag.constants import (
 )
 from lightrag.parser_routing import (
     canonicalize_parser_hinted_basename,
+    filename_parser_hint,
     resolve_file_parser_engine,
 )
 from lightrag.utils import (
@@ -1029,7 +1030,6 @@ def delete_file_variants_by_canonical_basename(
 
     deleted_files: list[str] = []
     errors: list[str] = []
-    seen_paths: set[Path] = set()
     candidate_dirs = [input_dir, input_dir / PARSED_DIR_NAME]
     input_dir_resolved = input_dir.resolve()
 
@@ -1044,9 +1044,6 @@ def delete_file_variants_by_canonical_basename(
 
         in_parsed_dir = candidate_dir.name == PARSED_DIR_NAME
         for candidate in candidates:
-            if candidate in seen_paths:
-                continue
-
             if candidate.is_file():
                 if (
                     canonicalize_archived_file_variant_basename(
@@ -1066,7 +1063,6 @@ def delete_file_variants_by_canonical_basename(
 
                 try:
                     safe_candidate.unlink()
-                    seen_paths.add(candidate)
                     deleted_files.append(
                         str(safe_candidate.relative_to(input_dir_resolved))
                     )
@@ -1078,7 +1074,10 @@ def delete_file_variants_by_canonical_basename(
                 canonical_for_dir = _canonical_basename_for_parsed_artifact_dir(
                     candidate.name
                 )
-                if canonical_for_dir is None or canonical_for_dir not in canonical_names:
+                if (
+                    canonical_for_dir is None
+                    or canonical_for_dir not in canonical_names
+                ):
                     continue
 
                 safe_candidate = validate_file_path_security(
@@ -1090,12 +1089,13 @@ def delete_file_variants_by_canonical_basename(
 
                 try:
                     shutil.rmtree(safe_candidate)
-                    seen_paths.add(candidate)
                     deleted_files.append(
                         str(safe_candidate.relative_to(input_dir_resolved))
                     )
                 except Exception as e:
-                    errors.append(f"Failed to delete artifact dir {candidate.name}: {e}")
+                    errors.append(
+                        f"Failed to delete artifact dir {candidate.name}: {e}"
+                    )
 
     return deleted_files, errors
 
@@ -1914,30 +1914,41 @@ async def run_scanning_process(
         logger.info(f"Found {total_files} files to index.")
 
         if new_files:
-            unique_files = []
-            files_by_canonical_name: dict[str, Path] = {}
+            # Group canonical-equivalent files so we can prefer hint-bearing
+            # variants over plain ones. Within each group sort order is
+            # preserved as a deterministic tiebreaker.
+            files_by_canonical_name: dict[str, list[Path]] = {}
             for file_path in sorted(
                 new_files, key=lambda p: get_pinyin_sort_key(str(p))
             ):
                 canonical_name = normalize_file_path(str(file_path))
-                first_file = files_by_canonical_name.get(canonical_name)
-                if first_file is None:
-                    files_by_canonical_name[canonical_name] = file_path
-                    unique_files.append(file_path)
-                    continue
+                files_by_canonical_name.setdefault(canonical_name, []).append(file_path)
 
-                warning = (
-                    "Skipping duplicate file in scan batch: "
-                    f"{file_path.name} duplicates {first_file.name} "
-                    f"(canonical: {canonical_name})"
+            unique_files: list[Path] = []
+            for canonical_name, group in files_by_canonical_name.items():
+                # Prefer the first file carrying a supported parser hint so
+                # the user's explicit engine choice wins over plain variants;
+                # otherwise fall back to the first sorted entry.
+                chosen = next(
+                    (f for f in group if filename_parser_hint(f.name) is not None),
+                    group[0],
                 )
-                await record_scan_warning(rag, warning)
-                try:
-                    await move_file_to_parsed_dir(file_path)
-                except Exception as move_error:
-                    logger.error(
-                        f"Failed to move duplicate scan file {file_path.name} to {PARSED_DIR_NAME}: {move_error}"
+                unique_files.append(chosen)
+                for duplicate in group:
+                    if duplicate is chosen:
+                        continue
+                    warning = (
+                        "Skipping duplicate file in scan batch: "
+                        f"{duplicate.name} duplicates {chosen.name} "
+                        f"(canonical: {canonical_name})"
                     )
+                    await record_scan_warning(rag, warning)
+                    try:
+                        await move_file_to_parsed_dir(duplicate)
+                    except Exception as move_error:
+                        logger.error(
+                            f"Failed to move duplicate scan file {duplicate.name} to {PARSED_DIR_NAME}: {move_error}"
+                        )
 
             # Check for files with PROCESSED status and filter them out
             valid_files = []

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -29,7 +29,10 @@ from lightrag.constants import (
     PARSER_ENGINE_LEGACY,
     PARSED_DIR_NAME,
 )
-from lightrag.parser_routing import resolve_file_parser_engine
+from lightrag.parser_routing import (
+    canonicalize_parser_hinted_basename,
+    resolve_file_parser_engine,
+)
 from lightrag.utils import (
     generate_track_id,
     move_file_to_parsed_dir,
@@ -83,7 +86,7 @@ def normalize_file_path(file_path: str | None) -> str:
     if normalized in LEGACY_EMPTY_FILE_PATH_SENTINELS:
         return UNKNOWN_FILE_SOURCE
 
-    return Path(normalized).name or UNKNOWN_FILE_SOURCE
+    return canonicalize_parser_hinted_basename(normalized) or UNKNOWN_FILE_SOURCE
 
 
 def is_valid_file_source(file_source: str | None) -> bool:
@@ -953,7 +956,7 @@ def get_doc_track_id(doc_status: Any) -> str:
 async def get_existing_doc_by_file_path_candidates(
     doc_status: Any, file_path: Path | str
 ) -> dict[str, Any] | None:
-    """Find an existing document by file basename via the storage backend."""
+    """Find an existing document by canonical basename."""
     basename = normalize_file_path(str(file_path))
     if basename == UNKNOWN_FILE_SOURCE:
         return None
@@ -962,6 +965,23 @@ async def get_existing_doc_by_file_path_candidates(
         return None
     _, existing_doc_data = match
     return existing_doc_data
+
+
+def find_existing_file_by_canonical_basename(
+    input_dir: Path, canonical_basename: str
+) -> Path | None:
+    """Find an input-dir file whose canonical basename matches."""
+    if not canonical_basename or canonical_basename == UNKNOWN_FILE_SOURCE:
+        return None
+    try:
+        for candidate in input_dir.iterdir():
+            if not candidate.is_file():
+                continue
+            if normalize_file_path(candidate.name) == canonical_basename:
+                return candidate
+    except FileNotFoundError:
+        return None
+    return None
 
 
 async def record_scan_warning(rag: LightRAG, message: str) -> None:
@@ -1778,11 +1798,35 @@ async def run_scanning_process(
         logger.info(f"Found {total_files} files to index.")
 
         if new_files:
+            unique_files = []
+            files_by_canonical_name: dict[str, Path] = {}
+            for file_path in sorted(
+                new_files, key=lambda p: get_pinyin_sort_key(str(p))
+            ):
+                canonical_name = normalize_file_path(str(file_path))
+                first_file = files_by_canonical_name.get(canonical_name)
+                if first_file is None:
+                    files_by_canonical_name[canonical_name] = file_path
+                    unique_files.append(file_path)
+                    continue
+
+                warning = (
+                    "Skipping duplicate file in scan batch: "
+                    f"{file_path.name} duplicates {first_file.name}"
+                )
+                await record_scan_warning(rag, warning)
+                try:
+                    await move_file_to_parsed_dir(file_path)
+                except Exception as move_error:
+                    logger.error(
+                        f"Failed to move duplicate scan file {file_path.name} to {PARSED_DIR_NAME}: {move_error}"
+                    )
+
             # Check for files with PROCESSED status and filter them out
             valid_files = []
             processed_files = []
 
-            for file_path in new_files:
+            for file_path in unique_files:
                 filename = file_path.name
                 existing_doc_data = await get_existing_doc_by_file_path_candidates(
                     rag.doc_status, file_path
@@ -2233,8 +2277,12 @@ def create_document_routes(
                     track_id=existing_track_id,
                 )
 
-            # Check if file already exists in file system
-            if file_path.exists():
+            # Check if file already exists in file system, using canonical parser-hint names.
+            canonical_filename = normalize_file_path(safe_filename)
+            existing_input_file = find_existing_file_by_canonical_basename(
+                doc_manager.input_dir, canonical_filename
+            )
+            if existing_input_file:
                 return InsertResponse(
                     status="duplicated",
                     message=f"File '{safe_filename}' already exists in the input directory.",

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -1812,7 +1812,8 @@ async def run_scanning_process(
 
                 warning = (
                     "Skipping duplicate file in scan batch: "
-                    f"{file_path.name} duplicates {first_file.name}"
+                    f"{file_path.name} duplicates {first_file.name} "
+                    f"(canonical: {canonical_name})"
                 )
                 await record_scan_warning(rag, warning)
                 try:
@@ -2278,10 +2279,14 @@ def create_document_routes(
                 )
 
             # Check if file already exists in file system, using canonical parser-hint names.
+            # Fast path: exact filename match avoids iterdir on large input directories.
             canonical_filename = normalize_file_path(safe_filename)
-            existing_input_file = find_existing_file_by_canonical_basename(
-                doc_manager.input_dir, canonical_filename
-            )
+            if file_path.exists():
+                existing_input_file: Path | None = file_path
+            else:
+                existing_input_file = find_existing_file_by_canonical_basename(
+                    doc_manager.input_dir, canonical_filename
+                )
             if existing_input_file:
                 return InsertResponse(
                     status="duplicated",

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -999,6 +999,7 @@ class DeletionResult:
     message: str
     status_code: int = 200
     file_path: str | None = None
+    source_path: str | None = None
 
 
 # Unified Query Result Data Structures for Reference List Support

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -6821,6 +6821,7 @@ class LightRAG:
         deletion_stage = "initializing"
         doc_status_data: dict[str, Any] | None = None
         file_path: str | None = None
+        source_path: str | None = None
 
         async with pipeline_status_lock:
             log_message = f"Starting deletion process for document {doc_id}"
@@ -6832,6 +6833,9 @@ class LightRAG:
             # 1. Get the document status and related data
             doc_status_data = await self.doc_status.get_by_id(doc_id)
             file_path = doc_status_data.get("file_path") if doc_status_data else None
+            full_doc_data = await self.full_docs.get_by_id(doc_id) or {}
+            if isinstance(full_doc_data, dict):
+                source_path = full_doc_data.get("source_path")
             if not doc_status_data:
                 logger.warning(f"Document {doc_id} not found")
                 return DeletionResult(
@@ -6964,6 +6968,7 @@ class LightRAG:
                     message=log_message,
                     status_code=200,
                     file_path=file_path,
+                    source_path=source_path,
                 )
 
             # Mark that deletion operations have started
@@ -7547,6 +7552,7 @@ class LightRAG:
                 message=log_message,
                 status_code=200,
                 file_path=file_path,
+                source_path=source_path,
             )
 
         except Exception as e:
@@ -7585,6 +7591,7 @@ class LightRAG:
                 message=error_message,
                 status_code=500,
                 file_path=file_path,
+                source_path=source_path,
             )
 
         finally:

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -6832,10 +6832,6 @@ class LightRAG:
         try:
             # 1. Get the document status and related data
             doc_status_data = await self.doc_status.get_by_id(doc_id)
-            file_path = doc_status_data.get("file_path") if doc_status_data else None
-            full_doc_data = await self.full_docs.get_by_id(doc_id) or {}
-            if isinstance(full_doc_data, dict):
-                source_path = full_doc_data.get("source_path")
             if not doc_status_data:
                 logger.warning(f"Document {doc_id} not found")
                 return DeletionResult(
@@ -6845,6 +6841,10 @@ class LightRAG:
                     status_code=404,
                     file_path="",
                 )
+            file_path = doc_status_data.get("file_path")
+            full_doc_data = await self.full_docs.get_by_id(doc_id)
+            if isinstance(full_doc_data, dict):
+                source_path = full_doc_data.get("source_path")
 
             # Check document status and log warning for non-completed documents
             raw_status = doc_status_data.get("status")

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -146,7 +146,10 @@ from lightrag.utils import (
 from lightrag.types import KnowledgeGraph
 from dotenv import load_dotenv
 from lightrag.extraction.interchange import parse_interchange_jsonl
-from lightrag.parser_routing import resolve_stored_document_parser_engine
+from lightrag.parser_routing import (
+    canonicalize_parser_hinted_basename,
+    resolve_stored_document_parser_engine,
+)
 
 # use the .env that is inside the current folder
 # allows to use different .env file for each lightrag instance
@@ -223,7 +226,7 @@ def _document_source_key(file_path: Any) -> str:
     source = str(file_path or "").strip()
     if source in PLACEHOLDER_DOCUMENT_SOURCES:
         return "unknown_source"
-    filename = Path(source).name.strip()
+    filename = canonicalize_parser_hinted_basename(source).strip()
     if filename in PLACEHOLDER_DOCUMENT_SOURCES:
         return "unknown_source"
     return filename or "unknown_source"
@@ -294,9 +297,8 @@ async def _get_existing_doc_by_file_basename(
 ) -> tuple[str, Any] | None:
     """Find an existing doc_status record by file basename.
 
-    Delegates to the storage backend's basename index when available so the
-    lookup avoids scanning every record. Backends without a native index fall
-    back to the default scan implemented in DocStatusStorage.
+    Parser hints are canonicalized before lookup, so storage backends only need
+    to compare stored values.
     """
     basename = _document_source_key(file_path)
     if basename == "unknown_source":
@@ -4824,7 +4826,10 @@ class LightRAG:
         self, source_path: str | None = None, file_path: str | None = None
     ) -> Path:
         parsed_dir = self._parsed_dir_for_source(source_path)
-        source_name = Path(source_path or file_path or "document").name or "document"
+        source_name = (
+            canonicalize_parser_hinted_basename(source_path or file_path or "document")
+            or "document"
+        )
         artifact_name = f"{source_name}.parsed"
         artifact_dir = parsed_dir / artifact_name
         if not artifact_dir.exists() or artifact_dir.is_dir():
@@ -4907,7 +4912,7 @@ class LightRAG:
         parsed_dir = self._parsed_artifact_dir_for_source(source_path, file_path)
         parsed_dir.mkdir(parents=True, exist_ok=True)
 
-        source_name = Path(file_path).name or f"{doc_id}.bin"
+        source_name = canonicalize_parser_hinted_basename(file_path) or f"{doc_id}.bin"
         base_name = Path(source_name).stem or source_name
         blocks_path = parsed_dir / f"{base_name}.blocks.jsonl"
         tables_path = parsed_dir / f"{base_name}.tables.json"

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -297,8 +297,10 @@ async def _get_existing_doc_by_file_basename(
 ) -> tuple[str, Any] | None:
     """Find an existing doc_status record by file basename.
 
-    Parser hints are canonicalized before lookup, so storage backends only need
-    to compare stored values.
+    Both write and lookup paths feed file_path through ``_document_source_key``
+    first, so stored basenames are already canonical (parser hints stripped).
+    Storage backends therefore compare canonical-vs-canonical and do not need
+    to re-run any normalization themselves.
     """
     basename = _document_source_key(file_path)
     if basename == "unknown_source":

--- a/lightrag/parser_routing.py
+++ b/lightrag/parser_routing.py
@@ -24,6 +24,12 @@ _PARSER_ENGINE_ENDPOINT_ENV = {
     PARSER_ENGINE_DOCLING: "DOCLING_ENDPOINT",
 }
 
+# Trailing parser-hint pattern: matches ``.[engine].ext`` at end of basename.
+# Group 1 captures the raw engine token (still needs normalize_parser_engine
+# and SUPPORTED_PARSER_ENGINES validation); group 2 captures ``.ext`` so it
+# can be reattached when stripping the hint.
+_PARSER_HINT_RE = re.compile(r"\.\[([^\]]+)\](\.[^.]+)$")
+
 
 class ParserRoutingConfigError(ValueError):
     """Raised when LIGHTRAG_PARSER contains an invalid routing rule."""
@@ -67,7 +73,7 @@ def _engine_is_usable(
 
 
 def filename_parser_hint(file_path: str | Path) -> str | None:
-    m = re.search(r"\.\[([^\]]+)\]\.[^.]+$", Path(file_path).name)
+    m = _PARSER_HINT_RE.search(Path(file_path).name)
     if not m:
         return None
     engine = normalize_parser_engine(m.group(1))
@@ -83,7 +89,7 @@ def canonicalize_parser_hinted_basename(file_path: str | Path) -> str:
     ``name.[native].pdf`` — additional outer hints are not unwrapped.
     """
     basename = Path(file_path).name
-    m = re.search(r"\.\[([^\]]+)\](\.[^.]+)$", basename)
+    m = _PARSER_HINT_RE.search(basename)
     if not m:
         return basename
     engine = normalize_parser_engine(m.group(1))

--- a/lightrag/parser_routing.py
+++ b/lightrag/parser_routing.py
@@ -77,8 +77,10 @@ def filename_parser_hint(file_path: str | Path) -> str | None:
 def canonicalize_parser_hinted_basename(file_path: str | Path) -> str:
     """Return basename with a supported parser hint removed.
 
-    Only the final ``.[engine].ext`` segment is stripped, and only when the
-    bracketed value normalizes to a supported parser engine.
+    Only the final ``.[engine].ext`` segment is stripped, exactly once, and
+    only when the bracketed value normalizes to a supported parser engine.
+    Nested hints such as ``name.[native].[mineru].pdf`` therefore become
+    ``name.[native].pdf`` — additional outer hints are not unwrapped.
     """
     basename = Path(file_path).name
     m = re.search(r"\.\[([^\]]+)\](\.[^.]+)$", basename)

--- a/lightrag/parser_routing.py
+++ b/lightrag/parser_routing.py
@@ -74,6 +74,22 @@ def filename_parser_hint(file_path: str | Path) -> str | None:
     return engine if engine in SUPPORTED_PARSER_ENGINES else None
 
 
+def canonicalize_parser_hinted_basename(file_path: str | Path) -> str:
+    """Return basename with a supported parser hint removed.
+
+    Only the final ``.[engine].ext`` segment is stripped, and only when the
+    bracketed value normalizes to a supported parser engine.
+    """
+    basename = Path(file_path).name
+    m = re.search(r"\.\[([^\]]+)\](\.[^.]+)$", basename)
+    if not m:
+        return basename
+    engine = normalize_parser_engine(m.group(1))
+    if engine not in SUPPORTED_PARSER_ENGINES:
+        return basename
+    return f"{basename[: m.start()]}{m.group(2)}"
+
+
 def parser_rules_from_env() -> str:
     return os.getenv("LIGHTRAG_PARSER", "").strip()
 

--- a/tests/test_document_routes_docx_archive.py
+++ b/tests/test_document_routes_docx_archive.py
@@ -572,9 +572,16 @@ def test_delete_file_variants_removes_canonical_hint_variants(tmp_path):
     ]
     for path in unrelated_files:
         path.write_bytes(b"keep me")
-    artifact_dir = parsed_dir / "report.docx.parsed"
-    artifact_dir.mkdir()
-    (artifact_dir / "report.blocks.jsonl").write_text("{}", encoding="utf-8")
+    artifact_dirs = [
+        parsed_dir / "report.docx.parsed",
+        parsed_dir / "report.docx.parsed_001",
+    ]
+    for artifact_dir in artifact_dirs:
+        artifact_dir.mkdir()
+        (artifact_dir / "report.blocks.jsonl").write_text("{}", encoding="utf-8")
+    unrelated_artifact_dir = parsed_dir / "other.docx.parsed"
+    unrelated_artifact_dir.mkdir()
+    (unrelated_artifact_dir / "other.blocks.jsonl").write_text("{}", encoding="utf-8")
 
     deleted_files, errors = _document_routes.delete_file_variants_by_canonical_basename(
         tmp_path,
@@ -589,10 +596,13 @@ def test_delete_file_variants_removes_canonical_hint_variants(tmp_path):
         str(Path(PARSED_DIR_NAME) / "report.[mineru].docx"),
         str(Path(PARSED_DIR_NAME) / "report.[native]_001.docx"),
         str(Path(PARSED_DIR_NAME) / "report_001.docx"),
+        str(Path(PARSED_DIR_NAME) / "report.docx.parsed"),
+        str(Path(PARSED_DIR_NAME) / "report.docx.parsed_001"),
     }
     assert all(not path.exists() for path in files_to_delete)
     assert all(path.exists() for path in unrelated_files)
-    assert artifact_dir.is_dir()
+    assert all(not artifact_dir.exists() for artifact_dir in artifact_dirs)
+    assert unrelated_artifact_dir.is_dir()
 
 
 async def test_background_delete_removes_parser_hint_file_variants(tmp_path):

--- a/tests/test_document_routes_docx_archive.py
+++ b/tests/test_document_routes_docx_archive.py
@@ -1,7 +1,9 @@
 import importlib
 import sys
 from io import BytesIO
+from pathlib import Path
 from types import SimpleNamespace
+from uuid import uuid4
 
 import pytest
 
@@ -15,6 +17,7 @@ _utils = importlib.import_module("lightrag.utils")
 sys.argv = _original_argv
 
 DocStatus = _base.DocStatus
+DeletionResult = _base.DeletionResult
 FULL_DOCS_FORMAT_LIGHTRAG = _constants.FULL_DOCS_FORMAT_LIGHTRAG
 FULL_DOCS_FORMAT_PENDING_PARSE = _constants.FULL_DOCS_FORMAT_PENDING_PARSE
 PARSED_DIR_NAME = _constants.PARSED_DIR_NAME
@@ -116,6 +119,20 @@ class _ScanRag:
 class _DuplicateUploadRag:
     def __init__(self, docs_by_path):
         self.doc_status = _ScanDocStatus(docs_by_path)
+
+
+class _DeleteRag:
+    def __init__(self, result):
+        self.result = result
+        self.workspace = f"delete-test-{uuid4().hex}"
+        self.deleted_doc_ids = []
+
+    async def adelete_by_doc_id(self, doc_id, delete_llm_cache=False):
+        self.deleted_doc_ids.append((doc_id, delete_llm_cache))
+        return self.result
+
+    async def apipeline_process_enqueue_documents(self):
+        return None
 
 
 class _ArchiveFailureRag:
@@ -534,6 +551,85 @@ async def test_upload_rejects_parser_hinted_filesystem_duplicate(tmp_path, monke
     assert response.status == "duplicated"
     assert response.track_id == ""
     assert not (tmp_path / "existing.[native].docx").exists()
+
+
+def test_delete_file_variants_removes_canonical_hint_variants(tmp_path):
+    parsed_dir = tmp_path / PARSED_DIR_NAME
+    parsed_dir.mkdir()
+    files_to_delete = [
+        tmp_path / "report.docx",
+        tmp_path / "report.[native].docx",
+        parsed_dir / "report.[mineru].docx",
+        parsed_dir / "report.[native]_001.docx",
+        parsed_dir / "report_001.docx",
+    ]
+    for path in files_to_delete:
+        path.write_bytes(b"delete me")
+    unrelated_files = [
+        tmp_path / "report_001.docx",
+        tmp_path / "report_2024.docx",
+        parsed_dir / "other.[native].docx",
+    ]
+    for path in unrelated_files:
+        path.write_bytes(b"keep me")
+    artifact_dir = parsed_dir / "report.docx.parsed"
+    artifact_dir.mkdir()
+    (artifact_dir / "report.blocks.jsonl").write_text("{}", encoding="utf-8")
+
+    deleted_files, errors = _document_routes.delete_file_variants_by_canonical_basename(
+        tmp_path,
+        "report.docx",
+        str(tmp_path / "report.[native].docx"),
+    )
+
+    assert errors == []
+    assert set(deleted_files) == {
+        "report.docx",
+        "report.[native].docx",
+        str(Path(PARSED_DIR_NAME) / "report.[mineru].docx"),
+        str(Path(PARSED_DIR_NAME) / "report.[native]_001.docx"),
+        str(Path(PARSED_DIR_NAME) / "report_001.docx"),
+    }
+    assert all(not path.exists() for path in files_to_delete)
+    assert all(path.exists() for path in unrelated_files)
+    assert artifact_dir.is_dir()
+
+
+async def test_background_delete_removes_parser_hint_file_variants(tmp_path):
+    shared_storage = importlib.import_module("lightrag.kg.shared_storage")
+    parsed_dir = tmp_path / PARSED_DIR_NAME
+    parsed_dir.mkdir()
+    source_file = tmp_path / "paper.[native].docx"
+    source_file.write_bytes(b"source")
+    parsed_variant = parsed_dir / "paper.[mineru]_001.docx"
+    parsed_variant.write_bytes(b"parsed")
+    unrelated_file = tmp_path / "other.[native].docx"
+    unrelated_file.write_bytes(b"keep")
+    doc_manager = DocumentManager(str(tmp_path))
+    rag = _DeleteRag(
+        DeletionResult(
+            status="success",
+            doc_id="doc-paper",
+            message="deleted",
+            file_path="paper.docx",
+            source_path=str(source_file),
+        )
+    )
+    shared_storage.initialize_share_data()
+    await shared_storage.initialize_pipeline_status(workspace=rag.workspace)
+
+    await _document_routes.background_delete_documents(
+        rag,
+        doc_manager,
+        ["doc-paper"],
+        delete_file=True,
+        delete_llm_cache=True,
+    )
+
+    assert rag.deleted_doc_ids == [("doc-paper", True)]
+    assert not source_file.exists()
+    assert not parsed_variant.exists()
+    assert unrelated_file.exists()
 
 
 async def test_docx_archive_failure_is_best_effort(tmp_path, monkeypatch):

--- a/tests/test_document_routes_docx_archive.py
+++ b/tests/test_document_routes_docx_archive.py
@@ -440,14 +440,17 @@ async def test_scan_archives_same_batch_canonical_duplicates(tmp_path, monkeypat
 
     await run_scanning_process(rag, doc_manager, "track-scan")
 
+    # Hinted variant is preferred so the user's explicit engine choice wins;
+    # the plain variant is the one that gets archived.
     assert len(calls) == 1
-    assert len(calls[0]["file_paths"]) == 1
+    assert calls[0]["file_paths"] == [hinted_file]
     assert calls[0]["kwargs"] == {"reprocess_existing_non_processed": True}
     archived_names = {
         path.name for path in (tmp_path / PARSED_DIR_NAME).iterdir() if path.is_file()
     }
-    assert archived_names in ({"same.docx"}, {"same.[native].docx"})
-    assert sum(path.exists() for path in (plain_file, hinted_file)) == 1
+    assert archived_names == {"same.docx"}
+    assert hinted_file.exists()
+    assert not plain_file.exists()
 
 
 async def test_scan_existing_non_processed_reprocesses_file(tmp_path, monkeypatch):

--- a/tests/test_document_routes_docx_archive.py
+++ b/tests/test_document_routes_docx_archive.py
@@ -373,6 +373,66 @@ async def test_scan_processed_same_name_archives_with_unique_name(
     assert (parsed_dir / "already-parsed_001.docx").read_bytes() == b"docx bytes"
 
 
+async def test_scan_processed_canonical_name_archives_hinted_file(
+    tmp_path, monkeypatch
+):
+    file_path = tmp_path / "already-parsed.[native].docx"
+    file_path.write_bytes(b"docx bytes")
+    doc_manager = DocumentManager(str(tmp_path))
+    rag = _ScanRag(
+        {
+            "already-parsed.docx": {
+                "status": DocStatus.PROCESSED.value,
+                "file_path": "already-parsed.docx",
+                "track_id": "track-existing",
+            }
+        }
+    )
+
+    async def fail_if_reenqueue(*args, **kwargs):
+        raise AssertionError("canonical duplicate should not be re-enqueued")
+
+    monkeypatch.setattr(_document_routes, "pipeline_index_files", fail_if_reenqueue)
+
+    await run_scanning_process(rag, doc_manager, "track-scan")
+
+    assert not file_path.exists()
+    assert (tmp_path / PARSED_DIR_NAME / file_path.name).read_bytes() == b"docx bytes"
+
+
+async def test_scan_archives_same_batch_canonical_duplicates(tmp_path, monkeypatch):
+    plain_file = tmp_path / "same.docx"
+    hinted_file = tmp_path / "same.[native].docx"
+    plain_file.write_bytes(b"plain docx bytes")
+    hinted_file.write_bytes(b"hinted docx bytes")
+    doc_manager = DocumentManager(str(tmp_path))
+    rag = _ScanRag({})
+    calls = []
+
+    async def capture_pipeline(rag_arg, file_paths, track_id, **kwargs):
+        calls.append(
+            {
+                "rag": rag_arg,
+                "file_paths": file_paths,
+                "track_id": track_id,
+                "kwargs": kwargs,
+            }
+        )
+
+    monkeypatch.setattr(_document_routes, "pipeline_index_files", capture_pipeline)
+
+    await run_scanning_process(rag, doc_manager, "track-scan")
+
+    assert len(calls) == 1
+    assert len(calls[0]["file_paths"]) == 1
+    assert calls[0]["kwargs"] == {"reprocess_existing_non_processed": True}
+    archived_names = {
+        path.name for path in (tmp_path / PARSED_DIR_NAME).iterdir() if path.is_file()
+    }
+    assert archived_names in ({"same.docx"}, {"same.[native].docx"})
+    assert sum(path.exists() for path in (plain_file, hinted_file)) == 1
+
+
 async def test_scan_existing_non_processed_reprocesses_file(tmp_path, monkeypatch):
     file_path = tmp_path / "retry.docx"
     file_path.write_bytes(b"docx bytes")
@@ -449,6 +509,31 @@ async def test_upload_rejects_same_name_failed_doc_status_without_full_docs(
     assert response.track_id == "track-failed"
     assert "Status: failed" in response.message
     assert not (tmp_path / "failed.docx").exists()
+
+
+async def test_upload_rejects_parser_hinted_filesystem_duplicate(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        _document_routes, "global_args", SimpleNamespace(max_upload_size=None)
+    )
+    (tmp_path / "existing.docx").write_bytes(b"existing docx bytes")
+    doc_manager = DocumentManager(str(tmp_path))
+    rag = _DuplicateUploadRag({})
+    router = create_document_routes(rag, doc_manager)
+    upload_endpoint = [
+        route.endpoint
+        for route in router.routes
+        if getattr(route, "name", "") == "upload_to_input_dir"
+    ][-1]
+    upload_file = _document_routes.UploadFile(
+        filename="existing.[native].docx",
+        file=BytesIO(b"replacement docx bytes"),
+    )
+
+    response = await upload_endpoint(_document_routes.BackgroundTasks(), upload_file)
+
+    assert response.status == "duplicated"
+    assert response.track_id == ""
+    assert not (tmp_path / "existing.[native].docx").exists()
 
 
 async def test_docx_archive_failure_is_best_effort(tmp_path, monkeypatch):

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -204,6 +204,33 @@ def test_enqueue_dedupes_parser_hinted_filename_variants(tmp_path):
 
 
 @pytest.mark.offline
+def test_delete_result_preserves_parser_hinted_source_path(tmp_path):
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+        try:
+            source_path = str(tmp_path / "abc.[native].docx")
+            await rag.apipeline_enqueue_documents(
+                "",
+                file_paths=source_path,
+                docs_format=FULL_DOCS_FORMAT_PENDING_PARSE,
+                parsed_engine=PARSER_ENGINE_NATIVE,
+                track_id="track-delete-source",
+            )
+
+            doc_id = compute_mdhash_id("abc.docx", prefix="doc-")
+            result = await rag.adelete_by_doc_id(doc_id)
+
+            assert result.status == "success"
+            assert result.file_path == "abc.docx"
+            assert result.source_path == source_path
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
 def test_enqueue_without_file_paths_uses_content_ids(tmp_path):
     async def _run():
         rag = _new_rag(tmp_path)

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -113,6 +113,21 @@ def test_canonicalize_parser_hinted_basename():
     assert canonicalize_parser_hinted_basename("abc.[native].docx") == "abc.docx"
     assert canonicalize_parser_hinted_basename("/tmp/a.b.[mineru].pdf") == "a.b.pdf"
     assert canonicalize_parser_hinted_basename("abc.[draft].docx") == "abc.[draft].docx"
+    # Engine token is case-insensitive (normalize_parser_engine lower-cases).
+    assert canonicalize_parser_hinted_basename("abc.[NATIVE].docx") == "abc.docx"
+    # Engine sub-variants like "mineru-iet" normalize to a base engine.
+    assert canonicalize_parser_hinted_basename("abc.[mineru-iet].pdf") == "abc.pdf"
+    # No extension after the bracket: pattern requires ``.[engine].ext``.
+    assert canonicalize_parser_hinted_basename("abc.[native]") == "abc.[native]"
+    # Plain basename without any hint is returned unchanged.
+    assert canonicalize_parser_hinted_basename("abc.docx") == "abc.docx"
+    # Bracket without a leading dot is not a hint.
+    assert canonicalize_parser_hinted_basename("[native].docx") == "[native].docx"
+    # Nested hints: only the outermost segment is stripped.
+    assert (
+        canonicalize_parser_hinted_basename("name.[native].[mineru].pdf")
+        == "name.[native].pdf"
+    )
 
 
 @pytest.mark.offline

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -16,6 +16,7 @@ from lightrag.constants import (
 from lightrag.operate import _get_relationship_vdb_timeout_seconds
 from lightrag.parser_routing import (
     ParserRoutingConfigError,
+    canonicalize_parser_hinted_basename,
     resolve_file_parser_engine,
     validate_parser_routing_config,
 )
@@ -108,6 +109,13 @@ def test_parse_engine_rule_fallback_and_default_legacy(tmp_path, monkeypatch):
 
 
 @pytest.mark.offline
+def test_canonicalize_parser_hinted_basename():
+    assert canonicalize_parser_hinted_basename("abc.[native].docx") == "abc.docx"
+    assert canonicalize_parser_hinted_basename("/tmp/a.b.[mineru].pdf") == "a.b.pdf"
+    assert canonicalize_parser_hinted_basename("abc.[draft].docx") == "abc.[draft].docx"
+
+
+@pytest.mark.offline
 def test_enqueue_dedupes_by_filename_and_content_hash(tmp_path):
     async def _run():
         rag = _new_rag(tmp_path)
@@ -155,6 +163,40 @@ def test_enqueue_dedupes_by_filename_and_content_hash(tmp_path):
                 if getattr(doc, "metadata", {}).get("is_duplicate")
             }
             assert {"filename", "content_hash"}.issubset(kinds)
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_enqueue_dedupes_parser_hinted_filename_variants(tmp_path):
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+        try:
+            await rag.apipeline_enqueue_documents(
+                "alpha body",
+                file_paths="abc.docx",
+                track_id="track-a",
+            )
+            first_id = compute_mdhash_id("abc.docx", prefix="doc-")
+            first_doc = await rag.full_docs.get_by_id(first_id)
+            assert first_doc is not None
+
+            await rag.apipeline_enqueue_documents(
+                "changed body",
+                file_paths="/tmp/abc.[native].docx",
+                track_id="track-b",
+            )
+            assert (await rag.full_docs.get_by_id(first_id))["content"] == "alpha body"
+
+            failed_docs = await rag.doc_status.get_docs_by_status(DocStatus.FAILED)
+            assert any(
+                getattr(doc, "metadata", {}).get("duplicate_kind") == "filename"
+                and getattr(doc, "file_path", "") == "abc.docx"
+                for doc in failed_docs.values()
+            )
         finally:
             await rag.finalize_storages()
 
@@ -964,6 +1006,42 @@ def test_write_lightrag_document_preserves_headings_and_table_dimensions(
         )
 
         await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_write_lightrag_document_strips_parser_hint_from_artifact_names(
+    tmp_path, monkeypatch
+):
+    async def _run():
+        monkeypatch.setenv("INPUT_DIR", str(tmp_path))
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+        try:
+            source_path = tmp_path / "demo.[native].docx"
+            source_path.write_bytes(b"docx bytes")
+
+            parsed = await rag._write_lightrag_document_from_content_list(
+                doc_id="doc-hinted",
+                file_path="demo.[native].docx",
+                content_list=[{"type": "text", "text": "body"}],
+                engine="native",
+                source_path=str(source_path),
+            )
+
+            blocks_path = Path(parsed["blocks_path"])
+            assert blocks_path == (
+                tmp_path / PARSED_DIR_NAME / "demo.docx.parsed" / "demo.blocks.jsonl"
+            )
+            assert not source_path.exists()
+            assert (tmp_path / PARSED_DIR_NAME / source_path.name).exists()
+            full_doc = await rag.full_docs.get_by_id("doc-hinted")
+            assert full_doc["lightrag_document_path"] == (
+                "__parsed__/demo.docx.parsed/demo.blocks.jsonl"
+            )
+        finally:
+            await rag.finalize_storages()
 
     asyncio.run(_run())
 


### PR DESCRIPTION
## Description

Normalize parser-hinted filenames before filename deduplication so files such as `abc.docx` and `abc.[native].docx` are treated as the same document source. Also use the canonical filename for LightRAG Document artifact paths.

## Related Issues

n/a

## Changes Made

- Added parser-hint basename canonicalization for supported engines only.
- Applied canonical names to upload checks, scan filtering, core enqueue deduplication, and parsed LightRAG Document artifact naming.
- Added same-scan duplicate handling so only one canonical filename variant is processed and the rest are archived. When both plain and hint-bearing variants are present, the hinted one wins so the user's explicit engine choice is preserved.
- Extended document deletion to remove parser-hint and numbered archive variants from both `input_dir` and `__parsed__/`, including the `<basename>.parsed[_NNN]/` artifact directories. `DeletionResult` now carries `source_path` so the original parser-hinted path remains available downstream.
- Updated Chinese file processing documentation to describe canonical filenames, scan behavior, and parsed artifact paths.
- Added regression coverage for enqueue, upload, scan, parser hint canonicalization, deletion of hint/archive variants, and LightRAG Document output paths.

## Migration Notes

- Artifact directories created by older builds may use the un-canonicalized name (for example `report.[native].docx.parsed/`). These legacy directories will not be picked up by the new delete-by-canonical-basename cleanup and should be removed manually after upgrade if cleanup is desired. New artifact directories produced after this PR all use the canonical name (`report.docx.parsed/`).

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Local validation:

- \`./scripts/test.sh tests/test_pipeline_release_closure.py tests/test_document_routes_docx_archive.py\`
- \`ruff check lightrag/parser_routing.py lightrag/lightrag.py lightrag/base.py lightrag/api/routers/document_routes.py lightrag/kg/json_doc_status_impl.py tests/test_pipeline_release_closure.py tests/test_document_routes_docx_archive.py\`