### PR TITLE
♻️ refactor(api): move delete_entity/delete_relation to graph API (breaking)

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -25,7 +25,7 @@ from fastapi import (
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from lightrag import LightRAG
-from lightrag.base import DeletionResult, DocProcessingStatus, DocStatus
+from lightrag.base import DocProcessingStatus, DocStatus
 from lightrag.constants import (
     FULL_DOCS_FORMAT_PENDING_PARSE,
     PARSER_ENGINE_LEGACY,
@@ -619,29 +619,6 @@ class DeleteDocRequest(BaseModel):
             raise ValueError("Document IDs must be unique")
 
         return validated_ids
-
-
-class DeleteEntityRequest(BaseModel):
-    entity_name: str = Field(..., description="The name of the entity to delete.")
-
-    @field_validator("entity_name", mode="after")
-    @classmethod
-    def validate_entity_name(cls, entity_name: str) -> str:
-        if not entity_name or not entity_name.strip():
-            raise ValueError("Entity name cannot be empty")
-        return entity_name.strip()
-
-
-class DeleteRelationRequest(BaseModel):
-    source_entity: str = Field(..., description="The name of the source entity.")
-    target_entity: str = Field(..., description="The name of the target entity.")
-
-    @field_validator("source_entity", "target_entity", mode="after")
-    @classmethod
-    def validate_entity_names(cls, entity_name: str) -> str:
-        if not entity_name or not entity_name.strip():
-            raise ValueError("Entity name cannot be empty")
-        return entity_name.strip()
 
 
 class DocStatusResponse(BaseModel):
@@ -4104,81 +4081,6 @@ def create_document_routes(
             logger.error(f"Error clearing cache: {str(e)}")
             logger.error(traceback.format_exc())
             raise HTTPException(status_code=500, detail=str(e))
-
-    @router.delete(
-        "/delete_entity",
-        response_model=DeletionResult,
-        dependencies=[Depends(combined_auth)],
-    )
-    async def delete_entity(request: DeleteEntityRequest):
-        """
-        Delete an entity and all its relationships from the knowledge graph.
-
-        Args:
-            request (DeleteEntityRequest): The request body containing the entity name.
-
-        Returns:
-            DeletionResult: An object containing the outcome of the deletion process.
-
-        Raises:
-            HTTPException: If the entity is not found (404) or an error occurs (500).
-        """
-        try:
-            await check_pipeline_busy_or_raise(rag)
-            result = await rag.adelete_by_entity(entity_name=request.entity_name)
-            if result.status == "not_found":
-                raise HTTPException(status_code=404, detail=result.message)
-            if result.status == "fail":
-                raise HTTPException(status_code=500, detail=result.message)
-            # Set doc_id to empty string since this is an entity operation, not document
-            result.doc_id = ""
-            return result
-        except HTTPException:
-            raise
-        except Exception as e:
-            error_msg = f"Error deleting entity '{request.entity_name}': {str(e)}"
-            logger.error(error_msg)
-            logger.error(traceback.format_exc())
-            raise HTTPException(status_code=500, detail=error_msg)
-
-    @router.delete(
-        "/delete_relation",
-        response_model=DeletionResult,
-        dependencies=[Depends(combined_auth)],
-    )
-    async def delete_relation(request: DeleteRelationRequest):
-        """
-        Delete a relationship between two entities from the knowledge graph.
-
-        Args:
-            request (DeleteRelationRequest): The request body containing the source and target entity names.
-
-        Returns:
-            DeletionResult: An object containing the outcome of the deletion process.
-
-        Raises:
-            HTTPException: If the relation is not found (404) or an error occurs (500).
-        """
-        try:
-            await check_pipeline_busy_or_raise(rag)
-            result = await rag.adelete_by_relation(
-                source_entity=request.source_entity,
-                target_entity=request.target_entity,
-            )
-            if result.status == "not_found":
-                raise HTTPException(status_code=404, detail=result.message)
-            if result.status == "fail":
-                raise HTTPException(status_code=500, detail=result.message)
-            # Set doc_id to empty string since this is a relation operation, not document
-            result.doc_id = ""
-            return result
-        except HTTPException:
-            raise
-        except Exception as e:
-            error_msg = f"Error deleting relation from '{request.source_entity}' to '{request.target_entity}': {str(e)}"
-            logger.error(error_msg)
-            logger.error(traceback.format_exc())
-            raise HTTPException(status_code=500, detail=error_msg)
 
     @router.get(
         "/track_status/{track_id}",

--- a/lightrag/api/routers/graph_routes.py
+++ b/lightrag/api/routers/graph_routes.py
@@ -5,8 +5,9 @@ This module contains all graph-related routes for the LightRAG API.
 from typing import Optional, Dict, Any
 import traceback
 from fastapi import APIRouter, Depends, Query, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
+from lightrag.base import DeletionResult
 from lightrag.utils import logger
 from ..utils_api import get_combined_auth_dependency
 from .document_routes import check_pipeline_busy_or_raise
@@ -57,6 +58,29 @@ class EntityCreateRequest(BaseModel):
             }
         ],
     )
+
+
+class DeleteEntityRequest(BaseModel):
+    entity_name: str = Field(..., description="The name of the entity to delete.")
+
+    @field_validator("entity_name", mode="after")
+    @classmethod
+    def validate_entity_name(cls, entity_name: str) -> str:
+        if not entity_name or not entity_name.strip():
+            raise ValueError("Entity name cannot be empty")
+        return entity_name.strip()
+
+
+class DeleteRelationRequest(BaseModel):
+    source_entity: str = Field(..., description="The name of the source entity.")
+    target_entity: str = Field(..., description="The name of the target entity.")
+
+    @field_validator("source_entity", "target_entity", mode="after")
+    @classmethod
+    def validate_entity_names(cls, entity_name: str) -> str:
+        if not entity_name or not entity_name.strip():
+            raise ValueError("Entity name cannot be empty")
+        return entity_name.strip()
 
 
 class RelationCreateRequest(BaseModel):
@@ -704,5 +728,80 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             raise HTTPException(
                 status_code=500, detail=f"Error merging entities: {str(e)}"
             )
+
+    @router.delete(
+        "/graph/entity/delete",
+        response_model=DeletionResult,
+        dependencies=[Depends(combined_auth)],
+    )
+    async def delete_entity(request: DeleteEntityRequest):
+        """
+        Delete an entity and all its relationships from the knowledge graph.
+
+        Args:
+            request (DeleteEntityRequest): The request body containing the entity name.
+
+        Returns:
+            DeletionResult: An object containing the outcome of the deletion process.
+
+        Raises:
+            HTTPException: If the entity is not found (404) or an error occurs (500).
+        """
+        try:
+            await check_pipeline_busy_or_raise(rag)
+            result = await rag.adelete_by_entity(entity_name=request.entity_name)
+            if result.status == "not_found":
+                raise HTTPException(status_code=404, detail=result.message)
+            if result.status == "fail":
+                raise HTTPException(status_code=500, detail=result.message)
+            # Set doc_id to empty string since this is an entity operation, not document
+            result.doc_id = ""
+            return result
+        except HTTPException:
+            raise
+        except Exception as e:
+            error_msg = f"Error deleting entity '{request.entity_name}': {str(e)}"
+            logger.error(error_msg)
+            logger.error(traceback.format_exc())
+            raise HTTPException(status_code=500, detail=error_msg)
+
+    @router.delete(
+        "/graph/relation/delete",
+        response_model=DeletionResult,
+        dependencies=[Depends(combined_auth)],
+    )
+    async def delete_relation(request: DeleteRelationRequest):
+        """
+        Delete a relationship between two entities from the knowledge graph.
+
+        Args:
+            request (DeleteRelationRequest): The request body containing the source and target entity names.
+
+        Returns:
+            DeletionResult: An object containing the outcome of the deletion process.
+
+        Raises:
+            HTTPException: If the relation is not found (404) or an error occurs (500).
+        """
+        try:
+            await check_pipeline_busy_or_raise(rag)
+            result = await rag.adelete_by_relation(
+                source_entity=request.source_entity,
+                target_entity=request.target_entity,
+            )
+            if result.status == "not_found":
+                raise HTTPException(status_code=404, detail=result.message)
+            if result.status == "fail":
+                raise HTTPException(status_code=500, detail=result.message)
+            # Set doc_id to empty string since this is a relation operation, not document
+            result.doc_id = ""
+            return result
+        except HTTPException:
+            raise
+        except Exception as e:
+            error_msg = f"Error deleting relation from '{request.source_entity}' to '{request.target_entity}': {str(e)}"
+            logger.error(error_msg)
+            logger.error(traceback.format_exc())
+            raise HTTPException(status_code=500, detail=error_msg)
 
     return router

--- a/tests/api/routes/test_graph_routes_pipeline_busy.py
+++ b/tests/api/routes/test_graph_routes_pipeline_busy.py
@@ -8,8 +8,8 @@ with HTTP 409 while the document pipeline is busy:
 - POST /graph/entity/create        (graph_routes)
 - POST /graph/relation/create      (graph_routes)
 - POST /graph/entities/merge       (graph_routes)
-- DELETE /documents/delete_entity  (document_routes)
-- DELETE /documents/delete_relation (document_routes)
+- DELETE /graph/entity/delete      (graph_routes)
+- DELETE /graph/relation/delete    (graph_routes)
 
 The guard logic itself lives in
 ``lightrag.api.routers.document_routes.check_pipeline_busy_or_raise`` and is
@@ -171,13 +171,13 @@ _ENDPOINTS = [
     ),
     pytest.param(
         "DELETE",
-        "/documents/delete_entity",
+        "/graph/entity/delete",
         {"entity_name": "Alice"},
         id="delete_entity",
     ),
     pytest.param(
         "DELETE",
-        "/documents/delete_relation",
+        "/graph/relation/delete",
         {"source_entity": "Alice", "target_entity": "Bob"},
         id="delete_relation",
     ),


### PR DESCRIPTION
## Summary

`/delete_entity` and `/delete_relation` operate on knowledge-graph entities and relations, so they belong under the **graph API** — next to `/graph/entity/edit`, `/graph/entity/create`, `/graph/relation/edit`, `/graph/relation/create`, and `/graph/entities/merge`. They were mistakenly defined in `document_routes.py` and mounted under the `/documents` prefix (OpenAPI `documents` tag).

This PR moves both endpoints (and their request models `DeleteEntityRequest` / `DeleteRelationRequest`) to `graph_routes.py`, and renames the paths to match the existing `/graph/*` naming convention.

## ⚠️ Breaking change

| Before | After |
| --- | --- |
| `DELETE /documents/delete_entity` | `DELETE /graph/entity/delete` |
| `DELETE /documents/delete_relation` | `DELETE /graph/relation/delete` |

The frontend (WebUI) does not call these endpoints, so **no backward-compat shim is provided**. Request bodies and response models (`DeletionResult`) are unchanged; only the path and OpenAPI tag change.

## Changes

- **`graph_routes.py`**: add `DeleteEntityRequest` / `DeleteRelationRequest` models and the two `DELETE` endpoints (logic identical to the originals — `check_pipeline_busy_or_raise` guard, 404/500 handling, `result.doc_id = ""`). Imports `DeletionResult` and `field_validator`.
- **`document_routes.py`**: remove the two endpoints, the two request models, and the now-unused `DeletionResult` import.
- **`tests/api/routes/test_graph_routes_pipeline_busy.py`**: update the pipeline-busy guard test to hit the new graph paths (docstring + `_ENDPOINTS` table). Mocks and assertions unchanged.

## Verification

- `pytest tests/api/routes/test_graph_routes_pipeline_busy.py` — 11 passed (the 7-endpoint busy-guard parametrization now includes both delete endpoints at their new paths).
- `ruff check` on both routers — clean.
- No remaining references to the old paths in `lightrag/` or `tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
