### PR TITLE
refact(postgres): defer PGVector embedding to index_done_callback

### DIFF
--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -3796,9 +3796,7 @@ class PGVectorStorage(BaseVectorStorage):
             if self.db is None:
                 return
 
-            timing_label = (
-                f"{self.workspace} PGVectorStorage.flush[{self.namespace}]"
-            )
+            timing_label = f"{self.workspace} PGVectorStorage.flush[{self.namespace}]"
             total_start = time.perf_counter()
             performance_timing_log(
                 "[%s] start upserts=%s deletes=%s max_batch_size=%s",
@@ -3816,8 +3814,7 @@ class PGVectorStorage(BaseVectorStorage):
             ]
             if docs_to_embed:
                 contents = [
-                    pending_doc.item["content"]
-                    for _, pending_doc in docs_to_embed
+                    pending_doc.item["content"] for _, pending_doc in docs_to_embed
                 ]
                 batches = [
                     contents[i : i + self._max_batch_size]
@@ -3856,9 +3853,7 @@ class PGVectorStorage(BaseVectorStorage):
                 build_tuple = self._upsert_chunks
             elif is_namespace(self.namespace, NameSpace.VECTOR_STORE_ENTITIES):
                 build_tuple = self._upsert_entities
-            elif is_namespace(
-                self.namespace, NameSpace.VECTOR_STORE_RELATIONSHIPS
-            ):
+            elif is_namespace(self.namespace, NameSpace.VECTOR_STORE_RELATIONSHIPS):
                 build_tuple = self._upsert_relationships
             else:
                 raise ValueError(f"{self.namespace} is not supported")
@@ -3911,9 +3906,7 @@ class PGVectorStorage(BaseVectorStorage):
                         )
 
             try:
-                await self.db._run_with_retry(
-                    _flush_batch, timing_label=timing_label
-                )
+                await self.db._run_with_retry(_flush_batch, timing_label=timing_label)
             except Exception as e:
                 logger.warning(
                     f"[{self.workspace}] PGVectorStorage flush failed; "
@@ -4224,18 +4217,13 @@ class PGVectorStorage(BaseVectorStorage):
                 remaining.append(doc_id)
 
         if docs_to_embed:
-            contents = [
-                pending_doc.item["content"] for _, pending_doc in docs_to_embed
-            ]
+            contents = [pending_doc.item["content"] for _, pending_doc in docs_to_embed]
             batches = [
                 contents[i : i + self._max_batch_size]
                 for i in range(0, len(contents), self._max_batch_size)
             ]
             embeddings_list = await asyncio.gather(
-                *[
-                    self.embedding_func(batch, context="document")
-                    for batch in batches
-                ]
+                *[self.embedding_func(batch, context="document") for batch in batches]
             )
             embeddings = np.concatenate(embeddings_list)
             if len(embeddings) != len(docs_to_embed):

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -4097,23 +4097,26 @@ class PGVectorStorage(BaseVectorStorage):
         ``_flush_lock`` so it cannot interleave with a flush of buffered
         relation upserts.
 
-        Buffer semantics:
+        Buffer semantics — post-prune with caller short-circuit contract:
             Any pending relation upsert whose ``src_id`` or ``tgt_id``
             matches ``entity_name`` is pruned from ``_pending_vector_docs``
-            *only after* the SQL predicate delete succeeds, and will NOT be
-            re-inserted after that point — even if it would have created a
-            new edge. This matches the "delete all relations touching this
-            entity" intent. If the SQL raises, the pending docs are left
-            untouched so a subsequent retry can still observe them, and
-            the exception is logged and re-raised so the caller (e.g.
-            ``adelete_by_entity``) short-circuits before
-            ``_persist_graph_updates()`` flushes those preserved pending
-            upserts back into the table. Matches the cross-backend
-            contract documented on the Qdrant / Milvus / Mongo
-            implementations: "server-side failures are re-raised; the
-            caller decides whether to retry." Callers that need to rename
-            or re-link the entity must re-issue the relation upserts after
-            this call.
+            **only after** the SQL predicate delete succeeds. On SQL
+            failure the pending docs are left intact and the exception is
+            re-raised. This avoids silently dropping buffered relation
+            vectors that the user never told us to discard.
+
+            Correctness relies on the caller short-circuiting before it
+            can trigger ``index_done_callback`` and flush those preserved
+            pending upserts back into the table (which would undo the
+            delete intent on a partial server-side delete). The single
+            in-tree caller ``adelete_by_entity`` in ``utils_graph.py``
+            honors this: its ``except`` clause skips both ``delete_node``
+            and ``_persist_graph_updates``, so on failure both the graph
+            and the pending vector buffer stay consistent with the
+            "delete never happened" state and the operation converges on
+            the next retry. Callers that need to rename or re-link the
+            entity must re-issue the relation upserts after a successful
+            call.
 
         Raises:
             RuntimeError: if called before ``initialize()`` (``_flush_lock``
@@ -4154,16 +4157,12 @@ class PGVectorStorage(BaseVectorStorage):
                 )
                 # SQL succeeded — safe to prune pending relation docs. If
                 # it had raised, we'd skip this so the pending state
-                # remains for retry on the next flush.
+                # remains for retry on the next call.
                 _prune_pending()
             logger.debug(
                 f"[{self.workspace}] Successfully deleted relations for entity {entity_name}"
             )
         except Exception as e:
-            # Re-raise so the caller can short-circuit and skip the
-            # subsequent flush; otherwise the pending relation upserts
-            # we just preserved would be persisted back, undoing the
-            # delete.
             logger.error(
                 f"[{self.workspace}] Error deleting relations for entity {entity_name}: {e}"
             )

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -3987,8 +3987,11 @@ class PGVectorStorage(BaseVectorStorage):
 
         Runs the SQL predicate delete (``WHERE entity_name=$2``) immediately
         under ``_flush_lock`` so it cannot interleave with a flush of the
-        same namespace, and additionally prunes the matching pending docs
-        and any pending delete that would otherwise re-fire after this.
+        same namespace, and — only after the SQL succeeds — prunes the
+        matching pending docs and any pending delete that would otherwise
+        re-fire. If the SQL raises, the buffer is left untouched so a
+        subsequent ``index_done_callback()`` flush can still observe and
+        retry the pending state instead of silently losing it.
 
         The SQL predicate is kept (rather than ``self.delete([ent_id])``) as
         a safety net for legacy rows whose ``id`` may not equal
@@ -4001,22 +4004,27 @@ class PGVectorStorage(BaseVectorStorage):
             )
             return
         entity_id = compute_mdhash_id(entity_name, prefix="ent-")
+
+        def _prune_pending() -> None:
+            # Drop any pending upsert keyed by hash id or matching
+            # entity_name in the buffered payload (relationship docs
+            # have no entity_name; the lookup is a harmless no-op).
+            self._pending_vector_docs.pop(entity_id, None)
+            for buffered_id in [
+                k
+                for k, v in self._pending_vector_docs.items()
+                if v.item.get("entity_name") == entity_name
+            ]:
+                self._pending_vector_docs.pop(buffered_id, None)
+            # Drop any redundant pending delete; the SQL above covered it.
+            self._pending_vector_deletes.discard(entity_id)
+
         try:
             async with self._flush_lock:
-                # Prune any pending upsert keyed by hash id or matching
-                # entity_name in the buffered payload (relationship docs
-                # have no entity_name; the lookup is a harmless no-op).
-                self._pending_vector_docs.pop(entity_id, None)
-                for buffered_id in [
-                    k
-                    for k, v in self._pending_vector_docs.items()
-                    if v.item.get("entity_name") == entity_name
-                ]:
-                    self._pending_vector_docs.pop(buffered_id, None)
-                # Drop any redundant pending delete; the SQL below covers it.
-                self._pending_vector_deletes.discard(entity_id)
-
                 if self.db is None:
+                    # Storage already finalized; buffer is the only state
+                    # left, so apply the delete intent there.
+                    _prune_pending()
                     return
                 delete_sql = (
                     f"DELETE FROM {self.table_name} "
@@ -4026,6 +4034,9 @@ class PGVectorStorage(BaseVectorStorage):
                     delete_sql,
                     {"workspace": self.workspace, "entity_name": entity_name},
                 )
+                # SQL succeeded — safe to prune buffer. If it had raised,
+                # we'd skip this so the pending state remains for retry.
+                _prune_pending()
             logger.debug(
                 f"[{self.workspace}] Successfully deleted entity {entity_name}"
             )
@@ -4042,11 +4053,14 @@ class PGVectorStorage(BaseVectorStorage):
         Buffer semantics:
             Any pending relation upsert whose ``src_id`` or ``tgt_id``
             matches ``entity_name`` is pruned from ``_pending_vector_docs``
-            and will NOT be re-inserted after the SQL predicate delete —
-            even if it would have created a new edge. This matches the
-            "delete all relations touching this entity" intent. Callers
-            that need to rename or re-link the entity must re-issue the
-            relation upserts after this call.
+            *only after* the SQL predicate delete succeeds, and will NOT be
+            re-inserted after that point — even if it would have created a
+            new edge. This matches the "delete all relations touching this
+            entity" intent. If the SQL raises, the pending docs are left
+            untouched so a subsequent ``index_done_callback()`` flush can
+            still observe and retry them. Callers that need to rename or
+            re-link the entity must re-issue the relation upserts after
+            this call.
         """
         if self._flush_lock is None:
             logger.warning(
@@ -4054,18 +4068,22 @@ class PGVectorStorage(BaseVectorStorage):
                 f"before initialize(); ignoring delete for entity '{entity_name}'"
             )
             return
+
+        def _prune_pending() -> None:
+            for buffered_id in [
+                k
+                for k, v in self._pending_vector_docs.items()
+                if v.item.get("src_id") == entity_name
+                or v.item.get("tgt_id") == entity_name
+            ]:
+                self._pending_vector_docs.pop(buffered_id, None)
+
         try:
             async with self._flush_lock:
-                # Prune pending relationship docs matching the predicate.
-                for buffered_id in [
-                    k
-                    for k, v in self._pending_vector_docs.items()
-                    if v.item.get("src_id") == entity_name
-                    or v.item.get("tgt_id") == entity_name
-                ]:
-                    self._pending_vector_docs.pop(buffered_id, None)
-
                 if self.db is None:
+                    # Storage already finalized; buffer is the only state
+                    # left, so apply the delete intent there.
+                    _prune_pending()
                     return
                 delete_sql = (
                     f"DELETE FROM {self.table_name} "
@@ -4075,6 +4093,10 @@ class PGVectorStorage(BaseVectorStorage):
                     delete_sql,
                     {"workspace": self.workspace, "entity_name": entity_name},
                 )
+                # SQL succeeded — safe to prune pending relation docs. If
+                # it had raised, we'd skip this so the pending state
+                # remains for retry on the next flush.
+                _prune_pending()
             logger.debug(
                 f"[{self.workspace}] Successfully deleted relations for entity {entity_name}"
             )

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -3990,8 +3990,13 @@ class PGVectorStorage(BaseVectorStorage):
         same namespace, and — only after the SQL succeeds — prunes the
         matching pending docs and any pending delete that would otherwise
         re-fire. If the SQL raises, the buffer is left untouched so a
-        subsequent ``index_done_callback()`` flush can still observe and
-        retry the pending state instead of silently losing it.
+        subsequent retry can still observe the pending state instead of
+        silently losing it, and the exception is logged and re-raised so
+        the caller (e.g. ``adelete_by_entity``) short-circuits before
+        ``_persist_graph_updates()`` flushes those preserved pending
+        upserts back into the table. Matches the cross-backend contract
+        documented on the Qdrant / Milvus / Mongo implementations: "server-
+        side failures are re-raised; the caller decides whether to retry."
 
         The SQL predicate is kept (rather than ``self.delete([ent_id])``) as
         a safety net for legacy rows whose ``id`` may not equal
@@ -4041,7 +4046,11 @@ class PGVectorStorage(BaseVectorStorage):
                 f"[{self.workspace}] Successfully deleted entity {entity_name}"
             )
         except Exception as e:
+            # Re-raise so the caller can short-circuit and skip the
+            # subsequent flush; otherwise the pending upsert we just
+            # preserved would be persisted back, undoing the delete.
             logger.error(f"[{self.workspace}] Error deleting entity {entity_name}: {e}")
+            raise
 
     async def delete_entity_relation(self, entity_name: str) -> None:
         """Delete all relation vectors where ``entity_name`` is src or tgt.
@@ -4057,9 +4066,15 @@ class PGVectorStorage(BaseVectorStorage):
             re-inserted after that point — even if it would have created a
             new edge. This matches the "delete all relations touching this
             entity" intent. If the SQL raises, the pending docs are left
-            untouched so a subsequent ``index_done_callback()`` flush can
-            still observe and retry them. Callers that need to rename or
-            re-link the entity must re-issue the relation upserts after
+            untouched so a subsequent retry can still observe them, and
+            the exception is logged and re-raised so the caller (e.g.
+            ``adelete_by_entity``) short-circuits before
+            ``_persist_graph_updates()`` flushes those preserved pending
+            upserts back into the table. Matches the cross-backend
+            contract documented on the Qdrant / Milvus / Mongo
+            implementations: "server-side failures are re-raised; the
+            caller decides whether to retry." Callers that need to rename
+            or re-link the entity must re-issue the relation upserts after
             this call.
         """
         if self._flush_lock is None:
@@ -4101,9 +4116,14 @@ class PGVectorStorage(BaseVectorStorage):
                 f"[{self.workspace}] Successfully deleted relations for entity {entity_name}"
             )
         except Exception as e:
+            # Re-raise so the caller can short-circuit and skip the
+            # subsequent flush; otherwise the pending relation upserts
+            # we just preserved would be persisted back, undoing the
+            # delete.
             logger.error(
                 f"[{self.workspace}] Error deleting relations for entity {entity_name}: {e}"
             )
+            raise
 
     async def get_by_id(self, id: str) -> dict[str, Any] | None:
         """Get vector data by its ID with read-your-writes against the buffer.

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -4381,10 +4381,35 @@ class PGVectorStorage(BaseVectorStorage):
         return result
 
     async def drop(self) -> dict[str, str]:
