### PR TITLE
feat(pipeline): surface parse/analyze progress to pipeline_status

### DIFF
--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1486,6 +1486,10 @@ class _PipelineMixin:
                     status_doc=status_doc_w,
                     file_path=file_path_w,
                 )
+                async with ctx.pipeline_status_lock:
+                    log_message = f"Parsing ({engine}): {file_path_w}"
+                    ctx.pipeline_status["latest_message"] = log_message
+                    ctx.pipeline_status["history_messages"].append(log_message)
                 if engine == "mineru":
                     parsed_data_w = await self.parse_mineru(
                         doc_id_w, file_path_w, content_data_w
@@ -1592,6 +1596,8 @@ class _PipelineMixin:
                     doc_id=doc_id_w,
                     file_path=file_path_w,
                     parsed_data=parsed_data_w,
+                    pipeline_status=ctx.pipeline_status,
+                    pipeline_status_lock=ctx.pipeline_status_lock,
                 )
                 await ctx.q_process.put((doc_id_w, status_doc_w, analyzed))
             except Exception as e:
@@ -3486,6 +3492,8 @@ class _PipelineMixin:
         parsed_data: dict[str, Any],
         *,
         process_options: str | None = None,
+        pipeline_status: dict | None = None,
+        pipeline_status_lock: Any | None = None,
     ) -> dict[str, Any]:
         """Phase 2: Multimodal analysis (VLM). Writes llm_analyze_result to LightRAG Document.
 
@@ -4150,6 +4158,7 @@ class _PipelineMixin:
                     process_opts.equations,
                 ),
             ]
+            start_logged = False
             for sidecar_path, root_key, kind, enabled in sidecars:
                 if not enabled or not sidecar_path.exists():
                     continue
@@ -4162,6 +4171,18 @@ class _PipelineMixin:
                 items = payload.get(root_key, {})
                 if not isinstance(items, dict):
                     continue
+
+                if (
+                    items
+                    and not start_logged
+                    and pipeline_status is not None
+                    and pipeline_status_lock is not None
+                ):
+                    async with pipeline_status_lock:
+                        log_message = f"Analyzing multimodal: {file_path}"
+                        pipeline_status["latest_message"] = log_message
+                        pipeline_status["history_messages"].append(log_message)
+                    start_logged = True
 
                 valid_keys: list[str] = []
                 analyze_tasks: list[Any] = []
@@ -4188,21 +4209,32 @@ class _PipelineMixin:
                     outcome = analyzed[idx]
                     if isinstance(outcome, MultimodalAnalysisError):
                         item["llm_analyze_result"] = _failure_result(str(outcome))
+                        item_status = "failed"
                         if failure_to_raise is None:
                             failure_to_raise = outcome
-                        continue
-                    if isinstance(outcome, Exception):
+                    elif isinstance(outcome, Exception):
                         item["llm_analyze_result"] = _failure_result(
                             f"unexpected error: {outcome}"
                         )
+                        item_status = "failed"
                         if failure_to_raise is None:
                             failure_to_raise = MultimodalAnalysisError(
                                 f"{root_key}/{item_id}: unexpected error: {outcome}"
                             )
-                        continue
-                    result_obj, cache_id = outcome
-                    item["llm_analyze_result"] = result_obj
-                    _attach_cache_id(item, cache_id)
+                    else:
+                        result_obj, cache_id = outcome
+                        item["llm_analyze_result"] = result_obj
+                        _attach_cache_id(item, cache_id)
+                        item_status = (
+                            "ok" if result_obj.get("status") == "success" else "skipped"
+                        )
+                    if pipeline_status is not None and pipeline_status_lock is not None:
+                        async with pipeline_status_lock:
+                            log_message = (
+                                f"  {kind}/{item_id} {item_status}: {file_path}"
+                            )
+                            pipeline_status["latest_message"] = log_message
+                            pipeline_status["history_messages"].append(log_message)
                 try:
                     sidecar_path.write_text(
                         json.dumps(payload, ensure_ascii=False, indent=2),

--- a/tests/test_pipeline_release_closure.py
+++ b/tests/test_pipeline_release_closure.py
@@ -1996,7 +1996,7 @@ def test_three_phase_status_flow(tmp_path, monkeypatch):
                 "blocks_path": "",
             }
 
-        async def _fake_analyze(doc_id, file_path, parsed_data):
+        async def _fake_analyze(doc_id, file_path, parsed_data, **kwargs):
             parsed_data["multimodal_processed"] = True
             return parsed_data
 


### PR DESCRIPTION
## Summary

Adds `pipeline_status["latest_message"]` / `history_messages` updates for the parse and multimodal-analyze workers so frontends polling `/documents/pipeline_status` can observe progress during the long-running pre-extract phases.

## Motivation

`process_single_document` already writes verbose progress to `pipeline_status` (Extracting / Processing d-id / Completed processing …), but the upstream `_parse_worker` (Layer 1) and `_analyze_worker` → `analyze_multimodal` (Layer 2) were completely silent. A document might spend tens of seconds to several minutes parsing or in VLM calls with no UI feedback whatsoever; users have no way to tell whether the pipeline is stuck or making progress.

## What's changed

Three new pipeline_status messages, each capped near ~100 chars:

| Stage | Format | Example |
|---|---|---|
| Parser startup | `Parsing ({engine}): {file_path}` | `Parsing (mineru): paper-2024.pdf` |
| Multimodal startup | `Analyzing multimodal: {file_path}` | `Analyzing multimodal: paper-2024.pdf` |
| Per-item completion | `  {kind}/{item_id} {status}: {file_path}` | `  drawing/img_3 ok: paper-2024.pdf` |

- `_parse_worker`: logs after the `PARSING` status transition is committed (avoids leaving "started" traces if the upsert itself fails).
- `analyze_multimodal`: gains optional `pipeline_status` / `pipeline_status_lock` kwargs (defaults `None`); the startup message fires at most once per document, gated on at least one enabled sidecar containing real items, so documents without `i` / `t` / `e` opt-in or with empty sidecars stay clean. Per-item logging covers all three outcomes — `ok` (success), `skipped` (size/format guards), `failed` (`MultimodalAnalysisError` or unexpected exception) — without changing the existing `failure_to_raise` deferred-raise semantics.
- `_analyze_worker`: passes `ctx.pipeline_status` / `ctx.pipeline_status_lock` through to `analyze_multimodal`.

## What's broken / migration

- **Source-compatible**: `analyze_multimodal`'s new kwargs default to `None`. Direct callers in tests and CLI (~15 sites under `tests/`) keep working unchanged; logging is no-op when either kwarg is absent.
- **One test mock updated**: `tests/test_pipeline_release_closure.py::test_three_phase_status_flow`'s `_fake_analyze` monkeypatch now accepts `**kwargs` to absorb the new optional arguments.

## How it works

- All three log sites grab `pipeline_status_lock` per write, mirroring the existing pattern in `process_single_document`. The lock is asyncio-only and uncontended outside the pipeline, so per-item acquisitions add no measurable overhead even on documents with many drawings.
- `start_logged` flag inside `analyze_multimodal` ensures the "Analyzing multimodal" line appears exactly once per document regardless of how many modality sidecars get processed.
- The per-item `item_status` derivation reads `result_obj["status"]` (already populated by `_skipped_result` / success path) and maps `success → ok`, anything else → `skipped`; `MultimodalAnalysisError` and other exceptions map to `failed`.

## Test plan

- [x] `pytest tests/test_pipeline_analyze_multimodal.py` — 15 passed
- [x] `pytest tests/test_parse_native_lightrag_e2e.py` — 5 passed
- [x] `pytest tests/ -k "pipeline or parse_worker or analyze"` — 110 passed, 1 skipped, 0 failed
- [x] `ruff check lightrag/pipeline.py` — clean
- [ ] Manual: upload a PDF with images via the UI, observe `pipeline_status` progresses through `Parsing` → `Analyzing multimodal` → per-item lines → `Extracting stage …`

🤖 Generated with [Claude Code](https://claude.com/claude-code)