### PR TITLE
feat(query): cap parent-heading length to match extraction breadcrumb

### DIFF
--- a/lightrag/chunk_schema.py
+++ b/lightrag/chunk_schema.py
@@ -122,7 +122,34 @@ def _clean_heading_text(text: str) -> str:
     return text.strip()
 
 
-def format_parent_headings(dp: dict[str, Any]) -> str:
+def _truncate_heading_level(text: str, max_chars: int) -> str:
+    """Hard-cap a single heading level, marking elision with an ellipsis."""
+    if max_chars <= 0 or len(text) <= max_chars:
+        return text
+    # Reserve one char for the ellipsis so the result length stays <= max_chars.
+    return text[: max_chars - 1].rstrip() + "…"
+
+
+def _clean_and_cap_headings(headings: list[str], max_heading_len: int) -> list[str]:
+    """Clean each heading, drop empties, then hard-cap each level's length.
+
+    Shared by :func:`format_parent_headings` and :func:`format_heading_context`
+    so both the query-stage and extraction-stage breadcrumbs apply identical
+    cleaning (:func:`_clean_heading_text`) and per-level truncation, and cannot
+    drift apart. Order matters: clean → drop empties → cap.
+    """
+    return [
+        _truncate_heading_level(c, max_heading_len)
+        for c in (_clean_heading_text(h) for h in headings)
+        if c
+    ]
+
+
+def format_parent_headings(
+    dp: dict[str, Any],
+    *,
+    max_heading_len: int = DEFAULT_HEADING_LEVEL_MAX_CHARS,
+) -> str:
     """Join a chunk's parent heading chain into ``h1 → h2 → h3``.
 
     Reuses :func:`normalize_chunk_heading` so both the nested and legacy flat
@@ -130,22 +157,16 @@ def format_parent_headings(dp: dict[str, Any]) -> str:
     :func:`_clean_heading_text` so the string sent to the LLM is a single tidy
     line. Returns an empty string when the chunk has no (non-empty) parent
     headings, so callers can simply omit the field when it is empty.
+
+    Each individual heading level is capped at ``max_heading_len`` characters
+    (set ``<= 0`` to disable), matching :func:`format_heading_context`, so one
+    runaway title cannot bloat the query context before its token truncation.
     """
     normalized = normalize_chunk_heading(dp)
     if not normalized:
         return ""
-    cleaned = [
-        c for c in (_clean_heading_text(h) for h in normalized["parent_headings"]) if c
-    ]
+    cleaned = _clean_and_cap_headings(normalized["parent_headings"], max_heading_len)
     return HEADING_BREADCRUMB_SEP.join(cleaned)
