### PR TITLE
perf(nano): defer vector embedding to flush time

### DIFF
--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -195,6 +195,10 @@ class NanoVectorDBStorage(BaseVectorStorage):
         # it never duplicates rows already written to the client. Flushed
         # under _storage_lock by _flush_pending_locked().
         self._pending_upserts: dict[str, _PendingNanoDoc] = {}
+        # True when self._client has materialized changes that have not been
+        # successfully saved to disk yet. This lets finalize retry a save even
+        # after a previous flush cleared the pending buffer.
+        self._client_dirty = False
 
     async def initialize(self):
         """Initialize storage data"""
@@ -358,6 +362,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
             list_data.append(record)
 
         self._client.upsert(datas=list_data)
+        self._client_dirty = True
 
         # Clear only the entries we just flushed (an upsert that arrived after
         # the snapshot would have re-set vector=None and must not be dropped).
@@ -469,6 +474,8 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 # Calculate actual deleted count
                 after_count = len(self._client)
                 deleted_count = before_count - after_count
+                if deleted_count:
+                    self._client_dirty = True
 
             logger.debug(
                 f"[{self.workspace}] Successfully deleted {deleted_count} vectors from {self.namespace}"
@@ -507,6 +514,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 )
                 if self._client.get([entity_id]):
                     self._client.delete([entity_id])
+                    self._client_dirty = True
                     deleted = True
                 else:
                     deleted = False
@@ -559,6 +567,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 ]
                 if ids_to_delete:
                     self._client.delete(ids_to_delete)
+                    self._client_dirty = True
 
             total = len(pending_ids) + len(ids_to_delete)
             if total:
@@ -612,6 +621,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 await set_all_update_flags(self.namespace, workspace=self.workspace)
                 # Reset own update flag to avoid self-reloading
                 self.storage_updated.value = False
+                self._client_dirty = False
                 return True  # Return success
             except Exception as e:
                 logger.error(
@@ -791,6 +801,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
                     self.embedding_func.embedding_dim,
                     storage_file=self._client_file_name,
                 )
+                self._client_dirty = False
 
                 # Notify other processes that data has been updated
                 await set_all_update_flags(self.namespace, workspace=self.workspace)
@@ -815,13 +826,15 @@ class NanoVectorDBStorage(BaseVectorStorage):
         recorded (``finalize_storages`` logs it as an error).
         """
         async with self._storage_lock:
-            if not self._pending_upserts:
+            if not self._pending_upserts and not self._client_dirty:
                 return
-            self._reload_client_from_disk_locked(for_write=True)
-            await self._flush_pending_locked()
+            if self._pending_upserts:
+                self._reload_client_from_disk_locked(for_write=True)
+                await self._flush_pending_locked()
             self._save_to_disk_locked()
             await set_all_update_flags(self.namespace, workspace=self.workspace)
             self.storage_updated.value = False
+            self._client_dirty = False
             leftover = len(self._pending_upserts)
 
         if leftover:

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -142,9 +142,10 @@ class NanoVectorDBStorage(BaseVectorStorage):
         caches the vector back for the next flush. ``query`` and
         ``client_storage`` see only data already materialized into
         ``self._client`` — unflushed pending data is intentionally not
-        queryable. A flush failure (embedding error / count mismatch) raises,
-        leaves the pending buffer intact, and skips the disk write so no data
-        is silently lost.
+        queryable. A flush failure (embedding error, count mismatch, or save
+        IO error) raises through ``index_done_callback``; the pending buffer
+        is preserved, and if only the save failed ``_client_dirty`` stays
+        ``True`` so a subsequent ``finalize`` retries the save.
     """
 
     def __post_init__(self):
@@ -559,11 +560,15 @@ class NanoVectorDBStorage(BaseVectorStorage):
                     del self._pending_upserts[doc_id]
 
                 # ...then scan the materialized client and delete matches.
+                # Use .get() for src_id / tgt_id to match the pending-side
+                # lookup above: rows without those keys (foreign namespaces)
+                # simply don't match instead of raising KeyError.
                 storage = getattr(self._client, "_NanoVectorDB__storage")
                 ids_to_delete = [
                     dp["__id__"]
                     for dp in storage["data"]
-                    if dp["src_id"] == entity_name or dp["tgt_id"] == entity_name
+                    if dp.get("src_id") == entity_name
+                    or dp.get("tgt_id") == entity_name
                 ]
                 if ids_to_delete:
                     self._client.delete(ids_to_delete)
@@ -592,44 +597,35 @@ class NanoVectorDBStorage(BaseVectorStorage):
                snapshot while preserving this process's pending buffer.
             2. ``_flush_pending_locked`` embeds every buffered upsert (once
                per id) and materializes it into ``self._client``. A failure
-               here **raises** — pending is kept, nothing is written — so the
-               loss surfaces through ``_insert_done`` instead of being silent.
+               here **raises** — pending is kept, nothing is written.
             3. ``_save_to_disk_locked`` (``atomic_write``) lays a tmp file
                beside the target and renames it into place — readers either
                see the previous file in full or the new file in full, never a
-               torn write.
+               torn write. A failure here **also raises**; ``_client_dirty``
+               stays ``True`` so a later ``finalize`` retries the save.
             4. ``set_all_update_flags`` flips every registered process's
                ``storage_updated`` flag, then we immediately reset our own
                flag to ``False`` so the writer does not self-reload on the
                next call to ``_get_client``.
 
-        If this worker's client is stale, reload the latest on-disk snapshot
-        first, then flush the process-local pending buffer into that fresh
-        client. Returning early here would strand deferred upserts because
-        ``_insert_done`` does not retry based on the boolean result.
+        Either failure surfaces loudly through ``_insert_done`` so the caller
+        can abort the document batch instead of silently losing vectors. The
+        bool return is kept for legacy callers but is effectively always
+        ``True`` on the success path.
         """
         async with self._storage_lock:
             self._reload_client_from_disk_locked(for_write=True)
 
-            # Flush deferred embeddings after any reload. On embedding error / count
-            # mismatch this raises, leaving pending intact and skipping the
-            # disk write (no silent data loss); the exception propagates.
+            # Flush + save both raise on failure (embedding mismatch / save IO
+            # error). The exception propagates out of the lock so _insert_done
+            # aborts the batch; pending stays intact and _client_dirty stays
+            # True (if only the save failed) for a later retry.
             await self._flush_pending_locked()
-            try:
-                self._save_to_disk_locked()
-                # Notify other processes that data has been updated
-                await set_all_update_flags(self.namespace, workspace=self.workspace)
-                # Reset own update flag to avoid self-reloading
-                self.storage_updated.value = False
-                self._client_dirty = False
-                return True  # Return success
-            except Exception as e:
-                logger.error(
-                    f"[{self.workspace}] Error saving data for {self.namespace}: {e}"
-                )
-                return False  # Return error
-
-        return True  # Return success
+            self._save_to_disk_locked()
+            await set_all_update_flags(self.namespace, workspace=self.workspace)
+            self.storage_updated.value = False
+            self._client_dirty = False
+            return True
 
     @staticmethod
     def _format_record(dp: dict[str, Any]) -> dict[str, Any]:
@@ -819,26 +815,33 @@ class NanoVectorDBStorage(BaseVectorStorage):
     async def finalize(self):
         """Flush any buffered upserts and persist before shutdown (safety net).
 
