### PR TITLE
⚡ feat(postgres): chunk-level transaction fallback for PGGraph batch writes

### DIFF
--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -5814,21 +5814,6 @@ def _is_transient_graph_write_error(exc: BaseException) -> bool:
     )
 
 
-# Transaction-scoped advisory lock that serialises concurrent upserts of the
-# same logical edge. Keyed on (graph_name, ordered (src, tgt)) so {A,B}/{B,A}
-# collide while the same pair in a different graph/workspace does not. See
-# PGGraphStorage.upsert_edge for the full rationale.
-_EDGE_ADVISORY_LOCK_SQL = (
-    "SELECT pg_advisory_xact_lock("
-    "  hashtextextended("
-    "    $1::text || E'\\x01' ||"
-    "    LEAST($2::text, $3::text) || E'\\x01' || GREATEST($2::text, $3::text),"
-    "    0"
-    "  )"
-    ")"
-)
-
-
 @final
 @dataclass
 class PGGraphStorage(BaseGraphStorage):
@@ -6346,8 +6331,7 @@ class PGGraphStorage(BaseGraphStorage):
         Shared by ``upsert_edge`` and ``upsert_edges_batch``. The endpoint ids
         are parameterized; edge properties are inlined in the CREATE clause (the
         only reliable way to persist edge properties in AGE -- see
-        ``upsert_edge`` for the full rationale). The advisory lock is issued
-        separately via ``_EDGE_ADVISORY_LOCK_SQL``.
+        ``upsert_edge`` for the full rationale).
         """
         props_literal = self._format_properties(edge_data) if edge_data else "{}"
         cypher_query = f"""MATCH (source:base {{entity_id: $src_id}})
@@ -6398,6 +6382,11 @@ class PGGraphStorage(BaseGraphStorage):
     async def upsert_node(self, node_id: str, node_data: dict[str, str]) -> None:
         """
         Upsert a node in the Neo4j database.
+
+        Caller contract:
+            Not exposed as a public API and not meant for direct/concurrent use.
+            The caller MUST guarantee single-writer-per-workspace
+            (``pipeline_status`` idle) so no other writer races this node.
 
         Args:
             node_id: The unique identifier for the node (used as label)
@@ -6452,6 +6441,12 @@ class PGGraphStorage(BaseGraphStorage):
         """
         Upsert an edge and its properties between two nodes identified by their labels.
 
+        Caller contract:
+            Not exposed as a public API and not meant for direct/concurrent use.
+            The caller MUST guarantee single-writer-per-workspace (the document
+            pipeline's ``busy`` / ``destructive_busy`` gate, i.e. ``pipeline_status``
+            idle) so no other writer races this edge. See the class docstring.
+
         Args:
             source_node_id (str): Label of the source node (used as identifier)
             target_node_id (str): Label of the target node (used as identifier)
@@ -6465,22 +6460,11 @@ class PGGraphStorage(BaseGraphStorage):
         # directly in a CREATE clause. We use OPTIONAL MATCH to delete any existing
         # edge first so the operation remains idempotent.
         #
-        # Concurrency: OPTIONAL MATCH + DELETE + CREATE is not atomic against other
-        # writers — two transactions upserting the same pair could both observe no
-        # existing edge and both CREATE one, leaving duplicate DIRECTED rows that
-        # inflate degree counts and duplicate relations. We serialise per logical
-        # edge with a transaction-scoped advisory lock keyed on
-        # (graph_name, ordered (src_id, tgt_id)) so:
-        #   - {A,B} and {B,A} collide on the same lock (the OPTIONAL MATCH is
-        #     undirected), and
-        #   - the same (A,B) pair in different AGE graphs / workspaces does NOT
-        #     collide. pg_advisory_xact_lock is database-wide, and we don't want
-        #     independent tenants to serialise each other's ingestion.
-        # AGE refuses to plan a join against a cypher() call that contains a
-        # CREATE clause ("cypher create clause cannot be rescanned"), so we cannot
-        # use a CTE for the lock. Instead we open an explicit transaction and run
-        # two statements on the same connection: the lock acquisition first, then
-        # the cypher upsert. The lock is released when the transaction commits.
+        # Concurrency: OPTIONAL MATCH + DELETE + CREATE is not atomic against a
+        # *concurrent* writer of the same pair (both could observe no edge and both
+        # CREATE one, leaving duplicate DIRECTED rows). No DB-side advisory lock is
+        # taken: the single-writer-per-workspace contract above guarantees there is
+        # no concurrent writer, so the lone-statement transaction is sufficient.
         cypher_sql, params_json = self._build_upsert_edge_sql(
             source_node_id, target_node_id, edge_data
         )
@@ -6495,12 +6479,6 @@ class PGGraphStorage(BaseGraphStorage):
 
         async def _operation(connection: asyncpg.Connection) -> None:
             async with connection.transaction():
-                await connection.execute(
-                    _EDGE_ADVISORY_LOCK_SQL,
-                    self.graph_name,
-                    source_node_id,
-                    target_node_id,
-                )
                 await connection.execute(cypher_sql, params_json)
 
         try:
@@ -6609,6 +6587,11 @@ class PGGraphStorage(BaseGraphStorage):
         AGE-configure / transaction overhead of the old serial fallback.
         Deduplicating by node ID first preserves last-write-wins.
 
+        Caller contract:
+            Not exposed as a public API and not meant for direct/concurrent use.
+            The caller MUST guarantee single-writer-per-workspace
+            (``pipeline_status`` idle) so no other writer races these nodes.
+
         Args:
             nodes: List of (node_id, node_data) tuples.
         """
@@ -6660,23 +6643,13 @@ class PGGraphStorage(BaseGraphStorage):
         """Upsert one chunk of edges in a single AGE transaction.
 
         Each edge runs its OPTIONAL MATCH + DELETE + CREATE as one statement, all
-        wrapped in a single transaction. Unlike the single-row ``upsert_edge``,
-        the batch path does **not** take the per-edge ``pg_advisory_xact_lock``:
-
-          * Same-edge write races are already excluded by the single-writer
-            -per-workspace pipeline contract and the application-level keyed
-            locks the callers hold (operate.py's per-edge
-            ``get_storage_keyed_lock`` for the single path, and
-            ``ainsert_custom_kg``'s coarse keyed lock over every endpoint for the
-            batch path), so the lock's cross-process defense is redundant here.
-          * Holding one advisory lock per edge until the chunk commits would mean
-            up to ``_max_upsert_records_per_batch`` simultaneous locks (and
-            unboundedly many if the cap is disabled), risking shared-lock-table
-            exhaustion -- the opposite of what chunking is for.
-
-        Edges are still deduped within the chunk, so no edge is touched twice in
-        one transaction. Retry semantics mirror ``upsert_edge``: MERGE / DELETE +
-        CREATE are idempotent, so a full-chunk replay is safe.
+        wrapped in a single transaction. Like ``upsert_edge``, no advisory lock is
+        taken: the single-writer-per-workspace contract (caller keeps
+        ``pipeline_status`` idle) guarantees no concurrent writer, so the
+        DELETE+CREATE cannot race. Edges are also deduped within the chunk, so no
+        edge is touched twice in one transaction. Retry semantics mirror
+        ``upsert_edge``: DELETE + CREATE is idempotent, so a full-chunk replay is
+        safe.
         """
         built = [
             self._build_upsert_edge_sql(src, tgt, edge_data)
@@ -6719,7 +6692,12 @@ class PGGraphStorage(BaseGraphStorage):
         the per-edge transaction / AGE-configure overhead of the old serial
         fallback. Iteration is in canonical (LEAST, GREATEST) order purely for
         deterministic dedup / reproducible replay; see ``_upsert_edge_chunk`` for
-        why the batch path does not take per-edge advisory locks.
+        why no advisory lock is taken.
+
+        Caller contract:
+            Not exposed as a public API and not meant for direct/concurrent use.
+            The caller MUST guarantee single-writer-per-workspace
+            (``pipeline_status`` idle) so no other writer races these edges.
 
         Args:
             edges: List of (source_node_id, target_node_id, edge_data) tuples.
@@ -6752,6 +6730,11 @@ class PGGraphStorage(BaseGraphStorage):
     async def delete_node(self, node_id: str) -> None:
         """
         Delete a node from the graph.
+
+        Caller contract:
+            Not exposed as a public API and not meant for direct/concurrent use.
+            The caller MUST guarantee single-writer-per-workspace
+            (``pipeline_status`` idle) so no other writer races this delete.
 
         Args:
             node_id (str): The ID of the node to delete.

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -5832,13 +5832,28 @@ _EDGE_ADVISORY_LOCK_SQL = (
     ")"
 )
 
-# Transaction-scoped advisory lock keyed on the whole graph ($1 = graph_name).
-# Used by the edge *batch* path: rather than one per-edge lock per row (which
-# would pile up to the chunk size and risk shared-lock-table exhaustion), a
-# chunk takes a single graph-wide lock -- one advisory lock regardless of how
-# many edges the batch carries -- serialising bulk edge writes on the graph as
-# one unit.
+# Graph-wide advisory locks keyed on the whole graph ($1 = graph_name), used so
+# the edge *batch* path conflicts with concurrent single-edge writers without
+# taking one lock per edge.
+#
+#   * EXCLUSIVE (batch): one ``pg_advisory_xact_lock`` per chunk -- a single
+#     advisory lock regardless of edge count, so it can't pile up to the chunk
+#     size or exhaust the shared lock table. It serialises a bulk edge write
+#     against the graph as one unit.
+#   * SHARED (single): every single ``upsert_edge`` also takes
+#     ``pg_advisory_xact_lock_shared`` on the same key. Shared/shared is
+#     compatible, so concurrent single-edge writes on *different* edges do not
+#     serialise (pipeline concurrency preserved); shared/exclusive conflicts, so
+#     a batch and any single-edge writer on the same graph cannot interleave
+#     their OPTIONAL MATCH/DELETE/CREATE and create duplicate DIRECTED rows.
+#
+# The shared graph lock does NOT serialise two single writers of the *same*
+# edge (shared/shared is compatible) -- that is what the per-edge
+# ``_EDGE_ADVISORY_LOCK_SQL`` is for; the two cover different races.
 _GRAPH_ADVISORY_LOCK_SQL = "SELECT pg_advisory_xact_lock(hashtextextended($1::text, 0))"
+_GRAPH_ADVISORY_LOCK_SHARED_SQL = (
+    "SELECT pg_advisory_xact_lock_shared(hashtextextended($1::text, 0))"
+)
 
 
 @final
@@ -6488,12 +6503,17 @@ class PGGraphStorage(BaseGraphStorage):
         # Concurrency: OPTIONAL MATCH + DELETE + CREATE is not atomic against a
         # concurrent writer of the same pair (both could observe no edge and both
         # CREATE one, leaving duplicate DIRECTED rows). The graph-edit endpoints do
-        # not hold the pipeline writer slot, so we serialise per logical edge with a
-        # transaction-scoped advisory lock keyed on (graph_name, ordered (src, tgt))
-        # acquired before the cypher upsert, on the same connection / transaction.
-        # AGE refuses to plan a join against a cypher() call containing a CREATE
-        # ("cypher create clause cannot be rescanned"), so the lock cannot live in a
-        # CTE -- it is a separate statement inside the explicit transaction.
+        # not hold the pipeline writer slot, so the transaction takes two
+        # transaction-scoped advisory locks before the cypher upsert (AGE refuses
+        # to plan a join against a cypher() containing CREATE, so the locks cannot
+        # live in a CTE -- they are separate statements on the same connection):
+        #   1. per-edge EXCLUSIVE lock keyed on (graph_name, ordered (src, tgt)) --
+        #      serialises same-edge single-vs-single writers while letting
+        #      different edges proceed concurrently (pipeline concurrency);
+        #   2. graph-wide SHARED lock -- conflicts with the batch path's graph-wide
+        #      EXCLUSIVE lock so a bulk upsert_edges_batch and a single edge write
+        #      cannot interleave, without serialising single writers against each
+        #      other (shared/shared is compatible).
         cypher_sql, params_json = self._build_upsert_edge_sql(
             source_node_id, target_node_id, edge_data
         )
@@ -6513,6 +6533,9 @@ class PGGraphStorage(BaseGraphStorage):
                     self.graph_name,
                     source_node_id,
                     target_node_id,
+                )
+                await connection.execute(
+                    _GRAPH_ADVISORY_LOCK_SHARED_SQL, self.graph_name
                 )
                 await connection.execute(cypher_sql, params_json)
 
@@ -6678,12 +6701,14 @@ class PGGraphStorage(BaseGraphStorage):
         Each edge runs its OPTIONAL MATCH + DELETE + CREATE as one statement, all
         wrapped in a single transaction. Instead of the single-row path's per-edge
         advisory lock (which would pile up to the chunk size), the chunk takes ONE
