### PR TITLE
fix(concurrency): wrap ainsert_custom_kg writes with keyed lock (follow-up to #3056)

### DIFF
--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -5747,11 +5747,12 @@ class PGGraphStorage(BaseGraphStorage):
             deduped_edges.pop(edge_key, None)
             deduped_edges[edge_key] = (src, tgt, edge_data)
 
-        # Iterate in canonical (LEAST, GREATEST) order so concurrent
-        # upsert_edges_batch calls always acquire the per-edge advisory locks
-        # in the same global order. Without this, dict insertion-order could
-        # let two batches acquire locks for {A,B} and {C,D} in opposite
-        # sequences and deadlock on each other in PostgreSQL.
+        # Iterate in canonical (LEAST, GREATEST) order rather than dict
+        # insertion order. upsert_edge opens an independent transaction per
+        # call and releases the advisory lock on commit, so this is not a
+        # deadlock fix — but a deterministic iteration order makes logs and
+        # replays reproducible across callers, and matches the dedup key
+        # already used above.
         for edge_key in sorted(deduped_edges):
             src, tgt, edge_data = deduped_edges[edge_key]
             await self.upsert_edge(src, tgt, edge_data=edge_data)

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -5747,7 +5747,13 @@ class PGGraphStorage(BaseGraphStorage):
             deduped_edges.pop(edge_key, None)
             deduped_edges[edge_key] = (src, tgt, edge_data)
 
-        for src, tgt, edge_data in deduped_edges.values():
+        # Iterate in canonical (LEAST, GREATEST) order so concurrent
+        # upsert_edges_batch calls always acquire the per-edge advisory locks
+        # in the same global order. Without this, dict insertion-order could
+        # let two batches acquire locks for {A,B} and {C,D} in opposite
+        # sequences and deadlock on each other in PostgreSQL.
+        for edge_key in sorted(deduped_edges):
+            src, tgt, edge_data = deduped_edges[edge_key]
             await self.upsert_edge(src, tgt, edge_data=edge_data)
 
     async def delete_node(self, node_id: str) -> None:

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -84,6 +84,7 @@ from lightrag.kg.shared_storage import (
     get_default_workspace,
     set_default_workspace,
     get_namespace_lock,
+    get_storage_keyed_lock,
 )
 
 from lightrag.base import (
@@ -1529,10 +1530,6 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 all_entities_data.append(node_data_copy)
                 update_storage = True
 
-            # Batch insert entities (reduces N serial awaits to 1)
-            if entity_nodes:
-                await self.chunk_entity_relation_graph.upsert_nodes_batch(entity_nodes)
-
             # Relationship storage is undirected, so keep only the last update
             # for each endpoint pair regardless of order.
             deduped_relationships: dict[tuple[str, str], dict[str, Any]] = {}
@@ -1543,130 +1540,172 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 deduped_relationships.pop(relation_key, None)
                 deduped_relationships[relation_key] = relationship_data
 
-            # Insert relationships into knowledge graph (batch for performance)
-            all_relationships_data: list[dict[str, str]] = []
-            edge_list: list[tuple[str, str, dict[str, str]]] = []
-
-            # Batch check which relationship endpoints exist (1 await instead of 2M)
-            needed_node_ids: set[str] = set()
+            # Coarse-grained keyed lock covering every entity that this batch
+            # touches — entity nodes, every relationship endpoint, and any
+            # placeholder nodes we'll auto-create. The doc-ingest pipeline
+            # (operate.py:_locked_process_edges / _locked_process_entity_name)
+            # locks the same namespace per-entity / per-edge-pair; sharing the
+            # namespace lets a concurrent insert_custom_kg block on those
+            # locks instead of racing them. Two concurrent custom-KG inserts
+            # of the same (src, tgt) likewise collide on the endpoint locks.
+            #
+            # Falls back to a coarse single-entity name when the batch is empty
+            # of entities and edges so the with-block still has a valid key.
+            lock_key_set: set[str] = {entity_name for entity_name, _ in entity_nodes}
             for relationship_data in deduped_relationships.values():
-                needed_node_ids.add(relationship_data["src_id"])
-                needed_node_ids.add(relationship_data["tgt_id"])
+                lock_key_set.add(relationship_data["src_id"])
+                lock_key_set.add(relationship_data["tgt_id"])
 
-            existing_nodes = await self.chunk_entity_relation_graph.has_nodes_batch(
-                list(needed_node_ids)
-            )
+            workspace = self.workspace or ""
+            namespace = f"{workspace}:GraphDB" if workspace else "GraphDB"
 
-            # Create missing nodes in batch
-            missing_nodes: list[tuple[str, dict[str, str]]] = []
-            for relationship_data in deduped_relationships.values():
-                src_id = relationship_data["src_id"]
-                tgt_id = relationship_data["tgt_id"]
-                source_chunk_id = relationship_data.get("source_id", "UNKNOWN")
-                source_id = chunk_to_source_map.get(source_chunk_id, "UNKNOWN")
-                file_path = normalize_document_file_path(
-                    relationship_data.get("file_path", "custom_kg")
-                )
-
-                if source_id == "UNKNOWN":
-                    logger.warning(
-                        f"Relationship from '{src_id}' to '{tgt_id}' has an UNKNOWN source_id. Please check the source mapping."
+            async def _do_graph_and_vdb_writes() -> None:
+                # Batch insert entities (reduces N serial awaits to 1)
+                if entity_nodes:
+                    await self.chunk_entity_relation_graph.upsert_nodes_batch(
+                        entity_nodes
                     )
 
-                for need_insert_id in [src_id, tgt_id]:
-                    if need_insert_id not in existing_nodes:
-                        missing_nodes.append(
-                            (
-                                need_insert_id,
-                                {
-                                    "entity_id": need_insert_id,
-                                    "source_id": source_id,
-                                    "description": "UNKNOWN",
-                                    "entity_type": "UNKNOWN",
-                                    "file_path": file_path,
-                                    "created_at": int(time.time()),
-                                },
-                            )
+                # Insert relationships into knowledge graph (batch for performance)
+                all_relationships_data: list[dict[str, str]] = []
+                edge_list: list[tuple[str, str, dict[str, str]]] = []
+
+                # Batch check which relationship endpoints exist (1 await instead of 2M)
+                needed_node_ids: set[str] = set()
+                for relationship_data in deduped_relationships.values():
+                    needed_node_ids.add(relationship_data["src_id"])
+                    needed_node_ids.add(relationship_data["tgt_id"])
+
+                existing_nodes = await self.chunk_entity_relation_graph.has_nodes_batch(
+                    list(needed_node_ids)
+                )
+
+                # Create missing nodes in batch
+                missing_nodes: list[tuple[str, dict[str, str]]] = []
+                for relationship_data in deduped_relationships.values():
+                    src_id = relationship_data["src_id"]
+                    tgt_id = relationship_data["tgt_id"]
+                    source_chunk_id = relationship_data.get("source_id", "UNKNOWN")
+                    source_id = chunk_to_source_map.get(source_chunk_id, "UNKNOWN")
+                    file_path = normalize_document_file_path(
+                        relationship_data.get("file_path", "custom_kg")
+                    )
+
+                    if source_id == "UNKNOWN":
+                        logger.warning(
+                            f"Relationship from '{src_id}' to '{tgt_id}' has an UNKNOWN source_id. Please check the source mapping."
                         )
-                        existing_nodes.add(need_insert_id)
 
-                normalized_src_id, normalized_tgt_id = sorted((src_id, tgt_id))
+                    for need_insert_id in [src_id, tgt_id]:
+                        if need_insert_id not in existing_nodes:
+                            missing_nodes.append(
+                                (
+                                    need_insert_id,
+                                    {
+                                        "entity_id": need_insert_id,
+                                        "source_id": source_id,
+                                        "description": "UNKNOWN",
+                                        "entity_type": "UNKNOWN",
+                                        "file_path": file_path,
+                                        "created_at": int(time.time()),
+                                    },
+                                )
+                            )
+                            existing_nodes.add(need_insert_id)
 
-                edge_data = {
-                    "weight": relationship_data.get("weight", 1.0),
-                    "description": relationship_data["description"],
-                    "keywords": relationship_data["keywords"],
-                    "source_id": source_id,
-                    "file_path": file_path,
-                    "created_at": int(time.time()),
-                }
-                edge_list.append((src_id, tgt_id, edge_data))
+                    normalized_src_id, normalized_tgt_id = sorted((src_id, tgt_id))
 
-                all_relationships_data.append(
-                    {
-                        "src_id": normalized_src_id,
-                        "tgt_id": normalized_tgt_id,
+                    edge_data = {
+                        "weight": relationship_data.get("weight", 1.0),
                         "description": relationship_data["description"],
                         "keywords": relationship_data["keywords"],
                         "source_id": source_id,
-                        "weight": relationship_data.get("weight", 1.0),
                         "file_path": file_path,
                         "created_at": int(time.time()),
                     }
-                )
-                update_storage = True
+                    edge_list.append((src_id, tgt_id, edge_data))
 
-            # Batch insert missing placeholder nodes
-            if missing_nodes:
-                await self.chunk_entity_relation_graph.upsert_nodes_batch(missing_nodes)
+                    all_relationships_data.append(
+                        {
+                            "src_id": normalized_src_id,
+                            "tgt_id": normalized_tgt_id,
+                            "description": relationship_data["description"],
+                            "keywords": relationship_data["keywords"],
+                            "source_id": source_id,
+                            "weight": relationship_data.get("weight", 1.0),
+                            "file_path": file_path,
+                            "created_at": int(time.time()),
+                        }
+                    )
 
-            # Batch insert edges
-            if edge_list:
-                await self.chunk_entity_relation_graph.upsert_edges_batch(edge_list)
+                # Batch insert missing placeholder nodes
+                if missing_nodes:
+                    await self.chunk_entity_relation_graph.upsert_nodes_batch(
+                        missing_nodes
+                    )
 
-            # Insert entities and relationships into vector storage (parallel)
-            data_for_entities_vdb = {
-                compute_mdhash_id(dp["entity_name"], prefix="ent-"): {
-                    "content": dp["entity_name"] + "\n" + dp["description"],
-                    "entity_name": dp["entity_name"],
-                    "source_id": dp["source_id"],
-                    "description": dp["description"],
-                    "entity_type": dp["entity_type"],
-                    "file_path": dp.get("file_path", "custom_kg"),
+                # Batch insert edges
+                if edge_list:
+                    await self.chunk_entity_relation_graph.upsert_edges_batch(edge_list)
+
+                # Insert entities and relationships into vector storage (parallel)
+                data_for_entities_vdb = {
+                    compute_mdhash_id(dp["entity_name"], prefix="ent-"): {
+                        "content": dp["entity_name"] + "\n" + dp["description"],
+                        "entity_name": dp["entity_name"],
+                        "source_id": dp["source_id"],
+                        "description": dp["description"],
+                        "entity_type": dp["entity_type"],
+                        "file_path": dp.get("file_path", "custom_kg"),
+                    }
+                    for dp in all_entities_data
                 }
-                for dp in all_entities_data
-            }
 
-            data_for_rels_vdb = {
-                compute_mdhash_id(dp["src_id"] + dp["tgt_id"], prefix="rel-"): {
-                    "src_id": dp["src_id"],
-                    "tgt_id": dp["tgt_id"],
-                    "source_id": dp["source_id"],
-                    "content": f"{dp['keywords']}\t{dp['src_id']}\n{dp['tgt_id']}\n{dp['description']}",
-                    "keywords": dp["keywords"],
-                    "description": dp["description"],
-                    "weight": dp["weight"],
-                    "file_path": dp.get("file_path", "custom_kg"),
-                }
-                for dp in all_relationships_data
-            }
-
-            legacy_rel_ids_to_delete = sorted(
-                {
-                    rel_id
+                data_for_rels_vdb = {
+                    compute_mdhash_id(dp["src_id"] + dp["tgt_id"], prefix="rel-"): {
+                        "src_id": dp["src_id"],
+                        "tgt_id": dp["tgt_id"],
+                        "source_id": dp["source_id"],
+                        "content": f"{dp['keywords']}\t{dp['src_id']}\n{dp['tgt_id']}\n{dp['description']}",
+                        "keywords": dp["keywords"],
+                        "description": dp["description"],
+                        "weight": dp["weight"],
+                        "file_path": dp.get("file_path", "custom_kg"),
+                    }
                     for dp in all_relationships_data
-                    for rel_id in make_relation_vdb_ids(dp["src_id"], dp["tgt_id"])[1:]
                 }
-            )
 
-            # Parallel VDB upserts (was serial in original)
-            await asyncio.gather(
-                self.entities_vdb.upsert(data_for_entities_vdb),
-                self.relationships_vdb.upsert(data_for_rels_vdb),
-            )
+                legacy_rel_ids_to_delete = sorted(
+                    {
+                        rel_id
+                        for dp in all_relationships_data
+                        for rel_id in make_relation_vdb_ids(dp["src_id"], dp["tgt_id"])[
+                            1:
+                        ]
+                    }
+                )
 
-            if legacy_rel_ids_to_delete:
-                await self.relationships_vdb.delete(legacy_rel_ids_to_delete)
+                # Parallel VDB upserts (was serial in original)
+                await asyncio.gather(
+                    self.entities_vdb.upsert(data_for_entities_vdb),
+                    self.relationships_vdb.upsert(data_for_rels_vdb),
+                )
+
+                if legacy_rel_ids_to_delete:
+                    await self.relationships_vdb.delete(legacy_rel_ids_to_delete)
+
+            if lock_key_set:
+                if entity_nodes or deduped_relationships:
+                    update_storage = True
+                async with get_storage_keyed_lock(
+                    sorted(lock_key_set),
+                    namespace=namespace,
+                    enable_logging=False,
+                ):
+                    await _do_graph_and_vdb_writes()
+            else:
+                # No entities, no relationships — nothing to serialise on.
+                await _do_graph_and_vdb_writes()
 
         except Exception as e:
             logger.error(f"Error in ainsert_custom_kg: {e}")

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1540,17 +1540,15 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 deduped_relationships.pop(relation_key, None)
                 deduped_relationships[relation_key] = relationship_data
 
-            # Coarse-grained keyed lock covering every entity that this batch
-            # touches — entity nodes, every relationship endpoint, and any
-            # placeholder nodes we'll auto-create. The doc-ingest pipeline
-            # (operate.py:_locked_process_edges / _locked_process_entity_name)
-            # locks the same namespace per-entity / per-edge-pair; sharing the
-            # namespace lets a concurrent insert_custom_kg block on those
-            # locks instead of racing them. Two concurrent custom-KG inserts
-            # of the same (src, tgt) likewise collide on the endpoint locks.
-            #
-            # Falls back to a coarse single-entity name when the batch is empty
-            # of entities and edges so the with-block still has a valid key.
+            # Coarse-grained keyed lock covering every entity name and every
+            # relationship endpoint this batch will write. Keys collide with
+            # the per-entity and sorted([src, tgt]) edge locks held by the
+            # doc-ingest pipeline (operate.py:_locked_process_entity_name and
+            # _locked_process_edges) in the same namespace, so a concurrent
+            # insert_custom_kg waits behind an in-flight document ingest
+            # rather than racing it. Two concurrent custom-KG inserts that
+            # touch overlapping entities likewise mutually exclude here.
+            # An empty batch skips the lock entirely — nothing to serialise on.
             lock_key_set: set[str] = {entity_name for entity_name, _ in entity_nodes}
             for relationship_data in deduped_relationships.values():
                 lock_key_set.add(relationship_data["src_id"])

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -86,8 +86,32 @@ async def adelete_by_entity(
     # Use keyed lock for entity to ensure atomic graph and vector db operations
     workspace = entities_vdb.global_config.get("workspace", "")
     namespace = f"{workspace}:GraphDB" if workspace else "GraphDB"
+
+    # delete_node() detaches every incident edge, so the lock set must cover
+    # every (entity_name, other) endpoint — otherwise the doc-ingest pipeline
+    # (which locks edges under sorted([src, tgt]) keys) lives in a disjoint
+    # partition and can race against this delete on the same edge.
+    #
+    # A short race window exists between this pre-fetch and lock acquisition;
+    # the storage-layer advisory lock in upsert_edge is the final safety net
+    # against duplicate DIRECTED rows for edges that appear in that window.
+    lock_key_set: set[str] = {entity_name}
+    try:
+        prefetched_edges = await chunk_entity_relation_graph.get_node_edges(entity_name)
+    except Exception as edge_fetch_error:
+        logger.warning(
+            f"Entity Delete: failed to pre-fetch edges for `{entity_name}` "
+            f"(lock-set extension): {edge_fetch_error}"
+        )
+        prefetched_edges = None
+    if prefetched_edges:
+        for src, tgt in prefetched_edges:
+            lock_key_set.add(src)
+            lock_key_set.add(tgt)
+    lock_keys = sorted(lock_key_set)
+
     async with get_storage_keyed_lock(
-        [entity_name], namespace=namespace, enable_logging=False
+        lock_keys, namespace=namespace, enable_logging=False
     ):
         try:
             # Check if the entity exists
@@ -99,7 +123,8 @@ async def adelete_by_entity(
                     message=f"Entity '{entity_name}' not found.",
                     status_code=404,
                 )
-            # Retrieve related relationships before deleting the node
+            # Re-fetch related relationships inside the lock so the count and
+            # downstream cleanup reflect any edges added during the race window.
             edges = await chunk_entity_relation_graph.get_node_edges(entity_name)
             related_relations_count = len(edges) if edges else 0
 
@@ -585,10 +610,39 @@ async def aedit_entity(
     new_entity_name = updated_data.get("entity_name", entity_name)
     is_renaming = new_entity_name != entity_name
 
-    lock_keys = sorted({entity_name, new_entity_name}) if is_renaming else [entity_name]
-
     workspace = entities_vdb.global_config.get("workspace", "")
     namespace = f"{workspace}:GraphDB" if workspace else "GraphDB"
+
+    # When renaming, _edit_entity_impl rewrites every (entity_name, other)
+    # edge as (new_entity_name, other). The doc-ingest pipeline locks edges
+    # under sorted([src, tgt]) keys (operate.py:_locked_process_edges), so a
+    # lock set of just {entity_name, new_entity_name} lives in a disjoint
+    # partition from the per-edge locks and can race against concurrent edge
+    # writes. Pre-fetch the edges here, extend the lock set to cover every
+    # other endpoint, and acquire all keys atomically.
+    #
+    # A short race window exists between this pre-fetch and lock acquisition:
+    # a new edge might appear whose other endpoint is not in lock_keys. The
+    # storage-layer advisory lock inside PGGraphStorage.upsert_edge is the
+    # final safety net against duplicate DIRECTED rows in that case, and the
+    # rename loop re-fetches edges inside the lock anyway.
+    lock_key_set: set[str] = {entity_name, new_entity_name}
+    if is_renaming:
+        try:
+            prefetched_edges = await chunk_entity_relation_graph.get_node_edges(
+                entity_name
+            )
+        except Exception as edge_fetch_error:
+            logger.warning(
+                f"Entity Edit: failed to pre-fetch edges for `{entity_name}` "
+                f"(rename lock-set extension): {edge_fetch_error}"
+            )
+            prefetched_edges = None
+        if prefetched_edges:
+            for src, tgt in prefetched_edges:
+                lock_key_set.add(src)
+                lock_key_set.add(tgt)
+    lock_keys = sorted(lock_key_set) if is_renaming else [entity_name]
 
     operation_summary: dict[str, Any] = {
         "merged": False,

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -83,35 +83,15 @@ async def adelete_by_entity(
         entity_chunks_storage: Optional KV storage for tracking chunks that reference this entity
         relation_chunks_storage: Optional KV storage for tracking chunks that reference relations
     """
-    # Use keyed lock for entity to ensure atomic graph and vector db operations
+    # Use keyed lock for entity to ensure atomic graph and vector db operations.
+    # The doc-ingest pipeline locks edges under sorted([src, tgt]) in this same
+    # namespace, so [entity_name] already mutually excludes any concurrent edge
+    # write that touches this entity — get_storage_keyed_lock acquires one
+    # mutex per key, and identical key strings share the same mutex.
     workspace = entities_vdb.global_config.get("workspace", "")
     namespace = f"{workspace}:GraphDB" if workspace else "GraphDB"
-
-    # delete_node() detaches every incident edge, so the lock set must cover
-    # every (entity_name, other) endpoint — otherwise the doc-ingest pipeline
-    # (which locks edges under sorted([src, tgt]) keys) lives in a disjoint
-    # partition and can race against this delete on the same edge.
-    #
-    # A short race window exists between this pre-fetch and lock acquisition;
-    # the storage-layer advisory lock in upsert_edge is the final safety net
-    # against duplicate DIRECTED rows for edges that appear in that window.
-    lock_key_set: set[str] = {entity_name}
-    try:
-        prefetched_edges = await chunk_entity_relation_graph.get_node_edges(entity_name)
-    except Exception as edge_fetch_error:
-        logger.warning(
-            f"Entity Delete: failed to pre-fetch edges for `{entity_name}` "
-            f"(lock-set extension): {edge_fetch_error}"
-        )
-        prefetched_edges = None
-    if prefetched_edges:
-        for src, tgt in prefetched_edges:
-            lock_key_set.add(src)
-            lock_key_set.add(tgt)
-    lock_keys = sorted(lock_key_set)
-
     async with get_storage_keyed_lock(
-        lock_keys, namespace=namespace, enable_logging=False
+        [entity_name], namespace=namespace, enable_logging=False
     ):
         try:
             # Check if the entity exists
@@ -123,8 +103,7 @@ async def adelete_by_entity(
                     message=f"Entity '{entity_name}' not found.",
                     status_code=404,
                 )
-            # Re-fetch related relationships inside the lock so the count and
-            # downstream cleanup reflect any edges added during the race window.
+            # Retrieve related relationships before deleting the node
             edges = await chunk_entity_relation_graph.get_node_edges(entity_name)
             related_relations_count = len(edges) if edges else 0
 
@@ -610,39 +589,15 @@ async def aedit_entity(
     new_entity_name = updated_data.get("entity_name", entity_name)
     is_renaming = new_entity_name != entity_name
 
+    # Lock the (old, new) entity names. The doc-ingest pipeline acquires
+    # edge locks as sorted([src, tgt]) in the same namespace, and
+    # get_storage_keyed_lock takes one mutex per key — so locking the
+    # entity name already mutually excludes any concurrent edge write that
+    # touches it, no need to enumerate incident edges here.
+    lock_keys = sorted({entity_name, new_entity_name}) if is_renaming else [entity_name]
+
     workspace = entities_vdb.global_config.get("workspace", "")
     namespace = f"{workspace}:GraphDB" if workspace else "GraphDB"
-
-    # When renaming, _edit_entity_impl rewrites every (entity_name, other)
-    # edge as (new_entity_name, other). The doc-ingest pipeline locks edges
-    # under sorted([src, tgt]) keys (operate.py:_locked_process_edges), so a
-    # lock set of just {entity_name, new_entity_name} lives in a disjoint
-    # partition from the per-edge locks and can race against concurrent edge
-    # writes. Pre-fetch the edges here, extend the lock set to cover every
-    # other endpoint, and acquire all keys atomically.
-    #
-    # A short race window exists between this pre-fetch and lock acquisition:
-    # a new edge might appear whose other endpoint is not in lock_keys. The
-    # storage-layer advisory lock inside PGGraphStorage.upsert_edge is the
-    # final safety net against duplicate DIRECTED rows in that case, and the
-    # rename loop re-fetches edges inside the lock anyway.
-    lock_key_set: set[str] = {entity_name, new_entity_name}
-    if is_renaming:
-        try:
-            prefetched_edges = await chunk_entity_relation_graph.get_node_edges(
-                entity_name
-            )
-        except Exception as edge_fetch_error:
-            logger.warning(
-                f"Entity Edit: failed to pre-fetch edges for `{entity_name}` "
-                f"(rename lock-set extension): {edge_fetch_error}"
-            )
-            prefetched_edges = None
-        if prefetched_edges:
-            for src, tgt in prefetched_edges:
-                lock_key_set.add(src)
-                lock_key_set.add(tgt)
-    lock_keys = sorted(lock_key_set) if is_renaming else [entity_name]
 
     operation_summary: dict[str, Any] = {
         "merged": False,

--- a/tests/test_graph_keyed_locks.py
+++ b/tests/test_graph_keyed_locks.py
@@ -1,0 +1,436 @@
+"""
+Regression tests for the keyed-lock extension on entity-mutation paths.
+
+`aedit_entity` (rename) and `adelete_by_entity` both rewrite or detach every
+incident edge of the target entity. The doc-ingest pipeline
+(`operate.py:_locked_process_edges`) locks edges under `sorted([src, tgt])`
+keys, so a lock set of only {entity_name} (or {entity_name, new_entity_name})
+lives in a disjoint partition from those per-edge locks and would race against
+concurrent edge writes.
+
+The fix pre-fetches each entity's edges outside the lock, extends the lock
+set to cover every other endpoint, and acquires all keys atomically. These
+tests pin the extension by spying on `get_storage_keyed_lock` and asserting
+the `keys` argument it receives.
+"""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_keyed_lock_spy():
+    """Return (spy_callable, captured_calls_list).
+
+    The spy returns an async context manager so `async with get_storage_keyed_lock(...)`
+    just yields. Each invocation appends {"keys": ..., "namespace": ...} to the
+    captured list.
+    """
+    captured: list[dict] = []
+
+    @asynccontextmanager
+    async def _noop_lock():
+        yield
+
+    def spy(keys, namespace="default", enable_logging=False):
+        captured.append({"keys": list(keys), "namespace": namespace})
+        return _noop_lock()
+
+    return spy, captured
+
+
+def _make_graph_mock(
+    edges_for_entity: list[tuple[str, str]],
+    *,
+    existing_entity: str = "X",
+):
+    """Minimal `chunk_entity_relation_graph` mock for aedit / adelete.
+
+    `has_node` returns True only for `existing_entity` so a rename target
+    (e.g. "Y") is treated as not-yet-existing — otherwise aedit_entity would
+    short-circuit with "Entity name 'Y' already exists" before reaching the
+    upsert path.
+    """
+    graph = MagicMock()
+    graph.get_node_edges = AsyncMock(return_value=edges_for_entity)
+    graph.has_node = AsyncMock(side_effect=lambda name: name == existing_entity)
+    graph.get_node = AsyncMock(
+        return_value={
+            "entity_id": existing_entity,
+            "description": "old description",
+            "entity_type": "PERSON",
+            "source_id": "chunk-1",
+            "file_path": "test.txt",
+        }
+    )
+    graph.upsert_node = AsyncMock(return_value=None)
+    graph.upsert_edge = AsyncMock(return_value=None)
+    graph.upsert_nodes_batch = AsyncMock(return_value=None)
+    graph.upsert_edges_batch = AsyncMock(return_value=None)
+    graph.has_nodes_batch = AsyncMock(return_value=set())
+    graph.delete_node = AsyncMock(return_value=None)
+    graph.get_edge = AsyncMock(
+        return_value={
+            "weight": 1.0,
+            "description": "rel",
+            "keywords": "k",
+            "source_id": "chunk-1",
+            "file_path": "test.txt",
+            "created_at": 0,
+        }
+    )
+    graph.index_done_callback = AsyncMock(return_value=None)
+    return graph
+
+
+def _make_vdb_mock(workspace: str = ""):
+    vdb = MagicMock()
+    vdb.global_config = {"workspace": workspace}
+    vdb.upsert = AsyncMock(return_value=None)
+    vdb.delete = AsyncMock(return_value=None)
+    vdb.delete_entity = AsyncMock(return_value=None)
+    vdb.delete_entity_relation = AsyncMock(return_value=None)
+    vdb.index_done_callback = AsyncMock(return_value=None)
+    vdb.client_storage = MagicMock()
+    return vdb
+
+
+# ---------------------------------------------------------------------------
+# aedit_entity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aedit_entity_rename_locks_extend_to_edge_endpoints():
+    """When renaming X -> Y, the lock set must include every other endpoint
+    of X's edges (A, B in this fixture), not just {X, Y}.
+
+    Without this, the doc-ingest pipeline can hold sorted([X, A]) or
+    sorted([Y, A]) edge locks at the same time aedit_entity is rewriting
+    those edges, since {X, Y} and sorted([X, A]) live in disjoint key
+    partitions within the same namespace.
+    """
+    from lightrag import utils_graph
+
+    spy, captured = _make_keyed_lock_spy()
+    graph = _make_graph_mock(edges_for_entity=[("X", "A"), ("B", "X")])
+    entities_vdb = _make_vdb_mock(workspace="ws1")
+    relationships_vdb = _make_vdb_mock(workspace="ws1")
+
+    # Stop the actual edit work from running too far — we only care about the
+    # lock arguments. Patching get_node also blocks _edit_entity_impl from
+    # walking past the lock with a sentinel exception that we catch below.
+    sentinel = RuntimeError("stop after lock acquisition")
+    graph.upsert_node.side_effect = sentinel
+
+    with patch.object(utils_graph, "get_storage_keyed_lock", spy):
+        with pytest.raises(RuntimeError, match="stop after lock acquisition"):
+            await utils_graph.aedit_entity(
+                chunk_entity_relation_graph=graph,
+                entities_vdb=entities_vdb,
+                relationships_vdb=relationships_vdb,
+                entity_name="X",
+                updated_data={"entity_name": "Y", "description": "renamed"},
+                allow_rename=True,
+            )
+
+    # Exactly one lock acquisition happened.
+    assert len(captured) == 1
+    call = captured[0]
+
+    # Namespace pinned to workspace-aware form.
+    assert call["namespace"] == "ws1:GraphDB"
+
+    # Keys: {X, Y} ∪ {A, B} from get_node_edges, sorted.
+    assert call["keys"] == ["A", "B", "X", "Y"]
+
+
+@pytest.mark.asyncio
+async def test_aedit_entity_non_rename_keeps_single_entity_lock():
+    """Non-rename edits don't touch edges, so the lock set stays at just the
+    entity name — no need to extend or pre-fetch edges."""
+    from lightrag import utils_graph
+
+    spy, captured = _make_keyed_lock_spy()
+    graph = _make_graph_mock(edges_for_entity=[])
+    entities_vdb = _make_vdb_mock(workspace="")
+    relationships_vdb = _make_vdb_mock(workspace="")
+
+    sentinel = RuntimeError("stop after lock acquisition")
+    graph.upsert_node.side_effect = sentinel
+
+    with patch.object(utils_graph, "get_storage_keyed_lock", spy):
+        with pytest.raises(RuntimeError, match="stop after lock acquisition"):
+            await utils_graph.aedit_entity(
+                chunk_entity_relation_graph=graph,
+                entities_vdb=entities_vdb,
+                relationships_vdb=relationships_vdb,
+                entity_name="X",
+                updated_data={"description": "updated"},
+                allow_rename=False,
+            )
+
+    assert len(captured) == 1
+    assert captured[0]["keys"] == ["X"]
+    # Empty workspace falls back to the bare "GraphDB" namespace.
+    assert captured[0]["namespace"] == "GraphDB"
+
+    # No need to pre-fetch edges when not renaming — the implementation only
+    # walks get_node_edges inside the rename branch.
+    graph.get_node_edges.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_aedit_entity_rename_tolerates_edge_fetch_failure():
+    """If pre-fetching edges fails (storage hiccup), the rename still
+    proceeds with the narrower {entity, new_entity} lock set, logging a
+    warning. The PG advisory lock is the final safety net here."""
+    from lightrag import utils_graph
+
+    spy, captured = _make_keyed_lock_spy()
+    graph = _make_graph_mock(edges_for_entity=[])
+    graph.get_node_edges.side_effect = RuntimeError("simulated storage error")
+    entities_vdb = _make_vdb_mock(workspace="")
+    relationships_vdb = _make_vdb_mock(workspace="")
+
+    sentinel = RuntimeError("stop after lock acquisition")
+    graph.upsert_node.side_effect = sentinel
+
+    with patch.object(utils_graph, "get_storage_keyed_lock", spy):
+        with pytest.raises(RuntimeError, match="stop after lock acquisition"):
+            await utils_graph.aedit_entity(
+                chunk_entity_relation_graph=graph,
+                entities_vdb=entities_vdb,
+                relationships_vdb=relationships_vdb,
+                entity_name="X",
+                updated_data={"entity_name": "Y", "description": "renamed"},
+                allow_rename=True,
+            )
+
+    assert len(captured) == 1
+    # Falls back to the narrow set when pre-fetch fails.
+    assert captured[0]["keys"] == ["X", "Y"]
+
+
+# ---------------------------------------------------------------------------
+# adelete_by_entity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_adelete_by_entity_locks_extend_to_edge_endpoints():
+    """`delete_node` detaches every incident edge, so the lock set must
+    include every other endpoint."""
+    from lightrag import utils_graph
+
+    spy, captured = _make_keyed_lock_spy()
+    graph = _make_graph_mock(edges_for_entity=[("X", "Y"), ("Z", "X")])
+    entities_vdb = _make_vdb_mock(workspace="ws1")
+    relationships_vdb = _make_vdb_mock(workspace="ws1")
+
+    with patch.object(utils_graph, "get_storage_keyed_lock", spy):
+        result = await utils_graph.adelete_by_entity(
+            chunk_entity_relation_graph=graph,
+            entities_vdb=entities_vdb,
+            relationships_vdb=relationships_vdb,
+            entity_name="X",
+        )
+
+    # Deletion ran to completion since all mocks return defaults.
+    assert result.status == "success"
+
+    assert len(captured) == 1
+    call = captured[0]
+    assert call["namespace"] == "ws1:GraphDB"
+    # {X} ∪ {Y, Z} from get_node_edges (called pre-lock for set extension), sorted.
+    assert call["keys"] == ["X", "Y", "Z"]
+
+    # get_node_edges is called twice: once pre-lock (for set extension), once
+    # inside the lock (the authoritative read used by the cleanup code).
+    assert graph.get_node_edges.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_adelete_by_entity_tolerates_edge_fetch_failure():
+    """Pre-fetch failure falls back to the narrow {entity_name} lock; the
+    delete still proceeds via the second (inside-lock) get_node_edges."""
+    from lightrag import utils_graph
+
+    spy, captured = _make_keyed_lock_spy()
+    graph = _make_graph_mock(edges_for_entity=[("X", "Y")])
+
+    call_outcomes = [RuntimeError("simulated storage error"), [("X", "Y")]]
+
+    async def flaky_get_node_edges(_name):
+        outcome = call_outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    graph.get_node_edges = AsyncMock(side_effect=flaky_get_node_edges)
+    entities_vdb = _make_vdb_mock(workspace="")
+    relationships_vdb = _make_vdb_mock(workspace="")
+
+    with patch.object(utils_graph, "get_storage_keyed_lock", spy):
+        result = await utils_graph.adelete_by_entity(
+            chunk_entity_relation_graph=graph,
+            entities_vdb=entities_vdb,
+            relationships_vdb=relationships_vdb,
+            entity_name="X",
+        )
+
+    assert result.status == "success"
+    assert len(captured) == 1
+    # Narrow fallback when pre-fetch fails.
+    assert captured[0]["keys"] == ["X"]
+
+
+# ---------------------------------------------------------------------------
+# ainsert_custom_kg
+# ---------------------------------------------------------------------------
+
+
+class _AbortOnEnterLock:
+    """Async context manager that captures lock args and aborts on __aenter__.
+
+    Lets the test inspect the lock_keys argument without having to mock every
+    downstream storage operation that would run inside the with-block.
+    """
+
+    def __init__(self):
+        self.captured: list[dict] = []
+
+    def __call__(self, keys, namespace="default", enable_logging=False):
+        self.captured.append({"keys": list(keys), "namespace": namespace})
+        return self
+
+    async def __aenter__(self):
+        raise _LockCaptured("captured")
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _LockCaptured(RuntimeError):
+    """Sentinel raised from the captured lock context to short-circuit the
+    enclosing async with block."""
+
+
+@pytest.mark.asyncio
+async def test_ainsert_custom_kg_locks_extend_to_every_endpoint():
+    """ainsert_custom_kg must hold a single coarse-grained keyed lock whose
+    key set covers every entity name plus every relationship endpoint in the
+    batch — sharing the namespace with the doc-ingest pipeline so a
+    concurrent insert_custom_kg call on overlapping entities serialises
+    properly instead of racing.
+    """
+    from lightrag import lightrag as lightrag_module
+    from lightrag.lightrag import LightRAG
+
+    # Build a bare LightRAG shell without running __init__ — we only need a
+    # handful of attributes for ainsert_custom_kg to walk far enough to
+    # acquire the keyed lock.
+    rag = LightRAG.__new__(LightRAG)
+    rag.workspace = "ws1"
+    rag.tokenizer = MagicMock()
+    rag.tokenizer.encode = lambda _content: []
+    rag.chunks_vdb = _make_vdb_mock(workspace="ws1")
+    rag.text_chunks = _make_vdb_mock(workspace="ws1")
+    rag.chunk_entity_relation_graph = _make_graph_mock(edges_for_entity=[])
+    rag.entities_vdb = _make_vdb_mock(workspace="ws1")
+    rag.relationships_vdb = _make_vdb_mock(workspace="ws1")
+    # The finally-block calls _insert_done() which walks several storages we
+    # haven't stubbed; replace it wholesale since we only care about the lock
+    # arguments.
+    rag._insert_done = AsyncMock(return_value=None)
+
+    lock_spy = _AbortOnEnterLock()
+
+    custom_kg = {
+        "chunks": [],
+        "entities": [
+            {
+                "entity_name": "Alice",
+                "entity_type": "PERSON",
+                "description": "x",
+                "source_id": "chunk-1",
+                "file_path": "f",
+            },
+            {
+                "entity_name": "Bob",
+                "entity_type": "PERSON",
+                "description": "y",
+                "source_id": "chunk-1",
+                "file_path": "f",
+            },
+        ],
+        "relationships": [
+            {
+                "src_id": "Alice",
+                "tgt_id": "Bob",
+                "description": "knows",
+                "keywords": "k",
+                "weight": 1.0,
+                "source_id": "chunk-1",
+                "file_path": "f",
+            },
+            {
+                "src_id": "Bob",
+                "tgt_id": "Carol",
+                "description": "knows",
+                "keywords": "k",
+                "weight": 1.0,
+                "source_id": "chunk-1",
+                "file_path": "f",
+            },
+        ],
+    }
+
+    with patch.object(lightrag_module, "get_storage_keyed_lock", lock_spy):
+        with pytest.raises(_LockCaptured):
+            await rag.ainsert_custom_kg(custom_kg)
+
+    # Exactly one keyed lock acquisition attempted.
+    assert len(lock_spy.captured) == 1
+    call = lock_spy.captured[0]
+
+    # Namespace pinned to workspace-aware form, matching the doc-ingest pipeline.
+    assert call["namespace"] == "ws1:GraphDB"
+
+    # Keys: union of entity names ({Alice, Bob}) and every relationship
+    # endpoint ({Alice, Bob, Carol}), sorted.
+    assert call["keys"] == ["Alice", "Bob", "Carol"]
+
+
+@pytest.mark.asyncio
+async def test_ainsert_custom_kg_empty_batch_skips_keyed_lock():
+    """A custom_kg with no entities or relationships has nothing for the
+    business-layer keyed lock to serialise, so it must not acquire one — the
+    chunk-only path still works."""
+    from lightrag import lightrag as lightrag_module
+    from lightrag.lightrag import LightRAG
+
+    rag = LightRAG.__new__(LightRAG)
+    rag.workspace = ""
+    rag.tokenizer = MagicMock()
+    rag.tokenizer.encode = lambda _content: []
+    rag.chunks_vdb = _make_vdb_mock(workspace="")
+    rag.text_chunks = _make_vdb_mock(workspace="")
+    rag.chunk_entity_relation_graph = _make_graph_mock(edges_for_entity=[])
+    rag.entities_vdb = _make_vdb_mock(workspace="")
+    rag.relationships_vdb = _make_vdb_mock(workspace="")
+    rag._insert_done = AsyncMock(return_value=None)
+
+    lock_spy = _AbortOnEnterLock()
+
+    with patch.object(lightrag_module, "get_storage_keyed_lock", lock_spy):
+        # No exception expected — the with-block is skipped entirely.
+        await rag.ainsert_custom_kg({"chunks": [], "entities": [], "relationships": []})
+
+    assert lock_spy.captured == []

--- a/tests/test_graph_keyed_locks.py
+++ b/tests/test_graph_keyed_locks.py
@@ -1,17 +1,18 @@
 """
-Regression tests for the keyed-lock extension on entity-mutation paths.
+Pin the business-layer keyed-lock contracts on the entity-mutation paths.
 
-`aedit_entity` (rename) and `adelete_by_entity` both rewrite or detach every
-incident edge of the target entity. The doc-ingest pipeline
-(`operate.py:_locked_process_edges`) locks edges under `sorted([src, tgt])`
-keys, so a lock set of only {entity_name} (or {entity_name, new_entity_name})
-lives in a disjoint partition from those per-edge locks and would race against
-concurrent edge writes.
+`get_storage_keyed_lock(keys, namespace=...)` acquires one mutex per key in
+the given namespace, so identical key strings share the same mutex across
+callers. Locking `[entity_name]` is therefore already enough to mutually
+exclude any concurrent edge write that names the same entity in
+`sorted([src, tgt])` — no need to enumerate incident edges here.
 
-The fix pre-fetches each entity's edges outside the lock, extends the lock
-set to cover every other endpoint, and acquires all keys atomically. These
-tests pin the extension by spying on `get_storage_keyed_lock` and asserting
-the `keys` argument it receives.
+These tests pin:
+- `aedit_entity` locks {old, new} on rename, {entity_name} otherwise.
+- `adelete_by_entity` locks {entity_name}.
+- `ainsert_custom_kg` locks every entity name plus every relationship
+  endpoint that the batch will write, sharing the doc-ingest namespace.
+- An empty `ainsert_custom_kg` batch skips the lock entirely.
 """
 
 from contextlib import asynccontextmanager
@@ -28,9 +29,8 @@ import pytest
 def _make_keyed_lock_spy():
     """Return (spy_callable, captured_calls_list).
 
-    The spy returns an async context manager so `async with get_storage_keyed_lock(...)`
-    just yields. Each invocation appends {"keys": ..., "namespace": ...} to the
-    captured list.
+    Spy yields a no-op async context manager and records every invocation's
+    `keys` / `namespace` arguments.
     """
     captured: list[dict] = []
 
@@ -46,19 +46,18 @@ def _make_keyed_lock_spy():
 
 
 def _make_graph_mock(
-    edges_for_entity: list[tuple[str, str]],
+    edges_for_entity: list[tuple[str, str]] | None = None,
     *,
     existing_entity: str = "X",
 ):
-    """Minimal `chunk_entity_relation_graph` mock for aedit / adelete.
+    """Minimal `chunk_entity_relation_graph` mock.
 
     `has_node` returns True only for `existing_entity` so a rename target
     (e.g. "Y") is treated as not-yet-existing — otherwise aedit_entity would
-    short-circuit with "Entity name 'Y' already exists" before reaching the
-    upsert path.
+    short-circuit with "Entity name 'Y' already exists".
     """
     graph = MagicMock()
-    graph.get_node_edges = AsyncMock(return_value=edges_for_entity)
+    graph.get_node_edges = AsyncMock(return_value=edges_for_entity or [])
     graph.has_node = AsyncMock(side_effect=lambda name: name == existing_entity)
     graph.get_node = AsyncMock(
         return_value={
@@ -107,27 +106,21 @@ def _make_vdb_mock(workspace: str = ""):
 
 
 @pytest.mark.asyncio
-async def test_aedit_entity_rename_locks_extend_to_edge_endpoints():
-    """When renaming X -> Y, the lock set must include every other endpoint
-    of X's edges (A, B in this fixture), not just {X, Y}.
-
-    Without this, the doc-ingest pipeline can hold sorted([X, A]) or
-    sorted([Y, A]) edge locks at the same time aedit_entity is rewriting
-    those edges, since {X, Y} and sorted([X, A]) live in disjoint key
-    partitions within the same namespace.
-    """
+async def test_aedit_entity_rename_locks_old_and_new_names():
+    """Renaming X -> Y locks only {X, Y}. The doc-ingest pipeline uses the
+    same namespace and acquires per-key mutexes, so locking the entity name
+    already excludes any sorted([X, *]) or sorted([Y, *]) edge lock — no
+    need to enumerate incident edges here."""
     from lightrag import utils_graph
 
     spy, captured = _make_keyed_lock_spy()
-    graph = _make_graph_mock(edges_for_entity=[("X", "A"), ("B", "X")])
+    graph = _make_graph_mock()
     entities_vdb = _make_vdb_mock(workspace="ws1")
     relationships_vdb = _make_vdb_mock(workspace="ws1")
 
-    # Stop the actual edit work from running too far — we only care about the
-    # lock arguments. Patching get_node also blocks _edit_entity_impl from
-    # walking past the lock with a sentinel exception that we catch below.
-    sentinel = RuntimeError("stop after lock acquisition")
-    graph.upsert_node.side_effect = sentinel
+    # Short-circuit before the rename actually runs — we only care about the
+    # lock arguments.
+    graph.upsert_node.side_effect = RuntimeError("stop after lock acquisition")
 
     with patch.object(utils_graph, "get_storage_keyed_lock", spy):
         with pytest.raises(RuntimeError, match="stop after lock acquisition"):
@@ -140,30 +133,25 @@ async def test_aedit_entity_rename_locks_extend_to_edge_endpoints():
                 allow_rename=True,
             )
 
-    # Exactly one lock acquisition happened.
     assert len(captured) == 1
-    call = captured[0]
+    assert captured[0]["keys"] == ["X", "Y"]
+    assert captured[0]["namespace"] == "ws1:GraphDB"
 
-    # Namespace pinned to workspace-aware form.
-    assert call["namespace"] == "ws1:GraphDB"
-
-    # Keys: {X, Y} ∪ {A, B} from get_node_edges, sorted.
-    assert call["keys"] == ["A", "B", "X", "Y"]
+    # No pre-fetch of incident edges — that would only add I/O.
+    graph.get_node_edges.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_aedit_entity_non_rename_keeps_single_entity_lock():
-    """Non-rename edits don't touch edges, so the lock set stays at just the
-    entity name — no need to extend or pre-fetch edges."""
+async def test_aedit_entity_non_rename_locks_single_entity_name():
+    """Non-rename edits lock just the entity name."""
     from lightrag import utils_graph
 
     spy, captured = _make_keyed_lock_spy()
-    graph = _make_graph_mock(edges_for_entity=[])
+    graph = _make_graph_mock()
     entities_vdb = _make_vdb_mock(workspace="")
     relationships_vdb = _make_vdb_mock(workspace="")
 
-    sentinel = RuntimeError("stop after lock acquisition")
-    graph.upsert_node.side_effect = sentinel
+    graph.upsert_node.side_effect = RuntimeError("stop after lock acquisition")
 
     with patch.object(utils_graph, "get_storage_keyed_lock", spy):
         with pytest.raises(RuntimeError, match="stop after lock acquisition"):
@@ -180,42 +168,7 @@ async def test_aedit_entity_non_rename_keeps_single_entity_lock():
     assert captured[0]["keys"] == ["X"]
     # Empty workspace falls back to the bare "GraphDB" namespace.
     assert captured[0]["namespace"] == "GraphDB"
-
-    # No need to pre-fetch edges when not renaming — the implementation only
-    # walks get_node_edges inside the rename branch.
     graph.get_node_edges.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_aedit_entity_rename_tolerates_edge_fetch_failure():
-    """If pre-fetching edges fails (storage hiccup), the rename still
-    proceeds with the narrower {entity, new_entity} lock set, logging a
-    warning. The PG advisory lock is the final safety net here."""
-    from lightrag import utils_graph
-
-    spy, captured = _make_keyed_lock_spy()
-    graph = _make_graph_mock(edges_for_entity=[])
-    graph.get_node_edges.side_effect = RuntimeError("simulated storage error")
-    entities_vdb = _make_vdb_mock(workspace="")
-    relationships_vdb = _make_vdb_mock(workspace="")
-
-    sentinel = RuntimeError("stop after lock acquisition")
-    graph.upsert_node.side_effect = sentinel
-
-    with patch.object(utils_graph, "get_storage_keyed_lock", spy):
-        with pytest.raises(RuntimeError, match="stop after lock acquisition"):
-            await utils_graph.aedit_entity(
-                chunk_entity_relation_graph=graph,
-                entities_vdb=entities_vdb,
-                relationships_vdb=relationships_vdb,
-                entity_name="X",
-                updated_data={"entity_name": "Y", "description": "renamed"},
-                allow_rename=True,
-            )
-
-    assert len(captured) == 1
-    # Falls back to the narrow set when pre-fetch fails.
-    assert captured[0]["keys"] == ["X", "Y"]
 
 
 # ---------------------------------------------------------------------------
@@ -224,9 +177,8 @@ async def test_aedit_entity_rename_tolerates_edge_fetch_failure():
 
 
 @pytest.mark.asyncio
-async def test_adelete_by_entity_locks_extend_to_edge_endpoints():
-    """`delete_node` detaches every incident edge, so the lock set must
-    include every other endpoint."""
+async def test_adelete_by_entity_locks_single_entity_name():
+    """Entity delete locks just the entity name."""
     from lightrag import utils_graph
 
     spy, captured = _make_keyed_lock_spy()
@@ -242,53 +194,13 @@ async def test_adelete_by_entity_locks_extend_to_edge_endpoints():
             entity_name="X",
         )
 
-    # Deletion ran to completion since all mocks return defaults.
-    assert result.status == "success"
-
-    assert len(captured) == 1
-    call = captured[0]
-    assert call["namespace"] == "ws1:GraphDB"
-    # {X} ∪ {Y, Z} from get_node_edges (called pre-lock for set extension), sorted.
-    assert call["keys"] == ["X", "Y", "Z"]
-
-    # get_node_edges is called twice: once pre-lock (for set extension), once
-    # inside the lock (the authoritative read used by the cleanup code).
-    assert graph.get_node_edges.await_count == 2
-
-
-@pytest.mark.asyncio
-async def test_adelete_by_entity_tolerates_edge_fetch_failure():
-    """Pre-fetch failure falls back to the narrow {entity_name} lock; the
-    delete still proceeds via the second (inside-lock) get_node_edges."""
-    from lightrag import utils_graph
-
-    spy, captured = _make_keyed_lock_spy()
-    graph = _make_graph_mock(edges_for_entity=[("X", "Y")])
-
-    call_outcomes = [RuntimeError("simulated storage error"), [("X", "Y")]]
-
-    async def flaky_get_node_edges(_name):
-        outcome = call_outcomes.pop(0)
-        if isinstance(outcome, Exception):
-            raise outcome
-        return outcome
-
-    graph.get_node_edges = AsyncMock(side_effect=flaky_get_node_edges)
-    entities_vdb = _make_vdb_mock(workspace="")
-    relationships_vdb = _make_vdb_mock(workspace="")
-
-    with patch.object(utils_graph, "get_storage_keyed_lock", spy):
-        result = await utils_graph.adelete_by_entity(
-            chunk_entity_relation_graph=graph,
-            entities_vdb=entities_vdb,
-            relationships_vdb=relationships_vdb,
-            entity_name="X",
-        )
-
     assert result.status == "success"
     assert len(captured) == 1
-    # Narrow fallback when pre-fetch fails.
     assert captured[0]["keys"] == ["X"]
+    assert captured[0]["namespace"] == "ws1:GraphDB"
+    # get_node_edges runs exactly once, inside the lock, to drive cleanup —
+    # not as a pre-fetch for lock-set extension.
+    assert graph.get_node_edges.await_count == 1
 
 
 # ---------------------------------------------------------------------------
@@ -323,31 +235,24 @@ class _LockCaptured(RuntimeError):
 
 
 @pytest.mark.asyncio
-async def test_ainsert_custom_kg_locks_extend_to_every_endpoint():
+async def test_ainsert_custom_kg_locks_every_entity_and_endpoint():
     """ainsert_custom_kg must hold a single coarse-grained keyed lock whose
     key set covers every entity name plus every relationship endpoint in the
-    batch — sharing the namespace with the doc-ingest pipeline so a
-    concurrent insert_custom_kg call on overlapping entities serialises
-    properly instead of racing.
+    batch — sharing the doc-ingest namespace so concurrent callers on
+    overlapping entities serialise instead of racing.
     """
     from lightrag import lightrag as lightrag_module
     from lightrag.lightrag import LightRAG
 
-    # Build a bare LightRAG shell without running __init__ — we only need a
-    # handful of attributes for ainsert_custom_kg to walk far enough to
-    # acquire the keyed lock.
     rag = LightRAG.__new__(LightRAG)
     rag.workspace = "ws1"
     rag.tokenizer = MagicMock()
     rag.tokenizer.encode = lambda _content: []
     rag.chunks_vdb = _make_vdb_mock(workspace="ws1")
     rag.text_chunks = _make_vdb_mock(workspace="ws1")
-    rag.chunk_entity_relation_graph = _make_graph_mock(edges_for_entity=[])
+    rag.chunk_entity_relation_graph = _make_graph_mock()
     rag.entities_vdb = _make_vdb_mock(workspace="ws1")
     rag.relationships_vdb = _make_vdb_mock(workspace="ws1")
-    # The finally-block calls _insert_done() which walks several storages we
-    # haven't stubbed; replace it wholesale since we only care about the lock
-    # arguments.
     rag._insert_done = AsyncMock(return_value=None)
 
     lock_spy = _AbortOnEnterLock()
@@ -396,23 +301,23 @@ async def test_ainsert_custom_kg_locks_extend_to_every_endpoint():
         with pytest.raises(_LockCaptured):
             await rag.ainsert_custom_kg(custom_kg)
 
-    # Exactly one keyed lock acquisition attempted.
     assert len(lock_spy.captured) == 1
     call = lock_spy.captured[0]
 
-    # Namespace pinned to workspace-aware form, matching the doc-ingest pipeline.
+    # Namespace matches the doc-ingest pipeline so the same key strings
+    # mutually exclude across paths.
     assert call["namespace"] == "ws1:GraphDB"
 
-    # Keys: union of entity names ({Alice, Bob}) and every relationship
-    # endpoint ({Alice, Bob, Carol}), sorted.
+    # Union of entity names ({Alice, Bob}) and every relationship endpoint
+    # ({Alice, Bob, Carol}), sorted.
     assert call["keys"] == ["Alice", "Bob", "Carol"]
 
 
 @pytest.mark.asyncio
 async def test_ainsert_custom_kg_empty_batch_skips_keyed_lock():
     """A custom_kg with no entities or relationships has nothing for the
-    business-layer keyed lock to serialise, so it must not acquire one — the
-    chunk-only path still works."""
+    business-layer keyed lock to serialise on — no lock is acquired and the
+    chunk-only path still completes."""
     from lightrag import lightrag as lightrag_module
     from lightrag.lightrag import LightRAG
 
@@ -422,7 +327,7 @@ async def test_ainsert_custom_kg_empty_batch_skips_keyed_lock():
     rag.tokenizer.encode = lambda _content: []
     rag.chunks_vdb = _make_vdb_mock(workspace="")
     rag.text_chunks = _make_vdb_mock(workspace="")
-    rag.chunk_entity_relation_graph = _make_graph_mock(edges_for_entity=[])
+    rag.chunk_entity_relation_graph = _make_graph_mock()
     rag.entities_vdb = _make_vdb_mock(workspace="")
     rag.relationships_vdb = _make_vdb_mock(workspace="")
     rag._insert_done = AsyncMock(return_value=None)
@@ -430,7 +335,6 @@ async def test_ainsert_custom_kg_empty_batch_skips_keyed_lock():
     lock_spy = _AbortOnEnterLock()
 
     with patch.object(lightrag_module, "get_storage_keyed_lock", lock_spy):
-        # No exception expected — the with-block is skipped entirely.
         await rag.ainsert_custom_kg({"chunks": [], "entities": [], "relationships": []})
 
     assert lock_spy.captured == []

--- a/tests/test_postgres_upsert_edge_cypher.py
+++ b/tests/test_postgres_upsert_edge_cypher.py
@@ -315,3 +315,65 @@ async def test_upsert_edge_does_not_retry_non_transient_errors(monkeypatch):
     assert excinfo.value.__cause__ is boom
     assert _is_transient_graph_write_error(excinfo.value) is False
     assert call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_upsert_edges_batch_iterates_in_sorted_order():
+    """upsert_edges_batch must call upsert_edge in canonical (LEAST, GREATEST)
+    order regardless of insertion order.
+
+    The per-edge advisory lock keys hash the sorted endpoint pair. If two
+    concurrent batches iterated in different orders (Python dict iteration is
+    insertion order, not sorted order), they could acquire the lock objects
+    in opposite sequences and deadlock on PostgreSQL.
+    """
+    storage = make_graph_storage()
+
+    captured: list[tuple[str, str]] = []
+
+    async def fake_upsert_edge(src, tgt, edge_data):  # noqa: ARG001
+        captured.append((src, tgt))
+
+    storage.upsert_edge = AsyncMock(side_effect=fake_upsert_edge)
+
+    # Insertion order intentionally non-canonical: B-A, C-A, D-A.
+    await storage.upsert_edges_batch(
+        [
+            ("B", "A", {"weight": "1"}),
+            ("C", "A", {"weight": "2"}),
+            ("D", "A", {"weight": "3"}),
+        ]
+    )
+
+    # Edge keys after canonicalisation: (A,B), (A,C), (A,D). The values
+    # preserve the caller's original orientation per pair, but the iteration
+    # visits them in sorted-key order.
+    canonical_keys = [tuple(sorted(pair)) for pair in captured]
+    assert canonical_keys == sorted(canonical_keys)
+    assert canonical_keys == [("A", "B"), ("A", "C"), ("A", "D")]
+
+
+@pytest.mark.asyncio
+async def test_upsert_edges_batch_dedupes_last_write_wins():
+    """Reciprocal duplicates collapse to a single upsert with the LATEST
+    edge_data, regardless of which orientation arrives last — preserves the
+    historical serial-fallback semantics documented on the method."""
+    storage = make_graph_storage()
+
+    captured: list[tuple[str, str, dict]] = []
+
+    async def fake_upsert_edge(src, tgt, edge_data):
+        captured.append((src, tgt, edge_data))
+
+    storage.upsert_edge = AsyncMock(side_effect=fake_upsert_edge)
+
+    await storage.upsert_edges_batch(
+        [
+            ("A", "B", {"weight": "first"}),
+            ("B", "A", {"weight": "second"}),  # reciprocal, wins
+        ]
+    )
+
+    assert len(captured) == 1
+    # Orientation = last write's caller order; edge_data = last write's payload.
+    assert captured[0] == ("B", "A", {"weight": "second"})

--- a/tests/test_postgres_upsert_edge_cypher.py
+++ b/tests/test_postgres_upsert_edge_cypher.py
@@ -319,13 +319,13 @@ async def test_upsert_edge_does_not_retry_non_transient_errors(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_upsert_edges_batch_iterates_in_sorted_order():
-    """upsert_edges_batch must call upsert_edge in canonical (LEAST, GREATEST)
+    """upsert_edges_batch calls upsert_edge in canonical (LEAST, GREATEST)
     order regardless of insertion order.
 
-    The per-edge advisory lock keys hash the sorted endpoint pair. If two
-    concurrent batches iterated in different orders (Python dict iteration is
-    insertion order, not sorted order), they could acquire the lock objects
-    in opposite sequences and deadlock on PostgreSQL.
+    upsert_edge opens an independent transaction per call and releases the
+    advisory lock on commit, so this iteration order is not a deadlock fix
+    — but a deterministic order matches the dedup key already used above
+    and keeps logs / replays reproducible across callers.
     """
     storage = make_graph_storage()
 


### PR DESCRIPTION
## Summary

Follow-up to #3056. That PR added a PostgreSQL advisory lock inside `PGGraphStorage.upsert_edge` as the **storage-layer** safeguard against duplicate `DIRECTED` rows under concurrent writers. This PR fills in the one real business-layer gap left open at the time:

**`ainsert_custom_kg → upsert_edges_batch` had no business-layer keyed lock.** Two concurrent `insert_custom_kg` calls touching overlapping entities could race on the same `(src, tgt)` pair without the business layer noticing.

## Changes

### `lightrag/lightrag.py` — wrap `ainsert_custom_kg` writes in a keyed lock

After dedup, compute `lock_key_set` = union of every entity name and every relationship endpoint in the batch. Acquire `get_storage_keyed_lock(sorted(lock_key_set), namespace=f\"{workspace}:GraphDB\")` once, then run all graph + vdb writes (entity upserts, missing-node fill, edge upserts, vdb upserts, legacy-vdb deletes) inside the same critical section. Namespace matches what `operate.py:_locked_process_edges` and `_locked_process_entity_name` use, so the per-key mutexes (`get_storage_keyed_lock` acquires one mutex per key in the namespace) collide across paths — a concurrent custom-KG insert waits behind an in-flight document ingest instead of racing it. Empty batches skip the lock entirely.

### `lightrag/kg/postgres_impl.py` — deterministic batch iteration

`upsert_edges_batch` now iterates `sorted(deduped_edges)` instead of `deduped_edges.values()`. The dedup key is already `tuple(sorted((src, tgt)))`, so iterating by sorted key gives every caller the same global order. **Not a deadlock fix** — `upsert_edge` opens an independent transaction per call and releases the advisory lock on commit, so the batch never holds two advisory locks simultaneously. The change is purely for reproducible logs / replays.

## Test plan

- [x] **`tests/test_graph_keyed_locks.py`** (new, 5 cases) pins the keyed-lock contracts:
  - `test_aedit_entity_rename_locks_old_and_new_names` — rename locks `{old, new}`, no pre-fetch of incident edges.
  - `test_aedit_entity_non_rename_locks_single_entity_name` — non-rename locks `{entity}`.
  - `test_adelete_by_entity_locks_single_entity_name` — delete locks `{entity}`.
  - `test_ainsert_custom_kg_locks_every_entity_and_endpoint` — verify the new coarse-grained lock includes every entity name + every relationship endpoint, sorted.
  - `test_ainsert_custom_kg_empty_batch_skips_keyed_lock` — empty batch acquires no lock at all.
- [x] **`tests/test_postgres_upsert_edge_cypher.py`** additions:
  - `test_upsert_edges_batch_iterates_in_sorted_order` — deterministic iteration order regardless of insertion order.
  - `test_upsert_edges_batch_dedupes_last_write_wins` — reciprocal duplicates collapse to one upsert with the latest `edge_data`.
- [x] Full `pytest tests/` — **1601 passed, 1 skipped, 31 deselected**.
- [x] `pre-commit run` clean.

## Review notes

The first commit on this branch attempted to also extend the lock set in `aedit_entity` / `adelete_by_entity` by pre-fetching incident edges, and framed the `upsert_edges_batch` sort as an AB-BA deadlock fix. **Both rationales were wrong:**

- `get_storage_keyed_lock` acquires one mutex per key in a shared namespace. Identical key strings already mutually exclude across callers, so `[entity_name]` already collides with `sorted([src, tgt])` whenever the edge names the entity — no need to enumerate incident edges.
- `upsert_edges_batch` calls `upsert_edge` one edge at a time, and each call commits before the next starts, so the batch never holds two advisory locks at once. There is no AB-BA risk to fix.

The second commit on this branch (`ce60a7a4`) reverts those over-reaches and rewrites the corresponding comments / tests to reflect the correct concurrency model. The final scope is the single `ainsert_custom_kg` lock + a cosmetic deterministic-iteration tweak on `upsert_edges_batch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)