### PR TITLE
feat(query): optionally send chunk heading path to the LLM

### DIFF
--- a/env.example
+++ b/env.example
@@ -121,6 +121,10 @@ OLLAMA_EMULATING_MODEL_TAG=latest
 ###     Higher values increase re-ranking time
 # RELATED_CHUNK_NUMBER=5
 
+### Append each chunk's heading path (parent headings joined by " → ") as a
+### `content_headings` field in the chunk JSON sent to the LLM. Costs extra tokens.
+# ENABLE_CONTENT_HEADINGS=false
+
 #########################################################
 ### Reranking configuration
 ### RERANK_BINDING type: null, cohere, jina, aliyun

--- a/lightrag/chunk_schema.py
+++ b/lightrag/chunk_schema.py
@@ -74,6 +74,19 @@ def normalize_chunk_heading(dp: dict[str, Any]) -> dict[str, Any] | None:
     }
 
 
+def format_parent_headings(dp: dict[str, Any]) -> str:
+    """Join a chunk's parent heading chain into ``h1 → h2 → h3``.
+
+    Reuses :func:`normalize_chunk_heading` so both the nested and legacy flat
+    heading shapes are handled. Returns an empty string when the chunk has no
+    parent headings, so callers can simply omit the field when it is empty.
+    """
+    normalized = normalize_chunk_heading(dp)
+    if not normalized:
+        return ""
+    return " → ".join(normalized["parent_headings"])
+
+
 def normalize_chunk_sidecar(dp: dict[str, Any]) -> dict[str, Any] | None:
     """Return the canonical sidecar dict or ``None`` when absent / invalid.
 
@@ -251,6 +264,7 @@ def strip_internal_multimodal_markup_for_extraction(
 
 __all__ = [
     "normalize_chunk_heading",
+    "format_parent_headings",
     "normalize_chunk_sidecar",
     "strip_internal_multimodal_markup_for_extraction",
 ]

--- a/lightrag/chunk_schema.py
+++ b/lightrag/chunk_schema.py
@@ -74,17 +74,51 @@ def normalize_chunk_heading(dp: dict[str, Any]) -> dict[str, Any] | None:
     }
 
 
+# Zero-width / invisible characters that ``\s`` does NOT match but that only add
+# token noise to a heading shown to the LLM. Built from code points + chr() so the
+# source stays pure ASCII and readable (no literal invisible characters inline).
+_HEADING_ZERO_WIDTH_CODEPOINTS = (
+    0x200B,  # ZERO WIDTH SPACE
+    0x200C,  # ZERO WIDTH NON-JOINER
+    0x200D,  # ZERO WIDTH JOINER
+    0x2060,  # WORD JOINER
+    0xFEFF,  # ZERO WIDTH NO-BREAK SPACE (BOM)
+)
+_HEADING_ZERO_WIDTH_RE = re.compile(
+    "[" + "".join(chr(cp) for cp in _HEADING_ZERO_WIDTH_CODEPOINTS) + "]"
+)
+_HEADING_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _clean_heading_text(text: str) -> str:
+    """Flatten a heading into one clean line for the LLM.
+
+    Drops zero-width / invisible characters and collapses every run of
+    whitespace (tab, newline, NBSP, full-width / ideographic space, ...) into a
+    single regular space. Never inserts spaces between adjacent CJK characters,
+    so it is safe for Chinese headings.
+    """
+    text = _HEADING_ZERO_WIDTH_RE.sub("", text)
+    text = _HEADING_WHITESPACE_RE.sub(" ", text)
+    return text.strip()
+
+
 def format_parent_headings(dp: dict[str, Any]) -> str:
     """Join a chunk's parent heading chain into ``h1 → h2 → h3``.
 
     Reuses :func:`normalize_chunk_heading` so both the nested and legacy flat
-    heading shapes are handled. Returns an empty string when the chunk has no
-    parent headings, so callers can simply omit the field when it is empty.
+    heading shapes are handled, then cleans each heading via
+    :func:`_clean_heading_text` so the string sent to the LLM is a single tidy
+    line. Returns an empty string when the chunk has no (non-empty) parent
+    headings, so callers can simply omit the field when it is empty.
     """
     normalized = normalize_chunk_heading(dp)
     if not normalized:
         return ""
-    return " → ".join(normalized["parent_headings"])
+    cleaned = [
+        c for c in (_clean_heading_text(h) for h in normalized["parent_headings"]) if c
+    ]
+    return " → ".join(cleaned)
 
 
 def normalize_chunk_sidecar(dp: dict[str, Any]) -> dict[str, Any] | None:

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -235,6 +235,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     )
     """Method for selecting text chunks: 'WEIGHT' for weight-based selection, 'VECTOR' for embedding similarity-based selection."""
 
+    enable_content_headings: bool = field(
+        default_factory=lambda: get_env_value("ENABLE_CONTENT_HEADINGS", False, bool)
+    )
+    """Append each chunk's parent heading path as a `content_headings` field in the chunk JSON sent to the LLM."""
+
     # Entity extraction
     # ---
 
