### PR TITLE
refactor(multimodal): inline bracket-label format for mm chunks

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -170,6 +170,31 @@ def _truncate_vdb_content(content: str, global_config: dict, content_label: str)
     return truncated_content
 
 
+_MM_DISPLAY_NAME_PATTERN = re.compile(
+    r"^\[(?:Image|Table|Equation) Name\](.+)$",
+    flags=re.MULTILINE,
+)
+
+
+def _parse_mm_display_name(content: str, fallback: str) -> str:
+    """Return the friendly name embedded in a multimodal chunk.
+
+    Matches the leading ``[Image Name]…`` / ``[Table Name]…`` /
+    ``[Equation Name]…`` segment produced by
+    ``LightRAG._build_mm_chunks_from_sidecars`` — the producer-side
+    contract is documented in that function's ``_render`` helper. Falls
+    back to the sidecar id when the segment is missing or empty so
+    callers never end up with a blank label.
+    """
+    if content:
+        match = _MM_DISPLAY_NAME_PATTERN.search(content)
+        if match:
+            candidate = match.group(1).strip()
+            if candidate:
+                return candidate
+    return fallback
+
+
 async def _handle_entity_relation_summary(
     description_type: str,
     entity_or_relation_name: str,
@@ -3512,20 +3537,9 @@ async def extract_entities(
                     heading_label = (
                         str(heading_block.get("heading") or "").strip() or "unknown"
                     )
-                # Friendly name for the relation description: parse the
-                # leading "- {Image|Table|Equation} Name:\n<name>" section
-                # from the chunk content; fall back to sidecar id.
-                mm_display_name = sidecar_id
-                content_for_name = chunk_dp.get("content", "") or ""
-                first_name_match = re.search(
-                    r"^- (?:Image|Table|Equation) Name:\n(.+)$",
-                    content_for_name,
-                    flags=re.MULTILINE,
+                mm_display_name = _parse_mm_display_name(
+                    chunk_dp.get("content", "") or "", sidecar_id
                 )
-                if first_name_match:
-                    candidate = first_name_match.group(1).strip()
-                    if candidate:
-                        mm_display_name = candidate
                 for tgt in list(maybe_nodes.keys()):
                     if tgt == mm_entity_name:
                         continue

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -4079,29 +4079,28 @@ class _PipelineMixin:
             footnotes_joined: str,
             equation_body: str,
         ) -> str:
-            sections: list[str] = []
+            # NOTE: the `[Image Name]` / `[Table Name]` / `[Equation Name]`
+            # leading labels below are a contract consumed by
+            # ``lightrag.operate._parse_mm_display_name`` (regex
+            # ``_MM_DISPLAY_NAME_PATTERN``). If you rename or restructure
+            # these labels, update that regex too, or relation descriptions
+            # will silently fall back to sidecar ids. The
+            # ``test_parse_mm_display_name_on_real_builder_output``
+            # regression pins this contract end-to-end.
             if kind == "drawing":
-                sections.append(f"- Image Name:\n{name}")
-                sections.append(f"- Image Type:\n{image_type}")
-                if description:
-                    sections.append(f"- Image Description:\n{description}")
-                if footnotes_joined:
-                    sections.append(f"- Image Footnotes:\n{footnotes_joined}")
+                head = f"[Image Name]{name}\n[Image Type]{image_type}"
+                footnote_label = "Image Footnotes"
             elif kind == "table":
-                sections.append(f"- Table Name:\n{name}")
-                if description:
-                    sections.append(f"- Table Description:\n{description}")
-                if footnotes_joined:
-                    sections.append(f"- Table Footnotes:\n{footnotes_joined}")
-            else:
-                sections.append(f"- Equation Name:\n{name}")
-                if equation_body:
-                    sections.append(f"- Equation Body:\n{equation_body}")
-                if description:
-                    sections.append(f"- Equation Description:\n{description}")
-                if footnotes_joined:
-                    sections.append(f"- Equation Footnotes:\n{footnotes_joined}")
-            return "\n\n".join(sections).strip()
+                head = f"[Table Name]{name}"
+                footnote_label = "Table Footnotes"
+            else:  # equation
+                head = f"{equation_body}\n[Equation Name]{name}"
+                footnote_label = "Equation Footnotes"
+
+            sections = [head, description]
+            if footnotes_joined:
+                sections.append(f"[{footnote_label}]{footnotes_joined}")
+            return "\n\n".join(s for s in sections if s).strip()
 
         max_tokens = DEFAULT_MAX_EXTRACT_INPUT_TOKENS
         min_desc_tokens = DEFAULT_MM_CHUNK_DESCRIPTION_MIN_TOKENS

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -4074,6 +4074,7 @@ class _PipelineMixin:
         def _render(
             kind: str,
             name: str,
+            image_type: str,
             description: str,
             footnotes_joined: str,
             equation_body: str,
@@ -4081,11 +4082,7 @@ class _PipelineMixin:
             sections: list[str] = []
             if kind == "drawing":
                 sections.append(f"- Image Name:\n{name}")
-                # type field comes from caller via name interpolation: omit
-                # when blank because the prompt enforces it as required so a
-                # missing type should already have raised.
-                # The image type was inserted at call-site by the caller via a
-                # secondary call to this helper if needed.
+                sections.append(f"- Image Type:\n{image_type}")
                 if description:
                     sections.append(f"- Image Description:\n{description}")
                 if footnotes_joined:
@@ -4104,22 +4101,6 @@ class _PipelineMixin:
                     sections.append(f"- Equation Description:\n{description}")
                 if footnotes_joined:
                     sections.append(f"- Equation Footnotes:\n{footnotes_joined}")
-            return "\n\n".join(sections).strip()
-
-        def _render_image(
-            name: str,
-            image_type: str,
-            description: str,
-            footnotes_joined: str,
-        ) -> str:
-            sections = [
-                f"- Image Name:\n{name}",
-                f"- Image Type:\n{image_type}",
-            ]
-            if description:
-                sections.append(f"- Image Description:\n{description}")
-            if footnotes_joined:
-                sections.append(f"- Image Footnotes:\n{footnotes_joined}")
             return "\n\n".join(sections).strip()
 
         max_tokens = DEFAULT_MAX_EXTRACT_INPUT_TOKENS
@@ -4180,16 +4161,10 @@ class _PipelineMixin:
                 footnotes_joined = "; ".join(footnotes_list)
 
                 def _compose(desc: str) -> str:
-                    if kind == "drawing":
-                        return _render_image(
-                            name=name,
-                            image_type=image_type,
-                            description=desc,
-                            footnotes_joined=footnotes_joined,
-                        )
                     return _render(
                         kind=kind,
                         name=name,
+                        image_type=image_type,
                         description=desc,
                         footnotes_joined=footnotes_joined,
                         equation_body=equation_body,

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -12,7 +12,10 @@ from lightrag.constants import (
     PARSED_DIR_NAME,
     PARSER_ENGINE_NATIVE,
 )
-from lightrag.operate import _get_relationship_vdb_timeout_seconds
+from lightrag.operate import (
+    _get_relationship_vdb_timeout_seconds,
+    _parse_mm_display_name,
+)
 from lightrag.parser_routing import (
     ParserRoutingConfigError,
     canonicalize_parser_hinted_basename,
@@ -2624,8 +2627,8 @@ def test_mm_chunks_and_modality_relations_from_sidecars(tmp_path):
         assert len(mm_chunks) == 1
         chunk = mm_chunks[0]
         # New nested schema: heading + sidecar + llm_cache_list merge.
-        assert chunk["content"].startswith("- Image Name:")
-        assert "- Image Type:\nChart" in chunk["content"]
+        assert chunk["content"].startswith("[Image Name]")
+        assert "[Image Type]Chart" in chunk["content"]
         assert chunk["sidecar"] == {
             "type": "drawing",
             "id": "d1",
@@ -2639,7 +2642,155 @@ def test_mm_chunks_and_modality_relations_from_sidecars(tmp_path):
         assert chunk["llm_cache_list"] == ["default:analysis:abc123"]
         # Multimodal entity injection now lives in
         # operate.extract_entities._process_single_content; this test only
-        # covers chunk assembly.
+        # covers chunk assembly. The companion regression below
+        # (test_parse_mm_display_name_matches_chunk_format) pins the
+        # builder/consumer format contract.
+
+        await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_parse_mm_display_name_matches_chunk_format():
+    """Pin the builder/consumer contract: the chunk content emitted by
+    ``_build_mm_chunks_from_sidecars`` must parse cleanly via
+    ``operate._parse_mm_display_name`` for all three modalities.
+    Regression for the case where the renderer's label format diverged
+    from the consumer's regex and display names silently fell back to
+    sidecar ids.
+    """
+
+    drawing_content = (
+        "[Image Name]系统架构图\n[Image Type]Chart\n\n模块交互关系\n\n"
+        "[Image Footnotes]脚注1; 脚注2"
+    )
+    assert _parse_mm_display_name(drawing_content, "d1") == "系统架构图"
+
+    table_content = "[Table Name]性能对比表\n\n各方法的指标对比"
+    assert _parse_mm_display_name(table_content, "t1") == "性能对比表"
+
+    equation_content = "E = mc^2\n[Equation Name]质能方程\n\n爱因斯坦的质能等效公式"
+    assert _parse_mm_display_name(equation_content, "e1") == "质能方程"
+
+    # Fallbacks: missing marker, empty content, marker with blank name.
+    assert _parse_mm_display_name("no marker here", "fallback-id") == "fallback-id"
+    assert _parse_mm_display_name("", "fallback-id") == "fallback-id"
+    assert _parse_mm_display_name("[Image Name]   ", "fallback-id") == "fallback-id"
+
+
+@pytest.mark.offline
+def test_parse_mm_display_name_on_real_builder_output(tmp_path):
+    """End-to-end pin: feed actual chunks from
+    ``_build_mm_chunks_from_sidecars`` for all three modalities straight
+    into the consumer's parser, and require the analysis ``name`` field
+    to come back. This locks the bidirectional builder/consumer contract
+    so that renaming the ``[Image|Table|Equation] Name`` label without
+    updating the regex in ``operate._parse_mm_display_name`` immediately
+    breaks here instead of silently degrading relation descriptions.
+    """
+
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+
+        blocks = tmp_path / "demo.pdf.blocks.jsonl"
+        blocks.write_text("", encoding="utf-8")
+
+        heading = {"level": 1, "heading": "章节A", "parent_headings": []}
+
+        (tmp_path / "demo.pdf.drawings.json").write_text(
+            json.dumps(
+                {
+                    "drawings": {
+                        "d1": {
+                            "heading": heading,
+                            "footnotes": [],
+                            "llm_cache_list": [],
+                            "llm_analyze_result": {
+                                "name": "系统架构图",
+                                "type": "Chart",
+                                "description": "模块交互关系",
+                                "analyze_time": 1700000000,
+                                "status": "success",
+                                "message": "",
+                            },
+                        }
+                    }
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+        (tmp_path / "demo.pdf.tables.json").write_text(
+            json.dumps(
+                {
+                    "tables": {
+                        "t1": {
+                            "heading": heading,
+                            "footnotes": [],
+                            "llm_cache_list": [],
+                            "llm_analyze_result": {
+                                "name": "性能对比表",
+                                "description": "各方法的指标对比",
+                                "analyze_time": 1700000001,
+                                "status": "success",
+                                "message": "",
+                            },
+                        }
+                    }
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+        (tmp_path / "demo.pdf.equations.json").write_text(
+            json.dumps(
+                {
+                    "equations": {
+                        "e1": {
+                            "heading": heading,
+                            "footnotes": [],
+                            "llm_cache_list": [],
+                            "llm_analyze_result": {
+                                "name": "质能方程",
+                                "equation": "E = mc^2",
+                                "description": "爱因斯坦的质能等效公式",
+                                "analyze_time": 1700000002,
+                                "status": "success",
+                                "message": "",
+                            },
+                        }
+                    }
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+
+        mm_chunks = rag._build_mm_chunks_from_sidecars(
+            doc_id="doc-1",
+            file_path="demo.pdf",
+            blocks_path=str(blocks),
+            base_order_index=0,
+            process_options="ite",
+        )
+        # Index by sidecar type for stable assertions independent of
+        # iteration order in the builder.
+        by_type = {chunk["sidecar"]["type"]: chunk for chunk in mm_chunks}
+        assert set(by_type.keys()) == {"drawing", "table", "equation"}
+
+        expected = {
+            "drawing": ("d1", "系统架构图"),
+            "table": ("t1", "性能对比表"),
+            "equation": ("e1", "质能方程"),
+        }
+        for kind, (sidecar_id, name) in expected.items():
+            display = _parse_mm_display_name(by_type[kind]["content"], sidecar_id)
+            assert display == name, (
+                f"{kind}: parser failed to extract '{name}' from builder "
+                f"output, got '{display}' (content: {by_type[kind]['content']!r})"
+            )
 
         await rag.finalize_storages()
 


### PR DESCRIPTION
## Summary

This PR bundles two related refactors of the multimodal chunk pipeline:

1. **Consolidate image rendering** (`73b96b55`) — merge `_render_image` into `_render` by adding an `image_type` parameter, remove the redundant helper plus its dead-code drawing branch left behind by the earlier rewrite, and simplify `_compose` to a single unified call.

2. **Switch chunk content to inline bracket-label format** (`e26c29be`):
   - `_render` now emits `[Image|Table|Equation Name]value` inline labels instead of the old multi-line `- X:\n value` blocks; description loses its label and becomes plain body text; equation body moves to the head with no label.
   - Replace the inline regex in `operate.extract_entities` with a small `_parse_mm_display_name` helper + precompiled `_MM_DISPLAY_NAME_PATTERN`, kept in sync with the new producer format so relation descriptions resolve to the friendly analysis `name` instead of silently falling back to sidecar ids.
   - Document the producer/consumer contract from both sides (NOTE block in `_render`, docstring in `_parse_mm_display_name`) and add an end-to-end regression that feeds real builder output through the consumer parser for all three modalities.

## Test plan

- [x] `pytest tests/test_pipeline_release_closure.py` — 60 passed, 1 xfailed (pre-existing)
- [x] New regressions cover all three modalities:
  - `test_parse_mm_display_name_matches_chunk_format` — unit-level parser robustness incl. fallbacks
  - `test_parse_mm_display_name_on_real_builder_output` — end-to-end producer/consumer contract lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)