### PR TITLE
🐛 fix(neo4j): sanitize Lucene reserved chars in label search

### DIFF
--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -1,6 +1,7 @@
 import os
 import re
 from dataclasses import dataclass
+from typing import ClassVar
 
 # from typing import final
 import configparser
@@ -65,6 +66,16 @@ READ_RETRY = retry(
 # @final (removed per request in Issue #3130)
 @dataclass
 class Neo4JStorage(BaseGraphStorage):
+    # Lucene query-syntax reserved characters. The full-text query parser
+    # interprets these (e.g. '-' as NOT) before the analyzer runs, so a raw
+    # 'tb-' becomes a NOT clause and silently matches nothing. Replace them
+    # with spaces so the parser sees plain terms — the index already tokenizes
+    # on these boundaries anyway. Annotated as ClassVar so @dataclass does not
+    # treat it as an instance field.
+    _LUCENE_RESERVED: ClassVar[re.Pattern[str]] = re.compile(
+        r'[+\-&|!(){}\[\]^"~*?:\\/]'
+    )
+
     def __init__(self, namespace, global_config, embedding_func, workspace=None):
         # Read env and override the arg if present
         neo4j_workspace = os.environ.get("NEO4J_WORKSPACE")
@@ -132,6 +143,17 @@ class Neo4JStorage(BaseGraphStorage):
             r"[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]|[\U00020000-\U0002fa1f]"
         )
         return bool(cjk_pattern.search(text))
+
+    @classmethod
+    def _sanitize_fulltext_query(cls, text: str) -> str:
+        """Replace Lucene reserved characters with spaces and collapse whitespace.
+
+        Lets the full-text query parser see plain terms instead of misreading
+        reserved characters as operators (e.g. '-' as NOT). Returns an empty
+        string when the input is composed entirely of reserved characters.
+        """
+        cleaned = cls._LUCENE_RESERVED.sub(" ", text)
+        return " ".join(cleaned.split())
 
     async def initialize(self):
         async with get_data_init_lock():
@@ -1869,6 +1891,15 @@ class Neo4JStorage(BaseGraphStorage):
         is_chinese = self._is_chinese_text(query_strip)
         index_name = self._get_fulltext_index_name(workspace_label)
 
+        # Strip Lucene reserved characters before handing the text to the
+        # full-text query parser (see _sanitize_fulltext_query). The CASE-based
+        # scoring below still uses the raw query_strip / query_lower.
+        sanitized_query = self._sanitize_fulltext_query(query_strip)
+        if not sanitized_query:
+            # Query was composed entirely of reserved characters (e.g. "---").
+            # Return empty rather than falling back to a full-graph CONTAINS scan.
+            return []
+
         # Attempt to use the full-text index first
         try:
             async with self._driver.session(
@@ -1892,7 +1923,7 @@ class Neo4JStorage(BaseGraphStorage):
                     LIMIT $limit
                     """
                     # For Chinese, don't add wildcard as it may not work properly with CJK analyzer
-                    search_query = query_strip
+                    search_query = sanitized_query
                 else:
                     # For non-Chinese text, use the original logic with wildcard
                     cypher_query = f"""
@@ -1911,7 +1942,7 @@ class Neo4JStorage(BaseGraphStorage):
                     ORDER BY final_score DESC, label ASC
                     LIMIT $limit
                     """
-                    search_query = f"{query_strip}*"
+                    search_query = f"{sanitized_query}*"
 
                 result = await session.run(
                     cypher_query,

--- a/tests/kg/neo4j_impl/test_neo4j_fulltext_index.py
+++ b/tests/kg/neo4j_impl/test_neo4j_fulltext_index.py
@@ -167,6 +167,49 @@ async def test_search_labels_with_workspace_index(neo4j_storage):
 
 @pytest.mark.integration
 @pytest.mark.requires_db
+async def test_search_labels_with_hyphen(neo4j_storage):
+    """
+    Regression test: searching a label fragment containing a hyphen (or other
+    Lucene reserved character) must still return matches via the full-text index
+    instead of being misparsed into an empty result.
+    """
+    storage = neo4j_storage
+
+    test_nodes = [
+        {"entity_id": "tb-alpha", "entity_type": "Test"},
+        {"entity_id": "tb-beta", "entity_type": "Test"},
+        {"entity_id": "tbcd", "entity_type": "Test"},
+    ]
+
+    for node_data in test_nodes:
+        await storage.upsert_node(node_data["entity_id"], node_data)
+
+    # Give the eventually-consistent index time to catch up.
+    await asyncio.sleep(2)
+
+    # Plain prefix returns all three (baseline that already worked).
+    results = await storage.search_labels("tb", limit=10)
+    for expected in ("tb-alpha", "tb-beta", "tbcd"):
+        assert expected in results, f"'{expected}' should match 'tb', got {results}"
+
+    # The reported bug: a trailing hyphen previously cleared the dropdown.
+    results_hyphen = await storage.search_labels("tb-", limit=10)
+    assert (
+        "tb-alpha" in results_hyphen
+    ), f"'tb-' should match 'tb-alpha', got {results_hyphen}"
+    assert (
+        "tb-beta" in results_hyphen
+    ), f"'tb-' should match 'tb-beta', got {results_hyphen}"
+
+    # An exact hyphenated label resolves to itself.
+    results_exact = await storage.search_labels("tb-alpha", limit=10)
+    assert (
+        "tb-alpha" in results_exact
+    ), f"'tb-alpha' should match itself, got {results_exact}"
+
+
+@pytest.mark.integration
+@pytest.mark.requires_db
 async def test_search_labels_chinese_text(neo4j_storage):
     """
     Test that search_labels works with Chinese text using the CJK analyzer.

--- a/tests/kg/neo4j_impl/test_search_labels_sanitize.py
+++ b/tests/kg/neo4j_impl/test_search_labels_sanitize.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+"""
+Unit tests for Neo4JStorage._sanitize_fulltext_query.
+
+These run without a live Neo4j instance and guard the regression where a label
+search containing Lucene reserved characters (e.g. "tb-") was misparsed by the
+full-text query parser ('-' as NOT) and silently returned nothing.
+"""
+
+import os
+import sys
+
+import pytest
+
+# Add the project root directory to the Python path
+sys.path.append(
+    os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    )
+)
+
+from lightrag.kg.neo4j_impl import Neo4JStorage
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # Reserved characters are replaced with spaces and whitespace collapsed.
+        ("tb-", "tb"),
+        ("tb-foo", "tb foo"),
+        ("node:x", "node x"),
+        ("a (b)", "a b"),
+        ("C++", "C"),
+        ("foo && bar", "foo bar"),
+        ("name*", "name"),
+        # Composed entirely of reserved characters -> empty (caller returns []).
+        ("---", ""),
+        ("+++", ""),
+        ("()[]{}", ""),
+        # No reserved characters -> unchanged (modulo whitespace collapsing).
+        ("machine learning", "machine learning"),
+        ("  spaced   out  ", "spaced out"),
+        ("学习", "学习"),
+        ("机器-学习", "机器 学习"),
+    ],
+)
+def test_sanitize_fulltext_query(raw, expected):
+    assert Neo4JStorage._sanitize_fulltext_query(raw) == expected


