### PR TITLE
🔧 refactor(constants): centralize LLM call priorities and align analysis stage with processing

### DIFF
--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -289,6 +289,28 @@ DEFAULT_MAX_PARALLEL_PARSE_DOCLING = 2
 DEFAULT_QUEUE_SIZE_DEFAULT = 100
 DEFAULT_QUEUE_SIZE_INSERT = 4
 
+# LLM / embedding call priority levels.  Lower values run first
+# (asyncio.PriorityQueue semantics); priority only orders calls *within* a
+# single role queue (extract / keyword / query / vlm).  These name the values
+# passed as the ``_priority`` argument to the priority_limit_async_func_call
+# wrapper, centralizing the magic numbers that were previously inlined at each
+# call site.
+#
+# Query stage (interactive: query/keyword LLM calls and query-time embeddings)
+# gets the highest priority so user requests stay responsive.
+DEFAULT_QUERY_PRIORITY = 5
+# Entity/relation description summary generation — ahead of raw extraction but
+# behind interactive query work.
+DEFAULT_SUMMARY_PRIORITY = 8
+# Processing stage entity/relation extraction (ingestion).  Also the wrapper's
+# baseline default for any call that does not pass ``_priority``.
+DEFAULT_PROCESSING_PRIORITY = 10
+# Priority used for all multimodal analysis LLM calls.  Set equal to
+# DEFAULT_PROCESSING_PRIORITY so analysis and ingestion work share the EXTRACT
+# queue fairly and advance evenly — otherwise a busy ingestion queue starves
+# analysis tasks, stalling analysis nodes and dragging down overall throughput.
+DEFAULT_MM_ANALYSIS_PRIORITY = DEFAULT_PROCESSING_PRIORITY
+
 # Multimodal analysis / chunk thresholds
 # Minimum token count retained when truncating a multimodal chunk's
 # description to fit within DEFAULT_MAX_EXTRACT_INPUT_TOKENS.  Falling below
@@ -299,10 +321,6 @@ DEFAULT_MM_CHUNK_DESCRIPTION_MIN_TOKENS = 100
 # Anything smaller is treated as decorative (icons, separators, etc.) and
 # written as status="skipped".
 DEFAULT_MM_IMAGE_MIN_PIXEL = 32
-# Priority used for all multimodal analysis LLM calls.  Higher numbers run
-# behind entity extraction (priority 10) so a busy ingestion queue still
-# prefers KG-building work.
-DEFAULT_MM_ANALYSIS_PRIORITY = 12
 
 # Embedding configuration defaults
 DEFAULT_EMBEDDING_FUNC_MAX_ASYNC = 8  # Default max async for embedding functions

--- a/lightrag/kg/deprecated/chroma_impl.py
+++ b/lightrag/kg/deprecated/chroma_impl.py
@@ -5,6 +5,7 @@ from typing import Any, final
 import numpy as np
 
 from lightrag.base import BaseVectorStorage
+from lightrag.constants import DEFAULT_QUERY_PRIORITY
 from lightrag.utils import logger
 import pipmaster as pm
 
