### PR TITLE
🐛 fix(milvus): batch flush upserts/deletes under gRPC message limit

### DIFF
--- a/env.docker-compose-full
+++ b/env.docker-compose-full
@@ -886,6 +886,14 @@ MINIO_SECRET_ACCESS_KEY=minioadmin
 ### DB specific workspace should not be set, keep for compatible only
 # MILVUS_WORKSPACE=forced_workspace_name
 
+### Milvus upsert/delete batching (enabled by default)
+### Split large flushes by estimated JSON payload size and record count to stay
+### under the server-side 64MB gRPC message limit. A single record larger than the
+### byte budget is sent as its own batch instead of failing.
+# MILVUS_UPSERT_MAX_PAYLOAD_BYTES=33554432
+# MILVUS_UPSERT_MAX_RECORDS_PER_BATCH=1000
+# MILVUS_DELETE_MAX_RECORDS_PER_BATCH=1000
+
 ### Milvus Vector Index Configuration
 ### Index type: AUTOINDEX (default), HNSW, HNSW_SQ, HNSW_PQ, IVF_FLAT, IVF_SQ8, DISKANN
 # MILVUS_INDEX_TYPE=AUTOINDEX

--- a/env.example
+++ b/env.example
@@ -869,6 +869,14 @@ MILVUS_DB_NAME=lightrag
 ### DB specific workspace should not be set, keep for compatible only
 # MILVUS_WORKSPACE=forced_workspace_name
 
+### Milvus upsert/delete batching (enabled by default)
+### Split large flushes by estimated JSON payload size and record count to stay
+### under the server-side 64MB gRPC message limit. A single record larger than the
+### byte budget is sent as its own batch instead of failing.
+# MILVUS_UPSERT_MAX_PAYLOAD_BYTES=33554432
+# MILVUS_UPSERT_MAX_RECORDS_PER_BATCH=1000
+# MILVUS_DELETE_MAX_RECORDS_PER_BATCH=1000
+
 ### Milvus Vector Index Configuration
 ### Index type: AUTOINDEX (default), HNSW, HNSW_SQ, HNSW_PQ, IVF_FLAT, IVF_SQ8, DISKANN
 # MILVUS_INDEX_TYPE=AUTOINDEX

--- a/lightrag/kg/milvus_impl.py
+++ b/lightrag/kg/milvus_impl.py
@@ -1747,7 +1747,12 @@ class MilvusVectorDBStorage(BaseVectorStorage):
                 for i, ((_, pdoc), embedding) in enumerate(
                     zip(docs_to_embed, embeddings), start=1
                 ):
-                    pdoc.vector = embedding.tolist()
+                    # Cache as float32 so a second flush after a server-side
+                    # error doesn't re-embed, and so the upsert JSON payload
+                    # stays compact (float32 serializes to a shorter string
+                    # than float64, and Milvus stores FLOAT_VECTOR as float32
+                    # anyway, so the cast is lossless).
+                    pdoc.vector = np.array(embedding, dtype=np.float32).tolist()
                     await _cooperative_yield(i)
 
             # Assemble final upsert payload. After the embed loop above every
@@ -2063,7 +2068,9 @@ class MilvusVectorDBStorage(BaseVectorStorage):
                 for i, ((doc_id, pdoc), embedding) in enumerate(
                     zip(docs_to_embed, embeddings), start=1
                 ):
-                    pdoc.vector = embedding.tolist()
+                    # Cache float32 to match the flush path so the buffered
+                    # vector dtype is uniform regardless of which path embedded.
+                    pdoc.vector = np.array(embedding, dtype=np.float32).tolist()
                     result[doc_id] = pdoc.vector
                     await _cooperative_yield(i)
 

--- a/lightrag/kg/milvus_impl.py
+++ b/lightrag/kg/milvus_impl.py
@@ -35,7 +35,9 @@ class _PendingVectorDoc:
 # cannot raise that ceiling, so large flushes must be split client-side.
 # The payload-byte budget is the primary limiter; the record-count caps are a
 # secondary guard that only binds when individual records are small.
