### PR TITLE
♻️ refactor(config): rename MAX_ASYNC to MAX_ASYNC_LLM with alias fallback

### DIFF
--- a/docs/DockerDeployment.md
+++ b/docs/DockerDeployment.md
@@ -57,7 +57,7 @@ validation rules and provider-specific behavior.
 
 **RAG Configuration**
 
-- `MAX_ASYNC`: Maximum async operations
+- `MAX_ASYNC_LLM`: Maximum async operations (deprecated alias: `MAX_ASYNC`)
 - `MAX_TOKENS`: Maximum token size
 - `EMBEDDING_DIM`: Embedding dimensions
 

--- a/docs/FileProcessingPipeline-zh.md
+++ b/docs/FileProcessingPipeline-zh.md
@@ -724,7 +724,7 @@ PENDING ─►├─ q_mineru  ──► [mineru parser  × N2] ─┼─► q_a
 | `MAX_PARALLEL_PARSE_MINERU` | `2` | N2: MinerU 解析并发 worker 数 | MinerU 占用 GPU/CPU 显著，**默认 2 为适度并发**。资源紧张时可降到 1；本地部署且显存充足时可设 2-3；走 MinerU 官方云端服务时可适当提高（受云端配额限制） |
 | `MAX_PARALLEL_PARSE_DOCLING` | `2` | N3: Docling 解析并发 worker 数 | Docling 同样资源敏感，**默认 2 为适度并发**。资源紧张时可降到 1；本地部署且 CPU/GPU 充足时可设 2-3 |
 | `MAX_PARALLEL_ANALYZE` | `5` | N4: 多模态分析（VLM 图片 / 表格描述）并发 worker 数 | 直接消耗 VLM 配额。建议 ≤ VLM 服务并发上限 |
-| `MAX_PARALLEL_INSERT` | `3` | N5: 实体 / 关系抽取 + 入库阶段并发文档数 | 推荐 `MAX_ASYNC / 3`，区间 2~10。该阶段每个文档会触发多次 LLM 调用，过高会撞 LLM 限流。同时该值还作为 `asyncio.Semaphore` 用于二次约束（worker 数和信号量值一致） |
+| `MAX_PARALLEL_INSERT` | `3` | N5: 实体 / 关系抽取 + 入库阶段并发文档数 | 推荐 `MAX_ASYNC_LLM / 3`，区间 2~10。该阶段每个文档会触发多次 LLM 调用，过高会撞 LLM 限流。同时该值还作为 `asyncio.Semaphore` 用于二次约束（worker 数和信号量值一致） |
 | `QUEUE_SIZE_PARSE` | `20` | parse（native/MinerU/Docling）输入队列长度 | 一般无需调整。队列内仅为轻量 doc_id（大文档体在进入 analyze 前已剥离），仅限制 pipeline 一次预派发给 parse worker 的待处理文档数，调整影响很小 |
 | `QUEUE_SIZE_ANALYZE` | `100` | analyze 队列（parse → analyze 阶段）的有界容量 | 一般无需调整。极少量大批量任务（成千上万）可适当提高，避免 enqueue 端反压；内存紧张时可调低 |
 | `QUEUE_SIZE_INSERT` | `4` | analyze → process 阶段间的队列容量 | process 是流水线中最慢、最耗内存的阶段，队列特意做小，给上游提供反压防止内存堆积 |
@@ -741,7 +741,7 @@ PENDING ─►├─ q_mineru  ──► [mineru parser  × N2] ─┼─► q_a
 
 - 大量 PDF + 本地 MinerU 单 GPU：`MAX_PARALLEL_PARSE_MINERU=2`、`MAX_PARALLEL_ANALYZE=5`、`MAX_PARALLEL_INSERT=3`（默认即可；显存紧张时把 MINERU 降到 1）。
 - 大量 PDF + MinerU 云端服务：`MAX_PARALLEL_PARSE_MINERU=3~5`（视云端配额），其它保持默认。
-- 纯 docx / txt（仅走 native）：`MAX_PARALLEL_PARSE_NATIVE=10`、`MAX_PARALLEL_INSERT` 按 `MAX_ASYNC/3` 推算。
+- 纯 docx / txt（仅走 native）：`MAX_PARALLEL_PARSE_NATIVE=10`、`MAX_PARALLEL_INSERT` 按 `MAX_ASYNC_LLM/3` 推算。
 - LLM 限流明显：先降 `MAX_PARALLEL_INSERT`（process 阶段每文档多次 LLM 调用），再降 `MAX_PARALLEL_ANALYZE`（VLM 是独立配额）。
 
 ## 七、流水线启动时的续跑规则

