### PR TITLE
feat(webui): inject path prefix at runtime — one build serves all sites

### DIFF
--- a/docs/MultiSiteDeployment.md
+++ b/docs/MultiSiteDeployment.md
@@ -1,23 +1,17 @@
 # Single-Server Multi-Site Deployment
 
-This document explains how to run multiple isolated LightRAG instances
-behind one host using a reverse proxy (nginx, Traefik, Kubernetes Ingress,
-…), with **one shared WebUI build** reused by every instance.
+This document explains how to run multiple isolated LightRAG instances behind one host using a reverse proxy (nginx, Traefik, Kubernetes Ingress, …), with **one shared WebUI build** reused by every instance.
 
-> Looking for the basic single-instance Docker setup? See
-> [DockerDeployment.md](./DockerDeployment.md). For frontend build
+> Looking for the basic single-instance Docker setup? See [DockerDeployment.md](./DockerDeployment.md). For frontend build
 > mechanics in general, see [FrontendBuildGuide.md](./FrontendBuildGuide.md).
 
 ---
 
 ## TL;DR
 
-- Set `LIGHTRAG_API_PREFIX` and `LIGHTRAG_WEBUI_PATH` per-instance, on the
-  **backend only**.
-- Build the WebUI **once**. The same artifacts work under any reverse-proxy
-  prefix.
-- Point your reverse proxy at each backend, stripping the site prefix
-  before forwarding.
+- Set `LIGHTRAG_API_PREFIX` and `LIGHTRAG_WEBUI_PATH` per-instance, on the **backend only**.
+- Build the WebUI **once**. The same artifacts work under any reverse-proxy prefix.
+- Point your reverse proxy at each backend, stripping the site prefix before forwarding.
 
 ```bash
 # One image, two containers, two prefixes — no rebuild.
@@ -29,34 +23,21 @@ docker run -e LIGHTRAG_API_PREFIX=/site02 -p 9622:9621 lightrag:latest
 
 ## Why "build once, deploy many"
 
-Earlier versions of LightRAG baked the site prefix into the JavaScript
-bundle at build time (via `VITE_API_PREFIX` / `VITE_WEBUI_PREFIX`). Every
-site that used a different prefix needed its own WebUI build, and reusing
-a single Docker image across sites required a rebuild step at deploy time.
+Earlier versions of LightRAG baked the site prefix into the JavaScript bundle at build time (via `VITE_API_PREFIX` / `VITE_WEBUI_PREFIX`). Every site that used a different prefix needed its own WebUI build, and reusing a single Docker image across sites required a rebuild step at deploy time. Since the runtime-config-injection refactor:
 
-Since the runtime-config-injection refactor:
+- **Asset URLs** in `index.html` are emitted as relative paths (`./assets/index-abc.js`). The browser resolves them against the current document URL, so they work under any mount point.
+- **API base URL** and **in-app links** read their prefix from `window.__LIGHTRAG_CONFIG__`, which the FastAPI server injects into `index.html` on each response based on its own `LIGHTRAG_API_PREFIX` / `LIGHTRAG_WEBUI_PATH`.
 
-- **Asset URLs** in `index.html` are emitted as relative paths
-  (`./assets/index-abc.js`). The browser resolves them against the current
-  document URL, so they work under any mount point.
-- **API base URL** and **in-app links** read their prefix from
-  `window.__LIGHTRAG_CONFIG__`, which the FastAPI server injects into
-  `index.html` on each response based on its own
-  `LIGHTRAG_API_PREFIX` / `LIGHTRAG_WEBUI_PATH`.
-
-The result: a single `lightrag/api/webui/` directory (or Docker image) is
-reusable across any number of sites with no per-site build artifact.
+The result: a single `lightrag/api/webui/` directory (or Docker image) is reusable across any number of sites with no per-site build artifact.
 
 ---
 
 ## How runtime prefix injection works
 
-Each request for `index.html` goes through `SmartStaticFiles` in
-`lightrag/api/lightrag_server.py`, which:
+Each request for `index.html` goes through `SmartStaticFiles` in `lightrag/api/lightrag_server.py`, which:
 
 1. Reads the static `index.html` produced by `bun run build`.
-2. Looks for the placeholder comment
-   `<!-- __LIGHTRAG_RUNTIME_CONFIG__ -->`.
+2. Looks for the placeholder comment `<!-- __LIGHTRAG_RUNTIME_CONFIG__ -->`.
 3. Replaces it with
    `<script>window.__LIGHTRAG_CONFIG__ = {"apiPrefix":"…","webuiPrefix":"…"}</script>`,
    computed from the configured `LIGHTRAG_API_PREFIX` / `LIGHTRAG_WEBUI_PATH`.
@@ -64,22 +45,22 @@ Each request for `index.html` goes through `SmartStaticFiles` in
 Sequence — browser request to a site-prefixed instance:
 
 ```
-Browser            nginx                  uvicorn            SmartStaticFiles
-  │                  │                       │                       │
-  │ GET /site01/webui/                       │                       │
-  │─────────────────►│                       │                       │
-  │                  │ GET /webui/  (strips /site01)                 │
-  │                  │──────────────────────►│                       │
-  │                  │                       │ get_response("")      │
-  │                  │                       │──────────────────────►│
-  │                  │                       │                       │ inject
-  │                  │                       │                       │ window.__LIGHTRAG_CONFIG__
-  │                  │                       │                       │  = { apiPrefix: "/site01",
-  │                  │                       │                       │      webuiPrefix: "/site01/webui/" }
-  │                  │                       │◄──────────────────────│
-  │                  │◄──────────────────────│                       │
-  │◄─────────────────│                       │                       │
-  │ index.html with injected runtime config                          │
+Browser            nginx                  uvicorn         SmartStaticFiles
+  │                  │                       │                    │
+  │ GET /site01/webui/                       │                    │
+  │─────────────────►│                       │                    │
+  │                  │ GET /webui/  (strips /site01)              │
+  │                  │──────────────────────►│                    │
+  │                  │                       │ get_response("")   │
+  │                  │                       │───────────────────►│
+  │                  │                       │                    │ inject
+  │                  │                       │                    │ window.__LIGHTRAG_CONFIG__
+  │                  │                       │                    │ = { apiPrefix: "/site01",
+  │                  │                       │                    │ webuiPrefix: "/site01/webui/" }
+  │                  │                       │◄───────────────────│
+  │                  │◄──────────────────────│                    │
+  │◄─────────────────│                       │                    │
+  │ index.html with injected runtime config
 ```
 
 The SPA reads the injected config via `src/lib/runtimeConfig.ts` and uses
@@ -95,12 +76,9 @@ and in-app links.
 | `LIGHTRAG_API_PREFIX` | `""` | Reverse-proxy prefix that the upstream proxy strips before forwarding to FastAPI. Passed to FastAPI as `root_path`. |
 | `LIGHTRAG_WEBUI_PATH` | `/webui` | In-app mount path for the WebUI **after** the proxy has stripped the API prefix. Leave as `/webui` unless you have a specific reason to relocate it. |
 
-`window.__LIGHTRAG_CONFIG__.webuiPrefix` is computed as
-`LIGHTRAG_API_PREFIX + LIGHTRAG_WEBUI_PATH + "/"`. You do **not** set this
-yourself.
+`window.__LIGHTRAG_CONFIG__.webuiPrefix` is computed as `LIGHTRAG_API_PREFIX + LIGHTRAG_WEBUI_PATH + "/"`. You do **not** set this yourself.
 
-There are no longer any frontend `VITE_API_PREFIX` / `VITE_WEBUI_PREFIX`
-variables. Setting them has no effect (they are ignored by the build).
+There are no longer any frontend `VITE_API_PREFIX` / `VITE_WEBUI_PREFIX` variables. Setting them has no effect (they are ignored by the build).
 
 ---
 
@@ -180,10 +158,7 @@ server {
 }
 ```
 
-Browsing `https://host.example.com/site01/webui/` shows site01's WebUI;
-`https://host.example.com/site02/webui/` shows site02's. The same Docker
-image serves both — no per-site build artifact, no rebuild on prefix
-changes.
+Browsing `https://host.example.com/site01/webui/` shows site01's WebUI; `https://host.example.com/site02/webui/` shows site02's. The same Docker image serves both — no per-site build artifact, no rebuild on prefix changes.
 
 ### What each layer sees
 
@@ -218,8 +193,7 @@ COPY --from=webui-build /src/lightrag/api/webui /app/lightrag/api/webui
 # … rest of the image …
 ```
 
-Run any number of containers from the same image, each with its own
-prefix:
+Run any number of containers from the same image, each with its own prefix:
 
 ```bash
 # Plain single-instance, no prefix.
@@ -271,19 +245,14 @@ Backends still set `LIGHTRAG_API_PREFIX=/site01` / `=/site02`.
 
 ## Local development with `bun run dev`
 
-The dev server mirrors production injection: it serves `index.html` via
-the same `transformIndexHtml` mechanism the FastAPI server uses at request
-time, so the SPA reads `window.__LIGHTRAG_CONFIG__` in dev exactly the
-way it does in prod. Only **two** environment variables matter:
+The dev server mirrors production injection: it serves `index.html` via the same `transformIndexHtml` mechanism the FastAPI server uses at request time, so the SPA reads `window.__LIGHTRAG_CONFIG__` in dev exactly the way it does in prod. Only **two** environment variables matter:
 
 | Variable | Purpose | Where it lives |
 | --- | --- | --- |
 | `VITE_BACKEND_URL` | Where the dev server forwards proxied API calls. | `lightrag_webui/.env*` |
 | `VITE_DEV_API_PREFIX` | Prefix to **simulate** (matches the production `LIGHTRAG_API_PREFIX`). Empty → no prefix. | `lightrag_webui/.env*` |
 
-`VITE_DEV_WEBUI_PREFIX` is also accepted but only affects the home/logo
-`<a href>` link inside the SPA — set it to `${VITE_DEV_API_PREFIX}/webui/`
-if you care about that link in dev, otherwise leave it empty.
+`VITE_DEV_WEBUI_PREFIX` is also accepted but only affects the home/logo `<a href>` link inside the SPA — set it to `${VITE_DEV_API_PREFIX}/webui/` if you care about that link in dev, otherwise leave it empty.
 
 Three scenarios cover everything you'll hit:
 
@@ -311,13 +280,11 @@ cd lightrag_webui && bun run dev # in another; open http://localhost:5173/
 
 ### Scenario 2 — simulate the production prefix WITHOUT running nginx (recommended)
 
-You want to develop against a prefix-configured backend, but don't want
-to install / configure nginx locally just to debug. **The Vite dev
-server's built-in proxy plays the role of the reverse proxy.**
+You want to develop against a prefix-configured backend, but don't want to install / configure nginx locally just to debug. **The Vite dev server's built-in proxy plays the role of the reverse proxy.**
 
 ```
-Browser ──► localhost:5173 (Vite, simulates /site01) ──► localhost:9621 (backend, root_path=/site01)
-                                                          (no nginx in this picture)
+Browser ──► localhost:5173  ───────────► localhost:9621(no nginx in this scenario)
+            (Vite, simulates /site01)    (backend, root_path=/site01)
 ```
 
 Setup:
@@ -339,8 +306,7 @@ LIGHTRAG_API_PREFIX=/site01 lightrag-server
 cd lightrag_webui && bun run dev
 ```
 
-Then open **`http://localhost:5173/`** (root, NOT `/site01/`). Vite serves
-the SPA at `/`; the SPA generates prefixed API URLs at runtime.
+Then open **`http://localhost:5173/`** (root, NOT `/site01/`). Vite serves the SPA at `/`; the SPA generates prefixed API URLs at runtime.
 
 What happens:
 
@@ -349,16 +315,11 @@ What happens:
 - `server.proxy` matches `/site01/documents` and forwards verbatim to `http://localhost:9621/site01/documents/foo`.
 - The backend (`root_path=/site01`) accepts the prefixed path and serves it.
 
-HMR continues to work unchanged. **No nginx, no Docker — just two
-processes on localhost.**
+HMR continues to work unchanged. **No nginx, no Docker — just two processes on localhost.**
 
 ### Scenario 3 — local dev frontend against a real (remote) backend
 
-You want to iterate on the WebUI on your laptop while hitting a backend
-that's already in production behind nginx — typically because the real
-backend has data / configs that are painful to reproduce locally. The
-WebUI is purely local (HMR on your laptop); only API traffic crosses the
-network.
+You want to iterate on the WebUI on your laptop while hitting a backend that's already in production behind nginx — typically because the real backend has data / configs that are painful to reproduce locally. The WebUI is purely local (HMR on your laptop); only API traffic crosses the network.
 
 ```
 Local machine                                Remote production host
@@ -367,80 +328,54 @@ Browser ──► localhost:5173 (Vite + HMR)
                 │
                 │  Vite proxy forwards /site01/* verbatim
                 ▼
-              ─── network ───►  nginx ──strips /site01/──► lightrag-server
-                                                          (backend; may
-                                                           or may not have
+                ── network ───► nginx(strips /site01) ──► lightrag-server
+                                                          (may or may not have
                                                            LIGHTRAG_API_PREFIX
                                                            set — both work)
 ```
 
-The key insight: the production nginx is **already** doing the prefix
-strip. Vite's only job is to forward prefixed paths to nginx unchanged,
-and nginx behaves exactly as it would for a real production browser
-request.
+The key insight: the production nginx is **already** doing the prefix strip. Vite's only job is to forward prefixed paths to nginx unchanged, and nginx behaves exactly as it would for a real production browser request.
 
 **Setup:**
 
-1. **Production nginx + backend:** unchanged. Whatever your real deploy
-   already runs.
-
+1. **Production nginx + backend:** unchanged. Whatever your real deploy already runs.
+   
 2. **Dev server (`.env.local`):**
+   
    ```bash
    # Point at the production reverse proxy — NOT the backend port.
-   VITE_BACKEND_URL=https://prod.example.com         # or http://10.0.0.5
+   VITE_BACKEND_URL=https://prod.example.com     # or http://10.0.0.5
    VITE_API_PROXY=true
    VITE_API_ENDPOINTS=/api,/documents,/graphs,/graph,/health,/query,/docs,/redoc,/openapi.json,/login,/auth-status,/static
    VITE_DEV_API_PREFIX=/site01
    VITE_DEV_WEBUI_PREFIX=/site01/webui/
    ```
-
+   
 3. Run `bun run dev` and open **`http://localhost:5173/`**.
 
 What happens for an API call:
 
-- SPA fetches `/site01/documents/foo` (because `apiPrefix=/site01` was
-  injected into `window.__LIGHTRAG_CONFIG__`).
+- SPA fetches `/site01/documents/foo` (because `apiPrefix=/site01` was injected into `window.__LIGHTRAG_CONFIG__`).
 - Vite's `server.proxy` matches `/site01/documents` and forwards verbatim
-  to `https://prod.example.com/site01/documents/foo`.
-  (`changeOrigin: true` is already set, so the `Host` header is rewritten
-  to the upstream — required for SNI / virtual hosts.)
-- Production nginx matches `/site01/`, strips it, forwards
-  `/documents/foo` to the backend.
-- Backend serves it. `LIGHTRAG_API_PREFIX` on the backend can be set or
-  unset; FastAPI's `root_path` accepts both prefixed and natural forms
-  either way.
+  to `https://prod.example.com/site01/documents/foo`. (`changeOrigin: true` is already set, so the `Host` header is rewritten to the upstream — required for SNI / virtual hosts.)
+- Production nginx matches `/site01/`, strips it, forwards `/documents/foo` to the backend.
+- Backend serves it. `LIGHTRAG_API_PREFIX` on the backend can be set or unset; FastAPI's `root_path` accepts both prefixed and natural forms either way.
 
-HMR is purely local — the browser only talks to localhost:5173 for SPA
-assets. No nginx involvement, no special WebSocket-upgrade config to
-worry about.
+HMR is purely local — the browser only talks to localhost:5173 for SPA assets. No nginx involvement, no special WebSocket-upgrade config to worry about.
 
 #### Why `VITE_BACKEND_URL` does **not** include `/site01`
 
-Vite forwards the request path **verbatim** (no rewrite). The browser
-already emits `/site01/documents/foo`, so the URL Vite sends upstream is
-`${VITE_BACKEND_URL}/site01/documents/foo`. If you set
-`VITE_BACKEND_URL=https://prod.example.com/site01` you'd get
-`https://prod.example.com/site01/site01/documents/foo` — a duplicated
-prefix that nginx and the backend both reject.
+Vite forwards the request path **verbatim** (no rewrite). The browser already emits `/site01/documents/foo`, so the URL Vite sends upstream is `${VITE_BACKEND_URL}/site01/documents/foo`. If you set
+`VITE_BACKEND_URL=https://prod.example.com/site01` you'd get `https://prod.example.com/site01/site01/documents/foo` — a duplicated prefix that nginx and the backend both reject.
 
-Same logic applies to Scenario 2 (`VITE_BACKEND_URL=http://localhost:9621`,
-no prefix): Vite forwards `/site01/documents/foo` unchanged to the
-backend, and FastAPI's `root_path=/site01` matches the prefixed form
-natively.
+Same logic applies to Scenario 2 (`VITE_BACKEND_URL=http://localhost:9621`, no prefix): Vite forwards `/site01/documents/foo` unchanged to the backend, and FastAPI's `root_path=/site01` matches the prefixed form natively.
 
 #### Common pitfalls
 
-- **HTTPS upstream + self-signed cert**: Vite's proxy will reject by
-  default. Set `proxy: { ..., secure: false }` in `vite.config.ts` to
-  skip cert validation when targeting a staging proxy with a non-public
+- **HTTPS upstream + self-signed cert**: Vite's proxy will reject by default. Set `proxy: { ..., secure: false }` in `vite.config.ts` to skip cert validation when targeting a staging proxy with a non-public
   cert.
-- **Auth required**: if the production backend requires `LIGHTRAG_API_KEY`,
-  log in via the dev SPA exactly as you would in prod — the auth token
-  flows through the proxy unchanged.
-- **CORS errors**: shouldn't happen because the browser sees same-origin
-  requests to localhost:5173. If they appear, check that
-  `changeOrigin: true` is in effect (it is, by default in
-  `vite.config.ts`).
+- **Auth required**: if the production backend requires `LIGHTRAG_API_KEY`, log in via the dev SPA exactly as you would in prod — the auth token flows through the proxy unchanged.
+- **CORS errors**: shouldn't happen because the browser sees same-origin requests to localhost:5173. If they appear, check that `changeOrigin: true` is in effect (it is, by default in `vite.config.ts`).
 
 ### Quick decision matrix
 