-        """Drop the storage. Discards pending buffers before the table delete.
+        """Drop all rows scoped to this storage's workspace.
 
-        Runs under ``_flush_lock`` so a concurrent flush / upsert cannot
-        land writes against rows that are being torn down.
+        The underlying table is shared across workspaces and is NOT
+        dropped — this method issues ``DELETE FROM <table> WHERE
+        workspace=$1`` and clears the pending buffers (queued
+        upserts/deletes against rows that are about to disappear are
+        meaningless).
+
+        Concurrency contract:
+            ``_flush_lock`` guards same-process flush / upsert / delete
+            races only. Cross-worker buffered writes are NOT covered —
+            another worker's pending buffer can flush stale rows back
+            into the table immediately after this call returns. Callers
+            running inside the LightRAG framework MUST hold
+            ``pipeline_status["destructive_busy"] = True`` (acquired
+            atomically via ``_acquire_destructive_busy``) for the entire
+            duration of the drop; the ``/documents/clear`` endpoint
+            already does this before invoking ``drop()`` on every
+            storage. Direct callers (tests, ops scripts, debugging) are
+            responsible for ensuring no other writer is touching this
+            workspace.
+
+        Returns:
+            ``{"status": "success" | "error", "message": ...}``. Unlike
+            ``delete()`` / ``delete_entity()`` / ``delete_entity_relation()``
+            which re-raise on failure, ``drop()`` swallows the exception
+            into the return dict — callers MUST inspect ``status`` to
+            detect failure. The exception is also logged at ``error``
+            level so a missed status check still leaves a trail.
         """
         try:
             async with self._flush_lock:
@@ -4396,6 +4421,10 @@ class PGVectorStorage(BaseVectorStorage):
                 await self.db.execute(drop_sql, {"workspace": self.workspace})
             return {"status": "success", "message": "data dropped"}
         except Exception as e:
+            logger.error(
+                f"[{self.workspace}] Error dropping vector storage "
+                f"{self.namespace}: {e}"
+            )
             return {"status": "error", "message": str(e)}
 
 

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -36,8 +36,13 @@ from ..base import (
 )
 from ..exceptions import DataMigrationError
 from ..namespace import NameSpace, is_namespace
-from ..utils import logger, _cooperative_yield, performance_timing_log
-from ..kg.shared_storage import get_data_init_lock
+from ..utils import (
+    logger,
+    compute_mdhash_id,
+    _cooperative_yield,
+    performance_timing_log,
+)
+from ..kg.shared_storage import get_data_init_lock, get_namespace_lock
 
 import pipmaster as pm
 
@@ -3032,6 +3037,15 @@ class PGKVStorage(BaseKVStorage):
             return {"status": "error", "message": str(e)}
 
 
+@dataclass
+class _PendingPGVectorDoc:
+    """Buffered PG vector upsert awaiting embedding and batched flush."""
+
+    item: dict[str, Any]
+    created_at: datetime.datetime
+    vector: list[float] | None = None
+
+
 @final
 @dataclass
 class PGVectorStorage(BaseVectorStorage):
@@ -3078,6 +3092,14 @@ class PGVectorStorage(BaseVectorStorage):
                 f"(length: {len(self.table_name)}). "
                 f"Consider using a shorter embedding model name or workspace name."
             )
+
+        # Pending buffers: upsert() and delete() queue work here until
+        # _flush_pending_vector_ops() runs from index_done_callback() /
+        # finalize(). Mirrors OpenSearchVectorDBStorage / NanoVectorDBStorage.
+        self._pending_vector_docs: dict[str, _PendingPGVectorDoc] = {}
+        self._pending_vector_deletes: set[str] = set()
+        # Namespace-keyed lock; created in initialize() after workspace is final.
+        self._flush_lock = None
 
     @staticmethod
     async def _pg_create_table(
@@ -3531,10 +3553,44 @@ class PGVectorStorage(BaseVectorStorage):
                 base_table=self.legacy_table_name,  # base_table for DDL template lookup
             )
 
+        if self._flush_lock is None:
+            self._flush_lock = get_namespace_lock(
+                self.namespace, workspace=self.workspace
+            )
+
     async def finalize(self):
-        if self.db is not None:
-            await ClientManager.release_client(self.db)
-            self.db = None
+        """Flush pending vector ops then release the shared PG client.
+
+        Captures regular ``Exception`` from the flush so it can be re-raised
+        as a ``RuntimeError`` naming the unflushed buffer counts after the
+        client is released. ``BaseException`` (cancellation, shutdown) is
+        intentionally NOT caught so it can propagate through ``finally``.
+        """
+        flush_error: Exception | None = None
+        try:
+            try:
+                await self._flush_pending_vector_ops()
+            except Exception as e:
+                flush_error = e
+        finally:
+            if self.db is not None:
+                await ClientManager.release_client(self.db)
+                self.db = None
+
+        pending_docs = len(self._pending_vector_docs)
+        pending_deletes = len(self._pending_vector_deletes)
+        if flush_error is not None:
+            raise RuntimeError(
+                f"[{self.workspace}] PGVectorStorage.finalize() flush raised; "
+                f"{pending_docs} pending upserts and {pending_deletes} pending "
+                f"deletes were left buffered (client released, data lost)"
+            ) from flush_error
+        if pending_docs or pending_deletes:
+            raise RuntimeError(
+                f"[{self.workspace}] PGVectorStorage.finalize() left "
+                f"{pending_docs} pending upserts and {pending_deletes} "
+                f"pending deletes buffered after final flush attempt"
+            )
 
     def _upsert_chunks(
         self, item: dict[str, Any], current_time: datetime.datetime
@@ -3631,125 +3687,209 @@ class PGVectorStorage(BaseVectorStorage):
         return upsert_sql, values
 
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
-        logger.debug(f"[{self.workspace}] Inserting {len(data)} to {self.namespace}")
+        """Buffer vector docs for embedding and batched flush.
+
+        Correctness premise:
+            LightRAG's pipeline is the normal write path for graph/vector
+            mutations and guarantees a single writer process per workspace.
+            This storage follows the same deferred-embedding contract as
+            OpenSearchVectorDBStorage: the pending buffer is process-local,
+            and cross-worker visibility requires the writing worker to call
+            index_done_callback().
+
+            Non-pipeline writers must provide equivalent single-writer
+            serialization and must flush explicitly before depending on
+            reads from another worker.
+        """
         if not data:
             return
 
-        timing_label = f"{self.workspace} PGVectorStorage.upsert[{self.namespace}]"
-        total_start = time.perf_counter()
-        performance_timing_log(
-            "[%s] start records=%s max_batch_size=%s",
-            timing_label,
-            len(data),
-            self._max_batch_size,
+        logger.debug(
+            f"[{self.workspace}] Buffering {len(data)} vectors for {self.namespace}"
         )
 
-        # Get current UTC time and convert to naive datetime for database storage
+        # Build pending docs outside the lock; UTC naive datetime mirrors
+        # the previous direct-write code path (the _upsert_* helpers feed
+        # this straight into asyncpg as a timestamp).
         current_time = datetime.datetime.now(timezone.utc).replace(tzinfo=None)
-        list_data = []
-        list_data_build_start = time.perf_counter()
+        pending_docs: list[tuple[str, _PendingPGVectorDoc]] = []
         for i, (k, v) in enumerate(data.items(), start=1):
-            list_data.append(
-                {
-                    "__id__": k,
-                    **{k1: v1 for k1, v1 in v.items()},
-                }
+            pending_docs.append(
+                (
+                    k,
+                    _PendingPGVectorDoc(
+                        item={"__id__": k, **v},
+                        created_at=current_time,
+                    ),
+                )
             )
             await _cooperative_yield(i)
-        performance_timing_log(
-            "[%s] list_data build completed in %.4fs records=%s",
-            timing_label,
-            time.perf_counter() - list_data_build_start,
-            len(list_data),
-        )
-        contents = [v["content"] for v in data.values()]
-        embedding_split_start = time.perf_counter()
-        batches = [
-            contents[i : i + self._max_batch_size]
-            for i in range(0, len(contents), self._max_batch_size)
-        ]
-        performance_timing_log(
-            "[%s] embedding batch split completed in %.4fs batches=%s",
-            timing_label,
-            time.perf_counter() - embedding_split_start,
-            len(batches),
-        )
 
-        embedding_tasks = [
-            self.embedding_func(batch, context="document") for batch in batches
-        ]
-        embedding_generation_start = time.perf_counter()
-        embeddings_list = await asyncio.gather(*embedding_tasks)
-        performance_timing_log(
-            "[%s] embedding generation completed in %.4fs batches=%s",
-            timing_label,
-            time.perf_counter() - embedding_generation_start,
-            len(embeddings_list),
-        )
+        async with self._flush_lock:
+            for doc_id, pending_doc in pending_docs:
+                # Invariant: a later upsert wins over an earlier delete; the
+                # unconditional dict assignment also discards any cached
+                # stale vector from a prior upsert of the same id.
+                self._pending_vector_deletes.discard(doc_id)
+                self._pending_vector_docs[doc_id] = pending_doc
 
-        embeddings = np.concatenate(embeddings_list)
-        assert len(embeddings) == len(
-            list_data
-        ), f"Embedding count mismatch: expected {len(list_data)}, got {len(embeddings)}"
-        embedding_fill_start = time.perf_counter()
-        for i, d in enumerate(list_data, start=1):
-            d["__vector__"] = embeddings[i - 1]
-            await _cooperative_yield(i)
-        performance_timing_log(
-            "[%s] vector backfill completed in %.4fs records=%s",
-            timing_label,
-            time.perf_counter() - embedding_fill_start,
-            len(list_data),
-        )
+    async def _flush_pending_vector_ops(self) -> None:
+        """Flush buffered PG vector upserts and deletes in one transaction.
 
-        # Prepare batch values for executemany
-        batch_values: list[tuple[Any, ...]] = []
-        upsert_sql = None
-        tuple_build_start = time.perf_counter()
+        Concurrency:
+            All buffer reads/writes and destructive server mutations on
+            this storage run under ``self._flush_lock``. Embedding stays
+            inside that lock so a destructive operation cannot interleave
+            between embedding and the PG write in the same process.
 
