### PR TITLE
🔧 chore(neo4j): drop @final from Neo4JStorage to allow subclassing

### DIFF
--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -1,6 +1,7 @@
 import os
 import re
 from dataclasses import dataclass
+
 # from typing import final
 import configparser
 

--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -1,7 +1,7 @@
 import os
 import re
 from dataclasses import dataclass
-from typing import final
+# from typing import final
 import configparser
 
 
@@ -61,7 +61,7 @@ READ_RETRY = retry(
 )
 
 
-@final
+# @final (removed per request in Issue #3130)
 @dataclass
 class Neo4JStorage(BaseGraphStorage):
     def __init__(self, namespace, global_config, embedding_func, workspace=None):


### PR DESCRIPTION
## Description

Removes the `@final` decorator (and its now-unused `typing.final` import) from `Neo4JStorage`. The decorator previously prevented subclassing, forcing production users to monkey-patch the class. Lifting it lets users subclass `Neo4JStorage` to inject their own managed driver (e.g. an AuraDB connection pool) through clean inheritance instead.

## Related Issues

Addresses the third ask in #3130 ("Is there appetite to additionally drop `@final` from `Neo4JStorage` so production users can subclass to inject a managed driver instead of monkey-patching?").

## Changes Made

- Removed the `@final` class decorator from `Neo4JStorage` in `lightrag/kg/neo4j_impl.py`.
- Removed the now-unused `from typing import final` import.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

This is a minimal, backward-compatible change: it only relaxes a subclassing restriction and does not alter any runtime behavior of `Neo4JStorage`. The broader read-path scaling work discussed in #3130 (bounded edge fanout, top-K denormalization) is intentionally out of scope and would land as separate PRs.
