### PR TITLE
fix(server): normalize scope.path so Mount works in proxy-strip mode

### DIFF
--- a/docs/MultiSiteDeployment.md
+++ b/docs/MultiSiteDeployment.md
@@ -73,11 +73,20 @@ and in-app links.
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
-| `LIGHTRAG_API_PREFIX` | `""` | Reverse-proxy prefix that the upstream proxy strips before forwarding to FastAPI. Passed to FastAPI as `root_path`. |
+| `LIGHTRAG_API_PREFIX` | `""` | Reverse-proxy mount prefix. The backend accepts both strip and verbatim forwarding — pick whichever fits your proxy stack. Passed to FastAPI as `root_path`. |
 
 The WebUI is always mounted at `/webui` server-side. `window.__LIGHTRAG_CONFIG__.webuiPrefix` is computed as `LIGHTRAG_API_PREFIX + "/webui/"` and injected for the SPA — you do **not** set it yourself.
 
 There are no longer any frontend `VITE_API_PREFIX` / `VITE_WEBUI_PREFIX` variables. Setting them has no effect (they are ignored by the build).
+
+### Forwarding modes: strip and verbatim both work
+
+After setting `LIGHTRAG_API_PREFIX=/site01`, the backend resolves all routes correctly under either forwarding style:
+
+- **Strip** — proxy removes the prefix, backend sees `/webui/` and `/documents/foo`. The nginx example below uses this style.
+- **Verbatim** — proxy forwards the request unchanged, backend sees `/site01/webui/` and `/site01/documents/foo`. The Vite dev flow ([Scenario 2](#scenario-2--simulate-a-site-prefix)) and any non-rewriting proxy use this style.
+
+A small ASGI middleware in `create_app` prepends `root_path` to `scope["path"]` whenever the path does not already include it, so plain Routes and Mount sub-apps (the WebUI's `StaticFiles`) both resolve identically in either mode. You do not need to standardize on one — both coexist on the same backend without configuration toggles.
 
 ---
 

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -2566,6 +2566,7 @@ def main():
         "host": global_args.host,
         "port": global_args.port,
         "log_config": None,  # Disable default config
+        "root_path": global_args.api_prefix if global_args.api_prefix else "", #properly pass api prefix to uvicorn
     }
 
     if global_args.ssl:

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -385,6 +385,60 @@ def _inject_swagger_theme(html: str, theme: str) -> str:
 WEBUI_PATH = "/webui"
 
 
+def _normalize_api_prefix(value: str | None) -> str:
+    """Canonicalize an API prefix before handing it to FastAPI's ``root_path``.
+
+    Strips surrounding whitespace, ensures a leading slash, drops a trailing
+    slash, and treats empty/"/" as "no prefix". Raw CLI/env input like
+    ``"site01"`` or ``"/site01/"`` would otherwise feed an invalid form to
+    FastAPI and to the WebUI prefix injection.
+    """
+    if value is None:
+        return ""
+    value = value.strip()
+    if not value or value == "/":
+        return ""
+    if not value.startswith("/"):
+        value = "/" + value
+    return value.rstrip("/")
+
+
+class _RootPathNormalizationMiddleware:
+    """Make Mount sub-apps work when the reverse proxy strips the API prefix.
+
+    When ``LIGHTRAG_API_PREFIX=/site01`` and nginx strips ``/site01`` before
+    forwarding, the backend sees ``scope["path"]="/webui/"`` while FastAPI's
+    ``__call__`` sets ``scope["root_path"]="/site01"``. Starlette's outer
+    Mount.matches still hits via ``get_route_path`` 's fallback branch (path
+    not starting with root_path is returned unchanged), but it mutates the
+    child scope to ``root_path="/site01/webui"`` without touching
+    ``scope["path"]``. The inner ``StaticFiles.get_path`` then sees a
+    non-overlapping pair and falls through to a literal ``webui`` filename
+    lookup → 404 on the actual file system.
+
+    Prepending ``root_path`` to a non-prefixed ``scope["path"]`` restores the
+    canonical ASGI form (path always contains root_path), matching what a
+    verbatim-forwarding proxy produces natively. Plain Routes are unaffected
+    because their handlers do not redo nested ``get_route_path`` resolution.
+
+    See docs/MultiSiteDeployment.md for the deployment modes this enables.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") in ("http", "websocket"):
+            root_path = scope.get("root_path", "")
+            path = scope.get("path", "")
+            if root_path and not path.startswith(root_path):
+                scope = {**scope, "path": root_path + path}
+                raw_path = scope.get("raw_path")
+                if isinstance(raw_path, (bytes, bytearray)):
+                    scope["raw_path"] = root_path.encode("ascii") + bytes(raw_path)
+        await self.app(scope, receive, send)
+
+
 def _clean_workspace_value(value: Any) -> str | None:
     if value is None:
         return None
@@ -843,20 +897,8 @@ def create_app(args):
         + "\n\n[View ReDoc documentation](/redoc)"
     )
 
-    # Normalize the API prefix from CLI/env. Strip surrounding whitespace,
-    # strip a trailing slash, and treat empty/"/" as "no prefix". A leading
-    # slash is ensured. The WebUI mount path is fixed at "/webui" — see
+    # The WebUI mount path is fixed at "/webui" — see
     # docs/MultiSiteDeployment.md for the rationale.
-    def _normalize_api_prefix(value: str | None) -> str:
-        if value is None:
-            return ""
-        value = value.strip()
-        if not value or value == "/":
-            return ""
-        if not value.startswith("/"):
-            value = "/" + value
-        return value.rstrip("/")
-
     api_prefix = _normalize_api_prefix(getattr(args, "api_prefix", None))
     webui_path = WEBUI_PATH
 
@@ -917,6 +959,13 @@ def create_app(args):
         if origins_str == "*":
             return ["*"]
         return [origin.strip() for origin in origins_str.split(",")]
+
+    # Normalize scope["path"] for proxy-strip deployments so the WebUI
+    # Mount (and any other Mount) routes correctly. Added before CORS so it
+    # runs first in the middleware stack — see _RootPathNormalizationMiddleware
+    # docstring.
+    if api_prefix:
+        app.add_middleware(_RootPathNormalizationMiddleware)
 
     # Add CORS middleware
     app.add_middleware(
@@ -2560,13 +2609,14 @@ def main():
     # Create application instance directly instead of using factory function
     app = create_app(global_args)
 
-    # Start Uvicorn in single process mode
+    # Start Uvicorn in single process mode. Do not pass root_path here;
+    # the prefix lives only on FastAPI's app.root_path. See
+    # docs/MultiSiteDeployment.md.
     uvicorn_config = {
         "app": app,  # Pass application instance directly instead of string path
         "host": global_args.host,
         "port": global_args.port,
         "log_config": None,  # Disable default config
-        "root_path": global_args.api_prefix if global_args.api_prefix else "", #properly pass api prefix to uvicorn
     }
 
     if global_args.ssl:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ api = [
     "aiofiles",
     "ascii_colors",
     "distro",
-    "fastapi",
+    "fastapi>=0.108",  # 0.108 adds FastAPI.__call__ scope["root_path"] override; api_prefix relies on it
     "httpcore",
     "httpx>=0.28.1",
     "jiter",

--- a/tests/test_path_prefixes.py
+++ b/tests/test_path_prefixes.py
@@ -452,3 +452,204 @@ class TestRuntimeConfigInjection:
         cache_control = response.headers.get("cache-control", "")
         assert "no-cache" in cache_control
         assert "no-store" in cache_control
+
+
+class TestUvicornRootPathSemantics:
+    """Lock in the deployment contract that both proxy-strip and verbatim
+    forwarding work through FastAPI's app-level ``root_path`` plus a
+    ``_RootPathNormalizationMiddleware`` — without ever passing
+    ``root_path`` through to uvicorn/gunicorn.
+
+    Background:
+
+      - uvicorn builds ``scope["path"] = uvicorn.root_path + <incoming http
+        path>`` and ``scope["root_path"] = uvicorn.root_path``
+        (uvicorn/protocols/http/h11_impl.py).
+      - FastAPI's ``__call__`` overrides ``scope["root_path"]`` from
+        ``app.root_path`` but does NOT touch ``scope["path"]``
+        (fastapi/applications.py:1131-1134).
+      - Starlette's ``Mount.matches`` mutates the child scope's root_path
+        to ``original + matched_path`` and again leaves ``scope["path"]``
+        untouched (starlette/routing.py:401-432). The inner sub-app
+        (e.g. StaticFiles) then sees ``scope["path"]`` and
+        ``scope["root_path"]`` that do not overlap, and 404s.
+
+    Concrete failure mode without the middleware (proxy strips /site01,
+    backend sees ``/webui/``):
+
+        outer get_route_path:  /webui/ does not start with /site01 → /webui/
+        Mount.matches:         path_regex "^/webui/(?P<path>.*)$" matches
+                               child scope.root_path = /site01/webui
+                               child scope.path      = /webui/  (unchanged)
+        StaticFiles.get_path:  /webui/ does not start with /site01/webui →
+                               returns /webui/ → looked up as filename
+                               "webui" inside the webui static dir → 404
+
+    ``_RootPathNormalizationMiddleware`` runs before routing and prepends
+    ``root_path`` to ``scope["path"]`` whenever the latter does not already
+    start with it. This makes both modes converge to the canonical ASGI
+    form (path always contains root_path) without requiring uvicorn's
+    --root-path — which would break verbatim mode by double-prefixing.
+    """
+
+    @staticmethod
+    async def _call_with_scope(app, http_path, *, uvicorn_root_path=""):
+        """Drive the ASGI app the way uvicorn would.
+
+        Simulates uvicorn's scope construction so we can catch the
+        path-doubling bug that TestClient hides.
+        """
+        full_path = uvicorn_root_path + http_path
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "client": ("testclient", 50000),
+            "root_path": uvicorn_root_path,
+            "path": full_path,
+            "raw_path": full_path.encode("ascii"),
+            "query_string": b"",
+            "headers": [],
+            "state": {},
+        }
+        status = {"code": None}
+
+        async def receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message):
+            if message["type"] == "http.response.start":
+                status["code"] = message["status"]
+
+        await app(scope, receive, send)
+        return status["code"]
+
+    def _build_app_with_prefix(self, prefix):
+        original_argv = sys.argv.copy()
+        try:
+            sys.argv = ["lightrag-server", "--api-prefix", prefix]
+            from lightrag.api.config import parse_args
+            from lightrag.api.lightrag_server import create_app
+
+            args = parse_args()
+            with patch("lightrag.api.lightrag_server.LightRAG") as mock_rag:
+                mock_rag.return_value = MagicMock()
+                return create_app(args)
+        finally:
+            sys.argv = original_argv
+
+    @pytest.mark.asyncio
+    async def test_route_strip_mode_matches(self):
+        """Plain Route, proxy-strip mode: backend receives /openapi.json."""
+        app = self._build_app_with_prefix("/site01")
+        status = await self._call_with_scope(app, "/openapi.json")
+        assert status == 200
+
+    @pytest.mark.asyncio
+    async def test_route_verbatim_mode_matches(self):
+        """Plain Route, verbatim mode: backend receives /site01/openapi.json.
+
+        Locks in the contract that PR #3128's original fix broke: setting
+        uvicorn root_path would have made this case 404 by doubling the
+        prefix in scope["path"].
+        """
+        app = self._build_app_with_prefix("/site01")
+        status = await self._call_with_scope(app, "/site01/openapi.json")
+        assert status == 200
+
+    @pytest.mark.asyncio
+    async def test_mount_strip_mode_matches(self):
+        """WebUI Mount, proxy-strip mode: backend receives /webui/.
+
+        This is the bug the middleware fixes. Without normalization,
+        StaticFiles.get_path sees path=/webui/ and root_path=/site01/webui
+        (mutated by Mount.matches) and serves the literal "webui" filename
+        lookup → 404. With normalization, scope.path becomes
+        /site01/webui/ before routing and the lookup resolves to
+        index.html.
+        """
+        app = self._build_app_with_prefix("/site01")
+        status = await self._call_with_scope(app, "/webui/")
+        assert status == 200
+
+    @pytest.mark.asyncio
+    async def test_mount_verbatim_mode_matches(self):
+        """WebUI Mount, verbatim mode: backend receives /site01/webui/.
+
+        Already canonical; the middleware is a no-op for this case. The
+        test guards against accidentally regressing verbatim while fixing
+        strip — symmetric to test_route_verbatim_mode_matches but exercises
+        the Mount path with its nested ``get_route_path`` resolution.
+        """
+        app = self._build_app_with_prefix("/site01")
+        status = await self._call_with_scope(app, "/site01/webui/")
+        assert status == 200
+
+    @pytest.mark.asyncio
+    async def test_simulated_uvicorn_root_path_breaks_verbatim(self):
+        """Document the failure mode that the revert prevents.
+
+        If uvicorn's root_path were also "/site01", uvicorn would build
+        scope.path = "/site01" + "/site01/openapi.json". Starlette strips
+        one prefix; the remaining "/site01/openapi.json" has no route.
+        """
+        app = self._build_app_with_prefix("/site01")
+        status = await self._call_with_scope(
+            app, "/site01/openapi.json", uvicorn_root_path="/site01"
+        )
+        assert status == 404
+
+    def test_launcher_does_not_pass_root_path_to_uvicorn(self, monkeypatch, tmp_path):
+        """Guard against re-adding root_path to the uvicorn launcher kwargs.
+
+        Mocks uvicorn.run and exercises lightrag_server.main() far enough
+        to capture the config dict, then asserts root_path is absent.
+        """
+        monkeypatch.setenv("LIGHTRAG_API_PREFIX", "/site01")
+        monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+
+        from lightrag.api import lightrag_server
+
+        captured = {}
+
+        def fake_run(**kwargs):
+            captured.update(kwargs)
+
+        monkeypatch.setattr(lightrag_server, "uvicorn", MagicMock(run=fake_run))
+        monkeypatch.setattr(lightrag_server, "check_env_file", lambda: True)
+        monkeypatch.setattr(
+            lightrag_server, "check_and_install_dependencies", lambda: None
+        )
+        monkeypatch.setattr(lightrag_server, "configure_logging", lambda: None)
+        monkeypatch.setattr(lightrag_server, "update_uvicorn_mode_config", lambda: None)
+        monkeypatch.setattr(lightrag_server, "display_splash_screen", lambda *_: None)
+        with patch("lightrag.api.lightrag_server.LightRAG") as mock_rag:
+            mock_rag.return_value = MagicMock()
+            # Re-parse args under the patched env so global_args picks up the prefix.
+            from lightrag.api.config import parse_args, global_args as _ga
+
+            new_args = parse_args()
+            for attr in vars(new_args):
+                setattr(_ga, attr, getattr(new_args, attr))
+
+            lightrag_server.main()
+
+        assert "root_path" not in captured, (
+            "uvicorn_config must not include root_path; rely on FastAPI's "
+            "app-level root_path only — see TestUvicornRootPathSemantics docstring."
+        )
+
+    def test_gunicorn_uses_upstream_uvicorn_worker(self):
+        """Symmetric guard for the multi-worker launcher.
+
+        gunicorn_config.worker_class must remain the upstream
+        ``uvicorn.workers.UvicornWorker`` — a custom subclass injecting
+        root_path via CONFIG_KWARGS would re-introduce the same
+        path-doubling regression in worker processes.
+        """
+        from lightrag.api import gunicorn_config
+
+        assert gunicorn_config.worker_class == "uvicorn.workers.UvicornWorker"


### PR DESCRIPTION
## Description

`LIGHTRAG_API_PREFIX` exists to support deployments where one host serves multiple LightRAG sites behind a reverse proxy. `docs/MultiSiteDeployment.md` documents two compatible flows:

- **proxy-strip mode** (the nginx example at L138-150): the proxy strips `/site01/` and forwards `/webui/` to the backend.
- **verbatim mode** (the Vite dev flow at L279-315): the proxy forwards `/site01/webui/` unchanged.

Both flows must work because Vite dev relies on verbatim forwarding while production nginx examples rely on the strip form.

### The actual bug

Without uvicorn's `root_path` set, **strip mode breaks the WebUI Mount** even though plain Routes still work:

- Backend receives `scope["path"]="/webui/"`, `scope["root_path"]=""`.
- FastAPI's `__call__` overrides `scope["root_path"]="/site01"` (since 0.108).
- Outer `Mount.matches` resolves via `get_route_path`'s fallback (path that does not start with root_path is returned unchanged → `/webui/`), regex hits, and mutates the child scope to `root_path="/site01/webui"` while leaving `scope["path"]` as `/webui/`.
- Inner `StaticFiles.get_path` calls `get_route_path` again: `/webui/` does not start with `/site01/webui` → returns `/webui/` unchanged → `os.path.normpath` turns it into the filename `webui` looked up inside the static dir → 404.

Plain Routes do not chain into a nested `get_route_path`, which is why `/openapi.json` works in strip mode while `/webui/` does not.

The originally reported "redirect drops the prefix" symptom is a different but related issue, and is real on FastAPI < 0.108 (no `scope["root_path"]` override in `__call__`).

### Why PR #3128's original direction was incomplete

Setting uvicorn's `root_path` would have fixed strip mode (it reconstructs the canonical ASGI form where `scope["path"]` always includes `root_path`), but it breaks verbatim mode: uvicorn builds `scope["path"] = root_path + <incoming>`, so a verbatim-forwarded `/site01/webui/` becomes `/site01/site01/webui/` → 404. The two modes are incompatible at the uvicorn config layer.

### What this PR does

A small ASGI middleware (`_RootPathNormalizationMiddleware`) runs before routing and prepends `root_path` to `scope["path"]` iff it does not already start with `root_path`. Both modes converge to the canonical ASGI form without touching uvicorn's config — Mount routing works in both, no doc rewrite needed.

## Changes

- Add `_RootPathNormalizationMiddleware` in `lightrag/api/lightrag_server.py`; wire it into `create_app` before CORS when `api_prefix` is set
- Hoist `_normalize_api_prefix` to module scope (folded in from `7522a909`'s cleanup)
- Pin `fastapi>=0.108` in `pyproject.toml` so the redirect handler's `scope["root_path"]` lookup is always populated
- Drop the original `root_path` line from `lightrag_server.main()`'s uvicorn kwargs
- Add `TestUvicornRootPathSemantics` (7 tests) in `tests/test_path_prefixes.py` covering Route and Mount routing in both deployment modes, plus launcher kwargs and gunicorn worker_class guards

## Manual verification

`LIGHTRAG_API_PREFIX=/site01`, server on `localhost:9621`:

| GET | Before | After |
|---|---|---|
| `/webui/` | 404 | 200 |
| `/site01/webui/` | 200 | 200 |
| `/openapi.json` | 200 | 200 |
| `/site01/openapi.json` | 200 | 200 |

## Related Issues

- [#3039](https://github.com/HKUDS/LightRAG/pull/3039)

## Testing

`tests/test_path_prefixes.py`: 26/26 passing (19 existing + 7 new in `TestUvicornRootPathSemantics`).

## Checklist

- [x] Changes were tested
- [x] Code reviewed
- [x] Documentation reflects the actual fix
- [x] Unit tests added