### PR TITLE
⚡ perf(opensearch): collapse edge point-lookups onto canonical _id

### DIFF
--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -2376,25 +2376,18 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             return False
 
     async def has_edge(self, source_node_id: str, target_node_id: str) -> bool:
-        """Check whether an edge exists between two nodes (bidirectional).
+        """Check whether an edge exists between two nodes.
 
-        Uses mget with the two candidate edge IDs so the check is real-time
-        (translog-backed), consistent with has_node() and independent of the
-        index refresh cycle.
+        Startup migration is fail-fast, so after initialize() every edge is keyed
+        by its canonical (sorted-pair) ``_id``. Point-check that single id with
+        exists(), mirroring has_node() — real-time (translog-backed), independent
+        of the index refresh cycle, no candidate-id fan-out.
         """
         if not self._indices_ready:
             return False
         try:
-            forward_id = compute_mdhash_id(
-                f"{source_node_id}-{target_node_id}", prefix="edge-"
-            )
-            reverse_id = compute_mdhash_id(
-                f"{target_node_id}-{source_node_id}", prefix="edge-"
-            )
-            response = await self.client.mget(
-                index=self._edges_index, body={"ids": [forward_id, reverse_id]}
-            )
-            return any(doc.get("found") for doc in response.get("docs", []))
+            edge_id = _canonical_edge_id(source_node_id, target_node_id)
+            return await self.client.exists(index=self._edges_index, id=edge_id)
         except OpenSearchException as e:
             if _is_missing_index_error(e):
                 self._mark_indices_missing()
@@ -2450,30 +2443,22 @@ class OpenSearchGraphStorage(BaseGraphStorage):
     async def get_edge(
         self, source_node_id: str, target_node_id: str
     ) -> dict[str, str] | None:
-        """Get an edge between two nodes (bidirectional), or None.
+        """Get an edge between two nodes, or None.
 
-        Uses mget with the two candidate edge IDs so the read is real-time
-        (translog-backed), consistent with get_node() and independent of the
-        index refresh cycle.
+        Edges are stored under their canonical (sorted-pair) ``_id`` once the
+        fail-fast startup migration completes, so read that single id directly via
+        mget — real-time (translog-backed), no candidate-id fan-out.
         """
         if not self._indices_ready:
             return None
         try:
-            forward_id = compute_mdhash_id(
-                f"{source_node_id}-{target_node_id}", prefix="edge-"
-            )
-            reverse_id = compute_mdhash_id(
-                f"{target_node_id}-{source_node_id}", prefix="edge-"
-            )
-            response = await self.client.mget(
-                index=self._edges_index, body={"ids": [forward_id, reverse_id]}
-            )
-            for doc in response.get("docs", []):
-                if doc.get("found"):
-                    result = doc["_source"]
-                    result["_id"] = doc["_id"]
-                    return result
-            return None
+            edge_id = _canonical_edge_id(source_node_id, target_node_id)
+            response = await _mget_optional_doc(self.client, self._edges_index, edge_id)
+            if response is None:
+                return None
+            result = response["_source"]
+            result["_id"] = response["_id"]
+            return result
         except OpenSearchException as e:
             if _is_missing_index_error(e):
                 self._mark_indices_missing()
@@ -2928,16 +2913,12 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             logger.error(f"[{self.workspace}] Error removing nodes: {e}")
 
     async def remove_edges(self, edges: list[tuple[str, str]]) -> None:
-        """Batch-delete multiple edges by deterministic ID (real-time).
+        """Batch-delete multiple edges by canonical ID (real-time).
 
