### PR TITLE
perf(opensearch): defer vector embedding until flush

### DIFF
--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -3598,8 +3598,10 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
                 return None
             pending = self._pending_vector_docs.get(id)
             if pending is not None:
+                # pending.source is built in upsert from created_at + meta_fields
+                # and never carries the embedding, so no "vector" strip is needed
+                # here (unlike the mget path below, which excludes it server-side).
                 doc = dict(pending.source)
-                doc.pop("vector", None)
                 doc["id"] = id
                 return doc
             if not self._index_ready:
@@ -3641,8 +3643,8 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
                     continue
                 pending = self._pending_vector_docs.get(doc_id)
                 if pending is not None:
+                    # pending.source never carries the embedding; see get_by_id.
                     doc = dict(pending.source)
-                    doc.pop("vector", None)
                     doc["id"] = doc_id
                     buffered[doc_id] = doc
                     continue

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -3357,6 +3357,16 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
         orders concurrent cross-worker flushes against the same OpenSearch
         index.
 
+        Embedding deliberately runs *inside* this lock (not in ``upsert`` or
+        lock-free): it makes deferred embedding and bulk indexing atomic
+        against concurrent upserts and destructive mutations (``drop`` /
+        ``delete_entity_relation``). This is what lets
+        ``index_done_callback`` / ``finalize`` promise that every buffered
+        vector is embedded and persisted on return. Moving embedding out of
+        the lock to avoid blocking reads would let a destructive op
+        interleave between embed and bulk and resurrect or drop vectors out
+        of order -- do not do it.
+
         Failure handling:
           * If ``_ensure_index_ready`` raises, the buffers are left intact
             and the next flush will retry.
@@ -3412,10 +3422,14 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
                     )
                     raise
                 embeddings = np.concatenate(embeddings_list)
-                assert len(embeddings) == len(docs_to_embed), (
-                    f"Embedding count mismatch: expected {len(docs_to_embed)}, "
-                    f"got {len(embeddings)}"
-                )
+                # Explicit check (not assert): a count mismatch would silently
+                # truncate via zip() under `python -O`, mis-pairing vectors with
+                # docs. Raise instead so buffers stay intact for the next flush.
+                if len(embeddings) != len(docs_to_embed):
+                    raise RuntimeError(
+                        f"[{self.workspace}] Embedding count mismatch: expected "
+                        f"{len(docs_to_embed)}, got {len(embeddings)}"
+                    )
                 for i, ((_, pending_doc), embedding) in enumerate(
                     zip(docs_to_embed, embeddings), start=1
                 ):
@@ -3570,6 +3584,14 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
         before any buffered writes are abandoned. The refresh step is
         skipped only when the index is still not ready after the flush
         attempt -- refreshing a half-built index is pointless.
+
+        Durability contract: each call embeds and bulk-indexes the *entire*
+        pending buffer in one shot. Deferred embedding runs inside
+        ``_flush_pending_vector_ops``'s ``_flush_lock`` section (not in
+        ``upsert``) precisely so this callback can guarantee every buffered
+        vector is embedded and flushed together; only transient per-doc
+        failures stay buffered for the next flush. Do not move embedding
+        out of the lock -- see ``_flush_pending_vector_ops`` for why.
         """
         await self._flush_pending_vector_ops()
         if not self._index_ready:
@@ -3719,13 +3741,18 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
                     )
                     raise
                 embeddings = np.concatenate(embeddings_list)
-                assert len(embeddings) == len(docs_to_embed), (
-                    f"Embedding count mismatch: expected {len(docs_to_embed)}, "
-                    f"got {len(embeddings)}"
-                )
-                for (doc_id, pending_doc), embedding in zip(docs_to_embed, embeddings):
+                # Explicit check (not assert): see _flush_pending_vector_ops.
+                if len(embeddings) != len(docs_to_embed):
+                    raise RuntimeError(
+                        f"[{self.workspace}] Embedding count mismatch: expected "
+                        f"{len(docs_to_embed)}, got {len(embeddings)}"
+                    )
+                for i, ((doc_id, pending_doc), embedding) in enumerate(
+                    zip(docs_to_embed, embeddings), start=1
+                ):
                     pending_doc.vector = embedding.tolist()
                     result[doc_id] = pending_doc.vector
+                    await _cooperative_yield(i)
 
         if not remaining:
             return result

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -86,6 +86,15 @@ class _FailedBulkOp:
     error: str
 
 
+@dataclass
+class _PendingVectorDoc:
+    """Buffered vector upsert waiting for embedding and/or bulk flush."""
+
+    source: dict[str, Any]
+    content: str
+    vector: list[float] | None = None
+
+
 def _summarize_bulk_error(error: Any) -> str:
     """Turn an opensearch-py per-action ``error`` payload into a short string.
 