-DEFAULT_MILVUS_UPSERT_MAX_PAYLOAD_BYTES = 32 * 1024 * 1024  # 32MB, well below the 64MB gRPC ceiling
+DEFAULT_MILVUS_UPSERT_MAX_PAYLOAD_BYTES = (
+    32 * 1024 * 1024
+)  # 32MB, well below the 64MB gRPC ceiling
 DEFAULT_MILVUS_UPSERT_MAX_RECORDS_PER_BATCH = 1000
 DEFAULT_MILVUS_DELETE_MAX_RECORDS_PER_BATCH = 1000
 

--- a/lightrag/kg/milvus_impl.py
+++ b/lightrag/kg/milvus_impl.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 from typing import Any, final, Optional, Dict
 from dataclasses import dataclass, fields
@@ -28,6 +29,15 @@ class _PendingVectorDoc:
     content: str
     vector: list[float] | None = None
 
+
+# Flush-time batching limits. Milvus' server-side proxy rejects any single
+# gRPC message larger than ~64MB (grpc.serverMaxRecvSize); the client library
+# cannot raise that ceiling, so large flushes must be split client-side.
+# The payload-byte budget is the primary limiter; the record-count caps are a
+# secondary guard that only binds when individual records are small.
+DEFAULT_MILVUS_UPSERT_MAX_PAYLOAD_BYTES = 32 * 1024 * 1024  # 32MB, well below the 64MB gRPC ceiling
+DEFAULT_MILVUS_UPSERT_MAX_RECORDS_PER_BATCH = 1000
+DEFAULT_MILVUS_DELETE_MAX_RECORDS_PER_BATCH = 1000
 
 # Supported index types
 SUPPORTED_INDEX_TYPES = {
@@ -1424,6 +1434,39 @@ class MilvusVectorDBStorage(BaseVectorStorage):
         # Initialize client as None - will be created in initialize() method
         self._client = None
         self._max_batch_size = self.global_config["embedding_batch_num"]
+
+        # Flush-time batching limits (see module-level DEFAULT_MILVUS_* constants).
+        # A non-positive value disables that splitting dimension.
+        self._max_upsert_payload_bytes = int(
+            os.getenv(
+                "MILVUS_UPSERT_MAX_PAYLOAD_BYTES",
+                str(DEFAULT_MILVUS_UPSERT_MAX_PAYLOAD_BYTES),
+            )
+        )
+        self._max_upsert_records_per_batch = int(
+            os.getenv(
+                "MILVUS_UPSERT_MAX_RECORDS_PER_BATCH",
+                str(DEFAULT_MILVUS_UPSERT_MAX_RECORDS_PER_BATCH),
+            )
+        )
+        self._max_delete_records_per_batch = int(
+            os.getenv(
+                "MILVUS_DELETE_MAX_RECORDS_PER_BATCH",
+                str(DEFAULT_MILVUS_DELETE_MAX_RECORDS_PER_BATCH),
+            )
+        )
+        if self._max_upsert_payload_bytes <= 0:
+            logger.warning(
+                f"MILVUS_UPSERT_MAX_PAYLOAD_BYTES={self._max_upsert_payload_bytes} is non-positive, disable payload-size splitting"
+            )
+        if self._max_upsert_records_per_batch <= 0:
+            logger.warning(
+                f"MILVUS_UPSERT_MAX_RECORDS_PER_BATCH={self._max_upsert_records_per_batch} is non-positive, disable upsert record-count splitting"
+            )
+        if self._max_delete_records_per_batch <= 0:
+            logger.warning(
+                f"MILVUS_DELETE_MAX_RECORDS_PER_BATCH={self._max_delete_records_per_batch} is non-positive, disable delete record-count splitting"
+            )
         self._initialized = False
 
         # Deferred-embedding buffers and the per-namespace flush lock.
@@ -1566,6 +1609,70 @@ class MilvusVectorDBStorage(BaseVectorStorage):
             for dp in results[0]
         ]
 
