### PR TITLE
perf(faiss): defer vector embedding to flush time

### DIFF
--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -21,6 +21,25 @@ from .shared_storage import (
 import faiss  # type: ignore
 
 
+@dataclass
+class _PendingFaissDoc:
+    """A buffered upsert waiting for deferred embedding and materialization.
+
+    ``record`` holds ``__id__`` / ``__created_at__`` plus the ``meta_fields``
+    (which always include ``content`` for the entity/relation/chunk vdbs), so
+    the content needed for deferred embedding lives in the record itself — no
+    separate copy is kept. ``vector`` starts as ``None`` and is filled either
+    during the lock-held flush or by a lazy ``get_vectors_by_ids`` embedding;
+    once set it is always an **already-L2-normalized float32 1D ndarray**, so
+    the next flush can ``vstack`` and ``index.add`` without re-normalizing.
+    ``__vector__`` is materialized into the metadata dict only at flush time,
+    right before ``self._index.add``.
+    """
+
+    record: dict[str, Any]
+    vector: np.ndarray | None = None
+
+
 @final
 @dataclass
 class FaissVectorDBStorage(BaseVectorStorage):
@@ -48,8 +67,13 @@ class FaissVectorDBStorage(BaseVectorStorage):
         **Cross-file atomicity is not guaranteed**: the two ``atomic_write``
         renames in ``_save_faiss_index`` are independent, so a crash
         between them can leave ``.index`` and ``.meta.json`` referring to
-        different snapshots. ``_load_faiss_index`` tolerates this by
-        skipping metadata rows whose ``fid`` exceeds ``self._index.ntotal``.
+        different snapshots. ``_load_faiss_index`` tolerates both
+        directions on load: ``meta > index`` rows are dropped silently;
+        ``index > meta`` (the more dangerous case) is logged as a warning
+        but **not** auto-repaired — orphan vectors remain in the loaded
+        index but are unreachable via custom-id lookups. Repair semantics
+        (truncate index vs rebuild meta) are deliberately left to a
+        follow-up PR.
 
     Concurrency invariants (the code here is correct *only* while all
     three hold):
@@ -94,29 +118,73 @@ class FaissVectorDBStorage(BaseVectorStorage):
         spanning both intra-process coroutines and inter-process workers.
         It wraps:
             * ``_get_index`` reload checks.
-            * The two critical sections in ``index_done_callback``.
-            * The rebuild inside ``_remove_faiss_ids`` (which mutates
-              ``self._index`` and ``self._id_to_meta`` together).
+            * Pending-buffer mutations in ``upsert`` and pending-buffer
+              reads in ``get_by_id`` / ``get_by_ids`` /
+              ``get_vectors_by_ids`` (read-your-writes).
+            * The single critical section in ``index_done_callback`` and
+              ``finalize`` (reload → flush → save → notify).
+            * The pending-cancel + rebuild critical sections in
+              ``delete`` / ``delete_entity_relation``.
             * The entire ``drop`` body.
-        It does **not** wrap routine ``index.search`` /
-        ``self._id_to_meta`` reads or the ``index.add`` /
-        ``self._id_to_meta.update`` mutations in ``upsert`` — those rely
-        on invariant (3) above. If either premise is broken (e.g.
-        Faiss calls moved to a thread pool), the lock scope must be
-        widened.
+        The lock is **non-reentrant**, so ``_flush_pending_locked`` /
+        ``_remove_faiss_ids_locked`` / ``_save_faiss_index`` /
+        ``_reload_index_from_disk_locked`` all require the caller to
+        already hold it and never re-enter via ``_get_index``. Routine
+        ``index.search`` outside ``_get_index`` and the synchronous
+        ``client_storage`` read rely on invariant (3) above — if either
+        premise is broken (e.g. Faiss calls moved to a thread pool),
+        the lock scope must be widened.
 
-    Caveat — methods that read ``_id_to_meta`` *without* going through
-    ``_get_index``:
-        ``client_storage`` (synchronous property), ``delete``,
-        ``delete_entity_relation``, ``get_by_id``, ``get_by_ids``,
-        ``get_vectors_by_ids``, and ``_find_faiss_id_by_custom_id``
-        directly read ``self._id_to_meta`` without first calling
-        ``_get_index``. In a reader process that has not yet observed a
-        commit (no recent ``_get_index`` call), these can return data
-        from before a writer's most recent ``index_done_callback``. This
-        is consistent with invariant (2) but is a stricter staleness
-        bound than NanoVectorDB's equivalents, which always funnel
-        through ``_get_client`` first.
+    Caveat — synchronous ``client_storage`` reads:
+        ``client_storage`` is a synchronous property and does **not** go
+        through ``_get_index``, so in a reader process it can return data
+        older than the latest committed snapshot until some other method
+        triggers a reload. The async read methods (``get_by_id`` /
+        ``get_by_ids`` / ``get_vectors_by_ids``) now funnel through
+        ``_get_index`` after checking the pending buffer, so they observe
+        the latest on-disk snapshot.
+
+    Deferred-embedding protocol:
+        ``upsert`` does **not** call the embedding model. It only buffers
+        a ``_PendingFaissDoc`` (content-bearing record + ``vector=None``)
+        in the minimal ``self._pending_upserts`` area, overwriting any
+        prior pending doc for the same id (which also clears a temp
+        vector a previous ``get_vectors_by_ids`` may have cached). The
+        model is called once per id at flush time
+        (``_flush_pending_locked``), so repeated upserts of the same id —
+        and many small upsert calls — embed only once. See issue #2785
+        and the ``NanoVectorDBStorage`` / ``OpenSearchVectorDBStorage``
+        equivalents.
+
+        Embedding runs **inside ``_storage_lock``** during the flush (not
+        in ``upsert``): under the single-writer invariant this keeps the
+        content used for embedding consistent with the rows written to
+        disk and prevents a destructive op from interleaving between
+        embed and write. The lock is non-reentrant, so
+        ``_flush_pending_locked`` requires the caller to already hold it
+        and operates on ``self._index`` / ``self._id_to_meta`` directly
+        (never through ``_get_index``).
+
+        Vector storage invariant: once a ``_PendingFaissDoc.vector`` is
+        set it is an **already-L2-normalized float32 1D ndarray** — both
+        flush and lazy ``get_vectors_by_ids`` normalize the entire batch
+        with ``faiss.normalize_L2`` before caching back, so a later flush
+        can ``vstack`` and ``index.add`` without re-normalizing.
+
+        Reads are read-your-writes: ``get_by_id`` / ``get_by_ids`` /
+        ``get_vectors_by_ids`` consult ``_pending_upserts`` first, then
+        funnel through ``_get_index`` for the materialized fallback.
+        ``get_vectors_by_ids`` lazily embeds a pending doc on demand and
+        caches the (normalized) vector back for the next flush.
+        ``query`` and ``client_storage`` see only data already
+        materialized into ``self._index`` / ``self._id_to_meta`` —
+        unflushed pending data is intentionally not queryable.
+
+        A flush failure (embedding error, count mismatch, or save IO
+        error) raises through ``index_done_callback``; the pending buffer
+        is preserved on flush failure, and if only the save failed
+        ``_index_dirty`` stays ``True`` so a subsequent ``finalize``
+        retries the save without re-embedding.
 
     Non-pipeline write paths:
         The pipeline ``busy`` gate serializes ``upsert`` / ``delete`` /
@@ -170,6 +238,17 @@ class FaissVectorDBStorage(BaseVectorStorage):
         # Maps <int faiss_id> → metadata (including your original ID).
         self._id_to_meta = {}
 
+        # Minimal pending area for deferred embedding: custom-id -> _PendingFaissDoc.
+        # Holds only records not yet embedded+materialized into self._index;
+        # it never duplicates rows already added to the Faiss index. Flushed
+        # under _storage_lock by _flush_pending_locked().
+        self._pending_upserts: dict[str, _PendingFaissDoc] = {}
+        # True when self._index / self._id_to_meta have materialized changes
+        # that have not been successfully saved to disk yet. This lets
+        # finalize retry a save even after a previous flush cleared the
+        # pending buffer (see _flush_pending_locked / index_done_callback).
+        self._index_dirty = False
+
         # Sweep orphan tmp siblings left behind by hard kills mid-save.
         # The meta file also needs an extra pattern: legacy versions of this
         # storage wrote a fixed "<meta>.tmp" suffix without further dot-segments,
@@ -194,28 +273,49 @@ class FaissVectorDBStorage(BaseVectorStorage):
             self.namespace, workspace=self.workspace
         )
 
+    def _reload_index_from_disk_locked(self, *, for_write: bool = False) -> bool:
+        """Reload ``self._index`` + ``self._id_to_meta`` if another process committed newer data.
+
+        Precondition: the caller must already hold ``_storage_lock``. This is
+        used by write paths as well as reads because deferred upserts mean a
+        stale writer must merge its pending buffer into the latest on-disk
+        snapshot, not save over it or return without flushing.
+
+        Returns True if a reload happened, False if the local snapshot was
+        already current.
+        """
+        if not self.storage_updated.value:
+            return False
+
+        log_message = (
+            f"[{self.workspace}] Process {os.getpid()} FAISS reloading {self.namespace} "
+            "due to update by another process"
+        )
+        if for_write:
+            logger.warning(log_message)
+        else:
+            logger.info(log_message)
+
+        self._index = faiss.IndexFlatIP(self._dim)
+        self._id_to_meta = {}
+        self._load_faiss_index()
+        self.storage_updated.value = False
+        return True
+
     async def _get_index(self):
         """Return the live Faiss index, reloading from disk if needed.
 
-        This is the entry point through which ``upsert`` and ``query``
-        fetch ``self._index``. When another process has committed (via
-        ``index_done_callback``) and flipped this process's
-        ``storage_updated`` flag, the next call here rebuilds *both*
-        ``self._index`` and ``self._id_to_meta`` by re-reading the
-        ``.index`` + ``.meta.json`` pair from disk. Faiss has no
-        incremental sync API — the reload is unconditionally a full
-        file reload.
+        Read paths (``query`` / ``get_by_id`` / ``get_by_ids`` /
+        ``get_vectors_by_ids``) funnel through this method so that a stale
+        reader picks up any commit made by another process before reading
+        ``self._index`` / ``self._id_to_meta``. Faiss has no incremental
+        sync API — the reload is unconditionally a full reload of both
+        files via ``_reload_index_from_disk_locked``.
 
         Under the *Single writer* invariant (see class docstring), the
         reload branch never fires in the writer process: the writer
         resets its own flag at the end of every ``index_done_callback``.
         The branch exists for readers.
-
-        Note that several methods (``client_storage``, ``delete``,
-        ``delete_entity_relation``, ``get_by_*``) read
-        ``self._id_to_meta`` directly without funnelling through this
-        method — see class docstring *Caveat* for the staleness
-        implications.
 
         ``_storage_lock`` is held during the check-and-reload to (a)
         serialize concurrent reload attempts by sibling coroutines and
@@ -223,20 +323,11 @@ class FaissVectorDBStorage(BaseVectorStorage):
         observe a partially-saved file pair.
         """
         async with self._storage_lock:
-            # Check if storage was updated by another process
-            if self.storage_updated.value:
-                logger.info(
-                    f"[{self.workspace}] Process {os.getpid()} FAISS reloading {self.namespace} due to update by another process"
-                )
-                # Reload data
-                self._index = faiss.IndexFlatIP(self._dim)
-                self._id_to_meta = {}
-                self._load_faiss_index()
-                self.storage_updated.value = False
+            self._reload_index_from_disk_locked()
             return self._index
 
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
-        """Insert or update vectors in the Faiss index; persistence is deferred.
+        """Buffer vectors for deferred embedding; persistence is deferred too.
 
         ``data`` shape::
 
@@ -246,101 +337,58 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 ...
             }
 
+        Embedding is **not** performed here. Each record is buffered in
+        ``self._pending_upserts`` with ``vector=None`` and the embedding
+        model is called once per id at flush time (``_flush_pending_locked``
+        during ``index_done_callback`` / ``finalize``). This coalesces
+        repeated upserts of the same id and many small upsert calls into a
+        single embedding pass (see class docstring,
+        *Deferred-embedding protocol*, and issue #2785).
+
         Persistence:
             Changes live only in this process's memory until the next
             ``index_done_callback``. Cross-process readers will not see
             them until that commit fires (see class docstring,
-            *Cross-process sync protocol*).
-
-        Concurrency:
-            The embedding step runs **outside** ``_storage_lock`` on
-            purpose — it can issue network / GPU calls and we don't want
-            to hold the per-namespace lock for that latency. The
-            existing-id lookup (``_find_faiss_id_by_custom_id``) and
-            the rebuild path (``_remove_faiss_ids``) run *before*
-            ``_get_index`` is called; ``_remove_faiss_ids`` takes the
-            lock itself for its rebuild. The final ``index.add`` and
-            ``self._id_to_meta.update`` mutations are unlocked and rely
-            on the class docstring *Lock scope* invariant (synchronous
-            Faiss ops + single-writer pipeline gate).
+            *Cross-process sync protocol*). Until the flush, an upserted
+            id is observable only through the read-your-writes read paths,
+            not through ``query``.
         """
-        logger.debug(
-            f"[{self.workspace}] FAISS: Inserting {len(data)} to {self.namespace}"
-        )
         if not data:
             return
 
         current_time = int(time.time())
-
-        # Prepare data for embedding
-        list_data = []
-        contents = []
-        for k, v in data.items():
-            # Store only known meta fields if needed
-            meta = {mf: v[mf] for mf in self.meta_fields if mf in v}
-            meta["__id__"] = k
-            meta["__created_at__"] = current_time
-            list_data.append(meta)
-            contents.append(v["content"])
-
-        # Split into batches for embedding if needed
-        batches = [
-            contents[i : i + self._max_batch_size]
-            for i in range(0, len(contents), self._max_batch_size)
-        ]
-
-        embedding_tasks = [
-            self.embedding_func(batch, context="document") for batch in batches
-        ]
-        embeddings_list = await asyncio.gather(*embedding_tasks)
-
-        # Flatten the list of arrays
-        embeddings = np.concatenate(embeddings_list, axis=0)
-        if len(embeddings) != len(list_data):
-            logger.error(
-                f"[{self.workspace}] Embedding size mismatch. Embeddings: {len(embeddings)}, Data: {len(list_data)}"
+        pending = [
+            (
+                k,
+                {
+                    "__id__": k,
+                    "__created_at__": current_time,
+                    **{mf: v[mf] for mf in self.meta_fields if mf in v},
+                },
             )
-            return []
+            for k, v in data.items()
+        ]
 
-        # Convert to float32 and normalize embeddings for cosine similarity (in-place)
-        embeddings = embeddings.astype(np.float32)
-        faiss.normalize_L2(embeddings)
-
-        # Upsert logic:
-        # 1. Identify which vectors to remove if they exist
-        # 2. Remove them
-        # 3. Add the new vectors
-        existing_ids_to_remove = []
-        for meta, emb in zip(list_data, embeddings):
-            faiss_internal_id = self._find_faiss_id_by_custom_id(meta["__id__"])
-            if faiss_internal_id is not None:
-                existing_ids_to_remove.append(faiss_internal_id)
-
-        if existing_ids_to_remove:
-            await self._remove_faiss_ids(existing_ids_to_remove)
-
-        # Step 2: Add new vectors
-        index = await self._get_index()
-        start_idx = index.ntotal
-        index.add(embeddings)
-
-        # Step 3: Store metadata + vector for each new ID
-        for i, meta in enumerate(list_data):
-            fid = start_idx + i
-            # Store the raw vector so we can rebuild if something is removed
-            meta["__vector__"] = embeddings[i].tolist()
-            self._id_to_meta.update({fid: meta})
-
-        logger.debug(
-            f"[{self.workspace}] Upserted {len(list_data)} vectors into Faiss index."
-        )
-        return [m["__id__"] for m in list_data]
+        # Buffer under the lock to interlock with the lock-held flush. A new
+        # _PendingFaissDoc(vector=None) overwrites any prior pending doc for
+        # the same id, discarding a temp vector a previous get_vectors_by_ids
+        # may have cached (content-version change -> must re-embed new content).
+        async with self._storage_lock:
+            for doc_id, record in pending:
+                self._pending_upserts[doc_id] = _PendingFaissDoc(record=record)
 
     async def query(
         self, query: str, top_k: int, query_embedding: list[float] = None
     ) -> list[dict[str, Any]]:
-        """
-        Search by a textual query; returns top_k results with their metadata + similarity distance.
+        """Similarity search over data already materialized into ``self._index``.
+
+        Buffered (unflushed) upserts are intentionally **not** searchable —
+        only rows that a prior ``index_done_callback`` / ``finalize``
+        flushed are considered. Use the read-your-writes paths
+        (``get_by_id`` / ``get_by_ids`` / ``get_vectors_by_ids``) to observe
+        pending data before a flush.
+
+        Returns top_k results with their metadata + similarity distance.
         """
         if query_embedding is not None:
             embedding = np.array([query_embedding], dtype=np.float32)
@@ -370,7 +418,16 @@ class FaissVectorDBStorage(BaseVectorStorage):
             if dist < self.cosine_better_than_threshold:
                 continue
 
