### PR TITLE
fix(chunker): preserve HTML table row group wrappers

### DIFF
--- a/lightrag/chunker/paragraph_semantic.py
+++ b/lightrag/chunker/paragraph_semantic.py
@@ -90,6 +90,18 @@ _TABLE_FORMAT_RE = re.compile(r"""format\s*=\s*["'](?P<fmt>[^"']+)["']""")
 # so a non-greedy match is sufficient for well-formed input.
 _HTML_TR_RE = re.compile(r"<tr\b[^>]*>.*?</tr>", re.DOTALL | re.IGNORECASE)
 
+# Combined scanner for row-grouping wrappers and rows themselves. Used
+# to attribute each <tr> to its surrounding <thead>/<tbody>/<tfoot> so
+# the wrapper can be reconstructed around chunk boundaries instead of
+# being silently dropped during row-level table splitting.
+_HTML_ROW_PARTS_RE = re.compile(
+    r"(?P<wrap></?(?:thead|tbody|tfoot)\b[^>]*>)" r"|(?P<tr><tr\b[^>]*>.*?</tr>)",
+    re.DOTALL | re.IGNORECASE,
+)
+_HTML_WRAPPER_TAG_RE = re.compile(
+    r"<(?P<slash>/?)(?P<name>thead|tbody|tfoot)\b", re.IGNORECASE
+)
+
 _LEGACY_TABLE_CHUNK_SUFFIX_RE = re.compile(r"\s*\[表格片段\d+\]\s*$")
 _PART_SUFFIX_RE = re.compile(r"\s*\[part\s+\d+\]\s*$", re.IGNORECASE)
 
@@ -199,39 +211,88 @@ def _detect_table_format(attrs: str, body: str) -> str | None:
     return None
 
 
-def _split_html_rows(body: str) -> list[str] | None:
-    """Extract ``<tr>...</tr>`` rows from an HTML table body.
+def _split_html_rows(body: str) -> list[tuple[str, str]] | None:
+    """Extract ``<tr>...</tr>`` rows tagged with their wrapper context.
 
-    Returns the list of row strings (each preserved with its ``<tr>``
-    wrapper) or ``None`` if no row was found — the latter is the signal
-    for the caller to fall through to character splitting.
+    Returns a list of ``(wrapper_name, tr_str)`` tuples where
+    ``wrapper_name`` is ``"thead"`` / ``"tbody"`` / ``"tfoot"`` (lower-
+    cased) for rows that sit inside the corresponding wrapper, or ``""``
+    for rows outside any of those wrappers. ``None`` signals "no row
+    found" so the caller falls through to character splitting.
 
