### PR TITLE
feat(multimodal): strip parser-internal markup from sidecar surrounding

### DIFF
--- a/docs/LightRAGSidecarFormat-zh.md
+++ b/docs/LightRAGSidecarFormat-zh.md
@@ -273,12 +273,19 @@ equations.json 文件的 `blockid` `heading` `surrounding` `llm_analyze_result` 
 
 ## 七、surrounding
 
-`surrounding.leading` 和 `surrounding.trailing` 是 sidecar item 的可分析上下文窗口，目的是提供图片、表格和公式所在段落的上下文信息，提高多模态分析的质量。
+`surrounding.leading` 和 `surrounding.trailing` 是 sidecar item 的可分析上下文窗口，目的是提供图片、表格和公式所在段落的上下文信息，提高多模态分析的质量。**surrounding内容有LightRAG在分析阶段自动注入，不需要在文档解析引擎中主动写入sidecar文件中**。以下是surrounding内容的生成逻辑：
 
 - 取自同一 `blockid` 对应的 content 行文本，以多模态占位标签的位置为切分点；
-- 每一侧不超过 `2000` tokens（按 tokenizer 截断，倾向保留靠近目标的句子）；
-- 文本中保留**同行其他**多模态对象的占位标签，这让模型能感知"图 1 之后还有公式 1"这种上下文；
-- 当目标对象本身位于 block 起点 / 终点时，对应一侧为 `""` 而不是 `"n/a"`（提示词组装时再把空字符串显示为 `n/a`）。
+- 每一侧的 token 上限由环境变量 `SURROUNDING_LEADING_MAX_TOKENS` / `SURROUNDING_TRAILING_MAX_TOKENS` 控制（缺省 `2000`，可独立调整）；按 tokenizer 截断，倾向保留靠近目标的句子；
+- 文本中保留**同行其他**多模态对象的占位标签，这让模型能感知"图 1 之后还有公式 1"这种上下文；但解析器内部标识符（`id` / `path` / `src` / `refid`）已被 `strip_internal_multimodal_markup_for_extraction` 剥离 —— 与 chunk content 实体抽取前的清理一致，避免噪声进入 VLM/LLM prompt。具体清理规则：
+  - `<drawing id="dr-…" path="…" src="…" caption="Fig 1" />` → `<drawing caption="Fig 1" />`；**没有 caption 的 drawing 整段移除**（标签不再携带任何对模型可见的信息）；
+  - `<table id="tb-…" format="json" caption="…">rows</table>` → `<table format="json" caption="…">rows</table>`；
+  - `<equation id="eq-…" format="latex">body</equation>` → `<equation format="latex">body</equation>`；
+  - `<cite type="table" refid="tb-…">表 1</cite>` → `<cite type="table">表 1</cite>`；`<cite type="equation" refid="eq-…">公式 2</cite>` → `<cite type="equation">公式 2</cite>`。仅删 `refid` 属性，保留 `<cite type="…">…</cite>` 包装 —— 让 VLM/LLM 能识别"这是对其他表/公式的引用"而非普通的文本，同时屏蔽 LLM 看不到的解析器内部 id；
+    - 例外：`tables.json` 类型的 surrounding 在 strip 之前先走 `remove_table_tags`，把所有 `<cite type="table">` 整段移除（分析目标表时不希望被对其他表的悬挂引用干扰）；
+- 清理发生在 token 预算截断**之前**：token 数按"LLM 实际看到的内容"统计，且截断点不会落到未清理的 `id="…"` 属性中间，避免标签结构残缺；
+- 当目标对象本身位于 block 起点 / 终点时，对应一侧为 `""` 而不是 `"n/a"`（提示词组装时再把空字符串显示为 `n/a`）；
+- `enrich_sidecars_with_surrounding` 是幂等的：每次 `analyze_multimodal` 入口都会重新计算并覆盖 `surrounding`，因此修改 `SURROUNDING_LEADING_MAX_TOKENS` / `SURROUNDING_TRAILING_MAX_TOKENS` 后无需手动清理 sidecar，重新执行多模态分析即可按新预算重写。
 
 ## 八、positions
 