--- a/docs/FileProcessingPipeline.md
+++ b/docs/FileProcessingPipeline.md
@@ -724,7 +724,7 @@ At enqueue time, `resolve_stored_document_parser_engine` puts each document into
 | `MAX_PARALLEL_PARSE_MINERU` | `2` | N2: number of concurrent workers for MinerU parsing | MinerU has significant GPU/CPU usage; **the default of 2 is a modest amount of parallelism**. Lower to 1 when resources are tight; with local deployment and ample VRAM, you can set 2–3; when going through MinerU's official cloud service, you can raise it appropriately (subject to cloud quotas). |
 | `MAX_PARALLEL_PARSE_DOCLING` | `2` | N3: number of concurrent workers for Docling parsing | Docling is similarly resource-sensitive; **the default of 2 is a modest amount of parallelism**. Lower to 1 when resources are tight; with local deployment and ample CPU/GPU, you can set 2–3. |
 | `MAX_PARALLEL_ANALYZE` | `5` | N4: number of concurrent workers for multimodal analysis (VLM image / table description) | Directly consumes the VLM quota. Recommended ≤ VLM service concurrency cap. |
-| `MAX_PARALLEL_INSERT` | `3` | N5: number of concurrent documents at the entity / relation extraction + ingest stage | Recommended `MAX_ASYNC / 3`, in the range 2–10. This stage triggers multiple LLM calls per document; setting it too high will hit LLM rate limits. This value also serves as the `asyncio.Semaphore` for an additional constraint (worker count and semaphore value are the same). |
+| `MAX_PARALLEL_INSERT` | `3` | N5: number of concurrent documents at the entity / relation extraction + ingest stage | Recommended `MAX_ASYNC_LLM / 3`, in the range 2–10. This stage triggers multiple LLM calls per document; setting it too high will hit LLM rate limits. This value also serves as the `asyncio.Semaphore` for an additional constraint (worker count and semaphore value are the same). |
 | `QUEUE_SIZE_PARSE` | `20` | Bounded capacity of the parse-input queues (native/MinerU/Docling) | Generally no need to tune. Items here are lightweight doc_ids (the large parsed body is stripped before the analyze stage); this only bounds how many pending docs the pipeline pre-dispatches to parse workers, so tuning has little effect. |
 | `QUEUE_SIZE_ANALYZE` | `100` | Bounded capacity of the analyze queue (parse → analyze stage) | Generally no need to tune. For very large batches (thousands or more), can be raised to avoid backpressure at the enqueue side; lower it when memory is tight. |
 | `QUEUE_SIZE_INSERT` | `4` | Queue capacity between the analyze → process stage | The process stage is the slowest and most memory-hungry in the pipeline; the queue is deliberately small to provide backpressure to upstream and prevent memory bloat. |
@@ -741,7 +741,7 @@ At enqueue time, `resolve_stored_document_parser_engine` puts each document into
 
 - Large batch of PDFs + local MinerU on a single GPU: `MAX_PARALLEL_PARSE_MINERU=2`, `MAX_PARALLEL_ANALYZE=5`, `MAX_PARALLEL_INSERT=3` (defaults are fine; lower MINERU to 1 if VRAM is tight).
 - Large batch of PDFs + MinerU cloud service: `MAX_PARALLEL_PARSE_MINERU=3~5` (depending on cloud quota), others at defaults.
-- Pure docx / txt (only native): `MAX_PARALLEL_PARSE_NATIVE=10`; `MAX_PARALLEL_INSERT` derived from `MAX_ASYNC/3`.
+- Pure docx / txt (only native): `MAX_PARALLEL_PARSE_NATIVE=10`; `MAX_PARALLEL_INSERT` derived from `MAX_ASYNC_LLM/3`.
 - Heavy LLM rate-limiting: first lower `MAX_PARALLEL_INSERT` (the process stage makes multiple LLM calls per document), then lower `MAX_PARALLEL_ANALYZE` (VLM is a separate quota).
 
 ## 7. Pipeline Resume Rules at Startup