-            meta = self._id_to_meta.get(idx, {})
+            meta = self._id_to_meta.get(idx)
+            if not meta:
+                # Orphan vector: a row lives at this fid in self._index but
+                # has no metadata in self._id_to_meta. This happens after an
+                # index > meta skew on reload (see _load_faiss_index). The
+                # vector is reachable via faiss search but not via custom id;
+                # surfacing it as {"id": None, ...} would leak a ghost row to
+                # callers, so we silently skip — the skew was already warned
+                # about at load time.
+                continue
             # Filter out __vector__ from query results to avoid returning large vector data
             filtered_meta = {k: v for k, v in meta.items() if k != "__vector__"}
             results.append(
@@ -386,20 +443,25 @@ class FaissVectorDBStorage(BaseVectorStorage):
 
     @property
     def client_storage(self):
-        """Return a snapshot view of the metadata dict for debugging.
+        """Return a snapshot view of the materialized metadata dict for debugging.
+
+        **Buffered (unflushed) upserts are intentionally not visible here**
+        — only rows that a prior ``index_done_callback`` / ``finalize``
+        flushed into ``self._id_to_meta`` are returned. Use the
+        read-your-writes paths (``get_by_id`` / ``get_by_ids`` /
+        ``get_vectors_by_ids``) to observe pending data before a flush.
 
         The outer list is a fresh shallow copy taken at access time, but
         each element is still a **live reference** into
         ``self._id_to_meta``; callers must not mutate them and must not
         retain them across operations that may rebuild the index
-        (``upsert`` / ``delete`` / ``_remove_faiss_ids`` /
-        ``_get_index`` reload), since a rebuild swaps ``self._index``
-        and replaces ``self._id_to_meta`` with a new dict.
+        (``upsert`` flush, ``delete``, ``_remove_faiss_ids_locked``,
+        ``_get_index`` reload), since a rebuild swaps ``self._index`` and
+        replaces ``self._id_to_meta`` with a new dict.
 
         This property is **synchronous and does not call** ``_get_index``,
         so in a reader process it can return data older than the latest
-        committed snapshot until some other method triggers a reload —
-        see class docstring *Caveat*.
+        committed snapshot until some other method triggers a reload.
         """
         return {"data": list(self._id_to_meta.values())}
 
@@ -412,23 +474,33 @@ class FaissVectorDBStorage(BaseVectorStorage):
             is handled by ``_insert_done()`` at the end of the document
             batch. Callers outside the pipeline must persist explicitly.
 
-        Note: the id-resolution step ``_find_faiss_id_by_custom_id`` reads
-        ``self._id_to_meta`` directly without going through
-        ``_get_index``; the actual rebuild happens inside
-        ``_remove_faiss_ids`` under ``_storage_lock``. See class
-        docstring *Caveat*.
-        """
-        logger.debug(
-            f"[{self.workspace}] Deleting {len(ids)} vectors from {self.namespace}"
-        )
-        to_remove = []
-        for cid in ids:
-            fid = self._find_faiss_id_by_custom_id(cid)
-            if fid is not None:
-                to_remove.append(fid)
+        Errors propagate to the caller — Faiss delete is destructive enough
+        that document deletion / status updates must not proceed if the
+        vectors were not actually removed. (This intentionally diverges
+        from Nano, whose delete swallows + logs.)
 
-        if to_remove:
-            await self._remove_faiss_ids(to_remove)
+        Args:
+            ids: List of custom IDs to be deleted.
+        """
+        # Hold the lock so the pending-cancel and the rebuild are a single
+        # critical section against a concurrent flush. Operate on
+        # self._index / self._id_to_meta directly (the lock is
+        # non-reentrant; no _get_index).
+        async with self._storage_lock:
+            self._reload_index_from_disk_locked(for_write=True)
+
+            for doc_id in ids:
+                self._pending_upserts.pop(doc_id, None)
+
+            # Use the find-all variant so legacy/corrupt stores with
+            # duplicate __id__ rows still get fully cleaned.
+            to_remove: list[int] = []
+            for cid in ids:
+                to_remove.extend(self._find_faiss_ids_by_custom_id(cid))
+            if to_remove:
+                self._remove_faiss_ids_locked(to_remove)
+                self._index_dirty = True
+
         logger.debug(
             f"[{self.workspace}] Successfully deleted {len(to_remove)} vectors from {self.namespace}"
         )
@@ -457,39 +529,56 @@ class FaissVectorDBStorage(BaseVectorStorage):
     async def delete_entity_relation(self, entity_name: str) -> None:
         """Delete every relation vector incident to ``entity_name``.
 
-        Scans ``self._id_to_meta`` for entries whose ``src_id`` or
-        ``tgt_id`` matches and rebuilds the index via
-        ``_remove_faiss_ids``.
+        Scans both ``self._pending_upserts`` (so buffered relation upserts
+        get cancelled) and ``self._id_to_meta`` (the materialized rows) for
+        entries whose ``src_id`` or ``tgt_id`` matches, then rebuilds the
+        index without them.
 
         Persistence:
             Changes are in-memory only; cross-process visibility requires
             a subsequent ``index_done_callback``. Callers outside the
             pipeline must persist explicitly.
 
-        Note: the scan reads ``self._id_to_meta`` directly without going
-        through ``_get_index``. In a reader process this can miss
-        relations added by a writer whose commit has not yet been
-        observed locally; the actual rebuild happens inside
-        ``_remove_faiss_ids`` under ``_storage_lock``. See class
-        docstring *Caveat*.
+        Errors propagate (same rationale as ``delete``).
 
         **Not pipeline-gated** — see class docstring
         *Non-pipeline write paths*. The caller is responsible for
         ensuring single-writer serialization.
         """
-        logger.debug(f"[{self.workspace}] Searching relations for entity {entity_name}")
-        relations = []
-        for fid, meta in self._id_to_meta.items():
-            if meta.get("src_id") == entity_name or meta.get("tgt_id") == entity_name:
-                relations.append(fid)
+        async with self._storage_lock:
+            self._reload_index_from_disk_locked(for_write=True)
 
-        logger.debug(
-            f"[{self.workspace}] Found {len(relations)} relations for {entity_name}"
-        )
-        if relations:
-            await self._remove_faiss_ids(relations)
+            # Prune matching buffered upserts (their records carry src_id /
+            # tgt_id from the relationships vdb meta_fields)...
+            pending_ids = [
+                doc_id
+                for doc_id, pdoc in self._pending_upserts.items()
+                if pdoc.record.get("src_id") == entity_name
+                or pdoc.record.get("tgt_id") == entity_name
+            ]
+            for doc_id in pending_ids:
+                del self._pending_upserts[doc_id]
+
+            # ...then scan the materialized rows. .get() so rows from
+            # foreign namespaces (no src_id / tgt_id) silently don't match.
+            relations = [
+                fid
+                for fid, meta in self._id_to_meta.items()
+                if meta.get("src_id") == entity_name
+                or meta.get("tgt_id") == entity_name
+            ]
+            if relations:
+                self._remove_faiss_ids_locked(relations)
+                self._index_dirty = True
+
+        total = len(pending_ids) + len(relations)
+        if total:
             logger.debug(
-                f"[{self.workspace}] Deleted {len(relations)} relations for {entity_name}"
+                f"[{self.workspace}] Deleted {total} relations for {entity_name}"
+            )
+        else:
+            logger.debug(
+                f"[{self.workspace}] No relations found for entity {entity_name}"
             )
 
     # --------------------------------------------------------------------------------
@@ -497,23 +586,55 @@ class FaissVectorDBStorage(BaseVectorStorage):
     # --------------------------------------------------------------------------------
 
     def _find_faiss_id_by_custom_id(self, custom_id: str):
-        """
-        Return the Faiss internal ID for a given custom ID, or None if not found.
+        """Return the first Faiss internal ID matching ``custom_id``, or ``None``.
+
+        Adequate for read paths (any of N duplicate rows would carry the same
+        ``__id__`` so returning one is fine semantically). Write paths that
+        need to remove **all** duplicates — flush overwrite, ``delete`` —
+        must use :py:meth:`_find_faiss_ids_by_custom_id` (plural) instead.
         """
         for fid, meta in self._id_to_meta.items():
             if meta.get("__id__") == custom_id:
                 return fid
         return None
 
-    async def _remove_faiss_ids(self, fid_list):
-        """
-        Remove a list of internal Faiss IDs from the index.
-        Because IndexFlatIP doesn't support 'removals',
-        we rebuild the index excluding those vectors.
-        """
-        keep_fids = [fid for fid in self._id_to_meta if fid not in fid_list]
+    def _find_faiss_ids_by_custom_id(self, custom_id: str) -> list[int]:
+        """Return **every** Faiss internal ID whose metadata's ``__id__`` matches.
 
-        # Rebuild the index
+        In a healthy store every custom id maps to at most one fid (each flush
+        rebuilds the index without the prior fid before adding the new one).
+        This plural variant exists to defend against legacy / externally
+        corrupted stores where multiple fids share a ``__id__`` — a re-upsert
+        or ``delete`` using only the first match would leave stale duplicates
+        behind. Used by ``_flush_pending_locked`` and ``delete``.
+        """
+        return [
+            fid
+            for fid, meta in self._id_to_meta.items()
+            if meta.get("__id__") == custom_id
+        ]
+
+    def _remove_faiss_ids_locked(self, fid_list) -> None:
+        """Remove a list of internal Faiss IDs by rebuilding the index.
+
+        Precondition: the caller must already hold ``_storage_lock``. This
+        is synchronous (no ``await``) because every step — dict scan,
+        ``IndexFlatIP`` re-init, ``index.add`` — is synchronous, and the
+        single critical section guarantees ``self._index`` and
+        ``self._id_to_meta`` flip together. Because ``IndexFlatIP`` has no
+        in-place removal API, we collect the kept vectors and rebuild.
+
+        Callers that mutate via this helper are responsible for setting
+        ``self._index_dirty = True`` themselves (skipped here so a no-op
+        call — empty intersection between ``fid_list`` and current ids —
+        does not falsely mark the storage dirty).
+        """
+        if not fid_list:
+            return
+
+        fid_set = set(fid_list)
+        keep_fids = [fid for fid in self._id_to_meta if fid not in fid_set]
+
         vectors_to_keep = []
         new_id_to_meta = {}
         for old_fid in keep_fids:
@@ -533,23 +654,113 @@ class FaissVectorDBStorage(BaseVectorStorage):
             vectors_to_keep.append(vec)
             new_id_to_meta[new_fid] = vec_meta
 
-        async with self._storage_lock:
-            # Re-init index
-            self._index = faiss.IndexFlatIP(self._dim)
-            if vectors_to_keep:
-                arr = np.array(vectors_to_keep, dtype=np.float32)
-                self._index.add(arr)
+        self._index = faiss.IndexFlatIP(self._dim)
+        if vectors_to_keep:
+            arr = np.array(vectors_to_keep, dtype=np.float32)
+            self._index.add(arr)
+        self._id_to_meta = new_id_to_meta
 
-            self._id_to_meta = new_id_to_meta
+    async def _flush_pending_locked(self) -> None:
+        """Embed pending docs and materialize them into ``self._index`` + ``self._id_to_meta``.
+
+        Precondition: the caller **must already hold** ``_storage_lock``. The
+        lock is non-reentrant, so this helper never calls ``_get_index`` and
+        operates on ``self._index`` / ``self._id_to_meta`` directly. Embedding
+        runs inside the lock on purpose (see class docstring,
+        *Deferred-embedding protocol*).
+
+        Invariant: once ``_PendingFaissDoc.vector`` is set it is an **already
+        L2-normalized float32 1D ndarray**. The flush honours this — vectors
+        cached by a prior ``get_vectors_by_ids`` are not re-normalized; only
+        newly embedded vectors go through ``faiss.normalize_L2``.
+
+        Failure handling:
+            * Embedding error / count mismatch → raises; ``_pending_upserts``
+              is left intact, ``self._index_dirty`` is not touched, nothing
+              is written to ``self._index``.
+            * Rebuild / ``index.add`` failure → raises before
+              ``_index_dirty=True`` flips, so the materialized state is not
+              falsely marked dirty (Faiss ops are synchronous and typically
+              all-or-nothing).
+        """
+        if not self._pending_upserts:
+            return
+
+        # Snapshot for stable ordering between the embed list and the write.
+        pending_items = list(self._pending_upserts.items())
+        to_embed = [
+            (doc_id, pdoc) for doc_id, pdoc in pending_items if pdoc.vector is None
+        ]
+
+        if to_embed:
+            contents = [pdoc.record["content"] for _, pdoc in to_embed]
+            batches = [
+                contents[i : i + self._max_batch_size]
+                for i in range(0, len(contents), self._max_batch_size)
+            ]
+            embeddings_list = await asyncio.gather(
+                *[self.embedding_func(batch, context="document") for batch in batches]
+            )
+            arr = np.concatenate(embeddings_list, axis=0).astype(np.float32)
+            if len(arr) != len(to_embed):
+                # Explicit raise (not a log): a mismatch would mis-pair vectors
+                # with records. Keep pending intact so the next flush retries.
+                raise RuntimeError(
+                    f"[{self.workspace}] embedding is not 1-1 with pending data, "
+                    f"{len(arr)} != {len(to_embed)}"
+                )
+            # Batch in-place normalize once (faiss.normalize_L2 requires 2D).
+            faiss.normalize_L2(arr)
+            for (_, pdoc), i in zip(to_embed, range(len(to_embed))):
+                pdoc.vector = arr[i].copy()
+
+        # All pending vectors are now non-None and already-normalized float32.
+        # Remove every existing fid in self._id_to_meta whose custom id is
+        # being re-upserted (find-all so duplicate __id__ rows from a legacy /
+        # corrupt store still get fully cleaned), then add the new vectors in
+        # a single batch.
+        existing_fids: list[int] = []
+        for doc_id, _ in pending_items:
+            existing_fids.extend(self._find_faiss_ids_by_custom_id(doc_id))
+        self._remove_faiss_ids_locked(existing_fids)
+
+        matrix = np.vstack([pdoc.vector for _, pdoc in pending_items]).astype(
+            np.float32
+        )
+        start_idx = self._index.ntotal
+        self._index.add(matrix)
+        for i, (_, pdoc) in enumerate(pending_items):
+            fid = start_idx + i
+            record = pdoc.record
+            record["__vector__"] = matrix[i].tolist()
+            self._id_to_meta[fid] = record
+
+        self._index_dirty = True
+
+        # Clear only the entries we just flushed (an upsert that arrived after
+        # the snapshot would have re-set vector=None and must not be dropped).
+        for doc_id, pdoc in pending_items:
+            if self._pending_upserts.get(doc_id) is pdoc:
+                del self._pending_upserts[doc_id]
 
     def _save_faiss_index(self):
-        """
-        Save the current Faiss index + metadata to disk so it can persist across runs.
+        """Atomically persist ``self._index`` + ``self._id_to_meta`` to disk.
+
+        Precondition: the caller must already hold ``_storage_lock`` (this is
+        the symmetric counterpart of ``_flush_pending_locked`` — see Nano's
+        ``_save_to_disk_locked``).
 
         Each file lands via a per-writer tmp + os.replace so a crash mid-write
-        leaves the prior snapshot intact. Cross-file consistency between the
-        .index and .meta.json (the two renames are not joint) is intentionally
-        out of scope here.
+        leaves the prior snapshot intact. **Cross-file consistency between
+        the .index and .meta.json is not guaranteed**: the two renames are
+        independent, so a crash between them can produce
+        ``ntotal(.index) > rows(.meta)`` skew. ``_load_faiss_index`` tolerates
+        skew on load by skipping unbacked rows and logs a warning if the
+        index has more vectors than the meta describes. The
+        ``index < meta`` direction is covered by
+        ``test_faiss_meta_inconsistency``; the ``index > meta`` direction is
+        a known gap (logged on reload, not auto-repaired) — see class
+        docstring *Storage model*.
         """
         atomic_write(
             self._faiss_index_file,
@@ -615,6 +826,20 @@ class FaissVectorDBStorage(BaseVectorStorage):
                     meta["__vector__"] = self._index.reconstruct(fid).tolist()
                 self._id_to_meta[fid] = meta
 
+            # Cross-file skew detection (index > meta direction): a crash
+            # between the two atomic_writes in _save_faiss_index can leave
+            # the index with more vectors than the meta describes. We log
+            # but do not auto-repair — repair semantics (truncate index vs
+            # rebuild meta) are out of scope here. See class docstring.
+            if self._index.ntotal > len(self._id_to_meta):
+                logger.warning(
+                    f"[{self.workspace}] FAISS index has {self._index.ntotal} vectors "
+                    f"but only {len(self._id_to_meta)} metadata rows — index > meta "
+                    f"skew from a prior crash between the .index and .meta.json "
+                    f"writes. Not auto-repairing; orphan vectors remain in the index "
+                    f"but unreachable via custom-id lookups."
+                )
+
             logger.info(
                 f"[{self.workspace}] Faiss index loaded with {self._index.ntotal} vectors from {self._faiss_index_file}"
             )
@@ -628,64 +853,58 @@ class FaissVectorDBStorage(BaseVectorStorage):
             self._index = faiss.IndexFlatIP(self._dim)
             self._id_to_meta = {}
 
-    async def index_done_callback(self) -> None:
-        """Commit in-memory state to disk and notify other processes.
+    async def index_done_callback(self) -> bool:
+        """Flush deferred embeddings, commit to disk, and notify other processes.
 
         This is the writer's **commit point** in the cross-process sync
-        protocol (see class docstring). Two effects, in order:
-            1. ``_save_faiss_index`` atomically writes ``.index`` and
-               ``.meta.json`` (per file; cross-file atomicity is *not*
-               guaranteed — see ``_save_faiss_index`` and class docstring
-               *Storage model*).
-            2. ``set_all_update_flags`` flips every registered process's
-               ``storage_updated`` flag, then we immediately reset our
-               own flag to ``False`` so the writer does not self-reload
-               on the next call to ``_get_index``.
+        protocol (see class docstring). Effects, in order:
+            1. If another process committed first, reload the latest on-disk
+               snapshot while preserving this process's pending buffer.
+            2. ``_flush_pending_locked`` embeds every buffered upsert (once
+               per id) and materializes it into ``self._index`` +
+               ``self._id_to_meta``. A failure here **raises** — pending is
+               kept, ``_index_dirty`` is not touched, nothing is written to
+               the index.
+            3. ``_save_faiss_index`` atomically writes ``.index`` and
+               ``.meta.json``. A failure here **also raises**;
+               ``_pending_upserts`` is already empty (flush succeeded) and
+               ``_index_dirty`` stays ``True`` so a later ``finalize``
+               retries the save without re-embedding.
+            4. ``set_all_update_flags`` flips every registered process's
+               ``storage_updated`` flag, then we immediately reset our own
+               flag to ``False`` so the writer does not self-reload on the
+               next call to ``_get_index``.
 
-        Two-block structure (intentional, do not collapse):
-            * **First ``async with``** — early-return path for a
-              hypothetical second writer. Under the current single-writer
-              pipeline contract (class docstring, invariant 1) the
-              ``storage_updated.value`` check is permanently ``False`` in
-              the writer, so this branch is **dead code in production**.
-              It is kept as defensive scaffolding for any future
-              relaxation of the single-writer invariant; removing it
-              would silently re-enable lost-write bugs the moment a
-              second writer is introduced.
-            * **Second ``async with``** — the actual save + notify.
+        Either failure surfaces loudly through ``_insert_done`` so the
+        caller can abort the document batch instead of silently losing
+        vectors. The bool return is kept for legacy callers but is
+        effectively always ``True`` on the success path.
         """
         async with self._storage_lock:
-            # Check if storage was updated by another process
-            if self.storage_updated.value:
-                # Storage was updated by another process, reload data instead of saving
-                logger.warning(
-                    f"[{self.workspace}] Storage for FAISS {self.namespace} was updated by another process, reloading..."
-                )
-                self._index = faiss.IndexFlatIP(self._dim)
-                self._id_to_meta = {}
-                self._load_faiss_index()
-                self.storage_updated.value = False
-                return False  # Return error
+            self._reload_index_from_disk_locked(for_write=True)
 
-        # Acquire lock and perform persistence
-        async with self._storage_lock:
-            try:
-                # Save data to disk
-                self._save_faiss_index()
-                # Notify other processes that data has been updated
-                await set_all_update_flags(self.namespace, workspace=self.workspace)
-                # Reset own update flag to avoid self-reloading
-                self.storage_updated.value = False
-            except Exception as e:
-                logger.error(
-                    f"[{self.workspace}] Error saving FAISS index for {self.namespace}: {e}"
-                )
-                return False  # Return error
+            # Flush + save both raise on failure (embedding mismatch / save IO
+            # error). The exception propagates out of the lock so _insert_done
+            # aborts the batch; pending stays intact and _index_dirty stays
+            # True (if only the save failed) for a later retry.
+            await self._flush_pending_locked()
+            self._save_faiss_index()
+            await set_all_update_flags(self.namespace, workspace=self.workspace)
+            self.storage_updated.value = False
+            self._index_dirty = False
+            return True
 
-        return True  # Return success
+    @staticmethod
+    def _format_record(dp: dict[str, Any]) -> dict[str, Any]:
+        """Shape a stored/pending record into the public read result."""
+        return {
+            **{k: v for k, v in dp.items() if k != "__vector__"},
+            "id": dp.get("__id__"),
+            "created_at": dp.get("__created_at__"),
+        }
 
     async def get_by_id(self, id: str) -> dict[str, Any] | None:
-        """Get vector data by its ID
+        """Get vector data by its ID (read-your-writes against the pending buffer).
 
         Args:
             id: The unique identifier of the vector
@@ -693,58 +912,63 @@ class FaissVectorDBStorage(BaseVectorStorage):
         Returns:
             The vector data if found, or None if not found
         """
-        # Find the Faiss internal ID for the custom ID
+        # Read-your-writes: a buffered upsert is visible before its flush.
+        async with self._storage_lock:
+            pending = self._pending_upserts.get(id)
+            if pending is not None:
+                return self._format_record(pending.record)
+
+        await self._get_index()  # reload-if-stale
         fid = self._find_faiss_id_by_custom_id(id)
         if fid is None:
             return None
-
-        # Get the metadata for the found ID
-        metadata = self._id_to_meta.get(fid, {})
-        if not metadata:
-            return None
-
-        # Filter out __vector__ from metadata to avoid returning large vector data
-        filtered_metadata = {k: v for k, v in metadata.items() if k != "__vector__"}
-        return {
-            **filtered_metadata,
-            "id": metadata.get("__id__"),
-            "created_at": metadata.get("__created_at__"),
-        }
+        metadata = self._id_to_meta.get(fid)
+        return self._format_record(metadata) if metadata else None
 
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
-        """Get multiple vector data by their IDs
+        """Get multiple vector data by their IDs (read-your-writes), preserving order.
 
         Args:
             ids: List of unique identifiers
 
         Returns:
-            List of vector data objects that were found
+            List of vector data objects (or ``None`` placeholders) in the
+            same order as ``ids``.
         """
         if not ids:
             return []
 
-        results: list[dict[str, Any] | None] = []
-        for id in ids:
-            record = None
-            fid = self._find_faiss_id_by_custom_id(id)
-            if fid is not None:
+        # Read-your-writes: serve buffered upserts from the pending area and
+        # only query the materialized index for the remaining ids.
+        result_map: dict[str, dict[str, Any]] = {}
+        remaining: list[str] = []
+        async with self._storage_lock:
+            for requested_id in ids:
+                pending = self._pending_upserts.get(requested_id)
+                if pending is not None:
+                    result_map[str(requested_id)] = self._format_record(pending.record)
+                else:
+                    remaining.append(requested_id)
+
+        if remaining:
+            await self._get_index()  # reload-if-stale
+            for cid in remaining:
+                fid = self._find_faiss_id_by_custom_id(cid)
+                if fid is None:
+                    continue
                 metadata = self._id_to_meta.get(fid)
                 if metadata:
-                    # Filter out __vector__ from metadata to avoid returning large vector data
-                    filtered_metadata = {
-                        k: v for k, v in metadata.items() if k != "__vector__"
-                    }
-                    record = {
-                        **filtered_metadata,
-                        "id": metadata.get("__id__"),
-                        "created_at": metadata.get("__created_at__"),
-                    }
-            results.append(record)
+                    result_map[str(cid)] = self._format_record(metadata)
 
-        return results
+        return [result_map.get(str(requested_id)) for requested_id in ids]
 
     async def get_vectors_by_ids(self, ids: list[str]) -> dict[str, list[float]]:
-        """Get vectors by their IDs, returning only ID and vector data for efficiency
+        """Get vectors by their IDs (read-your-writes), returning only ID and vector.
+
+        For buffered upserts the vector is computed lazily (and cached back
+        onto the pending doc so the next flush reuses it instead of
+        re-embedding); for materialized rows the stored normalized vector is
+        returned directly.
 
         Args:
             ids: List of unique identifiers
@@ -756,15 +980,55 @@ class FaissVectorDBStorage(BaseVectorStorage):
         if not ids:
             return {}
 
-        vectors_dict = {}
-        for id in ids:
-            # Find the Faiss internal ID for the custom ID
-            fid = self._find_faiss_id_by_custom_id(id)
-            if fid is not None and fid in self._id_to_meta:
+        vectors_dict: dict[str, list[float]] = {}
+        remaining: list[str] = []
+        async with self._storage_lock:
+            to_embed: list[tuple[str, _PendingFaissDoc]] = []
+            for requested_id in ids:
+                pending = self._pending_upserts.get(requested_id)
+                if pending is None:
+                    remaining.append(requested_id)
+                elif pending.vector is not None:
+                    vectors_dict[requested_id] = pending.vector.astype(
+                        np.float32
+                    ).tolist()
+                else:
+                    to_embed.append((requested_id, pending))
+
+            if to_embed:
+                contents = [pdoc.record["content"] for _, pdoc in to_embed]
+                batches = [
+                    contents[i : i + self._max_batch_size]
+                    for i in range(0, len(contents), self._max_batch_size)
+                ]
+                embeddings_list = await asyncio.gather(
+                    *[
+                        self.embedding_func(batch, context="document")
+                        for batch in batches
+                    ]
+                )
+                arr = np.concatenate(embeddings_list, axis=0).astype(np.float32)
+                if len(arr) != len(to_embed):
+                    raise RuntimeError(
+                        f"[{self.workspace}] embedding is not 1-1 with pending data, "
+                        f"{len(arr)} != {len(to_embed)}"
+                    )
+                # Batch normalize once; shared invariant with _flush_pending_locked.
+                faiss.normalize_L2(arr)
+                for i, (requested_id, pdoc) in enumerate(to_embed):
+                    # Cache the normalized vector back so the next flush reuses it.
+                    pdoc.vector = arr[i].copy()
+                    vectors_dict[requested_id] = arr[i].tolist()
+
+        if remaining:
+            await self._get_index()  # reload-if-stale
+            for cid in remaining:
+                fid = self._find_faiss_id_by_custom_id(cid)
+                if fid is None or fid not in self._id_to_meta:
+                    continue
                 metadata = self._id_to_meta[fid]
-                # Get the stored vector from metadata
                 if "__vector__" in metadata:
-                    vectors_dict[id] = metadata["__vector__"]
+                    vectors_dict[cid] = metadata["__vector__"]
 
         return vectors_dict
 
@@ -795,6 +1059,9 @@ class FaissVectorDBStorage(BaseVectorStorage):
         """
         try:
             async with self._storage_lock:
+                # Discard buffered (unflushed) upserts along with the data.
+                self._pending_upserts.clear()
+
                 # Reset the index
                 self._index = faiss.IndexFlatIP(self._dim)
                 self._id_to_meta = {}
@@ -807,6 +1074,7 @@ class FaissVectorDBStorage(BaseVectorStorage):
 
                 self._id_to_meta = {}
                 self._load_faiss_index()
+                self._index_dirty = False
 
                 # Notify other processes
                 await set_all_update_flags(self.namespace, workspace=self.workspace)
@@ -821,3 +1089,37 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 f"[{self.workspace}] Error dropping FAISS index {self.namespace}: {e}"
             )
             return {"status": "error", "message": str(e)}
+
+    async def finalize(self):
+        """Flush any buffered upserts and persist before shutdown (safety net).
+
+        Normally ``index_done_callback`` has already drained the pending
+        buffer and synced to disk, but two paths land here with work to do:
+
+        - **Pending upserts only** (no prior ``index_done_callback``): flush
+          and save. We reload first so a stale process picks up other
+          writers' commits before merging its pending buffer in.
+        - **Unsaved materialized changes** (``_index_dirty=True``): an
+          earlier ``index_done_callback`` flushed pending into ``self._index``
+          but its save raised. Skip the reload — reloading would drop those
+          materialized-but-unsaved rows — and just retry the save.
+
+        Flush / save failures propagate (same contract as
+        ``index_done_callback``); a partially flushed buffer is preserved
+        for a future retry.
+        """
+        async with self._storage_lock:
+            if not self._pending_upserts and not self._index_dirty:
+                return
+            if self._pending_upserts:
+                # Only reload when we have nothing un-persisted in self._index.
+                # A dirty index carries successfully-flushed-but-unsaved rows
+                # from a prior index_done_callback; reloading would silently
+                # drop them.
+                if not self._index_dirty:
+                    self._reload_index_from_disk_locked(for_write=True)
+                await self._flush_pending_locked()
+            self._save_faiss_index()
+            await set_all_update_flags(self.namespace, workspace=self.workspace)
+            self.storage_updated.value = False
+            self._index_dirty = False

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -705,9 +705,24 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 contents[i : i + self._max_batch_size]
                 for i in range(0, len(contents), self._max_batch_size)
             ]
-            embeddings_list = await asyncio.gather(
-                *[self.embedding_func(batch, context="document") for batch in batches]
+            logger.info(
+                f"[{self.workspace}] {self.namespace} flush: embedding "
+                f"{len(to_embed)} vectors in {len(batches)} batch(es) "
+                f"(batch_num={self._max_batch_size})"
             )
+            try:
+                embeddings_list = await asyncio.gather(
+                    *[
+                        self.embedding_func(batch, context="document")
+                        for batch in batches
+                    ]
+                )
+            except Exception as e:
+                logger.error(
+                    f"[{self.workspace}] Error embedding pending vector ops "
+                    f"(upserts={len(to_embed)}): {e}"
+                )
+                raise
             arr = np.concatenate(embeddings_list, axis=0).astype(np.float32)
             if len(arr) != len(to_embed):
                 # Explicit raise (not a log): a mismatch would mis-pair vectors

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -675,13 +675,20 @@ class FaissVectorDBStorage(BaseVectorStorage):
         newly embedded vectors go through ``faiss.normalize_L2``.
 
         Failure handling:
-            * Embedding error / count mismatch → raises; ``_pending_upserts``
-              is left intact, ``self._index_dirty`` is not touched, nothing
-              is written to ``self._index``.
-            * Rebuild / ``index.add`` failure → raises before
-              ``_index_dirty=True`` flips, so the materialized state is not
-              falsely marked dirty (Faiss ops are synchronous and typically
-              all-or-nothing).
+            * Embedding error / count mismatch → raises before any mutation
+              to ``self._index`` / ``self._id_to_meta``; ``_pending_upserts``
+              is left intact and ``self._index_dirty`` is not touched.
+            * Rebuild / ``index.add`` failure → raises mid-write. The
+              materialized state may already be partially mutated (e.g.
+              ``_remove_faiss_ids_locked`` ran and dropped the prior fids
+              for re-upserted ids), but ``_index_dirty`` is **not** set
+              because we deliberately treat ``_pending_upserts`` as the
+              source of truth on this path: pending stays intact, and the
+              next ``finalize`` call re-enters ``_flush_pending_locked``,
+              which will rebuild the affected rows from the cached vectors
+              and re-add them — self-healing without re-embedding. The
+              dirty flag is reserved for "materialized but unsaved",
+              which is only true after ``index.add`` completes.
         """
         if not self._pending_upserts:
             return
@@ -711,7 +718,7 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 )
             # Batch in-place normalize once (faiss.normalize_L2 requires 2D).
             faiss.normalize_L2(arr)