@@ -3124,7 +3133,7 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
         # Pending writes are flushed via _flush_pending_vector_ops() during
         # index_done_callback() / finalize(). This batches many small upsert()
         # invocations into a single async_bulk roundtrip. See issue #2785.
-        self._pending_vector_docs: dict[str, dict[str, Any]] = {}
+        self._pending_vector_docs: dict[str, _PendingVectorDoc] = {}
         self._pending_vector_deletes: set[str] = set()
         # Namespace-keyed lock (multi-process safe) is initialised in
         # initialize(). All buffer reads / writes and any destructive server
@@ -3290,7 +3299,7 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
             )
 
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
-        """Generate embeddings and buffer vector docs for batched flush.
+        """Buffer vector docs for embedding and batched flush.
 
         Docs are buffered in ``self._pending_vector_docs`` and flushed in a
         single ``async_bulk`` call during ``index_done_callback()`` /
@@ -3300,9 +3309,11 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
         backends ("changes will be persisted during the next
         index_done_callback").
 
-        The embedding computation is performed outside the namespace lock to
-        avoid blocking concurrent reads while remote embedding calls are in
-        flight; only the final buffer-write loop holds the lock.
+        Embedding is deferred to the flush path so repeated upserts of the
+        same id and many small upsert calls can be embedded once in a single
+        batch. Flush holds the namespace lock while embedding and bulk
+        indexing so cross-worker destructive mutations cannot interleave with
+        partially-flushed vector writes.
         """
         if not data:
             return
@@ -3312,56 +3323,46 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
         )
         current_time = int(time.time())
 
-        list_data = []
+        pending_docs: list[tuple[str, _PendingVectorDoc]] = []
         for i, (k, v) in enumerate(data.items(), start=1):
-            list_data.append(
-                {
-                    "_id": k,
-                    "created_at": current_time,
-                    **{k1: v1 for k1, v1 in v.items() if k1 in self.meta_fields},
-                }
+            content = v["content"]
+            source = {
+                "created_at": current_time,
+                **{k1: v1 for k1, v1 in v.items() if k1 in self.meta_fields},
+            }
+            pending_docs.append(
+                (
+                    k,
+                    _PendingVectorDoc(
+                        source=source,
+                        content=content,
+                    ),
+                )
             )
-            await _cooperative_yield(i)
-        contents = [v["content"] for v in data.values()]
-
-        batches = [
-            contents[i : i + self._max_batch_size]
-            for i in range(0, len(contents), self._max_batch_size)
-        ]
-        # Run embeddings outside the lock to avoid blocking reads on slow
-        # remote embedding providers.
-        embeddings_list = await asyncio.gather(
-            *[self.embedding_func(batch, context="document") for batch in batches]
-        )
-        embeddings = np.concatenate(embeddings_list)
-        assert len(embeddings) == len(
-            list_data
-        ), f"Embedding count mismatch: expected {len(list_data)}, got {len(embeddings)}"
-        for i, doc in enumerate(list_data, start=1):
-            doc["vector"] = embeddings[i - 1].tolist()
             await _cooperative_yield(i)
 
         # Buffer: an upsert overrides a pending delete on the same id.
         async with self._flush_lock:
-            for doc in list_data:
-                doc_id = doc["_id"]
+            for doc_id, pending_doc in pending_docs:
                 self._pending_vector_deletes.discard(doc_id)
-                self._pending_vector_docs[doc_id] = {
-                    k: v for k, v in doc.items() if k != "_id"
-                }
+                self._pending_vector_docs[doc_id] = pending_doc
 
     async def _flush_pending_vector_ops(self) -> None:
         """Flush buffered vector upserts and deletes via a single async_bulk call.
 
-        Concurrency contract: the entire flush runs under ``_flush_lock``
-        (a ``get_namespace_lock`` instance) and so do all buffer reads /
-        writes and destructive server mutations on this storage. That keeps
-        the operation sequential within the process and orders concurrent
-        cross-worker flushes against the same OpenSearch index.
+        Concurrency contract: the entire flush, including deferred embedding,
+        runs under ``_flush_lock`` (a ``get_namespace_lock`` instance), and so
+        do all buffer reads / writes and destructive server mutations on this
+        storage. That keeps the operation sequential within the process and
+        orders concurrent cross-worker flushes against the same OpenSearch
+        index.
 
         Failure handling:
           * If ``_ensure_index_ready`` raises, the buffers are left intact
             and the next flush will retry.
+          * If embedding raises, the buffers are left intact and the next
+            flush will retry. Model providers already retry internally, so
+            this is treated like a persistence failure.
           * If ``async_bulk`` itself raises (network / parse error), the
             buffers are left intact and the next flush will retry. Index
             ops are idempotent on ``_id`` and a re-issued delete on a
@@ -3383,10 +3384,43 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
             # buffers untouched and bubbles up to the caller.
             await self._ensure_index_ready()
 
-            # Build the action list directly from the live buffers; the
-            # lock guarantees nothing else mutates them concurrently.
             pending_docs = self._pending_vector_docs
             pending_deletes = self._pending_vector_deletes
+
+            docs_to_embed = [
+                (doc_id, pending_doc)
+                for doc_id, pending_doc in pending_docs.items()
+                if pending_doc.vector is None
+            ]
+            if docs_to_embed:
+                contents = [pending_doc.content for _, pending_doc in docs_to_embed]
+                batches = [
+                    contents[i : i + self._max_batch_size]
+                    for i in range(0, len(contents), self._max_batch_size)
+                ]
+                try:
+                    embeddings_list = await asyncio.gather(
+                        *[
+                            self.embedding_func(batch, context="document")
+                            for batch in batches
+                        ]
+                    )
+                except Exception as e:
+                    logger.error(
+                        f"[{self.workspace}] Error embedding pending vector ops "
+                        f"(upserts={len(docs_to_embed)}): {e}"
+                    )
+                    raise
+                embeddings = np.concatenate(embeddings_list)
+                assert len(embeddings) == len(docs_to_embed), (
+                    f"Embedding count mismatch: expected {len(docs_to_embed)}, "
+                    f"got {len(embeddings)}"
+                )
+                for i, ((_, pending_doc), embedding) in enumerate(
+                    zip(docs_to_embed, embeddings), start=1
+                ):
+                    pending_doc.vector = embedding.tolist()
+                    await _cooperative_yield(i)
 
             actions: list[dict[str, Any]] = []
             for doc_id in pending_deletes:
@@ -3397,15 +3431,24 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
                         "_id": doc_id,
                     }
                 )
