### PR TITLE
Replace sys.exit with exceptions in DOCX parser validation

### DIFF
--- a/lightrag/parser/cli.py
+++ b/lightrag/parser/cli.py
@@ -141,6 +141,7 @@ async def _run(args: argparse.Namespace) -> int:
         PARSER_ENGINE_SUFFIX_CAPABILITIES,
     )
     from lightrag.parser.debug import build_debug_rag
+    from lightrag.parser.docx.parse_document import DocxContentError
     from lightrag.utils import compute_mdhash_id
     import lightrag.pipeline as pipeline_mod
     import lightrag.utils_pipeline as utils_pipeline_mod
@@ -243,14 +244,22 @@ async def _run(args: argparse.Namespace) -> int:
             )
         )
 
-        result = await parse_method(
-            doc_id,
-            str(source),
-            {
-                "parse_format": FULL_DOCS_FORMAT_PENDING_PARSE,
-                "content": "",
-            },
-        )
+        try:
+            result = await parse_method(
+                doc_id,
+                str(source),
+                {
+                    "parse_format": FULL_DOCS_FORMAT_PENDING_PARSE,
+                    "content": "",
+                },
+            )
+        except DocxContentError as exc:
+            # The native DOCX parser now raises (instead of sys.exit) on a
+            # content-limit violation so the server pipeline can fail just the
+            # offending document. Preserve the friendly CLI UX: print the
+            # formatted message and return a non-zero exit code, no traceback.
+            print(str(exc), file=sys.stderr)
+            return 1
 
     blocks_path = Path(result["blocks_path"])
     _print_summary(blocks_path, raw_dir, args.preview)

--- a/lightrag/parser/docx/parse_document.py
+++ b/lightrag/parser/docx/parse_document.py
@@ -9,12 +9,13 @@ import sys
 
 try:
     from docx import Document
