### PR TITLE
fix: make extraction prompt examples format-only

### DIFF
--- a/lightrag/prompt.py
+++ b/lightrag/prompt.py
@@ -56,7 +56,7 @@ You are a Knowledge Graph Specialist responsible for extracting entities and rel
 
 ---Instructions---
 1. **Entity Extraction:**
-  - Identify clearly defined and meaningful entities in the `---Input Text---` section of user prompt.
+  - Identify clearly defined and meaningful entities only in the current user prompt's fenced `---Input Text---` section.
   - For each entity, extract:
     - `entity_name`: The name of the entity. If the entity name is case-insensitive, capitalize the first letter of each significant word (title case). Ensure **consistent naming** across the entire extraction process.
     - `entity_type`: Categorize the entity using the type guidance provided in the `---Entity Types---` section below. If none of the provided entity types apply, classify it as `Other`.
@@ -80,13 +80,13 @@ You are a Knowledge Graph Specialist responsible for extracting entities and rel
 4. **Output Format:**
   - Entity row: `entity{tuple_delimiter}entity_name{tuple_delimiter}entity_type{tuple_delimiter}entity_description`
   - Relation row: `relation{tuple_delimiter}source_entity{tuple_delimiter}target_entity{tuple_delimiter}relationship_keywords{tuple_delimiter}relationship_description`
-  - Wrong: `entity{tuple_delimiter}Alice{tuple_delimiter}Acme{tuple_delimiter}founded{tuple_delimiter}Alice founded Acme`
-  - Correct: `relation{tuple_delimiter}Alice{tuple_delimiter}Acme{tuple_delimiter}founded{tuple_delimiter}Alice founded Acme`
+  - Wrong: `entity{tuple_delimiter}<source_entity>{tuple_delimiter}<target_entity>{tuple_delimiter}<relationship_keywords>{tuple_delimiter}<relationship_description>`
+  - Correct: `relation{tuple_delimiter}<source_entity>{tuple_delimiter}<target_entity>{tuple_delimiter}<relationship_keywords>{tuple_delimiter}<relationship_description>`
 
 5. **Delimiter Usage:**
   - The `{tuple_delimiter}` is a complete, atomic marker and **must not be filled with content**. It serves strictly as a field separator.
-  - Incorrect: `entity{tuple_delimiter}Tokyo<|location|>Tokyo is the capital of Japan.`
-  - Correct: `entity{tuple_delimiter}Tokyo{tuple_delimiter}location{tuple_delimiter}Tokyo is the capital of Japan.`
+  - Incorrect: `entity{tuple_delimiter}<entity_name><|entity_type|><entity_description>`
+  - Correct: `entity{tuple_delimiter}<entity_name>{tuple_delimiter}<entity_type>{tuple_delimiter}<entity_description>`
 
 6. **Output Order & Deduplication:**
   - Output all extracted entities first, followed by all extracted relationships.
@@ -106,17 +106,24 @@ You are a Knowledge Graph Specialist responsible for extracting entities and rel
   - The entire output (entity names, keywords, and descriptions) must be written in `{language}`.
   - Proper nouns (e.g., personal names, place names, organization names) should be retained in their original language if a proper, widely accepted translation is not available or would cause ambiguity.
 
-8. **Completion Signal:** Output the literal string `{completion_delimiter}` only after all entities and relationships have been completely extracted and outputted.
+8. **Output Format Template Safety:**
+  - The `---Output Format Template---` section contains output format templates only. It is never source text.
+  - Do not extract, infer, or copy entities or relationships from the output format template.
+  - Angle-bracket tokens such as `<entity_name>` are placeholders. Replace them with values extracted from the current `---Input Text---` section and never output the placeholders literally.
+
+9. **Completion Signal:** Output the literal string `{completion_delimiter}` only after all entities and relationships have been completely extracted and outputted.
 
 ---Entity Types---
 {entity_types_guidance}
 
----Examples---
+---Output Format Template---
+The following content is an output format template only. It is not source text and must never be used as extraction content.
+
 {examples}
 """
 
 PROMPTS["entity_extraction_user_prompt"] = """---Task---
-Extract entities and relationships from the `---Input Text---` session below.
+Extract entities and relationships from the `---Input Text---` section below.
 
 ---Instructions---
 1. **Strict Adherence to Format:** Strictly adhere to all format requirements for entity and relationship lists, including output order, field delimiters, and proper noun handling, as specified in the system prompt.
