### PR TITLE
fix(webui): resolve react-hooks lint errors after eslint-plugin upgrade

### DIFF
--- a/lightrag_webui/src/App.tsx
+++ b/lightrag_webui/src/App.tsx
@@ -154,13 +154,15 @@ function App() {
     []
   )
 
-  useEffect(() => {
-    if (message) {
-      if (message.includes(InvalidApiKeyError) || message.includes(RequireApiKeError)) {
-        setApiKeyAlertOpen(true)
-      }
+  // React to backend message changes during render rather than via useEffect
+  // (avoids cascading renders flagged by react-hooks/set-state-in-effect)
+  const [previousMessage, setPreviousMessage] = useState(message)
+  if (message !== previousMessage) {
+    setPreviousMessage(message)
+    if (message && (message.includes(InvalidApiKeyError) || message.includes(RequireApiKeError))) {
+      setApiKeyAlertOpen(true)
     }
-  }, [message])
+  }
 
   return (
     <ThemeProvider>

--- a/lightrag_webui/src/components/documents/ClearDocumentsDialog.tsx
+++ b/lightrag_webui/src/components/documents/ClearDocumentsDialog.tsx
@@ -50,20 +50,20 @@ export default function ClearDocumentsDialog({ onDocumentsCleared }: ClearDocume
   // Timeout constant (30 seconds)
   const CLEAR_TIMEOUT = 30000
 
-  // Reset state when dialog closes
-  useEffect(() => {
-    if (!open) {
+  // Reset state when dialog closes - handled in onOpenChange to avoid setState in effect
+  const handleOpenChange = useCallback((newOpen: boolean) => {
+    setOpen(newOpen)
+    if (!newOpen) {
       setConfirmText('')
       setClearCacheOption(false)
       setIsClearing(false)
 
-      // Clear timeout timer
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current)
         timeoutRef.current = null
       }
     }
-  }, [open])
+  }, [])
 
   // Cleanup when component unmounts
   useEffect(() => {
@@ -115,7 +115,7 @@ export default function ClearDocumentsDialog({ onDocumentsCleared }: ClearDocume
       }
 
       // Close dialog after all operations succeed
-      setOpen(false)
+      handleOpenChange(false)
     } catch (err) {
       toast.error(t('documentPanel.clearDocuments.error', { error: errorMessage(err) }))
       setConfirmText('')
@@ -127,10 +127,10 @@ export default function ClearDocumentsDialog({ onDocumentsCleared }: ClearDocume
       }
       setIsClearing(false)
     }
-  }, [isConfirmEnabled, isClearing, clearCacheOption, setOpen, t, onDocumentsCleared, CLEAR_TIMEOUT])
+  }, [isConfirmEnabled, isClearing, clearCacheOption, handleOpenChange, t, onDocumentsCleared, CLEAR_TIMEOUT])
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
         <Button variant="outline" side="bottom" tooltip={t('documentPanel.clearDocuments.tooltip')} size="sm">
           <EraserIcon/> {t('documentPanel.clearDocuments.button')}
