### PR TITLE
fix(pipeline): align Docling parse protocol with docling-serve API

### DIFF
--- a/env.example
+++ b/env.example
@@ -280,7 +280,12 @@ ENTITY_EXTRACTION_USE_JSON=true
 # DOCLING_ID_FIELD=task_id
 # DOCLING_STATUS_FIELD=task_status
 # DOCLING_RESULT_URL_FIELD=result_url
-# DOCLING_CONTENT_FIELD=content
+### docling-serve's /v1/result/{task_id} returns
+### {"document": {"md_content": "...", "text_content": "...", "html_content": "...",
+### "json_content": {...}, "doctags_content": "..."}, ...}.
+### The default extracts ``document.md_content``; switch to ``document.text_content``
+### (plain text) or ``document.html_content`` for other formats.
+# DOCLING_CONTENT_FIELD=document.md_content
 # DOCLING_SUCCESS_VALUES=success
 # DOCLING_FAILED_VALUES=failure
 # DOCLING_POLL_INTERVAL_SECONDS=2

--- a/env.example
+++ b/env.example
@@ -256,24 +256,31 @@ ENTITY_EXTRACTION_USE_JSON=true
 # MINERU_ENDPOINT=http://localhost:8000/api/v1/task
 # MINERU_POLL_ENDPOINT=http://localhost:8000/api/v1/task/{trace_id}
 # MINERU_POLL_METHOD=GET
+# MINERU_UPLOAD_FIELD_NAME=file
 # MINERU_ID_FIELD=trace_id
 # MINERU_STATUS_FIELD=status
 # MINERU_RESULT_URL_FIELD=result_url
+# MINERU_RESULT_URL_TEMPLATE=
 # MINERU_CONTENT_FIELD=content
 # MINERU_SUCCESS_VALUES=done,success,completed
 # MINERU_FAILED_VALUES=failed,error,cancelled
 # MINERU_POLL_INTERVAL_SECONDS=2
 # MINERU_MAX_POLLS=180
 
-# DOCLING_ENDPOINT=http://localhost:8081/v1/convert/file/async
-# DOCLING_POLL_ENDPOINT=http://localhost:8081/v1/convert/file/async/{task_id}
+### Docling-serve defaults below match the official API spec
+### (multipart field "files", task_status enum, /v1/status/poll/{task_id},
+### /v1/result/{task_id}). Override only if your deployment differs.
+# DOCLING_ENDPOINT=http://localhost:5001/v1/convert/file/async
+# DOCLING_POLL_ENDPOINT=http://localhost:5001/v1/status/poll/{task_id}
+# DOCLING_RESULT_URL_TEMPLATE=http://localhost:5001/v1/result/{task_id}
 # DOCLING_POLL_METHOD=GET
+# DOCLING_UPLOAD_FIELD_NAME=files
 # DOCLING_ID_FIELD=task_id
-# DOCLING_STATUS_FIELD=status
+# DOCLING_STATUS_FIELD=task_status
 # DOCLING_RESULT_URL_FIELD=result_url
 # DOCLING_CONTENT_FIELD=content
-# DOCLING_SUCCESS_VALUES=done,success,completed
-# DOCLING_FAILED_VALUES=failed,error,cancelled
+# DOCLING_SUCCESS_VALUES=success,done,completed
+# DOCLING_FAILED_VALUES=failure,failed,error
 # DOCLING_POLL_INTERVAL_SECONDS=2
 # DOCLING_MAX_POLLS=180
 

--- a/env.example
+++ b/env.example
@@ -268,8 +268,10 @@ ENTITY_EXTRACTION_USE_JSON=true
 # MINERU_MAX_POLLS=180
 
 ### Docling-serve defaults below match the official API spec
-### (multipart field "files", task_status enum, /v1/status/poll/{task_id},
-### /v1/result/{task_id}). Override only if your deployment differs.
+### (multipart field "files", task_status enum: pending|started|success|failure,
+### /v1/status/poll/{task_id}, /v1/result/{task_id}). Override only if your
+### deployment differs. The code accepts a broader set of success/failed
+### aliases for resilience; the values shown here are the spec-canonical ones.
 # DOCLING_ENDPOINT=http://localhost:5001/v1/convert/file/async
 # DOCLING_POLL_ENDPOINT=http://localhost:5001/v1/status/poll/{task_id}
 # DOCLING_RESULT_URL_TEMPLATE=http://localhost:5001/v1/result/{task_id}
@@ -279,8 +281,8 @@ ENTITY_EXTRACTION_USE_JSON=true
 # DOCLING_STATUS_FIELD=task_status
 # DOCLING_RESULT_URL_FIELD=result_url
 # DOCLING_CONTENT_FIELD=content
-# DOCLING_SUCCESS_VALUES=success,done,completed
-# DOCLING_FAILED_VALUES=failure,failed,error
+# DOCLING_SUCCESS_VALUES=success
+# DOCLING_FAILED_VALUES=failure
 # DOCLING_POLL_INTERVAL_SECONDS=2
 # DOCLING_MAX_POLLS=180
 

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -2146,13 +2146,14 @@ class _PipelineMixin:
     async def parse_docling(
         self, doc_id: str, file_path: str, content_data: dict[str, Any]
     ) -> dict[str, Any]:
-        endpoint = os.getenv("DOCLING_ENDPOINT", "").strip()
+        endpoint = os.getenv("DOCLING_ENDPOINT", "").strip().rstrip("/")
         if not endpoint:
             raise ValueError("DOCLING_ENDPOINT is required for Docling parsing")
         # docling-serve mounts paths under a common base. Derive defaults for
         # poll/result paths from the upload endpoint when the user only sets
         # DOCLING_ENDPOINT, so out-of-the-box config matches the real spec
-        # (https://docling-project.github.io/docling-serve/usage/).
+        # (https://docling-project.github.io/docling-serve/usage/). The
+        # rstrip above makes the suffix check tolerant of trailing slashes.
         upload_suffix = "/v1/convert/file/async"
         if endpoint.endswith(upload_suffix):
             base = endpoint[: -len(upload_suffix)]
@@ -2243,7 +2244,12 @@ class _PipelineMixin:
         result_url_field = str(protocol.get("result_url_field", "result_url"))
         result_url_tpl = str(protocol.get("result_url_template", "")).strip()
         content_field = str(protocol.get("content_field", "content"))
-        upload_field_name = str(protocol.get("upload_field_name", "file"))
+        # Normalize: an explicit empty string or whitespace-only env value
+        # would otherwise produce an invalid multipart key. Fall back to the
+        # historical default rather than letting the upload fail obscurely.
+        upload_field_name = (
+            str(protocol.get("upload_field_name") or "").strip() or "file"
+        )
         poll_url_tpl = str(protocol.get("poll_url_template", "")).strip()
         poll_method = str(protocol.get("poll_method", "GET")).upper()
         poll_interval = float(protocol.get("poll_interval_seconds", 2.0))

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -2173,7 +2173,14 @@ class _PipelineMixin:
             "result_url_template": os.getenv(
                 "DOCLING_RESULT_URL_TEMPLATE", default_result_tpl
             ),
