### PR TITLE
Setup wizard: role-specific LLM models, Bedrock auth docs, env tidy

### DIFF
--- a/env.example
+++ b/env.example
@@ -565,7 +565,7 @@ OLLAMA_LLM_NUM_CTX=32768
 # # LLM_BINDING=bedrock
 # # LLM_BINDING_HOST=DEFAULT_BEDROCK_ENDPOINT
 # # LLM_MODEL=us.amazon.nova-lite-v1:0
-### Authentication (choose ONE of the following two approaches):
+### Authentication (choose ONE of the following three approaches):
 ### Bedrock API key (bearer token). Bedrock ignores LLM_BINDING_API_KEY;
 ### set AWS_BEARER_TOKEN_BEDROCK directly before startup. This is a
 ### process-level AWS SDK setting and cannot be overridden per role.
@@ -574,7 +574,14 @@ OLLAMA_LLM_NUM_CTX=32768
 # AWS_ACCESS_KEY_ID=your_aws_access_key_id
 # AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
 # AWS_SESSION_TOKEN=your_optional_aws_session_token
-### Region is required for both auth modes (Bedrock endpoints are regional).
+### Ambient credentials (AWS SDK default credential chain).
+### To use this mode, leave AWS_BEARER_TOKEN_BEDROCK, AWS_ACCESS_KEY_ID,
+### AWS_SECRET_ACCESS_KEY, and AWS_SESSION_TOKEN above commented out — the
+### AWS SDK will then resolve credentials from ~/.aws/credentials, IAM role,
+### instance profile, SSO, or environment variables outside .env.
+### Activating any of the lines above forces that explicit mode and bypasses
+### the credential chain.
+### Region is required for all three modes (Bedrock endpoints are regional).
 # AWS_REGION=us-west-1
 ### use the following command to see all supported options for Bedrock
 ### lightrag-server --llm-binding bedrock --help
@@ -684,7 +691,7 @@ OLLAMA_EMBEDDING_NUM_CTX=8192
 # # Or set EMBEDDING_BINDING_HOST to a custom Bedrock-compatible proxy/gateway URL
 # # EMBEDDING_MODEL=amazon.titan-embed-text-v2:0
 # # EMBEDDING_DIM=1024
-### Authentication (choose ONE of the following two approaches):
+### Authentication (choose ONE of the following three approaches):
 ### Bedrock API key (bearer token). Bedrock ignores EMBEDDING_BINDING_API_KEY;
 ### set AWS_BEARER_TOKEN_BEDROCK directly before startup. This is a
 ### process-level AWS SDK setting and cannot be overridden per role.
@@ -693,7 +700,14 @@ OLLAMA_EMBEDDING_NUM_CTX=8192
 # AWS_ACCESS_KEY_ID=your_aws_access_key_id
 # AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
 # AWS_SESSION_TOKEN=your_optional_aws_session_token
-### Region is required for both auth modes (Bedrock endpoints are regional).
+### Ambient credentials (AWS SDK default credential chain).
+### To use this mode, leave AWS_BEARER_TOKEN_BEDROCK, AWS_ACCESS_KEY_ID,
+### AWS_SECRET_ACCESS_KEY, and AWS_SESSION_TOKEN above commented out — the
+### AWS SDK will then resolve credentials from ~/.aws/credentials, IAM role,
+### instance profile, SSO, or environment variables outside .env.
+### Activating any of the lines above forces that explicit mode and bypasses
+### the credential chain.
+### Region is required for all three modes (Bedrock endpoints are regional).
 # AWS_REGION=us-west-1
 
 ### Jina AI Embedding

--- a/env.example
+++ b/env.example
@@ -263,7 +263,7 @@ MINERU_LOCAL_BACKEND=hybrid-auto-engine
 ###   Pure VLM backends (`vlm-auto-engine`, `vlm-http-client`) ignore this
 ###   parameter -- the VLM model handles layout/OCR natively.
 MINERU_LOCAL_PARSE_METHOD=auto
-### MINERU_LOCAL_IMAGE_ANALYSIS: enable VLM image/chart analysis pass for 
+### MINERU_LOCAL_IMAGE_ANALYSIS: enable VLM image/chart analysis pass for
 ###   better caption an footnote recognition.
 ###   Only consumed by `vlm-auto-engine`, `vlm-http-client`,
 ###   `hybrid-auto-engine`, `hybrid-http-client`. The `pipeline` backend