-        graph-wide ``_GRAPH_ADVISORY_LOCK_SQL`` at the top of the transaction --
-        a single advisory lock regardless of edge count -- which serialises bulk
-        edge writes against the same graph and prevents the concurrent
-        OPTIONAL MATCH/DELETE/CREATE duplicate race. Edges are also deduped within
-        the chunk. Retry semantics mirror ``upsert_edge``: DELETE + CREATE is
-        idempotent, so a full-chunk replay is safe.
+        graph-wide EXCLUSIVE ``_GRAPH_ADVISORY_LOCK_SQL`` at the top of the
+        transaction -- a single advisory lock regardless of edge count. It
+        conflicts with the graph-wide SHARED lock every single ``upsert_edge``
+        takes, so a bulk edge write and any concurrent single-edge write on the
+        same graph cannot interleave their OPTIONAL MATCH/DELETE/CREATE and create
+        duplicate DIRECTED rows. Edges are also deduped within the chunk. Retry
+        semantics mirror ``upsert_edge``: DELETE + CREATE is idempotent, so a
+        full-chunk replay is safe.
         """
         built = [
             self._build_upsert_edge_sql(src, tgt, edge_data)

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -5814,6 +5814,33 @@ def _is_transient_graph_write_error(exc: BaseException) -> bool:
     )
 
 
+# Transaction-scoped advisory lock that serialises concurrent upserts of the
+# *same logical edge* (single-row ``upsert_edge``). Keyed on
+# (graph_name, ordered (src, tgt)) so {A,B}/{B,A} collide while the same pair in
+# a different graph/workspace does not. It is the DB-level last line of defense
+# for the busy-check race on the graph-edit endpoints (see
+# document_routes.check_pipeline_busy_or_raise): two concurrent writers could
+# otherwise both pass the OPTIONAL MATCH and both CREATE, leaving duplicate
+# DIRECTED rows.
+_EDGE_ADVISORY_LOCK_SQL = (
+    "SELECT pg_advisory_xact_lock("
+    "  hashtextextended("
+    "    $1::text || E'\\x01' ||"
+    "    LEAST($2::text, $3::text) || E'\\x01' || GREATEST($2::text, $3::text),"
+    "    0"
+    "  )"
+    ")"
+)
+
+# Transaction-scoped advisory lock keyed on the whole graph ($1 = graph_name).
+# Used by the edge *batch* path: rather than one per-edge lock per row (which
+# would pile up to the chunk size and risk shared-lock-table exhaustion), a
+# chunk takes a single graph-wide lock -- one advisory lock regardless of how
+# many edges the batch carries -- serialising bulk edge writes on the graph as
+# one unit.
+_GRAPH_ADVISORY_LOCK_SQL = "SELECT pg_advisory_xact_lock(hashtextextended($1::text, 0))"
+
+
 @final
 @dataclass
 class PGGraphStorage(BaseGraphStorage):
@@ -6438,10 +6465,12 @@ class PGGraphStorage(BaseGraphStorage):
         Upsert an edge and its properties between two nodes identified by their labels.
 
         Caller contract:
-            Not exposed as a public API and not meant for direct/concurrent use.
-            The caller MUST guarantee single-writer-per-workspace (the document
-            pipeline's ``busy`` / ``destructive_busy`` gate, i.e. ``pipeline_status``
-            idle) so no other writer races this edge. See the class docstring.
+            Not exposed as a public API. Document-pipeline callers run under the
+            single-writer gate, but the graph-edit endpoints
+            (``/graph/relation/edit`` etc.) only best-effort-check
+            ``pipeline_status`` (``check_pipeline_busy_or_raise``) and can race a
+            pipeline write in the check-to-write window — so this path keeps the
+            per-edge advisory lock below as the DB-level last line of defense.
 
         Args:
             source_node_id (str): Label of the source node (used as identifier)
@@ -6457,10 +6486,14 @@ class PGGraphStorage(BaseGraphStorage):
         # edge first so the operation remains idempotent.
         #
         # Concurrency: OPTIONAL MATCH + DELETE + CREATE is not atomic against a
-        # *concurrent* writer of the same pair (both could observe no edge and both
-        # CREATE one, leaving duplicate DIRECTED rows). No DB-side advisory lock is
-        # taken: the single-writer-per-workspace contract above guarantees there is
-        # no concurrent writer, so the lone-statement transaction is sufficient.
+        # concurrent writer of the same pair (both could observe no edge and both
+        # CREATE one, leaving duplicate DIRECTED rows). The graph-edit endpoints do
+        # not hold the pipeline writer slot, so we serialise per logical edge with a
+        # transaction-scoped advisory lock keyed on (graph_name, ordered (src, tgt))
+        # acquired before the cypher upsert, on the same connection / transaction.
+        # AGE refuses to plan a join against a cypher() call containing a CREATE
+        # ("cypher create clause cannot be rescanned"), so the lock cannot live in a
+        # CTE -- it is a separate statement inside the explicit transaction.
         cypher_sql, params_json = self._build_upsert_edge_sql(
             source_node_id, target_node_id, edge_data
         )
@@ -6475,6 +6508,12 @@ class PGGraphStorage(BaseGraphStorage):
 
         async def _operation(connection: asyncpg.Connection) -> None:
             async with connection.transaction():
+                await connection.execute(
+                    _EDGE_ADVISORY_LOCK_SQL,
+                    self.graph_name,
+                    source_node_id,
+                    target_node_id,
+                )
                 await connection.execute(cypher_sql, params_json)
 
         try:
@@ -6637,13 +6676,14 @@ class PGGraphStorage(BaseGraphStorage):
         """Upsert one chunk of edges in a single AGE transaction.
 
         Each edge runs its OPTIONAL MATCH + DELETE + CREATE as one statement, all
-        wrapped in a single transaction. Like ``upsert_edge``, no advisory lock is
-        taken: the single-writer-per-workspace contract (caller keeps
-        ``pipeline_status`` idle) guarantees no concurrent writer, so the
-        DELETE+CREATE cannot race. Edges are also deduped within the chunk, so no
-        edge is touched twice in one transaction. Retry semantics mirror
-        ``upsert_edge``: DELETE + CREATE is idempotent, so a full-chunk replay is
-        safe.
+        wrapped in a single transaction. Instead of the single-row path's per-edge
+        advisory lock (which would pile up to the chunk size), the chunk takes ONE
+        graph-wide ``_GRAPH_ADVISORY_LOCK_SQL`` at the top of the transaction --
+        a single advisory lock regardless of edge count -- which serialises bulk
+        edge writes against the same graph and prevents the concurrent
+        OPTIONAL MATCH/DELETE/CREATE duplicate race. Edges are also deduped within
+        the chunk. Retry semantics mirror ``upsert_edge``: DELETE + CREATE is
+        idempotent, so a full-chunk replay is safe.
         """
         built = [
             self._build_upsert_edge_sql(src, tgt, edge_data)
@@ -6653,6 +6693,7 @@ class PGGraphStorage(BaseGraphStorage):
 
         async def _operation(connection: asyncpg.Connection) -> None:
             async with connection.transaction():
+                await connection.execute(_GRAPH_ADVISORY_LOCK_SQL, self.graph_name)
                 for cypher_sql, params_json in built:
                     await connection.execute(cypher_sql, params_json)
 
@@ -6685,13 +6726,13 @@ class PGGraphStorage(BaseGraphStorage):
         payload/record-bounded chunks, each run in one transaction -- removing
         the per-edge transaction / AGE-configure overhead of the old serial
         fallback. Iteration is in canonical (LEAST, GREATEST) order purely for
-        deterministic dedup / reproducible replay; see ``_upsert_edge_chunk`` for
-        why no advisory lock is taken.
+        deterministic dedup / reproducible replay. Each chunk takes one graph-wide
+        advisory lock (see ``_upsert_edge_chunk``) rather than a lock per edge.
 
         Caller contract:
-            Not exposed as a public API and not meant for direct/concurrent use.
-            The caller MUST guarantee single-writer-per-workspace
-            (``pipeline_status`` idle) so no other writer races these edges.
+            Not exposed as a public API. The only in-tree caller
+            (``ainsert_custom_kg``) holds a coarse keyed lock over every endpoint;
+            the per-chunk graph-wide advisory lock is the DB-level backstop.
 
         Args:
             edges: List of (source_node_id, target_node_id, edge_data) tuples.

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -5814,12 +5814,36 @@ def _is_transient_graph_write_error(exc: BaseException) -> bool:
     )
 
 
+# Transaction-scoped advisory lock that serialises concurrent upserts of the
+# same logical edge. Keyed on (graph_name, ordered (src, tgt)) so {A,B}/{B,A}
+# collide while the same pair in a different graph/workspace does not. See
+# PGGraphStorage.upsert_edge for the full rationale.
+_EDGE_ADVISORY_LOCK_SQL = (
+    "SELECT pg_advisory_xact_lock("
+    "  hashtextextended("
+    "    $1::text || E'\\x01' ||"
+    "    LEAST($2::text, $3::text) || E'\\x01' || GREATEST($2::text, $3::text),"
+    "    0"
+    "  )"
+    ")"
+)
+
+
 @final
 @dataclass
 class PGGraphStorage(BaseGraphStorage):
     def __post_init__(self):
         # Graph name will be dynamically generated in initialize() based on workspace
         self.db: PostgreSQLDB | None = None
+        # Chunk-level batching limits for the batch upsert / remove paths. The
+        # payload budget bounds the Cypher text inlined per chunk and the
+        # transaction / advisory-lock duration; the record caps bound the chunk
+        # size. Shared with the KV/Vector/DocStatus knobs.
+        (
+            self._max_upsert_payload_bytes,
+            self._max_upsert_records_per_batch,
+            self._max_delete_records_per_batch,
+        ) = _resolve_pg_batch_limits()
 
     def _get_workspace_graph_name(self) -> str:
         """
@@ -6282,6 +6306,89 @@ class PGGraphStorage(BaseGraphStorage):
 
         return edges
 
+    def _build_upsert_node_sql(
+        self, node_id: str, node_data: dict[str, str]
+    ) -> tuple[str, str]:
+        """Build the (SQL, agtype params JSON) for a single node upsert.
+
+        Shared by ``upsert_node`` (single statement) and ``upsert_nodes_batch``
+        (chunk transaction) so the two paths cannot drift. Raises ValueError if
+        ``entity_id`` is missing.
+
+        AGE supports binding scalar values in Cypher parameters here, but not a
+        bound agtype object on ``SET n += $props`` (verified on AGE 1.5.0), so
+        the node ID is parameterized and the property map is inlined as a safely
+        escaped literal.
+        """
+        if "entity_id" not in node_data:
+            raise ValueError(
+                "PostgreSQL: node properties must contain an 'entity_id' field"
+            )
+        node_props = {k: v for k, v in node_data.items() if k != "entity_id"}
+        props_literal = self._format_properties(node_props)
+        cypher_query = f"""MERGE (n:base {{entity_id: $entity_id}})
+                     SET n += {props_literal}
+                     RETURN n"""
+        query = (
+            f"SELECT * FROM cypher("
+            f"{_dollar_quote(self.graph_name)}::name, "
+            f"{_dollar_quote(cypher_query)}::cstring, "
+            f"$1::agtype) AS (n agtype)"
+        )
+        params_json = json.dumps({"entity_id": node_id}, ensure_ascii=False)
+        return query, params_json
+
+    def _build_upsert_edge_sql(
+        self, source_node_id: str, target_node_id: str, edge_data: dict[str, str]
+    ) -> tuple[str, str]:
+        """Build the (Cypher SQL, agtype params JSON) for a single edge upsert.
+
+        Shared by ``upsert_edge`` and ``upsert_edges_batch``. The endpoint ids
+        are parameterized; edge properties are inlined in the CREATE clause (the
+        only reliable way to persist edge properties in AGE -- see
+        ``upsert_edge`` for the full rationale). The advisory lock is issued
+        separately via ``_EDGE_ADVISORY_LOCK_SQL``.
+        """
+        props_literal = self._format_properties(edge_data) if edge_data else "{}"
+        cypher_query = f"""MATCH (source:base {{entity_id: $src_id}})
+                     WITH source
+                     MATCH (target:base {{entity_id: $tgt_id}})
+                     WITH source, target
+                     OPTIONAL MATCH (source)-[old:DIRECTED]-(target)
+                     DELETE old
+                     WITH source, target
+                     CREATE (source)-[r:DIRECTED {props_literal}]->(target)
+                     RETURN r"""
+        cypher_sql = (
+            f"SELECT r FROM cypher("
+            f"{_dollar_quote(self.graph_name)}::name, "
+            f"{_dollar_quote(cypher_query)}::cstring, "
+            f"$1::agtype) AS (r agtype)"
+        )
+        params_json = json.dumps(
+            {"src_id": source_node_id, "tgt_id": target_node_id},
+            ensure_ascii=False,
+        )
+        return cypher_sql, params_json
+
+    def _estimate_node_cypher_bytes(
+        self, node_id: str, node_data: dict[str, str]
+    ) -> int:
+        """Estimate the inlined-Cypher byte size of one node upsert (for chunking)."""
+        node_props = {k: v for k, v in node_data.items() if k != "entity_id"}
+        return len(
+            (node_id + self._format_properties(node_props)).encode("utf-8")
+        )
+
+    def _estimate_edge_cypher_bytes(
+        self, source_node_id: str, target_node_id: str, edge_data: dict[str, str]
+    ) -> int:
+        """Estimate the inlined-Cypher byte size of one edge upsert (for chunking)."""
+        props_literal = self._format_properties(edge_data) if edge_data else "{}"
+        return len(
+            (source_node_id + target_node_id + props_literal).encode("utf-8")
+        )
+
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=4, max=10),
@@ -6296,32 +6403,8 @@ class PGGraphStorage(BaseGraphStorage):
             node_id: The unique identifier for the node (used as label)
             node_data: Dictionary of node properties
         """
-        if "entity_id" not in node_data:
-            raise ValueError(
-                "PostgreSQL: node properties must contain an 'entity_id' field"
-            )
-
-        # AGE supports binding scalar values in Cypher parameters here, but not
-        # using a bound agtype object on ``SET n += $props`` (verified on AGE 1.5.0).
-        # Keep the node ID parameterized and inline a safely escaped property map literal.
-        node_props = {k: v for k, v in node_data.items() if k != "entity_id"}
-        props_literal = self._format_properties(node_props)
-        cypher_query = f"""MERGE (n:base {{entity_id: $entity_id}})
-                     SET n += {props_literal}
-                     RETURN n"""
-
-        query = (
-            f"SELECT * FROM cypher("
-            f"{_dollar_quote(self.graph_name)}::name, "
-            f"{_dollar_quote(cypher_query)}::cstring, "
-            f"$1::agtype) AS (n agtype)"
-        )
-        pg_params = {
-            "params": json.dumps(
-                {"entity_id": node_id},
-                ensure_ascii=False,
-            )
-        }
+        query, node_params_json = self._build_upsert_node_sql(node_id, node_data)
+        pg_params = {"params": node_params_json}
         timing_label = f"{self.workspace} PGGraphStorage.upsert_node"
         total_start = time.perf_counter()
         performance_timing_log(
@@ -6398,35 +6481,8 @@ class PGGraphStorage(BaseGraphStorage):
         # use a CTE for the lock. Instead we open an explicit transaction and run
         # two statements on the same connection: the lock acquisition first, then
         # the cypher upsert. The lock is released when the transaction commits.
-        props_literal = self._format_properties(edge_data) if edge_data else "{}"
-        cypher_query = f"""MATCH (source:base {{entity_id: $src_id}})
-                     WITH source
-                     MATCH (target:base {{entity_id: $tgt_id}})
-                     WITH source, target
-                     OPTIONAL MATCH (source)-[old:DIRECTED]-(target)
-                     DELETE old
-                     WITH source, target
-                     CREATE (source)-[r:DIRECTED {props_literal}]->(target)
-                     RETURN r"""
-
-        lock_sql = (
-            "SELECT pg_advisory_xact_lock("
-            "  hashtextextended("
-            "    $1::text || E'\\x01' ||"
-            "    LEAST($2::text, $3::text) || E'\\x01' || GREATEST($2::text, $3::text),"
-            "    0"
-            "  )"
-            ")"
-        )
-        cypher_sql = (
-            f"SELECT r FROM cypher("
-            f"{_dollar_quote(self.graph_name)}::name, "
-            f"{_dollar_quote(cypher_query)}::cstring, "
-            f"$1::agtype) AS (r agtype)"
-        )
-        params_json = json.dumps(
-            {"src_id": source_node_id, "tgt_id": target_node_id},
-            ensure_ascii=False,
+        cypher_sql, params_json = self._build_upsert_edge_sql(
+            source_node_id, target_node_id, edge_data
         )
         timing_label = f"{self.workspace} PGGraphStorage.upsert_edge"
         total_start = time.perf_counter()
@@ -6440,7 +6496,10 @@ class PGGraphStorage(BaseGraphStorage):
         async def _operation(connection: asyncpg.Connection) -> None:
             async with connection.transaction():
                 await connection.execute(
-                    lock_sql, self.graph_name, source_node_id, target_node_id
+                    _EDGE_ADVISORY_LOCK_SQL,
+                    self.graph_name,
+                    source_node_id,
+                    target_node_id,
                 )
                 await connection.execute(cypher_sql, params_json)
 
@@ -6492,12 +6551,63 @@ class PGGraphStorage(BaseGraphStorage):
                 }
             ) from e
 
-    async def upsert_nodes_batch(self, nodes: list[tuple[str, dict[str, str]]]) -> None:
-        """Batch insert/update multiple nodes while preserving input-order semantics.
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=4, max=10),
+        retry=retry_if_exception(_is_transient_graph_write_error),
+        reraise=True,
+    )
+    async def _upsert_node_chunk(
+        self, chunk: list[tuple[str, dict[str, str]]]
+    ) -> None:
+        """Upsert one chunk of nodes in a single AGE transaction.
 
-        PostgreSQL/AGE write paths embed properties directly in Cypher strings and do not
-        yet support parameterized UNWIND. Deduplicating by node ID first preserves the
-        last-write-wins behaviour of the historical serial fallback.
+        Each node's MERGE runs as its own statement on one shared connection,
+        all wrapped in a single transaction so a mid-chunk failure rolls the
+        whole chunk back. ``_run_with_retry`` handles connection-level transient
+        errors; the ``@retry`` here handles query-level ones (deadlock /
+        serialization / lock) wrapped as PGGraphQueryException, mirroring
+        ``upsert_node``. MERGE is idempotent, so a full-chunk replay is safe.
+        """
+        built = [
+            self._build_upsert_node_sql(node_id, node_data)
+            for node_id, node_data in chunk
+        ]
+        timing_label = f"{self.workspace} PGGraphStorage.upsert_nodes_batch"
+
+        async def _operation(connection: asyncpg.Connection) -> None:
+            async with connection.transaction():
+                for query, params_json in built:
+                    await connection.execute(query, params_json)
+
+        try:
+            await self.db._run_with_retry(
+                _operation,
+                with_age=True,
+                graph_name=self.graph_name,
+                timing_label=timing_label,
+            )
+        except Exception as e:
+            if isinstance(e, PGGraphQueryException):
+                raise
+            raise PGGraphQueryException(
+                {
+                    "message": "Error executing graph upsert_nodes_batch chunk",
+                    "wrapped": built[0][0] if built else "",
+                    "detail": repr(e),
+                    "error_type": e.__class__.__name__,
+                }
+            ) from e
+
+    async def upsert_nodes_batch(self, nodes: list[tuple[str, dict[str, str]]]) -> None:
+        """Batch insert/update multiple nodes in chunk-level transactions.
+
+        AGE inlines properties in Cypher and has no parameterized UNWIND bulk
+        upsert, so this keeps the per-node MERGE but groups nodes into
+        payload/record-bounded chunks, each run in one transaction on a single
+        shared connection -- removing the per-node connection-acquire /
+        AGE-configure / transaction overhead of the old serial fallback.
+        Deduplicating by node ID first preserves last-write-wins.
 
         Args:
             nodes: List of (node_id, node_data) tuples.
@@ -6509,8 +6619,20 @@ class PGGraphStorage(BaseGraphStorage):
             deduped_nodes.pop(node_id, None)
             deduped_nodes[node_id] = node_data
 
-        for node_id, node_data in deduped_nodes.items():
-            await self.upsert_node(node_id, node_data=node_data)
+        items = list(deduped_nodes.items())
+        batches = _chunk_by_budget(
+            items,
+            lambda pair: self._estimate_node_cypher_bytes(pair[0], pair[1]),
+            self._max_upsert_payload_bytes,
+            self._max_upsert_records_per_batch,
+        )
+        if len(batches) > 1:
+            logger.info(
+                f"[{self.workspace}] {self.namespace} nodes: node upsert split "
+                f"into {len(batches)} chunks for {len(items)} nodes"
+            )
+        for chunk, _estimated_bytes in batches:
+            await self._upsert_node_chunk(chunk)
 
     async def has_nodes_batch(self, node_ids: list[str]) -> set[str]:
         """Check existence of multiple nodes using a single array-based SQL query.
