### PR TITLE
♻️ refactor(webui): split document status filter tabs

### DIFF
--- a/lightrag_webui/src/features/DocumentManager.tsx
+++ b/lightrag_webui/src/features/DocumentManager.tsx
@@ -57,7 +57,7 @@ type StatusDisplayConfig = {
   className: string
 }
 
-const STATUS_BUCKETS: StatusBucket[] = ['processed', 'analyzing', 'processing', 'pending', 'failed']
+const STATUS_BUCKETS: StatusBucket[] = ['completed', 'parse', 'analyze', 'process', 'failed']
 
 // Utility functions defined outside component for better performance and to avoid dependency issues
 const getCountValue = (counts: Record<string, number>, ...keys: string[]): number => {
@@ -85,7 +85,8 @@ const buildLegacyDocs = (documents: DocStatusResponse[]): DocsStatusesResponse =
   }, {} as Record<StatusBucket, DocStatusResponse[]>)
 
   documents.forEach((doc) => {
-    statuses[getStatusBucket(doc.status)].push(doc)
+    const bucket = getStatusBucket(doc.status)
+    if (bucket) statuses[bucket].push(doc)
   })
 
   return { statuses }
@@ -434,10 +435,10 @@ export default function DocumentManager() {
   // State to store page number for each status filter
   const [pageByStatus, setPageByStatus] = useState<Record<StatusFilter, number>>({
     all: 1,
-    processed: 1,
-    analyzing: 1,
-    processing: 1,
-    pending: 1,
+    completed: 1,
+    parse: 1,
+    analyze: 1,
+    process: 1,
     failed: 1,
   });
 
@@ -513,10 +514,10 @@ export default function DocumentManager() {
     // Reset all status filters' page memory since sorting affects all
     setPageByStatus({
       all: 1,
-      processed: 1,
-      analyzing: 1,
-      processing: 1,
-      pending: 1,
+      completed: 1,
+      parse: 1,
+      analyze: 1,
+      process: 1,
       failed: 1,
     });
   };
@@ -694,26 +695,17 @@ export default function DocumentManager() {
     return counts;
   }, [docs]);
 
-  const processedCount = getCountValue(statusCounts, 'PROCESSED', 'processed') || documentCounts.processed || 0;
-  const analyzingCount =
-    getAggregateCount(statusCounts, 'PARSING', 'parsing', 'ANALYZING', 'analyzing', 'PREPROCESSED', 'preprocessed') ||
-    documentCounts.analyzing ||
-    0;
-  const processingCount =
-    getAggregateCount(statusCounts, 'PROCESSING', 'processing') ||
-    documentCounts.processing ||
-    0;
-  const pendingCount = getCountValue(statusCounts, 'PENDING', 'pending') || documentCounts.pending || 0;
+  const completedCount = getCountValue(statusCounts, 'PROCESSED', 'processed') || documentCounts.completed || 0;
+  const parseCount = getCountValue(statusCounts, 'PARSING', 'parsing') || documentCounts.parse || 0;
+  const analyzeCount = getCountValue(statusCounts, 'ANALYZING', 'analyzing') || documentCounts.analyze || 0;
+  const processCount = getCountValue(statusCounts, 'PROCESSING', 'processing') || documentCounts.process || 0;
   const failedCount = getCountValue(statusCounts, 'FAILED', 'failed') || documentCounts.failed || 0;
 
   // Store previous status counts