-            for (_, pdoc), i in zip(to_embed, range(len(to_embed))):
+            for i, (_, pdoc) in enumerate(to_embed):
                 pdoc.vector = arr[i].copy()
 
         # All pending vectors are now non-None and already-normalized float32.
@@ -737,8 +744,13 @@ class FaissVectorDBStorage(BaseVectorStorage):
 
         self._index_dirty = True
 
-        # Clear only the entries we just flushed (an upsert that arrived after
-        # the snapshot would have re-set vector=None and must not be dropped).
+        # Clear only the entries we just flushed. Today the non-reentrant
+        # _storage_lock locks out concurrent upserts for the entire flush
+        # (including the asyncio.gather await), so the `is pdoc` identity
+        # check is always True — it's kept as defensive scaffolding so that
+        # if the lock scope is ever relaxed (e.g. embedding moved outside the
+        # lock), a concurrent upsert that re-set vector=None would not be
+        # silently dropped here.
         for doc_id, pdoc in pending_items:
             if self._pending_upserts.get(doc_id) is pdoc:
                 del self._pending_upserts[doc_id]

--- a/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
@@ -1,0 +1,693 @@
+"""Deferred-embedding coverage for ``FaissVectorDBStorage``.
+
+The storage no longer embeds eagerly in ``upsert``: it buffers a pending doc
+and embeds once per id at flush time (``index_done_callback`` / ``finalize``).
+These tests pin that contract using a counting mock embedding function — no
+live model or network. They mirror the protocol proven for
+``NanoVectorDBStorage`` (issue #2785) plus three Faiss-specific cases:
+
+- ``test_reupsert_after_flush_replaces_single_fid`` — Faiss has no in-place
+  upsert; verify the rebuild keeps a single fid per custom id.
+- ``test_index_done_callback_save_failure_raises`` — flush succeeds, save IO
+  fails: pending is empty, ``_index_dirty`` stays True, the materialized index
+  is preserved for a finalize retry.
+- ``test_reload_warns_on_index_meta_skew`` — ``index > meta`` on-disk skew
+  (from a crash between the two atomic_writes) is logged on reload but **not**
+  auto-repaired.
+"""
+
+import json
+import os
+
+import numpy as np
+import pytest
+
+faiss = pytest.importorskip("faiss")
+
+from lightrag.kg.faiss_impl import FaissVectorDBStorage  # noqa: E402
+from lightrag.kg.shared_storage import (  # noqa: E402
+    initialize_share_data,
+    finalize_share_data,
+)
+from lightrag.utils import EmbeddingFunc  # noqa: E402
+
+DIM = 8
+
+
+@pytest.fixture(autouse=True)
+def _shared_data():
+    finalize_share_data()
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
+class _CountingEmbed:
+    """Async embedding callable that records how many texts it embedded and how
+    many times it was invoked (one invocation == one batch)."""
+
+    def __init__(self, dim: int = DIM):
+        self.dim = dim
+        self.call_count = 0
+        self.embedded_texts: list[str] = []
+
+    async def __call__(self, texts, **kwargs):
+        self.call_count += 1
+        self.embedded_texts.extend(texts)
+        # Deterministic per-text vector so duplicates are still 1-1.
+        return np.array(
+            [
+                np.full(self.dim, (abs(hash(t)) % 97) + 1, dtype=np.float32)
+                for t in texts
+            ]
+        )
+
+
+def _make_storage(tmp_path, embed: _CountingEmbed) -> FaissVectorDBStorage:
+    return FaissVectorDBStorage(
+        namespace="test_vectors",
+        workspace="ws",
+        global_config={
+            "working_dir": str(tmp_path),
+            "embedding_batch_num": 32,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+        },
+        embedding_func=EmbeddingFunc(embedding_dim=DIM, max_token_size=512, func=embed),
+        meta_fields={"content"},
+    )
+
+
+def _assert_consistent(storage: FaissVectorDBStorage) -> None:
+    """Faiss has two structures (index + meta dict); the root failure mode is
+    them diverging. Every test that mutates state asserts they match."""
+    assert storage._index.ntotal == len(storage._id_to_meta), (
+        f"index ntotal ({storage._index.ntotal}) != meta length "
+        f"({len(storage._id_to_meta)})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (A) Nano-ported tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_upsert_defers_embedding_to_index_done_callback(tmp_path):
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert(
+        {
+            "id1": {"content": "alpha"},
+            "id2": {"content": "beta"},
+        }
+    )
+    assert embed.call_count == 0, "upsert must not embed"
+    assert storage._index.ntotal == 0, "nothing should be materialized yet"
+    _assert_consistent(storage)
+
+    await storage.index_done_callback()
+    assert embed.call_count == 1, "flush should embed in a single batch"
+    assert sorted(embed.embedded_texts) == ["alpha", "beta"]
+    assert storage._index.ntotal == 2
+    _assert_consistent(storage)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_repeated_upserts_same_id_embed_once_per_flush(tmp_path):
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "v1"}})
+    await storage.upsert({"id1": {"content": "v2"}})
+    await storage.upsert({"id1": {"content": "v3"}})
+
+    await storage.index_done_callback()
+
+    assert embed.call_count == 1
+    assert embed.embedded_texts == ["v3"], "only the latest content is embedded"
+    assert storage._index.ntotal == 1
+    _assert_consistent(storage)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_get_vectors_caches_and_flush_reuses(tmp_path):
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "alpha"}})
+
+    vecs = await storage.get_vectors_by_ids(["id1"])
+    assert "id1" in vecs and len(vecs["id1"]) == DIM
+    assert embed.call_count == 1, "get_vectors_by_ids embeds pending lazily"
+
+    # Flush must reuse the cached vector, not re-embed.
+    await storage.index_done_callback()
+    assert embed.call_count == 1, "flush should reuse the cached temp vector"
+    assert storage._index.ntotal == 1
+    _assert_consistent(storage)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_reupsert_after_get_vectors_clears_cached_vector(tmp_path):
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "old"}})
+    await storage.get_vectors_by_ids(["id1"])  # caches a temp vector for "old"
+    assert embed.call_count == 1
+
+    # New content version must clear the cached vector and re-embed at flush.
+    await storage.upsert({"id1": {"content": "new"}})
+    await storage.index_done_callback()
+
+    assert embed.call_count == 2
+    assert embed.embedded_texts == ["old", "new"]
+    _assert_consistent(storage)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_delete_cancels_pending_and_removes_materialized(tmp_path):
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    # Materialize id1; leave id2 only as a pending (unflushed) upsert.
+    await storage.upsert({"id1": {"content": "alpha"}})
+    await storage.index_done_callback()
+    await storage.upsert({"id2": {"content": "beta"}})
+
+    await storage.delete(["id1", "id2"])
+
+    assert "id2" not in storage._pending_upserts, "delete cancels pending upsert"
+    assert storage._index.ntotal == 0, "delete removes the materialized row"
+    assert await storage.get_by_id("id1") is None
+    assert await storage.get_by_id("id2") is None
+    _assert_consistent(storage)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_stale_client_reload_still_flushes_pending_upsert(tmp_path):
+    embed = _CountingEmbed()
+    writer = _make_storage(tmp_path, embed)
+    stale_writer = _make_storage(tmp_path, embed)
+    await writer.initialize()
+    await stale_writer.initialize()
+
+    await writer.upsert({"id1": {"content": "alpha"}})
+    assert await writer.index_done_callback() is True
+    assert stale_writer.storage_updated.value is True
+
+    await stale_writer.upsert({"id2": {"content": "beta"}})
+    assert await stale_writer.index_done_callback() is True
+
+    reader = _make_storage(tmp_path, embed)
+    await reader.initialize()
+    rows = await reader.get_by_ids(["id1", "id2"])
+    assert [row["id"] for row in rows] == ["id1", "id2"]
+    assert stale_writer._pending_upserts == {}
+    _assert_consistent(reader)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_delete_reloads_stale_client_before_mutating(tmp_path):
+    embed = _CountingEmbed()
+    writer = _make_storage(tmp_path, embed)
+    stale_deleter = _make_storage(tmp_path, embed)
+    await writer.initialize()
+    await stale_deleter.initialize()
+
+    await writer.upsert({"id1": {"content": "alpha"}})
+    assert await writer.index_done_callback() is True
+    assert stale_deleter.storage_updated.value is True
+
+    await stale_deleter.delete(["id1"])
+    assert stale_deleter.storage_updated.value is False
+    assert await stale_deleter.index_done_callback() is True
+
+    reader = _make_storage(tmp_path, embed)
+    await reader.initialize()
+    assert await reader.get_by_id("id1") is None
+    _assert_consistent(reader)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_finalize_reloads_stale_client_before_flushing(tmp_path):
+    embed = _CountingEmbed()
+    writer = _make_storage(tmp_path, embed)
+    stale_finalizer = _make_storage(tmp_path, embed)
+    await writer.initialize()
+    await stale_finalizer.initialize()
+
+    await writer.upsert({"id1": {"content": "alpha"}})
+    assert await writer.index_done_callback() is True
+    assert stale_finalizer.storage_updated.value is True
+
+    await stale_finalizer.upsert({"id2": {"content": "beta"}})
+    await stale_finalizer.finalize()
+
+    reader = _make_storage(tmp_path, embed)
+    await reader.initialize()
+    rows = await reader.get_by_ids(["id1", "id2"])
+    assert [row["id"] for row in rows] == ["id1", "id2"]
+    assert stale_finalizer._pending_upserts == {}
+    _assert_consistent(reader)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_read_your_writes_and_query_after_flush(tmp_path):
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "alpha"}})
+
+    # Before flush: read paths see the pending row, query does not.
+    hit = await storage.get_by_id("id1")
+    assert hit is not None and hit["id"] == "id1" and hit["content"] == "alpha"
+    by_ids = await storage.get_by_ids(["id1", "missing"])
+    assert by_ids[0]["id"] == "id1" and by_ids[1] is None
+    assert await storage.query("alpha", top_k=5) == [], "query ignores unflushed data"
+
+    # After flush: query returns the row.
+    await storage.index_done_callback()
+    results = await storage.query("alpha", top_k=5)
+    assert any(r["id"] == "id1" for r in results)
+    _assert_consistent(storage)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_finalize_flushes_pending(tmp_path):
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "alpha"}})
+    await storage.finalize()
+
+    assert embed.call_count == 1
+    assert storage._pending_upserts == {}
+    assert storage._index.ntotal == 1
+    _assert_consistent(storage)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_delete_entity_relation_cancels_pending(tmp_path):
+    embed = _CountingEmbed()
+    storage = FaissVectorDBStorage(
+        namespace="test_relations",
+        workspace="ws",
+        global_config={
+            "working_dir": str(tmp_path),
+            "embedding_batch_num": 32,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+        },
+        embedding_func=EmbeddingFunc(embedding_dim=DIM, max_token_size=512, func=embed),
+        meta_fields={"content", "src_id", "tgt_id"},
+    )
+    await storage.initialize()
+
+    # Materialize r1 (A->B), leave r2 (A->C) and r3 (X->Y) as pending.
+    await storage.upsert({"r1": {"content": "rel1", "src_id": "A", "tgt_id": "B"}})
+    await storage.index_done_callback()
+    await storage.upsert(
+        {
+            "r2": {"content": "rel2", "src_id": "A", "tgt_id": "C"},
+            "r3": {"content": "rel3", "src_id": "X", "tgt_id": "Y"},
+        }
+    )
+
+    await storage.delete_entity_relation("A")
+
+    assert "r2" not in storage._pending_upserts, "incident pending entry cancelled"
+    assert "r3" in storage._pending_upserts, "unrelated pending entry preserved"
+    assert storage._index.ntotal == 0, "materialized A->B removed"
+    _assert_consistent(storage)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_flush_embedding_failure_raises_and_keeps_pending(tmp_path):
+    class _FailingEmbed:
+        def __init__(self):
+            self.call_count = 0
+
+        async def __call__(self, texts, **kwargs):
+            self.call_count += 1
+            raise RuntimeError("embed boom")
+
+    embed = _FailingEmbed()
+    storage = FaissVectorDBStorage(
+        namespace="test_vectors",
+        workspace="ws",
+        global_config={
+            "working_dir": str(tmp_path),
+            "embedding_batch_num": 32,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+        },
+        embedding_func=EmbeddingFunc(embedding_dim=DIM, max_token_size=512, func=embed),
+        meta_fields={"content"},
+    )
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "alpha"}})
+
+    with pytest.raises(RuntimeError, match="embed boom"):
+        await storage.index_done_callback()
+
+    assert "id1" in storage._pending_upserts, "pending preserved for retry"
+    assert storage._index.ntotal == 0, "nothing materialized on embed failure"
+    # Embed failure happens before self._index.add in _flush_pending_locked,
+    # so _index_dirty must NOT be set. (A save-stage failure would leave it True
+    # — see test_index_done_callback_save_failure_raises.)
+    assert storage._index_dirty is False
+    _assert_consistent(storage)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_drop_discards_pending_without_embedding(tmp_path):
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "alpha"}})
+    assert "id1" in storage._pending_upserts
+
+    result = await storage.drop()
+
+    assert result["status"] == "success"
+    assert storage._pending_upserts == {}, "drop discards buffered upserts"
+    assert embed.call_count == 0, "drop must not embed"
+    assert storage._index_dirty is False
+    _assert_consistent(storage)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_finalize_retries_save_after_flush_failure(tmp_path):
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "alpha"}})
+
+    original_save = storage._save_faiss_index
+    save_calls = 0
+
+    def fail_once():
+        nonlocal save_calls
+        save_calls += 1
+        if save_calls == 1:
+            raise OSError("boom")
+        original_save()
+
+    storage._save_faiss_index = fail_once
+
+    with pytest.raises(OSError, match="boom"):
+        await storage.finalize()
+
+    assert storage._pending_upserts == {}
+    assert storage._index_dirty is True
+
+    await storage.finalize()
+
+    assert save_calls == 2
+    assert storage._index_dirty is False
+
+    reader = _make_storage(tmp_path, embed)
+    await reader.initialize()
+    hit = await reader.get_by_id("id1")
+    assert hit is not None and hit["id"] == "id1"
+    _assert_consistent(reader)
+
+
+# ---------------------------------------------------------------------------
+# (B) Faiss-specific tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_reupsert_after_flush_replaces_single_fid(tmp_path):
+    """Faiss has no in-place upsert: re-upserting an already-materialized id
+    must rebuild the index without the old fid, so we still end up with
+    exactly one row per custom id."""
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "old"}})
+    await storage.index_done_callback()
+    assert storage._index.ntotal == 1
+    _assert_consistent(storage)
+
+    await storage.upsert({"id1": {"content": "new"}})
+    await storage.index_done_callback()
+
+    assert storage._index.ntotal == 1, "rebuild must remove old fid before adding new"
+    assert len(storage._id_to_meta) == 1
+    _assert_consistent(storage)
+
+    hit = await storage.get_by_id("id1")
+    assert hit is not None and hit["content"] == "new"
+    assert embed.call_count == 2, "each flush embeds the latest content once"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_index_done_callback_save_failure_raises(tmp_path):
+    """Save failure in index_done_callback must propagate, leave pending empty
+    (flush already succeeded), and keep _index_dirty=True so finalize retries."""
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "alpha"}})
+
+    original_save = storage._save_faiss_index
+
+    def fail_save():
+        raise OSError("save boom")
+
+    storage._save_faiss_index = fail_save
+
+    with pytest.raises(OSError, match="save boom"):
+        await storage.index_done_callback()
+
+    assert storage._pending_upserts == {}, "flush succeeded so pending is empty"
+    assert storage._index_dirty is True, "save failure preserves dirty for retry"
+    assert storage._index.ntotal == 1, "materialized state is preserved"
+    _assert_consistent(storage)
+
+    # Restore real save; finalize must retry only the save (no re-embed).
+    storage._save_faiss_index = original_save
+    embed_before = embed.call_count
+    await storage.finalize()
+    assert embed.call_count == embed_before, "save retry must not re-embed"
+    assert storage._index_dirty is False
+
+    reader = _make_storage(tmp_path, embed)
+    await reader.initialize()
+    hit = await reader.get_by_id("id1")
+    assert hit is not None and hit["id"] == "id1"
+    _assert_consistent(reader)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_reload_warns_on_index_meta_skew(tmp_path, caplog):
+    """A crash between the .index write and the .meta.json write leaves
+    ``ntotal(.index) > rows(.meta)``. ``_load_faiss_index`` must log a warning
+    on reload; auto-repair is intentionally not in scope here."""
+    import logging
+
+    from lightrag.utils import logger as lightrag_logger
+
+    embed = _CountingEmbed()
+    writer = _make_storage(tmp_path, embed)
+    await writer.initialize()
+
+    await writer.upsert({"id1": {"content": "alpha"}, "id2": {"content": "beta"}})
+    await writer.index_done_callback()
+
+    # Corrupt the meta file: drop one entry so disk has index > meta.
+    with open(writer._meta_file, "r", encoding="utf-8") as f:
+        meta = json.load(f)
+    assert len(meta) == 2
+    dropped_key = next(iter(meta))
+    del meta[dropped_key]
+    with open(writer._meta_file, "w", encoding="utf-8") as f:
+        json.dump(meta, f)
+
+    # The lightrag logger sets propagate=False (lightrag/utils.py), so caplog —
+    # which attaches to root by default — never sees its records. Flip propagate
+    # for the duration of the reload, then restore.
+    caplog.clear()
+    old_propagate = lightrag_logger.propagate
+    lightrag_logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger="lightrag"):
+            reader = _make_storage(tmp_path, embed)
+            await reader.initialize()
+    finally:
+        lightrag_logger.propagate = old_propagate
+
+    # The reader's index still has 2 vectors but only 1 reachable via meta —
+    # this is the "known risk, not auto-repaired" state.
+    assert reader._index.ntotal == 2
+    assert len(reader._id_to_meta) == 1
+    skew_messages = [
+        rec.message
+        for rec in caplog.records
+        if "skew" in rec.message or "index > meta" in rec.message
+    ]
+    assert skew_messages, (
+        f"expected an index>meta skew warning; got: "
+        f"{[r.message for r in caplog.records]}"
+    )
+
+    # Sanity: state files exist where we left them.
+    assert os.path.exists(writer._faiss_index_file)
+    assert os.path.exists(writer._meta_file)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_query_skips_orphan_faiss_hits(tmp_path):
+    """After an ``index > meta`` skew the orphan vector is still searchable by
+    similarity, but ``query`` must skip it instead of leaking a ghost
+    ``{"id": None, ...}`` row to the caller."""
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    # Materialize two rows.
+    await storage.upsert({"id1": {"content": "alpha"}, "id2": {"content": "beta"}})
+    await storage.index_done_callback()
+    assert storage._index.ntotal == 2
+
+    # Synthesize the skew: drop one meta row in memory, keeping the faiss
+    # index untouched. This mirrors what _load_faiss_index would surface on
+    # reload after a crash between the two atomic_writes.
+    orphan_fid = next(iter(storage._id_to_meta))
+    del storage._id_to_meta[orphan_fid]
+    assert storage._index.ntotal == 2
+    assert len(storage._id_to_meta) == 1
+
+    # The orphan vector still scores high in similarity search; query must
+    # filter it out instead of returning {"id": None, ...}.
+    results = await storage.query("anything", top_k=5)
+    for row in results:
+        assert row["id"] is not None, f"orphan hit leaked: {row}"
+    # And the surviving row is still returned.
+    surviving_id = next(iter(storage._id_to_meta.values()))["__id__"]
+    assert any(r["id"] == surviving_id for r in results)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_reupsert_cleans_duplicate_custom_id_rows(tmp_path):
+    """Defends against legacy / externally corrupted stores where multiple
+    fids in ``_id_to_meta`` share the same ``__id__``. A re-upsert + flush
+    must collapse them to a single row; a ``delete`` must remove all of them."""
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    # Hand-craft a corrupt state: two fids carry the same custom id "dup".
+    matrix = np.array([[1.0] * DIM, [2.0] * DIM], dtype=np.float32)
+    faiss.normalize_L2(matrix)
+    storage._index.add(matrix)
+    storage._id_to_meta[0] = {
+        "__id__": "dup",
+        "__created_at__": 1,
+        "content": "v1",
+        "__vector__": matrix[0].tolist(),
+    }
+    storage._id_to_meta[1] = {
+        "__id__": "dup",
+        "__created_at__": 1,
+        "content": "v2",
+        "__vector__": matrix[1].tolist(),
+    }
+    _assert_consistent(storage)
+    assert storage._find_faiss_ids_by_custom_id("dup") == [0, 1]
+
+    # Re-upsert + flush: both duplicates must be removed in the rebuild
+    # before the new vector is added; final state is a single row.
+    await storage.upsert({"dup": {"content": "v3"}})
+    await storage.index_done_callback()
+
+    assert storage._index.ntotal == 1, "flush rebuild must drop both duplicates"
+    assert len(storage._id_to_meta) == 1
+    assert storage._find_faiss_ids_by_custom_id("dup") == list(
+        storage._id_to_meta.keys()
+    )
+    hit = await storage.get_by_id("dup")
+    assert hit is not None and hit["content"] == "v3"
+    _assert_consistent(storage)
+
+    # Re-seed two more duplicates and verify delete also removes them all.
+    matrix2 = np.array([[3.0] * DIM, [4.0] * DIM], dtype=np.float32)
+    faiss.normalize_L2(matrix2)
+    storage._index.add(matrix2)
+    next_fid = max(storage._id_to_meta) + 1
+    storage._id_to_meta[next_fid] = {
+        "__id__": "dup",
+        "__created_at__": 2,
+        "content": "dup-a",
+        "__vector__": matrix2[0].tolist(),
+    }
+    storage._id_to_meta[next_fid + 1] = {
+        "__id__": "dup",
+        "__created_at__": 2,
+        "content": "dup-b",
+        "__vector__": matrix2[1].tolist(),
+    }
+    assert len(storage._find_faiss_ids_by_custom_id("dup")) == 3
+
+    await storage.delete(["dup"])
+    assert storage._find_faiss_ids_by_custom_id("dup") == []
+    assert storage._index.ntotal == 0
+    _assert_consistent(storage)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_delete_propagates_errors(tmp_path, monkeypatch):
+    """Faiss ``delete`` must NOT swallow errors — the caller (document
+    deletion / status update path) needs to abort if vectors weren't
+    actually removed. This intentionally diverges from Nano."""
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "alpha"}})
+    await storage.index_done_callback()
+
+    def boom(_self, _fids):
+        raise RuntimeError("rebuild boom")
+
+    # _remove_faiss_ids_locked is what delete calls under the hood.
+    monkeypatch.setattr(
+        FaissVectorDBStorage, "_remove_faiss_ids_locked", boom, raising=True
+    )
+
+    with pytest.raises(RuntimeError, match="rebuild boom"):
+        await storage.delete(["id1"])