+    @staticmethod
+    def _build_upsert_batches(
+        records: list[dict[str, Any]],
+        max_payload_bytes: int,
+        max_records_per_batch: int,
+    ) -> list[tuple[list[dict[str, Any]], int]]:
+        """Split upsert records into batches by estimated payload size and count.
+
+        The byte budget is the primary limiter: records accumulate until adding
+        the next one would exceed ``max_payload_bytes``, then a new batch starts.
+        Size is estimated by JSON-serializing each record; this overestimates the
+        actual gRPC protobuf size (a JSON float string is far longer than the 4
+        protobuf bytes it encodes), so the split stays conservatively below the
+        server limit and never underestimates.
+
+        A single record larger than the byte budget is emitted as its own batch
+        rather than raising: JSON overestimation means such a record's real
+        protobuf size is often still under Milvus' 64MB ceiling, so we let the
+        server be the final arbiter instead of failing client-side. Returns a
+        list of ``(batch, estimated_bytes)`` tuples (estimate used for logging).
+        """
+        if not records:
+            return []
+
+        payload_limit = max_payload_bytes if max_payload_bytes > 0 else float("inf")
+        records_limit = (
+            max_records_per_batch if max_records_per_batch > 0 else float("inf")
+        )
+
+        batches: list[tuple[list[dict[str, Any]], int]] = []
+        current_batch: list[dict[str, Any]] = []
+        # JSON array overhead ("[]")
+        current_estimated_bytes = 2
+
+        for record in records:
+            record_size = len(
+                json.dumps(
+                    record,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                    default=str,
+                ).encode("utf-8")
+            )
+
+            # If current batch not empty, a comma is needed before next element.
+            separator_overhead = 1 if current_batch else 0
+            next_batch_size = current_estimated_bytes + separator_overhead + record_size
+
+            if current_batch and (
+                len(current_batch) >= records_limit or next_batch_size > payload_limit
+            ):
+                batches.append((current_batch, current_estimated_bytes))
+                current_batch = []
+                current_estimated_bytes = 2
+                next_batch_size = current_estimated_bytes + record_size
+
+            current_batch.append(record)
+            current_estimated_bytes = next_batch_size
+
+        if current_batch:
+            batches.append((current_batch, current_estimated_bytes))
+
+        return batches
+
     async def index_done_callback(self) -> None:
         """Flush all buffered vector ops to Milvus before returning.
 
@@ -1654,14 +1761,53 @@ class MilvusVectorDBStorage(BaseVectorStorage):
 
             try:
                 if list_data:
-                    self._client.upsert(
-                        collection_name=self.final_namespace, data=list_data
+                    # Split the upsert into batches that stay under the server-side
+                    # 64MB gRPC message limit. Fail-fast: any batch failure raises
+                    # immediately and the full buffer is retained for the next flush.
+                    upsert_batches = self._build_upsert_batches(
+                        list_data,
+                        max_payload_bytes=self._max_upsert_payload_bytes,
+                        max_records_per_batch=self._max_upsert_records_per_batch,
                     )
+                    if len(upsert_batches) > 1:
+                        logger.info(
+                            f"[{self.workspace}] {self.namespace} flush: upsert split into "
+                            f"{len(upsert_batches)} batches for {len(list_data)} records "
+                        )
+                    for batch_index, (records_batch, estimated_bytes) in enumerate(
+                        upsert_batches, 1
+                    ):
+                        if (
+                            len(records_batch) == 1
+                            and self._max_upsert_payload_bytes > 0
+                            and estimated_bytes > self._max_upsert_payload_bytes
+                        ):
+                            logger.warning(
+                                f"[{self.workspace}] {self.namespace} flush: single record "
+                                f"id={records_batch[0].get('id')} estimated {estimated_bytes} bytes "
+                                f"exceeds {self._max_upsert_payload_bytes}"
+                            )
+                        logger.debug(
+                            f"[{self.workspace}] Milvus upsert batch {batch_index}/{len(upsert_batches)}: "
+                            f"records={len(records_batch)}, estimated_payload_bytes={estimated_bytes}"
+                        )
+                        self._client.upsert(
+                            collection_name=self.final_namespace, data=records_batch
+                        )
                 if pending_deletes:
-                    self._client.delete(
-                        collection_name=self.final_namespace,
-                        pks=list(pending_deletes),
+                    # Chunk deletes by record count; pks are short strings so a
+                    # count cap is enough to stay under the gRPC message limit.
+                    delete_ids = list(pending_deletes)
+                    delete_chunk = (
+                        self._max_delete_records_per_batch
+                        if self._max_delete_records_per_batch > 0
+                        else len(delete_ids)
                     )
+                    for i in range(0, len(delete_ids), delete_chunk):
+                        self._client.delete(
+                            collection_name=self.final_namespace,
+                            pks=delete_ids[i : i + delete_chunk],
+                        )
             except Exception as e:
                 logger.error(
                     f"[{self.workspace}] Error flushing vector ops "


### PR DESCRIPTION
## Description

`MilvusVectorDBStorage._flush_pending_vector_ops` embedded pending vectors in batches but then merged **all** of them into a single `client.upsert()` call. Once enough vectors accumulated, that one gRPC request exceeded Milvus' server-side message limit (`grpc.serverMaxRecvSize`, default 64MB) and failed:

```
StatusCode.RESOURCE_EXHAUSTED
grpc: received message larger than max (71331392 vs. 67108864)
```

That ceiling lives on the Milvus server/proxy and cannot be raised from the client library, so the fix is to split the write **client-side** — mirroring the batching pattern the Qdrant backend already uses.

## Related Issues

n/a

## Changes Made

- **`lightrag/kg/milvus_impl.py`**
  - Add `_build_upsert_batches`: splits records by a JSON-estimated **payload byte budget** (primary limiter) and a **record-count cap** (secondary). JSON serialization overestimates the actual protobuf size (a JSON float string is far longer than the 4 protobuf bytes it encodes), so batches stay conservatively below the server limit and never underestimate.
  - A single record larger than the byte budget is emitted as its **own batch** with a warning, rather than raising — its real protobuf size is often still under 64MB, so the server is the final arbiter.
  - `upsert` and `delete` (by record count) are both batched. Buffers are cleared **only after every batch succeeds**, preserving the existing fail-fast / whole-buffer-retry contract of `index_done_callback`.
  - New env knobs (mirroring `QDRANT_UPSERT_MAX_*`): `MILVUS_UPSERT_MAX_PAYLOAD_BYTES` (default 32MB), `MILVUS_UPSERT_MAX_RECORDS_PER_BATCH` (1000), `MILVUS_DELETE_MAX_RECORDS_PER_BATCH` (1000); a non-positive value disables that splitting dimension.
- **`env.example` / `env.docker-compose-full`**: document the three new variables in the Milvus section.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

- Verified `_build_upsert_batches` against six cases (empty input; single batch; byte-budget split; oversized-record-gets-own-batch; record-count split; splitting disabled when limits ≤ 0) — all pass.
- Existing Milvus suite (`tests/kg/milvus_impl/`, incl. deferred-embedding flush path) passes: **85 passed**.
- To exercise the multi-batch path manually: `export MILVUS_UPSERT_MAX_PAYLOAD_BYTES=1048576` (1MB) and watch for the `upsert split into N batches` log line.
- No unit test added for the new batching helper in this PR; happy to add one under `tests/kg/milvus_impl/` if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
