### PR TITLE
🐛 fix(pipeline): guarantee worker teardown + isolate enqueue get_by_id on backend outage

### DIFF
--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1275,38 +1275,18 @@ class _PipelineMixin:
         # ``busy`` — leaving busy=False while processing visibly continues.
         batch_aborted_by_exception = False
         try:
-            # Add pending files to the correct parsing queue
-            for current_file_number, (doc_id, status_doc) in enumerate(
-                to_process_docs.items(), start=1
-            ):
-                file_path = getattr(status_doc, "file_path", "unknown_source")
-                # Per-document isolation: the engine-routing get_by_id is the only
-                # orchestrator-level storage read in this loop. A transient/corrupt
-                # single-doc failure must FAIL just that document and continue with
-                # the rest of the batch — not escape and abort the whole batch.
-                # During a full outage _finalize_doc_failure's own doc_status write
-                # also raises; that escape is caught by the finally below (workers
-                # are cleanly cancelled) and the batch aborts as a whole.
-                try:
-                    content_data = await self.full_docs.get_by_id(doc_id) or {}
-                except Exception as e:
-                    await self._finalize_doc_failure(
-                        doc_id=doc_id,
-                        status_doc=status_doc,
-                        file_path=file_path,
-                        error=e,
-                        stage_label="parse",
-                        current_file_number=current_file_number,
-                        total_files=total_files,
-                        failed_chunks_snapshot=([], 0),
-                        pending_tasks=[],
-                        metadata_extra={},
-                        pipeline_status=pipeline_status,
-                        pipeline_status_lock=pipeline_status_lock,
-                    )
-                    continue
+            # Add pending files to the correct parsing queue. An orchestrator-
+            # level storage read here (e.g. full_docs.get_by_id during a backend
+            # outage) that raises aborts the whole batch — the finally below
+            # cancels the workers cleanly and the caller releases ``busy``, with
+            # affected documents left queued (PENDING) for the next run. We do
+            # NOT per-doc isolate this read: the same unguarded read also runs in
+            # _validate_and_fix_document_consistency before this batch, so a clean
+            # whole-batch abort is the consistent behavior across both sites.
+            for doc_id, status_doc in to_process_docs.items():
+                content_data = await self.full_docs.get_by_id(doc_id) or {}
                 engine = resolve_stored_document_parser_engine(
-                    file_path=file_path,
+                    file_path=getattr(status_doc, "file_path", "unknown_source"),
                     content_data=content_data,
                 )
                 if engine == "mineru":

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -2795,6 +2795,19 @@ class _PipelineMixin:
         """
         if isinstance(error, PipelineCancelledException):
             cancel_label = self._cancellation_label(pipeline_status)
+            # The cancel exceptions raised by the merge/summary stages hardcode a
+            # generic "User cancelled during <stage>" message. When the batch was
+            # actually aborted by an internal error (e.g. a storage outage), that
+            # mislabels the cause. Swap the generic prefix for the reason-aware
+            # label so doc_status records "Cancelled by internal error: <detail>
+            # during <stage>" rather than "User cancelled during <stage>".
+            raw = str(error)
+            if raw.startswith("User cancelled"):
+                doc_error_msg = f"{cancel_label}{raw[len('User cancelled'):]}"
+            elif raw:
+                doc_error_msg = f"{cancel_label}: {raw}"
+            else:
+                doc_error_msg = cancel_label
             if stage_label == "merge":
                 error_msg = (
                     f"{cancel_label} during merge {current_file_number}/"
@@ -2809,6 +2822,7 @@ class _PipelineMixin:
                 pipeline_status["latest_message"] = error_msg
                 pipeline_status["history_messages"].append(error_msg)
         else:
+            doc_error_msg = str(error)
             logger.error(traceback.format_exc())
             if stage_label == "merge":
                 error_msg = (
@@ -2843,7 +2857,7 @@ class _PipelineMixin:
             status_doc=status_doc,
             file_path=file_path,
             extra_fields={
-                "error_msg": str(error),
+                "error_msg": doc_error_msg,
                 "chunks_count": failed_chunks_count,
                 "chunks_list": failed_chunks_list,
             },

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1273,6 +1273,7 @@ class _PipelineMixin:
         # an escape here would orphan the workers — they keep draining the queues and
         # appending to history_messages while the caller's finally has already cleared
         # ``busy`` — leaving busy=False while processing visibly continues.
+        batch_aborted_by_exception = False
         try:
             # Add pending files to the correct parsing queue
             for current_file_number, (doc_id, status_doc) in enumerate(
@@ -1320,24 +1321,32 @@ class _PipelineMixin:
             )
             await ctx.q_analyze.join()
             await ctx.q_process.join()
+        except BaseException:
+            batch_aborted_by_exception = True
+            raise
         finally:
             for w in workers:
                 w.cancel()
             await asyncio.gather(*workers, return_exceptions=True)
 
-        # If the batch aborted on an internal storage error, the shared
-        # cross-file flush buffers may still hold records from the documents
-        # that were marked FAILED. Discard them now (workers are stopped, so
-        # this does not race a flush) so they are neither re-flushed nor
-        # carried into the next batch — every affected document is reprocessed
-        # on retry. See _discard_pending_index_ops / drop_pending_index_ops.
-        async with pipeline_status_lock:
-            internal_abort = (
-                pipeline_status.get("cancellation_requested", False)
-                and pipeline_status.get("cancellation_reason") == "internal_error"
-            )
-        if internal_abort:
-            await self._discard_pending_index_ops()
+            # Discard not-yet-flushed shared cross-file buffers when the batch
+            # aborts, so they are neither re-flushed nor carried into the next
+            # batch — otherwise stale KG/vector records from already-merged
+            # in-flight docs could later be persisted for documents that were
+            # FAILED/reset rather than marked PROCESSED. This must run on BOTH:
+            #   - the cooperative internal-error abort (cancellation flag), and
+            #   - an exception escaping this method (e.g. an orchestrator-level
+            #     storage call failed during an outage and reached the finally).
+            # Workers are already stopped above, so this does not race a flush.
+            # _discard_pending_index_ops is best-effort (never raises), so it
+            # cannot mask the original abort cause. See drop_pending_index_ops.
+            async with pipeline_status_lock:
+                internal_abort = (
+                    pipeline_status.get("cancellation_requested", False)
+                    and pipeline_status.get("cancellation_reason") == "internal_error"
+                )
+            if internal_abort or batch_aborted_by_exception:
+                await self._discard_pending_index_ops()
 
     async def _validate_and_fix_document_consistency(
         self,

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1273,20 +1273,39 @@ class _PipelineMixin:
         # an escape here would orphan the workers — they keep draining the queues and
         # appending to history_messages while the caller's finally has already cleared
         # ``busy`` — leaving busy=False while processing visibly continues.
-        batch_aborted_by_exception = False
         try:
-            # Add pending files to the correct parsing queue. An orchestrator-
-            # level storage read here (e.g. full_docs.get_by_id during a backend
-            # outage) that raises aborts the whole batch — the finally below
-            # cancels the workers cleanly and the caller releases ``busy``, with
-            # affected documents left queued (PENDING) for the next run. We do
-            # NOT per-doc isolate this read: the same unguarded read also runs in
-            # _validate_and_fix_document_consistency before this batch, so a clean
-            # whole-batch abort is the consistent behavior across both sites.
-            for doc_id, status_doc in to_process_docs.items():
-                content_data = await self.full_docs.get_by_id(doc_id) or {}
+            # Add pending files to the correct parsing queue
+            for current_file_number, (doc_id, status_doc) in enumerate(
+                to_process_docs.items(), start=1
+            ):
+                file_path = getattr(status_doc, "file_path", "unknown_source")
+                # Per-document isolation: the engine-routing get_by_id is the only
+                # orchestrator-level storage read in this loop. A transient/corrupt
+                # single-doc failure must FAIL just that document and continue with
+                # the rest of the batch — not escape and abort the whole batch.
+                # During a full outage _finalize_doc_failure's own doc_status write
+                # also raises; that escape is caught by the finally below (workers
+                # are cleanly cancelled) and the batch aborts as a whole.
+                try:
+                    content_data = await self.full_docs.get_by_id(doc_id) or {}
+                except Exception as e:
+                    await self._finalize_doc_failure(
+                        doc_id=doc_id,
+                        status_doc=status_doc,
+                        file_path=file_path,
+                        error=e,
+                        stage_label="parse",
+                        current_file_number=current_file_number,
+                        total_files=total_files,
+                        failed_chunks_snapshot=([], 0),
+                        pending_tasks=[],
+                        metadata_extra={},
+                        pipeline_status=pipeline_status,
+                        pipeline_status_lock=pipeline_status_lock,
+                    )
+                    continue
                 engine = resolve_stored_document_parser_engine(
-                    file_path=getattr(status_doc, "file_path", "unknown_source"),
+                    file_path=file_path,
                     content_data=content_data,
                 )
                 if engine == "mineru":
@@ -1301,32 +1320,24 @@ class _PipelineMixin:
             )
             await ctx.q_analyze.join()
             await ctx.q_process.join()
-        except BaseException:
-            batch_aborted_by_exception = True
-            raise
         finally:
             for w in workers:
                 w.cancel()
             await asyncio.gather(*workers, return_exceptions=True)
 
-            # Discard not-yet-flushed shared cross-file buffers when the batch
-            # aborts, so they are neither re-flushed nor carried into the next
-            # batch — otherwise stale KG/vector records from already-merged
-            # in-flight docs could later be persisted for documents that were
-            # FAILED/reset rather than marked PROCESSED. This must run on BOTH:
-            #   - the cooperative internal-error abort (cancellation flag), and
-            #   - an exception escaping this method (e.g. an orchestrator-level
-            #     storage call failed during an outage and reached the finally).
-            # Workers are already stopped above, so this does not race a flush.
-            # _discard_pending_index_ops is best-effort (never raises), so it
-            # cannot mask the original abort cause. See drop_pending_index_ops.
-            async with pipeline_status_lock:
-                internal_abort = (
-                    pipeline_status.get("cancellation_requested", False)
-                    and pipeline_status.get("cancellation_reason") == "internal_error"
-                )
-            if internal_abort or batch_aborted_by_exception:
-                await self._discard_pending_index_ops()
+        # If the batch aborted on an internal storage error, the shared
+        # cross-file flush buffers may still hold records from the documents
+        # that were marked FAILED. Discard them now (workers are stopped, so
+        # this does not race a flush) so they are neither re-flushed nor
+        # carried into the next batch — every affected document is reprocessed
+        # on retry. See _discard_pending_index_ops / drop_pending_index_ops.
+        async with pipeline_status_lock:
+            internal_abort = (
+                pipeline_status.get("cancellation_requested", False)
+                and pipeline_status.get("cancellation_reason") == "internal_error"
+            )
+        if internal_abort:
+            await self._discard_pending_index_ops()
 
     async def _validate_and_fix_document_consistency(
         self,

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1267,29 +1267,63 @@ class _PipelineMixin:
         for _ in range(max(1, self.max_parallel_insert)):
             workers.append(asyncio.create_task(self._process_worker(ctx)))
 
-        # Add pending files to the correct parsing queue
-        for doc_id, status_doc in to_process_docs.items():
-            content_data = await self.full_docs.get_by_id(doc_id) or {}
-            engine = resolve_stored_document_parser_engine(
-                file_path=getattr(status_doc, "file_path", "unknown_source"),
-                content_data=content_data,
+        # The workers above are live asyncio tasks; their cancellation MUST be
+        # guaranteed even if enqueuing or a queue join raises (e.g. an orchestrator-
+        # level storage call fails during a backend outage). Without this try/finally
+        # an escape here would orphan the workers — they keep draining the queues and
+        # appending to history_messages while the caller's finally has already cleared
+        # ``busy`` — leaving busy=False while processing visibly continues.
+        try:
+            # Add pending files to the correct parsing queue
+            for current_file_number, (doc_id, status_doc) in enumerate(
+                to_process_docs.items(), start=1
+            ):
+                file_path = getattr(status_doc, "file_path", "unknown_source")
+                # Per-document isolation: the engine-routing get_by_id is the only
+                # orchestrator-level storage read in this loop. A transient/corrupt
+                # single-doc failure must FAIL just that document and continue with
+                # the rest of the batch — not escape and abort the whole batch.
+                # During a full outage _finalize_doc_failure's own doc_status write
+                # also raises; that escape is caught by the finally below (workers
+                # are cleanly cancelled) and the batch aborts as a whole.
+                try:
+                    content_data = await self.full_docs.get_by_id(doc_id) or {}
+                except Exception as e:
+                    await self._finalize_doc_failure(
+                        doc_id=doc_id,
+                        status_doc=status_doc,
+                        file_path=file_path,
+                        error=e,
+                        stage_label="parse",
+                        current_file_number=current_file_number,
+                        total_files=total_files,
+                        failed_chunks_snapshot=([], 0),
+                        pending_tasks=[],
+                        metadata_extra={},
+                        pipeline_status=pipeline_status,
+                        pipeline_status_lock=pipeline_status_lock,
+                    )
+                    continue
+                engine = resolve_stored_document_parser_engine(
+                    file_path=file_path,
+                    content_data=content_data,
+                )
+                if engine == "mineru":
+                    await ctx.q_mineru.put((doc_id, status_doc))
+                elif engine == "docling":
+                    await ctx.q_docling.put((doc_id, status_doc))
+                else:
+                    await ctx.q_native.put((doc_id, status_doc))
+
+            await asyncio.gather(
+                ctx.q_native.join(), ctx.q_mineru.join(), ctx.q_docling.join()
             )
-            if engine == "mineru":
-                await ctx.q_mineru.put((doc_id, status_doc))
-            elif engine == "docling":
-                await ctx.q_docling.put((doc_id, status_doc))
-            else:
-                await ctx.q_native.put((doc_id, status_doc))
-
-        await asyncio.gather(
-            ctx.q_native.join(), ctx.q_mineru.join(), ctx.q_docling.join()
-        )
-        await ctx.q_analyze.join()
-        await ctx.q_process.join()
-
-        for w in workers:
-            w.cancel()
-        await asyncio.gather(*workers, return_exceptions=True)
+            await ctx.q_analyze.join()
+            await ctx.q_process.join()
+        finally:
+            for w in workers:
+                w.cancel()
+            await asyncio.gather(*workers, return_exceptions=True)
 
         # If the batch aborted on an internal storage error, the shared
         # cross-file flush buffers may still hold records from the documents

--- a/tests/pipeline/test_pipeline_internal_abort.py
+++ b/tests/pipeline/test_pipeline_internal_abort.py
@@ -388,3 +388,94 @@ async def test_process_worker_survives_unhandled_error(tmp_path, monkeypatch):
         assert "process worker unhandled error" in status["cancellation_detail"]
     finally:
         await rag.finalize_storages()
+
+
+# ===========================================================================
+# doc_status error_msg reflects the real cancel cause (internal vs user)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_finalize_doc_failure_labels_internal_error_in_doc_status(tmp_path):
+    """A doc cancelled mid-merge because of an INTERNAL-error abort must record
+    'Cancelled by internal error: <detail>' in doc_status — not the generic
+    'User cancelled' string hardcoded in the merge-stage cancel exception."""
+    rag = await _build_rag(tmp_path)
+    try:
+        doc_id = "doc-internal"
+        status_doc = _make_status_doc(doc_id)
+        pipeline_status = await get_namespace_data(
+            "pipeline_status", workspace=rag.workspace
+        )
+        pipeline_status_lock = get_namespace_lock(
+            "pipeline_status", workspace=rag.workspace
+        )
+        pipeline_status["history_messages"] = []
+        pipeline_status["cancellation_reason"] = "internal_error"
+        pipeline_status["cancellation_detail"] = "RedisKVStorage[full_docs]: boom"
+
+        await rag._finalize_doc_failure(
+            doc_id=doc_id,
+            status_doc=status_doc,
+            file_path=f"{doc_id}.txt",
+            error=PipelineCancelledException("User cancelled during relation merge"),
+            stage_label="merge",
+            current_file_number=3,
+            total_files=10,
+            failed_chunks_snapshot=([], 0),
+            pending_tasks=[],
+            metadata_extra={},
+            pipeline_status=pipeline_status,
+            pipeline_status_lock=pipeline_status_lock,
+        )
+
+        row = await rag.doc_status.get_by_id(doc_id)
+        assert _status_to_text(row["status"]) == "failed"
+        error_msg = row["error_msg"]
+        assert error_msg.startswith("Cancelled by internal error:")
+        assert "RedisKVStorage[full_docs]: boom" in error_msg
+        # Stage granularity from the raw exception is preserved.
+        assert "during relation merge" in error_msg
+        # The misleading user-cancel wording must be gone.
+        assert not error_msg.startswith("User cancelled")
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_finalize_doc_failure_keeps_user_cancel_label(tmp_path):
+    """A genuine user cancel (no internal-error reason) still reads as
+    'User cancelled during <stage>' in doc_status."""
+    rag = await _build_rag(tmp_path)
+    try:
+        doc_id = "doc-user"
+        status_doc = _make_status_doc(doc_id)
+        pipeline_status = await get_namespace_data(
+            "pipeline_status", workspace=rag.workspace
+        )
+        pipeline_status_lock = get_namespace_lock(
+            "pipeline_status", workspace=rag.workspace
+        )
+        pipeline_status["history_messages"] = []
+        pipeline_status["cancellation_reason"] = None
+        pipeline_status["cancellation_detail"] = None
+
+        await rag._finalize_doc_failure(
+            doc_id=doc_id,
+            status_doc=status_doc,
+            file_path=f"{doc_id}.txt",
+            error=PipelineCancelledException("User cancelled during relation merge"),
+            stage_label="merge",
+            current_file_number=1,
+            total_files=2,
+            failed_chunks_snapshot=([], 0),
+            pending_tasks=[],
+            metadata_extra={},
+            pipeline_status=pipeline_status,
+            pipeline_status_lock=pipeline_status_lock,
+        )
+
+        row = await rag.doc_status.get_by_id(doc_id)
+        assert row["error_msg"] == "User cancelled during relation merge"
+    finally:
+        await rag.finalize_storages()

--- a/tests/pipeline/test_pipeline_orchestrator_get_by_id_failure.py
+++ b/tests/pipeline/test_pipeline_orchestrator_get_by_id_failure.py
@@ -1,0 +1,200 @@
+"""Offline tests for orchestrator-level storage failures during batch enqueue.
+
+Covers the fix that:
+
+* guarantees the parse/analyze/process workers created in ``_run_pipeline_batch``
+  are ALWAYS cancelled+awaited via a try/finally — so an exception escaping the
+  enqueue loop (e.g. an orchestrator-level ``full_docs.get_by_id`` failing during
+  a backend outage) can never orphan live worker tasks that keep draining the
+  queues and appending to ``history_messages`` while the caller's finally has
+  already cleared ``busy`` (busy=False but processing visibly continues); and
+* isolates a single failing document's engine-routing ``get_by_id`` so that a
+  transient/corrupt doc is marked FAILED and the rest of the batch still
+  processes, instead of escaping and aborting the whole batch.
+
+The orchestrator's ``full_docs.get_by_id`` at batch enqueue is the read under
+test. ``_validate_and_fix_document_consistency`` (which also reads full_docs,
+but BEFORE any worker is created — so an escape there is a clean stop, not an
+orphan) is bypassed to target the enqueue path deterministically.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import uuid4
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG
+from lightrag.base import DocStatus
+from lightrag.kg.shared_storage import get_namespace_data
+from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
+
+pytestmark = pytest.mark.offline
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _dummy_embedding(texts: list[str]) -> np.ndarray:
+    return np.ones((len(texts), 8), dtype=float)
+
+
+async def _dummy_llm(*args, **kwargs) -> str:
+    return "ok"
+
+
+def _deterministic_chunking(
+    tokenizer,
+    content: str,
+    split_by_character,
+    split_by_character_only: bool,
+    chunk_overlap_token_size: int,
+    chunk_token_size: int,
+) -> list[dict]:
+    return [
+        {"tokens": 1, "content": f"{content}::chunk1", "chunk_order_index": 0},
+    ]
+
+
+def _status_to_text(status: object) -> str:
+    if isinstance(status, DocStatus):
+        return status.value
+    return str(status).replace("DocStatus.", "").lower()
+
+
+async def _build_rag(tmp_path) -> LightRAG:
+    rag = LightRAG(
+        working_dir=str(tmp_path / "wd"),
+        workspace=f"orphan-{uuid4().hex[:8]}",
+        llm_model_func=_dummy_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8, max_token_size=8192, func=_dummy_embedding
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        chunking_func=_deterministic_chunking,
+        max_parallel_insert=1,
+    )
+    await rag.initialize_storages()
+    return rag
+
+
+def _live_worker_tasks() -> list[asyncio.Task]:
+    """Pipeline worker tasks (parse/analyze/process) that are still pending.
+
+    With the try/finally fix these are always cancelled+awaited before
+    ``_run_pipeline_batch`` returns, so this is empty afterwards. Without it,
+    an escape orphans them and they linger here.
+    """
+    live = []
+    for task in asyncio.all_tasks():
+        qualname = getattr(task.get_coro(), "__qualname__", "")
+        if any(
+            marker in qualname
+            for marker in ("_parse_worker", "_analyze_worker", "_process_worker")
+        ):
+            if not task.done():
+                live.append(task)
+    return live
+
+
+async def _passthrough_validate(self_docs, pipeline_status, pipeline_status_lock):
+    # Skip the pre-enqueue full_docs read so the only get_by_id for the bad
+    # doc is the orchestrator enqueue read under test.
+    return self_docs
+
+
+@pytest.mark.asyncio
+async def test_single_doc_get_by_id_failure_is_isolated_no_orphans(
+    tmp_path, monkeypatch
+):
+    """One doc's enqueue get_by_id fails -> that doc FAILED, the rest PROCESSED,
+    busy released, and no worker tasks are orphaned."""
+    rag = await _build_rag(tmp_path)
+    try:
+        bad_path = "bad.txt"
+        good_path = "good.txt"
+        bad_id = compute_mdhash_id(bad_path, prefix="doc-")
+        good_id = compute_mdhash_id(good_path, prefix="doc-")
+        await rag.apipeline_enqueue_documents(
+            input=["bad content", "good content"],
+            file_paths=[bad_path, good_path],
+        )
+
+        monkeypatch.setattr(
+            rag, "_validate_and_fix_document_consistency", _passthrough_validate
+        )
+
+        orig_get = rag.full_docs.get_by_id
+
+        async def flaky_get(doc_id):
+            if doc_id == bad_id:
+                raise ConnectionError("redis down for this doc")
+            return await orig_get(doc_id)
+
+        monkeypatch.setattr(rag.full_docs, "get_by_id", flaky_get)
+
+        await rag.apipeline_process_enqueue_documents()
+        # Give any (incorrectly) orphaned tasks a tick to surface.
+        await asyncio.sleep(0)
+
+        assert _live_worker_tasks() == [], "worker tasks were orphaned"
+
+        bad_status = await rag.doc_status.get_by_id(bad_id)
+        good_status = await rag.doc_status.get_by_id(good_id)
+        assert _status_to_text(bad_status["status"]) == "failed"
+        assert _status_to_text(good_status["status"]) == "processed"
+
+        pipeline_status = await get_namespace_data(
+            "pipeline_status", workspace=rag.workspace
+        )
+        assert pipeline_status.get("busy") is False
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_full_outage_escape_still_cancels_workers(tmp_path, monkeypatch):
+    """When even the FAILED-status write fails (full outage), the exception
+    escapes the enqueue loop, but the try/finally still cancels all workers
+    and the caller's finally releases busy — no orphans, busy=False."""
+    rag = await _build_rag(tmp_path)
+    try:
+        await rag.apipeline_enqueue_documents(
+            input="outage content", file_paths="outage.txt"
+        )
+
+        monkeypatch.setattr(
+            rag, "_validate_and_fix_document_consistency", _passthrough_validate
+        )
+
+        async def dead_get(doc_id):
+            raise ConnectionError("redis fully down")
+
+        async def dead_upsert(*args, **kwargs):
+            raise ConnectionError("redis fully down")
+
+        monkeypatch.setattr(rag.full_docs, "get_by_id", dead_get)
+        # _finalize_doc_failure's doc_status write also fails -> escape.
+        monkeypatch.setattr(rag.doc_status, "upsert", dead_upsert)
+
+        # apipeline_process_enqueue_documents lets the storage error propagate
+        # out (its finally releases busy but does not swallow the exception).
+        with pytest.raises(Exception):
+            await rag.apipeline_process_enqueue_documents()
+        await asyncio.sleep(0)
+
+        assert _live_worker_tasks() == [], "worker tasks were orphaned on escape"
+
+        pipeline_status = await get_namespace_data(
+            "pipeline_status", workspace=rag.workspace
+        )
+        assert pipeline_status.get("busy") is False
+    finally:
+        await rag.finalize_storages()

