### PR TITLE
⚡️ perf(mongo): exact single-edge reads use canonical (edge_lo, edge_hi) index

### DIFF
--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -1424,20 +1424,15 @@ class MongoGraphStorage(BaseGraphStorage):
     async def has_edge(self, source_node_id: str, target_node_id: str) -> bool:
         """
         Check if there's a direct single-hop edge between source_node_id and target_node_id.
+
+        Matches on the canonical ``(edge_lo, edge_hi)`` pair (direction-independent)
+        instead of the bidirectional ``$or``, so this point lookup is served by the
+        compound unique index. Safe because the fail-fast migration in
+        ``initialize`` guarantees every served doc carries the endpoints.
         """
+        edge_lo, edge_hi = _canonical_edge_endpoints(source_node_id, target_node_id)
         doc = await self.edge_collection.find_one(
-            {
-                "$or": [
-                    {
-                        "source_node_id": source_node_id,
-                        "target_node_id": target_node_id,
-                    },
-                    {
-                        "source_node_id": target_node_id,
-                        "target_node_id": source_node_id,
-                    },
-                ]
-            },
+            {"edge_lo": edge_lo, "edge_hi": edge_hi},
             {"_id": 1},
         )
         return doc is not None
@@ -1486,19 +1481,11 @@ class MongoGraphStorage(BaseGraphStorage):
     async def get_edge(
         self, source_node_id: str, target_node_id: str
     ) -> dict[str, str] | None:
+        # Canonical (edge_lo, edge_hi) point lookup served by the compound unique
+        # index (see has_edge); the fail-fast migration guarantees the endpoints.
+        edge_lo, edge_hi = _canonical_edge_endpoints(source_node_id, target_node_id)
         return await self.edge_collection.find_one(
-            {
-                "$or": [
-                    {
-                        "source_node_id": source_node_id,
-                        "target_node_id": target_node_id,
-                    },
-                    {
-                        "source_node_id": target_node_id,
-                        "target_node_id": source_node_id,
-                    },
-                ]
-            }
+            {"edge_lo": edge_lo, "edge_hi": edge_hi}
         )
 
     async def get_node_edges(self, source_node_id: str) -> list[tuple[str, str]] | None:
@@ -2321,14 +2308,18 @@ class MongoGraphStorage(BaseGraphStorage):
         if not edges:
             return
 
+        # Match each edge by its canonical (edge_lo, edge_hi) pair: one clause per
+        # edge (vs. the old two-clause bidirectional pair) served by the compound
+        # unique index, with reciprocal/duplicate inputs collapsed. Safe because
+        # the fail-fast migration guarantees every served doc carries the endpoints.
+        seen: set[tuple[str, str]] = set()
         all_edge_pairs = []
         for source_id, target_id in edges:
-            all_edge_pairs.append(
-                {"source_node_id": source_id, "target_node_id": target_id}
-            )
-            all_edge_pairs.append(
-                {"source_node_id": target_id, "target_node_id": source_id}
-            )
+            endpoints = _canonical_edge_endpoints(source_id, target_id)
+            if endpoints in seen:
+                continue
+            seen.add(endpoints)
+            all_edge_pairs.append({"edge_lo": endpoints[0], "edge_hi": endpoints[1]})
 
         await self.edge_collection.delete_many({"$or": all_edge_pairs})
 

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -203,6 +203,27 @@ def _resolve_upsert_batch_limits() -> tuple[int, int]:
     return max_payload_bytes, max_records_per_batch
 
 
