### PR TITLE
fix(api): prevent cross-workspace info disclosure via LIGHTRAG-WORKSPACE header on /health

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -471,6 +471,10 @@ def create_app(args):
 
         Returns:
             Workspace identifier (may be empty string for global namespace)
+
+        Raises:
+            HTTPException: 403 if the requested workspace does not match the
+                server's configured workspace.
         """
         # Check custom header first
         workspace = request.headers.get("LIGHTRAG-WORKSPACE", "").strip()
@@ -485,6 +489,18 @@ def create_app(args):
                     f"Sanitized to '{sanitized}'."
                 )
                 workspace = sanitized
+
+            server_workspace = args.workspace or get_default_workspace() or ""
+            if workspace != server_workspace:
+                logger.warning(
+                    "Unauthorized workspace access attempt: "
+                    f"requested '{workspace}', "
+                    f"server workspace is '{server_workspace}'."
+                )
+                raise HTTPException(
+                    status_code=403,
+                    detail="Unauthorized workspace",
+                )
 
         return workspace
 
@@ -1384,6 +1400,8 @@ def create_app(args):
                 "webui_title": webui_title,
                 "webui_description": webui_description,
             }
+        except HTTPException:
+            raise
         except Exception as e:
             logger.error(f"Error getting health status: {str(e)}")
             raise HTTPException(status_code=500, detail=str(e))

--- a/tests/test_workspace_header_authz.py
+++ b/tests/test_workspace_header_authz.py
@@ -1,0 +1,102 @@
+"""Regression test for cross-workspace access via LIGHTRAG-WORKSPACE."""
+
+import argparse
+import asyncio
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from lightrag.api.config import initialize_config
+
+pytestmark = pytest.mark.offline
+
+
+def _make_args(tmp_path) -> argparse.Namespace:
+    return argparse.Namespace(
+        host="127.0.0.1", port=9621, working_dir=str(tmp_path / "rag_storage"),
+        input_dir=str(tmp_path / "inputs"), timeout=30, max_async=4,
+        summary_max_tokens=128, summary_context_size=1024,
+        summary_length_recommended=128, log_level="ERROR", verbose=False, key=None,
+        ssl=False, ssl_certfile=None, ssl_keyfile=None,
+        simulated_model_name="lightrag", simulated_model_tag="latest",
+        workspace="production", workers=1, llm_binding="openai",
+        llm_binding_host="http://localhost", llm_model="dummy",
+        llm_binding_api_key="dummy", embedding_binding="openai",
+        embedding_binding_host="http://localhost", embedding_model="dummy",
+        embedding_dim=8, embedding_binding_api_key="dummy",
+        embedding_token_limit=8192, embedding_func_max_async=4,
+        embedding_batch_num=1, embedding_send_dim=False,
+        embedding_asymmetric=False, embedding_asymmetric_configured=False,
+        embedding_query_prefix=None, embedding_document_prefix=None,
+        embedding_query_prefix_configured=False,
+        embedding_document_prefix_configured=False, rerank_binding="null",
+        rerank_binding_host=None, rerank_binding_api_key=None, rerank_model=None,
+        kv_storage="JsonKVStorage", graph_storage="NetworkXStorage",
+        vector_storage="NanoVectorDBStorage",
+        doc_status_storage="JsonDocStatusStorage",
+        enable_llm_cache_for_extract=True, enable_llm_cache=True,
+        max_parallel_insert=1, max_graph_nodes=1000, summary_language="English",
+        entity_types=["organization", "person"], cosine_threshold=0.2,
+        top_k=10, related_chunk_number=5, min_rerank_score=0.0,
+        chunk_size=1200, chunk_overlap_size=100, cors_origins="*",
+        whitelist_paths="/health,/api/*", auth_accounts="", token_secret=None,
+        token_expire_hours=48, guest_token_expire_hours=24,
+        jwt_algorithm="HS256", token_auto_renew=True, token_renew_threshold=0.5,
+        docling=False, document_loading_engine="DEFAULT",
+        pdf_decrypt_password=None, force_llm_summary_on_merge=0,
+    )
+
+
+def test_health_rejects_cross_workspace_header(tmp_path):
+    args = _make_args(tmp_path)
+    os.makedirs(args.input_dir, exist_ok=True)
+    initialize_config(args, force=True)
+
+    with patch(
+        "lightrag.api.lightrag_server.check_frontend_build",
+        return_value=(False, False),
+    ), patch("lightrag.api.lightrag_server.LightRAG") as mock_rag_cls:
+        rag = mock_rag_cls.return_value
+        rag.initialize_storages = AsyncMock()
+        rag.check_and_migrate_data = AsyncMock()
+        rag.finalize_storages = AsyncMock()
+        rag.workspace = args.workspace
+
+        from lightrag.api.lightrag_server import create_app
+        from lightrag.kg.shared_storage import (
+            finalize_share_data,
+            get_namespace_data,
+            initialize_pipeline_status,
+            initialize_share_data,
+        )
+
+        initialize_share_data(workers=1)
+        try:
+            asyncio.run(initialize_pipeline_status(workspace=args.workspace))
+            asyncio.run(initialize_pipeline_status(workspace="secret_internal"))
+            secret_status = asyncio.run(
+                get_namespace_data("pipeline_status", workspace="secret_internal")
+            )
+            secret_status["busy"] = True
+
+            client = TestClient(create_app(args))
+
+            direct = client.get(
+                "/health", headers={"LIGHTRAG-WORKSPACE": "secret_internal"}
+            )
+            assert direct.status_code == 403
+
+            sanitized_variant = client.get(
+                "/health", headers={"LIGHTRAG-WORKSPACE": "secret-internal"}
+            )
+            assert sanitized_variant.status_code == 403
+
+            allowed = client.get(
+                "/health", headers={"LIGHTRAG-WORKSPACE": args.workspace}
+            )
+            assert allowed.status_code == 200
+            assert allowed.json()["pipeline_busy"] is False
+        finally:
+            finalize_share_data()


### PR DESCRIPTION
## Summary

The `/health` endpoint accepts a `LIGHTRAG-WORKSPACE` request header and uses it to look up the pipeline status for an arbitrary workspace name. Because `/health` is in the default `WHITELIST_PATHS` (`/health,/api/*`), it is reachable without authentication. An unauthenticated attacker can:

1. Probe whether arbitrary workspace names exist on the server (a non-existent or uninitialized workspace returns a 500 with `PipelineNotInitializedError`; an existing one returns 200).
2. Read the `pipeline_busy` boolean of any other workspace's pipeline.

Additionally, the existing sanitizer replaces non-alphanumeric characters with `_`, so a header value like `secret-internal` is silently rewritten to `secret_internal`. Any naive `equals` check on the raw header would have been bypassable by this near-miss mapping. The fix correctly compares **after** sanitization.

- **CWE:** CWE-285 (Improper Authorization) / CWE-200 (Information Exposure). The original triage label of CWE-22 (path traversal) is a misnomer — there is no filesystem traversal involved.
- **Severity:** Low. The leaked data is limited to workspace existence and a single boolean; no documents, configuration, or credentials are exposed via this path.
- **Affected code:** `get_workspace_from_request` and the `/health` handler in `lightrag/api/lightrag_server.py`.
- **Data flow:** unauthenticated HTTP request → `LIGHTRAG-WORKSPACE` header → `get_workspace_from_request` → `get_namespace_data("pipeline_status", workspace=...)` → response body.

## Fix

In `get_workspace_from_request`, after sanitizing the header value, compare it to the server's configured workspace (`args.workspace`, falling back to `get_default_workspace()`). If they differ, log the attempt and return HTTP 403. The `/health` handler is updated to re-raise `HTTPException` so the 403 isn't swallowed and converted to a 500 by the existing generic exception handler.

Why this scope: `get_workspace_from_request` is only consumed by `/health`. All other routers operate on the server-bound `rag.workspace` set at startup, so they cannot be steered by this header. The change is therefore intentionally narrow — 18 lines in the server module.

## Tests

Added `tests/test_workspace_header_authz.py` with three assertions against a real `TestClient`:

1. `LIGHTRAG-WORKSPACE: secret_internal` → **403** (direct cross-workspace request rejected).
2. `LIGHTRAG-WORKSPACE: secret-internal` → **403** (sanitization-based bypass rejected; the dash would otherwise normalize to underscore and collide with `secret_internal`).
3. `LIGHTRAG-WORKSPACE: production` (the configured workspace) → **200** with `pipeline_busy: false` (legitimate use still works).

The test pre-creates a `secret_internal` pipeline namespace with `busy=True` to confirm the attacker cannot read it after the fix. All three pass locally.

## Security analysis

We verified exploitability against the default configuration: `WHITELIST_PATHS` includes `/health`, so no API key or JWT is needed to reach the vulnerable code. With network access alone, an attacker can enumerate workspace names (binary signal via 200 vs 500) and observe pipeline busy state — useful for reconnaissance and timing of further attacks against a multi-tenant deployment.

The fix closes the only call site that consumes the attacker-controlled header. Other endpoints already use the server-bound `rag.workspace` and are unaffected.

### Adversarial review

Before submitting, we tried to disprove this finding. We checked whether the auth middleware would block the request (it doesn't — `/health` is whitelisted by default), whether the sanitization layer alone was sufficient (it wasn't — it permits lossy collisions like `secret-internal` → `secret_internal`), and whether other routers might offer the same primitive (they don't — they ignore the header and use the server-bound workspace). We also considered whether an operator could simply remove `/health` from the whitelist as a workaround; they can, but the default config is the realistic threat model and shouldn't leak cross-tenant state. The leaked information is admittedly small (existence + a boolean), which is why we've labeled this low severity rather than something more dramatic.

cc @lewiswigmore
