### PR TITLE
fix(PGGraphStorage): edge properties lost on upsert with Apache AGE

### DIFF
--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -5162,14 +5162,21 @@ class PGGraphStorage(BaseGraphStorage):
             edge_data (dict): dictionary of properties to set on the edge
         """
         # AGE does not support binding a full agtype map in ``SET r += $props``
-        # (verified on AGE 1.5.0). Keep endpoint identifiers parameterized and
-        # inline a safely escaped property map literal for the relationship payload.
-        props_literal = self._format_properties(edge_data)
+        # (verified on AGE 1.5.0), and the inlined literal form ``SET r += {map}``
+        # is also silently ignored for edges (though it works for nodes). Individual
+        # ``SET r.key = value`` assignments run without error but also do not persist.
+        # The only reliable way to write edge properties in AGE is to inline them
+        # directly in a CREATE clause. We use OPTIONAL MATCH to delete any existing
+        # edge first so the operation remains idempotent.
+        props_literal = self._format_properties(edge_data) if edge_data else "{}"
         cypher_query = f"""MATCH (source:base {{entity_id: $src_id}})
                      WITH source
                      MATCH (target:base {{entity_id: $tgt_id}})
-                     MERGE (source)-[r:DIRECTED]-(target)
-                     SET r += {props_literal}
+                     WITH source, target
+                     OPTIONAL MATCH (source)-[old:DIRECTED]-(target)
+                     DELETE old
+                     WITH source, target
+                     CREATE (source)-[r:DIRECTED {props_literal}]->(target)
                      RETURN r"""
 
         query = (

--- a/tests/test_postgres_upsert_edge_cypher.py
+++ b/tests/test_postgres_upsert_edge_cypher.py
@@ -1,12 +1,13 @@
 """
 Unit tests for PGGraphStorage.upsert_edge Cypher query generation.
 
