### PR TITLE
feat: introduce BaseExternalParser protocol for pluggable OCR/VLM backends

### DIFF
--- a/lightrag/parser/external/_base.py
+++ b/lightrag/parser/external/_base.py
@@ -1,0 +1,68 @@
+"""BaseExternalParser protocol for pluggable OCR/VLM backends.
+
+See RFC: https://github.com/HKUDS/LightRAG/issues/3197
+
+Every external parser engine (MinerU, Docling, PaddleOCR-VL, etc.)
+implements this protocol. The pipeline dispatches through a registry
+dict instead of a growing ``if engine == …`` chain.
+
+Minimal contract:
+
+- ``is_bundle_valid`` — cheap cache-hit check against the raw bundle
+  on disk.  Returns True when the bundle is reusable (skip download).
+- ``download_into`` — fetch the raw bundle from the external service
+  and land it under ``raw_dir/``.  Called only on cache miss.
+- ``build_ir`` — convert the raw bundle to an :class:`IRDoc`.  Called
+  unconditionally after the cache/download step.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lightrag.sidecar.ir import IRDoc
+
+
+class BaseExternalParser(ABC):
+    """Abstract base for external parser engines.
+
+    Subclasses must set:
+    - ``engine_name`` — canonical engine identifier (e.g. ``"mineru"``).
+    - ``raw_dir_suffix`` — suffix for the raw bundle directory
+      (e.g. ``".mineru_raw"``).
+    - ``force_reparse_env`` — env var that forces a re-parse
+      (e.g. ``"LIGHTRAG_FORCE_REPARSE_MINERU"``).
+    """
+
+    engine_name: str
+    raw_dir_suffix: str
+    force_reparse_env: str
+
+    @abstractmethod
+    def is_bundle_valid(self, raw_dir: Path, source_path: Path) -> bool:
+        """Return True if the raw bundle in ``raw_dir`` is a valid
+        cache hit for ``source_path``."""
+        ...
+
+    @abstractmethod
+    async def download_into(
+        self,
+        raw_dir: Path,
+        source_path: Path,
+        **kwargs: object,
+    ) -> None:
+        """Download the raw bundle from the external service into
+        ``raw_dir/``.  Called only on cache miss."""
+        ...
+
+    @abstractmethod
+    def build_ir(
+        self,
+        raw_dir: Path,
+        document_name: str,
+    ) -> IRDoc:
+        """Convert the raw bundle in ``raw_dir`` to an :class:`IRDoc`."""
+        ...

--- a/lightrag/parser/external/_registry.py
+++ b/lightrag/parser/external/_registry.py
@@ -1,0 +1,52 @@
+"""Registry for external parser engines.
+
+Maps engine names to their :class:`BaseExternalParser` implementations.
+New engines register here instead of adding ``if engine == …`` branches
+in the pipeline.
+
+Usage::
+
+    from lightrag.parser.external._registry import get_parser, register_parser
+
+    # At module level (each engine registers itself):
+    register_parser("mineru", MinerUParser)
+    register_parser("docling", DoclingParser)
+
+    # At runtime:
+    parser = get_parser("mineru")
+    if parser.is_bundle_valid(raw_dir, source_path):
+        ...
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Type
+
+if TYPE_CHECKING:
+    from lightrag.parser.external._base import BaseExternalParser
+
+_REGISTRY: dict[str, Type[BaseExternalParser]] = {}
+
+
+def register_parser(engine_name: str, parser_cls: Type[BaseExternalParser]) -> None:
+    """Register a parser class for an engine name."""
+    _REGISTRY[engine_name] = parser_cls
+
+
+def get_parser(engine_name: str) -> BaseExternalParser:
+    """Get a parser instance for an engine name.
+
+    Raises KeyError if the engine is not registered.
+    """
+    cls = _REGISTRY.get(engine_name)
+    if cls is None:
+        raise KeyError(
+            f"No parser registered for engine {engine_name!r}. "
+            f"Registered engines: {', '.join(sorted(_REGISTRY))}"
+        )
+    return cls()
+
+
+def registered_engines() -> list[str]:
+    """Return sorted list of registered engine names."""
+    return sorted(_REGISTRY)