@@ -6526,14 +6648,71 @@ class PGGraphStorage(BaseGraphStorage):
         result = await self.get_nodes_batch(node_ids)
         return set(result.keys())
 
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=4, max=10),
+        retry=retry_if_exception(_is_transient_graph_write_error),
+        reraise=True,
+    )
+    async def _upsert_edge_chunk(
+        self, chunk: list[tuple[str, str, dict[str, str]]]
+    ) -> None:
+        """Upsert one chunk of edges in a single AGE transaction.
+
+        Each edge acquires its transaction-scoped advisory lock then runs its
+        OPTIONAL MATCH + DELETE + CREATE, all in one transaction. The caller
+        feeds edges in canonical (LEAST, GREATEST) order, so a chunk acquires its
+        several locks in a globally consistent order across workers -- this is
+        what prevents deadlocks now that a chunk holds multiple edge locks until
+        commit. Retry semantics mirror ``upsert_edge``.
+        """
+        built = [
+            (src, tgt, *self._build_upsert_edge_sql(src, tgt, edge_data))
+            for src, tgt, edge_data in chunk
+        ]
+        timing_label = f"{self.workspace} PGGraphStorage.upsert_edges_batch"
+
+        async def _operation(connection: asyncpg.Connection) -> None:
+            async with connection.transaction():
+                for src, tgt, cypher_sql, params_json in built:
+                    await connection.execute(
+                        _EDGE_ADVISORY_LOCK_SQL, self.graph_name, src, tgt
+                    )
+                    await connection.execute(cypher_sql, params_json)
+
+        try:
+            await self.db._run_with_retry(
+                _operation,
+                with_age=True,
+                graph_name=self.graph_name,
+                timing_label=timing_label,
+            )
+        except Exception as e:
+            if isinstance(e, PGGraphQueryException):
+                raise
+            raise PGGraphQueryException(
+                {
+                    "message": "Error executing graph upsert_edges_batch chunk",
+                    "wrapped": built[0][2] if built else "",
+                    "detail": repr(e),
+                    "error_type": e.__class__.__name__,
+                }
+            ) from e
+
     async def upsert_edges_batch(
         self, edges: list[tuple[str, str, dict[str, str]]]
     ) -> None:
-        """Batch insert/update multiple edges while preserving input-order semantics.
+        """Batch insert/update multiple edges in chunk-level transactions.
 
-        PostgreSQL/AGE relationships are undirected (`MERGE (source)-[r:DIRECTED]-(target)`),
-        so batches containing reciprocal duplicates must retain the last update for each
-        endpoint pair to match the historical serial fallback.
+        AGE relationships are undirected, so reciprocal duplicates are deduped to
+        the last update per endpoint pair. Edges are processed in canonical
+        (LEAST, GREATEST) order and grouped into payload/record-bounded chunks,
+        each run in one transaction -- removing the per-edge transaction / AGE
+        configure overhead of the old serial fallback. The canonical order is now
+        load-bearing: a chunk holds several advisory locks until commit, and a
+        consistent global acquisition order across workers prevents deadlocks
+        (do not disable the record cap, or a chunk could hold unboundedly many
+        locks for an unbounded time).
 
         Args:
             edges: List of (source_node_id, target_node_id, edge_data) tuples.
@@ -6546,15 +6725,22 @@ class PGGraphStorage(BaseGraphStorage):
             deduped_edges.pop(edge_key, None)
             deduped_edges[edge_key] = (src, tgt, edge_data)
 
-        # Iterate in canonical (LEAST, GREATEST) order rather than dict
-        # insertion order. upsert_edge opens an independent transaction per
-        # call and releases the advisory lock on commit, so this is not a
-        # deadlock fix — but a deterministic iteration order makes logs and
-        # replays reproducible across callers, and matches the dedup key
-        # already used above.
-        for edge_key in sorted(deduped_edges):
-            src, tgt, edge_data = deduped_edges[edge_key]
-            await self.upsert_edge(src, tgt, edge_data=edge_data)
+        ordered = [deduped_edges[key] for key in sorted(deduped_edges)]
+        batches = _chunk_by_budget(
+            ordered,
+            lambda triple: self._estimate_edge_cypher_bytes(
+                triple[0], triple[1], triple[2]
+            ),
+            self._max_upsert_payload_bytes,
+            self._max_upsert_records_per_batch,
+        )
+        if len(batches) > 1:
+            logger.info(
+                f"[{self.workspace}] {self.namespace} edges: edge upsert split "
+                f"into {len(batches)} chunks for {len(ordered)} edges"
+            )
+        for chunk, _estimated_bytes in batches:
+            await self._upsert_edge_chunk(chunk)
 
     async def delete_node(self, node_id: str) -> None:
         """
@@ -6578,49 +6764,104 @@ class PGGraphStorage(BaseGraphStorage):
             raise
 
     async def remove_nodes(self, node_ids: list[str]) -> None:
-        """
-        Remove multiple nodes from the graph.
+        """Remove multiple nodes from the graph.
+
+        Node ids are inlined into a Cypher ``IN [...]`` list, so the list is
+        chunked by the delete record cap and the payload-byte budget to keep each
+        statement's Cypher text bounded. All chunks run in ONE transaction so the
+        removal stays all-or-nothing, matching the original single-statement
+        behaviour.
 
         Args:
             node_ids (list[str]): A list of node IDs to remove.
         """
+        if not node_ids:
+            return
         node_ids_normalized = [self._normalize_node_id(node_id) for node_id in node_ids]
-        node_id_list = ", ".join([f'"{node_id}"' for node_id in node_ids_normalized])
+        batches = _chunk_by_budget(
+            node_ids_normalized,
+            lambda nid: len(nid.encode("utf-8")) + 4,  # quotes + ", " separator
+            self._max_upsert_payload_bytes,
+            self._max_delete_records_per_batch,
+        )
+        if len(batches) > 1:
+            logger.info(
+                f"[{self.workspace}] {self.namespace} nodes: node removal split "
+                f"into {len(batches)} chunks for {len(node_ids_normalized)} nodes"
+            )
 
-        # Build Cypher query with dynamic dollar-quoting to handle entity_id containing $ sequences
-        cypher_query = f"""MATCH (n:base)
+        # Build Cypher with dynamic dollar-quoting to handle entity_id containing $ sequences
+        queries: list[str] = []
+        for chunk, _estimated_bytes in batches:
+            node_id_list = ", ".join(f'"{nid}"' for nid in chunk)
+            cypher_query = f"""MATCH (n:base)
                      WHERE n.entity_id IN [{node_id_list}]
                      DETACH DELETE n"""
+            queries.append(
+                f"SELECT * FROM cypher({_dollar_quote(self.graph_name)}, {_dollar_quote(cypher_query)}) AS (n agtype)"
+            )
 
-        query = f"SELECT * FROM cypher({_dollar_quote(self.graph_name)}, {_dollar_quote(cypher_query)}) AS (n agtype)"
+        async def _operation(connection: asyncpg.Connection) -> None:
+            async with connection.transaction():
+                for query in queries:
+                    await connection.execute(query)
 
         try:
-            await self._query(query, readonly=False)
+            await self.db._run_with_retry(
+                _operation, with_age=True, graph_name=self.graph_name
+            )
         except Exception as e:
             logger.error(f"[{self.workspace}] Error during node removal: {e}")
             raise
 
     async def remove_edges(self, edges: list[tuple[str, str]]) -> None:
-        """
-        Remove multiple edges from the graph.
+        """Remove multiple edges from the graph.
+
+        Endpoint ids are inlined into Cypher, so the edge list is chunked by the
+        delete record cap and the payload-byte budget. Each chunk runs in one
+        transaction (the old path opened one transaction per edge), bounding both
+        the Cypher text and the transaction duration per chunk.
 
         Args:
             edges (list[tuple[str, str]]): A list of edges to remove, where each edge is a tuple of (source_node_id, target_node_id).
         """
-        for source, target in edges:
-            src_label = self._normalize_node_id(source)
-            tgt_label = self._normalize_node_id(target)
-
-            # Build Cypher query with dynamic dollar-quoting to handle entity_id containing $ sequences
-            cypher_query = f"""MATCH (a:base {{entity_id: "{src_label}"}})-[r]-(b:base {{entity_id: "{tgt_label}"}})
+        if not edges:
+            return
+        normalized = [
+            (self._normalize_node_id(src), self._normalize_node_id(tgt))
+            for src, tgt in edges
+        ]
+        batches = _chunk_by_budget(
+            normalized,
+            lambda pair: len(pair[0].encode("utf-8")) + len(pair[1].encode("utf-8")) + 8,
+            self._max_upsert_payload_bytes,
+            self._max_delete_records_per_batch,
+        )
+        if len(batches) > 1:
+            logger.info(
+                f"[{self.workspace}] {self.namespace} edges: edge removal split "
+                f"into {len(batches)} chunks for {len(normalized)} edges"
+            )
+        for chunk, _estimated_bytes in batches:
+            # Build Cypher with dynamic dollar-quoting to handle entity_id containing $ sequences
+            queries: list[str] = []
+            for src_label, tgt_label in chunk:
+                cypher_query = f"""MATCH (a:base {{entity_id: "{src_label}"}})-[r]-(b:base {{entity_id: "{tgt_label}"}})
                          DELETE r"""
+                queries.append(
+                    f"SELECT * FROM cypher({_dollar_quote(self.graph_name)}, {_dollar_quote(cypher_query)}) AS (r agtype)"
+                )
 
-            query = f"SELECT * FROM cypher({_dollar_quote(self.graph_name)}, {_dollar_quote(cypher_query)}) AS (r agtype)"
+            async def _operation(
+                connection: asyncpg.Connection, _queries: list[str] = queries
+            ) -> None:
+                async with connection.transaction():
+                    for query in _queries:
+                        await connection.execute(query)
 
             try:
-                await self._query(query, readonly=False)
-                logger.debug(
-                    f"[{self.workspace}] Deleted edge from '{source}' to '{target}'"
+                await self.db._run_with_retry(
+                    _operation, with_age=True, graph_name=self.graph_name
                 )
             except Exception as e:
                 logger.error(f"[{self.workspace}] Error during edge deletion: {str(e)}")

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -6360,18 +6360,14 @@ class PGGraphStorage(BaseGraphStorage):
     ) -> int:
         """Estimate the inlined-Cypher byte size of one node upsert (for chunking)."""
         node_props = {k: v for k, v in node_data.items() if k != "entity_id"}
-        return len(
-            (node_id + self._format_properties(node_props)).encode("utf-8")
-        )
+        return len((node_id + self._format_properties(node_props)).encode("utf-8"))
 
     def _estimate_edge_cypher_bytes(
         self, source_node_id: str, target_node_id: str, edge_data: dict[str, str]
     ) -> int:
         """Estimate the inlined-Cypher byte size of one edge upsert (for chunking)."""
         props_literal = self._format_properties(edge_data) if edge_data else "{}"
-        return len(
-            (source_node_id + target_node_id + props_literal).encode("utf-8")
-        )
+        return len((source_node_id + target_node_id + props_literal).encode("utf-8"))
 
     @retry(
         stop=stop_after_attempt(3),
@@ -6535,9 +6531,7 @@ class PGGraphStorage(BaseGraphStorage):
         retry=retry_if_exception(_is_transient_graph_write_error),
         reraise=True,
     )
-    async def _upsert_node_chunk(
-        self, chunk: list[tuple[str, dict[str, str]]]
-    ) -> None:
+    async def _upsert_node_chunk(self, chunk: list[tuple[str, dict[str, str]]]) -> None:
         """Upsert one chunk of nodes in a single AGE transaction.
 
         Each node's MERGE runs as its own statement on one shared connection,