-        for i, item in enumerate(list_data, start=1):
+        Failure handling:
+            PG cannot expose per-document statuses, so flush is
+            all-or-nothing:
+              * If embedding fails the buffers stay intact (next flush
+                retries; cached vectors are reused).
+              * If ``_run_with_retry`` raises the transaction rolls back
+                and the buffers stay intact. Cached vectors stay attached
+                to pending docs so the next flush does not re-embed.
+              * On success both buffers are cleared.
+        """
+        if self._flush_lock is None:
+            return
+
+        async with self._flush_lock:
+            if not self._pending_vector_docs and not self._pending_vector_deletes:
+                return
+            if self.db is None:
+                return
+
+            timing_label = (
+                f"{self.workspace} PGVectorStorage.flush[{self.namespace}]"
+            )
+            total_start = time.perf_counter()
+            performance_timing_log(
+                "[%s] start upserts=%s deletes=%s max_batch_size=%s",
+                timing_label,
+                len(self._pending_vector_docs),
+                len(self._pending_vector_deletes),
+                self._max_batch_size,
+            )
+
+            # --- Embedding phase ---------------------------------------------
+            docs_to_embed = [
+                (doc_id, pending_doc)
+                for doc_id, pending_doc in self._pending_vector_docs.items()
+                if pending_doc.vector is None
+            ]
+            if docs_to_embed:
+                contents = [
+                    pending_doc.item["content"]
+                    for _, pending_doc in docs_to_embed
+                ]
+                batches = [
+                    contents[i : i + self._max_batch_size]
+                    for i in range(0, len(contents), self._max_batch_size)
+                ]
+                embedding_start = time.perf_counter()
+                embeddings_list = await asyncio.gather(
+                    *[
+                        self.embedding_func(batch, context="document")
+                        for batch in batches
+                    ]
+                )
+                performance_timing_log(
+                    "[%s] embedding completed in %.4fs docs=%s batches=%s",
+                    timing_label,
+                    time.perf_counter() - embedding_start,
+                    len(docs_to_embed),
+                    len(batches),
+                )
+                embeddings = np.concatenate(embeddings_list)
+                # Explicit check: a count mismatch under `python -O` would
+                # silently truncate via zip(), mispairing vectors with docs.
+                if len(embeddings) != len(docs_to_embed):
+                    raise RuntimeError(
+                        f"[{self.workspace}] Embedding count mismatch: "
+                        f"expected {len(docs_to_embed)}, got {len(embeddings)}"
+                    )
+                for i, ((_, pending_doc), embedding) in enumerate(
+                    zip(docs_to_embed, embeddings), start=1
+                ):
+                    pending_doc.vector = embedding.tolist()
+                    await _cooperative_yield(i)
+
+            # --- Build batch tuples ------------------------------------------
             if is_namespace(self.namespace, NameSpace.VECTOR_STORE_CHUNKS):
-                upsert_sql, values = self._upsert_chunks(item, current_time)
+                build_tuple = self._upsert_chunks
             elif is_namespace(self.namespace, NameSpace.VECTOR_STORE_ENTITIES):
-                upsert_sql, values = self._upsert_entities(item, current_time)
-            elif is_namespace(self.namespace, NameSpace.VECTOR_STORE_RELATIONSHIPS):
-                upsert_sql, values = self._upsert_relationships(item, current_time)
+                build_tuple = self._upsert_entities
+            elif is_namespace(
+                self.namespace, NameSpace.VECTOR_STORE_RELATIONSHIPS
+            ):
+                build_tuple = self._upsert_relationships
             else:
                 raise ValueError(f"{self.namespace} is not supported")
 
-            batch_values.append(values)
-            await _cooperative_yield(i)
-        performance_timing_log(
-            "[%s] upsert tuple build completed in %.4fs records=%s",
-            timing_label,
-            time.perf_counter() - tuple_build_start,
-            len(batch_values),
-        )
-
-        # Use executemany for batch execution - significantly reduces DB round-trips
-        # Note: register_vector is already called on pool init, no need to call it again
-        if batch_values and upsert_sql:
-
-            async def _batch_upsert(connection: asyncpg.Connection) -> None:
-                execute_start = time.perf_counter()
-                await connection.executemany(upsert_sql, batch_values)
-                performance_timing_log(
-                    "[%s] executemany completed in %.4fs batch_size=%s",
-                    timing_label,
-                    time.perf_counter() - execute_start,
-                    len(batch_values),
+            batch_values: list[tuple[Any, ...]] = []
+            upsert_sql: str | None = None
+            for i, (doc_id, pending_doc) in enumerate(
+                self._pending_vector_docs.items(), start=1
+            ):
+                if pending_doc.vector is None:
+                    # Should not happen: every pending doc was embedded above
+                    # or had a cached vector from a previous lazy embed.
+                    raise RuntimeError(
+                        f"[{self.workspace}] Pending vector for id={doc_id} "
+                        f"missing after embedding phase"
+                    )
+                # Convert cached list[float] to numpy float32 right before
+                # the executemany; pgvector's asyncpg codec accepts both
+                # list and ndarray but ndarray is the safer path. Keep the
+                # cache as list[float] so it stays JSON-friendly for retry.
+                item = dict(pending_doc.item)
+                item["__vector__"] = np.asarray(
+                    pending_doc.vector, dtype=np.float32
                 )
+                upsert_sql, values = build_tuple(item, pending_doc.created_at)
+                batch_values.append(values)
+                await _cooperative_yield(i)
 
-            await self.db._run_with_retry(_batch_upsert, timing_label=timing_label)
-            logger.debug(
-                f"[{self.workspace}] Batch upserted {len(batch_values)} records to {self.namespace}"
+            pending_delete_ids = list(self._pending_vector_deletes)
+
+            # --- Persistence -------------------------------------------------
+            async def _flush_batch(connection: asyncpg.Connection) -> None:
+                async with connection.transaction():
+                    if batch_values and upsert_sql:
+                        execute_start = time.perf_counter()
+                        await connection.executemany(upsert_sql, batch_values)
+                        performance_timing_log(
+                            "[%s] executemany completed in %.4fs batch_size=%s",
+                            timing_label,
+                            time.perf_counter() - execute_start,
+                            len(batch_values),
+                        )
+                    if pending_delete_ids:
+                        delete_sql = (
+                            f"DELETE FROM {self.table_name} "
+                            "WHERE workspace=$1 AND id = ANY($2)"
+                        )
+                        await connection.execute(
+                            delete_sql, self.workspace, pending_delete_ids
+                        )
+
+            await self.db._run_with_retry(
+                _flush_batch, timing_label=timing_label
             )
-        performance_timing_log(
-            "[%s] total complete in %.4fs records=%s",
-            timing_label,
-            time.perf_counter() - total_start,
-            len(data),
-        )
+
+            # Success: clear committed buffers. Cached vectors live on
+            # those records and are GC'd with them.
+            self._pending_vector_docs.clear()
+            self._pending_vector_deletes.clear()
+            performance_timing_log(
+                "[%s] total complete in %.4fs upserts=%s deletes=%s",
+                timing_label,
+                time.perf_counter() - total_start,
+                len(batch_values),
+                len(pending_delete_ids),
+            )
 
     #################### query method ###############
     async def query(
@@ -3784,46 +3924,65 @@ class PGVectorStorage(BaseVectorStorage):
         return results
 
     async def index_done_callback(self) -> None:
-        # PG handles persistence automatically
-        pass
+        await self._flush_pending_vector_ops()
 
     async def delete(self, ids: list[str]) -> None:
-        """Delete vectors with specified IDs from the storage.
+        """Buffer vector deletes for batched flush.
 
-        Args:
-            ids: List of vector IDs to be deleted
+        A delete cancels any pending upsert for the same id. The actual PG
+        delete is performed by ``_flush_pending_vector_ops`` during the next
+        ``index_done_callback`` / ``finalize`` call.
         """
         if not ids:
             return
-
-        delete_sql = (
-            f"DELETE FROM {self.table_name} WHERE workspace=$1 AND id = ANY($2)"
+        if isinstance(ids, set):
+            ids = list(ids)
+        async with self._flush_lock:
+            for doc_id in ids:
+                self._pending_vector_docs.pop(doc_id, None)
+                self._pending_vector_deletes.add(doc_id)
+        logger.debug(
+            f"[{self.workspace}] Buffered delete for {len(ids)} vectors in {self.namespace}"
         )
 
-        try:
-            await self.db.execute(delete_sql, {"workspace": self.workspace, "ids": ids})
-            logger.debug(
-                f"[{self.workspace}] Successfully deleted {len(ids)} vectors from {self.namespace}"
-            )
-        except Exception as e:
-            logger.error(
-                f"[{self.workspace}] Error while deleting vectors from {self.namespace}: {e}"
-            )
-
     async def delete_entity(self, entity_name: str) -> None:
-        """Delete an entity by its name from the vector storage.
+        """Delete an entity vector by entity name.
 
-        Args:
-            entity_name: The name of the entity to delete
+        Runs the SQL predicate delete (``WHERE entity_name=$2``) immediately
+        under ``_flush_lock`` so it cannot interleave with a flush of the
+        same namespace, and additionally prunes the matching pending docs
+        and any pending delete that would otherwise re-fire after this.
+
+        The SQL predicate is kept (rather than ``self.delete([ent_id])``) as
+        a safety net for legacy rows whose ``id`` may not equal
+        ``compute_mdhash_id(entity_name, prefix="ent-")``.
         """
+        entity_id = compute_mdhash_id(entity_name, prefix="ent-")
         try:
-            # Construct SQL to delete the entity using dynamic table name
-            delete_sql = f"""DELETE FROM {self.table_name}
-                            WHERE workspace=$1 AND entity_name=$2"""
+            async with self._flush_lock:
+                # Prune any pending upsert keyed by hash id or matching
+                # entity_name in the buffered payload (relationship docs
+                # have no entity_name; the lookup is a harmless no-op).
+                self._pending_vector_docs.pop(entity_id, None)
+                for buffered_id in [
+                    k
+                    for k, v in self._pending_vector_docs.items()
+                    if v.item.get("entity_name") == entity_name
+                ]:
+                    self._pending_vector_docs.pop(buffered_id, None)
+                # Drop any redundant pending delete; the SQL below covers it.
+                self._pending_vector_deletes.discard(entity_id)
 
-            await self.db.execute(
-                delete_sql, {"workspace": self.workspace, "entity_name": entity_name}
-            )
+                if self.db is None:
+                    return
+                delete_sql = (
+                    f"DELETE FROM {self.table_name} "
+                    "WHERE workspace=$1 AND entity_name=$2"
+                )
+                await self.db.execute(
+                    delete_sql,
+                    {"workspace": self.workspace, "entity_name": entity_name},
+                )
             logger.debug(
                 f"[{self.workspace}] Successfully deleted entity {entity_name}"
             )
@@ -3831,19 +3990,33 @@ class PGVectorStorage(BaseVectorStorage):
             logger.error(f"[{self.workspace}] Error deleting entity {entity_name}: {e}")
 
     async def delete_entity_relation(self, entity_name: str) -> None:
-        """Delete all relations associated with an entity.
+        """Delete all relation vectors where ``entity_name`` is src or tgt.
 
-        Args:
-            entity_name: The name of the entity whose relations should be deleted
+        Predicate-based; runs immediately. The whole method holds
+        ``_flush_lock`` so it cannot interleave with a flush of buffered
+        relation upserts.
         """
         try:
-            # Delete relations where the entity is either the source or target
-            delete_sql = f"""DELETE FROM {self.table_name}
-                            WHERE workspace=$1 AND (source_id=$2 OR target_id=$2)"""
+            async with self._flush_lock:
+                # Prune pending relationship docs matching the predicate.
+                for buffered_id in [
+                    k
+                    for k, v in self._pending_vector_docs.items()
+                    if v.item.get("src_id") == entity_name
+                    or v.item.get("tgt_id") == entity_name
+                ]:
+                    self._pending_vector_docs.pop(buffered_id, None)
 
-            await self.db.execute(
-                delete_sql, {"workspace": self.workspace, "entity_name": entity_name}
-            )
+                if self.db is None:
+                    return
+                delete_sql = (
+                    f"DELETE FROM {self.table_name} "
+                    "WHERE workspace=$1 AND (source_id=$2 OR target_id=$2)"
+                )
+                await self.db.execute(
+                    delete_sql,
+                    {"workspace": self.workspace, "entity_name": entity_name},
+                )
             logger.debug(
                 f"[{self.workspace}] Successfully deleted relations for entity {entity_name}"
             )
@@ -3853,19 +4026,32 @@ class PGVectorStorage(BaseVectorStorage):
             )
 
     async def get_by_id(self, id: str) -> dict[str, Any] | None:
-        """Get vector data by its ID
+        """Get vector data by its ID with read-your-writes against the buffer.
 
-        Args:
-            id: The unique identifier of the vector
-
-        Returns:
-            The vector data if found, or None if not found
+        ``__vector__`` and ``__id__`` are stripped from buffered results to
+        match the other vector backends; callers needing embeddings must use
+        ``get_vectors_by_ids``.
         """
-        query = f"SELECT *, EXTRACT(EPOCH FROM create_time)::BIGINT as created_at FROM {self.table_name} WHERE workspace=$1 AND id=$2"
-        params = {"workspace": self.workspace, "id": id}
+        async with self._flush_lock:
+            if id in self._pending_vector_deletes:
+                return None
+            pending = self._pending_vector_docs.get(id)
+            if pending is not None:
+                doc = {
+                    k: v
+                    for k, v in pending.item.items()
+                    if k not in ("__id__", "__vector__")
+                }
+                doc["id"] = id
+                doc["created_at"] = int(pending.created_at.timestamp())
+                return doc
 
+        query = (
+            f"SELECT *, EXTRACT(EPOCH FROM create_time)::BIGINT as created_at "
+            f"FROM {self.table_name} WHERE workspace=$1 AND id=$2"
+        )
         try:
-            result = await self.db.query(query, list(params.values()))
+            result = await self.db.query(query, [self.workspace, id])
             if result:
                 return dict(result)
             return None
@@ -3876,105 +4062,175 @@ class PGVectorStorage(BaseVectorStorage):
             return None
 
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
-        """Get multiple vector data by their IDs
+        """Get multiple vector docs by ID, preserving caller order.
 
-        Args:
-            ids: List of unique identifiers
-
-        Returns:
-            List of vector data objects that were found
+        Pending deletes return ``None`` in their slot. Pending upserts are
+        served from the buffer; remaining ids fall through to a single
+        parameterized ``id = ANY($2)`` SQL query (replacing the previous
+        string-built ``IN (...)`` form).
         """
         if not ids:
             return []
 
-        ids_str = ",".join([f"'{id}'" for id in ids])
-        query = f"SELECT *, EXTRACT(EPOCH FROM create_time)::BIGINT as created_at FROM {self.table_name} WHERE workspace=$1 AND id IN ({ids_str})"
-        params = {"workspace": self.workspace}
+        buffered: dict[str, dict[str, Any] | None] = {}
+        remaining: list[str] = []
+        async with self._flush_lock:
+            for doc_id in ids:
+                if doc_id in self._pending_vector_deletes:
+                    buffered[doc_id] = None
+                    continue
+                pending = self._pending_vector_docs.get(doc_id)
+                if pending is not None:
+                    doc = {
+                        k: v
+                        for k, v in pending.item.items()
+                        if k not in ("__id__", "__vector__")
+                    }
+                    doc["id"] = doc_id
+                    doc["created_at"] = int(pending.created_at.timestamp())
+                    buffered[doc_id] = doc
+                    continue
+                remaining.append(doc_id)
 
-        try:
-            results = await self.db.query(query, list(params.values()), multirows=True)
-            if not results:
+        id_map: dict[str, dict[str, Any]] = {}
+        if remaining:
+            query = (
+                f"SELECT *, EXTRACT(EPOCH FROM create_time)::BIGINT as created_at "
+                f"FROM {self.table_name} WHERE workspace=$1 AND id = ANY($2)"
+            )
+            try:
+                results = await self.db.query(
+                    query, [self.workspace, remaining], multirows=True
+                )
+                for record in results or []:
+                    if record is None:
+                        continue
+                    record_dict = dict(record)
+                    row_id = record_dict.get("id")
+                    if row_id is not None:
+                        id_map[str(row_id)] = record_dict
+            except Exception as e:
+                logger.error(
+                    f"[{self.workspace}] Error retrieving vector data for IDs {ids}: {e}"
+                )
                 return []
 
-            # Preserve caller requested ordering while normalizing asyncpg rows to dicts.
-            id_map: dict[str, dict[str, Any]] = {}
-            for record in results:
-                if record is None:
-                    continue
-                record_dict = dict(record)
-                row_id = record_dict.get("id")
-                if row_id is not None:
-                    id_map[str(row_id)] = record_dict
-
-            ordered_results: list[dict[str, Any] | None] = []
-            for requested_id in ids:
+        ordered_results: list[dict[str, Any] | None] = []
+        for requested_id in ids:
+            if requested_id in buffered:
+                ordered_results.append(buffered[requested_id])
+            else:
                 ordered_results.append(id_map.get(str(requested_id)))