-    Text between rows (``<thead>`` / ``<tbody>`` wrappers, whitespace,
-    captions outside ``<tr>``) is dropped: each output string is a
-    self-contained row. This is a pragmatic simplification — full DOM
-    parsing would require ``lxml`` / ``beautifulsoup4``, an unjustified
-    dependency for a fallback path.
+    The wrapper attribution exists so :func:`_serialize_rows_with_wrappers`
+    can rebuild ``<thead>`` / ``<tbody>`` / ``<tfoot>`` around row groups
+    in each chunk — without it, oversized HTML tables would emerge from
+    Stage B with their structural wrappers silently stripped.
+
+    Whitespace, captions, comments, ``<colgroup>`` and any other text
+    outside the recognised row-wrappers is still dropped — this is a
+    regex extractor, not a full DOM parser. Wrapper attributes (e.g.
+    ``<thead class="…">``) are also dropped on re-emission; chunked
+    output uses bare wrapper tags.
     """
-    rows = _HTML_TR_RE.findall(body or "")
+    rows: list[tuple[str, str]] = []
+    current_wrapper = ""
+    for match in _HTML_ROW_PARTS_RE.finditer(body or ""):
+        wrap = match.group("wrap")
+        tr = match.group("tr")
+        if wrap is not None:
+            tag = _HTML_WRAPPER_TAG_RE.match(wrap)
+            if tag:
+                slash = tag.group("slash")
+                name = tag.group("name").lower()
+                if slash == "/":
+                    if current_wrapper == name:
+                        current_wrapper = ""
+                else:
+                    current_wrapper = name
+        elif tr is not None:
+            rows.append((current_wrapper, tr))
     if not rows:
         return None
     return rows
 
 
+def _serialize_rows_with_wrappers(rows: list[tuple[str, str]]) -> str:
+    """Re-emit rows grouped under their original ``<thead>`` / ``<tbody>`` /
+    ``<tfoot>`` wrappers.
+
+    Consecutive rows sharing the same wrapper name collapse into a
+    single wrapper block; transitions emit a closing tag for the
+    previous wrapper and an opening tag for the next. Rows tagged with
+    ``""`` (no wrapper) emit bare ``<tr>...</tr>``.
+    """
+    parts: list[str] = []
+    current_wrapper = ""
+    for wrapper, tr in rows:
+        if wrapper != current_wrapper:
+            if current_wrapper:
+                parts.append(f"</{current_wrapper}>")
+            if wrapper:
+                parts.append(f"<{wrapper}>")
+            current_wrapper = wrapper
+        parts.append(tr)
+    if current_wrapper:
+        parts.append(f"</{current_wrapper}>")
+    return "".join(parts)
+
+
 def _split_html_rows_by_tokens(
-    rows: list[str],
+    rows: list[tuple[str, str]],
     tokenizer: Tokenizer,
     *,
     target_max: int,
     target_ideal: int,
     last_min: int,
-) -> list[list[str]]:
-    """HTML-string analog of :func:`_split_rows_by_tokens`.
+) -> list[list[tuple[str, str]]]:
+    """HTML-tuple analog of :func:`_split_rows_by_tokens`.
 
-    Same balanced-split + tail-merge algorithm; rows are concatenated
-    with ``""`` (rather than serialised as JSON) for token measurement.
+    Same balanced-split + tail-merge algorithm; tokens are measured on
+    the row payloads (``tr_str``) only — wrapper overhead is amortised
+    later by the per-chunk serialiser plus the re-split-on-overflow
+    safety net in :func:`_split_table_text`.
     """
-    total = _count_tokens(tokenizer, "".join(rows))
+    total = _count_tokens(tokenizer, "".join(tr for _, tr in rows))
     if total <= target_max or len(rows) <= 1:
         return [rows]
 
