### PR TITLE
Add offline sample retrieval check for RAGAS evaluation

### DIFF
--- a/lightrag/evaluation/README_EVALUASTION_RAGAS.md
+++ b/lightrag/evaluation/README_EVALUASTION_RAGAS.md
@@ -54,6 +54,15 @@ pip install -e ".[evaluation]"
 
 ### 2. Run Evaluation
 
+**Optional offline sample retrieval check (no API/model calls):**
+```bash
+python lightrag/evaluation/offline_retrieval_check.py --strict
+```
+
+This checks whether the bundled sample questions can lexically retrieve their
+expected sample documents before running LightRAG, embeddings, LLM calls, or
+RAGAS.
+
 **Basic usage (uses defaults):**
 ```bash
 cd /path/to/LightRAG

--- a/lightrag/evaluation/offline_retrieval_check.py
+++ b/lightrag/evaluation/offline_retrieval_check.py
@@ -157,10 +157,18 @@ def audit_samples(
             raise ValueError(f"No oracle entry for question: {question}")
 
         query_tokens = tokenize(question)
-        ranked = sorted(
-            documents,
-            key=lambda doc: (-score_query(query_tokens, doc, idf), doc.name),
-        )
+        scored_documents = [
+            (score_query(query_tokens, document, idf), document)
+            for document in documents
+        ]
+        ranked = [
+            document
+            for score, document in sorted(
+                scored_documents,
+                key=lambda item: (-item[0], item[1].name),
+            )
+            if score > 0
+        ]
         results.append(
             QueryResult(
                 question=question,

--- a/lightrag/evaluation/offline_retrieval_check.py
+++ b/lightrag/evaluation/offline_retrieval_check.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Offline sanity check for the bundled LightRAG evaluation samples.
+
+The check uses a small deterministic lexical ranker. It does not start
+LightRAG, call the API server, compute embeddings, or call LLM/RAGAS services.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+EVAL_DIR = Path(__file__).resolve().parent
+DEFAULT_DATASET = EVAL_DIR / "sample_dataset.json"
+DEFAULT_DOCS_DIR = EVAL_DIR / "sample_documents"
+DEFAULT_ORACLE = EVAL_DIR / "sample_retrieval_oracle.json"
+
+STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "by",
+    "for",
+    "from",
+    "how",
+    "in",
+    "into",
+    "is",
+    "it",
+    "its",
+    "of",
+    "on",
+    "or",
+    "that",
+    "the",
+    "their",
+    "to",
+    "what",
+    "with",
+}
+
+
+@dataclass
+class Document:
+    name: str
+    tokens: Counter[str]
+
+
+@dataclass
+class QueryResult:
+    question: str
+    expected: list[str]
+    ranked: list[str]
+
+    def recall_at(self, top_k: int) -> float:
+        hits = set(self.expected) & set(self.ranked[:top_k])
+        return len(hits) / len(self.expected)
+
+    def reciprocal_rank(self) -> float:
+        for rank, document in enumerate(self.ranked, start=1):
+            if document in self.expected:
+                return 1 / rank
+        return 0.0
+
+
+def tokenize(text: str) -> list[str]:
+    tokens = re.findall(r"[a-z0-9]+", text.lower())
+    return [token for token in tokens if token not in STOPWORDS and len(token) > 1]
+
+
+def load_cases(dataset_path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(dataset_path.read_text(encoding="utf-8"))
+    cases = payload.get("test_cases")
+    if not isinstance(cases, list):
+        raise ValueError(f"{dataset_path} must contain a test_cases list")
+    return cases
+
+
+def load_oracle(oracle_path: Path) -> dict[str, list[str]]:
+    payload = json.loads(oracle_path.read_text(encoding="utf-8"))
+    entries = payload.get("oracle")
+    if not isinstance(entries, list):
+        raise ValueError(f"{oracle_path} must contain an oracle list")
+
+    oracle: dict[str, list[str]] = {}
+    for entry in entries:
+        question = str(entry.get("question", "")).strip()
+        expected = entry.get("expected_documents")
+        if not question or not isinstance(expected, list) or not expected:
+            raise ValueError("Each oracle entry needs question and expected_documents")
+        oracle[question] = [str(document) for document in expected]
+    return oracle
+
+
+def load_documents(docs_dir: Path) -> list[Document]:
+    documents: list[Document] = []
+    for path in sorted(docs_dir.glob("*.md")):
+        if path.name.lower() == "readme.md":
+            continue
+        documents.append(
+            Document(
+                name=path.name,
+                tokens=Counter(tokenize(path.read_text(encoding="utf-8"))),
+            )
+        )
+    if not documents:
+        raise ValueError(f"No markdown sample documents found in {docs_dir}")
+    return documents
+
+
+def inverse_document_frequency(documents: list[Document]) -> dict[str, float]:
+    document_frequency: Counter[str] = Counter()
+    for document in documents:
+        document_frequency.update(document.tokens.keys())
+    doc_count = len(documents)
+    return {
+        token: math.log((doc_count + 1) / (frequency + 1)) + 1
+        for token, frequency in document_frequency.items()
+    }
+
+
+def score_query(
+    query_tokens: list[str],
+    document: Document,
+    idf: dict[str, float],
+) -> float:
+    score = 0.0
+    for token in query_tokens:
+        if token in document.tokens:
+            score += (1 + math.log(document.tokens[token])) * idf.get(token, 0.0)
+    return score
+
+
+def audit_samples(
+    cases: list[dict[str, Any]],
+    oracle: dict[str, list[str]],
+    documents: list[Document],
+) -> list[QueryResult]:
+    idf = inverse_document_frequency(documents)
+    results: list[QueryResult] = []
+
+    for case in cases:
+        question = str(case.get("question", "")).strip()
+        if question not in oracle:
+            raise ValueError(f"No oracle entry for question: {question}")
+
+        query_tokens = tokenize(question)
+        ranked = sorted(
+            documents,
+            key=lambda doc: (-score_query(query_tokens, doc, idf), doc.name),
+        )
+        results.append(
+            QueryResult(
+                question=question,
+                expected=oracle[question],
+                ranked=[document.name for document in ranked],
+            )
+        )
+    return results
+
+
+def summarize(results: list[QueryResult], top_k: int) -> dict[str, Any]:
+    if not results:
+        raise ValueError("No query results to summarize")
+    recalls = [result.recall_at(top_k) for result in results]
+    reciprocal_ranks = [result.reciprocal_rank() for result in results]
+    return {
+        "queries": len(results),
+        "top_k": top_k,
+        "average_recall_at_k": sum(recalls) / len(recalls),
+        "mean_reciprocal_rank": sum(reciprocal_ranks) / len(reciprocal_ranks),
+        "full_recall_queries": sum(recall == 1.0 for recall in recalls),
+        "no_hit_queries": sum(recall == 0.0 for recall in recalls),
+    }
+
+
+def print_report(results: list[QueryResult], top_k: int) -> None:
+    summary = summarize(results, top_k)
+    print("LightRAG sample retrieval check")
+    print(f"Queries: {summary['queries']}")
+    print(f"Top-k: {summary['top_k']}")
+    print(f"Average recall@k: {summary['average_recall_at_k']:.3f}")
+    print(f"Mean reciprocal rank: {summary['mean_reciprocal_rank']:.3f}")
+    print(f"Full-recall queries: {summary['full_recall_queries']}/{summary['queries']}")
+    print(f"No-hit queries: {summary['no_hit_queries']}")
+    print()
+    for index, result in enumerate(results, start=1):
+        top_docs = ", ".join(result.ranked[:top_k])
+        expected = ", ".join(result.expected)
+        print(f"{index}. recall@{top_k}={result.recall_at(top_k):.3f}")
+        print(f"   expected: {expected}")
+        print(f"   top docs: {top_docs}")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run an offline retrieval check for LightRAG evaluation samples."
+    )
+    parser.add_argument("--dataset", default=str(DEFAULT_DATASET))
+    parser.add_argument("--docs-dir", default=str(DEFAULT_DOCS_DIR))
+    parser.add_argument("--oracle", default=str(DEFAULT_ORACLE))
+    parser.add_argument("--top-k", type=int, default=2)
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero unless every sample query has full recall@k.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    if args.top_k <= 0:
+        print("--top-k must be positive", file=sys.stderr)
+        return 2
+
+    try:
+        cases = load_cases(Path(args.dataset).expanduser())
+        oracle = load_oracle(Path(args.oracle).expanduser())
+        documents = load_documents(Path(args.docs_dir).expanduser())
+        results = audit_samples(cases, oracle, documents)
+        print_report(results, args.top_k)
+        summary = summarize(results, args.top_k)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"Sample retrieval check failed: {exc}", file=sys.stderr)
+        return 2
+
+    if args.strict and summary["full_recall_queries"] != summary["queries"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lightrag/evaluation/sample_retrieval_oracle.json
+++ b/lightrag/evaluation/sample_retrieval_oracle.json
@@ -1,0 +1,31 @@
+{
+  "oracle": [
+    {
+      "question": "How does LightRAG solve the hallucination problem in large language models?",
+      "expected_documents": ["01_lightrag_overview.md"]
+    },
+    {
+      "question": "What are the three main components required in a RAG system?",
+      "expected_documents": ["02_rag_architecture.md"]
+    },
+    {
+      "question": "How does LightRAG's retrieval performance compare to traditional RAG approaches?",
+      "expected_documents": ["03_lightrag_improvements.md"]
+    },
+    {
+      "question": "What vector databases does LightRAG support and what are their key characteristics?",
+      "expected_documents": ["04_supported_databases.md"]
+    },
+    {
+      "question": "What are the four key metrics for evaluating RAG system quality and what does each metric measure?",
+      "expected_documents": ["05_evaluation_and_deployment.md"]
+    },
+    {
+      "question": "What are the core benefits of LightRAG and how does it improve upon traditional RAG systems?",
+      "expected_documents": [
+        "01_lightrag_overview.md",
+        "03_lightrag_improvements.md"
+      ]
+    }
+  ]
+}

--- a/tests/test_evaluation_offline_retrieval_check.py
+++ b/tests/test_evaluation_offline_retrieval_check.py
@@ -27,12 +27,12 @@ class OfflineRetrievalCheckTests(unittest.TestCase):
             )
             dataset = root / "dataset.json"
             dataset.write_text(
-                '{"test_cases":[{"question":"Which document covers vector search?"}]}',
+                '{"test_cases":[{"question":"Which file explains vector search?"}]}',
                 encoding="utf-8",
             )
             oracle = root / "oracle.json"
             oracle.write_text(
-                '{"oracle":[{"question":"Which document covers vector search?",'
+                '{"oracle":[{"question":"Which file explains vector search?",'
                 '"expected_documents":["alpha.md"]}]}',
                 encoding="utf-8",
             )
@@ -47,6 +47,42 @@ class OfflineRetrievalCheckTests(unittest.TestCase):
         self.assertEqual(results[0].ranked[0], "alpha.md")
         self.assertEqual(summary["queries"], 1)
         self.assertEqual(summary["average_recall_at_k"], 1.0)
+
+    def test_zero_score_documents_do_not_count_as_hits(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            docs_dir = root / "docs"
+            docs_dir.mkdir()
+            (docs_dir / "alpha.md").write_text(
+                "Alpha covers deployment pipelines.",
+                encoding="utf-8",
+            )
+            (docs_dir / "beta.md").write_text(
+                "Beta covers monitoring dashboards.",
+                encoding="utf-8",
+            )
+            dataset = root / "dataset.json"
+            dataset.write_text(
+                '{"test_cases":[{"question":"Which file explains vector search?"}]}',
+                encoding="utf-8",
+            )
+            oracle = root / "oracle.json"
+            oracle.write_text(
+                '{"oracle":[{"question":"Which file explains vector search?",'
+                '"expected_documents":["alpha.md"]}]}',
+                encoding="utf-8",
+            )
+
+            results = audit_samples(
+                load_cases(dataset),
+                load_oracle(oracle),
+                load_documents(docs_dir),
+            )
+            summary = summarize(results, top_k=1)
+
+        self.assertEqual(results[0].ranked, [])
+        self.assertEqual(summary["average_recall_at_k"], 0.0)
+        self.assertEqual(summary["no_hit_queries"], 1)
 
     def test_sample_oracle_has_full_recall_at_two(self):
         results = audit_samples(

--- a/tests/test_evaluation_offline_retrieval_check.py
+++ b/tests/test_evaluation_offline_retrieval_check.py
@@ -1,0 +1,65 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from lightrag.evaluation.offline_retrieval_check import (
+    audit_samples,
+    load_cases,
+    load_documents,
+    load_oracle,
+    summarize,
+)
+
+
+class OfflineRetrievalCheckTests(unittest.TestCase):
+    def test_expected_document_ranks_first(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            docs_dir = root / "docs"
+            docs_dir.mkdir()
+            (docs_dir / "alpha.md").write_text(
+                "Alpha covers vector search and filtering.",
+                encoding="utf-8",
+            )
+            (docs_dir / "beta.md").write_text(
+                "Beta covers deployment and monitoring.",
+                encoding="utf-8",
+            )
+            dataset = root / "dataset.json"
+            dataset.write_text(
+                '{"test_cases":[{"question":"Which document covers vector search?"}]}',
+                encoding="utf-8",
+            )
+            oracle = root / "oracle.json"
+            oracle.write_text(
+                '{"oracle":[{"question":"Which document covers vector search?",'
+                '"expected_documents":["alpha.md"]}]}',
+                encoding="utf-8",
+            )
+
+            results = audit_samples(
+                load_cases(dataset),
+                load_oracle(oracle),
+                load_documents(docs_dir),
+            )
+            summary = summarize(results, top_k=1)
+
+        self.assertEqual(results[0].ranked[0], "alpha.md")
+        self.assertEqual(summary["queries"], 1)
+        self.assertEqual(summary["average_recall_at_k"], 1.0)
+
+    def test_sample_oracle_has_full_recall_at_two(self):
+        results = audit_samples(
+            load_cases(Path("lightrag/evaluation/sample_dataset.json")),
+            load_oracle(Path("lightrag/evaluation/sample_retrieval_oracle.json")),
+            load_documents(Path("lightrag/evaluation/sample_documents")),
+        )
+        summary = summarize(results, top_k=2)
+
+        self.assertEqual(summary["queries"], 6)
+        self.assertEqual(summary["full_recall_queries"], 6)
+        self.assertEqual(summary["no_hit_queries"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds a small offline retrieval sanity check for the bundled LightRAG RAGAS evaluation samples.

Changes:

- add `sample_retrieval_oracle.json` to map each sample question to its expected sample document(s)
- add `offline_retrieval_check.py`, a deterministic lexical check that does not start LightRAG or call API/model/RAGAS services
- add regression coverage for the checker and bundled sample oracle
- document the optional check in the RAGAS evaluation README

## Why

The existing evaluation flow can require a running LightRAG server, indexed documents, embeddings, LLM calls, and RAGAS. Before spending that setup time or API budget, it is useful to verify that the bundled sample questions are structurally aligned with the bundled sample documents.

This check catches a narrower failure mode: sample questions whose expected documents are not retrievable even under a simple deterministic baseline. It also documents that the final bundled sample question expects two documents, so top-1 retrieval only gives partial recall while top-2 gives full recall.

## Validation

From the repo root:

```bash
python3 -m py_compile lightrag/evaluation/offline_retrieval_check.py tests/test_evaluation_offline_retrieval_check.py
python3 lightrag/evaluation/offline_retrieval_check.py --strict
python3 -m unittest tests/test_evaluation_offline_retrieval_check.py
git diff --check
```

Observed result for the default strict check:

```text
Queries: 6
Top-k: 2
Average recall@k: 1.000
Mean reciprocal rank: 1.000
Full-recall queries: 6/6
No-hit queries: 0
```

I also checked `--top-k 1 --strict`; it exits non-zero because the multi-document sample has recall@1 = 0.500, which is the intended strict behavior.

`pytest` and `ruff` are not installed in my local environment, so I could not run those commands here.

## Scope / limits

This PR does not change LightRAG retrieval behavior, the API server, embeddings, LLM calls, or RAGAS scoring. It only adds an offline sample-data sanity check and test coverage for that check.
