### PR TITLE
feat(graph): block graph mutations while pipeline is busy

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -1063,6 +1063,54 @@ async def _reserve_enqueue_slot(rag: LightRAG) -> bool:
     return True
 
 
+async def check_pipeline_busy_or_raise(rag: LightRAG) -> None:
+    """Refuse the request with HTTP 409 when the document pipeline is busy.
+
+    Intended for short, fine-grained graph mutations (entity/relation
+    edit/create/delete/merge). Reads ``pipeline_status['busy']`` under
+    the namespace lock and raises immediately on contention -- it does
+    NOT set any flag, so it cannot block the pipeline itself.
+
+    ``busy`` is set by the processing loop and by destructive jobs
+    (``/documents/clear`` / per-doc delete). Both paths concurrently
+    write the same graph storages that these endpoints mutate, so a
+    409 here mirrors the existing UI guard and tells clients to wait.
+
+    A narrow race remains between this check and the underlying graph
+    write: if the pipeline transitions to busy in that window, the
+    per-edge/-node locks inside the storage layer are the last line of
+    defense. That trade-off is deliberate -- holding ``busy`` here
+    would serialise every UI edit against document ingestion, which is
+    a worse user-visible failure mode than tolerating the race.
+
+    No-op (returns silently) when ``pipeline_status`` was never
+    bootstrapped, matching the behaviour of ``_acquire_destructive_busy``
+    so test rigs without a real shared-storage Manager keep working.
+    """
+    from lightrag.exceptions import PipelineNotInitializedError
+    from lightrag.kg.shared_storage import get_namespace_data, get_namespace_lock
+
+    try:
+        pipeline_status = await get_namespace_data(
+            "pipeline_status", workspace=rag.workspace
+        )
+    except PipelineNotInitializedError:
+        return
+    pipeline_status_lock = get_namespace_lock(
+        "pipeline_status", workspace=rag.workspace
+    )
+    async with pipeline_status_lock:
+        if pipeline_status.get("busy"):
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "Pipeline is busy with another operation. "
+                    "Wait for the running job to finish before editing "
+                    "the knowledge graph."
+                ),
+            )
+
+
 async def _acquire_destructive_busy(rag: LightRAG) -> tuple[bool, str | None]:
     """Atomically reserve the destructive busy slot for ``/documents/clear``
     or ``/documents/delete_document``.
@@ -3748,6 +3796,7 @@ def create_document_routes(
             HTTPException: If the entity is not found (404) or an error occurs (500).
         """
         try:
+            await check_pipeline_busy_or_raise(rag)
             result = await rag.adelete_by_entity(entity_name=request.entity_name)
             if result.status == "not_found":
                 raise HTTPException(status_code=404, detail=result.message)
