### PR TITLE
refactor(parser): make every recognized heading its own block

### DIFF
--- a/docs/LightRAGSidecarFormat-zh.md
+++ b/docs/LightRAGSidecarFormat-zh.md
@@ -114,7 +114,7 @@ inputs/space1/__parsed__/<规范文件名>.parsed/
 | `blockid` | 全局唯一的Block ID |
 | `format` | 内容形态，目前固定为 `"plain_text"` |
 | `content` | 文本内容；**公式和图片此以占位标签出现，表格以带table标签的JSON或HTLM格式出现**（见 3.3） |
-| `heading` | content所在章节的最高层级标题；heading真实存在时，应该同时出现在content的开头；如果heading之后紧接着下一个层级的heading，则把下一个层级的heading正文看待。这样做的目的是需要保证所有 Block 的 content字段内容拼接后形成完整的原文。 |
+| `heading` | content所在章节的最高层级标题；heading真实存在时，应该同时出现在content的开头。**每个被识别出的标题都独立成块**：若标题后紧跟正文，正文与该标题合并进同一个块（content = 标题 + 正文）；若标题后没有正文（例如其后紧接下一个层级的标题），该标题仍单独成块、content 仅为标题文本。这样可保证所有 Block 的 content 字段拼接后仍能完整、无重叠地还原原文。 |
 | `parent_headings` | 字符串数组: 自顶向下的祖先标题列表，不含当前 `heading` |
 | `level` | 整数: `heading` 在文档大纲中的层级（`1` = H1 / 一级标题，0表示无标题） |
 | `session_type` | Block所处区域：`body` `preface` `TOC` `references` `appendix` |

--- a/docs/LightRAGSidecarFormat.md
+++ b/docs/LightRAGSidecarFormat.md
@@ -114,7 +114,7 @@ Each content line is the minimum addressable unit of an original document "block
 | `blockid` | Globally unique Block ID |
 | `format` | Content form, currently fixed to `"plain_text"` |
 | `content` | Text content; **equations and images appear as placeholder tags here, tables appear as JSON or HTML wrapped in table tags** (see §3.3) |
-| `heading` | The top-most-level heading of the section containing this content. When `heading` is real, it should also appear at the beginning of `content`; if a heading is immediately followed by a heading at the next level, the next-level heading should be treated as body text. The goal is to ensure that concatenating the `content` fields of all blocks reconstructs the complete original text. |
+| `heading` | The top-most-level heading of the section containing this content. When `heading` is real, it should also appear at the beginning of `content`. **Every recognized heading starts its own block**: if a heading is immediately followed by body text, that body is merged into the same block (content = heading + body); if a heading has no following body (e.g., it is immediately followed by a heading at the next level), it still becomes a standalone block whose content is just the heading text. This ensures that concatenating the `content` fields of all blocks still reconstructs the complete original text without overlap. |
 | `parent_headings` | String array: the top-down list of ancestor headings, excluding the current `heading` |
 | `level` | Integer: the level of `heading` in the document outline (`1` = H1 / first-level heading; `0` means no heading) |
 | `session_type` | The region the block belongs to: `body` `preface` `TOC` `references` `appendix` |

