### PR TITLE
🐛 fix(pipeline): byte-aware entity truncation & fail-fast on storage flush errors

### DIFF
--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -175,6 +175,20 @@ class StorageNameSpace(ABC):
     async def index_done_callback(self) -> None:
         """Commit the storage operations after indexing"""
 
+    async def drop_pending_index_ops(self) -> None:
+        """Discard any not-yet-flushed buffered index ops.
+
+        Backends that defer writes to ``index_done_callback`` (via an
+        in-memory ``_pending_*`` buffer) override this to clear that buffer.
+        The pipeline calls it when a batch is aborting on an internal error:
+        every still-buffered record belongs to a document that is being
+        marked FAILED and fully reprocessed on the next run, so dropping the
+        buffer is safe and prevents the poisoned/stale records from being
+        re-flushed by the remaining in-flight documents or carried over to
+        the next batch. Immediate-write backends keep the default no-op.
+        """
+        return None
+
     @abstractmethod
     async def drop(self) -> dict[str, str]:
         """Drop all data from storage and clean up resources

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -16,6 +16,11 @@ DEFAULT_MAX_GRAPH_NODES = 1000
 DEFAULT_SUMMARY_LANGUAGE = "English"  # Default language for document processing
 DEFAULT_MAX_GLEANING = 1
 DEFAULT_ENTITY_NAME_MAX_LENGTH = 256
+# Max UTF-8 byte length for entity identifiers. Milvus enforces VARCHAR
+# max_length in BYTES (not characters), so a CJK name within the character
+# limit can still exceed the field limit. MUST stay <= the max_length of the
+# entity_name / src_id / tgt_id fields in lightrag/kg/milvus_impl.py.
+DEFAULT_ENTITY_NAME_MAX_BYTES = 512
 
 # Per-response output limits for entity extraction prompts
 DEFAULT_MAX_EXTRACTION_RECORDS = 100

--- a/lightrag/exceptions.py
+++ b/lightrag/exceptions.py
@@ -109,6 +109,20 @@ class PipelineCancelledException(Exception):
         self.message = message
 
 
+class IndexFlushError(Exception):
+    """Raised when a storage backend fails to flush buffered index ops.
+
+    Carries the storage driver name and namespace so the pipeline can abort
+    the batch with an actionable reason. The underlying error is preserved as
+    the exception ``__cause__`` (set via ``raise ... from cause``).
+    """
+
+    def __init__(self, storage_name: str, namespace: str, cause: BaseException):
+        self.storage_name = storage_name
+        self.namespace = namespace
+        super().__init__(f"{storage_name}[{namespace}] index flush failed: {cause}")
+
+
 class ChunkTokenLimitExceededError(ValueError):
     """Raised when a chunk exceeds the configured token limit."""
 

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -893,7 +893,25 @@ class FaissVectorDBStorage(BaseVectorStorage):
             self._id_to_meta = {}
 
     async def drop_pending_index_ops(self) -> None:
-        """Discard buffered upserts (pipeline aborting on error)."""
+        """Discard buffered upserts on an aborting batch.
+
+        Only the pending buffer is dropped; vectors already materialized into
+        ``self._index`` by a prior ``_flush_pending_locked`` whose save step
+        then failed (``_index_dirty=True``) are intentionally NOT rolled back.
+
+        The pipeline treats each file as an atomic unit: an abort marks the
+        affected documents FAILED and the whole file is reprocessed on the
+        next run. Because upserts are keyed by deterministic ids (entity-name
+        / relation / chunk hashes), reprocessing overwrites those vectors
+        idempotently, so the final state is identical whether or not we roll
+        back here. This matches the server-backed backends (Milvus / OpenSearch
+        / Postgres / Mongo / Qdrant), which likewise keep a sibling flush's
+        already-committed partial data on abort rather than rolling it back;
+        and if the process crashes before the next save, these in-memory
+        writes are dropped anyway. Rolling back only FAISS/Nano would add an
+        inconsistent, non-load-bearing "FAILED == clean" guarantee, so it is
+        deliberately omitted.
+        """
         if self._storage_lock is None:
             self._pending_upserts.clear()
             return

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -892,6 +892,14 @@ class FaissVectorDBStorage(BaseVectorStorage):
             self._index = faiss.IndexFlatIP(self._dim)
             self._id_to_meta = {}
 
+    async def drop_pending_index_ops(self) -> None:
+        """Discard buffered upserts (pipeline aborting on error)."""
+        if self._storage_lock is None:
+            self._pending_upserts.clear()
+            return
+        async with self._storage_lock:
+            self._pending_upserts.clear()
+
     async def index_done_callback(self) -> bool:
         """Flush deferred embeddings, commit to disk, and notify other processes.
 

--- a/lightrag/kg/milvus_impl.py
+++ b/lightrag/kg/milvus_impl.py
@@ -1691,6 +1691,12 @@ class MilvusVectorDBStorage(BaseVectorStorage):
         """
         await self._flush_pending_vector_ops()
 
+    async def drop_pending_index_ops(self) -> None:
+        """Discard buffered upserts/deletes (pipeline aborting on error)."""
+        async with self._flush_lock:
+            self._pending_vector_docs.clear()
+            self._pending_vector_deletes.clear()
+
     async def _flush_pending_vector_ops(self) -> None:
         """Flush buffered vector upserts and deletes to Milvus.
 

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -3203,6 +3203,12 @@ class MongoVectorDBStorage(BaseVectorStorage):
         """Flush buffered vector ops; Mongo persists automatically once written."""
         await self._flush_pending_vector_ops()
 
+    async def drop_pending_index_ops(self) -> None:
+        """Discard buffered upserts/deletes (pipeline aborting on error)."""
+        async with self._flush_lock:
+            self._pending_vector_docs.clear()
+            self._pending_vector_deletes.clear()
+
     async def _flush_pending_vector_ops(self) -> None:
         """Flush buffered vector upserts and deletes in batched bulk writes.
 

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -630,6 +630,14 @@ class NanoVectorDBStorage(BaseVectorStorage):
             )
             raise
 
+    async def drop_pending_index_ops(self) -> None:
+        """Discard buffered upserts (pipeline aborting on error)."""
+        if self._storage_lock is None:
+            self._pending_upserts.clear()
+            return
+        async with self._storage_lock:
+            self._pending_upserts.clear()
+
     async def index_done_callback(self) -> bool:
         """Flush deferred embeddings, commit to disk, and notify other processes.
 

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -631,7 +631,25 @@ class NanoVectorDBStorage(BaseVectorStorage):
             raise
 
     async def drop_pending_index_ops(self) -> None:
-        """Discard buffered upserts (pipeline aborting on error)."""
+        """Discard buffered upserts on an aborting batch.
+
+        Only the pending buffer is dropped; records already materialized into
+        ``self._client`` by a prior ``_flush_pending_locked`` whose save step
+        then failed (``_client_dirty=True``) are intentionally NOT rolled back.
+
+        The pipeline treats each file as an atomic unit: an abort marks the
+        affected documents FAILED and the whole file is reprocessed on the
+        next run. Because upserts are keyed by deterministic ids (entity-name
+        / relation / chunk hashes), reprocessing overwrites those vectors
+        idempotently, so the final state is identical whether or not we roll
+        back here. This matches the server-backed backends (Milvus / OpenSearch
+        / Postgres / Mongo / Qdrant), which likewise keep a sibling flush's
+        already-committed partial data on abort rather than rolling it back;
+        and if the process crashes before the next save, these in-memory
+        writes are dropped anyway. Rolling back only FAISS/Nano would add an
+        inconsistent, non-load-bearing "FAILED == clean" guarantee, so it is
+        deliberately omitted.
+        """
         if self._storage_lock is None:
             self._pending_upserts.clear()
             return

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -740,8 +740,13 @@ class NetworkXStorage(BaseGraphStorage):
                 self.storage_updated.value = False
                 return True  # Return success
             except Exception as e:
+                # Raise (do NOT swallow + return False): _insert_done's
+                # _flush_one only detects failures via exceptions, so a
+                # swallowed graph-save error would let the document be marked
+                # PROCESSED with the graph changes unpersisted. Surfacing it
+                # aligns this backend with the others (faiss/nano raise too).
                 logger.error(f"[{self.workspace}] Error saving graph: {e}")
-                return False  # Return error
+                raise
 
         return True
 

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -1735,8 +1735,7 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
             if _is_missing_index_error(e):
                 self._mark_index_missing()
                 return
-        except Exception:
-            pass
+            raise
 
     async def is_empty(self) -> bool:
         """Return True if the index contains no documents."""

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -1063,11 +1063,15 @@ class OpenSearchKVStorage(BaseKVStorage):
             retryable_ids, non_retryable_ops = _extract_bulk_failed_ids(failed)
             non_retryable_ids = {op.doc_id for op in non_retryable_ops}
 
-            # Clear only successfully-written entries. Retryable ops stay for
-            # the next flush; non-retryable ops also stay buffered so the
-            # permanent failure is re-surfaced (we raise below) rather than
-            # silently dropped while the document is marked PROCESSED.
-            keep_ids = retryable_ids | non_retryable_ids
+            # Keep ONLY retryable ops buffered for the next flush. Successful
+            # ops are popped; non-retryable (permanent 4xx) ops are dropped
+            # here, not retained: a permanently-unwritable op can never land,
+            # so keeping it would replay-and-refail on every later flush and
+            # poison every caller that shares this buffer — including direct
+            # flush paths (e.g. _persist_parsed_full_docs) that never run the
+            # pipeline's cleanup. The raise below (not retention) is what
+            # surfaces the failure and prevents a silent PROCESSED.
+            keep_ids = retryable_ids
             for doc_id in list(pending_upserts.keys()):
                 if doc_id not in keep_ids:
                     pending_upserts.pop(doc_id, None)
@@ -4130,13 +4134,16 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
                 raise
 
             retryable_ids, non_retryable_ops = _extract_bulk_failed_ids(failed)
-            non_retryable_ids = {op.doc_id for op in non_retryable_ops}
 
-            # Clear only successfully-written entries. Retryable ops stay for
-            # the next flush; non-retryable ops also stay buffered so the
-            # permanent failure is re-surfaced (we raise below) rather than
-            # silently dropped while the document is marked PROCESSED.
-            keep_ids = retryable_ids | non_retryable_ids
+            # Keep ONLY retryable ops buffered for the next flush. Successful
+            # ops are popped; non-retryable (permanent 4xx) ops are dropped
+            # here, not retained: a permanently-unwritable op can never land,
+            # so keeping it would replay-and-refail on every later flush and
+            # poison every caller that shares this buffer — including direct
+            # flush paths that never run the pipeline's cleanup. The raise
+            # below (not retention) is what surfaces the failure and prevents
+            # a silent PROCESSED.
+            keep_ids = retryable_ids
             for doc_id in committed_doc_ids:
                 if doc_id not in keep_ids:
                     pending_docs.pop(doc_id, None)

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -1063,14 +1063,17 @@ class OpenSearchKVStorage(BaseKVStorage):
             retryable_ids, non_retryable_ops = _extract_bulk_failed_ids(failed)
             non_retryable_ids = {op.doc_id for op in non_retryable_ops}
 
-            # Clear successful + non-retryable entries; keep retryable ones.
+            # Clear only successfully-written entries. Retryable ops stay for
+            # the next flush; non-retryable ops also stay buffered so the
+            # permanent failure is re-surfaced (we raise below) rather than
+            # silently dropped while the document is marked PROCESSED.
+            keep_ids = retryable_ids | non_retryable_ids
             for doc_id in list(pending_upserts.keys()):
-                if doc_id not in retryable_ids:
+                if doc_id not in keep_ids:
                     pending_upserts.pop(doc_id, None)
-            new_deletes: set[str] = set()
-            for doc_id in pending_deletes:
-                if doc_id in retryable_ids:
-                    new_deletes.add(doc_id)
+            new_deletes: set[str] = {
+                doc_id for doc_id in pending_deletes if doc_id in keep_ids
+            }
             pending_deletes.clear()
             pending_deletes.update(new_deletes)
 
@@ -1079,29 +1082,30 @@ class OpenSearchKVStorage(BaseKVStorage):
                     f"[{self.workspace}] {len(retryable_ids)} KV ops will "
                     f"retry on the next flush (transient failure)"
                 )
+            logger.debug(
+                f"[{self.workspace}] Flushed KV ops: {success} ok, "
+                f"retry={len(retryable_ids)}, permanent_fail={len(non_retryable_ids)}"
+            )
             if non_retryable_ops:
                 sample = non_retryable_ops[:5]
                 sample_text = ", ".join(
                     f"{op.op}/{op.doc_id}/status={op.status}/{op.error}"
                     for op in sample
                 )
-                logger.warning(
-                    f"[{self.workspace}] {len(non_retryable_ops)} KV ops "
-                    f"failed permanently and were dropped (non-retryable status). "
-                    f"Sample: {sample_text}"
+                # A permanent (non-retryable) bulk failure means the data did
+                # not land. Raise so index_done_callback surfaces it and the
+                # pipeline aborts instead of marking the document PROCESSED.
+                raise RuntimeError(
+                    f"[{self.workspace}] {self.namespace} flush: "
+                    f"{len(non_retryable_ops)} KV ops failed permanently "
+                    f"(non-retryable). Sample: {sample_text}"
                 )
-                if len(non_retryable_ops) > len(sample):
-                    logger.debug(
-                        f"[{self.workspace}] Remaining permanent failures: "
-                        + ", ".join(
-                            f"{op.op}/{op.doc_id}/status={op.status}/{op.error}"
-                            for op in non_retryable_ops[len(sample) :]
-                        )
-                    )
-            logger.debug(
-                f"[{self.workspace}] Flushed KV ops: {success} ok, "
-                f"retry={len(retryable_ids)}, dropped={len(non_retryable_ids)}"
-            )
+
+    async def drop_pending_index_ops(self) -> None:
+        """Discard buffered upserts/deletes (pipeline aborting on error)."""
+        async with self._flush_lock:
+            self._pending_upserts.clear()
+            self._pending_kv_deletes.clear()
 
     async def index_done_callback(self) -> None:
         """Flush pending KV ops and refresh the index for search visibility.
@@ -1120,8 +1124,7 @@ class OpenSearchKVStorage(BaseKVStorage):
             if _is_missing_index_error(e):
                 self._mark_index_missing()
                 return
-        except Exception:
-            pass
+            raise
 
     async def is_empty(self) -> bool:
         """Return True if the index (plus pending buffer) contains no docs.
@@ -1414,6 +1417,10 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
             )
         except OpenSearchException as e:
             logger.error(f"[{self.workspace}] Error upserting doc statuses: {e}")
