### PR TITLE
🐛 fix(parser): split over-long outline headings at soft line break

### DIFF
--- a/lightrag/parser/docx/parse_document.py
+++ b/lightrag/parser/docx/parse_document.py
@@ -1608,6 +1608,44 @@ def extract_docx_blocks(
             # Check if this is a heading using the new function
             outline_level = get_heading_level(element, styles_outline)
 
+            # A "heading" longer than MAX_HEADING_LENGTH is not a real heading.
+            # The common cause (WPS/Word): the author set an outline level on a
+            # paragraph but typed the body with soft line breaks (Shift+Enter →
+            # <w:br/> → '\n') instead of starting a new paragraph, so heading
+            # text + body live in one <w:p>. Split at the first soft break: the
+            # first line stays the heading, the remainder becomes body text. If
+            # there is no usable soft break (a genuine single-line over-long
+            # heading), demote the whole paragraph to body text. Either way we
+            # avoid crashing via validate_heading_length() and never drop content.
+            demoted_body_text = None
+            if outline_level is not None and len(full_text) > MAX_HEADING_LENGTH:
+                head, sep, rest = full_text.partition("\n")
+                if sep and len(head) <= MAX_HEADING_LENGTH:
+                    full_text = head
+                    demoted_body_text = rest.strip() or None
+                    if parse_warnings is not None:
+                        parse_warnings["heading_softbreak_split_count"] = (
+                            parse_warnings.get("heading_softbreak_split_count", 0) + 1
+                        )
+                    print(
+                        f"Warning: heading paragraph exceeded {MAX_HEADING_LENGTH} "
+                        "chars; split at soft line break — kept first line as "
+                        "heading, rest as body.",
+                        file=sys.stderr,
+                    )
+                else:
+                    outline_level = None
+                    if parse_warnings is not None:
+                        parse_warnings["demoted_oversize_heading_count"] = (
+                            parse_warnings.get("demoted_oversize_heading_count", 0) + 1
+                        )
+                    print(
+                        f"Warning: paragraph has outline level but is "
+                        f"{len(full_text)} chars (> {MAX_HEADING_LENGTH}); treating "
+                        "as body text, not a heading.",
+                        file=sys.stderr,
+                    )
+
             if outline_level is not None:
                 # This is a heading (outline level 0-8)
                 # Convert 0-based to 1-based level
@@ -1708,6 +1746,17 @@ def extract_docx_blocks(
                         {
                             "text": render_heading_line(level, truncated_text),
                             "para_id": para_id,
+                            "is_table": False,
+                        }
+                    )
+
+                # Carry the body text that followed a soft break in an over-long
+                # heading paragraph as a regular body paragraph in the same block.
+                if demoted_body_text:
+                    current_paragraphs.append(
+                        {
+                            "text": demoted_body_text,
+                            "para_id": heading_para_id,
                             "is_table": False,
                         }
                     )

--- a/tests/parser/docx/test_native_docx_extract.py
+++ b/tests/parser/docx/test_native_docx_extract.py
@@ -230,6 +230,92 @@ def test_heading_markdown_prefix_capped_at_six(tmp_path) -> None:
     ]
 
 
