### PR TITLE
feat(doc-status): add per-stage start time and parse-skipped flag

### DIFF
--- a/lightrag/_version.py
+++ b/lightrag/_version.py
@@ -1,4 +1,4 @@
 """Lightweight version definitions shared by packaging and runtime code."""
 
 __version__ = "1.5.0"
-__api_version__ = "0292"
+__api_version__ = "0293"

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1383,6 +1383,17 @@ class _PipelineMixin:
                 # subsequent state transition for stage-duration analysis.
                 if not isinstance(status_doc_w.metadata, dict):
                     status_doc_w.metadata = {}
+                # Drop stale per-attempt fields from any prior failed/retried
+                # attempt before stamping the new parsing_start_time.
+                # ``analyzing_start_time`` and ``parse_stage_skipped`` are
+                # downstream of this point and would otherwise be carried
+                # forward via carry-over, skewing stage-duration metrics and
+                # the raw-cache-hit signal for the new attempt. The cache-hit
+                # mirror block below only re-writes ``parse_stage_skipped``
+                # when the parser actually returns a hit, so cache-miss
+                # retries land with the field absent (= not skipped).
+                status_doc_w.metadata.pop("analyzing_start_time", None)
+                status_doc_w.metadata.pop("parse_stage_skipped", None)
                 status_doc_w.metadata["parsing_start_time"] = int(time.time())
                 await self._upsert_doc_status_transition(
                     doc_id=doc_id_w,

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1377,6 +1377,13 @@ class _PipelineMixin:
                     raise Exception(
                         f"Document content not found in full_docs for doc_id: {doc_id_w}"
                     )
+                # Stamp parsing_start_time on the in-memory status_doc so
+                # carry-over (_DOC_STATUS_METADATA_CARRY_OVER_KEYS) writes it
+                # into doc_status here and preserves it across every
+                # subsequent state transition for stage-duration analysis.
+                if not isinstance(status_doc_w.metadata, dict):
+                    status_doc_w.metadata = {}
+                status_doc_w.metadata["parsing_start_time"] = int(time.time())
                 await self._upsert_doc_status_transition(
                     doc_id=doc_id_w,
                     status=DocStatus.PARSING,
@@ -1405,6 +1412,15 @@ class _PipelineMixin:
                     if not isinstance(status_doc_w.metadata, dict):
                         status_doc_w.metadata = {}
                     status_doc_w.metadata["parse_warnings"] = parse_warnings_payload_w
+
+                # Mirror raw-bundle cache-hit flag from mineru/docling so the
+                # next upsert (ANALYZING) carries it into doc_status; absence
+                # means the parse stage actually ran. Only ``True`` is written
+                # so cache-miss documents stay clean.
+                if parsed_data_w.get("parse_stage_skipped"):
+                    if not isinstance(status_doc_w.metadata, dict):
+                        status_doc_w.metadata = {}
+                    status_doc_w.metadata["parse_stage_skipped"] = True
 
                 # parse_* may have patched content_hash for
                 # pending_parse → raw transitions.
@@ -1464,6 +1480,12 @@ class _PipelineMixin:
                 refreshed_length_w = len(refreshed_content_w)
                 status_doc_w.content_summary = refreshed_summary_w
                 status_doc_w.content_length = refreshed_length_w
+                # Stamp analyzing_start_time so per-stage durations stay
+                # derivable from doc_status even after PROCESSED / FAILED;
+                # carry-over preserves it across later upserts.
+                if not isinstance(status_doc_w.metadata, dict):
+                    status_doc_w.metadata = {}
+                status_doc_w.metadata["analyzing_start_time"] = int(time.time())
                 await self._upsert_doc_status_transition(
                     doc_id=doc_id_w,
                     status=DocStatus.ANALYZING,
@@ -2490,11 +2512,13 @@ class _PipelineMixin:
             "on",
         }
 
+        parse_stage_skipped = False
         if not force_reparse and is_bundle_valid(raw_dir, source_file_path):
             # Cache hit: keep the path purely local so a re-parse still
             # succeeds if MinerU credentials/endpoint are temporarily
             # unavailable (key rotation, debugging, etc.). Network config
             # is only required on cache miss below.
+            parse_stage_skipped = True
             logger.info(
                 "[parse_mineru] raw cache hit doc_id=%s raw_dir=%s",
                 doc_id,
@@ -2556,6 +2580,7 @@ class _PipelineMixin:
             "parse_format": FULL_DOCS_FORMAT_LIGHTRAG,
             "content": parsed_data["content"],
             "blocks_path": str(blocks_path),
+            "parse_stage_skipped": parse_stage_skipped,
         }
 
     async def parse_docling(
@@ -2608,9 +2633,11 @@ class _PipelineMixin:
             "on",
         }
 
+        parse_stage_skipped = False
         if not force_reparse and is_bundle_valid(raw_dir, source_file_path):
             # Cache hit: keep purely local so re-parses still work when the
             # docling-serve endpoint is temporarily unavailable.
+            parse_stage_skipped = True
             logger.info(
                 "[parse_docling] raw cache hit doc_id=%s raw_dir=%s",
                 doc_id,
@@ -2680,6 +2707,7 @@ class _PipelineMixin:
             "parse_format": FULL_DOCS_FORMAT_LIGHTRAG,
             "content": parsed_data["content"],
             "blocks_path": str(blocks_path),
+            "parse_stage_skipped": parse_stage_skipped,
         }
 
     # ============================================================

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -217,13 +217,20 @@ def doc_status_field(doc: Any, field: str, default: Any = "") -> Any:
 # ``parse_stage_skipped`` is written by ``parse_mineru`` / ``parse_docling``
 # when the raw bundle cache is valid and the parse stage round trip is
 # skipped; absence == not skipped (e.g. native parser, or cache miss).
+#
+# The order of this tuple is the rendering order of metadata fields in
+# the WebUI ``DocumentStatusDetailsDialog`` (carry-over builds the new
+# metadata dict by iterating this tuple, and dict / JSON / JSX preserve
+# insertion order all the way to the rendered output). Keep fields
+# grouped by stage: parse-stage fields together, analyze-stage fields
+# together, etc., so the dialog reads top-to-bottom along the pipeline.
 _DOC_STATUS_METADATA_CARRY_OVER_KEYS: tuple[str, ...] = (
     "process_options",
     "parse_warnings",
     "chunk_opts",
     "parsing_start_time",
-    "analyzing_start_time",
     "parse_stage_skipped",
+    "analyzing_start_time",
 )
 
 

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -210,10 +210,20 @@ def doc_status_field(doc: Any, field: str, default: Any = "") -> Any:
 # format as the ``Chunking <strategy>: ...`` log line (params portion only).
 # Carrying it forward keeps the value visible after PROCESSING -> FAILED,
 # whose ``metadata_extra`` only carries timing fields.
+# ``parsing_start_time`` / ``analyzing_start_time`` are Unix epoch seconds
+# stamped at the entry of ``_parse_worker`` / ``_analyze_worker`` (mirrors
+# the existing ``processing_start_time`` set when entering PROCESSING) so
+# per-stage durations can be derived from doc_status post-mortem.
+# ``parse_stage_skipped`` is written by ``parse_mineru`` / ``parse_docling``
+# when the raw bundle cache is valid and the parse stage round trip is
+# skipped; absence == not skipped (e.g. native parser, or cache miss).
 _DOC_STATUS_METADATA_CARRY_OVER_KEYS: tuple[str, ...] = (
     "process_options",
     "parse_warnings",
     "chunk_opts",
+    "parsing_start_time",
+    "analyzing_start_time",
+    "parse_stage_skipped",
 )
 
 

--- a/lightrag_webui/src/features/DocumentManager.tsx
+++ b/lightrag_webui/src/features/DocumentManager.tsx
@@ -114,6 +114,20 @@ const getDisplayFileName = (doc: DocStatusResponse, maxLength: number = 20): str
 const formatMetadata = (metadata: Record<string, any>): string => {
   const formattedMetadata = { ...metadata };
 
+  if (formattedMetadata.parsing_start_time && typeof formattedMetadata.parsing_start_time === 'number') {
+    const date = new Date(formattedMetadata.parsing_start_time * 1000);
+    if (!isNaN(date.getTime())) {
+      formattedMetadata.parsing_start_time = date.toLocaleString();
+    }
+  }
+
+  if (formattedMetadata.analyzing_start_time && typeof formattedMetadata.analyzing_start_time === 'number') {
+    const date = new Date(formattedMetadata.analyzing_start_time * 1000);
+    if (!isNaN(date.getTime())) {
+      formattedMetadata.analyzing_start_time = date.toLocaleString();
+    }
+  }
+
   if (formattedMetadata.processing_start_time && typeof formattedMetadata.processing_start_time === 'number') {
     const date = new Date(formattedMetadata.processing_start_time * 1000);
     if (!isNaN(date.getTime())) {


### PR DESCRIPTION
## Summary

- Record `parsing_start_time` and `analyzing_start_time` (int Unix epoch seconds) on `doc_status.metadata` at the entry of `_parse_worker` / `_analyze_worker`, mirroring the existing `processing_start_time` written when entering PROCESSING. The three timestamps together let operators derive per-stage durations from `doc_status` even after the document reaches PROCESSED / FAILED.
- Surface a `parse_stage_skipped=true` flag from `parse_mineru` / `parse_docling` when the raw-bundle cache hits (the same `is_bundle_valid` branch fixed by [acef76c2](https://github.com/HKUDS/LightRAG/commit/acef76c2)), giving operators visibility into raw-cache effectiveness. Absence ≡ not skipped (cache miss or native parser).
- All three keys are added to `_DOC_STATUS_METADATA_CARRY_OVER_KEYS` so they survive every state transition (PENDING → PARSING → ANALYZING → PROCESSING → PROCESSED / FAILED).
- WebUI's existing metadata formatter (`DocumentStatusDetailsDialog` in `DocumentManager.tsx`) is extended to render the two new timestamps via `toLocaleString()`, identical to the existing `processing_start_time` / `processing_end_time` handling. `parse_stage_skipped` renders naturally as a boolean — no extra UI work needed.

## Why this is safe to merge

- Backend write is additive: `metadata` is an opaque dict, and the new keys flow through the same `doc_status_transition_metadata` carry-over plumbing used by `process_options` / `parse_warnings` / `chunk_opts`.
- No schema migration: JSON / Postgres / Mongo doc_status backends already serialize the `metadata` dict opaquely.
- `parse_native` (no raw cache) and pre-existing documents without the new keys remain valid — the WebUI only formats keys when present.
- Frontend type (`Record<string, any>`) already accepts the new keys; no type definition changes required.

## Test plan

- [ ] Backend type check passes (`python -m pyright lightrag/pipeline.py lightrag/utils_pipeline.py` or project equivalent).
- [ ] Frontend type check passes (`bun tsc --noEmit -p lightrag_webui`).
- [ ] **Cache miss (first parse)**: ingest a fresh file through mineru / docling; verify `doc_status[doc_id].metadata` contains `parsing_start_time` < `analyzing_start_time` < `processing_start_time`, and `parse_stage_skipped` is **absent**.
- [ ] **Cache hit (re-parse)**: delete the doc_status row and re-ingest the same source; verify `[parse_*] raw cache hit` log appears and `metadata.parse_stage_skipped == true`, with the three timestamps still present.
- [ ] **State穿透**: open `DocumentStatusDetailsDialog` on a PROCESSED doc and confirm all four timestamp fields render as locale strings.
- [ ] **Failure path**: trigger an analyze_worker exception (e.g. multimodal error) and confirm the FAILED row still carries `parsing_start_time` and `analyzing_start_time`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)