### PR TITLE
🐛 fix(pipeline): clean stale per-attempt metadata earlier for PENDING docs

### DIFF
--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -83,7 +83,10 @@ from lightrag.utils_pipeline import (
     load_lightrag_document_content,
     make_lightrag_doc_content,
     normalize_document_file_path,
+    doc_status_metadata_has_attempt_fields,
+    doc_status_reset_metadata,
     parsed_artifact_dir_for,
+    read_source_file_basename,
     resolve_doc_file_path,
     sidecar_blocks_path,
     sidecar_uri_for,
@@ -126,18 +129,11 @@ def _call_source_file_resolver(
     return resolver(source_file or file_path)
 
 
-def _read_source_file(data: Any) -> str | None:
-    """Read the source-file basename with backward compatibility.
-
-    The ``source_file_name`` → ``source_file`` rename means documents enqueued
-    before the change persisted the old key in full_docs content_data /
-    doc_status.metadata.  Resumed/legacy docs are read through here so they
-    still resolve their original source basename; write sites always use the
-    new ``source_file`` key.
-    """
-    if not isinstance(data, dict):
-        return None
-    return data.get("source_file") or data.get("source_file_name")
+# Backward-compatible source-file reader.  Implementation lives in
+# utils_pipeline so reset/normalisation helpers there can reuse it without a
+# reverse import into this module; kept as a module-level alias for the
+# existing call sites below.
+_read_source_file = read_source_file_basename
 
 
 # Map ``process_options.chunking`` selector → ``extraction_meta.chunk_method``
@@ -1393,51 +1389,80 @@ class _PipelineMixin:
         #     pipeline_status["latest_message"] = final_message
         #     pipeline_status["history_messages"].append(final_message)
 
-        # Reset interrupted documents that pass consistency checks to PENDING status
+        # Bring every to-be-processed document into a clean PENDING state.
+        # Two cases are handled here so stale per-attempt metadata never
+        # survives into the PENDING wait window (where the WebUI would render
+        # last attempt's parse/analyze timings):
+        #   * interrupted docs (PROCESSING/PARSING/ANALYZING/FAILED) are reset
+        #     to PENDING, clearing error_msg and resetting metadata to the
+        #     enqueue-time directives only;
+        #   * docs that are ALREADY PENDING but still carry per-attempt fields
+        #     (e.g. reset by an older build that preserved them) are normalised
+        #     in place to directives-only.
+        # In BOTH cases the cleaned metadata is mirrored back onto the in-memory
+        # ``status_doc`` so the downstream parse worker — which no longer scrubs
+        # stale keys itself — carries the clean dict forward through
+        # ``doc_status_transition_metadata`` at every later transition.
         docs_to_reset = {}
         reset_count = 0
+        normalized_count = 0
 
         for doc_id, status_doc in to_process_docs.items():
             # Check if document has corresponding content in full_docs (consistency check)
             content_data = await self.full_docs.get_by_id(doc_id)
-            if content_data:  # Document passes consistency check
-                # Check if document is in interrupted status
-                if hasattr(status_doc, "status") and status_doc.status in [
-                    DocStatus.PROCESSING,
-                    DocStatus.FAILED,
-                    DocStatus.PARSING,
-                    DocStatus.ANALYZING,
-                ]:
-                    preserved_chunks_list, preserved_chunks_count = (
-                        chunk_fields_from_status_doc(status_doc)
-                    )
-                    resolved_file_path = resolve_doc_file_path(
-                        status_doc=status_doc,
-                        content_data=content_data,
-                    )
-                    # Prepare document for status reset to PENDING
-                    docs_to_reset[doc_id] = {
-                        "status": DocStatus.PENDING,
-                        "content_summary": status_doc.content_summary,
-                        "content_length": status_doc.content_length,
-                        "chunks_count": preserved_chunks_count,
-                        "chunks_list": preserved_chunks_list,
-                        "created_at": status_doc.created_at,
-                        "updated_at": datetime.now(timezone.utc).isoformat(),
-                        "file_path": resolved_file_path,
-                        "track_id": getattr(status_doc, "track_id", ""),
-                        "content_hash": getattr(status_doc, "content_hash", None),
-                        # Clear transient error / processing fields but preserve
-                        # long-lived per-doc metadata (process_options) seeded
-                        # at enqueue time.
-                        "error_msg": "",
-                        "metadata": doc_status_transition_metadata(status_doc),
-                    }
+            if not content_data:  # Fails consistency check; handled above
+                continue
+            status = getattr(status_doc, "status", None)
+            is_interrupted = status in (
+                DocStatus.PROCESSING,
+                DocStatus.FAILED,
+                DocStatus.PARSING,
+                DocStatus.ANALYZING,
+            )
+            # Only normalise an already-PENDING doc when it actually carries a
+            # stale per-attempt field — a precise trigger so unrelated/custom
+            # metadata on a clean PENDING is never rewritten or dropped.
+            needs_pending_normalize = (
+                status == DocStatus.PENDING
+                and doc_status_metadata_has_attempt_fields(status_doc)
+            )
+            if not (is_interrupted or needs_pending_normalize):
+                continue
 
-                    # Update the status in to_process_docs as well
-                    status_doc.status = DocStatus.PENDING
-                    status_doc.file_path = resolved_file_path
-                    reset_count += 1
+            preserved_chunks_list, preserved_chunks_count = (
+                chunk_fields_from_status_doc(status_doc)
+            )
+            resolved_file_path = resolve_doc_file_path(
+                status_doc=status_doc,
+                content_data=content_data,
+            )
+            # Directives-only metadata: drop per-attempt timing/result fields,
+            # keep process_options / source_file (legacy source_file_name
+            # tolerant).
+            reset_metadata = doc_status_reset_metadata(status_doc)
+            docs_to_reset[doc_id] = {
+                "status": DocStatus.PENDING,
+                "content_summary": status_doc.content_summary,
+                "content_length": status_doc.content_length,
+                "chunks_count": preserved_chunks_count,
+                "chunks_list": preserved_chunks_list,
+                "created_at": status_doc.created_at,
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+                "file_path": resolved_file_path,
+                "track_id": getattr(status_doc, "track_id", ""),
+                "content_hash": getattr(status_doc, "content_hash", None),
+                "error_msg": "",
+                "metadata": reset_metadata,
+            }
+
+            # Mirror onto the in-memory status_doc so workers carry it forward.
+            status_doc.status = DocStatus.PENDING
+            status_doc.file_path = resolved_file_path
+            status_doc.metadata = reset_metadata
+            if is_interrupted:
+                reset_count += 1
+            else:
+                normalized_count += 1
 
         # Update doc_status storage if there are documents to reset
         if docs_to_reset:
@@ -1447,6 +1472,12 @@ class _PipelineMixin:
                 reset_message = (
                     f"Reset {reset_count} documents from "
                     "PARSING/ANALYZING/PROCESSING/FAILED to PENDING status"
+                    + (
+                        f"; normalized {normalized_count} PENDING document(s) "
+                        "with stale metadata"
+                        if normalized_count
+                        else ""
+                    )
                 )
                 logger.info(reset_message)
                 pipeline_status["latest_message"] = reset_message
@@ -1563,25 +1594,11 @@ class _PipelineMixin:
                 # subsequent state transition for stage-duration analysis.
                 if not isinstance(status_doc_w.metadata, dict):
                     status_doc_w.metadata = {}
-                # Drop stale per-attempt fields from any prior failed/retried
-                # attempt before stamping the new parse_start_time. All of
-                # these are written by either this worker (cache-hit /
-                # cache-miss branches below) or the downstream analyze worker,
-                # and would otherwise be carried forward via carry-over,
-                # skewing stage-duration metrics and the raw-cache-hit /
-                # skipped signals for the new attempt. The cache-hit mirror
-                # block only writes ``parse_stage_skipped`` when the parser
-                # actually returns a hit; the cache-miss branch only writes
-                # ``parse_end_time`` when parse actually runs; the analyze
-                # worker writes its pair on re-entry.
-                for _stale_key in (
-                    "parse_end_time",
-                    "parse_stage_skipped",
-                    "analyzing_start_time",
-                    "analyzing_end_time",
-                    "analyzing_stage_skipped",
-                ):
-                    status_doc_w.metadata.pop(_stale_key, None)
+                # Stale per-attempt fields (parse_end_time / *_stage_skipped /
+                # analyzing_*) from a prior failed/retried attempt are already
+                # scrubbed when the document is brought to PENDING in
+                # _validate_and_fix_document_consistency (the single cleanup
+                # point), so they are not carried into this PARSING upsert.
                 status_doc_w.metadata["parse_start_time"] = int(time.time())
                 await self._upsert_doc_status_transition(
                     doc_id=doc_id_w,

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -171,6 +171,21 @@ def doc_status_field(doc: Any, field: str, default: Any = "") -> Any:
     return getattr(doc, field, default)
 
 
+def read_source_file_basename(data: Any) -> str | None:
+    """Read the source-file basename with backward compatibility.
+
+    The ``source_file_name`` → ``source_file`` rename means documents enqueued
+    before the change persisted the old key in full_docs content_data /
+    doc_status.metadata.  Read through here so resumed/legacy docs still resolve
+    their original source basename; write sites always use the new
+    ``source_file`` key.  Lives here (not in pipeline.py) so utils_pipeline
+    helpers can reuse it without importing back into the pipeline module.
+    """
+    if not isinstance(data, dict):
+        return None
+    return data.get("source_file") or data.get("source_file_name")
+
+
 # Long-lived per-document metadata fields that must survive every
 # doc_status state transition.  ``process_options`` records the user's
 # per-file processing strategy at enqueue time and is read by analyze /
@@ -272,6 +287,91 @@ def doc_status_transition_metadata(
     if extra:
         payload.update(extra)
     return payload
+
+
+# Long-lived per-document *directives* that record how the document should be
+# processed (written at enqueue time by ``_initial_doc_status``).  Unlike the
+# full carry-over list above, this is the subset that must survive a *reset*
+# back to PENDING: it deliberately EXCLUDES the per-attempt timing / result
+# fields (``parse_*`` / ``analyzing_*`` / ``parse_warnings`` / ``chunk_opts``),
+# which the next attempt regenerates and which would otherwise show stale
+# values while the document waits in PENDING.
+_DOC_STATUS_METADATA_DIRECTIVE_KEYS: tuple[str, ...] = (
+    "process_options",
+    "source_file",
+)
+
+
+# Per-attempt metadata produced by a parse/analyze/process attempt.  Used as
+# the *precise* trigger for normalising an already-PENDING document's metadata
+# (see ``apipeline_process_enqueue_documents``' consistency check): only a
+# document carrying one of these stale keys is rebuilt to directives-only, so
+# unrelated (future / custom) metadata is never dropped just for being
+# non-directive.  Covers the timing/skip pairs, parser warnings, and the
+# ``extraction_meta`` fields stamped when entering PROCESSING.
+_DOC_STATUS_METADATA_ATTEMPT_KEYS: frozenset[str] = frozenset(
+    {
+        "parse_start_time",
+        "parse_end_time",
+        "parse_stage_skipped",
+        "analyzing_start_time",
+        "analyzing_end_time",
+        "analyzing_stage_skipped",
+        "parse_warnings",
+        "chunk_opts",
+        "process_start_time",
+        "process_end_time",
+        "parse_format",
+        "parse_engine",
+        "chunk_method",
+        "skip_kg",
+        "mm_chunks",
+        "hard_fallback_split",
+    }
+)
+
+
+def doc_status_reset_metadata(status_doc: Any) -> dict[str, Any]:
+    """Build the ``metadata`` payload for a reset back to PENDING.
+
+    Keeps only the long-lived processing directives
+    (``_DOC_STATUS_METADATA_DIRECTIVE_KEYS``) and drops every per-attempt
+    timing/result field, so a document that is interrupted and re-queued does
+    not surface stale parse/analyze timings (or warnings / chunk opts) while it
+    waits in PENDING.  ``source_file`` is read with legacy ``source_file_name``
+    tolerance and normalised onto the new key, mirroring the parse worker's own
+    normalisation so a resumed legacy pending_parse doc keeps its source hint.
+    """
+    payload: dict[str, Any] = {}
+    raw_metadata = doc_status_field(status_doc, "metadata", {})
+    if not isinstance(raw_metadata, dict):
+        return payload
+    # Iterate the directive whitelist so a future addition to
+    # _DOC_STATUS_METADATA_DIRECTIVE_KEYS is automatically carried across a
+    # reset.  ``source_file`` is read with legacy ``source_file_name``
+    # tolerance and normalised onto the new key; all other directives carry
+    # verbatim when present and non-blank.
+    for key in _DOC_STATUS_METADATA_DIRECTIVE_KEYS:
+        if key == "source_file":
+            value = read_source_file_basename(raw_metadata)
+        else:
+            value = raw_metadata.get(key)
+        if value not in (None, ""):
+            payload[key] = value
+    return payload
+
+
+def doc_status_metadata_has_attempt_fields(status_doc: Any) -> bool:
+    """True when ``status_doc.metadata`` carries any per-attempt field.
+
+    Used to decide whether an already-PENDING document needs its metadata
+    normalised to directives-only — avoids a redundant upsert for documents
+    whose metadata is already clean (or only holds non-attempt custom fields).
+    """
+    raw_metadata = doc_status_field(status_doc, "metadata", {})
+    if not isinstance(raw_metadata, dict):
+        return False
+    return not _DOC_STATUS_METADATA_ATTEMPT_KEYS.isdisjoint(raw_metadata)
 
 
 def doc_status_value(doc: Any) -> str:

--- a/tests/pipeline/test_doc_status_reset_metadata.py
+++ b/tests/pipeline/test_doc_status_reset_metadata.py
@@ -19,7 +19,7 @@ from uuid import uuid4
 import numpy as np
 import pytest
 
-from lightrag.base import DocStatus
+from lightrag.base import DocProcessingStatus, DocStatus
 from lightrag.lightrag import LightRAG
 from lightrag.utils import EmbeddingFunc, Tokenizer
 from lightrag.utils_pipeline import (
@@ -364,5 +364,92 @@ async def test_pending_custom_metadata_semantic_lock(tmp_path):
         mixed_stored = await rag.doc_status.get_by_id(stale_plus_custom_id)
         assert mixed_stored["metadata"] == {"process_options": "F"}
         assert "custom_field" not in mixed_stored["metadata"]
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_reset_and_normalize_with_string_status(tmp_path):
+    """Non-JSON backends (Redis/Mongo/OpenSearch/Postgres) hydrate
+    ``DocProcessingStatus.status`` as a raw string (``"processing"`` /
+    ``"pending"``) rather than a ``DocStatus`` member.  Because ``DocStatus``
+    subclasses ``str``, the enum-membership checks in
+    ``_validate_and_fix_document_consistency`` still match — this test pins
+    that behaviour so a future change to ``DocStatus`` (e.g. dropping the
+    ``str`` base) cannot silently stop string-status docs from being cleaned.
+
+    Builds the ``to_process_docs`` objects directly with string statuses to
+    exercise the string path (``get_docs_by_status`` would return enum-valued
+    members from the in-memory store).
+    """
+    rag = await _build_rag(tmp_path, "reset_string_status")
+    try:
+        processing_id = "doc-string-processing"
+        pending_id = "doc-string-pending"
+        now = datetime.now(timezone.utc).isoformat()
+        await rag.full_docs.upsert(
+            {
+                processing_id: {"content": "p", "file_path": "proc.pdf"},
+                pending_id: {"content": "q", "file_path": "pend.pdf"},
+            }
+        )
+
+        # Status is a plain string, exactly as a non-JSON backend hydrates it.
+        to_process_docs = {
+            processing_id: DocProcessingStatus(
+                content_summary="p",
+                content_length=1,
+                file_path="proc.pdf",
+                status="processing",
+                created_at=now,
+                updated_at=now,
+                track_id="track-proc",
+                chunks_count=1,
+                chunks_list=["c-1"],
+                error_msg="old error",
+                metadata=dict(_FULL_ATTEMPT_METADATA),
+            ),
+            pending_id: DocProcessingStatus(
+                content_summary="q",
+                content_length=1,
+                file_path="pend.pdf",
+                status="pending",
+                created_at=now,
+                updated_at=now,
+                track_id="track-pend",
+                chunks_count=0,
+                chunks_list=[],
+                error_msg="",
+                metadata={"process_options": "F", "analyzing_start_time": 7},
+            ),
+        }
+        assert isinstance(to_process_docs[processing_id].status, str)
+        assert not isinstance(to_process_docs[processing_id].status, DocStatus)
+
+        pipeline_status = {"latest_message": "", "history_messages": []}
+        await rag._validate_and_fix_document_consistency(
+            to_process_docs=to_process_docs,
+            pipeline_status=pipeline_status,
+            pipeline_status_lock=asyncio.Lock(),
+        )
+
+        # String "processing" is reset to a clean PENDING.
+        proc_stored = await rag.doc_status.get_by_id(processing_id)
+        assert proc_stored is not None
+        assert _status_to_text(proc_stored["status"]) == "pending"
+        assert proc_stored["metadata"] == {
+            "process_options": "iF",
+            "source_file": "report.pdf",
+        }
+        assert to_process_docs[processing_id].metadata == {
+            "process_options": "iF",
+            "source_file": "report.pdf",
+        }
+
+        # String "pending" carrying a stale field is normalized in place.
+        pend_stored = await rag.doc_status.get_by_id(pending_id)
+        assert pend_stored is not None
+        assert pend_stored["metadata"] == {"process_options": "F"}
+        assert to_process_docs[pending_id].metadata == {"process_options": "F"}
     finally:
         await rag.finalize_storages()

--- a/tests/pipeline/test_doc_status_reset_metadata.py
+++ b/tests/pipeline/test_doc_status_reset_metadata.py
@@ -1,0 +1,368 @@
+"""Tests for directive-only metadata cleanup when (re)queuing to PENDING.
+
+Covers:
+  * ``doc_status_reset_metadata`` — keeps long-lived directives
+    (``process_options`` / ``source_file``, legacy ``source_file_name``
+    tolerant) and drops every per-attempt timing/result field.
+  * ``doc_status_metadata_has_attempt_fields`` — the precise trigger used to
+    decide whether an already-PENDING doc needs normalising.
+  * ``_validate_and_fix_document_consistency`` — interrupted docs reset to a
+    clean PENDING (storage AND in-memory), already-PENDING docs carrying stale
+    per-attempt fields normalised in place, and the locked semantic for
+    docs that hold non-attempt custom metadata.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import numpy as np
+import pytest
+
+from lightrag.base import DocStatus
+from lightrag.lightrag import LightRAG
+from lightrag.utils import EmbeddingFunc, Tokenizer
+from lightrag.utils_pipeline import (
+    doc_status_metadata_has_attempt_fields,
+    doc_status_reset_metadata,
+)
+
+pytestmark = pytest.mark.offline
+
+
+# A metadata blob carrying every per-attempt field a document could have
+# accumulated across parse/analyze/process plus the two long-lived directives.
+_FULL_ATTEMPT_METADATA = {
+    "process_options": "iF",
+    "source_file": "report.pdf",
+    "parse_start_time": 100,
+    "parse_end_time": 200,
+    "parse_stage_skipped": True,
+    "parse_warnings": {"docx": "missing paraId"},
+    "analyzing_start_time": 300,
+    "analyzing_end_time": 400,
+    "analyzing_stage_skipped": True,
+    "chunk_opts": "size=512, overlap=256",
+    "process_start_time": 500,
+    "process_end_time": 600,
+    "parse_format": "raw",
+    "parse_engine": "native",
+    "chunk_method": "fixed_token",
+    "skip_kg": True,
+    "mm_chunks": 3,
+    "hard_fallback_split": "256 -> 512",
+}
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _dummy_embedding(texts: list[str]) -> np.ndarray:
+    return np.ones((len(texts), 8), dtype=float)
+
+
+async def _dummy_llm(*args, **kwargs) -> str:
+    return "ok"
+
+
+def _deterministic_chunking(
+    tokenizer,
+    content: str,
+    split_by_character,
+    split_by_character_only: bool,
+    chunk_overlap_token_size: int,
+    chunk_token_size: int,
+) -> list[dict]:
+    return [{"tokens": 1, "content": content, "chunk_order_index": 0}]
+
+
+def _status_to_text(status: object) -> str:
+    if isinstance(status, DocStatus):
+        return status.value
+    return str(status).replace("DocStatus.", "").lower()
+
+
+async def _build_rag(tmp_path, test_name: str) -> LightRAG:
+    workspace = f"{test_name}_{uuid4().hex[:8]}"
+    rag = LightRAG(
+        working_dir=str(tmp_path / test_name),
+        workspace=workspace,
+        llm_model_func=_dummy_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8,
+            max_token_size=8192,
+            func=_dummy_embedding,
+        ),
+        tokenizer=Tokenizer("test-tokenizer", _SimpleTokenizerImpl()),
+        chunking_func=_deterministic_chunking,
+        max_parallel_insert=1,
+    )
+    await rag.initialize_storages()
+    return rag
+
+
+# ----------------------------------------------------------------------------
+# doc_status_reset_metadata unit tests
+# ----------------------------------------------------------------------------
+
+
+def test_reset_metadata_keeps_directives_drops_attempt_fields():
+    result = doc_status_reset_metadata({"metadata": dict(_FULL_ATTEMPT_METADATA)})
+    assert result == {"process_options": "iF", "source_file": "report.pdf"}
+
+
+def test_reset_metadata_normalizes_legacy_source_file_name():
+    result = doc_status_reset_metadata(
+        {"metadata": {"source_file_name": "legacy.docx", "process_options": "t"}}
+    )
+    assert result == {"process_options": "t", "source_file": "legacy.docx"}
+
+
+def test_reset_metadata_prefers_new_source_file_over_legacy():
+    result = doc_status_reset_metadata(
+        {"metadata": {"source_file": "new.pdf", "source_file_name": "old.pdf"}}
+    )
+    assert result == {"source_file": "new.pdf"}
+
+
+def test_reset_metadata_handles_empty_or_invalid_metadata():
+    assert doc_status_reset_metadata({"metadata": {}}) == {}
+    assert doc_status_reset_metadata({"metadata": None}) == {}
+    assert doc_status_reset_metadata({}) == {}
+    assert doc_status_reset_metadata(None) == {}
+    # blank directive values are not carried
+    assert (
+        doc_status_reset_metadata(
+            {"metadata": {"process_options": "", "source_file": ""}}
+        )
+        == {}
+    )
+
+
+def test_has_attempt_fields_trigger():
+    assert doc_status_metadata_has_attempt_fields({"metadata": {"parse_end_time": 1}})
+    assert doc_status_metadata_has_attempt_fields(
+        {"metadata": {"process_options": "F", "chunk_opts": "x"}}
+    )
+    # only directives / custom non-attempt fields -> no trigger
+    assert not doc_status_metadata_has_attempt_fields(
+        {"metadata": {"process_options": "F", "source_file": "a.pdf"}}
+    )
+    assert not doc_status_metadata_has_attempt_fields(
+        {"metadata": {"custom_field": "x"}}
+    )
+    assert not doc_status_metadata_has_attempt_fields({"metadata": {}})
+    assert not doc_status_metadata_has_attempt_fields({"metadata": None})
+
+
+# ----------------------------------------------------------------------------
+# _validate_and_fix_document_consistency integration tests
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_interrupted_reset_clears_attempt_metadata_in_storage_and_memory(
+    tmp_path,
+):
+    rag = await _build_rag(tmp_path, "reset_clears_attempt_metadata")
+    try:
+        doc_id = "doc-interrupted"
+        now = datetime.now(timezone.utc).isoformat()
+        await rag.full_docs.upsert(
+            {doc_id: {"content": "interrupted doc", "file_path": "report.pdf"}}
+        )
+        await rag.doc_status.upsert(
+            {
+                doc_id: {
+                    "status": DocStatus.PROCESSING,
+                    "content_summary": "interrupted",
+                    "content_length": 15,
+                    "chunks_count": 1,
+                    "chunks_list": ["c-1"],
+                    "created_at": now,
+                    "updated_at": now,
+                    "file_path": "report.pdf",
+                    "track_id": "track-1",
+                    "error_msg": "old error",
+                    "metadata": dict(_FULL_ATTEMPT_METADATA),
+                }
+            }
+        )
+
+        to_process_docs = await rag.doc_status.get_docs_by_status(DocStatus.PROCESSING)
+        pipeline_status = {"latest_message": "", "history_messages": []}
+        await rag._validate_and_fix_document_consistency(
+            to_process_docs=to_process_docs,
+            pipeline_status=pipeline_status,
+            pipeline_status_lock=asyncio.Lock(),
+        )
+
+        # Storage: directives only, error cleared, chunks preserved.
+        stored = await rag.doc_status.get_by_id(doc_id)
+        assert stored is not None
+        assert _status_to_text(stored["status"]) == "pending"
+        assert stored["metadata"] == {
+            "process_options": "iF",
+            "source_file": "report.pdf",
+        }
+        assert stored["error_msg"] == ""
+        assert stored["chunks_list"] == ["c-1"]
+
+        # In-memory status_doc carried forward by workers is cleaned too.
+        assert to_process_docs[doc_id].metadata == {
+            "process_options": "iF",
+            "source_file": "report.pdf",
+        }
+        assert _status_to_text(to_process_docs[doc_id].status) == "pending"
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_stale_pending_normalized_clean_pending_untouched(tmp_path):
+    rag = await _build_rag(tmp_path, "stale_pending_normalized")
+    try:
+        stale_id = "doc-stale-pending"
+        clean_id = "doc-clean-pending"
+        now = datetime.now(timezone.utc).isoformat()
+        await rag.full_docs.upsert(
+            {
+                stale_id: {"content": "stale", "file_path": "stale.pdf"},
+                clean_id: {"content": "clean", "file_path": "clean.pdf"},
+            }
+        )
+        await rag.doc_status.upsert(
+            {
+                stale_id: {
+                    "status": DocStatus.PENDING,
+                    "content_summary": "stale",
+                    "content_length": 5,
+                    "chunks_count": 0,
+                    "chunks_list": [],
+                    "created_at": now,
+                    "updated_at": now,
+                    "file_path": "stale.pdf",
+                    "track_id": "track-stale",
+                    "error_msg": "",
+                    "metadata": {
+                        "process_options": "F",
+                        "parse_end_time": 999,
+                        "analyzing_start_time": 111,
+                    },
+                },
+                clean_id: {
+                    "status": DocStatus.PENDING,
+                    "content_summary": "clean",
+                    "content_length": 5,
+                    "chunks_count": 0,
+                    "chunks_list": [],
+                    "created_at": now,
+                    "updated_at": now,
+                    "file_path": "clean.pdf",
+                    "track_id": "track-clean",
+                    "error_msg": "",
+                    "metadata": {"process_options": "F", "source_file": "clean.pdf"},
+                },
+            }
+        )
+
+        to_process_docs = await rag.doc_status.get_docs_by_status(DocStatus.PENDING)
+        pipeline_status = {"latest_message": "", "history_messages": []}
+        await rag._validate_and_fix_document_consistency(
+            to_process_docs=to_process_docs,
+            pipeline_status=pipeline_status,
+            pipeline_status_lock=asyncio.Lock(),
+        )
+
+        # Stale PENDING normalized to directives-only (storage + memory).
+        stale_stored = await rag.doc_status.get_by_id(stale_id)
+        assert stale_stored["metadata"] == {"process_options": "F"}
+        assert to_process_docs[stale_id].metadata == {"process_options": "F"}
+
+        # Clean PENDING left untouched: no rewrite (updated_at unchanged).
+        clean_stored = await rag.doc_status.get_by_id(clean_id)
+        assert clean_stored["metadata"] == {
+            "process_options": "F",
+            "source_file": "clean.pdf",
+        }
+        assert clean_stored["updated_at"] == now
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_pending_custom_metadata_semantic_lock(tmp_path):
+    """Locks the chosen action semantic for already-PENDING docs:
+
+    * only custom (non-attempt) metadata, no stale key -> left untouched;
+    * stale key + custom field -> collapsed to directives-only (custom
+      dropped), matching the interrupted-reset path.
+    """
+    rag = await _build_rag(tmp_path, "pending_custom_metadata_lock")
+    try:
+        custom_only_id = "doc-custom-only"
+        stale_plus_custom_id = "doc-stale-plus-custom"
+        now = datetime.now(timezone.utc).isoformat()
+        await rag.full_docs.upsert(
+            {
+                custom_only_id: {"content": "c", "file_path": "custom.pdf"},
+                stale_plus_custom_id: {"content": "s", "file_path": "mixed.pdf"},
+            }
+        )
+        await rag.doc_status.upsert(
+            {
+                custom_only_id: {
+                    "status": DocStatus.PENDING,
+                    "content_summary": "c",
+                    "content_length": 1,
+                    "chunks_count": 0,
+                    "chunks_list": [],
+                    "created_at": now,
+                    "updated_at": now,
+                    "file_path": "custom.pdf",
+                    "track_id": "track-custom",
+                    "error_msg": "",
+                    "metadata": {"custom_field": "keep-me"},
+                },
+                stale_plus_custom_id: {
+                    "status": DocStatus.PENDING,
+                    "content_summary": "s",
+                    "content_length": 1,
+                    "chunks_count": 0,
+                    "chunks_list": [],
+                    "created_at": now,
+                    "updated_at": now,
+                    "file_path": "mixed.pdf",
+                    "track_id": "track-mixed",
+                    "error_msg": "",
+                    "metadata": {
+                        "process_options": "F",
+                        "custom_field": "drop-me",
+                        "parse_start_time": 42,
+                    },
+                },
+            }
+        )
+
+        to_process_docs = await rag.doc_status.get_docs_by_status(DocStatus.PENDING)
+        pipeline_status = {"latest_message": "", "history_messages": []}
+        await rag._validate_and_fix_document_consistency(
+            to_process_docs=to_process_docs,
+            pipeline_status=pipeline_status,
+            pipeline_status_lock=asyncio.Lock(),
+        )
+
+        custom_stored = await rag.doc_status.get_by_id(custom_only_id)
+        assert custom_stored["metadata"] == {"custom_field": "keep-me"}
+        assert custom_stored["updated_at"] == now
+
+        mixed_stored = await rag.doc_status.get_by_id(stale_plus_custom_id)
+        assert mixed_stored["metadata"] == {"process_options": "F"}
+        assert "custom_field" not in mixed_stored["metadata"]
+    finally:
+        await rag.finalize_storages()


### PR DESCRIPTION
## Description

When `apipeline_process_enqueue_documents` resumes work, interrupted documents are reset back to `PENDING` by `_validate_and_fix_document_consistency`. That reset reused the full carry-over list (`doc_status_transition_metadata`), so the **previous attempt's** per-attempt metadata — `parse_*`/`analyzing_*` timings, `*_stage_skipped` flags, `parse_warnings`, `chunk_opts` — was dragged into the new `PENDING` record.

The only cleanup happened later, in `_parse_worker` right before `PARSING` (and it only scrubbed 5 of those keys, missing `parse_warnings`/`chunk_opts`). As a result, while a document waited in the `PENDING` queue the WebUI rendered stale parse/analyze timestamps that did not reflect "waiting to be reprocessed".

The fix keeps the **classification** correct (`process_options`/`source_file` are long-lived directives that must survive a reset; everything else is a per-attempt product) but fixes the **mechanism**: cleanup is moved to a single point during the consistency check, so a document is clean the moment it enters `PENDING`.

## Related Issues

N/A

## Changes Made

- **`lightrag/utils_pipeline.py`**
  - Add `read_source_file_basename()` — the backward-compatible `source_file_name` → `source_file` reader now lives here so reset helpers can reuse it without a reverse import from `pipeline.py`.
  - Add `_DOC_STATUS_METADATA_DIRECTIVE_KEYS` and `doc_status_reset_metadata()` — a directive-only rebuild used on the reset path. It **iterates** the directive whitelist (so future directive additions are carried automatically) and normalises `source_file` with legacy tolerance.
  - Add `_DOC_STATUS_METADATA_ATTEMPT_KEYS` and `doc_status_metadata_has_attempt_fields()` — a precise trigger (timing/skip pairs, `parse_warnings`, `chunk_opts`, and the `PROCESSING` `extraction_meta` fields) for normalising an already-`PENDING` doc.
- **`lightrag/pipeline.py`**
  - `_read_source_file` now delegates to the shared helper.
  - `_validate_and_fix_document_consistency` is the single cleanup point: interrupted docs are reset to a clean `PENDING`, and already-`PENDING` docs that still carry a stale per-attempt field are normalised in place. In both cases the cleaned metadata is mirrored onto the in-memory `status_doc` so later transitions (which rebuild metadata from it) don't reintroduce stale fields.
  - Remove the now-redundant stale-field `pop` loop in `_parse_worker` (the `parse_start_time` stamp and the `source_file` normalisation block are kept).
  - The forward carry-over (`_DOC_STATUS_METADATA_CARRY_OVER_KEYS` / `doc_status_transition_metadata`) is unchanged — forward transitions still carry timing fields through to the terminal record.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

New tests in `tests/pipeline/test_doc_status_reset_metadata.py` cover: `doc_status_reset_metadata` (keep directives / drop attempt fields / legacy `source_file_name` tolerance / blank handling), the `has_attempt_fields` trigger, the interrupted reset clearing both storage and in-memory metadata, stale-`PENDING` normalisation vs. clean-`PENDING` left untouched, and a **semantic lock**: a `PENDING` doc holding only non-attempt custom metadata is left untouched, while one holding a stale key + custom field is collapsed to directives-only.

Verification: `tests/pipeline/` 202 passed, `tests/api/routes/test_document_routes_docx_archive.py` 46 passed, `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
