### PR TITLE
🔒 fix(opensearch): merge reverse payload into canonical on duplicate migration

### DIFF
--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -27,7 +27,7 @@ from ..base import (
     DocStatus,
     DocStatusStorage,
 )
-from ..utils import logger, compute_mdhash_id, _cooperative_yield
+from ..utils import logger, compute_mdhash_id, _cooperative_yield, merge_source_ids
 from ..types import KnowledgeGraph, KnowledgeGraphNode, KnowledgeGraphEdge
 from ..constants import GRAPH_FIELD_SEP
 from ..kg.shared_storage import get_data_init_lock, get_namespace_lock
@@ -38,7 +38,12 @@ if not pm.is_installed("opensearch-py"):
     pm.install("opensearch-py")
 
 from opensearchpy import AsyncOpenSearch, helpers  # type: ignore
-from opensearchpy.exceptions import OpenSearchException, NotFoundError, RequestError  # type: ignore
+from opensearchpy.exceptions import (  # type: ignore
+    OpenSearchException,
+    NotFoundError,
+    RequestError,
+    ConflictError,
+)
 
 config = configparser.ConfigParser()
 config.read("config.ini", "utf-8")
@@ -306,6 +311,63 @@ def _canonical_edge_id(source_node_id: str, target_node_id: str) -> str:
     """
     lo, hi = sorted((source_node_id, target_node_id))
     return compute_mdhash_id(f"{lo}-{hi}", prefix="edge-")
+
+
+def _merge_edge_payloads(docs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Merge edge-doc relation payloads when consolidating legacy duplicates.
+
+    Mirrors ``mongo_impl``'s dedupe merge and ``operate.py``'s
+    ``_merge_edges_then_upsert`` field semantics (minus LLM description
+    summarisation): ``source_id``/``source_ids``/``file_path``/``description``
+    union their ``GRAPH_FIELD_SEP`` components, ``keywords`` are comma-set-
+    unioned, and ``weight`` takes the max. Returns only the merged fields (to be
+    layered onto the surviving doc).
+
+    Idempotent: every field unions split components and ``weight`` is a max, so
+    re-merging an already-merged doc is a no-op (safe across fail-fast retries).
+    Legacy string weights are coerced to float; non-numeric values are skipped
+    so a bad value cannot crash the migration.
+    """
+    source_ids: list[str] = []
+    file_paths: list[str] = []
+    descriptions: list[str] = []
+    keywords: set[str] = set()
+    weights: list[float] = []
+    for d in docs:
+        sids = d.get("source_ids")
+        if not sids and d.get("source_id"):
+            sids = d["source_id"].split(GRAPH_FIELD_SEP)
+        source_ids = merge_source_ids(source_ids, sids or [])
+        fp = d.get("file_path")
+        file_paths = merge_source_ids(
+            file_paths, fp.split(GRAPH_FIELD_SEP) if fp else []
+        )
+        desc = d.get("description")
+        descriptions = merge_source_ids(
+            descriptions, desc.split(GRAPH_FIELD_SEP) if desc else []
+        )
+        kw = d.get("keywords")
+        if kw:
+            keywords.update(k.strip() for k in kw.split(",") if k.strip())
+        w = d.get("weight")
+        if w is not None:
+            try:
+                weights.append(float(w))
+            except (TypeError, ValueError):
+                pass
+    merged: dict[str, Any] = {}
+    if source_ids:
+        merged["source_ids"] = source_ids
+        merged["source_id"] = GRAPH_FIELD_SEP.join(source_ids)
+    if file_paths:
+        merged["file_path"] = GRAPH_FIELD_SEP.join(file_paths)
+    if descriptions:
+        merged["description"] = GRAPH_FIELD_SEP.join(descriptions)
+    if keywords:
+        merged["keywords"] = ",".join(sorted(keywords))
+    if weights:
+        merged["weight"] = max(weights)
+    return merged
 
 
 # Detected at first connection; True when OpenSearch >= 3.3.0.
@@ -2023,17 +2085,22 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                     what="canonical edge-id migration (create)",
                     raise_on_error=False,
                 )
-                # Fail fast on any non-benign create error (e.g. 429/503): raise
-                # BEFORE deleting any source row, so no edge is dropped without
-                # its canonical counterpart in place. The flag stays unset and
-                # the next startup rescans.
-                real_create_errors = [
-                    e
-                    for e in errors
-                    if not (
-                        isinstance(e, dict) and e.get("create", {}).get("status") == 409
-                    )
-                ]
+                # A create 409 means the canonical doc already exists (a forward
+                # legacy doc, i.e. a reciprocal duplicate): merge this reverse
+                # doc's relation payload into it (below) so deleting the reverse
+                # loses no evidence. Any other create error (e.g. 429/503) fails
+                # fast BEFORE any delete, so no edge is dropped without its
+                # canonical counterpart in place; the flag stays unset and the
+                # next startup rescans.
+                conflicted_canonicals: list[str] = []
+                real_create_errors = []
+                for e in errors:
+                    info = e.get("create") if isinstance(e, dict) else None
+                    if info is not None and info.get("status") == 409:
+                        if info.get("_id"):
+                            conflicted_canonicals.append(info["_id"])
+                        continue
+                    real_create_errors.append(e)
                 if real_create_errors:
                     raise RuntimeError(
                         f"Canonical edge-id migration: {len(real_create_errors)} "
@@ -2041,10 +2108,21 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                         f"(no source rows deleted)"
                     )
 
-                # Phase 2 — every create succeeded or 409'd, so the canonical now
-                # exists for all; delete the old ids. delete 404 is benign
-                # (another run already removed it); any other delete error fails
-                # fast.
+                if conflicted_canonicals:
+                    source_by_canonical = {
+                        canonical: source for canonical, _old_id, source in batch
+                    }
+                    for canonical in conflicted_canonicals:
+                        reverse_source = source_by_canonical.get(canonical)
+                        if reverse_source is not None:
+                            await self._merge_into_canonical_edge(
+                                canonical, reverse_source
+                            )
+
+                # Phase 2 — every create succeeded, 409'd-then-merged, so the
+                # canonical now exists for all; delete the old ids. delete 404 is
+                # benign (another run already removed it); any other delete error
+                # fails fast.
                 delete_actions = [
                     {"_op_type": "delete", "_index": self._edges_index, "_id": old_id}
                     for _canonical, old_id, _source in batch
@@ -2133,9 +2211,9 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             )
             # Mark complete (only reached on full success) so subsequent startups
             # skip the full scan. Legacy reciprocal duplicates collapsed onto one
-            # canonical doc: the forward/existing doc wins (create is insert-only)
-            # and the other orientation was deleted — acceptable, edges are
-            # undirected.
+            # canonical doc: the reverse doc's relation payload was merged into
+            # the existing canonical (see _merge_into_canonical_edge) and the
+            # reverse orientation deleted — no relation evidence lost.
             await self.client.indices.put_mapping(
                 index=self._edges_index,
                 body={"_meta": {**meta, _EDGE_ID_CANONICAL_META_FLAG: True}},
@@ -2148,6 +2226,51 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 f"{self._edges_index}: {e}; aborting startup"
             )
             raise
+
+    async def _merge_into_canonical_edge(
+        self, canonical_id: str, reverse_source: dict[str, Any]
+    ) -> None:
+        """Merge a legacy reverse-orientation doc's payload into an existing
+        canonical doc (the create-409 reciprocal-duplicate case) so deleting the
+        reverse loses no relation evidence (mirrors mongo_impl's dedupe merge).
+
+        Uses optimistic concurrency (``if_seq_no``/``if_primary_term``) so a
+        concurrent live write during a rolling deploy is never clobbered: on a
+        version conflict we re-read — now including that write — and re-merge.
+        The merge is idempotent (see ``_merge_edge_payloads``), so a fail-fast
+        retry over an already-merged canonical is a no-op.
+        """
+        for _attempt in range(3):
+            try:
+                current = await self.client.get(
+                    index=self._edges_index, id=canonical_id
+                )
+            except NotFoundError:
+                # Canonical vanished between the create-409 and now; recreate it
+                # from the reverse source (nothing to merge against).
+                await self.client.index(
+                    index=self._edges_index, id=canonical_id, body=reverse_source
+                )
+                return
+            base = current.get("_source", {})
+            merged = {**base, **_merge_edge_payloads([base, reverse_source])}
+            try:
+                await self.client.index(
+                    index=self._edges_index,
+                    id=canonical_id,
+                    body=merged,
+                    if_seq_no=current["_seq_no"],
+                    if_primary_term=current["_primary_term"],
+                )
+                return
+            except ConflictError:
+                # A concurrent write changed the canonical doc; re-read and
+                # re-merge so we never overwrite that write with stale data.
+                continue
+        raise RuntimeError(
+            f"Canonical edge-id migration: could not merge into {canonical_id} "
+            f"after retries in {self._edges_index}; aborting startup"
+        )
 
     async def finalize(self):
         """Release the OpenSearch client connection."""

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -313,31 +313,50 @@ def _canonical_edge_id(source_node_id: str, target_node_id: str) -> str:
     return compute_mdhash_id(f"{lo}-{hi}", prefix="edge-")
 
 
