### PR TITLE
feat(pipeline-status): probe + throttled refresh for prompt scan/upload feedback

### DIFF
--- a/lightrag/_version.py
+++ b/lightrag/_version.py
@@ -1,4 +1,4 @@
 """Lightweight version definitions shared by packaging and runtime code."""
 
 __version__ = "1.5.0"
-__api_version__ = "0293"
+__api_version__ = "0294"

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -1811,6 +1811,21 @@ def create_app(args):
                 "pipeline_status", workspace=workspace
             )
 
+            pipeline_busy = bool(pipeline_status.get("busy", False))
+            pipeline_scanning = bool(pipeline_status.get("scanning", False))
+            pipeline_destructive_busy = bool(
+                pipeline_status.get("destructive_busy", False)
+            )
+            pipeline_pending_enqueues = int(
+                pipeline_status.get("pending_enqueues", 0) or 0
+            )
+            pipeline_active = (
+                pipeline_busy
+                or pipeline_scanning
+                or pipeline_destructive_busy
+                or pipeline_pending_enqueues > 0
+            )
+
             if not auth_configured:
                 auth_mode = "disabled"
             else:
@@ -1869,7 +1884,11 @@ def create_app(args):
                     "role_llm_config": rag.get_llm_role_config(),
                 },
                 "auth_mode": auth_mode,
-                "pipeline_busy": pipeline_status.get("busy", False),
+                "pipeline_busy": pipeline_busy,
+                "pipeline_active": pipeline_active,
+                "pipeline_scanning": pipeline_scanning,
+                "pipeline_destructive_busy": pipeline_destructive_busy,
+                "pipeline_pending_enqueues": pipeline_pending_enqueues,
                 "keyed_locks": keyed_lock_info,
                 "llm_queue_status": await rag.get_llm_queue_status(include_base=True),
                 "embedding_queue_status": await rag.get_embedding_queue_status(),

