### PR TITLE
fix issue #3126 POSTGRES user, password, db are not configurable

### DIFF
--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -1342,16 +1342,14 @@ collect_postgres_config() {
   existing_user="${ORIGINAL_ENV_VALUES[POSTGRES_USER]-${ENV_VALUES[POSTGRES_USER]:-}}"
   existing_password="${ORIGINAL_ENV_VALUES[POSTGRES_PASSWORD]-${ENV_VALUES[POSTGRES_PASSWORD]:-}}"
   existing_database="${ORIGINAL_ENV_VALUES[POSTGRES_DATABASE]-${ENV_VALUES[POSTGRES_DATABASE]:-}}"
-  if [[ "$use_docker" == "yes" && -z "$existing_user" && -z "$existing_password" ]]; then
+  if [[ "$use_docker" == "yes" ]]; then
     user="rag"
     password="rag"
-  else
-    user="$(prompt_with_default "PostgreSQL user" "${existing_user:-rag}")"
-    password="$(prompt_secret_with_default "PostgreSQL password: " "${existing_password:-rag}")"
-  fi
-  if [[ "$use_docker" == "yes" && -z "$existing_database" ]]; then
     database="rag"
+    log_info "PostgreSQL running locally via Docker requires pre-configured image credentials: User='rag', DB='rag'."
   else
+    user="$(prompt_with_default "PostgreSQL user" "${existing_user:-postgres}")"
+    password="$(prompt_secret_with_default "PostgreSQL password: " "${existing_password:-}")"
     database="$(prompt_with_default "PostgreSQL database" "${existing_database:-lightrag}")"
   fi
 

--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -1348,8 +1348,8 @@ collect_postgres_config() {
     database="rag"
     log_info "PostgreSQL running locally via Docker requires pre-configured image credentials: User='rag', DB='rag'."
   else
-    user="$(prompt_with_default "PostgreSQL user" "${existing_user:-postgres}")"
-    password="$(prompt_secret_with_default "PostgreSQL password: " "${existing_password:-}")"
+    user="$(prompt_with_default "PostgreSQL user" "${existing_user:-rag}")"
+    password="$(prompt_secret_with_default "PostgreSQL password: " "${existing_password:-rag}")"
     database="$(prompt_with_default "PostgreSQL database" "${existing_database:-lightrag}")"
   fi
 

--- a/tests/test_interactive_setup/test_collect.py
+++ b/tests/test_interactive_setup/test_collect.py
@@ -95,8 +95,8 @@ printf 'PROMPT_LOG=%s\\n' "$(paste -sd '|' "$PROMPT_LOG_FILE")\"
     assert values["PROMPT_LOG"] == "PostgreSQL host"
 
 
-def test_collect_postgres_config_prompts_for_existing_docker_credentials() -> None:
-    """Docker PostgreSQL should preserve editability when old `.env` creds already exist."""
+def test_collect_postgres_config_forces_rag_credentials_even_with_existing_docker_credentials() -> None:
+    """Docker PostgreSQL should always force 'rag' credentials even when old `.env` creds already exist."""
     values = run_bash_lines(f"""
 set -euo pipefail
 source "{REPO_ROOT}/scripts/setup/setup.sh"
@@ -110,14 +110,12 @@ prompt_with_default() {{
   printf '%s[%s]\\n' "$1" "$2" >> "$PROMPT_LOG_FILE"
   case "$1" in
     "PostgreSQL host") printf 'localhost' ;;
-    "PostgreSQL user") printf 'updated-user' ;;
-    "PostgreSQL database") printf 'updated-db' ;;
     *) printf '%s' "$2" ;;
   esac
 }}
 prompt_secret_with_default() {{
   printf '%s[%s]\\n' "$1" "$2" >> "$PROMPT_LOG_FILE"
-  printf 'updated-password'
+  printf '%s' "$2"
 }}
 
 ORIGINAL_ENV_VALUES[POSTGRES_USER]="existing-user"
@@ -131,12 +129,12 @@ printf 'POSTGRES_PASSWORD=%s\\n' "${{ENV_VALUES[POSTGRES_PASSWORD]}}"
 printf 'POSTGRES_DATABASE=%s\\n' "${{ENV_VALUES[POSTGRES_DATABASE]}}"
 printf 'PROMPT_LOG=%s\\n' "$(paste -sd '|' "$PROMPT_LOG_FILE")\"
 """)
-    assert values["POSTGRES_USER"] == "updated-user"
-    assert values["POSTGRES_PASSWORD"] == "updated-password"
-    assert values["POSTGRES_DATABASE"] == "updated-db"
+    assert values["POSTGRES_USER"] == "rag"
+    assert values["POSTGRES_PASSWORD"] == "rag"
+    assert values["POSTGRES_DATABASE"] == "rag"
     assert (
         values["PROMPT_LOG"]
-        == "PostgreSQL host[localhost]|PostgreSQL user[existing-user]|PostgreSQL password: [existing-password]|PostgreSQL database[existing-db]"
+        == "PostgreSQL host[localhost]"
     )
 
 

--- a/tests/test_interactive_setup/test_collect.py
+++ b/tests/test_interactive_setup/test_collect.py
@@ -95,7 +95,9 @@ printf 'PROMPT_LOG=%s\\n' "$(paste -sd '|' "$PROMPT_LOG_FILE")\"
     assert values["PROMPT_LOG"] == "PostgreSQL host"
 
 
-def test_collect_postgres_config_forces_rag_credentials_even_with_existing_docker_credentials() -> None:
+def test_collect_postgres_config_forces_rag_credentials_even_with_existing_docker_credentials() -> (
+    None
+):
     """Docker PostgreSQL should always force 'rag' credentials even when old `.env` creds already exist."""
     values = run_bash_lines(f"""
 set -euo pipefail
@@ -132,10 +134,7 @@ printf 'PROMPT_LOG=%s\\n' "$(paste -sd '|' "$PROMPT_LOG_FILE")\"
     assert values["POSTGRES_USER"] == "rag"
     assert values["POSTGRES_PASSWORD"] == "rag"
     assert values["POSTGRES_DATABASE"] == "rag"
-    assert (
-        values["PROMPT_LOG"]
-        == "PostgreSQL host[localhost]"
-    )
+    assert values["PROMPT_LOG"] == "PostgreSQL host[localhost]"
 
 
 def test_collect_postgres_config_still_prompts_for_host_credentials() -> None:


### PR DESCRIPTION
approach to address this:
> Force 'rag' under Docker: When PostgreSQL runs via local Docker, the wizard enforces rag / rag / rag and skips credential prompts to prevent configuration mismatches.

> Preserve External DB Customization: When running on an external or host PostgreSQL instance, the wizard still prompts for custom credentials.

>Updated Tests: Adjusted the unit tests in tests/test_interactive_setup/test_collect.py to align with this logics.