+            # Surface the failure instead of returning as if the status write
+            # succeeded — a silently-lost doc-status row corrupts pipeline
+            # bookkeeping (a doc could never be recorded FAILED/PROCESSED).
+            raise
 
     async def get_status_counts(self) -> dict[str, int]:
         """Get document counts grouped by status."""
@@ -3664,8 +3671,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             if _is_missing_index_error(e):
                 self._mark_indices_missing()
                 return
-        except Exception:
-            pass
+            raise
 
     async def drop(self) -> dict[str, str]:
         """Delete both node and edge indices."""
@@ -4125,16 +4131,19 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
                 raise
 
             retryable_ids, non_retryable_ops = _extract_bulk_failed_ids(failed)
+            non_retryable_ids = {op.doc_id for op in non_retryable_ops}
 
-            # Clear successful and non-retryable entries; keep retryable ones
-            # in place for the next flush.
+            # Clear only successfully-written entries. Retryable ops stay for
+            # the next flush; non-retryable ops also stay buffered so the
+            # permanent failure is re-surfaced (we raise below) rather than
+            # silently dropped while the document is marked PROCESSED.
+            keep_ids = retryable_ids | non_retryable_ids
             for doc_id in committed_doc_ids:
-                if doc_id not in retryable_ids:
+                if doc_id not in keep_ids:
                     pending_docs.pop(doc_id, None)
-            new_deletes: set[str] = set()
-            for doc_id in pending_deletes:
-                if doc_id in retryable_ids:
-                    new_deletes.add(doc_id)
+            new_deletes: set[str] = {
+                doc_id for doc_id in pending_deletes if doc_id in keep_ids
+            }
             pending_deletes.clear()
             pending_deletes.update(new_deletes)
 
@@ -4149,10 +4158,13 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
                     f"{op.op}/{op.doc_id}/status={op.status}/{op.error}"
                     for op in sample
                 )
-                logger.warning(
-                    f"[{self.workspace}] {len(non_retryable_ops)} vector ops "
-                    f"failed permanently and were dropped (non-retryable status). "
-                    f"Sample: {sample_text}"
+                # A permanent (non-retryable) bulk failure means the data did
+                # not land. Raise so index_done_callback surfaces it and the
+                # pipeline aborts instead of marking the document PROCESSED.
+                raise RuntimeError(
+                    f"[{self.workspace}] {self.namespace} flush: "
+                    f"{len(non_retryable_ops)} vector ops failed permanently "
+                    f"(non-retryable). Sample: {sample_text}"
                 )
 
     async def query(
@@ -4209,6 +4221,12 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
             logger.error(f"[{self.workspace}] Error querying vectors: {e}")
             return []
 
+    async def drop_pending_index_ops(self) -> None:
+        """Discard buffered upserts/deletes (pipeline aborting on error)."""
+        async with self._flush_lock:
+            self._pending_vector_docs.clear()
+            self._pending_vector_deletes.clear()
+
     async def index_done_callback(self) -> None:
         """Flush pending vector ops and refresh the index for k-NN visibility.
 
@@ -4235,8 +4253,7 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
             if _is_missing_index_error(e):
                 self._mark_index_missing()
                 return
-        except Exception:
-            pass
+            raise
 
     async def get_by_id(self, id: str) -> dict[str, Any] | None:
         """Get a vector document by ID, with read-your-writes against the buffer.

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -4269,6 +4269,12 @@ class PGVectorStorage(BaseVectorStorage):
     async def index_done_callback(self) -> None:
         await self._flush_pending_vector_ops()
 
+    async def drop_pending_index_ops(self) -> None:
+        """Discard buffered upserts/deletes (pipeline aborting on error)."""
+        async with self._flush_lock:
+            self._pending_vector_docs.clear()
+            self._pending_vector_deletes.clear()
+
     async def delete(self, ids: list[str]) -> None:
         """Buffer vector deletes for batched flush.
 

--- a/lightrag/kg/qdrant_impl.py
+++ b/lightrag/kg/qdrant_impl.py
@@ -744,6 +744,12 @@ class QdrantVectorDBStorage(BaseVectorStorage):
         """Flush buffered vector ops; Qdrant persists automatically once written."""
         await self._flush_pending_vector_ops()
 
+    async def drop_pending_index_ops(self) -> None:
+        """Discard buffered upserts/deletes (pipeline aborting on error)."""
+        async with self._flush_lock:
+            self._pending_vector_docs.clear()
+            self._pending_vector_deletes.clear()
+
     async def _flush_pending_vector_ops(self) -> None:
         """Flush buffered vector upserts and deletes via batched client calls.
 

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1484,29 +1484,43 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         ]
 
     async def _discard_pending_index_ops(self) -> None:
-        """Drop every storage's not-yet-flushed buffer on an aborting batch.
+        """Drop not-yet-flushed buffers on an aborting batch.
 
         Called when a batch aborts on an internal storage error. Each
-        still-buffered record belongs to a document that will be marked FAILED
-        and fully reprocessed, so dropping the shared cross-file buffers is
-        safe and stops the poisoned/stale records from being re-flushed by
-        remaining in-flight documents or carried into the next batch.
+        still-buffered KG/vector record belongs to a document that will be
+        marked FAILED and fully reprocessed, so dropping the shared cross-file
+        buffers is safe and stops the poisoned/stale records from being
+        re-flushed by remaining in-flight documents or carried into the next
+        batch.
 
-        The LLM response cache is dropped here too — deliberately, not skipped.
-        A buffer is pending (unwritten) work, not a persistence mechanism: by
-        abort time every *flushable* cache entry has already been committed by
-        the per-document flush paths (``_insert_done`` /
-        ``_finalize_doc_failure`` / ``_mark_doc_cancelled_in_stage``), which on
-        a per-item backend like OpenSearch pop the successes and keep only the
-        entries that could not be written. Skipping the cache would leave those
-        un-writable entries buffered, so a permanently-failing cache item (now
-        that OpenSearch raises on non-retryable bulk failures) would re-flush
-        and re-abort on every subsequent batch — wedging the pipeline. Dropping
-        them loses nothing persistable (the cache is an optimization; a dropped
-        entry is simply recomputed on reprocess). Best-effort: a clear failure
-        is logged, not raised, so cleanup never masks the original abort cause.
+        The LLM response cache gets a final flush *before* its buffer is
+        dropped, because — unlike regenerable KG data — re-running LLM calls
+        is expensive, so cached results must be persisted maximally:
+
+        * When the abort was NOT caused by the cache, the cache backend is
+          healthy and this flush commits every still-buffered entry, leaving
+          the buffer empty so the subsequent drop discards nothing persistable.
+        * When a poisoned cache item is itself the abort cause (OpenSearch now
+          raises on non-retryable bulk failures), the flush persists the
+          writable entries (per-item backends pop successes) while the
+          un-writable item stays buffered and the drop then clears it — so a
+          bad cache entry cannot re-flush and re-abort every subsequent batch
+          and wedge the pipeline.
+
+        Best-effort throughout: a flush/clear failure is logged, not raised,
+        so cleanup never masks the original abort cause.
         """
         for storage_inst in self._index_storages():
+            if storage_inst is self.llm_response_cache:
+                # Persist what can still be written, then fall through to drop
+                # whatever could not (a poisoned item) so it cannot wedge the
+                # next batch.
+                try:
+                    await cast(
+                        StorageNameSpace, storage_inst
+                    ).index_done_callback()
+                except Exception as e:
+                    logger.error(f"Failed to persist LLM cache on abort: {e}")
             try:
                 await cast(StorageNameSpace, storage_inst).drop_pending_index_ops()
             except Exception as e:

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1558,7 +1558,27 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 )
                 raise IndexFlushError(type(storage_inst).__name__, namespace, e) from e
 
-        await asyncio.gather(*[_flush_one(inst) for inst in storages])
+        # Await every flush to completion (return_exceptions=True) before
+        # raising. With the default gather, the first IndexFlushError is
+        # propagated while sibling flush coroutines keep running detached —
+        # they could commit records or race _discard_pending_index_ops after
+        # the abort decision, and a second failing sibling would surface as a
+        # "Task exception was never retrieved" warning. Collecting all results
+        # first makes teardown deterministic and lets us report every failure.
+        results = await asyncio.gather(
+            *[_flush_one(inst) for inst in storages], return_exceptions=True
+        )
+        errors = [r for r in results if isinstance(r, BaseException)]
+        if errors:
+            # A cooperative cancellation must propagate as-is, not be reported
+            # as a storage flush failure (_flush_one's `except Exception` does
+            # not catch CancelledError, so it lands here as a result).
+            for exc in errors:
+                if isinstance(exc, asyncio.CancelledError):
+                    raise exc
+            for extra in errors[1:]:
+                logger.error(f"Additional index flush failure: {extra}")
+            raise errors[0]
 
         log_message = "In memory DB persist to disk"
         logger.info(log_message)

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1516,9 +1516,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 # whatever could not (a poisoned item) so it cannot wedge the
                 # next batch.
                 try:
-                    await cast(
-                        StorageNameSpace, storage_inst
-                    ).index_done_callback()
+                    await cast(StorageNameSpace, storage_inst).index_done_callback()
                 except Exception as e:
                     logger.error(f"Failed to persist LLM cache on abort: {e}")
             try:

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1439,7 +1439,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
 
         finally:
             if update_storage:
-                await self._insert_done()
+                await self._insert_done_with_cleanup()
 
     async def _process_extract_entities(
         self, chunk: dict[str, Any], pipeline_status=None, pipeline_status_lock=None
@@ -1594,6 +1594,26 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             async with pipeline_status_lock:
                 pipeline_status["latest_message"] = log_message
                 pipeline_status["history_messages"].append(log_message)
+
+    async def _insert_done_with_cleanup(self) -> None:
+        """``_insert_done`` for direct (non-pipeline) callers, discarding the
+        pending buffers on a flush failure.
+
+        The file pipeline aborts and calls ``_discard_pending_index_ops()``
+        centrally, but direct callers (custom KG / chunks insert,
+        delete/rebuild) have no such cleanup. Without it, a permanent flush
+        failure leaves the poisoned op buffered — OpenSearch keeps a
+        non-retryable bulk item; milvus/qdrant/postgres/mongo keep the whole
+        buffer — and every later ``_insert_done()`` replays it, even after the
+        caller submits otherwise valid work. Discard pending on
+        ``IndexFlushError`` so the buffer is clean for the next attempt, then
+        re-raise so the failure still surfaces to the caller.
+        """
+        try:
+            await self._insert_done()
+        except IndexFlushError:
+            await self._discard_pending_index_ops()
+            raise
 
     def insert_custom_kg(
         self, custom_kg: dict[str, Any], full_doc_id: str = None
@@ -1866,7 +1886,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             raise
         finally:
             if update_storage:
-                await self._insert_done()
+                await self._insert_done_with_cleanup()
 
     def query(
         self,
@@ -2862,7 +2882,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
 
         # ---- 6. Persist pre-rebuild changes ----
         try:
-            await self._insert_done()
+            await self._insert_done_with_cleanup()
         except Exception as e:
             logger.error(f"[purge] Failed to persist pre-rebuild changes: {e}")
             raise Exception(f"Failed to persist pre-rebuild changes: {e}") from e
@@ -3618,7 +3638,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             # Persist changes to graph database before entity and relationship rebuild
             try:
                 deletion_stage = "persist_pre_rebuild_changes"
-                await self._insert_done()
+                await self._insert_done_with_cleanup()
             except Exception as e:
                 logger.error(f"Failed to persist pre-rebuild changes: {e}")
                 raise Exception(f"Failed to persist pre-rebuild changes: {e}") from e
@@ -3767,7 +3787,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             # ALWAYS ensure persistence if any deletion operations were started
             if deletion_operations_started:
                 try:
-                    await self._insert_done()
+                    await self._insert_done_with_cleanup()
                 except Exception as persistence_error:
                     persistence_error_msg = f"Failed to persist data after deletion attempt for {doc_id}: {persistence_error}"
                     logger.error(persistence_error_msg)

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1484,28 +1484,29 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         ]
 
     async def _discard_pending_index_ops(self) -> None:
-        """Drop regenerable buffers on abort, but never touch the LLM cache.
+        """Drop every storage's not-yet-flushed buffer on an aborting batch.
 
-        Called when a batch aborts on an internal storage error: each
-        still-buffered KG/vector record belongs to a document that will be
-        marked FAILED and fully reprocessed, so dropping the shared cross-file
-        buffer is safe and stops the poisoned/stale records from being
-        re-flushed by remaining in-flight documents or carried into the next
-        batch.
+        Called when a batch aborts on an internal storage error. Each
+        still-buffered record belongs to a document that will be marked FAILED
+        and fully reprocessed, so dropping the shared cross-file buffers is
+        safe and stops the poisoned/stale records from being re-flushed by
+        remaining in-flight documents or carried into the next batch.
 
-        The LLM response cache is skipped entirely — not discarded (re-running
-        LLM calls is the expensive part, so cached results must survive) and
-        not re-flushed here either: every document that ended already persisted
-        it via its success / failure / cancel path (``_insert_done`` and
-        ``_finalize_doc_failure`` / ``_mark_doc_cancelled_in_stage``), so a
-        flush here would be redundant — and, if the cache backend was itself
-        the abort cause, a pointless retry of an operation that just failed.
-        Best-effort: a clear failure is logged, not raised, so cleanup never
-        masks the original abort cause.
+        The LLM response cache is dropped here too — deliberately, not skipped.
+        A buffer is pending (unwritten) work, not a persistence mechanism: by
+        abort time every *flushable* cache entry has already been committed by
+        the per-document flush paths (``_insert_done`` /
+        ``_finalize_doc_failure`` / ``_mark_doc_cancelled_in_stage``), which on
+        a per-item backend like OpenSearch pop the successes and keep only the
+        entries that could not be written. Skipping the cache would leave those
+        un-writable entries buffered, so a permanently-failing cache item (now
+        that OpenSearch raises on non-retryable bulk failures) would re-flush
+        and re-abort on every subsequent batch — wedging the pipeline. Dropping
+        them loses nothing persistable (the cache is an optimization; a dropped
+        entry is simply recomputed on reprocess). Best-effort: a clear failure
+        is logged, not raised, so cleanup never masks the original abort cause.
         """
         for storage_inst in self._index_storages():
-            if storage_inst is self.llm_response_cache:
-                continue
             try:
                 await cast(StorageNameSpace, storage_inst).drop_pending_index_ops()
             except Exception as e:

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1493,6 +1493,16 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         re-flushed by remaining in-flight documents or carried into the next
         batch.
 
+        ``full_docs`` and ``doc_status`` are skipped: they are written by the
+        concurrent ``apipeline_enqueue_documents`` path (under
+        ``enqueue_serialize_lock``, which this cleanup does not hold), as
+        ``full_docs.upsert -> index_done_callback -> doc_status.upsert``.
+        Clearing ``full_docs``'s buffer in the window between an in-flight
+        upload's upsert and its flush would drop the document body while the
+        PENDING ``doc_status`` row still gets written, leaving an accepted
+        document with no content. Those writes self-flush immediately, so
+        skipping them discards nothing processing-owned.
+
         The LLM response cache gets a final flush *before* its buffer is
         dropped, because — unlike regenerable KG data — re-running LLM calls
         is expensive, so cached results must be persisted maximally:
@@ -1511,6 +1521,9 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         so cleanup never masks the original abort cause.
         """
         for storage_inst in self._index_storages():
+            if storage_inst is self.full_docs or storage_inst is self.doc_status:
+                # enqueue-owned (see docstring): never clear their buffers here.
+                continue
             if storage_inst is self.llm_response_cache:
                 # Persist what can still be written, then fall through to drop
                 # whatever could not (a poisoned item) so it cannot wedge the

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -113,6 +113,7 @@ from lightrag.operate import (
 )
 from lightrag.utils_pipeline import normalize_document_file_path
 from lightrag.constants import GRAPH_FIELD_SEP
+from lightrag.exceptions import IndexFlushError
 from lightrag.utils import (
     Tokenizer,
     TiktokenTokenizer,
@@ -1461,12 +1462,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 pipeline_status["history_messages"].append(error_msg)
             raise e
 
-    async def _insert_done(
-        self, pipeline_status=None, pipeline_status_lock=None
-    ) -> None:
-        tasks = [
-            cast(StorageNameSpace, storage_inst).index_done_callback()
-            for storage_inst in [  # type: ignore
+    def _index_storages(self) -> list:
+        """All storages flushed together by index_done_callback / abort."""
+        return [
+            storage_inst
+            for storage_inst in [
                 self.full_docs,
                 self.doc_status,
                 self.text_chunks,
@@ -1482,7 +1482,57 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             ]
             if storage_inst is not None
         ]
-        await asyncio.gather(*tasks)
+
+    async def _discard_pending_index_ops(self) -> None:
+        """Drop regenerable buffers on abort, but never touch the LLM cache.
+
+        Called when a batch aborts on an internal storage error: each
+        still-buffered KG/vector record belongs to a document that will be
+        marked FAILED and fully reprocessed, so dropping the shared cross-file
+        buffer is safe and stops the poisoned/stale records from being
+        re-flushed by remaining in-flight documents or carried into the next
+        batch.
+
+        The LLM response cache is skipped entirely — not discarded (re-running
+        LLM calls is the expensive part, so cached results must survive) and
+        not re-flushed here either: every document that ended already persisted
+        it via its success / failure / cancel path (``_insert_done`` and
+        ``_finalize_doc_failure`` / ``_mark_doc_cancelled_in_stage``), so a
+        flush here would be redundant — and, if the cache backend was itself
+        the abort cause, a pointless retry of an operation that just failed.
+        Best-effort: a clear failure is logged, not raised, so cleanup never
+        masks the original abort cause.
+        """
+        for storage_inst in self._index_storages():
+            if storage_inst is self.llm_response_cache:
+                continue
+            try:
+                await cast(StorageNameSpace, storage_inst).drop_pending_index_ops()
+            except Exception as e:
+                logger.error(
+                    f"Failed to discard pending ops on "
+                    f"{type(storage_inst).__name__}: {e}"
+                )
+
+    async def _insert_done(
+        self, pipeline_status=None, pipeline_status_lock=None
+    ) -> None:
+        storages = self._index_storages()
+
+        async def _flush_one(storage_inst) -> None:
+            # Wrap each flush so a failure carries the driver name + namespace.
+            # The pipeline uses this to abort the batch with an actionable
+            # reason instead of misattributing a shared-buffer flush error to
+            # whichever document happened to trigger index_done_callback.
+            try:
+                await cast(StorageNameSpace, storage_inst).index_done_callback()
+            except Exception as e:
+                namespace = getattr(storage_inst, "final_namespace", None) or getattr(
+                    storage_inst, "namespace", ""
+                )
+                raise IndexFlushError(type(storage_inst).__name__, namespace, e) from e
+
+        await asyncio.gather(*[_flush_one(inst) for inst in storages])
 
         log_message = "In memory DB persist to disk"
         logger.info(log_message)

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1596,18 +1596,25 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 pipeline_status["history_messages"].append(log_message)
 
     async def _insert_done_with_cleanup(self) -> None:
-        """``_insert_done`` for direct (non-pipeline) callers, discarding the
-        pending buffers on a flush failure.
+        """``_insert_done`` for UPSERT-oriented direct (non-pipeline) callers,
+        discarding the pending buffers on a flush failure.
 
         The file pipeline aborts and calls ``_discard_pending_index_ops()``
-        centrally, but direct callers (custom KG / chunks insert,
-        delete/rebuild) have no such cleanup. Without it, a permanent flush
-        failure leaves the poisoned op buffered — OpenSearch keeps a
-        non-retryable bulk item; milvus/qdrant/postgres/mongo keep the whole
-        buffer — and every later ``_insert_done()`` replays it, even after the
-        caller submits otherwise valid work. Discard pending on
-        ``IndexFlushError`` so the buffer is clean for the next attempt, then
-        re-raise so the failure still surfaces to the caller.
+        centrally, but direct insert callers (custom KG / chunks insert) have
+        no such cleanup. Without it, a permanent flush failure leaves the
+        poisoned op buffered — OpenSearch keeps a non-retryable bulk item;
+        milvus/qdrant/postgres/mongo keep the whole buffer — and every later
+        ``_insert_done()`` replays it, even after the caller submits otherwise
+        valid work. Discard pending on ``IndexFlushError`` so the buffer is
+        clean for the next attempt, then re-raise so the failure still
+        surfaces to the caller.
+
+        WARNING: do NOT use this on deletion paths. ``_discard_pending_index_ops``
+        drops pending DELETES too, but deletes are not regenerable by
+        reprocessing (the document is being removed, nothing re-issues them).
+        Dropping them — while a deletion may still report success — would leave
+        stale vectors/KV searchable. Deletion paths must use plain
+        ``_insert_done`` so failed deletes stay buffered for a later retry.
         """
         try:
             await self._insert_done()
@@ -2881,8 +2888,12 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 raise Exception(f"Failed to delete entities: {e}") from e
 
         # ---- 6. Persist pre-rebuild changes ----
+        # Use plain _insert_done (no discard-on-failure): the pending buffer
+        # here holds DELETES, which are not regenerable by reprocessing. On a
+        # flush failure they must stay buffered for a later retry, not be
+        # discarded (see _insert_done_with_cleanup docstring).
         try:
-            await self._insert_done_with_cleanup()
+            await self._insert_done()
         except Exception as e:
             logger.error(f"[purge] Failed to persist pre-rebuild changes: {e}")
             raise Exception(f"Failed to persist pre-rebuild changes: {e}") from e
@@ -3636,9 +3647,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     raise Exception(f"Failed to delete entities: {e}") from e
 
             # Persist changes to graph database before entity and relationship rebuild
+            # Plain _insert_done: pending DELETES must be retained for retry on
+            # failure, not discarded (see _insert_done_with_cleanup docstring).
             try:
                 deletion_stage = "persist_pre_rebuild_changes"
-                await self._insert_done_with_cleanup()
+                await self._insert_done()
             except Exception as e:
                 logger.error(f"Failed to persist pre-rebuild changes: {e}")
                 raise Exception(f"Failed to persist pre-rebuild changes: {e}") from e
@@ -3786,8 +3799,12 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         finally:
             # ALWAYS ensure persistence if any deletion operations were started
             if deletion_operations_started:
+                # Plain _insert_done: this finally reports the deletion as
+                # successful after logging a persistence error, so discarding
+                # pending DELETES here would drop them with no retry and leave
+                # stale vectors/KV behind. Keep them buffered for a later flush.
                 try:
-                    await self._insert_done_with_cleanup()
+                    await self._insert_done()
                 except Exception as persistence_error:
                     persistence_error_msg = f"Failed to persist data after deletion attempt for {doc_id}: {persistence_error}"
                     logger.error(persistence_error_msg)

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1483,7 +1483,9 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             if storage_inst is not None
         ]
 