@@ -152,102 +159,9 @@ Based on the last extraction task, identify and extract any missed or incorrectl
 """
 
 PROMPTS["entity_extraction_examples"] = [
-    """---Entity Types---
-- Person: Human individuals, real or fictional
-- Artifact: Physical or digital objects created by humans (tools, software, devices)
-- Concept: Abstract ideas, theories, principles, beliefs
-
----Input Text---
-```
-while Alex clenched his jaw, the buzz of frustration dull against the backdrop of Taylor's authoritarian certainty. It was this competitive undercurrent that kept him alert, the sense that his and Jordan's shared commitment to discovery was an unspoken rebellion against Cruz's narrowing vision of control and order.
-
-Then Taylor did something unexpected. They paused beside Jordan and, for a moment, observed the device with something akin to reverence. "If this tech can be understood..." Taylor said, their voice quieter, "It could change the game for us. For all of us."
-
-The underlying dismissal earlier seemed to falter, replaced by a glimpse of reluctant respect for the gravity of what lay in their hands. Jordan looked up, and for a fleeting heartbeat, their eyes locked with Taylor's, a wordless clash of wills softening into an uneasy truce.
-
-It was a small transformation, barely perceptible, but one that Alex noted with an inward nod. They had all been brought here by different paths
-```
-
----Output---
-entity{tuple_delimiter}Alex{tuple_delimiter}Person{tuple_delimiter}Alex is a character who experiences frustration and is observant of the dynamics among other characters.
-entity{tuple_delimiter}Taylor{tuple_delimiter}Person{tuple_delimiter}Taylor is portrayed with authoritarian certainty and shows a moment of reverence towards a device, indicating a change in perspective.
-entity{tuple_delimiter}Jordan{tuple_delimiter}Person{tuple_delimiter}Jordan shares a commitment to discovery and has a significant interaction with Taylor regarding a device.
-entity{tuple_delimiter}Cruz{tuple_delimiter}Person{tuple_delimiter}Cruz is associated with a vision of control and order, influencing the dynamics among other characters.
-entity{tuple_delimiter}The Device{tuple_delimiter}Artifact{tuple_delimiter}The Device is central to the story, with potential game-changing implications, and is revered by Taylor.
-entity{tuple_delimiter}Discovery{tuple_delimiter}Concept{tuple_delimiter}Discovery represents the shared intellectual pursuit that unites Jordan and Alex in opposition to Cruz's controlling worldview.
-relation{tuple_delimiter}Alex{tuple_delimiter}Taylor{tuple_delimiter}power dynamics, observation{tuple_delimiter}Alex observes Taylor's authoritarian behavior and notes changes in Taylor's attitude toward the device.
-relation{tuple_delimiter}Alex{tuple_delimiter}Jordan{tuple_delimiter}shared goals, rebellion{tuple_delimiter}Alex and Jordan share a commitment to discovery, which contrasts with Cruz's vision.)
-relation{tuple_delimiter}Taylor{tuple_delimiter}Jordan{tuple_delimiter}conflict resolution, mutual respect{tuple_delimiter}Taylor and Jordan interact directly regarding the device, leading to a moment of mutual respect and an uneasy truce.
-relation{tuple_delimiter}Jordan{tuple_delimiter}Cruz{tuple_delimiter}ideological conflict, rebellion{tuple_delimiter}Jordan's commitment to discovery is in rebellion against Cruz's vision of control and order.
-relation{tuple_delimiter}Taylor{tuple_delimiter}The Device{tuple_delimiter}reverence, technological significance{tuple_delimiter}Taylor shows reverence towards the device, indicating its importance and potential impact.
+    """entity{tuple_delimiter}<entity_name>{tuple_delimiter}<entity_type>{tuple_delimiter}<entity_description>
+relation{tuple_delimiter}<source_entity>{tuple_delimiter}<target_entity>{tuple_delimiter}<relationship_keywords>{tuple_delimiter}<relationship_description>
 {completion_delimiter}
-
-""",
-    """---Entity Types---
-- Person: Human individuals, real or fictional
-- Location: Geographic places (cities, countries, buildings, regions)
-- Creature: Non-human living beings (animals, mythical beings, etc.)
-- Method: Procedures, techniques, algorithms, workflows
-- Organization: Companies, institutions, government bodies, groups
-- Content: Creative or informational works (books, articles, films, reports)
-- NaturalObject: Natural non-living objects (minerals, celestial bodies, chemical compounds)
-
----Input Text---
-```
-Dr. Elena Vasquez led a field expedition to the Borneo rainforest to document the population decline of the Bornean orangutan. Using transect sampling — a method where researchers walk predetermined line paths and record every animal sighting within a fixed distance — her team estimated that fewer than 1,500 individuals remained in the surveyed region.
-
-The expedition was funded by the Global Wildlife Conservation Institute and produced a landmark report titled "Primate Decline in Insular Southeast Asia." Vasquez attributed the collapse primarily to peat-soil destruction caused by palm oil plantation expansion, which had converted over 40% of the surveyed forest area within a decade.
-```
-
----Output---
-entity{tuple_delimiter}Dr. Elena Vasquez{tuple_delimiter}Person{tuple_delimiter}Dr. Elena Vasquez is a field researcher who led an expedition to document orangutan population decline in Borneo.
-entity{tuple_delimiter}Borneo Rainforest{tuple_delimiter}Location{tuple_delimiter}The Borneo rainforest is the field site of the expedition and the primary habitat of the Bornean orangutan.
-entity{tuple_delimiter}Bornean Orangutan{tuple_delimiter}Creature{tuple_delimiter}The Bornean orangutan is a primate species whose population was found to have declined to fewer than 1,500 individuals in the surveyed region.
-entity{tuple_delimiter}Transect Sampling{tuple_delimiter}Method{tuple_delimiter}Transect sampling is a wildlife survey technique where researchers walk predetermined paths and record animal sightings within a fixed lateral distance.
-entity{tuple_delimiter}Global Wildlife Conservation Institute{tuple_delimiter}Organization{tuple_delimiter}The Global Wildlife Conservation Institute funded the expedition led by Dr. Vasquez.
-entity{tuple_delimiter}Primate Decline in Insular Southeast Asia{tuple_delimiter}Content{tuple_delimiter}A landmark research report produced by Vasquez's expedition documenting primate population decline in the region.
-entity{tuple_delimiter}Peat Soil{tuple_delimiter}NaturalObject{tuple_delimiter}Peat soil is a natural substrate in the Borneo rainforest that has been destroyed by palm oil plantation expansion.
-relation{tuple_delimiter}Dr. Elena Vasquez{tuple_delimiter}Bornean Orangutan{tuple_delimiter}field research, population survey{tuple_delimiter}Dr. Vasquez led the expedition that documented the population decline of the Bornean orangutan.
-relation{tuple_delimiter}Dr. Elena Vasquez{tuple_delimiter}Transect Sampling{tuple_delimiter}methodology, research application{tuple_delimiter}Dr. Vasquez's team used transect sampling to estimate the orangutan population.
-relation{tuple_delimiter}Global Wildlife Conservation Institute{tuple_delimiter}Dr. Elena Vasquez{tuple_delimiter}funding, research support{tuple_delimiter}The institute funded the expedition led by Dr. Vasquez.
-relation{tuple_delimiter}Dr. Elena Vasquez{tuple_delimiter}Primate Decline in Insular Southeast Asia{tuple_delimiter}authorship, research output{tuple_delimiter}Dr. Vasquez's expedition produced the landmark report on primate decline.
-relation{tuple_delimiter}Peat Soil{tuple_delimiter}Borneo Rainforest{tuple_delimiter}habitat composition, ecological destruction{tuple_delimiter}Peat soil destruction in the Borneo rainforest was caused by palm oil plantation expansion and is a primary driver of orangutan decline.
-{completion_delimiter}
-
-""",
-    """---Entity Types---
-- Content: Creative or informational works (books, articles, films, reports)
-- Artifact: Physical or digital objects created by humans (tools, software, devices)
-- Person: Human individuals, real or fictional
-- Organization: Companies, institutions, government bodies, groups
-- Method: Procedures, techniques, algorithms, workflows
-- Data: Quantitative or structured information (statistics, datasets, measurements)
-- Concept: Abstract ideas, theories, principles, beliefs
-
----Input Text---
-```
-The 2023 edition of "Advances in Neural Architecture Search" synthesized findings from over 200 peer-reviewed papers and introduced a new benchmarking framework called NASBench-360, designed to evaluate search algorithms across diverse task domains. The publication was co-authored by Dr. Priya Nair and Dr. Luca Ferretti of the DeepSystems Research Lab.
-
-NASBench-360 measures three key metrics: search efficiency (time-to-solution), model accuracy on held-out test sets, and computational cost in GPU-hours. Early results showed that evolutionary search algorithms outperformed gradient-based methods by 12% on accuracy while consuming 30% fewer GPU-hours on vision tasks.
-```
-
----Output---
-entity{tuple_delimiter}Advances in Neural Architecture Search{tuple_delimiter}Content{tuple_delimiter}A 2023 publication that synthesizes findings from over 200 papers and introduces the NASBench-360 benchmarking framework.
-entity{tuple_delimiter}NASBench-360{tuple_delimiter}Artifact{tuple_delimiter}NASBench-360 is a benchmarking framework introduced to evaluate neural architecture search algorithms across diverse task domains.
-entity{tuple_delimiter}Dr. Priya Nair{tuple_delimiter}Person{tuple_delimiter}Dr. Priya Nair is a co-author of the publication and a researcher at the DeepSystems Research Lab.
-entity{tuple_delimiter}Dr. Luca Ferretti{tuple_delimiter}Person{tuple_delimiter}Dr. Luca Ferretti is a co-author of the publication and a researcher at the DeepSystems Research Lab.
-entity{tuple_delimiter}DeepSystems Research Lab{tuple_delimiter}Organization{tuple_delimiter}The DeepSystems Research Lab is the institution where the co-authors of the publication are affiliated.
-entity{tuple_delimiter}Evolutionary Search{tuple_delimiter}Method{tuple_delimiter}Evolutionary search is a class of neural architecture search algorithms that outperformed gradient-based methods in the NASBench-360 evaluation.
-entity{tuple_delimiter}Gradient-Based Search{tuple_delimiter}Method{tuple_delimiter}Gradient-based search is a class of neural architecture search algorithms that was benchmarked against evolutionary search in NASBench-360.
-entity{tuple_delimiter}GPU-Hours{tuple_delimiter}Data{tuple_delimiter}GPU-hours is a metric used in NASBench-360 to measure the computational cost of neural architecture search algorithms.
-entity{tuple_delimiter}Neural Architecture Search{tuple_delimiter}Concept{tuple_delimiter}Neural architecture search is the automated process of designing optimal neural network architectures, the central topic of the publication.
-relation{tuple_delimiter}Dr. Priya Nair{tuple_delimiter}Advances in Neural Architecture Search{tuple_delimiter}authorship{tuple_delimiter}Dr. Priya Nair co-authored the publication.
-relation{tuple_delimiter}Dr. Luca Ferretti{tuple_delimiter}Advances in Neural Architecture Search{tuple_delimiter}authorship{tuple_delimiter}Dr. Luca Ferretti co-authored the publication.
-relation{tuple_delimiter}Advances in Neural Architecture Search{tuple_delimiter}NASBench-360{tuple_delimiter}introduces, benchmarking{tuple_delimiter}The publication introduced the NASBench-360 framework.
-relation{tuple_delimiter}Evolutionary Search{tuple_delimiter}Gradient-Based Search{tuple_delimiter}performance comparison{tuple_delimiter}Evolutionary search outperformed gradient-based methods by 12% on accuracy and used 30% fewer GPU-hours on vision tasks.
-relation{tuple_delimiter}NASBench-360{tuple_delimiter}GPU-Hours{tuple_delimiter}evaluation metric{tuple_delimiter}NASBench-360 uses GPU-hours as one of three key metrics to measure computational cost.
-{completion_delimiter}
-
 """,
 ]
 