--- a/lightrag/parser/external/docling/__init__.py
+++ b/lightrag/parser/external/docling/__init__.py
@@ -39,3 +39,9 @@ __all__ = [
     "is_bundle_valid",
     "raw_dir_for_parsed_dir",
 ]
+
+# Register with the parser registry (RFC #3197)
+from lightrag.parser.external._registry import register_parser
+from lightrag.parser.external.docling.adapter import DoclingParser
+
+register_parser("docling", DoclingParser)

--- a/lightrag/parser/external/docling/adapter.py
+++ b/lightrag/parser/external/docling/adapter.py
@@ -1,0 +1,37 @@
+"""Docling adapter implementing BaseExternalParser."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from lightrag.parser.external._base import BaseExternalParser
+from lightrag.sidecar.ir import IRDoc
+
+
+class DoclingParser(BaseExternalParser):
+    """Docling engine adapter."""
+
+    engine_name = "docling"
+    raw_dir_suffix = ".docling_raw"
+    force_reparse_env = "LIGHTRAG_FORCE_REPARSE_DOCLING"
+
+    def is_bundle_valid(self, raw_dir: Path, source_path: Path) -> bool:
+        from lightrag.parser.external.docling.cache import is_bundle_valid
+        return is_bundle_valid(raw_dir, source_path)
+
+    async def download_into(
+        self,
+        raw_dir: Path,
+        source_path: Path,
+        **kwargs: object,
+    ) -> None:
+        from lightrag.parser.external.docling.client import DoclingRawClient
+        client = DoclingRawClient()
+        upload_filename = kwargs.get("upload_filename", source_path.name)
+        await client.download_into(raw_dir, source_path, upload_filename=str(upload_filename))
+
+    def build_ir(self, raw_dir: Path, document_name: str) -> IRDoc:
+        from lightrag.parser.external.docling.ir_builder import DoclingIRBuilder
+        builder = DoclingIRBuilder()
+        return builder.normalize_from_workdir(raw_dir, document_name=document_name)

--- a/lightrag/parser/external/docling/adapter.py
+++ b/lightrag/parser/external/docling/adapter.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 from lightrag.parser.external._base import BaseExternalParser
 from lightrag.sidecar.ir import IRDoc
@@ -18,6 +17,7 @@ class DoclingParser(BaseExternalParser):
 
     def is_bundle_valid(self, raw_dir: Path, source_path: Path) -> bool:
         from lightrag.parser.external.docling.cache import is_bundle_valid
+
         return is_bundle_valid(raw_dir, source_path)
 
     async def download_into(
@@ -27,11 +27,15 @@ class DoclingParser(BaseExternalParser):
         **kwargs: object,
     ) -> None:
         from lightrag.parser.external.docling.client import DoclingRawClient
+
         client = DoclingRawClient()
         upload_filename = kwargs.get("upload_filename", source_path.name)
-        await client.download_into(raw_dir, source_path, upload_filename=str(upload_filename))
+        await client.download_into(
+            raw_dir, source_path, upload_filename=str(upload_filename)
+        )
 
     def build_ir(self, raw_dir: Path, document_name: str) -> IRDoc:
         from lightrag.parser.external.docling.ir_builder import DoclingIRBuilder
+
         builder = DoclingIRBuilder()
         return builder.normalize_from_workdir(raw_dir, document_name=document_name)

--- a/lightrag/parser/external/mineru/__init__.py
+++ b/lightrag/parser/external/mineru/__init__.py
@@ -29,3 +29,9 @@ __all__ = [
     "is_bundle_valid",
     "raw_dir_for_parsed_dir",
 ]
+
+# Register with the parser registry (RFC #3197)
+from lightrag.parser.external._registry import register_parser
+from lightrag.parser.external.mineru.adapter import MinerUParser
+
+register_parser("mineru", MinerUParser)

--- a/lightrag/parser/external/mineru/adapter.py
+++ b/lightrag/parser/external/mineru/adapter.py
@@ -1,0 +1,37 @@
+"""MinerU adapter implementing BaseExternalParser."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from lightrag.parser.external._base import BaseExternalParser
+from lightrag.sidecar.ir import IRDoc
+
+
+class MinerUParser(BaseExternalParser):
+    """MinerU engine adapter."""
+
+    engine_name = "mineru"
+    raw_dir_suffix = ".mineru_raw"
+    force_reparse_env = "LIGHTRAG_FORCE_REPARSE_MINERU"
+
+    def is_bundle_valid(self, raw_dir: Path, source_path: Path) -> bool:
+        from lightrag.parser.external.mineru.cache import is_bundle_valid
+        return is_bundle_valid(raw_dir, source_path)
+
+    async def download_into(
+        self,
+        raw_dir: Path,
+        source_path: Path,
+        **kwargs: object,
+    ) -> None:
+        from lightrag.parser.external.mineru.client import MinerURawClient
+        client = MinerURawClient()
+        upload_name = kwargs.get("upload_name", source_path.name)
+        await client.download_into(raw_dir, source_path, upload_name=str(upload_name))
+
+    def build_ir(self, raw_dir: Path, document_name: str) -> IRDoc:
+        from lightrag.parser.external.mineru.ir_builder import MinerUIRBuilder
+        builder = MinerUIRBuilder()
+        return builder.normalize_from_workdir(raw_dir, document_name=document_name)

