### PR TITLE
feat(mongo): batch bulk_write upserts/deletes across all MongoDB storage paths

### DIFF
--- a/env.example
+++ b/env.example
@@ -828,7 +828,8 @@ MONGO_URI=mongodb://localhost:27017/
 MONGO_DATABASE=LightRAG
 ### DB specific workspace should not be set, keep for compatible only
 # MONGODB_WORKSPACE=forced_workspace_name
-# Flush-time batching limits for MongoVectorDBStorage (non-positive disables that dimension)
+# Flush-time bulk_write batching limits for MongoDB upsert paths (KV, vector, graph).
+# (non-positive disables that dimension; DELETE cap applies to MongoVectorDBStorage)
 # MONGO_UPSERT_MAX_PAYLOAD_BYTES=16777216
 # MONGO_UPSERT_MAX_RECORDS_PER_BATCH=128
 # MONGO_DELETE_MAX_RECORDS_PER_BATCH=1000

--- a/env.example
+++ b/env.example
@@ -828,6 +828,10 @@ MONGO_URI=mongodb://localhost:27017/
 MONGO_DATABASE=LightRAG
 ### DB specific workspace should not be set, keep for compatible only
 # MONGODB_WORKSPACE=forced_workspace_name
+# Flush-time batching limits for MongoVectorDBStorage (non-positive disables that dimension)
+# MONGO_UPSERT_MAX_PAYLOAD_BYTES=16777216
+# MONGO_UPSERT_MAX_RECORDS_PER_BATCH=128
+# MONGO_DELETE_MAX_RECORDS_PER_BATCH=1000
 
 # Community/local Docker MongoDB example for KV, graph, or doc-status storage only:
 # MONGO_URI=mongodb://localhost:27017/

