### PR TITLE
fix(parser): surface accurate error for non-ZIP .docx files

### DIFF
--- a/lightrag/parser/docx/parse_document.py
+++ b/lightrag/parser/docx/parse_document.py
@@ -9,6 +9,7 @@ import sys
 
 try:
     from docx import Document
+    from docx.opc.exceptions import PackageNotFoundError
 except ImportError as exc:
     # Raise instead of sys.exit: this module is imported in-process by the
     # gunicorn/uvicorn worker, where a SystemExit would tear down the whole
@@ -102,6 +103,98 @@ def format_error(title: str, details: str, solution: str) -> str:
 def print_error(title: str, details: str, solution: str):
     """Print a friendly, formatted error message to stderr."""
     print(format_error(title, details, solution), file=sys.stderr)
+
+
+def _diagnose_invalid_docx(file_path: str) -> tuple[str, str]:
+    """Diagnose why a ``.docx`` file is not a valid OOXML/ZIP package.
+
+    python-docx raises ``PackageNotFoundError("Package not found at '...'")``
+    both when the path is missing AND when the file exists but is not a valid
+    zip. By the time this runs the file has already been confirmed to exist
+    (the native worker validates ``p.exists()`` first), so the real cause is a
+    corrupt file or a non-DOCX payload wearing a ``.docx`` extension. Sniff the
+    magic bytes to name the actual format so the error message reflects the
+    real problem instead of an empty "not found".
+
+    Returns a ``(details, solution)`` tuple for :func:`format_error`. Reads only
+    the file header and never raises — any IO failure degrades to a generic
+    "cannot read" diagnosis.
+    """
+    import zipfile
+
+    convert_solution = (
+        "  1. Open the file in Microsoft Word or WPS\n"
+        '  2. Use "Save As" and choose "Word Document (*.docx)"\n'
+        "  3. Re-upload the converted .docx to LightRAG"
+    )
+
+    try:
+        with open(file_path, "rb") as f:
+            head = f.read(8)
+    except OSError as exc:
+        return (
+            f"The file at '{file_path}' could not be read: {exc}",
+            "  1. Verify the file exists and is readable\n"
+            "  2. Re-upload it to LightRAG",
+        )
+
+    if not head:
+        return (
+            f"The file at '{file_path}' is empty (0 bytes). The upload was "
+            "likely truncated or the source file is corrupt.",
+            "  1. Check the original document opens correctly\n"
+            "  2. Re-upload a complete copy to LightRAG",
+        )
+
+    if head.startswith(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"):
+        # OLE2 Compound File — the legacy binary Word 97-2003 .doc format.
+        return (
+            f"The file at '{file_path}' is a legacy Word 97-2003 (.doc) "
+            "document saved with a .docx extension. The .doc binary format is "
+            "not a ZIP/OOXML package and cannot be parsed by the native engine.",
+            convert_solution,
+        )
+
+    if head.startswith(b"{\\rtf"):
+        return (
+            f"The file at '{file_path}' is an RTF document saved with a .docx "
+            "extension. RTF is not a ZIP/OOXML package.",
+            convert_solution,
+        )
+
+    if head.startswith(b"%PDF"):
+        return (
+            f"The file at '{file_path}' is a PDF saved with a .docx extension. "
+            "It is not a ZIP/OOXML package.",
+            "  1. Convert the PDF to .docx, or upload it through a PDF-capable "
+            "parser engine (e.g. mineru/docling)\n"
+            "  2. Re-upload to LightRAG",
+        )
+
+    stripped = head.lstrip()
+    if stripped.startswith(b"<"):
+        # <?xml ...>, <html ...>, or Word 2003 "<w:wordDocument>" flat XML.
+        return (
+            f"The file at '{file_path}' is an HTML or XML document saved with a "
+            ".docx extension, not a ZIP/OOXML package.",
+            convert_solution,
+        )
+
+    if head.startswith(b"PK\x03\x04") and not zipfile.is_zipfile(file_path):
+        # Has the ZIP local-file-header magic but the archive is unreadable.
+        return (
+            f"The file at '{file_path}' starts like a ZIP archive but is "
+            "truncated or corrupt, so it cannot be opened as a DOCX package.",
+            "  1. Check the original document opens correctly\n"
+            "  2. Re-upload a complete, uncorrupted copy to LightRAG",
+        )
+
+    return (
+        f"The file at '{file_path}' is not a valid DOCX (ZIP/OOXML) package. "
+        "It is either corrupt or a different file format saved with a .docx "
+        "extension.",
+        convert_solution,
+    )
 
 
 def truncate_heading(heading_text: str, para_id: str = None) -> str:
@@ -1555,7 +1648,19 @@ def extract_docx_blocks(
     Returns:
         List of block dictionaries with heading, content, type, and metadata
     """
-    doc = Document(file_path)
+    try:
+        doc = Document(file_path)
+    except PackageNotFoundError as exc:
+        # python-docx surfaces a misleading "Package not found at '...'" for any
+        # file it cannot open as a ZIP/OOXML package — including files that
+        # exist but are corrupt or a different format wearing a .docx extension.
+        # Diagnose the real cause from the magic bytes and raise a DocxContentError
+        # (a ValueError) so the pipeline's per-document handler marks just this
+        # document FAILED with an accurate, actionable message.
+        details, solution = _diagnose_invalid_docx(file_path)
+        raise DocxContentError(
+            format_error("File is not a valid DOCX document", details, solution)
+        ) from exc
     resolver = NumberingResolver(file_path)
     styles_outline = parse_styles_outline_levels(file_path)
 

--- a/tests/parser/docx/test_native_docx_extract.py
+++ b/tests/parser/docx/test_native_docx_extract.py
@@ -24,6 +24,7 @@ from lxml import etree
 
 from lightrag.parser.docx import parse_document as parse_doc
 from lightrag.parser.docx.parse_document import (
+    DocxContentError,
     extract_docx_blocks,
     extract_paragraph_content,
 )
@@ -379,3 +380,54 @@ def test_empty_tables_are_skipped(tmp_path) -> None:
         "must be dropped before the placeholder is emitted"
     )
     assert any('"A"' in b["content"] and '"B"' in b["content"] for b in blocks)
+
+
+# --- invalid (non-ZIP) .docx files surface an accurate error ---------------
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize(
+    ("header", "format_hint"),
+    [
+        (b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1" + b"junk", "Word 97-2003"),
+        (b"{\\rtf1\\ansi}", "RTF"),
+        (b"%PDF-1.7\n%binary", "PDF"),
+        (b"<?xml version='1.0'?><html></html>", "HTML or XML"),
+        (b"plain text masquerading as docx", "not a valid DOCX"),
+    ],
+)
+def test_invalid_docx_raises_accurate_error(tmp_path, header, format_hint) -> None:
+    """A file that exists but is not a ZIP/OOXML package must fail with an
+    accurate message — never the misleading python-docx "Package not found".
+
+    The native worker confirms the file exists before parsing, so the only way
+    ``PackageNotFoundError`` can fire here is a corrupt file or a non-DOCX
+    payload wearing a .docx extension. The error must name the real format and
+    keep the file path.
+    """
+    docx_path = tmp_path / "masquerade.docx"
+    docx_path.write_bytes(header)
+
+    with pytest.raises(DocxContentError) as excinfo:
+        extract_docx_blocks(str(docx_path), fixlevel=0)
+
+    message = str(excinfo.value)
+    assert "Package not found" not in message
+    assert "valid DOCX" in message
+    assert str(docx_path) in message
+    assert format_hint in message
+
+
+@pytest.mark.offline
+def test_empty_docx_file_reports_truncation(tmp_path) -> None:
+    """A 0-byte .docx must be diagnosed as empty/truncated, not 'not found'."""
+    docx_path = tmp_path / "empty.docx"
+    docx_path.write_bytes(b"")
+
+    with pytest.raises(DocxContentError) as excinfo:
+        extract_docx_blocks(str(docx_path), fixlevel=0)
+
+    message = str(excinfo.value)
+    assert "Package not found" not in message
+    assert "empty" in message
+    assert str(docx_path) in message


### PR DESCRIPTION
## Description

When the native parser receives a file whose extension is `.docx` but whose
content is **not a valid ZIP/OOXML package**, the worker logs a misleading
error:

```
ERROR: Parse worker failed (native): Package not found at '/.../监督检查-消防安全重点单位标准化考核评分表.docx'
```

This message comes straight from python-docx
(`docx/opc/phys_pkg.py`), which raises `PackageNotFoundError` whenever
`is_zipfile()` returns `False`. That check returns `False` both when the path
is missing **and** when the file exists but is corrupt or not a real docx — so
the message reads as a *path-not-found* error even though the native worker has
**already confirmed the file exists** (`p.exists() and p.is_file()` in
`parse_native`). The actual cause is a corrupt file or a non-DOCX payload
(legacy `.doc`, RTF, HTML, PDF) wearing a `.docx` extension.

This PR makes the error reflect the real problem.

## Related Issues

N/A (small targeted fix)

## Changes Made

- `lightrag/parser/docx/parse_document.py`:
  - Import `PackageNotFoundError` from `docx.opc.exceptions`.
  - Add `_diagnose_invalid_docx()` — reads only the file header and sniffs the
    magic bytes to identify the real format (OLE2 legacy `.doc`, RTF, PDF,
    HTML/XML, truncated ZIP, empty file, or unknown/corrupt), returning a
    tailored `(details, solution)` pair. The helper is self-guarding and never
    raises.
  - Wrap the `Document(file_path)` call in `extract_docx_blocks` with
    `try/except PackageNotFoundError`, re-raising a `DocxContentError` built via
    the existing `format_error()` so the message names the real format and keeps
    the file path.
- `tests/parser/docx/test_native_docx_extract.py`:
  - Parametrized test over OLE2/RTF/PDF/HTML/plain-text payloads plus a 0-byte
    file, asserting the error no longer says "Package not found", includes
    "valid DOCX", keeps the file path, and names the detected format.

`DocxContentError` is a `ValueError` subclass, so the pipeline's per-document
handler still marks **only that document** `FAILED` while the worker keeps
running. The new message flows through to the logs and `doc_status.error_msg`
unchanged — no change to failure behavior, only to the message accuracy.

No changes to `pipeline.py`; no parser fallback introduced (out of scope).

### Example: legacy `.doc` renamed to `.docx`

```
====================================================================
ERROR: File is not a valid DOCX document
====================================================================

The file at '/.../监督检查-消防安全重点单位标准化考核评分表.docx' is a legacy
Word 97-2003 (.doc) document saved with a .docx extension. The .doc binary
format is not a ZIP/OOXML package and cannot be parsed by the native engine.

SOLUTION:
  1. Open the file in Microsoft Word or WPS
  2. Use "Save As" and choose "Word Document (*.docx)"
  3. Re-upload the converted .docx to LightRAG
====================================================================
```

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

`tests/parser/docx/` passes in full (38 tests). The fix lives at the lowest
boundary (`extract_docx_blocks`), so it also benefits direct callers (tests and
any future CLI), not just the pipeline path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