--- a/lightrag/parser/docx/parse_document.py
+++ b/lightrag/parser/docx/parse_document.py
@@ -1527,9 +1527,6 @@ def extract_docx_blocks(
     current_heading_stack = {}  # {level: heading_text} - Use dict to correctly track heading hierarchy
     current_parent_headings = []  # Parent headings for current block
     current_paragraphs = []  # Track paragraphs with metadata for splitting
-    has_body_content = (
-        False  # Track if current block has body content (non-heading paragraphs/tables)
-    )
     matched_fixlevel_heading = False  # Track whether --fixlevel matched any heading
     table_split_counter = (
         0  # Track cumulative table split suffix numbers within current block
@@ -1607,9 +1604,12 @@ def extract_docx_blocks(
                     if fixlevel is not None and fixlevel > 0:
                         matched_fixlevel_heading = True
 
-                    # This heading triggers a block split
-                    # Only save previous block if it has body content
-                    if has_body_content and current_paragraphs:
+                    # This heading triggers a block split. Always flush the
+                    # accumulated paragraphs so every recognized heading starts
+                    # its own block. A heading with no body therefore becomes a
+                    # standalone block whose content is just the heading text,
+                    # instead of being folded into the next heading's block.
+                    if current_paragraphs:
                         _flush_current_block(
                             blocks,
                             current_heading,
@@ -1622,7 +1622,6 @@ def extract_docx_blocks(
 
                         # Reset for new block
                         current_paragraphs = []
-                        has_body_content = False
                         table_split_counter = (
                             0  # Reset table split counter for new heading
                         )
@@ -1664,9 +1663,6 @@ def extract_docx_blocks(
                     current_paragraphs.append(
                         {"text": truncated_text, "para_id": para_id, "is_table": False}
                     )
-
-                    # Mark that we have body content
-                    has_body_content = True
             else:
                 # Regular paragraph content
                 para_id = extract_para_id(element)
@@ -1679,9 +1675,6 @@ def extract_docx_blocks(
                 current_paragraphs.append(
                     {"text": full_text, "para_id": para_id, "is_table": False}
                 )
-
-                # Mark that we have body content
-                has_body_content = True
 
             # Check for paragraph-level section break (after processing paragraph)
             # sectPr in pPr means this paragraph ends a section
@@ -1776,7 +1769,6 @@ def extract_docx_blocks(
                                 "_table_header": header_rows_or_none,
                             }
                         )
-                        has_body_content = True
                     else:
                         # Middle or last chunk: save current block first
                         if current_paragraphs:
@@ -1790,7 +1782,6 @@ def extract_docx_blocks(
                                 debug,
                             )
                             current_paragraphs = []
-                            has_body_content = False
 
                         # Generate heading using suffix_number from chunk
                         if chunk["suffix_number"] is not None:
@@ -1841,7 +1832,6 @@ def extract_docx_blocks(
                                     "_table_header": header_rows_or_none,
                                 }
                             )
-                            has_body_content = True
                         else:
                             # Middle chunk: output immediately as standalone block
                             blocks.append(chunk_block)
@@ -1864,9 +1854,6 @@ def extract_docx_blocks(
                         "_table_header": header_rows_or_none,
                     }
                 )
-
-                # Mark that we have body content
-                has_body_content = True
 
             # Reset numbering tracking after table (table end boundary)
             resolver.reset_tracking_state()

--- a/lightrag/parser/external/docling/ir_builder.py
+++ b/lightrag/parser/external/docling/ir_builder.py
@@ -150,7 +150,6 @@ class DoclingIRBuilder:
         cb_heading = PREFACE_HEADING
         cb_level = 0
         cb_parents: list[str] = []
-        cb_has_body = False
 
         visited: set[str] = set()
         kv_count = len(doc.get("key_value_items") or [])
@@ -160,7 +159,7 @@ class DoclingIRBuilder:
 
         def _flush_block() -> None:
             nonlocal cb_lines, cb_tables, cb_drawings, cb_equations
-            nonlocal cb_page_set, cb_bbox_positions, cb_has_body
+            nonlocal cb_page_set, cb_bbox_positions
             has_payload = bool(cb_lines or cb_tables or cb_drawings or cb_equations)
             if not has_payload:
                 return
@@ -169,7 +168,6 @@ class DoclingIRBuilder:
                 cb_lines = []
                 cb_page_set = set()
                 cb_bbox_positions = []
-                cb_has_body = False
                 return
             positions = [
                 IRPosition(type="bbox", anchor=p)
@@ -193,7 +191,6 @@ class DoclingIRBuilder:
             cb_equations = []
             cb_page_set = set()
             cb_bbox_positions = []
-            cb_has_body = False
 
         def _open_block(heading: str, level: int, parents: list[str]) -> None:
             nonlocal cb_heading, cb_level, cb_parents
@@ -203,16 +200,10 @@ class DoclingIRBuilder:
             md_prefix = "#" * max(level, 1)
             cb_lines.append(f"{md_prefix} {heading}")
 
-        def _merge_heading_as_body(heading: str, level: int) -> None:
-            md_prefix = "#" * max(level, 1)
-            cb_lines.append(f"{md_prefix} {heading}")
-
         def _append_text(text: str) -> bool:
-            nonlocal cb_has_body
             if not text:
                 return False
             cb_lines.append(text)
-            cb_has_body = True
             return True
 
         def _record_positions(item: dict) -> None:
@@ -350,7 +341,7 @@ class DoclingIRBuilder:
                 _append_text(line)
 
         def _handle_text(item: dict) -> None:
-            nonlocal doc_title, heading_stack, cb_has_body
+            nonlocal doc_title, heading_stack
             label = str(item.get("label") or "").lower()
             text = _text_of(item).strip()
 
@@ -360,14 +351,10 @@ class DoclingIRBuilder:
                 heading_stack = heading_stack[: max(heading_level - 1, 0)]
                 parents = [h for h in heading_stack if h]
                 heading_stack.append(text)
-                # Adjacency merge
-                if cb_level > 0 and not cb_has_body and heading_level > cb_level:
-                    _merge_heading_as_body(text, heading_level)
-                    _record_positions(item)
-                    if not doc_title and heading_level == 1:
-                        doc_title = text
-                    _visit_children(item)
-                    return
+                # Every recognized heading starts its own block: flush the
+                # in-flight block (body or bare heading) and open a fresh one.
+                # A heading with no following body becomes a standalone block
+                # whose content is just the heading line.
                 _flush_block()
                 _open_block(text, heading_level, parents)
                 _record_positions(item)
@@ -421,7 +408,6 @@ class DoclingIRBuilder:
             if not placeholder:
                 return
             cb_lines.append(placeholder)
-            _bump_has_body()
             _record_positions(item)
 
         def _make_equation_placeholder(item: dict, *, is_block: bool) -> str:
@@ -441,10 +427,6 @@ class DoclingIRBuilder:
             )
             return f"{{{{{token}:{placeholder}}}}}"
 
-        def _bump_has_body() -> None:
-            nonlocal cb_has_body
-            cb_has_body = True
-
         def _handle_table(item: dict) -> None:
             table = _build_ir_table(item, ref_index)
             if table is None:
@@ -456,7 +438,6 @@ class DoclingIRBuilder:
             table.placeholder_key = placeholder
             cb_tables.append(table)
             cb_lines.append(f"{{{{TBL:{placeholder}}}}}")
-            _bump_has_body()
             _record_positions(item)
 
         def _handle_picture(item: dict) -> None:
@@ -476,7 +457,6 @@ class DoclingIRBuilder:
                 assets.append(asset)
             cb_drawings.append(drawing)
             cb_lines.append(f"{{{{IMG:{placeholder}}}}}")
-            _bump_has_body()
             _record_positions(item)
 
         # Kick off traversal from body.children

--- a/lightrag/parser/external/mineru/ir_builder.py
+++ b/lightrag/parser/external/mineru/ir_builder.py
@@ -175,11 +175,6 @@ class MinerUIRBuilder:
         cb_heading = PREFACE_HEADING
         cb_level = 0
         cb_parents: list[str] = []
-        # ``cb_has_body`` flips True the moment we accumulate any non-heading
-        # payload into the current block. While it stays False, an adjacent
-        # deeper heading is folded into this block as a body line (aligning
-        # with the native docx parser's behaviour for back-to-back headings).
-        cb_has_body = False
 
         def _record_position(item: dict) -> None:
             """Route an item's positional info into the right channel.
@@ -200,7 +195,7 @@ class MinerUIRBuilder:
         def _flush_block() -> None:
             """Emit the in-flight block if it carries any content."""
             nonlocal cb_lines, cb_tables, cb_drawings, cb_equations
-            nonlocal cb_page_set, cb_bbox_positions, cb_has_body
+            nonlocal cb_page_set, cb_bbox_positions
             has_payload = bool(cb_lines or cb_tables or cb_drawings or cb_equations)
             if not has_payload:
                 return
@@ -210,7 +205,6 @@ class MinerUIRBuilder:
                 cb_lines = []
                 cb_page_set = set()
                 cb_bbox_positions = []
-                cb_has_body = False
                 return
             positions = [
                 IRPosition(type="bbox", anchor=p)
@@ -234,7 +228,6 @@ class MinerUIRBuilder:
             cb_equations = []
             cb_page_set = set()
             cb_bbox_positions = []
-            cb_has_body = False
 
         def _open_block(heading: str, level: int, parents: list[str]) -> None:
             nonlocal cb_heading, cb_level, cb_parents
@@ -252,23 +245,10 @@ class MinerUIRBuilder:
             decide whether to also record the item's source position — an
             empty text item must NOT leak its ``page_idx`` to the block.
             """
-            nonlocal cb_has_body
             if not text:
                 return False
             cb_lines.append(text)
-            cb_has_body = True
             return True
-
-        def _merge_heading_as_body(heading: str, level: int) -> None:
-            """Fold an adjacent deeper heading into the current block.
-
-            The line keeps its markdown ``#`` prefix so the rendered block
-            still reads as ``# Section\n## Subsection``. Does NOT flip
-            ``cb_has_body`` — successive headings can keep folding until a
-            real body item lands.
-            """
-            md_prefix = "#" * max(level, 1)
-            cb_lines.append(f"{md_prefix} {heading}")
 
         for item_index, item in enumerate(content_list):
             if not isinstance(item, dict):
@@ -284,17 +264,11 @@ class MinerUIRBuilder:
                 parents = [h for h in heading_stack if h]
                 heading_stack.append(heading_text)
 
-                # Adjacency merge: previous block is a real heading with no
-                # body yet AND the new heading is strictly deeper — append
-                # this heading as body to the existing block instead of
-                # flushing. (Preface, level=0, is never merged into.)
-                if cb_level > 0 and not cb_has_body and heading_level > cb_level:
-                    _merge_heading_as_body(heading_text, heading_level)
-                    _record_position(item)
-                    if not doc_title and heading_level == 1:
-                        doc_title = heading_text
-                    continue
-
+                # Every recognized heading starts its own block: flush the
+                # in-flight block (whether it had body or was a bare heading)
+                # and open a fresh one. A heading with no following body thus
+                # becomes a standalone block whose content is just the heading
+                # line, matching the native docx parser's behaviour.
                 _flush_block()
                 _open_block(heading_text, heading_level, parents)
                 _record_position(item)
@@ -348,7 +322,6 @@ class MinerUIRBuilder:
                     )
                 )
                 cb_lines.append(f"{{{{{token}:{placeholder}}}}}")
-                cb_has_body = True
                 _record_position(item)
                 continue
 
@@ -364,7 +337,6 @@ class MinerUIRBuilder:
                 table.self_ref = _content_list_self_ref(item_index)
                 cb_tables.append(table)
                 cb_lines.append(f"{{{{TBL:{placeholder}}}}}")
-                cb_has_body = True
                 _record_position(item)
                 continue
 
@@ -377,7 +349,6 @@ class MinerUIRBuilder:
                     assets.append(asset)
                 cb_drawings.append(drawing)
                 cb_lines.append(f"{{{{IMG:{placeholder}}}}}")
-                cb_has_body = True
                 _record_position(item)
                 continue
 

--- a/tests/parser/docx/test_native_docx_extract.py
+++ b/tests/parser/docx/test_native_docx_extract.py
@@ -18,6 +18,7 @@ from io import BytesIO
 
 import pytest
 from docx import Document
+from docx.oxml import OxmlElement
 from docx.oxml.ns import qn
 from lxml import etree
 
@@ -139,6 +140,66 @@ def _build_docx_with_three_tables() -> BytesIO:
     doc.save(buf)
     buf.seek(0)
     return buf
+
+
+# --- end-to-end: every heading becomes its own block ----------------------
+
+
+def _add_heading(doc, text: str, level: int) -> None:
+    """Append a heading paragraph with an explicit ``w:outlineLvl``.
+
+    Setting outlineLvl directly on the paragraph (rather than relying on the
+    template's built-in Heading styles) keeps ``get_heading_level`` detection
+    deterministic. ``level`` is 1-based (1 = H1); outlineLvl val is 0-based.
+    """
+    para = doc.add_paragraph(text)
+    pPr = para._p.get_or_add_pPr()
+    outline = OxmlElement("w:outlineLvl")
+    outline.set(qn("w:val"), str(level - 1))
+    pPr.append(outline)
+
+
+@pytest.mark.offline
+def test_each_heading_becomes_its_own_block(tmp_path) -> None:
+    """Headings with no body must each form a standalone block.
+
+    Layout: H1 (no body) → H2 (no body) → H3 (with body) → H1 (no body, last).
+    Previously the empty H1/H2 were folded into the next heading's block; now
+    every recognized heading starts its own block. A heading with no following
+    body yields a block whose ``content`` is just the heading text, while a
+    heading with body merges that body into the same block. ``parent_headings``
+    must track the outline hierarchy correctly.
+    """
+    doc = Document()
+    _add_heading(doc, "Chapter One", level=1)
+    _add_heading(doc, "Section 1.1", level=2)
+    _add_heading(doc, "Subsection 1.1.1", level=3)
+    doc.add_paragraph("Body text under subsection.")
+    _add_heading(doc, "Appendix", level=1)
+
+    buf = BytesIO()
+    doc.save(buf)
+    docx_path = tmp_path / "headings.docx"
+    docx_path.write_bytes(buf.getvalue())
+
+    # fixlevel=0 mirrors the production path (pipeline.py): split at every
+    # heading level, no token-based splitting or small-block merging.
+    blocks = extract_docx_blocks(str(docx_path), fixlevel=0)
+
+    summary = [
+        (b["heading"], b["content"], b["level"], b["parent_headings"]) for b in blocks
+    ]
+    assert summary == [
+        ("Chapter One", "Chapter One", 1, []),
+        ("Section 1.1", "Section 1.1", 2, ["Chapter One"]),
+        (
+            "Subsection 1.1.1",
+            "Subsection 1.1.1\nBody text under subsection.",
+            3,
+            ["Chapter One", "Section 1.1"],
+        ),
+        ("Appendix", "Appendix", 1, []),
+    ]
 
 
 @pytest.mark.offline

--- a/tests/parser/external/docling/test_ir_builder.py
+++ b/tests/parser/external/docling/test_ir_builder.py
@@ -159,9 +159,12 @@ def test_docling_adapter_simple_heading_hierarchy(tmp_path: Path) -> None:
     assert ir.blocks[2].content_template.splitlines()[0] == "### Details"
 
 
-def test_docling_adapter_adjacency_merge_folds_empty_heading(tmp_path: Path) -> None:
-    """When a heading block has no body and the next heading is deeper,
-    the deeper heading folds in as a body line (matches MinerU §5.1.4)."""
+def test_docling_adapter_empty_heading_becomes_standalone_block(
+    tmp_path: Path,
+) -> None:
+    """A heading with no body becomes its own standalone block whose content
+    is just the heading line; the following heading (with body) is a separate
+    block. No adjacency folding (matches the native docx parser)."""
     texts = [
         _text_item(label="title", text="Whole Doc Title", self_ref="#/texts/0"),
         _text_item(
@@ -177,15 +180,18 @@ def test_docling_adapter_adjacency_merge_folds_empty_heading(tmp_path: Path) -> 
         ),
     )
     ir = DoclingIRBuilder().normalize_from_workdir(raw_dir, document_name="demo.pdf")
-    # Title had no body → Background folded into it as a `## ` line
-    assert len(ir.blocks) == 1
-    block = ir.blocks[0]
-    assert block.heading == "Whole Doc Title"
-    assert block.level == 1
-    lines = block.content_template.splitlines()
-    assert lines[0] == "# Whole Doc Title"
-    assert "## Background" in lines
-    assert "Body for Background." in lines
+    summary = [
+        (b.heading, b.content_template, b.level, b.parent_headings) for b in ir.blocks
+    ]
+    assert summary == [
+        ("Whole Doc Title", "# Whole Doc Title", 1, []),
+        (
+            "Background",
+            "## Background\nBody for Background.",
+            2,
+            ["Whole Doc Title"],
+        ),
+    ]
 
 
 def test_docling_adapter_preserves_docling_heading_level(tmp_path: Path) -> None:

--- a/tests/parser/external/mineru/test_ir_builder.py
+++ b/tests/parser/external/mineru/test_ir_builder.py
@@ -324,10 +324,11 @@ def test_adapter_empty_text_item_does_not_leak_page_to_block(
 
 
 @pytest.mark.offline
-def test_adapter_adjacent_deeper_heading_merged_as_body(tmp_path: Path) -> None:
-    """Two headings in a row with no body between them: when the second is
-    strictly deeper (level number larger), it folds into the first heading's
-    block as a body line. Mirrors the native docx parser's behaviour.
+def test_adapter_each_heading_starts_its_own_block(tmp_path: Path) -> None:
+    """Every recognized heading starts its own block. Back-to-back headings
+    with no body between them are NOT folded — each becomes a standalone
+    block whose content is just the heading line; the heading that does have
+    a following body merges that body in. Mirrors the native docx parser.
     """
     raw = _write_bundle(
         tmp_path,
@@ -342,25 +343,20 @@ def test_adapter_adjacent_deeper_heading_merged_as_body(tmp_path: Path) -> None:
     )
     ir = MinerUIRBuilder().normalize_from_workdir(raw, document_name="m.pdf")
 
-    # First "1 Top" absorbs the immediately-following deeper headings;
-    # body lands inside the same block. Then a new top-level heading
-    # opens a fresh block.
-    assert len(ir.blocks) == 2
-
-    merged = ir.blocks[0]
-    assert merged.heading == "1 Top"
-    assert merged.level == 1
-    assert merged.parent_headings == []
-    assert merged.content_template == (
-        "# 1 Top\n## 1.1 Mid\n### 1.1.1 Deep\nBody for deep."
-    )
-
-    fresh = ir.blocks[1]
-    assert fresh.heading == "2 Top Again"
-    assert fresh.level == 1
-    # Heading stack reset cleanly — no stale deep parents leak.
-    assert fresh.parent_headings == []
-    assert fresh.content_template == "# 2 Top Again\nMore body."
+    summary = [
+        (b.heading, b.content_template, b.level, b.parent_headings) for b in ir.blocks
+    ]
+    assert summary == [
+        ("1 Top", "# 1 Top", 1, []),
+        ("1.1 Mid", "## 1.1 Mid", 2, ["1 Top"]),
+        (
+            "1.1.1 Deep",
+            "### 1.1.1 Deep\nBody for deep.",
+            3,
+            ["1 Top", "1.1 Mid"],
+        ),
+        ("2 Top Again", "# 2 Top Again\nMore body.", 1, []),
+    ]
 
 
 @pytest.mark.offline


### PR DESCRIPTION
## Description

Make **every recognized heading start its own block** across all three parsing engines (native docx, MinerU, Docling).

Previously a heading with no body was folded/absorbed into the next heading's block:
- the **docx** parser kept it as a content line under the *first* heading (the `has_body_content` guard only flushed a block when it carried body), and
- the **MinerU / Docling** IR builders merged a deeper adjacent heading in as a body line (the `cb_has_body` adjacency-merge branch).

As a result, parent/empty headings — chapter titles whose subsections carry the actual content — were lost or mis-attributed to a sibling/ancestor heading.

After this change:
- A heading immediately followed by body text merges that body into the same block (`content` = heading + body).
- A heading with **no** following body becomes a standalone block whose `content` is just the heading text.
- Consecutive headings each become their own block, and `parent_headings` are derived correctly from the heading stack.

The "concatenating all blocks' `content` reconstructs the full document" invariant is preserved (each heading's text appears in exactly one block, no loss, no overlap), and the three engines now behave identically with respect to heading → block mapping.

## Related Issues

N/A

## Changes Made

- **docx** (`lightrag/parser/docx/parse_document.py`): flush the accumulated paragraphs on every splitting heading regardless of whether body content was seen; remove the now-dead `has_body_content` tracking.
- **MinerU** (`lightrag/parser/external/mineru/ir_builder.py`): remove the adjacency-merge branch so each heading opens a fresh block; drop the now-dead `cb_has_body` state and `_merge_heading_as_body` helper.
- **Docling** (`lightrag/parser/external/docling/ir_builder.py`): same removal, plus the now-unused `_bump_has_body` helper.
- **Docs**: update the `heading` field description in both `docs/LightRAGSidecarFormat.md` and `docs/LightRAGSidecarFormat-zh.md` to describe the new per-heading behavior (old wording said the next-level heading was treated as body text).
- **Tests**: add/update coverage for the new per-heading behavior in all three engines' test suites.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

- Production parsing runs the docx parser at `fixlevel=0`, where `merge_small_blocks` is skipped — so heading-only blocks survive to `blocks.jsonl` as intended.
- The P (paragraph-semantic) chunker consumes the new format correctly: its Stage D small-block merging consolidates the now-more-numerous heading-only blocks, content/blockid traceability/hierarchy are all preserved. Note this is **not** byte-identical to pre-change P output — at former fold boundaries the in-block separator changes from `\n` to `\n\n` (Stage D join) and `sidecar.refs` becomes finer-grained (one blockid per heading). Re-ingesting an existing document will therefore re-chunk it; any byte-level golden snapshots of P output need regenerating.
- Local run: `tests/parser/ tests/chunker/` → 333 passed; `ruff check` clean on all touched files.
