### PR TITLE
Fix CWE-89: parameterize graph_name in PostgreSQLDB.configure_age()

### DIFF
--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -610,7 +610,7 @@ class PostgreSQLDB:
                 'SET search_path = ag_catalog, "$user", public'
             )
             await connection.execute(  # type: ignore
-                f"select create_graph('{graph_name}')"
+                "SELECT create_graph($1)", graph_name
             )
         except (
             asyncpg.exceptions.InvalidSchemaNameError,

--- a/tests/test_configure_age_sqli.py
+++ b/tests/test_configure_age_sqli.py
@@ -1,0 +1,82 @@
+"""
+PoC / regression test for CWE-89: SQL injection in configure_age() via graph_name.
+
+The configure_age() static method on PostgreSQLDB previously interpolated
+``graph_name`` directly into an f-string SQL statement:
+
+    f"select create_graph('{graph_name}')"
+
+A malicious graph_name (e.g. containing a single-quote) allows SQL injection.
+
+After the fix, configure_age() must use a parameterized query ($1) so that
+the graph_name is safely bound.
+
+This test does NOT need a running PostgreSQL instance; it mocks asyncpg to
+capture the exact SQL and parameters that would be sent.
+"""
+
+import pytest
+from unittest.mock import AsyncMock
+
+
+@pytest.fixture
+def mock_connection():
+    """Create a mock asyncpg connection that records execute() calls."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock(return_value=None)
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_configure_age_uses_parameterized_query(mock_connection):
+    """configure_age must NOT embed graph_name literally into the SQL string."""
+    from lightrag.kg.postgres_impl import PostgreSQLDB
+
+    malicious_name = "test'); DROP SCHEMA public CASCADE; --"
+
+    await PostgreSQLDB.configure_age(mock_connection, malicious_name)
+
+    calls = mock_connection.execute.call_args_list
+
+    # We expect two calls:
+    # 1. SET search_path = ...
+    # 2. SELECT create_graph($1) with the graph_name as a bound parameter
+    assert len(calls) == 2, f"Expected 2 execute calls, got {len(calls)}: {calls}"
+
+    # Second call should use a parameterized query, NOT string interpolation
+    create_graph_call = calls[1]
+    sql_arg = create_graph_call.args[0] if create_graph_call.args else ""
+
+    # The SQL must contain a placeholder ($1) rather than the literal name
+    assert "$1" in sql_arg, (
+        f"create_graph SQL should use parameterized query ($1), "
+        f"but got: {sql_arg!r}"
+    )
+
+    # The literal malicious string must NOT appear in the SQL
+    assert malicious_name not in sql_arg, (
+        f"graph_name was interpolated directly into SQL (injection!): {sql_arg!r}"
+    )
+
+    # The malicious name should be passed as a separate parameter
+    bound_params = create_graph_call.args[1:] if len(create_graph_call.args) > 1 else ()
+    assert malicious_name in bound_params, (
+        f"graph_name should be passed as a bound parameter, "
+        f"but params were: {bound_params}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_configure_age_safe_name_still_works(mock_connection):
+    """Even with a safe name, parameterized query should be used."""
+    from lightrag.kg.postgres_impl import PostgreSQLDB
+
+    safe_name = "my_workspace_graph"
+    await PostgreSQLDB.configure_age(mock_connection, safe_name)
+
+    calls = mock_connection.execute.call_args_list
+    assert len(calls) == 2
+
+    create_graph_call = calls[1]
+    sql_arg = create_graph_call.args[0]
+    assert "$1" in sql_arg, f"Expected parameterized query, got: {sql_arg!r}"


### PR DESCRIPTION
## Summary

Fix a SQL injection (CWE-89) in `PostgreSQLDB.configure_age()` where the `graph_name` argument was interpolated directly into a SQL f-string passed to `asyncpg`'s `connection.execute()`.

## Vulnerability details

- **File:** `lightrag/kg/postgres_impl.py`
- **Function:** `PostgreSQLDB.configure_age()` (around line 610)
- **CWE:** [CWE-89 — SQL Injection](https://cwe.mitre.org/data/definitions/89.html)

The vulnerable line was:

```python
await connection.execute(
    f"select create_graph('{graph_name}')"
)
```

If `graph_name` ever contains a single quote (e.g. `x'); DROP SCHEMA public CASCADE; --`), the literal is closed early and the rest is executed as SQL on the database connection, with whatever privileges the LightRAG database user holds (typically full DDL on the application schema, including AGE graph schemas).

## Fix

Switch to a parameterized query so `asyncpg` binds `graph_name` as a text parameter rather than embedding it into the SQL text:

```python
await connection.execute(
    "SELECT create_graph($1)", graph_name
)
```

This is the standard `asyncpg` parameter-binding form and is functionally equivalent for any legitimate graph name, while making the call structurally immune to injection at this sink.

The change is intentionally minimal — one line in `postgres_impl.py` — to keep the patch easy to review and merge.

## Tests

Added `tests/test_configure_age_sqli.py` with two regression tests that mock the asyncpg connection and assert:

1. `configure_age()` calls `execute()` with a `$1` placeholder, **not** the literal `graph_name`, even when given a malicious payload (`test'); DROP SCHEMA public CASCADE; --`).
2. The malicious string appears as a bound parameter, not in the SQL text.
3. Behavior is unchanged for normal names.

Local run:

```
tests/test_configure_age_sqli.py::test_configure_age_uses_parameterized_query PASSED
tests/test_configure_age_sqli.py::test_configure_age_safe_name_still_works    PASSED
============================== 2 passed in 0.18s ===============================
```

The tests do not require a running PostgreSQL instance.

## Security analysis

`configure_age()` is a `@staticmethod` on `PostgreSQLDB`, called whenever a new asyncpg connection is initialized for an AGE-backed graph. The `graph_name` argument is taken from `PGGraphStorage.graph_name`, which is built from a workspace + namespace combination.

In the current shipped API path, both inputs are already passed through `re.sub(r"[^a-zA-Z0-9_]", "_", ...)` (in `_get_workspace_graph_name()` and in `get_workspace_from_request()` for the `LIGHTRAG-WORKSPACE` HTTP header), which strips quotes and semicolons before they reach this sink. So a remote unauthenticated attacker hitting the HTTP API as it ships today cannot directly exploit this line.

That said, the fix is still worthwhile:

- `configure_age()` is a public static method on `PostgreSQLDB` and can be (and is likely to be) called from other integrations or future code paths that don't necessarily route through the API sanitizer. Treating the SQL boundary correctly here means the function is safe regardless of caller hygiene.
- It removes a fragile defense-in-depth dependency: the safety of this call currently relies entirely on every caller remembering to apply the regex sanitizer. Parameter binding makes that no longer load-bearing.
- The change is local, behavior-preserving, and covered by tests.

### Adversarial review

Before submitting we tried to disprove this. The main candidate mitigation is the workspace/namespace regex sanitizer applied at the API layer — and it does block the obvious HTTP exploitation path today. We're not claiming a remote-unauth RCE here. What the sanitizer doesn't do is make `configure_age()` itself safe: it's a public method on a reusable DB helper, and any caller that constructs `graph_name` differently (custom integrations, scripts, future API routes) re-opens the hole. Parameterizing the query fixes the sink itself rather than relying on every caller to scrub input correctly, which is the right place to put this guarantee.

### Note for maintainers (out of scope for this PR)

While reviewing, I noticed the same f-string interpolation pattern used with `self.graph_name` in `PGGraphStorage` initialization (around lines 4293–4309 of `postgres_impl.py`), including DDL like `CREATE INDEX ... ON {self.graph_name}."..."`. Those sites currently rely on the same upstream regex sanitizer. I kept this PR narrow to the `configure_age()` sink so it's easy to review, but I'd be happy to follow up with a separate PR that parameterizes / safely quotes those as well if you'd like.

cc @lewiswigmore