@@ -450,9 +385,7 @@ natively.
 | Reproduce a multi-site bug locally | `http://localhost:9621` | `/site01` | local backend with `LIGHTRAG_API_PREFIX=/site01`, no nginx | `http://localhost:5173/` |
 | Hit a real (remote) backend through its production nginx | `https://prod.example.com` | `/site01` | production nginx already strips `/site01/` | `http://localhost:5173/` |
 
-In every case the browser only talks to local Vite at `localhost:5173`;
-the column on the right is the same. Where the API traffic ultimately
-lands is what differs.
+In every case the browser only talks to local Vite at `localhost:5173`; the column on the right is the same. Where the API traffic ultimately lands is what differs.
 
 ---
 
@@ -460,17 +393,11 @@ lands is what differs.
 
 If you were on the previous build-time-prefix model:
 
-- **Stop setting `VITE_API_PREFIX` and `VITE_WEBUI_PREFIX`.** They are
-  ignored by the new build. Remove them from your CI / build scripts.
-- **Drop per-site Docker images.** A single image works for every prefix.
-  CI no longer needs a "build once per site" matrix.
+- **Stop setting `VITE_API_PREFIX` and `VITE_WEBUI_PREFIX`.** They are ignored by the new build. Remove them from your CI / build scripts.
+- **Drop per-site Docker images.** A single image works for every prefix. CI no longer needs a "build once per site" matrix.
 - **No more "prefix mismatch" warnings at startup.** The
-  `check_webui_build_prefix` function and its banner have been removed —
-  there is nothing to mismatch.
-- **The `lightrag_webui/index.html` template now contains the placeholder
-  comment `<!-- __LIGHTRAG_RUNTIME_CONFIG__ -->`.** If you fork the
-  template, keep that line in `<head>` or the runtime config will not be
-  injected (the SPA falls back to no-prefix defaults).
+  `check_webui_build_prefix` function and its banner have been removed — there is nothing to mismatch.
+- **The `lightrag_webui/index.html` template now contains the placeholder comment `<!-- __LIGHTRAG_RUNTIME_CONFIG__ -->`.** If you fork the template, keep that line in `<head>` or the runtime config will not be injected (the SPA falls back to no-prefix defaults).
 
 ---
 
@@ -478,32 +405,18 @@ If you were on the previous build-time-prefix model:
 
 ### Asset URLs 404 when accessing the WebUI
 
-The base URL must end with `/`. Accessing `/site01/webui` (no trailing
-slash) makes the browser resolve `./assets/foo.js` against `/site01/`,
-which 404s. The server already redirects the no-slash form to the
-slash form; verify the redirect is reaching nginx (check
-`X-Forwarded-Prefix` and that nginx uses `proxy_pass http://…/` with the
-trailing slash).
+The base URL must end with `/`. Accessing `/site01/webui` (no trailing slash) makes the browser resolve `./assets/foo.js` against `/site01/`, which 404s. The server already redirects the no-slash form to the
+slash form; verify the redirect is reaching nginx (check `X-Forwarded-Prefix` and that nginx uses `proxy_pass http://…/` with the trailing slash).
 
 ### `apiPrefix` is empty in `window.__LIGHTRAG_CONFIG__` after deploy
 
-View the page source. If you see the literal placeholder
-`<!-- __LIGHTRAG_RUNTIME_CONFIG__ -->` instead of an injected
-`<script>` tag, the request did not go through `SmartStaticFiles` —
-double-check that `lightrag/api/webui/index.html` exists in the running
-container and that the WebUI mount succeeded (the server logs
-`WebUI assets mounted at <path>` at startup).
+View the page source. If you see the literal placeholder `<!-- __LIGHTRAG_RUNTIME_CONFIG__ -->` instead of an injected `<script>` tag, the request did not go through `SmartStaticFiles` — double-check that `lightrag/api/webui/index.html` exists in the running container and that the WebUI mount succeeded (the server logs `WebUI assets mounted at <path>` at startup).
 
 ### `bun run dev` proxy returns 404 with `VITE_DEV_API_PREFIX` set
 
-Confirm the backend is also running with the matching
-`LIGHTRAG_API_PREFIX`. The dev proxy forwards prefixed paths verbatim;
-if the backend has no prefix configured, it does not register routes
-under that path.
+Confirm the backend is also running with the matching `LIGHTRAG_API_PREFIX`. The dev proxy forwards prefixed paths verbatim; if the backend has no prefix configured, it does not register routes under that path.
 
 ### I want to disable the WebUI entirely
 
-Don't build the frontend — `lightrag/api/webui/index.html` will not exist
-and the server will skip the WebUI mount, redirecting `/` and the
-WebUI path to `/docs` instead. The runtime-config injection is purely
-opt-in via the existence of the build artifact.
+Don't build the frontend — `lightrag/api/webui/index.html` will not exist and the server will skip the WebUI mount, redirecting `/` and the WebUI path to `/docs` instead. The runtime-config injection is purely opt-in via the existence of the build artifact.
+

--- a/docs/MultiSiteDeployment.md
+++ b/docs/MultiSiteDeployment.md
@@ -353,18 +353,6 @@ Rows 2A and 2B share **everything except `VITE_BACKEND_URL`** — the choice is 
 
 ---
 
-## Migration notes
-
-If you were on the previous build-time-prefix model:
-
-- **Stop setting `VITE_API_PREFIX` and `VITE_WEBUI_PREFIX`.** They are ignored by the new build. Remove them from your CI / build scripts.
-- **Drop per-site Docker images.** A single image works for every prefix. CI no longer needs a "build once per site" matrix.
-- **No more "prefix mismatch" warnings at startup.** The
-  `check_webui_build_prefix` function and its banner have been removed — there is nothing to mismatch.
-- **The `lightrag_webui/index.html` template now contains the placeholder comment `<!-- __LIGHTRAG_RUNTIME_CONFIG__ -->`.** If you fork the template, keep that line in `<head>` or the runtime config will not be injected (the SPA falls back to no-prefix defaults).
-
----
-
 ## Troubleshooting
 
 ### Asset URLs 404 when accessing the WebUI

--- a/docs/MultiSiteDeployment.md
+++ b/docs/MultiSiteDeployment.md
@@ -9,7 +9,7 @@ This document explains how to run multiple isolated LightRAG instances behind on
 
 ## TL;DR
 
-- Set `LIGHTRAG_API_PREFIX` and `LIGHTRAG_WEBUI_PATH` per-instance, on the **backend only**.
+- Set `LIGHTRAG_API_PREFIX` per-instance, on the **backend only**. The WebUI is always mounted at `/webui` (not configurable).
 - Build the WebUI **once**. The same artifacts work under any reverse-proxy prefix.
 - Point your reverse proxy at each backend, stripping the site prefix before forwarding.
 
@@ -26,7 +26,7 @@ docker run -e LIGHTRAG_API_PREFIX=/site02 -p 9622:9621 lightrag:latest
 Earlier versions of LightRAG baked the site prefix into the JavaScript bundle at build time (via `VITE_API_PREFIX` / `VITE_WEBUI_PREFIX`). Every site that used a different prefix needed its own WebUI build, and reusing a single Docker image across sites required a rebuild step at deploy time. Since the runtime-config-injection refactor:
 
 - **Asset URLs** in `index.html` are emitted as relative paths (`./assets/index-abc.js`). The browser resolves them against the current document URL, so they work under any mount point.
-- **API base URL** and **in-app links** read their prefix from `window.__LIGHTRAG_CONFIG__`, which the FastAPI server injects into `index.html` on each response based on its own `LIGHTRAG_API_PREFIX` / `LIGHTRAG_WEBUI_PATH`.
+- **API base URL** and **in-app links** read their prefix from `window.__LIGHTRAG_CONFIG__`, which the FastAPI server injects into `index.html` on each response based on its own `LIGHTRAG_API_PREFIX`.
 
 The result: a single `lightrag/api/webui/` directory (or Docker image) is reusable across any number of sites with no per-site build artifact.
 
@@ -40,7 +40,7 @@ Each request for `index.html` goes through `SmartStaticFiles` in `lightrag/api/l
 2. Looks for the placeholder comment `<!-- __LIGHTRAG_RUNTIME_CONFIG__ -->`.
 3. Replaces it with
    `<script>window.__LIGHTRAG_CONFIG__ = {"apiPrefix":"…","webuiPrefix":"…"}</script>`,
-   computed from the configured `LIGHTRAG_API_PREFIX` / `LIGHTRAG_WEBUI_PATH`.
+   computed from the configured `LIGHTRAG_API_PREFIX` (the in-app `/webui` mount is hardcoded server-side).
 
 Sequence — browser request to a site-prefixed instance:
 
@@ -69,14 +69,13 @@ and in-app links.
 
 ---
 
-## Two backend variables, that's it
+## One backend variable, that's it
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
 | `LIGHTRAG_API_PREFIX` | `""` | Reverse-proxy prefix that the upstream proxy strips before forwarding to FastAPI. Passed to FastAPI as `root_path`. |
-| `LIGHTRAG_WEBUI_PATH` | `/webui` | In-app mount path for the WebUI **after** the proxy has stripped the API prefix. Leave as `/webui` unless you have a specific reason to relocate it. |
 
-`window.__LIGHTRAG_CONFIG__.webuiPrefix` is computed as `LIGHTRAG_API_PREFIX + LIGHTRAG_WEBUI_PATH + "/"`. You do **not** set this yourself.
+The WebUI is always mounted at `/webui` server-side. `window.__LIGHTRAG_CONFIG__.webuiPrefix` is computed as `LIGHTRAG_API_PREFIX + "/webui/"` and injected for the SPA — you do **not** set it yourself.
 
 There are no longer any frontend `VITE_API_PREFIX` / `VITE_WEBUI_PREFIX` variables. Setting them has no effect (they are ignored by the build).
 
@@ -91,7 +90,6 @@ There are no longer any frontend `VITE_API_PREFIX` / `VITE_WEBUI_PREFIX` variabl
 HOST=0.0.0.0
 PORT=9621
 LIGHTRAG_API_PREFIX=/site01
-LIGHTRAG_WEBUI_PATH=/webui
 WORKING_DIR=/data/site01/storage
 INPUT_DIR=/data/site01/inputs
 LIGHTRAG_API_KEY=site01-secret
@@ -103,7 +101,6 @@ LIGHTRAG_API_KEY=site01-secret
 HOST=0.0.0.0
 PORT=9621
 LIGHTRAG_API_PREFIX=/site02
-LIGHTRAG_WEBUI_PATH=/webui
 WORKING_DIR=/data/site02/storage
 INPUT_DIR=/data/site02/inputs
 LIGHTRAG_API_KEY=site02-secret
@@ -202,13 +199,6 @@ docker run --rm -p 9621:9621 lightrag:latest
 # Same image, different prefixes — runtime decides.
 docker run --rm -e LIGHTRAG_API_PREFIX=/site01 -p 9621:9621 lightrag:latest
 docker run --rm -e LIGHTRAG_API_PREFIX=/site02 -p 9622:9621 lightrag:latest
-
-# Custom in-app mount.
-docker run --rm \
-  -e LIGHTRAG_API_PREFIX=/team-a \
-  -e LIGHTRAG_WEBUI_PATH=/admin-ui \
-  -p 9623:9621 \
-  lightrag:latest
 ```
 
 ### Kubernetes Ingress equivalent