-    async def _discard_pending_index_ops(self) -> None:
+    async def _discard_pending_index_ops(
+        self, *, skip_enqueue_owned: bool = True
+    ) -> None:
         """Drop not-yet-flushed buffers on an aborting batch.
 
         Called when a batch aborts on an internal storage error. Each
@@ -1493,15 +1495,29 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         re-flushed by remaining in-flight documents or carried into the next
         batch.
 
-        ``full_docs`` and ``doc_status`` are skipped: they are written by the
-        concurrent ``apipeline_enqueue_documents`` path (under
-        ``enqueue_serialize_lock``, which this cleanup does not hold), as
-        ``full_docs.upsert -> index_done_callback -> doc_status.upsert``.
-        Clearing ``full_docs``'s buffer in the window between an in-flight
-        upload's upsert and its flush would drop the document body while the
-        PENDING ``doc_status`` row still gets written, leaving an accepted
-        document with no content. Those writes self-flush immediately, so
-        skipping them discards nothing processing-owned.
+        ``skip_enqueue_owned`` controls whether ``full_docs`` / ``doc_status``
+        are cleared:
+
+        * ``True`` (the file pipeline) — skip them. They are written by the
+          concurrent ``apipeline_enqueue_documents`` path (under
+          ``enqueue_serialize_lock``, which this cleanup does not hold), as
+          ``full_docs.upsert -> index_done_callback -> doc_status.upsert``.
+          Clearing ``full_docs``'s buffer in the window between an in-flight
+          upload's upsert and its flush would drop the document body while the
+          PENDING ``doc_status`` row still gets written, leaving an accepted
+          document with no content. Those writes self-flush immediately, so
+          skipping them discards nothing processing-owned.
+        * ``False`` (direct, non-pipeline callers like ``ainsert_custom_chunks``
+          via ``_insert_done_with_cleanup``) — clear them too. There is no
+          concurrent-enqueue contract for these callers, and a permanent
+          ``full_docs`` bulk failure (e.g. OpenSearch KV) must be cleared or it
+          stays buffered and every later ``_insert_done()`` replays the same
+          poisoned record. ``doc_status`` is immediate-write (no buffered
+          backend overrides ``drop_pending_index_ops``), so dropping it is a
+          no-op; only ``full_docs`` is meaningfully cleared. (Edge: a direct
+          insert racing a concurrent enqueue mid-window could still drop that
+          enqueue's in-flight body, but per-item backends only retain the
+          failed item and the enqueue race is a pipeline-only concern.)
 
         The LLM response cache gets a final flush *before* its buffer is
         dropped, because — unlike regenerable KG data — re-running LLM calls
@@ -1528,8 +1544,12 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         so cleanup never masks the original abort cause.
         """
         for storage_inst in self._index_storages():
-            if storage_inst is self.full_docs or storage_inst is self.doc_status:
-                # enqueue-owned (see docstring): never clear their buffers here.
+            if skip_enqueue_owned and (
+                storage_inst is self.full_docs or storage_inst is self.doc_status
+            ):
+                # enqueue-owned (see docstring): skipped for the file pipeline
+                # to avoid racing a concurrent enqueue; direct callers pass
+                # skip_enqueue_owned=False so a poisoned full_docs op is cleared.
                 continue
             if storage_inst is self.llm_response_cache:
                 # Persist what can still be written, then fall through to drop
@@ -1619,7 +1639,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         try:
             await self._insert_done()
         except IndexFlushError:
-            await self._discard_pending_index_ops()
+            # Direct callers have no concurrent-enqueue contract, so clear
+            # full_docs too (skip_enqueue_owned=False) — otherwise a permanent
+            # full_docs bulk failure stays buffered and replays on every later
+            # _insert_done().
+            await self._discard_pending_index_ops(skip_enqueue_owned=False)
             raise
 
     def insert_custom_kg(

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1517,6 +1517,13 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
           bad cache entry cannot re-flush and re-abort every subsequent batch
           and wedge the pipeline.
 
+        Backends that materialize writes in memory and only persist on a
+        later save (FAISS / Nano) discard just the pending buffer here and do
+        NOT roll back already-materialized-but-unsaved writes: the FAILED
+        documents are reprocessed idempotently, so the rollback would be
+        non-load-bearing and inconsistent with the server-backed backends
+        (see those backends' ``drop_pending_index_ops`` docstrings).
+
         Best-effort throughout: a flush/clear failure is logged, not raised,
         so cleanup never masks the original abort cause.
         """

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -72,6 +72,7 @@ from lightrag.constants import (
     DEFAULT_FILE_PATH_MORE_PLACEHOLDER,
     DEFAULT_MAX_FILE_PATHS,
     DEFAULT_ENTITY_NAME_MAX_LENGTH,
+    DEFAULT_ENTITY_NAME_MAX_BYTES,
 )
 from lightrag.kg.shared_storage import get_storage_keyed_lock
 import time
@@ -109,21 +110,40 @@ def _format_relation_edge_label(edge_key: tuple[str, str] | list[str]) -> str:
 
 
 def _truncate_entity_identifier(
-    identifier: str, limit: int, chunk_key: str, identifier_role: str
+    identifier: str,
+    limit: int,
+    chunk_key: str,
+    identifier_role: str,
+    byte_limit: int = DEFAULT_ENTITY_NAME_MAX_BYTES,
 ) -> str:
-    """Truncate entity identifiers that exceed the configured length limit."""
+    """Truncate entity identifiers that exceed the configured length limit.
 
-    if len(identifier) <= limit:
+    Enforces both a character limit (``limit``) and a UTF-8 byte limit
+    (``byte_limit``). Milvus validates VARCHAR ``max_length`` in BYTES, not
+    characters, so a CJK identifier within the character limit can still
+    overflow the field (e.g. 256 Chinese chars ~= 694 bytes > 512). The byte
+    truncation cuts on a character boundary so the result stays valid UTF-8.
+    """
+
+    char_len = len(identifier)
+    byte_len = len(identifier.encode("utf-8"))
+    if char_len <= limit and byte_len <= byte_limit:
         return identifier
 
     display_value = identifier[:limit]
+    encoded = display_value.encode("utf-8")
+    if len(encoded) > byte_limit:
+        # Drop the partial trailing multi-byte char left by the byte slice.
+        display_value = encoded[:byte_limit].decode("utf-8", errors="ignore")
     preview = identifier[:20]  # Show first 20 characters as preview
     logger.warning(
-        "%s: %s len %d > %d chars (Name: '%s...')",
+        "%s: %s len %d chars / %d bytes > %d chars / %d bytes (Name: '%s...')",
         chunk_key,
         identifier_role,
-        len(identifier),
+        char_len,
+        byte_len,
         limit,
+        byte_limit,
         preview,
     )
     return display_value

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -135,7 +135,7 @@ def _truncate_entity_identifier(
     if len(encoded) > byte_limit:
         # Drop the partial trailing multi-byte char left by the byte slice.
         display_value = encoded[:byte_limit].decode("utf-8", errors="ignore")
-    preview = identifier[:20]  # Show first 20 characters as preview
+    preview = identifier[:50]  # Show first 50 characters as preview
     logger.warning(
         "%s: %s len %d chars / %d bytes > %d chars / %d bytes (Name: '%s...')",
         chunk_key,

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -39,7 +39,11 @@ from lightrag.constants import (
     PARSER_ENGINE_MINERU,
     PARSER_ENGINE_NATIVE,
 )
-from lightrag.exceptions import MultimodalAnalysisError, PipelineCancelledException
+from lightrag.exceptions import (
+    MultimodalAnalysisError,
+    PipelineCancelledException,
+    IndexFlushError,
+)
 from lightrag.kg.shared_storage import get_namespace_data, get_namespace_lock
 from lightrag.operate import merge_nodes_and_edges
 from lightrag.parser.routing import (
@@ -1043,6 +1047,8 @@ class _PipelineMixin:
                         "cur_batch": 0,  # Number of files already processed
                         "request_pending": False,  # Clear any previous request
                         "cancellation_requested": False,  # Initialize cancellation flag
+                        "cancellation_reason": None,  # "internal_error" or None (user)
+                        "cancellation_detail": None,  # driver + root cause for internal
                         "latest_message": "",
                     }
                 )
@@ -1076,10 +1082,12 @@ class _PipelineMixin:
                         pipeline_status["request_pending"] = False
                         pipeline_status["cancellation_requested"] = False
 
-                        log_message = "Pipeline cancelled by user"
+                        log_message = f"Pipeline cancelled ({self._cancellation_label(pipeline_status)})"
                         logger.info(log_message)
                         pipeline_status["latest_message"] = log_message
                         pipeline_status["history_messages"].append(log_message)
+                        pipeline_status["cancellation_reason"] = None
+                        pipeline_status["cancellation_detail"] = None
 
                         # Exit directly, skipping request_pending check
                         return
@@ -1170,6 +1178,8 @@ class _PipelineMixin:
                 pipeline_status["cancellation_requested"] = (
                     False  # Always reset cancellation flag
                 )
+                pipeline_status["cancellation_reason"] = None
+                pipeline_status["cancellation_detail"] = None
                 pipeline_status["latest_message"] = log_message
                 pipeline_status["history_messages"].append(log_message)
 
@@ -1250,6 +1260,20 @@ class _PipelineMixin:
         for w in workers:
             w.cancel()
         await asyncio.gather(*workers, return_exceptions=True)
+
+        # If the batch aborted on an internal storage error, the shared
+        # cross-file flush buffers may still hold records from the documents
+        # that were marked FAILED. Discard them now (workers are stopped, so
+        # this does not race a flush) so they are neither re-flushed nor
+        # carried into the next batch — every affected document is reprocessed
+        # on retry. See _discard_pending_index_ops / drop_pending_index_ops.
+        async with pipeline_status_lock:
+            internal_abort = (
+                pipeline_status.get("cancellation_requested", False)
+                and pipeline_status.get("cancellation_reason") == "internal_error"
+            )
+        if internal_abort:
+            await self._discard_pending_index_ops()
 
     async def _validate_and_fix_document_consistency(
         self,
@@ -2353,6 +2377,16 @@ class _PipelineMixin:
                             file_path=file_path,
                         )
 
+                    # If another in-flight document already triggered an abort
+                    # (e.g. a storage flush error set cancellation_requested),
+                    # do not mark PROCESSED or re-run _insert_done here: the
+                    # shared flush buffer is being torn down, so re-flushing
+                    # would just re-raise the same error. Bail out as cancelled
+                    # so this document is FAILED and retried on the next run.
+                    await self._raise_if_cancelled(
+                        ctx.pipeline_status, ctx.pipeline_status_lock
+                    )
+
                     process_end_time = int(time.time())
                     await self._upsert_doc_status_transition(
                         doc_id=doc_id,
@@ -2383,6 +2417,26 @@ class _PipelineMixin:
                         ctx.pipeline_status["history_messages"].append(log_message)
 
                 except Exception as e:
+                    # A storage flush failure (raised by _insert_done) is not
+                    # attributable to this document: index_done_callback flushes
+                    # a buffer shared across concurrently-processed files. We
+                    # cannot tell whose record failed, so continuing risks
+                    # marking other in-flight files PROCESSED with missing data.
+                    # Abort the whole batch via the cooperative cancellation
+                    # flag, tagging it as an internal error with the driver name
+                    # and root cause so it is distinguishable from a user cancel.
+                    if isinstance(e, IndexFlushError):
+                        async with ctx.pipeline_status_lock:
+                            ctx.pipeline_status["cancellation_requested"] = True
+                            ctx.pipeline_status["cancellation_reason"] = (
+                                "internal_error"
+                            )
+                            ctx.pipeline_status["cancellation_detail"] = (
+                                f"{e.storage_name}[{e.namespace}]: {e.__cause__}"
+                            )
+                        logger.error(
+                            f"Aborting pipeline batch due to storage flush error: {e}"
+                        )
                     await self._finalize_doc_failure(
                         doc_id=doc_id,
                         status_doc=status_doc,
@@ -2532,6 +2586,18 @@ class _PipelineMixin:
             if pipeline_status.get("cancellation_requested", False):
                 raise PipelineCancelledException("User cancelled")
 
+    @staticmethod
+    def _cancellation_label(pipeline_status: dict) -> str:
+        """Human-readable cancel cause: internal error (with detail) vs user.
+
+        Callers building cancellation messages use this so an internal abort
+        (e.g. a storage flush failure) is not mislabeled as a user cancel.
+        """
+        if pipeline_status.get("cancellation_reason") == "internal_error":
+            detail = pipeline_status.get("cancellation_detail") or "unknown"
+            return f"Cancelled by internal error: {detail}"
+        return "User cancelled"
+
     async def _cancellation_requested(
         self,
         pipeline_status: dict,
@@ -2565,7 +2631,10 @@ class _PipelineMixin:
         sibling tasks (e.g. successful multimodal items inside a doc that is
         being cancelled) survive a server restart.
         """
-        error_msg = f"User cancelled during {stage_label}: {file_path}"
+        error_msg = (
+            f"{self._cancellation_label(pipeline_status)} during "
+            f"{stage_label}: {file_path}"
+        )
         logger.warning(error_msg)
         async with pipeline_status_lock:
             pipeline_status["latest_message"] = error_msg
@@ -2609,14 +2678,15 @@ class _PipelineMixin:
         preserves the failed chunks snapshot and processing-time metadata.
         """
         if isinstance(error, PipelineCancelledException):
+            cancel_label = self._cancellation_label(pipeline_status)
             if stage_label == "merge":
                 error_msg = (
-                    f"User cancelled during merge {current_file_number}/"
+                    f"{cancel_label} during merge {current_file_number}/"
                     f"{total_files}: {file_path}"
                 )
             else:
                 error_msg = (
-                    f"User cancelled {current_file_number}/{total_files}: {file_path}"
+                    f"{cancel_label} {current_file_number}/{total_files}: {file_path}"
                 )
             logger.warning(error_msg)
             async with pipeline_status_lock:

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1079,11 +1079,32 @@ class _PipelineMixin:
                 # Check for cancellation request at the start of main loop
                 async with pipeline_status_lock:
                     if pipeline_status.get("cancellation_requested", False):
+                        # Read the cause BEFORE resetting reason/detail below.
+                        is_internal = (
+                            pipeline_status.get("cancellation_reason")
+                            == "internal_error"
+                        )
+                        label = self._cancellation_label(pipeline_status)
                         pipeline_status["request_pending"] = False
                         pipeline_status["cancellation_requested"] = False
 
-                        log_message = f"Pipeline cancelled ({self._cancellation_label(pipeline_status)})"
-                        logger.info(log_message)
+                        if is_internal:
+                            # Unrecoverable storage error: halting is intentional
+                            # (auto-retry into a broken backend will not recover).
+                            # Surface at error level with an actionable message;
+                            # affected docs stay queued (PENDING/FAILED) and are
+                            # picked up when processing is restarted after the
+                            # storage issue is resolved.
+                            log_message = (
+                                f"Pipeline halted on internal storage error "
+                                f"({label}). Resolve the storage issue and "
+                                f"restart processing; affected documents remain "
+                                f"queued (PENDING/FAILED)."
+                            )
+                            logger.error(log_message)
+                        else:
+                            log_message = f"Pipeline cancelled ({label})"
+                            logger.info(log_message)
                         pipeline_status["latest_message"] = log_message
                         pipeline_status["history_messages"].append(log_message)
                         pipeline_status["cancellation_reason"] = None

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1095,12 +1095,7 @@ class _PipelineMixin:
                             # affected docs stay queued (PENDING/FAILED) and are
                             # picked up when processing is restarted after the
                             # storage issue is resolved.
-                            log_message = (
-                                f"Pipeline halted on internal storage error "
-                                f"({label}). Resolve the storage issue and "
-                                f"restart processing; affected documents remain "
-                                f"queued (PENDING/FAILED)."
-                            )
+                            log_message = self._internal_halt_message(label)
                             logger.error(log_message)
                         else:
                             log_message = f"Pipeline cancelled ({label})"
@@ -1186,8 +1181,8 @@ class _PipelineMixin:
                 )
 
         finally:
-            log_message = "Enqueued document processing pipeline stopped"
-            logger.info(log_message)
+            stopped_message = "Enqueued document processing pipeline stopped"
+            logger.info(stopped_message)
             # If the loop already released ``busy`` under the atomic exit
             # check, don't clobber it here — a concurrent enqueue may have
             # observed busy=False and started a new processing pass that
@@ -1196,13 +1191,31 @@ class _PipelineMixin:
             async with pipeline_status_lock:
                 if not busy_released_in_loop:
                     pipeline_status["busy"] = False
+                # An internal-error abort normally exits via the batch's
+                # ``break`` (not the loop-top cancellation handler, which
+                # logs + clears the reason itself), so without this the only
+                # visible trace would be the generic "stopped" line. Surface
+                # the actionable halt reason here too, BEFORE clearing the
+                # reason/detail. Read it first so _cancellation_label still
+                # sees the cause.
+                internal_halt = None
+                if pipeline_status.get("cancellation_reason") == "internal_error":
+                    internal_halt = self._internal_halt_message(
+                        self._cancellation_label(pipeline_status)
+                    )
+                    logger.error(internal_halt)
                 pipeline_status["cancellation_requested"] = (
                     False  # Always reset cancellation flag
                 )
                 pipeline_status["cancellation_reason"] = None
                 pipeline_status["cancellation_detail"] = None
-                pipeline_status["latest_message"] = log_message
-                pipeline_status["history_messages"].append(log_message)
+                pipeline_status["history_messages"].append(stopped_message)
+                if internal_halt is not None:
+                    pipeline_status["history_messages"].append(internal_halt)
+                    # Prefer the actionable halt reason as the latest message.
+                    pipeline_status["latest_message"] = internal_halt
+                else:
+                    pipeline_status["latest_message"] = stopped_message
 
     # ============================================================
     # Pipeline orchestration
@@ -2636,6 +2649,19 @@ class _PipelineMixin:
             detail = pipeline_status.get("cancellation_detail") or "unknown"
             return f"Cancelled by internal error: {detail}"
         return "User cancelled"
+
+    @staticmethod
+    def _internal_halt_message(label: str) -> str:
+        """Actionable halt message for an internal-error abort.
+
+        Shared by the loop-top cancellation handler and the finally cleanup so
+        the same wording surfaces whichever exit path the batch takes.
+        """
+        return (
+            f"Pipeline halted on internal storage error ({label}). Resolve the "
+            f"storage issue and restart processing; affected documents remain "
+            f"queued (PENDING/FAILED)."
+        )
 
     async def _cancellation_requested(
         self,

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1838,6 +1838,24 @@ class _PipelineMixin:
                     parsed_data=parsed_data_w,
                     ctx=ctx,
                 )
+            except Exception as e:
+                # process_single_document handles its own per-doc failures; an
+                # escape here means even the FAILED-status write failed (e.g.
+                # the doc_status backend is down). Do NOT let the worker die —
+                # that strands the remaining queued items and hangs
+                # q_process.join() forever, wedging the pipeline busy. Route it
+                # to the batch-abort path (same flag as IndexFlushError) and
+                # keep draining so the batch winds down cleanly. CancelledError
+                # is a BaseException, not caught here, so a normal worker
+                # cancellation at batch end still propagates.
+                logger.error(f"Unhandled error in process worker; aborting batch: {e}")
+                logger.error(traceback.format_exc())
+                async with ctx.pipeline_status_lock:
+                    ctx.pipeline_status["cancellation_requested"] = True
+                    ctx.pipeline_status["cancellation_reason"] = "internal_error"
+                    ctx.pipeline_status["cancellation_detail"] = (
+                        f"process worker unhandled error: {e}"
+                    )
             finally:
                 ctx.q_process.task_done()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,13 @@ def _hermetic_mineru_env(monkeypatch):
     unrelated API/FastAPI tests (``test_bedrock_llm.py``,
     ``test_path_prefixes.py``).
 
+    The ``MINERU_LOCAL_*`` parser options are stripped for the same reason:
+    a developer ``.env`` that pins e.g. ``MINERU_LOCAL_PARSE_METHOD=ocr``
+    leaks a non-default into tests that assume the built-in defaults
+    (``test_client_local_mode_round_trip`` expects ``parse_method=auto``;
+    ``test_invalid_when_local_parser_options_change`` toggles each option
+    and expects the change to invalidate a bundle recorded with defaults).
+
     Strip these variables globally; tests that need a specific mode can
     still ``monkeypatch.setenv(...)`` themselves and monkeypatch will
     restore the inherited value at teardown.
@@ -40,6 +47,10 @@ def _hermetic_mineru_env(monkeypatch):
     monkeypatch.delenv("MINERU_API_TOKEN", raising=False)
     monkeypatch.delenv("MINERU_LOCAL_ENDPOINT", raising=False)
     monkeypatch.delenv("MINERU_OFFICIAL_ENDPOINT", raising=False)
+    monkeypatch.delenv("MINERU_LOCAL_BACKEND", raising=False)
+    monkeypatch.delenv("MINERU_LOCAL_PARSE_METHOD", raising=False)
+    monkeypatch.delenv("MINERU_LOCAL_IMAGE_ANALYSIS", raising=False)
+    monkeypatch.delenv("MINERU_LOCAL_START_PAGE_ID", raising=False)
     monkeypatch.delenv("LIGHTRAG_PARSER", raising=False)
     monkeypatch.delenv("DOCLING_ENDPOINT", raising=False)
 

--- a/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
@@ -766,3 +766,59 @@ async def test_flush_recovers_from_index_add_failure_without_re_embedding(tmp_pa
     await reader.initialize()
     hit = await reader.get_by_id("id1")
     assert hit is not None and hit["content"] == "alpha"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_drop_pending_index_ops_clears_buffer(tmp_path):
+    """An internal-error abort calls drop_pending_index_ops to discard the
+    not-yet-flushed buffer without materializing anything into the index."""
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "alpha"}, "id2": {"content": "beta"}})
+    assert storage._pending_upserts, "upsert buffers, does not flush"
+
+    await storage.drop_pending_index_ops()
+
+    assert storage._pending_upserts == {}
+    assert embed.call_count == 0, "drop must not embed"
+    assert storage._index.ntotal == 0, "nothing was materialized"
+    _assert_consistent(storage)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_drop_pending_does_not_rollback_materialized(tmp_path):
+    """drop_pending_index_ops discards ONLY the pending buffer; rows already
+    materialized into the index by a flush whose save then failed
+    (``_index_dirty=True``) are intentionally NOT rolled back."""
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    # Flush id1 into the index, then fail the save so it stays
+    # materialized-but-unsaved (dirty) and the pending buffer is emptied.
+    await storage.upsert({"id1": {"content": "alpha"}})
+
+    def fail_save():
+        raise OSError("save boom")
+
+    storage._save_faiss_index = fail_save
+    with pytest.raises(OSError, match="save boom"):
+        await storage.index_done_callback()
+    assert storage._pending_upserts == {}, "flush succeeded so pending is empty"
+    assert storage._index_dirty is True
+    assert storage._index.ntotal == 1, "id1 materialized, not saved"
+
+    # A new pending op arrives, then the batch aborts and drops pending.
+    await storage.upsert({"id2": {"content": "beta"}})
+    assert "id2" in storage._pending_upserts
+
+    await storage.drop_pending_index_ops()
+
+    assert storage._pending_upserts == {}, "pending id2 dropped"
+    assert storage._index.ntotal == 1, "materialized id1 NOT rolled back"
+    assert storage._index_dirty is True, "still dirty for a later save retry"
+    _assert_consistent(storage)

--- a/tests/kg/milvus_impl/test_milvus_deferred_embedding.py
+++ b/tests/kg/milvus_impl/test_milvus_deferred_embedding.py
@@ -512,3 +512,18 @@ async def test_drop_clears_pending_buffers():
         assert result["status"] == "success"
         assert s._pending_vector_docs == {}
         assert s._pending_vector_deletes == set()
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_drop_pending_index_ops_clears_buffers():
+    """On an internal-error abort the pipeline calls drop_pending_index_ops to
+    discard buffered upserts/deletes without flushing them (PR #3187)."""
+    embed = CountingEmbeddingFunc()
+    s = _make_storage(embed)
+    await s.upsert({"v1": {"content": "x"}, "v2": {"content": "y"}})
+    s._pending_vector_deletes.add("old-id")
+    assert s._pending_vector_docs
+    await s.drop_pending_index_ops()
+    assert not s._pending_vector_docs
+    assert not s._pending_vector_deletes

--- a/tests/kg/mongo_impl/test_mongo_deferred_embedding.py
+++ b/tests/kg/mongo_impl/test_mongo_deferred_embedding.py
@@ -550,3 +550,18 @@ async def test_drop_clears_pending_buffers():
         assert result["status"] == "success"
         assert s._pending_vector_docs == {}
         assert s._pending_vector_deletes == set()
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_drop_pending_index_ops_clears_buffers():
+    """On an internal-error abort the pipeline calls drop_pending_index_ops to
+    discard buffered upserts/deletes without flushing them (PR #3187)."""
+    embed = CountingEmbeddingFunc()
+    s = _make_storage(embed)
+    await s.upsert({"v1": {"content": "x"}, "v2": {"content": "y"}})
+    s._pending_vector_deletes.add("old-id")
+    assert s._pending_vector_docs
+    await s.drop_pending_index_ops()
+    assert not s._pending_vector_docs
+    assert not s._pending_vector_deletes

--- a/tests/kg/nano_impl/test_nano_deferred_embedding.py
+++ b/tests/kg/nano_impl/test_nano_deferred_embedding.py
@@ -394,3 +394,57 @@ async def test_finalize_retries_save_after_flush_failure(tmp_path):
     await reader.initialize()
     hit = await reader.get_by_id("id1")
     assert hit is not None and hit["id"] == "id1"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_drop_pending_index_ops_clears_buffer(tmp_path):
+    """An internal-error abort calls drop_pending_index_ops to discard the
+    not-yet-flushed buffer without materializing anything."""
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "alpha"}, "id2": {"content": "beta"}})
+    assert storage._pending_upserts, "upsert buffers, does not flush"
+
+    await storage.drop_pending_index_ops()
+
+    assert storage._pending_upserts == {}
+    assert embed.call_count == 0, "drop must not embed"
+    assert len(storage._client) == 0, "nothing was materialized"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_drop_pending_does_not_rollback_materialized(tmp_path):
+    """drop_pending_index_ops discards ONLY the pending buffer; records already
+    materialized into self._client by a flush whose save then failed
+    (``_client_dirty=True``) are intentionally NOT rolled back."""
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    # Flush id1 into the in-memory client, then fail the save so it stays
+    # materialized-but-unsaved (dirty) and the pending buffer is emptied.
+    await storage.upsert({"id1": {"content": "alpha"}})
+
+    def fail_save():
+        raise OSError("save boom")
+
+    storage._save_to_disk_locked = fail_save
+    with pytest.raises(OSError, match="save boom"):
+        await storage.index_done_callback()
+    assert storage._pending_upserts == {}, "flush succeeded so pending is empty"
+    assert storage._client_dirty is True
+    assert len(storage._client) == 1, "id1 materialized, not saved"
+
+    # A new pending op arrives, then the batch aborts and drops pending.
+    await storage.upsert({"id2": {"content": "beta"}})
+    assert "id2" in storage._pending_upserts
+
+    await storage.drop_pending_index_ops()
+
+    assert storage._pending_upserts == {}, "pending id2 dropped"
+    assert len(storage._client) == 1, "materialized id1 NOT rolled back"
+    assert storage._client_dirty is True, "still dirty for a later save retry"