--- a/lightrag/chunk_schema.py
+++ b/lightrag/chunk_schema.py
@@ -117,6 +117,15 @@ _CITE_RE = re.compile(
     flags=re.IGNORECASE | re.DOTALL,
 )
 
+# Inner attribute stripper used when the caller wants to *preserve* the
+# `<cite type="…">…</cite>` wrapper but drop the parser-internal `refid`.
+# Matches ` refid="…"` (leading whitespace + quoted value) so the
+# surrounding attribute layout (e.g. `type="table"`) stays intact.
+_CITE_REFID_ATTR_RE = re.compile(
+    r'\s+refid\s*=\s*"[^"]*"',
+    flags=re.IGNORECASE,
+)
+
 # Self-closing `<drawing ...>` placeholder.  We keep `caption` (visible) and
 # drop `id`, `path`, `src`, `format`, etc.  Tags without any caption are
 # removed entirely so they don't pollute extraction input.
@@ -196,16 +205,17 @@ def _replace_table(match: re.Match[str]) -> str:
     return f"<table{_format_attrs(keep)}>{body}</table>"
 
 
-def strip_internal_multimodal_markup_for_extraction(content: str) -> str:
+def strip_internal_multimodal_markup_for_extraction(
+    content: str, *, keep_cite_tag: bool = False
+) -> str:
     """Strip parser-internal identifiers from a chunk content string.
 
     Only the entity-extraction prompt should receive the cleaned form;
     callers must NOT mutate the stored chunk ``content`` so query-time
     citations still resolve back to the original parser output.
 
-    Transformations:
+    Transformations always applied:
 
-    - ``<cite type="…" refid="…">Table 1</cite>`` → ``Table 1``
     - ``<drawing id="dr-…" path="…" src="…" caption="Fig 1" />``
         → ``<drawing caption="Fig 1" />``
         (drops the entire tag when no caption is present)
@@ -213,10 +223,26 @@ def strip_internal_multimodal_markup_for_extraction(content: str) -> str:
         → ``<table format="json" caption="…">rows</table>``
     - ``<equation id="eq-…" format="latex">…</equation>``
         → ``<equation format="latex">…</equation>``
+
+    Cite-tag handling depends on ``keep_cite_tag``:
+
+    - ``keep_cite_tag=False`` (default — entity-extraction path):
+      ``<cite type="…" refid="…">Table 1</cite>`` → ``Table 1``.  The
+      cite wrapper is dropped so the extractor does not surface it as
+      a noisy structural entity.
+    - ``keep_cite_tag=True`` (multimodal-analysis surrounding path):
+      ``<cite type="table" refid="…">Table 1</cite>`` →
+      ``<cite type="table">Table 1</cite>``.  Only the internal
+      ``refid`` is removed; the wrapper survives so the VLM/LLM can
+      tell visible reference labels (e.g. "Table 1") apart from inline
+      prose.
     """
     if not content:
         return content
-    cleaned = _CITE_RE.sub(lambda m: m.group(1), content)
+    if keep_cite_tag:
+        cleaned = _CITE_REFID_ATTR_RE.sub("", content)
+    else:
+        cleaned = _CITE_RE.sub(lambda m: m.group(1), content)
     cleaned = _DRAWING_RE.sub(_replace_drawing, cleaned)
     cleaned = _TABLE_RE.sub(_replace_table, cleaned)
     cleaned = _EQUATION_RE.sub(_replace_equation, cleaned)

--- a/lightrag/multimodal_context.py
+++ b/lightrag/multimodal_context.py
@@ -36,6 +36,29 @@ entries the table tags are preserved when they fit; oversized JSON or
 HTML tables are row-trimmed (tail rows for leading, head rows for
 trailing) so the surrounding keeps the rows physically closest to the
 target.