-        New writes key edges by their canonical (sorted-pair) id, but we still
-        delete *both* directed candidates per edge:
-          forward  = compute_mdhash_id("src-tgt", prefix="edge-")
-          reverse  = compute_mdhash_id("tgt-src", prefix="edge-")
-        The canonical id is always one of these two, and deleting the other is a
-        harmless 404 — this keeps deletes effective for any legacy doc not yet
-        collapsed by the canonical-id migration. The raw bulk API does not raise
-        on a 404 delete.
+        Startup migration is fail-fast, so every edge is keyed by its canonical
+        (sorted-pair) ``_id``. Delete that single id per edge — dedup via a set so
+        reciprocal inputs ``(A,B)`` and ``(B,A)`` collapse to one delete op. The
+        raw bulk API does not raise on a 404 delete.
 
         Marks edge search views dirty so refresh happens lazily on the next
         search/count-based graph read.
@@ -2946,20 +2927,16 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             return
         logger.info(f"[{self.workspace}] Deleting {len(edges)} edges")
         try:
-            operations = []
-            for src, tgt in edges:
-                for edge_id in (
-                    compute_mdhash_id(f"{src}-{tgt}", prefix="edge-"),
-                    compute_mdhash_id(f"{tgt}-{src}", prefix="edge-"),
-                ):
-                    operations.append(
-                        {
-                            "delete": {
-                                "_index": self._edges_index,
-                                "_id": edge_id,
-                            }
-                        }
-                    )
+            edge_ids = {_canonical_edge_id(src, tgt) for src, tgt in edges}
+            operations = [
+                {
+                    "delete": {
+                        "_index": self._edges_index,
+                        "_id": edge_id,
+                    }
+                }
+                for edge_id in edge_ids
+            ]
             # The raw bulk API does not auto-chunk (unlike helpers.async_bulk),
             # so split the operation list by the delete record-count cap to keep
             # each request bounded (mirrors mongo_impl's chunked delete_many).

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -2017,22 +2017,24 @@ class TestGraphStorage:
 
     @pytest.mark.asyncio
     async def test_has_edge(self, global_config, embed_func, mock_client):
-        mock_client.search = AsyncMock(
-            return_value={
-                "hits": {"hits": [], "total": {"value": 1}},
-                "aggregations": {
-                    "status_counts": {"buckets": []},
-                    "src": {"buckets": []},
-                    "tgt": {"buckets": []},
-                    "source_degrees": {"buckets": []},
-                    "target_degrees": {"buckets": []},
-                },
-            }
-        )
+        # has_edge point-checks the single canonical _id via exists().
+        mock_client.exists = AsyncMock(return_value=True)
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()
             assert await s.has_edge("A", "B") is True
+            mock_client.exists.assert_awaited_once_with(
+                index=s._edges_index, id=_canonical_edge_id("A", "B")
+            )
+            mock_client.mget.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_has_edge_false(self, global_config, embed_func, mock_client):
+        mock_client.exists = AsyncMock(return_value=False)
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            assert await s.has_edge("A", "B") is False
 
     @pytest.mark.asyncio
     async def test_node_degree(self, global_config, embed_func, mock_client):
@@ -2081,22 +2083,19 @@ class TestGraphStorage:
 
     @pytest.mark.asyncio
     async def test_get_edge(self, global_config, embed_func, mock_client):