--- a/tests/kg/networkx_impl/test_networkx_index_done.py
+++ b/tests/kg/networkx_impl/test_networkx_index_done.py
@@ -1,0 +1,65 @@
+"""NetworkXStorage.index_done_callback must RAISE on a graph-save failure
+(PR #3187), not swallow it and return False.
+
+A swallowed save error would let _insert_done's _flush_one treat the flush as
+successful (it only detects failures via exceptions), so the document would be
+marked PROCESSED with the graph changes unpersisted — silent data loss. This
+locks the raise-on-failure behavior that aligns NetworkX with the other
+backends (faiss/nano raise too).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from lightrag.kg.networkx_impl import NetworkXStorage
+from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
+from lightrag.utils import EmbeddingFunc
+
+pytestmark = pytest.mark.offline
+
+
+@pytest.fixture(autouse=True)
+def _shared_data():
+    finalize_share_data()
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
+async def _embed(texts):
+    return np.random.rand(len(texts), 8)
+
+
+def _make_storage(tmp_path) -> NetworkXStorage:
+    return NetworkXStorage(
+        namespace="test_graph",
+        workspace="ws",
+        global_config={
+            "working_dir": str(tmp_path),
+            "embedding_batch_num": 10,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.5},
+        },
+        embedding_func=EmbeddingFunc(embedding_dim=8, max_token_size=512, func=_embed),
+    )
+
+
+@pytest.mark.asyncio
+async def test_index_done_callback_raises_on_save_failure(tmp_path, monkeypatch):
+    storage = _make_storage(tmp_path)
+    await storage.initialize()
+    try:
+        await storage.upsert_node("n1", {"entity_id": "n1", "description": "x"})
+
+        def boom(graph, file_name, workspace):
+            raise OSError("save boom")
+
+        # write_nx_graph is invoked as NetworkXStorage.write_nx_graph(...).
+        monkeypatch.setattr(NetworkXStorage, "write_nx_graph", staticmethod(boom))
+
+        # Must surface the error (NOT return False / swallow it).
+        with pytest.raises(OSError, match="save boom"):
+            await storage.index_done_callback()
+    finally:
+        await storage.finalize()

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -1228,8 +1228,9 @@ class TestKVStorageBatching:
     ):
         """Permanent (4xx, e.g. mapping error) failures must surface as an
         error so _insert_done aborts the pipeline instead of silently marking