+def _edge_source_id_list(doc: dict[str, Any]) -> list[str]:
+    """Return an edge doc's source ids, from the ``source_ids`` array or by
+    splitting the ``GRAPH_FIELD_SEP``-joined ``source_id`` string."""
+    sids = doc.get("source_ids")
+    if not sids and doc.get("source_id"):
+        sids = doc["source_id"].split(GRAPH_FIELD_SEP)
+    return list(sids or [])
+
+
+def _coerce_weight(weight: Any) -> float | None:
+    """Coerce a (possibly string) edge weight to float, or None if non-numeric."""
+    if weight is None:
+        return None
+    try:
+        return float(weight)
+    except (TypeError, ValueError):
+        return None
+
+
 def _merge_edge_payloads(docs: list[dict[str, Any]]) -> dict[str, Any]:
     """Merge edge-doc relation payloads when consolidating legacy duplicates.
 
+    ``docs[0]`` is the survivor/base; the rest are duplicates folded into it.
     Mirrors ``mongo_impl``'s dedupe merge and ``operate.py``'s
     ``_merge_edges_then_upsert`` field semantics (minus LLM description
     summarisation): ``source_id``/``source_ids``/``file_path``/``description``
     union their ``GRAPH_FIELD_SEP`` components, ``keywords`` are comma-set-
-    unioned, and ``weight`` takes the max. Returns only the merged fields (to be
-    layered onto the surviving doc).
+    unioned, and ``weight`` is **summed** (duplicate docs carry separate
+    accumulated weight). Returns only the merged fields (to be layered onto the
+    surviving doc).
 
-    Idempotent: every field unions split components and ``weight`` is a max, so
-    re-merging an already-merged doc is a no-op (safe across fail-fast retries).
-    Legacy string weights are coerced to float; non-numeric values are skipped
-    so a bad value cannot crash the migration.
+    Idempotent across fail-fast retries: the union fields union split components
+    (re-merging an already-merged base is a no-op), and the weight sum counts the
+    base's current weight once plus each duplicate only while its source_ids are
+    not already folded into the base — so a retry (whose base already contains
+    them) does not double-count. Legacy string weights are coerced; non-numeric
+    values are skipped so a bad value cannot crash the migration.
     """
     source_ids: list[str] = []
     file_paths: list[str] = []
     descriptions: list[str] = []
     keywords: set[str] = set()
-    weights: list[float] = []
     for d in docs:
-        sids = d.get("source_ids")
-        if not sids and d.get("source_id"):
-            sids = d["source_id"].split(GRAPH_FIELD_SEP)
-        source_ids = merge_source_ids(source_ids, sids or [])
+        source_ids = merge_source_ids(source_ids, _edge_source_id_list(d))
         fp = d.get("file_path")
         file_paths = merge_source_ids(
             file_paths, fp.split(GRAPH_FIELD_SEP) if fp else []
@@ -349,12 +368,23 @@ def _merge_edge_payloads(docs: list[dict[str, Any]]) -> dict[str, Any]:
         kw = d.get("keywords")
         if kw:
             keywords.update(k.strip() for k in kw.split(",") if k.strip())
-        w = d.get("weight")
-        if w is not None:
-            try:
-                weights.append(float(w))
-            except (TypeError, ValueError):
-                pass
+
+    # Idempotent summed weight: base (docs[0]) counts once; each duplicate adds
+    # its weight only if its source_ids are not already folded into the base.
+    base = docs[0] if docs else {}
+    base_sids = set(_edge_source_id_list(base))
+    weights: list[float] = []
+    bw = _coerce_weight(base.get("weight"))
+    if bw is not None:
+        weights.append(bw)
+    for d in docs[1:]:
+        d_sids = set(_edge_source_id_list(d))
+        if not d_sids or d_sids <= base_sids:
+            continue  # no new trackable evidence -> don't (re-)add its weight
+        dw = _coerce_weight(d.get("weight"))
+        if dw is not None:
+            weights.append(dw)
+
     merged: dict[str, Any] = {}
     if source_ids:
         merged["source_ids"] = source_ids
@@ -366,7 +396,7 @@ def _merge_edge_payloads(docs: list[dict[str, Any]]) -> dict[str, Any]:
     if keywords:
         merged["keywords"] = ",".join(sorted(keywords))
     if weights:
-        merged["weight"] = max(weights)
+        merged["weight"] = sum(weights)
     return merged
 
 

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -2084,20 +2084,41 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                     return
                 batch, pending = pending, []
 
-                # Phase 1 — create the canonical docs. op_type=create
-                # (insert-only): a create 409 means the canonical doc already
-                # exists (forward legacy doc), which is benign — the reverse
-                # source row is then safe to drop. raise_on_error=False so a 409
-                # does not abort.
-                create_actions = [
-                    {
-                        "_op_type": "create",
-                        "_index": self._edges_index,
-                        "_id": canonical,
-                        "_source": source,
-                    }
-                    for canonical, _old_id, source in batch
-                ]
+                # Group this batch by canonical id. A node pair can have >1
+                # pending non-canonical doc (e.g. several legacy reciprocal
+                # duplicates), and they all map to the same canonical id; carry
+                # each doc's old _id so it can be deleted after consolidation.
+                docs_by_canonical: dict[str, list[tuple[str, dict[str, Any]]]] = {}
+                for canonical, old_id, source in batch:
+                    docs_by_canonical.setdefault(canonical, []).append((old_id, source))
+
+                # Phase 1 — create exactly ONE canonical doc per canonical id.
+                # When a canonical has >1 pending doc we pre-merge their payloads
+                # in memory so the single create carries the summed weight/unioned
+                # provenance: issuing one create per doc instead would let one win
+                # the insert and the rest 409, and folding those 409'd docs back in
+                # would re-merge the create winner (its source is now the base),
+                # double-counting its weight. op_type=create (insert-only): a 409
+                # then means the canonical already existed *independently of this
+                # batch* (a forward legacy doc, or a prior batch/run), so every doc
+                # this batch mapped to it is a loser to fold in. raise_on_error=
+                # False so a 409 does not abort.
+                create_actions = []
+                for canonical, reverse_docs in docs_by_canonical.items():
+                    sources = [source for _old_id, source in reverse_docs]
+                    source = (
+                        {**sources[0], **_merge_edge_payloads(sources)}
+                        if len(sources) > 1
+                        else sources[0]
+                    )
+                    create_actions.append(
+                        {
+                            "_op_type": "create",
+                            "_index": self._edges_index,
+                            "_id": canonical,
+                            "_source": source,
+                        }
+                    )
                 _success, errors = await _run_chunked_async_bulk(
                     self.client,
                     create_actions,
@@ -2107,9 +2128,8 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                     what="canonical edge-id migration (create)",
                     raise_on_error=False,
                 )
-                # A create 409 means the canonical doc already exists (a forward
-                # legacy doc, i.e. a reciprocal duplicate): merge this reverse
-                # doc's relation payload into it (below) so deleting the reverse
+                # A create 409 means the canonical doc already exists: merge the
+                # pending doc(s)' relation payload into it (below) so deleting them
                 # loses no evidence. Any other create error (e.g. 429/503) fails
                 # fast BEFORE any delete, so no edge is dropped without its
                 # canonical counterpart in place; the flag stays unset and the
@@ -2130,22 +2150,13 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                         f"(no source rows deleted)"
                     )
 
-                if conflicted_canonicals:
-                    # A single canonical can be the target of more than one
-                    # pending reverse doc in this batch (e.g. 3+ legacy docs for
-                    # one node pair, where only one wins the insert and the rest
-                    # 409). Collect *all* reverse docs mapping to each conflicted
-                    # canonical (carrying their old _id so they can be deleted
-                    # right after the merge) and fold them together so no reverse
-                    # payload is dropped.
-                    docs_by_canonical: dict[str, list[tuple[str, dict[str, Any]]]] = {}
-                    for canonical, old_id, source in batch:
-                        if canonical in conflicted_canonicals:
-                            docs_by_canonical.setdefault(canonical, []).append(
-                                (old_id, source)
-                            )
-                    for canonical, reverse_docs in docs_by_canonical.items():
-                        await self._merge_into_canonical_edge(canonical, reverse_docs)
+                # The canonical pre-existed (the create did not write it), so fold
+                # *every* doc this batch mapped to it — none is the create winner —
+                # then delete their old ids (in _merge_into_canonical_edge).
+                for canonical in conflicted_canonicals:
+                    await self._merge_into_canonical_edge(
+                        canonical, docs_by_canonical[canonical]
+                    )
 
                 # Phase 2 — every create succeeded, 409'd-then-merged, so the
                 # canonical now exists for all; delete the old ids. delete 404 is

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -340,21 +340,26 @@ def _merge_edge_payloads(docs: list[dict[str, Any]]) -> dict[str, Any]:
     ``_merge_edges_then_upsert`` field semantics (minus LLM description
     summarisation): ``source_id``/``source_ids``/``file_path``/``description``
     union their ``GRAPH_FIELD_SEP`` components, ``keywords`` are comma-set-
