### PR TITLE
fix(pipeline): emit per-item analyze logs in real time

### DIFF
--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -4135,6 +4135,37 @@ class _PipelineMixin:
                     existing.append(cache_id)
                 item_obj["llm_cache_list"] = existing
 
+            async def _run_with_progress_log(coro, kind: str, item_id: str):
+                """Append per-item completion log to pipeline_status the moment
+                this single ``_analyze_*`` task finishes — not after the whole
+                ``asyncio.gather`` batch returns — so the UI sees each
+                drawing/table/equation result land in real time."""
+                try:
+                    result = await coro
+                except Exception:
+                    if (
+                        pipeline_status is not None
+                        and pipeline_status_lock is not None
+                    ):
+                        async with pipeline_status_lock:
+                            log_message = f"  {kind}/{item_id} failed: {file_path}"
+                            pipeline_status["latest_message"] = log_message
+                            pipeline_status["history_messages"].append(log_message)
+                    raise
+                if pipeline_status is not None and pipeline_status_lock is not None:
+                    result_obj = result[0] if isinstance(result, tuple) else {}
+                    item_status = (
+                        "ok"
+                        if isinstance(result_obj, dict)
+                        and result_obj.get("status") == "success"
+                        else "skipped"
+                    )
+                    async with pipeline_status_lock:
+                        log_message = f"  {kind}/{item_id} {item_status}: {file_path}"
+                        pipeline_status["latest_message"] = log_message
+                        pipeline_status["history_messages"].append(log_message)
+                return result
+
             base_name = str(block_file)
             if base_name.endswith(".blocks.jsonl"):
                 base_name = base_name[: -len(".blocks.jsonl")]
@@ -4191,13 +4222,14 @@ class _PipelineMixin:
                         continue
                     valid_keys.append(item_id)
                     if kind == "drawing":
-                        analyze_tasks.append(
-                            _analyze_drawing(item_id, item, sidecar_path.parent)
+                        inner_coro = _analyze_drawing(
+                            item_id, item, sidecar_path.parent
                         )
                     else:
-                        analyze_tasks.append(
-                            _analyze_text_modality(kind, item_id, item)
-                        )
+                        inner_coro = _analyze_text_modality(kind, item_id, item)
+                    analyze_tasks.append(
+                        _run_with_progress_log(inner_coro, kind, item_id)
+                    )
 
                 analyzed = await asyncio.gather(*analyze_tasks, return_exceptions=True)
 
@@ -4209,14 +4241,12 @@ class _PipelineMixin:
                     outcome = analyzed[idx]
                     if isinstance(outcome, MultimodalAnalysisError):
                         item["llm_analyze_result"] = _failure_result(str(outcome))
-                        item_status = "failed"
                         if failure_to_raise is None:
                             failure_to_raise = outcome
                     elif isinstance(outcome, Exception):
                         item["llm_analyze_result"] = _failure_result(
                             f"unexpected error: {outcome}"
                         )
-                        item_status = "failed"
                         if failure_to_raise is None:
                             failure_to_raise = MultimodalAnalysisError(
                                 f"{root_key}/{item_id}: unexpected error: {outcome}"
@@ -4225,16 +4255,6 @@ class _PipelineMixin:
                         result_obj, cache_id = outcome
                         item["llm_analyze_result"] = result_obj
                         _attach_cache_id(item, cache_id)
-                        item_status = (
-                            "ok" if result_obj.get("status") == "success" else "skipped"
-                        )
-                    if pipeline_status is not None and pipeline_status_lock is not None:
-                        async with pipeline_status_lock:
-                            log_message = (
-                                f"  {kind}/{item_id} {item_status}: {file_path}"
-                            )
-                            pipeline_status["latest_message"] = log_message
-                            pipeline_status["history_messages"].append(log_message)
                 try:
                     sidecar_path.write_text(
                         json.dumps(payload, ensure_ascii=False, indent=2),

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -4143,10 +4143,7 @@ class _PipelineMixin:
                 try:
                     result = await coro
                 except Exception:
-                    if (
-                        pipeline_status is not None
-                        and pipeline_status_lock is not None
-                    ):
+                    if pipeline_status is not None and pipeline_status_lock is not None:
                         async with pipeline_status_lock:
                             log_message = f"Analyzing {kind}/{item_id}: failed"
                             pipeline_status["latest_message"] = log_message

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1487,7 +1487,7 @@ class _PipelineMixin:
                     file_path=file_path_w,
                 )
                 async with ctx.pipeline_status_lock:
-                    log_message = f"Parsing ({engine}): {file_path_w}"
+                    log_message = f"Parsing ({engine}): {doc_id_w}"
                     ctx.pipeline_status["latest_message"] = log_message
                     ctx.pipeline_status["history_messages"].append(log_message)
                 if engine == "mineru":
@@ -4148,7 +4148,7 @@ class _PipelineMixin:
                         and pipeline_status_lock is not None
                     ):
                         async with pipeline_status_lock:
-                            log_message = f"  {kind}/{item_id} failed: {file_path}"
+                            log_message = f"Analyzing {kind}/{item_id}: failed"
                             pipeline_status["latest_message"] = log_message
                             pipeline_status["history_messages"].append(log_message)
                     raise
@@ -4161,7 +4161,7 @@ class _PipelineMixin:
                         else "skipped"
                     )
                     async with pipeline_status_lock:
-                        log_message = f"  {kind}/{item_id} {item_status}: {file_path}"
+                        log_message = f"Analyzing  {kind}/{item_id}: {item_status}"
                         pipeline_status["latest_message"] = log_message
                         pipeline_status["history_messages"].append(log_message)
                 return result
@@ -4210,7 +4210,7 @@ class _PipelineMixin:
                     and pipeline_status_lock is not None
                 ):
                     async with pipeline_status_lock:
-                        log_message = f"Analyzing multimodal: {file_path}"
+                        log_message = f"Analyzing multimodal: {doc_id}"
                         pipeline_status["latest_message"] = log_message
                         pipeline_status["history_messages"].append(log_message)
                     start_logged = True


### PR DESCRIPTION
## Summary

Follow-up to #3118. The original implementation appended the per-item completion line
(`  drawing/img_3 ok: foo.pdf`) inside the post-`asyncio.gather` outcome loop, so for any
modality with N items the UI saw all N log lines appear together AFTER every LLM call for
that modality had returned — not as each individual call resolved.

## Motivation

Real-world tester reports: "logs aren't emitted right after the LLM call ends; they all
print together at the end of the file." For a document with many drawings/tables, this
makes the multimodal analyze stage look hung in the UI even though work is progressing.

## What's changed

Introduce `_run_with_progress_log(coro, kind, item_id)` inside `analyze_multimodal`,
which:

- `await`s the inner `_analyze_drawing` / `_analyze_text_modality` coroutine
- Immediately appends `  {kind}/{item_id} {ok|skipped|failed}: {file_path}` to
  `pipeline_status["latest_message"]` / `history_messages` under the existing lock
- Re-raises on exception so `asyncio.gather(..., return_exceptions=True)` still
  collects the error for the outcome loop, which continues to populate `_failure_result`
  and `failure_to_raise` exactly as before

The post-gather outcome loop is now strictly about updating `item["llm_analyze_result"]`
and `failure_to_raise` — all logging side-effects moved into the wrapper.

## What's broken / migration

- No public API change.
- No new dependencies.
- One mock in `tests/test_pipeline_release_closure.py` already accepts `**kwargs` from #3118; nothing else needs updating.

## How it works

- `asyncio.gather` schedules every wrapped coroutine and waits concurrently. Each
  wrapper completes in whatever order its LLM call finishes (network latency / cache hit /
  skip) and appends its log line then. The order in `history_messages` therefore reflects
  real completion order, not the order of `valid_keys`.
- `result_obj.get("status") == "success"` decides `ok` vs `skipped`; matches the
  semantics of `_skipped_result` / success-result objects already produced upstream.

## Test plan

- [x] `pytest tests/test_pipeline_analyze_multimodal.py` — 15 passed
- [x] `pytest tests/test_parse_native_lightrag_e2e.py` — 5 passed
- [x] `pytest tests/ -k "pipeline or parse_worker or analyze"` — 110 passed, 1 skipped
- [x] `ruff check lightrag/pipeline.py` — clean
- [ ] Manual: upload a PDF with several images, watch `/documents/pipeline_status` —
      `  drawing/imgN ok:` lines should appear progressively as each VLM call returns,
      not all at once when the file finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)