### PR TITLE
feat(docx-parser): drop revision/comment markers and skip empty tables

### DIFF
--- a/lightrag/parser/docx/parse_document.py
+++ b/lightrag/parser/docx/parse_document.py
@@ -47,6 +47,15 @@ TABLE_MIN_LAST_CHUNK_TOKENS = int(
 )  # Minimum size for last chunk to avoid tiny fragments
 TABLE_CHUNK_SUFFIX_LABEL = "表格片段"  # Label prefix for split table chunk headings
 
+# OOXML tracked-change/comment tags whose subtree must be dropped so we only
+# surface the *final* revised text. w:ins / w:moveTo are kept via default
+# recursion so inserted/moved-in content survives.
+_SKIP_REVISION_TAGS = frozenset({"del", "moveFrom"})
+_SKIP_COMMENT_TAGS = frozenset(
+    {"commentRangeStart", "commentRangeEnd", "commentReference", "annotationRef"}
+)
+_SKIP_PARAGRAPH_TAGS = _SKIP_REVISION_TAGS | _SKIP_COMMENT_TAGS
+
 
 def print_error(title: str, details: str, solution: str):
     """
@@ -1360,9 +1369,10 @@ def extract_paragraph_content(
 
     def append_from(node) -> None:
         tag = node.tag.split("}")[-1]
-        # Skip deleted content (w:del) and moved-from content (w:moveFrom) in tracked changes
-        # to maintain consistency with w:delText handling
-        if tag in ("del", "moveFrom"):
+        # Drop tracked-change deletions (w:del/w:moveFrom) and comment markers
+        # (w:commentRangeStart/End, w:commentReference, w:annotationRef) so the
+        # output only contains the final revised text without annotation glyphs.
+        if tag in _SKIP_PARAGRAPH_TAGS:
             return
         if tag == "r":
             parts.append(
@@ -1392,6 +1402,11 @@ def extract_paragraph_content(
         append_from(child)
 
     return "".join(parts)
+
+
+def _is_table_empty(rows: list) -> bool:
+    """Return True iff every cell in ``rows`` is whitespace-only."""
+    return all(not (cell or "").strip() for row in rows for cell in row)
 
 
 def _collect_table_headers(paragraphs: list) -> list:
@@ -1700,6 +1715,13 @@ def extract_docx_blocks(
             para_ids = table_metadata["para_ids"]
             para_ids_end = table_metadata["para_ids_end"]  # Last paraId in each cell
             header_indices = table_metadata["header_indices"]
+
+            # Skip tables whose every cell is whitespace-only — otherwise an
+            # empty `<table>[[""]]</table>` placeholder would leak into block
+            # content and a useless IRTable would appear in tables.json.
+            if _is_table_empty(table_rows):
+                resolver.reset_tracking_state()
+                continue
 
             # Count tables whose cells carry no w14:paraId. Legacy / non-Word
             # docx authors omit these attributes; we no longer fail-fast, but

--- a/lightrag/parser/docx/table_extractor.py
+++ b/lightrag/parser/docx/table_extractor.py
@@ -16,6 +16,19 @@ from .drawing_image_extractor import (
     extract_vml_image_placeholder_from_element,
 )
 
+# Keep in sync with parse_document._SKIP_PARAGRAPH_TAGS — duplicated here to
+# avoid a circular import between parse_document and table_extractor.
+_SKIP_PARAGRAPH_TAGS = frozenset(
+    {
+        "del",
+        "moveFrom",
+        "commentRangeStart",
+        "commentRangeEnd",
+        "commentReference",
+        "annotationRef",
+    }
+)
+
 
 def extract_text_from_run_table(
     run_elem,
@@ -105,9 +118,10 @@ def extract_paragraph_content_table(
 
     def append_from(node) -> None:
         tag = node.tag.split("}")[-1]
-        # Skip deleted content (w:del) and moved-from content (w:moveFrom) in tracked changes
-        # to maintain consistency with w:delText handling
-        if tag in ("del", "moveFrom"):
+        # Drop tracked-change deletions (w:del/w:moveFrom) and comment markers
+        # (w:commentRangeStart/End, w:commentReference, w:annotationRef) so the
+        # output only contains the final revised text without annotation glyphs.
+        if tag in _SKIP_PARAGRAPH_TAGS:
             return
         if tag == "r":
             parts.append(

--- a/tests/parser/docx/test_native_docx_extract.py
+++ b/tests/parser/docx/test_native_docx_extract.py
@@ -1,0 +1,157 @@
+"""Unit tests for native docx tracked-change / comment / empty-table handling.
+
+Locks in the contract that:
+- ``w:ins`` content survives (final revised text),
+- ``w:del`` / ``w:moveFrom`` content is dropped,
+- ``w:commentRangeStart`` / ``w:commentRangeEnd`` / ``w:commentReference`` /
+  ``w:annotationRef`` markers are dropped,
+- tables whose every cell is whitespace-only are omitted from the parser
+  output (no ``<table>`` placeholder, so no IRTable downstream).
+
+These were previously emergent properties (skip lists in two places + a
+run-level white-list); regressions now fail loudly.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+import pytest
+from docx import Document
+from docx.oxml.ns import qn
+from lxml import etree
+
+from lightrag.parser.docx.parse_document import (
+    extract_docx_blocks,
+    extract_paragraph_content,
+)
+from lightrag.parser.docx.table_extractor import extract_paragraph_content_table
+
+W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+PARAGRAPH_NS = {
+    "w": W_NS,
+    "wp": "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing",
+    "m": "http://schemas.openxmlformats.org/officeDocument/2006/math",
+}
+
+
+def _p(inner_xml: str):
+    """Build a ``<w:p>`` lxml element from inner OOXML."""
+    return etree.fromstring(f'<w:p xmlns:w="{W_NS}">{inner_xml}</w:p>'.encode("utf-8"))
+
+
+# --- paragraph walker (parse_document.extract_paragraph_content) -----------
+
+
+@pytest.mark.offline
+def test_paragraph_keeps_w_ins_content() -> None:
+    para = _p("<w:ins><w:r><w:t>kept</w:t></w:r></w:ins>")
+
+    assert extract_paragraph_content(para, PARAGRAPH_NS) == "kept"
+
+
+@pytest.mark.offline
+def test_paragraph_drops_w_del_content() -> None:
+    para = _p("<w:del><w:r><w:t>removed</w:t></w:r></w:del>")
+
+    assert extract_paragraph_content(para, PARAGRAPH_NS) == ""
+
+
+@pytest.mark.offline
+def test_paragraph_drops_w_movefrom_content() -> None:
+    para = _p("<w:moveFrom><w:r><w:t>moved away</w:t></w:r></w:moveFrom>")
+
+    assert extract_paragraph_content(para, PARAGRAPH_NS) == ""
+
+
+@pytest.mark.offline
+def test_paragraph_drops_comment_markers_but_keeps_surrounding_text() -> None:
+    para = _p(
+        '<w:commentRangeStart w:id="0"/>'
+        "<w:r><w:t>visible</w:t></w:r>"
+        '<w:commentRangeEnd w:id="0"/>'
+        "<w:r>"
+        '  <w:rPr><w:rStyle w:val="CommentReference"/></w:rPr>'
+        '  <w:commentReference w:id="0"/>'
+        "</w:r>"
+    )
+
+    assert extract_paragraph_content(para, PARAGRAPH_NS) == "visible"
+
+
+# --- table-cell walker (table_extractor.extract_paragraph_content_table) ---
+
+
+@pytest.mark.offline
+def test_table_cell_keeps_w_ins_content() -> None:
+    para = _p("<w:ins><w:r><w:t>kept</w:t></w:r></w:ins>")
+
+    assert extract_paragraph_content_table(para, qn) == "kept"
+
+
+@pytest.mark.offline
+def test_table_cell_drops_w_del_content() -> None:
+    para = _p("<w:del><w:r><w:t>removed</w:t></w:r></w:del>")
+
+    assert extract_paragraph_content_table(para, qn) == ""
+
+
+@pytest.mark.offline
+def test_table_cell_drops_comment_markers() -> None:
+    para = _p(
+        '<w:commentRangeStart w:id="0"/>'
+        "<w:r><w:t>cell-text</w:t></w:r>"
+        '<w:commentRangeEnd w:id="0"/>'
+    )
+
+    assert extract_paragraph_content_table(para, qn) == "cell-text"
+
+
+# --- end-to-end: empty tables vanish from blocks output --------------------
+
+
+def _populate_cell(cell, text: str) -> None:
+    cell.paragraphs[0].text = text
+
+
+def _build_docx_with_three_tables() -> BytesIO:
+    """One real table, one all-empty table, one whitespace-only table.
+
+    Returns a BytesIO containing the rendered .docx so it can be fed to
+    ``extract_docx_blocks`` via a tempfile-backed path or directly.
+    """
+    doc = Document()
+    doc.add_paragraph("intro")
+
+    real = doc.add_table(rows=1, cols=2)
+    _populate_cell(real.rows[0].cells[0], "A")
+    _populate_cell(real.rows[0].cells[1], "B")
+
+    empty = doc.add_table(rows=2, cols=2)
+    # leave every cell at python-docx default (empty paragraph)
+    assert all(c.text == "" for row in empty.rows for c in row.cells)
+
+    whitespace = doc.add_table(rows=1, cols=2)
+    _populate_cell(whitespace.rows[0].cells[0], "   ")
+    _populate_cell(whitespace.rows[0].cells[1], "\t")
+
+    buf = BytesIO()
+    doc.save(buf)
+    buf.seek(0)
+    return buf
+
+
+@pytest.mark.offline
+def test_empty_tables_are_skipped(tmp_path) -> None:
+    docx_bytes = _build_docx_with_three_tables()
+    docx_path = tmp_path / "three_tables.docx"
+    docx_path.write_bytes(docx_bytes.getvalue())
+
+    blocks = extract_docx_blocks(str(docx_path))
+
+    table_placeholders = sum(b["content"].count("<table>") for b in blocks)
+    assert table_placeholders == 1, (
+        "exactly one real table should survive; empty + whitespace tables "
+        "must be dropped before the placeholder is emitted"
+    )
+    assert any('"A"' in b["content"] and '"B"' in b["content"] for b in blocks)


