### PR TITLE
perf(opensearch): batch KV operations under namespace lock

### DIFF
--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -404,6 +404,17 @@ class BaseKVStorage(StorageNameSpace, ABC):
         Importance notes for in-memory storage:
         1. Changes will be persisted to disk during the next index_done_callback
         2. update flags to notify other processes that data persistence is needed
+
+        Multi-worker note:
+            Backends that buffer writes in process memory (e.g.
+            OpenSearchKVStorage as of the KV-batching change derived from
+            #2822) keep the buffer process-local. In a multi-worker
+            deployment (e.g. lightrag-gunicorn) other workers will not
+            observe these writes until the writing worker has called
+            index_done_callback(). Callers that depend on cross-worker
+            read-after-write visibility must explicitly await
+            index_done_callback() before relying on reads from another
+            worker.
         """
 
     @abstractmethod
@@ -413,6 +424,9 @@ class BaseKVStorage(StorageNameSpace, ABC):
         Importance notes for in-memory storage:
         1. Changes will be persisted to disk during the next index_done_callback
         2. update flags to notify other processes that data persistence is needed
+
+        Multi-worker note: see ``upsert`` -- buffered tombstones are
+        process-local until index_done_callback() runs.
 
         Args:
             ids (list[str]): List of document IDs to be deleted from storage

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -458,13 +458,45 @@ class OpenSearchKVStorage(BaseKVStorage):
             raise
 
     async def finalize(self):
-        """Flush pending writes and release the OpenSearch client connection."""
+        """Flush pending writes and release the OpenSearch client connection.
+
+        Raises ``RuntimeError`` if the buffer still contains pending ops
+        after the final flush attempt -- e.g. because retryable bulk
+        failures (5xx) left rows behind. The client is released either
+        way so we don't leak a connection on shutdown, but the caller
+        must learn that buffered data did not reach OpenSearch.
+        """
+        flush_error: BaseException | None = None
         try:
             await self._flush_pending_kv_ops()
-        finally:
-            if self.client is not None:
-                await ClientManager.release_client(self.client)
-                self.client = None
+        except BaseException as e:
+            # _flush_pending_kv_ops leaves the buffers intact on raise;
+            # capture the error so we can re-surface it after the client
+            # is released (we still must not leak the connection).
+            flush_error = e
+
+        if self.client is not None:
+            await ClientManager.release_client(self.client)
+            self.client = None
+
+        # Snapshot remaining buffer state to report concrete counts.
+        pending_upserts = len(self._pending_upserts)
+        pending_deletes = len(self._pending_kv_deletes)
+
+        if flush_error is not None:
+            raise RuntimeError(
+                f"[{self.workspace}] OpenSearchKVStorage.finalize() flush "
+                f"raised; {pending_upserts} pending upserts and "
+                f"{pending_deletes} pending deletes were left buffered "
+                f"(client released, data lost)"
+            ) from flush_error
+        if pending_upserts or pending_deletes:
+            raise RuntimeError(
+                f"[{self.workspace}] OpenSearchKVStorage.finalize() left "
+                f"{pending_upserts} pending upserts and {pending_deletes} "
+                f"pending deletes buffered after final flush attempt "
+                f"(transient bulk failure); these writes have been lost"
+            )
 
     async def _iter_raw_docs(
         self, batch_size: int = 1000
@@ -3205,13 +3237,41 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
             raise
 
     async def finalize(self):
-        """Release the OpenSearch client connection."""
+        """Flush pending writes and release the OpenSearch client connection.
+
+        Raises ``RuntimeError`` if the buffer still contains pending ops
+        after the final flush attempt -- e.g. because retryable bulk
+        failures (5xx) left rows behind. The client is released either
+        way so we don't leak a connection on shutdown, but the caller
+        must learn that buffered data did not reach OpenSearch.
+        """
+        flush_error: BaseException | None = None
         try:
             await self._flush_pending_vector_ops()
-        finally:
-            if self.client is not None:
-                await ClientManager.release_client(self.client)
-                self.client = None
+        except BaseException as e:
+            flush_error = e
+
+        if self.client is not None:
+            await ClientManager.release_client(self.client)
+            self.client = None
+
+        pending_docs = len(self._pending_vector_docs)
+        pending_deletes = len(self._pending_vector_deletes)
+
+        if flush_error is not None:
+            raise RuntimeError(
+                f"[{self.workspace}] OpenSearchVectorDBStorage.finalize() "
+                f"flush raised; {pending_docs} pending upserts and "
+                f"{pending_deletes} pending deletes were left buffered "
+                f"(client released, data lost)"
+            ) from flush_error
+        if pending_docs or pending_deletes:
+            raise RuntimeError(
+                f"[{self.workspace}] OpenSearchVectorDBStorage.finalize() "
+                f"left {pending_docs} pending upserts and {pending_deletes} "
+                f"pending deletes buffered after final flush attempt "
+                f"(transient bulk failure); these writes have been lost"
+            )
 
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
         """Generate embeddings and buffer vector docs for batched flush.

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -579,9 +579,7 @@ class OpenSearchKVStorage(BaseKVStorage):
                     continue
                 pending = self._pending_upserts.get(doc_id)
                 if pending is not None:
-                    buffered[doc_id] = self._materialize_pending_kv_doc(
-                        doc_id, pending
-                    )
+                    buffered[doc_id] = self._materialize_pending_kv_doc(doc_id, pending)
                     continue
                 remaining.append(doc_id)
             index_ready = self._index_ready
@@ -604,9 +602,7 @@ class OpenSearchKVStorage(BaseKVStorage):
                 if _is_missing_index_error(e):
                     self._mark_index_missing()
                 else:
-                    logger.error(
-                        f"[{self.workspace}] Error getting documents: {e}"
-                    )
+                    logger.error(f"[{self.workspace}] Error getting documents: {e}")
 
         return [
             buffered[doc_id] if doc_id in buffered else doc_map.get(doc_id)
@@ -870,9 +866,7 @@ class OpenSearchKVStorage(BaseKVStorage):
             try:
                 try:
                     await self.client.indices.delete(index=self._index_name)
-                    logger.info(
-                        f"[{self.workspace}] Dropped index: {self._index_name}"
-                    )
+                    logger.info(f"[{self.workspace}] Dropped index: {self._index_name}")
                 except NotFoundError:
                     logger.info(
                         f"[{self.workspace}] Index already missing during drop: {self._index_name}"
@@ -888,9 +882,7 @@ class OpenSearchKVStorage(BaseKVStorage):
                 return {"status": "error", "message": str(e)}
             except Exception as e:
                 self._mark_index_missing()
-                logger.error(
-                    f"[{self.workspace}] Unexpected error dropping index: {e}"
-                )
+                logger.error(f"[{self.workspace}] Unexpected error dropping index: {e}")
                 return {"status": "error", "message": str(e)}
 
 

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -385,6 +385,18 @@ class OpenSearchKVStorage(BaseKVStorage):
         self.workspace, self.final_namespace, self._index_name = _build_index_name(
             self.workspace, self.namespace
         )
+        # Pending writes are flushed via _flush_pending_kv_ops() during
+        # index_done_callback() / finalize(). Buffering many small upsert()
+        # invocations into a single async_bulk roundtrip avoids the per-call
+        # HTTP overhead profiled in issue #2785; the lock-everywhere model
+        # mirrors what #3043 introduced for OpenSearchVectorDBStorage.
+        self._pending_upserts: dict[str, dict[str, Any]] = {}
+        self._pending_kv_deletes: set[str] = set()
+        # Namespace-keyed lock (multi-process aware) is assigned in
+        # initialize(). All buffer reads / writes and the flush itself
+        # acquire this lock so an in-flight flush cannot interleave with
+        # concurrent get_by_id / upsert / delete on the same workspace.
+        self._flush_lock = None
 
     async def initialize(self):
         """Initialize client connection and create index if needed."""
@@ -395,6 +407,10 @@ class OpenSearchKVStorage(BaseKVStorage):
             self._index_ready = True
             logger.debug(
                 f"[{self.workspace}] OpenSearch KV storage initialized: {self._index_name}"
+            )
+        if self._flush_lock is None:
+            self._flush_lock = get_namespace_lock(
+                self.namespace, workspace=self.workspace
             )
 
     async def _ensure_index_ready(self):
@@ -442,10 +458,13 @@ class OpenSearchKVStorage(BaseKVStorage):
             raise
 
     async def finalize(self):
-        """Release the OpenSearch client connection."""
-        if self.client is not None:
-            await ClientManager.release_client(self.client)
-            self.client = None
+        """Flush pending writes and release the OpenSearch client connection."""
+        try:
+            await self._flush_pending_kv_ops()
+        finally:
+            if self.client is not None:
+                await ClientManager.release_client(self.client)
+                self.client = None
 
     async def _iter_raw_docs(
         self, batch_size: int = 1000
@@ -493,10 +512,38 @@ class OpenSearchKVStorage(BaseKVStorage):
             logger.error(f"[{self.workspace}] Error scanning documents: {e}")
             raise
 
+    def _materialize_pending_kv_doc(
+        self, doc_id: str, source: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Return a get_by_id-shaped view of a buffered upsert.
+
+        Mirrors the post-processing applied to mget hits: drops the
+        ``__mirrored_id`` PIT sort key, attaches the ``_id`` field and
+        ensures ``create_time`` / ``update_time`` defaults are populated.
+        The buffer entry itself is not mutated.
+        """
+        doc = {k: v for k, v in source.items() if k != "__mirrored_id"}
+        doc["_id"] = doc_id
+        doc.setdefault("create_time", 0)
+        doc.setdefault("update_time", 0)
+        return doc
+
     async def get_by_id(self, id: str) -> dict[str, Any] | None:
-        """Get a document by its ID, or None if not found."""
-        if not self._index_ready:
-            return None
+        """Get a document by its ID, with read-your-writes against the buffer.
+
+        Priority: pending delete (tombstone) → pending upsert (buffered
+        write) → OpenSearch via mget. The buffered path strips
+        ``__mirrored_id`` so the returned dict has the same shape as the
+        mget path.
+        """
+        async with self._flush_lock:
+            if id in self._pending_kv_deletes:
+                return None
+            pending = self._pending_upserts.get(id)
+            if pending is not None:
+                return self._materialize_pending_kv_doc(id, pending)
+            if not self._index_ready:
+                return None
         try:
             response = await _mget_optional_doc(self.client, self._index_name, id)
             if response is None:
@@ -515,85 +562,267 @@ class OpenSearchKVStorage(BaseKVStorage):
             return None
 
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
-        """Get multiple documents by IDs, preserving input order."""
-        if not self._index_ready:
-            return [None] * len(ids)
-        try:
-            response = await self.client.mget(index=self._index_name, body={"ids": ids})
-            doc_map = {}
-            for doc in response["docs"]:
-                if doc.get("found"):
-                    data = doc["_source"]
-                    data.pop("__mirrored_id", None)
-                    data["_id"] = doc["_id"]
-                    data.setdefault("create_time", 0)
-                    data.setdefault("update_time", 0)
-                    doc_map[doc["_id"]] = data
-            return [doc_map.get(id) for id in ids]
-        except OpenSearchException as e:
-            if _is_missing_index_error(e):
-                self._mark_index_missing()
-                return [None] * len(ids)
-            logger.error(f"[{self.workspace}] Error getting documents: {e}")
-            return [None] * len(ids)
+        """Get multiple documents by IDs (read-your-writes), preserving order.
+
+        Buffer is consulted under the lock with the same three-tier
+        priority as ``get_by_id``; remaining ids fall through to mget
+        outside the lock so the network call does not stall the flush.
+        """
+        if not ids:
+            return []
+        buffered: dict[str, dict[str, Any] | None] = {}
+        remaining: list[str] = []
+        async with self._flush_lock:
+            for doc_id in ids:
+                if doc_id in self._pending_kv_deletes:
+                    buffered[doc_id] = None
+                    continue
+                pending = self._pending_upserts.get(doc_id)
+                if pending is not None:
+                    buffered[doc_id] = self._materialize_pending_kv_doc(
+                        doc_id, pending
+                    )
+                    continue
+                remaining.append(doc_id)
+            index_ready = self._index_ready
+
+        doc_map: dict[str, dict[str, Any] | None] = {}
+        if remaining and index_ready:
+            try:
+                response = await self.client.mget(
+                    index=self._index_name, body={"ids": remaining}
+                )
+                for doc in response["docs"]:
+                    if doc.get("found"):
+                        data = doc["_source"]
+                        data.pop("__mirrored_id", None)
+                        data["_id"] = doc["_id"]
+                        data.setdefault("create_time", 0)
+                        data.setdefault("update_time", 0)
+                        doc_map[doc["_id"]] = data
+            except OpenSearchException as e:
+                if _is_missing_index_error(e):
+                    self._mark_index_missing()
+                else:
+                    logger.error(
+                        f"[{self.workspace}] Error getting documents: {e}"
+                    )
+
+        return [
+            buffered[doc_id] if doc_id in buffered else doc_map.get(doc_id)
+            for doc_id in ids
+        ]
 
     async def filter_keys(self, keys: set[str]) -> set[str]:
-        """Return the subset of keys that do not exist in storage."""
-        if not self._index_ready:
-            return keys
+        """Return the subset of keys that do not exist in storage.
+
+        Buffer-aware: buffered upserts count as "exists" (and so are
+        removed from the missing set), buffered deletes count as
+        "missing" and are NOT queried via mget (a persisted-but-pending-
+        delete row would otherwise be misclassified as existing).
+        """
+        async with self._flush_lock:
+            pending_upserts = set(self._pending_upserts)
+            pending_deletes = set(self._pending_kv_deletes)
+            index_ready = self._index_ready
+
+        # Buffered upserts shadow OpenSearch -- they will exist after flush.
+        to_check = keys - pending_upserts - pending_deletes
+        if not to_check:
+            # All keys are accounted for by the buffer alone.
+            return keys - pending_upserts
+        if not index_ready:
+            return keys - pending_upserts
         try:
             response = await self.client.mget(
-                index=self._index_name, body={"ids": list(keys)}, _source=False
+                index=self._index_name,
+                body={"ids": list(to_check)},
+                _source=False,
             )
-            existing_ids = {doc["_id"] for doc in response["docs"] if doc.get("found")}
-            return keys - existing_ids
+            existing_on_server = {
+                doc["_id"] for doc in response["docs"] if doc.get("found")
+            }
+            return (keys - pending_upserts) - existing_on_server
         except OpenSearchException as e:
             if _is_missing_index_error(e):
                 self._mark_index_missing()
-                return keys
+                return keys - pending_upserts
             logger.error(f"[{self.workspace}] Error filtering keys: {e}")
-            return keys
+            return keys - pending_upserts
 
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
-        """Insert or update documents with automatic timestamping."""
+        """Buffer documents for batched flush.
+
+        Time-stamping and ``__mirrored_id`` injection happen eagerly so the
+        persisted shape matches what reads expect; the actual ``async_bulk``
+        call is deferred to ``_flush_pending_kv_ops()`` invoked from
+        ``index_done_callback`` / ``finalize``.
+
+        Multi-worker note: the buffer is process-local. Other workers will
+        not see these writes until ``index_done_callback()`` flushes them.
+        """
         if not data:
             return
         await self._ensure_index_ready()
         logger.debug(
-            f"[{self.workspace}] Upserting {len(data)} documents to {self.namespace}"
+            f"[{self.workspace}] Buffering {len(data)} documents for {self.namespace}"
         )
         current_time = int(time.time())
-        actions = []
+
+        # Construct sources outside the lock (no IO; just dict shuffling)
+        # so we hold the lock only for the buffer-swap step.
+        prepared: list[tuple[str, dict[str, Any]]] = []
         for i, (doc_id, doc_data) in enumerate(data.items(), start=1):
             doc_data["update_time"] = current_time
             doc_data.setdefault("create_time", current_time)
             source = {k: v for k, v in doc_data.items() if k != "_id"}
             source["__mirrored_id"] = doc_id
-            actions.append(
-                {
-                    "_op_type": "index",
-                    "_index": self._index_name,
-                    "_id": doc_id,
-                    "_source": source,
-                }
-            )
+            prepared.append((doc_id, source))
             await _cooperative_yield(i)
-        try:
-            # No per-operation refresh: immediate reads use ID-based mget (translog),
-            # search visibility is guaranteed after index_done_callback() batch refresh.
-            success, failed = await helpers.async_bulk(
-                self.client, actions, raise_on_error=False
-            )
-            if failed:
-                logger.warning(
-                    f"[{self.workspace}] {len(failed)} documents failed to upsert"
+
+        # Buffer: an upsert cancels any pending delete on the same id.
+        async with self._flush_lock:
+            for doc_id, source in prepared:
+                self._pending_kv_deletes.discard(doc_id)
+                self._pending_upserts[doc_id] = source
+
+    async def delete(self, ids: list[str]) -> None:
+        """Buffer document deletes for batched flush.
+
+        A delete cancels any pending upsert on the same id; the actual
+        bulk delete is performed by ``_flush_pending_kv_ops`` during the
+        next ``index_done_callback`` / ``finalize`` call.
+
+        ``_index_ready`` is intentionally NOT checked here: even if the
+        index has been marked missing, the buffered upsert (if any) must
+        still be invalidated, otherwise a subsequent flush would resurrect
+        a logically-deleted key.
+        """
+        if not ids:
+            return
+        if isinstance(ids, set):
+            ids = list(ids)
+        async with self._flush_lock:
+            for doc_id in ids:
+                self._pending_upserts.pop(doc_id, None)
+                self._pending_kv_deletes.add(doc_id)
+        logger.debug(
+            f"[{self.workspace}] Buffered delete for {len(ids)} documents in {self.namespace}"
+        )
+
+    async def _flush_pending_kv_ops(self) -> None:
+        """Flush buffered upserts + deletes via a single async_bulk call.
+
+        Concurrency contract: the entire flush runs under ``_flush_lock``;
+        ``upsert`` / ``delete`` / reads / ``drop`` all acquire the same lock
+        so an in-flight flush cannot interleave with concurrent buffer
+        mutations.
+
+        Failure handling mirrors the Vector-side helper:
+          * If ``_ensure_index_ready`` raises, the buffers are left intact
+            and the next flush retries.
+          * If ``async_bulk`` raises, the buffers are left intact.
+          * Per-doc retryable failures (408 / 429 / 5xx) stay in the buffer.
+          * Per-doc non-retryable failures (most 4xx) are cleared and a
+            sample is logged at WARNING with op / id / status / error.
+        """
+        async with self._flush_lock:
+            if not self._pending_upserts and not self._pending_kv_deletes:
+                return
+            if self.client is None:
+                return
+
+            await self._ensure_index_ready()
+
+            pending_upserts = self._pending_upserts
+            pending_deletes = self._pending_kv_deletes
+
+            # Deletes come first so that a delete followed (in time) by an
+            # upsert on the same id is still observable as an index after
+            # the bulk completes; we also dedupe via the set/dict already.
+            actions: list[dict[str, Any]] = []
+            for doc_id in pending_deletes:
+                actions.append(
+                    {
+                        "_op_type": "delete",
+                        "_index": self._index_name,
+                        "_id": doc_id,
+                    }
                 )
-        except OpenSearchException as e:
-            logger.error(f"[{self.workspace}] Error upserting documents: {e}")
-            raise
+            for doc_id, source in pending_upserts.items():
+                actions.append(
+                    {
+                        "_op_type": "index",
+                        "_index": self._index_name,
+                        "_id": doc_id,
+                        "_source": source,
+                    }
+                )
+
+            try:
+                success, failed = await helpers.async_bulk(
+                    self.client, actions, raise_on_error=False
+                )
+            except OpenSearchException as e:
+                logger.error(
+                    f"[{self.workspace}] Error flushing KV ops "
+                    f"(upserts={len(pending_upserts)}, "
+                    f"deletes={len(pending_deletes)}): {e}"
+                )
+                raise
+
+            retryable_ids, non_retryable_ops = _extract_bulk_failed_ids(failed)
+            non_retryable_ids = {op.doc_id for op in non_retryable_ops}
+
+            # Clear successful + non-retryable entries; keep retryable ones.
+            for doc_id in list(pending_upserts.keys()):
+                if doc_id not in retryable_ids:
+                    pending_upserts.pop(doc_id, None)
+            new_deletes: set[str] = set()
+            for doc_id in pending_deletes:
+                if doc_id in retryable_ids:
+                    new_deletes.add(doc_id)
+            pending_deletes.clear()
+            pending_deletes.update(new_deletes)
+
+            if retryable_ids:
+                logger.warning(
+                    f"[{self.workspace}] {len(retryable_ids)} KV ops will "
+                    f"retry on the next flush (transient failure)"
+                )
+            if non_retryable_ops:
+                sample = non_retryable_ops[:5]
+                sample_text = ", ".join(
+                    f"{op.op}/{op.doc_id}/status={op.status}/{op.error}"
+                    for op in sample
+                )
+                logger.warning(
+                    f"[{self.workspace}] {len(non_retryable_ops)} KV ops "
+                    f"failed permanently and were dropped (non-retryable status). "
+                    f"Sample: {sample_text}"
+                )
+                if len(non_retryable_ops) > len(sample):
+                    logger.debug(
+                        f"[{self.workspace}] Remaining permanent failures: "
+                        + ", ".join(
+                            f"{op.op}/{op.doc_id}/status={op.status}/{op.error}"
+                            for op in non_retryable_ops[len(sample) :]
+                        )
+                    )
+            logger.debug(
+                f"[{self.workspace}] Flushed KV ops: {success} ok, "
+                f"retry={len(retryable_ids)}, dropped={len(non_retryable_ids)}"
+            )
 
     async def index_done_callback(self) -> None:
-        """Refresh index to make recently indexed documents searchable."""
+        """Flush pending KV ops and refresh the index for search visibility.
+
+        Flush runs first so a previously-missing index gets recreated by
+        ``_flush_pending_kv_ops`` (via ``_ensure_index_ready``) before any
+        buffered writes are abandoned. The refresh step is skipped only
+        when the index is still not ready after the flush attempt.
+        """
+        await self._flush_pending_kv_ops()
         if not self._index_ready:
             return
         try:
@@ -606,8 +835,19 @@ class OpenSearchKVStorage(BaseKVStorage):
             pass
 
     async def is_empty(self) -> bool:
-        """Return True if the index contains no documents."""
-        if not self._index_ready:
+        """Return True if the index (plus pending buffer) contains no docs.
+
+        Buffer-aware: a pending upsert makes is_empty False immediately,
+        avoiding the counterintuitive "I just upserted but is_empty
+        returned True" case. Pending deletes alone are not enough to flip
+        the answer because we cannot tell whether other persisted rows
+        survive without flushing.
+        """
+        async with self._flush_lock:
+            if self._pending_upserts:
+                return False
+            index_ready = self._index_ready
+        if not index_ready:
             return True
         try:
             response = await self.client.count(index=self._index_name)
@@ -617,53 +857,41 @@ class OpenSearchKVStorage(BaseKVStorage):
                 self._mark_index_missing()
             return True
 
-    async def delete(self, ids: list[str]) -> None:
-        """Delete documents by their IDs."""
-        if not ids:
-            return
-        if not self._index_ready:
-            return
-        if isinstance(ids, set):
-            ids = list(ids)
-        try:
-            # No per-operation refresh: immediate reads use ID-based mget (translog),
-            # search visibility is guaranteed after index_done_callback() batch refresh.
-            actions = [
-                {"_op_type": "delete", "_index": self._index_name, "_id": doc_id}
-                for doc_id in ids
-            ]
-            success, _ = await helpers.async_bulk(
-                self.client, actions, raise_on_error=False
-            )
-            logger.info(
-                f"[{self.workspace}] Deleted {success} documents from {self.namespace}"
-            )
-        except OpenSearchException as e:
-            if _is_missing_index_error(e):
-                self._mark_index_missing()
-                return
-            logger.error(f"[{self.workspace}] Error deleting documents: {e}")
-
     async def drop(self) -> dict[str, str]:
-        """Delete the entire index."""
-        try:
+        """Delete the entire index, discarding pending buffers.
+
+        Runs entirely under ``_flush_lock`` so a concurrent flush / upsert
+        cannot land writes against an index that is being deleted.
+        """
+        async with self._flush_lock:
+            # Pending writes are meaningless once the index is dropped.
+            self._pending_upserts.clear()
+            self._pending_kv_deletes.clear()
             try:
-                await self.client.indices.delete(index=self._index_name)
-                logger.info(f"[{self.workspace}] Dropped index: {self._index_name}")
-            except NotFoundError:
-                logger.info(
-                    f"[{self.workspace}] Index already missing during drop: {self._index_name}"
+                try:
+                    await self.client.indices.delete(index=self._index_name)
+                    logger.info(
+                        f"[{self.workspace}] Dropped index: {self._index_name}"
+                    )
+                except NotFoundError:
+                    logger.info(
+                        f"[{self.workspace}] Index already missing during drop: {self._index_name}"
+                    )
+                self._mark_index_missing()
+                return {
+                    "status": "success",
+                    "message": f"Index {self._index_name} dropped",
+                }
+            except OpenSearchException as e:
+                self._mark_index_missing()
+                logger.error(f"[{self.workspace}] Error dropping index: {e}")
+                return {"status": "error", "message": str(e)}
+            except Exception as e:
+                self._mark_index_missing()
+                logger.error(
+                    f"[{self.workspace}] Unexpected error dropping index: {e}"
                 )
-            self._mark_index_missing()
-            return {"status": "success", "message": f"Index {self._index_name} dropped"}
-        except OpenSearchException as e:
-            self._mark_index_missing()
-            logger.error(f"[{self.workspace}] Error dropping index: {e}")
-            return {"status": "error", "message": str(e)}
-        except Exception as e:
-            self._mark_index_missing()
-            logger.error(f"[{self.workspace}] Unexpected error dropping index: {e}")
-            return {"status": "error", "message": str(e)}
+                return {"status": "error", "message": str(e)}
 
 
 @final

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -460,26 +460,34 @@ class OpenSearchKVStorage(BaseKVStorage):
     async def finalize(self):
         """Flush pending writes and release the OpenSearch client connection.
 
-        Raises ``RuntimeError`` if the buffer still contains pending ops
-        after the final flush attempt -- e.g. because retryable bulk
-        failures (5xx) left rows behind. The client is released either
-        way so we don't leak a connection on shutdown, but the caller
-        must learn that buffered data did not reach OpenSearch.
+        Regular flush failures (any ``Exception``) are captured so they
+        can be re-surfaced as a ``RuntimeError`` that names the unflushed
+        buffer counts -- otherwise ``LightRAG.finalize_storages()`` would
+        log the storage as successfully finalized while writes silently
+        failed to reach OpenSearch.
+
+        ``BaseException`` subclasses other than ``Exception`` (notably
+        ``asyncio.CancelledError`` / ``KeyboardInterrupt`` / ``SystemExit``)
+        are NOT caught: they propagate through the ``finally`` block so
+        shutdown cancellation is honoured and not silently swallowed.
+        The client is released in ``finally`` so it does not leak whether
+        the flush succeeded, failed, or was cancelled.
         """
-        flush_error: BaseException | None = None
+        flush_error: Exception | None = None
         try:
-            await self._flush_pending_kv_ops()
-        except BaseException as e:
-            # _flush_pending_kv_ops leaves the buffers intact on raise;
-            # capture the error so we can re-surface it after the client
-            # is released (we still must not leak the connection).
-            flush_error = e
+            try:
+                await self._flush_pending_kv_ops()
+            except Exception as e:
+                # _flush_pending_kv_ops leaves the buffers intact on raise.
+                flush_error = e
+        finally:
+            if self.client is not None:
+                await ClientManager.release_client(self.client)
+                self.client = None
 
-        if self.client is not None:
-            await ClientManager.release_client(self.client)
-            self.client = None
-
-        # Snapshot remaining buffer state to report concrete counts.
+        # Reached only when no BaseException propagated through the
+        # finally above. Snapshot remaining buffer state to report
+        # concrete counts.
         pending_upserts = len(self._pending_upserts)
         pending_deletes = len(self._pending_kv_deletes)
 
@@ -3239,21 +3247,29 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
     async def finalize(self):
         """Flush pending writes and release the OpenSearch client connection.
 
-        Raises ``RuntimeError`` if the buffer still contains pending ops
-        after the final flush attempt -- e.g. because retryable bulk
-        failures (5xx) left rows behind. The client is released either
-        way so we don't leak a connection on shutdown, but the caller
-        must learn that buffered data did not reach OpenSearch.
-        """
-        flush_error: BaseException | None = None
-        try:
-            await self._flush_pending_vector_ops()
-        except BaseException as e:
-            flush_error = e
+        Regular flush failures (any ``Exception``) are captured so they
+        can be re-surfaced as a ``RuntimeError`` that names the unflushed
+        buffer counts -- otherwise ``LightRAG.finalize_storages()`` would
+        log the storage as successfully finalized while writes silently
+        failed to reach OpenSearch.
 
-        if self.client is not None:
-            await ClientManager.release_client(self.client)
-            self.client = None
+        ``BaseException`` subclasses other than ``Exception`` (notably
+        ``asyncio.CancelledError`` / ``KeyboardInterrupt`` / ``SystemExit``)
+        are NOT caught: they propagate through the ``finally`` block so
+        shutdown cancellation is honoured and not silently swallowed.
+        The client is released in ``finally`` so it does not leak whether
+        the flush succeeded, failed, or was cancelled.
+        """
+        flush_error: Exception | None = None
+        try:
+            try:
+                await self._flush_pending_vector_ops()
+            except Exception as e:
+                flush_error = e
+        finally:
+            if self.client is not None:
+                await ClientManager.release_client(self.client)
+                self.client = None
 
         pending_docs = len(self._pending_vector_docs)
         pending_deletes = len(self._pending_vector_deletes)

--- a/tests/test_opensearch_storage.py
+++ b/tests/test_opensearch_storage.py
@@ -936,6 +936,67 @@ class TestKVStorageBatching:
                 assert s.client is None
 
     @pytest.mark.asyncio
+    async def test_kv_finalize_raises_when_retryable_buffer_remains(
+        self, global_config, embed_func, mock_client
+    ):
+        """finalize() must surface a RuntimeError when retryable bulk
+        failures left rows buffered, otherwise the upstream
+        finalize_storages() call would log the storage as successfully
+        finalized while writes are silently lost.
+
+        The client is still released so we don't leak a connection on
+        shutdown.
+        """
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch.object(
+                ClientManager, "release_client", new_callable=AsyncMock
+            ) as mock_release:
+                with patch(
+                    "lightrag.kg.opensearch_impl.helpers.async_bulk",
+                    new_callable=AsyncMock,
+                ) as mock_bulk:
+                    # 503 is retryable; flush keeps it in the buffer.
+                    mock_bulk.return_value = (
+                        0,
+                        [{"index": {"_id": "k1", "status": 503, "error": "down"}}],
+                    )
+                    s = self._make(global_config, embed_func)
+                    await s.initialize()
+                    await s.upsert({"k1": {"content": "stuck"}})
+                    with pytest.raises(RuntimeError, match="pending upserts"):
+                        await s.finalize()
+                    # Client released regardless of the failure.
+                    mock_release.assert_awaited_once()
+                    assert s.client is None
+
+    @pytest.mark.asyncio
+    async def test_kv_finalize_propagates_flush_exception(
+        self, global_config, embed_func, mock_client
+    ):
+        """If async_bulk itself raises, finalize() still releases the
+        client and wraps the original error in a RuntimeError that
+        names the unflushed buffer counts.
+        """
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch.object(
+                ClientManager, "release_client", new_callable=AsyncMock
+            ) as mock_release:
+                with patch(
+                    "lightrag.kg.opensearch_impl.helpers.async_bulk",
+                    new_callable=AsyncMock,
+                ) as mock_bulk:
+                    mock_bulk.side_effect = OpenSearchException("connection reset")
+                    s = self._make(global_config, embed_func)
+                    await s.initialize()
+                    await s.upsert({"k1": {"content": "stuck"}})
+                    with pytest.raises(RuntimeError) as exc_info:
+                        await s.finalize()
+                    # Wrapped: cause is the original OpenSearchException.
+                    assert isinstance(exc_info.value.__cause__, OpenSearchException)
+                    mock_release.assert_awaited_once()
+                    assert s.client is None
+
+    @pytest.mark.asyncio
     async def test_kv_drop_discards_buffers_and_serialises_with_flush(
         self, global_config, embed_func, mock_client
     ):
@@ -3305,6 +3366,63 @@ class TestVectorStorageBatching:
                 await s.finalize()
                 mock_bulk.assert_awaited_once()
                 assert s.client is None
+
+    @pytest.mark.asyncio
+    async def test_vector_finalize_raises_when_retryable_buffer_remains(
+        self, global_config, embed_func, mock_client
+    ):
+        """finalize() must surface a RuntimeError when retryable bulk
+        failures left vector rows buffered, otherwise the upstream
+        finalize_storages() call would log the storage as successfully
+        finalized while writes are silently lost.
+
+        The client is still released regardless to avoid connection leak.
+        """
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch.object(
+                ClientManager, "release_client", new_callable=AsyncMock
+            ) as mock_release:
+                with patch(
+                    "lightrag.kg.opensearch_impl.helpers.async_bulk",
+                    new_callable=AsyncMock,
+                ) as mock_bulk:
+                    mock_bulk.return_value = (
+                        0,
+                        [{"index": {"_id": "v1", "status": 503, "error": "down"}}],
+                    )
+                    s = self._make(global_config, embed_func)
+                    await s.initialize()
+                    await s.upsert({"v1": {"content": "stuck"}})
+                    with pytest.raises(RuntimeError, match="pending upserts"):
+                        await s.finalize()
+                    mock_release.assert_awaited_once()
+                    assert s.client is None
+
+    @pytest.mark.asyncio
+    async def test_vector_finalize_propagates_flush_exception(
+        self, global_config, embed_func, mock_client
+    ):
+        """If async_bulk raises during the final flush, finalize() still
+        releases the client and wraps the original error in a RuntimeError
+        that names the unflushed buffer counts.
+        """
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch.object(
+                ClientManager, "release_client", new_callable=AsyncMock
+            ) as mock_release:
+                with patch(
+                    "lightrag.kg.opensearch_impl.helpers.async_bulk",
+                    new_callable=AsyncMock,
+                ) as mock_bulk:
+                    mock_bulk.side_effect = OpenSearchException("connection reset")
+                    s = self._make(global_config, embed_func)
+                    await s.initialize()
+                    await s.upsert({"v1": {"content": "stuck"}})
+                    with pytest.raises(RuntimeError) as exc_info:
+                        await s.finalize()
+                    assert isinstance(exc_info.value.__cause__, OpenSearchException)
+                    mock_release.assert_awaited_once()
+                    assert s.client is None
 
     @pytest.mark.asyncio
     async def test_drop_discards_pending_buffers(

--- a/tests/test_opensearch_storage.py
+++ b/tests/test_opensearch_storage.py
@@ -966,9 +966,9 @@ class TestKVStorageBatching:
                 drop_task = asyncio.create_task(s.drop())
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not drop_delete_started.is_set(), (
-                    "indices.delete should be blocked behind the flush lock"
-                )
+                assert (
+                    not drop_delete_started.is_set()
+                ), "indices.delete should be blocked behind the flush lock"
                 assert not drop_task.done()
                 flush_can_finish.set()
                 await flush_task
@@ -1062,9 +1062,9 @@ class TestKVStorageBatching:
                 )
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not concurrent_task.done(), (
-                    "concurrent upsert should be blocked by the flush lock"
-                )
+                assert (
+                    not concurrent_task.done()
+                ), "concurrent upsert should be blocked by the flush lock"
                 assert "k2" not in s._pending_upserts
 
                 flush_can_finish.set()

--- a/tests/test_opensearch_storage.py
+++ b/tests/test_opensearch_storage.py
@@ -452,6 +452,7 @@ class TestKVStorage:
     async def test_upsert_no_per_operation_refresh(
         self, global_config, embed_func, mock_client
     ):
+        """The flush (during index_done_callback) must not request per-op refresh."""
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             with patch(
                 "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
@@ -460,11 +461,15 @@ class TestKVStorage:
                 s = self._make(global_config, embed_func)
                 await s.initialize()
                 await s.upsert({"k1": {"content": "v1"}})
+                # upsert buffers; bulk fires on flush.
+                mock_bulk.assert_not_awaited()
+                await s.index_done_callback()
                 _, kwargs = mock_bulk.call_args
                 assert "refresh" not in kwargs
 
     @pytest.mark.asyncio
     async def test_upsert_sets_timestamps(self, global_config, embed_func, mock_client):
+        """Buffered docs carry create_time / update_time set eagerly during upsert."""
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             with patch(
                 "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
@@ -473,6 +478,10 @@ class TestKVStorage:
                 s = self._make(global_config, embed_func)
                 await s.initialize()
                 await s.upsert({"k1": {"content": "v1"}})
+                # Timestamps are visible in the pending buffer immediately.
+                assert "create_time" in s._pending_upserts["k1"]
+                assert "update_time" in s._pending_upserts["k1"]
+                await s.index_done_callback()
                 actions = mock_bulk.call_args[0][1]
                 src = actions[0]["_source"]
                 assert "create_time" in src
@@ -488,6 +497,7 @@ class TestKVStorage:
 
     @pytest.mark.asyncio
     async def test_delete(self, global_config, embed_func, mock_client):
+        """delete() buffers tombstones; the bulk delete fires on flush."""
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             with patch(
                 "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
@@ -496,7 +506,11 @@ class TestKVStorage:
                 s = self._make(global_config, embed_func)
                 await s.initialize()
                 await s.delete(["a", "b"])
+                mock_bulk.assert_not_awaited()
+                assert s._pending_kv_deletes == {"a", "b"}
+                await s.index_done_callback()
                 actions = mock_bulk.call_args[0][1]
+                assert len(actions) == 2
                 assert all(a["_op_type"] == "delete" for a in actions)
 
     @pytest.mark.asyncio
@@ -651,6 +665,415 @@ class TestKVStorage:
                 await s.finalize()
                 mock_release.assert_awaited_once()
                 assert s.client is None
+
+
+# ---------------------------------------------------------------------------
+# KV storage write batching (derived from issue #2785 / PR #2822)
+# ---------------------------------------------------------------------------
+
+
+class TestKVStorageBatching:
+    """Tests for the buffered upsert/delete + flush behaviour."""
+
+    def _make(self, global_config, embed_func, workspace="test"):
+        return OpenSearchKVStorage(
+            namespace="text_chunks",
+            global_config=global_config,
+            embedding_func=embed_func,
+            workspace=workspace,
+        )
+
+    @pytest.mark.asyncio
+    async def test_repeated_kv_upserts_flush_in_single_bulk_call(
+        self, global_config, embed_func, mock_client
+    ):
+        """Many small upsert() calls collapse to one async_bulk on flush."""
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch(
+                "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
+            ) as mock_bulk:
+                mock_bulk.return_value = (5, [])
+                s = self._make(global_config, embed_func)
+                await s.initialize()
+                for i in range(5):
+                    await s.upsert({f"k{i}": {"content": f"doc {i}"}})
+                mock_bulk.assert_not_awaited()
+                await s.index_done_callback()
+                mock_bulk.assert_awaited_once()
+                actions = mock_bulk.call_args[0][1]
+                assert len(actions) == 5
+                assert {a["_id"] for a in actions} == {f"k{i}" for i in range(5)}
+
+    @pytest.mark.asyncio
+    async def test_kv_upsert_overwrites_pending_doc_for_same_id(
+        self, global_config, embed_func, mock_client
+    ):
+        """Upserting the same id twice keeps only the latest payload."""
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch(
+                "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
+            ) as mock_bulk:
+                mock_bulk.return_value = (1, [])
+                s = self._make(global_config, embed_func)
+                await s.initialize()
+                await s.upsert({"k1": {"content": "first"}})
+                await s.upsert({"k1": {"content": "second"}})
+                await s.index_done_callback()
+                actions = mock_bulk.call_args[0][1]
+                assert len(actions) == 1
+                assert actions[0]["_source"]["content"] == "second"
+
+    @pytest.mark.asyncio
+    async def test_kv_delete_cancels_pending_upsert(
+        self, global_config, embed_func, mock_client
+    ):
+        """A delete after a buffered upsert removes the upsert from the buffer.
+
+        Without this, the flush would re-index the doc and silently
+        resurrect a logically-deleted key.
+        """
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch(
+                "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
+            ) as mock_bulk:
+                mock_bulk.return_value = (1, [])
+                s = self._make(global_config, embed_func)
+                await s.initialize()
+                await s.upsert({"k1": {"content": "doomed"}})
+                await s.delete(["k1"])
+                assert "k1" not in s._pending_upserts
+                assert "k1" in s._pending_kv_deletes
+                await s.index_done_callback()
+                actions = mock_bulk.call_args[0][1]
+                assert len(actions) == 1
+                assert actions[0]["_op_type"] == "delete"
+
+    @pytest.mark.asyncio
+    async def test_kv_upsert_cancels_pending_delete(
+        self, global_config, embed_func, mock_client
+    ):
+        """An upsert after a buffered delete removes the tombstone."""
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch(
+                "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
+            ) as mock_bulk:
+                mock_bulk.return_value = (1, [])
+                s = self._make(global_config, embed_func)
+                await s.initialize()
+                await s.delete(["k1"])
+                await s.upsert({"k1": {"content": "resurrected"}})
+                assert "k1" not in s._pending_kv_deletes
+                assert "k1" in s._pending_upserts
+                await s.index_done_callback()
+                actions = mock_bulk.call_args[0][1]
+                assert len(actions) == 1
+                assert actions[0]["_op_type"] == "index"
+
+    @pytest.mark.asyncio
+    async def test_kv_delete_works_when_index_not_ready(
+        self, global_config, embed_func, mock_client
+    ):
+        """delete() must invalidate pending upserts even if the index has
+        been marked missing -- otherwise the next flush would resurrect
+        the logically-deleted key.
+        """
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch(
+                "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
+            ) as mock_bulk:
+                mock_bulk.return_value = (1, [])
+                s = self._make(global_config, embed_func)
+                await s.initialize()
+                await s.upsert({"k1": {"content": "x"}})
+                s._mark_index_missing()
+                await s.delete(["k1"])
+                # Buffer invariants hold regardless of _index_ready.
+                assert "k1" not in s._pending_upserts
+                assert "k1" in s._pending_kv_deletes
+
+    @pytest.mark.asyncio
+    async def test_kv_get_by_id_reads_pending_buffer(
+        self, global_config, embed_func, mock_client
+    ):
+        """Buffered upserts are visible to get_by_id without hitting OpenSearch."""
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            await s.upsert({"k1": {"content": "buffered"}})
+            doc = await s.get_by_id("k1")
+            assert doc is not None
+            assert doc["_id"] == "k1"
+            assert doc["content"] == "buffered"
+            mock_client.mget.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_kv_get_by_id_returns_none_for_pending_delete(
+        self, global_config, embed_func, mock_client
+    ):
+        """A pending tombstone shadows any persisted doc, without mget RTT."""
+        mock_client.mget = AsyncMock()
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            await s.delete(["k1"])
+            assert await s.get_by_id("k1") is None
+            mock_client.mget.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_kv_get_by_id_strips_mirrored_id_from_buffer_path(
+        self, global_config, embed_func, mock_client
+    ):
+        """Buffered docs internally carry __mirrored_id (used for PIT sort);
+        the returned dict must NOT expose it, matching the mget read path."""
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            await s.upsert({"k1": {"content": "x"}})
+            # Sanity: the buffer entry itself carries __mirrored_id.
+            assert s._pending_upserts["k1"]["__mirrored_id"] == "k1"
+            doc = await s.get_by_id("k1")
+            assert doc is not None
+            assert "__mirrored_id" not in doc
+            assert doc["_id"] == "k1"
+
+    @pytest.mark.asyncio
+    async def test_kv_get_by_ids_merges_buffer_and_mget(
+        self, global_config, embed_func, mock_client
+    ):
+        """get_by_ids returns buffered docs and falls back to mget for the rest."""
+        mock_client.mget = AsyncMock(
+            return_value={
+                "docs": [
+                    {
+                        "_id": "k2",
+                        "found": True,
+                        "_source": {"content": "from_index"},
+                    },
+                ]
+            }
+        )
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            await s.upsert({"k1": {"content": "buffered"}})
+            docs = await s.get_by_ids(["k1", "k2"])
+            assert docs[0]["content"] == "buffered"
+            assert "__mirrored_id" not in docs[0]
+            assert docs[1]["content"] == "from_index"
+            mock_client.mget.assert_awaited_once_with(
+                index=s._index_name, body={"ids": ["k2"]}
+            )
+
+    @pytest.mark.asyncio
+    async def test_kv_filter_keys_excludes_buffered_upserts(
+        self, global_config, embed_func, mock_client
+    ):
+        """Buffered upserts shadow OpenSearch: filter_keys treats them as
+        existing and never queries them via mget."""
+        mock_client.mget = AsyncMock(
+            return_value={"docs": [{"_id": "k2", "found": False}]}
+        )
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            await s.upsert({"k1": {"content": "x"}})
+            missing = await s.filter_keys({"k1", "k2"})
+            assert missing == {"k2"}
+            # Only the unbuffered id is queried server-side.
+            ((_, kwargs),) = mock_client.mget.await_args_list[0:1]
+            assert kwargs["body"] == {"ids": ["k2"]}
+
+    @pytest.mark.asyncio
+    async def test_kv_filter_keys_treats_buffered_deletes_as_missing(
+        self, global_config, embed_func, mock_client
+    ):
+        """A persisted-but-pending-delete key must be reported as missing
+        AND must NOT be looked up via mget (otherwise the still-persisted
+        row would be misclassified as existing)."""
+        mock_client.mget = AsyncMock(
+            return_value={"docs": [{"_id": "k3", "found": True}]}
+        )
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            await s.delete(["k1"])  # tombstone
+            missing = await s.filter_keys({"k1", "k3"})
+            assert "k1" in missing  # tombstoned key counts as missing
+            assert "k3" not in missing  # exists on server
+            # The tombstone id was NOT sent to mget.
+            mget_kwargs = mock_client.mget.await_args_list[0].kwargs
+            assert mget_kwargs["body"] == {"ids": ["k3"]}
+
+    @pytest.mark.asyncio
+    async def test_kv_is_empty_returns_false_with_pending_upsert(
+        self, global_config, embed_func, mock_client
+    ):
+        """is_empty short-circuits to False when the buffer has pending
+        upserts -- avoiding the counterintuitive "I just upserted but
+        is_empty returned True" outcome."""
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            await s.upsert({"k1": {"content": "x"}})
+            assert await s.is_empty() is False
+            mock_client.count.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_kv_finalize_flushes_pending(
+        self, global_config, embed_func, mock_client
+    ):
+        """finalize() flushes the buffer before releasing the client."""
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch(
+                "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
+            ) as mock_bulk:
+                mock_bulk.return_value = (1, [])
+                s = self._make(global_config, embed_func)
+                await s.initialize()
+                await s.upsert({"k1": {"content": "to flush"}})
+                await s.finalize()
+                mock_bulk.assert_awaited_once()
+                assert s.client is None
+
+    @pytest.mark.asyncio
+    async def test_kv_drop_discards_buffers_and_serialises_with_flush(
+        self, global_config, embed_func, mock_client
+    ):
+        """drop() drops both buffers and is serialised with any in-flight
+        flush so indices.delete cannot land mid-bulk."""
+        flush_started = asyncio.Event()
+        flush_can_finish = asyncio.Event()
+        drop_delete_started = asyncio.Event()
+
+        async def slow_bulk(client, actions, raise_on_error=False, **kwargs):
+            flush_started.set()
+            await flush_can_finish.wait()
+            return (len(actions), [])
+
+        async def watch_indices_delete(**kwargs):
+            drop_delete_started.set()
+
+        mock_client.indices.delete = AsyncMock(side_effect=watch_indices_delete)
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch("lightrag.kg.opensearch_impl.helpers.async_bulk", new=slow_bulk):
+                s = self._make(global_config, embed_func)
+                await s.initialize()
+                await s.upsert({"k1": {"content": "x"}})
+                await s.delete(["k2"])
+
+                flush_task = asyncio.create_task(s.index_done_callback())
+                await flush_started.wait()
+                drop_task = asyncio.create_task(s.drop())
+                for _ in range(5):
+                    await asyncio.sleep(0)
+                assert not drop_delete_started.is_set(), (
+                    "indices.delete should be blocked behind the flush lock"
+                )
+                assert not drop_task.done()
+                flush_can_finish.set()
+                await flush_task
+                await drop_task
+                assert drop_delete_started.is_set()
+                # Even though flush flushed k1/k2, drop() then cleared the
+                # buffer state (no-op here because flush already drained
+                # them, but the assertion confirms drop() does not crash
+                # against the now-empty buffer).
+                assert s._pending_upserts == {}
+                assert s._pending_kv_deletes == set()
+
+    @pytest.mark.asyncio
+    async def test_kv_failed_flush_retains_retryable(
+        self, global_config, embed_func, mock_client
+    ):
+        """Transient (5xx) per-doc failures stay buffered for the next flush."""
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch(
+                "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
+            ) as mock_bulk:
+                mock_bulk.return_value = (
+                    1,
+                    [{"index": {"_id": "k2", "status": 503, "error": "down"}}],
+                )
+                s = self._make(global_config, embed_func)
+                await s.initialize()
+                await s.upsert({"k1": {"content": "ok"}, "k2": {"content": "boom"}})
+                await s.index_done_callback()
+                assert "k1" not in s._pending_upserts
+                assert "k2" in s._pending_upserts
+
+    @pytest.mark.asyncio
+    async def test_kv_failed_flush_drops_non_retryable(
+        self, global_config, embed_func, mock_client
+    ):
+        """Permanent (4xx, e.g. mapping error) failures are cleared from
+        the buffer rather than retried forever."""
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch(
+                "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
+            ) as mock_bulk:
+                mock_bulk.return_value = (
+                    0,
+                    [
+                        {
+                            "index": {
+                                "_id": "k1",
+                                "status": 400,
+                                "error": {
+                                    "type": "mapper_parsing_exception",
+                                    "reason": "bad",
+                                },
+                            }
+                        },
+                        {"index": {"_id": "k2", "status": 503, "error": "down"}},
+                    ],
+                )
+                s = self._make(global_config, embed_func)
+                await s.initialize()
+                await s.upsert({"k1": {"content": "x"}, "k2": {"content": "y"}})
+                await s.index_done_callback()
+                assert "k1" not in s._pending_upserts
+                assert "k2" in s._pending_upserts
+
+    @pytest.mark.asyncio
+    async def test_kv_concurrent_upsert_during_flush_blocked(
+        self, global_config, embed_func, mock_client
+    ):
+        """A concurrent upsert that lands while async_bulk is in flight is
+        blocked by the namespace lock and lands in the buffer only after
+        the flush completes."""
+        flush_started = asyncio.Event()
+        flush_can_finish = asyncio.Event()
+
+        async def slow_bulk(client, actions, raise_on_error=False, **kwargs):
+            flush_started.set()
+            await flush_can_finish.wait()
+            return (len(actions), [])
+
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch("lightrag.kg.opensearch_impl.helpers.async_bulk", new=slow_bulk):
+                s = self._make(global_config, embed_func)
+                await s.initialize()
+                await s.upsert({"k1": {"content": "first"}})
+
+                flush_task = asyncio.create_task(s.index_done_callback())
+                await flush_started.wait()
+                concurrent_task = asyncio.create_task(
+                    s.upsert({"k2": {"content": "concurrent"}})
+                )
+                for _ in range(5):
+                    await asyncio.sleep(0)
+                assert not concurrent_task.done(), (
+                    "concurrent upsert should be blocked by the flush lock"
+                )
+                assert "k2" not in s._pending_upserts
+
+                flush_can_finish.set()
+                await flush_task
+                await concurrent_task
+
+                # k1 flushed and cleared; k2 added after flush released.
+                assert "k1" not in s._pending_upserts
+                assert "k2" in s._pending_upserts
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_opensearch_storage.py
+++ b/tests/test_opensearch_storage.py
@@ -997,6 +997,33 @@ class TestKVStorageBatching:
                     assert s.client is None
 
     @pytest.mark.asyncio
+    async def test_kv_finalize_propagates_cancellation(
+        self, global_config, embed_func, mock_client
+    ):
+        """asyncio.CancelledError raised during the final flush must
+        propagate UN-wrapped so the shutdown sequence honours the
+        cancellation signal. The client is still released (finally
+        block) before the cancellation continues.
+        """
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch.object(
+                ClientManager, "release_client", new_callable=AsyncMock
+            ) as mock_release:
+                with patch(
+                    "lightrag.kg.opensearch_impl.helpers.async_bulk",
+                    new_callable=AsyncMock,
+                ) as mock_bulk:
+                    mock_bulk.side_effect = asyncio.CancelledError()
+                    s = self._make(global_config, embed_func)
+                    await s.initialize()
+                    await s.upsert({"k1": {"content": "stuck"}})
+                    with pytest.raises(asyncio.CancelledError):
+                        await s.finalize()
+                    # finally block still released the client.
+                    mock_release.assert_awaited_once()
+                    assert s.client is None
+
+    @pytest.mark.asyncio
     async def test_kv_drop_discards_buffers_and_serialises_with_flush(
         self, global_config, embed_func, mock_client
     ):
@@ -3421,6 +3448,32 @@ class TestVectorStorageBatching:
                     with pytest.raises(RuntimeError) as exc_info:
                         await s.finalize()
                     assert isinstance(exc_info.value.__cause__, OpenSearchException)
+                    mock_release.assert_awaited_once()
+                    assert s.client is None
+
+    @pytest.mark.asyncio
+    async def test_vector_finalize_propagates_cancellation(
+        self, global_config, embed_func, mock_client
+    ):
+        """asyncio.CancelledError raised during the final flush must
+        propagate UN-wrapped so the shutdown sequence honours the
+        cancellation signal. The client is still released (finally
+        block) before the cancellation continues.
+        """
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch.object(
+                ClientManager, "release_client", new_callable=AsyncMock
+            ) as mock_release:
+                with patch(
+                    "lightrag.kg.opensearch_impl.helpers.async_bulk",
+                    new_callable=AsyncMock,
+                ) as mock_bulk:
+                    mock_bulk.side_effect = asyncio.CancelledError()
+                    s = self._make(global_config, embed_func)
+                    await s.initialize()
+                    await s.upsert({"v1": {"content": "stuck"}})
+                    with pytest.raises(asyncio.CancelledError):
+                        await s.finalize()
                     mock_release.assert_awaited_once()
                     assert s.client is None
 


### PR DESCRIPTION
## Summary

Refs #2785. Supersedes the KV-storage portion of #2822 (Vector was already covered by #3043; Graph is deferred to a separate follow-up).

`OpenSearchKVStorage.upsert()` and `delete()` each previously issued an `async_bulk` call per invocation. The profile in #2785 shows the upstream pipeline calling KV `upsert` 651 times for the demo workload, dominating the KV path with sequential HTTP roundtrips even though every call is technically a "bulk" of 1.

This PR buffers writes and deletes in memory and flushes them in a single `async_bulk` call inside `index_done_callback()` / `finalize()`, matching the contract documented on `BaseKVStorage` ("changes will be persisted during the next `index_done_callback`"). All buffer reads / writes are serialised through `get_namespace_lock`, mirroring the model introduced for the Vector backend in #3043.

Credit goes to @he-yufeng for the original KV batching implementation in #2822; this PR is a rebase + redesign for the post-#3043 lock model with a fix for the resurrect bug (see below).

## What changed in `OpenSearchKVStorage`

### Batched writes
- `upsert()` time-stamps + injects `__mirrored_id` eagerly outside the lock; the buffer-write loop is the only step that holds `_flush_lock`. An upsert cancels any pending tombstone for the same id.
- `delete()` buffers ids into `_pending_kv_deletes`. A delete cancels any pending upsert for the same id. `_index_ready` is intentionally NOT checked — the cancellation invariant must hold even if the index has been marked missing.
- `_flush_pending_kv_ops()` issues a single `async_bulk` for all pending deletes + upserts (deletes first), lock-guarded. Reuses the `_extract_bulk_failed_ids` / `_FailedBulkOp` / `_summarize_bulk_error` helpers added by #3043.
- `index_done_callback()` flushes pending ops before refreshing the index.
- `finalize()` flushes pending ops, releases the client unconditionally to avoid connection leaks, **and raises `RuntimeError` if any ops remained buffered after the final flush** (e.g. due to retryable 5xx failures). Without this last step, `LightRAG.finalize_storages()` would log the storage as successfully finalized while buffered writes silently failed to reach OpenSearch. The same fix is applied to `OpenSearchVectorDBStorage.finalize()`, which had the identical bug since #3043.
- `drop()` runs entirely under `_flush_lock`, clearing both buffers and serialising with any in-flight flush.

### Concurrency
- `_flush_lock` is a `get_namespace_lock(namespace, workspace=...)` instance (multi-process aware), set in `initialize()`. Same primitive as `NanoVectorDBStorage._storage_lock` and `OpenSearchVectorDBStorage._flush_lock`.
- All buffer mutations and reads acquire this lock; remote IO (mget, `client.count`) runs outside the lock so RTT does not block flushes.

### Read-your-writes, with consistent shape
- `get_by_id` / `get_by_ids` follow a three-tier priority under the lock: pending delete (return `None`) → pending upsert (return buffered source) → fall through to mget.
- The buffered path strips `__mirrored_id` (the PIT-sort sentinel injected during upsert) and attaches `_id` / `create_time` / `update_time`, matching the mget read path. Without this strip, callers would see a `__mirrored_id` field for buffered docs but not for persisted ones.
- `filter_keys` treats buffered upserts as existing (excluded from the missing set) and buffered deletes as missing (the tombstone id is NOT sent to mget — otherwise a persisted-but-pending-delete row would be misclassified as existing).
- `is_empty` short-circuits to False when the buffer has pending upserts, avoiding the counterintuitive "I just upserted but is_empty returned True" outcome.

### Failure handling
- Per-doc bulk failures are classified by HTTP status via `_extract_bulk_failed_ids`:
  - Retryable (408 / 429 / 5xx / missing status): kept in the buffer for the next flush.
  - Non-retryable (most 4xx, mapping errors): dropped from the buffer. A sample of `(op, id, status, error)` is logged at WARNING with dict-shape errors summarised via `reason` / `type`, capped at 200 chars; remaining failures dump at DEBUG.
  - `404` on a delete is treated as success-equivalent.
- If `helpers.async_bulk` raises, the buffers are left intact — KV ops are idempotent on `_id`.

## The resurrect bug (and why KV delete also buffers)

Without delete buffering, mixing upsert + delete on the same id would silently re-index the row:

```
T0: upsert("k1", v1)          → _pending_upserts["k1"] = v1
T1: delete(["k1"])            → directly async_bulk delete; buffer untouched
T2: get_by_id("k1")           → buffer hit returns v1 (the doc has been deleted)
T3: index_done_callback flush → re-indexes the buffered v1, reviving the row
```

The fix is the upsert↔delete cancellation pair: each buffer entry is the authoritative pending state, and a delete actively pops the upsert from `_pending_upserts` (not the other way around). The flush then sees the correct intent and emits one delete action.

## Backwards compatibility

No public API changes. Method signatures, return types, and error paths are unchanged.

Behavioural changes worth noting:

1. **KV writes are deferred until `index_done_callback()` / `finalize()`** — matches `BaseKVStorage`'s documented contract and the behaviour of every other LightRAG storage backend.

2. **Cross-worker read-after-write visibility now requires `index_done_callback()`** (multi-worker deployments, e.g. `lightrag-gunicorn`). Before this PR, OpenSearch's per-call `async_bulk` made writes visible to other workers via mget/translog within milliseconds. After this PR, the in-memory buffer is **process-local**, so Worker B's `get_by_id` will not see Worker A's buffered writes until A has flushed. The `BaseKVStorage` docstring now states this explicitly. Application code that relies on cross-worker sub-second visibility must `await rag.text_chunks.index_done_callback()` (or wait for the pipeline's own `_insert_done()`) before reading from another worker. The pipeline itself is unaffected because it holds `pipeline_status.busy` for the duration of ingestion.

## Out of scope

- **Graph storage batching**: deferred to a separate PR. Graph has ~12 read paths that would need to consult the buffer (`has_node` / `get_node` / `get_edge` / `get_node_edges` / `get_edges_batch` / `get_nodes_batch` / `node_degree` / `edge_degree` / `get_knowledge_graph` / `get_all_labels` / `get_popular_labels` / `search_labels`) plus inter-entity cascades (delete_node invalidating buffered edges). Single PR risk too high; cleaner to split.
- **Vector storage**: already covered by #3043, untouched here.
- **Sharing the failure-handling helper across backends**: `_extract_bulk_failed_ids` is reused; full base-class extraction can wait until Graph lands.

## Test plan

- [x] `ruff check .` passes.
- [x] `pytest tests/test_opensearch_storage.py` — 168 passed (17 new + 3 updated).
- [x] `TestKVStorageBatching` covers:
  - repeated `upsert()` calls collapse into a single `async_bulk`
  - upserting the same id twice keeps the latest payload
  - `delete()` cancels a pending upsert; `upsert()` cancels a pending delete
  - `delete()` still cancels pending upsert when `_index_ready` is False (resurrect-bug guard)
  - `get_by_id` reads the buffer (no `mget`)
  - `get_by_id` returns `None` for pending tombstones (no `mget`)
  - `get_by_id` strips `__mirrored_id` from the buffer path
  - `get_by_ids` merges buffer + mget for unbuffered ids only
  - `filter_keys` excludes buffered upserts from the missing set
  - `filter_keys` treats buffered deletes as missing AND skips them in mget
  - `is_empty` returns False with a pending upsert (no `client.count`)
  - `finalize()` flushes before releasing the client
  - `finalize()` raises when retryable bulk failures left ops buffered (KV + Vector)
  - `finalize()` wraps a flushing `OpenSearchException` in a RuntimeError that names the unflushed buffer counts (KV + Vector)
  - `drop()` discards both buffers AND is serialised with an in-flight flush
  - per-doc retryable failures (5xx) are retained for retry
  - per-doc non-retryable failures (4xx) are dropped
  - concurrent `upsert` during flush is blocked by the lock and lands after release
- [x] All 151 pre-existing OpenSearch tests still pass.