-            return ordered_results
-        except Exception as e:
-            logger.error(
-                f"[{self.workspace}] Error retrieving vector data for IDs {ids}: {e}"
-            )
-            return []
+        return ordered_results
 
     async def get_vectors_by_ids(self, ids: list[str]) -> dict[str, list[float]]:
-        """Get vectors by their IDs, returning only ID and vector data for efficiency
+        """Get vector embeddings by ID, with read-your-writes against the buffer.
 
-        Args:
-            ids: List of unique identifiers
-
-        Returns:
-            Dictionary mapping IDs to their vector embeddings
-            Format: {id: [vector_values], ...}
+        Lazily embeds pending docs whose vector has not been computed yet,
+        caches the result on the pending record (so the next flush reuses
+        it), and falls through to a parameterized SQL query for ids not in
+        the buffer.
         """
         if not ids:
             return {}
 
-        ids_str = ",".join([f"'{id}'" for id in ids])
-        query = f"SELECT id, content_vector FROM {self.table_name} WHERE workspace=$1 AND id IN ({ids_str})"
-        params = {"workspace": self.workspace}
+        result: dict[str, list[float]] = {}
+        remaining: list[str] = []
+        async with self._flush_lock:
+            docs_to_embed: list[tuple[str, _PendingPGVectorDoc]] = []
+            for doc_id in ids:
+                if doc_id in self._pending_vector_deletes:
+                    continue
+                pending = self._pending_vector_docs.get(doc_id)
+                if pending is not None:
+                    if pending.vector is None:
+                        docs_to_embed.append((doc_id, pending))
+                    else:
+                        result[doc_id] = pending.vector
+                    continue
+                remaining.append(doc_id)
 
+            if docs_to_embed:
+                contents = [
+                    pending_doc.item["content"]
+                    for _, pending_doc in docs_to_embed
+                ]
+                batches = [
+                    contents[i : i + self._max_batch_size]
+                    for i in range(0, len(contents), self._max_batch_size)
+                ]
+                embeddings_list = await asyncio.gather(
+                    *[
+                        self.embedding_func(batch, context="document")
+                        for batch in batches
+                    ]
+                )
+                embeddings = np.concatenate(embeddings_list)
+                if len(embeddings) != len(docs_to_embed):
+                    raise RuntimeError(
+                        f"[{self.workspace}] Embedding count mismatch: "
+                        f"expected {len(docs_to_embed)}, got {len(embeddings)}"
+                    )
+                for i, ((doc_id, pending_doc), embedding) in enumerate(
+                    zip(docs_to_embed, embeddings), start=1
+                ):
+                    pending_doc.vector = embedding.tolist()
+                    result[doc_id] = pending_doc.vector
+                    await _cooperative_yield(i)
+
+        if not remaining:
+            return result
+
+        query = (
+            f"SELECT id, content_vector FROM {self.table_name} "
+            f"WHERE workspace=$1 AND id = ANY($2)"
+        )
         try:
-            results = await self.db.query(query, list(params.values()), multirows=True)
-            vectors_dict = {}
-
-            for result in results:
-                if result and "content_vector" in result and "id" in result:
-                    try:
-                        vector_data = result["content_vector"]
-                        # Handle both pgvector-registered connections (returns list/tuple)
-                        # and non-registered connections (returns JSON string)
-                        if isinstance(vector_data, (list, tuple)):
-                            vectors_dict[result["id"]] = list(vector_data)
-                        elif isinstance(vector_data, str):
-                            parsed = json.loads(vector_data)
-                            if isinstance(parsed, list):
-                                vectors_dict[result["id"]] = parsed
-                        # Handle numpy arrays from pgvector
-                        elif hasattr(vector_data, "tolist"):
-                            vectors_dict[result["id"]] = vector_data.tolist()
-                        elif hasattr(vector_data, "to_list") and callable(
-                            vector_data.to_list
-                        ):
-                            vectors_dict[result["id"]] = vector_data.to_list()
-                    except (json.JSONDecodeError, TypeError) as e:
-                        logger.warning(
-                            f"[{self.workspace}] Failed to parse vector data for ID {result['id']}: {e}"
-                        )
-
-            return vectors_dict
+            results = await self.db.query(
+                query, [self.workspace, remaining], multirows=True
+            )
+            for row in results or []:
+                if not row or "content_vector" not in row or "id" not in row:
+                    continue
+                vector_data = row["content_vector"]
+                try:
+                    if isinstance(vector_data, (list, tuple)):
+                        result[row["id"]] = list(vector_data)
+                    elif isinstance(vector_data, str):
+                        parsed = json.loads(vector_data)
+                        if isinstance(parsed, list):
+                            result[row["id"]] = parsed
+                    elif hasattr(vector_data, "tolist"):
+                        result[row["id"]] = vector_data.tolist()
+                    elif hasattr(vector_data, "to_list") and callable(
+                        vector_data.to_list
+                    ):
+                        result[row["id"]] = vector_data.to_list()
+                except (json.JSONDecodeError, TypeError) as e:
+                    logger.warning(
+                        f"[{self.workspace}] Failed to parse vector data for ID {row['id']}: {e}"
+                    )
         except Exception as e:
             logger.error(
                 f"[{self.workspace}] Error retrieving vectors by IDs from {self.namespace}: {e}"
             )
-            return {}
+
+        return result
 
     async def drop(self) -> dict[str, str]:
-        """Drop the storage"""
+        """Drop the storage. Discards pending buffers before the table delete.
+
+        Runs under ``_flush_lock`` so a concurrent flush / upsert cannot
+        land writes against rows that are being torn down.
+        """
         try:
-            drop_sql = SQL_TEMPLATES["drop_specifiy_table_workspace"].format(
-                table_name=self.table_name
-            )
-            await self.db.execute(drop_sql, {"workspace": self.workspace})
+            async with self._flush_lock:
+                self._pending_vector_docs.clear()
+                self._pending_vector_deletes.clear()
+                drop_sql = SQL_TEMPLATES["drop_specifiy_table_workspace"].format(
+                    table_name=self.table_name
+                )
+                await self.db.execute(drop_sql, {"workspace": self.workspace})
             return {"status": "success", "message": "data dropped"}
         except Exception as e:
             return {"status": "error", "message": str(e)}

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -4214,10 +4214,15 @@ class PGVectorStorage(BaseVectorStorage):
         Embedding I/O runs *outside* ``_flush_lock`` so a slow embedding
         provider cannot block concurrent ``upsert`` / ``delete`` / read
         calls on this storage. The lock is re-acquired briefly to cache
-        the result, and the pending record's identity is re-checked first
-        — if a concurrent ``upsert`` / ``delete`` / ``drop`` replaced or
-        removed the record, the embedding is returned to the caller but
-        not cached on the new/missing record (rare, accepted trade-off).
+        the result, and the pending record's identity is re-checked
+        first: if a concurrent ``upsert`` / ``delete`` / ``drop`` replaced
+        or removed the record during the embedding window, that ID is
+        dropped from the response entirely — we neither cache the stale
+        vector on the new/missing record nor return it to the caller, so
+        callers cannot observe an embedding that no longer matches the
+        current buffer state. Affected callers should treat the missing
+        key the same as the existing "id was deleted before the call"
+        case and retry if needed.
         """
         if not ids:
             return {}
@@ -4254,9 +4259,13 @@ class PGVectorStorage(BaseVectorStorage):
                     f"expected {len(docs_to_embed)}, got {len(embeddings)}"
                 )
 
-            # Re-acquire the lock just long enough to cache results on the
-            # same record (identity check avoids clobbering a concurrent
-            # re-upsert that swapped in a new _PendingPGVectorDoc).
+            # Re-acquire the lock just long enough to cache results on
+            # the same record. The identity check gates BOTH the cache
+            # write and the response entry: if the pending record was
+            # swapped or removed during the embedding window (concurrent
+            # upsert / delete / drop), the just-computed vector no longer
+            # matches the current buffer state for this id, so we drop it
+            # from the response rather than return a stale embedding.
             async with self._flush_lock:
                 for i, ((doc_id, original_pending), embedding) in enumerate(
                     zip(docs_to_embed, embeddings), start=1
@@ -4264,7 +4273,7 @@ class PGVectorStorage(BaseVectorStorage):
                     current = self._pending_vector_docs.get(doc_id)
                     if current is original_pending:
                         current.vector = embedding
-                    result[doc_id] = embedding.tolist()
+                        result[doc_id] = embedding.tolist()
                     await _cooperative_yield(i)
 
         if not remaining:

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -3039,11 +3039,16 @@ class PGKVStorage(BaseKVStorage):
 
 @dataclass
 class _PendingPGVectorDoc:
-    """Buffered PG vector upsert awaiting embedding and batched flush."""
+    """Buffered PG vector upsert awaiting embedding and batched flush.
+
+    ``vector`` is stored as a numpy ndarray (typically float32 from the
+    embedding function) once embedded; pgvector's asyncpg codec accepts
+    ndarray directly so no per-flush conversion is needed.
+    """
 
     item: dict[str, Any]
     created_at: datetime.datetime
-    vector: list[float] | None = None
+    vector: np.ndarray | None = None
 
 
 @final
@@ -3563,9 +3568,30 @@ class PGVectorStorage(BaseVectorStorage):
 
         Captures regular ``Exception`` from the flush so it can be re-raised
         as a ``RuntimeError`` naming the unflushed buffer counts after the
-        client is released. ``BaseException`` (cancellation, shutdown) is
-        intentionally NOT caught so it can propagate through ``finally``.
+        client is released. ``BaseException`` (``CancelledError``,
+        ``KeyboardInterrupt``, ``SystemExit``) is intentionally NOT caught
+        so it can propagate through ``finally`` — the buffer-count reframing
+        below is skipped in that case (the propagating exception already
+        signals shutdown; conflating it with "left N pending" would be
+        misleading).
+
+        Idempotency:
+            Re-entry after a successful or failed first call is a no-op for
+            the flush (client is already released), but still raises if
+            buffers remain non-empty so the operator sees the data-loss
+            signal again.
         """
+        if self.db is None:
+            pending_docs = len(self._pending_vector_docs)
+            pending_deletes = len(self._pending_vector_deletes)
+            if pending_docs or pending_deletes:
+                raise RuntimeError(
+                    f"[{self.workspace}] PGVectorStorage.finalize() re-entry: "
+                    f"client already released; {pending_docs} pending upserts "
+                    f"and {pending_deletes} pending deletes cannot be flushed"
+                )
+            return
+
         flush_error: Exception | None = None
         try:
             try:
@@ -3693,13 +3719,22 @@ class PGVectorStorage(BaseVectorStorage):
             LightRAG's pipeline is the normal write path for graph/vector
             mutations and guarantees a single writer process per workspace.
             This storage follows the same deferred-embedding contract as
-            OpenSearchVectorDBStorage: the pending buffer is process-local,
-            and cross-worker visibility requires the writing worker to call
-            index_done_callback().
+            OpenSearchVectorDBStorage: the pending buffer is process-local.
+            Committed PG rows are immediately visible across workers, but
+            *buffered* writes are not — readers in other workers will not
+            see them until the writing worker calls index_done_callback().
 
             Non-pipeline writers must provide equivalent single-writer
             serialization and must flush explicitly before depending on
             reads from another worker.
+
+        Memory expectation:
+            Pending docs (raw ``content`` strings, plus cached float32
+            vectors once embedded) accumulate in process memory until the
+            next ``index_done_callback()`` / ``finalize()``. This matches
+            the OpenSearch/Nano/Faiss contract. Callers performing very
+            large ingests should flush periodically (every N upserts) to
+            cap working-set size.
         """
         if not data:
             return
@@ -3813,7 +3848,7 @@ class PGVectorStorage(BaseVectorStorage):
                 for i, ((_, pending_doc), embedding) in enumerate(
                     zip(docs_to_embed, embeddings), start=1
                 ):
-                    pending_doc.vector = embedding.tolist()
+                    pending_doc.vector = embedding
                     await _cooperative_yield(i)
 
             # --- Build batch tuples ------------------------------------------
@@ -3840,14 +3875,14 @@ class PGVectorStorage(BaseVectorStorage):
                         f"[{self.workspace}] Pending vector for id={doc_id} "
                         f"missing after embedding phase"
                     )
-                # Convert cached list[float] to numpy float32 right before
-                # the executemany; pgvector's asyncpg codec accepts both
-                # list and ndarray but ndarray is the safer path. Keep the
-                # cache as list[float] so it stays JSON-friendly for retry.
+                # Coerce to float32 ndarray if not already (defensive; the
+                # embedding func typically returns float32 but a custom
+                # provider may return float64 — pgvector wants float32).
                 item = dict(pending_doc.item)
-                item["__vector__"] = np.asarray(
-                    pending_doc.vector, dtype=np.float32
-                )
+                vector = pending_doc.vector
+                if not isinstance(vector, np.ndarray) or vector.dtype != np.float32:
+                    vector = np.asarray(vector, dtype=np.float32)
+                item["__vector__"] = vector
                 upsert_sql, values = build_tuple(item, pending_doc.created_at)
                 batch_values.append(values)
                 await _cooperative_yield(i)
@@ -3875,9 +3910,18 @@ class PGVectorStorage(BaseVectorStorage):
                             delete_sql, self.workspace, pending_delete_ids
                         )
 
-            await self.db._run_with_retry(
-                _flush_batch, timing_label=timing_label
-            )
+            try:
+                await self.db._run_with_retry(
+                    _flush_batch, timing_label=timing_label
+                )
+            except Exception as e:
+                logger.warning(
+                    f"[{self.workspace}] PGVectorStorage flush failed; "
+                    f"buffer preserved for retry "
+                    f"({len(batch_values)} upserts, "
+                    f"{len(pending_delete_ids)} deletes left pending): {e}"
+                )
+                raise
 
             # Success: clear committed buffers. Cached vectors live on
             # those records and are GC'd with them.
