### PR TITLE
feat(setup): allow custom PostgreSQL credentials for Docker deployments

### DIFF
--- a/docs/DockerDeployment.md
+++ b/docs/DockerDeployment.md
@@ -21,12 +21,12 @@ cd LightRAG
 
 ```bash
 # Linux/MacOS
-cp .env.example .env
+cp env.example .env
 # Edit .env with your preferred configuration
 ```
 ```powershell
 # Windows PowerShell
-Copy-Item .env.example .env
+Copy-Item env.example .env
 # Edit .env with your preferred configuration
 ```
 
@@ -239,6 +239,8 @@ This keeps generated host mounts under the same `./data` root used by the defaul
 
 The interactive setup defaults PostgreSQL to `gzdaniel/postgres-for-rag:pg18-age-pgvector`. This image bundles both Apache AGE and pgvector so the generated stack works with `PGGraphStorage` and `PGVectorStorage` without extra extension setup.
 
+The image no longer ships fixed credentials; on first start it creates the user, password, and database from the `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` environment variables. The setup wizard prompts for these values (defaulting to `rag` / `rag` / `lightrag`) and injects them into the generated `docker-compose.final.yml`, so you can choose any user, password, and database name.
+
 **Important Note**: If PGGraphStorage is not required for vector storage, you may replace the upper docker image with the latest official pgvector image `pgvector/pgvector:pg18`. Please note that data file formats are incompatible across different PostgreSQL major versions; once this Docker image is deployed, it cannot be rolled back to a previous version.
 
 #### Build the PostgreSQL image
@@ -286,7 +288,7 @@ docker compose up
 
 ### Offline deployment
 
-Software packages requiring `transformers`, `torch`, or `cuda` will is not preinstalled in the dokcer images. Consequently, document extraction tools such as Docling, as well as local LLM models like Hugging Face and LMDeploy, can not be used in an off line enviroment. These high-compute-resource-demanding services should not be integrated into LightRAG. Docling will be decoupled and deployed as a standalone service.
+Software packages requiring `transformers`, `torch`, or `cuda` are not preinstalled in the docker images. Consequently, document extraction tools such as Docling, as well as local LLM models like Hugging Face and LMDeploy, cannot be used in an offline environment. These high-compute-resource-demanding services should not be integrated into LightRAG. Docling will be decoupled and deployed as a standalone service.
 
 ## 📦 Build Docker Images
 

