### PR TITLE
refactor(mongo): align doc-status storage with JSON storage for parity

### DIFF
--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -561,6 +561,16 @@ class MongoDocStatusStorage(DocStatusStorage):
                     "keys": [("status", 1), ("file_path", 1)],
                     "collation": collation_config,
                 },
+                # Partial index on content_hash for content-based dedup lookups.
+                # Mirrors the PG partial index: skip legacy/empty values so the
+                # index stays small and a content_hash="" query is a guaranteed miss.
+                {
+                    "name": f"{workspace_prefix}content_hash",
+                    "keys": [("content_hash", 1)],
+                    "partialFilterExpression": {
+                        "content_hash": {"$exists": True, "$type": "string", "$gt": ""}
+                    },
+                },
             ]
 
             # 2. Handle legacy index cleanup: only drop old indexes that exist in THIS collection
@@ -573,6 +583,7 @@ class MongoDocStatusStorage(DocStatusStorage):
                 "created_at",
                 "id",
                 "track_id",
+                "content_hash",
             ]
 
             for legacy_name in legacy_index_names:
@@ -599,6 +610,10 @@ class MongoDocStatusStorage(DocStatusStorage):
                     create_kwargs = {"name": index_name}
                     if "collation" in index_info:
                         create_kwargs["collation"] = index_info["collation"]
