### PR TITLE
feat: dedupe cross-filename uploads via merged_text normalization

### DIFF
--- a/docs/LightRAGSidecarFormat-zh.md
+++ b/docs/LightRAGSidecarFormat-zh.md
@@ -69,7 +69,7 @@ inputs/space1/__parsed__/<规范文件名>.parsed/
 | `version` | `str` | sidecar schema 版本 |
 | `document_name` | `str` | 规范文件名（含后缀，不含处理指示） |
 | `document_format` | `str` | 文件格式（目前以文件后缀表示） |
-| `document_hash` | `"sha256:<hex>"` | 原始文件内容哈希，用于跨次解析去重 |
+| `document_hash` | `"sha256:<hex>"` | sidecar 正文指纹，定义为 `SHA-256(merged_text)`，其中 `merged_text` 是所有非空 content 行的 `content` 字段按 `"\n\n"` 拼接后的字符串。供外部消费者快速判断两份 `.parsed/` 是否同源（不必逐行比对 body），并作为 sidecar 文件的自描述内容校验位。注意：LightRAG 入库流水线本身不读此字段，跨文档去重由 `doc_status.content_hash` 单独承担 |
 | `table_file` / `equation_file` / `drawing_file` | `bool` | 是否存在对应 sidecar 文件（为真时对应文件必然存在） |
 | `asset_dir` | `bool` | 是否存在`blocks.assets`资源目录 |
 | `split_option` | `object` | 文件提取时的分块参数。此字段留给文件提取引擎自己记录和使用 |

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -75,7 +75,6 @@ from lightrag.utils_pipeline import (
     archive_source_after_full_docs_sync,
     build_chunks_dict_from_chunking_result,
     chunk_fields_from_status_doc,
-    compute_file_content_hash,
     compute_text_content_hash,
     doc_status_field,
     doc_status_transition_metadata,
@@ -429,12 +428,13 @@ class _PipelineMixin:
             body_length = len(strip_lightrag_doc_prefix(content, doc_format))
 
             # Compute content hash: skip for pending_parse (content extracted later).
+            # RAW and LIGHTRAG both hash the bare merged text so the same body
+            # carried by different envelopes (raw text vs sidecar) dedupes
+            # against itself across formats.
             content_hash: str | None = None
-            if doc_format == FULL_DOCS_FORMAT_RAW:
-                content_hash = compute_text_content_hash(content or "")
-            elif doc_format == FULL_DOCS_FORMAT_LIGHTRAG and lightrag_document_path:
-                content_hash = compute_file_content_hash(
-                    resolve_lightrag_document_path(lightrag_document_path)
+            if doc_format in (FULL_DOCS_FORMAT_RAW, FULL_DOCS_FORMAT_LIGHTRAG):
+                content_hash = compute_text_content_hash(
+                    strip_lightrag_doc_prefix(content or "", doc_format)
                 )
 
             known_source = has_known_document_source(canonical_key)
@@ -2768,14 +2768,14 @@ class _PipelineMixin:
         """
         fmt = record.get("parse_format")
         content_hash: str | None = None
-        if fmt == FULL_DOCS_FORMAT_RAW:
-            content_hash = compute_text_content_hash(record.get("content") or "")
-        elif fmt == FULL_DOCS_FORMAT_LIGHTRAG:
-            blocks_path = record.get("lightrag_document_path") or ""
-            if blocks_path:
-                content_hash = compute_file_content_hash(
-                    resolve_lightrag_document_path(blocks_path)
-                )
+        # Hash the bare merged text (after stripping the ``{{LRdoc}}`` marker
+        # for lightrag-format) so cross-filename dedup fires regardless of
+        # whether the same body was ingested as raw text or via a sidecar.
+        # ``strip_lightrag_doc_prefix`` is a no-op for non-lightrag formats.
+        if fmt in (FULL_DOCS_FORMAT_RAW, FULL_DOCS_FORMAT_LIGHTRAG):
+            content_hash = compute_text_content_hash(
+                strip_lightrag_doc_prefix(record.get("content") or "", fmt)
+            )
 
         existing = await self.full_docs.get_by_id(doc_id)
         if isinstance(existing, dict):

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import time
 from pathlib import Path
 from typing import Any, cast
@@ -262,9 +263,38 @@ def doc_status_value(doc: Any) -> str:
     return str(status or "")
 
 
+# Sidecar item ids embed ``doc_hash`` (= doc_id without the ``doc-`` prefix),
+# and for pending_parse uploads doc_id derives from the filename — so the
+# same content under two filenames renders with different ids in
+# ``merged_text``. Strip those surfaces before hashing so cross-filename
+# content_hash dedup actually fires.
+_SIDECAR_ID_PATTERN = re.compile(r"\b(tb|im|eq)-[0-9a-f]{32}-(\d{4})\b")
+_ASSET_PATH_PATTERN = re.compile(r'(?<=path=")[^"]*\.blocks\.assets/')
+
+
+def normalize_merged_text_for_hash(content: str) -> str:
+    """Strip filename-derived prefixes from sidecar ids and asset paths.
+
+    Idempotent and safe on plain text (matches the doc_hash literal only —
+    32 lowercase hex digits between the modality prefix and a 4-digit
+    sequence). RAW text bodies without sidecar markup pass through
+    unchanged.
+    """
+    if not content:
+        return content
+    content = _SIDECAR_ID_PATTERN.sub(r"\1-<DOC>-\2", content)
+    content = _ASSET_PATH_PATTERN.sub("<ASSETS>/", content)
+    return content
+
+
 def compute_text_content_hash(content: str) -> str:
-    """MD5 hex digest of text content used for cross-filename dedup."""
-    return compute_mdhash_id(content, prefix="")
+    """MD5 hex digest of text content used for cross-filename dedup.
+
+    Input is normalized via :func:`normalize_merged_text_for_hash` first so
+    sidecar-rendered bodies dedupe across filenames despite carrying
+    filename-derived item ids and asset paths.
+    """
+    return compute_mdhash_id(normalize_merged_text_for_hash(content), prefix="")
 
 
 def compute_file_content_hash(path_str: str) -> str | None:

--- a/tests/test_content_hash_normalization.py
+++ b/tests/test_content_hash_normalization.py
@@ -1,0 +1,70 @@
+"""Cross-filename content_hash dedup via merged_text normalization.
+
+Sidecar-rendered bodies embed ``tb-<doc_hash>-NNNN`` / ``im-<doc_hash>-NNNN`` /
+``eq-<doc_hash>-NNNN`` ids and ``path="<base>.blocks.assets/..."`` asset
+references — both derive from the filename for pending_parse uploads.
+``compute_text_content_hash`` normalizes those surfaces before hashing so
+the same content under two filenames produces the same ``content_hash``
+and post-parse dedup fires.
+"""
+
+from __future__ import annotations
+
+from lightrag.utils_pipeline import (
+    compute_text_content_hash,
+    normalize_merged_text_for_hash,
+)
+
+
+def _render(doc_hash: str, base_name: str) -> str:
+    """Approximate the sidecar writer's merged_text for a doc with one table,
+    one drawing, and one block equation."""
+    return (
+        "标题 1\n\n"
+        f'正文段落引用表格 <table id="tb-{doc_hash}-0001" format="json">[[]]</table>。\n\n'
+        f'<drawing id="im-{doc_hash}-0001" format="png" '
+        f'path="{base_name}.blocks.assets/image1.png" src="rId4" />\n\n'
+        f'<equation id="eq-{doc_hash}-0001" format="latex">E=mc^2</equation>'
+    )
+
+
+def test_same_content_different_filename_dedupes():
+    """Same merged_text with two different doc_hash / base names hashes to
+    the same content_hash."""
+    text_a = _render("a" * 32, "report-A")
+    text_b = _render("b" * 32, "report-B")
+
+    assert text_a != text_b, "sanity: raw bodies must differ"
+    assert compute_text_content_hash(text_a) == compute_text_content_hash(text_b)
+
+
+def test_different_content_still_distinguishes():
+    """Distinct bodies (different block text) still produce distinct hashes
+    after normalization."""
+    text_a = _render("a" * 32, "doc-A") + "\n\n附加段落 X"
+    text_b = _render("a" * 32, "doc-A") + "\n\n附加段落 Y"
+
+    assert compute_text_content_hash(text_a) != compute_text_content_hash(text_b)
+
+
+def test_plain_text_unaffected():
+    """RAW text without sidecar markup is passed through unchanged so its
+    hash matches the legacy ``MD5(text)`` value."""
+    plain = "纯文本上传，没有任何 sidecar 标签。"
+    assert normalize_merged_text_for_hash(plain) == plain
+
+
+def test_asset_filename_still_distinguishes():
+    """The asset filename suffix is preserved — only the ``<base>.blocks.assets/``
+    prefix is stripped — so two drawings pointing at different images still
+    yield different hashes."""
+    h = "c" * 32
+    text_a = (
+        f'<drawing id="im-{h}-0001" format="png" '
+        f'path="doc.blocks.assets/image1.png" src="r1" />'
+    )
+    text_b = (
+        f'<drawing id="im-{h}-0001" format="png" '
+        f'path="doc.blocks.assets/image2.png" src="r1" />'
+    )
+    assert compute_text_content_hash(text_a) != compute_text_content_hash(text_b)

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -1757,27 +1757,15 @@ def test_state_machine_upsert_preserves_content_hash(tmp_path):
 
 
 @pytest.mark.offline
-@pytest.mark.xfail(
-    reason=(
-        "Native parsing now produces LIGHTRAG-format full_docs and "
-        "content_hash is the MD5 of the .blocks.jsonl file. The writer "
-        "embeds doc_id into every block's blockid (md5 of "
-        "doc_id:idx:heading:content), so two distinct docx filenames "
-        "deterministically produce different .blocks.jsonl bytes even when "
-        "their underlying content is identical. Cross-document content_hash "
-        "dedup for native docx is therefore architecturally impossible "
-        "without changing the blockid scheme; tracked separately."
-    ),
-    strict=True,
-)
 def test_pending_parse_duplicate_hash_fails_and_archives_source(tmp_path, monkeypatch):
-    """Two PENDING_PARSE docx files producing identical .blocks.jsonl content
-    must be detected as content_hash duplicates and the loser archived.
+    """Two PENDING_PARSE docx files with identical extracted bodies must be
+    detected as content_hash duplicates and the loser archived.
 
-    See xfail reason above for why this is currently impossible to satisfy
-    without a blockid scheme change. Test body retained so that a future
-    refactor of the blockid algorithm (e.g., dropping doc_id from the hash
-    inputs) can flip this back to passing.
+    ``content_hash`` for LIGHTRAG-format docs is the MD5 of the normalized
+    ``merged_text`` (sidecar item ids and ``<base>.blocks.assets/`` prefixes
+    stripped via :func:`normalize_merged_text_for_hash`), so identical
+    bodies under different filenames produce the same hash and
+    ``_mark_duplicate_after_parse`` fires.
     """
 
     async def _run():


### PR DESCRIPTION
## Summary

- **Problem**: Upload-time dedup runs on filename only. After parse, `content_hash` is recomputed per format — but on the LIGHTRAG path it was MD5 of the `*.blocks.jsonl` *bytes*, which include `parse_time`, `doc_id`, and `document_name` in the meta line. The same source file uploaded under two filenames produced different bytes → different `content_hash` → `_mark_duplicate_after_parse` never fired.
- **Fix**: Two-step.
  1. (`d382f3c3`) Unify hash input across paths — both RAW and LIGHTRAG now hash `merged_text` (the body after stripping the `{{LRdoc}}` marker) using `compute_text_content_hash`.
  2. (`ce12663c`) Normalize filename-leaking surfaces *inside* `merged_text` before hashing — sidecar item ids (`tb-/im-/eq-<doc_hash>-NNNN`) and `<drawing path="<base>.blocks.assets/...">` prefixes — so the same content under different filenames produces the same hash.

## Why two commits

The hash-input unification (commit 1) is structurally correct but insufficient on its own: pending_parse uploads derive `doc_id` from the filename, and the sidecar writer bakes `doc_hash = doc_id.removeprefix("doc-")` into every rendered table/drawing/equation tag. So `a.docx` and `b.docx` with identical bytes still produced different `merged_text` even after commit 1. Commit 2 closes that gap with a regex normalization at the hash boundary.

## Effects

| Scenario | Before | After |
|---|---|---|
| Same DOCX under two filenames → native | not deduped | deduped (post-parse FAILED, `duplicate_kind=content_hash`) |
| Same PDF under two filenames → mineru | not deduped | deduped |
| Re-parse same file (meta.parse_time differs) | not deduped | deduped |
| RAW text body equals LIGHTRAG merged_text | algorithm mismatch | deduped |

## Scope of changes

- [lightrag/pipeline.py](lightrag/pipeline.py) — `_add_content` and `_persist_parsed_full_docs` now share a single hash path; `compute_file_content_hash` no longer used here.
- [lightrag/utils_pipeline.py](lightrag/utils_pipeline.py) — adds `normalize_merged_text_for_hash`; wires it into `compute_text_content_hash`.
- [docs/LightRAGSidecarFormat-zh.md](docs/LightRAGSidecarFormat-zh.md) — clarifies that sidecar `document_hash` is `SHA-256(merged_text)` for self-description; pipeline dedup uses the separate `doc_status.content_hash` (MD5 of normalized `merged_text`). The two fields are deliberately decoupled.

## Compatibility note

No migration. Existing `doc_status.content_hash` rows computed with the old algorithm won't dedupe against new uploads, but the field is only consulted for dedup decisions — nothing else breaks. New uploads dedupe against each other normally.

## Test plan

- [x] `tests/test_content_hash_normalization.py` — 4 new tests covering: same-content/different-filename → same hash, different-content → different hash, plain RAW text → unchanged, different asset filenames → different hashes
- [x] `pytest tests/test_chunking_raw_lightrag_parity.py tests/test_parse_native_lightrag_e2e.py tests/test_parse_mineru_sidecar.py tests/test_doc_status_chunk_preservation.py` — 38/38 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)