### PR TITLE
Tokenizer.encode: gracefully handle disallowed special tokens in content

### DIFF
--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -939,7 +939,24 @@ class Tokenizer:
         Returns:
             A list of integer tokens.
         """
-        return self.tokenizer.encode(content)
+        try:
+            return self.tokenizer.encode(content)
+        except ValueError as e:
+            # tiktoken (and some other tokenizers) raise ValueError when the
+            # content contains literal special-token strings such as
+            # "<|endoftext|>", because by default disallowed_special is the
+            # full set of special tokens. This crashes document indexing on
+            # any user content that happens to contain those strings — common
+            # in documentation, notes, or model output captured in source
+            # corpora. Retry with disallowed_special=() so the tokens are
+            # encoded as ordinary text. Tokenizers that don't accept the
+            # kwarg fall through and re-raise the original error.
+            if "special token" not in str(e):
+                raise
+            try:
+                return self.tokenizer.encode(content, disallowed_special=())
+            except TypeError:
+                raise e
 
     def decode(self, tokens: List[int]) -> str:
         """


### PR DESCRIPTION
## Problem

Document indexing crashes whenever a chunk contains a literal special-token string such as `<|endoftext|>`. tiktoken's default `disallowed_special` includes all model special tokens, so `tokenizer.encode("text with <|endoftext|> in it")` raises:

```
ValueError: Encountered text corresponding to disallowed special token '<|endoftext|>'.
If you want this text to be encoded as a special token, pass it to `allowed_special`, e.g. `allowed_special={'<|endoftext|>', ...}`.
If you want this text to be encoded as normal text, disable the check for this token by passing `disallowed_special=()`.
```

This bubbles up through `lightrag/operate.py:_process_single_content` → `_process_with_semaphore`, and the entire document (often dozens of chunks) is dropped from the run.

This is hit reliably by any corpus that contains:
- Technical documentation about LLMs
- Captured model output preserved in notes
- Anything quoting model templates

## Fix

`Tokenizer.encode` retries the call with `disallowed_special=()` on `ValueError`, so the literal string is encoded as ordinary text:

```python
try:
    return self.tokenizer.encode(content)
except ValueError as e:
    if "special token" not in str(e):
        raise
    try:
        return self.tokenizer.encode(content, disallowed_special=())
    except TypeError:
        raise e
```

The `"special token" not in str(e)` guard preserves any other `ValueError` paths. The `TypeError` fallback covers tokenizer implementations that don't accept `disallowed_special` (most non-tiktoken ones), re-raising the original error in that case.

## Behavior change

| Before | After |
|---|---|
| Doc with one `<|endoftext|>` chunk → whole doc skipped | Doc encoded as ordinary text, indexed normally |
| Non-tiktoken tokenizer → unchanged | Unchanged |
| Other `ValueError` paths → unchanged | Unchanged |

## Verified

5-call functional smoke test with a fake tokenizer mirroring tiktoken's behavior:
- Plain content: 1 encode call, returns tokens
- Content with `<|endoftext|>`: 2 encode calls (initial raises, retry with `disallowed_special=()` succeeds), returns tokens

Observed in production where the patched path successfully encoded documents that previously crashed the indexer.