-            for doc_id, source in pending_docs.items():
+            committed_doc_ids: set[str] = set()
+            for doc_id, pending_doc in pending_docs.items():
+                if pending_doc.vector is None:
+                    continue
+                committed_doc_ids.add(doc_id)
                 actions.append(
                     {
                         "_op_type": "index",
                         "_index": self._index_name,
                         "_id": doc_id,
-                        "_source": source,
+                        "_source": {
+                            **pending_doc.source,
+                            "vector": pending_doc.vector,
+                        },
                     }
                 )
+            if not actions:
+                return
 
             try:
                 # No per-operation refresh: search visibility is established
@@ -3428,7 +3471,7 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
 
             # Clear successful and non-retryable entries; keep retryable ones
             # in place for the next flush.
-            for doc_id in list(pending_docs.keys()):
+            for doc_id in committed_doc_ids:
                 if doc_id not in retryable_ids:
                     pending_docs.pop(doc_id, None)
             new_deletes: set[str] = set()
@@ -3555,7 +3598,8 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
                 return None
             pending = self._pending_vector_docs.get(id)
             if pending is not None:
-                doc = {k: v for k, v in pending.items() if k != "vector"}
+                doc = dict(pending.source)
+                doc.pop("vector", None)
                 doc["id"] = id
                 return doc
             if not self._index_ready:
@@ -3597,7 +3641,8 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
                     continue
                 pending = self._pending_vector_docs.get(doc_id)
                 if pending is not None:
-                    doc = {k: v for k, v in pending.items() if k != "vector"}
+                    doc = dict(pending.source)
+                    doc.pop("vector", None)
                     doc["id"] = doc_id
                     buffered[doc_id] = doc
                     continue
@@ -3638,15 +3683,47 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
         result: dict[str, list[float]] = {}
         remaining: list[str] = []
         async with self._flush_lock:
+            docs_to_embed: list[tuple[str, _PendingVectorDoc]] = []
             for doc_id in ids:
                 if doc_id in self._pending_vector_deletes:
                     continue
                 pending = self._pending_vector_docs.get(doc_id)
-                if pending is not None and "vector" in pending:
-                    result[doc_id] = pending["vector"]
+                if pending is not None:
+                    if pending.vector is None:
+                        docs_to_embed.append((doc_id, pending))
+                    else:
+                        result[doc_id] = pending.vector
                     continue
                 remaining.append(doc_id)
             index_ready = self._index_ready
+
+            if docs_to_embed:
+                contents = [pending_doc.content for _, pending_doc in docs_to_embed]
+                batches = [
+                    contents[i : i + self._max_batch_size]
+                    for i in range(0, len(contents), self._max_batch_size)
+                ]
+                try:
+                    embeddings_list = await asyncio.gather(
+                        *[
+                            self.embedding_func(batch, context="document")
+                            for batch in batches
+                        ]
+                    )
+                except Exception as e:
+                    logger.error(
+                        f"[{self.workspace}] Error lazily embedding pending vectors "
+                        f"(upserts={len(docs_to_embed)}): {e}"
+                    )
+                    raise
+                embeddings = np.concatenate(embeddings_list)
+                assert len(embeddings) == len(docs_to_embed), (
+                    f"Embedding count mismatch: expected {len(docs_to_embed)}, "
+                    f"got {len(embeddings)}"
+                )
+                for (doc_id, pending_doc), embedding in zip(docs_to_embed, embeddings):
+                    pending_doc.vector = embedding.tolist()
+                    result[doc_id] = pending_doc.vector
 
         if not remaining:
             return result
@@ -3709,7 +3786,8 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
             for doc_id in [
                 k
                 for k, v in self._pending_vector_docs.items()
-                if v.get("src_id") == entity_name or v.get("tgt_id") == entity_name
+                if v.source.get("src_id") == entity_name
+                or v.source.get("tgt_id") == entity_name
             ]:
                 self._pending_vector_docs.pop(doc_id, None)
 

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -112,6 +112,27 @@ class MockEmbeddingFunc:
         return np.random.rand(len(texts), self.embedding_dim).astype(np.float32)
 
 
+class CountingEmbeddingFunc(MockEmbeddingFunc):
+    """Embedding test double that records calls and can fail a fixed number of times."""
+
+    def __init__(self, dim=128, fail_times=0):
+        super().__init__(dim=dim)
+        self.fail_times = fail_times
+        self.call_count = 0
+        self.batches: list[list[str]] = []
+        self.texts: list[str] = []
+
+    async def __call__(self, texts, **kwargs):
+        self.call_count += 1
+        batch = list(texts)
+        self.batches.append(batch)
+        self.texts.extend(batch)
+        if self.fail_times > 0:
+            self.fail_times -= 1
+            raise RuntimeError("embedding failed")
+        return await super().__call__(texts, **kwargs)
+
+
 @pytest.fixture
 def global_config():
     """Standard global config fixture for all storage tests."""