+def _resolve_delete_batch_limit() -> int:
+    """Resolve the flush-time delete record-count cap from env, with module default.
+
+    Shared by every MongoDB delete path that fans a list of match clauses into a
+    single server message (``delete_many`` with ``$in``/``$or``), so the cap that
+    keeps one delete under the bulk message / 16MB query limit is consistent. A
+    non-positive value disables record-count splitting.
+    """
+    max_records_per_batch = int(
+        os.getenv(
+            "MONGO_DELETE_MAX_RECORDS_PER_BATCH",
+            str(DEFAULT_MONGO_DELETE_MAX_RECORDS_PER_BATCH),
+        )
+    )
+    if max_records_per_batch <= 0:
+        logger.warning(
+            f"MONGO_DELETE_MAX_RECORDS_PER_BATCH={max_records_per_batch} is non-positive, disable delete record-count splitting"
+        )
+    return max_records_per_batch
+
+
 async def _run_batched_bulk_write(
     collection,
     ops: list[tuple[Any, int, str]],
@@ -1100,6 +1121,7 @@ class MongoGraphStorage(BaseGraphStorage):
             self._max_upsert_payload_bytes,
             self._max_upsert_records_per_batch,
         ) = _resolve_upsert_batch_limits()
+        self._max_delete_records_per_batch = _resolve_delete_batch_limit()
 
     async def initialize(self):
         async with get_data_init_lock():
@@ -2321,7 +2343,18 @@ class MongoGraphStorage(BaseGraphStorage):
             seen.add(endpoints)
             all_edge_pairs.append({"edge_lo": endpoints[0], "edge_hi": endpoints[1]})
 
-        await self.edge_collection.delete_many({"$or": all_edge_pairs})
+        # Chunk the $or by record count so a large delete stays under the bulk
+        # message / 16MB query limit; endpoints are bounded id strings, so a count
+        # cap is enough (no byte budget needed). A non-positive cap disables it.
+        chunk = (
+            self._max_delete_records_per_batch
+            if self._max_delete_records_per_batch > 0
+            else len(all_edge_pairs)
+        )
+        for i in range(0, len(all_edge_pairs), chunk):
+            await self.edge_collection.delete_many(
+                {"$or": all_edge_pairs[i : i + chunk]}
+            )
 
         logger.debug(f"[{self.workspace}] Successfully deleted edges: {edges}")
 
@@ -2864,23 +2897,14 @@ class MongoVectorDBStorage(BaseVectorStorage):
         self._max_batch_size = self.global_config["embedding_batch_num"]
 
         # Flush-time batching limits (see module-level DEFAULT_MONGO_* constants).
-        # A non-positive value disables that splitting dimension. The two upsert
-        # limits are shared with KV/graph via _resolve_upsert_batch_limits(); the
-        # delete count cap is vector-specific (only the VDB batches deletes here).
+        # A non-positive value disables that splitting dimension. The upsert and
+        # delete caps are shared across KV/graph/VDB via the _resolve_* helpers so
+        # every path stays under the same bulk message / 16MB query limit.
         (
             self._max_upsert_payload_bytes,
             self._max_upsert_records_per_batch,
         ) = _resolve_upsert_batch_limits()
-        self._max_delete_records_per_batch = int(
-            os.getenv(
-                "MONGO_DELETE_MAX_RECORDS_PER_BATCH",
-                str(DEFAULT_MONGO_DELETE_MAX_RECORDS_PER_BATCH),
-            )
-        )
-        if self._max_delete_records_per_batch <= 0:
-            logger.warning(
-                f"MONGO_DELETE_MAX_RECORDS_PER_BATCH={self._max_delete_records_per_batch} is non-positive, disable delete record-count splitting"
-            )
+        self._max_delete_records_per_batch = _resolve_delete_batch_limit()
 
         # Deferred-embedding buffers and the per-namespace flush lock.
         # Constructed in initialize() once shared-storage primitives are

--- a/tests/kg/mongo_impl/test_mongo_storage.py
+++ b/tests/kg/mongo_impl/test_mongo_storage.py
@@ -454,6 +454,75 @@ class TestMongoEdgeKey:
         assert second["keywords"] == first["keywords"] == "alpha,beta,gamma"
 
 
