### PR TITLE
feat(multimodal): defer sidecar surrounding to analyze entry; env-tunable budgets

### DIFF
--- a/env.example
+++ b/env.example
@@ -265,6 +265,13 @@ CHUNK_P_SIZE=2000
 ### below must be configured before server startup.
 # LIGHTRAG_PARSER=docx:native
 
+### Multimodal surrounding-context budget (per-half token cap for the
+### `leading` / `trailing` text injected into VLM and extract prompts).
+### Computed at analyze_multimodal entry; the two halves are independent
+### so deployments can bias context forward or backward as needed.
+# SURROUNDING_LEADING_MAX_TOKENS=2000
+# SURROUNDING_TRAILING_MAX_TOKENS=2000
+
 ### Async parser service protocol (optional)
 ### Configure these when using remote MinerU/Docling async services
 # MINERU_ENDPOINT=http://localhost:8000/api/v1/task

--- a/lightrag/multimodal_context.py
+++ b/lightrag/multimodal_context.py
@@ -702,16 +702,65 @@ def load_content_rows_by_blockid(blocks_path: str) -> dict[str, str]:
     return rows
 
 
+DEFAULT_SURROUNDING_MAX_TOKENS = 2000
+
+
+def _resolve_surrounding_budget(
+    leading_max_tokens: int | None,
+    trailing_max_tokens: int | None,
+) -> tuple[int, int]:
+    """Resolve per-half token budgets, defaulting to env vars then 2000.
+
+    Reads ``SURROUNDING_LEADING_MAX_TOKENS`` / ``SURROUNDING_TRAILING_MAX_TOKENS``
+    when the caller passes ``None``.  Invalid env values fall back to
+    :data:`DEFAULT_SURROUNDING_MAX_TOKENS`.
+    """
+
+    def _from_env(env_var: str) -> int:
+        raw = os.getenv(env_var)
+        if raw is None or not raw.strip():
+            return DEFAULT_SURROUNDING_MAX_TOKENS
+        try:
+            value = int(raw)
+        except ValueError:
+            logger.warning(
+                "[multimodal_context] invalid %s=%r; falling back to %d",
+                env_var,
+                raw,
+                DEFAULT_SURROUNDING_MAX_TOKENS,
+            )
+            return DEFAULT_SURROUNDING_MAX_TOKENS
+        return max(0, value)
+
+    leading = (
+        leading_max_tokens
+        if leading_max_tokens is not None
+        else _from_env("SURROUNDING_LEADING_MAX_TOKENS")
+    )
+    trailing = (
+        trailing_max_tokens
+        if trailing_max_tokens is not None
+        else _from_env("SURROUNDING_TRAILING_MAX_TOKENS")
+    )
+    return leading, trailing
+
+
 def build_surrounding(
     *,
     kind: str,
     block_content: str,
     span: tuple[int, int],
     tokenizer: Tokenizer,
-    max_tokens: int,
+    leading_max_tokens: int,
+    trailing_max_tokens: int,
     separators: list[str],
 ) -> dict[str, str]:
-    """Compute ``{"leading": …, "trailing": …}`` for one sidecar entry."""
+    """Compute ``{"leading": …, "trailing": …}`` for one sidecar entry.
+
+    ``leading_max_tokens`` and ``trailing_max_tokens`` are independent
+    per-half caps so deployments can tune the two contexts separately
+    via ``SURROUNDING_LEADING_MAX_TOKENS`` / ``SURROUNDING_TRAILING_MAX_TOKENS``.
+    """
     start, end = span
     leading_src = block_content[:start]
     trailing_src = block_content[end:]
@@ -719,14 +768,14 @@ def build_surrounding(
         leading_src,
         kind=kind,
         tokenizer=tokenizer,
-        max_tokens=max_tokens,
+        max_tokens=leading_max_tokens,
         separators=separators,
     )
     trailing = _build_trailing(
         trailing_src,
         kind=kind,
         tokenizer=tokenizer,
-        max_tokens=max_tokens,
+        max_tokens=trailing_max_tokens,
         separators=separators,
     )
     return {"leading": leading, "trailing": trailing}
