### PR TITLE
perf(qdrant): defer vector embedding until flush

### DIFF
--- a/lightrag/kg/qdrant_impl.py
+++ b/lightrag/kg/qdrant_impl.py
@@ -690,6 +690,15 @@ class QdrantVectorDBStorage(BaseVectorStorage):
     async def query(
         self, query: str, top_k: int, query_embedding: list[float] = None
     ) -> list[dict[str, Any]]:
+        """Query the vector database via Qdrant ``query_points``.
+
+        Reads from the server-side index only; buffered upserts and deletes
+        are NOT visible until ``index_done_callback`` / ``finalize`` flushes
+        them. Callers that need read-your-writes for a freshly upserted id
+        should use ``get_by_id`` / ``get_by_ids`` (which consult the buffer)
+        or flush first. Matches the deferred-embedding contract used by the
+        other lazy-embedding backends (Mongo / OpenSearch / FAISS / Nano).
+        """
         if query_embedding is not None:
             embedding = query_embedding
         else:
@@ -731,6 +740,11 @@ class QdrantVectorDBStorage(BaseVectorStorage):
         ``_build_upsert_batches`` to respect Qdrant's payload size limit.
         Any failure (embed or server write) raises and leaves both
         buffers intact; the next ``index_done_callback`` retries.
+
+        Concurrency invariant: ``_flush_lock`` is a non-reentrant asyncio
+        lock. Callers MUST NOT hold it when invoking this method --
+        re-entry would deadlock. The only in-tree callers are
+        ``index_done_callback`` and ``finalize``, both lock-free.
         """
         async with self._flush_lock:
             if not self._pending_vector_docs and not self._pending_vector_deletes:
@@ -781,7 +795,7 @@ class QdrantVectorDBStorage(BaseVectorStorage):
                 ):
                     # Cache the raw numpy row so a second flush after a
                     # server-side error doesn't re-embed.
-                    pdoc.vector = embedding.tolist()
+                    pdoc.vector = np.array(embedding, dtype=np.float32).tolist()
                     await _cooperative_yield(i)
 
             # Build PointStruct list, converting caller-supplied ids to
@@ -1064,6 +1078,16 @@ class QdrantVectorDBStorage(BaseVectorStorage):
         Pending docs whose vector hasn't been embedded yet are embedded
         lazily inside the lock; the resulting vector is cached on the
         buffered ``_PendingVectorDoc`` so the next flush won't re-embed.
+
+        Visibility caveat for ids not in the buffer: the server-side
+        ``retrieve`` fallback runs *outside* ``_flush_lock``. A concurrent
+        ``delete()`` that lands between lock release and the server read
+        only buffers the delete -- the old vector is still on disk
+        until the next flush, so this method may return a stale vector
+        for an id that has been buffered for deletion. This is
+        best-effort read-after-uncommitted-delete and matches the
+        ``query()`` contract: callers needing strict consistency must
+        ``index_done_callback()`` first.
         """
         if not ids:
             return {}
@@ -1111,7 +1135,7 @@ class QdrantVectorDBStorage(BaseVectorStorage):
                 for i, ((doc_id, pdoc), embedding) in enumerate(
                     zip(docs_to_embed, embeddings), start=1
                 ):
-                    pdoc.vector = embedding.tolist()
+                    pdoc.vector = np.array(embedding, dtype=np.float32).tolist()
                     result[doc_id] = pdoc.vector
                     await _cooperative_yield(i)
 
@@ -1154,19 +1178,31 @@ class QdrantVectorDBStorage(BaseVectorStorage):
         on GC), but we still need to fail loudly when a transient bulk
         error left writes buffered. ``_flush_pending_vector_ops`` is
         all-or-nothing: it either clears both buffers or raises with
-        them intact, so we only need to handle the raise path.
+        them intact, but we still defensively check both buffers after a
+        successful flush in case a future refactor breaks that invariant.
         """
+        flush_error: Exception | None = None
         try:
             await self._flush_pending_vector_ops()
         except Exception as e:
-            async with self._flush_lock:
-                pending_docs = len(self._pending_vector_docs)
-                pending_deletes = len(self._pending_vector_deletes)
+            flush_error = e
+
+        async with self._flush_lock:
+            pending_docs = len(self._pending_vector_docs)
+            pending_deletes = len(self._pending_vector_deletes)
+
+        if flush_error is not None:
             raise RuntimeError(
                 f"[{self.workspace}] QdrantVectorDBStorage.finalize() flush raised; "
                 f"{pending_docs} pending upserts and {pending_deletes} pending "
                 f"deletes were left buffered (data lost)"
-            ) from e
+            ) from flush_error
+        if pending_docs or pending_deletes:
+            raise RuntimeError(
+                f"[{self.workspace}] QdrantVectorDBStorage.finalize() left "
+                f"{pending_docs} pending upserts and {pending_deletes} pending "
+                f"deletes buffered after final flush attempt (these writes have been lost)"
+            )
 
     async def drop(self) -> dict[str, str]:
         """Drop all vector data for the current workspace. Destructive.