@@ -6823,7 +6817,9 @@ class PGGraphStorage(BaseGraphStorage):
         ]
         batches = _chunk_by_budget(
             normalized,
-            lambda pair: len(pair[0].encode("utf-8")) + len(pair[1].encode("utf-8")) + 8,
+            lambda pair: len(pair[0].encode("utf-8"))
+            + len(pair[1].encode("utf-8"))
+            + 8,
             self._max_upsert_payload_bytes,
             self._max_delete_records_per_batch,
         )

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -6659,25 +6659,34 @@ class PGGraphStorage(BaseGraphStorage):
     ) -> None:
         """Upsert one chunk of edges in a single AGE transaction.
 
-        Each edge acquires its transaction-scoped advisory lock then runs its
-        OPTIONAL MATCH + DELETE + CREATE, all in one transaction. The caller
-        feeds edges in canonical (LEAST, GREATEST) order, so a chunk acquires its
-        several locks in a globally consistent order across workers -- this is
-        what prevents deadlocks now that a chunk holds multiple edge locks until
-        commit. Retry semantics mirror ``upsert_edge``.
+        Each edge runs its OPTIONAL MATCH + DELETE + CREATE as one statement, all
+        wrapped in a single transaction. Unlike the single-row ``upsert_edge``,
+        the batch path does **not** take the per-edge ``pg_advisory_xact_lock``:
+
+          * Same-edge write races are already excluded by the single-writer
+            -per-workspace pipeline contract and the application-level keyed
+            locks the callers hold (operate.py's per-edge
+            ``get_storage_keyed_lock`` for the single path, and
+            ``ainsert_custom_kg``'s coarse keyed lock over every endpoint for the
+            batch path), so the lock's cross-process defense is redundant here.
+          * Holding one advisory lock per edge until the chunk commits would mean
+            up to ``_max_upsert_records_per_batch`` simultaneous locks (and
+            unboundedly many if the cap is disabled), risking shared-lock-table
+            exhaustion -- the opposite of what chunking is for.
+
+        Edges are still deduped within the chunk, so no edge is touched twice in
+        one transaction. Retry semantics mirror ``upsert_edge``: MERGE / DELETE +
+        CREATE are idempotent, so a full-chunk replay is safe.
         """
         built = [
-            (src, tgt, *self._build_upsert_edge_sql(src, tgt, edge_data))
+            self._build_upsert_edge_sql(src, tgt, edge_data)
             for src, tgt, edge_data in chunk
         ]
         timing_label = f"{self.workspace} PGGraphStorage.upsert_edges_batch"
 
         async def _operation(connection: asyncpg.Connection) -> None:
             async with connection.transaction():
-                for src, tgt, cypher_sql, params_json in built:
-                    await connection.execute(
-                        _EDGE_ADVISORY_LOCK_SQL, self.graph_name, src, tgt
-                    )
+                for cypher_sql, params_json in built:
                     await connection.execute(cypher_sql, params_json)
 
         try:
@@ -6693,7 +6702,7 @@ class PGGraphStorage(BaseGraphStorage):
             raise PGGraphQueryException(
                 {
                     "message": "Error executing graph upsert_edges_batch chunk",
-                    "wrapped": built[0][2] if built else "",
+                    "wrapped": built[0][0] if built else "",
                     "detail": repr(e),
                     "error_type": e.__class__.__name__,
                 }
@@ -6705,14 +6714,12 @@ class PGGraphStorage(BaseGraphStorage):
         """Batch insert/update multiple edges in chunk-level transactions.
 
         AGE relationships are undirected, so reciprocal duplicates are deduped to
-        the last update per endpoint pair. Edges are processed in canonical
-        (LEAST, GREATEST) order and grouped into payload/record-bounded chunks,
-        each run in one transaction -- removing the per-edge transaction / AGE
-        configure overhead of the old serial fallback. The canonical order is now
-        load-bearing: a chunk holds several advisory locks until commit, and a
-        consistent global acquisition order across workers prevents deadlocks
-        (do not disable the record cap, or a chunk could hold unboundedly many
-        locks for an unbounded time).
+        the last update per endpoint pair. Edges are grouped into
+        payload/record-bounded chunks, each run in one transaction -- removing
+        the per-edge transaction / AGE-configure overhead of the old serial
+        fallback. Iteration is in canonical (LEAST, GREATEST) order purely for
+        deterministic dedup / reproducible replay; see ``_upsert_edge_chunk`` for
+        why the batch path does not take per-edge advisory locks.
 
         Args:
             edges: List of (source_node_id, target_node_id, edge_data) tuples.

--- a/tests/kg/postgres_impl/test_postgres_cypher_injection.py
+++ b/tests/kg/postgres_impl/test_postgres_cypher_injection.py
@@ -230,17 +230,10 @@ async def test_upsert_edge_uses_parameterized_cypher():
         storage, "Alice", "Bob", {"weight": "1.0", "description": "knows"}
     )
 
-    # Two statements run on the connection: advisory lock first, then cypher.
-    assert len(calls) == 2
+    # The edge path takes no advisory lock: a single cypher statement.
+    assert len(calls) == 1
 
-    lock_sql = calls[0]["sql"]
-    # Raw node IDs are positional params on the lock, never interpolated.
-    assert "Alice" not in lock_sql
-    assert "Bob" not in lock_sql
-    # graph_name flows as $1, the endpoint pair as $2/$3.
-    assert calls[0]["args"] == ("test_graph", "Alice", "Bob")
-
-    cypher_call = calls[1]
+    cypher_call = calls[0]
     cypher_sql = cypher_call["sql"]
     assert "$1::agtype" in cypher_sql
     assert '"Alice"' not in cypher_sql.replace("$1::agtype", "")
@@ -264,7 +257,7 @@ async def test_upsert_edge_injection_payload():
         storage, injection_src, injection_tgt, {"description": "edge"}
     )
 
-    # Injection payloads must never appear in either SQL template — they only
+    # Injection payloads must never appear in the SQL template — they only
     # flow through positional params.
     for call in calls:
         assert "DETACH DELETE" not in call["sql"]
@@ -272,11 +265,8 @@ async def test_upsert_edge_injection_payload():
         assert injection_src not in call["sql"]
         assert injection_tgt not in call["sql"]
 
-    # Lock statement passes graph_name + raw IDs as positional params.
-    assert calls[0]["args"] == ("test_graph", injection_src, injection_tgt)
-
     # Cypher params arrive as a single positional agtype JSON arg.
-    params = json.loads(calls[1]["args"][0])
+    params = json.loads(calls[0]["args"][0])
     assert params["src_id"] == injection_src
     assert params["tgt_id"] == injection_tgt
 
@@ -291,15 +281,12 @@ async def test_upsert_edge_unicode_entity_ids():
         storage, src, tgt, {"description": "\u8def\u7ebf"}
     )
 
-    # Lock statement carries graph_name + raw IDs as positional params, not
-    # interpolated.
-    assert calls[0]["args"] == ("test_graph", src, tgt)
-    assert src not in calls[0]["sql"]
-    assert tgt not in calls[0]["sql"]
-
-    # Cypher params parsed from the positional agtype JSON arg.
-    cypher_sql = calls[1]["sql"]
-    params = json.loads(calls[1]["args"][0])
+    # Cypher params parsed from the positional agtype JSON arg; raw IDs never
+    # interpolated into the SQL template.
+    cypher_sql = calls[0]["sql"]
+    assert src not in cypher_sql
+    assert tgt not in cypher_sql
+    params = json.loads(calls[0]["args"][0])
     assert params["src_id"] == src
     assert params["tgt_id"] == tgt
     assert '`description`: "路线"' in cypher_sql

--- a/tests/kg/postgres_impl/test_postgres_cypher_injection.py
+++ b/tests/kg/postgres_impl/test_postgres_cypher_injection.py
@@ -230,8 +230,8 @@ async def test_upsert_edge_uses_parameterized_cypher():
         storage, "Alice", "Bob", {"weight": "1.0", "description": "knows"}
     )
 
-    # Two statements run on the connection: advisory lock first, then cypher.
-    assert len(calls) == 2
+    # Three statements: per-edge lock, graph-wide shared lock, then cypher.
+    assert len(calls) == 3
 
     lock_sql = calls[0]["sql"]
     # Raw node IDs are positional params on the lock, never interpolated.
@@ -240,7 +240,7 @@ async def test_upsert_edge_uses_parameterized_cypher():
     # graph_name flows as $1, the endpoint pair as $2/$3.
     assert calls[0]["args"] == ("test_graph", "Alice", "Bob")
 
-    cypher_call = calls[1]
+    cypher_call = calls[2]
     cypher_sql = cypher_call["sql"]
     assert "$1::agtype" in cypher_sql
     assert '"Alice"' not in cypher_sql.replace("$1::agtype", "")
@@ -275,8 +275,9 @@ async def test_upsert_edge_injection_payload():
     # Lock statement passes graph_name + raw IDs as positional params.
     assert calls[0]["args"] == ("test_graph", injection_src, injection_tgt)
 
-    # Cypher params arrive as a single positional agtype JSON arg.
-    params = json.loads(calls[1]["args"][0])
+    # Cypher params arrive as a single positional agtype JSON arg (3rd statement,
+    # after the per-edge and graph-wide-shared locks).
+    params = json.loads(calls[2]["args"][0])
     assert params["src_id"] == injection_src
     assert params["tgt_id"] == injection_tgt
 
@@ -297,9 +298,9 @@ async def test_upsert_edge_unicode_entity_ids():
     assert src not in calls[0]["sql"]
     assert tgt not in calls[0]["sql"]
 
-    # Cypher params parsed from the positional agtype JSON arg.
-    cypher_sql = calls[1]["sql"]
-    params = json.loads(calls[1]["args"][0])
+    # Cypher params parsed from the positional agtype JSON arg (3rd statement).
+    cypher_sql = calls[2]["sql"]
+    params = json.loads(calls[2]["args"][0])
     assert params["src_id"] == src
     assert params["tgt_id"] == tgt
     assert '`description`: "路线"' in cypher_sql

--- a/tests/kg/postgres_impl/test_postgres_cypher_injection.py
+++ b/tests/kg/postgres_impl/test_postgres_cypher_injection.py
@@ -230,10 +230,17 @@ async def test_upsert_edge_uses_parameterized_cypher():
         storage, "Alice", "Bob", {"weight": "1.0", "description": "knows"}
     )
 
-    # The edge path takes no advisory lock: a single cypher statement.
-    assert len(calls) == 1
+    # Two statements run on the connection: advisory lock first, then cypher.
+    assert len(calls) == 2
 
-    cypher_call = calls[0]
+    lock_sql = calls[0]["sql"]
+    # Raw node IDs are positional params on the lock, never interpolated.
+    assert "Alice" not in lock_sql
+    assert "Bob" not in lock_sql
+    # graph_name flows as $1, the endpoint pair as $2/$3.
+    assert calls[0]["args"] == ("test_graph", "Alice", "Bob")
+
+    cypher_call = calls[1]
     cypher_sql = cypher_call["sql"]
     assert "$1::agtype" in cypher_sql
     assert '"Alice"' not in cypher_sql.replace("$1::agtype", "")
@@ -257,7 +264,7 @@ async def test_upsert_edge_injection_payload():
         storage, injection_src, injection_tgt, {"description": "edge"}
     )
 
-    # Injection payloads must never appear in the SQL template — they only
+    # Injection payloads must never appear in either SQL template — they only
     # flow through positional params.
     for call in calls:
         assert "DETACH DELETE" not in call["sql"]
@@ -265,8 +272,11 @@ async def test_upsert_edge_injection_payload():
         assert injection_src not in call["sql"]
         assert injection_tgt not in call["sql"]
 
+    # Lock statement passes graph_name + raw IDs as positional params.
+    assert calls[0]["args"] == ("test_graph", injection_src, injection_tgt)
+
     # Cypher params arrive as a single positional agtype JSON arg.
-    params = json.loads(calls[0]["args"][0])
+    params = json.loads(calls[1]["args"][0])
     assert params["src_id"] == injection_src
     assert params["tgt_id"] == injection_tgt
 
@@ -281,12 +291,15 @@ async def test_upsert_edge_unicode_entity_ids():
         storage, src, tgt, {"description": "\u8def\u7ebf"}
     )
 
-    # Cypher params parsed from the positional agtype JSON arg; raw IDs never
-    # interpolated into the SQL template.
-    cypher_sql = calls[0]["sql"]
-    assert src not in cypher_sql
-    assert tgt not in cypher_sql
-    params = json.loads(calls[0]["args"][0])
+    # Lock statement carries graph_name + raw IDs as positional params, not
+    # interpolated.
+    assert calls[0]["args"] == ("test_graph", src, tgt)
+    assert src not in calls[0]["sql"]
+    assert tgt not in calls[0]["sql"]
+
+    # Cypher params parsed from the positional agtype JSON arg.
+    cypher_sql = calls[1]["sql"]
+    params = json.loads(calls[1]["args"][0])
     assert params["src_id"] == src
     assert params["tgt_id"] == tgt
     assert '`description`: "路线"' in cypher_sql

--- a/tests/kg/postgres_impl/test_postgres_graph_batch.py
+++ b/tests/kg/postgres_impl/test_postgres_graph_batch.py
@@ -1,0 +1,229 @@
+"""Unit tests for PGGraphStorage chunk-level transaction batch paths.
+
+Covers the PR-2 chunk-level fallback: ``upsert_nodes_batch`` /
+``upsert_edges_batch`` group per-row Cypher into payload/record-bounded chunks
+run in a single transaction; ``remove_nodes`` runs all chunks in ONE
+transaction (all-or-nothing); ``remove_edges`` runs one transaction per chunk.
+"""
+
+import pytest
+from unittest.mock import AsyncMock
+
+from lightrag.kg.postgres_impl import PGGraphStorage
+
+
+# ---------------------------------------------------------------------------
+# Capture harness
+# ---------------------------------------------------------------------------
+
+
+class _Capture:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []  # every connection.execute(sql, *args)
+        self.tx_count = 0  # connection.transaction() opens
+        self.run_count = 0  # _run_with_retry invocations (= chunks issued)
+
+
+class _FakeTransaction:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeConnection:
+    def __init__(self, capture: _Capture):
+        self._capture = capture
+
+    def transaction(self):
+        self._capture.tx_count += 1
+        return _FakeTransaction()
+
+    async def execute(self, sql, *args):
+        self._capture.calls.append({"sql": sql, "args": args})
+        return ""
+
+
+def make_graph_storage(
+    *,
+    max_upsert_records: int | None = None,
+    max_upsert_payload: int | None = None,
+    max_delete_records: int | None = None,
+) -> tuple[PGGraphStorage, _Capture]:
+    storage = PGGraphStorage.__new__(PGGraphStorage)
+    storage.workspace = "test_ws"
+    storage.namespace = "test_graph"
+    storage.graph_name = "test_graph"
+    storage.__post_init__()  # resolves the chunk-level batch limits
+    if max_upsert_records is not None:
+        storage._max_upsert_records_per_batch = max_upsert_records
+    if max_upsert_payload is not None:
+        storage._max_upsert_payload_bytes = max_upsert_payload
+    if max_delete_records is not None:
+        storage._max_delete_records_per_batch = max_delete_records
+
+    capture = _Capture()
+    conn = _FakeConnection(capture)
+
+    async def fake_run_with_retry(operation, **_kwargs):
+        capture.run_count += 1
+        return await operation(conn)
+
+    storage.db = AsyncMock()
+    storage.db._run_with_retry = AsyncMock(side_effect=fake_run_with_retry)
+    return storage, capture
+
+
+def _sql_count(capture: _Capture, needle: str) -> int:
+    return sum(1 for c in capture.calls if needle in c["sql"])
+
+
+# ---------------------------------------------------------------------------
+# upsert_nodes_batch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_nodes_batch_splits_into_chunk_transactions():
+    storage, cap = make_graph_storage(max_upsert_records=2)
+    nodes = [(f"n{i}", {"entity_id": f"n{i}", "v": str(i)}) for i in range(5)]
+
+    await storage.upsert_nodes_batch(nodes)
+
+    # 5 nodes / cap 2 => 3 chunks, each its own _run_with_retry + transaction.
+    assert cap.run_count == 3
+    assert cap.tx_count == 3
+    # One MERGE per node.
+    assert _sql_count(cap, "MERGE (n:base") == 5
+
+
+@pytest.mark.asyncio
+async def test_upsert_nodes_batch_dedupes_last_write_wins():
+    storage, cap = make_graph_storage()
+    await storage.upsert_nodes_batch(
+        [
+            ("A", {"entity_id": "A", "weight": "first"}),
+            ("A", {"entity_id": "A", "weight": "second"}),
+        ]
+    )
+
+    merge_calls = [c for c in cap.calls if "MERGE (n:base" in c["sql"]]
+    assert len(merge_calls) == 1
+    assert '"second"' in merge_calls[0]["sql"]
+    assert '"first"' not in merge_calls[0]["sql"]
+
+
+@pytest.mark.asyncio
+async def test_upsert_nodes_batch_splits_by_payload_bytes():
+    # Disable the record cap, force a small byte budget so each big node lands
+    # in its own chunk.
+    storage, cap = make_graph_storage(max_upsert_records=0, max_upsert_payload=200)
+    nodes = [(f"n{i}", {"entity_id": f"n{i}", "blob": "X" * 150}) for i in range(3)]
+
+    await storage.upsert_nodes_batch(nodes)
+
+    assert cap.run_count == 3
+
+
+@pytest.mark.asyncio
+async def test_upsert_nodes_batch_missing_entity_id_raises_before_tx():
+    storage, cap = make_graph_storage()
+    with pytest.raises(ValueError, match="entity_id"):
+        await storage.upsert_nodes_batch([("A", {"foo": "bar"})])
+    # The builder runs before the transaction opens, so nothing was issued.
+    assert cap.run_count == 0
+
+
+@pytest.mark.asyncio
+async def test_upsert_nodes_batch_empty_noop():
+    storage, cap = make_graph_storage()
+    await storage.upsert_nodes_batch([])
+    assert cap.run_count == 0
+
+
+# ---------------------------------------------------------------------------
+# upsert_edges_batch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_edges_batch_splits_into_chunk_transactions():
+    storage, cap = make_graph_storage(max_upsert_records=2)
+    edges = [(f"s{i}", f"t{i}", {"w": str(i)}) for i in range(5)]
+
+    await storage.upsert_edges_batch(edges)
+
+    # 5 edges / cap 2 => 3 chunks; each chunk = one transaction.
+    assert cap.run_count == 3
+    assert cap.tx_count == 3
+    # Per edge: one advisory lock + one CREATE cypher.
+    assert _sql_count(cap, "pg_advisory_xact_lock") == 5
+    assert _sql_count(cap, "CREATE (source)-[r:DIRECTED") == 5
+
+
+@pytest.mark.asyncio
+async def test_upsert_edges_batch_lock_precedes_cypher_per_edge():
+    storage, cap = make_graph_storage()
+    await storage.upsert_edges_batch([("A", "B", {"w": "1"})])
+
+    # Order within the chunk: lock, then cypher.
+    assert "pg_advisory_xact_lock" in cap.calls[0]["sql"]
+    assert "CREATE (source)-[r:DIRECTED" in cap.calls[1]["sql"]
+
+
+@pytest.mark.asyncio
+async def test_upsert_edges_batch_empty_noop():
+    storage, cap = make_graph_storage()
+    await storage.upsert_edges_batch([])
+    assert cap.run_count == 0
+
+
+# ---------------------------------------------------------------------------
+# remove_nodes — all chunks in ONE transaction (all-or-nothing)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remove_nodes_chunks_share_one_transaction():
+    storage, cap = make_graph_storage(max_delete_records=2)
+    await storage.remove_nodes([f"n{i}" for i in range(5)])
+
+    # One transaction wraps all chunks (preserves single-statement atomicity).
+    assert cap.run_count == 1
+    assert cap.tx_count == 1
+    # 5 ids / cap 2 => 3 bounded IN [...] DETACH DELETE statements.
+    assert _sql_count(cap, "DETACH DELETE n") == 3
+
+
+@pytest.mark.asyncio
+async def test_remove_nodes_empty_noop():
+    storage, cap = make_graph_storage()
+    await storage.remove_nodes([])
+    assert cap.run_count == 0
+
+
+# ---------------------------------------------------------------------------
+# remove_edges — one transaction per chunk
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remove_edges_one_transaction_per_chunk():
+    storage, cap = make_graph_storage(max_delete_records=2)
+    edges = [(f"s{i}", f"t{i}") for i in range(5)]
+
+    await storage.remove_edges(edges)
+
+    # 5 edges / cap 2 => 3 chunks, each its own transaction.
+    assert cap.run_count == 3
+    assert cap.tx_count == 3
+    # One DELETE r statement per edge.
+    assert _sql_count(cap, "DELETE r") == 5
+
+
+@pytest.mark.asyncio
+async def test_remove_edges_empty_noop():
+    storage, cap = make_graph_storage()
+    await storage.remove_edges([])
+    assert cap.run_count == 0

--- a/tests/kg/postgres_impl/test_postgres_graph_batch.py
+++ b/tests/kg/postgres_impl/test_postgres_graph_batch.py
@@ -157,19 +157,26 @@ async def test_upsert_edges_batch_splits_into_chunk_transactions():
     # 5 edges / cap 2 => 3 chunks; each chunk = one transaction.
     assert cap.run_count == 3
     assert cap.tx_count == 3
-    # One CREATE cypher per edge.
+    # One CREATE cypher per edge, and exactly one graph-wide lock per chunk.
     assert _sql_count(cap, "CREATE (source)-[r:DIRECTED") == 5
+    assert _sql_count(cap, "pg_advisory_xact_lock") == 3
 
 
 @pytest.mark.asyncio
-async def test_upsert_edges_batch_takes_no_advisory_lock():
-    """The batch path relies on single-writer + the caller's keyed lock, so it
-    must NOT take per-edge advisory locks (which would pile up per chunk)."""
+async def test_upsert_edges_batch_takes_one_graph_lock_per_chunk():
+    """The batch chunk takes a single graph-wide advisory lock (keyed on
+    graph_name only), not one lock per edge -- bounded regardless of edge count."""
     storage, cap = make_graph_storage()
-    await storage.upsert_edges_batch([("A", "B", {"w": "1"})])
+    await storage.upsert_edges_batch(
+        [(f"s{i}", f"t{i}", {"w": str(i)}) for i in range(4)]
+    )
 
-    assert _sql_count(cap, "pg_advisory_xact_lock") == 0
-    assert _sql_count(cap, "CREATE (source)-[r:DIRECTED") == 1
+    lock_calls = [c for c in cap.calls if "pg_advisory_xact_lock" in c["sql"]]
+    assert len(lock_calls) == 1  # one chunk, one lock (not 4)
+    assert lock_calls[0]["args"] == ("test_graph",)  # graph-keyed, no endpoints
+    assert _sql_count(cap, "CREATE (source)-[r:DIRECTED") == 4
+    # The lock is acquired before any edge cypher in the chunk.
+    assert "pg_advisory_xact_lock" in cap.calls[0]["sql"]
 
 
 @pytest.mark.asyncio

--- a/tests/kg/postgres_impl/test_postgres_graph_batch.py
+++ b/tests/kg/postgres_impl/test_postgres_graph_batch.py
@@ -157,19 +157,19 @@ async def test_upsert_edges_batch_splits_into_chunk_transactions():
     # 5 edges / cap 2 => 3 chunks; each chunk = one transaction.
     assert cap.run_count == 3
     assert cap.tx_count == 3
-    # Per edge: one advisory lock + one CREATE cypher.
-    assert _sql_count(cap, "pg_advisory_xact_lock") == 5
+    # One CREATE cypher per edge.
     assert _sql_count(cap, "CREATE (source)-[r:DIRECTED") == 5
 
 
 @pytest.mark.asyncio
-async def test_upsert_edges_batch_lock_precedes_cypher_per_edge():
+async def test_upsert_edges_batch_takes_no_advisory_lock():
+    """The batch path relies on single-writer + the caller's keyed lock, so it
+    must NOT take per-edge advisory locks (which would pile up per chunk)."""
     storage, cap = make_graph_storage()
     await storage.upsert_edges_batch([("A", "B", {"w": "1"})])
 
-    # Order within the chunk: lock, then cypher.
-    assert "pg_advisory_xact_lock" in cap.calls[0]["sql"]
-    assert "CREATE (source)-[r:DIRECTED" in cap.calls[1]["sql"]
+    assert _sql_count(cap, "pg_advisory_xact_lock") == 0
+    assert _sql_count(cap, "CREATE (source)-[r:DIRECTED") == 1
 
 
 @pytest.mark.asyncio

--- a/tests/kg/postgres_impl/test_postgres_upsert_edge_cypher.py
+++ b/tests/kg/postgres_impl/test_postgres_upsert_edge_cypher.py
@@ -89,8 +89,8 @@ async def test_upsert_edge_uses_delete_create_not_set():
         storage, "NodeA", "NodeB", {"weight": "1.0", "description": "test edge"}
     )
 
-    # The cypher statement is the second one (after the lock acquisition).
-    cypher_sql = calls[1]["sql"]
+    # The cypher statement is the third one (after the per-edge + shared locks).
+    cypher_sql = calls[2]["sql"]
 
     # The new query must not contain any SET-based edge update — those silently
     # fail against AGE. All edge props live inline in the CREATE clause.
@@ -107,7 +107,7 @@ async def test_upsert_edge_contains_optional_match_delete_create():
     storage = make_graph_storage()
     calls = await _capture_upsert_edge(storage, "Alice", "Bob", {"weight": "0.5"})
 
-    cypher_sql = calls[1]["sql"]
+    cypher_sql = calls[2]["sql"]
     assert "OPTIONAL MATCH (source)-[old:DIRECTED]-(target)" in cypher_sql
     assert "DELETE old" in cypher_sql
     assert "CREATE (source)-[r:DIRECTED" in cypher_sql
@@ -123,7 +123,7 @@ async def test_upsert_edge_handles_empty_props():
     storage = make_graph_storage()
     calls = await _capture_upsert_edge(storage, "Alice", "Bob", {})
 
-    cypher_sql = calls[1]["sql"]
+    cypher_sql = calls[2]["sql"]
     assert "CREATE (source)-[r:DIRECTED {}]->(target)" in cypher_sql
 
 
@@ -133,7 +133,7 @@ async def test_upsert_edge_uses_parameterized_match_ids():
     storage = make_graph_storage()
     calls = await _capture_upsert_edge(storage, "Node A", "Node B", {"weight": "1.0"})
 
-    cypher_call = calls[1]
+    cypher_call = calls[2]
     cypher_sql = cypher_call["sql"]
     assert "entity_id: $src_id" in cypher_sql
     assert "entity_id: $tgt_id" in cypher_sql
@@ -162,11 +162,11 @@ async def test_upsert_edge_serialises_with_advisory_lock():
     storage = make_graph_storage()
     calls = await _capture_upsert_edge(storage, "Alice", "Bob", {"weight": "0.5"})
 
-    # Two statements: lock first, then cypher upsert.
-    assert len(calls) == 2
+    # Three statements: per-edge exclusive lock, graph-wide shared lock, cypher.
+    assert len(calls) == 3
 
     lock_sql = calls[0]["sql"]
-    assert "pg_advisory_xact_lock" in lock_sql
+    assert "pg_advisory_xact_lock(" in lock_sql  # exclusive (not _shared)
     # graph_name flows as $1 so independent AGE graphs in the same DB do not
     # serialise each other's edges.
     assert "$1::text || E'\\x01' ||" in lock_sql
@@ -179,9 +179,16 @@ async def test_upsert_edge_serialises_with_advisory_lock():
     assert "Alice" not in lock_sql and "Bob" not in lock_sql
     assert calls[0]["args"] == ("test_graph", "Alice", "Bob")
 
-    # The cypher statement must not contain the lock — that would cause AGE to
+    # Second statement: graph-wide SHARED lock keyed on graph_name only, so it
+    # conflicts with the batch path's exclusive graph lock but not with other
+    # single writers.
+    shared_sql = calls[1]["sql"]
+    assert "pg_advisory_xact_lock_shared" in shared_sql
+    assert calls[1]["args"] == ("test_graph",)
+
+    # The cypher statement must not contain a lock — that would cause AGE to
     # reject the plan with "cypher create clause cannot be rescanned".
-    cypher_sql = calls[1]["sql"]
+    cypher_sql = calls[2]["sql"]
     assert "pg_advisory_xact_lock" not in cypher_sql
 
 

--- a/tests/kg/postgres_impl/test_postgres_upsert_edge_cypher.py
+++ b/tests/kg/postgres_impl/test_postgres_upsert_edge_cypher.py
@@ -89,9 +89,8 @@ async def test_upsert_edge_uses_delete_create_not_set():
         storage, "NodeA", "NodeB", {"weight": "1.0", "description": "test edge"}
     )
 
-    # The batch/single edge path takes no advisory lock: a single cypher stmt.
-    assert len(calls) == 1
-    cypher_sql = calls[0]["sql"]
+    # The cypher statement is the second one (after the lock acquisition).
+    cypher_sql = calls[1]["sql"]
 
     # The new query must not contain any SET-based edge update — those silently
     # fail against AGE. All edge props live inline in the CREATE clause.
@@ -108,7 +107,7 @@ async def test_upsert_edge_contains_optional_match_delete_create():
     storage = make_graph_storage()
     calls = await _capture_upsert_edge(storage, "Alice", "Bob", {"weight": "0.5"})
 
-    cypher_sql = calls[0]["sql"]
+    cypher_sql = calls[1]["sql"]
     assert "OPTIONAL MATCH (source)-[old:DIRECTED]-(target)" in cypher_sql
     assert "DELETE old" in cypher_sql
     assert "CREATE (source)-[r:DIRECTED" in cypher_sql
@@ -124,7 +123,7 @@ async def test_upsert_edge_handles_empty_props():
     storage = make_graph_storage()
     calls = await _capture_upsert_edge(storage, "Alice", "Bob", {})
 
-    cypher_sql = calls[0]["sql"]
+    cypher_sql = calls[1]["sql"]
     assert "CREATE (source)-[r:DIRECTED {}]->(target)" in cypher_sql
 
 
@@ -134,7 +133,7 @@ async def test_upsert_edge_uses_parameterized_match_ids():
     storage = make_graph_storage()
     calls = await _capture_upsert_edge(storage, "Node A", "Node B", {"weight": "1.0"})
 
-    cypher_call = calls[0]
+    cypher_call = calls[1]
     cypher_sql = cypher_call["sql"]
     assert "entity_id: $src_id" in cypher_sql
     assert "entity_id: $tgt_id" in cypher_sql
@@ -146,15 +145,104 @@ async def test_upsert_edge_uses_parameterized_match_ids():
 
 
 @pytest.mark.asyncio
-async def test_upsert_edge_takes_no_advisory_lock():
-    """The edge upsert relies on the single-writer contract, not a DB lock, so
-    it must issue exactly one statement (the cypher) and no pg_advisory_xact_lock."""
+async def test_upsert_edge_serialises_with_advisory_lock():
+    """Concurrent upserts on the same edge must be serialised via pg_advisory_xact_lock.
+
+    OPTIONAL MATCH + DELETE + CREATE is not atomic on its own: two transactions
+    could both pass the OPTIONAL MATCH and both run CREATE, leaving duplicate
+    DIRECTED rows. We open a transaction and acquire a transaction-scoped
+    advisory lock keyed on (graph_name, ordered (src_id, tgt_id)) before running
+    the cypher upsert, so concurrent upserts of the same logical edge run
+    serially without serialising independent graphs.
+
+    AGE refuses to plan a join against a cypher() call that contains a CREATE
+    clause, so the lock cannot live in a CTE — it must be a separate statement
+    on the same connection inside an explicit transaction.
+    """
     storage = make_graph_storage()
     calls = await _capture_upsert_edge(storage, "Alice", "Bob", {"weight": "0.5"})
 
-    assert len(calls) == 1
-    assert "pg_advisory_xact_lock" not in calls[0]["sql"]
-    assert "CREATE (source)-[r:DIRECTED" in calls[0]["sql"]
+    # Two statements: lock first, then cypher upsert.
+    assert len(calls) == 2
+
+    lock_sql = calls[0]["sql"]
+    assert "pg_advisory_xact_lock" in lock_sql
+    # graph_name flows as $1 so independent AGE graphs in the same DB do not
+    # serialise each other's edges.
+    assert "$1::text || E'\\x01' ||" in lock_sql
+    # Key must be order-independent for (src, tgt) so {A, B} and {B, A} collide
+    # on the same lock (the OPTIONAL MATCH is undirected).
+    assert "LEAST($2::text, $3::text)" in lock_sql
+    assert "GREATEST($2::text, $3::text)" in lock_sql
+    # Raw graph_name + node IDs flow as positional params — never interpolated.
+    assert "test_graph" not in lock_sql
+    assert "Alice" not in lock_sql and "Bob" not in lock_sql
+    assert calls[0]["args"] == ("test_graph", "Alice", "Bob")
+
+    # The cypher statement must not contain the lock — that would cause AGE to
+    # reject the plan with "cypher create clause cannot be rescanned".
+    cypher_sql = calls[1]["sql"]
+    assert "pg_advisory_xact_lock" not in cypher_sql
+
+
+@pytest.mark.asyncio
+async def test_upsert_edge_lock_key_includes_graph_name():
+    """Advisory lock key must include graph_name so independent AGE graphs in
+    the same PostgreSQL database don't serialise each other's edges.
+
+    Regression for the codex review on PR #3056: pg_advisory_xact_lock is
+    database-wide, so hashing only (src, tgt) would make {Alice, Bob} in
+    `graph_a` block {Alice, Bob} in `graph_b` even though they touch different
+    AGE graph tables.
+    """
+    storage_a = make_graph_storage()
+    storage_a.graph_name = "graph_a"
+    storage_b = make_graph_storage()
+    storage_b.graph_name = "graph_b"
+
+    calls_a = await _capture_upsert_edge(storage_a, "Alice", "Bob", {})
+    calls_b = await _capture_upsert_edge(storage_b, "Alice", "Bob", {})
+
+    # graph_name flows as the first positional arg into the lock SQL so the
+    # hashed lock key differs between graphs even when (src, tgt) match.
+    assert calls_a[0]["args"] == ("graph_a", "Alice", "Bob")
+    assert calls_b[0]["args"] == ("graph_b", "Alice", "Bob")
+
+    # And the lock template references graph_name as $1, with the ID pair as
+    # $2/$3 — keep the param order pinned so future refactors don't silently
+    # swap them.
+    lock_sql = calls_a[0]["sql"]
+    assert "$1::text" in lock_sql
+    assert "LEAST($2::text, $3::text)" in lock_sql
+    assert "GREATEST($2::text, $3::text)" in lock_sql
+
+
+@pytest.mark.asyncio
+async def test_upsert_edge_lock_key_is_endpoint_order_independent():
+    """{A, B} and {B, A} must produce the same advisory lock key.
+
+    The lock SQL itself is identical across both call directions; only the
+    positional args differ. LEAST/GREATEST inside the template then normalises
+    them to the same hash input, so concurrent {A,B} and {B,A} writes collide
+    on a single lock (matching the undirected OPTIONAL MATCH).
+    """
+    storage = make_graph_storage()
+    forward = await _capture_upsert_edge(storage, "Alice", "Bob", {})
+    reverse = await _capture_upsert_edge(storage, "Bob", "Alice", {})
+
+    # Same lock SQL template for both directions.
+    assert forward[0]["sql"] == reverse[0]["sql"]
+    # graph_name first, then the endpoint pair in whatever order the caller
+    # passed — LEAST/GREATEST canonicalises inside the SQL.
+    assert forward[0]["args"][0] == reverse[0]["args"][0] == "test_graph"
+    assert (
+        set(forward[0]["args"][1:])
+        == set(reverse[0]["args"][1:])
+        == {
+            "Alice",
+            "Bob",
+        }
+    )
 
 
 @pytest.mark.asyncio
@@ -162,8 +250,9 @@ async def test_upsert_edge_wraps_transient_errors_for_retry(monkeypatch):
     """Query-level transient errors must be wrapped in PGGraphQueryException so
     the outer @retry predicate can identify them and retry.
 
-    Regression: upsert_edge runs the cypher via self.db._run_with_retry (not
-    self._query), so the _query exception-wrapping path is bypassed. A raw
+    Regression: when upsert_edge was moved off self._query onto
+    self.db._run_with_retry (to run the advisory lock + cypher in one
+    transaction), the _query exception-wrapping path was bypassed. A raw
     asyncpg.DeadlockDetectedError surfacing from connection.execute would
     therefore fail _is_transient_graph_write_error's first guard
     (isinstance(exc, PGGraphQueryException)) and skip the retry loop, silently
@@ -257,9 +346,12 @@ async def test_upsert_edges_batch_iterates_in_sorted_order():
         ],
     )
 