-    unioned, and ``weight`` is **summed** (duplicate docs carry separate
-    accumulated weight). Returns only the merged fields (to be layered onto the
-    surviving doc).
+    unioned, and ``weight`` is **summed across every fragment** (base + each
+    duplicate). Returns only the merged fields (to be layered onto the surviving
+    doc).
 
-    Idempotent across fail-fast retries: the union fields union split components
-    (re-merging an already-merged base is a no-op), and the weight sum counts the
-    base's current weight once plus each duplicate only while its source_ids are
-    not already folded into the base — so a retry (whose base already contains
-    them) does not double-count. Legacy string weights are coerced; non-numeric
-    values are skipped so a bad value cannot crash the migration.
+    Weight summing deliberately does NOT dedup by ``source_id``: just like
+    ``_merge_edges_then_upsert``, every edge fragment contributes its weight even
+    when fragments share a source/chunk id — reciprocal duplicates that came from
+    the same chunk still carry separate accumulated weight, so skipping them would
+    undercount the relation. This function is therefore not idempotent on its own;
+    idempotency across fail-fast retries is a property of the migration flow, not
+    this math: each folded reverse doc is deleted right after the canonical write
+    (see ``_merge_into_canonical_edge``), so a re-scan never re-presents an
+    already-folded reverse for summing. Legacy string weights are coerced;
+    non-numeric values are skipped so a bad value cannot crash the migration.
     """
     source_ids: list[str] = []
     file_paths: list[str] = []
     descriptions: list[str] = []
     keywords: set[str] = set()
+    weights: list[float] = []
     for d in docs:
         source_ids = merge_source_ids(source_ids, _edge_source_id_list(d))
         fp = d.get("file_path")
@@ -368,19 +373,6 @@ def _merge_edge_payloads(docs: list[dict[str, Any]]) -> dict[str, Any]:
         kw = d.get("keywords")
         if kw:
             keywords.update(k.strip() for k in kw.split(",") if k.strip())
-
-    # Idempotent summed weight: base (docs[0]) counts once; each duplicate adds
-    # its weight only if its source_ids are not already folded into the base.
-    base = docs[0] if docs else {}
-    base_sids = set(_edge_source_id_list(base))
-    weights: list[float] = []
-    bw = _coerce_weight(base.get("weight"))
-    if bw is not None:
-        weights.append(bw)
-    for d in docs[1:]:
-        d_sids = set(_edge_source_id_list(d))
-        if not d_sids or d_sids <= base_sids:
-            continue  # no new trackable evidence -> don't (re-)add its weight
         dw = _coerce_weight(d.get("weight"))
         if dw is not None:
             weights.append(dw)
@@ -2142,18 +2134,18 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                     # A single canonical can be the target of more than one
                     # pending reverse doc in this batch (e.g. 3+ legacy docs for
                     # one node pair, where only one wins the insert and the rest
-                    # 409). Collect *all* sources mapping to each conflicted
-                    # canonical and merge them together so no reverse payload is
-                    # dropped; re-merging the source that won the insert is a
-                    # no-op (idempotent — see _merge_edge_payloads).
-                    sources_by_canonical: dict[str, list[dict[str, Any]]] = {}
-                    for canonical, _old_id, source in batch:
+                    # 409). Collect *all* reverse docs mapping to each conflicted
+                    # canonical (carrying their old _id so they can be deleted
+                    # right after the merge) and fold them together so no reverse
+                    # payload is dropped.
+                    docs_by_canonical: dict[str, list[tuple[str, dict[str, Any]]]] = {}
+                    for canonical, old_id, source in batch:
                         if canonical in conflicted_canonicals:
-                            sources_by_canonical.setdefault(canonical, []).append(
-                                source
+                            docs_by_canonical.setdefault(canonical, []).append(
+                                (old_id, source)
                             )
-                    for canonical, sources in sources_by_canonical.items():
-                        await self._merge_into_canonical_edge(canonical, sources)
+                    for canonical, reverse_docs in docs_by_canonical.items():
+                        await self._merge_into_canonical_edge(canonical, reverse_docs)
 
                 # Phase 2 — every create succeeded, 409'd-then-merged, so the
                 # canonical now exists for all; delete the old ids. delete 404 is
@@ -2264,21 +2256,30 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             raise
 
     async def _merge_into_canonical_edge(
-        self, canonical_id: str, reverse_sources: list[dict[str, Any]]
+        self, canonical_id: str, reverse_docs: list[tuple[str, dict[str, Any]]]
     ) -> None:
         """Merge legacy reverse-orientation doc(s)' payload into an existing
         canonical doc (the create-409 reciprocal-duplicate case) so deleting the
         reverse loses no relation evidence (mirrors mongo_impl's dedupe merge).
 
-        ``reverse_sources`` carries every pending source in this batch that maps
-        to ``canonical_id`` (usually one, but >1 when a node pair has 3+ legacy
-        docs); all are folded into the canonical in a single write.
+        ``reverse_docs`` carries every pending reverse doc in this batch that maps
+        to ``canonical_id`` as ``(old_id, source)`` pairs (usually one, but >1
+        when a node pair has 3+ legacy docs); all are folded into the canonical in
+        a single write, then deleted by their old ids.
 
         Uses optimistic concurrency (``if_seq_no``/``if_primary_term``) so a
         concurrent live write during a rolling deploy is never clobbered: on a
         version conflict we re-read — now including that write — and re-merge.
-        The merge is idempotent (see ``_merge_edge_payloads``), so a fail-fast
-        retry over an already-merged canonical is a no-op.
+
+        Weight summing is per-fragment and not self-idempotent (see
+        ``_merge_edge_payloads``), so idempotency across fail-fast retries comes
+        from deleting each folded reverse right after the canonical write: a
+        re-scan no longer finds it, so it is never folded (and summed) twice. The
+        delete is best-effort — the batch's Phase-2 delete re-attempts the same
+        ids — so it deliberately does not abort the migration; the only window in
+        which a weight could double-count is a crash strictly between the
+        canonical write and this delete, a bounded and non-fatal ranking
+        perturbation for a one-time migration.
         """
         for _attempt in range(3):
             try:
@@ -2289,6 +2290,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 # Canonical vanished between the create-409 and now; recreate it
                 # by merging the reverse sources together (nothing else to merge
                 # against).
+                reverse_sources = [source for _old_id, source in reverse_docs]
                 recreated = {
                     **reverse_sources[0],
                     **_merge_edge_payloads(reverse_sources),
@@ -2296,8 +2298,10 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 await self.client.index(
                     index=self._edges_index, id=canonical_id, body=recreated
                 )
+                await self._delete_folded_reverse_edges(reverse_docs)
                 return
             base = current.get("_source", {})
+            reverse_sources = [source for _old_id, source in reverse_docs]
             merged = {**base, **_merge_edge_payloads([base, *reverse_sources])}
             try:
                 await self.client.index(
@@ -2307,15 +2311,39 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                     if_seq_no=current["_seq_no"],
                     if_primary_term=current["_primary_term"],
                 )
-                return
             except ConflictError:
                 # A concurrent write changed the canonical doc; re-read and
                 # re-merge so we never overwrite that write with stale data.
                 continue
+            await self._delete_folded_reverse_edges(reverse_docs)
+            return
         raise RuntimeError(
             f"Canonical edge-id migration: could not merge into {canonical_id} "
             f"after retries in {self._edges_index}; aborting startup"
         )
+
+    async def _delete_folded_reverse_edges(
+        self, reverse_docs: list[tuple[str, dict[str, Any]]]
+    ) -> None:
+        """Delete legacy reverse docs whose payload was just folded into the
+        canonical, so a fail-fast re-scan never re-folds (and re-sums) them.
+
+        Best-effort: a 404 means another run already removed it, and any other
+        error is swallowed (logged) rather than raised — the migration's Phase-2
+        bulk delete re-attempts these same ids, so failing here must not abort
+        startup nor leave the canonical without its merged evidence.
+        """
+        for old_id, _source in reverse_docs:
+            try:
+                await self.client.delete(index=self._edges_index, id=old_id)
+            except NotFoundError:
+                pass
+            except OpenSearchException as e:
+                logger.warning(
+                    f"[{self.workspace}] Canonical edge-id migration: could not "
+                    f"delete folded reverse doc {old_id} in {self._edges_index} "
+                    f"(Phase-2 delete will retry): {e}"
+                )
 
     async def finalize(self):
         """Release the OpenSearch client connection."""

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -2122,13 +2122,13 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 # fast BEFORE any delete, so no edge is dropped without its
                 # canonical counterpart in place; the flag stays unset and the
                 # next startup rescans.
-                conflicted_canonicals: list[str] = []
+                conflicted_canonicals: set[str] = set()
                 real_create_errors = []
                 for e in errors:
                     info = e.get("create") if isinstance(e, dict) else None
                     if info is not None and info.get("status") == 409:
                         if info.get("_id"):
-                            conflicted_canonicals.append(info["_id"])
+                            conflicted_canonicals.add(info["_id"])
                         continue
                     real_create_errors.append(e)
                 if real_create_errors:
@@ -2139,15 +2139,21 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                     )
 
                 if conflicted_canonicals:
-                    source_by_canonical = {
-                        canonical: source for canonical, _old_id, source in batch
-                    }
-                    for canonical in conflicted_canonicals:
-                        reverse_source = source_by_canonical.get(canonical)
-                        if reverse_source is not None:
-                            await self._merge_into_canonical_edge(
-                                canonical, reverse_source
+                    # A single canonical can be the target of more than one
+                    # pending reverse doc in this batch (e.g. 3+ legacy docs for
+                    # one node pair, where only one wins the insert and the rest
+                    # 409). Collect *all* sources mapping to each conflicted
+                    # canonical and merge them together so no reverse payload is
+                    # dropped; re-merging the source that won the insert is a
+                    # no-op (idempotent — see _merge_edge_payloads).
+                    sources_by_canonical: dict[str, list[dict[str, Any]]] = {}
+                    for canonical, _old_id, source in batch:
+                        if canonical in conflicted_canonicals:
+                            sources_by_canonical.setdefault(canonical, []).append(
+                                source
                             )
+                    for canonical, sources in sources_by_canonical.items():
+                        await self._merge_into_canonical_edge(canonical, sources)
 
                 # Phase 2 — every create succeeded, 409'd-then-merged, so the
                 # canonical now exists for all; delete the old ids. delete 404 is
@@ -2258,11 +2264,15 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             raise
 
     async def _merge_into_canonical_edge(
-        self, canonical_id: str, reverse_source: dict[str, Any]
+        self, canonical_id: str, reverse_sources: list[dict[str, Any]]
     ) -> None:
-        """Merge a legacy reverse-orientation doc's payload into an existing
+        """Merge legacy reverse-orientation doc(s)' payload into an existing
         canonical doc (the create-409 reciprocal-duplicate case) so deleting the
         reverse loses no relation evidence (mirrors mongo_impl's dedupe merge).
+
+        ``reverse_sources`` carries every pending source in this batch that maps
+        to ``canonical_id`` (usually one, but >1 when a node pair has 3+ legacy
+        docs); all are folded into the canonical in a single write.
 
         Uses optimistic concurrency (``if_seq_no``/``if_primary_term``) so a
         concurrent live write during a rolling deploy is never clobbered: on a
@@ -2277,13 +2287,18 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 )
             except NotFoundError:
                 # Canonical vanished between the create-409 and now; recreate it
-                # from the reverse source (nothing to merge against).
+                # by merging the reverse sources together (nothing else to merge
+                # against).
+                recreated = {
+                    **reverse_sources[0],
+                    **_merge_edge_payloads(reverse_sources),
+                }
                 await self.client.index(
-                    index=self._edges_index, id=canonical_id, body=reverse_source
+                    index=self._edges_index, id=canonical_id, body=recreated
                 )
                 return
             base = current.get("_source", {})
-            merged = {**base, **_merge_edge_payloads([base, reverse_source])}
+            merged = {**base, **_merge_edge_payloads([base, *reverse_sources])}
             try:
                 await self.client.index(
                     index=self._edges_index,

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -1187,9 +1187,9 @@ class TestKVStorageBatching:
                 drop_task = asyncio.create_task(s.drop())
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not drop_delete_started.is_set()
-                ), "indices.delete should be blocked behind the flush lock"
+                assert not drop_delete_started.is_set(), (
+                    "indices.delete should be blocked behind the flush lock"
+                )
                 assert not drop_task.done()
                 flush_can_finish.set()
                 await flush_task
@@ -1283,9 +1283,9 @@ class TestKVStorageBatching:
                 )
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not concurrent_task.done()
-                ), "concurrent upsert should be blocked by the flush lock"
+                assert not concurrent_task.done(), (
+                    "concurrent upsert should be blocked by the flush lock"
+                )
                 assert "k2" not in s._pending_upserts
 
                 flush_can_finish.set()
@@ -2572,10 +2572,144 @@ class TestGraphStorage:
             side_effect=[ConflictError(409, "version_conflict", {}), None]
         )
 
-        await s._merge_into_canonical_edge("edge-canon", {"source_id": "c9"})
+        await s._merge_into_canonical_edge("edge-canon", [{"source_id": "c9"}])
 
         assert mock_client.get.await_count == 2  # re-read after the conflict
         assert mock_client.index.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_merge_into_canonical_recreates_when_canonical_vanished(
+        self, global_config, embed_func, mock_client
+    ):
+        """If the canonical doc disappears between the create-409 and the merge
+        GET, recreate it from the (merged) reverse sources rather than crashing."""
+        s = self._make(global_config, embed_func)
+        s.client = mock_client
+        mock_client.get = AsyncMock(side_effect=NotFoundError(404, "not_found", {}))
+        mock_client.index = AsyncMock()
+
+        await s._merge_into_canonical_edge(
+            "edge-canon",
+            [
+                {"source_ids": ["c1"], "weight": 1.0, "source_node_id": "A"},
+                {"source_ids": ["c2"], "weight": 2.0},
+            ],
+        )
+
+        # Recreated with a plain index (no optimistic concurrency to honour —
+        # there is no current version) carrying the merged reverse payload.
+        kwargs = mock_client.index.await_args.kwargs
+        assert kwargs["id"] == "edge-canon"
+        assert "if_seq_no" not in kwargs
+        body = kwargs["body"]
+        assert body["source_ids"] == ["c1", "c2"]
+        assert body["weight"] == 3.0  # summed across both reverse sources
+        assert body["source_node_id"] == "A"  # base reverse-source fields kept
+
+    @pytest.mark.asyncio
+    async def test_merge_into_canonical_aborts_after_persistent_conflicts(
+        self, global_config, embed_func, mock_client
+    ):
+        """Persistent version conflicts abort startup (fail-safe: raised before
+        any delete) rather than silently giving up."""
+        s = self._make(global_config, embed_func)
+        s.client = mock_client
+        mock_client.get = AsyncMock(
+            return_value={
+                "_id": "edge-canon",
+                "_seq_no": 1,
+                "_primary_term": 1,
+                "_source": {"source_node_id": "A", "target_node_id": "B"},
+            }
+        )
+        mock_client.index = AsyncMock(
+            side_effect=ConflictError(409, "version_conflict", {})
+        )
+
+        with pytest.raises(RuntimeError, match="could not merge into edge-canon"):
+            await s._merge_into_canonical_edge("edge-canon", [{"source_id": "c9"}])
+        assert mock_client.index.await_count == 3  # bounded retries
+
+    @pytest.mark.asyncio
+    async def test_migrate_merges_multiple_reverse_docs_into_one_canonical(
+        self, global_config, embed_func, mock_client
+    ):
+        """When 3+ legacy docs map to one canonical pair, every 409'd reverse
+        source is folded in — not just the last one (no evidence dropped)."""
+        s = self._make(global_config, embed_func)
+        s.client = mock_client
+        canonical = _canonical_edge_id("A", "B")
+        mock_client.indices.exists = AsyncMock(return_value=True)
+        mock_client.indices.get_mapping = AsyncMock(
+            return_value={s._edges_index: {"mappings": {}}}
+        )
+        mock_client.indices.put_mapping = AsyncMock()
+        # Two reverse-orientation docs (distinct old ids) for the same pair, each
+        # with its own provenance, both non-canonical so both end up pending.
+        mock_client.search = AsyncMock(
+            return_value={
+                "_scroll_id": "s1",
+                "hits": {
+                    "hits": [
+                        {
+                            "_id": "edge-rev1",
+                            "_source": {
+                                "source_node_id": "B",
+                                "target_node_id": "A",
+                                "source_ids": ["c2"],
+                                "weight": 2.0,
+                            },
+                        },
+                        {
+                            "_id": "edge-rev2",
+                            "_source": {
+                                "source_node_id": "B",
+                                "target_node_id": "A",
+                                "source_ids": ["c3"],
+                                "weight": 3.0,
+                            },
+                        },
+                    ]
+                },
+            }
+        )
+        mock_client.scroll = AsyncMock(
+            return_value={"_scroll_id": "s1", "hits": {"hits": []}}
+        )
+        mock_client.clear_scroll = AsyncMock()
+        mock_client.get = AsyncMock(
+            return_value={
+                "_id": canonical,
+                "_seq_no": 7,
+                "_primary_term": 1,
+                "_source": {
+                    "source_node_id": "A",
+                    "target_node_id": "B",
+                    "source_ids": ["c1"],
+                    "weight": 1.0,
+                },
+            }
+        )
+        mock_client.index = AsyncMock()
+
+        async def capture_bulk(_client, actions, *args, **kwargs):
+            acts = list(actions)
+            if acts and acts[0]["_op_type"] == "create":
+                # First create wins the insert; the second 409s on the same id.
+                return (1, [{"create": {"_id": canonical, "status": 409}}])
+            return (len(acts), [])
+
+        with patch(
+            "lightrag.kg.opensearch_impl.helpers.async_bulk",
+            new=AsyncMock(side_effect=capture_bulk),
+        ):
+            await s._migrate_edges_to_canonical_id_if_needed()
+
+        # A single merge write into the canonical folds in *both* reverse docs.
+        assert mock_client.index.await_count == 1
+        merged = mock_client.index.await_args.kwargs["body"]
+        assert merged["source_ids"] == ["c1", "c2", "c3"]  # all provenance kept
+        assert merged["weight"] == 6.0  # 1.0 + 2.0 + 3.0 summed
 
     def test_merge_edge_payloads_sums_weight_idempotently(self):
         """Weight is summed (not max), and re-merging an already-merged base
@@ -4404,9 +4538,9 @@ class TestVectorStorageBatching:
                 # embedding computation and arrive at the lock.
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not concurrent_task.done()
-                ), "concurrent upsert should be blocked by the flush lock"
+                assert not concurrent_task.done(), (
+                    "concurrent upsert should be blocked by the flush lock"
+                )
                 # v2 must not be visible in the buffer yet.
                 assert "v2" not in s._pending_vector_docs
 