@@ -400,7 +400,7 @@ DOCLING_DO_FORMULA_ENRICHMENT=false
 ###     CHUNK_P_SIZE: per-strategy chunk_token_size override; defaults to 2000 when unset
 ###       (does NOT fall back to CHUNK_SIZE — paragraph-semantic merging needs more
 ###       headroom than the global default to keep related paragraphs together).
-###     CHUNK_P_OVERLAP_SIZE: overlap for prose fallback and table-bridge context; 
+###     CHUNK_P_OVERLAP_SIZE: overlap for prose fallback and table-bridge context;
 ###                           falls back to CHUNK_OVERLAP_SIZE when unset
 # CHUNK_P_SIZE=2000
 # CHUNK_P_OVERLAP_SIZE=100
@@ -436,7 +436,7 @@ DOCLING_DO_FORMULA_ENRICHMENT=false
 ###    KEEP: Keep oldest (less merge action and faster)
 # SOURCE_IDS_LIMIT_METHOD=FIFO
 
-### Maximum number of file paths stored in entity/relation file_path field 
+### Maximum number of file paths stored in entity/relation file_path field
 ### For displayed only, does not affect query performance
 # MAX_FILE_PATHS=100
 

--- a/env.example
+++ b/env.example
@@ -35,10 +35,9 @@ WEBUI_DESCRIPTION='Simple and Fast Graph Based RAG System'
 # SSL_KEYFILE=/path/to/key.pem
 
 ### Directory Configuration (defaults to current working directory)
-### Default value is: ./inputs ./rag_storage ./prompts
+### Default value is: ./inputs ./rag_storage
 # INPUT_DIR=<absolute_path_for_doc_input_dir>
 # WORKING_DIR=<absolute_path_for_working_dir>
-# PROMPT_DIR=<absolute_path_for_prompt_dir>
 
 ### Tiktoken cache directory (Store cached files in this folder for offline deployment)
 # TIKTOKEN_CACHE_DIR=/app/data/tiktoken
@@ -192,71 +191,19 @@ RERANK_BINDING=null
 ########################################
 ### Document processing configuration
 ########################################
-ENABLE_LLM_CACHE_FOR_EXTRACT=true
-
 ### Document processing output language: English, Chinese, French, German ...
 SUMMARY_LANGUAGE=English
 
-### File upload size limit (in bytes)
-### Default: 104857600 (100MB)
-### Set to 0 or None for unlimited upload size
-### Examples:
-###   52428800  = 50MB
-###   104857600 = 100MB (default)
-###   209715200 = 200MB
-### Note: If using Nginx as reverse proxy, also configure client_max_body_size
-# MAX_UPLOAD_SIZE=104857600
+### Enable JSON-structured output for entity extraction
+### Default behavior: JSON output is disabled when ENTITY_EXTRACTION_USE_JSON is unset
+### JSON output incurs higher latency but delivers improved reliability
+ENTITY_EXTRACTION_USE_JSON=true
 
