### PR TITLE
Add PostgreSQL 18 AGE pgvector image

### DIFF
--- a/Dockerfile.postgres
+++ b/Dockerfile.postgres
@@ -1,0 +1,43 @@
+# Build stage: compile Apache AGE against PostgreSQL 18 on top of pgvector
+FROM pgvector/pgvector:pg18-trixie AS build
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends --no-install-suggests \
+       ca-certificates \
+       git \
+       bison \
+       build-essential \
+       flex \
+       postgresql-server-dev-18
+
+RUN git clone --depth 1 --branch release/PG18/1.7.0 https://github.com/apache/age.git /usr/src/age \
+    && cd /usr/src/age \
+    && make \
+    && make install
+
+# Final stage: Create a final image by copying the files created in the build stage
+FROM pgvector/pgvector:pg18-trixie
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends --no-install-suggests \
+    locales
+
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
+    && locale-gen \
+    && update-locale LANG=en_US.UTF-8
+
+ENV LANG=en_US.UTF-8
+ENV LC_COLLATE=en_US.UTF-8
+ENV LC_CTYPE=en_US.UTF-8
+
+COPY --from=build /usr/lib/postgresql/18/lib/age.so /usr/lib/postgresql/18/lib/
+COPY --from=build /usr/share/postgresql/18/extension/age--1.7.0.sql /usr/share/postgresql/18/extension/
+COPY --from=build /usr/share/postgresql/18/extension/age.control /usr/share/postgresql/18/extension/
+
+RUN printf '%s\n' \
+    'CREATE EXTENSION IF NOT EXISTS vector;' \
+    'CREATE EXTENSION IF NOT EXISTS age CASCADE;' \
+    > /docker-entrypoint-initdb.d/00-create-extensions.sql
+
+# Note: AGE extension require to be loaded  shared_preload_libraries
+CMD ["postgres", "-c", "shared_preload_libraries=age"]

--- a/docs/DockerDeployment.md
+++ b/docs/DockerDeployment.md
@@ -237,7 +237,7 @@ This keeps generated host mounts under the same `./data` root used by the defaul
 
 ### PostgreSQL image
 
-The interactive setup defaults PostgreSQL to `gzdaniel/postgres-for-rag:16.6`. This image bundles both Apache AGE and pgvector so the generated stack works with `PGGraphStorage` and `PGVectorStorage` without extra extension setup.
+The interactive setup defaults PostgreSQL to `gzdaniel/postgres-for-rag:pg18-age-pgvector`. This image bundles both Apache AGE and pgvector so the generated stack works with `PGGraphStorage` and `PGVectorStorage` without extra extension setup.
 
 **Important Note**: If PGGraphStorage is not required for vector storage, you may replace the upper docker image with the latest official pgvector image `pgvector/pgvector:pg18`. Please note that data file formats are incompatible across different PostgreSQL major versions; once this Docker image is deployed, it cannot be rolled back to a previous version.
 

--- a/docs/DockerDeployment.md
+++ b/docs/DockerDeployment.md
@@ -241,6 +241,40 @@ The interactive setup defaults PostgreSQL to `gzdaniel/postgres-for-rag:pg18-age
 
 **Important Note**: If PGGraphStorage is not required for vector storage, you may replace the upper docker image with the latest official pgvector image `pgvector/pgvector:pg18`. Please note that data file formats are incompatible across different PostgreSQL major versions; once this Docker image is deployed, it cannot be rolled back to a previous version.
 
+#### Build the PostgreSQL image
+
+The default PostgreSQL image can be rebuilt from the repository root with `Dockerfile.postgres`. The Dockerfile starts from `pgvector/pgvector:pg18-trixie`, builds Apache AGE for PostgreSQL 18, and installs an init script that creates both the `vector` and `age` extensions for new databases.
+
+For local development or single-host deployment:
+
+```bash
+docker build -f Dockerfile.postgres \
+  -t gzdaniel/postgres-for-rag:pg18-age-pgvector \
+  .
+```
+
+To publish the image to your own registry, use a private tag:
+
+```bash
+docker build -f Dockerfile.postgres \
+  -t registry.example.com/postgres-for-rag:pg18-age-pgvector \
+  .
+docker push registry.example.com/postgres-for-rag:pg18-age-pgvector
+```
+
+For a multi-architecture image:
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -f Dockerfile.postgres \
+  -t registry.example.com/postgres-for-rag:pg18-age-pgvector \
+  --push \
+  .
+```
+
+After building a custom tag, update the `postgres.image` value in the generated `docker-compose.final.yml` to point at that tag. On later setup wizard reruns, existing wizard-managed service images are preserved.
+
 ### Updates
 
 To update the Docker container:

--- a/scripts/setup/templates/postgres.yml
+++ b/scripts/setup/templates/postgres.yml
@@ -1,5 +1,5 @@
   postgres:
-    image: gzdaniel/postgres-for-rag:16.6
+    image: gzdaniel/postgres-for-rag:pg18-age-pgvector
     ports:
       - "5432:5432"
     volumes:

--- a/tests/setup/test_env.py
+++ b/tests/setup/test_env.py
@@ -2156,7 +2156,7 @@ confirm_required_yes_no() {{ return 0; }}
 env_storage_flow
 """)
     result = (tmp_path / "docker-compose.final.yml").read_text(encoding="utf-8")
-    assert "image: gzdaniel/postgres-for-rag:16.6" in result
+    assert "image: gzdaniel/postgres-for-rag:pg18-age-pgvector" in result
     assert 'POSTGRES_USER: "updated-user"' in result
 
 
@@ -2220,7 +2220,7 @@ confirm_required_yes_no() {{ return 0; }}
 env_storage_flow
 """)
     result = (tmp_path / "docker-compose.final.yml").read_text(encoding="utf-8")
-    assert "image: gzdaniel/postgres-for-rag:16.6" in result
+    assert "image: gzdaniel/postgres-for-rag:pg18-age-pgvector" in result
     assert "image: neo4j:5-community" in result
     assert "registry.example.com/postgres-for-rag:patched" not in result
     assert "registry.example.com/neo4j:custom" not in result
@@ -2239,7 +2239,7 @@ def test_env_storage_flow_backs_up_existing_compose_before_rewrite(
                 "    environment:",
                 '      LEGACY_SETTING: "1"',
                 "  postgres:",
-                "    image: gzdaniel/postgres-for-rag:16.6",
+                "    image: gzdaniel/postgres-for-rag:pg18-age-pgvector",
             ]
         )
         + "\n"

--- a/tests/setup/test_generate.py
+++ b/tests/setup/test_generate.py
@@ -1485,7 +1485,7 @@ add_docker_service vllm-embed
 generate_docker_compose "$REPO_ROOT/docker-compose.final.yml\"
 """)
     result = (tmp_path / "docker-compose.final.yml").read_text(encoding="utf-8")
-    assert "image: gzdaniel/postgres-for-rag:16.6" in result
+    assert "image: gzdaniel/postgres-for-rag:pg18-age-pgvector" in result
     assert "image: vllm/vllm-openai-cpu:latest" in result
     assert "registry.example.com/postgres-for-rag:patched" not in result
     assert "vllm/vllm-openai-cpu:patched" not in result

--- a/tests/setup/test_misc.py
+++ b/tests/setup/test_misc.py
@@ -871,7 +871,7 @@ def test_switching_to_non_docker_storage_removes_stale_services_from_compose(
                 "  lightrag:",
                 "    image: example/lightrag:test",
                 "  postgres:",
-                "    image: gzdaniel/postgres-for-rag:16.6",
+                "    image: gzdaniel/postgres-for-rag:pg18-age-pgvector",
                 "  neo4j:",
                 "    image: neo4j:5.26.21-community",
                 "  sidecar:",


### PR DESCRIPTION
## Description

Update the Docker-based PostgreSQL setup to use a PostgreSQL 18 image that bundles Apache AGE and pgvector, add the Dockerfile used to build that image, and document how to build custom PostgreSQL image tags.

## Related Issues

N/A

## Changes Made

- Add `Dockerfile.postgres` for building Apache AGE against PostgreSQL 18 on top of the pgvector image.
- Update the setup PostgreSQL compose template to use `gzdaniel/postgres-for-rag:pg18-age-pgvector`.
- Update Docker deployment documentation for the new default PostgreSQL image and custom image build commands.
- Update setup tests to expect the new PostgreSQL image tag.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Upgrade note: this changes the default PostgreSQL image from PG16 to PG18. Existing PG16 data is not migrated automatically. The generated compose setup keeps the same `postgres_data` volume, so older versioned PostgreSQL data directories remain available in the volume, but PG18 initializes and uses its own data directory. Users with existing PostgreSQL data should back up and migrate manually, for example with `pg_dump`/`pg_restore` or `pg_upgrade`, before relying on the PG18 database.

Local validation:

- `docker build -f Dockerfile.postgres -t lightrag-postgres-review .`
- Temporary container initialized with `age 1.7.0` and `vector 0.8.2` installed.
- `./scripts/test.sh tests/setup/test_env.py tests/setup/test_generate.py tests/setup/test_misc.py` passed with 164 tests.