### PR TITLE
Refactor multimodal: status semantics, nested chunk schema, per-chunk entity injection

### DIFF
--- a/lightrag/chunk_schema.py
+++ b/lightrag/chunk_schema.py
@@ -1,0 +1,201 @@
+"""Chunk schema helpers shared across the chunking + extraction pipeline.
+
+Three responsibilities live here so chunker implementations and the pipeline
+both consume identical normalization rules:
+
+- :func:`normalize_chunk_heading` collapses the legacy flat
+  ``heading``/``parent_headings``/``level`` triple and the new nested form
+  into the canonical ``{"level", "heading", "parent_headings"}`` dict.
+- :func:`normalize_chunk_sidecar` validates the new ``sidecar`` payload and
+  ensures ``refs`` is always present as a list (single-source items may omit
+  it before normalization; we materialize a single-element list for the
+  storage layer).
+- :func:`strip_internal_multimodal_markup_for_extraction` rewrites
+  ``<cite>`` / ``<drawing>`` / ``<equation>`` markup so the entity-extraction
+  LLM sees a clean text body. The original ``chunk["content"]`` is never
+  mutated; the cleaned string is only used to build the extraction prompt.
+
+The clean function is intentionally conservative: it only strips
+parser-emitted identifier attributes that have no business reaching the LLM
+(``id``, ``refid``, ``path``, ``src``). Visible captions and equation bodies
+are preserved so the extracted entities can still ground against them.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+_SIDECAR_TYPES = frozenset({"block", "drawing", "table", "equation"})
+
+
+def normalize_chunk_heading(dp: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the canonical nested heading dict or ``None`` when absent.
+
+    Accepts:
+
+    - ``dp["heading"]`` already a dict ``{"level", "heading", "parent_headings"}``.
+    - Legacy flat fields ``heading: str`` + ``parent_headings: list[str]`` +
+      ``level: int``.
+
+    Empty / missing inputs collapse to ``None`` so callers can simply omit
+    the field when writing the chunk record.
+    """
+    nested = dp.get("heading")
+    if isinstance(nested, dict):
+        heading_text = str(nested.get("heading") or "").strip()
+        parents_raw = nested.get("parent_headings") or []
+        level_raw = nested.get("level", 0)
+    else:
+        heading_text = str(nested or "").strip()
+        parents_raw = dp.get("parent_headings") or []
+        level_raw = dp.get("level", 0)
+
+    parent_headings: list[str] = []
+    if isinstance(parents_raw, list):
+        for entry in parents_raw:
+            text = str(entry or "").strip()
+            if text:
+                parent_headings.append(text)
+
+    try:
+        level = int(level_raw or 0)
+    except (TypeError, ValueError):
+        level = 0
+
+    if not heading_text and not parent_headings and level == 0:
+        return None
+
+    return {
+        "level": level,
+        "heading": heading_text,
+        "parent_headings": parent_headings,
+    }
+
+
+def normalize_chunk_sidecar(dp: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the canonical sidecar dict or ``None`` when absent / invalid.
+
+    Output shape::
+
+        {"type": <one of block|drawing|table|equation>,
+         "id":   <primary source id>,
+         "refs": [{"type": ..., "id": ...}, ...]}
+
+    ``refs`` is always materialized as a list with at least the primary id.
+    Single-source chunks therefore land in storage with ``refs=[{type,id}]``
+    so downstream consumers don't need to special-case the field's presence.
+    """
+    sidecar = dp.get("sidecar")
+    if not isinstance(sidecar, dict):
+        return None
+    sidecar_type = str(sidecar.get("type") or "").strip()
+    sidecar_id = str(sidecar.get("id") or "").strip()
+    if sidecar_type not in _SIDECAR_TYPES or not sidecar_id:
+        return None
+
+    refs_raw = sidecar.get("refs")
+    refs: list[dict[str, str]] = []
+    if isinstance(refs_raw, list):
+        for entry in refs_raw:
+            if not isinstance(entry, dict):
+                continue
+            ref_type = str(entry.get("type") or "").strip()
+            ref_id = str(entry.get("id") or "").strip()
+            if ref_type in _SIDECAR_TYPES and ref_id:
+                refs.append({"type": ref_type, "id": ref_id})
+    if not refs:
+        refs = [{"type": sidecar_type, "id": sidecar_id}]
+
+    return {"type": sidecar_type, "id": sidecar_id, "refs": refs}
+
+
+# `<cite type="..." refid="...">visible text</cite>` → `visible text`.
+_CITE_RE = re.compile(
+    r"<cite\b[^>]*>(.*?)</cite>",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+
+# Self-closing `<drawing ...>` placeholder.  We keep `caption` (visible) and
+# drop `id`, `path`, `src`, `format`, etc.  Tags without any caption are
+# removed entirely so they don't pollute extraction input.
+_DRAWING_RE = re.compile(
+    r"<drawing\b([^>]*)/>",
+    flags=re.IGNORECASE,
+)
+
+# Container `<equation id="..." format="...">latex</equation>`.  Strip
+# identifier attributes; preserve the body and the `format` attribute so
+# extraction still sees the equation is a structured element.
+_EQUATION_RE = re.compile(
+    r"<equation\b([^>]*)>(.*?)</equation>",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+
+# Match attribute pairs like ``caption="text with \"escapes\""``.  We treat
+# only the safe identifier-style attributes; complex quoting is rare in
+# parser output.
+_ATTR_RE = re.compile(
+    r'(\w+)\s*=\s*"((?:[^"\\]|\\.)*)"',
+)
+
+
+def _attrs_to_dict(attr_string: str) -> dict[str, str]:
+    return {match.group(1).lower(): match.group(2) for match in _ATTR_RE.finditer(attr_string)}
+
+
+def _format_attrs(pairs: list[tuple[str, str]]) -> str:
+    return "".join(f' {k}="{v}"' for k, v in pairs if v)
+
+
+def _replace_drawing(match: re.Match[str]) -> str:
+    attrs = _attrs_to_dict(match.group(1))
+    caption = attrs.get("caption", "")
+    if not caption.strip():
+        return ""
+    return f"<drawing{_format_attrs([('caption', caption)])} />"
+
+
+def _replace_equation(match: re.Match[str]) -> str:
+    attrs = _attrs_to_dict(match.group(1))
+    body = match.group(2)
+    keep: list[tuple[str, str]] = []
+    fmt = attrs.get("format", "")
+    if fmt:
+        keep.append(("format", fmt))
+    caption = attrs.get("caption", "")
+    if caption.strip():
+        keep.append(("caption", caption))
+    return f"<equation{_format_attrs(keep)}>{body}</equation>"
+
+
+def strip_internal_multimodal_markup_for_extraction(content: str) -> str:
+    """Strip parser-internal identifiers from a chunk content string.
+
+    Only the entity-extraction prompt should receive the cleaned form;
+    callers must NOT mutate the stored chunk ``content`` so query-time
+    citations still resolve back to the original parser output.
+
+    Transformations:
+
+    - ``<cite type="…" refid="…">Table 1</cite>`` → ``Table 1``
+    - ``<drawing id="dr-…" path="…" src="…" caption="Fig 1" />``
+        → ``<drawing caption="Fig 1" />``
+        (drops the entire tag when no caption is present)
+    - ``<equation id="eq-…" format="latex">…</equation>``
+        → ``<equation format="latex">…</equation>``
+    """
+    if not content:
+        return content
+    cleaned = _CITE_RE.sub(lambda m: m.group(1), content)
+    cleaned = _DRAWING_RE.sub(_replace_drawing, cleaned)
+    cleaned = _EQUATION_RE.sub(_replace_equation, cleaned)
+    return cleaned
+
+
+__all__ = [
+    "normalize_chunk_heading",
+    "normalize_chunk_sidecar",
+    "strip_internal_multimodal_markup_for_extraction",
+]

--- a/lightrag/chunk_schema.py
+++ b/lightrag/chunk_schema.py
@@ -142,7 +142,10 @@ _ATTR_RE = re.compile(
 
 
 def _attrs_to_dict(attr_string: str) -> dict[str, str]:
-    return {match.group(1).lower(): match.group(2) for match in _ATTR_RE.finditer(attr_string)}
+    return {
+        match.group(1).lower(): match.group(2)
+        for match in _ATTR_RE.finditer(attr_string)
+    }
 
 
 def _format_attrs(pairs: list[tuple[str, str]]) -> str:

--- a/lightrag/chunk_schema.py
+++ b/lightrag/chunk_schema.py
@@ -133,6 +133,16 @@ _EQUATION_RE = re.compile(
     flags=re.IGNORECASE | re.DOTALL,
 )
 
+# Container `<table id="tb-..." format="json" caption="...">rows</table>`.
+# Native parser emits the internal ``tb-<doc>-NNNN`` identifier here, which
+# would otherwise leak into the entity-extraction prompt and become a noisy
+# entity. Strip ``id``; keep ``format`` / ``caption`` (and the body verbatim)
+# so the extractor still recognizes the element as a structured table.
+_TABLE_RE = re.compile(
+    r"<table\b([^>]*)>(.*?)</table>",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+
 # Match attribute pairs like ``caption="text with \"escapes\""``.  We treat
 # only the safe identifier-style attributes; complex quoting is rare in
 # parser output.
@@ -173,6 +183,19 @@ def _replace_equation(match: re.Match[str]) -> str:
     return f"<equation{_format_attrs(keep)}>{body}</equation>"
 
 
+def _replace_table(match: re.Match[str]) -> str:
+    attrs = _attrs_to_dict(match.group(1))
+    body = match.group(2)
+    keep: list[tuple[str, str]] = []
+    fmt = attrs.get("format", "")
+    if fmt:
+        keep.append(("format", fmt))
+    caption = attrs.get("caption", "")
+    if caption.strip():
+        keep.append(("caption", caption))
+    return f"<table{_format_attrs(keep)}>{body}</table>"
+
+
 def strip_internal_multimodal_markup_for_extraction(content: str) -> str:
     """Strip parser-internal identifiers from a chunk content string.
 
@@ -186,6 +209,8 @@ def strip_internal_multimodal_markup_for_extraction(content: str) -> str:
     - ``<drawing id="dr-…" path="…" src="…" caption="Fig 1" />``
         → ``<drawing caption="Fig 1" />``
         (drops the entire tag when no caption is present)
+    - ``<table id="tb-…" format="json" caption="…">rows</table>``
+        → ``<table format="json" caption="…">rows</table>``
     - ``<equation id="eq-…" format="latex">…</equation>``
         → ``<equation format="latex">…</equation>``
     """
@@ -193,6 +218,7 @@ def strip_internal_multimodal_markup_for_extraction(content: str) -> str:
         return content
     cleaned = _CITE_RE.sub(lambda m: m.group(1), content)
     cleaned = _DRAWING_RE.sub(_replace_drawing, cleaned)
+    cleaned = _TABLE_RE.sub(_replace_table, cleaned)
     cleaned = _EQUATION_RE.sub(_replace_equation, cleaned)
     return cleaned
 

--- a/lightrag/chunker/paragraph_semantic.py
+++ b/lightrag/chunker/paragraph_semantic.py
@@ -225,6 +225,16 @@ def _split_html_rows_by_tokens(
     return chunks
 
 
+def _dedup_preserving_order(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for v in values:
+        if v and v not in seen:
+            seen.add(v)
+            out.append(v)
+    return out
+
+
 def _new_block(
     *,
     heading: str,
@@ -233,6 +243,7 @@ def _new_block(
     paragraphs: list[dict[str, Any]],
     table_chunk_role: str,
     tokenizer: Tokenizer,
+    blockids: list[str] | None = None,
 ) -> dict[str, Any]:
     content = "\n".join(p["text"] for p in paragraphs)
     return {
@@ -243,6 +254,9 @@ def _new_block(
         "content": content,
         "tokens": _count_tokens(tokenizer, content),
         "table_chunk_role": table_chunk_role,
+        # Ordered list of source blockids (deduped). Empty when the input
+        # blocks.jsonl row did not carry a blockid (raw/legacy input).
+        "blockids": _dedup_preserving_order(list(blockids or [])),
     }
 
 
@@ -550,6 +564,7 @@ def _expand_block_with_table_splits(
                 paragraphs=cur_paras,
                 table_chunk_role=cur_role,
                 tokenizer=tokenizer,
+                blockids=block.get("blockids"),
             )
         )
         cur_paras.clear()
@@ -569,6 +584,7 @@ def _expand_block_with_table_splits(
                 paragraphs=paragraphs,
                 table_chunk_role=table_chunk_role,
                 tokenizer=tokenizer,
+                blockids=block.get("blockids"),
             )
         )
 
@@ -726,6 +742,7 @@ def _expand_block_with_table_splits(
                         paragraphs=[chunk_para],
                         table_chunk_role="middle",
                         tokenizer=tokenizer,
+                        blockids=block.get("blockids"),
                     )
                 )
 
@@ -749,6 +766,7 @@ def _split_long_block(
     target_max: int,
     target_ideal: int,
     chunk_overlap_token_size: int = 100,
+    blockids: list[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Split an oversized block into balanced sub-blocks at short-paragraph anchors.
 
@@ -776,6 +794,7 @@ def _split_long_block(
                 paragraphs=paragraphs,
                 table_chunk_role=table_chunk_role,
                 tokenizer=tokenizer,
+                blockids=blockids,
             )
         ]
 
@@ -900,6 +919,7 @@ def _split_long_block(
                     paragraphs=paragraphs,
                     table_chunk_role=table_chunk_role,
                     tokenizer=tokenizer,
+                    blockids=blockids,
                 )
             ]
 
@@ -920,6 +940,7 @@ def _split_long_block(
                     # construction (mirrors the anchor-split path below).
                     table_chunk_role=table_chunk_role if i == 0 else "none",
                     tokenizer=tokenizer,
+                    blockids=blockids,
                 )
             )
         return sub_blocks
@@ -956,6 +977,7 @@ def _split_long_block(
                     paragraphs=slice_paras,
                     table_chunk_role=cur_role,
                     tokenizer=tokenizer,
+                    blockids=blockids,
                 )
             )
         # Anchor becomes the first paragraph (and heading) of the next sub-block.
@@ -978,6 +1000,7 @@ def _split_long_block(
                 paragraphs=tail,
                 table_chunk_role=cur_role,
                 tokenizer=tokenizer,
+                blockids=blockids,
             )
         )
 
@@ -999,6 +1022,7 @@ def _split_long_block(
                     target_max=target_max,
                     target_ideal=target_ideal,
                     chunk_overlap_token_size=chunk_overlap_token_size,
+                    blockids=sub.get("blockids") or blockids,
                 )
             )
         else:
@@ -1031,6 +1055,9 @@ def _merged_pair(
     base = left if keep == "left" else right
     paragraphs = list(left["paragraphs"]) + list(right["paragraphs"])
     content = left["content"] + "\n\n" + right["content"]
+    merged_blockids = _dedup_preserving_order(
+        list(left.get("blockids") or []) + list(right.get("blockids") or [])
+    )
     return {
         "heading": base["heading"],
         "parent_headings": list(base["parent_headings"]),
@@ -1039,6 +1066,7 @@ def _merged_pair(
         "content": content,
         "tokens": _count_tokens(tokenizer, content),
         "table_chunk_role": "none",
+        "blockids": merged_blockids,
     }
 
 
@@ -1390,6 +1418,7 @@ def chunking_by_paragraph_semantic(
         paragraphs = _block_to_paragraphs(text)
         if not paragraphs:
             continue
+        row_blockid = str(row.get("blockid") or "").strip()
         initial.append(
             _new_block(
                 heading=row.get("heading", "") or "",
@@ -1398,6 +1427,7 @@ def chunking_by_paragraph_semantic(
                 paragraphs=paragraphs,
                 table_chunk_role="none",
                 tokenizer=tokenizer,
+                blockids=[row_blockid] if row_blockid else None,
             )
         )
 
@@ -1429,6 +1459,7 @@ def chunking_by_paragraph_semantic(
                     target_max=target_max,
                     target_ideal=target_ideal,
                     chunk_overlap_token_size=overlap,
+                    blockids=split_blk.get("blockids") or blk.get("blockids"),
                 )
             )
         after_c.extend(_apply_part_suffixes(block_after_c))
@@ -1442,22 +1473,31 @@ def chunking_by_paragraph_semantic(
         small_tail_threshold=small_tail_threshold,
     )
 
-    # Convert internal block dicts to the chunking_by_token_size schema,
-    # enriched with heading metadata so KG extraction has access to the
-    # document hierarchy.
+    # Convert internal block dicts to the new chunk schema: nested heading
+    # dict + sidecar block carrying source blockid refs so the multimodal
+    # pipeline (and document-delete cache cleanup) can trace each chunk
+    # back to its blocks.jsonl row(s).
     chunks: list[dict[str, Any]] = []
     for idx, blk in enumerate(final):
         body = blk["content"].strip()
         if not body:
             continue
-        chunks.append(
-            {
-                "tokens": blk["tokens"],
-                "content": body,
-                "chunk_order_index": idx,
-                "heading": blk["heading"],
-                "parent_headings": list(blk["parent_headings"]),
-                "level": blk["level"],
+        chunk_dict: dict[str, Any] = {
+            "tokens": blk["tokens"],
+            "content": body,
+            "chunk_order_index": idx,
+            "heading": {
+                "level": int(blk.get("level") or 0),
+                "heading": str(blk.get("heading") or ""),
+                "parent_headings": list(blk.get("parent_headings") or []),
+            },
+        }
+        blockids = blk.get("blockids") or []
+        if blockids:
+            chunk_dict["sidecar"] = {
+                "type": "block",
+                "id": blockids[0],
+                "refs": [{"type": "block", "id": bid} for bid in blockids],
             }
-        )
+        chunks.append(chunk_dict)
     return chunks

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -241,6 +241,21 @@ SUPPORTED_PROCESS_OPTIONS = frozenset(
 
 DEFAULT_MAX_PARALLEL_ANALYZE = 2  # Multimodal analysis (VLM) concurrency
 
+# Multimodal analysis / chunk thresholds
+# Minimum token count retained when truncating a multimodal chunk's
+# description to fit within DEFAULT_MAX_EXTRACT_INPUT_TOKENS.  Falling below
+# this floor leaves the description too thin to ground a useful entity
+# description, so the pipeline raises instead of producing a stub.
+DEFAULT_MM_CHUNK_DESCRIPTION_MIN_TOKENS = 100
+# Minimum image side (width or height) in pixels accepted for VLM analysis.
+# Anything smaller is treated as decorative (icons, separators, etc.) and
+# written as status="skipped".
+DEFAULT_MM_IMAGE_MIN_PIXEL = 32
+# Priority used for all multimodal analysis LLM calls.  Higher numbers run
+# behind entity extraction (priority 10) so a busy ingestion queue still
+# prefers KG-building work.
+DEFAULT_MM_ANALYSIS_PRIORITY = 12
+
 # Embedding configuration defaults
 DEFAULT_EMBEDDING_FUNC_MAX_ASYNC = 8  # Default max async for embedding functions
 DEFAULT_EMBEDDING_BATCH_NUM = 10  # Default batch size for embedding computations

--- a/lightrag/exceptions.py
+++ b/lightrag/exceptions.py
@@ -137,3 +137,14 @@ class DataMigrationError(Exception):
     def __init__(self, message: str):
         super().__init__(message)
         self.message = message
+
+
+class MultimodalAnalysisError(RuntimeError):
+    """Raised when multimodal analysis must fail the current document.
+
+    Hard failures (missing required field, schema mismatch, model not
+    available, sidecar already carries ``status="failure"``) bubble this
+    exception so the pipeline marks the document failed instead of writing
+    an unusable analyze result. Callers persist a ``status="failure"``
+    sidecar entry alongside the raise so a re-run sees the failure.
+    """

--- a/lightrag/llm/_vision_utils.py
+++ b/lightrag/llm/_vision_utils.py
@@ -211,11 +211,7 @@ def _read_jpeg_dimensions(data: bytes) -> tuple[int, int] | None:
 
 
 def _read_webp_dimensions(data: bytes) -> tuple[int, int] | None:
-    if (
-        len(data) < 30
-        or data[0:4] != _WEBP_RIFF
-        or data[8:12] != _WEBP_TAG
-    ):
+    if len(data) < 30 or data[0:4] != _WEBP_RIFF or data[8:12] != _WEBP_TAG:
         return None
     chunk_type = data[12:16]
     if chunk_type == b"VP8 ":

--- a/lightrag/llm/_vision_utils.py
+++ b/lightrag/llm/_vision_utils.py
@@ -22,7 +22,9 @@ from __future__ import annotations
 import base64
 import hashlib
 import re
+import struct
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 DATA_URL_RE = re.compile(
@@ -151,3 +153,124 @@ def image_audit_metadata(images: list[NormalizedImage]) -> list[dict[str, Any]]:
         }
         for img in images
     ]
+
+
+def _read_png_dimensions(data: bytes) -> tuple[int, int] | None:
+    # IHDR is the first chunk; width/height are big-endian uint32 at offsets
+    # 16/20 (8-byte signature + 4 length + 4 "IHDR" + 4 width + 4 height).
+    if len(data) < 24 or not data.startswith(_PNG_SIGNATURE):
+        return None
+    width, height = struct.unpack(">II", data[16:24])
+    return width, height
+
+
+def _read_gif_dimensions(data: bytes) -> tuple[int, int] | None:
+    # Logical screen descriptor: width/height are little-endian uint16 at
+    # offsets 6/8.
+    if len(data) < 10 or not any(data.startswith(sig) for sig in _GIF_SIGNATURES):
+        return None
+    width, height = struct.unpack("<HH", data[6:10])
+    return width, height
+
+
+def _read_jpeg_dimensions(data: bytes) -> tuple[int, int] | None:
+    # Scan for a Start-Of-Frame marker (SOF0 / SOF2 / etc.). Skip segments by
+    # their length field. We deliberately accept any SOF variant the codec
+    # might emit rather than enumerating each one.
+    if len(data) < 4 or not data.startswith(_JPEG_SIGNATURE):
+        return None
+    i = 2
+    n = len(data)
+    while i < n:
+        if data[i] != 0xFF:
+            return None
+        # Skip fill bytes.
+        while i < n and data[i] == 0xFF:
+            i += 1
+        if i >= n:
+            return None
+        marker = data[i]
+        i += 1
+        # Standalone markers without a length field.
+        if marker in (0xD8, 0xD9) or 0xD0 <= marker <= 0xD7:
+            continue
+        if i + 2 > n:
+            return None
+        segment_len = struct.unpack(">H", data[i : i + 2])[0]
+        if segment_len < 2 or i + segment_len > n:
+            return None
+        # SOF0..SOF15 except 0xC4 (DHT), 0xC8 (JPG reserved), 0xCC (DAC).
+        if 0xC0 <= marker <= 0xCF and marker not in (0xC4, 0xC8, 0xCC):
+            # SOF payload: precision(1) + height(2) + width(2) + …
+            if i + 7 > n:
+                return None
+            height, width = struct.unpack(">HH", data[i + 3 : i + 7])
+            return width, height
+        i += segment_len
+    return None
+
+
+def _read_webp_dimensions(data: bytes) -> tuple[int, int] | None:
+    if (
+        len(data) < 30
+        or data[0:4] != _WEBP_RIFF
+        or data[8:12] != _WEBP_TAG
+    ):
+        return None
+    chunk_type = data[12:16]
+    if chunk_type == b"VP8 ":
+        # Lossy: 3-byte tag + 3-byte sync code at offset 23, then 4 bytes
+        # holding 14-bit width / 14-bit height in little-endian halves.
+        if len(data) < 30:
+            return None
+        width = struct.unpack("<H", data[26:28])[0] & 0x3FFF
+        height = struct.unpack("<H", data[28:30])[0] & 0x3FFF
+        return width, height
+    if chunk_type == b"VP8L":
+        # Lossless: signature(0x2F) + 4 bytes encoding 14-bit width-1 / 14-bit
+        # height-1 starting at offset 21.
+        if len(data) < 25 or data[20] != 0x2F:
+            return None
+        b0, b1, b2, b3 = data[21], data[22], data[23], data[24]
+        width = ((b1 & 0x3F) << 8 | b0) + 1
+        height = ((b3 & 0x0F) << 10 | b2 << 2 | (b1 & 0xC0) >> 6) + 1
+        return width, height
+    if chunk_type == b"VP8X":
+        # Extended: 3 bytes width-1 / 3 bytes height-1, little-endian, at
+        # offsets 24/27.
+        if len(data) < 30:
+            return None
+        width = (data[24] | data[25] << 8 | data[26] << 16) + 1
+        height = (data[27] | data[28] << 8 | data[29] << 16) + 1
+        return width, height
+    return None
+
+
+def read_image_dimensions(path: Path) -> tuple[int, int] | None:
+    """Return ``(width, height)`` for a raster image, or ``None`` if unknown.
+
+    Reads only the file header — no Pillow dependency. Supports PNG, JPEG,
+    GIF and WebP (VP8 / VP8L / VP8X). Returns ``None`` for unsupported
+    formats and on any I/O or parse error so callers can fall back to a
+    skipped/failure decision without raising.
+    """
+    try:
+        with open(path, "rb") as fh:
+            header = fh.read(64 * 1024)
+    except OSError:
+        return None
+    if not header:
+        return None
+    for reader in (
+        _read_png_dimensions,
+        _read_gif_dimensions,
+        _read_jpeg_dimensions,
+        _read_webp_dimensions,
+    ):
+        try:
+            dims = reader(header)
+        except (struct.error, IndexError, ValueError):
+            continue
+        if dims:
+            return dims
+    return None

--- a/lightrag/llm/_vision_utils.py
+++ b/lightrag/llm/_vision_utils.py
@@ -49,6 +49,10 @@ class NormalizedImage:
     source_file: str | None
     modality: str | None
     doc_id: str | None
+    # Pixel dimensions parsed from the raster header (None when the format
+    # is recognized but dimensions could not be extracted).
+    width: int | None = None
+    height: int | None = None
 
 
 def _detect_mime(raw: bytes) -> str:
@@ -106,6 +110,8 @@ def normalize_image_inputs(
         mime_type = item.get("mime_type") or _detect_mime(raw_bytes)
         sha = hashlib.sha256(raw_bytes).hexdigest()
         clean_b64 = base64.b64encode(raw_bytes).decode("ascii")
+        dims = _dimensions_from_bytes(raw_bytes)
+        width, height = (dims[0], dims[1]) if dims else (None, None)
         result.append(
             NormalizedImage(
                 index=idx,
@@ -117,19 +123,30 @@ def normalize_image_inputs(
                 source_file=item.get("source_file"),
                 modality=item.get("modality"),
                 doc_id=item.get("doc_id"),
+                width=width,
+                height=height,
             )
         )
     return result
 
 
 def image_cache_metadata(images: list[NormalizedImage]) -> list[dict[str, Any]]:
-    """Return cache-key-safe image metadata (no source identifiers)."""
+    """Return cache-key-safe image metadata (no source identifiers).
+
+    Includes ``width`` / ``height`` so the cache key reflects the full
+    image digest the design contract specifies (mime, sha256, bytes,
+    width, height).  The sha256 alone is sufficient for identity, but
+    surfacing dimensions matches the documented audit shape and gives
+    diagnostics a one-line "what was sent" without re-decoding.
+    """
     return [
         {
             "index": img.index,
             "mime_type": img.mime_type,
             "sha256": img.sha256,
             "bytes": len(img.raw_bytes),
+            "width": img.width,
+            "height": img.height,
         }
         for img in images
     ]
@@ -146,6 +163,8 @@ def image_audit_metadata(images: list[NormalizedImage]) -> list[dict[str, Any]]:
             "mime_type": img.mime_type,
             "sha256": img.sha256,
             "bytes": len(img.raw_bytes),
+            "width": img.width,
+            "height": img.height,
             "source_id": img.source_id,
             "source_file": img.source_file,
             "modality": img.modality,
@@ -255,7 +274,17 @@ def read_image_dimensions(path: Path) -> tuple[int, int] | None:
             header = fh.read(64 * 1024)
     except OSError:
         return None
-    if not header:
+    return _dimensions_from_bytes(header)
+
+
+def _dimensions_from_bytes(data: bytes) -> tuple[int, int] | None:
+    """Run the four header readers against a byte buffer.
+
+    Shared between the file-path entry point (:func:`read_image_dimensions`)
+    and :func:`normalize_image_inputs`, which receives raster payloads
+    decoded from the unified ``image_inputs`` parameter.
+    """
+    if not data:
         return None
     for reader in (
         _read_png_dimensions,
@@ -264,7 +293,7 @@ def read_image_dimensions(path: Path) -> tuple[int, int] | None:
         _read_webp_dimensions,
     ):
         try:
-            dims = reader(header)
+            dims = reader(data)
         except (struct.error, IndexError, ValueError):
             continue
         if dims:

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import asyncio
 import json
+import hashlib
 import re
 import warnings
 import json_repair
@@ -54,6 +55,7 @@ from lightrag.base import (
     QueryResult,
     QueryContextResult,
 )
+from lightrag.chunk_schema import strip_internal_multimodal_markup_for_extraction
 from lightrag.prompt import PROMPTS, resolve_entity_extraction_prompt_profile
 from lightrag.constants import (
     GRAPH_FIELD_SEP,
@@ -3289,7 +3291,12 @@ async def extract_entities(
         nonlocal processed_chunks
         chunk_key = chunk_key_dp[0]
         chunk_dp = chunk_key_dp[1]
-        content = chunk_dp["content"]
+        # Strip parser-internal markup (<cite refid>, <drawing id/path/src>,
+        # <equation id>) before building the extraction prompt. The stored
+        # chunk content is left intact so query-time citations still resolve.
+        content = strip_internal_multimodal_markup_for_extraction(
+            chunk_dp["content"]
+        )
         # Get file path from chunk data or use default
         file_path = chunk_dp.get("file_path", "unknown_source")
 
@@ -3426,6 +3433,85 @@ async def extract_entities(
                     # New edge from gleaning stage
                     maybe_edges[edge_key] = list(glean_edge_list)
                 await _cooperative_yield(i, every=8)
+
+        # Inject multimodal entity + associations for drawing/table/equation
+        # chunks. Placed before update_chunk_cache_list so the per-chunk
+        # cache write still happens after; placed inside the chunk's
+        # concurrency slot (rather than the centralized post-pass that used
+        # to live in utils_pipeline.augment_chunk_results_with_mm_entities)
+        # so each multimodal chunk benefits from the chunk-level concurrency
+        # already enforced by extract_entities.
+        sidecar_block = chunk_dp.get("sidecar")
+        if isinstance(sidecar_block, dict):
+            sidecar_type = sidecar_block.get("type")
+            sidecar_id = sidecar_block.get("id")
+            if (
+                sidecar_type in {"drawing", "table", "equation"}
+                and isinstance(sidecar_id, str)
+                and sidecar_id
+            ):
+                full_doc_id = str(chunk_dp.get("full_doc_id") or "")
+                mm_entity_digest = hashlib.md5(
+                    f"{full_doc_id}:{sidecar_type}:{sidecar_id}".encode("utf-8")
+                ).hexdigest()
+                mm_entity_name = f"{sidecar_type}-{mm_entity_digest}"
+                now_ts = int(time.time())
+                mm_nodes_list = maybe_nodes.setdefault(mm_entity_name, [])
+                mm_nodes_list.append(
+                    {
+                        "entity_name": mm_entity_name,
+                        "entity_type": sidecar_type,
+                        # description == the full multimodal chunk content so
+                        # the extracted entity carries the same grounding
+                        # surface the prompt produced; analyze_multimodal's
+                        # description/name field is already inlined there.
+                        "description": chunk_dp.get("content", "") or "",
+                        "source_id": chunk_key,
+                        "file_path": file_path,
+                        "timestamp": now_ts,
+                    }
+                )
+                heading_block = chunk_dp.get("heading")
+                heading_label = "unknown"
+                if isinstance(heading_block, dict):
+                    heading_label = (
+                        str(heading_block.get("heading") or "").strip() or "unknown"
+                    )
+                # Friendly name for the relation description: parse the
+                # leading "- {Image|Table|Equation} Name:\n<name>" section
+                # from the chunk content; fall back to sidecar id.
+                mm_display_name = sidecar_id
+                content_for_name = chunk_dp.get("content", "") or ""
+                first_name_match = re.search(
+                    r"^- (?:Image|Table|Equation) Name:\n(.+)$",
+                    content_for_name,
+                    flags=re.MULTILINE,
+                )
+                if first_name_match:
+                    candidate = first_name_match.group(1).strip()
+                    if candidate:
+                        mm_display_name = candidate
+                for tgt in list(maybe_nodes.keys()):
+                    if tgt == mm_entity_name:
+                        continue
+                    edge_key = (mm_entity_name, tgt)
+                    edge_list = maybe_edges.setdefault(edge_key, [])
+                    edge_list.append(
+                        {
+                            "src_id": mm_entity_name,
+                            "tgt_id": tgt,
+                            "weight": 1.0,
+                            "description": (
+                                f"{tgt} is associated with {sidecar_type} "
+                                f"{mm_display_name} in section {heading_label} "
+                                f'of document "{file_path}"'
+                            ),
+                            "keywords": "associated with, contained in",
+                            "source_id": chunk_key,
+                            "file_path": file_path,
+                            "timestamp": now_ts,
+                        }
+                    )
 
         # Batch update chunk's llm_cache_list with all collected cache keys
         if cache_keys_collector and text_chunks_storage:

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -3294,9 +3294,7 @@ async def extract_entities(
         # Strip parser-internal markup (<cite refid>, <drawing id/path/src>,
         # <equation id>) before building the extraction prompt. The stored
         # chunk content is left intact so query-time citations still resolve.
-        content = strip_internal_multimodal_markup_for_extraction(
-            chunk_dp["content"]
-        )
+        content = strip_internal_multimodal_markup_for_extraction(chunk_dp["content"])
         # Get file path from chunk data or use default
         file_path = chunk_dp.get("file_path", "unknown_source")
 

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -16,6 +16,8 @@ import base64
 import hashlib
 import inspect
 import json
+
+import json_repair
 import mimetypes
 import os
 from copy import deepcopy
@@ -1481,7 +1483,24 @@ class _PipelineMixin:
                 )
                 await ctx.q_process.put((doc_id_w, status_doc_w, analyzed))
             except Exception as e:
+                # Mirror _parse_worker: failures here must transition the
+                # document to FAILED with a diagnostic ``error_msg``, otherwise
+                # MultimodalAnalysisError (raised by analyze_multimodal under
+                # the new hard-failure contract) would leave the doc stuck in
+                # ANALYZING forever.
                 logger.error(f"Analyze worker failed: {e}")
+                try:
+                    await self._upsert_doc_status_transition(
+                        doc_id=doc_id_w,
+                        status=DocStatus.FAILED,
+                        status_doc=status_doc_w,
+                        file_path=getattr(
+                            status_doc_w, "file_path", "unknown_source"
+                        ),
+                        extra_fields={"error_msg": str(e)},
+                    )
+                except Exception:
+                    pass
             finally:
                 ctx.q_analyze.task_done()
 
@@ -1830,6 +1849,9 @@ class _PipelineMixin:
                         file_path=file_path,
                         blocks_path=blocks_path,
                         base_order_index=max_order + 1,
+                        process_options=(content_data or {}).get(
+                            "process_options"
+                        ),
                     )
                     if mm_chunks:
                         chunking_result = list(chunking_result) + mm_chunks
@@ -3307,11 +3329,23 @@ class _PipelineMixin:
             _VLM_RASTER_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
 
             def _json_extract(text: str) -> dict[str, Any]:
+                """Tolerant JSON object recovery.
+
+                Mirrors :func:`lightrag.operate._process_json_extraction_result`
+                so weaker models that emit ```json ... ``` fenced output,
+                trailing commas, or unquoted keys are still salvageable.
+                The order of attempts is:
+
+                1. Strip a leading ```json fence if present.
+                2. Hand the cleaned string to ``json_repair.loads`` (handles
+                   minor structural slips like trailing commas).
+                3. Fall back to a greedy ``{...}`` regex slice for outputs
+                   that wrap the JSON object in prose, then re-run
+                   ``json_repair.loads`` on the slice.
+                """
                 if not text:
                     return {}
                 candidate = text.strip()
-                # Tolerate ```json …``` fenced output and stray prose around the
-                # JSON object; mirror _process_json_extraction_result's recovery.
                 fence_match = re.match(
                     r"^```(?:json)?\s*\n(.*?)\n```$",
                     candidate,
@@ -3320,7 +3354,7 @@ class _PipelineMixin:
                 if fence_match:
                     candidate = fence_match.group(1).strip()
                 try:
-                    obj = json.loads(candidate)
+                    obj = json_repair.loads(candidate)
                     if isinstance(obj, dict):
                         return obj
                 except Exception:
@@ -3328,7 +3362,7 @@ class _PipelineMixin:
                 m = re.search(r"\{[\s\S]*\}", candidate)
                 if m:
                     try:
-                        obj = json.loads(m.group(0))
+                        obj = json_repair.loads(m.group(0))
                         if isinstance(obj, dict):
                             return obj
                     except Exception:
@@ -3842,6 +3876,7 @@ class _PipelineMixin:
         file_path: str,
         blocks_path: str,
         base_order_index: int,
+        process_options: str | None = None,
     ) -> list[dict[str, Any]]:
         """Build multimodal chunks from sidecars carrying analysis results.
 
@@ -3857,6 +3892,11 @@ class _PipelineMixin:
         underlying sidecar item so document deletion can clean up the
         ``cache_type="analysis"`` entries it created.
 
+        ``process_options`` gates which modality sidecars are read: a
+        document re-processed after opting out of ``i`` / ``t`` / ``e``
+        must NOT pick up stale success results from a prior pass.  When
+        ``None`` (e.g. ad-hoc unit tests), every modality is considered.
+
         Raises:
             MultimodalAnalysisError: when an item carries ``status="failure"``,
                 or when the multimodal chunk cannot be fit under the
@@ -3867,6 +3907,7 @@ class _PipelineMixin:
             DEFAULT_MAX_EXTRACT_INPUT_TOKENS,
             DEFAULT_MM_CHUNK_DESCRIPTION_MIN_TOKENS,
         )
+        from lightrag.parser_routing import parse_process_options
 
         block_file = Path(blocks_path)
         if not block_file.exists():
@@ -3876,10 +3917,26 @@ class _PipelineMixin:
         if base.endswith(".blocks.jsonl"):
             base = base[: -len(".blocks.jsonl")]
 
+        if process_options is None:
+            allowed = {"drawing", "table", "equation"}
+        else:
+            opts = parse_process_options(process_options)
+            allowed = set()
+            if opts.images:
+                allowed.add("drawing")
+            if opts.tables:
+                allowed.add("table")
+            if opts.equations:
+                allowed.add("equation")
+
         sidecar_defs = [
-            ("drawings", Path(base + ".drawings.json"), "drawing"),
-            ("tables", Path(base + ".tables.json"), "table"),
-            ("equations", Path(base + ".equations.json"), "equation"),
+            (root, Path(base + suffix), kind)
+            for root, suffix, kind in (
+                ("drawings", ".drawings.json", "drawing"),
+                ("tables", ".tables.json", "table"),
+                ("equations", ".equations.json", "equation"),
+            )
+            if kind in allowed
         ]
 
         mm_chunks: list[dict[str, Any]] = []

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1494,9 +1494,7 @@ class _PipelineMixin:
                         doc_id=doc_id_w,
                         status=DocStatus.FAILED,
                         status_doc=status_doc_w,
-                        file_path=getattr(
-                            status_doc_w, "file_path", "unknown_source"
-                        ),
+                        file_path=getattr(status_doc_w, "file_path", "unknown_source"),
                         extra_fields={"error_msg": str(e)},
                     )
                 except Exception:
@@ -1849,9 +1847,7 @@ class _PipelineMixin:
                         file_path=file_path,
                         blocks_path=blocks_path,
                         base_order_index=max_order + 1,
-                        process_options=(content_data or {}).get(
-                            "process_options"
-                        ),
+                        process_options=(content_data or {}).get("process_options"),
                     )
                     if mm_chunks:
                         chunking_result = list(chunking_result) + mm_chunks

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1842,12 +1842,21 @@ class _PipelineMixin:
                             ch.get("chunk_order_index"), int
                         ):
                             max_order = max(max_order, int(ch["chunk_order_index"]))
+                    # Default to "" (no modalities) when full_docs has no
+                    # ``process_options`` key for this doc: a reinsert that
+                    # omits i/t/e must NOT re-index stale successful sidecars
+                    # left over from an earlier multimodal run. The builder's
+                    # None branch is reserved for ad-hoc callers (unit tests)
+                    # that intentionally want every modality considered.
                     mm_chunks = self._build_mm_chunks_from_sidecars(
                         doc_id=doc_id,
                         file_path=file_path,
                         blocks_path=blocks_path,
                         base_order_index=max_order + 1,
-                        process_options=(content_data or {}).get("process_options"),
+                        process_options=(content_data or {}).get(
+                            "process_options"
+                        )
+                        or "",
                     )
                     if mm_chunks:
                         chunking_result = list(chunking_result) + mm_chunks

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -43,7 +43,7 @@ from lightrag.constants import (
     PARSER_ENGINE_MINERU,
     PARSER_ENGINE_NATIVE,
 )
-from lightrag.exceptions import PipelineCancelledException
+from lightrag.exceptions import MultimodalAnalysisError, PipelineCancelledException
 from lightrag.kg.shared_storage import get_namespace_data, get_namespace_lock
 from lightrag.operate import merge_nodes_and_edges
 from lightrag.parser_routing import (
@@ -57,6 +57,7 @@ from lightrag.utils import (
     compute_args_hash,
     compute_mdhash_id,
     enforce_chunk_token_limit_before_embedding,
+    generate_cache_key,
     generate_track_id,
     get_content_summary,
     get_llm_cache_identity,
@@ -69,7 +70,6 @@ from lightrag.utils import (
 from lightrag.utils_pipeline import (
     archive_docx_source_after_full_docs_sync,
     archive_source_after_full_docs_sync,
-    augment_chunk_results_with_mm_entities,
     build_chunks_dict_from_chunking_result,
     chunk_fields_from_status_doc,
     compute_file_content_hash,
@@ -1817,7 +1817,6 @@ class _PipelineMixin:
                     extraction_meta=extraction_meta,
                 )
 
-                mm_specs: list[dict[str, Any]] = []
                 blocks_path = str(parsed_data.get("blocks_path") or "").strip()
                 if blocks_path:
                     max_order = -1
@@ -1826,7 +1825,7 @@ class _PipelineMixin:
                             ch.get("chunk_order_index"), int
                         ):
                             max_order = max(max_order, int(ch["chunk_order_index"]))
-                    mm_chunks, mm_specs = self._build_mm_chunks_from_sidecars(
+                    mm_chunks = self._build_mm_chunks_from_sidecars(
                         doc_id=doc_id,
                         file_path=file_path,
                         blocks_path=blocks_path,
@@ -1923,11 +1922,6 @@ class _PipelineMixin:
                         )
                     )
                     chunk_results = await entity_relation_task
-                    chunk_results = augment_chunk_results_with_mm_entities(
-                        chunk_results=chunk_results,
-                        mm_specs=mm_specs,
-                        file_path=file_path,
-                    )
                 file_extraction_stage_ok = True
 
             except Exception as e:
@@ -3268,35 +3262,72 @@ class _PipelineMixin:
             if not isinstance(meta, dict) or meta.get("type") != "meta":
                 return parsed_data
 
-            # Analyze sidecar multimodal items by VLM model role.
-            use_vlm_func = self.role_llm_funcs["vlm"]
-            effective_vlm_max_async = self._get_effective_role_llm_max_async("vlm")
-            sem = asyncio.Semaphore(max(1, effective_vlm_max_async))
-            max_image_bytes = max(
-                256 * 1024, int(os.getenv("VLM_MAX_IMAGE_BYTES", str(5 * 1024 * 1024)))
-            )
-            vlm_global_config = self._build_global_config()
-            vlm_process_enable = bool(
-                vlm_global_config.get("vlm_process_enable", False)
-            )
             from lightrag.llm._vision_utils import (
                 image_audit_metadata,
                 image_cache_metadata,
                 normalize_image_inputs,
+                read_image_dimensions,
+            )
+            from lightrag.prompt_multimodal import (
+                IMAGE_TYPE_ENUM,
+                IMAGE_TYPE_FALLBACK,
+                MULTIMODAL_PROMPTS,
+            )
+            from lightrag.constants import (
+                DEFAULT_MM_ANALYSIS_PRIORITY,
+                DEFAULT_MM_IMAGE_MIN_PIXEL,
+                DEFAULT_SUMMARY_LANGUAGE,
             )
 
-            vlm_cache_identity = get_llm_cache_identity(vlm_global_config, role="vlm")
+            global_config = self._build_global_config()
+            addon_params = global_config.get("addon_params") or {}
+            language = (
+                global_config.get("_resolved_summary_language")
+                or addon_params.get("language")
+                or DEFAULT_SUMMARY_LANGUAGE
+            )
+            vlm_process_enable = bool(global_config.get("vlm_process_enable", False))
+            max_image_bytes = max(
+                256 * 1024,
+                int(os.getenv("VLM_MAX_IMAGE_BYTES", str(5 * 1024 * 1024))),
+            )
+            min_image_pixel = max(
+                1,
+                int(
+                    os.getenv("VLM_MIN_IMAGE_PIXEL", str(DEFAULT_MM_IMAGE_MIN_PIXEL))
+                ),
+            )
 
-            def _extract_json_obj(text: str) -> dict[str, Any]:
+            use_vlm_func = self.role_llm_funcs.get("vlm")
+            use_extract_func = self.role_llm_funcs.get("extract")
+            vlm_cache_identity = get_llm_cache_identity(global_config, role="vlm")
+            extract_cache_identity = get_llm_cache_identity(
+                global_config, role="extract"
+            )
+
+            _IMAGE_TYPE_VALUES = set(IMAGE_TYPE_ENUM)
+            _VLM_RASTER_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
+
+            def _json_extract(text: str) -> dict[str, Any]:
                 if not text:
                     return {}
+                candidate = text.strip()
+                # Tolerate ```json …``` fenced output and stray prose around the
+                # JSON object; mirror _process_json_extraction_result's recovery.
+                fence_match = re.match(
+                    r"^```(?:json)?\s*\n(.*?)\n```$",
+                    candidate,
+                    re.DOTALL | re.IGNORECASE,
+                )
+                if fence_match:
+                    candidate = fence_match.group(1).strip()
                 try:
-                    obj = json.loads(text)
+                    obj = json.loads(candidate)
                     if isinstance(obj, dict):
                         return obj
                 except Exception:
                     pass
-                m = re.search(r"\{[\s\S]*\}", text)
+                m = re.search(r"\{[\s\S]*\}", candidate)
                 if m:
                     try:
                         obj = json.loads(m.group(0))
@@ -3306,190 +3337,142 @@ class _PipelineMixin:
                         pass
                 return {}
 
-            # Raster image formats that vision-capable providers accept.
-            # WMF/EMF/SVG and other vector formats are rejected with a
-            # warning: the parser does not transcode them and feeding them to
-            # OpenAI/Anthropic/Bedrock/Gemini would only fail mid-call.
-            _VLM_RASTER_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
-
-            async def _analyze_item(
-                root_key: str,
-                item_id: str,
-                item: dict[str, Any],
-                sidecar_dir: Path,
-            ) -> dict[str, Any] | None:
-                def _conservative_result(reason: str) -> dict[str, Any]:
-                    base_name = item.get("caption") or item_id
-                    modality = (
-                        "image"
-                        if root_key == "drawings"
-                        else "table"
-                        if root_key == "tables"
-                        else "equation"
+            def _normalize_text(value: Any) -> str:
+                if value is None:
+                    return ""
+                if isinstance(value, str):
+                    return value.strip()
+                if isinstance(value, (list, tuple)):
+                    return "\n".join(
+                        str(v).strip() for v in value if str(v).strip()
                     )
-                    conservative = {
-                        "name": base_name,
-                        "summary": (
-                            f"Conservative summary only: unavailable or weak visual evidence for {modality}."
-                        ),
-                        "detail_description": (
-                            f"No grounded visual evidence. Reason: {reason}. "
-                            "Only metadata-level description is retained."
-                        ),
-                        "grounded": False,
-                        "grounding_reason": reason,
-                    }
-                    if root_key == "drawings":
-                        conservative["image_type"] = ""
-                    return conservative
+                return str(value).strip()
 
-                def _build_image_payload(
-                    path_str: str | None,
-                ) -> dict[str, Any] | None:
-                    if not path_str:
-                        return None
-                    # Sidecar entries write parser-relative paths (see
-                    # `lightrag/native_parser/docx/lightrag_adapter.py`).
-                    # Resolve them against the sidecar's own directory before
-                    # falling back to a plain cwd-relative interpretation.
-                    candidate = Path(path_str)
-                    if not candidate.is_absolute():
-                        sidecar_candidate = sidecar_dir / path_str
-                        if sidecar_candidate.exists() and sidecar_candidate.is_file():
-                            candidate = sidecar_candidate
-                    if not candidate.exists() or not candidate.is_file():
-                        return None
-                    ext = candidate.suffix.lower()
-                    if ext not in _VLM_RASTER_EXTS:
-                        logger.warning(
-                            f"[analyze_multimodal] unsupported image format "
-                            f"'{ext}' for {root_key}/{item_id}; vision providers "
-                            "only accept raster formats (png/jpeg/gif/webp). "
-                            "Skipping image input."
-                        )
-                        return None
-                    try:
-                        raw = candidate.read_bytes()
-                    except Exception:
-                        return None
-                    if not raw:
-                        return None
-                    if len(raw) > max_image_bytes:
-                        logger.warning(
-                            f"[analyze_multimodal] image too large ({len(raw)} bytes) for {root_key}/{item_id}, skip image input"
-                        )
-                        return None
-                    mime, _ = mimetypes.guess_type(str(candidate))
-                    if not mime:
-                        mime = "image/png"
-                    modality = (
-                        "image"
-                        if root_key == "drawings"
-                        else "table"
-                        if root_key == "tables"
-                        else "equation"
+            def _captions_value(item_obj: dict[str, Any]) -> str:
+                return _normalize_text(item_obj.get("caption")) or "n/a"
+
+            def _footnotes_value(item_obj: dict[str, Any]) -> str:
+                raw = item_obj.get("footnotes")
+                if isinstance(raw, (list, tuple)):
+                    joined = "; ".join(
+                        str(v).strip() for v in raw if str(v).strip()
                     )
-                    return {
-                        "base64": base64.b64encode(raw).decode("ascii"),
-                        "mime_type": mime,
-                        "source_id": item_id,
-                        "source_file": str(candidate),
-                        "modality": modality,
-                        "doc_id": doc_id,
-                    }
+                    return joined or "n/a"
+                text = _normalize_text(raw)
+                return text or "n/a"
 
-                def _normalize_text(value: Any) -> str:
-                    if value is None:
-                        return ""
-                    if isinstance(value, str):
-                        return value.strip()
-                    if isinstance(value, (list, tuple)):
-                        return "\n".join(
-                            str(v).strip() for v in value if str(v).strip()
-                        )
-                    return str(value).strip()
+            def _surrounding_value(item_obj: dict[str, Any], key: str) -> str:
+                surrounding = item_obj.get("surrounding") or {}
+                if not isinstance(surrounding, dict):
+                    return "n/a"
+                value = _normalize_text(surrounding.get(key))
+                return value or "n/a"
 
-                def _normalize_grounded_value(value: Any) -> Any:
-                    if isinstance(value, bool) or value is None:
-                        return value
-                    if isinstance(value, str):
-                        lowered = value.strip().lower()
-                        if lowered == "true":
-                            return True
-                        if lowered == "false":
-                            return False
-                    if isinstance(value, (int, float)) and value in {0, 1}:
-                        return bool(value)
-                    return value
-
-                default_result = {
-                    "name": item.get("caption") or item_id,
-                    "summary": "",
-                    "detail_description": "",
-                }
-                if root_key == "drawings":
-                    default_result["image_type"] = ""
-                schema_hint = (
-                    '{"name":"string","summary":"string","detail_description":"string","grounded":"boolean","grounding_reason":"string"}'
-                    if root_key != "drawings"
-                    else '{"name":"string","image_type":"string","summary":"string","detail_description":"string","grounded":"boolean","grounding_reason":"string"}'
-                )
-                if not vlm_process_enable:
-                    # Do NOT write back a conservative result here: persisting
-                    # llm_analyze_result would let the idempotency guard in the
-                    # outer dispatch skip this item forever, even after the
-                    # operator enables VLM and re-runs analysis.
-                    logger.warning(
-                        f"[analyze_multimodal] VLM_PROCESS_ENABLE=false, skipping "
-                        f"{root_key}/{item_id} for d-id: {doc_id}"
-                    )
+            def _resolve_image_path(
+                path_str: str | None, sidecar_dir: Path
+            ) -> Path | None:
+                if not path_str:
                     return None
+                candidate = Path(path_str)
+                if not candidate.is_absolute():
+                    sidecar_candidate = sidecar_dir / path_str
+                    if sidecar_candidate.exists() and sidecar_candidate.is_file():
+                        candidate = sidecar_candidate
+                if candidate.exists() and candidate.is_file():
+                    return candidate
+                return None
 
-                img_payload = _build_image_payload(
-                    item.get("path") or item.get("img_path") or item.get("image_path")
-                )
-                has_visual_evidence = img_payload is not None
-                caption_text = _normalize_text(item.get("caption"))
-                footnotes_text = _normalize_text(item.get("footnotes"))
-                content_text = _normalize_text(item.get("content"))
-                has_textual_evidence = root_key in {
-                    "tables",
-                    "equations",
-                } and any((caption_text, footnotes_text, content_text))
-                evidence_mode = (
-                    "visual"
-                    if has_visual_evidence
-                    else "textual"
-                    if has_textual_evidence
-                    else "none"
-                )
-                prompt = (
-                    "You are a multimodal analyzer.\n"
-                    "Return ONLY one JSON object. No markdown. No explanation.\n"
-                    "Grounding policy:\n"
-                    "- Do NOT invent unseen objects, domains, diseases, or scenarios.\n"
-                    "- Prefer the strongest available evidence source.\n"
-                    "- For tables/equations without image evidence, analyze from content/caption/footnotes first.\n"
-                    "- In textual-only mode, do not invent appearance/layout details that are not supported by the provided content.\n"
-                    "- If evidence is missing/weak/uncertain, set grounded=false and keep summary/detail conservative.\n"
-                    "- If grounded=false, avoid rich semantic claims; keep to metadata-level statements only.\n"
-                    f"JSON schema example: {schema_hint}\n"
-                    f"modality={root_key}\n"
-                    f"item_id={item_id}\n"
-                    f"caption={caption_text}\n"
-                    f"footnotes={footnotes_text}\n"
-                    f"content={content_text}\n"
-                    f"has_visual_evidence={has_visual_evidence}\n"
-                    f"has_textual_evidence={has_textual_evidence}\n"
-                    f"evidence_mode={evidence_mode}\n"
-                    "Constraints:\n"
-                    "- summary: <= 120 words\n"
-                    "- detail_description: <= 500 words\n"
-                )
+            def _failure_result(message: str) -> dict[str, Any]:
+                return {
+                    "analyze_time": int(time.time()),
+                    "status": "failure",
+                    "message": message,
+                }
 
-                image_inputs_arg = [img_payload] if img_payload else None
-                normalized_images = (
-                    normalize_image_inputs(image_inputs_arg) if image_inputs_arg else []
+            def _skipped_result(message: str) -> dict[str, Any]:
+                return {
+                    "analyze_time": int(time.time()),
+                    "status": "skipped",
+                    "message": message,
+                }
+
+            async def _analyze_drawing(
+                item_id: str, item: dict[str, Any], sidecar_dir: Path
+            ) -> tuple[dict[str, Any], str | None]:
+                path_str = (
+                    item.get("path")
+                    or item.get("img_path")
+                    or item.get("image_path")
+                )
+                candidate = _resolve_image_path(path_str, sidecar_dir)
+                if candidate is None:
+                    return (
+                        _skipped_result(
+                            f"image file not found: {path_str or 'n/a'}"
+                        ),
+                        None,
+                    )
+                ext = candidate.suffix.lower()
+                if ext not in _VLM_RASTER_EXTS:
+                    return (
+                        _skipped_result(f"unsupported image format: {ext}"),
+                        None,
+                    )
+                dims = read_image_dimensions(candidate)
+                if dims is not None and (
+                    dims[0] < min_image_pixel or dims[1] < min_image_pixel
+                ):
+                    return (
+                        _skipped_result(
+                            f"image width or height is smaller than "
+                            f"{min_image_pixel}px"
+                        ),
+                        None,
+                    )
+                if not vlm_process_enable or use_vlm_func is None:
+                    raise MultimodalAnalysisError(
+                        f"drawings/{item_id}: VLM analysis required but "
+                        "VLM role is not available "
+                        "(VLM_PROCESS_ENABLE or vlm role config)"
+                    )
+                try:
+                    raw = candidate.read_bytes()
+                except OSError as exc:
+                    raise MultimodalAnalysisError(
+                        f"drawings/{item_id}: cannot read image {candidate}: {exc}"
+                    ) from exc
+                if not raw:
+                    raise MultimodalAnalysisError(
+                        f"drawings/{item_id}: image file is empty"
+                    )
+                if len(raw) > max_image_bytes:
+                    return (
+                        _skipped_result(
+                            f"image too large: {len(raw)} bytes "
+                            f"(limit {max_image_bytes})"
+                        ),
+                        None,
+                    )
+                mime, _ = mimetypes.guess_type(str(candidate))
+                mime = mime or "image/png"
+                img_payload = {
+                    "base64": base64.b64encode(raw).decode("ascii"),
+                    "mime_type": mime,
+                    "source_id": item_id,
+                    "source_file": str(candidate),
+                    "modality": "image",
+                    "doc_id": doc_id,
+                }
+                normalized_images = normalize_image_inputs([img_payload])
+                prompt = MULTIMODAL_PROMPTS["image_analysis"].format(
+                    language=language,
+                    content="",
+                    captions=_captions_value(item),
+                    footnotes=_footnotes_value(item),
+                    leading=_surrounding_value(item, "leading"),
+                    trailing=_surrounding_value(item, "trailing"),
+                    item_id=item_id,
+                    file_path=file_path,
                 )
                 args_hash = compute_args_hash(
                     prompt,
@@ -3497,8 +3480,12 @@ class _PipelineMixin:
                     "",
                     serialize_llm_cache_identity(vlm_cache_identity),
                     _serialize_cache_variant({"type": "json_object"}),
-                    _serialize_cache_variant(image_cache_metadata(normalized_images)),
+                    _serialize_cache_variant(
+                        image_cache_metadata(normalized_images)
+                    ),
+                    "drawing",
                 )
+                cache_id = generate_cache_key("default", "analysis", args_hash)
                 cached = await handle_cache(
                     self.llm_response_cache,
                     args_hash,
@@ -3506,50 +3493,48 @@ class _PipelineMixin:
                     mode="default",
                     cache_type="analysis",
                 )
-                fresh_response = False
                 if cached is not None:
                     result_text = cached[0]
+                    fresh = False
                 else:
-                    async with sem:
-                        try:
-                            result_text = await use_vlm_func(
-                                prompt,
-                                stream=False,
-                                image_inputs=image_inputs_arg,
-                            )
-                        except Exception as msg_err:
-                            logger.warning(
-                                f"[analyze_multimodal] visual call failed for "
-                                f"{root_key}/{item_id}: {msg_err}"
-                            )
-                            return _conservative_result("visual_call_failed")
-                    fresh_response = True
-
-                parsed = _extract_json_obj(str(result_text))
-                if not (
-                    parsed
-                    and isinstance(parsed.get("name"), str)
-                    and isinstance(parsed.get("summary"), str)
-                    and isinstance(parsed.get("detail_description"), str)
-                ):
-                    # Do NOT cache invalid responses: caching here would lock
-                    # the item into invalid_json_schema on every future run
-                    # until the cache is manually cleared.
-                    logger.warning(
-                        f"[analyze_multimodal] invalid VLM JSON for "
-                        f"{root_key}/{item_id}, skipping"
+                    try:
+                        result_text = await use_vlm_func(
+                            prompt,
+                            stream=False,
+                            image_inputs=[img_payload],
+                            _priority=DEFAULT_MM_ANALYSIS_PRIORITY,
+                        )
+                    except Exception as exc:
+                        raise MultimodalAnalysisError(
+                            f"drawings/{item_id}: VLM call failed: {exc}"
+                        ) from exc
+                    fresh = True
+                parsed = _json_extract(str(result_text))
+                name = parsed.get("name")
+                type_value = parsed.get("type")
+                description = parsed.get("description")
+                if not isinstance(name, str) or not name.strip():
+                    raise MultimodalAnalysisError(
+                        f"drawings/{item_id}: missing or invalid field 'name'"
                     )
-                    if evidence_mode == "none":
-                        return _conservative_result("missing_image")
-                    return _conservative_result("invalid_json_schema")
-
-                if fresh_response:
+                if not isinstance(description, str) or not description.strip():
+                    raise MultimodalAnalysisError(
+                        f"drawings/{item_id}: missing or invalid field 'description'"
+                    )
+                if not isinstance(type_value, str) or not type_value.strip():
+                    raise MultimodalAnalysisError(
+                        f"drawings/{item_id}: missing or invalid field 'type'"
+                    )
+                if type_value not in _IMAGE_TYPE_VALUES:
+                    type_value = IMAGE_TYPE_FALLBACK
+                if fresh:
                     audit_blob = image_audit_metadata(normalized_images)
-                    original_prompt = (
-                        prompt
-                        + f"\n<vlm_images>{json.dumps(audit_blob, ensure_ascii=False)}</vlm_images>"
+                    original_prompt = prompt + (
+                        f"\n<vlm_images>"
+                        f"{json.dumps(audit_blob, ensure_ascii=False)}"
+                        "</vlm_images>"
                         if audit_blob
-                        else prompt
+                        else ""
                     )
                     await save_to_cache(
                         self.llm_response_cache,
@@ -3562,131 +3547,242 @@ class _PipelineMixin:
                             chunk_id=None,
                         ),
                     )
-
-                if "grounded" in parsed:
-                    parsed["grounded"] = _normalize_grounded_value(
-                        parsed.get("grounded")
-                    )
-                default_result.update(
+                return (
                     {
-                        k: v
-                        for k, v in parsed.items()
-                        if k
-                        in {
-                            "name",
-                            "summary",
-                            "detail_description",
-                            "image_type",
-                            "grounded",
-                            "grounding_reason",
-                        }
-                    }
+                        "name": name.strip(),
+                        "type": type_value,
+                        "description": description.strip(),
+                        "analyze_time": int(time.time()),
+                        "status": "success",
+                        "message": "",
+                    },
+                    cache_id,
                 )
-                if evidence_mode == "none":
-                    return _conservative_result("missing_image")
-                if parsed.get("grounded") is False:
-                    reason = str(
-                        parsed.get("grounding_reason")
-                        or (
-                            "weak_visual_evidence"
-                            if evidence_mode == "visual"
-                            else "weak_textual_evidence"
-                        )
-                    )
-                    return _conservative_result(reason)
-                if "grounded" not in default_result:
-                    default_result["grounded"] = True
-                if not default_result.get("grounding_reason"):
-                    default_result["grounding_reason"] = (
-                        "visual_evidence"
-                        if evidence_mode == "visual"
-                        else "textual_content_only"
-                    )
-                return default_result
 
-            # Write back llm_analyze_result to multimodal sidecar files.
+            async def _analyze_text_modality(
+                kind: str, item_id: str, item: dict[str, Any]
+            ) -> tuple[dict[str, Any], str | None]:
+                if use_extract_func is None:
+                    raise MultimodalAnalysisError(
+                        f"{kind}/{item_id}: EXTRACT role is required but not configured"
+                    )
+                content_text = _normalize_text(item.get("content"))
+                if not content_text:
+                    raise MultimodalAnalysisError(
+                        f"{kind}/{item_id}: missing {kind} content"
+                    )
+                template = MULTIMODAL_PROMPTS[f"{kind}_analysis"]
+                prompt = template.format(
+                    language=language,
+                    content=content_text,
+                    captions=_captions_value(item),
+                    footnotes=_footnotes_value(item),
+                    leading=_surrounding_value(item, "leading"),
+                    trailing=_surrounding_value(item, "trailing"),
+                    item_id=item_id,
+                    file_path=file_path,
+                )
+                args_hash = compute_args_hash(
+                    prompt,
+                    "",
+                    "",
+                    serialize_llm_cache_identity(extract_cache_identity),
+                    _serialize_cache_variant({"type": "json_object"}),
+                    _serialize_cache_variant([]),
+                    kind,
+                )
+                cache_id = generate_cache_key("default", "analysis", args_hash)
+                cached = await handle_cache(
+                    self.llm_response_cache,
+                    args_hash,
+                    prompt,
+                    mode="default",
+                    cache_type="analysis",
+                )
+                if cached is not None:
+                    result_text = cached[0]
+                    fresh = False
+                else:
+                    try:
+                        result_text = await use_extract_func(
+                            prompt,
+                            stream=False,
+                            response_format={"type": "json_object"},
+                            _priority=DEFAULT_MM_ANALYSIS_PRIORITY,
+                        )
+                    except Exception as exc:
+                        raise MultimodalAnalysisError(
+                            f"{kind}/{item_id}: EXTRACT call failed: {exc}"
+                        ) from exc
+                    fresh = True
+                parsed = _json_extract(str(result_text))
+                name = parsed.get("name")
+                description = parsed.get("description")
+                if not isinstance(name, str) or not name.strip():
+                    raise MultimodalAnalysisError(
+                        f"{kind}/{item_id}: missing or invalid field 'name'"
+                    )
+                if not isinstance(description, str) or not description.strip():
+                    raise MultimodalAnalysisError(
+                        f"{kind}/{item_id}: missing or invalid field 'description'"
+                    )
+                result_obj: dict[str, Any] = {
+                    "name": name.strip(),
+                    "description": description.strip(),
+                    "analyze_time": int(time.time()),
+                    "status": "success",
+                    "message": "",
+                }
+                if kind == "equation":
+                    equation_value = parsed.get("equation")
+                    if (
+                        not isinstance(equation_value, str)
+                        or not equation_value.strip()
+                    ):
+                        raise MultimodalAnalysisError(
+                            f"equation/{item_id}: missing or invalid field 'equation'"
+                        )
+                    result_obj["equation"] = equation_value.strip()
+                if fresh:
+                    await save_to_cache(
+                        self.llm_response_cache,
+                        CacheData(
+                            args_hash=args_hash,
+                            content=str(result_text),
+                            prompt=prompt,
+                            mode="default",
+                            cache_type="analysis",
+                            chunk_id=None,
+                        ),
+                    )
+                return (result_obj, cache_id)
+
+            def _attach_cache_id(item_obj: dict[str, Any], cache_id: str | None) -> None:
+                if not cache_id:
+                    return
+                existing = item_obj.get("llm_cache_list")
+                if not isinstance(existing, list):
+                    existing = []
+                if cache_id not in existing:
+                    existing.append(cache_id)
+                item_obj["llm_cache_list"] = existing
+
             base_name = str(block_file)
             if base_name.endswith(".blocks.jsonl"):
                 base_name = base_name[: -len(".blocks.jsonl")]
             sidecars = [
-                (Path(base_name + ".drawings.json"), "drawings", process_opts.images),
-                (Path(base_name + ".tables.json"), "tables", process_opts.tables),
+                (
+                    Path(base_name + ".drawings.json"),
+                    "drawings",
+                    "drawing",
+                    process_opts.images,
+                ),
+                (
+                    Path(base_name + ".tables.json"),
+                    "tables",
+                    "table",
+                    process_opts.tables,
+                ),
                 (
                     Path(base_name + ".equations.json"),
                     "equations",
+                    "equation",
                     process_opts.equations,
                 ),
             ]
-            for sidecar_path, root_key, enabled in sidecars:
-                if not enabled:
-                    continue
-                if not sidecar_path.exists():
+            for sidecar_path, root_key, kind, enabled in sidecars:
+                if not enabled or not sidecar_path.exists():
                     continue
                 try:
                     payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
-                    items = payload.get(root_key, {})
-                    if isinstance(items, dict):
-                        analyze_tasks = []
-                        valid_keys = []
-                        skipped_existing = 0
-                        for item_id, item in items.items():
-                            if not isinstance(item, dict):
-                                continue
-                            # Idempotency: skip items that already have a VLM
-                            # result from a prior pass.  A user re-enabling
-                            # additional modalities should not re-spend tokens
-                            # on items that were already analyzed.
-                            if isinstance(item.get("llm_analyze_result"), dict):
-                                skipped_existing += 1
-                                continue
-                            valid_keys.append(item_id)
-                            analyze_tasks.append(
-                                _analyze_item(
-                                    root_key,
-                                    item_id,
-                                    item,
-                                    sidecar_dir=sidecar_path.parent,
-                                )
+                except Exception as exc:
+                    raise MultimodalAnalysisError(
+                        f"failed to read sidecar {sidecar_path}: {exc}"
+                    ) from exc
+                items = payload.get(root_key, {})
+                if not isinstance(items, dict):
+                    continue
+
+                valid_keys: list[str] = []
+                analyze_tasks: list[Any] = []
+                skipped_existing = 0
+                for item_id, item in items.items():
+                    if not isinstance(item, dict):
+                        continue
+                    existing = item.get("llm_analyze_result")
+                    if isinstance(existing, dict):
+                        existing_status = existing.get("status")
+                        if existing_status in ("success", "skipped"):
+                            skipped_existing += 1
+                            continue
+                        if existing_status == "failure":
+                            raise MultimodalAnalysisError(
+                                f"{root_key}/{item_id}: prior llm_analyze_result "
+                                f"is failure ({existing.get('message') or 'no message'})"
                             )
-                        if skipped_existing:
-                            logger.debug(
-                                f"[analyze_multimodal] {root_key}: "
-                                f"{skipped_existing} item(s) already have "
-                                f"llm_analyze_result, skipping; "
-                                f"{len(analyze_tasks)} item(s) to analyze"
-                            )
-                        analyzed_results = await asyncio.gather(
-                            *analyze_tasks, return_exceptions=True
+                        # Unknown legacy status falls through to re-analysis.
+                    valid_keys.append(item_id)
+                    if kind == "drawing":
+                        analyze_tasks.append(
+                            _analyze_drawing(item_id, item, sidecar_path.parent)
                         )
-                        for idx, item_id in enumerate(valid_keys):
-                            item = items.get(item_id)
-                            if not isinstance(item, dict):
-                                continue
-                            result_obj = analyzed_results[idx]
-                            if isinstance(result_obj, Exception):
-                                logger.warning(
-                                    f"[analyze_multimodal] item analyze failed: {root_key}/{item_id}: {result_obj}"
-                                )
-                                continue
-                            if result_obj is None:
-                                # Skip signal (e.g. VLM_PROCESS_ENABLE=false):
-                                # do not persist anything so re-runs after the
-                                # operator enables VLM will re-process the item.
-                                continue
-                            item["llm_analyze_result"] = result_obj
+                    else:
+                        analyze_tasks.append(
+                            _analyze_text_modality(kind, item_id, item)
+                        )
+                if skipped_existing:
+                    logger.debug(
+                        f"[analyze_multimodal] {root_key}: "
+                        f"{skipped_existing} item(s) already analyzed, skipping; "
+                        f"{len(analyze_tasks)} item(s) to analyze"
+                    )
+
+                analyzed = await asyncio.gather(
+                    *analyze_tasks, return_exceptions=True
+                )
+
+                failure_to_raise: MultimodalAnalysisError | None = None
+                for idx, item_id in enumerate(valid_keys):
+                    item = items.get(item_id)
+                    if not isinstance(item, dict):
+                        continue
+                    outcome = analyzed[idx]
+                    if isinstance(outcome, MultimodalAnalysisError):
+                        item["llm_analyze_result"] = _failure_result(str(outcome))
+                        if failure_to_raise is None:
+                            failure_to_raise = outcome
+                        continue
+                    if isinstance(outcome, Exception):
+                        item["llm_analyze_result"] = _failure_result(
+                            f"unexpected error: {outcome}"
+                        )
+                        if failure_to_raise is None:
+                            failure_to_raise = MultimodalAnalysisError(
+                                f"{root_key}/{item_id}: unexpected error: {outcome}"
+                            )
+                        continue
+                    result_obj, cache_id = outcome
+                    item["llm_analyze_result"] = result_obj
+                    _attach_cache_id(item, cache_id)
+                try:
                     sidecar_path.write_text(
                         json.dumps(payload, ensure_ascii=False, indent=2),
                         encoding="utf-8",
                     )
-                except Exception as sidecar_error:
+                except OSError as exc:
                     logger.warning(
-                        f"[analyze_multimodal] failed to write sidecar {sidecar_path}: {sidecar_error}"
+                        f"[analyze_multimodal] failed to write sidecar "
+                        f"{sidecar_path}: {exc}"
                     )
+                if failure_to_raise is not None:
+                    raise failure_to_raise
 
             parsed_data["multimodal_processed"] = True
             logger.info(
                 f"[analyze_multimodal] completed for d-id: {doc_id}, file: {file_path}"
             )
+        except MultimodalAnalysisError:
+            raise
         except Exception as e:
             logger.warning(f"[analyze_multimodal] failed for d-id: {doc_id}: {e}")
         return parsed_data
@@ -3758,11 +3854,35 @@ class _PipelineMixin:
         file_path: str,
         blocks_path: str,
         base_order_index: int,
-    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-        """Build multimodal chunks and modality descriptors from sidecars."""
+    ) -> list[dict[str, Any]]:
+        """Build multimodal chunks from sidecars carrying analysis results.
+
+        Only items whose ``llm_analyze_result.status == "success"`` produce
+        chunks.  ``"skipped"`` items are silently ignored; ``"failure"``
+        items raise :class:`MultimodalAnalysisError` so the document is
+        marked failed (a failure should already have aborted the analyze
+        phase — this is a defensive recheck).
+
+        Each chunk follows the new schema: nested ``heading`` and
+        ``sidecar`` dicts, no flat ``parent_headings`` / ``level`` /
+        ``content_type`` fields.  ``llm_cache_list`` is merged from the
+        underlying sidecar item so document deletion can clean up the
+        ``cache_type="analysis"`` entries it created.
+
+        Raises:
+            MultimodalAnalysisError: when an item carries ``status="failure"``,
+                or when the multimodal chunk cannot be fit under the
+                extraction token budget even after truncating description
+                to :data:`DEFAULT_MM_CHUNK_DESCRIPTION_MIN_TOKENS`.
+        """
+        from lightrag.constants import (
+            DEFAULT_MAX_EXTRACT_INPUT_TOKENS,
+            DEFAULT_MM_CHUNK_DESCRIPTION_MIN_TOKENS,
+        )
+
         block_file = Path(blocks_path)
         if not block_file.exists():
-            return [], []
+            return []
 
         base = str(block_file)
         if base.endswith(".blocks.jsonl"):
@@ -3775,10 +3895,9 @@ class _PipelineMixin:
         ]
 
         mm_chunks: list[dict[str, Any]] = []
-        mm_specs: list[dict[str, Any]] = []
         order = base_order_index
 
-        def _norm_list(v: Any) -> list[str]:
+        def _norm_str_list(v: Any) -> list[str]:
             if v is None:
                 return []
             if isinstance(v, list):
@@ -3786,10 +3905,88 @@ class _PipelineMixin:
             s = str(v).strip()
             return [s] if s else []
 
-        def _mm_entity_name(kind: str, raw_payload: dict[str, Any]) -> str:
-            payload = json.dumps(raw_payload, ensure_ascii=False, sort_keys=True)
-            digest = hashlib.md5(payload.encode("utf-8")).hexdigest()
-            return f"{kind}-{digest}"
+        def _norm_parent_headings(value: Any) -> list[str]:
+            if not isinstance(value, list):
+                return []
+            return [str(p).strip() for p in value if str(p or "").strip()]
+
+        def _build_heading_dict(item: dict[str, Any]) -> dict[str, Any] | None:
+            heading_raw = item.get("heading")
+            if isinstance(heading_raw, dict):
+                heading_text = str(heading_raw.get("heading") or "").strip()
+                parents = _norm_parent_headings(heading_raw.get("parent_headings"))
+                try:
+                    level = int(heading_raw.get("level") or 0)
+                except (TypeError, ValueError):
+                    level = 0
+            else:
+                heading_text = str(heading_raw or "").strip()
+                parents = _norm_parent_headings(item.get("parent_headings"))
+                try:
+                    level = int(item.get("level") or 0)
+                except (TypeError, ValueError):
+                    level = 0
+            if not heading_text and not parents and level == 0:
+                return None
+            return {
+                "level": level,
+                "heading": heading_text,
+                "parent_headings": parents,
+            }
+
+        def _render(
+            kind: str,
+            name: str,
+            description: str,
+            footnotes_joined: str,
+            equation_body: str,
+        ) -> str:
+            sections: list[str] = []
+            if kind == "drawing":
+                sections.append(f"- Image Name:\n{name}")
+                # type field comes from caller via name interpolation: omit
+                # when blank because the prompt enforces it as required so a
+                # missing type should already have raised.
+                # The image type was inserted at call-site by the caller via a
+                # secondary call to this helper if needed.
+                if description:
+                    sections.append(f"- Image Description:\n{description}")
+                if footnotes_joined:
+                    sections.append(f"- Image Footnotes:\n{footnotes_joined}")
+            elif kind == "table":
+                sections.append(f"- Table Name:\n{name}")
+                if description:
+                    sections.append(f"- Table Description:\n{description}")
+                if footnotes_joined:
+                    sections.append(f"- Table Footnotes:\n{footnotes_joined}")
+            else:
+                sections.append(f"- Equation Name:\n{name}")
+                if equation_body:
+                    sections.append(f"- Equation Body:\n{equation_body}")
+                if description:
+                    sections.append(f"- Equation Description:\n{description}")
+                if footnotes_joined:
+                    sections.append(f"- Equation Footnotes:\n{footnotes_joined}")
+            return "\n\n".join(sections).strip()
+
+        def _render_image(
+            name: str,
+            image_type: str,
+            description: str,
+            footnotes_joined: str,
+        ) -> str:
+            sections = [
+                f"- Image Name:\n{name}",
+                f"- Image Type:\n{image_type}",
+            ]
+            if description:
+                sections.append(f"- Image Description:\n{description}")
+            if footnotes_joined:
+                sections.append(f"- Image Footnotes:\n{footnotes_joined}")
+            return "\n\n".join(sections).strip()
+
+        max_tokens = DEFAULT_MAX_EXTRACT_INPUT_TOKENS
+        min_desc_tokens = DEFAULT_MM_CHUNK_DESCRIPTION_MIN_TOKENS
 
         for root_key, sidecar_path, kind in sidecar_defs:
             if not sidecar_path.exists():
@@ -3806,124 +4003,109 @@ class _PipelineMixin:
                 if not isinstance(item, dict):
                     continue
 
-                # mm_chunks are VLM-output containers: without llm_analyze_result
-                # there is nothing meaningful to index. analyze_multimodal only
-                # writes this field for modalities opted into via i/t/e in
-                # process_options, so unopted modalities (and VLM failures)
-                # naturally produce no chunks here.
                 analysis = item.get("llm_analyze_result")
-                if not isinstance(analysis, dict) or not analysis:
+                if not isinstance(analysis, dict):
                     continue
-                name = str(analysis.get("name") or item.get("caption") or item_id)
-                summary = str(analysis.get("summary") or "").strip()
-                detail = str(analysis.get("detail_description") or "").strip()
-                heading = str(item.get("heading") or "").strip()
-                captions = _norm_list(item.get("caption"))
-                footnotes = _norm_list(item.get("footnotes"))
-                image_type = str(analysis.get("image_type") or "").strip()
-
-                raw_for_hash: dict[str, Any] = {
-                    "kind": kind,
-                    "name": name,
-                    "summary": summary,
-                    "detail": detail,
-                    "content": item.get("content"),
-                    "path": item.get("path"),
-                    "src": item.get("src"),
-                    "caption": item.get("caption"),
-                }
-                entity_name = _mm_entity_name(kind, raw_for_hash)
-                chunk_id = f"{doc_id}-mm-{kind}-{local_idx:03d}"
-
-                if kind == "drawing":
-                    lines = [
-                        f"Image_Name: {name}",
-                    ]
-                    if image_type:
-                        lines.append(f"Image_Type: {image_type}")
-                    lines.extend(
-                        [
-                            "Image_Location:",
-                            f"  - Document_Name: {Path(file_path).name}",
-                        ]
+                status = analysis.get("status")
+                if status == "skipped":
+                    continue
+                if status == "failure":
+                    raise MultimodalAnalysisError(
+                        f"{root_key}/{item_id}: llm_analyze_result.status='failure' "
+                        f"({analysis.get('message') or 'no message'})"
                     )
-                    if heading:
-                        lines.append(f"  - Session_Heading: {heading}")
-                    if captions:
-                        lines.append("Image_Captions:")
-                        lines.extend([f"  - {x}" for x in captions])
-                    if footnotes:
-                        lines.append("Image_Footnotes:")
-                        lines.extend([f"  - {x}" for x in footnotes])
-                    if summary:
-                        lines.append(f'Image_Summary: "{summary}"')
-                    if detail:
-                        lines.append(f'Image_Detail_Description: "{detail}"')
-                elif kind == "table":
-                    lines = [
-                        f"Table_Name: {name}",
-                        "Table_Location:",
-                        f"  - Document_Name: {Path(file_path).name}",
-                    ]
-                    if heading:
-                        lines.append(f"  - Session_Heading: {heading}")
-                    if captions:
-                        lines.append("Table_Captions:")
-                        lines.extend([f"  - {x}" for x in captions])
-                    if footnotes:
-                        lines.append("Table_Footnotes:")
-                        lines.extend([f"  - {x}" for x in footnotes])
-                    if summary:
-                        lines.append(f'Table_Summary: "{summary}"')
-                    if detail:
-                        lines.append(f'Table_Detail_Description: "{detail}"')
-                else:
-                    lines = [
-                        f"Equation_Name: {name}",
-                        "Equation_Location:",
-                        f"  - Document_Name: {Path(file_path).name}",
-                    ]
-                    if heading:
-                        lines.append(f"  - Session_Heading: {heading}")
-                    if captions:
-                        lines.append("Equation_Captions:")
-                        lines.extend([f"  - {x}" for x in captions])
-                    if footnotes:
-                        lines.append("Equation_Footnotes:")
-                        lines.extend([f"  - {x}" for x in footnotes])
-                    if summary:
-                        lines.append(f'Equation_Summary: "{summary}"')
-                    if detail:
-                        lines.append(f'Equation_Detail_Description: "{detail}"')
+                if status != "success":
+                    # Treat unknown / legacy status as missing — no chunk.
+                    continue
 
-                chunk_content = "\n".join(lines).strip()
+                name = str(analysis.get("name") or "").strip()
+                description = str(analysis.get("description") or "").strip()
+                equation_body = str(analysis.get("equation") or "").strip()
+                image_type = str(analysis.get("type") or "").strip()
+                if not name:
+                    raise MultimodalAnalysisError(
+                        f"{root_key}/{item_id}: success result missing 'name'"
+                    )
+                if not description:
+                    raise MultimodalAnalysisError(
+                        f"{root_key}/{item_id}: success result missing 'description'"
+                    )
+                if kind == "drawing" and not image_type:
+                    raise MultimodalAnalysisError(
+                        f"drawings/{item_id}: success result missing 'type'"
+                    )
+                if kind == "equation" and not equation_body:
+                    raise MultimodalAnalysisError(
+                        f"equations/{item_id}: success result missing 'equation'"
+                    )
+
+                footnotes_list = _norm_str_list(item.get("footnotes"))
+                footnotes_joined = "; ".join(footnotes_list)
+
+                def _compose(desc: str) -> str:
+                    if kind == "drawing":
+                        return _render_image(
+                            name=name,
+                            image_type=image_type,
+                            description=desc,
+                            footnotes_joined=footnotes_joined,
+                        )
+                    return _render(
+                        kind=kind,
+                        name=name,
+                        description=desc,
+                        footnotes_joined=footnotes_joined,
+                        equation_body=equation_body,
+                    )
+
+                chunk_content = _compose(description)
+                tokens = len(self.tokenizer.encode(chunk_content))
+                if tokens > max_tokens:
+                    # Truncate only the description, never name/type/equation.
+                    desc_tokens = self.tokenizer.encode(description)
+                    overflow = tokens - max_tokens
+                    keep = max(min_desc_tokens, len(desc_tokens) - overflow)
+                    while True:
+                        truncated_desc = self.tokenizer.decode(desc_tokens[:keep])
+                        chunk_content = _compose(truncated_desc)
+                        tokens = len(self.tokenizer.encode(chunk_content))
+                        if tokens <= max_tokens or keep <= min_desc_tokens:
+                            break
+                        keep = max(min_desc_tokens, keep - (tokens - max_tokens))
+                    if tokens > max_tokens:
+                        raise MultimodalAnalysisError(
+                            f"{root_key}/{item_id}: multimodal chunk exceeds "
+                            f"{max_tokens} tokens even after truncating description "
+                            f"to {min_desc_tokens} tokens"
+                        )
+
                 if not chunk_content:
                     continue
 
-                mm_chunks.append(
-                    {
-                        "chunk_id": chunk_id,
-                        "chunk_order_index": order,
-                        "content": chunk_content,
-                        "tokens": len(self.tokenizer.encode(chunk_content)),
-                        "content_type": kind,
-                        "heading": heading,
-                        "parent_headings": [],
-                        "level": 0,
-                    }
+                heading_dict = _build_heading_dict(item)
+                sidecar_block = {
+                    "type": kind,
+                    "id": str(item_id),
+                    "refs": [{"type": kind, "id": str(item_id)}],
+                }
+                cache_list = item.get("llm_cache_list")
+                cache_list = (
+                    [str(c) for c in cache_list if str(c).strip()]
+                    if isinstance(cache_list, list)
+                    else []
                 )
-                mm_specs.append(
-                    {
-                        "kind": kind,
-                        "chunk_id": chunk_id,
-                        "entity_name": entity_name,
-                        "entity_type": kind,
-                        "name": name,
-                        "caption_text": "; ".join(captions),
-                        "heading": heading,
-                        "summary": summary,
-                    }
-                )
+
+                chunk_dict: dict[str, Any] = {
+                    "chunk_id": f"{doc_id}-mm-{kind}-{local_idx:03d}",
+                    "chunk_order_index": order,
+                    "content": chunk_content,
+                    "tokens": tokens,
+                    "sidecar": sidecar_block,
+                    "llm_cache_list": cache_list,
+                }
+                if heading_dict is not None:
+                    chunk_dict["heading"] = heading_dict
+                mm_chunks.append(chunk_dict)
                 order += 1
 
-        return mm_chunks, mm_specs
+        return mm_chunks

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1853,9 +1853,7 @@ class _PipelineMixin:
                         file_path=file_path,
                         blocks_path=blocks_path,
                         base_order_index=max_order + 1,
-                        process_options=(content_data or {}).get(
-                            "process_options"
-                        )
+                        process_options=(content_data or {}).get("process_options")
                         or "",
                     )
                     if mm_chunks:

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -3293,9 +3293,7 @@ class _PipelineMixin:
             )
             min_image_pixel = max(
                 1,
-                int(
-                    os.getenv("VLM_MIN_IMAGE_PIXEL", str(DEFAULT_MM_IMAGE_MIN_PIXEL))
-                ),
+                int(os.getenv("VLM_MIN_IMAGE_PIXEL", str(DEFAULT_MM_IMAGE_MIN_PIXEL))),
             )
 
             use_vlm_func = self.role_llm_funcs.get("vlm")
@@ -3343,9 +3341,7 @@ class _PipelineMixin:
                 if isinstance(value, str):
                     return value.strip()
                 if isinstance(value, (list, tuple)):
-                    return "\n".join(
-                        str(v).strip() for v in value if str(v).strip()
-                    )
+                    return "\n".join(str(v).strip() for v in value if str(v).strip())
                 return str(value).strip()
 
             def _captions_value(item_obj: dict[str, Any]) -> str:
@@ -3354,9 +3350,7 @@ class _PipelineMixin:
             def _footnotes_value(item_obj: dict[str, Any]) -> str:
                 raw = item_obj.get("footnotes")
                 if isinstance(raw, (list, tuple)):
-                    joined = "; ".join(
-                        str(v).strip() for v in raw if str(v).strip()
-                    )
+                    joined = "; ".join(str(v).strip() for v in raw if str(v).strip())
                     return joined or "n/a"
                 text = _normalize_text(raw)
                 return text or "n/a"
@@ -3400,16 +3394,12 @@ class _PipelineMixin:
                 item_id: str, item: dict[str, Any], sidecar_dir: Path
             ) -> tuple[dict[str, Any], str | None]:
                 path_str = (
-                    item.get("path")
-                    or item.get("img_path")
-                    or item.get("image_path")
+                    item.get("path") or item.get("img_path") or item.get("image_path")
                 )
                 candidate = _resolve_image_path(path_str, sidecar_dir)
                 if candidate is None:
                     return (
-                        _skipped_result(
-                            f"image file not found: {path_str or 'n/a'}"
-                        ),
+                        _skipped_result(f"image file not found: {path_str or 'n/a'}"),
                         None,
                     )
                 ext = candidate.suffix.lower()
@@ -3480,9 +3470,7 @@ class _PipelineMixin:
                     "",
                     serialize_llm_cache_identity(vlm_cache_identity),
                     _serialize_cache_variant({"type": "json_object"}),
-                    _serialize_cache_variant(
-                        image_cache_metadata(normalized_images)
-                    ),
+                    _serialize_cache_variant(image_cache_metadata(normalized_images)),
                     "drawing",
                 )
                 cache_id = generate_cache_key("default", "analysis", args_hash)
@@ -3657,7 +3645,9 @@ class _PipelineMixin:
                     )
                 return (result_obj, cache_id)
 
-            def _attach_cache_id(item_obj: dict[str, Any], cache_id: str | None) -> None:
+            def _attach_cache_id(
+                item_obj: dict[str, Any], cache_id: str | None
+            ) -> None:
                 if not cache_id:
                     return
                 existing = item_obj.get("llm_cache_list")
@@ -3737,9 +3727,7 @@ class _PipelineMixin:
                         f"{len(analyze_tasks)} item(s) to analyze"
                     )
 
-                analyzed = await asyncio.gather(
-                    *analyze_tasks, return_exceptions=True
-                )
+                analyzed = await asyncio.gather(*analyze_tasks, return_exceptions=True)
 
                 failure_to_raise: MultimodalAnalysisError | None = None
                 for idx, item_id in enumerate(valid_keys):

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -3317,6 +3317,17 @@ class _PipelineMixin:
                 1,
                 int(os.getenv("VLM_MIN_IMAGE_PIXEL", str(DEFAULT_MM_IMAGE_MIN_PIXEL))),
             )
+            # Multimodal analysis shares the entity-extraction cache flag
+            # (both run with mode="default" — see handle_cache short-circuit
+            # in lightrag.utils).  When the flag is off we must NOT save the
+            # response either, otherwise stale cache entries would still
+            # accumulate while reads are blocked.  cache_id attachment to
+            # the sidecar item.llm_cache_list is likewise gated so a
+            # disabled cache does not seed cache-cleanup metadata that
+            # corresponds to entries that were never persisted.
+            analysis_cache_enabled = bool(
+                global_config.get("enable_llm_cache_for_entity_extract")
+            )
 
             use_vlm_func = self.role_llm_funcs.get("vlm")
             use_extract_func = self.role_llm_funcs.get("extract")
@@ -3549,7 +3560,8 @@ class _PipelineMixin:
                     )
                 if type_value not in _IMAGE_TYPE_VALUES:
                     type_value = IMAGE_TYPE_FALLBACK
-                if fresh:
+                cache_id_to_attach: str | None = None
+                if fresh and analysis_cache_enabled:
                     audit_blob = image_audit_metadata(normalized_images)
                     original_prompt = prompt + (
                         f"\n<vlm_images>"
@@ -3569,6 +3581,11 @@ class _PipelineMixin:
                             chunk_id=None,
                         ),
                     )
+                    cache_id_to_attach = cache_id
+                elif not fresh:
+                    # Cache hit: the entry exists, so attaching its id is
+                    # safe (and necessary for document-delete cleanup).
+                    cache_id_to_attach = cache_id
                 return (
                     {
                         "name": name.strip(),
@@ -3578,7 +3595,7 @@ class _PipelineMixin:
                         "status": "success",
                         "message": "",
                     },
-                    cache_id,
+                    cache_id_to_attach,
                 )
 
             async def _analyze_text_modality(
@@ -3665,7 +3682,8 @@ class _PipelineMixin:
                             f"equation/{item_id}: missing or invalid field 'equation'"
                         )
                     result_obj["equation"] = equation_value.strip()
-                if fresh:
+                cache_id_to_attach: str | None = None
+                if fresh and analysis_cache_enabled:
                     await save_to_cache(
                         self.llm_response_cache,
                         CacheData(
@@ -3677,7 +3695,12 @@ class _PipelineMixin:
                             chunk_id=None,
                         ),
                     )
-                return (result_obj, cache_id)
+                    cache_id_to_attach = cache_id
+                elif not fresh:
+                    # Cache hit path (handle_cache already gated by flag):
+                    # safe to surface the existing cache_id for cleanup.
+                    cache_id_to_attach = cache_id
+                return (result_obj, cache_id_to_attach)
 
             def _attach_cache_id(
                 item_obj: dict[str, Any], cache_id: str | None

--- a/lightrag/prompt_multimodal.py
+++ b/lightrag/prompt_multimodal.py
@@ -52,7 +52,9 @@ IMAGE_TYPE_FALLBACK = "Other"
 MULTIMODAL_PROMPTS: dict[str, str] = {}
 
 
-MULTIMODAL_PROMPTS["image_analysis"] = """You are an expert image analyzer. Analyze the provided image and return a single JSON object describing its content.
+MULTIMODAL_PROMPTS[
+    "image_analysis"
+] = """You are an expert image analyzer. Analyze the provided image and return a single JSON object describing its content.
 
 ================ INSTRUCTIONS ================
 
@@ -129,7 +131,9 @@ Output:
 """
 
 
-MULTIMODAL_PROMPTS["table_analysis"] = """You are an expert table analyzer. The provided content contains table content in JSON or HTML format. Analyze it and return a single JSON object describing its structure and content.
+MULTIMODAL_PROMPTS[
+    "table_analysis"
+] = """You are an expert table analyzer. The provided content contains table content in JSON or HTML format. Analyze it and return a single JSON object describing its structure and content.
 
 ================ INSTRUCTIONS ================
 
@@ -210,7 +214,9 @@ Output:
 """
 
 
-MULTIMODAL_PROMPTS["equation_analysis"] = """You are an expert analyzer of mathematical and chemical equations. The input is a TEXT-form equation written in LaTeX or Markdown. Analyze it and return a single JSON object describing its meaning and role.
+MULTIMODAL_PROMPTS[
+    "equation_analysis"
+] = """You are an expert analyzer of mathematical and chemical equations. The input is a TEXT-form equation written in LaTeX or Markdown. Analyze it and return a single JSON object describing its meaning and role.
 
 ================ INSTRUCTIONS ================
 

--- a/lightrag/prompt_multimodal.py
+++ b/lightrag/prompt_multimodal.py
@@ -1,0 +1,316 @@
+"""Multimodal analysis prompts for LightRAG.
+
+These templates are consumed by ``LightRAG.analyze_multimodal`` to produce
+modality-specific analysis JSON written into each sidecar item's
+``llm_analyze_result``.
+
+Each template accepts the same variable set so the caller can format them
+uniformly:
+
+- ``language``  : target language for ``name`` / ``description`` outputs.
+- ``content``   : modality body (table JSON/HTML, equation LaTeX, etc.).
+                  Images pass an empty string and rely on ``image_inputs``.
+- ``captions``  : caption text or ``"n/a"``.
+- ``footnotes`` : joined footnotes string or ``"n/a"``.
+- ``leading``   : surrounding leading context or ``"n/a"``.
+- ``trailing``  : surrounding trailing context or ``"n/a"``.
+- ``item_id``   : sidecar item identifier (for diagnostics, not required by
+                  every template).
+- ``file_path`` : source document path (diagnostics only).
+
+The output schema differs by modality:
+
+- Image    : ``{"name": str, "type": str, "description": str}``
+- Table    : ``{"name": str, "description": str}``
+- Equation : ``{"name": str, "equation": str, "description": str}``
+
+Image ``type`` is restricted to :data:`IMAGE_TYPE_ENUM`; values outside the
+enum are folded into :data:`IMAGE_TYPE_FALLBACK` by the caller.
+"""
+
+from __future__ import annotations
+
+
+IMAGE_TYPE_ENUM: tuple[str, ...] = (
+    "Photo",
+    "Illustration",
+    "Screenshot",
+    "Icon",
+    "Chart",
+    "Table",
+    "Infographic",
+    "Flowchart",
+    "Chat Log",
+    "Wireframe",
+    "Texture",
+    "Other",
+)
+
+IMAGE_TYPE_FALLBACK = "Other"
+
+
+MULTIMODAL_PROMPTS: dict[str, str] = {}
+
+
+MULTIMODAL_PROMPTS["image_analysis"] = """You are an expert image analyzer. Analyze the provided image and return a single JSON object describing its content.
+
+================ INSTRUCTIONS ================
+
+1. CONTENT RECOGNITION
+   Examine the image carefully and identify:
+   - The primary subject(s), scene, or composition.
+   - Salient visual elements (objects, people, text overlays, diagrams, charts, screenshots, etc.).
+   - Spatial layout when meaningful (e.g. left/right, foreground/background, panels of a figure).
+   - Any visible text — quote it verbatim when short; summarize when long.
+   - Color, style, or visual cues only when they materially aid interpretation.
+
+2. USE OF ADDITIONAL CONTEXT
+   The Additional Context section provides surrounding information that may help disambiguate the image's role in its source document:
+   - Captions      : caption attached to the image ("n/a" = none)
+   - Footnotes     : footnote attached to the image ("n/a" = none)
+   - Leading Text  : text appearing immediately BEFORE the image ("n/a" = none)
+   - Trailing Text : text appearing immediately AFTER the image ("n/a" = none)
+
+   Rules:
+   - Use context to disambiguate abbreviations, units, named entities, and the image's purpose.
+   - The IMAGE ITSELF takes priority when it conflicts with context — describe what is visible.
+   - Only mention a relationship between the image and Leading/Trailing Text if it is clearly supported. If uncertain, omit it.
+   - Captions, footnotes, leading text and trailing text must NOT be used to invent visual content not present in the image.
+
+3. NAMING (`name`)
+   - Produce a concise, distinctive name (3–8 words, snake_case preferred).
+   - It should convey what the image depicts, not just "image".
+   - Good examples: `crispr_cas9_workflow_diagram`, `q4_revenue_bar_chart`, `paris_eiffel_tower_photo`.
+   - Bad examples: `image`, `figure`, `picture_1`.
+
+4. TYPE (`type`)
+   - Pick exactly one value from this fixed list (verbatim, case-sensitive):
+     Photo, Illustration, Screenshot, Icon, Chart, Table, Infographic, Flowchart, Chat Log, Wireframe, Texture, Other
+   - Choose the single best fit. Use `Other` when no listed type clearly applies.
+
+5. DESCRIPTION (`description`, ≤ 500 words, natural prose — not bullets)
+   Cover the following where applicable:
+   - What the image depicts overall and what question/claim it visually supports.
+   - The primary subject(s), their attributes, and any meaningful relationships between them.
+   - Quantitative findings if the image is a chart/diagram (cite specific values when visible).
+   - Visible text content that carries meaning (labels, annotations, axis titles).
+   - Use specific proper nouns rather than pronouns whenever possible.
+   - If the image clearly supports the Leading/Trailing Text, briefly note that relationship at the end. Otherwise omit.
+
+6. OUTPUT RULES
+   - Return ONE valid JSON object only.
+   - No surrounding markdown, no code fences, no preamble, no explanation.
+   - All string values must be properly escaped JSON strings (escape `"` as `\\"`, newlines as `\\n`).
+   - The output values for the JSON fields `name` and `description` must be written in `{language}`.
+
+================ ADDITIONAL CONTEXT ================
+- Captions: {captions}
+
+- Footnotes: {footnotes}
+
+- Leading Text:
+```
+{leading}
+```
+
+- Trailing Text:
+```
+{trailing}
+```
+
+================ OUTPUT FORMAT ================
+{{
+  "name": "<concise distinctive name>",
+  "type": "<one value from the fixed type list>",
+  "description": "<interpretive description, ≤500 words>"
+}}
+
+Output:
+"""
+
+
+MULTIMODAL_PROMPTS["table_analysis"] = """You are an expert table analyzer. The provided content contains table content in JSON or HTML format. Analyze it and return a single JSON object describing its structure and content.
+
+================ INSTRUCTIONS ================
+
+1. CONTENT RECOGNITION
+   Read the table carefully and identify:
+   - Overall structure: number of rows and columns, presence of merged cells, multi-level headers, row groupings, or totals/subtotals rows.
+   - Column headers and (if present) row headers — capture their exact wording.
+   - Units of measurement (%, $, ms, kg, etc.) and any scale indicators ("in millions", "×1000").
+   - Key data points: maxima, minima, outliers, notable values, totals.
+   - Patterns and trends across rows or columns (growth, decline, correlation, ranking).
+   - Empty cells, "—", "N/A", or other null markers — preserve them as-is, do NOT fabricate values.
+   - Footnote markers inside cells (e.g. "*", "†", "[1]") and what they refer to.
+
+2. USE OF ADDITIONAL CONTEXT
+   The Additional Context section provides surrounding information to help you understand the table's role in its source document:
+   - Captions      : the table's caption ("n/a" = none)
+   - Footnotes     : footnote attached to the table ("n/a" = none)
+   - Leading Text  : text appearing immediately BEFORE the table ("n/a" = none)
+   - Trailing Text : text appearing immediately AFTER the table ("n/a" = none)
+
+   Rules:
+   - Use context to disambiguate column meanings, units, abbreviations, and entity names.
+   - TABLE CONTENT TAKES PRIORITY over context when they conflict. Describe what you actually see; note the discrepancy only if it is material.
+   - Only mention a relationship between the table and Leading/Trailing Text if it is clearly supported. If uncertain, omit it.
+   - Captions, footnotes, leading text and trailing text may only be used for disambiguation purposes and must not be used to infer or fabricate content not present in TABLE CONTENT.
+   - NEVER invent rows, columns, values, units, or entities that are not visible.
+
+3. NAMING (`name`)
+   - Produce a concise, distinctive name (3–8 words, snake_case preferred).
+   - It should convey what the table is about, not just "table".
+   - Good examples: `q4_2024_revenue_by_region`, `model_benchmark_accuracy_latency`, `patient_demographics_baseline`.
+   - Bad examples: `table`, `data_table`, `results`.
+
+4. DESCRIPTION (`description`, ≤ 500 words, natural prose — not bullets)
+   Cover the following where applicable:
+   - What the table is about and what question it answers.
+   - What the rows represent and what the columns represent (the "shape" of the data).
+   - Units, time range, and scope of the data.
+   - The most important patterns, trends, comparisons, or outliers — cite specific values from the table to support each observation (e.g. "revenue grew from $1.2M in Q1 to $3.8M in Q4").
+   - Any totals, subtotals, averages, or computed columns and what they reveal.
+   - Use specific proper nouns (entity names, column names) instead of pronouns.
+   - If the table clearly illustrates or supports the Leading/Trailing Text, briefly note that relationship at the end. Otherwise omit.
+   - Do not restate the table cell by cell or row by row; focus on interpretation.
+
+5. OUTPUT RULES
+   - Return ONE valid JSON object only.
+   - No surrounding markdown, no code fences, no preamble, no explanation.
+   - All string values must be properly escaped JSON strings (escape `"` as `\\"`, newlines as `\\n`).
+   - The output values for the JSON fields `name` and `description` must be written in `{language}`.
+
+================ TABLE CONTENT ================
+```
+{content}
+```
+
+================ ADDITIONAL CONTEXT ================
+- Captions: {captions}
+
+- Footnotes: {footnotes}
+
+- Leading Text:
+```
+{leading}
+```
+
+- Trailing Text:
+```
+{trailing}
+```
+
+================ OUTPUT FORMAT ================
+{{
+  "name": "<concise distinctive name>",
+  "description": "<interpretive description of the table, ≤500 words>"
+}}
+
+Output:
+"""
+
+
+MULTIMODAL_PROMPTS["equation_analysis"] = """You are an expert analyzer of mathematical and chemical equations. The input is a TEXT-form equation written in LaTeX or Markdown. Analyze it and return a single JSON object describing its meaning and role.
+
+================ INSTRUCTIONS ================
+
+1. CONTENT RECOGNITION
+   Read the equation carefully and identify:
+   - The type of expression: definition, identity, equation to solve, inequality, differential / integral equation, recurrence, chemical reaction, balance equation, etc.
+   - The mathematical or chemical meaning of the expression as a whole.
+   - The variables, constants, operators, and functions that appear, and what each likely denotes given the surrounding context.
+   - The application domain (e.g. classical mechanics, probability, thermodynamics, organic chemistry, machine learning loss function) inferred from context.
+   - Any physical, statistical, or theoretical significance.
+   - Whether the expression matches a well-known named formula (e.g. Bayes' theorem, Schrödinger equation, softmax, Michaelis–Menten). Name it explicitly when you are confident; do NOT guess.
+
+2. USE OF ADDITIONAL CONTEXT
+   The Additional Context section provides surrounding information to help you understand the equation's role in its source document:
+   - Captions      : the equation's caption or label ("n/a" = none)
+   - Footnotes     : footnote attached to the equation ("n/a" = none)
+   - Leading Text  : text appearing immediately BEFORE the equation ("n/a" = none)
+   - Trailing Text : text appearing immediately AFTER the equation ("n/a" = none)
+
+   Rules:
+   - Use context to determine variable meanings, units, and the domain of discussion.
+   - THE EQUATION ITSELF TAKES PRIORITY over context if they conflict; note the discrepancy if material.
+   - Only mention a relationship between the equation and Leading/Trailing Text if it is clearly supported. If uncertain, omit it.
+   - Captions, footnotes, leading text and trailing text may only be used for disambiguation purposes and must not be used to infer or fabricate content not present in EQUATION BODY.
+   - NEVER invent variables, terms, or interpretations that are not justified by either the equation or the context.
+
+3. NAMING (`name`)
+   - Produce a concise, distinctive name (3–8 words, snake_case preferred).
+   - It should convey what the equation IS or DOES, not just "equation".
+   - Good examples:
+       `bayes_theorem_posterior`
+       `softmax_cross_entropy_loss`
+       `ideal_gas_law`
+       `michaelis_menten_rate`
+       `combustion_of_methane`
+       `quadratic_formula_roots`
+   - Bad examples:
+       `equation`, `formula`, `math`, `the_equation`, `eq_1`
+
+4. NORMALIZED EQUATION (`equation`)
+   - Output the math-mode BODY ONLY. Do NOT wrap in any delimiter or environment: no `$...$`, no `$$...$$`, no `\\(...\\)`, no `\\[...\\]`, no `\\begin{{equation}}...\\end{{equation}}`.
+   - Strip those outer wrappers if present in the input.
+   - KEEP semantic inner environments such as `aligned`, `cases`, `pmatrix`, `bmatrix`, `array`, `split` — they are part of the equation's structure, not delimiters.
+   - If the input uses `\\begin{{align}}` or `\\begin{{align*}}`, convert to `\\begin{{aligned}}`.
+   - Strip equation numbering (`\\tag{{...}}`, automatic numbers from `align`/`equation`).
+   - Preserve all symbols, subscripts, superscripts, and operators faithfully. Do NOT simplify or rename variables.
+   - Convert Markdown / plain-text / Unicode math to standard LaTeX (`x^2` → `x^{{2}}`, `sqrt(a)` → `\\sqrt{{a}}`, `≤` → `\\leq`, `α` → `\\alpha`).
+   - For chemical equations, use `mhchem`: `\\ce{{2H2 + O2 -> 2H2O}}`.
+   - If multiple independent equations appear together, join them with `\\\\` inside a single `\\begin{{aligned}}...\\end{{aligned}}` and note the grouping in `description`.
+
+5. DESCRIPTION (`description`, ≤ 300 words, natural prose — not bullets)
+   Cover the following where applicable:
+   - What the equation expresses and what problem it addresses.
+   - Its role in the surrounding text (e.g. defines a quantity, states a constraint, derives a result, models a phenomenon).
+   - The named formula it corresponds to, if any, and where it is commonly used.
+   - Briefly clarify only those symbols whose meaning is non-obvious or domain-specific, OR whose meaning is fixed by the Leading/Trailing Text. Do NOT enumerate every symbol mechanically.
+   - Use specific proper nouns (variable names, entity names) instead of pronouns.
+   - If the equation clearly illustrates or supports the Leading/Trailing Text, briefly note that relationship at the end. Otherwise omit.
+
+6. OUTPUT RULES
+   - Return ONE valid JSON object only.
+   - No surrounding markdown, no code fences, no preamble, no explanation.
+   - All string values must be properly escaped JSON strings (escape `"` as `\\"`, escape backslashes as `\\\\`, newlines as `\\n`).
+   - LaTeX backslashes inside the `equation` string must be double-escaped (e.g. `\\frac{{a}}{{b}}` is written as `"\\\\frac{{a}}{{b}}"` in the JSON).
+   - If the input uses `\\begin{{align}}` or `\\begin{{align*}}`, convert to `\\begin{{aligned}}` in the output (since the outer display wrapper is stripped).
+   - The output values for the JSON fields `name` and `description` must be written in `{language}`.
+
+================ EQUATION BODY ================
+```
+{content}
+```
+
+================ ADDITIONAL CONTEXT ================
+- Captions: {captions}
+
+- Footnotes: {footnotes}
+
+- Leading Text:
+```
+{leading}
+```
+
+- Trailing Text:
+```
+{trailing}
+```
+
+================ OUTPUT FORMAT ================
+{{
+  "name": "<concise distinctive name>",
+  "equation": "<normalized LaTeX, math-mode body only>",
+  "description": "<interpretive description, ≤300 words>"
+}}
+
+Output:
+"""
+
+
+__all__ = [
+    "IMAGE_TYPE_ENUM",
+    "IMAGE_TYPE_FALLBACK",
+    "MULTIMODAL_PROMPTS",
+]

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -1871,7 +1871,9 @@ def enforce_chunk_token_limit_before_embedding(
             except Exception:
                 new_dp["tokens"] = max(1, int(len(piece) * 0.5))
 
-            # Keep heading/parent_headings/level unchanged; only split payload.
+            # Shallow-copy preserves the nested heading dict and sidecar
+            # block from the source chunk; only the payload (content/tokens
+            # /chunk_id) is rewritten per split slice.
             if isinstance(base_chunk_id, str) and base_chunk_id.strip():
                 new_dp["chunk_id"] = f"{base_chunk_id}-s{i:02d}"
 

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -71,11 +71,23 @@ def build_chunks_dict_from_chunking_result(
                 f"{doc_id}:{order}:{chunk_content}",
                 prefix="chunk-",
             )
+        # Preserve any pre-populated cache ids on dp (multimodal chunks
+        # arrive with analysis cache ids already attached so document
+        # deletion can find them via the per-chunk llm_cache_list).
+        existing_cache_list = dp.get("llm_cache_list")
+        seed_cache_list: list[str] = []
+        if isinstance(existing_cache_list, list):
+            seen: set[str] = set()
+            for entry in existing_cache_list:
+                key = str(entry or "").strip()
+                if key and key not in seen:
+                    seen.add(key)
+                    seed_cache_list.append(key)
         chunks[chunk_key] = {
             **dp,
             "full_doc_id": doc_id,
             "file_path": file_path,
-            "llm_cache_list": [],
+            "llm_cache_list": seed_cache_list,
         }
     return chunks
 

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -588,82 +588,9 @@ def normalize_parser_result_to_content_list(
         return None
 
 
-# ---------------------------------------------------------------------------
-# Multimodal entity augmentation
-# ---------------------------------------------------------------------------
-
-
-def augment_chunk_results_with_mm_entities(
-    chunk_results: list,
-    mm_specs: list[dict[str, Any]],
-    file_path: str,
-) -> list:
-    """Inject modality object entities and relations into merge inputs."""
-    if not mm_specs:
-        return chunk_results
-
-    extracted_by_chunk: dict[str, set[str]] = {}
-    for maybe_nodes, _ in chunk_results:
-        if not isinstance(maybe_nodes, dict):
-            continue
-        for entity_name, entity_records in maybe_nodes.items():
-            if not isinstance(entity_records, list):
-                continue
-            for rec in entity_records:
-                if not isinstance(rec, dict):
-                    continue
-                source_id = str(rec.get("source_id") or "")
-                if not source_id:
-                    continue
-                extracted_by_chunk.setdefault(source_id, set()).add(str(entity_name))
-
-    now_ts = int(time.time())
-    mm_nodes: dict[str, list[dict[str, Any]]] = {}
-    mm_edges: dict[tuple[str, str], list[dict[str, Any]]] = {}
-    for spec in mm_specs:
-        src = str(spec["entity_name"])
-        chunk_id = str(spec["chunk_id"])
-        kind = str(spec["kind"])
-        title = str(spec.get("name") or src)
-        caption_text = str(spec.get("caption_text") or "").strip()
-        heading = str(spec.get("heading") or "").strip()
-        summary = str(spec.get("summary") or "").strip()
-
-        mm_nodes.setdefault(src, []).append(
-            {
-                "entity_name": src,
-                "entity_type": kind,
-                "description": summary or f"{kind} object: {title}",
-                "source_id": chunk_id,
-                "file_path": file_path,
-                "timestamp": now_ts,
-            }
-        )
-
-        targets = extracted_by_chunk.get(chunk_id, set())
-        for tgt in sorted(targets):
-            if tgt == src:
-                continue
-            desc = (
-                f"Entity `{tgt}` is associated with {kind} `{title}` "
-                f"in section `{heading or 'unknown'}`."
-            )
-            if caption_text:
-                desc += f" Captions: {caption_text}."
-            edge_key = tuple(sorted((src, tgt)))
-            mm_edges.setdefault(edge_key, []).append(
-                {
-                    "src_id": src,
-                    "tgt_id": tgt,
-                    "weight": 1.0,
-                    "description": desc,
-                    "keywords": "belongs to,part of,contained in",
-                    "source_id": chunk_id,
-                    "file_path": file_path,
-                    "timestamp": now_ts,
-                }
-            )
-
-    if mm_nodes or mm_edges:
-        chunk_results = list(chunk_results) + [(mm_nodes, mm_edges)]
-    return chunk_results
+# Multimodal entity injection used to live here as a centralized post-pass
+# over all chunk_results. It has been moved into
+# :func:`lightrag.operate.extract_entities._process_single_content` so each
+# multimodal chunk injects its own entity/relation records while still under
+# its concurrency slot.  The chunk's ``sidecar.type`` (drawing/table/equation)
+# is the dispatch key; see operate.py for the new logic.

--- a/tests/test_paragraph_semantic_split_long_block.py
+++ b/tests/test_paragraph_semantic_split_long_block.py
@@ -258,10 +258,7 @@ def test_public_chunking_adds_part_suffixes_for_anchor_split(tmp_path):
         "Mid anchor. [part 2]",
     ]
     assert all(
-        all(
-            "[part " not in parent
-            for parent in chunk["heading"]["parent_headings"]
-        )
+        all("[part " not in parent for parent in chunk["heading"]["parent_headings"])
         for chunk in chunks
     )
 

--- a/tests/test_paragraph_semantic_split_long_block.py
+++ b/tests/test_paragraph_semantic_split_long_block.py
@@ -225,7 +225,7 @@ def test_public_chunking_keeps_unsplit_heading_without_part_suffix(tmp_path):
     )
 
     assert len(chunks) == 1
-    assert chunks[0]["heading"] == "Heading"
+    assert chunks[0]["heading"]["heading"] == "Heading"
 
 
 @pytest.mark.offline
@@ -253,12 +253,15 @@ def test_public_chunking_adds_part_suffixes_for_anchor_split(tmp_path):
         chunk_overlap_token_size=0,
     )
 
-    assert [chunk["heading"] for chunk in chunks] == [
+    assert [chunk["heading"]["heading"] for chunk in chunks] == [
         "Heading [part 1]",
         "Mid anchor. [part 2]",
     ]
     assert all(
-        all("[part " not in parent for parent in chunk["parent_headings"])
+        all(
+            "[part " not in parent
+            for parent in chunk["heading"]["parent_headings"]
+        )
         for chunk in chunks
     )
 
@@ -316,7 +319,7 @@ def test_public_chunking_adds_part_suffixes_for_long_text_fallback(
         chunk_overlap_token_size=0,
     )
 
-    assert [chunk["heading"] for chunk in chunks] == [
+    assert [chunk["heading"]["heading"] for chunk in chunks] == [
         "Heading [part 1]",
         "Heading [part 2]",
         "Heading [part 3]",

--- a/tests/test_paragraph_semantic_table_split.py
+++ b/tests/test_paragraph_semantic_table_split.py
@@ -306,10 +306,10 @@ def test_public_chunking_adds_part_suffixes_to_all_table_split_fragments(tmp_pat
     )
 
     assert len(chunks) > 1
-    assert [chunk["heading"] for chunk in chunks] == [
+    assert [chunk["heading"]["heading"] for chunk in chunks] == [
         f"Section [part {idx}]" for idx in range(1, len(chunks) + 1)
     ]
-    assert all("表格片段" not in chunk["heading"] for chunk in chunks)
+    assert all("表格片段" not in chunk["heading"]["heading"] for chunk in chunks)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline_analyze_multimodal.py
+++ b/tests/test_pipeline_analyze_multimodal.py
@@ -1,28 +1,39 @@
-"""End-to-end offline tests for the VLM analyze_multimodal pipeline.
+"""End-to-end offline tests for the analyze_multimodal pipeline.
 
-Covers the three behaviours unique to the unified image_inputs rewrite:
+Covers the contract introduced by the LR2 multimodal rewrite:
 
-1. ``VLM_PROCESS_ENABLE=False`` short-circuits every multimodal item with a
-   warning and never invokes the VLM mock.
-2. ``VLM_PROCESS_ENABLE=True`` writes a ``default:analysis:*`` cache entry on
-   the first call and serves the second call from cache without calling the
-   VLM mock again.
-3. The cache entry's ``original_prompt`` carries the ``<vlm_images>`` audit
-   block but never embeds the raw base64 payload.
+1. Drawings route to the VLM role; tables/equations route to the EXTRACT
+   role. ``VLM_PROCESS_ENABLE=False`` (or a missing VLM role) is a hard
+   failure for image-enabled documents.
+2. ``llm_analyze_result`` uses the new ``status / message / analyze_time``
+   shape with modality-specific required fields
+   (``name/type/description`` for images, ``name/description`` for tables,
+   ``name/equation/description`` for equations).
+3. Each VLM/EXTRACT call carries ``_priority=DEFAULT_MM_ANALYSIS_PRIORITY``
+   and ``image_inputs`` (not legacy ``messages``).
+4. Analysis cache ids are written back to the sidecar item's
+   ``llm_cache_list`` so document deletion can clean them up.
+5. Images smaller than ``VLM_MIN_IMAGE_PIXEL`` (32 px) and unsupported
+   formats are pre-emptively flagged ``status="skipped"`` without an LLM
+   call.
+6. Invalid model JSON is a hard failure — the sidecar carries
+   ``status="failure"`` and :class:`MultimodalAnalysisError` propagates.
 """
 
 from __future__ import annotations
 
-import asyncio
 import base64
 import json
 import logging
+import struct
+import zlib
 from pathlib import Path
 
 import numpy as np
 import pytest
 
 from lightrag import LightRAG, ROLES, RoleLLMConfig
+from lightrag.exceptions import MultimodalAnalysisError
 from lightrag.utils import EmbeddingFunc, Tokenizer
 
 
@@ -34,12 +45,24 @@ def _propagate_lightrag_logger(monkeypatch):
 pytestmark = pytest.mark.offline
 
 
-PNG_BYTES = (
-    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
-    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc\xf8"
-    b"\xcf\xc0\x00\x00\x00\x03\x00\x01\x5c\xcc\xd9\x9e\x00\x00\x00\x00"
-    b"IEND\xaeB`\x82"
-)
+def _png_bytes(width: int, height: int) -> bytes:
+    """Build a minimal but parser-accepted PNG with the given dimensions."""
+    signature = b"\x89PNG\r\n\x1a\n"
+    ihdr_payload = struct.pack(">II", width, height) + b"\x08\x06\x00\x00\x00"
+    ihdr_crc = zlib.crc32(b"IHDR" + ihdr_payload).to_bytes(4, "big")
+    ihdr = struct.pack(">I", len(ihdr_payload)) + b"IHDR" + ihdr_payload + ihdr_crc
+    idat_raw = b"\x00" * (width * height * 4 + height)
+    idat_compressed = zlib.compress(idat_raw)
+    idat_crc = zlib.crc32(b"IDAT" + idat_compressed).to_bytes(4, "big")
+    idat = (
+        struct.pack(">I", len(idat_compressed)) + b"IDAT" + idat_compressed + idat_crc
+    )
+    iend = b"\x00\x00\x00\x00IEND\xaeB`\x82"
+    return signature + ihdr + idat + iend
+
+
+PNG_BYTES = _png_bytes(64, 64)
+TINY_PNG_BYTES = _png_bytes(8, 8)
 
 
 class _SimpleTokenizerImpl:
@@ -60,27 +83,47 @@ def _make_vlm_mock(call_log: list[dict]):
         return json.dumps(
             {
                 "name": "fig-1",
-                "summary": "short summary",
-                "detail_description": "detail",
-                "grounded": True,
-                "grounding_reason": "visual_evidence",
+                "type": "Chart",
+                "description": "concise figure description",
             }
         )
 
     return vlm_func
 
 
-def _build_rag(tmp_path: Path, *, vlm_process_enable: bool, vlm_func) -> LightRAG:
-    role_configs = {
-        spec.name: RoleLLMConfig(func=vlm_func)
-        if spec.name == "vlm"
-        else RoleLLMConfig()
-        for spec in ROLES
-    }
+def _make_extract_mock(call_log: list[dict]):
+    async def extract_func(prompt, **kwargs):
+        call_log.append({"prompt": prompt, "kwargs": dict(kwargs)})
+        return json.dumps(
+            {
+                "name": "tbl-1",
+                "description": "table summary",
+            }
+        )
+
+    return extract_func
+
+
+def _build_rag(
+    tmp_path: Path,
+    *,
+    vlm_process_enable: bool = True,
+    vlm_func=None,
+    extract_func=None,
+) -> LightRAG:
+    role_configs = {}
+    for spec in ROLES:
+        if spec.name == "vlm" and vlm_func is not None:
+            role_configs[spec.name] = RoleLLMConfig(func=vlm_func)
+        elif spec.name == "extract" and extract_func is not None:
+            role_configs[spec.name] = RoleLLMConfig(func=extract_func)
+        else:
+            role_configs[spec.name] = RoleLLMConfig()
+    base_func = vlm_func or extract_func
     return LightRAG(
         working_dir=str(tmp_path),
         workspace=f"vlm-pipeline-{tmp_path.name}",
-        llm_model_func=vlm_func,
+        llm_model_func=base_func,
         embedding_func=EmbeddingFunc(
             embedding_dim=8,
             max_token_size=1024,
@@ -125,11 +168,11 @@ def _write_sidecar_fixtures(tmp_path: Path) -> tuple[str, dict, Path]:
 
 
 @pytest.mark.asyncio
-async def test_vlm_process_enable_false_skips_with_warning(
+async def test_vlm_process_enable_false_hard_fails_for_images(
     tmp_path, caplog, _propagate_lightrag_logger
 ):
-    """Disabled-VLM items must NOT be persisted: otherwise the idempotency
-    guard would lock the item out forever once the operator enables VLM."""
+    """With i opted-in but VLM disabled, analyze_multimodal must hard-fail
+    the document rather than silently skipping."""
     call_log: list[dict] = []
     rag = _build_rag(
         tmp_path, vlm_process_enable=False, vlm_func=_make_vlm_mock(call_log)
@@ -137,31 +180,28 @@ async def test_vlm_process_enable_false_skips_with_warning(
     await rag.initialize_storages()
     try:
         doc_id, parsed_data, sidecar_path = _write_sidecar_fixtures(tmp_path)
-        with caplog.at_level("WARNING"):
+        with pytest.raises(MultimodalAnalysisError):
             await rag.analyze_multimodal(
                 doc_id=doc_id,
                 file_path="fixture.pdf",
                 parsed_data=parsed_data,
                 process_options="i",
             )
-
         # VLM mock must not be invoked when the master switch is off.
         assert call_log == []
-        assert any("VLM_PROCESS_ENABLE=false" in rec.message for rec in caplog.records)
-
-        # No llm_analyze_result is persisted — re-running after enabling VLM
-        # must be able to re-process this item.
         payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
         item = payload["drawings"]["dr-001"]
-        assert "llm_analyze_result" not in item
+        assert item["llm_analyze_result"]["status"] == "failure"
+        assert "VLM" in item["llm_analyze_result"]["message"]
     finally:
         await rag.finalize_storages()
 
 
 @pytest.mark.asyncio
 async def test_vlm_disabled_then_enabled_reprocesses_item(tmp_path):
-    """Re-running analyze_multimodal after flipping VLM_PROCESS_ENABLE from
-    false to true must actually call the VLM and persist a real result."""
+    """After the first run hard-failed under VLM=disabled, flipping the
+    switch and clearing the failure marker must re-invoke the VLM and
+    persist a success result."""
     call_log: list[dict] = []
     vlm_func = _make_vlm_mock(call_log)
 
@@ -169,17 +209,24 @@ async def test_vlm_disabled_then_enabled_reprocesses_item(tmp_path):
     await rag_off.initialize_storages()
     try:
         doc_id, parsed_data, sidecar_path = _write_sidecar_fixtures(tmp_path)
-        await rag_off.analyze_multimodal(
-            doc_id=doc_id,
-            file_path="fixture.pdf",
-            parsed_data=parsed_data,
-            process_options="i",
-        )
+        with pytest.raises(MultimodalAnalysisError):
+            await rag_off.analyze_multimodal(
+                doc_id=doc_id,
+                file_path="fixture.pdf",
+                parsed_data=parsed_data,
+                process_options="i",
+            )
         assert call_log == []
     finally:
         await rag_off.finalize_storages()
 
-    # Flip the master switch; reuse the same on-disk workspace.
+    # Operator clears the failure marker before the second run.
+    payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
+    payload["drawings"]["dr-001"].pop("llm_analyze_result", None)
+    sidecar_path.write_text(
+        json.dumps(payload, ensure_ascii=False), encoding="utf-8"
+    )
+
     rag_on = _build_rag(tmp_path, vlm_process_enable=True, vlm_func=vlm_func)
     await rag_on.initialize_storages()
     try:
@@ -192,9 +239,43 @@ async def test_vlm_disabled_then_enabled_reprocesses_item(tmp_path):
         assert len(call_log) == 1
         payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
         result = payload["drawings"]["dr-001"]["llm_analyze_result"]
-        assert result["grounded"] is True
+        assert result["status"] == "success"
+        assert result["type"] == "Chart"
+        assert result["description"] == "concise figure description"
+        assert "analyze_time" in result
     finally:
         await rag_on.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_vlm_call_carries_image_inputs(tmp_path):
+    """Sanity check the call kwargs: image_inputs (not legacy `messages`)
+    must be present.  The ``_priority`` argument is consumed by the role
+    wrapper before reaching the raw model func, so it is not observable on
+    the mock — see ``priority_limit_async_func_call`` in lightrag.utils."""
+    call_log: list[dict] = []
+    rag = _build_rag(
+        tmp_path, vlm_process_enable=True, vlm_func=_make_vlm_mock(call_log)
+    )
+    await rag.initialize_storages()
+    try:
+        doc_id, parsed_data, _ = _write_sidecar_fixtures(tmp_path)
+        await rag.analyze_multimodal(
+            doc_id=doc_id,
+            file_path="fixture.pdf",
+            parsed_data=parsed_data,
+            process_options="i",
+        )
+        assert len(call_log) == 1
+        kwargs = call_log[0]["kwargs"]
+        assert kwargs.get("stream") is False
+        assert kwargs.get("image_inputs") is not None
+        assert "messages" not in kwargs
+        # _priority is consumed by the wrapper (see lightrag.utils
+        # priority_limit_async_func_call); not observable on the raw mock.
+        assert "_priority" not in kwargs
+    finally:
+        await rag.finalize_storages()
 
 
 @pytest.mark.asyncio
@@ -207,7 +288,6 @@ async def test_vlm_cache_hit_on_second_run(tmp_path):
     try:
         doc_id, parsed_data, sidecar_path = _write_sidecar_fixtures(tmp_path)
 
-        # First run: should invoke VLM and persist a cache entry.
         await rag.analyze_multimodal(
             doc_id=doc_id,
             file_path="fixture.pdf",
@@ -215,13 +295,6 @@ async def test_vlm_cache_hit_on_second_run(tmp_path):
             process_options="i",
         )
         assert len(call_log) == 1
-        first_call_kwargs = call_log[0]["kwargs"]
-        assert first_call_kwargs.get("stream") is False
-        # The pipeline must pass image_inputs (not the legacy `messages`).
-        assert first_call_kwargs.get("image_inputs") is not None
-        assert "messages" not in first_call_kwargs
-
-        # Cache entry exists under default:analysis:*
         await rag.llm_response_cache.index_done_callback()
         cache_file = (
             Path(rag.working_dir) / rag.workspace / "kv_store_llm_response_cache.json"
@@ -231,16 +304,20 @@ async def test_vlm_cache_hit_on_second_run(tmp_path):
             k for k in cache_blob.keys() if k.startswith("default:analysis:")
         ]
         assert len(analysis_keys) == 1
-        entry = cache_blob[analysis_keys[0]]
+        cache_id = analysis_keys[0]
+        entry = cache_blob[cache_id]
         original_prompt = entry["original_prompt"]
         assert "<vlm_images>" in original_prompt
         # Raw base64 must NOT be embedded in the audit block.
         raw_b64 = base64.b64encode(PNG_BYTES).decode("ascii")
         assert raw_b64 not in original_prompt
 
-        # Second run with idempotency-tracked sidecar removed: hit cache.
-        await asyncio.sleep(0)
+        # Cache id was written back to the sidecar item for delete-time cleanup.
         payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        assert cache_id in payload["drawings"]["dr-001"]["llm_cache_list"]
+
+        # Clear the analysis result and re-run: should hit the cache and not
+        # call the VLM again.
         payload["drawings"]["dr-001"].pop("llm_analyze_result", None)
         sidecar_path.write_text(
             json.dumps(payload, ensure_ascii=False), encoding="utf-8"
@@ -252,7 +329,6 @@ async def test_vlm_cache_hit_on_second_run(tmp_path):
             parsed_data=parsed_data,
             process_options="i",
         )
-        # VLM mock must not be invoked again — cache hit.
         assert len(call_log) == 1
     finally:
         await rag.finalize_storages()
@@ -260,10 +336,8 @@ async def test_vlm_cache_hit_on_second_run(tmp_path):
 
 @pytest.mark.asyncio
 async def test_image_path_resolved_relative_to_sidecar_dir(tmp_path):
-    """The native docx parser writes sidecar paths relative to parsed_dir
-    (see commit d8efbf7f). The pipeline must resolve them against the
-    sidecar's own directory before considering them missing.
-    """
+    """Sidecar paths are parsed_dir-relative; the pipeline must resolve
+    them against the sidecar directory before falling back to skipped."""
     call_log: list[dict] = []
     rag = _build_rag(
         tmp_path, vlm_process_enable=True, vlm_func=_make_vlm_mock(call_log)
@@ -273,7 +347,6 @@ async def test_image_path_resolved_relative_to_sidecar_dir(tmp_path):
         parsed_dir = tmp_path / "parsed"
         parsed_dir.mkdir()
 
-        # Image lives inside the parsed_dir under a relative subfolder.
         assets_dir = parsed_dir / "doc.blocks.assets"
         assets_dir.mkdir()
         (assets_dir / "image1.png").write_bytes(PNG_BYTES)
@@ -290,7 +363,6 @@ async def test_image_path_resolved_relative_to_sidecar_dir(tmp_path):
                     "drawings": {
                         "dr-001": {
                             "caption": "Figure 1",
-                            # Parsed_dir-relative path, not absolute.
                             "path": "doc.blocks.assets/image1.png",
                         }
                     }
@@ -306,28 +378,20 @@ async def test_image_path_resolved_relative_to_sidecar_dir(tmp_path):
             process_options="i",
         )
 
-        # The VLM was invoked with image_inputs (path resolved successfully)
-        # — not short-circuited to missing_image.
         assert len(call_log) == 1
         assert call_log[0]["kwargs"].get("image_inputs") is not None
 
         payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
         result = payload["drawings"]["dr-001"]["llm_analyze_result"]
-        # Grounded result, not the conservative missing_image fallback.
-        assert result["grounded"] is True
-        assert result["grounding_reason"] != "missing_image"
+        assert result["status"] == "success"
     finally:
         await rag.finalize_storages()
 
 
 @pytest.mark.asyncio
-async def test_unsupported_vector_format_falls_back_with_warning(
-    tmp_path, caplog, _propagate_lightrag_logger
-):
-    """WMF/EMF/SVG cannot be sent to vision providers; the pipeline must
-    skip the image with a warning rather than trying to base64-encode and
-    failing mid-call.
-    """
+async def test_unsupported_vector_format_writes_skipped(tmp_path):
+    """WMF/EMF/SVG and other non-raster formats short-circuit to
+    status=skipped without calling the VLM."""
     call_log: list[dict] = []
     rag = _build_rag(
         tmp_path, vlm_process_enable=True, vlm_func=_make_vlm_mock(call_log)
@@ -361,68 +425,95 @@ async def test_unsupported_vector_format_falls_back_with_warning(
             encoding="utf-8",
         )
 
-        with caplog.at_level("WARNING"):
-            await rag.analyze_multimodal(
-                doc_id="doc-1",
-                file_path="fixture.docx",
-                parsed_data={"blocks_path": str(blocks_path)},
-                process_options="i",
-            )
+        await rag.analyze_multimodal(
+            doc_id="doc-1",
+            file_path="fixture.docx",
+            parsed_data={"blocks_path": str(blocks_path)},
+            process_options="i",
+        )
 
-        # Warning emitted, VLM still called (no visual evidence, no textual
-        # evidence for drawings) — and result lands in conservative branch.
-        assert any("unsupported image format" in rec.message for rec in caplog.records)
+        assert call_log == []
         payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
         result = payload["drawings"]["dr-001"]["llm_analyze_result"]
-        assert result["grounded"] is False
-        assert result["grounding_reason"] == "missing_image"
+        assert result["status"] == "skipped"
+        assert "unsupported image format" in result["message"]
     finally:
         await rag.finalize_storages()
 
 
-def _make_invalid_then_valid_vlm(call_log: list[dict]):
-    """Returns garbage on the first call, valid JSON on the second."""
-
-    async def vlm_func(prompt, **kwargs):
-        call_log.append({"prompt": prompt, "kwargs": dict(kwargs)})
-        if len(call_log) == 1:
-            return "this is not JSON at all"
-        return json.dumps(
-            {
-                "name": "fig-1",
-                "summary": "recovered",
-                "detail_description": "recovered detail",
-                "grounded": True,
-                "grounding_reason": "visual_evidence",
-            }
-        )
-
-    return vlm_func
-
-
 @pytest.mark.asyncio
-async def test_invalid_vlm_response_is_not_cached(tmp_path):
-    """Invalid VLM responses must NOT poison the analysis cache; the next
-    run for the same prompt+image must re-invoke the VLM."""
+async def test_tiny_image_writes_skipped_without_vlm_call(tmp_path):
+    """Image smaller than VLM_MIN_IMAGE_PIXEL (32px) is decorative; skip
+    without calling VLM."""
     call_log: list[dict] = []
     rag = _build_rag(
-        tmp_path,
-        vlm_process_enable=True,
-        vlm_func=_make_invalid_then_valid_vlm(call_log),
+        tmp_path, vlm_process_enable=True, vlm_func=_make_vlm_mock(call_log)
     )
     await rag.initialize_storages()
     try:
-        doc_id, parsed_data, sidecar_path = _write_sidecar_fixtures(tmp_path)
+        parsed_dir = tmp_path / "parsed"
+        parsed_dir.mkdir()
+        img_path = parsed_dir / "tiny.png"
+        img_path.write_bytes(TINY_PNG_BYTES)
 
-        # First run: VLM returns garbage -> conservative writeback, NO cache.
+        blocks_path = parsed_dir / "doc.blocks.jsonl"
+        blocks_path.write_text(
+            json.dumps({"type": "meta", "doc_id": "doc-1"}) + "\n",
+            encoding="utf-8",
+        )
+        sidecar_path = parsed_dir / "doc.drawings.json"
+        sidecar_path.write_text(
+            json.dumps(
+                {
+                    "drawings": {
+                        "dr-001": {
+                            "caption": "tiny icon",
+                            "path": str(img_path),
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
         await rag.analyze_multimodal(
-            doc_id=doc_id,
+            doc_id="doc-1",
             file_path="fixture.pdf",
-            parsed_data=parsed_data,
+            parsed_data={"blocks_path": str(blocks_path)},
             process_options="i",
         )
-        assert len(call_log) == 1
+        assert call_log == []
+        payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        result = payload["drawings"]["dr-001"]["llm_analyze_result"]
+        assert result["status"] == "skipped"
+        assert "smaller than" in result["message"]
+    finally:
+        await rag.finalize_storages()
 
+
+@pytest.mark.asyncio
+async def test_invalid_vlm_response_hard_fails(tmp_path):
+    """Invalid model JSON propagates MultimodalAnalysisError and lands a
+    status=failure marker on the sidecar so re-runs don't silently
+    consume the failure."""
+    call_log: list[dict] = []
+
+    async def vlm_func(prompt, **kwargs):
+        call_log.append({"prompt": prompt, "kwargs": dict(kwargs)})
+        return "not-json"
+
+    rag = _build_rag(tmp_path, vlm_process_enable=True, vlm_func=vlm_func)
+    await rag.initialize_storages()
+    try:
+        doc_id, parsed_data, sidecar_path = _write_sidecar_fixtures(tmp_path)
+        with pytest.raises(MultimodalAnalysisError):
+            await rag.analyze_multimodal(
+                doc_id=doc_id,
+                file_path="fixture.pdf",
+                parsed_data=parsed_data,
+                process_options="i",
+            )
+        assert len(call_log) == 1
         await rag.llm_response_cache.index_done_callback()
         cache_file = (
             Path(rag.working_dir) / rag.workspace / "kv_store_llm_response_cache.json"
@@ -435,25 +526,62 @@ async def test_invalid_vlm_response_is_not_cached(tmp_path):
             assert (
                 analysis_keys == []
             ), f"invalid VLM response was cached: {analysis_keys}"
-
-        # Clear the conservative writeback so idempotency does not skip us,
-        # then re-run. The VLM must be invoked a second time (no cache hit).
         payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
-        payload["drawings"]["dr-001"].pop("llm_analyze_result", None)
-        sidecar_path.write_text(
-            json.dumps(payload, ensure_ascii=False), encoding="utf-8"
+        item = payload["drawings"]["dr-001"]
+        assert item["llm_analyze_result"]["status"] == "failure"
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_table_routes_to_extract_role_not_vlm(tmp_path):
+    """Per design §3.1 tables (and equations) must hit the EXTRACT role,
+    not VLM. The mocks below assert exactly that."""
+    extract_log: list[dict] = []
+    vlm_log: list[dict] = []
+    rag = _build_rag(
+        tmp_path,
+        vlm_process_enable=True,
+        vlm_func=_make_vlm_mock(vlm_log),
+        extract_func=_make_extract_mock(extract_log),
+    )
+    await rag.initialize_storages()
+    try:
+        parsed_dir = tmp_path / "parsed"
+        parsed_dir.mkdir()
+        blocks_path = parsed_dir / "doc.blocks.jsonl"
+        blocks_path.write_text(
+            json.dumps({"type": "meta", "doc_id": "doc-1"}) + "\n",
+            encoding="utf-8",
+        )
+        tables_path = parsed_dir / "doc.tables.json"
+        tables_path.write_text(
+            json.dumps(
+                {
+                    "tables": {
+                        "tb-001": {
+                            "caption": "Table 1",
+                            "content": "<table><tr><td>A</td></tr></table>",
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
         )
 
         await rag.analyze_multimodal(
-            doc_id=doc_id,
+            doc_id="doc-1",
             file_path="fixture.pdf",
-            parsed_data=parsed_data,
-            process_options="i",
+            parsed_data={"blocks_path": str(blocks_path)},
+            process_options="t",
         )
-        assert len(call_log) == 2
-        payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
-        result = payload["drawings"]["dr-001"]["llm_analyze_result"]
-        assert result["grounded"] is True
-        assert result["summary"] == "recovered"
+        assert vlm_log == []
+        assert len(extract_log) == 1
+        kwargs = extract_log[0]["kwargs"]
+        assert kwargs.get("response_format") == {"type": "json_object"}
+        payload = json.loads(tables_path.read_text(encoding="utf-8"))
+        result = payload["tables"]["tb-001"]["llm_analyze_result"]
+        assert result["status"] == "success"
+        assert "default:analysis:" in payload["tables"]["tb-001"]["llm_cache_list"][0]
     finally:
         await rag.finalize_storages()

--- a/tests/test_pipeline_analyze_multimodal.py
+++ b/tests/test_pipeline_analyze_multimodal.py
@@ -223,9 +223,7 @@ async def test_vlm_disabled_then_enabled_reprocesses_item(tmp_path):
     # Operator clears the failure marker before the second run.
     payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
     payload["drawings"]["dr-001"].pop("llm_analyze_result", None)
-    sidecar_path.write_text(
-        json.dumps(payload, ensure_ascii=False), encoding="utf-8"
-    )
+    sidecar_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
 
     rag_on = _build_rag(tmp_path, vlm_process_enable=True, vlm_func=vlm_func)
     await rag_on.initialize_storages()

--- a/tests/test_pipeline_analyze_multimodal.py
+++ b/tests/test_pipeline_analyze_multimodal.py
@@ -583,3 +583,116 @@ async def test_table_routes_to_extract_role_not_vlm(tmp_path):
         assert "default:analysis:" in payload["tables"]["tb-001"]["llm_cache_list"][0]
     finally:
         await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_with_trailing_comma_is_repaired(tmp_path):
+    """Slightly malformed VLM JSON (trailing comma) must be repaired via
+    ``json_repair`` instead of hard-failing the document — mirrors the
+    extraction-side repair contract in operate._process_json_extraction_result.
+    """
+    call_log: list[dict] = []
+
+    async def vlm_func(prompt, **kwargs):
+        call_log.append({"prompt": prompt, "kwargs": dict(kwargs)})
+        # Trailing comma after "description" — strict json.loads would reject.
+        return (
+            '{"name": "fig-1", "type": "Chart", '
+            '"description": "ok",}'
+        )
+
+    rag = _build_rag(tmp_path, vlm_process_enable=True, vlm_func=vlm_func)
+    await rag.initialize_storages()
+    try:
+        doc_id, parsed_data, sidecar_path = _write_sidecar_fixtures(tmp_path)
+        await rag.analyze_multimodal(
+            doc_id=doc_id,
+            file_path="fixture.pdf",
+            parsed_data=parsed_data,
+            process_options="i",
+        )
+        assert len(call_log) == 1
+        payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        result = payload["drawings"]["dr-001"]["llm_analyze_result"]
+        assert result["status"] == "success"
+        assert result["name"] == "fig-1"
+        assert result["type"] == "Chart"
+        assert result["description"] == "ok"
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_analyze_worker_marks_doc_failed_on_multimodal_error(tmp_path):
+    """When analyze_multimodal raises MultimodalAnalysisError, the worker
+    must upsert DocStatus.FAILED with a diagnostic error_msg instead of
+    letting the document stay stuck in ANALYZING."""
+    import asyncio
+    from dataclasses import asdict
+    from lightrag.base import DocProcessingStatus, DocStatus
+    from lightrag.pipeline import _BatchRunContext
+
+    async def vlm_func(prompt, **kwargs):
+        return ""
+
+    rag = _build_rag(tmp_path, vlm_process_enable=True, vlm_func=vlm_func)
+    await rag.initialize_storages()
+    try:
+        doc_id = "doc-fail-1"
+        file_path = "demo.pdf"
+        status_doc = DocProcessingStatus(
+            content_summary="",
+            content_length=0,
+            file_path=file_path,
+            status=DocStatus.PENDING,
+            created_at="2026-05-14T00:00:00Z",
+            updated_at="2026-05-14T00:00:00Z",
+            track_id="t",
+            content_hash="h",
+        )
+        await rag.doc_status.upsert({doc_id: asdict(status_doc)})
+
+        async def _raise_mm_error(**_kwargs):
+            from lightrag.exceptions import MultimodalAnalysisError
+
+            raise MultimodalAnalysisError("forced failure for test")
+
+        # Patch instance method so the worker's call site picks the mock.
+        rag.analyze_multimodal = _raise_mm_error  # type: ignore[assignment]
+
+        ctx = _BatchRunContext(
+            pipeline_status={
+                "latest_message": "",
+                "history_messages": [],
+                "cancellation_requested": False,
+            },
+            pipeline_status_lock=asyncio.Lock(),
+            semaphore=asyncio.Semaphore(1),
+            total_files=1,
+            q_native=asyncio.Queue(),
+            q_mineru=asyncio.Queue(),
+            q_docling=asyncio.Queue(),
+            q_analyze=asyncio.Queue(),
+            q_process=asyncio.Queue(),
+        )
+        worker = asyncio.create_task(rag._analyze_worker(ctx))
+        await ctx.q_analyze.put((doc_id, status_doc, {"content": "body"}))
+        await ctx.q_analyze.join()
+        worker.cancel()
+        try:
+            await worker
+        except asyncio.CancelledError:
+            pass
+
+        refreshed = await rag.doc_status.get_by_id(doc_id)
+        # doc_status backends return either a dict or a dataclass-style obj.
+        if not isinstance(refreshed, dict):
+            refreshed = asdict(refreshed)
+        assert refreshed["status"] == DocStatus.FAILED
+        assert "forced failure for test" in (refreshed.get("error_msg") or "")
+        # The worker must NOT advance to q_process when the analyze step
+        # raises — otherwise process_single_document would run on a
+        # half-baked document.
+        assert ctx.q_process.empty()
+    finally:
+        await rag.finalize_storages()

--- a/tests/test_pipeline_analyze_multimodal.py
+++ b/tests/test_pipeline_analyze_multimodal.py
@@ -596,10 +596,7 @@ async def test_invalid_json_with_trailing_comma_is_repaired(tmp_path):
     async def vlm_func(prompt, **kwargs):
         call_log.append({"prompt": prompt, "kwargs": dict(kwargs)})
         # Trailing comma after "description" — strict json.loads would reject.
-        return (
-            '{"name": "fig-1", "type": "Chart", '
-            '"description": "ok",}'
-        )
+        return '{"name": "fig-1", "type": "Chart", ' '"description": "ok",}'
 
     rag = _build_rag(tmp_path, vlm_process_enable=True, vlm_func=vlm_func)
     await rag.initialize_storages()

--- a/tests/test_pipeline_analyze_multimodal.py
+++ b/tests/test_pipeline_analyze_multimodal.py
@@ -696,3 +696,60 @@ async def test_analyze_worker_marks_doc_failed_on_multimodal_error(tmp_path):
         assert ctx.q_process.empty()
     finally:
         await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_analysis_cache_respects_disabled_flag(tmp_path):
+    """When enable_llm_cache_for_entity_extract is False, analyze_multimodal
+    must NOT persist the analysis response and MUST NOT attach a cache id
+    to sidecar item.llm_cache_list — otherwise document deletion would try
+    to clean up cache entries that were never written."""
+    call_log: list[dict] = []
+    rag = LightRAG(
+        working_dir=str(tmp_path),
+        workspace=f"vlm-pipeline-cache-{tmp_path.name}",
+        llm_model_func=_make_vlm_mock(call_log),
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8,
+            max_token_size=1024,
+            func=_mock_embedding,
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        vlm_process_enable=True,
+        # Disable the analysis cache (same flag handle_cache uses for mode="default").
+        enable_llm_cache_for_entity_extract=False,
+        role_llm_configs={
+            spec.name: (
+                RoleLLMConfig(func=_make_vlm_mock(call_log))
+                if spec.name == "vlm"
+                else RoleLLMConfig()
+            )
+            for spec in ROLES
+        },
+    )
+    await rag.initialize_storages()
+    try:
+        doc_id, parsed_data, sidecar_path = _write_sidecar_fixtures(tmp_path)
+        await rag.analyze_multimodal(
+            doc_id=doc_id,
+            file_path="fixture.pdf",
+            parsed_data=parsed_data,
+            process_options="i",
+        )
+        await rag.llm_response_cache.index_done_callback()
+        cache_file = (
+            Path(rag.working_dir) / rag.workspace / "kv_store_llm_response_cache.json"
+        )
+        if cache_file.exists():
+            cache_blob = json.loads(cache_file.read_text(encoding="utf-8"))
+            assert not any(
+                k.startswith("default:analysis:") for k in cache_blob.keys()
+            ), "analysis cache must not be written when the flag is off"
+        payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        item = payload["drawings"]["dr-001"]
+        # Analysis still succeeded — only the cache side-effects are gated.
+        assert item["llm_analyze_result"]["status"] == "success"
+        # No cache id may be attached when nothing was written.
+        assert item.get("llm_cache_list", []) == []
+    finally:
+        await rag.finalize_storages()

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -2850,3 +2850,26 @@ def test_build_mm_chunks_respects_process_options_filter(tmp_path):
         await rag.finalize_storages()
 
     asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_strip_internal_multimodal_markup_cleans_table_id():
+    """Regression: parser-emitted ``<table id="tb-...">`` tags must have
+    their internal id stripped before the entity-extraction prompt sees
+    them. ``format`` / ``caption`` and the row body stay verbatim so the
+    extractor still recognizes the structured element."""
+    from lightrag.chunk_schema import (
+        strip_internal_multimodal_markup_for_extraction,
+    )
+
+    source = (
+        '<table id="tb-doc-1-0001" format="json" caption="Indicator metrics">'
+        '[[\"a\",\"b\"],[\"1\",\"2\"]]'
+        "</table>"
+    )
+    cleaned = strip_internal_multimodal_markup_for_extraction(source)
+    assert "tb-doc-1-0001" not in cleaned
+    assert 'format="json"' in cleaned
+    assert 'caption="Indicator metrics"' in cleaned
+    # Row body preserved.
+    assert '[["a","b"],["1","2"]]' in cleaned

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -1242,9 +1242,7 @@ def test_analyze_multimodal_skips_already_analyzed_items(tmp_path):
             "blocks_path": str(blocks),
             "content": "body",
         }
-        await rag.analyze_multimodal(
-            "doc-1", "demo.pdf", parsed, process_options="it"
-        )
+        await rag.analyze_multimodal("doc-1", "demo.pdf", parsed, process_options="it")
 
         drawings_payload = json.loads(drawings.read_text(encoding="utf-8"))
         existing = drawings_payload["drawings"]["id1"]["llm_analyze_result"]
@@ -2187,9 +2185,7 @@ def test_analyze_multimodal_unknown_image_type_folds_to_other(tmp_path):
             "blocks_path": str(blocks),
             "content": "body",
         }
-        await rag.analyze_multimodal(
-            "doc-1", "demo.pdf", parsed, process_options="i"
-        )
+        await rag.analyze_multimodal("doc-1", "demo.pdf", parsed, process_options="i")
 
         payload = json.loads(drawings.read_text(encoding="utf-8"))
         result = payload["drawings"]["id1"]["llm_analyze_result"]
@@ -2258,9 +2254,7 @@ def test_analyze_multimodal_skips_tiny_image_without_vlm_call(tmp_path):
             "blocks_path": str(blocks),
             "content": "body",
         }
-        await rag.analyze_multimodal(
-            "doc-1", "demo.pdf", parsed, process_options="i"
-        )
+        await rag.analyze_multimodal("doc-1", "demo.pdf", parsed, process_options="i")
 
         payload = json.loads(drawings.read_text(encoding="utf-8"))
         result = payload["drawings"]["id1"]["llm_analyze_result"]
@@ -2457,9 +2451,7 @@ def test_analyze_multimodal_table_without_image_uses_textual_analysis(tmp_path):
             "blocks_path": str(blocks),
             "content": "body",
         }
-        await rag.analyze_multimodal(
-            "doc-1", "demo.pdf", parsed, process_options="t"
-        )
+        await rag.analyze_multimodal("doc-1", "demo.pdf", parsed, process_options="t")
 
         payload = json.loads(tables.read_text(encoding="utf-8"))
         result = payload["tables"]["id1"]["llm_analyze_result"]

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -2873,3 +2873,79 @@ def test_strip_internal_multimodal_markup_cleans_table_id():
     assert 'caption="Indicator metrics"' in cleaned
     # Row body preserved.
     assert '[["a","b"],["1","2"]]' in cleaned
+
+
+@pytest.mark.offline
+def test_reinsert_without_process_options_skips_stale_mm_chunks(tmp_path):
+    """Regression for the call-site fallback in process_single_document.
+
+    A document re-inserted without ``process_options`` is signalled by a
+    missing / falsy ``content_data["process_options"]`` field.  The
+    pipeline must pass ``""`` (not ``None``) to
+    ``_build_mm_chunks_from_sidecars`` so the builder honors the
+    "no modalities" contract: stale ``status="success"`` sidecar entries
+    from an earlier i/t/e pass MUST NOT be re-indexed.
+
+    The new builder happens to handle ``None`` by enabling every
+    modality for ad-hoc callers (unit tests), so this test pins the
+    call-site behaviour rather than the helper's default — passing the
+    same falsy value via ``or ""`` makes the intent explicit.
+    """
+
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+
+        blocks = tmp_path / "demo.blocks.jsonl"
+        blocks.write_text(
+            "\n".join(
+                [
+                    json.dumps({"type": "meta", "format_version": "1.0"}),
+                    json.dumps({"type": "content", "content": "body"}),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        # Stale success from an earlier multimodal run.
+        drawings = tmp_path / "demo.drawings.json"
+        drawings.write_text(
+            json.dumps(
+                {
+                    "drawings": {
+                        "d1": {
+                            "id": "d1",
+                            "llm_analyze_result": {
+                                "name": "old",
+                                "type": "Chart",
+                                "description": "stale drawing",
+                                "analyze_time": 1700000000,
+                                "status": "success",
+                                "message": "",
+                            },
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        # Simulate the call-site contract: ``content_data`` has no
+        # ``process_options`` key, so ``.get(...) or ""`` yields "".
+        content_data: dict[str, str] = {}
+        effective = (content_data or {}).get("process_options") or ""
+        assert effective == ""
+
+        mm_chunks = rag._build_mm_chunks_from_sidecars(
+            doc_id="doc-1",
+            file_path="demo.pdf",
+            blocks_path=str(blocks),
+            base_order_index=0,
+            process_options=effective,
+        )
+        assert mm_chunks == []
+
+        await rag.finalize_storages()
+
+    asyncio.run(_run())

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -1150,21 +1150,33 @@ def test_analyze_multimodal_skips_already_analyzed_items(tmp_path):
     """
 
     async def _run():
-        call_count = {"n": 0}
+        vlm_calls = {"n": 0}
+        extract_calls = {"n": 0}
 
         async def _vlm(_prompt, **_kwargs):
-            call_count["n"] += 1
+            vlm_calls["n"] += 1
             return json.dumps(
                 {
-                    "name": "Item",
-                    "summary": "ok",
-                    "detail_description": "details",
-                    "grounded": True,
-                    "grounding_reason": "visual_evidence",
+                    "name": "Image",
+                    "type": "Chart",
+                    "description": "details",
                 }
             )
 
-        rag = _new_rag(tmp_path, vlm_llm_model_func=_vlm)
+        async def _extract(_prompt, **_kwargs):
+            extract_calls["n"] += 1
+            return json.dumps(
+                {
+                    "name": "Item",
+                    "description": "table content summary",
+                }
+            )
+
+        rag = _new_rag(
+            tmp_path,
+            vlm_llm_model_func=_vlm,
+            extract_llm_model_func=_extract,
+        )
         await rag.initialize_storages()
 
         # Minimal blocks file with valid meta.
@@ -1180,8 +1192,7 @@ def test_analyze_multimodal_skips_already_analyzed_items(tmp_path):
             encoding="utf-8",
         )
 
-        # Drawings sidecar with ONE item that already has llm_analyze_result
-        # (simulates a prior pass).
+        # Drawings sidecar with ONE item already analyzed (status=success).
         drawings = tmp_path / "demo.drawings.json"
         drawings.write_text(
             json.dumps(
@@ -1191,11 +1202,14 @@ def test_analyze_multimodal_skips_already_analyzed_items(tmp_path):
                         "id1": {
                             "id": "id1",
                             "caption": "fig1",
+                            "path": "missing.png",
                             "llm_analyze_result": {
                                 "name": "Existing",
-                                "summary": "from prior run",
-                                "detail_description": "kept as-is",
-                                "grounded": True,
+                                "type": "Photo",
+                                "description": "kept as-is",
+                                "analyze_time": 1700000000,
+                                "status": "success",
+                                "message": "",
                             },
                         }
                     },
@@ -1228,26 +1242,25 @@ def test_analyze_multimodal_skips_already_analyzed_items(tmp_path):
             "blocks_path": str(blocks),
             "content": "body",
         }
-        # Second pass enables BOTH images and tables; drawings should be
-        # skipped (already analyzed) and only tables should hit the VLM.
-        await rag.analyze_multimodal("doc-1", "demo.pdf", parsed, process_options="it")
+        await rag.analyze_multimodal(
+            "doc-1", "demo.pdf", parsed, process_options="it"
+        )
 
         drawings_payload = json.loads(drawings.read_text(encoding="utf-8"))
         existing = drawings_payload["drawings"]["id1"]["llm_analyze_result"]
         # Existing result preserved verbatim — VLM was NOT called for this item.
         assert existing["name"] == "Existing"
-        assert existing["summary"] == "from prior run"
+        assert existing["status"] == "success"
 
         tables_payload = json.loads(tables.read_text(encoding="utf-8"))
         new_result = tables_payload["tables"]["tbl1"]["llm_analyze_result"]
-        # The newly-enabled modality was analyzed.
         assert new_result["name"] == "Item"
-        assert new_result["summary"] == "ok"
+        assert new_result["status"] == "success"
 
-        # Exactly ONE VLM call total (for the table).  Per-item
-        # ``llm_analyze_result`` already-present is the idempotency guard:
-        # the count would be 2 if it were missing.
-        assert call_count["n"] == 1
+        # Drawings were idempotently skipped (VLM never called); tables took
+        # the EXTRACT role (per design §3.1), not VLM.
+        assert vlm_calls["n"] == 0
+        assert extract_calls["n"] == 1
 
     asyncio.run(_run())
 
@@ -1950,10 +1963,10 @@ def test_three_phase_status_flow(tmp_path, monkeypatch):
 
 
 @pytest.mark.offline
-def test_analyze_multimodal_invalid_json_skips_without_retry(tmp_path):
-    """The business-level JSON-schema retry was deliberately removed; an
-    invalid VLM response must produce a conservative writeback after exactly
-    one VLM call (network-level retries remain inside the provider)."""
+def test_analyze_multimodal_invalid_json_hard_fails(tmp_path):
+    """An invalid VLM response is a hard failure under the new contract:
+    the sidecar item gets status='failure' and MultimodalAnalysisError
+    bubbles up so the document fails (no silent conservative fallback)."""
 
     async def _run():
         calls = {"n": 0}
@@ -1964,13 +1977,27 @@ def test_analyze_multimodal_invalid_json_skips_without_retry(tmp_path):
 
         rag = _new_rag(tmp_path, vlm_llm_model_func=_broken_vlm)
         await rag.initialize_storages()
-        # 1x1 transparent PNG for grounded image-path flow
+        # 64x64 PNG so the image-pixel skip guard does NOT short-circuit
+        # before the VLM call.
         img_path = tmp_path / "img1.png"
-        img_path.write_bytes(
-            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
-            b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc`\x00\x00"
-            b"\x00\x02\x00\x01\xe2!\xbc3\x00\x00\x00\x00IEND\xaeB`\x82"
-        )
+        import struct
+        import zlib
+
+        def _png_bytes(w: int, h: int) -> bytes:
+            sig = b"\x89PNG\r\n\x1a\n"
+            ihdr = struct.pack(">II", w, h) + b"\x08\x06\x00\x00\x00"
+            crc = zlib.crc32(b"IHDR" + ihdr).to_bytes(4, "big")
+            ihdr_chunk = struct.pack(">I", len(ihdr)) + b"IHDR" + ihdr + crc
+            idat_payload = b"\x00" * (w * h * 4 + h)
+            compressed = zlib.compress(idat_payload)
+            crc_idat = zlib.crc32(b"IDAT" + compressed).to_bytes(4, "big")
+            idat_chunk = (
+                struct.pack(">I", len(compressed)) + b"IDAT" + compressed + crc_idat
+            )
+            iend_chunk = b"\x00\x00\x00\x00IEND\xaeB`\x82"
+            return sig + ihdr_chunk + idat_chunk + iend_chunk
+
+        img_path.write_bytes(_png_bytes(64, 64))
 
         blocks = tmp_path / "demo.blocks.jsonl"
         blocks.write_text(
@@ -2009,15 +2036,21 @@ def test_analyze_multimodal_invalid_json_skips_without_retry(tmp_path):
             "blocks_path": str(blocks),
             "content": "body",
         }
-        await rag.analyze_multimodal("doc-1", "demo.pdf", parsed, process_options="ite")
+        from lightrag.exceptions import MultimodalAnalysisError
+
+        with pytest.raises(MultimodalAnalysisError):
+            await rag.analyze_multimodal(
+                "doc-1", "demo.pdf", parsed, process_options="i"
+            )
 
         drawings_payload = json.loads(drawings.read_text(encoding="utf-8"))
         result = drawings_payload["drawings"]["id1"]["llm_analyze_result"]
         # No retry: VLM mock called exactly once.
         assert calls["n"] == 1
-        # Conservative writeback under invalid_json_schema reason.
-        assert result["grounded"] is False
-        assert result["grounding_reason"] == "invalid_json_schema"
+        # Sidecar carries a failure marker so a re-run sees the prior failure
+        # and does not silently consume it.
+        assert result["status"] == "failure"
+        assert "missing or invalid field" in result["message"]
 
     asyncio.run(_run())
 
@@ -2088,29 +2121,34 @@ def test_relationship_vdb_timeout_has_120s_floor():
 
 
 @pytest.mark.offline
-def test_analyze_multimodal_normalizes_string_grounded_to_bool(tmp_path):
+def test_analyze_multimodal_unknown_image_type_folds_to_other(tmp_path):
+    """Model output with an out-of-enum ``type`` is folded to ``Other``
+    instead of failing the document (per design §3.4)."""
+
     async def _run():
         async def _vlm(_prompt, **_kwargs):
             return json.dumps(
                 {
                     "name": "Figure A",
-                    "image_type": "diagram",
-                    "summary": "ok",
-                    "detail_description": "details",
-                    "grounded": "true",
-                    "grounding_reason": "visual_evidence",
+                    "type": "diagram",  # not in IMAGE_TYPE_ENUM
+                    "description": "details",
                 },
                 ensure_ascii=False,
             )
 
         rag = _new_rag(tmp_path, vlm_llm_model_func=_vlm)
         await rag.initialize_storages()
+        import struct
+        import zlib
+
+        def _png(w, h):
+            sig = b"\x89PNG\r\n\x1a\n"
+            ihdr = struct.pack(">II", w, h) + b"\x08\x06\x00\x00\x00"
+            crc = zlib.crc32(b"IHDR" + ihdr).to_bytes(4, "big")
+            return sig + struct.pack(">I", len(ihdr)) + b"IHDR" + ihdr + crc
+
         img_path = tmp_path / "img1.png"
-        img_path.write_bytes(
-            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
-            b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc`\x00\x00"
-            b"\x00\x02\x00\x01\xe2!\xbc3\x00\x00\x00\x00IEND\xaeB`\x82"
-        )
+        img_path.write_bytes(_png(64, 64))
 
         blocks = tmp_path / "demo.blocks.jsonl"
         blocks.write_text(
@@ -2149,24 +2187,41 @@ def test_analyze_multimodal_normalizes_string_grounded_to_bool(tmp_path):
             "blocks_path": str(blocks),
             "content": "body",
         }
-        await rag.analyze_multimodal("doc-1", "demo.pdf", parsed, process_options="ite")
+        await rag.analyze_multimodal(
+            "doc-1", "demo.pdf", parsed, process_options="i"
+        )
 
         payload = json.loads(drawings.read_text(encoding="utf-8"))
         result = payload["drawings"]["id1"]["llm_analyze_result"]
-        assert result["grounded"] is True
-        assert isinstance(result["grounded"], bool)
+        assert result["status"] == "success"
+        assert result["type"] == "Other"
+        assert result["description"] == "details"
+        assert "analyze_time" in result
 
     asyncio.run(_run())
 
 
 @pytest.mark.offline
-def test_analyze_multimodal_without_image_uses_conservative_output(tmp_path):
+def test_analyze_multimodal_skips_tiny_image_without_vlm_call(tmp_path):
+    """Images smaller than VLM_MIN_IMAGE_PIXEL (default 32px) are flagged
+    status=skipped without invoking the VLM."""
+
     async def _run():
+        calls = {"n": 0}
+
         async def _vlm(_prompt, **_kwargs):
-            return '{"name":"X","summary":"hallucinated rich details","detail_description":"very specific claims","grounded":false}'
+            calls["n"] += 1
+            return "{}"
 
         rag = _new_rag(tmp_path, vlm_llm_model_func=_vlm)
         await rag.initialize_storages()
+        # 1x1 PNG.
+        img_path = tmp_path / "tiny.png"
+        img_path.write_bytes(
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+            b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc`\x00\x00"
+            b"\x00\x02\x00\x01\xe2!\xbc3\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
 
         blocks = tmp_path / "demo.blocks.jsonl"
         blocks.write_text(
@@ -2186,10 +2241,13 @@ def test_analyze_multimodal_without_image_uses_conservative_output(tmp_path):
                 {
                     "version": "1.0",
                     "drawings": {
-                        "id1": {"id": "id1", "caption": "图1 测试图", "footnotes": []}
+                        "id1": {
+                            "id": "id1",
+                            "caption": "tiny",
+                            "path": str(img_path),
+                        }
                     },
-                },
-                ensure_ascii=False,
+                }
             ),
             encoding="utf-8",
         )
@@ -2200,13 +2258,15 @@ def test_analyze_multimodal_without_image_uses_conservative_output(tmp_path):
             "blocks_path": str(blocks),
             "content": "body",
         }
-        await rag.analyze_multimodal("doc-1", "demo.pdf", parsed, process_options="ite")
+        await rag.analyze_multimodal(
+            "doc-1", "demo.pdf", parsed, process_options="i"
+        )
 
         payload = json.loads(drawings.read_text(encoding="utf-8"))
         result = payload["drawings"]["id1"]["llm_analyze_result"]
-        assert result["grounded"] is False
-        assert "Conservative summary only" in result["summary"]
-        assert "missing_image" in result["detail_description"]
+        assert result["status"] == "skipped"
+        assert "smaller than" in result["message"]
+        assert calls["n"] == 0
 
     asyncio.run(_run())
 
@@ -2340,19 +2400,24 @@ def test_write_lightrag_document_strips_parser_hint_from_artifact_names(
 @pytest.mark.offline
 def test_analyze_multimodal_table_without_image_uses_textual_analysis(tmp_path):
     async def _run():
-        async def _vlm(_prompt, **_kwargs):
+        # Tables now route to the EXTRACT role, not VLM (per design §3.1).
+        async def _extract(_prompt, **_kwargs):
             return json.dumps(
                 {
-                    "name": "指标表",
-                    "summary": "该表展示符号、代表意义和单位的对应关系。",
-                    "detail_description": "表格包含三列，分别为符号、代表意义和单位，列出了 A、F、e 等符号。",
-                    "grounded": True,
-                    "grounding_reason": "textual_content_only",
+                    "name": "model_benchmark_metrics",
+                    "description": "表格包含三列，分别为符号、代表意义和单位，列出了 A、F、e 等符号。",
                 },
                 ensure_ascii=False,
             )
 
-        rag = _new_rag(tmp_path, vlm_llm_model_func=_vlm)
+        async def _vlm_unused(_prompt, **_kwargs):
+            raise AssertionError("VLM must not be called for tables")
+
+        rag = _new_rag(
+            tmp_path,
+            vlm_llm_model_func=_vlm_unused,
+            extract_llm_model_func=_extract,
+        )
         await rag.initialize_storages()
 
         blocks = tmp_path / "demo.blocks.jsonl"
@@ -2392,14 +2457,20 @@ def test_analyze_multimodal_table_without_image_uses_textual_analysis(tmp_path):
             "blocks_path": str(blocks),
             "content": "body",
         }
-        await rag.analyze_multimodal("doc-1", "demo.pdf", parsed, process_options="ite")
+        await rag.analyze_multimodal(
+            "doc-1", "demo.pdf", parsed, process_options="t"
+        )
 
         payload = json.loads(tables.read_text(encoding="utf-8"))
         result = payload["tables"]["id1"]["llm_analyze_result"]
-        assert result["grounded"] is True
-        assert result["grounding_reason"] == "textual_content_only"
-        assert "Conservative summary only" not in result["summary"]
-        assert "符号、代表意义和单位" in result["summary"]
+        assert result["status"] == "success"
+        assert result["name"] == "model_benchmark_metrics"
+        assert "符号、代表意义和单位" in result["description"]
+        # Cache id was written back so document delete can clean it up.
+        assert any(
+            cid.startswith("default:analysis:")
+            for cid in payload["tables"]["id1"].get("llm_cache_list", [])
+        )
 
     asyncio.run(_run())
 
@@ -2533,11 +2604,16 @@ def test_mm_chunks_and_modality_relations_from_sidecars(tmp_path):
                             "id": "d1",
                             "heading": "章节A",
                             "caption": "图1 架构",
+                            "llm_cache_list": [
+                                "default:analysis:abc123",
+                            ],
                             "llm_analyze_result": {
                                 "name": "系统架构图",
-                                "image_type": "Chart",
-                                "summary": "展示系统模块",
-                                "detail_description": "模块交互关系",
+                                "type": "Chart",
+                                "description": "模块交互关系",
+                                "analyze_time": 1700000000,
+                                "status": "success",
+                                "message": "",
                             },
                         }
                     },
@@ -2547,47 +2623,31 @@ def test_mm_chunks_and_modality_relations_from_sidecars(tmp_path):
             encoding="utf-8",
         )
 
-        mm_chunks, mm_specs = rag._build_mm_chunks_from_sidecars(
+        mm_chunks = rag._build_mm_chunks_from_sidecars(
             doc_id="doc-1",
             file_path="demo.pdf",
             blocks_path=str(blocks),
             base_order_index=2,
         )
         assert len(mm_chunks) == 1
-        assert mm_chunks[0]["content"].startswith("Image_Name:")
-        assert len(mm_specs) == 1
-        assert mm_specs[0]["entity_name"].startswith("drawing-")
-
-        # Simulate extracted entities from same mm chunk
-        chunk_id = mm_specs[0]["chunk_id"]
-        chunk_results = [
-            (
-                {
-                    "系统模块": [
-                        {
-                            "entity_name": "系统模块",
-                            "entity_type": "concept",
-                            "description": "模块",
-                            "source_id": chunk_id,
-                            "file_path": "demo.pdf",
-                            "timestamp": 1,
-                        }
-                    ]
-                },
-                {},
-            )
-        ]
-        from lightrag.utils_pipeline import augment_chunk_results_with_mm_entities
-
-        augmented = augment_chunk_results_with_mm_entities(
-            chunk_results=chunk_results,
-            mm_specs=mm_specs,
-            file_path="demo.pdf",
-        )
-        assert len(augmented) == 2
-        mm_nodes, mm_edges = augmented[-1]
-        assert any(k.startswith("drawing-") for k in mm_nodes.keys())
-        assert mm_edges  # has relation from modality object to extracted entity
+        chunk = mm_chunks[0]
+        # New nested schema: heading + sidecar + llm_cache_list merge.
+        assert chunk["content"].startswith("- Image Name:")
+        assert "- Image Type:\nChart" in chunk["content"]
+        assert chunk["sidecar"] == {
+            "type": "drawing",
+            "id": "d1",
+            "refs": [{"type": "drawing", "id": "d1"}],
+        }
+        assert chunk["heading"] == {
+            "level": 0,
+            "heading": "章节A",
+            "parent_headings": [],
+        }
+        assert chunk["llm_cache_list"] == ["default:analysis:abc123"]
+        # Multimodal entity injection now lives in
+        # operate.extract_entities._process_single_content; this test only
+        # covers chunk assembly.
 
         await rag.finalize_storages()
 

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -2864,7 +2864,7 @@ def test_strip_internal_multimodal_markup_cleans_table_id():
 
     source = (
         '<table id="tb-doc-1-0001" format="json" caption="Indicator metrics">'
-        '[[\"a\",\"b\"],[\"1\",\"2\"]]'
+        '[["a","b"],["1","2"]]'
         "</table>"
     )
     cleaned = strip_internal_multimodal_markup_for_extraction(source)

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -2702,3 +2702,151 @@ def test_parse_docling_empty_service_result_raises_without_fallback(
         await rag.finalize_storages()
 
     asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_build_chunks_dict_preserves_existing_llm_cache_list():
+    """Regression: build_chunks_dict_from_chunking_result must not overwrite
+    a chunk's pre-existing llm_cache_list — multimodal chunks arrive with
+    analysis cache ids already attached so document deletion can clean
+    them up via the per-chunk llm_cache_list."""
+    from lightrag.utils_pipeline import build_chunks_dict_from_chunking_result
+
+    chunking_result = [
+        {
+            "chunk_order_index": 0,
+            "content": "first chunk",
+            "tokens": 4,
+        },
+        {
+            "chunk_id": "doc-1-mm-drawing-000",
+            "chunk_order_index": 1,
+            "content": "second chunk",
+            "tokens": 6,
+            "llm_cache_list": [
+                "default:analysis:abc",
+                "default:analysis:abc",  # dedup verification
+                "default:analysis:def",
+            ],
+        },
+    ]
+
+    chunks = build_chunks_dict_from_chunking_result(
+        chunking_result, doc_id="doc-1", file_path="demo.pdf"
+    )
+    # Order is chunking_result order; locate by chunk_id.
+    mm_chunk = next(
+        v for v in chunks.values() if v.get("chunk_id") == "doc-1-mm-drawing-000"
+    )
+    text_chunk = next(
+        v for v in chunks.values() if v.get("chunk_id") != "doc-1-mm-drawing-000"
+    )
+    assert mm_chunk["llm_cache_list"] == [
+        "default:analysis:abc",
+        "default:analysis:def",
+    ]
+    # Plain text chunks still start with an empty list (no pre-existing ids).
+    assert text_chunk["llm_cache_list"] == []
+
+
+@pytest.mark.offline
+def test_build_mm_chunks_respects_process_options_filter(tmp_path):
+    """Regression: _build_mm_chunks_from_sidecars must gate sidecar reads
+    by the active process_options.  A document re-processed after opting
+    out of i/t/e MUST NOT pick up stale success results from a prior pass.
+    """
+
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+
+        blocks = tmp_path / "demo.blocks.jsonl"
+        blocks.write_text(
+            "\n".join(
+                [
+                    json.dumps({"type": "meta", "format_version": "1.0"}),
+                    json.dumps({"type": "content", "content": "body"}),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        # Both modalities carry a stale ``success`` from a prior pass.
+        drawings = tmp_path / "demo.drawings.json"
+        drawings.write_text(
+            json.dumps(
+                {
+                    "drawings": {
+                        "d1": {
+                            "id": "d1",
+                            "llm_analyze_result": {
+                                "name": "old",
+                                "type": "Chart",
+                                "description": "stale drawing",
+                                "analyze_time": 1700000000,
+                                "status": "success",
+                                "message": "",
+                            },
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        tables = tmp_path / "demo.tables.json"
+        tables.write_text(
+            json.dumps(
+                {
+                    "tables": {
+                        "t1": {
+                            "id": "t1",
+                            "llm_analyze_result": {
+                                "name": "old",
+                                "description": "stale table",
+                                "analyze_time": 1700000000,
+                                "status": "success",
+                                "message": "",
+                            },
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        # process_options="t" → only tables are considered; the drawing
+        # success entry must NOT generate a chunk.
+        only_tables = rag._build_mm_chunks_from_sidecars(
+            doc_id="doc-1",
+            file_path="demo.pdf",
+            blocks_path=str(blocks),
+            base_order_index=0,
+            process_options="t",
+        )
+        assert len(only_tables) == 1
+        assert only_tables[0]["sidecar"]["type"] == "table"
+
+        # Empty/None process_options → no modalities active → no chunks.
+        none_active = rag._build_mm_chunks_from_sidecars(
+            doc_id="doc-1",
+            file_path="demo.pdf",
+            blocks_path=str(blocks),
+            base_order_index=0,
+            process_options="",
+        )
+        assert none_active == []
+
+        # Backwards-compat: callers that pass process_options=None see
+        # every modality (legacy behaviour for ad-hoc unit tests).
+        legacy = rag._build_mm_chunks_from_sidecars(
+            doc_id="doc-1",
+            file_path="demo.pdf",
+            blocks_path=str(blocks),
+            base_order_index=0,
+        )
+        assert {ch["sidecar"]["type"] for ch in legacy} == {"drawing", "table"}
+
+        await rag.finalize_storages()
+
+    asyncio.run(_run())

--- a/tests/test_vlm_cache_key.py
+++ b/tests/test_vlm_cache_key.py
@@ -172,10 +172,7 @@ def test_image_dimensions_change_changes_cache_key():
     idat_compressed = zlib.compress(idat_payload)
     idat_crc = zlib.crc32(b"IDAT" + idat_compressed).to_bytes(4, "big")
     idat = (
-        struct.pack(">I", len(idat_compressed))
-        + b"IDAT"
-        + idat_compressed
-        + idat_crc
+        struct.pack(">I", len(idat_compressed)) + b"IDAT" + idat_compressed + idat_crc
     )
     iend = b"\x00\x00\x00\x00IEND\xaeB`\x82"
     big_png = sig + ihdr + idat + iend

--- a/tests/test_vlm_cache_key.py
+++ b/tests/test_vlm_cache_key.py
@@ -138,3 +138,51 @@ def test_audit_block_in_original_prompt_does_not_leak_raw_base64():
     # sha256 digest is present; raw base64 must not be.
     assert audit_blob[0]["sha256"] in original_prompt
     assert _b64(PNG_A) not in original_prompt
+
+
+def test_image_metadata_includes_width_height():
+    """Design §5.2 contract: image digest metadata must surface
+    width/height alongside mime/sha256/bytes so cache keys and audit blocks
+    capture the full pixel footprint."""
+    normalized = normalize_image_inputs([{"base64": _b64(PNG_A)}])
+    cache_blob = image_cache_metadata(normalized)
+    audit_blob = image_audit_metadata(normalized)
+    assert len(cache_blob) == 1
+    # 1x1 PNG fixture — dimensions are decodable from the IHDR chunk.
+    assert cache_blob[0]["width"] == 1
+    assert cache_blob[0]["height"] == 1
+    assert audit_blob[0]["width"] == 1
+    assert audit_blob[0]["height"] == 1
+
+
+def test_image_dimensions_change_changes_cache_key():
+    """Two PNGs with the same pixel byte payload but different declared
+    dimensions still differ at the byte level and therefore must hash to
+    distinct args_hashes — the width/height fields in cache metadata
+    document the difference without being the sole identity source."""
+    # Build a 32x16 PNG and compare it against the 1x1 PNG_A.
+    import struct
+    import zlib
+
+    sig = b"\x89PNG\r\n\x1a\n"
+    ihdr_payload = struct.pack(">II", 32, 16) + b"\x08\x06\x00\x00\x00"
+    ihdr_crc = zlib.crc32(b"IHDR" + ihdr_payload).to_bytes(4, "big")
+    ihdr = struct.pack(">I", len(ihdr_payload)) + b"IHDR" + ihdr_payload + ihdr_crc
+    idat_payload = b"\x00" * (32 * 16 * 4 + 16)
+    idat_compressed = zlib.compress(idat_payload)
+    idat_crc = zlib.crc32(b"IDAT" + idat_compressed).to_bytes(4, "big")
+    idat = (
+        struct.pack(">I", len(idat_compressed))
+        + b"IDAT"
+        + idat_compressed
+        + idat_crc
+    )
+    iend = b"\x00\x00\x00\x00IEND\xaeB`\x82"
+    big_png = sig + ihdr + idat + iend
+
+    normalized_small = normalize_image_inputs([{"base64": _b64(PNG_A)}])
+    normalized_big = normalize_image_inputs([{"base64": _b64(big_png)}])
+
+    assert image_cache_metadata(normalized_small)[0]["width"] == 1
+    assert image_cache_metadata(normalized_big)[0]["width"] == 32
+    assert image_cache_metadata(normalized_big)[0]["height"] == 16


### PR DESCRIPTION
## Summary

- **Modality-aware analysis**: drawings now route to the VLM role while tables and equations route to the EXTRACT role, each with its own template in [lightrag/prompt_multimodal.py](lightrag/prompt_multimodal.py). `llm_analyze_result` switches to explicit `status / message / analyze_time` semantics, replacing the old `grounded / conservative` branches. Image format checks and a 32px pixel floor short-circuit to `status="skipped"` without an LLM call; required-field failures raise `MultimodalAnalysisError` so the document fails instead of writing an unusable result.
- **Cache lifecycle closed**: analysis cache ids are written back to each sidecar item's `llm_cache_list` and merged into the multimodal chunk's `llm_cache_list`. The existing document-delete cleanup path now naturally removes `cache_type="analysis"` entries that previously leaked when documents were deleted.
- **Chunk schema upgrade + per-chunk entity injection**: multimodal and paragraph-semantic chunks both adopt the new nested `heading = {level, heading, parent_headings}` + `sidecar = {type, id, refs}` schema. P-chunks propagate `blockid` through Stage B/C splits and merge them in Stage D so each chunk traces back to its source blocks. Multimodal entity injection moves from the centralized post-pass in `utils_pipeline.augment_chunk_results_with_mm_entities` (deleted) to per-chunk dispatch inside `operate._process_single_content`, keyed by `chunk.sidecar.type`. Extraction prompts are pre-cleaned of `<cite>` / `<drawing>` / `<equation>` internal identifiers without mutating the stored chunk content.

## Test plan

- [x] `./scripts/test.sh tests` — **1240 passed / 1 skipped / 1 xfailed**
- [x] `ruff check lightrag tests` — clean
- [ ] End-to-end smoke on a .docx with image / table / equation modalities enabled
  - sidecar JSON shows `llm_analyze_result.status="success"` and `llm_cache_list` populated for each modality
  - multimodal chunks carry the correct nested `sidecar.type` and inherited analysis cache ids
  - `drawing-* / table-* / equation-*` entities + relations land in the graph
  - second run hits the analysis cache for every modality (no model calls)
  - `await rag.adelete_by_doc_id(...)` clears the `default:analysis:*` entries