--- a/docs/LightRAG-API-Server-zh.md
+++ b/docs/LightRAG-API-Server-zh.md
@@ -503,8 +503,8 @@ LightRAG 服务器可以在 `Gunicorn + Uvicorn` 预加载模式下运行。Guni
 WORKERS=2
 ### 一批中并行处理的文件数
 MAX_PARALLEL_INSERT=3
-# LLM 的最大并发请求数
-MAX_ASYNC=4
+# LLM 的最大并发请求数(MAX_ASYNC 作为兼容旧名仍可用)
+MAX_ASYNC_LLM=4
 ```
 
 在 macOS 上，Gunicorn 多工作进程模式还要求 Objective-C fork safety 覆盖变量必须在 Python 进程启动前就存在。不要依赖 `.env` 设置这个变量； `.env` 会在 Python 启动后才加载，对 Objective-C 运行时来说已经太晚：
@@ -897,7 +897,7 @@ MAX_ASYNC_RERANK=4
 RERANK_TIMEOUT=30
 ```
 
-`MAX_ASYNC_RERANK` 未设置时回退到 `MAX_ASYNC`。`RERANK_TIMEOUT` 有独立默认值，因为 reranker 请求通常比 LLM 生成请求短。更完整的 reranker 配置示例，包括 Cohere-compatible chunking 选项以及 Jina/阿里云 endpoint，请参阅 `env.example` 文件。
+`MAX_ASYNC_RERANK` 未设置时回退到 `MAX_ASYNC_LLM`(`MAX_ASYNC` 作为兼容旧名仍可用)。`RERANK_TIMEOUT` 有独立默认值，因为 reranker 请求通常比 LLM 生成请求短。更完整的 reranker 配置示例，包括 Cohere-compatible chunking 选项以及 Jina/阿里云 endpoint，请参阅 `env.example` 文件。
 
 ### 启用 Reranking
 
@@ -988,7 +988,7 @@ LIGHTRAG_PARSER=*:native-teP,*:legacy-R
 
 ### LLM Configuration (Use valid host. For local services installed with docker, you can use host.docker.internal)
 TIMEOUT=150
-MAX_ASYNC=4
+MAX_ASYNC_LLM=4
 
 LLM_BINDING=openai
 LLM_MODEL=gpt-4o-mini
@@ -1114,7 +1114,7 @@ notes.[-R].md
 
 ### 流水线并发
 
-`MAX_PARALLEL_INSERT` 控制并行处理的文件数量。`MAX_ASYNC` 控制并发 LLM 调用，包括抽取、合并、查询关键词生成和最终回答生成。解析压力较大的部署可以使用可选的分阶段流水线变量，例如 `MAX_PARALLEL_PARSE_NATIVE`、`MAX_PARALLEL_PARSE_MINERU`、`MAX_PARALLEL_PARSE_DOCLING` 和 `MAX_PARALLEL_ANALYZE`。
+`MAX_PARALLEL_INSERT` 控制并行处理的文件数量。`MAX_ASYNC_LLM`(兼容旧名:`MAX_ASYNC`)控制并发 LLM 调用，包括抽取、合并、查询关键词生成和最终回答生成。解析压力较大的部署可以使用可选的分阶段流水线变量，例如 `MAX_PARALLEL_PARSE_NATIVE`、`MAX_PARALLEL_PARSE_MINERU`、`MAX_PARALLEL_PARSE_DOCLING` 和 `MAX_PARALLEL_ANALYZE`。
 
 当处理循环 busy 时，上传和文本插入仍可被接受；运行中的循环会被通知并拾取新 pending 文档。`/documents/clear`、单文档删除等破坏性任务，以及 `/documents/scan` 的分类阶段仍会拒绝并发入队，以保护存储一致性。失败文件可通过 WebUI 重新处理，也可以触发 `/documents/scan`。
 

--- a/docs/LightRAG-API-Server.md
+++ b/docs/LightRAG-API-Server.md
@@ -503,8 +503,8 @@ Though LightRAG Server uses one worker to process the document indexing pipeline
 WORKERS=2
 ### Number of parallel files to process in one batch
 MAX_PARALLEL_INSERT=3
-### Max concurrent requests to the LLM
-MAX_ASYNC=4
+### Max concurrent requests to the LLM (MAX_ASYNC is still accepted as a deprecated alias)
+MAX_ASYNC_LLM=4
 ```
 
 On macOS, Gunicorn multi-worker mode also requires the Objective-C fork-safety override to be present before the Python process starts. Do not rely on `.env` for this variable; `.env` is loaded after Python startup and is too late for the Objective-C runtime:
@@ -897,7 +897,7 @@ MAX_ASYNC_RERANK=4
 RERANK_TIMEOUT=30
 ```
 
