### PR TITLE
fix: guard against IndexError on empty LLM choices list

### DIFF
--- a/examples/generate_query.py
+++ b/examples/generate_query.py
@@ -17,7 +17,7 @@ def openai_complete_if_cache(
     response = openai_client.chat.completions.create(
         model=model, messages=messages, **kwargs
     )
-    if not response.choices:
+    if not response.choices or response.choices[0].message is None:
         return ""
     return response.choices[0].message.content
 

--- a/examples/generate_query.py
+++ b/examples/generate_query.py
@@ -17,6 +17,8 @@ def openai_complete_if_cache(
     response = openai_client.chat.completions.create(
         model=model, messages=messages, **kwargs
     )
+    if not response.choices:
+        return ""
     return response.choices[0].message.content
 
 

--- a/examples/lightrag_azure_openai_demo.py
+++ b/examples/lightrag_azure_openai_demo.py
@@ -52,6 +52,8 @@ async def llm_model_func(
         top_p=kwargs.get("top_p", 1),
         n=kwargs.get("n", 1),
     )
+    if not chat_completion.choices:
+        return ""
     return chat_completion.choices[0].message.content
 
 

--- a/examples/lightrag_azure_openai_demo.py
+++ b/examples/lightrag_azure_openai_demo.py
@@ -52,7 +52,7 @@ async def llm_model_func(
         top_p=kwargs.get("top_p", 1),
         n=kwargs.get("n", 1),
     )
-    if not chat_completion.choices:
+    if not chat_completion.choices or chat_completion.choices[0].message is None:
         return ""
     return chat_completion.choices[0].message.content
 

--- a/lightrag/llm/zhipu.py
+++ b/lightrag/llm/zhipu.py
@@ -103,6 +103,8 @@ async def zhipu_complete_if_cache(
         kwargs["thinking"] = thinking
 
     response = client.chat.completions.create(model=model, messages=messages, **kwargs)
+    if not response.choices:
+        return ""
     message = response.choices[0].message
     content = message.content or ""
     reasoning_content = getattr(message, "reasoning_content", "") or ""

--- a/lightrag/llm/zhipu.py
+++ b/lightrag/llm/zhipu.py
@@ -103,7 +103,7 @@ async def zhipu_complete_if_cache(
         kwargs["thinking"] = thinking
 
     response = client.chat.completions.create(model=model, messages=messages, **kwargs)
-    if not response.choices:
+    if not response.choices or response.choices[0].message is None:
         return ""
     message = response.choices[0].message
     content = message.content or ""


### PR DESCRIPTION
## Problem

Three call sites access `choices[0]` without first checking whether the API returned any choices. When the LLM:

- applies a **content-policy filter** and returns `choices=[]`
- hits a **token limit** before generating the first choice
- returns a non-standard error body

the code raises a bare `IndexError` that crashes the calling pipeline.

## Changes

| File | Fix |
|------|-----|
| `lightrag/llm/zhipu.py` | `if not response.choices: return ""` before accessing `choices[0].message` |
| `examples/generate_query.py` | same pattern for OpenAI API |
| `examples/lightrag_azure_openai_demo.py` | same pattern for Azure OpenAI |

Returning `""` on empty choices matches the existing `content = message.content or ""` pattern in `zhipu.py` and keeps the calling code consistent.

---
*Found by [pact](https://github.com/qizwiz/pact) static analysis — `llm_response_unguarded` mode.*