### PR TITLE
fix(sidecar): use source spans for chunk backfill

### DIFF
--- a/lightrag/chunker/recursive_character.py
+++ b/lightrag/chunker/recursive_character.py
@@ -31,6 +31,62 @@ except ImportError:
     RecursiveCharacterTextSplitter = None  # type: ignore[assignment]
 
 
+def _locate_chunk_start(
+    content: str,
+    body: str,
+    tokenizer: Tokenizer,
+    *,
+    prev_start: int | None,
+    prev_body: str | None,
+    overlap_tokens: int,
+    cursor: int,
+) -> int:
+    """Return the source-text offset where ``body`` begins, or ``-1``.
+
+    A plain forward :meth:`str.find` is safe for unique text but collapses on
+    repeated content: identical overlapping chunks all match the nearest
+    repetition, so every span packs into the document head and the tail is left
+    without provenance. To avoid that we *predict* this chunk's start from the
+    previous one using the token-overlap geometry — ``prev_body`` length minus
+    the characters its trailing ``overlap_tokens`` re-share with this chunk —
+    and trust the prediction when it lands exactly. Only when it misses (from a
+    variable token/char ratio or a stripped separator) do we snap to the
+    occurrence nearest the prediction, always staying at or past ``cursor`` (a
+    monotonic floor) so spans never move backward.
+    """
+    if prev_start is None or prev_body is None:
+        return content.find(body, cursor)
+
+    prev_tokens = tokenizer.encode(prev_body)
+    take = min(len(prev_tokens), overlap_tokens)
+    overlap_chars = (
+        len(tokenizer.decode(prev_tokens[len(prev_tokens) - take :])) if take else 0
+    )
+    step = max(1, len(prev_body) - overlap_chars)
+    guess = prev_start + step
+    if content[guess : guess + len(body)] == body:
+        return guess
+
+    # Prediction was off; snap to the occurrence nearest it within a one-chunk
+    # window, never before the monotonic floor.
+    lo = max(cursor, guess - len(body))
+    hi = guess + len(body)
+    nearest = -1
+    best: int | None = None
+    i = content.find(body, lo)
+    while i != -1 and i <= hi:
+        dist = abs(i - guess)
+        if best is None or dist < best:
+            best, nearest = dist, i
+        i = content.find(body, i + 1)
+    if nearest != -1:
+        return nearest
+
+    # Nothing near the prediction: fall back to the first match at/after the
+    # monotonic floor so a forward-consistent span is still recorded.
+    return content.find(body, cursor)
+
+
 def chunking_by_recursive_character(
     tokenizer: Tokenizer,
     content: str,
@@ -83,22 +139,30 @@ def chunking_by_recursive_character(
     # each chunk's true start. The result is ``start_index == -1`` for unique
     # text (lost ``_source_span`` → backfill failure under
     # ``require_source_span``) or a match against a later identical run (wrong
-    # provenance). Instead we recover spans with our own monotonic forward
-    # cursor, which only ever advances and re-derives each span by exact match.
+    # provenance). Instead we recover spans ourselves via ``_locate_chunk_start``.
+    overlap_tokens = max(int(chunk_overlap_token_size), 0)
     docs = splitter.create_documents([content])
     results: list[dict[str, Any]] = []
+    prev_start: int | None = None
+    prev_body: str | None = None
     cursor = 0
     for doc in docs:
         body = doc.page_content.strip()
         if not body:
             continue
-        start_index = content.find(body, cursor)
+        start_index = _locate_chunk_start(
+            content,
+            body,
+            tokenizer,
+            prev_start=prev_start,
+            prev_body=prev_body,
+            overlap_tokens=overlap_tokens,
+            cursor=cursor,
+        )
         source_span = None
         if start_index >= 0:
             source_span = {"start": start_index, "end": start_index + len(body)}
-            # Next chunk's start is strictly past this one (chunk starts are
-            # monotonically increasing, even with overlap), so advance by one
-            # to keep the cursor moving without skipping the next true start.
+            prev_start, prev_body = start_index, body
             cursor = start_index + 1
         results.append(
             {

--- a/lightrag/chunker/recursive_character.py
+++ b/lightrag/chunker/recursive_character.py
@@ -68,23 +68,32 @@ def chunking_by_recursive_character(
         "chunk_size": max(int(chunk_token_size), 1),
         "chunk_overlap": max(int(chunk_overlap_token_size), 0),
         "length_function": lambda s: len(tokenizer.encode(s)),
+        "add_start_index": True,
+        "strip_whitespace": True,
     }
     if separators is not None:
         splitter_kwargs["separators"] = list(separators)
 
     splitter = RecursiveCharacterTextSplitter(**splitter_kwargs)
 
-    pieces = splitter.split_text(content)
+    docs = splitter.create_documents([content])
     results: list[dict[str, Any]] = []
-    for piece in pieces:
-        body = piece.strip()
+    for doc in docs:
+        body = doc.page_content.strip()
         if not body:
             continue
+        start_index = doc.metadata.get("start_index")
+        source_span = None
+        if isinstance(start_index, int) and start_index >= 0:
+            end_index = start_index + len(body)
+            if content[start_index:end_index] == body:
+                source_span = {"start": start_index, "end": end_index}
         results.append(
             {
                 "tokens": len(tokenizer.encode(body)),
                 "content": body,
                 "chunk_order_index": len(results),
+                **({"_source_span": source_span} if source_span else {}),
             }
         )
 
@@ -99,11 +108,17 @@ def chunking_by_recursive_character(
         )
         body = content.strip()
         if body:
+            start = content.find(body)
             results.append(
                 {
                     "tokens": len(tokenizer.encode(body)),
                     "content": body,
                     "chunk_order_index": 0,
+                    **(
+                        {"_source_span": {"start": start, "end": start + len(body)}}
+                        if start >= 0
+                        else {}
+                    ),
                 }
             )
 

--- a/lightrag/chunker/recursive_character.py
+++ b/lightrag/chunker/recursive_character.py
@@ -68,7 +68,6 @@ def chunking_by_recursive_character(
         "chunk_size": max(int(chunk_token_size), 1),
         "chunk_overlap": max(int(chunk_overlap_token_size), 0),
         "length_function": lambda s: len(tokenizer.encode(s)),
-        "add_start_index": True,
         "strip_whitespace": True,
     }
     if separators is not None:
@@ -76,18 +75,31 @@ def chunking_by_recursive_character(
 
     splitter = RecursiveCharacterTextSplitter(**splitter_kwargs)
 
+    # We deliberately do *not* request LangChain's ``add_start_index``. That
+    # offset is computed with a character-vs-token unit mismatch when a
+    # token-based ``length_function`` is in play: ``create_documents`` advances
+    # its search cursor by ``previous_chunk_len`` (characters) minus
+    # ``chunk_overlap`` (tokens), so on overlapping chunks the cursor overshoots
+    # each chunk's true start. The result is ``start_index == -1`` for unique
+    # text (lost ``_source_span`` → backfill failure under
+    # ``require_source_span``) or a match against a later identical run (wrong
+    # provenance). Instead we recover spans with our own monotonic forward
+    # cursor, which only ever advances and re-derives each span by exact match.
     docs = splitter.create_documents([content])
     results: list[dict[str, Any]] = []
+    cursor = 0
     for doc in docs:
         body = doc.page_content.strip()
         if not body:
             continue
-        start_index = doc.metadata.get("start_index")
+        start_index = content.find(body, cursor)
         source_span = None
-        if isinstance(start_index, int) and start_index >= 0:
-            end_index = start_index + len(body)
-            if content[start_index:end_index] == body:
-                source_span = {"start": start_index, "end": end_index}
+        if start_index >= 0:
+            source_span = {"start": start_index, "end": start_index + len(body)}
+            # Next chunk's start is strictly past this one (chunk starts are
+            # monotonically increasing, even with overlap), so advance by one
+            # to keep the cursor moving without skipping the next true start.
+            cursor = start_index + 1
         results.append(
             {
                 "tokens": len(tokenizer.encode(body)),

--- a/lightrag/chunker/recursive_character.py
+++ b/lightrag/chunker/recursive_character.py
@@ -18,6 +18,8 @@ final hard split before embedding.
 
 from __future__ import annotations
 
+import re
+from collections.abc import Callable, Sequence
 from typing import Any
 
 from lightrag.utils import Tokenizer, logger
@@ -31,60 +33,260 @@ except ImportError:
     RecursiveCharacterTextSplitter = None  # type: ignore[assignment]
 
 
-def _locate_chunk_start(
-    content: str,
-    body: str,
-    tokenizer: Tokenizer,
+_SpanPiece = tuple[str, int, int]
+
+
+def _split_text_with_regex_spans(
+    text: str,
+    separator_pattern: str,
     *,
-    prev_start: int | None,
-    prev_body: str | None,
-    overlap_tokens: int,
-    cursor: int,
-) -> int:
-    """Return the source-text offset where ``body`` begins, or ``-1``.
+    keep_separator: bool | str,
+    base_offset: int,
+) -> list[_SpanPiece]:
+    """Mirror LangChain's regex split while retaining source offsets."""
+    if not separator_pattern:
+        return [
+            (char, base_offset + index, base_offset + index + 1)
+            for index, char in enumerate(text)
+            if char
+        ]
 
-    A plain forward :meth:`str.find` is safe for unique text but collapses on
-    repeated content: identical overlapping chunks all match the nearest
-    repetition, so every span packs into the document head and the tail is left
-    without provenance. To avoid that we *predict* this chunk's start from the
-    previous one using the token-overlap geometry — ``prev_body`` length minus
-    the characters its trailing ``overlap_tokens`` re-share with this chunk —
-    and trust the prediction when it lands exactly. Only when it misses (from a
-    variable token/char ratio or a stripped separator) do we snap to the
-    occurrence nearest the prediction, always staying at or past ``cursor`` (a
-    monotonic floor) so spans never move backward.
-    """
-    if prev_start is None or prev_body is None:
-        return content.find(body, cursor)
+    matches = list(re.finditer(separator_pattern, text))
+    if not matches:
+        return [(text, base_offset, base_offset + len(text))] if text else []
 
-    prev_tokens = tokenizer.encode(prev_body)
-    take = min(len(prev_tokens), overlap_tokens)
-    overlap_chars = (
-        len(tokenizer.decode(prev_tokens[len(prev_tokens) - take :])) if take else 0
+    pieces: list[_SpanPiece] = []
+    if keep_separator:
+        if keep_separator == "end":
+            cursor = 0
+            for match in matches:
+                if match.end() > cursor:
+                    pieces.append(
+                        (
+                            text[cursor : match.end()],
+                            base_offset + cursor,
+                            base_offset + match.end(),
+                        )
+                    )
+                cursor = match.end()
+            if cursor < len(text):
+                pieces.append(
+                    (text[cursor:], base_offset + cursor, base_offset + len(text))
+                )
+        else:
+            first = matches[0]
+            if first.start() > 0:
+                pieces.append(
+                    (text[: first.start()], base_offset, base_offset + first.start())
+                )
+            for index, match in enumerate(matches):
+                end = (
+                    matches[index + 1].start()
+                    if index + 1 < len(matches)
+                    else len(text)
+                )
+                if end > match.start():
+                    pieces.append(
+                        (
+                            text[match.start() : end],
+                            base_offset + match.start(),
+                            base_offset + end,
+                        )
+                    )
+    else:
+        cursor = 0
+        for match in matches:
+            if match.start() > cursor:
+                pieces.append(
+                    (
+                        text[cursor : match.start()],
+                        base_offset + cursor,
+                        base_offset + match.start(),
+                    )
+                )
+            cursor = match.end()
+        if cursor < len(text):
+            pieces.append(
+                (text[cursor:], base_offset + cursor, base_offset + len(text))
+            )
+
+    return [piece for piece in pieces if piece[0]]
+
+
+def _join_span_pieces(
+    pieces: list[_SpanPiece],
+    separator: str,
+    *,
+    strip_whitespace: bool,
+) -> _SpanPiece | None:
+    """Join split pieces exactly as LangChain does and compute the trimmed span."""
+    if not pieces:
+        return None
+
+    chars: list[str] = []
+    char_offsets: list[int] = []
+    for index, (fragment, start, end) in enumerate(pieces):
+        if index > 0 and separator:
+            previous_end = pieces[index - 1][2]
+            for sep_index, sep_char in enumerate(separator):
+                chars.append(sep_char)
+                char_offsets.append(previous_end + sep_index)
+        chars.extend(fragment)
+        char_offsets.extend(range(start, end))
+
+    text = "".join(chars)
+    if strip_whitespace:
+        left = 0
+        right = len(text)
+        while left < right and text[left].isspace():
+            left += 1
+        while right > left and text[right - 1].isspace():
+            right -= 1
+    else:
+        left, right = 0, len(text)
+
+    if left >= right:
+        return None
+    return text[left:right], char_offsets[left], char_offsets[right - 1] + 1
+
+
+def _merge_splits_with_spans(
+    splits: Sequence[_SpanPiece],
+    separator: str,
+    *,
+    chunk_size: int,
+    chunk_overlap: int,
+    length_function: Callable[[str], int],
+    strip_whitespace: bool,
+) -> list[_SpanPiece]:
+    """Mirror ``TextSplitter._merge_splits`` while preserving source spans."""
+    separator_len = length_function(separator)
+    docs: list[_SpanPiece] = []
+    current_doc: list[_SpanPiece] = []
+    total = 0
+
+    for split in splits:
+        split_len = length_function(split[0])
+        if (
+            total + split_len + (separator_len if len(current_doc) > 0 else 0)
+            > chunk_size
+        ):
+            if total > chunk_size:
+                logger.warning(
+                    "Created a chunk of size %d, which is longer than the specified %d",
+                    total,
+                    chunk_size,
+                )
+            if len(current_doc) > 0:
+                doc = _join_span_pieces(
+                    current_doc,
+                    separator,
+                    strip_whitespace=strip_whitespace,
+                )
+                if doc is not None:
+                    docs.append(doc)
+                while total > chunk_overlap or (
+                    total + split_len + (separator_len if len(current_doc) > 0 else 0)
+                    > chunk_size
+                    and total > 0
+                ):
+                    total -= length_function(current_doc[0][0]) + (
+                        separator_len if len(current_doc) > 1 else 0
+                    )
+                    current_doc = current_doc[1:]
+        current_doc.append(split)
+        total += split_len + (separator_len if len(current_doc) > 1 else 0)
+
+    doc = _join_span_pieces(
+        current_doc,
+        separator,
+        strip_whitespace=strip_whitespace,
     )
-    step = max(1, len(prev_body) - overlap_chars)
-    guess = prev_start + step
-    if content[guess : guess + len(body)] == body:
-        return guess
+    if doc is not None:
+        docs.append(doc)
+    return docs
 
-    # Prediction was off; snap to the occurrence nearest it within a one-chunk
-    # window, never before the monotonic floor.
-    lo = max(cursor, guess - len(body))
-    hi = guess + len(body)
-    nearest = -1
-    best: int | None = None
-    i = content.find(body, lo)
-    while i != -1 and i <= hi:
-        dist = abs(i - guess)
-        if best is None or dist < best:
-            best, nearest = dist, i
-        i = content.find(body, i + 1)
-    if nearest != -1:
-        return nearest
 
-    # Nothing near the prediction: fall back to the first match at/after the
-    # monotonic floor so a forward-consistent span is still recorded.
-    return content.find(body, cursor)
+def _split_text_with_spans(
+    text: str,
+    *,
+    base_offset: int,
+    separators: Sequence[str],
+    chunk_size: int,
+    chunk_overlap: int,
+    length_function: Callable[[str], int],
+    keep_separator: bool | str,
+    is_separator_regex: bool,
+    strip_whitespace: bool,
+) -> list[_SpanPiece]:
+    """Mirror ``RecursiveCharacterTextSplitter._split_text`` with offsets."""
+    separator = separators[-1]
+    new_separators: Sequence[str] = []
+    for index, candidate in enumerate(separators):
+        separator_pattern = candidate if is_separator_regex else re.escape(candidate)
+        if not candidate:
+            separator = candidate
+            break
+        if re.search(separator_pattern, text):
+            separator = candidate
+            new_separators = separators[index + 1 :]
+            break
+
+    separator_pattern = separator if is_separator_regex else re.escape(separator)
+    splits = _split_text_with_regex_spans(
+        text,
+        separator_pattern,
+        keep_separator=keep_separator,
+        base_offset=base_offset,
+    )
+
+    final_chunks: list[_SpanPiece] = []
+    good_splits: list[_SpanPiece] = []
+    merge_separator = "" if keep_separator else separator
+    for split in splits:
+        if length_function(split[0]) < chunk_size:
+            good_splits.append(split)
+        else:
+            if good_splits:
+                final_chunks.extend(
+                    _merge_splits_with_spans(
+                        good_splits,
+                        merge_separator,
+                        chunk_size=chunk_size,
+                        chunk_overlap=chunk_overlap,
+                        length_function=length_function,
+                        strip_whitespace=strip_whitespace,
+                    )
+                )
+                good_splits = []
+            if not new_separators:
+                final_chunks.append(split)
+            else:
+                final_chunks.extend(
+                    _split_text_with_spans(
+                        split[0],
+                        base_offset=split[1],
+                        separators=new_separators,
+                        chunk_size=chunk_size,
+                        chunk_overlap=chunk_overlap,
+                        length_function=length_function,
+                        keep_separator=keep_separator,
+                        is_separator_regex=is_separator_regex,
+                        strip_whitespace=strip_whitespace,
+                    )
+                )
+    if good_splits:
+        final_chunks.extend(
+            _merge_splits_with_spans(
+                good_splits,
+                merge_separator,
+                chunk_size=chunk_size,
+                chunk_overlap=chunk_overlap,
+                length_function=length_function,
+                strip_whitespace=strip_whitespace,
+            )
+        )
+    return final_chunks
 
 
 def chunking_by_recursive_character(
@@ -120,10 +322,13 @@ def chunking_by_recursive_character(
     if not content or not content.strip():
         return []
 
+    def length_function(text: str) -> int:
+        return len(tokenizer.encode(text))
+
     splitter_kwargs: dict[str, Any] = {
         "chunk_size": max(int(chunk_token_size), 1),
         "chunk_overlap": max(int(chunk_overlap_token_size), 0),
-        "length_function": lambda s: len(tokenizer.encode(s)),
+        "length_function": length_function,
         "strip_whitespace": True,
     }
     if separators is not None:
@@ -133,43 +338,39 @@ def chunking_by_recursive_character(
 
     # We deliberately do *not* request LangChain's ``add_start_index``. That
     # offset is computed with a character-vs-token unit mismatch when a
-    # token-based ``length_function`` is in play: ``create_documents`` advances
-    # its search cursor by ``previous_chunk_len`` (characters) minus
-    # ``chunk_overlap`` (tokens), so on overlapping chunks the cursor overshoots
-    # each chunk's true start. The result is ``start_index == -1`` for unique
-    # text (lost ``_source_span`` → backfill failure under
-    # ``require_source_span``) or a match against a later identical run (wrong
-    # provenance). Instead we recover spans ourselves via ``_locate_chunk_start``.
-    overlap_tokens = max(int(chunk_overlap_token_size), 0)
-    docs = splitter.create_documents([content])
+    # token-based ``length_function`` is in play, and text-search recovery is
+    # ambiguous for repeated blocks. Instead we mirror LangChain's split/merge
+    # control flow while carrying each split unit's source offsets through it.
+    pieces = _split_text_with_spans(
+        content,
+        base_offset=0,
+        separators=list(splitter._separators),
+        chunk_size=int(splitter._chunk_size),
+        chunk_overlap=int(splitter._chunk_overlap),
+        length_function=length_function,
+        keep_separator=splitter._keep_separator,
+        is_separator_regex=bool(splitter._is_separator_regex),
+        strip_whitespace=bool(splitter._strip_whitespace),
+    )
     results: list[dict[str, Any]] = []
-    prev_start: int | None = None
-    prev_body: str | None = None
-    cursor = 0
-    for doc in docs:
-        body = doc.page_content.strip()
+    for raw_body, start_index, end_index in pieces:
+        left = 0
+        right = len(raw_body)
+        while left < right and raw_body[left].isspace():
+            left += 1
+        while right > left and raw_body[right - 1].isspace():
+            right -= 1
+        body = raw_body[left:right]
         if not body:
             continue
-        start_index = _locate_chunk_start(
-            content,
-            body,
-            tokenizer,
-            prev_start=prev_start,
-            prev_body=prev_body,
-            overlap_tokens=overlap_tokens,
-            cursor=cursor,
-        )
-        source_span = None
-        if start_index >= 0:
-            source_span = {"start": start_index, "end": start_index + len(body)}
-            prev_start, prev_body = start_index, body
-            cursor = start_index + 1
+        start_index += left
+        end_index -= len(raw_body) - right
         results.append(
             {
                 "tokens": len(tokenizer.encode(body)),
                 "content": body,
                 "chunk_order_index": len(results),
-                **({"_source_span": source_span} if source_span else {}),
+                "_source_span": {"start": start_index, "end": end_index},
             }
         )
 

--- a/lightrag/chunker/semantic_vector.py
+++ b/lightrag/chunker/semantic_vector.py
@@ -111,7 +111,21 @@ def _semantic_groups_with_spans(
     splitter: SemanticChunker,
     text: str,
 ) -> list[tuple[str, int, int]]:
-    """Mirror SemanticChunker grouping while keeping original source spans."""
+    """Mirror SemanticChunker grouping while keeping original source spans.
+
+    .. warning::
+        This re-implements the body of ``SemanticChunker.split_text`` so each group
+        carries its exact source span (``text[start:end]``) instead of the upstream
+        ``" ".join(sentences)`` reflow. It relies on **private** members
+        (``sentence_split_regex``, ``breakpoint_threshold_type``, ``min_chunk_size``,
+        ``number_of_chunks``, ``_calculate_sentence_distances``,
+        ``_threshold_from_clusters``, ``_calculate_breakpoint_threshold``). Verified
+        byte-for-byte against ``langchain-experimental`` 0.3.x–0.4.x (the range pinned
+        in ``pyproject.toml``: ``langchain-experimental>=0.3,<1``). If that pin is
+        widened, re-verify against the new upstream ``split_text`` —
+        ``tests/chunker/test_chunker_semantic_vector.py`` has a drift guard that
+        compares this mirror's grouping to the live ``splitter.split_text`` output.
+    """
     single_sentences_list = re.split(splitter.sentence_split_regex, text)
     spans = _sentence_spans(text, single_sentences_list)
 

--- a/lightrag/chunker/semantic_vector.py
+++ b/lightrag/chunker/semantic_vector.py
@@ -127,8 +127,8 @@ def _semantic_groups_with_spans(
         (``sentence_split_regex``, ``breakpoint_threshold_type``, ``min_chunk_size``,
         ``number_of_chunks``, ``_calculate_sentence_distances``,
         ``_threshold_from_clusters``, ``_calculate_breakpoint_threshold``). Verified
-        byte-for-byte against ``langchain-experimental`` 0.3.x–0.4.x (the range pinned
-        in ``pyproject.toml``: ``langchain-experimental>=0.3,<1``). If that pin is
+        byte-for-byte against ``langchain-experimental`` 0.3.2–0.4.x (the range pinned
+        in ``pyproject.toml``: ``langchain-experimental>=0.3.2,<1``). If that pin is
         widened, re-verify against the new upstream ``split_text`` —
         ``tests/chunker/test_chunker_semantic_vector.py`` has a drift guard that
         compares this mirror's grouping to the live ``splitter.split_text`` output.
@@ -261,7 +261,7 @@ async def chunking_by_semantic_vector(
     if not _LANGCHAIN_EXPERIMENTAL_AVAILABLE:
         raise ImportError(
             "langchain-experimental is required for the 'V' chunking "
-            "strategy; install with `pip install langchain-experimental>=0.3`."
+            "strategy; install with `pip install langchain-experimental>=0.3.2`."
         )
 
     loop = asyncio.get_running_loop()

--- a/lightrag/chunker/semantic_vector.py
+++ b/lightrag/chunker/semantic_vector.py
@@ -35,7 +35,9 @@ from lightrag.constants import DEFAULT_SENTENCE_SPLIT_REGEX
 from lightrag.utils import EmbeddingFunc, Tokenizer, logger
 
 if TYPE_CHECKING:
-    from langchain_experimental.text_splitter import SemanticChunker as SemanticChunkerType
+    from langchain_experimental.text_splitter import (
+        SemanticChunker as SemanticChunkerType,
+    )
 else:
     SemanticChunkerType = Any
 

--- a/lightrag/chunker/semantic_vector.py
+++ b/lightrag/chunker/semantic_vector.py
@@ -28,6 +28,7 @@ Caveats:
 from __future__ import annotations
 
 import asyncio
+import re
 from typing import Any
 
 from lightrag.constants import DEFAULT_SENTENCE_SPLIT_REGEX
@@ -78,6 +79,95 @@ class _AsyncEmbeddingFuncAdapter(Embeddings):
         return self._run([text], context="query")[0]
 
 
+def _sentence_spans(text: str, sentences: list[str]) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    cursor = 0
+    for sentence in sentences:
+        if not sentence:
+            spans.append((cursor, cursor))
+            continue
+        start = text.find(sentence, cursor)
+        if start < 0:
+            start = text.find(sentence)
+        if start < 0:
+            start = cursor
+        end = start + len(sentence)
+        spans.append((start, end))
+        cursor = end
+    return spans
+
+
+def _trim_span(text: str, start: int, end: int) -> tuple[int, int]:
+    start = max(0, min(start, len(text)))
+    end = max(start, min(end, len(text)))
+    while start < end and text[start].isspace():
+        start += 1
+    while end > start and text[end - 1].isspace():
+        end -= 1
+    return start, end
+
+
+def _semantic_groups_with_spans(
+    splitter: SemanticChunker,
+    text: str,
+) -> list[tuple[str, int, int]]:
+    """Mirror SemanticChunker grouping while keeping original source spans."""
+    single_sentences_list = re.split(splitter.sentence_split_regex, text)
+    spans = _sentence_spans(text, single_sentences_list)
+
+    def _group(start_index: int, end_index: int) -> tuple[str, int, int] | None:
+        start, _ = spans[start_index]
+        _, end = spans[end_index]
+        start, end = _trim_span(text, start, end)
+        if start >= end:
+            return None
+        return text[start:end], start, end
+
+    if len(single_sentences_list) == 1:
+        group = _group(0, 0)
+        return [group] if group else []
+    if (
+        splitter.breakpoint_threshold_type == "gradient"
+        and len(single_sentences_list) == 2
+    ):
+        return [g for i in range(2) if (g := _group(i, i)) is not None]
+
+    distances, sentences = splitter._calculate_sentence_distances(single_sentences_list)
+    if splitter.number_of_chunks is not None:
+        breakpoint_distance_threshold = splitter._threshold_from_clusters(distances)
+        breakpoint_array = distances
+    else:
+        breakpoint_distance_threshold, breakpoint_array = (
+            splitter._calculate_breakpoint_threshold(distances)
+        )
+
+    indices_above_thresh = [
+        i for i, x in enumerate(breakpoint_array) if x > breakpoint_distance_threshold
+    ]
+
+    chunks: list[tuple[str, int, int]] = []
+    start_index = 0
+    for index in indices_above_thresh:
+        end_index = index
+        group_sentences = sentences[start_index : end_index + 1]
+        combined_text = " ".join([d["sentence"] for d in group_sentences])
+        if (
+            splitter.min_chunk_size is not None
+            and len(combined_text) < splitter.min_chunk_size
+        ):
+            continue
+        group = _group(start_index, end_index)
+        if group is not None:
+            chunks.append(group)
+        start_index = index + 1
+
+    if start_index < len(sentences):
+        group = _group(start_index, len(sentences) - 1)
+        if group is not None:
+            chunks.append(group)
+    return chunks
+
+
 async def chunking_by_semantic_vector(
     tokenizer: Tokenizer,
     content: str,
@@ -88,6 +178,8 @@ async def chunking_by_semantic_vector(
     breakpoint_threshold_amount: float | None = None,
     buffer_size: int = 1,
     sentence_split_regex: str = DEFAULT_SENTENCE_SPLIT_REGEX,
+    number_of_chunks: int | None = None,
+    min_chunk_size: int | None = None,
 ) -> list[dict[str, Any]]:
     """Semantic vector chunker — the ``"V"`` chunking strategy.
 
@@ -113,6 +205,8 @@ async def chunking_by_semantic_vector(
             Default extends the upstream English-only pattern with
             Chinese sentence terminators ``。？！`` so mixed-language and
             pure-Chinese inputs split correctly.
+        number_of_chunks: Optional target chunk count (LangChain SemanticChunker).
+        min_chunk_size: Optional minimum character size for semantic groups.
 
     Returns:
         Ordered list of ``{"tokens", "content", "chunk_order_index"}``
@@ -157,6 +251,8 @@ async def chunking_by_semantic_vector(
         "buffer_size": int(buffer_size),
         "breakpoint_threshold_type": breakpoint_threshold_type,
         "sentence_split_regex": sentence_split_regex,
+        "number_of_chunks": number_of_chunks,
+        "min_chunk_size": min_chunk_size,
     }
     if breakpoint_threshold_amount is not None:
         chunker_kwargs["breakpoint_threshold_amount"] = float(
@@ -164,7 +260,7 @@ async def chunking_by_semantic_vector(
         )
 
     splitter = SemanticChunker(**chunker_kwargs)
-    pieces = await asyncio.to_thread(splitter.split_text, content)
+    pieces = await asyncio.to_thread(_semantic_groups_with_spans, splitter, content)
 
     # SemanticChunker has no internal size cap; oversized pieces here
     # would otherwise rely on the embedding-time hard fallback (which
@@ -180,7 +276,7 @@ async def chunking_by_semantic_vector(
 
     target_max = max(int(chunk_token_size), 1)
     results: list[dict[str, Any]] = []
-    for piece in pieces:
+    for piece, source_start, source_end in pieces:
         body = piece.strip()
         if not body:
             continue
@@ -191,6 +287,10 @@ async def chunking_by_semantic_vector(
                     "tokens": piece_tokens,
                     "content": body,
                     "chunk_order_index": len(results),
+                    "_source_span": {
+                        "start": source_start,
+                        "end": source_end,
+                    },
                 }
             )
             continue
@@ -207,11 +307,22 @@ async def chunking_by_semantic_vector(
             sub_body = sub.get("content", "")
             if not sub_body:
                 continue
+            sub_span = sub.get("_source_span")
+            source_span = None
+            if isinstance(sub_span, dict):
+                try:
+                    source_span = {
+                        "start": source_start + int(sub_span["start"]),
+                        "end": source_start + int(sub_span["end"]),
+                    }
+                except (KeyError, TypeError, ValueError):
+                    source_span = None
             results.append(
                 {
                     "tokens": sub.get("tokens", len(tokenizer.encode(sub_body))),
                     "content": sub_body,
                     "chunk_order_index": len(results),
+                    **({"_source_span": source_span} if source_span else {}),
                 }
             )
     return results

--- a/lightrag/chunker/semantic_vector.py
+++ b/lightrag/chunker/semantic_vector.py
@@ -29,10 +29,15 @@ from __future__ import annotations
 
 import asyncio
 import re
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from lightrag.constants import DEFAULT_SENTENCE_SPLIT_REGEX
 from lightrag.utils import EmbeddingFunc, Tokenizer, logger
+
+if TYPE_CHECKING:
+    from langchain_experimental.text_splitter import SemanticChunker as SemanticChunkerType
+else:
+    SemanticChunkerType = Any
 
 try:
     from langchain_core.embeddings import Embeddings
@@ -108,7 +113,7 @@ def _trim_span(text: str, start: int, end: int) -> tuple[int, int]:
 
 
 def _semantic_groups_with_spans(
-    splitter: SemanticChunker,
+    splitter: SemanticChunkerType,
     text: str,
 ) -> list[tuple[str, int, int]]:
     """Mirror SemanticChunker grouping while keeping original source spans.

--- a/lightrag/chunker/token_size.py
+++ b/lightrag/chunker/token_size.py
@@ -29,6 +29,67 @@ from lightrag.exceptions import ChunkTokenLimitExceededError
 from lightrag.utils import Tokenizer, logger
 
 
+def _trimmed_span(content: str, start: int, end: int) -> tuple[int, int]:
+    """Return the source span after applying the chunker's ``.strip()``."""
+    start = max(0, min(start, len(content)))
+    end = max(start, min(end, len(content)))
+    while start < end and content[start].isspace():
+        start += 1
+    while end > start and content[end - 1].isspace():
+        end -= 1
+    return start, end
+
+
+def _source_span(content: str, start: int, end: int) -> dict[str, int] | None:
+    start, end = _trimmed_span(content, start, end)
+    if start >= end:
+        return None
+    return {"start": start, "end": end}
+
+
+def _token_window_source_span(
+    tokenizer: Tokenizer,
+    content: str,
+    tokens: list[int],
+    start_token: int,
+    end_token: int,
+) -> dict[str, int] | None:
+    """Map a decoded token window back to its exact source span."""
+    window = tokenizer.decode(tokens[start_token:end_token])
+    prefix = tokenizer.decode(tokens[:start_token])
+    start = len(prefix)
+    end = start + len(window)
+    if content[start:end] != window:
+        found = content.find(
+            window,
+            max(0, start - 32),
+            min(len(content), end + 32 + len(window)),
+        )
+        if found < 0:
+            return None
+        start = found
+        end = found + len(window)
+    return _source_span(content, start, end)
+
+
+def _make_chunk(
+    *,
+    content: str,
+    tokens: int,
+    order: int,
+    source_span: dict[str, int] | None,
+    emit_source_span: bool,
+) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "tokens": tokens,
+        "content": content.strip(),
+        "chunk_order_index": order,
+    }
+    if emit_source_span and source_span is not None:
+        item["_source_span"] = source_span
+    return item
+
+
 def chunking_by_token_size(
     tokenizer: Tokenizer,
     content: str,
@@ -36,6 +97,8 @@ def chunking_by_token_size(
     split_by_character_only: bool = False,
     chunk_overlap_token_size: int = 100,
     chunk_token_size: int = 1200,
+    *,
+    _emit_source_span: bool = False,
 ) -> list[dict[str, Any]]:
     """Legacy 6-arg fixed-token chunker (default for ``LightRAG.chunking_func``).
 
@@ -47,9 +110,16 @@ def chunking_by_token_size(
     results: list[dict[str, Any]] = []
     if split_by_character:
         raw_chunks = content.split(split_by_character)
+        raw_spans: list[tuple[int, int]] = []
+        cursor = 0
+        for raw_chunk in raw_chunks:
+            start = cursor
+            end = start + len(raw_chunk)
+            raw_spans.append((start, end))
+            cursor = end + len(split_by_character)
         new_chunks = []
         if split_by_character_only:
-            for chunk in raw_chunks:
+            for chunk, (chunk_start, chunk_end) in zip(raw_chunks, raw_spans):
                 _tokens = tokenizer.encode(chunk)
                 if len(_tokens) > chunk_token_size:
                     logger.warning(
@@ -62,9 +132,14 @@ def chunking_by_token_size(
                         chunk_token_limit=chunk_token_size,
                         chunk_preview=chunk[:120],
                     )
-                new_chunks.append((len(_tokens), chunk))
+                span = (
+                    _source_span(content, chunk_start, chunk_end)
+                    if _emit_source_span
+                    else None
+                )
+                new_chunks.append((len(_tokens), chunk, span))
         else:
-            for chunk in raw_chunks:
+            for chunk, (chunk_start, chunk_end) in zip(raw_chunks, raw_spans):
                 _tokens = tokenizer.encode(chunk)
                 if len(_tokens) > chunk_token_size:
                     for start in range(
@@ -73,30 +148,63 @@ def chunking_by_token_size(
                         chunk_content = tokenizer.decode(
                             _tokens[start : start + chunk_token_size]
                         )
+                        span = None
+                        if _emit_source_span:
+                            span = _token_window_source_span(
+                                tokenizer,
+                                chunk,
+                                _tokens,
+                                start,
+                                min(start + chunk_token_size, len(_tokens)),
+                            )
+                        if span is not None:
+                            span = {
+                                "start": chunk_start + span["start"],
+                                "end": chunk_start + span["end"],
+                            }
                         new_chunks.append(
-                            (min(chunk_token_size, len(_tokens) - start), chunk_content)
+                            (
+                                min(chunk_token_size, len(_tokens) - start),
+                                chunk_content,
+                                span,
+                            )
                         )
                 else:
-                    new_chunks.append((len(_tokens), chunk))
-        for index, (_len, chunk) in enumerate(new_chunks):
+                    span = (
+                        _source_span(content, chunk_start, chunk_end)
+                        if _emit_source_span
+                        else None
+                    )
+                    new_chunks.append((len(_tokens), chunk, span))
+        for index, (_len, chunk, span) in enumerate(new_chunks):
             results.append(
-                {
-                    "tokens": _len,
-                    "content": chunk.strip(),
-                    "chunk_order_index": index,
-                }
+                _make_chunk(
+                    content=chunk,
+                    tokens=_len,
+                    order=index,
+                    source_span=span,
+                    emit_source_span=_emit_source_span,
+                )
             )
     else:
         for index, start in enumerate(
             range(0, len(tokens), chunk_token_size - chunk_overlap_token_size)
         ):
-            chunk_content = tokenizer.decode(tokens[start : start + chunk_token_size])
+            end = min(start + chunk_token_size, len(tokens))
+            chunk_content = tokenizer.decode(tokens[start:end])
+            span = (
+                _token_window_source_span(tokenizer, content, tokens, start, end)
+                if _emit_source_span
+                else None
+            )
             results.append(
-                {
-                    "tokens": min(chunk_token_size, len(tokens) - start),
-                    "content": chunk_content.strip(),
-                    "chunk_order_index": index,
-                }
+                _make_chunk(
+                    content=chunk_content,
+                    tokens=min(chunk_token_size, len(tokens) - start),
+                    order=index,
+                    source_span=span,
+                    emit_source_span=_emit_source_span,
+                )
             )
     return results
 
@@ -109,6 +217,7 @@ def chunking_by_fixed_token(
     chunk_overlap_token_size: int = 100,
     split_by_character: str | None = None,
     split_by_character_only: bool = False,
+    _emit_source_span: bool = False,
 ) -> list[dict[str, Any]]:
     """Fixed-token chunker — file-chunker contract for the ``"F"`` strategy.
 
@@ -125,4 +234,5 @@ def chunking_by_fixed_token(
         split_by_character_only=split_by_character_only,
         chunk_overlap_token_size=chunk_overlap_token_size,
         chunk_token_size=chunk_token_size,
+        _emit_source_span=_emit_source_span,
     )

--- a/lightrag/chunker/token_size.py
+++ b/lightrag/chunker/token_size.py
@@ -53,11 +53,32 @@ def _token_window_source_span(
     tokens: list[int],
     start_token: int,
     end_token: int,
-) -> dict[str, int] | None:
-    """Map a decoded token window back to its exact source span."""
+    *,
+    anchor: tuple[int, int],
+) -> tuple[dict[str, int] | None, tuple[int, int]]:
+    """Map a decoded token window back to its exact source span.
+
+    ``anchor`` is the previous window's *verified* ``(start_token, start_char)``.
+    Window starts are monotonically increasing, so instead of re-decoding the whole
+    ``tokens[:start_token]`` prefix (O(N) per window → O(N²) overall) we decode only
+    the delta ``tokens[anchor_token:start_token]`` (≈ one chunking step) to predict
+    the start char. The predicted offset is then verified against ``content`` exactly
+    as a full prefix decode would be: byte-level BPE decode is non-concatenative at a
+    multi-byte UTF-8 boundary, so a delta can be off by the few chars of one split
+    char — the ±32 ``find`` fallback corrects that, and re-anchoring on the verified
+    position each call keeps the error from accumulating. Net cost is O(N) total
+    while the located span stays byte-exact.
+
+    Returns ``(span, new_anchor)``. On an unlocatable (U+FFFD) window the span is
+    ``None`` and the anchor is returned unchanged so the next window still predicts
+    from the last verified position.
+    """
+    anchor_token, anchor_char = anchor
     window = tokenizer.decode(tokens[start_token:end_token])
-    prefix = tokenizer.decode(tokens[:start_token])
-    start = len(prefix)
+    if start_token >= anchor_token:
+        start = anchor_char + len(tokenizer.decode(tokens[anchor_token:start_token]))
+    else:  # non-monotonic caller (not expected) — fall back to a full prefix decode
+        start = len(tokenizer.decode(tokens[:start_token]))
     end = start + len(window)
     if content[start:end] != window:
         found = content.find(
@@ -66,10 +87,10 @@ def _token_window_source_span(
             min(len(content), end + 32 + len(window)),
         )
         if found < 0:
-            return None
+            return None, anchor
         start = found
         end = found + len(window)
-    return _source_span(content, start, end)
+    return _source_span(content, start, end), (start_token, start)
 
 
 def _make_chunk(
@@ -142,20 +163,23 @@ def chunking_by_token_size(
             for chunk, (chunk_start, chunk_end) in zip(raw_chunks, raw_spans):
                 _tokens = tokenizer.encode(chunk)
                 if len(_tokens) > chunk_token_size:
+                    # Anchor is chunk-relative (offsets are shifted by chunk_start
+                    # below), so it resets per split-by-character segment.
+                    anchor = (0, 0)
                     for start in range(
                         0, len(_tokens), chunk_token_size - chunk_overlap_token_size
                     ):
-                        chunk_content = tokenizer.decode(
-                            _tokens[start : start + chunk_token_size]
-                        )
+                        end_token = min(start + chunk_token_size, len(_tokens))
+                        chunk_content = tokenizer.decode(_tokens[start:end_token])
                         span = None
                         if _emit_source_span:
-                            span = _token_window_source_span(
+                            span, anchor = _token_window_source_span(
                                 tokenizer,
                                 chunk,
                                 _tokens,
                                 start,
-                                min(start + chunk_token_size, len(_tokens)),
+                                end_token,
+                                anchor=anchor,
                             )
                         if span is not None:
                             span = {
@@ -187,16 +211,17 @@ def chunking_by_token_size(
                 )
             )
     else:
+        anchor = (0, 0)
         for index, start in enumerate(
             range(0, len(tokens), chunk_token_size - chunk_overlap_token_size)
         ):
             end = min(start + chunk_token_size, len(tokens))
             chunk_content = tokenizer.decode(tokens[start:end])
-            span = (
-                _token_window_source_span(tokenizer, content, tokens, start, end)
-                if _emit_source_span
-                else None
-            )
+            span = None
+            if _emit_source_span:
+                span, anchor = _token_window_source_span(
+                    tokenizer, content, tokens, start, end, anchor=anchor
+                )
             results.append(
                 _make_chunk(
                     content=chunk_content,

--- a/lightrag/exceptions.py
+++ b/lightrag/exceptions.py
@@ -131,6 +131,36 @@ class ChunkTokenLimitExceededError(ValueError):
         self.chunk_preview = truncated_preview
 
 
+class ChunkBlockMatchError(ValueError):
+    """Raised when a chunk cannot be located in the document's blocks.jsonl.
+
+    Sidecar backfill (``lightrag.sidecar.backfill``) maps F/R/V chunks back to
+    their source block(s) by matching chunk content against the parse-time
+    ``*.blocks.jsonl`` merged text. When a sidecar-less chunk cannot be located,
+    this is raised so the pipeline marks the document FAILED rather than
+    persisting chunks with missing/incorrect provenance.
+    """
+
+    def __init__(
+        self,
+        chunk_order_index: int,
+        chunk_preview: str | None = None,
+        blocks_path: str | None = None,
+    ) -> None:
+        preview = chunk_preview.strip() if chunk_preview else None
+        truncated_preview = preview[:80] if preview else None
+        preview_note = f" Preview: '{truncated_preview}'" if truncated_preview else ""
+        path_note = f" (blocks: {blocks_path})" if blocks_path else ""
+        message = (
+            f"Chunk #{chunk_order_index} could not be located in the document "
+            f"blocks during sidecar backfill.{preview_note}{path_note}"
+        )
+        super().__init__(message)
+        self.chunk_order_index = chunk_order_index
+        self.chunk_preview = truncated_preview
+        self.blocks_path = blocks_path
+
+
 class DataMigrationError(Exception):
     """Raised when data migration from legacy collection/table fails."""
 

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -2157,11 +2157,7 @@ class _PipelineMixin:
                 if blocks_path and sidecar_backfill_eligible:
                     from lightrag.sidecar import backfill_chunk_sidecars
 
-                    backfill_chunk_sidecars(
-                        chunking_result,
-                        blocks_path,
-                        require_source_span=True,
-                    )
+                    backfill_chunk_sidecars(chunking_result, blocks_path)
 
                 chunks = build_chunks_dict_from_chunking_result(
                     chunking_result, doc_id=doc_id, file_path=file_path

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -2006,31 +2006,24 @@ class _PipelineMixin:
                     )
                     from lightrag.chunker import chunking_by_token_size
 
+                    # Only the unmodified default fixed-token chunker understands the
+                    # private ``_emit_source_span`` kwarg; a user-supplied
+                    # ``chunking_func`` must not receive it.
+                    legacy_kwargs = {}
                     if self.chunking_func is chunking_by_token_size:
-                        chunking_result = self.chunking_func(
-                            self.tokenizer,
-                            content,
-                            f_opts.get("split_by_character"),
-                            f_opts.get("split_by_character_only", False),
-                            f_opts.get(
-                                "chunk_overlap_token_size",
-                                self.chunk_overlap_token_size,
-                            ),
-                            legacy_chunk_size,
-                            _emit_source_span=True,
-                        )
-                    else:
-                        chunking_result = self.chunking_func(
-                            self.tokenizer,
-                            content,
-                            f_opts.get("split_by_character"),
-                            f_opts.get("split_by_character_only", False),
-                            f_opts.get(
-                                "chunk_overlap_token_size",
-                                self.chunk_overlap_token_size,
-                            ),
-                            legacy_chunk_size,
-                        )
+                        legacy_kwargs["_emit_source_span"] = True
+                    chunking_result = self.chunking_func(
+                        self.tokenizer,
+                        content,
+                        f_opts.get("split_by_character"),
+                        f_opts.get("split_by_character_only", False),
+                        f_opts.get(
+                            "chunk_overlap_token_size",
+                            self.chunk_overlap_token_size,
+                        ),
+                        legacy_chunk_size,
+                        **legacy_kwargs,
+                    )
                 if inspect.isawaitable(chunking_result):
                     chunking_result = await chunking_result
 

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1968,6 +1968,7 @@ class _PipelineMixin:
                             self.tokenizer,
                             content,
                             f_chunk_size,
+                            _emit_source_span=True,
                             **f_opts,
                         )
                 else:
@@ -2003,17 +2004,33 @@ class _PipelineMixin:
                     logger.info(
                         f"Chunking F(legacy): {chunk_opts_str}, doc_id: {doc_id}"
                     )
-                    chunking_result = self.chunking_func(
-                        self.tokenizer,
-                        content,
-                        f_opts.get("split_by_character"),
-                        f_opts.get("split_by_character_only", False),
-                        f_opts.get(
-                            "chunk_overlap_token_size",
-                            self.chunk_overlap_token_size,
-                        ),
-                        legacy_chunk_size,
-                    )
+                    from lightrag.chunker import chunking_by_token_size
+
+                    if self.chunking_func is chunking_by_token_size:
+                        chunking_result = self.chunking_func(
+                            self.tokenizer,
+                            content,
+                            f_opts.get("split_by_character"),
+                            f_opts.get("split_by_character_only", False),
+                            f_opts.get(
+                                "chunk_overlap_token_size",
+                                self.chunk_overlap_token_size,
+                            ),
+                            legacy_chunk_size,
+                            _emit_source_span=True,
+                        )
+                    else:
+                        chunking_result = self.chunking_func(
+                            self.tokenizer,
+                            content,
+                            f_opts.get("split_by_character"),
+                            f_opts.get("split_by_character_only", False),
+                            f_opts.get(
+                                "chunk_overlap_token_size",
+                                self.chunk_overlap_token_size,
+                            ),
+                            legacy_chunk_size,
+                        )
                 if inspect.isawaitable(chunking_result):
                     chunking_result = await chunking_result
 
@@ -2119,6 +2136,39 @@ class _PipelineMixin:
                         extraction_meta["hard_fallback_split"] = (
                             f"{original_chunk_count} -> {len(chunking_result)}"
                         )
+
+                # Backfill block provenance for F/R/V chunks (P already carries
+                # sidecars; multimodal chunks too). Runs on the final, post-split
+                # chunk list so each slice maps precisely to the block(s) its
+                # content covers. Raises ChunkBlockMatchError -> doc FAILED when a
+                # chunk cannot be located in blocks.jsonl.
+                #
+                # Gated to the built-in F/R/V strategies — or the legacy path only
+                # when ``chunking_func`` is still the unmodified default fixed-token
+                # chunker. A user-supplied ``chunking_func`` may emit summaries /
+                # rewritten text that cannot be located in blocks.jsonl, which would
+                # wrongly FAIL the document.
+                if doc_process_opts.chunking_explicit:
+                    sidecar_backfill_eligible = doc_process_opts.chunking in {
+                        "F",
+                        "R",
+                        "V",
+                    }
+                else:
+                    from lightrag.chunker import chunking_by_token_size
+
+                    sidecar_backfill_eligible = (
+                        self.chunking_func is chunking_by_token_size
+                    )
+
+                if blocks_path and sidecar_backfill_eligible:
+                    from lightrag.sidecar import backfill_chunk_sidecars
+
+                    backfill_chunk_sidecars(
+                        chunking_result,
+                        blocks_path,
+                        require_source_span=True,
+                    )
 
                 chunks = build_chunks_dict_from_chunking_result(
                     chunking_result, doc_id=doc_id, file_path=file_path

--- a/lightrag/sidecar/__init__.py
+++ b/lightrag/sidecar/__init__.py
@@ -10,7 +10,8 @@ emits the spec-compliant ``*.parsed/`` directory.
 See :func:`lightrag.sidecar.writer.write_sidecar` for the entry point.
 """
 
-from lightrag.sidecar.backfill import backfill_chunk_sidecars
+from typing import TYPE_CHECKING
+
 from lightrag.sidecar.ir import (
     AssetSpec,
     IRBlock,
@@ -21,6 +22,9 @@ from lightrag.sidecar.ir import (
     IRTable,
 )
 from lightrag.sidecar.writer import write_sidecar
+
+if TYPE_CHECKING:
+    from lightrag.sidecar.backfill import backfill_chunk_sidecars
 
 __all__ = [
     "AssetSpec",
@@ -33,3 +37,16 @@ __all__ = [
     "backfill_chunk_sidecars",
     "write_sidecar",
 ]
+
+
+def __getattr__(name: str):
+    # Lazily expose ``backfill_chunk_sidecars`` so that merely importing
+    # ``lightrag.sidecar`` (for the IR/writer exports) does not pull in
+    # ``lightrag.sidecar.backfill`` -> ``lightrag.exceptions`` -> ``httpx``.
+    # ``httpx`` only ships with the ``api`` extra, so an eager import would
+    # break core installs that just need the writer.
+    if name == "backfill_chunk_sidecars":
+        from lightrag.sidecar.backfill import backfill_chunk_sidecars
+
+        return backfill_chunk_sidecars
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/lightrag/sidecar/__init__.py
+++ b/lightrag/sidecar/__init__.py
@@ -10,6 +10,7 @@ emits the spec-compliant ``*.parsed/`` directory.
 See :func:`lightrag.sidecar.writer.write_sidecar` for the entry point.
 """
 
+from lightrag.sidecar.backfill import backfill_chunk_sidecars
 from lightrag.sidecar.ir import (
     AssetSpec,
     IRBlock,
@@ -29,5 +30,6 @@ __all__ = [
     "IREquation",
     "IRPosition",
     "IRTable",
+    "backfill_chunk_sidecars",
     "write_sidecar",
 ]

--- a/lightrag/sidecar/backfill.py
+++ b/lightrag/sidecar/backfill.py
@@ -1,0 +1,352 @@
+"""Backfill chunk ``sidecar`` provenance for the F/R/V chunking strategies.
+
+The ``P`` (paragraph_semantic) strategy records a ``sidecar`` field on each chunk
+mapping it back to its source row(s) in the parse-time ``*.blocks.jsonl`` sidecar
+file. The ``F`` / ``R`` / ``V`` strategies chunk the merged document text without
+that provenance. When a document was parsed into the LightRAG sidecar format
+(``blocks.jsonl`` exists), :func:`backfill_chunk_sidecars` scans the blocks and
+attaches a ``sidecar`` to each chunk that lacks one.
+
+Matching contract
+-----------------
+The merged text a chunker received is exactly reproducible from ``blocks.jsonl``:
+both :func:`lightrag.sidecar.writer.write_sidecar` and
+:func:`lightrag.utils_pipeline.load_lightrag_document_content` build it as
+``"\\n\\n".join(raw_content for content rows where content.strip())``. We rebuild
+the same string here, record each block's character span, and locate each chunk's
+content within it.
+
+F decodes/strips token windows (verbatim substrings, with token overlap); R strips
+LangChain pieces (verbatim, possible overlap); V strips ``SemanticChunker`` pieces
+that rejoin sentences with a single space — so newlines collapse to spaces *and* a
+space may be inserted between sentences that were originally adjacent with no
+whitespace, making the text *not* byte-verbatim. To cover all three uniformly,
+matching runs over a **whitespace-stripped** projection of both sides (every
+whitespace char removed, not merely collapsed to a single space). Because whitespace
+removal is monotonic, a chunk's non-whitespace characters are always a contiguous
+substring of the merged text's non-whitespace characters — regardless of how either
+side spaced them — so V's reflowing can never spuriously fail a match.
+
+Multimodal placeholder tags (``<table …>…</table>``, ``<drawing …/>``,
+``<equation …>…</equation>``) appear identically in block content and chunk content,
+so they project identically under whitespace stripping and match — markup is never
+stripped before matching.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from lightrag.chunk_schema import normalize_chunk_sidecar
+from lightrag.exceptions import ChunkBlockMatchError
+from lightrag.utils import logger
+
+# Separator used to join block content into the merged document text. Must match
+# lightrag/sidecar/writer.py and lightrag/utils_pipeline.py.
+_BLOCK_SEPARATOR = "\n\n"
+
+
+def _load_content_blocks(blocks_path: str) -> list[tuple[str, str]]:
+    """Read ``type == "content"`` rows from a blocks.jsonl file in order.
+
+    Returns ``(blockid, raw_content)`` pairs, skipping the meta header and any
+    malformed lines. Mirrors ``paragraph_semantic._load_blocks_from_jsonl`` but
+    keeps the raw (un-stripped) content needed to reproduce the chunker input.
+
+    Note: ``utils_pipeline.load_lightrag_document_content`` (which produces the
+    merged text the chunker actually received) skips line 0 *by index*; here we
+    skip *by type* instead. The two agree only because ``writer.write_sidecar``
+    always emits the meta header as the very first line — under that invariant
+    skip-by-type is equivalent, and it stays correct even if a stray non-content
+    row ever appears mid-file.
+    """
+    blocks: list[tuple[str, str]] = []
+    with Path(blocks_path).open("r", encoding="utf-8") as fh:
+        for raw in fh:
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(obj, dict) or obj.get("type") != "content":
+                continue
+            content = obj.get("content", "")
+            if not isinstance(content, str):
+                continue
+            blockid = str(obj.get("blockid") or "").strip()
+            blocks.append((blockid, content))
+    return blocks
+
+
+def _build_block_spans(
+    blocks: list[tuple[str, str]],
+) -> tuple[str, list[tuple[int, int, str]]]:
+    """Reconstruct the merged text and each kept block's char span.
+
+    Only rows whose ``content.strip()`` is truthy are kept (matching
+    ``utils_pipeline.load_lightrag_document_content``). Returns ``(merged, spans)``
+    where each span is ``(start, end, blockid)`` over ``merged`` char offsets. The
+    ``"\\n\\n"`` separators between blocks belong to no span.
+    """
+    spans: list[tuple[int, int, str]] = []
+    parts: list[str] = []
+    cursor = 0
+    for blockid, content in blocks:
+        if not content.strip():
+            continue
+        if parts:
+            cursor += len(_BLOCK_SEPARATOR)
+        start = cursor
+        end = start + len(content)
+        spans.append((start, end, blockid))
+        parts.append(content)
+        cursor = end
+    return _BLOCK_SEPARATOR.join(parts), spans
+
+
+def _normalize_projection(merged: str) -> tuple[str, list[int]]:
+    """Drop every whitespace char; map each kept char back to its merged offset.
+
+    Returns ``(norm_text, norm_to_orig)`` where ``norm_to_orig[i]`` is the offset
+    in ``merged`` of the ``i``-th surviving (non-whitespace) character. Removing all
+    whitespace — rather than collapsing runs to a single space — keeps the two sides
+    aligned even when V inserts a space between originally-adjacent sentences. Because
+    whitespace removal is monotonic, any contiguous region of ``merged`` projects to a
+    contiguous substring of ``norm_text``, so chunk lookups stay exact.
+    """
+    norm_chars: list[str] = []
+    norm_to_orig: list[int] = []
+    for idx, ch in enumerate(merged):
+        if ch.isspace():
+            continue
+        norm_chars.append(ch)
+        norm_to_orig.append(idx)
+    return "".join(norm_chars), norm_to_orig
+
+
+def _normalize_text(text: str) -> str:
+    """Whitespace-stripped form of a chunk body (every whitespace char removed).
+
+    Uses ``str.split()``'s whitespace definition, which matches ``str.isspace()``
+    used by :func:`_normalize_projection`, so both sides agree on what is stripped.
+    """
+    return "".join(text.split())
+
+
+def _covered_blockids(
+    spans: list[tuple[int, int, str]], o_start: int, o_end: int
+) -> list[str]:
+    """Blockids whose content span overlaps ``[o_start, o_end)``, in order, deduped."""
+    covered: list[str] = []
+    seen: set[str] = set()
+    for start, end, blockid in spans:
+        # Overlap test on half-open intervals; separators (gaps) match nothing.
+        if start < o_end and o_start < end and blockid and blockid not in seen:
+            seen.add(blockid)
+            covered.append(blockid)
+    return covered
+
+
+def _chunk_source_span(
+    chunk: dict[str, Any],
+    merged: str,
+) -> tuple[int, int] | None:
+    span = chunk.get("_source_span")
+    if not isinstance(span, dict):
+        return None
+    try:
+        start = int(span["start"])
+        end = int(span["end"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if start < 0 or end <= start or end > len(merged):
+        return None
+    body = chunk.get("content", "")
+    if not isinstance(body, str):
+        return None
+    source_text = merged[start:end]
+    if source_text != body and _normalize_text(source_text) != _normalize_text(body):
+        return None
+    return start, end
+
+
+def _within_single_block(
+    spans: list[tuple[int, int, str]], o_start: int, o_end: int
+) -> bool:
+    """True if ``[o_start, o_end)`` lies entirely within one block's content span.
+
+    A block's content is contiguous (no internal gaps), so an interval contained in a
+    single ``(start, end)`` touches exactly that block. An interval that straddles a
+    separator gap is contained in no span and returns ``False``.
+    """
+    for start, end, _ in spans:
+        if start <= o_start and o_end <= end:
+            return True
+        if start > o_start:
+            break  # spans are start-ordered; no later span can contain o_start
+    return False
+
+
+def _locate_chunk(
+    norm_merged: str,
+    nq: str,
+    prev_start: int,
+    prev_end: int,
+    norm_to_orig: list[int],
+    spans: list[tuple[int, int, str]],
+) -> int:
+    """Locate ``nq`` consistently with forward, contiguous chunking; -1 if absent.
+
+    F/R/V chunks cover the merged text in order. With token overlap each chunk shares
+    a prefix with the previous one but always adds new content *past* it, so its end
+    advances forward. Starts are not a reliable signal: stripping the whitespace a
+    window falls on can make two consecutive chunks share a start (e.g. a window whose
+    only non-whitespace content begins right after a separator the next window also
+    begins with). The chunk **end** is the dependable monotonic anchor, and we further
+    prefer matches that don't straddle a block boundary:
+
+    - Primary: the leftmost occurrence at/after ``prev_start`` that (a) ends past
+      ``prev_end`` and (b) lies entirely within a single block. Requiring forward
+      end-progress rejects a pure-suffix duplicate inside the previous chunk (no new
+      coverage); requiring single-block containment rejects a *cross-block artifact* —
+      a match that exists only because whitespace stripping glued the tail of one block
+      to the head of the next across a now-removed separator. Leftmost then resolves an
+      overlap chunk to its true position rather than a later duplicate.
+    - Cross-block fallback: if no single-block occurrence advances coverage, the
+      leftmost occurrence that merely ends past ``prev_end``. A chunk whose window
+      genuinely spanned blocks (its raw content held the separator) matches only here,
+      so real cross-block chunks still resolve.
+    - Tail fallback: when nothing extends coverage — a chunk clamped at the document
+      tail, or a window that reduced to a duplicate of the previous one — the leftmost
+      occurrence at/after ``prev_start`` (or -1 when the text is absent entirely).
+    """
+    length = len(nq)
+    first_advancing = -1
+    search = prev_start
+    while True:
+        p = norm_merged.find(nq, search)
+        if p == -1:
+            break
+        search = p + 1
+        if p + length <= prev_end:
+            continue  # does not extend coverage; skip suffix/duplicate matches
+        if first_advancing == -1:
+            first_advancing = p
+        o_start = norm_to_orig[p]
+        o_end = norm_to_orig[p + length - 1] + 1
+        if _within_single_block(spans, o_start, o_end):
+            return p
+    if first_advancing != -1:
+        return first_advancing  # genuine cross-block chunk (no single-block match)
+    return norm_merged.find(nq, prev_start)
+
+
+def backfill_chunk_sidecars(
+    chunking_result: list[dict[str, Any]],
+    blocks_path: str,
+    *,
+    require_source_span: bool = False,
+) -> None:
+    """Attach a ``sidecar`` to each chunk lacking one, in place.
+
+    No-op when ``blocks_path`` is empty/unreadable or carries no content rows.
+    Chunks that already have a valid sidecar (P / multimodal) and empty-content
+    chunks are skipped. ``_source_span`` is preferred when present. Raises
+    :class:`ChunkBlockMatchError` when a sidecar-less, non-empty chunk cannot be
+    located in the reconstructed merged text.
+    """
+    if not blocks_path:
+        return
+
+    try:
+        blocks = _load_content_blocks(blocks_path)
+    except OSError as exc:
+        logger.warning(
+            f"[sidecar-backfill] cannot read blocks.jsonl at {blocks_path}: {exc}; "
+            "skipping sidecar backfill"
+        )
+        return
+
+    merged, spans = _build_block_spans(blocks)
+    if not spans:
+        return
+
+    norm_merged, norm_to_orig = _normalize_projection(merged)
+
+    # Forward cursor over the normalized text. ``prev_start`` is the previous chunk's
+    # matched start; ``prev_end`` the furthest offset covered so far (monotonic, since
+    # each chunk's end advances). ``_locate_chunk`` anchors on end-progress to place
+    # each chunk consistently with contiguous, overlapping chunking — see its docstring.
+    prev_start = 0
+    prev_end = 0
+    for chunk in chunking_result:
+        if not isinstance(chunk, dict):
+            continue
+        if normalize_chunk_sidecar(chunk) is not None:
+            continue
+        body = chunk.get("content", "")
+        if not isinstance(body, str) or not body.strip():
+            continue
+
+        source_span = _chunk_source_span(chunk, merged)
+        if source_span is not None:
+            o_start, o_end = source_span
+            covered = _covered_blockids(spans, o_start, o_end)
+            if not covered:
+                raise ChunkBlockMatchError(
+                    chunk_order_index=int(chunk.get("chunk_order_index", -1)),
+                    chunk_preview=body,
+                    blocks_path=blocks_path,
+                )
+            chunk["sidecar"] = {
+                "type": "block",
+                "id": covered[0],
+                "refs": [{"type": "block", "id": bid} for bid in covered],
+            }
+            continue
+
+        if require_source_span:
+            raise ChunkBlockMatchError(
+                chunk_order_index=int(chunk.get("chunk_order_index", -1)),
+                chunk_preview=body,
+                blocks_path=blocks_path,
+            )
+
+        nq = _normalize_text(body)
+        if not nq:
+            continue
+
+        pos = _locate_chunk(norm_merged, nq, prev_start, prev_end, norm_to_orig, spans)
+        if pos == -1:
+            raise ChunkBlockMatchError(
+                chunk_order_index=int(chunk.get("chunk_order_index", -1)),
+                chunk_preview=body,
+                blocks_path=blocks_path,
+            )
+
+        norm_end = pos + len(nq)
+        o_start = norm_to_orig[pos]
+        # Map the last matched normalized char back, then extend one past it.
+        o_end = norm_to_orig[norm_end - 1] + 1
+        prev_start = pos
+        prev_end = max(prev_end, norm_end)
+
+        covered = _covered_blockids(spans, o_start, o_end)
+        if not covered:
+            # The match landed entirely on separator gaps — should not happen for
+            # non-empty normalized content, but guard rather than emit an empty ref.
+            raise ChunkBlockMatchError(
+                chunk_order_index=int(chunk.get("chunk_order_index", -1)),
+                chunk_preview=body,
+                blocks_path=blocks_path,
+            )
+
+        chunk["sidecar"] = {
+            "type": "block",
+            "id": covered[0],
+            "refs": [{"type": "block", "id": bid} for bid in covered],
+        }

--- a/lightrag/sidecar/backfill.py
+++ b/lightrag/sidecar/backfill.py
@@ -47,6 +47,26 @@ from lightrag.utils import logger
 # lightrag/sidecar/writer.py and lightrag/utils_pipeline.py.
 _BLOCK_SEPARATOR = "\n\n"
 
+# U+FFFD. The fixed-token chunker decodes arbitrary token windows; when a window
+# boundary splits a multi-byte UTF-8 character (4-byte supplementary-plane chars:
+# emoji, rare CJK extensions), the partial decode yields this replacement character
+# in *both* the span probe and the chunk's own content. Such a chunk is then
+# inherently unlocatable in the source — by span or by text — so provenance is
+# impossible for it. We degrade to no-sidecar for that single chunk rather than
+# failing the whole document.
+_REPLACEMENT_CHAR = "�"
+
+
+def _is_unlocatable(body: str) -> bool:
+    """True when a chunk's content cannot be located in the source by any means.
+
+    See :data:`_REPLACEMENT_CHAR`: a chunk whose decoded content carries U+FFFD lost
+    bytes at a multi-byte token boundary, so neither its span nor its text can be
+    matched against the verbatim ``blocks.jsonl`` content. Callers skip provenance for
+    such chunks instead of marking the document FAILED.
+    """
+    return _REPLACEMENT_CHAR in body
+
 
 def _load_content_blocks(blocks_path: str) -> list[tuple[str, str]]:
     """Read ``type == "content"`` rows from a blocks.jsonl file in order.
@@ -258,6 +278,12 @@ def backfill_chunk_sidecars(
     chunks are skipped. ``_source_span`` is preferred when present. Raises
     :class:`ChunkBlockMatchError` when a sidecar-less, non-empty chunk cannot be
     located in the reconstructed merged text.
+
+    Exception: a chunk whose content carries the Unicode replacement character
+    (:data:`_REPLACEMENT_CHAR`) is inherently unlocatable — a multi-byte UTF-8
+    character was split at a token-window boundary, corrupting both its span probe
+    and its own content. Such a chunk is skipped (no sidecar) instead of failing the
+    document, even under ``require_source_span``.
     """
     if not blocks_path:
         return
@@ -310,6 +336,13 @@ def backfill_chunk_sidecars(
             continue
 
         if require_source_span:
+            if _is_unlocatable(body):
+                logger.warning(
+                    f"[sidecar-backfill] chunk #{chunk.get('chunk_order_index', -1)} "
+                    "contains replacement characters from a multi-byte token-boundary "
+                    "split; skipping provenance for it"
+                )
+                continue
             raise ChunkBlockMatchError(
                 chunk_order_index=int(chunk.get("chunk_order_index", -1)),
                 chunk_preview=body,
@@ -322,6 +355,13 @@ def backfill_chunk_sidecars(
 
         pos = _locate_chunk(norm_merged, nq, prev_start, prev_end, norm_to_orig, spans)
         if pos == -1:
+            if _is_unlocatable(body):
+                logger.warning(
+                    f"[sidecar-backfill] chunk #{chunk.get('chunk_order_index', -1)} "
+                    "contains replacement characters from a multi-byte token-boundary "
+                    "split; skipping provenance for it"
+                )
+                continue
             raise ChunkBlockMatchError(
                 chunk_order_index=int(chunk.get("chunk_order_index", -1)),
                 chunk_preview=body,

--- a/lightrag/sidecar/backfill.py
+++ b/lightrag/sidecar/backfill.py
@@ -3,34 +3,38 @@
 The ``P`` (paragraph_semantic) strategy records a ``sidecar`` field on each chunk
 mapping it back to its source row(s) in the parse-time ``*.blocks.jsonl`` sidecar
 file. The ``F`` / ``R`` / ``V`` strategies chunk the merged document text without
-that provenance. When a document was parsed into the LightRAG sidecar format
-(``blocks.jsonl`` exists), :func:`backfill_chunk_sidecars` scans the blocks and
-attaches a ``sidecar`` to each chunk that lacks one.
+that provenance, but each chunk carries a private ``_source_span`` — the half-open
+``[start, end)`` char offsets of its content within the merged text the chunker
+received. When a document was parsed into the LightRAG sidecar format
+(``blocks.jsonl`` exists), :func:`backfill_chunk_sidecars` reconstructs that merged
+text, records each block's character span, and attaches a ``sidecar`` to each chunk
+by mapping its ``_source_span`` onto the block(s) it overlaps.
 
-Matching contract
------------------
-The merged text a chunker received is exactly reproducible from ``blocks.jsonl``:
-both :func:`lightrag.sidecar.writer.write_sidecar` and
+Span contract
+-------------
+The merged text is exactly reproducible from ``blocks.jsonl``: both
+:func:`lightrag.sidecar.writer.write_sidecar` and
 :func:`lightrag.utils_pipeline.load_lightrag_document_content` build it as
 ``"\\n\\n".join(raw_content for content rows where content.strip())``. We rebuild
-the same string here, record each block's character span, and locate each chunk's
-content within it.
+the same string here so a chunk's ``_source_span`` indexes directly into it.
 
-F decodes/strips token windows (verbatim substrings, with token overlap); R strips
-LangChain pieces (verbatim, possible overlap); V strips ``SemanticChunker`` pieces
-that rejoin sentences with a single space — so newlines collapse to spaces *and* a
-space may be inserted between sentences that were originally adjacent with no
-whitespace, making the text *not* byte-verbatim. To cover all three uniformly,
-matching runs over a **whitespace-stripped** projection of both sides (every
-whitespace char removed, not merely collapsed to a single space). Because whitespace
-removal is monotonic, a chunk's non-whitespace characters are always a contiguous
-substring of the merged text's non-whitespace characters — regardless of how either
-side spaced them — so V's reflowing can never spuriously fail a match.
+F/R emit byte-verbatim spans (the span text equals the chunk content). V's
+``SemanticChunker`` rejoins sentences with a single space, so a V chunk's content
+may differ from its span text by whitespace alone; span validation therefore accepts
+either a byte-exact match or a **whitespace-stripped** match (every whitespace char
+removed, not merely collapsed to a single space). A span whose text matches the
+chunk under neither test is treated as absent.
+
+A chunk that reaches this stage without a usable ``_source_span`` is a hard error:
+the document is marked FAILED via :class:`ChunkBlockMatchError`. The sole exception
+is a chunk whose decoded content carries the Unicode replacement character
+(:data:`_REPLACEMENT_CHAR`) — a multi-byte UTF-8 char split at a token-window
+boundary corrupts both its span probe and its own content, making provenance
+impossible; such a chunk degrades to no-sidecar rather than failing the document.
 
 Multimodal placeholder tags (``<table …>…</table>``, ``<drawing …/>``,
-``<equation …>…</equation>``) appear identically in block content and chunk content,
-so they project identically under whitespace stripping and match — markup is never
-stripped before matching.
+``<equation …>…</equation>``) appear verbatim in both block content and chunk
+content, so a span covering them maps to the right block(s) unchanged.
 """
 
 from __future__ import annotations
@@ -128,31 +132,15 @@ def _build_block_spans(
     return _BLOCK_SEPARATOR.join(parts), spans
 
 
-def _normalize_projection(merged: str) -> tuple[str, list[int]]:
-    """Drop every whitespace char; map each kept char back to its merged offset.
-
-    Returns ``(norm_text, norm_to_orig)`` where ``norm_to_orig[i]`` is the offset
-    in ``merged`` of the ``i``-th surviving (non-whitespace) character. Removing all
-    whitespace — rather than collapsing runs to a single space — keeps the two sides
-    aligned even when V inserts a space between originally-adjacent sentences. Because
-    whitespace removal is monotonic, any contiguous region of ``merged`` projects to a
-    contiguous substring of ``norm_text``, so chunk lookups stay exact.
-    """
-    norm_chars: list[str] = []
-    norm_to_orig: list[int] = []
-    for idx, ch in enumerate(merged):
-        if ch.isspace():
-            continue
-        norm_chars.append(ch)
-        norm_to_orig.append(idx)
-    return "".join(norm_chars), norm_to_orig
-
-
 def _normalize_text(text: str) -> str:
-    """Whitespace-stripped form of a chunk body (every whitespace char removed).
+    """Whitespace-stripped form of a string (every whitespace char removed).
 
-    Uses ``str.split()``'s whitespace definition, which matches ``str.isspace()``
-    used by :func:`_normalize_projection`, so both sides agree on what is stripped.
+    Used by :func:`_chunk_source_span` to validate a span whose text differs from the
+    chunk content by whitespace only — V's ``SemanticChunker`` rejoins sentences with
+    a single space, so its chunk content is not byte-verbatim against the source span.
+    Removing all whitespace (rather than collapsing runs to a single space) keeps the
+    two sides aligned even when V inserts a space between originally-adjacent
+    sentences.
     """
     return "".join(text.split())
 
@@ -194,96 +182,24 @@ def _chunk_source_span(
     return start, end
 
 
-def _within_single_block(
-    spans: list[tuple[int, int, str]], o_start: int, o_end: int
-) -> bool:
-    """True if ``[o_start, o_end)`` lies entirely within one block's content span.
-
-    A block's content is contiguous (no internal gaps), so an interval contained in a
-    single ``(start, end)`` touches exactly that block. An interval that straddles a
-    separator gap is contained in no span and returns ``False``.
-    """
-    for start, end, _ in spans:
-        if start <= o_start and o_end <= end:
-            return True
-        if start > o_start:
-            break  # spans are start-ordered; no later span can contain o_start
-    return False
-
-
-def _locate_chunk(
-    norm_merged: str,
-    nq: str,
-    prev_start: int,
-    prev_end: int,
-    norm_to_orig: list[int],
-    spans: list[tuple[int, int, str]],
-) -> int:
-    """Locate ``nq`` consistently with forward, contiguous chunking; -1 if absent.
-
-    F/R/V chunks cover the merged text in order. With token overlap each chunk shares
-    a prefix with the previous one but always adds new content *past* it, so its end
-    advances forward. Starts are not a reliable signal: stripping the whitespace a
-    window falls on can make two consecutive chunks share a start (e.g. a window whose
-    only non-whitespace content begins right after a separator the next window also
-    begins with). The chunk **end** is the dependable monotonic anchor, and we further
-    prefer matches that don't straddle a block boundary:
-
-    - Primary: the leftmost occurrence at/after ``prev_start`` that (a) ends past
-      ``prev_end`` and (b) lies entirely within a single block. Requiring forward
-      end-progress rejects a pure-suffix duplicate inside the previous chunk (no new
-      coverage); requiring single-block containment rejects a *cross-block artifact* —
-      a match that exists only because whitespace stripping glued the tail of one block
-      to the head of the next across a now-removed separator. Leftmost then resolves an
-      overlap chunk to its true position rather than a later duplicate.
-    - Cross-block fallback: if no single-block occurrence advances coverage, the
-      leftmost occurrence that merely ends past ``prev_end``. A chunk whose window
-      genuinely spanned blocks (its raw content held the separator) matches only here,
-      so real cross-block chunks still resolve.
-    - Tail fallback: when nothing extends coverage — a chunk clamped at the document
-      tail, or a window that reduced to a duplicate of the previous one — the leftmost
-      occurrence at/after ``prev_start`` (or -1 when the text is absent entirely).
-    """
-    length = len(nq)
-    first_advancing = -1
-    search = prev_start
-    while True:
-        p = norm_merged.find(nq, search)
-        if p == -1:
-            break
-        search = p + 1
-        if p + length <= prev_end:
-            continue  # does not extend coverage; skip suffix/duplicate matches
-        if first_advancing == -1:
-            first_advancing = p
-        o_start = norm_to_orig[p]
-        o_end = norm_to_orig[p + length - 1] + 1
-        if _within_single_block(spans, o_start, o_end):
-            return p
-    if first_advancing != -1:
-        return first_advancing  # genuine cross-block chunk (no single-block match)
-    return norm_merged.find(nq, prev_start)
-
-
 def backfill_chunk_sidecars(
     chunking_result: list[dict[str, Any]],
     blocks_path: str,
-    *,
-    require_source_span: bool = False,
 ) -> None:
-    """Attach a ``sidecar`` to each chunk lacking one, in place.
+    """Attach a ``sidecar`` to each F/R/V chunk via its ``_source_span``, in place.
 
     No-op when ``blocks_path`` is empty/unreadable or carries no content rows.
     Chunks that already have a valid sidecar (P / multimodal) and empty-content
-    chunks are skipped. ``_source_span`` is preferred when present. Raises
-    :class:`ChunkBlockMatchError` when a sidecar-less, non-empty chunk cannot be
-    located in the reconstructed merged text.
+    chunks are skipped. Every remaining chunk must carry a ``_source_span`` that
+    resolves to its content in the reconstructed merged text and overlaps at least
+    one block; one that does not raises :class:`ChunkBlockMatchError`, marking the
+    document FAILED.
 
     Exception: a chunk whose content carries the Unicode replacement character
     (:data:`_REPLACEMENT_CHAR`) is inherently unlocatable — a multi-byte UTF-8
     character was split at a token-window boundary, corrupting both its span probe
     and its own content. Such a chunk is skipped (no sidecar) instead of failing the
-    document, even under ``require_source_span``.
+    document.
     """
     if not blocks_path:
         return
@@ -301,14 +217,6 @@ def backfill_chunk_sidecars(
     if not spans:
         return
 
-    norm_merged, norm_to_orig = _normalize_projection(merged)
-
-    # Forward cursor over the normalized text. ``prev_start`` is the previous chunk's
-    # matched start; ``prev_end`` the furthest offset covered so far (monotonic, since
-    # each chunk's end advances). ``_locate_chunk`` anchors on end-progress to place
-    # each chunk consistently with contiguous, overlapping chunking — see its docstring.
-    prev_start = 0
-    prev_end = 0
     for chunk in chunking_result:
         if not isinstance(chunk, dict):
             continue
@@ -319,23 +227,11 @@ def backfill_chunk_sidecars(
             continue
 
         source_span = _chunk_source_span(chunk, merged)
-        if source_span is not None:
-            o_start, o_end = source_span
-            covered = _covered_blockids(spans, o_start, o_end)
-            if not covered:
-                raise ChunkBlockMatchError(
-                    chunk_order_index=int(chunk.get("chunk_order_index", -1)),
-                    chunk_preview=body,
-                    blocks_path=blocks_path,
-                )
-            chunk["sidecar"] = {
-                "type": "block",
-                "id": covered[0],
-                "refs": [{"type": "block", "id": bid} for bid in covered],
-            }
-            continue
-
-        if require_source_span:
+        if source_span is None:
+            # No usable span: provenance is impossible. Degrade silently only for the
+            # inherently-unlocatable replacement-char case; otherwise FAIL the document
+            # rather than guess (the old text-matching fallback could not disambiguate
+            # a genuine cross-block match from a whitespace-glue artifact).
             if _is_unlocatable(body):
                 logger.warning(
                     f"[sidecar-backfill] chunk #{chunk.get('chunk_order_index', -1)} "
@@ -349,36 +245,11 @@ def backfill_chunk_sidecars(
                 blocks_path=blocks_path,
             )
 
-        nq = _normalize_text(body)
-        if not nq:
-            continue
-
-        pos = _locate_chunk(norm_merged, nq, prev_start, prev_end, norm_to_orig, spans)
-        if pos == -1:
-            if _is_unlocatable(body):
-                logger.warning(
-                    f"[sidecar-backfill] chunk #{chunk.get('chunk_order_index', -1)} "
-                    "contains replacement characters from a multi-byte token-boundary "
-                    "split; skipping provenance for it"
-                )
-                continue
-            raise ChunkBlockMatchError(
-                chunk_order_index=int(chunk.get("chunk_order_index", -1)),
-                chunk_preview=body,
-                blocks_path=blocks_path,
-            )
-
-        norm_end = pos + len(nq)
-        o_start = norm_to_orig[pos]
-        # Map the last matched normalized char back, then extend one past it.
-        o_end = norm_to_orig[norm_end - 1] + 1
-        prev_start = pos
-        prev_end = max(prev_end, norm_end)
-
+        o_start, o_end = source_span
         covered = _covered_blockids(spans, o_start, o_end)
         if not covered:
-            # The match landed entirely on separator gaps — should not happen for
-            # non-empty normalized content, but guard rather than emit an empty ref.
+            # The span landed entirely on separator gaps — should not happen for
+            # non-empty content, but guard rather than emit an empty ref.
             raise ChunkBlockMatchError(
                 chunk_order_index=int(chunk.get("chunk_order_index", -1)),
                 chunk_preview=body,

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -1846,6 +1846,34 @@ def split_text_by_token_limit(
     return [x for x in out if x.strip()]
 
 
+def _child_source_span(
+    parent_content: str,
+    parent_span: Any,
+    piece: str,
+    search_from: int,
+) -> tuple[dict[str, int] | None, int]:
+    if not isinstance(parent_span, dict):
+        return None, search_from
+    try:
+        parent_start = int(parent_span["start"])
+        parent_end = int(parent_span["end"])
+    except (KeyError, TypeError, ValueError):
+        return None, search_from
+    if parent_start < 0 or parent_end < parent_start:
+        return None, search_from
+
+    local_start = parent_content.find(piece, max(0, search_from))
+    if local_start < 0:
+        return None, search_from
+    local_end = local_start + len(piece)
+    if parent_start + local_end > parent_end:
+        return None, search_from
+    return (
+        {"start": parent_start + local_start, "end": parent_start + local_end},
+        local_end,
+    )
+
+
 def enforce_chunk_token_limit_before_embedding(
     chunking_result: list[dict[str, Any]] | tuple[dict[str, Any], ...],
     tokenizer: Tokenizer,
@@ -1886,6 +1914,8 @@ def enforce_chunk_token_limit_before_embedding(
             continue
 
         base_chunk_id = dp.get("chunk_id")
+        parent_span = dp.get("_source_span")
+        span_search_from = 0
         total_parts = len(pieces)
         for i, piece in enumerate(pieces, 1):
             new_dp = dict(dp)
@@ -1900,6 +1930,14 @@ def enforce_chunk_token_limit_before_embedding(
             # /chunk_id) is rewritten per split slice.
             if isinstance(base_chunk_id, str) and base_chunk_id.strip():
                 new_dp["chunk_id"] = f"{base_chunk_id}-s{i:02d}"
+
+            child_span, span_search_from = _child_source_span(
+                content, parent_span, piece, span_search_from
+            )
+            if child_span is not None:
+                new_dp["_source_span"] = child_span
+            elif "_source_span" in new_dp:
+                new_dp.pop("_source_span", None)
 
             new_dp["split_type"] = "hard_fallback"
             new_dp["split_part"] = i

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -1897,8 +1897,8 @@ def _child_source_span(
     separated those sentences with a single space/newline. In that case we fall
     back to a whitespace-stripped match (the same projection sidecar backfill uses),
     which stays exact because whitespace removal is monotonic. Without this fallback
-    the child would lose its span and ``require_source_span`` backfill would wrongly
-    FAIL the document.
+    the child would lose its span and sidecar backfill would wrongly FAIL the
+    document.
 
     Returns ``(span | None, next_search_from)`` where ``next_search_from`` is a
     ``parent_content`` offset threaded forward by the caller so repeated pieces

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4,6 +4,7 @@ import weakref
 import sys
 
 import asyncio
+import bisect
 import html
 import csv
 import inspect
@@ -1846,12 +1847,63 @@ def split_text_by_token_limit(
     return [x for x in out if x.strip()]
 
 
+def _normalized_child_offsets(
+    parent_content: str,
+    piece: str,
+    search_from: int,
+) -> tuple[int, int] | None:
+    """Locate ``piece`` in ``parent_content`` ignoring all whitespace.
+
+    Returns ``(start, end)`` char offsets into ``parent_content`` for the first
+    whitespace-stripped occurrence at/after ``search_from``, or ``None`` if absent.
+    Removing every whitespace char (not collapsing runs) keeps the match exact even
+    when the two sides space the same characters differently — the same monotonic
+    projection :mod:`lightrag.sidecar.backfill` uses.
+    """
+    norm_piece = "".join(piece.split())
+    if not norm_piece:
+        return None
+    norm_chars: list[str] = []
+    norm_to_orig: list[int] = []
+    for idx, ch in enumerate(parent_content):
+        if ch.isspace():
+            continue
+        norm_chars.append(ch)
+        norm_to_orig.append(idx)
+    norm_parent = "".join(norm_chars)
+    # First normalized index whose source offset is >= search_from (norm_to_orig is
+    # strictly increasing), so repeated pieces resolve forward in order.
+    norm_start = bisect.bisect_left(norm_to_orig, search_from)
+    pos = norm_parent.find(norm_piece, norm_start)
+    if pos < 0:
+        return None
+    o_start = norm_to_orig[pos]
+    o_end = norm_to_orig[pos + len(norm_piece) - 1] + 1
+    return o_start, o_end
+
+
 def _child_source_span(
     parent_content: str,
     parent_span: Any,
     piece: str,
     search_from: int,
 ) -> tuple[dict[str, int] | None, int]:
+    """Locate a hard-split child ``piece`` inside its parent's source span.
+
+    Pieces are usually verbatim substrings of ``parent_content`` (token-window
+    slices), so an exact forward ``find`` resolves them precisely. But
+    :func:`split_text_by_token_limit` rejoins multiple sentence units with
+    ``"\\n\\n"``, so a multi-unit piece is *not* byte-verbatim when the source
+    separated those sentences with a single space/newline. In that case we fall
+    back to a whitespace-stripped match (the same projection sidecar backfill uses),
+    which stays exact because whitespace removal is monotonic. Without this fallback
+    the child would lose its span and ``require_source_span`` backfill would wrongly
+    FAIL the document.
+
+    Returns ``(span | None, next_search_from)`` where ``next_search_from`` is a
+    ``parent_content`` offset threaded forward by the caller so repeated pieces
+    resolve in order.
+    """
     if not isinstance(parent_span, dict):
         return None, search_from
     try:
@@ -1862,10 +1914,19 @@ def _child_source_span(
     if parent_start < 0 or parent_end < parent_start:
         return None, search_from
 
-    local_start = parent_content.find(piece, max(0, search_from))
-    if local_start < 0:
-        return None, search_from
-    local_end = local_start + len(piece)
+    search_from = max(0, search_from)
+
+    # Exact: verbatim token-window pieces.
+    local_start = parent_content.find(piece, search_from)
+    if local_start >= 0:
+        local_end = local_start + len(piece)
+    else:
+        # Whitespace-normalized fallback: multi-unit pieces rejoined with "\n\n".
+        offsets = _normalized_child_offsets(parent_content, piece, search_from)
+        if offsets is None:
+            return None, search_from
+        local_start, local_end = offsets
+
     if parent_start + local_end > parent_end:
         return None, search_from
     return (

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -86,8 +86,9 @@ def build_chunks_dict_from_chunking_result(
                 if key and key not in seen:
                     seen.add(key)
                     seed_cache_list.append(key)
+        stored_chunk = {k: v for k, v in dp.items() if k != "_source_span"}
         chunks[chunk_key] = {
-            **dp,
+            **stored_chunk,
             "full_doc_id": doc_id,
             "file_path": file_path,
             "llm_cache_list": seed_cache_list,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ api = [
     "defusedxml>=0.7.0,<1.0.0",    # Safer XML parser used by parser/docx
     # Chunking strategies (process_options=R / V); lazy-imported by lightrag.chunker
     "langchain-text-splitters>=0.3,<2",
-    "langchain-experimental>=0.3,<1",
+    "langchain-experimental>=0.3.2,<1",  # >=0.3.2: SemanticChunker gained min_chunk_size
 ]
 
 # Offline deployment dependencies (layered design for flexibility)

--- a/tests/chunker/test_chunker_recursive_character.py
+++ b/tests/chunker/test_chunker_recursive_character.py
@@ -108,3 +108,59 @@ def test_recursive_chunks_carry_exact_source_spans_with_overlap():
     for chunk in chunks:
         span = chunk["_source_span"]
         assert body[span["start"] : span["end"]] == chunk["content"]
+
+
+@pytest.mark.offline
+def test_long_unique_text_keeps_every_source_span():
+    """Every chunk of a long, non-repeating document must carry a span.
+
+    Regression for the LangChain ``add_start_index`` unit mismatch: with a
+    token-based length function its search cursor overshot each chunk's true
+    start, dropping ``_source_span`` (and failing ``require_source_span``
+    backfill) on roughly half of a unique document's chunks.
+    """
+    body = " ".join(f"word{i}" for i in range(800))
+    chunks = chunking_by_recursive_character(
+        _tok(),
+        body,
+        chunk_token_size=50,
+        chunk_overlap_token_size=10,
+    )
+
+    assert len(chunks) > 5
+    for chunk in chunks:
+        span = chunk["_source_span"]
+        assert body[span["start"] : span["end"]] == chunk["content"]
+
+
+@pytest.mark.offline
+def test_repeated_text_spans_tile_whole_document():
+    """Spans over heavily repeated text must tile the document, not cluster.
+
+    Regression for the repeated-content ambiguity: a naive forward ``find``
+    matches every identical overlapping chunk to the nearest repetition, so all
+    spans collapse into the document head and the tail gets no provenance. The
+    geometry-anchored locator must instead advance spans across the whole text.
+    """
+    unit = "ABCDE fghij. "
+    body = unit * 60
+    chunks = chunking_by_recursive_character(
+        _tok(),
+        body,
+        chunk_token_size=40,
+        chunk_overlap_token_size=10,
+    )
+
+    spans = [c["_source_span"] for c in chunks]
+    assert len(spans) == len(chunks)  # no chunk lost its span
+
+    # Each span is exact and starts are monotonically non-decreasing.
+    for chunk, span in zip(chunks, spans):
+        assert body[span["start"] : span["end"]] == chunk["content"]
+    starts = [s["start"] for s in spans]
+    assert starts == sorted(starts)
+
+    # Spans reach the document tail rather than clustering at the head. Under
+    # the old nearest-repetition behaviour the furthest end stalled near the
+    # first few hundred chars; tiling reaches within one ``unit`` of the end.
+    assert max(s["end"] for s in spans) >= len(body) - len(unit)

--- a/tests/chunker/test_chunker_recursive_character.py
+++ b/tests/chunker/test_chunker_recursive_character.py
@@ -118,8 +118,8 @@ def test_long_unique_text_keeps_every_source_span():
 
     Regression for the LangChain ``add_start_index`` unit mismatch: with a
     token-based length function its search cursor overshot each chunk's true
-    start, dropping ``_source_span`` (and failing ``require_source_span``
-    backfill) on roughly half of a unique document's chunks.
+    start, dropping ``_source_span`` (and failing span-first backfill) on
+    roughly half of a unique document's chunks.
     """
     body = " ".join(f"word{i}" for i in range(800))
     chunks = chunking_by_recursive_character(

--- a/tests/chunker/test_chunker_recursive_character.py
+++ b/tests/chunker/test_chunker_recursive_character.py
@@ -3,8 +3,10 @@
 import pytest
 
 pytest.importorskip("langchain_text_splitters")
+from langchain_text_splitters import RecursiveCharacterTextSplitter  # noqa: E402
 
 from lightrag.chunker import chunking_by_recursive_character  # noqa: E402
+from lightrag.chunker.recursive_character import _split_text_with_spans  # noqa: E402
 from lightrag.utils import Tokenizer, TokenizerInterface  # noqa: E402
 
 
@@ -140,7 +142,7 @@ def test_repeated_text_spans_tile_whole_document():
     Regression for the repeated-content ambiguity: a naive forward ``find``
     matches every identical overlapping chunk to the nearest repetition, so all
     spans collapse into the document head and the tail gets no provenance. The
-    geometry-anchored locator must instead advance spans across the whole text.
+    offset-aware splitter mirror must instead advance spans across the whole text.
     """
     unit = "ABCDE fghij. "
     body = unit * 60
@@ -164,3 +166,89 @@ def test_repeated_text_spans_tile_whole_document():
     # the old nearest-repetition behaviour the furthest end stalled near the
     # first few hundred chars; tiling reaches within one ``unit`` of the end.
     assert max(s["end"] for s in spans) >= len(body) - len(unit)
+
+
+@pytest.mark.offline
+def test_span_mirror_matches_langchain_split_text():
+    """Drift guard for the offset-aware mirror of LangChain's splitter."""
+    body = (
+        "Alpha repeats.\n\n"
+        "ff hh aa hh ee\n"
+        "ff hh aa hh ee\n\n"
+        "Tail repeats. Tail repeats. Tail repeats."
+    )
+    tok = _tok()
+
+    def length_function(text: str) -> int:
+        return len(tok.encode(text))
+
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=36,
+        chunk_overlap=14,
+        length_function=length_function,
+        strip_whitespace=True,
+    )
+
+    mirrored = _split_text_with_spans(
+        body,
+        base_offset=0,
+        separators=splitter._separators,
+        chunk_size=splitter._chunk_size,
+        chunk_overlap=splitter._chunk_overlap,
+        length_function=length_function,
+        keep_separator=splitter._keep_separator,
+        is_separator_regex=splitter._is_separator_regex,
+        strip_whitespace=splitter._strip_whitespace,
+    )
+
+    assert [piece for piece, _, _ in mirrored] == splitter.split_text(body)
+    for piece, start, end in mirrored:
+        assert body[start:end] == piece
+
+
+@pytest.mark.offline
+def test_chunk_repeating_an_earlier_block_maps_to_its_own_block():
+    """A chunk whose text also appears in an earlier, different block must map
+    to *its own* occurrence, not the earlier copy.
+
+    Regression for cross-block duplicate provenance: merged text ``"ff aa\\n\\naa"``
+    splits into ``["ff aa", "aa"]``. The second chunk ``"aa"`` is block 2, so its
+    span must point at the *second* ``"aa"`` (offset 7), not the ``"aa"`` inside
+    ``"ff aa"`` (offset 3). The earlier locator anchored on a predicted offset
+    and snapped to the nearest copy, silently emitting the wrong — but
+    legal-looking — span that strict backfill would trust.
+    """
+    merged = "ff aa\n\naa"
+    chunks = chunking_by_recursive_character(
+        _tok(),
+        merged,
+        chunk_token_size=5,
+        chunk_overlap_token_size=1,
+    )
+
+    assert [c["content"] for c in chunks] == ["ff aa", "aa"]
+    assert chunks[0]["_source_span"] == {"start": 0, "end": 5}
+    # The second "aa" lives in block 2 at offset 7, after the "\n\n" separator —
+    # not the "aa" embedded in "ff aa" at offset 3.
+    assert chunks[1]["_source_span"] == {"start": 7, "end": 9}
+    assert merged[7:9] == "aa"
+
+
+@pytest.mark.offline
+def test_repeated_block_window_does_not_shift_to_previous_duplicate():
+    """A repeated multi-block chunk must not slide back into the prior duplicate."""
+    block = "ff hh aa hh ee"
+    merged = "\n\n".join([block] * 4)
+    chunks = chunking_by_recursive_character(
+        _tok(),
+        merged,
+        chunk_token_size=36,
+        chunk_overlap_token_size=14,
+    )
+
+    assert [c["content"] for c in chunks] == [
+        f"{block}\n\n{block}",
+        f"{block}\n\n{block}",
+    ]
+    assert chunks[0]["_source_span"] == {"start": 0, "end": 30}
+    assert chunks[1]["_source_span"] == {"start": 32, "end": 62}

--- a/tests/chunker/test_chunker_recursive_character.py
+++ b/tests/chunker/test_chunker_recursive_character.py
@@ -35,6 +35,7 @@ def test_short_input_single_chunk():
 
     assert len(chunks) == 1
     assert chunks[0]["content"] == body
+    assert chunks[0]["_source_span"] == {"start": 0, "end": len(body)}
     assert chunks[0]["chunk_order_index"] == 0
     assert chunks[0]["tokens"] == len(body)
 
@@ -91,3 +92,19 @@ def test_custom_separators_are_honored():
     # Every chunk fits the cap.
     for c in chunks:
         assert c["tokens"] <= 10
+
+
+@pytest.mark.offline
+def test_recursive_chunks_carry_exact_source_spans_with_overlap():
+    body = "Alpha section.\n\nBeta section.\n\nGamma section."
+    chunks = chunking_by_recursive_character(
+        _tok(),
+        body,
+        chunk_token_size=22,
+        chunk_overlap_token_size=6,
+    )
+
+    assert len(chunks) >= 2
+    for chunk in chunks:
+        span = chunk["_source_span"]
+        assert body[span["start"] : span["end"]] == chunk["content"]

--- a/tests/chunker/test_chunker_semantic_vector.py
+++ b/tests/chunker/test_chunker_semantic_vector.py
@@ -75,6 +75,9 @@ def test_v_chunker_runs_with_stub_embedding():
     assert [c["chunk_order_index"] for c in chunks] == list(range(len(chunks)))
     # No empty content rows.
     assert all(c["content"].strip() for c in chunks)
+    for chunk in chunks:
+        span = chunk["_source_span"]
+        assert body[span["start"] : span["end"]] == chunk["content"]
 
 
 class _ListHandler(logging.Handler):
@@ -125,3 +128,50 @@ def test_v_chunker_empty_input_returns_empty_list():
         return await chunking_by_semantic_vector(_tok(), "")
 
     assert asyncio.run(_run()) == []
+
+
+@pytest.mark.offline
+def test_v_chunker_spans_repeated_sentences_and_number_of_chunks():
+    body = (
+        "Repeat sentence.\n"
+        "Repeat sentence. "
+        "A distant topic appears. "
+        "Another distant topic appears."
+    )
+
+    async def _run():
+        return await chunking_by_semantic_vector(
+            _tok(),
+            body,
+            chunk_token_size=400,
+            embedding_func=_make_deterministic_embedding(),
+            number_of_chunks=2,
+        )
+
+    chunks = asyncio.run(_run())
+
+    assert chunks
+    for chunk in chunks:
+        span = chunk["_source_span"]
+        assert body[span["start"] : span["end"]] == chunk["content"]
+
+
+@pytest.mark.offline
+def test_v_oversized_group_resplit_preserves_child_source_spans():
+    body = " ".join(f"word{i:02d}" for i in range(30)) + "."
+
+    async def _run():
+        return await chunking_by_semantic_vector(
+            _tok(),
+            body,
+            chunk_token_size=35,
+            embedding_func=_make_deterministic_embedding(),
+        )
+
+    chunks = asyncio.run(_run())
+
+    assert len(chunks) > 1
+    for chunk in chunks:
+        span = chunk["_source_span"]
+        assert body[span["start"] : span["end"]] == chunk["content"]
+        assert chunk["tokens"] <= 35

--- a/tests/chunker/test_chunker_semantic_vector.py
+++ b/tests/chunker/test_chunker_semantic_vector.py
@@ -175,3 +175,58 @@ def test_v_oversized_group_resplit_preserves_child_source_spans():
         span = chunk["_source_span"]
         assert body[span["start"] : span["end"]] == chunk["content"]
         assert chunk["tokens"] <= 35
+
+
+@pytest.mark.offline
+def test_semantic_groups_mirror_matches_upstream_split_text():
+    """Drift guard: ``_semantic_groups_with_spans`` re-implements the private body
+    of ``SemanticChunker.split_text`` to keep verbatim source spans. If an upstream
+    langchain-experimental release changes that grouping (or a private member it
+    relies on), this catches it — the mirror must yield the same group count and the
+    same content modulo whitespace (it keeps the verbatim slice; upstream reflows
+    sentences with single spaces)."""
+    from langchain_core.embeddings import Embeddings
+    from langchain_experimental.text_splitter import SemanticChunker
+
+    from lightrag.chunker.semantic_vector import _semantic_groups_with_spans
+    from lightrag.constants import DEFAULT_SENTENCE_SPLIT_REGEX
+
+    class _SyncEmbeddings(Embeddings):
+        """Deterministic per-text vectors, mirroring _make_deterministic_embedding
+        but synchronous so SemanticChunker can be driven directly."""
+
+        def embed_documents(self, texts):
+            rows = []
+            for text in texts:
+                seed = abs(hash(text)) % (2**32)
+                rng = np.random.default_rng(seed=seed)
+                vec = rng.normal(size=8).astype(np.float64)
+                vec /= np.linalg.norm(vec) or 1.0
+                rows.append(vec.tolist())
+            return rows
+
+        def embed_query(self, text):
+            return self.embed_documents([text])[0]
+
+    text = (
+        "Quantum mechanics describes nature at small scales. "
+        "It contradicts classical intuition. "
+        "Bread is baked from flour. "
+        "Sourdough requires a long fermentation."
+    )
+    splitter = SemanticChunker(
+        _SyncEmbeddings(),
+        buffer_size=1,
+        breakpoint_threshold_type="percentile",
+        sentence_split_regex=DEFAULT_SENTENCE_SPLIT_REGEX,
+    )
+
+    # Same process → identical deterministic embeddings on both calls → identical
+    # distances/breakpoints, so any divergence is a real grouping drift.
+    upstream = splitter.split_text(text)
+    mirror = _semantic_groups_with_spans(splitter, text)
+
+    assert len(mirror) == len(upstream)
+    for (grp_text, start, end), up in zip(mirror, upstream):
+        assert grp_text == text[start:end]  # mirror keeps the verbatim source slice
+        assert "".join(grp_text.split()) == "".join(up.split())

--- a/tests/chunker/test_sidecar_backfill_integration.py
+++ b/tests/chunker/test_sidecar_backfill_integration.py
@@ -282,6 +282,45 @@ def test_real_tiktoken_token_windows_match_verbatim(tmp_path: Path) -> None:
 
 
 @pytest.mark.offline
+def test_real_tiktoken_multibyte_boundary_degrades_not_fails(tmp_path: Path) -> None:
+    # Regression: tiktoken is byte-level, so a 4-byte UTF-8 char (emoji / rare CJK
+    # extension) can have its bytes split across a token-window boundary. Decoding the
+    # partial window yields U+FFFD in BOTH the chunk content and its span probe, so the
+    # chunk is unlocatable by span or by text. With require_source_span this previously
+    # FAILED the entire document; it must now skip provenance for the corrupt chunks
+    # while still attributing the clean ones.
+    pytest.importorskip("tiktoken")
+    from lightrag.utils import TiktokenTokenizer
+
+    tok = TiktokenTokenizer()
+    # Emoji are supplementary-plane (4-byte) chars that force byte-fallback tokens.
+    block = "Status update 🎉🚀 progress 😀😁😂 and more text 🔥💡✅ keep going. " * 20
+    blocks_path, merged = _write_blocks(tmp_path, [("b1", block)])
+
+    chunks = chunking_by_fixed_token(
+        tok,
+        merged,
+        chunk_token_size=18,
+        chunk_overlap_token_size=4,
+        _emit_source_span=True,
+    )
+    # The window splits at least one emoji -> some chunks carry U+FFFD and lack a span.
+    assert any("�" in c["content"] for c in chunks)
+    assert any("_source_span" not in c for c in chunks)
+
+    # Must NOT raise: corrupt chunks are skipped, the rest are attributed.
+    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+
+    for ch in chunks:
+        if "�" in ch["content"]:
+            assert "sidecar" not in ch  # provenance degraded, document not failed
+        elif ch["content"].strip():  # empty tail chunks are skipped entirely
+            assert ch["sidecar"]["refs"] == [{"type": "block", "id": "b1"}]
+    # At least the clean chunks resolved into the single source block.
+    assert any("sidecar" in ch for ch in chunks)
+
+
+@pytest.mark.offline
 def test_backfilled_sidecar_persists_into_chunks_dict(tmp_path: Path) -> None:
     blocks_path, merged = _write_blocks(
         tmp_path, [("b1", "Alpha body."), ("b2", "Beta body.")]

--- a/tests/chunker/test_sidecar_backfill_integration.py
+++ b/tests/chunker/test_sidecar_backfill_integration.py
@@ -83,7 +83,7 @@ def test_real_overlap_tail_chunk_maps_to_next_block(tmp_path: Path) -> None:
     )
     assert [c["content"] for c in chunks] == ["aa", "a", "a"]
 
-    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+    backfill_chunk_sidecars(chunks, blocks_path)
 
     assert [r["id"] for r in chunks[0]["sidecar"]["refs"]] == ["b1"]
     assert [r["id"] for r in chunks[1]["sidecar"]["refs"]] == ["b2"]
@@ -111,7 +111,7 @@ def test_real_overlap_on_stripped_separator_does_not_strand_chunks(
     )
     assert [c["content"] for c in chunks] == ["a", "", "a", "ab", "ba", "ab", "b"]
 
-    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+    backfill_chunk_sidecars(chunks, blocks_path)
 
     assert [r["id"] for r in chunks[0]["sidecar"]["refs"]] == ["b1"]
     # The empty chunk is skipped (no sidecar); all remaining chunks belong to b2.
@@ -140,7 +140,7 @@ def test_real_identical_adjacent_blocks_no_cross_block_artifact(
     )
     assert [c["content"] for c in chunks] == ["aa", "", "aa"]
 
-    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+    backfill_chunk_sidecars(chunks, blocks_path)
 
     assert chunks[0]["_source_span"] == {"start": 0, "end": 2}
     assert chunks[2]["_source_span"] == {"start": 4, "end": 6}
@@ -165,7 +165,7 @@ def test_real_fixed_token_chunks_get_full_coverage(tmp_path: Path) -> None:
     )
     assert len(chunks) >= 2  # multiple blocks per chunk at this size
 
-    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+    backfill_chunk_sidecars(chunks, blocks_path)
 
     # Every chunk is located and carries block provenance.
     for ch in chunks:
@@ -198,7 +198,7 @@ def test_hard_split_slices_get_precise_refs(tmp_path: Path) -> None:
     chunks = enforce_chunk_token_limit_before_embedding(chunks, tok, max_tokens=30)
     assert len(chunks) > 1  # hard-split fired
 
-    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+    backfill_chunk_sidecars(chunks, blocks_path)
 
     # The early slices live entirely inside "big" -> single ref, not both blocks.
     assert chunks[0]["sidecar"]["refs"] == [{"type": "block", "id": "big"}]
@@ -215,7 +215,7 @@ def test_hard_split_multi_sentence_rejoin_keeps_provenance(tmp_path: Path) -> No
     # split regroups whole sentence units and rejoins them with "\n\n", so the
     # resulting slice content is NOT byte-verbatim in the source. Span propagation
     # must fall back to whitespace-normalized matching instead of dropping the span
-    # — otherwise require_source_span backfill would wrongly FAIL the document.
+    # — otherwise span-first backfill would wrongly FAIL the document.
     block = "ab. cd. ef. gh. ij. kl."
     blocks_path, merged = _write_blocks(tmp_path, [("b1", block)])
     tok = _tokenizer()
@@ -238,7 +238,7 @@ def test_hard_split_multi_sentence_rejoin_keeps_provenance(tmp_path: Path) -> No
 
     # Must NOT raise: every slice keeps a span via the normalized fallback, and
     # each maps back to the single source block it came from.
-    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+    backfill_chunk_sidecars(chunks, blocks_path)
 
     for ch in chunks:
         assert [r["id"] for r in ch["sidecar"]["refs"]] == ["b1"]
@@ -271,7 +271,7 @@ def test_real_tiktoken_token_windows_match_verbatim(tmp_path: Path) -> None:
     )
     assert len(chunks) >= 2  # small window + overlap -> multiple chunks
 
-    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+    backfill_chunk_sidecars(chunks, blocks_path)
 
     for ch in chunks:
         assert ch["sidecar"]["type"] == "block"
@@ -286,9 +286,9 @@ def test_real_tiktoken_multibyte_boundary_degrades_not_fails(tmp_path: Path) -> 
     # Regression: tiktoken is byte-level, so a 4-byte UTF-8 char (emoji / rare CJK
     # extension) can have its bytes split across a token-window boundary. Decoding the
     # partial window yields U+FFFD in BOTH the chunk content and its span probe, so the
-    # chunk is unlocatable by span or by text. With require_source_span this previously
-    # FAILED the entire document; it must now skip provenance for the corrupt chunks
-    # while still attributing the clean ones.
+    # chunk is unlocatable by span or by text. Span-first backfill must skip provenance
+    # for the corrupt chunks while still attributing the clean ones, not FAIL the whole
+    # document.
     pytest.importorskip("tiktoken")
     from lightrag.utils import TiktokenTokenizer
 
@@ -309,7 +309,7 @@ def test_real_tiktoken_multibyte_boundary_degrades_not_fails(tmp_path: Path) -> 
     assert any("_source_span" not in c for c in chunks)
 
     # Must NOT raise: corrupt chunks are skipped, the rest are attributed.
-    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+    backfill_chunk_sidecars(chunks, blocks_path)
 
     for ch in chunks:
         if "�" in ch["content"]:
@@ -330,7 +330,7 @@ def test_backfilled_sidecar_persists_into_chunks_dict(tmp_path: Path) -> None:
     chunks = chunking_by_fixed_token(
         tok, merged, chunk_token_size=200, _emit_source_span=True
     )
-    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+    backfill_chunk_sidecars(chunks, blocks_path)
 
     chunks_dict = build_chunks_dict_from_chunking_result(
         chunks, doc_id="doc-xyz", file_path="doc.docx"
@@ -363,7 +363,7 @@ def test_span_first_disambiguates_repeated_cross_block_text(tmp_path: Path) -> N
     )
     assert [c["content"] for c in chunks] == ["ab\n\ncd", "abcd"]
 
-    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+    backfill_chunk_sidecars(chunks, blocks_path)
 
     assert [r["id"] for r in chunks[0]["sidecar"]["refs"]] == ["b1", "b2"]
     assert [r["id"] for r in chunks[1]["sidecar"]["refs"]] == ["b3"]

--- a/tests/chunker/test_sidecar_backfill_integration.py
+++ b/tests/chunker/test_sidecar_backfill_integration.py
@@ -210,6 +210,41 @@ def test_hard_split_slices_get_precise_refs(tmp_path: Path) -> None:
 
 
 @pytest.mark.offline
+def test_hard_split_multi_sentence_rejoin_keeps_provenance(tmp_path: Path) -> None:
+    # A single block whose sentences are separated by single spaces. The hard
+    # split regroups whole sentence units and rejoins them with "\n\n", so the
+    # resulting slice content is NOT byte-verbatim in the source. Span propagation
+    # must fall back to whitespace-normalized matching instead of dropping the span
+    # — otherwise require_source_span backfill would wrongly FAIL the document.
+    block = "ab. cd. ef. gh. ij. kl."
+    blocks_path, merged = _write_blocks(tmp_path, [("b1", block)])
+    tok = _tokenizer()
+
+    chunks = chunking_by_fixed_token(
+        tok,
+        merged,
+        chunk_token_size=200,
+        chunk_overlap_token_size=0,
+        _emit_source_span=True,
+    )
+    assert len(chunks) == 1
+    assert chunks[0]["_source_span"] == {"start": 0, "end": len(merged)}
+
+    chunks = enforce_chunk_token_limit_before_embedding(chunks, tok, max_tokens=7)
+    assert len(chunks) > 1  # hard split fired into multiple slices
+    # At least one slice rejoined sentence units with "\n\n" (not byte-verbatim),
+    # which is exactly the case the normalized span fallback must cover.
+    assert any("\n\n" in ch["content"] for ch in chunks)
+
+    # Must NOT raise: every slice keeps a span via the normalized fallback, and
+    # each maps back to the single source block it came from.
+    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+
+    for ch in chunks:
+        assert [r["id"] for r in ch["sidecar"]["refs"]] == ["b1"]
+
+
+@pytest.mark.offline
 def test_real_tiktoken_token_windows_match_verbatim(tmp_path: Path) -> None:
     # The char tokenizer guarantees decode(encode(x)) == x; a real BPE tokenizer
     # does not split on character boundaries, so this exercises that tiktoken's

--- a/tests/chunker/test_sidecar_backfill_integration.py
+++ b/tests/chunker/test_sidecar_backfill_integration.py
@@ -1,0 +1,317 @@
+"""Integration tests: real F chunker + hard-split + sidecar backfill + chunks dict.
+
+Unlike ``tests/sidecar/test_backfill.py`` (which hand-builds chunk lists), these
+drive the actual ``chunking_by_fixed_token`` chunker over the exact merged text a
+parsed document would yield, then apply the real
+``enforce_chunk_token_limit_before_embedding`` hard-split and
+``build_chunks_dict_from_chunking_result`` persistence step — verifying that
+backfilled sidecars are precise per final slice and survive into the chunks dict.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lightrag.chunker import chunking_by_fixed_token
+from lightrag.sidecar import backfill_chunk_sidecars
+from lightrag.utils import (
+    Tokenizer,
+    enforce_chunk_token_limit_before_embedding,
+)
+from lightrag.utils_pipeline import build_chunks_dict_from_chunking_result
+
+_BLOCK_SEPARATOR = "\n\n"
+
+
+class _CharTokenizerImpl:
+    """Deterministic char-per-token tokenizer; decode(encode(x)) == x so F
+    chunks are verbatim substrings and token sizes are character counts."""
+
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+def _tokenizer() -> Tokenizer:
+    return Tokenizer("char", _CharTokenizerImpl())
+
+
+def _write_blocks(tmp_path: Path, blocks: list[tuple[str, str]]) -> tuple[str, str]:
+    """Write blocks.jsonl; return (path, merged_text)."""
+    path = tmp_path / "doc.blocks.jsonl"
+    lines = [json.dumps({"type": "meta", "format": "lightrag", "version": "1.0"})]
+    parts: list[str] = []
+    for blockid, content in blocks:
+        lines.append(
+            json.dumps(
+                {
+                    "type": "content",
+                    "blockid": blockid,
+                    "content": content,
+                    "heading": "",
+                    "parent_headings": [],
+                    "level": 1,
+                }
+            )
+        )
+        if content.strip():
+            parts.append(content)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(path), _BLOCK_SEPARATOR.join(parts)
+
+
+@pytest.mark.offline
+def test_real_overlap_tail_chunk_maps_to_next_block(tmp_path: Path) -> None:
+    # End-to-end reproduction of the overlap-tail ambiguity with the real chunker.
+    # Simple case: b1="aa", b2="a", chunk_size=3, overlap=1 -> ["aa", "a", "a"]. The
+    # middle window [2:5] = "\n\na" strips to b2's "a" (the overlap landed on the
+    # separator), so the tail chunks belong to b2 — not the earlier "a" inside b1.
+    blocks_path, merged = _write_blocks(tmp_path, [("b1", "aa"), ("b2", "a")])
+    tok = _tokenizer()
+
+    chunks = chunking_by_fixed_token(
+        tok,
+        merged,
+        chunk_token_size=3,
+        chunk_overlap_token_size=1,
+        _emit_source_span=True,
+    )
+    assert [c["content"] for c in chunks] == ["aa", "a", "a"]
+
+    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+
+    assert [r["id"] for r in chunks[0]["sidecar"]["refs"]] == ["b1"]
+    assert [r["id"] for r in chunks[1]["sidecar"]["refs"]] == ["b2"]
+    assert [r["id"] for r in chunks[2]["sidecar"]["refs"]] == ["b2"]
+
+
+@pytest.mark.offline
+def test_real_overlap_on_stripped_separator_does_not_strand_chunks(
+    tmp_path: Path,
+) -> None:
+    # Harder end-to-end case: b1="a", b2="abab", chunk_size=2, overlap=1 ->
+    # ["a", "", "a", "ab", "ba", "ab", "b"]. The token overlap repeatedly lands on the
+    # stripped separator, so consecutive non-empty chunks can share a normalized start
+    # and only the end advances. The empty chunk is skipped; every other tail chunk
+    # must resolve into b2 without raising ChunkBlockMatchError.
+    blocks_path, merged = _write_blocks(tmp_path, [("b1", "a"), ("b2", "abab")])
+    tok = _tokenizer()
+
+    chunks = chunking_by_fixed_token(
+        tok,
+        merged,
+        chunk_token_size=2,
+        chunk_overlap_token_size=1,
+        _emit_source_span=True,
+    )
+    assert [c["content"] for c in chunks] == ["a", "", "a", "ab", "ba", "ab", "b"]
+
+    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+
+    assert [r["id"] for r in chunks[0]["sidecar"]["refs"]] == ["b1"]
+    # The empty chunk is skipped (no sidecar); all remaining chunks belong to b2.
+    assert "sidecar" not in chunks[1]
+    for ch in chunks[2:]:
+        assert [r["id"] for r in ch["sidecar"]["refs"]] == ["b2"]
+
+
+@pytest.mark.offline
+def test_real_identical_adjacent_blocks_no_cross_block_artifact(
+    tmp_path: Path,
+) -> None:
+    # End-to-end: identical adjacent blocks b1="aa", b2="aa", chunk_size=2, overlap=0
+    # -> ["aa", "", "aa"]. Stripping glues them to "aaaa", where "aa" also matches at
+    # offset 1 across the (removed) separator. The final chunk must reference only b2,
+    # not spuriously span both blocks.
+    blocks_path, merged = _write_blocks(tmp_path, [("b1", "aa"), ("b2", "aa")])
+    tok = _tokenizer()
+
+    chunks = chunking_by_fixed_token(
+        tok,
+        merged,
+        chunk_token_size=2,
+        chunk_overlap_token_size=0,
+        _emit_source_span=True,
+    )
+    assert [c["content"] for c in chunks] == ["aa", "", "aa"]
+
+    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+
+    assert chunks[0]["_source_span"] == {"start": 0, "end": 2}
+    assert chunks[2]["_source_span"] == {"start": 4, "end": 6}
+
+    assert [r["id"] for r in chunks[0]["sidecar"]["refs"]] == ["b1"]
+    assert "sidecar" not in chunks[1]
+    assert [r["id"] for r in chunks[2]["sidecar"]["refs"]] == ["b2"]
+
+
+@pytest.mark.offline
+def test_real_fixed_token_chunks_get_full_coverage(tmp_path: Path) -> None:
+    blocks = [(f"b{i}", f"Block number {i} body content here.") for i in range(6)]
+    blocks_path, merged = _write_blocks(tmp_path, blocks)
+    tok = _tokenizer()
+
+    chunks = chunking_by_fixed_token(
+        tok,
+        merged,
+        chunk_token_size=40,
+        chunk_overlap_token_size=5,
+        _emit_source_span=True,
+    )
+    assert len(chunks) >= 2  # multiple blocks per chunk at this size
+
+    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+
+    # Every chunk is located and carries block provenance.
+    for ch in chunks:
+        assert ch["sidecar"]["type"] == "block"
+        assert ch["sidecar"]["refs"]
+    # Union of all refs covers every block.
+    seen = {r["id"] for ch in chunks for r in ch["sidecar"]["refs"]}
+    assert seen == {b for b, _ in blocks}
+
+
+@pytest.mark.offline
+def test_hard_split_slices_get_precise_refs(tmp_path: Path) -> None:
+    # One large block followed by a small one. A single fixed-token chunk covers
+    # both; the hard-split then breaks the big-content chunk into slices that
+    # each lie inside one block, so refs must NOT all inherit the full set.
+    big = "A" * 120
+    blocks_path, merged = _write_blocks(tmp_path, [("big", big), ("small", "tail.")])
+    tok = _tokenizer()
+
+    chunks = chunking_by_fixed_token(
+        tok,
+        merged,
+        chunk_token_size=200,
+        chunk_overlap_token_size=0,
+        _emit_source_span=True,
+    )
+    assert len(chunks) == 1  # everything in one chunk pre-split
+    assert chunks[0]["_source_span"] == {"start": 0, "end": len(merged)}
+
+    chunks = enforce_chunk_token_limit_before_embedding(chunks, tok, max_tokens=30)
+    assert len(chunks) > 1  # hard-split fired
+
+    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+
+    # The early slices live entirely inside "big" -> single ref, not both blocks.
+    assert chunks[0]["sidecar"]["refs"] == [{"type": "block", "id": "big"}]
+    # "small" is referenced only by the slice that actually reaches its content.
+    small_refs = [
+        ch for ch in chunks if any(r["id"] == "small" for r in ch["sidecar"]["refs"])
+    ]
+    assert len(small_refs) == 1
+
+
+@pytest.mark.offline
+def test_real_tiktoken_token_windows_match_verbatim(tmp_path: Path) -> None:
+    # The char tokenizer guarantees decode(encode(x)) == x; a real BPE tokenizer
+    # does not split on character boundaries, so this exercises that tiktoken's
+    # decoded token windows (after the chunker's .strip()) are still locatable in
+    # the reconstructed merged text — including across the token-overlap fallback.
+    tiktoken = pytest.importorskip("tiktoken")
+    del tiktoken  # only needed to gate the test
+    from lightrag.utils import TiktokenTokenizer
+
+    tok = TiktokenTokenizer()
+    blocks = [
+        ("b1", "The quick brown fox jumps over the lazy dog repeatedly."),
+        ("b2", "Pack my box with five dozen liquor jugs, said the printer."),
+        ("b3", "How vexingly quick daft zebras jump across the meadow."),
+    ]
+    blocks_path, merged = _write_blocks(tmp_path, blocks)
+
+    chunks = chunking_by_fixed_token(
+        tok,
+        merged,
+        chunk_token_size=12,
+        chunk_overlap_token_size=3,
+        _emit_source_span=True,
+    )
+    assert len(chunks) >= 2  # small window + overlap -> multiple chunks
+
+    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+
+    for ch in chunks:
+        assert ch["sidecar"]["type"] == "block"
+        assert ch["sidecar"]["refs"]
+    # Union of all refs covers every block.
+    seen = {r["id"] for ch in chunks for r in ch["sidecar"]["refs"]}
+    assert seen == {b for b, _ in blocks}
+
+
+@pytest.mark.offline
+def test_backfilled_sidecar_persists_into_chunks_dict(tmp_path: Path) -> None:
+    blocks_path, merged = _write_blocks(
+        tmp_path, [("b1", "Alpha body."), ("b2", "Beta body.")]
+    )
+    tok = _tokenizer()
+
+    chunks = chunking_by_fixed_token(
+        tok, merged, chunk_token_size=200, _emit_source_span=True
+    )
+    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+
+    chunks_dict = build_chunks_dict_from_chunking_result(
+        chunks, doc_id="doc-xyz", file_path="doc.docx"
+    )
+    assert chunks_dict  # non-empty
+    for record in chunks_dict.values():
+        assert "sidecar" in record
+        assert "_source_span" not in record
+        assert record["sidecar"]["type"] == "block"
+        assert record["sidecar"]["refs"]
+
+
+@pytest.mark.offline
+def test_span_first_disambiguates_repeated_cross_block_text(tmp_path: Path) -> None:
+    # Latest pathological case: the real first chunk is b1 + separator + b2
+    # ("ab\n\ncd"), but stripping whitespace makes it textually equal to b3
+    # ("abcd"). Span-first backfill must map by source coverage, not by the
+    # ambiguous stripped string.
+    blocks_path, merged = _write_blocks(
+        tmp_path, [("b1", "ab"), ("b2", "cd"), ("b3", "abcd")]
+    )
+    tok = _tokenizer()
+
+    chunks = chunking_by_fixed_token(
+        tok,
+        merged,
+        chunk_token_size=6,
+        chunk_overlap_token_size=0,
+        _emit_source_span=True,
+    )
+    assert [c["content"] for c in chunks] == ["ab\n\ncd", "abcd"]
+
+    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+
+    assert [r["id"] for r in chunks[0]["sidecar"]["refs"]] == ["b1", "b2"]
+    assert [r["id"] for r in chunks[1]["sidecar"]["refs"]] == ["b3"]
+
+
+@pytest.mark.offline
+def test_split_by_character_only_emits_exact_source_spans() -> None:
+    tok = _tokenizer()
+    content = "  alpha|beta|gamma  "
+
+    chunks = chunking_by_fixed_token(
+        tok,
+        content,
+        chunk_token_size=20,
+        split_by_character="|",
+        split_by_character_only=True,
+        _emit_source_span=True,
+    )
+
+    assert [c["content"] for c in chunks] == ["alpha", "beta", "gamma"]
+    assert [c["_source_span"] for c in chunks] == [
+        {"start": 2, "end": 7},
+        {"start": 8, "end": 12},
+        {"start": 13, "end": 18},
+    ]

--- a/tests/chunker/test_token_window_source_span.py
+++ b/tests/chunker/test_token_window_source_span.py
@@ -110,8 +110,7 @@ def _ref_full_prefix_span(
 def _windows(n_tokens: int, chunk_size: int, overlap: int) -> list[tuple[int, int]]:
     step = chunk_size - overlap
     return [
-        (start, min(start + chunk_size, n_tokens))
-        for start in range(0, n_tokens, step)
+        (start, min(start + chunk_size, n_tokens)) for start in range(0, n_tokens, step)
     ]
 
 

--- a/tests/chunker/test_token_window_source_span.py
+++ b/tests/chunker/test_token_window_source_span.py
@@ -1,0 +1,202 @@
+"""Regression tests for the O(N) delta-decode in ``_token_window_source_span``.
+
+The fixed-token chunker maps each decoded token window back to its exact source
+span. The offset of a window's start used to be recomputed with a full
+``decode(tokens[:start_token])`` prefix decode on every window — O(N) per window,
+O(N²) over a document. It now decodes only the delta since the previous *verified*
+anchor (O(N) total). These tests pin three properties:
+
+1. **Equivalence** — the delta path yields byte-identical spans to a reference
+   full-prefix implementation, window for window (incl. a non-1:1 tokenizer and a
+   real tiktoken BPE tokenizer).
+2. **Exactness** — every emitted span is a verbatim slice of the source.
+3. **Linear decode budget** — total tokens handed to ``decode`` scales ~O(N), not
+   O(N²); the pre-optimization prefix decode would blow well past the bound.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lightrag.chunker import chunking_by_fixed_token
+from lightrag.chunker.token_size import _source_span, _token_window_source_span
+from lightrag.utils import Tokenizer, TokenizerInterface
+
+
+class _CharTokenizer(TokenizerInterface):
+    """1:1 char-per-token; ``decode(encode(x)) == x`` so windows are verbatim."""
+
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+class _MultiTokenTokenizer(TokenizerInterface):
+    """Non-uniform char→token ratio: uppercase = 2 tokens, ``.?!`` = 3, else 1.
+
+    Exercises the offset arithmetic where token count != char count, so a bug that
+    confuses the two surfaces immediately.
+    """
+
+    def encode(self, content: str) -> list[int]:
+        tokens: list[int] = []
+        for ch in content:
+            if ch.isupper():
+                tokens.extend([ord(ch), ord(ch) + 1000])
+            elif ch in (".", "?", "!"):
+                tokens.extend([ord(ch), ord(ch) + 2000, ord(ch) + 3000])
+            else:
+                tokens.append(ord(ch))
+        return tokens
+
+    def decode(self, tokens: list[int]) -> str:
+        result: list[str] = []
+        i = 0
+        while i < len(tokens):
+            base = tokens[i]
+            if (
+                i + 2 < len(tokens)
+                and tokens[i + 1] == base + 2000
+                and tokens[i + 2] == base + 3000
+            ):
+                result.append(chr(base))
+                i += 3
+            elif i + 1 < len(tokens) and tokens[i + 1] == base + 1000:
+                result.append(chr(base))
+                i += 2
+            else:
+                result.append(chr(base))
+                i += 1
+        return "".join(result)
+
+
+class _CountingTokenizer(TokenizerInterface):
+    """Wraps a char tokenizer and tallies every token handed to ``decode``."""
+
+    def __init__(self) -> None:
+        self.decoded_tokens = 0
+
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        self.decoded_tokens += len(tokens)
+        return "".join(chr(t) for t in tokens)
+
+
+def _ref_full_prefix_span(
+    tokenizer: Tokenizer,
+    content: str,
+    tokens: list[int],
+    start_token: int,
+    end_token: int,
+) -> dict[str, int] | None:
+    """The pre-optimization implementation: full ``decode(tokens[:start_token])``."""
+    window = tokenizer.decode(tokens[start_token:end_token])
+    start = len(tokenizer.decode(tokens[:start_token]))
+    end = start + len(window)
+    if content[start:end] != window:
+        found = content.find(
+            window, max(0, start - 32), min(len(content), end + 32 + len(window))
+        )
+        if found < 0:
+            return None
+        start, end = found, found + len(window)
+    return _source_span(content, start, end)
+
+
+def _windows(n_tokens: int, chunk_size: int, overlap: int) -> list[tuple[int, int]]:
+    step = chunk_size - overlap
+    return [
+        (start, min(start + chunk_size, n_tokens))
+        for start in range(0, n_tokens, step)
+    ]
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize(
+    "content",
+    [
+        " ".join(f"word{i:03d}" for i in range(400)),
+        "Alpha. BETA gamma? Delta! " * 120,
+        "Repeated phrase. " * 200,  # heavily repeated — exact offsets must not drift
+    ],
+)
+def test_delta_decode_matches_full_prefix_reference(content: str) -> None:
+    for impl in (_CharTokenizer(), _MultiTokenTokenizer()):
+        tok = Tokenizer(model_name="t", tokenizer=impl)
+        tokens = tok.encode(content)
+        chunk_size, overlap = 60, 12
+        anchor = (0, 0)
+        for start_token, end_token in _windows(len(tokens), chunk_size, overlap):
+            got, anchor = _token_window_source_span(
+                tok, content, tokens, start_token, end_token, anchor=anchor
+            )
+            ref = _ref_full_prefix_span(tok, content, tokens, start_token, end_token)
+            assert got == ref
+
+
+@pytest.mark.offline
+def test_delta_decode_matches_full_prefix_with_tiktoken() -> None:
+    pytest.importorskip("tiktoken")
+    from lightrag.utils import TiktokenTokenizer
+
+    tok = TiktokenTokenizer()
+    content = (
+        "The quick brown fox jumps over the lazy dog. "
+        "Pack my box with five dozen liquor jugs. "
+        "How vexingly quick daft zebras jump. "
+    ) * 40
+    tokens = tok.encode(content)
+    anchor = (0, 0)
+    for start_token, end_token in _windows(len(tokens), 24, 6):
+        got, anchor = _token_window_source_span(
+            tok, content, tokens, start_token, end_token, anchor=anchor
+        )
+        ref = _ref_full_prefix_span(tok, content, tokens, start_token, end_token)
+        assert got == ref
+
+
+@pytest.mark.offline
+def test_fixed_token_spans_are_exact_on_long_doc() -> None:
+    content = " ".join(f"token{i:04d}" for i in range(1500))
+    tok = Tokenizer(model_name="char", tokenizer=_CharTokenizer())
+
+    chunks = chunking_by_fixed_token(
+        tok,
+        content,
+        chunk_token_size=120,
+        chunk_overlap_token_size=20,
+        _emit_source_span=True,
+    )
+
+    assert len(chunks) > 5
+    for chunk in chunks:
+        span = chunk["_source_span"]
+        assert content[span["start"] : span["end"]] == chunk["content"]
+
+
+@pytest.mark.offline
+def test_decode_budget_is_linear_not_quadratic() -> None:
+    # char tokenizer => len(tokens) == len(content). With the old full-prefix
+    # decode the helper alone would decode ~sum(starts) == N^2/(2*step) tokens;
+    # the delta path decodes ~one step per window plus each window once. Assert
+    # the total stays under a small linear multiple of N, a bound the quadratic
+    # implementation cannot meet.
+    content = "x" * 8000
+    counting = _CountingTokenizer()
+    tok = Tokenizer(model_name="counting", tokenizer=counting)
+    n = len(tok.encode(content))  # 8000
+
+    chunking_by_fixed_token(
+        tok,
+        content,
+        chunk_token_size=200,
+        chunk_overlap_token_size=20,
+        _emit_source_span=True,
+    )
+
+    # Empirically ~3.2*N for the delta path; the old prefix decode is ~24*N here.
+    assert counting.decoded_tokens <= 6 * n

--- a/tests/sidecar/test_backfill.py
+++ b/tests/sidecar/test_backfill.py
@@ -1,0 +1,412 @@
+"""Unit tests for :func:`lightrag.sidecar.backfill.backfill_chunk_sidecars`.
+
+These exercise the F/R/V sidecar backfill in isolation: a small ``blocks.jsonl``
+is written to ``tmp_path`` and hand-built chunk lists are matched against it, so
+no real chunker, tokenizer, or embedding is needed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lightrag.exceptions import ChunkBlockMatchError
+from lightrag.sidecar import backfill_chunk_sidecars
+
+# The merged text the chunker would have received is
+# "\n\n".join(content for content rows with content.strip()).
+_BLOCK_SEPARATOR = "\n\n"
+
+
+def _write_blocks(tmp_path: Path, blocks: list[tuple[str, str]]) -> str:
+    """Write a blocks.jsonl with a meta header + ``(blockid, content)`` rows."""
+    path = tmp_path / "doc.blocks.jsonl"
+    lines = [json.dumps({"type": "meta", "format": "lightrag", "version": "1.0"})]
+    for blockid, content in blocks:
+        lines.append(
+            json.dumps(
+                {
+                    "type": "content",
+                    "blockid": blockid,
+                    "format": "plain_text",
+                    "content": content,
+                    "heading": "",
+                    "parent_headings": [],
+                    "level": 1,
+                }
+            )
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(path)
+
+
+def _chunk(content: str, order: int) -> dict:
+    return {"content": content, "tokens": len(content), "chunk_order_index": order}
+
+
+def _refs(chunk: dict) -> list[str]:
+    return [r["id"] for r in chunk["sidecar"]["refs"]]
+
+
+@pytest.mark.offline
+def test_chunk_spanning_two_blocks_lists_both_refs(tmp_path: Path) -> None:
+    blocks_path = _write_blocks(
+        tmp_path, [("b1", "Alpha paragraph."), ("b2", "Beta paragraph.")]
+    )
+    merged = _BLOCK_SEPARATOR.join(["Alpha paragraph.", "Beta paragraph."])
+    chunks = [_chunk(merged, 0)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert chunks[0]["sidecar"]["type"] == "block"
+    assert chunks[0]["sidecar"]["id"] == "b1"
+    assert _refs(chunks[0]) == ["b1", "b2"]
+
+
+@pytest.mark.offline
+def test_chunk_equal_to_single_block(tmp_path: Path) -> None:
+    blocks_path = _write_blocks(
+        tmp_path, [("b1", "Alpha paragraph."), ("b2", "Beta paragraph.")]
+    )
+    chunks = [_chunk("Beta paragraph.", 0)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert chunks[0]["sidecar"]["id"] == "b2"
+    assert _refs(chunks[0]) == ["b2"]
+
+
+@pytest.mark.offline
+def test_whitespace_normalized_match_for_v_style(tmp_path: Path) -> None:
+    # Block content has internal newlines; the V chunker rejoins sentences with
+    # single spaces, so the chunk body is not byte-verbatim.
+    block = "First sentence.\nSecond sentence.\nThird sentence."
+    blocks_path = _write_blocks(tmp_path, [("b1", block)])
+    chunks = [_chunk("First sentence. Second sentence. Third sentence.", 0)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1"]
+
+
+@pytest.mark.offline
+def test_v_inserts_space_between_adjacent_sentences_still_matches(
+    tmp_path: Path,
+) -> None:
+    # The source block has two sentences with NO whitespace at the boundary
+    # ("sentence.Second"); the V SemanticChunker rejoins sentences with a single
+    # space, inserting whitespace the source never had. Collapse-to-space matching
+    # would mismatch and raise; whitespace-stripped matching must still locate it.
+    blocks_path = _write_blocks(tmp_path, [("b1", "First sentence.Second sentence.")])
+    chunks = [_chunk("First sentence. Second sentence.", 0)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1"]
+
+
+@pytest.mark.offline
+def test_v_reflow_across_blocks_keeps_boundary_refs(tmp_path: Path) -> None:
+    # V reflows internal newlines to spaces and the chunk spans the block
+    # boundary. Whitespace-stripped matching must still attribute both blocks.
+    blocks_path = _write_blocks(
+        tmp_path,
+        [("b1", "Alpha line one.\nAlpha line two."), ("b2", "Beta block body.")],
+    )
+    chunks = [_chunk("Alpha line one. Alpha line two. Beta block body.", 0)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1", "b2"]
+
+
+@pytest.mark.offline
+def test_repeated_identical_blocks_map_to_distinct_blocks(tmp_path: Path) -> None:
+    blocks_path = _write_blocks(
+        tmp_path, [("b1", "Repeated text."), ("b2", "Repeated text.")]
+    )
+    chunks = [_chunk("Repeated text.", 0), _chunk("Repeated text.", 1)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1"]
+    assert _refs(chunks[1]) == ["b2"]
+
+
+@pytest.mark.offline
+def test_phrase_recurring_inside_previous_chunk_resolves_forward(
+    tmp_path: Path,
+) -> None:
+    # "common" appears inside b1; the next chunk's true home is b2. The forward
+    # cursor must not re-match the occurrence inside the previous chunk.
+    blocks_path = _write_blocks(
+        tmp_path,
+        [("b1", "common prefix and common middle"), ("b2", "common tail block")],
+    )
+    chunks = [
+        _chunk("common prefix and common middle", 0),
+        _chunk("common tail block", 1),
+    ]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1"]
+    assert _refs(chunks[1]) == ["b2"]
+
+
+@pytest.mark.offline
+def test_overlapping_chunks_match_inside_previous_span(tmp_path: Path) -> None:
+    # Simulate F/R token overlap: chunk 2 begins inside chunk 1's span. The
+    # forward-from-start cursor resolves the overlap position directly.
+    blocks_path = _write_blocks(
+        tmp_path, [("b1", "one two three four five six seven eight")]
+    )
+    chunks = [
+        _chunk("one two three four five", 0),
+        _chunk("four five six seven eight", 1),
+    ]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1"]
+    assert _refs(chunks[1]) == ["b1"]
+
+
+@pytest.mark.offline
+def test_overlap_chunk_with_later_duplicate_resolves_to_overlap(
+    tmp_path: Path,
+) -> None:
+    # Regression: an overlapping chunk whose normalized text recurs LATER in the
+    # document. The overlap chunk extends past the previous chunk's end (as real F/R
+    # overlap chunks always do) AND its text reappears in a later block. The cursor
+    # must resolve it to the *leftmost* end-advancing occurrence (the overlap inside
+    # b1), not jump to the later b2 duplicate and strand the following chunk.
+    #
+    # Merged text (normalized): "xxyyzz" + "yyzz" = "xxyyzzyyzz".
+    #   "yyzz" appears at the b1 overlap (offset 2) AND as b2 (offset 6).
+    blocks_path = _write_blocks(tmp_path, [("b1", "xx yy zz"), ("b2", "yy zz")])
+    chunks = [
+        _chunk("xx yy", 0),  # b1
+        _chunk("yy zz", 1),  # overlaps chunk 0 (shares "yy", adds "zz") -> still b1
+        _chunk("yy zz", 2),  # the genuine b2 occurrence
+    ]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1"]
+    assert _refs(chunks[1]) == ["b1"]
+    assert _refs(chunks[2]) == ["b2"]
+
+
+@pytest.mark.offline
+def test_overlap_window_on_stripped_separator_advances_into_next_block(
+    tmp_path: Path,
+) -> None:
+    # Regression for the reviewer's second case: b1="a", b2="abab", chunk_size=2,
+    # overlap=1 yields (non-empty) chunks ["a", "a", "ab", "ba", "ab", "b"]. The token
+    # overlap repeatedly falls on the stripped separator, so consecutive chunks can
+    # share a normalized START — only the END advances. A start-anchored cursor
+    # strands "ba" (its true position sits at/under the previous start) and raises;
+    # the end-anchored cursor places every tail chunk inside b2.
+    blocks_path = _write_blocks(tmp_path, [("b1", "a"), ("b2", "abab")])
+    chunks = [
+        _chunk("a", 0),  # b1
+        _chunk("a", 1),  # window crossed the stripped separator -> b2
+        _chunk("ab", 2),
+        _chunk("ba", 3),
+        _chunk("ab", 4),
+        _chunk("b", 5),
+    ]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1"]
+    for ch in chunks[1:]:
+        assert _refs(ch) == ["b2"]
+
+
+@pytest.mark.offline
+def test_cross_block_artifact_from_stripping_is_rejected(tmp_path: Path) -> None:
+    # Regression: identical adjacent blocks b1="aa", b2="aa" with no overlap yield
+    # chunks ["aa", "aa"]. In the stripped projection "aaaa", "aa" also occurs at
+    # offset 1, spanning b1's tail + b2's head across the removed separator — an
+    # artifact of stripping, not a real chunk. The second "aa" must map to b2 alone,
+    # so matching must prefer the single-block occurrence over the cross-block one.
+    blocks_path = _write_blocks(tmp_path, [("b1", "aa"), ("b2", "aa")])
+    chunks = [_chunk("aa", 0), _chunk("aa", 1)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1"]
+    assert _refs(chunks[1]) == ["b2"]
+
+
+@pytest.mark.offline
+def test_genuine_cross_block_chunk_still_lists_both(tmp_path: Path) -> None:
+    # A chunk whose content genuinely spans the boundary (its window held the
+    # separator) has no single-block occurrence, so the cross-block fallback keeps it
+    # and both blocks are listed — the single-block preference must not break this.
+    blocks_path = _write_blocks(tmp_path, [("b1", "alpha"), ("b2", "beta")])
+    merged = _BLOCK_SEPARATOR.join(["alpha", "beta"])
+    chunks = [_chunk(merged, 0)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1", "b2"]
+
+
+@pytest.mark.offline
+def test_source_span_preferred_over_ambiguous_text(tmp_path: Path) -> None:
+    # "ab\n\ncd" and "abcd" collapse to the same whitespace-stripped text,
+    # but the chunk's private source span is authoritative.
+    blocks_path = _write_blocks(tmp_path, [("b1", "ab"), ("b2", "cd"), ("b3", "abcd")])
+    chunks = [
+        {
+            **_chunk("ab\n\ncd", 0),
+            "_source_span": {"start": 0, "end": 6},
+        },
+        {
+            **_chunk("abcd", 1),
+            "_source_span": {"start": 8, "end": 12},
+        },
+    ]
+
+    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+
+    assert _refs(chunks[0]) == ["b1", "b2"]
+    assert _refs(chunks[1]) == ["b3"]
+
+
+@pytest.mark.offline
+def test_require_source_span_rejects_missing_span(tmp_path: Path) -> None:
+    blocks_path = _write_blocks(tmp_path, [("b1", "Present content.")])
+    chunks = [_chunk("Present content.", 4)]
+
+    with pytest.raises(ChunkBlockMatchError) as exc:
+        backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+
+    assert exc.value.chunk_order_index == 4
+
+
+@pytest.mark.offline
+def test_require_source_span_rejects_invalid_span(tmp_path: Path) -> None:
+    blocks_path = _write_blocks(tmp_path, [("b1", "Present content.")])
+    chunks = [
+        {
+            **_chunk("Present content.", 5),
+            "_source_span": {"start": 0, "end": 10_000},
+        }
+    ]
+
+    with pytest.raises(ChunkBlockMatchError) as exc:
+        backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+
+    assert exc.value.chunk_order_index == 5
+
+
+@pytest.mark.offline
+def test_require_source_span_rejects_mismatched_span_text(tmp_path: Path) -> None:
+    blocks_path = _write_blocks(tmp_path, [("b1", "Alpha."), ("b2", "Beta.")])
+    chunks = [
+        {
+            **_chunk("Beta.", 6),
+            "_source_span": {"start": 0, "end": 6},
+        }
+    ]
+
+    with pytest.raises(ChunkBlockMatchError) as exc:
+        backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+
+    assert exc.value.chunk_order_index == 6
+
+
+@pytest.mark.offline
+def test_unmatchable_chunk_raises(tmp_path: Path) -> None:
+    blocks_path = _write_blocks(tmp_path, [("b1", "Present content.")])
+    chunks = [_chunk("Absent content not in any block.", 3)]
+
+    with pytest.raises(ChunkBlockMatchError) as exc:
+        backfill_chunk_sidecars(chunks, blocks_path)
+    assert exc.value.chunk_order_index == 3
+
+
+@pytest.mark.offline
+def test_empty_blocks_path_is_noop(tmp_path: Path) -> None:
+    chunks = [_chunk("anything", 0)]
+    backfill_chunk_sidecars(chunks, "")
+    assert "sidecar" not in chunks[0]
+
+
+@pytest.mark.offline
+def test_meta_only_file_is_noop(tmp_path: Path) -> None:
+    blocks_path = _write_blocks(tmp_path, [])
+    chunks = [_chunk("anything", 0)]
+    backfill_chunk_sidecars(chunks, blocks_path)
+    assert "sidecar" not in chunks[0]
+
+
+@pytest.mark.offline
+def test_unreadable_path_is_noop(tmp_path: Path) -> None:
+    chunks = [_chunk("anything", 0)]
+    backfill_chunk_sidecars(chunks, str(tmp_path / "does_not_exist.blocks.jsonl"))
+    assert "sidecar" not in chunks[0]
+
+
+@pytest.mark.offline
+def test_existing_sidecar_is_preserved(tmp_path: Path) -> None:
+    blocks_path = _write_blocks(tmp_path, [("b1", "Alpha."), ("b2", "Beta.")])
+    # A P/mm-style chunk whose content would NOT match block order; it must be
+    # left untouched because it already carries a valid sidecar.
+    pre = {
+        "content": "Beta.",
+        "tokens": 1,
+        "chunk_order_index": 0,
+        "sidecar": {
+            "type": "drawing",
+            "id": "im-xyz-0001",
+            "refs": [{"type": "drawing", "id": "im-xyz-0001"}],
+        },
+    }
+    chunks = [pre]
+    backfill_chunk_sidecars(chunks, blocks_path)
+    assert chunks[0]["sidecar"]["type"] == "drawing"
+    assert chunks[0]["sidecar"]["id"] == "im-xyz-0001"
+
+
+@pytest.mark.offline
+def test_multimodal_tag_block_matches_verbatim(tmp_path: Path) -> None:
+    block = 'See: <table id="tb-abc-0001" format="json">[[1,2]]</table> done.'
+    blocks_path = _write_blocks(tmp_path, [("b1", block)])
+    chunks = [_chunk(block, 0)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1"]
+
+
+@pytest.mark.offline
+def test_whitespace_only_block_excluded_from_refs(tmp_path: Path) -> None:
+    # The middle row is whitespace-only -> not part of the merged text and never
+    # contributes a ref. A chunk spanning b1..b3 lists only b1 and b3.
+    blocks_path = _write_blocks(
+        tmp_path, [("b1", "First."), ("bws", "   "), ("b3", "Third.")]
+    )
+    merged = _BLOCK_SEPARATOR.join(["First.", "Third."])
+    chunks = [_chunk(merged, 0)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert _refs(chunks[0]) == ["b1", "b3"]
+
+
+@pytest.mark.offline
+def test_empty_chunk_skipped_then_following_matches(tmp_path: Path) -> None:
+    blocks_path = _write_blocks(tmp_path, [("b1", "Real content.")])
+    chunks = [_chunk("", 0), _chunk("Real content.", 1)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert "sidecar" not in chunks[0]
+    assert _refs(chunks[1]) == ["b1"]

--- a/tests/sidecar/test_backfill.py
+++ b/tests/sidecar/test_backfill.py
@@ -3,6 +3,11 @@
 These exercise the F/R/V sidecar backfill in isolation: a small ``blocks.jsonl``
 is written to ``tmp_path`` and hand-built chunk lists are matched against it, so
 no real chunker, tokenizer, or embedding is needed.
+
+Backfill is span-first: each F/R/V chunk carries a private ``_source_span`` (char
+offsets into the reconstructed merged text) and is mapped to the block(s) that span
+overlaps. A chunk without a usable span FAILs the document, except the inherently
+unlocatable replacement-char case, which degrades to no-sidecar.
 """
 
 from __future__ import annotations
@@ -43,7 +48,13 @@ def _write_blocks(tmp_path: Path, blocks: list[tuple[str, str]]) -> str:
 
 
 def _chunk(content: str, order: int) -> dict:
+    """A sidecar-less chunk WITHOUT a source span (FAILs unless it is unlocatable)."""
     return {"content": content, "tokens": len(content), "chunk_order_index": order}
+
+
+def _span_chunk(content: str, order: int, start: int, end: int) -> dict:
+    """A chunk carrying the ``_source_span`` a real F/R/V chunker would emit."""
+    return {**_chunk(content, order), "_source_span": {"start": start, "end": end}}
 
 
 def _refs(chunk: dict) -> list[str]:
@@ -51,12 +62,27 @@ def _refs(chunk: dict) -> list[str]:
 
 
 @pytest.mark.offline
-def test_chunk_spanning_two_blocks_lists_both_refs(tmp_path: Path) -> None:
+def test_span_within_single_block_maps_to_it(tmp_path: Path) -> None:
     blocks_path = _write_blocks(
         tmp_path, [("b1", "Alpha paragraph."), ("b2", "Beta paragraph.")]
     )
     merged = _BLOCK_SEPARATOR.join(["Alpha paragraph.", "Beta paragraph."])
-    chunks = [_chunk(merged, 0)]
+    start = merged.index("Beta paragraph.")
+    chunks = [_span_chunk("Beta paragraph.", 0, start, start + len("Beta paragraph."))]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert chunks[0]["sidecar"]["id"] == "b2"
+    assert _refs(chunks[0]) == ["b2"]
+
+
+@pytest.mark.offline
+def test_span_spanning_two_blocks_lists_both_refs(tmp_path: Path) -> None:
+    blocks_path = _write_blocks(
+        tmp_path, [("b1", "Alpha paragraph."), ("b2", "Beta paragraph.")]
+    )
+    merged = _BLOCK_SEPARATOR.join(["Alpha paragraph.", "Beta paragraph."])
+    chunks = [_span_chunk(merged, 0, 0, len(merged))]
 
     backfill_chunk_sidecars(chunks, blocks_path)
 
@@ -66,25 +92,17 @@ def test_chunk_spanning_two_blocks_lists_both_refs(tmp_path: Path) -> None:
 
 
 @pytest.mark.offline
-def test_chunk_equal_to_single_block(tmp_path: Path) -> None:
-    blocks_path = _write_blocks(
-        tmp_path, [("b1", "Alpha paragraph."), ("b2", "Beta paragraph.")]
-    )
-    chunks = [_chunk("Beta paragraph.", 0)]
-
-    backfill_chunk_sidecars(chunks, blocks_path)
-
-    assert chunks[0]["sidecar"]["id"] == "b2"
-    assert _refs(chunks[0]) == ["b2"]
-
-
-@pytest.mark.offline
-def test_whitespace_normalized_match_for_v_style(tmp_path: Path) -> None:
-    # Block content has internal newlines; the V chunker rejoins sentences with
-    # single spaces, so the chunk body is not byte-verbatim.
+def test_v_reflowed_content_matches_span_via_whitespace_strip(tmp_path: Path) -> None:
+    # The block has internal newlines; the V chunker rejoins sentences with single
+    # spaces, so the chunk body is not byte-verbatim against its source span. Span
+    # validation must accept the whitespace-stripped match.
     block = "First sentence.\nSecond sentence.\nThird sentence."
     blocks_path = _write_blocks(tmp_path, [("b1", block)])
-    chunks = [_chunk("First sentence. Second sentence. Third sentence.", 0)]
+    chunks = [
+        _span_chunk(
+            "First sentence. Second sentence. Third sentence.", 0, 0, len(block)
+        )
+    ]
 
     backfill_chunk_sidecars(chunks, blocks_path)
 
@@ -96,11 +114,12 @@ def test_v_inserts_space_between_adjacent_sentences_still_matches(
     tmp_path: Path,
 ) -> None:
     # The source block has two sentences with NO whitespace at the boundary
-    # ("sentence.Second"); the V SemanticChunker rejoins sentences with a single
-    # space, inserting whitespace the source never had. Collapse-to-space matching
-    # would mismatch and raise; whitespace-stripped matching must still locate it.
-    blocks_path = _write_blocks(tmp_path, [("b1", "First sentence.Second sentence.")])
-    chunks = [_chunk("First sentence. Second sentence.", 0)]
+    # ("sentence.Second"); V rejoins them with a single space, inserting whitespace
+    # the source never had. Collapse-to-single-space validation would mismatch;
+    # whitespace-stripped validation must still accept the span.
+    block = "First sentence.Second sentence."
+    blocks_path = _write_blocks(tmp_path, [("b1", block)])
+    chunks = [_span_chunk("First sentence. Second sentence.", 0, 0, len(block))]
 
     backfill_chunk_sidecars(chunks, blocks_path)
 
@@ -109,13 +128,20 @@ def test_v_inserts_space_between_adjacent_sentences_still_matches(
 
 @pytest.mark.offline
 def test_v_reflow_across_blocks_keeps_boundary_refs(tmp_path: Path) -> None:
-    # V reflows internal newlines to spaces and the chunk spans the block
-    # boundary. Whitespace-stripped matching must still attribute both blocks.
+    # V reflows internal newlines to spaces and the chunk spans the block boundary;
+    # the span covers both blocks (and the separator), so both are attributed.
     blocks_path = _write_blocks(
         tmp_path,
         [("b1", "Alpha line one.\nAlpha line two."), ("b2", "Beta block body.")],
     )
-    chunks = [_chunk("Alpha line one. Alpha line two. Beta block body.", 0)]
+    merged = _BLOCK_SEPARATOR.join(
+        ["Alpha line one.\nAlpha line two.", "Beta block body."]
+    )
+    chunks = [
+        _span_chunk(
+            "Alpha line one. Alpha line two. Beta block body.", 0, 0, len(merged)
+        )
+    ]
 
     backfill_chunk_sidecars(chunks, blocks_path)
 
@@ -123,31 +149,17 @@ def test_v_reflow_across_blocks_keeps_boundary_refs(tmp_path: Path) -> None:
 
 
 @pytest.mark.offline
-def test_repeated_identical_blocks_map_to_distinct_blocks(tmp_path: Path) -> None:
+def test_repeated_identical_blocks_map_via_distinct_spans(tmp_path: Path) -> None:
+    # Identical content in two blocks; the span — not the text — disambiguates which
+    # block each chunk belongs to.
     blocks_path = _write_blocks(
         tmp_path, [("b1", "Repeated text."), ("b2", "Repeated text.")]
     )
-    chunks = [_chunk("Repeated text.", 0), _chunk("Repeated text.", 1)]
-
-    backfill_chunk_sidecars(chunks, blocks_path)
-
-    assert _refs(chunks[0]) == ["b1"]
-    assert _refs(chunks[1]) == ["b2"]
-
-
-@pytest.mark.offline
-def test_phrase_recurring_inside_previous_chunk_resolves_forward(
-    tmp_path: Path,
-) -> None:
-    # "common" appears inside b1; the next chunk's true home is b2. The forward
-    # cursor must not re-match the occurrence inside the previous chunk.
-    blocks_path = _write_blocks(
-        tmp_path,
-        [("b1", "common prefix and common middle"), ("b2", "common tail block")],
-    )
+    merged = _BLOCK_SEPARATOR.join(["Repeated text.", "Repeated text."])
+    b2_start = merged.index("Repeated text.", 1)
     chunks = [
-        _chunk("common prefix and common middle", 0),
-        _chunk("common tail block", 1),
+        _span_chunk("Repeated text.", 0, 0, len("Repeated text.")),
+        _span_chunk("Repeated text.", 1, b2_start, b2_start + len("Repeated text.")),
     ]
 
     backfill_chunk_sidecars(chunks, blocks_path)
@@ -157,184 +169,63 @@ def test_phrase_recurring_inside_previous_chunk_resolves_forward(
 
 
 @pytest.mark.offline
-def test_overlapping_chunks_match_inside_previous_span(tmp_path: Path) -> None:
-    # Simulate F/R token overlap: chunk 2 begins inside chunk 1's span. The
-    # forward-from-start cursor resolves the overlap position directly.
-    blocks_path = _write_blocks(
-        tmp_path, [("b1", "one two three four five six seven eight")]
-    )
-    chunks = [
-        _chunk("one two three four five", 0),
-        _chunk("four five six seven eight", 1),
-    ]
-
-    backfill_chunk_sidecars(chunks, blocks_path)
-
-    assert _refs(chunks[0]) == ["b1"]
-    assert _refs(chunks[1]) == ["b1"]
-
-
-@pytest.mark.offline
-def test_overlap_chunk_with_later_duplicate_resolves_to_overlap(
+def test_source_span_disambiguates_cross_block_from_later_duplicate(
     tmp_path: Path,
 ) -> None:
-    # Regression: an overlapping chunk whose normalized text recurs LATER in the
-    # document. The overlap chunk extends past the previous chunk's end (as real F/R
-    # overlap chunks always do) AND its text reappears in a later block. The cursor
-    # must resolve it to the *leftmost* end-advancing occurrence (the overlap inside
-    # b1), not jump to the later b2 duplicate and strand the following chunk.
-    #
-    # Merged text (normalized): "xxyyzz" + "yyzz" = "xxyyzzyyzz".
-    #   "yyzz" appears at the b1 overlap (offset 2) AND as b2 (offset 6).
-    blocks_path = _write_blocks(tmp_path, [("b1", "xx yy zz"), ("b2", "yy zz")])
-    chunks = [
-        _chunk("xx yy", 0),  # b1
-        _chunk("yy zz", 1),  # overlaps chunk 0 (shares "yy", adds "zz") -> still b1
-        _chunk("yy zz", 2),  # the genuine b2 occurrence
-    ]
-
-    backfill_chunk_sidecars(chunks, blocks_path)
-
-    assert _refs(chunks[0]) == ["b1"]
-    assert _refs(chunks[1]) == ["b1"]
-    assert _refs(chunks[2]) == ["b2"]
-
-
-@pytest.mark.offline
-def test_overlap_window_on_stripped_separator_advances_into_next_block(
-    tmp_path: Path,
-) -> None:
-    # Regression for the reviewer's second case: b1="a", b2="abab", chunk_size=2,
-    # overlap=1 yields (non-empty) chunks ["a", "a", "ab", "ba", "ab", "b"]. The token
-    # overlap repeatedly falls on the stripped separator, so consecutive chunks can
-    # share a normalized START — only the END advances. A start-anchored cursor
-    # strands "ba" (its true position sits at/under the previous start) and raises;
-    # the end-anchored cursor places every tail chunk inside b2.
-    blocks_path = _write_blocks(tmp_path, [("b1", "a"), ("b2", "abab")])
-    chunks = [
-        _chunk("a", 0),  # b1
-        _chunk("a", 1),  # window crossed the stripped separator -> b2
-        _chunk("ab", 2),
-        _chunk("ba", 3),
-        _chunk("ab", 4),
-        _chunk("b", 5),
-    ]
-
-    backfill_chunk_sidecars(chunks, blocks_path)
-
-    assert _refs(chunks[0]) == ["b1"]
-    for ch in chunks[1:]:
-        assert _refs(ch) == ["b2"]
-
-
-@pytest.mark.offline
-def test_cross_block_artifact_from_stripping_is_rejected(tmp_path: Path) -> None:
-    # Regression: identical adjacent blocks b1="aa", b2="aa" with no overlap yield
-    # chunks ["aa", "aa"]. In the stripped projection "aaaa", "aa" also occurs at
-    # offset 1, spanning b1's tail + b2's head across the removed separator — an
-    # artifact of stripping, not a real chunk. The second "aa" must map to b2 alone,
-    # so matching must prefer the single-block occurrence over the cross-block one.
-    blocks_path = _write_blocks(tmp_path, [("b1", "aa"), ("b2", "aa")])
-    chunks = [_chunk("aa", 0), _chunk("aa", 1)]
-
-    backfill_chunk_sidecars(chunks, blocks_path)
-
-    assert _refs(chunks[0]) == ["b1"]
-    assert _refs(chunks[1]) == ["b2"]
-
-
-@pytest.mark.offline
-def test_genuine_cross_block_chunk_still_lists_both(tmp_path: Path) -> None:
-    # A chunk whose content genuinely spans the boundary (its window held the
-    # separator) has no single-block occurrence, so the cross-block fallback keeps it
-    # and both blocks are listed — the single-block preference must not break this.
-    blocks_path = _write_blocks(tmp_path, [("b1", "alpha"), ("b2", "beta")])
-    merged = _BLOCK_SEPARATOR.join(["alpha", "beta"])
-    chunks = [_chunk(merged, 0)]
-
-    backfill_chunk_sidecars(chunks, blocks_path)
-
-    assert _refs(chunks[0]) == ["b1", "b2"]
-
-
-@pytest.mark.offline
-def test_source_span_preferred_over_ambiguous_text(tmp_path: Path) -> None:
-    # "ab\n\ncd" and "abcd" collapse to the same whitespace-stripped text,
-    # but the chunk's private source span is authoritative.
+    # Regression: "ab\n\ncd" and a later "abcd" block collapse to the same
+    # whitespace-stripped text. The old text-matching fallback would prefer the later
+    # single-block "abcd" and strand the real cross-block chunk; the span is
+    # authoritative and resolves each chunk to its true block(s).
     blocks_path = _write_blocks(tmp_path, [("b1", "ab"), ("b2", "cd"), ("b3", "abcd")])
     chunks = [
-        {
-            **_chunk("ab\n\ncd", 0),
-            "_source_span": {"start": 0, "end": 6},
-        },
-        {
-            **_chunk("abcd", 1),
-            "_source_span": {"start": 8, "end": 12},
-        },
+        _span_chunk("ab\n\ncd", 0, 0, 6),
+        _span_chunk("abcd", 1, 8, 12),
     ]
 
-    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+    backfill_chunk_sidecars(chunks, blocks_path)
 
     assert _refs(chunks[0]) == ["b1", "b2"]
     assert _refs(chunks[1]) == ["b3"]
 
 
 @pytest.mark.offline
-def test_require_source_span_rejects_missing_span(tmp_path: Path) -> None:
+def test_missing_span_fails_document(tmp_path: Path) -> None:
     blocks_path = _write_blocks(tmp_path, [("b1", "Present content.")])
     chunks = [_chunk("Present content.", 4)]
 
     with pytest.raises(ChunkBlockMatchError) as exc:
-        backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+        backfill_chunk_sidecars(chunks, blocks_path)
 
     assert exc.value.chunk_order_index == 4
 
 
 @pytest.mark.offline
-def test_require_source_span_rejects_invalid_span(tmp_path: Path) -> None:
+def test_out_of_range_span_fails_document(tmp_path: Path) -> None:
     blocks_path = _write_blocks(tmp_path, [("b1", "Present content.")])
-    chunks = [
-        {
-            **_chunk("Present content.", 5),
-            "_source_span": {"start": 0, "end": 10_000},
-        }
-    ]
+    chunks = [_span_chunk("Present content.", 5, 0, 10_000)]
 
     with pytest.raises(ChunkBlockMatchError) as exc:
-        backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+        backfill_chunk_sidecars(chunks, blocks_path)
 
     assert exc.value.chunk_order_index == 5
 
 
 @pytest.mark.offline
-def test_require_source_span_rejects_mismatched_span_text(tmp_path: Path) -> None:
+def test_mismatched_span_text_fails_document(tmp_path: Path) -> None:
+    # The span points at "Alpha." but the chunk content is "Beta." — neither a
+    # byte-exact nor a whitespace-stripped match, so the span is treated as absent.
     blocks_path = _write_blocks(tmp_path, [("b1", "Alpha."), ("b2", "Beta.")])
-    chunks = [
-        {
-            **_chunk("Beta.", 6),
-            "_source_span": {"start": 0, "end": 6},
-        }
-    ]
+    chunks = [_span_chunk("Beta.", 6, 0, 6)]
 
     with pytest.raises(ChunkBlockMatchError) as exc:
-        backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+        backfill_chunk_sidecars(chunks, blocks_path)
 
     assert exc.value.chunk_order_index == 6
 
 
 @pytest.mark.offline
-def test_unmatchable_chunk_raises(tmp_path: Path) -> None:
-    blocks_path = _write_blocks(tmp_path, [("b1", "Present content.")])
-    chunks = [_chunk("Absent content not in any block.", 3)]
-
-    with pytest.raises(ChunkBlockMatchError) as exc:
-        backfill_chunk_sidecars(chunks, blocks_path)
-    assert exc.value.chunk_order_index == 3
-
-
-@pytest.mark.offline
 def test_empty_blocks_path_is_noop(tmp_path: Path) -> None:
-    chunks = [_chunk("anything", 0)]
+    chunks = [_span_chunk("anything", 0, 0, 8)]
     backfill_chunk_sidecars(chunks, "")
     assert "sidecar" not in chunks[0]
 
@@ -342,14 +233,14 @@ def test_empty_blocks_path_is_noop(tmp_path: Path) -> None:
 @pytest.mark.offline
 def test_meta_only_file_is_noop(tmp_path: Path) -> None:
     blocks_path = _write_blocks(tmp_path, [])
-    chunks = [_chunk("anything", 0)]
+    chunks = [_span_chunk("anything", 0, 0, 8)]
     backfill_chunk_sidecars(chunks, blocks_path)
     assert "sidecar" not in chunks[0]
 
 
 @pytest.mark.offline
 def test_unreadable_path_is_noop(tmp_path: Path) -> None:
-    chunks = [_chunk("anything", 0)]
+    chunks = [_span_chunk("anything", 0, 0, 8)]
     backfill_chunk_sidecars(chunks, str(tmp_path / "does_not_exist.blocks.jsonl"))
     assert "sidecar" not in chunks[0]
 
@@ -357,8 +248,8 @@ def test_unreadable_path_is_noop(tmp_path: Path) -> None:
 @pytest.mark.offline
 def test_existing_sidecar_is_preserved(tmp_path: Path) -> None:
     blocks_path = _write_blocks(tmp_path, [("b1", "Alpha."), ("b2", "Beta.")])
-    # A P/mm-style chunk whose content would NOT match block order; it must be
-    # left untouched because it already carries a valid sidecar.
+    # A P/mm-style chunk that already carries a valid sidecar must be left untouched,
+    # even though it has no source span.
     pre = {
         "content": "Beta.",
         "tokens": 1,
@@ -376,10 +267,10 @@ def test_existing_sidecar_is_preserved(tmp_path: Path) -> None:
 
 
 @pytest.mark.offline
-def test_multimodal_tag_block_matches_verbatim(tmp_path: Path) -> None:
+def test_multimodal_tag_span_matches_verbatim(tmp_path: Path) -> None:
     block = 'See: <table id="tb-abc-0001" format="json">[[1,2]]</table> done.'
     blocks_path = _write_blocks(tmp_path, [("b1", block)])
-    chunks = [_chunk(block, 0)]
+    chunks = [_span_chunk(block, 0, 0, len(block))]
 
     backfill_chunk_sidecars(chunks, blocks_path)
 
@@ -389,12 +280,12 @@ def test_multimodal_tag_block_matches_verbatim(tmp_path: Path) -> None:
 @pytest.mark.offline
 def test_whitespace_only_block_excluded_from_refs(tmp_path: Path) -> None:
     # The middle row is whitespace-only -> not part of the merged text and never
-    # contributes a ref. A chunk spanning b1..b3 lists only b1 and b3.
+    # contributes a ref. A chunk whose span covers b1..b3 lists only b1 and b3.
     blocks_path = _write_blocks(
         tmp_path, [("b1", "First."), ("bws", "   "), ("b3", "Third.")]
     )
     merged = _BLOCK_SEPARATOR.join(["First.", "Third."])
-    chunks = [_chunk(merged, 0)]
+    chunks = [_span_chunk(merged, 0, 0, len(merged))]
 
     backfill_chunk_sidecars(chunks, blocks_path)
 
@@ -404,7 +295,7 @@ def test_whitespace_only_block_excluded_from_refs(tmp_path: Path) -> None:
 @pytest.mark.offline
 def test_empty_chunk_skipped_then_following_matches(tmp_path: Path) -> None:
     blocks_path = _write_blocks(tmp_path, [("b1", "Real content.")])
-    chunks = [_chunk("", 0), _chunk("Real content.", 1)]
+    chunks = [_chunk("", 0), _span_chunk("Real content.", 1, 0, len("Real content."))]
 
     backfill_chunk_sidecars(chunks, blocks_path)
 
@@ -416,8 +307,8 @@ def test_empty_chunk_skipped_then_following_matches(tmp_path: Path) -> None:
 def test_replacement_char_chunk_skipped_not_failed(tmp_path: Path) -> None:
     # A multi-byte UTF-8 char split at a token-window boundary decodes to U+FFFD in
     # both the chunk content and its span probe, so the chunk is unlocatable by any
-    # means. Under require_source_span it must be SKIPPED (no sidecar), not raise and
-    # FAIL the whole document; the following clean chunk still maps correctly.
+    # means. It must be SKIPPED (no sidecar), not raise and FAIL the whole document;
+    # the following clean chunk (with a valid span) still maps correctly.
     b1, b2 = "Status update 🎉 done.", "Clean tail block."
     blocks_path = _write_blocks(tmp_path, [("b1", b1), ("b2", b2)])
     merged = _BLOCK_SEPARATOR.join([b1, b2])
@@ -425,28 +316,10 @@ def test_replacement_char_chunk_skipped_not_failed(tmp_path: Path) -> None:
     chunks = [
         # First chunk lost a byte at the emoji boundary -> U+FFFD, no usable span.
         _chunk("Status update � done.", 0),
-        # The clean chunk carries a valid span (as the real chunker would emit), so
-        # the strict contract is preserved for it.
-        {
-            **_chunk(b2, 1),
-            "_source_span": {"start": b2_start, "end": b2_start + len(b2)},
-        },
+        _span_chunk(b2, 1, b2_start, b2_start + len(b2)),
     ]
-
-    # Must not raise even with the strict span contract.
-    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
-
-    assert "sidecar" not in chunks[0]  # provenance degraded for the corrupt chunk
-    assert _refs(chunks[1]) == ["b2"]  # clean chunk still resolves
-
-
-@pytest.mark.offline
-def test_replacement_char_chunk_skipped_in_text_fallback(tmp_path: Path) -> None:
-    # Same degradation in the non-required (text-matching) path: a U+FFFD chunk is
-    # skipped rather than raising ChunkBlockMatchError.
-    blocks_path = _write_blocks(tmp_path, [("b1", "Alpha 🚀 beta.")])
-    chunks = [_chunk("Alpha � beta.", 0)]
 
     backfill_chunk_sidecars(chunks, blocks_path)
 
-    assert "sidecar" not in chunks[0]
+    assert "sidecar" not in chunks[0]  # provenance degraded for the corrupt chunk
+    assert _refs(chunks[1]) == ["b2"]  # clean chunk still resolves

--- a/tests/sidecar/test_backfill.py
+++ b/tests/sidecar/test_backfill.py
@@ -410,3 +410,43 @@ def test_empty_chunk_skipped_then_following_matches(tmp_path: Path) -> None:
 
     assert "sidecar" not in chunks[0]
     assert _refs(chunks[1]) == ["b1"]
+
+
+@pytest.mark.offline
+def test_replacement_char_chunk_skipped_not_failed(tmp_path: Path) -> None:
+    # A multi-byte UTF-8 char split at a token-window boundary decodes to U+FFFD in
+    # both the chunk content and its span probe, so the chunk is unlocatable by any
+    # means. Under require_source_span it must be SKIPPED (no sidecar), not raise and
+    # FAIL the whole document; the following clean chunk still maps correctly.
+    b1, b2 = "Status update 🎉 done.", "Clean tail block."
+    blocks_path = _write_blocks(tmp_path, [("b1", b1), ("b2", b2)])
+    merged = _BLOCK_SEPARATOR.join([b1, b2])
+    b2_start = merged.index(b2)
+    chunks = [
+        # First chunk lost a byte at the emoji boundary -> U+FFFD, no usable span.
+        _chunk("Status update � done.", 0),
+        # The clean chunk carries a valid span (as the real chunker would emit), so
+        # the strict contract is preserved for it.
+        {
+            **_chunk(b2, 1),
+            "_source_span": {"start": b2_start, "end": b2_start + len(b2)},
+        },
+    ]
+
+    # Must not raise even with the strict span contract.
+    backfill_chunk_sidecars(chunks, blocks_path, require_source_span=True)
+
+    assert "sidecar" not in chunks[0]  # provenance degraded for the corrupt chunk
+    assert _refs(chunks[1]) == ["b2"]  # clean chunk still resolves
+
+
+@pytest.mark.offline
+def test_replacement_char_chunk_skipped_in_text_fallback(tmp_path: Path) -> None:
+    # Same degradation in the non-required (text-matching) path: a U+FFFD chunk is
+    # skipped rather than raising ChunkBlockMatchError.
+    blocks_path = _write_blocks(tmp_path, [("b1", "Alpha 🚀 beta.")])
+    chunks = [_chunk("Alpha � beta.", 0)]
+
+    backfill_chunk_sidecars(chunks, blocks_path)
+
+    assert "sidecar" not in chunks[0]

--- a/uv.lock
+++ b/uv.lock
@@ -2287,7 +2287,7 @@ requires-dist = [
     { name = "jiter", marker = "extra == 'api'" },
     { name = "json-repair" },
     { name = "json-repair", marker = "extra == 'api'" },
-    { name = "langchain-experimental", marker = "extra == 'api'", specifier = ">=0.3,<1" },
+    { name = "langchain-experimental", marker = "extra == 'api'", specifier = ">=0.3.2,<1" },
     { name = "langchain-text-splitters", marker = "extra == 'api'", specifier = ">=0.3,<2" },
     { name = "langfuse", marker = "extra == 'observability'", specifier = ">=3.8.1" },
     { name = "lightrag-hku", extras = ["api"], marker = "extra == 'evaluation'" },


### PR DESCRIPTION
## Summary

The `P` (paragraph_semantic) chunking strategy records a `sidecar` field on each chunk that maps it back to its source block(s) in the parse-time `*.blocks.jsonl` sidecar file, enabling provenance/traceability for the multimodal pipeline and document-delete cache cleanup. The `F` (fixed token), `R` (recursive character), and `V` (semantic vector) strategies did **not** carry that provenance.

This PR makes F/R/V chunks also record a correct `sidecar` field **when a `blocks.jsonl` sidecar exists** for the document. Built-in F/R/V chunkers now carry private `_source_span` metadata through chunking and hard fallback splitting; after chunking, backfill maps those source spans to the covered block id(s) and writes them into each chunk's `sidecar`. Text matching remains only as a compatibility fallback for non-pipeline callers.

## Motivation

Provenance was only available for `P`-chunked documents. Documents parsed into the LightRAG sidecar format but chunked with F/R/V lost the chunk→block mapping, so downstream consumers couldn't trace those chunks back to source blocks.

The old text-matching fallback also became ambiguous after whitespace stripping in extremely short/repeated chunks. Carrying spans from the chunkers makes the mapping lossless for built-in pipeline paths instead of relying on heuristics to reconstruct offsets later.

## Related Issues

n/a

## Changes Made

- Add private `_source_span` emission for built-in fixed-token, recursive-character, and semantic-vector chunking paths.
- Make pipeline sidecar backfill require source spans for built-in F/R/V and default legacy fixed-token processing.
- Preserve source spans through hard fallback splits and strip `_source_span` before persisted chunk records are built.
- **Preserve spans across the hard-fallback rejoin.** `split_text_by_token_limit` regroups whole sentence units and rejoins them with `"\n\n"`, so a multi-unit slice is *not* byte-verbatim in its parent when the source separated those sentences with a single space/newline. `_child_source_span` previously used an exact `find()` and dropped the span for such slices — and because the pipeline runs backfill with `require_source_span=True`, the document was wrongly marked **FAILED**. It now falls back to a whitespace-normalized match (the same monotonic projection backfill uses) when the exact match fails; the verbatim fast path and the strict `require_source_span` contract are unchanged.
- Keep the existing whitespace-normalized text matcher as a non-required fallback.
- Document the private-API coupling in `_semantic_groups_with_spans` (it mirrors `SemanticChunker.split_text` internals) against the pinned `langchain-experimental>=0.3,<1` range, and add a **drift guard** test that compares the V mirror's grouping to the live `splitter.split_text` output so an upstream change is caught.
- Add regression tests for repeated/ambiguous text, cross-block chunks, hard split provenance (including the multi-sentence `"\n\n"`-rejoin case), and invalid/missing span failure.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Validated locally with:

- `./scripts/test.sh tests/sidecar/test_backfill.py tests/chunker/test_sidecar_backfill_integration.py tests/chunker/test_chunker_recursive_character.py tests/chunker/test_chunker_semantic_vector.py`
- `./scripts/test.sh tests/chunker tests/sidecar` (215 passed)
- `./scripts/test.sh tests/pipeline/test_pipeline_release_closure.py tests/pipeline/test_doc_status_chunk_preservation.py` (90 passed)
- `ruff check lightrag/chunker/token_size.py lightrag/chunker/recursive_character.py lightrag/chunker/semantic_vector.py lightrag/sidecar/backfill.py lightrag/utils.py lightrag/utils_pipeline.py tests/sidecar/test_backfill.py tests/chunker/test_sidecar_backfill_integration.py tests/chunker/test_chunker_recursive_character.py tests/chunker/test_chunker_semantic_vector.py`
