### PR TITLE
✨ feat(extract): enforce MAX_EXTRACT_INPUT_TOKENS for analyze & gleaning

### DIFF
--- a/env.example
+++ b/env.example
@@ -265,13 +265,6 @@ CHUNK_P_SIZE=2000
 ### below must be configured before server startup.
 # LIGHTRAG_PARSER=docx:native
 
-### Multimodal surrounding-context budget (per-half token cap for the
-### `leading` / `trailing` text injected into VLM and extract prompts).
-### Computed at analyze_multimodal entry; the two halves are independent
-### so deployments can bias context forward or backward as needed.
-# SURROUNDING_LEADING_MAX_TOKENS=2000
-# SURROUNDING_TRAILING_MAX_TOKENS=2000
-
 ### Async parser service protocol (optional)
 ### Configure these when using remote MinerU/Docling async services
 # MINERU_ENDPOINT=http://localhost:8000/api/v1/task
@@ -308,6 +301,13 @@ CHUNK_P_SIZE=2000
 # SUMMARY_CONTEXT_SIZE=12000
 ### Maximum token size allowed for entity extraction input context
 # MAX_EXTRACT_INPUT_TOKENS=20480
+
+### Multimodal surrounding-context budget (per-half token cap for the
+### `leading` / `trailing` text injected into VLM and extract prompts).
+### Computed at analyze_multimodal entry; the two halves are independent
+### so deployments can bias context forward or backward as needed.
+# SURROUNDING_LEADING_MAX_TOKENS=2000
+# SURROUNDING_TRAILING_MAX_TOKENS=2000
 
 ### Per-response cap on total entity+relationship rows/records emitted by the LLM
 # MAX_EXTRACTION_RECORDS=100