+class TestMongoEdgeReadCanonicalFilter:
+    """Exact single-edge reads/deletes use the canonical (edge_lo, edge_hi)
+    filter so they hit the compound unique index instead of the bidirectional
+    ``$or``. Per-node scans (node_degree/get_node_edges/delete_node) intentionally
+    keep ``$or`` — edge_hi is not a compound-index prefix, so they gain nothing."""
+
+    def _make_storage(self):
+        s = MongoGraphStorage.__new__(MongoGraphStorage)
+        s.workspace = "test"
+        s.namespace = "chunk_entity_relation"
+        s._edge_collection_name = "test_edges"
+        s.edge_collection = SimpleNamespace()
+        return s
+
+    @pytest.mark.asyncio
+    async def test_has_edge_uses_canonical_filter(self):
+        s = self._make_storage()
+        s.edge_collection.find_one = AsyncMock(return_value={"_id": "x"})
+        assert await s.has_edge("B", "A") is True
+
+        filt, projection = s.edge_collection.find_one.call_args[0]
+        lo, hi = _canonical_edge_endpoints("B", "A")
+        assert filt == {"edge_lo": lo, "edge_hi": hi}
+        assert projection == {"_id": 1}
+
+    @pytest.mark.asyncio
+    async def test_has_edge_direction_independent(self):
+        s = self._make_storage()
+        s.edge_collection.find_one = AsyncMock(return_value=None)
+        await s.has_edge("A", "B")
+        forward = s.edge_collection.find_one.call_args[0][0]
+        await s.has_edge("B", "A")
+        backward = s.edge_collection.find_one.call_args[0][0]
+        assert forward == backward
+
+    @pytest.mark.asyncio
+    async def test_get_edge_uses_canonical_filter(self):
+        s = self._make_storage()
+        s.edge_collection.find_one = AsyncMock(return_value={"weight": 1.0})
+        await s.get_edge("B", "A")
+        filt = s.edge_collection.find_one.call_args[0][0]
+        lo, hi = _canonical_edge_endpoints("B", "A")
+        assert filt == {"edge_lo": lo, "edge_hi": hi}
+
+    @pytest.mark.asyncio
+    async def test_remove_edges_uses_canonical_pairs_and_collapses_reciprocals(self):
+        s = self._make_storage()
+        s.edge_collection.delete_many = AsyncMock()
+        # (A,B) and its reciprocal (B,A) must collapse to a single clause.
+        await s.remove_edges([("A", "B"), ("B", "A"), ("C", "D")])
+
+        query = s.edge_collection.delete_many.call_args[0][0]
+        lo_ab, hi_ab = _canonical_edge_endpoints("A", "B")
+        lo_cd, hi_cd = _canonical_edge_endpoints("C", "D")
+        assert query == {
+            "$or": [
+                {"edge_lo": lo_ab, "edge_hi": hi_ab},
+                {"edge_lo": lo_cd, "edge_hi": hi_cd},
+            ]
+        }
+
+    @pytest.mark.asyncio
+    async def test_remove_edges_empty_is_noop(self):
+        s = self._make_storage()
+        s.edge_collection.delete_many = AsyncMock()
+        await s.remove_edges([])
+        s.edge_collection.delete_many.assert_not_awaited()
+
+
 class TestMongoDocStatusLookup:
     """Cover the Mongo-native overrides for basename / content_hash lookups."""
 

