### PR TITLE
fix(webui): prevent double-click on Send from aborting the query

### DIFF
--- a/lightrag_webui/src/features/RetrievalView.tsx
+++ b/lightrag_webui/src/features/RetrievalView.tsx
@@ -139,6 +139,11 @@ export default function RetrievalView() {
   })
   const [inputValue, setInputValue] = useState('')
   const [isLoading, setIsLoading] = useState(false)
+  // Briefly disable the Stop button right after a query starts so a fast
+  // double-click on Send (which morphs into Stop at the same position) can't
+  // accidentally abort the query it just launched.
+  const [stopDisabled, setStopDisabled] = useState(false)
+  const stopCooldownTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [inputError, setInputError] = useState('') // Error message for input
   const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null)
 
@@ -255,6 +260,13 @@ export default function RetrievalView() {
       // Clear input and set loading
       setInputValue('')
       setIsLoading(true)
+      // Disable the Stop button for a short cooldown so a fast double-click on
+      // Send doesn't immediately abort this query. Set synchronously (same batch
+      // as setIsLoading) so the Stop button is already disabled on its first
+      // paint, leaving no enabled gap for the second click to land in.
+      setStopDisabled(true)
+      if (stopCooldownTimerRef.current) clearTimeout(stopCooldownTimerRef.current)
+      stopCooldownTimerRef.current = setTimeout(() => setStopDisabled(false), 500)
 
       // Reset input height to minimum after clearing input
       if (inputRef.current) {
@@ -557,6 +569,10 @@ export default function RetrievalView() {
       if (thinkingStartTime.current) {
         thinkingStartTime.current = null;
       }
+      if (stopCooldownTimerRef.current) {
+        clearTimeout(stopCooldownTimerRef.current);
+        stopCooldownTimerRef.current = null;
+      }
     };
   }, []);
 
@@ -688,6 +704,12 @@ export default function RetrievalView() {
     thinkingProcessed.current = false
 
     setIsLoading(false)
+    // Cancel any pending Stop-button cooldown and reset it for the next query.
+    if (stopCooldownTimerRef.current) {
+      clearTimeout(stopCooldownTimerRef.current)
+      stopCooldownTimerRef.current = null
+    }
+    setStopDisabled(false)
     // eslint-disable-next-line react-hooks/immutability
     isReceivingResponseRef.current = false
   }, [messages, setMessages])
@@ -880,7 +902,7 @@ export default function RetrievalView() {
             )}
           </div>
           {isLoading ? (
-            <Button type="button" variant="destructive" onClick={handleStop} size="sm">
+            <Button type="button" variant="destructive" onClick={handleStop} disabled={stopDisabled} size="sm">
               <SquareIcon />
               {t('retrievePanel.retrieval.stop')}
             </Button>


### PR DESCRIPTION
## Description

In the Retrieval panel, the **Send** button and the **Stop** button occupy the same position and swap based on `isLoading`. Clicking Send synchronously sets `isLoading = true` and assigns the `AbortController`. Because a React re-render (~16ms) is far faster than a typical double-click interval (~200–500ms), a fast double-click on Send lands its **second** click on the freshly-rendered Stop button and immediately aborts the query that was just launched.

There was previously no guard against this: `handleSubmit` only guards re-submission, and `handleStop` proceeds because the controller is already set.

This PR disables the Stop button for a short **500ms cooldown** right after a query starts, so an accidental second click can't terminate the query.

## Related Issues

N/A — small UX fix.

## Changes Made

In `lightrag_webui/src/features/RetrievalView.tsx`:

- Added a `stopDisabled` state and a `stopCooldownTimerRef` timer ref.
- In `handleSubmit`, set `stopDisabled = true` **synchronously** alongside `setIsLoading(true)` (same render batch), so the Stop button is already disabled on its first paint — no enabled gap for the second click to land in. A 500ms timer then re-enables it.
- In `handleStop`, clear the pending cooldown timer and reset `stopDisabled` for the next query.
- Cleared the timer in the unmount cleanup effect to avoid leaks / post-unmount `setState`.
- Applied `disabled={stopDisabled}` to the Stop button, reusing `Button`'s existing `disabled:opacity-50 disabled:pointer-events-none` styling.

The second click during the cooldown is harmlessly absorbed by `pointer-events-none` (the area behind has no actionable `onClick`). 500ms is well under any intentional-stop reaction time, so normal aborts are unaffected.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

`tsc --noEmit` and `eslint` both pass clean. No new strings or styles were introduced. Manual test: a fast double-click on Send now keeps the query running (Stop shows a brief half-transparent disabled state); waiting ~1s and clicking Stop aborts as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
