### PR TITLE
🔒 fix(mongo): rebuild FAILED Atlas vector index instead of wedging queries

### DIFF
--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -2992,14 +2992,19 @@ class MongoVectorDBStorage(BaseVectorStorage):
         """Create the Atlas Vector Search index, repairing a FAILED one.
 
         Atlas/mongot leaves a vector index in the terminal ``FAILED`` state
-        after a build error and never retries it on its own; every
-        subsequent ``$vectorSearch`` then raises ``cannot query vector index
-        ... while in state FAILED``. Matching the index only by name would
-        treat that dead index as healthy and wedge all queries permanently,
-        so a same-dimension FAILED index is dropped and rebuilt here. The
-        dimension-mismatch guard runs *before* the rebuild: a FAILED index
-        built under a different embedding model raises rather than being
-        auto-rebuilt against incompatible stored vectors. Transitional states
+        after a build error and never retries it on its own; when that index
+        is also non-queryable every subsequent ``$vectorSearch`` raises
+        ``cannot query vector index ... while in state FAILED``. Matching the
+        index only by name would treat that dead index as healthy and wedge
+        all queries permanently, so a non-queryable, same-dimension FAILED
+        index is dropped and rebuilt here.
+
+        Two guards run *before* the rebuild: (1) a FAILED index that is still
+        ``queryable`` (a background rebuild/update failed but the previously
+        built index keeps serving) is left in place to avoid taking a
+        still-serving index offline; (2) a FAILED index built under a
+        different embedding model raises rather than being auto-rebuilt
+        against incompatible stored vectors. Transitional states
         (``PENDING``/``BUILDING``) are left alone -- they become queryable
         without intervention.
         """
@@ -3037,16 +3042,34 @@ class MongoVectorDBStorage(BaseVectorStorage):
                     logger.error(f"[{self.workspace}] {error_msg}")
                     raise ValueError(error_msg)
 
-                # A FAILED build is terminal: drop it and fall through to
-                # recreate (the same self-heal `drop()` relies on). Only
-                # reached once the dimension guard above has confirmed the
-                # stored dimension matches the current embedding model. Wait
-                # for the drop to clear first -- create_search_index rejects a
-                # name that still exists while the old index is DELETING.
+                # Self-heal a FAILED index, but ONLY when it is actually
+                # non-queryable. Atlas can report status="FAILED" while
+                # queryable=true -- e.g. a background rebuild/update failed
+                # yet the previously-built index keeps serving queries (see
+                # the listSearchIndexes status docs). Dropping such an index
+                # here would take a still-serving index offline and cause
+                # avoidable query downtime while we wait for deletion and
+                # rebuild. Reached only once the dimension guard above
+                # confirmed the stored dimension matches.
                 if index.get("status") == "FAILED":
+                    if index.get("queryable", True):
+                        logger.warning(
+                            f"[{self.workspace}] vector index {self._index_name} reports "
+                            f"FAILED status but is still queryable; leaving the active "
+                            f"index in place. A background rebuild/update likely failed -- "
+                            f"inspect $listSearchIndexes statusDetail and drop/rebuild "
+                            f"manually if queries degrade."
+                        )
+                        return
+
+                    # Non-queryable FAILED build is terminal: drop and fall
+                    # through to recreate (the same self-heal `drop()` relies
+                    # on). Wait for the drop to clear first -- create_search_index
+                    # rejects a name that still exists while the old index is
+                    # DELETING.
                     logger.warning(
-                        f"[{self.workspace}] vector index {self._index_name} is in "
-                        f"FAILED state; dropping and recreating it"
+                        f"[{self.workspace}] vector index {self._index_name} is FAILED "
+                        f"and non-queryable; dropping and recreating it"
                     )
                     await self._data.drop_search_index(self._index_name)
                     await self._wait_for_search_index_absent(self._index_name)

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -2996,7 +2996,10 @@ class MongoVectorDBStorage(BaseVectorStorage):
         subsequent ``$vectorSearch`` then raises ``cannot query vector index
         ... while in state FAILED``. Matching the index only by name would
         treat that dead index as healthy and wedge all queries permanently,