-`MAX_ASYNC_RERANK` falls back to `MAX_ASYNC` when unset. `RERANK_TIMEOUT` has an independent default because reranker requests are usually shorter than LLM generation requests. For comprehensive reranker configuration examples, including Cohere-compatible chunking options and Jina/Aliyun endpoints, refer to the `env.example` file.
+`MAX_ASYNC_RERANK` falls back to `MAX_ASYNC_LLM` when unset (`MAX_ASYNC` is still accepted as a deprecated alias). `RERANK_TIMEOUT` has an independent default because reranker requests are usually shorter than LLM generation requests. For comprehensive reranker configuration examples, including Cohere-compatible chunking options and Jina/Aliyun endpoints, refer to the `env.example` file.
 
 ### Enable Reranking
 
@@ -988,7 +988,7 @@ LIGHTRAG_PARSER=*:native-teP,*:legacy-R
 
 ### LLM Configuration (Use valid host. For local services installed with docker, you can use host.docker.internal)
 TIMEOUT=150
-MAX_ASYNC=4
+MAX_ASYNC_LLM=4
 
 LLM_BINDING=openai
 LLM_MODEL=gpt-4o-mini
@@ -1114,7 +1114,7 @@ For the full routing syntax, supported extensions, parser cache behavior, chunke
 
 ### Pipeline Concurrency
 
-`MAX_PARALLEL_INSERT` controls how many files are processed in parallel. `MAX_ASYNC` controls concurrent LLM calls, including extraction, merging, query keyword generation, and final answer generation. Optional staged-pipeline variables such as `MAX_PARALLEL_PARSE_NATIVE`, `MAX_PARALLEL_PARSE_MINERU`, `MAX_PARALLEL_PARSE_DOCLING`, and `MAX_PARALLEL_ANALYZE` can be used for parser-heavy deployments.
+`MAX_PARALLEL_INSERT` controls how many files are processed in parallel. `MAX_ASYNC_LLM` (deprecated alias: `MAX_ASYNC`) controls concurrent LLM calls, including extraction, merging, query keyword generation, and final answer generation. Optional staged-pipeline variables such as `MAX_PARALLEL_PARSE_NATIVE`, `MAX_PARALLEL_PARSE_MINERU`, `MAX_PARALLEL_PARSE_DOCLING`, and `MAX_PARALLEL_ANALYZE` can be used for parser-heavy deployments.
 
 Uploads and text inserts can be accepted while the processing loop is busy; the running loop is nudged to pick up the new pending work. Destructive jobs such as document clear/delete and the classification phase of `/documents/scan` still reject concurrent enqueues to protect storage consistency. Failed files can be reprocessed from the WebUI or by triggering `/documents/scan`.
 

--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -87,7 +87,7 @@ Notes:
 | **llm_model_name** | `str` | LLM model name for generation | `meta-llama/Llama-3.2-1B-Instruct` |
 | **summary_context_size** | `int` | Maximum tokens send to LLM to generate summaries for entity relation merging | `10000`（configured by env var SUMMARY_CONTEXT_SIZE) |
 | **summary_max_tokens** | `int` | Maximum token size for entity/relation description | `500`（configured by env var SUMMARY_MAX_TOKENS) |
-| **llm_model_max_async** | `int` | Maximum number of concurrent asynchronous LLM processes | `4`（default value changed by env var MAX_ASYNC) |
+| **llm_model_max_async** | `int` | Maximum number of concurrent asynchronous LLM processes | `4`（default value changed by env var MAX_ASYNC_LLM; MAX_ASYNC is still accepted as a deprecated alias) |
 | **llm_model_kwargs** | `dict` | Additional parameters for LLM generation | |
 | **vector_db_storage_cls_kwargs** | `dict` | Additional parameters for vector database, like setting the threshold for nodes and relations retrieval | cosine_better_than_threshold: 0.2（default value changed by env var COSINE_THRESHOLD) |
 | **enable_llm_cache** | `bool` | If `TRUE`, stores LLM results in cache; repeated prompts return cached responses | `TRUE` |