--- a/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
@@ -691,3 +691,78 @@ async def test_delete_propagates_errors(tmp_path, monkeypatch):
 
     with pytest.raises(RuntimeError, match="rebuild boom"):
         await storage.delete(["id1"])
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_flush_recovers_from_index_add_failure_without_re_embedding(tmp_path):
+    """Self-heal contract: if ``index.add`` raises mid-flush (after embedding
+    already succeeded), the pending buffer keeps the cached vectors and a
+    subsequent ``finalize`` retries the flush **without re-embedding**. Pins
+    the "pending is the source of truth on mid-write failure" invariant
+    documented on ``_flush_pending_locked``."""
+
+    class _AddFailsOnce:
+        """Wraps a real faiss index, raising on the first ``.add`` call. After
+        the second add succeeds it swaps the storage's ``_index`` attribute
+        back to the real instance, so ``faiss.write_index`` (which requires a
+        real SWIG-wrapped object) can run during the retry's save step. This
+        is a test-only shim — in production ``self._index`` is always a real
+        faiss index throughout the retry.
+        """
+
+        def __init__(self, storage, real):
+            self._storage = storage
+            self._real = real
+            self._calls = 0
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+        def add(self, arr):
+            self._calls += 1
+            if self._calls == 1:
+                raise RuntimeError("add boom")
+            result = self._real.add(arr)
+            self._storage._index = self._real
+            return result
+
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "alpha"}})
+
+    real_index = storage._index
+    storage._index = _AddFailsOnce(storage, real_index)
+
+    with pytest.raises(RuntimeError, match="add boom"):
+        await storage.index_done_callback()
+
+    # Embedding completed once (failure happened after embed, in index.add).
+    assert embed.call_count == 1
+    # Pending preserved with cached vectors — that's the self-healing key.
+    assert "id1" in storage._pending_upserts
+    assert storage._pending_upserts["id1"].vector is not None
+    # _index_dirty stays False: docstring says we deliberately don't flip it
+    # on mid-write failure (pending is the source of truth).
+    assert storage._index_dirty is False
+    assert storage._index.ntotal == 0
+
+    # Retry through the same public entry point. The wrapper's second add
+    # succeeds, unwraps itself, and the rest of finalize (save + notify)
+    # runs against the real index.
+    await storage.finalize()
+
+    assert embed.call_count == 1, "retry must reuse cached vectors, not re-embed"
+    assert storage._index is real_index, "wrapper unwrapped itself on the second add"
+    assert storage._index.ntotal == 1
+    assert storage._pending_upserts == {}
+    assert storage._index_dirty is False
+    _assert_consistent(storage)
+
+    # And the row was persisted to disk by the retry's save.
+    reader = _make_storage(tmp_path, embed)
+    await reader.initialize()
+    hit = await reader.get_by_id("id1")
+    assert hit is not None and hit["content"] == "alpha"


