### PR TITLE
Backfill block sidecars for F/R/V chunking strategies

### DIFF
--- a/lightrag/exceptions.py
+++ b/lightrag/exceptions.py
@@ -131,6 +131,36 @@ class ChunkTokenLimitExceededError(ValueError):
         self.chunk_preview = truncated_preview
 
 
+class ChunkBlockMatchError(ValueError):
+    """Raised when a chunk cannot be located in the document's blocks.jsonl.
+
+    Sidecar backfill (``lightrag.sidecar.backfill``) maps F/R/V chunks back to
+    their source block(s) by matching chunk content against the parse-time
+    ``*.blocks.jsonl`` merged text. When a sidecar-less chunk cannot be located,
+    this is raised so the pipeline marks the document FAILED rather than
+    persisting chunks with missing/incorrect provenance.
+    """
+
+    def __init__(
+        self,
+        chunk_order_index: int,
+        chunk_preview: str | None = None,
+        blocks_path: str | None = None,
+    ) -> None:
+        preview = chunk_preview.strip() if chunk_preview else None
+        truncated_preview = preview[:80] if preview else None
+        preview_note = f" Preview: '{truncated_preview}'" if truncated_preview else ""
+        path_note = f" (blocks: {blocks_path})" if blocks_path else ""
+        message = (
+            f"Chunk #{chunk_order_index} could not be located in the document "
+            f"blocks during sidecar backfill.{preview_note}{path_note}"
+        )
+        super().__init__(message)
+        self.chunk_order_index = chunk_order_index
+        self.chunk_preview = truncated_preview
+        self.blocks_path = blocks_path
+
+
 class DataMigrationError(Exception):
     """Raised when data migration from legacy collection/table fails."""
 

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -2023,24 +2023,6 @@ class _PipelineMixin:
                         f"got {type(chunking_result)}"
                     )
 
-                # Sidecar backfill (below, after the hard-split) only runs for the
-                # built-in F/R/V strategies — or the legacy path when it is still
-                # the unmodified default fixed-token chunker. A user-supplied
-                # ``chunking_func`` may emit summaries / rewritten text that cannot
-                # be located in blocks.jsonl, which would wrongly FAIL the document.
-                if doc_process_opts.chunking_explicit:
-                    sidecar_backfill_eligible = doc_process_opts.chunking in {
-                        "F",
-                        "R",
-                        "V",
-                    }
-                else:
-                    from lightrag.chunker import chunking_by_token_size
-
-                    sidecar_backfill_eligible = (
-                        self.chunking_func is chunking_by_token_size
-                    )
-
                 # Reflect the format actually persisted in full_docs.
                 # Previously a structured-parse fallback always tagged
                 # parse_format=raw, which silently mislabelled lightrag docs;
@@ -2143,6 +2125,25 @@ class _PipelineMixin:
                 # chunk list so each slice maps precisely to the block(s) its
                 # content covers. Raises ChunkBlockMatchError -> doc FAILED when a
                 # chunk cannot be located in blocks.jsonl.
+                #
+                # Gated to the built-in F/R/V strategies — or the legacy path only
+                # when ``chunking_func`` is still the unmodified default fixed-token
+                # chunker. A user-supplied ``chunking_func`` may emit summaries /
+                # rewritten text that cannot be located in blocks.jsonl, which would
+                # wrongly FAIL the document.
+                if doc_process_opts.chunking_explicit:
+                    sidecar_backfill_eligible = doc_process_opts.chunking in {
+                        "F",
+                        "R",
+                        "V",
+                    }
+                else:
+                    from lightrag.chunker import chunking_by_token_size
+
+                    sidecar_backfill_eligible = (
+                        self.chunking_func is chunking_by_token_size
+                    )
+
                 if blocks_path and sidecar_backfill_eligible:
                     from lightrag.sidecar import backfill_chunk_sidecars
 

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -2023,6 +2023,24 @@ class _PipelineMixin:
                         f"got {type(chunking_result)}"
                     )
 
+                # Sidecar backfill (below, after the hard-split) only runs for the
+                # built-in F/R/V strategies — or the legacy path when it is still
+                # the unmodified default fixed-token chunker. A user-supplied
+                # ``chunking_func`` may emit summaries / rewritten text that cannot
+                # be located in blocks.jsonl, which would wrongly FAIL the document.
+                if doc_process_opts.chunking_explicit:
+                    sidecar_backfill_eligible = doc_process_opts.chunking in {
+                        "F",
+                        "R",
+                        "V",
+                    }
+                else:
+                    from lightrag.chunker import chunking_by_token_size
+
+                    sidecar_backfill_eligible = (
+                        self.chunking_func is chunking_by_token_size
+                    )
+
                 # Reflect the format actually persisted in full_docs.
                 # Previously a structured-parse fallback always tagged
                 # parse_format=raw, which silently mislabelled lightrag docs;
@@ -2119,6 +2137,16 @@ class _PipelineMixin:
                         extraction_meta["hard_fallback_split"] = (
                             f"{original_chunk_count} -> {len(chunking_result)}"
                         )