-except ImportError:
-    print(
-        "Error: python-docx not installed. Run: pip install python-docx",
-        file=sys.stderr,
-    )
-    sys.exit(1)
+except ImportError as exc:
+    # Raise instead of sys.exit: this module is imported in-process by the
+    # gunicorn/uvicorn worker, where a SystemExit would tear down the whole
+    # worker rather than surfacing a normal, catchable error.
+    raise ImportError(
+        "python-docx not installed. Run: pip install python-docx"
+    ) from exc
 
 from lightrag.parser._markdown import (
     render_heading_line,
@@ -61,22 +62,46 @@ _SKIP_COMMENT_TAGS = frozenset(
 _SKIP_PARAGRAPH_TAGS = _SKIP_REVISION_TAGS | _SKIP_COMMENT_TAGS
 
 
-def print_error(title: str, details: str, solution: str):
+class DocxContentError(ValueError):
+    """DOCX content violates a parsing constraint (heading/table/anchor limits).
+
+    Raised instead of calling ``sys.exit`` so the pipeline's per-document
+    ``except Exception`` handler marks just that document FAILED while the
+    gunicorn/uvicorn worker process keeps running. Subclasses ``ValueError``
+    (i.e. an ``Exception``, not ``BaseException``) so the existing pipeline
+    handlers catch it.
     """
-    Print a friendly, formatted error message.
+
+
+def format_error(title: str, details: str, solution: str) -> str:
+    """
+    Build a friendly, formatted error message (title / details / SOLUTION).
 
     Args:
         title: Error title
         details: Detailed error information
         solution: Suggested solution steps
+
+    Returns:
+        str: The formatted multi-line message.
     """
-    print("\n" + "=" * 80, file=sys.stderr)
-    print(f"ERROR: {title}", file=sys.stderr)
-    print("=" * 80, file=sys.stderr)
-    print(f"\n{details}", file=sys.stderr)
-    print("\nSOLUTION:", file=sys.stderr)
-    print(solution, file=sys.stderr)
-    print("\n" + "=" * 80 + "\n", file=sys.stderr)
+    return (
+        "\n"
+        + "=" * 80
+        + f"\nERROR: {title}\n"
+        + "=" * 80
+        + f"\n\n{details}"
+        + "\n\nSOLUTION:\n"
+        + solution
+        + "\n\n"
+        + "=" * 80
+        + "\n"
+    )
+
+
+def print_error(title: str, details: str, solution: str):
+    """Print a friendly, formatted error message to stderr."""
+    print(format_error(title, details, solution), file=sys.stderr)
 
 
 def truncate_heading(heading_text: str, para_id: str = None) -> str:
@@ -110,23 +135,24 @@ def validate_heading_length(heading_text: str, para_id: str):
         heading_text: The heading text to validate
         para_id: The paragraph ID for error reporting
 
-    Exits:
-        sys.exit(1) if heading exceeds maximum length
+    Raises:
+        DocxContentError: if heading exceeds maximum length
     """
     if len(heading_text) > MAX_HEADING_LENGTH:
         preview = (
             heading_text[:100] + "..." if len(heading_text) > 100 else heading_text
         )
-        print_error(
-            f"Heading too long ({len(heading_text)} characters, max {MAX_HEADING_LENGTH})",
-            f'The following heading exceeds the maximum allowed length:\n\n  "{preview}"\n\n'
-            f"Location: Paragraph ID {para_id}\n"
-            f"Actual length: {len(heading_text)} characters",
-            "  1. Open the document in Microsoft Word\n"
-            f"  2. Shorten this heading to {MAX_HEADING_LENGTH} characters or less\n"
-            "  3. Re-upload it to LightRAG",
+        raise DocxContentError(
+            format_error(
+                f"Heading too long ({len(heading_text)} characters, max {MAX_HEADING_LENGTH})",
+                f'The following heading exceeds the maximum allowed length:\n\n  "{preview}"\n\n'
+                f"Location: Paragraph ID {para_id}\n"
+                f"Actual length: {len(heading_text)} characters",
+                "  1. Open the document in Microsoft Word\n"
+                f"  2. Shorten this heading to {MAX_HEADING_LENGTH} characters or less\n"
+                "  3. Re-upload it to LightRAG",
+            )
         )
-        sys.exit(1)
 
 
 def validate_table_tokens(table_json: str, block_heading: str):
@@ -137,24 +163,25 @@ def validate_table_tokens(table_json: str, block_heading: str):
         table_json: The JSON representation of the table
         block_heading: The heading of the block containing this table
 
-    Exits:
-        sys.exit(1) if table exceeds maximum token limit
+    Raises:
+        DocxContentError: if table exceeds maximum token limit
     """
     table_tokens = estimate_tokens(table_json)
     if table_tokens > MAX_BLOCK_CONTENT_TOKENS:
-        print_error(
-            f"Table too large (~{table_tokens} tokens, max {MAX_BLOCK_CONTENT_TOKENS})",
-            f"A table in the document is too large for LLM processing.\n\n"
-            f'Location: Under heading "{block_heading}"\n'
-            f"Table size: ~{table_tokens} tokens ({len(table_json)} characters)\n\n"
-            "Large tables can cause issues with file chunking.",
-            "  1. Open the document in Microsoft Word\n"
-            f'  2. Locate the table under heading "{block_heading}"\n'
-            "  3. Split the table into smaller tables, or\n"
-            "  4. Simplify the table content\n"
-            "  5. Re-upload it to LightRAG",
+        raise DocxContentError(
+            format_error(
+                f"Table too large (~{table_tokens} tokens, max {MAX_BLOCK_CONTENT_TOKENS})",
+                f"A table in the document is too large for LLM processing.\n\n"
+                f'Location: Under heading "{block_heading}"\n'
+                f"Table size: ~{table_tokens} tokens ({len(table_json)} characters)\n\n"
+                "Large tables can cause issues with file chunking.",
+                "  1. Open the document in Microsoft Word\n"
+                f'  2. Locate the table under heading "{block_heading}"\n'
+                "  3. Split the table into smaller tables, or\n"
+                "  4. Simplify the table content\n"
+                "  5. Re-upload it to LightRAG",
+            )
         )
-        sys.exit(1)
 
 
 def find_first_valid_para_id(para_ids: list) -> str | None:
@@ -884,8 +911,8 @@ def split_long_block(
     Returns:
         List of block dictionaries (may be split into multiple blocks), each with 'level' field
 
-    Exits:
-        sys.exit(1) if no suitable anchor found and content exceeds limit
+    Raises:
+        DocxContentError: if no suitable anchor found and content exceeds limit
     """
     import math
 
@@ -961,20 +988,21 @@ def split_long_block(
         preview = (
             block_heading[:80] + "..." if len(block_heading) > 80 else block_heading
         )
-        print_error(
-            "Cannot split long block (no suitable anchor paragraphs found)",
-            f"A text block is too long (~{total_tokens} tokens, max {MAX_BLOCK_CONTENT_TOKENS})\n"
-            f"but no paragraphs <= {MAX_ANCHOR_CANDIDATE_LENGTH} characters were found to use as split points.\n\n"
-            f'Location: Under heading "{preview}"\n'
-            f"Block size: ~{total_tokens} tokens ({len(total_content)} characters)\n"
-            f"Number of paragraphs: {len(paragraphs)}\n"
-            f"Calculated target blocks: {target_blocks}",
-            "  1. Open the document in Microsoft Word\n"
-            f'  2. Locate the section under heading "{preview}"\n'
-            f"  3. Add short headings or paragraph breaks (≤{MAX_ANCHOR_CANDIDATE_LENGTH} chars) to divide the content\n"
-            "  4. Re-upload it to LightRAG",
+        raise DocxContentError(
+            format_error(
+                "Cannot split long block (no suitable anchor paragraphs found)",
+                f"A text block is too long (~{total_tokens} tokens, max {MAX_BLOCK_CONTENT_TOKENS})\n"
+                f"but no paragraphs <= {MAX_ANCHOR_CANDIDATE_LENGTH} characters were found to use as split points.\n\n"
+                f'Location: Under heading "{preview}"\n'
+                f"Block size: ~{total_tokens} tokens ({len(total_content)} characters)\n"
+                f"Number of paragraphs: {len(paragraphs)}\n"
+                f"Calculated target blocks: {target_blocks}",
+                "  1. Open the document in Microsoft Word\n"
+                f'  2. Locate the section under heading "{preview}"\n'
+                f"  3. Add short headings or paragraph breaks (≤{MAX_ANCHOR_CANDIDATE_LENGTH} chars) to divide the content\n"
+                "  4. Re-upload it to LightRAG",
+            )
         )
-        sys.exit(1)
 
     # Select anchors for splitting (target_blocks - 1 split points needed)
     selected_anchors = []
@@ -1087,14 +1115,15 @@ def split_long_block(
                     if len(block["heading"]) > 80
                     else block["heading"]
                 )
-                print_error(
-                    "Cannot re-split oversized block (internal error)",
-                    f"A block exceeded MAX_BLOCK_CONTENT_TOKENS but paragraph metadata was lost.\n\n"
-                    f"Location: Under heading \"{preview}\"\n"
-                    f"Block size: ~{block_tokens} tokens ({len(block['content'])} characters)",
-                    "This is an internal error. Please report this issue.",
+                raise DocxContentError(
+                    format_error(
+                        "Cannot re-split oversized block (internal error)",
+                        f"A block exceeded MAX_BLOCK_CONTENT_TOKENS but paragraph metadata was lost.\n\n"
+                        f"Location: Under heading \"{preview}\"\n"
+                        f"Block size: ~{block_tokens} tokens ({len(block['content'])} characters)",
+                        "This is an internal error. Please report this issue.",
+                    )
                 )
-                sys.exit(1)
 
             # Recursively split this oversized block
             # The recursive call will either find more anchors or raise an error

--- a/tests/parser/docx/test_validation_raises.py
+++ b/tests/parser/docx/test_validation_raises.py
@@ -1,0 +1,55 @@
+"""Native DOCX content-limit validation must *raise*, never ``sys.exit``.
+
+The DOCX parser runs in-process inside the gunicorn/uvicorn worker (via
+``LightRAG.parse_native`` → ``extract_docx_blocks``). A ``sys.exit`` there
+raises ``SystemExit`` (a ``BaseException``), which slips past the pipeline's
+per-document ``except Exception`` handler and tears down the whole worker —
+gunicorn then reports ``WORKER TIMEOUT`` and kills it with SIGABRT (code 134),
+interrupting the entire processing pipeline.
+
+These tests lock in that the content-limit checks raise ``DocxContentError``
+(an ``Exception`` subclass) so just the offending document fails while the
+worker keeps running.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lightrag.parser.docx.parse_document import (
+    DocxContentError,
+    MAX_BLOCK_CONTENT_TOKENS,
+    MAX_HEADING_LENGTH,
+    validate_heading_length,
+    validate_table_tokens,
+)
+
+
+def test_docx_content_error_is_an_exception_not_just_baseexception():
+    # The pipeline parse worker catches ``except Exception``; SystemExit
+    # (BaseException) would bypass it. Guard against a future regression that
+    # reintroduces a BaseException-only error type.
+    assert issubclass(DocxContentError, Exception)
+
+
+def test_validate_heading_length_raises_instead_of_exiting():
+    long_heading = "x" * (MAX_HEADING_LENGTH + 213)  # mirrors the 413-char report
+    with pytest.raises(DocxContentError) as exc_info:
+        validate_heading_length(long_heading, "p1")
+    message = str(exc_info.value)
+    assert f"Heading too long ({len(long_heading)} characters" in message
+    assert "SOLUTION:" in message
+
+
+def test_validate_heading_length_does_not_raise_within_limit():
+    # Exactly at the limit and below must pass through silently.
+    validate_heading_length("x" * MAX_HEADING_LENGTH, "p2")
+    validate_heading_length("short heading", "p3")
+
+
+def test_validate_table_tokens_raises_instead_of_exiting():
+    # estimate_tokens(json) > MAX_BLOCK_CONTENT_TOKENS for this payload.
+    oversized_table = "a" * (MAX_BLOCK_CONTENT_TOKENS * 8)
+    with pytest.raises(DocxContentError) as exc_info:
+        validate_table_tokens(oversized_table, "Some Heading")
+    assert "Table too large" in str(exc_info.value)


### PR DESCRIPTION
## Description

Replace `sys.exit()` calls with proper exception raising in the DOCX parser's content validation functions. This prevents worker process teardown when validation fails, allowing the pipeline to mark only the offending document as failed while keeping the gunicorn/uvicorn worker alive.

## Related Issues

Addresses worker timeout issues when DOCX documents violate content constraints (heading length, table size, block size).

## Changes Made

- **New `DocxContentError` exception class**: A `ValueError` subclass raised instead of calling `sys.exit()` for content-limit violations. Subclassing `Exception` (not `BaseException`) ensures the pipeline's per-document exception handler catches it.

- **Refactored error formatting**: 
  - Extracted `print_error()` logic into a new `format_error()` function that returns a formatted string
  - `print_error()` now calls `format_error()` and prints to stderr
  - Error messages can now be included in exception messages

- **Updated validation functions** to raise `DocxContentError` instead of calling `sys.exit()`:
  - `validate_heading_length()`: Raises on heading exceeding `MAX_HEADING_LENGTH`
  - `validate_table_tokens()`: Raises on table exceeding `MAX_BLOCK_CONTENT_TOKENS`
  - `split_long_block()`: Raises when no suitable anchor paragraphs found or on internal errors

- **Updated import error handling**: Changed `python-docx` import failure from `sys.exit(1)` to raising `ImportError` with context, preventing worker teardown in in-process scenarios.

- **CLI error handling**: Added try-catch in `cli.py` to gracefully handle `DocxContentError`, printing the formatted message and returning exit code 1 without a traceback.

- **Added comprehensive tests** (`test_validation_raises.py`):
  - Verifies `DocxContentError` is an `Exception` subclass
  - Tests that validation functions raise instead of exiting
  - Tests that validation passes for content within limits

## Checklist

- [x] Changes tested locally (new unit tests added)
- [x] Code reviewed for exception safety
- [x] Documentation updated (docstrings clarified)
- [x] Unit tests added for validation behavior

## Additional Notes

This change is critical for production stability. When the DOCX parser runs in-process within a gunicorn/uvicorn worker, `sys.exit()` raises `SystemExit` (a `BaseException`), which bypasses the pipeline's per-document `except Exception` handler and tears down the entire worker process. By raising `DocxContentError` (an `Exception` subclass) instead, only the offending document fails while the worker continues processing other documents.

https://claude.ai/code/session_0151ifHFVczTZSSSGsYa6a7A