-    # The batch path takes no advisory lock; order is observed from the cypher
-    # calls' bound (src_id, tgt_id) params, canonicalised.
-    assert not any("pg_advisory_xact_lock" in c["sql"] for c in calls)
+    # The batch chunk takes ONE graph-wide advisory lock (keyed on graph_name
+    # only, no per-edge endpoints), not a per-edge lock. Order is observed from
+    # the cypher calls' bound (src_id, tgt_id) params, canonicalised.
+    lock_calls = [c for c in calls if "pg_advisory_xact_lock" in c["sql"]]
+    assert len(lock_calls) == 1
+    assert lock_calls[0]["args"] == ("test_graph",)
     cypher_calls = [c for c in calls if "CREATE (source)-[r:DIRECTED" in c["sql"]]
     edge_pairs = [
         (json.loads(c["args"][0])["src_id"], json.loads(c["args"][0])["tgt_id"])

--- a/tests/kg/postgres_impl/test_postgres_upsert_edge_cypher.py
+++ b/tests/kg/postgres_impl/test_postgres_upsert_edge_cypher.py
@@ -32,6 +32,7 @@ def make_graph_storage() -> PGGraphStorage:
     storage.workspace = "test_ws"
     storage.namespace = "test_graph"
     storage.graph_name = "test_graph"
+    storage.__post_init__()  # resolves chunk-level batch-limit attrs
     storage.db = MagicMock()
     return storage
 
@@ -317,63 +318,70 @@ async def test_upsert_edge_does_not_retry_non_transient_errors(monkeypatch):
     assert call_count == 1
 
 
+async def _capture_upsert_edges_batch(storage: PGGraphStorage, edges):
+    """Run upsert_edges_batch against a fake connection; return captured calls."""
+    conn = _FakeConnection()
+
+    async def fake_run_with_retry(operation, **_kwargs):
+        return await operation(conn)
+
+    storage.db._run_with_retry = AsyncMock(side_effect=fake_run_with_retry)
+    await storage.upsert_edges_batch(edges)
+    return conn.calls
+
+
 @pytest.mark.asyncio
 async def test_upsert_edges_batch_iterates_in_sorted_order():
-    """upsert_edges_batch calls upsert_edge in canonical (LEAST, GREATEST)
-    order regardless of insertion order.
+    """A chunk acquires its advisory locks in canonical (LEAST, GREATEST) order
+    regardless of insertion order.
 
-    upsert_edge opens an independent transaction per call and releases the
-    advisory lock on commit, so this iteration order is not a deadlock fix
-    — but a deterministic order matches the dedup key already used above
-    and keeps logs / replays reproducible across callers.
+    Now load-bearing: a chunk transaction holds several edge locks until commit,
+    so a globally consistent acquisition order is what prevents cross-worker
+    deadlocks.
     """
     storage = make_graph_storage()
 
-    captured: list[tuple[str, str]] = []
-
-    async def fake_upsert_edge(src, tgt, edge_data):  # noqa: ARG001
-        captured.append((src, tgt))
-
-    storage.upsert_edge = AsyncMock(side_effect=fake_upsert_edge)
-
     # Insertion order intentionally non-canonical: B-A, C-A, D-A.
-    await storage.upsert_edges_batch(
+    calls = await _capture_upsert_edges_batch(
+        storage,
         [
             ("B", "A", {"weight": "1"}),
             ("C", "A", {"weight": "2"}),
             ("D", "A", {"weight": "3"}),
-        ]
+        ],
     )
 
-    # Edge keys after canonicalisation: (A,B), (A,C), (A,D). The values
-    # preserve the caller's original orientation per pair, but the iteration
-    # visits them in sorted-key order.
-    canonical_keys = [tuple(sorted(pair)) for pair in captured]
+    # Lock statements carry (graph_name, src, tgt); collect them in execution
+    # order and check the canonicalised pairs are sorted.
+    lock_pairs = [
+        (c["args"][1], c["args"][2])
+        for c in calls
+        if "pg_advisory_xact_lock" in c["sql"]
+    ]
+    canonical_keys = [tuple(sorted(pair)) for pair in lock_pairs]
     assert canonical_keys == sorted(canonical_keys)
     assert canonical_keys == [("A", "B"), ("A", "C"), ("A", "D")]
 
 
 @pytest.mark.asyncio
 async def test_upsert_edges_batch_dedupes_last_write_wins():
-    """Reciprocal duplicates collapse to a single upsert with the LATEST
-    edge_data, regardless of which orientation arrives last — preserves the
-    historical serial-fallback semantics documented on the method."""
+    """Reciprocal duplicates collapse to a single edge upsert carrying the
+    LATEST edge_data, regardless of which orientation arrives last."""
     storage = make_graph_storage()
 
-    captured: list[tuple[str, str, dict]] = []
-
-    async def fake_upsert_edge(src, tgt, edge_data):
-        captured.append((src, tgt, edge_data))
-
-    storage.upsert_edge = AsyncMock(side_effect=fake_upsert_edge)
-
-    await storage.upsert_edges_batch(
+    calls = await _capture_upsert_edges_batch(
+        storage,
         [
             ("A", "B", {"weight": "first"}),
             ("B", "A", {"weight": "second"}),  # reciprocal, wins
-        ]
+        ],
     )
 
-    assert len(captured) == 1
-    # Orientation = last write's caller order; edge_data = last write's payload.
-    assert captured[0] == ("B", "A", {"weight": "second"})
+    # Exactly one edge cypher (CREATE) ran, with the latest payload inlined and
+    # the last write's orientation in the bound params.
+    cypher_calls = [c for c in calls if "CREATE (source)-[r:DIRECTED" in c["sql"]]
+    assert len(cypher_calls) == 1
+    assert '"second"' in cypher_calls[0]["sql"]
+    assert '"first"' not in cypher_calls[0]["sql"]
+    params_json = cypher_calls[0]["args"][0]
+    assert json.loads(params_json) == {"src_id": "B", "tgt_id": "A"}

--- a/tests/kg/postgres_impl/test_postgres_upsert_edge_cypher.py
+++ b/tests/kg/postgres_impl/test_postgres_upsert_edge_cypher.py
@@ -332,13 +332,8 @@ async def _capture_upsert_edges_batch(storage: PGGraphStorage, edges):
 
 @pytest.mark.asyncio
 async def test_upsert_edges_batch_iterates_in_sorted_order():
-    """A chunk acquires its advisory locks in canonical (LEAST, GREATEST) order
-    regardless of insertion order.
-
-    Now load-bearing: a chunk transaction holds several edge locks until commit,
-    so a globally consistent acquisition order is what prevents cross-worker
-    deadlocks.
-    """
+    """A chunk emits edge cypher in canonical (LEAST, GREATEST) order regardless
+    of insertion order (deterministic dedup / reproducible replay)."""
     storage = make_graph_storage()
 
     # Insertion order intentionally non-canonical: B-A, C-A, D-A.
@@ -351,14 +346,15 @@ async def test_upsert_edges_batch_iterates_in_sorted_order():
         ],
     )
 
-    # Lock statements carry (graph_name, src, tgt); collect them in execution
-    # order and check the canonicalised pairs are sorted.
-    lock_pairs = [
-        (c["args"][1], c["args"][2])
-        for c in calls
-        if "pg_advisory_xact_lock" in c["sql"]
+    # The batch path takes no advisory lock; order is observed from the cypher
+    # calls' bound (src_id, tgt_id) params, canonicalised.
+    assert not any("pg_advisory_xact_lock" in c["sql"] for c in calls)
+    cypher_calls = [c for c in calls if "CREATE (source)-[r:DIRECTED" in c["sql"]]
+    edge_pairs = [
+        (json.loads(c["args"][0])["src_id"], json.loads(c["args"][0])["tgt_id"])
+        for c in cypher_calls
     ]
-    canonical_keys = [tuple(sorted(pair)) for pair in lock_pairs]
+    canonical_keys = [tuple(sorted(pair)) for pair in edge_pairs]
     assert canonical_keys == sorted(canonical_keys)
     assert canonical_keys == [("A", "B"), ("A", "C"), ("A", "D")]
 

--- a/tests/kg/postgres_impl/test_postgres_upsert_edge_cypher.py
+++ b/tests/kg/postgres_impl/test_postgres_upsert_edge_cypher.py
@@ -89,8 +89,9 @@ async def test_upsert_edge_uses_delete_create_not_set():
         storage, "NodeA", "NodeB", {"weight": "1.0", "description": "test edge"}
     )
 
-    # The cypher statement is the second one (after the lock acquisition).
-    cypher_sql = calls[1]["sql"]
+    # The batch/single edge path takes no advisory lock: a single cypher stmt.
+    assert len(calls) == 1
+    cypher_sql = calls[0]["sql"]
 
     # The new query must not contain any SET-based edge update — those silently
     # fail against AGE. All edge props live inline in the CREATE clause.
@@ -107,7 +108,7 @@ async def test_upsert_edge_contains_optional_match_delete_create():
     storage = make_graph_storage()
     calls = await _capture_upsert_edge(storage, "Alice", "Bob", {"weight": "0.5"})
 
-    cypher_sql = calls[1]["sql"]
+    cypher_sql = calls[0]["sql"]
     assert "OPTIONAL MATCH (source)-[old:DIRECTED]-(target)" in cypher_sql
     assert "DELETE old" in cypher_sql
     assert "CREATE (source)-[r:DIRECTED" in cypher_sql
@@ -123,7 +124,7 @@ async def test_upsert_edge_handles_empty_props():
     storage = make_graph_storage()
     calls = await _capture_upsert_edge(storage, "Alice", "Bob", {})
 
-    cypher_sql = calls[1]["sql"]
+    cypher_sql = calls[0]["sql"]
     assert "CREATE (source)-[r:DIRECTED {}]->(target)" in cypher_sql
 
 
@@ -133,7 +134,7 @@ async def test_upsert_edge_uses_parameterized_match_ids():
     storage = make_graph_storage()
     calls = await _capture_upsert_edge(storage, "Node A", "Node B", {"weight": "1.0"})
 
-    cypher_call = calls[1]
+    cypher_call = calls[0]
     cypher_sql = cypher_call["sql"]
     assert "entity_id: $src_id" in cypher_sql
     assert "entity_id: $tgt_id" in cypher_sql
@@ -145,104 +146,15 @@ async def test_upsert_edge_uses_parameterized_match_ids():
 
 
 @pytest.mark.asyncio
-async def test_upsert_edge_serialises_with_advisory_lock():
-    """Concurrent upserts on the same edge must be serialised via pg_advisory_xact_lock.
-
-    OPTIONAL MATCH + DELETE + CREATE is not atomic on its own: two transactions
-    could both pass the OPTIONAL MATCH and both run CREATE, leaving duplicate
-    DIRECTED rows. We open a transaction and acquire a transaction-scoped
-    advisory lock keyed on (graph_name, ordered (src_id, tgt_id)) before running
-    the cypher upsert, so concurrent upserts of the same logical edge run
-    serially without serialising independent graphs.
-
-    AGE refuses to plan a join against a cypher() call that contains a CREATE
-    clause, so the lock cannot live in a CTE — it must be a separate statement
-    on the same connection inside an explicit transaction.
-    """
+async def test_upsert_edge_takes_no_advisory_lock():
+    """The edge upsert relies on the single-writer contract, not a DB lock, so
+    it must issue exactly one statement (the cypher) and no pg_advisory_xact_lock."""
     storage = make_graph_storage()
     calls = await _capture_upsert_edge(storage, "Alice", "Bob", {"weight": "0.5"})
 
-    # Two statements: lock first, then cypher upsert.
-    assert len(calls) == 2
-
-    lock_sql = calls[0]["sql"]
-    assert "pg_advisory_xact_lock" in lock_sql
-    # graph_name flows as $1 so independent AGE graphs in the same DB do not
-    # serialise each other's edges.
-    assert "$1::text || E'\\x01' ||" in lock_sql
-    # Key must be order-independent for (src, tgt) so {A, B} and {B, A} collide
-    # on the same lock (the OPTIONAL MATCH is undirected).
-    assert "LEAST($2::text, $3::text)" in lock_sql
-    assert "GREATEST($2::text, $3::text)" in lock_sql
-    # Raw graph_name + node IDs flow as positional params — never interpolated.
-    assert "test_graph" not in lock_sql
-    assert "Alice" not in lock_sql and "Bob" not in lock_sql
-    assert calls[0]["args"] == ("test_graph", "Alice", "Bob")
-
-    # The cypher statement must not contain the lock — that would cause AGE to
-    # reject the plan with "cypher create clause cannot be rescanned".
-    cypher_sql = calls[1]["sql"]
-    assert "pg_advisory_xact_lock" not in cypher_sql
-
-
-@pytest.mark.asyncio
-async def test_upsert_edge_lock_key_includes_graph_name():
-    """Advisory lock key must include graph_name so independent AGE graphs in
-    the same PostgreSQL database don't serialise each other's edges.
-
-    Regression for the codex review on PR #3056: pg_advisory_xact_lock is
-    database-wide, so hashing only (src, tgt) would make {Alice, Bob} in
-    `graph_a` block {Alice, Bob} in `graph_b` even though they touch different
-    AGE graph tables.
-    """
-    storage_a = make_graph_storage()
-    storage_a.graph_name = "graph_a"
-    storage_b = make_graph_storage()
-    storage_b.graph_name = "graph_b"
-
-    calls_a = await _capture_upsert_edge(storage_a, "Alice", "Bob", {})
-    calls_b = await _capture_upsert_edge(storage_b, "Alice", "Bob", {})
-
-    # graph_name flows as the first positional arg into the lock SQL so the
-    # hashed lock key differs between graphs even when (src, tgt) match.
-    assert calls_a[0]["args"] == ("graph_a", "Alice", "Bob")
-    assert calls_b[0]["args"] == ("graph_b", "Alice", "Bob")
-
-    # And the lock template references graph_name as $1, with the ID pair as
-    # $2/$3 — keep the param order pinned so future refactors don't silently
-    # swap them.
-    lock_sql = calls_a[0]["sql"]
-    assert "$1::text" in lock_sql
-    assert "LEAST($2::text, $3::text)" in lock_sql
-    assert "GREATEST($2::text, $3::text)" in lock_sql
-
-
-@pytest.mark.asyncio
-async def test_upsert_edge_lock_key_is_endpoint_order_independent():
-    """{A, B} and {B, A} must produce the same advisory lock key.
-
-    The lock SQL itself is identical across both call directions; only the
-    positional args differ. LEAST/GREATEST inside the template then normalises
-    them to the same hash input, so concurrent {A,B} and {B,A} writes collide
-    on a single lock (matching the undirected OPTIONAL MATCH).
-    """
-    storage = make_graph_storage()
-    forward = await _capture_upsert_edge(storage, "Alice", "Bob", {})
-    reverse = await _capture_upsert_edge(storage, "Bob", "Alice", {})
-
-    # Same lock SQL template for both directions.
-    assert forward[0]["sql"] == reverse[0]["sql"]
-    # graph_name first, then the endpoint pair in whatever order the caller
-    # passed — LEAST/GREATEST canonicalises inside the SQL.
-    assert forward[0]["args"][0] == reverse[0]["args"][0] == "test_graph"
-    assert (
-        set(forward[0]["args"][1:])
-        == set(reverse[0]["args"][1:])
-        == {
-            "Alice",
-            "Bob",
-        }
-    )
+    assert len(calls) == 1
+    assert "pg_advisory_xact_lock" not in calls[0]["sql"]
+    assert "CREATE (source)-[r:DIRECTED" in calls[0]["sql"]
 
 
 @pytest.mark.asyncio
@@ -250,9 +162,8 @@ async def test_upsert_edge_wraps_transient_errors_for_retry(monkeypatch):
     """Query-level transient errors must be wrapped in PGGraphQueryException so
     the outer @retry predicate can identify them and retry.
 
-    Regression: when upsert_edge was moved off self._query onto
-    self.db._run_with_retry (to run the advisory lock + cypher in one
-    transaction), the _query exception-wrapping path was bypassed. A raw
+    Regression: upsert_edge runs the cypher via self.db._run_with_retry (not
+    self._query), so the _query exception-wrapping path is bypassed. A raw
     asyncpg.DeadlockDetectedError surfacing from connection.execute would
     therefore fail _is_transient_graph_write_error's first guard
     (isinstance(exc, PGGraphQueryException)) and skip the retry loop, silently

--- a/tests/kg/test_batch_graph_operations.py
+++ b/tests/kg/test_batch_graph_operations.py
@@ -840,9 +840,7 @@ class TestPostgresBatchOrdering:
             ],
         )
 
