### PR TITLE
🔧 fix(milvus): shrink upsert batch count to 128 (align with Qdrant)

### DIFF
--- a/env.docker-compose-full
+++ b/env.docker-compose-full
@@ -891,7 +891,7 @@ MINIO_SECRET_ACCESS_KEY=minioadmin
 ### under the server-side 64MB gRPC message limit. A single record larger than the
 ### byte budget is sent as its own batch instead of failing.
 # MILVUS_UPSERT_MAX_PAYLOAD_BYTES=33554432
-# MILVUS_UPSERT_MAX_RECORDS_PER_BATCH=1000
+# MILVUS_UPSERT_MAX_RECORDS_PER_BATCH=128
 # MILVUS_DELETE_MAX_RECORDS_PER_BATCH=1000
 
 ### Milvus Vector Index Configuration

--- a/env.example
+++ b/env.example
@@ -874,7 +874,7 @@ MILVUS_DB_NAME=lightrag
 ### under the server-side 64MB gRPC message limit. A single record larger than the
 ### byte budget is sent as its own batch instead of failing.
 # MILVUS_UPSERT_MAX_PAYLOAD_BYTES=33554432
-# MILVUS_UPSERT_MAX_RECORDS_PER_BATCH=1000
+# MILVUS_UPSERT_MAX_RECORDS_PER_BATCH=128
 # MILVUS_DELETE_MAX_RECORDS_PER_BATCH=1000
 
 ### Milvus Vector Index Configuration

--- a/lightrag/kg/milvus_impl.py
+++ b/lightrag/kg/milvus_impl.py
@@ -35,10 +35,13 @@ class _PendingVectorDoc:
 # cannot raise that ceiling, so large flushes must be split client-side.
 # The payload-byte budget is the primary limiter; the record-count caps are a
 # secondary guard that only binds when individual records are small.
+# Upsert and delete have separate count caps on purpose: upsert records each
+# carry a full embedding vector and are far heavier than delete pks, so the
+# upsert batch count is kept much smaller than the delete one.
 DEFAULT_MILVUS_UPSERT_MAX_PAYLOAD_BYTES = (
     32 * 1024 * 1024
 )  # 32MB, well below the 64MB gRPC ceiling
-DEFAULT_MILVUS_UPSERT_MAX_RECORDS_PER_BATCH = 1000
+DEFAULT_MILVUS_UPSERT_MAX_RECORDS_PER_BATCH = 128
 DEFAULT_MILVUS_DELETE_MAX_RECORDS_PER_BATCH = 1000
 
 # Supported index types


### PR DESCRIPTION
## Description

Follow-up to the Milvus (#3164) and Qdrant (#3165) flush-batching work. The Milvus backend already defined **separate** record-count caps for upsert and delete, but both defaulted to `1000`. Upsert records each carry a full embedding vector and are far heavier than delete pks (plain id strings), so a 1000-record upsert batch is much larger than a 1000-pk delete batch. The Qdrant backend already reflects this asymmetry (upsert `128` / delete `1000`); this PR brings Milvus in line.

## Related Issues

#XXXX (follow-up to #3164, #3165)

## Changes Made

- **`lightrag/kg/milvus_impl.py`**: lower `DEFAULT_MILVUS_UPSERT_MAX_RECORDS_PER_BATCH` from `1000` to `128`; `DEFAULT_MILVUS_DELETE_MAX_RECORDS_PER_BATCH` stays `1000`. Added a comment explaining why the two caps differ.
- **`env.example` / `env.docker-compose-full`**: update the documented `MILVUS_UPSERT_MAX_RECORDS_PER_BATCH` default to `128`.

The payload-byte budget (`MILVUS_UPSERT_MAX_PAYLOAD_BYTES`, 32MB) remains the **primary** limiter; this change only makes the secondary count cap reflect per-record weight, so very large vectors are split into smaller, more predictable batches.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

- `tests/kg/milvus_impl/` passes: **85 passed**. No test pinned the old `1000` default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