--- a/tests/pipeline/test_pipeline_orchestrator_get_by_id_failure.py
+++ b/tests/pipeline/test_pipeline_orchestrator_get_by_id_failure.py
@@ -1,21 +1,23 @@
 """Offline tests for orchestrator-level storage failures during batch enqueue.
 
-Covers the fix that:
+Covers the fix that guarantees the parse/analyze/process workers created in
+``_run_pipeline_batch`` are ALWAYS cancelled+awaited via a try/finally — so an
+exception escaping the enqueue loop (e.g. an orchestrator-level
+``full_docs.get_by_id`` failing during a backend outage) can never orphan live
+worker tasks that keep draining the queues and appending to ``history_messages``
+while the caller's finally has already cleared ``busy`` (the observed
+"busy=False but processing visibly continues" symptom). The same finally also
+discards not-yet-flushed shared index buffers so stale records are not carried
+into the next batch.
 
-* guarantees the parse/analyze/process workers created in ``_run_pipeline_batch``
-  are ALWAYS cancelled+awaited via a try/finally — so an exception escaping the
-  enqueue loop (e.g. an orchestrator-level ``full_docs.get_by_id`` failing during
-  a backend outage) can never orphan live worker tasks that keep draining the
-  queues and appending to ``history_messages`` while the caller's finally has
-  already cleared ``busy`` (busy=False but processing visibly continues); and
-* isolates a single failing document's engine-routing ``get_by_id`` so that a
-  transient/corrupt doc is marked FAILED and the rest of the batch still
-  processes, instead of escaping and aborting the whole batch.
+By design there is NO per-document isolation of this read: the same unguarded
+``full_docs.get_by_id`` also runs in ``_validate_and_fix_document_consistency``
+before the batch, so a failure aborts the whole batch CLEANLY (workers torn
+down, busy released, docs left PENDING for retry) rather than being isolated.
 
-The orchestrator's ``full_docs.get_by_id`` at batch enqueue is the read under
-test. ``_validate_and_fix_document_consistency`` (which also reads full_docs,
-but BEFORE any worker is created — so an escape there is a clean stop, not an
-orphan) is bypassed to target the enqueue path deterministically.
+``_validate_and_fix_document_consistency`` is bypassed in these tests so the
+escape lands inside ``_run_pipeline_batch`` (where workers are live) — the path
+that actually exercises worker teardown.
 """
 
 from __future__ import annotations
