### PR TITLE
fix(mineru): preserve HTML table content

### DIFF
--- a/lightrag/parser/external/mineru/ir_builder.py
+++ b/lightrag/parser/external/mineru/ir_builder.py
@@ -20,10 +20,13 @@ Conversion rules (informed by spec §3-§六):
   ``Preface/Uncategorized`` block at level 0.
 - ``list`` items joined with ``\n``; ``code`` body taken from ``code_body``
   if present.
-- ``table`` → IRTable + ``{{TBL:k}}`` placeholder. ``table_body`` (HTML) or
-  the ``rows`` field (2D array) become ``html`` / ``rows`` on IRTable.
-  ``num_rows`` / ``num_cols`` are taken from MinerU if present, otherwise
-  inferred. ``header`` populates ``table_header`` (per spec §5).
+- ``table`` → IRTable + ``{{TBL:k}}`` placeholder. MinerU HTML tables are
+  preserved verbatim on ``IRTable.html`` so merged cells (``rowspan`` /
+  ``colspan``) survive in ``tables.json``; the block placeholder receives
+  only the table's inner HTML to avoid nested ``<table>`` wrappers. ``rows``
+  is reserved for explicit 2D-array / non-HTML compatibility inputs. A real
+  HTML ``<thead>`` populates ``table_header`` (per spec §5); otherwise the
+  adapter does not guess a header row.
 - ``image`` / ``picture`` / ``drawing`` → IRDrawing + ``{{IMG:k}}`` placeholder.
   Asset bytes are referenced via ``img_path`` relative to the raw dir.
 - ``equation`` → IREquation. ``is_block`` is decided by whether
@@ -42,6 +45,7 @@ Conversion rules (informed by spec §3-§六):
 
 from __future__ import annotations
 
+from html.parser import HTMLParser
 import json
 import os
 from pathlib import Path
@@ -394,6 +398,7 @@ class MinerUIRBuilder:
     def _build_ir_table(self, item: dict) -> IRTable | None:
         rows: list[list[str]] | None = None
         html: str | None = None
+        body_override: str | None = None
         body_field = item.get("rows")
         body = body_field if body_field is not None else item.get("table_body")
 
@@ -401,7 +406,11 @@ class MinerUIRBuilder:
             rows = _normalize_grid(body)
         elif isinstance(body, str):
             stripped = body.strip()
-            if stripped.startswith("[") and stripped.endswith("]"):
+            if _looks_like_html_table_payload(stripped):
+                html = stripped or None
+                if html:
+                    body_override = _html_table_inner_body(html)
+            elif stripped.startswith("[") and stripped.endswith("]"):
                 try:
                     decoded = json.loads(stripped)
                     if isinstance(decoded, list):
@@ -434,6 +443,13 @@ class MinerUIRBuilder:
         num_rows = int(item.get("num_rows") or (len(rows) if rows else 0) or 0)
         num_cols_default = max((len(r) for r in rows), default=0) if rows else 0
         num_cols = int(item.get("num_cols") or num_cols_default or 0)
+        html_table_info: _HTMLTableInfo | None = None
+        if html and (num_rows <= 0 or num_cols <= 0):
+            html_table_info = _extract_html_table_info(html)
+            if num_rows <= 0:
+                num_rows = html_table_info.num_rows
+            if num_cols <= 0:
+                num_cols = html_table_info.num_cols
 
         captions = item.get("table_caption")
         caption = str(item.get("caption") or "")
@@ -444,6 +460,10 @@ class MinerUIRBuilder:
         table_header: list[list[str]] | None = None
         if isinstance(table_header_raw, list) and table_header_raw:
             table_header = _normalize_grid(table_header_raw)