-        so a FAILED index is dropped and rebuilt here. Transitional states
+        so a same-dimension FAILED index is dropped and rebuilt here. The
+        dimension-mismatch guard runs *before* the rebuild: a FAILED index
+        built under a different embedding model raises rather than being
+        auto-rebuilt against incompatible stored vectors. Transitional states
         (``PENDING``/``BUILDING``) are left alone -- they become queryable
         without intervention.
         """
@@ -3007,20 +3010,13 @@ class MongoVectorDBStorage(BaseVectorStorage):
                 if index["name"] != self._index_name:
                     continue
 
-                # A FAILED build is terminal: drop it and fall through to
-                # recreate (the same self-heal `drop()` relies on). Wait for
-                # the drop to clear first -- create_search_index rejects a
-                # name that still exists while the old index is DELETING.
-                if index.get("status") == "FAILED":
-                    logger.warning(
-                        f"[{self.workspace}] vector index {self._index_name} is in "
-                        f"FAILED state; dropping and recreating it"
-                    )
-                    await self._data.drop_search_index(self._index_name)
-                    await self._wait_for_search_index_absent(self._index_name)
-                    break
-
-                # Check if the existing index has matching vector dimensions
+                # Read the stored vector dimension first so the mismatch
+                # guard below runs even for a FAILED index. A FAILED index
+                # built under a *different* embedding model must NOT be
+                # silently auto-rebuilt: recreating with the new dimension
+                # against incompatible stored vectors would just FAIL again
+                # and hide the required data-directory reset from the
+                # operator. Only a same-dimension FAILED index is self-healed.
                 existing_dim = None
                 definition = index.get("latestDefinition", {})
                 fields = definition.get("fields", [])
@@ -3040,6 +3036,21 @@ class MongoVectorDBStorage(BaseVectorStorage):
                     )
                     logger.error(f"[{self.workspace}] {error_msg}")
                     raise ValueError(error_msg)
+
+                # A FAILED build is terminal: drop it and fall through to
+                # recreate (the same self-heal `drop()` relies on). Only
+                # reached once the dimension guard above has confirmed the
+                # stored dimension matches the current embedding model. Wait
+                # for the drop to clear first -- create_search_index rejects a
+                # name that still exists while the old index is DELETING.
+                if index.get("status") == "FAILED":
+                    logger.warning(
+                        f"[{self.workspace}] vector index {self._index_name} is in "
+                        f"FAILED state; dropping and recreating it"
+                    )
+                    await self._data.drop_search_index(self._index_name)
+                    await self._wait_for_search_index_absent(self._index_name)
+                    break
 
                 logger.info(
                     f"[{self.workspace}] vector index {self._index_name} already exists with matching dimensions ({expected_dim})"

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -2963,41 +2963,88 @@ class MongoVectorDBStorage(BaseVectorStorage):
                 f"deletes buffered after final flush attempt (these writes have been lost)"
             )
 
+    async def _wait_for_search_index_absent(
+        self, index_name: str, *, timeout: float = 120.0, interval: float = 2.0
+    ) -> None:
+        """Poll until a dropped search index disappears.
+
+        ``create_search_index`` rejects a name that still exists while the
+        prior drop is in the DELETING state, so a recreate must wait for the
+        old index to clear first. Best-effort: on timeout it logs and returns
+        so the subsequent create surfaces any genuine conflict itself rather
+        than blocking initialize() indefinitely.
+        """
+        deadline = time.monotonic() + timeout
+        while True:
+            cursor = await self._data.list_search_indexes()
+            names = {idx["name"] for idx in await cursor.to_list(length=None)}
+            if index_name not in names:
+                return
+            if time.monotonic() >= deadline:
+                logger.warning(
+                    f"[{self.workspace}] dropped search index {index_name} still "
+                    f"present after {timeout:.0f}s; proceeding to recreate"
+                )
+                return
+            await asyncio.sleep(interval)
+
     async def create_vector_index_if_not_exists(self):
-        """Creates an Atlas Vector Search index."""
+        """Create the Atlas Vector Search index, repairing a FAILED one.
+
+        Atlas/mongot leaves a vector index in the terminal ``FAILED`` state
+        after a build error and never retries it on its own; every
+        subsequent ``$vectorSearch`` then raises ``cannot query vector index
+        ... while in state FAILED``. Matching the index only by name would
+        treat that dead index as healthy and wedge all queries permanently,
+        so a FAILED index is dropped and rebuilt here. Transitional states
+        (``PENDING``/``BUILDING``) are left alone -- they become queryable
+        without intervention.
+        """
         try:
             indexes_cursor = await self._data.list_search_indexes()
             indexes = await indexes_cursor.to_list(length=None)
             for index in indexes:
-                if index["name"] == self._index_name:
-                    # Check if the existing index has matching vector dimensions
-                    existing_dim = None
-                    definition = index.get("latestDefinition", {})
-                    fields = definition.get("fields", [])
-                    for field in fields:
-                        if (
-                            field.get("type") == "vector"
-                            and field.get("path") == "vector"
-                        ):
-                            existing_dim = field.get("numDimensions")
-                            break
+                if index["name"] != self._index_name:
+                    continue
 
-                    expected_dim = self.embedding_func.embedding_dim
-
-                    if existing_dim is not None and existing_dim != expected_dim:
-                        error_msg = (
-                            f"Vector dimension mismatch! Index '{self._index_name}' has "
-                            f"dimension {existing_dim}, but current embedding model expects "
-                            f"dimension {expected_dim}. Please drop the existing index or "
-                            f"use an embedding model with matching dimensions."
-                        )
-                        logger.error(f"[{self.workspace}] {error_msg}")
-                        raise ValueError(error_msg)
-
-                    logger.info(
-                        f"[{self.workspace}] vector index {self._index_name} already exists with matching dimensions ({expected_dim})"
+                # A FAILED build is terminal: drop it and fall through to
+                # recreate (the same self-heal `drop()` relies on). Wait for
+                # the drop to clear first -- create_search_index rejects a
+                # name that still exists while the old index is DELETING.
+                if index.get("status") == "FAILED":
+                    logger.warning(
+                        f"[{self.workspace}] vector index {self._index_name} is in "
+                        f"FAILED state; dropping and recreating it"
                     )
-                    return
+                    await self._data.drop_search_index(self._index_name)
+                    await self._wait_for_search_index_absent(self._index_name)
+                    break
+
+                # Check if the existing index has matching vector dimensions
+                existing_dim = None
+                definition = index.get("latestDefinition", {})
+                fields = definition.get("fields", [])
+                for field in fields:
+                    if field.get("type") == "vector" and field.get("path") == "vector":
+                        existing_dim = field.get("numDimensions")
+                        break
+
+                expected_dim = self.embedding_func.embedding_dim
+
+                if existing_dim is not None and existing_dim != expected_dim:
+                    error_msg = (
+                        f"Vector dimension mismatch! Index '{self._index_name}' has "
+                        f"dimension {existing_dim}, but current embedding model expects "
+                        f"dimension {expected_dim}. Please drop the existing index or "
+                        f"use an embedding model with matching dimensions."
+                    )
+                    logger.error(f"[{self.workspace}] {error_msg}")
+                    raise ValueError(error_msg)
+
+                logger.info(
+                    f"[{self.workspace}] vector index {self._index_name} already exists with matching dimensions ({expected_dim})"
+                )
+                return
 
             search_index_model = SearchIndexModel(
                 definition={


### PR DESCRIPTION
## Description

A MongoDB-backed deployment started failing every query with:

```
Query failed: ... cannot query vector index vector_knn_index_space2_entities ... while in state FAILED
```

Atlas/`mongot` leaves a vector search index in the **terminal `FAILED`** state after a build error and never retries it on its own. `MongoVectorDBStorage.create_vector_index_if_not_exists` matched the existing index **only by name** and returned as if healthy, so a `FAILED` index wedged all `$vectorSearch` queries permanently. Worse, `drop()` / `clear_documents` could not recover either — their "recreate" step goes through the same function and hit the same early `return`, so a `FAILED` index was unrecoverable through the normal API.

Root-cause note: in the affected database the stored vectors were all valid (1481 docs, all 1024-dim, no NaN/Inf/zero-norm), so the `FAILED` state was a stale leftover from an earlier one-off build failure, not corrupt data. Dropping and recreating the index rebuilt it to `READY` immediately.

## Changes Made

- `create_vector_index_if_not_exists`: on a name match, detect `status == "FAILED"`, drop the dead index, wait for the drop to clear, then fall through to recreate. Healthy/transitional states (`PENDING`/`BUILDING`) and the dimension-mismatch guard are unchanged.
- Add `_wait_for_search_index_absent`: bounded (120s) best-effort poll so the recreate doesn't collide with a name still in the `DELETING` state; on timeout it logs and proceeds rather than blocking `initialize()` indefinitely.
- This also restores `drop()` / `clear_documents` as a recovery path for a `FAILED` index.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable) — existing `tests/kg/mongo_impl/test_mongo_deferred_embedding.py` (23) pass; verified idempotency against a live healthy index (READY index untouched) and the drop→wait→recreate path against a live `FAILED` index (rebuilt to `READY`, `$vectorSearch` returns).

## Additional Notes

The dimension-mismatch case still raises `ValueError` (intentional guard against silently rebuilding under a changed embedding model); only the terminal `FAILED` state triggers an automatic rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)