### PR TITLE
🐛 fix(postgres): rank get_knowledge_graph("*") nodes by undirected degree

### DIFF
--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -7589,9 +7589,7 @@ class PGGraphStorage(BaseGraphStorage):
                 LEFT JOIN node_degrees d ON d.node_id = v.id
                 ORDER BY degree DESC, v.id ASC
                 LIMIT $1"""
-            node_results = await self._query(
-                query_nodes, params={"limit": max_nodes}
-            )
+            node_results = await self._query(query_nodes, params={"limit": max_nodes})
 
             node_ids = [str(result["node_id"]) for result in node_results]
 

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -7567,15 +7567,31 @@ class PGGraphStorage(BaseGraphStorage):
             total_nodes = count_result[0]["total_nodes"] if count_result else 0
             is_truncated = total_nodes > max_nodes
 
-            # Get max_nodes with highest degrees
-            query_nodes = f"""SELECT * FROM cypher('{self.graph_name}', $$
-                    MATCH (n:base)
-                    OPTIONAL MATCH (n)-[r]->()
-                    RETURN id(n) as node_id, count(r) as degree
-                $$) AS (node_id BIGINT, degree BIGINT)
-                ORDER BY degree DESC
-                LIMIT {max_nodes}"""
-            node_results = await self._query(query_nodes)
+            # Get max_nodes with highest degrees using native SQL on AGE's
+            # underlying tables (same pattern as get_popular_labels).
+            # Degree is UNDIRECTED: count both start_id and end_id so a node
+            # that is mostly an edge target is not under-ranked and dropped on
+            # truncation. LEFT JOIN from the base vertex table + COALESCE keeps
+            # isolated (degree-0) nodes, matching the previous OPTIONAL MATCH
+            # behaviour when the graph is not truncated. Stable tie-break on id.
+            query_nodes = f"""
+                WITH node_degrees AS (
+                    SELECT node_id, COUNT(*) AS degree
+                    FROM (
+                        SELECT start_id AS node_id FROM {self.graph_name}._ag_label_edge
+                        UNION ALL
+                        SELECT end_id AS node_id FROM {self.graph_name}._ag_label_edge
+                    ) AS all_edges
+                    GROUP BY node_id
+                )
+                SELECT v.id AS node_id, COALESCE(d.degree, 0) AS degree
+                FROM {self.graph_name}.base v
+                LEFT JOIN node_degrees d ON d.node_id = v.id
+                ORDER BY degree DESC, v.id ASC
+                LIMIT $1"""
+            node_results = await self._query(
+                query_nodes, params={"limit": max_nodes}
+            )
 
             node_ids = [str(result["node_id"]) for result in node_results]
 

--- a/tests/kg/postgres_impl/test_postgres_get_knowledge_graph_all.py
+++ b/tests/kg/postgres_impl/test_postgres_get_knowledge_graph_all.py
@@ -1,0 +1,189 @@
+"""
+Unit tests for PGGraphStorage.get_knowledge_graph("*") — the full-graph view.
+
+These cover the undirected fix for the degree-based node selection used when the
+graph is truncated to ``max_nodes``: the previous implementation counted only
+outgoing edges (``OPTIONAL MATCH (n)-[r]->()``), so a node that is mostly an edge
+*target* was under-ranked and could be dropped on truncation. The fix selects
+top-degree nodes via native SQL that counts both ``start_id`` and ``end_id``
+(undirected degree), LEFT JOIN-ing the base vertex table so isolated nodes are
+preserved when the graph is not truncated.
+
+The subgraph edge read intentionally stays directed: ``a`` iterates over every
+selected node, so ``(a)-[r]->(b)`` already captures every edge whose endpoints
+are both selected. These tests guard against an accidental regression there.
+
+All tests mock ``PGGraphStorage._query`` and inspect the SQL it receives.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from lightrag.kg.postgres_impl import PGGraphStorage
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_graph_storage() -> PGGraphStorage:
+    """Construct a PGGraphStorage instance with a mocked _query method."""
+    storage = PGGraphStorage.__new__(PGGraphStorage)
+    storage.workspace = "test_ws"
+    storage.namespace = "test_graph"
+    storage.graph_name = "test_graph"
+    storage.global_config = {"max_graph_nodes": 1000}
+    storage.db = MagicMock()
+    return storage
+
+
+class _QueryCapture:
+    """Dispatch the three _query calls of the '*' branch by SQL content."""
+
+    def __init__(self, *, total_nodes, degree_rows, subgraph_rows):
+        self._total_nodes = total_nodes
+        self._degree_rows = degree_rows
+        self._subgraph_rows = subgraph_rows
+        self.count_sql = None
+        self.degree_sql = None
+        self.degree_params = None
+        self.subgraph_sql = None
+
+    def as_side_effect(self):
+        """Return an ``async def`` so AsyncMock awaits it (a callable instance is not)."""
+
+        async def fake_query(query, **kwargs):
+            if "count(distinct n)" in query:
+                self.count_sql = query
+                return [{"total_nodes": self._total_nodes}]
+            if "node_degrees" in query:
+                self.degree_sql = query
+                self.degree_params = kwargs.get("params")
+                return self._degree_rows
+            # subgraph read
+            self.subgraph_sql = query
+            return self._subgraph_rows
+
+        return fake_query
+
+
+def _node(node_id, entity_id):
+    return {"id": node_id, "properties": {"entity_id": entity_id}}
+
+
+def _edge(edge_id, start_id, end_id, weight="1"):
+    return {
+        "id": edge_id,
+        "label": "DIRECTED",
+        "start_id": start_id,
+        "end_id": end_id,
+        "properties": {"weight": weight},
+    }
+
+
+# ---------------------------------------------------------------------------
+# degree node selection SQL
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_degree_selection_sql_is_undirected_and_preserves_isolated():
+    """The degree query must count start_id + end_id and keep degree-0 nodes."""
+    capture = _QueryCapture(
+        total_nodes=2,
+        degree_rows=[{"node_id": 1, "degree": 3}, {"node_id": 2, "degree": 0}],
+        subgraph_rows=[{"a": _node(1, "Alice"), "r": None, "b": None}],
+    )
+    storage = make_graph_storage()
+
+    with patch.object(storage, "_query", side_effect=capture.as_side_effect()):
+        await storage.get_knowledge_graph("*", max_nodes=50)
+
+    sql = capture.degree_sql
+    assert sql is not None, "degree selection query was never issued"
+    # Undirected: both edge endpoints are counted.
+    assert "start_id" in sql
+    assert "end_id" in sql
+    assert "UNION ALL" in sql
+    # Isolated nodes preserved.
+    assert "LEFT JOIN" in sql
+    assert "COALESCE" in sql
+    # Stable ordering with id tie-break.
+    assert "ORDER BY degree DESC" in sql
+    assert "v.id ASC" in sql
+    # The old outgoing-only Cypher must be gone.
+    assert "-[r]->()" not in sql
+    assert "OPTIONAL MATCH (n)-[r]->()" not in sql
+
+
+@pytest.mark.asyncio
+async def test_degree_selection_limit_is_parameterized():
+    """max_nodes must be passed via params, not interpolated into the SQL."""
+    capture = _QueryCapture(
+        total_nodes=2,
+        degree_rows=[{"node_id": 1, "degree": 3}],
+        subgraph_rows=[{"a": _node(1, "Alice"), "r": None, "b": None}],
+    )
+    storage = make_graph_storage()
+
+    with patch.object(storage, "_query", side_effect=capture.as_side_effect()):
+        await storage.get_knowledge_graph("*", max_nodes=37)
+
+    assert "LIMIT $1" in capture.degree_sql
+    assert "37" not in capture.degree_sql
+    assert capture.degree_params == {"limit": 37}
+
+
+@pytest.mark.asyncio
+async def test_isolated_node_survives_end_to_end():
+    """A degree-0 node selected by the degree query reaches the final KnowledgeGraph."""
+    capture = _QueryCapture(
+        total_nodes=2,
+        degree_rows=[{"node_id": 1, "degree": 2}, {"node_id": 2, "degree": 0}],
+        subgraph_rows=[
+            {"a": _node(1, "Alice"), "r": None, "b": None},
+            # MATCH (a) still returns the isolated node with null r/b.
+            {"a": _node(2, "Bob"), "r": None, "b": None},
+        ],
+    )
+    storage = make_graph_storage()
+
+    with patch.object(storage, "_query", side_effect=capture.as_side_effect()):
+        kg = await storage.get_knowledge_graph("*", max_nodes=50)
+
+    # The isolated node id is formatted into the subgraph id list...
+    assert "2" in capture.subgraph_sql
+    # ...and present in the returned graph.
+    assert {node.id for node in kg.nodes} == {"1", "2"}
+    assert kg.is_truncated is False
+
+
+# ---------------------------------------------------------------------------
+# subgraph edge read — regression guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_subgraph_read_stays_directed_and_dedupes_edges():
+    """Subgraph read keeps the directed (a)-[r]->(b) match and dedupes by edge id."""
+    duplicate_edge = _edge(10, 1, 2)
+    capture = _QueryCapture(
+        total_nodes=2,
+        degree_rows=[{"node_id": 1, "degree": 1}, {"node_id": 2, "degree": 1}],
+        subgraph_rows=[
+            {"a": _node(1, "Alice"), "r": duplicate_edge, "b": _node(2, "Bob")},
+            # Same AGE edge id appearing twice must collapse to one edge.
+            {"a": _node(1, "Alice"), "r": duplicate_edge, "b": _node(2, "Bob")},
+        ],
+    )
+    storage = make_graph_storage()
+
+    with patch.object(storage, "_query", side_effect=capture.as_side_effect()):
+        kg = await storage.get_knowledge_graph("*", max_nodes=50)
+
+    assert "(a)-[r]->(b)" in capture.subgraph_sql
+    assert len(kg.edges) == 1
+    edge = kg.edges[0]
+    assert edge.source == "1"
+    assert edge.target == "2"