+def _add_outline_para_with_softbreak(doc, head_text: str, body_text: str, level: int):
+    """Append one ``<w:p>`` carrying an outline level whose runs are
+    ``head_text`` + a soft line break (``<w:br/>``) + ``body_text``.
+
+    Mirrors the real-world WPS/Word pattern where an author sets an outline
+    level on a paragraph but types the body with Shift+Enter (a soft break)
+    instead of a new paragraph, so heading + body live in a single paragraph.
+    """
+    para = doc.add_paragraph(head_text)
+    pPr = para._p.get_or_add_pPr()
+    outline = OxmlElement("w:outlineLvl")
+    outline.set(qn("w:val"), str(level - 1))
+    pPr.append(outline)
+    para.add_run().add_break()  # default WD_BREAK.LINE → soft <w:br/> → '\n'
+    para.add_run(body_text)
+    return para
+
+
+@pytest.mark.offline
+def test_oversize_outline_heading_with_softbreak_splits(tmp_path) -> None:
+    """An over-long heading paragraph that contains a soft break must split:
+    the first line stays the heading, the remainder becomes body text. No
+    DocxContentError, and the body content is preserved in full."""
+    head = "A、处置程序"
+    body = "施工现场一旦发生事故时应立即采取相应的应急处置措施并以最快速度报警。" * 8
+    assert len(head) + 1 + len(body) > 200  # would trip validate_heading_length
+
+    doc = Document()
+    _add_outline_para_with_softbreak(doc, head, body, level=4)
+
+    buf = BytesIO()
+    doc.save(buf)
+    docx_path = tmp_path / "softbreak.docx"
+    docx_path.write_bytes(buf.getvalue())
+
+    blocks = extract_docx_blocks(str(docx_path), fixlevel=0)
+
+    # The short first line becomes the heading; the long remainder is body.
+    heading_block = next(b for b in blocks if b["heading"] == head)
+    assert body in heading_block["content"]
+    # Heading field carries only the first line, not the body.
+    assert body not in heading_block["heading"]
+
+
+@pytest.mark.offline
+def test_oversize_outline_heading_no_softbreak_demoted_to_body(tmp_path) -> None:
+    """A single-line over-long outline paragraph (no soft break) is demoted to
+    body text rather than raising — content preserved, not treated as a heading."""
+    long_text = "施工现场应急处置措施说明，" * 30  # well over 200 chars, no '\n'
+    assert len(long_text) > 200
+
+    doc = Document()
+    _add_heading(doc, long_text, level=2)
+
+    buf = BytesIO()
+    doc.save(buf)
+    docx_path = tmp_path / "demote.docx"
+    docx_path.write_bytes(buf.getvalue())
+
+    blocks = extract_docx_blocks(str(docx_path), fixlevel=0)
+
+    # The text survives as body content, and no block adopts it as a heading.
+    assert any(long_text in b["content"] for b in blocks)
+    assert all(b["heading"] != long_text for b in blocks)
+
+
+@pytest.mark.offline
+def test_short_outline_paragraph_still_heading(tmp_path) -> None:
+    """A within-limit outline paragraph must still be recognized as a heading —
+    the over-long handling never demotes short headings."""
+    doc = Document()
+    _add_heading(doc, "处置程序", level=3)
+    doc.add_paragraph("body under heading.")
+
+    buf = BytesIO()
+    doc.save(buf)
+    docx_path = tmp_path / "short.docx"
+    docx_path.write_bytes(buf.getvalue())
+
+    blocks = extract_docx_blocks(str(docx_path), fixlevel=0)
+
+    heading_block = next(b for b in blocks if b["heading"] == "处置程序")
+    assert heading_block["level"] == 3
+    assert heading_block["content"].startswith("### 处置程序")
+
+
 @pytest.mark.offline
 def test_existing_markdown_heading_keeps_content_but_metadata_is_clean(
     tmp_path,


### PR DESCRIPTION
## Description

The native docx engine could abort the parse of an entire document by misclassifying a normal body paragraph as an over-long heading.

A `<w:p>` paragraph that carries an outline level (`w:outlineLvl`) but whose text exceeds `MAX_HEADING_LENGTH` (200) was passed to `validate_heading_length()`, which raises `DocxContentError` and tears down the whole document parse.

The common real-world cause is a WPS/Word authoring pattern: the author sets an outline level on a paragraph (intending a short sub-heading) but types the body with **soft line breaks** (Shift+Enter → `<w:br/>` → `'\n'`) instead of starting a new paragraph. As a result the heading text and a long body live in a *single* `<w:p>`. `extract_text_from_run` turns the soft break into `'\n'`, so the paragraph's `full_text` becomes e.g. `"A、处置程序\n施工现场一旦发生事故时,..."` (413 chars) and trips the length check.

## Related Issues

#XXXX

## Changes Made

In `extract_docx_blocks` ([lightrag/parser/docx/parse_document.py](../blob/main/lightrag/parser/docx/parse_document.py)), at the heading-detection call site:

- When a paragraph is detected as a heading but its text exceeds `MAX_HEADING_LENGTH`:
  - **Contains a soft break** → split at the first `'\n'`: the first line stays the heading, the remainder is carried as a regular body paragraph in the same block. The author's intended sub-heading is preserved and the body content is kept in full.
  - **No usable soft break** (a genuine single-line over-long heading) → demote the whole paragraph to body text.
- Either path avoids the `DocxContentError` crash and never drops content.
- Within-limit paragraphs are untouched, so golden outputs are unchanged.
- `validate_heading_length()` is left intact as a defense-in-depth guard on the anchor re-split path; the split heading's first line is now well under the limit.
- New non-fatal counters surfaced via `parse_warnings`: `heading_softbreak_split_count`, `demoted_oversize_heading_count`.

Added regression tests in `tests/parser/docx/test_native_docx_extract.py`:
- over-long outline heading **with** soft break → splits (heading kept, body preserved);
- over-long outline heading **without** soft break → demoted to body;
- short outline paragraph → still recognized as a heading (no regression).

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Verified end to end on a real document that previously failed with `ERROR: Heading too long (413 characters, max 200)`:

- `python -m pytest tests/parser/docx/test_native_docx_extract.py tests/parser/docx/test_native_docx_golden.py tests/parser/docx/test_validation_raises.py -q` → 27 passed (golden unchanged).
- Re-running the failing CLI command now completes; the `A、处置程序` sub-heading is preserved as the block heading and the full ~1100-char body is retained as block content, with a single soft-break-split warning on stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
