### PR TITLE
feat(mineru): split-by-heading block merging with markdown titles

### DIFF
--- a/lightrag/parser_adapters/mineru.py
+++ b/lightrag/parser_adapters/mineru.py
@@ -7,11 +7,19 @@ only reads the content list and image asset bytes.
 
 Conversion rules (informed by spec §3-§六):
 
-- ``text`` / ``list`` / ``code`` → IRBlock; list items joined with ``\n``;
-  ``code`` body taken from ``code_body`` if present.
-- ``title`` / ``section_header`` → updates the heading stack AND emits its
-  own block whose content equals the heading (consistent with the native
-  adapter so "first H1" can serve as ``doc_title``).
+- ``text`` items with ``text_level>0`` and ``title`` / ``section_header``
+  start a NEW block. The heading text is rendered with a markdown ``#``
+  prefix matching the level (``# foo``, ``## bar`` …) as the first line of
+  the new block's content.
+- All other items (``text``, ``list``, ``code``, ``table``, ``image``,
+  ``equation``) are MERGED into the current block — their text / placeholder
+  is appended (newline-separated) to the heading's block. This mirrors the
+  native docx parser's "split-by-heading, merge-everything-under-heading"
+  behavior (see ``native_parser/docx/parse_document.py``).
+- Content emitted before the first heading lands in a synthetic
+  ``Preface/Uncategorized`` block at level 0.
+- ``list`` items joined with ``\n``; ``code`` body taken from ``code_body``
+  if present.
 - ``table`` → IRTable + ``{{TBL:k}}`` placeholder. ``table_body`` (HTML) or
   the ``rows`` field (2D array) become ``html`` / ``rows`` on IRTable.
   ``num_rows`` / ``num_cols`` are taken from MinerU if present, otherwise
@@ -20,10 +28,12 @@ Conversion rules (informed by spec §3-§六):
   Asset bytes are referenced via ``img_path`` relative to the raw dir.
 - ``equation`` → IREquation. ``is_block`` is decided by whether
   ``text_format=="block"`` (MinerU explicit flag) OR ``text_level==0`` with
-  no inline neighbours; otherwise inline. A bare ``$..$`` wrapper on
-  ``text`` is stripped before being treated as LaTeX.
+  no inline neighbours; otherwise inline. The latex string is preserved
+  verbatim (including any ``$$``/``$`` wrappers) so ``blocks.jsonl``'s
+  ``<equation>`` body matches MinerU's raw output; the writer strips the
+  wrappers when persisting ``equations.json`` content.
 - ``page_idx`` + ``bbox`` → ``IRPosition(type="bbox", anchor=page, range=[x0,y0,x1,y1])``.
-  Empty/missing bbox is acceptable.
+  Empty/missing bbox is acceptable; positions accumulate on the merged block.
 - ``IRDoc.split_option`` records the MinerU engine version when available.
 - ``IRDoc.bbox_attributes`` defaults to ``{"origin":"LEFTTOP","max":1000}``
   reflecting MinerU's PDF coordinate convention. Operators may override
@@ -34,7 +44,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -51,7 +60,7 @@ from lightrag.sidecar.ir import (
 from lightrag.utils import logger
 
 
-_LATEX_DOLLAR_RE = re.compile(r"^\s*\$\$?(.+?)\$\$?\s*$", re.DOTALL)
+PREFACE_HEADING = "Preface/Uncategorized"
 
 
 class MinerUAdapter:
@@ -133,12 +142,10 @@ class MinerUAdapter:
     ) -> IRDoc:
         document_format = Path(document_name).suffix.lower().lstrip(".")
 
-        heading_stack: list[str] = []
         blocks: list[IRBlock] = []
         assets: list[AssetSpec] = []
         seen_assets: dict[str, str] = {}  # ref → suggested_name
         doc_title = ""
-
         placeholder_counter = 0
 
         def _next_key(prefix: str) -> str:
@@ -146,18 +153,102 @@ class MinerUAdapter:
             placeholder_counter += 1
             return f"{prefix}{placeholder_counter}"
 
-        def _update_heading(text: str, level: int) -> tuple[str, int, list[str]]:
-            clean = (text or "").strip()
-            lv = max(int(level or 1), 1)
-            nonlocal heading_stack
-            heading_stack = heading_stack[: max(lv - 1, 0)]
-            parents = [h for h in heading_stack if h]
-            heading_stack.append(clean)
-            return clean, lv, parents
+        # Heading hierarchy stack — index = level-1 (level 1 lives at [0]).
+        heading_stack: list[str] = []
 
-        current_heading = ""
-        current_level = 0
-        current_parents: list[str] = []
+        # Current-block accumulator. The block is materialized when the next
+        # heading arrives (or at end-of-document). The initial block is the
+        # synthetic "Preface/Uncategorized" container at level 0.
+        cb_lines: list[str] = []
+        cb_tables: list[IRTable] = []
+        cb_drawings: list[IRDrawing] = []
+        cb_equations: list[IREquation] = []
+        cb_positions: list[IRPosition] = []
+        cb_heading = PREFACE_HEADING
+        cb_level = 0
+        cb_parents: list[str] = []
+        # ``cb_has_body`` flips True the moment we accumulate any non-heading
+        # payload into the current block. While it stays False, an adjacent
+        # deeper heading is folded into this block as a body line (aligning
+        # with the native docx parser's behaviour for back-to-back headings).
+        cb_has_body = False
+
+        def _flush_block() -> None:
+            """Emit the in-flight block if it carries any content."""
+            nonlocal cb_lines, cb_tables, cb_drawings, cb_equations, cb_positions
+            nonlocal cb_has_body
+            has_payload = bool(
+                cb_lines or cb_tables or cb_drawings or cb_equations
+            )
+            if not has_payload:
+                return
+            content = "\n".join(line for line in cb_lines if line)
+            if not content.strip() and not (
+                cb_tables or cb_drawings or cb_equations
+            ):
+                # Reset and skip — nothing meaningful to emit.
+                cb_lines = []
+                cb_positions = []
+                cb_has_body = False
+                return
+            blocks.append(
+                IRBlock(
+                    content_template=content,
+                    heading=cb_heading,
+                    level=cb_level,
+                    parent_headings=list(cb_parents),
+                    positions=list(cb_positions),
+                    tables=list(cb_tables),
+                    drawings=list(cb_drawings),
+                    equations=list(cb_equations),
+                )
+            )
+            cb_lines = []
+            cb_tables = []
+            cb_drawings = []
+            cb_equations = []
+            cb_positions = []
+            cb_has_body = False
+
+        def _open_block(
+            heading: str,
+            level: int,
+            parents: list[str],
+            position: IRPosition | None,
+        ) -> None:
+            nonlocal cb_heading, cb_level, cb_parents
+            cb_heading = heading
+            cb_level = level
+            cb_parents = parents
+            # Render the heading line into the block body so the merged
+            # text reads like markdown (``# Foo`` / ``## Bar`` / …).
+            md_prefix = "#" * max(level, 1)
+            cb_lines.append(f"{md_prefix} {heading}")
+            if position is not None:
+                cb_positions.append(position)
+
+        def _append_text(text: str, position: IRPosition | None) -> None:
+            nonlocal cb_has_body
+            if text:
+                cb_lines.append(text)
+                cb_has_body = True
+            if position is not None:
+                cb_positions.append(position)
+
+        def _merge_heading_as_body(
+            heading: str, level: int, position: IRPosition | None
+        ) -> None:
+            """Fold an adjacent deeper heading into the current block.
+
+            The line keeps its markdown ``#`` prefix so the rendered block
+            still reads as ``# Section\n## Subsection``. Does NOT flip
+            ``cb_has_body`` — successive headings can keep folding until a
+            real body item lands.
+            """
+            md_prefix = "#" * max(level, 1)
+            cb_lines.append(f"{md_prefix} {heading}")
+            if position is not None:
+                cb_positions.append(position)
 
         for item in content_list:
             if not isinstance(item, dict):
@@ -165,81 +256,51 @@ class MinerUAdapter:
             item_type = str(item.get("type") or item.get("label") or "").lower()
             position = _extract_position(item)
 
-            if item_type in {"text"}:
-                text = _coerce_text(item)
-                if not text:
+            heading_text, heading_level = _detect_heading(item, item_type)
+            if heading_text:
+                # Heading hierarchy is updated unconditionally so deeper
+                # parents resolve correctly once the next real body item
+                # opens a fresh block.
+                heading_stack = heading_stack[: max(heading_level - 1, 0)]
+                parents = [h for h in heading_stack if h]
+                heading_stack.append(heading_text)
+
+                # Adjacency merge: previous block is a real heading with no
+                # body yet AND the new heading is strictly deeper — append
+                # this heading as body to the existing block instead of
+                # flushing. (Preface, level=0, is never merged into.)
+                if (
+                    cb_level > 0
+                    and not cb_has_body
+                    and heading_level > cb_level
+                ):
+                    _merge_heading_as_body(heading_text, heading_level, position)
+                    if not doc_title and heading_level == 1:
+                        doc_title = heading_text
                     continue
-                inferred_level = int(item.get("text_level") or 0)
-                if inferred_level > 0:
-                    current_heading, current_level, current_parents = _update_heading(
-                        text, inferred_level
-                    )
-                    if not doc_title and inferred_level == 1:
-                        doc_title = current_heading
-                blocks.append(
-                    IRBlock(
-                        content_template=text,
-                        heading=current_heading,
-                        level=current_level if inferred_level > 0 else current_level,
-                        parent_headings=list(current_parents),
-                        positions=[position] if position else [],
-                    )
-                )
+
+                _flush_block()
+                _open_block(heading_text, heading_level, parents, position)
+
+                if not doc_title and heading_level == 1:
+                    doc_title = heading_text
                 continue
 
-            if item_type in {"title", "section_header"}:
-                text = _coerce_text(item)
-                if not text:
-                    continue
-                inferred_level = int(item.get("text_level") or item.get("level") or 1)
-                current_heading, current_level, current_parents = _update_heading(
-                    text, inferred_level
-                )
-                if not doc_title and inferred_level == 1:
-                    doc_title = current_heading
-                blocks.append(
-                    IRBlock(
-                        content_template=text,
-                        heading=current_heading,
-                        level=current_level,
-                        parent_headings=list(current_parents),
-                        positions=[position] if position else [],
-                    )
-                )
+            if item_type == "text":
+                _append_text(_coerce_text(item), position)
                 continue
 
-            if item_type in {"list"}:
+            if item_type == "list":
                 items = item.get("list_items")
                 if isinstance(items, list):
                     text = "\n".join(str(x) for x in items if str(x).strip())
                 else:
                     text = _coerce_text(item)
-                if not text:
-                    continue
-                blocks.append(
-                    IRBlock(
-                        content_template=text,
-                        heading=current_heading,
-                        level=current_level,
-                        parent_headings=list(current_parents),
-                        positions=[position] if position else [],
-                    )
-                )
+                _append_text(text, position)
                 continue
 
-            if item_type in {"code"}:
-                text = item.get("code_body") or _coerce_text(item)
-                if not text:
-                    continue
-                blocks.append(
-                    IRBlock(
-                        content_template=text,
-                        heading=current_heading,
-                        level=current_level,
-                        parent_headings=list(current_parents),
-                        positions=[position] if position else [],
-                    )
-                )
+            if item_type == "code":
+                _append_text(item.get("code_body") or _coerce_text(item), position)
                 continue
 
             if item_type == "equation":
@@ -247,46 +308,39 @@ class MinerUAdapter:
                 if not latex_raw:
                     # Spec compliance fix: empty equation must not enter sidecar.
                     continue
-                m = _LATEX_DOLLAR_RE.match(latex_raw)
-                latex = m.group(1).strip() if m else latex_raw.strip()
+                # Preserve MinerU's raw latex (including any ``$$``/``$``
+                # wrappers); the writer strips them when emitting
+                # equations.json so blocks.jsonl shows the raw form while
+                # the per-equation sidecar holds clean latex.
+                latex = latex_raw.strip()
                 is_block = _is_block_equation(item)
                 caption = str(item.get("caption") or "")
                 placeholder = _next_key("eq")
                 token = "EQ" if is_block else "EQI"
-                blocks.append(
-                    IRBlock(
-                        content_template=f"{{{{{token}:{placeholder}}}}}",
-                        heading=current_heading,
-                        level=current_level,
-                        parent_headings=list(current_parents),
-                        equations=[
-                            IREquation(
-                                placeholder_key=placeholder,
-                                latex=latex,
-                                is_block=is_block,
-                                caption=caption,
-                                footnotes=_as_str_list(item.get("footnotes")),
-                            )
-                        ],
-                        positions=[position] if position else [],
+                cb_equations.append(
+                    IREquation(
+                        placeholder_key=placeholder,
+                        latex=latex,
+                        is_block=is_block,
+                        caption=caption,
+                        footnotes=_as_str_list(item.get("footnotes")),
                     )
                 )
+                cb_lines.append(f"{{{{{token}:{placeholder}}}}}")
+                cb_has_body = True
+                if position is not None:
+                    cb_positions.append(position)
                 continue
 
             if item_type == "table":
                 table = self._build_ir_table(item)
                 placeholder = _next_key("tb")
                 table.placeholder_key = placeholder
-                blocks.append(
-                    IRBlock(
-                        content_template=f"{{{{TBL:{placeholder}}}}}",
-                        heading=current_heading,
-                        level=current_level,
-                        parent_headings=list(current_parents),
-                        tables=[table],
-                        positions=[position] if position else [],
-                    )
-                )
+                cb_tables.append(table)
+                cb_lines.append(f"{{{{TBL:{placeholder}}}}}")
+                cb_has_body = True
+                if position is not None:
+                    cb_positions.append(position)
                 continue
 
             if item_type in {"image", "picture", "drawing"}:
@@ -295,31 +349,18 @@ class MinerUAdapter:
                 drawing.placeholder_key = placeholder
                 if asset is not None and asset.ref not in {a.ref for a in assets}:
                     assets.append(asset)
-                blocks.append(
-                    IRBlock(
-                        content_template=f"{{{{IMG:{placeholder}}}}}",
-                        heading=current_heading,
-                        level=current_level,
-                        parent_headings=list(current_parents),
-                        drawings=[drawing],
-                        positions=[position] if position else [],
-                    )
-                )
+                cb_drawings.append(drawing)
+                cb_lines.append(f"{{{{IMG:{placeholder}}}}}")
+                cb_has_body = True
+                if position is not None:
+                    cb_positions.append(position)
                 continue
 
             # Fallback: serialize unknown items as plain text so we don't
             # silently drop information.
-            text = _coerce_text(item)
-            if text:
-                blocks.append(
-                    IRBlock(
-                        content_template=text,
-                        heading=current_heading,
-                        level=current_level,
-                        parent_headings=list(current_parents),
-                        positions=[position] if position else [],
-                    )
-                )
+            _append_text(_coerce_text(item), position)
+
+        _flush_block()
 
         if not doc_title:
             doc_title = Path(document_name).stem or document_name
@@ -453,6 +494,26 @@ class MinerUAdapter:
 # ----------------------------------------------------------------------
 # helpers
 # ----------------------------------------------------------------------
+
+
+def _detect_heading(item: dict, item_type: str) -> tuple[str, int]:
+    """Return ``(heading_text, level)`` if ``item`` is a heading, else ``("", 0)``.
+
+    A heading is either an explicit ``title``/``section_header`` block, or a
+    ``text`` block whose ``text_level`` is positive (MinerU's convention).
+    """
+    if item_type in {"title", "section_header"}:
+        text = _coerce_text(item).strip()
+        level = max(int(item.get("text_level") or item.get("level") or 1), 1)
+        return text, level
+    if item_type == "text":
+        try:
+            tl = int(item.get("text_level") or 0)
+        except (TypeError, ValueError):
+            tl = 0
+        if tl > 0:
+            return _coerce_text(item).strip(), tl
+    return "", 0
 
 
 def _coerce_text(item: dict) -> str:

--- a/lightrag/parser_adapters/mineru.py
+++ b/lightrag/parser_adapters/mineru.py
@@ -177,15 +177,11 @@ class MinerUAdapter:
             """Emit the in-flight block if it carries any content."""
             nonlocal cb_lines, cb_tables, cb_drawings, cb_equations, cb_positions
             nonlocal cb_has_body
-            has_payload = bool(
-                cb_lines or cb_tables or cb_drawings or cb_equations
-            )
+            has_payload = bool(cb_lines or cb_tables or cb_drawings or cb_equations)
             if not has_payload:
                 return
             content = "\n".join(line for line in cb_lines if line)
-            if not content.strip() and not (
-                cb_tables or cb_drawings or cb_equations
-            ):
+            if not content.strip() and not (cb_tables or cb_drawings or cb_equations):
                 # Reset and skip — nothing meaningful to emit.
                 cb_lines = []
                 cb_positions = []
@@ -269,11 +265,7 @@ class MinerUAdapter:
                 # body yet AND the new heading is strictly deeper — append
                 # this heading as body to the existing block instead of
                 # flushing. (Preface, level=0, is never merged into.)
-                if (
-                    cb_level > 0
-                    and not cb_has_body
-                    and heading_level > cb_level
-                ):
+                if cb_level > 0 and not cb_has_body and heading_level > cb_level:
                     _merge_heading_as_body(heading_text, heading_level, position)
                     if not doc_title and heading_level == 1:
                         doc_title = heading_text

--- a/lightrag/sidecar/writer.py
+++ b/lightrag/sidecar/writer.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
@@ -582,6 +583,24 @@ def _drawing_item_dict(
     return item
 
 
+_LATEX_DOLLAR_RE = re.compile(r"^\s*\$\$?(.+?)\$\$?\s*$", re.DOTALL)
+
+
+def _strip_latex_dollar_wrappers(latex: str) -> str:
+    """Strip leading/trailing ``$``/``$$`` wrappers from a latex string.
+
+    ``equations.json`` stores clean latex (per the MinerU adapter contract:
+    ``blocks.jsonl`` keeps the parser's raw form so the rendered
+    ``<equation>`` body is byte-identical to the source, while the
+    per-equation sidecar carries delimiter-free latex). Leaves strings
+    without wrappers untouched.
+    """
+    if not latex:
+        return latex
+    m = _LATEX_DOLLAR_RE.match(latex)
+    return m.group(1).strip() if m else latex.strip()
+
+
 def _equation_item_dict(
     eq_id: str,
     blockid: str,
@@ -593,7 +612,7 @@ def _equation_item_dict(
         "blockid": blockid,
         "heading": heading,
         "format": "latex",
-        "content": equation.latex,
+        "content": _strip_latex_dollar_wrappers(equation.latex),
         "caption": equation.caption,
         "footnotes": list(equation.footnotes),
     }

--- a/tests/parser_adapters/test_mineru_adapter.py
+++ b/tests/parser_adapters/test_mineru_adapter.py
@@ -33,16 +33,85 @@ def test_adapter_simple_text_and_heading(tmp_path: Path) -> None:
 
     assert ir.doc_title == "1 Introduction"
     assert ir.document_format == "pdf"
-    assert len(ir.blocks) == 4
+    # Heading + body merge into a single block per heading.
+    assert len(ir.blocks) == 2
     assert ir.blocks[0].heading == "1 Introduction"
     assert ir.blocks[0].level == 1
-    # Body inherits the current heading + level.
-    assert ir.blocks[1].heading == "1 Introduction"
-    assert ir.blocks[1].level == 1
+    # Heading line is rendered with markdown ``#`` prefix matching the level.
+    assert ir.blocks[0].content_template == "# 1 Introduction\nBody paragraph."
     # Sub-heading updates stack and records parent.
-    assert ir.blocks[2].heading == "1.1 Sub"
-    assert ir.blocks[2].level == 2
-    assert ir.blocks[2].parent_headings == ["1 Introduction"]
+    assert ir.blocks[1].heading == "1.1 Sub"
+    assert ir.blocks[1].level == 2
+    assert ir.blocks[1].parent_headings == ["1 Introduction"]
+    assert ir.blocks[1].content_template == "## 1.1 Sub\nSub body."
+
+
+@pytest.mark.offline
+def test_adapter_preface_block_for_pre_heading_content(tmp_path: Path) -> None:
+    """Items emitted before the first heading land in a synthetic
+    ``Preface/Uncategorized`` block at level 0."""
+    raw = _write_bundle(
+        tmp_path,
+        [
+            {"type": "text", "text": "Floating intro line."},
+            {"type": "list", "list_items": ["a", "b"]},
+            {"type": "text", "text": "Section A", "text_level": 1},
+            {"type": "text", "text": "A body."},
+        ],
+    )
+    ir = MinerUAdapter().normalize_from_workdir(raw, document_name="p.pdf")
+
+    assert len(ir.blocks) == 2
+    preface = ir.blocks[0]
+    assert preface.heading == "Preface/Uncategorized"
+    assert preface.level == 0
+    assert preface.parent_headings == []
+    assert preface.content_template == "Floating intro line.\na\nb"
+
+    section = ir.blocks[1]
+    assert section.heading == "Section A"
+    assert section.level == 1
+    assert section.content_template == "# Section A\nA body."
+
+
+@pytest.mark.offline
+def test_adapter_merges_mixed_payloads_under_heading(tmp_path: Path) -> None:
+    """Tables / images / equations / code under the same heading merge into
+    one block; their placeholders appear in document order."""
+    raw = _write_bundle(
+        tmp_path,
+        [
+            {"type": "text", "text": "Methods", "text_level": 1},
+            {"type": "text", "text": "We did stuff."},
+            {
+                "type": "table",
+                "table_body": [["a", "b"], ["1", "2"]],
+                "num_rows": 2,
+                "num_cols": 2,
+            },
+            {"type": "image", "img_path": "images/fig1.png"},
+            {"type": "equation", "text": "$$E = mc^2$$"},
+            {"type": "code", "code_body": "print('ok')"},
+        ],
+    )
+    ir = MinerUAdapter().normalize_from_workdir(raw, document_name="m.pdf")
+    assert len(ir.blocks) == 1
+    block = ir.blocks[0]
+    assert block.heading == "Methods"
+    assert block.level == 1
+    assert len(block.tables) == 1
+    assert len(block.drawings) == 1
+    assert len(block.equations) == 1
+    # Lines are joined in source order; the heading carries its ``#`` prefix.
+    expected_lines = [
+        "# Methods",
+        "We did stuff.",
+        f"{{{{TBL:{block.tables[0].placeholder_key}}}}}",
+        f"{{{{IMG:{block.drawings[0].placeholder_key}}}}}",
+        f"{{{{EQ:{block.equations[0].placeholder_key}}}}}",
+        "print('ok')",
+    ]
+    assert block.content_template == "\n".join(expected_lines)
 
 
 @pytest.mark.offline
@@ -93,9 +162,126 @@ def test_adapter_table_and_drawing_and_equation(tmp_path: Path) -> None:
 
     equation_block = next(b for b in ir.blocks if b.equations)
     eq = equation_block.equations[0]
-    assert eq.latex == "E = mc^2"  # $..$ stripped
+    # IREquation.latex preserves MinerU's raw form so blocks.jsonl shows it
+    # verbatim; equations.json strips the ``$`` wrappers downstream (writer).
+    assert eq.latex == "$E = mc^2$"
     assert eq.is_block is True
     assert eq.caption == "Eq 1"
+
+
+@pytest.mark.offline
+def test_adapter_adjacent_deeper_heading_merged_as_body(tmp_path: Path) -> None:
+    """Two headings in a row with no body between them: when the second is
+    strictly deeper (level number larger), it folds into the first heading's
+    block as a body line. Mirrors the native docx parser's behaviour.
+    """
+    raw = _write_bundle(
+        tmp_path,
+        [
+            {"type": "text", "text": "1 Top", "text_level": 1},
+            {"type": "text", "text": "1.1 Mid", "text_level": 2},
+            {"type": "text", "text": "1.1.1 Deep", "text_level": 3},
+            {"type": "text", "text": "Body for deep."},
+            {"type": "text", "text": "2 Top Again", "text_level": 1},
+            {"type": "text", "text": "More body."},
+        ],
+    )
+    ir = MinerUAdapter().normalize_from_workdir(raw, document_name="m.pdf")
+
+    # First "1 Top" absorbs the immediately-following deeper headings;
+    # body lands inside the same block. Then a new top-level heading
+    # opens a fresh block.
+    assert len(ir.blocks) == 2
+
+    merged = ir.blocks[0]
+    assert merged.heading == "1 Top"
+    assert merged.level == 1
+    assert merged.parent_headings == []
+    assert merged.content_template == (
+        "# 1 Top\n## 1.1 Mid\n### 1.1.1 Deep\nBody for deep."
+    )
+
+    fresh = ir.blocks[1]
+    assert fresh.heading == "2 Top Again"
+    assert fresh.level == 1
+    # Heading stack reset cleanly — no stale deep parents leak.
+    assert fresh.parent_headings == []
+    assert fresh.content_template == "# 2 Top Again\nMore body."
+
+
+@pytest.mark.offline
+def test_adapter_adjacent_shallower_heading_starts_new_block(
+    tmp_path: Path,
+) -> None:
+    """Inverse case: when the second adjacent heading is shallower (level
+    number smaller or equal), it must NOT merge — it starts a new block.
+    """
+    raw = _write_bundle(
+        tmp_path,
+        [
+            {"type": "text", "text": "1.1 Mid first", "text_level": 2},
+            {"type": "text", "text": "2 Top after", "text_level": 1},
+            {"type": "text", "text": "body"},
+        ],
+    )
+    ir = MinerUAdapter().normalize_from_workdir(raw, document_name="m.pdf")
+
+    # The first block is heading-only; the writer downstream will keep it
+    # (the merged-heading rule only forwards DEEPER headings).
+    assert len(ir.blocks) == 2
+    assert ir.blocks[0].heading == "1.1 Mid first"
+    assert ir.blocks[0].level == 2
+    assert ir.blocks[0].content_template == "## 1.1 Mid first"
+
+    assert ir.blocks[1].heading == "2 Top after"
+    assert ir.blocks[1].level == 1
+    assert ir.blocks[1].content_template == "# 2 Top after\nbody"
+
+
+@pytest.mark.offline
+def test_adapter_body_breaks_adjacent_heading_merge(tmp_path: Path) -> None:
+    """Once any body content lands in the current block, the next heading —
+    even a deeper one — must flush and open a fresh block (no merge)."""
+    raw = _write_bundle(
+        tmp_path,
+        [
+            {"type": "text", "text": "1 Top", "text_level": 1},
+            {"type": "text", "text": "Intro line under 1."},
+            {"type": "text", "text": "1.1 Mid", "text_level": 2},
+            {"type": "text", "text": "Mid body."},
+        ],
+    )
+    ir = MinerUAdapter().normalize_from_workdir(raw, document_name="m.pdf")
+
+    assert len(ir.blocks) == 2
+    assert ir.blocks[0].content_template == "# 1 Top\nIntro line under 1."
+    assert ir.blocks[1].heading == "1.1 Mid"
+    assert ir.blocks[1].parent_headings == ["1 Top"]
+    assert ir.blocks[1].content_template == "## 1.1 Mid\nMid body."
+
+
+@pytest.mark.offline
+def test_adapter_block_equation_preserves_dollar_wrappers(tmp_path: Path) -> None:
+    """Block equations keep the ``$$`` markers verbatim on IREquation.latex
+    so the writer renders blocks.jsonl's ``<equation>`` body byte-identical
+    to MinerU's source. The downstream writer is responsible for stripping
+    them when generating equations.json."""
+    raw = _write_bundle(
+        tmp_path,
+        [
+            {
+                "type": "equation",
+                "text": "$$\n\\int_0^1 x dx = \\tfrac{1}{2}\n$$",
+                "text_format": "block",
+                "caption": "Eq A",
+            },
+        ],
+    )
+    ir = MinerUAdapter().normalize_from_workdir(raw, document_name="b.pdf")
+    eq = ir.blocks[0].equations[0]
+    assert eq.is_block is True
+    # No stripping in the adapter; whitespace.strip() only.
+    assert eq.latex == "$$\n\\int_0^1 x dx = \\tfrac{1}{2}\n$$"
 
 
 @pytest.mark.offline

--- a/tests/sidecar/test_writer.py
+++ b/tests/sidecar/test_writer.py
@@ -148,6 +148,47 @@ def test_writer_drawing_path_points_into_assets_dir(tmp_path: Path) -> None:
 
 
 @pytest.mark.offline
+def test_writer_equation_strips_dollar_wrappers_for_equations_json(
+    tmp_path: Path,
+) -> None:
+    """When IREquation.latex carries MinerU's raw ``$$...$$``/``$..$``
+    wrappers (preserved so blocks.jsonl shows the source verbatim), the
+    writer must strip them when persisting equations.json content — that
+    file holds clean latex by contract."""
+    parsed = tmp_path / "d.parsed"
+    ir = IRDoc(
+        document_name="d.pdf",
+        document_format="pdf",
+        doc_title="d",
+        split_option={},
+        blocks=[
+            IRBlock(
+                content_template="see {{EQ:b1}}",
+                equations=[
+                    IREquation(
+                        placeholder_key="b1",
+                        latex="$$\nE = mc^2\n$$",
+                        is_block=True,
+                    ),
+                ],
+            )
+        ],
+    )
+    write_sidecar(ir, parsed_dir=parsed, doc_id="doc-deadbeef", engine="mineru")
+
+    # blocks.jsonl: <equation> body preserves the parser's raw form.
+    body = _load_jsonl(parsed / "d.blocks.jsonl")[1][0]["content"]
+    assert (
+        '<equation id="eq-deadbeef-0001" format="latex">$$\nE = mc^2\n$$</equation>'
+        in body
+    )
+
+    # equations.json: dollar wrappers removed.
+    equations = json.loads((parsed / "d.equations.json").read_text())["equations"]
+    assert equations["eq-deadbeef-0001"]["content"] == "E = mc^2"
+
+
+@pytest.mark.offline
 def test_writer_equation_caption_preserved_block_and_inline(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- Re-shape MinerU `content_list.json` → IRDoc conversion to mirror the native docx parser's "split-by-heading, merge-everything-under-heading" layout
- Render heading text with matching markdown `#` prefix (`# Foo`, `## Bar`, …) as the first line of each block; pre-heading items fall into a synthetic `Preface/Uncategorized` block at level 0
- Fold an adjacent deeper heading into the previous heading's block as a body line when no real body has landed yet — aligns with the docx parser's `has_body_content` gating
- Preserve MinerU's raw `$$`/`$` wrappers on `IREquation.latex` so `blocks.jsonl` shows the source verbatim; the sidecar writer strips them when persisting `equations.json` content

## Motivation
The previous MinerU adapter emitted one IR block per content_list entry. That left downstream chunkers with awkward inputs: headings sat in their own micro-blocks with no inline `#` cues, equations lost their delimiter context, and `Preface/Uncategorized` boundary handling diverged from the native docx flow. This PR brings MinerU output in line with the docx parser so multimodal / chunking consumers see a uniform shape regardless of engine.

## What's changed
- `lightrag/parser_adapters/mineru.py`: rewritten `_normalize_content_list` with a current-block accumulator (`cb_*` state + `cb_has_body` flag), heading-aware flushing, adjacency merge, and markdown-rendered heading lines; equation handling no longer strips `$$`/`$`
- `lightrag/sidecar/writer.py`: new `_strip_latex_dollar_wrappers` helper; `_equation_item_dict` strips wrappers when writing `equations.json`
- Tests: updated existing MinerU adapter expectations for the new merged-block shape; added coverage for the preface block, mixed-payload merging under one heading, adjacent-heading merge (deeper folds in, shallower does not, body breaks the merge), block-equation dollar preservation, and writer-side wrapper stripping

## What's broken and how to roll forward
- `IREquation.latex` semantics now carry the parser's raw form. Other adapters (`native_docx`, `docling`) already pass clean latex without `$` wrappers, so the writer change is a no-op for them. Any downstream code that reads `equation.latex` directly and expected clean latex must instead read from `equations.json` content, or run `_strip_latex_dollar_wrappers` itself.
- MinerU outputs noticeably fewer (larger) blocks than before. Downstream block-count assertions / chunk-size budgets tuned to the old shape may need re-baselining.

## Test plan
- [x] `./scripts/test.sh tests/parser_adapters/test_mineru_adapter.py` (20 passed)
- [x] `./scripts/test.sh tests/sidecar tests/parser_adapters tests/test_parse_mineru_sidecar.py tests/test_delete_file_variants_mineru_raw.py` (47 passed)
- [x] `ruff check lightrag/parser_adapters/mineru.py lightrag/sidecar/writer.py tests/parser_adapters/test_mineru_adapter.py tests/sidecar/test_writer.py` (clean)
- [ ] Spot-check a real `.mineru_raw/` bundle end-to-end to confirm rendered `blocks.jsonl` / `equations.json` shape matches expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)