-### Chunk size for document splitting, 500~1500 is recommended
-# CHUNK_SIZE=1200
-# CHUNK_OVERLAP_SIZE=100
-
-### Fixed-token chunker (process_options=F, default) settings
-###     CHUNK_F_OVERLAP_SIZE: token overlap; falls back to CHUNK_OVERLAP_SIZE when unset
-###     CHUNK_F_SPLIT_BY_CHARACTER: optional separator string; pre-segment before token windowing
-###     CHUNK_F_SPLIT_BY_CHARACTER_ONLY: when true, raise on oversize segment instead of token re-split
-# CHUNK_F_OVERLAP_SIZE=100
-# CHUNK_F_SPLIT_BY_CHARACTER=
-# CHUNK_F_SPLIT_BY_CHARACTER_ONLY=false
-
-### Recursive character chunker (process_options=R) settings
-###     CHUNK_R_SIZE: per-strategy chunk_token_size override; falls back to CHUNK_SIZE when unset
-###     CHUNK_R_OVERLAP_SIZE: token overlap between adjacent chunks; falls back to CHUNK_OVERLAP_SIZE when unset
-###     CHUNK_R_SEPARATORS: JSON array of cascaded separators tried by RecursiveCharacterTextSplitter.
-###       Default includes CJK sentence-ending punctuation so Chinese / mixed-language
-###       documents split at semantic boundaries.  Order: paragraph (\n\n) > line (\n) >
-###       Chinese sentence-end (。！？) > Chinese semi-clause (；，) > space > char.
-###       English ".?!" are intentionally omitted (literal match would split "0.95" /
-###       "e.g."); the English path falls through space / char as before.
-# CHUNK_R_SIZE=1200
-# CHUNK_R_OVERLAP_SIZE=100
-# CHUNK_R_SEPARATORS=["\n\n","\n","。","！","？","；","，"," ",""]
-
-### Semantic vector chunker (process_options=V) settings
-###     CHUNK_V_SIZE: per-strategy chunk_token_size hard cap (oversized pieces are
-###       re-split via R before being emitted); falls back to CHUNK_SIZE when unset
-###     CHUNK_V_BREAKPOINT_THRESHOLD_TYPE: percentile | standard_deviation | interquartile | gradient
-###     CHUNK_V_BREAKPOINT_THRESHOLD_AMOUNT: leave empty to use the LangChain per-type default (e.g. 95 for percentile)
-###     CHUNK_V_BUFFER_SIZE: number of adjacent sentences combined when computing distances
-###     CHUNK_V_SENTENCE_SPLIT_REGEX: regex fed to LangChain SemanticChunker for the
-###       initial sentence split.  Default extends the upstream English-only pattern
-###       with CJK sentence-end punctuation (。？！).  Override if you need a
-###       different language mix.  Note: env value is the raw regex string, no JSON
-###       quoting.
-# CHUNK_V_SIZE=1200
-# CHUNK_V_BREAKPOINT_THRESHOLD_TYPE=percentile
-# CHUNK_V_BREAKPOINT_THRESHOLD_AMOUNT=
-# CHUNK_V_BUFFER_SIZE=1
-# CHUNK_V_SENTENCE_SPLIT_REGEX=(?<=[.?!])\s+|(?<=[。？！])
-
-### Paragraph semantic chunker (process_options=P) settings
-###     CHUNK_P_SIZE: per-strategy chunk_token_size override; defaults to 2000 when unset
-###       (does NOT fall back to CHUNK_SIZE — paragraph-semantic merging needs more
-###       headroom than the global default to keep related paragraphs together).
-###     CHUNK_P_OVERLAP_SIZE: overlap for prose fallback and table-bridge context; 
-###                           falls back to CHUNK_OVERLAP_SIZE when unset
-# CHUNK_P_SIZE=2000
-# CHUNK_P_OVERLAP_SIZE=100
+### Optional external YAML profile for entity type guidance and extraction examples
+### Profiles are loaded from PROMPT_DIR/entity_type (PROMPT_DIR defaults to ./prompts).
+### A reference template is shipped at prompts/samples/entity_type_prompt.sample.yml;
+# ENTITY_TYPE_PROMPT_FILE=entity_type_prompt.yml
+# PROMPT_DIR=<absolute_path_for_prompt_dir>
 
 ### Multimodal parsing/analyze integration
 ### Optional parser routing rules. Example for VLM & MinerU enabled configuration:
@@ -336,16 +283,8 @@ MINERU_LOCAL_IMAGE_ANALYSIS=true
 # MINERU_MODEL_VERSION=vlm
 # MINERU_IS_OCR=false
 
-### MinerU raw bundle handling (introduced with unified sidecar pipeline).
-### - MINERU_IMAGE_URL_TEMPLATE: optional fallback for content_list image refs
-###     that are not present in the downloaded zip. Supports {name} and {path}.
-### - MINERU_ENGINE_VERSION: recorded in <base>.mineru_raw/_manifest.json.
-###     Mismatch with the recorded value forces a cache miss → re-download.
-###     Leave empty to skip this check.
-### - LIGHTRAG_FORCE_REPARSE_MINERU: when truthy ("1"/"true"), bypass the
-###     mineru raw cache and re-upload on every parse_mineru call.
-# MINERU_IMAGE_URL_TEMPLATE=
-# MINERU_ENGINE_VERSION=
+### Force re-upload of file to MinerU on every retry after failure
+### Disables caching of result outcomes
 # LIGHTRAG_FORCE_REPARSE_MINERU=false
 
 ### Docling parser (docling-serve v1 / async API).
@@ -400,9 +339,71 @@ DOCLING_DO_FORMULA_ENRICHMENT=false
 # DOCLING_OCR_LANG=
 # DOCLING_POLL_INTERVAL_SECONDS=5
 # DOCLING_MAX_POLLS=240
-# DOCLING_ENGINE_VERSION=
-# LIGHTRAG_FORCE_REPARSE_DOCLING=false
 # DOCLING_BBOX_ATTRIBUTES={"origin":"LEFTBOTTOM"}