--- a/lightrag/kg/milvus_impl.py
+++ b/lightrag/kg/milvus_impl.py
@@ -1783,6 +1783,7 @@ class MilvusVectorDBStorage(BaseVectorStorage):
                         logger.info(
                             f"[{self.workspace}] {self.namespace} flush: upsert split into "
                             f"{len(upsert_batches)} batches for {len(list_data)} records "
+                            f"(max_payload={self._max_upsert_payload_bytes} batch={self._max_upsert_records_per_batch})"
                         )
                     for batch_index, (records_batch, estimated_bytes) in enumerate(
                         upsert_batches, 1

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -62,6 +62,13 @@ def _estimate_doc_bytes(doc: Any) -> int:
     JSON overestimates the real BSON size MongoDB writes (a JSON float string is
     far longer than the 8 bytes a BSON double encodes), so callers stay
     conservatively below server limits and never underestimate.
+
+    This is a splitting *heuristic*, not the exact wire size: upsert callers pass
+    only the dominant payload field (the ``$set`` body / ``update_doc``), not the
+    full ``UpdateOne`` op (filter, ``$setOnInsert``, ``$or`` wrapper). Those extras
+    are tiny next to an embedding/document body, and the 16MB estimate budget sits
+    far under MongoDB's 48MB bulk-command limit, so the under-count is immaterial;
+    the server stays the final arbiter.
     """
     return len(
         json.dumps(doc, ensure_ascii=False, separators=(",", ":"), default=str).encode(
@@ -379,6 +386,10 @@ class MongoKVStorage(BaseKVStorage):
             )
             await _cooperative_yield(i)
 
+        # ordered=False (intentional): the old single bulk_write used pymongo's
+        # default ordered=True, but every op targets a distinct flattened _id, so
+        # the writes are order-independent. ordered=False lets the server apply
+        # them in parallel and is the right choice for idempotent upserts.
         await _run_batched_bulk_write(
             self._data,
             operations,
@@ -2829,10 +2840,10 @@ class MongoVectorDBStorage(BaseVectorStorage):
             # pending doc has a non-None vector (count-mismatch was checked),
             # so we can iterate without re-guarding. Each full_doc carries its
             # own "_id" (from source), matching the UpdateOne filter key.
-            committed_ids: list[str] = list(pending_docs.keys())
+            ids_to_commit: list[str] = list(pending_docs.keys())
             list_data: list[dict[str, Any]] = [
                 {**pending_docs[doc_id].source, "vector": pending_docs[doc_id].vector}
-                for doc_id in committed_ids
+                for doc_id in ids_to_commit
             ]
 
             try:
@@ -2905,7 +2916,7 @@ class MongoVectorDBStorage(BaseVectorStorage):
 
             # On success, clear the buffers in-place so external references
             # (e.g. drop()) see the cleared state.
-            for doc_id in committed_ids:
+            for doc_id in ids_to_commit:
                 pending_docs.pop(doc_id, None)
             pending_deletes.clear()
 

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -41,7 +41,8 @@ config.read("config.ini", "utf-8")
 
 GRAPH_BFS_MODE = os.getenv("MONGO_GRAPH_BFS_MODE", "bidirectional")
 
-# Flush-time batching limits for MongoVectorDBStorage.
+# Flush-time batching limits shared by every MongoDB upsert path
+# (MongoVectorDBStorage, MongoKVStorage, MongoGraphStorage).
 # The payload-byte budget is the primary limiter; the record-count caps are a
 # secondary guard that only binds when individual records are small.
 # Upsert and delete have separate count caps on purpose: upsert records each
@@ -53,6 +54,148 @@ GRAPH_BFS_MODE = os.getenv("MONGO_GRAPH_BFS_MODE", "bidirectional")
 DEFAULT_MONGO_UPSERT_MAX_PAYLOAD_BYTES = 16 * 1024 * 1024  # 16MB
 DEFAULT_MONGO_UPSERT_MAX_RECORDS_PER_BATCH = 128
 DEFAULT_MONGO_DELETE_MAX_RECORDS_PER_BATCH = 1000
+
+
+def _estimate_doc_bytes(doc: Any) -> int:
+    """Estimate a document's serialized byte size via compact JSON.
+
+    JSON overestimates the real BSON size MongoDB writes (a JSON float string is
+    far longer than the 8 bytes a BSON double encodes), so callers stay
+    conservatively below server limits and never underestimate.
+    """
+    return len(
+        json.dumps(
+            doc, ensure_ascii=False, separators=(",", ":"), default=str
+        ).encode("utf-8")
+    )
+
+
+def _chunk_by_budget(
+    items: list[Any],
+    size_of,
+    max_payload_bytes: int,
+    max_records_per_batch: int,
+) -> list[tuple[list[Any], int]]:
+    """Split items into batches by estimated payload size (primary) and count.
+
+    The byte budget is the primary limiter: items accumulate until adding the
+    next one would exceed ``max_payload_bytes``, then a new batch starts.
+    ``size_of(item)`` returns an item's estimated serialized byte size. A single
+    item larger than the byte budget is emitted as its own batch rather than
+    raising; the server stays the final arbiter. A non-positive limit disables
+    that dimension. Returns ``(batch, summed_estimated_bytes)`` tuples (the
+    estimate is used for logging).
+    """
+    if not items:
+        return []
+
+    payload_limit = max_payload_bytes if max_payload_bytes > 0 else float("inf")
+    records_limit = (
+        max_records_per_batch if max_records_per_batch > 0 else float("inf")
+    )
+
+    batches: list[tuple[list[Any], int]] = []
+    current: list[Any] = []
+    # JSON array overhead ("[]")
+    current_bytes = 2
+
+    for item in items:
+        item_bytes = size_of(item)
+        # If current batch not empty, a comma is needed before next element.
+        separator_overhead = 1 if current else 0
+        next_bytes = current_bytes + separator_overhead + item_bytes
+
+        if current and (
+            len(current) >= records_limit or next_bytes > payload_limit
+        ):
+            batches.append((current, current_bytes))
+            current = []
+            current_bytes = 2
+            next_bytes = current_bytes + item_bytes
+
+        current.append(item)
+        current_bytes = next_bytes
+
+    if current:
+        batches.append((current, current_bytes))
+
+    return batches
+
+
+def _resolve_upsert_batch_limits() -> tuple[int, int]:
+    """Resolve flush-time upsert batching limits from env, with module defaults.
+
+    Shared by every MongoDB upsert path so the byte/record caps that bound a
+    single ``bulk_write`` are consistent across all of them. A non-positive
+    value disables that splitting dimension.
+    """
+    max_payload_bytes = int(
+        os.getenv(
+            "MONGO_UPSERT_MAX_PAYLOAD_BYTES",
+            str(DEFAULT_MONGO_UPSERT_MAX_PAYLOAD_BYTES),
+        )
+    )
+    max_records_per_batch = int(
+        os.getenv(
+            "MONGO_UPSERT_MAX_RECORDS_PER_BATCH",
+            str(DEFAULT_MONGO_UPSERT_MAX_RECORDS_PER_BATCH),
+        )
+    )
+    if max_payload_bytes <= 0:
+        logger.warning(
+            f"MONGO_UPSERT_MAX_PAYLOAD_BYTES={max_payload_bytes} is non-positive, disable payload-size splitting"
+        )
+    if max_records_per_batch <= 0:
+        logger.warning(
+            f"MONGO_UPSERT_MAX_RECORDS_PER_BATCH={max_records_per_batch} is non-positive, disable upsert record-count splitting"
+        )
+    return max_payload_bytes, max_records_per_batch
+
+
+async def _run_batched_bulk_write(
+    collection,
+    ops: list[tuple[Any, int, str]],
+    *,
+    max_payload_bytes: int,
+    max_records_per_batch: int,
+    ordered: bool,
+    log_prefix: str,
+    what: str,
+) -> None:
+    """Execute UpdateOne ops as payload-size/record-count bounded bulk_write batches.
+
+    ``ops`` is a list of ``(operation, estimated_bytes, id_for_log)`` triples.
+    Splitting keeps each bulk command below MongoDB's 48MB message ceiling and
+    bounds the in-memory op list. Fail-fast: a batch failure raises and no
+    further batches run, so callers must treat the whole write as retryable
+    (UpdateOne(..., upsert=True) is idempotent).
+    """
+    if not ops:
+        return
+
+    batches = _chunk_by_budget(
+        ops, lambda triple: triple[1], max_payload_bytes, max_records_per_batch
+    )
+    if len(batches) > 1:
+        logger.info(
+            f"{log_prefix} {what} split into {len(batches)} batches "
+            f"for {len(ops)} records"
+        )
+    for batch_index, (batch, estimated_bytes) in enumerate(batches, 1):
+        if (
+            len(batch) == 1
+            and max_payload_bytes > 0
+            and estimated_bytes > max_payload_bytes
+        ):
+            logger.warning(
+                f"{log_prefix} {what}: single record id={batch[0][2]} "
+                f"estimated {estimated_bytes} bytes exceeds {max_payload_bytes}"
+            )
+        logger.debug(
+            f"{log_prefix} {what} batch {batch_index}/{len(batches)}: "
+            f"records={len(batch)}, estimated_payload_bytes={estimated_bytes}"
+        )
+        await collection.bulk_write([triple[0] for triple in batch], ordered=ordered)
 
 
 class ClientManager:
@@ -145,6 +288,10 @@ class MongoKVStorage(BaseKVStorage):
             )
 
         self._collection_name = self.final_namespace
+        (
+            self._max_upsert_payload_bytes,
+            self._max_upsert_records_per_batch,
+        ) = _resolve_upsert_batch_limits()
 
     async def initialize(self):
         async with get_data_init_lock():
@@ -198,10 +345,10 @@ class MongoKVStorage(BaseKVStorage):
         if not data:
             return
 
-        # Unified handling for all namespaces with flattened keys
-        # Use bulk_write for better performance
-
-        operations = []
+        # Unified handling for all namespaces with flattened keys. KV docs
+        # (full_docs, text_chunks, llm_response_cache) can be large, so the
+        # upsert is split into payload-bounded bulk_write batches.
+        operations: list[tuple[Any, int, str]] = []
         current_time = int(time.time())  # Get current Unix timestamp
 
         for i, (k, v) in enumerate(data.items(), start=1):
@@ -219,21 +366,32 @@ class MongoKVStorage(BaseKVStorage):
             v_for_set.pop("create_time", None)
 
             operations.append(
-                UpdateOne(
-                    {"_id": k},
-                    {
-                        "$set": v_for_set,  # Update all fields except create_time
-                        "$setOnInsert": {
-                            "create_time": current_time
-                        },  # Set create_time only on insert
-                    },
-                    upsert=True,
+                (
+                    UpdateOne(
+                        {"_id": k},
+                        {
+                            "$set": v_for_set,  # Update all fields except create_time
+                            "$setOnInsert": {
+                                "create_time": current_time
+                            },  # Set create_time only on insert
+                        },
+                        upsert=True,
+                    ),
+                    _estimate_doc_bytes(v_for_set),
+                    k,
                 )
             )
             await _cooperative_yield(i)
 
-        if operations:
-            await self._data.bulk_write(operations)
+        await _run_batched_bulk_write(
+            self._data,
+            operations,
+            max_payload_bytes=self._max_upsert_payload_bytes,
+            max_records_per_batch=self._max_upsert_records_per_batch,
+            ordered=False,
+            log_prefix=f"[{self.workspace}] {self.namespace} upsert:",
+            what="upsert",
+        )
 
     async def index_done_callback(self) -> None:
         # Mongo handles persistence automatically
@@ -883,6 +1041,10 @@ class MongoGraphStorage(BaseGraphStorage):
 
         self._collection_name = self.final_namespace
         self._edge_collection_name = f"{self._collection_name}_edges"
+        (
+            self._max_upsert_payload_bytes,
+            self._max_upsert_records_per_batch,
+        ) = _resolve_upsert_batch_limits()
 
     async def initialize(self):
         async with get_data_init_lock():
@@ -1200,15 +1362,29 @@ class MongoGraphStorage(BaseGraphStorage):
         """
         if not nodes:
             return
-        ops = []
+        ops: list[tuple[Any, int, str]] = []
         for node_id, node_data in nodes:
             update_doc: dict = {"$set": {**node_data}}
             if node_data.get("source_id", ""):
                 update_doc["$set"]["source_ids"] = node_data["source_id"].split(
                     GRAPH_FIELD_SEP
                 )
-            ops.append(UpdateOne({"_id": node_id}, update_doc, upsert=True))
-        await self.collection.bulk_write(ops, ordered=True)
+            ops.append(
+                (
+                    UpdateOne({"_id": node_id}, update_doc, upsert=True),
+                    _estimate_doc_bytes(update_doc),
+                    node_id,
+                )
+            )
+        await _run_batched_bulk_write(
+            self.collection,
+            ops,
+            max_payload_bytes=self._max_upsert_payload_bytes,
+            max_records_per_batch=self._max_upsert_records_per_batch,
+            ordered=True,
+            log_prefix=f"[{self.workspace}] {self.namespace} nodes:",
+            what="node upsert",
+        )
 
     async def has_nodes_batch(self, node_ids: list[str]) -> set[str]:
         """Check existence of multiple nodes using a single $in query.
@@ -1241,13 +1417,25 @@ class MongoGraphStorage(BaseGraphStorage):
 
         # Ensure all source nodes exist (mirrors upsert_edge's upsert_node call)
         source_node_ids = list(dict.fromkeys(src for src, _tgt, _data in edges))
-        node_ops = [
-            UpdateOne({"_id": src}, {"$setOnInsert": {"_id": src}}, upsert=True)
+        node_ops: list[tuple[Any, int, str]] = [
+            (
+                UpdateOne({"_id": src}, {"$setOnInsert": {"_id": src}}, upsert=True),
+                _estimate_doc_bytes({"_id": src}),
+                src,
+            )
             for src in source_node_ids
         ]
-        await self.collection.bulk_write(node_ops, ordered=False)
+        await _run_batched_bulk_write(
+            self.collection,
+            node_ops,
+            max_payload_bytes=self._max_upsert_payload_bytes,
+            max_records_per_batch=self._max_upsert_records_per_batch,
+            ordered=False,
+            log_prefix=f"[{self.workspace}] {self.namespace} edges:",
+            what="source-node placeholder upsert",
+        )
 
-        edge_ops = []
+        edge_ops: list[tuple[Any, int, str]] = []
         for source_node_id, target_node_id, edge_data in edges:
             update_doc: dict = {"$set": {**edge_data}}
             if edge_data.get("source_id", ""):
@@ -1257,24 +1445,36 @@ class MongoGraphStorage(BaseGraphStorage):
             update_doc["$set"]["source_node_id"] = source_node_id
             update_doc["$set"]["target_node_id"] = target_node_id
             edge_ops.append(
-                UpdateOne(
-                    {
-                        "$or": [
-                            {
-                                "source_node_id": source_node_id,
-                                "target_node_id": target_node_id,
-                            },
-                            {
-                                "source_node_id": target_node_id,
-                                "target_node_id": source_node_id,
-                            },
-                        ]
-                    },
-                    update_doc,
-                    upsert=True,
+                (
+                    UpdateOne(
+                        {
+                            "$or": [
+                                {
+                                    "source_node_id": source_node_id,
+                                    "target_node_id": target_node_id,
+                                },
+                                {
+                                    "source_node_id": target_node_id,
+                                    "target_node_id": source_node_id,
+                                },
+                            ]
+                        },
+                        update_doc,
+                        upsert=True,
+                    ),
+                    _estimate_doc_bytes(update_doc),
+                    f"{source_node_id}->{target_node_id}",
                 )
             )
-        await self.edge_collection.bulk_write(edge_ops, ordered=True)
+        await _run_batched_bulk_write(
+            self.edge_collection,
+            edge_ops,
+            max_payload_bytes=self._max_upsert_payload_bytes,
+            max_records_per_batch=self._max_upsert_records_per_batch,
+            ordered=True,
+            log_prefix=f"[{self.workspace}] {self.namespace} edges:",
+            what="edge upsert",
+        )
 
     #
     # -------------------------------------------------------------------------
@@ -2329,33 +2529,19 @@ class MongoVectorDBStorage(BaseVectorStorage):
         self._max_batch_size = self.global_config["embedding_batch_num"]
 
         # Flush-time batching limits (see module-level DEFAULT_MONGO_* constants).
-        # A non-positive value disables that splitting dimension.
-        self._max_upsert_payload_bytes = int(
-            os.getenv(
-                "MONGO_UPSERT_MAX_PAYLOAD_BYTES",
-                str(DEFAULT_MONGO_UPSERT_MAX_PAYLOAD_BYTES),
-            )
-        )
-        self._max_upsert_records_per_batch = int(
-            os.getenv(
-                "MONGO_UPSERT_MAX_RECORDS_PER_BATCH",
-                str(DEFAULT_MONGO_UPSERT_MAX_RECORDS_PER_BATCH),
-            )
-        )
+        # A non-positive value disables that splitting dimension. The two upsert
+        # limits are shared with KV/graph via _resolve_upsert_batch_limits(); the
+        # delete count cap is vector-specific (only the VDB batches deletes here).
+        (
+            self._max_upsert_payload_bytes,
+            self._max_upsert_records_per_batch,
+        ) = _resolve_upsert_batch_limits()
         self._max_delete_records_per_batch = int(
             os.getenv(
                 "MONGO_DELETE_MAX_RECORDS_PER_BATCH",
                 str(DEFAULT_MONGO_DELETE_MAX_RECORDS_PER_BATCH),
             )
         )
-        if self._max_upsert_payload_bytes <= 0:
-            logger.warning(
-                f"MONGO_UPSERT_MAX_PAYLOAD_BYTES={self._max_upsert_payload_bytes} is non-positive, disable payload-size splitting"
-            )
-        if self._max_upsert_records_per_batch <= 0:
-            logger.warning(
-                f"MONGO_UPSERT_MAX_RECORDS_PER_BATCH={self._max_upsert_records_per_batch} is non-positive, disable upsert record-count splitting"
-            )
         if self._max_delete_records_per_batch <= 0:
             logger.warning(
                 f"MONGO_DELETE_MAX_RECORDS_PER_BATCH={self._max_delete_records_per_batch} is non-positive, disable delete record-count splitting"
@@ -2573,70 +2759,6 @@ class MongoVectorDBStorage(BaseVectorStorage):
             for doc in results
         ]
 
-    @staticmethod
-    def _build_upsert_batches(
-        records: list[dict[str, Any]],
-        max_payload_bytes: int,
-        max_records_per_batch: int,
-    ) -> list[tuple[list[dict[str, Any]], int]]:
-        """Split upsert records into batches by estimated payload size and count.
-
-        The byte budget is the primary limiter: records accumulate until adding
-        the next one would exceed ``max_payload_bytes``, then a new batch starts.
-        Size is estimated by JSON-serializing each record; this overestimates the
-        actual BSON size MongoDB writes (a JSON float string is far longer than
-        the 8 bytes a BSON double encodes), so the split stays conservatively
-        below the server limit and never underestimates.
-
-        A single record larger than the byte budget is emitted as its own batch
-        rather than raising: JSON overestimation means such a record's real BSON
-        size is often still under MongoDB's 16MB document ceiling, so we let the
-        server be the final arbiter instead of failing client-side. Returns a
-        list of ``(batch, estimated_bytes)`` tuples (estimate used for logging).
-        """
-        if not records:
-            return []
-
-        payload_limit = max_payload_bytes if max_payload_bytes > 0 else float("inf")
-        records_limit = (
-            max_records_per_batch if max_records_per_batch > 0 else float("inf")
-        )
-
-        batches: list[tuple[list[dict[str, Any]], int]] = []
-        current_batch: list[dict[str, Any]] = []
-        # JSON array overhead ("[]")
-        current_estimated_bytes = 2
-
-        for record in records:
-            record_size = len(
-                json.dumps(
-                    record,
-                    ensure_ascii=False,
-                    separators=(",", ":"),
-                    default=str,
-                ).encode("utf-8")
-            )
-
-            # If current batch not empty, a comma is needed before next element.
-            separator_overhead = 1 if current_batch else 0
-            next_batch_size = current_estimated_bytes + separator_overhead + record_size
-
-            if current_batch and (
-                len(current_batch) >= records_limit or next_batch_size > payload_limit
-            ):
-                batches.append((current_batch, current_estimated_bytes))
-                current_batch = []
-                current_estimated_bytes = 2
-                next_batch_size = current_estimated_bytes + record_size
-
-            current_batch.append(record)
-            current_estimated_bytes = next_batch_size
-
-        if current_batch:
-            batches.append((current_batch, current_estimated_bytes))
-
-        return batches
-
     async def index_done_callback(self) -> None:
         """Flush buffered vector ops; Mongo persists automatically once written."""
         await self._flush_pending_vector_ops()
@@ -2723,15 +2845,19 @@ class MongoVectorDBStorage(BaseVectorStorage):
                     # bulk-command message limit and bound peak memory. Fail-fast:
                     # any batch failure raises immediately and the full buffer is
                     # retained for the next flush (upsert/delete are idempotent).
-                    upsert_batches = self._build_upsert_batches(
+                    # Logging is kept aligned with MilvusVectorDBStorage; the
+                    # batching maths is shared via _chunk_by_budget.
+                    upsert_batches = _chunk_by_budget(
                         list_data,
-                        max_payload_bytes=self._max_upsert_payload_bytes,
-                        max_records_per_batch=self._max_upsert_records_per_batch,
+                        _estimate_doc_bytes,
+                        self._max_upsert_payload_bytes,
+                        self._max_upsert_records_per_batch,
                     )
                     if len(upsert_batches) > 1:
                         logger.info(
                             f"[{self.workspace}] {self.namespace} flush: upsert split into "
                             f"{len(upsert_batches)} batches for {len(list_data)} records "
+                            f"(max_payload={self._max_upsert_payload_bytes} batch={self._max_upsert_records_per_batch})"
                         )
                     for batch_index, (records_batch, estimated_bytes) in enumerate(
                         upsert_batches, 1

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -1,5 +1,6 @@
 import os
 import re
+import json
 import time
 from dataclasses import dataclass, field
 import numpy as np
@@ -28,7 +29,7 @@ if not pm.is_installed("pymongo"):
     pm.install("pymongo")
 
 from pymongo import AsyncMongoClient  # type: ignore
-from pymongo import UpdateOne, DeleteOne  # type: ignore
+from pymongo import UpdateOne  # type: ignore
 from pymongo.asynchronous.database import AsyncDatabase  # type: ignore
 from pymongo.asynchronous.collection import AsyncCollection  # type: ignore
 from pymongo.operations import SearchIndexModel  # type: ignore
@@ -39,6 +40,19 @@ config = configparser.ConfigParser()
 config.read("config.ini", "utf-8")
 
 GRAPH_BFS_MODE = os.getenv("MONGO_GRAPH_BFS_MODE", "bidirectional")
+
+# Flush-time batching limits for MongoVectorDBStorage.
+# The payload-byte budget is the primary limiter; the record-count caps are a
+# secondary guard that only binds when individual records are small.
+# Upsert and delete have separate count caps on purpose: upsert records each
+# carry a full embedding vector and are far heavier than delete _ids, so the
+# upsert batch count is kept much smaller than the delete one.
+# MongoDB caps a single BSON document at 16MB and a single bulk command message
+# at 48MB; a 16MB JSON estimate (which overestimates the real BSON size) keeps
+# every bulk_write comfortably below the wire limit and bounds peak memory.
+DEFAULT_MONGO_UPSERT_MAX_PAYLOAD_BYTES = 16 * 1024 * 1024  # 16MB
+DEFAULT_MONGO_UPSERT_MAX_RECORDS_PER_BATCH = 128
+DEFAULT_MONGO_DELETE_MAX_RECORDS_PER_BATCH = 1000
 
 
 class ClientManager:
@@ -2314,6 +2328,39 @@ class MongoVectorDBStorage(BaseVectorStorage):
         self._collection_name = self.final_namespace
         self._max_batch_size = self.global_config["embedding_batch_num"]
 
+        # Flush-time batching limits (see module-level DEFAULT_MONGO_* constants).
+        # A non-positive value disables that splitting dimension.
+        self._max_upsert_payload_bytes = int(
+            os.getenv(
+                "MONGO_UPSERT_MAX_PAYLOAD_BYTES",
+                str(DEFAULT_MONGO_UPSERT_MAX_PAYLOAD_BYTES),
+            )
+        )
+        self._max_upsert_records_per_batch = int(
+            os.getenv(
+                "MONGO_UPSERT_MAX_RECORDS_PER_BATCH",
+                str(DEFAULT_MONGO_UPSERT_MAX_RECORDS_PER_BATCH),
+            )
+        )
+        self._max_delete_records_per_batch = int(
+            os.getenv(
+                "MONGO_DELETE_MAX_RECORDS_PER_BATCH",
+                str(DEFAULT_MONGO_DELETE_MAX_RECORDS_PER_BATCH),
+            )
+        )
+        if self._max_upsert_payload_bytes <= 0:
+            logger.warning(
+                f"MONGO_UPSERT_MAX_PAYLOAD_BYTES={self._max_upsert_payload_bytes} is non-positive, disable payload-size splitting"
+            )
+        if self._max_upsert_records_per_batch <= 0:
+            logger.warning(
+                f"MONGO_UPSERT_MAX_RECORDS_PER_BATCH={self._max_upsert_records_per_batch} is non-positive, disable upsert record-count splitting"
+            )
+        if self._max_delete_records_per_batch <= 0:
+            logger.warning(
+                f"MONGO_DELETE_MAX_RECORDS_PER_BATCH={self._max_delete_records_per_batch} is non-positive, disable delete record-count splitting"
+            )
+
         # Deferred-embedding buffers and the per-namespace flush lock.
         # Constructed in initialize() once shared-storage primitives are
         # available; keyed on final_namespace so two instances pointing at
@@ -2526,12 +2573,76 @@ class MongoVectorDBStorage(BaseVectorStorage):
             for doc in results
         ]
 
+    @staticmethod
+    def _build_upsert_batches(
+        records: list[dict[str, Any]],
+        max_payload_bytes: int,
+        max_records_per_batch: int,
+    ) -> list[tuple[list[dict[str, Any]], int]]:
+        """Split upsert records into batches by estimated payload size and count.
+
+        The byte budget is the primary limiter: records accumulate until adding
+        the next one would exceed ``max_payload_bytes``, then a new batch starts.
+        Size is estimated by JSON-serializing each record; this overestimates the
+        actual BSON size MongoDB writes (a JSON float string is far longer than
+        the 8 bytes a BSON double encodes), so the split stays conservatively
+        below the server limit and never underestimates.
+
+        A single record larger than the byte budget is emitted as its own batch
+        rather than raising: JSON overestimation means such a record's real BSON
+        size is often still under MongoDB's 16MB document ceiling, so we let the
+        server be the final arbiter instead of failing client-side. Returns a
+        list of ``(batch, estimated_bytes)`` tuples (estimate used for logging).
+        """
+        if not records:
+            return []
+
+        payload_limit = max_payload_bytes if max_payload_bytes > 0 else float("inf")
+        records_limit = (
+            max_records_per_batch if max_records_per_batch > 0 else float("inf")
+        )
+
+        batches: list[tuple[list[dict[str, Any]], int]] = []
+        current_batch: list[dict[str, Any]] = []
+        # JSON array overhead ("[]")
+        current_estimated_bytes = 2
+
+        for record in records:
+            record_size = len(
+                json.dumps(
+                    record,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                    default=str,
+                ).encode("utf-8")
+            )
+
+            # If current batch not empty, a comma is needed before next element.
+            separator_overhead = 1 if current_batch else 0
+            next_batch_size = current_estimated_bytes + separator_overhead + record_size
+
+            if current_batch and (
+                len(current_batch) >= records_limit or next_batch_size > payload_limit
+            ):
+                batches.append((current_batch, current_estimated_bytes))
+                current_batch = []
+                current_estimated_bytes = 2
+                next_batch_size = current_estimated_bytes + record_size
+
+            current_batch.append(record)
+            current_estimated_bytes = next_batch_size
+
+        if current_batch:
+            batches.append((current_batch, current_estimated_bytes))
+
+        return batches
+
     async def index_done_callback(self) -> None:
         """Flush buffered vector ops; Mongo persists automatically once written."""
         await self._flush_pending_vector_ops()
 
     async def _flush_pending_vector_ops(self) -> None:
-        """Flush buffered vector upserts and deletes via a single bulk_write.
+        """Flush buffered vector upserts and deletes in batched bulk writes.
 
         Embedding runs *inside* this lock (not in `upsert` or lock-free):
         it makes deferred embedding and the bulk write atomic against
@@ -2596,23 +2707,72 @@ class MongoVectorDBStorage(BaseVectorStorage):
                     pdoc.vector = np.array(embedding, dtype=np.float32).tolist()
                     await _cooperative_yield(i)
 
-            # Build the bulk_write op list.
-            ops: list[Any] = []
-            committed_ids: list[str] = []
-            for doc_id, pdoc in pending_docs.items():
-                if pdoc.vector is None:
-                    continue
-                committed_ids.append(doc_id)
-                full_doc = {**pdoc.source, "vector": pdoc.vector}
-                ops.append(UpdateOne({"_id": doc_id}, {"$set": full_doc}, upsert=True))
-            for doc_id in pending_deletes:
-                ops.append(DeleteOne({"_id": doc_id}))
-
-            if not ops:
-                return
+            # Assemble final upsert payload. After the embed loop above every
+            # pending doc has a non-None vector (count-mismatch was checked),
+            # so we can iterate without re-guarding. Each full_doc carries its
+            # own "_id" (from source), matching the UpdateOne filter key.
+            committed_ids: list[str] = list(pending_docs.keys())
+            list_data: list[dict[str, Any]] = [
+                {**pending_docs[doc_id].source, "vector": pending_docs[doc_id].vector}
+                for doc_id in committed_ids
+            ]
 
             try:
-                await self._data.bulk_write(ops, ordered=False)
+                if list_data:
+                    # Split the upsert into batches that stay under the server-side
+                    # bulk-command message limit and bound peak memory. Fail-fast:
+                    # any batch failure raises immediately and the full buffer is
+                    # retained for the next flush (upsert/delete are idempotent).
+                    upsert_batches = self._build_upsert_batches(
+                        list_data,
+                        max_payload_bytes=self._max_upsert_payload_bytes,
+                        max_records_per_batch=self._max_upsert_records_per_batch,
+                    )
+                    if len(upsert_batches) > 1:
+                        logger.info(
+                            f"[{self.workspace}] {self.namespace} flush: upsert split into "
+                            f"{len(upsert_batches)} batches for {len(list_data)} records "
+                        )
+                    for batch_index, (records_batch, estimated_bytes) in enumerate(
+                        upsert_batches, 1
+                    ):
+                        if (
+                            len(records_batch) == 1
+                            and self._max_upsert_payload_bytes > 0
+                            and estimated_bytes > self._max_upsert_payload_bytes
+                        ):
+                            logger.warning(
+                                f"[{self.workspace}] {self.namespace} flush: single record "
+                                f"id={records_batch[0].get('_id')} estimated {estimated_bytes} bytes "
+                                f"exceeds {self._max_upsert_payload_bytes}"
+                            )
+                        logger.debug(
+                            f"[{self.workspace}] MongoDB upsert batch {batch_index}/{len(upsert_batches)}: "
+                            f"records={len(records_batch)}, estimated_payload_bytes={estimated_bytes}"
+                        )
+                        await self._data.bulk_write(
+                            [
+                                UpdateOne(
+                                    {"_id": doc["_id"]}, {"$set": doc}, upsert=True
+                                )
+                                for doc in records_batch
+                            ],
+                            ordered=False,
+                        )
+                if pending_deletes:
+                    # Chunk deletes by record count; _ids are short strings so a
+                    # count cap is enough to stay under the bulk message limit.
+                    # delete_many($in) is the 1:1 equivalent of a batched delete.
+                    delete_ids = list(pending_deletes)
+                    delete_chunk = (
+                        self._max_delete_records_per_batch
+                        if self._max_delete_records_per_batch > 0
+                        else len(delete_ids)
+                    )
+                    for i in range(0, len(delete_ids), delete_chunk):
+                        await self._data.delete_many(
+                            {"_id": {"$in": delete_ids[i : i + delete_chunk]}}
+                        )
             except Exception as e:
                 logger.error(
                     f"[{self.workspace}] Error flushing vector ops "

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -64,9 +64,9 @@ def _estimate_doc_bytes(doc: Any) -> int:
     conservatively below server limits and never underestimate.
     """
     return len(
-        json.dumps(
-            doc, ensure_ascii=False, separators=(",", ":"), default=str
-        ).encode("utf-8")
+        json.dumps(doc, ensure_ascii=False, separators=(",", ":"), default=str).encode(
+            "utf-8"
+        )
     )
 
 
@@ -90,9 +90,7 @@ def _chunk_by_budget(
         return []
 
     payload_limit = max_payload_bytes if max_payload_bytes > 0 else float("inf")
-    records_limit = (
-        max_records_per_batch if max_records_per_batch > 0 else float("inf")
-    )
+    records_limit = max_records_per_batch if max_records_per_batch > 0 else float("inf")
 
     batches: list[tuple[list[Any], int]] = []
     current: list[Any] = []
@@ -105,9 +103,7 @@ def _chunk_by_budget(
         separator_overhead = 1 if current else 0
         next_bytes = current_bytes + separator_overhead + item_bytes
 
-        if current and (
-            len(current) >= records_limit or next_bytes > payload_limit
-        ):
+        if current and (len(current) >= records_limit or next_bytes > payload_limit):
             batches.append((current, current_bytes))
             current = []
             current_bytes = 2

--- a/lightrag/kg/qdrant_impl.py
+++ b/lightrag/kg/qdrant_impl.py
@@ -842,8 +842,8 @@ class QdrantVectorDBStorage(BaseVectorStorage):
                     if len(point_batches) > 1:
                         logger.info(
                             f"[{self.workspace}] Qdrant upsert split into {len(point_batches)} batches "
-                            f"for {len(list_points)} points (max_payload_bytes={self._max_upsert_payload_bytes}, "
-                            f"max_points_per_batch={self._max_upsert_points_per_batch})"
+                            f"for {len(list_points)} records (max_payload={self._max_upsert_payload_bytes}, "
+                            f"batch={self._max_upsert_points_per_batch})"
                         )
 
                     for batch_index, (points_batch, estimated_bytes) in enumerate(

--- a/tests/kg/mongo_impl/test_mongo_deferred_embedding.py
+++ b/tests/kg/mongo_impl/test_mongo_deferred_embedding.py
@@ -17,7 +17,7 @@ pytest.importorskip(
     reason="pymongo is required for Mongo storage tests",
 )
 
-from pymongo import UpdateOne, DeleteOne  # type: ignore
+from pymongo import UpdateOne  # type: ignore
 
 from lightrag.kg.mongo_impl import MongoVectorDBStorage
 
@@ -304,13 +304,13 @@ async def test_upsert_then_delete_same_id_keeps_delete():
     assert "v1" in s._pending_vector_deletes
 
     await s.index_done_callback()
-    ops = s._data.bulk_write.call_args.args[0]
-    assert len(ops) == 1
-    assert isinstance(ops[0], DeleteOne)
+    s._data.bulk_write.assert_not_called()
+    s._data.delete_many.assert_awaited_once_with({"_id": {"$in": ["v1"]}})
+    assert s._pending_vector_deletes == set()
 
 
 @pytest.mark.asyncio
-async def test_bulk_write_uses_update_one_and_delete_one_mix():
+async def test_flush_uses_update_one_and_delete_many_mix():
     embed = CountingEmbeddingFunc()
     s = _make_storage(embed)
 
@@ -319,10 +319,28 @@ async def test_bulk_write_uses_update_one_and_delete_one_mix():
 
     await s.index_done_callback()
     ops = s._data.bulk_write.call_args.args[0]
-    op_types = {type(op).__name__ for op in ops}
-    assert op_types == {"UpdateOne", "DeleteOne"}
     assert sum(isinstance(op, UpdateOne) for op in ops) == 2
-    assert sum(isinstance(op, DeleteOne) for op in ops) == 2
+    s._data.delete_many.assert_awaited_once()
+    delete_filter = s._data.delete_many.await_args.args[0]
+    assert set(delete_filter["_id"]["$in"]) == {"d1", "d2"}
+
+
+@pytest.mark.asyncio
+async def test_flush_chunks_deletes_by_record_count():
+    embed = CountingEmbeddingFunc()
+    s = _make_storage(embed)
+    s._max_delete_records_per_batch = 2
+
+    await s.delete([f"d{i}" for i in range(5)])
+
+    await s.index_done_callback()
+
+    assert s._data.delete_many.await_count == 3
+    chunk_sizes = sorted(
+        len(call.args[0]["_id"]["$in"]) for call in s._data.delete_many.await_args_list
+    )
+    assert chunk_sizes == [1, 2, 2]
+    assert s._pending_vector_deletes == set()
 
 
 @pytest.mark.asyncio

--- a/tests/kg/test_batch_graph_operations.py
+++ b/tests/kg/test_batch_graph_operations.py
@@ -814,10 +814,18 @@ class TestMongoBatchOrdering:
     @pytest.mark.asyncio
     async def test_upsert_nodes_batch_uses_ordered_bulk_write(self):
         pytest.importorskip("pymongo")
-        from lightrag.kg.mongo_impl import MongoGraphStorage
+        from lightrag.kg.mongo_impl import (
+            MongoGraphStorage,
+            DEFAULT_MONGO_UPSERT_MAX_PAYLOAD_BYTES,
+            DEFAULT_MONGO_UPSERT_MAX_RECORDS_PER_BATCH,
+        )
 
         storage = MongoGraphStorage.__new__(MongoGraphStorage)
         storage.collection = AsyncMock()
+        storage.workspace = "test_ws"
+        storage.namespace = "test_graph"
+        storage._max_upsert_payload_bytes = DEFAULT_MONGO_UPSERT_MAX_PAYLOAD_BYTES
+        storage._max_upsert_records_per_batch = DEFAULT_MONGO_UPSERT_MAX_RECORDS_PER_BATCH
 
         await MongoGraphStorage.upsert_nodes_batch(
             storage,
@@ -833,11 +841,19 @@ class TestMongoBatchOrdering:
     @pytest.mark.asyncio
     async def test_upsert_edges_batch_uses_ordered_bulk_write(self):
         pytest.importorskip("pymongo")
-        from lightrag.kg.mongo_impl import MongoGraphStorage
+        from lightrag.kg.mongo_impl import (
+            MongoGraphStorage,
+            DEFAULT_MONGO_UPSERT_MAX_PAYLOAD_BYTES,
+            DEFAULT_MONGO_UPSERT_MAX_RECORDS_PER_BATCH,
+        )
 
         storage = MongoGraphStorage.__new__(MongoGraphStorage)
         storage.collection = AsyncMock()
         storage.edge_collection = AsyncMock()
+        storage.workspace = "test_ws"
+        storage.namespace = "test_graph"
+        storage._max_upsert_payload_bytes = DEFAULT_MONGO_UPSERT_MAX_PAYLOAD_BYTES
+        storage._max_upsert_records_per_batch = DEFAULT_MONGO_UPSERT_MAX_RECORDS_PER_BATCH
 
         await MongoGraphStorage.upsert_edges_batch(
             storage,
@@ -853,11 +869,19 @@ class TestMongoBatchOrdering:
     @pytest.mark.asyncio
     async def test_upsert_edges_batch_deduplicates_source_node_upserts(self):
         pytest.importorskip("pymongo")
-        from lightrag.kg.mongo_impl import MongoGraphStorage
+        from lightrag.kg.mongo_impl import (
+            MongoGraphStorage,
+            DEFAULT_MONGO_UPSERT_MAX_PAYLOAD_BYTES,
+            DEFAULT_MONGO_UPSERT_MAX_RECORDS_PER_BATCH,
+        )
 
         storage = MongoGraphStorage.__new__(MongoGraphStorage)
         storage.collection = AsyncMock()
         storage.edge_collection = AsyncMock()
+        storage.workspace = "test_ws"
+        storage.namespace = "test_graph"
+        storage._max_upsert_payload_bytes = DEFAULT_MONGO_UPSERT_MAX_PAYLOAD_BYTES
+        storage._max_upsert_records_per_batch = DEFAULT_MONGO_UPSERT_MAX_RECORDS_PER_BATCH
 
         await MongoGraphStorage.upsert_edges_batch(
             storage,

--- a/tests/kg/test_batch_graph_operations.py
+++ b/tests/kg/test_batch_graph_operations.py
@@ -825,7 +825,9 @@ class TestMongoBatchOrdering:
         storage.workspace = "test_ws"
         storage.namespace = "test_graph"
         storage._max_upsert_payload_bytes = DEFAULT_MONGO_UPSERT_MAX_PAYLOAD_BYTES
-        storage._max_upsert_records_per_batch = DEFAULT_MONGO_UPSERT_MAX_RECORDS_PER_BATCH
+        storage._max_upsert_records_per_batch = (
+            DEFAULT_MONGO_UPSERT_MAX_RECORDS_PER_BATCH
+        )
 
         await MongoGraphStorage.upsert_nodes_batch(
             storage,
@@ -853,7 +855,9 @@ class TestMongoBatchOrdering:
         storage.workspace = "test_ws"
         storage.namespace = "test_graph"
         storage._max_upsert_payload_bytes = DEFAULT_MONGO_UPSERT_MAX_PAYLOAD_BYTES
-        storage._max_upsert_records_per_batch = DEFAULT_MONGO_UPSERT_MAX_RECORDS_PER_BATCH
+        storage._max_upsert_records_per_batch = (
+            DEFAULT_MONGO_UPSERT_MAX_RECORDS_PER_BATCH
+        )
 
         await MongoGraphStorage.upsert_edges_batch(
             storage,
@@ -881,7 +885,9 @@ class TestMongoBatchOrdering:
         storage.workspace = "test_ws"
         storage.namespace = "test_graph"
         storage._max_upsert_payload_bytes = DEFAULT_MONGO_UPSERT_MAX_PAYLOAD_BYTES
-        storage._max_upsert_records_per_batch = DEFAULT_MONGO_UPSERT_MAX_RECORDS_PER_BATCH
+        storage._max_upsert_records_per_batch = (
+            DEFAULT_MONGO_UPSERT_MAX_RECORDS_PER_BATCH
+        )
 
         await MongoGraphStorage.upsert_edges_batch(
             storage,


### PR DESCRIPTION
## Description

A single MongoDB flush could previously accumulate thousands of vector/KV/graph documents and ship them as **one** `bulk_write` (or one `delete_many`). That keeps the entire op list — each carrying a full embedding or document body — in memory at once and offers no payload control, no observability, and no tuning knob. `MilvusVectorDBStorage` already solved the equivalent problem by splitting upserts by **payload-byte budget (primary) + record count (secondary)** and deletes by record count.

This PR brings that batching to **every MongoDB write path** (vector, KV, graph) behind shared helpers and shared, env-configurable limits, and aligns the vector-flush log output with the now-standardized vector-DB batch logging.

## Related Issues

N/A (maintenance / robustness improvement).

## Changes Made

**MongoDB batched writes (`lightrag/kg/mongo_impl.py`)**
- New module-level helpers shared by all upsert paths:
  - `_estimate_doc_bytes()` — compact-JSON byte estimate (deliberately overestimates real BSON, so splits stay conservatively under server limits). It is a splitting *heuristic* over the dominant payload field (`$set` body / `update_doc`), not the exact wire size; the under-count of the filter/`$setOnInsert`/`$or` wrapper is immaterial next to an embedding/document body and against the 48MB bulk-command limit.
  - `_chunk_by_budget()` — generic payload-size-primary / record-count-secondary splitter (non-positive limit disables that dimension; an oversized single record is emitted as its own batch).
  - `_resolve_upsert_batch_limits()` — reads `MONGO_UPSERT_MAX_*` env vars with module defaults + non-positive warnings, shared across all three storage classes.
  - `_run_batched_bulk_write()` — executes `UpdateOne` ops as size/count-bounded `bulk_write` batches (used by KV & graph).
- `MongoVectorDBStorage._flush_pending_vector_ops`: upserts split into batches; deletes switched to **chunked `delete_many({"_id": {"$in": …}})`** (1:1 equivalent of Milvus `client.delete(pks=…)`). Fail-fast: any batch failure raises and leaves both buffers intact for the next `index_done_callback` retry (idempotent).
- `MongoKVStorage.upsert` and `MongoGraphStorage.upsert_nodes_batch` / `upsert_edges_batch`: now batched via the shared helper.
  - **Graph** paths preserve their original `ordered` semantics (nodes/edges `ordered=True`, source-node placeholders `ordered=False`).
  - **KV** intentionally switches from the old single `bulk_write(...)` (which used pymongo's implicit `ordered=True` default) to `ordered=False`: every op targets a distinct flattened `_id`, so the writes are order-independent, and `ordered=False` lets the server apply idempotent upserts in parallel. This is a deliberate change, documented at the call site.

**Logging standardization (`milvus_impl.py`, `qdrant_impl.py`)**
- Vector-DB batch logs standardized to include `max_payload` / `batch` context; Qdrant wording aligned from "points" to "records".
- Milvus: the split-INFO log gains the `max_payload`/`batch` context suffix (net-new on this line; it uses Milvus's real attribute `_max_upsert_records_per_batch`). _No pre-existing bug is being fixed here — `main` never referenced an undefined attribute on this line; it simply lacked the context suffix._
- `MongoVectorDBStorage` flush logs aligned 1:1 with Milvus (with backend-appropriate field swaps: `_id` vs `id`, `MongoDB` vs `Milvus`).

**Config & tests**
- `env.example`: documented `MONGO_UPSERT_MAX_PAYLOAD_BYTES` (16 MiB), `MONGO_UPSERT_MAX_RECORDS_PER_BATCH` (128), `MONGO_DELETE_MAX_RECORDS_PER_BATCH` (1000).
- Updated graph/vector unit tests for the shared batching attributes.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

- Default limits chosen for MongoDB's ceilings: 16 MiB payload budget stays well under the 48 MB bulk-command message limit and bounds peak memory; the JSON estimate overestimates real BSON, so the split never underestimates.
- `pymongo` already auto-splits `bulk_write` at the wire level, so the practical wins here are **bounded peak memory, observable/tunable batches, and consistent behavior** across all MongoDB write paths — not avoiding a hard wire error.
- Verification: `tests/kg/` offline suite passes (429 passed); `ruff` clean; helper unit checks cover count/byte caps, disabled dimensions, empty input, oversized-single passthrough, and `ordered` passthrough.
- Out of scope (noted for follow-up): very large `$in` read/delete queries still pass the full id list in one query document — only a concern at ~hundreds of thousands of ids.