@@ -111,63 +113,23 @@ async def _passthrough_validate(self_docs, pipeline_status, pipeline_status_lock
 
 
 @pytest.mark.asyncio
-async def test_single_doc_get_by_id_failure_is_isolated_no_orphans(
-    tmp_path, monkeypatch
-):
-    """One doc's enqueue get_by_id fails -> that doc FAILED, the rest PROCESSED,
-    busy released, and no worker tasks are orphaned."""
+async def test_enqueue_get_by_id_failure_aborts_batch_cleanly(tmp_path, monkeypatch):
+    """An orchestrator-level get_by_id failure during batch enqueue (after the
+    workers exist) aborts the whole batch CLEANLY: the exception propagates,
+    every worker task is cancelled (no orphans), pending index buffers are
+    discarded, and the caller releases ``busy``. The document is left in a
+    non-PROCESSED state for the next run (no per-doc isolation by design).
+
+    ``_validate_and_fix_document_consistency`` is bypassed so the escape lands
+    inside ``_run_pipeline_batch`` (where workers are live) rather than in the
+    earlier validation read — the path that actually exercises worker teardown.
+    """
     rag = await _build_rag(tmp_path)
     try:
-        bad_path = "bad.txt"
-        good_path = "good.txt"
-        bad_id = compute_mdhash_id(bad_path, prefix="doc-")
-        good_id = compute_mdhash_id(good_path, prefix="doc-")
+        doc_path = "outage.txt"
+        doc_id = compute_mdhash_id(doc_path, prefix="doc-")
         await rag.apipeline_enqueue_documents(
-            input=["bad content", "good content"],
-            file_paths=[bad_path, good_path],
-        )
-
-        monkeypatch.setattr(
-            rag, "_validate_and_fix_document_consistency", _passthrough_validate
-        )
-
-        orig_get = rag.full_docs.get_by_id
-
-        async def flaky_get(doc_id):
-            if doc_id == bad_id:
-                raise ConnectionError("redis down for this doc")
-            return await orig_get(doc_id)
-
-        monkeypatch.setattr(rag.full_docs, "get_by_id", flaky_get)
-
-        await rag.apipeline_process_enqueue_documents()
-        # Give any (incorrectly) orphaned tasks a tick to surface.
-        await asyncio.sleep(0)
-
-        assert _live_worker_tasks() == [], "worker tasks were orphaned"
-
-        bad_status = await rag.doc_status.get_by_id(bad_id)
-        good_status = await rag.doc_status.get_by_id(good_id)
-        assert _status_to_text(bad_status["status"]) == "failed"
-        assert _status_to_text(good_status["status"]) == "processed"
-
-        pipeline_status = await get_namespace_data(
-            "pipeline_status", workspace=rag.workspace
-        )
-        assert pipeline_status.get("busy") is False
-    finally:
-        await rag.finalize_storages()
-
-
-@pytest.mark.asyncio
-async def test_full_outage_escape_still_cancels_workers(tmp_path, monkeypatch):
-    """When even the FAILED-status write fails (full outage), the exception
-    escapes the enqueue loop, but the try/finally still cancels all workers
-    and the caller's finally releases busy — no orphans, busy=False."""
-    rag = await _build_rag(tmp_path)
-    try:
-        await rag.apipeline_enqueue_documents(
-            input="outage content", file_paths="outage.txt"
+            input="outage content", file_paths=doc_path
         )
 
         monkeypatch.setattr(
@@ -175,17 +137,12 @@ async def test_full_outage_escape_still_cancels_workers(tmp_path, monkeypatch):
         )
 
         async def dead_get(doc_id):
-            raise ConnectionError("redis fully down")
-
-        async def dead_upsert(*args, **kwargs):
-            raise ConnectionError("redis fully down")
+            raise ConnectionError("redis down during enqueue")
 
         monkeypatch.setattr(rag.full_docs, "get_by_id", dead_get)
-        # _finalize_doc_failure's doc_status write also fails -> escape.
-        monkeypatch.setattr(rag.doc_status, "upsert", dead_upsert)
 
-        # The batch's finally must discard not-yet-flushed shared buffers on an
-        # exception escape (not just the cooperative internal-error flag), so
+        # The batch's finally must discard not-yet-flushed shared buffers when an
+        # exception escapes (not just on the cooperative internal-error flag), so
         # stale KG/vector records are not carried into the next batch.
         discard_calls = 0
         orig_discard = rag._discard_pending_index_ops
@@ -210,5 +167,9 @@ async def test_full_outage_escape_still_cancels_workers(tmp_path, monkeypatch):
             "pipeline_status", workspace=rag.workspace
         )
         assert pipeline_status.get("busy") is False