### PR DESCRIPTION
## Summary

`FaissVectorDBStorage.upsert()` embedded **eagerly** on every call, so repeated upserts of the same id — and many small upsert calls — re-triggered the embedding model. This applies the deferred-embedding pattern already proven for `NanoVectorDBStorage` (PR #3145) to the Faiss backend: buffer upserts and embed **once per id at flush time**.

Closes the Faiss-backend case of the repeated-embedding problem in #2785.

## Motivation

- Same as #2785 / #3145: per-call embedding wastes model calls when the same id is upserted multiple times or content arrives in many small batches.
- `NanoVectorDBStorage` already solved this in this codebase. Faiss is the other in-process / file-backed vector backend, so the same pattern fits cleanly. The Nano protocol is the authoritative reference; this PR is a careful 1:1 port plus three Faiss-specific cases the Nano playbook didn't need to cover.

## What's changed (`lightrag/kg/faiss_impl.py`)

- New `_PendingFaissDoc` dataclass + `self._pending_upserts: dict[str, _PendingFaissDoc]` buffer + `self._index_dirty` flag.
- `upsert()` now buffers `_PendingFaissDoc(vector=None)` under the lock; **no embedding inline**. Re-upserting the same id overwrites the prior pending doc (clearing any temp vector a previous `get_vectors_by_ids` had cached).
- New `_flush_pending_locked()` (caller must hold the **non-reentrant** `_storage_lock`):
  - Batch-embeds all `vector is None` pending docs.
  - One in-place `faiss.normalize_L2(arr)` on the whole batch (Faiss requires 2D); the per-row normalized vector is cached back to `_PendingFaissDoc.vector` (invariant: `pdoc.vector` is always **already L2-normalized float32**).
  - One `_remove_faiss_ids_locked` rebuild that strips every existing fid for any re-upserted custom id (uses the new plural helper — see below), then one `index.add(matrix)` for the whole pending batch.
  - Raises on embedding / count-mismatch failure; pending stays intact, `_index_dirty` is not touched.
- `index_done_callback()` rewritten: `reload-if-stale → flush → save → notify`. Flush / save **both raise** on failure (no silent log + return False). If only the save fails, `_pending_upserts` is empty (flush succeeded) and `_index_dirty=True` so a later `finalize` retries the save without re-embedding.
- New `finalize()` safety net: flushes any pending and saves. Skips the reload when `_index_dirty=True` so materialized-but-unsaved rows aren't dropped.
- Read-your-writes for `get_by_id` / `get_by_ids` / `get_vectors_by_ids`: consult `_pending_upserts` first; fall back through `_get_index()` (reload-if-stale) + `_id_to_meta`. `get_vectors_by_ids` lazy-embeds pending docs (same batch-normalize, cache-back invariant as flush). The pre-existing "Caveat — methods read `_id_to_meta` without `_get_index`" is now eliminated for async reads (still documented for the synchronous `client_storage` property).
- `delete` / `delete_entity` / `delete_entity_relation` / `drop` cancel matching pending entries under the lock, reload-if-stale, then mutate. **`delete` / `delete_entity_relation` propagate exceptions** rather than swallowing them — this intentionally diverges from Nano's swallow-and-log so document deletion / status-update flows abort if vectors weren't actually removed.
- `_remove_faiss_ids` → synchronous `_remove_faiss_ids_locked` (caller holds the lock). Single rebuild API used by both delete paths and flush.
- New plural helper `_find_faiss_ids_by_custom_id(custom_id) -> list[int]`. The singular variant stays for read paths; the plural variant is used in `_flush_pending_locked` and `delete` to defend against legacy / externally corrupted stores where multiple fids share a `__id__`.
- `_load_faiss_index` now logs a warning on `index > meta` cross-file skew (a crash between the two atomic_writes). `query()` skips orphan faiss hits so callers never see `{"id": None, ...}`. **Auto-repair of the on-disk skew is out of scope and left to a follow-up PR** (semantics decision: truncate index vs rebuild meta).

## Behavior notes

- **`query()` and `client_storage` see only flushed (materialized) data** — unflushed pending upserts are intentionally not searchable / visible. Same contract as Nano; matches the OpenSearch implementation.
- A flush failure now **raises** through `_insert_done` instead of silently logging — same lift in failure visibility as PR #3145 made for Nano.
- The `_PendingFaissDoc.vector` invariant (always normalized after the first time it is set) ensures the flush never re-normalizes a vector that `get_vectors_by_ids` has already cached.

## Test plan

- [x] New `tests/kg/faiss_impl/test_faiss_deferred_embedding.py`:
  - **14 tests** ported from the Nano deferred-embedding suite: no embed on upsert; embed on `index_done_callback`; same-id coalesced; `get_vectors_by_ids` lazy embed + flush reuse; re-upsert clears cached vector; delete cancels pending + removes materialized; stale-client reload paths for `upsert` / `delete` / `finalize`; read-your-writes + query-after-flush; `delete_entity_relation` cancels pending; embed-failure raises + preserves pending; `drop` discards pending; `finalize` retries save after flush failure.
  - **6 Faiss-specific tests**: `reupsert_after_flush_replaces_single_fid`, `index_done_callback_save_failure_raises`, `reload_warns_on_index_meta_skew`, `query_skips_orphan_faiss_hits`, `reupsert_cleans_duplicate_custom_id_rows`, `delete_propagates_errors`.
  - Every state-mutating test asserts `_index.ntotal == len(_id_to_meta)` via the local `_assert_consistent` helper — Faiss's root failure mode is the two structures diverging, so single-side assertions aren't enough.
- [x] `./scripts/test.sh tests/kg/faiss_impl` → **26 passed** (20 new + 6 existing `test_atomic_write_faiss` / `test_faiss_meta_inconsistency`).
- [x] `./scripts/test.sh tests/kg/nano_impl` → 17 passed (no cross-backend regression).
- [x] `ruff check lightrag/kg/faiss_impl.py tests/kg/faiss_impl/test_faiss_deferred_embedding.py` clean.

---
_Generated by [Claude Code](https://claude.ai/code)_