### PR TITLE
feat(mineru): emit page-level positions from page_idx

### DIFF
--- a/docs/LightRAGSidecarFormat-zh.md
+++ b/docs/LightRAGSidecarFormat-zh.md
@@ -175,7 +175,7 @@ inputs/space1/__parsed__/<规范文件名>.parsed/
   },
   "llm_cache_list": [
     "default:analysis:fcf4c4f88227ee1c1bf0ed4394039e37"
-  ]  
+  ]
 }
 ```
 
@@ -223,7 +223,7 @@ inputs/space1/__parsed__/<规范文件名>.parsed/
   },
   "llm_cache_list": [
     "default:analysis:b316aacd40fdca0cb56430870bb89a62"
-  ]  
+  ]
 }
 ```
 
@@ -269,7 +269,7 @@ tables.json 文件的 `blockid` `heading` `surrounding` `llm_analyze_result` 字
   },
   "llm_cache_list": [
     "default:analysis:fcf4c4f88227ee1c1bf0ed4394039e37"
-  ]    
+  ]
 }
 ```
 

--- a/lightrag/parser_adapters/mineru.py
+++ b/lightrag/parser_adapters/mineru.py
@@ -163,7 +163,14 @@ class MinerUAdapter:
         cb_tables: list[IRTable] = []
         cb_drawings: list[IRDrawing] = []
         cb_equations: list[IREquation] = []
-        cb_positions: list[IRPosition] = []
+        # Positions are split into two channels:
+        # - ``cb_page_set`` collects ``page_idx`` of bbox-less items; at flush
+        #   each unique page becomes one anchor-only summary ``IRPosition``.
+        # - ``cb_bbox_positions`` keeps one fine-grained position per item that
+        #   carried a parseable bbox (anchor + range), in source order, with
+        #   no deduplication.
+        cb_page_set: set[str] = set()
+        cb_bbox_positions: list[IRPosition] = []
         cb_heading = PREFACE_HEADING
         cb_level = 0
         cb_parents: list[str] = []
@@ -173,10 +180,26 @@ class MinerUAdapter:
         # with the native docx parser's behaviour for back-to-back headings).
         cb_has_body = False
 
+        def _record_position(item: dict) -> None:
+            """Route an item's positional info into the right channel.
+
+            Items with a parseable ``bbox`` produce one fine-grained
+            IRPosition appended to ``cb_bbox_positions`` (no dedupe).
+            Otherwise, ``page_idx`` (if any) is added to ``cb_page_set``
+            and emitted as a single anchor-only summary entry at flush.
+            """
+            bbox_pos = _extract_bbox_position(item)
+            if bbox_pos is not None:
+                cb_bbox_positions.append(bbox_pos)
+                return
+            page = _extract_page_anchor(item)
+            if page is not None:
+                cb_page_set.add(page)
+
         def _flush_block() -> None:
             """Emit the in-flight block if it carries any content."""
-            nonlocal cb_lines, cb_tables, cb_drawings, cb_equations, cb_positions
-            nonlocal cb_has_body
+            nonlocal cb_lines, cb_tables, cb_drawings, cb_equations
+            nonlocal cb_page_set, cb_bbox_positions, cb_has_body
             has_payload = bool(cb_lines or cb_tables or cb_drawings or cb_equations)
             if not has_payload:
                 return
@@ -184,16 +207,21 @@ class MinerUAdapter:
             if not content.strip() and not (cb_tables or cb_drawings or cb_equations):
                 # Reset and skip — nothing meaningful to emit.
                 cb_lines = []
-                cb_positions = []
+                cb_page_set = set()
+                cb_bbox_positions = []
                 cb_has_body = False
                 return
+            positions = [
+                IRPosition(type="bbox", anchor=p)
+                for p in _sort_page_anchors(cb_page_set)
+            ] + list(cb_bbox_positions)
             blocks.append(
                 IRBlock(
                     content_template=content,
                     heading=cb_heading,
                     level=cb_level,
                     parent_headings=list(cb_parents),
-                    positions=list(cb_positions),
+                    positions=positions,
                     tables=list(cb_tables),
                     drawings=list(cb_drawings),
                     equations=list(cb_equations),
@@ -203,15 +231,11 @@ class MinerUAdapter:
             cb_tables = []
             cb_drawings = []
             cb_equations = []
-            cb_positions = []
+            cb_page_set = set()
+            cb_bbox_positions = []
             cb_has_body = False
 
-        def _open_block(
-            heading: str,
-            level: int,
-            parents: list[str],
-            position: IRPosition | None,
-        ) -> None:
+        def _open_block(heading: str, level: int, parents: list[str]) -> None:
             nonlocal cb_heading, cb_level, cb_parents
             cb_heading = heading
             cb_level = level
@@ -220,20 +244,21 @@ class MinerUAdapter:
             # text reads like markdown (``# Foo`` / ``## Bar`` / …).
             md_prefix = "#" * max(level, 1)
             cb_lines.append(f"{md_prefix} {heading}")
-            if position is not None:
-                cb_positions.append(position)
 
-        def _append_text(text: str, position: IRPosition | None) -> None:
+        def _append_text(text: str) -> bool:
+            """Append ``text`` to the current block body and return whether
+            anything was actually written. Callers use the return value to
+            decide whether to also record the item's source position — an
+            empty text item must NOT leak its ``page_idx`` to the block.
+            """
             nonlocal cb_has_body
-            if text:
-                cb_lines.append(text)
-                cb_has_body = True
-            if position is not None:
-                cb_positions.append(position)
+            if not text:
+                return False
+            cb_lines.append(text)
+            cb_has_body = True
+            return True
 
-        def _merge_heading_as_body(
-            heading: str, level: int, position: IRPosition | None
-        ) -> None:
+        def _merge_heading_as_body(heading: str, level: int) -> None:
             """Fold an adjacent deeper heading into the current block.
 
             The line keeps its markdown ``#`` prefix so the rendered block
@@ -243,14 +268,11 @@ class MinerUAdapter:
             """
             md_prefix = "#" * max(level, 1)
             cb_lines.append(f"{md_prefix} {heading}")
-            if position is not None:
-                cb_positions.append(position)
 
         for item in content_list:
             if not isinstance(item, dict):
                 continue
             item_type = str(item.get("type") or item.get("label") or "").lower()
-            position = _extract_position(item)
 
             heading_text, heading_level = _detect_heading(item, item_type)
             if heading_text:
@@ -266,20 +288,23 @@ class MinerUAdapter:
                 # this heading as body to the existing block instead of
                 # flushing. (Preface, level=0, is never merged into.)
                 if cb_level > 0 and not cb_has_body and heading_level > cb_level:
-                    _merge_heading_as_body(heading_text, heading_level, position)
+                    _merge_heading_as_body(heading_text, heading_level)
+                    _record_position(item)
                     if not doc_title and heading_level == 1:
                         doc_title = heading_text
                     continue
 
                 _flush_block()
-                _open_block(heading_text, heading_level, parents, position)
+                _open_block(heading_text, heading_level, parents)
+                _record_position(item)
 
                 if not doc_title and heading_level == 1:
                     doc_title = heading_text
                 continue
 
             if item_type == "text":
-                _append_text(_coerce_text(item), position)
+                if _append_text(_coerce_text(item)):
+                    _record_position(item)
                 continue
 
             if item_type == "list":
@@ -288,11 +313,13 @@ class MinerUAdapter:
                     text = "\n".join(str(x) for x in items if str(x).strip())
                 else:
                     text = _coerce_text(item)
-                _append_text(text, position)
+                if _append_text(text):
+                    _record_position(item)
                 continue
 
             if item_type == "code":
-                _append_text(item.get("code_body") or _coerce_text(item), position)
+                if _append_text(item.get("code_body") or _coerce_text(item)):
+                    _record_position(item)
                 continue
 
             if item_type == "equation":
@@ -320,8 +347,7 @@ class MinerUAdapter:
                 )
                 cb_lines.append(f"{{{{{token}:{placeholder}}}}}")
                 cb_has_body = True
-                if position is not None:
-                    cb_positions.append(position)
+                _record_position(item)
                 continue
 
             if item_type == "table":
@@ -331,8 +357,7 @@ class MinerUAdapter:
                 cb_tables.append(table)
                 cb_lines.append(f"{{{{TBL:{placeholder}}}}}")
                 cb_has_body = True
-                if position is not None:
-                    cb_positions.append(position)
+                _record_position(item)
                 continue
 
             if item_type in {"image", "picture", "drawing"}:
@@ -344,13 +369,15 @@ class MinerUAdapter:
                 cb_drawings.append(drawing)
                 cb_lines.append(f"{{{{IMG:{placeholder}}}}}")
                 cb_has_body = True
-                if position is not None:
-                    cb_positions.append(position)
+                _record_position(item)
                 continue
 
             # Fallback: serialize unknown items as plain text so we don't
-            # silently drop information.
-            _append_text(_coerce_text(item), position)
+            # silently drop information. Position only recorded when the
+            # fallback actually contributed text — empty unknown items must
+            # not leak their page_idx into the current block.
+            if _append_text(_coerce_text(item)):
+                _record_position(item)
 
         _flush_block()
 
@@ -558,11 +585,46 @@ def _is_block_equation(item: dict) -> bool:
     return True
 
 
-def _extract_position(item: dict) -> IRPosition | None:
-    """Build an ``IRPosition`` from MinerU page_idx + bbox if available.
+def _extract_page_anchor(item: dict) -> str | None:
+    """Return a 1-based page anchor from MinerU's ``page_idx`` / ``page``.
 
-    Returns ``None`` when no positional information is present, so blocks
-    that legitimately lack a bbox don't get an empty position object.
+    Always returns a string so ``blocks.jsonl`` carries a uniform anchor
+    type across Roman / letter / numeric page labels. Integers are bumped
+    to 1-based (``page_idx=0`` → ``"1"``); strings are stripped and passed
+    through verbatim. Returns ``None`` when no usable page info is present.
+    """
+    page_raw = item.get("page_idx")
+    if page_raw is None:
+        page_raw = item.get("page")
+    if isinstance(page_raw, bool):
+        # bool is a subclass of int — guard so True/False don't sneak in.
+        return None
+    if isinstance(page_raw, int):
+        return str(page_raw + 1 if page_raw >= 0 else page_raw)
+    if isinstance(page_raw, str) and page_raw.strip():
+        return page_raw.strip()
+    return None
+
+
+def _sort_page_anchors(pages: set[str]) -> list[str]:
+    """Order page anchors using book pagination convention.
+
+    Non-numeric labels (Roman preface pages ``i``/``ii``/``iv``…, letter
+    pages like ``A``, ``B-1``) come first in lexical order; numeric labels
+    follow, sorted by their integer value so ``"2"`` precedes ``"10"``.
+    Mixing both kinds is safe — the bucketed key avoids the ``TypeError``
+    that ``sorted({"ii", "1"})`` raises when ints and strings mix.
+    """
+    non_numeric = sorted(p for p in pages if not p.isdigit())
+    numeric = sorted((p for p in pages if p.isdigit()), key=int)
+    return non_numeric + numeric
+
+
+def _extract_bbox_position(item: dict) -> IRPosition | None:
+    """Build a fine-grained ``IRPosition`` when ``bbox`` is parseable.
+
+    Returns ``None`` when ``bbox`` is missing or malformed; the caller then
+    falls back to page-only tracking via :func:`_extract_page_anchor`.
     """
     bbox = item.get("bbox")
     if not isinstance(bbox, (list, tuple)) or len(bbox) < 4:
@@ -571,19 +633,7 @@ def _extract_position(item: dict) -> IRPosition | None:
         coords = [float(x) for x in bbox[:4]]
     except (TypeError, ValueError):
         return None
-
-    page_raw = item.get("page_idx")
-    if page_raw is None:
-        page_raw = item.get("page")
-    anchor: Any
-    if isinstance(page_raw, int):
-        anchor = page_raw + 1 if page_raw >= 0 else page_raw
-    elif isinstance(page_raw, str) and page_raw.strip():
-        anchor = page_raw
-    else:
-        anchor = None
-
-    return IRPosition(type="bbox", anchor=anchor, range=coords)
+    return IRPosition(type="bbox", anchor=_extract_page_anchor(item), range=coords)
 
 
 def _safe_local_asset_path(

--- a/tests/parser_adapters/test_mineru_adapter.py
+++ b/tests/parser_adapters/test_mineru_adapter.py
@@ -152,9 +152,15 @@ def test_adapter_table_and_drawing_and_equation(tmp_path: Path) -> None:
     drawing = drawing_block.drawings[0]
     assert drawing.fmt == "jpg"
     assert drawing.caption == "Fig 1"
-    # Position carried through.
+    # Position carried through. The bbox-bearing item produces exactly one
+    # fine-grained position (anchor + range) and is NOT also rolled into the
+    # page-only summary channel — so the block has a single position entry,
+    # not a duplicate summary + bbox pair.
+    assert len(drawing_block.positions) == 1
     assert drawing_block.positions[0].type == "bbox"
-    assert drawing_block.positions[0].anchor == 2  # page_idx+1
+    # Anchor is always serialized as a string (uniform on-disk format,
+    # accommodates book pagination labels like Roman "ii").
+    assert drawing_block.positions[0].anchor == "2"  # page_idx+1
     assert drawing_block.positions[0].range == [10.0, 20.0, 30.0, 40.0]
 
     # Asset is declared with the relative path as ref.
@@ -167,6 +173,151 @@ def test_adapter_table_and_drawing_and_equation(tmp_path: Path) -> None:
     assert eq.latex == "$E = mc^2$"
     assert eq.is_block is True
     assert eq.caption == "Eq 1"
+
+
+@pytest.mark.offline
+def test_adapter_page_idx_aggregated_and_deduped_when_no_bbox(
+    tmp_path: Path,
+) -> None:
+    """Real MinerU output carries ``page_idx`` on every item but rarely a
+    ``bbox``. Each unique page contributing to a merged block must surface as
+    one anchor-only ``{type:"bbox", anchor:<page+1>}`` entry, sorted, no
+    duplicates, no ``range``.
+    """
+    raw = _write_bundle(
+        tmp_path,
+        [
+            {"type": "text", "text": "Section", "text_level": 1, "page_idx": 0},
+            {"type": "text", "text": "line A", "page_idx": 0},
+            {"type": "text", "text": "line B", "page_idx": 1},
+            {"type": "text", "text": "line C", "page_idx": 1},
+            {"type": "text", "text": "line D", "page_idx": 2},
+        ],
+    )
+    ir = MinerUAdapter().normalize_from_workdir(raw, document_name="p.pdf")
+
+    assert len(ir.blocks) == 1
+    block = ir.blocks[0]
+    # Pages 0, 1, 2 → anchors "1", "2", "3" — one entry per unique page.
+    # Anchors are persisted as strings for on-disk uniformity.
+    assert len(block.positions) == 3
+    anchors = [p.anchor for p in block.positions]
+    assert anchors == ["1", "2", "3"]
+    for pos in block.positions:
+        assert pos.type == "bbox"
+        # Page-only summary entries have no range; ``to_jsonable`` must omit
+        # the key entirely.
+        assert pos.range is None
+        assert "range" not in pos.to_jsonable()
+
+
+@pytest.mark.offline
+def test_adapter_bbox_items_and_page_only_items_coexist(tmp_path: Path) -> None:
+    """When a block merges both bbox-bearing and bbox-less items, the bbox
+    items are emitted per-item (no dedupe, with ``range``) and only the
+    bbox-less items contribute to the page-only summary. Ordering: summary
+    first (sorted by anchor), bbox entries after (source order).
+    """
+    raw = _write_bundle(
+        tmp_path,
+        [
+            {"type": "text", "text": "Mixed", "text_level": 1, "page_idx": 1},
+            {
+                "type": "image",
+                "img_path": "images/fig.png",
+                "page_idx": 1,
+                "bbox": [10, 20, 30, 40],
+            },
+            {"type": "text", "text": "tail line", "page_idx": 2},
+        ],
+    )
+    ir = MinerUAdapter().normalize_from_workdir(raw, document_name="m.pdf")
+
+    assert len(ir.blocks) == 1
+    positions = ir.blocks[0].positions
+    # One page-only summary for page 3 (the bbox-less tail line) and one
+    # bbox entry for page 2 (the image). The heading item has page_idx=1
+    # but no bbox, so it adds anchor 2 to the page set — combined with the
+    # tail item's anchor 3 the summary section has TWO anchors (1+1, 2+1).
+    assert [(p.anchor, p.range) for p in positions] == [
+        ("2", None),
+        ("3", None),
+        ("2", [10.0, 20.0, 30.0, 40.0]),
+    ]
+
+
+@pytest.mark.offline
+def test_adapter_page_sort_books_convention_with_mixed_anchors(
+    tmp_path: Path,
+) -> None:
+    """Block merges items with Roman preface labels and Arabic numerals.
+
+    Two guarantees:
+
+    1. The adapter must not crash when sorting heterogeneous anchors — a
+       previous bug surfaced ``TypeError: '<' not supported between
+       instances of 'str' and 'int'`` whenever ``page_idx`` mixed types.
+    2. Output order follows book pagination convention: Roman / letter
+       labels first (lexical), then numeric pages by integer value, so
+       ``"2"`` precedes ``"10"`` (not ``"10"`` before ``"2"`` as a naive
+       lexical sort would do).
+    """
+    raw = _write_bundle(
+        tmp_path,
+        [
+            {
+                "type": "text",
+                "text": "Mixed Pagination",
+                "text_level": 1,
+                "page_idx": "i",
+            },
+            {"type": "text", "text": "preface intro", "page_idx": "i"},
+            {"type": "text", "text": "preface tail", "page_idx": "ii"},
+            {"type": "text", "text": "chapter line A", "page_idx": 1},  # → "2"
+            {"type": "text", "text": "chapter line B", "page_idx": 9},  # → "10"
+        ],
+    )
+    ir = MinerUAdapter().normalize_from_workdir(raw, document_name="mix.pdf")
+
+    assert len(ir.blocks) == 1
+    anchors = [p.anchor for p in ir.blocks[0].positions]
+    # Roman labels first (lex order), then numerics by int value.
+    assert anchors == ["i", "ii", "2", "10"]
+
+
+@pytest.mark.offline
+def test_adapter_empty_text_item_does_not_leak_page_to_block(
+    tmp_path: Path,
+) -> None:
+    """An item whose body is empty must NOT contribute its ``page_idx`` to
+    the current block's positions — otherwise spurious pages from
+    content-less items poison provenance.
+
+    Regression: empty text on page 99 sits between two real headings; its
+    page must not appear under either block.
+    """
+    raw = _write_bundle(
+        tmp_path,
+        [
+            {"type": "text", "text": "Section A", "text_level": 1, "page_idx": 0},
+            {"type": "text", "text": "real body", "page_idx": 0},
+            # Empty body — should be silently dropped, page_idx not recorded.
+            {"type": "text", "text": "", "page_idx": 98},
+            {"type": "text", "text": "Section B", "text_level": 1, "page_idx": 1},
+            {"type": "text", "text": "next body", "page_idx": 1},
+        ],
+    )
+    ir = MinerUAdapter().normalize_from_workdir(raw, document_name="leak.pdf")
+
+    assert len(ir.blocks) == 2
+    a_anchors = [p.anchor for p in ir.blocks[0].positions]
+    b_anchors = [p.anchor for p in ir.blocks[1].positions]
+    # Section A only mentions page 1 (page_idx 0 + 1) — NOT 99 from the
+    # dropped empty item.
+    assert a_anchors == ["1"]
+    assert "99" not in a_anchors and "99" not in b_anchors
+    # Section B only mentions page 2 (page_idx 1 + 1).
+    assert b_anchors == ["2"]
 
 
 @pytest.mark.offline


### PR DESCRIPTION
## Summary

- `MinerUAdapter` now derives block `positions` from `page_idx` instead of requiring `bbox` to be present. Real MinerU output carries `page_idx` on every item but rarely a `bbox`, so previously every block in `blocks.jsonl` shipped with `positions: []` — page provenance was lost end-to-end.
- Merged items contribute their pages to a per-block set; each unique page produces one `{type:"bbox", anchor:"<page>"}` entry. Items that DO carry a `bbox` keep their fine-grained `{anchor, range}` entry (no dedupe) alongside the summary.
- Anchors are persisted as strings for uniform on-disk format. Sorting follows book pagination convention: Roman / letter labels (e.g. `"i"`, `"ii"`) first lexically, then numeric pages by integer value (`"2"` before `"10"`).
- Fixes two reviewer findings:
  - **P2**: heterogeneous anchors (mixed Roman + Arabic) no longer crash `sorted()`.
  - **P3**: empty text / list / code / fallback items no longer leak their `page_idx` to the surrounding block — `_append_text` returns whether anything was written and callers guard `_record_position` accordingly.
- Bundled: a `🎨 chore(docs)` commit trimming trailing whitespace in `LightRAGSidecarFormat-zh.md` (unrelated drive-by).

## Output shape

Block where every merged item lacked `bbox`, spans pages 1 & 2:

\`\`\`json
\"positions\": [
  {\"type\": \"bbox\", \"anchor\": \"1\"},
  {\"type\": \"bbox\", \"anchor\": \"2\"}
]
\`\`\`

Block with one bbox-bearing image on page 3 and one bbox-less tail line on page 4:

\`\`\`json
\"positions\": [
  {\"type\": \"bbox\", \"anchor\": \"4\"},
  {\"type\": \"bbox\", \"anchor\": \"3\", \"range\": [247.0, 217.0, 760.0, 267.0]}
]
\`\`\`

## Test plan

- [x] \`pytest tests/parser_adapters/test_mineru_adapter.py -v\` — 24/24 pass, including 4 new cases:
  - \`test_adapter_page_idx_aggregated_and_deduped_when_no_bbox\`
  - \`test_adapter_bbox_items_and_page_only_items_coexist\`
  - \`test_adapter_page_sort_books_convention_with_mixed_anchors\` (P2 regression)
  - \`test_adapter_empty_text_item_does_not_leak_page_to_block\` (P3 regression)
- [x] \`ruff check\` clean on the changed files.
- [x] End-to-end sanity on \`inputs/space1/__parsed__/m012-manual.docx.mineru_raw\`: all 39 blocks now have non-empty \`positions\`; the Preface block correctly aggregates pages 1+2 into two deduped entries; serialized JSON matches the expected shape.
- [ ] Reviewer to spot-check one row of a freshly produced \`*.blocks.jsonl\` after running the full parse pipeline on a real MinerU bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)