-        cypher_calls = [
-            c for c in calls if "CREATE (source)-[r:DIRECTED" in c["sql"]
-        ]
+        cypher_calls = [c for c in calls if "CREATE (source)-[r:DIRECTED" in c["sql"]]
         log = [
             (json.loads(c["args"][0])["src_id"], json.loads(c["args"][0])["tgt_id"])
             for c in cypher_calls

--- a/tests/kg/test_batch_graph_operations.py
+++ b/tests/kg/test_batch_graph_operations.py
@@ -9,6 +9,7 @@ Verifies:
 5. upsert_edges_batch and upsert_nodes_batch are idempotent (safe to call twice).
 """
 
+import json
 import time
 import tempfile
 import pytest
@@ -757,18 +758,54 @@ class TestAinsertCustomKgBatchPath:
 
 
 class TestPostgresBatchOrdering:
+    @staticmethod
+    def _make_pg_storage():
+        """PGGraphStorage with a fake connection capturing executed Cypher.
+
+        The chunk-level batch paths build SQL and run it via
+        ``db._run_with_retry`` instead of calling ``upsert_node`` / ``upsert_edge``
+        per row, so the captured statements are how we observe dedup + ordering.
+        """
+        from lightrag.kg.postgres_impl import PGGraphStorage
+
+        storage = PGGraphStorage.__new__(PGGraphStorage)
+        storage.workspace = "test_ws"
+        storage.namespace = "test_graph"
+        storage.graph_name = "test_graph"
+        storage.__post_init__()  # resolves chunk-level batch limits
+
+        calls: list[dict] = []
+
+        class _Tx:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+        class _Conn:
+            def transaction(self):
+                return _Tx()
+
+            async def execute(self, sql, *args):
+                calls.append({"sql": sql, "args": args})
+                return ""
+
+        conn = _Conn()
+
+        async def fake_run_with_retry(operation, **_kwargs):
+            return await operation(conn)
+
+        storage.db = AsyncMock()
+        storage.db._run_with_retry = AsyncMock(side_effect=fake_run_with_retry)
+        return storage, calls
+
     @pytest.mark.offline
     @pytest.mark.asyncio
     async def test_upsert_nodes_batch_preserves_last_write_wins(self):
         from lightrag.kg.postgres_impl import PGGraphStorage
 
-        storage = PGGraphStorage.__new__(PGGraphStorage)
-        call_log: list[tuple[str, str]] = []
-
-        async def spy(node_id, *, node_data):
-            call_log.append((node_id, node_data["description"]))
-
-        storage.upsert_node = spy  # type: ignore[assignment]
+        storage, calls = self._make_pg_storage()
 
         await PGGraphStorage.upsert_nodes_batch(
             storage,
@@ -779,23 +816,20 @@ class TestPostgresBatchOrdering:
             ],
         )
 
-        assert call_log == [
-            ("EntityA", "latest"),
-            ("EntityB", "Description of EntityB"),
-        ]
+        merge_calls = [c for c in calls if "MERGE (n:base" in c["sql"]]
+        entity_ids = [json.loads(c["args"][0])["entity_id"] for c in merge_calls]
+        # Deduped to one EntityA (moved to its last position), then EntityB.
+        assert entity_ids == ["EntityA", "EntityB"]
+        # EntityA carries the latest payload, not the first.
+        assert '"latest"' in merge_calls[0]["sql"]
+        assert "Description of EntityA" not in merge_calls[0]["sql"]
 
     @pytest.mark.offline
     @pytest.mark.asyncio
     async def test_upsert_edges_batch_preserves_last_write_wins(self):
         from lightrag.kg.postgres_impl import PGGraphStorage
 
-        storage = PGGraphStorage.__new__(PGGraphStorage)
-        call_log: list[tuple[str, str, float]] = []
-
-        async def spy(src, tgt, *, edge_data):
-            call_log.append((src, tgt, edge_data["weight"]))
-
-        storage.upsert_edge = spy  # type: ignore[assignment]
+        storage, calls = self._make_pg_storage()
 
         await PGGraphStorage.upsert_edges_batch(
             storage,
@@ -806,7 +840,17 @@ class TestPostgresBatchOrdering:
             ],
         )
 
-        assert call_log == [("EntityB", "EntityA", 2.0), ("EntityB", "EntityC", 3.0)]
+        cypher_calls = [
+            c for c in calls if "CREATE (source)-[r:DIRECTED" in c["sql"]
+        ]
+        log = [
+            (json.loads(c["args"][0])["src_id"], json.loads(c["args"][0])["tgt_id"])
+            for c in cypher_calls
+        ]
+        # Canonical (LEAST, GREATEST) key order: (A,B) then (B,C); each pair keeps
+        # its last-write orientation/payload.
+        assert log == [("EntityB", "EntityA"), ("EntityB", "EntityC")]
+        assert "2.0" in cypher_calls[0]["sql"]  # weight 2.0 won the (A,B) pair
 
 
 class TestMongoBatchOrdering:

--- a/tests/kg/test_graph_storage.py
+++ b/tests/kg/test_graph_storage.py
@@ -1025,16 +1025,18 @@ async def test_graph_query_helpers(storage):
         popular = await storage.get_popular_labels(limit=2)
         assert isinstance(popular, list)
         assert len(popular) <= 2
-        assert popular and popular[0] == "Alpha", (
-            f"highest-degree label should be 'Alpha', got {popular}"
-        )
+        assert (
+            popular and popular[0] == "Alpha"
+        ), f"highest-degree label should be 'Alpha', got {popular}"
 
         # 4. search_labels - substring / prefix match, and a clear miss
         print("== Testing search_labels")
         gamma_hits = await storage.search_labels("Gam")
         assert "Gamma" in gamma_hits, f"search 'Gam' should find 'Gamma': {gamma_hits}"
         alpha_hits = await storage.search_labels("Alpha")
-        assert "Alpha" in alpha_hits, f"search 'Alpha' should find 'Alpha': {alpha_hits}"
+        assert (
+            "Alpha" in alpha_hits
+        ), f"search 'Alpha' should find 'Alpha': {alpha_hits}"
         misses = await storage.search_labels("NoSuchEntityXYZ")
         assert "Alpha" not in misses and "Gamma" not in misses
 
@@ -1749,7 +1751,9 @@ async def main():
                                 )
                                 await reset_storage("String Escaping Regression Test")
                                 escaping_result = (
-                                    await test_graph_string_escaping_regressions(storage)
+                                    await test_graph_string_escaping_regressions(
+                                        storage
+                                    )
                                 )
 
                                 if escaping_result is not False:

--- a/tests/kg/test_graph_storage.py
+++ b/tests/kg/test_graph_storage.py
@@ -977,6 +977,77 @@ async def test_graph_batch_upsert(storage):
 
 @pytest.mark.integration
 @pytest.mark.requires_db
+async def test_graph_query_helpers(storage):
+    """
+    Cover the whole-graph query helpers that the other tests don't touch:
+    1. get_all_nodes  - every node as a dict carrying its "id".
+    2. get_all_edges  - every edge as a dict carrying "source"/"target".
+    3. get_popular_labels - labels ordered by degree (highest first).
+    4. search_labels  - substring/fuzzy label search.
+    """
+    try:
+        # Star topology so degrees are distinct: Alpha=3, others=1.
+        node_ids = ["Alpha", "Beta", "Gamma", "Alphabet"]
+        for nid in node_ids:
+            await storage.upsert_node(
+                nid,
+                {
+                    "entity_id": nid,
+                    "description": f"desc of {nid}",
+                    "entity_type": "T",
+                },
+            )
+        star_edges = [("Alpha", "Beta"), ("Alpha", "Gamma"), ("Alpha", "Alphabet")]
+        for src, tgt in star_edges:
+            await storage.upsert_edge(
+                src, tgt, {"relationship": "rel", "weight": 1.0, "description": "d"}
+            )
+
+        # 1. get_all_nodes
+        print("== Testing get_all_nodes")
+        all_nodes = await storage.get_all_nodes()
+        assert isinstance(all_nodes, list)
+        ids = {n.get("id") for n in all_nodes}
+        assert ids == set(node_ids), f"get_all_nodes ids mismatch: {ids}"
+
+        # 2. get_all_edges (undirected: compare unordered endpoint pairs)
+        print("== Testing get_all_edges")
+        all_edges = await storage.get_all_edges()
+        assert isinstance(all_edges, list)
+        assert (
+            len(all_edges) == 3
+        ), f"get_all_edges should return 3 edges, got {len(all_edges)}"
+        edge_pairs = {frozenset((e["source"], e["target"])) for e in all_edges}
+        assert edge_pairs == {frozenset(p) for p in star_edges}
+
+        # 3. get_popular_labels - highest degree first
+        print("== Testing get_popular_labels")
+        popular = await storage.get_popular_labels(limit=2)
+        assert isinstance(popular, list)
+        assert len(popular) <= 2
+        assert popular and popular[0] == "Alpha", (
+            f"highest-degree label should be 'Alpha', got {popular}"
+        )
+
+        # 4. search_labels - substring / prefix match, and a clear miss
+        print("== Testing search_labels")
+        gamma_hits = await storage.search_labels("Gam")
+        assert "Gamma" in gamma_hits, f"search 'Gam' should find 'Gamma': {gamma_hits}"
+        alpha_hits = await storage.search_labels("Alpha")
+        assert "Alpha" in alpha_hits, f"search 'Alpha' should find 'Alpha': {alpha_hits}"
+        misses = await storage.search_labels("NoSuchEntityXYZ")
+        assert "Alpha" not in misses and "Gamma" not in misses
+
+        print("\nQuery helper tests completed.")
+        return True
+
+    except Exception as e:
+        ASCIIColors.red(f"An error occurred during the test: {str(e)}")
+        return False
+
+
+@pytest.mark.integration
+@pytest.mark.requires_db
 async def test_graph_special_characters(storage):
     """
     Test the graph database's handling of special characters:
@@ -1614,12 +1685,15 @@ async def main():
         ASCIIColors.white(
             "7. Batch Upsert Test (upsert_nodes_batch / upsert_edges_batch, dedup, has_node)"
         )
-        ASCIIColors.white("8. All Tests")
+        ASCIIColors.white(
+            "8. Query Helpers Test (get_all_nodes / get_all_edges / get_popular_labels / search_labels)"
+        )
+        ASCIIColors.white("9. All Tests")
 
-        choice = input("\nEnter your choice (1/2/3/4/5/6/7/8): ")
+        choice = input("\nEnter your choice (1/2/3/4/5/6/7/8/9): ")
 
         # Clean data before running tests
-        if choice in ["1", "2", "3", "4", "5", "6", "7", "8"]:
+        if choice in ["1", "2", "3", "4", "5", "6", "7", "8", "9"]:
             await reset_storage("running tests")
 
         if choice == "1":
@@ -1637,6 +1711,8 @@ async def main():
         elif choice == "7":
             await test_graph_batch_upsert(storage)
         elif choice == "8":
+            await test_graph_query_helpers(storage)
+        elif choice == "9":
             ASCIIColors.cyan("\n=== Starting Basic Test ===")
             await reset_storage("Basic Test")
             basic_result = await test_graph_basic(storage)
@@ -1681,7 +1757,16 @@ async def main():
                                         "\n=== Starting Batch Upsert Test ==="
                                     )
                                     await reset_storage("Batch Upsert Test")