--- a/lightrag/kg/qdrant_impl.py
+++ b/lightrag/kg/qdrant_impl.py
@@ -1016,9 +1016,7 @@ class QdrantVectorDBStorage(BaseVectorStorage):
         if remaining:
             try:
                 qdrant_ids = [
-                    compute_mdhash_id_for_qdrant(
-                        id, prefix=self.effective_workspace
-                    )
+                    compute_mdhash_id_for_qdrant(id, prefix=self.effective_workspace)
                     for id in remaining
                 ]
                 results = self._client.retrieve(
@@ -1154,34 +1152,33 @@ class QdrantVectorDBStorage(BaseVectorStorage):
         Qdrant has no client connection that needs explicit release here
         (the QdrantClient is held by the storage instance and torn down
         on GC), but we still need to fail loudly when a transient bulk
-        error left writes buffered.
+        error left writes buffered. ``_flush_pending_vector_ops`` is
+        all-or-nothing: it either clears both buffers or raises with
+        them intact, so we only need to handle the raise path.
         """
-        flush_error: Exception | None = None
         try:
             await self._flush_pending_vector_ops()
         except Exception as e:
-            flush_error = e
-
-        pending_docs = len(self._pending_vector_docs)
-        pending_deletes = len(self._pending_vector_deletes)
-
-        if flush_error is not None:
+            async with self._flush_lock:
+                pending_docs = len(self._pending_vector_docs)
+                pending_deletes = len(self._pending_vector_deletes)
             raise RuntimeError(
                 f"[{self.workspace}] QdrantVectorDBStorage.finalize() flush raised; "
                 f"{pending_docs} pending upserts and {pending_deletes} pending "
                 f"deletes were left buffered (data lost)"
-            ) from flush_error
-        if pending_docs or pending_deletes:
-            raise RuntimeError(
-                f"[{self.workspace}] QdrantVectorDBStorage.finalize() left "
-                f"{pending_docs} pending upserts and {pending_deletes} pending "
-                f"deletes buffered after final flush attempt (these writes have been lost)"
-            )
+            ) from e
 
     async def drop(self) -> dict[str, str]:
-        """Drop all vector data from storage and clean up resources
+        """Drop all vector data from storage and clean up resources.
 
-        This method will delete all data for the current workspace from the Qdrant collection.
+        This method deletes all data for the current workspace from the
+        Qdrant collection. The pending-write buffers are cleared *before*
+        the server-side delete is issued so a concurrent flush cannot
+        resurrect the dropped data. This means that if the server-side
+        delete fails, the buffered writes are also lost — the caller
+        cannot recover them by retrying ``drop()``. This is consistent
+        with ``drop()``'s contract ("discard everything for this
+        workspace") and matches the other lazy-embedding backends.
 
         Returns:
             dict[str, str]: Operation status and message
@@ -1200,9 +1197,7 @@ class QdrantVectorDBStorage(BaseVectorStorage):
                     collection_name=self.final_namespace,
                     points_selector=models.FilterSelector(
                         filter=models.Filter(
-                            must=[
-                                workspace_filter_condition(self.effective_workspace)
-                            ]
+                            must=[workspace_filter_condition(self.effective_workspace)]
                         )
                     ),
                     wait=True,

--- a/lightrag/kg/qdrant_impl.py
+++ b/lightrag/kg/qdrant_impl.py
@@ -1169,21 +1169,40 @@ class QdrantVectorDBStorage(BaseVectorStorage):
             ) from e
 
     async def drop(self) -> dict[str, str]:
-        """Drop all vector data from storage and clean up resources.
+        """Drop all vector data for the current workspace. Destructive.
 
-        This method deletes all data for the current workspace from the
-        Qdrant collection. The pending-write buffers are cleared *before*
-        the server-side delete is issued so a concurrent flush cannot
-        resurrect the dropped data. This means that if the server-side
-        delete fails, the buffered writes are also lost — the caller
-        cannot recover them by retrying ``drop()``. This is consistent
-        with ``drop()``'s contract ("discard everything for this
-        workspace") and matches the other lazy-embedding backends.
+        Deletes every point matching ``effective_workspace`` from the
+        shared Qdrant collection ``final_namespace`` (Qdrant partitions a
+        single physical collection across workspaces via the
+        ``workspace_id`` payload field, so sibling workspaces on the same
+        collection are untouched). The collection itself and its vector
+        index are NOT recreated — they were provisioned at
+        ``initialize()`` and remain in place.
+
+        MUST only be called when ``pipeline_status`` is idle (see the
+        Pipeline concurrency contract in ``AGENTS.md``); the only
+        in-tree caller ``clear_documents`` enforces this.
+
+        Pending-write buffers are cleared *before* the server-side delete
+        is issued so a concurrent flush on this instance cannot resurrect
+        the dropped data. As a consequence, if the server-side delete
+        fails, the buffered writes are also lost — the caller cannot
+        recover them by retrying ``drop()``. This matches ``drop()``'s
+        contract ("discard everything for this workspace") and the other
+        lazy-embedding backends.
+
+        Caveat — only this instance's buffers are cleared. Other
+        ``QdrantVectorDBStorage`` instances aliased onto the same
+        ``(final_namespace, effective_workspace)`` (multi-worker
+        processes, or distinct workspaces collapsed by
+        ``QDRANT_WORKSPACE``) keep their own buffers; a sibling whose
+        prior flush failed and left buffers intact will, on its next
+        flush, upsert those stale points back into the freshly emptied
+        workspace. Direct callers bypassing the idle precondition MUST
+        flush every aliased instance first.
 
         Returns:
-            dict[str, str]: Operation status and message
-            - On success: {"status": "success", "message": "data dropped"}
-            - On failure: {"status": "error", "message": "<error details>"}
+            dict[str, str]: ``{"status": "success"|"error", "message": str}``
         """
         try:
             async with self._flush_lock:

--- a/lightrag/kg/qdrant_impl.py
+++ b/lightrag/kg/qdrant_impl.py
@@ -12,13 +12,23 @@ import pipmaster as pm
 
 from ..base import BaseVectorStorage
 from ..exceptions import DataMigrationError
-from ..kg.shared_storage import get_data_init_lock
-from ..utils import compute_mdhash_id, logger
+from ..kg.shared_storage import get_data_init_lock, get_namespace_lock
+from ..utils import _cooperative_yield, compute_mdhash_id, logger
 
 if not pm.is_installed("qdrant-client"):
     pm.install("qdrant-client")
 
 from qdrant_client import QdrantClient, models  # type: ignore
+
+
+@dataclass
+class _PendingVectorDoc:
+    """Buffered vector upsert waiting for embedding and/or bulk flush."""
+
+    source: dict[str, Any]
+    content: str
+    vector: list[float] | None = None
+
 
 DEFAULT_WORKSPACE = "_"
 WORKSPACE_ID_FIELD = "workspace_id"
@@ -485,6 +495,15 @@ class QdrantVectorDBStorage(BaseVectorStorage):
             )
         self._initialized = False
 
+        # Deferred-embedding buffers and the per-namespace flush lock.
+        # Qdrant partitions a single physical collection across workspaces
+        # via the workspace_id payload field, so the lock must include the
+        # effective workspace (not just final_namespace) to avoid letting
+        # two effectively-different writers race on the same collection.
+        self._pending_vector_docs: dict[str, _PendingVectorDoc] = {}
+        self._pending_vector_deletes: set[str] = set()
+        self._flush_lock = None
+
     @staticmethod
     def _to_json_serializable(value: Any) -> Any:
         """Convert nested values to JSON-serializable types for payload size estimation."""
@@ -623,8 +642,20 @@ class QdrantVectorDBStorage(BaseVectorStorage):
                 )
                 raise
 
+        if self._flush_lock is None:
+            self._flush_lock = get_namespace_lock(
+                namespace=self.final_namespace,
+                workspace=self.effective_workspace,
+            )
+
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
-        logger.debug(f"[{self.workspace}] Inserting {len(data)} to {self.namespace}")
+        """Buffer vector docs for embedding and batched flush.
+
+        Embedding deliberately does NOT happen here: repeated upserts of
+        the same id, or many small batches, collapse into a single
+        flush-time embedding pass. The buffer is keyed by the caller's
+        original doc id; the Qdrant UUID conversion runs at flush time.
+        """
         if not data:
             return
 
@@ -632,67 +663,29 @@ class QdrantVectorDBStorage(BaseVectorStorage):
 
         current_time = int(time.time())
 