@@ -3957,6 +4001,12 @@ class PGVectorStorage(BaseVectorStorage):
         a safety net for legacy rows whose ``id`` may not equal
         ``compute_mdhash_id(entity_name, prefix="ent-")``.
         """
+        if self._flush_lock is None:
+            logger.warning(
+                f"[{self.workspace}] PGVectorStorage.delete_entity called before "
+                f"initialize(); ignoring delete for entity '{entity_name}'"
+            )
+            return
         entity_id = compute_mdhash_id(entity_name, prefix="ent-")
         try:
             async with self._flush_lock:
@@ -3995,7 +4045,22 @@ class PGVectorStorage(BaseVectorStorage):
         Predicate-based; runs immediately. The whole method holds
         ``_flush_lock`` so it cannot interleave with a flush of buffered
         relation upserts.
+
+        Buffer semantics:
+            Any pending relation upsert whose ``src_id`` or ``tgt_id``
+            matches ``entity_name`` is pruned from ``_pending_vector_docs``
+            and will NOT be re-inserted after the SQL predicate delete —
+            even if it would have created a new edge. This matches the
+            "delete all relations touching this entity" intent. Callers
+            that need to rename or re-link the entity must re-issue the
+            relation upserts after this call.
         """
+        if self._flush_lock is None:
+            logger.warning(
+                f"[{self.workspace}] PGVectorStorage.delete_entity_relation called "
+                f"before initialize(); ignoring delete for entity '{entity_name}'"
+            )
+            return
         try:
             async with self._flush_lock:
                 # Prune pending relationship docs matching the predicate.
@@ -4130,14 +4195,22 @@ class PGVectorStorage(BaseVectorStorage):
         caches the result on the pending record (so the next flush reuses
         it), and falls through to a parameterized SQL query for ids not in
         the buffer.
+
+        Embedding I/O runs *outside* ``_flush_lock`` so a slow embedding
+        provider cannot block concurrent ``upsert`` / ``delete`` / read
+        calls on this storage. The lock is re-acquired briefly to cache
+        the result, and the pending record's identity is re-checked first
+        — if a concurrent ``upsert`` / ``delete`` / ``drop`` replaced or
+        removed the record, the embedding is returned to the caller but
+        not cached on the new/missing record (rare, accepted trade-off).
         """
         if not ids:
             return {}
 
         result: dict[str, list[float]] = {}
         remaining: list[str] = []
+        docs_to_embed: list[tuple[str, _PendingPGVectorDoc]] = []
         async with self._flush_lock:
-            docs_to_embed: list[tuple[str, _PendingPGVectorDoc]] = []
             for doc_id in ids:
                 if doc_id in self._pending_vector_deletes:
                     continue
@@ -4146,36 +4219,42 @@ class PGVectorStorage(BaseVectorStorage):
                     if pending.vector is None:
                         docs_to_embed.append((doc_id, pending))
                     else:
-                        result[doc_id] = pending.vector
+                        result[doc_id] = pending.vector.tolist()
                     continue
                 remaining.append(doc_id)
 
-            if docs_to_embed:
-                contents = [
-                    pending_doc.item["content"]
-                    for _, pending_doc in docs_to_embed
+        if docs_to_embed:
+            contents = [
+                pending_doc.item["content"] for _, pending_doc in docs_to_embed
+            ]
+            batches = [
+                contents[i : i + self._max_batch_size]
+                for i in range(0, len(contents), self._max_batch_size)
+            ]
+            embeddings_list = await asyncio.gather(
+                *[
+                    self.embedding_func(batch, context="document")
+                    for batch in batches
                 ]
-                batches = [
-                    contents[i : i + self._max_batch_size]
-                    for i in range(0, len(contents), self._max_batch_size)
-                ]
-                embeddings_list = await asyncio.gather(
-                    *[
-                        self.embedding_func(batch, context="document")
-                        for batch in batches
-                    ]
+            )
+            embeddings = np.concatenate(embeddings_list)
+            if len(embeddings) != len(docs_to_embed):
+                raise RuntimeError(
+                    f"[{self.workspace}] Embedding count mismatch: "
+                    f"expected {len(docs_to_embed)}, got {len(embeddings)}"
                 )
-                embeddings = np.concatenate(embeddings_list)
-                if len(embeddings) != len(docs_to_embed):
-                    raise RuntimeError(
-                        f"[{self.workspace}] Embedding count mismatch: "
-                        f"expected {len(docs_to_embed)}, got {len(embeddings)}"
-                    )
-                for i, ((doc_id, pending_doc), embedding) in enumerate(
+
+            # Re-acquire the lock just long enough to cache results on the
+            # same record (identity check avoids clobbering a concurrent
+            # re-upsert that swapped in a new _PendingPGVectorDoc).
+            async with self._flush_lock:
+                for i, ((doc_id, original_pending), embedding) in enumerate(
                     zip(docs_to_embed, embeddings), start=1
                 ):
-                    pending_doc.vector = embedding.tolist()
-                    result[doc_id] = pending_doc.vector
+                    current = self._pending_vector_docs.get(doc_id)
+                    if current is original_pending:
+                        current.vector = embedding
+                    result[doc_id] = embedding.tolist()
                     await _cooperative_yield(i)
 
         if not remaining:

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -3786,15 +3786,36 @@ class PGVectorStorage(BaseVectorStorage):
                 and the buffers stay intact. Cached vectors stay attached
                 to pending docs so the next flush does not re-embed.
               * On success both buffers are cleared.
+
+        Post-finalize / pre-initialize:
+            Calling this after ``finalize()`` (``self.db is None``) or
+            before ``initialize()`` (``self._flush_lock is None``) with a
+            non-empty buffer raises ``RuntimeError`` — silently dropping
+            buffered writes would defeat the data-loss visibility that
+            ``finalize()`` provides. An empty-buffer call is a no-op.
         """
         if self._flush_lock is None:
+            pending_docs = len(self._pending_vector_docs)
+            pending_deletes = len(self._pending_vector_deletes)
+            if pending_docs or pending_deletes:
+                raise RuntimeError(
+                    f"[{self.workspace}] PGVectorStorage._flush_pending_vector_ops "
+                    f"called before initialize(); {pending_docs} pending upserts "
+                    f"and {pending_deletes} pending deletes cannot be flushed"
+                )
             return
 
         async with self._flush_lock:
             if not self._pending_vector_docs and not self._pending_vector_deletes:
                 return
             if self.db is None:
-                return
+                pending_docs = len(self._pending_vector_docs)
+                pending_deletes = len(self._pending_vector_deletes)
+                raise RuntimeError(
+                    f"[{self.workspace}] PGVectorStorage._flush_pending_vector_ops "
+                    f"called after client release; {pending_docs} pending upserts "
+                    f"and {pending_deletes} pending deletes cannot be flushed"
+                )
 
             timing_label = f"{self.workspace} PGVectorStorage.flush[{self.namespace}]"
             total_start = time.perf_counter()
@@ -4001,13 +4022,19 @@ class PGVectorStorage(BaseVectorStorage):
         The SQL predicate is kept (rather than ``self.delete([ent_id])``) as
         a safety net for legacy rows whose ``id`` may not equal
         ``compute_mdhash_id(entity_name, prefix="ent-")``.
+
+        Raises:
+            RuntimeError: if called before ``initialize()`` (``_flush_lock``
+                is still ``None``). Silently dropping a destructive intent
+                would defeat the data-loss visibility that the rest of this
+                storage enforces; the caller must initialize first.
         """
         if self._flush_lock is None:
-            logger.warning(
+            raise RuntimeError(
                 f"[{self.workspace}] PGVectorStorage.delete_entity called before "
-                f"initialize(); ignoring delete for entity '{entity_name}'"
+                f"initialize(); call initialize_storages() on the LightRAG instance "
+                f"before issuing destructive operations"
             )
-            return
         entity_id = compute_mdhash_id(entity_name, prefix="ent-")
 
         def _prune_pending() -> None:
@@ -4076,13 +4103,19 @@ class PGVectorStorage(BaseVectorStorage):
             caller decides whether to retry." Callers that need to rename
             or re-link the entity must re-issue the relation upserts after
             this call.
+
+        Raises:
+            RuntimeError: if called before ``initialize()`` (``_flush_lock``
+                is still ``None``). Silently dropping a destructive intent
+                would defeat the data-loss visibility that the rest of this
+                storage enforces; the caller must initialize first.
         """
         if self._flush_lock is None:
-            logger.warning(
+            raise RuntimeError(
                 f"[{self.workspace}] PGVectorStorage.delete_entity_relation called "
-                f"before initialize(); ignoring delete for entity '{entity_name}'"
+                f"before initialize(); call initialize_storages() on the LightRAG "
+                f"instance before issuing destructive operations"
             )
-            return
 
         def _prune_pending() -> None:
             for buffered_id in [
@@ -4131,6 +4164,15 @@ class PGVectorStorage(BaseVectorStorage):
         ``__vector__`` and ``__id__`` are stripped from buffered results to
         match the other vector backends; callers needing embeddings must use
         ``get_vectors_by_ids``.
+
+        Response shape:
+            Buffered hits return ``{"id", "content", <payload fields>,
+            "created_at"}`` only — no embedding column. SQL-fallback hits
+            return the full row including ``content_vector`` (and any
+            namespace-specific columns such as ``entity_name`` or
+            ``source_id``). Callers that only read documented payload
+            fields (``content``, ``id``, ``created_at``) are unaffected;
+            consumers iterating over all keys must tolerate both shapes.
         """
         async with self._flush_lock:
             if id in self._pending_vector_deletes:
@@ -4168,6 +4210,9 @@ class PGVectorStorage(BaseVectorStorage):
         served from the buffer; remaining ids fall through to a single
         parameterized ``id = ANY($2)`` SQL query (replacing the previous
         string-built ``IN (...)`` form).
+
+        Response shape: same buffered-vs-SQL inconsistency as
+        ``get_by_id`` — see that docstring for details.
         """
         if not ids:
             return []

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -3841,13 +3841,25 @@ class PGVectorStorage(BaseVectorStorage):
                     contents[i : i + self._max_batch_size]
                     for i in range(0, len(contents), self._max_batch_size)
                 ]
-                embedding_start = time.perf_counter()
-                embeddings_list = await asyncio.gather(
-                    *[
-                        self.embedding_func(batch, context="document")
-                        for batch in batches
-                    ]
+                logger.info(
+                    f"[{self.workspace}] {self.namespace} flush: embedding "
+                    f"{len(docs_to_embed)} vectors in {len(batches)} batch(es) "
+                    f"(batch_num={self._max_batch_size})"
                 )
+                embedding_start = time.perf_counter()
+                try:
+                    embeddings_list = await asyncio.gather(
+                        *[
+                            self.embedding_func(batch, context="document")
+                            for batch in batches
+                        ]
+                    )
+                except Exception as e:
+                    logger.error(
+                        f"[{self.workspace}] Error embedding pending vector ops "
+                        f"(upserts={len(docs_to_embed)}): {e}"
+                    )
+                    raise
                 performance_timing_log(
                     "[%s] embedding completed in %.4fs docs=%s batches=%s",
                     timing_label,
@@ -3929,11 +3941,10 @@ class PGVectorStorage(BaseVectorStorage):
             try:
                 await self.db._run_with_retry(_flush_batch, timing_label=timing_label)
             except Exception as e:
-                logger.warning(
-                    f"[{self.workspace}] PGVectorStorage flush failed; "
-                    f"buffer preserved for retry "
-                    f"({len(batch_values)} upserts, "
-                    f"{len(pending_delete_ids)} deletes left pending): {e}"
+                logger.error(
+                    f"[{self.workspace}] Error flushing vector ops "
+                    f"(upserts={len(batch_values)}, "
+                    f"deletes={len(pending_delete_ids)}): {e}"
                 )
                 raise
 
@@ -4314,9 +4325,19 @@ class PGVectorStorage(BaseVectorStorage):
                 contents[i : i + self._max_batch_size]
                 for i in range(0, len(contents), self._max_batch_size)
             ]
-            embeddings_list = await asyncio.gather(
-                *[self.embedding_func(batch, context="document") for batch in batches]
-            )
+            try:
+                embeddings_list = await asyncio.gather(
+                    *[
+                        self.embedding_func(batch, context="document")
+                        for batch in batches
+                    ]
+                )
+            except Exception as e:
+                logger.error(
+                    f"[{self.workspace}] Error lazily embedding pending vectors "
+                    f"(upserts={len(docs_to_embed)}): {e}"
+                )
+                raise
             embeddings = np.concatenate(embeddings_list)
             if len(embeddings) != len(docs_to_embed):
                 raise RuntimeError(
@@ -4374,9 +4395,7 @@ class PGVectorStorage(BaseVectorStorage):
                         f"[{self.workspace}] Failed to parse vector data for ID {row['id']}: {e}"
                     )
         except Exception as e:
-            logger.error(
-                f"[{self.workspace}] Error retrieving vectors by IDs from {self.namespace}: {e}"
-            )
+            logger.error(f"[{self.workspace}] Error getting vectors: {e}")
 
         return result
 

--- a/tests/kg/postgres_impl/test_postgres_upsert.py
+++ b/tests/kg/postgres_impl/test_postgres_upsert.py
@@ -9,6 +9,7 @@ Verifies:
 5. Empty data returns without any DB call.
 """
 
+import asyncio
 import json
 import pytest
 import numpy as np
@@ -94,9 +95,19 @@ def make_vector_storage(namespace: str) -> PGVectorStorage:
     async def fake_run_with_retry(operation, **kwargs):
         retry_kwargs.append(kwargs)
         mock_conn = AsyncMock()
+        # connection.transaction() is a synchronous factory in asyncpg that
+        # returns an async context manager. AsyncMock would return a coroutine,
+        # so swap in a MagicMock that returns an AsyncMock-backed context.
+        tx_cm = AsyncMock()
+        tx_cm.__aenter__.return_value = None
+        tx_cm.__aexit__.return_value = None
+        mock_conn.transaction = MagicMock(return_value=tx_cm)
         await operation(mock_conn)
         for call in mock_conn.executemany.call_args_list:
             captured.append((call.args[0], call.args[1]))
+        # Also capture connection.execute calls (delete SQL inside flush).
+        for call in mock_conn.execute.call_args_list:
+            captured.append((call.args[0], call.args[1:]))
 
     db._run_with_retry = AsyncMock(side_effect=fake_run_with_retry)
     db.workspace = "test_ws"
@@ -121,6 +132,7 @@ def make_vector_storage(namespace: str) -> PGVectorStorage:
         embedding_func=embedding,
     )
     storage.db = db
+    storage._flush_lock = asyncio.Lock()
     storage._captured = captured
     storage._retry_kwargs = retry_kwargs
     return storage
@@ -681,7 +693,10 @@ async def test_doc_status_upsert_sql_protects_existing_content_hash():
 
 
 @pytest.mark.asyncio
-async def test_vector_upsert_passes_timing_label():
+async def test_vector_flush_passes_timing_label():
+    """upsert() now buffers; the timing_label is emitted by the flush path
+    that runs from index_done_callback() / finalize().
+    """
     storage = make_vector_storage(NameSpace.VECTOR_STORE_CHUNKS)
     await storage.upsert(
         {
@@ -694,7 +709,11 @@ async def test_vector_upsert_passes_timing_label():
             }
         }
     )
+    # No retry call until flush.
+    assert storage._retry_kwargs == []
+
+    await storage.index_done_callback()
 
     assert storage._retry_kwargs[0]["timing_label"] == (
-        f"test_ws PGVectorStorage.upsert[{NameSpace.VECTOR_STORE_CHUNKS}]"
+        f"test_ws PGVectorStorage.flush[{NameSpace.VECTOR_STORE_CHUNKS}]"
     )

--- a/tests/kg/postgres_impl/test_postgres_vector_deferred.py
+++ b/tests/kg/postgres_impl/test_postgres_vector_deferred.py
@@ -620,9 +620,9 @@ async def test_delete_entity_serializes_against_in_flight_flush():
     # Give the event loop a few turns to confirm delete_entity is blocked.
     for _ in range(5):
         await asyncio.sleep(0)
-    assert not delete_task.done(), (
-        "delete_entity should be waiting on _flush_lock while flush holds it"
-    )
+    assert (
+        not delete_task.done()
+    ), "delete_entity should be waiting on _flush_lock while flush holds it"
 
     # Unblock the flush; both should complete.
     embed.gate.set()
@@ -684,9 +684,7 @@ async def test_embedding_count_mismatch_raises_and_preserves_buffer():
 
     async def short_embed(texts, **kwargs):
         rows = max(0, len(list(texts)) - 1)
-        return np.array(
-            [[1.0, 0.0, 0.0] for _ in range(rows)], dtype=np.float32
-        )
+        return np.array([[1.0, 0.0, 0.0] for _ in range(rows)], dtype=np.float32)
 
     storage.embedding_func = short_embed
 

--- a/tests/kg/postgres_impl/test_postgres_vector_deferred.py
+++ b/tests/kg/postgres_impl/test_postgres_vector_deferred.py
@@ -1,0 +1,572 @@
+"""Unit tests for PGVectorStorage deferred-embedding contract.
+
+PGVectorStorage now buffers upserts/deletes in process-local pending buffers
+and embeds + persists only during ``index_done_callback()`` / ``finalize()``.
+This mirrors OpenSearchVectorDBStorage and NanoVectorDBStorage.
+
+These tests use the same ``MagicMock``-based DB stub as
+``test_postgres_upsert.py``, plus a counting embedding function adapted from
+``tests/kg/opensearch_impl/test_opensearch_storage.py``.
+"""
+
+import asyncio
+
+import numpy as np
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from lightrag.kg.postgres_impl import (
+    PGVectorStorage,
+    _PendingPGVectorDoc,
+)
+from lightrag.namespace import NameSpace
+from lightrag.utils import EmbeddingFunc, compute_mdhash_id
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class CountingEmbed:
+    """Embedding test double that records calls and can fail N times first."""
+
+    def __init__(self, dim: int = 3, fail_times: int = 0):
+        self.embedding_dim = dim
+        self.max_token_size = 512
+        self.model_name = "test_model"
+        self.fail_times = fail_times
+        self.call_count = 0
+        self.batches: list[list[str]] = []
+
+    async def __call__(self, texts, **kwargs):
+        self.call_count += 1
+        batch = list(texts)
+        self.batches.append(batch)
+        if self.fail_times > 0:
+            self.fail_times -= 1
+            raise RuntimeError("embedding failed")
+        return np.array(
+            [[float(self.call_count), 0.0, 0.0] for _ in batch], dtype=np.float32
+        )
+
+
+def _make_storage(
+    namespace: str = NameSpace.VECTOR_STORE_CHUNKS,
+    embed: CountingEmbed | None = None,
+    embedding_batch_num: int = 10,
+    fail_run_with_retry: bool = False,
+) -> PGVectorStorage:
+    """Construct a PGVectorStorage with a stubbed DB and embedding func."""
+    db = MagicMock()
+    captured_executemany: list[tuple] = []
+    captured_execute: list[tuple] = []
+    retry_kwargs: list[dict] = []
+    retry_call_count = {"n": 0}
+
+    async def fake_run_with_retry(operation, **kwargs):
+        retry_kwargs.append(kwargs)
+        retry_call_count["n"] += 1
+        if fail_run_with_retry:
+            raise RuntimeError("simulated PG failure")
+        mock_conn = AsyncMock()
+        tx_cm = AsyncMock()
+        tx_cm.__aenter__.return_value = None
+        tx_cm.__aexit__.return_value = None
+        mock_conn.transaction = MagicMock(return_value=tx_cm)
+        await operation(mock_conn)
+        for call in mock_conn.executemany.call_args_list:
+            captured_executemany.append((call.args[0], call.args[1]))
+        for call in mock_conn.execute.call_args_list:
+            captured_execute.append((call.args[0], call.args[1:]))
+
+    db._run_with_retry = AsyncMock(side_effect=fake_run_with_retry)
+
+    # db.execute is used by delete_entity, delete_entity_relation, drop.
+    db.execute = AsyncMock(return_value=None)
+    db.query = AsyncMock(return_value=[])
+    db.workspace = "test_ws"
+
+    embedding = embed or CountingEmbed()
+    embedding_func = EmbeddingFunc(
+        embedding_dim=embedding.embedding_dim,
+        func=embedding,
+        model_name=embedding.model_name,
+    )
+    storage = PGVectorStorage(
+        namespace=namespace,
+        workspace="test_ws",
+        global_config={
+            "embedding_batch_num": embedding_batch_num,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.5},
+        },
+        embedding_func=embedding_func,
+    )
+    storage.db = db
+    storage._flush_lock = asyncio.Lock()
+    storage._counting_embed = embedding
+    storage._captured_executemany = captured_executemany
+    storage._captured_execute = captured_execute
+    storage._retry_kwargs = retry_kwargs
+    storage._retry_call_count = retry_call_count
+    return storage
+
+
+def _chunk_data(**overrides):
+    base = {
+        "tokens": 1,
+        "chunk_order_index": 0,
+        "full_doc_id": "doc-1",
+        "content": "alpha",
+        "file_path": "/a.txt",
+    }
+    base.update(overrides)
+    return base
+
+
+def _entity_data(name: str = "Alice", **overrides):
+    base = {
+        "entity_name": name,
+        "content": f"{name} content",
+        "source_id": "chunk-1",
+        "file_path": "/e.txt",
+    }
+    base.update(overrides)
+    return base
+
+
+def _relation_data(src: str = "Alice", tgt: str = "Bob", **overrides):
+    base = {
+        "src_id": src,
+        "tgt_id": tgt,
+        "content": f"{src}->{tgt}",
+        "source_id": "chunk-1",
+        "file_path": "/r.txt",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# 1. upsert() buffers only
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_buffers_without_embedding_or_db_call():
+    storage = _make_storage()
+    await storage.upsert({"c1": _chunk_data(content="alpha")})
+
+    assert storage._counting_embed.call_count == 0
+    assert storage._retry_call_count["n"] == 0
+    assert "c1" in storage._pending_vector_docs
+    pending = storage._pending_vector_docs["c1"]
+    assert isinstance(pending, _PendingPGVectorDoc)
+    assert pending.vector is None
+    assert pending.item["__id__"] == "c1"
+    assert pending.item["content"] == "alpha"
+
+
+# ---------------------------------------------------------------------------
+# 2. Deferred batching across many upsert() calls
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_many_upserts_flush_in_one_executemany():
+    storage = _make_storage(embedding_batch_num=3)
+    for i in range(5):
+        await storage.upsert({f"c{i}": _chunk_data(content=f"doc {i}")})
+
+    assert storage._counting_embed.call_count == 0
+    await storage.index_done_callback()
+
+    # Embedding split only by embedding_batch_num (3 + 2).
+    assert [len(b) for b in storage._counting_embed.batches] == [3, 2]
+    # One executemany for 5 records (not one per upsert call).
+    assert len(storage._captured_executemany) == 1
+    sql, rows = storage._captured_executemany[0]
+    assert len(rows) == 5
+    assert "LIGHTRAG_VDB_CHUNKS" in sql
+
+
+# ---------------------------------------------------------------------------
+# 3. Same-id upsert overwrite
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_same_id_upsert_overwrites():
+    storage = _make_storage()
+    await storage.upsert({"x": _chunk_data(content="a")})
+    await storage.upsert({"x": _chunk_data(content="b")})
+    await storage.index_done_callback()
+
+    rows = storage._captured_executemany[0][1]
+    assert len(rows) == 1
+    # The chunk tuple position 6 ($6) is content.
+    assert rows[0][5] == "b"
+
+
+# ---------------------------------------------------------------------------
+# 4. Lazy vector cache: get_vectors_by_ids embeds, flush reuses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lazy_vector_cache_reused_by_flush():
+    storage = _make_storage()
+    await storage.upsert({"c1": _chunk_data(content="alpha")})
+    vecs = await storage.get_vectors_by_ids(["c1"])
+    assert "c1" in vecs
+    assert storage._counting_embed.call_count == 1
+
+    await storage.index_done_callback()
+    # Flush must not re-embed; total call count stays 1.
+    assert storage._counting_embed.call_count == 1
+    # The vector that landed in the executemany row equals what get_vectors_by_ids returned.
+    rows = storage._captured_executemany[0][1]
+    persisted_vec = rows[0][6]  # chunks tuple: $7 is content_vector
+    assert list(np.asarray(persisted_vec, dtype=np.float32)) == list(
+        np.asarray(vecs["c1"], dtype=np.float32)
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Upsert after lazy cache discards the cached vector
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_after_lazy_cache_discards_cached_vector():
+    storage = _make_storage()
+    await storage.upsert({"c1": _chunk_data(content="a")})
+    await storage.get_vectors_by_ids(["c1"])  # embed call #1
+    assert storage._pending_vector_docs["c1"].vector is not None
+
+    await storage.upsert({"c1": _chunk_data(content="b")})  # discards cache
+    assert storage._pending_vector_docs["c1"].vector is None
+
+    await storage.index_done_callback()
+    # Two embed calls total: one lazy, one for the new content during flush.
+    assert storage._counting_embed.call_count == 2
+    # And the persisted content is "b".
+    rows = storage._captured_executemany[0][1]
+    assert rows[0][5] == "b"
+
+
+# ---------------------------------------------------------------------------
+# 6. Embedding failure leaves buffers intact
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_embedding_failure_leaves_pending_for_retry():
+    embed = CountingEmbed(fail_times=1)
+    storage = _make_storage(embed=embed)
+    await storage.upsert({"c1": _chunk_data(content="retry me")})
+
+    with pytest.raises(RuntimeError, match="embedding failed"):
+        await storage.index_done_callback()
+
+    assert storage._retry_call_count["n"] == 0
+    assert "c1" in storage._pending_vector_docs
+    assert storage._pending_vector_docs["c1"].vector is None
+
+    # Next flush succeeds; embed called twice total (one failure + one success).
+    await storage.index_done_callback()
+    assert embed.call_count == 2
+    assert storage._pending_vector_docs == {}
+    assert len(storage._captured_executemany) == 1
+
+
+# ---------------------------------------------------------------------------
+# 7. _run_with_retry failure leaves buffers + cached vectors intact
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_persistence_failure_keeps_buffers_and_cached_vectors():
+    storage = _make_storage(fail_run_with_retry=True)
+    await storage.upsert({"c1": _chunk_data(content="alpha")})
+
+    with pytest.raises(RuntimeError, match="simulated PG failure"):
+        await storage.index_done_callback()
+
+    # Buffer intact, vector cached (so next flush won't re-embed).
+    assert "c1" in storage._pending_vector_docs
+    assert storage._pending_vector_docs["c1"].vector is not None
+    embed_calls_before = storage._counting_embed.call_count
+
+    # Repair the DB and flush again.
+    storage.db._run_with_retry.side_effect = None
+    storage.db._run_with_retry.return_value = None
+
+    # We need to actually persist this time; re-attach a working side_effect.
+    captured_em = storage._captured_executemany
+    captured_ex = storage._captured_execute
+
+    async def working_retry(operation, **kwargs):
+        mock_conn = AsyncMock()
+        tx_cm = AsyncMock()
+        tx_cm.__aenter__.return_value = None
+        tx_cm.__aexit__.return_value = None
+        mock_conn.transaction = MagicMock(return_value=tx_cm)
+        await operation(mock_conn)
+        for call in mock_conn.executemany.call_args_list:
+            captured_em.append((call.args[0], call.args[1]))
+        for call in mock_conn.execute.call_args_list:
+            captured_ex.append((call.args[0], call.args[1:]))
+
+    storage.db._run_with_retry.side_effect = working_retry
+
+    await storage.index_done_callback()
+    # No re-embed thanks to the cached vector.
+    assert storage._counting_embed.call_count == embed_calls_before
+    assert storage._pending_vector_docs == {}
+    assert len(captured_em) == 1
+
+
+# ---------------------------------------------------------------------------
+# 8. Delete cancels pending upsert
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_cancels_pending_upsert():
+    storage = _make_storage()
+    await storage.upsert({"c1": _chunk_data()})
+    await storage.delete(["c1"])
+
+    assert "c1" not in storage._pending_vector_docs
+    assert "c1" in storage._pending_vector_deletes
+
+    await storage.index_done_callback()
+    # Only a delete went out, no upsert executemany.
+    assert storage._captured_executemany == []
+    assert len(storage._captured_execute) == 1
+    sql, args = storage._captured_execute[0]
+    assert "DELETE FROM" in sql
+    assert args[0] == "test_ws"
+    assert args[1] == ["c1"]
+
+
+# ---------------------------------------------------------------------------
+# 9. Upsert cancels pending delete
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_cancels_pending_delete():
+    storage = _make_storage()
+    await storage.delete(["c1"])
+    await storage.upsert({"c1": _chunk_data(content="new")})
+
+    assert "c1" in storage._pending_vector_docs
+    assert "c1" not in storage._pending_vector_deletes
+
+    await storage.index_done_callback()
+    assert len(storage._captured_executemany) == 1
+    # And no DELETE in the same flush.
+    assert storage._captured_execute == []
+
+
+# ---------------------------------------------------------------------------
+# 10. delete_entity prunes pending docs and runs SQL predicate under lock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_entity_prunes_pending_and_runs_sql():
+    storage = _make_storage(namespace=NameSpace.VECTOR_STORE_ENTITIES)
+    entity_id = compute_mdhash_id("Alice", prefix="ent-")
+    # Pending entity keyed by the hash id.
+    await storage.upsert({entity_id: _entity_data(name="Alice")})
+
+    await storage.delete_entity("Alice")
+
+    # Pending pruned.
+    assert entity_id not in storage._pending_vector_docs
+    # SQL predicate fired against db.execute (the immediate path).
+    storage.db.execute.assert_awaited_once()
+    sql_arg = storage.db.execute.await_args.args[0]
+    params_arg = storage.db.execute.await_args.args[1]
+    assert "entity_name=$2" in sql_arg
+    assert params_arg == {"workspace": "test_ws", "entity_name": "Alice"}
+
+
+# ---------------------------------------------------------------------------
+# 11. delete_entity_relation prunes pending relation docs + runs SQL predicate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_entity_relation_prunes_pending_and_runs_sql():
+    storage = _make_storage(namespace=NameSpace.VECTOR_STORE_RELATIONSHIPS)
+    await storage.upsert(
+        {
+            "r1": _relation_data(src="Alice", tgt="Bob"),
+            "r2": _relation_data(src="Carol", tgt="Alice"),
+            "r3": _relation_data(src="Eve", tgt="Mallory"),
+        }
+    )
+
+    await storage.delete_entity_relation("Alice")
+
+    assert "r1" not in storage._pending_vector_docs
+    assert "r2" not in storage._pending_vector_docs
+    assert "r3" in storage._pending_vector_docs
+
+    storage.db.execute.assert_awaited_once()
+    sql_arg = storage.db.execute.await_args.args[0]
+    assert "source_id=$2 OR target_id=$2" in sql_arg
+
+
+# ---------------------------------------------------------------------------
+# 12. drop() clears buffers and runs workspace delete
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_drop_clears_buffers_and_runs_delete():
+    storage = _make_storage()
+    await storage.upsert({"c1": _chunk_data()})
+    await storage.delete(["c2"])
+    assert storage._pending_vector_docs and storage._pending_vector_deletes
+
+    result = await storage.drop()
+    assert result["status"] == "success"
+    assert storage._pending_vector_docs == {}
+    assert storage._pending_vector_deletes == set()
+    storage.db.execute.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 13. Read-your-writes: get_by_id, get_by_ids, get_vectors_by_ids
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_returns_pending_and_hides_deletes():
+    storage = _make_storage()
+    await storage.upsert({"c1": _chunk_data(content="hello")})
+
+    doc = await storage.get_by_id("c1")
+    assert doc is not None
+    assert doc["id"] == "c1"
+    assert doc["content"] == "hello"
+    assert "__vector__" not in doc
+    assert "__id__" not in doc
+    assert "created_at" in doc
+
+    # SQL not touched for buffered hits.
+    storage.db.query.assert_not_called()
+
+    # Now delete and ensure the buffered tombstone wins over SQL.
+    await storage.delete(["c1"])
+    assert (await storage.get_by_id("c1")) is None
+
+
+@pytest.mark.asyncio
+async def test_get_by_ids_preserves_order_and_uses_any_sql():
+    storage = _make_storage()
+    await storage.upsert({"c1": _chunk_data(content="a")})
+    await storage.delete(["c2"])
+
+    # c3 will fall through to SQL.
+    storage.db.query = AsyncMock(
+        return_value=[{"id": "c3", "content": "from-pg", "created_at": 0}]
+    )
+
+    docs = await storage.get_by_ids(["c1", "c2", "c3"])
+    assert docs[0] is not None and docs[0]["id"] == "c1" and docs[0]["content"] == "a"
+    assert docs[1] is None  # pending delete
+    assert docs[2] is not None and docs[2]["id"] == "c3"
+
+    # SQL fallback used `id = ANY($2)` (not string-built IN).
+    sql_used = storage.db.query.await_args.args[0]
+    assert "id = ANY($2)" in sql_used
+    assert storage.db.query.await_args.args[1] == ["test_ws", ["c3"]]
+
+
+@pytest.mark.asyncio
+async def test_get_vectors_by_ids_returns_cached_and_skips_deletes():
+    storage = _make_storage()
+    await storage.upsert({"c1": _chunk_data(content="a")})
+    await storage.upsert({"c2": _chunk_data(content="b")})
+    await storage.delete(["c2"])
+
+    # c3 falls through to SQL.
+    storage.db.query = AsyncMock(
+        return_value=[{"id": "c3", "content_vector": [0.5, 0.6, 0.7]}]
+    )
+
+    vecs = await storage.get_vectors_by_ids(["c1", "c2", "c3"])
+    # c1 lazily embedded; c2 skipped; c3 from SQL.
+    assert "c1" in vecs and len(vecs["c1"]) == 3
+    assert "c2" not in vecs
+    assert vecs["c3"] == [0.5, 0.6, 0.7]
+
+    sql_used = storage.db.query.await_args.args[0]
+    assert "id = ANY($2)" in sql_used
+
+
+# ---------------------------------------------------------------------------
+# 14. finalize() raises with pending counts if flush failed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_finalize_raises_when_flush_fails_and_releases_client():
+    storage = _make_storage(fail_run_with_retry=True)
+    await storage.upsert({"c1": _chunk_data()})
+    await storage.delete(["c2"])
+
+    # Patch ClientManager.release_client to a no-op so we don't touch real state.
+    from lightrag.kg import postgres_impl
+
+    release_mock = AsyncMock()
+    original = postgres_impl.ClientManager.release_client
+    postgres_impl.ClientManager.release_client = release_mock
+    try:
+        with pytest.raises(RuntimeError, match="pending upserts"):
+            await storage.finalize()
+        release_mock.assert_awaited_once()
+        assert storage.db is None
+    finally:
+        postgres_impl.ClientManager.release_client = original
+
+
+@pytest.mark.asyncio
+async def test_finalize_clean_path_flushes_then_releases_client():
+    storage = _make_storage()
+    await storage.upsert({"c1": _chunk_data()})
+
+    from lightrag.kg import postgres_impl
+
+    release_mock = AsyncMock()
+    original = postgres_impl.ClientManager.release_client
+    postgres_impl.ClientManager.release_client = release_mock
+    try:
+        await storage.finalize()
+    finally:
+        postgres_impl.ClientManager.release_client = original
+
+    release_mock.assert_awaited_once()
+    assert storage.db is None
+    assert storage._pending_vector_docs == {}
+
+
+# ---------------------------------------------------------------------------
+# 15. Empty input no-ops
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_inputs_are_noops():
+    storage = _make_storage()
+    await storage.upsert({})
+    await storage.delete([])
+    await storage.index_done_callback()
+    assert storage._retry_call_count["n"] == 0
+    assert storage._counting_embed.call_count == 0

--- a/tests/kg/postgres_impl/test_postgres_vector_deferred.py
+++ b/tests/kg/postgres_impl/test_postgres_vector_deferred.py
@@ -570,3 +570,201 @@ async def test_empty_inputs_are_noops():
     await storage.index_done_callback()
     assert storage._retry_call_count["n"] == 0
     assert storage._counting_embed.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 16. delete_entity serializes against an in-flight flush via _flush_lock
+# ---------------------------------------------------------------------------
+
+
+class _GatedEmbed:
+    """Embedding func that blocks on a gate so a flush can be paused mid-call."""
+
+    def __init__(self, dim: int = 3):
+        self.embedding_dim = dim
+        self.max_token_size = 512
+        self.model_name = "test_model"
+        self.gate = asyncio.Event()
+        self.entered = asyncio.Event()
+        self.call_count = 0
+
+    async def __call__(self, texts, **kwargs):
+        self.call_count += 1
+        self.entered.set()
+        await self.gate.wait()
+        return np.array([[1.0, 0.0, 0.0] for _ in texts], dtype=np.float32)
+
+
+@pytest.mark.asyncio
+async def test_delete_entity_serializes_against_in_flight_flush():
+    """A `delete_entity` issued while a flush is mid-embedding must wait for
+    the flush's lock to release before its SQL predicate runs — otherwise the
+    flush could persist the entity row a microsecond after the predicate
+    deleted it. This pins the lock-then-SQL contract in the source.
+    """
+    embed = _GatedEmbed()
+    storage = _make_storage(namespace=NameSpace.VECTOR_STORE_ENTITIES, embed=embed)
+
+    entity_id = compute_mdhash_id("Alice", prefix="ent-")
+    await storage.upsert({entity_id: _entity_data(name="Alice")})
+
+    flush_task = asyncio.create_task(storage.index_done_callback())
+
+    # Wait until the flush is blocked inside the embedding call (it now holds
+    # _flush_lock).
+    await asyncio.wait_for(embed.entered.wait(), timeout=1.0)
+
+    # Kick off delete_entity; it must block on the same lock.
+    delete_task = asyncio.create_task(storage.delete_entity("Alice"))
+
+    # Give the event loop a few turns to confirm delete_entity is blocked.
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert not delete_task.done(), (
+        "delete_entity should be waiting on _flush_lock while flush holds it"
+    )
+
+    # Unblock the flush; both should complete.
+    embed.gate.set()
+    await asyncio.wait_for(flush_task, timeout=1.0)
+    await asyncio.wait_for(delete_task, timeout=1.0)
+
+    # Flush ran its executemany, then delete_entity ran its predicate SQL.
+    assert len(storage._captured_executemany) == 1
+    storage.db.execute.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 17. Deletes-only flush: no executemany, single ANY($2) DELETE
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deletes_only_flush_skips_executemany():
+    """A flush that has only buffered deletes (no upserts) must still issue
+    the parameterized DELETE under the transaction, and must NOT call
+    executemany with an empty batch.
+    """
+    storage = _make_storage()
+    await storage.delete(["c1", "c2", "c3"])
+    assert storage._pending_vector_docs == {}
+    assert len(storage._pending_vector_deletes) == 3
+
+    await storage.index_done_callback()
+
+    # No embedding was needed.
+    assert storage._counting_embed.call_count == 0
+    # No upsert executemany ran.
+    assert storage._captured_executemany == []
+    # Exactly one parameterized DELETE under the transaction.
+    assert len(storage._captured_execute) == 1
+    sql, args = storage._captured_execute[0]
+    assert "DELETE FROM" in sql
+    assert "id = ANY($2)" in sql
+    assert args[0] == "test_ws"
+    assert sorted(args[1]) == ["c1", "c2", "c3"]
+    # Buffers cleared on success.
+    assert storage._pending_vector_deletes == set()
+
+
+# ---------------------------------------------------------------------------
+# 18. Embedding count mismatch raises and preserves the buffer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_embedding_count_mismatch_raises_and_preserves_buffer():
+    """The in-flush ``len(embeddings) != len(docs_to_embed)`` check is
+    defense-in-depth against an embedding provider that bypasses the
+    ``EmbeddingFunc`` wrapper validation. Bypass the wrapper by replacing
+    ``storage.embedding_func`` with a bare async callable that returns
+    fewer rows than requested.
+    """
+    storage = _make_storage(embedding_batch_num=10)
+
+    async def short_embed(texts, **kwargs):
+        rows = max(0, len(list(texts)) - 1)
+        return np.array(
+            [[1.0, 0.0, 0.0] for _ in range(rows)], dtype=np.float32
+        )
+
+    storage.embedding_func = short_embed
+
+    await storage.upsert({"c1": _chunk_data(content="a")})
+    await storage.upsert({"c2": _chunk_data(content="b")})
+
+    with pytest.raises(RuntimeError, match="Embedding count mismatch"):
+        await storage.index_done_callback()
+
+    # Buffer survives the mismatch; nothing was persisted.
+    assert {"c1", "c2"} == set(storage._pending_vector_docs.keys())
+    assert storage._retry_call_count["n"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 19. delete_entity discards a matching pending delete for the same hash id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_entity_discards_matching_pending_delete():
+    """If both `delete()` (which buffers a tombstone) and `delete_entity()`
+    fire for the same entity, the pending tombstone for the entity's hash id
+    must be discarded — the predicate SQL covers it and we don't want a
+    redundant ANY-DELETE for the same id in the next flush.
+    """
+    storage = _make_storage(namespace=NameSpace.VECTOR_STORE_ENTITIES)
+    entity_id = compute_mdhash_id("Alice", prefix="ent-")
+
+    await storage.delete([entity_id])
+    assert entity_id in storage._pending_vector_deletes
+
+    await storage.delete_entity("Alice")
+
+    # The pending tombstone for the hash id was discarded.
+    assert entity_id not in storage._pending_vector_deletes
+    # And the predicate SQL ran.
+    storage.db.execute.assert_awaited_once()
+
+    # A subsequent flush has nothing to do.
+    await storage.index_done_callback()
+    assert storage._retry_call_count["n"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 20. delete_entity / delete_entity_relation are safe pre-initialize()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_entity_pre_initialize_is_safe_noop():
+    """Calling delete_entity before initialize() (i.e. _flush_lock is still
+    None) must log-and-return rather than raise TypeError on `async with`.
+    """
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=None)
+    embed = CountingEmbed()
+    embedding_func = EmbeddingFunc(
+        embedding_dim=embed.embedding_dim,
+        func=embed,
+        model_name=embed.model_name,
+    )
+    storage = PGVectorStorage(
+        namespace=NameSpace.VECTOR_STORE_ENTITIES,
+        workspace="test_ws",
+        global_config={
+            "embedding_batch_num": 10,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.5},
+        },
+        embedding_func=embedding_func,
+    )
+    storage.db = db
+    # Intentionally do NOT set _flush_lock (mimics pre-initialize state).
+    assert storage._flush_lock is None
+
+    # Both must be no-ops, not raise.
+    await storage.delete_entity("Alice")
+    await storage.delete_entity_relation("Alice")
+
+    # No SQL fired (the methods short-circuited before touching db.execute).
+    db.execute.assert_not_called()

--- a/tests/kg/postgres_impl/test_postgres_vector_deferred.py
+++ b/tests/kg/postgres_impl/test_postgres_vector_deferred.py
@@ -10,6 +10,7 @@ These tests use the same ``MagicMock``-based DB stub as
 """
 
 import asyncio
+import datetime
 
 import numpy as np
 import pytest
@@ -730,14 +731,17 @@ async def test_delete_entity_discards_matching_pending_delete():
 
 
 # ---------------------------------------------------------------------------
-# 20. delete_entity / delete_entity_relation are safe pre-initialize()
+# 20. delete_entity / delete_entity_relation raise pre-initialize()
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_delete_entity_pre_initialize_is_safe_noop():
-    """Calling delete_entity before initialize() (i.e. _flush_lock is still
-    None) must log-and-return rather than raise TypeError on `async with`.
+async def test_delete_entity_pre_initialize_raises():
+    """Calling delete_entity / delete_entity_relation before initialize()
+    must raise RuntimeError, not silently drop the destructive intent.
+
+    Silent no-op would defeat the data-loss visibility that finalize() and
+    _flush_pending_vector_ops enforce on the symmetric paths.
     """
     db = MagicMock()
     db.execute = AsyncMock(return_value=None)
@@ -760,9 +764,113 @@ async def test_delete_entity_pre_initialize_is_safe_noop():
     # Intentionally do NOT set _flush_lock (mimics pre-initialize state).
     assert storage._flush_lock is None
 
-    # Both must be no-ops, not raise.
-    await storage.delete_entity("Alice")
-    await storage.delete_entity_relation("Alice")
+    with pytest.raises(RuntimeError, match="called before initialize"):
+        await storage.delete_entity("Alice")
+    with pytest.raises(RuntimeError, match="called before initialize"):
+        await storage.delete_entity_relation("Alice")
 
     # No SQL fired (the methods short-circuited before touching db.execute).
     db.execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 21. _flush_pending_vector_ops raises on lifecycle violations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_flush_after_client_release_raises_with_counts():
+    """Direct call to _flush_pending_vector_ops after db release with a
+    non-empty buffer must raise — silent return would lose data without any
+    operator-visible signal (the symmetric path in finalize() already raises).
+    """
+    storage = _make_storage()
+    await storage.upsert({"c1": _chunk_data()})
+    await storage.delete(["c2"])
+
+    # Mimic post-finalize state: client released, buffers preserved.
+    storage.db = None
+
+    with pytest.raises(RuntimeError, match="after client release"):
+        await storage._flush_pending_vector_ops()
+    # Buffers untouched — the call must not have eaten the data on its way out.
+    assert "c1" in storage._pending_vector_docs
+    assert "c2" in storage._pending_vector_deletes
+
+
+@pytest.mark.asyncio
+async def test_flush_pre_initialize_with_pending_raises():
+    """Pre-initialize call with a non-empty buffer (programmer error path:
+    direct buffer manipulation before initialize) also raises rather than
+    silently returning."""
+    storage = _make_storage()
+    # Reset to pre-initialize state but seed the buffer to simulate the
+    # programmer-error scenario.
+    storage._flush_lock = None
+    storage._pending_vector_docs["c1"] = _PendingPGVectorDoc(
+        item={"__id__": "c1", **_chunk_data()},
+        created_at=datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None),
+    )
+
+    with pytest.raises(RuntimeError, match="called before initialize"):
+        await storage._flush_pending_vector_ops()
+
+
+# ---------------------------------------------------------------------------
+# 22. get_vectors_by_ids drops embeddings whose pending record changed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_vectors_by_ids_drops_when_pending_record_swapped():
+    """If a concurrent upsert replaces the pending record while embedding I/O
+    is in flight (outside the lock), the freshly-computed vector no longer
+    matches the current buffer state and must be dropped from the response
+    rather than returned stale."""
+    embed = _GatedEmbed()
+    storage = _make_storage(embed=embed)
+
+    # Seed the original pending doc.
+    await storage.upsert({"c1": _chunk_data(content="original")})
+    original_pending = storage._pending_vector_docs["c1"]
+
+    # Kick off get_vectors_by_ids — it will block inside the embedding gate
+    # *outside* _flush_lock.
+    task = asyncio.create_task(storage.get_vectors_by_ids(["c1"]))
+    await asyncio.wait_for(embed.entered.wait(), timeout=1.0)
+
+    # While embedding is in flight, replace the pending record via upsert.
+    # The new doc has a different content and a vector=None.
+    await storage.upsert({"c1": _chunk_data(content="replaced")})
+    assert storage._pending_vector_docs["c1"] is not original_pending
+
+    # Release the gate; the embedding completes and the identity check fires.
+    embed.gate.set()
+    result = await asyncio.wait_for(task, timeout=1.0)
+
+    # The stale embedding is NOT returned, and is NOT cached on the new
+    # pending record (which keeps vector=None for the next flush to embed).
+    assert result == {}
+    assert storage._pending_vector_docs["c1"].vector is None
+
+
+@pytest.mark.asyncio
+async def test_get_vectors_by_ids_drops_when_pending_record_removed():
+    """Same identity-check guard but for the delete-while-embedding race."""
+    embed = _GatedEmbed()
+    storage = _make_storage(embed=embed)
+
+    await storage.upsert({"c1": _chunk_data(content="original")})
+
+    task = asyncio.create_task(storage.get_vectors_by_ids(["c1"]))
+    await asyncio.wait_for(embed.entered.wait(), timeout=1.0)
+
+    # Delete the pending record mid-embedding.
+    await storage.delete(["c1"])
+    assert "c1" not in storage._pending_vector_docs
+
+    embed.gate.set()
+    result = await asyncio.wait_for(task, timeout=1.0)
+
+    # The vector for the removed id is dropped from the response.
+    assert result == {}


### PR DESCRIPTION
## Summary

`PGVectorStorage` now follows the same deferred-embedding contract as `OpenSearchVectorDBStorage`, `NanoVectorDBStorage`, and `FaissVectorDBStorage`: `upsert()` buffers raw documents process-locally, and embedding + persistence runs in one PG transaction during `index_done_callback()` / `finalize()`.

## Motivation

PG was the last vector backend still embedding eagerly inside `upsert()`. That blocked:

- Deduplication of repeated upserts of the same id within a working batch.
- Coalescing many small `upsert()` calls into one larger embedding batch.
- A uniform lifecycle contract across all vector backends.

## What's Changed

### Production (`lightrag/kg/postgres_impl.py`)

- New module-level dataclass `_PendingPGVectorDoc(item, created_at, vector=None)`.
- `__post_init__` initializes `_pending_vector_docs`, `_pending_vector_deletes`, `_flush_lock`.
- `initialize()` creates the namespace lock via `get_namespace_lock(self.namespace, workspace=self.workspace)` after workspace resolution.
- `upsert()` buffers only — no embedding, no DB call. Same-id upsert overwrites the prior pending doc (and discards any cached stale vector). A pending upsert wins over an earlier pending delete for the same id.
- New `_flush_pending_vector_ops()`:
  - Runs entirely under `_flush_lock`.
  - Embeds pending docs whose vector is `None`, batched by `embedding_batch_num`, with explicit count-mismatch check.
  - Builds tuples via the existing `_upsert_chunks` / `_upsert_entities` / `_upsert_relationships` helpers (no signature change). Converts cached `list[float]` to `np.float32` array right before `executemany` for the pgvector codec.
  - Persists upserts + deletes in **one asyncpg transaction** wrapped in `_run_with_retry`. **All-or-nothing**: any failure leaves buffers and cached vectors intact for the next flush.
- `index_done_callback()` flushes.
- `finalize()` loud-failure contract: captures `Exception` from flush, releases the client in `finally`, then raises `RuntimeError` naming pending upsert/delete counts. `BaseException` (cancellation/shutdown) still propagates.
- `delete(ids)` buffers and cancels matching pending upserts.
- `delete_entity(name)` runs the SQL `WHERE entity_name=$2` predicate immediately under the lock (kept as a safety net for legacy rows whose `id` may not equal `compute_mdhash_id(name, "ent-")`), and also prunes matching pending docs.
- `delete_entity_relation(name)` prunes pending relationship docs by `src_id`/`tgt_id` and runs the server-side predicate delete under the lock.
- `get_by_id` / `get_by_ids` / `get_vectors_by_ids` serve pending state under the lock and release the lock before SQL fallback. SQL fallback now uses parameterized `id = ANY($2)` instead of the previous string-built `IN (...)`. `get_vectors_by_ids` lazily embeds buffered docs and caches the vector on the pending record so the next flush reuses it.
- `drop()` clears both buffers and runs the existing workspace-scoped table delete under the lock.

### What's Broken / Behaviour Changes

- `upsert()` is no longer durable on return. Callers depending on cross-worker visibility must call `index_done_callback()` (the LightRAG pipeline already does). Documented as the "correctness premise" in `upsert()`'s docstring.
- Flush is all-or-nothing per transaction: a single bad row in `executemany` rolls back the whole batch, including the same-flush deletes. The buffer remains intact for the next attempt. This trade-off was deliberately chosen over per-doc partial-failure handling (which PG cannot expose like OpenSearch's bulk API).
- `finalize()` now raises `RuntimeError` instead of silently dropping unflushed writes.

### Tests

- New `tests/kg/postgres_impl/test_postgres_vector_deferred.py` (18 tests) covering: buffer-only `upsert()`, deferred batching across many small calls, same-id overwrite, lazy vector cache + flush reuse, upsert after lazy cache discards the cached vector, embedding failure leaves buffer intact, `_run_with_retry` failure preserves buffer and cached vector, delete cancels pending upsert and vice versa, `delete_entity` prunes pending + runs SQL, `delete_entity_relation` predicate, `drop` clears buffers, read-your-writes for all three read methods, `id = ANY($2)` SQL fallback shape, and `finalize()` raise-with-counts on flush failure.
- `tests/kg/postgres_impl/test_postgres_upsert.py` updated to seed `_flush_lock` and to assert the new `flush[...]` timing label after `index_done_callback()`.

### How It Works

1. `await rag.ainsert(...)` → pipeline → `PGVectorStorage.upsert()` → buffer.
2. (...repeat with many small upserts; same-id deduped, deletes cancel upserts, etc.)
3. `await rag._insert_done()` → `index_done_callback()` → `_flush_pending_vector_ops()` →
   1. embed all `vector is None` pending docs in `embedding_batch_num` batches via `asyncio.gather`.
   2. `executemany` upserts + `execute` delete inside one `connection.transaction()`.
   3. clear buffers on success; keep them on any failure.
4. `await rag.finalize_storages()` → `PGVectorStorage.finalize()` flushes, releases the client, raises if anything is still pending.

## Test plan

- [x] `ruff check lightrag/kg/postgres_impl.py tests/kg/postgres_impl/` — clean.
- [x] `./scripts/test.sh tests/kg/postgres_impl/` — all passed.
- [x] `./scripts/test.sh tests/kg/opensearch_impl/` — regression sanity, all passed.
- [x] `./scripts/test.sh tests/kg/postgres_impl/ tests/kg/opensearch_impl/ tests/kg/nano_impl/ tests/kg/faiss_impl/` — 352 passed.
- [ ] Live PG harness with pgvector enabled (not available in this environment):
  - Insert a small corpus end-to-end and confirm `index_done_callback()` writes all chunks/entities/relations.
  - Run a query and compare results with the pre-refactor baseline.
  - Exercise `delete_entity()` and `delete_entity_relation()` followed by `index_done_callback()`.
  - Confirm vectors round-trip through the pgvector asyncpg codec (already converted to `np.float32` ndarray immediately before `executemany`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01T115bMNJLmh3v5jpfTt4kS)_