### PR TITLE
✨ feat(sidecar): shorten item IDs by stripping doc- prefix

### DIFF
--- a/docs/LightRAGSidecarFormat-zh.md
+++ b/docs/LightRAGSidecarFormat-zh.md
@@ -74,7 +74,7 @@ inputs/space1/__parsed__/<规范文件名>.parsed/
 | `asset_dir` | `bool` | 是否存在`blocks.assets`资源目录 |
 | `split_option` | `object` | 文件提取时的分块参数。此字段留给文件提取引擎自己记录和使用 |
 | `blocks` | `int` | content 行数（不含 meta） |
-| `doc_id` | `"doc-<md5>"` | 文档全局 id，作为 sidecar item id 的前缀 |
+| `doc_id` | `"doc-<md5>"` | 文档全局 id。sidecar item id（`dr-/tb-/eq-`）使用 `doc_id` 去掉 `doc-` 前缀后的哈希部分，以缩短嵌入正文中的占位标签 |
 | `parse_engine` | `str` | 解析引擎`native/mineru/docling/legacy` |
 | `parse_time` | `str` | 解析完成时间; 格式：ISO-8601 UTC |
 | `doc_title` | `str` | 文档标题（通常为首个 H1）；可选 |
@@ -153,7 +153,7 @@ inputs/space1/__parsed__/<规范文件名>.parsed/
 
 ```json
 {
-  "id": "dr-doc-f1bee60173d067d88595c00e7d9b0ce5-0004",
+  "id": "dr-f1bee60173d067d88595c00e7d9b0ce5-0004",
   "blockid": "2f52b70839d13a936d97955916820147",
   "heading": "2.3 结构尺寸及重量",
   "format": "png",
@@ -178,7 +178,7 @@ inputs/space1/__parsed__/<规范文件名>.parsed/
 
 | 字段 | 说明 |
 |---|---|
-| `id` | `dr-<doc_id>-<NNNN>` 形式 |
+| `id` | `dr-<doc_hash>-<NNNN>` 形式（`doc_hash` 为 `doc_id` 去掉 `doc-` 前缀后的 32 位 md5） |
 | `blockid` | 指向产生该图形的 content 行 |
 | `heading` | 所在章节标题 |
 | `format` | 原始扩展名（去点）：`png` / `jpeg` / `gif` / `webp` / `wmf` / `emf` / … |
@@ -197,7 +197,7 @@ inputs/space1/__parsed__/<规范文件名>.parsed/
 
 ```json
 {
-  "id": "tb-doc-f1bee60173d067d88595c00e7d9b0ce5-0007",
+  "id": "tb-f1bee60173d067d88595c00e7d9b0ce5-0007",
   "blockid": "3f33897b5e105d254addc655f1efbf8c",
   "heading": "2.4.4 温度-湿度-高度（随系统进行）",
   "dimension": [16, 8],
@@ -224,7 +224,7 @@ tables.json 文件的 `blockid` `heading` `surrounding` `llm_analyze_result` 字
 
 | 字段 | 说明 |
 |---|---|
-| `id` | `tb-<doc_id>-<NNNN>` 形式 |
+| `id` | `tb-<doc_hash>-<NNNN>` 形式（`doc_hash` 为 `doc_id` 去掉 `doc-` 前缀后的 32 位 md5） |
 | `dimension` | 整数数组：`[num_rows, num_cols]`，包含表头行 |
 | `format` | `"json"` (二维数组) 或 `"html"` (负载 `<table>…</table>` 片段，含起止标签) |
 | `content` | 字符串：表格正文，按 `format` 决定结构；这是后续多模态 chunk 真正使用的字符串。 |
@@ -238,7 +238,7 @@ tables.json 文件的 `blockid` `heading` `surrounding` `llm_analyze_result` 字
 
 ```json
 {
-  "id": "eq-doc-f1bee60173d067d88595c00e7d9b0ce5-0001",
+  "id": "eq-f1bee60173d067d88595c00e7d9b0ce5-0001",
   "blockid": "2f52b70839d13a936d97955916820147",
   "heading": "2.3 结构尺寸及重量",
   "format": "latex",
@@ -264,9 +264,8 @@ equations.json 文件的 `blockid` `heading` `surrounding` `llm_analyze_result` 
 
 | 字段 | 说明 |
 |---|---|
-| `id` | `tb-<doc_id>-<NNNN>` 形式 |
-| `dimension` | 整数数组：`[num_rows, num_cols]`，包含表头行 |
-| `format` | `"json"` (二维数组) 或 `"html"` (负载 `<table>…</table>` 片段，含起止标签) |
+| `id` | `eq-<doc_hash>-<NNNN>` 形式（`doc_hash` 为 `doc_id` 去掉 `doc-` 前缀后的 32 位 md5） |
+| `format` | 固定为 `"latex"` |
 | `content` | 字符串：是**原始** LaTeX（可能包含 Unicode 运算符、外层 `\[ \]`），不包含两头的`$`分割符；模态分析阶段直接读这里 |
 | `llm_analyze_result.equation` | 字符串：是大模型输出的**规范化**后的 LaTeX公式（外层 `$ / \[ \] / equation` 环境，Unicode 转 LaTeX，不包含联投的`$`分割符），这是后续多模态 chunk 真正使用的字符串； |
 

--- a/lightrag/native_parser/docx/lightrag_adapter.py
+++ b/lightrag/native_parser/docx/lightrag_adapter.py
@@ -238,7 +238,7 @@ def _parse_docx_sync(
             nonlocal local_table_count
             local_table_count += 1
             idx = table_idx + local_table_count
-            tb_id = f"tb-{doc_id}-{idx:04d}"
+            tb_id = f"tb-{doc_id.removeprefix('doc-')}-{idx:04d}"
             caption = ""
             table_json = match.group(1)
             try:
@@ -292,7 +292,7 @@ def _parse_docx_sync(
 
             local_equation_count += 1
             idx = equation_idx + local_equation_count
-            eq_id = f"eq-{doc_id}-{idx:04d}"
+            eq_id = f"eq-{doc_id.removeprefix('doc-')}-{idx:04d}"
             caption = ""
             pending_equations[eq_id] = {
                 "id": eq_id,
@@ -314,7 +314,7 @@ def _parse_docx_sync(
             idx = drawing_idx + local_drawing_count
             placeholder = match.group(0)
             attrs = parse_drawing_attributes(placeholder)
-            dr_id = f"dr-{doc_id}-{idx:04d}"
+            dr_id = f"dr-{doc_id.removeprefix('doc-')}-{idx:04d}"
             caption = ""
             path_val = attrs.get("path", "") or ""
             src_val = attrs.get("src", "") or ""

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -2926,7 +2926,10 @@ class _PipelineMixin:
 
             if item_type == "equation":
                 equation_idx += 1
-                eq_id = str(item.get("id") or f"eq-{doc_id}-{equation_idx:04d}")
+                eq_id = str(
+                    item.get("id")
+                    or f"eq-{doc_id.removeprefix('doc-')}-{equation_idx:04d}"
+                )
                 caption = str(item.get("caption") or f"公式{equation_idx}")
                 footnotes = _to_list_str(
                     item.get("equation_footnote") or item.get("footnotes")
@@ -2956,7 +2959,10 @@ class _PipelineMixin:
 
             if item_type == "table":
                 table_idx += 1
-                table_id = str(item.get("id") or f"tb-{doc_id}-{table_idx:04d}")
+                table_id = str(
+                    item.get("id")
+                    or f"tb-{doc_id.removeprefix('doc-')}-{table_idx:04d}"
+                )
                 caption = str(item.get("caption") or f"表格{table_idx}")
                 table_caption = _to_list_str(item.get("table_caption"))
                 if table_caption and not item.get("caption"):
@@ -3001,7 +3007,10 @@ class _PipelineMixin:
 
             if item_type in {"image", "picture", "drawing"}:
                 drawing_idx += 1
-                drawing_id = str(item.get("id") or f"dr-{doc_id}-{drawing_idx:04d}")
+                drawing_id = str(
+                    item.get("id")
+                    or f"dr-{doc_id.removeprefix('doc-')}-{drawing_idx:04d}"
+                )
                 image_caption = _to_list_str(
                     item.get("image_caption") or item.get("captions")
                 )

--- a/tests/test_multimodal_surrounding_context.py
+++ b/tests/test_multimodal_surrounding_context.py
@@ -42,39 +42,41 @@ def _tokenizer() -> Tokenizer:
 def test_find_target_span_drawing_in_mixed_content():
     content = (
         "leading text. "
-        '<drawing id="dr-doc-0001" format="png" path="img.png" src="img" /> '
+        '<drawing id="dr-abcd-0001" format="png" path="img.png" src="img" /> '
         "trailing text."
     )
-    span = find_target_span("drawings", "dr-doc-0001", content)
+    span = find_target_span("drawings", "dr-abcd-0001", content)
     assert span is not None
     start, end = span
-    assert content[start:end].startswith('<drawing id="dr-doc-0001"')
+    assert content[start:end].startswith('<drawing id="dr-abcd-0001"')
     assert content[start:end].endswith("/>")
 
 
 @pytest.mark.offline
 def test_find_target_span_table_with_id_anywhere_in_attrs():
     # id is not first attribute — locator must still find it.
-    content = 'before <table format="json" id="tb-doc-0007">[[1,2],[3,4]]</table> after'
-    span = find_target_span("tables", "tb-doc-0007", content)
+    content = (
+        'before <table format="json" id="tb-abcd-0007">[[1,2],[3,4]]</table> after'
+    )
+    span = find_target_span("tables", "tb-abcd-0007", content)
     assert span is not None
     snippet = content[span[0] : span[1]]
     assert snippet.endswith("</table>")
-    assert 'id="tb-doc-0007"' in snippet
+    assert 'id="tb-abcd-0007"' in snippet
 
 
 @pytest.mark.offline
 def test_find_target_span_table_cite_marker():
-    content = 'before <cite type="table" refid="tb-doc-0007">表1</cite> after'
-    span = find_target_span("tables", "tb-doc-0007", content)
+    content = 'before <cite type="table" refid="tb-abcd-0007">表1</cite> after'
+    span = find_target_span("tables", "tb-abcd-0007", content)
     assert span is not None
     assert content[span[0] : span[1]].startswith("<cite")
 
 
 @pytest.mark.offline
 def test_find_target_span_equation():
-    content = 'A <equation id="eq-doc-0002" format="latex">x^2</equation> B'
-    span = find_target_span("equations", "eq-doc-0002", content)
+    content = 'A <equation id="eq-abcd-0002" format="latex">x^2</equation> B'
+    span = find_target_span("equations", "eq-abcd-0002", content)
     assert span is not None
     assert content[span[0] : span[1]].endswith("</equation>")
 

--- a/tests/test_parse_native_lightrag_e2e.py
+++ b/tests/test_parse_native_lightrag_e2e.py
@@ -254,7 +254,7 @@ def test_native_lightrag_path_leaves_unknown_table_caption_empty(tmp_path, monke
 
         tables_path = blocks_path.with_suffix("").with_suffix(".tables.json")
         tables = json.loads(tables_path.read_text(encoding="utf-8"))
-        table_entry = tables["tables"]["tb-doc-table-0001"]
+        table_entry = tables["tables"]["tb-table-0001"]
         assert table_entry["caption"] == ""
 
         # Surrounding is now backfilled at analyze_multimodal entry, not in
@@ -267,7 +267,7 @@ def test_native_lightrag_path_leaves_unknown_table_caption_empty(tmp_path, monke
             tokenizer=rag.tokenizer,
         )
         tables = json.loads(tables_path.read_text(encoding="utf-8"))
-        table_entry = tables["tables"]["tb-doc-table-0001"]
+        table_entry = tables["tables"]["tb-table-0001"]
         assert table_entry["surrounding"] == {
             "leading": "before\n",
             "trailing": "\nafter",

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -2320,10 +2320,10 @@ def test_write_lightrag_document_preserves_headings_and_table_dimensions(
         content_blocks = blocks[1:]
         body_block = next(x for x in content_blocks if x["content"] == "这是正文段落。")
         table_block = next(
-            x for x in content_blocks if 'refid="tb-doc-1-0001"' in x["content"]
+            x for x in content_blocks if 'refid="tb-1-0001"' in x["content"]
         )
         image_block = next(
-            x for x in content_blocks if 'id="dr-doc-1-0001"' in x["content"]
+            x for x in content_blocks if 'id="dr-1-0001"' in x["content"]
         )
 
         assert body_block["heading"] == "1.1 研究背景"
@@ -2333,7 +2333,7 @@ def test_write_lightrag_document_preserves_headings_and_table_dimensions(
 
         base = str(blocks_path)[: -len(".blocks.jsonl")]
         tables = json.loads(Path(base + ".tables.json").read_text(encoding="utf-8"))
-        table_entry = tables["tables"]["tb-doc-1-0001"]
+        table_entry = tables["tables"]["tb-1-0001"]
         assert table_entry["heading"] == "1.1 研究背景"
         assert table_entry["dimension"] == [2, 3]
         assert table_entry["format"] == "json"
@@ -2343,7 +2343,7 @@ def test_write_lightrag_document_preserves_headings_and_table_dimensions(
         ]
 
         drawings = json.loads(Path(base + ".drawings.json").read_text(encoding="utf-8"))
-        assert drawings["drawings"]["dr-doc-1-0001"]["heading"] == "1.1 研究背景"
+        assert drawings["drawings"]["dr-1-0001"]["heading"] == "1.1 研究背景"
 
         full_doc = await rag.full_docs.get_by_id("doc-1")
         assert full_doc["lightrag_document_path"] == (
@@ -2863,12 +2863,12 @@ def test_strip_internal_multimodal_markup_cleans_table_id():
     )
 
     source = (
-        '<table id="tb-doc-1-0001" format="json" caption="Indicator metrics">'
+        '<table id="tb-1-0001" format="json" caption="Indicator metrics">'
         '[["a","b"],["1","2"]]'
         "</table>"
     )
     cleaned = strip_internal_multimodal_markup_for_extraction(source)
-    assert "tb-doc-1-0001" not in cleaned
+    assert "tb-1-0001" not in cleaned
     assert 'format="json"' in cleaned
     assert 'caption="Indicator metrics"' in cleaned
     # Row body preserved.


### PR DESCRIPTION
## Summary

- Sidecar item IDs (`dr-/tb-/eq-`) now use only the 32-char md5 portion of `doc_id` instead of the full `doc-<md5>` form — IDs shrink from `dr-doc-<md5>-NNNN` to `dr-<md5>-NNNN`, trimming 4 chars off every inline placeholder tag in `blocks.jsonl`.
- All three extractor write paths updated: native (`lightrag_adapter.py`) plus the shared mineru/docling fallback in `pipeline.py`.
- Docs (`LightRAGSidecarFormat-zh.md`) and unit tests synced; downstream readers (`enrich_sidecars_with_surrounding`, `strip_internal_multimodal_markup_for_extraction`) are already prefix-agnostic, so existing on-disk sidecars keep working.

## Test plan

- [x] `pytest tests/test_multimodal_surrounding_context.py tests/test_parse_native_lightrag_e2e.py -q` — 26 passed.
- [x] `pytest tests/test_pipeline_release_closure.py -q` — 56 passed, 1 xfailed.
- [x] Static grep: no remaining `f"dr-{doc_id}` / `f"tb-{doc_id}` / `f"eq-{doc_id}` patterns; no `dr-doc-` / `tb-doc-` / `eq-doc-` literals in `lightrag/`, `tests/`, or `docs/LightRAGSidecarFormat-zh.md`.
- [ ] Manual end-to-end on a docx with figures/tables/equations: verify `blocks.jsonl` placeholders, sidecar JSON keys, and `surrounding.leading/trailing` filled correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)