@@ -4455,9 +4589,9 @@ class TestVectorStorageBatching:
                 delete_task = asyncio.create_task(s.delete(["v1"]))
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not delete_task.done()
-                ), "concurrent delete should be blocked by the flush lock"
+                assert not delete_task.done(), (
+                    "concurrent delete should be blocked by the flush lock"
+                )
 
                 flush_can_finish.set()
                 await flush_task
@@ -4668,9 +4802,9 @@ class TestVectorStorageBatching:
                 rel_task = asyncio.create_task(s.delete_entity_relation("Alice"))
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not delete_started.is_set()
-                ), "delete_by_query should be blocked behind the flush lock"
+                assert not delete_started.is_set(), (
+                    "delete_by_query should be blocked behind the flush lock"
+                )
                 assert not rel_task.done()
 
                 flush_can_finish.set()
@@ -4710,9 +4844,9 @@ class TestVectorStorageBatching:
                 drop_task = asyncio.create_task(s.drop())
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not drop_delete_started.is_set()
-                ), "indices.delete should be blocked behind the flush lock"
+                assert not drop_delete_started.is_set(), (
+                    "indices.delete should be blocked behind the flush lock"
+                )
                 assert not drop_task.done()
 
                 flush_can_finish.set()
@@ -4755,9 +4889,9 @@ class TestVectorStorageBatching:
                 drop_task = asyncio.create_task(s.drop())
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not drop_delete_started.is_set()
-                ), "indices.delete should be blocked during deferred embedding"
+                assert not drop_delete_started.is_set(), (
+                    "indices.delete should be blocked during deferred embedding"
+                )
                 assert not drop_task.done()
 
                 embedding_can_finish.set()

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -1186,9 +1186,9 @@ class TestKVStorageBatching:
                 drop_task = asyncio.create_task(s.drop())
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not drop_delete_started.is_set(), (
-                    "indices.delete should be blocked behind the flush lock"
-                )
+                assert (
+                    not drop_delete_started.is_set()
+                ), "indices.delete should be blocked behind the flush lock"
                 assert not drop_task.done()
                 flush_can_finish.set()
                 await flush_task