-
-
-def _truncate_heading_level(text: str, max_chars: int) -> str:
-    """Hard-cap a single heading level, marking elision with an ellipsis."""
-    if max_chars <= 0 or len(text) <= max_chars:
-        return text
-    # Reserve one char for the ellipsis so the result length stays <= max_chars.
-    return text[: max_chars - 1].rstrip() + "…"
 
 
 def format_heading_context(
@@ -173,11 +194,7 @@ def format_heading_context(
     chain = list(normalized["parent_headings"])
     if normalized["heading"]:
         chain.append(normalized["heading"])
-    cleaned = [
-        _truncate_heading_level(c, max_heading_len)
-        for c in (_clean_heading_text(h) for h in chain)
-        if c
-    ]
+    cleaned = _clean_and_cap_headings(chain, max_heading_len)
     return HEADING_BREADCRUMB_SEP.join(cleaned)
 
 

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -4680,15 +4680,27 @@ async def _attach_content_headings(
     the chunks up by ``chunk_id`` in text_chunks storage and attach the parent
     heading path. Only chunks that actually have parent headings get the field,
     so empty paths are omitted from the JSON sent to the LLM.
+
+    Each level is char-capped inside ``format_parent_headings`` and the joined
+    path is token-budgeted against ``DEFAULT_MAX_SECTION_CONTEXT_TOKENS`` here —
+    mirroring the extraction breadcrumb (see ``_truncate_section_context``). The
+    query-context token truncation only keeps/drops whole chunks; it never trims
+    this metadata inside a retained chunk, so a deep heading chain (the per-level
+    cap bounds each level's length, not the number of levels) is bounded here.
     """
     if not text_chunks_db or not chunks:
         return
+    tokenizer = text_chunks_db.global_config.get("tokenizer")
     chunk_ids = [c.get("chunk_id") for c in chunks]
     chunk_data_list = await text_chunks_db.get_by_ids(chunk_ids)
     for chunk, data in zip(chunks, chunk_data_list):
         if not isinstance(data, dict):
             continue
-        headings = format_parent_headings(data)
+        headings = _truncate_section_context(
+            format_parent_headings(data),
+            tokenizer,
+            DEFAULT_MAX_SECTION_CONTEXT_TOKENS,
+        )
         if headings:
             chunk["content_headings"] = headings
 

--- a/tests/extraction/test_entity_extraction_stability.py
+++ b/tests/extraction/test_entity_extraction_stability.py
@@ -1479,6 +1479,69 @@ def test_format_parent_headings_basic_behavior_preserved():
     assert format_parent_headings(chunk) == "h1 → h2"  # leaf NOT appended
 
 
+class _FakeChunksDB:
+    """Minimal text_chunks_db for _attach_content_headings: get_by_ids + config."""
+
+    def __init__(self, data_by_id: dict, tokenizer):
+        self._data = data_by_id
+        self.global_config = {"tokenizer": tokenizer}
+
+    async def get_by_ids(self, ids):
+        return [self._data.get(i) for i in ids]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_attach_content_headings_token_budgets_deep_path():
+    """A deep heading chain (per-level cap bounds length, not count) is collapsed
+    to fit DEFAULT_MAX_SECTION_CONTEXT_TOKENS, mirroring the extraction stage."""
+    from lightrag.chunk_schema import HEADING_BREADCRUMB_SEP
+    from lightrag.constants import DEFAULT_MAX_SECTION_CONTEXT_TOKENS
+    from lightrag.operate import _attach_content_headings
+
+    tok = Tokenizer("dummy", DummyTokenizer())  # 1 char == 1 token
+    deep = [f"Level{i:02d}" for i in range(100)]  # well over the token budget
+    db = _FakeChunksDB(
+        {"c1": {"heading": {"level": 99, "heading": "Leaf", "parent_headings": deep}}},
+        tok,
+    )
+    chunks = [{"chunk_id": "c1"}]
+
+    await _attach_content_headings(chunks, db)
+
+    out = chunks[0]["content_headings"]
+    assert len(tok.encode(out)) <= DEFAULT_MAX_SECTION_CONTEXT_TOKENS
+    # Collapsed to first → … → leaf, so a middle level is gone.
+    assert f"{HEADING_BREADCRUMB_SEP}…{HEADING_BREADCRUMB_SEP}" in out
+    assert "Level50" not in out
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_attach_content_headings_keeps_short_path_intact():
+    """A within-budget path is attached unchanged (no token collapsing)."""
+    from lightrag.operate import _attach_content_headings
+
+    tok = Tokenizer("dummy", DummyTokenizer())
+    db = _FakeChunksDB(
+        {
+            "c1": {
+                "heading": {
+                    "level": 2,
+                    "heading": "Leaf",
+                    "parent_headings": ["h1", "h2"],
+                }
+            }
+        },
+        tok,
+    )
+    chunks = [{"chunk_id": "c1"}]
+
+    await _attach_content_headings(chunks, db)
+
+    assert chunks[0]["content_headings"] == "h1 → h2"
+
+
 @pytest.mark.offline
 def test_truncate_section_context_noop_within_budget():
     from lightrag.operate import _truncate_section_context

--- a/tests/extraction/test_entity_extraction_stability.py
+++ b/tests/extraction/test_entity_extraction_stability.py
@@ -1409,6 +1409,76 @@ def test_format_heading_context_per_level_cap_can_be_disabled():
     assert format_heading_context(chunk, max_heading_len=0) == long_title
 
 
+# ---------------------------------------------------------------------------
+# Query-stage format_parent_headings: same per-level cap + cleaning as extraction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.offline
+def test_format_parent_headings_caps_long_level():
+    """A runaway parent heading is truncated to the per-level char cap, matching
+    the extraction-stage format_heading_context."""
+    from lightrag.chunk_schema import (
+        DEFAULT_HEADING_LEVEL_MAX_CHARS,
+        format_parent_headings,
+    )
+
+    long_title = "A" * (DEFAULT_HEADING_LEVEL_MAX_CHARS + 50)
+    chunk = {
+        "heading": {"level": 2, "heading": "Leaf", "parent_headings": [long_title]}
+    }
+
+    out = format_parent_headings(chunk)
+    assert out.endswith("…")
+    assert len(out) == DEFAULT_HEADING_LEVEL_MAX_CHARS  # only the parent, capped
+
+
+@pytest.mark.offline
+def test_format_parent_headings_per_level_cap_can_be_disabled():
+    from lightrag.chunk_schema import format_parent_headings
+
+    long_title = "B" * 300
+    chunk = {
+        "heading": {"level": 2, "heading": "Leaf", "parent_headings": [long_title]}
+    }
+
+    assert format_parent_headings(chunk, max_heading_len=0) == long_title
+
+
+@pytest.mark.offline
+def test_format_parent_headings_cleaning_matches_extraction():
+    """Parent headings get the same cleaning as extraction: → folded to a space,
+    Cc/Cf control chars stripped (shared _clean_heading_text)."""
+    from lightrag.chunk_schema import format_parent_headings
+
+    # chr(0) is a Cc control; chr(0x200B) is ZWSP (Cf) — both stripped. Built
+    # via chr() so the source carries no literal invisible characters.
+    second_level = "x" + chr(0) + "y" + chr(0x200B) + "z"
+    chunk = {
+        "heading": {
+            "level": 2,
+            "heading": "Leaf",
+            "parent_headings": ["A→B", second_level],
+        }
+    }
+    # "A→B" -> "A B"; control + format chars removed from the second level.
+    assert format_parent_headings(chunk) == "A B → xyz"
+
+
+@pytest.mark.offline
+def test_format_parent_headings_basic_behavior_preserved():
+    """Existing behavior is unchanged: empty when no heading, normal multi-level
+    path joined with the breadcrumb separator."""
+    from lightrag.chunk_schema import format_parent_headings
+
+    assert format_parent_headings({"content": "...", "chunk_order_index": 0}) == ""
+
+    chunk = {
+        "heading": {"level": 2, "heading": "Leaf", "parent_headings": ["h1", "h2"]}
+    }
+    assert format_parent_headings(chunk) == "h1 → h2"  # leaf NOT appended
+
+
 @pytest.mark.offline
 def test_truncate_section_context_noop_within_budget():
     from lightrag.operate import _truncate_section_context


### PR DESCRIPTION
## What

Bring the **query-stage** heading breadcrumb (`format_parent_headings` → the `content_headings` field injected into the query context JSON) in line with the **extraction-stage** breadcrumb introduced in #3225, on **two** axes: per-level char cap **and** joined-path token budget.

## Why

`format_parent_headings` already shared `_clean_heading_text` with the extraction breadcrumb, so once #3225 lands the **text cleaning** (`→`→space, strip Cc/Cf control/format chars) is already identical across both stages. Two gaps remained:

1. **Per-level length bounding**: `format_heading_context` caps each heading level at `DEFAULT_HEADING_LEVEL_MAX_CHARS`, but `format_parent_headings` did not — so a single runaway heading could enter the query context JSON verbatim.
2. **Joined-path token budget**: even with each level capped, a *deep* heading chain (many levels) could still bloat the JSON. The extraction stage already token-budgets its breadcrumb via `_truncate_section_context`; the query stage did not.

## How

- New shared helper `_clean_and_cap_headings(headings, max_heading_len)` (clean → drop empties → per-level cap), now used by **both** `format_parent_headings` and `format_heading_context`. This removes the near-duplicate bodies and prevents the two stages from drifting apart again.
- `format_parent_headings` gains `*, max_heading_len=DEFAULT_HEADING_LEVEL_MAX_CHARS`, matching `format_heading_context`.
- `_attach_content_headings` now wraps `format_parent_headings(...)` in `_truncate_section_context(..., tokenizer, DEFAULT_MAX_SECTION_CONTEXT_TOKENS)`, mirroring the extraction call site. The tokenizer comes from `text_chunks_db.global_config`; a missing tokenizer disables the cap (graceful degradation — the per-level char cap still applies).

## Why the joined-path token budget is needed (not just the per-level cap)

`content_headings` is attached **before** the query-context token truncation (see the "before token truncation so it counts toward the budget" comments at the two `_attach_content_headings` call sites), so the breadcrumb **does** count toward the overall budget. But that overall truncation only keeps/drops **whole chunks** — it never trims this metadata *inside* a retained chunk. So a single retained chunk with a deep heading chain could still push the JSON oversized on its own. The per-level char cap bounds each level's *length* but not the *number* of levels, so the joined-path token budget is the backstop that bounds the chain depth — exactly mirroring `_truncate_section_context` on the extraction side.

## Tests

Added to `tests/extraction/test_entity_extraction_stability.py`:
- `format_parent_headings` per-level cap applied / can be disabled (`max_heading_len=0`).
- Cleaning parity: `→` folded, Cc/Cf stripped (shared `_clean_heading_text`).
- Existing behavior preserved: empty when no heading; normal multi-level path; leaf NOT appended.
- `_attach_content_headings` token-budgets a deep path (collapses to `first → … → leaf`) and leaves a within-budget path intact.
- `format_heading_context` regression suite still green after the helper refactor.

`tests/extraction`: **91 passed**. `pre-commit run ruff-format` / `ruff`: clean.

## Note

Stacked on #3225 (base = `feat/extract-section-context-heading`) because `_truncate_heading_level`, `DEFAULT_HEADING_LEVEL_MAX_CHARS`, and the upgraded `_clean_heading_text` all live there and are not yet on `main`. Will retarget/rebase onto `main` once #3225 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