--- a/docs/RoleSpecificLLMConfiguration-zh.md
+++ b/docs/RoleSpecificLLMConfiguration-zh.md
@@ -28,8 +28,8 @@ LLM_BINDING_API_KEY=your_api_key
 # 所有 LLM 请求的默认超时时间
 LLM_TIMEOUT=180
 
-# 所有 LLM 调用的默认最大并发数
-MAX_ASYNC=4
+# 所有 LLM 调用的默认最大并发数(MAX_ASYNC 作为兼容旧名仍可用)
+MAX_ASYNC_LLM=4
 ```
 
 常用字段：
@@ -41,7 +41,7 @@ MAX_ASYNC=4
 | `LLM_BINDING_HOST` | 基础 provider endpoint。对于 SDK 默认 endpoint，可使用对应 sentinel，例如 `DEFAULT_GEMINI_ENDPOINT` 或 `DEFAULT_BEDROCK_ENDPOINT`。 |
 | `LLM_BINDING_API_KEY` | 基础 API key。Bedrock 不使用这个字段。 |
 | `LLM_TIMEOUT` | 基础 LLM timeout。角色未设置 timeout 时继承它。 |
-| `MAX_ASYNC` | 基础 LLM 最大并发。角色未设置 `{ROLE}_MAX_ASYNC_LLM` 时继承它。 |
+| `MAX_ASYNC_LLM` | 基础 LLM 最大并发。角色未设置 `{ROLE}_MAX_ASYNC_LLM` 时继承它。`MAX_ASYNC` 作为兼容旧名仍可用。 |
 
 ## 角色覆盖变量
 
@@ -64,7 +64,7 @@ QUERY_LLM_TIMEOUT=240
 | `{ROLE}_LLM_MODEL` | 覆盖角色模型名。 |
 | `{ROLE}_LLM_BINDING_HOST` | 覆盖角色 endpoint。 |
 | `{ROLE}_LLM_BINDING_API_KEY` | 覆盖角色 API key。Bedrock 不支持。 |
-| `{ROLE}_MAX_ASYNC_LLM` | 覆盖角色最大并发。未设置时继承 `MAX_ASYNC`。 |
+| `{ROLE}_MAX_ASYNC_LLM` | 覆盖角色最大并发。未设置时继承 `MAX_ASYNC_LLM`。 |
 | `{ROLE}_LLM_TIMEOUT` | 覆盖角色 timeout。未设置时继承 `LLM_TIMEOUT`。 |
 
 ## Provider 参数覆盖
@@ -110,7 +110,7 @@ VLM_GEMINI_LLM_TEMPERATURE=0.2
 - 未设置 `{ROLE}_LLM_BINDING_HOST` 时继承 `LLM_BINDING_HOST`。
 - 未设置 `{ROLE}_LLM_BINDING_API_KEY` 时继承 `LLM_BINDING_API_KEY`。
 - 未设置 `{ROLE}_LLM_TIMEOUT` 时继承 `LLM_TIMEOUT`。
-- 未设置 `{ROLE}_MAX_ASYNC_LLM` 时继承 `MAX_ASYNC`。
+- 未设置 `{ROLE}_MAX_ASYNC_LLM` 时继承 `MAX_ASYNC_LLM`。
 - provider 参数先继承基础 provider options，再叠加角色专属 provider options。
 
 因此，同一个 provider 下只想换模型时，只需要写模型名：
@@ -245,7 +245,7 @@ LLM_MODEL=gpt-5-mini
 LLM_BINDING_HOST=https://api.openai.com/v1
 LLM_BINDING_API_KEY=your_extract_openai_api_key
 LLM_TIMEOUT=180
-MAX_ASYNC=4
+MAX_ASYNC_LLM=4
 
 ###########################################################################
 # IMPORTANT:

--- a/docs/RoleSpecificLLMConfiguration.md
+++ b/docs/RoleSpecificLLMConfiguration.md
@@ -28,8 +28,8 @@ LLM_BINDING_API_KEY=your_api_key
 # Default timeout for all LLM requests
 LLM_TIMEOUT=180
 
-# Default maximum concurrency for all LLM calls
-MAX_ASYNC=4
+# Default maximum concurrency for all LLM calls (MAX_ASYNC is still accepted as a deprecated alias)
+MAX_ASYNC_LLM=4
 ```
 
 Common fields:
@@ -41,7 +41,7 @@ Common fields:
 | `LLM_BINDING_HOST` | Base provider endpoint. For SDK default endpoints, use the corresponding sentinel, such as `DEFAULT_GEMINI_ENDPOINT` or `DEFAULT_BEDROCK_ENDPOINT`. |
 | `LLM_BINDING_API_KEY` | Base API key. Bedrock does not use this field. |
 | `LLM_TIMEOUT` | Base LLM timeout. A role inherits it when no role timeout is set. |
-| `MAX_ASYNC` | Base maximum LLM concurrency. A role inherits it when `{ROLE}_MAX_ASYNC_LLM` is not set. |
+| `MAX_ASYNC_LLM` | Base maximum LLM concurrency. A role inherits it when `{ROLE}_MAX_ASYNC_LLM` is not set. `MAX_ASYNC` is still accepted as a deprecated alias. |
 
 ## Role Override Variables
 
@@ -64,7 +64,7 @@ Variable format:
 | `{ROLE}_LLM_MODEL` | Overrides the role model name. |
 | `{ROLE}_LLM_BINDING_HOST` | Overrides the role endpoint. |
 | `{ROLE}_LLM_BINDING_API_KEY` | Overrides the role API key. Bedrock does not support it. |
-| `{ROLE}_MAX_ASYNC_LLM` | Overrides the role maximum concurrency. Inherits `MAX_ASYNC` when unset. |
+| `{ROLE}_MAX_ASYNC_LLM` | Overrides the role maximum concurrency. Inherits `MAX_ASYNC_LLM` when unset. |
 | `{ROLE}_LLM_TIMEOUT` | Overrides the role timeout. Inherits `LLM_TIMEOUT` when unset. |
 
 ## Provider Option Overrides
@@ -110,7 +110,7 @@ If a role does not set `{ROLE}_LLM_BINDING`, or sets it to the same value as the
 - Inherits `LLM_BINDING_HOST` when `{ROLE}_LLM_BINDING_HOST` is not set.
 - Inherits `LLM_BINDING_API_KEY` when `{ROLE}_LLM_BINDING_API_KEY` is not set.
 - Inherits `LLM_TIMEOUT` when `{ROLE}_LLM_TIMEOUT` is not set.
-- Inherits `MAX_ASYNC` when `{ROLE}_MAX_ASYNC_LLM` is not set.
+- Inherits `MAX_ASYNC_LLM` when `{ROLE}_MAX_ASYNC_LLM` is not set.
 - Provider options first inherit the base provider options, then apply role-specific provider options.
 
 Therefore, when you only want to change the model within the same provider, you only need to set the model name:
@@ -245,7 +245,7 @@ LLM_MODEL=gpt-5-mini
 LLM_BINDING_HOST=https://api.openai.com/v1
 LLM_BINDING_API_KEY=your_extract_openai_api_key
 LLM_TIMEOUT=180
-MAX_ASYNC=4
+MAX_ASYNC_LLM=4
 
 ###########################################################################
 # IMPORTANT:

--- a/env.docker-compose-full
+++ b/env.docker-compose-full
@@ -140,7 +140,7 @@ RERANK_BINDING_API_KEY=3f5abc937e4263cdefc4f77df4cb0c37
 # RERANK_BY_DEFAULT=True
 
 ### Rerank concurrency and timeout (independent from base LLM settings)
-### MAX_ASYNC_RERANK falls back to MAX_ASYNC when unset.
+### MAX_ASYNC_RERANK falls back to MAX_ASYNC_LLM when unset.
 ### RERANK_TIMEOUT has its own default (30s) since reranker calls are
 ### typically much shorter than full LLM generation.
 # MAX_ASYNC_RERANK=4
@@ -451,7 +451,7 @@ ENABLE_LLM_CACHE_FOR_EXTRACT=true
 ########################################
 ### Pipeline Concurrency Configuration
 ########################################
-### Number of parallel processing documents(between 2~10, MAX_ASYNC/3 is recommended)
+### Number of parallel processing documents(between 2~10, MAX_ASYNC_LLM/3 is recommended)
 MAX_PARALLEL_INSERT=3
 ### Optional per-stage document pipeline concurrency
 # MAX_PARALLEL_PARSE_NATIVE=5
@@ -487,7 +487,8 @@ LLM_MODEL=gemini-3-flash-preview
 # LLM_MODEL=gpt-5.4-mini
 
 ### Max concurrency requests of LLM