@@ -1282,9 +1282,9 @@ class TestKVStorageBatching:
                 )
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not concurrent_task.done(), (
-                    "concurrent upsert should be blocked by the flush lock"
-                )
+                assert (
+                    not concurrent_task.done()
+                ), "concurrent upsert should be blocked by the flush lock"
                 assert "k2" not in s._pending_upserts
 
                 flush_can_finish.set()
@@ -4388,9 +4388,9 @@ class TestVectorStorageBatching:
                 # embedding computation and arrive at the lock.
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not concurrent_task.done(), (
-                    "concurrent upsert should be blocked by the flush lock"
-                )
+                assert (
+                    not concurrent_task.done()
+                ), "concurrent upsert should be blocked by the flush lock"
                 # v2 must not be visible in the buffer yet.
                 assert "v2" not in s._pending_vector_docs
 
@@ -4439,9 +4439,9 @@ class TestVectorStorageBatching:
                 delete_task = asyncio.create_task(s.delete(["v1"]))
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not delete_task.done(), (
-                    "concurrent delete should be blocked by the flush lock"
-                )
+                assert (
+                    not delete_task.done()
+                ), "concurrent delete should be blocked by the flush lock"
 
                 flush_can_finish.set()
                 await flush_task
@@ -4652,9 +4652,9 @@ class TestVectorStorageBatching:
                 rel_task = asyncio.create_task(s.delete_entity_relation("Alice"))
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not delete_started.is_set(), (
-                    "delete_by_query should be blocked behind the flush lock"
-                )
+                assert (
+                    not delete_started.is_set()
+                ), "delete_by_query should be blocked behind the flush lock"
                 assert not rel_task.done()
 
                 flush_can_finish.set()
@@ -4694,9 +4694,9 @@ class TestVectorStorageBatching:
                 drop_task = asyncio.create_task(s.drop())
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not drop_delete_started.is_set(), (
-                    "indices.delete should be blocked behind the flush lock"
-                )
+                assert (
+                    not drop_delete_started.is_set()
+                ), "indices.delete should be blocked behind the flush lock"
                 assert not drop_task.done()
 
                 flush_can_finish.set()
@@ -4739,9 +4739,9 @@ class TestVectorStorageBatching:
                 drop_task = asyncio.create_task(s.drop())
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not drop_delete_started.is_set(), (
-                    "indices.delete should be blocked during deferred embedding"
-                )
+                assert (
+                    not drop_delete_started.is_set()
+                ), "indices.delete should be blocked during deferred embedding"
                 assert not drop_task.done()
 
                 embedding_can_finish.set()

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -18,7 +18,11 @@ pytest.importorskip(
     reason="opensearchpy is required for OpenSearch storage tests",
 )
 
-from opensearchpy.exceptions import NotFoundError, OpenSearchException  # type: ignore
+from opensearchpy.exceptions import (  # type: ignore
+    NotFoundError,
+    OpenSearchException,
+    ConflictError,
+)
 from lightrag.kg.opensearch_impl import (
     OpenSearchKVStorage,
     OpenSearchDocStatusStorage,
@@ -1182,9 +1186,9 @@ class TestKVStorageBatching:
                 drop_task = asyncio.create_task(s.drop())
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not drop_delete_started.is_set()
-                ), "indices.delete should be blocked behind the flush lock"
+                assert not drop_delete_started.is_set(), (
+                    "indices.delete should be blocked behind the flush lock"
+                )
                 assert not drop_task.done()
                 flush_can_finish.set()
                 await flush_task
@@ -1278,9 +1282,9 @@ class TestKVStorageBatching:
                 )
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not concurrent_task.done()
-                ), "concurrent upsert should be blocked by the flush lock"
+                assert not concurrent_task.done(), (
+                    "concurrent upsert should be blocked by the flush lock"
+                )
                 assert "k2" not in s._pending_upserts
 
                 flush_can_finish.set()
