### PR TITLE
fix(embed): normalize text for OpenAI embeddings; demo safety

### DIFF
--- a/examples/lightrag_openai_demo.py
+++ b/examples/lightrag_openai_demo.py
@@ -89,6 +89,7 @@ async def initialize_rag():
 
 
 async def main():
+    rag = None
     # Check if OPENAI_API_KEY environment variable exists
     if not os.getenv("OPENAI_API_KEY"):
         print(

--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -2,6 +2,7 @@ from ..utils import verbose_debug, VERBOSE_DEBUG
 import os
 import logging
 import warnings
+import unicodedata
 
 from collections.abc import AsyncIterator
 
@@ -97,6 +98,40 @@ EMBEDDING_USE_BASE64: bool = os.getenv("EMBEDDING_USE_BASE64", "true").lower() i
     "1",
     "yes",
 )
+
+# Optional compatibility workaround for environments that fail on typographic
+# punctuation before the OpenAI request is sent (for example, legacy Windows
+# console/logging/proxy paths). Disabled by default so embedded text matches
+# stored text unless the caller explicitly opts in.
+OPENAI_EMBED_NORMALIZE_UNICODE: bool = os.getenv(
+    "OPENAI_EMBED_NORMALIZE_UNICODE", "false"
+).lower() in ("true", "1", "yes")
+
+
+def _normalize_texts_for_openai_embedding(texts: list[str]) -> list[str]:
+    """Normalize Unicode for the opt-in OpenAI embedding compatibility path.
+
+    Real documents often contain typographic quotes. The OpenAI SDK itself sends
+    UTF-8, but surrounding environments may still choke before the request is
+    sent. When ``OPENAI_EMBED_NORMALIZE_UNICODE`` is enabled, NFC plus ASCII
+    quote mapping provides a narrow workaround without changing default
+    embedding semantics.
+    """
+    trans = str.maketrans(
+        {
+            "\u2018": "'",
+            "\u2019": "'",
+            "\u201c": '"',
+            "\u201d": '"',
+        }
+    )
+    out: list[str] = []
+    for t in texts:
+        if not t:
+            out.append(t)
+            continue
+        out.append(unicodedata.normalize("NFC", t).translate(trans))
+    return out
 
 
 def _get_tiktoken_encoding_for_model(model: str) -> Any:
@@ -917,6 +952,9 @@ async def openai_embed(
         RateLimitError: If the OpenAI API rate limit is exceeded.
         APITimeoutError: If the OpenAI API request times out.
     """
+    texts = list(texts)
+    if OPENAI_EMBED_NORMALIZE_UNICODE:
+        texts = _normalize_texts_for_openai_embedding(texts)
     # Apply context-based prefixes if provided
     if context == "query" and query_prefix:
         texts = [query_prefix + text for text in texts]


### PR DESCRIPTION
## Context

Follow-up to the Unicode/ascii-codec reports seen around real extracted text with typographic punctuation, including the downstream RAG-Anything discussion in #184.

I do **not** have the original full `UnicodeEncodeError` traceback available anymore, so this PR no longer treats smart quotes as a proven OpenAI SDK failure mode. The OpenAI client should send UTF-8 correctly; the error is more likely to come from surrounding runtime paths (Windows console/logging, proxy, older tokenization stack, etc.).

## Changes

- Add an opt-in compatibility flag: `OPENAI_EMBED_NORMALIZE_UNICODE=true`.
- When enabled, `openai_embed` normalizes input text with NFC and maps common smart quotes to straight quotes before prefixing/truncation/API submission.
- Keep default behavior unchanged: normalization is **off by default**, so embedded text matches stored text unless callers explicitly opt in.
- `examples/lightrag_openai_demo.py`: initialize `rag = None` so the `finally` block cannot raise if startup exits early (for example, missing API key).

## Compatibility note

This is intentionally a narrow escape hatch, not a root-cause fix. If the project prefers ingestion-boundary normalization instead, I’m happy to close or rework this toward that direction.