### PR TITLE
✨ feat(postgres): bound non-graph bulk upsert/delete payload/record size

### DIFF
--- a/env.example
+++ b/env.example
@@ -772,6 +772,11 @@ POSTGRES_VCHORDRQ_BUILD_OPTIONS=
 POSTGRES_VCHORDRQ_PROBES=
 POSTGRES_VCHORDRQ_EPSILON=1.9
 
+### Batch write limits for KV/Vector/DocStatus (split a single executemany / ANY($2) delete; non-positive disables that dimension)
+# POSTGRES_UPSERT_MAX_PAYLOAD_BYTES=16777216
+# POSTGRES_UPSERT_MAX_RECORDS_PER_BATCH=200
+# POSTGRES_DELETE_MAX_RECORDS_PER_BATCH=1000
+
 ### PostgreSQL Connection Retry Configuration (Network Robustness)
 ### NEW DEFAULTS (v1.4.10+): Optimized for HA deployments with ~30s switchover time
 ### These defaults provide out-of-the-box support for PostgreSQL High Availability setups

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -4137,10 +4137,14 @@ class PGVectorStorage(BaseVectorStorage):
                     f"for {len(batch_values)} records"
                 )
 
+            # ``or 1`` guards an upsert-only flush: with the delete cap disabled
+            # (<= 0) and no pending deletes, the fallback would be 0 and the
+            # range() step below would raise even though there is nothing to
+            # delete. The empty-list loop then simply no-ops.
             delete_chunk = (
                 self._max_delete_records_per_batch
                 if self._max_delete_records_per_batch > 0
-                else len(pending_delete_ids)
+                else len(pending_delete_ids) or 1
             )
             if pending_delete_ids and len(pending_delete_ids) > delete_chunk:
                 logger.info(

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -3179,8 +3179,11 @@ class PGKVStorage(BaseKVStorage):
 
         delete_sql = f"DELETE FROM {table_name} WHERE workspace=$1 AND id = ANY($2)"
 
-        # Chunk the id list so a very large ANY($2) array stays a bounded
-        # single request (a non-positive cap disables chunking).
+        # Chunk the id list so each statement's ANY($2) array stays bounded
+        # (a non-positive cap disables chunking). All chunks run in ONE
+        # transaction so a mid-delete failure rolls every chunk back, preserving
+        # the original single-statement all-or-nothing behaviour; _run_with_retry
+        # re-runs the whole closure on transient errors (DELETE is idempotent).
         chunk = (
             self._max_delete_records_per_batch
             if self._max_delete_records_per_batch > 0
@@ -3191,12 +3194,16 @@ class PGKVStorage(BaseKVStorage):
                 f"[{self.workspace}] {self.namespace} delete: {len(ids)} ids "
                 f"split into chunks (chunk={chunk})"
             )
+
+        async def _batch_delete(connection: asyncpg.Connection) -> None:
+            async with connection.transaction():
+                for i in range(0, len(ids), chunk):
+                    await connection.execute(
+                        delete_sql, self.workspace, ids[i : i + chunk]
+                    )
+
         try:
-            for i in range(0, len(ids), chunk):
-                id_slice = ids[i : i + chunk]
-                await self.db.execute(
-                    delete_sql, {"workspace": self.workspace, "ids": id_slice}
-                )
+            await self.db._run_with_retry(_batch_delete)
             logger.debug(
                 f"[{self.workspace}] Successfully deleted {len(ids)} records from {self.namespace}"
             )
@@ -5552,8 +5559,11 @@ class PGDocStatusStorage(DocStatusStorage):
 
         delete_sql = f"DELETE FROM {table_name} WHERE workspace=$1 AND id = ANY($2)"
 
-        # Chunk the id list so a very large ANY($2) array stays a bounded
-        # single request (a non-positive cap disables chunking).
+        # Chunk the id list so each statement's ANY($2) array stays bounded
+        # (a non-positive cap disables chunking). All chunks run in ONE
+        # transaction so a mid-delete failure rolls every chunk back, preserving
+        # the original single-statement all-or-nothing behaviour; _run_with_retry
+        # re-runs the whole closure on transient errors (DELETE is idempotent).
         chunk = (
             self._max_delete_records_per_batch
             if self._max_delete_records_per_batch > 0
@@ -5564,12 +5574,16 @@ class PGDocStatusStorage(DocStatusStorage):
                 f"[{self.workspace}] {self.namespace} delete: {len(ids)} ids "
                 f"split into chunks (chunk={chunk})"
             )
+
+        async def _batch_delete(connection: asyncpg.Connection) -> None:
+            async with connection.transaction():
+                for i in range(0, len(ids), chunk):
+                    await connection.execute(
+                        delete_sql, self.workspace, ids[i : i + chunk]
+                    )
+
         try:
-            for i in range(0, len(ids), chunk):
-                id_slice = ids[i : i + chunk]
-                await self.db.execute(
-                    delete_sql, {"workspace": self.workspace, "ids": id_slice}
-                )
+            await self.db._run_with_retry(_batch_delete)
             logger.debug(
                 f"[{self.workspace}] Successfully deleted {len(ids)} records from {self.namespace}"
             )

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -67,6 +67,150 @@ T = TypeVar("T")
 # PostgreSQL identifier length limit (in bytes)
 PG_MAX_IDENTIFIER_LENGTH = 63
 
+# Flush-time batching limits shared by the PostgreSQL non-graph write paths
+# (PGKVStorage, PGVectorStorage, PGDocStatusStorage). Mirrors the MONGO_* /
+# OPENSEARCH_* contract: the payload-byte budget is the primary limiter and the
+# record-count caps are a secondary guard. Unlike Mongo/OpenSearch there is no
+# single server-side bulk message to stay under -- asyncpg's executemany
+# pipelines each row over a reused prepared statement -- so for PostgreSQL the
+# byte budget mainly bounds client-side peak memory and transaction duration.
+# The default record cap keeps PGKVStorage's historical 200 behaviour; delete
+# ids are short strings so a larger count cap is safe.
+DEFAULT_PG_UPSERT_MAX_PAYLOAD_BYTES = 16 * 1024 * 1024  # 16 MiB
+DEFAULT_PG_UPSERT_MAX_RECORDS_PER_BATCH = 200
+DEFAULT_PG_DELETE_MAX_RECORDS_PER_BATCH = 1000
+
+
+def _estimate_record_bytes(record: tuple[Any, ...]) -> int:
+    """Estimate the serialized byte size of one asyncpg parameter tuple.
+
+    A splitting *heuristic* for ``_chunk_by_budget``, not the exact wire size.
+    numpy vectors dominate vector rows and large text dominates KV rows, so the
+    estimate sums those accurately and treats scalars as a small constant:
+
+      * ``np.ndarray`` -> ``.nbytes`` (the binary pgvector payload)
+      * ``str`` -> UTF-8 byte length
+      * ``bytes`` / ``bytearray`` -> ``len``
+      * ``dict`` / ``list`` -> compact-JSON UTF-8 length (already-serialized
+        JSON columns are passed as ``str`` and handled above; this covers any
+        not-yet-serialized field)
+      * ``None`` -> 0
+      * everything else (int / float / datetime / ...) -> a small constant
+    """
+    total = 0
+    for field_value in record:
+        if isinstance(field_value, np.ndarray):
+            total += field_value.nbytes
+        elif isinstance(field_value, str):
+            total += len(field_value.encode("utf-8"))
+        elif isinstance(field_value, (bytes, bytearray)):
+            total += len(field_value)
+        elif field_value is None:
+            total += 0
+        elif isinstance(field_value, (dict, list)):
+            total += len(
+                json.dumps(
+                    field_value,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                    default=str,
+                ).encode("utf-8")
+            )
+        else:
+            total += 16
+    return total
+
+
+def _chunk_by_budget(
+    items: list[T],
+    size_of: Callable[[T], int],
+    max_payload_bytes: int,
+    max_records_per_batch: int,
+) -> list[tuple[list[T], int]]:
+    """Split items into batches by estimated payload size (primary) and count.
+
+    The byte budget is the primary limiter: items accumulate until adding the
+    next one would exceed ``max_payload_bytes``, then a new batch starts.
+    ``size_of(item)`` returns an item's estimated serialized byte size. A single
+    item larger than the byte budget is emitted as its own batch rather than
+    raising; the server stays the final arbiter. A non-positive limit disables
+    that dimension. Returns ``(batch, summed_estimated_bytes)`` tuples (the
+    estimate is used for logging). Semantically identical to mongo_impl's
+    ``_chunk_by_budget``.
+    """
+    if not items:
+        return []
+
+    payload_limit = max_payload_bytes if max_payload_bytes > 0 else float("inf")
+    records_limit = max_records_per_batch if max_records_per_batch > 0 else float("inf")
+
+    batches: list[tuple[list[T], int]] = []
+    current: list[T] = []
+    # JSON array overhead ("[]")
+    current_bytes = 2
+
+    for item in items:
+        item_bytes = size_of(item)
+        # If current batch not empty, a comma is needed before next element.
+        separator_overhead = 1 if current else 0
+        next_bytes = current_bytes + separator_overhead + item_bytes
+
+        if current and (len(current) >= records_limit or next_bytes > payload_limit):
+            batches.append((current, current_bytes))
+            current = []
+            current_bytes = 2
+            next_bytes = current_bytes + item_bytes
+
+        current.append(item)
+        current_bytes = next_bytes
+
+    if current:
+        batches.append((current, current_bytes))
+
+    return batches
+
+
+def _resolve_pg_batch_limits() -> tuple[int, int, int]:
+    """Resolve flush-time batching limits from env, with module defaults.
+
+    Shared by every PostgreSQL non-graph write path so the byte/record caps that
+    bound a single ``executemany`` / ``DELETE ... ANY($2)`` are consistent across
+    all of them. A non-positive value disables that splitting dimension and logs
+    a warning. Returns ``(upsert_payload_bytes, upsert_records, delete_records)``.
+    """
+    upsert_payload_bytes = int(
+        os.environ.get(
+            "POSTGRES_UPSERT_MAX_PAYLOAD_BYTES",
+            str(DEFAULT_PG_UPSERT_MAX_PAYLOAD_BYTES),
+        )
+    )
+    upsert_records = int(
+        os.environ.get(
+            "POSTGRES_UPSERT_MAX_RECORDS_PER_BATCH",
+            str(DEFAULT_PG_UPSERT_MAX_RECORDS_PER_BATCH),
+        )
+    )
+    delete_records = int(
+        os.environ.get(
+            "POSTGRES_DELETE_MAX_RECORDS_PER_BATCH",
+            str(DEFAULT_PG_DELETE_MAX_RECORDS_PER_BATCH),
+        )
+    )
+    if upsert_payload_bytes <= 0:
+        logger.warning(
+            f"POSTGRES_UPSERT_MAX_PAYLOAD_BYTES={upsert_payload_bytes} is non-positive, disable payload-size splitting"
+        )
+    if upsert_records <= 0:
+        logger.warning(
+            f"POSTGRES_UPSERT_MAX_RECORDS_PER_BATCH={upsert_records} is non-positive, disable upsert record-count splitting"
+        )
+    if delete_records <= 0:
+        logger.warning(
+            f"POSTGRES_DELETE_MAX_RECORDS_PER_BATCH={delete_records} is non-positive, disable delete record-count splitting"
+        )
+    return upsert_payload_bytes, upsert_records, delete_records
+
+
 # All known vector index suffixes, used to drop conflicting indexes when switching types
 _VECTOR_INDEX_SUFFIXES = [
     "hnsw_cosine",
@@ -2377,6 +2521,11 @@ class PGKVStorage(BaseKVStorage):
 
     def __post_init__(self):
         self._max_batch_size = 200  # DB batch size, independent of embedding batch size
+        (
+            self._max_upsert_payload_bytes,
+            self._max_upsert_records_per_batch,
+            self._max_delete_records_per_batch,
+        ) = _resolve_pg_batch_limits()
 
     async def initialize(self):
         async with get_data_init_lock():
@@ -2921,14 +3070,36 @@ class PGKVStorage(BaseKVStorage):
             _timing_details_suffix(namespace=self.namespace),
         )
         if batch_values:
-            # Split into sub-batches to prevent database overload
-            num_batches = (
-                len(batch_values) + self._max_batch_size - 1
-            ) // self._max_batch_size
-            for batch_index, i in enumerate(
-                range(0, len(batch_values), self._max_batch_size), start=1
+            # Split into payload-byte (primary) / record-count (secondary)
+            # bounded sub-batches to bound peak memory and transaction duration
+            # (mirrors mongo_impl's _run_batched_bulk_write). asyncpg pipelines
+            # each row in executemany, so the byte budget caps client-side
+            # assembly rather than a single server message.
+            batches = _chunk_by_budget(
+                batch_values,
+                _estimate_record_bytes,
+                self._max_upsert_payload_bytes,
+                self._max_upsert_records_per_batch,
+            )
+            num_batches = len(batches)
+            log_prefix = f"[{self.workspace}] {self.namespace} upsert:"
+            if num_batches > 1:
+                logger.info(
+                    f"{log_prefix} split into {num_batches} batches "
+                    f"for {len(batch_values)} records"
+                )
+            for batch_index, (sub_batch, estimated_bytes) in enumerate(
+                batches, start=1
             ):
-                sub_batch = batch_values[i : i + self._max_batch_size]
+                if (
+                    len(sub_batch) == 1
+                    and self._max_upsert_payload_bytes > 0
+                    and estimated_bytes > self._max_upsert_payload_bytes
+                ):
+                    logger.warning(
+                        f"{log_prefix} single record estimated {estimated_bytes} "
+                        f"bytes exceeds {self._max_upsert_payload_bytes}"
+                    )
 
                 async def _batch_upsert(
                     connection: asyncpg.Connection,
@@ -3008,8 +3179,24 @@ class PGKVStorage(BaseKVStorage):
 
         delete_sql = f"DELETE FROM {table_name} WHERE workspace=$1 AND id = ANY($2)"
 
+        # Chunk the id list so a very large ANY($2) array stays a bounded
+        # single request (a non-positive cap disables chunking).
+        chunk = (
+            self._max_delete_records_per_batch
+            if self._max_delete_records_per_batch > 0
+            else len(ids)
+        )
+        if len(ids) > chunk:
+            logger.info(
+                f"[{self.workspace}] {self.namespace} delete: {len(ids)} ids "
+                f"split into chunks (chunk={chunk})"
+            )
         try:
-            await self.db.execute(delete_sql, {"workspace": self.workspace, "ids": ids})
+            for i in range(0, len(ids), chunk):
+                id_slice = ids[i : i + chunk]
+                await self.db.execute(
+                    delete_sql, {"workspace": self.workspace, "ids": id_slice}
+                )
             logger.debug(
                 f"[{self.workspace}] Successfully deleted {len(ids)} records from {self.namespace}"
             )
@@ -3059,6 +3246,12 @@ class PGVectorStorage(BaseVectorStorage):
     def __post_init__(self):
         self._validate_embedding_func()
         self._max_batch_size = self.global_config["embedding_batch_num"]
+        # DB-write batching limits (distinct from the embedding batch size above).
+        (
+            self._max_upsert_payload_bytes,
+            self._max_upsert_records_per_batch,
+            self._max_delete_records_per_batch,
+        ) = _resolve_pg_batch_limits()
         config = self.global_config.get("vector_db_storage_cls_kwargs", {})
         cosine_threshold = config.get("cosine_better_than_threshold")
         if cosine_threshold is None:
@@ -3918,28 +4111,96 @@ class PGVectorStorage(BaseVectorStorage):
             pending_delete_ids = list(self._pending_vector_deletes)
 
             # --- Persistence -------------------------------------------------
-            async def _flush_batch(connection: asyncpg.Connection) -> None:
-                async with connection.transaction():
-                    if batch_values and upsert_sql:
-                        execute_start = time.perf_counter()
-                        await connection.executemany(upsert_sql, batch_values)
-                        performance_timing_log(
-                            "[%s] executemany completed in %.4fs batch_size=%s",
-                            timing_label,
-                            time.perf_counter() - execute_start,
-                            len(batch_values),
-                        )
-                    if pending_delete_ids:
-                        delete_sql = (
-                            f"DELETE FROM {self.table_name} "
-                            "WHERE workspace=$1 AND id = ANY($2)"
-                        )
-                        await connection.execute(
-                            delete_sql, self.workspace, pending_delete_ids
-                        )
+            # upsert and delete run as separate, payload/record-bounded phases
+            # (mirrors mongo_impl). The two buffers are disjoint -- upsert()
+            # discards from pending_deletes and delete() pops from pending_docs
+            # -- so phase ordering is irrelevant. Each chunk is its own
+            # transaction; both ops are idempotent (ON CONFLICT / ANY($2)), so a
+            # mid-flush failure raises with the buffers intact and the next
+            # flush replays everything (fail-fast-retain). This trades the old
+            # single-transaction atomicity for bounded peak memory / tx duration.
+            log_prefix = f"[{self.workspace}] {self.namespace} flush:"
+
+            upsert_batches = (
+                _chunk_by_budget(
+                    batch_values,
+                    _estimate_record_bytes,
+                    self._max_upsert_payload_bytes,
+                    self._max_upsert_records_per_batch,
+                )
+                if batch_values and upsert_sql
+                else []
+            )
+            if len(upsert_batches) > 1:
+                logger.info(
+                    f"{log_prefix} upsert split into {len(upsert_batches)} batches "
+                    f"for {len(batch_values)} records"
+                )
+
+            delete_chunk = (
+                self._max_delete_records_per_batch
+                if self._max_delete_records_per_batch > 0
+                else len(pending_delete_ids)
+            )
+            if pending_delete_ids and len(pending_delete_ids) > delete_chunk:
+                logger.info(
+                    f"{log_prefix} delete {len(pending_delete_ids)} ids split "
+                    f"into chunks (chunk={delete_chunk})"
+                )
+            delete_sql = (
+                f"DELETE FROM {self.table_name} WHERE workspace=$1 AND id = ANY($2)"
+            )
 
             try:
-                await self.db._run_with_retry(_flush_batch, timing_label=timing_label)
+                for batch_index, (sub_batch, estimated_bytes) in enumerate(
+                    upsert_batches, start=1
+                ):
+                    if (
+                        len(sub_batch) == 1
+                        and self._max_upsert_payload_bytes > 0
+                        and estimated_bytes > self._max_upsert_payload_bytes
+                    ):
+                        logger.warning(
+                            f"{log_prefix} single record estimated {estimated_bytes} "
+                            f"bytes exceeds {self._max_upsert_payload_bytes}"
+                        )
+
+                    async def _flush_upsert(
+                        connection: asyncpg.Connection,
+                        _sql: str = upsert_sql,
+                        _data: list[tuple] = sub_batch,
+                        _batch_index: int = batch_index,
+                        _num_batches: int = len(upsert_batches),
+                    ) -> None:
+                        async with connection.transaction():
+                            execute_start = time.perf_counter()
+                            await connection.executemany(_sql, _data)
+                            performance_timing_log(
+                                "[%s] sub-batch %s/%s executemany completed in %.4fs batch_size=%s",
+                                timing_label,
+                                _batch_index,
+                                _num_batches,
+                                time.perf_counter() - execute_start,
+                                len(_data),
+                            )
+
+                    await self.db._run_with_retry(
+                        _flush_upsert, timing_label=timing_label
+                    )
+
+                for i in range(0, len(pending_delete_ids), delete_chunk):
+                    id_slice = pending_delete_ids[i : i + delete_chunk]
+
+                    async def _flush_delete(
+                        connection: asyncpg.Connection,
+                        _ids: list[str] = id_slice,
+                    ) -> None:
+                        async with connection.transaction():
+                            await connection.execute(delete_sql, self.workspace, _ids)
+
+                    await self.db._run_with_retry(
+                        _flush_delete, timing_label=timing_label
+                    )
             except Exception as e:
                 logger.error(
                     f"[{self.workspace}] Error flushing vector ops "
@@ -4485,6 +4746,13 @@ def _parse_doc_status_datetime(
 @dataclass
 class PGDocStatusStorage(DocStatusStorage):
     db: PostgreSQLDB = field(default=None)
+
+    def __post_init__(self):
+        (
+            self._max_upsert_payload_bytes,
+            self._max_upsert_records_per_batch,
+            self._max_delete_records_per_batch,
+        ) = _resolve_pg_batch_limits()
 
     def _format_datetime_with_timezone(self, dt):
         """Convert datetime to ISO format string with timezone info"""
@@ -5280,8 +5548,24 @@ class PGDocStatusStorage(DocStatusStorage):
 
         delete_sql = f"DELETE FROM {table_name} WHERE workspace=$1 AND id = ANY($2)"
 
+        # Chunk the id list so a very large ANY($2) array stays a bounded
+        # single request (a non-positive cap disables chunking).
+        chunk = (
+            self._max_delete_records_per_batch
+            if self._max_delete_records_per_batch > 0
+            else len(ids)
+        )
+        if len(ids) > chunk:
+            logger.info(
+                f"[{self.workspace}] {self.namespace} delete: {len(ids)} ids "
+                f"split into chunks (chunk={chunk})"
+            )
         try:
-            await self.db.execute(delete_sql, {"workspace": self.workspace, "ids": ids})
+            for i in range(0, len(ids), chunk):
+                id_slice = ids[i : i + chunk]
+                await self.db.execute(
+                    delete_sql, {"workspace": self.workspace, "ids": id_slice}
+                )
             logger.debug(
                 f"[{self.workspace}] Successfully deleted {len(ids)} records from {self.namespace}"
             )
@@ -5392,22 +5676,53 @@ class PGDocStatusStorage(DocStatusStorage):
             len(skipped),
         )
 
-        async def _batch_upsert(
-            connection: asyncpg.Connection,
-            _sql: str = sql,
-            _data: list[tuple] = batch,
-        ) -> None:
-            execute_start = time.perf_counter()
-            async with connection.transaction():
-                await connection.executemany(_sql, _data)
-            performance_timing_log(
-                "[%s] transaction + executemany completed in %.4fs batch_size=%s",
-                timing_label,
-                time.perf_counter() - execute_start,
-                len(_data),
+        # Split into payload-byte / record-count bounded sub-batches, each its
+        # own transaction (mirrors KV upsert / mongo_impl). ON CONFLICT makes
+        # every chunk idempotent, so a mid-flush failure is safely retryable.
+        batches = _chunk_by_budget(
+            batch,
+            _estimate_record_bytes,
+            self._max_upsert_payload_bytes,
+            self._max_upsert_records_per_batch,
+        )
+        num_batches = len(batches)
+        log_prefix = f"[{self.workspace}] {self.namespace} upsert:"
+        if num_batches > 1:
+            logger.info(
+                f"{log_prefix} split into {num_batches} batches "
+                f"for {len(batch)} records"
             )
+        for batch_index, (sub_batch, estimated_bytes) in enumerate(batches, start=1):
+            if (
+                len(sub_batch) == 1
+                and self._max_upsert_payload_bytes > 0
+                and estimated_bytes > self._max_upsert_payload_bytes
+            ):
+                logger.warning(
+                    f"{log_prefix} single record estimated {estimated_bytes} "
+                    f"bytes exceeds {self._max_upsert_payload_bytes}"
+                )
 
-        await self.db._run_with_retry(_batch_upsert, timing_label=timing_label)
+            async def _batch_upsert(
+                connection: asyncpg.Connection,
+                _sql: str = sql,
+                _data: list[tuple] = sub_batch,
+                _batch_index: int = batch_index,
+                _num_batches: int = num_batches,
+            ) -> None:
+                execute_start = time.perf_counter()
+                async with connection.transaction():
+                    await connection.executemany(_sql, _data)
+                performance_timing_log(
+                    "[%s] sub-batch %s/%s transaction + executemany completed in %.4fs batch_size=%s",
+                    timing_label,
+                    _batch_index,
+                    _num_batches,
+                    time.perf_counter() - execute_start,
+                    len(_data),
+                )
+
+            await self.db._run_with_retry(_batch_upsert, timing_label=timing_label)
         logger.debug(
             f"[{self.workspace}] Batch upserted {len(batch)} records to {self.namespace}"
         )

--- a/tests/kg/postgres_impl/test_postgres_batch_limits.py
+++ b/tests/kg/postgres_impl/test_postgres_batch_limits.py
@@ -1,0 +1,160 @@
+"""Unit tests for the PostgreSQL batch-limit helpers.
+
+Covers the module-level batching primitives shared by the PG non-graph write
+paths (mirrors the MONGO_* / OPENSEARCH_* contract):
+
+- ``_resolve_pg_batch_limits``: env parsing, defaults, non-positive disable.
+- ``_estimate_record_bytes``: per-field byte estimation for asyncpg tuples.
+- ``_chunk_by_budget``: record-count + payload-byte splitting.
+"""
+
+import json
+from unittest.mock import patch
+
+import numpy as np
+
+from lightrag.kg.postgres_impl import (
+    DEFAULT_PG_DELETE_MAX_RECORDS_PER_BATCH,
+    DEFAULT_PG_UPSERT_MAX_PAYLOAD_BYTES,
+    DEFAULT_PG_UPSERT_MAX_RECORDS_PER_BATCH,
+    _chunk_by_budget,
+    _estimate_record_bytes,
+    _resolve_pg_batch_limits,
+)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_pg_batch_limits
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePgBatchLimits:
+    def test_defaults(self):
+        with patch.dict("os.environ", {}, clear=True):
+            payload, upserts, deletes = _resolve_pg_batch_limits()
+        assert payload == DEFAULT_PG_UPSERT_MAX_PAYLOAD_BYTES
+        assert upserts == DEFAULT_PG_UPSERT_MAX_RECORDS_PER_BATCH
+        assert deletes == DEFAULT_PG_DELETE_MAX_RECORDS_PER_BATCH
+
+    def test_default_record_cap_keeps_kv_historical_200(self):
+        # The PG-wide upsert record default deliberately stays at 200 (KV's
+        # historical batch size), not Mongo/OS's 128.
+        assert DEFAULT_PG_UPSERT_MAX_RECORDS_PER_BATCH == 200
+
+    def test_env_override(self):
+        env = {
+            "POSTGRES_UPSERT_MAX_PAYLOAD_BYTES": "12345",
+            "POSTGRES_UPSERT_MAX_RECORDS_PER_BATCH": "7",
+            "POSTGRES_DELETE_MAX_RECORDS_PER_BATCH": "9",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            assert _resolve_pg_batch_limits() == (12345, 7, 9)
+
+    def test_non_positive_disables_and_warns(self):
+        env = {
+            "POSTGRES_UPSERT_MAX_PAYLOAD_BYTES": "0",
+            "POSTGRES_UPSERT_MAX_RECORDS_PER_BATCH": "-1",
+            "POSTGRES_DELETE_MAX_RECORDS_PER_BATCH": "0",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            with patch("lightrag.kg.postgres_impl.logger") as mock_logger:
+                payload, upserts, deletes = _resolve_pg_batch_limits()
+        assert (payload, upserts, deletes) == (0, -1, 0)
+        warnings = [c.args[0] for c in mock_logger.warning.call_args_list]
+        assert sum("non-positive" in msg for msg in warnings) == 3
+
+
+# ---------------------------------------------------------------------------
+# _estimate_record_bytes
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateRecordBytes:
+    def test_ndarray_uses_nbytes(self):
+        vec = np.zeros(128, dtype=np.float32)
+        # 128 * 4 bytes (nbytes) plus the 2-byte "id" str.
+        assert _estimate_record_bytes(("id", vec)) == vec.nbytes + 2
+
+    def test_str_uses_utf8_length(self):
+        assert _estimate_record_bytes(("abc",)) == 3
+
+    def test_multibyte_str(self):
+        # Each CJK char is 3 bytes in UTF-8.
+        assert _estimate_record_bytes(("中文",)) == 6
+
+    def test_bytes_and_none(self):
+        assert _estimate_record_bytes((b"abcd", None)) == 4
+
+    def test_dict_and_list_use_compact_json(self):
+        payload = {"a": 1, "b": [1, 2, 3]}
+        expected = len(
+            json.dumps(
+                payload, ensure_ascii=False, separators=(",", ":"), default=str
+            ).encode("utf-8")
+        )
+        assert _estimate_record_bytes((payload,)) == expected
+
+    def test_scalar_constant(self):
+        # int + float + None -> 16 + 16 + 0
+        assert _estimate_record_bytes((1, 2.0, None)) == 32
+
+    def test_mixed_tuple(self):
+        vec = np.ones(4, dtype=np.float32)  # 16 bytes
+        record = ("ws", "id", "hello", vec, None, 42)
+        # 2 + 2 + 5 + 16 + 0 + 16
+        assert _estimate_record_bytes(record) == 41
+
+
+# ---------------------------------------------------------------------------
+# _chunk_by_budget
+# ---------------------------------------------------------------------------
+
+
+class TestChunkByBudget:
+    def test_empty(self):
+        assert _chunk_by_budget([], lambda x: 1, 100, 100) == []
+
+    def test_split_by_record_count(self):
+        items = list(range(7))
+        batches = _chunk_by_budget(
+            items, lambda x: 1, max_payload_bytes=0, max_records_per_batch=3
+        )
+        sizes = [len(b) for b, _ in batches]
+        assert sizes == [3, 3, 1]
+
+    def test_split_by_payload_bytes(self):
+        # Each item ~10 bytes; a 25-byte budget fits 2 per batch (2 overhead +
+        # 10 + 1 + 10 = 23 <= 25; adding a third would exceed).
+        items = ["x" * 10, "y" * 10, "z" * 10, "w" * 10]
+        batches = _chunk_by_budget(
+            items, lambda s: len(s), max_payload_bytes=25, max_records_per_batch=0
+        )
+        sizes = [len(b) for b, _ in batches]
+        assert sizes == [2, 2]
+
+    def test_both_dimensions_record_cap_wins(self):
+        items = ["x" * 5] * 10
+        # record cap 4 binds before the generous byte budget.
+        batches = _chunk_by_budget(
+            items, lambda s: len(s), max_payload_bytes=10_000, max_records_per_batch=4
+        )
+        sizes = [len(b) for b, _ in batches]
+        assert sizes == [4, 4, 2]
+
+    def test_oversized_single_item_becomes_own_batch(self):
+        items = ["small", "X" * 1000, "small2"]
+        batches = _chunk_by_budget(
+            items, lambda s: len(s), max_payload_bytes=50, max_records_per_batch=0
+        )
+        # The 1000-byte item is emitted alone rather than raising.
+        sizes = [len(b) for b, _ in batches]
+        assert sizes == [1, 1, 1]
+        assert batches[1][0] == ["X" * 1000]
+
+    def test_non_positive_disables_both_dimensions(self):
+        items = list(range(100))
+        batches = _chunk_by_budget(
+            items, lambda x: 999, max_payload_bytes=0, max_records_per_batch=0
+        )
+        assert len(batches) == 1
+        assert len(batches[0][0]) == 100

--- a/tests/kg/postgres_impl/test_postgres_upsert.py
+++ b/tests/kg/postgres_impl/test_postgres_upsert.py
@@ -81,6 +81,7 @@ def make_doc_status_storage() -> PGDocStatusStorage:
     storage.workspace = "test_ws"
     storage.global_config = GLOBAL_CONFIG
     storage.db = db
+    storage.__post_init__()  # resolves batch-limit attrs (payload/records caps)
     storage._captured = captured
     storage._retry_kwargs = retry_kwargs
     return storage
@@ -490,7 +491,8 @@ async def test_upsert_relation_chunks_tuple_order():
 @pytest.mark.asyncio
 async def test_sub_batching_splits_correctly():
     storage = make_storage(NameSpace.KV_STORE_FULL_DOCS)
-    storage._max_batch_size = 3  # Override to small value for testing
+    # upsert splits by _max_upsert_records_per_batch (byte cap left at default).
+    storage._max_upsert_records_per_batch = 3
 
     data = {f"doc-{i}": {"content": f"text {i}", "file_path": ""} for i in range(7)}
     await storage.upsert(data)
@@ -505,7 +507,7 @@ async def test_sub_batching_splits_correctly():
 @pytest.mark.asyncio
 async def test_sub_batching_exact_multiple():
     storage = make_storage(NameSpace.KV_STORE_FULL_DOCS)
-    storage._max_batch_size = 3
+    storage._max_upsert_records_per_batch = 3
 
     data = {f"doc-{i}": {"content": f"text {i}", "file_path": ""} for i in range(6)}
     await storage.upsert(data)
@@ -717,3 +719,81 @@ async def test_vector_flush_passes_timing_label():
     assert storage._retry_kwargs[0]["timing_label"] == (
         f"test_ws PGVectorStorage.flush[{NameSpace.VECTOR_STORE_CHUNKS}]"
     )
+
+
+# ---------------------------------------------------------------------------
+# Batch limits: KV byte-budget split + delete chunking
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kv_upsert_splits_by_payload_bytes():
+    storage = make_storage(NameSpace.KV_STORE_FULL_DOCS)
+    # Disable the record cap; force a byte cap that no two rows can share.
+    storage._max_upsert_records_per_batch = 0
+    storage._max_upsert_payload_bytes = 200
+
+    data = {f"doc-{i}": {"content": "X" * 150, "file_path": ""} for i in range(3)}
+    await storage.upsert(data)
+
+    # Each ~150-byte content row exceeds half the budget -> 3 separate batches.
+    assert len(storage._captured) == 3
+
+
+@pytest.mark.asyncio
+async def test_kv_delete_splits_by_id_cap():
+    storage = make_storage(NameSpace.KV_STORE_FULL_DOCS)
+    storage._max_delete_records_per_batch = 2
+    storage.db.execute = AsyncMock()
+
+    await storage.delete([f"doc-{i}" for i in range(5)])
+
+    # 5 ids / cap 2 => 3 bounded ANY($2) DELETE statements.
+    assert storage.db.execute.await_count == 3
+    slices = [call.args[1]["ids"] for call in storage.db.execute.await_args_list]
+    assert [len(s) for s in slices] == [2, 2, 1]
+
+
+# ---------------------------------------------------------------------------
+# Batch limits: DocStatus record-cap split + delete chunking
+# ---------------------------------------------------------------------------
+
+
+def _doc_status_payload(i: int) -> dict:
+    return {
+        "content_summary": f"summary {i}",
+        "content_length": 10,
+        "chunks_count": 1,
+        "status": "processed",
+        "file_path": f"/{i}.txt",
+        "chunks_list": ["chunk-1"],
+        "metadata": {"source": "test"},
+        "created_at": "2024-01-01T00:00:00+00:00",
+        "updated_at": "2024-01-01T00:00:00+00:00",
+    }
+
+
+@pytest.mark.asyncio
+async def test_doc_status_upsert_splits_by_record_cap():
+    storage = make_doc_status_storage()
+    storage._max_upsert_records_per_batch = 2
+
+    data = {f"doc-{i}": _doc_status_payload(i) for i in range(5)}
+    await storage.upsert(data)
+
+    # 5 records / cap 2 => 3 executemany calls.
+    assert len(storage._captured) == 3
+    assert [len(rows) for _, rows in storage._captured] == [2, 2, 1]
+
+
+@pytest.mark.asyncio
+async def test_doc_status_delete_splits_by_id_cap():
+    storage = make_doc_status_storage()
+    storage._max_delete_records_per_batch = 2
+    storage.db.execute = AsyncMock()
+
+    await storage.delete([f"doc-{i}" for i in range(5)])
+
+    assert storage.db.execute.await_count == 3
+    slices = [call.args[1]["ids"] for call in storage.db.execute.await_args_list]
+    assert [len(s) for s in slices] == [2, 2, 1]

--- a/tests/kg/postgres_impl/test_postgres_upsert.py
+++ b/tests/kg/postgres_impl/test_postgres_upsert.py
@@ -30,16 +30,24 @@ def make_storage(namespace: str) -> PGKVStorage:
     """Construct a PGKVStorage instance with a mocked db."""
     db = MagicMock()
     captured: list[tuple] = []
+    captured_execute: list[tuple] = []
     retry_kwargs: list[dict] = []
 
     async def fake_run_with_retry(operation, **kwargs):
         """Call the closure with a mock connection to capture executemany args."""
         retry_kwargs.append(kwargs)
         mock_conn = AsyncMock()
+        tx = AsyncMock()
+        tx.__aenter__.return_value = tx
+        tx.__aexit__.return_value = False
+        mock_conn.transaction = MagicMock(return_value=tx)
         await operation(mock_conn)
         # Store (sql, data) from each executemany call
         for call in mock_conn.executemany.call_args_list:
             captured.append((call.args[0], call.args[1]))
+        # Store (sql, args) from each execute call (chunked delete path).
+        for call in mock_conn.execute.call_args_list:
+            captured_execute.append((call.args[0], call.args[1:]))
 
     db._run_with_retry = AsyncMock(side_effect=fake_run_with_retry)
     db.workspace = "test_ws"
@@ -52,6 +60,7 @@ def make_storage(namespace: str) -> PGKVStorage:
     storage.__post_init__()
 
     storage._captured = captured
+    storage._captured_execute = captured_execute
     storage._retry_kwargs = retry_kwargs
     return storage
 
@@ -60,6 +69,7 @@ def make_doc_status_storage() -> PGDocStatusStorage:
     """Construct a PGDocStatusStorage instance with a mocked db."""
     db = MagicMock()
     captured: list[tuple] = []
+    captured_execute: list[tuple] = []
     retry_kwargs: list[dict] = []
 
     async def fake_run_with_retry(operation, **kwargs):
@@ -72,6 +82,8 @@ def make_doc_status_storage() -> PGDocStatusStorage:
         await operation(mock_conn)
         for call in mock_conn.executemany.call_args_list:
             captured.append((call.args[0], call.args[1]))
+        for call in mock_conn.execute.call_args_list:
+            captured_execute.append((call.args[0], call.args[1:]))
 
     db._run_with_retry = AsyncMock(side_effect=fake_run_with_retry)
     db.workspace = "test_ws"
@@ -83,6 +95,7 @@ def make_doc_status_storage() -> PGDocStatusStorage:
     storage.db = db
     storage.__post_init__()  # resolves batch-limit attrs (payload/records caps)
     storage._captured = captured
+    storage._captured_execute = captured_execute
     storage._retry_kwargs = retry_kwargs
     return storage
 
@@ -744,14 +757,45 @@ async def test_kv_upsert_splits_by_payload_bytes():
 async def test_kv_delete_splits_by_id_cap():
     storage = make_storage(NameSpace.KV_STORE_FULL_DOCS)
     storage._max_delete_records_per_batch = 2
-    storage.db.execute = AsyncMock()
 
     await storage.delete([f"doc-{i}" for i in range(5)])
 
-    # 5 ids / cap 2 => 3 bounded ANY($2) DELETE statements.
-    assert storage.db.execute.await_count == 3
-    slices = [call.args[1]["ids"] for call in storage.db.execute.await_args_list]
+    # 5 ids / cap 2 => 3 bounded ANY($2) DELETE statements, all in ONE
+    # transaction (a single _run_with_retry closure) for all-or-nothing semantics.
+    assert len(storage._retry_kwargs) == 1
+    assert len(storage._captured_execute) == 3
+    slices = [args[1] for _, args in storage._captured_execute]
     assert [len(s) for s in slices] == [2, 2, 1]
+    assert all("DELETE FROM" in sql for sql, _ in storage._captured_execute)
+
+
+@pytest.mark.asyncio
+async def test_kv_delete_chunks_share_one_transaction():
+    """All delete chunks run inside a single connection.transaction()."""
+    storage = make_storage(NameSpace.KV_STORE_FULL_DOCS)
+    storage._max_delete_records_per_batch = 2
+
+    tx_calls = {"n": 0}
+
+    async def run(operation, **kwargs):
+        mock_conn = AsyncMock()
+        tx = AsyncMock()
+        tx.__aenter__.return_value = tx
+        tx.__aexit__.return_value = False
+
+        def _make_tx():
+            tx_calls["n"] += 1
+            return tx
+
+        mock_conn.transaction = MagicMock(side_effect=_make_tx)
+        await operation(mock_conn)
+
+    storage.db._run_with_retry = AsyncMock(side_effect=run)
+
+    await storage.delete([f"doc-{i}" for i in range(5)])
+
+    # One transaction wrapping all 3 chunks, not one per chunk.
+    assert tx_calls["n"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -790,10 +834,11 @@ async def test_doc_status_upsert_splits_by_record_cap():
 async def test_doc_status_delete_splits_by_id_cap():
     storage = make_doc_status_storage()
     storage._max_delete_records_per_batch = 2
-    storage.db.execute = AsyncMock()
 
     await storage.delete([f"doc-{i}" for i in range(5)])
 
-    assert storage.db.execute.await_count == 3
-    slices = [call.args[1]["ids"] for call in storage.db.execute.await_args_list]
+    # One transaction (single _run_with_retry) wrapping 3 bounded DELETEs.
+    assert len(storage._retry_kwargs) == 1
+    assert len(storage._captured_execute) == 3
+    slices = [args[1] for _, args in storage._captured_execute]
     assert [len(s) for s in slices] == [2, 2, 1]

--- a/tests/kg/postgres_impl/test_postgres_vector_deferred.py
+++ b/tests/kg/postgres_impl/test_postgres_vector_deferred.py
@@ -931,6 +931,38 @@ async def test_flush_delete_splits_by_id_cap():
 
 
 @pytest.mark.asyncio
+async def test_upsert_only_flush_with_delete_splitting_disabled():
+    """Regression: delete cap <= 0 + no pending deletes must not raise.
+
+    The disabled-delete fallback used to yield delete_chunk == 0, making the
+    empty-delete range() step raise ValueError and fail the upsert.
+    """
+    storage = _make_storage()
+    storage._max_delete_records_per_batch = 0  # documented "disable splitting"
+
+    await storage.upsert({"c1": _chunk_data(content="alpha")})
+    await storage.index_done_callback()  # upsert-only flush, no deletes
+
+    assert len(storage._captured_executemany) == 1
+    assert storage._captured_execute == []
+    assert storage._pending_vector_docs == {}
+
+
+@pytest.mark.asyncio
+async def test_flush_delete_with_splitting_disabled_runs_single_statement():
+    """delete cap <= 0 sends every pending id in one ANY($2) statement."""
+    storage = _make_storage()
+    storage._max_delete_records_per_batch = 0
+
+    await storage.delete([f"c{i}" for i in range(5)])
+    await storage.index_done_callback()
+
+    assert len(storage._captured_execute) == 1
+    _, args = storage._captured_execute[0]
+    assert len(args[1]) == 5
+
+
+@pytest.mark.asyncio
 async def test_flush_upsert_and_delete_are_separate_phases():
     storage = _make_storage()
     storage._max_upsert_records_per_batch = 10

--- a/tests/kg/postgres_impl/test_postgres_vector_deferred.py
+++ b/tests/kg/postgres_impl/test_postgres_vector_deferred.py
@@ -874,3 +874,86 @@ async def test_get_vectors_by_ids_drops_when_pending_record_removed():
 
     # The vector for the removed id is dropped from the response.
     assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Flush batching: upsert split by record cap, delete split by id cap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_flush_upsert_splits_by_record_cap():
+    storage = _make_storage()
+    storage._max_upsert_records_per_batch = 2  # byte cap left at default
+
+    await storage.upsert({f"c{i}": _chunk_data(content=f"text {i}") for i in range(5)})
+    await storage.index_done_callback()
+
+    # 5 records / cap 2 => 3 executemany calls (one per upsert chunk).
+    assert len(storage._captured_executemany) == 3
+    assert [len(rows) for _, rows in storage._captured_executemany] == [2, 2, 1]
+    # No deletes in this flush.
+    assert storage._captured_execute == []
+    assert storage._pending_vector_docs == {}
+
+
+@pytest.mark.asyncio
+async def test_flush_upsert_splits_by_payload_bytes():
+    storage = _make_storage()
+    # Disable record cap; force a byte cap small enough that each big chunk
+    # lands in its own batch.
+    storage._max_upsert_records_per_batch = 0
+    storage._max_upsert_payload_bytes = 200
+
+    await storage.upsert({f"c{i}": _chunk_data(content="X" * 150) for i in range(3)})
+    await storage.index_done_callback()
+
+    # Each ~150-byte content row exceeds half the 200-byte budget, so the three
+    # rows cannot coalesce -> 3 separate executemany calls.
+    assert len(storage._captured_executemany) == 3
+
+
+@pytest.mark.asyncio
+async def test_flush_delete_splits_by_id_cap():
+    storage = _make_storage()
+    storage._max_delete_records_per_batch = 2
+
+    await storage.delete([f"c{i}" for i in range(5)])
+    await storage.index_done_callback()
+
+    # 5 ids / cap 2 => 3 DELETE statements, each a bounded ANY($2) slice.
+    assert len(storage._captured_execute) == 3
+    slices = [args[1] for _, args in storage._captured_execute]
+    assert [len(s) for s in slices] == [2, 2, 1]
+    # Every captured statement is a DELETE.
+    assert all("DELETE FROM" in sql for sql, _ in storage._captured_execute)
+    assert storage._pending_vector_deletes == set()
+
+
+@pytest.mark.asyncio
+async def test_flush_upsert_and_delete_are_separate_phases():
+    storage = _make_storage()
+    storage._max_upsert_records_per_batch = 10
+    storage._max_delete_records_per_batch = 10
+
+    await storage.upsert({"keep": _chunk_data(content="v")})
+    await storage.delete(["gone1", "gone2"])
+    await storage.index_done_callback()
+
+    # One upsert executemany + one delete execute (disjoint buffers).
+    assert len(storage._captured_executemany) == 1
+    assert len(storage._captured_execute) == 1
+
+
+@pytest.mark.asyncio
+async def test_flush_failure_keeps_pending_buffers():
+    storage = _make_storage(fail_run_with_retry=True)
+    await storage.upsert({"c1": _chunk_data()})
+    await storage.delete(["c2"])
+
+    with pytest.raises(RuntimeError, match="simulated PG failure"):
+        await storage.index_done_callback()
+
+    # Fail-fast-retain: nothing cleared, next flush replays everything.
+    assert "c1" in storage._pending_vector_docs
+    assert "c2" in storage._pending_vector_deletes


### PR DESCRIPTION
## Summary

Ports the `MONGO_*` / `OPENSEARCH_*` batching contract to the PostgreSQL **KV / Vector / DocStatus** write paths: every bulk write/delete is now bounded by **payload bytes (primary) + record count (secondary)**, env-tunable, with visible split logging and fail-fast-retain semantics.

This is **PR 1** of a staged plan; PGGraph (chunk-level transaction fallback / AGE true-bulk) and oversized read-side `ANY($2)` lists are left as separate follow-ups.

## Background

asyncpg's `executemany` pipelines each row over a reused prepared statement, so — unlike Mongo's single 48 MB bulk command or OpenSearch's bulk request — there is **no single server message to stay under**, and each row's parameter count is far below asyncpg's 32767 cap. For PostgreSQL the byte budget therefore bounds **client-side peak memory and transaction duration**, and splitting is done **client-side** (mongo_impl style), not delegated to the driver.

Most urgent gap: `PGVectorStorage._flush_pending_vector_ops` flushed the **entire** buffer in one `executemany` + one `ANY($2)` delete — tens of thousands of large vectors in a single transaction.

## Changes

- **Helpers** (`lightrag/kg/postgres_impl.py`): `_resolve_pg_batch_limits()`, `_estimate_record_bytes()` (ndarray→`.nbytes`, str→UTF-8, dict/list→compact JSON, scalar→const), and `_chunk_by_budget()` (copied from `mongo_impl`; byte budget primary, record count secondary, oversized single record emitted alone, non-positive disables a dimension).
- **`__post_init__`**: `PGKVStorage` / `PGVectorStorage` / `PGDocStatusStorage` resolve and store the three caps (`PGDocStatusStorage` gains a `__post_init__`).
- **KV upsert**: fixed-200 record split → `_chunk_by_budget` (byte+record). **Vector flush**: whole-buffer `executemany` → bounded chunks, with **upsert/delete run as separate phases** (the buffers are disjoint). **DocStatus upsert**: bounded chunks. **All three deletes** chunk the `ANY($2)` id list by the delete cap.
- **Transactions**: Vector flush / DocStatus upsert move from one transaction to **one transaction per chunk**. upsert (`ON CONFLICT`) and delete (`ANY($2)`) are idempotent and the buffer is cleared only on full success, so a mid-flush failure raises with buffers intact and the next flush replays everything (fail-fast-retain) — same semantics as Mongo/OpenSearch.
- **`env.example`**: three `POSTGRES_*` knobs.

## Defaults

| Knob | Default | Rationale |
|---|---|---|
| `POSTGRES_UPSERT_MAX_PAYLOAD_BYTES` | `16777216` (16 MiB) | client-side memory / tx-duration bound |
| `POSTGRES_UPSERT_MAX_RECORDS_PER_BATCH` | `200` | keeps PGKVStorage's historical batch size (intentionally not Mongo/OS's 128) |
| `POSTGRES_DELETE_MAX_RECORDS_PER_BATCH` | `1000` | matches OpenSearch |

## Test plan

- [x] `ruff check lightrag/kg/postgres_impl.py tests/kg/postgres_impl/` — clean
- [x] `pytest tests/kg/postgres_impl/ -q` — **172 passed, 6 skipped** (live-PG tests skip)
- [x] New `test_postgres_batch_limits.py`: env defaults / override / non-positive-disable, `_estimate_record_bytes` per-field, `_chunk_by_budget` record/byte/dual/oversized
- [x] New flush tests: Vector upsert split by record & by byte budget, delete chunking, upsert/delete separate phases, fail-fast-retain keeps pending; KV byte-split + delete chunk; DocStatus record-split + delete chunk

## Out of scope (follow-ups)

- **PR 2**: PGGraph chunk-level transaction fallback (`upsert_nodes/edges_batch`, `remove_nodes`, `remove_edges`).
- **PR 3**: AGE true-bulk (`UNWIND`) exploration.
- Oversized read-side `ANY($2)` id lists (a Mongo-PR follow-up too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)