+        elif html:
+            if html_table_info is None:
+                html_table_info = _extract_html_table_info(html)
+            table_header = html_table_info.table_header
 
         return IRTable(
             placeholder_key="",  # filled by caller
@@ -454,6 +474,7 @@ class MinerUIRBuilder:
             caption=caption,
             footnotes=_as_str_list(item.get("table_footnote") or item.get("footnotes")),
             table_header=table_header,
+            body_override=body_override,
         )
 
     def _build_ir_drawing(
@@ -552,6 +573,143 @@ def _as_str_list(value: Any) -> list[str]:
         return [str(x) for x in value if str(x).strip()]
     s = str(value).strip()
     return [s] if s else []
+
+
+class _HTMLTableInfo:
+    def __init__(
+        self,
+        *,
+        num_rows: int = 0,
+        num_cols: int = 0,
+        table_header: list[list[str]] | None = None,
+    ) -> None:
+        self.num_rows = num_rows
+        self.num_cols = num_cols
+        self.table_header = table_header
+
+
+class _HTMLTableInfoParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.rows: list[tuple[bool, list[str], int]] = []
+        self._thead_depth = 0
+        self._tr_depth = 0
+        self._cell_depth = 0
+        self._row_in_thead = False
+        self._row_cells: list[str] = []
+        self._row_col_count = 0
+        self._cell_parts: list[str] = []
+        self._cell_colspan = 1
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.lower()
+        if tag == "thead":
+            self._thead_depth += 1
+            return
+        if tag == "tr":
+            if self._tr_depth == 0:
+                self._row_in_thead = self._thead_depth > 0
+                self._row_cells = []
+                self._row_col_count = 0
+            self._tr_depth += 1
+            return
+        if tag in {"td", "th"} and self._tr_depth > 0:
+            if self._cell_depth == 0:
+                self._cell_parts = []
+                self._cell_colspan = _cell_colspan(attrs)
+            self._cell_depth += 1
+
+    def handle_data(self, data: str) -> None:
+        if self._cell_depth > 0:
+            self._cell_parts.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+        if tag in {"td", "th"} and self._cell_depth > 0:
+            self._cell_depth -= 1
+            if self._cell_depth == 0:
+                text = " ".join("".join(self._cell_parts).split())
+                self._row_cells.append(text)
+                self._row_col_count += self._cell_colspan
+                self._cell_parts = []
+                self._cell_colspan = 1
+            return
+        if tag == "tr" and self._tr_depth > 0:
+            self._tr_depth -= 1
+            if self._tr_depth == 0 and (self._row_cells or self._row_col_count > 0):
+                self.rows.append(
+                    (
+                        self._row_in_thead,
+                        list(self._row_cells),
+                        self._row_col_count,
+                    )
+                )
+                self._row_cells = []
+                self._row_col_count = 0
+            return
+        if tag == "thead" and self._thead_depth > 0:
+            self._thead_depth -= 1
+
+
+def _cell_colspan(attrs: list[tuple[str, str | None]]) -> int:
+    for key, value in attrs:
+        if key.lower() != "colspan":
+            continue
+        try:
+            return max(int(value or "1"), 1)
+        except ValueError:
+            return 1
+    return 1
+
+
+def _extract_html_table_info(html: str) -> _HTMLTableInfo:
+    parser = _HTMLTableInfoParser()
+    try:
+        parser.feed(html or "")
+        parser.close()
+    except Exception as exc:  # pragma: no cover - HTMLParser is forgiving.
+        logger.debug("[mineru_ir_builder] failed to parse table HTML: %s", exc)
+        return _HTMLTableInfo()
+
+    header_rows = [
+        cells
+        for in_thead, cells, _ in parser.rows
+        if in_thead and any(cell.strip() for cell in cells)
+    ]
+    return _HTMLTableInfo(
+        num_rows=len(parser.rows),
+        num_cols=max((col_count for _, _, col_count in parser.rows), default=0),
+        table_header=header_rows or None,
+    )
+
+
+def _looks_like_html_table_payload(body: str) -> bool:
+    lower = (body or "").lstrip().lower()
+    return any(
+        _starts_with_html_tag(lower, tag)
+        for tag in ("table", "thead", "tbody", "tfoot", "tr")
+    )
+
+
+def _starts_with_html_tag(lower: str, tag: str) -> bool:
+    prefix = f"<{tag}"
+    if not lower.startswith(prefix):
+        return False
+    if len(lower) == len(prefix):
+        return True
+    return lower[len(prefix)] in {" ", "\t", "\r", "\n", ">", "/"}
+
+
+def _html_table_inner_body(html: str) -> str:
+    stripped = (html or "").strip()
+    lower = stripped.lower()
+    if not _starts_with_html_tag(lower, "table"):
+        return stripped
+    open_end = stripped.find(">")
+    close_start = lower.rfind("</table>")
+    if open_end < 0 or close_start <= open_end:
+        return stripped
+    return stripped[open_end + 1 : close_start].strip()
 
 
 def _content_list_self_ref(index: int) -> str:

--- a/lightrag/parser/external/mineru/ir_builder.py
+++ b/lightrag/parser/external/mineru/ir_builder.py
@@ -45,6 +45,7 @@ Conversion rules (informed by spec §3-§六):
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from html.parser import HTMLParser
 import json
 import os
@@ -409,7 +410,10 @@ class MinerUIRBuilder:
             if _looks_like_html_table_payload(stripped):
                 html = stripped or None
                 if html:
-                    body_override = _html_table_inner_body(html)
+                    # ``or None`` so a degenerate ``<table></table>`` (empty
+                    # inner body) falls back to rendering ``table.html`` in the
+                    # writer instead of emitting an empty ``body_override``.
+                    body_override = _html_table_inner_body(html) or None
             elif stripped.startswith("[") and stripped.endswith("]"):
                 try:
                     decoded = json.loads(stripped)
@@ -575,17 +579,11 @@ def _as_str_list(value: Any) -> list[str]:
     return [s] if s else []
 
 
+@dataclass
 class _HTMLTableInfo:
-    def __init__(
-        self,
-        *,
-        num_rows: int = 0,
-        num_cols: int = 0,
-        table_header: list[list[str]] | None = None,
-    ) -> None:
-        self.num_rows = num_rows
-        self.num_cols = num_cols
-        self.table_header = table_header
+    num_rows: int = 0
+    num_cols: int = 0
+    table_header: list[list[str]] | None = None
 
 
 class _HTMLTableInfoParser(HTMLParser):
@@ -705,11 +703,27 @@ def _html_table_inner_body(html: str) -> str:
     lower = stripped.lower()
     if not _starts_with_html_tag(lower, "table"):
         return stripped
-    open_end = stripped.find(">")
+    open_end = _open_tag_end(stripped)
     close_start = lower.rfind("</table>")
     if open_end < 0 or close_start <= open_end:
         return stripped
     return stripped[open_end + 1 : close_start].strip()
+
+
+def _open_tag_end(html: str) -> int:
+    """Index of the ``>`` closing the leading tag, skipping quoted attribute
+    values so a ``>`` inside an attribute (e.g. ``<table data-x="a>b">``) does
+    not terminate the tag early. Returns -1 when no closing ``>`` is found."""
+    quote: str | None = None
+    for idx, ch in enumerate(html):
+        if quote is not None:
+            if ch == quote:
+                quote = None
+        elif ch in {'"', "'"}:
+            quote = ch
+        elif ch == ">":
+            return idx
+    return -1
 
 
 def _content_list_self_ref(index: int) -> str:

--- a/lightrag/parser/external/mineru/ir_builder.py
+++ b/lightrag/parser/external/mineru/ir_builder.py
@@ -408,7 +408,11 @@ class MinerUIRBuilder:
         elif isinstance(body, str):
             stripped = body.strip()
             if _looks_like_html_table_payload(stripped):
-                html = stripped or None
+                # MinerU's table model sometimes wraps output in a
+                # ``<html><body>…</body></html>`` document; unwrap to the bare
+                # ``<table>…</table>`` so the sidecar ``content`` stays a single
+                # clean table and the writer does not nest ``<table>`` wrappers.
+                html = _unwrap_html_table(stripped) or None
                 if html:
                     # ``or None`` so a degenerate ``<table></table>`` (empty
                     # inner body) falls back to rendering ``table.html`` in the
@@ -421,7 +425,9 @@ class MinerUIRBuilder:
                         rows = _normalize_grid(decoded)
                 except json.JSONDecodeError:
                     pass
-            if rows is None:
+            if rows is None and html is None:
+                # Non-HTML, non-JSON string (or JSON that failed to parse):
+                # fall back to the raw payload as the html body.
                 html = stripped or None
         elif isinstance(body, dict):
             grid = body.get("grid") or body.get("rows")
@@ -685,8 +691,39 @@ def _looks_like_html_table_payload(body: str) -> bool:
     lower = (body or "").lstrip().lower()
     return any(
         _starts_with_html_tag(lower, tag)
-        for tag in ("table", "thead", "tbody", "tfoot", "tr")
+        for tag in ("table", "thead", "tbody", "tfoot", "tr", "html", "body")
     )
+
+
+def _unwrap_html_table(payload: str) -> str:
+    """Strip a ``<html>/<body>`` document wrapper that MinerU's table model
+    sometimes emits, returning the outermost ``<table…>…</table>`` span. Keeps
+    a single clean ``<table>`` so the writer does not nest tables and the
+    non-greedy ``TABLE_TAG_RE`` is not truncated at an inner ``</table>``.
+    Falls back to the stripped payload when no ``<table>`` element exists."""
+    stripped = (payload or "").strip()
+    lower = stripped.lower()
+    start = _find_table_open(lower)
+    if start < 0:
+        return stripped
+    close = lower.rfind("</table>")
+    if close < start:
+        return stripped
+    return stripped[start : close + len("</table>")]
+
+
+def _find_table_open(lower: str) -> int:
+    """First index of a real ``<table`` start tag (not e.g. ``<tablefoo``).
+    Returns -1 when none is present."""
+    idx = 0
+    while True:
+        idx = lower.find("<table", idx)
+        if idx < 0:
+            return -1
+        nxt = idx + len("<table")
+        if nxt >= len(lower) or lower[nxt] in {" ", "\t", "\r", "\n", ">", "/"}:
+            return idx
+        idx = nxt
 
 
 def _starts_with_html_tag(lower: str, tag: str) -> bool:

--- a/lightrag/parser/external/mineru/ir_builder.py
+++ b/lightrag/parser/external/mineru/ir_builder.py
@@ -595,15 +595,19 @@ class _HTMLTableInfo:
 class _HTMLTableInfoParser(HTMLParser):
     def __init__(self) -> None:
         super().__init__(convert_charrefs=True)
-        self.rows: list[tuple[bool, list[str], int]] = []
+        # Each row is ``(in_thead, cells, col_count)`` where ``cells`` carries
+        # ``(text, colspan, rowspan)`` per cell so a spanned ``<thead>`` can be
+        # expanded into a rectangular grid (see ``_build_header_grid``).
+        self.rows: list[tuple[bool, list[tuple[str, int, int]], int]] = []
         self._thead_depth = 0
         self._tr_depth = 0
         self._cell_depth = 0
         self._row_in_thead = False
-        self._row_cells: list[str] = []
+        self._row_cells: list[tuple[str, int, int]] = []
         self._row_col_count = 0
         self._cell_parts: list[str] = []
         self._cell_colspan = 1
+        self._cell_rowspan = 1
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         tag = tag.lower()
@@ -620,7 +624,8 @@ class _HTMLTableInfoParser(HTMLParser):
         if tag in {"td", "th"} and self._tr_depth > 0:
             if self._cell_depth == 0:
                 self._cell_parts = []
-                self._cell_colspan = _cell_colspan(attrs)
+                self._cell_colspan = _cell_span(attrs, "colspan")
+                self._cell_rowspan = _cell_span(attrs, "rowspan")
             self._cell_depth += 1
 
     def handle_data(self, data: str) -> None:
@@ -633,10 +638,11 @@ class _HTMLTableInfoParser(HTMLParser):
             self._cell_depth -= 1
             if self._cell_depth == 0:
                 text = " ".join("".join(self._cell_parts).split())
-                self._row_cells.append(text)
+                self._row_cells.append((text, self._cell_colspan, self._cell_rowspan))
                 self._row_col_count += self._cell_colspan
                 self._cell_parts = []
                 self._cell_colspan = 1
+                self._cell_rowspan = 1
             return
         if tag == "tr" and self._tr_depth > 0:
             self._tr_depth -= 1
@@ -655,9 +661,10 @@ class _HTMLTableInfoParser(HTMLParser):
             self._thead_depth -= 1
 
 
-def _cell_colspan(attrs: list[tuple[str, str | None]]) -> int:
+def _cell_span(attrs: list[tuple[str, str | None]], name: str) -> int:
+    """Read a ``colspan``/``rowspan`` attribute as an int ``>= 1`` (default 1)."""
     for key, value in attrs:
-        if key.lower() != "colspan":
+        if key.lower() != name:
             continue
         try:
             return max(int(value or "1"), 1)
@@ -675,16 +682,53 @@ def _extract_html_table_info(html: str) -> _HTMLTableInfo:
         logger.debug("[mineru_ir_builder] failed to parse table HTML: %s", exc)
         return _HTMLTableInfo()
 
-    header_rows = [
-        cells
-        for in_thead, cells, _ in parser.rows
-        if in_thead and any(cell.strip() for cell in cells)
-    ]
+    thead_rows = [cells for in_thead, cells, _ in parser.rows if in_thead]
+    header_grid = _build_header_grid(thead_rows)
+    # Drop a header that is entirely blank (e.g. a spacer ``<thead>`` row) so
+    # the writer omits ``table_header`` rather than emitting empty ``<th>``s.
+    if not any(cell.strip() for row in header_grid for cell in row):
+        header_grid = []
     return _HTMLTableInfo(
         num_rows=len(parser.rows),
         num_cols=max((col_count for _, _, col_count in parser.rows), default=0),
-        table_header=header_rows or None,
+        table_header=header_grid or None,
     )
+
+
+def _build_header_grid(rows: list[list[tuple[str, int, int]]]) -> list[list[str]]:
+    """Expand spanned ``<thead>`` cells into a rectangular text grid.
+
+    ``table_header`` is rendered cell-per-``<th>`` (no spans) when repeated onto
+    later chunks of a split HTML table, so a ragged header (``colspan``/
+    ``rowspan`` collapsed to one cell) would misalign with the table body.
+    Duplicating each spanned cell's text across the columns/rows it covers keeps
+    the recovered header rectangular and column-aligned.
+    """
+    grid: list[dict[int, str]] = []
+    carry: dict[int, list] = {}  # column -> [text, rows_remaining]
+    for src_cells in rows:
+        row_out: dict[int, str] = {}
+        next_carry: dict[int, list] = {}
+        # Fill columns still occupied by a rowspan started in an earlier row.
+        for col, (text, left) in carry.items():
+            row_out[col] = text
+            if left - 1 > 0:
+                next_carry[col] = [text, left - 1]
+        # Place this row's own cells into the next free columns.
+        col = 0
+        for text, colspan, rowspan in src_cells:
+            while col in row_out:
+                col += 1
+            for k in range(colspan):
+                row_out[col + k] = text
+                if rowspan > 1:
+                    next_carry[col + k] = [text, rowspan - 1]
+            col += colspan
+        carry = next_carry
+        grid.append(row_out)
+
+    width = max((max(row) + 1 for row in grid if row), default=0)
+    return [[row.get(c, "") for c in range(width)] for row in grid]
 
 
 def _looks_like_html_table_payload(body: str) -> bool:

--- a/lightrag/sidecar/ir.py
+++ b/lightrag/sidecar/ir.py
@@ -108,6 +108,11 @@ class IRTable:
     # in the adapter (``rows`` is None), ``html`` is used as the structured
     # fallback and the writer renders ``format="html"`` with the body_override
     # string verbatim — keeping the original (unparseable) bytes intact.
+    #
+    # MinerU HTML tables also use this: ``rows`` is None, ``html`` holds the
+    # unwrapped ``<table>…</table>`` for the sidecar ``content``, and
+    # ``body_override`` holds that table's *inner* body so the writer's own
+    # ``<table …>`` wrapper is not nested.
     body_override: str | None = None
 
 

--- a/tests/parser/external/mineru/test_ir_builder.py
+++ b/tests/parser/external/mineru/test_ir_builder.py
@@ -622,6 +622,35 @@ def test_adapter_html_table_without_thead_does_not_guess_header(
 
 
 @pytest.mark.offline
+def test_adapter_html_table_attr_with_gt_keeps_inner_body(tmp_path: Path) -> None:
+    """A ``>`` inside a ``<table>`` attribute must not truncate the open tag,
+    so ``body_override`` still strips the full ``<table …>`` wrapper."""
+    table_html = '<table data-x="a>b"><tbody><tr><td>v</td></tr></tbody></table>'
+    raw = _write_bundle(
+        tmp_path,
+        [{"type": "table", "table_body": table_html}],
+    )
+    ir = MinerUIRBuilder().normalize_from_workdir(raw, document_name="h.pdf")
+    table = ir.blocks[0].tables[0]
+    assert table.html == table_html
+    assert table.body_override == "<tbody><tr><td>v</td></tr></tbody>"
+
+
+@pytest.mark.offline
+def test_adapter_empty_html_table_falls_back_to_full_html(tmp_path: Path) -> None:
+    """A degenerate ``<table></table>`` has no inner body, so ``body_override``
+    stays None and the writer renders ``table.html`` verbatim."""
+    raw = _write_bundle(
+        tmp_path,
+        [{"type": "table", "table_body": "<table></table>"}],
+    )
+    ir = MinerUIRBuilder().normalize_from_workdir(raw, document_name="h.pdf")
+    table = ir.blocks[0].tables[0]
+    assert table.html == "<table></table>"
+    assert table.body_override is None
+
+
+@pytest.mark.offline
 def test_adapter_list_items_joined_with_newline(tmp_path: Path) -> None:
     raw = _write_bundle(
         tmp_path,

--- a/tests/parser/external/mineru/test_ir_builder.py
+++ b/tests/parser/external/mineru/test_ir_builder.py
@@ -591,7 +591,33 @@ def test_adapter_html_table_preserves_merged_cells_and_extracts_thead(
     assert table.num_rows == 3
     assert table.num_cols == 3
     assert table.caption == "Tbl"
-    assert table.table_header == [["Metric", "Group"], ["A", "B"]]
+    # Spanned <thead> is expanded into a rectangular grid: ``Metric`` (rowspan)
+    # fills both header rows' first column, ``Group`` (colspan) fills two.
+    assert table.table_header == [["Metric", "Group", "Group"], ["Metric", "A", "B"]]
+
+
+@pytest.mark.offline
+def test_adapter_html_table_header_grid_is_rectangular(tmp_path: Path) -> None:
+    """A spanned <thead> must expand to a rectangular grid so the repeated
+    header (rendered cell-per-<th> downstream) stays column-aligned with the
+    body — every header row must have exactly ``num_cols`` cells."""
+    table_html = (
+        "<table><thead>"
+        '<tr><th>ID</th><th colspan="3">Scores</th></tr>'
+        '<tr><th>n</th><th>A</th><th colspan="2">BC</th></tr>'
+        "</thead><tbody>"
+        "<tr><td>1</td><td>x</td><td>y</td><td>z</td></tr>"
+        "</tbody></table>"
+    )
+    raw = _write_bundle(tmp_path, [{"type": "table", "table_body": table_html}])
+    ir = MinerUIRBuilder().normalize_from_workdir(raw, document_name="h.pdf")
+    table = ir.blocks[0].tables[0]
+    assert table.num_cols == 4
+    assert table.table_header == [
+        ["ID", "Scores", "Scores", "Scores"],
+        ["n", "A", "BC", "BC"],
+    ]
+    assert all(len(row) == table.num_cols for row in table.table_header)
 
 
 @pytest.mark.offline
@@ -666,7 +692,7 @@ def test_adapter_html_table_strips_html_body_wrapper(tmp_path: Path) -> None:
     assert table.html == f"<table>{inner}</table>"  # <html>/<body> wrapper gone
     assert table.body_override == inner  # block text renders only the inner body
     assert table.num_cols == 2
-    assert table.table_header == [["G"]]
+    assert table.table_header == [["G", "G"]]  # colspan=2 expanded to a 2-col grid
 
 
 @pytest.mark.offline

--- a/tests/parser/external/mineru/test_ir_builder.py
+++ b/tests/parser/external/mineru/test_ir_builder.py
@@ -559,24 +559,66 @@ def test_adapter_missing_content_list_raises(tmp_path: Path) -> None:
 
 
 @pytest.mark.offline
-def test_adapter_html_table_fallback(tmp_path: Path) -> None:
-    """If table_body is a string that is not JSON, treat as HTML and keep
-    on IRTable.html so the writer emits format="html"."""
+def test_adapter_html_table_preserves_merged_cells_and_extracts_thead(
+    tmp_path: Path,
+) -> None:
+    """MinerU HTML table_body must stay HTML so rowspan/colspan survive."""
+    table_html = (
+        '<table><thead><tr><th rowspan="2">Metric</th>'
+        '<th colspan="2">Group</th></tr><tr><th>A</th><th>B</th></tr></thead>'
+        "<tbody><tr><td>Accuracy</td><td>91%</td><td>93%</td></tr></tbody></table>"
+    )
     raw = _write_bundle(
         tmp_path,
         [
             {
                 "type": "table",
-                "table_body": "<table><tr><td>a</td></tr></table>",
+                "table_body": table_html,
+                "table_caption": ["Tbl"],
+            }
+        ],
+    )
+    ir = MinerUIRBuilder().normalize_from_workdir(raw, document_name="h.pdf")
+    table = ir.blocks[0].tables[0]
+
+    assert table.rows is None
+    assert table.html == table_html
+    assert 'rowspan="2"' in table.html
+    assert 'colspan="2"' in table.html
+    assert table.body_override == table_html.removeprefix("<table>").removesuffix(
+        "</table>"
+    )
+    assert table.num_rows == 3
+    assert table.num_cols == 3
+    assert table.caption == "Tbl"
+    assert table.table_header == [["Metric", "Group"], ["A", "B"]]
+
+
+@pytest.mark.offline
+def test_adapter_html_table_without_thead_does_not_guess_header(
+    tmp_path: Path,
+) -> None:
+    """Only a real HTML <thead> should populate table_header."""
+    table_html = (
+        "<table><tbody><tr><td>H1</td><td>H2</td></tr>"
+        "<tr><td>a</td><td>b</td></tr></tbody></table>"
+    )
+    raw = _write_bundle(
+        tmp_path,
+        [
+            {
+                "type": "table",
+                "table_body": table_html,
                 "num_rows": 1,
-                "num_cols": 1,
+                "num_cols": 2,
             }
         ],
     )
     ir = MinerUIRBuilder().normalize_from_workdir(raw, document_name="h.pdf")
     table = ir.blocks[0].tables[0]
     assert table.rows is None
-    assert table.html and "<td>a</td>" in table.html
+    assert table.html == table_html
+    assert table.table_header is None
 
 
 @pytest.mark.offline

--- a/tests/parser/external/mineru/test_ir_builder.py
+++ b/tests/parser/external/mineru/test_ir_builder.py
@@ -651,6 +651,25 @@ def test_adapter_empty_html_table_falls_back_to_full_html(tmp_path: Path) -> Non
 
 
 @pytest.mark.offline
+def test_adapter_html_table_strips_html_body_wrapper(tmp_path: Path) -> None:
+    """MinerU's table model may wrap output in ``<html><body>``; the adapter
+    must unwrap to a single ``<table>`` so the writer does not nest tables and
+    ``TABLE_TAG_RE`` consumers are not truncated at the inner ``</table>``."""
+    inner = (
+        '<thead><tr><th colspan="2">G</th></tr></thead>'
+        "<tbody><tr><td>a</td><td>b</td></tr></tbody>"
+    )
+    payload = f"<html><body><table>{inner}</table></body></html>"
+    raw = _write_bundle(tmp_path, [{"type": "table", "table_body": payload}])
+    ir = MinerUIRBuilder().normalize_from_workdir(raw, document_name="h.pdf")
+    table = ir.blocks[0].tables[0]
+    assert table.html == f"<table>{inner}</table>"  # <html>/<body> wrapper gone
+    assert table.body_override == inner  # block text renders only the inner body
+    assert table.num_cols == 2
+    assert table.table_header == [["G"]]
+
+
+@pytest.mark.offline
 def test_adapter_list_items_joined_with_newline(tmp_path: Path) -> None:
     raw = _write_bundle(
         tmp_path,

--- a/tests/parser/external/mineru/test_parse_mineru_sidecar.py
+++ b/tests/parser/external/mineru/test_parse_mineru_sidecar.py
@@ -279,8 +279,8 @@ def test_parse_mineru_emits_compliant_sidecar(
             assert 'rowspan="2"' in table_item["content"]
             assert 'colspan="2"' in table_item["content"]
             assert json.loads(table_item["table_header"]) == [
-                ["Metric", "Score"],
-                ["A", "B"],
+                ["Metric", "Score", "Score"],
+                ["Metric", "A", "B"],
             ]
             assert table_item["self_ref"] == "content_list.json#/2"
 

--- a/tests/parser/external/mineru/test_parse_mineru_sidecar.py
+++ b/tests/parser/external/mineru/test_parse_mineru_sidecar.py
@@ -66,14 +66,19 @@ def _new_rag(tmp_path: Path) -> LightRAG:
     )
 
 
+_FAKE_TABLE_HTML = (
+    '<table><thead><tr><th rowspan="2">Metric</th>'
+    '<th colspan="2">Score</th></tr><tr><th>A</th><th>B</th></tr></thead>'
+    "<tbody><tr><td>Accuracy</td><td>91%</td><td>93%</td></tr></tbody></table>"
+)
+
+
 _FAKE_CONTENT_LIST = [
     {"type": "text", "text": "1 Introduction", "text_level": 1},
     {"type": "text", "text": "Body paragraph."},
     {
         "type": "table",
-        "table_body": [["A", "B"], ["1", "2"]],
-        "num_rows": 2,
-        "num_cols": 2,
+        "table_body": _FAKE_TABLE_HTML,
         "table_caption": ["Tbl"],
         "page_idx": 0,
         "bbox": [10, 10, 100, 50],
@@ -236,7 +241,10 @@ def test_parse_mineru_emits_compliant_sidecar(
             # Spec fix: <table> placeholder inline, not <cite>
             contents = " ".join(row.get("content", "") for row in rows)
             assert '<table id="tb-' in contents
-            assert 'format="json"' in contents
+            assert 'format="html"' in contents
+            assert 'format="json"' not in contents
+            assert 'rowspan="2"' in contents
+            assert 'colspan="2"' in contents
             assert "<cite" not in contents
 
             # bbox positions present on at least one block
@@ -265,6 +273,15 @@ def test_parse_mineru_emits_compliant_sidecar(
             tables = json.loads((parsed_dir / "demo.tables.json").read_text())["tables"]
             (_, table_item) = next(iter(tables.items()))
             assert "image" not in table_item
+            assert table_item["format"] == "html"
+            assert table_item["content"] == _FAKE_TABLE_HTML
+            assert table_item["dimension"] == [3, 3]
+            assert 'rowspan="2"' in table_item["content"]
+            assert 'colspan="2"' in table_item["content"]
+            assert json.loads(table_item["table_header"]) == [
+                ["Metric", "Score"],
+                ["A", "B"],
+            ]
             assert table_item["self_ref"] == "content_list.json#/2"
 
             equations = json.loads((parsed_dir / "demo.equations.json").read_text())[


### PR DESCRIPTION
## Description

Preserve MinerU HTML table payloads in LightRAG sidecars so merged-cell semantics such as `rowspan` and `colspan` are not lost by converting tables into JSON grids. The MinerU adapter now extracts `table_header` only from real HTML `<thead>` rows.

## Related Issues

#XXXX

## Changes Made

- Preserve MinerU HTML `table_body` content in `tables.json` with `format: "html"`.
- Render block table placeholders with inner HTML to avoid nested `<table>` wrappers while keeping full HTML in the table sidecar.
- Extract table headers from HTML `<thead>` using the standard-library HTML parser.
- Add regression coverage for merged-cell HTML tables, `<thead>` header extraction, no-header behavior, and parse_mineru sidecar output.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Validated with:

- `./scripts/test.sh tests/parser/external/mineru/test_ir_builder.py`
- `./scripts/test.sh tests/parser/external/mineru/test_parse_mineru_sidecar.py`
- `./scripts/test.sh tests/chunker/test_paragraph_semantic_table_split.py`
- `ruff check lightrag/parser/external/mineru/ir_builder.py tests/parser/external/mineru/test_ir_builder.py tests/parser/external/mineru/test_parse_mineru_sidecar.py`