### PR TITLE
🐛 fix(qdrant): resilient flush — own-batch oversized points, batch deletes

### DIFF
--- a/env.docker-compose-full
+++ b/env.docker-compose-full
@@ -921,11 +921,14 @@ MINIO_SECRET_ACCESS_KEY=minioadmin
 QDRANT_URL=http://localhost:6333
 # QDRANT_DEVICE=cpu
 # QDRANT_API_KEY=your-api-key
-### Qdrant upsert batching (enabled by default)
-### Split large upserts by estimated JSON payload size and point count
-### Default 16MB keeps safe headroom below common 32MB gateway/request limits
+### Qdrant upsert/delete batching (enabled by default)
+### Split large upserts by estimated JSON payload size and point count, and
+### large deletes by point count, to stay under the server/gateway request limit.
+### Default 16MB keeps safe headroom below common 32MB gateway/request limits.
+### A single point larger than the byte budget is sent as its own batch instead of failing.
 # QDRANT_UPSERT_MAX_PAYLOAD_BYTES=16777216
 # QDRANT_UPSERT_MAX_POINTS_PER_BATCH=128
+# QDRANT_DELETE_MAX_POINTS_PER_BATCH=1000
 ### DB specific workspace should not be set, keep for compatible only
 # QDRANT_WORKSPACE=forced_workspace_name
 

--- a/env.example
+++ b/env.example
@@ -904,11 +904,14 @@ MILVUS_DB_NAME=lightrag
 QDRANT_URL=http://localhost:6333
 # QDRANT_DEVICE=cpu
 # QDRANT_API_KEY=your-api-key
-### Qdrant upsert batching (enabled by default)
-### Split large upserts by estimated JSON payload size and point count
-### Default 16MB keeps safe headroom below common 32MB gateway/request limits
+### Qdrant upsert/delete batching (enabled by default)
+### Split large upserts by estimated JSON payload size and point count, and
+### large deletes by point count, to stay under the server/gateway request limit.
+### Default 16MB keeps safe headroom below common 32MB gateway/request limits.
+### A single point larger than the byte budget is sent as its own batch instead of failing.
 # QDRANT_UPSERT_MAX_PAYLOAD_BYTES=16777216
 # QDRANT_UPSERT_MAX_POINTS_PER_BATCH=128
+# QDRANT_DELETE_MAX_POINTS_PER_BATCH=1000
 ### DB specific workspace should not be set, keep for compatible only
 # QDRANT_WORKSPACE=forced_workspace_name
 

--- a/lightrag/kg/qdrant_impl.py
+++ b/lightrag/kg/qdrant_impl.py
@@ -37,6 +37,7 @@ CREATED_AT_FIELD = "created_at"
 ID_FIELD = "id"
 DEFAULT_QDRANT_UPSERT_MAX_PAYLOAD_BYTES = 16 * 1024 * 1024  # 16MB
 DEFAULT_QDRANT_UPSERT_MAX_POINTS_PER_BATCH = 128
+DEFAULT_QDRANT_DELETE_MAX_POINTS_PER_BATCH = 1000
 
 config = configparser.ConfigParser()
 config.read("config.ini", "utf-8")
@@ -485,6 +486,12 @@ class QdrantVectorDBStorage(BaseVectorStorage):
                 str(DEFAULT_QDRANT_UPSERT_MAX_POINTS_PER_BATCH),
             )
         )
+        self._max_delete_points_per_batch = int(
+            os.getenv(
+                "QDRANT_DELETE_MAX_POINTS_PER_BATCH",
+                str(DEFAULT_QDRANT_DELETE_MAX_POINTS_PER_BATCH),
+            )
+        )
         if self._max_upsert_payload_bytes <= 0:
             logger.warning(
                 f"QDRANT_UPSERT_MAX_PAYLOAD_BYTES={self._max_upsert_payload_bytes} is non-positive, disable payload-size splitting"
@@ -492,6 +499,10 @@ class QdrantVectorDBStorage(BaseVectorStorage):
         if self._max_upsert_points_per_batch <= 0:
             logger.warning(
                 f"QDRANT_UPSERT_MAX_POINTS_PER_BATCH={self._max_upsert_points_per_batch} is non-positive, disable point-count splitting"
+            )
+        if self._max_delete_points_per_batch <= 0:
+            logger.warning(
+                f"QDRANT_DELETE_MAX_POINTS_PER_BATCH={self._max_delete_points_per_batch} is non-positive, disable delete point-count splitting"
             )
         self._initialized = False
 
@@ -544,7 +555,17 @@ class QdrantVectorDBStorage(BaseVectorStorage):
         max_payload_bytes: int,
         max_points_per_batch: int,
     ) -> list[tuple[list[models.PointStruct], int]]:
-        """Split points into batches using payload size and point count limits."""
+        """Split points into batches using payload size and point count limits.
+
+        The byte budget is the primary limiter; the point count is a secondary
+        guard. A single point larger than the byte budget is emitted as its own
+        single-point batch rather than raising: the JSON estimate is
+        conservative (and the default budget sits well below the real
+        server/gateway limit), so the request may still be accepted. Leaving the
+        server as the final arbiter avoids failing the entire flush over one
+        oversized point, which would also block every healthy point buffered
+        alongside it from ever committing.
+        """
         if not points:
             return []
 