@@ -2889,7 +2910,8 @@ class TestVectorStorage:
     async def test_upsert_generates_embeddings(
         self, global_config, embed_func, mock_client
     ):
-        """Embeddings are generated eagerly during upsert; bulk write is deferred to flush."""
+        """Embeddings are deferred until flush; upsert only buffers payloads."""
+        embed_func = CountingEmbeddingFunc()
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             with patch(
                 "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
@@ -2905,15 +2927,17 @@ class TestVectorStorage:
                 )
                 # Upsert buffers; no bulk write yet.
                 mock_bulk.assert_not_awaited()
+                assert embed_func.call_count == 0
                 assert set(s._pending_vector_docs.keys()) == {"v1", "v2"}
-                assert "vector" in s._pending_vector_docs["v1"]
-                assert len(s._pending_vector_docs["v1"]["vector"]) == 128
-                # Flush triggers a single bulk call with both docs.
+                assert s._pending_vector_docs["v1"].vector is None
+                # Flush embeds and triggers a single bulk call with both docs.
                 await s.index_done_callback()
+                assert embed_func.call_count == 1
                 mock_bulk.assert_awaited_once()
                 actions = mock_bulk.call_args[0][1]
                 assert len(actions) == 2
                 assert all(a["_op_type"] == "index" for a in actions)
+                assert all("vector" in a["_source"] for a in actions)
 
     @pytest.mark.asyncio
     async def test_query_cosine_score_conversion(
@@ -3228,6 +3252,7 @@ class TestVectorStorageBatching:
         self, global_config, embed_func, mock_client
     ):
         """Many small upsert() calls collapse to one async_bulk on flush."""