-        Normally ``index_done_callback`` has already drained the pending buffer,
-        but a flow that upserts without a trailing callback would otherwise lose
-        those vectors silently. Flush + save here, and if anything remains
-        buffered afterward raise ``RuntimeError`` naming the count so the loss is
-        recorded (``finalize_storages`` logs it as an error).
+        Normally ``index_done_callback`` has already drained the pending buffer
+        and synced to disk, but two paths land here with work to do:
+
+        - **Pending upserts only** (no prior ``index_done_callback``): flush
+          and save. We reload first so a stale process picks up other writers'
+          commits before merging its pending buffer in.
+        - **Unsaved materialized changes** (``_client_dirty=True``): an earlier
+          ``index_done_callback`` flushed pending into ``self._client`` but
+          its save raised. Skip the reload — reloading would drop those
+          materialized-but-unsaved rows — and just retry the save.
+
+        Flush / save failures propagate (same contract as
+        ``index_done_callback``); a partially flushed buffer is preserved for
+        a future retry.
         """
         async with self._storage_lock:
             if not self._pending_upserts and not self._client_dirty:
                 return
             if self._pending_upserts:
-                self._reload_client_from_disk_locked(for_write=True)
+                # Only reload when we have nothing un-persisted in self._client.
+                # A dirty client carries successfully-flushed-but-unsaved rows
+                # from a prior index_done_callback; reloading would silently
+                # drop them.
+                if not self._client_dirty:
+                    self._reload_client_from_disk_locked(for_write=True)
                 await self._flush_pending_locked()
             self._save_to_disk_locked()
             await set_all_update_flags(self.namespace, workspace=self.workspace)
             self.storage_updated.value = False
             self._client_dirty = False
-            leftover = len(self._pending_upserts)
-
-        if leftover:
-            raise RuntimeError(
-                f"[{self.workspace}] NanoVectorDBStorage.finalize() left {leftover} "
-                f"pending upserts buffered after the final flush for {self.namespace}"
-            )

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -817,6 +817,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
         async with self._storage_lock:
             if not self._pending_upserts:
                 return
+            self._reload_client_from_disk_locked(for_write=True)
             await self._flush_pending_locked()
             self._save_to_disk_locked()
             await set_all_update_flags(self.namespace, workspace=self.workspace)

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -207,6 +207,33 @@ class NanoVectorDBStorage(BaseVectorStorage):
             self.namespace, workspace=self.workspace
         )
 
+    def _reload_client_from_disk_locked(self, *, for_write: bool = False) -> bool:
+        """Reload ``self._client`` if another process committed newer data.
+
+        Precondition: the caller must already hold ``_storage_lock``. This is
+        used by write paths as well as reads because deferred upserts mean a
+        stale writer must merge its pending buffer into the latest on-disk
+        snapshot, not save over it or return without flushing.
+        """
+        if not self.storage_updated.value:
+            return False
+
+        log_message = (
+            f"[{self.workspace}] Process {os.getpid()} reloading {self.namespace} "
+            "due to update by another process"
+        )
+        if for_write:
+            logger.warning(log_message)
+        else:
+            logger.info(log_message)
+
+        self._client = NanoVectorDB(
+            self.embedding_func.embedding_dim,
+            storage_file=self._client_file_name,
+        )
+        self.storage_updated.value = False
+        return True
+
     async def _get_client(self):
         """Return the live ``NanoVectorDB`` instance, reloading from disk if needed.
 
@@ -230,19 +257,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
         so a reader cannot observe a partially-saved file.
         """
         async with self._storage_lock:
-            # Check if data needs to be reloaded
-            if self.storage_updated.value:
-                logger.info(
-                    f"[{self.workspace}] Process {os.getpid()} reloading {self.namespace} due to update by another process"
-                )
-                # Reload data
-                self._client = NanoVectorDB(
-                    self.embedding_func.embedding_dim,
-                    storage_file=self._client_file_name,
-                )
-                # Reset update flag
-                self.storage_updated.value = False
-
+            self._reload_client_from_disk_locked()
             return self._client
 
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
@@ -317,10 +332,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 for i in range(0, len(contents), self._max_batch_size)
             ]
             embeddings_list = await asyncio.gather(
-                *[
-                    self.embedding_func(batch, context="document")
-                    for batch in batches
-                ]
+                *[self.embedding_func(batch, context="document") for batch in batches]
             )
             embeddings = np.concatenate(embeddings_list)
             if len(embeddings) != len(to_embed):
@@ -444,6 +456,8 @@ class NanoVectorDBStorage(BaseVectorStorage):
             # single critical section against a concurrent flush. Operate on
             # self._client directly (the lock is non-reentrant; no _get_client).
             async with self._storage_lock:
+                self._reload_client_from_disk_locked(for_write=True)
+
                 for doc_id in ids:
                     self._pending_upserts.pop(doc_id, None)
 
@@ -484,9 +498,13 @@ class NanoVectorDBStorage(BaseVectorStorage):
             )
 
             async with self._storage_lock:
+                self._reload_client_from_disk_locked(for_write=True)
+
                 # Cancel a buffered upsert for this entity, then delete from the
                 # materialized client (lock non-reentrant; no _get_client).
-                pending_cancelled = self._pending_upserts.pop(entity_id, None) is not None
+                pending_cancelled = (
+                    self._pending_upserts.pop(entity_id, None) is not None
+                )
                 if self._client.get([entity_id]):
                     self._client.delete([entity_id])
                     deleted = True
@@ -519,6 +537,8 @@ class NanoVectorDBStorage(BaseVectorStorage):
 
         try:
             async with self._storage_lock:
+                self._reload_client_from_disk_locked(for_write=True)
+
                 # Prune matching buffered upserts (their records carry src_id /
                 # tgt_id from the relationships vdb meta_fields)...
                 pending_ids = [
@@ -559,50 +579,30 @@ class NanoVectorDBStorage(BaseVectorStorage):
 
         This is the writer's **commit point** in the cross-process sync
         protocol (see class docstring). Effects, in order:
-            1. ``_flush_pending_locked`` embeds every buffered upsert (once
+            1. If another process committed first, reload the latest on-disk
+               snapshot while preserving this process's pending buffer.
+            2. ``_flush_pending_locked`` embeds every buffered upsert (once
                per id) and materializes it into ``self._client``. A failure
                here **raises** — pending is kept, nothing is written — so the
                loss surfaces through ``_insert_done`` instead of being silent.
-            2. ``_save_to_disk_locked`` (``atomic_write``) lays a tmp file
+            3. ``_save_to_disk_locked`` (``atomic_write``) lays a tmp file
                beside the target and renames it into place — readers either
                see the previous file in full or the new file in full, never a
                torn write.
-            3. ``set_all_update_flags`` flips every registered process's
+            4. ``set_all_update_flags`` flips every registered process's
                ``storage_updated`` flag, then we immediately reset our own
                flag to ``False`` so the writer does not self-reload on the
                next call to ``_get_client``.
 
-        Two-block structure (intentional, do not collapse):
-            * **First ``async with``** — early-return path for a
-              hypothetical second writer. Under the current single-writer
-              pipeline contract (class docstring, invariant 1) the
-              ``storage_updated.value`` check is permanently ``False`` in
-              the writer, so this branch is **dead code in production**.
-              It is kept as defensive scaffolding for any future relaxation
-              of the single-writer invariant; removing it would silently
-              re-enable lost-write bugs the moment a second writer is
-              introduced. The pending buffer is left intact here so the next
-              callback retries the flush.
-            * **Second ``async with``** — flush + save + notify.
+        If this worker's client is stale, reload the latest on-disk snapshot
+        first, then flush the process-local pending buffer into that fresh
+        client. Returning early here would strand deferred upserts because
+        ``_insert_done`` does not retry based on the boolean result.
         """
         async with self._storage_lock:
-            # Check if storage was updated by another process
-            if self.storage_updated.value:
-                # Storage was updated by another process, reload data instead of saving
-                logger.warning(
-                    f"[{self.workspace}] Storage for {self.namespace} was updated by another process, reloading..."
-                )
-                self._client = NanoVectorDB(
-                    self.embedding_func.embedding_dim,
-                    storage_file=self._client_file_name,
-                )
-                # Reset update flag
-                self.storage_updated.value = False
-                return False  # Return error
+            self._reload_client_from_disk_locked(for_write=True)
 
-        # Acquire lock and perform flush + persistence
-        async with self._storage_lock:
-            # Flush deferred embeddings first. On embedding error / count
+            # Flush deferred embeddings after any reload. On embedding error / count
             # mismatch this raises, leaving pending intact and skipping the
             # disk write (no silent data loss); the exception propagates.
             await self._flush_pending_locked()

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -22,6 +22,24 @@ from .shared_storage import (
 )
 
 
+@dataclass
+class _PendingNanoDoc:
+    """A buffered upsert waiting for deferred embedding and materialization.
+
+    ``record`` holds ``__id__`` / ``__created_at__`` plus the ``meta_fields``
+    (which always include ``content`` for the entity/relation/chunk vdbs), so
+    the content needed for deferred embedding lives in the record itself — no
+    separate copy is kept. ``vector`` starts as ``None`` and is filled either
+    during the lock-held flush or by a lazy ``get_vectors_by_ids`` embedding;
+    once set it is reused by the next flush instead of re-calling the model.
+    The compressed ``vector`` / raw ``__vector__`` keys are added to ``record``
+    only at flush time, right before ``client.upsert``.
+    """
+
+    record: dict[str, Any]
+    vector: np.ndarray | None = None
+
+
 @final
 @dataclass
 class NanoVectorDBStorage(BaseVectorStorage):
@@ -99,6 +117,34 @@ class NanoVectorDBStorage(BaseVectorStorage):
               not exposed in the WebUI. If you wire them up to a new
               caller, that caller must arrange single-writer
               serialization the same way the pipeline does.
+
+    Deferred-embedding protocol:
+        ``upsert`` does **not** call the embedding model. It only buffers a
+        ``_PendingNanoDoc`` (content-bearing record + ``vector=None``) in the
+        minimal ``self._pending_upserts`` area, overwriting any prior pending
+        doc for the same id (which also clears a temp vector a previous
+        ``get_vectors_by_ids`` may have cached). The model is called once per
+        id at flush time (``_flush_pending_locked``), so repeated upserts of
+        the same id — and many small upsert calls — embed only once. See
+        issue #2785 and the ``OpenSearchVectorDBStorage`` equivalent.
+
+        Embedding runs **inside ``_storage_lock``** during the flush (not in
+        ``upsert``): under the single-writer invariant this keeps the content
+        used for embedding consistent with the record written to disk and
+        prevents a destructive op from interleaving between embed and write.
+        The lock is non-reentrant, so ``_flush_pending_locked`` requires the
+        caller to already hold it and operates on ``self._client`` directly
+        (never through ``_get_client``).
+
+        Reads are read-your-writes: ``get_by_id`` / ``get_by_ids`` /
+        ``get_vectors_by_ids`` consult ``_pending_upserts`` first.
+        ``get_vectors_by_ids`` lazily embeds a pending doc on demand and
+        caches the vector back for the next flush. ``query`` and
+        ``client_storage`` see only data already materialized into
+        ``self._client`` — unflushed pending data is intentionally not
+        queryable. A flush failure (embedding error / count mismatch) raises,
+        leaves the pending buffer intact, and skips the disk write so no data
+        is silently lost.
     """
 
     def __post_init__(self):
@@ -143,6 +189,12 @@ class NanoVectorDBStorage(BaseVectorStorage):
             self.embedding_func.embedding_dim,
             storage_file=self._client_file_name,
         )
+
+        # Minimal pending area for deferred embedding: id -> _PendingNanoDoc.
+        # Holds only records not yet embedded+materialized into self._client;
+        # it never duplicates rows already written to the client. Flushed
+        # under _storage_lock by _flush_pending_locked().
+        self._pending_upserts: dict[str, _PendingNanoDoc] = {}
 
     async def initialize(self):
         """Initialize storage data"""
@@ -194,69 +246,144 @@ class NanoVectorDBStorage(BaseVectorStorage):
             return self._client
 
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
-        """Insert or update vectors in memory; persistence is deferred.
+        """Buffer vectors for deferred embedding; persistence is deferred too.
+
+        Embedding is **not** performed here. Each record is buffered in
+        ``self._pending_upserts`` with ``vector=None`` and the embedding model
+        is called once per id at flush time (``_flush_pending_locked`` during
+        ``index_done_callback`` / ``finalize``). This coalesces repeated
+        upserts of the same id and many small upsert calls into a single
+        embedding pass (see class docstring, *Deferred-embedding protocol*,
+        and issue #2785).
 
         Persistence:
             Changes live only in this process's memory until the next
             ``index_done_callback``. Cross-process readers will not see
             them until that commit fires (see class docstring,
-            *Cross-process sync protocol*).
-
-        Concurrency:
-            The embedding step runs **outside** ``_storage_lock`` on
-            purpose — it can issue network / GPU calls and we don't
-            want to hold the per-namespace lock for that latency. The
-            actual ``client.upsert`` call happens after ``_get_client``;
-            correctness during that unlocked window relies on the class
-            docstring *Lock scope* invariant (synchronous NanoVectorDB
-            ops + single-writer pipeline gate).
+            *Cross-process sync protocol*). Until the flush, an upserted id
+            is observable only through the read-your-writes read paths, not
+            through ``query``.
         """
-        # logger.debug(f"[{self.workspace}] Inserting {len(data)} to {self.namespace}")
+        # logger.debug(f"[{self.workspace}] Buffering {len(data)} to {self.namespace}")
         if not data:
             return
 
         current_time = int(time.time())