@@ -2349,9 +2353,6 @@ class TestGraphStorage:
         "create_errors, delete_errors, expect_raise",
         [
             ([], [], False),  # clean run → flag set
-            # canonical already exists (forward legacy doc) — benign 409, source
-            # safe to drop, run completes.
-            ([{"create": {"_id": "C", "status": 409}}], [], False),
             # stale source already removed by another run — benign 404.
             ([], [{"delete": {"_id": "edge-old", "status": 404}}], False),
             # busy cluster rejected the create — fail fast, no flag.
@@ -2461,6 +2462,119 @@ class TestGraphStorage:
         all_actions = [a for call in bulk_calls for a in call]
         assert not [a for a in all_actions if a["_op_type"] == "delete"]
         mock_client.indices.put_mapping.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_migrate_merges_reverse_payload_into_canonical_on_conflict(
+        self, global_config, embed_func, mock_client
+    ):
+        """A reciprocal duplicate (create 409) merges the reverse doc's relation
+        payload into the existing canonical before deleting the reverse — no
+        evidence lost, mirroring the Mongo dedupe merge."""
+        s = self._make(global_config, embed_func)
+        s.client = mock_client
+        canonical = _canonical_edge_id("A", "B")
+        mock_client.indices.exists = AsyncMock(return_value=True)
+        mock_client.indices.get_mapping = AsyncMock(
+            return_value={s._edges_index: {"mappings": {}}}
+        )
+        mock_client.indices.put_mapping = AsyncMock()
+        # Scroll yields the reverse-orientation doc with its own payload.
+        mock_client.search = AsyncMock(
+            return_value={
+                "_scroll_id": "s1",
+                "hits": {
+                    "hits": [
+                        {
+                            "_id": "edge-reverse",
+                            "_source": {
+                                "source_node_id": "B",
+                                "target_node_id": "A",
+                                "description": "d2",
+                                "keywords": "beta,gamma",
+                                "weight": 2.0,
+                                "source_ids": ["c2"],
+                                "file_path": "f2",
+                            },
+                        }
+                    ]
+                },
+            }
+        )
+        mock_client.scroll = AsyncMock(
+            return_value={"_scroll_id": "s1", "hits": {"hits": []}}
+        )
+        mock_client.clear_scroll = AsyncMock()
+        # The existing canonical (forward) doc with distinct payload.
+        mock_client.get = AsyncMock(
+            return_value={
+                "_id": canonical,
+                "_seq_no": 7,
+                "_primary_term": 1,
+                "_source": {
+                    "source_node_id": "A",
+                    "target_node_id": "B",
+                    "description": "d1",
+                    "keywords": "alpha,beta",
+                    "weight": 1.0,
+                    "source_ids": ["c1"],
+                    "file_path": "f1",
+                },
+            }
+        )
+        mock_client.index = AsyncMock()
+
+        async def capture_bulk(_client, actions, *args, **kwargs):
+            acts = list(actions)
+            if acts and acts[0]["_op_type"] == "create":
+                # canonical already exists -> 409 conflict
+                return (0, [{"create": {"_id": canonical, "status": 409}}])
+            return (len(acts), [])
+
+        with patch(
+            "lightrag.kg.opensearch_impl.helpers.async_bulk",
+            new=AsyncMock(side_effect=capture_bulk),
+        ):
+            await s._migrate_edges_to_canonical_id_if_needed()
+
+        # Merged write goes to the canonical id with optimistic concurrency.
+        index_kwargs = mock_client.index.await_args.kwargs
+        assert index_kwargs["id"] == canonical
+        assert index_kwargs["if_seq_no"] == 7
+        assert index_kwargs["if_primary_term"] == 1
+        merged = index_kwargs["body"]
+        assert merged["description"] == "d1<SEP>d2"  # both descriptions kept
+        assert merged["keywords"] == "alpha,beta,gamma"  # comma set-union
+        assert merged["weight"] == 2.0  # max
+        assert merged["source_ids"] == ["c1", "c2"]  # provenance unioned
+        assert merged["file_path"] == "f1<SEP>f2"
+        # Direction fields kept from the surviving canonical doc.
+        assert merged["source_node_id"] == "A"
+        mock_client.indices.put_mapping.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_merge_into_canonical_retries_on_version_conflict(
+        self, global_config, embed_func, mock_client
+    ):
+        """A concurrent write (version conflict) is not clobbered: the merge
+        re-reads and retries."""
+        s = self._make(global_config, embed_func)
+        s.client = mock_client
+        mock_client.get = AsyncMock(
+            return_value={
+                "_id": "edge-canon",
+                "_seq_no": 1,
+                "_primary_term": 1,
+                "_source": {"source_node_id": "A", "target_node_id": "B"},
+            }
+        )
+        mock_client.index = AsyncMock(
+            side_effect=[ConflictError(409, "version_conflict", {}), None]
+        )
+
+        await s._merge_into_canonical_edge("edge-canon", {"source_id": "c9"})
+
+        assert mock_client.get.await_count == 2  # re-read after the conflict
+        assert mock_client.index.await_count == 2
 
     @pytest.mark.asyncio
     async def test_migrate_edges_logs_progress_for_large_scan(
@@ -4274,9 +4388,9 @@ class TestVectorStorageBatching:
                 # embedding computation and arrive at the lock.
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not concurrent_task.done()
-                ), "concurrent upsert should be blocked by the flush lock"
+                assert not concurrent_task.done(), (
+                    "concurrent upsert should be blocked by the flush lock"
+                )
                 # v2 must not be visible in the buffer yet.
                 assert "v2" not in s._pending_vector_docs
 
@@ -4325,9 +4439,9 @@ class TestVectorStorageBatching:
                 delete_task = asyncio.create_task(s.delete(["v1"]))
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not delete_task.done()
-                ), "concurrent delete should be blocked by the flush lock"
+                assert not delete_task.done(), (
+                    "concurrent delete should be blocked by the flush lock"
+                )
 
                 flush_can_finish.set()
                 await flush_task
@@ -4538,9 +4652,9 @@ class TestVectorStorageBatching:
                 rel_task = asyncio.create_task(s.delete_entity_relation("Alice"))
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not delete_started.is_set()
-                ), "delete_by_query should be blocked behind the flush lock"
+                assert not delete_started.is_set(), (
+                    "delete_by_query should be blocked behind the flush lock"
+                )
                 assert not rel_task.done()
 
                 flush_can_finish.set()
@@ -4580,9 +4694,9 @@ class TestVectorStorageBatching:
                 drop_task = asyncio.create_task(s.drop())
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not drop_delete_started.is_set()
-                ), "indices.delete should be blocked behind the flush lock"
+                assert not drop_delete_started.is_set(), (
+                    "indices.delete should be blocked behind the flush lock"
+                )
                 assert not drop_task.done()
 
                 flush_can_finish.set()
@@ -4625,9 +4739,9 @@ class TestVectorStorageBatching:
                 drop_task = asyncio.create_task(s.drop())
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not drop_delete_started.is_set()
-                ), "indices.delete should be blocked during deferred embedding"
+                assert not drop_delete_started.is_set(), (
+                    "indices.delete should be blocked during deferred embedding"
+                )
                 assert not drop_task.done()
 
                 embedding_can_finish.set()

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -1187,9 +1187,9 @@ class TestKVStorageBatching:
                 drop_task = asyncio.create_task(s.drop())
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not drop_delete_started.is_set(), (
-                    "indices.delete should be blocked behind the flush lock"
-                )
+                assert (
+                    not drop_delete_started.is_set()
+                ), "indices.delete should be blocked behind the flush lock"
                 assert not drop_task.done()
                 flush_can_finish.set()
                 await flush_task
@@ -1283,9 +1283,9 @@ class TestKVStorageBatching:
                 )
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not concurrent_task.done(), (
-                    "concurrent upsert should be blocked by the flush lock"
-                )
+                assert (
+                    not concurrent_task.done()
+                ), "concurrent upsert should be blocked by the flush lock"
                 assert "k2" not in s._pending_upserts
 
                 flush_can_finish.set()
@@ -4538,9 +4538,9 @@ class TestVectorStorageBatching:
                 # embedding computation and arrive at the lock.
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not concurrent_task.done(), (
-                    "concurrent upsert should be blocked by the flush lock"
-                )
+                assert (
+                    not concurrent_task.done()
+                ), "concurrent upsert should be blocked by the flush lock"
                 # v2 must not be visible in the buffer yet.
                 assert "v2" not in s._pending_vector_docs
 
@@ -4589,9 +4589,9 @@ class TestVectorStorageBatching:
                 delete_task = asyncio.create_task(s.delete(["v1"]))
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not delete_task.done(), (
-                    "concurrent delete should be blocked by the flush lock"
-                )
+                assert (
+                    not delete_task.done()
+                ), "concurrent delete should be blocked by the flush lock"
 
                 flush_can_finish.set()
                 await flush_task
@@ -4802,9 +4802,9 @@ class TestVectorStorageBatching:
                 rel_task = asyncio.create_task(s.delete_entity_relation("Alice"))
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not delete_started.is_set(), (
-                    "delete_by_query should be blocked behind the flush lock"
-                )
+                assert (
+                    not delete_started.is_set()
+                ), "delete_by_query should be blocked behind the flush lock"
                 assert not rel_task.done()
 
                 flush_can_finish.set()
@@ -4844,9 +4844,9 @@ class TestVectorStorageBatching:
                 drop_task = asyncio.create_task(s.drop())
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not drop_delete_started.is_set(), (
-                    "indices.delete should be blocked behind the flush lock"
-                )
+                assert (
+                    not drop_delete_started.is_set()
+                ), "indices.delete should be blocked behind the flush lock"
                 assert not drop_task.done()
 
                 flush_can_finish.set()
@@ -4889,9 +4889,9 @@ class TestVectorStorageBatching:
                 drop_task = asyncio.create_task(s.drop())
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not drop_delete_started.is_set(), (
-                    "indices.delete should be blocked during deferred embedding"
-                )
+                assert (
+                    not drop_delete_started.is_set()
+                ), "indices.delete should be blocked during deferred embedding"
                 assert not drop_task.done()
 
                 embedding_can_finish.set()

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -2572,10 +2572,16 @@ class TestGraphStorage:
             side_effect=[ConflictError(409, "version_conflict", {}), None]
         )
 
-        await s._merge_into_canonical_edge("edge-canon", [{"source_id": "c9"}])
+        await s._merge_into_canonical_edge(
+            "edge-canon", [("edge-rev9", {"source_id": "c9"})]
+        )
 
         assert mock_client.get.await_count == 2  # re-read after the conflict
         assert mock_client.index.await_count == 2