-Verifies the Cypher query sent to AGE contains exactly one SET clause
-(regression test for duplicate SET copy-paste bug).
+Verifies the Cypher query sent to AGE uses the OPTIONAL MATCH + DELETE +
+CREATE pattern with inline edge properties — the only reliable way to write
+edge properties in Apache AGE (SET r += {...}, ON CREATE/ON MATCH SET, and
+SET r.key = value all silently fail for DIRECTED edges).
 """
 
 import json
-import re
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -34,8 +35,13 @@ def make_graph_storage() -> PGGraphStorage:
 
 
 @pytest.mark.asyncio
-async def test_upsert_edge_single_set_clause():
-    """The Cypher query must contain exactly one SET clause, not a duplicate."""
+async def test_upsert_edge_uses_delete_create_not_set():
+    """Cypher must use OPTIONAL MATCH + DELETE + CREATE — not SET-based update.
+
+    Apache AGE silently drops edge properties written via SET r += {...},
+    SET r.key = value, and ON CREATE/ON MATCH SET. The only reliable pattern
+    is to delete any existing edge and CREATE a new one with inline props.
+    """
     storage = make_graph_storage()
     captured_sql: list[str] = []
 
@@ -51,14 +57,16 @@ async def test_upsert_edge_single_set_clause():
     assert len(captured_sql) == 1
     sql = captured_sql[0]
 
-    # Count occurrences of SET in the Cypher query
-    set_count = len(re.findall(r"\bSET\b", sql))
-    assert set_count == 1, f"Expected 1 SET clause, found {set_count} in: {sql}"
+    # The new query must not contain any SET-based edge update — those silently
+    # fail against AGE. All edge props live inline in the CREATE clause.
+    assert "SET r" not in sql, f"Edge SET clauses are silently dropped by AGE: {sql}"
+    assert "ON CREATE SET" not in sql
+    assert "ON MATCH SET" not in sql
 
 
 @pytest.mark.asyncio
-async def test_upsert_edge_contains_merge_and_set():
-    """The Cypher query must contain MERGE and SET with edge properties."""
+async def test_upsert_edge_contains_optional_match_delete_create():
+    """The Cypher query must use OPTIONAL MATCH + DELETE + CREATE with inline props."""
     storage = make_graph_storage()
     captured_sql: list[str] = []
 
@@ -70,9 +78,30 @@ async def test_upsert_edge_contains_merge_and_set():
         await storage.upsert_edge("Alice", "Bob", {"weight": "0.5"})
 
     sql = captured_sql[0]
-    assert "MERGE" in sql
-    assert "SET r +=" in sql
+    assert "OPTIONAL MATCH (source)-[old:DIRECTED]-(target)" in sql
+    assert "DELETE old" in sql
+    assert "CREATE (source)-[r:DIRECTED" in sql
+    assert "]->(target)" in sql
+    # Edge properties must be inlined into the CREATE clause as a literal map.
+    assert "`weight`: \"0.5\"" in sql
     assert "RETURN r" in sql
+
+
+@pytest.mark.asyncio
+async def test_upsert_edge_handles_empty_props():
+    """Empty edge_data must inline an empty literal map, not crash."""
+    storage = make_graph_storage()
+    captured_sql: list[str] = []
+
+    async def fake_query(sql, **kwargs):
+        captured_sql.append(sql)
+        return []
+
+    with patch.object(storage, "_query", side_effect=fake_query):
+        await storage.upsert_edge("Alice", "Bob", {})
+
+    sql = captured_sql[0]
+    assert "CREATE (source)-[r:DIRECTED {}]->(target)" in sql
 
 
 @pytest.mark.asyncio

--- a/tests/test_postgres_upsert_edge_cypher.py
+++ b/tests/test_postgres_upsert_edge_cypher.py
@@ -83,7 +83,7 @@ async def test_upsert_edge_contains_optional_match_delete_create():
     assert "CREATE (source)-[r:DIRECTED" in sql
     assert "]->(target)" in sql
     # Edge properties must be inlined into the CREATE clause as a literal map.
-    assert "`weight`: \"0.5\"" in sql
+    assert '`weight`: "0.5"' in sql
     assert "RETURN r" in sql
 
 


### PR DESCRIPTION
Hey! 👋 I ran into a frustrating issue where the LightRAG knowledge graph web UI was rendering nodes correctly but showing **no labels on any edges** after uploading documents with the PostgreSQL backend. Spent a while debugging and traced it down to `upsert_edge` in `PGGraphStorage`.

## What's happening

`SET r += {map_literal}` silently drops all properties on **edges** in Apache AGE — it works fine for nodes, but for relationships the write just disappears without an error. So every `DIRECTED` edge ends up with `properties = {}`, and relation keywords/descriptions/weights are never stored.

The comment in the code already flags that the parameterized form (`SET r += $props`) doesn't work, and the inlined literal was meant as the fix — but unfortunately the inlined form has the same silent failure for edges.

I tried a couple of alternatives before finding one that works:

| Pattern | Result on AGE 1.5.0 |
|---------|---------------------|
| `SET r += {map_literal}` | ❌ silently ignored |
| `ON CREATE SET / ON MATCH SET` | ❌ syntax error |
| `SET r.key = value` | ❌ no error, but not persisted |
| Inline props in `CREATE` clause | ✅ works |

## The fix

The only reliable way to write edge properties in AGE is to inline them directly in a `CREATE` statement. Since you can't do `MERGE + CREATE`, I use `OPTIONAL MATCH` to find and delete the old edge first, then `CREATE` the new one with all properties inlined:

```cypher
MATCH (source:base {entity_id: $src_id})
WITH source
MATCH (target:base {entity_id: $tgt_id})
WITH source, target
OPTIONAL MATCH (source)-[old:DIRECTED]-(target)
DELETE old
WITH source, target
CREATE (source)-[r:DIRECTED {props_literal}]->(target)
RETURN r
```

`_format_properties` (already in the codebase) produces exactly the inlined map literal needed here — so it's a small, self-contained change.

## Verification

```sql
LOAD 'age';
SET search_path = ag_catalog, $user, public;
SELECT * FROM cypher('chunk_entity_relation', $$
  MATCH (a)-[r:DIRECTED]->(b)
  RETURN a.entity_id, b.entity_id, properties(r)
  LIMIT 5
$$) AS (src agtype, tgt agtype, props agtype);
```

Before: `props` = `{}` for every edge.
After: `props` = `{keywords: ..., weight: 1.0, description: ...}` ✅

Tested on Apache AGE 1.5.0 / PostgreSQL 16. Hope this helps someone else who's been staring at a graph with invisible edge labels! 😄