-                                    await test_graph_batch_upsert(storage)
+                                    batch_upsert_result = await test_graph_batch_upsert(
+                                        storage
+                                    )
+
+                                    if batch_upsert_result is not False:
+                                        ASCIIColors.cyan(
+                                            "\n=== Starting Query Helpers Test ==="
+                                        )
+                                        await reset_storage("Query Helpers Test")
+                                        await test_graph_query_helpers(storage)
         else:
             ASCIIColors.red("Invalid choice")
 

--- a/tests/kg/test_graph_storage.py
+++ b/tests/kg/test_graph_storage.py
@@ -869,6 +869,114 @@ async def test_graph_batch_operations(storage):
 
 @pytest.mark.integration
 @pytest.mark.requires_db
+async def test_graph_batch_upsert(storage):
+    """
+    Test the batch *write* paths end-to-end against the configured backend:
+    1. upsert_nodes_batch inserts many nodes (forced across multiple chunks on
+       backends that chunk by record count, e.g. PGGraphStorage).
+    2. Same-batch last-write-wins dedup for nodes.
+    3. has_node / has_nodes_batch existence checks.
+    4. upsert_edges_batch inserts many edges, including a reciprocal duplicate
+       that must collapse to the last write (undirected last-write-wins).
+    5. Read-back of node/edge properties, degrees, and undirected consistency.
+
+    These paths are otherwise only covered by mock unit tests; this is the only
+    place they run against a real graph backend.
+    """
+    try:
+        # Force >1 chunk on backends that chunk batch upserts by record count
+        # (PGGraphStorage). Other backends simply ignore this attribute.
+        if hasattr(storage, "_max_upsert_records_per_batch"):
+            storage._max_upsert_records_per_batch = 2
+
+        # 1. Batch node upsert with a same-batch duplicate (last write wins).
+        nodes = [
+            ("E1", {"entity_id": "E1", "description": "first", "entity_type": "T"}),
+            ("E2", {"entity_id": "E2", "description": "second", "entity_type": "T"}),
+            ("E3", {"entity_id": "E3", "description": "third", "entity_type": "T"}),
+            ("E4", {"entity_id": "E4", "description": "fourth", "entity_type": "T"}),
+            ("E5", {"entity_id": "E5", "description": "fifth", "entity_type": "T"}),
+            # duplicate of E1 later in the same batch -> must keep this payload
+            (
+                "E1",
+                {"entity_id": "E1", "description": "first-updated", "entity_type": "T"},
+            ),
+        ]
+        print("== Testing upsert_nodes_batch (multi-chunk + same-batch dedup)")
+        await storage.upsert_nodes_batch(nodes)
+
+        # 2. All five distinct nodes exist; has_node / has_nodes_batch.
+        for nid in ["E1", "E2", "E3", "E4", "E5"]:
+            assert await storage.has_node(
+                nid
+            ), f"{nid} should exist after upsert_nodes_batch"
+        existing = await storage.has_nodes_batch(["E1", "E3", "E5", "DOES_NOT_EXIST"])
+        assert existing == {
+            "E1",
+            "E3",
+            "E5",
+        }, f"has_nodes_batch returned unexpected set: {existing}"
+
+        # Last-write-wins: the second E1 in the batch wins.
+        e1 = await storage.get_node("E1")
+        assert (
+            e1 is not None and e1["description"] == "first-updated"
+        ), "Same-batch node dedup should keep the last write"
+
+        # Batch read-back of the rest.
+        nodes_dict = await storage.get_nodes_batch(["E2", "E3", "E4", "E5"])
+        assert set(nodes_dict) == {"E2", "E3", "E4", "E5"}
+        assert nodes_dict["E3"]["description"] == "third"
+
+        # 3. Batch edge upsert with a reciprocal duplicate (undirected dedup).
+        edges = [
+            ("E1", "E2", {"relationship": "r12", "weight": 1.0, "description": "d12"}),
+            ("E2", "E3", {"relationship": "r23", "weight": 1.0, "description": "d23"}),
+            ("E3", "E4", {"relationship": "r34", "weight": 1.0, "description": "d34"}),
+            ("E4", "E5", {"relationship": "r45", "weight": 1.0, "description": "d45"}),
+            # reciprocal of (E1, E2): undirected -> last write wins
+            (
+                "E2",
+                "E1",
+                {
+                    "relationship": "r12-updated",
+                    "weight": 2.0,
+                    "description": "d12-updated",
+                },
+            ),
+        ]
+        print("== Testing upsert_edges_batch (multi-chunk + reciprocal dedup)")
+        await storage.upsert_edges_batch(edges)
+
+        # 4. Every edge readable in both directions (undirected).
+        for a, b in [("E1", "E2"), ("E2", "E3"), ("E3", "E4"), ("E4", "E5")]:
+            fwd = await storage.get_edge(a, b)
+            rev = await storage.get_edge(b, a)
+            assert fwd is not None, f"Edge {a}->{b} missing after upsert_edges_batch"
+            assert rev is not None, f"Reverse edge {b}->{a} missing (undirected)"
+            assert fwd == rev, f"Edge {a}<->{b} not undirected-consistent"
+
+        # Reciprocal dedup last-write-wins on (E1, E2).
+        e12 = await storage.get_edge("E1", "E2")
+        assert e12["relationship"] == "r12-updated", "Reciprocal edge dedup lost"
+        assert e12["weight"] == 2.0, "Reciprocal edge dedup kept the wrong weight"
+
+        # 5. Degrees reflect exactly the four distinct edges.
+        assert await storage.node_degree("E1") == 1
+        assert await storage.node_degree("E2") == 2
+        assert await storage.node_degree("E3") == 2
+        assert await storage.node_degree("E5") == 1
+
+        print("\nBatch upsert tests completed.")
+        return True
+
+    except Exception as e:
+        ASCIIColors.red(f"An error occurred during the test: {str(e)}")
+        return False
+
+
+@pytest.mark.integration
+@pytest.mark.requires_db
 async def test_graph_special_characters(storage):
     """
     Test the graph database's handling of special characters:
@@ -1503,12 +1611,15 @@ async def main():
         ASCIIColors.white(
             "6. String Escaping Regression Test (Quoted and escaped entity IDs across graph operations)"
         )
-        ASCIIColors.white("7. All Tests")
+        ASCIIColors.white(
+            "7. Batch Upsert Test (upsert_nodes_batch / upsert_edges_batch, dedup, has_node)"
+        )
+        ASCIIColors.white("8. All Tests")
 
-        choice = input("\nEnter your choice (1/2/3/4/5/6/7): ")
+        choice = input("\nEnter your choice (1/2/3/4/5/6/7/8): ")
 
         # Clean data before running tests
-        if choice in ["1", "2", "3", "4", "5", "6", "7"]:
+        if choice in ["1", "2", "3", "4", "5", "6", "7", "8"]:
             await reset_storage("running tests")
 
         if choice == "1":
@@ -1524,6 +1635,8 @@ async def main():
         elif choice == "6":
             await test_graph_string_escaping_regressions(storage)
         elif choice == "7":
+            await test_graph_batch_upsert(storage)
+        elif choice == "8":
             ASCIIColors.cyan("\n=== Starting Basic Test ===")
             await reset_storage("Basic Test")
             basic_result = await test_graph_basic(storage)
@@ -1559,7 +1672,16 @@ async def main():
                                     "\n=== Starting String Escaping Regression Test ==="
                                 )
                                 await reset_storage("String Escaping Regression Test")
-                                await test_graph_string_escaping_regressions(storage)
+                                escaping_result = (
+                                    await test_graph_string_escaping_regressions(storage)
+                                )
+
+                                if escaping_result is not False:
+                                    ASCIIColors.cyan(
+                                        "\n=== Starting Batch Upsert Test ==="
+                                    )
+                                    await reset_storage("Batch Upsert Test")
+                                    await test_graph_batch_upsert(storage)
         else:
             ASCIIColors.red("Invalid choice")
 


### PR DESCRIPTION
## Summary

**PR 2** of the PostgreSQL batching plan (after the merged KV/Vector/DocStatus PR). Apache AGE has no parameterized `UNWIND` bulk upsert, so `PGGraphStorage`'s batch methods kept per-row Cypher but ran **each row** in its own connection-acquire → AGE-configure → transaction cycle — high overhead under large ingests. This groups rows into payload/record-bounded **chunks**, each run in a **single transaction** on one shared connection. It does not reach single-`UNWIND` performance, but removes the per-row transaction/connection overhead with low risk.

## Changes

- **Shared SQL builders**: extract `_build_upsert_node_sql` / `_build_upsert_edge_sql` so the single-row (`upsert_node`/`upsert_edge`) and batch paths emit identical Cypher and cannot drift.
- **Limits**: `PGGraphStorage.__post_init__` resolves the shared `POSTGRES_UPSERT_MAX_*` / `POSTGRES_DELETE_MAX_RECORDS_PER_BATCH` knobs.
- **`upsert_nodes_batch` / `upsert_edges_batch`**: dedup (last-write-wins) → `_chunk_by_budget` → each chunk run in one transaction via a `@retry`-wrapped `_upsert_node_chunk` / `_upsert_edge_chunk`. Each chunk keeps the **two-layer retry** of the single-row path: `_run_with_retry` for connection-level transients, the tenacity `@retry` + `_is_transient_graph_write_error` for query-level deadlock/serialization errors wrapped as `PGGraphQueryException`.
- **Edge serialization (advisory locks)** — the edge upsert's `OPTIONAL MATCH + DELETE + CREATE` is not atomic against a concurrent writer of the same pair (both could observe no edge and both `CREATE`, leaving duplicate `DIRECTED` rows). The graph-edit endpoints (`/graph/relation/edit` etc.) only best-effort-check `pipeline_status` and don't reserve the writer slot, so the storage-layer advisory lock is the documented last line of defense. Locks are arranged so the single and batch paths share a lock domain while preserving pipeline concurrency:
  - **single `upsert_edge`** takes a per-edge **EXCLUSIVE** lock keyed on `(graph_name, ordered (src,tgt))` — serialises same-edge single-vs-single, lets different edges run concurrently — **plus** a graph-wide **SHARED** lock (`pg_advisory_xact_lock_shared`, keyed on `graph_name`).
  - **batch `upsert_edges_batch`** takes one graph-wide **EXCLUSIVE** lock per chunk (`_GRAPH_ADVISORY_LOCK_SQL`) — a single advisory lock regardless of edge count, no per-edge pile-up.
  - shared/shared is compatible (concurrent single writers on different edges don't serialise); shared/exclusive conflicts, so a bulk batch and any single edge write on the same graph cannot interleave their `OPTIONAL MATCH/DELETE/CREATE` → no cross-path duplicate rows.
- **`remove_nodes`**: chunk the inlined `IN [...]` list (bounds Cypher text) but run **all chunks in ONE transaction**, preserving the original single-statement all-or-nothing semantics.
- **`remove_edges`**: chunk and run **one transaction per chunk** (the old path opened one transaction *per edge*), bounding Cypher text and transaction duration per chunk.

## Test plan

- [x] `ruff check` — clean
- [x] New `tests/kg/postgres_impl/test_postgres_graph_batch.py`: chunk counts, per-chunk vs single-transaction (`remove_nodes` = 1 tx, `remove_edges` = 1 tx/chunk), dedup last-write-wins, byte-budget split, missing-`entity_id` raises before any tx, empty no-ops, and that the edge batch takes exactly **one graph-keyed exclusive lock per chunk** (not per-edge).
- [x] `test_postgres_upsert_edge_cypher.py` / `test_postgres_cypher_injection.py`: single `upsert_edge` issues per-edge exclusive lock + graph-wide shared lock + cypher (asserted against the 3-statement sequence); cross-backend `test_batch_graph_operations.py` ordering tests updated to the chunk flow.
- [x] `pytest tests/kg/ -q` — **680 passed, 17 skipped** (live-PG cases skip)

## Out of scope (follow-up)

- **PR 3**: explore AGE true `UNWIND` bulk upsert to replace the per-row-in-chunk execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)