--- a/lightrag/parser/external/mineru/adapter.py
+++ b/lightrag/parser/external/mineru/adapter.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 from lightrag.parser.external._base import BaseExternalParser
 from lightrag.sidecar.ir import IRDoc
@@ -18,6 +17,7 @@ class MinerUParser(BaseExternalParser):
 
     def is_bundle_valid(self, raw_dir: Path, source_path: Path) -> bool:
         from lightrag.parser.external.mineru.cache import is_bundle_valid
+
         return is_bundle_valid(raw_dir, source_path)
 
     async def download_into(
@@ -27,11 +27,13 @@ class MinerUParser(BaseExternalParser):
         **kwargs: object,
     ) -> None:
         from lightrag.parser.external.mineru.client import MinerURawClient
+
         client = MinerURawClient()
         upload_name = kwargs.get("upload_name", source_path.name)
         await client.download_into(raw_dir, source_path, upload_name=str(upload_name))
 
     def build_ir(self, raw_dir: Path, document_name: str) -> IRDoc:
         from lightrag.parser.external.mineru.ir_builder import MinerUIRBuilder
+
         builder = MinerUIRBuilder()
         return builder.normalize_from_workdir(raw_dir, document_name=document_name)


### PR DESCRIPTION
## Problem

Every new OCR/VLM parser engine copies the same four-file structure and adds another `if engine == …` branch in the pipeline. No shared contract exists between engines.

Fixes #3197

## Solution

### 1. `BaseExternalParser` protocol (`_base.py`)

Abstract base class with three methods:
- `is_bundle_valid(raw_dir, source_path)` — cache-hit check
- `download_into(raw_dir, source_path)` — fetch raw bundle from external service
- `build_ir(raw_dir, document_name)` — convert raw bundle to IRDoc

### 2. Engine registry (`_registry.py`)

Dict mapping engine names to parser classes:
- `register_parser("mineru", MinerUParser)`
- `register_parser("docling", DoclingParser)`

New engines register here instead of adding pipeline branches.

### 3. MinerU adapter (`mineru/adapter.py`)

Wraps existing `MinerURawClient` + `MinerUIRBuilder` + `is_bundle_valid` behind the protocol.

### 4. Docling adapter (`docling/adapter.py`)

Wraps existing `DoclingRawClient` + `DoclingIRBuilder` + `is_bundle_valid` behind the protocol.

## What this does NOT change

- No behavior change for existing MinerU/Docling usage
- No changes to on-disk cache format or IRDoc schema
- No changes to `pipeline.py` dispatch logic (that's a follow-up)
- The existing `parse_mineru`/`parse_docling` methods continue to work

## Next steps (follow-up PRs)

1. Add a generic `parse_external` method to the pipeline that uses the registry
2. New engines (PaddleOCR-VL, DeepSeek-OCR, etc.) implement the protocol
3. Eventually remove the `if engine == …` chain from the pipeline
