### PR TITLE
feat(api): add anthropic LLM binding (works with Zhipu Coding Plan)

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -316,6 +316,7 @@ def create_app(args):
         "azure_openai",
         "aws_bedrock",
         "gemini",
+        "anthropic",
     ]:
         raise Exception("llm binding not supported")
 
@@ -632,6 +633,81 @@ def create_app(args):
 
         return optimized_gemini_model_complete
 
+    def create_optimized_anthropic_llm_func(args, llm_timeout: int):
+        """Anthropic-compatible LLM function (works with Zhipu /api/anthropic endpoint).
+        Uses non-streaming + retry on rate limit / timeout / connection error.
+        """
+        from anthropic import (
+            AsyncAnthropic,
+            RateLimitError,
+            APIConnectionError,
+            APITimeoutError,
+        )
+        from tenacity import (
+            retry,
+            stop_after_attempt,
+            wait_random_exponential,
+            retry_if_exception_type,
+        )
+
+        @retry(
+            stop=stop_after_attempt(10),  # 最多 10 次（覆盖 ~5 分钟限流风暴）
+            # 带 jitter 的指数退避：避免所有 retry 同步重发引发二次雪崩
+            wait=wait_random_exponential(multiplier=2, min=4, max=120),
+            retry=retry_if_exception_type(
+                (RateLimitError, APIConnectionError, APITimeoutError)
+            ),
+            reraise=True,
+        )
+        async def _call_with_retry(client, create_params):
+            return await client.messages.create(**create_params)
+
+        async def optimized_anthropic_model_complete(
+            prompt,
+            system_prompt=None,
+            history_messages=None,
+            keyword_extraction=False,
+            **kwargs,
+        ) -> str:
+            for k in ("keyword_extraction", "response_format", "hashing_kv",
+                      "stream", "enable_cot", "history_messages"):
+                kwargs.pop(k, None)
+
+            if history_messages is None:
+                history_messages = []
+
+            client_kwargs = {
+                "api_key": args.llm_binding_api_key,
+                "timeout": llm_timeout,
+            }
+            if args.llm_binding_host:
+                client_kwargs["base_url"] = args.llm_binding_host
+            client = AsyncAnthropic(**client_kwargs)
+
+            messages = list(history_messages)
+            messages.append({"role": "user", "content": prompt})
+
+            create_params = {
+                "model": args.llm_model,
+                "messages": messages,
+                "max_tokens": int(os.getenv("ANTHROPIC_LLM_MAX_TOKENS", "8192")),
+            }
+            if system_prompt:
+                create_params["system"] = system_prompt
+            for k, v in kwargs.items():
+                if k not in ("timeout",):
+                    create_params[k] = v
+
+            msg = await _call_with_retry(client, create_params)
+            parts = []
+            for block in getattr(msg, "content", []) or []:
+                text = getattr(block, "text", None)
+                if text:
+                    parts.append(text)
+            return "".join(parts)
+
+        return optimized_anthropic_model_complete
+
     def create_llm_model_func(binding: str):
         """
         Create LLM model function based on binding type.
@@ -655,6 +731,8 @@ def create_app(args):
                 )
             elif binding == "gemini":
                 return create_optimized_gemini_llm_func(config_cache, args, llm_timeout)
+            elif binding == "anthropic":
+                return create_optimized_anthropic_llm_func(args, llm_timeout)
             else:  # openai and compatible
                 # Use optimized function with pre-processed configuration
                 return create_optimized_openai_llm_func(config_cache, args, llm_timeout)


### PR DESCRIPTION
## Description

Adds first-class support for Anthropic-protocol LLM endpoints, including third-party providers that expose an Anthropic-compatible API such as Zhipu's GLM Coding Plan (`https://open.bigmodel.cn/api/anthropic`).

`lightrag/llm/anthropic.py` already exists in the repo, but the FastAPI server did not whitelist `anthropic` in its LLM-binding selector and did not provide a factory wired to the optimized server pipeline, so users could not select it via `LLM_BINDING=anthropic` in `.env`. This PR closes that gap.

## Related Issues

Several community discussions ask how to use Zhipu / GLM-Coding-Plan as a backend (the plan exposes an Anthropic-compatible endpoint; native Anthropic SDK works against it as long as `base_url` is overridable). This is the cleanest path.

## Changes Made

- Whitelist `anthropic` in the LLM binding selector (`create_app`).
- Add `create_optimized_anthropic_llm_func` factory:
  - Uses `anthropic.AsyncAnthropic` with optional custom `base_url` so the same code path serves both the official Anthropic API (no host) and Anthropic-clone backends.
  - Non-streaming `messages.create` — more compatible with Anthropic-clone backends whose SSE stream may not exactly match the official SDK's expectations (Zhipu's stream emits `Message` objects rather than the SDK's expected `MessageStream`, which broke the existing `lightrag/llm/anthropic.py` flow).
  - Filters incoming kwargs that aren't valid for `messages.create` (`keyword_extraction`, `response_format`, `hashing_kv`, `stream`, `enable_cot`, `history_messages`).
  - Default `max_tokens` from env `ANTHROPIC_LLM_MAX_TOKENS=8192` — the Anthropic API requires it but LightRAG core does not pass one.
  - `tenacity` retry with random-exponential backoff (4s..120s, up to 10 attempts) on `RateLimitError` / `APIConnectionError` / `APITimeoutError`. Required for Zhipu Coding Plan whose burst concurrency cap is undocumented and triggers transient 429s — without retry, the entire ingestion job fails docs at random.
- Add `anthropic` branch to `create_llm_model_func` so the new factory is wired up.

## Usage

For Zhipu (Anthropic-compatible endpoint):
```env
LLM_BINDING=anthropic
LLM_BINDING_HOST=https://open.bigmodel.cn/api/anthropic
LLM_BINDING_API_KEY=<your_zhipu_api_key>
LLM_MODEL=glm-5.1
```

For the official Anthropic API, just omit `LLM_BINDING_HOST`.

## Checklist

- [x] Changes tested locally — ran a multi-thousand-document ingestion against Zhipu's `https://open.bigmodel.cn/api/anthropic` endpoint, with `glm-5.1`, embedding via local Ollama `bge-m3`. Stable under `MAX_PARALLEL_INSERT=10`, `MAX_ASYNC=10`.
- [x] Same pattern as the existing OpenAI / Gemini / Ollama optimized factories
- [x] No changes to existing bindings
- [ ] Documentation update — happy to add a section to README / `env.example` if maintainers want it

## Additional Notes

The retry behavior is intentionally generous (10 attempts, up to 120s backoff) because third-party Anthropic-clone backends can have very tight per-account concurrency caps and the failure mode without retry is silent data loss in the doc pipeline. For the official Anthropic API the retries virtually never trigger.