--- a/lightrag/multimodal_context.py
+++ b/lightrag/multimodal_context.py
@@ -789,6 +789,70 @@ def _resolve_surrounding_budget(
     return leading, trailing
 
 
+_CONTENT_TRUNCATION_MARKER = (
+    "\n<!-- content truncated from {original} to {final} tokens, head preserved -->"
+)
+
+
+def trim_content_to_budget(
+    content: str,
+    *,
+    kind: str,
+    max_tokens: int,
+    tokenizer: Tokenizer | None,
+) -> tuple[str, bool]:
+    """Trim sidecar ``content`` to fit within ``max_tokens``, preserving the head.
+
+    Used by ``analyze_multimodal`` to keep the EXTRACT-role prompt within
+    :data:`lightrag.constants.DEFAULT_MAX_EXTRACT_INPUT_TOKENS`.  Only ``content``
+    is compressed — surrounding/captions/footnotes already have their own caps
+    and the prompt template is fixed.
+
+    Strategy:
+      - ``tables`` (``<table>…</table>`` wrapped): row-aware trim via
+        :func:`_row_trim_table_trailing` (keep head rows / first k <tr>);
+        falls back to ``_char_fallback_*`` (still ``<table>``-wrapped) when
+        no single row fits.  Non-``<table>`` content falls through to char
+        trim from the tail.
+      - ``equations`` / other: :func:`_char_trim_trailing` (keep head chars).
+
+    A trailing HTML-comment marker is appended *outside* the ``<table>``
+    wrapper (when trimmed) so the LLM knows the body is incomplete.  The
+    marker is included in the token budget.
+
+    Returns ``(possibly_trimmed_content, was_trimmed)``.  When
+    ``max_tokens <= 0`` or ``tokenizer is None`` the input is returned
+    unchanged with ``was_trimmed=False``.
+    """
+    if not content or tokenizer is None or max_tokens <= 0:
+        return content, False
+    original_tokens = _count_tokens(tokenizer, content)
+    if original_tokens <= max_tokens:
+        return content, False
+
+    # Reserve token room for the truncation marker before trimming.
+    marker_probe = _CONTENT_TRUNCATION_MARKER.format(
+        original=original_tokens, final=max_tokens
+    )
+    marker_tokens = _count_tokens(tokenizer, marker_probe)
+    inner_budget = max(0, max_tokens - marker_tokens)
+
+    trimmed_inner: str | None = None
+    if kind == "tables" and TABLE_TAG_RE.match(content.strip()):
+        # _row_trim_table_trailing keeps head rows and internally falls back
+        # to char-level fits while preserving the <table> wrapper.  Only
+        # malformed / unrecognized-format markup returns None.
+        trimmed_inner = _row_trim_table_trailing(content, inner_budget, tokenizer)
+    if trimmed_inner is None:
+        trimmed_inner = _char_trim_trailing(content, inner_budget, tokenizer)
+
+    final_tokens = _count_tokens(tokenizer, trimmed_inner)
+    marker = _CONTENT_TRUNCATION_MARKER.format(
+        original=original_tokens, final=final_tokens
+    )
+    return trimmed_inner + marker, True
+
+
 def build_surrounding(
     *,
     kind: str,
@@ -960,4 +1024,5 @@ __all__ = [
     "load_chunk_separators",
     "load_content_rows_by_blockid",
     "remove_table_tags",
+    "trim_content_to_budget",
 ]

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -28,6 +28,7 @@ from lightrag.utils import (
     save_to_cache,
     CacheData,
     use_llm_func_with_cache,
+    get_env_value,
     get_llm_cache_identity,
     serialize_llm_cache_identity,
     update_chunk_cache_list,
@@ -60,6 +61,7 @@ from lightrag.prompt import PROMPTS, resolve_entity_extraction_prompt_profile
 from lightrag.constants import (
     GRAPH_FIELD_SEP,
     DEFAULT_MAX_ENTITY_TOKENS,
+    DEFAULT_MAX_EXTRACT_INPUT_TOKENS,
     DEFAULT_MAX_RELATION_TOKENS,
     DEFAULT_MAX_TOTAL_TOKENS,
     DEFAULT_RELATED_CHUNK_NUMBER,
@@ -3221,6 +3223,17 @@ async def extract_entities(
 
     use_llm_func: callable = global_config["role_llm_funcs"]["extract"]
     entity_extract_max_gleaning = global_config["entity_extract_max_gleaning"]
+    # Cap on the gleaning LLM call's combined input (system + history user
+    # prompt + history assistant response + continue prompt).  Pulled from
+    # the same env knob that gates ``analyze_multimodal``'s sidecar trimming
+    # so both EXTRACT-role consumers share one source of truth.  ``0``
+    # disables the gleaning guard (gleaning always runs regardless of size).
+    max_extract_input_tokens = get_env_value(
+        "MAX_EXTRACT_INPUT_TOKENS",
+        DEFAULT_MAX_EXTRACT_INPUT_TOKENS,
+        int,
+    )
+    extract_tokenizer: Tokenizer | None = global_config.get("tokenizer")
 
     # Check if JSON structured output mode is enabled
     use_json_extraction = global_config.get("entity_extraction_use_json", False)
@@ -3359,7 +3372,36 @@ async def extract_entities(
             )
 
         # Process additional gleaning results only 1 time when entity_extract_max_gleaning is greater than zero.
-        if entity_extract_max_gleaning > 0:
+        run_gleaning = entity_extract_max_gleaning > 0
+        if (
+            run_gleaning
+            and extract_tokenizer is not None
+            and max_extract_input_tokens > 0
+        ):
+            # Gleaning replays the initial extraction's user/assistant pair
+            # via ``history_messages`` and appends a "continue" instruction.
+            # When the initial response was large (many entities/edges) or
+            # the chunk content is itself near the budget, that combined
+            # payload can blow past MAX_EXTRACT_INPUT_TOKENS and yield a
+            # provider ``context_length_exceeded`` error.  Pre-check here
+            # and skip rather than fail.
+            gleaning_token_count = (
+                len(extract_tokenizer.encode(entity_extraction_system_prompt))
+                + sum(
+                    len(extract_tokenizer.encode(msg.get("content", "") or ""))
+                    for msg in history
+                )
+                + len(extract_tokenizer.encode(entity_continue_extraction_user_prompt))
+            )
+            if gleaning_token_count > max_extract_input_tokens:
+                logger.warning(
+                    f"Gleaning stopped for chunk {chunk_key}: "
+                    f"Input tokens ({gleaning_token_count}) exceeded limit "
+                    f"({max_extract_input_tokens})."
+                )
+                run_gleaning = False
+
+        if run_gleaning:
             glean_result, timestamp = await use_llm_func_with_cache(
                 entity_continue_extraction_user_prompt,
                 use_llm_func,

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -62,6 +62,7 @@ from lightrag.utils import (
     generate_cache_key,
     generate_track_id,
     get_content_summary,
+    get_env_value,
     get_llm_cache_identity,
     handle_cache,
     logger,
@@ -3605,16 +3606,90 @@ class _PipelineMixin:
                         f"{kind}/{item_id}: missing {kind} content"
                     )
                 template = MULTIMODAL_PROMPTS[f"{kind}_analysis"]
-                prompt = template.format(
-                    language=language,
-                    content=content_text,
-                    captions=_captions_value(item),
-                    footnotes=_footnotes_value(item),
-                    leading=_surrounding_value(item, "leading"),
-                    trailing=_surrounding_value(item, "trailing"),
-                    item_id=item_id,
-                    file_path=file_path,
-                )
+
+                def _render(content_value: str) -> str:
+                    return template.format(
+                        language=language,
+                        content=content_value,
+                        captions=_captions_value(item),
+                        footnotes=_footnotes_value(item),
+                        leading=_surrounding_value(item, "leading"),
+                        trailing=_surrounding_value(item, "trailing"),
+                        item_id=item_id,
+                        file_path=file_path,
+                    )
+
+                prompt = _render(content_text)
+
+                # Cap the EXTRACT prompt at MAX_EXTRACT_INPUT_TOKENS by
+                # trimming the (typically huge) sidecar `content` field — the
+                # other slots (surrounding/captions/footnotes) already have
+                # their own per-field caps upstream.  The cap is resolved
+                # from the env var (falling back to
+                # DEFAULT_MAX_EXTRACT_INPUT_TOKENS) so deployments can tune
+                # it for their model's context window.
+                tokenizer = getattr(self, "tokenizer", None)
+                if tokenizer is not None:
+                    from lightrag.constants import DEFAULT_MAX_EXTRACT_INPUT_TOKENS
+                    from lightrag.multimodal_context import trim_content_to_budget
+
+                    SAFETY_BUFFER = 256
+                    max_extract_tokens = get_env_value(
+                        "MAX_EXTRACT_INPUT_TOKENS",
+                        DEFAULT_MAX_EXTRACT_INPUT_TOKENS,
+                        int,
+                    )
+                    total_tokens = len(tokenizer.encode(prompt))
+                    if max_extract_tokens > 0 and total_tokens > max_extract_tokens:
+                        frame_tokens = len(tokenizer.encode(_render("")))
+                        content_budget = (
+                            max_extract_tokens - frame_tokens - SAFETY_BUFFER
+                        )
+                        if content_budget <= 0:
+                            # The prompt template alone (with empty content)
+                            # already exceeds the cap — no content trim can
+                            # bring the request under the limit.  Fail this
+                            # item rather than handing the LLM a payload we
+                            # know will trigger ``context_length_exceeded``.
+                            # Operators must raise MAX_EXTRACT_INPUT_TOKENS
+                            # above the template frame for analysis to
+                            # succeed; the document is reprocessable
+                            # idempotently once the cap is widened.
+                            raise MultimodalAnalysisError(
+                                f"{kind}/{item_id}: prompt frame "
+                                f"({frame_tokens} tokens) exceeds "
+                                f"MAX_EXTRACT_INPUT_TOKENS "
+                                f"({max_extract_tokens}); raise the cap"
+                            )
+                        trimmed, was_trimmed = trim_content_to_budget(
+                            content_text,
+                            kind=f"{kind}s",
+                            max_tokens=content_budget,
+                            tokenizer=tokenizer,
+                        )
+                        if was_trimmed:
+                            prompt = _render(trimmed)
+                            logger.warning(
+                                f"[analyze_multimodal] {kind}/{item_id} "
+                                f"content trimmed (prompt {total_tokens} "
+                                f"→ fit {max_extract_tokens}, "
+                                f"content_budget={content_budget})"
+                            )
+                        # Post-trim hard guard: ``trim_content_to_budget``
+                        # is constrained by ``content_budget`` so the final
+                        # prompt should fit within ``max_extract_tokens``;
+                        # defend against tokenizer rounding / future template
+                        # changes that could push it over.  Refuse the call
+                        # rather than send an over-cap prompt to the LLM.
+                        final_tokens = len(tokenizer.encode(prompt))
+                        if final_tokens > max_extract_tokens:
+                            raise MultimodalAnalysisError(
+                                f"{kind}/{item_id}: trimmed prompt "
+                                f"({final_tokens} tokens) still exceeds "
+                                f"MAX_EXTRACT_INPUT_TOKENS "
+                                f"({max_extract_tokens})"
+                            )
+
                 args_hash = compute_args_hash(
                     prompt,
                     "",

--- a/tests/test_extract_entities.py
+++ b/tests/test_extract_entities.py
@@ -1,10 +1,19 @@
 """Tests for entity extraction gleaning token limit guard."""
 
-from unittest.mock import AsyncMock, patch
+import logging
+from unittest.mock import AsyncMock
 
 import pytest
 
 from lightrag.utils import Tokenizer, TokenizerInterface
+
+
+@pytest.fixture
+def _propagate_lightrag_logger(monkeypatch):
+    """``lightrag.utils.logger`` sets ``propagate = False`` to avoid noisy
+    test output; restore propagation locally so ``caplog`` can capture
+    WARNING records emitted from inside ``lightrag.operate``."""
+    monkeypatch.setattr(logging.getLogger("lightrag"), "propagate", True)
 
 
 class DummyTokenizer(TokenizerInterface):
@@ -18,7 +27,6 @@ class DummyTokenizer(TokenizerInterface):
 
 
 def _make_global_config(
-    max_extract_input_tokens: int = 20480,
     entity_extract_max_gleaning: int = 1,
 ) -> dict:
     """Build a minimal global_config dict for extract_entities."""
@@ -37,7 +45,6 @@ def _make_global_config(
         "entity_extract_max_entities": 40,
         "addon_params": {},
         "tokenizer": tokenizer,
-        "max_extract_input_tokens": max_extract_input_tokens,
         "llm_model_max_async": 1,
     }
 
@@ -61,73 +68,111 @@ def _make_chunks(content: str = "Test content.") -> dict[str, dict]:
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_gleaning_skipped_when_tokens_exceed_limit():
-    """Current behavior: one extra gleaning round runs when max_gleaning>0."""
+async def test_gleaning_skipped_when_tokens_exceed_limit(
+    monkeypatch, caplog, _propagate_lightrag_logger
+):
+    """Gleaning must be skipped (with a WARNING) when the projected
+    gleaning input — system + history(user+assistant) + continue prompt —
+    exceeds ``MAX_EXTRACT_INPUT_TOKENS``.  This prevents
+    ``context_length_exceeded`` errors from the LLM provider on the second
+    round when the initial response was long.
+    """
     from lightrag.operate import extract_entities
 
-    # Use a very small token limit so the gleaning context will exceed it
-    global_config = _make_global_config(
-        max_extract_input_tokens=10,
-        entity_extract_max_gleaning=1,
-    )
+    # 10 tokens cannot fit any realistic prompt — guard must trip.
+    monkeypatch.setenv("MAX_EXTRACT_INPUT_TOKENS", "10")
 
+    global_config = _make_global_config(entity_extract_max_gleaning=1)
     llm_func = global_config["llm_model_func"]
     llm_func.return_value = _EXTRACTION_RESULT
 
-    with patch("lightrag.operate.logger"):
+    with caplog.at_level("WARNING", logger="lightrag"):
         await extract_entities(
             chunks=_make_chunks(),
             global_config=global_config,
         )
 
-    # Current extraction implementation always performs one gleaning round when enabled.
-    assert llm_func.await_count == 2
-
-
-@pytest.mark.offline
-@pytest.mark.asyncio
-async def test_gleaning_proceeds_when_tokens_within_limit():
-    """Gleaning should proceed when estimated tokens are within max_extract_input_tokens."""
-    from lightrag.operate import extract_entities
-
-    # Use a very large token limit so gleaning will proceed
-    global_config = _make_global_config(
-        max_extract_input_tokens=999999,
-        entity_extract_max_gleaning=1,
-    )
-
-    llm_func = global_config["llm_model_func"]
-    llm_func.return_value = _EXTRACTION_RESULT
-
-    with patch("lightrag.operate.logger"):
-        await extract_entities(
-            chunks=_make_chunks(),
-            global_config=global_config,
-        )
-
-    # LLM should be called twice (initial extraction + gleaning)
-    assert llm_func.await_count == 2
-
-
-@pytest.mark.offline
-@pytest.mark.asyncio
-async def test_no_gleaning_when_max_gleaning_zero():
-    """No gleaning when entity_extract_max_gleaning is 0, regardless of token limit."""
-    from lightrag.operate import extract_entities
-
-    global_config = _make_global_config(
-        max_extract_input_tokens=999999,
-        entity_extract_max_gleaning=0,
-    )
-
-    llm_func = global_config["llm_model_func"]
-    llm_func.return_value = _EXTRACTION_RESULT
-
-    with patch("lightrag.operate.logger"):
-        await extract_entities(
-            chunks=_make_chunks(),
-            global_config=global_config,
-        )
-
-    # LLM should be called exactly once (initial extraction only)
+    # Only the initial extraction round ran; gleaning was skipped.
     assert llm_func.await_count == 1
+
+    warnings_emitted = [
+        rec.getMessage()
+        for rec in caplog.records
+        if rec.levelname == "WARNING"
+        and rec.getMessage().startswith("Gleaning stopped for chunk chunk-001:")
+    ]
+    assert warnings_emitted, (
+        "expected a WARNING log explaining gleaning was skipped due to "
+        "token limit; got: "
+        f"{[r.getMessage() for r in caplog.records]}"
+    )
+    # Message must surface both the measured token count and the limit so
+    # operators can size MAX_EXTRACT_INPUT_TOKENS appropriately.
+    msg = warnings_emitted[0]
+    assert "exceeded limit (10)" in msg
+    assert "Input tokens (" in msg
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_gleaning_proceeds_when_tokens_within_limit(monkeypatch):
+    """Gleaning runs normally when the projected input fits the cap."""
+    from lightrag.operate import extract_entities
+
+    monkeypatch.setenv("MAX_EXTRACT_INPUT_TOKENS", "999999")
+
+    global_config = _make_global_config(entity_extract_max_gleaning=1)
+    llm_func = global_config["llm_model_func"]
+    llm_func.return_value = _EXTRACTION_RESULT
+
+    await extract_entities(
+        chunks=_make_chunks(),
+        global_config=global_config,
+    )
+
+    # Both rounds run: initial extraction + one gleaning pass.
+    assert llm_func.await_count == 2
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_no_gleaning_when_max_gleaning_zero(monkeypatch):
+    """``entity_extract_max_gleaning=0`` disables gleaning regardless of
+    token budget — the guard is downstream of the feature flag."""
+    from lightrag.operate import extract_entities
+
+    monkeypatch.setenv("MAX_EXTRACT_INPUT_TOKENS", "999999")
+
+    global_config = _make_global_config(entity_extract_max_gleaning=0)
+    llm_func = global_config["llm_model_func"]
+    llm_func.return_value = _EXTRACTION_RESULT
+
+    await extract_entities(
+        chunks=_make_chunks(),
+        global_config=global_config,
+    )
+
+    assert llm_func.await_count == 1
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_gleaning_guard_disabled_when_max_tokens_zero(monkeypatch):
+    """Setting ``MAX_EXTRACT_INPUT_TOKENS=0`` opts out of the guard so
+    gleaning always runs regardless of input size — useful for callers
+    whose provider has no hard input ceiling."""
+    from lightrag.operate import extract_entities
+
+    monkeypatch.setenv("MAX_EXTRACT_INPUT_TOKENS", "0")
+
+    global_config = _make_global_config(entity_extract_max_gleaning=1)
+    llm_func = global_config["llm_model_func"]
+    llm_func.return_value = _EXTRACTION_RESULT
+
+    await extract_entities(
+        chunks=_make_chunks(),
+        global_config=global_config,
+    )
+
+    # Guard disabled → gleaning still runs even with tight projected input.
+    assert llm_func.await_count == 2

--- a/tests/test_multimodal_content_truncation.py
+++ b/tests/test_multimodal_content_truncation.py
@@ -1,0 +1,199 @@
+"""Unit tests for ``trim_content_to_budget`` in ``multimodal_context``.
+
+Companion to ``test_multimodal_surrounding_context.py``.  Uses the same
+1:1 character-token tokenizer so budgets in each scenario stay readable.
+"""
+
+import json
+import re
+
+import pytest
+
+from lightrag.multimodal_context import trim_content_to_budget
+from lightrag.utils import Tokenizer, TokenizerInterface
+
+
+class _CharTokenizer(TokenizerInterface):
+    def encode(self, content: str):
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens):
+        return "".join(chr(t) for t in tokens)
+
+
+def _tokenizer() -> Tokenizer:
+    return Tokenizer(model_name="char", tokenizer=_CharTokenizer())
+
+
+_MARKER_RE = re.compile(
+    r"<!-- content truncated from (\d+) to (\d+) tokens, head preserved -->"
+)
+
+
+@pytest.mark.offline
+def test_short_content_passes_through():
+    tok = _tokenizer()
+    content = "<table><tr><td>cell</td></tr></table>"
+    out, was_trimmed = trim_content_to_budget(
+        content, kind="tables", max_tokens=10_000, tokenizer=tok
+    )
+    assert out == content
+    assert was_trimmed is False
+    assert _MARKER_RE.search(out) is None
+
+
+@pytest.mark.offline
+def test_table_html_row_trim_keeps_head():
+    tok = _tokenizer()
+    rows_html = "".join(f"<tr><td>r{i}c0</td><td>r{i}c1</td></tr>" for i in range(10))
+    body = f"<tbody>{rows_html}</tbody>"
+    content = f'<table id="t-html" format="html">{body}</table>'
+    out, was_trimmed = trim_content_to_budget(
+        content, kind="tables", max_tokens=200, tokenizer=tok
+    )
+    assert was_trimmed is True
+    assert "<table " in out
+    # Marker sits outside the </table> wrapper.
+    table_close = out.rfind("</table>")
+    marker_match = _MARKER_RE.search(out)
+    assert marker_match is not None
+    assert marker_match.start() > table_close
+    # Head rows preserved, tail rows dropped.
+    assert "r0c0" in out
+    assert "r9c0" not in out
+    assert len(tok.encode(out)) <= 200
+
+
+@pytest.mark.offline
+def test_table_json_row_trim_keeps_head():
+    tok = _tokenizer()
+    rows = [[f"r{i}c0", f"r{i}c1"] for i in range(10)]
+    content = '<table id="t-json" format="json">' + json.dumps(rows) + "</table>"
+    out, was_trimmed = trim_content_to_budget(
+        content, kind="tables", max_tokens=150, tokenizer=tok
+    )
+    assert was_trimmed is True
+    assert "<table " in out
+    assert "</table>" in out
+    # First row preserved, last row dropped.
+    assert "r0c0" in out
+    assert "r9c0" not in out
+    # Marker present and outside </table>.
+    table_close = out.rfind("</table>")
+    marker_match = _MARKER_RE.search(out)
+    assert marker_match is not None
+    assert marker_match.start() > table_close
+    assert len(tok.encode(out)) <= 150
+
+
+@pytest.mark.offline
+def test_table_char_fallback_when_single_row_oversized():
+    tok = _tokenizer()
+    # A single huge JSON row whose serialized form alone exceeds budget.
+    long_cell = "X" * 400
+    content = (
+        '<table id="t-big" format="json">'
+        + json.dumps([[long_cell]], ensure_ascii=False)
+        + "</table>"
+    )
+    out, was_trimmed = trim_content_to_budget(
+        content, kind="tables", max_tokens=120, tokenizer=tok
+    )
+    assert was_trimmed is True
+    # <table> wrapper must still be present even after char fallback.
+    assert out.lstrip().startswith("<table ")
+    assert "</table>" in out
+    # Marker still appended outside the wrapper.
+    assert _MARKER_RE.search(out) is not None
+    assert len(tok.encode(out)) <= 120
+
+
+@pytest.mark.offline
+def test_equation_char_trim_keeps_head():
+    tok = _tokenizer()
+    content = "HEAD_" + "A" * 500 + "_TAIL"
+    out, was_trimmed = trim_content_to_budget(
+        content, kind="equations", max_tokens=100, tokenizer=tok
+    )
+    assert was_trimmed is True
+    assert out.startswith("HEAD_")
+    # Tail must have been dropped.
+    assert "_TAIL" not in out
+    assert _MARKER_RE.search(out) is not None
+    assert len(tok.encode(out)) <= 100
+
+
+@pytest.mark.offline
+def test_malformed_table_falls_back_to_char_trim():
+    tok = _tokenizer()
+    # Missing closing </table> tag — TABLE_TAG_RE will reject this, so the
+    # generic char-trim path applies (no <table> wrapper reconstruction).
+    content = "<table><tr><td>" + "Z" * 500 + "</td></tr>"
+    out, was_trimmed = trim_content_to_budget(
+        content, kind="tables", max_tokens=100, tokenizer=tok
+    )
+    assert was_trimmed is True
+    assert out.startswith("<table>")
+    assert _MARKER_RE.search(out) is not None
+    assert len(tok.encode(out)) <= 100
+
+
+@pytest.mark.offline
+def test_zero_budget_returns_input_unchanged():
+    tok = _tokenizer()
+    content = "x" * 5000
+    out, was_trimmed = trim_content_to_budget(
+        content, kind="tables", max_tokens=0, tokenizer=tok
+    )
+    assert out == content
+    assert was_trimmed is False
+
+
+@pytest.mark.offline
+def test_negative_budget_returns_input_unchanged():
+    tok = _tokenizer()
+    content = "x" * 5000
+    out, was_trimmed = trim_content_to_budget(
+        content, kind="equations", max_tokens=-10, tokenizer=tok
+    )
+    assert out == content
+    assert was_trimmed is False
+
+
+@pytest.mark.offline
+def test_tokenizer_none_returns_input_unchanged():
+    content = "x" * 5000
+    out, was_trimmed = trim_content_to_budget(
+        content, kind="tables", max_tokens=100, tokenizer=None
+    )
+    assert out == content
+    assert was_trimmed is False
+
+
+@pytest.mark.offline
+def test_marker_reports_original_and_final_token_counts():
+    tok = _tokenizer()
+    content = "x" * 500
+    out, was_trimmed = trim_content_to_budget(
+        content, kind="equations", max_tokens=100, tokenizer=tok
+    )
+    assert was_trimmed is True
+    match = _MARKER_RE.search(out)
+    assert match is not None
+    original_in_marker = int(match.group(1))
+    final_in_marker = int(match.group(2))
+    assert original_in_marker == 500
+    # The reported final-token count is the inner-content size (before marker),
+    # so it should be strictly less than the original.
+    assert final_in_marker < original_in_marker
+    assert len(tok.encode(out)) <= 100
+
+
+@pytest.mark.offline
+def test_empty_content_returns_unchanged():
+    tok = _tokenizer()
+    out, was_trimmed = trim_content_to_budget(
+        "", kind="tables", max_tokens=100, tokenizer=tok
+    )
+    assert out == ""
+    assert was_trimmed is False

--- a/tests/test_pipeline_analyze_multimodal.py
+++ b/tests/test_pipeline_analyze_multimodal.py
@@ -750,3 +750,246 @@ async def test_analysis_cache_respects_disabled_flag(tmp_path):
         assert item.get("llm_cache_list", []) == []
     finally:
         await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_oversized_table_content_truncated_to_extract_budget(tmp_path):
+    """A sidecar table whose ``content`` alone exceeds the EXTRACT input
+    cap must be trimmed before reaching the LLM.  The captured prompt
+    must (a) fit within ``DEFAULT_MAX_EXTRACT_INPUT_TOKENS``, (b) still
+    wrap the trimmed body in a ``<table>`` tag, and (c) include the
+    truncation marker so the LLM is told the body is incomplete.
+    """
+    from lightrag.constants import DEFAULT_MAX_EXTRACT_INPUT_TOKENS
+
+    extract_log: list[dict] = []
+    rag = _build_rag(
+        tmp_path,
+        vlm_process_enable=False,
+        extract_func=_make_extract_mock(extract_log),
+    )
+    await rag.initialize_storages()
+    try:
+        parsed_dir = tmp_path / "parsed"
+        parsed_dir.mkdir()
+        blocks_path = parsed_dir / "doc.blocks.jsonl"
+        blocks_path.write_text(
+            json.dumps({"type": "meta", "doc_id": "doc-big"}) + "\n",
+            encoding="utf-8",
+        )
+
+        # Build a JSON-format table whose total token count is well above
+        # DEFAULT_MAX_EXTRACT_INPUT_TOKENS so the trim path must engage.
+        # Each row is small; the row count is the lever.
+        rows = [[f"r{i}c0", f"r{i}c1"] for i in range(8000)]
+        big_table = '<table id="tb-big" format="json">' + json.dumps(rows) + "</table>"
+        original_tokens = len(rag.tokenizer.encode(big_table))
+        assert original_tokens > DEFAULT_MAX_EXTRACT_INPUT_TOKENS
+
+        tables_path = parsed_dir / "doc.tables.json"
+        tables_path.write_text(
+            json.dumps(
+                {
+                    "tables": {
+                        "tb-big": {
+                            "caption": "huge table",
+                            "content": big_table,
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        await rag.analyze_multimodal(
+            doc_id="doc-big",
+            file_path="fixture.pdf",
+            parsed_data={"blocks_path": str(blocks_path)},
+            process_options="t",
+        )
+        assert len(extract_log) == 1
+        sent_prompt = extract_log[0]["prompt"]
+        prompt_tokens = len(rag.tokenizer.encode(sent_prompt))
+
+        # Whole prompt fits within the EXTRACT input cap.
+        assert prompt_tokens <= DEFAULT_MAX_EXTRACT_INPUT_TOKENS, (
+            f"prompt of {prompt_tokens} tokens exceeds "
+            f"{DEFAULT_MAX_EXTRACT_INPUT_TOKENS}"
+        )
+
+        # Truncation marker present, <table> tag still closed inside the
+        # CONTENT section.
+        assert (
+            "<!-- content truncated from " in sent_prompt
+            and "head preserved -->" in sent_prompt
+        )
+        # Head rows preserved, last rows dropped.
+        assert "r0c0" in sent_prompt
+        assert "r7999c0" not in sent_prompt
+
+        # Analysis still succeeded — trimming is transparent to status.
+        payload = json.loads(tables_path.read_text(encoding="utf-8"))
+        assert payload["tables"]["tb-big"]["llm_analyze_result"]["status"] == "success"
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_max_extract_input_tokens_env_var_lowers_cap_and_logs_warning(
+    tmp_path, caplog, _propagate_lightrag_logger, monkeypatch
+):
+    """``MAX_EXTRACT_INPUT_TOKENS`` env var overrides the compile-time
+    default, and any truncation emits a WARNING-level log line so
+    operators see when sidecar bodies are being cut for the EXTRACT call.
+    """
+    # Cap well below the default 20480 so a modest table triggers trimming,
+    # but still comfortably above the ~3980-char prompt template frame so
+    # `content_budget` stays positive.
+    monkeypatch.setenv("MAX_EXTRACT_INPUT_TOKENS", "8000")
+
+    extract_log: list[dict] = []
+    rag = _build_rag(
+        tmp_path,
+        vlm_process_enable=False,
+        extract_func=_make_extract_mock(extract_log),
+    )
+    await rag.initialize_storages()
+    try:
+        parsed_dir = tmp_path / "parsed"
+        parsed_dir.mkdir()
+        blocks_path = parsed_dir / "doc.blocks.jsonl"
+        blocks_path.write_text(
+            json.dumps({"type": "meta", "doc_id": "doc-mid"}) + "\n",
+            encoding="utf-8",
+        )
+
+        # Table sized comfortably between the env cap (8000) and the
+        # compile-time default (20480) — would NOT trim under the default,
+        # MUST trim under the env override.
+        rows = [[f"r{i}c0", f"r{i}c1"] for i in range(800)]
+        mid_table = '<table id="tb-mid" format="json">' + json.dumps(rows) + "</table>"
+        original_tokens = len(rag.tokenizer.encode(mid_table))
+        assert 8000 < original_tokens < 20480
+
+        tables_path = parsed_dir / "doc.tables.json"
+        tables_path.write_text(
+            json.dumps(
+                {
+                    "tables": {
+                        "tb-mid": {
+                            "caption": "mid table",
+                            "content": mid_table,
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="lightrag.pipeline"):
+            await rag.analyze_multimodal(
+                doc_id="doc-mid",
+                file_path="fixture.pdf",
+                parsed_data={"blocks_path": str(blocks_path)},
+                process_options="t",
+            )
+        assert len(extract_log) == 1
+        sent_prompt = extract_log[0]["prompt"]
+        # Env cap honored.
+        assert len(rag.tokenizer.encode(sent_prompt)) <= 8000
+        assert "<!-- content truncated from " in sent_prompt
+
+        # WARNING-level log line was emitted naming this item.
+        warning_records = [
+            r
+            for r in caplog.records
+            if r.levelname == "WARNING"
+            and "[analyze_multimodal]" in r.getMessage()
+            and "tb-mid" in r.getMessage()
+            and "content trimmed" in r.getMessage()
+        ]
+        assert (
+            warning_records
+        ), "expected a WARNING-level log line announcing content truncation"
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_extract_cap_below_prompt_frame_fails_item_without_llm_call(
+    tmp_path, monkeypatch
+):
+    """When ``MAX_EXTRACT_INPUT_TOKENS`` sits below the prompt template's
+    own ``frame_tokens + SAFETY_BUFFER``, ``content_budget`` goes
+    non-positive — no content trim can bring the request under the cap
+    because the frame itself overflows.  The pipeline must refuse to
+    invoke the LLM and fail this item via :class:`MultimodalAnalysisError`,
+    so the sidecar records ``status="failure"`` and operators get a clear
+    actionable signal (raise the cap).  Guards the P1 regression where
+    marker-replacement merely shrank ``content`` while leaving the
+    over-cap frame intact."""
+    # The table_analysis prompt frame is ~3980 chars; pick a cap small
+    # enough that the frame alone overflows.
+    monkeypatch.setenv("MAX_EXTRACT_INPUT_TOKENS", "1000")
+
+    extract_log: list[dict] = []
+    rag = _build_rag(
+        tmp_path,
+        vlm_process_enable=False,
+        extract_func=_make_extract_mock(extract_log),
+    )
+    await rag.initialize_storages()
+    try:
+        parsed_dir = tmp_path / "parsed"
+        parsed_dir.mkdir()
+        blocks_path = parsed_dir / "doc.blocks.jsonl"
+        blocks_path.write_text(
+            json.dumps({"type": "meta", "doc_id": "doc-tight"}) + "\n",
+            encoding="utf-8",
+        )
+        tables_path = parsed_dir / "doc.tables.json"
+        tables_path.write_text(
+            json.dumps(
+                {
+                    "tables": {
+                        "tb-tight": {
+                            "content": (
+                                '<table id="tb-tight" format="json">'
+                                '[["A","B"]]</table>'
+                            )
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(MultimodalAnalysisError) as excinfo:
+            await rag.analyze_multimodal(
+                doc_id="doc-tight",
+                file_path="fixture.pdf",
+                parsed_data={"blocks_path": str(blocks_path)},
+                process_options="t",
+            )
+
+        # Critical: the LLM mock must NOT have been invoked — we refused
+        # to send an over-cap prompt rather than letting the provider
+        # reject it with context_length_exceeded.
+        assert extract_log == [], (
+            f"EXTRACT must not be called when frame exceeds cap; "
+            f"got {len(extract_log)} call(s)"
+        )
+
+        msg = str(excinfo.value)
+        assert "table/tb-tight" in msg
+        assert "MAX_EXTRACT_INPUT_TOKENS" in msg
+        assert "1000" in msg
+
+        # Sidecar records status=failure for the item, so operators can
+        # spot it and re-run after raising the cap.
+        payload = json.loads(tables_path.read_text(encoding="utf-8"))
+        item = payload["tables"]["tb-tight"]
+        assert item["llm_analyze_result"]["status"] == "failure"
+        assert "MAX_EXTRACT_INPUT_TOKENS" in item["llm_analyze_result"]["message"]
+    finally:
+        await rag.finalize_storages()


### PR DESCRIPTION
## Summary

Both EXTRACT-role consumers previously sent prompts to the LLM with no upper bound, risking provider `context_length_exceeded` errors:

- **`analyze_multimodal`** embedded the raw sidecar `content` field (table HTML/JSON, equation LaTeX) directly into the prompt with no trim — a giant table could blow past any model's context window.
- **Entity-extraction gleaning** replays the initial extraction's `user + assistant` pair via `history_messages` before appending a continue prompt, so a long initial response on a near-cap chunk could push the second-round request past the limit.

This PR caps both paths at `MAX_EXTRACT_INPUT_TOKENS` (env, falls back to `DEFAULT_MAX_EXTRACT_INPUT_TOKENS = 20480`), resolved via the shared `get_env_value` helper so both consumers share one source of truth.

## Changes

### `analyze_multimodal` — sidecar `content` trimming
- New `lightrag.multimodal_context.trim_content_to_budget(content, kind, max_tokens, tokenizer)` — head-preserving truncation:
  - Tables (`<table>` wrapped): row-aware trim (preserves wrapper) → char-level fallback.
  - Equations / other: char trim from tail.
  - Appends `<!-- content truncated from N to M tokens, head preserved -->` outside the `<table>` so the LLM knows the body is incomplete.
- `_analyze_text_modality` integrates the trim before `compute_args_hash`, computing `content_budget = max_extract_tokens - frame_tokens - SAFETY_BUFFER (256)` and re-rendering when trim engages.
- **Fail-fast guard**: when `content_budget <= 0` (cap below the prompt template frame) or the post-trim prompt still overflows, the item raises `MultimodalAnalysisError` instead of sending an over-cap prompt to the LLM. Sidecar records `status=\"failure\"`; the document is idempotently reprocessable after raising the cap.
- Trim events log at `WARNING` level (operator-visible quality-degrading event).

### Entity extraction — gleaning guard
- `_process_single_content` now precomputes the projected gleaning input tokens (`system + history[user+assistant] + continue_prompt`) and **skips** the second LLM round with a `WARNING` when it exceeds `MAX_EXTRACT_INPUT_TOKENS`:
  - `Gleaning stopped for chunk {chunk_key}: Input tokens ({N}) exceeded limit ({M}).`
- Initial extraction result is preserved (gleaning is purely additive).
- `MAX_EXTRACT_INPUT_TOKENS=0` disables the guard for callers whose provider has no hard input ceiling.

### Tests (16 new)
- `tests/test_multimodal_content_truncation.py` (11): trim primitives, marker placement, char fallback, malformed table fallback, zero/negative/None budget edge cases.
- `tests/test_pipeline_analyze_multimodal.py` (3 new): oversized table trims to fit cap; env-var-imposed lower cap engages trim + emits WARNING; cap-below-frame refuses to call LLM and writes `status=failure` (the P1 regression guard).
- `tests/test_extract_entities.py` (4): gleaning skipped on overflow with WARNING; gleaning runs within budget; gleaning disabled by `entity_extract_max_gleaning=0`; `MAX_EXTRACT_INPUT_TOKENS=0` disables guard.

### Code simplification & cleanup
- `env.example`: reorder `SURROUNDING_*_MAX_TOKENS` block to sit next to the related `MAX_EXTRACT_INPUT_TOKENS` entry (already documented but previously read-only).

## Test plan

- [x] Unit tests for `trim_content_to_budget` pass (11 tests).
- [x] E2E tests for `analyze_multimodal` trim integration pass — including the cap-below-frame fail-fast path with `extract_log == []` (LLM not invoked).
- [x] Gleaning guard unit tests pass (4 tests).
- [x] Full multimodal + entity-extraction regression suites pass (111 tests, no regressions).
- [x] `pre-commit run --files <changed>` clean (ruff-format, ruff, end-of-file, trailing-whitespace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)