@@ -737,7 +786,8 @@ def enrich_sidecars_with_surrounding(
     blocks_path: str,
     enabled_modalities: set[str],
     tokenizer: Tokenizer,
-    max_tokens: int = 2000,
+    leading_max_tokens: int | None = None,
+    trailing_max_tokens: int | None = None,
     separators: list[str] | None = None,
 ) -> dict[str, int]:
     """Backfill ``surrounding`` on enabled-modality sidecars.
@@ -747,7 +797,10 @@ def enrich_sidecars_with_surrounding(
         enabled_modalities: subset of ``{"drawings", "tables",
             "equations"}`` reflecting the document's ``process_options``.
         tokenizer: tokenizer used to enforce the per-half token budget.
-        max_tokens: per-half cap (default 2000).
+        leading_max_tokens: leading-half cap.  ``None`` reads
+            ``SURROUNDING_LEADING_MAX_TOKENS`` (default 2000).
+        trailing_max_tokens: trailing-half cap.  ``None`` reads
+            ``SURROUNDING_TRAILING_MAX_TOKENS`` (default 2000).
         separators: explicit separator cascade.  Defaults to the cascade
             resolved from ``CHUNK_R_SEPARATORS`` (or
             ``DEFAULT_R_SEPARATORS``).
@@ -768,6 +821,10 @@ def enrich_sidecars_with_surrounding(
     content_by_blockid = load_content_rows_by_blockid(blocks_path)
     if separators is None:
         separators = load_chunk_separators()
+
+    leading_tokens, trailing_tokens = _resolve_surrounding_budget(
+        leading_max_tokens, trailing_max_tokens
+    )
 
     base = str(blocks_file)
     if base.endswith(".blocks.jsonl"):
@@ -816,7 +873,8 @@ def enrich_sidecars_with_surrounding(
                 block_content=block_content,
                 span=span,
                 tokenizer=tokenizer,
-                max_tokens=max_tokens,
+                leading_max_tokens=leading_tokens,
+                trailing_max_tokens=trailing_tokens,
                 separators=separators,
             )
             item["surrounding"] = surrounding
@@ -845,6 +903,7 @@ def enrich_sidecars_with_surrounding(
 
 
 __all__ = [
+    "DEFAULT_SURROUNDING_MAX_TOKENS",
     "build_surrounding",
     "enrich_sidecars_with_surrounding",
     "find_target_span",

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -3253,9 +3253,7 @@ class _PipelineMixin:
                     logger.info(
                         f"[analyze_multimodal] surrounding backfilled for "
                         f"d-id: {doc_id}, file: {file_path}: "
-                        + ", ".join(
-                            f"{k}={v}" for k, v in enrich_counts.items() if v
-                        )
+                        + ", ".join(f"{k}={v}" for k, v in enrich_counts.items() if v)
                     )
             except Exception as enrich_err:
                 logger.warning(

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -2310,11 +2310,6 @@ class _PipelineMixin:
                 )
 
                 blocks_path = Path(parsed_data["blocks_path"])
-                self._enrich_parsed_sidecars_with_surrounding(
-                    str(blocks_path),
-                    doc_id=doc_id,
-                    file_path=file_path,
-                )
                 stored_blocks_path = str(blocks_path)
                 try:
                     stored_blocks_path = str(blocks_path.relative_to(input_dir_path()))
@@ -2718,49 +2713,6 @@ class _PipelineMixin:
                 return str(candidate)
         return file_path
 
-    def _enrich_parsed_sidecars_with_surrounding(
-        self,
-        blocks_path: str | None,
-        *,
-        doc_id: str,
-        file_path: str,
-    ) -> dict[str, int]:
-        """Backfill parse-stage sidecar ``surrounding`` fields.
-
-        This runs immediately after a LightRAG Document writer emits
-        ``.blocks.jsonl`` and sidecars, before ``full_docs`` is updated and
-        before the VLM analysis stage.  Keeping the enrichment here makes
-        the parse artifacts stable regardless of later ``process_options``
-        choices.
-        """
-        path = str(blocks_path or "").strip()
-        tokenizer = getattr(self, "tokenizer", None)
-        if not path or tokenizer is None:
-            return {"drawings": 0, "tables": 0, "equations": 0}
-        try:
-            from lightrag.multimodal_context import (
-                enrich_sidecars_with_surrounding,
-            )
-
-            counts = enrich_sidecars_with_surrounding(
-                blocks_path=path,
-                enabled_modalities={"drawings", "tables", "equations"},
-                tokenizer=tokenizer,
-            )
-            if any(counts.values()):
-                logger.info(
-                    f"[parse_native] surrounding backfilled for d-id: {doc_id}, "
-                    f"file: {file_path}: "
-                    + ", ".join(f"{k}={v}" for k, v in counts.items() if v)
-                )
-            return counts
-        except Exception as enrich_err:
-            logger.warning(
-                f"[parse_native] surrounding enrichment failed for "
-                f"d-id: {doc_id}, file: {file_path}: {enrich_err}"
-            )
-            return {"drawings": 0, "tables": 0, "equations": 0}
-
     async def _write_lightrag_document_from_content_list(
         self,
         doc_id: str,
@@ -3151,12 +3103,6 @@ class _PipelineMixin:
                 encoding="utf-8",
             )
 
-        self._enrich_parsed_sidecars_with_surrounding(
-            str(blocks_path),
-            doc_id=doc_id,
-            file_path=file_path,
-        )
-
         # Keep full_docs in sync so restart/reprocess can directly use LightRAG Document.
         stored_blocks_path = str(blocks_path)
         try:
@@ -3276,6 +3222,46 @@ class _PipelineMixin:
                 f"but the parser produced no such sidecar; VLM analysis skipped "
                 f"for those modalities."
             )
+
+        # Backfill sidecar `surrounding` for the enabled modalities just
+        # before VLM consumption.  Universal coverage: native, MinerU,
+        # Docling, and pre-existing LightRAG documents reused from disk
+        # all go through this single entrypoint.  Idempotent: re-runs
+        # overwrite with stable output given unchanged block content.
+        enabled_modalities = {
+            mod
+            for mod, on in (
+                ("drawings", process_opts.images),
+                ("tables", process_opts.tables),
+                ("equations", process_opts.equations),
+            )
+            if on
+        }
+        tokenizer = getattr(self, "tokenizer", None)
+        if enabled_modalities and tokenizer is not None:
+            try:
+                from lightrag.multimodal_context import (
+                    enrich_sidecars_with_surrounding,
+                )
+
+                enrich_counts = enrich_sidecars_with_surrounding(
+                    blocks_path=str(block_file),
+                    enabled_modalities=enabled_modalities,
+                    tokenizer=tokenizer,
+                )
+                if any(enrich_counts.values()):
+                    logger.info(
+                        f"[analyze_multimodal] surrounding backfilled for "
+                        f"d-id: {doc_id}, file: {file_path}: "
+                        + ", ".join(
+                            f"{k}={v}" for k, v in enrich_counts.items() if v
+                        )
+                    )
+            except Exception as enrich_err:
+                logger.warning(
+                    f"[analyze_multimodal] surrounding enrichment failed for "
+                    f"d-id: {doc_id}, file: {file_path}: {enrich_err}"
+                )
 
         try:
             lines = block_file.read_text(encoding="utf-8").splitlines()

--- a/tests/test_document_routes_docx_archive.py
+++ b/tests/test_document_routes_docx_archive.py
@@ -249,9 +249,6 @@ class _ParseTokenizer(_utils.TokenizerInterface):
 
 class _ParseRag:
     _persist_parsed_full_docs = LightRAG._persist_parsed_full_docs
-    _enrich_parsed_sidecars_with_surrounding = (
-        LightRAG._enrich_parsed_sidecars_with_surrounding
-    )
     # parse_native now delegates to the LightRAG Document writer, which the
     # tests need to exercise to validate archive + full_docs side effects.
     _write_lightrag_document_from_content_list = (

--- a/tests/test_multimodal_surrounding_context.py
+++ b/tests/test_multimodal_surrounding_context.py
@@ -104,7 +104,7 @@ def test_drawing_surrounding_kept_within_block_only():
         block_content=block,
         span=span,
         tokenizer=tok,
-        max_tokens=2000,
+        leading_max_tokens=2000, trailing_max_tokens=2000,
         separators=load_chunk_separators(),
     )
     assert surr["leading"].endswith("paragraph two. ")
@@ -125,7 +125,7 @@ def test_equation_surrounding_protects_drawing_atom():
         block_content=block,
         span=span,
         tokenizer=tok,
-        max_tokens=2000,
+        leading_max_tokens=2000, trailing_max_tokens=2000,
         separators=load_chunk_separators(),
     )
     # The drawing atom must appear in full, not half-cut.
@@ -155,7 +155,7 @@ def test_table_surrounding_strips_other_tables_before_counting():
         block_content=block,
         span=span,
         tokenizer=tok,
-        max_tokens=2000,
+        leading_max_tokens=2000, trailing_max_tokens=2000,
         separators=load_chunk_separators(),
     )
     # Sibling table must NOT appear in surrounding.
@@ -179,7 +179,7 @@ def test_table_surrounding_supports_cite_marker_and_strips_sibling_cites():
         block_content=block,
         span=span,
         tokenizer=tok,
-        max_tokens=2000,
+        leading_max_tokens=2000, trailing_max_tokens=2000,
         separators=load_chunk_separators(),
     )
     assert "tb-other" not in surr["leading"]
@@ -209,7 +209,7 @@ def test_chunk_r_separators_env_drives_segment_boundary(monkeypatch):
         block_content=block,
         span=span,
         tokenizer=tok,
-        max_tokens=12,
+        leading_max_tokens=12, trailing_max_tokens=12,
         separators=seps,
     )
     # Leading should end at a '|' boundary (one whole segment), not be
@@ -236,7 +236,7 @@ def test_oversized_closest_segment_char_truncated():
         block_content=block,
         span=span,
         tokenizer=tok,
-        max_tokens=200,
+        leading_max_tokens=200, trailing_max_tokens=200,
         separators=load_chunk_separators(),
     )
     assert len(tok.encode(surr["leading"])) <= 200
@@ -256,7 +256,7 @@ def test_oversized_trailing_char_truncated_at_head():
         block_content=block,
         span=span,
         tokenizer=tok,
-        max_tokens=200,
+        leading_max_tokens=200, trailing_max_tokens=200,
         separators=load_chunk_separators(),
     )
     assert len(tok.encode(surr["trailing"])) <= 200
@@ -282,7 +282,7 @@ def test_drawing_surrounding_row_trims_oversized_json_table():
         block_content=block,
         span=span,
         tokenizer=tok,
-        max_tokens=80,
+        leading_max_tokens=80, trailing_max_tokens=80,
         separators=load_chunk_separators(),
     )
     # Result must be a complete (smaller) <table>...</table>, contain
@@ -314,7 +314,7 @@ def test_drawing_surrounding_row_trims_oversized_html_table():
         block_content=block,
         span=span,
         tokenizer=tok,
-        max_tokens=120,
+        leading_max_tokens=120, trailing_max_tokens=120,
         separators=load_chunk_separators(),
     )
     trailing = surr["trailing"]
@@ -344,7 +344,7 @@ def test_drawing_surrounding_char_trims_oversized_single_json_row():
         block_content=block,
         span=span,
         tokenizer=tok,
-        max_tokens=90,
+        leading_max_tokens=90, trailing_max_tokens=90,
         separators=load_chunk_separators(),
     )
 
@@ -375,7 +375,7 @@ def test_drawing_surrounding_char_trims_oversized_single_html_row():
         block_content=block,
         span=span,
         tokenizer=tok,
-        max_tokens=100,
+        leading_max_tokens=100, trailing_max_tokens=100,
         separators=load_chunk_separators(),
     )
 
@@ -463,7 +463,7 @@ def test_enrich_only_updates_enabled_modalities(tmp_path):
         blocks_path=str(tmp_path / f"{base}.blocks.jsonl"),
         enabled_modalities={"drawings"},
         tokenizer=_tokenizer(),
-        max_tokens=2000,
+        leading_max_tokens=2000, trailing_max_tokens=2000,
     )
     assert counts["drawings"] == 1
     assert counts["tables"] == 0
@@ -522,7 +522,7 @@ def test_enrich_runs_even_when_llm_analyze_result_present(tmp_path):
         blocks_path=str(tmp_path / f"{base}.blocks.jsonl"),
         enabled_modalities={"drawings"},
         tokenizer=_tokenizer(),
-        max_tokens=2000,
+        leading_max_tokens=2000, trailing_max_tokens=2000,
     )
     assert counts["drawings"] == 1
     payload = json.loads(drawings_path.read_text(encoding="utf-8"))
@@ -572,10 +572,80 @@ def test_enrich_does_not_cross_block_boundaries(tmp_path):
         blocks_path=str(tmp_path / f"{base}.blocks.jsonl"),
         enabled_modalities={"drawings"},
         tokenizer=_tokenizer(),
-        max_tokens=2000,
+        leading_max_tokens=2000, trailing_max_tokens=2000,
     )
     payload = json.loads(drawings_path.read_text(encoding="utf-8"))
     surr = payload["drawings"]["dr-1"]["surrounding"]
     # Must come from block B only — content of block A absent.
     assert "earlier block content" not in surr["leading"]
     assert surr["leading"].startswith("later block.")
+
+
+# ---------------------------------------------------------------------------
+# Per-half token budgets via SURROUNDING_LEADING/TRAILING_MAX_TOKENS env vars.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.offline
+def test_env_var_leading_and_trailing_budgets_apply_independently(
+    tmp_path, monkeypatch
+):
+    # Asymmetric budgets must produce asymmetric leading / trailing sizes.
+    monkeypatch.setenv("SURROUNDING_LEADING_MAX_TOKENS", "5")
+    monkeypatch.setenv("SURROUNDING_TRAILING_MAX_TOKENS", "20")
+
+    base = "doc"
+    blockid = "b1"
+    content = "X" * 200 + '<drawing id="dr-1" path="a.png" src="a" />' + "Y" * 200
+    _write_blocks(
+        tmp_path,
+        base,
+        [
+            {
+                "type": "content",
+                "blockid": blockid,
+                "format": "plain_text",
+                "content": content,
+                "heading": "h",
+                "parent_headings": [],
+                "level": 1,
+            }
+        ],
+    )
+    drawings_path = tmp_path / f"{base}.drawings.json"
+    _write_sidecar(
+        drawings_path,
+        "drawings",
+        {"dr-1": {"id": "dr-1", "blockid": blockid, "heading": "h"}},
+    )
+
+    tok = _tokenizer()
+    enrich_sidecars_with_surrounding(
+        blocks_path=str(tmp_path / f"{base}.blocks.jsonl"),
+        enabled_modalities={"drawings"},
+        tokenizer=tok,
+    )
+
+    surr = json.loads(drawings_path.read_text(encoding="utf-8"))[
+        "drawings"
+    ]["dr-1"]["surrounding"]
+    assert len(tok.encode(surr["leading"])) <= 5
+    assert len(tok.encode(surr["trailing"])) <= 20
+    # Trailing is allowed to use its larger budget, so it must be strictly
+    # longer than leading here.
+    assert len(surr["trailing"]) > len(surr["leading"])
+
+
+@pytest.mark.offline
+def test_env_var_invalid_value_falls_back_to_default(monkeypatch):
+    # An unparseable env value must not crash; it falls back to 2000.
+    monkeypatch.setenv("SURROUNDING_LEADING_MAX_TOKENS", "not-a-number")
+    monkeypatch.setenv("SURROUNDING_TRAILING_MAX_TOKENS", "not-a-number")
+    from lightrag.multimodal_context import (
+        DEFAULT_SURROUNDING_MAX_TOKENS,
+        _resolve_surrounding_budget,
+    )
+
+    leading, trailing = _resolve_surrounding_budget(None, None)
+    assert leading == DEFAULT_SURROUNDING_MAX_TOKENS
+    assert trailing == DEFAULT_SURROUNDING_MAX_TOKENS

--- a/tests/test_multimodal_surrounding_context.py
+++ b/tests/test_multimodal_surrounding_context.py
@@ -104,7 +104,8 @@ def test_drawing_surrounding_kept_within_block_only():
         block_content=block,
         span=span,
         tokenizer=tok,
-        leading_max_tokens=2000, trailing_max_tokens=2000,
+        leading_max_tokens=2000,
+        trailing_max_tokens=2000,
         separators=load_chunk_separators(),
     )
     assert surr["leading"].endswith("paragraph two. ")
@@ -125,7 +126,8 @@ def test_equation_surrounding_protects_drawing_atom():
         block_content=block,
         span=span,
         tokenizer=tok,
-        leading_max_tokens=2000, trailing_max_tokens=2000,
+        leading_max_tokens=2000,
+        trailing_max_tokens=2000,
         separators=load_chunk_separators(),
     )
     # The drawing atom must appear in full, not half-cut.
@@ -155,7 +157,8 @@ def test_table_surrounding_strips_other_tables_before_counting():
         block_content=block,
         span=span,
         tokenizer=tok,
-        leading_max_tokens=2000, trailing_max_tokens=2000,
+        leading_max_tokens=2000,
+        trailing_max_tokens=2000,
         separators=load_chunk_separators(),
     )
     # Sibling table must NOT appear in surrounding.
@@ -179,7 +182,8 @@ def test_table_surrounding_supports_cite_marker_and_strips_sibling_cites():
         block_content=block,
         span=span,
         tokenizer=tok,
-        leading_max_tokens=2000, trailing_max_tokens=2000,
+        leading_max_tokens=2000,
+        trailing_max_tokens=2000,
         separators=load_chunk_separators(),
     )
     assert "tb-other" not in surr["leading"]
@@ -209,7 +213,8 @@ def test_chunk_r_separators_env_drives_segment_boundary(monkeypatch):
         block_content=block,
         span=span,
         tokenizer=tok,
-        leading_max_tokens=12, trailing_max_tokens=12,
+        leading_max_tokens=12,
+        trailing_max_tokens=12,
         separators=seps,
     )
     # Leading should end at a '|' boundary (one whole segment), not be
@@ -236,7 +241,8 @@ def test_oversized_closest_segment_char_truncated():
         block_content=block,
         span=span,
         tokenizer=tok,
-        leading_max_tokens=200, trailing_max_tokens=200,
+        leading_max_tokens=200,
+        trailing_max_tokens=200,
         separators=load_chunk_separators(),
     )
     assert len(tok.encode(surr["leading"])) <= 200
@@ -256,7 +262,8 @@ def test_oversized_trailing_char_truncated_at_head():
         block_content=block,
         span=span,
         tokenizer=tok,
-        leading_max_tokens=200, trailing_max_tokens=200,
+        leading_max_tokens=200,
+        trailing_max_tokens=200,
         separators=load_chunk_separators(),
     )
     assert len(tok.encode(surr["trailing"])) <= 200
@@ -282,7 +289,8 @@ def test_drawing_surrounding_row_trims_oversized_json_table():
         block_content=block,
         span=span,
         tokenizer=tok,
-        leading_max_tokens=80, trailing_max_tokens=80,
+        leading_max_tokens=80,
+        trailing_max_tokens=80,
         separators=load_chunk_separators(),
     )
     # Result must be a complete (smaller) <table>...</table>, contain
@@ -314,7 +322,8 @@ def test_drawing_surrounding_row_trims_oversized_html_table():
         block_content=block,
         span=span,
         tokenizer=tok,
-        leading_max_tokens=120, trailing_max_tokens=120,
+        leading_max_tokens=120,
+        trailing_max_tokens=120,
         separators=load_chunk_separators(),
     )
     trailing = surr["trailing"]
@@ -344,7 +353,8 @@ def test_drawing_surrounding_char_trims_oversized_single_json_row():
         block_content=block,
         span=span,
         tokenizer=tok,
-        leading_max_tokens=90, trailing_max_tokens=90,
+        leading_max_tokens=90,
+        trailing_max_tokens=90,
         separators=load_chunk_separators(),
     )
 
@@ -375,7 +385,8 @@ def test_drawing_surrounding_char_trims_oversized_single_html_row():
         block_content=block,
         span=span,
         tokenizer=tok,
-        leading_max_tokens=100, trailing_max_tokens=100,
+        leading_max_tokens=100,
+        trailing_max_tokens=100,
         separators=load_chunk_separators(),
     )
 
@@ -463,7 +474,8 @@ def test_enrich_only_updates_enabled_modalities(tmp_path):
         blocks_path=str(tmp_path / f"{base}.blocks.jsonl"),
         enabled_modalities={"drawings"},
         tokenizer=_tokenizer(),
-        leading_max_tokens=2000, trailing_max_tokens=2000,
+        leading_max_tokens=2000,
+        trailing_max_tokens=2000,
     )
     assert counts["drawings"] == 1
     assert counts["tables"] == 0
@@ -522,7 +534,8 @@ def test_enrich_runs_even_when_llm_analyze_result_present(tmp_path):
         blocks_path=str(tmp_path / f"{base}.blocks.jsonl"),
         enabled_modalities={"drawings"},
         tokenizer=_tokenizer(),
-        leading_max_tokens=2000, trailing_max_tokens=2000,
+        leading_max_tokens=2000,
+        trailing_max_tokens=2000,
     )
     assert counts["drawings"] == 1
     payload = json.loads(drawings_path.read_text(encoding="utf-8"))
@@ -572,7 +585,8 @@ def test_enrich_does_not_cross_block_boundaries(tmp_path):
         blocks_path=str(tmp_path / f"{base}.blocks.jsonl"),
         enabled_modalities={"drawings"},
         tokenizer=_tokenizer(),
-        leading_max_tokens=2000, trailing_max_tokens=2000,
+        leading_max_tokens=2000,
+        trailing_max_tokens=2000,
     )
     payload = json.loads(drawings_path.read_text(encoding="utf-8"))
     surr = payload["drawings"]["dr-1"]["surrounding"]
@@ -626,9 +640,9 @@ def test_env_var_leading_and_trailing_budgets_apply_independently(
         tokenizer=tok,
     )
 
-    surr = json.loads(drawings_path.read_text(encoding="utf-8"))[
-        "drawings"
-    ]["dr-1"]["surrounding"]
+    surr = json.loads(drawings_path.read_text(encoding="utf-8"))["drawings"]["dr-1"][
+        "surrounding"
+    ]
     assert len(tok.encode(surr["leading"])) <= 5
     assert len(tok.encode(surr["trailing"])) <= 20
     # Trailing is allowed to use its larger budget, so it must be strictly

--- a/tests/test_parse_native_lightrag_e2e.py
+++ b/tests/test_parse_native_lightrag_e2e.py
@@ -74,9 +74,6 @@ class _MiniRag:
     """Just enough surface for parse_native + native_parser/docx adapter."""
 
     _persist_parsed_full_docs = LightRAG._persist_parsed_full_docs
-    _enrich_parsed_sidecars_with_surrounding = (
-        LightRAG._enrich_parsed_sidecars_with_surrounding
-    )
 
     def __init__(self, working_dir):
         self.working_dir = str(working_dir)
@@ -259,6 +256,18 @@ def test_native_lightrag_path_leaves_unknown_table_caption_empty(tmp_path, monke
         tables = json.loads(tables_path.read_text(encoding="utf-8"))
         table_entry = tables["tables"]["tb-doc-table-0001"]
         assert table_entry["caption"] == ""
+
+        # Surrounding is now backfilled at analyze_multimodal entry, not in
+        # parse_native — invoke the same routine directly to mirror that.
+        from lightrag.multimodal_context import enrich_sidecars_with_surrounding
+
+        enrich_sidecars_with_surrounding(
+            blocks_path=str(blocks_path),
+            enabled_modalities={"tables"},
+            tokenizer=rag.tokenizer,
+        )
+        tables = json.loads(tables_path.read_text(encoding="utf-8"))
+        table_entry = tables["tables"]["tb-doc-table-0001"]
         assert table_entry["surrounding"] == {
             "leading": "before\n",
             "trailing": "\nafter",
@@ -268,8 +277,11 @@ def test_native_lightrag_path_leaves_unknown_table_caption_empty(tmp_path, monke
 
 
 @pytest.mark.offline
-def test_native_parse_backfills_surrounding_for_all_sidecars(tmp_path, monkeypatch):
-    """Parse-stage sidecars should be self-contained before VLM analysis."""
+def test_analyze_entrypoint_backfills_surrounding_for_all_sidecars(
+    tmp_path, monkeypatch
+):
+    """Surrounding is backfilled at analyze_multimodal entry, covering native
+    parse output as well as any other sidecar-producing engine."""
 
     async def _run():
         input_dir = tmp_path / "input"
@@ -308,6 +320,23 @@ def test_native_parse_backfills_surrounding_for_all_sidecars(tmp_path, monkeypat
 
         blocks_path = Path(result["blocks_path"])
         base = str(blocks_path)[: -len(".blocks.jsonl")]
+
+        # Parse-time sidecars must NOT contain surrounding — that field is
+        # now produced at analyze_multimodal entry.
+        for root in ("drawings", "tables", "equations"):
+            payload = json.loads(Path(base + f".{root}.json").read_text("utf-8"))
+            for item in payload[root].values():
+                assert "surrounding" not in item
+
+        # Now invoke the same routine analyze_multimodal calls and verify
+        # all modalities get populated.
+        from lightrag.multimodal_context import enrich_sidecars_with_surrounding
+
+        enrich_sidecars_with_surrounding(
+            blocks_path=str(blocks_path),
+            enabled_modalities={"drawings", "tables", "equations"},
+            tokenizer=rag.tokenizer,
+        )
         for root in ("drawings", "tables", "equations"):
             payload = json.loads(Path(base + f".{root}.json").read_text("utf-8"))
             items = payload[root]


### PR DESCRIPTION
## Summary

- Move sidecar `surrounding` backfill from parse-time to `analyze_multimodal` entry so every sidecar-producing engine (native, MinerU, Docling, and pre-existing LightRAG documents reused from disk) gets covered through a single entrypoint.
- Add `SURROUNDING_LEADING_MAX_TOKENS` / `SURROUNDING_TRAILING_MAX_TOKENS` env vars (default 2000 each) — leading and trailing halves are now independently tunable.

## Motivation

`surrounding` (`{leading, trailing}` text around each sidecar item) is consumed exclusively when `analyze_multimodal` assembles VLM and extract prompts — chunking does not read it. Today it is computed at parse-time in two narrow places:

- `parse_native` for the pending-parse `.docx` branch.
- `_write_lightrag_document_from_content_list` (MinerU / Docling content-list path).

The `FULL_DOCS_FORMAT_LIGHTRAG` branch — used when the user uploads a pre-built LightRAG document or reuses sidecars from a previous run — never triggered enrichment, so `surrounding` ended up missing and VLM prompts received only `\"n/a\"`. The per-half budget was also hardcoded to 2000 with no way to tune.

Running enrichment once at `analyze_multimodal` entry fixes both: every sidecar source flows through the same call, and the per-half budget is now driven by env vars.

## What's changed

- **`lightrag/multimodal_context.py`**
  - `build_surrounding` / `enrich_sidecars_with_surrounding`: replace single `max_tokens=2000` with independent `leading_max_tokens` / `trailing_max_tokens` (each accepting `None` to read env).
  - New `_resolve_surrounding_budget` helper reads `SURROUNDING_LEADING_MAX_TOKENS` / `SURROUNDING_TRAILING_MAX_TOKENS` (invalid values log a warning and fall back to the default 2000).
  - Export `DEFAULT_SURROUNDING_MAX_TOKENS`.

- **`lightrag/pipeline.py`**
  - Delete the private `_enrich_parsed_sidecars_with_surrounding` method and both parse-time call sites.
  - In `analyze_multimodal`, right after the opt-in / sidecar mismatch diagnostics, derive `enabled_modalities` from `process_opts` and call `enrich_sidecars_with_surrounding` exactly once. Wrapped in its own try/except so enrichment failures never block VLM analysis.

- **`env.example`** — document the two new variables under the multimodal section.

- **Tests**
  - `test_multimodal_surrounding_context.py`: rename `max_tokens=` to the per-half pair (14 call sites); add two new tests covering asymmetric env budgets and invalid-value fallback.
  - `test_parse_native_lightrag_e2e.py`: parse-stage sidecars now explicitly assert no `surrounding` field, then exercise the enrichment routine and re-assert. Rename the test to reflect the new responsibility split.
  - `test_document_routes_docx_archive.py`: drop the now-deleted helper reference.

## What's broken / behavior changes

- **Parse artifacts no longer carry `surrounding`.** Any downstream that reads sidecar JSON directly *before* `analyze_multimodal` (production code: none; only tests) will see no `surrounding` key. Tests have been updated accordingly.
- **Modality-gated enrichment.** When `process_options` opts into no `i`/`t`/`e` modality, `analyze_multimodal` returns early and `surrounding` is not written. This is intentional — the only consumer is the gated VLM/extract path; re-enabling a modality and re-running analyze backfills idempotently on the next pass.
- Idempotency preserved: `enrich_sidecars_with_surrounding` overwrites unconditionally, but `build_surrounding` is pure so repeated runs over unchanged blocks produce byte-identical output.

## How it works

```
parse_worker → analyze_worker (NEW: enrich here) → process_worker
                ├ derive enabled_modalities from process_opts
                ├ enrich_sidecars_with_surrounding (covers all engines)
                └ run VLM / extract per modality (reads the just-written
                  surrounding via _surrounding_value)
```

## Test plan

- [x] `./scripts/test.sh tests/test_multimodal_surrounding_context.py` — 21 passed (incl. 2 new env-var tests)
- [x] `./scripts/test.sh tests/test_parse_native_lightrag_e2e.py` — 5 passed
- [x] `./scripts/test.sh tests/test_pipeline_analyze_multimodal.py` — 12 passed
- [x] `./scripts/test.sh tests/test_document_routes_docx_archive.py` — 44 passed
- [x] `./scripts/test.sh tests` — 1258 passed (full offline suite)
- [x] `ruff check lightrag/multimodal_context.py lightrag/pipeline.py tests/test_multimodal_surrounding_context.py tests/test_parse_native_lightrag_e2e.py tests/test_document_routes_docx_archive.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)