+### Force re-upload of file to Docling on every retry after failure
+### Disables caching of result outcomes
+# LIGHTRAG_FORCE_REPARSE_DOCLING=false
+
+### File upload size limit (in bytes)
+### Default: 104857600 (100MB)
+### Set to 0 or None for unlimited upload size
+### Examples:
+###   52428800  = 50MB
+###   104857600 = 100MB (default)
+###   209715200 = 200MB
+### Note: If using Nginx as reverse proxy, also configure client_max_body_size
+# MAX_UPLOAD_SIZE=104857600
+
+### Chunk size for document splitting, 500~1500 is recommended
+# CHUNK_SIZE=1200
+# CHUNK_OVERLAP_SIZE=100
+
+### Fixed-token chunker (process_options=F, default) settings
+###     CHUNK_F_OVERLAP_SIZE: token overlap; falls back to CHUNK_OVERLAP_SIZE when unset
+###     CHUNK_F_SPLIT_BY_CHARACTER: optional separator string; pre-segment before token windowing
+###     CHUNK_F_SPLIT_BY_CHARACTER_ONLY: when true, raise on oversize segment instead of token re-split
+# CHUNK_F_OVERLAP_SIZE=100
+# CHUNK_F_SPLIT_BY_CHARACTER=
+# CHUNK_F_SPLIT_BY_CHARACTER_ONLY=false
+
+### Recursive character chunker (process_options=R) settings
+###     CHUNK_R_SIZE: per-strategy chunk_token_size override; falls back to CHUNK_SIZE when unset
+###     CHUNK_R_OVERLAP_SIZE: token overlap between adjacent chunks; falls back to CHUNK_OVERLAP_SIZE when unset
+###     CHUNK_R_SEPARATORS: JSON array of cascaded separators tried by RecursiveCharacterTextSplitter.
+###       Default includes CJK sentence-ending punctuation so Chinese / mixed-language
+###       documents split at semantic boundaries.  Order: paragraph (\n\n) > line (\n) >
+###       Chinese sentence-end (。！？) > Chinese semi-clause (；，) > space > char.
+###       English ".?!" are intentionally omitted (literal match would split "0.95" /
+###       "e.g."); the English path falls through space / char as before.
+# CHUNK_R_SIZE=1200
+# CHUNK_R_OVERLAP_SIZE=100
+# CHUNK_R_SEPARATORS=["\n\n","\n","。","！","？","；","，"," ",""]
+
+### Semantic vector chunker (process_options=V) settings
+###     CHUNK_V_SIZE: per-strategy chunk_token_size hard cap (oversized pieces are
+###       re-split via R before being emitted); falls back to CHUNK_SIZE when unset
+###     CHUNK_V_BREAKPOINT_THRESHOLD_TYPE: percentile | standard_deviation | interquartile | gradient
+###     CHUNK_V_BREAKPOINT_THRESHOLD_AMOUNT: leave empty to use the LangChain per-type default (e.g. 95 for percentile)
+###     CHUNK_V_BUFFER_SIZE: number of adjacent sentences combined when computing distances
+###     CHUNK_V_SENTENCE_SPLIT_REGEX: regex fed to LangChain SemanticChunker for the
+###       initial sentence split.  Default extends the upstream English-only pattern
+###       with CJK sentence-end punctuation (。？！).  Override if you need a
+###       different language mix.  Note: env value is the raw regex string, no JSON
+###       quoting.
+# CHUNK_V_SIZE=1200
+# CHUNK_V_BREAKPOINT_THRESHOLD_TYPE=percentile
+# CHUNK_V_BREAKPOINT_THRESHOLD_AMOUNT=
+# CHUNK_V_BUFFER_SIZE=1
+# CHUNK_V_SENTENCE_SPLIT_REGEX=(?<=[.?!])\s+|(?<=[。？！])
+
+### Paragraph semantic chunker (process_options=P) settings
+###     CHUNK_P_SIZE: per-strategy chunk_token_size override; defaults to 2000 when unset
+###       (does NOT fall back to CHUNK_SIZE — paragraph-semantic merging needs more
+###       headroom than the global default to keep related paragraphs together).
+###     CHUNK_P_OVERLAP_SIZE: overlap for prose fallback and table-bridge context; 
+###                           falls back to CHUNK_OVERLAP_SIZE when unset
+# CHUNK_P_SIZE=2000
+# CHUNK_P_OVERLAP_SIZE=100
 
 ### Number of summary segments or tokens to trigger LLM summary on entity/relation merge (at least 3 is recommended)
 # FORCE_LLM_SUMMARY_ON_MERGE=8
