### PR TITLE
test: harden hermetic env fixture and fix MinerU put() fake

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _hermetic_mineru_env(monkeypatch):
-    """Make every test start with MinerU env vars in their unset state.
+    """Make every test start with parser-routing env vars in their unset state.
 
     ``lightrag/api/{auth,config}.py`` call ``load_dotenv(override=False)``
     at import time, leaking the developer's local ``.env`` into the test
@@ -24,15 +24,24 @@ def _hermetic_mineru_env(monkeypatch):
       ``"MINERU_API_TOKEN"`` instead of ``"MINERU_LOCAL_ENDPOINT"``,
       breaking the validation-error string match.
 
-    Strip the variable globally; tests that need a specific mode can
-    still ``monkeypatch.setenv("MINERU_API_MODE", "official")``
-    themselves and monkeypatch will restore the inherited value at
-    teardown.
+    ``LIGHTRAG_PARSER`` is cleared for the same reason: a routing rule
+    like ``docx:mineru-iet`` in the developer's ``.env`` forces
+    ``parser_routing.validate_parser_routing_config`` to require the
+    corresponding endpoint (``MINERU_LOCAL_ENDPOINT`` /
+    ``DOCLING_ENDPOINT``) at every ``create_app`` call, which then trips
+    unrelated API/FastAPI tests (``test_bedrock_llm.py``,
+    ``test_path_prefixes.py``).
+
+    Strip these variables globally; tests that need a specific mode can
+    still ``monkeypatch.setenv(...)`` themselves and monkeypatch will
+    restore the inherited value at teardown.
     """
     monkeypatch.delenv("MINERU_API_MODE", raising=False)
     monkeypatch.delenv("MINERU_API_TOKEN", raising=False)
     monkeypatch.delenv("MINERU_LOCAL_ENDPOINT", raising=False)
     monkeypatch.delenv("MINERU_OFFICIAL_ENDPOINT", raising=False)
+    monkeypatch.delenv("LIGHTRAG_PARSER", raising=False)
+    monkeypatch.delenv("DOCLING_ENDPOINT", raising=False)
 
 
 def pytest_configure(config):

--- a/tests/mineru_raw/test_client.py
+++ b/tests/mineru_raw/test_client.py
@@ -79,9 +79,17 @@ class _FakeAsyncClient:
         )
 
     async def put(
-        self, url: str, data: Any = None, headers: Any = None
+        self,
+        url: str,
+        data: Any = None,
+        content: Any = None,
+        headers: Any = None,
     ) -> _FakeResponse:
-        return _CURRENT.dispatcher.put(url, data=data, headers=headers)
+        # ``content=`` was added to match production ``client.put(url, content=bytes)``
+        # introduced for httpx 0.28+ compatibility (see lightrag/mineru_raw/client.py).
+        return _CURRENT.dispatcher.put(
+            url, data=data, content=content, headers=headers
+        )
 
     async def get(
         self, url: str, params: Any = None, headers: Any = None


### PR DESCRIPTION
## Summary
- Fix 22 false-failure tests by clearing `LIGHTRAG_PARSER` / `DOCLING_ENDPOINT` in the autouse hermetic env fixture (developer `.env` was leaking into `test_bedrock_llm.py` / `test_path_prefixes.py` via `load_dotenv` at import time)
- Fix 3 crashing tests by extending `_FakeAsyncClient.put` to accept the `content=` kwarg that production code adopted for httpx 0.28+ compatibility (commit `181b578c`)

## Motivation
A full-suite run on `dev` produced 25 false failures even on a clean checkout. Triage:

| Symptom | Files | Root cause |
|---|---|---|
| `TypeError: _FakeAsyncClient.put() got an unexpected keyword argument 'content'` (×3) | `tests/mineru_raw/test_client.py` | `MinerURawClient._upload_official` switched to `client.put(url, content=bytes)` for httpx 0.28+ (a `SyncByteStream` rejection in the prior `data=file_object` form), but the test fake's signature was not updated. |
| `ParserRoutingConfigError: rule 1 ('docx:mineru-iet') requires MINERU_LOCAL_ENDPOINT to be configured` (×22) | `tests/test_bedrock_llm.py`, `tests/test_path_prefixes.py` | `lightrag/api/{auth,config}.py` call `load_dotenv(override=False)` at import time; the autouse `_hermetic_mineru_env` fixture in `tests/conftest.py` cleared `MINERU_*` vars but not `LIGHTRAG_PARSER`, so any developer with a mineru routing rule in their local `.env` saw `create_app` fail in unrelated FastAPI / Bedrock tests. |

Both classes pre-existed on `dev` (verified by checking out `181b578c`); they are not introduced by my [PR #3079](https://github.com/HKUDS/LightRAG/pull/3079).

## What's changed
- `tests/mineru_raw/test_client.py`: add `content: Any = None` to `_FakeAsyncClient.put` and forward it to the dispatcher (which already accepts `**_`)
- `tests/conftest.py`: extend `_hermetic_mineru_env` to also `monkeypatch.delenv` `LIGHTRAG_PARSER` and `DOCLING_ENDPOINT`; expand the docstring to explain why

## Test plan
- [x] `./scripts/test.sh tests/mineru_raw/test_client.py tests/test_path_prefixes.py tests/test_bedrock_llm.py` — 48 passed (was 25 failing across these files)
- [x] `./scripts/test.sh tests/` — 1364 passed, 1 skipped, 31 deselected (was 1346 passed, 25 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)