@@ -560,15 +581,6 @@ class QdrantVectorDBStorage(BaseVectorStorage):
 
         for point in points:
             point_size = QdrantVectorDBStorage._estimate_point_payload_bytes(point)
-            point_with_array_overhead = point_size + 2
-            point_id = str(point.id)
-
-            if point_with_array_overhead > payload_limit:
-                raise ValueError(
-                    f"Single Qdrant point exceeds payload limit: id={point_id}, "
-                    f"estimated_bytes={point_with_array_overhead}, "
-                    f"limit={int(payload_limit)}"
-                )
 
             # If current batch not empty, a comma is needed before next element.
             separator_overhead = 1 if current_batch else 0
@@ -837,6 +849,17 @@ class QdrantVectorDBStorage(BaseVectorStorage):
                     for batch_index, (points_batch, estimated_bytes) in enumerate(
                         point_batches, 1
                     ):
+                        if (
+                            len(points_batch) == 1
+                            and self._max_upsert_payload_bytes > 0
+                            and estimated_bytes > self._max_upsert_payload_bytes
+                        ):
+                            logger.warning(
+                                f"[{self.workspace}] {self.namespace} flush: single point "
+                                f"id={points_batch[0].id} estimated {estimated_bytes} bytes "
+                                f"exceeds QDRANT_UPSERT_MAX_PAYLOAD_BYTES="
+                                f"{self._max_upsert_payload_bytes}; sending as its own batch"
+                            )
                         logger.debug(
                             f"[{self.workspace}] Qdrant upsert batch {batch_index}/{len(point_batches)}: "
                             f"points={len(points_batch)}, estimated_payload_bytes={estimated_bytes}"
@@ -857,11 +880,21 @@ class QdrantVectorDBStorage(BaseVectorStorage):
                         )
                         for doc_id in pending_deletes
                     ]