--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -543,7 +543,7 @@ See `test_neo4j.py` for a working example.
 PostgreSQL can provide a one-stop solution as KV store, VectorDB (pgvector), and GraphDB (apache AGE). PostgreSQL version 16.6 or higher is supported.
 
 - PostgreSQL is lightweight; the whole binary distribution including all necessary plugins can be zipped to 40MB: Ref to [Windows Release](https://github.com/ShanGor/apache-age-windows/releases/tag/PG17%2Fv1.5.0-rc0) as it is easy to install for Linux/Mac.
-- If you prefer Docker, start with this image to avoid hiccups (Default user password: rag/rag): https://hub.docker.com/r/gzdaniel/postgres-for-rag
+- If you prefer Docker, start with this image to avoid hiccups: https://hub.docker.com/r/gzdaniel/postgres-for-rag. The latest image no longer ships hardcoded credentials; on first start it creates the user, password, and database from the `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` environment variables (these are set automatically when you deploy via the `scripts/setup/setup.sh` wizard, so you can pick any values).
 - How to start: see [examples/lightrag_gemini_postgres_demo.py](https://github.com/HKUDS/LightRAG/blob/main/examples/lightrag_gemini_postgres_demo.py)
 - For high-performance graph database requirements, Neo4j is recommended as Apache AGE's performance is not as competitive.
 

--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -1339,21 +1339,15 @@ collect_postgres_config() {
     set_compose_override "POSTGRES_PORT" ""
   fi
 
+  # The bundled postgres image creates its user/password/database from the
+  # POSTGRES_USER/POSTGRES_PASSWORD/POSTGRES_DB env vars on first start, so docker
+  # and host deployments share the same prompts and defaults (rag/rag/lightrag).
   existing_user="${ORIGINAL_ENV_VALUES[POSTGRES_USER]-${ENV_VALUES[POSTGRES_USER]:-}}"
   existing_password="${ORIGINAL_ENV_VALUES[POSTGRES_PASSWORD]-${ENV_VALUES[POSTGRES_PASSWORD]:-}}"
   existing_database="${ORIGINAL_ENV_VALUES[POSTGRES_DATABASE]-${ENV_VALUES[POSTGRES_DATABASE]:-}}"
-  if [[ "$use_docker" == "yes" && -z "$existing_user" && -z "$existing_password" ]]; then
-    user="rag"
-    password="rag"
-  else
-    user="$(prompt_with_default "PostgreSQL user" "${existing_user:-rag}")"
-    password="$(prompt_secret_with_default "PostgreSQL password: " "${existing_password:-rag}")"
-  fi
-  if [[ "$use_docker" == "yes" && -z "$existing_database" ]]; then
-    database="rag"
-  else
-    database="$(prompt_with_default "PostgreSQL database" "${existing_database:-lightrag}")"
-  fi
+  user="$(prompt_with_default "PostgreSQL user" "${existing_user:-rag}")"
+  password="$(prompt_secret_with_default "PostgreSQL password: " "${existing_password:-rag}")"
+  database="$(prompt_with_default "PostgreSQL database" "${existing_database:-lightrag}")"
 
   ENV_VALUES["POSTGRES_HOST"]="$host"
   ENV_VALUES["POSTGRES_PORT"]="$port"

--- a/tests/setup/test_collect.py
+++ b/tests/setup/test_collect.py
@@ -36,6 +36,7 @@ prompt_with_default() {{
     *) printf '%s' "$2" ;;
   esac
 }}
+prompt_secret_with_default() {{ printf '%s' "$2"; }}
 mask_sensitive_input() {{ printf 'supersecret'; }}
 
 collect_postgres_config yes
@@ -53,10 +54,10 @@ printf 'DOCKER_SERVICE=%s\\n' "${{DOCKER_SERVICES[0]}}\"
     assert values["DOCKER_SERVICE"] == "postgres"
 
 
-def test_collect_postgres_config_uses_rag_defaults_without_prompt_for_empty_docker_credentials() -> (
+def test_collect_postgres_config_prompts_with_host_defaults_for_empty_docker_credentials() -> (
     None
 ):
-    """Docker PostgreSQL should auto-fill bundled credentials when old `.env` creds are empty."""
+    """Docker PostgreSQL should prompt for editable creds using the host-mode defaults."""
     values = run_bash_lines(f"""
 set -euo pipefail
 source "{REPO_ROOT}/scripts/setup/setup.sh"
@@ -67,14 +68,14 @@ PROMPT_LOG_FILE="$(mktemp)"
 
 confirm_default_yes() {{ return 0; }}
 prompt_with_default() {{
-  printf '%s\\n' "$1" >> "$PROMPT_LOG_FILE"
+  printf '%s[%s]\\n' "$1" "$2" >> "$PROMPT_LOG_FILE"
   case "$1" in
     "PostgreSQL host") printf 'localhost' ;;
     *) printf '%s' "$2" ;;
   esac
 }}
 prompt_secret_with_default() {{
-  printf 'secret:%s\\n' "$1" >> "$PROMPT_LOG_FILE"
+  printf 'secret:%s[%s]\\n' "$1" "$2" >> "$PROMPT_LOG_FILE"
   printf '%s' "$2"
 }}
 
@@ -91,8 +92,11 @@ printf 'PROMPT_LOG=%s\\n' "$(paste -sd '|' "$PROMPT_LOG_FILE")\"
 """)
     assert values["POSTGRES_USER"] == "rag"
     assert values["POSTGRES_PASSWORD"] == "rag"
-    assert values["POSTGRES_DATABASE"] == "rag"
-    assert values["PROMPT_LOG"] == "PostgreSQL host"
+    assert values["POSTGRES_DATABASE"] == "lightrag"
+    assert (
+        values["PROMPT_LOG"]
+        == "PostgreSQL host[localhost]|PostgreSQL user[rag]|secret:PostgreSQL password: [rag]|PostgreSQL database[lightrag]"
+    )
 
 
 def test_collect_postgres_config_prompts_for_existing_docker_credentials() -> None:

--- a/tests/setup/test_env.py
+++ b/tests/setup/test_env.py
@@ -1859,10 +1859,10 @@ env_storage_flow
     assert "env_file:" not in generated_compose
 
 
-def test_env_storage_flow_uses_rag_defaults_for_empty_postgres_docker_credentials(
+def test_env_storage_flow_uses_host_defaults_for_empty_postgres_docker_credentials(
     tmp_path: Path,
 ) -> None:
-    """env-storage should write bundled postgres credentials when old `.env` creds are empty."""
+    """env-storage should write the host-mode postgres defaults when old `.env` creds are empty."""
     env_file = tmp_path / ".env"
     env_file.write_text(
         "\n".join(
@@ -1934,10 +1934,10 @@ printf 'PROMPT_LOG=%s\\n' "$(paste -sd '|' "$PROMPT_LOG_FILE")\"
     )
     assert "POSTGRES_USER=rag" in generated_env
     assert "POSTGRES_PASSWORD=rag" in generated_env
-    assert "POSTGRES_DATABASE=rag" in generated_env
+    assert "POSTGRES_DATABASE=lightrag" in generated_env
     assert 'POSTGRES_USER: "rag"' in generated_compose
     assert 'POSTGRES_PASSWORD: "rag"' in generated_compose
-    assert 'POSTGRES_DB: "rag"' in generated_compose
+    assert 'POSTGRES_DB: "lightrag"' in generated_compose
 
 
 def test_env_storage_flow_preserves_existing_postgres_image_during_rewrite(


### PR DESCRIPTION
## Description

The setup wizard previously forced `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DATABASE` to `rag` / `rag` / `rag` whenever PostgreSQL was deployed via Docker and the existing `.env` had no credentials, and it skipped the prompts entirely so the values could not be edited. This was a constraint of an older Docker image.

The current image (`gzdaniel/postgres-for-rag:pg18-age-pgvector`) ships no hardcoded credentials — it creates the user, password, and database from the `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` environment variables on first start. So any values work, and the wizard already injects them into the generated compose file.

This PR drops the Docker-specific forcing so Docker and host deployments share the same prompts and defaults (`rag` / `rag` / `lightrag`), letting users pick any values.

## Related Issues

#3126 

## Changes Made

- `scripts/setup/setup.sh`: remove the Docker-only branches in `collect_postgres_config()` that forced `rag` credentials and skipped prompts; Docker and host now share one prompt path with defaults `rag` / `rag` / `lightrag`.
- `tests/setup/test_collect.py`: add a `prompt_secret_with_default` mock to the bundled-port test (Docker now collects the password too); rewrite/rename the former "auto-fill rag" test to assert the new prompting behavior with host-mode defaults.
- `tests/setup/test_env.py`: rename the end-to-end empty-credentials Docker test and update its database assertions from `rag` to `lightrag` (user/password stay `rag`).
- `docs/ProgramingWithCore.md`: replace the stale "Default user password: rag/rag" note with an explanation that the image creates credentials from env vars on first start and the wizard sets them.
- `docs/DockerDeployment.md`: document the env-var-driven credential behavior in the PostgreSQL image section; fix a stale `.env.example` → `env.example` reference; fix typos (`dokcer`, `off line`, `enviroment`, grammar) in the offline-deployment note.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

`env.example` keeps `POSTGRES_DATABASE=rag` unchanged (it documents the manual / image default). The full offline setup test suite passes: `pytest tests/setup -m offline` → 259 passed. `bash -n scripts/setup/setup.sh` reports no syntax issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
