### PR TITLE
feat(pipeline): propagate /cancel_pipeline into PARSE and ANALYZE

### DIFF
--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1451,6 +1451,22 @@ class _PipelineMixin:
             try:
                 doc_id_w, status_doc_w = item
                 file_path_w = getattr(status_doc_w, "file_path", "unknown_source")
+                # Boundary cancellation check: skip parsing the next queued doc
+                # without invoking the engine, mark it FAILED with a friendly
+                # "User cancelled" message, and let the finally task_done()
+                # drain the queue so q.join() in _run_pipeline_batch returns.
+                if await self._cancellation_requested(
+                    ctx.pipeline_status, ctx.pipeline_status_lock
+                ):
+                    await self._mark_doc_cancelled_in_stage(
+                        doc_id=doc_id_w,
+                        status_doc=status_doc_w,
+                        file_path=file_path_w,
+                        stage_label="parse",
+                        pipeline_status=ctx.pipeline_status,
+                        pipeline_status_lock=ctx.pipeline_status_lock,
+                    )
+                    continue
                 content_data_w = await self.full_docs.get_by_id(doc_id_w)
                 if not content_data_w:
                     raise Exception(
@@ -1547,6 +1563,20 @@ class _PipelineMixin:
                     continue
 
                 await ctx.q_analyze.put((doc_id_w, status_doc_w, parsed_data_w))
+            except PipelineCancelledException:
+                # Cancellation raised from inside the parse engine (future-
+                # proofing — engines don't currently call _raise_if_cancelled,
+                # but if they do, route through the same friendly message
+                # path as the boundary check above instead of the generic
+                # except block below.
+                await self._mark_doc_cancelled_in_stage(
+                    doc_id=doc_id_w,
+                    status_doc=status_doc_w,
+                    file_path=getattr(status_doc_w, "file_path", "unknown_source"),
+                    stage_label="parse",
+                    pipeline_status=ctx.pipeline_status,
+                    pipeline_status_lock=ctx.pipeline_status_lock,
+                )
             except Exception as e:
                 logger.error(f"Parse worker failed ({engine}): {e}")
                 try:
@@ -1575,6 +1605,22 @@ class _PipelineMixin:
             try:
                 doc_id_w, status_doc_w, parsed_data_w = item
                 file_path_w = getattr(status_doc_w, "file_path", "unknown_source")
+                # Boundary cancellation check: same pattern as _parse_worker.
+                # Items already past PARSING that are still queued for analyze
+                # are short-circuited to FAILED here so the multimodal VLM
+                # path is not entered after the user clicked cancel.
+                if await self._cancellation_requested(
+                    ctx.pipeline_status, ctx.pipeline_status_lock
+                ):
+                    await self._mark_doc_cancelled_in_stage(
+                        doc_id=doc_id_w,
+                        status_doc=status_doc_w,
+                        file_path=file_path_w,
+                        stage_label="analyze",
+                        pipeline_status=ctx.pipeline_status,
+                        pipeline_status_lock=ctx.pipeline_status_lock,
+                    )
+                    continue
                 refreshed_content_w = parsed_data_w.get("content", "") or ""
                 refreshed_summary_w = get_content_summary(refreshed_content_w)
                 refreshed_length_w = len(refreshed_content_w)
@@ -1600,6 +1646,19 @@ class _PipelineMixin:
                     pipeline_status_lock=ctx.pipeline_status_lock,
                 )
                 await ctx.q_process.put((doc_id_w, status_doc_w, analyzed))
+            except PipelineCancelledException:
+                # In-flight cancellation surfaced from analyze_multimodal
+                # (poll loop detected cancellation_requested mid-VLM).
+                # Route through the friendly message path so error_msg and
+                # history_messages match the boundary-check branch.
+                await self._mark_doc_cancelled_in_stage(
+                    doc_id=doc_id_w,
+                    status_doc=status_doc_w,
+                    file_path=getattr(status_doc_w, "file_path", "unknown_source"),
+                    stage_label="analyze",
+                    pipeline_status=ctx.pipeline_status,
+                    pipeline_status_lock=ctx.pipeline_status_lock,
+                )
             except Exception as e:
                 # Mirror _parse_worker: failures here must transition the
                 # document to FAILED with a diagnostic ``error_msg``, otherwise
@@ -2300,6 +2359,60 @@ class _PipelineMixin:
         async with pipeline_status_lock:
             if pipeline_status.get("cancellation_requested", False):
                 raise PipelineCancelledException("User cancelled")