-            "content_field": os.getenv("DOCLING_CONTENT_FIELD", "content"),
+            # docling-serve's /v1/result/{task_id} returns a wrapper JSON:
+            # {"document": {"md_content": "...", "text_content": "...", ...}}.
+            # Default to ``document.md_content`` so the parsed markdown is
+            # extracted; switch to ``document.text_content`` (plain text) or
+            # ``document.html_content`` via this env var for other formats.
+            "content_field": os.getenv(
+                "DOCLING_CONTENT_FIELD", "document.md_content"
+            ),
             "success_values": os.getenv(
                 "DOCLING_SUCCESS_VALUES",
                 "done,success,succeeded,completed,finished",
@@ -2312,7 +2319,23 @@ class _PipelineMixin:
                     if result_url:
                         dl = await client.get(str(result_url))
                         dl.raise_for_status()
-                        return dl.text
+                        raw_text = dl.text
+                        # docling-serve's /v1/result/{task_id} returns a JSON
+                        # wrapper ({"document": {"md_content": ...}, ...}),
+                        # not the parsed body. Extract via content_field when
+                        # the response parses as JSON; otherwise fall through
+                        # to the raw text (plain-text result endpoints, e.g.
+                        # the test mock and some MinerU deployments).
+                        if content_field:
+                            try:
+                                parsed = json.loads(raw_text)
+                            except (ValueError, TypeError):
+                                parsed = None
+                            if isinstance(parsed, (dict, list)):
+                                extracted = get_by_path(parsed, content_field)
+                                if isinstance(extracted, str) and extracted:
+                                    return extracted
+                        return raw_text
                     content_val = get_by_path(poll_payload, content_field)
                     return str(content_val) if content_val else None
                 if status_val in failed_values:

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -2084,6 +2084,7 @@ class _PipelineMixin:
             raise ValueError("MINERU_ENDPOINT is required for MinerU parsing")
         protocol = {
             "upload_url": endpoint,
+            "upload_field_name": os.getenv("MINERU_UPLOAD_FIELD_NAME", "file"),
             "poll_url_template": os.getenv(
                 "MINERU_POLL_ENDPOINT",
                 endpoint + "/{trace_id}",
@@ -2092,6 +2093,7 @@ class _PipelineMixin:
             "id_field": os.getenv("MINERU_ID_FIELD", "trace_id"),
             "status_field": os.getenv("MINERU_STATUS_FIELD", "status"),
             "result_url_field": os.getenv("MINERU_RESULT_URL_FIELD", "result_url"),
+            "result_url_template": os.getenv("MINERU_RESULT_URL_TEMPLATE", ""),
             "content_field": os.getenv("MINERU_CONTENT_FIELD", "content"),
             "success_values": os.getenv(
                 "MINERU_SUCCESS_VALUES",
@@ -2147,22 +2149,37 @@ class _PipelineMixin:
         endpoint = os.getenv("DOCLING_ENDPOINT", "").strip()
         if not endpoint:
             raise ValueError("DOCLING_ENDPOINT is required for Docling parsing")
+        # docling-serve mounts paths under a common base. Derive defaults for
+        # poll/result paths from the upload endpoint when the user only sets
+        # DOCLING_ENDPOINT, so out-of-the-box config matches the real spec
+        # (https://docling-project.github.io/docling-serve/usage/).
+        upload_suffix = "/v1/convert/file/async"
+        if endpoint.endswith(upload_suffix):
+            base = endpoint[: -len(upload_suffix)]
+            default_poll = base + "/v1/status/poll/{task_id}"
+            default_result_tpl = base + "/v1/result/{task_id}"
+        else:
+            default_poll = endpoint + "/{task_id}"
+            default_result_tpl = ""
         protocol = {
             "upload_url": endpoint,
-            "poll_url_template": os.getenv(
-                "DOCLING_POLL_ENDPOINT",
-                endpoint + "/{task_id}",
-            ),
+            "upload_field_name": os.getenv("DOCLING_UPLOAD_FIELD_NAME", "files"),
+            "poll_url_template": os.getenv("DOCLING_POLL_ENDPOINT", default_poll),
             "poll_method": os.getenv("DOCLING_POLL_METHOD", "GET"),
             "id_field": os.getenv("DOCLING_ID_FIELD", "task_id"),
-            "status_field": os.getenv("DOCLING_STATUS_FIELD", "status"),
+            "status_field": os.getenv("DOCLING_STATUS_FIELD", "task_status"),
             "result_url_field": os.getenv("DOCLING_RESULT_URL_FIELD", "result_url"),
+            "result_url_template": os.getenv(
+                "DOCLING_RESULT_URL_TEMPLATE", default_result_tpl
+            ),
             "content_field": os.getenv("DOCLING_CONTENT_FIELD", "content"),
             "success_values": os.getenv(
                 "DOCLING_SUCCESS_VALUES",
                 "done,success,succeeded,completed,finished",
             ),
-            "failed_values": os.getenv("DOCLING_FAILED_VALUES", "failed,error"),
+            "failed_values": os.getenv(
+                "DOCLING_FAILED_VALUES", "failed,failure,error"
+            ),
             "poll_interval_seconds": float(
                 os.getenv("DOCLING_POLL_INTERVAL_SECONDS", "2")
             ),
@@ -2224,7 +2241,9 @@ class _PipelineMixin:
         id_field = str(protocol.get("id_field", "id"))
         status_field = str(protocol.get("status_field", "status"))
         result_url_field = str(protocol.get("result_url_field", "result_url"))
+        result_url_tpl = str(protocol.get("result_url_template", "")).strip()
         content_field = str(protocol.get("content_field", "content"))
+        upload_field_name = str(protocol.get("upload_field_name", "file"))
         poll_url_tpl = str(protocol.get("poll_url_template", "")).strip()
         poll_method = str(protocol.get("poll_method", "GET")).upper()
         poll_interval = float(protocol.get("poll_interval_seconds", 2.0))
@@ -2248,7 +2267,8 @@ class _PipelineMixin:
         async with httpx.AsyncClient(timeout=timeout) as client:
             with open(file_path, "rb") as f:
                 resp = await client.post(
-                    upload_url, files={"file": (Path(file_path).name, f)}
+                    upload_url,
+                    files={upload_field_name: (Path(file_path).name, f)},
                 )
             if resp.status_code >= 400:
                 raise RuntimeError(
@@ -2279,6 +2299,10 @@ class _PipelineMixin:
 
                 if status_val in success_values:
                     result_url = get_by_path(poll_payload, result_url_field)
+                    if not result_url and result_url_tpl:
+                        result_url = result_url_tpl.format(
+                            task_id=task_id, trace_id=task_id, id=task_id
+                        )
                     if result_url:
                         dl = await client.get(str(result_url))
                         dl.raise_for_status()

--- a/tests/test_docling_serve_integration.py
+++ b/tests/test_docling_serve_integration.py
@@ -1,0 +1,348 @@
+"""Real-container integration test for the docling-serve fix in PR #3045.
+
+The offline tests in ``test_protocol_parse_service.py`` mock the docling-serve
+contract per the upstream spec (https://docling-project.github.io/docling-serve/usage/).
+This file goes one step further: it spins up an actual ``docling-serve`` Docker
+container, pushes a freshly-generated PDF through the full
+``upload → poll → result`` cycle, and asserts that ``parse_docling`` lands the
+extracted Markdown — not the raw JSON wrapper — as the document body.
+
+Skipped by default. Activate with::
+
+    pytest tests/test_docling_serve_integration.py --run-integration
+
+Skips cleanly (rather than failing) when:
+  * Docker is unavailable or the daemon is unreachable.
+  * The ``quay.io/docling-project/docling-serve-cpu:latest`` image cannot be
+    pulled or already-pulled within ``IMAGE_PULL_TIMEOUT``.
+  * ``fpdf2`` is missing (used to generate a parseable PDF on the fly).
+  * The container fails to become ready within ``CONTAINER_READY_TIMEOUT``.
+
+Tunables (env vars, with sensible defaults):
+  * ``LIGHTRAG_DOCLING_IMAGE``    — image ref. Default ``docling-serve-cpu:latest``.
+  * ``LIGHTRAG_DOCLING_PULL_S``   — image pull deadline. Default 600s.
+  * ``LIGHTRAG_DOCLING_READY_S``  — readiness deadline. Default 300s.
+  * ``LIGHTRAG_DOCLING_PARSE_S``  — full parse deadline. Default 600s.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import socket
+import subprocess
+import time
+from pathlib import Path
+from typing import Iterator
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG
+from lightrag.utils import EmbeddingFunc, Tokenizer
+
+
+pytestmark = pytest.mark.integration
+
+
+# --------------------------------------------------------------------------
+# Skip gates
+# --------------------------------------------------------------------------
+
+
+DEFAULT_IMAGE = os.getenv(
+    "LIGHTRAG_DOCLING_IMAGE", "quay.io/docling-project/docling-serve-cpu:latest"
+)
+IMAGE_PULL_TIMEOUT = float(os.getenv("LIGHTRAG_DOCLING_PULL_S", "600"))
+CONTAINER_READY_TIMEOUT = float(os.getenv("LIGHTRAG_DOCLING_READY_S", "300"))
+PARSE_TIMEOUT = float(os.getenv("LIGHTRAG_DOCLING_PARSE_S", "600"))
+
+
+def _docker_available() -> bool:
+    """Return True iff the docker CLI is on PATH and the daemon responds."""
+    if shutil.which("docker") is None:
+        return False
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+        )
+        return result.returncode == 0
+    except (subprocess.SubprocessError, OSError):
+        return False
+
+
+def _ensure_image(image: str, deadline: float) -> bool:
+    """Make ``image`` available locally. Returns False on pull failure / timeout.
+
+    Already-cached images short-circuit the pull. Network failures are
+    converted to a graceful skip rather than a test error so CI without
+    egress to quay.io still passes the offline suite.
+    """
+    inspect = subprocess.run(
+        ["docker", "image", "inspect", image],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    if inspect.returncode == 0:
+        return True
+
+    try:
+        pull = subprocess.run(
+            ["docker", "pull", image],
+            timeout=deadline,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+    except subprocess.TimeoutExpired:
+        return False
+    return pull.returncode == 0
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+# --------------------------------------------------------------------------
+# Container lifecycle
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def docling_container() -> Iterator[dict]:
+    """Start ``docling-serve-cpu``, yield its base URL, and clean up on exit.
+
+    Skips the test (rather than failing) when docker is unavailable or the
+    image cannot be obtained — network outages and missing daemons are
+    environmental, not regressions in the code under test.
+    """
+
+    if not _docker_available():
+        pytest.skip("docker daemon not reachable — skipping real-container test")
+
+    if not _ensure_image(DEFAULT_IMAGE, IMAGE_PULL_TIMEOUT):
+        pytest.skip(
+            f"unable to pull {DEFAULT_IMAGE} within {IMAGE_PULL_TIMEOUT:.0f}s "
+            "(no network or registry unavailable)"
+        )
+
+    httpx = pytest.importorskip("httpx")
+
+    name = f"lightrag-docling-it-{int(time.time())}"
+    port = _free_port()
+    run_args = [
+        "docker",
+        "run",
+        "-d",
+        "--rm",
+        "--name",
+        name,
+        "-p",
+        f"{port}:5001",
+        DEFAULT_IMAGE,
+    ]
+    started = subprocess.run(
+        run_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+    )
+    if started.returncode != 0:
+        pytest.skip(f"failed to start docling-serve container: {started.stderr}")
+
+    container_id = started.stdout.strip()
+    base = f"http://127.0.0.1:{port}"
+
+    try:
+        deadline = time.time() + CONTAINER_READY_TIMEOUT
+        while time.time() < deadline:
+            try:
+                # docling-serve exposes /docs (FastAPI's Swagger UI) once the
+                # ASGI app is ready; this is the cheapest readiness probe.
+                resp = httpx.get(f"{base}/docs", timeout=2.0)
+                if resp.status_code == 200:
+                    break
+            except httpx.HTTPError:
+                pass
+            time.sleep(2.0)
+        else:
+            logs = subprocess.run(
+                ["docker", "logs", "--tail", "60", container_id],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            pytest.skip(
+                "docling-serve container failed readiness within "
+                f"{CONTAINER_READY_TIMEOUT:.0f}s. Last logs:\n{logs.stdout}"
+            )
+
+        yield {"base": base, "container_id": container_id}
+
+    finally:
+        subprocess.run(
+            ["docker", "rm", "-f", container_id],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+
+# --------------------------------------------------------------------------
+# PDF generation (skip if fpdf2 missing)
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def sample_pdf(tmp_path_factory) -> Path:
+    fpdf = pytest.importorskip("fpdf")
+    out = tmp_path_factory.mktemp("docling-it") / "sample.pdf"
+    pdf = fpdf.FPDF()
+    pdf.add_page()
+    pdf.set_font("Helvetica", size=14)
+    pdf.cell(0, 10, "Hello LightRAG", ln=True)
+    pdf.set_font("Helvetica", size=11)
+    pdf.multi_cell(
+        0,
+        7,
+        "This document is generated for the docling-serve integration test "
+        "in PR #3045. Its body must round-trip through the upload, poll, and "
+        "result endpoints, and the markdown returned by docling-serve must "
+        "be persisted by parse_docling instead of the raw JSON wrapper.",
+    )
+    pdf.output(str(out))
+    assert out.stat().st_size > 0
+    return out
+
+
+# --------------------------------------------------------------------------
+# LightRAG fixture (mirrors the offline tests)
+# --------------------------------------------------------------------------
+
+
+async def _embed(texts: list[str]) -> np.ndarray:
+    return np.zeros((len(texts), 8), dtype=float)
+
+
+async def _llm(prompt: str, **_) -> str:
+    return ""
+
+
+class _Tok:
+    def encode(self, content: str) -> list[int]:
+        return [ord(c) for c in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+def _new_rag(tmp_path: Path) -> LightRAG:
+    return LightRAG(
+        working_dir=str(tmp_path),
+        workspace=f"docling-it-{tmp_path.name}",
+        llm_model_func=_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8, max_token_size=512, func=_embed
+        ),
+        tokenizer=Tokenizer("mock", _Tok()),
+    )
+
+
+# --------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------
+
+
+def test_real_docling_serve_returns_extractable_wrapper(
+    tmp_path, docling_container, sample_pdf
+):
+    """Sanity probe: hit the live container directly (no LightRAG in the
+    loop) and verify the response shape we coded against still matches the
+    runtime contract. If this assertion ever fires, docling-serve has
+    diverged from its documented spec and the offline tests are stale.
+    """
+
+    httpx = pytest.importorskip("httpx")
+    base = docling_container["base"]
+
+    with httpx.Client(timeout=httpx.Timeout(PARSE_TIMEOUT, connect=30.0)) as client:
+        with open(sample_pdf, "rb") as f:
+            up = client.post(
+                f"{base}/v1/convert/file/async",
+                files={"files": (sample_pdf.name, f, "application/pdf")},
+            )
+        assert up.status_code < 400, up.text
+        upload_payload = up.json()
+        task_id = upload_payload.get("task_id")
+        assert task_id, f"no task_id in upload payload: {upload_payload}"
+
+        deadline = time.time() + PARSE_TIMEOUT
+        while time.time() < deadline:
+            poll = client.get(f"{base}/v1/status/poll/{task_id}")
+            poll.raise_for_status()
+            status = poll.json().get("task_status")
+            if status == "success":
+                break
+            if status == "failure":
+                pytest.fail(f"docling-serve reported failure: {poll.json()}")
+            time.sleep(1.0)
+        else:
+            pytest.fail("docling-serve poll never returned success")
+
+        result = client.get(f"{base}/v1/result/{task_id}")
+        result.raise_for_status()
+        body = result.json()
+
+    assert isinstance(body, dict), body
+    assert "document" in body, body
+    document = body["document"]
+    assert isinstance(document, dict)
+    md = document.get("md_content", "")
+    assert isinstance(md, str) and md.strip(), document
+    assert "Hello LightRAG" in md or "LightRAG" in md, md
+
+
+def test_parse_docling_against_real_container_persists_markdown(
+    tmp_path, docling_container, sample_pdf, monkeypatch
+):
+    """Full end-to-end: parse_docling + a real docling-serve container.
+    The persisted document content must be the markdown extracted from
+    ``document.md_content``, not the raw JSON wrapper. This is the bug
+    the codex review on PR #3045 surfaced.
+    """
+
+    base = docling_container["base"]
+    monkeypatch.setenv("DOCLING_ENDPOINT", f"{base}/v1/convert/file/async")
+    monkeypatch.setenv("DOCLING_MAX_POLLS", "600")
+    monkeypatch.setenv("DOCLING_POLL_INTERVAL_SECONDS", "1")
+    # Default DOCLING_CONTENT_FIELD (document.md_content) — do not override.
+    monkeypatch.delenv("DOCLING_CONTENT_FIELD", raising=False)
+
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+        try:
+            result = await rag.parse_docling(
+                doc_id="docling-it-1",
+                file_path=str(sample_pdf),
+                content_data={
+                    "content": "x",
+                    "source_path": str(sample_pdf),
+                },
+            )
+        finally:
+            await rag.finalize_storages()
+
+        content = result.get("content", "")
+        assert isinstance(content, str)
+        # Must be Markdown extracted from document.md_content, not the JSON
+        # wrapper. Anchors below are deliberately spec-aware: the wrapper
+        # would contain literal ``"document"`` and ``"md_content"`` keys
+        # while the extracted markdown will contain neither.
+        assert "Hello LightRAG" in content or "LightRAG" in content, content
+        assert '"document"' not in content
+        assert '"md_content"' not in content
+        assert '"task_status"' not in content
+
+    asyncio.run(_run())

--- a/tests/test_protocol_parse_service.py
+++ b/tests/test_protocol_parse_service.py
@@ -13,16 +13,17 @@ These cover the regressions reported in GitHub issue #2995:
 from __future__ import annotations
 
 import asyncio
+import json
 import threading
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import httpx
 import pytest
 import uvicorn
-from fastapi import FastAPI, File, HTTPException, UploadFile
-from fastapi.responses import PlainTextResponse
+from fastapi import FastAPI, File, HTTPException, Response, UploadFile
+from fastapi.responses import JSONResponse, PlainTextResponse
 
 from lightrag import LightRAG
 from lightrag.utils import EmbeddingFunc, Tokenizer
@@ -35,7 +36,14 @@ import numpy as np
 # --------------------------------------------------------------------------
 
 
-def _build_app() -> tuple[FastAPI, dict[str, dict]]:
+ResultFactory = Callable[[str], Response]
+
+
+def _build_app(
+    *,
+    wrapped_result: bool = False,
+    result_factory: ResultFactory | None = None,
+) -> tuple[FastAPI, dict[str, dict]]:
     app = FastAPI()
     tasks: dict[str, dict] = {}
 
@@ -53,9 +61,34 @@ def _build_app() -> tuple[FastAPI, dict[str, dict]]:
         tasks[task_id]["polls"] += 1
         return {"task_id": task_id, "task_status": "success"}
 
-    @app.get("/v1/result/{task_id}")
-    async def result(task_id: str):
-        return PlainTextResponse(f"PARSED:{task_id}")
+    if result_factory is not None:
+        @app.get("/v1/result/{task_id}")
+        async def result(task_id: str):
+            return result_factory(task_id)
+    elif wrapped_result:
+        # Mirror the real docling-serve shape: a JSON wrapper with the parsed
+        # body nested under ``document.md_content`` (plus other format slots).
+        @app.get("/v1/result/{task_id}")
+        async def result(task_id: str):
+            return JSONResponse(
+                {
+                    "document": {
+                        "md_content": f"# Parsed {task_id}\n\nbody",
+                        "text_content": f"Parsed {task_id} body",
+                        "html_content": "",
+                        "json_content": {},
+                        "doctags_content": "",
+                    },
+                    "status": "success",
+                    "processing_time": 0.01,
+                    "timings": {},
+                    "errors": [],
+                }
+            )
+    else:
+        @app.get("/v1/result/{task_id}")
+        async def result(task_id: str):
+            return PlainTextResponse(f"PARSED:{task_id}")
 
     return app, tasks
 
@@ -107,6 +140,57 @@ def mock_docling_serve():
         }
     finally:
         thread.stop()
+
+
+@pytest.fixture
+def mock_docling_serve_wrapped():
+    """docling-serve mock whose /v1/result/{task_id} returns the real JSON
+    wrapper ({"document": {"md_content": ..., ...}, ...}) — used to verify
+    that ``_call_protocol_parse_service`` extracts via ``content_field``
+    instead of persisting the raw wrapper as document content."""
+
+    app, tasks = _build_app(wrapped_result=True)
+    port = _free_port()
+    thread = _ServerThread(app, port)
+    thread.start()
+    thread.wait_ready()
+    try:
+        yield {
+            "base": f"http://127.0.0.1:{port}",
+            "tasks": tasks,
+        }
+    finally:
+        thread.stop()
+
+
+def _spawn_server(result_factory: ResultFactory) -> tuple[_ServerThread, str]:
+    """Spin up a one-off mock server whose /v1/result returns ``result_factory``.
+
+    Caller is responsible for stopping the thread.
+    """
+    app, _tasks = _build_app(result_factory=result_factory)
+    port = _free_port()
+    thread = _ServerThread(app, port)
+    thread.start()
+    thread.wait_ready()
+    return thread, f"http://127.0.0.1:{port}"
+
+
+def _build_protocol(base: str, *, content_field: str) -> dict[str, Any]:
+    return {
+        "upload_url": f"{base}/v1/convert/file/async",
+        "upload_field_name": "files",
+        "poll_url_template": f"{base}/v1/status/poll/{{task_id}}",
+        "id_field": "task_id",
+        "status_field": "task_status",
+        "result_url_field": "result_url",
+        "result_url_template": f"{base}/v1/result/{{task_id}}",
+        "content_field": content_field,
+        "success_values": "success",
+        "failed_values": "failure",
+        "poll_interval_seconds": 0.05,
+        "max_polls": 20,
+    }
 
 
 # --------------------------------------------------------------------------
@@ -380,6 +464,146 @@ def test_parse_docling_endpoint_with_trailing_slash_still_derives_defaults(
 
 
 @pytest.mark.offline
+def test_call_protocol_extracts_content_field_from_json_result_wrapper(
+    tmp_path, mock_docling_serve_wrapped
+):
+    """Regression for codex review on PR #3045: docling-serve's
+    ``/v1/result/{task_id}`` returns ``{"document": {"md_content": "..."}, ...}``,
+    not plain text. ``_call_protocol_parse_service`` must use ``content_field``
+    (default ``document.md_content`` for parse_docling) to extract the parsed
+    body, otherwise the raw JSON wrapper is persisted as document content."""
+
+    base = mock_docling_serve_wrapped["base"]
+
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+
+        sample = tmp_path / "sample.pdf"
+        sample.write_bytes(b"%PDF-1.4 fake")
+
+        protocol: dict[str, Any] = {
+            "upload_url": f"{base}/v1/convert/file/async",
+            "upload_field_name": "files",
+            "poll_url_template": f"{base}/v1/status/poll/{{task_id}}",
+            "id_field": "task_id",
+            "status_field": "task_status",
+            "result_url_field": "result_url",
+            "result_url_template": f"{base}/v1/result/{{task_id}}",
+            "content_field": "document.md_content",
+            "success_values": "success",
+            "failed_values": "failure",
+            "poll_interval_seconds": 0.05,
+            "max_polls": 20,
+        }
+
+        out = await rag._call_protocol_parse_service(
+            protocol=protocol, file_path=str(sample)
+        )
+
+        assert out is not None
+        assert out.startswith("# Parsed task-")
+        assert "body" in out
+        # The raw JSON wrapper must NOT have leaked through.
+        assert '"document"' not in out
+        assert "md_content" not in out
+
+        await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_call_protocol_falls_back_to_raw_text_when_json_path_missing(
+    tmp_path, mock_docling_serve_wrapped
+):
+    """If ``content_field`` does not resolve in the JSON wrapper (e.g. the
+    user pointed it at a missing key), the call must fall back to the raw
+    body rather than swallow the response. This preserves the historical
+    contract for plain-text result endpoints and gives downstream
+    ``normalize_parser_result_to_content_list`` a chance to recover."""
+
+    base = mock_docling_serve_wrapped["base"]
+
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+
+        sample = tmp_path / "sample.pdf"
+        sample.write_bytes(b"%PDF-1.4 fake")
+
+        protocol: dict[str, Any] = {
+            "upload_url": f"{base}/v1/convert/file/async",
+            "upload_field_name": "files",
+            "poll_url_template": f"{base}/v1/status/poll/{{task_id}}",
+            "id_field": "task_id",
+            "status_field": "task_status",
+            "result_url_field": "result_url",
+            "result_url_template": f"{base}/v1/result/{{task_id}}",
+            "content_field": "does.not.exist",
+            "success_values": "success",
+            "failed_values": "failure",
+            "poll_interval_seconds": 0.05,
+            "max_polls": 20,
+        }
+
+        out = await rag._call_protocol_parse_service(
+            protocol=protocol, file_path=str(sample)
+        )
+        assert out is not None
+        assert '"document"' in out  # raw JSON wrapper preserved
+
+        await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_parse_docling_default_content_field_is_document_md_content(
+    tmp_path, monkeypatch
+):
+    """``parse_docling`` must default ``content_field`` to
+    ``document.md_content`` so the wrapper returned by docling-serve's
+    ``/v1/result/{task_id}`` is unwrapped automatically."""
+
+    captured: dict[str, Any] = {}
+
+    async def _capture(self, protocol, file_path):
+        captured.update(protocol)
+        return "noop"
+
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+
+        sample = tmp_path / "sample.pdf"
+        sample.write_bytes(b"%PDF-1.4 fake")
+
+        monkeypatch.setenv(
+            "DOCLING_ENDPOINT", "http://localhost:5001/v1/convert/file/async"
+        )
+        monkeypatch.delenv("DOCLING_CONTENT_FIELD", raising=False)
+        monkeypatch.setattr(
+            type(rag), "_call_protocol_parse_service", _capture, raising=True
+        )
+
+        try:
+            await rag.parse_docling(
+                doc_id="d-3",
+                file_path=str(sample),
+                content_data={"content": "x"},
+            )
+        except Exception:
+            pass
+
+        assert captured["content_field"] == "document.md_content"
+
+        await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
 @pytest.mark.parametrize("bad_value", ["", "   ", None])
 def test_call_protocol_normalizes_empty_upload_field_name(
     tmp_path, mock_docling_serve, bad_value
@@ -421,3 +645,517 @@ def test_call_protocol_normalizes_empty_upload_field_name(
         await rag.finalize_storages()
 
     asyncio.run(_run())
+
+
+# --------------------------------------------------------------------------
+# Exhaustive edge-case coverage for JSON-result extraction
+#
+# Each test below pins a distinct branch of ``_call_protocol_parse_service``'s
+# result-fetch path:
+#
+#   raw_text = dl.text
+#   if content_field:
+#       try: parsed = json.loads(raw_text)
+#       except (ValueError, TypeError): parsed = None
+#       if isinstance(parsed, (dict, list)):
+#           extracted = get_by_path(parsed, content_field)
+#           if isinstance(extracted, str) and extracted:
+#               return extracted
+#   return raw_text
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.offline
+def test_result_json_text_content_extracted_when_content_field_overridden(tmp_path):
+    """Override ``content_field`` to ``document.text_content`` — must extract
+    plain text instead of markdown, both fields populated in the wrapper."""
+
+    def factory(task_id: str) -> Response:
+        return JSONResponse(
+            {
+                "document": {
+                    "md_content": "# md should be ignored",
+                    "text_content": f"plain {task_id} body",
+                    "html_content": "<p>html</p>",
+                },
+                "status": "success",
+            }
+        )
+
+    thread, base = _spawn_server(factory)
+    try:
+        async def _run():
+            rag = _new_rag(tmp_path)
+            await rag.initialize_storages()
+            sample = tmp_path / "x.pdf"
+            sample.write_bytes(b"%PDF-1.4 fake")
+            protocol = _build_protocol(base, content_field="document.text_content")
+            out = await rag._call_protocol_parse_service(
+                protocol=protocol, file_path=str(sample)
+            )
+            assert out == "plain task-1 body"
+            await rag.finalize_storages()
+
+        asyncio.run(_run())
+    finally:
+        thread.stop()
+
+
+@pytest.mark.offline
+def test_result_json_html_content_extracted_when_content_field_overridden(tmp_path):
+    """Same wrapper, ``content_field=document.html_content`` — extracts HTML."""
+
+    def factory(task_id: str) -> Response:
+        return JSONResponse(
+            {
+                "document": {
+                    "md_content": "# md",
+                    "text_content": "plain",
+                    "html_content": f"<h1>html {task_id}</h1>",
+                },
+                "status": "success",
+            }
+        )
+
+    thread, base = _spawn_server(factory)
+    try:
+        async def _run():
+            rag = _new_rag(tmp_path)
+            await rag.initialize_storages()
+            sample = tmp_path / "x.pdf"
+            sample.write_bytes(b"%PDF-1.4 fake")
+            protocol = _build_protocol(base, content_field="document.html_content")
+            out = await rag._call_protocol_parse_service(
+                protocol=protocol, file_path=str(sample)
+            )
+            assert out == "<h1>html task-1</h1>"
+            await rag.finalize_storages()
+
+        asyncio.run(_run())
+    finally:
+        thread.stop()
+
+
+@pytest.mark.offline
+def test_result_json_invalid_falls_back_to_raw_text(tmp_path):
+    """If the response body is *not* valid JSON, the raw text must be
+    returned verbatim — regression guard for the existing plain-text path."""
+
+    def factory(task_id: str) -> Response:
+        # Deliberately malformed JSON-looking content.
+        return PlainTextResponse(f"{{not json: {task_id}")
+
+    thread, base = _spawn_server(factory)
+    try:
+        async def _run():
+            rag = _new_rag(tmp_path)
+            await rag.initialize_storages()
+            sample = tmp_path / "x.pdf"
+            sample.write_bytes(b"%PDF-1.4 fake")
+            protocol = _build_protocol(base, content_field="document.md_content")
+            out = await rag._call_protocol_parse_service(
+                protocol=protocol, file_path=str(sample)
+            )
+            assert out == "{not json: task-1"
+            await rag.finalize_storages()
+
+        asyncio.run(_run())
+    finally:
+        thread.stop()
+
+
+@pytest.mark.offline
+def test_result_json_empty_string_at_path_falls_back_to_raw(tmp_path):
+    """If ``content_field`` resolves to an empty string in the wrapper, the
+    extractor must fall back to the raw body (so the user can debug — silent
+    empty would mask configuration errors)."""
+
+    def factory(task_id: str) -> Response:
+        return JSONResponse(
+            {"document": {"md_content": "", "text_content": "fallback"}}
+        )
+
+    thread, base = _spawn_server(factory)
+    try:
+        async def _run():
+            rag = _new_rag(tmp_path)
+            await rag.initialize_storages()
+            sample = tmp_path / "x.pdf"
+            sample.write_bytes(b"%PDF-1.4 fake")
+            protocol = _build_protocol(base, content_field="document.md_content")
+            out = await rag._call_protocol_parse_service(
+                protocol=protocol, file_path=str(sample)
+            )
+            assert out is not None
+            # Raw JSON wrapper preserved so downstream
+            # normalize_parser_result_to_content_list can attempt recovery.
+            assert isinstance(out, str)
+            payload = json.loads(out)
+            assert payload["document"]["text_content"] == "fallback"
+            await rag.finalize_storages()
+
+        asyncio.run(_run())
+    finally:
+        thread.stop()
+
+
+@pytest.mark.offline
+def test_result_json_non_string_at_path_falls_back_to_raw(tmp_path):
+    """If ``content_field`` resolves to a dict (e.g.
+    ``document.json_content``), the extractor must fall back to the raw
+    text rather than ``str()``-coercing the dict."""
+
+    def factory(task_id: str) -> Response:
+        return JSONResponse(
+            {
+                "document": {
+                    "md_content": "# md",
+                    "json_content": {"sections": [{"text": "x"}]},
+                }
+            }
+        )
+
+    thread, base = _spawn_server(factory)
+    try:
+        async def _run():
+            rag = _new_rag(tmp_path)
+            await rag.initialize_storages()
+            sample = tmp_path / "x.pdf"
+            sample.write_bytes(b"%PDF-1.4 fake")
+            protocol = _build_protocol(base, content_field="document.json_content")
+            out = await rag._call_protocol_parse_service(
+                protocol=protocol, file_path=str(sample)
+            )
+            assert isinstance(out, str)
+            payload = json.loads(out)
+            assert isinstance(payload["document"]["json_content"], dict)
+            await rag.finalize_storages()
+
+        asyncio.run(_run())
+    finally:
+        thread.stop()
+
+
+@pytest.mark.offline
+def test_result_json_top_level_list_falls_back_to_raw(tmp_path):
+    """A top-level JSON list shouldn't be unwrapped via ``get_by_path`` (only
+    dict traversal is supported); the raw text must be returned so the
+    downstream normalizer can pick it up."""
+
+    def factory(task_id: str) -> Response:
+        return JSONResponse(
+            [{"type": "text", "text": f"chunk {task_id}"}]
+        )
+
+    thread, base = _spawn_server(factory)
+    try:
+        async def _run():
+            rag = _new_rag(tmp_path)
+            await rag.initialize_storages()
+            sample = tmp_path / "x.pdf"
+            sample.write_bytes(b"%PDF-1.4 fake")
+            protocol = _build_protocol(base, content_field="document.md_content")
+            out = await rag._call_protocol_parse_service(
+                protocol=protocol, file_path=str(sample)
+            )
+            assert isinstance(out, str)
+            payload = json.loads(out)
+            assert isinstance(payload, list) and payload[0]["type"] == "text"
+            await rag.finalize_storages()
+
+        asyncio.run(_run())
+    finally:
+        thread.stop()
+
+
+@pytest.mark.offline
+def test_result_json_top_level_scalar_falls_back_to_raw(tmp_path):
+    """A bare JSON-encoded string (e.g. ``"hello"``) should pass through as
+    raw text — ``get_by_path`` only walks dicts so the result is unchanged."""
+
+    def factory(task_id: str) -> Response:
+        return Response(content='"hello"', media_type="application/json")
+
+    thread, base = _spawn_server(factory)
+    try:
+        async def _run():
+            rag = _new_rag(tmp_path)
+            await rag.initialize_storages()
+            sample = tmp_path / "x.pdf"
+            sample.write_bytes(b"%PDF-1.4 fake")
+            protocol = _build_protocol(base, content_field="document.md_content")
+            out = await rag._call_protocol_parse_service(
+                protocol=protocol, file_path=str(sample)
+            )
+            assert out == '"hello"'
+            await rag.finalize_storages()
+
+        asyncio.run(_run())
+    finally:
+        thread.stop()
+
+
+@pytest.mark.offline
+def test_result_json_empty_content_field_disables_unwrap(tmp_path):
+    """If ``content_field`` is empty, the JSON-unwrap branch must be skipped
+    entirely (back-compat for callers who don't want any extraction)."""
+
+    def factory(task_id: str) -> Response:
+        return JSONResponse(
+            {"document": {"md_content": f"md-{task_id}"}}
+        )
+
+    thread, base = _spawn_server(factory)
+    try:
+        async def _run():
+            rag = _new_rag(tmp_path)
+            await rag.initialize_storages()
+            sample = tmp_path / "x.pdf"
+            sample.write_bytes(b"%PDF-1.4 fake")
+            protocol = _build_protocol(base, content_field="")
+            out = await rag._call_protocol_parse_service(
+                protocol=protocol, file_path=str(sample)
+            )
+            assert isinstance(out, str)
+            payload = json.loads(out)
+            assert payload["document"]["md_content"] == "md-task-1"
+            await rag.finalize_storages()
+
+        asyncio.run(_run())
+    finally:
+        thread.stop()
+
+
+@pytest.mark.offline
+def test_result_json_path_with_dots_in_keys_returns_none_safely(tmp_path):
+    """``get_by_path`` splits on ``.`` — keys containing literal dots are not
+    addressable. Must fall back to raw text rather than crash."""
+
+    def factory(task_id: str) -> Response:
+        # The literal key ``"a.b"`` is not reachable via dotted traversal
+        # because get_by_path splits ``"a.b"`` into ``["a", "b"]``.
+        return JSONResponse({"a.b": "unreachable", "fallback": "x"})
+
+    thread, base = _spawn_server(factory)
+    try:
+        async def _run():
+            rag = _new_rag(tmp_path)
+            await rag.initialize_storages()
+            sample = tmp_path / "x.pdf"
+            sample.write_bytes(b"%PDF-1.4 fake")
+            protocol = _build_protocol(base, content_field="a.b")
+            out = await rag._call_protocol_parse_service(
+                protocol=protocol, file_path=str(sample)
+            )
+            assert isinstance(out, str)
+            payload = json.loads(out)
+            assert payload["a.b"] == "unreachable"
+            await rag.finalize_storages()
+
+        asyncio.run(_run())
+    finally:
+        thread.stop()
+
+
+@pytest.mark.offline
+def test_result_json_deeply_nested_path_extracts(tmp_path):
+    """Sanity check that ``get_by_path`` traverses multi-level dotted paths
+    correctly — important if a future docling-serve version nests further."""
+
+    def factory(task_id: str) -> Response:
+        return JSONResponse(
+            {"a": {"b": {"c": {"d": f"deep-{task_id}"}}}}
+        )
+
+    thread, base = _spawn_server(factory)
+    try:
+        async def _run():
+            rag = _new_rag(tmp_path)
+            await rag.initialize_storages()
+            sample = tmp_path / "x.pdf"
+            sample.write_bytes(b"%PDF-1.4 fake")
+            protocol = _build_protocol(base, content_field="a.b.c.d")
+            out = await rag._call_protocol_parse_service(
+                protocol=protocol, file_path=str(sample)
+            )
+            assert out == "deep-task-1"
+            await rag.finalize_storages()
+
+        asyncio.run(_run())
+    finally:
+        thread.stop()
+
+
+# --------------------------------------------------------------------------
+# End-to-end: parse_docling against the wrapped mock must persist *markdown*
+# as the document content, not the raw JSON wrapper. This is the bug the
+# codex review surfaced.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.offline
+def test_parse_docling_persists_extracted_markdown_not_raw_json_wrapper(
+    tmp_path, mock_docling_serve_wrapped, monkeypatch
+):
+    base = mock_docling_serve_wrapped["base"]
+
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+
+        sample = tmp_path / "input.pdf"
+        sample.write_bytes(b"%PDF-1.4 fake")
+
+        monkeypatch.setenv("DOCLING_ENDPOINT", f"{base}/v1/convert/file/async")
+        # Default DOCLING_CONTENT_FIELD (document.md_content) — do not override.
+        monkeypatch.delenv("DOCLING_CONTENT_FIELD", raising=False)
+
+        result = await rag.parse_docling(
+            doc_id="d-e2e-1",
+            file_path=str(sample),
+            content_data={"content": "x", "source_path": str(sample)},
+        )
+
+        # The persisted ``content`` must be the extracted markdown — NOT the
+        # JSON wrapper. Both anchors below come from the mock factory above.
+        content = result.get("content", "")
+        assert content.startswith("# Parsed task-")
+        assert "body" in content
+        # Critical: no raw-JSON leakage.
+        assert '"document"' not in content
+        assert '"md_content"' not in content
+        assert '"status": "success"' not in content
+
+        await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_parse_docling_with_text_content_override_persists_plain_text(
+    tmp_path, mock_docling_serve_wrapped, monkeypatch
+):
+    """End-to-end coverage for the documented override:
+    ``DOCLING_CONTENT_FIELD=document.text_content`` should land plain-text
+    body in ``full_docs``, not markdown."""
+
+    base = mock_docling_serve_wrapped["base"]
+
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+
+        sample = tmp_path / "input.pdf"
+        sample.write_bytes(b"%PDF-1.4 fake")
+
+        monkeypatch.setenv("DOCLING_ENDPOINT", f"{base}/v1/convert/file/async")
+        monkeypatch.setenv("DOCLING_CONTENT_FIELD", "document.text_content")
+
+        result = await rag.parse_docling(
+            doc_id="d-e2e-2",
+            file_path=str(sample),
+            content_data={"content": "x", "source_path": str(sample)},
+        )
+
+        content = result.get("content", "")
+        assert content == "Parsed task-1 body"
+
+        await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+# --------------------------------------------------------------------------
+# MinerU back-compat: the result-URL JSON-unwrap path is shared with MinerU.
+# Verify that:
+#   1. Plain-text result (the historical MinerU contract) still passes through.
+#   2. JSON result with a top-level ``content`` key extracts cleanly (this is
+#      a behavior improvement — previously persisted as raw JSON — but a
+#      deliberate one, kept consistent with poll-payload extraction).
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.offline
+def test_mineru_plain_text_result_url_unchanged(tmp_path):
+    """MinerU deployments that serve the parsed body as plain text from
+    ``result_url`` must continue to receive the raw text verbatim."""
+
+    def factory(task_id: str) -> Response:
+        return PlainTextResponse(f"MINERU PARSED:{task_id}")
+
+    thread, base = _spawn_server(factory)
+    try:
+        async def _run():
+            rag = _new_rag(tmp_path)
+            await rag.initialize_storages()
+            sample = tmp_path / "x.pdf"
+            sample.write_bytes(b"%PDF-1.4 fake")
+            # MinerU's historical defaults — content_field=content.
+            protocol = _build_protocol(base, content_field="content")
+            out = await rag._call_protocol_parse_service(
+                protocol=protocol, file_path=str(sample)
+            )
+            assert out == "MINERU PARSED:task-1"
+            await rag.finalize_storages()
+
+        asyncio.run(_run())
+    finally:
+        thread.stop()
+
+
+@pytest.mark.offline
+def test_mineru_json_with_content_field_extracts(tmp_path):
+    """MinerU deployments that wrap the body as ``{"content": "..."}`` from
+    ``result_url`` will now have ``content`` extracted (consistent with the
+    existing poll-payload extraction). Documents the behavior delta."""
+
+    def factory(task_id: str) -> Response:
+        return JSONResponse({"content": f"mineru body {task_id}"})
+
+    thread, base = _spawn_server(factory)
+    try:
+        async def _run():
+            rag = _new_rag(tmp_path)
+            await rag.initialize_storages()
+            sample = tmp_path / "x.pdf"
+            sample.write_bytes(b"%PDF-1.4 fake")
+            protocol = _build_protocol(base, content_field="content")
+            out = await rag._call_protocol_parse_service(
+                protocol=protocol, file_path=str(sample)
+            )
+            assert out == "mineru body task-1"
+            await rag.finalize_storages()
+
+        asyncio.run(_run())
+    finally:
+        thread.stop()
+
+
+# --------------------------------------------------------------------------
+# Status-code propagation: a 500 from /v1/result must surface as an error,
+# not be silently treated as text. Pins the ``raise_for_status()`` contract.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.offline
+def test_result_endpoint_500_raises_http_status_error(tmp_path):
+    def factory(task_id: str) -> Response:
+        return Response(content="boom", status_code=500)
+
+    thread, base = _spawn_server(factory)
+    try:
+        async def _run():
+            rag = _new_rag(tmp_path)
+            await rag.initialize_storages()
+            sample = tmp_path / "x.pdf"
+            sample.write_bytes(b"%PDF-1.4 fake")
+            protocol = _build_protocol(base, content_field="document.md_content")
+            with pytest.raises(httpx.HTTPStatusError):
+                await rag._call_protocol_parse_service(
+                    protocol=protocol, file_path=str(sample)
+                )
+            await rag.finalize_storages()
+
+        asyncio.run(_run())
+    finally:
+        thread.stop()

--- a/tests/test_protocol_parse_service.py
+++ b/tests/test_protocol_parse_service.py
@@ -1,0 +1,326 @@
+"""Tests for the protocol-driven parse service used by Docling and MinerU.
+
+These cover the regressions reported in GitHub issue #2995:
+  * Docling-serve expects multipart field name ``files`` (plural).
+  * Docling-serve poll responses use ``task_status`` (lowercase enum:
+    ``pending|started|success|failure``) — not ``status``.
+  * Docling-serve serves results from a separate ``/v1/result/{task_id}``
+    path, not from a ``result_url`` payload field.
+  * Default poll/result paths must derive from the upload endpoint when
+    only ``DOCLING_ENDPOINT`` is configured.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import uvicorn
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi.responses import PlainTextResponse
+
+from lightrag import LightRAG
+from lightrag.utils import EmbeddingFunc, Tokenizer
+
+import numpy as np
+
+
+# --------------------------------------------------------------------------
+# Mock docling-serve endpoint (matches the real spec)
+# --------------------------------------------------------------------------
+
+
+def _build_app() -> tuple[FastAPI, dict[str, dict]]:
+    app = FastAPI()
+    tasks: dict[str, dict] = {}
+
+    @app.post("/v1/convert/file/async")
+    async def upload(files: list[UploadFile] = File(...)):
+        body = await files[0].read()
+        task_id = f"task-{len(tasks) + 1}"
+        tasks[task_id] = {"size": len(body), "polls": 0}
+        return {"task_id": task_id, "task_status": "pending"}
+
+    @app.get("/v1/status/poll/{task_id}")
+    async def poll(task_id: str):
+        if task_id not in tasks:
+            raise HTTPException(404, "no such task")
+        tasks[task_id]["polls"] += 1
+        return {"task_id": task_id, "task_status": "success"}
+
+    @app.get("/v1/result/{task_id}")
+    async def result(task_id: str):
+        return PlainTextResponse(f"PARSED:{task_id}")
+
+    return app, tasks
+
+
+def _free_port() -> int:
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _ServerThread(threading.Thread):
+    def __init__(self, app: FastAPI, port: int) -> None:
+        super().__init__(daemon=True)
+        config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+        self.server = uvicorn.Server(config)
+        self.port = port
+
+    def run(self) -> None:
+        self.server.run()
+
+    def wait_ready(self, timeout: float = 5.0) -> None:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            try:
+                httpx.get(f"http://127.0.0.1:{self.port}/docs", timeout=0.3)
+                return
+            except Exception:
+                time.sleep(0.05)
+        raise RuntimeError("mock docling-serve did not start in time")
+
+    def stop(self) -> None:
+        self.server.should_exit = True
+        self.join(timeout=5.0)
+
+
+@pytest.fixture
+def mock_docling_serve():
+    app, tasks = _build_app()
+    port = _free_port()
+    thread = _ServerThread(app, port)
+    thread.start()
+    thread.wait_ready()
+    try:
+        yield {
+            "base": f"http://127.0.0.1:{port}",
+            "tasks": tasks,
+        }
+    finally:
+        thread.stop()
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+async def _embed(texts: list[str]) -> np.ndarray:
+    return np.zeros((len(texts), 8), dtype=float)
+
+
+async def _llm(prompt: str, **_) -> str:
+    return ""
+
+
+class _Tok:
+    def encode(self, content: str) -> list[int]:
+        return [ord(c) for c in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+def _new_rag(tmp_path: Path) -> LightRAG:
+    return LightRAG(
+        working_dir=str(tmp_path),
+        workspace=f"protocol-{tmp_path.name}",
+        llm_model_func=_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8, max_token_size=512, func=_embed
+        ),
+        tokenizer=Tokenizer("mock", _Tok()),
+    )
+
+
+# --------------------------------------------------------------------------
+# Tests for _call_protocol_parse_service
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.offline
+def test_call_protocol_uses_configured_multipart_field(
+    tmp_path, mock_docling_serve
+):
+    """Default ``upload_field_name`` is ``"file"`` — verify the override sends
+    the multipart field as ``"files"`` so docling-serve does not return 422."""
+
+    base = mock_docling_serve["base"]
+
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+
+        sample = tmp_path / "sample.pdf"
+        sample.write_bytes(b"%PDF-1.4 fake")
+
+        protocol: dict[str, Any] = {
+            "upload_url": f"{base}/v1/convert/file/async",
+            "upload_field_name": "files",
+            "poll_url_template": f"{base}/v1/status/poll/{{task_id}}",
+            "id_field": "task_id",
+            "status_field": "task_status",
+            "result_url_field": "result_url",
+            "result_url_template": f"{base}/v1/result/{{task_id}}",
+            "success_values": "success",
+            "failed_values": "failure",
+            "poll_interval_seconds": 0.05,
+            "max_polls": 20,
+        }
+
+        out = await rag._call_protocol_parse_service(
+            protocol=protocol, file_path=str(sample)
+        )
+        assert out is not None and out.startswith("PARSED:task-")
+
+        await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_call_protocol_default_field_name_rejected_by_docling(
+    tmp_path, mock_docling_serve
+):
+    """Without overriding upload_field_name, the call sends ``file`` and
+    docling-serve returns 422 — the regression from issue #2995."""
+
+    base = mock_docling_serve["base"]
+
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+
+        sample = tmp_path / "sample.pdf"
+        sample.write_bytes(b"%PDF-1.4 fake")
+
+        protocol: dict[str, Any] = {
+            "upload_url": f"{base}/v1/convert/file/async",
+            # no upload_field_name -> defaults to "file"
+            "poll_url_template": f"{base}/v1/status/poll/{{task_id}}",
+            "id_field": "task_id",
+            "status_field": "task_status",
+            "success_values": "success",
+            "failed_values": "failure",
+            "poll_interval_seconds": 0.05,
+            "max_polls": 5,
+        }
+
+        with pytest.raises(RuntimeError, match=r"422"):
+            await rag._call_protocol_parse_service(
+                protocol=protocol, file_path=str(sample)
+            )
+
+        await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_call_protocol_falls_back_to_result_url_template(
+    tmp_path, mock_docling_serve
+):
+    """When the poll payload omits ``result_url`` (real docling-serve
+    behavior), the result must be fetched from ``result_url_template``."""
+
+    base = mock_docling_serve["base"]
+
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+
+        sample = tmp_path / "sample.pdf"
+        sample.write_bytes(b"%PDF-1.4 fake")
+
+        protocol: dict[str, Any] = {
+            "upload_url": f"{base}/v1/convert/file/async",
+            "upload_field_name": "files",
+            "poll_url_template": f"{base}/v1/status/poll/{{task_id}}",
+            "id_field": "task_id",
+            "status_field": "task_status",
+            "result_url_field": "result_url",  # not present in poll payload
+            "result_url_template": f"{base}/v1/result/{{task_id}}",
+            "success_values": "success",
+            "failed_values": "failure",
+            "poll_interval_seconds": 0.05,
+            "max_polls": 20,
+        }
+
+        out = await rag._call_protocol_parse_service(
+            protocol=protocol, file_path=str(sample)
+        )
+        assert out is not None and out.startswith("PARSED:task-")
+
+        await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+# --------------------------------------------------------------------------
+# Tests for parse_docling default protocol construction
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.offline
+def test_parse_docling_protocol_defaults_match_docling_serve(
+    tmp_path, monkeypatch
+):
+    """Capture the protocol dict built by ``parse_docling`` when only
+    ``DOCLING_ENDPOINT`` is set, and assert it matches the docling-serve
+    spec."""
+
+    captured: dict[str, Any] = {}
+
+    async def _capture(self, protocol, file_path):
+        captured.update(protocol)
+        return "noop"
+
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+
+        sample = tmp_path / "sample.pdf"
+        sample.write_bytes(b"%PDF-1.4 fake")
+
+        monkeypatch.setenv(
+            "DOCLING_ENDPOINT", "http://localhost:5001/v1/convert/file/async"
+        )
+        monkeypatch.setattr(
+            type(rag), "_call_protocol_parse_service", _capture, raising=True
+        )
+
+        # parse_docling will call _capture (returning "noop"), then attempt to
+        # persist; we only care about ``captured``.
+        try:
+            await rag.parse_docling(
+                doc_id="d-1",
+                file_path=str(sample),
+                content_data={"content": "x"},
+            )
+        except Exception:
+            pass
+
+        assert captured["upload_field_name"] == "files"
+        assert captured["status_field"] == "task_status"
+        assert (
+            captured["poll_url_template"]
+            == "http://localhost:5001/v1/status/poll/{task_id}"
+        )
+        assert (
+            captured["result_url_template"]
+            == "http://localhost:5001/v1/result/{task_id}"
+        )
+        assert "failure" in captured["failed_values"]
+
+        await rag.finalize_storages()
+
+    asyncio.run(_run())

--- a/tests/test_protocol_parse_service.py
+++ b/tests/test_protocol_parse_service.py
@@ -324,3 +324,100 @@ def test_parse_docling_protocol_defaults_match_docling_serve(
         await rag.finalize_storages()
 
     asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_parse_docling_endpoint_with_trailing_slash_still_derives_defaults(
+    tmp_path, monkeypatch
+):
+    """A trailing slash on ``DOCLING_ENDPOINT`` must not defeat the
+    suffix-based derivation of poll/result paths."""
+
+    captured: dict[str, Any] = {}
+
+    async def _capture(self, protocol, file_path):
+        captured.update(protocol)
+        return "noop"
+
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+
+        sample = tmp_path / "sample.pdf"
+        sample.write_bytes(b"%PDF-1.4 fake")
+
+        monkeypatch.setenv(
+            "DOCLING_ENDPOINT", "http://localhost:5001/v1/convert/file/async/"
+        )
+        monkeypatch.setattr(
+            type(rag), "_call_protocol_parse_service", _capture, raising=True
+        )
+
+        try:
+            await rag.parse_docling(
+                doc_id="d-2",
+                file_path=str(sample),
+                content_data={"content": "x"},
+            )
+        except Exception:
+            pass
+
+        # rstrip("/") on the endpoint must drop the trailing slash so the
+        # derivation produces spec paths, not endpoint + "/{task_id}".
+        assert (
+            captured["poll_url_template"]
+            == "http://localhost:5001/v1/status/poll/{task_id}"
+        )
+        assert (
+            captured["result_url_template"]
+            == "http://localhost:5001/v1/result/{task_id}"
+        )
+        assert captured["upload_url"] == "http://localhost:5001/v1/convert/file/async"
+
+        await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize("bad_value", ["", "   ", None])
+def test_call_protocol_normalizes_empty_upload_field_name(
+    tmp_path, mock_docling_serve, bad_value
+):
+    """Empty / whitespace-only / missing ``upload_field_name`` must fall back
+    to the historical default ``"file"`` rather than producing an invalid
+    multipart key. With docling-serve as the upstream this still 422s
+    (expected — the default is wrong for docling), but the failure mode is
+    explicit instead of a silent malformed request."""
+
+    base = mock_docling_serve["base"]
+
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+
+        sample = tmp_path / "sample.pdf"
+        sample.write_bytes(b"%PDF-1.4 fake")
+
+        protocol: dict[str, Any] = {
+            "upload_url": f"{base}/v1/convert/file/async",
+            "upload_field_name": bad_value,
+            "poll_url_template": f"{base}/v1/status/poll/{{task_id}}",
+            "id_field": "task_id",
+            "status_field": "task_status",
+            "success_values": "success",
+            "failed_values": "failure",
+            "poll_interval_seconds": 0.05,
+            "max_polls": 5,
+        }
+
+        # The 422 response from docling-serve must mention the missing
+        # ``files`` field — proving the fallback used a real multipart key.
+        with pytest.raises(RuntimeError, match=r"422.*files"):
+            await rag._call_protocol_parse_service(
+                protocol=protocol, file_path=str(sample)
+            )
+
+        await rag.finalize_storages()
+
+    asyncio.run(_run())


### PR DESCRIPTION
Closes #2995.

## Summary

`_call_protocol_parse_service` (used by `parse_docling` and `parse_mineru`) hardcoded the multipart field name as `"file"` and shipped Docling defaults that did not match the official [docling-serve API](https://docling-project.github.io/docling-serve/usage/). Every out-of-the-box Docling call returned:

```
422 {"detail":[{"type":"missing","loc":["body","files"],"msg":"Field required","input":null}]}
```

and even after the upload was fixed the polling loop hung because the status field name and endpoint paths were wrong.

## Bugs vs. docling-serve spec

| # | Defect | Previous behavior | docling-serve actual |
|---|---|---|---|
| 1 | Multipart field hardcoded | `files={"file": ...}` (not configurable) | `files` (plural) |
| 2 | Status field name | `DOCLING_STATUS_FIELD=status` | `task_status` |
| 3 | Poll URL template | `{endpoint}/{task_id}` (i.e. `/v1/convert/file/async/{id}`) | `/v1/status/poll/{task_id}` |
| 4 | Failed-state vocabulary | `failed,error` | enum includes `failure` |
| 5 | Result URL field | only `result_url` from poll payload | docling-serve serves results from `/v1/result/{task_id}` |

## Changes

- **`lightrag/pipeline.py`**
  - `_call_protocol_parse_service`: multipart field driven by `protocol["upload_field_name"]` (default `"file"` keeps generic/MinerU back-compat). Added `result_url_template` fallback for services that publish the parsed body at a separate path rather than returning `result_url` in the poll payload.
  - `parse_docling`: defaults realigned with docling-serve:
    - `upload_field_name = "files"`
    - `status_field = "task_status"`
    - `failed_values` includes `"failure"`
    - poll/result paths derived from `DOCLING_ENDPOINT` when it ends in `/v1/convert/file/async` → `/v1/status/poll/{task_id}` and `/v1/result/{task_id}`. Both remain overridable via `DOCLING_POLL_ENDPOINT` and `DOCLING_RESULT_URL_TEMPLATE`.
  - `parse_mineru`: exposes the same `upload_field_name` and `result_url_template` knobs for symmetry; defaults preserve existing MinerU behavior.
- **`env.example`**: documents the new variables (`DOCLING_UPLOAD_FIELD_NAME`, `DOCLING_RESULT_URL_TEMPLATE`, `MINERU_UPLOAD_FIELD_NAME`, `MINERU_RESULT_URL_TEMPLATE`) and updates the Docling block with spec-correct defaults.
- **`tests/test_protocol_parse_service.py`** (new, all `@pytest.mark.offline`):
  1. `test_call_protocol_uses_configured_multipart_field` — fix path against an in-process docling-serve mock returns the parsed body.
  2. `test_call_protocol_default_field_name_rejected_by_docling` — regression guard: legacy `"file"` against docling-serve raises `RuntimeError: ...422...`.
  3. `test_call_protocol_falls_back_to_result_url_template` — verifies fetch from `/v1/result/{task_id}` when the poll payload omits `result_url`.
  4. `test_parse_docling_protocol_defaults_match_docling_serve` — captures the protocol dict built from a bare `DOCLING_ENDPOINT` and asserts every field matches the spec.

## Test plan

- [x] `python -m pytest tests/test_protocol_parse_service.py` — 4/4 pass
- [x] `python -m pytest tests/test_pipeline_release_closure.py -k "parse_mineru or parse_docling"` — 3/3 pass (no regressions in existing parse coverage)
- [x] `ruff check lightrag/pipeline.py tests/test_protocol_parse_service.py` — clean
- [x] Reproduced the original 422 against an in-process mock that mimics docling-serve and confirmed the fix returns the expected parsed body.

## Backwards compatibility

- Existing `MINERU_*` deployments are unaffected (defaults unchanged).
- Existing `DOCLING_*` deployments that already overrode the protocol via env vars are unaffected (overrides take precedence over the new defaults).
- Users who previously relied on `DOCLING_ENDPOINT` alone (the documented setup) and were hitting the 422 will now see Docling work out of the box.