### PR DESCRIPTION
## Description

Optimize the native docx parser so its output is no longer polluted by tracked-change scaffolding, comment markers, or empty tables:

- **Only the final revised text** is surfaced: existing skip handling for `w:del` / `w:moveFrom` is now explicit via a named constant, with `w:ins` (and `w:moveTo`) kept by default recursion.
- **Comment markers are explicitly dropped**: `w:commentRangeStart`, `w:commentRangeEnd`, `w:commentReference`, `w:annotationRef`. Previously they were filtered out only because of a coincidental gap in the run-level whitelist; this is now an enforced contract.
- **Empty tables are skipped**: tables whose every cell is whitespace-only no longer emit a `<table>` placeholder into block content, and therefore no longer produce an `IRTable` in `tables.json`.

## Changes Made

- `lightrag/parser/docx/parse_document.py`
  - Introduce `_SKIP_REVISION_TAGS` / `_SKIP_COMMENT_TAGS` / `_SKIP_PARAGRAPH_TAGS` module constants.
  - `extract_paragraph_content` now consults the unified skip set.
  - Add `_is_table_empty(rows)` and early-`continue` in the `<w:tbl>` branch (with explicit `resolver.reset_tracking_state()` so the table-boundary numbering reset is preserved).
- `lightrag/parser/docx/table_extractor.py`
  - Mirror the skip set (duplicated with a `keep in sync` comment to avoid a circular import).
- `tests/parser/docx/test_native_docx_extract.py` (new) — 8 unit cases:
  - paragraph walker: keep `w:ins`, drop `w:del` / `w:moveFrom`, drop comment markers around live text;
  - table-cell walker: same three contracts;
  - end-to-end on a synthesized docx with 3 tables (one populated, one all-empty, one whitespace-only) — only the populated table survives.

## Checklist

- [x] Changes tested locally (`pytest tests/parser/docx/` → 21 passed, including the 7 existing byte-equivalence golden tests).
- [x] Unit tests added.
- [ ] Documentation updated — n/a (no behavior is publicly documented for these elements).

## Additional Notes

- `w:ins` and `w:moveTo` content are deliberately kept — they are part of the final revised text.
- `w:rPrChange` / `w:pPrChange` / `w:sectPrChange` are untouched because they are property-level change tracking and never produce text output.
- No downstream changes needed in `ir_builder.py` or the sidecar writer: dropping a table at the parser layer means no placeholder ever reaches `_BlockBuilder.replace_table`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)