@@ -168,7 +169,7 @@ class ChromaVectorDBStorage(BaseVectorStorage):
     async def query(self, query: str, top_k: int) -> list[dict[str, Any]]:
         try:
             embedding = await self.embedding_func(
-                [query], _priority=5
+                [query], _priority=DEFAULT_QUERY_PRIORITY
             )  # higher priority for query
 
             results = self._collection.query(

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from lightrag.file_atomic import atomic_write, reap_orphan_tmp_files
 from lightrag.utils import logger, compute_mdhash_id
 from lightrag.base import BaseVectorStorage
+from lightrag.constants import DEFAULT_QUERY_PRIORITY
 
 from .shared_storage import (
     get_namespace_lock,
@@ -394,7 +395,7 @@ class FaissVectorDBStorage(BaseVectorStorage):
             embedding = np.array([query_embedding], dtype=np.float32)
         else:
             embedding = await self.embedding_func(
-                [query], context="query", _priority=5
+                [query], context="query", _priority=DEFAULT_QUERY_PRIORITY
             )  # higher priority for query
             # embedding is shape (1, dim)
             embedding = np.array(embedding, dtype=np.float32)

--- a/lightrag/kg/milvus_impl.py
+++ b/lightrag/kg/milvus_impl.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, fields
 import numpy as np
 from lightrag.utils import logger, compute_mdhash_id, _cooperative_yield
 from ..base import BaseVectorStorage
-from ..constants import DEFAULT_MAX_FILE_PATH_LENGTH
+from ..constants import DEFAULT_MAX_FILE_PATH_LENGTH, DEFAULT_QUERY_PRIORITY
 from ..kg.shared_storage import get_data_init_lock, get_namespace_lock
 import pipmaster as pm
 
@@ -1579,7 +1579,7 @@ class MilvusVectorDBStorage(BaseVectorStorage):
             embedding = [query_embedding]  # Milvus expects a list of embeddings
         else:
             embedding = await self.embedding_func(
-                [query], context="query", _priority=5
+                [query], context="query", _priority=DEFAULT_QUERY_PRIORITY
             )  # higher priority for query
 
         # Include all meta_fields (created_at is now always included)

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -19,7 +19,7 @@ from ..base import (
 )
 from ..utils import logger, compute_mdhash_id, _cooperative_yield, merge_source_ids
 from ..types import KnowledgeGraph, KnowledgeGraphNode, KnowledgeGraphEdge
-from ..constants import GRAPH_FIELD_SEP
+from ..constants import GRAPH_FIELD_SEP, DEFAULT_QUERY_PRIORITY
 from .._version import __version__
 from ..kg.shared_storage import get_data_init_lock, get_namespace_lock
 
@@ -3163,7 +3163,7 @@ class MongoVectorDBStorage(BaseVectorStorage):
         else:
             # Generate the embedding
             embedding = await self.embedding_func(
-                [query], context="query", _priority=5
+                [query], context="query", _priority=DEFAULT_QUERY_PRIORITY
             )  # higher priority for query
             # Convert numpy array to a list to ensure compatibility with MongoDB
             query_vector = embedding[0].tolist()

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -14,6 +14,7 @@ from lightrag.utils import (
 )
 
 from lightrag.base import BaseVectorStorage
+from lightrag.constants import DEFAULT_QUERY_PRIORITY
 from nano_vectordb import NanoVectorDB
 from .shared_storage import (
     get_namespace_lock,
@@ -423,7 +424,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
         else:
             # Execute embedding outside of lock to avoid improve cocurrent
             embedding = await self.embedding_func(
-                [query], context="query", _priority=5
+                [query], context="query", _priority=DEFAULT_QUERY_PRIORITY
             )  # higher priority for query
             embedding = embedding[0]
 

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -29,7 +29,7 @@ from ..base import (
 )
 from ..utils import logger, compute_mdhash_id, _cooperative_yield, merge_source_ids
 from ..types import KnowledgeGraph, KnowledgeGraphNode, KnowledgeGraphEdge
-from ..constants import GRAPH_FIELD_SEP
+from ..constants import GRAPH_FIELD_SEP, DEFAULT_QUERY_PRIORITY
 from ..kg.shared_storage import get_data_init_lock, get_namespace_lock
 
 import pipmaster as pm
@@ -4168,7 +4168,9 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
                 else list(query_embedding)
             )
         else:
-            embedding = await self.embedding_func([query], context="query", _priority=5)
+            embedding = await self.embedding_func(
+                [query], context="query", _priority=DEFAULT_QUERY_PRIORITY
+            )
             query_vector = embedding[0].tolist()
 
         search_body = {

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -34,6 +34,7 @@ from ..base import (
     DocStatus,
     DocStatusStorage,
 )
+from ..constants import DEFAULT_QUERY_PRIORITY
 from ..exceptions import DataMigrationError
 from ..namespace import NameSpace, is_namespace
 from ..utils import (
@@ -4241,7 +4242,7 @@ class PGVectorStorage(BaseVectorStorage):
             embedding = query_embedding
         else:
             embeddings = await self.embedding_func(
-                [query], context="query", _priority=5
+                [query], context="query", _priority=DEFAULT_QUERY_PRIORITY
             )  # higher priority for query
             embedding = embeddings[0]
 

--- a/lightrag/kg/qdrant_impl.py
+++ b/lightrag/kg/qdrant_impl.py
@@ -11,6 +11,7 @@ import numpy as np
 import pipmaster as pm
 
 from ..base import BaseVectorStorage
+from ..constants import DEFAULT_QUERY_PRIORITY
 from ..exceptions import DataMigrationError
 from ..kg.shared_storage import get_data_init_lock, get_namespace_lock
 from ..utils import _cooperative_yield, compute_mdhash_id, logger
@@ -715,7 +716,7 @@ class QdrantVectorDBStorage(BaseVectorStorage):
             embedding = query_embedding
         else:
             embedding_result = await self.embedding_func(
-                [query], context="query", _priority=5
+                [query], context="query", _priority=DEFAULT_QUERY_PRIORITY
             )  # higher priority for query
             embedding = embedding_result[0]
 

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -46,6 +46,7 @@ from lightrag.constants import (
     DEFAULT_MAX_ENTITY_TOKENS,
     DEFAULT_MAX_RELATION_TOKENS,
     DEFAULT_MAX_TOTAL_TOKENS,
+    DEFAULT_SUMMARY_PRIORITY,
     DEFAULT_COSINE_THRESHOLD,
     DEFAULT_RELATED_CHUNK_NUMBER,
     DEFAULT_KG_CHUNK_PICK_METHOD,
@@ -2091,9 +2092,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 )
             elif param.mode == "bypass":
                 # Bypass mode: directly use LLM without knowledge retrieval
-                # Apply higher priority (8) to entity/relation summary tasks
+                # Apply higher priority to entity/relation summary tasks
                 use_llm_func = partial(
-                    global_config["role_llm_funcs"]["query"], _priority=8
+                    global_config["role_llm_funcs"]["query"],
+                    _priority=DEFAULT_SUMMARY_PRIORITY,
                 )
 
                 param.stream = True if param.stream is None else param.stream

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -62,6 +62,8 @@ from lightrag.constants import (
     DEFAULT_MAX_EXTRACT_INPUT_TOKENS,
     DEFAULT_MAX_RELATION_TOKENS,
     DEFAULT_MAX_TOTAL_TOKENS,
+    DEFAULT_QUERY_PRIORITY,
+    DEFAULT_SUMMARY_PRIORITY,
     DEFAULT_RELATED_CHUNK_NUMBER,
     DEFAULT_KG_CHUNK_PICK_METHOD,
     DEFAULT_SUMMARY_LANGUAGE,
@@ -341,7 +343,7 @@ async def _summarize_descriptions(
     """
     use_llm_func: callable = global_config["role_llm_funcs"]["extract"]
     # Apply higher priority (8) to entity/relation summary tasks
-    use_llm_func = partial(use_llm_func, _priority=8)
+    use_llm_func = partial(use_llm_func, _priority=DEFAULT_SUMMARY_PRIORITY)
 
     addon_params = global_config.get("addon_params") or {}
     language = global_config.get("_resolved_summary_language")
@@ -3691,7 +3693,9 @@ async def kg_query(
         return QueryResult(content=PROMPTS["fail_response"])
 
     # Apply higher priority (5) to query relation LLM function
-    use_model_func = partial(global_config["role_llm_funcs"]["query"], _priority=5)
+    use_model_func = partial(
+        global_config["role_llm_funcs"]["query"], _priority=DEFAULT_QUERY_PRIORITY
+    )
     llm_cache_identity = get_llm_cache_identity(global_config, "query")
 
     hl_keywords, ll_keywords = await get_keywords_from_query(
@@ -4068,7 +4072,9 @@ async def extract_keywords_only(
 
     # 4. Call the LLM for keyword extraction
     # Apply higher priority (5) to query relation LLM function
-    use_model_func = partial(global_config["role_llm_funcs"]["keyword"], _priority=5)
+    use_model_func = partial(
+        global_config["role_llm_funcs"]["keyword"], _priority=DEFAULT_QUERY_PRIORITY
+    )
 
     result = await use_model_func(kw_prompt, response_format={"type": "json_object"})
 
@@ -4233,7 +4239,7 @@ async def _perform_kg_search(
         if texts_to_embed:
             try:
                 all_embeddings = await actual_embedding_func(
-                    texts_to_embed, context="query", _priority=5
+                    texts_to_embed, context="query", _priority=DEFAULT_QUERY_PRIORITY
                 )
                 for i, purpose in enumerate(text_purposes):
                     if purpose == "query":
@@ -5580,7 +5586,9 @@ async def naive_query(
         return QueryResult(content=PROMPTS["fail_response"])
 
     # Apply higher priority (5) to query relation LLM function
-    use_model_func = partial(global_config["role_llm_funcs"]["query"], _priority=5)
+    use_model_func = partial(
+        global_config["role_llm_funcs"]["query"], _priority=DEFAULT_QUERY_PRIORITY
+    )
     llm_cache_identity = get_llm_cache_identity(global_config, "query")
 
     tokenizer: Tokenizer = global_config["tokenizer"]

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -41,6 +41,7 @@ from lightrag.constants import (
     DEFAULT_LOG_FILENAME,
     GRAPH_FIELD_SEP,
     DEFAULT_MAX_TOTAL_TOKENS,
+    DEFAULT_PROCESSING_PRIORITY,
     DEFAULT_SOURCE_IDS_LIMIT_METHOD,
     VALID_SOURCE_IDS_LIMIT_METHODS,
     SOURCE_IDS_LIMIT_METHOD_FIFO,
@@ -1241,7 +1242,11 @@ def priority_limit_async_func_call(
 
         @wraps(func)
         async def wait_func(
-            *args, _priority=10, _timeout=None, _queue_timeout=None, **kwargs
+            *args,
+            _priority=DEFAULT_PROCESSING_PRIORITY,
+            _timeout=None,
+            _queue_timeout=None,
+            **kwargs,
         ):
             """
             Execute function with enhanced priority-based concurrency control and timeout handling


### PR DESCRIPTION
## Description

Multimodal **analysis-stage** LLM calls (drawing VLM analysis, table/equation EXTRACT analysis) used `DEFAULT_MM_ANALYSIS_PRIORITY = 12`, while **processing-stage** entity/relation extraction uses the wrapper's default priority `10`. Since lower numbers run first (`asyncio.PriorityQueue` semantics) and the table/equation analysis calls go through the **same `extract` role queue** as processing-stage entity extraction, a busy ingestion queue (priority 10) continually preempted analysis tasks (priority 12). Analysis nodes were starved and stalled, dragging down overall throughput once the processing queue drained but still waited on analysis output.

This PR sets the analysis priority equal to the processing priority so both advance evenly (fair, FIFO-style interleaving within the shared queue), and centralizes every previously inlined `_priority` literal into named constants so the priority scheme has a single source of truth.

## Related Issues

N/A

## Changes Made

- Added named priority constants in `lightrag/constants.py`:
  - `DEFAULT_QUERY_PRIORITY = 5` — interactive query / keyword LLM calls and query-time embeddings
  - `DEFAULT_SUMMARY_PRIORITY = 8` — entity/relation description summary generation
  - `DEFAULT_PROCESSING_PRIORITY = 10` — ingestion extraction; also the `priority_limit_async_func_call` wrapper default
- `DEFAULT_MM_ANALYSIS_PRIORITY` now references `DEFAULT_PROCESSING_PRIORITY` (effectively `12 → 10`), making the "analysis == processing" intent explicit in code.
- Replaced all hardcoded `_priority` literals with the constants across:
  - `lightrag/utils.py` (wrapper default), `lightrag/operate.py`, `lightrag/lightrag.py`
  - All vector-DB backends: `qdrant`, `mongo`, `faiss`, `postgres`, `nano_vector_db`, `opensearch`, `milvus`, and deprecated `chroma`
- No public interfaces added/removed; existing priority ordering (5 < 8 < 10) is preserved — only the analysis stage moves from 12 to 10.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

- Each LLM role (`extract` / `keyword` / `query` / `vlm`) has its own priority queue; priority only orders calls *within* a queue. The cross-stage contention this PR fixes is specifically in the shared **`extract`** queue (analysis table/equation extraction vs. processing entity extraction). The VLM call has its own analysis-only queue, so its value change is a no-op in practice but kept consistent via the shared constant.
- `grep -rn "_priority=[0-9]" lightrag/` returns no remaining hardcoded literals.
- `tests/pipeline/test_pipeline_analyze_multimodal.py` passes (15 passed). That suite asserts `_priority` is consumed by the wrapper (not observable on the raw mock) and references the constant by name, so it remains accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