+
+Parser-internal identifiers (``id`` / ``path`` / ``src`` / ``refid``) are
+stripped from the candidate text via
+:func:`lightrag.chunk_schema.strip_internal_multimodal_markup_for_extraction`
+**before** atomization and token-budgeted truncation.  This mirrors the
+treatment given to chunk content prior to entity extraction (see
+``lightrag.operate._process_single_content``) and ensures the
+multimodal analysis prompt never sees those internal markers.  Cleaning
+before truncation also guarantees the truncation point can never land
+inside an ``id="…"`` attribute and leave a malformed tag the strip
+regex would no longer recognize.
+
+Unlike the entity-extraction call site, the surrounding path invokes
+the cleaner with ``keep_cite_tag=True``: parser-internal ``refid`` is
+removed but the ``<cite type="…">…</cite>`` wrapper is preserved so the
+VLM/LLM can still tell a reference label apart from inline prose
+(e.g. ``<cite type="table">表1</cite>`` makes it obvious the visible
+text "表1" denotes another table elsewhere in the document, rather
+than appearing as an ordinary noun phrase).  Note this only affects
+``drawings.json`` / ``equations.json`` surroundings — ``tables.json``
+surroundings still drop all cite tags via :func:`remove_table_tags`
+because the target-table analysis should not be steered by dangling
+references to other tables.
 """
 
 from __future__ import annotations
@@ -47,6 +70,7 @@ import re
 from html import escape as html_escape
 from html import unescape as html_unescape
 from pathlib import Path
+from lightrag.chunk_schema import strip_internal_multimodal_markup_for_extraction
 from lightrag.constants import DEFAULT_R_SEPARATORS
 from lightrag.table_markup import (
     TABLE_TAG_RE,
@@ -448,13 +472,26 @@ def _build_leading(
     max_tokens: int,
     separators: list[str],
 ) -> str:
-    """Build the ``leading`` half: suffix of ``source`` within budget."""
+    """Build the ``leading`` half: suffix of ``source`` within budget.
+
+    ``source`` is cleaned via
+    :func:`lightrag.chunk_schema.strip_internal_multimodal_markup_for_extraction`
+    *before* atomization and token-budgeted accumulation, so parser-internal
+    identifiers (``id`` / ``path`` / ``src`` / ``refid``) never reach the
+    accumulated output and the token budget reflects what the LLM actually
+    sees.  Cleaning before truncation also prevents a truncation point from
+    landing inside an ``id="…"`` attribute and producing a malformed tag
+    that the strip regex would no longer recognize.
+    """
     if not source or max_tokens <= 0:
         return ""
     if kind == "tables":
         source = remove_table_tags(source)
         if not source:
             return ""
+    source = strip_internal_multimodal_markup_for_extraction(source, keep_cite_tag=True)
+    if not source:
+        return ""
     accumulated = ""
     atoms = _atomize(source)
     for atom_idx in range(len(atoms) - 1, -1, -1):
@@ -559,13 +596,20 @@ def _build_trailing(
     max_tokens: int,
     separators: list[str],
 ) -> str:
-    """Build the ``trailing`` half: prefix of ``source`` within budget."""
+    """Build the ``trailing`` half: prefix of ``source`` within budget.
+
+    See :func:`_build_leading` for the rationale behind stripping
+    parser-internal markers *before* atomization and truncation.
+    """
     if not source or max_tokens <= 0:
         return ""
     if kind == "tables":
         source = remove_table_tags(source)
         if not source:
             return ""
+    source = strip_internal_multimodal_markup_for_extraction(source, keep_cite_tag=True)
+    if not source:
+        return ""
     accumulated = ""
     atoms = _atomize(source)
     for atom_kind, atom_text in atoms:
@@ -760,6 +804,12 @@ def build_surrounding(
     ``leading_max_tokens`` and ``trailing_max_tokens`` are independent
     per-half caps so deployments can tune the two contexts separately
     via ``SURROUNDING_LEADING_MAX_TOKENS`` / ``SURROUNDING_TRAILING_MAX_TOKENS``.
+
+    The returned strings have parser-internal markers (``id`` / ``path``
+    / ``src`` / ``refid``) stripped — the cleaning happens before
+    token-budgeted truncation inside :func:`_build_leading` /
+    :func:`_build_trailing`, so the budget reflects the LLM-visible
+    content and truncation cannot leave malformed tags behind.
     """
     start, end = span
     leading_src = block_content[:start]

