### PR TITLE
fix(operate): truncate over-limit summaries before embedding

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -405,15 +405,19 @@ async def _summarize_descriptions(
     # Check summary token length against embedding limit
     embedding_token_limit = global_config.get("embedding_token_limit")
     if embedding_token_limit is not None and summary:
-        tokenizer = global_config["tokenizer"]
-        summary_token_count = len(tokenizer.encode(summary))
         threshold = int(embedding_token_limit)
-
-        if summary_token_count > threshold:
-            logger.warning(
-                f"Summary tokens({summary_token_count}) exceeds embedding_token_limit({embedding_token_limit}) "
-                f" for {description_type}: {description_name}"
-            )
+        # Non-positive limits are treated as "disabled" to stay consistent
+        # with the hard-fallback split in pipeline.py (which only runs when
+        # embedding_token_limit > 0).
+        if threshold > 0:
+            tokenizer = global_config["tokenizer"]
+            tokens = tokenizer.encode(summary)
+            if len(tokens) > threshold:
+                logger.warning(
+                    f"Summary tokens({len(tokens)}) exceeds embedding_token_limit({threshold}) "
+                    f"for {description_type}: {description_name}. Truncating to fit."
+                )
+                summary = tokenizer.decode(tokens[:threshold])
 
     return summary
 


### PR DESCRIPTION
## Summary
Truncate LLM-generated entity/relation summaries that exceed `embedding_token_limit` instead of only logging a warning and then handing the oversize text to the embedding provider.

## Motivation
`_summarize_descriptions` in `lightrag/operate.py` checked the summary token count, emitted a warning when it crossed `embedding_token_limit`, and then returned the original, untruncated summary. The downstream embedding call therefore still hit the provider's hard limit and failed — exactly the failure mode `embedding_token_limit` was supposed to prevent.

This PR is a re-targeted, minimal version of #3105 (reverted in #3120). The earlier change also touched `LightRAG.__post_init__` to re-read `EMBEDDING_TOKEN_LIMIT` from the environment, which turned out to be redundant and harmful:

- The env var is already resolved once in [`lightrag/api/config.py`](lightrag/api/config.py) (`args.embedding_token_limit`) and merged with the provider default in [`lightrag/api/lightrag_server.py`](lightrag/api/lightrag_server.py) (`args.embedding_token_limit or provider_max_token_size`), which is then written onto `embedding_func.max_token_size`. `LightRAG.__post_init__` picks that up via `self.embedding_func.max_token_size`, so the env override is already in effect by the time `self.embedding_token_limit` is assigned.
- Reading the env again inside the core library bypassed `args` resolution, forced env precedence onto pure-SDK callers (who can only configure the limit via `EmbeddingFunc.max_token_size`), and let `0` / negative values slip past the `args.embedding_token_limit or provider_max_token_size` fallback.

So the only real bug to fix is the missing truncation.

## Changes
- `lightrag/operate.py::_summarize_descriptions`: when `summary_token_count > embedding_token_limit`, truncate `summary` via `tokenizer.encode → [:threshold] → decode` before returning. Added a `threshold > 0` guard so non-positive limits behave as "disabled" — consistent with the hard-fallback split in `lightrag/pipeline.py` (which only runs when `embedding_token_limit > 0`) rather than silently zero-truncating the summary.

## What's not in this PR
- No changes to `LightRAG.__post_init__` — see *Motivation* above.
- The `split_by_character` / `split_by_character_only` API field additions that were part of #3105's revert are intentionally excluded; they belong in a separate PR.

## Known limitation
The truncation uses the configured local `tokenizer`. If the embedding provider tokenizes differently, an exact-cut summary could still marginally exceed the provider's true limit. This matches existing behavior elsewhere in `operate.py` and `pipeline.py`; addressing tokenizer/provider drift is out of scope for this fix.

## Testing
- `ruff check lightrag/operate.py` passes.
- Behavioral verification: with `EMBEDDING_TOKEN_LIMIT` set, the warning now reports the actual truncation and downstream `embed` calls receive a summary within the limit. Existing pipeline tests continue to pass.