+        embed_func = CountingEmbeddingFunc()
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             with patch(
                 "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
@@ -3238,17 +3263,45 @@ class TestVectorStorageBatching:
                 for i in range(5):
                     await s.upsert({f"v{i}": {"content": f"doc {i}"}})
                 mock_bulk.assert_not_awaited()
+                assert embed_func.call_count == 0
                 await s.index_done_callback()
+                assert embed_func.call_count == 1
+                assert embed_func.batches == [[f"doc {i}" for i in range(5)]]
                 mock_bulk.assert_awaited_once()
                 actions = mock_bulk.call_args[0][1]
                 assert len(actions) == 5
                 assert {a["_id"] for a in actions} == {f"v{i}" for i in range(5)}
 
     @pytest.mark.asyncio
+    async def test_deferred_embeddings_respect_batch_size(
+        self, global_config, embed_func, mock_client
+    ):
+        """Flush batches deferred embeddings by embedding_batch_num."""
+        embed_func = CountingEmbeddingFunc()
+        config = {**global_config, "embedding_batch_num": 2}
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch(
+                "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
+            ) as mock_bulk:
+                mock_bulk.return_value = (5, [])
+                s = self._make(config, embed_func)
+                await s.initialize()
+                for i in range(5):
+                    await s.upsert({f"v{i}": {"content": f"doc {i}"}})
+                await s.index_done_callback()
+                assert embed_func.batches == [
+                    ["doc 0", "doc 1"],
+                    ["doc 2", "doc 3"],
+                    ["doc 4"],
+                ]
+                mock_bulk.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_upsert_overwrites_pending_doc_for_same_id(
         self, global_config, embed_func, mock_client
     ):
         """Upserting the same id twice keeps only the latest payload."""
+        embed_func = CountingEmbeddingFunc()
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             with patch(
                 "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
@@ -3259,6 +3312,8 @@ class TestVectorStorageBatching:
                 await s.upsert({"v1": {"content": "first"}})
                 await s.upsert({"v1": {"content": "second"}})
                 await s.index_done_callback()
+                assert embed_func.call_count == 1
+                assert embed_func.texts == ["second"]
                 actions = mock_bulk.call_args[0][1]
                 assert len(actions) == 1
                 assert actions[0]["_source"]["content"] == "second"
@@ -3368,14 +3423,38 @@ class TestVectorStorageBatching:
         self, global_config, embed_func, mock_client
     ):
         """get_vectors_by_ids returns buffered embeddings without an mget roundtrip."""
+        embed_func = CountingEmbeddingFunc()
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()
             await s.upsert({"v1": {"content": "x"}})
+            assert embed_func.call_count == 0
             vecs = await s.get_vectors_by_ids(["v1"])
             assert "v1" in vecs
             assert len(vecs["v1"]) == 128
+            assert embed_func.call_count == 1
+            assert s._pending_vector_docs["v1"].vector == vecs["v1"]
             mock_client.mget.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_lazy_get_vectors_cache_is_reused_by_flush(
+        self, global_config, embed_func, mock_client
+    ):
+        """A lazy pending-vector read should not force a second embedding during flush."""
+        embed_func = CountingEmbeddingFunc()
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch(
+                "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
+            ) as mock_bulk:
+                mock_bulk.return_value = (1, [])
+                s = self._make(global_config, embed_func)
+                await s.initialize()
+                await s.upsert({"v1": {"content": "x"}})
+                vecs = await s.get_vectors_by_ids(["v1"])
+                await s.index_done_callback()
+                assert embed_func.call_count == 1
+                actions = mock_bulk.call_args[0][1]
+                assert actions[0]["_source"]["vector"] == vecs["v1"]
 
     @pytest.mark.asyncio
     async def test_finalize_flushes_pending_ops(
@@ -3500,15 +3579,19 @@ class TestVectorStorageBatching:
         self, global_config, embed_func, mock_client
     ):
         """Transient (5xx) per-doc failures stay buffered for the next flush."""
+        embed_func = CountingEmbeddingFunc()
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             with patch(
                 "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
             ) as mock_bulk:
                 # First flush: v1 succeeds, v2 fails with 503 (retryable).
-                mock_bulk.return_value = (
-                    1,
-                    [{"index": {"_id": "v2", "status": 503, "error": "down"}}],
-                )
+                mock_bulk.side_effect = [
+                    (
+                        1,
+                        [{"index": {"_id": "v2", "status": 503, "error": "down"}}],
+                    ),
+                    (1, []),
+                ]
                 s = self._make(global_config, embed_func)
                 await s.initialize()
                 await s.upsert(
@@ -3521,6 +3604,64 @@ class TestVectorStorageBatching:
                 # v1 cleared, v2 retained for retry.
                 assert "v1" not in s._pending_vector_docs
                 assert "v2" in s._pending_vector_docs
+                assert s._pending_vector_docs["v2"].vector is not None
+                assert embed_func.call_count == 1
+
+                await s.index_done_callback()
+                assert "v2" not in s._pending_vector_docs
+                assert embed_func.call_count == 1
+                assert mock_bulk.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_embedding_failure_leaves_pending_for_retry(
+        self, global_config, embed_func, mock_client
+    ):
+        """Embedding failures behave like flush failures: buffers stay intact."""
+        embed_func = CountingEmbeddingFunc(fail_times=1)
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch(
+                "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
+            ) as mock_bulk:
+                mock_bulk.return_value = (1, [])
+                s = self._make(global_config, embed_func)
+                await s.initialize()
+                await s.upsert({"v1": {"content": "retry me"}})
+
+                with pytest.raises(RuntimeError, match="embedding failed"):
+                    await s.index_done_callback()
+                mock_bulk.assert_not_awaited()
+                assert "v1" in s._pending_vector_docs
+                assert s._pending_vector_docs["v1"].vector is None
+
+                await s.index_done_callback()
+                mock_bulk.assert_awaited_once()
+                assert "v1" not in s._pending_vector_docs
+                assert embed_func.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_finalize_wraps_embedding_failure(
+        self, global_config, embed_func, mock_client
+    ):
+        """finalize() reports pending buffers when deferred embedding fails."""
+        embed_func = CountingEmbeddingFunc(fail_times=1)
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch.object(
+                ClientManager, "release_client", new_callable=AsyncMock
+            ) as mock_release:
+                with patch(
+                    "lightrag.kg.opensearch_impl.helpers.async_bulk",
+                    new_callable=AsyncMock,
+                ) as mock_bulk:
+                    s = self._make(global_config, embed_func)
+                    await s.initialize()
+                    await s.upsert({"v1": {"content": "stuck"}})
+                    with pytest.raises(RuntimeError, match="pending upserts"):
+                        await s.finalize()
+                    mock_bulk.assert_not_awaited()
+                    mock_release.assert_awaited_once()
+                    assert s.client is None
+                    assert "v1" in s._pending_vector_docs
+                    assert s._pending_vector_docs["v1"].vector is None
 
     @pytest.mark.asyncio
     async def test_delete_entity_relation_prunes_pending_buffer(
@@ -4005,6 +4146,51 @@ class TestVectorStorageBatching:
                 assert not drop_task.done()
 
                 flush_can_finish.set()
+                await flush_task
+                await drop_task
+                assert drop_delete_started.is_set()
+
+    @pytest.mark.asyncio
+    async def test_drop_serialised_with_flush_embedding_phase(
+        self, global_config, mock_client
+    ):
+        """drop must also wait while deferred embedding runs under the flush lock."""
+        embedding_started = asyncio.Event()
+        embedding_can_finish = asyncio.Event()
+        drop_delete_started = asyncio.Event()
+
+        class GatedEmbeddingFunc(MockEmbeddingFunc):
+            async def __call__(self, texts, **kwargs):
+                embedding_started.set()
+                await embedding_can_finish.wait()
+                return await super().__call__(texts, **kwargs)
+
+        async def watch_indices_delete(**kwargs):
+            drop_delete_started.set()
+
+        mock_client.indices.delete = AsyncMock(side_effect=watch_indices_delete)
+        embed_func = GatedEmbeddingFunc()
+
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch(
+                "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
+            ) as mock_bulk:
+                mock_bulk.return_value = (1, [])
+                s = self._make(global_config, embed_func)
+                await s.initialize()
+                await s.upsert({"v1": {"content": "x"}})
+
+                flush_task = asyncio.create_task(s.index_done_callback())
+                await embedding_started.wait()
+                drop_task = asyncio.create_task(s.drop())
+                for _ in range(5):
+                    await asyncio.sleep(0)
+                assert (
+                    not drop_delete_started.is_set()
+                ), "indices.delete should be blocked during deferred embedding"
+                assert not drop_task.done()
+
+                embedding_can_finish.set()
                 await flush_task
                 await drop_task
                 assert drop_delete_started.is_set()


### PR DESCRIPTION
## Description

Defers OpenSearch vector embedding generation from `upsert()` to the flush/read paths so repeated pending writes can be deduplicated and embedded in larger batches while preserving cross-worker destructive mutation ordering.

## Related Issues

N/A

## Changes Made

- Added a `_PendingVectorDoc` buffer record that stores metadata, raw content, and an optional cached vector.
- Changed `OpenSearchVectorDBStorage.upsert()` to buffer payloads without calling the embedding function.
- Moved pending-document embedding into `_flush_pending_vector_ops()` under the namespace flush lock, before bulk indexing.
- Treat embedding failures like persistence failures: pending docs remain buffered for retry, and `finalize()` reports pending writes.
- Kept `get_vectors_by_ids()` read-your-writes behavior by lazily embedding pending docs and caching the vector for later flush.
- Added mock-based regression coverage for deferred batching, lazy-cache reuse, retry behavior, embedding failures, and destructive mutation serialization during the embedding phase.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Local verification:

- `ruff check lightrag/kg/opensearch_impl.py tests/kg/opensearch_impl/test_opensearch_storage.py`
- `./scripts/test.sh tests/kg/opensearch_impl/test_opensearch_storage.py` (179 passed)
- `./scripts/test.sh tests/kg/opensearch_impl` (195 passed)