@@ -2154,6 +2159,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 global_config,
                 hashing_kv=self.llm_response_cache,
                 system_prompt=None,
+                text_chunks_db=self.text_chunks,
             )
         elif data_param.mode == "bypass":
             logger.debug("[aquery_data] Using bypass mode")
@@ -2250,6 +2256,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     global_config,
                     hashing_kv=self.llm_response_cache,
                     system_prompt=system_prompt,
+                    text_chunks_db=self.text_chunks,
                 )
             elif param.mode == "bypass":
                 # Bypass mode: directly use LLM without knowledge retrieval

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -54,7 +54,10 @@ from lightrag.base import (
     QueryResult,
     QueryContextResult,
 )
-from lightrag.chunk_schema import strip_internal_multimodal_markup_for_extraction
+from lightrag.chunk_schema import (
+    format_parent_headings,
+    strip_internal_multimodal_markup_for_extraction,
+)
 from lightrag.prompt import PROMPTS, resolve_entity_extraction_prompt_profile
 from lightrag.constants import (
     GRAPH_FIELD_SEP,
@@ -3805,6 +3808,7 @@ async def kg_query(
         ll_keywords_str,
         query_param.user_prompt or "",
         query_param.enable_rerank,
+        global_config.get("enable_content_headings", False),
         "\n<llm_identity>\n",
         serialize_llm_cache_identity(llm_cache_identity),
     )
@@ -3841,6 +3845,9 @@ async def kg_query(
                 "ll_keywords": ll_keywords_str,
                 "user_prompt": query_param.user_prompt or "",
                 "enable_rerank": query_param.enable_rerank,
+                "enable_content_headings": global_config.get(
+                    "enable_content_headings", False
+                ),
             }
             await save_to_cache(
                 hashing_kv,
@@ -4573,6 +4580,29 @@ async def _apply_token_truncation(
     }
 
 
+async def _attach_content_headings(
+    chunks: list[dict], text_chunks_db: BaseKVStorage | None
+) -> None:
+    """Backfill the ``content_headings`` field onto chunks in place.
+
+    Vector chunks never carry a ``heading`` field (chunks_vdb does not store it),
+    and the round-robin merge drops the entity/relation headings too. So we look
+    the chunks up by ``chunk_id`` in text_chunks storage and attach the parent
+    heading path. Only chunks that actually have parent headings get the field,
+    so empty paths are omitted from the JSON sent to the LLM.
+    """
+    if not text_chunks_db or not chunks:
+        return
+    chunk_ids = [c.get("chunk_id") for c in chunks]
+    chunk_data_list = await text_chunks_db.get_by_ids(chunk_ids)
+    for chunk, data in zip(chunks, chunk_data_list):
+        if not isinstance(data, dict):
+            continue
+        headings = format_parent_headings(data)
+        if headings:
+            chunk["content_headings"] = headings
+
+
 async def _merge_all_chunks(
     filtered_entities: list[dict],
     filtered_relations: list[dict],
@@ -4671,6 +4701,12 @@ async def _merge_all_chunks(
     logger.info(
         f"Round-robin merged chunks: {origin_len} -> {len(merged_chunks)} (deduplicated {origin_len - len(merged_chunks)})"
     )
+
+    # Backfill heading path before token truncation so it counts toward the budget
+    if text_chunks_db and text_chunks_db.global_config.get(
+        "enable_content_headings", False
+    ):
+        await _attach_content_headings(merged_chunks, text_chunks_db)
 
     return merged_chunks
 
@@ -4779,12 +4815,13 @@ async def _build_context_str(
     # The actual tokens may be slightly less than available_chunk_tokens due to deduplication logic
     chunks_context = []
     for i, chunk in enumerate(truncated_chunks):
-        chunks_context.append(
-            {
-                "reference_id": chunk["reference_id"],
-                "content": chunk["content"],
-            }
-        )
+        entry = {
+            "reference_id": chunk["reference_id"],
+            "content": chunk["content"],
+        }
+        if chunk.get("content_headings"):
+            entry["content_headings"] = chunk["content_headings"]
+        chunks_context.append(entry)
 
     text_units_str = "\n".join(
         json.dumps(text_unit, ensure_ascii=False) for text_unit in chunks_context
@@ -5557,6 +5594,7 @@ async def naive_query(
     global_config: dict[str, str],
     hashing_kv: BaseKVStorage | None = None,
     system_prompt: str | None = None,
+    text_chunks_db: BaseKVStorage | None = None,
     return_raw_data: Literal[True] = True,
 ) -> dict[str, Any]: ...
 
@@ -5569,6 +5607,7 @@ async def naive_query(
     global_config: dict[str, str],
     hashing_kv: BaseKVStorage | None = None,
     system_prompt: str | None = None,
+    text_chunks_db: BaseKVStorage | None = None,
     return_raw_data: Literal[False] = False,
 ) -> str | AsyncIterator[str]: ...
 
@@ -5580,6 +5619,7 @@ async def naive_query(
     global_config: dict[str, str],
     hashing_kv: BaseKVStorage | None = None,
     system_prompt: str | None = None,
+    text_chunks_db: BaseKVStorage | None = None,
 ) -> QueryResult | None:
     """
     Execute naive query and return unified QueryResult object.
@@ -5623,6 +5663,10 @@ async def naive_query(
             "[naive_query] No relevant document chunks found; returning no-result."
         )
         return None
+
+    # Backfill heading path before token truncation so it counts toward the budget
+    if global_config.get("enable_content_headings", False):
+        await _attach_content_headings(chunks, text_chunks_db)
 
     # Calculate dynamic token limit for chunks
     max_total_tokens = getattr(
@@ -5704,12 +5748,13 @@ async def naive_query(
     # Build chunks_context from processed chunks with reference IDs
     chunks_context = []
     for i, chunk in enumerate(processed_chunks_with_ref_ids):
-        chunks_context.append(
-            {
-                "reference_id": chunk["reference_id"],
-                "content": chunk["content"],
-            }
-        )
+        entry = {
+            "reference_id": chunk["reference_id"],
+            "content": chunk["content"],
+        }
+        if chunk.get("content_headings"):
+            entry["content_headings"] = chunk["content_headings"]
+        chunks_context.append(entry)
 
     text_units_str = "\n".join(
         json.dumps(text_unit, ensure_ascii=False) for text_unit in chunks_context
@@ -5753,6 +5798,7 @@ async def naive_query(
         query_param.max_total_tokens,
         query_param.user_prompt or "",
         query_param.enable_rerank,
+        global_config.get("enable_content_headings", False),
         "\n<llm_identity>\n",
         serialize_llm_cache_identity(llm_cache_identity),
     )
@@ -5785,6 +5831,9 @@ async def naive_query(
                 "max_total_tokens": query_param.max_total_tokens,
                 "user_prompt": query_param.user_prompt or "",
                 "enable_rerank": query_param.enable_rerank,
+                "enable_content_headings": global_config.get(
+                    "enable_content_headings", False
+                ),
             }
             await save_to_cache(
                 hashing_kv,

--- a/lightrag/prompt.py
+++ b/lightrag/prompt.py
@@ -596,7 +596,7 @@ Knowledge Graph Data (Relationship):
 {relations_str}
 ```
 
-Document Chunks (Each entry has a reference_id refer to the `Reference Document List`):
+Document Chunks (Each entry has a reference_id refer to the `Reference Document List`; the optional `content_headings` field gives the chunk's heading path within its source document, e.g. `Section 1 → Subsection 1.2`):
 
 ```json
 {text_chunks_str}
@@ -611,7 +611,7 @@ Reference Document List (Each entry starts with a [reference_id] that correspond
 """
 
 PROMPTS["naive_query_context"] = """
-Document Chunks (Each entry has a reference_id refer to the `Reference Document List`):
+Document Chunks (Each entry has a reference_id refer to the `Reference Document List`; the optional `content_headings` field gives the chunk's heading path within its source document, e.g. `Section 1 → Subsection 1.2`):
 
 ```json
 {text_chunks_str}


### PR DESCRIPTION
## Description

Adds an **opt-in** `content_headings` field to each document-chunk JSON that gets sent to the LLM. The field carries the chunk's parent heading chain (e.g. `Section 1 → Subsection 1.2`) taken from the stored `heading.parent_headings`, so the model can ground its answer in the document's structure.

The behavior is controlled by a new environment variable `ENABLE_CONTENT_HEADINGS` and is **disabled by default** — when off, behavior is identical to before with zero extra I/O.

The heading text is also cleaned before it reaches the LLM so the model isn't burdened by parser noise (stray tabs/newlines, NBSP, full-width spaces, repeated spaces, zero-width invisibles).

## Related Issues

N/A

## Motivation

At query time the chunk's structural position (which section / subsection it came from) is dropped before the prompt is built — the LLM only sees `reference_id` + `content`. For long, deeply-structured documents this loses useful grounding signal. Exposing the parent heading path lets the model reason about where a passage sits in the document hierarchy. It is gated behind a flag because it costs extra prompt tokens and is not always desirable.

## Changes Made

### Feature: `content_headings` in chunk context

- **`lightrag/chunk_schema.py`** — new `format_parent_headings()` helper that joins the parent heading chain with ` → ` (reuses `normalize_chunk_heading`, so both the nested and legacy flat heading shapes are handled; returns `""` when there is no parent chain).
- **`lightrag/operate.py`**
  - new `_attach_content_headings()` that backfills `content_headings` onto chunks by `chunk_id` from text_chunks storage. Vector chunks never carry a heading (chunks_vdb does not store it) and the round-robin merge drops entity/relation headings, so a storage backfill is required.
  - The backfill runs **before** `process_chunks_unified`, so the extra tokens are counted against the chunk token budget — no change to the truncation logic itself.
  - Wired into both `kg_query` (via `_merge_all_chunks`) and `naive_query`. The field is appended **last** in the chunk JSON and **omitted** when the parent chain is empty.
  - `naive_query` gains a `text_chunks_db` parameter (also added to its `@overload` signatures).
- **`lightrag/lightrag.py`** — new `enable_content_headings` config field (env `ENABLE_CONTENT_HEADINGS`, default `False`); both `naive_query` call sites pass `self.text_chunks`.
- **`lightrag/prompt.py`** — `kg_query_context` / `naive_query_context` document the optional `content_headings` field.
- **`env.example`** — documents `ENABLE_CONTENT_HEADINGS` under the Query Configuration section (commented out / default off).

### Correctness: cache key includes the flag

- The query cache key (`compute_args_hash` + the saved `queryparam` dict) now includes `enable_content_headings` in **both** `kg_query` and `naive_query`. Without this, toggling `ENABLE_CONTENT_HEADINGS` could return a stale cached answer generated under the old prompt. (The keyword-extraction cache in `extract_keywords_only` is intentionally left unchanged — `content_headings` does not affect keyword extraction.)

### Cleanup: tidy heading text before sending to the LLM

Parent headings come straight from the parser and may carry tabs, newlines, NBSP, full-width / ideographic spaces, runs of spaces, or zero-width invisibles (common in docx/PDF output). `_clean_heading_text()` (in `chunk_schema.py`) cleans each parent heading before joining:

- collapses every whitespace run into a single regular space, then strips — Python's Unicode `\s` already covers tab / newline / CR / FF / VT / NBSP (U+00A0) / narrow NBSP (U+202F) / full-width space (U+3000) / thin space / line & paragraph separators;
- drops zero-width / invisible characters (U+200B / U+200C / U+200D / U+2060 / U+FEFF) that `\s` does **not** match — they cost tokens without being visible;
- drops parent entries that become empty after cleaning, so no blank segment appears between the `→` separators.

Notes:
- Collapsing never inserts spaces between adjacent CJK characters, so Chinese headings stay intact (`方法<ZWSP>论` → `方法论`).
- Scoped to `format_parent_headings` (the LLM-facing string only); `normalize_chunk_heading` and the ingest/storage path are untouched.
- The zero-width set is built from hex code points + `chr()` so the source contains **no literal invisible characters**.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

- **Default off = zero regression**: the gate sits at the backfill call, so when disabled there is no extra `get_by_ids`, no field on the chunk dict, no change to token counting, and nothing added to the prompt.
- **Verified locally**:
  - `format_parent_headings` across nested / legacy-flat / empty-parents / no-heading inputs;
  - cleaning across tab / newline / NBSP / full-width space / narrow-NBSP / zero-width / zero-width-only-entry / CJK-no-space-insertion inputs;
  - `compute_args_hash` produces different hashes for the flag on vs off;
  - `pytest -k "chunk_schema or heading or normalize_chunk or cache"` → all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