-  const prevStatusCounts = useRef({
-    processed: 0,
-    analyzing: 0,
-    processing: 0,
-    pending: 0,
-    failed: 0
-  })
+  // Fingerprint of per-bucket counts. Kept key-agnostic on purpose: `docs.statuses`
+  // may be keyed by raw DocStatus (backend) or by filter bucket (buildLegacyDocs),
+  // so we compare a stable digest of all buckets rather than fixed keys.
+  const prevStatusFingerprint = useRef('')
 
   // Add pulse style to document
   useEffect(() => {
@@ -848,10 +840,10 @@ export default function DocumentManager() {
     // Reset all status filters to page 1 when page size changes
     setPageByStatus({
       all: 1,
-      processed: 1,
-      analyzing: 1,
-      processing: 1,
-      pending: 1,
+      completed: 1,
+      parse: 1,
+      analyze: 1,
+      process: 1,
       failed: 1,
     });
 
@@ -1236,29 +1228,23 @@ export default function DocumentManager() {
   useEffect(() => {
     if (!docs) return;
 
-    // Get new status counts
-    const newStatusCounts = {
-      processed: docs?.statuses?.processed?.length || 0,
-      analyzing: docs?.statuses?.analyzing?.length || 0,
-      processing: docs?.statuses?.processing?.length || 0,
-      pending: docs?.statuses?.pending?.length || 0,
-      failed: docs?.statuses?.failed?.length || 0
-    }
+    // Build a key-agnostic digest of every status bucket's count. Sorting keeps
+    // it stable regardless of object iteration order or whether buckets are keyed
+    // by raw DocStatus or by filter bucket.
+    const fingerprint = Object.entries(docs.statuses)
+      .map(([key, list]) => `${key}:${list?.length || 0}`)
+      .sort()
+      .join('|')
 
-    // Check if any status count has changed
-    const hasStatusCountChange = (Object.keys(newStatusCounts) as Array<keyof typeof newStatusCounts>).some(
-      status => newStatusCounts[status] !== prevStatusCounts.current[status]
-    )
-
-    // Trigger health check if changes detected and component is still mounted.
-    // Skip when the activity probe is running — the probe already drives /health
-    // on its own schedule, and double-firing would burn cache and skew rate.
-    if (hasStatusCountChange && isMountedRef.current && !probeActiveRef.current) {
+    // Trigger health check if any bucket count changed and component is still
+    // mounted. Skip when the activity probe is running — the probe already drives
+    // /health on its own schedule, and double-firing would burn cache and skew rate.
+    if (fingerprint !== prevStatusFingerprint.current && isMountedRef.current && !probeActiveRef.current) {
       useBackendState.getState().check()
     }
 
     // Always update the snapshot so the first post-probe transition still fires.
-    prevStatusCounts.current = newStatusCounts
+    prevStatusFingerprint.current = fingerprint
   }, [docs]);
 
   // Handle page change - only update state
@@ -1483,51 +1469,51 @@ export default function DocumentManager() {
                   </Button>
                   <Button
                     size="sm"
-                    variant={statusFilter === 'processed' ? 'secondary' : 'outline'}
-                    onClick={() => handleStatusFilterChange('processed')}
+                    variant={statusFilter === 'completed' ? 'secondary' : 'outline'}
+                    onClick={() => handleStatusFilterChange('completed')}
                     disabled={isRefreshing}
                     className={cn(
-                      processedCount > 0 ? 'text-green-600' : 'text-gray-500',
-                      statusFilter === 'processed' && 'bg-green-100 dark:bg-green-900/30 font-medium border border-green-400 dark:border-green-600 shadow-sm'
+                      completedCount > 0 ? 'text-green-600' : 'text-gray-500',
+                      statusFilter === 'completed' && 'bg-green-100 dark:bg-green-900/30 font-medium border border-green-400 dark:border-green-600 shadow-sm'
                     )}
                   >
-                    {t('documentPanel.documentManager.filters.completed')} ({processedCount})
+                    {t('documentPanel.documentManager.filters.completed')} ({completedCount})
                   </Button>
                   <Button
                     size="sm"
-                    variant={statusFilter === 'analyzing' ? 'secondary' : 'outline'}
-                    onClick={() => handleStatusFilterChange('analyzing')}
+                    variant={statusFilter === 'parse' ? 'secondary' : 'outline'}
+                    onClick={() => handleStatusFilterChange('parse')}
                     disabled={isRefreshing}
                     className={cn(
-                      analyzingCount > 0 ? 'text-indigo-600' : 'text-gray-500',
-                      statusFilter === 'analyzing' && 'bg-indigo-100 dark:bg-indigo-900/30 font-medium border border-indigo-400 dark:border-indigo-600 shadow-sm'
+                      parseCount > 0 ? 'text-cyan-600' : 'text-gray-500',
+                      statusFilter === 'parse' && 'bg-cyan-100 dark:bg-cyan-900/30 font-medium border border-cyan-400 dark:border-cyan-600 shadow-sm'
                     )}
                   >
-                    {t('documentPanel.documentManager.filters.analyzing')} ({analyzingCount})
+                    {t('documentPanel.documentManager.filters.parse')} ({parseCount})
                   </Button>
                   <Button
                     size="sm"
-                    variant={statusFilter === 'processing' ? 'secondary' : 'outline'}
-                    onClick={() => handleStatusFilterChange('processing')}
+                    variant={statusFilter === 'analyze' ? 'secondary' : 'outline'}
+                    onClick={() => handleStatusFilterChange('analyze')}
                     disabled={isRefreshing}
                     className={cn(
-                      processingCount > 0 ? 'text-blue-600' : 'text-gray-500',
-                      statusFilter === 'processing' && 'bg-blue-100 dark:bg-blue-900/30 font-medium border border-blue-400 dark:border-blue-600 shadow-sm'
+                      analyzeCount > 0 ? 'text-indigo-600' : 'text-gray-500',
+                      statusFilter === 'analyze' && 'bg-indigo-100 dark:bg-indigo-900/30 font-medium border border-indigo-400 dark:border-indigo-600 shadow-sm'
                     )}
                   >
-                    {t('documentPanel.documentManager.filters.processing')} ({processingCount})
+                    {t('documentPanel.documentManager.filters.analyze')} ({analyzeCount})
                   </Button>
                   <Button
                     size="sm"
-                    variant={statusFilter === 'pending' ? 'secondary' : 'outline'}
-                    onClick={() => handleStatusFilterChange('pending')}
+                    variant={statusFilter === 'process' ? 'secondary' : 'outline'}
+                    onClick={() => handleStatusFilterChange('process')}
                     disabled={isRefreshing}
                     className={cn(
-                      pendingCount > 0 ? 'text-yellow-600' : 'text-gray-500',
-                      statusFilter === 'pending' && 'bg-yellow-100 dark:bg-yellow-900/30 font-medium border border-yellow-400 dark:border-yellow-600 shadow-sm'
+                      processCount > 0 ? 'text-blue-600' : 'text-gray-500',
+                      statusFilter === 'process' && 'bg-blue-100 dark:bg-blue-900/30 font-medium border border-blue-400 dark:border-blue-600 shadow-sm'
                     )}
                   >
-                    {t('documentPanel.documentManager.filters.pending')} ({pendingCount})
+                    {t('documentPanel.documentManager.filters.process')} ({processCount})
                   </Button>
                   <Button
                     size="sm"

--- a/lightrag_webui/src/features/documentStatusFilters.test.ts
+++ b/lightrag_webui/src/features/documentStatusFilters.test.ts
@@ -3,24 +3,21 @@ import { describe, expect, test } from 'bun:test'
 import { getStatusRequestFilters, matchesStatusFilter } from '@/features/documentStatusFilters'
 
 describe('documentStatusFilters', () => {
-  test('builds grouped request filters for analyzing tab', () => {
-    expect(getStatusRequestFilters('analyzing')).toEqual({
-      status_filter: null,
-      status_filters: ['preprocessed', 'parsing', 'analyzing']
-    })
-  })
-
-  test('builds exact request filters for non-grouped tabs', () => {
-    expect(getStatusRequestFilters('processing')).toEqual({
-      status_filter: 'processing',
-      status_filters: null
-    })
-    expect(getStatusRequestFilters('processed')).toEqual({
+  test('builds exact single-status request filters for each tab', () => {
+    expect(getStatusRequestFilters('completed')).toEqual({
       status_filter: 'processed',
       status_filters: null
     })
-    expect(getStatusRequestFilters('pending')).toEqual({
-      status_filter: 'pending',
+    expect(getStatusRequestFilters('parse')).toEqual({
+      status_filter: 'parsing',
+      status_filters: null
+    })
+    expect(getStatusRequestFilters('analyze')).toEqual({
+      status_filter: 'analyzing',
+      status_filters: null
+    })
+    expect(getStatusRequestFilters('process')).toEqual({
+      status_filter: 'processing',
       status_filters: null
     })
     expect(getStatusRequestFilters('failed')).toEqual({
@@ -36,9 +33,17 @@ describe('documentStatusFilters', () => {
     })
   })
 
-  test('matches grouped statuses for analyzing tab', () => {
-    expect(matchesStatusFilter('parsing', 'analyzing')).toBe(true)
-    expect(matchesStatusFilter('preprocessed', 'analyzing')).toBe(true)
-    expect(matchesStatusFilter('processing', 'analyzing')).toBe(false)
+  test('matches a single status per non-all tab', () => {
+    expect(matchesStatusFilter('parsing', 'parse')).toBe(true)
+    expect(matchesStatusFilter('analyzing', 'analyze')).toBe(true)
+    expect(matchesStatusFilter('processing', 'process')).toBe(true)
+    expect(matchesStatusFilter('analyzing', 'parse')).toBe(false)
+    expect(matchesStatusFilter('preprocessed', 'analyze')).toBe(false)
+  })
+
+  test('the all tab matches every status, including deprecated and hidden ones', () => {
+    expect(matchesStatusFilter('pending', 'all')).toBe(true)
+    expect(matchesStatusFilter('preprocessed', 'all')).toBe(true)
+    expect(matchesStatusFilter('processed', 'all')).toBe(true)
   })
 })

--- a/lightrag_webui/src/features/documentStatusFilters.ts
+++ b/lightrag_webui/src/features/documentStatusFilters.ts
@@ -1,61 +1,45 @@
 import type { DocStatus, DocumentsRequest } from '@/api/lightrag'
 
-export type StatusBucket = 'processed' | 'analyzing' | 'processing' | 'pending' | 'failed'
+export type StatusBucket = 'completed' | 'parse' | 'analyze' | 'process' | 'failed'
 export type StatusFilter = StatusBucket | 'all'
 
-const ANALYZING_STATUS_FILTERS: DocStatus[] = ['preprocessed', 'parsing', 'analyzing']
-
-export const getStatusBucket = (status: DocStatus): StatusBucket => {
-  if (ANALYZING_STATUS_FILTERS.includes(status)) {
-    return 'analyzing'
-  }
-  if (status === 'processing') {
-    return 'processing'
-  }
-  return status as Exclude<DocStatus, 'parsing' | 'analyzing' | 'preprocessed'>
+// Each filter bucket maps to exactly one DocStatus. `pending` and the deprecated
+// `preprocessed` intentionally have no dedicated bucket — they only surface under
+// the "all" tab.
+const BUCKET_TO_STATUS: Record<StatusBucket, DocStatus> = {
+  completed: 'processed',
+  parse: 'parsing',
+  analyze: 'analyzing',
+  process: 'processing',
+  failed: 'failed'
 }
 
-export const getGroupedStatusesForFilter = (statusFilter: StatusFilter): DocStatus[] | null => {
-  switch (statusFilter) {
-    case 'analyzing':
-      return ANALYZING_STATUS_FILTERS
-    case 'processed':
-    case 'processing':
-    case 'pending':
-    case 'failed':
-      return [statusFilter]
-    case 'all':
-    default:
-      return null
-  }
+const STATUS_TO_BUCKET: Partial<Record<DocStatus, StatusBucket>> = {
+  processed: 'completed',
+  parsing: 'parse',
+  analyzing: 'analyze',
+  processing: 'process',
+  failed: 'failed'
 }
+
+export const getStatusBucket = (status: DocStatus): StatusBucket | null =>
+  STATUS_TO_BUCKET[status] ?? null
 
 export const getStatusRequestFilters = (
   statusFilter: StatusFilter
 ): Pick<DocumentsRequest, 'status_filter' | 'status_filters'> => {
-  const groupedStatuses = getGroupedStatusesForFilter(statusFilter)
-
-  if (groupedStatuses === null) {
+  if (statusFilter === 'all') {
     return {
       status_filter: null,
       status_filters: null
     }
   }
 
-  if (statusFilter === 'analyzing') {
-    return {
-      status_filter: null,
-      status_filters: groupedStatuses
-    }
-  }
-
   return {
-    status_filter: groupedStatuses[0],
+    status_filter: BUCKET_TO_STATUS[statusFilter],
     status_filters: null
   }
 }
 
-export const matchesStatusFilter = (status: DocStatus, statusFilter: StatusFilter): boolean => {
-  const groupedStatuses = getGroupedStatusesForFilter(statusFilter)
-  return groupedStatuses === null || groupedStatuses.includes(status)
-}
+export const matchesStatusFilter = (status: DocStatus, statusFilter: StatusFilter): boolean =>
+  statusFilter === 'all' || BUCKET_TO_STATUS[statusFilter] === status

--- a/lightrag_webui/src/locales/ar.json
+++ b/lightrag_webui/src/locales/ar.json
@@ -139,9 +139,9 @@
       "filters": {
         "all": "الكل",
         "completed": "مكتمل",
-        "analyzing": "جارٍ التحليل",
-        "processing": "قيد المعالجة",
-        "pending": "معلق",
+        "parse": "استخراج",
+        "analyze": "تحليل",
+        "process": "معالجة",
         "failed": "فشل"
       },
       "status": {

--- a/lightrag_webui/src/locales/de.json
+++ b/lightrag_webui/src/locales/de.json
@@ -139,9 +139,9 @@
       "filters": {
         "all": "Alle",
         "completed": "Abgeschlossen",
-        "analyzing": "Wird analysiert",
-        "processing": "Verarbeitung",
-        "pending": "Ausstehend",
+        "parse": "Extraktion",
+        "analyze": "Analyse",
+        "process": "Verarbeitung",
         "failed": "Fehlgeschlagen"
       },
       "status": {

--- a/lightrag_webui/src/locales/en.json
+++ b/lightrag_webui/src/locales/en.json
@@ -139,10 +139,10 @@
       "filters": {
         "all": "All",
         "completed": "Completed",
-        "analyzing": "Analyzing",
-        "processing": "Processing",
-        "pending": "Pending",
-        "failed": "Failed"
+        "parse": "Parse",
+        "analyze": "Analyze",
+        "process": "Process",
+        "failed": "Fail"
       },
       "status": {
         "all": "All",

--- a/lightrag_webui/src/locales/fr.json
+++ b/lightrag_webui/src/locales/fr.json
@@ -139,9 +139,9 @@
       "filters": {
         "all": "Tous",
         "completed": "Terminé",
-        "analyzing": "Analyse en cours",
-        "processing": "En traitement",
-        "pending": "En attente",
+        "parse": "Extraction",
+        "analyze": "Analyse",
+        "process": "Traitement",
         "failed": "Échec"
       },
       "status": {

--- a/lightrag_webui/src/locales/ja.json
+++ b/lightrag_webui/src/locales/ja.json
@@ -139,9 +139,9 @@
       "filters": {
         "all": "すべて",
         "completed": "完了",
-        "analyzing": "分析中",
-        "processing": "処理中",
-        "pending": "保留中",
+        "parse": "抽出",
+        "analyze": "分析",
+        "process": "処理",
         "failed": "失敗"
       },
       "status": {

--- a/lightrag_webui/src/locales/ko.json
+++ b/lightrag_webui/src/locales/ko.json
@@ -139,9 +139,9 @@
       "filters": {
         "all": "전체",
         "completed": "완료",
-        "analyzing": "분석 중",
-        "processing": "처리 중",
-        "pending": "대기 중",
+        "parse": "추출",
+        "analyze": "분석",
+        "process": "처리",
         "failed": "실패"
       },
       "status": {

--- a/lightrag_webui/src/locales/ru.json
+++ b/lightrag_webui/src/locales/ru.json
@@ -139,9 +139,9 @@
       "filters": {
         "all": "Все",
         "completed": "Завершено",
-        "analyzing": "Анализ",
-        "processing": "Обработка",
-        "pending": "Ожидание",
+        "parse": "Извлечение",
+        "analyze": "Анализ",
+        "process": "Обработка",
         "failed": "Ошибка"
       },
       "status": {

--- a/lightrag_webui/src/locales/uk.json
+++ b/lightrag_webui/src/locales/uk.json
@@ -139,9 +139,9 @@
       "filters": {
         "all": "Усі",
         "completed": "Завершено",
-        "analyzing": "Аналіз",
-        "processing": "Обробка",
-        "pending": "Очікування",
+        "parse": "Видобування",
+        "analyze": "Аналіз",
+        "process": "Обробка",
         "failed": "Помилка"
       },
       "status": {

--- a/lightrag_webui/src/locales/vi.json
+++ b/lightrag_webui/src/locales/vi.json
@@ -139,9 +139,9 @@
       "filters": {
         "all": "Tất cả",
         "completed": "Hoàn tất",
-        "analyzing": "Đang phân tích",
-        "processing": "Đang xử lý",
-        "pending": "Đang chờ",
+        "parse": "Trích xuất",
+        "analyze": "Phân tích",
+        "process": "Xử lý",
         "failed": "Thất bại"
       },
       "status": {

--- a/lightrag_webui/src/locales/zh.json
+++ b/lightrag_webui/src/locales/zh.json
@@ -139,9 +139,9 @@
       "filters": {
         "all": "全部",
         "completed": "已完成",
-        "analyzing": "分析中",
-        "processing": "处理中",
-        "pending": "等待中",
+        "parse": "内容解析",
+        "analyze": "模态分析",
+        "process": "抽取处理",
         "failed": "失败"
       },
       "status": {

--- a/lightrag_webui/src/locales/zh_TW.json
+++ b/lightrag_webui/src/locales/zh_TW.json
@@ -139,9 +139,9 @@
       "filters": {
         "all": "全部",
         "completed": "已完成",
-        "analyzing": "分析中",
-        "processing": "處理中",
-        "pending": "等待中",
+        "parse": "內容解析",
+        "analyze": "模態分析",
+        "process": "抽取處理",
         "failed": "失敗"
       },
       "status": {


### PR DESCRIPTION
## Description

Optimizes the document management status filter bar. The previous bar merged `preprocessed + parsing + analyzing` into a single **Analyzing** tab and exposed a **Pending** tab. This PR splits the merged tab into two dedicated, single-status tabs — **Parse** (parsing) and **Analyze** (analyzing) — and hides **Pending**. The deprecated `preprocessed` status is no longer a standalone filter.

The filter bar is now a fixed set of 6 tabs: `All / Completed / Parse / Analyze / Process / Fail`. `pending` and `preprocessed` documents still appear under the **All** tab (no dedicated filter entry).

This is a **frontend-only** change — the `/documents/paginated` API is untouched.

## Related Issues

N/A

## Changes Made

- **`documentStatusFilters.ts`**: `StatusBucket` is now `completed | parse | analyze | process | failed`. Each bucket maps to exactly one `DocStatus` via `BUCKET_TO_STATUS` / `STATUS_TO_BUCKET`, replacing the old `ANALYZING_STATUS_FILTERS` aggregation and `getGroupedStatusesForFilter`. `getStatusRequestFilters` now always sends a single-value `status_filter` (`status_filters` array is dropped). `getStatusBucket` returns `null` for `pending`/`preprocessed`.
- **`DocumentManager.tsx`**: renders the 6 tabs (Parse = cyan, Analyze = indigo, Process = blue), removes the Pending tab, renames count derivations (`completedCount` / `parseCount` / `analyzeCount` / `processCount` / `failedCount`), guards `buildLegacyDocs` against null buckets, and makes the docs-change health-check trigger key-agnostic (a sorted per-bucket digest instead of fixed status keys, since `docs.statuses` may be keyed by raw `DocStatus` or by filter bucket).
- **i18n**: updates the `documentPanel.documentManager.filters.*` sub-object across all 11 locales (added `parse`/`analyze`/`process`, removed `pending`). Chinese label for `process` is `抽取处理` / `抽取處理`.
- **Tests**: rewrote `documentStatusFilters.test.ts` to assert the single-status mapping and that the All tab matches every status (including deprecated/hidden ones).

Backend note: `status_filter: Optional[DocStatus]` already supports `parsing`/`analyzing`/`processing` as exact single-value filters (`resolve_status_filter_values` in `lightrag/base.py`), so no server changes are required.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Verified locally:
- `bun test src/features/documentStatusFilters.test.ts` → 4 pass
- `npx tsc --noEmit` → no errors
- `bun run lint` → clean