-        list_data = [
-            {
+        pending_docs: list[tuple[str, _PendingVectorDoc]] = []
+        for i, (k, v) in enumerate(data.items(), start=1):
+            source = {
                 ID_FIELD: k,
                 WORKSPACE_ID_FIELD: self.effective_workspace,
                 CREATED_AT_FIELD: current_time,
                 **{k1: v1 for k1, v1 in v.items() if k1 in self.meta_fields},
             }
-            for k, v in data.items()
-        ]
-        contents = [v["content"] for v in data.values()]
-        batches = [
-            contents[i : i + self._max_batch_size]
-            for i in range(0, len(contents), self._max_batch_size)
-        ]
-
-        embedding_tasks = [
-            self.embedding_func(batch, context="document") for batch in batches
-        ]
-        embeddings_list = await asyncio.gather(*embedding_tasks)
-
-        embeddings = np.concatenate(embeddings_list)
-
-        list_points = []
-        for i, d in enumerate(list_data):
-            list_points.append(
-                models.PointStruct(
-                    id=compute_mdhash_id_for_qdrant(
-                        d[ID_FIELD], prefix=self.effective_workspace
-                    ),
-                    vector=embeddings[i],
-                    payload=d,
+            pending_docs.append(
+                (
+                    k,
+                    _PendingVectorDoc(source=source, content=v["content"]),
                 )
             )
+            await _cooperative_yield(i)
 
-        point_batches = self._build_upsert_batches(
-            list_points,
-            max_payload_bytes=self._max_upsert_payload_bytes,
-            max_points_per_batch=self._max_upsert_points_per_batch,
-        )
-
-        if len(point_batches) > 1:
-            logger.info(
-                f"[{self.workspace}] Qdrant upsert split into {len(point_batches)} batches "
-                f"for {len(list_points)} points (max_payload_bytes={self._max_upsert_payload_bytes}, "
-                f"max_points_per_batch={self._max_upsert_points_per_batch})"
-            )
-
-        results = None
-        for batch_index, (points_batch, estimated_bytes) in enumerate(point_batches, 1):
-            logger.debug(
-                f"[{self.workspace}] Qdrant upsert batch {batch_index}/{len(point_batches)}: "
-                f"points={len(points_batch)}, estimated_payload_bytes={estimated_bytes}"
-            )
-            # Fail-fast: any batch failure raises immediately and stops subsequent batches.
-            results = self._client.upsert(
-                collection_name=self.final_namespace,
-                points=points_batch,
-                wait=True,
-            )
-
-        return results
+        # An upsert overrides any pending delete on the same id; installing
+        # a fresh _PendingVectorDoc invalidates any vector cached by a
+        # prior get_vectors_by_ids() call on a stale revision.
+        async with self._flush_lock:
+            for doc_id, pdoc in pending_docs:
+                self._pending_vector_deletes.discard(doc_id)
+                self._pending_vector_docs[doc_id] = pdoc
 
     async def query(
         self, query: str, top_k: int, query_embedding: list[float] = None
@@ -726,95 +719,188 @@ class QdrantVectorDBStorage(BaseVectorStorage):
         ]
 
     async def index_done_callback(self) -> None:
-        # Qdrant handles persistence automatically
-        pass
+        """Flush buffered vector ops; Qdrant persists automatically once written."""
+        await self._flush_pending_vector_ops()
 
-    async def delete(self, ids: List[str]) -> None:
-        """Delete vectors with specified IDs
+    async def _flush_pending_vector_ops(self) -> None:
+        """Flush buffered vector upserts and deletes via batched client calls.
 
-        Args:
-            ids: List of vector IDs to be deleted
+        Embedding runs *inside* this lock (not in `upsert` or lock-free):
+        it makes deferred embedding and the upsert atomic against
+        concurrent upserts and destructive mutations. Reuses
+        ``_build_upsert_batches`` to respect Qdrant's payload size limit.
+        Any failure (embed or server write) raises and leaves both
+        buffers intact; the next ``index_done_callback`` retries.
         """
-        try:
-            if not ids:
+        async with self._flush_lock:
+            if not self._pending_vector_docs and not self._pending_vector_deletes:
+                return
+            if self._client is None:
                 return
 
-            # Convert regular ids to Qdrant compatible ids
-            qdrant_ids = [
-                compute_mdhash_id_for_qdrant(id, prefix=self.effective_workspace)
-                for id in ids
+            pending_docs = self._pending_vector_docs
+            pending_deletes = self._pending_vector_deletes
+
+            docs_to_embed: list[tuple[str, _PendingVectorDoc]] = [
+                (doc_id, pdoc)
+                for doc_id, pdoc in pending_docs.items()
+                if pdoc.vector is None
             ]
-            # Delete points from the collection with workspace filtering
-            self._client.delete(
-                collection_name=self.final_namespace,
-                points_selector=models.PointIdsList(points=qdrant_ids),
-                wait=True,
-            )
-            logger.debug(
-                f"[{self.workspace}] Successfully deleted {len(ids)} vectors from {self.namespace}"
-            )
-        except Exception as e:
-            logger.error(
-                f"[{self.workspace}] Error while deleting vectors from {self.namespace}: {e}"
-            )
+
+            if docs_to_embed:
+                contents = [pdoc.content for _, pdoc in docs_to_embed]
+                batches = [
+                    contents[i : i + self._max_batch_size]
+                    for i in range(0, len(contents), self._max_batch_size)
+                ]
+                logger.info(
+                    f"[{self.workspace}] {self.namespace} flush: embedding "
+                    f"{len(docs_to_embed)} vectors in {len(batches)} batch(es)"
+                )
+                try:
+                    embeddings_list = await asyncio.gather(
+                        *[
+                            self.embedding_func(batch, context="document")
+                            for batch in batches
+                        ]
+                    )
+                except Exception as e:
+                    logger.error(
+                        f"[{self.workspace}] Error embedding pending vectors for {self.namespace}: {e}"
+                    )
+                    raise
+
+                embeddings = np.concatenate(embeddings_list)
+                if len(embeddings) != len(docs_to_embed):
+                    raise RuntimeError(
+                        f"[{self.workspace}] Embedding count mismatch in {self.namespace}: "
+                        f"expected {len(docs_to_embed)}, got {len(embeddings)}"
+                    )
+                for i, ((_, pdoc), embedding) in enumerate(
+                    zip(docs_to_embed, embeddings), start=1
+                ):
+                    # Cache the raw numpy row so a second flush after a
+                    # server-side error doesn't re-embed.
+                    pdoc.vector = embedding.tolist()
+                    await _cooperative_yield(i)
+
+            # Build PointStruct list, converting caller-supplied ids to
+            # Qdrant UUIDs only now (the buffer keeps caller ids so
+            # read-your-writes works against the same key).
+            list_points: list[models.PointStruct] = []
+            committed_ids: list[str] = []
+            for doc_id, pdoc in pending_docs.items():
+                if pdoc.vector is None:
+                    continue
+                committed_ids.append(doc_id)
+                list_points.append(
+                    models.PointStruct(
+                        id=compute_mdhash_id_for_qdrant(
+                            doc_id, prefix=self.effective_workspace
+                        ),
+                        vector=pdoc.vector,
+                        payload=dict(pdoc.source),
+                    )
+                )
+
+            try:
+                if list_points:
+                    point_batches = self._build_upsert_batches(
+                        list_points,
+                        max_payload_bytes=self._max_upsert_payload_bytes,
+                        max_points_per_batch=self._max_upsert_points_per_batch,
+                    )
+
+                    if len(point_batches) > 1:
+                        logger.info(
+                            f"[{self.workspace}] Qdrant upsert split into {len(point_batches)} batches "
+                            f"for {len(list_points)} points (max_payload_bytes={self._max_upsert_payload_bytes}, "
+                            f"max_points_per_batch={self._max_upsert_points_per_batch})"
+                        )
+
+                    for batch_index, (points_batch, estimated_bytes) in enumerate(
+                        point_batches, 1
+                    ):
+                        logger.debug(
+                            f"[{self.workspace}] Qdrant upsert batch {batch_index}/{len(point_batches)}: "
+                            f"points={len(points_batch)}, estimated_payload_bytes={estimated_bytes}"
+                        )
+                        # Fail-fast: any batch failure raises immediately
+                        # and stops subsequent batches; the full buffer is
+                        # retained so the next flush retries.
+                        self._client.upsert(
+                            collection_name=self.final_namespace,
+                            points=points_batch,
+                            wait=True,
+                        )
+
+                if pending_deletes:
+                    qdrant_delete_ids = [
+                        compute_mdhash_id_for_qdrant(
+                            doc_id, prefix=self.effective_workspace
+                        )
+                        for doc_id in pending_deletes
+                    ]
+                    self._client.delete(
+                        collection_name=self.final_namespace,
+                        points_selector=models.PointIdsList(points=qdrant_delete_ids),
+                        wait=True,
+                    )
+            except Exception as e:
+                logger.error(
+                    f"[{self.workspace}] Error flushing vector ops for {self.namespace}: {e}"
+                )
+                raise
+
+            for doc_id in committed_ids:
+                pending_docs.pop(doc_id, None)
+            pending_deletes.clear()
+
+    async def delete(self, ids: List[str]) -> None:
+        """Buffer vector deletes for batched flush."""
+        if not ids:
+            return
+        if isinstance(ids, set):
+            ids = list(ids)
+        async with self._flush_lock:
+            for doc_id in ids:
+                self._pending_vector_docs.pop(doc_id, None)
+                self._pending_vector_deletes.add(doc_id)
+        logger.debug(
+            f"[{self.workspace}] Buffered delete for {len(ids)} vectors in {self.namespace}"
+        )
 
     async def delete_entity(self, entity_name: str) -> None:
-        """Delete an entity by name
-
-        Args:
-            entity_name: Name of the entity to delete
-        """
-        try:
-            # Compute entity ID from name (same as Milvus)
-            entity_id = compute_mdhash_id(entity_name, prefix=ENTITY_PREFIX)
-            logger.debug(
-                f"[{self.workspace}] Attempting to delete entity {entity_name} with ID {entity_id}"
-            )
-
-            # Scroll to find the entity by its ID field in payload with workspace filtering
-            # This is safer than reconstructing the Qdrant point ID
-            results = self._client.scroll(
-                collection_name=self.final_namespace,
-                scroll_filter=models.Filter(
-                    must=[
-                        workspace_filter_condition(self.effective_workspace),
-                        models.FieldCondition(
-                            key=ID_FIELD, match=models.MatchValue(value=entity_id)
-                        ),
-                    ]
-                ),
-                with_payload=False,
-                limit=1,
-            )
-
-            # Extract point IDs to delete
-            points = results[0]
-            if points:
-                ids_to_delete = [point.id for point in points]
-                self._client.delete(
-                    collection_name=self.final_namespace,
-                    points_selector=models.PointIdsList(points=ids_to_delete),
-                    wait=True,
-                )
-                logger.debug(
-                    f"[{self.workspace}] Successfully deleted entity {entity_name}"
-                )
-            else:
-                logger.debug(
-                    f"[{self.workspace}] Entity {entity_name} not found in storage"
-                )
-        except Exception as e:
-            logger.error(f"[{self.workspace}] Error deleting entity {entity_name}: {e}")
+        """Buffer an entity vector delete by computing its hash ID."""
+        entity_id = compute_mdhash_id(entity_name, prefix=ENTITY_PREFIX)
+        async with self._flush_lock:
+            self._pending_vector_docs.pop(entity_id, None)
+            self._pending_vector_deletes.add(entity_id)
+        logger.debug(
+            f"[{self.workspace}] Buffered delete for entity {entity_name} (id={entity_id})"
+        )
 
     async def delete_entity_relation(self, entity_name: str) -> None:
-        """Delete all relations associated with an entity
+        """Delete all relation vectors where entity appears as src or tgt.
 
-        Args:
-            entity_name: Name of the entity whose relations should be deleted
+        The whole method runs under ``_flush_lock`` so the server-side
+        scroll + delete cannot interleave with an in-flight bulk upsert.
+        Server-side failures are re-raised (no log-and-swallow): the
+        caller decides whether to retry.
         """
-        try:
-            # Build the filter to find relations where entity is either source or target
-            # must + should = workspace_id matches AND (src_id matches OR tgt_id matches)
+        async with self._flush_lock:
+            # Prune matching docs from the pending upsert buffer.
+            for doc_id in [
+                k
+                for k, v in self._pending_vector_docs.items()
+                if v.source.get("src_id") == entity_name
+                or v.source.get("tgt_id") == entity_name
+            ]:
+                self._pending_vector_docs.pop(doc_id, None)
+
+            if self._client is None:
+                return
+
             relation_filter = models.Filter(
                 must=[workspace_filter_condition(self.effective_workspace)],
                 should=[
@@ -827,14 +913,11 @@ class QdrantVectorDBStorage(BaseVectorStorage):
                 ],
             )
 
-            # Paginate through all matching relations to handle large datasets
             total_deleted = 0
             offset = None
             batch_size = 1000
 
             while True:
-                # Scroll to find relations, using with_payload=False for efficiency
-                # since we only need point IDs for deletion
                 results = self._client.scroll(
                     collection_name=self.final_namespace,
                     scroll_filter=relation_filter,
@@ -848,10 +931,7 @@ class QdrantVectorDBStorage(BaseVectorStorage):
                 if not points:
                     break
 
-                # Extract point IDs to delete
                 ids_to_delete = [point.id for point in points]
-
-                # Delete the batch of relations
                 self._client.delete(
                     collection_name=self.final_namespace,
                     points_selector=models.PointIdsList(points=ids_to_delete),
@@ -859,7 +939,6 @@ class QdrantVectorDBStorage(BaseVectorStorage):
                 )
                 total_deleted += len(ids_to_delete)
 
-                # Check if we've reached the end
                 if next_offset is None:
                     break
                 offset = next_offset
@@ -872,27 +951,25 @@ class QdrantVectorDBStorage(BaseVectorStorage):
                 logger.debug(
                     f"[{self.workspace}] No relations found for entity {entity_name}"
                 )
-        except Exception as e:
-            logger.error(
-                f"[{self.workspace}] Error deleting relations for {entity_name}: {e}"
-            )
 
     async def get_by_id(self, id: str) -> dict[str, Any] | None:
-        """Get vector data by its ID
+        """Get vector data by its ID, with read-your-writes against the buffer."""
+        async with self._flush_lock:
+            if id in self._pending_vector_deletes:
+                return None
+            pending = self._pending_vector_docs.get(id)
+            if pending is not None:
+                # Buffer hits return the source payload (no vector); the
+                # Qdrant fallback path also returns just the payload.
+                payload = dict(pending.source)
+                payload.setdefault(CREATED_AT_FIELD, None)
+                return payload
 
-        Args:
-            id: The unique identifier of the vector
-
-        Returns:
-            The vector data if found, or None if not found
-        """
         try:
-            # Convert to Qdrant compatible ID
             qdrant_id = compute_mdhash_id_for_qdrant(
                 id, prefix=self.effective_workspace
             )
 
-            # Retrieve the point by ID with workspace filtering
             result = self._client.retrieve(
                 collection_name=self.final_namespace,
                 ids=[qdrant_id],
@@ -914,108 +991,192 @@ class QdrantVectorDBStorage(BaseVectorStorage):
             return None
 
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
-        """Get multiple vector data by their IDs
-
-        Args:
-            ids: List of unique identifiers
-
-        Returns:
-            List of vector data objects that were found
-        """
+        """Get multiple vector data by their IDs (read-your-writes), preserving order."""
         if not ids:
             return []
 
-        try:
-            # Convert to Qdrant compatible IDs
-            qdrant_ids = [
-                compute_mdhash_id_for_qdrant(id, prefix=self.effective_workspace)
-                for id in ids
-            ]
+        buffered: dict[str, dict[str, Any] | None] = {}
+        remaining: list[str] = []
+        async with self._flush_lock:
+            for doc_id in ids:
+                if doc_id in self._pending_vector_deletes:
+                    buffered[doc_id] = None
+                    continue
+                pending = self._pending_vector_docs.get(doc_id)
+                if pending is not None:
+                    payload = dict(pending.source)
+                    payload.setdefault(CREATED_AT_FIELD, None)
+                    buffered[doc_id] = payload
+                    continue
+                remaining.append(doc_id)
 
-            # Retrieve the points by IDs
-            results = self._client.retrieve(
-                collection_name=self.final_namespace,
-                ids=qdrant_ids,
-                with_payload=True,
-            )
+        payload_by_original_id: dict[str, dict[str, Any]] = {}
+        payload_by_qdrant_id: dict[str, dict[str, Any]] = {}
 
-            # Ensure each result contains created_at field and preserve caller ordering
-            payload_by_original_id: dict[str, dict[str, Any]] = {}
-            payload_by_qdrant_id: dict[str, dict[str, Any]] = {}
+        if remaining:
+            try:
+                qdrant_ids = [
+                    compute_mdhash_id_for_qdrant(
+                        id, prefix=self.effective_workspace
+                    )
+                    for id in remaining
+                ]
+                results = self._client.retrieve(
+                    collection_name=self.final_namespace,
+                    ids=qdrant_ids,
+                    with_payload=True,
+                )
 
-            for point in results:
-                payload = dict(point.payload or {})
-                if CREATED_AT_FIELD not in payload:
-                    payload[CREATED_AT_FIELD] = None
+                for point in results:
+                    payload = dict(point.payload or {})
+                    if CREATED_AT_FIELD not in payload:
+                        payload[CREATED_AT_FIELD] = None
 
-                qdrant_point_id = str(point.id) if point.id is not None else ""
-                if qdrant_point_id:
-                    payload_by_qdrant_id[qdrant_point_id] = payload
+                    qdrant_point_id = str(point.id) if point.id is not None else ""
+                    if qdrant_point_id:
+                        payload_by_qdrant_id[qdrant_point_id] = payload
 
-                original_id = payload.get(ID_FIELD)
-                if original_id is not None:
-                    payload_by_original_id[str(original_id)] = payload
+                    original_id = payload.get(ID_FIELD)
+                    if original_id is not None:
+                        payload_by_original_id[str(original_id)] = payload
+            except Exception as e:
+                logger.error(
+                    f"[{self.workspace}] Error retrieving vector data for IDs {remaining}: {e}"
+                )
+                return []
 
-            ordered_payloads: list[dict[str, Any] | None] = []
-            for requested_id, qdrant_id in zip(ids, qdrant_ids):
-                payload = payload_by_original_id.get(str(requested_id))
-                if payload is None:
-                    payload = payload_by_qdrant_id.get(str(qdrant_id))
-                ordered_payloads.append(payload)
-
-            return ordered_payloads
-        except Exception as e:
-            logger.error(
-                f"[{self.workspace}] Error retrieving vector data for IDs {ids}: {e}"
-            )
-            return []
+        ordered_payloads: list[dict[str, Any] | None] = []
+        for doc_id in ids:
+            if doc_id in buffered:
+                ordered_payloads.append(buffered[doc_id])
+                continue
+            payload = payload_by_original_id.get(str(doc_id))
+            if payload is None:
+                payload = payload_by_qdrant_id.get(
+                    compute_mdhash_id_for_qdrant(
+                        doc_id, prefix=self.effective_workspace
+                    )
+                )
+            ordered_payloads.append(payload)
+        return ordered_payloads
 
     async def get_vectors_by_ids(self, ids: list[str]) -> dict[str, list[float]]:
-        """Get vectors by their IDs, returning only ID and vector data for efficiency
+        """Get vector embeddings for given IDs, with read-your-writes.
 
-        Args:
-            ids: List of unique identifiers
-
-        Returns:
-            Dictionary mapping IDs to their vector embeddings
-            Format: {id: [vector_values], ...}
+        Pending docs whose vector hasn't been embedded yet are embedded
+        lazily inside the lock; the resulting vector is cached on the
+        buffered ``_PendingVectorDoc`` so the next flush won't re-embed.
         """
         if not ids:
             return {}
 
+        result: dict[str, list[float]] = {}
+        remaining: list[str] = []
+        async with self._flush_lock:
+            docs_to_embed: list[tuple[str, _PendingVectorDoc]] = []
+            for doc_id in ids:
+                if doc_id in self._pending_vector_deletes:
+                    continue
+                pending = self._pending_vector_docs.get(doc_id)
+                if pending is not None:
+                    if pending.vector is None:
+                        docs_to_embed.append((doc_id, pending))
+                    else:
+                        result[doc_id] = pending.vector
+                    continue
+                remaining.append(doc_id)
+
+            if docs_to_embed:
+                contents = [pdoc.content for _, pdoc in docs_to_embed]
+                batches = [
+                    contents[i : i + self._max_batch_size]
+                    for i in range(0, len(contents), self._max_batch_size)
+                ]
+                try:
+                    embeddings_list = await asyncio.gather(
+                        *[
+                            self.embedding_func(batch, context="document")
+                            for batch in batches
+                        ]
+                    )
+                except Exception as e:
+                    logger.error(
+                        f"[{self.workspace}] Error lazily embedding pending vectors: {e}"
+                    )
+                    raise
+                embeddings = np.concatenate(embeddings_list)
+                if len(embeddings) != len(docs_to_embed):
+                    raise RuntimeError(
+                        f"[{self.workspace}] Embedding count mismatch in lazy embed: "
+                        f"expected {len(docs_to_embed)}, got {len(embeddings)}"
+                    )
+                for i, ((doc_id, pdoc), embedding) in enumerate(
+                    zip(docs_to_embed, embeddings), start=1
+                ):
+                    pdoc.vector = embedding.tolist()
+                    result[doc_id] = pdoc.vector
+                    await _cooperative_yield(i)
+
+        if not remaining:
+            return result
+
         try:
-            # Convert to Qdrant compatible IDs
             qdrant_ids = [
                 compute_mdhash_id_for_qdrant(id, prefix=self.effective_workspace)
-                for id in ids
+                for id in remaining
             ]
-
-            # Retrieve the points by IDs with vectors
             results = self._client.retrieve(
                 collection_name=self.final_namespace,
                 ids=qdrant_ids,
-                with_vectors=True,  # Important: request vectors
+                with_vectors=True,
                 with_payload=True,
             )
 
-            vectors_dict = {}
             for point in results:
                 if point and point.vector is not None and point.payload:
-                    # Get original ID from payload
                     original_id = point.payload.get(ID_FIELD)
                     if original_id:
-                        # Convert numpy array to list if needed
                         vector_data = point.vector
                         if isinstance(vector_data, np.ndarray):
                             vector_data = vector_data.tolist()
-                        vectors_dict[original_id] = vector_data
+                        result[original_id] = vector_data
 
-            return vectors_dict
+            return result
         except Exception as e:
             logger.error(
                 f"[{self.workspace}] Error retrieving vectors by IDs from {self.namespace}: {e}"
             )
-            return {}
+            return result
+
+    async def finalize(self):
+        """Flush pending vector ops; surface unflushed data as RuntimeError.
+
+        Qdrant has no client connection that needs explicit release here
+        (the QdrantClient is held by the storage instance and torn down
+        on GC), but we still need to fail loudly when a transient bulk
+        error left writes buffered.
+        """
+        flush_error: Exception | None = None
+        try:
+            await self._flush_pending_vector_ops()
+        except Exception as e:
+            flush_error = e
+
+        pending_docs = len(self._pending_vector_docs)
+        pending_deletes = len(self._pending_vector_deletes)
+
+        if flush_error is not None:
+            raise RuntimeError(
+                f"[{self.workspace}] QdrantVectorDBStorage.finalize() flush raised; "
+                f"{pending_docs} pending upserts and {pending_deletes} pending "
+                f"deletes were left buffered (data lost)"
+            ) from flush_error
+        if pending_docs or pending_deletes:
+            raise RuntimeError(
+                f"[{self.workspace}] QdrantVectorDBStorage.finalize() left "
+                f"{pending_docs} pending upserts and {pending_deletes} pending "
+                f"deletes buffered after final flush attempt (these writes have been lost)"
+            )
 
     async def drop(self) -> dict[str, str]:
         """Drop all vector data from storage and clean up resources
@@ -1027,18 +1188,25 @@ class QdrantVectorDBStorage(BaseVectorStorage):
             - On success: {"status": "success", "message": "data dropped"}
             - On failure: {"status": "error", "message": "<error details>"}
         """
-        # No need to lock: data integrity is ensured by allowing only one process to hold pipeline at a time
         try:
-            # Delete all points for the current workspace
-            self._client.delete(
-                collection_name=self.final_namespace,
-                points_selector=models.FilterSelector(
-                    filter=models.Filter(
-                        must=[workspace_filter_condition(self.effective_workspace)]
-                    )
-                ),
-                wait=True,
-            )
+            async with self._flush_lock:
+                # Discard buffered writes before the workspace is wiped;
+                # a concurrent flush would otherwise resurrect them.
+                self._pending_vector_docs.clear()
+                self._pending_vector_deletes.clear()
+
+                # Delete all points for the current workspace
+                self._client.delete(
+                    collection_name=self.final_namespace,
+                    points_selector=models.FilterSelector(
+                        filter=models.Filter(
+                            must=[
+                                workspace_filter_condition(self.effective_workspace)
+                            ]
+                        )
+                    ),
+                    wait=True,
+                )
 
             logger.info(
                 f"[{self.workspace}] Process {os.getpid()} dropped workspace data from Qdrant collection {self.namespace}"

--- a/tests/kg/qdrant_impl/test_qdrant_deferred_embedding.py
+++ b/tests/kg/qdrant_impl/test_qdrant_deferred_embedding.py
@@ -1,0 +1,412 @@
+"""Unit tests for QdrantVectorDBStorage's deferred-embedding flush pipeline.
+
+All tests use mocks — no running Qdrant instance required.
+Mirrors the structure of tests/kg/opensearch_impl/test_opensearch_storage.py's
+TestVectorStorageBatching to keep behaviour aligned across backends.
+"""
+
+import asyncio
+import os
+
+import numpy as np
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytest.importorskip(
+    "qdrant_client",
+    reason="qdrant-client is required for Qdrant storage tests",
+)
+
+from lightrag.kg.qdrant_impl import (  # noqa: E402
+    QdrantVectorDBStorage,
+    compute_mdhash_id_for_qdrant,
+)
+
+pytestmark = pytest.mark.offline
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+class MockEmbeddingFunc:
+    def __init__(self, dim=8):
+        self.embedding_dim = dim
+        self.max_token_size = 512
+        self.model_name = "mock-embed"
+
+    async def __call__(self, texts, **kwargs):
+        return np.random.rand(len(texts), self.embedding_dim).astype(np.float32)
+
+
+class CountingEmbeddingFunc(MockEmbeddingFunc):
+    def __init__(self, dim=8, fail_times=0):
+        super().__init__(dim=dim)
+        self.fail_times = fail_times
+        self.call_count = 0
+        self.batches: list[list[str]] = []
+        self.texts: list[str] = []
+
+    async def __call__(self, texts, **kwargs):
+        self.call_count += 1
+        batch = list(texts)
+        self.batches.append(batch)
+        self.texts.extend(batch)
+        if self.fail_times > 0:
+            self.fail_times -= 1
+            raise RuntimeError("embedding failed")
+        return await super().__call__(texts, **kwargs)
+
+
+@pytest.fixture(autouse=True)
+def patch_namespace_lock():
+    """Cache real asyncio.Locks per (namespace, workspace) for shared semantics."""
+    cache: dict[tuple[str, str | None], asyncio.Lock] = {}
+
+    def factory(namespace, workspace=None, enable_logging=False):
+        key = (namespace, workspace or "")
+        lock = cache.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            cache[key] = lock
+        return lock
+
+    with patch("lightrag.kg.qdrant_impl.get_namespace_lock", side_effect=factory):
+        yield cache
+
+
+def _make_storage(
+    embed_func,
+    *,
+    namespace="entities",
+    workspace="test_ws",
+    meta_fields=None,
+):
+    if meta_fields is None:
+        meta_fields = {"content", "entity_name", "src_id", "tgt_id"}
+
+    # Bypass real initialization paths (e.g. model suffix generation),
+    # mirroring the existing pattern in test_qdrant_upsert_batching.py.
+    storage = QdrantVectorDBStorage.__new__(QdrantVectorDBStorage)
+    storage.workspace = workspace
+    storage.namespace = namespace
+    storage.effective_workspace = workspace
+    storage.final_namespace = f"lightrag_vdb_{namespace}_mock"
+    storage.meta_fields = meta_fields
+    storage.embedding_func = embed_func
+    storage._max_batch_size = 10
+    storage._max_upsert_payload_bytes = 16 * 1024 * 1024
+    storage._max_upsert_points_per_batch = 128
+    storage._pending_vector_docs = {}
+    storage._pending_vector_deletes = set()
+
+    storage._client = MagicMock()
+    storage._client.upsert = MagicMock()
+    storage._client.delete = MagicMock()
+    storage._client.retrieve = MagicMock(return_value=[])
+    storage._client.scroll = MagicMock(return_value=([], None))
+
+    from lightrag.kg.qdrant_impl import get_namespace_lock
+
+    storage._flush_lock = get_namespace_lock(
+        namespace=storage.final_namespace, workspace=storage.effective_workspace
+    )
+    return storage
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_buffers_without_embedding():
+    embed = CountingEmbeddingFunc()
+    s = _make_storage(embed)
+
+    await s.upsert({"v1": {"content": "hello"}, "v2": {"content": "world"}})
+
+    assert embed.call_count == 0
+    assert set(s._pending_vector_docs.keys()) == {"v1", "v2"}
+    assert s._pending_vector_docs["v1"].vector is None
+    s._client.upsert.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_index_done_callback_triggers_flush():
+    embed = CountingEmbeddingFunc()
+    s = _make_storage(embed)
+
+    await s.upsert({"v1": {"content": "hello"}, "v2": {"content": "world"}})
+    await s.index_done_callback()
+
+    assert embed.call_count == 1
+    s._client.upsert.assert_called_once()
+    kwargs = s._client.upsert.call_args.kwargs
+    assert kwargs["collection_name"] == s.final_namespace
+    points = kwargs["points"]
+    assert len(points) == 2
+    expected_ids = {
+        compute_mdhash_id_for_qdrant("v1", prefix=s.effective_workspace),
+        compute_mdhash_id_for_qdrant("v2", prefix=s.effective_workspace),
+    }
+    assert {p.id for p in points} == expected_ids
+    assert s._pending_vector_docs == {}
+
+
+@pytest.mark.asyncio
+async def test_repeated_upsert_same_id_embeds_once():
+    embed = CountingEmbeddingFunc()
+    s = _make_storage(embed)
+
+    await s.upsert({"v1": {"content": "first"}})
+    await s.upsert({"v1": {"content": "second"}})
+    await s.upsert({"v1": {"content": "third"}})
+    await s.index_done_callback()
+
+    assert embed.call_count == 1
+    assert embed.texts == ["third"]
+    s._client.upsert.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_deferred_embeddings_respect_batch_size():
+    embed = CountingEmbeddingFunc()
+    s = _make_storage(embed)
+    s._max_batch_size = 2
+
+    await s.upsert({f"v{i}": {"content": f"doc {i}"} for i in range(5)})
+    await s.index_done_callback()
+
+    assert embed.call_count == 3
+    assert [len(b) for b in embed.batches] == [2, 2, 1]
+
+
+@pytest.mark.asyncio
+async def test_get_vectors_by_ids_lazy_embed_then_reuse_in_flush():
+    embed = CountingEmbeddingFunc()
+    s = _make_storage(embed)
+
+    await s.upsert({"v1": {"content": "hello"}})
+    vectors = await s.get_vectors_by_ids(["v1"])
+    assert "v1" in vectors
+    assert embed.call_count == 1
+    assert s._pending_vector_docs["v1"].vector is not None
+
+    await s.index_done_callback()
+    assert embed.call_count == 1
+    s._client.upsert.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_flush_failure_keeps_buffer_no_double_embed_on_retry():
+    embed = CountingEmbeddingFunc(fail_times=1)
+    s = _make_storage(embed)
+
+    await s.upsert({"v1": {"content": "hello"}})
+
+    with pytest.raises(RuntimeError, match="embedding failed"):
+        await s.index_done_callback()
+
+    assert "v1" in s._pending_vector_docs
+    assert s._pending_vector_docs["v1"].vector is None
+    s._client.upsert.assert_not_called()
+
+    await s.index_done_callback()
+    assert embed.call_count == 2
+    s._client.upsert.assert_called_once()
+    assert s._pending_vector_docs == {}
+
+
+@pytest.mark.asyncio
+async def test_server_upsert_failure_keeps_buffer():
+    embed = CountingEmbeddingFunc()
+    s = _make_storage(embed)
+    s._client.upsert.side_effect = RuntimeError("qdrant down")
+
+    await s.upsert({"v1": {"content": "hello"}})
+
+    with pytest.raises(RuntimeError, match="qdrant down"):
+        await s.index_done_callback()
+
+    assert "v1" in s._pending_vector_docs
+    assert s._pending_vector_docs["v1"].vector is not None
+
+    s._client.upsert.side_effect = None
+    await s.index_done_callback()
+    assert embed.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_finalize_raises_when_buffer_unflushed():
+    embed = CountingEmbeddingFunc()
+    s = _make_storage(embed)
+    s._client.upsert.side_effect = RuntimeError("transient qdrant error")
+
+    await s.upsert({"v1": {"content": "hello"}})
+
+    with pytest.raises(RuntimeError, match="finalize.*flush raised"):
+        await s.finalize()
+    assert "v1" in s._pending_vector_docs
+
+
+@pytest.mark.asyncio
+async def test_delete_then_upsert_same_id_keeps_upsert():
+    embed = CountingEmbeddingFunc()
+    s = _make_storage(embed)
+
+    await s.delete(["v1"])
+    assert "v1" in s._pending_vector_deletes
+
+    await s.upsert({"v1": {"content": "hello"}})
+    assert "v1" in s._pending_vector_docs
+    assert "v1" not in s._pending_vector_deletes
+
+    await s.index_done_callback()
+    s._client.upsert.assert_called_once()
+    s._client.delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upsert_then_delete_same_id_keeps_delete():
+    embed = CountingEmbeddingFunc()
+    s = _make_storage(embed)
+
+    await s.upsert({"v1": {"content": "hello"}})
+    await s.delete(["v1"])
+    assert "v1" not in s._pending_vector_docs
+    assert "v1" in s._pending_vector_deletes
+
+    await s.index_done_callback()
+    s._client.upsert.assert_not_called()
+    s._client.delete.assert_called_once()
+    qdrant_delete_ids = s._client.delete.call_args.kwargs["points_selector"].points
+    assert qdrant_delete_ids == [
+        compute_mdhash_id_for_qdrant("v1", prefix=s.effective_workspace)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delete_entity_relation_raises_on_server_failure():
+    """scroll-then-delete pattern: server-side failure must bubble up."""
+    embed = CountingEmbeddingFunc()
+    s = _make_storage(embed)
+    fake_point = MagicMock()
+    fake_point.id = "qid1"
+    s._client.scroll.return_value = ([fake_point], None)
+    s._client.delete.side_effect = RuntimeError("qdrant delete failed")
+
+    with pytest.raises(RuntimeError, match="qdrant delete failed"):
+        await s.delete_entity_relation("X")
+
+
+@pytest.mark.asyncio
+async def test_delete_entity_relation_prunes_pending_buffer():
+    embed = CountingEmbeddingFunc()
+    s = _make_storage(embed)
+
+    await s.upsert(
+        {
+            "rel-A-B": {"content": "A→B", "src_id": "A", "tgt_id": "B"},
+            "rel-C-D": {"content": "C→D", "src_id": "C", "tgt_id": "D"},
+        }
+    )
+    s._client.scroll.return_value = ([], None)
+
+    await s.delete_entity_relation("A")
+    assert "rel-A-B" not in s._pending_vector_docs
+    assert "rel-C-D" in s._pending_vector_docs
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_reads_pending_buffer_without_vector():
+    embed = CountingEmbeddingFunc()
+    s = _make_storage(embed)
+
+    await s.upsert({"v1": {"content": "hello", "entity_name": "E1"}})
+    doc = await s.get_by_id("v1")
+    assert doc is not None
+    assert doc.get("entity_name") == "E1"
+    assert "vector" not in doc
+    s._client.retrieve.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_returns_none_for_pending_delete():
+    embed = CountingEmbeddingFunc()
+    s = _make_storage(embed)
+
+    await s.delete(["v1"])
+    assert await s.get_by_id("v1") is None
+    s._client.retrieve.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_flush_uses_build_upsert_batches_for_multiple_batches():
+    """When the points exceed the per-batch point limit, flush calls
+    `_client.upsert` multiple times — and a mid-batch failure keeps the
+    entire buffer for retry.
+    """
+    embed = CountingEmbeddingFunc()
+    s = _make_storage(embed)
+    s._max_upsert_points_per_batch = 2  # force batching
+
+    await s.upsert({f"v{i}": {"content": f"c{i}"} for i in range(5)})
+    s._client.upsert.side_effect = [None, RuntimeError("batch 2 failed"), None]
+
+    with pytest.raises(RuntimeError, match="batch 2 failed"):
+        await s.index_done_callback()
+
+    # Stopped at batch 2, total 2 calls so far.
+    assert s._client.upsert.call_count == 2
+    # Buffer preserved.
+    assert len(s._pending_vector_docs) == 5
+
+
+@pytest.mark.asyncio
+async def test_env_workspace_override_shares_flush_lock(patch_namespace_lock):
+    cache = patch_namespace_lock
+    embed = CountingEmbeddingFunc()
+
+    with patch.dict(os.environ, {"QDRANT_WORKSPACE": "shared_ws"}, clear=False):
+        # Two callers passing different `workspace` would both be redirected
+        # by the env override to "shared_ws". Since `_make_storage` skips
+        # __post_init__, simulate the override directly:
+        a = _make_storage(embed, workspace="shared_ws")
+        b = _make_storage(embed, workspace="shared_ws")
+        assert a.final_namespace == b.final_namespace
+        assert a.effective_workspace == b.effective_workspace == "shared_ws"
+        assert a._flush_lock is b._flush_lock
+        assert (
+            len([k for k in cache if k == (a.final_namespace, "shared_ws")]) == 1
+        )
+
+
+@pytest.mark.asyncio
+async def test_distinct_workspaces_in_same_collection_get_independent_locks(
+    patch_namespace_lock,
+):
+    """Same final_namespace but different workspaces → independent locks."""
+    embed = CountingEmbeddingFunc()
+    a = _make_storage(embed, workspace="ws_a")
+    b = _make_storage(embed, workspace="ws_b")
+    # final_namespace depends on namespace only (model suffix is mocked),
+    # so the two share it, but workspaces differ → different locks.
+    assert a.final_namespace == b.final_namespace
+    assert a.effective_workspace != b.effective_workspace
+    assert a._flush_lock is not b._flush_lock
+
+
+@pytest.mark.asyncio
+async def test_drop_clears_pending_buffers():
+    embed = CountingEmbeddingFunc()
+    s = _make_storage(embed)
+    await s.upsert({"v1": {"content": "hello"}})
+    await s.delete(["v2"])
+    assert s._pending_vector_docs and s._pending_vector_deletes
+
+    result = await s.drop()
+    assert result["status"] == "success"
+    assert s._pending_vector_docs == {}
+    assert s._pending_vector_deletes == set()

--- a/tests/kg/qdrant_impl/test_qdrant_deferred_embedding.py
+++ b/tests/kg/qdrant_impl/test_qdrant_deferred_embedding.py
@@ -378,9 +378,7 @@ async def test_env_workspace_override_shares_flush_lock(patch_namespace_lock):
         assert a.final_namespace == b.final_namespace
         assert a.effective_workspace == b.effective_workspace == "shared_ws"
         assert a._flush_lock is b._flush_lock
-        assert (
-            len([k for k in cache if k == (a.final_namespace, "shared_ws")]) == 1
-        )
+        assert len([k for k in cache if k == (a.final_namespace, "shared_ws")]) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/kg/qdrant_impl/test_qdrant_upsert_batching.py
+++ b/tests/kg/qdrant_impl/test_qdrant_upsert_batching.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -65,7 +66,13 @@ def test_build_upsert_batches_raises_for_single_oversized_point():
 
 
 @pytest.mark.asyncio
-async def test_upsert_fail_fast_stops_on_first_failed_batch():
+async def test_flush_fail_fast_stops_on_first_failed_batch():
+    """Flush-time fail-fast: once any batch raises, subsequent batches are skipped.
+
+    Mirrors the pre-deferred-embedding `upsert()` contract: the failure
+    bubbles out of `_flush_pending_vector_ops`, and the buffer is preserved
+    so the next flush can retry.
+    """
     storage = QdrantVectorDBStorage.__new__(QdrantVectorDBStorage)
     storage.workspace = "test_ws"
     storage.namespace = "chunks"
@@ -76,6 +83,9 @@ async def test_upsert_fail_fast_stops_on_first_failed_batch():
     storage._max_upsert_points_per_batch = 2
     storage.final_namespace = "test_collection"
     storage._client = MagicMock()
+    storage._pending_vector_docs = {}
+    storage._pending_vector_deletes = set()
+    storage._flush_lock = asyncio.Lock()
 
     async def fake_embedding_func(texts, **kwargs):
         return np.array([[float(len(text)), 0.0] for text in texts], dtype=np.float32)
@@ -85,8 +95,12 @@ async def test_upsert_fail_fast_stops_on_first_failed_batch():
 
     data = {f"chunk-{i}": {"content": f"content-{i}"} for i in range(5)}
 
+    # `upsert` only buffers; the failure surfaces from `_flush_pending_vector_ops`.
+    await storage.upsert(data)
+    assert len(storage._pending_vector_docs) == 5
+
     with pytest.raises(RuntimeError, match="batch failed"):
-        await storage.upsert(data)
+        await storage._flush_pending_vector_ops()
 
     # 5 items with max 2 points per batch => expected 3 batches, but stop at batch #2 on error.
     assert storage._client.upsert.call_count == 2
@@ -94,3 +108,5 @@ async def test_upsert_fail_fast_stops_on_first_failed_batch():
     second_call = storage._client.upsert.call_args_list[1]
     assert len(first_call.kwargs["points"]) == 2
     assert len(second_call.kwargs["points"]) == 2
+    # Buffer is preserved so the next flush can retry.
+    assert len(storage._pending_vector_docs) == 5


### PR DESCRIPTION
## Summary

Mirror the OpenSearch / FAISS / Nano lazy-embedding pattern in `QdrantVectorDBStorage`:

- `upsert()` buffers `_PendingVectorDoc` instances keyed by the caller's original doc id (not the Qdrant UUID); the UUID conversion via `compute_mdhash_id_for_qdrant` runs at flush time. Repeated upserts of the same id collapse into a single flush-time embed.
- `delete()` / `delete_entity()` buffer ids in `_pending_vector_deletes` and clear matching pending upserts so the two buffers stay mutually exclusive.
- `delete_entity_relation()` runs under the flush lock and now re-raises server-side failures (scroll + `PointIdsList` delete) instead of logging-and-swallowing.
- `_flush_pending_vector_ops()` (new) embeds inside the namespace lock, then **reuses the existing `_build_upsert_batches`** to split points by payload size / point count and dispatches `client.upsert(points=batch, wait=True)` per batch; deletes go through one `client.delete(points_selector=PointIdsList(...), wait=True)` at the end. Any embed/server failure leaves both buffers intact for retry.
- `index_done_callback()` calls the flush; `finalize()` (new override) flushes and raises `RuntimeError` when data is left buffered.
- `get_by_id` / `get_by_ids` / `get_vectors_by_ids` consult the buffer first (read-your-writes); `get_vectors_by_ids` lazily embeds pending docs so the next flush won't re-embed the same content.
- `drop()` clears the buffers under the lock before deleting workspace data.

## Motivation

PR #3143 introduced this deferred-embedding pattern for OpenSearch; faiss (b6db685) and nano (94f8bc6) followed. Qdrant was still embedding on every `upsert()` call, so a doc ingestion pipeline that upserts the same entity from multiple chunks paid one embedding round-trip per call. This change collapses them into a single flush-time batch while preserving the existing per-batch payload-size discipline (`_build_upsert_batches`).

## Lock partitioning — Qdrant-specific

The flush lock is keyed on `(final_namespace, effective_workspace)`, **not just `final_namespace`**. Unlike Milvus and Mongo, Qdrant partitions a single physical collection across workspaces via the `workspace_id` payload field, so two writers with different `effective_workspace` but the same `final_namespace` are operating on logically disjoint partitions and should not serialize against each other. The test suite asserts both directions: same `final_namespace` + same workspace → shared lock; same `final_namespace` + different workspace → independent locks.

## What's changed

- `lightrag/kg/qdrant_impl.py`: new `_PendingVectorDoc` dataclass; new `_flush_pending_vector_ops()`, `finalize()`; rewritten `upsert`, `delete`, `delete_entity`, `delete_entity_relation`, `get_by_id`, `get_by_ids`, `get_vectors_by_ids`, `index_done_callback`, `drop`. Imports: pulls in `_cooperative_yield` and `get_namespace_lock`.
- `tests/kg/qdrant_impl/test_qdrant_deferred_embedding.py` (new, 18 tests): covers all the standard deferred-embedding contracts plus Qdrant-specific concerns (`_build_upsert_batches` reuse with mid-flush failure preserving the buffer, UUID conversion timing, workspace lock partitioning).
- `tests/kg/qdrant_impl/test_qdrant_upsert_batching.py`: migrates the pre-existing `test_upsert_fail_fast_stops_on_first_failed_batch` into `test_flush_fail_fast_stops_on_first_failed_batch` — the same batched fail-fast contract now applies at `_flush_pending_vector_ops` time rather than `upsert` time, and the test also asserts the buffer is preserved for retry.

## Test plan

- [x] `ruff check lightrag/kg/qdrant_impl.py tests/kg/qdrant_impl/` — clean
- [x] `./scripts/test.sh tests/kg/qdrant_impl/` — 30 passed (18 new + 12 existing, no regressions; one test migrated to flush-time semantics)
- [ ] Manual smoke against a live Qdrant deployment (reviewer)

## Related

Companion PRs: #3149 (Milvus), #3150 (Mongo).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmM5LRgAPNdsSgzyLpg8e7)_