### PR TITLE
feat(parser_routing): per-file process options and canonical basename

### DIFF
--- a/docs/FileProcessingConfiguration-zh.md
+++ b/docs/FileProcessingConfiguration-zh.md
@@ -15,7 +15,7 @@
 
 ## 修改默认内容抽取方式
 
-使用环境变量 `LIGHTRAG_PARSER`可以给不同的文件后最配资默认的文件内容提取方式：
+使用环境变量 `LIGHTRAG_PARSER`可以给不同的文件后缀配置默认的文件内容提取方式以及默认的处理选项：
 
 ```bash
 LIGHTRAG_PARSER=pdf:mineru,docx:docling,pptx:docling,xlsx:docling,*:legacy
@@ -28,6 +28,7 @@ DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
 ```text
 后缀:引擎,后缀:引擎,*:legacy
 后缀:引擎;后缀:引擎;*:legacy
+后缀:引擎-选项                # 在引擎后追加默认处理选项（见下文“处理选项”一节）
 ```
 
 注意事项：
@@ -35,9 +36,10 @@ DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
 - 左侧匹配的是文件后缀，不是完整文件名；应写 `pdf:mineru`，不要写 `*.pdf:mineru`。
 - 规则可以使用英文逗号 `,` 或分号 `;` 分隔。
 - 规则按从左到右的顺序检查；优先规则放在前面；通配符规则应放在最后。
-- 启动时会严格校验规则：未知内容提取引擎、错误后缀写法、显式使用不支持的后缀、外部引擎缺少 endpoint 都会导致启动失败。
+- 启动时会严格校验规则：未知内容提取引擎、错误后缀写法、显式使用不支持的后缀、外部引擎缺少 endpoint、处理选项中的非法字符都会导致启动失败。
 - 通配符规则只会让引擎处理其能力表支持的后缀。例如 `*:mineru;html:docling` 中，MinerU 只接管 MinerU 支持的后缀，`html` 会继续匹配到后续 `docling` 规则。
 - 如果所有规则都不可用，文件内容提取方式会回退到 `legacy`，如果legacy也不支持对应的文件后缀，会向系统加一个错误条目，上传文件保留在`INPUT`目录。
+- 引擎后缀 `-选项` 部分作为该规则匹配文件的默认 `process_options`，会被文件名 hint 中的 `[...]` 覆盖。例如 `LIGHTRAG_PARSER=docx:native-iet` 表示所有 `.docx` 默认采用 `native` 引擎并开启图、表、公式分析。
 
 ## 对单文件指定内容抽取方式
 
@@ -50,7 +52,60 @@ memo.[native].docx
 report.[legacy].pdf
 ```
 
-文件名 hint 的优先级高于 `LIGHTRAG_PARSER`。如果指定的引擎不支持该后缀，系统会回退到默认规则继续选择可用引擎。如果所有规则都不可用，文件内容提取方式会回退到 `legacy`，如果legacy也不支持对应的文件后缀，会向系统加一个错误条目，上传文件保留在`INPUT`目录。
+中括号内的内容支持三种形式：
+
+```text
+[ENGINE]              # 仅指定引擎，处理选项使用默认或 LIGHTRAG_PARSER 提供的默认
+[ENGINE-OPTIONS]      # 引擎 + 处理选项
+[OPTIONS]             # 仅指定处理选项，引擎仍按 LIGHTRAG_PARSER / 默认规则解析
+```
+
+仅当首段以 `-` 分隔出第二段时第一段才被作为引擎候选；否则若整段能整体匹配引擎名（`mineru` / `native` / `docling` / `legacy`），视为只指定引擎；否则整段视为选项串。文件名 hint 的优先级高于 `LIGHTRAG_PARSER`。如果指定的引擎不支持该后缀，系统会回退到默认规则继续选择可用引擎。如果所有规则都不可用，文件内容提取方式会回退到 `legacy`，如果legacy也不支持对应的文件后缀，会向系统加一个错误条目，上传文件保留在`INPUT`目录。
+
+## 处理选项
+
+处理选项控制单个文件在多模态分析、知识图谱构建和文本分块上的行为。所有选项都是可选的；缺省值见下表。同一文件最多指定一种分块方式（`F` / `R` / `S`），其它选项可任意组合。
+
+| 选项 | 类型 | 默认 | 含义 |
+| --- | --- | --- | --- |
+| `i` | 多模态 | 关闭 | 启用图像分析（VLM） |
+| `t` | 多模态 | 关闭 | 启用表格分析（VLM） |
+| `e` | 多模态 | 关闭 | 启用公式分析（VLM） |
+| `!` | 流水线 | 关闭 | 禁止实体/关系抽取，不构建知识图谱（仅保留 chunks 向量索引，naive / mix 检索仍可用） |
+| `F` | 分块 | 默认 | 固定长度或按分隔符机械分割（按分隔符分割时块不重叠） |
+| `R` | 分块 | — | 递归语义分块（优先按段落、句子分割）；当前版本回退至 `F`，行为等同于固定分块 |
+| `S` | 分块 | — | 标题语义分块（优先按标题分割，标题块不重叠）；要求 `native` 抽取出的结构化输出，否则降级到 `F` |
+
+举例：
+
+```text
+my-proposal.[native-iet].docx   # 使用 native 引擎，开启图、表、公式分析
+my-memo.[native-R!].md          # 使用 native 引擎，递归语义分块，禁止知识图谱构建，多模态默认关
+my-proposal.[!].docx            # 使用默认引擎（按 LIGHTRAG_PARSER 解析），仅禁止知识图谱构建
+my-proposal.[mineru].docx       # 使用 MinerU 引擎，多模态、分块、KG 全部默认（即多模态关、F 分块、构建 KG）
+```
+
+校验与解析规则：
+
+- `F`/`R`/`S` 至多出现一个；同一选项重复时只生效一次但不报错。
+- 大小写敏感：分块选项 `F`/`R`/`S` 必须大写；其它选项 `i`/`t`/`e`/`!` 小写。
+- 中括号内出现非法字符时，整个 hint 失效，引擎按默认规则解析、选项按 `LIGHTRAG_PARSER` 默认或全部默认；同时落日志 warning。
+- 如果文件名 hint 提供了非空选项串，则以 hint 为准；否则使用 `LIGHTRAG_PARSER` 规则中匹配项的默认选项；都没有则使用全部默认。
+- `S` 仅对 `native` 抽取出的结构化结果（interchange JSONL）有效；对 `legacy` 路径或非结构化输出会自动降级到 `F` 并记录 warning。
+
+> 多模态全局开关 `addon_params["enable_multimodal_pipeline"]` 已废弃，相关行为统一由文件级 `i` / `t` / `e` 选项控制。如启动配置仍包含该字段，会在日志输出 deprecation warning 并被忽略。
+
+### 选项作用阶段
+
+处理选项的不同字符在流水线的不同阶段生效，具体如下：
+
+| 选项 | 作用阶段 | 说明 |
+| --- | --- | --- |
+| `i` / `t` / `e` | ANALYZING（VLM 分析） | 决定是否对 sidecar 中的图像 / 表格 / 公式调用 VLM 做摘要分析。**抽取阶段不受影响**：内容提取引擎按文档实际内容输出 `drawings.json` / `tables.json` / `equations.json` sidecar 文件。这样后续仅修改 `i`/`t`/`e` 选项触发"再分析"即可补做 VLM，无须重新解析原始文件。 |
+| `!` | EXTRACTION（实体关系抽取） | 跳过实体/关系抽取与图谱写入；chunks 仍写入向量库以保留 naive / mix 检索能力。 |
+| `F` / `R` / `S` | CHUNKING（文本分块） | 决定使用哪种分块策略；对解析阶段输出无影响。 |
+
+> 模态可用性以"sidecar 文件是否存在"为唯一信号，内容提取引擎不需要在 meta 中声明能力。某文档若没有任何图像/表格/公式，对应 sidecar 不会写入；用户即使开启了 `i`/`t`/`e`，对应模态也只会被静默跳过，但 `analyze_multimodal` 会在该篇文档落一行 INFO 级日志（`[analyze_multimodal] process_options opted into i:drawings ... but the parser produced no such sidecar`），便于排查"VLM 为何没跑"。这种情况不会报错。
 
 ## 推荐配置
 
@@ -68,6 +123,12 @@ report.[legacy].pdf
 
 ```bash
 LIGHTRAG_PARSER=docx:native
+```
+
+为 docx 默认开启图、表、公式分析（处理选项默认）：
+
+```bash
+LIGHTRAG_PARSER=docx:native-iet
 ```
 
 ### 梦幻组合
@@ -90,25 +151,28 @@ DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
 
 | 字段 | 说明 |
 | --- | --- |
-| `file_path` | 文件名 basename（不含目录）。如果文件名带有支持的处理指引 hint，例如 `abc.[native].docx`，会先规范化为 `abc.docx` 后保存。未提供有效来源时保存为 `unknown_source`；有效文件名的重复判定与内容溯源都基于该字段。 |
-| `source_path` | 入队时提供的原始路径（仅当与规范化后的 `file_path` 不同才会写入），供 `native` / `mineru` / `docling` 解析器定位真实文件位置。 |
+| `file_path` | 文件名 basename（不含目录），**保留用户提供的原始名（含中括号 hint）**，例如 `abc.[native-iet].docx` 原样写入。未提供有效来源时保存为 `unknown_source`。文件名 hint 不会被剥离，方便管理 UI 直接展示用户原本的命名意图。 |
+| `canonical_basename` | 去掉处理提示 hint 后的规范化 basename（例如 `abc.docx`）。文件名查重以此字段为索引 key，保证 `abc.docx` 与 `abc.[native-iet].docx` 视为同一逻辑文档。 |
+| `source_path` | 入队时提供的原始路径（仅当含目录分隔符或绝对路径时才写入），供 `native` / `mineru` / `docling` 解析器定位真实文件位置。 |
 | `format` | 内容格式：`pending_parse`, `raw`, `lightrag`。 |
 | `content` | `raw` 时保存抽取文本；`pending_parse` 时为空字符串；`lightrag` 时固定为以 `{{LRdoc}}`开头的一段内容摘要。 |
 | `content_hash` | 内容 MD5，用于跨文件名查重。`format=raw` 取 `sanitize_text_for_encoding` 后文本的 hash；`format=lightrag` 取 `*.blocks.jsonl` 文件 hash；`format=pending_parse` 不写入，待抽取完成后补上。 |
-| `lightrag_document_path` | `format=lightrag` 时保存结构化 LightRAG Document 的路径；新记录优先保存为相对 `INPUT_DIR` 的路径，例如 `__parsed__/report.docx.parsed/report.blocks.jsonl`。 |
+| `lightrag_document_path` | `format=lightrag` 时保存结构化 LightRAG Document 的路径；新记录优先保存为相对 `INPUT_DIR` 的路径，例如 `__parsed__/report.docx.parsed/report.blocks.jsonl`。注意路径中的子目录与 blocks 文件名都使用规范化 basename（不含 hint）。 |
 | `parsed_engine` | 实际完成抽取的引擎：`legacy`, `native`, `mineru`, `docling`。对于待抽取文件，也可暂存目标引擎。 |