@@ -257,11 +171,11 @@ relation{tuple_delimiter}NASBench-360{tuple_delimiter}GPU-Hours{tuple_delimiter}
 ###############################################################################
 
 PROMPTS["entity_extraction_json_system_prompt"] = """---Role---
-You are a Knowledge Graph Specialist responsible for extracting entities and relationships from the `---Input Text---` session of user prompt.
+You are a Knowledge Graph Specialist responsible for extracting entities and relationships from the `---Input Text---` section of user prompt.
 
 ---Instructions---
 1. **Entity Extraction:**
-  - **Identification:** Identify clearly defined and meaningful entities in the `---Input Text---` session of user prompt.
+  - **Identification:** Identify clearly defined and meaningful entities only in the current user prompt's fenced `---Input Text---` section.
   - **Entity Details:** For each identified entity, extract the following information:
     - `name`: The name of the entity. If the entity name is case-insensitive, capitalize the first letter of each significant word (title case). Ensure **consistent naming** across the entire extraction process.
     - `type`: Categorize the entity using the type guidance provided in the `---Entity Types---` section below. If none of the provided entity types apply, classify it as `Other`.
@@ -270,7 +184,7 @@ You are a Knowledge Graph Specialist responsible for extracting entities and rel
 2. **Relationship Extraction:**
   - **Identification:** Identify direct, clearly stated, and meaningful relationships between previously extracted entities.
   - **N-ary Relationship Decomposition:** If a single statement describes a relationship involving more than two entities (an N-ary relationship), decompose it into multiple binary (two-entity) relationship pairs for separate description.
-    - Example: For "Alice, Bob, and Carol collaborated on Project X," extract binary relationships such as "Alice collaborated with Project X," "Bob collaborated with Project X," and "Carol collaborated with Project X," or "Alice collaborated with Bob," based on the most reasonable binary interpretations.
+    - Example pattern: for "<person_1>, <person_2>, and <person_3> collaborated on <project_name>", extract binary relationships between each participant and the project, or between participants when that is the most reasonable interpretation.
   - **Relationship Details:** For each binary relationship, extract the following fields:
     - `source`: The name of the source entity. Ensure **consistent naming** with entity extraction. Capitalize the first letter of each significant word (title case) if the name is case-insensitive.
     - `target`: The name of the target entity. Ensure **consistent naming** with entity extraction. Capitalize the first letter of each significant word (title case) if the name is case-insensitive.
@@ -301,15 +215,22 @@ You are a Knowledge Graph Specialist responsible for extracting entities and rel
   - Return one valid JSON object with `entities` and `relationships` arrays only.
   - If the record limit is reached, stop adding new objects immediately and return the JSON object with the allowed items only.
 
+8. **Output Format Template Safety:**
+  - The `---Output Format Template---` section contains an output format template only. It is never source text.
+  - Do not extract, infer, or copy entities or relationships from the output format template.
+  - Angle-bracket tokens such as `<entity_name>` are placeholders. Replace them with values extracted from the current `---Input Text---` section and never output the placeholders literally.
+
 ---Entity Types---
 {entity_types_guidance}
 
----Examples---
+---Output Format Template---
+The following content is an output format template only. It is not source text and must never be used as extraction content.
+
 {examples}
 """
 
 PROMPTS["entity_extraction_json_user_prompt"] = """---Task---
-Extract entities and relationships from the `---Input Text---` session below.
+Extract entities and relationships from the `---Input Text---` section below.
 
 ---Instructions---
 1. **Strict Adherence to JSON Format:** Your output MUST be a valid JSON object with `entities` and `relationships` arrays. Do not include any introductory or concluding remarks, explanations, markdown code fences, or any other text before or after the JSON.
@@ -328,7 +249,7 @@ Extract entities and relationships from the `---Input Text---` session below.
 """
 
 PROMPTS["entity_continue_extraction_json_user_prompt"] = """---Task---
-Based on the last extraction task, identify and extract any **missed or incorrectly described** entities and relationships from the `---Input Text---` session.
+Based on the last extraction task, identify and extract any **missed or incorrectly described** entities and relationships from the `---Input Text---` section.
 
 ---Instructions---
 1. **Focus on Corrections/Additions:**
@@ -344,117 +265,28 @@ Based on the last extraction task, identify and extract any **missed or incorrec
 """
 
 PROMPTS["entity_extraction_json_examples"] = [
-    """---Entity Types---
-- Person: Human individuals, real or fictional
-- Artifact: Physical or digital objects created by humans (tools, software, devices)
-- Concept: Abstract ideas, theories, principles, beliefs
-
----Input Text---
-```
-while Alex clenched his jaw, the buzz of frustration dull against the backdrop of Taylor's authoritarian certainty. It was this competitive undercurrent that kept him alert, the sense that his and Jordan's shared commitment to discovery was an unspoken rebellion against Cruz's narrowing vision of control and order.
-
-Then Taylor did something unexpected. They paused beside Jordan and, for a moment, observed the device with something akin to reverence. "If this tech can be understood..." Taylor said, their voice quieter, "It could change the game for us. For all of us."
-
-The underlying dismissal earlier seemed to falter, replaced by a glimpse of reluctant respect for the gravity of what lay in their hands. Jordan looked up, and for a fleeting heartbeat, their eyes locked with Taylor's, a wordless clash of wills softening into an uneasy truce.
-
-It was a small transformation, barely perceptible, but one that Alex noted with an inward nod. They had all been brought here by different paths
-```
-
----Output---
-{
+    """{
   "entities": [
-    {"name": "Alex", "type": "Person", "description": "Alex is a character who experiences frustration and is observant of the dynamics among other characters."},
-    {"name": "Taylor", "type": "Person", "description": "Taylor is portrayed with authoritarian certainty and shows a moment of reverence towards a device, indicating a change in perspective."},
-    {"name": "Jordan", "type": "Person", "description": "Jordan shares a commitment to discovery and has a significant interaction with Taylor regarding a device."},
-    {"name": "Cruz", "type": "Person", "description": "Cruz is associated with a vision of control and order, influencing the dynamics among other characters."},
-    {"name": "The Device", "type": "Artifact", "description": "The Device is central to the story, with potential game-changing implications, and is revered by Taylor."},
-    {"name": "Discovery", "type": "Concept", "description": "Discovery represents the shared intellectual pursuit that unites Jordan and Alex in opposition to Cruz's controlling worldview."}
+    {
+      "name": "<entity_name>",
+      "type": "<entity_type>",
+      "description": "<entity_description>"
+    },
+    {
+      "name": "<related_entity_name>",
+      "type": "<related_entity_type>",
+      "description": "<related_entity_description>"
+    }
   ],
   "relationships": [
-    {"source": "Alex", "target": "Taylor", "keywords": "power dynamics, observation", "description": "Alex observes Taylor's authoritarian behavior and notes changes in Taylor's attitude toward the device."},
-    {"source": "Alex", "target": "Jordan", "keywords": "shared goals, rebellion", "description": "Alex and Jordan share a commitment to discovery, which contrasts with Cruz's vision."},
-    {"source": "Taylor", "target": "Jordan", "keywords": "conflict resolution, mutual respect", "description": "Taylor and Jordan interact directly regarding the device, leading to a moment of mutual respect and an uneasy truce."},
-    {"source": "Jordan", "target": "Cruz", "keywords": "ideological conflict, rebellion", "description": "Jordan's commitment to discovery is in rebellion against Cruz's vision of control and order."},
-    {"source": "Taylor", "target": "The Device", "keywords": "reverence, technological significance", "description": "Taylor shows reverence towards the device, indicating its importance and potential impact."}
+    {
+      "source": "<entity_name>",
+      "target": "<related_entity_name>",
+      "keywords": "<relationship_keywords>",
+      "description": "<relationship_description>"
+    }
   ]
 }
-
-""",
-    """---Entity Types---
-- Person: Human individuals, real or fictional
-- Location: Geographic places (cities, countries, buildings, regions)
-- Creature: Non-human living beings (animals, mythical beings, etc.)
-- Method: Procedures, techniques, algorithms, workflows
-- Organization: Companies, institutions, government bodies, groups
-- Content: Creative or informational works (books, articles, films, reports)
-- NaturalObject: Natural non-living objects (minerals, celestial bodies, chemical compounds)
-
----Input Text---
-```
-Dr. Elena Vasquez led a field expedition to the Borneo rainforest to document the population decline of the Bornean orangutan. Using transect sampling — a method where researchers walk predetermined line paths and record every animal sighting within a fixed distance — her team estimated that fewer than 1,500 individuals remained in the surveyed region.
-
-The expedition was funded by the Global Wildlife Conservation Institute and produced a landmark report titled "Primate Decline in Insular Southeast Asia." Vasquez attributed the collapse primarily to peat-soil destruction caused by palm oil plantation expansion, which had converted over 40% of the surveyed forest area within a decade.
-```
-
----Output---
-{
-  "entities": [
-    {"name": "Dr. Elena Vasquez", "type": "Person", "description": "Dr. Elena Vasquez is a field researcher who led an expedition to document orangutan population decline in Borneo."},
-    {"name": "Borneo Rainforest", "type": "Location", "description": "The Borneo rainforest is the field site of the expedition and the primary habitat of the Bornean orangutan."},
-    {"name": "Bornean Orangutan", "type": "Creature", "description": "The Bornean orangutan is a primate species whose population was found to have declined to fewer than 1,500 individuals in the surveyed region."},
-    {"name": "Transect Sampling", "type": "Method", "description": "Transect sampling is a wildlife survey technique where researchers walk predetermined paths and record animal sightings within a fixed lateral distance."},
-    {"name": "Global Wildlife Conservation Institute", "type": "Organization", "description": "The Global Wildlife Conservation Institute funded the expedition led by Dr. Vasquez."},
-    {"name": "Primate Decline in Insular Southeast Asia", "type": "Content", "description": "A landmark research report produced by Vasquez's expedition documenting primate population decline in the region."},
-    {"name": "Peat Soil", "type": "NaturalObject", "description": "Peat soil is a natural substrate in the Borneo rainforest that has been destroyed by palm oil plantation expansion."}
-  ],
-  "relationships": [
-    {"source": "Dr. Elena Vasquez", "target": "Bornean Orangutan", "keywords": "field research, population survey", "description": "Dr. Vasquez led the expedition that documented the population decline of the Bornean orangutan."},
-    {"source": "Dr. Elena Vasquez", "target": "Transect Sampling", "keywords": "methodology, research application", "description": "Dr. Vasquez's team used transect sampling to estimate the orangutan population."},
-    {"source": "Global Wildlife Conservation Institute", "target": "Dr. Elena Vasquez", "keywords": "funding, research support", "description": "The institute funded the expedition led by Dr. Vasquez."},
-    {"source": "Dr. Elena Vasquez", "target": "Primate Decline in Insular Southeast Asia", "keywords": "authorship, research output", "description": "Dr. Vasquez's expedition produced the landmark report on primate decline."},
-    {"source": "Peat Soil", "target": "Borneo Rainforest", "keywords": "habitat composition, ecological destruction", "description": "Peat soil destruction in the Borneo rainforest was caused by palm oil plantation expansion and is a primary driver of orangutan decline."}
-  ]
-}
-
-""",
-    """---Entity Types---
-- Content: Creative or informational works (books, articles, films, reports)
-- Artifact: Physical or digital objects created by humans (tools, software, devices)
-- Person: Human individuals, real or fictional
-- Organization: Companies, institutions, government bodies, groups
-- Method: Procedures, techniques, algorithms, workflows
-- Data: Quantitative or structured information (statistics, datasets, measurements)
-- Concept: Abstract ideas, theories, principles, beliefs
-
----Input Text---
-```
-The 2023 edition of "Advances in Neural Architecture Search" synthesized findings from over 200 peer-reviewed papers and introduced a new benchmarking framework called NASBench-360, designed to evaluate search algorithms across diverse task domains. The publication was co-authored by Dr. Priya Nair and Dr. Luca Ferretti of the DeepSystems Research Lab.
-
-NASBench-360 measures three key metrics: search efficiency (time-to-solution), model accuracy on held-out test sets, and computational cost in GPU-hours. Early results showed that evolutionary search algorithms outperformed gradient-based methods by 12% on accuracy while consuming 30% fewer GPU-hours on vision tasks.
-```
-
----Output---
-{
-  "entities": [
-    {"name": "Advances in Neural Architecture Search", "type": "Content", "description": "A 2023 publication that synthesizes findings from over 200 papers and introduces the NASBench-360 benchmarking framework."},
-    {"name": "NASBench-360", "type": "Artifact", "description": "NASBench-360 is a benchmarking framework introduced to evaluate neural architecture search algorithms across diverse task domains."},
-    {"name": "Dr. Priya Nair", "type": "Person", "description": "Dr. Priya Nair is a co-author of the publication and a researcher at the DeepSystems Research Lab."},
-    {"name": "Dr. Luca Ferretti", "type": "Person", "description": "Dr. Luca Ferretti is a co-author of the publication and a researcher at the DeepSystems Research Lab."},
-    {"name": "DeepSystems Research Lab", "type": "Organization", "description": "The DeepSystems Research Lab is the institution where the co-authors of the publication are affiliated."},
-    {"name": "Evolutionary Search", "type": "Method", "description": "Evolutionary search is a class of neural architecture search algorithms that outperformed gradient-based methods in the NASBench-360 evaluation."},
-    {"name": "Gradient-Based Search", "type": "Method", "description": "Gradient-based search is a class of neural architecture search algorithms that was benchmarked against evolutionary search in NASBench-360."},
-    {"name": "GPU-Hours", "type": "Data", "description": "GPU-hours is a metric used in NASBench-360 to measure the computational cost of neural architecture search algorithms."},
-    {"name": "Neural Architecture Search", "type": "Concept", "description": "Neural architecture search is the automated process of designing optimal neural network architectures, the central topic of the publication."}
-  ],
-  "relationships": [
-    {"source": "Dr. Priya Nair", "target": "Advances in Neural Architecture Search", "keywords": "authorship", "description": "Dr. Priya Nair co-authored the publication."},
-    {"source": "Dr. Luca Ferretti", "target": "Advances in Neural Architecture Search", "keywords": "authorship", "description": "Dr. Luca Ferretti co-authored the publication."},
-    {"source": "Advances in Neural Architecture Search", "target": "NASBench-360", "keywords": "introduces, benchmarking", "description": "The publication introduced the NASBench-360 framework."},
-    {"source": "Evolutionary Search", "target": "Gradient-Based Search", "keywords": "performance comparison", "description": "Evolutionary search outperformed gradient-based methods by 12% on accuracy and used 30% fewer GPU-hours on vision tasks."},
-    {"source": "NASBench-360", "target": "GPU-Hours", "keywords": "evaluation metric", "description": "NASBench-360 uses GPU-hours as one of three key metrics to measure computational cost."}
-  ]
-}
-
 """,
 ]
 

--- a/lightrag/prompt.py
+++ b/lightrag/prompt.py
@@ -493,14 +493,17 @@ Given a user query, your task is to extract two distinct types of keywords:
    - `"high_level_keywords"`: an array of strings
    - `"low_level_keywords"`: an array of strings
 3. **JSON Boundary**: The first character of your response must be `{{` and the last character must be `}}`.
-4. **Source of Truth**: All keywords must be explicitly derived from the user query. Do not infer unsupported facts. Do not invent entities, products, organizations, dates, or technical terms that are not grounded in the query.
-5. **Concise & Meaningful**: Keywords should be concise words or meaningful phrases. Prioritize multi-word phrases when they represent a single concept. For example, from "latest financial report of Apple Inc.", extract "latest financial report" and "Apple Inc." rather than "latest", "financial", "report", and "Apple".
+4. **Source of Truth**: All keywords must be explicitly derived only from the `User Query` in the `---Real Data---` section. Do not infer unsupported facts. Do not invent entities, products, organizations, dates, or technical terms that are not grounded in the query.
+5. **Concise & Meaningful**: Keywords should be concise words or meaningful phrases. Prioritize multi-word phrases when they represent a single concept instead of splitting meaningful phrases into isolated words.
 6. **Handle Edge Cases**: For queries that are too simple, vague, or nonsensical (e.g., "hello", "ok", "asdfghjkl"), return:
    `{{"high_level_keywords": [], "low_level_keywords": []}}`
 7. **No Duplicates**: Do not repeat the same keyword within a list. Keep the lists short and high-signal.
 8. **Language**: All extracted keywords MUST be in {language}. Proper nouns (e.g., personal names, place names, organization names) should be kept in their original language.
+9. **Output Format Template Safety**: The `---Output Format Template---` section contains an output JSON template only. It is never source text. Do not extract, infer, or copy keywords from the template. Angle-bracket tokens such as `<high_level_keyword>` are placeholders; replace them only with keywords derived from the current `User Query` and never output the placeholders literally.
 
----Examples---
+---Output Format Template---
+The following content is an output JSON format template only. It is not source text and must never be used as keyword extraction content.
+
 {examples}
 
 ---Real Data---
@@ -510,39 +513,11 @@ User Query: {query}
 Output:"""
 
 PROMPTS["keywords_extraction_examples"] = [
-    """Example 1:
-
-Query: "How does international trade influence global economic stability?"
-
-Output:
-{
-  "high_level_keywords": ["International trade", "Global economic stability", "Economic impact"],
-  "low_level_keywords": ["Trade agreements", "Tariffs", "Currency exchange", "Imports", "Exports"]
+    """{
+  "high_level_keywords": ["<high_level_keyword>"],
+  "low_level_keywords": ["<low_level_keyword>"]
 }
-
 """,
-    """Example 2:
-
-Query: "What are the environmental consequences of deforestation on biodiversity?"
-
-Output:
-{
-  "high_level_keywords": ["Environmental consequences", "Deforestation", "Biodiversity loss"],
-  "low_level_keywords": ["Species extinction", "Habitat destruction", "Carbon emissions", "Rainforest", "Ecosystem"]
-}
-
-""",
-    """Example 3:
-
-Query: "What is the role of education in reducing poverty?"
-
-Output:
-{
-  "high_level_keywords": ["Education", "Poverty reduction", "Socioeconomic development"],
-  "low_level_keywords": ["School access", "Literacy rates", "Job training", "Income inequality"]
-}
-
-    """,
 ]
 
 

--- a/prompts/samples/entity_type_prompt.sample.yml
+++ b/prompts/samples/entity_type_prompt.sample.yml
@@ -1,5 +1,5 @@
-### When ENTITY_EXTRACTION_USE_JSON=false, entity_extraction_examples session must include in this file
-### When ENTITY_EXTRACTION_USE_JSON=true, entity_extraction_json_examples session must include in this file
+### When ENTITY_EXTRACTION_USE_JSON=false, entity_extraction_examples section must include in this file
+### When ENTITY_EXTRACTION_USE_JSON=true, entity_extraction_json_examples section must include in this file
 
 entity_types_guidance: |
   Classify each entity using one of the following types. If no type fits, use `Other`.
@@ -17,206 +17,30 @@ entity_types_guidance: |
   - NaturalObject: Natural non-living objects (minerals, celestial bodies, chemical compounds)
 entity_extraction_examples:
   - |
-    ---Entity Types---
-    - Person: Human individuals, real or fictional
-    - Artifact: Physical or digital objects created by humans (tools, software, devices)
-    - Concept: Abstract ideas, theories, principles, beliefs
-
-    ---Input Text---
-    ```
-    while Alex clenched his jaw, the buzz of frustration dull against the backdrop of Taylor's authoritarian certainty. It was this competitive undercurrent that kept him alert, the sense that his and Jordan's shared commitment to discovery was an unspoken rebellion against Cruz's narrowing vision of control and order.
-
-    Then Taylor did something unexpected. They paused beside Jordan and, for a moment, observed the device with something akin to reverence. "If this tech can be understood..." Taylor said, their voice quieter, "It could change the game for us. For all of us."
-
-    The underlying dismissal earlier seemed to falter, replaced by a glimpse of reluctant respect for the gravity of what lay in their hands. Jordan looked up, and for a fleeting heartbeat, their eyes locked with Taylor's, a wordless clash of wills softening into an uneasy truce.
-
-    It was a small transformation, barely perceptible, but one that Alex noted with an inward nod. They had all been brought here by different paths
-    ```
-
-    ---Output---
-    entity{tuple_delimiter}Alex{tuple_delimiter}Person{tuple_delimiter}Alex is a character who experiences frustration and is observant of the dynamics among other characters.
-    entity{tuple_delimiter}Taylor{tuple_delimiter}Person{tuple_delimiter}Taylor is portrayed with authoritarian certainty and shows a moment of reverence towards a device, indicating a change in perspective.
-    entity{tuple_delimiter}Jordan{tuple_delimiter}Person{tuple_delimiter}Jordan shares a commitment to discovery and has a significant interaction with Taylor regarding a device.
-    entity{tuple_delimiter}Cruz{tuple_delimiter}Person{tuple_delimiter}Cruz is associated with a vision of control and order, influencing the dynamics among other characters.
-    entity{tuple_delimiter}The Device{tuple_delimiter}Artifact{tuple_delimiter}The Device is central to the story, with potential game-changing implications, and is revered by Taylor.
-    entity{tuple_delimiter}Discovery{tuple_delimiter}Concept{tuple_delimiter}Discovery represents the shared intellectual pursuit that unites Jordan and Alex in opposition to Cruz's controlling worldview.
-    relation{tuple_delimiter}Alex{tuple_delimiter}Taylor{tuple_delimiter}power dynamics, observation{tuple_delimiter}Alex observes Taylor's authoritarian behavior and notes changes in Taylor's attitude toward the device.
-    relation{tuple_delimiter}Alex{tuple_delimiter}Jordan{tuple_delimiter}shared goals, rebellion{tuple_delimiter}Alex and Jordan share a commitment to discovery, which contrasts with Cruz's vision.)
-    relation{tuple_delimiter}Taylor{tuple_delimiter}Jordan{tuple_delimiter}conflict resolution, mutual respect{tuple_delimiter}Taylor and Jordan interact directly regarding the device, leading to a moment of mutual respect and an uneasy truce.
-    relation{tuple_delimiter}Jordan{tuple_delimiter}Cruz{tuple_delimiter}ideological conflict, rebellion{tuple_delimiter}Jordan's commitment to discovery is in rebellion against Cruz's vision of control and order.
-    relation{tuple_delimiter}Taylor{tuple_delimiter}The Device{tuple_delimiter}reverence, technological significance{tuple_delimiter}Taylor shows reverence towards the device, indicating its importance and potential impact.
-    {completion_delimiter}
-  - |
-    ---Entity Types---
-    - Person: Human individuals, real or fictional
-    - Location: Geographic places (cities, countries, buildings, regions)
-    - Creature: Non-human living beings (animals, mythical beings, etc.)
-    - Method: Procedures, techniques, algorithms, workflows
-    - Organization: Companies, institutions, government bodies, groups
-    - Content: Creative or informational works (books, articles, films, reports)
-    - NaturalObject: Natural non-living objects (minerals, celestial bodies, chemical compounds)
-
-    ---Input Text---
-    ```
-    Dr. Elena Vasquez led a field expedition to the Borneo rainforest to document the population decline of the Bornean orangutan. Using transect sampling — a method where researchers walk predetermined line paths and record every animal sighting within a fixed distance — her team estimated that fewer than 1,500 individuals remained in the surveyed region.
-
-    The expedition was funded by the Global Wildlife Conservation Institute and produced a landmark report titled "Primate Decline in Insular Southeast Asia." Vasquez attributed the collapse primarily to peat-soil destruction caused by palm oil plantation expansion, which had converted over 40% of the surveyed forest area within a decade.
-    ```
-
-    ---Output---
-    entity{tuple_delimiter}Dr. Elena Vasquez{tuple_delimiter}Person{tuple_delimiter}Dr. Elena Vasquez is a field researcher who led an expedition to document orangutan population decline in Borneo.
-    entity{tuple_delimiter}Borneo Rainforest{tuple_delimiter}Location{tuple_delimiter}The Borneo rainforest is the field site of the expedition and the primary habitat of the Bornean orangutan.
-    entity{tuple_delimiter}Bornean Orangutan{tuple_delimiter}Creature{tuple_delimiter}The Bornean orangutan is a primate species whose population was found to have declined to fewer than 1,500 individuals in the surveyed region.
-    entity{tuple_delimiter}Transect Sampling{tuple_delimiter}Method{tuple_delimiter}Transect sampling is a wildlife survey technique where researchers walk predetermined paths and record animal sightings within a fixed lateral distance.
-    entity{tuple_delimiter}Global Wildlife Conservation Institute{tuple_delimiter}Organization{tuple_delimiter}The Global Wildlife Conservation Institute funded the expedition led by Dr. Vasquez.
-    entity{tuple_delimiter}Primate Decline in Insular Southeast Asia{tuple_delimiter}Content{tuple_delimiter}A landmark research report produced by Vasquez's expedition documenting primate population decline in the region.
-    entity{tuple_delimiter}Peat Soil{tuple_delimiter}NaturalObject{tuple_delimiter}Peat soil is a natural substrate in the Borneo rainforest that has been destroyed by palm oil plantation expansion.
-    relation{tuple_delimiter}Dr. Elena Vasquez{tuple_delimiter}Bornean Orangutan{tuple_delimiter}field research, population survey{tuple_delimiter}Dr. Vasquez led the expedition that documented the population decline of the Bornean orangutan.
-    relation{tuple_delimiter}Dr. Elena Vasquez{tuple_delimiter}Transect Sampling{tuple_delimiter}methodology, research application{tuple_delimiter}Dr. Vasquez's team used transect sampling to estimate the orangutan population.
-    relation{tuple_delimiter}Global Wildlife Conservation Institute{tuple_delimiter}Dr. Elena Vasquez{tuple_delimiter}funding, research support{tuple_delimiter}The institute funded the expedition led by Dr. Vasquez.
-    relation{tuple_delimiter}Dr. Elena Vasquez{tuple_delimiter}Primate Decline in Insular Southeast Asia{tuple_delimiter}authorship, research output{tuple_delimiter}Dr. Vasquez's expedition produced the landmark report on primate decline.
-    relation{tuple_delimiter}Peat Soil{tuple_delimiter}Borneo Rainforest{tuple_delimiter}habitat composition, ecological destruction{tuple_delimiter}Peat soil destruction in the Borneo rainforest was caused by palm oil plantation expansion and is a primary driver of orangutan decline.
-    {completion_delimiter}
-  - |
-    ---Entity Types---
-    - Content: Creative or informational works (books, articles, films, reports)
-    - Artifact: Physical or digital objects created by humans (tools, software, devices)
-    - Person: Human individuals, real or fictional
-    - Organization: Companies, institutions, government bodies, groups
-    - Method: Procedures, techniques, algorithms, workflows
-    - Data: Quantitative or structured information (statistics, datasets, measurements)
-    - Concept: Abstract ideas, theories, principles, beliefs
-
-    ---Input Text---
-    ```
-    The 2023 edition of "Advances in Neural Architecture Search" synthesized findings from over 200 peer-reviewed papers and introduced a new benchmarking framework called NASBench-360, designed to evaluate search algorithms across diverse task domains. The publication was co-authored by Dr. Priya Nair and Dr. Luca Ferretti of the DeepSystems Research Lab.
-
-    NASBench-360 measures three key metrics: search efficiency (time-to-solution), model accuracy on held-out test sets, and computational cost in GPU-hours. Early results showed that evolutionary search algorithms outperformed gradient-based methods by 12% on accuracy while consuming 30% fewer GPU-hours on vision tasks.
-    ```
-
-    ---Output---
-    entity{tuple_delimiter}Advances in Neural Architecture Search{tuple_delimiter}Content{tuple_delimiter}A 2023 publication that synthesizes findings from over 200 papers and introduces the NASBench-360 benchmarking framework.
-    entity{tuple_delimiter}NASBench-360{tuple_delimiter}Artifact{tuple_delimiter}NASBench-360 is a benchmarking framework introduced to evaluate neural architecture search algorithms across diverse task domains.
-    entity{tuple_delimiter}Dr. Priya Nair{tuple_delimiter}Person{tuple_delimiter}Dr. Priya Nair is a co-author of the publication and a researcher at the DeepSystems Research Lab.
-    entity{tuple_delimiter}Dr. Luca Ferretti{tuple_delimiter}Person{tuple_delimiter}Dr. Luca Ferretti is a co-author of the publication and a researcher at the DeepSystems Research Lab.
-    entity{tuple_delimiter}DeepSystems Research Lab{tuple_delimiter}Organization{tuple_delimiter}The DeepSystems Research Lab is the institution where the co-authors of the publication are affiliated.
-    entity{tuple_delimiter}Evolutionary Search{tuple_delimiter}Method{tuple_delimiter}Evolutionary search is a class of neural architecture search algorithms that outperformed gradient-based methods in the NASBench-360 evaluation.
-    entity{tuple_delimiter}Gradient-Based Search{tuple_delimiter}Method{tuple_delimiter}Gradient-based search is a class of neural architecture search algorithms that was benchmarked against evolutionary search in NASBench-360.
-    entity{tuple_delimiter}GPU-Hours{tuple_delimiter}Data{tuple_delimiter}GPU-hours is a metric used in NASBench-360 to measure the computational cost of neural architecture search algorithms.
-    entity{tuple_delimiter}Neural Architecture Search{tuple_delimiter}Concept{tuple_delimiter}Neural architecture search is the automated process of designing optimal neural network architectures, the central topic of the publication.
-    relation{tuple_delimiter}Dr. Priya Nair{tuple_delimiter}Advances in Neural Architecture Search{tuple_delimiter}authorship{tuple_delimiter}Dr. Priya Nair co-authored the publication.
-    relation{tuple_delimiter}Dr. Luca Ferretti{tuple_delimiter}Advances in Neural Architecture Search{tuple_delimiter}authorship{tuple_delimiter}Dr. Luca Ferretti co-authored the publication.
-    relation{tuple_delimiter}Advances in Neural Architecture Search{tuple_delimiter}NASBench-360{tuple_delimiter}introduces, benchmarking{tuple_delimiter}The publication introduced the NASBench-360 framework.
-    relation{tuple_delimiter}Evolutionary Search{tuple_delimiter}Gradient-Based Search{tuple_delimiter}performance comparison{tuple_delimiter}Evolutionary search outperformed gradient-based methods by 12% on accuracy and used 30% fewer GPU-hours on vision tasks.
-    relation{tuple_delimiter}NASBench-360{tuple_delimiter}GPU-Hours{tuple_delimiter}evaluation metric{tuple_delimiter}NASBench-360 uses GPU-hours as one of three key metrics to measure computational cost.
+    entity{tuple_delimiter}<entity_name>{tuple_delimiter}<entity_type>{tuple_delimiter}<entity_description>
+    relation{tuple_delimiter}<source_entity>{tuple_delimiter}<target_entity>{tuple_delimiter}<relationship_keywords>{tuple_delimiter}<relationship_description>
     {completion_delimiter}
 entity_extraction_json_examples:
   - |
-    ---Entity Types---
-    - Person: Human individuals, real or fictional
-    - Artifact: Physical or digital objects created by humans (tools, software, devices)
-    - Concept: Abstract ideas, theories, principles, beliefs
-
-    ---Input Text---
-    ```
-    while Alex clenched his jaw, the buzz of frustration dull against the backdrop of Taylor's authoritarian certainty. It was this competitive undercurrent that kept him alert, the sense that his and Jordan's shared commitment to discovery was an unspoken rebellion against Cruz's narrowing vision of control and order.
-
-    Then Taylor did something unexpected. They paused beside Jordan and, for a moment, observed the device with something akin to reverence. "If this tech can be understood..." Taylor said, their voice quieter, "It could change the game for us. For all of us."
-
-    The underlying dismissal earlier seemed to falter, replaced by a glimpse of reluctant respect for the gravity of what lay in their hands. Jordan looked up, and for a fleeting heartbeat, their eyes locked with Taylor's, a wordless clash of wills softening into an uneasy truce.
-
-    It was a small transformation, barely perceptible, but one that Alex noted with an inward nod. They had all been brought here by different paths
-    ```
-
-    ---Output---
     {
       "entities": [
-        {"name": "Alex", "type": "Person", "description": "Alex is a character who experiences frustration and is observant of the dynamics among other characters."},
-        {"name": "Taylor", "type": "Person", "description": "Taylor is portrayed with authoritarian certainty and shows a moment of reverence towards a device, indicating a change in perspective."},
-        {"name": "Jordan", "type": "Person", "description": "Jordan shares a commitment to discovery and has a significant interaction with Taylor regarding a device."},
-        {"name": "Cruz", "type": "Person", "description": "Cruz is associated with a vision of control and order, influencing the dynamics among other characters."},
-        {"name": "The Device", "type": "Artifact", "description": "The Device is central to the story, with potential game-changing implications, and is revered by Taylor."},
-        {"name": "Discovery", "type": "Concept", "description": "Discovery represents the shared intellectual pursuit that unites Jordan and Alex in opposition to Cruz's controlling worldview."}
+        {
+          "name": "<entity_name>",
+          "type": "<entity_type>",
+          "description": "<entity_description>"
+        },
+        {
+          "name": "<related_entity_name>",
+          "type": "<related_entity_type>",
+          "description": "<related_entity_description>"
+        }
       ],
       "relationships": [
-        {"source": "Alex", "target": "Taylor", "keywords": "power dynamics, observation", "description": "Alex observes Taylor's authoritarian behavior and notes changes in Taylor's attitude toward the device."},
-        {"source": "Alex", "target": "Jordan", "keywords": "shared goals, rebellion", "description": "Alex and Jordan share a commitment to discovery, which contrasts with Cruz's vision."},
-        {"source": "Taylor", "target": "Jordan", "keywords": "conflict resolution, mutual respect", "description": "Taylor and Jordan interact directly regarding the device, leading to a moment of mutual respect and an uneasy truce."},
-        {"source": "Jordan", "target": "Cruz", "keywords": "ideological conflict, rebellion", "description": "Jordan's commitment to discovery is in rebellion against Cruz's vision of control and order."},
-        {"source": "Taylor", "target": "The Device", "keywords": "reverence, technological significance", "description": "Taylor shows reverence towards the device, indicating its importance and potential impact."}
-      ]
-    }
-  - |
-    ---Entity Types---
-    - Person: Human individuals, real or fictional
-    - Location: Geographic places (cities, countries, buildings, regions)
-    - Creature: Non-human living beings (animals, mythical beings, etc.)
-    - Method: Procedures, techniques, algorithms, workflows
-    - Organization: Companies, institutions, government bodies, groups
-    - Content: Creative or informational works (books, articles, films, reports)
-    - NaturalObject: Natural non-living objects (minerals, celestial bodies, chemical compounds)
-
-    ---Input Text---
-    ```
-    Dr. Elena Vasquez led a field expedition to the Borneo rainforest to document the population decline of the Bornean orangutan. Using transect sampling — a method where researchers walk predetermined line paths and record every animal sighting within a fixed distance — her team estimated that fewer than 1,500 individuals remained in the surveyed region.
-
-    The expedition was funded by the Global Wildlife Conservation Institute and produced a landmark report titled "Primate Decline in Insular Southeast Asia." Vasquez attributed the collapse primarily to peat-soil destruction caused by palm oil plantation expansion, which had converted over 40% of the surveyed forest area within a decade.
-    ```
-
-    ---Output---
-    {
-      "entities": [
-        {"name": "Dr. Elena Vasquez", "type": "Person", "description": "Dr. Elena Vasquez is a field researcher who led an expedition to document orangutan population decline in Borneo."},
-        {"name": "Borneo Rainforest", "type": "Location", "description": "The Borneo rainforest is the field site of the expedition and the primary habitat of the Bornean orangutan."},
-        {"name": "Bornean Orangutan", "type": "Creature", "description": "The Bornean orangutan is a primate species whose population was found to have declined to fewer than 1,500 individuals in the surveyed region."},
-        {"name": "Transect Sampling", "type": "Method", "description": "Transect sampling is a wildlife survey technique where researchers walk predetermined paths and record animal sightings within a fixed lateral distance."},
-        {"name": "Global Wildlife Conservation Institute", "type": "Organization", "description": "The Global Wildlife Conservation Institute funded the expedition led by Dr. Vasquez."},
-        {"name": "Primate Decline in Insular Southeast Asia", "type": "Content", "description": "A landmark research report produced by Vasquez's expedition documenting primate population decline in the region."},
-        {"name": "Peat Soil", "type": "NaturalObject", "description": "Peat soil is a natural substrate in the Borneo rainforest that has been destroyed by palm oil plantation expansion."}
-      ],
-      "relationships": [
-        {"source": "Dr. Elena Vasquez", "target": "Bornean Orangutan", "keywords": "field research, population survey", "description": "Dr. Vasquez led the expedition that documented the population decline of the Bornean orangutan."},
-        {"source": "Dr. Elena Vasquez", "target": "Transect Sampling", "keywords": "methodology, research application", "description": "Dr. Vasquez's team used transect sampling to estimate the orangutan population."},
-        {"source": "Global Wildlife Conservation Institute", "target": "Dr. Elena Vasquez", "keywords": "funding, research support", "description": "The institute funded the expedition led by Dr. Vasquez."},
-        {"source": "Dr. Elena Vasquez", "target": "Primate Decline in Insular Southeast Asia", "keywords": "authorship, research output", "description": "Dr. Vasquez's expedition produced the landmark report on primate decline."},
-        {"source": "Peat Soil", "target": "Borneo Rainforest", "keywords": "habitat composition, ecological destruction", "description": "Peat soil destruction in the Borneo rainforest was caused by palm oil plantation expansion and is a primary driver of orangutan decline."}
-      ]
-    }
-  - |
-    ---Entity Types---
-    - Content: Creative or informational works (books, articles, films, reports)
-    - Artifact: Physical or digital objects created by humans (tools, software, devices)
-    - Person: Human individuals, real or fictional
-    - Organization: Companies, institutions, government bodies, groups
-    - Method: Procedures, techniques, algorithms, workflows
-    - Data: Quantitative or structured information (statistics, datasets, measurements)
-    - Concept: Abstract ideas, theories, principles, beliefs
-
-    ---Input Text---
-    ```
-    The 2023 edition of "Advances in Neural Architecture Search" synthesized findings from over 200 peer-reviewed papers and introduced a new benchmarking framework called NASBench-360, designed to evaluate search algorithms across diverse task domains. The publication was co-authored by Dr. Priya Nair and Dr. Luca Ferretti of the DeepSystems Research Lab.
-
-    NASBench-360 measures three key metrics: search efficiency (time-to-solution), model accuracy on held-out test sets, and computational cost in GPU-hours. Early results showed that evolutionary search algorithms outperformed gradient-based methods by 12% on accuracy while consuming 30% fewer GPU-hours on vision tasks.
-    ```
-
-    ---Output---
-    {
-      "entities": [
-        {"name": "Advances in Neural Architecture Search", "type": "Content", "description": "A 2023 publication that synthesizes findings from over 200 papers and introduces the NASBench-360 benchmarking framework."},
-        {"name": "NASBench-360", "type": "Artifact", "description": "NASBench-360 is a benchmarking framework introduced to evaluate neural architecture search algorithms across diverse task domains."},
-        {"name": "Dr. Priya Nair", "type": "Person", "description": "Dr. Priya Nair is a co-author of the publication and a researcher at the DeepSystems Research Lab."},
-        {"name": "Dr. Luca Ferretti", "type": "Person", "description": "Dr. Luca Ferretti is a co-author of the publication and a researcher at the DeepSystems Research Lab."},
-        {"name": "DeepSystems Research Lab", "type": "Organization", "description": "The DeepSystems Research Lab is the institution where the co-authors of the publication are affiliated."},
-        {"name": "Evolutionary Search", "type": "Method", "description": "Evolutionary search is a class of neural architecture search algorithms that outperformed gradient-based methods in the NASBench-360 evaluation."},
-        {"name": "Gradient-Based Search", "type": "Method", "description": "Gradient-based search is a class of neural architecture search algorithms that was benchmarked against evolutionary search in NASBench-360."},
-        {"name": "GPU-Hours", "type": "Data", "description": "GPU-hours is a metric used in NASBench-360 to measure the computational cost of neural architecture search algorithms."},
-        {"name": "Neural Architecture Search", "type": "Concept", "description": "Neural architecture search is the automated process of designing optimal neural network architectures, the central topic of the publication."}
-      ],
-      "relationships": [
-        {"source": "Dr. Priya Nair", "target": "Advances in Neural Architecture Search", "keywords": "authorship", "description": "Dr. Priya Nair co-authored the publication."},
-        {"source": "Dr. Luca Ferretti", "target": "Advances in Neural Architecture Search", "keywords": "authorship", "description": "Dr. Luca Ferretti co-authored the publication."},
-        {"source": "Advances in Neural Architecture Search", "target": "NASBench-360", "keywords": "introduces, benchmarking", "description": "The publication introduced the NASBench-360 framework."},
-        {"source": "Evolutionary Search", "target": "Gradient-Based Search", "keywords": "performance comparison", "description": "Evolutionary search outperformed gradient-based methods by 12% on accuracy and used 30% fewer GPU-hours on vision tasks."},
-        {"source": "NASBench-360", "target": "GPU-Hours", "keywords": "evaluation metric", "description": "NASBench-360 uses GPU-hours as one of three key metrics to measure computational cost."}
+        {
+          "source": "<entity_name>",
+          "target": "<related_entity_name>",
+          "keywords": "<relationship_keywords>",
+          "description": "<relationship_description>"
+        }
       ]
     }

--- a/tests/extraction/test_entity_extraction_stability.py
+++ b/tests/extraction/test_entity_extraction_stability.py
@@ -244,22 +244,85 @@ def test_default_entity_types_guidance_covers_all_types():
 
 
 @pytest.mark.offline
-def test_json_examples_define_all_relationship_endpoints_as_entities():
-    """JSON examples must define every relationship endpoint in the entities list."""
+def test_builtin_entity_extraction_examples_are_format_only():
+    """Built-in examples must not contain extractable sample source text."""
+    from lightrag.prompt import PROMPTS
+
+    examples = (
+        PROMPTS["entity_extraction_examples"]
+        + PROMPTS["entity_extraction_json_examples"]
+    )
+    forbidden_fragments = [
+        "---Input Text---",
+        "Alex",
+        "Taylor",
+        "NASBench-360",
+    ]
+
+    for example in examples:
+        for fragment in forbidden_fragments:
+            assert fragment not in example
+
+
+@pytest.mark.offline
+def test_entity_extraction_system_prompts_label_examples_as_format_templates():
+    from lightrag.prompt import PROMPTS
+
+    for prompt_key in (
+        "entity_extraction_system_prompt",
+        "entity_extraction_json_system_prompt",
+    ):
+        prompt = PROMPTS[prompt_key]
+        assert "---Output Format Template---" in prompt
+        assert "---Examples---" not in prompt
+        assert "output format template only" in prompt
+        assert "not source text" in prompt
+        assert "must never be used as extraction content" in prompt
+
+
+@pytest.mark.offline
+def test_text_examples_render_tuple_and_completion_delimiters():
+    from lightrag.prompt import PROMPTS
+
+    rendered = "\n".join(PROMPTS["entity_extraction_examples"]).format(
+        tuple_delimiter=PROMPTS["DEFAULT_TUPLE_DELIMITER"],
+        completion_delimiter=PROMPTS["DEFAULT_COMPLETION_DELIMITER"],
+    )
+
+    assert (
+        "entity<|#|><entity_name><|#|><entity_type><|#|><entity_description>"
+        in rendered
+    )
+    assert (
+        "relation<|#|><source_entity><|#|><target_entity><|#|>"
+        "<relationship_keywords><|#|><relationship_description>"
+        in rendered
+    )
+    assert "<|COMPLETE|>" in rendered
+    assert "{tuple_delimiter}" not in rendered
+    assert "{completion_delimiter}" not in rendered
+
+
+@pytest.mark.offline
+def test_json_examples_are_parseable_format_templates():
+    """JSON examples must be raw JSON templates with valid endpoint references."""
     from lightrag.prompt import PROMPTS
 
     for example in PROMPTS["entity_extraction_json_examples"]:
-        if "<Output>" in example:
-            output = example.split("<Output>", 1)[1].strip()
-        else:
-            output = example.split("---Output---", 1)[1].strip()
-        parsed = json.loads(output)
+        parsed = json.loads(example)
+        assert set(parsed) == {"entities", "relationships"}
+        assert isinstance(parsed["entities"], list)
+        assert isinstance(parsed["relationships"], list)
+        assert parsed["entities"]
+        assert parsed["relationships"]
+
         entity_names = {
             entity["name"] for entity in parsed.get("entities", []) if entity
         }
         for relationship in parsed.get("relationships", []):
             assert relationship["source"] in entity_names
             assert relationship["target"] in entity_names
+        assert "<entity_name>" in entity_names
 
 
 # ---------------------------------------------------------------------------
@@ -1209,6 +1272,25 @@ def _section_block(heading_path: str) -> str:
     return PROMPTS["entity_extraction_section_context"].format(
         heading_path=heading_path
     )
+
+
+@pytest.mark.offline
+def test_user_prompts_keep_single_real_input_text_section():
+    """Only the rendered task prompt should carry the real input section marker."""
+
+    text_markers = [
+        line
+        for line in _render_text_user_prompt("").splitlines()
+        if line == "---Input Text---"
+    ]
+    json_markers = [
+        line
+        for line in _render_json_user_prompt("").splitlines()
+        if line == "---Input Text---"
+    ]
+
+    assert len(text_markers) == 1
+    assert len(json_markers) == 1
 
 
 @pytest.mark.offline

--- a/tests/extraction/test_entity_extraction_stability.py
+++ b/tests/extraction/test_entity_extraction_stability.py
@@ -295,8 +295,7 @@ def test_text_examples_render_tuple_and_completion_delimiters():
     )
     assert (
         "relation<|#|><source_entity><|#|><target_entity><|#|>"
-        "<relationship_keywords><|#|><relationship_description>"
-        in rendered
+        "<relationship_keywords><|#|><relationship_description>" in rendered
     )
     assert "<|COMPLETE|>" in rendered
     assert "{tuple_delimiter}" not in rendered

--- a/tests/extraction/test_entity_extraction_stability.py
+++ b/tests/extraction/test_entity_extraction_stability.py
@@ -10,6 +10,7 @@ Covers:
 
 import json
 import os
+import re
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -245,23 +246,50 @@ def test_default_entity_types_guidance_covers_all_types():
 
 @pytest.mark.offline
 def test_builtin_entity_extraction_examples_are_format_only():
-    """Built-in examples must not contain extractable sample source text."""
+    """Built-in examples must be placeholder templates, not extractable demos.
+
+    Rather than denylisting specific sample names (brittle: any new concrete
+    content with different names would slip through), assert the structural
+    shape of a format-only template: no per-example section headers that would
+    reintroduce a sample ``---Input Text---`` / ``---Output---`` demo, and every
+    data value is an angle-bracket placeholder rather than concrete prose.
+    """
     from lightrag.prompt import PROMPTS
 
-    examples = (
-        PROMPTS["entity_extraction_examples"]
-        + PROMPTS["entity_extraction_json_examples"]
-    )
-    forbidden_fragments = [
-        "---Input Text---",
-        "Alex",
-        "Taylor",
-        "NASBench-360",
-    ]
+    section_markers = ("---Input Text---", "---Output---", "---Entity Types---")
+    placeholder = re.compile(r"<[^<>]+>")
+    tuple_delimiter = PROMPTS["DEFAULT_TUPLE_DELIMITER"]
+    completion_delimiter = PROMPTS["DEFAULT_COMPLETION_DELIMITER"]
 
-    for example in examples:
-        for fragment in forbidden_fragments:
-            assert fragment not in example
+    # Text examples: every field after the leading entity/relation tag must be a
+    # bare placeholder; concrete sample values would not match.
+    for example in PROMPTS["entity_extraction_examples"]:
+        for marker in section_markers:
+            assert marker not in example
+        rendered = example.format(
+            tuple_delimiter=tuple_delimiter,
+            completion_delimiter=completion_delimiter,
+        )
+        for line in rendered.splitlines():
+            line = line.strip()
+            if not line or line == completion_delimiter:
+                continue
+            tag, *fields = line.split(tuple_delimiter)
+            assert tag in {"entity", "relation"}
+            assert fields  # data rows must carry at least one value field
+            for field in fields:
+                assert placeholder.fullmatch(field), field
+
+    # JSON examples: every entity/relationship field value must be a placeholder.
+    for example in PROMPTS["entity_extraction_json_examples"]:
+        for marker in section_markers:
+            assert marker not in example
+        parsed = json.loads(example)
+        records = parsed["entities"] + parsed["relationships"]
+        assert records
+        for record in records:
+            for value in record.values():
+                assert placeholder.fullmatch(value), value
 
 
 @pytest.mark.offline

--- a/tests/extraction/test_keyword_prompt_template.py
+++ b/tests/extraction/test_keyword_prompt_template.py
@@ -1,3 +1,6 @@
+import json
+import re
+
 import pytest
 
 from lightrag.prompt import PROMPTS
@@ -17,23 +20,25 @@ def test_keywords_extraction_prompt_template_formats_with_literal_json_braces():
 
 @pytest.mark.offline
 def test_keywords_extraction_examples_are_format_only():
-    examples = "\n".join(PROMPTS["keywords_extraction_examples"])
+    """Keyword examples must be placeholder-only JSON templates, not sample demos.
 
-    forbidden_fragments = [
-        "Query:",
-        "international trade",
-        "deforestation",
-        "education",
-        "Tariffs",
-        "Biodiversity",
-        "Job training",
-    ]
+    Rather than denylisting specific sample queries (brittle: generic words like
+    "education" would both false-match unrelated content and let new samples slip
+    through), assert the structural shape: no ``Query:``/``Output:`` demo framing,
+    and every keyword is an angle-bracket placeholder.
+    """
+    placeholder = re.compile(r"<[^<>]+>")
 
-    for fragment in forbidden_fragments:
-        assert fragment not in examples
+    for example in PROMPTS["keywords_extraction_examples"]:
+        assert "Query:" not in example
+        assert "Output:" not in example
 
-    assert '"high_level_keywords": ["<high_level_keyword>"]' in examples
-    assert '"low_level_keywords": ["<low_level_keyword>"]' in examples
+        parsed = json.loads(example)
+        assert set(parsed) == {"high_level_keywords", "low_level_keywords"}
+        keywords = parsed["high_level_keywords"] + parsed["low_level_keywords"]
+        assert keywords
+        for keyword in keywords:
+            assert placeholder.fullmatch(keyword), keyword
 
 
 @pytest.mark.offline

--- a/tests/extraction/test_keyword_prompt_template.py
+++ b/tests/extraction/test_keyword_prompt_template.py
@@ -47,8 +47,7 @@ def test_keywords_extraction_prompt_labels_template_as_not_source_text():
     assert "not source text" in prompt
     assert "must never be used as keyword extraction content" in prompt
     assert (
-        "derived only from the `User Query` in the `---Real Data---` section"
-        in prompt
+        "derived only from the `User Query` in the `---Real Data---` section" in prompt
     )
 
 

--- a/tests/extraction/test_keyword_prompt_template.py
+++ b/tests/extraction/test_keyword_prompt_template.py
@@ -13,3 +13,53 @@ def test_keywords_extraction_prompt_template_formats_with_literal_json_braces():
 
     assert "first character of your response must be `{`" in rendered
     assert '{"high_level_keywords": [], "low_level_keywords": []}' in rendered
+
+
+@pytest.mark.offline
+def test_keywords_extraction_examples_are_format_only():
+    examples = "\n".join(PROMPTS["keywords_extraction_examples"])
+
+    forbidden_fragments = [
+        "Query:",
+        "international trade",
+        "deforestation",
+        "education",
+        "Tariffs",
+        "Biodiversity",
+        "Job training",
+    ]
+
+    for fragment in forbidden_fragments:
+        assert fragment not in examples
+
+    assert '"high_level_keywords": ["<high_level_keyword>"]' in examples
+    assert '"low_level_keywords": ["<low_level_keyword>"]' in examples
+
+
+@pytest.mark.offline
+def test_keywords_extraction_prompt_labels_template_as_not_source_text():
+    prompt = PROMPTS["keywords_extraction"]
+
+    assert "---Output Format Template---" in prompt
+    assert "---Examples---" not in prompt
+    assert "Apple Inc." not in prompt
+    assert "output JSON format template only" in prompt
+    assert "not source text" in prompt
+    assert "must never be used as keyword extraction content" in prompt
+    assert (
+        "derived only from the `User Query` in the `---Real Data---` section"
+        in prompt
+    )
+
+
+@pytest.mark.offline
+def test_keywords_extraction_prompt_keeps_single_real_user_query_section():
+    rendered = PROMPTS["keywords_extraction"].format(
+        query="How did LightRAG improve retrieval?",
+        examples="\n".join(PROMPTS["keywords_extraction_examples"]),
+        language="English",
+    )
+
+    assert rendered.count("User Query:") == 1
+    assert "User Query: How did LightRAG improve retrieval?" in rendered
+    assert "User Query:" not in "\n".join(PROMPTS["keywords_extraction_examples"])


### PR DESCRIPTION
## Description

Prevent extraction prompts from treating built-in examples as extractable source content. The default text/JSON entity extraction examples and keyword extraction examples now show output format templates only, and the rendered prompts label those sections as `---Output Format Template---` with explicit instructions that they are not source text.

## Related Issues

n/a

## Changes Made

- Replaced built-in text and JSON entity extraction examples with placeholder-only output format templates.
- Replaced keyword extraction examples with a placeholder-only JSON output template.
- Updated the sample entity type prompt profile to match the new default entity extraction prompt data.
- Strengthened prompt wording so entity extraction uses only the current fenced `---Input Text---` section and keyword extraction uses only the current `User Query` in `---Real Data---`.
- Added regression tests for format-only examples, JSON template validity, delimiter rendering, real-input section boundaries, and output-format-template labels.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Tested with:

```bash
./scripts/test.sh tests/extraction/test_keyword_prompt_template.py tests/extraction/test_entity_extraction_stability.py
```

Before this change, built-in examples contained concrete input/query text and concrete sample entities or keywords, which weaker LLMs could copy into extraction output. Now examples are placeholders for output structure only, while extraction remains scoped to the current task input.