-        list_data = [
-            {
-                "__id__": k,
-                "__created_at__": current_time,
-                **{k1: v1 for k1, v1 in v.items() if k1 in self.meta_fields},
-            }
+        pending = [
+            (
+                k,
+                {
+                    "__id__": k,
+                    "__created_at__": current_time,
+                    **{k1: v1 for k1, v1 in v.items() if k1 in self.meta_fields},
+                },
+            )
             for k, v in data.items()
         ]
-        contents = [v["content"] for v in data.values()]
-        batches = [
-            contents[i : i + self._max_batch_size]
-            for i in range(0, len(contents), self._max_batch_size)
+
+        # Buffer under the lock to interlock with the lock-held flush. A new
+        # _PendingNanoDoc(vector=None) overwrites any prior pending doc for the
+        # same id, discarding a temp vector a previous get_vectors_by_ids may
+        # have cached (content-version change -> must re-embed new content).
+        async with self._storage_lock:
+            for doc_id, record in pending:
+                self._pending_upserts[doc_id] = _PendingNanoDoc(record=record)
+
+    async def _flush_pending_locked(self) -> None:
+        """Embed pending docs and materialize them into ``self._client``.
+
+        Precondition: the caller **must already hold** ``_storage_lock``. The
+        lock is non-reentrant, so this helper never calls ``_get_client`` and
+        operates on ``self._client`` directly. Embedding runs inside the lock
+        on purpose (see class docstring, *Deferred-embedding protocol*).
+
+        Failure handling: if embedding raises or the returned count does not
+        match, the exception propagates and ``_pending_upserts`` is left intact
+        so the next flush retries; nothing is written to ``self._client``.
+        """
+        if not self._pending_upserts:
+            return
+
+        # Snapshot for stable ordering between the embed list and the write.
+        pending_items = list(self._pending_upserts.items())
+        to_embed = [
+            (doc_id, pdoc) for doc_id, pdoc in pending_items if pdoc.vector is None
         ]
 
-        # Execute embedding outside of lock to avoid long lock times
-        embedding_tasks = [
-            self.embedding_func(batch, context="document") for batch in batches
-        ]
-        embeddings_list = await asyncio.gather(*embedding_tasks)
-
-        embeddings = np.concatenate(embeddings_list)
-        if len(embeddings) == len(list_data):
-            for i, d in enumerate(list_data):
-                # Compress vector using Float16 + zlib + Base64 for storage optimization
-                vector_f16 = embeddings[i].astype(np.float16)
-                compressed_vector = zlib.compress(vector_f16.tobytes())
-                encoded_vector = base64.b64encode(compressed_vector).decode("utf-8")
-                d["vector"] = encoded_vector
-                d["__vector__"] = embeddings[i]
-            client = await self._get_client()
-            results = client.upsert(datas=list_data)
-            return results
-        else:
-            # sometimes the embedding is not returned correctly. just log it.
-            logger.error(
-                f"[{self.workspace}] embedding is not 1-1 with data, {len(embeddings)} != {len(list_data)}"
+        if to_embed:
+            contents = [pdoc.record["content"] for _, pdoc in to_embed]
+            batches = [
+                contents[i : i + self._max_batch_size]
+                for i in range(0, len(contents), self._max_batch_size)
+            ]
+            embeddings_list = await asyncio.gather(
+                *[
+                    self.embedding_func(batch, context="document")
+                    for batch in batches
+                ]
             )
+            embeddings = np.concatenate(embeddings_list)
+            if len(embeddings) != len(to_embed):
+                # Explicit raise (not a log): a mismatch would mis-pair vectors
+                # with records. Keep pending intact so the next flush retries.
+                raise RuntimeError(
+                    f"[{self.workspace}] embedding is not 1-1 with pending data, "
+                    f"{len(embeddings)} != {len(to_embed)}"
+                )
+            for (_, pdoc), embedding in zip(to_embed, embeddings):
+                pdoc.vector = embedding
+
+        list_data = []
+        for _, pdoc in pending_items:
+            vector = pdoc.vector
+            # Compress vector using Float16 + zlib + Base64 for storage optimization
+            vector_f16 = vector.astype(np.float16)
+            compressed_vector = zlib.compress(vector_f16.tobytes())
+            encoded_vector = base64.b64encode(compressed_vector).decode("utf-8")
+            record = pdoc.record
+            record["vector"] = encoded_vector
+            record["__vector__"] = vector
+            list_data.append(record)
+
+        self._client.upsert(datas=list_data)
+
+        # Clear only the entries we just flushed (an upsert that arrived after
+        # the snapshot would have re-set vector=None and must not be dropped).
+        for doc_id, pdoc in pending_items:
+            if self._pending_upserts.get(doc_id) is pdoc:
+                del self._pending_upserts[doc_id]
+
+    def _save_to_disk_locked(self) -> None:
+        """Atomically persist ``self._client`` and notify other processes.
+
+        Precondition: the caller must already hold ``_storage_lock``. Factored
+        out of ``index_done_callback`` so ``finalize`` reuses the exact same
+        save+notify sequence. ``NanoVectorDB.save()`` always writes to whatever
+        path is on the instance, so we temporarily redirect ``storage_file`` to
+        the per-writer tmp and let ``atomic_write`` own the rename; the original
+        path is restored on every path (success and exception).
+        """
+
+        def _save_atomic(tmp: str) -> None:
+            original = self._client.storage_file
+            self._client.storage_file = tmp
+            try:
+                self._client.save()
+            finally:
+                self._client.storage_file = original
+
+        atomic_write(self._client_file_name, _save_atomic, self.workspace or "_")
 
     async def query(
         self, query: str, top_k: int, query_embedding: list[float] = None
     ) -> list[dict[str, Any]]:
+        """Similarity search over data already materialized into ``self._client``.
+
+        Buffered (unflushed) upserts are **not** searchable — only rows that a
+        prior ``index_done_callback`` / ``finalize`` flushed are considered.
+        Use the read-your-writes paths (``get_by_id`` / ``get_by_ids`` /
+        ``get_vectors_by_ids``) to observe pending data before a flush.
+        """
         # Use provided embedding or compute it
         if query_embedding is not None:
             embedding = query_embedding
@@ -313,15 +440,21 @@ class NanoVectorDBStorage(BaseVectorStorage):
             ids: List of vector IDs to be deleted
         """
         try:
-            client = await self._get_client()
-            # Record count before deletion
-            before_count = len(client)
+            # Hold the lock so the pending-cancel and the client delete are a
+            # single critical section against a concurrent flush. Operate on
+            # self._client directly (the lock is non-reentrant; no _get_client).
+            async with self._storage_lock:
+                for doc_id in ids:
+                    self._pending_upserts.pop(doc_id, None)
 
-            client.delete(ids)
+                # Record count before deletion
+                before_count = len(self._client)
 
-            # Calculate actual deleted count
-            after_count = len(client)
-            deleted_count = before_count - after_count
+                self._client.delete(ids)
+
+                # Calculate actual deleted count
+                after_count = len(self._client)
+                deleted_count = before_count - after_count
 
             logger.debug(
                 f"[{self.workspace}] Successfully deleted {deleted_count} vectors from {self.namespace}"
@@ -350,10 +483,17 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 f"[{self.workspace}] Attempting to delete entity {entity_name} with ID {entity_id}"
             )
 
-            # Check if the entity exists
-            client = await self._get_client()
-            if client.get([entity_id]):
-                client.delete([entity_id])
+            async with self._storage_lock:
+                # Cancel a buffered upsert for this entity, then delete from the
+                # materialized client (lock non-reentrant; no _get_client).
+                pending_cancelled = self._pending_upserts.pop(entity_id, None) is not None
+                if self._client.get([entity_id]):
+                    self._client.delete([entity_id])
+                    deleted = True
+                else:
+                    deleted = False
+
+            if deleted or pending_cancelled:
                 logger.debug(
                     f"[{self.workspace}] Successfully deleted entity {entity_name}"
                 )
@@ -378,23 +518,32 @@ class NanoVectorDBStorage(BaseVectorStorage):
         """
 
         try:
-            client = await self._get_client()
-            storage = getattr(client, "_NanoVectorDB__storage")
-            relations = [
-                dp
-                for dp in storage["data"]
-                if dp["src_id"] == entity_name or dp["tgt_id"] == entity_name
-            ]
-            logger.debug(
-                f"[{self.workspace}] Found {len(relations)} relations for entity {entity_name}"
-            )
-            ids_to_delete = [relation["__id__"] for relation in relations]
+            async with self._storage_lock:
+                # Prune matching buffered upserts (their records carry src_id /
+                # tgt_id from the relationships vdb meta_fields)...
+                pending_ids = [
+                    doc_id
+                    for doc_id, pdoc in self._pending_upserts.items()
+                    if pdoc.record.get("src_id") == entity_name
+                    or pdoc.record.get("tgt_id") == entity_name
+                ]
+                for doc_id in pending_ids:
+                    del self._pending_upserts[doc_id]
 
-            if ids_to_delete:
-                client = await self._get_client()
-                client.delete(ids_to_delete)
+                # ...then scan the materialized client and delete matches.
+                storage = getattr(self._client, "_NanoVectorDB__storage")
+                ids_to_delete = [
+                    dp["__id__"]
+                    for dp in storage["data"]
+                    if dp["src_id"] == entity_name or dp["tgt_id"] == entity_name
+                ]
+                if ids_to_delete:
+                    self._client.delete(ids_to_delete)
+
+            total = len(pending_ids) + len(ids_to_delete)
+            if total:
                 logger.debug(
-                    f"[{self.workspace}] Deleted {len(ids_to_delete)} relations for {entity_name}"
+                    f"[{self.workspace}] Deleted {total} relations for {entity_name}"
                 )
             else:
                 logger.debug(
@@ -406,17 +555,22 @@ class NanoVectorDBStorage(BaseVectorStorage):
             )
 
     async def index_done_callback(self) -> bool:
-        """Commit in-memory state to disk and notify other processes.
+        """Flush deferred embeddings, commit to disk, and notify other processes.
 
         This is the writer's **commit point** in the cross-process sync
-        protocol (see class docstring). Two effects, in order:
-            1. ``atomic_write`` lays a tmp file beside the target and
-               renames it into place — readers either see the previous
-               file in full or the new file in full, never a torn write.
-            2. ``set_all_update_flags`` flips every registered process's
-               ``storage_updated`` flag, then we immediately reset our
-               own flag to ``False`` so the writer does not self-reload
-               on the next call to ``_get_client``.
+        protocol (see class docstring). Effects, in order:
+            1. ``_flush_pending_locked`` embeds every buffered upsert (once
+               per id) and materializes it into ``self._client``. A failure
+               here **raises** — pending is kept, nothing is written — so the
+               loss surfaces through ``_insert_done`` instead of being silent.
+            2. ``_save_to_disk_locked`` (``atomic_write``) lays a tmp file
+               beside the target and renames it into place — readers either
+               see the previous file in full or the new file in full, never a
+               torn write.
+            3. ``set_all_update_flags`` flips every registered process's
+               ``storage_updated`` flag, then we immediately reset our own
+               flag to ``False`` so the writer does not self-reload on the
+               next call to ``_get_client``.
 
         Two-block structure (intentional, do not collapse):
             * **First ``async with``** — early-return path for a
@@ -427,15 +581,9 @@ class NanoVectorDBStorage(BaseVectorStorage):
               It is kept as defensive scaffolding for any future relaxation
               of the single-writer invariant; removing it would silently
               re-enable lost-write bugs the moment a second writer is
-              introduced.
-            * **Second ``async with``** — the actual save + notify.
-
-        ``_save_atomic`` temporarily reassigns ``self._client.storage_file``
-        to the tmp path so ``NanoVectorDB.save()`` (which always writes to
-        whatever path is on the instance) lands in the right place. This
-        is safe because (a) no other ``NanoVectorDB`` method reads
-        ``storage_file`` and (b) the reassignment is bracketed by
-        try/finally and held under ``_storage_lock``.
+              introduced. The pending buffer is left intact here so the next
+              callback retries the flush.
+            * **Second ``async with``** — flush + save + notify.
         """
         async with self._storage_lock:
             # Check if storage was updated by another process
@@ -452,26 +600,14 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 self.storage_updated.value = False
                 return False  # Return error
 
-        # Acquire lock and perform persistence
+        # Acquire lock and perform flush + persistence
         async with self._storage_lock:
+            # Flush deferred embeddings first. On embedding error / count
+            # mismatch this raises, leaving pending intact and skipping the
+            # disk write (no silent data loss); the exception propagates.
+            await self._flush_pending_locked()
             try:
-                # Save data to disk atomically. NanoVectorDB.save() always
-                # writes to whatever path is in `self._client.storage_file`,
-                # so we temporarily redirect it to the per-writer tmp and let
-                # atomic_write own the rename. The original path is restored
-                # on every path (success and exception) so subsequent reads
-                # against the client continue to point at the real file.
-                def _save_atomic(tmp: str) -> None:
-                    original = self._client.storage_file
-                    self._client.storage_file = tmp
-                    try:
-                        self._client.save()
-                    finally:
-                        self._client.storage_file = original
-
-                atomic_write(
-                    self._client_file_name, _save_atomic, self.workspace or "_"
-                )
+                self._save_to_disk_locked()
                 # Notify other processes that data has been updated
                 await set_all_update_flags(self.namespace, workspace=self.workspace)
                 # Reset own update flag to avoid self-reloading
@@ -485,8 +621,17 @@ class NanoVectorDBStorage(BaseVectorStorage):
 
         return True  # Return success
 
+    @staticmethod
+    def _format_record(dp: dict[str, Any]) -> dict[str, Any]:
+        """Shape a stored/pending record into the public read result."""
+        return {
+            **{k: v for k, v in dp.items() if k not in ("vector", "__vector__")},
+            "id": dp.get("__id__"),
+            "created_at": dp.get("__created_at__"),
+        }
+
     async def get_by_id(self, id: str) -> dict[str, Any] | None:
-        """Get vector data by its ID
+        """Get vector data by its ID (read-your-writes against the pending buffer).
 
         Args:
             id: The unique identifier of the vector
@@ -494,19 +639,20 @@ class NanoVectorDBStorage(BaseVectorStorage):
         Returns:
             The vector data if found, or None if not found
         """
+        # Read-your-writes: a buffered upsert is visible before its flush.
+        async with self._storage_lock:
+            pending = self._pending_upserts.get(id)
+            if pending is not None:
+                return self._format_record(pending.record)
+
         client = await self._get_client()
         result = client.get([id])
         if result:
-            dp = result[0]
-            return {
-                **{k: v for k, v in dp.items() if k != "vector"},
-                "id": dp.get("__id__"),
-                "created_at": dp.get("__created_at__"),
-            }
+            return self._format_record(result[0])
         return None
 
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
-        """Get multiple vector data by their IDs
+        """Get multiple vector data by their IDs (read-your-writes), preserving order.
 
         Args:
             ids: List of unique identifiers
@@ -517,30 +663,36 @@ class NanoVectorDBStorage(BaseVectorStorage):
         if not ids:
             return []
 
-        client = await self._get_client()
-        results = client.get(ids)
+        # Read-your-writes: serve buffered upserts from the pending area and
+        # only query the materialized client for the remaining ids.
         result_map: dict[str, dict[str, Any]] = {}
+        remaining: list[str] = []
+        async with self._storage_lock:
+            for requested_id in ids:
+                pending = self._pending_upserts.get(requested_id)
+                if pending is not None:
+                    result_map[str(requested_id)] = self._format_record(pending.record)
+                else:
+                    remaining.append(requested_id)
 
-        for dp in results:
-            if not dp:
-                continue
-            record = {
-                **{k: v for k, v in dp.items() if k != "vector"},
-                "id": dp.get("__id__"),
-                "created_at": dp.get("__created_at__"),
-            }
-            key = record.get("id")
-            if key is not None:
-                result_map[str(key)] = record
+        if remaining:
+            client = await self._get_client()
+            for dp in client.get(remaining):
+                if not dp:
+                    continue
+                record = self._format_record(dp)
+                key = record.get("id")
+                if key is not None:
+                    result_map[str(key)] = record
 
-        ordered_results: list[dict[str, Any] | None] = []
-        for requested_id in ids:
-            ordered_results.append(result_map.get(str(requested_id)))
-
-        return ordered_results
+        return [result_map.get(str(requested_id)) for requested_id in ids]
 
     async def get_vectors_by_ids(self, ids: list[str]) -> dict[str, list[float]]:
-        """Get vectors by their IDs, returning only ID and vector data for efficiency
+        """Get vectors by their IDs (read-your-writes), returning only ID and vector.
+
+        For buffered upserts the vector is computed lazily (and cached back onto
+        the pending doc so the next flush reuses it instead of re-embedding);
+        for materialized rows the stored compressed vector is decoded.
 
         Args:
             ids: List of unique identifiers
@@ -552,18 +704,54 @@ class NanoVectorDBStorage(BaseVectorStorage):
         if not ids:
             return {}
 
-        client = await self._get_client()
-        results = client.get(ids)
+        vectors_dict: dict[str, list[float]] = {}
+        remaining: list[str] = []
+        async with self._storage_lock:
+            to_embed: list[tuple[str, _PendingNanoDoc]] = []
+            for requested_id in ids:
+                pending = self._pending_upserts.get(requested_id)
+                if pending is None:
+                    remaining.append(requested_id)
+                elif pending.vector is not None:
+                    vectors_dict[requested_id] = pending.vector.astype(
+                        np.float32
+                    ).tolist()
+                else:
+                    to_embed.append((requested_id, pending))
 
-        vectors_dict = {}
-        for result in results:
-            if result and "vector" in result and "__id__" in result:
-                # Decompress vector data (Base64 + zlib + Float16 compressed)
-                decoded = base64.b64decode(result["vector"])
-                decompressed = zlib.decompress(decoded)
-                vector_f16 = np.frombuffer(decompressed, dtype=np.float16)
-                vector_f32 = vector_f16.astype(np.float32).tolist()
-                vectors_dict[result["__id__"]] = vector_f32
+            if to_embed:
+                contents = [pdoc.record["content"] for _, pdoc in to_embed]
+                batches = [
+                    contents[i : i + self._max_batch_size]
+                    for i in range(0, len(contents), self._max_batch_size)
+                ]
+                embeddings_list = await asyncio.gather(
+                    *[
+                        self.embedding_func(batch, context="document")
+                        for batch in batches
+                    ]
+                )
+                embeddings = np.concatenate(embeddings_list)
+                if len(embeddings) != len(to_embed):
+                    raise RuntimeError(
+                        f"[{self.workspace}] embedding is not 1-1 with pending data, "
+                        f"{len(embeddings)} != {len(to_embed)}"
+                    )
+                for (requested_id, pdoc), embedding in zip(to_embed, embeddings):
+                    # Cache the vector back so the next flush reuses it.
+                    pdoc.vector = embedding
+                    vectors_dict[requested_id] = embedding.astype(np.float32).tolist()
+
+        if remaining:
+            client = await self._get_client()
+            for result in client.get(remaining):
+                if result and "vector" in result and "__id__" in result:
+                    # Decompress vector data (Base64 + zlib + Float16 compressed)
+                    decoded = base64.b64decode(result["vector"])
+                    decompressed = zlib.decompress(decoded)
+                    vector_f16 = np.frombuffer(decompressed, dtype=np.float16)
+                    vector_f32 = vector_f16.astype(np.float32).tolist()
+                    vectors_dict[result["__id__"]] = vector_f32
 
         return vectors_dict
 
@@ -592,6 +780,9 @@ class NanoVectorDBStorage(BaseVectorStorage):
         """
         try:
             async with self._storage_lock:
+                # Discard buffered (unflushed) upserts along with the data.
+                self._pending_upserts.clear()
+
                 # delete _client_file_name
                 if os.path.exists(self._client_file_name):
                     os.remove(self._client_file_name)
@@ -613,3 +804,27 @@ class NanoVectorDBStorage(BaseVectorStorage):
         except Exception as e:
             logger.error(f"[{self.workspace}] Error dropping {self.namespace}: {e}")
             return {"status": "error", "message": str(e)}
+
+    async def finalize(self):
+        """Flush any buffered upserts and persist before shutdown (safety net).
+
+        Normally ``index_done_callback`` has already drained the pending buffer,
+        but a flow that upserts without a trailing callback would otherwise lose
+        those vectors silently. Flush + save here, and if anything remains
+        buffered afterward raise ``RuntimeError`` naming the count so the loss is
+        recorded (``finalize_storages`` logs it as an error).
+        """
+        async with self._storage_lock:
+            if not self._pending_upserts:
+                return
+            await self._flush_pending_locked()
+            self._save_to_disk_locked()
+            await set_all_update_flags(self.namespace, workspace=self.workspace)
+            self.storage_updated.value = False
+            leftover = len(self._pending_upserts)
+
+        if leftover:
+            raise RuntimeError(
+                f"[{self.workspace}] NanoVectorDBStorage.finalize() left {leftover} "
+                f"pending upserts buffered after the final flush for {self.namespace}"
+            )

--- a/tests/kg/nano_impl/test_nano_deferred_embedding.py
+++ b/tests/kg/nano_impl/test_nano_deferred_embedding.py
@@ -334,6 +334,9 @@ async def test_flush_embedding_failure_raises_and_keeps_pending(tmp_path):
 
     assert "id1" in storage._pending_upserts, "pending preserved for retry"
     assert len(storage._client) == 0, "nothing materialized on embed failure"
+    # Embed failure happens before self._client.upsert in _flush_pending_locked,
+    # so _client_dirty must NOT be set. (A save-stage failure would leave it True
+    # — see test_finalize_retries_save_after_flush_failure.)
     assert storage._client_dirty is False
 
 

--- a/tests/kg/nano_impl/test_nano_deferred_embedding.py
+++ b/tests/kg/nano_impl/test_nano_deferred_embedding.py
@@ -266,3 +266,41 @@ async def test_finalize_flushes_pending(tmp_path):
     assert embed.call_count == 1
     assert storage._pending_upserts == {}
     assert len(storage._client) == 1
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_finalize_retries_save_after_flush_failure(tmp_path):
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "alpha"}})
+
+    original_save = storage._save_to_disk_locked
+    save_calls = 0
+
+    def fail_once():
+        nonlocal save_calls
+        save_calls += 1
+        if save_calls == 1:
+            raise OSError("boom")
+        original_save()
+
+    storage._save_to_disk_locked = fail_once
+
+    with pytest.raises(OSError, match="boom"):
+        await storage.finalize()
+
+    assert storage._pending_upserts == {}
+    assert storage._client_dirty is True
+
+    await storage.finalize()
+
+    assert save_calls == 2
+    assert storage._client_dirty is False
+
+    reader = _make_storage(tmp_path, embed)
+    await reader.initialize()
+    hit = await reader.get_by_id("id1")
+    assert hit is not None and hit["id"] == "id1"

--- a/tests/kg/nano_impl/test_nano_deferred_embedding.py
+++ b/tests/kg/nano_impl/test_nano_deferred_embedding.py
@@ -210,6 +210,29 @@ async def test_delete_reloads_stale_client_before_mutating(tmp_path):
 
 @pytest.mark.offline
 @pytest.mark.asyncio
+async def test_finalize_reloads_stale_client_before_flushing(tmp_path):
+    embed = _CountingEmbed()
+    writer = _make_storage(tmp_path, embed)
+    stale_finalizer = _make_storage(tmp_path, embed)
+    await writer.initialize()
+    await stale_finalizer.initialize()
+
+    await writer.upsert({"id1": {"content": "alpha"}})
+    assert await writer.index_done_callback() is True
+    assert stale_finalizer.storage_updated.value is True
+
+    await stale_finalizer.upsert({"id2": {"content": "beta"}})
+    await stale_finalizer.finalize()
+
+    reader = _make_storage(tmp_path, embed)
+    await reader.initialize()
+    rows = await reader.get_by_ids(["id1", "id2"])
+    assert [row["id"] for row in rows] == ["id1", "id2"]
+    assert stale_finalizer._pending_upserts == {}
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
 async def test_read_your_writes_and_query_after_flush(tmp_path):
     embed = _CountingEmbed()
     storage = _make_storage(tmp_path, embed)

--- a/tests/kg/nano_impl/test_nano_deferred_embedding.py
+++ b/tests/kg/nano_impl/test_nano_deferred_embedding.py
@@ -1,0 +1,199 @@
+"""Deferred-embedding coverage for ``NanoVectorDBStorage``.
+
+The storage no longer embeds eagerly in ``upsert``: it buffers a pending doc
+and embeds once per id at flush time (``index_done_callback`` / ``finalize``).
+These tests pin that contract using a counting mock embedding function — no
+live model or network. They mirror the protocol proven for
+``OpenSearchVectorDBStorage`` (issue #2785).
+"""
+
+import numpy as np
+import pytest
+
+nano_vectordb = pytest.importorskip("nano_vectordb")  # noqa: F841
+
+from lightrag.kg.nano_vector_db_impl import NanoVectorDBStorage  # noqa: E402
+from lightrag.kg.shared_storage import (  # noqa: E402
+    initialize_share_data,
+    finalize_share_data,
+)
+from lightrag.utils import EmbeddingFunc  # noqa: E402
+
+DIM = 8
+
+
+@pytest.fixture(autouse=True)
+def _shared_data():
+    finalize_share_data()
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
+class _CountingEmbed:
+    """Async embedding callable that records how many texts it embedded and how
+    many times it was invoked (one invocation == one batch)."""
+
+    def __init__(self, dim: int = DIM):
+        self.dim = dim
+        self.call_count = 0
+        self.embedded_texts: list[str] = []
+
+    async def __call__(self, texts, **kwargs):
+        self.call_count += 1
+        self.embedded_texts.extend(texts)
+        # Deterministic per-text vector so duplicates are still 1-1.
+        return np.array(
+            [np.full(self.dim, (abs(hash(t)) % 97) + 1, dtype=np.float32) for t in texts]
+        )
+
+
+def _make_storage(tmp_path, embed: _CountingEmbed) -> NanoVectorDBStorage:
+    return NanoVectorDBStorage(
+        namespace="test_vectors",
+        workspace="ws",
+        global_config={
+            "working_dir": str(tmp_path),
+            "embedding_batch_num": 32,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+        },
+        embedding_func=EmbeddingFunc(
+            embedding_dim=DIM, max_token_size=512, func=embed
+        ),
+        meta_fields={"content"},
+    )
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_upsert_defers_embedding_to_index_done_callback(tmp_path):
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert(
+        {
+            "id1": {"content": "alpha"},
+            "id2": {"content": "beta"},
+        }
+    )
+    assert embed.call_count == 0, "upsert must not embed"
+    assert len(storage._client) == 0, "nothing should be materialized yet"
+
+    await storage.index_done_callback()
+    assert embed.call_count == 1, "flush should embed in a single batch"
+    assert sorted(embed.embedded_texts) == ["alpha", "beta"]
+    assert len(storage._client) == 2
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_repeated_upserts_same_id_embed_once_per_flush(tmp_path):
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "v1"}})
+    await storage.upsert({"id1": {"content": "v2"}})
+    await storage.upsert({"id1": {"content": "v3"}})
+
+    await storage.index_done_callback()
+
+    assert embed.call_count == 1
+    assert embed.embedded_texts == ["v3"], "only the latest content is embedded"
+    assert len(storage._client) == 1
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_get_vectors_caches_and_flush_reuses(tmp_path):
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "alpha"}})
+
+    vecs = await storage.get_vectors_by_ids(["id1"])
+    assert "id1" in vecs and len(vecs["id1"]) == DIM
+    assert embed.call_count == 1, "get_vectors_by_ids embeds pending lazily"
+
+    # Flush must reuse the cached vector, not re-embed.
+    await storage.index_done_callback()
+    assert embed.call_count == 1, "flush should reuse the cached temp vector"
+    assert len(storage._client) == 1
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_reupsert_after_get_vectors_clears_cached_vector(tmp_path):
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "old"}})
+    await storage.get_vectors_by_ids(["id1"])  # caches a temp vector for "old"
+    assert embed.call_count == 1
+
+    # New content version must clear the cached vector and re-embed at flush.
+    await storage.upsert({"id1": {"content": "new"}})
+    await storage.index_done_callback()
+
+    assert embed.call_count == 2
+    assert embed.embedded_texts == ["old", "new"]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_delete_cancels_pending_and_removes_materialized(tmp_path):
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    # Materialize id1; leave id2 only as a pending (unflushed) upsert.
+    await storage.upsert({"id1": {"content": "alpha"}})
+    await storage.index_done_callback()
+    await storage.upsert({"id2": {"content": "beta"}})
+
+    await storage.delete(["id1", "id2"])
+
+    assert "id2" not in storage._pending_upserts, "delete cancels pending upsert"
+    assert len(storage._client) == 0, "delete removes the materialized row immediately"
+    assert await storage.get_by_id("id1") is None
+    assert await storage.get_by_id("id2") is None
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_read_your_writes_and_query_after_flush(tmp_path):
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "alpha"}})
+
+    # Before flush: read paths see the pending row, query does not.
+    hit = await storage.get_by_id("id1")
+    assert hit is not None and hit["id"] == "id1" and hit["content"] == "alpha"
+    by_ids = await storage.get_by_ids(["id1", "missing"])
+    assert by_ids[0]["id"] == "id1" and by_ids[1] is None
+    assert await storage.query("alpha", top_k=5) == [], "query ignores unflushed data"
+
+    # After flush: query returns the row.
+    await storage.index_done_callback()
+    results = await storage.query("alpha", top_k=5)
+    assert any(r["id"] == "id1" for r in results)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_finalize_flushes_pending(tmp_path):
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "alpha"}})
+    await storage.finalize()
+
+    assert embed.call_count == 1
+    assert storage._pending_upserts == {}
+    assert len(storage._client) == 1

--- a/tests/kg/nano_impl/test_nano_deferred_embedding.py
+++ b/tests/kg/nano_impl/test_nano_deferred_embedding.py
@@ -270,6 +270,93 @@ async def test_finalize_flushes_pending(tmp_path):
 
 @pytest.mark.offline
 @pytest.mark.asyncio
+async def test_delete_entity_relation_cancels_pending(tmp_path):
+    embed = _CountingEmbed()
+    storage = NanoVectorDBStorage(
+        namespace="test_relations",
+        workspace="ws",
+        global_config={
+            "working_dir": str(tmp_path),
+            "embedding_batch_num": 32,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+        },
+        embedding_func=EmbeddingFunc(embedding_dim=DIM, max_token_size=512, func=embed),
+        meta_fields={"content", "src_id", "tgt_id"},
+    )
+    await storage.initialize()
+
+    # Materialize r1 (A->B), leave r2 (A->C) and r3 (X->Y) as pending.
+    await storage.upsert({"r1": {"content": "rel1", "src_id": "A", "tgt_id": "B"}})
+    await storage.index_done_callback()
+    await storage.upsert(
+        {
+            "r2": {"content": "rel2", "src_id": "A", "tgt_id": "C"},
+            "r3": {"content": "rel3", "src_id": "X", "tgt_id": "Y"},
+        }
+    )
+
+    await storage.delete_entity_relation("A")
+
+    assert "r2" not in storage._pending_upserts, "incident pending entry cancelled"
+    assert "r3" in storage._pending_upserts, "unrelated pending entry preserved"
+    assert len(storage._client) == 0, "materialized A->B removed"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_flush_embedding_failure_raises_and_keeps_pending(tmp_path):
+    class _FailingEmbed:
+        def __init__(self):
+            self.call_count = 0
+
+        async def __call__(self, texts, **kwargs):
+            self.call_count += 1
+            raise RuntimeError("embed boom")
+
+    embed = _FailingEmbed()
+    storage = NanoVectorDBStorage(
+        namespace="test_vectors",
+        workspace="ws",
+        global_config={
+            "working_dir": str(tmp_path),
+            "embedding_batch_num": 32,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+        },
+        embedding_func=EmbeddingFunc(embedding_dim=DIM, max_token_size=512, func=embed),
+        meta_fields={"content"},
+    )
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "alpha"}})
+
+    with pytest.raises(RuntimeError, match="embed boom"):
+        await storage.index_done_callback()
+
+    assert "id1" in storage._pending_upserts, "pending preserved for retry"
+    assert len(storage._client) == 0, "nothing materialized on embed failure"
+    assert storage._client_dirty is False
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_drop_discards_pending_without_embedding(tmp_path):
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "alpha"}})
+    assert "id1" in storage._pending_upserts
+
+    result = await storage.drop()
+
+    assert result["status"] == "success"
+    assert storage._pending_upserts == {}, "drop discards buffered upserts"
+    assert embed.call_count == 0, "drop must not embed"
+    assert storage._client_dirty is False
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
 async def test_finalize_retries_save_after_flush_failure(tmp_path):
     embed = _CountingEmbed()
     storage = _make_storage(tmp_path, embed)

--- a/tests/kg/nano_impl/test_nano_deferred_embedding.py
+++ b/tests/kg/nano_impl/test_nano_deferred_embedding.py
@@ -44,7 +44,10 @@ class _CountingEmbed:
         self.embedded_texts.extend(texts)
         # Deterministic per-text vector so duplicates are still 1-1.
         return np.array(
-            [np.full(self.dim, (abs(hash(t)) % 97) + 1, dtype=np.float32) for t in texts]
+            [
+                np.full(self.dim, (abs(hash(t)) % 97) + 1, dtype=np.float32)
+                for t in texts
+            ]
         )
 
 
@@ -57,9 +60,7 @@ def _make_storage(tmp_path, embed: _CountingEmbed) -> NanoVectorDBStorage:
             "embedding_batch_num": 32,
             "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
         },
-        embedding_func=EmbeddingFunc(
-            embedding_dim=DIM, max_token_size=512, func=embed
-        ),
+        embedding_func=EmbeddingFunc(embedding_dim=DIM, max_token_size=512, func=embed),
         meta_fields={"content"},
     )
 
@@ -160,6 +161,51 @@ async def test_delete_cancels_pending_and_removes_materialized(tmp_path):
     assert len(storage._client) == 0, "delete removes the materialized row immediately"
     assert await storage.get_by_id("id1") is None
     assert await storage.get_by_id("id2") is None
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_stale_client_reload_still_flushes_pending_upsert(tmp_path):
+    embed = _CountingEmbed()
+    writer = _make_storage(tmp_path, embed)
+    stale_writer = _make_storage(tmp_path, embed)
+    await writer.initialize()
+    await stale_writer.initialize()
+
+    await writer.upsert({"id1": {"content": "alpha"}})
+    assert await writer.index_done_callback() is True
+    assert stale_writer.storage_updated.value is True
+
+    await stale_writer.upsert({"id2": {"content": "beta"}})
+    assert await stale_writer.index_done_callback() is True
+
+    reader = _make_storage(tmp_path, embed)
+    await reader.initialize()
+    rows = await reader.get_by_ids(["id1", "id2"])
+    assert [row["id"] for row in rows] == ["id1", "id2"]
+    assert stale_writer._pending_upserts == {}
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_delete_reloads_stale_client_before_mutating(tmp_path):
+    embed = _CountingEmbed()
+    writer = _make_storage(tmp_path, embed)
+    stale_deleter = _make_storage(tmp_path, embed)
+    await writer.initialize()
+    await stale_deleter.initialize()
+
+    await writer.upsert({"id1": {"content": "alpha"}})
+    assert await writer.index_done_callback() is True
+    assert stale_deleter.storage_updated.value is True
+
+    await stale_deleter.delete(["id1"])
+    assert stale_deleter.storage_updated.value is False
+    assert await stale_deleter.index_done_callback() is True
+
+    reader = _make_storage(tmp_path, embed)
+    await reader.initialize()
+    assert await reader.get_by_id("id1") is None
 
 
 @pytest.mark.offline


### PR DESCRIPTION
## Summary

`NanoVectorDBStorage.upsert()` embedded **eagerly** on every call, so repeated upserts of the same id — and many small upsert calls — re-triggered the embedding model. This applies the deferred-embedding pattern already proven for `OpenSearchVectorDBStorage` to the Nano backend: buffer upserts and embed **once per id at flush time**.

Closes the Nano-backend case of the repeated-embedding problem in #2785.

## Motivation

- Same as #2785: per-call embedding wastes model calls when the same id is upserted multiple times or content arrives in many small batches.
- `OpenSearchVectorDBStorage` already solved this (deferred buffer + lock-held flush). NanoVectorDB is an in-process memory store, so this PR uses a **minimal** pending area that holds only not-yet-embedded records (it does not duplicate rows already materialized into the client).

## What's changed (`lightrag/kg/nano_vector_db_impl.py`)

- New `_PendingNanoDoc` dataclass and a `self._pending_upserts` buffer.
- `upsert()` now buffers a `_PendingNanoDoc(vector=None)` instead of embedding. Re-upserting an id overwrites the pending doc, clearing any temp vector a prior `get_vectors_by_ids` cached (content-version change → re-embed).
- New `_flush_pending_locked()` (caller must hold the **non-reentrant** `_storage_lock`; operates on `self._client` directly): embeds `vector is None` docs in batches **inside the lock** (consistency, matches OpenSearch), reuses already-set vectors, compresses, and `client.upsert`s. On embedding error / count mismatch it **raises** — pending kept, nothing written.
- `index_done_callback()` flushes before the atomic save; a flush failure propagates (no silent loss). New `finalize()` safety net flushes + persists and raises on leftover pending.
- Read-your-writes: `get_by_id` / `get_by_ids` consult the pending buffer first; `get_vectors_by_ids` lazily embeds pending docs and caches the vector for reuse by the next flush.
- `delete` / `delete_entity` / `delete_entity_relation` / `drop` cancel matching pending entries.

## Behavior notes

- **`query()` sees only flushed (materialized) data** — unflushed pending upserts are intentionally not queryable (use the read-your-writes paths before a flush). This matches OpenSearch.
- A flush failure now **raises** through `_insert_done` instead of silently returning `False` (all callers already ignored the bool return), so lost-vector risk is surfaced loudly.

## Test plan

- [x] New `tests/kg/nano_impl/test_nano_deferred_embedding.py` (offline, counting mock embed): no embed on upsert; embed on `index_done_callback`; same-id coalesced to one embed per flush; `get_vectors_by_ids` lazy-embed + flush reuse; re-upsert clears cached vector; delete cancels pending + removes materialized; read-your-writes + query-after-flush; `finalize` flushes.
- [x] `./scripts/test.sh tests/kg/nano_impl` → 10 passed.
- [x] `ruff check` clean. (Other `tests/kg` failures in this sandbox are environmental: blocked tiktoken download + missing `asyncpg`/`redis` optional drivers — unrelated to this change.)


---
_Generated by [Claude Code](https://claude.ai/code/session_015LhLKBoLBGxXe478UUMAZp)_