### PR TITLE
✨ feat(multimodal): declare table content format (html/json) in analysis prompt

### DIFF
--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -4152,6 +4152,7 @@ class _PipelineMixin:
                 IMAGE_TYPE_ENUM,
                 IMAGE_TYPE_FALLBACK,
                 MULTIMODAL_PROMPTS,
+                table_content_format_label,
             )
             from lightrag.constants import (
                 DEFAULT_MM_ANALYSIS_PRIORITY,
@@ -4484,10 +4485,24 @@ class _PipelineMixin:
                     )
                 template = MULTIMODAL_PROMPTS[f"{kind}_analysis"]
 
+                # A table item written by the sidecar writer ALWAYS carries a
+                # valid ``format``; a missing/unknown one means a corrupt or
+                # incompatible sidecar — fail loudly rather than guess.
+                content_format = ""
+                if kind == "table":
+                    fmt = (item.get("format") or "").strip().lower()
+                    if fmt not in ("html", "json"):
+                        raise MultimodalAnalysisError(
+                            f"table/{item_id}: missing or invalid table format "
+                            f"{item.get('format')!r} ({file_path})"
+                        )
+                    content_format = table_content_format_label(fmt)
+
                 def _render(content_value: str) -> str:
                     return template.format(
                         language=language,
                         content=content_value,
+                        content_format=content_format,
                         captions=_captions_value(item),
                         footnotes=_footnotes_value(item),
                         leading=_surrounding_value(item, "leading"),

--- a/lightrag/prompt_multimodal.py
+++ b/lightrag/prompt_multimodal.py
@@ -49,6 +49,37 @@ IMAGE_TYPE_ENUM: tuple[str, ...] = (
 IMAGE_TYPE_FALLBACK = "Other"
 
 
+_TABLE_FORMAT_LABELS: dict[str, str] = {
+    "html": (
+        "HTML format — a <table> fragment where merged cells use "
+        "rowspan/colspan and the header (if any) is inside <thead>"
+    ),
+    "json": (
+        "JSON format — a 2-D array where each inner array is one table row "
+        "(rows[i][j] is the cell at row i, column j); the first row(s) may be "
+        "the header"
+    ),
+}
+
+
+def table_content_format_label(fmt: str) -> str:
+    """Human-readable format declaration for the ``table_analysis`` prompt.
+
+    Maps the sidecar table item's ``format`` (``"html"`` / ``"json"``) to a
+    short clause describing how to read the body. Raises :class:`ValueError` on
+    any other value — a table item written by the sidecar writer ALWAYS carries
+    a valid format, so a missing/unknown one means a corrupt or incompatible
+    sidecar and must fail loudly rather than be guessed.
+    """
+    key = (fmt or "").strip().lower()
+    try:
+        return _TABLE_FORMAT_LABELS[key]
+    except KeyError:
+        raise ValueError(
+            f"unknown table format {fmt!r}; expected 'html' or 'json'"
+        ) from None
+
+
 MULTIMODAL_PROMPTS: dict[str, str] = {}
 
 
@@ -133,7 +164,7 @@ Output:
 
 MULTIMODAL_PROMPTS[
     "table_analysis"
-] = """You are an expert table analyzer. The provided content contains table content in JSON or HTML format. Analyze it and return a single JSON object describing its structure and content.
+] = """You are an expert table analyzer. The exact format of the table (HTML or a JSON 2-D array) is declared in the TABLE CONTENT section below. Analyze it and return a single JSON object describing its structure and content.
 
 ================ INSTRUCTIONS ================
 
@@ -185,6 +216,7 @@ MULTIMODAL_PROMPTS[
    - The output values for the JSON fields `name` and `description` must be written in `{language}`.
 
 ================ TABLE CONTENT ================
+The TABLE CONTENT below is in {content_format}.
 ```
 {content}
 ```
@@ -319,4 +351,5 @@ __all__ = [
     "IMAGE_TYPE_ENUM",
     "IMAGE_TYPE_FALLBACK",
     "MULTIMODAL_PROMPTS",
+    "table_content_format_label",
 ]

--- a/tests/pipeline/test_pipeline_analyze_multimodal.py
+++ b/tests/pipeline/test_pipeline_analyze_multimodal.py
@@ -548,6 +548,7 @@ async def test_table_routes_to_extract_role_not_vlm(tmp_path):
                     "tables": {
                         "tb-001": {
                             "caption": "Table 1",
+                            "format": "html",
                             "content": "<table><tr><td>A</td></tr></table>",
                         }
                     }
@@ -782,6 +783,7 @@ async def test_oversized_table_content_truncated_to_extract_budget(tmp_path):
                     "tables": {
                         "tb-big": {
                             "caption": "huge table",
+                            "format": "json",
                             "content": big_table,
                         }
                     }
@@ -867,6 +869,7 @@ async def test_max_extract_input_tokens_env_var_lowers_cap_and_logs_warning(
                     "tables": {
                         "tb-mid": {
                             "caption": "mid table",
+                            "format": "json",
                             "content": mid_table,
                         }
                     }
@@ -942,10 +945,11 @@ async def test_extract_cap_below_prompt_frame_fails_item_without_llm_call(
                 {
                     "tables": {
                         "tb-tight": {
+                            "format": "json",
                             "content": (
                                 '<table id="tb-tight" format="json">'
                                 '[["A","B"]]</table>'
-                            )
+                            ),
                         }
                     }
                 }
@@ -982,3 +986,102 @@ async def test_extract_cap_below_prompt_frame_fails_item_without_llm_call(
         assert "MAX_EXTRACT_INPUT_TOKENS" in item["llm_analyze_result"]["message"]
     finally:
         await rag.finalize_storages()
+
+
+# ---------------------------------------------------------------------------
+# Table content-format declaration (prompt tells the LLM html vs json).
+# ---------------------------------------------------------------------------
+
+
+def test_table_content_format_label_html_and_json():
+    from lightrag.prompt_multimodal import table_content_format_label
+
+    html_label = table_content_format_label("html")
+    assert "HTML" in html_label
+    assert "rowspan" in html_label and "colspan" in html_label
+    assert "<thead>" in html_label
+
+    json_label = table_content_format_label("JSON")  # case-insensitive
+    assert "JSON" in json_label
+    assert "2-D" in json_label and "row" in json_label
+
+
+@pytest.mark.parametrize("bad", [None, "", "csv", "markdown"])
+def test_table_content_format_label_rejects_unknown(bad):
+    from lightrag.prompt_multimodal import table_content_format_label
+
+    with pytest.raises(ValueError):
+        table_content_format_label(bad)
+
+
+async def _capture_table_prompt(tmp_path, *, fmt, content):
+    """Run analyze_multimodal on a single table item and return the rendered
+    EXTRACT prompt captured by the mock."""
+    extract_log: list[dict] = []
+    rag = _build_rag(tmp_path, extract_func=_make_extract_mock(extract_log))
+    await rag.initialize_storages()
+    try:
+        parsed_dir = tmp_path / "parsed"
+        parsed_dir.mkdir()
+        blocks_path = parsed_dir / "doc.blocks.jsonl"
+        blocks_path.write_text(
+            json.dumps({"type": "meta", "doc_id": "doc-1"}) + "\n",
+            encoding="utf-8",
+        )
+        item: dict = {"caption": "Table 1", "content": content}
+        if fmt is not None:
+            item["format"] = fmt
+        (parsed_dir / "doc.tables.json").write_text(
+            json.dumps({"tables": {"tb-001": item}}),
+            encoding="utf-8",
+        )
+        await rag.analyze_multimodal(
+            doc_id="doc-1",
+            file_path="fixture.pdf",
+            parsed_data={"blocks_path": str(blocks_path)},
+            process_options="t",
+        )
+        return extract_log
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_table_prompt_declares_html_format(tmp_path):
+    """The EXTRACT prompt for an HTML table must state it is HTML."""
+    extract_log = await _capture_table_prompt(
+        tmp_path,
+        fmt="html",
+        content="<table><tr><td>A</td></tr></table>",
+    )
+    assert len(extract_log) == 1
+    prompt = extract_log[0]["prompt"]
+    assert "in HTML format —" in prompt
+    assert "rowspan/colspan" in prompt
+
+
+@pytest.mark.asyncio
+async def test_table_prompt_declares_json_format(tmp_path):
+    """The EXTRACT prompt for a JSON table must state it is JSON."""
+    extract_log = await _capture_table_prompt(
+        tmp_path,
+        fmt="json",
+        content='[["A","B"],["1","2"]]',
+    )
+    assert len(extract_log) == 1
+    prompt = extract_log[0]["prompt"]
+    assert "in JSON format —" in prompt
+    assert "2-D array" in prompt
+
+
+@pytest.mark.asyncio
+async def test_table_missing_format_hard_fails(tmp_path):
+    """A table item without a valid ``format`` is a corrupt sidecar — the
+    worker must raise MultimodalAnalysisError, not guess the format."""
+    with pytest.raises(MultimodalAnalysisError) as excinfo:
+        await _capture_table_prompt(
+            tmp_path,
+            fmt=None,
+            content="<table><tr><td>A</td></tr></table>",
+        )
+    assert "tb-001" in str(excinfo.value)

--- a/tests/pipeline/test_pipeline_release_closure.py
+++ b/tests/pipeline/test_pipeline_release_closure.py
@@ -1566,6 +1566,7 @@ def test_analyze_multimodal_overwrites_already_analyzed_items(tmp_path):
                         "tbl1": {
                             "id": "tbl1",
                             "caption": "tbl",
+                            "format": "html",
                             "content": "Header|Row",
                         }
                     },
@@ -2788,6 +2789,7 @@ def test_analyze_multimodal_table_without_image_uses_textual_analysis(tmp_path):
                             "id": "id1",
                             "caption": "表1 指标说明",
                             "footnotes": ["单位：国际标准单位"],
+                            "format": "html",
                             "content": "<table><tr><th>符号</th><th>代表意义</th><th>单位</th></tr><tr><td>A</td><td>面积</td><td>m2</td></tr></table>",
                         }
                     },


### PR DESCRIPTION
## Description

The `table_analysis` multimodal prompt sends the LLM either an HTML `<table>` fragment or a JSON 2-D array as `TABLE CONTENT`, but it never declared **which** format the current payload was — the model had to infer it. This PR makes the prompt explicitly state the format and how to read it.

This is especially useful now that the HTML-table path preserves merged-cell semantics (`rowspan`/`colspan`, `<thead>`): telling the LLM "this is HTML, merged cells use rowspan/colspan, headers are in `<thead>`" (or, for JSON, "a 2-D array, each inner array is one row") directly improves its interpretation of merged headers and table structure.

## Related Issues

n/a

## Changes Made

- Add `table_content_format_label(fmt)` in `lightrag/prompt_multimodal.py` mapping `"html"`/`"json"` (case-insensitive) to a short reading-hint clause. Unknown/missing values `raise ValueError` — **no content sniffing / heuristic guessing**.
- `table_analysis` template: tighten the intro line to point at the declaration, and inject `The TABLE CONTENT below is in {content_format}.` right above the body.
- `pipeline._analyze_text_modality`: validate the sidecar table item's `format` and raise `MultimodalAnalysisError` (with `item_id`/`file_path`) when it is missing or invalid. A table item written by the sidecar writer always carries a valid `format`, so a missing one means a corrupt/incompatible sidecar and must fail loudly. The extra `content_format` kwarg is harmless for the equation prompt (`str.format` ignores unreferenced kwargs).
- Backfill the `format` field on existing table fixtures, and add unit tests (label mapping + `ValueError` on unknown), prompt-content assertions (HTML/JSON declaration present), and a hard-fail regression test for missing format.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Validated with:

- `./scripts/test.sh tests/pipeline/test_pipeline_analyze_multimodal.py tests/pipeline/test_pipeline_release_closure.py` (93 passed)
- `./scripts/test.sh tests/parser/test_parse_native_lightrag_e2e.py tests/pipeline/test_pipeline_cancellation.py` (10 passed; covers the equation path → confirms no `KeyError` from the new kwarg)
- `pre-commit run ruff-format` / `ruff` on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