--- a/tests/kg/mongo_impl/test_mongo_storage.py
+++ b/tests/kg/mongo_impl/test_mongo_storage.py
@@ -460,11 +460,12 @@ class TestMongoEdgeReadCanonicalFilter:
     ``$or``. Per-node scans (node_degree/get_node_edges/delete_node) intentionally
     keep ``$or`` — edge_hi is not a compound-index prefix, so they gain nothing."""
 
-    def _make_storage(self):
+    def _make_storage(self, max_delete_records_per_batch=1000):
         s = MongoGraphStorage.__new__(MongoGraphStorage)
         s.workspace = "test"
         s.namespace = "chunk_entity_relation"
         s._edge_collection_name = "test_edges"
+        s._max_delete_records_per_batch = max_delete_records_per_batch
         s.edge_collection = SimpleNamespace()
         return s
 
@@ -521,6 +522,35 @@ class TestMongoEdgeReadCanonicalFilter:
         s.edge_collection.delete_many = AsyncMock()
         await s.remove_edges([])
         s.edge_collection.delete_many.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_remove_edges_chunks_large_or_by_record_cap(self):
+        # 5 distinct edges with a cap of 2 → 3 delete_many calls (2 + 2 + 1),
+        # and every input edge is covered exactly once across the chunks.
+        s = self._make_storage(max_delete_records_per_batch=2)
+        s.edge_collection.delete_many = AsyncMock()
+        edges = [(f"n{i}", f"n{i + 1}") for i in range(5)]
+        await s.remove_edges(edges)
+
+        calls = s.edge_collection.delete_many.call_args_list
+        assert [len(c[0][0]["$or"]) for c in calls] == [2, 2, 1]
+        clauses = [clause for c in calls for clause in c[0][0]["$or"]]
+        expected = [
+            {"edge_lo": lo, "edge_hi": hi}
+            for lo, hi in (_canonical_edge_endpoints(src, tgt) for src, tgt in edges)
+        ]
+        assert clauses == expected
+
+    @pytest.mark.asyncio
+    async def test_remove_edges_non_positive_cap_disables_chunking(self):
+        # A non-positive cap means "no record-count splitting": one delete_many.
+        s = self._make_storage(max_delete_records_per_batch=0)
+        s.edge_collection.delete_many = AsyncMock()
+        edges = [(f"n{i}", f"n{i + 1}") for i in range(5)]
+        await s.remove_edges(edges)
+
+        assert s.edge_collection.delete_many.await_count == 1
+        assert len(s.edge_collection.delete_many.call_args[0][0]["$or"]) == 5
 
 
 class TestMongoDocStatusLookup:


### PR DESCRIPTION
## Background

Stacked on #3172 (canonical `(edge_lo, edge_hi)` + compound unique index). That PR closes the same-edge upsert race and adds a partial **compound unique index** `edge_endpoints_unique` on `(edge_lo, edge_hi)`, plus a **fail-fast migration** that guarantees every served edge doc carries the endpoints before reads begin. It deliberately left the read path on the bidirectional `$or` to keep that PR scoped to the write race. This is the follow-up.

> **Base:** `feat/mongo-canonical-edge-key` (depends on #3172). Once #3172 merges, GitHub will retarget this to `main`.

## What this PR does

Switch the **exact single-edge** lookups from the bidirectional `source_node_id`/`target_node_id` `$or` to the canonical `{edge_lo, edge_hi}` filter, so they are served by the compound unique index instead of a scan/secondary index:

- **`has_edge`** — direction-independent point lookup, one index hit.
- **`get_edge`** — same canonical point lookup.
- **`remove_edges`** — one canonical clause per edge (vs. the old two bidirectional clauses, halving the `$or`), with reciprocal/duplicate inputs collapsed.

**Why it's safe:** the fail-fast migration in `initialize` (from #3172) aborts startup unless every doc has `edge_lo`/`edge_hi`, and every new write sets them — so once reads are being served, the canonical filter matches exactly what the old `$or` matched.

## What this PR does NOT change

Per-node scans keep the bidirectional `$or` on purpose: `node_degree`, `get_node_edges`, `get_nodes_edges_batch`, `node_degrees_batch`, `delete_node`, and the KG-traversal aggregations all fan out over *every edge touching a node*. `edge_hi` is not a prefix of the `(edge_lo, edge_hi)` compound index, so an `{$or: [{edge_lo: X}, {edge_hi: X}]}` rewrite would gain nothing (and the `edge_hi` half would be unindexed). Those queries want their own `source_node_id`/`target_node_id` indexes, which is a separate concern.

## Testing

`pytest tests/kg/mongo_impl/ -q` → **51 passed**, `ruff` check + format clean.

New `TestMongoEdgeReadCanonicalFilter`: `has_edge`/`get_edge` use the canonical filter and are direction-independent; `remove_edges` emits one canonical clause per edge and collapses reciprocals; empty `remove_edges` is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