@@ -258,9 +248,7 @@ The dev server mirrors production injection: it serves `index.html` via the same
 | `VITE_BACKEND_URL` | Where the dev server forwards proxied API calls. | `lightrag_webui/.env*` |
 | `VITE_DEV_API_PREFIX` | Prefix to **simulate** (matches the backend LIGHTRAG_API_PREFIX`). Empty → no prefix. | `lightrag_webui/.env*` |
 
-`VITE_DEV_API_PREFIX` injects `apiPrefix` into `window.__LIGHTRAG_CONFIG__` in the browser, mirroring the backend behavior. It also serves as a prefix for `VITE_API_ENDPOINTS`, ensuring correct access to backend APIs.
-
-`VITE_DEV_WEBUI_PREFIX` is also accepted, and the only purpose is injecting `webuiPrefix` to `window.__LIGHTRAG_CONFIG__` for the browser. It only affects the home/logo `<a href>` link inside the SPA — set it to `${VITE_DEV_API_PREFIX}/webui/` if you care about that link in dev, otherwise leave it empty.
+`VITE_DEV_API_PREFIX` injects `apiPrefix` into `window.__LIGHTRAG_CONFIG__` in the browser, mirroring the backend behavior. It also serves as a prefix for `VITE_API_ENDPOINTS`, ensuring correct access to backend APIs. The matching `webuiPrefix` is derived as `${VITE_DEV_API_PREFIX}/webui/` automatically — you don't need a separate variable for it.
 
 Three scenarios cover everything you'll hit:
 
@@ -303,7 +291,6 @@ VITE_BACKEND_URL=http://localhost:9621
 VITE_API_PROXY=true
 VITE_API_ENDPOINTS=/api,/documents,/graphs,/graph,/health,/query,/docs,/redoc,/openapi.json,/login,/auth-status,/static
 VITE_DEV_API_PREFIX=/site01
-VITE_DEV_WEBUI_PREFIX=/site01/webui/
 ```
 
 ```bash
@@ -354,7 +341,6 @@ The key insight: the production nginx is **already** doing the prefix strip. Vit
    VITE_API_PROXY=true
    VITE_API_ENDPOINTS=/api,/documents,/graphs,/graph,/health,/query,/docs,/redoc,/openapi.json,/login,/auth-status,/static
    VITE_DEV_API_PREFIX=/site01
-   VITE_DEV_WEBUI_PREFIX=/site01/webui/
    ```
 3. Run `bun run dev` and open **`http://localhost:5173/`**.
 

--- a/docs/MultiSiteDeployment.md
+++ b/docs/MultiSiteDeployment.md
@@ -354,46 +354,79 @@ processes on localhost.**
 
 ### Scenario 3 — debug through your real production reverse proxy
 
-You already have nginx (or Traefik / Caddy) running locally with the
-exact rules from the deployment guide, and you want HMR to flow through
-it so you're testing the actual deploy path.
+You already have nginx (or Traefik / Caddy) running locally and want HMR
+to flow through it, e.g. to validate that the production reverse-proxy
+rules don't break the WebUI.
+
+The trick: **API traffic must go nginx → backend directly. Do NOT route
+it through Vite.** Vite's `server.proxy` rules are registered with the
+simulated prefix (`/site01/documents/...`), but nginx strips that prefix
+before forwarding, so by the time a request reaches Vite the prefix is
+gone and no Vite proxy rule matches. Splitting nginx into two location
+blocks avoids this trap and also mirrors the real production layout
+(WebUI assets vs API live on different routes anyway).
 
 ```
-Browser ──► localhost:80 (nginx) ──► localhost:5173 (Vite) ──► localhost:9621 (backend)
-                  │
-                  └── strips /site01/ before forwarding to Vite
+                    ┌─► /site01/webui/* ──► localhost:5173 (Vite, HMR)
+Browser ─► nginx ───┤
+                    └─► /site01/*       ──► localhost:9621 (backend)
 ```
 
-This requires three things:
+**Setup:**
 
-1. **Backend with the prefix:** `LIGHTRAG_API_PREFIX=/site01 lightrag-server`.
-2. **Dev server config (`.env.local`):**
+1. **Backend:** `LIGHTRAG_API_PREFIX=/site01 lightrag-server`.
+
+2. **Dev server (`.env.local`):**
    ```bash
-   VITE_BACKEND_URL=http://localhost:9621      # Vite still forwards directly to backend
+   # Vite's server.proxy is unused in this scenario — nginx forwards API
+   # calls to the backend directly. Keep VITE_BACKEND_URL pointed at the
+   # backend anyway so Scenario 2 still works if you bypass nginx.
+   VITE_BACKEND_URL=http://localhost:9621
    VITE_API_PROXY=true
    VITE_API_ENDPOINTS=/api,/documents,/graphs,/graph,/health,/query,/docs,/redoc,/openapi.json,/login,/auth-status,/static
    VITE_DEV_API_PREFIX=/site01
    VITE_DEV_WEBUI_PREFIX=/site01/webui/
    ```
-3. **nginx route the WebUI to Vite, not to the backend:**
+
+3. **nginx — two location blocks, longest match wins:**
    ```nginx
-   location /site01/ {
-       # Forward EVERYTHING to Vite — Vite's proxy handles API forwarding
-       proxy_pass http://127.0.0.1:5173/;
+   # WebUI assets + HMR → Vite
+   location /site01/webui/ {
+       proxy_pass http://127.0.0.1:5173/webui/;   # keep /webui/ so Vite's
+                                                  # asset paths still resolve
        proxy_http_version 1.1;
-       proxy_set_header Upgrade $http_upgrade;        # required for HMR
+       proxy_set_header Upgrade $http_upgrade;    # HMR websocket
        proxy_set_header Connection "upgrade";
        proxy_set_header Host $host;
+   }
+
+   # Everything else under /site01/ → backend (API, /docs, /openapi.json…)
+   location /site01/ {
+       proxy_pass http://127.0.0.1:9621/;         # strips /site01/
        proxy_set_header X-Forwarded-Prefix /site01;
+       proxy_set_header Host $host;
    }
    ```
 
-Open **`http://localhost/site01/`**. The HMR websocket upgrades through
-nginx → Vite, API calls flow Vite → backend.
+Open **`http://localhost/site01/webui/`**. HMR upgrades through nginx →
+Vite; API calls flow browser → nginx → backend (Vite is not in the API
+path).
 
-> Most contributors should prefer Scenario 2. Scenario 3 is only useful
-> when you suspect a bug specific to the reverse-proxy path (e.g. a
-> header-rewriting rule, a redirect mismatch).
+> Most contributors should stay on Scenario 2. Scenario 3 is only worth
+> the setup when you suspect a bug specific to the reverse-proxy itself
+> (a header-rewriting rule, a strip-vs-no-strip mismatch, or a redirect
+> that only fires through nginx).
+
+#### Why `VITE_BACKEND_URL` does **not** need a `/site01` prefix
+
+Vite's proxy is bypassed entirely in this scenario, so `VITE_BACKEND_URL`
+is irrelevant — nginx forwards directly to the backend. If you ever fall
+back to Scenario 2 (no nginx) you'll want `VITE_BACKEND_URL` to stay at
+the backend root: Vite forwards prefixed paths verbatim
+(`/site01/documents/foo` → `http://localhost:9621/site01/documents/foo`),
+and FastAPI's `root_path` matches the prefixed form natively. Adding a
+`/site01` to `VITE_BACKEND_URL` would produce `/site01/site01/documents/foo`
+and 404.
 
 ### Quick decision matrix
 

--- a/docs/MultiSiteDeployment.md
+++ b/docs/MultiSiteDeployment.md
@@ -352,89 +352,107 @@ What happens:
 HMR continues to work unchanged. **No nginx, no Docker — just two
 processes on localhost.**
 
-### Scenario 3 — debug through your real production reverse proxy
+### Scenario 3 — local dev frontend against a real (remote) backend
 
-You already have nginx (or Traefik / Caddy) running locally and want HMR
-to flow through it, e.g. to validate that the production reverse-proxy
-rules don't break the WebUI.
-
-The trick: **API traffic must go nginx → backend directly. Do NOT route
-it through Vite.** Vite's `server.proxy` rules are registered with the
-simulated prefix (`/site01/documents/...`), but nginx strips that prefix
-before forwarding, so by the time a request reaches Vite the prefix is
-gone and no Vite proxy rule matches. Splitting nginx into two location
-blocks avoids this trap and also mirrors the real production layout
-(WebUI assets vs API live on different routes anyway).
+You want to iterate on the WebUI on your laptop while hitting a backend
+that's already in production behind nginx — typically because the real
+backend has data / configs that are painful to reproduce locally. The
+WebUI is purely local (HMR on your laptop); only API traffic crosses the
+network.
 
 ```
-                    ┌─► /site01/webui/* ──► localhost:5173 (Vite, HMR)
-Browser ─► nginx ───┤
-                    └─► /site01/*       ──► localhost:9621 (backend)
+Local machine                                Remote production host
+─────────────────                            ────────────────────────
+Browser ──► localhost:5173 (Vite + HMR)
+                │
+                │  Vite proxy forwards /site01/* verbatim
+                ▼
+              ─── network ───►  nginx ──strips /site01/──► lightrag-server
+                                                          (backend; may
+                                                           or may not have
+                                                           LIGHTRAG_API_PREFIX
+                                                           set — both work)
 ```
+
+The key insight: the production nginx is **already** doing the prefix
+strip. Vite's only job is to forward prefixed paths to nginx unchanged,
+and nginx behaves exactly as it would for a real production browser
+request.
 
 **Setup:**
 
-1. **Backend:** `LIGHTRAG_API_PREFIX=/site01 lightrag-server`.
+1. **Production nginx + backend:** unchanged. Whatever your real deploy
+   already runs.
 
 2. **Dev server (`.env.local`):**
    ```bash
-   # Vite's server.proxy is unused in this scenario — nginx forwards API
-   # calls to the backend directly. Keep VITE_BACKEND_URL pointed at the
-   # backend anyway so Scenario 2 still works if you bypass nginx.
-   VITE_BACKEND_URL=http://localhost:9621
+   # Point at the production reverse proxy — NOT the backend port.
+   VITE_BACKEND_URL=https://prod.example.com         # or http://10.0.0.5
    VITE_API_PROXY=true
    VITE_API_ENDPOINTS=/api,/documents,/graphs,/graph,/health,/query,/docs,/redoc,/openapi.json,/login,/auth-status,/static
    VITE_DEV_API_PREFIX=/site01
    VITE_DEV_WEBUI_PREFIX=/site01/webui/
    ```
 
-3. **nginx — two location blocks, longest match wins:**
-   ```nginx
-   # WebUI assets + HMR → Vite
-   location /site01/webui/ {
-       proxy_pass http://127.0.0.1:5173/webui/;   # keep /webui/ so Vite's
-                                                  # asset paths still resolve
-       proxy_http_version 1.1;
-       proxy_set_header Upgrade $http_upgrade;    # HMR websocket
-       proxy_set_header Connection "upgrade";
-       proxy_set_header Host $host;
-   }
+3. Run `bun run dev` and open **`http://localhost:5173/`**.
 
-   # Everything else under /site01/ → backend (API, /docs, /openapi.json…)
-   location /site01/ {
-       proxy_pass http://127.0.0.1:9621/;         # strips /site01/
-       proxy_set_header X-Forwarded-Prefix /site01;
-       proxy_set_header Host $host;
-   }
-   ```
+What happens for an API call:
 
-Open **`http://localhost/site01/webui/`**. HMR upgrades through nginx →
-Vite; API calls flow browser → nginx → backend (Vite is not in the API
-path).
+- SPA fetches `/site01/documents/foo` (because `apiPrefix=/site01` was
+  injected into `window.__LIGHTRAG_CONFIG__`).
+- Vite's `server.proxy` matches `/site01/documents` and forwards verbatim
+  to `https://prod.example.com/site01/documents/foo`.
+  (`changeOrigin: true` is already set, so the `Host` header is rewritten
+  to the upstream — required for SNI / virtual hosts.)
+- Production nginx matches `/site01/`, strips it, forwards
+  `/documents/foo` to the backend.
+- Backend serves it. `LIGHTRAG_API_PREFIX` on the backend can be set or
+  unset; FastAPI's `root_path` accepts both prefixed and natural forms
+  either way.
 
-> Most contributors should stay on Scenario 2. Scenario 3 is only worth
-> the setup when you suspect a bug specific to the reverse-proxy itself
-> (a header-rewriting rule, a strip-vs-no-strip mismatch, or a redirect
-> that only fires through nginx).
+HMR is purely local — the browser only talks to localhost:5173 for SPA
+assets. No nginx involvement, no special WebSocket-upgrade config to
+worry about.
 
-#### Why `VITE_BACKEND_URL` does **not** need a `/site01` prefix
+#### Why `VITE_BACKEND_URL` does **not** include `/site01`
 
-Vite's proxy is bypassed entirely in this scenario, so `VITE_BACKEND_URL`
-is irrelevant — nginx forwards directly to the backend. If you ever fall
-back to Scenario 2 (no nginx) you'll want `VITE_BACKEND_URL` to stay at
-the backend root: Vite forwards prefixed paths verbatim
-(`/site01/documents/foo` → `http://localhost:9621/site01/documents/foo`),
-and FastAPI's `root_path` matches the prefixed form natively. Adding a
-`/site01` to `VITE_BACKEND_URL` would produce `/site01/site01/documents/foo`
-and 404.
+Vite forwards the request path **verbatim** (no rewrite). The browser
+already emits `/site01/documents/foo`, so the URL Vite sends upstream is
+`${VITE_BACKEND_URL}/site01/documents/foo`. If you set
+`VITE_BACKEND_URL=https://prod.example.com/site01` you'd get
+`https://prod.example.com/site01/site01/documents/foo` — a duplicated
+prefix that nginx and the backend both reject.
+
+Same logic applies to Scenario 2 (`VITE_BACKEND_URL=http://localhost:9621`,
+no prefix): Vite forwards `/site01/documents/foo` unchanged to the
+backend, and FastAPI's `root_path=/site01` matches the prefixed form
+natively.
+
+#### Common pitfalls
+
+- **HTTPS upstream + self-signed cert**: Vite's proxy will reject by
+  default. Set `proxy: { ..., secure: false }` in `vite.config.ts` to
+  skip cert validation when targeting a staging proxy with a non-public
+  cert.
+- **Auth required**: if the production backend requires `LIGHTRAG_API_KEY`,
+  log in via the dev SPA exactly as you would in prod — the auth token
+  flows through the proxy unchanged.
+- **CORS errors**: shouldn't happen because the browser sees same-origin
+  requests to localhost:5173. If they appear, check that
+  `changeOrigin: true` is in effect (it is, by default in
+  `vite.config.ts`).
 
 ### Quick decision matrix
 
-| You want to… | Backend `LIGHTRAG_API_PREFIX` | `VITE_DEV_API_PREFIX` | Reverse proxy? | Open in browser |
+| You want to… | `VITE_BACKEND_URL` | `VITE_DEV_API_PREFIX` | What's in front of the backend | Open in browser |
 | --- | --- | --- | --- | --- |
-| Default single-instance dev | unset | unset | no | `http://localhost:5173/` |
-| Reproduce a multi-site bug locally | `/site01` | `/site01` | no (Vite proxy is enough) | `http://localhost:5173/` |
-| Validate the actual nginx rules | `/site01` | `/site01` | yes (nginx → Vite) | `http://localhost/site01/` |
+| Default single-instance dev | `http://localhost:9621` | unset | local backend, no proxy | `http://localhost:5173/` |
+| Reproduce a multi-site bug locally | `http://localhost:9621` | `/site01` | local backend with `LIGHTRAG_API_PREFIX=/site01`, no nginx | `http://localhost:5173/` |
+| Hit a real (remote) backend through its production nginx | `https://prod.example.com` | `/site01` | production nginx already strips `/site01/` | `http://localhost:5173/` |
+
+In every case the browser only talks to local Vite at `localhost:5173`;
+the column on the right is the same. Where the API traffic ultimately
+lands is what differs.
 
 ---
 

--- a/docs/MultiSiteDeployment.md
+++ b/docs/MultiSiteDeployment.md
@@ -410,4 +410,3 @@ Confirm the backend is also running with the matching `LIGHTRAG_API_PREFIX`. The
 ### I want to disable the WebUI entirely
 
 Don't build the frontend — `lightrag/api/webui/index.html` will not exist and the server will skip the WebUI mount, redirecting `/` and the WebUI path to `/docs` instead. The runtime-config injection is purely opt-in via the existence of the build artifact.
-

--- a/docs/MultiSiteDeployment.md
+++ b/docs/MultiSiteDeployment.md
@@ -245,14 +245,22 @@ Backends still set `LIGHTRAG_API_PREFIX=/site01` / `=/site02`.
 
 ## Local development with `bun run dev`
 
+> **Always open `http://localhost:5173/` — root path, no `/webui`, no `/site01` — regardless of which scenario below you're in.**
+>
+> Vite's dev server serves the SPA at its own root (`/`) no matter what prefix you configure. `VITE_DEV_API_PREFIX` only affects how the SPA composes API URLs *after* the page is loaded, and which paths the dev proxy intercepts; it does **not** change the URL you type in the address bar. Trying to access `localhost:5173/site01/webui/` works (Vite's SPA fallback returns the same `index.html`), but it's not the canonical entry point and only differs cosmetically in the address bar.
+>
+> This is the deliberate consequence of `base: './'` in [`vite.config.ts`](../lightrag_webui/vite.config.ts) — the same setting that makes one production build reusable across any number of reverse-proxy mount points. Tying the dev URL to a prefix would force the build to bake the prefix back in.
+
 The dev server mirrors production injection: it serves `index.html` via the same `transformIndexHtml` mechanism the FastAPI server uses at request time, so the SPA reads `window.__LIGHTRAG_CONFIG__` in dev exactly the way it does in prod. Only **two** environment variables matter:
 
 | Variable | Purpose | Where it lives |
 | --- | --- | --- |
 | `VITE_BACKEND_URL` | Where the dev server forwards proxied API calls. | `lightrag_webui/.env*` |