### PR DESCRIPTION
## Problem

`PGGraphStorage.get_knowledge_graph("*")` selects its top-N nodes (when the graph exceeds `max_nodes` and must be truncated) by node degree. The previous query used:

```cypher
OPTIONAL MATCH (n)-[r]->()
RETURN id(n) as node_id, count(r) as degree
```

This counts **only outgoing edges**. A node that is mostly an edge *target* (high in-degree, low out-degree) gets a low degree and can be dropped on truncation — so the `*` view loses genuinely central nodes. This violates LightRAG's undirected edge semantics (any direction is the same connection).

The sibling `get_popular_labels()` already computes degree the right way (native SQL, `start_id` + `end_id`); this PR brings the `*` node selection in line.

## Change

Replace the degree query with native SQL over AGE's underlying tables:

- **Undirected degree** — `UNION ALL` of `start_id` and `end_id` from `_ag_label_edge`, mirroring `get_popular_labels()`.
- **Isolated nodes preserved** — `LEFT JOIN {graph}.base` + `COALESCE(degree, 0)` keeps degree-0 nodes when the graph is *not* truncated (the old `OPTIONAL MATCH` did this; a plain `JOIN` would silently drop them).
- **Deterministic ordering** — `ORDER BY degree DESC, v.id ASC` tie-break.
- **Parameterized `LIMIT`** — `$1` via `params={"limit": max_nodes}`.