-        # get_edge now uses mget (translog real-time) instead of search.
+        # get_edge reads the single canonical _id via mget (translog real-time).
+        canonical = _canonical_edge_id("A", "B")
         mock_client.mget = AsyncMock(
             return_value={
                 "docs": [
                     {
-                        "_id": "e1",
+                        "_id": canonical,
                         "found": True,
                         "_source": {
                             "source_node_id": "A",
                             "target_node_id": "B",
                             "weight": 1.0,
                         },
-                    },
-                    {
-                        "_id": "e2",
-                        "found": False,
                     },
                 ]
             }
@@ -2107,6 +2106,10 @@ class TestGraphStorage:
             edge = await s.get_edge("A", "B")
             assert edge is not None
             assert edge["weight"] == 1.0
+            assert edge["_id"] == canonical
+            mock_client.mget.assert_awaited_once_with(
+                index=s._edges_index, body={"ids": [canonical]}
+            )
 
     @pytest.mark.asyncio
     async def test_get_node_edges(self, global_config, embed_func, mock_client):
@@ -2991,17 +2994,35 @@ class TestGraphStorage:
 
     @pytest.mark.asyncio
     async def test_remove_edges(self, global_config, embed_func, mock_client):
-        # remove_edges now uses bulk delete with deterministic IDs instead of
-        # delete_by_query, so mock bulk as AsyncMock.
+        # remove_edges bulk-deletes one canonical _id per edge.
         mock_client.bulk = AsyncMock(return_value={"errors": False, "items": []})
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()
             await s.remove_edges([("A", "B"), ("C", "D")])
-            # 2 edges × 2 candidate directions = 4 delete actions in one bulk call
+            # 2 distinct canonical edges = 2 delete actions in one bulk call
             mock_client.bulk.assert_awaited_once()
             call_body = mock_client.bulk.call_args.kwargs["body"]
-            assert len(call_body) == 4
+            assert len(call_body) == 2
+            assert {op["delete"]["_id"] for op in call_body} == {
+                _canonical_edge_id("A", "B"),
+                _canonical_edge_id("C", "D"),
+            }
+
+    @pytest.mark.asyncio
+    async def test_remove_edges_dedups_reciprocal(
+        self, global_config, embed_func, mock_client
+    ):
+        # (A,B) and (B,A) share a canonical _id, so they collapse to one op.
+        mock_client.bulk = AsyncMock(return_value={"errors": False, "items": []})
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            await s.remove_edges([("A", "B"), ("B", "A")])
+            mock_client.bulk.assert_awaited_once()
+            call_body = mock_client.bulk.call_args.kwargs["body"]
+            assert len(call_body) == 1
+            assert call_body[0]["delete"]["_id"] == _canonical_edge_id("A", "B")
 
     @pytest.mark.asyncio
     async def test_get_all_labels(self, global_config, embed_func, mock_client):


### PR DESCRIPTION
## Background

`OpenSearchGraphStorage` keys every edge document under `_canonical_edge_id(src, tgt)` — the two endpoints sorted then hashed, so `(A,B)` and `(B,A)` collapse onto the same document. The startup `_migrate_edges_to_canonical_id_if_needed()` is **fail-fast**: the service does not finish initializing until migration completes, after which the edge index holds canonical `_id`s only.

Given that invariant, point-lookup/delete paths for a known endpoint pair no longer need to build forward/reverse candidate IDs — they can address the single canonical `_id` directly.

## Changes

- **`has_edge()`**: point-checks the canonical `_id` with `client.exists()`, mirroring `has_node()` — real-time (translog-backed), independent of the index refresh cycle, no candidate-id fan-out.
- **`get_edge()`**: reads the single canonical document via `_mget_optional_doc()`, identical to `get_node()`; return behavior unchanged (still writes `_id` back into the result dict).
- **`remove_edges()`**: emits one delete op per canonical `_id`, deduped via a set so reciprocal inputs `(A,B)`/`(B,A)` collapse to a single op.

Traversal-style paths that rely on the `source_node_id`/`target_node_id` field indexes (`node_degree`, `get_node_edges`, BFS, subgraph aggregations, etc.) are untouched — the canonical `_id` is a hash and cannot answer "all edges of node X", so those must still query the field indexes.

## Compatibility note

The canonical-only delete in `remove_edges()` depends on the migration having fully succeeded. If there is a rolling-upgrade window where non-canonical edges are still being written, a canonical delete cannot reap those stragglers — in that case, clear the `_meta` flag and re-run the migration as documented in the migration comments.

## Tests

Updated and extended `tests/kg/opensearch_impl/test_opensearch_storage.py`:
- `test_has_edge` now mocks `client.exists`, asserts it is called with the canonical `_id` and that `mget` is not called; added `test_has_edge_false`.
- `test_get_edge` uses a single canonical document and asserts the mget body and the returned `_id`.
- `test_remove_edges` asserts one op per distinct canonical edge; added `test_remove_edges_dedups_reciprocal` to verify dedup.

```
./scripts/test.sh tests/kg/opensearch_impl/test_opensearch_storage.py
# 208 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)