+
+                # Backfill block provenance for F/R/V chunks (P already carries
+                # sidecars; multimodal chunks too). Runs on the final, post-split
+                # chunk list so each slice maps precisely to the block(s) its
+                # content covers. Raises ChunkBlockMatchError -> doc FAILED when a
+                # chunk cannot be located in blocks.jsonl.
+                if blocks_path and sidecar_backfill_eligible:
+                    from lightrag.sidecar import backfill_chunk_sidecars
+
+                    backfill_chunk_sidecars(chunking_result, blocks_path)
 
                 chunks = build_chunks_dict_from_chunking_result(
                     chunking_result, doc_id=doc_id, file_path=file_path

--- a/lightrag/sidecar/__init__.py
+++ b/lightrag/sidecar/__init__.py
@@ -10,6 +10,7 @@ emits the spec-compliant ``*.parsed/`` directory.
 See :func:`lightrag.sidecar.writer.write_sidecar` for the entry point.
 """
 
+from lightrag.sidecar.backfill import backfill_chunk_sidecars
 from lightrag.sidecar.ir import (
     AssetSpec,
     IRBlock,
@@ -29,5 +30,6 @@ __all__ = [
     "IREquation",
     "IRPosition",
     "IRTable",
+    "backfill_chunk_sidecars",
     "write_sidecar",
 ]

--- a/lightrag/sidecar/backfill.py
+++ b/lightrag/sidecar/backfill.py
@@ -151,6 +151,51 @@ def _covered_blockids(
     return covered
 
 
+def _locate_chunk(norm_merged: str, nq: str, prev_start: int, covered_end: int) -> int:
+    """Locate ``nq`` consistently with forward, contiguous chunking; -1 if absent.
+
+    Contiguous F/R/V chunking covers the merged text in order with overlaps, so each
+    chunk starts strictly after the previous chunk's start and at/before the furthest
+    offset covered so far (``covered_end``) — overlap or adjacency, never a gap. When
+    ``nq`` occurs more than once we resolve it using *both* endpoints:
+
+    - Prefer the occurrence that reaches **furthest forward within the reachable
+      window** ``(prev_start, covered_end]`` (largest start, hence largest end). This
+      maps a short overlap-tail chunk to the block its content actually advances into
+      — e.g. the token that followed a now-stripped separator — instead of an earlier
+      duplicate still sitting inside the previous chunk.
+    - If nothing matches inside the window, take the first occurrence after
+      ``prev_start`` (a forward jump: the first chunk, or non-contiguous inputs).
+    - Only if the text exists nowhere after ``prev_start`` do we accept an occurrence
+      at ``prev_start`` itself — a trailing duplicate clamped at the document end,
+      where two adjacent windows reduce to the same source token.
+
+    A ``prev_end``-only anchor skips overlap matches (they sit before ``prev_end``) and
+    can jump to a spurious *later* duplicate; a ``prev_start``-only anchor accepts an
+    *earlier* duplicate inside the previous chunk. The windowed rule avoids both.
+    """
+    best = -1
+    first_after = -1
+    search = prev_start + 1
+    while True:
+        p = norm_merged.find(nq, search)
+        if p == -1:
+            break
+        if first_after == -1:
+            first_after = p
+        if p <= covered_end:
+            best = p  # within the reachable window; keep the furthest-forward one
+            search = p + 1
+        else:
+            break  # occurrences only get later; nothing more inside the window
+    if best != -1:
+        return best
+    if first_after != -1:
+        return first_after
+    # Nothing strictly after prev_start: allow a clamped trailing duplicate at it.
+    return norm_merged.find(nq, prev_start) if prev_start >= 0 else -1
+
+
 def backfill_chunk_sidecars(
     chunking_result: list[dict[str, Any]],
     blocks_path: str,
@@ -180,17 +225,12 @@ def backfill_chunk_sidecars(
 
     norm_merged, norm_to_orig = _normalize_projection(merged)
 
-    # Forward-only cursor keyed on each chunk's *start* offset in the normalized
-    # text. Contiguous F/R/V chunking guarantees the next chunk begins strictly
-    # after the previous chunk's start (positive step) and at/before its end (token
-    # overlap or plain adjacency — never a gap). So the correct match is the first
-    # occurrence strictly past ``prev_start``: it lands on the overlap position for
-    # F/R chunks that begin inside the previous chunk and on the next occurrence for
-    # adjacent / repeated content. A ``prev_end`` anchor is structurally wrong here —
-    # an overlap match always sits before ``prev_end``, so searching from ``prev_end``
-    # skips it and can grab a spurious *later* duplicate of the same text, which then
-    # strands the following chunk and raises a false ChunkBlockMatchError.
+    # Forward cursor over the normalized text. ``prev_start`` is the previous chunk's
+    # matched start; ``covered_end`` the furthest offset matched so far. ``_locate_chunk``
+    # uses both to place each chunk consistently with contiguous, overlapping chunking
+    # — see its docstring for why neither endpoint alone suffices.
     prev_start = -1
+    covered_end = 0
     for chunk in chunking_result:
         if not isinstance(chunk, dict):
             continue
@@ -204,7 +244,7 @@ def backfill_chunk_sidecars(
         if not nq:
             continue
 
-        pos = norm_merged.find(nq, prev_start + 1)
+        pos = _locate_chunk(norm_merged, nq, prev_start, covered_end)
         if pos == -1:
             raise ChunkBlockMatchError(
                 chunk_order_index=int(chunk.get("chunk_order_index", -1)),
@@ -217,6 +257,7 @@ def backfill_chunk_sidecars(
         # Map the last matched normalized char back, then extend one past it.
         o_end = norm_to_orig[norm_end - 1] + 1
         prev_start = pos
+        covered_end = max(covered_end, norm_end)
 
         covered = _covered_blockids(spans, o_start, o_end)
         if not covered:

--- a/lightrag/sidecar/backfill.py
+++ b/lightrag/sidecar/backfill.py
@@ -18,13 +18,19 @@ content within it.
 
 F decodes/strips token windows (verbatim substrings, with token overlap); R strips
 LangChain pieces (verbatim, possible overlap); V strips ``SemanticChunker`` pieces
-that rejoin sentences with a single space (so newlines become spaces and the text is
-*not* byte-verbatim). To cover all three uniformly, matching runs over a
-whitespace-normalized projection of both sides.
+that rejoin sentences with a single space — so newlines collapse to spaces *and* a
+space may be inserted between sentences that were originally adjacent with no
+whitespace, making the text *not* byte-verbatim. To cover all three uniformly,
+matching runs over a **whitespace-stripped** projection of both sides (every
+whitespace char removed, not merely collapsed to a single space). Because whitespace
+removal is monotonic, a chunk's non-whitespace characters are always a contiguous
+substring of the merged text's non-whitespace characters — regardless of how either
+side spaced them — so V's reflowing can never spuriously fail a match.
 
 Multimodal placeholder tags (``<table …>…</table>``, ``<drawing …/>``,
 ``<equation …>…</equation>``) appear identically in block content and chunk content,
-so they match verbatim — markup is never stripped before matching.
+so they project identically under whitespace stripping and match — markup is never
+stripped before matching.
 """
 
 from __future__ import annotations
@@ -48,6 +54,13 @@ def _load_content_blocks(blocks_path: str) -> list[tuple[str, str]]:
     Returns ``(blockid, raw_content)`` pairs, skipping the meta header and any
     malformed lines. Mirrors ``paragraph_semantic._load_blocks_from_jsonl`` but
     keeps the raw (un-stripped) content needed to reproduce the chunker input.
+
+    Note: ``utils_pipeline.load_lightrag_document_content`` (which produces the
+    merged text the chunker actually received) skips line 0 *by index*; here we
+    skip *by type* instead. The two agree only because ``writer.write_sidecar``
+    always emits the meta header as the very first line — under that invariant
+    skip-by-type is equivalent, and it stays correct even if a stray non-content
+    row ever appears mid-file.
     """
     blocks: list[tuple[str, str]] = []
     with Path(blocks_path).open("r", encoding="utf-8") as fh:
@@ -96,36 +109,32 @@ def _build_block_spans(
 
 
 def _normalize_projection(merged: str) -> tuple[str, list[int]]:
-    """Collapse whitespace runs to single spaces; map back to merged offsets.
+    """Drop every whitespace char; map each kept char back to its merged offset.
 
     Returns ``(norm_text, norm_to_orig)`` where ``norm_to_orig[i]`` is the offset
-    in ``merged`` of the ``i``-th normalized character. Leading/trailing whitespace
-    is dropped so chunk- and merged-side normalization agree at boundaries.
+    in ``merged`` of the ``i``-th surviving (non-whitespace) character. Removing all
+    whitespace — rather than collapsing runs to a single space — keeps the two sides
+    aligned even when V inserts a space between originally-adjacent sentences. Because
+    whitespace removal is monotonic, any contiguous region of ``merged`` projects to a
+    contiguous substring of ``norm_text``, so chunk lookups stay exact.
     """
     norm_chars: list[str] = []
     norm_to_orig: list[int] = []
-    prev_space = True  # leading-space suppression
     for idx, ch in enumerate(merged):
         if ch.isspace():
-            if prev_space:
-                continue
-            norm_chars.append(" ")
-            norm_to_orig.append(idx)
-            prev_space = True
-        else:
-            norm_chars.append(ch)
-            norm_to_orig.append(idx)
-            prev_space = False
-    # Drop a single trailing space if present.
-    if norm_chars and norm_chars[-1] == " ":
-        norm_chars.pop()
-        norm_to_orig.pop()
+            continue
+        norm_chars.append(ch)
+        norm_to_orig.append(idx)
     return "".join(norm_chars), norm_to_orig
 
 
 def _normalize_text(text: str) -> str:
-    """Whitespace-normalized form of a chunk body (collapse runs, strip ends)."""
-    return " ".join(text.split())
+    """Whitespace-stripped form of a chunk body (every whitespace char removed).
+
+    Uses ``str.split()``'s whitespace definition, which matches ``str.isspace()``
+    used by :func:`_normalize_projection`, so both sides agree on what is stripped.
+    """
+    return "".join(text.split())
 
 
 def _covered_blockids(

--- a/lightrag/sidecar/backfill.py
+++ b/lightrag/sidecar/backfill.py
@@ -151,49 +151,40 @@ def _covered_blockids(
     return covered
 
 
-def _locate_chunk(norm_merged: str, nq: str, prev_start: int, covered_end: int) -> int:
+def _locate_chunk(norm_merged: str, nq: str, prev_start: int, prev_end: int) -> int:
     """Locate ``nq`` consistently with forward, contiguous chunking; -1 if absent.
 
-    Contiguous F/R/V chunking covers the merged text in order with overlaps, so each
-    chunk starts strictly after the previous chunk's start and at/before the furthest
-    offset covered so far (``covered_end``) — overlap or adjacency, never a gap. When
-    ``nq`` occurs more than once we resolve it using *both* endpoints:
+    F/R/V chunks cover the merged text in order. With token overlap each chunk shares
+    a prefix with the previous one but always adds new content *past* it, so its end
+    advances forward. Starts are not a reliable signal: stripping the whitespace a
+    window falls on can make two consecutive chunks share a start (e.g. a window whose
+    only non-whitespace content begins right after a separator that the next window
+    also begins with). The chunk **end** is the dependable monotonic anchor.
 
-    - Prefer the occurrence that reaches **furthest forward within the reachable
-      window** ``(prev_start, covered_end]`` (largest start, hence largest end). This
-      maps a short overlap-tail chunk to the block its content actually advances into
-      — e.g. the token that followed a now-stripped separator — instead of an earlier
-      duplicate still sitting inside the previous chunk.
-    - If nothing matches inside the window, take the first occurrence after
-      ``prev_start`` (a forward jump: the first chunk, or non-contiguous inputs).
-    - Only if the text exists nowhere after ``prev_start`` do we accept an occurrence
-      at ``prev_start`` itself — a trailing duplicate clamped at the document end,
-      where two adjacent windows reduce to the same source token.
+    - Primary: the leftmost occurrence at/after ``prev_start`` whose end passes
+      ``prev_end`` (the previous chunk's end). Requiring forward end-progress rejects a
+      pure-suffix duplicate sitting inside the previous chunk — it adds no new coverage
+      — while taking the *leftmost* qualifying occurrence resolves an overlap chunk to
+      its true position instead of a spurious *later* duplicate of the same text.
+    - Fallback: when nothing extends coverage — a chunk clamped at the document tail,
+      or a window that reduced to a duplicate of the previous one — the leftmost
+      occurrence at/after ``prev_start`` (or -1 when the text is absent entirely).
 
-    A ``prev_end``-only anchor skips overlap matches (they sit before ``prev_end``) and
-    can jump to a spurious *later* duplicate; a ``prev_start``-only anchor accepts an
-    *earlier* duplicate inside the previous chunk. The windowed rule avoids both.
+    A ``prev_end``-only anchor skips overlap matches (they begin before ``prev_end``)
+    and can jump to a later duplicate; a ``prev_start``-only anchor accepts an earlier
+    duplicate inside the previous chunk or, after a stripped separator, cannot advance.
+    Anchoring on end-progress avoids all three.
     """
-    best = -1
-    first_after = -1
-    search = prev_start + 1
+    length = len(nq)
+    search = prev_start
     while True:
         p = norm_merged.find(nq, search)
         if p == -1:
             break
-        if first_after == -1:
-            first_after = p
-        if p <= covered_end:
-            best = p  # within the reachable window; keep the furthest-forward one
-            search = p + 1
-        else:
-            break  # occurrences only get later; nothing more inside the window
-    if best != -1:
-        return best
-    if first_after != -1:
-        return first_after
-    # Nothing strictly after prev_start: allow a clamped trailing duplicate at it.
-    return norm_merged.find(nq, prev_start) if prev_start >= 0 else -1
+        if p + length > prev_end:
+            return p
+        search = p + 1
+    return norm_merged.find(nq, prev_start)
 
 
 def backfill_chunk_sidecars(
@@ -226,11 +217,11 @@ def backfill_chunk_sidecars(
     norm_merged, norm_to_orig = _normalize_projection(merged)
 
     # Forward cursor over the normalized text. ``prev_start`` is the previous chunk's
-    # matched start; ``covered_end`` the furthest offset matched so far. ``_locate_chunk``
-    # uses both to place each chunk consistently with contiguous, overlapping chunking
-    # — see its docstring for why neither endpoint alone suffices.
-    prev_start = -1
-    covered_end = 0
+    # matched start; ``prev_end`` the furthest offset covered so far (monotonic, since
+    # each chunk's end advances). ``_locate_chunk`` anchors on end-progress to place
+    # each chunk consistently with contiguous, overlapping chunking — see its docstring.
+    prev_start = 0
+    prev_end = 0
     for chunk in chunking_result:
         if not isinstance(chunk, dict):
             continue
@@ -244,7 +235,7 @@ def backfill_chunk_sidecars(
         if not nq:
             continue
 
-        pos = _locate_chunk(norm_merged, nq, prev_start, covered_end)
+        pos = _locate_chunk(norm_merged, nq, prev_start, prev_end)
         if pos == -1:
             raise ChunkBlockMatchError(
                 chunk_order_index=int(chunk.get("chunk_order_index", -1)),
@@ -257,7 +248,7 @@ def backfill_chunk_sidecars(
         # Map the last matched normalized char back, then extend one past it.
         o_end = norm_to_orig[norm_end - 1] + 1
         prev_start = pos
-        covered_end = max(covered_end, norm_end)
+        prev_end = max(prev_end, norm_end)
 
         covered = _covered_blockids(spans, o_start, o_end)
         if not covered:

--- a/lightrag/sidecar/backfill.py
+++ b/lightrag/sidecar/backfill.py
@@ -180,12 +180,17 @@ def backfill_chunk_sidecars(
 
     norm_merged, norm_to_orig = _normalize_projection(merged)
 
-    # Forward-only cursor over the normalized text. ``prev_end`` is preferred so
-    # repeated content and phrases recurring inside the previous chunk resolve to
-    # the next occurrence; ``prev_start`` is the overlap fallback for F/R chunks
-    # that legitimately begin inside the previous chunk's span.
-    prev_start = 0
-    prev_end = 0
+    # Forward-only cursor keyed on each chunk's *start* offset in the normalized
+    # text. Contiguous F/R/V chunking guarantees the next chunk begins strictly
+    # after the previous chunk's start (positive step) and at/before its end (token
+    # overlap or plain adjacency — never a gap). So the correct match is the first
+    # occurrence strictly past ``prev_start``: it lands on the overlap position for
+    # F/R chunks that begin inside the previous chunk and on the next occurrence for
+    # adjacent / repeated content. A ``prev_end`` anchor is structurally wrong here —
+    # an overlap match always sits before ``prev_end``, so searching from ``prev_end``
+    # skips it and can grab a spurious *later* duplicate of the same text, which then
+    # strands the following chunk and raises a false ChunkBlockMatchError.
+    prev_start = -1
     for chunk in chunking_result:
         if not isinstance(chunk, dict):
             continue
@@ -199,9 +204,7 @@ def backfill_chunk_sidecars(
         if not nq:
             continue
 
-        pos = norm_merged.find(nq, prev_end)
-        if pos == -1:
-            pos = norm_merged.find(nq, prev_start)
+        pos = norm_merged.find(nq, prev_start + 1)
         if pos == -1:
             raise ChunkBlockMatchError(
                 chunk_order_index=int(chunk.get("chunk_order_index", -1)),
@@ -213,7 +216,7 @@ def backfill_chunk_sidecars(
         o_start = norm_to_orig[pos]
         # Map the last matched normalized char back, then extend one past it.
         o_end = norm_to_orig[norm_end - 1] + 1
-        prev_start, prev_end = pos, norm_end
+        prev_start = pos
 
         covered = _covered_blockids(spans, o_start, o_end)
         if not covered:

--- a/lightrag/sidecar/backfill.py
+++ b/lightrag/sidecar/backfill.py
@@ -151,39 +151,74 @@ def _covered_blockids(
     return covered
 
 
-def _locate_chunk(norm_merged: str, nq: str, prev_start: int, prev_end: int) -> int:
+def _within_single_block(
+    spans: list[tuple[int, int, str]], o_start: int, o_end: int
+) -> bool:
+    """True if ``[o_start, o_end)`` lies entirely within one block's content span.
+
+    A block's content is contiguous (no internal gaps), so an interval contained in a
+    single ``(start, end)`` touches exactly that block. An interval that straddles a
+    separator gap is contained in no span and returns ``False``.
+    """
+    for start, end, _ in spans:
+        if start <= o_start and o_end <= end:
+            return True
+        if start > o_start:
+            break  # spans are start-ordered; no later span can contain o_start
+    return False
+
+
+def _locate_chunk(
+    norm_merged: str,
+    nq: str,
+    prev_start: int,
+    prev_end: int,
+    norm_to_orig: list[int],
+    spans: list[tuple[int, int, str]],
+) -> int:
     """Locate ``nq`` consistently with forward, contiguous chunking; -1 if absent.
 
     F/R/V chunks cover the merged text in order. With token overlap each chunk shares
     a prefix with the previous one but always adds new content *past* it, so its end
     advances forward. Starts are not a reliable signal: stripping the whitespace a
     window falls on can make two consecutive chunks share a start (e.g. a window whose
-    only non-whitespace content begins right after a separator that the next window
-    also begins with). The chunk **end** is the dependable monotonic anchor.
+    only non-whitespace content begins right after a separator the next window also
+    begins with). The chunk **end** is the dependable monotonic anchor, and we further
+    prefer matches that don't straddle a block boundary:
 
-    - Primary: the leftmost occurrence at/after ``prev_start`` whose end passes
-      ``prev_end`` (the previous chunk's end). Requiring forward end-progress rejects a
-      pure-suffix duplicate sitting inside the previous chunk — it adds no new coverage
-      — while taking the *leftmost* qualifying occurrence resolves an overlap chunk to
-      its true position instead of a spurious *later* duplicate of the same text.
-    - Fallback: when nothing extends coverage — a chunk clamped at the document tail,
-      or a window that reduced to a duplicate of the previous one — the leftmost
+    - Primary: the leftmost occurrence at/after ``prev_start`` that (a) ends past
+      ``prev_end`` and (b) lies entirely within a single block. Requiring forward
+      end-progress rejects a pure-suffix duplicate inside the previous chunk (no new
+      coverage); requiring single-block containment rejects a *cross-block artifact* —
+      a match that exists only because whitespace stripping glued the tail of one block
+      to the head of the next across a now-removed separator. Leftmost then resolves an
+      overlap chunk to its true position rather than a later duplicate.
+    - Cross-block fallback: if no single-block occurrence advances coverage, the
+      leftmost occurrence that merely ends past ``prev_end``. A chunk whose window
+      genuinely spanned blocks (its raw content held the separator) matches only here,
+      so real cross-block chunks still resolve.
+    - Tail fallback: when nothing extends coverage — a chunk clamped at the document
+      tail, or a window that reduced to a duplicate of the previous one — the leftmost
       occurrence at/after ``prev_start`` (or -1 when the text is absent entirely).
-
-    A ``prev_end``-only anchor skips overlap matches (they begin before ``prev_end``)
-    and can jump to a later duplicate; a ``prev_start``-only anchor accepts an earlier
-    duplicate inside the previous chunk or, after a stripped separator, cannot advance.
-    Anchoring on end-progress avoids all three.
     """
     length = len(nq)
+    first_advancing = -1
     search = prev_start
     while True:
         p = norm_merged.find(nq, search)
         if p == -1:
             break
-        if p + length > prev_end:
-            return p
         search = p + 1
+        if p + length <= prev_end:
+            continue  # does not extend coverage; skip suffix/duplicate matches
+        if first_advancing == -1:
+            first_advancing = p
+        o_start = norm_to_orig[p]
+        o_end = norm_to_orig[p + length - 1] + 1
+        if _within_single_block(spans, o_start, o_end):
+            return p
+    if first_advancing != -1:
+        return first_advancing  # genuine cross-block chunk (no single-block match)
     return norm_merged.find(nq, prev_start)
 
 
@@ -235,7 +270,7 @@ def backfill_chunk_sidecars(
         if not nq:
             continue
 
-        pos = _locate_chunk(norm_merged, nq, prev_start, prev_end)
+        pos = _locate_chunk(norm_merged, nq, prev_start, prev_end, norm_to_orig, spans)
         if pos == -1:
             raise ChunkBlockMatchError(
                 chunk_order_index=int(chunk.get("chunk_order_index", -1)),

--- a/lightrag/sidecar/backfill.py
+++ b/lightrag/sidecar/backfill.py
@@ -1,0 +1,223 @@
+"""Backfill chunk ``sidecar`` provenance for the F/R/V chunking strategies.
+
+The ``P`` (paragraph_semantic) strategy records a ``sidecar`` field on each chunk
+mapping it back to its source row(s) in the parse-time ``*.blocks.jsonl`` sidecar
+file. The ``F`` / ``R`` / ``V`` strategies chunk the merged document text without
+that provenance. When a document was parsed into the LightRAG sidecar format
+(``blocks.jsonl`` exists), :func:`backfill_chunk_sidecars` scans the blocks and
+attaches a ``sidecar`` to each chunk that lacks one.
+
+Matching contract
+-----------------
+The merged text a chunker received is exactly reproducible from ``blocks.jsonl``:
+both :func:`lightrag.sidecar.writer.write_sidecar` and
+:func:`lightrag.utils_pipeline.load_lightrag_document_content` build it as
+``"\\n\\n".join(raw_content for content rows where content.strip())``. We rebuild
+the same string here, record each block's character span, and locate each chunk's
+content within it.
+
+F decodes/strips token windows (verbatim substrings, with token overlap); R strips
+LangChain pieces (verbatim, possible overlap); V strips ``SemanticChunker`` pieces
+that rejoin sentences with a single space (so newlines become spaces and the text is
+*not* byte-verbatim). To cover all three uniformly, matching runs over a
+whitespace-normalized projection of both sides.
+
+Multimodal placeholder tags (``<table …>…</table>``, ``<drawing …/>``,
+``<equation …>…</equation>``) appear identically in block content and chunk content,
+so they match verbatim — markup is never stripped before matching.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from lightrag.chunk_schema import normalize_chunk_sidecar
+from lightrag.exceptions import ChunkBlockMatchError
+from lightrag.utils import logger
+
+# Separator used to join block content into the merged document text. Must match
+# lightrag/sidecar/writer.py and lightrag/utils_pipeline.py.
+_BLOCK_SEPARATOR = "\n\n"
+
+
+def _load_content_blocks(blocks_path: str) -> list[tuple[str, str]]:
+    """Read ``type == "content"`` rows from a blocks.jsonl file in order.
+
+    Returns ``(blockid, raw_content)`` pairs, skipping the meta header and any
+    malformed lines. Mirrors ``paragraph_semantic._load_blocks_from_jsonl`` but
+    keeps the raw (un-stripped) content needed to reproduce the chunker input.
+    """
+    blocks: list[tuple[str, str]] = []
+    with Path(blocks_path).open("r", encoding="utf-8") as fh:
+        for raw in fh:
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(obj, dict) or obj.get("type") != "content":
+                continue
+            content = obj.get("content", "")
+            if not isinstance(content, str):
+                continue
+            blockid = str(obj.get("blockid") or "").strip()
+            blocks.append((blockid, content))
+    return blocks
+
+
+def _build_block_spans(
+    blocks: list[tuple[str, str]],
+) -> tuple[str, list[tuple[int, int, str]]]:
+    """Reconstruct the merged text and each kept block's char span.
+
+    Only rows whose ``content.strip()`` is truthy are kept (matching
+    ``utils_pipeline.load_lightrag_document_content``). Returns ``(merged, spans)``
+    where each span is ``(start, end, blockid)`` over ``merged`` char offsets. The
+    ``"\\n\\n"`` separators between blocks belong to no span.
+    """
+    spans: list[tuple[int, int, str]] = []
+    parts: list[str] = []
+    cursor = 0
+    for blockid, content in blocks:
+        if not content.strip():
+            continue
+        if parts:
+            cursor += len(_BLOCK_SEPARATOR)
+        start = cursor
+        end = start + len(content)
+        spans.append((start, end, blockid))
+        parts.append(content)
+        cursor = end
+    return _BLOCK_SEPARATOR.join(parts), spans
+
+
+def _normalize_projection(merged: str) -> tuple[str, list[int]]:
+    """Collapse whitespace runs to single spaces; map back to merged offsets.
+
+    Returns ``(norm_text, norm_to_orig)`` where ``norm_to_orig[i]`` is the offset
+    in ``merged`` of the ``i``-th normalized character. Leading/trailing whitespace
+    is dropped so chunk- and merged-side normalization agree at boundaries.
+    """
+    norm_chars: list[str] = []
+    norm_to_orig: list[int] = []
+    prev_space = True  # leading-space suppression
+    for idx, ch in enumerate(merged):
+        if ch.isspace():
+            if prev_space:
+                continue
+            norm_chars.append(" ")
+            norm_to_orig.append(idx)
+            prev_space = True
+        else:
+            norm_chars.append(ch)
+            norm_to_orig.append(idx)
+            prev_space = False
+    # Drop a single trailing space if present.
+    if norm_chars and norm_chars[-1] == " ":
+        norm_chars.pop()
+        norm_to_orig.pop()
+    return "".join(norm_chars), norm_to_orig
+
+
+def _normalize_text(text: str) -> str:
+    """Whitespace-normalized form of a chunk body (collapse runs, strip ends)."""
+    return " ".join(text.split())
+
+
+def _covered_blockids(
+    spans: list[tuple[int, int, str]], o_start: int, o_end: int
+) -> list[str]:
+    """Blockids whose content span overlaps ``[o_start, o_end)``, in order, deduped."""
+    covered: list[str] = []
+    seen: set[str] = set()
+    for start, end, blockid in spans:
+        # Overlap test on half-open intervals; separators (gaps) match nothing.
+        if start < o_end and o_start < end and blockid and blockid not in seen:
+            seen.add(blockid)
+            covered.append(blockid)
+    return covered
+
+
+def backfill_chunk_sidecars(
+    chunking_result: list[dict[str, Any]],
+    blocks_path: str,
+) -> None:
+    """Attach a ``sidecar`` to each chunk lacking one, in place.
+
+    No-op when ``blocks_path`` is empty/unreadable or carries no content rows.
+    Chunks that already have a valid sidecar (P / multimodal) and empty-content
+    chunks are skipped. Raises :class:`ChunkBlockMatchError` when a sidecar-less,
+    non-empty chunk cannot be located in the reconstructed merged text.
+    """
+    if not blocks_path:
+        return
+
+    try:
+        blocks = _load_content_blocks(blocks_path)
+    except OSError as exc:
+        logger.warning(
+            f"[sidecar-backfill] cannot read blocks.jsonl at {blocks_path}: {exc}; "
+            "skipping sidecar backfill"
+        )
+        return
+
+    merged, spans = _build_block_spans(blocks)
+    if not spans:
+        return
+
+    norm_merged, norm_to_orig = _normalize_projection(merged)
+
+    # Forward-only cursor over the normalized text. ``prev_end`` is preferred so
+    # repeated content and phrases recurring inside the previous chunk resolve to
+    # the next occurrence; ``prev_start`` is the overlap fallback for F/R chunks
+    # that legitimately begin inside the previous chunk's span.
+    prev_start = 0
+    prev_end = 0
+    for chunk in chunking_result:
+        if not isinstance(chunk, dict):
+            continue
+        if normalize_chunk_sidecar(chunk) is not None:
+            continue
+        body = chunk.get("content", "")
+        if not isinstance(body, str) or not body.strip():
+            continue
+
+        nq = _normalize_text(body)
+        if not nq:
+            continue
+
+        pos = norm_merged.find(nq, prev_end)
+        if pos == -1:
+            pos = norm_merged.find(nq, prev_start)
+        if pos == -1:
+            raise ChunkBlockMatchError(
+                chunk_order_index=int(chunk.get("chunk_order_index", -1)),
+                chunk_preview=body,
+                blocks_path=blocks_path,
+            )
+
+        norm_end = pos + len(nq)
+        o_start = norm_to_orig[pos]
+        # Map the last matched normalized char back, then extend one past it.
+        o_end = norm_to_orig[norm_end - 1] + 1
+        prev_start, prev_end = pos, norm_end
+
+        covered = _covered_blockids(spans, o_start, o_end)
+        if not covered:
+            # The match landed entirely on separator gaps — should not happen for
+            # non-empty normalized content, but guard rather than emit an empty ref.
+            raise ChunkBlockMatchError(
+                chunk_order_index=int(chunk.get("chunk_order_index", -1)),
+                chunk_preview=body,
+                blocks_path=blocks_path,
+            )
+
+        chunk["sidecar"] = {
+            "type": "block",
+            "id": covered[0],
+            "refs": [{"type": "block", "id": bid} for bid in covered],
+        }

--- a/tests/chunker/test_sidecar_backfill_integration.py
+++ b/tests/chunker/test_sidecar_backfill_integration.py
@@ -113,6 +113,29 @@ def test_real_overlap_on_stripped_separator_does_not_strand_chunks(
 
 
 @pytest.mark.offline
+def test_real_identical_adjacent_blocks_no_cross_block_artifact(
+    tmp_path: Path,
+) -> None:
+    # End-to-end: identical adjacent blocks b1="aa", b2="aa", chunk_size=2, overlap=0
+    # -> ["aa", "", "aa"]. Stripping glues them to "aaaa", where "aa" also matches at
+    # offset 1 across the (removed) separator. The final chunk must reference only b2,
+    # not spuriously span both blocks.
+    blocks_path, merged = _write_blocks(tmp_path, [("b1", "aa"), ("b2", "aa")])
+    tok = _tokenizer()
+
+    chunks = chunking_by_fixed_token(
+        tok, merged, chunk_token_size=2, chunk_overlap_token_size=0
+    )
+    assert [c["content"] for c in chunks] == ["aa", "", "aa"]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert [r["id"] for r in chunks[0]["sidecar"]["refs"]] == ["b1"]
+    assert "sidecar" not in chunks[1]
+    assert [r["id"] for r in chunks[2]["sidecar"]["refs"]] == ["b2"]
+
+
+@pytest.mark.offline
 def test_real_fixed_token_chunks_get_full_coverage(tmp_path: Path) -> None:
     blocks = [(f"b{i}", f"Block number {i} body content here.") for i in range(6)]
     blocks_path, merged = _write_blocks(tmp_path, blocks)

--- a/tests/chunker/test_sidecar_backfill_integration.py
+++ b/tests/chunker/test_sidecar_backfill_integration.py
@@ -67,10 +67,10 @@ def _write_blocks(tmp_path: Path, blocks: list[tuple[str, str]]) -> tuple[str, s
 
 @pytest.mark.offline
 def test_real_overlap_tail_chunk_maps_to_next_block(tmp_path: Path) -> None:
-    # End-to-end reproduction of the overlap-tail ambiguity with the real chunker:
-    # b1="aa", b2="a", chunk_size=3, overlap=1 -> ["aa", "a", "a"]. The middle window
-    # [2:5] = "\n\na" strips to b2's "a" (the overlap landed on the separator), so the
-    # tail chunks belong to b2 — not the earlier "a" inside b1.
+    # End-to-end reproduction of the overlap-tail ambiguity with the real chunker.
+    # Simple case: b1="aa", b2="a", chunk_size=3, overlap=1 -> ["aa", "a", "a"]. The
+    # middle window [2:5] = "\n\na" strips to b2's "a" (the overlap landed on the
+    # separator), so the tail chunks belong to b2 — not the earlier "a" inside b1.
     blocks_path, merged = _write_blocks(tmp_path, [("b1", "aa"), ("b2", "a")])
     tok = _tokenizer()
 
@@ -84,6 +84,32 @@ def test_real_overlap_tail_chunk_maps_to_next_block(tmp_path: Path) -> None:
     assert [r["id"] for r in chunks[0]["sidecar"]["refs"]] == ["b1"]
     assert [r["id"] for r in chunks[1]["sidecar"]["refs"]] == ["b2"]
     assert [r["id"] for r in chunks[2]["sidecar"]["refs"]] == ["b2"]
+
+
+@pytest.mark.offline
+def test_real_overlap_on_stripped_separator_does_not_strand_chunks(
+    tmp_path: Path,
+) -> None:
+    # Harder end-to-end case: b1="a", b2="abab", chunk_size=2, overlap=1 ->
+    # ["a", "", "a", "ab", "ba", "ab", "b"]. The token overlap repeatedly lands on the
+    # stripped separator, so consecutive non-empty chunks can share a normalized start
+    # and only the end advances. The empty chunk is skipped; every other tail chunk
+    # must resolve into b2 without raising ChunkBlockMatchError.
+    blocks_path, merged = _write_blocks(tmp_path, [("b1", "a"), ("b2", "abab")])
+    tok = _tokenizer()
+
+    chunks = chunking_by_fixed_token(
+        tok, merged, chunk_token_size=2, chunk_overlap_token_size=1
+    )
+    assert [c["content"] for c in chunks] == ["a", "", "a", "ab", "ba", "ab", "b"]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert [r["id"] for r in chunks[0]["sidecar"]["refs"]] == ["b1"]
+    # The empty chunk is skipped (no sidecar); all remaining chunks belong to b2.
+    assert "sidecar" not in chunks[1]
+    for ch in chunks[2:]:
+        assert [r["id"] for r in ch["sidecar"]["refs"]] == ["b2"]
 
 
 @pytest.mark.offline

--- a/tests/chunker/test_sidecar_backfill_integration.py
+++ b/tests/chunker/test_sidecar_backfill_integration.py
@@ -110,9 +110,7 @@ def test_hard_split_slices_get_precise_refs(tmp_path: Path) -> None:
     assert chunks[0]["sidecar"]["refs"] == [{"type": "block", "id": "big"}]
     # "small" is referenced only by the slice that actually reaches its content.
     small_refs = [
-        ch
-        for ch in chunks
-        if any(r["id"] == "small" for r in ch["sidecar"]["refs"])
+        ch for ch in chunks if any(r["id"] == "small" for r in ch["sidecar"]["refs"])
     ]
     assert len(small_refs) == 1
 

--- a/tests/chunker/test_sidecar_backfill_integration.py
+++ b/tests/chunker/test_sidecar_backfill_integration.py
@@ -66,6 +66,27 @@ def _write_blocks(tmp_path: Path, blocks: list[tuple[str, str]]) -> tuple[str, s
 
 
 @pytest.mark.offline
+def test_real_overlap_tail_chunk_maps_to_next_block(tmp_path: Path) -> None:
+    # End-to-end reproduction of the overlap-tail ambiguity with the real chunker:
+    # b1="aa", b2="a", chunk_size=3, overlap=1 -> ["aa", "a", "a"]. The middle window
+    # [2:5] = "\n\na" strips to b2's "a" (the overlap landed on the separator), so the
+    # tail chunks belong to b2 — not the earlier "a" inside b1.
+    blocks_path, merged = _write_blocks(tmp_path, [("b1", "aa"), ("b2", "a")])
+    tok = _tokenizer()
+
+    chunks = chunking_by_fixed_token(
+        tok, merged, chunk_token_size=3, chunk_overlap_token_size=1
+    )
+    assert [c["content"] for c in chunks] == ["aa", "a", "a"]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert [r["id"] for r in chunks[0]["sidecar"]["refs"]] == ["b1"]
+    assert [r["id"] for r in chunks[1]["sidecar"]["refs"]] == ["b2"]
+    assert [r["id"] for r in chunks[2]["sidecar"]["refs"]] == ["b2"]
+
+
+@pytest.mark.offline
 def test_real_fixed_token_chunks_get_full_coverage(tmp_path: Path) -> None:
     blocks = [(f"b{i}", f"Block number {i} body content here.") for i in range(6)]
     blocks_path, merged = _write_blocks(tmp_path, blocks)

--- a/tests/chunker/test_sidecar_backfill_integration.py
+++ b/tests/chunker/test_sidecar_backfill_integration.py
@@ -116,6 +116,39 @@ def test_hard_split_slices_get_precise_refs(tmp_path: Path) -> None:
 
 
 @pytest.mark.offline
+def test_real_tiktoken_token_windows_match_verbatim(tmp_path: Path) -> None:
+    # The char tokenizer guarantees decode(encode(x)) == x; a real BPE tokenizer
+    # does not split on character boundaries, so this exercises that tiktoken's
+    # decoded token windows (after the chunker's .strip()) are still locatable in
+    # the reconstructed merged text — including across the token-overlap fallback.
+    tiktoken = pytest.importorskip("tiktoken")
+    del tiktoken  # only needed to gate the test
+    from lightrag.utils import TiktokenTokenizer
+
+    tok = TiktokenTokenizer()
+    blocks = [
+        ("b1", "The quick brown fox jumps over the lazy dog repeatedly."),
+        ("b2", "Pack my box with five dozen liquor jugs, said the printer."),
+        ("b3", "How vexingly quick daft zebras jump across the meadow."),
+    ]
+    blocks_path, merged = _write_blocks(tmp_path, blocks)
+
+    chunks = chunking_by_fixed_token(
+        tok, merged, chunk_token_size=12, chunk_overlap_token_size=3
+    )
+    assert len(chunks) >= 2  # small window + overlap -> multiple chunks
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    for ch in chunks:
+        assert ch["sidecar"]["type"] == "block"
+        assert ch["sidecar"]["refs"]
+    # Union of all refs covers every block.
+    seen = {r["id"] for ch in chunks for r in ch["sidecar"]["refs"]}
+    assert seen == {b for b, _ in blocks}
+
+
+@pytest.mark.offline
 def test_backfilled_sidecar_persists_into_chunks_dict(tmp_path: Path) -> None:
     blocks_path, merged = _write_blocks(
         tmp_path, [("b1", "Alpha body."), ("b2", "Beta body.")]

--- a/tests/chunker/test_sidecar_backfill_integration.py
+++ b/tests/chunker/test_sidecar_backfill_integration.py
@@ -1,0 +1,137 @@
+"""Integration tests: real F chunker + hard-split + sidecar backfill + chunks dict.
+
+Unlike ``tests/sidecar/test_backfill.py`` (which hand-builds chunk lists), these
+drive the actual ``chunking_by_fixed_token`` chunker over the exact merged text a
+parsed document would yield, then apply the real
+``enforce_chunk_token_limit_before_embedding`` hard-split and
+``build_chunks_dict_from_chunking_result`` persistence step — verifying that
+backfilled sidecars are precise per final slice and survive into the chunks dict.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lightrag.chunker import chunking_by_fixed_token
+from lightrag.sidecar import backfill_chunk_sidecars
+from lightrag.utils import (
+    Tokenizer,
+    enforce_chunk_token_limit_before_embedding,
+)
+from lightrag.utils_pipeline import build_chunks_dict_from_chunking_result
+
+_BLOCK_SEPARATOR = "\n\n"
+
+
+class _CharTokenizerImpl:
+    """Deterministic char-per-token tokenizer; decode(encode(x)) == x so F
+    chunks are verbatim substrings and token sizes are character counts."""
+
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+def _tokenizer() -> Tokenizer:
+    return Tokenizer("char", _CharTokenizerImpl())
+
+
+def _write_blocks(tmp_path: Path, blocks: list[tuple[str, str]]) -> tuple[str, str]:
+    """Write blocks.jsonl; return (path, merged_text)."""
+    path = tmp_path / "doc.blocks.jsonl"
+    lines = [json.dumps({"type": "meta", "format": "lightrag", "version": "1.0"})]
+    parts: list[str] = []
+    for blockid, content in blocks:
+        lines.append(
+            json.dumps(
+                {
+                    "type": "content",
+                    "blockid": blockid,
+                    "content": content,
+                    "heading": "",
+                    "parent_headings": [],
+                    "level": 1,
+                }
+            )
+        )
+        if content.strip():
+            parts.append(content)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(path), _BLOCK_SEPARATOR.join(parts)
+
+
+@pytest.mark.offline
+def test_real_fixed_token_chunks_get_full_coverage(tmp_path: Path) -> None:
+    blocks = [(f"b{i}", f"Block number {i} body content here.") for i in range(6)]
+    blocks_path, merged = _write_blocks(tmp_path, blocks)
+    tok = _tokenizer()
+
+    chunks = chunking_by_fixed_token(
+        tok, merged, chunk_token_size=40, chunk_overlap_token_size=5
+    )
+    assert len(chunks) >= 2  # multiple blocks per chunk at this size
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    # Every chunk is located and carries block provenance.
+    for ch in chunks:
+        assert ch["sidecar"]["type"] == "block"
+        assert ch["sidecar"]["refs"]
+    # Union of all refs covers every block.
+    seen = {r["id"] for ch in chunks for r in ch["sidecar"]["refs"]}
+    assert seen == {b for b, _ in blocks}
+
+
+@pytest.mark.offline
+def test_hard_split_slices_get_precise_refs(tmp_path: Path) -> None:
+    # One large block followed by a small one. A single fixed-token chunk covers
+    # both; the hard-split then breaks the big-content chunk into slices that
+    # each lie inside one block, so refs must NOT all inherit the full set.
+    big = "A" * 120
+    blocks_path, merged = _write_blocks(tmp_path, [("big", big), ("small", "tail.")])
+    tok = _tokenizer()
+
+    chunks = chunking_by_fixed_token(
+        tok, merged, chunk_token_size=200, chunk_overlap_token_size=0
+    )
+    assert len(chunks) == 1  # everything in one chunk pre-split
+
+    chunks = enforce_chunk_token_limit_before_embedding(chunks, tok, max_tokens=30)
+    assert len(chunks) > 1  # hard-split fired
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    # The early slices live entirely inside "big" -> single ref, not both blocks.
+    assert chunks[0]["sidecar"]["refs"] == [{"type": "block", "id": "big"}]
+    # "small" is referenced only by the slice that actually reaches its content.
+    small_refs = [
+        ch
+        for ch in chunks
+        if any(r["id"] == "small" for r in ch["sidecar"]["refs"])
+    ]
+    assert len(small_refs) == 1
+
+
+@pytest.mark.offline
+def test_backfilled_sidecar_persists_into_chunks_dict(tmp_path: Path) -> None:
+    blocks_path, merged = _write_blocks(
+        tmp_path, [("b1", "Alpha body."), ("b2", "Beta body.")]
+    )
+    tok = _tokenizer()
+
+    chunks = chunking_by_fixed_token(tok, merged, chunk_token_size=200)
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    chunks_dict = build_chunks_dict_from_chunking_result(
+        chunks, doc_id="doc-xyz", file_path="doc.docx"
+    )
+    assert chunks_dict  # non-empty
+    for record in chunks_dict.values():
+        assert "sidecar" in record
+        assert record["sidecar"]["type"] == "block"
+        assert record["sidecar"]["refs"]

--- a/tests/sidecar/test_backfill.py
+++ b/tests/sidecar/test_backfill.py
@@ -139,8 +139,8 @@ def test_repeated_identical_blocks_map_to_distinct_blocks(tmp_path: Path) -> Non
 def test_phrase_recurring_inside_previous_chunk_resolves_forward(
     tmp_path: Path,
 ) -> None:
-    # "common" appears inside b1; the next chunk's true home is b2. End-first
-    # search must not re-match the occurrence inside the previous chunk.
+    # "common" appears inside b1; the next chunk's true home is b2. The forward
+    # cursor must not re-match the occurrence inside the previous chunk.
     blocks_path = _write_blocks(
         tmp_path,
         [("b1", "common prefix and common middle"), ("b2", "common tail block")],
@@ -157,8 +157,9 @@ def test_phrase_recurring_inside_previous_chunk_resolves_forward(
 
 
 @pytest.mark.offline
-def test_overlapping_chunks_match_via_start_fallback(tmp_path: Path) -> None:
-    # Simulate F/R token overlap: chunk 2 begins inside chunk 1's span.
+def test_overlapping_chunks_match_inside_previous_span(tmp_path: Path) -> None:
+    # Simulate F/R token overlap: chunk 2 begins inside chunk 1's span. The
+    # forward-from-start cursor resolves the overlap position directly.
     blocks_path = _write_blocks(
         tmp_path, [("b1", "one two three four five six seven eight")]
     )
@@ -171,6 +172,34 @@ def test_overlapping_chunks_match_via_start_fallback(tmp_path: Path) -> None:
 
     assert _refs(chunks[0]) == ["b1"]
     assert _refs(chunks[1]) == ["b1"]
+
+
+@pytest.mark.offline
+def test_overlap_chunk_with_later_duplicate_resolves_to_overlap(
+    tmp_path: Path,
+) -> None:
+    # Regression: an overlapping chunk whose normalized text recurs LATER in the
+    # document. A ``prev_end``-anchored search would skip the overlap occurrence
+    # (it sits before prev_end) and grab the later duplicate, advancing the cursor
+    # too far and stranding the following chunk -> false ChunkBlockMatchError.
+    # The forward-from-start cursor must resolve chunk 1 to its overlap position.
+    #
+    # Merged text (normalized): "AABBCCDDEE" + "CCDDFF" = "AABBCCDDEECCDDFF".
+    #   "CCDD" appears at the b1 overlap (offset 4) AND inside b2 (offset 10).
+    blocks_path = _write_blocks(
+        tmp_path, [("b1", "AA BB CC DD EE"), ("b2", "CC DD FF")]
+    )
+    chunks = [
+        _chunk("AA BB CC DD", 0),  # b1
+        _chunk("CC DD", 1),  # overlaps chunk 0 -> true home is b1, not the b2 dup
+        _chunk("EE", 2),  # lives between the overlap pos and the b2 duplicate
+    ]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1"]
+    assert _refs(chunks[1]) == ["b1"]
+    assert _refs(chunks[2]) == ["b1"]
 
 
 @pytest.mark.offline

--- a/tests/sidecar/test_backfill.py
+++ b/tests/sidecar/test_backfill.py
@@ -1,0 +1,232 @@
+"""Unit tests for :func:`lightrag.sidecar.backfill.backfill_chunk_sidecars`.
+
+These exercise the F/R/V sidecar backfill in isolation: a small ``blocks.jsonl``
+is written to ``tmp_path`` and hand-built chunk lists are matched against it, so
+no real chunker, tokenizer, or embedding is needed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lightrag.exceptions import ChunkBlockMatchError
+from lightrag.sidecar import backfill_chunk_sidecars
+
+# The merged text the chunker would have received is
+# "\n\n".join(content for content rows with content.strip()).
+_BLOCK_SEPARATOR = "\n\n"
+
+
+def _write_blocks(tmp_path: Path, blocks: list[tuple[str, str]]) -> str:
+    """Write a blocks.jsonl with a meta header + ``(blockid, content)`` rows."""
+    path = tmp_path / "doc.blocks.jsonl"
+    lines = [json.dumps({"type": "meta", "format": "lightrag", "version": "1.0"})]
+    for blockid, content in blocks:
+        lines.append(
+            json.dumps(
+                {
+                    "type": "content",
+                    "blockid": blockid,
+                    "format": "plain_text",
+                    "content": content,
+                    "heading": "",
+                    "parent_headings": [],
+                    "level": 1,
+                }
+            )
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(path)
+
+
+def _chunk(content: str, order: int) -> dict:
+    return {"content": content, "tokens": len(content), "chunk_order_index": order}
+
+
+def _refs(chunk: dict) -> list[str]:
+    return [r["id"] for r in chunk["sidecar"]["refs"]]
+
+
+@pytest.mark.offline
+def test_chunk_spanning_two_blocks_lists_both_refs(tmp_path: Path) -> None:
+    blocks_path = _write_blocks(
+        tmp_path, [("b1", "Alpha paragraph."), ("b2", "Beta paragraph.")]
+    )
+    merged = _BLOCK_SEPARATOR.join(["Alpha paragraph.", "Beta paragraph."])
+    chunks = [_chunk(merged, 0)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert chunks[0]["sidecar"]["type"] == "block"
+    assert chunks[0]["sidecar"]["id"] == "b1"
+    assert _refs(chunks[0]) == ["b1", "b2"]
+
+
+@pytest.mark.offline
+def test_chunk_equal_to_single_block(tmp_path: Path) -> None:
+    blocks_path = _write_blocks(
+        tmp_path, [("b1", "Alpha paragraph."), ("b2", "Beta paragraph.")]
+    )
+    chunks = [_chunk("Beta paragraph.", 0)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert chunks[0]["sidecar"]["id"] == "b2"
+    assert _refs(chunks[0]) == ["b2"]
+
+
+@pytest.mark.offline
+def test_whitespace_normalized_match_for_v_style(tmp_path: Path) -> None:
+    # Block content has internal newlines; the V chunker rejoins sentences with
+    # single spaces, so the chunk body is not byte-verbatim.
+    block = "First sentence.\nSecond sentence.\nThird sentence."
+    blocks_path = _write_blocks(tmp_path, [("b1", block)])
+    chunks = [_chunk("First sentence. Second sentence. Third sentence.", 0)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1"]
+
+
+@pytest.mark.offline
+def test_repeated_identical_blocks_map_to_distinct_blocks(tmp_path: Path) -> None:
+    blocks_path = _write_blocks(
+        tmp_path, [("b1", "Repeated text."), ("b2", "Repeated text.")]
+    )
+    chunks = [_chunk("Repeated text.", 0), _chunk("Repeated text.", 1)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1"]
+    assert _refs(chunks[1]) == ["b2"]
+
+
+@pytest.mark.offline
+def test_phrase_recurring_inside_previous_chunk_resolves_forward(
+    tmp_path: Path,
+) -> None:
+    # "common" appears inside b1; the next chunk's true home is b2. End-first
+    # search must not re-match the occurrence inside the previous chunk.
+    blocks_path = _write_blocks(
+        tmp_path,
+        [("b1", "common prefix and common middle"), ("b2", "common tail block")],
+    )
+    chunks = [
+        _chunk("common prefix and common middle", 0),
+        _chunk("common tail block", 1),
+    ]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1"]
+    assert _refs(chunks[1]) == ["b2"]
+
+
+@pytest.mark.offline
+def test_overlapping_chunks_match_via_start_fallback(tmp_path: Path) -> None:
+    # Simulate F/R token overlap: chunk 2 begins inside chunk 1's span.
+    blocks_path = _write_blocks(
+        tmp_path, [("b1", "one two three four five six seven eight")]
+    )
+    chunks = [
+        _chunk("one two three four five", 0),
+        _chunk("four five six seven eight", 1),
+    ]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1"]
+    assert _refs(chunks[1]) == ["b1"]
+
+
+@pytest.mark.offline
+def test_unmatchable_chunk_raises(tmp_path: Path) -> None:
+    blocks_path = _write_blocks(tmp_path, [("b1", "Present content.")])
+    chunks = [_chunk("Absent content not in any block.", 3)]
+
+    with pytest.raises(ChunkBlockMatchError) as exc:
+        backfill_chunk_sidecars(chunks, blocks_path)
+    assert exc.value.chunk_order_index == 3
+
+
+@pytest.mark.offline
+def test_empty_blocks_path_is_noop(tmp_path: Path) -> None:
+    chunks = [_chunk("anything", 0)]
+    backfill_chunk_sidecars(chunks, "")
+    assert "sidecar" not in chunks[0]
+
+
+@pytest.mark.offline
+def test_meta_only_file_is_noop(tmp_path: Path) -> None:
+    blocks_path = _write_blocks(tmp_path, [])
+    chunks = [_chunk("anything", 0)]
+    backfill_chunk_sidecars(chunks, blocks_path)
+    assert "sidecar" not in chunks[0]
+
+
+@pytest.mark.offline
+def test_unreadable_path_is_noop(tmp_path: Path) -> None:
+    chunks = [_chunk("anything", 0)]
+    backfill_chunk_sidecars(chunks, str(tmp_path / "does_not_exist.blocks.jsonl"))
+    assert "sidecar" not in chunks[0]
+
+
+@pytest.mark.offline
+def test_existing_sidecar_is_preserved(tmp_path: Path) -> None:
+    blocks_path = _write_blocks(tmp_path, [("b1", "Alpha."), ("b2", "Beta.")])
+    # A P/mm-style chunk whose content would NOT match block order; it must be
+    # left untouched because it already carries a valid sidecar.
+    pre = {
+        "content": "Beta.",
+        "tokens": 1,
+        "chunk_order_index": 0,
+        "sidecar": {
+            "type": "drawing",
+            "id": "im-xyz-0001",
+            "refs": [{"type": "drawing", "id": "im-xyz-0001"}],
+        },
+    }
+    chunks = [pre]
+    backfill_chunk_sidecars(chunks, blocks_path)
+    assert chunks[0]["sidecar"]["type"] == "drawing"
+    assert chunks[0]["sidecar"]["id"] == "im-xyz-0001"
+
+
+@pytest.mark.offline
+def test_multimodal_tag_block_matches_verbatim(tmp_path: Path) -> None:
+    block = 'See: <table id="tb-abc-0001" format="json">[[1,2]]</table> done.'
+    blocks_path = _write_blocks(tmp_path, [("b1", block)])
+    chunks = [_chunk(block, 0)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1"]
+
+
+@pytest.mark.offline
+def test_whitespace_only_block_excluded_from_refs(tmp_path: Path) -> None:
+    # The middle row is whitespace-only -> not part of the merged text and never
+    # contributes a ref. A chunk spanning b1..b3 lists only b1 and b3.
+    blocks_path = _write_blocks(
+        tmp_path, [("b1", "First."), ("bws", "   "), ("b3", "Third.")]
+    )
+    merged = _BLOCK_SEPARATOR.join(["First.", "Third."])
+    chunks = [_chunk(merged, 0)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1", "b3"]
+
+
+@pytest.mark.offline
+def test_empty_chunk_skipped_then_following_matches(tmp_path: Path) -> None:
+    blocks_path = _write_blocks(tmp_path, [("b1", "Real content.")])
+    chunks = [_chunk("", 0), _chunk("Real content.", 1)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert "sidecar" not in chunks[0]
+    assert _refs(chunks[1]) == ["b1"]

--- a/tests/sidecar/test_backfill.py
+++ b/tests/sidecar/test_backfill.py
@@ -203,6 +203,27 @@ def test_overlap_chunk_with_later_duplicate_resolves_to_overlap(
 
 
 @pytest.mark.offline
+def test_short_overlap_tail_maps_to_next_block_not_earlier_duplicate(
+    tmp_path: Path,
+) -> None:
+    # Regression (the inverse of the later-duplicate case): b1="aa", b2="a" with a
+    # tiny chunk_size and token overlap yields chunks ["aa", "a", "a"]. The token
+    # overlap fell on the stripped separator, so the middle "a" is really b2's token
+    # advancing past b1 — it must map to b2, NOT the earlier duplicate "a" still
+    # inside b1. A prev_start-anchored first-match would wrongly pick b1's "a"; the
+    # windowed rule picks the furthest-forward occurrence in the reachable window.
+    # The trailing "a" (clamped at the doc end) is b2 as well.
+    blocks_path = _write_blocks(tmp_path, [("b1", "aa"), ("b2", "a")])
+    chunks = [_chunk("aa", 0), _chunk("a", 1), _chunk("a", 2)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1"]
+    assert _refs(chunks[1]) == ["b2"]
+    assert _refs(chunks[2]) == ["b2"]
+
+
+@pytest.mark.offline
 def test_unmatchable_chunk_raises(tmp_path: Path) -> None:
     blocks_path = _write_blocks(tmp_path, [("b1", "Present content.")])
     chunks = [_chunk("Absent content not in any block.", 3)]

--- a/tests/sidecar/test_backfill.py
+++ b/tests/sidecar/test_backfill.py
@@ -179,48 +179,52 @@ def test_overlap_chunk_with_later_duplicate_resolves_to_overlap(
     tmp_path: Path,
 ) -> None:
     # Regression: an overlapping chunk whose normalized text recurs LATER in the
-    # document. A ``prev_end``-anchored search would skip the overlap occurrence
-    # (it sits before prev_end) and grab the later duplicate, advancing the cursor
-    # too far and stranding the following chunk -> false ChunkBlockMatchError.
-    # The forward-from-start cursor must resolve chunk 1 to its overlap position.
+    # document. The overlap chunk extends past the previous chunk's end (as real F/R
+    # overlap chunks always do) AND its text reappears in a later block. The cursor
+    # must resolve it to the *leftmost* end-advancing occurrence (the overlap inside
+    # b1), not jump to the later b2 duplicate and strand the following chunk.
     #
-    # Merged text (normalized): "AABBCCDDEE" + "CCDDFF" = "AABBCCDDEECCDDFF".
-    #   "CCDD" appears at the b1 overlap (offset 4) AND inside b2 (offset 10).
-    blocks_path = _write_blocks(
-        tmp_path, [("b1", "AA BB CC DD EE"), ("b2", "CC DD FF")]
-    )
+    # Merged text (normalized): "xxyyzz" + "yyzz" = "xxyyzzyyzz".
+    #   "yyzz" appears at the b1 overlap (offset 2) AND as b2 (offset 6).
+    blocks_path = _write_blocks(tmp_path, [("b1", "xx yy zz"), ("b2", "yy zz")])
     chunks = [
-        _chunk("AA BB CC DD", 0),  # b1
-        _chunk("CC DD", 1),  # overlaps chunk 0 -> true home is b1, not the b2 dup
-        _chunk("EE", 2),  # lives between the overlap pos and the b2 duplicate
+        _chunk("xx yy", 0),  # b1
+        _chunk("yy zz", 1),  # overlaps chunk 0 (shares "yy", adds "zz") -> still b1
+        _chunk("yy zz", 2),  # the genuine b2 occurrence
     ]
 
     backfill_chunk_sidecars(chunks, blocks_path)
 
     assert _refs(chunks[0]) == ["b1"]
     assert _refs(chunks[1]) == ["b1"]
-    assert _refs(chunks[2]) == ["b1"]
+    assert _refs(chunks[2]) == ["b2"]
 
 
 @pytest.mark.offline
-def test_short_overlap_tail_maps_to_next_block_not_earlier_duplicate(
+def test_overlap_window_on_stripped_separator_advances_into_next_block(
     tmp_path: Path,
 ) -> None:
-    # Regression (the inverse of the later-duplicate case): b1="aa", b2="a" with a
-    # tiny chunk_size and token overlap yields chunks ["aa", "a", "a"]. The token
-    # overlap fell on the stripped separator, so the middle "a" is really b2's token
-    # advancing past b1 — it must map to b2, NOT the earlier duplicate "a" still
-    # inside b1. A prev_start-anchored first-match would wrongly pick b1's "a"; the
-    # windowed rule picks the furthest-forward occurrence in the reachable window.
-    # The trailing "a" (clamped at the doc end) is b2 as well.
-    blocks_path = _write_blocks(tmp_path, [("b1", "aa"), ("b2", "a")])
-    chunks = [_chunk("aa", 0), _chunk("a", 1), _chunk("a", 2)]
+    # Regression for the reviewer's second case: b1="a", b2="abab", chunk_size=2,
+    # overlap=1 yields (non-empty) chunks ["a", "a", "ab", "ba", "ab", "b"]. The token
+    # overlap repeatedly falls on the stripped separator, so consecutive chunks can
+    # share a normalized START — only the END advances. A start-anchored cursor
+    # strands "ba" (its true position sits at/under the previous start) and raises;
+    # the end-anchored cursor places every tail chunk inside b2.
+    blocks_path = _write_blocks(tmp_path, [("b1", "a"), ("b2", "abab")])
+    chunks = [
+        _chunk("a", 0),  # b1
+        _chunk("a", 1),  # window crossed the stripped separator -> b2
+        _chunk("ab", 2),
+        _chunk("ba", 3),
+        _chunk("ab", 4),
+        _chunk("b", 5),
+    ]
 
     backfill_chunk_sidecars(chunks, blocks_path)
 
     assert _refs(chunks[0]) == ["b1"]
-    assert _refs(chunks[1]) == ["b2"]
-    assert _refs(chunks[2]) == ["b2"]
+    for ch in chunks[1:]:
+        assert _refs(ch) == ["b2"]
 
 
 @pytest.mark.offline

--- a/tests/sidecar/test_backfill.py
+++ b/tests/sidecar/test_backfill.py
@@ -228,6 +228,36 @@ def test_overlap_window_on_stripped_separator_advances_into_next_block(
 
 
 @pytest.mark.offline
+def test_cross_block_artifact_from_stripping_is_rejected(tmp_path: Path) -> None:
+    # Regression: identical adjacent blocks b1="aa", b2="aa" with no overlap yield
+    # chunks ["aa", "aa"]. In the stripped projection "aaaa", "aa" also occurs at
+    # offset 1, spanning b1's tail + b2's head across the removed separator — an
+    # artifact of stripping, not a real chunk. The second "aa" must map to b2 alone,
+    # so matching must prefer the single-block occurrence over the cross-block one.
+    blocks_path = _write_blocks(tmp_path, [("b1", "aa"), ("b2", "aa")])
+    chunks = [_chunk("aa", 0), _chunk("aa", 1)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1"]
+    assert _refs(chunks[1]) == ["b2"]
+
+
+@pytest.mark.offline
+def test_genuine_cross_block_chunk_still_lists_both(tmp_path: Path) -> None:
+    # A chunk whose content genuinely spans the boundary (its window held the
+    # separator) has no single-block occurrence, so the cross-block fallback keeps it
+    # and both blocks are listed — the single-block preference must not break this.
+    blocks_path = _write_blocks(tmp_path, [("b1", "alpha"), ("b2", "beta")])
+    merged = _BLOCK_SEPARATOR.join(["alpha", "beta"])
+    chunks = [_chunk(merged, 0)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1", "b2"]
+
+
+@pytest.mark.offline
 def test_unmatchable_chunk_raises(tmp_path: Path) -> None:
     blocks_path = _write_blocks(tmp_path, [("b1", "Present content.")])
     chunks = [_chunk("Absent content not in any block.", 3)]

--- a/tests/sidecar/test_backfill.py
+++ b/tests/sidecar/test_backfill.py
@@ -92,6 +92,37 @@ def test_whitespace_normalized_match_for_v_style(tmp_path: Path) -> None:
 
 
 @pytest.mark.offline
+def test_v_inserts_space_between_adjacent_sentences_still_matches(
+    tmp_path: Path,
+) -> None:
+    # The source block has two sentences with NO whitespace at the boundary
+    # ("sentence.Second"); the V SemanticChunker rejoins sentences with a single
+    # space, inserting whitespace the source never had. Collapse-to-space matching
+    # would mismatch and raise; whitespace-stripped matching must still locate it.
+    blocks_path = _write_blocks(tmp_path, [("b1", "First sentence.Second sentence.")])
+    chunks = [_chunk("First sentence. Second sentence.", 0)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1"]
+
+
+@pytest.mark.offline
+def test_v_reflow_across_blocks_keeps_boundary_refs(tmp_path: Path) -> None:
+    # V reflows internal newlines to spaces and the chunk spans the block
+    # boundary. Whitespace-stripped matching must still attribute both blocks.
+    blocks_path = _write_blocks(
+        tmp_path,
+        [("b1", "Alpha line one.\nAlpha line two."), ("b2", "Beta block body.")],
+    )
+    chunks = [_chunk("Alpha line one. Alpha line two. Beta block body.", 0)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1", "b2"]
+
+
+@pytest.mark.offline
 def test_repeated_identical_blocks_map_to_distinct_blocks(tmp_path: Path) -> None:
     blocks_path = _write_blocks(
         tmp_path, [("b1", "Repeated text."), ("b2", "Repeated text.")]


### PR DESCRIPTION
## Summary

The `P` (paragraph_semantic) chunking strategy records a `sidecar` field on each chunk that maps it back to its source block(s) in the parse-time `*.blocks.jsonl` sidecar file, enabling provenance/traceability for the multimodal pipeline and document-delete cache cleanup. The `F` (fixed token), `R` (recursive character), and `V` (semantic vector) strategies did **not** carry that provenance.

This PR makes F/R/V chunks also record a correct `sidecar` field **when a `blocks.jsonl` sidecar exists** for the document. After chunking, the blocks file is scanned and each F/R/V chunk is located in the reconstructed merged text; the covered block id(s) are written into the chunk's `sidecar`.

## Motivation

Provenance was only available for `P`-chunked documents. Documents parsed into the LightRAG sidecar format but chunked with F/R/V lost the chunk→block mapping, so downstream consumers couldn't trace those chunks back to source blocks.

## What's changed

- **`lightrag/sidecar/backfill.py`** (new) — `backfill_chunk_sidecars(chunking_result, blocks_path)`:
  - Rebuilds the merged document text exactly as the writer (`writer.py`) and loader (`utils_pipeline.load_lightrag_document_content`) do: raw content rows, skipping whitespace-only rows, joined with a blank line. Records each block's character span.
  - Matches each chunk over a **whitespace-normalized** projection of the merged text (so V's sentence rejoining — newlines collapsed to spaces — still matches), then maps the matched span back to the overlapping block id(s).
  - **Forward-only cursor**: searches from the previous match's end first (correct for non-overlapping chunks, repeated content, and phrases recurring inside the previous chunk), falling back to the previous match's start for F/R token-overlap.
  - Multimodal placeholder tags (`<table>`/`<drawing>`/`<equation>`) match verbatim — markup is never stripped.
- **`lightrag/exceptions.py`** — new `ChunkBlockMatchError`, raised when a sidecar-less chunk can't be located. It propagates through the existing `process_single_document` try/except and marks the document FAILED.
- **`lightrag/pipeline.py`** — invokes the backfill **after** the hard-fallback split (so each split slice maps precisely to the block(s) its content covers), gated to the built-in F/R/V strategies — or the legacy path only when `chunking_func` is still the unmodified default fixed-token chunker. Chunks already carrying a valid sidecar (P / multimodal) are skipped.

### Error / gating semantics

- Custom/overridden `chunking_func`, or `P` → backfill is **not invoked**.
- `blocks_path` empty / file missing or unreadable / no content rows → **no-op** (raw doc has no provenance).
- Blocks loaded but a sidecar-less, non-empty chunk can't be matched → **raise** → document FAILED.

## What's broken / risks

Nothing existing is broken — F/R/V chunks previously had no `sidecar` and now gain one only when a sidecar file is present and the chunk matches. The main correctness invariant is that the merged text is reconstructed exactly as the writer/loader produce it; this is covered by tests. Custom chunkers are deliberately excluded so rewritten text can't spuriously fail a document.

## Tests

- `tests/sidecar/test_backfill.py` — 14 unit tests: multi-block refs, single-block, V whitespace normalization, repeated blocks, recurring-phrase forward resolution, overlap fallback, unmatchable→raise, empty/meta-only/unreadable no-ops, existing-sidecar preserved, multimodal-tag match, whitespace-only block exclusion, empty-chunk skip.
- `tests/chunker/test_sidecar_backfill_integration.py` — 3 integration tests with the real `chunking_by_fixed_token` + `enforce_chunk_token_limit_before_embedding` + `build_chunks_dict_from_chunking_result`: full coverage, precise per-slice refs after hard-split, and sidecar persistence into the chunks dict.

All of `tests/sidecar`, `tests/chunker` (194) and `tests/pipeline` (162) pass; `ruff check` clean.

https://claude.ai/code/session_01CUMga8YxWtnUCXxpVxouRm

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUMga8YxWtnUCXxpVxouRm)_