@@ -427,17 +428,6 @@ DOCLING_DO_FORMULA_ENRICHMENT=false
 ### Per-response cap on entity rows/objects emitted by the LLM
 # MAX_EXTRACTION_ENTITIES=40
 
-### Enable JSON-structured output for entity extraction (Note: JSON output incurs higher latency but delivers improved reliability)
-### Default behavior: JSON output is disabled when ENTITY_EXTRACTION_USE_JSON is unset
-ENTITY_EXTRACTION_USE_JSON=true
-
-### Optional external YAML profile for entity type guidance and extraction examples
-### Profiles are loaded from PROMPT_DIR/entity_type (PROMPT_DIR defaults to ./prompts).
-### A reference template is shipped at prompts/samples/entity_type_prompt.sample.yml;
-### Alternatively, override guidance at runtime from Python:
-###   addon_params={"entity_types_guidance": "- CustomType: description..."}
-# ENTITY_TYPE_PROMPT_FILE=entity_type_prompt.yml
-
 ### control the maximum chunk_ids stored in vector and graph db
 # MAX_SOURCE_IDS_PER_ENTITY=300
 # MAX_SOURCE_IDS_PER_RELATION=300
@@ -446,11 +436,16 @@ ENTITY_EXTRACTION_USE_JSON=true
 ###    KEEP: Keep oldest (less merge action and faster)
 # SOURCE_IDS_LIMIT_METHOD=FIFO
 
-# Maximum number of file paths stored in entity/relation file_path field (For displayed only, does not affect query performance)
+### Maximum number of file paths stored in entity/relation file_path field 
+### For displayed only, does not affect query performance
 # MAX_FILE_PATHS=100
 
 ### PDF decryption password for protected PDF files
 # PDF_DECRYPT_PASSWORD=your_pdf_password_here
+
+### LLM cache for entity/relation extract is enable by default
+### Disabling it will prevent graph reconstruction after document deletion
+# ENABLE_LLM_CACHE_FOR_EXTRACT=true
 
 ###############################
 ### Concurrency Configuration

--- a/env.example
+++ b/env.example
@@ -644,7 +644,7 @@ EMBEDDING_MODEL=text-embedding-3-large
 EMBEDDING_DIM=3072
 EMBEDDING_TOKEN_LIMIT=8192
 EMBEDDING_SEND_DIM=false
-# EMBEDDING_USE_BASE64=true
+EMBEDDING_USE_BASE64=true
 
 ### Optional for Azure Embedding
 ### Use deployment name as model name or set AZURE_EMBEDDING_DEPLOYMENT instead

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -569,9 +569,7 @@ class _PipelineMixin:
                     )
                 except Exception as exc:
                     error_msg = f"load_lightrag_document_content failed: {exc}"
-                    logger.warning(
-                        f"[apipeline_enqueue] {error_msg} ({raw_path})"
-                    )
+                    logger.warning(f"[apipeline_enqueue] {error_msg} ({raw_path})")
                     file_size = 0
                     blocks_path_str = sidecar_blocks_path(sidecar_location)
                     if blocks_path_str:

--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -1745,17 +1745,6 @@ clear_bedrock_credentials() {
   unset 'ENV_VALUES[AWS_REGION]'
 }
 