--- a/tests/test_multimodal_surrounding_context.py
+++ b/tests/test_multimodal_surrounding_context.py
@@ -118,7 +118,8 @@ def test_drawing_surrounding_kept_within_block_only():
 def test_equation_surrounding_protects_drawing_atom():
     tok = _tokenizer()
     block = (
-        '<drawing id="dr-prev" path="a.png" src="a" /> intro text. '
+        '<drawing id="dr-prev" path="a.png" src="a" caption="Fig 1" />'
+        " intro text. "
         '<equation id="eq-1" format="latex">a+b=c</equation>'
         " conclusion text."
     )
@@ -132,8 +133,9 @@ def test_equation_surrounding_protects_drawing_atom():
         trailing_max_tokens=2000,
         separators=load_chunk_separators(),
     )
-    # The drawing atom must appear in full, not half-cut.
-    assert '<drawing id="dr-prev"' in surr["leading"]
+    # Parser-internal id/path/src are stripped, but caption survives and
+    # the drawing tag stays atomic (not cut in half).
+    assert '<drawing caption="Fig 1" />' in surr["leading"]
     assert "/>" in surr["leading"]
     # No half-open drawing/equation tags
     assert surr["leading"].count("<drawing") == surr["leading"].count("/>")
@@ -650,6 +652,230 @@ def test_env_var_leading_and_trailing_budgets_apply_independently(
     # Trailing is allowed to use its larger budget, so it must be strictly
     # longer than leading here.
     assert len(surr["trailing"]) > len(surr["leading"])
+
+
+# ---------------------------------------------------------------------------
+# Parser-internal markup stripping inside surrounding (mirrors what
+# ``strip_internal_multimodal_markup_for_extraction`` does for chunk
+# content before entity extraction).  The cleaning happens *before*
+# token-budgeted truncation, so the saved budget reflects what the
+# LLM actually receives and a truncation point can never land inside
+# an unprocessed ``id="…"`` attribute.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.offline
+def test_surrounding_strips_drawing_id_path_src():
+    tok = _tokenizer()
+    block = (
+        "leading prose. "
+        '<drawing id="dr-x" path="figs/a.png" src="raw/a.png" caption="Fig 1" />'
+        " between. "
+        '<equation id="eq-target" format="latex">x=1</equation>'
+        " trailing prose."
+    )
+    span = find_target_span("equations", "eq-target", block)
+    surr = build_surrounding(
+        kind="equations",
+        block_content=block,
+        span=span,
+        tokenizer=tok,
+        leading_max_tokens=2000,
+        trailing_max_tokens=2000,
+        separators=load_chunk_separators(),
+    )
+    leading = surr["leading"]
+    assert '<drawing caption="Fig 1" />' in leading
+    assert 'id="dr-x"' not in leading
+    assert "path=" not in leading
+    assert "src=" not in leading
+
+
+@pytest.mark.offline
+def test_surrounding_strips_table_internal_id():
+    tok = _tokenizer()
+    block = (
+        "prefix. "
+        '<table id="tb-x" format="json" caption="Sales">[[1,2],[3,4]]</table>'
+        " between. "
+        '<drawing id="dr-target" caption="Fig 2" />'
+        " suffix."
+    )
+    span = find_target_span("drawings", "dr-target", block)
+    surr = build_surrounding(
+        kind="drawings",
+        block_content=block,
+        span=span,
+        tokenizer=tok,
+        leading_max_tokens=2000,
+        trailing_max_tokens=2000,
+        separators=load_chunk_separators(),
+    )
+    leading = surr["leading"]
+    assert '<table format="json" caption="Sales">[[1,2],[3,4]]</table>' in leading
+    assert 'id="tb-x"' not in leading
+
+
+@pytest.mark.offline
+def test_surrounding_strips_cite_refid_keeping_visible_text():
+    tok = _tokenizer()
+    block = (
+        "see "
+        '<cite type="table" refid="tb-x">Table 1</cite>'
+        " for details. "
+        '<drawing id="dr-target" caption="Fig 3" />'
+        " end."
+    )
+    span = find_target_span("drawings", "dr-target", block)
+    surr = build_surrounding(
+        kind="drawings",
+        block_content=block,
+        span=span,
+        tokenizer=tok,
+        leading_max_tokens=2000,
+        trailing_max_tokens=2000,
+        separators=load_chunk_separators(),
+    )
+    leading = surr["leading"]
+    # Surrounding path uses keep_cite_tag=True: the cite wrapper survives
+    # (so the VLM/LLM can tell "Table 1" is a reference to an external
+    # table, not inline prose) but the parser-internal refid is gone.
+    assert '<cite type="table">Table 1</cite>' in leading
+    assert "refid=" not in leading
+    assert "tb-x" not in leading
+
+
+@pytest.mark.offline
+def test_surrounding_keeps_equation_cite_tag_and_strips_refid():
+    """In production, equations without LaTeX content emit as
+    ``<cite type="equation" refid="eq-…">公式 N</cite>`` rather than a
+    full ``<equation>`` tag.  Surrounding must keep the wrapper so the
+    multimodal analyzer can recognize the visible label as an external
+    referent, not inline prose."""
+    tok = _tokenizer()
+    block = (
+        "see "
+        '<cite type="equation" refid="eq-y">公式 2</cite>'
+        " above. "
+        '<drawing id="dr-target" caption="Fig 4" />'
+        " end."
+    )
+    span = find_target_span("drawings", "dr-target", block)
+    surr = build_surrounding(
+        kind="drawings",
+        block_content=block,
+        span=span,
+        tokenizer=tok,
+        leading_max_tokens=2000,
+        trailing_max_tokens=2000,
+        separators=load_chunk_separators(),
+    )
+    leading = surr["leading"]
+    assert '<cite type="equation">公式 2</cite>' in leading
+    assert "refid=" not in leading
+    assert "eq-y" not in leading
+
+
+@pytest.mark.offline
+def test_strip_happens_before_budget_truncation():
+    """Regression guard for the strip-before-truncate ordering.
+
+    Constructs a leading source whose raw form (with id/path/src) exceeds
+    the budget while its stripped form fits.  If strip ran *after*
+    truncation, the budget would be measured against the bloated raw
+    string and the saved surrounding would be cut early (possibly mid-
+    attribute, leaving ``id="…`` residue).
+    """
+    tok = _tokenizer()
+    # Raw drawing tag including attrs (~67 chars), stripped form is
+    # just '<drawing caption="C" />' (~24 chars).  Budget at 30 sits
+    # between the two — raw is too big, stripped fits.
+    block = (
+        '<drawing id="dr-prev" path="some/long/path.png" src="raw/long/path.png"'
+        ' caption="C" />'
+        '<equation id="eq-1" format="latex">y</equation>'
+        " tail."
+    )
+    span = find_target_span("equations", "eq-1", block)
+    surr = build_surrounding(
+        kind="equations",
+        block_content=block,
+        span=span,
+        tokenizer=tok,
+        leading_max_tokens=30,
+        trailing_max_tokens=2000,
+        separators=load_chunk_separators(),
+    )
+    leading = surr["leading"]
+    # Whole stripped tag must be present — proves strip ran before
+    # the budget gate.
+    assert leading == '<drawing caption="C" />'
+    # And no parser-internal markers leaked through.
+    assert "id=" not in leading
+    assert "path=" not in leading
+    assert "src=" not in leading
+
+
+@pytest.mark.offline
+def test_enrich_overwrites_surrounding_when_budget_changes(tmp_path):
+    """Idempotency: rerunning with a smaller budget overwrites the prior
+    surrounding, demonstrating that ``SURROUNDING_LEADING_MAX_TOKENS``
+    changes propagate without needing to clear sidecars first."""
+    base = "doc"
+    blockid = "b1"
+    content = "L" * 500 + '<drawing id="dr-1" caption="C" />' + "T" * 500
+    _write_blocks(
+        tmp_path,
+        base,
+        [
+            {
+                "type": "content",
+                "blockid": blockid,
+                "format": "plain_text",
+                "content": content,
+                "heading": "h",
+                "parent_headings": [],
+                "level": 1,
+            }
+        ],
+    )
+    drawings_path = tmp_path / f"{base}.drawings.json"
+    _write_sidecar(
+        drawings_path,
+        "drawings",
+        {"dr-1": {"id": "dr-1", "blockid": blockid, "heading": "h"}},
+    )
+
+    tok = _tokenizer()
+    enrich_sidecars_with_surrounding(
+        blocks_path=str(tmp_path / f"{base}.blocks.jsonl"),
+        enabled_modalities={"drawings"},
+        tokenizer=tok,
+        leading_max_tokens=300,
+        trailing_max_tokens=300,
+    )
+    first = json.loads(drawings_path.read_text(encoding="utf-8"))["drawings"]["dr-1"][
+        "surrounding"
+    ]
+    first_leading_len = len(first["leading"])
+    first_trailing_len = len(first["trailing"])
+
+    enrich_sidecars_with_surrounding(
+        blocks_path=str(tmp_path / f"{base}.blocks.jsonl"),
+        enabled_modalities={"drawings"},
+        tokenizer=tok,
+        leading_max_tokens=50,
+        trailing_max_tokens=50,
+    )
+    second = json.loads(drawings_path.read_text(encoding="utf-8"))["drawings"]["dr-1"][
+        "surrounding"
+    ]
+    # New budget is smaller, so saved surrounding must shrink — proving
+    # the previous value was overwritten, not preserved.
+    assert len(second["leading"]) < first_leading_len
+    assert len(second["trailing"]) < first_trailing_len
+    assert len(tok.encode(second["leading"])) <= 50
+    assert len(tok.encode(second["trailing"])) <= 50
 
 
 @pytest.mark.offline

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -2876,6 +2876,62 @@ def test_strip_internal_multimodal_markup_cleans_table_id():
 
 
 @pytest.mark.offline
+def test_strip_internal_multimodal_markup_cite_default_unwraps():
+    """Default (keep_cite_tag=False) is the entity-extraction path: the
+    ``<cite>`` wrapper is stripped so the extractor does not surface it
+    as a structural entity — only the visible label survives.
+
+    The surrounding-context path overrides this via keep_cite_tag=True
+    (verified in tests/test_multimodal_surrounding_context.py); this
+    test pins the default to prevent regressions on the extraction
+    path when callers refactor the function signature.
+    """
+    from lightrag.chunk_schema import (
+        strip_internal_multimodal_markup_for_extraction,
+    )
+
+    source = (
+        'see <cite type="table" refid="tb-1-0001">表 1</cite> and '
+        '<cite type="equation" refid="eq-1-0002">公式 2</cite> for details.'
+    )
+    cleaned = strip_internal_multimodal_markup_for_extraction(source)
+    # Wrappers and ids both gone; visible labels survive as plain text.
+    assert "<cite" not in cleaned
+    assert "refid=" not in cleaned
+    assert "tb-1-0001" not in cleaned
+    assert "eq-1-0002" not in cleaned
+    assert "表 1" in cleaned
+    assert "公式 2" in cleaned
+
+
+@pytest.mark.offline
+def test_strip_internal_multimodal_markup_cite_keep_tag_strips_refid_only():
+    """keep_cite_tag=True (surrounding-context path): preserve the
+    ``<cite type="…">label</cite>`` wrapper but drop the parser-
+    internal ``refid``.  Other identifier transformations
+    (``<table id=…>`` / ``<drawing id=…/>`` / ``<equation id=…>``) are
+    unaffected by the flag and still apply."""
+    from lightrag.chunk_schema import (
+        strip_internal_multimodal_markup_for_extraction,
+    )
+
+    source = (
+        'see <cite type="table" refid="tb-1-0001">表 1</cite>; '
+        '<drawing id="dr-1" path="a.png" src="a" caption="Fig" />'
+    )
+    cleaned = strip_internal_multimodal_markup_for_extraction(
+        source, keep_cite_tag=True
+    )
+    assert '<cite type="table">表 1</cite>' in cleaned
+    assert "refid=" not in cleaned
+    assert "tb-1-0001" not in cleaned
+    # Non-cite cleaning still applies in this mode.
+    assert '<drawing caption="Fig" />' in cleaned
+    assert 'id="dr-1"' not in cleaned
+    assert "path=" not in cleaned
+
+
+@pytest.mark.offline
 def test_reinsert_without_process_options_skips_stale_mm_chunks(tmp_path):
     """Regression for the call-site fallback in process_single_document.
 


### PR DESCRIPTION
## Summary

Apply `strip_internal_multimodal_markup_for_extraction` to sidecar `surrounding` before token-budgeted truncation, mirroring the cleaning already done for chunk content before entity extraction. The multimodal analysis prompt no longer sees parser-internal `id` / `path` / `src` / `refid`.

## Motivation

- `analyze_multimodal` was sending sidecar `surrounding.leading` / `surrounding.trailing` to the VLM/LLM with parser-internal markers intact (e.g. `<drawing id="dr-..." path="..." src="...">`, `<cite type="table" refid="tb-...">`). The same markup is already cleaned for the entity-extraction prompt via `strip_internal_multimodal_markup_for_extraction`, but the multimodal path silently kept it.
- Tables in production appear in block content as `<cite type="table" refid="tb-...">表 N</cite>` (not as full `<table>` tags) — so cite is the **standard reference form**, and dropping it entirely (extraction-style) would lose the "this is a reference, not inline prose" signal. We want to keep the wrapper while removing the noisy `refid`.

## What's changed

- **`lightrag/chunk_schema.py`** — `strip_internal_multimodal_markup_for_extraction` gains a `keep_cite_tag: bool = False` parameter:
  - `False` (default): entity-extraction path, unchanged — cite wrapper is dropped, only visible label survives.
  - `True`: surrounding path — `<cite type="table" refid="tb-x">表 1</cite>` → `<cite type="table">表 1</cite>`. New `_CITE_REFID_ATTR_RE` handles refid-only stripping.
- **`lightrag/multimodal_context.py`** — `_build_leading` / `_build_trailing` call the cleaner with `keep_cite_tag=True`, *after* `remove_table_tags` (tables surroundings still strip all cites entirely so target-table analysis is not steered by sibling references). Stripping happens **before** `_atomize` / token-budgeted truncation, so:
  - the truncation point can never land inside an unprocessed `id="..."` attribute,
  - the token budget reflects what the LLM actually receives.
- **`tests/test_multimodal_surrounding_context.py`** — cite-keeping tests for table and equation cite forms; `strip_happens_before_budget_truncation` regression; `enrich_overwrites_surrounding_when_budget_changes` to pin idempotent re-runs covering env-var changes.
- **`tests/test_pipeline_release_closure.py`** — pins entity-extraction default (cite is unwrapped) and the surrounding flag (`keep_cite_tag=True` strips only refid).
- **`docs/LightRAGSidecarFormat-zh.md`** — §七 surrounding section updated to document the new cite handling, env-tunable budgets, strip-before-truncate ordering, and idempotency.

## What's broken / how it works

- `enrich_sidecars_with_surrounding` remains idempotent: `item["surrounding"]` is unconditionally overwritten; changing `SURROUNDING_LEADING_MAX_TOKENS` / `SURROUNDING_TRAILING_MAX_TOKENS` and re-running `analyze_multimodal` propagates the new budget without manual cache invalidation (covered by `test_enrich_overwrites_surrounding_when_budget_changes`).
- Existing tables-type surrounding behavior is preserved (`remove_table_tags` removes all `<table>` and `<cite type="table">` before strip).
- Entity-extraction path is unchanged — `keep_cite_tag` defaults to `False` and `operate.py` still calls the function positionally.

## Test plan

- [x] `./scripts/test.sh tests/test_multimodal_surrounding_context.py` — 27/27 passed
- [x] `./scripts/test.sh tests/test_pipeline_release_closure.py` — including 3 new strip tests
- [x] `./scripts/test.sh tests/test_pipeline_analyze_multimodal.py` — 12/12 passed
- [x] `./scripts/test.sh tests` — full regression: **1266 passed**, 0 failed, 1 skipped, 31 deselected, 1 xfailed
- [x] `ruff check lightrag/chunk_schema.py lightrag/multimodal_context.py tests/test_multimodal_surrounding_context.py tests/test_pipeline_release_closure.py` — clean