@@ -3783,6 +3832,7 @@ def create_document_routes(
             HTTPException: If the relation is not found (404) or an error occurs (500).
         """
         try:
+            await check_pipeline_busy_or_raise(rag)
             result = await rag.adelete_by_relation(
                 source_entity=request.source_entity,
                 target_entity=request.target_entity,

--- a/lightrag/api/routers/graph_routes.py
+++ b/lightrag/api/routers/graph_routes.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field
 
 from lightrag.utils import logger
 from ..utils_api import get_combined_auth_dependency
+from .document_routes import check_pipeline_busy_or_raise
 
 
 class EntityUpdateRequest(BaseModel):
@@ -357,6 +358,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             }
         """
         try:
+            await check_pipeline_busy_or_raise(rag)
             result = await rag.aedit_entity(
                 entity_name=request.entity_name,
                 updated_data=request.updated_data,
@@ -399,6 +401,8 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
                 "data": entity_data,
                 "operation_summary": operation_summary,
             }
+        except HTTPException:
+            raise
         except ValueError as ve:
             logger.error(
                 f"Validation error updating entity '{request.entity_name}': {str(ve)}"
@@ -422,6 +426,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             Dict: Updated relation information
         """
         try:
+            await check_pipeline_busy_or_raise(rag)
             result = await rag.aedit_relation(
                 source_entity=request.source_id,
                 target_entity=request.target_id,
@@ -432,6 +437,8 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
                 "message": "Relation updated successfully",
                 "data": result,
             }
+        except HTTPException:
+            raise
         except ValueError as ve:
             logger.error(
                 f"Validation error updating relation between '{request.source_id}' and '{request.target_id}': {str(ve)}"
@@ -492,6 +499,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             }
         """
         try:
+            await check_pipeline_busy_or_raise(rag)
             # Use the proper acreate_entity method which handles:
             # - Graph lock for concurrency
             # - Vector embedding creation in entities_vdb
@@ -507,6 +515,8 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
                 "message": f"Entity '{request.entity_name}' created successfully",
                 "data": result,
             }
+        except HTTPException:
+            raise
         except ValueError as ve:
             logger.error(
                 f"Validation error creating entity '{request.entity_name}': {str(ve)}"
@@ -577,6 +587,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             }
         """
         try:
+            await check_pipeline_busy_or_raise(rag)
             # Use the proper acreate_relation method which handles:
             # - Graph lock for concurrency
             # - Entity existence validation
@@ -594,6 +605,8 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
                 "message": f"Relation created successfully between '{request.source_entity}' and '{request.target_entity}'",
                 "data": result,
             }
+        except HTTPException:
+            raise
         except ValueError as ve:
             logger.error(
                 f"Validation error creating relation between '{request.source_entity}' and '{request.target_entity}': {str(ve)}"
@@ -666,6 +679,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             - This operation cannot be undone, so verify entity names before merging
         """
         try:
+            await check_pipeline_busy_or_raise(rag)
             result = await rag.amerge_entities(
                 source_entities=request.entities_to_change,
                 target_entity=request.entity_to_change_into,
@@ -675,6 +689,8 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
                 "message": f"Successfully merged {len(request.entities_to_change)} entities into '{request.entity_to_change_into}'",
                 "data": result,
             }
+        except HTTPException:
+            raise
         except ValueError as ve:
             logger.error(
                 f"Validation error merging entities {request.entities_to_change} into '{request.entity_to_change_into}': {str(ve)}"

--- a/lightrag_webui/src/components/graph/EditablePropertyRow.tsx
+++ b/lightrag_webui/src/components/graph/EditablePropertyRow.tsx
@@ -32,6 +32,7 @@ interface EditablePropertyRowProps {
   onValueChange?: (newValue: any) => void  // Optional callback when value changes
   isEditable?: boolean         // Whether this property can be edited
   tooltip?: string             // Optional tooltip to display on hover
+  pipelineBusy?: boolean       // When true, hide edit entry & disable save (pipeline writing)
 }
 
 /**
@@ -51,7 +52,8 @@ const EditablePropertyRow = ({
   targetId,
   onValueChange,
   isEditable = false,
-  tooltip
+  tooltip,
+  pipelineBusy = false
 }: EditablePropertyRowProps) => {
   const { t } = useTranslation()
   const [isEditing, setIsEditing] = useState(false)
@@ -76,6 +78,7 @@ const EditablePropertyRow = ({
   }
 
   const handleEditClick = () => {
+    if (pipelineBusy) return
     if (isEditable && !isEditing) {
       setDraftValue(String(currentValue))
       setDraftAllowMerge(false)
@@ -275,7 +278,7 @@ const EditablePropertyRow = ({
   return (
     <div className="flex items-center gap-1 overflow-hidden">
       <PropertyName name={name} />
-      <EditIcon onClick={handleEditClick} />:
+      {!pipelineBusy && <EditIcon onClick={handleEditClick} />}:
       <PropertyValue
         value={currentValue}
         onClick={onClick}
@@ -292,6 +295,7 @@ const EditablePropertyRow = ({
         onAllowMergeChange={setDraftAllowMerge}
         isSubmitting={isSubmitting}
         errorMessage={errorMessage}
+        disableSave={pipelineBusy}
       />
 
       <MergeDialog

--- a/lightrag_webui/src/components/graph/PropertiesView.tsx
+++ b/lightrag_webui/src/components/graph/PropertiesView.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react'
 import { useGraphStore, RawNodeType, RawEdgeType } from '@/stores/graph'
+import { useBackendState } from '@/stores/state'
 import Text from '@/components/ui/Text'
 import Button from '@/components/ui/Button'
 import useLightragGraph from '@/hooks/useLightragGraph'
 import { useTranslation } from 'react-i18next'
-import { GitBranchPlus, Scissors } from 'lucide-react'
+import { GitBranchPlus, Scissors, Lock } from 'lucide-react'
 import EditablePropertyRow from './EditablePropertyRow'
 
 /**
@@ -17,6 +18,7 @@ const PropertiesView = () => {
   const selectedEdge = useGraphStore.use.selectedEdge()
   const focusedEdge = useGraphStore.use.focusedEdge()
   const graphDataVersion = useGraphStore.use.graphDataVersion()
+  const pipelineBusy = useBackendState.use.pipelineBusy()
 
   const { currentElement, currentType } = useMemo(() => {
     let type: 'node' | 'edge' | null = null
@@ -53,9 +55,9 @@ const PropertiesView = () => {
   return (
     <div className="bg-background/80 max-w-xs rounded-lg border-2 p-2 text-xs backdrop-blur-lg">
       {currentType == 'node' ? (
-        <NodePropertiesView node={currentElement as any} />
+        <NodePropertiesView node={currentElement as any} pipelineBusy={pipelineBusy} />
       ) : (
-        <EdgePropertiesView edge={currentElement as any} />
+        <EdgePropertiesView edge={currentElement as any} pipelineBusy={pipelineBusy} />
       )}
     </div>
   )
@@ -169,7 +171,8 @@ const PropertyRow = ({
   sourceId,
   targetId,
   isEditable = false,
-  truncate
+  truncate,
+  pipelineBusy = false
 }: {
   name: string
   value: any
@@ -184,6 +187,7 @@ const PropertyRow = ({
   targetId?: string
   isEditable?: boolean
   truncate?: string
+  pipelineBusy?: boolean
 }) => {
   const { t } = useTranslation()
 
@@ -225,6 +229,7 @@ const PropertyRow = ({
         sourceId={sourceId}
         targetId={targetId}
         isEditable={true}
+        pipelineBusy={pipelineBusy}
         tooltip={tooltip || (typeof value === 'string' ? value : JSON.stringify(value, null, 2))}
       />
     )
@@ -249,7 +254,7 @@ const PropertyRow = ({
   )
 }
 
-const NodePropertiesView = ({ node }: { node: NodeType }) => {
+const NodePropertiesView = ({ node, pipelineBusy }: { node: NodeType; pipelineBusy: boolean }) => {
   const { t } = useTranslation()
 
   const handleExpandNode = () => {
@@ -265,6 +270,20 @@ const NodePropertiesView = ({ node }: { node: NodeType }) => {
       <div className="flex justify-between items-center">
         <h3 className="text-md pl-1 font-bold tracking-wide text-blue-700">{t('graphPanel.propertiesView.node.title')}</h3>
         <div className="flex gap-3">
+          {pipelineBusy && (
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              aria-label={t('graphPanel.propertiesView.editLockedByPipeline')}
+              aria-disabled="true"
+              className="h-7 w-7 border border-amber-400 hover:bg-amber-50 dark:border-amber-600 dark:hover:bg-amber-900/40 !cursor-default"
+              tooltip={t('graphPanel.propertiesView.editLockedByPipeline')}
+              onClick={(e) => e.preventDefault()}
+            >
+              <Lock className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+            </Button>
+          )}
           <Button
             size="icon"
             variant="ghost"
@@ -312,6 +331,7 @@ const NodePropertiesView = ({ node }: { node: NodeType }) => {
                 entityType="node"
                 isEditable={name === 'description' || name === 'entity_id' || name === 'entity_type'}
                 truncate={node.properties['truncate']}
+                pipelineBusy={pipelineBusy}
               />
             )
           })}
@@ -341,11 +361,27 @@ const NodePropertiesView = ({ node }: { node: NodeType }) => {
   )
 }
 
-const EdgePropertiesView = ({ edge }: { edge: EdgeType }) => {
+const EdgePropertiesView = ({ edge, pipelineBusy }: { edge: EdgeType; pipelineBusy: boolean }) => {
   const { t } = useTranslation()
   return (
     <div className="flex flex-col gap-2">
-      <h3 className="text-md pl-1 font-bold tracking-wide text-violet-700">{t('graphPanel.propertiesView.edge.title')}</h3>
+      <div className="flex justify-between items-center">
+        <h3 className="text-md pl-1 font-bold tracking-wide text-violet-700">{t('graphPanel.propertiesView.edge.title')}</h3>
+        {pipelineBusy && (
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            aria-label={t('graphPanel.propertiesView.editLockedByPipeline')}
+            aria-disabled="true"
+            className="h-7 w-7 border border-amber-400 hover:bg-amber-50 dark:border-amber-600 dark:hover:bg-amber-900/40 !cursor-default"
+            tooltip={t('graphPanel.propertiesView.editLockedByPipeline')}
+            onClick={(e) => e.preventDefault()}
+          >
+            <Lock className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+          </Button>
+        )}
+      </div>
       <div className="bg-primary/5 max-h-96 overflow-auto rounded p-1">
         <PropertyRow name={t('graphPanel.propertiesView.edge.id')} value={edge.id} />
         {edge.type && <PropertyRow name={t('graphPanel.propertiesView.edge.type')} value={edge.type} />}
@@ -382,6 +418,7 @@ const EdgePropertiesView = ({ edge }: { edge: EdgeType }) => {
                 targetId={edge.targetNode?.properties['entity_id'] || edge.target}
                 isEditable={name === 'description' || name === 'keywords'}
                 truncate={edge.properties['truncate']}
+                pipelineBusy={pipelineBusy}
               />
             )
           })}

--- a/lightrag_webui/src/components/graph/PropertyEditDialog.tsx
+++ b/lightrag_webui/src/components/graph/PropertyEditDialog.tsx
@@ -21,6 +21,7 @@ interface PropertyEditDialogProps {
   onAllowMergeChange: (allowMerge: boolean) => void
   isSubmitting?: boolean
   errorMessage?: string | null
+  disableSave?: boolean
 }
 
 /**
@@ -37,7 +38,8 @@ const PropertyEditDialog = ({
   onValueChange,
   onAllowMergeChange,
   isSubmitting = false,
-  errorMessage = null
+  errorMessage = null,
+  disableSave = false
 }: PropertyEditDialogProps) => {
   const { t } = useTranslation()
 
@@ -103,6 +105,13 @@ const PropertyEditDialog = ({
           </DialogDescription>
         </DialogHeader>
 
+        {/* Pipeline busy banner: editing kept open with draft preserved, but save disabled */}
+        {disableSave && (
+          <div className="bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300 border border-amber-400/60 px-3 py-2 rounded-md text-sm">
+            {t('graphPanel.propertiesView.editLockedByPipeline')}
+          </div>
+        )}
+
         {/* Display error message if save fails */}
         {errorMessage && (
           <div className="bg-destructive/15 text-destructive px-4 py-2 rounded-md text-sm">
@@ -165,7 +174,7 @@ const PropertyEditDialog = ({
           <Button
             type="button"
             onClick={handleSave}
-            disabled={isSubmitting}
+            disabled={isSubmitting || disableSave}
           >
             {isSubmitting ? (
               <>

--- a/lightrag_webui/src/locales/ar.json
+++ b/lightrag_webui/src/locales/ar.json
@@ -320,6 +320,7 @@
     },
     "propertiesView": {
       "editProperty": "تعديل {{property}}",
+      "editLockedByPipeline": "خط الأنابيب مشغول؛ تم تعطيل التحرير",
       "editPropertyDescription": "قم بتحرير قيمة الخاصية في منطقة النص أدناه.",
       "errors": {
         "duplicateName": "اسم العقدة موجود بالفعل",

--- a/lightrag_webui/src/locales/de.json
+++ b/lightrag_webui/src/locales/de.json
@@ -320,6 +320,7 @@
     },
     "propertiesView": {
       "editProperty": "{{property}} bearbeiten",
+      "editLockedByPipeline": "Pipeline ist ausgelastet; Bearbeitung deaktiviert",
       "editPropertyDescription": "Bearbeiten Sie den Eigenschaftswert im Textbereich unten.",
       "errors": {
         "duplicateName": "Knotenname existiert bereits",

--- a/lightrag_webui/src/locales/en.json
+++ b/lightrag_webui/src/locales/en.json
@@ -320,6 +320,7 @@
     },
     "propertiesView": {
       "editProperty": "Edit {{property}}",
+      "editLockedByPipeline": "Pipeline is busy; editing disabled",
       "editPropertyDescription": "Edit the property value in the text area below.",
       "errors": {
         "duplicateName": "Node name already exists",

--- a/lightrag_webui/src/locales/fr.json
+++ b/lightrag_webui/src/locales/fr.json
@@ -320,6 +320,7 @@
     },
     "propertiesView": {
       "editProperty": "Modifier {{property}}",
+      "editLockedByPipeline": "Le pipeline est occupé ; modification désactivée",
       "editPropertyDescription": "Modifiez la valeur de la propriété dans la zone de texte ci-dessous.",
       "errors": {
         "duplicateName": "Le nom du nœud existe déjà",

--- a/lightrag_webui/src/locales/ja.json
+++ b/lightrag_webui/src/locales/ja.json
@@ -320,6 +320,7 @@
     },
     "propertiesView": {
       "editProperty": "{{property}}を編集",
+      "editLockedByPipeline": "パイプライン処理中のため、編集できません",
       "editPropertyDescription": "下のテキストエリアでプロパティ値を編集してください。",
       "errors": {
         "duplicateName": "ノード名が既に存在します",

--- a/lightrag_webui/src/locales/ko.json
+++ b/lightrag_webui/src/locales/ko.json
@@ -320,6 +320,7 @@
     },
     "propertiesView": {
       "editProperty": "{{property}} 수정",
+      "editLockedByPipeline": "파이프라인 사용 중 - 편집이 비활성화되었습니다",
       "editPropertyDescription": "아래 텍스트 영역에서 속성 값을 수정하세요.",
       "errors": {
         "duplicateName": "노드 이름이 이미 존재합니다",

--- a/lightrag_webui/src/locales/ru.json
+++ b/lightrag_webui/src/locales/ru.json
@@ -320,6 +320,7 @@
     },
     "propertiesView": {
       "editProperty": "Редактировать {{property}}",
+      "editLockedByPipeline": "Конвейер занят; редактирование отключено",
       "editPropertyDescription": "Отредактируйте значение свойства в текстовой области ниже.",
       "errors": {
         "duplicateName": "Имя узла уже существует",

--- a/lightrag_webui/src/locales/uk.json
+++ b/lightrag_webui/src/locales/uk.json
@@ -320,6 +320,7 @@
     },
     "propertiesView": {
       "editProperty": "Редагувати {{property}}",
+      "editLockedByPipeline": "Конвеєр зайнятий; редагування вимкнено",
       "editPropertyDescription": "Редагуйте значення властивості в текстовій області нижче.",
       "errors": {
         "duplicateName": "Ім'я вузла вже існує",

--- a/lightrag_webui/src/locales/vi.json
+++ b/lightrag_webui/src/locales/vi.json
@@ -320,6 +320,7 @@
     },
     "propertiesView": {
       "editProperty": "Chỉnh Sửa {{property}}",
+      "editLockedByPipeline": "Pipeline đang bận; chỉnh sửa đã bị tắt",
       "editPropertyDescription": "Chỉnh sửa giá trị thuộc tính trong vùng văn bản bên dưới.",
       "errors": {
         "duplicateName": "Tên nút đã tồn tại",

--- a/lightrag_webui/src/locales/zh.json
+++ b/lightrag_webui/src/locales/zh.json
@@ -320,6 +320,7 @@
     },
     "propertiesView": {
       "editProperty": "编辑{{property}}",
+      "editLockedByPipeline": "流水线正忙,暂时无法编辑",
       "editPropertyDescription": "在下方文本区域编辑属性值。",
       "errors": {
         "duplicateName": "节点名称已存在",

--- a/lightrag_webui/src/locales/zh_TW.json
+++ b/lightrag_webui/src/locales/zh_TW.json
@@ -320,6 +320,7 @@
     },
     "propertiesView": {
       "editProperty": "編輯{{property}}",
+      "editLockedByPipeline": "流水線正忙,暫時無法編輯",
       "editPropertyDescription": "在下方文字區域編輯屬性值。",
       "errors": {
         "duplicateName": "節點名稱已存在",

--- a/tests/api/routes/test_graph_routes_pipeline_busy.py
+++ b/tests/api/routes/test_graph_routes_pipeline_busy.py
@@ -1,0 +1,298 @@
+"""Pipeline-busy guard tests for graph mutation endpoints.
+
+These tests verify that all 7 graph-mutation endpoints refuse to operate
+with HTTP 409 while the document pipeline is busy:
+
+- POST /graph/entity/edit          (graph_routes)
+- POST /graph/relation/edit        (graph_routes)
+- POST /graph/entity/create        (graph_routes)
+- POST /graph/relation/create      (graph_routes)
+- POST /graph/entities/merge       (graph_routes)
+- DELETE /documents/delete_entity  (document_routes)
+- DELETE /documents/delete_relation (document_routes)
+
+The guard logic itself lives in
+``lightrag.api.routers.document_routes.check_pipeline_busy_or_raise`` and is
+exercised both at the endpoint integration layer (via monkeypatch, no
+shared-storage dependency) and at the unit layer (against a real
+``pipeline_status`` namespace).
+"""
+
+import importlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+# Importing routers loads ``lightrag.api.config`` which parses ``sys.argv`` via
+# argparse. Stash argv so pytest's CLI flags don't trip the parser.
+_original_argv = sys.argv[:]
+sys.argv = [sys.argv[0]]
+_graph_routes = importlib.import_module("lightrag.api.routers.graph_routes")
+_document_routes = importlib.import_module("lightrag.api.routers.document_routes")
+sys.argv = _original_argv
+
+create_graph_routes = _graph_routes.create_graph_routes
+create_document_routes = _document_routes.create_document_routes
+check_pipeline_busy_or_raise = _document_routes.check_pipeline_busy_or_raise
+
+pytestmark = pytest.mark.offline
+
+_API_KEY = "test-key"
+_HEADERS = {"X-API-Key": _API_KEY}
+
+
+# ---------------------------------------------------------------------------
+# Test scaffolding
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_rag() -> SimpleNamespace:
+    """Build a minimal LightRAG stand-in with the 7 mutation methods stubbed.
+
+    Each ``AsyncMock`` returns a payload shaped enough to satisfy the
+    endpoint's response model so the idle pass-through test can verify the
+    full request path. Busy tests don't rely on these return values; the
+    guard short-circuits before they're reached.
+    """
+    return SimpleNamespace(
+        workspace="",
+        aedit_entity=AsyncMock(
+            return_value={
+                "entity_name": "Alice",
+                "description": "updated",
+                "operation_summary": {
+                    "merged": False,
+                    "merge_status": "not_attempted",
+                    "merge_error": None,
+                    "operation_status": "success",
+                    "target_entity": None,
+                    "final_entity": "Alice",
+                    "renamed": False,
+                },
+            }
+        ),
+        aedit_relation=AsyncMock(return_value={"description": "updated"}),
+        acreate_entity=AsyncMock(return_value={"entity_name": "Alice"}),
+        acreate_relation=AsyncMock(return_value={"src_id": "a", "tgt_id": "b"}),
+        amerge_entities=AsyncMock(return_value={"merged_entity": "Alice"}),
+        adelete_by_entity=AsyncMock(
+            return_value=SimpleNamespace(
+                status="success", message="deleted", doc_id="ignored"
+            )
+        ),
+        adelete_by_relation=AsyncMock(
+            return_value=SimpleNamespace(
+                status="success", message="deleted", doc_id="ignored"
+            )
+        ),
+    )
+
+
+def _build_client(rag: SimpleNamespace) -> TestClient:
+    app = FastAPI()
+    app.include_router(create_graph_routes(rag, api_key=_API_KEY))
+    app.include_router(create_document_routes(rag, SimpleNamespace(), api_key=_API_KEY))
+    return TestClient(app)
+
+
+async def _force_busy_guard(_rag) -> None:
+    """Stand-in for ``check_pipeline_busy_or_raise`` that always refuses."""
+    raise HTTPException(
+        status_code=409,
+        detail=(
+            "Pipeline is busy with another operation. "
+            "Wait for the running job to finish before editing "
+            "the knowledge graph."
+        ),
+    )
+
+
+async def _noop_guard(_rag) -> None:
+    """Stand-in for ``check_pipeline_busy_or_raise`` that always permits."""
+    return None
+
+
+def _patch_guard(monkeypatch, replacement) -> None:
+    """Replace the guard reference in BOTH consumer modules.
+
+    ``graph_routes`` re-binds the name via ``from .document_routes import ...``
+    so patching only ``document_routes`` would miss the graph endpoints.
+    """
+    monkeypatch.setattr(_graph_routes, "check_pipeline_busy_or_raise", replacement)
+    monkeypatch.setattr(_document_routes, "check_pipeline_busy_or_raise", replacement)
+
+
+# ---------------------------------------------------------------------------
+# Part A: endpoint integration -- guard refuses with 409
+# ---------------------------------------------------------------------------
+
+_ENDPOINTS = [
+    pytest.param(
+        "POST",
+        "/graph/entity/edit",
+        {"entity_name": "Alice", "updated_data": {"description": "x"}},
+        id="update_entity",
+    ),
+    pytest.param(
+        "POST",
+        "/graph/relation/edit",
+        {
+            "source_id": "Alice",
+            "target_id": "Bob",
+            "updated_data": {"description": "x"},
+        },
+        id="update_relation",
+    ),
+    pytest.param(
+        "POST",
+        "/graph/entity/create",
+        {"entity_name": "Alice", "entity_data": {"description": "x"}},
+        id="create_entity",
+    ),
+    pytest.param(
+        "POST",
+        "/graph/relation/create",
+        {
+            "source_entity": "Alice",
+            "target_entity": "Bob",
+            "relation_data": {"description": "x"},
+        },
+        id="create_relation",
+    ),
+    pytest.param(
+        "POST",
+        "/graph/entities/merge",
+        {"entities_to_change": ["Alic"], "entity_to_change_into": "Alice"},
+        id="merge_entities",
+    ),
+    pytest.param(
+        "DELETE",
+        "/documents/delete_entity",
+        {"entity_name": "Alice"},
+        id="delete_entity",
+    ),
+    pytest.param(
+        "DELETE",
+        "/documents/delete_relation",
+        {"source_entity": "Alice", "target_entity": "Bob"},
+        id="delete_relation",
+    ),
+]
+
+
+@pytest.mark.parametrize("method, path, body", _ENDPOINTS)
+def test_endpoint_refuses_with_409_when_pipeline_busy(method, path, body, monkeypatch):
+    rag = _make_mock_rag()
+    client = _build_client(rag)
+    _patch_guard(monkeypatch, _force_busy_guard)
+
+    response = client.request(method, path, json=body, headers=_HEADERS)
+
+    assert response.status_code == 409, response.text
+    payload = response.json()
+    assert "Pipeline is busy" in payload["detail"]
+    # Guard must short-circuit before the underlying mutation runs.
+    for attr in (
+        "aedit_entity",
+        "aedit_relation",
+        "acreate_entity",
+        "acreate_relation",
+        "amerge_entities",
+        "adelete_by_entity",
+        "adelete_by_relation",
+    ):
+        getattr(rag, attr).assert_not_awaited()
+
+
+def test_endpoint_passes_through_when_pipeline_idle(monkeypatch):
+    """Sanity check: with an idle guard, the request reaches ``rag.aedit_entity``."""
+    rag = _make_mock_rag()
+    client = _build_client(rag)
+    _patch_guard(monkeypatch, _noop_guard)
+
+    response = client.post(
+        "/graph/entity/edit",
+        json={"entity_name": "Alice", "updated_data": {"description": "x"}},
+        headers=_HEADERS,
+    )
+
+    assert response.status_code == 200, response.text
+    rag.aedit_entity.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Part B: helper unit -- against real pipeline_status namespace
+# ---------------------------------------------------------------------------
+
+
+async def _with_pipeline_status(action):
+    """Bootstrap pipeline_status, run ``action(pipeline_status)``, then tear down.
+
+    ``initialize_share_data`` is idempotent within a process but
+    ``finalize_share_data`` is required to release the Manager/lock state so
+    repeated calls in subsequent tests start clean.
+    """
+    from lightrag.kg.shared_storage import (
+        finalize_share_data,
+        get_namespace_data,
+        initialize_pipeline_status,
+        initialize_share_data,
+    )
+
+    initialize_share_data()
+    try:
+        await initialize_pipeline_status(workspace="")
+        pipeline_status = await get_namespace_data("pipeline_status", workspace="")
+        await action(pipeline_status)
+    finally:
+        finalize_share_data()
+
+
+async def test_helper_raises_409_when_busy_flag_set():
+    async def _do(pipeline_status):
+        pipeline_status["busy"] = True
+        rag = SimpleNamespace(workspace="")
+        with pytest.raises(HTTPException) as exc_info:
+            await check_pipeline_busy_or_raise(rag)
+        assert exc_info.value.status_code == 409
+        assert "Pipeline is busy" in exc_info.value.detail
+
+    await _with_pipeline_status(_do)
+
+
+async def test_helper_returns_silently_when_pipeline_idle():
+    async def _do(pipeline_status):
+        pipeline_status["busy"] = False
+        rag = SimpleNamespace(workspace="")
+        # Should not raise.
+        await check_pipeline_busy_or_raise(rag)
+
+    await _with_pipeline_status(_do)
+
+
+async def test_helper_is_noop_when_pipeline_status_uninitialized():
+    """When pipeline_status namespace was never bootstrapped the helper must pass.
+
+    ``get_namespace_data`` raises ``PipelineNotInitializedError`` when the
+    pipeline_status namespace is missing (share data initialized but the
+    pipeline namespace never created); the helper swallows that error so test
+    rigs without an end-to-end RAG bootstrap stay green. Mirrors the existing
+    contract of ``_acquire_destructive_busy``.
+    """
+    from lightrag.kg.shared_storage import (
+        finalize_share_data,
+        initialize_share_data,
+    )
+
+    initialize_share_data()
+    try:
+        rag = SimpleNamespace(workspace="__never_bootstrapped__")
+        # Intentionally skip ``initialize_pipeline_status``: helper should
+        # catch ``PipelineNotInitializedError`` and return silently.
+        await check_pipeline_busy_or_raise(rag)
+    finally:
+        finalize_share_data()


### PR DESCRIPTION
## Summary

- Hide the entity/relation edit affordances in the WebUI while the document pipeline is busy, and keep any open edit dialog mounted with its draft preserved (save button disabled, banner shown).
- Reject every graph-mutation API call with HTTP 409 when the pipeline is busy, covering both edit/create/merge in `graph_routes.py` and the entity/relation delete endpoints in `document_routes.py`.

## Motivation

`update_entity` / `update_relation` / `delete_*` write the same graph storages that the ingestion pipeline mutates during document processing, scanning, and `/documents/clear`/`/documents/{id}` deletion. Until now the API accepted those mutations unconditionally, so a user editing a node while a re-index ran could overwrite freshly-extracted properties, silently lose merges, or surface confusing partial-success responses. The WebUI had no signal that editing was unsafe either.

## What's changed

### WebUI (`53df4985`)

- [`PropertiesView.tsx`](lightrag_webui/src/components/graph/PropertiesView.tsx) subscribes to `useBackendState.use.pipelineBusy()` (already maintained by the health-check poller) and forwards it down to `PropertyRow` → `EditablePropertyRow` and into a new lock indicator on the node/relation header rows.
- [`EditablePropertyRow.tsx`](lightrag_webui/src/components/graph/EditablePropertyRow.tsx) hides the pencil icon and guards `handleEditClick` while busy. The component stays mounted, so an in-flight edit dialog is **not** unmounted when the pipeline flips to busy — the draft survives.
- [`PropertyEditDialog.tsx`](lightrag_webui/src/components/graph/PropertyEditDialog.tsx) gains a `disableSave` prop. When set, it shows an amber banner and disables the save button (cancel stays available); when the pipeline returns to idle the banner disappears and save re-enables automatically.
- New i18n key `graphPanel.propertiesView.editLockedByPipeline` added to all 11 locales (`ar/de/en/fr/ja/ko/ru/uk/vi/zh/zh_TW`).

### Backend (`fb5a3c56`)

- New helper [`check_pipeline_busy_or_raise`](lightrag/api/routers/document_routes.py) in `document_routes.py`: read-only check on `pipeline_status['busy']` under the namespace lock, raises `HTTPException(409)` on contention. Crucially it does **not** acquire `busy` or `destructive_busy` itself — holding a flag for every UI edit would serialise document ingestion behind interactive graph work. The narrow race between the check and the underlying storage write is intentionally tolerated; the storage layer's per-edge/-node locks are the last line of defense.
- The guard is invoked at the entry of all 7 graph-mutation endpoints:
  - `POST /graph/entity/edit`, `POST /graph/relation/edit`
  - `POST /graph/entity/create`, `POST /graph/relation/create`
  - `POST /graph/entities/merge`
  - `DELETE /documents/delete_entity`, `DELETE /documents/delete_relation`
- Each `graph_routes.py` endpoint also gains `except HTTPException: raise` ahead of `except Exception`, aligning with `delete_entity`'s existing pattern so the 409 isn't swallowed and re-thrown as a 500.
- `PipelineNotInitializedError` is caught silently, matching `_acquire_destructive_busy` so test rigs without a bootstrapped shared-storage Manager keep working.

### Tests

- New [`tests/api/routes/test_graph_routes_pipeline_busy.py`](tests/api/routes/test_graph_routes_pipeline_busy.py):
  - 7 parametrised integration tests verify every endpoint returns 409 with `"Pipeline is busy"` in `detail` and that the underlying `aedit_*`/`acreate_*`/`amerge_*`/`adelete_*` is never awaited;
  - 1 idle pass-through test confirms the request reaches `rag.aedit_entity` when the guard permits;
  - 3 unit tests for the helper itself: raises 409 when `busy=True`, returns silently when `busy=False`, and stays no-op when `pipeline_status` was never bootstrapped.
- Marked `pytest.mark.offline`, no live services required.

## What this does not cover

- A user keeping an old edit dialog open and clicking save the moment busy flips on is still racy at the UI layer (the dialog is already open so the click handler executes); the backend 409 catches it. Likewise a programmatic client bypassing the WebUI is caught by the backend guard.
- Concurrency between two ingestion-pipeline writers (already serialised by `_PipelineMixin`) is unaffected.

## Test plan

- [x] `cd lightrag_webui && bun run lint && bun run build`
- [x] `ruff check lightrag/api/routers/graph_routes.py lightrag/api/routers/document_routes.py tests/api/routes/test_graph_routes_pipeline_busy.py`
- [x] `./scripts/test.sh tests/api/` — 138 passed, 14 skipped (integration/online), 0 failed
- [ ] Manual: trigger ingestion, open a node, confirm pencil icons disappear and a 🔒 indicator with localized tooltip appears in the header
- [ ] Manual: open an edit dialog with a long description draft, trigger ingestion mid-edit, confirm dialog stays open, draft survives, save button disables and re-enables when idle
- [ ] Manual: while pipeline is busy, `curl -X POST .../graph/entity/edit` returns 409 with the expected detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)