-                    self._client.delete(
-                        collection_name=self.final_namespace,
-                        points_selector=models.PointIdsList(points=qdrant_delete_ids),
-                        wait=True,
+                    # Chunk deletes by point count; ids are short so a count cap
+                    # is enough to keep each request under the server limit.
+                    delete_chunk = (
+                        self._max_delete_points_per_batch
+                        if self._max_delete_points_per_batch > 0
+                        else len(qdrant_delete_ids)
                     )
+                    for i in range(0, len(qdrant_delete_ids), delete_chunk):
+                        self._client.delete(
+                            collection_name=self.final_namespace,
+                            points_selector=models.PointIdsList(
+                                points=qdrant_delete_ids[i : i + delete_chunk]
+                            ),
+                            wait=True,
+                        )
             except Exception as e:
                 logger.error(
                     f"[{self.workspace}] Error flushing vector ops "

--- a/tests/kg/qdrant_impl/test_qdrant_deferred_embedding.py
+++ b/tests/kg/qdrant_impl/test_qdrant_deferred_embedding.py
@@ -98,6 +98,7 @@ def _make_storage(
     storage._max_batch_size = 10
     storage._max_upsert_payload_bytes = 16 * 1024 * 1024
     storage._max_upsert_points_per_batch = 128
+    storage._max_delete_points_per_batch = 1000
     storage._pending_vector_docs = {}
     storage._pending_vector_deletes = set()
 

--- a/tests/kg/qdrant_impl/test_qdrant_upsert_batching.py
+++ b/tests/kg/qdrant_impl/test_qdrant_upsert_batching.py
@@ -52,17 +52,46 @@ def test_build_upsert_batches_exact_payload_boundary_no_split():
     assert batches[0][1] == exact_limit
 
 
-def test_build_upsert_batches_raises_for_single_oversized_point():
+def test_build_upsert_batches_single_oversized_point_gets_own_batch():
+    """An oversized point is emitted as its own batch rather than raising.
+
+    Failing here would poison the whole flush; instead the server is left as
+    the final arbiter on whether the (conservatively estimated) point fits.
+    """
     point = _make_point("oversized", "x" * 64)
     point_size = QdrantVectorDBStorage._estimate_point_payload_bytes(point)
-    too_small_limit = point_size + 1
+    too_small_limit = point_size - 1
 
-    with pytest.raises(ValueError, match="Single Qdrant point exceeds payload limit"):
-        QdrantVectorDBStorage._build_upsert_batches(
-            [point],
-            max_payload_bytes=too_small_limit,
-            max_points_per_batch=128,
-        )
+    batches = QdrantVectorDBStorage._build_upsert_batches(
+        [point],
+        max_payload_bytes=too_small_limit,
+        max_points_per_batch=128,
+    )
+
+    assert len(batches) == 1
+    assert len(batches[0][0]) == 1
+    assert batches[0][0][0].id == "oversized"
+
+
+def test_build_upsert_batches_isolates_oversized_point_between_normal_ones():
+    """A mid-stream oversized point lands alone; neighbors are not polluted."""
+    small_a = _make_point("a", "x" * 4)
+    huge = _make_point("HUGE", "x" * 4096)
+    small_b = _make_point("b", "y" * 4)
+
+    # Budget fits a small point but not the huge one.
+    budget = QdrantVectorDBStorage._estimate_point_payload_bytes(small_a) + 16
+
+    batches = QdrantVectorDBStorage._build_upsert_batches(
+        [small_a, huge, small_b],
+        max_payload_bytes=budget,
+        max_points_per_batch=128,
+    )
+
+    huge_batches = [b for b, _ in batches if any(p.id == "HUGE" for p in b)]
+    assert len(huge_batches) == 1 and len(huge_batches[0]) == 1
+    # No point is dropped.
+    assert sum(len(b) for b, _ in batches) == 3
 
 
 @pytest.mark.asyncio
@@ -110,3 +139,34 @@ async def test_flush_fail_fast_stops_on_first_failed_batch():
     assert len(second_call.kwargs["points"]) == 2
     # Buffer is preserved so the next flush can retry.
     assert len(storage._pending_vector_docs) == 5
+
+
+@pytest.mark.asyncio
+async def test_flush_chunks_deletes_by_point_count():
+    """Deletes are split into chunks of at most _max_delete_points_per_batch."""
+    storage = QdrantVectorDBStorage.__new__(QdrantVectorDBStorage)
+    storage.workspace = "test_ws"
+    storage.namespace = "chunks"
+    storage.effective_workspace = "test_ws"
+    storage.meta_fields = {"content"}
+    storage._max_batch_size = 16
+    storage._max_upsert_payload_bytes = 1024 * 1024
+    storage._max_upsert_points_per_batch = 128
+    storage._max_delete_points_per_batch = 2
+    storage.final_namespace = "test_collection"
+    storage._client = MagicMock()
+    storage._pending_vector_docs = {}
+    storage._pending_vector_deletes = {f"chunk-{i}" for i in range(5)}
+    storage._flush_lock = asyncio.Lock()
+
+    await storage._flush_pending_vector_ops()
+
+    # 5 delete ids with max 2 per batch => 3 delete calls.
+    assert storage._client.delete.call_count == 3
+    chunk_sizes = sorted(
+        len(call.kwargs["points_selector"].points)
+        for call in storage._client.delete.call_args_list
+    )
+    assert chunk_sizes == [1, 2, 2]
+    # Buffer cleared on success.
+    assert len(storage._pending_vector_deletes) == 0


### PR DESCRIPTION
## Description

While adding flush batching to the Milvus backend (#3164), the same review surfaced two robustness gaps in `QdrantVectorDBStorage._flush_pending_vector_ops`. This PR brings Qdrant's flush in line with the more resilient Milvus behavior.

1. **A single oversized point poisoned the entire flush.** `_build_upsert_batches` raised `ValueError` when one point exceeded the upsert payload budget. That call sits inside the flush's `try` block, so the error was re-raised and the buffer retained — meaning **every** subsequent `index_done_callback` retry hit the same point and failed again, permanently blocking all healthy points buffered alongside it from ever committing. The conservative default budget (16MB, deliberately below the ~32MB server/gateway limit) made this reachable even for points the server would have accepted.
2. **Deletes were not batched.** All delete ids were sent in a single `client.delete()` call, so a very large delete set could exceed the request limit — the same class of failure the upsert batching already guards against.

## Related Issues

#XXXX (follow-up to #3164)

## Changes Made

- **`lightrag/kg/qdrant_impl.py`**
  - `_build_upsert_batches`: a point larger than the byte budget is now emitted as its **own single-point batch** instead of raising. The JSON size estimate is conservative, so such a request may still succeed; the server is left as the final arbiter rather than failing the whole flush.
  - Flush emits a `warning` when a single point is sent over-budget on its own (mirroring the Milvus backend), so oversized records stay visible in logs.
  - Deletes are chunked by point count via the new `QDRANT_DELETE_MAX_POINTS_PER_BATCH` env var (default 1000; a non-positive value disables splitting), mirroring the existing `QDRANT_UPSERT_MAX_*` knobs.
  - Buffers are still cleared only after **every** batch succeeds — the fail-fast / whole-buffer-retry contract is unchanged.
- **`env.example` / `env.docker-compose-full`**: document `QDRANT_DELETE_MAX_POINTS_PER_BATCH` and the new own-batch behavior in the Qdrant section.
- **Tests**: replaced the unit test that asserted the old `raise` behavior with one asserting the oversized point gets its own batch; added coverage for isolating a mid-stream oversized point (neighbors not polluted) and for delete chunking.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

- `tests/kg/qdrant_impl/` passes: **32 passed**.
- Note on the Qdrant transport: the client uses REST/HTTP (JSON), so the JSON byte estimate closely matches the real request size. A point above the *server's actual* limit will still be rejected by the server — but (a) the conservative 16MB default leaves a band where the own-batch point now succeeds, and (b) more importantly, one oversized point no longer holds the entire buffer hostage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