-        the document PROCESSED. Both the non-retryable and retryable ops stay
-        buffered (no silent drop)."""
+        the document PROCESSED. The non-retryable op is dropped from the buffer
+        (it can never land — keeping it would replay-and-refail on every later
+        flush and poison direct callers); the retryable op stays for retry."""
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             with patch(
                 "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
@@ -1255,8 +1256,8 @@ class TestKVStorageBatching:
                 await s.upsert({"k1": {"content": "x"}, "k2": {"content": "y"}})
                 with pytest.raises(RuntimeError, match="failed permanently"):
                     await s.index_done_callback()
-                # Non-retryable kept buffered (re-surfaced, not silently dropped).
-                assert "k1" in s._pending_upserts
+                # Non-retryable dropped (can never land; not replayed).
+                assert "k1" not in s._pending_upserts
                 # Retryable kept for the next flush.
                 assert "k2" in s._pending_upserts
 
@@ -4610,8 +4611,9 @@ class TestVectorStorageBatching:
         self, global_config, embed_func, mock_client
     ):
         """4xx (non-429) permanent failures must raise so the pipeline aborts
-        instead of marking the document PROCESSED; the failed op stays
-        buffered (no silent drop)."""
+        instead of marking the document PROCESSED; the failed op is dropped
+        from the buffer (it can never land — keeping it would replay-and-refail
+        on every later flush), while the retryable op stays for retry."""
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             with patch(
                 "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
@@ -4632,9 +4634,9 @@ class TestVectorStorageBatching:
                 )
                 with pytest.raises(RuntimeError, match="failed permanently"):
                     await s.index_done_callback()
-                # v1 (non-retryable) kept buffered, re-surfaced not silently
-                # dropped; v2 (retryable) retained for the next flush.
-                assert "v1" in s._pending_vector_docs
+                # v1 (non-retryable) dropped (can never land; not replayed);
+                # v2 (retryable) retained for the next flush.
+                assert "v1" not in s._pending_vector_docs
                 assert "v2" in s._pending_vector_docs
 
     @pytest.mark.asyncio

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -1223,11 +1223,13 @@ class TestKVStorageBatching:
                 assert "k2" in s._pending_upserts
 
     @pytest.mark.asyncio
-    async def test_kv_failed_flush_drops_non_retryable(
+    async def test_kv_failed_flush_raises_on_non_retryable(
         self, global_config, embed_func, mock_client
     ):
-        """Permanent (4xx, e.g. mapping error) failures are cleared from
-        the buffer rather than retried forever."""
+        """Permanent (4xx, e.g. mapping error) failures must surface as an
+        error so _insert_done aborts the pipeline instead of silently marking
+        the document PROCESSED. Both the non-retryable and retryable ops stay
+        buffered (no silent drop)."""
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             with patch(
                 "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
@@ -1251,8 +1253,11 @@ class TestKVStorageBatching:
                 s = self._make(global_config, embed_func)
                 await s.initialize()
                 await s.upsert({"k1": {"content": "x"}, "k2": {"content": "y"}})
-                await s.index_done_callback()
-                assert "k1" not in s._pending_upserts
+                with pytest.raises(RuntimeError, match="failed permanently"):
+                    await s.index_done_callback()
+                # Non-retryable kept buffered (re-surfaced, not silently dropped).
+                assert "k1" in s._pending_upserts
+                # Retryable kept for the next flush.
                 assert "k2" in s._pending_upserts
 
     @pytest.mark.asyncio
@@ -4601,10 +4606,12 @@ class TestVectorStorageBatching:
         assert non_retryable[0].error.endswith("...")
 
     @pytest.mark.asyncio
-    async def test_failed_flush_drops_non_retryable_entries(
+    async def test_failed_flush_raises_on_non_retryable_entries(
         self, global_config, embed_func, mock_client
     ):
-        """4xx (non-429) failures are dropped, not perpetually retried."""
+        """4xx (non-429) permanent failures must raise so the pipeline aborts
+        instead of marking the document PROCESSED; the failed op stays
+        buffered (no silent drop)."""
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             with patch(
                 "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
@@ -4623,10 +4630,28 @@ class TestVectorStorageBatching:
                 await s.upsert(
                     {"v1": {"content": "bad"}, "v2": {"content": "transient"}}
                 )
-                await s.index_done_callback()
-                # v1 is dropped (non-retryable), v2 is retained (retryable).
-                assert "v1" not in s._pending_vector_docs
+                with pytest.raises(RuntimeError, match="failed permanently"):
+                    await s.index_done_callback()
+                # v1 (non-retryable) kept buffered, re-surfaced not silently
+                # dropped; v2 (retryable) retained for the next flush.
+                assert "v1" in s._pending_vector_docs
                 assert "v2" in s._pending_vector_docs
+
+    @pytest.mark.asyncio
+    async def test_drop_pending_index_ops_clears_buffers(
+        self, global_config, embed_func, mock_client
+    ):
+        """On an internal-error abort the pipeline calls drop_pending_index_ops
+        to discard buffered upserts/deletes without flushing them."""
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            await s.upsert({"v1": {"content": "x"}, "v2": {"content": "y"}})
+            s._pending_vector_deletes.add("old-id")
+            assert s._pending_vector_docs
+            await s.drop_pending_index_ops()
+            assert not s._pending_vector_docs
+            assert not s._pending_vector_deletes
 
     @pytest.mark.asyncio
     async def test_concurrent_writes_during_flush_are_serialised(
@@ -4801,12 +4826,11 @@ class TestVectorStorageBatching:
             )
 
     @pytest.mark.asyncio
-    async def test_non_retryable_logs_sample_ids(
-        self, global_config, embed_func, mock_client, caplog
+    async def test_non_retryable_raises_with_sample_ids(
+        self, global_config, embed_func, mock_client
     ):
-        """Non-retryable bulk failures log a sample with id/status/error."""
-        import logging as _logging
-
+        """Non-retryable bulk failures raise an error carrying a sample with
+        id/status/error so the abort is diagnosable."""
         failed = [
             {
                 "index": {
@@ -4820,36 +4844,25 @@ class TestVectorStorageBatching:
             }
             for i in range(6)
         ]
-        # lightrag logger has propagate=False, so caplog's root handler
-        # would miss these records. Re-enable propagation just for this
-        # test so caplog can capture the warning we emit.
-        lightrag_logger = _logging.getLogger("lightrag")
-        original_propagate = lightrag_logger.propagate
-        lightrag_logger.propagate = True
-        try:
-            with patch.object(ClientManager, "get_client", return_value=mock_client):
-                with patch(
-                    "lightrag.kg.opensearch_impl.helpers.async_bulk",
-                    new_callable=AsyncMock,
-                ) as mock_bulk:
-                    mock_bulk.return_value = (0, failed)
-                    s = self._make(global_config, embed_func)
-                    await s.initialize()
-                    await s.upsert({f"v{i}": {"content": f"d{i}"} for i in range(6)})
-                    with caplog.at_level("WARNING", logger="lightrag"):
-                        await s.index_done_callback()
-        finally:
-            lightrag_logger.propagate = original_propagate
-        warning_text = "\n".join(
-            rec.message for rec in caplog.records if rec.levelname == "WARNING"
-        )
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            with patch(
+                "lightrag.kg.opensearch_impl.helpers.async_bulk",
+                new_callable=AsyncMock,
+            ) as mock_bulk:
+                mock_bulk.return_value = (0, failed)
+                s = self._make(global_config, embed_func)
+                await s.initialize()
+                await s.upsert({f"v{i}": {"content": f"d{i}"} for i in range(6)})
+                with pytest.raises(RuntimeError) as excinfo:
+                    await s.index_done_callback()
+        error_text = str(excinfo.value)
         # Sample contains the first 5 ids with op/status/reason text.
         for i in range(5):
-            assert f"v{i}" in warning_text
-        assert "status=400" in warning_text
-        assert "bad field" in warning_text
+            assert f"v{i}" in error_text
+        assert "status=400" in error_text
+        assert "bad field" in error_text
         # 6 permanent failures reported in aggregate.
-        assert "6 vector ops" in warning_text
+        assert "6 vector ops" in error_text
 
     @pytest.mark.asyncio
     async def test_index_done_callback_flushes_when_index_recreated(

--- a/tests/kg/postgres_impl/test_postgres_vector_deferred.py
+++ b/tests/kg/postgres_impl/test_postgres_vector_deferred.py
@@ -989,3 +989,17 @@ async def test_flush_failure_keeps_pending_buffers():
     # Fail-fast-retain: nothing cleared, next flush replays everything.
     assert "c1" in storage._pending_vector_docs
     assert "c2" in storage._pending_vector_deletes
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_drop_pending_index_ops_clears_buffers():
+    """On an internal-error abort the pipeline calls drop_pending_index_ops to
+    discard buffered upserts/deletes without flushing them (PR #3187)."""
+    storage = _make_storage()
+    await storage.upsert({"c1": _chunk_data(content="alpha")})
+    storage._pending_vector_deletes.add("old-id")
+    assert storage._pending_vector_docs
+    await storage.drop_pending_index_ops()
+    assert not storage._pending_vector_docs
+    assert not storage._pending_vector_deletes

--- a/tests/kg/qdrant_impl/test_qdrant_deferred_embedding.py
+++ b/tests/kg/qdrant_impl/test_qdrant_deferred_embedding.py
@@ -409,3 +409,18 @@ async def test_drop_clears_pending_buffers():
     assert result["status"] == "success"
     assert s._pending_vector_docs == {}
     assert s._pending_vector_deletes == set()
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_drop_pending_index_ops_clears_buffers():
+    """On an internal-error abort the pipeline calls drop_pending_index_ops to
+    discard buffered upserts/deletes without flushing them (PR #3187)."""
+    embed = CountingEmbeddingFunc()
+    s = _make_storage(embed)
+    await s.upsert({"v1": {"content": "x"}, "v2": {"content": "y"}})
+    s._pending_vector_deletes.add("old-id")
+    assert s._pending_vector_docs
+    await s.drop_pending_index_ops()
+    assert not s._pending_vector_docs
+    assert not s._pending_vector_deletes

--- a/tests/pipeline/test_insert_done_error_handling.py
+++ b/tests/pipeline/test_insert_done_error_handling.py
@@ -1,0 +1,507 @@
+"""Offline unit tests for the storage-flush error handling around
+``index_done_callback`` (PR #3187).
+
+These lock the ``LightRAG._insert_done`` / ``_discard_pending_index_ops`` /
+``_insert_done_with_cleanup`` contract that the file pipeline relies on to
+fail fast on a shared-buffer flush error instead of cascading every
+subsequent document into FAILED.
+
+The tests inject lightweight spy storages via ``_index_storages`` (and, for
+the enqueue-owned / LLM-cache special cases, by binding the spy onto the real
+``rag.full_docs`` / ``rag.doc_status`` / ``rag.llm_response_cache`` attributes
+so the ``is`` identity checks fire). No storage driver is imported and no real
+backend flush is exercised — this is pure lightrag.py logic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from uuid import uuid4
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG
+from lightrag.exceptions import IndexFlushError
+from lightrag.utils import EmbeddingFunc, Tokenizer
+
+pytestmark = pytest.mark.offline
+
+
+@pytest.fixture(autouse=True)
+def _propagate_lightrag_logs():
+    """The ``lightrag`` logger sets ``propagate=False``, so caplog's root
+    handler would miss its records. Re-enable propagation for these tests so
+    ``caplog`` can capture the best-effort error logs we assert on."""
+    lg = logging.getLogger("lightrag")
+    old = lg.propagate
+    lg.propagate = True
+    try:
+        yield
+    finally:
+        lg.propagate = old
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _mock_embedding(texts: list[str]) -> np.ndarray:
+    return np.ones((len(texts), 8), dtype=float)
+
+
+async def _noop_llm(*args, **kwargs) -> str:  # pragma: no cover - never invoked
+    return ""
+
+
+async def _make_rag(tmp_path) -> LightRAG:
+    rag = LightRAG(
+        working_dir=str(tmp_path / "wd"),
+        workspace=f"insdone-{uuid4().hex[:8]}",
+        llm_model_func=_noop_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8, max_token_size=1024, func=_mock_embedding
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+    )
+    await rag.initialize_storages()
+    return rag
+
+
+_UNSET = object()
+
+
+class _SpyStorage:
+    """Minimal stand-in for a StorageNameSpace with configurable flush/drop.
+
+    ``flush_error`` / ``drop_error`` are exception *instances* raised by the
+    respective coroutine. ``recorder`` is a shared list appended with
+    ``(label, "flush"|"drop")`` so call ordering across storages is assertable.
+    """
+
+    def __init__(
+        self,
+        label: str,
+        *,
+        namespace: str = "ns",
+        final_namespace=_UNSET,
+        flush_error: BaseException | None = None,
+        drop_error: BaseException | None = None,
+        recorder: list | None = None,
+    ):
+        self.label = label
+        self.namespace = namespace
+        if final_namespace is not _UNSET:
+            self.final_namespace = final_namespace
+        self._flush_error = flush_error
+        self._drop_error = drop_error
+        self._recorder = recorder if recorder is not None else []
+        self.index_done_calls = 0
+        self.drop_calls = 0
+
+    async def index_done_callback(self):
+        self.index_done_calls += 1
+        self._recorder.append((self.label, "flush"))
+        if self._flush_error is not None:
+            raise self._flush_error
+
+    async def drop_pending_index_ops(self):
+        self.drop_calls += 1
+        self._recorder.append((self.label, "drop"))
+        if self._drop_error is not None:
+            raise self._drop_error
+
+    async def finalize(self):
+        # No-op: keeps finalize_storages() quiet when a spy is bound onto a
+        # real storage attribute (full_docs / doc_status / llm_response_cache).
+        return None
+
+
+# ---------------------------------------------------------------------------
+# IndexFlushError class
+# ---------------------------------------------------------------------------
+
+
+def test_index_flush_error_attributes_and_message():
+    cause = RuntimeError("boom")
+    err = IndexFlushError("MilvusVectorDBStorage", "entities", cause)
+    assert err.storage_name == "MilvusVectorDBStorage"
+    assert err.namespace == "entities"
+    assert str(err) == "MilvusVectorDBStorage[entities] index flush failed: boom"
+    # __cause__ is NOT set by the constructor — only by `raise ... from e`
+    # inside _insert_done. That linkage is asserted in the _insert_done tests.
+    assert err.__cause__ is None
+
+
+# ---------------------------------------------------------------------------
+# _index_storages (internal contract — weak assertions)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_index_storages_filters_none_and_relative_order(tmp_path):
+    rag = await _make_rag(tmp_path)
+    try:
+        storages = rag._index_storages()
+        # None entries are filtered out.
+        assert all(s is not None for s in storages)
+        # Relative-order contract: enqueue-owned KVs come before the vdbs,
+        # and the LLM cache precedes every vector store. (No fixed count is
+        # asserted, so adding a new storage won't break this test.)
+        idx = {id(s): i for i, s in enumerate(storages)}
+        assert idx[id(rag.full_docs)] < idx[id(rag.entities_vdb)]
+        assert idx[id(rag.doc_status)] < idx[id(rag.entities_vdb)]
+        assert idx[id(rag.llm_response_cache)] < idx[id(rag.entities_vdb)]
+        assert idx[id(rag.llm_response_cache)] < idx[id(rag.chunks_vdb)]
+
+        # Filtering: drop one storage and confirm it disappears from the list.
+        rag.text_chunks = None
+        assert all(s is not None for s in rag._index_storages())
+    finally:
+        await rag.finalize_storages()
+
+
+# ---------------------------------------------------------------------------
+# _insert_done — success path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_insert_done_success_updates_pipeline_status(tmp_path, monkeypatch):
+    rag = await _make_rag(tmp_path)
+    try:
+        spies = [_SpyStorage("a"), _SpyStorage("b")]
+        monkeypatch.setattr(rag, "_index_storages", lambda: spies)
+        status = {"latest_message": "", "history_messages": []}
+        lock = asyncio.Lock()
+
+        await rag._insert_done(pipeline_status=status, pipeline_status_lock=lock)
+
+        assert all(s.index_done_calls == 1 for s in spies)
+        assert status["latest_message"] == "In memory DB persist to disk"
+        assert "In memory DB persist to disk" in status["history_messages"]
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_insert_done_success_without_status_no_update(tmp_path, monkeypatch):
+    rag = await _make_rag(tmp_path)
+    try:
+        spies = [_SpyStorage("a")]
+        monkeypatch.setattr(rag, "_index_storages", lambda: spies)
+        # Should not raise and not require a status dict.
+        await rag._insert_done()
+        await rag._insert_done(pipeline_status={"history_messages": []})  # lock None
+        assert spies[0].index_done_calls == 2
+    finally:
+        await rag.finalize_storages()
+
+
+# ---------------------------------------------------------------------------
+# _insert_done — failure wrapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_insert_done_single_failure_wraps_index_flush_error(
+    tmp_path, monkeypatch
+):
+    rag = await _make_rag(tmp_path)
+    try:
+        cause = RuntimeError("flush boom")
+        spies = [_SpyStorage("ok"), _SpyStorage("bad", flush_error=cause)]
+        monkeypatch.setattr(rag, "_index_storages", lambda: spies)
+
+        with pytest.raises(IndexFlushError) as ei:
+            await rag._insert_done()
+        assert ei.value.storage_name == "_SpyStorage"
+        # __cause__ linkage is established by `raise ... from e`.
+        assert ei.value.__cause__ is cause
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.parametrize(
+    "final_namespace, namespace, expected",
+    [
+        ("fns", "ns", "fns"),  # final_namespace wins
+        (_UNSET, "ns", "ns"),  # falls back to namespace
+        (_UNSET, "", ""),  # neither -> empty string
+    ],
+)
+@pytest.mark.asyncio
+async def test_insert_done_namespace_resolution(
+    tmp_path, monkeypatch, final_namespace, namespace, expected
+):
+    rag = await _make_rag(tmp_path)
+    try:
+        spy = _SpyStorage(
+            "bad",
+            namespace=namespace,
+            final_namespace=final_namespace,
+            flush_error=RuntimeError("x"),
+        )
+        monkeypatch.setattr(rag, "_index_storages", lambda: [spy])
+        with pytest.raises(IndexFlushError) as ei:
+            await rag._insert_done()
+        assert ei.value.namespace == expected
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_insert_done_multiple_failures_raises_first_logs_rest(
+    tmp_path, monkeypatch, caplog
+):
+    rag = await _make_rag(tmp_path)
+    try:
+        spies = [
+            _SpyStorage("a", flush_error=RuntimeError("first")),
+            _SpyStorage("b", flush_error=RuntimeError("second")),
+            _SpyStorage("c"),
+        ]
+        monkeypatch.setattr(rag, "_index_storages", lambda: spies)
+
+        with caplog.at_level("ERROR", logger="lightrag"):
+            with pytest.raises(IndexFlushError):
+                await rag._insert_done()
+
+        # gather(return_exceptions=True) runs ALL flushes to completion before
+        # raising — no detached coroutines.
+        assert all(s.index_done_calls == 1 for s in spies)
+        # The non-first failure is logged, not raised.
+        assert any(
+            "Additional index flush failure" in rec.message for rec in caplog.records
+        )
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_insert_done_cancelled_error_takes_priority(tmp_path, monkeypatch):
+    rag = await _make_rag(tmp_path)
+    try:
+        spies = [
+            _SpyStorage("normal", flush_error=RuntimeError("normal fail")),
+            _SpyStorage("cancel", flush_error=asyncio.CancelledError()),
+        ]
+        monkeypatch.setattr(rag, "_index_storages", lambda: spies)
+        # CancelledError must propagate as-is, not be wrapped in IndexFlushError.
+        with pytest.raises(asyncio.CancelledError):
+            await rag._insert_done()
+    finally:
+        await rag.finalize_storages()
+
+
+# ---------------------------------------------------------------------------
+# _discard_pending_index_ops
+# ---------------------------------------------------------------------------
+
+
+def _bind_enqueue_owned_spies(rag, recorder):
+    """Bind spies onto the identity-checked attributes and return the list
+    _index_storages should yield. ``other`` stands in for a regenerable vdb."""
+    full = _SpyStorage("full_docs", recorder=recorder)
+    status = _SpyStorage("doc_status", recorder=recorder)
+    cache = _SpyStorage("llm_cache", recorder=recorder)
+    other = _SpyStorage("other_vdb", recorder=recorder)
+    rag.full_docs = full
+    rag.doc_status = status
+    rag.llm_response_cache = cache
+    return full, status, cache, other
+
+
+@pytest.mark.asyncio
+async def test_discard_skip_enqueue_owned_true(tmp_path, monkeypatch):
+    rag = await _make_rag(tmp_path)
+    try:
+        rec: list = []
+        full, status, cache, other = _bind_enqueue_owned_spies(rag, rec)
+        monkeypatch.setattr(
+            rag, "_index_storages", lambda: [full, status, cache, other]
+        )
+
+        await rag._discard_pending_index_ops()  # skip_enqueue_owned=True default
+
+        # full_docs / doc_status are skipped.
+        assert full.drop_calls == 0
+        assert status.drop_calls == 0
+        # cache + other are dropped.
+        assert cache.drop_calls == 1
+        assert other.drop_calls == 1
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_discard_skip_enqueue_owned_false(tmp_path, monkeypatch):
+    rag = await _make_rag(tmp_path)
+    try:
+        rec: list = []
+        full, status, cache, other = _bind_enqueue_owned_spies(rag, rec)
+        monkeypatch.setattr(
+            rag, "_index_storages", lambda: [full, status, cache, other]
+        )
+
+        await rag._discard_pending_index_ops(skip_enqueue_owned=False)
+
+        # Now full_docs / doc_status are ALSO dropped.
+        assert full.drop_calls == 1
+        assert status.drop_calls == 1
+        assert cache.drop_calls == 1
+        assert other.drop_calls == 1
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_discard_llm_cache_flush_before_drop(tmp_path, monkeypatch):
+    rag = await _make_rag(tmp_path)
+    try:
+        rec: list = []
+        full, status, cache, other = _bind_enqueue_owned_spies(rag, rec)
+        monkeypatch.setattr(
+            rag, "_index_storages", lambda: [full, status, cache, other]
+        )
+
+        await rag._discard_pending_index_ops()
+
+        # The LLM cache is flushed (index_done_callback) BEFORE its buffer is
+        # dropped — expensive cached results are persisted maximally first.
+        assert ("llm_cache", "flush") in rec
+        assert rec.index(("llm_cache", "flush")) < rec.index(("llm_cache", "drop"))
+        # Non-cache storages are only dropped, never flushed here.
+        assert ("other_vdb", "flush") not in rec
+        assert cache.index_done_calls == 1
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_discard_best_effort_swallows_drop_error(tmp_path, monkeypatch, caplog):
+    rag = await _make_rag(tmp_path)
+    try:
+        rec: list = []
+        full, status, cache, _ = _bind_enqueue_owned_spies(rag, rec)
+        boom = _SpyStorage(
+            "boom_vdb", drop_error=RuntimeError("drop boom"), recorder=rec
+        )
+        after = _SpyStorage("after_vdb", recorder=rec)
+        monkeypatch.setattr(rag, "_index_storages", lambda: [cache, boom, after])
+
+        with caplog.at_level("ERROR", logger="lightrag"):
+            # Must NOT raise — cleanup is best-effort and never masks the
+            # original abort cause.
+            await rag._discard_pending_index_ops()
+
+        assert boom.drop_calls == 1
+        # A later storage is still processed despite the earlier drop error.
+        assert after.drop_calls == 1
+        assert any(
+            "Failed to discard pending ops" in rec_.message for rec_ in caplog.records
+        )
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_discard_llm_cache_flush_error_swallowed_still_drops(
+    tmp_path, monkeypatch, caplog
+):
+    rag = await _make_rag(tmp_path)
+    try:
+        rec: list = []
+        cache = _SpyStorage(
+            "llm_cache", flush_error=RuntimeError("cache flush boom"), recorder=rec
+        )
+        rag.llm_response_cache = cache
+        monkeypatch.setattr(rag, "_index_storages", lambda: [cache])
+
+        with caplog.at_level("ERROR", logger="lightrag"):
+            await rag._discard_pending_index_ops()
+
+        # Flush failed (logged), but the drop still ran so a poisoned cache
+        # item cannot wedge the next batch.
+        assert cache.index_done_calls == 1
+        assert cache.drop_calls == 1
+        assert any(
+            "Failed to persist LLM cache on abort" in r.message for r in caplog.records
+        )
+    finally:
+        await rag.finalize_storages()
+
+
+# ---------------------------------------------------------------------------
+# _insert_done_with_cleanup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_insert_done_with_cleanup_success_no_discard(tmp_path, monkeypatch):
+    rag = await _make_rag(tmp_path)
+    try:
+        monkeypatch.setattr(rag, "_index_storages", lambda: [_SpyStorage("a")])
+        discard_calls = 0
+
+        async def spy_discard(*, skip_enqueue_owned=True):
+            nonlocal discard_calls
+            discard_calls += 1
+
+        monkeypatch.setattr(rag, "_discard_pending_index_ops", spy_discard)
+        await rag._insert_done_with_cleanup()
+        assert discard_calls == 0
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_insert_done_with_cleanup_index_flush_error_discards_and_reraises(
+    tmp_path, monkeypatch
+):
+    rag = await _make_rag(tmp_path)
+    try:
+        spy = _SpyStorage("bad", flush_error=RuntimeError("boom"))
+        monkeypatch.setattr(rag, "_index_storages", lambda: [spy])
+        seen_kwargs = {}
+
+        async def spy_discard(*, skip_enqueue_owned=True):
+            seen_kwargs["skip_enqueue_owned"] = skip_enqueue_owned
+
+        monkeypatch.setattr(rag, "_discard_pending_index_ops", spy_discard)
+
+        with pytest.raises(IndexFlushError):
+            await rag._insert_done_with_cleanup()
+        # Direct callers clear full_docs too.
+        assert seen_kwargs == {"skip_enqueue_owned": False}
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_insert_done_with_cleanup_cancelled_propagates_no_discard(
+    tmp_path, monkeypatch
+):
+    rag = await _make_rag(tmp_path)
+    try:
+        spy = _SpyStorage("cancel", flush_error=asyncio.CancelledError())
+        monkeypatch.setattr(rag, "_index_storages", lambda: [spy])
+        discard_calls = 0
+
+        async def spy_discard(*, skip_enqueue_owned=True):
+            nonlocal discard_calls
+            discard_calls += 1
+
+        monkeypatch.setattr(rag, "_discard_pending_index_ops", spy_discard)
+
+        # CancelledError is not an IndexFlushError, so cleanup must NOT run.
+        with pytest.raises(asyncio.CancelledError):
+            await rag._insert_done_with_cleanup()
+        assert discard_calls == 0
+    finally:
+        await rag.finalize_storages()

--- a/tests/pipeline/test_pipeline_internal_abort.py
+++ b/tests/pipeline/test_pipeline_internal_abort.py
@@ -1,0 +1,390 @@
+"""Offline tests for the pipeline's internal-abort path (PR #3187).
+
+Two layers:
+
+* Pure helpers — ``_cancellation_label`` / ``_raise_if_cancelled`` /
+  ``_cancellation_requested`` — drive the user-cancel vs internal-error
+  distinction directly.
+* End-to-end — enqueue a real document and drive
+  ``apipeline_process_enqueue_documents`` with a storage flush forced to fail,
+  asserting the *current* semantics (not idealized ones, per review):
+    - the doc that triggers the flush error is FAILED with ``str(IndexFlushError)``
+      and a "Merging stage failed" status message (NOT a cancellation label);
+    - the finally cleanup surfaces an actionable "Pipeline halted on internal
+      storage error" message (and makes it latest_message) on the normal break
+      exit path, not just the generic "stopped" line;
+    - ``_discard_pending_index_ops`` is the observable internal-abort signal;
+    - the post-merge / pre-PROCESSED cancellation guard prevents an in-flight
+      sibling document from being mis-marked PROCESSED (deterministic injection
+      via a ``merge_nodes_and_edges`` wrapper, not a parallelism race);
+    - ``_process_worker`` survives an unhandled per-doc error without wedging
+      ``q_process.join()``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+import numpy as np
+import pytest
+
+import lightrag.pipeline as pipeline_module
+from lightrag import LightRAG
+from lightrag.base import DocProcessingStatus, DocStatus
+from lightrag.exceptions import PipelineCancelledException
+from lightrag.kg.shared_storage import get_namespace_data, get_namespace_lock
+from lightrag.pipeline import _BatchRunContext
+from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
+
+pytestmark = pytest.mark.offline
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _dummy_embedding(texts: list[str]) -> np.ndarray:
+    return np.ones((len(texts), 8), dtype=float)
+
+
+async def _dummy_llm(*args, **kwargs) -> str:
+    return "ok"
+
+
+def _deterministic_chunking(
+    tokenizer,
+    content: str,
+    split_by_character,
+    split_by_character_only: bool,
+    chunk_overlap_token_size: int,
+    chunk_token_size: int,
+) -> list[dict]:
+    return [
+        {"tokens": 1, "content": f"{content}::chunk1", "chunk_order_index": 0},
+        {"tokens": 1, "content": f"{content}::chunk2", "chunk_order_index": 1},
+    ]
+
+
+def _status_to_text(status: object) -> str:
+    if isinstance(status, DocStatus):
+        return status.value
+    return str(status).replace("DocStatus.", "").lower()
+
+
+async def _build_rag(tmp_path, *, max_parallel_insert: int = 1) -> LightRAG:
+    rag = LightRAG(
+        working_dir=str(tmp_path / "wd"),
+        workspace=f"abort-{uuid4().hex[:8]}",
+        llm_model_func=_dummy_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8, max_token_size=8192, func=_dummy_embedding
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        chunking_func=_deterministic_chunking,
+        max_parallel_insert=max_parallel_insert,
+    )
+    await rag.initialize_storages()
+    return rag
+
+
+def _make_status_doc(doc_id: str) -> DocProcessingStatus:
+    now = datetime.now(timezone.utc).isoformat()
+    return DocProcessingStatus(
+        content_summary=f"summary-{doc_id}",
+        content_length=10,
+        file_path=f"{doc_id}.txt",
+        status=DocStatus.PENDING,
+        created_at=now,
+        updated_at=now,
+        track_id=None,
+        content_hash=f"hash-{doc_id}",
+    )
+
+
+# ===========================================================================
+# Pure helpers
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_cancellation_label_internal_with_detail(tmp_path):
+    rag = await _build_rag(tmp_path)
+    try:
+        status = {
+            "cancellation_reason": "internal_error",
+            "cancellation_detail": "MilvusVectorDBStorage[entities]: boom",
+        }
+        assert rag._cancellation_label(status) == (
+            "Cancelled by internal error: MilvusVectorDBStorage[entities]: boom"
+        )
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_label_internal_without_detail(tmp_path):
+    rag = await _build_rag(tmp_path)
+    try:
+        status = {"cancellation_reason": "internal_error", "cancellation_detail": None}
+        assert rag._cancellation_label(status) == (
+            "Cancelled by internal error: unknown"
+        )
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_label_user(tmp_path):
+    rag = await _build_rag(tmp_path)
+    try:
+        assert rag._cancellation_label({}) == "User cancelled"
+        assert (
+            rag._cancellation_label({"cancellation_reason": None}) == "User cancelled"
+        )
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_raise_if_cancelled(tmp_path):
+    rag = await _build_rag(tmp_path)
+    try:
+        lock = asyncio.Lock()
+        # Not requested -> no raise.
+        await rag._raise_if_cancelled({"cancellation_requested": False}, lock)
+        # Requested -> PipelineCancelledException.
+        with pytest.raises(PipelineCancelledException):
+            await rag._raise_if_cancelled({"cancellation_requested": True}, lock)
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_requested_returns_bool(tmp_path):
+    rag = await _build_rag(tmp_path)
+    try:
+        lock = asyncio.Lock()
+        assert await rag._cancellation_requested({}, lock) is False
+        assert (
+            await rag._cancellation_requested({"cancellation_requested": True}, lock)
+            is True
+        )
+    finally:
+        await rag.finalize_storages()
+
+
+# ===========================================================================
+# e2e — IndexFlushError aborts the batch
+# ===========================================================================
+
+
+def _fail_flush(monkeypatch, storage):
+    """Force a storage's index_done_callback to raise (simulating a flush
+    failure) so _insert_done wraps it in IndexFlushError."""
+
+    async def boom():
+        raise RuntimeError("vdb flush boom")
+
+    monkeypatch.setattr(storage, "index_done_callback", boom)
+
+
+@pytest.mark.asyncio
+async def test_index_flush_error_marks_failed_with_real_semantics(
+    tmp_path, monkeypatch
+):
+    rag = await _build_rag(tmp_path)
+    try:
+        content = "internal abort document"
+        file_path = "abort.txt"
+        doc_id = compute_mdhash_id(file_path, prefix="doc-")
+        await rag.apipeline_enqueue_documents(input=content, file_paths=file_path)
+
+        _fail_flush(monkeypatch, rag.chunks_vdb)
+        await rag.apipeline_process_enqueue_documents()
+
+        doc_status = await rag.doc_status.get_by_id(doc_id)
+        assert doc_status is not None
+        assert _status_to_text(doc_status["status"]) == "failed"
+        # The triggering doc records str(IndexFlushError) — NOT a cancel label
+        # (it goes through _finalize_doc_failure's non-cancel branch).
+        assert "index flush failed" in doc_status["error_msg"]
+        assert "Cancelled by internal error" not in doc_status["error_msg"]
+
+        pipeline_status = await get_namespace_data(
+            "pipeline_status", workspace=rag.workspace
+        )
+        history = "\n".join(pipeline_status.get("history_messages", []))
+        assert "Merging stage failed in document" in history
+        # The finally cleanup surfaces the actionable halt reason on the
+        # normal break exit path (not just the generic "stopped" line), and
+        # makes it the latest_message so it is what the user sees.
+        assert "Pipeline halted on internal storage error" in history
+        assert "Pipeline halted on internal storage error" in pipeline_status.get(
+            "latest_message", ""
+        )
+        # Cancellation flags are reset by the finally block on the way out.
+        assert pipeline_status.get("cancellation_requested") is False
+        assert pipeline_status.get("cancellation_reason") is None
+        assert pipeline_status.get("cancellation_detail") is None
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_batch_discards_pending_on_internal_abort(
+    tmp_path, monkeypatch
+):
+    rag = await _build_rag(tmp_path)
+    try:
+        await rag.apipeline_enqueue_documents(
+            input="discard document", file_paths="discard.txt"
+        )
+        _fail_flush(monkeypatch, rag.chunks_vdb)
+
+        discard_calls = 0
+        orig_discard = rag._discard_pending_index_ops
+
+        async def spy_discard(*, skip_enqueue_owned=True):
+            nonlocal discard_calls
+            discard_calls += 1
+            await orig_discard(skip_enqueue_owned=skip_enqueue_owned)
+
+        monkeypatch.setattr(rag, "_discard_pending_index_ops", spy_discard)
+
+        await rag.apipeline_process_enqueue_documents()
+
+        # _run_pipeline_batch discards the shared buffers once on internal abort.
+        assert discard_calls >= 1
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_cascade_guard_prevents_processed_after_sibling_abort(
+    tmp_path, monkeypatch
+):
+    """The post-merge / pre-PROCESSED guard ([pipeline.py] _raise_if_cancelled)
+    bails a doc out as cancelled when a sibling already aborted — so it is NOT
+    mis-marked PROCESSED and _insert_done is NOT re-run on the torn-down buffer.
+
+    Deterministic injection: wrap merge_nodes_and_edges so the abort flag is
+    flipped right after merge completes (i.e. between the two guards), then
+    assert the guard fires.
+    """
+    rag = await _build_rag(tmp_path)
+    try:
+        await rag.apipeline_enqueue_documents(
+            input="cascade document", file_paths="cascade.txt"
+        )
+        doc_id = compute_mdhash_id("cascade.txt", prefix="doc-")
+
+        orig_merge = pipeline_module.merge_nodes_and_edges
+
+        async def merge_then_abort(**kwargs):
+            result = await orig_merge(**kwargs)
+            status = kwargs["pipeline_status"]
+            lock = kwargs["pipeline_status_lock"]
+            async with lock:
+                status["cancellation_requested"] = True
+                status["cancellation_reason"] = "internal_error"
+                status["cancellation_detail"] = "sibling abort"
+            return result
+
+        monkeypatch.setattr(pipeline_module, "merge_nodes_and_edges", merge_then_abort)
+
+        insert_done_calls = 0
+        orig_insert_done = rag._insert_done
+
+        async def spy_insert_done(*a, **k):
+            nonlocal insert_done_calls
+            insert_done_calls += 1
+            await orig_insert_done(*a, **k)
+
+        monkeypatch.setattr(rag, "_insert_done", spy_insert_done)
+
+        await rag.apipeline_process_enqueue_documents()
+
+        doc_status = await rag.doc_status.get_by_id(doc_id)
+        assert _status_to_text(doc_status["status"]) == "failed"
+        # The guard fired BEFORE the PROCESSED transition + _insert_done.
+        assert insert_done_calls == 0
+
+        pipeline_status = await get_namespace_data(
+            "pipeline_status", workspace=rag.workspace
+        )
+        history = "\n".join(pipeline_status.get("history_messages", []))
+        assert "Cancelled by internal error" in history
+    finally:
+        await rag.finalize_storages()
+
+
+# ===========================================================================
+# _process_worker resilience
+# ===========================================================================
+
+
+async def _make_ctx(rag: LightRAG) -> tuple[_BatchRunContext, dict, Any]:
+    pipeline_status = await get_namespace_data(
+        "pipeline_status", workspace=rag.workspace
+    )
+    pipeline_status_lock = get_namespace_lock(
+        "pipeline_status", workspace=rag.workspace
+    )
+    pipeline_status.clear()
+    pipeline_status.update(
+        {
+            "busy": True,
+            "history_messages": [],
+            "latest_message": "",
+            "cancellation_requested": False,
+            "cancellation_reason": None,
+            "cancellation_detail": None,
+        }
+    )
+    ctx = _BatchRunContext(
+        pipeline_status=pipeline_status,
+        pipeline_status_lock=pipeline_status_lock,
+        semaphore=asyncio.Semaphore(2),
+        total_files=1,
+        q_native=asyncio.Queue(),
+        q_mineru=asyncio.Queue(),
+        q_docling=asyncio.Queue(),
+        q_analyze=asyncio.Queue(),
+        q_process=asyncio.Queue(),
+    )
+    return ctx, pipeline_status, pipeline_status_lock
+
+
+@pytest.mark.asyncio
+async def test_process_worker_survives_unhandled_error(tmp_path, monkeypatch):
+    rag = await _build_rag(tmp_path)
+    try:
+        ctx, status, _ = await _make_ctx(rag)
+
+        async def boom(**kwargs):
+            raise RuntimeError("worker boom")
+
+        monkeypatch.setattr(rag, "process_single_document", boom)
+        await ctx.q_process.put(("doc-1", _make_status_doc("doc-1"), {}))
+
+        worker = asyncio.create_task(rag._process_worker(ctx))
+        try:
+            # join() returning proves the worker did NOT die — it drained the
+            # item (task_done) instead of hanging the queue forever.
+            await asyncio.wait_for(ctx.q_process.join(), timeout=2.0)
+        finally:
+            worker.cancel()
+            await asyncio.gather(worker, return_exceptions=True)
+
+        assert status["cancellation_requested"] is True
+        assert status["cancellation_reason"] == "internal_error"
+        assert "process worker unhandled error" in status["cancellation_detail"]
+    finally:
+        await rag.finalize_storages()


### PR DESCRIPTION
## Description

Production file-processing pipeline cascaded into FAILED documents after a single file errored with:

```
MilvusException: (code=1100, message=length of varchar field entity_name exceeds max length, row number: 28, length: 694, max length: 512)
```

Once one file's vector flush failed, every subsequent (otherwise fine) file failed too. There are **two independent root causes**, plus a cross-backend silent-failure audit.

### Root cause A — char vs byte truncation
`_truncate_entity_identifier` truncated identifiers by **character** count, but Milvus enforces `VARCHAR max_length` in **UTF-8 bytes**. 256 Chinese chars ≈ 694 bytes > 512, so both JSON- and text-mode extraction overflowed despite the existing 256-char cap (confirmed via Milvus docs: *"Milvus uses byte size for its max-length checks, not character count"*). Fixed by truncating against **both** a char limit (256) and a byte limit (`DEFAULT_ENTITY_NAME_MAX_BYTES = 512`), cutting on a character boundary. This single choke point covers the JSON, text and cache-rebuild extraction paths.

### Root cause B — deferred cross-file flush vs per-file atomicity
Files are processed concurrently and share one instance-level vector buffer flushed per file by `index_done_callback`. On a flush error the buffer was retained, so the poisoned record was re-flushed by every subsequent file → cascade. Because the buffer is shared and untagged, a flush error **cannot be attributed to a single document**, and silently skipping records would violate per-file insert atomicity. Now `_insert_done` wraps each storage and raises `IndexFlushError` (driver + namespace + cause); the pipeline aborts the batch via `pipeline_status["cancellation_requested"]` with reason `internal_error`, and cancellation messages distinguish internal errors from user cancels.

## Related Issues

N/A (production incident).

## Changes Made

- **`operate.py` / `constants.py`** — `_truncate_entity_identifier` enforces char **and** UTF-8 byte limits; add `DEFAULT_ENTITY_NAME_MAX_BYTES = 512`.
- **`lightrag.py`** — `_insert_done` attributes per-storage flush failures as `IndexFlushError`; add `_discard_pending_index_ops()` (preserves the LLM cache).
- **`pipeline.py`** — abort the batch on `IndexFlushError` via `cancellation_requested` (reason/detail = driver + root cause); cancellation messages distinguish internal vs user cancel; discard stale buffers after workers drain; cancel-check before `_insert_done` so in-flight docs don't re-flush.
- **`base.py` + all buffered backends** — add `drop_pending_index_ops()` (no-op default; overridden by milvus, opensearch vector+KV, qdrant, postgres, mongo, faiss, nano) to drop regenerable buffers on abort. The LLM response cache is handled specially: on abort it is **flushed before** its buffer is dropped (re-running LLM calls is expensive, so writable cached entries are persisted maximally), and only an unwritable/poisoned entry is then discarded so it cannot re-abort every subsequent batch. See `_discard_pending_index_ops` for the exact flush-then-drop ordering.
- **`opensearch_impl.py`** — stop swallowing failures so the abort policy holds: permanent (non-retryable 4xx) bulk failures now raise instead of being silently dropped; `index_done_callback` refresh no longer `except Exception: pass`; `DocStatusStorage.upsert` surfaces `OpenSearchException`.
- **tests** — updated 3 OpenSearch tests to the raise-on-permanent-failure semantics; added `drop_pending_index_ops` coverage.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

- Full regression: `tests/pipeline/`, `tests/extraction/`, `tests/kg/` → **952 passed, 19 skipped** (skips require live DBs). `ruff check` clean; `ruff format` clean against the repo-pinned ruff `v0.6.4`.
- **Ops note for the affected deployment:** the long-running worker still holds the old over-length records in its in-memory shared buffer, so after deploying, **restart the worker** to clear it, then re-run the previously FAILED documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