@@ -242,7 +303,7 @@ def _split_html_rows_by_tokens(
     target_chunks = min(target_chunks, len(rows))
     target_rows = len(rows) / target_chunks
 
-    chunks: list[list[str]] = []
+    chunks: list[list[tuple[str, str]]] = []
     start = 0
     for i in range(target_chunks):
         if i == target_chunks - 1:
@@ -258,10 +319,10 @@ def _split_html_rows_by_tokens(
             break
 
     if len(chunks) >= 2:
-        last_text = "".join(chunks[-1])
+        last_text = "".join(tr for _, tr in chunks[-1])
         if _count_tokens(tokenizer, last_text) < last_min:
             merged = chunks[-2] + chunks[-1]
-            merged_tokens = _count_tokens(tokenizer, "".join(merged))
+            merged_tokens = _count_tokens(tokenizer, "".join(tr for _, tr in merged))
             if merged_tokens <= target_max:
                 chunks[-2] = merged
                 chunks.pop()
@@ -475,8 +536,12 @@ def _split_table_text(
                 last_min=body_last_min,
             )
 
-            def serialize(chunk_rows: list[str]) -> str:
-                return f"<table {attrs}>{''.join(chunk_rows)}</table>"
+            def serialize(chunk_rows: list[tuple[str, str]]) -> str:
+                return (
+                    f"<table {attrs}>"
+                    f"{_serialize_rows_with_wrappers(chunk_rows)}"
+                    f"</table>"
+                )
 
     if row_chunks is None or serialize is None:
         # No row boundary available (single-row table, parse failure,

--- a/tests/test_paragraph_semantic_table_split.py
+++ b/tests/test_paragraph_semantic_table_split.py
@@ -342,7 +342,10 @@ def test_split_html_rows_extracts_tr_elements():
     rows = _split_html_rows(body)
     assert rows is not None
     assert len(rows) == 3
-    assert all(r.startswith("<tr") and r.endswith("</tr>") for r in rows)
+    # Each row carries its parent wrapper so the chunk serialiser can
+    # rebuild <thead>/<tbody> instead of dropping them silently.
+    assert [w for w, _ in rows] == ["thead", "tbody", "tbody"]
+    assert all(tr.startswith("<tr") and tr.endswith("</tr>") for _, tr in rows)
 
 
 @pytest.mark.offline
@@ -423,6 +426,51 @@ def test_split_table_text_html_table_split_by_tr():
     # rows individually exceeds target_max, so no character fallback).
     assert all(p.startswith("<table ") and p.endswith("</table>") for p in pieces)
     assert all(_count_tokens(tokenizer, p) <= 500 for p in pieces)
+
+
+@pytest.mark.offline
+def test_split_table_text_html_preserves_thead_tbody_wrappers():
+    # When an HTML table mixes <thead> and <tbody>, the row splitter
+    # used to drop the wrappers entirely — the chunked output came back
+    # as bare <tr> sequences. The fix re-emits each wrapper around its
+    # rows in every chunk so the table structure survives splitting.
+    tokenizer = _make_tokenizer()
+    head_row = "<tr><th>" + ("h" * 80) + "</th></tr>"
+    body_rows = "".join(f"<tr><td>{'b' * 80}{i}</td></tr>" for i in range(4))
+    body = f"<thead>{head_row}</thead><tbody>{body_rows}</tbody>"
+    table_text = f'<table id="tb-mixed" format="html">{body}</table>'
+
+    pieces = _split_table_text(
+        table_text,
+        tokenizer=tokenizer,
+        target_max=400,
+        target_ideal=280,
+        last_min=64,
+    )
+
+    # Multiple chunks expected and every chunk must remain a legal
+    # <table>-wrapped fragment.
+    assert len(pieces) >= 2
+    assert all(p.startswith("<table ") and p.endswith("</table>") for p in pieces)
+    # Every chunk that contains the header row must still wrap it in
+    # <thead>...</thead>; every chunk with body rows must wrap them in
+    # <tbody>...</tbody>. Before the fix, both wrappers vanished.
+    for piece in pieces:
+        if "<th>" in piece:
+            assert "<thead>" in piece and "</thead>" in piece, piece
+        if "<td>" in piece:
+            assert "<tbody>" in piece and "</tbody>" in piece, piece
+    # Round-trip: concatenating just the row payloads from every chunk
+    # recovers the original row sequence in order.
+    extracted_rows: list[str] = []
+    import re
+
+    for piece in pieces:
+        extracted_rows.extend(
+            re.findall(r"<tr\b[^>]*>.*?</tr>", piece, re.DOTALL | re.IGNORECASE)
+        )
+    expected_rows = re.findall(r"<tr\b[^>]*>.*?</tr>", body, re.DOTALL | re.IGNORECASE)
+    assert extracted_rows == expected_rows
 
 
 @pytest.mark.offline


### PR DESCRIPTION
## Summary

Preserve HTML table row-group wrappers when paragraph-semantic chunking splits oversized HTML tables by `<tr>` rows.

## Motivation

Oversized HTML tables that included `<thead>`, `<tbody>`, or `<tfoot>` were split into legal `<table>` fragments, but the row-group wrappers were silently dropped. This made header/body structure less clear for downstream parsing, display, and retrieval context.

## What's changed

- Track each extracted HTML `<tr>` row with its enclosing row-group wrapper.
- Re-emit `<thead>`, `<tbody>`, and `<tfoot>` around grouped rows when serializing split table chunks.
- Add regression coverage for mixed `<thead>` / `<tbody>` tables and row-order preservation.

## What's broken and how it works

Wrapper attributes and non-row content such as captions or colgroups are still not preserved by this regex-based fallback path. The fix preserves the structural row-group tags themselves without adding a full HTML parser dependency.

## Testing

- `./scripts/test.sh tests/test_paragraph_semantic_table_split.py`
- `uv run ruff check lightrag/chunker/paragraph_semantic.py tests/test_paragraph_semantic_table_split.py`
