### PR TITLE
fix(llm): retry transient OpenAI 5xx and 'could not parse JSON body' 400s

### DIFF
--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -468,6 +468,11 @@ async def openai_complete_if_cache(
             await openai_async_client.close()
         except Exception as close_error:
             logger.warning(f"Failed to close OpenAI client: {close_error}")
+        # Heuristic: match on the provider's error wording. It can drift across
+        # providers/proxies or localization, and a genuinely malformed request
+        # body (e.g. invalid user-supplied JSON) could also surface this text —
+        # in that case we simply retry 3x and still fail fast. We accept that
+        # "retry too much" trade-off to recover the common transient case.
         if "could not parse" in str(e).lower():
             logger.warning(f"Transient JSON-parse 400 from OpenAI, will retry: {e}")
             raise TransientBadRequestError(str(e)) from e

--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -16,6 +16,8 @@ from openai import (
     APIConnectionError,
     RateLimitError,
     APITimeoutError,
+    InternalServerError,
+    BadRequestError,
 )
 from tenacity import (
     retry,
@@ -71,6 +73,19 @@ load_dotenv(dotenv_path=".env", override=False)
 
 class InvalidResponseError(Exception):
     """Custom exception class for triggering retry mechanism"""
+
+    pass
+
+
+class TransientBadRequestError(Exception):
+    """Wrapper to trigger retry on transient HTTP 400 errors.
+
+    Some 400s are not genuine client errors: the OpenAI API (or a proxy in
+    front of it) intermittently returns "We could not parse the JSON body of
+    your request" when the request body is corrupted/truncated in transit.
+    These succeed on retry, so we re-raise them as this retryable type while
+    letting genuine 400s (bad params, content policy, etc.) fail fast.
+    """
 
     pass
 
@@ -216,6 +231,11 @@ def create_openai_async_client(
         | retry_if_exception_type(APIConnectionError)
         | retry_if_exception_type(APITimeoutError)
         | retry_if_exception_type(InvalidResponseError)
+        # Retry transient HTTP 5xx (OpenAI "500 server_error", proxy "upstream
+        # connect error"). InternalServerError covers all status >= 500.
+        | retry_if_exception_type(InternalServerError)
+        # Retry transient "could not parse JSON body" 400s (see handler below).
+        | retry_if_exception_type(TransientBadRequestError)
     ),
 )
 async def openai_complete_if_cache(
@@ -436,6 +456,18 @@ async def openai_complete_if_cache(
             await openai_async_client.close()
         except Exception as close_error:
             logger.warning(f"Failed to close OpenAI client: {close_error}")
+        raise
+    except BadRequestError as e:
+        # A "could not parse JSON body" 400 is transient (corrupted/truncated
+        # request body in transit) and succeeds on retry; re-raise it as a
+        # retryable type. Genuine 400s (bad params, content policy) fail fast.
+        if "could not parse" in str(e).lower():
+            logger.warning(f"Transient JSON-parse 400 from OpenAI, will retry: {e}")
+            try:
+                await openai_async_client.close()
+            except Exception as close_error:
+                logger.warning(f"Failed to close OpenAI client: {close_error}")
+            raise TransientBadRequestError(str(e)) from e
         raise
     except Exception as e:
         body = getattr(e, "body", None)
@@ -849,6 +881,8 @@ async def nvidia_openai_complete(
         retry_if_exception_type(RateLimitError)
         | retry_if_exception_type(APIConnectionError)
         | retry_if_exception_type(APITimeoutError)
+        # Retry transient HTTP 5xx (OpenAI 500 / proxy upstream errors).
+        | retry_if_exception_type(InternalServerError)
     ),
 )
 async def openai_embed(

--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -461,12 +461,15 @@ async def openai_complete_if_cache(
         # A "could not parse JSON body" 400 is transient (corrupted/truncated
         # request body in transit) and succeeds on retry; re-raise it as a
         # retryable type. Genuine 400s (bad params, content policy) fail fast.
+        # Either way we must close the client before re-raising, matching the
+        # other except branches above — otherwise non-transient 400s would
+        # leak httpx connections in validation-heavy/misconfigured runs.
+        try:
+            await openai_async_client.close()
+        except Exception as close_error:
+            logger.warning(f"Failed to close OpenAI client: {close_error}")
         if "could not parse" in str(e).lower():
             logger.warning(f"Transient JSON-parse 400 from OpenAI, will retry: {e}")
-            try:
-                await openai_async_client.close()
-            except Exception as close_error:
-                logger.warning(f"Failed to close OpenAI client: {close_error}")
             raise TransientBadRequestError(str(e)) from e
         raise
     except Exception as e:

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -3708,10 +3708,14 @@ def create_prefixed_exception(original_exception: Exception, prefix: str) -> Exc
         else:
             # Method 2: If no args, try single parameter construction.
             return type(original_exception)(f"{prefix}: {str(original_exception)}")
-    except (TypeError, ValueError, AttributeError):
-        # Method 3: If reconstruction fails, wrap it in a RuntimeError.
-        # This is the safest fallback, as attempting to create the same type
-        # with a single string can fail if the constructor requires multiple arguments.
+    except Exception:
+        # Method 3: If reconstruction fails for any reason, wrap it in a
+        # RuntimeError preserving the original type name and message. Many SDK
+        # exceptions cannot be rebuilt from their args alone because their
+        # constructor signatures differ — e.g. json.JSONDecodeError requires
+        # (msg, doc, pos) and openai.APIStatusError/BadRequestError require
+        # keyword-only (response, body). The original exception and its full
+        # traceback are preserved by the caller's `raise ... from original`.
         return RuntimeError(
             f"{prefix}: {type(original_exception).__name__}: {str(original_exception)}"
         )

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -3710,11 +3710,15 @@ def create_prefixed_exception(original_exception: Exception, prefix: str) -> Exc
             return type(original_exception)(f"{prefix}: {str(original_exception)}")
     except Exception:
         # Method 3: If reconstruction fails for any reason, wrap it in a
-        # RuntimeError preserving the original type name and message. Many SDK
-        # exceptions cannot be rebuilt from their args alone because their
-        # constructor signatures differ — e.g. json.JSONDecodeError requires
-        # (msg, doc, pos) and openai.APIStatusError/BadRequestError require
-        # keyword-only (response, body). The original exception and its full
+        # RuntimeError preserving the original type name and message. This is a
+        # defensive catch-all: most known failures already surface as TypeError
+        # (e.g. json.JSONDecodeError needs (msg, doc, pos) and
+        # openai.APIStatusError/BadRequestError need keyword-only
+        # (response, body), so rebuilding from args alone raises TypeError), but
+        # an exotic constructor could raise something else (KeyError, a
+        # validation error, ...). Catching `Exception` guarantees this helper
+        # never raises while prefixing — `KeyboardInterrupt`/`SystemExit` are
+        # BaseException and still propagate. The original exception and its full
         # traceback are preserved by the caller's `raise ... from original`.
         return RuntimeError(
             f"{prefix}: {type(original_exception).__name__}: {str(original_exception)}"

--- a/tests/llm/openai_impl/test_openai_retry_transient.py
+++ b/tests/llm/openai_impl/test_openai_retry_transient.py
@@ -1,0 +1,102 @@
+"""Regression tests for retrying transient OpenAI failures.
+
+Covers:
+  * HTTP 5xx (InternalServerError) is retried on both complete and embed.
+  * Transient "could not parse JSON body" 400s are converted to a retryable
+    TransientBadRequestError, while genuine 400s fail fast.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from openai import BadRequestError, InternalServerError
+
+from lightrag.llm.openai import (
+    TransientBadRequestError,
+    openai_complete_if_cache,
+    openai_embed,
+)
+
+
+def _retry_exception_types(func) -> set[type]:
+    """Collect the exception types a tenacity-decorated func retries on."""
+    types: set[type] = set()
+
+    def _walk(retry_obj):
+        # retry_any / retry_all expose `.retries`; retry_if_exception_type
+        # exposes `.exception_types` (a single type or a tuple of types).
+        for child in getattr(retry_obj, "retries", ()):
+            _walk(child)
+        exc_types = getattr(retry_obj, "exception_types", ())
+        if isinstance(exc_types, type):
+            exc_types = (exc_types,)
+        types.update(exc_types)
+
+    # openai_embed is wrapped by @wrap_embedding_func_with_attrs; the
+    # tenacity-decorated callable is on `.func`.
+    target = getattr(func, "func", func)
+    _walk(target.retry.retry)
+    return types
+
+
+def _make_bad_request(message: str) -> BadRequestError:
+    request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    response = httpx.Response(status_code=400, request=request)
+    return BadRequestError(message, response=response, body=None)
+
+
+def _make_error_client(error: Exception) -> SimpleNamespace:
+    return SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=AsyncMock(side_effect=error))
+        ),
+        close=AsyncMock(),
+    )
+
+
+@pytest.mark.offline
+def test_complete_retries_5xx_and_transient_400():
+    retried = _retry_exception_types(openai_complete_if_cache)
+    assert InternalServerError in retried
+    assert TransientBadRequestError in retried
+
+
+@pytest.mark.offline
+def test_embed_retries_5xx():
+    assert InternalServerError in _retry_exception_types(openai_embed)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_transient_json_parse_400_is_wrapped():
+    """A 'could not parse JSON body' 400 becomes a retryable wrapper."""
+    err = _make_bad_request(
+        "Error code: 400 - We could not parse the JSON body of your request."
+    )
+    fake_client = _make_error_client(err)
+    # Call the undecorated coroutine to exercise the handler exactly once
+    # (bypasses the tenacity retry loop and its waits).
+    with patch(
+        "lightrag.llm.openai.create_openai_async_client", return_value=fake_client
+    ):
+        with pytest.raises(TransientBadRequestError):
+            await openai_complete_if_cache.__wrapped__(
+                model="gpt-4o-mini", prompt="hello"
+            )
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_genuine_400_fails_fast():
+    """A non-parse 400 (e.g. bad params) is not wrapped and propagates."""
+    err = _make_bad_request("Error code: 400 - Invalid value for 'temperature'.")
+    fake_client = _make_error_client(err)
+    with patch(
+        "lightrag.llm.openai.create_openai_async_client", return_value=fake_client
+    ):
+        with pytest.raises(BadRequestError):
+            await openai_complete_if_cache.__wrapped__(
+                model="gpt-4o-mini", prompt="hello"
+            )

--- a/tests/llm/openai_impl/test_openai_retry_transient.py
+++ b/tests/llm/openai_impl/test_openai_retry_transient.py
@@ -85,12 +85,13 @@ async def test_transient_json_parse_400_is_wrapped():
             await openai_complete_if_cache.__wrapped__(
                 model="gpt-4o-mini", prompt="hello"
             )
+    fake_client.close.assert_awaited()
 
 
 @pytest.mark.offline
 @pytest.mark.asyncio
 async def test_genuine_400_fails_fast():
-    """A non-parse 400 (e.g. bad params) is not wrapped and propagates."""
+    """A non-parse 400 (e.g. bad params) is not wrapped, propagates, and closes the client."""
     err = _make_bad_request("Error code: 400 - Invalid value for 'temperature'.")
     fake_client = _make_error_client(err)
     with patch(
@@ -100,3 +101,6 @@ async def test_genuine_400_fails_fast():
             await openai_complete_if_cache.__wrapped__(
                 model="gpt-4o-mini", prompt="hello"
             )
+    # The non-transient 400 path must still close the underlying httpx client
+    # to avoid connection leaks in validation-heavy/misconfigured runs.
+    fake_client.close.assert_awaited()

--- a/tests/test_create_prefixed_exception.py
+++ b/tests/test_create_prefixed_exception.py
@@ -1,0 +1,49 @@
+"""Regression tests for create_prefixed_exception.
+
+Some exceptions cannot be reconstructed from their ``args`` alone because
+their constructor signatures differ (json.JSONDecodeError needs
+``(msg, doc, pos)``; openai SDK ``APIStatusError`` subclasses need keyword-only
+``response``/``body``). The helper must never raise while prefixing and must
+surface the original type name + message. See HKUDS/LightRAG #2710 and #2794.
+"""
+
+import json
+
+import pytest
+
+from lightrag.utils import create_prefixed_exception
+
+
+@pytest.mark.offline
+def test_reconstructable_exception_keeps_type_and_prefix():
+    result = create_prefixed_exception(ValueError("boom"), "`entity`")
+    assert isinstance(result, ValueError)
+    assert str(result) == "`entity`: boom"
+
+
+@pytest.mark.offline
+def test_jsondecodeerror_does_not_raise_and_preserves_message():
+    try:
+        json.loads('{\n  "x": "abc')  # unterminated string -> JSONDecodeError
+    except json.JSONDecodeError as exc:
+        result = create_prefixed_exception(exc, "`entity`")
+    # JSONDecodeError(msg) is missing (doc, pos): falls back to a clean RuntimeError
+    assert isinstance(result, RuntimeError)
+    assert result.args  # never an empty/garbled exception
+    assert "`entity`" in str(result)
+    assert "JSONDecodeError" in str(result)
+    assert "Unterminated string" in str(result)
+
+
+@pytest.mark.offline
+def test_keyword_only_constructor_exception_falls_back_cleanly():
+    """Mimics openai.APIStatusError: keyword-only required args."""
+
+    class KeywordOnlyError(Exception):
+        def __init__(self, message, *, response, body):
+            super().__init__(message)
+
+    exc = KeywordOnlyError("Error code: 500", response=object(), body=None)
+    result = create_prefixed_exception(exc, "chunk-1")
+    assert isinstance(result, RuntimeError)
+    assert str(result) == "chunk-1: KeywordOnlyError: Error code: 500"


### PR DESCRIPTION
## Summary

Large-batch document ingestion intermittently fails on **transient LLM provider/gateway errors that aren't retried** — a single blip kills the whole document instead of retrying. Observed in a 3,000-file ingestion: the failures were entirely transient (OpenAI `500 server_error`, proxy `upstream connect error / connection termination`, and `400 "could not parse JSON body"`), none caused by the input data.

## Motivation

The `@retry` policy on the OpenAI binding only covers `RateLimitError`, `APIConnectionError`, `APITimeoutError`, and `InvalidResponseError`:

- **HTTP 5xx** (`InternalServerError`) — OpenAI `500 server_error` and proxy `upstream connect error` — is **not retried**, so a transient server-side blip fails the document immediately.
- **`400 "We could not parse the JSON body of your request"`** is **transient** (request body corrupted/truncated in transit; succeeds on retry) but, as a `BadRequestError`, fails fast.

This is the core of #2794 (and the reconstruction symptom in #2710).

## What's changed

- `lightrag/llm/openai.py`
  - Add `InternalServerError` (covers all HTTP ≥500, including proxy 5xx) to the `@retry` policies on **both** `openai_complete_if_cache` and `openai_embed`.
  - Detect transient `"could not parse"` 400s in the exception handler and re-raise them as a new retryable `TransientBadRequestError`; **genuine** 400s (bad params, content policy, …) still fail fast. The match is a heuristic on the provider's error wording — see the inline note on the "retry too much" trade-off for genuinely malformed bodies.
- `lightrag/utils.py`
  - Defensively harden `create_prefixed_exception` to catch **any** reconstruction failure (not just `TypeError/ValueError/AttributeError`). Note: the previously-named SDK cases (`json.JSONDecodeError` → `(msg, doc, pos)`; openai `APIStatusError`/`BadRequestError` → keyword-only `response`/`body`) actually already raised `TypeError` and were caught by the old fallback, so this is **not** fixing an existing escape — it is a defensive widening so that an exotic constructor failing with some *other* exception (e.g. `KeyError`, a validation error) can never escape the prefixing helper either. `KeyboardInterrupt`/`SystemExit` are `BaseException` and still propagate. Original type/message preserved; traceback preserved via the caller's `raise ... from`.

## What could break / how it works

- Behavior change is limited to **retry scope**: previously-fatal transient 5xx and parse-error 400s now retry (3 attempts, existing exponential backoff). Non-transient errors (genuine 400s, auth, etc.) are unaffected and still fail fast.
- `create_prefixed_exception` change only widens the fallback `except`; the success path and message format are unchanged.

## Tests

- `tests/llm/openai_impl/test_openai_retry_transient.py` — retry membership (5xx + transient-400 on complete; 5xx on embed), transient-400 → `TransientBadRequestError` wrapping, genuine-400 passthrough.
- `tests/test_create_prefixed_exception.py` — reconstructable exceptions keep type+prefix; `JSONDecodeError` and keyword-only-constructor exceptions fall back cleanly without raising.
- All new tests pass; existing `tests/llm/openai_impl/` green; `ruff check` clean.

Closes #2794
Refs #2710