+        # Folded only after the write that finally succeeds (post-conflict).
+        mock_client.delete.assert_awaited_once_with(
+            index=s._edges_index, id="edge-rev9"
+        )
 
     @pytest.mark.asyncio
     async def test_merge_into_canonical_recreates_when_canonical_vanished(
@@ -2591,8 +2597,11 @@ class TestGraphStorage:
         await s._merge_into_canonical_edge(
             "edge-canon",
             [
-                {"source_ids": ["c1"], "weight": 1.0, "source_node_id": "A"},
-                {"source_ids": ["c2"], "weight": 2.0},
+                (
+                    "edge-rev1",
+                    {"source_ids": ["c1"], "weight": 1.0, "source_node_id": "A"},
+                ),
+                ("edge-rev2", {"source_ids": ["c2"], "weight": 2.0}),
             ],
         )
 
@@ -2605,6 +2614,9 @@ class TestGraphStorage:
         assert body["source_ids"] == ["c1", "c2"]
         assert body["weight"] == 3.0  # summed across both reverse sources
         assert body["source_node_id"] == "A"  # base reverse-source fields kept
+        # Both folded reverse docs are deleted so a re-scan never re-folds them.
+        deleted_ids = {c.kwargs["id"] for c in mock_client.delete.await_args_list}
+        assert deleted_ids == {"edge-rev1", "edge-rev2"}
 
     @pytest.mark.asyncio
     async def test_merge_into_canonical_aborts_after_persistent_conflicts(
@@ -2627,8 +2639,12 @@ class TestGraphStorage:
         )
 
         with pytest.raises(RuntimeError, match="could not merge into edge-canon"):
-            await s._merge_into_canonical_edge("edge-canon", [{"source_id": "c9"}])
+            await s._merge_into_canonical_edge(
+                "edge-canon", [("edge-rev9", {"source_id": "c9"})]
+            )
         assert mock_client.index.await_count == 3  # bounded retries
+        # The reverse doc is never deleted while its evidence is unmerged.
+        mock_client.delete.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_migrate_merges_multiple_reverse_docs_into_one_canonical(
@@ -2711,20 +2727,30 @@ class TestGraphStorage:
         assert merged["source_ids"] == ["c1", "c2", "c3"]  # all provenance kept
         assert merged["weight"] == 6.0  # 1.0 + 2.0 + 3.0 summed
 
-    def test_merge_edge_payloads_sums_weight_idempotently(self):
-        """Weight is summed (not max), and re-merging an already-merged base
-        does not double-count (idempotent across fail-fast retries)."""
-        base = {"source_ids": ["c1"], "weight": 1.0}
-        dup = {"source_ids": ["c2"], "weight": 2.0}
-        # First merge: disjoint evidence -> weights sum.
-        first = _merge_edge_payloads([base, dup])
-        assert first["weight"] == 3.0
-        assert first["source_ids"] == ["c1", "c2"]
-        # Retry: base already carries the merged source_ids + summed weight; the
-        # duplicate's source_ids are folded in, so its weight is not re-added.
-        merged_base = {"source_ids": ["c1", "c2"], "weight": 3.0}
-        second = _merge_edge_payloads([merged_base, dup])
-        assert second["weight"] == 3.0
+    def test_merge_edge_payloads_sums_every_fragment_weight(self):
+        """Weight is summed across every fragment (base + each duplicate), matching
+        operate.py's _merge_edges_then_upsert — including reciprocal duplicates that
+        share a source/chunk id, which must NOT be skipped (that undercounts)."""
+        # Disjoint provenance -> weights sum.
+        disjoint = _merge_edge_payloads(
+            [
+                {"source_ids": ["c1"], "weight": 1.0},
+                {"source_ids": ["c2"], "weight": 2.0},
+            ]
+        )
+        assert disjoint["weight"] == 3.0
+        assert disjoint["source_ids"] == ["c1", "c2"]
+        # Same-source reciprocal duplicate: both fragments carry separate
+        # accumulated weight, so their weights still sum (the regression this
+        # guards against silently dropped the duplicate's weight here).
+        same_source = _merge_edge_payloads(
+            [
+                {"source_ids": ["c1"], "weight": 1.0},
+                {"source_ids": ["c1"], "weight": 2.0},
+            ]
+        )
+        assert same_source["weight"] == 3.0
+        assert same_source["source_ids"] == ["c1"]
 
     @pytest.mark.asyncio
     async def test_migrate_edges_logs_progress_for_large_scan(

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -2727,6 +2727,84 @@ class TestGraphStorage:
         assert merged["source_ids"] == ["c1", "c2", "c3"]  # all provenance kept
         assert merged["weight"] == 6.0  # 1.0 + 2.0 + 3.0 summed
 
+    @pytest.mark.asyncio
+    async def test_migrate_premerges_same_canonical_docs_into_one_create(
+        self, global_config, embed_func, mock_client
+    ):
+        """When several non-canonical docs map to a canonical that does NOT yet
+        exist, the batch issues ONE pre-merged create (not one per doc). This
+        avoids the intra-batch create race where one doc wins the insert and the
+        rest 409, then folding the 409'd docs re-merges the create winner and
+        double-counts its weight. The single create carries the summed-once
+        weight and no merge-into-canonical write happens."""
+        s = self._make(global_config, embed_func)
+        s.client = mock_client
+        canonical = _canonical_edge_id("A", "B")
+        mock_client.indices.exists = AsyncMock(return_value=True)
+        mock_client.indices.get_mapping = AsyncMock(
+            return_value={s._edges_index: {"mappings": {}}}
+        )
+        mock_client.indices.put_mapping = AsyncMock()
+        # Two reverse-orientation docs for the same pair, both non-canonical.
+        mock_client.search = AsyncMock(
+            return_value={
+                "_scroll_id": "s1",
+                "hits": {
+                    "hits": [
+                        {
+                            "_id": "edge-rev1",
+                            "_source": {
+                                "source_node_id": "B",
+                                "target_node_id": "A",
+                                "source_ids": ["c2"],
+                                "weight": 2.0,
+                            },
+                        },
+                        {
+                            "_id": "edge-rev2",
+                            "_source": {
+                                "source_node_id": "B",
+                                "target_node_id": "A",
+                                "source_ids": ["c3"],
+                                "weight": 3.0,
+                            },
+                        },
+                    ]
+                },
+            }
+        )
+        mock_client.scroll = AsyncMock(
+            return_value={"_scroll_id": "s1", "hits": {"hits": []}}
+        )
+        mock_client.clear_scroll = AsyncMock()
+        mock_client.index = AsyncMock()
+
+        created = []
+
+        async def capture_bulk(_client, actions, *args, **kwargs):
+            acts = list(actions)
+            if acts and acts[0]["_op_type"] == "create":
+                created.extend(acts)
+                # Canonical did not pre-exist: the create succeeds (no 409).
+                return (len(acts), [])
+            return (len(acts), [])
+
+        with patch(
+            "lightrag.kg.opensearch_impl.helpers.async_bulk",
+            new=AsyncMock(side_effect=capture_bulk),
+        ):
+            await s._migrate_edges_to_canonical_id_if_needed()
+
+        # Exactly one create for the canonical, carrying the summed-once weight —
+        # the create winner is never re-merged, so weight is 5.0, not 7.0.
+        create_for_canon = [a for a in created if a["_id"] == canonical]
+        assert len(create_for_canon) == 1
+        body = create_for_canon[0]["_source"]
+        assert body["weight"] == 5.0  # 2.0 + 3.0, counted once
+        assert body["source_ids"] == ["c2", "c3"]
+        # No fold/merge write into the canonical (no create conflicted).
+        mock_client.index.assert_not_awaited()
+
     def test_merge_edge_payloads_sums_every_fragment_weight(self):
         """Weight is summed across every fragment (base + each duplicate), matching
         operate.py's _merge_edges_then_upsert — including reciprocal duplicates that

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -1187,9 +1187,9 @@ class TestKVStorageBatching:
                 drop_task = asyncio.create_task(s.drop())
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not drop_delete_started.is_set(), (
-                    "indices.delete should be blocked behind the flush lock"
-                )
+                assert (
+                    not drop_delete_started.is_set()
+                ), "indices.delete should be blocked behind the flush lock"
                 assert not drop_task.done()
                 flush_can_finish.set()
                 await flush_task
@@ -1283,9 +1283,9 @@ class TestKVStorageBatching:
                 )
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not concurrent_task.done(), (
-                    "concurrent upsert should be blocked by the flush lock"
-                )
+                assert (
+                    not concurrent_task.done()
+                ), "concurrent upsert should be blocked by the flush lock"
                 assert "k2" not in s._pending_upserts
 
                 flush_can_finish.set()
@@ -4404,9 +4404,9 @@ class TestVectorStorageBatching:
                 # embedding computation and arrive at the lock.
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not concurrent_task.done(), (
-                    "concurrent upsert should be blocked by the flush lock"
-                )
+                assert (
+                    not concurrent_task.done()
+                ), "concurrent upsert should be blocked by the flush lock"
                 # v2 must not be visible in the buffer yet.
                 assert "v2" not in s._pending_vector_docs
 
@@ -4455,9 +4455,9 @@ class TestVectorStorageBatching:
                 delete_task = asyncio.create_task(s.delete(["v1"]))
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not delete_task.done(), (
-                    "concurrent delete should be blocked by the flush lock"
-                )
+                assert (
+                    not delete_task.done()
+                ), "concurrent delete should be blocked by the flush lock"
 
                 flush_can_finish.set()
                 await flush_task
@@ -4668,9 +4668,9 @@ class TestVectorStorageBatching:
                 rel_task = asyncio.create_task(s.delete_entity_relation("Alice"))
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not delete_started.is_set(), (
-                    "delete_by_query should be blocked behind the flush lock"
-                )
+                assert (
+                    not delete_started.is_set()
+                ), "delete_by_query should be blocked behind the flush lock"
                 assert not rel_task.done()
 
                 flush_can_finish.set()
@@ -4710,9 +4710,9 @@ class TestVectorStorageBatching:
                 drop_task = asyncio.create_task(s.drop())
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not drop_delete_started.is_set(), (
-                    "indices.delete should be blocked behind the flush lock"
-                )
+                assert (
+                    not drop_delete_started.is_set()
+                ), "indices.delete should be blocked behind the flush lock"
                 assert not drop_task.done()
 
                 flush_can_finish.set()
@@ -4755,9 +4755,9 @@ class TestVectorStorageBatching:
                 drop_task = asyncio.create_task(s.drop())
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert not drop_delete_started.is_set(), (
-                    "indices.delete should be blocked during deferred embedding"
-                )
+                assert (
+                    not drop_delete_started.is_set()
+                ), "indices.delete should be blocked during deferred embedding"
                 assert not drop_task.done()
 
                 embedding_can_finish.set()

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -36,6 +36,7 @@ from lightrag.kg.opensearch_impl import (
     _resolve_bulk_batch_limits,
     _run_chunked_async_bulk,
     _canonical_edge_id,
+    _merge_edge_payloads,
     _EDGE_ID_CANONICAL_META_FLAG,
     _OPENSEARCH_UNBOUNDED_PAYLOAD_BYTES,
     DEFAULT_OPENSEARCH_UPSERT_MAX_PAYLOAD_BYTES,
@@ -1186,9 +1187,9 @@ class TestKVStorageBatching:
                 drop_task = asyncio.create_task(s.drop())
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not drop_delete_started.is_set()
-                ), "indices.delete should be blocked behind the flush lock"
+                assert not drop_delete_started.is_set(), (
+                    "indices.delete should be blocked behind the flush lock"
+                )
                 assert not drop_task.done()
                 flush_can_finish.set()
                 await flush_task
@@ -1282,9 +1283,9 @@ class TestKVStorageBatching:
                 )
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not concurrent_task.done()
-                ), "concurrent upsert should be blocked by the flush lock"
+                assert not concurrent_task.done(), (
+                    "concurrent upsert should be blocked by the flush lock"
+                )
                 assert "k2" not in s._pending_upserts
 
                 flush_can_finish.set()
@@ -2544,7 +2545,7 @@ class TestGraphStorage:
         merged = index_kwargs["body"]
         assert merged["description"] == "d1<SEP>d2"  # both descriptions kept
         assert merged["keywords"] == "alpha,beta,gamma"  # comma set-union
-        assert merged["weight"] == 2.0  # max
+        assert merged["weight"] == 3.0  # summed (1.0 + 2.0)
         assert merged["source_ids"] == ["c1", "c2"]  # provenance unioned
         assert merged["file_path"] == "f1<SEP>f2"
         # Direction fields kept from the surviving canonical doc.
@@ -2575,6 +2576,21 @@ class TestGraphStorage:
 
         assert mock_client.get.await_count == 2  # re-read after the conflict
         assert mock_client.index.await_count == 2
+
+    def test_merge_edge_payloads_sums_weight_idempotently(self):
+        """Weight is summed (not max), and re-merging an already-merged base
+        does not double-count (idempotent across fail-fast retries)."""
+        base = {"source_ids": ["c1"], "weight": 1.0}
+        dup = {"source_ids": ["c2"], "weight": 2.0}
+        # First merge: disjoint evidence -> weights sum.
+        first = _merge_edge_payloads([base, dup])
+        assert first["weight"] == 3.0
+        assert first["source_ids"] == ["c1", "c2"]
+        # Retry: base already carries the merged source_ids + summed weight; the
+        # duplicate's source_ids are folded in, so its weight is not re-added.
+        merged_base = {"source_ids": ["c1", "c2"], "weight": 3.0}
+        second = _merge_edge_payloads([merged_base, dup])
+        assert second["weight"] == 3.0
 
     @pytest.mark.asyncio
     async def test_migrate_edges_logs_progress_for_large_scan(
@@ -4388,9 +4404,9 @@ class TestVectorStorageBatching:
                 # embedding computation and arrive at the lock.
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not concurrent_task.done()
-                ), "concurrent upsert should be blocked by the flush lock"
+                assert not concurrent_task.done(), (
+                    "concurrent upsert should be blocked by the flush lock"
+                )
                 # v2 must not be visible in the buffer yet.
                 assert "v2" not in s._pending_vector_docs
 
@@ -4439,9 +4455,9 @@ class TestVectorStorageBatching:
                 delete_task = asyncio.create_task(s.delete(["v1"]))
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not delete_task.done()
-                ), "concurrent delete should be blocked by the flush lock"
+                assert not delete_task.done(), (
+                    "concurrent delete should be blocked by the flush lock"
+                )
 
                 flush_can_finish.set()
                 await flush_task
@@ -4652,9 +4668,9 @@ class TestVectorStorageBatching:
                 rel_task = asyncio.create_task(s.delete_entity_relation("Alice"))
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not delete_started.is_set()
-                ), "delete_by_query should be blocked behind the flush lock"
+                assert not delete_started.is_set(), (
+                    "delete_by_query should be blocked behind the flush lock"
+                )
                 assert not rel_task.done()
 
                 flush_can_finish.set()
@@ -4694,9 +4710,9 @@ class TestVectorStorageBatching:
                 drop_task = asyncio.create_task(s.drop())
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not drop_delete_started.is_set()
-                ), "indices.delete should be blocked behind the flush lock"
+                assert not drop_delete_started.is_set(), (
+                    "indices.delete should be blocked behind the flush lock"
+                )
                 assert not drop_task.done()
 
                 flush_can_finish.set()
@@ -4739,9 +4755,9 @@ class TestVectorStorageBatching:
                 drop_task = asyncio.create_task(s.drop())
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not drop_delete_started.is_set()
-                ), "indices.delete should be blocked during deferred embedding"
+                assert not drop_delete_started.is_set(), (
+                    "indices.delete should be blocked during deferred embedding"
+                )
                 assert not drop_task.done()
 
                 embedding_can_finish.set()


### PR DESCRIPTION
## Background

Follow-up to #3171 (merged), which migrated OpenSearch edges onto canonical sorted-pair `_id`s. That migration handled a reciprocal **duplicate** (a `create` 409 — a forward canonical doc already exists) by simply deleting the reverse doc, which **silently discarded the reverse doc's `description` / `keywords` / `weight` / `source_ids`**. Those duplicates are exactly the upsert-race artifacts the migration repairs, and sequential `_merge_edges_then_upsert` normally preserves that relation evidence — so the migration could degrade query context.

This also brings OpenSearch in line with the Mongo consistency fix (#3172), which merges the full relation payload when consolidating duplicates.

## What this PR does

When the migration hits a reciprocal duplicate (`create` 409), it now **merges the reverse doc's relation payload into the existing canonical doc before deleting the reverse**, instead of dropping it.

- New `_merge_edge_payloads(docs)` — shared field semantics with `mongo_impl` / `operate.py._merge_edges_then_upsert` (minus LLM description summarisation):
  - `source_id` / `source_ids` / `file_path` / `description` union their `GRAPH_FIELD_SEP` components,
  - `keywords` comma-set-unioned,
  - `weight` is **summed** (duplicate docs carry separate accumulated weight — matches the Mongo dedupe-merge in #3172).
  - **Idempotent** (every field unions split components; the weight sum counts each duplicate only while its `source_ids` are not already folded into the base) so re-merging an already-merged doc is a no-op across fail-fast retries.
  - **String-weight safe**: legacy weights are coerced to float, non-numeric skipped (the graph API is `dict[str, str]`), so a bad value can't crash startup.
- New `_merge_into_canonical_edge()` — `GET` the canonical doc, merge, write back with **optimistic concurrency** (`if_seq_no` / `if_primary_term`). A concurrent live write during a rolling deploy is never clobbered: on a version conflict it re-reads (incorporating that write) and re-merges, up to a bounded retry count, then **fails fast before any delete** (startup aborts, flag stays unset, next startup rescans). This keeps #3171's "create-only never clobbers a live write" guarantee through the merge path. If the canonical vanished between the 409 and the merge `GET`, it is recreated from the (merged) reverse sources.
- `_flush_pending` captures the 409 canonical ids and merges each before the delete phase. **All** pending sources mapping to one canonical are folded in together (a node pair with 3+ legacy docs can yield >1 reverse doc per canonical — only one wins the insert, the rest 409), so no reverse payload is dropped. Any non-409 create error still fails fast.

## Testing

`pytest tests/kg/opensearch_impl/ -q` → **221 passed**, `ruff` check + format clean.

New coverage:
- merge-on-conflict (asserts unioned `description`/`source_ids`/`file_path`, set-unioned `keywords`, summed `weight`, `if_seq_no`/`if_primary_term`, direction fields preserved),
- version-conflict retry (re-read + retry, never clobber),
- **multi reverse-doc → one canonical** (every 409'd source folded in, not just the last — `source_ids` + `weight` summed across all),
- **NotFoundError recreate** (canonical vanished → recreated from merged reverse sources, no optimistic-concurrency clobber),
- **persistent-conflict abort** (bounded retries → `RuntimeError` raised before any delete).

## Notes
- Builds on #3171 (merged); pairs with the Mongo dedupe-merge in #3172 — both backends now consolidate duplicates without losing relation evidence, idempotently and type-safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