### PR DESCRIPTION
## Description

When the graph backend is `Neo4JStorage`, typing a label fragment that contains a hyphen into the WebUI graph search box clears the dropdown. For example, typing `tb` correctly lists entities starting with `tb-`, but typing `tb-` empties the list. With `NetworkXStorage` the same input works fine.

**Root cause:** `Neo4JStorage.search_labels()` built the full-text query as `f"{query_strip}*"` and passed it straight to `db.index.fulltext.queryNodes`. Lucene's query parser interprets reserved characters — notably `-` (NOT) — at the syntax layer *before* the analyzer runs, so `tb-*` was parsed as a NOT clause and silently returned an empty result. Because no exception was raised, the existing `CONTAINS` fallback never triggered, so the dropdown was cleared. The same class of bug affects any reserved character (`+ - && || ! ( ) { } [ ] ^ " ~ * ? : \ /`), e.g. `node:`, `C++`, `(x)`.

The entity name itself is fine: typing `tb` recalls `tb-foo`, which proves the analyzer already tokenizes `tb-foo` into `tb` / `foo` at index time. The problem is purely in how the *query string* is parsed.

## Related Issues

N/A

## Changes Made

- `lightrag/kg/neo4j_impl.py`
  - Added `_LUCENE_RESERVED` precompiled regex (annotated `ClassVar[re.Pattern[str]]` so `@dataclass` does not treat it as an instance field) and a `_sanitize_fulltext_query()` classmethod that replaces Lucene reserved characters with spaces and collapses whitespace.
  - `search_labels()` now sanitizes the query before handing it to the full-text index, so `tb-` → `tb` → `tb*` and `tb-foo` → `tb foo` → `tb foo*` correctly recall hyphenated entities. The fast O(log n) full-text index path is preserved (no switch to a full-graph `CONTAINS` scan).
  - A query composed entirely of reserved characters (e.g. `---`, `+++`) now returns `[]` immediately rather than falling through to a full-graph scan.
  - The `CONTAINS` fallback for index unavailability/errors is unchanged.
- Tests
  - `tests/kg/neo4j_impl/test_search_labels_sanitize.py`: new DB-free unit tests covering the sanitization logic (runs in CI without Neo4j).
  - `tests/kg/neo4j_impl/test_neo4j_fulltext_index.py`: new integration test `test_search_labels_with_hyphen` regressing the reported bug (`--run-integration`, requires Neo4j).

**Known trade-off:** this is token-level prefix matching, not pure substring matching, so a mid-token fragment like `b-fo` ranks differently than NetworkX's substring match. This token-vs-substring difference already exists for non-special-character queries — it is inherent to the full-text index design, not newly introduced — and the core "narrow candidates by typing `tb-`" behavior is correct.

The frontend is unchanged: `encodeURIComponent` was already correct; the issue was entirely in the backend Lucene query construction.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

- Unit tests (`test_search_labels_sanitize.py`): 14 passed without a database.
- `ruff` check and `ruff-format` (pre-commit pinned) pass.
- The integration test and the WebUI end-to-end check (type `tb-` in the search box and confirm `tb-` entries remain) require a running Neo4j backend and were not executed in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
