### PR TITLE
🐛 fix(operate): correct final_data key path in debug log

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -4825,8 +4825,9 @@ async def _build_context_str(
         entity_id_to_original,
         relation_id_to_original,
     )
+    final_data_payload = final_data.get("data", {})
     logger.debug(
-        f"[_build_context_str] Final data after conversion: {len(final_data.get('entities', []))} entities, {len(final_data.get('relationships', []))} relationships, {len(final_data.get('chunks', []))} chunks"
+        f"[_build_context_str] Final data after conversion: {len(final_data_payload.get('entities', []))} entities, {len(final_data_payload.get('relationships', []))} relationships, {len(final_data_payload.get('chunks', []))} chunks"
     )
     return result, final_data
 


### PR DESCRIPTION
## Description

The debug log at the end of `_build_context_str` was reading entity / relationship / chunk counts directly off the top-level `final_data` dict, but `convert_to_user_format` nests those lists under a `data` key. As a result the log always reported `0 entities, 0 relationships, 0 chunks`, regardless of the actual payload.

## Changes Made

- `lightrag/operate.py`: pull `final_data["data"]` once into `final_data_payload`, then read `entities`/`relationships`/`chunks` from it for the debug log.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

Debug-log-only change; runtime behavior of the returned `final_data` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)