-MAX_ASYNC=4
+### MAX_ASYNC is still accepted as a deprecated alias
+MAX_ASYNC_LLM=4
 
 ###########################################################################
 ### Role-specific LLM/VLM overrides

--- a/env.example
+++ b/env.example
@@ -139,7 +139,7 @@ RERANK_BINDING=null
 # RERANK_BY_DEFAULT=True
 
 ### Rerank concurrency and timeout (independent from base LLM settings)
-### MAX_ASYNC_RERANK falls back to MAX_ASYNC when unset.
+### MAX_ASYNC_RERANK falls back to MAX_ASYNC_LLM when unset.
 ### RERANK_TIMEOUT has its own default (30s) since reranker calls are
 ### typically much shorter than full LLM generation.
 # MAX_ASYNC_RERANK=4
@@ -453,7 +453,7 @@ DOCLING_DO_FORMULA_ENRICHMENT=false
 ########################################
 ### Pipeline Concurrency Configuration
 ########################################
-### Number of parallel processing documents(between 2~10, MAX_ASYNC/3 is recommended)
+### Number of parallel processing documents(between 2~10, MAX_ASYNC_LLM/3 is recommended)
 MAX_PARALLEL_INSERT=3
 ### Optional per-stage document pipeline concurrency
 # MAX_PARALLEL_PARSE_NATIVE=5
@@ -486,7 +486,8 @@ LLM_BINDING_API_KEY=your_api_key
 LLM_MODEL=gpt-5.4-mini
 
 ### Max concurrency requests of LLM
-MAX_ASYNC=4
+### MAX_ASYNC is still accepted as a deprecated alias
+MAX_ASYNC_LLM=4
 
 ###########################################################################
 ### Role-specific LLM/VLM overrides

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -287,7 +287,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--max-async",
         type=int,
-        default=get_env_value("MAX_ASYNC", DEFAULT_MAX_ASYNC, int),
+        default=get_env_value(
+            "MAX_ASYNC_LLM", get_env_value("MAX_ASYNC", DEFAULT_MAX_ASYNC, int), int
+        ),
         help=f"Maximum async operations (default: from env or {DEFAULT_MAX_ASYNC})",
     )
     parser.add_argument(
@@ -669,7 +671,7 @@ def parse_args() -> argparse.Namespace:
     )
 
     # Rerank async/timeout configuration (independent from base LLM)
-    # rerank_max_async falls back to MAX_ASYNC; rerank_timeout has its own default.
+    # rerank_max_async falls back to MAX_ASYNC_LLM; rerank_timeout has its own default.
     args.rerank_max_async = get_env_value("MAX_ASYNC_RERANK", args.max_async, int)
     args.rerank_timeout = get_env_value("RERANK_TIMEOUT", DEFAULT_RERANK_TIMEOUT, int)
 

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -340,7 +340,7 @@ DEFAULT_LLM_TIMEOUT = 180
 DEFAULT_EMBEDDING_TIMEOUT = 30
 
 # Rerank async / timeout defaults
-# Concurrency falls back to base MAX_ASYNC when env unset; timeout has its own
+# Concurrency falls back to base MAX_ASYNC_LLM when env unset; timeout has its own
 # default since reranker calls are typically much faster than full LLM generation.
 DEFAULT_RERANK_MAX_ASYNC = DEFAULT_MAX_ASYNC
 DEFAULT_RERANK_TIMEOUT = 30

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -438,7 +438,9 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     """Recommended length of LLM summary output."""
 
     llm_model_max_async: int = field(
-        default=int(os.getenv("MAX_ASYNC", DEFAULT_MAX_ASYNC))
+        default=int(
+            os.getenv("MAX_ASYNC_LLM", os.getenv("MAX_ASYNC", DEFAULT_MAX_ASYNC))
+        )
     )
     """Maximum number of concurrent LLM calls."""
 