-| `VITE_DEV_API_PREFIX` | Prefix to **simulate** (matches the production `LIGHTRAG_API_PREFIX`). Empty → no prefix. | `lightrag_webui/.env*` |
+| `VITE_DEV_API_PREFIX` | Prefix to **simulate** (matches the backend LIGHTRAG_API_PREFIX`). Empty → no prefix. | `lightrag_webui/.env*` |
 
-`VITE_DEV_WEBUI_PREFIX` is also accepted but only affects the home/logo `<a href>` link inside the SPA — set it to `${VITE_DEV_API_PREFIX}/webui/` if you care about that link in dev, otherwise leave it empty.
+`VITE_DEV_API_PREFIX` injects `apiPrefix` into `window.__LIGHTRAG_CONFIG__` in the browser, mirroring the backend behavior. It also serves as a prefix for `VITE_API_ENDPOINTS`, ensuring correct access to backend APIs.
+
+`VITE_DEV_WEBUI_PREFIX` is also accepted, and the only purpose is injecting `webuiPrefix` to `window.__LIGHTRAG_CONFIG__` for the browser. It only affects the home/logo `<a href>` link inside the SPA — set it to `${VITE_DEV_API_PREFIX}/webui/` if you care about that link in dev, otherwise leave it empty.
 
 Three scenarios cover everything you'll hit:
 
@@ -382,7 +390,7 @@ Same logic applies to Scenario 2 (`VITE_BACKEND_URL=http://localhost:9621`, no p
 | Reproduce a multi-site bug locally | `http://localhost:9621` | `/site01` | local backend with `LIGHTRAG_API_PREFIX=/site01`, no nginx | `http://localhost:5173/` |
 | Hit a real (remote) backend through its production nginx | `https://prod.example.com` | `/site01` | production nginx already strips `/site01/` | `http://localhost:5173/` |
 
-In every case the browser only talks to local Vite at `localhost:5173`; the column on the right is the same. Where the API traffic ultimately lands is what differs.
+**The "Open in browser" column is always `http://localhost:5173/` — that is the entry point in every dev scenario.** What changes between rows is where the API traffic ultimately lands; the SPA itself is always served from the dev server's root.
 
 ---
 

--- a/docs/MultiSiteDeployment.md
+++ b/docs/MultiSiteDeployment.md
@@ -1,0 +1,358 @@
+# Single-Server Multi-Site Deployment
+
+This document explains how to run multiple isolated LightRAG instances
+behind one host using a reverse proxy (nginx, Traefik, Kubernetes Ingress,
+…), with **one shared WebUI build** reused by every instance.
+
+> Looking for the basic single-instance Docker setup? See
+> [DockerDeployment.md](./DockerDeployment.md). For frontend build
+> mechanics in general, see [FrontendBuildGuide.md](./FrontendBuildGuide.md).
+
+---
+
+## TL;DR
+
+- Set `LIGHTRAG_API_PREFIX` and `LIGHTRAG_WEBUI_PATH` per-instance, on the
+  **backend only**.
+- Build the WebUI **once**. The same artifacts work under any reverse-proxy
+  prefix.
+- Point your reverse proxy at each backend, stripping the site prefix
+  before forwarding.
+
+```bash
+# One image, two containers, two prefixes — no rebuild.
+docker run -e LIGHTRAG_API_PREFIX=/site01 -p 9621:9621 lightrag:latest
+docker run -e LIGHTRAG_API_PREFIX=/site02 -p 9622:9621 lightrag:latest
+```
+
+---
+
+## Why "build once, deploy many"
+
+Earlier versions of LightRAG baked the site prefix into the JavaScript
+bundle at build time (via `VITE_API_PREFIX` / `VITE_WEBUI_PREFIX`). Every
+site that used a different prefix needed its own WebUI build, and reusing
+a single Docker image across sites required a rebuild step at deploy time.
+
+Since the runtime-config-injection refactor:
+
+- **Asset URLs** in `index.html` are emitted as relative paths
+  (`./assets/index-abc.js`). The browser resolves them against the current
+  document URL, so they work under any mount point.
+- **API base URL** and **in-app links** read their prefix from
+  `window.__LIGHTRAG_CONFIG__`, which the FastAPI server injects into
+  `index.html` on each response based on its own
+  `LIGHTRAG_API_PREFIX` / `LIGHTRAG_WEBUI_PATH`.
+
+The result: a single `lightrag/api/webui/` directory (or Docker image) is
+reusable across any number of sites with no per-site build artifact.
+
+---
+
+## How runtime prefix injection works
+
+Each request for `index.html` goes through `SmartStaticFiles` in
+`lightrag/api/lightrag_server.py`, which:
+
+1. Reads the static `index.html` produced by `bun run build`.
+2. Looks for the placeholder comment
+   `<!-- __LIGHTRAG_RUNTIME_CONFIG__ -->`.
+3. Replaces it with
+   `<script>window.__LIGHTRAG_CONFIG__ = {"apiPrefix":"…","webuiPrefix":"…"}</script>`,
+   computed from the configured `LIGHTRAG_API_PREFIX` / `LIGHTRAG_WEBUI_PATH`.
+
+Sequence — browser request to a site-prefixed instance:
+
+```
+Browser            nginx                  uvicorn            SmartStaticFiles
+  │                  │                       │                       │
+  │ GET /site01/webui/                       │                       │
+  │─────────────────►│                       │                       │
+  │                  │ GET /webui/  (strips /site01)                 │
+  │                  │──────────────────────►│                       │
+  │                  │                       │ get_response("")      │
+  │                  │                       │──────────────────────►│
+  │                  │                       │                       │ inject
+  │                  │                       │                       │ window.__LIGHTRAG_CONFIG__
+  │                  │                       │                       │  = { apiPrefix: "/site01",
+  │                  │                       │                       │      webuiPrefix: "/site01/webui/" }
+  │                  │                       │◄──────────────────────│
+  │                  │◄──────────────────────│                       │
+  │◄─────────────────│                       │                       │
+  │ index.html with injected runtime config                          │
+```
+
+The SPA reads the injected config via `src/lib/runtimeConfig.ts` and uses
+it for `axios.baseURL`, `fetch()` template strings, the API-docs iframe,
+and in-app links.
+
+---
+
+## Two backend variables, that's it
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `LIGHTRAG_API_PREFIX` | `""` | Reverse-proxy prefix that the upstream proxy strips before forwarding to FastAPI. Passed to FastAPI as `root_path`. |
+| `LIGHTRAG_WEBUI_PATH` | `/webui` | In-app mount path for the WebUI **after** the proxy has stripped the API prefix. Leave as `/webui` unless you have a specific reason to relocate it. |
+
+`window.__LIGHTRAG_CONFIG__.webuiPrefix` is computed as
+`LIGHTRAG_API_PREFIX + LIGHTRAG_WEBUI_PATH + "/"`. You do **not** set this
+yourself.
+
+There are no longer any frontend `VITE_API_PREFIX` / `VITE_WEBUI_PREFIX`
+variables. Setting them has no effect (they are ignored by the build).
+
+---
+
+## End-to-end example: two sites behind one nginx
+
+### Instance configuration
+
+`site01.env`:
+```bash
+HOST=0.0.0.0
+PORT=9621
+LIGHTRAG_API_PREFIX=/site01
+LIGHTRAG_WEBUI_PATH=/webui
+WORKING_DIR=/data/site01/storage
+INPUT_DIR=/data/site01/inputs
+LIGHTRAG_API_KEY=site01-secret
+# … LLM / embedding config …
+```
+
+`site02.env`:
+```bash
+HOST=0.0.0.0
+PORT=9621
+LIGHTRAG_API_PREFIX=/site02
+LIGHTRAG_WEBUI_PATH=/webui
+WORKING_DIR=/data/site02/storage
+INPUT_DIR=/data/site02/inputs
+LIGHTRAG_API_KEY=site02-secret
+# … LLM / embedding config …
+```
+
+### docker-compose.yml (one image, two services)
+
+```yaml
+services:
+  site01:
+    image: ghcr.io/hkuds/lightrag:latest
+    env_file: site01.env
+    volumes:
+      - ./data/site01:/data/site01
+    ports:
+      - "127.0.0.1:9621:9621"
+
+  site02:
+    image: ghcr.io/hkuds/lightrag:latest
+    env_file: site02.env
+    volumes:
+      - ./data/site02:/data/site02
+    ports:
+      - "127.0.0.1:9622:9621"
+```
+
+### nginx config
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name host.example.com;
+
+    # site01: strips /site01/ before forwarding
+    location /site01/ {
+        proxy_pass http://127.0.0.1:9621/;
+        proxy_set_header X-Forwarded-Prefix /site01;
+        proxy_set_header Host $host;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+    }
+
+    # site02: strips /site02/ before forwarding
+    location /site02/ {
+        proxy_pass http://127.0.0.1:9622/;
+        proxy_set_header X-Forwarded-Prefix /site02;
+        proxy_set_header Host $host;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+    }
+}
+```
+
+Browsing `https://host.example.com/site01/webui/` shows site01's WebUI;
+`https://host.example.com/site02/webui/` shows site02's. The same Docker
+image serves both — no per-site build artifact, no rebuild on prefix
+changes.
+
+### What each layer sees
+
+| Layer | site01 GET /webui/ |
+| --- | --- |
+| Browser address bar | `https://host.example.com/site01/webui/` |
+| nginx receives | `/site01/webui/` |
+| nginx forwards | `/webui/` |
+| FastAPI `root_path` | `/site01` |
+| `app.mount` resolves | `/webui/` |
+| Injected `apiPrefix` | `/site01` |
+| Injected `webuiPrefix` | `/site01/webui/` |
+| Asset URLs in HTML | `./assets/index-abc.js` (resolves to `https://host.example.com/site01/webui/assets/index-abc.js`) |
+
+---
+
+## Single-image Docker recipe
+
+The `Dockerfile` builds the WebUI once, with no prefix:
+
+```dockerfile
+FROM oven/bun:1 AS webui-build
+WORKDIR /src/lightrag_webui
+COPY lightrag_webui/package.json lightrag_webui/bun.lock ./
+RUN bun install --frozen-lockfile
+COPY lightrag_webui/ ./
+COPY lightrag/api/webui/.gitkeep /src/lightrag/api/webui/.gitkeep
+RUN bun run build
+
+FROM python:3.11-slim
+COPY --from=webui-build /src/lightrag/api/webui /app/lightrag/api/webui
+# … rest of the image …
+```
+
+Run any number of containers from the same image, each with its own
+prefix:
+
+```bash
+# Plain single-instance, no prefix.
+docker run --rm -p 9621:9621 lightrag:latest
+
+# Same image, different prefixes — runtime decides.
+docker run --rm -e LIGHTRAG_API_PREFIX=/site01 -p 9621:9621 lightrag:latest
+docker run --rm -e LIGHTRAG_API_PREFIX=/site02 -p 9622:9621 lightrag:latest
+
+# Custom in-app mount.
+docker run --rm \
+  -e LIGHTRAG_API_PREFIX=/team-a \
+  -e LIGHTRAG_WEBUI_PATH=/admin-ui \
+  -p 9623:9621 \
+  lightrag:latest
+```
+
+### Kubernetes Ingress equivalent
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: lightrag-multisite
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+spec:
+  rules:
+  - host: host.example.com
+    http:
+      paths:
+      - path: /site01(/|$)(.*)
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: lightrag-site01
+            port: { number: 9621 }
+      - path: /site02(/|$)(.*)
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: lightrag-site02
+            port: { number: 9621 }
+```
+
+Backends still set `LIGHTRAG_API_PREFIX=/site01` / `=/site02`.
+
+---
+
+## Local development with prefix simulation
+
+`bun run dev` mirrors production injection so the SPA reads the same
+`window.__LIGHTRAG_CONFIG__` mechanism in dev. There are two modes:
+
+### A — default (no prefix)
+
+Just run `bun run dev`. The injected config is empty (`apiPrefix=""`,
+`webuiPrefix="/webui/"`), and `server.proxy` forwards relative paths like
+`/documents/...` to `http://localhost:9621` exactly as before.
+
+### B — simulate a site prefix
+
+Useful when iterating on UI while a real prefixed backend is running.
+
+`lightrag_webui/.env.local` (gitignored):
+```bash
+VITE_BACKEND_URL=http://localhost:9621
+VITE_API_PROXY=true
+VITE_API_ENDPOINTS=/api,/documents,/graphs,/graph,/health,/query,/docs,/redoc,/openapi.json,/login,/auth-status,/static
+VITE_DEV_API_PREFIX=/site01
+VITE_DEV_WEBUI_PREFIX=/site01/webui/
+```
+
+Backend started with `LIGHTRAG_API_PREFIX=/site01`. Now `bun run dev`:
+
+- Injects `window.__LIGHTRAG_CONFIG__ = { apiPrefix: "/site01", … }` into
+  the dev `index.html`.
+- Prefixes every entry of `VITE_API_ENDPOINTS` with `/site01` when
+  registering proxy targets, so requests to `/site01/documents/...` are
+  forwarded to `http://localhost:9621/site01/documents/...`.
+
+HMR continues to work unchanged.
+
+---
+
+## Migration notes
+
+If you were on the previous build-time-prefix model:
+
+- **Stop setting `VITE_API_PREFIX` and `VITE_WEBUI_PREFIX`.** They are
+  ignored by the new build. Remove them from your CI / build scripts.
+- **Drop per-site Docker images.** A single image works for every prefix.
+  CI no longer needs a "build once per site" matrix.
+- **No more "prefix mismatch" warnings at startup.** The
+  `check_webui_build_prefix` function and its banner have been removed —
+  there is nothing to mismatch.
+- **The `lightrag_webui/index.html` template now contains the placeholder
+  comment `<!-- __LIGHTRAG_RUNTIME_CONFIG__ -->`.** If you fork the
+  template, keep that line in `<head>` or the runtime config will not be
+  injected (the SPA falls back to no-prefix defaults).
+
+---
+
+## Troubleshooting
+
+### Asset URLs 404 when accessing the WebUI
+
+The base URL must end with `/`. Accessing `/site01/webui` (no trailing
+slash) makes the browser resolve `./assets/foo.js` against `/site01/`,
+which 404s. The server already redirects the no-slash form to the
+slash form; verify the redirect is reaching nginx (check
+`X-Forwarded-Prefix` and that nginx uses `proxy_pass http://…/` with the
+trailing slash).
+
+### `apiPrefix` is empty in `window.__LIGHTRAG_CONFIG__` after deploy
+
+View the page source. If you see the literal placeholder
+`<!-- __LIGHTRAG_RUNTIME_CONFIG__ -->` instead of an injected
+`<script>` tag, the request did not go through `SmartStaticFiles` —
+double-check that `lightrag/api/webui/index.html` exists in the running
+container and that the WebUI mount succeeded (the server logs
+`WebUI assets mounted at <path>` at startup).
+
+### `bun run dev` proxy returns 404 with `VITE_DEV_API_PREFIX` set
+
+Confirm the backend is also running with the matching
+`LIGHTRAG_API_PREFIX`. The dev proxy forwards prefixed paths verbatim;
+if the backend has no prefix configured, it does not register routes
+under that path.
+
+### I want to disable the WebUI entirely
+
+Don't build the frontend — `lightrag/api/webui/index.html` will not exist
+and the server will skip the WebUI mount, redirecting `/` and the
+WebUI path to `/docs` instead. The runtime-config injection is purely
+opt-in via the existence of the build artifact.

--- a/docs/MultiSiteDeployment.md
+++ b/docs/MultiSiteDeployment.md
@@ -274,107 +274,80 @@ lightrag-server                  # in one terminal, no LIGHTRAG_API_PREFIX
 cd lightrag_webui && bun run dev # in another; open http://localhost:5173/
 ```
 
-### Scenario 2 — simulate the production prefix WITHOUT running nginx (recommended)
+### Scenario 2 — simulate a site prefix
 
-You want to develop against a prefix-configured backend, but don't want to install / configure nginx locally just to debug. **The Vite dev server's built-in proxy plays the role of the reverse proxy.**
+You want the SPA to run under `/site01` (or whatever production prefix). Set `VITE_DEV_API_PREFIX=/site01`. Vite injects the matching `window.__LIGHTRAG_CONFIG__` and registers prefixed proxy keys; SPA requests like `fetch("/site01/documents/foo")` are forwarded verbatim to whatever `VITE_BACKEND_URL` points at. The upstream — local backend or production nginx — is responsible for understanding the prefix.
 
 ```
