### PR TITLE
🐛 fix(kg): post-prune pending buffer in vector delete_entity_relation

### DIFF
--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -541,6 +541,14 @@ class FaissVectorDBStorage(BaseVectorStorage):
 
         Errors propagate (same rationale as ``delete``).
 
+        Buffer semantics — post-prune with caller short-circuit contract:
+            The materialized index rebuild runs first; matching pending
+            upserts are pruned **only after** it succeeds. If the
+            rebuild raises, the pending buffer stays intact so the
+            caller (``adelete_by_entity`` in ``utils_graph.py``) can
+            short-circuit before ``_persist_graph_updates`` flushes a
+            half-cleaned buffer.
+
         **Not pipeline-gated** — see class docstring
         *Non-pipeline write paths*. The caller is responsible for
         ensuring single-writer serialization.
@@ -548,19 +556,10 @@ class FaissVectorDBStorage(BaseVectorStorage):
         async with self._storage_lock:
             self._reload_index_from_disk_locked(for_write=True)
 
-            # Prune matching buffered upserts (their records carry src_id /
-            # tgt_id from the relationships vdb meta_fields)...
-            pending_ids = [
-                doc_id
-                for doc_id, pdoc in self._pending_upserts.items()
-                if pdoc.record.get("src_id") == entity_name
-                or pdoc.record.get("tgt_id") == entity_name
-            ]
-            for doc_id in pending_ids:
-                del self._pending_upserts[doc_id]
-
-            # ...then scan the materialized rows. .get() so rows from
-            # foreign namespaces (no src_id / tgt_id) silently don't match.
+            # Materialized side first so a failure leaves the pending
+            # buffer intact for the caller's retry path. .get() so rows
+            # from foreign namespaces (no src_id / tgt_id) silently
+            # don't match.
             relations = [
                 fid
                 for fid, meta in self._id_to_meta.items()
@@ -570,6 +569,18 @@ class FaissVectorDBStorage(BaseVectorStorage):
             if relations:
                 self._remove_faiss_ids_locked(relations)
                 self._index_dirty = True
+
+            # Materialized rebuild succeeded — safe to prune matching
+            # buffered upserts (their records carry src_id / tgt_id from
+            # the relationships vdb meta_fields).
+            pending_ids = [
+                doc_id
+                for doc_id, pdoc in self._pending_upserts.items()
+                if pdoc.record.get("src_id") == entity_name
+                or pdoc.record.get("tgt_id") == entity_name
+            ]
+            for doc_id in pending_ids:
+                del self._pending_upserts[doc_id]
 
         total = len(pending_ids) + len(relations)
         if total:

--- a/lightrag/kg/milvus_impl.py
+++ b/lightrag/kg/milvus_impl.py
@@ -1694,6 +1694,14 @@ class MilvusVectorDBStorage(BaseVectorStorage):
         Server-side failures are re-raised (no log-and-swallow): the caller
         decides whether to retry.
 
+        Buffer semantics — post-prune with caller short-circuit contract:
+            Matching pending upserts in ``_pending_vector_docs`` are
+            pruned **only after** the server-side query + delete
+            succeeds. On failure the pending buffer stays intact and
+            the exception propagates so the caller (``adelete_by_entity``
+            in ``utils_graph.py``) can short-circuit before
+            ``_persist_graph_updates`` flushes a half-cleaned buffer.
+
         Semantic note (deferred-buffer ↔ persisted divergence): pruning only
         consults the *current* buffered ``src_id`` / ``tgt_id`` view; we do
         not re-read the persisted row a buffered upsert is about to
@@ -1706,8 +1714,8 @@ class MilvusVectorDBStorage(BaseVectorStorage):
         that require eager-equivalent semantics should call
         ``index_done_callback()`` before ``delete_entity_relation``.
         """
-        async with self._flush_lock:
-            # Prune matching docs from the pending upsert buffer.
+
+        def _prune_pending() -> None:
             for doc_id in [
                 k
                 for k, v in self._pending_vector_docs.items()
@@ -1716,7 +1724,11 @@ class MilvusVectorDBStorage(BaseVectorStorage):
             ]:
                 self._pending_vector_docs.pop(doc_id, None)
 
+        async with self._flush_lock:
             if self._client is None:
+                # No server state to mutate; buffer prune is the only
+                # delete intent we can record.
+                _prune_pending()
                 return
 
             self._ensure_collection_loaded()
@@ -1729,6 +1741,9 @@ class MilvusVectorDBStorage(BaseVectorStorage):
             )
 
             if not results:
+                # No server rows to delete — still safe to prune any
+                # pending upserts so they can't re-create the relation.
+                _prune_pending()
                 logger.debug(
                     f"[{self.workspace}] No relations found for entity {entity_name}"
                 )
@@ -1736,6 +1751,10 @@ class MilvusVectorDBStorage(BaseVectorStorage):
 
             relation_ids = [item["id"] for item in results]
             self._client.delete(collection_name=self.final_namespace, pks=relation_ids)
+            # Server-side delete succeeded — safe to prune the pending
+            # buffer so subsequent flushes don't re-upsert the deleted
+            # relations.
+            _prune_pending()
             logger.debug(
                 f"[{self.workspace}] Deleted {len(relation_ids)} relations for {entity_name}"
             )

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -2658,9 +2658,17 @@ class MongoVectorDBStorage(BaseVectorStorage):
         + delete cannot interleave with an in-flight bulk write. Server-side
         failures are re-raised (no log-and-swallow): the caller decides
         whether to retry.
+
+        Buffer semantics — post-prune with caller short-circuit contract:
+            Matching pending upserts in ``_pending_vector_docs`` are
+            pruned **only after** the server-side ``delete_many``
+            succeeds. On failure the pending buffer stays intact and
+            the exception propagates so the caller (``adelete_by_entity``
+            in ``utils_graph.py``) can short-circuit before
+            ``_persist_graph_updates`` flushes a half-cleaned buffer.
         """
-        async with self._flush_lock:
-            # Prune matching docs from the pending upsert buffer.
+
+        def _prune_pending() -> None:
             for doc_id in [
                 k
                 for k, v in self._pending_vector_docs.items()
@@ -2669,7 +2677,11 @@ class MongoVectorDBStorage(BaseVectorStorage):
             ]:
                 self._pending_vector_docs.pop(doc_id, None)
 
+        async with self._flush_lock:
             if self._data is None:
+                # No server state to mutate; buffer prune is the only
+                # delete intent we can record.
+                _prune_pending()
                 return
 
             # _id is the only field we need from the find; project to keep
@@ -2681,6 +2693,9 @@ class MongoVectorDBStorage(BaseVectorStorage):
             relations = await relations_cursor.to_list(length=None)
 
             if not relations:
+                # No server rows to delete — still safe to prune any
+                # pending upserts so they can't re-create the relation.
+                _prune_pending()
                 logger.debug(
                     f"[{self.workspace}] No relations found for entity {entity_name}"
                 )
@@ -2688,6 +2703,10 @@ class MongoVectorDBStorage(BaseVectorStorage):
 
             relation_ids = [relation["_id"] for relation in relations]
             await self._data.delete_many({"_id": {"$in": relation_ids}})
+            # Server-side delete succeeded — safe to prune the pending
+            # buffer so subsequent flushes don't re-upsert the deleted
+            # relations.
+            _prune_pending()
             logger.debug(
                 f"[{self.workspace}] Deleted {len(relation_ids)} relations for {entity_name}"
             )

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -509,11 +509,18 @@ class NanoVectorDBStorage(BaseVectorStorage):
             a subsequent ``index_done_callback``. Callers outside the
             pipeline must persist explicitly.
 
+        Buffer semantics — post-prune with caller short-circuit contract:
+            The materialized client delete runs first; the matching
+            pending upsert (if any) is popped **only after** it
+            succeeds. If the materialized delete raises, the pending
+            buffer stays intact and the exception is re-raised so the
+            caller can short-circuit before ``index_done_callback``
+            flushes a half-cleaned buffer.
+
         **Not pipeline-gated** — see class docstring
         *Non-pipeline write paths*. The caller is responsible for
         ensuring single-writer serialization.
         """
-
         try:
             entity_id = compute_mdhash_id(entity_name, prefix="ent-")
             logger.debug(
@@ -523,17 +530,20 @@ class NanoVectorDBStorage(BaseVectorStorage):
             async with self._storage_lock:
                 self._reload_client_from_disk_locked(for_write=True)
 
-                # Cancel a buffered upsert for this entity, then delete from the
-                # materialized client (lock non-reentrant; no _get_client).
-                pending_cancelled = (
-                    self._pending_upserts.pop(entity_id, None) is not None
-                )
+                # Materialized side first so a failure leaves the
+                # pending buffer intact for the caller's retry path.
                 if self._client.get([entity_id]):
                     self._client.delete([entity_id])
                     self._client_dirty = True
                     deleted = True
                 else:
                     deleted = False
+
+                # Materialized delete succeeded — safe to cancel any
+                # buffered upsert for this entity.
+                pending_cancelled = (
+                    self._pending_upserts.pop(entity_id, None) is not None
+                )
 
             if deleted or pending_cancelled:
                 logger.debug(
@@ -545,6 +555,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 )
         except Exception as e:
             logger.error(f"[{self.workspace}] Error deleting entity {entity_name}: {e}")
+            raise
 
     async def delete_entity_relation(self, entity_name: str) -> None:
         """Delete every relation vector incident to ``entity_name``.
@@ -554,30 +565,32 @@ class NanoVectorDBStorage(BaseVectorStorage):
             a subsequent ``index_done_callback``. Callers outside the
             pipeline must persist explicitly.
 
+        Buffer semantics — post-prune with caller short-circuit contract:
+            The materialized client delete runs first; matching pending
+            upserts are pruned **only after** it succeeds. If the
+            materialized delete raises, the pending buffer stays intact
+            and the exception is re-raised so the caller (e.g.
+            ``adelete_by_entity``) can short-circuit before
+            ``_persist_graph_updates`` triggers ``index_done_callback``
+            on a half-cleaned buffer.
+
+            Previously the buffer was pre-pruned and the outer
+            ``except`` swallowed exceptions into ``logger.error`` — that
+            combination silently dropped both buffered relation vectors
+            and the failure signal.
+
         **Not pipeline-gated** — see class docstring
         *Non-pipeline write paths*. The caller is responsible for
         ensuring single-writer serialization.
         """
-
         try:
             async with self._storage_lock:
                 self._reload_client_from_disk_locked(for_write=True)
 
-                # Prune matching buffered upserts (their records carry src_id /
-                # tgt_id from the relationships vdb meta_fields)...
-                pending_ids = [
-                    doc_id
-                    for doc_id, pdoc in self._pending_upserts.items()
-                    if pdoc.record.get("src_id") == entity_name
-                    or pdoc.record.get("tgt_id") == entity_name
-                ]
-                for doc_id in pending_ids:
-                    del self._pending_upserts[doc_id]
-
-                # ...then scan the materialized client and delete matches.
-                # Use .get() for src_id / tgt_id to match the pending-side
-                # lookup above: rows without those keys (foreign namespaces)
-                # simply don't match instead of raising KeyError.
+                # Materialized side first so a failure leaves the
+                # pending buffer intact for the caller's retry path.
+                # Use .get() for src_id / tgt_id so rows from foreign
+                # namespaces without those keys silently don't match.
                 storage = getattr(self._client, "_NanoVectorDB__storage")
                 ids_to_delete = [
                     dp["__id__"]
@@ -588,6 +601,18 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 if ids_to_delete:
                     self._client.delete(ids_to_delete)
                     self._client_dirty = True
+
+                # Materialized delete succeeded — safe to prune matching
+                # buffered upserts so a subsequent flush won't re-upsert
+                # the just-deleted relations.
+                pending_ids = [
+                    doc_id
+                    for doc_id, pdoc in self._pending_upserts.items()
+                    if pdoc.record.get("src_id") == entity_name
+                    or pdoc.record.get("tgt_id") == entity_name
+                ]
+                for doc_id in pending_ids:
+                    del self._pending_upserts[doc_id]
 
             total = len(pending_ids) + len(ids_to_delete)
             if total:
@@ -602,6 +627,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
             logger.error(
                 f"[{self.workspace}] Error deleting relations for {entity_name}: {e}"
             )
+            raise
 
     async def index_done_callback(self) -> bool:
         """Flush deferred embeddings, commit to disk, and notify other processes.

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -3804,9 +3804,25 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
         cannot interleave with an in-flight bulk indexing of a related doc.
         Buffered upserts that match are pruned in-memory; persisted rows are
         removed via the server-side ``delete_by_query``.
+
+        Buffer semantics — post-prune with caller short-circuit contract:
+            Matching pending upserts are pruned **only after** the
+            server-side ``delete_by_query`` succeeds (or returns the
+            equivalent of "index already missing"). On any other server
+            failure the exception is re-raised and the pending buffer
+            stays intact so a higher-level retry can still observe the
+            buffered relation vectors. Correctness relies on the caller
+            short-circuiting before ``index_done_callback`` can run;
+            ``adelete_by_entity`` in ``utils_graph.py`` honors this.
+
+            Previously this method pre-pruned the buffer and swallowed
+            ``OpenSearchException`` into a ``logger.error`` — that
+            combination silently dropped both the buffered relation
+            vectors and the server-side failure signal, leaving the
+            caller's graph + vector store permanently inconsistent.
         """
-        async with self._flush_lock:
-            # Prune matching docs from the pending upsert buffer.
+
+        def _prune_pending() -> None:
             for doc_id in [
                 k
                 for k, v in self._pending_vector_docs.items()
@@ -3815,33 +3831,48 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
             ]:
                 self._pending_vector_docs.pop(doc_id, None)
 
+        async with self._flush_lock:
             if not self._index_ready:
+                # No server state to mutate; buffer prune is the only
+                # delete intent we can record.
+                _prune_pending()
                 return
-            try:
-                body = {
-                    "query": {
-                        "bool": {
-                            "should": [
-                                {"term": {"src_id": entity_name}},
-                                {"term": {"tgt_id": entity_name}},
-                            ]
-                        }
+
+            body = {
+                "query": {
+                    "bool": {
+                        "should": [
+                            {"term": {"src_id": entity_name}},
+                            {"term": {"tgt_id": entity_name}},
+                        ]
                     }
                 }
+            }
+            try:
                 # conflicts="proceed" tolerates stale search view after refresh removal.
                 await self.client.delete_by_query(
                     index=self._index_name, body=body, params={"conflicts": "proceed"}
                 )
-                logger.debug(
-                    f"[{self.workspace}] Deleted relations for entity {entity_name}"
-                )
             except OpenSearchException as e:
                 if _is_missing_index_error(e):
+                    # Index gone is equivalent to "all rows already
+                    # deleted" — safe to prune pending and treat as
+                    # success.
                     self._mark_index_missing()
+                    _prune_pending()
                     return
                 logger.error(
                     f"[{self.workspace}] Error deleting relations for {entity_name}: {e}"
                 )
+                raise
+
+            # Server-side delete succeeded — safe to prune the pending
+            # buffer so subsequent flushes don't re-upsert the deleted
+            # relations.
+            _prune_pending()
+            logger.debug(
+                f"[{self.workspace}] Deleted relations for entity {entity_name}"
+            )
 
     async def drop(self) -> dict[str, str]:
         """Delete and recreate the vector index, discarding pending buffers.

--- a/lightrag/kg/qdrant_impl.py
+++ b/lightrag/kg/qdrant_impl.py
@@ -905,18 +905,35 @@ class QdrantVectorDBStorage(BaseVectorStorage):
         scroll + delete cannot interleave with an in-flight bulk upsert.
         Server-side failures are re-raised (no log-and-swallow): the
         caller decides whether to retry.
+
+        Buffer semantics — post-prune with caller short-circuit contract:
+            Matching pending upserts in ``_pending_vector_docs`` are
+            pruned **only after** the server-side scroll+delete loop
+            completes fully. If any iteration raises, the pending buffer
+            is left intact so a higher-level failure does not silently
+            drop buffered relation vectors that the user never told us
+            to discard. The trade-off is that partial server-side
+            deletes plus preserved pending upserts can re-insert deleted
+            relations on the next flush — correctness therefore relies
+            on the caller short-circuiting before ``index_done_callback``
+            can run. The single in-tree caller ``adelete_by_entity``
+            in ``utils_graph.py`` honors this: its ``except`` clause
+            skips both ``delete_node`` and ``_persist_graph_updates``,
+            so on failure the graph and the pending buffer stay
+            consistent with the "delete never happened" state and the
+            operation converges on the next retry.
         """
         async with self._flush_lock:
-            # Prune matching docs from the pending upsert buffer.
-            for doc_id in [
-                k
-                for k, v in self._pending_vector_docs.items()
-                if v.source.get("src_id") == entity_name
-                or v.source.get("tgt_id") == entity_name
-            ]:
-                self._pending_vector_docs.pop(doc_id, None)
-
             if self._client is None:
+                # pre-init / post-finalize: only buffer state remains, so
+                # apply the delete intent there.
+                for doc_id in [
+                    k
+                    for k, v in self._pending_vector_docs.items()
+                    if v.source.get("src_id") == entity_name
+                    or v.source.get("tgt_id") == entity_name
+                ]:
+                    self._pending_vector_docs.pop(doc_id, None)
                 return
 
             relation_filter = models.Filter(
@@ -960,6 +977,19 @@ class QdrantVectorDBStorage(BaseVectorStorage):
                 if next_offset is None:
                     break
                 offset = next_offset
+
+            # Server-side scroll+delete fully succeeded — safe to prune
+            # matching pending relation upserts so the next flush won't
+            # re-upsert the just-deleted relations. If the loop above
+            # raised, this prune is skipped and the buffer state stays
+            # available for the caller's retry path.
+            for doc_id in [
+                k
+                for k, v in self._pending_vector_docs.items()
+                if v.source.get("src_id") == entity_name
+                or v.source.get("tgt_id") == entity_name
+            ]:
+                self._pending_vector_docs.pop(doc_id, None)
 
             if total_deleted > 0:
                 logger.debug(


### PR DESCRIPTION
## Summary

Align all vector storage backends with the post-prune contract already used by `PGVectorStorage.delete_entity_relation`. Fixes a silent data-loss path in `Qdrant`, `Mongo`, `Milvus`, `OpenSearch`, `Faiss`, and `Nano`, plus a compound silent-failure bug in `OpenSearch` and `Nano`.

## Motivation

While reviewing `PGVectorStorage` and `QdrantVectorDBStorage` for equivalence, we found the two backends disagreed on the ordering between buffer pruning and the destructive server-side / materialized delete in `delete_entity_relation`:

- **pre-prune (Qdrant, Mongo, Milvus, OpenSearch, Faiss, Nano):** matching pending upserts are removed from `_pending_vector_docs` *before* the destructive call. If the destructive call raises, the buffered upserts are gone forever even though the higher-level operation (e.g. `adelete_by_entity` in `utils_graph.py`) catches the exception, short-circuits, and leaves both the graph and the persisted vector rows untouched. The user is told the delete failed, but writes they never asked to discard are silently lost.
- **post-prune (Postgres):** the destructive call runs first; pending upserts are only popped after success. On failure the buffer survives, the exception re-raises, the caller short-circuits past `_persist_graph_updates`, and the next retry can converge.

`OpenSearch` and `Nano` made this worse by swallowing the destructive failure into `logger.error` instead of re-raising. That defeats the caller short-circuit and lets `adelete_by_entity` continue through `delete_node` + `_persist_graph_updates`, so the graph node and the pending buffer get cleaned up while the persisted relation rows remain — permanent graph / vector-store inconsistency, reported back as `status="success"`.

The single in-tree caller, `adelete_by_entity` in [lightrag/utils_graph.py](../lightrag/utils_graph.py), already short-circuits correctly when `delete_entity_relation` raises (its `except` skips both `delete_node` and `_persist_graph_updates`), so the post-prune contract is the strictly safer pattern.

## What's Changed

Unified contract now followed by all 7 vector backends (`PG`, `Qdrant`, `Mongo`, `Milvus`, `OpenSearch`, `Faiss`, `Nano`):

1. Destructive side runs first — server-side `delete_by_query` / `delete_many` / `client.delete` / materialized index rebuild.
2. Matching pending upserts in `_pending_vector_docs` (or `_pending_upserts`) are pruned **only after** that succeeds.
3. Failures are re-raised so `adelete_by_entity`'s `except` clause skips `_persist_graph_updates` and the buffer state stays consistent with the unchanged graph.
4. `db is None` / `client is None` / `_index_ready is False` early-return paths still prune the buffer to record the delete intent (post-finalize / pre-init handling).
5. Empty-result branches also prune so a buffered upsert cannot re-create a just-deleted relation on the next flush.

Per-file changes:

| File | Method | Change |
|---|---|---|
| `lightrag/kg/qdrant_impl.py` | `delete_entity_relation` | post-prune (was pre-prune); pre-init / post-finalize path still prunes |
| `lightrag/kg/mongo_impl.py` | `delete_entity_relation` | post-prune; empty-result branch also prunes |
| `lightrag/kg/milvus_impl.py` | `delete_entity_relation` | post-prune; empty-result branch also prunes |
| `lightrag/kg/opensearch_impl.py` | `delete_entity_relation` | post-prune; non-missing-index `OpenSearchException` now re-raises (was logged and swallowed); missing-index treated as "already deleted" and still prunes |
| `lightrag/kg/faiss_impl.py` | `delete_entity_relation` | post-prune (materialized rebuild first) |
| `lightrag/kg/nano_vector_db_impl.py` | `delete_entity_relation`, `delete_entity` | post-prune; outer `except` re-raises (was logged and swallowed) |

PG was already post-prune (#3152) — no change needed in this PR.

## What's Broken and How It Works

- **Public API:** unchanged. `delete_entity_relation` and `delete_entity` keep the same signature and intent (`delete all relation/entity vectors for this name`).
- **Failure semantics, OpenSearch / Nano:** these now raise on destructive failure instead of silently logging. This is a behavior change for callers that depended on the old "always returns successfully" behavior. The only in-tree caller, `adelete_by_entity`, already wraps in `try / except Exception` and converts to `DeletionResult(status="fail")`, so the externally-visible behavior is "operations that previously reported success while leaving inconsistent state now correctly report failure".
- **Failure semantics, Mongo / Milvus / Qdrant / Faiss:** unchanged — these already re-raised destructive failures; only the prune ordering moved.
- **Empty-result handling:** Mongo and Milvus previously skipped pruning when the server-side query returned no rows. They now prune in this case too so a buffered upsert cannot re-create the relation. This is a behavior fix (previously a buffered relation upsert against an entity with no persisted relations would survive a `delete_entity_relation` call).
- **`db/client/index is None` paths:** continue to behave as buffer-only prune.
- **Pre-existing semantic note on Milvus** (deferred-buffer ↔ persisted divergence when an upsert is rewriting `src_id` / `tgt_id`) is preserved in the docstring.

## Test Plan

- [ ] `ruff format --check` clean on all 6 touched files
- [ ] `ruff check --ignore=E402` clean on all 6 touched files
- [ ] `ast.parse` succeeds on all 6 touched files
- [ ] Manual: with each vector backend, simulate a destructive failure during `delete_entity_relation` (force the server call to raise) and verify:
  - the exception propagates out of `delete_entity_relation`
  - `adelete_by_entity` returns `DeletionResult(status="fail")`
  - `_pending_vector_docs` still contains the matching pending upserts
  - retrying `adelete_by_entity` after the failure clears the persisted rows and prunes the buffer
- [ ] Manual: OpenSearch missing-index path still short-circuits (prunes buffer, marks index missing, returns) without raising
- [ ] Manual: empty-result branch on Mongo / Milvus now prunes a pre-buffered relation upsert against an entity with no persisted rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)