+| `process_options` | 入队时记录的原始处理选项串（不含引擎名和分隔 `-`），例如 `"iet"`、`"R!"`、`""`。下游各阶段以此字段为权威源，决定是否启用图像/表格/公式分析（`i`/`t`/`e`）、是否禁止知识图谱构建（`!`）以及分块方式（`F`/`R`/`S`）。空字符串等价于全部默认值。 |
 
 `pending_parse` 表示文件已经入队，但还没有完成抽取。抽取成功后会改写为 `raw` 或 `lightrag`，并补齐 `content_hash`。抽取失败时保留 `pending_parse` 和空 `content`，便于后续排查和重试。
 
-> `doc_status` 中也会同步保存规范化后的 `file_path`（basename）与 `content_hash`，作为 `get_doc_by_file_basename` / `get_doc_by_content_hash` 的查重索引来源。
+> `doc_status` 中也同步保存原始 `file_path`（含 hint）、`canonical_basename` 与 `content_hash`，作为 `get_doc_by_file_basename` / `get_doc_by_content_hash` 的查重索引来源。`get_doc_by_file_basename` 内部把传入参数先经 `canonicalize_parser_hinted_basename` 规范化后再与 `canonical_basename` 比对，因此 `abc.docx` 与 `abc.[native-iet].docx` 总是命中同一文档。
+> `process_options` 同时镜像写入 `doc_status.metadata["process_options"]`，便于管理 UI 直接展示当前文件的处理策略。
 
 ## 内容提取结果目录结构
 
 `__parsed__` 是输入目录旁的归档与分析结果目录。它同时保存已经处理过的原始文档，以及结构化解析产生的 LightRAG Document 文件和图片等资源。
 
-- 原始文件归档：`legacy` 本地抽取成功并入队后，原文件会移动到同级 `__parsed__` 目录；`native` / `mineru` / `docling` 会先保留原文件供 pipeline 解析，解析成功并写入 `full_docs` 后再移动到 `__parsed__`。
-- 分析结果目录：结构化解析结果会写入以规范化文件名加 `.parsed` 后缀命名的子目录，避免与归档原文件同名冲突。例如 `report.docx` 的分析结果目录为 `__parsed__/report.docx.parsed/`；`report.[native].docx` 也会写入 `__parsed__/report.docx.parsed/`。
-- 分析结果文件：LightRAG Document blocks 文件使用规范化文件名的主干命名，例如 `__parsed__/report.docx.parsed/report.blocks.jsonl`；同一目录下还可能包含 `report.tables.json`、`report.drawings.json`、`report.equations.json` 和 `report.blocks.assets/` 图片资源目录。
+- 原始文件归档：`legacy` 本地抽取成功并入队后，原文件会移动到同级 `__parsed__` 目录；`native` / `mineru` / `docling` 会先保留原文件供 pipeline 解析，解析成功并写入 `full_docs` 后再移动到 `__parsed__`。**归档时保留原始文件名（含 `[hint]`）**，例如 `report.[native-iet].docx` 归档为 `__parsed__/report.[native-iet].docx`，便于追溯用户最初的命名与处理选项。
+- 分析结果目录：结构化解析结果会写入以**规范化文件名**（去掉 `[hint]`）加 `.parsed` 后缀命名的子目录，避免与归档原文件同名冲突，并保证当文件名 hint 或处理选项变化时同一逻辑文档继续指向同一目录。例如 `report.docx`、`report.[native].docx`、`report.[native-iet].docx` 的分析结果都写入 `__parsed__/report.docx.parsed/`。
+- 分析结果文件：LightRAG Document blocks 文件以及 sidecar 都使用规范化文件名的主干命名，例如 `__parsed__/report.docx.parsed/report.blocks.jsonl`；同一目录下还可能包含 `report.tables.json`、`report.drawings.json`、`report.equations.json` 和 `report.blocks.assets/` 图片资源目录。**sidecar 是否生成由文档内容决定**：解析器只在文档实际包含表格/图片/公式时写出对应文件。这是模态可用性的唯一信号 —— 引擎不需要在 meta 中声明能力。`i`/`t`/`e` 选项只决定下一阶段是否对已存在的 sidecar 调用 VLM 做摘要分析。
 - 解析失败时，原文件不会移动，便于修复配置后重新处理。
 - `/documents/scan` 扫描到同名且已 `PROCESSED` 的文件时，该输入文件会被视为已处理并移动到 `__parsed__`，不会作为新文档入队。
 - `/documents/scan` 同一次扫描中发现多个规范化后同名的文件时，会优先保留带支持引擎 hint 的文件以尊重用户的引擎选择；如果没有任何变体带 hint，则按排序处理第一个文件。其余变体会输出 warning 并移动到 `__parsed__`，避免同批文件互相覆盖。例如 `abc.docx` 和 `abc.[native].docx` 同时存在时只会处理 `abc.[native].docx`。
@@ -122,7 +186,7 @@ DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
 ### 1) 文件名（basename）查重
 
 - 判断粒度为 basename，不包含目录路径和 workspace 路径。例如 `/data/a.pdf`、`inputs/a.pdf` 和 `a.pdf` 都视为同一个文件名 `a.pdf`。
-- 文件名查重会去掉文件名末尾的支持引擎处理指引 hint，即认为 `abc.docx` 与 `abc.[native].docx` 是文件名重复；不支持的 hint 不会被剥离，例如 `abc.[draft].docx` 仍按原文件名处理。
+- 文件名查重以 `canonical_basename` 为索引：将文件名末尾的支持引擎处理提示 hint 剥离后再比对，因此 `abc.docx`、`abc.[native].docx`、`abc.[native-iet].docx` 之间互相视为同名；不支持的 hint 不会被剥离，例如 `abc.[draft].docx` 仍按原文件名处理。
 - 对普通上传、文本接口和核心入队 API，只要 `doc_status` 中已经存在同名文件记录，无论该记录当前处于 `PENDING`、`PARSING`、`ANALYZING`、`PROCESSING`、`FAILED` 还是 `PROCESSED`，同名文件都会被视为重复。
 - 对 `/documents/scan` 目录扫描：
   - 同一次扫描中如果有多个文件规范化后同名，优先处理带支持引擎 hint 的文件；若无任何 hint 变体，则处理排序后的第一个文件，其余文件会归档到 `__parsed__` 并跳过。
@@ -133,7 +197,7 @@ DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
 - 核心 API `insert` / `ainsert` / `apipeline_enqueue_documents` 仍兼容未传 `file_paths` 的调用；这类文档的 `file_path` 会保存为 `unknown_source`，不会参与文件名查重，文档 ID 继续按文本内容生成。
 - 空字符串、`no-file-path` 和 `unknown_source` 都会被视为未知来源；它们不会阻止新的无来源文本入队，也不会作为同名文件互相去重。
 
-存储后端通过 `get_doc_by_file_basename` 提供 basename 直查能力。`JsonDocStatusStorage` 已经实现了内存级遍历；其它后端目前回落到默认实现（扫描全部状态后比对 basename），将在后续 PR 中补齐原生索引。
+存储后端通过 `get_doc_by_file_basename` 提供 basename 直查能力，内部按 `canonical_basename` 字段比对（传入参数会先经 `canonicalize_parser_hinted_basename` 规范化）。`JsonDocStatusStorage` 已经实现了内存级遍历；其它后端目前回落到默认实现（扫描全部状态后比对 `canonical_basename`），将在后续 PR 中补齐原生索引。
 
 ### 2) 内容 hash 查重
 

--- a/lightrag/addon_params.py
+++ b/lightrag/addon_params.py
@@ -17,7 +17,25 @@ from __future__ import annotations
 from typing import Any, Callable, Mapping
 
 from lightrag.constants import DEFAULT_SUMMARY_LANGUAGE
-from lightrag.utils import get_env_value
+from lightrag.utils import get_env_value, logger
+
+
+# Keys that used to live in addon_params but have been superseded by
+# per-document ``process_options``.  We log once when callers still pass them
+# so existing configs surface their drift without breaking.
+_DEPRECATED_ADDON_PARAM_KEYS: tuple[str, ...] = ("enable_multimodal_pipeline",)
+_warned_deprecated_keys: set[str] = set()
+
+
+def _emit_deprecated_addon_warnings(params: Mapping[str, Any]) -> None:
+    for key in _DEPRECATED_ADDON_PARAM_KEYS:
+        if key in params and key not in _warned_deprecated_keys:
+            logger.warning(
+                f"addon_params['{key}'] is deprecated and ignored; per-document "
+                f"behaviour is now controlled by filename-hint process_options "
+                f"(see docs/FileProcessingConfiguration-zh.md)."
+            )
+            _warned_deprecated_keys.add(key)
 
 
 def default_addon_params() -> dict[str, Any]:
@@ -32,7 +50,12 @@ def normalize_addon_params(addon_params: Mapping[str, Any] | None) -> dict[str, 
     if addon_params is None:
         normalized = default_addon_params()
     elif isinstance(addon_params, Mapping):
-        normalized = dict(addon_params)
+        _emit_deprecated_addon_warnings(addon_params)
+        normalized = {
+            k: v
+            for k, v in addon_params.items()
+            if k not in _DEPRECATED_ADDON_PARAM_KEYS
+        }
     else:
         raise TypeError(
             "addon_params must be a Mapping or None, got "

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -34,7 +34,7 @@ from lightrag.constants import (
 from lightrag.parser_routing import (
     canonicalize_parser_hinted_basename,
     filename_parser_hint,
-    resolve_file_parser_engine,
+    resolve_file_parser_directives,
 )
 from lightrag.utils import (
     generate_track_id,
@@ -1403,7 +1403,7 @@ async def pipeline_enqueue_file(
         except Exception:
             file_size = 0
 
-        extraction_engine = resolve_file_parser_engine(file_path)
+        extraction_engine, process_options = resolve_file_parser_directives(file_path)
         if extraction_engine != PARSER_ENGINE_LEGACY:
             try:
                 enqueue_kwargs = {
@@ -1412,6 +1412,8 @@ async def pipeline_enqueue_file(
                     "docs_format": FULL_DOCS_FORMAT_PENDING_PARSE,
                     "parsed_engine": extraction_engine,
                 }
+                if process_options:
+                    enqueue_kwargs["process_options"] = process_options
                 if reprocess_existing_non_processed:
                     enqueue_kwargs["reprocess_existing_non_processed"] = True
                 enqueue_result = await rag.apipeline_enqueue_documents(
@@ -1725,6 +1727,8 @@ async def pipeline_enqueue_file(
                     "track_id": track_id,
                     "parsed_engine": PARSER_ENGINE_LEGACY,
                 }
+                if process_options:
+                    enqueue_kwargs["process_options"] = process_options
                 if reprocess_existing_non_processed:
                     enqueue_kwargs["reprocess_existing_non_processed"] = True
                 enqueue_result = await rag.apipeline_enqueue_documents(

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -806,6 +806,12 @@ class DocProcessingStatus:
     Used together with file_path basename for duplicate detection. Empty for
     pending_parse records whose content has not been extracted yet.
     """
+    canonical_basename: str | None = None
+    """Canonical (parser-hint stripped) basename used as the dedup index key.
+
+    Stored alongside the original ``file_path`` so backends can look records
+    up by ``abc.docx`` even when the user-visible name is ``abc.[native].docx``.
+    """
     """Internal field: indicates if multimodal processing is complete. Not shown in repr() but accessible for debugging."""
 
     def __post_init__(self):
@@ -917,9 +923,12 @@ class DocStatusStorage(BaseKVStorage, ABC):
     ) -> tuple[str, dict[str, Any]] | None:
         """Get document by file basename (filename without directory).
 
-        Used for filename-based deduplication. Backends that can index by
-        basename should override this for efficiency. The default implementation
-        scans all documents via get_docs_by_statuses().
+        Used for filename-based deduplication.  Comparison is performed
+        against the canonical (parser-hint stripped) basename, so callers may
+        pass either the original or the canonical form.  Backends that can
+        index by ``canonical_basename`` should override this for efficiency.
+        The default implementation scans all documents via
+        :meth:`get_docs_by_statuses`.
 
         Args:
             basename: The filename basename to search for (e.g. "report.pdf").
@@ -929,6 +938,11 @@ class DocStatusStorage(BaseKVStorage, ABC):
         """
         if not basename:
             return None
+        # Imported lazily to avoid a hard dependency at module-load time and
+        # because parser_routing already depends on lightrag.constants.
+        from lightrag.parser_routing import canonicalize_parser_hinted_basename
+
+        target = canonicalize_parser_hinted_basename(basename)
         try:
             docs = await self.get_docs_by_statuses(list(DocStatus))
         except NotImplementedError:
@@ -936,14 +950,23 @@ class DocStatusStorage(BaseKVStorage, ABC):
         except Exception:
             return None
         for doc_id, doc in docs.items():
-            existing_path = (
-                doc.get("file_path")
+            stored_canonical = (
+                doc.get("canonical_basename")
                 if isinstance(doc, dict)
-                else getattr(doc, "file_path", None)
+                else getattr(doc, "canonical_basename", None)
             )
-            if not existing_path:
-                continue
-            if Path(str(existing_path)).name == basename:
+            if not stored_canonical:
+                existing_path = (
+                    doc.get("file_path")
+                    if isinstance(doc, dict)
+                    else getattr(doc, "file_path", None)
+                )
+                if not existing_path:
+                    continue
+                stored_canonical = canonicalize_parser_hinted_basename(
+                    Path(str(existing_path)).name
+                )
+            if stored_canonical == target:
                 return doc_id, (doc if isinstance(doc, dict) else asdict(doc))
         return None
 

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -168,6 +168,37 @@ PARSER_ENGINE_SUFFIX_CAPABILITIES = {
 }
 PARSED_DIR_NAME = "__parsed__"  # Dir for parsed files (renamed from __enqueued__)
 
+# Per-file processing options carried by filename hints / LIGHTRAG_PARSER rules.
+# See docs/FileProcessingConfiguration-zh.md for the full specification.
+PROCESS_OPTION_IMAGES = "i"  # Enable VLM analysis for drawings/images
+PROCESS_OPTION_TABLES = "t"  # Enable VLM analysis for tables
+PROCESS_OPTION_EQUATIONS = "e"  # Enable VLM analysis for equations
+PROCESS_OPTION_SKIP_KG = "!"  # Skip entity/relation extraction (no KG build)
+PROCESS_OPTION_CHUNK_FIXED = "F"  # Fixed-length / separator chunking (default)
+PROCESS_OPTION_CHUNK_RECURSIVE = (
+    "R"  # Recursive semantic chunking (currently aliased to F)
+)
+PROCESS_OPTION_CHUNK_HEADING = "S"  # Heading-driven semantic chunking
+
+PROCESS_OPTION_CHUNK_CHARS = frozenset(
+    {
+        PROCESS_OPTION_CHUNK_FIXED,
+        PROCESS_OPTION_CHUNK_RECURSIVE,
+        PROCESS_OPTION_CHUNK_HEADING,
+    }
+)
+SUPPORTED_PROCESS_OPTIONS = frozenset(
+    {
+        PROCESS_OPTION_IMAGES,
+        PROCESS_OPTION_TABLES,
+        PROCESS_OPTION_EQUATIONS,
+        PROCESS_OPTION_SKIP_KG,
+        PROCESS_OPTION_CHUNK_FIXED,
+        PROCESS_OPTION_CHUNK_RECURSIVE,
+        PROCESS_OPTION_CHUNK_HEADING,
+    }
+)
+
 DEFAULT_MAX_PARALLEL_ANALYZE = 2  # Multimodal analysis (VLM) concurrency
 
 # Embedding configuration defaults

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -404,23 +404,33 @@ class JsonDocStatusStorage(DocStatusStorage):
     async def get_doc_by_file_basename(
         self, basename: str
     ) -> Union[tuple[str, dict[str, Any]], None]:
-        """Find an existing record whose file_path basename matches.
+        """Find an existing record whose canonical basename matches.
 
-        Compares against the stored file_path's basename so legacy records
-        that still hold a full path are matched the same way as new records
-        whose file_path is already a basename.
+        Compares against the stored ``canonical_basename`` field, falling
+        back to ``canonicalize_parser_hinted_basename(file_path)`` for
+        legacy records that pre-date the field.  Inputs are likewise
+        canonicalized so callers can pass either ``abc.docx`` or
+        ``abc.[native].docx``.
         """
         if not basename:
             return None
         if self._storage_lock is None:
             raise StorageNotInitializedError("JsonDocStatusStorage")
 
+        from lightrag.parser_routing import canonicalize_parser_hinted_basename
+
+        target = canonicalize_parser_hinted_basename(basename)
         async with self._storage_lock:
             for doc_id, doc_data in self._data.items():
-                stored_path = doc_data.get("file_path")
-                if not stored_path:
-                    continue
-                if Path(str(stored_path)).name == basename:
+                stored_canonical = doc_data.get("canonical_basename")
+                if not stored_canonical:
+                    stored_path = doc_data.get("file_path")
+                    if not stored_path:
+                        continue
+                    stored_canonical = canonicalize_parser_hinted_basename(
+                        Path(str(stored_path)).name
+                    )
+                if stored_canonical == target:
                     return doc_id, doc_data
         return None
 

--- a/lightrag/parser_routing.py
+++ b/lightrag/parser_routing.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import fnmatch
 import os
 import re
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from lightrag.constants import (
     FULL_DOCS_FORMAT_LIGHTRAG,
@@ -15,8 +16,18 @@ from lightrag.constants import (
     PARSER_ENGINE_MINERU,
     PARSER_ENGINE_NATIVE,
     PARSER_ENGINE_SUFFIX_CAPABILITIES,
+    PROCESS_OPTION_CHUNK_CHARS,
+    PROCESS_OPTION_CHUNK_FIXED,
+    PROCESS_OPTION_CHUNK_HEADING,
+    PROCESS_OPTION_CHUNK_RECURSIVE,
+    PROCESS_OPTION_EQUATIONS,
+    PROCESS_OPTION_IMAGES,
+    PROCESS_OPTION_SKIP_KG,
+    PROCESS_OPTION_TABLES,
     SUPPORTED_PARSER_ENGINES,
+    SUPPORTED_PROCESS_OPTIONS,
 )
+from lightrag.utils import logger
 
 _PARSER_RULE_SPLIT_RE = re.compile(r"[;,]")
 _PARSER_ENGINE_ENDPOINT_ENV = {
@@ -38,6 +49,119 @@ class ParserRoutingConfigError(ValueError):
 def normalize_parser_engine(engine: Any) -> str:
     """Normalize engine hints such as mineru-iet to mineru."""
     return str(engine or "").strip().split("-", 1)[0].lower()
+
+
+# ---------------------------------------------------------------------------
+# Per-file processing options (i/t/e/!/F/R/S)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProcessOptions:
+    """Decoded view of a ``process_options`` string.
+
+    The ``raw`` string is preserved verbatim (with duplicates and ordering)
+    for storage / audit purposes; boolean flags reflect the deduped logical
+    state used by the pipeline.
+    """
+
+    raw: str = ""
+    images: bool = False
+    tables: bool = False
+    equations: bool = False
+    skip_kg: bool = False
+    chunking: Literal["F", "R", "S"] = PROCESS_OPTION_CHUNK_FIXED
+
+
+_PROCESS_OPTION_DEFAULT = ProcessOptions()
+
+
+def sanitize_process_options(options: Any) -> str:
+    """Strip non-supported characters / hyphen / whitespace from an options string.
+
+    Returns the raw token sequence as-is (no dedup, no reorder) so the
+    canonical user intent is preserved on disk.  Invalid characters are
+    silently dropped — the caller is expected to have already validated.
+    """
+    if not options:
+        return ""
+    return "".join(ch for ch in str(options) if ch in SUPPORTED_PROCESS_OPTIONS)
+
+
+def validate_process_options(
+    options: str, *, label: str = "process options"
+) -> list[str]:
+    """Return a list of error messages for an options string; empty if valid."""
+    errors: list[str] = []
+    if not options:
+        return errors
+    seen_chunkers: list[str] = []
+    for ch in options:
+        if ch in (" ", "-"):
+            continue
+        if ch not in SUPPORTED_PROCESS_OPTIONS:
+            errors.append(f"{label} contains unsupported character {ch!r}")
+            continue
+        if ch in PROCESS_OPTION_CHUNK_CHARS and ch not in seen_chunkers:
+            seen_chunkers.append(ch)
+    if len(seen_chunkers) > 1:
+        errors.append(
+            f"{label} specifies multiple chunking modes "
+            f"({'/'.join(seen_chunkers)}); pick one of "
+            f"{PROCESS_OPTION_CHUNK_FIXED}/{PROCESS_OPTION_CHUNK_RECURSIVE}/{PROCESS_OPTION_CHUNK_HEADING}"
+        )
+    return errors
+
+
+def parse_process_options(options: Any) -> ProcessOptions:
+    """Decode a process-options string into a :class:`ProcessOptions` view."""
+    raw = sanitize_process_options(options)
+    if not raw:
+        return _PROCESS_OPTION_DEFAULT
+    chars = set(raw)
+    chunking: Literal["F", "R", "S"] = PROCESS_OPTION_CHUNK_FIXED
+    # Pick the first chunking selector encountered; validate_process_options
+    # already filters duplicates upstream.
+    for ch in raw:
+        if ch in PROCESS_OPTION_CHUNK_CHARS:
+            chunking = ch  # type: ignore[assignment]
+            break
+    return ProcessOptions(
+        raw=raw,
+        images=PROCESS_OPTION_IMAGES in chars,
+        tables=PROCESS_OPTION_TABLES in chars,
+        equations=PROCESS_OPTION_EQUATIONS in chars,
+        skip_kg=PROCESS_OPTION_SKIP_KG in chars,
+        chunking=chunking,
+    )
+
+
+def split_engine_and_options(bracket_inner: str) -> tuple[str | None, str]:
+    """Decompose a bracket-hint inner string into ``(engine, options)``.
+
+    Format rules (see docs/FileProcessingConfiguration-zh.md):
+        - ``ENGINE-OPTIONS``: first ``-``-separated segment is the engine
+          candidate; the remainder is the options string.
+        - ``ENGINE``: matches a supported engine name as a whole.
+        - ``OPTIONS``: anything else is treated as options-only.
+    """
+    inner = (bracket_inner or "").strip()
+    if not inner:
+        return None, ""
+
+    if "-" in inner:
+        head, _, tail = inner.partition("-")
+        engine_candidate = normalize_parser_engine(head)
+        if engine_candidate in SUPPORTED_PARSER_ENGINES:
+            return engine_candidate, tail.strip()
+        # Unknown engine before "-"; treat the whole thing as opaque options
+        # (likely invalid — caller will validate downstream).
+        return None, inner
+
+    engine_candidate = normalize_parser_engine(inner)
+    if engine_candidate in SUPPORTED_PARSER_ENGINES:
+        return engine_candidate, ""
+    return None, inner
 
 
 def parser_suffix(file_path: str | Path) -> str:
@@ -72,29 +196,79 @@ def _engine_is_usable(
     return True
 
 
-def filename_parser_hint(file_path: str | Path) -> str | None:
-    m = _PARSER_HINT_RE.search(Path(file_path).name)
+def _filename_hint_match(
+    file_path: str | Path,
+) -> tuple[re.Match[str], str, str] | None:
+    """Locate a supported ``[hint]`` segment in a basename.
+
+    Returns ``(match, engine_or_empty, options)`` when the bracket inner is a
+    recognised hint per the spec; otherwise ``None``.  Both branches require
+    the options portion to pass :func:`validate_process_options` —
+    engine-qualified hints with bad option chars (e.g. ``[native-FR]``,
+    ``[native-Q]``) fail the same way options-only hints do, so the
+    documented "invalid characters → whole hint fails → defaults apply"
+    contract holds for every hint shape.
+    """
+    basename = Path(file_path).name
+    m = _PARSER_HINT_RE.search(basename)
     if not m:
         return None
-    engine = normalize_parser_engine(m.group(1))
-    return engine if engine in SUPPORTED_PARSER_ENGINES else None
+    engine, options = split_engine_and_options(m.group(1))
+    if options:
+        option_errors = validate_process_options(options)
+        if option_errors:
+            logger.warning(
+                f"[parser_routing] ignoring filename hint {m.group(0)!r} in "
+                f"{basename!r}: {'; '.join(option_errors)}"
+            )
+            return None
+    if engine in SUPPORTED_PARSER_ENGINES:
+        return m, engine, options
+    if engine is None and options:
+        return m, "", options
+    return None
+
+
+def filename_parser_hint(file_path: str | Path) -> str | None:
+    """Return the engine inferred from a filename hint, or ``None``."""
+    found = _filename_hint_match(file_path)
+    if not found:
+        return None
+    _, engine, _ = found
+    return engine or None
+
+
+def filename_process_options(file_path: str | Path) -> str:
+    """Return the raw process-options string from a filename hint."""
+    found = _filename_hint_match(file_path)
+    if not found:
+        return ""
+    return found[2]
+
+
+def filename_parser_directives(file_path: str | Path) -> tuple[str | None, str]:
+    """Return ``(engine, options)`` decoded from a filename hint."""
+    found = _filename_hint_match(file_path)
+    if not found:
+        return None, ""
+    _, engine, options = found
+    return (engine or None), options
 
 
 def canonicalize_parser_hinted_basename(file_path: str | Path) -> str:
     """Return basename with a supported parser hint removed.
 
-    Only the final ``.[engine].ext`` segment is stripped, exactly once, and
-    only when the bracketed value normalizes to a supported parser engine.
-    Nested hints such as ``name.[native].[mineru].pdf`` therefore become
-    ``name.[native].pdf`` — additional outer hints are not unwrapped.
+    Only the final ``.[engine].ext`` (or ``.[engine-options].ext`` /
+    ``.[options].ext``) segment is stripped, exactly once, and only when the
+    bracket content is a recognised hint.  Nested hints such as
+    ``name.[native].[mineru].pdf`` therefore become ``name.[native].pdf`` —
+    additional outer hints are not unwrapped.
     """
     basename = Path(file_path).name
-    m = _PARSER_HINT_RE.search(basename)
-    if not m:
+    found = _filename_hint_match(file_path)
+    if not found:
         return basename
-    engine = normalize_parser_engine(m.group(1))
-    if engine not in SUPPORTED_PARSER_ENGINES:
-        return basename
+    m, _, _ = found
     return f"{basename[: m.start()]}{m.group(2)}"
 
 
@@ -115,6 +289,17 @@ def _rule_pattern_matches_engine_capability(pattern: str, engine: str) -> bool:
     return any(fnmatch.fnmatch(suffix, pattern) for suffix in supported_suffixes)
 
 
+def _rule_engine_and_options(engine_hint: str) -> tuple[str, str]:
+    """Split a ``LIGHTRAG_PARSER`` rule's RHS (``engine[-options]``).
+
+    Returns ``(normalized_engine, options_str)``.  Unlike the filename hint
+    splitter this always treats the first ``-`` as the engine/options
+    boundary, since ``LIGHTRAG_PARSER`` rules cannot be options-only.
+    """
+    head, _, tail = engine_hint.partition("-")
+    return normalize_parser_engine(head), tail.strip()
+
+
 def validate_parser_routing_config(parser_rules: str | None = None) -> None:
     """Validate LIGHTRAG_PARSER syntax and required external parser endpoints."""
     rules = parser_rules_from_env() if parser_rules is None else parser_rules.strip()
@@ -131,7 +316,7 @@ def validate_parser_routing_config(parser_rules: str | None = None) -> None:
         pattern, engine_hint = item.split(":", 1)
         pattern = pattern.strip().lower()
         engine_hint = engine_hint.strip()
-        engine = normalize_parser_engine(engine_hint)
+        engine, options_str = _rule_engine_and_options(engine_hint)
 
         if not pattern:
             errors.append(f"{label} has an empty suffix pattern")
@@ -162,11 +347,51 @@ def validate_parser_routing_config(parser_rules: str | None = None) -> None:
         endpoint_env = _PARSER_ENGINE_ENDPOINT_ENV.get(engine)
         if endpoint_env and not parser_engine_endpoint_configured(engine):
             errors.append(f"{label} requires {endpoint_env} to be configured")
+        if options_str:
+            errors.extend(
+                f"{label}: {msg}"
+                for msg in validate_process_options(
+                    options_str, label="process options"
+                )
+            )
 
     if errors:
         raise ParserRoutingConfigError(
             "Invalid LIGHTRAG_PARSER configuration: " + "; ".join(errors)
         )
+
+
+def _matching_rule_directives(
+    file_path: str | Path,
+    *,
+    parser_rules: str | None,
+    require_external_endpoint: bool,
+) -> tuple[str | None, str]:
+    """Find the first matching ``LIGHTRAG_PARSER`` rule for ``file_path``.
+
+    Returns ``(engine, options_str)`` where ``engine`` is ``None`` when no
+    usable rule is found.  ``options_str`` is empty when a rule matched but
+    has no ``-options`` suffix.
+    """
+    suffix = parser_suffix(file_path)
+    rules = parser_rules_from_env() if parser_rules is None else parser_rules.strip()
+    if not rules:
+        return None, ""
+    for _, item in _iter_parser_rule_items(rules):
+        if ":" not in item:
+            continue
+        pattern, engine_hint = item.split(":", 1)
+        pattern = pattern.strip().lower()
+        engine, options_str = _rule_engine_and_options(engine_hint.strip())
+        if not fnmatch.fnmatch(suffix, pattern):
+            continue
+        if _engine_is_usable(
+            engine,
+            suffix,
+            require_external_endpoint=require_external_endpoint,
+        ):
+            return engine, options_str
+    return None, ""
 
 
 def resolve_file_parser_engine(
@@ -176,32 +401,49 @@ def resolve_file_parser_engine(
     require_external_endpoint: bool = True,
 ) -> str:
     """Resolve the extraction engine for a source file before content extraction."""
+    engine, _ = resolve_file_parser_directives(
+        file_path,
+        parser_rules=parser_rules,
+        require_external_endpoint=require_external_endpoint,
+    )
+    return engine
+
+
+def resolve_file_parser_directives(
+    file_path: str | Path,
+    *,
+    parser_rules: str | None = None,
+    require_external_endpoint: bool = True,
+) -> tuple[str, str]:
+    """Resolve ``(engine, process_options)`` for a source file before extraction.
+
+    Resolution order (mirrors :func:`resolve_file_parser_engine`):
+        1. Filename ``[hint]`` — engine and / or options take precedence.
+        2. ``LIGHTRAG_PARSER`` rules — first matching rule provides defaults
+           for whichever of engine / options the filename hint did not
+           specify.
+        3. Default engine ``legacy`` with empty options.
+    """
     suffix = parser_suffix(file_path)
 
-    hint = filename_parser_hint(file_path)
-    if hint and _engine_is_usable(
-        hint, suffix, require_external_endpoint=require_external_endpoint
+    hinted_engine, hinted_options = filename_parser_directives(file_path)
+    if hinted_engine and not _engine_is_usable(
+        hinted_engine, suffix, require_external_endpoint=require_external_endpoint
     ):
-        return hint
+        # Hinted engine cannot handle this file (e.g. wrong suffix or missing
+        # endpoint); fall back to rule-based resolution but keep the hinted
+        # options if any.
+        hinted_engine = None
 
-    rules = parser_rules_from_env() if parser_rules is None else parser_rules.strip()
-    if rules:
-        for _, item in _iter_parser_rule_items(rules):
-            if ":" not in item:
-                continue
-            pattern, engine_hint = item.split(":", 1)
-            pattern = pattern.strip().lower()
-            engine = normalize_parser_engine(engine_hint)
-            if not fnmatch.fnmatch(suffix, pattern):
-                continue
-            if _engine_is_usable(
-                engine,
-                suffix,
-                require_external_endpoint=require_external_endpoint,
-            ):
-                return engine
+    rule_engine, rule_options = _matching_rule_directives(
+        file_path,
+        parser_rules=parser_rules,
+        require_external_endpoint=require_external_endpoint,
+    )
 
-    return PARSER_ENGINE_LEGACY
+    engine = hinted_engine or rule_engine or PARSER_ENGINE_LEGACY
+    options_str = hinted_options or rule_options
+    return engine, sanitize_process_options(options_str)
 
 
 def resolve_stored_document_parser_engine(

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -66,6 +66,7 @@ from lightrag.utils_pipeline import (
     compute_text_content_hash,
     doc_status_field,
     doc_status_value,
+    document_canonical_key,
     document_source_key,
     get_by_path,
     get_duplicate_doc_by_content_hash,
@@ -101,6 +102,7 @@ class _PipelineMixin:
         docs_format: str = FULL_DOCS_FORMAT_RAW,
         lightrag_document_paths: str | list[str] | None = None,
         parsed_engine: str | list[str] | None = None,
+        process_options: str | list[str] | None = None,
         reprocess_existing_non_processed: bool = False,
     ) -> str:
         """
@@ -119,6 +121,10 @@ class _PipelineMixin:
             docs_format: "raw" (default) or "lightrag"; when "lightrag" content may be empty and content-dedup is skipped
             lightrag_document_paths: paths to LightRAG Document (e.g. .blocks.jsonl dir or base path), when docs_format is lightrag
             parsed_engine: file extraction engine already used or target engine for pending_parse
+            process_options: per-document processing options string (i/t/e/!/F/R/S);
+                accepted as a single string broadcast to every input or as a list
+                aligned with ``input``. Stored verbatim on ``full_docs`` and
+                mirrored to ``doc_status.metadata['process_options']``.
             reprocess_existing_non_processed: allow scan retries to overwrite
                 existing same-name records that have not reached PROCESSED.
 
@@ -140,6 +146,8 @@ class _PipelineMixin:
             )
         if isinstance(parsed_engine, str):
             parsed_engine = [parsed_engine] * len(input)
+        if isinstance(process_options, str):
+            process_options = [process_options] * len(input)
 
         # If file_paths is provided, ensure it matches the number of documents
         if file_paths is not None:
@@ -166,12 +174,23 @@ class _PipelineMixin:
             raise ValueError(
                 "Number of parsed engines must match the number of documents"
             )
+        if process_options is not None and len(process_options) != len(input):
+            raise ValueError(
+                "Number of process options must match the number of documents"
+            )
 
         def _parsed_engine_at(index: int) -> str | None:
             if parsed_engine is None:
                 return None
             engine = str(parsed_engine[index] or "").strip().lower()
             return engine or None
+
+        def _process_options_at(index: int) -> str:
+            if process_options is None:
+                return ""
+            from lightrag.parser_routing import sanitize_process_options
+
+            return sanitize_process_options(process_options[index])
 
         # 1. Validate ids and build contents (when lightrag: no content dedup, content may be empty)
         if ids is not None:
@@ -180,7 +199,15 @@ class _PipelineMixin:
             if len(ids) != len(set(ids)):
                 raise ValueError("IDs must be unique")
 
+        # Two basenames per file:
+        #  - source_keys: user-visible name preserved verbatim, written as
+        #    full_docs.file_path / doc_status.file_path so the UI can render
+        #    the user's original ``[hint]`` choice.
+        #  - canonical_keys: parser-hint stripped basename used for filename
+        #    dedup and as the seed for deterministic doc_ids; written as
+        #    full_docs.canonical_basename / doc_status.canonical_basename.
         source_keys = [document_source_key(path) for path in file_paths]
+        canonical_keys = [document_canonical_key(path) for path in file_paths]
         contents: dict[str, dict[str, Any]] = {}
         source_to_doc_id: dict[str, str] = {}
         content_hash_to_doc_id: dict[str, str] = {}
@@ -194,6 +221,7 @@ class _PipelineMixin:
             lightrag_document_path: str | None = None,
         ) -> None:
             source_key = source_keys[index]
+            canonical_key = canonical_keys[index]
             source_path = file_paths[index]
 
             # Compute content hash: skip for pending_parse (content extracted later).
@@ -205,25 +233,25 @@ class _PipelineMixin:
                     resolve_lightrag_document_path(lightrag_document_path)
                 )
 
-            known_source = has_known_document_source(source_key)
+            known_source = has_known_document_source(canonical_key)
             if ids is not None:
                 doc_id = ids[index]
             elif known_source:
-                doc_id = compute_mdhash_id(source_key, prefix="doc-")
+                doc_id = compute_mdhash_id(canonical_key, prefix="doc-")
             elif doc_format == FULL_DOCS_FORMAT_RAW:
                 doc_id = compute_mdhash_id(content or "", prefix="doc-")
             elif content_hash:
                 doc_id = compute_mdhash_id(content_hash, prefix="doc-")
             else:
                 doc_id = compute_mdhash_id(
-                    f"{source_key}-{track_id}-{index}", prefix="doc-"
+                    f"{canonical_key}-{track_id}-{index}", prefix="doc-"
                 )
 
-            if known_source and source_key in source_to_doc_id:
+            if known_source and canonical_key in source_to_doc_id:
                 duplicate_attempts.append(
                     {
                         "doc_id": doc_id,
-                        "original_doc_id": source_to_doc_id[source_key],
+                        "original_doc_id": source_to_doc_id[canonical_key],
                         "file_path": source_key,
                         "content_length": len(content or ""),
                         "existing_status": "batch_duplicate",
@@ -248,23 +276,31 @@ class _PipelineMixin:
                 return
 
             if known_source:
-                source_to_doc_id[source_key] = doc_id
+                source_to_doc_id[canonical_key] = doc_id
             if content_hash:
                 content_hash_to_doc_id[content_hash] = doc_id
 
-            content_data = {
+            content_data: dict[str, Any] = {
                 "content": content,
                 "file_path": source_key,
+                "canonical_basename": canonical_key,
                 "format": doc_format,
             }
             if content_hash:
                 content_data["content_hash"] = content_hash
-            if str(source_path).strip() and str(source_path).strip() != source_key:
+            # Persist the original path only when it actually carries directory
+            # information (absolute path or contains a separator); a plain
+            # basename is already captured by ``file_path``.
+            raw_source = str(source_path).strip()
+            if raw_source and (os.sep in raw_source or "/" in raw_source):
                 content_data["source_path"] = source_path
             if lightrag_document_path:
                 content_data["lightrag_document_path"] = lightrag_document_path
             if engine := _parsed_engine_at(index):
                 content_data["parsed_engine"] = engine
+            options_str = _process_options_at(index)
+            if options_str:
+                content_data["process_options"] = options_str
             contents[doc_id] = content_data
 
         if is_lightrag_format:
@@ -318,21 +354,28 @@ class _PipelineMixin:
                 _add_content(i, cleaned_content, FULL_DOCS_FORMAT_RAW)
 
         # 2. Generate document initial status (without content)
-        new_docs: dict[str, Any] = {
-            id_: {
+        def _initial_doc_status(content_data: dict[str, Any]) -> dict[str, Any]:
+            base: dict[str, Any] = {
                 "status": DocStatus.PENDING,
                 "content_summary": get_content_summary(content_data.get("content", "")),
                 "content_length": len(content_data.get("content", "")),
                 "created_at": datetime.now(timezone.utc).isoformat(),
                 "updated_at": datetime.now(timezone.utc).isoformat(),
                 "file_path": content_data["file_path"],
+                "canonical_basename": content_data.get("canonical_basename"),
                 "track_id": track_id,
-                **(
-                    {"content_hash": content_data["content_hash"]}
-                    if content_data.get("content_hash")
-                    else {}
-                ),
             }
+            if content_data.get("content_hash"):
+                base["content_hash"] = content_data["content_hash"]
+            options_str = content_data.get("process_options") or ""
+            if options_str:
+                # Mirror process_options into doc_status.metadata so admin UIs
+                # can surface the per-document strategy without a full_docs lookup.
+                base["metadata"] = {"process_options": options_str}
+            return base
+
+        new_docs: dict[str, Any] = {
+            id_: _initial_doc_status(content_data)
             for id_, content_data in contents.items()
         }
 
@@ -521,6 +564,7 @@ class _PipelineMixin:
             doc_id: {
                 "content": contents[doc_id].get("content", ""),
                 "file_path": contents[doc_id]["file_path"],
+                "canonical_basename": contents[doc_id].get("canonical_basename"),
                 "format": contents[doc_id].get("format", FULL_DOCS_FORMAT_RAW),
             }
             for doc_id in new_docs.keys()
@@ -539,6 +583,10 @@ class _PipelineMixin:
             if contents[doc_id].get("parsed_engine"):
                 full_docs_data[doc_id]["parsed_engine"] = contents[doc_id][
                     "parsed_engine"
+                ]
+            if contents[doc_id].get("process_options"):
+                full_docs_data[doc_id]["process_options"] = contents[doc_id][
+                    "process_options"
                 ]
         await self.full_docs.upsert(full_docs_data)
         # Persist data to disk immediately
@@ -1100,6 +1148,17 @@ class _PipelineMixin:
 
                             extraction_meta: dict[str, Any] = {}
 
+                            # Decode per-document processing options once; later
+                            # stages (multimodal hook / KG extraction) re-read
+                            # them from full_docs as well.
+                            from lightrag.parser_routing import (
+                                parse_process_options,
+                            )
+
+                            doc_process_opts = parse_process_options(
+                                (content_data or {}).get("process_options", "")
+                            )
+
                             # Try to parse as interchange JSONL (smart extraction output)
                             parsed_interchange = parse_interchange_jsonl(
                                 content, self.tokenizer
@@ -1118,14 +1177,26 @@ class _PipelineMixin:
                                         "format_version"
                                     ),
                                     "engine": interchange_meta.get("engine"),
-                                    "engine_capabilities": interchange_meta.get(
-                                        "engine_capabilities", []
-                                    ),
                                     "chunking_method": interchange_meta.get(
                                         "chunking_method"
                                     ),
                                 }
                             else:
+                                # Per-document chunking strategy:
+                                #  - 'F' (default): use the configured chunking_func
+                                #    (chunking_by_token_size).
+                                #  - 'S' / 'R': require structured input which the
+                                #    legacy text path cannot provide; fall back to
+                                #    'F' and log a warning so the user knows their
+                                #    selection had no effect for this document.
+                                if doc_process_opts.chunking != "F":
+                                    logger.warning(
+                                        f"[chunking] process_options chunking="
+                                        f"{doc_process_opts.chunking!r} requested for d-id: "
+                                        f"{doc_id}, file: {file_path}, but no structured "
+                                        f"interchange output is available; falling back to "
+                                        f"fixed chunking ('F')."
+                                    )
                                 # Call chunking function, supporting both sync and async implementations
                                 chunking_result = self.chunking_func(
                                     self.tokenizer,
@@ -1149,6 +1220,11 @@ class _PipelineMixin:
                                 extraction_meta = {
                                     "extraction_format": "plain_text_chunking",
                                     "engine": "legacy",
+                                    "chunking_method": (
+                                        "fixed_token_fallback"
+                                        if doc_process_opts.chunking != "F"
+                                        else "fixed_token"
+                                    ),
                                 }
 
                             # Multimodal post-process hook entrypoint:
@@ -1308,18 +1384,29 @@ class _PipelineMixin:
                             # Execute first stage tasks
                             await asyncio.gather(*first_stage_tasks)
 
-                            # Stage 2: Process entity relation graph (after text_chunks are saved)
-                            entity_relation_task = asyncio.create_task(
-                                self._process_extract_entities(
-                                    chunks, pipeline_status, pipeline_status_lock
+                            # Stage 2: Process entity relation graph (after text_chunks are saved).
+                            # When the user opted out via process_options '!', skip
+                            # entity/relation extraction entirely; chunks remain in
+                            # the vector store so naive / mix retrieval still works.
+                            if doc_process_opts.skip_kg:
+                                logger.info(
+                                    f"[skip_kg] process_options '!' set for d-id: {doc_id}; "
+                                    f"skipping entity/relation extraction"
                                 )
-                            )
-                            chunk_results = await entity_relation_task
-                            chunk_results = augment_chunk_results_with_mm_entities(
-                                chunk_results=chunk_results,
-                                mm_specs=mm_specs,
-                                file_path=file_path,
-                            )
+                                chunk_results = []
+                                extraction_meta["skip_kg"] = True
+                            else:
+                                entity_relation_task = asyncio.create_task(
+                                    self._process_extract_entities(
+                                        chunks, pipeline_status, pipeline_status_lock
+                                    )
+                                )
+                                chunk_results = await entity_relation_task
+                                chunk_results = augment_chunk_results_with_mm_entities(
+                                    chunk_results=chunk_results,
+                                    mm_specs=mm_specs,
+                                    file_path=file_path,
+                                )
                             file_extraction_stage_ok = True
 
                         except Exception as e:
@@ -1407,25 +1494,30 @@ class _PipelineMixin:
                                             "User cancelled"
                                         )
 
-                                # Use chunk_results from entity_relation_task
-                                await merge_nodes_and_edges(
-                                    chunk_results=chunk_results,  # result collected from entity_relation_task
-                                    knowledge_graph_inst=self.chunk_entity_relation_graph,
-                                    entity_vdb=self.entities_vdb,
-                                    relationships_vdb=self.relationships_vdb,
-                                    global_config=self._build_global_config(),
-                                    full_entities_storage=self.full_entities,
-                                    full_relations_storage=self.full_relations,
-                                    doc_id=doc_id,
-                                    pipeline_status=pipeline_status,
-                                    pipeline_status_lock=pipeline_status_lock,
-                                    llm_response_cache=self.llm_response_cache,
-                                    entity_chunks_storage=self.entity_chunks,
-                                    relation_chunks_storage=self.relation_chunks,
-                                    current_file_number=current_file_number,
-                                    total_files=total_files,
-                                    file_path=file_path,
-                                )
+                                # Use chunk_results from entity_relation_task.
+                                # When skip_kg is set, chunk_results is empty so
+                                # there are no nodes/edges to merge — but we
+                                # still need to flush the chunks_vdb / text_chunks
+                                # writes (already done above) and reach PROCESSED.
+                                if not doc_process_opts.skip_kg:
+                                    await merge_nodes_and_edges(
+                                        chunk_results=chunk_results,  # result collected from entity_relation_task
+                                        knowledge_graph_inst=self.chunk_entity_relation_graph,
+                                        entity_vdb=self.entities_vdb,
+                                        relationships_vdb=self.relationships_vdb,
+                                        global_config=self._build_global_config(),
+                                        full_entities_storage=self.full_entities,
+                                        full_relations_storage=self.full_relations,
+                                        doc_id=doc_id,
+                                        pipeline_status=pipeline_status,
+                                        pipeline_status_lock=pipeline_status_lock,
+                                        llm_response_cache=self.llm_response_cache,
+                                        entity_chunks_storage=self.entity_chunks,
+                                        relation_chunks_storage=self.relation_chunks,
+                                        current_file_number=current_file_number,
+                                        total_files=total_files,
+                                        file_path=file_path,
+                                    )
 
                                 # Record processing end time
                                 processing_end_time = int(time.time())
@@ -1766,11 +1858,25 @@ class _PipelineMixin:
         doc_id: str,
         file_path: str,
         parsed_data: dict[str, Any],
+        *,
+        process_options: str | None = None,
     ) -> dict[str, Any]:
         """Phase 2: Multimodal analysis (VLM). Writes llm_analyze_result and analyze_time to LightRAG Document.
-        Uses vlm_llm_model_func (VLM role). When Ray-Anything merges, bind VLM model here.
-        Default: no-op, returns parsed_data unchanged.
+
+        Per-document ``i`` / ``t`` / ``e`` flags from
+        ``full_docs.process_options`` decide which modalities are sent to the
+        VLM.  Sidecars are always written by the parser regardless of these
+        flags so toggling options later does not require re-parsing — only
+        the ``llm_analyze_result`` payload is gated here.
+
+        Args:
+            process_options: Optional override that bypasses the
+                ``full_docs.process_options`` lookup; primarily used by unit
+                tests that exercise the VLM analysis path without going
+                through the enqueue pipeline.
         """
+        from lightrag.parser_routing import parse_process_options
+
         blocks_path = parsed_data.get("blocks_path")
         if not blocks_path:
             return parsed_data
@@ -1778,6 +1884,56 @@ class _PipelineMixin:
         block_file = Path(blocks_path)
         if not block_file.exists():
             return parsed_data
+
+        # Resolve which modalities the user opted into for this document.
+        if process_options is None:
+            try:
+                content_data = await self.full_docs.get_by_id(doc_id) or {}
+            except Exception:
+                content_data = {}
+            options_str = (
+                content_data.get("process_options")
+                if isinstance(content_data, dict)
+                else ""
+            ) or ""
+        else:
+            options_str = process_options
+        process_opts = parse_process_options(options_str)
+        if not (process_opts.images or process_opts.tables or process_opts.equations):
+            logger.debug(
+                f"[analyze_multimodal] no i/t/e options set for d-id: {doc_id}; "
+                f"skipping VLM analysis"
+            )
+            return parsed_data
+
+        # Diagnose opt-in vs sidecar mismatch up-front so users investigating
+        # "why did VLM not run on my images" see a one-line INFO per document
+        # instead of silent skips.  Empty sidecars are a normal outcome
+        # (some documents simply have no images/tables/equations), so this is
+        # informational rather than a warning.
+        sidecar_base = str(block_file)
+        if sidecar_base.endswith(".blocks.jsonl"):
+            sidecar_base = sidecar_base[: -len(".blocks.jsonl")]
+        opt_in_missing: list[str] = []
+        for opt_char, modality, suffix in (
+            ("i", "drawings", ".drawings.json"),
+            ("t", "tables", ".tables.json"),
+            ("e", "equations", ".equations.json"),
+        ):
+            enabled = {
+                "i": process_opts.images,
+                "t": process_opts.tables,
+                "e": process_opts.equations,
+            }[opt_char]
+            if enabled and not Path(sidecar_base + suffix).exists():
+                opt_in_missing.append(f"{opt_char}:{modality}")
+        if opt_in_missing:
+            logger.info(
+                f"[analyze_multimodal] process_options opted into "
+                f"{','.join(opt_in_missing)} for d-id: {doc_id} (file={file_path}), "
+                f"but the parser produced no such sidecar; VLM analysis skipped "
+                f"for those modalities."
+            )
 
         try:
             lines = block_file.read_text(encoding="utf-8").splitlines()
@@ -2041,11 +2197,17 @@ class _PipelineMixin:
             if base_name.endswith(".blocks.jsonl"):
                 base_name = base_name[: -len(".blocks.jsonl")]
             sidecars = [
-                (Path(base_name + ".drawings.json"), "drawings"),
-                (Path(base_name + ".tables.json"), "tables"),
-                (Path(base_name + ".equations.json"), "equations"),
+                (Path(base_name + ".drawings.json"), "drawings", process_opts.images),
+                (Path(base_name + ".tables.json"), "tables", process_opts.tables),
+                (
+                    Path(base_name + ".equations.json"),
+                    "equations",
+                    process_opts.equations,
+                ),
             ]
-            for sidecar_path, root_key in sidecars:
+            for sidecar_path, root_key, enabled in sidecars:
+                if not enabled:
+                    continue
                 if not sidecar_path.exists():
                     continue
                 try:
@@ -2186,6 +2348,15 @@ class _PipelineMixin:
         ``get_doc_by_content_hash`` lookups can dedupe across pending_parse
         records that did not have a hash at enqueue time. Also patches the
         existing ``doc_status`` row so both storages stay aligned.
+
+        The original ``pending_parse`` record carries metadata seeded at
+        enqueue time (``process_options``, ``canonical_basename``,
+        ``source_path``, ...) that downstream stages still need after parsing.
+        ``full_docs`` upserts overwrite the entire row, so we merge the
+        existing record with the new ``record`` payload before upserting:
+        fresh fields from ``record`` (``content`` / ``format`` /
+        ``lightrag_document_path`` / ``parsed_engine`` / ``update_time``)
+        take precedence, while pre-existing fields are preserved.
         """
         fmt = record.get("format")
         content_hash: str | None = None
@@ -2198,7 +2369,11 @@ class _PipelineMixin:
                     resolve_lightrag_document_path(blocks_path)
                 )
 
-        payload = dict(record)
+        existing = await self.full_docs.get_by_id(doc_id)
+        if isinstance(existing, dict):
+            payload = {**existing, **record}
+        else:
+            payload = dict(record)
         if content_hash:
             payload["content_hash"] = content_hash
 
@@ -2970,21 +3145,45 @@ class _PipelineMixin:
 
         Default behavior is no-op. This method defines a stable extension point
         for built-in multimodal processors.
+
+        Activates when the per-document ``process_options`` opts into at least
+        one of ``i`` / ``t`` / ``e``.  Per-modality work in subsequent steps
+        (``_build_mm_chunks_from_sidecars``, ``analyze_multimodal``) decides
+        whether to act based on whether ``drawings.json`` / ``tables.json`` /
+        ``equations.json`` actually exist on disk — the parser declares
+        modality availability by writing those sidecars, not by listing
+        capabilities in meta.
         """
-        addon_params = self.addon_params
-        if not addon_params.get("enable_multimodal_pipeline", False):
-            return chunking_result
+        from lightrag.parser_routing import parse_process_options
 
         extraction_format = extraction_meta.get("extraction_format")
-        capabilities = set(extraction_meta.get("engine_capabilities", []) or [])
         if extraction_format != "interchange_jsonl":
             return chunking_result
-        if not capabilities.intersection({"i", "e", "t"}):
+
+        try:
+            content_data = await self.full_docs.get_by_id(doc_id) or {}
+        except Exception:
+            content_data = {}
+        process_opts = parse_process_options(
+            content_data.get("process_options")
+            if isinstance(content_data, dict)
+            else ""
+        )
+        active = {
+            ch
+            for ch, enabled in (
+                ("i", process_opts.images),
+                ("t", process_opts.tables),
+                ("e", process_opts.equations),
+            )
+            if enabled
+        }
+        if not active:
             return chunking_result
 
         logger.info(
             f"[multimodal-hook] enabled for d-id: {doc_id}, file: {file_path}, "
-            f"engine={extraction_meta.get('engine')}, caps={sorted(capabilities)}"
+            f"engine={extraction_meta.get('engine')}, opts={sorted(active)}"
         )
 
         # TODO(multimodal pipeline):

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -92,14 +92,35 @@ def resolve_doc_file_path(
 
 
 def document_source_key(file_path: Any) -> str:
-    """Return the filename-level key used for document uniqueness."""
+    """Return the user-visible basename for ``full_docs.file_path``.
+
+    Preserves any ``[hint]`` segment so the UI can show users their original
+    naming intent.  Use :func:`document_canonical_key` to get the canonical
+    form used for filename-based deduplication.
+    """
     source = str(file_path or "").strip()
     if source in PLACEHOLDER_DOCUMENT_SOURCES:
         return "unknown_source"
-    filename = canonicalize_parser_hinted_basename(source).strip()
-    if filename in PLACEHOLDER_DOCUMENT_SOURCES:
+    basename = Path(source).name.strip()
+    if basename in PLACEHOLDER_DOCUMENT_SOURCES:
         return "unknown_source"
-    return filename or "unknown_source"
+    return basename or "unknown_source"
+
+
+def document_canonical_key(file_path: Any) -> str:
+    """Return the canonical basename used for filename dedup / doc_id seeding.
+
+    Strips any supported ``[hint]`` segment so ``abc.docx`` and
+    ``abc.[native-iet].docx`` map to the same key.  Returns
+    ``"unknown_source"`` for placeholder sources.
+    """
+    source = str(file_path or "").strip()
+    if source in PLACEHOLDER_DOCUMENT_SOURCES:
+        return "unknown_source"
+    canonical = canonicalize_parser_hinted_basename(source).strip()
+    if canonical in PLACEHOLDER_DOCUMENT_SOURCES:
+        return "unknown_source"
+    return canonical or "unknown_source"
 
 
 def has_known_document_source(source_key: str) -> bool:
@@ -165,14 +186,14 @@ def configured_input_dir() -> Path:
 async def get_existing_doc_by_file_basename(
     doc_status: DocStatusStorage, file_path: Any
 ) -> tuple[str, Any] | None:
-    """Find an existing doc_status record by file basename.
+    """Find an existing doc_status record by canonical file basename.
 
-    Both write and lookup paths feed file_path through ``document_source_key``
-    first, so stored basenames are already canonical (parser hints stripped).
-    Storage backends therefore compare canonical-vs-canonical and do not need
-    to re-run any normalization themselves.
+    Stored ``file_path`` values keep any ``[hint]`` segment intact so the UI
+    can surface the user's original naming.  Filename-based dedup, however,
+    operates on the canonical (hint-stripped) basename so ``abc.docx`` and
+    ``abc.[native-iet].docx`` are treated as the same logical document.
     """
-    basename = document_source_key(file_path)
+    basename = document_canonical_key(file_path)
     if basename == "unknown_source":
         return None
     return await doc_status.get_doc_by_file_basename(basename)

--- a/tests/test_document_routes_docx_archive.py
+++ b/tests/test_document_routes_docx_archive.py
@@ -61,6 +61,7 @@ class _FakeRag:
         track_id=None,
         docs_format=None,
         parsed_engine=None,
+        process_options=None,
         reprocess_existing_non_processed=False,
     ):
         item = {
@@ -69,6 +70,7 @@ class _FakeRag:
             "track_id": track_id,
             "docs_format": docs_format,
             "parsed_engine": parsed_engine,
+            "process_options": process_options,
         }
         if reprocess_existing_non_processed:
             item["reprocess_existing_non_processed"] = True
@@ -145,6 +147,14 @@ class _ParseFullDocs:
         self.source_path = source_path
         self.events = []
         self.data = {}
+
+    async def get_by_id(self, doc_id):
+        # ``_persist_parsed_full_docs`` merges with the existing pending_parse
+        # record so metadata seeded at enqueue time (process_options,
+        # canonical_basename, ...) survives the parse-result overwrite. These
+        # tests only seed the row via the parser, so returning None is fine.
+        record = self.data.get(doc_id)
+        return dict(record) if record is not None else None
 
     async def upsert(self, data):
         self.events.append("upsert")
@@ -249,6 +259,7 @@ async def test_pipeline_enqueue_docx_plain_text_extracts_before_enqueue(
             "track_id": "track-docx",
             "docs_format": None,
             "parsed_engine": "legacy",
+            "process_options": None,
         }
     ]
     assert not file_path.exists()
@@ -272,6 +283,7 @@ async def test_pipeline_enqueue_md_moves_after_enqueue(tmp_path, monkeypatch):
             "track_id": "track-md",
             "docs_format": None,
             "parsed_engine": "legacy",
+            "process_options": None,
         }
     ]
     assert not file_path.exists()
@@ -330,8 +342,56 @@ async def test_pipeline_enqueue_parser_routed_pdf_defers_without_extraction(
             "track_id": "track-pdf",
             "docs_format": FULL_DOCS_FORMAT_PENDING_PARSE,
             "parsed_engine": "mineru",
+            "process_options": None,
         }
     ]
+
+
+async def test_pipeline_enqueue_passes_process_options_from_filename_hint(
+    tmp_path, monkeypatch
+):
+    """Filename hint ``[native-iet]`` flows into apipeline_enqueue_documents."""
+    monkeypatch.setenv("LIGHTRAG_PARSER", "docx:native")
+    file_path = tmp_path / "report.[native-iet].docx"
+    file_path.write_bytes(b"docx-bytes")
+    rag = _FakeRag()
+
+    success, returned_track_id = await pipeline_enqueue_file(
+        rag, file_path, "track-options"
+    )
+
+    assert success is True
+    assert returned_track_id == "track-options"
+    assert rag.enqueued == [
+        {
+            "input": "",
+            "file_path": str(file_path),
+            "track_id": "track-options",
+            "docs_format": FULL_DOCS_FORMAT_PENDING_PARSE,
+            "parsed_engine": "native",
+            "process_options": "iet",
+        }
+    ]
+    # Native engine deferral keeps the source file in place for the parser.
+    assert file_path.exists()
+
+
+async def test_pipeline_enqueue_lightrag_parser_rule_provides_default_options(
+    tmp_path, monkeypatch
+):
+    """LIGHTRAG_PARSER ``docx:native-iet`` becomes the default ``process_options``."""
+    monkeypatch.setenv("LIGHTRAG_PARSER", "docx:native-iet,*:legacy")
+    file_path = tmp_path / "rule_default.docx"
+    file_path.write_bytes(b"docx-bytes")
+    rag = _FakeRag()
+
+    success, _ = await pipeline_enqueue_file(rag, file_path, "track-rule-default")
+
+    assert success is True
+    assert len(rag.enqueued) == 1
+    enqueued = rag.enqueued[0]
+    assert enqueued["parsed_engine"] == "native"
+    assert enqueued["process_options"] == "iet"
 
 
 async def test_pipeline_index_files_leaves_lightrag_document_docx_batch(

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -129,6 +129,165 @@ def test_canonicalize_parser_hinted_basename():
         canonicalize_parser_hinted_basename("name.[native].[mineru].pdf")
         == "name.[native].pdf"
     )
+    # New options-only and engine+options forms strip cleanly too.
+    assert canonicalize_parser_hinted_basename("foo.[!].docx") == "foo.docx"
+    assert canonicalize_parser_hinted_basename("foo.[native-iet].docx") == "foo.docx"
+    assert canonicalize_parser_hinted_basename("foo.[mineru-R!].pdf") == "foo.pdf"
+    # Invalid options-only hint (unknown chars) is left alone.
+    assert canonicalize_parser_hinted_basename("foo.[xyz].docx") == "foo.[xyz].docx"
+
+
+@pytest.mark.offline
+def test_filename_parser_directives_decodes_engine_and_options():
+    from lightrag.parser_routing import filename_parser_directives
+
+    assert filename_parser_directives("paper.[native-iet].docx") == ("native", "iet")
+    assert filename_parser_directives("memo.[native-R!].md") == ("native", "R!")
+    assert filename_parser_directives("report.[!].pdf") == (None, "!")
+    assert filename_parser_directives("doc.[mineru].docx") == ("mineru", "")
+    assert filename_parser_directives("foo.docx") == (None, "")
+    # Unsupported tokens leave the hint untouched and unparsed.
+    assert filename_parser_directives("foo.[draft].docx") == (None, "")
+
+
+@pytest.mark.offline
+def test_filename_hint_rejects_invalid_engine_qualified_options():
+    """Engine-qualified hints with bad option chars must fail validation
+    the same way options-only hints do, so the documented behaviour
+    "invalid characters → whole hint fails → defaults apply" holds across
+    all hint shapes (otherwise foo.[native-FR].docx would be canonicalised
+    even though its options conflict).
+    """
+    from lightrag.parser_routing import (
+        canonicalize_parser_hinted_basename,
+        filename_parser_directives,
+    )
+
+    # F+R conflict → hint dropped; engine and options are NOT applied.
+    assert filename_parser_directives("foo.[native-FR].docx") == (None, "")
+    # Unknown char Q → hint dropped; engine native is also NOT applied.
+    assert filename_parser_directives("foo.[native-Q].docx") == (None, "")
+
+    # The basename must remain unchanged so the documented "defaults apply"
+    # path in the dedup index reflects the literal file the user supplied.
+    assert (
+        canonicalize_parser_hinted_basename("foo.[native-FR].docx")
+        == "foo.[native-FR].docx"
+    )
+    assert (
+        canonicalize_parser_hinted_basename("foo.[native-Q].docx")
+        == "foo.[native-Q].docx"
+    )
+
+
+@pytest.mark.offline
+def test_parse_process_options_decodes_flags():
+    from lightrag.parser_routing import parse_process_options
+
+    opts = parse_process_options("iet")
+    assert opts.images and opts.tables and opts.equations
+    assert not opts.skip_kg
+    assert opts.chunking == "F"
+
+    opts = parse_process_options("R!")
+    assert opts.skip_kg and opts.chunking == "R"
+    assert not opts.images and not opts.tables and not opts.equations
+
+    opts = parse_process_options("S")
+    assert opts.chunking == "S"
+
+    opts = parse_process_options("")
+    assert not (opts.images or opts.tables or opts.equations or opts.skip_kg)
+    assert opts.chunking == "F"
+
+
+@pytest.mark.offline
+def test_validate_process_options_rejects_invalid_combos():
+    from lightrag.parser_routing import validate_process_options
+
+    assert validate_process_options("iet") == []
+    assert validate_process_options("R!") == []
+    # F+R conflict is reported.
+    errs = validate_process_options("FR")
+    assert any("multiple chunking modes" in m for m in errs)
+    # Lowercase chunking selectors are not valid.
+    errs = validate_process_options("f")
+    assert any("'f'" in m for m in errs)
+    # Unknown chars are reported individually.
+    errs = validate_process_options("xyz")
+    assert sum(1 for m in errs if "unsupported character" in m) == 3
+
+
+@pytest.mark.offline
+def test_lightrag_parser_rule_supports_options_suffix(monkeypatch):
+    monkeypatch.setenv("MINERU_ENDPOINT", "http://fake-mineru")
+    monkeypatch.delenv("DOCLING_ENDPOINT", raising=False)
+    # Valid options suffix passes validation.
+    validate_parser_routing_config("docx:native-iet,*:legacy")
+
+    # Invalid options suffix is rejected with the rule label and message.
+    with pytest.raises(ParserRoutingConfigError, match="multiple chunking modes"):
+        validate_parser_routing_config("docx:native-FR,*:legacy")
+
+    with pytest.raises(ParserRoutingConfigError, match="unsupported character"):
+        validate_parser_routing_config("docx:native-Q,*:legacy")
+
+
+@pytest.mark.offline
+def test_resolve_file_parser_directives_priority(monkeypatch):
+    from lightrag.parser_routing import resolve_file_parser_directives
+
+    monkeypatch.setenv("MINERU_ENDPOINT", "http://fake-mineru")
+    monkeypatch.setenv("LIGHTRAG_PARSER", "docx:native-iet,*:legacy")
+
+    # Filename hint takes precedence for engine and options.
+    engine, options = resolve_file_parser_directives("paper.[native-R!].docx")
+    assert engine == "native"
+    assert options == "R!"
+
+    # No filename hint → fall through to LIGHTRAG_PARSER defaults for both.
+    engine, options = resolve_file_parser_directives("plain.docx")
+    assert engine == "native"
+    assert options == "iet"
+
+    # Options-only hint keeps engine from rule but uses hinted options.
+    engine, options = resolve_file_parser_directives("plain.[!].docx")
+    assert engine == "native"
+    assert options == "!"
+
+
+@pytest.mark.offline
+def test_apipeline_enqueue_persists_process_options(tmp_path):
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+        try:
+            await rag.apipeline_enqueue_documents(
+                "alpha body",
+                file_paths="abc.[native-R!].docx",
+                track_id="track-opts",
+                process_options="R!",
+            )
+            doc_id = compute_mdhash_id("abc.docx", prefix="doc-")
+            full_doc = await rag.full_docs.get_by_id(doc_id)
+            assert full_doc is not None
+            # full_docs preserves the user-visible name and the canonical key.
+            assert full_doc["file_path"] == "abc.[native-R!].docx"
+            assert full_doc.get("canonical_basename") == "abc.docx"
+            assert full_doc.get("process_options") == "R!"
+
+            status_doc = await rag.doc_status.get_by_id(doc_id)
+            assert status_doc is not None
+            metadata = (
+                status_doc.get("metadata")
+                if isinstance(status_doc, dict)
+                else getattr(status_doc, "metadata", {})
+            )
+            assert metadata.get("process_options") == "R!"
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
 
 
 @pytest.mark.offline
@@ -199,6 +358,10 @@ def test_enqueue_dedupes_parser_hinted_filename_variants(tmp_path):
             first_id = compute_mdhash_id("abc.docx", prefix="doc-")
             first_doc = await rag.full_docs.get_by_id(first_id)
             assert first_doc is not None
+            # file_path keeps the user's original basename verbatim, while
+            # canonical_basename carries the dedup key.
+            assert first_doc["file_path"] == "abc.docx"
+            assert first_doc.get("canonical_basename") == "abc.docx"
 
             await rag.apipeline_enqueue_documents(
                 "changed body",
@@ -208,9 +371,12 @@ def test_enqueue_dedupes_parser_hinted_filename_variants(tmp_path):
             assert (await rag.full_docs.get_by_id(first_id))["content"] == "alpha body"
 
             failed_docs = await rag.doc_status.get_docs_by_status(DocStatus.FAILED)
+            # The duplicate record reflects the second attempt's user-visible
+            # basename (hint preserved); the canonical dedup happened against
+            # ``abc.docx`` regardless.
             assert any(
                 getattr(doc, "metadata", {}).get("duplicate_kind") == "filename"
-                and getattr(doc, "file_path", "") == "abc.docx"
+                and getattr(doc, "file_path", "") == "abc.[native].docx"
                 for doc in failed_docs.values()
             )
         finally:
@@ -238,7 +404,9 @@ def test_delete_result_preserves_parser_hinted_source_path(tmp_path):
             result = await rag.adelete_by_doc_id(doc_id)
 
             assert result.status == "success"
-            assert result.file_path == "abc.docx"
+            # ``file_path`` now preserves the parser-hint segment for UI
+            # display; canonicalisation only affects the dedup key.
+            assert result.file_path == "abc.[native].docx"
             assert result.source_path == source_path
         finally:
             await rag.finalize_storages()
@@ -495,6 +663,67 @@ def test_persist_parsed_full_docs_syncs_hash_to_doc_status(tmp_path):
             match = await rag.doc_status.get_doc_by_content_hash(expected_hash)
             assert match is not None
             assert match[0] == doc_id
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_persist_parsed_full_docs_preserves_pending_metadata(tmp_path):
+    """``_persist_parsed_full_docs`` must keep process_options / canonical_basename
+    seeded at enqueue time so downstream stages (analyze_multimodal,
+    chunking selection, KG-skip) still see the user's original opt-ins after
+    the parse-result record overwrites the pending_parse row.
+    """
+
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+        try:
+            await rag.apipeline_enqueue_documents(
+                "",
+                file_paths="report.[native-iet!].docx",
+                docs_format=FULL_DOCS_FORMAT_PENDING_PARSE,
+                parsed_engine=PARSER_ENGINE_NATIVE,
+                process_options="iet!",
+                track_id="track-merge",
+            )
+            doc_id = compute_mdhash_id("report.docx", prefix="doc-")
+
+            pre = await rag.full_docs.get_by_id(doc_id)
+            assert pre is not None
+            assert pre.get("process_options") == "iet!"
+            assert pre.get("canonical_basename") == "report.docx"
+            assert pre.get("file_path") == "report.[native-iet!].docx"
+
+            # Simulate a parse_* completion: pass only the fresh fields the
+            # parsers actually emit and verify that pre-existing metadata
+            # survives the upsert.
+            await rag._persist_parsed_full_docs(
+                doc_id,
+                {
+                    "content": "extracted body",
+                    "file_path": "report.[native-iet!].docx",
+                    "format": "raw",
+                    "parsed_engine": PARSER_ENGINE_NATIVE,
+                    "update_time": 12345,
+                },
+            )
+
+            post = await rag.full_docs.get_by_id(doc_id)
+            assert post is not None
+            # Parser-supplied fields take precedence...
+            assert post["content"] == "extracted body"
+            assert post["format"] == "raw"
+            # ...while metadata seeded at enqueue time is preserved.
+            assert post.get("process_options") == "iet!"
+            assert post.get("canonical_basename") == "report.docx"
+            assert post.get("file_path") == "report.[native-iet!].docx"
+            # And content_hash is freshly computed from the parsed body.
+            assert post["content_hash"] == compute_mdhash_id(
+                "extracted body", prefix=""
+            )
         finally:
             await rag.finalize_storages()
 
@@ -814,7 +1043,7 @@ def test_analyze_multimodal_json_retry_and_writeback(tmp_path):
             "blocks_path": str(blocks),
             "content": "body",
         }
-        await rag.analyze_multimodal("doc-1", "demo.pdf", parsed)
+        await rag.analyze_multimodal("doc-1", "demo.pdf", parsed, process_options="ite")
 
         meta = json.loads(blocks.read_text(encoding="utf-8").splitlines()[0])
         assert meta.get("analyze_time")
@@ -849,7 +1078,9 @@ def test_analyze_multimodal_uses_effective_vlm_max_async_when_role_none(tmp_path
             "blocks_path": str(blocks),
             "content": "body",
         }
-        result = await rag.analyze_multimodal("doc-1", "demo.pdf", parsed)
+        result = await rag.analyze_multimodal(
+            "doc-1", "demo.pdf", parsed, process_options="ite"
+        )
 
         meta = json.loads(blocks.read_text(encoding="utf-8").splitlines()[0])
         assert meta.get("analyze_time")
@@ -956,7 +1187,7 @@ def test_analyze_multimodal_normalizes_string_grounded_to_bool(tmp_path):
             "blocks_path": str(blocks),
             "content": "body",
         }
-        await rag.analyze_multimodal("doc-1", "demo.pdf", parsed)
+        await rag.analyze_multimodal("doc-1", "demo.pdf", parsed, process_options="ite")
 
         payload = json.loads(drawings.read_text(encoding="utf-8"))
         result = payload["drawings"]["id1"]["llm_analyze_result"]
@@ -1006,7 +1237,7 @@ def test_analyze_multimodal_without_image_uses_conservative_output(tmp_path):
             "blocks_path": str(blocks),
             "content": "body",
         }
-        await rag.analyze_multimodal("doc-1", "demo.pdf", parsed)
+        await rag.analyze_multimodal("doc-1", "demo.pdf", parsed, process_options="ite")
 
         payload = json.loads(drawings.read_text(encoding="utf-8"))
         result = payload["drawings"]["id1"]["llm_analyze_result"]
@@ -1197,7 +1428,7 @@ def test_analyze_multimodal_table_without_image_uses_textual_analysis(tmp_path):
             "blocks_path": str(blocks),
             "content": "body",
         }
-        await rag.analyze_multimodal("doc-1", "demo.pdf", parsed)
+        await rag.analyze_multimodal("doc-1", "demo.pdf", parsed, process_options="ite")
 
         payload = json.loads(tables.read_text(encoding="utf-8"))
         result = payload["tables"]["id1"]["llm_analyze_result"]


### PR DESCRIPTION
## Summary
- Introduce a `process_options` string (i/t/e/!/F/R/S) carried via filename hints (`[ENGINE-OPTIONS]` / `[ENGINE]` / `[OPTIONS]`) and `LIGHTRAG_PARSER` engine-options suffix; controls multimodal VLM analysis, KG extraction skip, and chunking strategy on a per-document basis.
- Add a `canonical_basename` field for stable dedup and doc_id seeding while `file_path` keeps the user-visible name (with hint) for UI surfacing.
- Deprecate the global `addon_params["enable_multimodal_pipeline"]` flag in favour of per-document i/t/e options; emit a deprecation warning when legacy configs still set it.
- Persist `process_options` through `full_docs` and mirror it to `doc_status.metadata` so admin UIs can read it without cross-table joins.
- `_persist_parsed_full_docs` now merges with the existing pending_parse record so metadata seeded at enqueue time (process_options, canonical_basename, source_path) survives the parse-result overwrite (P1 fix).
- Engine-qualified hints with invalid option chars (e.g. `[native-FR]`, `[native-Q]`) now fail validation the same way options-only hints do, matching the documented "invalid characters → whole hint fails → defaults apply" contract (P2 fix).
- Drop the dead `engine_capabilities` field; modality availability is signalled by sidecar file existence (drawings.json / tables.json / equations.json), with an INFO log when an opt-in modality has no sidecar so users can diagnose silent VLM skips.

## Test plan
- [x] `ruff check lightrag tests` passes.
- [x] `pytest tests` — 1072 passed, 1 skipped, 1 xfailed (no regressions).
- [x] New unit tests in `tests/test_pipeline_release_closure.py`:
  - `parse_process_options` flag decoding (i/t/e/!/F/R/S)
  - `validate_process_options` rejects F+R combos and unsupported chars
  - `filename_parser_directives` decodes `[native-iet]`, `[native-R!]`, `[!]`, `[mineru]`
  - Engine-qualified hints with invalid options (`[native-FR]`, `[native-Q]`) drop the hint entirely
  - `LIGHTRAG_PARSER` rule supports `docx:native-iet` style options suffix
  - `resolve_file_parser_directives` priority: filename hint > LIGHTRAG_PARSER rule > legacy default
  - `apipeline_enqueue_documents` persists `process_options` to both `full_docs` and `doc_status.metadata`
  - `_persist_parsed_full_docs` preserves pending-parse metadata across the parse upsert
- [x] New e2e tests in `tests/test_document_routes_docx_archive.py`:
  - Filename hint `[native-iet]` flows through `pipeline_enqueue_file` to enqueue
  - `LIGHTRAG_PARSER=docx:native-iet` provides default options for plain-named docx files

## Follow-up (not in this PR)
- Tighten reentrancy guards: pipeline-busy checks at upload/scan endpoints, strict no-modify rules while the pipeline is busy, and idempotent resume by extracted-content state. Plan saved separately.

📚 docs: [docs/FileProcessingConfiguration-zh.md](docs/FileProcessingConfiguration-zh.md) updated with the full per-file processing options specification, dedup rules, and parsed-artifact directory naming conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)