-Browser ──► localhost:5173  ───────────► localhost:9621(no nginx in this scenario)
-            (Vite, simulates /site01)    (backend, root_path=/site01)
+Browser ──► localhost:5173 (Vite + HMR)
+                │
+                │  Vite proxy forwards /site01/* verbatim, no rewrite
+                ▼
+            VITE_BACKEND_URL  ──►  upstream that knows /site01
 ```
 
-Setup:
-
+`.env.local` (gitignored — your personal dev config):
 ```bash
-# lightrag_webui/.env.local  (gitignored — your personal dev config)
-VITE_BACKEND_URL=http://localhost:9621
+VITE_BACKEND_URL=…                             # see "Where to point VITE_BACKEND_URL" below
 VITE_API_PROXY=true
 VITE_API_ENDPOINTS=/api,/documents,/graphs,/graph,/health,/query,/docs,/redoc,/openapi.json,/login,/auth-status,/static
 VITE_DEV_API_PREFIX=/site01
 ```
 
-```bash
-# Terminal 1 — start the backend with the matching prefix
-LIGHTRAG_API_PREFIX=/site01 lightrag-server
+Run `bun run dev` and open **`http://localhost:5173/`**. HMR is purely local — the browser only talks to `localhost:5173` for SPA assets, no WebSocket-upgrade config needed on any upstream.
 
-# Terminal 2 — start the dev server
+#### Where to point `VITE_BACKEND_URL`
+
+Two options, picked by where the prefix-aware upstream lives. The Vite-side configuration is identical; only this one variable changes.
+
+**A. Local backend with `LIGHTRAG_API_PREFIX=/site01`** (no nginx anywhere) — the simplest setup, two processes on your laptop. Vite's proxy itself plays the role of the reverse proxy.
+
+```bash
+VITE_BACKEND_URL=http://localhost:9621
+```
+```bash
+# Terminal 1
+LIGHTRAG_API_PREFIX=/site01 lightrag-server
+# Terminal 2
 cd lightrag_webui && bun run dev
 ```
 
-Then open **`http://localhost:5173/`** (root, NOT `/site01/`). Vite serves the SPA at `/`; the SPA generates prefixed API URLs at runtime.
+The backend's FastAPI `root_path=/site01` accepts the prefixed form natively (Starlette's `get_route_path()` strips `root_path` from the request path before matching), so no extra rewriting is needed on either side.
 
-What happens:
+**B. Real (remote) backend reached through its production nginx** — useful when the actual backend has data / configs that are painful to reproduce locally. nginx already strips `/site01/` before forwarding to the backend; the dev frontend benefits without changing anything in production.
 
-- `vite.config.ts` injects `window.__LIGHTRAG_CONFIG__ = { apiPrefix: "/site01", … }` into the dev `index.html`.
-- The SPA emits requests like `fetch("/site01/documents/foo")`.
-- `server.proxy` matches `/site01/documents` and forwards verbatim to `http://localhost:9621/site01/documents/foo`.
-- The backend (`root_path=/site01`) accepts the prefixed path and serves it.
-
-HMR continues to work unchanged. **No nginx, no Docker — just two processes on localhost.**
-
-### Scenario 3 — local dev frontend against a real (remote) backend
-
-You want to iterate on the WebUI on your laptop while hitting a backend that's already in production behind nginx — typically because the real backend has data / configs that are painful to reproduce locally. The WebUI is purely local (HMR on your laptop); only API traffic crosses the network.
-
-```
-Local machine                                Remote production host
-─────────────────                            ────────────────────────
-Browser ──► localhost:5173 (Vite + HMR)
-                │
-                │  Vite proxy forwards /site01/* verbatim
-                ▼
-                ── network ───► nginx(strips /site01) ──► lightrag-server
-                                                          (may or may not have
-                                                           LIGHTRAG_API_PREFIX
-                                                           set — both work)
+```bash
+VITE_BACKEND_URL=https://prod.example.com      # or http://10.0.0.5 — the nginx URL
 ```
 
-The key insight: the production nginx is **already** doing the prefix strip. Vite's only job is to forward prefixed paths to nginx unchanged, and nginx behaves exactly as it would for a real production browser request.
+The production nginx and backend stay exactly as they are. The flow becomes:
 
-**Setup:**
-
-1. **Production nginx + backend:** unchanged. Whatever your real deploy already runs.
-2. **Dev server (`.env.local`):**
-   ```bash
-   # Point at the production reverse proxy — NOT the backend port.
-   VITE_BACKEND_URL=https://prod.example.com     # or http://10.0.0.5
-   VITE_API_PROXY=true
-   VITE_API_ENDPOINTS=/api,/documents,/graphs,/graph,/health,/query,/docs,/redoc,/openapi.json,/login,/auth-status,/static
-   VITE_DEV_API_PREFIX=/site01
-   ```
-3. Run `bun run dev` and open **`http://localhost:5173/`**.
-
-What happens for an API call:
-
-- SPA fetches `/site01/documents/foo` (because `apiPrefix=/site01` was injected into `window.__LIGHTRAG_CONFIG__`).
-- Vite's `server.proxy` matches `/site01/documents` and forwards verbatim
-  to `https://prod.example.com/site01/documents/foo`. (`changeOrigin: true` is already set, so the `Host` header is rewritten to the upstream — required for SNI / virtual hosts.)
-- Production nginx matches `/site01/`, strips it, forwards `/documents/foo` to the backend.
-- Backend serves it. `LIGHTRAG_API_PREFIX` on the backend can be set or unset; FastAPI's `root_path` accepts both prefixed and natural forms either way.
-
-HMR is purely local — the browser only talks to localhost:5173 for SPA assets. No nginx involvement, no special WebSocket-upgrade config to worry about.
+```
+SPA fetch /site01/documents/foo
+  → Vite forwards to https://prod.example.com/site01/documents/foo
+  → nginx matches /site01/, strips it, forwards /documents/foo to backend
+  → backend serves it
+```
 
 #### Why `VITE_BACKEND_URL` does **not** include `/site01`
 
-Vite forwards the request path **verbatim** (no rewrite). The browser already emits `/site01/documents/foo`, so the URL Vite sends upstream is `${VITE_BACKEND_URL}/site01/documents/foo`. If you set
-`VITE_BACKEND_URL=https://prod.example.com/site01` you'd get `https://prod.example.com/site01/site01/documents/foo` — a duplicated prefix that nginx and the backend both reject.
+Vite forwards the request path **verbatim** (no rewrite). The browser already emits `/site01/documents/foo`, so the URL Vite sends upstream is `${VITE_BACKEND_URL}/site01/documents/foo`. If you set `VITE_BACKEND_URL=https://prod.example.com/site01` you would get `https://prod.example.com/site01/site01/documents/foo` — a duplicated prefix that both nginx and the backend reject. Always point `VITE_BACKEND_URL` at the upstream **root**.
 
-Same logic applies to Scenario 2 (`VITE_BACKEND_URL=http://localhost:9621`, no prefix): Vite forwards `/site01/documents/foo` unchanged to the backend, and FastAPI's `root_path=/site01` matches the prefixed form natively.
+#### Common pitfalls (mostly relevant to option B)
 
-#### Common pitfalls
-
-- **HTTPS upstream + self-signed cert**: Vite's proxy will reject by default. Set `proxy: { ..., secure: false }` in `vite.config.ts` to skip cert validation when targeting a staging proxy with a non-public
-  cert.
-- **Auth required**: if the production backend requires `LIGHTRAG_API_KEY`, log in via the dev SPA exactly as you would in prod — the auth token flows through the proxy unchanged.
-- **CORS errors**: shouldn't happen because the browser sees same-origin requests to localhost:5173. If they appear, check that `changeOrigin: true` is in effect (it is, by default in `vite.config.ts`).
+- **HTTPS upstream + self-signed cert**: Vite's proxy rejects by default. Set `proxy: { ..., secure: false }` in `vite.config.ts` to skip cert validation when targeting a staging proxy with a non-public cert.
+- **Auth required**: if the upstream requires `LIGHTRAG_API_KEY`, log in via the dev SPA exactly as you would in prod — the auth token flows through the proxy unchanged.
+- **CORS errors**: shouldn't happen because the browser sees same-origin requests to `localhost:5173`. If they appear, check that `changeOrigin: true` is in effect (it is, by default in `vite.config.ts`).
 
 ### Quick decision matrix
 
-| You want to… | `VITE_BACKEND_URL` | `VITE_DEV_API_PREFIX` | What's in front of the backend | Open in browser |
+| Scenario | `VITE_BACKEND_URL` | `VITE_DEV_API_PREFIX` | Upstream the dev proxy talks to | Open in browser |
 | --- | --- | --- | --- | --- |
-| Default single-instance dev | `http://localhost:9621` | unset | local backend, no proxy | `http://localhost:5173/` |
-| Reproduce a multi-site bug locally | `http://localhost:9621` | `/site01` | local backend with `LIGHTRAG_API_PREFIX=/site01`, no nginx | `http://localhost:5173/` |
-| Hit a real (remote) backend through its production nginx | `https://prod.example.com` | `/site01` | production nginx already strips `/site01/` | `http://localhost:5173/` |
+| 1. Default single-instance dev | `http://localhost:9621` | unset | local backend, no prefix | `http://localhost:5173/` |
+| 2A. Simulate a prefix locally (no nginx) | `http://localhost:9621` | `/site01` | local backend with `LIGHTRAG_API_PREFIX=/site01` | `http://localhost:5173/` |
+| 2B. Hit a real backend through its production nginx | `https://prod.example.com` | `/site01` | remote nginx that already strips `/site01/` | `http://localhost:5173/` |
+
+Rows 2A and 2B share **everything except `VITE_BACKEND_URL`** — the choice is purely "is the prefix-aware upstream on my laptop or in production?".
 
 **The "Open in browser" column is always `http://localhost:5173/` — that is the entry point in every dev scenario.** What changes between rows is where the API traffic ultimately lands; the SPA itself is always served from the dev server's root.
 

--- a/docs/MultiSiteDeployment.md
+++ b/docs/MultiSiteDeployment.md
@@ -339,9 +339,7 @@ The key insight: the production nginx is **already** doing the prefix strip. Vit
 **Setup:**
 
 1. **Production nginx + backend:** unchanged. Whatever your real deploy already runs.
-   
 2. **Dev server (`.env.local`):**
-   
    ```bash
    # Point at the production reverse proxy — NOT the backend port.
    VITE_BACKEND_URL=https://prod.example.com     # or http://10.0.0.5
@@ -350,7 +348,6 @@ The key insight: the production nginx is **already** doing the prefix strip. Vit
    VITE_DEV_API_PREFIX=/site01
    VITE_DEV_WEBUI_PREFIX=/site01/webui/
    ```
-   
 3. Run `bun run dev` and open **`http://localhost:5173/`**.
 
 What happens for an API call:

--- a/docs/MultiSiteDeployment.md
+++ b/docs/MultiSiteDeployment.md
@@ -269,23 +269,61 @@ Backends still set `LIGHTRAG_API_PREFIX=/site01` / `=/site02`.
 
 ---
 
-## Local development with prefix simulation
+## Local development with `bun run dev`
 
-`bun run dev` mirrors production injection so the SPA reads the same
-`window.__LIGHTRAG_CONFIG__` mechanism in dev. There are two modes:
+The dev server mirrors production injection: it serves `index.html` via
+the same `transformIndexHtml` mechanism the FastAPI server uses at request
+time, so the SPA reads `window.__LIGHTRAG_CONFIG__` in dev exactly the
+way it does in prod. Only **two** environment variables matter:
 
-### A — default (no prefix)
+| Variable | Purpose | Where it lives |
+| --- | --- | --- |
+| `VITE_BACKEND_URL` | Where the dev server forwards proxied API calls. | `lightrag_webui/.env*` |
+| `VITE_DEV_API_PREFIX` | Prefix to **simulate** (matches the production `LIGHTRAG_API_PREFIX`). Empty → no prefix. | `lightrag_webui/.env*` |
 
-Just run `bun run dev`. The injected config is empty (`apiPrefix=""`,
-`webuiPrefix="/webui/"`), and `server.proxy` forwards relative paths like
-`/documents/...` to `http://localhost:9621` exactly as before.
+`VITE_DEV_WEBUI_PREFIX` is also accepted but only affects the home/logo
+`<a href>` link inside the SPA — set it to `${VITE_DEV_API_PREFIX}/webui/`
+if you care about that link in dev, otherwise leave it empty.
 
-### B — simulate a site prefix
+Three scenarios cover everything you'll hit:
 
-Useful when iterating on UI while a real prefixed backend is running.
+### Scenario 1 — single-instance dev (no prefix, no proxy)
 
-`lightrag_webui/.env.local` (gitignored):
+The default. Don't set anything beyond the existing `.env.development`.
+
+```
+Browser ──► localhost:5173 (Vite) ──► localhost:9621 (backend, no prefix)
+```
+
 ```bash
+# lightrag_webui/.env.development (already in repo as sample)
+VITE_BACKEND_URL=http://localhost:9621
+VITE_API_PROXY=true
+VITE_API_ENDPOINTS=/api,/documents,/graphs,/graph,/health,/query,/docs,/redoc,/openapi.json,/login,/auth-status,/static
+# VITE_DEV_API_PREFIX=          ← leave empty
+```
+
+Run:
+```bash
+lightrag-server                  # in one terminal, no LIGHTRAG_API_PREFIX
+cd lightrag_webui && bun run dev # in another; open http://localhost:5173/
+```
+
+### Scenario 2 — simulate the production prefix WITHOUT running nginx (recommended)
+
+You want to develop against a prefix-configured backend, but don't want
+to install / configure nginx locally just to debug. **The Vite dev
+server's built-in proxy plays the role of the reverse proxy.**
+
+```
+Browser ──► localhost:5173 (Vite, simulates /site01) ──► localhost:9621 (backend, root_path=/site01)
+                                                          (no nginx in this picture)
+```
+
+Setup:
+
+```bash
+# lightrag_webui/.env.local  (gitignored — your personal dev config)
 VITE_BACKEND_URL=http://localhost:9621
 VITE_API_PROXY=true
 VITE_API_ENDPOINTS=/api,/documents,/graphs,/graph,/health,/query,/docs,/redoc,/openapi.json,/login,/auth-status,/static
@@ -293,15 +331,77 @@ VITE_DEV_API_PREFIX=/site01
 VITE_DEV_WEBUI_PREFIX=/site01/webui/
 ```
 
-Backend started with `LIGHTRAG_API_PREFIX=/site01`. Now `bun run dev`:
+```bash
+# Terminal 1 — start the backend with the matching prefix
+LIGHTRAG_API_PREFIX=/site01 lightrag-server
 
-- Injects `window.__LIGHTRAG_CONFIG__ = { apiPrefix: "/site01", … }` into
-  the dev `index.html`.
-- Prefixes every entry of `VITE_API_ENDPOINTS` with `/site01` when
-  registering proxy targets, so requests to `/site01/documents/...` are
-  forwarded to `http://localhost:9621/site01/documents/...`.
+# Terminal 2 — start the dev server
+cd lightrag_webui && bun run dev
+```
 
-HMR continues to work unchanged.
+Then open **`http://localhost:5173/`** (root, NOT `/site01/`). Vite serves
+the SPA at `/`; the SPA generates prefixed API URLs at runtime.
+
+What happens:
+
+- `vite.config.ts` injects `window.__LIGHTRAG_CONFIG__ = { apiPrefix: "/site01", … }` into the dev `index.html`.
+- The SPA emits requests like `fetch("/site01/documents/foo")`.
+- `server.proxy` matches `/site01/documents` and forwards verbatim to `http://localhost:9621/site01/documents/foo`.
+- The backend (`root_path=/site01`) accepts the prefixed path and serves it.
+
+HMR continues to work unchanged. **No nginx, no Docker — just two
+processes on localhost.**
+
+### Scenario 3 — debug through your real production reverse proxy
+
+You already have nginx (or Traefik / Caddy) running locally with the
+exact rules from the deployment guide, and you want HMR to flow through
+it so you're testing the actual deploy path.
+
+```
+Browser ──► localhost:80 (nginx) ──► localhost:5173 (Vite) ──► localhost:9621 (backend)
+                  │
+                  └── strips /site01/ before forwarding to Vite
+```
+
+This requires three things:
+
+1. **Backend with the prefix:** `LIGHTRAG_API_PREFIX=/site01 lightrag-server`.
+2. **Dev server config (`.env.local`):**
+   ```bash
+   VITE_BACKEND_URL=http://localhost:9621      # Vite still forwards directly to backend
+   VITE_API_PROXY=true
+   VITE_API_ENDPOINTS=/api,/documents,/graphs,/graph,/health,/query,/docs,/redoc,/openapi.json,/login,/auth-status,/static
+   VITE_DEV_API_PREFIX=/site01
+   VITE_DEV_WEBUI_PREFIX=/site01/webui/
+   ```
+3. **nginx route the WebUI to Vite, not to the backend:**
+   ```nginx
+   location /site01/ {
+       # Forward EVERYTHING to Vite — Vite's proxy handles API forwarding
+       proxy_pass http://127.0.0.1:5173/;
+       proxy_http_version 1.1;
+       proxy_set_header Upgrade $http_upgrade;        # required for HMR
+       proxy_set_header Connection "upgrade";
+       proxy_set_header Host $host;
+       proxy_set_header X-Forwarded-Prefix /site01;
+   }
+   ```
+
+Open **`http://localhost/site01/`**. The HMR websocket upgrades through
+nginx → Vite, API calls flow Vite → backend.
+
+> Most contributors should prefer Scenario 2. Scenario 3 is only useful
+> when you suspect a bug specific to the reverse-proxy path (e.g. a
+> header-rewriting rule, a redirect mismatch).
+
+### Quick decision matrix
+
+| You want to… | Backend `LIGHTRAG_API_PREFIX` | `VITE_DEV_API_PREFIX` | Reverse proxy? | Open in browser |
+| --- | --- | --- | --- | --- |
+| Default single-instance dev | unset | unset | no | `http://localhost:5173/` |
+| Reproduce a multi-site bug locally | `/site01` | `/site01` | no (Vite proxy is enough) | `http://localhost:5173/` |
+| Validate the actual nginx rules | `/site01` | `/site01` | yes (nginx → Vite) | `http://localhost/site01/` |
 
 ---
 

--- a/env.example
+++ b/env.example
@@ -19,21 +19,18 @@ WEBUI_DESCRIPTION='Simple and Fast Graph Based RAG System'
 
 ### Path Prefix Configuration (Optional)
 ### Used to host multiple LightRAG instances on one host behind a reverse
-### proxy that routes by site prefix. Leave both unset (or empty) for a
+### proxy that routes by site prefix. Leave unset (or empty) for a
 ### single-instance deployment.
 ###
 ### - LIGHTRAG_API_PREFIX  : reverse-proxy prefix the upstream proxy strips
 ###                          before forwarding (passed to FastAPI as
 ###                          root_path). Empty / "/" disables it.
-### - LIGHTRAG_WEBUI_PATH  : in-app WebUI mount path. Default: /webui.
-###                          Leave as /webui unless you have a reason to
-###                          relocate it.
 ###
 ### One WebUI build serves any number of sites — the prefix is injected at
-### request time. See docs/MultiSiteDeployment.md for end-to-end examples
-### (nginx, docker-compose, Kubernetes Ingress, dev simulation).
+### request time. The WebUI is always mounted at /webui (not configurable).
+### See docs/MultiSiteDeployment.md for end-to-end examples (nginx,
+### docker-compose, Kubernetes Ingress, dev simulation).
 # LIGHTRAG_API_PREFIX=/site01
-# LIGHTRAG_WEBUI_PATH=/webui
 
 ### Optional SSL Configuration
 ### Docker note: generated compose files mount staged certs at /app/data/certs/ inside the container

--- a/env.example
+++ b/env.example
@@ -18,45 +18,20 @@ WEBUI_DESCRIPTION='Simple and Fast Graph Based RAG System'
 # CORS_ORIGINS=http://localhost:3000,http://localhost:8080
 
 ### Path Prefix Configuration (Optional)
-### Primary use case: hosting multiple LightRAG instances on one host, with
-### a reverse proxy routing by site prefix:
-###   https://host/site01/...  →  instance #1 (this .env)
-###   https://host/site02/...  →  instance #2 (a separate .env / container)
-### Each instance gets its own storage, API keys and WebUI under a unique
-### prefix. Empty or "/" disables the prefix; trailing slashes are
-### normalized automatically.
+### Used to host multiple LightRAG instances on one host behind a reverse
+### proxy that routes by site prefix. Leave both unset (or empty) for a
+### single-instance deployment.
 ###
-### How these two variables are interpreted:
-### - LIGHTRAG_API_PREFIX is passed to FastAPI as `root_path`. It does NOT
-###   rewrite route matching — it tells FastAPI "this app is mounted under
-###   <prefix> by an upstream proxy", so the OpenAPI `servers` URL and
-###   request.url_for() generate correct absolute URLs. The reverse proxy
-###   is expected to strip this prefix before forwarding to uvicorn.
+### - LIGHTRAG_API_PREFIX  : reverse-proxy prefix the upstream proxy strips
+###                          before forwarding (passed to FastAPI as
+###                          root_path). Empty / "/" disables it.
+### - LIGHTRAG_WEBUI_PATH  : in-app WebUI mount path. Default: /webui.
+###                          Leave as /webui unless you have a reason to
+###                          relocate it.
 ###
-###   nginx example for site01:
-###     location /site01/ {
-###         proxy_pass http://127.0.0.1:9621/;   # trailing / strips /site01
-###         proxy_set_header X-Forwarded-Prefix /site01;
-###     }
-###
-### - LIGHTRAG_WEBUI_PATH is the in-app mount path: app.mount(<path>, ...).
-###   It is what the *backend itself* sees AFTER the proxy has stripped
-###   LIGHTRAG_API_PREFIX, so leave it as `/webui` even when each instance
-###   has a different site prefix.
-###
-### Frontend interaction (build once, deploy many):
-### The WebUI is a static Vite bundle that no longer bakes any path prefix
-### at build time. Asset URLs are emitted as relative paths, and the API
-### base URL is read at runtime from `window.__LIGHTRAG_CONFIG__`, which
-### the FastAPI server injects into `index.html` based on the two LIGHTRAG_*
-### variables below. One build is therefore reusable across any number of
-### sites / Docker instances — including this one — with no rebuild.
-###
-### See `docs/MultiSiteDeployment.md` for end-to-end multi-site examples.
-###
-### Example — site01 instance, WebUI reachable at https://host/site01/webui/:
-###   LIGHTRAG_API_PREFIX=/site01
-###   LIGHTRAG_WEBUI_PATH=/webui
+### One WebUI build serves any number of sites — the prefix is injected at
+### request time. See docs/MultiSiteDeployment.md for end-to-end examples
+### (nginx, docker-compose, Kubernetes Ingress, dev simulation).
 # LIGHTRAG_API_PREFIX=/site01
 # LIGHTRAG_WEBUI_PATH=/webui
 

--- a/env.example
+++ b/env.example
@@ -44,28 +44,19 @@ WEBUI_DESCRIPTION='Simple and Fast Graph Based RAG System'
 ###   LIGHTRAG_API_PREFIX, so leave it as `/webui` even when each instance
 ###   has a different site prefix.
 ###
-### IMPORTANT — backend / frontend split:
-### The WebUI is a static bundle. Asset URLs (<script src>, <link href>)
-### and the in-bundle API base URL are BAKED IN at `bun run build` time
-### from VITE_API_PREFIX / VITE_WEBUI_PREFIX. The two LIGHTRAG_* vars below
-### only configure the Python server — they have NO effect on already-built
-### bundles. Consequence for multi-site deployments: each site that uses a
-### different prefix needs its OWN WebUI build (one image / artifact per
-### site), until runtime config injection lands in a follow-up PR. See
-### `lightrag_webui/.env.example` for the matching frontend variables.
+### Frontend interaction (build once, deploy many):
+### The WebUI is a static Vite bundle that no longer bakes any path prefix
+### at build time. Asset URLs are emitted as relative paths, and the API
+### base URL is read at runtime from `window.__LIGHTRAG_CONFIG__`, which
+### the FastAPI server injects into `index.html` based on the two LIGHTRAG_*
+### variables below. One build is therefore reusable across any number of
+### sites / Docker instances — including this one — with no rebuild.
 ###
-### Browser-visible URL (what the user types in the address bar) =
-### proxy prefix + in-app path. So at build time:
-###   VITE_API_PREFIX   = LIGHTRAG_API_PREFIX
-###   VITE_WEBUI_PREFIX = LIGHTRAG_API_PREFIX + LIGHTRAG_WEBUI_PATH + "/"
+### See `docs/MultiSiteDeployment.md` for end-to-end multi-site examples.
 ###
-### Example — site01 instance, WebUI at https://host/site01/webui/:
-###   Backend (this file):
-###     LIGHTRAG_API_PREFIX=/site01
-###     LIGHTRAG_WEBUI_PATH=/webui
-###   Frontend build (lightrag_webui/.env or .env.production):
-###     VITE_API_PREFIX=/site01
-###     VITE_WEBUI_PREFIX=/site01/webui/
+### Example — site01 instance, WebUI reachable at https://host/site01/webui/:
+###   LIGHTRAG_API_PREFIX=/site01
+###   LIGHTRAG_WEBUI_PATH=/webui
 # LIGHTRAG_API_PREFIX=/site01
 # LIGHTRAG_WEBUI_PATH=/webui
 

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -304,12 +304,6 @@ def parse_args() -> argparse.Namespace:
         default=get_env_value("LIGHTRAG_API_PREFIX", ""),
         help="API path prefix (e.g., /api/v1). Prepended to all API routes. Default: none (root).",
     )
-    parser.add_argument(
-        "--webui-path",
-        type=str,
-        default=get_env_value("LIGHTRAG_WEBUI_PATH", "/webui"),
-        help="Path to mount WebUI static files. Default: /webui",
-    )
 
     # Server workers configuration
     parser.add_argument(

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -80,6 +80,15 @@ webui_description = os.getenv("WEBUI_DESCRIPTION")
 auth_configured = bool(auth_handler.accounts)
 
 
+# Fixed WebUI mount path. Used as `app.mount(WEBUI_PATH, ...)` and as the
+# in-app component of `webuiPrefix` injected into window.__LIGHTRAG_CONFIG__
+# (which the browser sees as `LIGHTRAG_API_PREFIX + WEBUI_PATH + "/"`).
+# Not user-configurable: a single mount path simplifies the operator surface
+# and matches how LightRAG is deployed in practice. See
+# docs/MultiSiteDeployment.md.
+WEBUI_PATH = "/webui"
+
+
 class LLMConfigCache:
     """Smart LLM and Embedding configuration cache class"""
 
@@ -387,22 +396,22 @@ def create_app(args):
         + "\n\n[View ReDoc documentation](/redoc)"
     )
 
-    # Normalize API prefix and WebUI mount path. Both accept user input from
-    # CLI/env, so we strip surrounding whitespace, strip a trailing slash
-    # (Starlette's app.mount rejects mount paths ending in '/'), and treat
-    # empty/"/" as "use the default". A leading slash is ensured.
-    def _normalize_path(value: str | None, default: str) -> str:
+    # Normalize the API prefix from CLI/env. Strip surrounding whitespace,
+    # strip a trailing slash, and treat empty/"/" as "no prefix". A leading
+    # slash is ensured. The WebUI mount path is fixed at "/webui" — see
+    # docs/MultiSiteDeployment.md for the rationale.
+    def _normalize_api_prefix(value: str | None) -> str:
         if value is None:
-            return default
+            return ""
         value = value.strip()
         if not value or value == "/":
-            return default
+            return ""
         if not value.startswith("/"):
             value = "/" + value
         return value.rstrip("/")
 
-    api_prefix = _normalize_path(getattr(args, "api_prefix", None), default="")
-    webui_path = _normalize_path(getattr(args, "webui_path", None), default="/webui")
+    api_prefix = _normalize_api_prefix(getattr(args, "api_prefix", None))
+    webui_path = WEBUI_PATH
 
     app_kwargs = {
         "title": "LightRAG Server API",

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -4,11 +4,12 @@ LightRAG FastAPI Server
 
 from fastapi import FastAPI, Depends, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, FileResponse, Response
 from fastapi.openapi.docs import (
     get_swagger_ui_html,
     get_swagger_ui_oauth2_redirect_html,
 )
+import json
 import os
 import re
 import logging
@@ -282,98 +283,6 @@ def check_frontend_build():
         return (True, False)  # Assume assets exist and up-to-date on error
 
 
-def check_webui_build_prefix(api_prefix: str, webui_path: str) -> None:
-    """Warn if the WebUI build's baked-in path prefix doesn't match what
-    this server will expose.
-
-    Background: the WebUI is a Vite-built static bundle. `VITE_WEBUI_PREFIX`
-    is statically replaced into `index.html` and the JS chunk imports at
-    `bun run build` time. If an admin later changes `LIGHTRAG_API_PREFIX` /
-    `LIGHTRAG_WEBUI_PATH` without rebuilding (e.g. when reusing a single
-    image across multiple sites), `index.html` still loads, but every
-    `<script src=...>` and `<link href=...>` points at the OLD prefix and
-    404s — a confusing failure mode that's easy to miss in browser logs.
-
-    This check parses one asset reference from the built `index.html`,
-    derives the prefix that was baked in, and compares it to the
-    browser-visible path = api_prefix + webui_path + "/" — the same formula
-    documented in `env.example`. If they disagree it prints a loud warning
-    with the exact command to rebuild.
-
-    Args:
-        api_prefix: normalized LIGHTRAG_API_PREFIX (e.g. "/site01" or "")
-        webui_path: normalized LIGHTRAG_WEBUI_PATH (e.g. "/webui")
-    """
-    index_html = Path(__file__).parent / "webui" / "index.html"
-    if not index_html.exists():
-        # No build to check — `check_frontend_build` already warned.
-        return
-
-    try:
-        html = index_html.read_text(encoding="utf-8")
-    except OSError as e:
-        logger.warning(f"Could not read WebUI index.html for prefix check: {e}")
-        return
-
-    # Vite emits assets under `<base>assets/...` (see assetFileNames). Pull
-    # the prefix out of the first such reference. Match either src= or href=
-    # to cover <script> and <link> tags.
-    match = re.search(r'(?:src|href)="([^"]*?)/assets/[^"]*"', html)
-    if not match:
-        # Build artifact format unexpected — skip silently rather than
-        # spam a warning the admin can't act on.
-        logger.debug("Could not infer WebUI baked prefix from index.html")
-        return
-
-    baked_prefix = match.group(1) + "/"
-    expected_prefix = f"{api_prefix}{webui_path}/"
-
-    if baked_prefix == expected_prefix:
-        logger.info(f"WebUI build prefix matches server config: {expected_prefix}")
-        return
-
-    # Structured warning so log aggregators / tests can pick it up.
-    rebuild_cmd = (
-        ("VITE_API_PREFIX=" + api_prefix + " " if api_prefix else "")
-        + "VITE_WEBUI_PREFIX="
-        + expected_prefix
-        + " bun run build"
-    )
-    logger.warning(
-        "WebUI build prefix mismatch: built with %s but server will expose"
-        " at %s (LIGHTRAG_API_PREFIX=%s + LIGHTRAG_WEBUI_PATH=%s + '/')."
-        " Asset URLs will 404 until the WebUI is rebuilt with: %s",
-        baked_prefix,
-        expected_prefix,
-        api_prefix or "<empty>",
-        webui_path,
-        rebuild_cmd,
-    )
-
-    # Banner duplicates the warning for an operator watching the splash —
-    # easy to miss a single log line among startup chatter.
-    ASCIIColors.yellow("\n" + "=" * 80)
-    ASCIIColors.yellow("WARNING: WebUI Build Prefix Mismatch")
-    ASCIIColors.yellow("=" * 80)
-    ASCIIColors.yellow(f"WebUI was built with prefix:    {baked_prefix}")
-    ASCIIColors.yellow(f"This server will expose it at:  {expected_prefix}")
-    ASCIIColors.yellow(
-        f"  (LIGHTRAG_API_PREFIX={api_prefix or '<empty>'}"
-        f' + LIGHTRAG_WEBUI_PATH={webui_path} + "/")\n'
-    )
-    ASCIIColors.yellow("The WebUI HTML will load, but its asset URLs (JS/CSS) will 404")
-    ASCIIColors.yellow(
-        "because they were baked at build time. Rebuild the WebUI with:\n"
-    )
-    ASCIIColors.cyan("    cd lightrag_webui")
-    if api_prefix:
-        ASCIIColors.cyan(f"    VITE_API_PREFIX={api_prefix} \\")
-    ASCIIColors.cyan(f"    VITE_WEBUI_PREFIX={expected_prefix} \\")
-    ASCIIColors.cyan("    bun run build")
-    ASCIIColors.cyan("    cd ..")
-    ASCIIColors.yellow("=" * 80 + "\n")
-
-
 def create_app(args):
     # Check frontend build first and get status
     webui_assets_exist, is_frontend_outdated = check_frontend_build()
@@ -494,12 +403,6 @@ def create_app(args):
 
     api_prefix = _normalize_path(getattr(args, "api_prefix", None), default="")
     webui_path = _normalize_path(getattr(args, "webui_path", None), default="/webui")
-
-    # Loud warning at startup if the WebUI build's baked prefix disagrees
-    # with the prefix this server will expose. Skipped when no build exists
-    # (check_frontend_build already warned about that).
-    if webui_assets_exist:
-        check_webui_build_prefix(api_prefix, webui_path)
 
     app_kwargs = {
         "title": "LightRAG Server API",
@@ -1506,12 +1409,49 @@ def create_app(args):
             logger.error(f"Error getting health status: {str(e)}")
             raise HTTPException(status_code=500, detail=str(e))
 
-    # Custom StaticFiles class for smart caching
+    # Pre-render the runtime-config <script> once. The browser-visible URL
+    # prefixes are NOT baked into the bundle anymore — index.html ships with
+    # a placeholder comment that we replace with this snippet on every HTML
+    # response, so one build serves any reverse-proxy mount point.
+    #
+    # `</` → `<\/` escaping prevents an embedded "</script>" sequence from
+    # breaking out of the inline script (defense-in-depth — values come from
+    # admin config, not user input).
+    _runtime_config_payload = json.dumps(
+        {
+            "apiPrefix": api_prefix,
+            "webuiPrefix": f"{api_prefix}{webui_path}/",
+        }
+    ).replace("</", "<\\/")
+    runtime_config_script = (
+        f"<script>window.__LIGHTRAG_CONFIG__ = {_runtime_config_payload};</script>"
+    )
+
+    # Custom StaticFiles class for smart caching + runtime config injection
     class SmartStaticFiles(StaticFiles):  # Renamed from NoCacheStaticFiles
+        # Replaced in index.html on every request. Keep in sync with
+        # lightrag_webui/index.html.
+        RUNTIME_CONFIG_PLACEHOLDER = b"<!-- __LIGHTRAG_RUNTIME_CONFIG__ -->"
+
         async def get_response(self, path: str, scope):
             response = await super().get_response(path, scope)
 
-            is_html = path.endswith(".html") or response.media_type == "text/html"
+            # `path` is empty when accessing the mount root (StaticFiles
+            # rewrites it to index.html internally) — match on media_type
+            # too so we still inject in that case.
+            is_html = (
+                path.endswith(".html")
+                or path == ""
+                or path.endswith("/")
+                or getattr(response, "media_type", None) == "text/html"
+            )
+
+            if (
+                is_html
+                and getattr(response, "status_code", 0) == 200
+                and isinstance(response, FileResponse)
+            ):
+                response = self._inject_runtime_config(response)
 
             if is_html:
                 response.headers["Cache-Control"] = (
@@ -1534,6 +1474,32 @@ def create_app(args):
                 response.headers["Content-Type"] = "text/css"
 
             return response
+
+        def _inject_runtime_config(self, response: FileResponse) -> Response:
+            """Replace the runtime-config placeholder in index.html.
+
+            Returns the original FileResponse if the placeholder is absent
+            (older build, or a non-index HTML file) — avoids breaking
+            previously-working bundles during upgrades.
+            """
+            try:
+                content = Path(response.path).read_bytes()
+            except OSError as e:
+                logger.warning(
+                    "Could not read %s for runtime config injection: %s",
+                    response.path,
+                    e,
+                )
+                return response
+
+            if self.RUNTIME_CONFIG_PLACEHOLDER not in content:
+                return response
+
+            new_content = content.replace(
+                self.RUNTIME_CONFIG_PLACEHOLDER,
+                runtime_config_script.encode("utf-8"),
+            )
+            return Response(content=new_content, media_type="text/html")
 
     # Mount Swagger UI static files for offline support
     swagger_static_dir = Path(__file__).parent / "static" / "swagger-ui"

--- a/lightrag_webui/env.development.smaple
+++ b/lightrag_webui/env.development.smaple
@@ -5,7 +5,7 @@ VITE_API_ENDPOINTS=/api,/documents,/graphs,/graph,/health,/query,/docs,/redoc,/o
 
 # ──────────────────────────────────────────────────────────────────────────
 # Optional: simulate a reverse-proxied multi-site deployment in `bun run dev`.
-# Leave both empty for the default no-prefix dev workflow.
+# Leave empty for the default no-prefix dev workflow.
 #
 # When set, `vite.config.ts` injects `window.__LIGHTRAG_CONFIG__` into the
 # dev `index.html` (the same mechanism the FastAPI server uses in
@@ -13,14 +13,10 @@ VITE_API_ENDPOINTS=/api,/documents,/graphs,/graph,/health,/query,/docs,/redoc,/o
 # `/site01/documents/...` is forwarded to the backend running with
 # LIGHTRAG_API_PREFIX=/site01.
 #
-# These two values must match what the browser will see, i.e. include any
-# reverse-proxy prefix that the production deployment also uses. Empty / "/"
-# is normalized to no prefix.
+# The matching webuiPrefix is derived as `${VITE_DEV_API_PREFIX}/webui/`;
+# you only need to set this one variable. Empty / "/" → no prefix.
 #
 # See docs/MultiSiteDeployment.md for end-to-end examples.
 #
-# Example for site01:
-#   VITE_DEV_API_PREFIX=/site01
-#   VITE_DEV_WEBUI_PREFIX=/site01/webui/
+# Example for site01: VITE_DEV_API_PREFIX=/site01
 # VITE_DEV_API_PREFIX=
-# VITE_DEV_WEBUI_PREFIX=

--- a/lightrag_webui/env.development.smaple
+++ b/lightrag_webui/env.development.smaple
@@ -2,3 +2,25 @@
 VITE_BACKEND_URL=http://localhost:9621
 VITE_API_PROXY=true
 VITE_API_ENDPOINTS=/api,/documents,/graphs,/graph,/health,/query,/docs,/redoc,/openapi.json,/login,/auth-status,/static
+
+# ──────────────────────────────────────────────────────────────────────────
+# Optional: simulate a reverse-proxied multi-site deployment in `bun run dev`.
+# Leave both empty for the default no-prefix dev workflow.
+#
+# When set, `vite.config.ts` injects `window.__LIGHTRAG_CONFIG__` into the
+# dev `index.html` (the same mechanism the FastAPI server uses in
+# production), and `server.proxy` keys are prefixed automatically so e.g.
+# `/site01/documents/...` is forwarded to the backend running with
+# LIGHTRAG_API_PREFIX=/site01.
+#
+# These two values must match what the browser will see, i.e. include any
+# reverse-proxy prefix that the production deployment also uses. Empty / "/"
+# is normalized to no prefix.
+#
+# See docs/MultiSiteDeployment.md for end-to-end examples.
+#
+# Example for site01:
+#   VITE_DEV_API_PREFIX=/site01
+#   VITE_DEV_WEBUI_PREFIX=/site01/webui/
+# VITE_DEV_API_PREFIX=
+# VITE_DEV_WEBUI_PREFIX=

--- a/lightrag_webui/env.local.sample
+++ b/lightrag_webui/env.local.sample
@@ -2,43 +2,28 @@ VITE_BACKEND_URL=http://localhost:9621
 VITE_API_PROXY=true
 VITE_API_ENDPOINTS=/api,/documents,/graphs,/graph,/health,/query,/docs,/redoc,/openapi.json,/login,/auth-status
 
-# LightRAG WebUI — build-time configuration template.
+# LightRAG WebUI — runtime configuration template.
 #
-# Primary use case: hosting multiple LightRAG instances on one host behind a
-# reverse proxy that routes by site prefix:
-#   https://host/site01/webui/   →  WebUI for instance #1
-#   https://host/site02/webui/   →  WebUI for instance #2
-# Each site needs its OWN WebUI build with its own prefix values, because
-# Vite STATICALLY REPLACES these into the bundle at build time. There is no
-# runtime override yet — see the project root `env.example` for the matching
-# backend variables (LIGHTRAG_API_PREFIX / LIGHTRAG_WEBUI_PATH).
+# IMPORTANT: VITE_API_PREFIX and VITE_WEBUI_PREFIX have been removed. The
+# browser-visible URL prefixes are now resolved at REQUEST time from the
+# backend's LIGHTRAG_API_PREFIX and LIGHTRAG_WEBUI_PATH (see project root
+# `env.example`). One WebUI build is reusable across any number of
+# reverse-proxy prefixes / Docker instances — no per-site rebuild needed.
 #
-# How to use:
-# - Copy to `.env` (always loaded) or `.env.production` (only loaded for
-#   `bun run build`), or pass on the command line:
-#     VITE_API_PREFIX=/site01 VITE_WEBUI_PREFIX=/site01/webui/ bun run build
-# - Build output goes to `../lightrag/api/webui/`. To produce one bundle per
-#   site, build once per site and stash the output (e.g. into a per-site
-#   container image or a per-site directory mounted by the server).
-
-# Browser-visible URL prefix used as `axios.baseURL`, in `fetch()` template
-# strings, and as the iframe `src` for the API docs page.
+# How it works:
+# - Build artifacts contain `<!-- __LIGHTRAG_RUNTIME_CONFIG__ -->` and use
+#   relative asset URLs (`./assets/...`).
+# - On each request, the FastAPI server replaces the placeholder with
+#   `<script>window.__LIGHTRAG_CONFIG__ = { apiPrefix, webuiPrefix }</script>`.
+# - The SPA reads `window.__LIGHTRAG_CONFIG__` for `axios.baseURL`, fetch
+#   templates, and in-app links.
 #
-# Must equal the backend `LIGHTRAG_API_PREFIX` for the same site (the prefix
-# the reverse proxy strips before forwarding to FastAPI). Empty / "/" → no
-# prefix (single-instance / no reverse-proxy deployment).
+# This file only needs to define dev-server proxy settings; copy to `.env`
+# if you also want to run `bun run dev` from a deployed checkout.
 #
-# Example for site01: VITE_API_PREFIX=/site01
-# VITE_API_PREFIX=
-
-# Browser-visible URL prefix where the WebUI itself is served. Used as
-# Vite's `base` option (asset URL prefix in index.html) and by `<a>` links.
+# For dev-time multi-site simulation (running `bun run dev` against a
+# backend that is already configured with a site prefix), use
+# `VITE_DEV_API_PREFIX` and `VITE_DEV_WEBUI_PREFIX` — see
+# `env.development.smaple`.
 #
-# Must equal LIGHTRAG_API_PREFIX + LIGHTRAG_WEBUI_PATH + "/" — i.e. the FULL
-# path the user's browser sees, including any reverse-proxy prefix in front
-# of the in-app mount path. Trailing "/" is required by Vite; the
-# normalization helper enforces it automatically.
-#
-# Example for site01 (WebUI at https://host/site01/webui/):
-#   VITE_WEBUI_PREFIX=/site01/webui/
-# VITE_WEBUI_PREFIX=
+# End-to-end deployment guide: docs/MultiSiteDeployment.md

--- a/lightrag_webui/index.html
+++ b/lightrag_webui/index.html
@@ -8,6 +8,7 @@
     <link rel="icon" type="image/png" href="favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Lightrag</title>
+    <!-- __LIGHTRAG_RUNTIME_CONFIG__ -->
   </head>
   <body>
     <div id="root"></div>

--- a/lightrag_webui/src/lib/constants.ts
+++ b/lightrag_webui/src/lib/constants.ts
@@ -1,8 +1,9 @@
 import { ButtonVariantType } from '@/components/ui/Button'
 import { normalizeApiPrefix, normalizeWebuiPrefix } from '@/lib/pathPrefix'
+import { getRuntimeApiPrefix, getRuntimeWebuiPrefix } from '@/lib/runtimeConfig'
 
-export const backendBaseUrl = normalizeApiPrefix(import.meta.env.VITE_API_PREFIX)
-export const webuiPrefix = normalizeWebuiPrefix(import.meta.env.VITE_WEBUI_PREFIX)
+export const backendBaseUrl = normalizeApiPrefix(getRuntimeApiPrefix())
+export const webuiPrefix = normalizeWebuiPrefix(getRuntimeWebuiPrefix())
 
 export const controlButtonVariant: ButtonVariantType = 'ghost'
 

--- a/lightrag_webui/src/lib/runtimeConfig.ts
+++ b/lightrag_webui/src/lib/runtimeConfig.ts
@@ -1,0 +1,40 @@
+/**
+ * Runtime path prefix configuration.
+ *
+ * The browser-visible URL prefixes (API base, WebUI mount path) used to be
+ * baked into the bundle from `import.meta.env.VITE_*_PREFIX` at build time,
+ * forcing one build per reverse-proxy mount point. They are now resolved at
+ * REQUEST time: the FastAPI server replaces a `<!-- __LIGHTRAG_RUNTIME_CONFIG__ -->`
+ * comment in `index.html` with a `<script>window.__LIGHTRAG_CONFIG__ = ...</script>`
+ * snippet built from `LIGHTRAG_API_PREFIX` / `LIGHTRAG_WEBUI_PATH`. This module
+ * is the single read point for that injected value.
+ *
+ * Dev parity: `vite.config.ts` performs the same injection via a
+ * `transformIndexHtml` plugin using `VITE_DEV_API_PREFIX` /
+ * `VITE_DEV_WEBUI_PREFIX`, so dev and prod use the same lookup.
+ *
+ * Always read through {@link normalizeApiPrefix} / {@link normalizeWebuiPrefix}
+ * downstream (see `constants.ts`); this module returns the raw injected value.
+ */
+
+declare global {
+  interface Window {
+    __LIGHTRAG_CONFIG__?: {
+      apiPrefix?: string
+      webuiPrefix?: string
+    }
+  }
+}
+
+const config =
+  (typeof window !== 'undefined' && window.__LIGHTRAG_CONFIG__) || {}
+
+/** Browser-visible API prefix; empty string means same-origin / no prefix. */
+export function getRuntimeApiPrefix(): string | undefined {
+  return config.apiPrefix
+}
+
+/** Browser-visible WebUI mount path including the trailing slash. */
+export function getRuntimeWebuiPrefix(): string | undefined {
+  return config.webuiPrefix
+}