### Intentionally unchanged

The directed subgraph edge read `(a)-[r]->(b)` is **left as-is**: `a` iterates over every selected node, so it already captures every edge whose endpoints are both selected. Switching it to `-[r]-` would only produce duplicate rows handled by the existing `edge_id` dedup — no behavioral gain. Other edge paths (`has_edge`, `get_edge(s)`, `get_node_edges`, `node_degrees_batch`, `remove_edges`, …) are already undirected and untouched.

No public API or wire-shape change.

## Tests

New `tests/kg/postgres_impl/test_postgres_get_knowledge_graph_all.py` (mocks `_query`):

1. Degree SQL is undirected (`start_id`/`end_id`/`UNION ALL`), preserves isolated nodes (`LEFT JOIN`/`COALESCE`), stable tie-break, and no longer contains the out-only `-[r]->()` fragment.
2. `LIMIT` is parameterized (`$1` + `params={"limit": ...}`), not interpolated.
3. An isolated (degree-0) node survives end-to-end into the returned `KnowledgeGraph`.
4. Regression guard: subgraph read stays `(a)-[r]->(b)` and dedupes duplicate edge rows by `edge_id`.

```
./scripts/test.sh tests/kg/postgres_impl/test_postgres_get_knowledge_graph_all.py \
  tests/kg/postgres_impl/test_postgres_upsert_edge_cypher.py \
  tests/kg/postgres_impl/test_postgres_age_quote_fix.py \
  tests/kg/postgres_impl/test_postgres_graph_batch.py
# 41 passed
```

Integration tests against a live PostgreSQL/AGE backend (`LIGHTRAG_GRAPH_STORAGE=PGGraphStorage`) were not run in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)