### PR TITLE
✨ feat(pipeline): persist parse_engine/parse_format at PARSING stage

### DIFF
--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -88,6 +88,7 @@ from lightrag.utils_pipeline import (
     parsed_artifact_dir_for,
     read_source_file_basename,
     resolve_doc_file_path,
+    resolve_doc_status_parse_engine,
     sidecar_blocks_path,
     sidecar_uri_for,
     strip_lightrag_doc_prefix,
@@ -1683,6 +1684,31 @@ class _PipelineMixin:
                 else:
                     status_doc_w.metadata["parse_end_time"] = int(time.time())
 
+                # Stamp the parse-stage extraction metadata (parse_format /
+                # parse_engine) now that the engine has run and reported its
+                # actual format/engine. These are determined here, so record
+                # them at the PARSING upsert below instead of deferring to
+                # PROCESSING; carry-over (_DOC_STATUS_METADATA_CARRY_OVER_KEYS)
+                # then preserves them across ANALYZING → PROCESSING → PROCESSED.
+                # ``resolve_doc_status_parse_engine`` is the shared resolver
+                # used by process_single_document too, so the value never jumps
+                # between the early and final writes. The engine source order
+                # mirrors the process stage's read from full_docs: the parser's
+                # own report wins, then the enqueue-time directive on
+                # content_data (raw passthrough), then the format-based default.
+                parse_format_w = (
+                    parsed_data_w.get("parse_format") or FULL_DOCS_FORMAT_RAW
+                )
+                explicit_engine_w = parsed_data_w.get("parse_engine") or (
+                    content_data_w.get("parse_engine")
+                    if isinstance(content_data_w, dict)
+                    else None
+                )
+                status_doc_w.metadata["parse_format"] = parse_format_w
+                status_doc_w.metadata["parse_engine"] = resolve_doc_status_parse_engine(
+                    parse_format_w, explicit_engine_w
+                )
+
                 # parse_* may have patched content_hash for
                 # pending_parse → raw transitions.
                 refreshed = await self.doc_status.get_by_id(doc_id_w)
@@ -2254,11 +2280,11 @@ class _PipelineMixin:
                 )
                 extraction_meta = {
                     "parse_format": persisted_format,
-                    "parse_engine": persisted_engine
-                    or (
-                        "native"
-                        if persisted_format == FULL_DOCS_FORMAT_LIGHTRAG
-                        else "legacy"
+                    # Shared resolver with the parse stage (_parse_worker), so a
+                    # field already stamped at PARSING re-writes to the same
+                    # value here — no value jump across the transition.
+                    "parse_engine": resolve_doc_status_parse_engine(
+                        persisted_format, persisted_engine
                     ),
                     "chunk_method": (
                         # Explicit selector in process_options: reflect
@@ -3038,6 +3064,7 @@ class _PipelineMixin:
                 "doc_id": doc_id,
                 "file_path": file_path,
                 "parse_format": FULL_DOCS_FORMAT_LIGHTRAG,
+                "parse_engine": PARSER_ENGINE_NATIVE,
                 "content": parsed_data["content"],
                 "blocks_path": parsed_data["blocks_path"],
             }
@@ -3175,6 +3202,7 @@ class _PipelineMixin:
             "doc_id": doc_id,
             "file_path": file_path,
             "parse_format": FULL_DOCS_FORMAT_LIGHTRAG,
+            "parse_engine": PARSER_ENGINE_MINERU,
             "content": parsed_data["content"],
             "blocks_path": parsed_data["blocks_path"],
             "parse_stage_skipped": parse_stage_skipped,
@@ -3294,6 +3322,7 @@ class _PipelineMixin:
             "doc_id": doc_id,
             "file_path": file_path,
             "parse_format": FULL_DOCS_FORMAT_LIGHTRAG,
+            "parse_engine": PARSER_ENGINE_DOCLING,
             "content": parsed_data["content"],
             "blocks_path": parsed_data["blocks_path"],
             "parse_stage_skipped": parse_stage_skipped,

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -23,6 +23,8 @@ from lightrag.constants import (
     FULL_DOCS_FORMAT_LIGHTRAG,
     LIGHTRAG_DOC_CONTENT_PREFIX,
     PARSED_DIR_NAME,
+    PARSER_ENGINE_LEGACY,
+    PARSER_ENGINE_NATIVE,
 )
 from lightrag.parser.routing import canonicalize_parser_hinted_basename
 from lightrag.utils import (
@@ -236,6 +238,30 @@ def read_source_file_basename(data: Any) -> str | None:
 # insertion order all the way to the rendered output). Keep fields
 # grouped by stage: parse-stage fields together, analyze-stage fields
 # together, etc., so the dialog reads top-to-bottom along the pipeline.
+def resolve_doc_status_parse_engine(
+    parse_format: str | None,
+    explicit_engine: str | None,
+) -> str:
+    """Resolve the ``parse_engine`` value recorded in doc_status metadata.
+
+    Single source of truth shared by the parse stage (``_parse_worker``) and
+    the process stage (``process_single_document``) so both stamp the *same*
+    value — preventing a value "jump" when the field is written early at
+    PARSING and re-written later at PROCESSING.  ``explicit_engine`` wins when
+    a parser reported the engine it actually ran (or full_docs carries an
+    enqueue-time directive); otherwise fall back to ``native`` for the
+    structured ``lightrag`` format and ``legacy`` for everything else
+    (``raw`` passthrough), mirroring how a pre-engine corpus was processed.
+    """
+    if explicit_engine:
+        return explicit_engine
+    return (
+        PARSER_ENGINE_NATIVE
+        if parse_format == FULL_DOCS_FORMAT_LIGHTRAG
+        else PARSER_ENGINE_LEGACY
+    )
+
+
 _DOC_STATUS_METADATA_CARRY_OVER_KEYS: tuple[str, ...] = (
     "process_options",
     "source_file",
@@ -244,6 +270,8 @@ _DOC_STATUS_METADATA_CARRY_OVER_KEYS: tuple[str, ...] = (
     "parse_start_time",
     "parse_end_time",
     "parse_stage_skipped",
+    "parse_format",
+    "parse_engine",
     "analyzing_start_time",
     "analyzing_end_time",
     "analyzing_stage_skipped",

--- a/tests/pipeline/test_parse_engine_early_persist.py
+++ b/tests/pipeline/test_parse_engine_early_persist.py
@@ -1,0 +1,318 @@
+"""parse_engine / parse_format are stamped into doc_status at the PARSING
+stage (once the engine has run), not deferred to PROCESSING.
+
+Background: these two fields are determined by the parser the moment it
+finishes (native/mineru/docling each report a fixed engine; the resulting
+``parse_format`` is likewise known).  Historically they only landed in
+``doc_status.metadata`` at the PROCESSING/PROCESSED transition, bundled into
+``extraction_meta`` — so a document mid-flight (PARSING/ANALYZING) did not
+expose which engine/format produced it.
+
+These tests pin the new contract:
+
+* ``resolve_doc_status_parse_engine`` — the shared resolver used by both the
+  parse stage and the process stage (so the value never differs between the
+  early and final writes).
+* ``doc_status_metadata_carry_over`` now preserves ``parse_format`` /
+  ``parse_engine`` across transitions (they were added to the carry-over
+  allowlist), while ``doc_status_reset_metadata`` still drops them (they stay
+  per-attempt directives that a re-queue regenerates).
+* End-to-end: the first transition carrying ``parse_engine`` is the PARSING
+  one (proving early persistence), and the value never "jumps" between the
+  parse-stage write and the process-stage rewrite.
+"""
+
+import asyncio
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG
+from lightrag.base import DocStatus
+from lightrag.constants import (
+    FULL_DOCS_FORMAT_LIGHTRAG,
+    FULL_DOCS_FORMAT_RAW,
+    PARSER_ENGINE_DOCLING,
+    PARSER_ENGINE_LEGACY,
+    PARSER_ENGINE_MINERU,
+    PARSER_ENGINE_NATIVE,
+)
+from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
+from lightrag.utils_pipeline import (
+    _DOC_STATUS_METADATA_CARRY_OVER_KEYS,
+    doc_status_metadata_carry_over,
+    doc_status_reset_metadata,
+    resolve_doc_status_parse_engine,
+)
+
+pytestmark = pytest.mark.offline
+
+
+# ---------------------------------------------------------------------------
+# resolve_doc_status_parse_engine — unit
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_engine_explicit_wins():
+    # A parser that reported its engine (or an enqueue-time directive) is
+    # honoured verbatim regardless of format.
+    assert (
+        resolve_doc_status_parse_engine(FULL_DOCS_FORMAT_LIGHTRAG, PARSER_ENGINE_MINERU)
+        == PARSER_ENGINE_MINERU
+    )
+    assert (
+        resolve_doc_status_parse_engine(FULL_DOCS_FORMAT_RAW, PARSER_ENGINE_DOCLING)
+        == PARSER_ENGINE_DOCLING
+    )
+
+
+def test_resolve_engine_format_based_fallback():
+    # No explicit engine: structured lightrag → native, everything else
+    # (raw passthrough, unknown) → legacy. Mirrors how a pre-engine corpus
+    # was processed.
+    assert (
+        resolve_doc_status_parse_engine(FULL_DOCS_FORMAT_LIGHTRAG, None)
+        == PARSER_ENGINE_NATIVE
+    )
+    assert (
+        resolve_doc_status_parse_engine(FULL_DOCS_FORMAT_RAW, None)
+        == PARSER_ENGINE_LEGACY
+    )
+    assert resolve_doc_status_parse_engine(None, None) == PARSER_ENGINE_LEGACY
+    assert resolve_doc_status_parse_engine(FULL_DOCS_FORMAT_RAW, "") == (
+        PARSER_ENGINE_LEGACY
+    )
+
+
+# ---------------------------------------------------------------------------
+# carry-over / reset allowlist interplay — unit
+# ---------------------------------------------------------------------------
+
+
+def test_carry_over_preserves_parse_engine_and_format():
+    # Both keys are now in the carry-over allowlist, so a value stamped at
+    # PARSING survives every later transition's metadata replace.
+    assert "parse_format" in _DOC_STATUS_METADATA_CARRY_OVER_KEYS
+    assert "parse_engine" in _DOC_STATUS_METADATA_CARRY_OVER_KEYS
+
+    carried = doc_status_metadata_carry_over(
+        {
+            "metadata": {
+                "parse_format": FULL_DOCS_FORMAT_LIGHTRAG,
+                "parse_engine": PARSER_ENGINE_MINERU,
+                "process_options": "iF",
+            }
+        }
+    )
+    assert carried["parse_format"] == FULL_DOCS_FORMAT_LIGHTRAG
+    assert carried["parse_engine"] == PARSER_ENGINE_MINERU
+
+
+def test_reset_still_drops_parse_engine_and_format():
+    # Carry-over (across transitions) is independent of reset (back to
+    # PENDING): a re-queue regenerates these per-attempt directives, so they
+    # must NOT survive a reset even though they survive transitions.
+    reset = doc_status_reset_metadata(
+        {
+            "metadata": {
+                "parse_format": FULL_DOCS_FORMAT_LIGHTRAG,
+                "parse_engine": PARSER_ENGINE_MINERU,
+                "process_options": "iF",
+                "source_file": "report.pdf",
+            }
+        }
+    )
+    assert reset == {"process_options": "iF", "source_file": "report.pdf"}
+    assert "parse_engine" not in reset
+    assert "parse_format" not in reset
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: early persistence + no value jump
+# ---------------------------------------------------------------------------
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _mock_embedding(texts: list[str]) -> np.ndarray:
+    return np.random.rand(len(texts), 32)
+
+
+async def _mock_llm(prompt, **kwargs):
+    return '{"name":"x","summary":"s","detail_description":"d"}'
+
+
+def _new_rag(tmp_path: Path) -> LightRAG:
+    return LightRAG(
+        working_dir=str(tmp_path),
+        workspace=f"parse-engine-early-{tmp_path.name}",
+        llm_model_func=_mock_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=32,
+            max_token_size=4096,
+            func=_mock_embedding,
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        max_parallel_insert=1,
+    )
+
+
+def _attach_transition_spy(rag: LightRAG) -> list[tuple[str, dict]]:
+    """Record (status, written-metadata) at every state-transition upsert.
+
+    The written metadata mirrors what ``_upsert_doc_status_transition``
+    persists (carry-over allowlist + ``metadata_extra``), reconstructed via
+    the same helper so the recording matches storage exactly.
+    """
+    from lightrag.utils_pipeline import doc_status_transition_metadata
+
+    records: list[tuple[str, dict]] = []
+    orig = rag._upsert_doc_status_transition
+
+    async def _spy(doc_id, status, status_doc, file_path, **kwargs):
+        written = doc_status_transition_metadata(
+            status_doc, extra=kwargs.get("metadata_extra")
+        )
+        status_text = status.value if isinstance(status, DocStatus) else str(status)
+        records.append((status_text, dict(written)))
+        return await orig(doc_id, status, status_doc, file_path, **kwargs)
+
+    rag._upsert_doc_status_transition = _spy
+    return records
+
+
+def _assert_early_and_stable(records, *, expected_format, expected_engine):
+    """Assert parse_* lands at PARSING and never changes afterwards."""
+    with_engine = [(status, md) for status, md in records if "parse_engine" in md]
+    assert with_engine, "parse_engine never written to any doc_status transition"
+
+    # Early persistence: the FIRST transition that carries parse_engine is a
+    # PARSING one — not deferred to PROCESSING/PROCESSED.
+    first_status = with_engine[0][0]
+    assert first_status == DocStatus.PARSING.value, (
+        f"parse_engine first appeared at {first_status!r}; expected PARSING "
+        f"(early persistence). Full sequence: {[s for s, _ in records]}"
+    )
+
+    # No value jump: every transition that carries the fields agrees.
+    engines = {md["parse_engine"] for _, md in with_engine}
+    formats = {md["parse_format"] for _, md in with_engine if "parse_format" in md}
+    assert engines == {expected_engine}, (
+        f"parse_engine jumped across transitions: {engines!r}; "
+        f"expected a single value {expected_engine!r}"
+    )
+    assert formats == {expected_format}, (
+        f"parse_format jumped across transitions: {formats!r}; "
+        f"expected a single value {expected_format!r}"
+    )
+
+
+def test_raw_doc_records_legacy_engine_at_parsing(tmp_path):
+    """A raw passthrough doc: parse_engine resolves to ``legacy`` and is
+    stamped at PARSING, identical through PROCESSED (no jump)."""
+
+    async def _run():
+        rag = _new_rag(tmp_path / "raw")
+        await rag.initialize_storages()
+        records = _attach_transition_spy(rag)
+        try:
+            await rag.apipeline_enqueue_documents(
+                "Alpha body paragraph with enough words to look real.",
+                file_paths="early_raw.txt",
+                track_id="track-raw",
+            )
+            await rag.apipeline_process_enqueue_documents()
+
+            _assert_early_and_stable(
+                records,
+                expected_format=FULL_DOCS_FORMAT_RAW,
+                expected_engine=PARSER_ENGINE_LEGACY,
+            )
+
+            doc_id = compute_mdhash_id("early_raw.txt", prefix="doc-")
+            stored = await rag.doc_status.get_by_id(doc_id)
+            assert stored is not None
+            metadata = (
+                stored.get("metadata")
+                if isinstance(stored, dict)
+                else getattr(stored, "metadata", None)
+            )
+            assert metadata.get("parse_format") == FULL_DOCS_FORMAT_RAW
+            assert metadata.get("parse_engine") == PARSER_ENGINE_LEGACY
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def _write_lightrag_blocks(blocks_path: Path, body_paragraphs: list[str]) -> None:
+    lines = [
+        json.dumps(
+            {
+                "type": "meta",
+                "format": "lightrag",
+                "version": "1.0",
+                "format_version": "1.0",
+            },
+            ensure_ascii=False,
+        )
+    ]
+    for i, para in enumerate(body_paragraphs):
+        lines.append(
+            json.dumps(
+                {
+                    "type": "content",
+                    "blockid": f"b{i}",
+                    "format": "plain_text",
+                    "content": para,
+                },
+                ensure_ascii=False,
+            )
+        )
+    blocks_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_lightrag_doc_records_native_engine_at_parsing(tmp_path, monkeypatch):
+    """A lightrag-format doc (cache-hit, parser does not re-persist):
+    parse_engine resolves to ``native`` and is stamped at PARSING, identical
+    through PROCESSED."""
+
+    async def _run():
+        input_dir = tmp_path / "input"
+        parsed_dir = input_dir / "__parsed__"
+        parsed_dir.mkdir(parents=True)
+        monkeypatch.setenv("INPUT_DIR", str(input_dir))
+
+        blocks_path = parsed_dir / "early.blocks.jsonl"
+        _write_lightrag_blocks(blocks_path, ["Body paragraph for lightrag doc."])
+
+        rag = _new_rag(tmp_path / "work")
+        await rag.initialize_storages()
+        records = _attach_transition_spy(rag)
+        try:
+            await rag.apipeline_enqueue_documents(
+                "",
+                file_paths="early.lightrag",
+                docs_format=FULL_DOCS_FORMAT_LIGHTRAG,
+                lightrag_document_paths="__parsed__/early.blocks.jsonl",
+                track_id="track-lr",
+            )
+            await rag.apipeline_process_enqueue_documents()
+
+            _assert_early_and_stable(
+                records,
+                expected_format=FULL_DOCS_FORMAT_LIGHTRAG,
+                expected_engine=PARSER_ENGINE_NATIVE,
+            )
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())

--- a/tests/pipeline/test_pipeline_release_closure.py
+++ b/tests/pipeline/test_pipeline_release_closure.py
@@ -345,10 +345,12 @@ def test_carry_over_keys_grouped_by_stage():
     """Strict tuple-equality guard on ``_DOC_STATUS_METADATA_CARRY_OVER_KEYS``.
 
     The tuple order is the WebUI ``DocumentStatusDetailsDialog`` render order,
-    so per-stage fields must stay grouped (parse-stage trio then analyze-stage
-    trio). Locking the order here forces any future field addition to update
-    this assertion alongside the tuple, preventing silent regressions in the
-    dialog's timeline-ordered display.
+    so per-stage fields must stay grouped (parse-stage fields then analyze-stage
+    trio). ``parse_format`` / ``parse_engine`` join the parse-stage group so
+    they are stamped at PARSING (once the engine has run) and carried through
+    to PROCESSED instead of only landing at PROCESSING. Locking the order here
+    forces any future field addition to update this assertion alongside the
+    tuple, preventing silent regressions in the dialog's timeline display.
     """
     from lightrag.utils_pipeline import _DOC_STATUS_METADATA_CARRY_OVER_KEYS
 
@@ -360,6 +362,8 @@ def test_carry_over_keys_grouped_by_stage():
         "parse_start_time",
         "parse_end_time",
         "parse_stage_skipped",
+        "parse_format",
+        "parse_engine",
         "analyzing_start_time",
         "analyzing_end_time",
         "analyzing_stage_skipped",


### PR DESCRIPTION
## Description

`parse_engine` / `parse_format` are doc_status metadata fields that describe which engine parsed a document and what format it produced. They are **determined the moment the parser finishes** — `native`/`mineru`/`docling` each report a fixed engine, and the resulting `parse_format` is known at that point.

However, they only landed in `doc_status.metadata` at the **PROCESSING/PROCESSED** transition (bundled into `extraction_meta`). As a result, a document mid-flight (PARSING/ANALYZING) never exposed which engine/format produced it — the WebUI couldn't show this until processing was well underway.

This PR stamps both fields at the **PARSING** stage (right after the engine runs) and carries them through to the terminal state, with a guarantee that the value never changes between the early write and the final rewrite.

The deferral was never because the value was unknown — it was a side effect of two implementation details: (1) these keys were not in the carry-over allowlist, so an early write would be wiped by the next transition's metadata replace; (2) they were conveniently packed into `extraction_meta` alongside fields that genuinely require the process stage (`chunk_method`/`chunk_opts`).

## Related Issues

N/A — internal consistency / observability improvement.

## Changes Made

- **`lightrag/utils_pipeline.py`**
  - Add `resolve_doc_status_parse_engine(parse_format, explicit_engine)` — the single resolver shared by the parse stage and the process stage, so the early write and the final rewrite can never disagree (explicit engine wins; otherwise `native` for `lightrag`, `legacy` otherwise).
  - Add `parse_format` / `parse_engine` to `_DOC_STATUS_METADATA_CARRY_OVER_KEYS` (in the parse-stage group, matching the WebUI render order) so a value written at PARSING survives every later metadata replace. They remain in `_DOC_STATUS_METADATA_ATTEMPT_KEYS`, so a reset back to PENDING still drops them (a re-queue may pick a different engine).
- **`lightrag/pipeline.py`**
  - Each parser (`parse_native` pending-parse branch, `parse_mineru`, `parse_docling`) now reports its real engine in the returned `parsed_data`, so `_parse_worker` can stamp it without re-reading the (potentially large) body from `full_docs`.
  - `_parse_worker` stamps `parse_format` / `parse_engine` onto the in-memory `status_doc` before the PARSING upsert (engine source order: parser report → enqueue-time directive on `content_data` → format-based default), matching exactly what the process stage computes from `full_docs`.
  - `process_single_document` reuses the shared resolver instead of its inline fallback (DRY; the rewrite is idempotent, no value jump).
- **Tests**
  - New `tests/pipeline/test_parse_engine_early_persist.py`: unit tests for the resolver and the carry-over/reset allowlist interplay, plus end-to-end tests asserting the first transition carrying `parse_engine` is the PARSING one and the value is stable through PROCESSED (covers `raw → legacy` and `lightrag → native`).
  - Update the strict tuple guard in `tests/pipeline/test_pipeline_release_closure.py` to include the two new carry-over keys.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

- **No value jump by construction**: both the parse stage and the process stage call the same `resolve_doc_status_parse_engine`, fed from sources that agree (`raw → legacy`, `lightrag → native`, explicit engine verbatim).
- **Reset semantics preserved**: carry-over (across transitions) and reset-to-PENDING use *different* allowlists. Adding these keys to carry-over does not affect reset — they are still dropped on re-queue, which is correct since a retry may select a different engine.
- **Edge case**: a `raw` passthrough doc routes via `resolve_stored_document_parser_engine` → `"legacy"` but is handled by the `native` worker; the stamp deliberately uses the shared resolver (not the worker's `engine` arg) so it records `legacy`, consistent with the process stage.
- Verification: `pytest tests/pipeline/ tests/chunker/` → **380 passed**; `ruff check` clean on the touched files.
