### PR TITLE
fix(extract): drop "in section unknown" noise from multimodal relation descriptions

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -3546,11 +3546,17 @@ async def extract_entities(
                     }
                 )
                 heading_block = chunk_dp.get("heading")
-                heading_label = "unknown"
+                heading_label = ""
                 if isinstance(heading_block, dict):
-                    heading_label = (
-                        str(heading_block.get("heading") or "").strip() or "unknown"
-                    )
+                    heading_label = str(heading_block.get("heading") or "").strip()
+                # Omit the "in section ..." clause entirely when the chunk has no
+                # real heading — a literal "unknown" filler would otherwise leak
+                # into the relation description, embedding, and retrieval as noise.
+                location = (
+                    f"in section {heading_label} of document"
+                    if heading_label
+                    else "of document"
+                )
                 mm_display_name = _parse_mm_display_name(
                     chunk_dp.get("content", "") or "", sidecar_id
                 )
@@ -3566,8 +3572,8 @@ async def extract_entities(
                             "weight": 1.0,
                             "description": (
                                 f"{tgt} is associated with {sidecar_type} "
-                                f"{mm_display_name} in section {heading_label} "
-                                f'of document "{file_path}"'
+                                f"{mm_display_name} {location} "
+                                f'"{file_path}"'
                             ),
                             "keywords": "associated with, contained in",
                             "source_id": chunk_key,


### PR DESCRIPTION
## Description

In the entity-extraction stage, each multimodal object (table / drawing / equation) gets a relation edge to its co-located entities whose `description` reads:

> `{tgt} is associated with {sidecar_type} {mm_display_name} in section {heading_label} of document "{file_path}"`

When the multimodal chunk had **no real heading**, `heading_label` fell back to the literal string `"unknown"`, producing `... in section unknown of document ...`. That filler word is meaningless and leaks into the relation description — and therefore into the embedding and retrieval surface — as noise.

This PR omits the `in section ...` clause entirely when the chunk has no heading.

## Related Issues

N/A

## Changes Made

- **`lightrag/operate.py`** (`extract_entities` → `_process_single_content`): `heading_label` now defaults to `""` (only filled when a real `heading` exists), and the location clause is built conditionally:
  - **heading present** → `... {mm_display_name} in section {heading_label} of document "{file_path}"` (byte-identical to before).
  - **heading empty** → `... {mm_display_name} of document "{file_path}"` (no `in section`, no `unknown`).

`heading_label` is consumed only by this one description string, so changing its default has no other side effects.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

No existing test asserted this description string, so the default-value change breaks nothing; `tests/pipeline/test_pipeline_release_closure.py` passes (70 passed). The description is built inline deep inside `extract_entities` with no clean test seam (an isolated test would require either running full extraction or extracting a helper); per the minimal-diff intent, no new test was added. Verified: `pytest tests/pipeline/test_pipeline_release_closure.py` + `pre-commit run ruff-format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