@@ -185,7 +185,7 @@ export default function ClearDocumentsDialog({ onDocumentsCleared }: ClearDocume
         <DialogFooter>
           <Button
             variant="outline"
-            onClick={() => setOpen(false)}
+            onClick={() => handleOpenChange(false)}
             disabled={isClearing}
           >
             {t('common.cancel')}

--- a/lightrag_webui/src/components/documents/DeleteDocumentsDialog.tsx
+++ b/lightrag_webui/src/components/documents/DeleteDocumentsDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback } from 'react'
 import Button from '@/components/ui/Button'
 import {
   Dialog,
@@ -47,15 +47,16 @@ export default function DeleteDocumentsDialog({ selectedDocIds, onDocumentsDelet
   const [deleteLLMCache, setDeleteLLMCache] = useState(false)
   const isConfirmEnabled = confirmText.toLowerCase() === 'yes' && !isDeleting
 
-  // Reset state when dialog closes
-  useEffect(() => {
-    if (!open) {
+  // Reset state when dialog closes - handled in onOpenChange to avoid setState in effect
+  const handleOpenChange = useCallback((newOpen: boolean) => {
+    setOpen(newOpen)
+    if (!newOpen) {
       setConfirmText('')
       setDeleteFile(false)
       setDeleteLLMCache(false)
       setIsDeleting(false)
     }
-  }, [open])
+  }, [])
 
   const handleDelete = useCallback(async () => {
     if (!isConfirmEnabled || selectedDocIds.length === 0) return
@@ -89,17 +90,17 @@ export default function DeleteDocumentsDialog({ selectedDocIds, onDocumentsDelet
       }
 
       // Close dialog after successful operation
-      setOpen(false)
+      handleOpenChange(false)
     } catch (err) {
       toast.error(t('documentPanel.deleteDocuments.error', { error: errorMessage(err) }))
       setConfirmText('')
     } finally {
       setIsDeleting(false)
     }
-  }, [isConfirmEnabled, selectedDocIds, deleteFile, deleteLLMCache, setOpen, t, onDocumentsDeleted])
+  }, [isConfirmEnabled, selectedDocIds, deleteFile, deleteLLMCache, handleOpenChange, t, onDocumentsDeleted])
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
         <Button
           variant="destructive"
@@ -174,7 +175,7 @@ export default function DeleteDocumentsDialog({ selectedDocIds, onDocumentsDelet
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={() => setOpen(false)} disabled={isDeleting}>
+          <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={isDeleting}>
             {t('common.cancel')}
           </Button>
           <Button

--- a/lightrag_webui/src/components/graph/EditablePropertyRow.tsx
+++ b/lightrag_webui/src/components/graph/EditablePropertyRow.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { updateEntity, updateRelation, checkEntityNameExists } from '@/api/lightrag'
@@ -66,9 +66,14 @@ const EditablePropertyRow = ({
     sourceEntity: string
   } | null>(null)
 
-  useEffect(() => {
+  // Sync currentValue when the incoming initialValue prop changes.
+  // Uses a render-time previous-value comparison instead of useEffect to avoid
+  // cascading renders flagged by react-hooks/set-state-in-effect.
+  const [previousInitialValue, setPreviousInitialValue] = useState(initialValue)
+  if (initialValue !== previousInitialValue) {
+    setPreviousInitialValue(initialValue)
     setCurrentValue(initialValue)
-  }, [initialValue])
+  }
 
   const handleEditClick = () => {
     if (isEditable && !isEditing) {

--- a/lightrag_webui/src/components/graph/GraphLabels.tsx
+++ b/lightrag_webui/src/components/graph/GraphLabels.tsx
@@ -61,17 +61,21 @@ const GraphLabels = () => {
     initializeHistory()
   }, [])
 
-  // Force AsyncSelect to re-render when label changes externally (e.g., from entity rename/merge)
-  useEffect(() => {
+  // Force AsyncSelect to re-render when label or dropdownRefreshTrigger changes.
+  // Uses render-time previous-value comparison to avoid cascading renders from
+  // setState-in-useEffect, while still bumping the key on external changes.
+  const [previousLabel, setPreviousLabel] = useState(label)
+  const [previousDropdownTrigger, setPreviousDropdownTrigger] = useState(dropdownRefreshTrigger)
+  if (label !== previousLabel) {
+    setPreviousLabel(label)
     setSelectKey(prev => prev + 1)
-  }, [label])
-
-  // Force AsyncSelect to re-render when dropdown refresh is triggered (e.g., after entity rename)
-  useEffect(() => {
+  }
+  if (dropdownRefreshTrigger !== previousDropdownTrigger) {
+    setPreviousDropdownTrigger(dropdownRefreshTrigger)
     if (dropdownRefreshTrigger > 0) {
       setSelectKey(prev => prev + 1)
     }
-  }, [dropdownRefreshTrigger])
+  }
 
   // Monitor pipeline state changes: busy -> idle
   useEffect(() => {

--- a/lightrag_webui/src/components/graph/LayoutsControl.tsx
+++ b/lightrag_webui/src/components/graph/LayoutsControl.tsx
@@ -140,7 +140,6 @@ const WorkerLayoutControl = ({ layout, autoRunFor, mainLayout }: ExtendedWorkerL
     if (autoRunFor !== undefined && autoRunFor > -1 && sigma.getGraph().order > 0) {
       console.log('Auto-starting layout animation')
 
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       updatePositions() // transitively calls setIsRunning on error; intentional here
 
       // Set up interval for continuous updates
@@ -148,6 +147,7 @@ const WorkerLayoutControl = ({ layout, autoRunFor, mainLayout }: ExtendedWorkerL
         updatePositions()
       }, 200) // Reduced interval to create overlapping animations for smoother transitions
 
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsRunning(true) // deliberate: syncing UI to the interval we just started
 
       // Set a timeout to stop it if autoRunFor > 0

--- a/lightrag_webui/src/components/graph/Settings.tsx
+++ b/lightrag_webui/src/components/graph/Settings.tsx
@@ -74,9 +74,13 @@ const LabeledNumberInput = ({
     onEditFinishedRef.current = onEditFinished
   })
 
-  useEffect(() => {
+  // Sync local state when controlled value changes (render-time comparison
+  // avoids cascading renders flagged by react-hooks/set-state-in-effect).
+  const [previousValue, setPreviousValue] = useState(value)
+  if (value !== previousValue) {
+    setPreviousValue(value)
     setCurrentValue(value)
-  }, [value])
+  }
 
   // Commit any pending change when the component unmounts (e.g. popover closes)
   useEffect(() => {

--- a/lightrag_webui/src/components/retrieval/ChatMessage.tsx
+++ b/lightrag_webui/src/components/retrieval/ChatMessage.tsx
@@ -60,13 +60,21 @@ export const ChatMessage = ({
   // Directly use props passed from the parent.
   const { thinkingContent, displayContent, thinkingTime, isThinking } = message
 
-  // Reset expansion state when new thinking starts
-  useEffect(() => {
+  // Reset expansion state when new thinking starts.
+  // Render-time comparison avoids cascading renders from setState-in-useEffect.
+  const [previousThinkingState, setPreviousThinkingState] = useState({
+    isThinking,
+    messageId: message.id
+  })
+  if (
+    previousThinkingState.isThinking !== isThinking ||
+    previousThinkingState.messageId !== message.id
+  ) {
+    setPreviousThinkingState({ isThinking, messageId: message.id })
     if (isThinking) {
-      // When thinking starts, always reset to collapsed state
       setIsThinkingExpanded(false)
     }
-  }, [isThinking, message.id])
+  }
 
   // The content to display is now non-ambiguous.
   const finalThinkingContent = thinkingContent

--- a/lightrag_webui/src/components/ui/AsyncSearch.tsx
+++ b/lightrag_webui/src/components/ui/AsyncSearch.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react'
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { Loader2 } from 'lucide-react'
 import { useDebounce } from '@/hooks/useDebounce'
 
@@ -76,18 +76,13 @@ export function AsyncSearch<T>({
   className,
   noResultsMessage
 }: AsyncSearchProps<T>) {
-  const [mounted, setMounted] = useState(false)
   const [open, setOpen] = useState(false)
-  const [options, setOptions] = useState<T[]>([])
+  const [fetchedOptions, setFetchedOptions] = useState<T[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [searchTerm, setSearchTerm] = useState('')
   const debouncedSearchTerm = useDebounce(searchTerm, preload ? 0 : 150)
   const containerRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    setMounted(true)
-  }, [])
 
   // Handle clicks outside of the component
   useEffect(() => {
@@ -112,7 +107,7 @@ export function AsyncSearch<T>({
       setLoading(true)
       setError(null)
       const data = await fetcher(query)
-      setOptions(data)
+      setFetchedOptions(data)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch options')
     } finally {
@@ -120,28 +115,31 @@ export function AsyncSearch<T>({
     }
   }, [fetcher])
 
-  // Load options when search term changes
+  // Fetch options from server when not in preload mode (search term changes).
+  // The fetch is a genuine external side effect; setState happens inside fetchOptions
+  // after the async call resolves, so the rule fires on the synchronous loading flag.
   useEffect(() => {
-    if (!mounted) return
-
-    if (preload) {
-      if (debouncedSearchTerm) {
-        setOptions((prev) =>
-          prev.filter((option) =>
-            filterFn ? filterFn(option, debouncedSearchTerm) : true
-          )
-        )
-      }
-    } else {
-      fetchOptions(debouncedSearchTerm)
-    }
-  }, [mounted, debouncedSearchTerm, preload, filterFn, fetchOptions])
+    if (preload) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    fetchOptions(debouncedSearchTerm)
+  }, [preload, debouncedSearchTerm, fetchOptions])
 
   // Load initial value
   useEffect(() => {
-    if (!mounted || !value) return
+    if (!value) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchOptions(value)
-  }, [mounted, value, fetchOptions])
+  }, [value, fetchOptions])
+
+  // In preload mode, derive filtered options without mutating state
+  const options = useMemo(() => {
+    if (preload && debouncedSearchTerm) {
+      return fetchedOptions.filter((option) =>
+        filterFn ? filterFn(option, debouncedSearchTerm) : true
+      )
+    }
+    return fetchedOptions
+  }, [preload, debouncedSearchTerm, filterFn, fetchedOptions])
 
   const handleSelect = useCallback((currentValue: string) => {
     onChange(currentValue)

--- a/lightrag_webui/src/components/ui/AsyncSelect.tsx
+++ b/lightrag_webui/src/components/ui/AsyncSelect.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { Check, ChevronsUpDown, Loader2 } from 'lucide-react'
 import { useDebounce } from '@/hooks/useDebounce'
 
@@ -95,66 +95,37 @@ export function AsyncSelect<T>({
   clearable = true,
   debounceTime = 150
 }: AsyncSelectProps<T>) {
-  const [mounted, setMounted] = useState(false)
   const [open, setOpen] = useState(false)
-  const [options, setOptions] = useState<T[]>([])
+  const [originalOptions, setOriginalOptions] = useState<T[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [selectedValue, setSelectedValue] = useState(value)
-  const [selectedOption, setSelectedOption] = useState<T | null>(null)
   const [searchTerm, setSearchTerm] = useState('')
   const debouncedSearchTerm = useDebounce(searchTerm, preload ? 0 : debounceTime)
-  const [originalOptions, setOriginalOptions] = useState<T[]>([])
-  const [initialValueDisplay, setInitialValueDisplay] = useState<React.ReactNode | null>(null)
 
-  useEffect(() => {
-    setMounted(true)
-    setSelectedValue(value)
-  }, [value])
-
-  // Add an effect to handle initial value display
-  useEffect(() => {
-    if (value && (!options.length || !selectedOption)) {
-      // Create a temporary display until options are loaded
-      setInitialValueDisplay(<div>{value}</div>)
-    } else if (selectedOption) {
-      // Once we find the actual selectedOption, clear the temporary display
-      setInitialValueDisplay(null)
+  // Derive the displayed options from the fetched list and search term, instead
+  // of mirroring them via setState in an effect.
+  const options = useMemo(() => {
+    if (preload && debouncedSearchTerm) {
+      return originalOptions.filter((option) =>
+        filterFn ? filterFn(option, debouncedSearchTerm) : true
+      )
     }
-  }, [value, options.length, selectedOption])
+    return originalOptions
+  }, [preload, debouncedSearchTerm, filterFn, originalOptions])
 
-  // Initialize selectedOption when options are loaded and value exists
-  useEffect(() => {
-    if (value && options.length > 0) {
-      const option = options.find((opt) => getOptionValue(opt) === value)
-      if (option) {
-        setSelectedOption(option)
-      }
-    }
-  }, [value, options, getOptionValue])
+  // Derive selected option from value + currently-loaded options.
+  const selectedOption = useMemo(
+    () => (value ? options.find((opt) => getOptionValue(opt) === value) ?? null : null),
+    [value, options, getOptionValue]
+  )
 
-  // Effect for initial fetch
-  useEffect(() => {
-    const initializeOptions = async () => {
-      try {
-        setLoading(true)
-        setError(null)
-        // Always use empty query for initial load to show search history
-        const data = await fetcher('')
-        setOriginalOptions(data)
-        setOptions(data)
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to fetch options')
-      } finally {
-        setLoading(false)
-      }
-    }
+  // Show the raw value as a placeholder until the matching option is loaded.
+  const initialValueDisplay = useMemo(
+    () => (value && !selectedOption ? <div>{value}</div> : null),
+    [value, selectedOption]
+  )
 
-    if (!mounted) {
-      initializeOptions()
-    }
-  }, [mounted, fetcher])
-
+  // Fetch options whenever search term changes (skip filtering-only re-runs in preload mode)
   useEffect(() => {
     const fetchOptions = async () => {
       try {
@@ -162,7 +133,6 @@ export function AsyncSelect<T>({
         setError(null)
         const data = await fetcher(debouncedSearchTerm)
         setOriginalOptions(data)
-        setOptions(data)
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to fetch options')
       } finally {
@@ -170,33 +140,21 @@ export function AsyncSelect<T>({
       }
     }
 
-    if (!mounted) {
-      fetchOptions()
-    } else if (!preload) {
-      fetchOptions()
-    } else if (preload) {
-      if (debouncedSearchTerm) {
-        setOptions(
-          originalOptions.filter((option) =>
-            filterFn ? filterFn(option, debouncedSearchTerm) : true
-          )
-        )
-      } else {
-        setOptions(originalOptions)
-      }
+    if (preload && originalOptions.length > 0) {
+      // Already fetched; rely on the memoised filter above.
+      return
     }
+    fetchOptions()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fetcher, debouncedSearchTerm, mounted, preload, filterFn])
+  }, [fetcher, debouncedSearchTerm, preload])
 
   const handleSelect = useCallback(
     (currentValue: string) => {
-      const newValue = clearable && currentValue === selectedValue ? '' : currentValue
-      setSelectedValue(newValue)
-      setSelectedOption(options.find((option) => getOptionValue(option) === newValue) || null)
+      const newValue = clearable && currentValue === value ? '' : currentValue
       onChange(newValue)
       setOpen(false)
     },
-    [selectedValue, onChange, clearable, options, getOptionValue]
+    [value, onChange, clearable]
   )
 
   const handleOpenChange = useCallback(
@@ -284,7 +242,7 @@ export function AsyncSelect<T>({
                     <Check
                       className={cn(
                         'ml-auto h-3 w-3',
-                        selectedValue === optionValue ? 'opacity-100' : 'opacity-0'
+                        value === optionValue ? 'opacity-100' : 'opacity-0'
                       )}
                     />
                   </CommandItem>

--- a/lightrag_webui/src/components/ui/NumberInput.tsx
+++ b/lightrag_webui/src/components/ui/NumberInput.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, ChevronUp } from 'lucide-react'
-import { forwardRef, useCallback, useEffect, useState } from 'react'
+import { forwardRef, useCallback, useState } from 'react'
 import { NumericFormat, NumericFormatProps } from 'react-number-format'
 import Button from '@/components/ui/Button'
 import Input from '@/components/ui/Input'
@@ -43,12 +43,12 @@ const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
     const [value, setValue] = useState<number | undefined>(controlledValue ?? defaultValue)
 
     // Sync local state when the controlled value changes (e.g. parent resets the field).
-    // Synchronous setState in useEffect is intentional here: we want the displayed value
-    // to update in the same paint as the prop change, with no visible flicker.
-    useEffect(() => {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+    // Render-time comparison avoids cascading renders flagged by react-hooks/set-state-in-effect.
+    const [previousControlledValue, setPreviousControlledValue] = useState(controlledValue)
+    if (controlledValue !== previousControlledValue) {
+      setPreviousControlledValue(controlledValue)
       if (controlledValue !== undefined) setValue(controlledValue)
-    }, [controlledValue])
+    }
 
     const handleIncrement = useCallback(() => {
       setValue((prev) =>

--- a/lightrag_webui/src/components/ui/PaginationControls.tsx
+++ b/lightrag_webui/src/components/ui/PaginationControls.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from './Button'
 import Input from './Input'
@@ -40,10 +40,13 @@ export default function PaginationControls({
   const { t } = useTranslation()
   const [inputPage, setInputPage] = useState(currentPage.toString())
 
-  // Update input when currentPage changes
-  useEffect(() => {
+  // Sync input when currentPage changes externally (render-time comparison
+  // avoids cascading renders flagged by react-hooks/set-state-in-effect).
+  const [previousCurrentPage, setPreviousCurrentPage] = useState(currentPage)
+  if (currentPage !== previousCurrentPage) {
+    setPreviousCurrentPage(currentPage)
     setInputPage(currentPage.toString())
-  }, [currentPage])
+  }
 
   // Handle page input change with debouncing
   const handlePageInputChange = useCallback((value: string) => {

--- a/lightrag_webui/src/features/DocumentManager.tsx
+++ b/lightrag_webui/src/features/DocumentManager.tsx
@@ -1138,25 +1138,45 @@ export default function DocumentManager() {
   }, [clearPollingInterval, setStatusCounts, fetchDocuments, currentTab, health, startPollingInterval])
 
 
-  // Handle showFileName change - switch sort field if currently sorting by first column
-  useEffect(() => {
-    // Only switch if currently sorting by the first column (id or file_path)
+  // Handle showFileName change - switch sort field if currently sorting by first column.
+  // Render-time comparison avoids cascading renders flagged by react-hooks/set-state-in-effect.
+  const [previousShowFileName, setPreviousShowFileName] = useState(showFileName)
+  if (showFileName !== previousShowFileName) {
+    setPreviousShowFileName(showFileName)
     if (sortField === 'id' || sortField === 'file_path') {
       const newSortField = showFileName ? 'file_path' : 'id';
       if (sortField !== newSortField) {
         setSortField(newSortField);
       }
     }
-  }, [showFileName, sortField]);
+  }
 
-  // Reset selection state when page, status filter, or sort changes
-  useEffect(() => {
+  // Reset selection state when page, status filter, or sort changes (render-time comparison).
+  const [previousSelectionDeps, setPreviousSelectionDeps] = useState({
+    page: pagination.page,
+    statusFilter,
+    sortField,
+    sortDirection
+  })
+  if (
+    previousSelectionDeps.page !== pagination.page ||
+    previousSelectionDeps.statusFilter !== statusFilter ||
+    previousSelectionDeps.sortField !== sortField ||
+    previousSelectionDeps.sortDirection !== sortDirection
+  ) {
+    setPreviousSelectionDeps({
+      page: pagination.page,
+      statusFilter,
+      sortField,
+      sortDirection
+    })
     setSelectedDocIds([])
-  }, [pagination.page, statusFilter, sortField, sortDirection]);
+  }
 
-  // Central effect to handle all data fetching
+  // Central effect to handle all data fetching - genuine side effect (network call)
   useEffect(() => {
     if (currentTab === 'documents') {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       fetchPaginatedDocuments(pagination.page, pagination.page_size, statusFilter);
     }
   }, [

--- a/lightrag_webui/src/features/RetrievalTesting.tsx
+++ b/lightrag_webui/src/features/RetrievalTesting.tsx
@@ -622,6 +622,16 @@ export default function RetrievalTesting() {
     useSettingsStore.getState().setRetrievalHistory([])
   }, [setMessages])
 
+  // Disable auto-scroll when the user clicks inside the messages container.
+  // The ref mutation pattern is intentional and matches how it's mutated elsewhere
+  // (wheel/scroll handlers in the effect above); the linter flags it here regardless.
+  const handleMessagesContainerClick = useCallback(() => {
+    if (shouldFollowScrollRef.current) {
+      // eslint-disable-next-line react-hooks/immutability
+      shouldFollowScrollRef.current = false;
+    }
+  }, [])
+
   // Handle copying message content with robust clipboard support
   const handleCopyMessage = useCallback(async (message: MessageWithError) => {
     const contentToCopy = message.role === 'user'
@@ -682,11 +692,7 @@ export default function RetrievalTesting() {
           <div
             ref={messagesContainerRef}
             className="bg-primary-foreground/60 absolute inset-0 flex flex-col overflow-auto rounded-lg border p-2"
-            onClick={() => {
-              if (shouldFollowScrollRef.current) {
-                shouldFollowScrollRef.current = false;
-              }
-            }}
+            onClick={handleMessagesContainerClick}
           >
             <div className="flex min-h-0 flex-1 flex-col gap-2">
               {messages.length === 0 ? (


### PR DESCRIPTION
## Summary

The recent `eslint-plugin-react-hooks` v7 upgrade introduced two new rules (`set-state-in-effect` and `immutability`) that flagged 21 errors and 2 stale `eslint-disable` warnings in the WebUI codebase. `bun run lint` now exits with status 1, breaking CI lint checks.

This PR refactors each occurrence using React 19 idioms so the lint suite passes cleanly:

- **Render-time previous-value comparison** replaces `useEffect + setState` for prop-sync patterns: `App`, `EditablePropertyRow`, `GraphLabels`, `LabeledNumberInput` (in `Settings`), `ChatMessage`, `PaginationControls`, `NumberInput`, `DocumentManager`.
- **Dialog reset logic moved into `onOpenChange` handlers** in `ClearDocumentsDialog` and `DeleteDocumentsDialog`, so the cleanup is part of the close event rather than an effect.
- **`AsyncSelect`/`AsyncSearch`** derive `selectedOption`, `initialValueDisplay`, and the filtered option list via `useMemo` instead of mirroring them in state. Removed the redundant `mounted` gate.
- **Genuine external side effects** (timer/state sync, async fetches, ref mutations in event handlers) keep targeted `eslint-disable-next-line` comments with explanatory notes.

No behaviour change is intended; this is a purely lint-driven refactor.

## Test plan

- [x] `cd lightrag_webui && bun run lint` exits 0 with no errors or warnings (was 21 errors + 2 warnings)
- [x] `bunx tsc --noEmit` introduces no new TS errors in the touched files (3 pre-existing errors in unmodified files remain)
- [ ] Manual smoke test of dialogs (Clear Documents, Delete Documents), graph label dropdown refresh, retrieval testing scroll-follow, and pagination input
- [ ] WebUI build passes (`bun run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)