--- a/lightrag_webui/src/vite-env.d.ts
+++ b/lightrag_webui/src/vite-env.d.ts
@@ -14,9 +14,11 @@ interface ImportMetaEnv {
    *
    * Optional. Lets `bun run dev` mimic a reverse-proxied deployment so the
    * SPA can be exercised under the same path prefix it will see in
-   * production — without a rebuild. Both values are read by `vite.config.ts`
-   * and injected into `index.html` as `window.__LIGHTRAG_CONFIG__`, mirroring
-   * what the FastAPI server does at request time in production.
+   * production — without a rebuild. Read by `vite.config.ts` and injected
+   * into `index.html` as `window.__LIGHTRAG_CONFIG__`, mirroring what the
+   * FastAPI server does at request time in production. The matching
+   * `webuiPrefix` is derived as `${VITE_DEV_API_PREFIX}/webui/` (the WebUI
+   * mount path is fixed at /webui server-side).
    *
    * Empty / unset → no prefix; the dev server behaves the same as today.
    *
@@ -27,11 +29,6 @@ interface ImportMetaEnv {
   /** Browser-visible API prefix to simulate in dev. Must match the backend's
    *  `LIGHTRAG_API_PREFIX` if a real prefixed backend is being proxied to. */
   readonly VITE_DEV_API_PREFIX?: string
-
-  /** Browser-visible WebUI mount path to simulate in dev. Must equal
-   *  `LIGHTRAG_API_PREFIX + LIGHTRAG_WEBUI_PATH + "/"` to match the path the
-   *  reverse proxy will expose in production. */
-  readonly VITE_DEV_WEBUI_PREFIX?: string
 }
 
 interface ImportMeta {

--- a/lightrag_webui/src/vite-env.d.ts
+++ b/lightrag_webui/src/vite-env.d.ts
@@ -1,50 +1,37 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+  /* ───────────── dev-server proxy ───────────── */
+
+  /** When `true`, `bun run dev` proxies the listed endpoints to the backend. */
   readonly VITE_API_PROXY: string
+  /** Comma-separated list of paths the dev server forwards to the backend. */
   readonly VITE_API_ENDPOINTS: string
+  /** Backend origin the dev server forwards to (e.g. `http://localhost:9621`). */
   readonly VITE_BACKEND_URL: string
 
-  /**
-   * Browser-visible URL prefix used as `axios.baseURL`, in `fetch()` template
-   * strings, and as the iframe `src` for the API docs page.
+  /* ───────────── dev-time multi-site simulation ─────────────
    *
-   * Must equal the backend `LIGHTRAG_API_PREFIX` for the same site — i.e.
-   * the prefix the reverse proxy strips before forwarding to FastAPI.
-   * Empty / `/` → no prefix (single-instance deployment).
+   * Optional. Lets `bun run dev` mimic a reverse-proxied deployment so the
+   * SPA can be exercised under the same path prefix it will see in
+   * production — without a rebuild. Both values are read by `vite.config.ts`
+   * and injected into `index.html` as `window.__LIGHTRAG_CONFIG__`, mirroring
+   * what the FastAPI server does at request time in production.
    *
-   * Multi-site example (site01 routed at `https://host/site01/...`):
-   *     VITE_API_PREFIX=/site01
+   * Empty / unset → no prefix; the dev server behaves the same as today.
    *
-   * Statically replaced into the bundle at `bun run build` time, so each
-   * site needs its own WebUI build until runtime config injection lands.
-   * See `lightrag_webui/.env.example` and the project root `env.example`.
-   *
-   * Always read through {@link normalizeApiPrefix}; do not concatenate the
-   * raw value, otherwise `/` produces protocol-relative `//path` and a
-   * trailing slash produces `//`.
+   * See `lightrag_webui/env.development.smaple` and
+   * `docs/MultiSiteDeployment.md` for end-to-end examples.
    */
-  readonly VITE_API_PREFIX?: string
 
-  /**
-   * Browser-visible URL prefix where the WebUI itself is served. Used as
-   * Vite's `base` option (asset paths in `index.html`) and by `<a>` links.
-   *
-   * Must equal `LIGHTRAG_API_PREFIX + LIGHTRAG_WEBUI_PATH + "/"` — i.e. the
-   * FULL path the user's browser sees, including any reverse-proxy prefix
-   * in front of the in-app mount path.
-   *
-   * Multi-site example (site01 WebUI at `https://host/site01/webui/`):
-   *     VITE_WEBUI_PREFIX=/site01/webui/
-   *
-   * Statically replaced into the bundle at `bun run build` time, so each
-   * site needs its own WebUI build until runtime config injection lands.
-   * See `lightrag_webui/.env.example` and the project root `env.example`.
-   *
-   * Always read through {@link normalizeWebuiPrefix}; the helper guarantees
-   * a leading `/` and exactly one trailing `/` as Vite requires.
-   */
-  readonly VITE_WEBUI_PREFIX?: string
+  /** Browser-visible API prefix to simulate in dev. Must match the backend's
+   *  `LIGHTRAG_API_PREFIX` if a real prefixed backend is being proxied to. */
+  readonly VITE_DEV_API_PREFIX?: string
+
+  /** Browser-visible WebUI mount path to simulate in dev. Must equal
+   *  `LIGHTRAG_API_PREFIX + LIGHTRAG_WEBUI_PATH + "/"` to match the path the
+   *  reverse proxy will expose in production. */
+  readonly VITE_DEV_WEBUI_PREFIX?: string
 }
 
 interface ImportMeta {

--- a/lightrag_webui/vite.config.ts
+++ b/lightrag_webui/vite.config.ts
@@ -17,10 +17,15 @@ import { normalizeApiPrefix, normalizeWebuiPrefix } from './src/lib/pathPrefix'
  * `lightrag/api/lightrag_server.py`). Doing it in dev too means the SPA
  * always reads its prefix the same way, so behaviour matches between
  * `bun run dev` and a production deploy.
+ *
+ * Only `VITE_DEV_API_PREFIX` is read; the WebUI mount path is fixed at
+ * `/webui` (matching the backend's hardcoded `WEBUI_PATH`), so the
+ * injected `webuiPrefix` follows the production formula
+ * `apiPrefix + "/webui/"` automatically.
  */
 function lightragRuntimeConfigPlugin(env: Record<string, string>): Plugin {
   const apiPrefix = normalizeApiPrefix(env.VITE_DEV_API_PREFIX)
-  const webuiPrefix = normalizeWebuiPrefix(env.VITE_DEV_WEBUI_PREFIX)
+  const webuiPrefix = normalizeWebuiPrefix(apiPrefix ? `${apiPrefix}/webui/` : '')
   const payload = JSON.stringify({ apiPrefix, webuiPrefix }).replace(
     /<\//g,
     '<\\/'

--- a/lightrag_webui/vite.config.ts
+++ b/lightrag_webui/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, loadEnv } from 'vite'
+import { defineConfig, loadEnv, type Plugin } from 'vite'
 import path from 'path'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
@@ -7,20 +7,46 @@ import tailwindcss from '@tailwindcss/vite'
 // below and only takes effect during bundling — Node cannot resolve it when
 // loading vite.config.ts. Bun resolves tsconfig paths natively, masking the
 // issue, but Node does not.
-//
-// Likewise, do NOT pull `webuiPrefix` from './src/lib/constants': that value
-// is read from `import.meta.env.VITE_*`, which Vite only populates inside
-// source files (statically replaced at build). In the config file itself
-// `import.meta.env` lacks user `VITE_*` vars, so the constant would silently
-// collapse to its fallback. Use `loadEnv()` to get the real value.
-import { normalizeWebuiPrefix } from './src/lib/pathPrefix'
+import { normalizeApiPrefix, normalizeWebuiPrefix } from './src/lib/pathPrefix'
+
+/**
+ * Inject `<script>window.__LIGHTRAG_CONFIG__ = ...</script>` into index.html.
+ *
+ * This mirrors what the FastAPI server does at request time in production
+ * (see `SmartStaticFiles._inject_runtime_config` in
+ * `lightrag/api/lightrag_server.py`). Doing it in dev too means the SPA
+ * always reads its prefix the same way, so behaviour matches between
+ * `bun run dev` and a production deploy.
+ */
+function lightragRuntimeConfigPlugin(env: Record<string, string>): Plugin {
+  const apiPrefix = normalizeApiPrefix(env.VITE_DEV_API_PREFIX)
+  const webuiPrefix = normalizeWebuiPrefix(env.VITE_DEV_WEBUI_PREFIX)
+  const payload = JSON.stringify({ apiPrefix, webuiPrefix }).replace(
+    /<\//g,
+    '<\\/'
+  )
+  const snippet = `<script>window.__LIGHTRAG_CONFIG__ = ${payload};</script>`
+
+  return {
+    name: 'lightrag-dev-runtime-config',
+    apply: 'serve',
+    transformIndexHtml(html: string) {
+      return html.replace('<!-- __LIGHTRAG_RUNTIME_CONFIG__ -->', snippet)
+    }
+  }
+}
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
 
+  // Dev-only: prefix every proxied endpoint with the simulated site
+  // prefix so e.g. `/site01/documents/...` is forwarded to the backend
+  // running with LIGHTRAG_API_PREFIX=/site01.
+  const devApiPrefix = normalizeApiPrefix(env.VITE_DEV_API_PREFIX)
+
   return {
-    plugins: [react(), tailwindcss()],
+    plugins: [react(), tailwindcss(), lightragRuntimeConfigPlugin(env)],
     resolve: {
       alias: {
         '@': path.resolve(__dirname, './src')
@@ -29,7 +55,12 @@ export default defineConfig(({ mode }) => {
       // This ensures mhchem extension registered in main.tsx is available to rehype-katex
       dedupe: ['katex']
     },
-    base: normalizeWebuiPrefix(env.VITE_WEBUI_PREFIX),
+    // Relative base: asset URLs in index.html become `./assets/...` so the
+    // built bundle works under any reverse-proxy mount point. The browser
+    // resolves them against the current document URL — which means the
+    // server MUST serve index.html at a URL ending in '/' (the existing
+    // /webui → /webui/ redirect already handles this).
+    base: './',
     build: {
       outDir: path.resolve(__dirname, '../lightrag/api/webui'),
       emptyOutDir: true,
@@ -50,14 +81,12 @@ export default defineConfig(({ mode }) => {
       proxy: env.VITE_API_PROXY === 'true' && env.VITE_API_ENDPOINTS ?
         Object.fromEntries(
           env.VITE_API_ENDPOINTS.split(',').map(endpoint => [
-            endpoint,
+            devApiPrefix + endpoint,
             {
               target: env.VITE_BACKEND_URL || 'http://localhost:9621',
-              changeOrigin: true,
-              rewrite: endpoint === '/api' ?
-                (p: string) => p.replace(/^\/api/, '') :
-                endpoint === '/docs' || endpoint === '/redoc' || endpoint === '/openapi.json' || endpoint === '/static' ?
-                  (p: string) => p : undefined
+              changeOrigin: true
+              // No rewrite: the backend already understands its own prefix
+              // via FastAPI's root_path, so forward the path verbatim.
             }
           ])
         ) : {}

--- a/tests/test_path_prefixes.py
+++ b/tests/test_path_prefixes.py
@@ -29,7 +29,6 @@ _ENV_VARS_TO_ISOLATE = (
     "EMBEDDING_BINDING_API_KEY",
     "EMBEDDING_MODEL",
     "LIGHTRAG_API_PREFIX",
-    "LIGHTRAG_WEBUI_PATH",
     "LIGHTRAG_KV_STORAGE",
     "LIGHTRAG_VECTOR_STORAGE",
     "LIGHTRAG_GRAPH_STORAGE",
@@ -241,84 +240,33 @@ class TestOpenAPISpecIntegration:
 
 
 class TestWebUIPrefixIntegration:
-    """Test that WebUI is served at the correct path."""
+    """Test that the WebUI is served at the expected (fixed) /webui path,
+    composed with `root_path` when an API prefix is set."""
 
     def test_webui_at_prefixed_path(self, mock_args_api_prefix):
-        """Test WebUI assets are at the prefixed path.
-
-        When root_path is set, the WebUI is served under {root_path}{webui_path}
-        because FastAPI injects root_path into the ASGI scope.
-        """
+        """With root_path="/test-api" the WebUI lives at /test-api/webui/
+        because FastAPI injects root_path into the ASGI scope."""
         with patch("lightrag.api.lightrag_server.LightRAG") as mock_rag:
             mock_rag.return_value = MagicMock()
             from lightrag.api.lightrag_server import create_app
-            from lightrag.api.config import parse_args
 
-            original_argv = sys.argv.copy()
-            try:
-                sys.argv = [
-                    "lightrag-server",
-                    "--api-prefix",
-                    "/test-api",
-                    "--webui-path",
-                    "/test-webui",
-                ]
-                args = parse_args()
-                app = create_app(args)
-                client = TestClient(app)
+            app = create_app(mock_args_api_prefix)
+            client = TestClient(app)
 
-                # With root_path="/test-api" and webui_path="/test-webui",
-                # the WebUI is accessible at /test-api/test-webui/
-                # (root_path + webui_path, since FastAPI injects root_path)
-                response = client.get("/test-api/test-webui/")
-                assert response.status_code in [200, 307]
-            finally:
-                sys.argv = original_argv
+            response = client.get("/test-api/webui/")
+            assert response.status_code in [200, 307]
 
-    def test_webui_without_api_prefix(self):
-        """Test WebUI works with custom path when no API prefix is set."""
+    def test_webui_without_api_prefix(self, mock_args_no_prefix):
+        """Without an API prefix the WebUI is served at /webui/."""
         with patch("lightrag.api.lightrag_server.LightRAG") as mock_rag:
             mock_rag.return_value = MagicMock()
             from lightrag.api.lightrag_server import create_app
-            from lightrag.api.config import parse_args
 
-            original_argv = sys.argv.copy()
-            try:
-                sys.argv = ["lightrag-server", "--webui-path", "/test-webui"]
-                args = parse_args()
-                app = create_app(args)
-                client = TestClient(app)
+            app = create_app(mock_args_no_prefix)
+            client = TestClient(app)
 
-                response = client.get("/test-webui/")
-                assert response.status_code in [200, 307]
-            finally:
-                sys.argv = original_argv
-
-    def test_webui_not_at_default_path_with_custom(self, mock_args_api_prefix):
-        """Test /webui returns 404 when custom path is set."""
-        with patch("lightrag.api.lightrag_server.LightRAG") as mock_rag:
-            mock_rag.return_value = MagicMock()
-            from lightrag.api.lightrag_server import create_app
-            from lightrag.api.config import parse_args
-
-            original_argv = sys.argv.copy()
-            try:
-                sys.argv = [
-                    "lightrag-server",
-                    "--api-prefix",
-                    "/test-api",
-                    "--webui-path",
-                    "/test-webui",
-                ]
-                args = parse_args()
-                app = create_app(args)
-                client = TestClient(app)
-
-                # /webui should not exist when custom path is set
-                response = client.get("/webui/")
-                assert response.status_code == 404
-            finally:
-                sys.argv = original_argv
+            response = client.get("/webui/")
+            assert response.status_code in [200, 307]
 
 
 class TestEnvironmentVariables:
@@ -335,23 +283,10 @@ class TestEnvironmentVariables:
         finally:
             del os.environ["LIGHTRAG_API_PREFIX"]
 
-    def test_env_webui_path(self):
-        """Test LIGHTRAG_WEBUI_PATH environment variable."""
-        from lightrag.api.config import get_env_value
-
-        os.environ["LIGHTRAG_WEBUI_PATH"] = "unit-test-front/webui"
-        try:
-            value = get_env_value("LIGHTRAG_WEBUI_PATH", "/webui")
-            assert value == "unit-test-front/webui"
-        finally:
-            del os.environ["LIGHTRAG_WEBUI_PATH"]
-
-
 class TestPathNormalization:
-    """User input may contain trailing slashes, missing leading slash, or be
-    just '/'. create_app must canonicalize these before passing to FastAPI
-    (root_path) and Starlette (app.mount), neither of which accept arbitrary
-    strings."""
+    """User input for `--api-prefix` may contain trailing slashes, a missing
+    leading slash, or be just '/'. create_app must canonicalize these before
+    passing to FastAPI's `root_path`, which doesn't accept arbitrary strings."""
 
     def _build(self, *cli_args):
         # sys.argv must be the lightrag-server form *before* lightrag_server is
@@ -385,27 +320,6 @@ class TestPathNormalization:
     def test_api_prefix_missing_leading_slash_added(self):
         app = self._build("--api-prefix", "api/v1")
         assert app.root_path == "/api/v1"
-
-    def test_webui_path_trailing_slash_does_not_crash_mount(self):
-        """Starlette's app.mount asserts paths do not end in '/'. The
-        previous code passed user input through verbatim, which would crash
-        at startup if a user set LIGHTRAG_WEBUI_PATH=/webui/.
-
-        We assert that create_app() returns a working app (i.e. no
-        AssertionError raised inside Starlette) and that the WebUI is
-        reachable at the normalized path.
-        """
-        app = self._build("--webui-path", "/custom-ui/")
-        client = TestClient(app)
-        response = client.get("/custom-ui/")
-        assert response.status_code in (200, 307, 404)
-
-    def test_webui_path_slash_only_falls_back_to_default(self):
-        """`--webui-path /` is degenerate; must fall back to /webui."""
-        app = self._build("--webui-path", "/")
-        client = TestClient(app)
-        response = client.get("/webui/")
-        assert response.status_code in (200, 307, 404)
 
 
 class TestRuntimeConfigInjection:
@@ -468,9 +382,7 @@ class TestRuntimeConfigInjection:
         """With api_prefix=/site01, the injected script must carry both the
         api prefix and the composed webui prefix the browser will see."""
         self._stage_index_html(tmp_path)
-        app = self._build_app(
-            tmp_path, monkeypatch, "--api-prefix", "/site01", "--webui-path", "/webui"
-        )
+        app = self._build_app(tmp_path, monkeypatch, "--api-prefix", "/site01")
         client = TestClient(app)
 
         response = client.get("/site01/webui/")

--- a/tests/test_path_prefixes.py
+++ b/tests/test_path_prefixes.py
@@ -408,104 +408,136 @@ class TestPathNormalization:
         assert response.status_code in (200, 307, 404)
 
 
-class TestCheckWebuiBuildPrefix:
-    """Direct tests for check_webui_build_prefix.
+class TestRuntimeConfigInjection:
+    """End-to-end tests for the WebUI runtime-config injection.
 
-    These exercise an isolated index.html written to a temp dir, with the
-    function's baked-in path patched, so the test does not depend on
-    whatever prefix the committed `lightrag/api/webui/` happens to carry.
+    The browser-visible URL prefixes are no longer baked into the bundle.
+    Instead, the server replaces a placeholder comment in index.html with
+    a `<script>window.__LIGHTRAG_CONFIG__ = {...}</script>` snippet on
+    every HTML response, so one build can serve any reverse-proxy mount.
+
+    These tests stage a minimal index.html in a tmp dir, patch
+    `lightrag_server.__file__` so both `check_frontend_build()` and the
+    static-files mount resolve to it, then drive the app via TestClient
+    and assert that the body contains the expected injected JSON.
     """
 
-    def _stage_index_html(self, tmp_path, baked_prefix):
-        """Stage a minimal index.html under tmp_path/webui/ mimicking Vite
-        output. The check function reads `Path(__file__).parent / "webui"
-        / "index.html"`, so callers must also patch `lightrag_server.__file__`
-        to point inside tmp_path."""
-        prefix_no_slash = baked_prefix.rstrip("/")
+    PLACEHOLDER = "<!-- __LIGHTRAG_RUNTIME_CONFIG__ -->"
+
+    def _stage_index_html(self, tmp_path, *, with_placeholder=True):
+        """Mirror what Vite emits: a tiny index.html with the runtime-config
+        placeholder in <head> plus a hashed asset reference.
+
+        with_placeholder=False simulates a stale build that pre-dates this
+        feature — the server should serve it untouched, not crash.
+        """
         webui_dir = tmp_path / "webui"
         webui_dir.mkdir()
+        placeholder = self.PLACEHOLDER if with_placeholder else ""
         (webui_dir / "index.html").write_text(
             "<!doctype html><html><head>"
-            f'<script type="module" crossorigin src="{prefix_no_slash}/assets/index-X.js"></script>'
-            f'<link rel="stylesheet" href="{prefix_no_slash}/assets/index-X.css">'
-            "</head><body></body></html>",
+            f"{placeholder}"
+            '<script type="module" crossorigin src="./assets/index-X.js"></script>'
+            '<link rel="stylesheet" href="./assets/index-X.css">'
+            "</head><body><div id=root></div></body></html>",
             encoding="utf-8",
         )
 
-    def test_match_emits_info_log_and_no_warning(self, tmp_path, monkeypatch, caplog):
-        import logging
-
-        # Importing lightrag.api.lightrag_server eagerly evaluates
-        # `global_args.whitelist_paths` in utils_api at module top, which
-        # calls parse_args() against the current sys.argv. Under pytest
-        # that's the pytest invocation argv → argparse exits 2. Force a
-        # benign argv before the (potentially-fresh) module import.
-        monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+    def _build_app(self, tmp_path, monkeypatch, *cli_args):
+        # Force benign argv before the (potentially fresh) module import —
+        # see TestPathNormalization._build for the rationale.
+        monkeypatch.setattr(sys, "argv", ["lightrag-server", *cli_args])
+        from lightrag.api.config import parse_args
         from lightrag.api import lightrag_server
+        from lightrag.api.lightrag_server import create_app
 
-        self._stage_index_html(tmp_path, "/site01/webui/")
+        # Redirect both check_frontend_build() and the StaticFiles mount to
+        # our staged tmp directory.
         monkeypatch.setattr(
             lightrag_server, "__file__", str(tmp_path / "lightrag_server.py")
         )
 
-        # The lightrag logger has propagate=False; caplog attaches its
-        # handler at the root, so without re-enabling propagation we can't
-        # observe records here. Restore on teardown via monkeypatch.
-        lightrag_logger = logging.getLogger("lightrag")
-        monkeypatch.setattr(lightrag_logger, "propagate", True)
-        with caplog.at_level(logging.INFO, logger="lightrag"):
-            lightrag_server.check_webui_build_prefix(
-                api_prefix="/site01", webui_path="/webui"
-            )
+        args = parse_args()
+        with patch("lightrag.api.lightrag_server.LightRAG") as mock_rag:
+            mock_rag.return_value = MagicMock()
+            return create_app(args)
 
-        # Match path: only an info log, no warning record.
-        assert "matches server config" in caplog.text
-        assert not any(
-            r.levelno >= logging.WARNING for r in caplog.records
-        ), "match path must not emit a warning"
-
-    def test_mismatch_emits_warning_with_rebuild_command(
-        self, tmp_path, monkeypatch, caplog
+    def test_injection_populates_window_config_with_prefix(
+        self, tmp_path, monkeypatch
     ):
-        import logging
+        """With api_prefix=/site01, the injected script must carry both the
+        api prefix and the composed webui prefix the browser will see."""
+        self._stage_index_html(tmp_path)
+        app = self._build_app(
+            tmp_path, monkeypatch, "--api-prefix", "/site01", "--webui-path", "/webui"
+        )
+        client = TestClient(app)
 
-        monkeypatch.setattr(sys, "argv", ["lightrag-server"])
-        from lightrag.api import lightrag_server
+        response = client.get("/site01/webui/")
+        assert response.status_code == 200
+        body = response.text
 
-        # Build was made with /webui/ but admin reconfigures the server
-        # for site01 — classic "reused image, new prefix" failure mode.
-        self._stage_index_html(tmp_path, "/webui/")
-        monkeypatch.setattr(
-            lightrag_server, "__file__", str(tmp_path / "lightrag_server.py")
+        # Placeholder must be gone and replaced with the runtime config.
+        assert self.PLACEHOLDER not in body
+        assert "window.__LIGHTRAG_CONFIG__" in body
+        assert '"apiPrefix": "/site01"' in body or '"apiPrefix":"/site01"' in body
+        assert (
+            '"webuiPrefix": "/site01/webui/"' in body
+            or '"webuiPrefix":"/site01/webui/"' in body
         )
 
-        lightrag_logger = logging.getLogger("lightrag")
-        monkeypatch.setattr(lightrag_logger, "propagate", True)
-        with caplog.at_level(logging.WARNING, logger="lightrag"):
-            lightrag_server.check_webui_build_prefix(
-                api_prefix="/site01", webui_path="/webui"
-            )
+    def test_injection_default_prefixes_when_unconfigured(self, tmp_path, monkeypatch):
+        """No CLI flags → empty api prefix and the default webui mount.
+        The injected JSON must reflect this so the SPA falls through to
+        same-origin requests."""
+        self._stage_index_html(tmp_path)
+        app = self._build_app(tmp_path, monkeypatch)
+        client = TestClient(app)
 
-        warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
-        assert warning_records, "mismatch must emit a WARNING-level record"
-        msg = warning_records[0].getMessage()
-        # Show the actual baked vs expected values so admin can act.
-        assert "/webui/" in msg
-        assert "/site01/webui/" in msg
-        # Suggest a runnable rebuild command with the corrected env vars.
-        assert "VITE_WEBUI_PREFIX=/site01/webui/" in msg
-        assert "VITE_API_PREFIX=/site01" in msg
+        response = client.get("/webui/")
+        assert response.status_code == 200
+        body = response.text
 
-    def test_missing_build_does_not_raise(self, tmp_path, monkeypatch):
-        """When index.html is absent (no build yet), the function returns
-        silently — `check_frontend_build` already emits the build warning."""
-        monkeypatch.setattr(sys, "argv", ["lightrag-server"])
-        from lightrag.api import lightrag_server
+        assert '"apiPrefix": ""' in body or '"apiPrefix":""' in body
+        assert '"webuiPrefix": "/webui/"' in body or '"webuiPrefix":"/webui/"' in body
 
-        monkeypatch.setattr(
-            lightrag_server, "__file__", str(tmp_path / "lightrag_server.py")
-        )
-        # No webui/ subdir under tmp_path — index.html does not exist.
-        lightrag_server.check_webui_build_prefix(
-            api_prefix="/site01", webui_path="/webui"
-        )
+    def test_missing_placeholder_serves_original_html(self, tmp_path, monkeypatch):
+        """Older builds without the placeholder must still serve cleanly —
+        no 500, no partial replacement, just the original HTML. Avoids
+        breaking anyone whose pre-built bundle is in use during an upgrade."""
+        self._stage_index_html(tmp_path, with_placeholder=False)
+        app = self._build_app(tmp_path, monkeypatch)
+        client = TestClient(app)
+
+        response = client.get("/webui/")
+        assert response.status_code == 200
+        # No placeholder was present, so no injected script either.
+        assert "window.__LIGHTRAG_CONFIG__" not in response.text
+
+    def test_injection_idempotent_across_requests(self, tmp_path, monkeypatch):
+        """Each request reads the file fresh; the placeholder must be
+        present in the *file* even after replies (we don't mutate it)."""
+        self._stage_index_html(tmp_path)
+        app = self._build_app(tmp_path, monkeypatch, "--api-prefix", "/abc")
+        client = TestClient(app)
+
+        first = client.get("/abc/webui/").text
+        second = client.get("/abc/webui/").text
+        assert first == second
+        # Source file untouched.
+        on_disk = (tmp_path / "webui" / "index.html").read_text(encoding="utf-8")
+        assert self.PLACEHOLDER in on_disk
+
+    def test_html_response_keeps_no_cache_headers(self, tmp_path, monkeypatch):
+        """Injection must not regress the existing no-cache behaviour for
+        HTML — otherwise an updated runtime config could be cached client-
+        side and never picked up."""
+        self._stage_index_html(tmp_path)
+        app = self._build_app(tmp_path, monkeypatch, "--api-prefix", "/x")
+        client = TestClient(app)
+
+        response = client.get("/x/webui/")
+        assert response.status_code == 200
+        cache_control = response.headers.get("cache-control", "")
+        assert "no-cache" in cache_control
+        assert "no-store" in cache_control

--- a/tests/test_path_prefixes.py
+++ b/tests/test_path_prefixes.py
@@ -283,6 +283,7 @@ class TestEnvironmentVariables:
         finally:
             del os.environ["LIGHTRAG_API_PREFIX"]
 
+
 class TestPathNormalization:
     """User input for `--api-prefix` may contain trailing slashes, a missing
     leading slash, or be just '/'. create_app must canonicalize these before
@@ -376,9 +377,7 @@ class TestRuntimeConfigInjection:
             mock_rag.return_value = MagicMock()
             return create_app(args)
 
-    def test_injection_populates_window_config_with_prefix(
-        self, tmp_path, monkeypatch
-    ):
+    def test_injection_populates_window_config_with_prefix(self, tmp_path, monkeypatch):
         """With api_prefix=/site01, the injected script must carry both the
         api prefix and the composed webui prefix the browser will see."""
         self._stage_index_html(tmp_path)


### PR DESCRIPTION
## Summary

- The browser-visible URL prefix is no longer baked into the WebUI bundle. The FastAPI server replaces a placeholder comment in `index.html` with `<script>window.__LIGHTRAG_CONFIG__ = ...</script>` on every HTML response, computed from `LIGHTRAG_API_PREFIX`.
- Asset URLs are emitted as relative paths (`./assets/...`) so a single Vite bundle works under any reverse-proxy mount point — true "build once, deploy many" multi-site deployment from a single Docker image.
- Operator config surface shrunk to **one** variable per side: `LIGHTRAG_API_PREFIX` on the backend, `VITE_DEV_API_PREFIX` for dev simulation. `LIGHTRAG_WEBUI_PATH`, `VITE_API_PREFIX`, `VITE_WEBUI_PREFIX`, and `VITE_DEV_WEBUI_PREFIX` are gone; the WebUI mount is hardcoded at `/webui`.
- Removed `check_webui_build_prefix` and its startup banner — there is no longer any baked prefix to mismatch.

## Backend

- `SmartStaticFiles` (in `lightrag/api/lightrag_server.py`) intercepts HTML responses, reads the file fresh, and replaces `<!-- __LIGHTRAG_RUNTIME_CONFIG__ -->` with the JSON-encoded runtime config (with `</` → `<\/` escaping for inline-script safety). Cache headers and content-type behavior preserved.
- New `WEBUI_PATH = "/webui"` module constant; `--webui-path` CLI arg and `LIGHTRAG_WEBUI_PATH` env var removed.
- `_normalize_path` simplified to `_normalize_api_prefix` (only one path to normalize now).
- `check_webui_build_prefix` deleted along with its startup banner.

## Frontend

- `src/lib/runtimeConfig.ts` is the single read point for `window.__LIGHTRAG_CONFIG__`.
- `src/lib/constants.ts` resolves the API base URL and webui prefix at module load via the runtime values.
- `vite.config.ts`:
  - `base: './'` — relative asset URLs.
  - New `transformIndexHtml` plugin (`apply: 'serve'`) injects the same `window.__LIGHTRAG_CONFIG__` in dev from `VITE_DEV_API_PREFIX`. The matching `webuiPrefix` is derived as `${VITE_DEV_API_PREFIX}/webui/` automatically.
  - `server.proxy` keys are prefixed automatically; requests forwarded verbatim (no rewrite) so backend's `root_path` matches natively.
- `index.html` carries the placeholder comment in `<head>`.
- `src/vite-env.d.ts`: dropped `VITE_API_PREFIX` / `VITE_WEBUI_PREFIX` / `VITE_DEV_WEBUI_PREFIX`; only `VITE_DEV_API_PREFIX` remains.

## Docs / samples

- **New** `docs/MultiSiteDeployment.md` — end-to-end multi-site guide: how injection works (sequence diagram), nginx + docker-compose example for two sites behind one host, single-image Docker recipe, Kubernetes Ingress equivalent, three concrete dev-mode scenarios (no prefix / simulate prefix without nginx / hit a remote backend through its production nginx), decision matrix, migration notes, troubleshooting. Prominent callout that **all dev scenarios access `http://localhost:5173/`** regardless of any prefix configuration.
- `env.example`: replaced the verbose "per-site rebuild required" caveat with a short pointer to the docs and a single `LIGHTRAG_API_PREFIX` example.
- `lightrag_webui/env.local.sample`: documents the runtime mechanism, points to the new guide.
- `lightrag_webui/env.development.smaple`: documents the optional `VITE_DEV_API_PREFIX` for dev-time multi-site simulation.

## Tests (`tests/test_path_prefixes.py`)

- **Added** `TestRuntimeConfigInjection` — five new tests exercising the full injection flow via `TestClient`: prefix present, no prefix, missing placeholder (older builds still work), idempotency across requests, and cache-header preservation.
- **Removed** five obsolete tests that exercised `--webui-path` configurability (premise no longer exists): `test_webui_at_prefixed_path` / `test_webui_without_api_prefix` (rewritten for the fixed `/webui`), `test_webui_not_at_default_path_with_custom`, `test_webui_path_trailing_slash_does_not_crash_mount`, `test_webui_path_slash_only_falls_back_to_default`, plus `test_env_webui_path`.
- All other API-prefix normalization, `root_path`, OpenAPI, and route-matching tests retained.

## Test plan

- [x] `python -m pytest tests` — **853 passed, 1 skipped, 31 deselected** (19 prefix tests, all green)
- [x] `bun test` (in `lightrag_webui/`) — 14/14
- [x] `bun run build` — emits `<!-- __LIGHTRAG_RUNTIME_CONFIG__ -->` placeholder, relative asset URLs, **no** baked `VITE_*_PREFIX`, `LIGHTRAG_WEBUI_PATH`, or `/site01` strings in any chunk
- [x] `bun run lint` — clean
- [x] `ruff check` — clean
- [ ] Manual e2e: spin up the server with `LIGHTRAG_API_PREFIX=/site01` behind a reverse proxy, confirm injected `window.__LIGHTRAG_CONFIG__` and that all in-app navigation / asset loading works under the prefix
- [ ] Manual dev parity: run `bun run dev` with `VITE_DEV_API_PREFIX=/site01` against a backend with `LIGHTRAG_API_PREFIX=/site01`, confirm proxy forwards correctly and HMR works

## Migration notes for downstream users

- Stop setting `VITE_API_PREFIX` / `VITE_WEBUI_PREFIX` in build scripts — they are ignored now.
- Stop setting `LIGHTRAG_WEBUI_PATH` and `--webui-path`. The mount is fixed at `/webui`. The version that introduced these has not been released, so no public users are affected.
- Per-site Docker images are no longer needed; a single image works for every prefix.
- The `check_webui_build_prefix` startup banner is gone.

## End-result config surface

| Where | Variable | Purpose |
| --- | --- | --- |
| Backend | `LIGHTRAG_API_PREFIX` | Reverse-proxy site prefix; passed to FastAPI as `root_path`. |
| Frontend dev | `VITE_DEV_API_PREFIX` | Optional, simulates the production prefix in `bun run dev`. |
| Frontend dev | `VITE_BACKEND_URL` | Where the dev proxy forwards (existing). |

That's it. The `webuiPrefix` injected into `window.__LIGHTRAG_CONFIG__` is always `<api_prefix>/webui/` — never user-set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)