@@ -468,12 +470,13 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         default=int(
             os.getenv(
                 "MAX_ASYNC_RERANK",
-                os.getenv("MAX_ASYNC", DEFAULT_MAX_ASYNC),
+                os.getenv("MAX_ASYNC_LLM", os.getenv("MAX_ASYNC", DEFAULT_MAX_ASYNC)),
             )
         )
     )
     """Maximum number of concurrent rerank calls.
-    Falls back to MAX_ASYNC when MAX_ASYNC_RERANK is unset."""
+    Falls back to MAX_ASYNC_LLM when MAX_ASYNC_RERANK is unset
+    (MAX_ASYNC is still accepted as a deprecated alias)."""
 
     default_rerank_timeout: int = field(
         default=int(os.getenv("RERANK_TIMEOUT", DEFAULT_RERANK_TIMEOUT))

--- a/tests/api/config/test_api_config_role_max_async.py
+++ b/tests/api/config/test_api_config_role_max_async.py
@@ -3,12 +3,14 @@ import sys
 import pytest
 
 from lightrag.api.config import parse_args
+from lightrag.constants import DEFAULT_MAX_ASYNC
 
 
 pytestmark = pytest.mark.offline
 
 
 ROLE_MAX_ASYNC_ENV_KEYS = (
+    "MAX_ASYNC_LLM",
     "MAX_ASYNC",
     "EXTRACT_MAX_ASYNC_LLM",
     "KEYWORD_MAX_ASYNC_LLM",
@@ -61,3 +63,33 @@ def test_role_max_async_literal_none_string_is_preserved(monkeypatch):
 
     assert args.max_async == 10
     assert args.query_llm_max_async is None
+
+
+def test_max_async_llm_new_name(monkeypatch):
+    _clear_max_async_env(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+    monkeypatch.setenv("MAX_ASYNC_LLM", "8")
+
+    args = parse_args()
+
+    assert args.max_async == 8
+
+
+def test_max_async_llm_takes_precedence_over_legacy(monkeypatch):
+    _clear_max_async_env(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+    monkeypatch.setenv("MAX_ASYNC_LLM", "8")
+    monkeypatch.setenv("MAX_ASYNC", "10")
+
+    args = parse_args()
+
+    assert args.max_async == 8
+
+
+def test_max_async_defaults_when_unset(monkeypatch):
+    _clear_max_async_env(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+
+    args = parse_args()
+
+    assert args.max_async == DEFAULT_MAX_ASYNC


### PR DESCRIPTION
## Description

Renames the base LLM concurrency environment variable from `MAX_ASYNC` to `MAX_ASYNC_LLM`, making it consistent with the per-role `{ROLE}_MAX_ASYNC_LLM` naming and with the `README` (which already documents `MAX_ASYNC_LLM`). The legacy `MAX_ASYNC` keeps working as a deprecated alias, so existing deployments require no config changes.

Resolution order: **`MAX_ASYNC_LLM` > `MAX_ASYNC` (deprecated alias) > `DEFAULT_MAX_ASYNC` (4)**.

This is a configuration-template / naming consistency change, not a runtime logic fix — the alias fallback preserves full backward compatibility.

## Related Issues

N/A

## Changes Made

- **`lightrag/lightrag.py`**: `llm_model_max_async` default and the `rerank_model_max_async` fallback chain read `MAX_ASYNC_LLM` first, then fall back to the legacy `MAX_ASYNC`; docstring updated.
- **`lightrag/api/config.py`**: `--max-async` default now uses a nested `get_env_value` fallback. The CLI flag `--max-async` and attribute `args.max_async` are unchanged — only the env var name changed. Rerank fallback comment updated.
- **`lightrag/constants.py`**: comment aligned to `MAX_ASYNC_LLM`.
- **`env.example` / `env.docker-compose-full`**: primary key switched to `MAX_ASYNC_LLM=4`, with a note that `MAX_ASYNC` is still accepted as a deprecated alias; `MAX_PARALLEL_INSERT` recommendation updated to `MAX_ASYNC_LLM/3`.
- **Docs (EN + zh)**: `LightRAG-API-Server`, `RoleSpecificLLMConfiguration`, `FileProcessingPipeline`, `ProgramingWithCore`, `DockerDeployment` updated to the new name with the deprecated-alias note.
- **`tests/api/config/test_api_config_role_max_async.py`**: added cases for the new name, new-name precedence over the legacy alias, and the unset default; existing legacy-alias cases kept to verify backward compatibility.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Verified locally:

- `tests/api/config/test_api_config_role_max_async.py` + `tests/llm/test_llm_role_runtime.py`: **41 passed**.
- Manual precedence check (API config and core dataclass default): `MAX_ASYNC_LLM=8` → 8; legacy `MAX_ASYNC=10` → 10; both set → 8 (new name wins).
- Repo-wide grep confirms no stray bare `MAX_ASYNC` config/doc references remain (only the `DEFAULT_MAX_ASYNC` constant and intentional deprecated-alias annotations / backward-compat tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