+
+    async def _cancellation_requested(
+        self,
+        pipeline_status: dict,
+        pipeline_status_lock,
+    ) -> bool:
+        """Read-only cancellation check.
+
+        Use this when a worker wants to branch on the flag (e.g. drain a queue
+        item) instead of raising. Callers that prefer the exception style
+        should use :meth:`_raise_if_cancelled` instead.
+        """
+        async with pipeline_status_lock:
+            return bool(pipeline_status.get("cancellation_requested", False))
+
+    async def _mark_doc_cancelled_in_stage(
+        self,
+        *,
+        doc_id: str,
+        status_doc: DocProcessingStatus,
+        file_path: str,
+        stage_label: str,
+        pipeline_status: dict,
+        pipeline_status_lock,
+    ) -> None:
+        """Mark a queued document FAILED with a 'User cancelled' message.
+
+        Used by the PARSE and ANALYZE workers, which do not have the
+        chunks-snapshot / pending-tasks bookkeeping that
+        :meth:`_finalize_doc_failure` carries for the PROCESS stage. Also
+        flushes the LLM response cache so any cache_ids written by completed
+        sibling tasks (e.g. successful multimodal items inside a doc that is
+        being cancelled) survive a server restart.
+        """
+        error_msg = f"User cancelled during {stage_label}: {file_path}"
+        logger.warning(error_msg)
+        async with pipeline_status_lock:
+            pipeline_status["latest_message"] = error_msg
+            pipeline_status["history_messages"].append(error_msg)
+        if self.llm_response_cache:
+            try:
+                await self.llm_response_cache.index_done_callback()
+            except Exception as persist_error:
+                logger.error(f"Failed to persist LLM cache: {persist_error}")
+        try:
+            await self._upsert_doc_status_transition(
+                doc_id=doc_id,
+                status=DocStatus.FAILED,
+                status_doc=status_doc,
+                file_path=file_path,
+                extra_fields={"error_msg": error_msg},
+            )
+        except Exception as exc:
+            logger.error(f"Failed to mark cancelled doc {doc_id} as FAILED: {exc}")
 
     async def _finalize_doc_failure(
         self,
@@ -4212,46 +4325,111 @@ class _PipelineMixin:
                         pipeline_status["history_messages"].append(log_message)
                     start_logged = True
 
-                valid_keys: list[str] = []
-                analyze_tasks: list[Any] = []
+                # Pre-schedule cancellation check: if the user cancelled
+                # between _analyze_worker's boundary check and the moment
+                # we are about to spawn VLM tasks for this sidecar, raise
+                # here so no item task ever runs. Without this we'd briefly
+                # create tasks and then cancel them on the very first poll
+                # iteration — wasteful and harder to reason about.
+                if pipeline_status is not None and pipeline_status_lock is not None:
+                    await self._raise_if_cancelled(
+                        pipeline_status, pipeline_status_lock
+                    )
+
+                task_meta: dict[asyncio.Task, tuple[str, dict]] = {}
                 for item_id, item in items.items():
                     if not isinstance(item, dict):
                         continue
-                    valid_keys.append(item_id)
                     if kind == "drawing":
                         inner_coro = _analyze_drawing(
                             item_id, item, sidecar_path.parent
                         )
                     else:
                         inner_coro = _analyze_text_modality(kind, item_id, item)
-                    analyze_tasks.append(
+                    task = asyncio.create_task(
                         _run_with_progress_log(inner_coro, kind, item_id)
                     )
+                    task_meta[task] = (item_id, item)
 
-                analyzed = await asyncio.gather(*analyze_tasks, return_exceptions=True)
+                if not task_meta:
+                    # No valid items in this sidecar — asyncio.wait([]) would
+                    # ValueError, so skip the wait loop entirely.
+                    continue
 
-                failure_to_raise: MultimodalAnalysisError | None = None
-                for idx, item_id in enumerate(valid_keys):
-                    item = items.get(item_id)
-                    if not isinstance(item, dict):
-                        continue
-                    outcome = analyzed[idx]
-                    if isinstance(outcome, MultimodalAnalysisError):
-                        item["llm_analyze_result"] = _failure_result(str(outcome))
-                        if failure_to_raise is None:
-                            failure_to_raise = outcome
-                    elif isinstance(outcome, Exception):
-                        item["llm_analyze_result"] = _failure_result(
-                            f"unexpected error: {outcome}"
+                # Fail-fast polling loop. Three trigger paths:
+                #   1. an item task raises (e.g. MultimodalAnalysisError) →
+                #      asyncio.wait returns early via FIRST_EXCEPTION;
+                #   2. an item task raises PipelineCancelledException →
+                #      same path, preserving the exception type;
+                #   3. user clicks /cancel_pipeline mid-VLM → the
+                #      cancellation_requested check at the top of the next
+                #      poll iteration (≤ POLL_INTERVAL_SECONDS) fabricates
+                #      a PipelineCancelledException.
+                #
+                # Do NOT add a watcher coroutine to the wait set: it would be
+                # an infinite loop that stays pending when all items succeed,
+                # preventing FIRST_EXCEPTION from ever returning.
+                pending: set[asyncio.Task] = set(task_meta.keys())
+                fail_fast_exc: BaseException | None = None
+                POLL_INTERVAL_SECONDS = 0.5
+                while pending:
+                    if (
+                        pipeline_status is not None
+                        and pipeline_status_lock is not None
+                        and await self._cancellation_requested(
+                            pipeline_status, pipeline_status_lock
                         )
-                        if failure_to_raise is None:
-                            failure_to_raise = MultimodalAnalysisError(
-                                f"{root_key}/{item_id}: unexpected error: {outcome}"
-                            )
-                    else:
-                        result_obj, cache_id = outcome
+                    ):
+                        fail_fast_exc = PipelineCancelledException(
+                            "User cancelled during analyze"
+                        )
+                        break
+
+                    done_now, pending = await asyncio.wait(
+                        pending,
+                        timeout=POLL_INTERVAL_SECONDS,
+                        return_when=asyncio.FIRST_EXCEPTION,
+                    )
+                    for t in done_now:
+                        if t.cancelled():
+                            continue
+                        texc = t.exception()
+                        if texc is not None:
+                            # Preserve original exception type so the
+                            # _analyze_worker except dispatch can distinguish
+                            # PipelineCancelledException from
+                            # MultimodalAnalysisError.
+                            fail_fast_exc = texc
+                            break
+                    if fail_fast_exc is not None:
+                        break
+
+                # If we broke early, cancel the still-running tasks.
+                for t in pending:
+                    t.cancel()
+                if pending:
+                    await asyncio.gather(*pending, return_exceptions=True)
+
+                # Collect results — preserve completed successes so reprocess
+                # can hit the LLM cache instead of re-running the VLM.
+                for t, (item_id, item) in task_meta.items():
+                    if t.cancelled():
+                        item["llm_analyze_result"] = _failure_result("cancelled")
+                        continue
+                    texc = t.exception()
+                    if texc is None:
+                        result_obj, cache_id = t.result()
                         item["llm_analyze_result"] = result_obj
                         _attach_cache_id(item, cache_id)
+                    elif isinstance(texc, PipelineCancelledException):
+                        item["llm_analyze_result"] = _failure_result("cancelled")
+                    elif isinstance(texc, MultimodalAnalysisError):
+                        item["llm_analyze_result"] = _failure_result(str(texc))
+                    else:
+                        item["llm_analyze_result"] = _failure_result(
+                            f"unexpected error: {texc}"
+                        )
+
                 try:
                     sidecar_path.write_text(
                         json.dumps(payload, ensure_ascii=False, indent=2),
@@ -4262,11 +4440,30 @@ class _PipelineMixin:
                         f"[analyze_multimodal] failed to write sidecar "
                         f"{sidecar_path}: {exc}"
                     )
-                if failure_to_raise is not None:
-                    raise failure_to_raise
+
+                if fail_fast_exc is not None:
+                    # Best-effort cache flush so any cache_ids written by
+                    # already-completed sibling tasks survive a restart —
+                    # otherwise the sidecar references cache rows that
+                    # haven't been persisted yet. Mirrors
+                    # _finalize_doc_failure's PROCESS-stage behaviour.
+                    if self.llm_response_cache:
+                        try:
+                            await self.llm_response_cache.index_done_callback()
+                        except Exception as persist_error:
+                            logger.error(
+                                f"Failed to persist LLM cache after analyze "
+                                f"fail-fast: {persist_error}"
+                            )
+                    raise fail_fast_exc
 
             parsed_data["multimodal_processed"] = True
             logger.info(f"[analyze_multimodal] completed for d-id: {doc_id}")
+        except PipelineCancelledException:
+            # Must re-raise BEFORE the generic Exception handler below,
+            # otherwise the doc would be returned as if analyze succeeded
+            # and would advance to PROCESS instead of being marked FAILED.
+            raise
         except MultimodalAnalysisError:
             raise
         except Exception as e:

--- a/tests/test_pipeline_cancellation.py
+++ b/tests/test_pipeline_cancellation.py
@@ -1,0 +1,645 @@
+"""Offline tests for /cancel_pipeline propagation into PARSE and ANALYZE.
+
+Tests target the worker-level cancellation contract added alongside the
+existing PROCESS-stage support:
+
+* ``_parse_worker`` and ``_analyze_worker`` check ``cancellation_requested``
+  at the top of every loop iteration, drain queued items as FAILED with a
+  ``"User cancelled during {stage}: ..."`` ``error_msg``, and ``task_done()``
+  each one so ``q.join()`` in ``_run_pipeline_batch`` returns.
+* ``analyze_multimodal`` fails fast: the first item that raises (or a
+  ``cancellation_requested`` flip observed by the poll loop) cancels every
+  still-running sibling task, preserves already-completed item results in
+  the sidecar, and re-raises the original exception type.
+
+Tests construct ``_BatchRunContext`` and call worker methods directly to
+avoid the cross-task races inherent in driving the full
+``apipeline_process_enqueue_documents`` entry point.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG, ROLES, RoleLLMConfig
+from lightrag.base import DocProcessingStatus, DocStatus
+from lightrag.exceptions import MultimodalAnalysisError, PipelineCancelledException
+from lightrag.kg.shared_storage import get_namespace_data, get_namespace_lock
+from lightrag.pipeline import _BatchRunContext
+from lightrag.utils import EmbeddingFunc, Tokenizer
+
+
+pytestmark = pytest.mark.offline
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _mock_embedding(texts: list[str]) -> np.ndarray:
+    return np.random.rand(len(texts), 8)
+
+
+async def _noop_llm(prompt, **kwargs):  # pragma: no cover - never invoked
+    return ""
+
+
+def _build_rag(tmp_path: Path, *, vlm_func=None) -> LightRAG:
+    role_configs = {}
+    for spec in ROLES:
+        if spec.name == "vlm" and vlm_func is not None:
+            role_configs[spec.name] = RoleLLMConfig(func=vlm_func)
+        else:
+            role_configs[spec.name] = RoleLLMConfig()
+    return LightRAG(
+        working_dir=str(tmp_path),
+        workspace=f"cancel-{tmp_path.name}",
+        llm_model_func=vlm_func or _noop_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8,
+            max_token_size=1024,
+            func=_mock_embedding,
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        vlm_process_enable=True,
+        role_llm_configs=role_configs,
+    )
+
+
+async def _shutdown_role_workers(rag: LightRAG) -> None:
+    """Explicitly shut down each role wrapper's priority-queue workers.
+
+    finalize_storages() only finalizes storages — it does NOT touch the
+    per-role priority_limit worker pools. If a test triggered any role
+    LLM calls whose worker is still in ``await asyncio.sleep(...)`` when
+    pytest closes the function-scoped event loop, the leaked worker
+    tasks raise "Task was destroyed but it is pending" / "Event loop is
+    closed" and (worse, observed on macOS Python 3.12) prevent the
+    pytest process from exiting cleanly. Call this before
+    ``finalize_storages()`` to drain workers under a live loop first.
+    """
+    for func in rag.role_llm_funcs.values():
+        try:
+            await rag._shutdown_llm_wrapper(func)
+        except Exception as exc:
+            logging.getLogger("lightrag").warning(
+                f"role worker shutdown raised during test teardown: {exc}"
+            )
+
+
+async def _make_ctx(rag: LightRAG) -> tuple[_BatchRunContext, dict, Any]:
+    """Build a fresh _BatchRunContext bound to the RAG's workspace.
+
+    The pipeline_status dict and lock come from the same shared_storage
+    keyspace that production code uses, so worker reads of the
+    cancellation flag observe whatever the test writes.
+    """
+    pipeline_status = await get_namespace_data(
+        "pipeline_status", workspace=rag.workspace
+    )
+    pipeline_status_lock = get_namespace_lock(
+        "pipeline_status", workspace=rag.workspace
+    )
+    pipeline_status.clear()
+    pipeline_status.update(
+        {
+            "busy": True,
+            "history_messages": [],
+            "latest_message": "",
+            "cancellation_requested": False,
+        }
+    )
+    ctx = _BatchRunContext(
+        pipeline_status=pipeline_status,
+        pipeline_status_lock=pipeline_status_lock,
+        semaphore=asyncio.Semaphore(2),
+        total_files=0,
+        q_native=asyncio.Queue(),
+        q_mineru=asyncio.Queue(),
+        q_docling=asyncio.Queue(),
+        q_analyze=asyncio.Queue(),
+        q_process=asyncio.Queue(),
+    )
+    return ctx, pipeline_status, pipeline_status_lock
+
+
+def _make_status_doc(doc_id: str) -> DocProcessingStatus:
+    now = datetime.now(timezone.utc).isoformat()
+    return DocProcessingStatus(
+        content_summary=f"summary-{doc_id}",
+        content_length=10,
+        file_path=f"{doc_id}.pdf",
+        status=DocStatus.PENDING,
+        created_at=now,
+        updated_at=now,
+        track_id=None,
+        content_hash=f"hash-{doc_id}",
+    )
+
+
+async def _run_worker_until_drained(
+    worker_coro_factory,
+    queue: asyncio.Queue,
+    *,
+    timeout: float = 2.0,
+) -> None:
+    """Spin up the worker, await q.join(), then cancel the worker — same
+    teardown sequence as ``_run_pipeline_batch``."""
+    worker = asyncio.create_task(worker_coro_factory())
+    try:
+        await asyncio.wait_for(queue.join(), timeout=timeout)
+    finally:
+        worker.cancel()
+        await asyncio.gather(worker, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_parse_worker_drains_queue_when_cancelled_before_start(tmp_path):
+    """Cancellation set BEFORE the worker pulls any item: parser must not
+    run, every queued doc is FAILED with a friendly message, q.join()
+    returns quickly."""
+    rag = _build_rag(tmp_path)
+    await rag.initialize_storages()
+    try:
+        ctx, pipeline_status, _ = await _make_ctx(rag)
+
+        rag.parse_native = AsyncMock(
+            side_effect=AssertionError("parse_native must not be called")
+        )
+
+        for i in range(3):
+            doc_id = f"doc-{i}"
+            await rag.full_docs.upsert(
+                {doc_id: {"content": "hello", "file_path": f"{doc_id}.pdf"}}
+            )
+            await rag.doc_status.upsert(
+                {
+                    doc_id: {
+                        "status": DocStatus.PENDING.value,
+                        "content_summary": f"sum-{doc_id}",
+                        "content_length": 5,
+                        "file_path": f"{doc_id}.pdf",
+                        "created_at": datetime.now(timezone.utc).isoformat(),
+                        "updated_at": datetime.now(timezone.utc).isoformat(),
+                        "track_id": "t",
+                    }
+                }
+            )
+            await ctx.q_native.put((doc_id, _make_status_doc(doc_id)))
+
+        pipeline_status["cancellation_requested"] = True
+
+        start = time.monotonic()
+        await _run_worker_until_drained(
+            lambda: rag._parse_worker("native", ctx.q_native, ctx),
+            ctx.q_native,
+        )
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 1.0, f"queue drain should be fast, took {elapsed:.2f}s"
+        assert rag.parse_native.await_count == 0
+
+        cancel_messages = [
+            m
+            for m in pipeline_status["history_messages"]
+            if "User cancelled during parse" in m
+        ]
+        assert len(cancel_messages) == 3
+
+        for i in range(3):
+            doc_id = f"doc-{i}"
+            row = await rag.doc_status.get_by_id(doc_id)
+            assert row is not None
+            assert row.get("status") == DocStatus.FAILED.value
+            assert "User cancelled during parse" in (row.get("error_msg") or "")
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_analyze_worker_drains_queue_when_cancelled_before_start(tmp_path):
+    """ANALYZE-worker symmetric to the PARSE test above."""
+    rag = _build_rag(tmp_path)
+    await rag.initialize_storages()
+    try:
+        ctx, pipeline_status, _ = await _make_ctx(rag)
+
+        rag.analyze_multimodal = AsyncMock(
+            side_effect=AssertionError("analyze_multimodal must not be called")
+        )
+
+        for i in range(3):
+            doc_id = f"doc-{i}"
+            await rag.doc_status.upsert(
+                {
+                    doc_id: {
+                        "status": DocStatus.ANALYZING.value,
+                        "content_summary": f"sum-{doc_id}",
+                        "content_length": 5,
+                        "file_path": f"{doc_id}.pdf",
+                        "created_at": datetime.now(timezone.utc).isoformat(),
+                        "updated_at": datetime.now(timezone.utc).isoformat(),
+                        "track_id": "t",
+                    }
+                }
+            )
+            await ctx.q_analyze.put(
+                (doc_id, _make_status_doc(doc_id), {"content": "x"})
+            )
+
+        pipeline_status["cancellation_requested"] = True
+
+        start = time.monotonic()
+        await _run_worker_until_drained(
+            lambda: rag._analyze_worker(ctx),
+            ctx.q_analyze,
+        )
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 1.0, f"queue drain should be fast, took {elapsed:.2f}s"
+        assert rag.analyze_multimodal.await_count == 0
+
+        cancel_messages = [
+            m
+            for m in pipeline_status["history_messages"]
+            if "User cancelled during analyze" in m
+        ]
+        assert len(cancel_messages) == 3
+
+        for i in range(3):
+            row = await rag.doc_status.get_by_id(f"doc-{i}")
+            assert row is not None
+            assert row.get("status") == DocStatus.FAILED.value
+            assert "User cancelled during analyze" in (row.get("error_msg") or "")
+    finally:
+        await rag.finalize_storages()
+
+
+# Drawing sidecar fixture used by both in-flight cancellation and fail-fast
+# tests. Three items so we can have one slow / one fast-failing / one slow-
+# successful task and observe partial-result preservation.
+def _write_three_item_sidecar(tmp_path: Path) -> tuple[str, dict, Path]:
+    parsed_dir = tmp_path / "parsed"
+    parsed_dir.mkdir(exist_ok=True)
+    blocks_path = parsed_dir / "doc.blocks.jsonl"
+    blocks_path.write_text(
+        json.dumps({"type": "meta", "doc_id": "doc-1"}) + "\n",
+        encoding="utf-8",
+    )
+    sidecar_path = parsed_dir / "doc.drawings.json"
+    sidecar_path.write_text(
+        json.dumps(
+            {
+                "drawings": {
+                    "im-A": {"caption": "A", "path": "ignored-A"},
+                    "im-B": {"caption": "B", "path": "ignored-B"},
+                    "im-C": {"caption": "C", "path": "ignored-C"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    parsed_data = {"blocks_path": str(blocks_path)}
+    return "doc-1", parsed_data, sidecar_path
+
+
+@pytest.mark.asyncio
+async def test_analyze_multimodal_inflight_cancellation_polls_flag(
+    tmp_path, monkeypatch
+):
+    """User sets cancellation_requested while VLM tasks are running.
+    analyze_multimodal should observe the flag at the next poll boundary
+    (≤ 0.5s), cancel pending tasks, write the sidecar with partial
+    results, and raise PipelineCancelledException."""
+
+    async def slow_vlm(prompt, **kwargs):
+        # 1.2s is short enough that even when the priority-queue worker
+        # finishes the in-flight call after we've already raised (the
+        # role wrapper does not propagate outer-future cancellation to
+        # the worker), the post-analyze cleanup is bounded.
+        await asyncio.sleep(1.2)
+        return json.dumps(
+            {"name": "x", "type": "Chart", "description": "should not arrive"}
+        )
+
+    rag = _build_rag(tmp_path, vlm_func=slow_vlm)
+    await rag.initialize_storages()
+    try:
+        doc_id, parsed_data, sidecar_path = _write_three_item_sidecar(tmp_path)
+
+        # Bypass image-bytes validation: _analyze_drawing normally reads
+        # and validates the image file. Replace with a controlled mock so
+        # the only async work is the (slow_vlm) call we manage above.
+        async def fake_analyze_drawing(item_id, item, sidecar_dir):
+            await slow_vlm("dummy")  # honors the cancellation timing
+            return (
+                {
+                    "name": item_id,
+                    "type": "Chart",
+                    "description": "ok",
+                    "status": "success",
+                    "analyze_time": int(time.time()),
+                },
+                f"cache-{item_id}",
+            )
+
+        # analyze_multimodal defines _analyze_drawing as a local closure,
+        # so we can't monkeypatch it directly. Instead patch the helper
+        # it relies on (slow_vlm via the role wrapper); we accept the
+        # closure's image pre-validation and supply a minimal PNG fixture.
+        from tests.test_pipeline_analyze_multimodal import PNG_BYTES
+
+        for letter in ("A", "B", "C"):
+            (tmp_path / "parsed" / f"im-{letter}.png").write_bytes(PNG_BYTES)
+        sidecar_path.write_text(
+            json.dumps(
+                {
+                    "drawings": {
+                        f"im-{letter}": {
+                            "caption": letter,
+                            "path": str(tmp_path / "parsed" / f"im-{letter}.png"),
+                        }
+                        for letter in ("A", "B", "C")
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        # Use plain dict + asyncio.Lock so the poll loop's lock
+        # acquisition has no chance of contending with the real
+        # NamespaceLock used during LightRAG initialization paths.
+        pipeline_status: dict = {
+            "busy": True,
+            "history_messages": [],
+            "latest_message": "",
+            "cancellation_requested": False,
+        }
+        pipeline_status_lock = asyncio.Lock()
+
+        async def flip_after(delay: float):
+            await asyncio.sleep(delay)
+            async with pipeline_status_lock:
+                pipeline_status["cancellation_requested"] = True
+
+        flipper = asyncio.create_task(flip_after(0.1))
+
+        start = time.monotonic()
+        with pytest.raises(PipelineCancelledException):
+            await asyncio.wait_for(
+                rag.analyze_multimodal(
+                    doc_id=doc_id,
+                    file_path="fixture.pdf",
+                    parsed_data=parsed_data,
+                    process_options="i",
+                    pipeline_status=pipeline_status,
+                    pipeline_status_lock=pipeline_status_lock,
+                ),
+                timeout=15.0,
+            )
+        elapsed = time.monotonic() - start
+        await flipper
+
+        # Must cancel well before the 1.2s sleep — poll interval is 0.5s.
+        assert elapsed < 1.0, f"in-flight cancel took {elapsed:.2f}s (>1.0s)"
+
+        payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        # Sidecar should have been written even though we raised — every
+        # item carries a llm_analyze_result entry (cancelled / failure).
+        for letter in ("A", "B", "C"):
+            item = payload["drawings"][f"im-{letter}"]
+            assert "llm_analyze_result" in item
+            assert item["llm_analyze_result"]["status"] in ("failure", "success")
+    finally:
+        await _shutdown_role_workers(rag)
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_analyze_multimodal_fail_fast_preserves_successes(tmp_path):
+    """One item raises quickly; one already completed; one would have
+    taken longer. analyze_multimodal must not wait for the slow item,
+    must preserve the completed item's result in the sidecar, and must
+    raise MultimodalAnalysisError (not PipelineCancelledException)."""
+    from tests.test_pipeline_analyze_multimodal import PNG_BYTES
+
+    parsed_dir = tmp_path / "parsed"
+    parsed_dir.mkdir()
+    for letter in ("A", "B", "C"):
+        (parsed_dir / f"im-{letter}.png").write_bytes(PNG_BYTES)
+
+    blocks_path = parsed_dir / "doc.blocks.jsonl"
+    blocks_path.write_text(
+        json.dumps({"type": "meta", "doc_id": "doc-1"}) + "\n",
+        encoding="utf-8",
+    )
+    sidecar_path = parsed_dir / "doc.drawings.json"
+    sidecar_path.write_text(
+        json.dumps(
+            {
+                "drawings": {
+                    f"im-{letter}": {
+                        "caption": letter,
+                        "path": str(parsed_dir / f"im-{letter}.png"),
+                    }
+                    for letter in ("A", "B", "C")
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    parsed_data = {"blocks_path": str(blocks_path)}
+
+    # Per-call behaviour: call 1 succeeds quickly (~0.05s), call 2 fails
+    # quickly (~0.1s), call 3 would take 5s — we want to prove fail-fast
+    # cancels call 3 rather than wait. Ordering by call_count rather than
+    # by item identifier because the VLM role wrapper does not surface
+    # the item filename in its kwargs (only image_inputs bytes).
+    call_count = {"n": 0}
+    call_lock = asyncio.Lock()
+
+    async def vlm_func(prompt, **kwargs):
+        async with call_lock:
+            call_count["n"] += 1
+            seq = call_count["n"]
+        if seq == 1:
+            await asyncio.sleep(0.05)
+            return json.dumps({"name": "first", "type": "Chart", "description": "ok"})
+        if seq == 2:
+            await asyncio.sleep(0.1)
+            raise MultimodalAnalysisError("forced failure")
+        # 1.2s instead of 5s: still proves fail-fast doesn't wait (test
+        # checks elapsed < 0.8s) but keeps post-analyze cleanup bounded
+        # since the worker keeps running this sleep until completion.
+        await asyncio.sleep(1.2)
+        return json.dumps({"name": "late", "type": "Chart", "description": "late"})
+
+    rag = _build_rag(tmp_path, vlm_func=vlm_func)
+    await rag.initialize_storages()
+    try:
+        pipeline_status: dict = {
+            "busy": True,
+            "history_messages": [],
+            "latest_message": "",
+            "cancellation_requested": False,
+        }
+        pipeline_status_lock = asyncio.Lock()
+
+        start = time.monotonic()
+        with pytest.raises(MultimodalAnalysisError):
+            await asyncio.wait_for(
+                rag.analyze_multimodal(
+                    doc_id="doc-1",
+                    file_path="fixture.pdf",
+                    parsed_data=parsed_data,
+                    process_options="i",
+                    pipeline_status=pipeline_status,
+                    pipeline_status_lock=pipeline_status_lock,
+                ),
+                timeout=15.0,
+            )
+        elapsed = time.monotonic() - start
+
+        # Without fail-fast we'd have waited for the 1.2s sleep on the
+        # third call. 0.8s gives the second-call failure path room
+        # while still catching any regression that waits for call 3.
+        assert elapsed < 0.8, f"fail-fast still waited {elapsed:.2f}s for slow task"
+
+        payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        statuses = sorted(
+            payload["drawings"][f"im-{letter}"]["llm_analyze_result"]["status"]
+            for letter in ("A", "B", "C")
+        )
+        # Three items → one success (call 1), one failure (call 2), and
+        # one cancelled (call 3 was killed by fail-fast). All represented
+        # as failure status_strings except for the success.
+        assert statuses == ["failure", "failure", "success"]
+
+        # Find which item ended up cancelled — its message must say so.
+        cancelled_items = [
+            r["message"]
+            for r in (
+                payload["drawings"][f"im-{letter}"]["llm_analyze_result"]
+                for letter in ("A", "B", "C")
+            )
+            if r["status"] == "failure" and "cancelled" in r["message"]
+        ]
+        assert len(cancelled_items) == 1
+        forced_items = [
+            r["message"]
+            for r in (
+                payload["drawings"][f"im-{letter}"]["llm_analyze_result"]
+                for letter in ("A", "B", "C")
+            )
+            if r["status"] == "failure" and "forced failure" in r["message"]
+        ]
+        assert len(forced_items) == 1
+    finally:
+        await _shutdown_role_workers(rag)
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_analyze_multimodal_pre_schedule_cancellation_skips_task_creation(
+    tmp_path, monkeypatch
+):
+    """``cancellation_requested`` is already True when analyze_multimodal
+    enters the sidecar processing loop. The pre-schedule check must
+    raise immediately, before any per-item VLM task is even constructed
+    — not merely cancel them before the scheduler yields. Covers the
+    small window between ``_analyze_worker``'s boundary check and the
+    per-sidecar task spawn that the polling loop alone would miss.
+
+    Asserts both ``vlm_invocations == 0`` (no work executed) AND that
+    ``asyncio.create_task`` was never called for any
+    ``_run_with_progress_log`` coroutine — distinguishing the
+    early-raise implementation from a poll-then-cancel implementation
+    that would still construct and immediately cancel each task.
+    """
+    from tests.test_pipeline_analyze_multimodal import PNG_BYTES
+
+    parsed_dir = tmp_path / "parsed"
+    parsed_dir.mkdir()
+    image_path = parsed_dir / "im-X.png"
+    image_path.write_bytes(PNG_BYTES)
+    blocks_path = parsed_dir / "doc.blocks.jsonl"
+    blocks_path.write_text(
+        json.dumps({"type": "meta", "doc_id": "doc-1"}) + "\n",
+        encoding="utf-8",
+    )
+    sidecar_path = parsed_dir / "doc.drawings.json"
+    sidecar_path.write_text(
+        json.dumps({"drawings": {"im-X": {"caption": "X", "path": str(image_path)}}}),
+        encoding="utf-8",
+    )
+    parsed_data = {"blocks_path": str(blocks_path)}
+
+    vlm_invocations = 0
+
+    async def tripwire_vlm(prompt, **kwargs):
+        nonlocal vlm_invocations
+        vlm_invocations += 1
+        return json.dumps(
+            {"name": "X", "type": "Chart", "description": "must not be called"}
+        )
+
+    # Spy on asyncio.create_task to count per-item tasks spawned by
+    # analyze_multimodal. The per-item coroutine is _run_with_progress_log
+    # (a closure defined inside analyze_multimodal), so filter by qualname.
+    progress_log_tasks_created = 0
+    original_create_task = asyncio.create_task
+
+    def spy_create_task(coro, *args, **kwargs):
+        nonlocal progress_log_tasks_created
+        name = getattr(coro, "__qualname__", "") or getattr(
+            getattr(coro, "cr_code", None), "co_qualname", ""
+        )
+        if "_run_with_progress_log" in name:
+            progress_log_tasks_created += 1
+        return original_create_task(coro, *args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "create_task", spy_create_task)
+
+    rag = _build_rag(tmp_path, vlm_func=tripwire_vlm)
+    await rag.initialize_storages()
+    try:
+        pipeline_status: dict = {
+            "busy": True,
+            "history_messages": [],
+            "latest_message": "",
+            "cancellation_requested": True,  # set BEFORE the call
+        }
+        pipeline_status_lock = asyncio.Lock()
+
+        with pytest.raises(PipelineCancelledException):
+            await rag.analyze_multimodal(
+                doc_id="doc-1",
+                file_path="fixture.pdf",
+                parsed_data=parsed_data,
+                process_options="i",
+                pipeline_status=pipeline_status,
+                pipeline_status_lock=pipeline_status_lock,
+            )
+
+        # Stronger than "no work ran": the per-item task object was
+        # never even constructed. A poll-then-cancel implementation
+        # would still spawn and cancel — this assertion rules that out.
+        assert progress_log_tasks_created == 0
+        assert vlm_invocations == 0
+    finally:
+        await _shutdown_role_workers(rag)
+        await rag.finalize_storages()


### PR DESCRIPTION
## Summary
- `POST /cancel_pipeline` is now observed by the PARSE (`native`/`mineru`/`docling`) and ANALYZE (multimodal VLM) workers — not just by PROCESS. Documents queued for those stages are marked FAILED with the same `"User cancelled during {stage}: {file}"` message style PROCESS already emits.
- `analyze_multimodal` now fails fast: the first item that raises (or a `cancellation_requested` flip observed by an in-flight poll) cancels every still-running sibling immediately instead of waiting for `asyncio.gather` to drain. Already-completed items keep their `llm_analyze_result` in the sidecar so reprocess hits the LLM cache and avoids re-paying VLM tokens.
- Also fixes a latent bug: a broad `except Exception` near the bottom of `analyze_multimodal` would have swallowed `PipelineCancelledException` and let the doc advance to PROCESS instead of being marked FAILED. Re-raise added.

## Motivation
Without this change, clicking cancel on a job in the middle of a long MinerU/Docling parse, or while multimodal VLM tasks are mid-flight, leaves all queued documents running until they finish naturally. The user is told "cancellation requested" but the pipeline visibly keeps consuming LLM tokens and CPU. PROCESS already cooperatively observes the flag — this PR extends the same contract to the other two stages.

## What's changed

**`lightrag/pipeline.py`**
- New `_cancellation_requested()` (read-only branch check) and `_mark_doc_cancelled_in_stage()` (friendly FAILED message + LLM cache flush, mirroring `_finalize_doc_failure`).
- `_parse_worker` / `_analyze_worker`: boundary check at the top of every loop iteration drains queued items as FAILED; `except PipelineCancelledException` branch routes cancellations surfaced from inside `analyze_multimodal` through the same friendly path.
- `analyze_multimodal`:
  - Replaced `asyncio.gather(return_exceptions=True)` + collect-then-raise with a polling `asyncio.wait(FIRST_EXCEPTION, timeout=0.5s)` loop. Watcher coroutines are intentionally avoided — an unbounded watcher in the same wait set would prevent `FIRST_EXCEPTION` from returning when all items succeed.
  - Pre-schedule `_raise_if_cancelled` so cancellation already set when we enter a sidecar block does not even construct per-item tasks.
  - Empty-task-list guard (`asyncio.wait([])` raises `ValueError`).
  - `task_meta[task] = (item_id, item)` dict mapping replaces `tasks.index()` for result attribution.
  - Preserves completed item results in the sidecar even on fail-fast; flushes `llm_response_cache.index_done_callback()` before raising so `cache_id`s written by already-completed sibling tasks survive a restart.
  - Added `except PipelineCancelledException: raise` before the generic `except Exception` (bug fix described above).

**`tests/test_pipeline_cancellation.py`** (new, 5 cases — all `pytest.mark.offline`)
1. PARSE worker boundary drain — `parse_native` mocked to assert-fail; cancellation set before pull; 3 docs transition to FAILED, `q.join()` returns under 1s.
2. ANALYZE worker boundary drain — symmetric to PARSE.
3. `analyze_multimodal` in-flight cancellation via the poll loop — cancellation flipped 100ms after entry, raise observed within 0.5s budget.
4. `analyze_multimodal` fail-fast — three items where call 1 succeeds, call 2 raises, call 3 would sleep; total elapsed < 0.8s (vs. > 1.2s without fail-fast), sidecar carries one success + one failure + one `"cancelled"`.
5. Pre-schedule cancellation — spies `asyncio.create_task` by `__qualname__` to prove not even a `_run_with_progress_log` task object is constructed (distinguishes early-raise from poll-then-cancel implementations).

## What's broken and how it works

Nothing intentionally broken. Behavioural changes:
- `analyze_multimodal` no longer waits for every sibling item to finish before reporting a single-item failure. Callers that relied on the implicit "wait for all items, then surface first error" should expect a possibly-faster failure.
- Documents queued for PARSE / ANALYZE during a cancellation now transition to `DocStatus.FAILED` with `error_msg = "User cancelled during {parse|analyze}: {file_path}"`. Previously they would silently complete.
- In-flight MinerU/Docling HTTP downloads still run to completion (HTTP client is treated as a black box) — same semantics as the PROCESS stage not cancelling an in-flight LLM call. Cancelling those is left as a follow-up.