-bedrock_binding_in_use() {
-  [[ "${ENV_VALUES[LLM_BINDING]:-}" == "bedrock" ||
-    "${ENV_VALUES[EMBEDDING_BINDING]:-}" == "bedrock" ]]
-}
-
-clear_bedrock_credentials_if_unused() {
-  if ! bedrock_binding_in_use; then
-    clear_bedrock_credentials
-  fi
-}
-
 collect_bedrock_credentials() {
   local access_key secret_key session_token region
 
@@ -1939,7 +1928,6 @@ collect_llm_config() {
   ENV_VALUES["LLM_MODEL"]="$model"
   ENV_VALUES["LLM_BINDING_HOST"]="$host"
   store_optional_env_value "LLM_BINDING_API_KEY" "$api_key"
-  clear_bedrock_credentials_if_unused
 }
 
 collect_embedding_config() {
@@ -2009,7 +1997,6 @@ collect_embedding_config() {
   ENV_VALUES["EMBEDDING_DIM"]="$dim"
   ENV_VALUES["EMBEDDING_BINDING_HOST"]="$host"
   store_optional_env_value "EMBEDDING_BINDING_API_KEY" "$api_key"
-  clear_bedrock_credentials_if_unused
   # User chose a remote provider — clear the Docker deployment marker.
   unset 'ENV_VALUES[LIGHTRAG_SETUP_EMBEDDING_PROVIDER]'
 }

--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -1928,6 +1928,15 @@ collect_llm_config() {
   ENV_VALUES["LLM_MODEL"]="$model"
   ENV_VALUES["LLM_BINDING_HOST"]="$host"
   store_optional_env_value "LLM_BINDING_API_KEY" "$api_key"
+
+  # Role-specific LLM models — default to the base LLM_MODEL when unset in .env.
+  local keyword_default query_default keyword_model query_model
+  keyword_default="${ENV_VALUES[KEYWORD_LLM_MODEL]:-$model}"
+  query_default="${ENV_VALUES[QUERY_LLM_MODEL]:-$model}"
+  keyword_model="$(prompt_with_default "Keyword LLM model" "$keyword_default")"
+  query_model="$(prompt_with_default "Query LLM model" "$query_default")"
+  ENV_VALUES["KEYWORD_LLM_MODEL"]="$keyword_model"
+  ENV_VALUES["QUERY_LLM_MODEL"]="$query_model"
 }
 
 collect_embedding_config() {

--- a/tests/test_interactive_setup/test_collect.py
+++ b/tests/test_interactive_setup/test_collect.py
@@ -839,6 +839,70 @@ printf 'AWS_REGION_SET=%s\\n' "${{ENV_VALUES[AWS_REGION]+set}}\"
     assert values["AWS_REGION_SET"] == ""
 
 
+def test_collect_llm_config_role_models_default_to_base_model_when_unset() -> None:
+    """KEYWORD/QUERY_LLM_MODEL must default to the freshly-chosen LLM_MODEL when absent."""
+    output = run_bash(f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+reset_state
+
+prompt_choice() {{ printf 'openai'; }}
+prompt_with_default() {{
+  case "$1" in
+    "LLM model") printf 'gpt-4o' ;;
+    *) printf '%s' "$2" ;;
+  esac
+}}
+prompt_secret_until_valid_with_default() {{ printf 'fake-key'; }}
+
+collect_llm_config
+
+printf 'LLM_MODEL=%s\\n' "${{ENV_VALUES[LLM_MODEL]}}"
+printf 'KEYWORD_LLM_MODEL=%s\\n' "${{ENV_VALUES[KEYWORD_LLM_MODEL]}}"
+printf 'QUERY_LLM_MODEL=%s\\n' "${{ENV_VALUES[QUERY_LLM_MODEL]}}\"
+""")
+    values = parse_lines(output)
+    assert values["LLM_MODEL"] == "gpt-4o"
+    assert values["KEYWORD_LLM_MODEL"] == "gpt-4o"
+    assert values["QUERY_LLM_MODEL"] == "gpt-4o"
+
+
+def test_collect_llm_config_role_models_reuse_existing_values(tmp_path: Path) -> None:
+    """KEYWORD/QUERY_LLM_MODEL values already in .env survive a base wizard rerun."""
+    write_text_lines(
+        tmp_path / ".env",
+        [
+            "LLM_BINDING=openai",
+            "LLM_MODEL=gpt-4o",
+            "LLM_BINDING_HOST=https://api.openai.com/v1",
+            "LLM_BINDING_API_KEY=existing-key",
+            "KEYWORD_LLM_MODEL=custom-keyword-model",
+            "QUERY_LLM_MODEL=custom-query-model",
+        ],
+    )
+    output = run_bash(f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+reset_state
+load_existing_env_if_present
+
+prompt_choice() {{ printf 'openai'; }}
+prompt_with_default() {{ printf '%s' "$2"; }}
+prompt_secret_until_valid_with_default() {{ printf '%s' "$2"; }}
+
+collect_llm_config
+
+printf 'LLM_MODEL=%s\\n' "${{ENV_VALUES[LLM_MODEL]}}"
+printf 'KEYWORD_LLM_MODEL=%s\\n' "${{ENV_VALUES[KEYWORD_LLM_MODEL]}}"
+printf 'QUERY_LLM_MODEL=%s\\n' "${{ENV_VALUES[QUERY_LLM_MODEL]}}\"
+""")
+    values = parse_lines(output)
+    assert values["LLM_MODEL"] == "gpt-4o"
+    assert values["KEYWORD_LLM_MODEL"] == "custom-keyword-model"
+    assert values["QUERY_LLM_MODEL"] == "custom-query-model"
+
+
 def test_collect_rerank_config_preserves_api_key_when_disabled(tmp_path: Path) -> None:
     """Disabling reranking should preserve credentials so they survive re-enable."""
     write_text_lines(

--- a/tests/test_interactive_setup/test_misc.py
+++ b/tests/test_interactive_setup/test_misc.py
@@ -257,10 +257,17 @@ printf 'COMPOSE=%s\\n' "$(find_generated_compose_file)\"
     assert values["COMPOSE"] == str(tmp_path / "docker-compose.development.yml")
 
 
-def test_switching_both_providers_off_bedrock_clears_saved_aws_credentials(
+def test_switching_both_providers_off_bedrock_preserves_saved_aws_credentials(
     tmp_path: Path,
 ) -> None:
-    """Reruns should not keep stale AWS Bedrock secrets in regenerated `.env` files."""
+    """Switching LLM/Embedding away from Bedrock must preserve user-set AWS_* values.
+
+    AWS credentials are process-level SDK settings and may be used by code paths
+    outside the active LLM/embedding binding (S3, SecretsManager, etc.), so the
+    wizard must not erase them just because the active binding is no longer
+    ``bedrock``. Only the explicit ``collect_bedrock_credentials`` ambient branch
+    is allowed to clear them.
+    """
     write_text_lines(
         tmp_path / ".env",
         [
@@ -310,25 +317,23 @@ collect_llm_config
 collect_embedding_config
 generate_env_file "$REPO_ROOT/env.example" "$REPO_ROOT/.env.generated"
 
-printf 'AWS_ACCESS_KEY_ID_SET=%s\\n' "${{ENV_VALUES[AWS_ACCESS_KEY_ID]+set}}"
-printf 'AWS_SECRET_ACCESS_KEY_SET=%s\\n' "${{ENV_VALUES[AWS_SECRET_ACCESS_KEY]+set}}"
-printf 'AWS_SESSION_TOKEN_SET=%s\\n' "${{ENV_VALUES[AWS_SESSION_TOKEN]+set}}"
-printf 'AWS_REGION_SET=%s\\n' "${{ENV_VALUES[AWS_REGION]+set}}\"
+printf 'AWS_ACCESS_KEY_ID=%s\\n' "${{ENV_VALUES[AWS_ACCESS_KEY_ID]-}}"
+printf 'AWS_SECRET_ACCESS_KEY=%s\\n' "${{ENV_VALUES[AWS_SECRET_ACCESS_KEY]-}}"
+printf 'AWS_SESSION_TOKEN=%s\\n' "${{ENV_VALUES[AWS_SESSION_TOKEN]-}}"
+printf 'AWS_REGION=%s\\n' "${{ENV_VALUES[AWS_REGION]-}}"
 """)
     values = parse_lines(output)
     generated_lines = (
         (tmp_path / ".env.generated").read_text(encoding="utf-8").splitlines()
     )
-    assert values["AWS_ACCESS_KEY_ID_SET"] == ""
-    assert values["AWS_SECRET_ACCESS_KEY_SET"] == ""
-    assert values["AWS_SESSION_TOKEN_SET"] == ""
-    assert values["AWS_REGION_SET"] == ""
-    assert not any(line.startswith("AWS_ACCESS_KEY_ID=") for line in generated_lines)
-    assert not any(
-        line.startswith("AWS_SECRET_ACCESS_KEY=") for line in generated_lines
-    )
-    assert not any(line.startswith("AWS_SESSION_TOKEN=") for line in generated_lines)
-    assert not any(line.startswith("AWS_REGION=") for line in generated_lines)
+    assert values["AWS_ACCESS_KEY_ID"] == "AKIAOLDKEY"
+    assert values["AWS_SECRET_ACCESS_KEY"] == "oldsecretvalue"
+    assert values["AWS_SESSION_TOKEN"] == "oldsess"
+    assert values["AWS_REGION"] == "us-east-1"
+    assert "AWS_ACCESS_KEY_ID=AKIAOLDKEY" in generated_lines
+    assert "AWS_SECRET_ACCESS_KEY=oldsecretvalue" in generated_lines
+    assert "AWS_SESSION_TOKEN=oldsess" in generated_lines
+    assert "AWS_REGION=us-east-1" in generated_lines
 
 
 def test_load_existing_env_forces_cohere_binding_for_vllm_rerank(


### PR DESCRIPTION
## Summary

- **`make env-base` adds role-specific LLM prompts** (`KEYWORD_LLM_MODEL`, `QUERY_LLM_MODEL`). Each defaults to the freshly-chosen base `LLM_MODEL` when the `.env` doesn't yet have a value, and reuses the existing value on rerun.
- **Bedrock auth documentation in `env.example` now describes all three modes** (bearer token / SigV4 / ambient credential chain) and spells out which lines must stay commented for the AWS SDK to walk the default credential chain.
- **Removes the unused `clear_bedrock_credentials_if_unused` / `bedrock_binding_in_use` helpers** in `scripts/setup/setup.sh`. These were the root cause of `make env-base` erasing user-set `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` whenever the active binding wasn't Bedrock. AWS credentials are process-level SDK settings unrelated to `LLM_BINDING`; the explicit ambient branch in `collect_bedrock_credentials` is the only legitimate place to clear them, and it remains.
- **`env.example` cleanups** carried in from the same branch: consolidate chunking/entity-extraction sections, drop deprecated MinerU raw-bundle options, relocate the LLM-cache setting near document processing, and enable `EMBEDDING_USE_BASE64` by default to match current embedding requirements.

## Motivation

A real-world report: a user added explicit AWS SigV4 credentials to `.env` for use outside Bedrock (S3 / SecretsManager), and running `make env-base` with an OpenAI binding silently wiped them. Investigation traced it to the special-case `clear_bedrock_credentials_if_unused` path, which short-circuited the wizard's normal "preserve activated KEYs via `load_env_file`" contract for these four keys only. Removing the special case restores parity with every other commented-placeholder KEY in `env.example`.

Separately, the wizard previously had no way to set `KEYWORD_LLM_MODEL` / `QUERY_LLM_MODEL`, so users had to edit `.env` by hand. Falling back to the base `LLM_MODEL` keeps the first-run experience smooth while still letting power users override per role.

## What's changed

- `scripts/setup/setup.sh`
  - `collect_llm_config` now prompts for `KEYWORD_LLM_MODEL` and `QUERY_LLM_MODEL` after the base model is captured; default = existing value or just-chosen `LLM_MODEL`.
  - Removes `bedrock_binding_in_use()` and `clear_bedrock_credentials_if_unused()` and their two call sites at the end of `collect_llm_config` / `collect_embedding_config`. `clear_bedrock_credentials()` itself is kept; the ambient branch in `collect_bedrock_credentials` still uses it.
- `env.example`
  - LLM Bedrock block (around L568) and Embedding Bedrock block (around L687): "two approaches" → "three approaches"; new "Ambient credentials (AWS SDK default credential chain)" paragraph; region note updated to "all three modes".
  - Reorganized chunking / entity-extraction / LLM-cache sections (carried-in commits).
  - `EMBEDDING_USE_BASE64` now active by default.
- `tests/test_interactive_setup/test_collect.py`
  - Adds `test_collect_llm_config_role_models_default_to_base_model_when_unset` and `test_collect_llm_config_role_models_reuse_existing_values`.
- `tests/test_interactive_setup/test_misc.py`
  - The previous `test_switching_both_providers_off_bedrock_clears_saved_aws_credentials` encoded the now-removed misbehavior. It is replaced by `test_switching_both_providers_off_bedrock_preserves_saved_aws_credentials`, which asserts the four `AWS_*` values survive a non-Bedrock rerun and are correctly activated in the regenerated `.env`.

## What's broken and how it works

No external API or behavior contract is broken. The only intentionally incompatible change is the wizard contract: `make env-base/env-storage/env-server` no longer erase `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` / `AWS_REGION` based on the active LLM/Embedding binding. Users who relied on that auto-purge (none should, since it conflicted with the wizard's stated "non-LLM settings are preserved" guarantee) can still trigger the same cleanup by explicitly picking the Bedrock ambient credential branch inside `collect_bedrock_credentials`.

## Test plan

- [x] `uv run pytest tests/test_interactive_setup -q` — 256 passed
- [x] `bash -n scripts/setup/setup.sh` — syntax clean
- [ ] Manual sanity: prepare `.env` with explicit `AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_REGION`, run `make env-base` selecting `openai` for both LLM and Embedding, confirm the three AWS lines remain activated with their original values in the regenerated `.env`.
- [ ] Manual sanity: rerun `make env-base` selecting `bedrock` for LLM, choose "Reuse existing AWS Bedrock credentials"; confirm reuse path picks up the preserved values.
- [ ] Manual sanity: fresh `.env`, run `make env-base` choosing `openai` + `gpt-4o`; confirm `KEYWORD_LLM_MODEL` and `QUERY_LLM_MODEL` prompts both default to `gpt-4o` and are written to `.env`.