### PR TITLE
feat(openai): inject X-DashScope-Workspace header from DASHSCOPE_WORKSPACE_ID env

### DIFF
--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -169,6 +169,9 @@ def create_openai_async_client(
             "User-Agent": f"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_8) LightRAG/{__api_version__}",
             "Content-Type": "application/json",
         }
+        dashscope_workspace_id = os.getenv("DASHSCOPE_WORKSPACE_ID", "").strip()
+        if dashscope_workspace_id:
+            default_headers["X-DashScope-Workspace"] = dashscope_workspace_id
 
         if client_configs is None:
             client_configs = {}


### PR DESCRIPTION
## What this changes

`lightrag/llm/openai.py` reads an optional `DASHSCOPE_WORKSPACE_ID` env var and, when set, adds it to the OpenAI client's `default_headers` as `X-DashScope-Workspace`.

```diff
@@ -169,6 +169,9 @@
             "User-Agent": f"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_8) LightRAG/{__api_version__}",
             "Content-Type": "application/json",
         }
+        dashscope_workspace_id = os.getenv("DASHSCOPE_WORKSPACE_ID", "").strip()
+        if dashscope_workspace_id:
+            default_headers["X-DashScope-Workspace"] = dashscope_workspace_id

         if client_configs is None:
             client_configs = {}
```

Three lines. No other changes. No new dependencies. No behavior change when the env var is unset (default for everyone who doesn't use DashScope-Intl).

## Why

Workspace-scoped Alibaba DashScope-Intl API keys require the `X-DashScope-Workspace` header on every request. The OpenAI-compatible endpoint at `https://dashscope-intl.aliyuncs.com/compatible-mode/v1` does **not** surface this requirement: it silently returns `Model.AccessDenied` when the header is missing, even when the API key itself is valid for the workspace.

Without this patch, anyone using LightRAG with a workspace-scoped DashScope-Intl key (or any DashScope key from a non-default workspace) sees their queries fail with `Model.AccessDenied` and has to monkey-patch `lightrag/llm/openai.py` themselves to add the header. We've been carrying this exact patch in our production deployment since 2026-05-06 (Singapore region, workspace `ws-cixsy***********`); seems worth upstreaming so future LightRAG users don't have to repeat the monkey-patch.

The patch is **opt-in by env var** — `DASHSCOPE_WORKSPACE_ID` is read from `os.getenv()`, and the header is only added when the value is non-empty after `.strip()`. Existing LightRAG installs without that env var see no behavior change at all.

## Tested in production

Live in production at our deployment (Cloudflare Worker → LightRAG on Fly.io Singapore → DashScope-Intl with model `qwen3.5-flash` + embedding `text-embedding-v4`) since 2026-05-06. Without the patch, every single `/query` call returned `Model.AccessDenied`. With the patch, the workspace key authenticates correctly and queries return real KG-grounded answers (192-doc corpus at the time of testing, 5120 entities, 12060 relations).

## How to verify

```bash
# Without the env var — header NOT added (existing behavior, unchanged)
unset DASHSCOPE_WORKSPACE_ID
python -c "from lightrag.llm.openai import openai_complete_if_cache  # imports clean"

# With the env var — header gets injected
export DASHSCOPE_WORKSPACE_ID=ws-yourworkspaceid
# Set up a workspace-scoped DashScope-Intl key in DASHSCOPE_API_KEY.
# Run any LightRAG query against the .aliyuncs.com endpoint. Should succeed
# instead of Model.AccessDenied.
```

A network-mocked unit test could assert the header is present in the OpenAI client's `default_headers` when the env var is set, and absent when unset — happy to add that if maintainers prefer.

Thanks!