--- a/lightrag_webui/src/api/lightrag.ts
+++ b/lightrag_webui/src/api/lightrag.ts
@@ -99,6 +99,10 @@ export type LightragStatus = {
   api_version?: string
   auth_mode?: 'enabled' | 'disabled'
   pipeline_busy: boolean
+  pipeline_active?: boolean
+  pipeline_scanning?: boolean
+  pipeline_destructive_busy?: boolean
+  pipeline_pending_enqueues?: number
   llm_queue_status?: Record<string, LightragQueueStatus>
   embedding_queue_status?: LightragQueueStatus
   rerank_queue_status?: LightragQueueStatus

--- a/lightrag_webui/src/components/documents/UploadDocumentsDialog.tsx
+++ b/lightrag_webui/src/components/documents/UploadDocumentsDialog.tsx
@@ -19,9 +19,18 @@ import { useTranslation } from 'react-i18next'
 
 interface UploadDocumentsDialogProps {
   onDocumentsUploaded?: () => Promise<void>
+  /**
+   * Fired once per batch as soon as the first file is accepted by the server.
+   * Lets the parent start its activity probe as early as possible (rather
+   * than waiting for the whole sequential batch to finish).
+   */
+  onUploadBatchAccepted?: () => void
 }
 
-export default function UploadDocumentsDialog({ onDocumentsUploaded }: UploadDocumentsDialogProps) {
+export default function UploadDocumentsDialog({
+  onDocumentsUploaded,
+  onUploadBatchAccepted
+}: UploadDocumentsDialogProps) {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
   const [isUploading, setIsUploading] = useState(false)
@@ -76,6 +85,7 @@ export default function UploadDocumentsDialog({ onDocumentsUploaded }: UploadDoc
       try {
         // Track errors locally to ensure we have the final state
         const uploadErrors: Record<string, string> = {}
+        let batchProbeTriggered = false
 
         // Create a collator that supports Chinese sorting
         const collator = new Intl.Collator(['zh-CN', 'en'], {
@@ -112,6 +122,10 @@ export default function UploadDocumentsDialog({ onDocumentsUploaded }: UploadDoc
             } else {
               // Mark that we had at least one successful upload
               hasSuccessfulUpload = true
+              if (!batchProbeTriggered) {
+                batchProbeTriggered = true
+                onUploadBatchAccepted?.()
+              }
             }
           } catch (err) {
             console.error(`Upload failed for ${file.name}:`, err)
@@ -186,7 +200,7 @@ export default function UploadDocumentsDialog({ onDocumentsUploaded }: UploadDoc
         setIsUploading(false)
       }
     },
-    [setIsUploading, setProgresses, setFileErrors, t, onDocumentsUploaded]
+    [setIsUploading, setProgresses, setFileErrors, t, onDocumentsUploaded, onUploadBatchAccepted]
   )
 
   return (

--- a/lightrag_webui/src/features/DocumentManager.tsx
+++ b/lightrag_webui/src/features/DocumentManager.tsx
@@ -318,7 +318,9 @@ export default function DocumentManager() {
   // Track component mount status
   const isMountedRef = useRef(true);
 
-  // Set up mount/unmount status tracking
+  // Set up mount/unmount status tracking. Pending throttle/probe timers are NOT
+  // explicitly cleared on unmount — every timer callback checks isMountedRef
+  // before doing any work, so a stray fire is a no-op.
   useEffect(() => {
     isMountedRef.current = true;
 
@@ -338,7 +340,7 @@ export default function DocumentManager() {
   const [showPipelineStatus, setShowPipelineStatus] = useState(false)
   const { t, i18n } = useTranslation()
   const health = useBackendState.use.health()
-  const pipelineBusy = useBackendState.use.pipelineBusy()
+  const pipelineActive = useBackendState.use.pipelineActive()
 
   // Legacy state for backward compatibility
   const [docs, setDocs] = useState<DocsStatusesResponse | null>(null)
@@ -360,6 +362,13 @@ export default function DocumentManager() {
     has_prev: false
   })
   const [statusCounts, setStatusCounts] = useState<Record<string, number>>({ all: 0 })
+  // Mirror statusCounts in a ref so async callbacks (e.g. activity probe ticks)
+  // can read the latest value without being tied to the closure captured at
+  // schedule time. Synced via useEffect to satisfy react-hooks/refs.
+  const statusCountsRef = useRef(statusCounts)
+  useEffect(() => {
+    statusCountsRef.current = statusCounts
+  }, [statusCounts])
   const [isRefreshing, setIsRefreshing] = useState(false)
 
   // Sort state
@@ -383,15 +392,24 @@ export default function DocumentManager() {
   const [selectedDocIds, setSelectedDocIds] = useState<string[]>([])
   const isSelectionMode = selectedDocIds.length > 0
 
-  // Add refs to track previous pipelineBusy state and current interval
-  const prevPipelineBusyRef = useRef<boolean | undefined>(undefined);
+  // Add refs to track previous pipelineActive state and current interval
+  const prevPipelineActiveRef = useRef<boolean | undefined>(undefined);
   const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const activeRefreshPromiseRef = useRef<Promise<void> | null>(null);
   const pendingRefreshRequestRef = useRef<RefreshRequest | null>(null);
   const latestRefreshRequestVersionRef = useRef(0);
+  // Throttle gate: all auto-driven /documents/paginated entrances funnel through
+  // refreshDocumentsThrottled() to enforce a minimum 2s wall-clock interval.
+  const lastPaginatedAtRef = useRef(0);
+  const pendingPaginatedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Activity probe: exponential-backoff burst of /health calls that stops once
+  // pipelineActive flips true. Holds the pending setTimeout ids so re-entry can
+  // reset the schedule to t=0.
+  const probeTimersRef = useRef<ReturnType<typeof setTimeout>[] | null>(null);
+  const probeActiveRef = useRef(false);
 
-  // Add retry mechanism state
-  const [retryState, setRetryState] = useState({
+  // Add retry mechanism state (read by circuit breaker via setRetryState only).
+  const [, setRetryState] = useState({
     count: 0,
     lastError: null as Error | null,
     isBackingOff: false
@@ -933,6 +951,104 @@ export default function DocumentManager() {
     });
   }, [buildQuerySnapshot, enqueueRefresh, pagination.page]);
 
+  // Throttle gate: any caller wanting to refresh the document list goes through
+  // here. If the wall-clock gap since the last paginated request is >= 2s, fire
+  // immediately; otherwise schedule a single trailing call at the 2s boundary
+  // and drop any further calls into that pending slot (natural coalescing).
+  const refreshDocumentsThrottled = useCallback(() => {
+    const fire = () => {
+      lastPaginatedAtRef.current = Date.now()
+      handleIntelligentRefresh().catch((err) => {
+        console.error('Throttled document refresh failed:', err)
+      })
+    }
+    const gap = Date.now() - lastPaginatedAtRef.current
+    if (gap >= 2000) {
+      fire()
+      return
+    }
+    if (pendingPaginatedTimerRef.current !== null) return
+    // Snapshot the query identity. If page/filter/sort changes while we wait,
+    // the page-change useEffect bumps latestRefreshRequestVersionRef AND fires
+    // its own paginated request on the new query. Our trailing closure still
+    // holds the OLD handleIntelligentRefresh (capturing the old page), so we
+    // must drop it — otherwise the stale request would overwrite the new list
+    // (its requestVersion would be the newly-bumped value, so the in-flight
+    // stale-check inside runRefreshRequest can't catch it).
+    const versionAtSchedule = latestRefreshRequestVersionRef.current
+    pendingPaginatedTimerRef.current = setTimeout(() => {
+      pendingPaginatedTimerRef.current = null
+      if (!isMountedRef.current) return
+      if (versionAtSchedule !== latestRefreshRequestVersionRef.current) return
+      fire()
+    }, 2000 - gap)
+  }, [handleIntelligentRefresh]);
+
+  // Activity probe: short exponential-backoff burst of /health checks fired
+  // after scan/upload triggers. Stops as soon as pipelineActive flips true so
+  // we can hand off to the existing 5s active polling cadence. Re-entry
+  // (e.g. another scan while a probe is mid-flight) cancels the current
+  // schedule and restarts at t=0 so the latest action gets a fresh observation
+  // window.
+  const startActivityProbe = useCallback((reason: string) => {
+    if (probeTimersRef.current) {
+      probeTimersRef.current.forEach((id) => clearTimeout(id))
+      probeTimersRef.current = null
+    }
+    probeActiveRef.current = true
+    const timers: ReturnType<typeof setTimeout>[] = []
+    const probeSchedule = [0, 1000, 2000, 4000, 8000, 16000] as const
+    const refreshAt = new Set<number>([0, 2000, 4000, 8000, 16000])
+    const cleanup = () => {
+      timers.forEach((id) => clearTimeout(id))
+      if (probeTimersRef.current === timers) {
+        probeTimersRef.current = null
+        probeActiveRef.current = false
+      }
+    }
+    probeSchedule.forEach((delay, index) => {
+      const id = setTimeout(async () => {
+        if (!isMountedRef.current) {
+          cleanup()
+          return
+        }
+        try {
+          await useBackendState.getState().check()
+        } catch (err) {
+          console.error(`Activity probe (${reason}) check failed:`, err)
+        }
+        if (!isMountedRef.current) {
+          cleanup()
+          return
+        }
+        if (refreshAt.has(delay)) {
+          refreshDocumentsThrottled()
+        }
+        // Exit conditions (in priority order):
+        //  - pipelineActive=true AND the document list has caught up: the 5s
+        //    active polling cadence will take over from here.
+        //  - pipelineActive=false after the first tick: the scan/upload didn't
+        //    actually start any work (e.g. scan found nothing new, upload was
+        //    rejected) — no point continuing to burst /health.
+        //  - last tick: time budget exhausted, hand off to the polling loop.
+        // Note: NOT stopping on bare `pipelineActive=true` is intentional.
+        // /health flips to active on scanning/pending_enqueues before the new
+        // doc rows are visible in /documents/paginated, so a premature exit
+        // would strand the UI in 30s idle polling while classification is
+        // still running.
+        const active = useBackendState.getState().pipelineActive
+        const docsActive = hasActiveDocumentsStatus(statusCountsRef.current)
+        const isLast = index === probeSchedule.length - 1
+        const stop = (active && docsActive) || (!active && index > 0) || isLast
+        if (stop) {
+          cleanup()
+        }
+      }, delay)
+      timers.push(id)
+    })
+    probeTimersRef.current = timers
+  }, [refreshDocumentsThrottled]);
+
   // New paginated data fetching function
   const fetchPaginatedDocuments = useCallback(async (
     page: number,
@@ -971,90 +1087,44 @@ export default function DocumentManager() {
   const startPollingInterval = useCallback((intervalMs: number) => {
     clearPollingInterval();
 
-    pollingIntervalRef.current = setInterval(async () => {
-      try {
-        // Check circuit breaker before making request
-        if (isCircuitBreakerOpen()) {
-          return; // Skip this polling cycle
-        }
-
-        // Only perform fetch if component is still mounted
-        if (isMountedRef.current) {
-          await fetchDocuments();
-          recordSuccess(); // Record successful operation
-        }
-      } catch (err) {
-        // Only handle error if component is still mounted
-        if (isMountedRef.current) {
-          const errorClassification = classifyError(err);
-
-          // Always reset isRefreshing state on error
-          setIsRefreshing(false);
-
-          if (errorClassification.shouldShowToast) {
-            toast.error(t('documentPanel.documentManager.errors.scanProgressFailed', { error: errorMessage(err) }));
-          }
-
-          if (errorClassification.shouldRetry) {
-            recordFailure(err as Error);
-
-            // Implement exponential backoff for retries
-            const backoffDelay = Math.min(Math.pow(2, retryState.count) * 1000, 30000); // Max 30s
-
-            if (retryState.count < 3) { // Max 3 retries
-              setTimeout(() => {
-                if (isMountedRef.current) {
-                  setRetryState(prev => ({ ...prev, isBackingOff: false }));
-                }
-              }, backoffDelay);
-            }
-          } else {
-            // For non-retryable errors, stop polling
-            clearPollingInterval();
-          }
-        }
-      }
+    pollingIntervalRef.current = setInterval(() => {
+      if (!isMountedRef.current) return;
+      if (isCircuitBreakerOpen()) return;
+      // refreshDocumentsThrottled is fire-and-forget; errors are surfaced via
+      // toast/recordFailure inside runRefreshRequest.
+      refreshDocumentsThrottled();
+      recordSuccess();
     }, intervalMs);
-  }, [fetchDocuments, t, clearPollingInterval, isCircuitBreakerOpen, recordSuccess, recordFailure, classifyError, retryState.count]);
+  }, [refreshDocumentsThrottled, clearPollingInterval, isCircuitBreakerOpen, recordSuccess]);
 
   const scanDocuments = useCallback(async () => {
     try {
-      // Check if component is still mounted before starting the request
       if (!isMountedRef.current) return;
 
-      const { status, message, track_id: _track_id } = await scanNewDocuments(); // eslint-disable-line @typescript-eslint/no-unused-vars
+      const { status, message } = await scanNewDocuments();
 
-      // Check again if component is still mounted after the request completes
       if (!isMountedRef.current) return;
 
-      // Note: _track_id is available for future use (e.g., progress tracking)
       toast.message(message || status);
 
-      // Reset health check timer with 1 second delay to avoid race condition
-      useBackendState.getState().resetHealthCheckTimerDelayed(1000);
-
-      // Perform immediate refresh with 90s timeout after scan (tolerates PostgreSQL switchover)
-      await handleIntelligentRefresh(undefined, false, 90000);
-
-      // Start fast refresh with 2-second interval after initial refresh
-      startPollingInterval(2000);
-
-      // Set recovery timer to restore normal polling interval after 15 seconds
-      setTimeout(() => {
-        if (isMountedRef.current && currentTab === 'documents' && health) {
-          // Restore intelligent polling interval based on document status
-          const hasActiveDocuments = hasActiveDocumentsStatus(statusCounts);
-          const normalInterval = hasActiveDocuments ? 5000 : 30000;
-          startPollingInterval(normalInterval);
-        }
-      }, 15000); // Restore after 15 seconds
+      if (status === 'scanning_started') {
+        // Activity probe drives /health bursts + throttled document refreshes.
+        // It exits as soon as pipelineActive flips true, after which the
+        // standard 5s polling cadence (driven by hasActiveDocumentsStatus)
+        // takes over.
+        startActivityProbe('scan');
+      } else {
+        // scanning_skipped_pipeline_busy: a single check+refresh is enough,
+        // no need to start the probe (pipeline is already active).
+        useBackendState.getState().check().catch(() => undefined);
+        refreshDocumentsThrottled();
+      }
     } catch (err) {
-      // Only show error if component is still mounted
       if (isMountedRef.current) {
         toast.error(t('documentPanel.documentManager.errors.scanFailed', { error: errorMessage(err) }));
       }
     }
-  }, [t, startPollingInterval, currentTab, health, statusCounts, handleIntelligentRefresh])
+  }, [t, startActivityProbe, refreshDocumentsThrottled])
 
   // Handle manual refresh with pagination reset logic
   const handleManualRefresh = useCallback(async () => {
@@ -1069,49 +1139,45 @@ export default function DocumentManager() {
     latestRefreshRequestVersionRef.current += 1
   }, [pagination.page, pagination.page_size, statusFilter, sortField, sortDirection])
 
-  // Monitor pipelineBusy changes and trigger immediate refresh with timer reset
+  // Monitor pipelineActive changes and trigger an immediate refresh. The
+  // polling interval is reconciled by the main polling useEffect below
+  // (which also depends on pipelineActive), so there's no need to re-call
+  // startPollingInterval here.
   useEffect(() => {
-    // Skip the first render when prevPipelineBusyRef is undefined
-    if (prevPipelineBusyRef.current !== undefined && prevPipelineBusyRef.current !== pipelineBusy) {
-      // pipelineBusy state has changed, trigger immediate refresh
+    if (prevPipelineActiveRef.current !== undefined && prevPipelineActiveRef.current !== pipelineActive) {
       if (currentTab === 'documents' && health && isMountedRef.current) {
-        // Use intelligent refresh to preserve current page
-        handleIntelligentRefresh();
-
-        // Reset polling timer after intelligent refresh
-        const hasActiveDocuments = hasActiveDocumentsStatus(statusCounts);
-        const pollingInterval = hasActiveDocuments ? 5000 : 30000;
-        startPollingInterval(pollingInterval);
+        refreshDocumentsThrottled();
       }
     }
-    // Update the previous state
-    prevPipelineBusyRef.current = pipelineBusy;
+    prevPipelineActiveRef.current = pipelineActive;
   }, [
-    pipelineBusy,
+    pipelineActive,
     currentTab,
     health,
-    handleIntelligentRefresh,
-    statusCounts,
-    startPollingInterval
+    refreshDocumentsThrottled
   ]);
 
-  // Set up intelligent polling with dynamic interval based on document status
+  // Set up intelligent polling with dynamic interval based on document status.
+  // Treat pipelineActive=true as enough reason to stay in 5s fast polling even
+  // when statusCounts hasn't surfaced pending rows yet — /health flips active
+  // during scan classification / upload enqueue, well before the new doc rows
+  // appear in /documents/paginated. Without this, the UI would stall in 30s
+  // idle polling for several seconds after the user clicked scan/upload.
   useEffect(() => {
     if (currentTab !== 'documents' || !health) {
       clearPollingInterval();
       return
     }
 
-    // Determine polling interval based on document status
     const hasActiveDocuments = hasActiveDocumentsStatus(statusCounts);
-    const pollingInterval = hasActiveDocuments ? 5000 : 30000; // 5s if active, 30s if idle
+    const pollingInterval = (hasActiveDocuments || pipelineActive) ? 5000 : 30000;
 
     startPollingInterval(pollingInterval);
 
     return () => {
       clearPollingInterval();
     }
-  }, [health, t, currentTab, statusCounts, startPollingInterval, clearPollingInterval])
+  }, [health, t, currentTab, statusCounts, pipelineActive, startPollingInterval, clearPollingInterval])
 
   // Monitor docs changes to check status counts and trigger health check if needed
   useEffect(() => {
@@ -1131,12 +1197,14 @@ export default function DocumentManager() {
       status => newStatusCounts[status] !== prevStatusCounts.current[status]
     )
 
-    // Trigger health check if changes detected and component is still mounted
-    if (hasStatusCountChange && isMountedRef.current) {
+    // Trigger health check if changes detected and component is still mounted.
+    // Skip when the activity probe is running — the probe already drives /health
+    // on its own schedule, and double-firing would burn cache and skew rate.
+    if (hasStatusCountChange && isMountedRef.current && !probeActiveRef.current) {
       useBackendState.getState().check()
     }
 
-    // Update previous status counts
+    // Always update the snapshot so the first post-probe transition still fires.
     prevStatusCounts.current = newStatusCounts
   }, [docs]);
 
@@ -1284,7 +1352,7 @@ export default function DocumentManager() {
               tooltip={t('documentPanel.documentManager.pipelineStatusTooltip')}
               size="sm"
               className={cn(
-                pipelineBusy && 'pipeline-busy'
+                pipelineActive && 'pipeline-busy'
               )}
             >
               <ActivityIcon /> {t('documentPanel.documentManager.pipelineStatusButton')}
@@ -1332,7 +1400,10 @@ export default function DocumentManager() {
             ) : !isSelectionMode ? (
               <ClearDocumentsDialog onDocumentsCleared={handleDocumentsCleared} />
             ) : null}
-            <UploadDocumentsDialog onDocumentsUploaded={() => handleIntelligentRefresh(undefined, false, 120000)} />
+            <UploadDocumentsDialog
+              onUploadBatchAccepted={() => startActivityProbe('upload')}
+              onDocumentsUploaded={async () => { refreshDocumentsThrottled() }}
+            />
             <PipelineStatusDialog
               open={showPipelineStatus}
               onOpenChange={setShowPipelineStatus}

--- a/lightrag_webui/src/stores/state.ts
+++ b/lightrag_webui/src/stores/state.ts
@@ -11,6 +11,7 @@ interface BackendState {
   status: LightragStatus | null
   lastCheckTime: number
   pipelineBusy: boolean
+  pipelineActive: boolean
   healthCheckIntervalId: ReturnType<typeof setInterval> | null
   healthCheckFunction: (() => void) | null
   healthCheckIntervalValue: number
@@ -50,6 +51,7 @@ const useBackendStateStoreBase = create<BackendState>()((set, get) => ({
   lastCheckTime: Date.now(),
   status: null,
   pipelineBusy: false,
+  pipelineActive: false,
   healthCheckIntervalId: null,
   healthCheckFunction: null,
   healthCheckIntervalValue: healthCheckInterval * 1000, // Use constant from lib/constants
@@ -98,7 +100,8 @@ const useBackendStateStoreBase = create<BackendState>()((set, get) => ({
         messageTitle: null,
         lastCheckTime: Date.now(),
         status: health,
-        pipelineBusy: health.pipeline_busy
+        pipelineBusy: health.pipeline_busy,
+        pipelineActive: health.pipeline_active ?? health.pipeline_busy
       })
       return true
     }

--- a/tests/test_bedrock_llm.py
+++ b/tests/test_bedrock_llm.py
@@ -832,3 +832,71 @@ def test_health_role_llm_config_uses_runtime_snapshot(tmp_path, monkeypatch):
     assert body["llm_queue_status"]["query"]["rejected_total"] == 2
     assert body["embedding_queue_status"]["running"] == 1
     assert body["rerank_queue_status"]["available"] is False
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize(
+    "pipeline_state, expected_active",
+    [
+        ({"busy": False}, False),
+        ({"busy": True}, True),
+        ({"busy": False, "scanning": True}, True),
+        ({"busy": False, "destructive_busy": True}, True),
+        ({"busy": False, "pending_enqueues": 2}, True),
+        (
+            {
+                "busy": False,
+                "scanning": False,
+                "destructive_busy": False,
+                "pending_enqueues": 0,
+            },
+            False,
+        ),
+    ],
+)
+def test_health_pipeline_active_derivation(
+    tmp_path, monkeypatch, pipeline_state, expected_active
+):
+    _reload_api_modules_if_mocked()
+    monkeypatch.setattr(sys, "argv", ["pytest"])
+    config = importlib.import_module("lightrag.api.config")
+    config.initialize_config(_make_args(tmp_path), force=True)
+    lightrag_server = importlib.import_module("lightrag.api.lightrag_server")
+    monkeypatch.setattr(lightrag_server, "LightRAG", _FakeLightRAG)
+    monkeypatch.setattr(lightrag_server, "check_frontend_build", lambda: (True, False))
+    monkeypatch.setattr(
+        lightrag_server, "create_document_routes", lambda *_args, **_kwargs: APIRouter()
+    )
+    monkeypatch.setattr(
+        lightrag_server, "create_query_routes", lambda *_args, **_kwargs: APIRouter()
+    )
+    monkeypatch.setattr(
+        lightrag_server, "create_graph_routes", lambda *_args, **_kwargs: APIRouter()
+    )
+    monkeypatch.setattr(lightrag_server, "OllamaAPI", _FakeOllamaAPI)
+    monkeypatch.setattr(
+        lightrag_server,
+        "get_namespace_data",
+        AsyncMock(return_value=pipeline_state),
+    )
+    monkeypatch.setattr(lightrag_server, "get_default_workspace", lambda: "default")
+    monkeypatch.setattr(
+        lightrag_server,
+        "cleanup_keyed_lock",
+        lambda: {"cleanup_performed": {}, "current_status": {}},
+    )
+
+    app = lightrag_server.create_app(_make_args(tmp_path))
+    response = TestClient(app).get("/health")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["pipeline_busy"] is bool(pipeline_state.get("busy", False))
+    assert body["pipeline_scanning"] is bool(pipeline_state.get("scanning", False))
+    assert body["pipeline_destructive_busy"] is bool(
+        pipeline_state.get("destructive_busy", False)
+    )
+    assert body["pipeline_pending_enqueues"] == int(
+        pipeline_state.get("pending_enqueues", 0)
+    )
+    assert body["pipeline_active"] is expected_active


### PR DESCRIPTION
## Summary

Eliminates the 5~10s "pipeline-busy" button delay after clicking **Scan**, and surfaces newly-scanned/uploaded documents in the list with sub-2-second latency — without flooding the backend with paginated requests.

## Problem

After clicking **Scan**:

1. Backend sets `scanning=True` synchronously inside the endpoint, but the classification phase only sets `scanning_exclusive` — it does NOT set `busy`.
2. `/health` returned only `pipeline_busy` (= `busy`), so the frontend pulse-red button stayed grey for the entire classification phase.
3. The 1s delayed `resetHealthCheckTimerDelayed(1000)` typically landed in the middle of classification (still `busy=False`), wasting the call.
4. The next `/health` is then 15s away, leaving a 5~10s+ window where the user sees no UI feedback.

The document list had a similar gap: the existing `startPollingInterval(2000)+15s recovery` window often didn't survive long enough to cover the time-to-pending-row.

## Backend changes (`lightrag/api/lightrag_server.py`)

Add four derived fields to `/health`:

| Field | Source |
|---|---|
| `pipeline_active` | `busy \|\| scanning \|\| destructive_busy \|\| pending_enqueues > 0` |
| `pipeline_scanning` | `pipeline_status["scanning"]` |
| `pipeline_destructive_busy` | `pipeline_status["destructive_busy"]` |
| `pipeline_pending_enqueues` | `pipeline_status["pending_enqueues"]` |

`pipeline_busy` retains its original semantics for backward compatibility. The scan endpoint already sets `scanning=True` synchronously inside `pipeline_status_lock` (before returning), so any post-scan `/health` call now reports `pipeline_active=True` immediately.

## Frontend changes

### Activity probe (`DocumentManager.tsx::startActivityProbe`)

Exponential-backoff burst of `/health` calls fired by:
- `scanNewDocuments()` returning `scanning_started`
- The first `result.status === 'success'` in an upload batch (new `onUploadBatchAccepted` prop on `UploadDocumentsDialog`)

Schedule:

| Tick | /health | /documents/paginated |
|---|---|---|
| t=0s | ✓ | ✓ |
| t=1s | ✓ | — |
| t=2s | ✓ | ✓ |
| t=4s | ✓ | ✓ |
| t=8s | ✓ | ✓ |
| t=16s | ✓ | ✓ |

Exit conditions (priority order):
1. `pipelineActive=true` **AND** `hasActiveDocumentsStatus(statusCounts)=true` — pipeline is reported active and the doc list has caught up; hand off to the standard 5s polling cadence.
2. `pipelineActive=false` after the first tick — scan returned no new files / upload was rejected; nothing to observe.
3. `t=16s` — time budget exhausted, hand off to polling.

Re-entry (scan-then-upload, etc.) cancels the current schedule and restarts at t=0 so the latest action gets a fresh observation window.

### Throttle gate (`DocumentManager.tsx::refreshDocumentsThrottled`)

All auto-driven `/documents/paginated` calls funnel through here:
- Gap since last paginated request ≥ 2s → fire immediately.
- Otherwise schedule a single trailing call at the 2s boundary; further calls into that pending slot are dropped (natural coalescing).
- Trailing-refresh closures are version-stamped against `latestRefreshRequestVersionRef` and dropped if the user navigated away — prevents a stale captured query from overwriting the newly-loaded page.

### Polling stays in 5s mode while pipelineActive

The main polling useEffect now uses `(hasActiveDocuments || pipelineActive) ? 5000 : 30000`. This closes the gap where `/health` reports active but the doc list hasn't surfaced rows yet (scan still in classification / enqueue).

### Removed
- `resetHealthCheckTimerDelayed(1000)` after scan
- `startPollingInterval(2000) + 15s setTimeout` rollback
- Immediate `handleIntelligentRefresh(90000)` after scan
- Direct `setPipelineBusy(true)` calls (optimistic update was never wired)

## Behavior comparison

| Scenario | Before | After |
|---|---|---|
| Pipeline-busy button turns red after scan | 5~10s | **≤1s** (probe t=0 catches `scanning=true`) |
| Document list refresh during scan classification | up to 30s idle gap | ≤2s (probe + active polling) |
| Any two `/documents/paginated` interval | unbounded | **strict ≥ 2s** (throttle gate) |
| Upload single big file → button red | depends on health-check phase | ≤1s |
| Scan finding 0 new files | full 16s probe burst | 1 probe tick, exits early |
| 2s-window page change during trailing refresh | **stale query overwrites new list** | trailing dropped via version check |

## Test plan

- [x] `bun run lint && bun test && bun run build` (frontend)
- [x] `pytest tests/test_bedrock_llm.py -k health -v` — 7 passed (includes new `test_health_pipeline_active_derivation` parametrized over 6 pipeline-state shapes)
- [ ] Manual: empty input dir → scan → button red ≤1s, probe exits quickly
- [ ] Manual: input dir with 1 large file → scan → button red ≤1s, pending/processing rows visible at 2s cadence, polling falls back to 5s
- [ ] Manual: batch upload 10 files → only the first success triggers probe; subsequent successes don't re-trigger
- [ ] Manual: `scanning_skipped_pipeline_busy` (re-clicking scan while already running) → 1 check + 1 paginated, no second probe
- [ ] Manual: page change during 2s throttle window → no stale list overwrite
- [ ] DevTools Network: confirm any two `/documents/paginated` calls have Started At ≥ 2s apart

🤖 Generated with [Claude Code](https://claude.com/claude-code)