+                    if "partialFilterExpression" in index_info:
+                        create_kwargs["partialFilterExpression"] = index_info[
+                            "partialFilterExpression"
+                        ]
 
                     try:
                         await self._data.create_index(
@@ -747,6 +762,58 @@ class MongoDocStatusStorage(DocStatusStorage):
             Returns the same format as get_by_id method
         """
         return await self._data.find_one({"file_path": file_path})
+
+    async def get_doc_by_file_basename(
+        self, basename: str
+    ) -> Union[tuple[str, dict[str, Any]], None]:
+        """Mongo-native override of basename-based document lookup.
+
+        The caller is responsible for passing an already-canonical basename;
+        stored ``file_path`` values are canonicalized by the business layer, so
+        this lookup performs an exact match only and relies on the file_path
+        index created by ``create_and_migrate_indexes_if_not_exists``.
+        """
+        if not basename:
+            return None
+        if basename == "unknown_source":
+            return None
+
+        try:
+            doc = await self._data.find_one({"file_path": basename})
+        except PyMongoError as e:
+            logger.error(f"[{self.workspace}] Error in get_doc_by_file_basename: {e}")
+            return None
+        if not doc:
+            return None
+        doc_id = doc.get("_id")
+        if doc_id is None:
+            return None
+        return str(doc_id), doc
+
+    async def get_doc_by_content_hash(
+        self, content_hash: str
+    ) -> Union[tuple[str, dict[str, Any]], None]:
+        """Mongo-native override of content-hash document lookup.
+
+        Uses the partial ``content_hash`` index. Empty strings are treated as a
+        miss to align with the partial-index predicate; legacy rows missing the
+        field cannot match a non-empty query because ``find_one`` requires an
+        exact value.
+        """
+        if not content_hash:
+            return None
+
+        try:
+            doc = await self._data.find_one({"content_hash": content_hash})
+        except PyMongoError as e:
+            logger.error(f"[{self.workspace}] Error in get_doc_by_content_hash: {e}")
+            return None
+        if not doc:
+            return None
+        doc_id = doc.get("_id")
+        if doc_id is None:
+            return None
+        return str(doc_id), doc
 
 
 @final

--- a/tests/test_mongo_storage.py
+++ b/tests/test_mongo_storage.py
@@ -7,7 +7,7 @@ pytest.importorskip(
     reason="pymongo is required for Mongo storage tests",
 )
 
-from lightrag.kg.mongo_impl import MongoGraphStorage
+from lightrag.kg.mongo_impl import MongoDocStatusStorage, MongoGraphStorage
 
 pytestmark = pytest.mark.offline
 
@@ -95,3 +95,92 @@ class TestMongoGraphStorage:
         assert len(result.edges) == 1
         assert result.edges[0].source == "A"
         assert result.edges[0].target == "B"
+
+
+class TestMongoDocStatusLookup:
+    """Cover the Mongo-native overrides for basename / content_hash lookups."""
+
+    def _make_storage(self):
+        storage = MongoDocStatusStorage.__new__(MongoDocStatusStorage)
+        storage.workspace = "test"
+        storage.global_config = {}
+        storage._collection_name = "test_doc_status"
+        storage._data = SimpleNamespace()
+        return storage
+
+    @pytest.mark.asyncio
+    async def test_get_doc_by_file_basename_returns_tuple_on_hit(self):
+        storage = self._make_storage()
+        storage._data.find_one = AsyncMock(
+            return_value={"_id": "doc-1", "file_path": "report.pdf", "status": "processed"}
+        )
+
+        result = await storage.get_doc_by_file_basename("report.pdf")
+
+        assert result is not None
+        doc_id, doc = result
+        assert doc_id == "doc-1"
+        assert doc["file_path"] == "report.pdf"
+        storage._data.find_one.assert_awaited_once_with({"file_path": "report.pdf"})
+
+    @pytest.mark.asyncio
+    async def test_get_doc_by_file_basename_empty_returns_none_without_query(self):
+        storage = self._make_storage()
+        storage._data.find_one = AsyncMock()
+
+        assert await storage.get_doc_by_file_basename("") is None
+        storage._data.find_one.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_doc_by_file_basename_unknown_source_sentinel(self):
+        # Lookup for the sentinel must not match real rows that happen to have
+        # file_path == "unknown_source".
+        storage = self._make_storage()
+        storage._data.find_one = AsyncMock()
+
+        assert await storage.get_doc_by_file_basename("unknown_source") is None
+        storage._data.find_one.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_doc_by_file_basename_miss_returns_none(self):
+        storage = self._make_storage()
+        storage._data.find_one = AsyncMock(return_value=None)
+
+        assert await storage.get_doc_by_file_basename("missing.pdf") is None
+
+    @pytest.mark.asyncio
+    async def test_get_doc_by_content_hash_returns_tuple_on_hit(self):
+        storage = self._make_storage()
+        storage._data.find_one = AsyncMock(
+            return_value={
+                "_id": "doc-1",
+                "file_path": "report.pdf",
+                "content_hash": "abc123",
+                "status": "processed",
+            }
+        )
+
+        result = await storage.get_doc_by_content_hash("abc123")
+
+        assert result is not None
+        doc_id, doc = result
+        assert doc_id == "doc-1"
+        assert doc["content_hash"] == "abc123"
+        storage._data.find_one.assert_awaited_once_with({"content_hash": "abc123"})
+
+    @pytest.mark.asyncio
+    async def test_get_doc_by_content_hash_empty_returns_none_without_query(self):
+        # Empty hash must short-circuit so it cannot match legacy rows missing
+        # the field via accidental coercion.
+        storage = self._make_storage()
+        storage._data.find_one = AsyncMock()
+
+        assert await storage.get_doc_by_content_hash("") is None
+        storage._data.find_one.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_doc_by_content_hash_miss_returns_none(self):
+        storage = self._make_storage()
+        storage._data.find_one = AsyncMock(return_value=None)
+
+        assert await storage.get_doc_by_content_hash("zzz999") is None

--- a/tests/test_mongo_storage.py
+++ b/tests/test_mongo_storage.py
@@ -112,7 +112,11 @@ class TestMongoDocStatusLookup:
     async def test_get_doc_by_file_basename_returns_tuple_on_hit(self):
         storage = self._make_storage()
         storage._data.find_one = AsyncMock(
-            return_value={"_id": "doc-1", "file_path": "report.pdf", "status": "processed"}
+            return_value={
+                "_id": "doc-1",
+                "file_path": "report.pdf",
+                "status": "processed",
+            }
         )
 
         result = await storage.get_doc_by_file_basename("report.pdf")


### PR DESCRIPTION
## Summary

Bring the MongoDB storage to the same behavioral contract as the recent JsonKVStorage / JsonDocStatusStorage updates (and the Redis PR #3098 / PG parity refactor):

- **MongoDocStatusStorage**
  - Add `get_doc_by_file_basename`: indexed `find_one` on `file_path` with exact match. Honors the empty-string and `"unknown_source"` sentinel short-circuits required by the base contract.
  - Add `get_doc_by_content_hash`: indexed `find_one` on `content_hash`. Empty hash is a guaranteed miss, mirroring the PG partial-index semantics.
  - Add a partial index on `content_hash` in `create_and_migrate_indexes_if_not_exists` (filter expression: `$exists` + `$type:string` + `$gt:""`) so the index stays small and legacy / empty values are skipped. Wire `partialFilterExpression` through the `create_index` dispatch. Legacy unprefixed `content_hash` index name added to the workspace-prefix migration list.
- **MongoKVStorage (full_docs / text_chunks) needs no schema changes**: BSON is schemaless, and the existing `$set` upsert path persists whatever pipeline-derived fields the caller writes:
  - `full_docs`: `sidecar_location` / `parse_format` / `parse_engine` / `content_hash` / `process_options` / `chunk_options`
  - `text_chunks`: `heading` / `sidecar`
- **Backward compatibility**: `DocProcessingStatus.content_hash` already defaults to `None`, so legacy doc_status rows that lack the field still deserialize cleanly through `_prepare_doc_status_data` + `DocProcessingStatus(**data)`.

## Test plan

- [x] Extend `tests/test_mongo_storage.py` with `TestMongoDocStatusLookup` (7 cases: hit, miss, empty-input short-circuit, `"unknown_source"` sentinel — for both new methods).
- [x] `python -m pytest tests/test_mongo_storage.py -v` → 8 passed (including the pre-existing graph test, runs fully offline).
- [ ] Verify on a real MongoDB instance: confirm the `content_hash` partial index is created (`getIndexes()`) and that `find_one({"content_hash": ...})` / `find_one({"file_path": ...})` hit the indexes.

https://claude.ai/code/session_01Fwxqj1RkesaTpHqsHUuK9e