+
+        # Doc was not marked PROCESSED — it stays queued for the next run.
+        row = await rag.doc_status.get_by_id(doc_id)
+        assert _status_to_text(row["status"]) != "processed"
     finally:
         await rag.finalize_storages()

--- a/tests/pipeline/test_pipeline_orchestrator_get_by_id_failure.py
+++ b/tests/pipeline/test_pipeline_orchestrator_get_by_id_failure.py
@@ -1,23 +1,21 @@
 """Offline tests for orchestrator-level storage failures during batch enqueue.
 
-Covers the fix that guarantees the parse/analyze/process workers created in
-``_run_pipeline_batch`` are ALWAYS cancelled+awaited via a try/finally — so an
-exception escaping the enqueue loop (e.g. an orchestrator-level
-``full_docs.get_by_id`` failing during a backend outage) can never orphan live
-worker tasks that keep draining the queues and appending to ``history_messages``
-while the caller's finally has already cleared ``busy`` (the observed
-"busy=False but processing visibly continues" symptom). The same finally also
-discards not-yet-flushed shared index buffers so stale records are not carried
-into the next batch.
+Covers the fix that:
 
-By design there is NO per-document isolation of this read: the same unguarded
-``full_docs.get_by_id`` also runs in ``_validate_and_fix_document_consistency``
-before the batch, so a failure aborts the whole batch CLEANLY (workers torn
-down, busy released, docs left PENDING for retry) rather than being isolated.
+* guarantees the parse/analyze/process workers created in ``_run_pipeline_batch``
+  are ALWAYS cancelled+awaited via a try/finally — so an exception escaping the
+  enqueue loop (e.g. an orchestrator-level ``full_docs.get_by_id`` failing during
+  a backend outage) can never orphan live worker tasks that keep draining the
+  queues and appending to ``history_messages`` while the caller's finally has
+  already cleared ``busy`` (busy=False but processing visibly continues); and
+* isolates a single failing document's engine-routing ``get_by_id`` so that a
+  transient/corrupt doc is marked FAILED and the rest of the batch still
+  processes, instead of escaping and aborting the whole batch.
 
-``_validate_and_fix_document_consistency`` is bypassed in these tests so the
-escape lands inside ``_run_pipeline_batch`` (where workers are live) — the path
-that actually exercises worker teardown.
+The orchestrator's ``full_docs.get_by_id`` at batch enqueue is the read under
+test. ``_validate_and_fix_document_consistency`` (which also reads full_docs,
+but BEFORE any worker is created — so an escape there is a clean stop, not an
+orphan) is bypassed to target the enqueue path deterministically.
 """
 
 from __future__ import annotations
@@ -113,23 +111,63 @@ async def _passthrough_validate(self_docs, pipeline_status, pipeline_status_lock
 
 
 @pytest.mark.asyncio
-async def test_enqueue_get_by_id_failure_aborts_batch_cleanly(tmp_path, monkeypatch):
-    """An orchestrator-level get_by_id failure during batch enqueue (after the
-    workers exist) aborts the whole batch CLEANLY: the exception propagates,
-    every worker task is cancelled (no orphans), pending index buffers are
-    discarded, and the caller releases ``busy``. The document is left in a
-    non-PROCESSED state for the next run (no per-doc isolation by design).
-
-    ``_validate_and_fix_document_consistency`` is bypassed so the escape lands
-    inside ``_run_pipeline_batch`` (where workers are live) rather than in the
-    earlier validation read — the path that actually exercises worker teardown.
-    """
+async def test_single_doc_get_by_id_failure_is_isolated_no_orphans(
+    tmp_path, monkeypatch
+):
+    """One doc's enqueue get_by_id fails -> that doc FAILED, the rest PROCESSED,
+    busy released, and no worker tasks are orphaned."""
     rag = await _build_rag(tmp_path)
     try:
-        doc_path = "outage.txt"
-        doc_id = compute_mdhash_id(doc_path, prefix="doc-")
+        bad_path = "bad.txt"
+        good_path = "good.txt"
+        bad_id = compute_mdhash_id(bad_path, prefix="doc-")
+        good_id = compute_mdhash_id(good_path, prefix="doc-")
         await rag.apipeline_enqueue_documents(
-            input="outage content", file_paths=doc_path
+            input=["bad content", "good content"],
+            file_paths=[bad_path, good_path],
+        )
+
+        monkeypatch.setattr(
+            rag, "_validate_and_fix_document_consistency", _passthrough_validate
+        )
+
+        orig_get = rag.full_docs.get_by_id
+
+        async def flaky_get(doc_id):
+            if doc_id == bad_id:
+                raise ConnectionError("redis down for this doc")
+            return await orig_get(doc_id)
+
+        monkeypatch.setattr(rag.full_docs, "get_by_id", flaky_get)
+
+        await rag.apipeline_process_enqueue_documents()
+        # Give any (incorrectly) orphaned tasks a tick to surface.
+        await asyncio.sleep(0)
+
+        assert _live_worker_tasks() == [], "worker tasks were orphaned"
+
+        bad_status = await rag.doc_status.get_by_id(bad_id)
+        good_status = await rag.doc_status.get_by_id(good_id)
+        assert _status_to_text(bad_status["status"]) == "failed"
+        assert _status_to_text(good_status["status"]) == "processed"
+
+        pipeline_status = await get_namespace_data(
+            "pipeline_status", workspace=rag.workspace
+        )
+        assert pipeline_status.get("busy") is False
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_full_outage_escape_still_cancels_workers(tmp_path, monkeypatch):
+    """When even the FAILED-status write fails (full outage), the exception
+    escapes the enqueue loop, but the try/finally still cancels all workers
+    and the caller's finally releases busy — no orphans, busy=False."""
+    rag = await _build_rag(tmp_path)
+    try:
+        await rag.apipeline_enqueue_documents(
+            input="outage content", file_paths="outage.txt"
         )
 
         monkeypatch.setattr(
@@ -137,22 +175,14 @@ async def test_enqueue_get_by_id_failure_aborts_batch_cleanly(tmp_path, monkeypa
         )
 
         async def dead_get(doc_id):
-            raise ConnectionError("redis down during enqueue")
+            raise ConnectionError("redis fully down")
+
+        async def dead_upsert(*args, **kwargs):
+            raise ConnectionError("redis fully down")
 
         monkeypatch.setattr(rag.full_docs, "get_by_id", dead_get)
-
-        # The batch's finally must discard not-yet-flushed shared buffers when an
-        # exception escapes (not just on the cooperative internal-error flag), so
-        # stale KG/vector records are not carried into the next batch.
-        discard_calls = 0
-        orig_discard = rag._discard_pending_index_ops
-
-        async def spy_discard(*, skip_enqueue_owned=True):
-            nonlocal discard_calls
-            discard_calls += 1
-            await orig_discard(skip_enqueue_owned=skip_enqueue_owned)
-
-        monkeypatch.setattr(rag, "_discard_pending_index_ops", spy_discard)
+        # _finalize_doc_failure's doc_status write also fails -> escape.
+        monkeypatch.setattr(rag.doc_status, "upsert", dead_upsert)
 
         # apipeline_process_enqueue_documents lets the storage error propagate
         # out (its finally releases busy but does not swallow the exception).
@@ -161,15 +191,10 @@ async def test_enqueue_get_by_id_failure_aborts_batch_cleanly(tmp_path, monkeypa
         await asyncio.sleep(0)
 
         assert _live_worker_tasks() == [], "worker tasks were orphaned on escape"
-        assert discard_calls >= 1, "pending index buffers were not discarded on escape"
 
         pipeline_status = await get_namespace_data(
             "pipeline_status", workspace=rag.workspace
         )
         assert pipeline_status.get("busy") is False
-
-        # Doc was not marked PROCESSED — it stays queued for the next run.
-        row = await rag.doc_status.get_by_id(doc_id)
-        assert _status_to_text(row["status"]) != "processed"
     finally:
         await rag.finalize_storages()

--- a/tests/pipeline/test_pipeline_orchestrator_get_by_id_failure.py
+++ b/tests/pipeline/test_pipeline_orchestrator_get_by_id_failure.py
@@ -184,6 +184,19 @@ async def test_full_outage_escape_still_cancels_workers(tmp_path, monkeypatch):
         # _finalize_doc_failure's doc_status write also fails -> escape.
         monkeypatch.setattr(rag.doc_status, "upsert", dead_upsert)
 
+        # The batch's finally must discard not-yet-flushed shared buffers on an
+        # exception escape (not just the cooperative internal-error flag), so
+        # stale KG/vector records are not carried into the next batch.
+        discard_calls = 0
+        orig_discard = rag._discard_pending_index_ops
+
+        async def spy_discard(*, skip_enqueue_owned=True):
+            nonlocal discard_calls
+            discard_calls += 1
+            await orig_discard(skip_enqueue_owned=skip_enqueue_owned)
+
+        monkeypatch.setattr(rag, "_discard_pending_index_ops", spy_discard)
+
         # apipeline_process_enqueue_documents lets the storage error propagate
         # out (its finally releases busy but does not swallow the exception).
         with pytest.raises(Exception):
@@ -191,6 +204,7 @@ async def test_full_outage_escape_still_cancels_workers(tmp_path, monkeypatch):
         await asyncio.sleep(0)
 
         assert _live_worker_tasks() == [], "worker tasks were orphaned on escape"
+        assert discard_calls >= 1, "pending index buffers were not discarded on escape"
 
         pipeline_status = await get_namespace_data(
             "pipeline_status", workspace=rag.workspace


### PR DESCRIPTION
## Description

Fixes a `busy`-flag desync observed after a Redis (KV/doc_status) backend outage during active pipeline processing: the WebUI's flashing red "pipeline busy" indicator went off (looked stopped), yet the `/documents/pipeline_status` dialog kept showing `history_messages` updating and the backend kept processing remaining files.

This is **not** a `/health` bug. With a single workspace, `/health` and `/documents/pipeline_status` read the same shared `pipeline_status` Manager dict, and the Manager IPC was healthy (the status-card lock view kept updating). `/health` faithfully reported a `busy` value that had been cleared **too early**.

## Root Cause

The pipeline's storage-exception handling only covered the **per-document worker path** (parse/merge failures → `_finalize_doc_failure` marks the doc FAILED and swallows, `busy` stays True). The **orchestrator path** was unguarded:

1. `_run_pipeline_batch` creates the parse/analyze/process worker tasks, then calls `await self.full_docs.get_by_id(doc_id)` (engine routing — a KV/Redis read) inside the enqueue loop, and only cancelled the workers **after** all queue joins succeed. There was **no `try/finally`** around the worker lifecycle.
2. During the outage, that `get_by_id` raised `ConnectionError/RetryError`. The exception escaped `_run_pipeline_batch` (workers never cancelled → **orphaned**), propagated past the un-wrapped call site in `apipeline_process_enqueue_documents`, and hit the outer `finally`, which unconditionally set `pipeline_status["busy"] = False`.
3. The orphaned workers kept draining the already-enqueued docs and appending to `history_messages` — and, after Redis recovered, finished the work — while `busy=False`. Secondary risk: a later auto-scan/enqueue could see `busy=False` and start a **second** pass alongside the orphans.

## Changes Made

`lightrag/pipeline.py` — `_run_pipeline_batch`:
- **Wrap the enqueue loop + the three queue `join()`s in `try`, with `worker.cancel()` + `await gather(..., return_exceptions=True)` in `finally`.** Workers are always reclaimed, so no orphans and no `busy` desync.
- **Per-document isolation of the enqueue-time `get_by_id`.** A transient/corrupt single doc is marked FAILED (via `_finalize_doc_failure`) and the batch **continues to completion**, so in-flight documents reach terminal states instead of being stranded in PARSING/ANALYZING by an abrupt whole-batch abort. (A whole-batch-abort variant was tried and reverted — see Notes — because in production it stranded in-flight docs and perturbed teardown.)
- The internal-error abort still discards not-yet-flushed shared index buffers (`_discard_pending_index_ops`) after workers are stopped, so stale KG/vector records are not carried into the next batch.

`lightrag/pipeline.py` — `_finalize_doc_failure`:
- **Label internal-error cancels correctly in `doc_status`.** In-flight merge workers raise a hardcoded `"User cancelled during <stage>"` on a cooperative cancel; the doc's `error_msg` recorded that verbatim even when the batch was aborted by an **internal error**. Swap the generic `"User cancelled"` prefix for the reason-aware `_cancellation_label`, so `doc_status` records `"Cancelled by internal error: <detail> during <stage>"` while a genuine user cancel still reads `"User cancelled during <stage>"`.

`tests/pipeline/test_pipeline_orchestrator_get_by_id_failure.py` (new):
- single-doc enqueue `get_by_id` failure is isolated (bad → FAILED, good → PROCESSED), `busy` released, **no orphaned worker tasks**;
- full-outage escape still cancels all workers and releases `busy`.

`tests/pipeline/test_pipeline_internal_abort.py`:
- two `_finalize_doc_failure` cases asserting the `doc_status` `error_msg` label for internal-error vs user-cancel.

## Notes

A review-bot suggestion to (a) drop per-doc isolation in favor of a clean whole-batch abort and (b) discard buffers from inside the `finally` on any exception escape was implemented and then **reverted after a production retest**: removing isolation stranded in-flight documents in PARSING/ANALYZING, and discarding inside the teardown `finally` made the abort path itself hit Redis (LLM-cache flush → tenacity retry) during the very outage that triggered it. The bot's underlying concerns (stale buffers on a hard escape; the same unguarded read in `_validate_and_fix_document_consistency` running first) are valid but are deferred as separate hardening.

Out of scope (deliberate): `get_docs_by_statuses` at the loop top runs *between* batches with no live workers, so an escape there is a clean stop. This repo already has the `_atomic_release_busy_or_consume_pending` / `busy_released_in_loop` loop-exit-race fix (commit 8d46b0c3).

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Verification: `tests/pipeline/` → **207 passed**; `ruff check` clean. Production retest on commit `6fbebf47` (the state this PR is now restored to) confirmed clean teardown — all workers cancelled, no stranded docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)