### PR TITLE
feat(parser): standardize the parser engine interface through a registration mechanism with support for third-party parsers

### DIFF
--- a/docs/FileProcessingPipeline-zh.md
+++ b/docs/FileProcessingPipeline-zh.md
@@ -459,7 +459,7 @@ selector → 子字典映射：F → `fixed_token`，R → `recursive_character`
 | `canonical_basename` | 去掉处理提示 hint 后的规范化 basename（例如 `abc.docx`）。文件名查重以此字段为索引 key，保证 `abc.docx` 与 `abc.[native-iet].docx` 视为同一逻辑文档。 |
 | `source_path` | 入队时提供的原始路径（仅当含目录分隔符或绝对路径时才写入），供 `native` / `mineru` / `docling` 解析器定位真实文件位置。 |
 | `parse_format` | 内容格式：`pending_parse`, `raw`, `lightrag`。 |
-| `content` | `raw` 时保存抽取文本；`pending_parse` 时为空字符串；`lightrag` 时存储以 `{{LRdoc}}` 开头的**完整合并文本**（拼接 `.blocks.jsonl` 中所有 `type=="content"` 行的 body 段），分块阶段 `parse_native` 会剥离前缀后再交给 chunking_func，与 `raw` 走完全相同的代码路径。 |
+| `content` | `raw` 时保存抽取文本；`pending_parse` 时为空字符串；`lightrag` 时存储以 `{{LRdoc}}` 开头的**完整合并文本**（拼接 `.blocks.jsonl` 中所有 `type=="content"` 行的 body 段），解析阶段的 reuse handler（`ReuseParser`）会剥离前缀后再交给 chunking_func，与 `raw` 走完全相同的代码路径。 |
 | `content_hash` | 内容 MD5，用于跨文件名查重。`parse_format=raw` 取 `sanitize_text_for_encoding` 后文本的 hash；`parse_format=lightrag` 取 `*.blocks.jsonl` 文件 hash；`parse_format=pending_parse` 不写入，待抽取完成后补上。 |
 | `lightrag_document_path` | `parse_format=lightrag` 时保存结构化 LightRAG Document 的路径；新记录优先保存为相对 `INPUT_DIR` 的路径，例如 `__parsed__/report.docx.parsed/report.blocks.jsonl`。注意路径中的子目录与 blocks 文件名都使用规范化 basename（不含 hint）。 |
 | `parse_engine` | 实际完成抽取的引擎：`legacy`, `native`, `mineru`, `docling`。对于待抽取文件，也可暂存目标引擎。 |
@@ -711,12 +711,13 @@ upload 通过 reservation 后、保存文件前必须双道检查：
 `pipeline_status` 相关的锁解决的是"谁能写"的正确性问题，本节这一组参数解决的是"同时跑几个 worker"的吞吐量问题。流水线分为 3 个阶段，每个阶段的 worker 池数量独立可调：
 
 ```
-          ┌─ q_native  ──► [native parser  × N1] ─┐
-PENDING ─►├─ q_mineru  ──► [mineru parser  × N2] ─┼─► q_analyze ─►[analyzer × N4] ─► q_process ─►[processor × N5]
-          └─ q_docling ──► [docling parser × N3] ─┘
+          ┌─ parse_queues["native"]  ─► [native 池  × N1] ─┐   ← legacy 共享此池
+PENDING ─►├─ parse_queues["mineru"]  ─► [mineru 池  × N2] ─┼─► q_analyze ─►[analyzer × N4] ─► q_process ─►[processor × N5]
+          ├─ parse_queues["docling"] ─► [docling 池 × N3] ─┤
+          └─ parse_queues[<第三方组>] ─► [自定义并发池]  ──┘   ← 按 ParserSpec.queue_group 动态创建
 ```
 
-入队时 `resolve_stored_document_parser_engine` 根据每个文档的 `parser_engine`（来自 `LIGHTRAG_PARSER` 默认值或文件 hint）把它放入对应解析队列；3 个解析队列**完全互不阻塞**——mineru 占满不会拖慢 docling 或 native。解析完成后统一进入 `q_analyze`（多模态分析），再进入 `q_process`（实体/关系抽取 + 入库）。
+解析队列**按注册表的 `ParserSpec.queue_group` 动态创建**（每批取一次注册表快照）：内置 native/mineru/docling 各占一组，legacy 共享 native 池（本地、无网络），第三方引擎可声明独立组与自定义并发数（见 `docs/ThirdPartyParser-zh.md`）。入队时 `resolve_stored_document_parser_engine` 根据每个文档的 `parser_engine`（来自 `LIGHTRAG_PARSER` 默认值或文件 hint）把它放入对应解析队列；各解析队列**完全互不阻塞**——mineru 占满不会拖慢 docling 或 native。解析完成后统一进入 `q_analyze`（多模态分析），再进入 `q_process`（实体/关系抽取 + 入库）。
 
 | 环境变量 | 默认值 | 作用 | 调优建议 |
 | --- | --- | --- | --- |
@@ -762,7 +763,7 @@ PENDING ─►├─ q_mineru  ──► [mineru parser  × N2] ─┼─► q_a
 
 ### 7.2 分支 A：未抽取
 
-走完整流水线（`parse_native` / `parse_mineru` / `parse_docling` → `analyze_multimodal` → 分块 → 实体抽取），按 `full_docs.process_options` 决定每一阶段的行为。这是"首次入队"的常规流。
+走完整流水线（注册表派发解析 `get_parser(engine).parse(...)` → `analyze_multimodal` → 分块 → 实体抽取），按 `full_docs.process_options` 决定每一阶段的行为。这是"首次入队"的常规流。
 
 ### 7.3 分支 B：已抽取
 

--- a/docs/FileProcessingPipeline.md
+++ b/docs/FileProcessingPipeline.md
@@ -459,7 +459,7 @@ File enqueue and extraction results are written into `full_docs`:
 | `canonical_basename` | The canonicalized basename with the processing hint stripped (e.g., `abc.docx`). Filename deduplication uses this field as the index key, ensuring `abc.docx` and `abc.[native-iet].docx` are treated as the same logical document. |
 | `source_path` | The original path provided at enqueue time (written only when it contains a directory separator or is an absolute path), used by the `native` / `mineru` / `docling` parsers to locate the actual file. |
 | `parse_format` | Content format: `pending_parse`, `raw`, `lightrag`. |
-| `content` | When `raw`, holds the extracted text; when `pending_parse`, it is an empty string; when `lightrag`, holds the **complete merged text** starting with `{{LRdoc}}` (concatenated body segments of all `type=="content"` lines in `.blocks.jsonl`). During chunking, `parse_native` strips the prefix and hands it to the chunking_func, going through exactly the same code path as `raw`. |
+| `content` | When `raw`, holds the extracted text; when `pending_parse`, it is an empty string; when `lightrag`, holds the **complete merged text** starting with `{{LRdoc}}` (concatenated body segments of all `type=="content"` lines in `.blocks.jsonl`). At the parse stage, the reuse handler (`ReuseParser`) strips the prefix and hands it to the chunking_func, going through exactly the same code path as `raw`. |
 | `content_hash` | MD5 of the content, used for cross-filename deduplication. For `parse_format=raw`, takes the hash of text after `sanitize_text_for_encoding`; for `parse_format=lightrag`, takes the hash of the `*.blocks.jsonl` file; for `parse_format=pending_parse`, not written, filled in after extraction completes. |
 | `lightrag_document_path` | When `parse_format=lightrag`, saves the path to the structured LightRAG Document; new records prefer to save the path relative to `INPUT_DIR`, e.g., `__parsed__/report.docx.parsed/report.blocks.jsonl`. Note that the subdirectories and the blocks filename in the path both use the canonicalized basename (without hint). |
 | `parse_engine` | The engine that actually completed extraction: `legacy`, `native`, `mineru`, `docling`. For files awaiting extraction, can also temporarily store the target engine. |
@@ -711,12 +711,13 @@ The lock does **not** cover the `request_pending` nudge (outside the lock; only 
 The locks around `pipeline_status` solve the correctness problem of "who can write"; this section's set of parameters solves the throughput problem of "how many workers run concurrently". The pipeline is divided into 3 stages, each with an independently tunable worker pool:
 
 ```
-          ┌─ q_native  ──► [native parser  × N1] ─┐
-PENDING ─►├─ q_mineru  ──► [mineru parser  × N2] ─┼─► q_analyze ─►[analyzer × N4] ─► q_process ─►[processor × N5]
-          └─ q_docling ──► [docling parser × N3] ─┘
+          ┌─ parse_queues["native"]  ─► [native pool  × N1] ─┐   ← legacy shares this pool
+PENDING ─►├─ parse_queues["mineru"]  ─► [mineru pool  × N2] ─┼─► q_analyze ─►[analyzer × N4] ─► q_process ─►[processor × N5]
+          ├─ parse_queues["docling"] ─► [docling pool × N3] ─┤
+          └─ parse_queues[<3rd-party group>] ─► [custom pool] ┘   ← created per ParserSpec.queue_group
 ```
 
-At enqueue time, `resolve_stored_document_parser_engine` puts each document into the corresponding parse queue based on its `parser_engine` (from `LIGHTRAG_PARSER` defaults or the filename hint); the three parse queues are **completely non-blocking** with respect to each other — mineru saturation does not slow down docling or native. After parsing, they enter `q_analyze` (multimodal analysis) uniformly, and then enter `q_process` (entity/relation extraction + ingest).
+Parse queues are **created dynamically from the registry's `ParserSpec.queue_group`** (one registry snapshot per batch): the built-in native/mineru/docling each own a group, legacy shares the native pool (local, no network), and a third-party engine may declare its own group with a custom worker count (see `docs/ThirdPartyParser-zh.md`). At enqueue time, `resolve_stored_document_parser_engine` puts each document into the corresponding parse queue based on its `parser_engine` (from `LIGHTRAG_PARSER` defaults or the filename hint); the parse queues are **completely non-blocking** with respect to each other — mineru saturation does not slow down docling or native. After parsing, they enter `q_analyze` (multimodal analysis) uniformly, and then enter `q_process` (entity/relation extraction + ingest).
 
 | Environment variable | Default | Effect | Tuning advice |
 | --- | --- | --- | --- |
@@ -762,7 +763,7 @@ Read `full_docs[doc_id]`:
 
 ### 7.2 Branch A: Not Extracted
 
-Go through the full pipeline (`parse_native` / `parse_mineru` / `parse_docling` → `analyze_multimodal` → chunking → entity extraction), with each stage's behavior determined by `full_docs.process_options`. This is the normal flow of a "first-time enqueue".
+Go through the full pipeline (registry-dispatched parsing `get_parser(engine).parse(...)` → `analyze_multimodal` → chunking → entity extraction), with each stage's behavior determined by `full_docs.process_options`. This is the normal flow of a "first-time enqueue".
 
 ### 7.3 Branch B: Already Extracted
 

--- a/docs/ParserDebugCLI-zh.md
+++ b/docs/ParserDebugCLI-zh.md
@@ -1,6 +1,6 @@
 # Parser CLI Debuger使用指南
 
-本工具用于本地调试 LightRAG 的三个内容解析引擎（`native` / `mineru` / `docling`），针对**单个文件**触发 `LightRAG.parse_<engine>` 生产代码路径，并把解析产物（sidecar 与 raw 缓存）输出到一个**扁平目录布局**——与生产入库目录相比，区别仅在于：
+本工具用于本地调试 LightRAG 注册表中的任意内容解析引擎（内置 `native` / `legacy` / `mineru` / `docling`，以及通过 `lightrag.parsers` entry point 注册的第三方引擎，见 `docs/ThirdPartyParser-zh.md`），针对**单个文件**触发与 pipeline worker 相同的注册表派发路径（`get_parser(engine).parse(...)`），并把解析产物（sidecar 与 raw 缓存）输出到一个**扁平目录布局**——与生产入库目录相比，区别仅在于：
 
 - **无 `__parsed__/` 中间层**：产物直接落在指定父目录下，便于查看；
 - **源文件不会被归档**：源文件保留在原位置（生产路径会把源文件移到 `<INPUT_DIR>/__parsed__/`）；
@@ -12,7 +12,7 @@
 
 ```bash
 python -m lightrag.parser.cli <input_file> \
-    --engine {native|mineru|docling} \
+    --engine <engine> \
     [-o <sidecar_parent_dir>] \
     [--doc-id <doc-id>] \
     [--force-reparse] \
@@ -22,11 +22,11 @@ python -m lightrag.parser.cli <input_file> \
 | 参数 | 说明 |
 |---|---|
 | `input_file` | 待解析的源文件路径（位置参数，必填）。文件必须实际存在。 |
-| `--engine` | 必填：`native`（仅 `.docx`，本地解析）/ `mineru`（PDF/办公文档，调 MinerU 服务）/ `docling`（PDF/办公文档，调 docling-serve）。 |
+| `--engine` | 必填，可选值来自注册表：内置 `native`（仅 `.docx`，本地解析）/ `legacy`（纯文本抽取，无 sidecar）/ `mineru`（PDF/办公文档，调 MinerU 服务）/ `docling`（PDF/办公文档，调 docling-serve），以及任何已注册的第三方引擎。 |
 | `-o / --sidecar-parent-dir` | sidecar 与 raw 目录的父目录，默认 = 源文件所在目录。 |
 | `--doc-id` | 自定义文档 ID，默认 `doc-<md5(源文件绝对路径)>`（同一文件多次跑结果稳定）。 |
-| `--force-reparse` | 仅对 `mineru` / `docling` 生效：清空 raw 目录、强制重新下载与解析。默认行为是 raw 目录非空即复用。 |
-| `--preview N` | 解析完成后打印前 N 个 block 的预览（headings + 内容片段），默认 5；`0` 关闭。 |
+| `--force-reparse` | 仅对外部服务引擎（`mineru` / `docling` 及继承 `ExternalParserBase` 的第三方引擎）生效：清空 raw 目录、强制重新下载与解析。默认行为是 raw 目录非空即复用。 |
+| `--preview N` | 解析完成后打印前 N 个 block 的预览（headings + 内容片段），默认 5；`0` 关闭。对无 sidecar 的引擎（如 `legacy`），改为打印解析文本的前 400 字符。 |
 
 ## 输出目录布局
 

--- a/docs/ParserDebugCLI-zh.md
+++ b/docs/ParserDebugCLI-zh.md
@@ -64,7 +64,7 @@ python -m lightrag.parser.cli ./inputs/workspace/sample.docx --engine native
 python -m lightrag.parser.cli ./inputs/workspace/sample.pdf --engine mineru
 # 第二次（无任何修改）：raw 目录非空 → 直接复用 → 仅重建 sidecar，速度快
 python -m lightrag.parser.cli ./inputs/workspace/sample.pdf --engine mineru
-# 日志会显示： [parse_mineru] raw cache hit doc_id=... raw_dir=.../sample.pdf.mineru_raw
+# 日志会显示： [mineru] raw cache hit doc_id=...
 ```
 
 ### C. 用 Docling 解析 PDF + 复用已有 raw 目录
@@ -113,17 +113,17 @@ python -m lightrag.parser.cli ./inputs/workspace/sample.pdf \
 | raw 目录存在但 sidecar 内容仍是旧的 | 默认会**复用** raw 重建 sidecar。如果 raw 本身就过期或被替换，加 `--force-reparse` 清空重下。 |
 | MinerU 报 `MINERU_API_TOKEN` 缺失 / Docling 连接 `DOCLING_ENDPOINT` 失败 | 缓存未命中触发了外部服务调用——核对对应环境变量；或确认 raw 目录是否非空（命中缓存时无需服务）。 |
 | 源文件被意外移动 | 不应发生：CLI 已 mock 归档函数。若复现请提 issue（可能是 pipeline 内增加了新的归档调用点）。 |
-| `parse_docling` 报 `produced zero blocks` | docling raw 中的主 JSON 内容不可解析或为空。检查 raw 目录的 `*.json` 是否合法。 |
+| docling 报 `produced zero blocks` | docling raw 中的主 JSON 内容不可解析或为空。检查 raw 目录的 `*.json` 是否合法。 |
 
-## 与 `LightRAG.parse_*` 生产路径的等价性
+## 与生产解析路径的等价性
 
-本 CLI 直接调用生产代码路径 `LightRAG.parse_native` / `parse_mineru` / `parse_docling`（通过 `lightrag/parser/debug.py` 的轻量 RAG 替身），因此：
+本 CLI 与 pipeline parse worker 走同一条注册表派发路径——`get_parser(engine).parse(ParseContext(rag, ...))`（`rag` 是 `lightrag/parser/debug.py` 的轻量替身），因此：
 
 - sidecar 字段、命名、内容格式与生产入库完全一致；
 - IR 构建器、`write_sidecar` 调用、`_persist_parsed_full_docs` 行为完全一致；
 - 三处差异均由 CLI 内的 `monkey-patch` 实现，**不修改任何生产代码**：
-  1. `parsed_artifact_dir_for_source` → 返回扁平路径（无 `__parsed__/`）；
-  2. `is_bundle_valid` → 「raw 非空即有效」；
+  1. `parsed_artifact_dir_for` → 返回扁平路径（无 `__parsed__/`）；
+  2. 解析器实例的 `is_bundle_valid` → 「raw 非空即有效」（仅外部服务引擎）；
   3. `archive_docx_source_after_full_docs_sync` → no-op，保留源文件。
 
 可与 `tests/parser/docx/golden/native_docx/` 下的 golden fixture 对比验证（CLI 不冻结时间戳，比对时排除 `created_at` 等时间字段即可）。

--- a/docs/ParserDebugCLI.md
+++ b/docs/ParserDebugCLI.md
@@ -1,6 +1,6 @@
 # Parser CLI Debugger Guide
 
-This tool is used to locally debug LightRAG's three content parsing engines (`native` / `mineru` / `docling`). It triggers the `LightRAG.parse_<engine>` production code path for a **single file** and outputs the parsing artifacts (sidecar and raw cache) into a **flat directory layout**. Compared with the production ingestion directory, the only differences are:
+This tool is used to locally debug any parsing engine in LightRAG's registry (the built-in `native` / `legacy` / `mineru` / `docling`, plus third-party engines registered via the `lightrag.parsers` entry point — see `docs/ThirdPartyParser-zh.md`). It drives the same registry dispatch path as the pipeline worker (`get_parser(engine).parse(...)`) for a **single file** and outputs the parsing artifacts (sidecar and raw cache) into a **flat directory layout**. Compared with the production ingestion directory, the only differences are:
 
 - **No `__parsed__/` intermediate layer**: artifacts land directly under the specified parent directory for easy inspection;
 - **The source file is not archived**: the source file stays at its original location (the production path moves the source file to `<INPUT_DIR>/__parsed__/`);
@@ -12,7 +12,7 @@ The rest of the flow (IR construction, sidecar writing, `full_docs` synchronizat
 
 ```bash
 python -m lightrag.parser.cli <input_file> \
-    --engine {native|mineru|docling} \
+    --engine <engine> \
     [-o <sidecar_parent_dir>] \
     [--doc-id <doc-id>] \
     [--force-reparse] \
@@ -22,11 +22,11 @@ python -m lightrag.parser.cli <input_file> \
 | Argument | Description |
 |---|---|
 | `input_file` | Path to the source file to parse (positional argument, required). The file must actually exist. |
-| `--engine` | Required: `native` (only `.docx`, local parsing) / `mineru` (PDF/Office documents, calls MinerU service) / `docling` (PDF/Office documents, calls docling-serve). |
+| `--engine` | Required; choices come from the registry: built-in `native` (only `.docx`, local parsing) / `legacy` (plain-text extraction, no sidecar) / `mineru` (PDF/Office documents, calls MinerU service) / `docling` (PDF/Office documents, calls docling-serve), plus any registered third-party engine. |
 | `-o / --sidecar-parent-dir` | Parent directory of the sidecar and raw directories. Defaults to the directory containing the source file. |
 | `--doc-id` | Custom document ID. Defaults to `doc-<md5(absolute path of source file)>` (stable across multiple runs on the same file). |
-| `--force-reparse` | Effective only for `mineru` / `docling`: clears the raw directory and forces re-download and re-parse. By default, a non-empty raw directory is reused. |
-| `--preview N` | After parsing completes, prints a preview of the first N blocks (headings + content snippets). Default 5; `0` disables it. |
+| `--force-reparse` | Effective only for external-service engines (`mineru` / `docling` and third-party engines subclassing `ExternalParserBase`): clears the raw directory and forces re-download and re-parse. By default, a non-empty raw directory is reused. |
+| `--preview N` | After parsing completes, prints a preview of the first N blocks (headings + content snippets). Default 5; `0` disables it. For engines without a sidecar (e.g. `legacy`), prints the first 400 characters of the extracted text instead. |
 
 ## Output Directory Layout
 

--- a/docs/ParserDebugCLI.md
+++ b/docs/ParserDebugCLI.md
@@ -64,7 +64,7 @@ python -m lightrag.parser.cli ./inputs/workspace/sample.docx --engine native
 python -m lightrag.parser.cli ./inputs/workspace/sample.pdf --engine mineru
 # Second run (no changes): raw directory non-empty → reused directly → only regenerate sidecar, fast
 python -m lightrag.parser.cli ./inputs/workspace/sample.pdf --engine mineru
-# The log will show: [parse_mineru] raw cache hit doc_id=... raw_dir=.../sample.pdf.mineru_raw
+# The log will show: [mineru] raw cache hit doc_id=...
 ```
 
 ### C. Parse a PDF with Docling + reuse an existing raw directory
@@ -113,17 +113,17 @@ When the **cache is hit** (the raw directory already exists and is non-empty, an
 | Raw directory exists but sidecar content is still stale | The default behavior is to **reuse** raw and regenerate sidecar. If the raw itself is outdated or has been replaced, add `--force-reparse` to clear and re-download. |
 | MinerU reports `MINERU_API_TOKEN` missing / Docling fails to connect to `DOCLING_ENDPOINT` | A cache miss triggered an external service call — verify the corresponding environment variables; or confirm whether the raw directory is non-empty (no service needed when the cache hits). |
 | Source file is unexpectedly moved | Should not happen: the CLI has mocked the archive function. If reproducible, please file an issue (a new archive call site may have been added in the pipeline). |
-| `parse_docling` reports `produced zero blocks` | The main JSON content in docling raw is unparseable or empty. Check whether the `*.json` files in the raw directory are valid. |
+| docling reports `produced zero blocks` | The main JSON content in docling raw is unparseable or empty. Check whether the `*.json` files in the raw directory are valid. |
 
-## Equivalence with the `LightRAG.parse_*` Production Path
+## Equivalence with the Production Parsing Path
 
-This CLI directly calls the production code paths `LightRAG.parse_native` / `parse_mineru` / `parse_docling` (via the lightweight RAG stand-in in `lightrag/parser/debug.py`), so:
+This CLI drives the same registry dispatch path as the pipeline parse worker — `get_parser(engine).parse(ParseContext(rag, ...))` (with `rag` being the lightweight stand-in in `lightrag/parser/debug.py`), so:
 
 - The sidecar fields, naming, and content format are identical to production ingestion;
 - The IR builders, `write_sidecar` calls, and `_persist_parsed_full_docs` behavior are identical;
 - All three differences are implemented via `monkey-patch` inside the CLI — **no production code is modified**:
-  1. `parsed_artifact_dir_for_source` → returns the flat path (no `__parsed__/`);
-  2. `is_bundle_valid` → "raw is valid if non-empty";
+  1. `parsed_artifact_dir_for` → returns the flat path (no `__parsed__/`);
+  2. the resolved parser instance's `is_bundle_valid` → "raw is valid if non-empty" (external-service engines only);
   3. `archive_docx_source_after_full_docs_sync` → no-op, source file preserved.
 
 Results can be cross-validated against golden fixtures under `tests/parser/docx/golden/native_docx/` (the CLI does not freeze timestamps; just exclude time fields such as `created_at` when comparing).

--- a/docs/ThirdPartyParser-zh.md
+++ b/docs/ThirdPartyParser-zh.md
@@ -184,7 +184,7 @@ def register() -> None:
 
 `pip install my-pkg` 之后即装即用,无需改动 LightRAG 代码:
 
-- **API Server**:`create_app()` 在校验 `LIGHTRAG_PARSER` 路由规则**之前**调用 `load_third_party_parsers()`,因此路由规则可以直接引用第三方引擎名(如 `LIGHTRAG_PARSER="foo:myengine"`)。第三方引擎的 `suffixes` 还会**自动并入上传白名单与目录扫描**(`DocumentManager.supported_extensions` 动态联合第三方后缀;内置引擎的非白名单后缀如 mineru 的图片格式不受影响,仍不可直接上传);
+- **API Server**:`create_app()` 在校验 `LIGHTRAG_PARSER` 路由规则**之前**调用 `load_third_party_parsers()`,因此路由规则可以直接引用第三方引擎名(如 `LIGHTRAG_PARSER="foo:myengine"`)。上传白名单与目录扫描的文件类型(`DocumentManager.supported_extensions`)**完全由注册表实时派生**:所有 user-selectable 且 `endpoint_configured()` 通过的引擎后缀并集——第三方引擎注册后其 `suffixes` 自动变为可上传/可扫描;声明了 endpoint 闭包的引擎在 endpoint 未配置时,其独有后缀不会进入白名单(与内置 mineru/docling 的图片格式同一规则);
 - **调试 CLI**:`python -m lightrag.parser.cli sample.foo --engine myengine` 直接可用(`main()` 在构建 `--engine` choices 前加载插件)。无 sidecar 的引擎(`blocks_path=""`)CLI 会打印纯文本摘要而非 blocks 摘要;继承 `ExternalParserBase` 的引擎自动获得 raw 缓存展示与 `--force-reparse` 支持;
 - **库内嵌用法**(不经 server/CLI 直接用 LightRAG 类):在构建 pipeline 前自行调用一次:
 

--- a/docs/ThirdPartyParser-zh.md
+++ b/docs/ThirdPartyParser-zh.md
@@ -184,7 +184,7 @@ def register() -> None:
 
 `pip install my-pkg` 之后即装即用,无需改动 LightRAG 代码:
 
-- **API Server**:`create_app()` 在校验 `LIGHTRAG_PARSER` 路由规则**之前**调用 `load_third_party_parsers()`,因此路由规则可以直接引用第三方引擎名(如 `LIGHTRAG_PARSER="foo:myengine"`)。上传白名单与目录扫描的文件类型(`DocumentManager.supported_extensions`)**完全由注册表实时派生**:所有 user-selectable 且 `endpoint_configured()` 通过的引擎后缀并集——第三方引擎注册后其 `suffixes` 自动变为可上传/可扫描;声明了 endpoint 闭包的引擎在 endpoint 未配置时,其独有后缀不会进入白名单(与内置 mineru/docling 的图片格式同一规则);
+- **API Server**:`create_app()` 在校验 `LIGHTRAG_PARSER` 路由规则**之前**调用 `load_third_party_parsers()`,因此路由规则可以直接引用第三方引擎名(如 `LIGHTRAG_PARSER="foo:myengine"`)。上传与扫描的文件类型守门**完全由注册表 + 路由实时派生**,判据是"这份文件能否路由到一个支持它的引擎":裸后缀(无 hint)要求 `LIGHTRAG_PARSER` 规则把它指到你的引擎(否则默认 legacy 接不住会被拒,而不是收下后在解析阶段 FAILED);带文件名 hint 的上传(如 `report.[myengine].foo`)无需规则即可通过;endpoint 未配置的引擎其独有后缀不参与(与内置 mineru/docling 的图片格式同一规则)。**实践建议:发布第三方引擎时,在部署说明里让用户配套 `LIGHTRAG_PARSER="foo:myengine"` 规则**,裸文件名上传与目录扫描即自动生效;
 - **调试 CLI**:`python -m lightrag.parser.cli sample.foo --engine myengine` 直接可用(`main()` 在构建 `--engine` choices 前加载插件)。无 sidecar 的引擎(`blocks_path=""`)CLI 会打印纯文本摘要而非 blocks 摘要;继承 `ExternalParserBase` 的引擎自动获得 raw 缓存展示与 `--force-reparse` 支持;
 - **库内嵌用法**(不经 server/CLI 直接用 LightRAG 类):在构建 pipeline 前自行调用一次:
 

--- a/docs/ThirdPartyParser-zh.md
+++ b/docs/ThirdPartyParser-zh.md
@@ -184,7 +184,7 @@ def register() -> None:
 
 `pip install my-pkg` 之后即装即用,无需改动 LightRAG 代码:
 
-- **API Server**:`create_app()` 在校验 `LIGHTRAG_PARSER` 路由规则**之前**调用 `load_third_party_parsers()`,因此路由规则可以直接引用第三方引擎名(如 `LIGHTRAG_PARSER="foo:myengine"`);
+- **API Server**:`create_app()` 在校验 `LIGHTRAG_PARSER` 路由规则**之前**调用 `load_third_party_parsers()`,因此路由规则可以直接引用第三方引擎名(如 `LIGHTRAG_PARSER="foo:myengine"`)。第三方引擎的 `suffixes` 还会**自动并入上传白名单与目录扫描**(`DocumentManager.supported_extensions` 动态联合第三方后缀;内置引擎的非白名单后缀如 mineru 的图片格式不受影响,仍不可直接上传);
 - **调试 CLI**:`python -m lightrag.parser.cli sample.foo --engine myengine` 直接可用(`main()` 在构建 `--engine` choices 前加载插件)。无 sidecar 的引擎(`blocks_path=""`)CLI 会打印纯文本摘要而非 blocks 摘要;继承 `ExternalParserBase` 的引擎自动获得 raw 缓存展示与 `--force-reparse` 支持;
 - **库内嵌用法**(不经 server/CLI 直接用 LightRAG 类):在构建 pipeline 前自行调用一次:
 

--- a/docs/ThirdPartyParser-zh.md
+++ b/docs/ThirdPartyParser-zh.md
@@ -152,7 +152,7 @@ register_parser(ParserSpec(
 
 - pipeline 每批为**每个 `queue_group` 建一条队列 + 一组 worker**;
 - 组的 worker 数:内置组(`native`/`mineru`/`docling`)由 LightRAG 实例字段 `max_parallel_parse_*` 决定(支持构造参数覆盖);第三方独立组取该组唯一 owner spec 的 `concurrency`;一个组**只能有一个**声明了 `concurrency` 的 spec,多个会在批启动时报错;
-- `queue_group="native"` 蹭内置池时,`concurrency` 不生效(池大小由 `max_parallel_parse_native` 决定)——本地轻量引擎(如 legacy)适合这种方式,外部服务引擎建议独立组以免慢请求拖住本地解析。
+- `queue_group="native"` 蹭内置池时,`concurrency` 不生效(池大小由 `max_parallel_parse_native` 决定,被忽略的 spec 级 `concurrency` 会在批启动时记录 warning 日志)——本地轻量引擎(如 legacy)适合这种方式,外部服务引擎建议独立组以免慢请求拖住本地解析。
 
 ## 4. 注册:entry point 自动发现(推荐)
 

--- a/docs/ThirdPartyParser-zh.md
+++ b/docs/ThirdPartyParser-zh.md
@@ -1,0 +1,214 @@
+# 第三方 Parser 引擎开发与注册指南
+
+LightRAG 的解析层通过统一的 `BaseParser` 契约 + 中央引擎注册表(`lightrag/parser/registry.py`)派发所有解析引擎。内置引擎(`native` / `legacy` / `mineru` / `docling`)与第三方引擎走完全相同的派发路径:pipeline worker 与调试 CLI 都通过 `get_parser(engine).parse(ParseContext(...))` 驱动,**没有任何针对内置引擎的特判**。因此第三方包只需做两件事:
+
+1. **实现**一个 `BaseParser` 子类;
+2. **注册**一个 `ParserSpec`(推荐通过 `lightrag.parsers` entry point 自动发现)。
+
+完成后,该引擎自动获得:独立(或共享)的解析并发池、文件名 hint / `LIGHTRAG_PARSER` 路由规则 / API `parse_engine` 参数三种选择方式、后缀能力校验、以及 `python -m lightrag.parser.cli --engine <name>` 单文件调试支持。
+
+> 架构背景见 RFC #3197;sidecar 文件格式见 `docs/LightRAGSidecarFormat-zh.md`;CLI 用法见 `docs/ParserDebugCLI-zh.md`。
+
+---
+
+## 1. 派发流程总览
+
+```
+上传/扫描 → enqueue(PENDING_PARSE, parse_engine=<engine>)
+    → pipeline 按 ParserSpec.queue_group 选并发池
+    → parse worker: get_parser(engine).parse(ParseContext(rag, doc_id, file_path, content_data))
+        ├─ 成功 → ParseResult → 进入 analyze / chunk / KG 流水线
+        └─ 抛异常 → 该文档 doc_status=FAILED(只影响这一篇)
+```
+
+引擎对单篇文档的全部职责都收敛在一次 `parse(ctx)` 调用里:解析、持久化 `full_docs`、归档源文件、返回结构化结果。
+
+## 2. 实现 Parser
+
+### 2.1 契约(`lightrag/parser/base.py`)
+
+```python
+class MyParser(BaseParser):
+    engine_name = "myengine"          # 必须与 ParserSpec.engine_name 一致
+
+    async def parse(self, ctx: ParseContext) -> ParseResult: ...
+```
+
+`ParseContext` 提供:
+
+| 成员 | 说明 |
+|---|---|
+| `ctx.rag` | LightRAG 实例(用于 `_persist_parsed_full_docs` 等) |
+| `ctx.doc_id` / `ctx.file_path` / `ctx.content_data` | 文档标识、规范化文件路径、`full_docs` 行 |
+| `ctx.resolve(engine_name)` | 返回 `ResolvedSource(source_path, document_name, parsed_dir)` —— 解析磁盘源文件路径、规范化文档名、推导 `__parsed__/<base>.parsed/` 产物目录 |
+| `ctx.archive_source(path)` | 解析成功并完成 `full_docs` 同步后,把源文件归档进 `__parsed__/` |
+
+`ParseResult` 字段:`doc_id` / `file_path` / `parse_format`(`"raw"` 或 `"lightrag"`)/ `content` / `blocks_path`(无 sidecar 则 `""`)/ `parse_engine` / `parse_stage_skipped`(缓存命中等跳过场景)/ `parse_warnings`(非致命警告,会落到 `doc_status.metadata`)。
+
+### 2.2 三条实现路径(按引擎形态选基类)
+
+**A. 纯文本引擎(无 sidecar)— 直接继承 `BaseParser`**
+
+参考 `lightrag/parser/legacy/parser.py`(`LegacyParser`),核心骨架:
+
+```python
+class MyTextParser(BaseParser):
+    engine_name = "myengine"
+
+    async def parse(self, ctx: ParseContext) -> ParseResult:
+        rs = ctx.resolve(self.engine_name)
+        source = rs.source_path
+        if not source.is_file():
+            raise FileNotFoundError(f"myengine source not found: {source}")
+
+        text = await asyncio.to_thread(my_extract, source)  # CPU 活进线程
+        if not text.strip():
+            raise ValueError(f"extracted no usable text from {ctx.file_path}")
+
+        await ctx.rag._persist_parsed_full_docs(ctx.doc_id, {
+            "content": text,
+            "file_path": ctx.file_path,
+            "parse_format": FULL_DOCS_FORMAT_RAW,
+            "parse_engine": self.engine_name,
+            "update_time": int(time.time()),
+        })
+        await ctx.archive_source(str(source))
+        return ParseResult(
+            doc_id=ctx.doc_id, file_path=ctx.file_path,
+            parse_format=FULL_DOCS_FORMAT_RAW, content=text,
+            blocks_path="", parse_engine=self.engine_name,
+        )
+```
+
+**B. 本地解析、产 sidecar — 继承 `NativeParserBase`**(`lightrag/parser/native_base.py`)
+
+模板固定了「预清理产物目录(带回滚)→ 线程内抽取 → 构建 IR → 写 sidecar → 持久化 → 归档」的完整流程,只需实现两个钩子:
+
+```python
+class MyNativeParser(NativeParserBase):
+    engine_name = "myengine"
+
+    def extract(self, source, *, parsed_dir, asset_dir, base_name):
+        """同步,在线程中运行;返回 (blocks, warnings, metadata)。
+        可在 write_sidecar 之前把图片等资产写入 asset_dir。"""
+
+    def build_ir(self, blocks, *, document_name, asset_dir_name, metadata) -> IRDoc:
+        """blocks → IRDoc(交给统一的 sidecar writer)。"""
+```
+
+可选覆写:`validate_source`(默认仅要求文件存在)、`surface_warnings`(把抽取警告映射为 `parse_warnings`)。参考实现:`lightrag/parser/docx/parser.py`。
+
+**C. 外部解析服务(下载 raw bundle + 缓存)— 继承 `ExternalParserBase`**(`lightrag/parser/external/_base.py`)
+
+模板固定了「raw 缓存命中检查 → 未命中则清目录重新下载 → 构建 IR → 写 sidecar → 持久化 → 归档」,实现三个钩子 + 两个类属性:
+
+```python
+class MyExternalParser(ExternalParserBase):
+    engine_name = "myengine"
+    raw_dir_suffix = ".myengine_raw"          # raw bundle 目录后缀(以 . 开头)
+    force_reparse_env = "LIGHTRAG_FORCE_REPARSE_MYENGINE"
+
+    def is_bundle_valid(self, raw_dir, source_path) -> bool: ...   # 缓存命中检查
+    async def download_into(self, raw_dir, source_path, *, upload_name): ...
+    def build_ir(self, raw_dir, document_name) -> IRDoc: ...
+```
+
+可选覆写 `validate_ir`(构建后校验,如零 block 报错)。参考实现:`lightrag/parser/external/mineru/parser.py`、`.../docling/parser.py`。
+
+### 2.3 失败语义(重要)
+
+- `parse(ctx)` **抛出任何异常 ⇒ 仅该文档标记 FAILED**,错误信息写入 `doc_status.error_msg`,不影响批内其他文档。
+- 解析出**空内容时应抛异常**而不是返回空串——否则会产出一篇零知识文档静默进入 chunking(内置引擎均遵循此约定)。
+- worker 在调用引擎前会做后缀守门:`PENDING_PARSE` 文档的后缀不在该引擎 `ParserSpec.suffixes` 内 ⇒ 直接 FAILED,引擎代码不会被调用。
+
+## 3. 声明 `ParserSpec`(能力元数据)
+
+```python
+from lightrag.parser.registry import ParserSpec, register_parser
+
+register_parser(ParserSpec(
+    engine_name="myengine",
+    impl="my_pkg.parser:MyParser",       # "module:Class",get_parser 时才懒加载
+    suffixes=frozenset({"pdf", "foo"}),  # 小写、不带点
+    queue_group="myengine",              # 见下文并发模型
+    concurrency=int(os.getenv("MAX_PARALLEL_PARSE_MYENGINE", "2")),
+    # 仅外部服务引擎需要(routing 在 endpoint 未配置时跳过该引擎):
+    endpoint_configured=lambda: bool(os.getenv("MYENGINE_ENDPOINT", "").strip()),
+    endpoint_requirement=lambda: "MYENGINE_ENDPOINT",
+))
+```
+
+| 字段 | 必填 | 说明 |
+|---|---|---|
+| `engine_name` | ✓ | 注册表键,也是 `--engine` / 文件名 hint / `LIGHTRAG_PARSER` 里的引擎名。**与已有名字相同会覆盖原注册**(包括内置引擎)——除非有意替换实现,请勿与 `native/legacy/mineru/docling` 撞名。 |
+| `impl` | ✓ | `"module:Class"` 字符串。注册表只在文档实际解析时才 import 它,**注册阶段绝不能提前 import 实现**(保持能力查询 import-cheap,这是注册表的设计不变量)。 |
+| `suffixes` | ✓ | 该引擎能处理的扩展名(小写无点)。用于路由校验与 worker 端后缀守门。 |
+| `queue_group` | | 并发池分组,默认 `"native"`(共享 native 池)。独立池填唯一组名。 |
+| `concurrency` | | 该组 worker 数(组的唯一 owner 才需要填)。环境变量覆盖由**注册方在注册时自行烘焙**(如上例 `int(os.getenv(...))`),注册值即权威值。 |
+| `endpoint_configured` / `endpoint_requirement` | | 零参闭包(只读 env、不发网络)。前者返回该引擎依赖的外部服务是否已配置;后者返回缺失时提示用户的配置项名。本地引擎不用填(默认恒可用)。 |
+| `user_selectable` | | 默认 `True`。`False` 表示内部格式 handler(如 `reuse`/`passthrough`),不会出现在引擎选择面。 |
+
+### 并发模型
+
+- pipeline 每批为**每个 `queue_group` 建一条队列 + 一组 worker**;
+- 组的 worker 数:内置组(`native`/`mineru`/`docling`)由 LightRAG 实例字段 `max_parallel_parse_*` 决定(支持构造参数覆盖);第三方独立组取该组唯一 owner spec 的 `concurrency`;一个组**只能有一个**声明了 `concurrency` 的 spec,多个会在批启动时报错;
+- `queue_group="native"` 蹭内置池时,`concurrency` 不生效(池大小由 `max_parallel_parse_native` 决定)——本地轻量引擎(如 legacy)适合这种方式,外部服务引擎建议独立组以免慢请求拖住本地解析。
+
+## 4. 注册:entry point 自动发现(推荐)
+
+LightRAG 通过 `lightrag.parsers` entry-point group 自动发现第三方引擎(`lightrag/parser/plugins.py`)。第三方包只需:
+
+**① 在自己的 `pyproject.toml` 声明 entry point:**
+
+```toml
+[project.entry-points."lightrag.parsers"]
+myengine = "my_pkg.lightrag_plugin:register"
+```
+
+**② 提供一个零参注册函数:**
+
+```python
+# my_pkg/lightrag_plugin.py —— 保持 import-cheap:不要在这里 import 解析实现
+import os
+from lightrag.parser.registry import ParserSpec, register_parser
+
+def register() -> None:
+    register_parser(ParserSpec(
+        engine_name="myengine",
+        impl="my_pkg.parser:MyParser",   # 实现走懒加载
+        suffixes=frozenset({"foo"}),
+        queue_group="myengine",
+        concurrency=int(os.getenv("MAX_PARALLEL_PARSE_MYENGINE", "2")),
+    ))
+```
+
+`pip install my-pkg` 之后即装即用,无需改动 LightRAG 代码:
+
+- **API Server**:`create_app()` 在校验 `LIGHTRAG_PARSER` 路由规则**之前**调用 `load_third_party_parsers()`,因此路由规则可以直接引用第三方引擎名(如 `LIGHTRAG_PARSER="foo:myengine"`);
+- **调试 CLI**:`python -m lightrag.parser.cli sample.foo --engine myengine` 直接可用(`main()` 在构建 `--engine` choices 前加载插件)。无 sidecar 的引擎(`blocks_path=""`)CLI 会打印纯文本摘要而非 blocks 摘要;继承 `ExternalParserBase` 的引擎自动获得 raw 缓存展示与 `--force-reparse` 支持;
+- **库内嵌用法**(不经 server/CLI 直接用 LightRAG 类):在构建 pipeline 前自行调用一次:
+
+```python
+from lightrag.parser.plugins import load_third_party_parsers
+load_third_party_parsers()   # 进程内幂等
+```
+
+加载语义:每进程幂等(重复调用为 no-op);**单个插件抛异常只会被记录并跳过**,不会影响其他插件或内置引擎,更不会阻断 server 启动——但该引擎将不可用,请关注启动日志中的 `[parser-plugins]` 行。
+
+> 不想发包时也可以跳过 entry point,在自己的启动脚本里直接 `register_parser(...)` 后再启动/调用 LightRAG——注册表是进程内模块单例,效果相同,只是没有"装上即生效"。
+
+## 5. 路由:让文档用上你的引擎
+
+引擎选择优先级(`lightrag/parser/routing.py`):
+
+1. **文件名 hint**:`report.[myengine].foo`(可带处理选项 `report.[myengine-iet].foo`);
+2. **`LIGHTRAG_PARSER` 规则**:如 `LIGHTRAG_PARSER="foo:myengine,pdf:mineru"`(按后缀 glob 匹配,首条命中生效);
+3. **默认**:`legacy`。
+
+API 上传时显式传 `parse_engine="myengine"` 则直接固定该引擎(存入 PENDING_PARSE 行,worker 原样履约;后缀不支持会 FAILED 而非静默回退)。注册了 `endpoint_configured` 的引擎在 endpoint 未配置时会被路由跳过(hint/规则校验也会给出 `endpoint_requirement` 提示)。
+
+## 6. 测试建议
+
+- **单测引擎本体**:绕开 CLI,直接 `get_parser("myengine").parse(ParseContext(fake_rag, doc_id, file_path, content_data))`。`fake_rag` 只需提供 `_persist_parsed_full_docs` / `_resolve_source_file_for_parser` / `full_docs` / `doc_status`(参考 `lightrag/parser/debug.py` 的 `build_debug_rag()`,或 `tests/parser/test_legacy_parser.py` 的极简 `_FakeRag`);
+- **注册表是模块级单例**:测试中 `register_parser` 后,用 `finally: registry._REGISTRY.pop("myengine", None)` 清理(参考 `tests/parser/test_registry.py`);
+- **entry-point 加载逻辑**:参考 `tests/parser/test_plugins.py`(monkeypatch `lightrag.parser.plugins.entry_points` 注入 fake entry point;`plugins._loaded` 标志需复位)。

--- a/env.docker-compose-full
+++ b/env.docker-compose-full
@@ -1043,5 +1043,3 @@ MEMGRAPH_DATABASE=memgraph
 # LIGHTRAG_VECTOR_STORAGE=MongoVectorDBStorage
 
 ### ----- Extra setting from previous .env -----
-# ENTITY_TYPES='["Person", "Creature", "Organization", "Location", "Event", "Concept", "Method", "Content", "Data", "Artifact", "NaturalObject"]'
-POSTGRES_ENABLE_VECTOR=true

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -551,9 +551,6 @@ def parse_args() -> argparse.Namespace:
     )
     args.enable_llm_cache = get_env_value("ENABLE_LLM_CACHE", True, bool)
 
-    # PDF decryption password
-    args.pdf_decrypt_password = get_env_value("PDF_DECRYPT_PASSWORD", None)
-
     # --- Per-role LLM configuration (driven by lightrag.ROLES registry) ---
     for spec in ROLES:
         prefix = spec.env_prefix

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -51,6 +51,7 @@ from lightrag.api.routers.document_routes import (
     DocumentManager,
     create_document_routes,
 )
+from lightrag.parser.plugins import load_third_party_parsers
 from lightrag.parser.routing import (
     parser_rules_from_env,
     validate_parser_routing_config,
@@ -804,6 +805,9 @@ def create_app(args):
     # Setup logging
     logger.setLevel(args.log_level)
     set_verbose_debug(args.verbose)
+    # Discover third-party parser engines (``lightrag.parsers`` entry points)
+    # BEFORE validating routing rules, so LIGHTRAG_PARSER may reference them.
+    load_third_party_parsers()
     validate_parser_routing_config()
 
     # Create configuration cache (this will output configuration logs)

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -1013,7 +1013,7 @@ class DocumentManager:
         # Store the base input directory and workspace
         self.base_input_dir = Path(input_dir)
         self.workspace = workspace
-        self.supported_extensions = supported_extensions
+        self._base_supported_extensions = supported_extensions
         self.indexed_files = set()
 
         # Create workspace-specific input directory
@@ -1025,6 +1025,26 @@ class DocumentManager:
 
         # Create input directory if it doesn't exist
         self.input_dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def supported_extensions(self) -> tuple:
+        """Curated built-in allowlist ∪ third-party engine suffixes.
+
+        Computed live from the parser registry so a `lightrag.parsers`
+        plugin's file types become uploadable/scannable as soon as the
+        plugin is registered — without widening the curated built-in set
+        (e.g. mineru's image suffixes stay non-uploadable by default).
+        """
+        from lightrag.parser.registry import third_party_engine_suffixes
+
+        extra = tuple(
+            sorted(
+                f".{s}"
+                for s in third_party_engine_suffixes()
+                if f".{s}" not in self._base_supported_extensions
+            )
+        )
+        return self._base_supported_extensions + extra
 
     def scan_directory_for_new_files(self) -> List[Path]:
         """Scan input directory for new files"""

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -985,33 +985,85 @@ class DocumentManager:
 
     @property
     def supported_extensions(self) -> tuple:
-        """Upload/scan allowlist, derived live from the parser registry.
+        """Suffixes accepted for an unhinted filename, derived live.
 
-        Union of the suffixes of every user-selectable engine whose endpoint
-        gate passes (see ``available_engine_suffixes``): a default deployment
-        equals the local engines' types (legacy ∪ native); configuring an
-        external engine's endpoint (or registering a third-party plugin)
-        admits its types automatically — no hardcoded list to keep in sync.
+        A suffix is advertised only when it is *routable without extra
+        directives*: the engine that ``resolve_file_parser_engine`` picks for
+        a bare ``x.<suffix>`` (filename hint absent; ``LIGHTRAG_PARSER``
+        rules + default apply) must itself support the suffix. This keeps
+        "uploadable" aligned with "will actually parse": e.g. mineru's
+        ``png`` joins only when its endpoint is configured AND a routing
+        rule (or per-file hint, see ``is_supported_file``) sends pngs to it
+        — otherwise the default ``legacy`` engine would fail the suffix gate
+        at the parse stage. A default deployment equals the local engines'
+        (legacy ∪ native) types; no hardcoded list to keep in sync.
         """
         from lightrag.parser.registry import available_engine_suffixes
+        from lightrag.parser.routing import (
+            parser_engine_supports_suffix,
+            resolve_file_parser_engine,
+        )
 
-        return tuple(sorted(f".{s}" for s in available_engine_suffixes()))
+        out = []
+        for s in sorted(available_engine_suffixes()):
+            engine = resolve_file_parser_engine(f"x.{s}")
+            if parser_engine_supports_suffix(engine, s):
+                out.append(f".{s}")
+        return tuple(out)
 
     def scan_directory_for_new_files(self) -> List[Path]:
-        """Scan input directory for new files"""
+        """Scan input directory for new, routable files.
+
+        Globs over every *available* engine suffix (capability surface, so a
+        hint-carrying file like ``img.[mineru].png`` is discoverable even
+        when bare ``.png`` is not advertised), then keeps only files whose
+        resolved engine actually supports them (``is_supported_file``).
+        """
+        from lightrag.parser.registry import available_engine_suffixes
+        from lightrag.parser.routing import FilenameParserHintError
+
         new_files = []
-        for ext in self.supported_extensions:
+        for s in sorted(available_engine_suffixes()):
+            ext = f".{s}"
             logger.debug(f"Scanning for {ext} files in {self.input_dir}")
             for file_path in self.input_dir.glob(f"*{ext}"):
-                if file_path not in self.indexed_files:
-                    new_files.append(file_path)
+                if file_path in self.indexed_files:
+                    continue
+                try:
+                    if not self.is_supported_file(file_path.name):
+                        continue
+                except FilenameParserHintError:
+                    # Malformed hint: pass the file through — the enqueue
+                    # path reports a detailed error document, instead of the
+                    # scan silently ignoring the user's file.
+                    pass
+                new_files.append(file_path)
         return new_files
 
     def mark_as_indexed(self, file_path: Path):
         self.indexed_files.add(file_path)
 
     def is_supported_file(self, filename: str) -> bool:
-        return any(filename.lower().endswith(ext) for ext in self.supported_extensions)
+        """True when THIS filename routes to an engine that can parse it.
+
+        Resolves the engine for the concrete name — so a per-file hint
+        (``img.[mineru].png``) is honoured — and checks the resolved engine
+        supports the suffix. A bare suffix that would fall through to the
+        default ``legacy`` engine is rejected here instead of failing later
+        at the parse worker's suffix gate.
+
+        Raises :class:`FilenameParserHintError` for a malformed hint —
+        callers surface it (upload → HTTP 400 with the detailed message;
+        scan passes the file through so enqueue emits an error document).
+        """
+        from lightrag.parser.routing import (
+            parser_engine_supports_suffix,
+            parser_suffix,
+            resolve_file_parser_engine,
+        )
+
+        engine = resolve_file_parser_engine(filename)
+        return parser_engine_supports_suffix(engine, parser_suffix(filename))
 
 
 def validate_file_path_security(file_path_str: str, base_dir: Path) -> Optional[Path]:
@@ -2545,7 +2597,14 @@ def create_document_routes(
             # Sanitize filename to prevent Path Traversal attacks
             safe_filename = sanitize_filename(file.filename, doc_manager.input_dir)
 
-            if not doc_manager.is_supported_file(safe_filename):
+            try:
+                filename_supported = doc_manager.is_supported_file(safe_filename)
+            except FilenameParserHintError as hint_error:
+                # Reject malformed hints synchronously with the detailed
+                # message (previously surfaced asynchronously as an error
+                # document after the upload was accepted).
+                raise HTTPException(status_code=400, detail=str(hint_error))
+            if not filename_supported:
                 raise HTTPException(
                     status_code=400,
                     detail=f"Unsupported file type. Supported types: {doc_manager.supported_extensions}",

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -13,7 +13,6 @@ import traceback
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Any, Literal
-from io import BytesIO
 from fastapi import (
     APIRouter,
     BackgroundTasks,
@@ -28,7 +27,6 @@ from lightrag import LightRAG
 from lightrag.base import DocProcessingStatus, DocStatus
 from lightrag.constants import (
     FULL_DOCS_FORMAT_PENDING_PARSE,
-    PARSER_ENGINE_LEGACY,
     PARSED_ARTIFACT_DIR_SUFFIXES,
     PARSED_DIR_NAME,
     PROCESS_OPTION_CHUNK_FIXED,
@@ -1545,253 +1543,8 @@ async def record_scan_warning(rag: LightRAG, message: str) -> None:
         pass
 
 
-# Document processing helper functions (synchronous)
-# These functions run in thread pool via asyncio.to_thread() to avoid blocking the event loop
-
-
-def _extract_pdf_pypdf(file_bytes: bytes, password: str = None) -> str:
-    """Extract PDF content using pypdf (synchronous).
-
-    Args:
-        file_bytes: PDF file content as bytes
-        password: Optional password for encrypted PDFs
-
-    Returns:
-        str: Extracted text content
-
-    Raises:
-        Exception: If PDF is encrypted and password is incorrect or missing
-    """
-    from pypdf import PdfReader  # type: ignore
-
-    pdf_file = BytesIO(file_bytes)
-    reader = PdfReader(pdf_file)
-
-    # Check if PDF is encrypted
-    if reader.is_encrypted:
-        # Try empty password first (covers permission-only encrypted PDFs)
-        decrypt_result = reader.decrypt(password or "")
-        if decrypt_result == 0:
-            if password:
-                raise Exception("Incorrect PDF password")
-            else:
-                raise Exception("PDF is encrypted but no password provided")
-
-    # Extract text from all pages
-    content = ""
-    for page in reader.pages:
-        content += page.extract_text() + "\n"
-
-    return content
-
-
-def _extract_docx(file_bytes: bytes) -> str:
-    """Extract DOCX content including tables in document order (synchronous).
-
-    Args:
-        file_bytes: DOCX file content as bytes
-
-    Returns:
-        str: Extracted text content with tables in their original positions.
-             Tables are separated from paragraphs with blank lines for clarity.
-    """
-    from docx import Document  # type: ignore
-    from docx.table import Table  # type: ignore
-    from docx.text.paragraph import Paragraph  # type: ignore
-
-    docx_file = BytesIO(file_bytes)
-    doc = Document(docx_file)
-
-    def escape_cell(cell_value: str | None) -> str:
-        """Escape characters that would break tab-delimited layout.
-
-        Escape order is critical: backslashes first, then tabs/newlines.
-        This prevents double-escaping issues.
-
-        Args:
-            cell_value: The cell value to escape (can be None or str)
-
-        Returns:
-            str: Escaped cell value safe for tab-delimited format
-        """
-        if cell_value is None:
-            return ""
-        text = str(cell_value)
-        # CRITICAL: Escape backslash first to avoid double-escaping
-        return (
-            text.replace("\\", "\\\\")  # Must be first: \ -> \\
-            .replace("\t", "&emsp;&emsp;")  # Tab -> \t (visible)
-            .replace("\r\n", "<br>")  # Windows newline -> \n
-            .replace("\r", "<br>")  # Mac newline -> \n
-            .replace("\n", "<br>")  # Unix newline -> \n
-        )
-
-    content_parts = []
-    in_table = False  # Track if we're currently processing a table
-
-    # Iterate through all body elements in document order
-    for element in doc.element.body:
-        # Check if element is a paragraph
-        if element.tag.endswith("p"):
-            # If coming out of a table, add blank line after table
-            if in_table:
-                content_parts.append("")  # Blank line after table
-                in_table = False
-
-            paragraph = Paragraph(element, doc)
-            text = paragraph.text
-            # Always append to preserve document spacing (including blank paragraphs)
-            content_parts.append(text)
-
-        # Check if element is a table
-        elif element.tag.endswith("tbl"):
-            # Add blank line before table (if content exists)
-            if content_parts and not in_table:
-                content_parts.append("")  # Blank line before table
-
-            in_table = True
-            table = Table(element, doc)
-            for row in table.rows:
-                row_text = []
-                for cell in row.cells:
-                    cell_text = cell.text
-                    # Escape special characters to preserve tab-delimited structure
-                    row_text.append(escape_cell(cell_text))
-                # Only add row if at least one cell has content
-                if any(cell for cell in row_text):
-                    content_parts.append("\t".join(row_text))
-
-    return "\n".join(content_parts)
-
-
-def _extract_pptx(file_bytes: bytes) -> str:
-    """Extract PPTX content (synchronous).
-
-    Args:
-        file_bytes: PPTX file content as bytes
-
-    Returns:
-        str: Extracted text content
-    """
-    from pptx import Presentation  # type: ignore
-
-    pptx_file = BytesIO(file_bytes)
-    prs = Presentation(pptx_file)
-    content = ""
-    for slide in prs.slides:
-        for shape in slide.shapes:
-            if hasattr(shape, "text"):
-                content += shape.text + "\n"
-    return content
-
-
-def _extract_xlsx(file_bytes: bytes) -> str:
-    """Extract XLSX content in tab-delimited format with clear sheet separation.
-
-    This function processes Excel workbooks and converts them to a structured text format
-    suitable for LLM prompts and RAG systems. Each sheet is clearly delimited with
-    separator lines, and special characters are escaped to preserve the tab-delimited structure.
-
-    Features:
-    - Each sheet is wrapped with '====================' separators for visual distinction
-    - Special characters (tabs, newlines, backslashes) are escaped to prevent structure corruption
-    - Column alignment is preserved across all rows to maintain tabular structure
-    - Empty rows are preserved as blank lines to maintain row structure
-    - Uses sheet.max_column to determine column width efficiently
-
-    Args:
-        file_bytes: XLSX file content as bytes
-
-    Returns:
-        str: Extracted text content with all sheets in tab-delimited format.
-             Format: Sheet separators, sheet name, then tab-delimited rows.
-
-    Example output:
-        ==================== Sheet: Data ====================
-        Name\tAge\tCity
-        Alice\t30\tNew York
-        Bob\t25\tLondon
-
-        ==================== Sheet: Summary ====================
-        Total\t2
-        ====================
-    """
-    from openpyxl import load_workbook  # type: ignore
-
-    xlsx_file = BytesIO(file_bytes)
-    wb = load_workbook(xlsx_file)
-
-    def escape_cell(cell_value: str | int | float | None) -> str:
-        """Escape characters that would break tab-delimited layout.
-
-        Escape order is critical: backslashes first, then tabs/newlines.
-        This prevents double-escaping issues.
-
-        Args:
-            cell_value: The cell value to escape (can be None, str, int, or float)
-
-        Returns:
-            str: Escaped cell value safe for tab-delimited format
-        """
-        if cell_value is None:
-            return ""
-        text = str(cell_value)
-        # CRITICAL: Escape backslash first to avoid double-escaping
-        return (
-            text.replace("\\", "\\\\")  # Must be first: \ -> \\
-            .replace("\t", "\\t")  # Tab -> \t (visible)
-            .replace("\r\n", "\\n")  # Windows newline -> \n
-            .replace("\r", "\\n")  # Mac newline -> \n
-            .replace("\n", "\\n")  # Unix newline -> \n
-        )
-
-    def escape_sheet_title(title: str) -> str:
-        """Escape sheet title to prevent formatting issues in separators.
-
-        Args:
-            title: Original sheet title
-
-        Returns:
-            str: Sanitized sheet title with tabs/newlines replaced
-        """
-        return str(title).replace("\n", " ").replace("\t", " ").replace("\r", " ")
-
-    content_parts: list[str] = []
-    sheet_separator = "=" * 20
-
-    for idx, sheet in enumerate(wb):
-        if idx > 0:
-            content_parts.append("")  # Blank line between sheets for readability
-
-        # Escape sheet title to handle edge cases with special characters
-        safe_title = escape_sheet_title(sheet.title)
-        content_parts.append(f"{sheet_separator} Sheet: {safe_title} {sheet_separator}")
-
-        # Use sheet.max_column to get the maximum column width directly
-        max_columns = sheet.max_column if sheet.max_column else 0
-
-        # Extract rows with consistent width to preserve column alignment
-        for row in sheet.iter_rows(values_only=True):
-            row_parts = []
-
-            # Build row up to max_columns width
-            for idx in range(max_columns):
-                if idx < len(row):
-                    row_parts.append(escape_cell(row[idx]))
-                else:
-                    row_parts.append("")  # Pad short rows
-
-            # Check if row is completely empty
-            if all(part == "" for part in row_parts):
-                # Preserve empty rows as blank lines (maintains row structure)
-                content_parts.append("")
-            else:
-                # Join all columns to maintain consistent column count
-                content_parts.append("\t".join(row_parts))
-
-    # Final separator for symmetry (makes parsing easier)
-    content_parts.append(sheet_separator)
-    return "\n".join(content_parts)
+# Legacy text extractors moved to lightrag.parser.legacy.extractors; the
+# legacy engine now extracts at the worker stage (LegacyParser), not here.
 
 
 async def pipeline_enqueue_file(
@@ -1819,8 +1572,6 @@ async def pipeline_enqueue_file(
         track_id = generate_track_id("unknown")
 
     try:
-        content = ""
-        ext = file_path.suffix.lower()
         file_size = 0
 
         # Get file size for error reporting
@@ -1850,379 +1601,45 @@ async def pipeline_enqueue_file(
             return False, track_id
 
         api_process_options = process_options or PROCESS_OPTION_CHUNK_FIXED
-        if extraction_engine != PARSER_ENGINE_LEGACY:
-            try:
-                enqueue_kwargs = {
-                    "file_paths": str(file_path),
-                    "track_id": track_id,
-                    "docs_format": FULL_DOCS_FORMAT_PENDING_PARSE,
-                    "parse_engine": extraction_engine,
-                    "process_options": api_process_options,
-                    "from_scan": from_scan,
-                }
-                enqueue_result = await rag.apipeline_enqueue_documents(
-                    "", **enqueue_kwargs
-                )
-                if enqueue_result is None:
-                    try:
-                        await move_file_to_parsed_dir(file_path)
-                    except Exception as move_error:
-                        logger.error(
-                            f"Failed to move duplicate file {file_path.name} to {PARSED_DIR_NAME} directory: {move_error}"
-                        )
-                    return False, track_id
-                logger.info(
-                    f"[File Extraction]Deferred {file_path.name} to {extraction_engine} parser"
-                )
-                return True, track_id
-            except Exception as e:
-                error_files = [
-                    {
-                        "file_path": str(file_path.name),
-                        "error_description": "[File Extraction]Parser enqueue error",
-                        "original_error": f"Failed to enqueue file for parser: {str(e)}",
-                        "file_size": file_size,
-                    }
-                ]
-                await rag.apipeline_enqueue_error_documents(error_files, track_id)
-                logger.error(
-                    f"[File Extraction]Error enqueuing {file_path.name} for {extraction_engine}: {str(e)}"
-                )
-                return False, track_id
-
-        file = None
+        # All engines defer parsing to the worker stage: the file is already
+        # saved on disk, so we enqueue PENDING_PARSE with the chosen engine.
+        # Legacy now extracts at the worker (LegacyParser) instead of eagerly
+        # here, so every engine shares one ingestion path.
         try:
-            async with aiofiles.open(file_path, "rb") as f:
-                file = await f.read()
-        except PermissionError as e:
-            error_files = [
-                {
-                    "file_path": str(file_path.name),
-                    "error_description": "[File Extraction]Permission denied - cannot read file",
-                    "original_error": str(e),
-                    "file_size": file_size,
-                }
-            ]
-            await rag.apipeline_enqueue_error_documents(error_files, track_id)
-            logger.error(
-                f"[File Extraction]Permission denied reading file: {file_path.name}"
-            )
-            return False, track_id
-        except FileNotFoundError as e:
-            error_files = [
-                {
-                    "file_path": str(file_path.name),
-                    "error_description": "[File Extraction]File not found",
-                    "original_error": str(e),
-                    "file_size": file_size,
-                }
-            ]
-            await rag.apipeline_enqueue_error_documents(error_files, track_id)
-            logger.error(f"[File Extraction]File not found: {file_path.name}")
-            return False, track_id
-        except Exception as e:
-            error_files = [
-                {
-                    "file_path": str(file_path.name),
-                    "error_description": "[File Extraction]File reading error",
-                    "original_error": str(e),
-                    "file_size": file_size,
-                }
-            ]
-            await rag.apipeline_enqueue_error_documents(error_files, track_id)
-            logger.error(
-                f"[File Extraction]Error reading file {file_path.name}: {str(e)}"
-            )
-            return False, track_id
-
-        # Process based on file type
-        try:
-            match ext:
-                case (
-                    ".txt"
-                    | ".md"
-                    | ".mdx"
-                    | ".html"
-                    | ".htm"
-                    | ".tex"
-                    | ".json"
-                    | ".xml"
-                    | ".yaml"
-                    | ".yml"
-                    | ".rtf"
-                    | ".odt"
-                    | ".epub"
-                    | ".csv"
-                    | ".log"
-                    | ".conf"
-                    | ".ini"
-                    | ".properties"
-                    | ".sql"
-                    | ".bat"
-                    | ".sh"
-                    | ".c"
-                    | ".h"
-                    | ".cpp"
-                    | ".hpp"
-                    | ".py"
-                    | ".java"
-                    | ".js"
-                    | ".ts"
-                    | ".swift"
-                    | ".go"
-                    | ".rb"
-                    | ".php"
-                    | ".css"
-                    | ".scss"
-                    | ".less"
-                ):
-                    try:
-                        # Try to decode as UTF-8 (offloaded to thread to avoid blocking the event loop)
-                        content = await asyncio.to_thread(file.decode, "utf-8")
-
-                        # Validate content
-                        if not content or len(content.strip()) == 0:
-                            error_files = [
-                                {
-                                    "file_path": str(file_path.name),
-                                    "error_description": "[File Extraction]Empty file content",
-                                    "original_error": "File contains no content or only whitespace",
-                                    "file_size": file_size,
-                                }
-                            ]
-                            await rag.apipeline_enqueue_error_documents(
-                                error_files, track_id
-                            )
-                            logger.error(
-                                f"[File Extraction]Empty content in file: {file_path.name}"
-                            )
-                            return False, track_id
-
-                        # Check if content looks like binary data string representation
-                        if content.startswith("b'") or content.startswith('b"'):
-                            error_files = [
-                                {
-                                    "file_path": str(file_path.name),
-                                    "error_description": "[File Extraction]Binary data in text file",
-                                    "original_error": "File appears to contain binary data representation instead of text",
-                                    "file_size": file_size,
-                                }
-                            ]
-                            await rag.apipeline_enqueue_error_documents(
-                                error_files, track_id
-                            )
-                            logger.error(
-                                f"[File Extraction]File {file_path.name} appears to contain binary data representation instead of text"
-                            )
-                            return False, track_id
-
-                    except UnicodeDecodeError as e:
-                        error_files = [
-                            {
-                                "file_path": str(file_path.name),
-                                "error_description": "[File Extraction]UTF-8 encoding error, please convert it to UTF-8 before processing",
-                                "original_error": f"File is not valid UTF-8 encoded text: {str(e)}",
-                                "file_size": file_size,
-                            }
-                        ]
-                        await rag.apipeline_enqueue_error_documents(
-                            error_files, track_id
-                        )
-                        logger.error(
-                            f"[File Extraction]File {file_path.name} is not valid UTF-8 encoded text. Please convert it to UTF-8 before processing."
-                        )
-                        return False, track_id
-
-                case ".pdf":
-                    try:
-                        content = await asyncio.to_thread(
-                            _extract_pdf_pypdf,
-                            file,
-                            global_args.pdf_decrypt_password,
-                        )
-                    except Exception as e:
-                        error_files = [
-                            {
-                                "file_path": str(file_path.name),
-                                "error_description": "[File Extraction]PDF processing error",
-                                "original_error": f"Failed to extract text from PDF: {str(e)}",
-                                "file_size": file_size,
-                            }
-                        ]
-                        await rag.apipeline_enqueue_error_documents(
-                            error_files, track_id
-                        )
-                        logger.error(
-                            f"[File Extraction]Error processing PDF {file_path.name}: {str(e)}"
-                        )
-                        return False, track_id
-
-                case ".docx":
-                    try:
-                        content = await asyncio.to_thread(_extract_docx, file)
-                    except Exception as e:
-                        error_files = [
-                            {
-                                "file_path": str(file_path.name),
-                                "error_description": "[File Extraction]DOCX processing error",
-                                "original_error": f"Failed to extract text from DOCX: {str(e)}",
-                                "file_size": file_size,
-                            }
-                        ]
-                        await rag.apipeline_enqueue_error_documents(
-                            error_files, track_id
-                        )
-                        logger.error(
-                            f"[File Extraction]Error processing DOCX {file_path.name}: {str(e)}"
-                        )
-                        return False, track_id
-
-                case ".pptx":
-                    try:
-                        content = await asyncio.to_thread(_extract_pptx, file)
-                    except Exception as e:
-                        error_files = [
-                            {
-                                "file_path": str(file_path.name),
-                                "error_description": "[File Extraction]PPTX processing error",
-                                "original_error": f"Failed to extract text from PPTX: {str(e)}",
-                                "file_size": file_size,
-                            }
-                        ]
-                        await rag.apipeline_enqueue_error_documents(
-                            error_files, track_id
-                        )
-                        logger.error(
-                            f"[File Extraction]Error processing PPTX {file_path.name}: {str(e)}"
-                        )
-                        return False, track_id
-
-                case ".xlsx":
-                    try:
-                        content = await asyncio.to_thread(_extract_xlsx, file)
-                    except Exception as e:
-                        error_files = [
-                            {
-                                "file_path": str(file_path.name),
-                                "error_description": "[File Extraction]XLSX processing error",
-                                "original_error": f"Failed to extract text from XLSX: {str(e)}",
-                                "file_size": file_size,
-                            }
-                        ]
-                        await rag.apipeline_enqueue_error_documents(
-                            error_files, track_id
-                        )
-                        logger.error(
-                            f"[File Extraction]Error processing XLSX {file_path.name}: {str(e)}"
-                        )
-                        return False, track_id
-
-                case _:
-                    error_files = [
-                        {
-                            "file_path": str(file_path.name),
-                            "error_description": f"[File Extraction]Unsupported file type: {ext}",
-                            "original_error": f"File extension {ext} is not supported",
-                            "file_size": file_size,
-                        }
-                    ]
-                    await rag.apipeline_enqueue_error_documents(error_files, track_id)
-                    logger.error(
-                        f"[File Extraction]Unsupported file type: {file_path.name} (extension {ext})"
-                    )
-                    return False, track_id
-
-        except Exception as e:
-            error_files = [
-                {
-                    "file_path": str(file_path.name),
-                    "error_description": "[File Extraction]File format processing error",
-                    "original_error": f"Unexpected error during file extracting: {str(e)}",
-                    "file_size": file_size,
-                }
-            ]
-            await rag.apipeline_enqueue_error_documents(error_files, track_id)
-            logger.error(
-                f"[File Extraction]Unexpected error during {file_path.name} extracting: {str(e)}"
-            )
-            return False, track_id
-
-        # Insert into the RAG queue
-        if content:
-            # Check if content contains only whitespace characters
-            if not content.strip():
-                error_files = [
-                    {
-                        "file_path": str(file_path.name),
-                        "error_description": "[File Extraction]File contains only whitespace",
-                        "original_error": "File content contains only whitespace characters",
-                        "file_size": file_size,
-                    }
-                ]
-                await rag.apipeline_enqueue_error_documents(error_files, track_id)
-                logger.warning(
-                    f"[File Extraction]File contains only whitespace characters: {file_path.name}"
-                )
-                return False, track_id
-
-            try:
-                enqueue_kwargs = {
-                    "file_paths": file_path.name,
-                    "track_id": track_id,
-                    "parse_engine": PARSER_ENGINE_LEGACY,
-                    "process_options": api_process_options,
-                    "from_scan": from_scan,
-                }
-                enqueue_result = await rag.apipeline_enqueue_documents(
-                    content, **enqueue_kwargs
-                )
-                if enqueue_result is None:
-                    try:
-                        await move_file_to_parsed_dir(file_path)
-                    except Exception as move_error:
-                        logger.error(
-                            f"Failed to move duplicate file {file_path.name} to {PARSED_DIR_NAME} directory: {move_error}"
-                        )
-                    return False, track_id
-
-                logger.info(
-                    f"Successfully extracted and enqueued file: {file_path.name}"
-                )
-
-                # Move file to __parsed__ directory after enqueuing (LR2-PRD: parsed output dir)
+            enqueue_kwargs = {
+                "file_paths": str(file_path),
+                "track_id": track_id,
+                "docs_format": FULL_DOCS_FORMAT_PENDING_PARSE,
+                "parse_engine": extraction_engine,
+                "process_options": api_process_options,
+                "from_scan": from_scan,
+            }
+            enqueue_result = await rag.apipeline_enqueue_documents("", **enqueue_kwargs)
+            if enqueue_result is None:
                 try:
                     await move_file_to_parsed_dir(file_path)
                 except Exception as move_error:
                     logger.error(
-                        f"Failed to move file {file_path.name} to {PARSED_DIR_NAME} directory: {move_error}"
+                        f"Failed to move duplicate file {file_path.name} to {PARSED_DIR_NAME} directory: {move_error}"
                     )
-                    # Don't affect the main function's success status
-
-                return True, track_id
-
-            except Exception as e:
-                error_files = [
-                    {
-                        "file_path": str(file_path.name),
-                        "error_description": "Document enqueue error",
-                        "original_error": f"Failed to enqueue document: {str(e)}",
-                        "file_size": file_size,
-                    }
-                ]
-                await rag.apipeline_enqueue_error_documents(error_files, track_id)
-                logger.error(f"Error enqueueing document {file_path.name}: {str(e)}")
                 return False, track_id
-        else:
+            logger.info(
+                f"[File Extraction]Deferred {file_path.name} to {extraction_engine} parser"
+            )
+            return True, track_id
+        except Exception as e:
             error_files = [
                 {
                     "file_path": str(file_path.name),
-                    "error_description": "No content extracted",
-                    "original_error": "No content could be extracted from file",
+                    "error_description": "[File Extraction]Parser enqueue error",
+                    "original_error": f"Failed to enqueue file for parser: {str(e)}",
                     "file_size": file_size,
                 }
             ]
             await rag.apipeline_enqueue_error_documents(error_files, track_id)
-            logger.error(f"No content extracted from file: {file_path.name}")
+            logger.error(
+                f"[File Extraction]Error enqueuing {file_path.name} for {extraction_engine}: {str(e)}"
+            )
             return False, track_id
 
     except Exception as e:

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -967,53 +967,10 @@ class DocumentManager:
         self,
         input_dir: str,
         workspace: str = "",  # New parameter for workspace isolation
-        supported_extensions: tuple = (
-            ".txt",
-            ".md",
-            ".mdx",  # MDX (Markdown + JSX)
-            ".pdf",
-            ".docx",
-            ".pptx",
-            ".xlsx",
-            ".rtf",  # Rich Text Format
-            ".odt",  # OpenDocument Text
-            ".tex",  # LaTeX
-            ".epub",  # Electronic Publication
-            ".html",  # HyperText Markup Language
-            ".htm",  # HyperText Markup Language
-            ".csv",  # Comma-Separated Values
-            ".json",  # JavaScript Object Notation
-            ".xml",  # eXtensible Markup Language
-            ".yaml",  # YAML Ain't Markup Language
-            ".yml",  # YAML
-            ".log",  # Log files
-            ".conf",  # Configuration files
-            ".ini",  # Initialization files
-            ".properties",  # Java properties files
-            ".sql",  # SQL scripts
-            ".bat",  # Batch files
-            ".sh",  # Shell scripts
-            ".c",  # C source code
-            ".h",  # C header
-            ".cpp",  # C++ source code
-            ".hpp",  # C++ header
-            ".py",  # Python source code
-            ".java",  # Java source code
-            ".js",  # JavaScript source code
-            ".ts",  # TypeScript source code
-            ".swift",  # Swift source code
-            ".go",  # Go source code
-            ".rb",  # Ruby source code
-            ".php",  # PHP source code
-            ".css",  # Cascading Style Sheets
-            ".scss",  # Sassy CSS
-            ".less",  # LESS CSS
-        ),
     ):
         # Store the base input directory and workspace
         self.base_input_dir = Path(input_dir)
         self.workspace = workspace
-        self._base_supported_extensions = supported_extensions
         self.indexed_files = set()
 
         # Create workspace-specific input directory
@@ -1028,23 +985,17 @@ class DocumentManager:
 
     @property
     def supported_extensions(self) -> tuple:
-        """Curated built-in allowlist ∪ third-party engine suffixes.
+        """Upload/scan allowlist, derived live from the parser registry.
 
-        Computed live from the parser registry so a `lightrag.parsers`
-        plugin's file types become uploadable/scannable as soon as the
-        plugin is registered — without widening the curated built-in set
-        (e.g. mineru's image suffixes stay non-uploadable by default).
+        Union of the suffixes of every user-selectable engine whose endpoint
+        gate passes (see ``available_engine_suffixes``): a default deployment
+        equals the local engines' types (legacy ∪ native); configuring an
+        external engine's endpoint (or registering a third-party plugin)
+        admits its types automatically — no hardcoded list to keep in sync.
         """
-        from lightrag.parser.registry import third_party_engine_suffixes
+        from lightrag.parser.registry import available_engine_suffixes
 
-        extra = tuple(
-            sorted(
-                f".{s}"
-                for s in third_party_engine_suffixes()
-                if f".{s}" not in self._base_supported_extensions
-            )
-        )
-        return self._base_supported_extensions + extra
+        return tuple(sorted(f".{s}" for s in available_engine_suffixes()))
 
     def scan_directory_for_new_files(self) -> List[Path]:
         """Scan input directory for new files"""

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -138,100 +138,13 @@ FULL_DOCS_FORMAT_PENDING_PARSE = (
 # leading summary of the parsed document so paginated APIs can show a real
 # preview without loading the full LightRAG Document file.
 LIGHTRAG_DOC_CONTENT_PREFIX = "{{LRdoc}}"
+# Engine identifier strings (registry keys). The set of user-selectable
+# engines and their suffix capabilities now live in
+# lightrag.parser.registry (ParserSpec table) — the single source of truth.
 PARSER_ENGINE_LEGACY = "legacy"
 PARSER_ENGINE_NATIVE = "native"
 PARSER_ENGINE_MINERU = "mineru"
 PARSER_ENGINE_DOCLING = "docling"
-SUPPORTED_PARSER_ENGINES = frozenset(
-    {
-        PARSER_ENGINE_LEGACY,
-        PARSER_ENGINE_NATIVE,
-        PARSER_ENGINE_MINERU,
-        PARSER_ENGINE_DOCLING,
-    }
-)
-PARSER_ENGINE_SUFFIX_CAPABILITIES = {
-    PARSER_ENGINE_LEGACY: frozenset(
-        {
-            "txt",
-            "md",
-            "mdx",
-            "pdf",
-            "docx",
-            "pptx",
-            "xlsx",
-            "rtf",
-            "odt",
-            "tex",
-            "epub",
-            "html",
-            "htm",
-            "csv",
-            "json",
-            "xml",
-            "yaml",
-            "yml",
-            "log",
-            "conf",
-            "ini",
-            "properties",
-            "sql",
-            "bat",
-            "sh",
-            "c",
-            "h",
-            "cpp",
-            "hpp",
-            "py",
-            "java",
-            "js",
-            "ts",
-            "swift",
-            "go",
-            "rb",
-            "php",
-            "css",
-            "scss",
-            "less",
-        }
-    ),
-    PARSER_ENGINE_NATIVE: frozenset({"docx"}),
-    PARSER_ENGINE_MINERU: frozenset(
-        {
-            "pdf",
-            "doc",
-            "docx",
-            "ppt",
-            "pptx",
-            "xls",
-            "xlsx",
-            "png",
-            "jpg",
-            "jpeg",
-            "jp2",
-            "webp",
-            "gif",
-            "bmp",
-        }
-    ),
-    PARSER_ENGINE_DOCLING: frozenset(
-        {
-            "pdf",
-            "docx",
-            "pptx",
-            "xlsx",
-            "md",
-            "html",
-            "xhtml",
-            "png",
-            "jpg",
-            "jpeg",
-            "tiff",
-            "webp",
-            "bmp",
-        }
-    ),
-}
 PARSED_DIR_NAME = "__parsed__"  # Dir for parsed files (renamed from __enqueued__)
 
 # Suffixes for parser artifact subdirectories under ``<input>/__parsed__/``.

--- a/lightrag/parser/base.py
+++ b/lightrag/parser/base.py
@@ -92,6 +92,18 @@ class ParseContext:
         )
         return ResolvedSource(source_path, document_name, parsed_dir)
 
+    async def archive_source(self, source_path: str) -> str | None:
+        """Archive the source after a successful parse + full_docs sync.
+
+        Resolved through the pipeline module's namespace (where the function
+        is imported) so existing tests that patch
+        ``lightrag.pipeline.archive_docx_source_after_full_docs_sync`` keep
+        intercepting it now that the call site lives in the parser layer.
+        """
+        import lightrag.pipeline as _pipeline
+
+        return await _pipeline.archive_docx_source_after_full_docs_sync(source_path)
+
 
 @dataclass
 class ParseResult:

--- a/lightrag/parser/base.py
+++ b/lightrag/parser/base.py
@@ -1,0 +1,143 @@
+"""Unified parser contract for native + external parser engines.
+
+Every engine (native docx, mineru, docling, legacy, plus the internal
+``reuse``/``passthrough`` format handlers) implements :class:`BaseParser`.
+The pipeline dispatches through the registry
+(:mod:`lightrag.parser.registry`) instead of a growing ``if engine == …``
+chain.
+
+Design notes:
+
+- ``BaseParser`` carries *behaviour only* (the ``parse`` coroutine and any
+  engine-private hooks).  Capability metadata (supported suffixes, queue
+  group, endpoint requirements) lives in the registry's lightweight
+  ``ParserSpec`` table so capability queries never import a parser
+  implementation.
+- ``ParseResult.to_dict()`` emits only semantically-present fields so the
+  returned dict stays byte-for-byte compatible with the pre-refactor
+  ``parse_native``/``parse_mineru``/``parse_docling`` return shapes (the
+  worker reads these by ``.get(...)``).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from lightrag.sidecar.ir import IRDoc  # noqa: F401
+
+
+@dataclass
+class ResolvedSource:
+    """The common parse preamble shared by every engine."""
+
+    source_path: Path
+    document_name: str
+    parsed_dir: Path
+
+
+@dataclass
+class ParseContext:
+    """Inputs handed to :meth:`BaseParser.parse`.
+
+    Wraps the LightRAG instance plus the per-document handles so a parser
+    does not receive a bare ``self``.  Convenience helpers lazily import
+    pipeline-layer functions at call time, keeping this module import-cheap
+    and free of import cycles.
+    """
+
+    rag: Any
+    doc_id: str
+    file_path: str
+    content_data: dict[str, Any]
+
+    def source_path(self, parser_engine: str) -> Path:
+        """Resolve the on-disk source file for this document."""
+        from lightrag.pipeline import (
+            _call_source_file_resolver,
+            _read_source_file,
+        )
+
+        return Path(
+            _call_source_file_resolver(
+                self.rag,
+                self.file_path,
+                source_file=_read_source_file(self.content_data),
+                parser_engine=parser_engine,
+            )
+        )
+
+    def resolve(self, parser_engine: str) -> ResolvedSource:
+        """Resolve ``(source_path, document_name, parsed_dir)``.
+
+        Mirrors the preamble shared by ``parse_mineru``/``parse_docling``/
+        ``parse_native``: canonicalize the document name defensively (so
+        direct callers may pass absolute or hint-bearing paths) and derive
+        the ``__parsed__/<base>.parsed/`` output directory.
+        """
+        from lightrag.utils_pipeline import (
+            normalize_document_file_path,
+            parsed_artifact_dir_for,
+        )
+
+        source_path = self.source_path(parser_engine)
+        document_name = normalize_document_file_path(self.file_path)
+        if document_name == "unknown_source":
+            document_name = source_path.name or f"{self.doc_id}.bin"
+        parsed_dir = parsed_artifact_dir_for(
+            document_name, parent_hint=source_path.parent
+        )
+        return ResolvedSource(source_path, document_name, parsed_dir)
+
+
+@dataclass
+class ParseResult:
+    """Structured parser output.
+
+    ``to_dict`` only emits fields that carry meaning so the dict matches the
+    pre-refactor return shapes exactly (no spurious ``None``/``False`` keys).
+    """
+
+    doc_id: str
+    file_path: str
+    parse_format: str
+    content: str
+    blocks_path: str = ""
+    parse_engine: str | None = None
+    parse_stage_skipped: bool = False
+    parse_warnings: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "doc_id": self.doc_id,
+            "file_path": self.file_path,
+            "parse_format": self.parse_format,
+            "content": self.content,
+            "blocks_path": self.blocks_path,
+        }
+        if self.parse_engine is not None:
+            out["parse_engine"] = self.parse_engine
+        if self.parse_stage_skipped:
+            out["parse_stage_skipped"] = True
+        if self.parse_warnings:
+            out["parse_warnings"] = self.parse_warnings
+        return out
+
+
+class BaseParser(ABC):
+    """Abstract base for every parser engine.
+
+    Subclasses set ``engine_name`` and implement :meth:`parse`.  Capability
+    metadata (suffixes/queue group/endpoint) is declared in the registry
+    ``ParserSpec``, not here.
+    """
+
+    engine_name: str
+
+    @abstractmethod
+    async def parse(self, ctx: ParseContext) -> ParseResult:
+        """Parse one document and return its :class:`ParseResult`."""
+        ...

--- a/lightrag/parser/cli.py
+++ b/lightrag/parser/cli.py
@@ -1,9 +1,12 @@
-"""Unified sidecar debug CLI for native / mineru / docling parsers.
+"""Unified sidecar debug CLI for any registered parser engine.
 
-Drives ``LightRAG.parse_<engine>`` against a single source file and writes
-the resulting sidecar (and raw bundle, for mineru/docling) into a flat
-layout — no ``__parsed__/`` middle layer, source file never archived —
-so the artifacts can be inspected next to the input file.
+Dispatches one source file through the parser registry
+(``get_parser(engine).parse(...)``) and writes the resulting sidecar (and
+raw bundle, for external engines) into a flat layout — no ``__parsed__/``
+middle layer, source file never archived — so the artifacts can be
+inspected next to the input file. Because dispatch goes through the
+registry, a third-party engine registered via ``register_parser`` is a
+valid ``--engine`` choice with no CLI changes.
 
 Invocation::
 
@@ -24,8 +27,6 @@ from contextlib import ExitStack
 from pathlib import Path
 from typing import Any
 from unittest import mock
-
-ENGINES = ("native", "mineru", "docling")
 
 
 def _normalize_direct_script_sys_path() -> None:
@@ -50,11 +51,18 @@ _normalize_direct_script_sys_path()
 
 
 def _build_parser() -> argparse.ArgumentParser:
+    # Registry import is cheap by design (no parser impl is pulled in), so
+    # deriving --engine choices here keeps third-party engines selectable
+    # without making --help pay for a heavy import.
+    from lightrag.parser.registry import supported_parser_engines
+
+    engines = sorted(supported_parser_engines())
+
     parser = argparse.ArgumentParser(
         prog="parse_sidecar",
         description=(
-            "Run LightRAG.parse_<engine> on a single file and emit sidecar "
-            "artifacts (plus a raw bundle for mineru/docling) into a flat "
+            "Run a registered parser engine on a single file and emit sidecar "
+            "artifacts (plus a raw bundle for external engines) into a flat "
             "layout alongside the source. No __parsed__/ middle layer; the "
             "source file is never moved."
         ),
@@ -63,7 +71,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--engine",
         required=True,
-        choices=ENGINES,
+        choices=engines,
         help="Parser engine to drive.",
     )
     parser.add_argument(
@@ -137,7 +145,9 @@ async def _run(args: argparse.Namespace) -> int:
     # Pipeline + heavy parser imports are deferred so ``--help`` and the
     # input-file existence check don't pay for them.
     from lightrag.constants import FULL_DOCS_FORMAT_PENDING_PARSE
-    from lightrag.parser.registry import suffix_capabilities
+    from lightrag.parser.base import ParseContext
+    from lightrag.parser.external._base import ExternalParserBase
+    from lightrag.parser.registry import get_parser, suffix_capabilities
     from lightrag.parser.debug import build_debug_rag
     from lightrag.parser.docx.parse_document import DocxContentError
     from lightrag.utils import compute_mdhash_id
@@ -161,13 +171,22 @@ async def _run(args: argparse.Namespace) -> int:
         )
         return 1
 
+    parser = get_parser(args.engine)
+    if parser is None:
+        print(f"error: engine '{args.engine}' is not registered", file=sys.stderr)
+        return 1
+    is_external = isinstance(parser, ExternalParserBase)
+
     sidecar_parent = (args.sidecar_parent_dir or source.parent).resolve()
     sidecar_parent.mkdir(parents=True, exist_ok=True)
 
     parsed_dir = sidecar_parent / f"{source.name}.parsed"
+    # External engines preserve a raw bundle next to the sidecar; its name is
+    # derived from the engine's own raw_dir_suffix (mirrors the flattened
+    # raw_dir_for_parsed_dir layout), so any external engine works here.
     raw_dir = (
-        sidecar_parent / f"{source.name}.{args.engine}_raw"
-        if args.engine in ("mineru", "docling")
+        sidecar_parent / f"{source.name}{parser.raw_dir_suffix}"
+        if is_external
         else None
     )
 
@@ -195,7 +214,6 @@ async def _run(args: argparse.Namespace) -> int:
         return None
 
     rag = build_debug_rag()
-    parse_method = getattr(rag, f"parse_{args.engine}")
 
     with ExitStack() as stack:
         # Patch 1: redirect sidecar output to the flat layout.
@@ -216,24 +234,16 @@ async def _run(args: argparse.Namespace) -> int:
             )
         )
 
-        # Patch 2: raw cache strategy. parse_mineru / parse_docling do a
-        # function-local ``from lightrag.parser.external.<eng> import
-        # is_bundle_valid``, so we replace the name on the facade module.
-        if args.engine == "mineru":
-            import lightrag.parser.external.mineru as mineru_pkg
-
+        # Patch 2: raw cache strategy. ExternalParserBase.parse calls
+        # ``self.is_bundle_valid(...)``, so patch the resolved instance method
+        # directly — works for any external engine without knowing its module.
+        if is_external:
             stack.enter_context(
-                mock.patch.object(mineru_pkg, "is_bundle_valid", bundle_check)
-            )
-        elif args.engine == "docling":
-            import lightrag.parser.external.docling as docling_pkg
-
-            stack.enter_context(
-                mock.patch.object(docling_pkg, "is_bundle_valid", bundle_check)
+                mock.patch.object(parser, "is_bundle_valid", bundle_check)
             )
 
-        # Patch 3: keep the source file in place. All three parse_* methods
-        # call archive_docx_source_after_full_docs_sync at the end.
+        # Patch 3: keep the source file in place. Every engine archives via
+        # ctx.archive_source -> lightrag.pipeline.archive_docx_source_after_...
         stack.enter_context(
             mock.patch.object(
                 pipeline_mod,
@@ -243,14 +253,19 @@ async def _run(args: argparse.Namespace) -> int:
         )
 
         try:
-            result = await parse_method(
-                doc_id,
-                str(source),
-                {
-                    "parse_format": FULL_DOCS_FORMAT_PENDING_PARSE,
-                    "content": "",
-                },
-            )
+            result = (
+                await parser.parse(
+                    ParseContext(
+                        rag,
+                        doc_id,
+                        str(source),
+                        {
+                            "parse_format": FULL_DOCS_FORMAT_PENDING_PARSE,
+                            "content": "",
+                        },
+                    )
+                )
+            ).to_dict()
         except DocxContentError as exc:
             # The native DOCX parser now raises (instead of sys.exit) on a
             # content-limit violation so the server pipeline can fail just the

--- a/lightrag/parser/cli.py
+++ b/lightrag/parser/cli.py
@@ -136,10 +136,8 @@ def _print_summary(blocks_path: Path, raw_dir: Path | None, preview: int) -> Non
 async def _run(args: argparse.Namespace) -> int:
     # Pipeline + heavy parser imports are deferred so ``--help`` and the
     # input-file existence check don't pay for them.
-    from lightrag.constants import (
-        FULL_DOCS_FORMAT_PENDING_PARSE,
-        PARSER_ENGINE_SUFFIX_CAPABILITIES,
-    )
+    from lightrag.constants import FULL_DOCS_FORMAT_PENDING_PARSE
+    from lightrag.parser.registry import suffix_capabilities
     from lightrag.parser.debug import build_debug_rag
     from lightrag.parser.docx.parse_document import DocxContentError
     from lightrag.utils import compute_mdhash_id
@@ -154,7 +152,7 @@ async def _run(args: argparse.Namespace) -> int:
     # Reject suffix/engine mismatches up-front: the pipeline would otherwise
     # fail deep inside the IR builder with a less helpful message.
     suffix = source.suffix.lstrip(".").lower()
-    supported = PARSER_ENGINE_SUFFIX_CAPABILITIES.get(args.engine, frozenset())
+    supported = suffix_capabilities(args.engine)
     if suffix not in supported:
         print(
             f"error: engine '{args.engine}' does not support .{suffix or '<no suffix>'} "

--- a/lightrag/parser/cli.py
+++ b/lightrag/parser/cli.py
@@ -298,6 +298,12 @@ async def _run(args: argparse.Namespace) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
+    # Discover third-party parser engines before --engine choices are built,
+    # so a `lightrag.parsers` entry-point engine is selectable here exactly
+    # like in the server (which loads plugins in create_app).
+    from lightrag.parser.plugins import load_third_party_parsers
+
+    load_third_party_parsers()
     args = _build_parser().parse_args(argv)
     return asyncio.run(_run(args))
 

--- a/lightrag/parser/cli.py
+++ b/lightrag/parser/cli.py
@@ -141,6 +141,19 @@ def _print_summary(blocks_path: Path, raw_dir: Path | None, preview: int) -> Non
             )
 
 
+def _print_raw_summary(result: dict, preview: int) -> None:
+    """Summary for engines that emit plain content with no sidecar (legacy /
+    any non-sidecar third-party engine: ``blocks_path`` is empty)."""
+    content = result.get("content") or ""
+    print(f"engine     : {result.get('parse_engine')}")
+    print(f"format     : {result.get('parse_format')}")
+    print(f"content    : {len(content)} chars")
+    if preview > 0 and content:
+        snippet = content[:400]
+        print(f"--- preview (first {len(snippet)} of {len(content)} chars) ---")
+        print(snippet + ("..." if len(content) > len(snippet) else ""))
+
+
 async def _run(args: argparse.Namespace) -> int:
     # Pipeline + heavy parser imports are deferred so ``--help`` and the
     # input-file existence check don't pay for them.
@@ -274,8 +287,13 @@ async def _run(args: argparse.Namespace) -> int:
             print(str(exc), file=sys.stderr)
             return 1
 
-    blocks_path = Path(result["blocks_path"])
-    _print_summary(blocks_path, raw_dir, args.preview)
+    blocks_path = result.get("blocks_path") or ""
+    if blocks_path:
+        _print_summary(Path(blocks_path), raw_dir, args.preview)
+    else:
+        # No sidecar (legacy / non-sidecar third-party engine): the result
+        # carries plain content, so summarize that instead of a blocks file.
+        _print_raw_summary(result, args.preview)
     return 0
 
 

--- a/lightrag/parser/debug.py
+++ b/lightrag/parser/debug.py
@@ -1,4 +1,4 @@
-"""Shared debug LightRAG stand-in for the parse_* entry points.
+"""Shared debug LightRAG stand-in for registry-dispatched parsing.
 
 A minimal ``LightRAG`` stand-in plus a deterministic ``datetime`` shim,
 shared by the unified parser debug CLI (``lightrag/parser/cli.py``),
@@ -6,11 +6,12 @@ the golden-fixture regen script (``scripts/regen_native_docx_golden.py``),
 and the byte-equivalence golden tests
 (``tests/parser/docx/test_native_docx_golden.py``).
 
-All three engines (``native`` / ``mineru`` / ``docling``) read the same
-``self`` surface (``_persist_parsed_full_docs``, ``_resolve_source_file_for_parser``,
+Every engine is driven the same way — ``get_parser(engine).parse(
+ParseContext(rag, ...))`` — and ``ParseContext`` reads the same ``rag``
+surface (``_persist_parsed_full_docs``, ``_resolve_source_file_for_parser``,
 ``self.full_docs``, ``self.doc_status``), so a single stand-in covers every
-``parse_*`` method — when one of them grows a new dependency, extend
-this module rather than copy-pasting parallel stubs into each call site.
+engine — when a parser grows a new dependency, extend this module rather
+than copy-pasting parallel stubs into each call site.
 """
 
 from __future__ import annotations

--- a/lightrag/parser/debug.py
+++ b/lightrag/parser/debug.py
@@ -46,16 +46,16 @@ class DebugDocStatus:
 
 
 def build_debug_rag():
-    """Build a minimal LightRAG stand-in that exposes what ``parse_*`` reads.
+    """Build a minimal LightRAG stand-in that exposes what a parser reads.
 
     The import of ``LightRAG`` is intentionally function-local: deferring
     it avoids a circular import when this helper is loaded during package
     init (the parser CLI resolves ``lightrag.parser.debug`` before
     ``lightrag`` itself is fully bound).
 
-    LightRAG-side attributes the three ``parse_*`` methods read off ``self`` —
-    every entry MUST be provided by this stand-in, or the debug CLI / golden
-    tests / regen script will all break in sync:
+    A parser is driven via ``get_parser(engine).parse(ParseContext(rag, ...))``
+    (CLI / golden tests / regen script). ``ParseContext`` reads these off the
+    ``rag`` it is handed — every entry MUST be provided by this stand-in:
 
     - **methods** (rebound from :class:`LightRAG`):
         - ``_persist_parsed_full_docs(doc_id, payload)`` — async; touches
@@ -69,17 +69,14 @@ def build_debug_rag():
         - ``self.doc_status.get_by_id(...)`` / ``.upsert(...)`` —
           :class:`DebugDocStatus` covers both.
 
-    When any of the three ``LightRAG.parse_*`` methods grows a new
-    dependency on ``self``, extend this stand-in (and update the list
-    above) rather than copy-pasting a parallel stub into the call sites.
+    When a parser grows a new dependency on the ``rag`` handed to
+    ``ParseContext``, extend this stand-in (and update the list above) rather
+    than copy-pasting a parallel stub into the call sites.
     """
     from lightrag import LightRAG
 
     class _DebugRag:
         _persist_parsed_full_docs = LightRAG._persist_parsed_full_docs
-        parse_native = LightRAG.parse_native
-        parse_mineru = LightRAG.parse_mineru
-        parse_docling = LightRAG.parse_docling
 
         def __init__(self) -> None:
             self.full_docs = DebugFullDocs()

--- a/lightrag/parser/docx/parser.py
+++ b/lightrag/parser/docx/parser.py
@@ -1,0 +1,88 @@
+"""Native DOCX engine adapter (implements NativeParserBase hooks)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from lightrag.constants import PARSER_ENGINE_NATIVE
+from lightrag.parser.native_base import NativeParserBase
+from lightrag.utils import logger
+
+if TYPE_CHECKING:
+    from lightrag.sidecar.ir import IRDoc
+
+
+class NativeDocxParser(NativeParserBase):
+    engine_name = PARSER_ENGINE_NATIVE
+    sidecar_path_style = "basename_only"  # legacy native docx convention
+    empty_content_label = "DOCX"
+
+    def validate_source(self, source: Path, file_path: str) -> None:
+        if not (
+            source.exists() and source.is_file() and source.suffix.lower() == ".docx"
+        ):
+            raise ValueError(
+                f"Native parser does not support pending file: {file_path}"
+            )
+
+    def extract(
+        self, source: Path, *, parsed_dir: Path, asset_dir: Path, base_name: str
+    ) -> tuple[list[dict[str, Any]], dict[str, Any], dict[str, Any]]:
+        from lightrag.parser.docx.drawing_image_extractor import (
+            DrawingExtractionContext,
+            load_relationships,
+        )
+        from lightrag.parser.docx.parse_document import extract_docx_blocks
+
+        ctx = DrawingExtractionContext(
+            docx_path=source,
+            blocks_output_path=parsed_dir / f"{base_name}.blocks.jsonl",
+            export_dir_name=asset_dir.name,
+            export_dir_path=asset_dir,
+        )
+        load_relationships(ctx)
+        warnings: dict[str, Any] = {}
+        metadata: dict[str, Any] = {}
+        blocks = extract_docx_blocks(
+            str(source),
+            debug=False,
+            fixlevel=0,
+            drawing_context=ctx,
+            parse_warnings=warnings,
+            parse_metadata=metadata,
+        )
+        return blocks, warnings, metadata
+
+    def build_ir(
+        self,
+        blocks: list[dict[str, Any]],
+        *,
+        document_name: str,
+        asset_dir_name: str,
+        metadata: dict[str, Any],
+    ) -> "IRDoc":
+        from lightrag.parser.docx.ir_builder import NativeDocxIRBuilder
+
+        return NativeDocxIRBuilder().normalize(
+            blocks,
+            document_name=document_name,
+            asset_dir_name=asset_dir_name,
+            parse_metadata=metadata,
+        )
+
+    def surface_warnings(
+        self, warnings: dict[str, Any], source: Path
+    ) -> dict[str, Any] | None:
+        missing = int(warnings.get("missing_paraid_count", 0) or 0)
+        if missing > 0:
+            # Surface once per document; affected blocks emit
+            # ``positions: [{"type": "paraid", "range": null}]``.
+            logger.warning(
+                "[parse_native] %s: %d paragraphs lack paraId; "
+                "Re-saving file in Word 2013+ to regenerate ids.",
+                source.name,
+                missing,
+            )
+            return {"missing_paraid_count": missing}
+        return None

--- a/lightrag/parser/external/_base.py
+++ b/lightrag/parser/external/_base.py
@@ -66,7 +66,6 @@ class ExternalParserBase(BaseParser):
         )
         from lightrag.sidecar import write_sidecar
         from lightrag.utils_pipeline import (
-            archive_source_after_full_docs_sync,
             make_lightrag_doc_content,
             sidecar_uri_for,
         )
@@ -126,7 +125,7 @@ class ExternalParserBase(BaseParser):
                 "update_time": int(time.time()),
             },
         )
-        await archive_source_after_full_docs_sync(str(source))
+        await ctx.archive_source(str(source))
         return ParseResult(
             doc_id=ctx.doc_id,
             file_path=ctx.file_path,

--- a/lightrag/parser/external/_base.py
+++ b/lightrag/parser/external/_base.py
@@ -1,0 +1,138 @@
+"""Shared template for external (download + raw-bundle cache) parser engines.
+
+``ExternalParserBase.parse`` fixes the common MinerU/Docling flow once:
+
+    resolve → raw_dir → force-reparse check → cache-hit skip
+    else (mkdir + clear_dir_contents + download_into) → build_ir
+    → write_sidecar → persist full_docs (lightrag) → archive source
+
+Subclasses implement three engine-private hooks (``is_bundle_valid`` /
+``download_into`` / ``build_ir``) and set ``raw_dir_suffix`` /
+``force_reparse_env``.  This is the reshaped #3207 contract — now an
+*internal* template rather than the top-level parser interface — with its two
+gaps fixed: ``clear_dir_contents`` runs inside the template (cache-miss only),
+and the per-engine upload-name divergence is normalised to a single
+``upload_name`` hook parameter.
+"""
+
+from __future__ import annotations
+
+import time
+from abc import abstractmethod
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from lightrag.constants import FULL_DOCS_FORMAT_LIGHTRAG
+from lightrag.parser.base import BaseParser, ParseContext, ParseResult
+from lightrag.utils import logger
+
+if TYPE_CHECKING:
+    from lightrag.sidecar.ir import IRDoc
+
+
+class ExternalParserBase(BaseParser):
+    """Base for engines that fetch a raw bundle from an external service."""
+
+    raw_dir_suffix: str
+    force_reparse_env: str
+
+    # --- engine-private hooks ------------------------------------------------
+    @abstractmethod
+    def is_bundle_valid(self, raw_dir: Path, source_path: Path) -> bool:
+        """Cheap cache-hit check against the raw bundle on disk."""
+        ...
+
+    @abstractmethod
+    async def download_into(
+        self, raw_dir: Path, source_path: Path, *, upload_name: str
+    ) -> None:
+        """Fetch the raw bundle into ``raw_dir`` (called on cache miss only)."""
+        ...
+
+    @abstractmethod
+    def build_ir(self, raw_dir: Path, document_name: str) -> "IRDoc":
+        """Convert the raw bundle to an :class:`IRDoc`."""
+        ...
+
+    def validate_ir(self, ir: "IRDoc", *, file_path: str, raw_dir: Path) -> None:
+        """Optional post-build validation hook (default no-op)."""
+
+    # --- template ------------------------------------------------------------
+    async def parse(self, ctx: ParseContext) -> ParseResult:
+        from lightrag.parser.external._common import (
+            clear_dir_contents,
+            env_bool,
+            raw_dir_for_parsed_dir,
+        )
+        from lightrag.sidecar import write_sidecar
+        from lightrag.utils_pipeline import (
+            archive_source_after_full_docs_sync,
+            make_lightrag_doc_content,
+            sidecar_uri_for,
+        )
+
+        rs = ctx.resolve(self.engine_name)
+        source = rs.source_path
+        if not source.is_file():
+            raise FileNotFoundError(
+                f"{self.engine_name} source file not found: {source}"
+            )
+        raw_dir = raw_dir_for_parsed_dir(rs.parsed_dir, suffix=self.raw_dir_suffix)
+        force_reparse = env_bool(self.force_reparse_env, False)
+
+        parse_stage_skipped = False
+        if not force_reparse and self.is_bundle_valid(raw_dir, source):
+            # Cache hit: stay purely local so a re-parse still works when the
+            # external endpoint is temporarily unavailable.
+            parse_stage_skipped = True
+            logger.info("[%s] raw cache hit doc_id=%s", self.engine_name, ctx.doc_id)
+        else:
+            if force_reparse and raw_dir.exists():
+                logger.info(
+                    "[%s] %s set; discarding bundle at %s",
+                    self.engine_name,
+                    self.force_reparse_env,
+                    raw_dir,
+                )
+            # download_into mkdir's raw_dir; we wipe stale contents first so a
+            # previous bundle cannot leak into the new one (cache-miss only).
+            raw_dir.mkdir(parents=True, exist_ok=True)
+            clear_dir_contents(raw_dir)
+            logger.info(
+                "[%s] Parsing %s %s (may take a few minutes)",
+                self.engine_name,
+                ctx.doc_id,
+                source.name,
+            )
+            await self.download_into(raw_dir, source, upload_name=rs.document_name)
+
+        ir = self.build_ir(raw_dir, rs.document_name)
+        self.validate_ir(ir, file_path=ctx.file_path, raw_dir=raw_dir)
+        parsed_data = write_sidecar(
+            ir,
+            parsed_dir=rs.parsed_dir,
+            doc_id=ctx.doc_id,
+            engine=self.engine_name,
+        )
+
+        await ctx.rag._persist_parsed_full_docs(
+            ctx.doc_id,
+            {
+                "content": make_lightrag_doc_content(parsed_data["content"]),
+                "file_path": ctx.file_path,
+                "parse_format": FULL_DOCS_FORMAT_LIGHTRAG,
+                "sidecar_location": sidecar_uri_for(rs.parsed_dir),
+                "parse_engine": self.engine_name,
+                "update_time": int(time.time()),
+            },
+        )
+        await archive_source_after_full_docs_sync(str(source))
+        return ParseResult(
+            doc_id=ctx.doc_id,
+            file_path=ctx.file_path,
+            parse_format=FULL_DOCS_FORMAT_LIGHTRAG,
+            content=parsed_data["content"],
+            blocks_path=parsed_data["blocks_path"],
+            parse_engine=self.engine_name,
+            parse_stage_skipped=parse_stage_skipped,
+        )

--- a/lightrag/parser/external/docling/parser.py
+++ b/lightrag/parser/external/docling/parser.py
@@ -1,0 +1,49 @@
+"""Docling engine adapter (implements ExternalParserBase hooks)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from lightrag.constants import DOCLING_RAW_DIR_SUFFIX, PARSER_ENGINE_DOCLING
+from lightrag.parser.external._base import ExternalParserBase
+
+if TYPE_CHECKING:
+    from lightrag.sidecar.ir import IRDoc
+
+
+class DoclingParser(ExternalParserBase):
+    engine_name = PARSER_ENGINE_DOCLING
+    raw_dir_suffix = DOCLING_RAW_DIR_SUFFIX
+    force_reparse_env = "LIGHTRAG_FORCE_REPARSE_DOCLING"
+
+    def is_bundle_valid(self, raw_dir: Path, source_path: Path) -> bool:
+        from lightrag.parser.external.docling import is_bundle_valid
+
+        return is_bundle_valid(raw_dir, source_path)
+
+    async def download_into(
+        self, raw_dir: Path, source_path: Path, *, upload_name: str
+    ) -> None:
+        from lightrag.parser.external.docling import DoclingRawClient
+
+        # Map the canonical ``upload_name`` onto docling-serve's multipart
+        # filename so the bundle's main JSON is named ``<canonical_stem>.json``
+        # (the IR builder locates it via that canonical stem).
+        await DoclingRawClient().download_into(
+            raw_dir, source_path, upload_filename=upload_name
+        )
+
+    def build_ir(self, raw_dir: Path, document_name: str) -> "IRDoc":
+        from lightrag.parser.external.docling import DoclingIRBuilder
+
+        return DoclingIRBuilder().normalize_from_workdir(
+            raw_dir, document_name=document_name
+        )
+
+    def validate_ir(self, ir: "IRDoc", *, file_path: str, raw_dir: Path) -> None:
+        if not ir.blocks:
+            raise ValueError(
+                f"Docling IR builder produced zero blocks for {file_path} "
+                f"(raw_dir={raw_dir})"
+            )

--- a/lightrag/parser/external/mineru/parser.py
+++ b/lightrag/parser/external/mineru/parser.py
@@ -1,0 +1,39 @@
+"""MinerU engine adapter (implements ExternalParserBase hooks)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from lightrag.constants import MINERU_RAW_DIR_SUFFIX, PARSER_ENGINE_MINERU
+from lightrag.parser.external._base import ExternalParserBase
+
+if TYPE_CHECKING:
+    from lightrag.sidecar.ir import IRDoc
+
+
+class MinerUParser(ExternalParserBase):
+    engine_name = PARSER_ENGINE_MINERU
+    raw_dir_suffix = MINERU_RAW_DIR_SUFFIX
+    force_reparse_env = "LIGHTRAG_FORCE_REPARSE_MINERU"
+
+    def is_bundle_valid(self, raw_dir: Path, source_path: Path) -> bool:
+        from lightrag.parser.external.mineru import is_bundle_valid
+
+        return is_bundle_valid(raw_dir, source_path)
+
+    async def download_into(
+        self, raw_dir: Path, source_path: Path, *, upload_name: str
+    ) -> None:
+        from lightrag.parser.external.mineru import MinerURawClient
+
+        await MinerURawClient().download_into(
+            raw_dir, source_path, upload_name=upload_name
+        )
+
+    def build_ir(self, raw_dir: Path, document_name: str) -> "IRDoc":
+        from lightrag.parser.external.mineru import MinerUIRBuilder
+
+        return MinerUIRBuilder().normalize_from_workdir(
+            raw_dir, document_name=document_name
+        )

--- a/lightrag/parser/legacy/__init__.py
+++ b/lightrag/parser/legacy/__init__.py
@@ -1,0 +1,14 @@
+"""Legacy parser engine: simple in-process text extraction (no sidecar).
+
+Produces ``raw``-format plain text.  The extraction helpers
+(:func:`extract_text` and the per-format ``_extract_*`` functions) were moved
+here from the API layer so the core parser owns them (the API layer imports
+from here instead of the other way round).
+"""
+
+from lightrag.parser.legacy.extractors import (
+    LegacyExtractionError,
+    extract_text,
+)
+
+__all__ = ["LegacyExtractionError", "extract_text"]

--- a/lightrag/parser/legacy/extractors.py
+++ b/lightrag/parser/legacy/extractors.py
@@ -1,0 +1,185 @@
+"""Legacy text extractors (moved from the API layer).
+
+``extract_text`` dispatches on file suffix: binary office/pdf formats use the
+dedicated ``_extract_*`` helpers; everything else is decoded as UTF-8 text
+with the same validation (empty / binary-looking / non-UTF-8) the API upload
+path used to enforce — now raised as :class:`LegacyExtractionError` so a bad
+file fails the parse stage instead of silently yielding an empty document.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+
+class LegacyExtractionError(ValueError):
+    """Raised when legacy extraction cannot produce usable text."""
+
+
+def _extract_pdf_pypdf(file_bytes: bytes, password: str | None = None) -> str:
+    """Extract PDF content using pypdf (synchronous)."""
+    from pypdf import PdfReader  # type: ignore
+
+    pdf_file = BytesIO(file_bytes)
+    reader = PdfReader(pdf_file)
+
+    if reader.is_encrypted:
+        # Try empty password first (covers permission-only encrypted PDFs)
+        decrypt_result = reader.decrypt(password or "")
+        if decrypt_result == 0:
+            if password:
+                raise Exception("Incorrect PDF password")
+            else:
+                raise Exception("PDF is encrypted but no password provided")
+
+    content = ""
+    for page in reader.pages:
+        content += page.extract_text() + "\n"
+    return content
+
+
+def _extract_docx(file_bytes: bytes) -> str:
+    """Extract DOCX content including tables in document order (synchronous)."""
+    from docx import Document  # type: ignore
+    from docx.table import Table  # type: ignore
+    from docx.text.paragraph import Paragraph  # type: ignore
+
+    docx_file = BytesIO(file_bytes)
+    doc = Document(docx_file)
+
+    def escape_cell(cell_value: str | None) -> str:
+        if cell_value is None:
+            return ""
+        text = str(cell_value)
+        return (
+            text.replace("\\", "\\\\")
+            .replace("\t", "&emsp;&emsp;")
+            .replace("\r\n", "<br>")
+            .replace("\r", "<br>")
+            .replace("\n", "<br>")
+        )
+
+    content_parts = []
+    in_table = False
+    for element in doc.element.body:
+        if element.tag.endswith("p"):
+            if in_table:
+                content_parts.append("")
+                in_table = False
+            paragraph = Paragraph(element, doc)
+            content_parts.append(paragraph.text)
+        elif element.tag.endswith("tbl"):
+            if content_parts and not in_table:
+                content_parts.append("")
+            in_table = True
+            table = Table(element, doc)
+            for row in table.rows:
+                row_text = [escape_cell(cell.text) for cell in row.cells]
+                if any(cell for cell in row_text):
+                    content_parts.append("\t".join(row_text))
+    return "\n".join(content_parts)
+
+
+def _extract_pptx(file_bytes: bytes) -> str:
+    """Extract PPTX content (synchronous)."""
+    from pptx import Presentation  # type: ignore
+
+    pptx_file = BytesIO(file_bytes)
+    prs = Presentation(pptx_file)
+    content = ""
+    for slide in prs.slides:
+        for shape in slide.shapes:
+            if hasattr(shape, "text"):
+                content += shape.text + "\n"
+    return content
+
+
+def _extract_xlsx(file_bytes: bytes) -> str:
+    """Extract XLSX content in tab-delimited format with sheet separators."""
+    from openpyxl import load_workbook  # type: ignore
+
+    xlsx_file = BytesIO(file_bytes)
+    wb = load_workbook(xlsx_file)
+
+    def escape_cell(cell_value: str | int | float | None) -> str:
+        if cell_value is None:
+            return ""
+        text = str(cell_value)
+        return (
+            text.replace("\\", "\\\\")
+            .replace("\t", "\\t")
+            .replace("\r\n", "\\n")
+            .replace("\r", "\\n")
+            .replace("\n", "\\n")
+        )
+
+    def escape_sheet_title(title: str) -> str:
+        return str(title).replace("\n", " ").replace("\t", " ").replace("\r", " ")
+
+    content_parts: list[str] = []
+    sheet_separator = "=" * 20
+
+    for idx, sheet in enumerate(wb):
+        if idx > 0:
+            content_parts.append("")
+        safe_title = escape_sheet_title(sheet.title)
+        content_parts.append(f"{sheet_separator} Sheet: {safe_title} {sheet_separator}")
+        max_columns = sheet.max_column if sheet.max_column else 0
+        for row in sheet.iter_rows(values_only=True):
+            row_parts = []
+            for col_idx in range(max_columns):
+                if col_idx < len(row):
+                    row_parts.append(escape_cell(row[col_idx]))
+                else:
+                    row_parts.append("")
+            if all(part == "" for part in row_parts):
+                content_parts.append("")
+            else:
+                content_parts.append("\t".join(row_parts))
+    content_parts.append(sheet_separator)
+    return "\n".join(content_parts)
+
+
+# Suffixes (without dot) routed to dedicated binary extractors.
+_BINARY_EXTRACTORS = {
+    "pdf": _extract_pdf_pypdf,
+    "docx": _extract_docx,
+    "pptx": _extract_pptx,
+    "xlsx": _extract_xlsx,
+}
+
+
+def _decode_text(file_bytes: bytes) -> str:
+    """UTF-8 decode with the upload-path validation, raised on failure."""
+    try:
+        content = file_bytes.decode("utf-8")
+    except UnicodeDecodeError as e:
+        raise LegacyExtractionError(
+            "File is not valid UTF-8 encoded text. Please convert it to "
+            f"UTF-8 before processing: {e}"
+        ) from e
+    if not content or len(content.strip()) == 0:
+        raise LegacyExtractionError("File contains no content or only whitespace")
+    if content.startswith("b'") or content.startswith('b"'):
+        raise LegacyExtractionError(
+            "File appears to contain binary data representation instead of text"
+        )
+    return content
+
+
+def extract_text(
+    file_bytes: bytes, suffix: str, *, pdf_password: str | None = None
+) -> str:
+    """Extract plain text from ``file_bytes`` based on ``suffix`` (no dot).
+
+    Synchronous; callers run it in a thread.  Raises
+    :class:`LegacyExtractionError` (or the extractor's own exception) on
+    failure.
+    """
+    suffix = suffix.lower().lstrip(".")
+    extractor = _BINARY_EXTRACTORS.get(suffix)
+    if extractor is _extract_pdf_pypdf:
+        return _extract_pdf_pypdf(file_bytes, pdf_password)
+    if extractor is not None:
+        return extractor(file_bytes)
+    return _decode_text(file_bytes)

--- a/lightrag/parser/legacy/parser.py
+++ b/lightrag/parser/legacy/parser.py
@@ -1,0 +1,64 @@
+"""Legacy engine adapter: worker-stage plain-text extraction (RAW output)."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+
+from lightrag.constants import FULL_DOCS_FORMAT_RAW, PARSER_ENGINE_LEGACY
+from lightrag.parser.base import BaseParser, ParseContext, ParseResult
+
+
+class LegacyParser(BaseParser):
+    """Extract plain text in-process and store it as a ``raw`` document.
+
+    Also serves as the dispatch fallback engine: an unknown/unsupported
+    suffix raises (caught at the parse stage → doc_status FAILED) rather than
+    silently producing empty content.
+    """
+
+    engine_name = PARSER_ENGINE_LEGACY
+
+    async def parse(self, ctx: ParseContext) -> ParseResult:
+        from lightrag.parser.legacy.extractors import extract_text
+        from lightrag.parser.registry import suffix_capabilities
+        from lightrag.utils_pipeline import archive_source_after_full_docs_sync
+
+        rs = ctx.resolve(self.engine_name)
+        source = rs.source_path
+        if not source.is_file():
+            raise FileNotFoundError(f"legacy source file not found: {source}")
+
+        suffix = source.suffix.lower().lstrip(".")
+        if suffix not in suffix_capabilities(self.engine_name):
+            raise ValueError(
+                f"legacy parser does not support .{suffix or '<no suffix>'}: "
+                f"doc_id={ctx.doc_id} file={ctx.file_path}"
+            )
+
+        file_bytes = await asyncio.to_thread(source.read_bytes)
+        pdf_password = os.getenv("PDF_DECRYPT_PASSWORD") or None
+        text = await asyncio.to_thread(
+            extract_text, file_bytes, suffix, pdf_password=pdf_password
+        )
+
+        await ctx.rag._persist_parsed_full_docs(
+            ctx.doc_id,
+            {
+                "content": text,
+                "file_path": ctx.file_path,
+                "parse_format": FULL_DOCS_FORMAT_RAW,
+                "parse_engine": self.engine_name,
+                "update_time": int(time.time()),
+            },
+        )
+        await archive_source_after_full_docs_sync(str(source))
+        return ParseResult(
+            doc_id=ctx.doc_id,
+            file_path=ctx.file_path,
+            parse_format=FULL_DOCS_FORMAT_RAW,
+            content=text,
+            blocks_path="",
+            parse_engine=self.engine_name,
+        )

--- a/lightrag/parser/legacy/parser.py
+++ b/lightrag/parser/legacy/parser.py
@@ -40,10 +40,10 @@ class LegacyParser(BaseParser):
             )
 
         file_bytes = await asyncio.to_thread(source.read_bytes)
-        # The PDF password is sourced from env only. The API layer's
-        # ``global_args.pdf_decrypt_password`` is filled from this same env
-        # var; the parser layer must not read ``global_args`` (that would
-        # invert the parser -> API dependency direction).
+        # The PDF password is sourced from env only: the parser layer reads
+        # ``PDF_DECRYPT_PASSWORD`` directly rather than from the API layer's
+        # ``global_args`` (which would invert the parser -> API dependency
+        # direction).
         pdf_password = os.getenv("PDF_DECRYPT_PASSWORD") or None
         text = await asyncio.to_thread(
             extract_text, file_bytes, suffix, pdf_password=pdf_password

--- a/lightrag/parser/legacy/parser.py
+++ b/lightrag/parser/legacy/parser.py
@@ -21,7 +21,10 @@ class LegacyParser(BaseParser):
     engine_name = PARSER_ENGINE_LEGACY
 
     async def parse(self, ctx: ParseContext) -> ParseResult:
-        from lightrag.parser.legacy.extractors import extract_text
+        from lightrag.parser.legacy.extractors import (
+            LegacyExtractionError,
+            extract_text,
+        )
         from lightrag.parser.registry import suffix_capabilities
 
         rs = ctx.resolve(self.engine_name)
@@ -41,6 +44,15 @@ class LegacyParser(BaseParser):
         text = await asyncio.to_thread(
             extract_text, file_bytes, suffix, pdf_password=pdf_password
         )
+        # The binary extractors (pdf/docx/pptx/xlsx) return whatever the
+        # library yields — a scanned PDF with no text layer extracts to pure
+        # whitespace. Fail the parse (like the text-decode path already does)
+        # instead of persisting an empty document into chunking.
+        if not text.strip():
+            raise LegacyExtractionError(
+                f"extracted no usable text from {ctx.file_path} "
+                f"(doc_id={ctx.doc_id})"
+            )
 
         await ctx.rag._persist_parsed_full_docs(
             ctx.doc_id,

--- a/lightrag/parser/legacy/parser.py
+++ b/lightrag/parser/legacy/parser.py
@@ -23,7 +23,6 @@ class LegacyParser(BaseParser):
     async def parse(self, ctx: ParseContext) -> ParseResult:
         from lightrag.parser.legacy.extractors import extract_text
         from lightrag.parser.registry import suffix_capabilities
-        from lightrag.utils_pipeline import archive_source_after_full_docs_sync
 
         rs = ctx.resolve(self.engine_name)
         source = rs.source_path
@@ -53,7 +52,7 @@ class LegacyParser(BaseParser):
                 "update_time": int(time.time()),
             },
         )
-        await archive_source_after_full_docs_sync(str(source))
+        await ctx.archive_source(str(source))
         return ParseResult(
             doc_id=ctx.doc_id,
             file_path=ctx.file_path,

--- a/lightrag/parser/legacy/parser.py
+++ b/lightrag/parser/legacy/parser.py
@@ -40,6 +40,10 @@ class LegacyParser(BaseParser):
             )
 
         file_bytes = await asyncio.to_thread(source.read_bytes)
+        # The PDF password is sourced from env only. The API layer's
+        # ``global_args.pdf_decrypt_password`` is filled from this same env
+        # var; the parser layer must not read ``global_args`` (that would
+        # invert the parser -> API dependency direction).
         pdf_password = os.getenv("PDF_DECRYPT_PASSWORD") or None
         text = await asyncio.to_thread(
             extract_text, file_bytes, suffix, pdf_password=pdf_password

--- a/lightrag/parser/native_base.py
+++ b/lightrag/parser/native_base.py
@@ -1,0 +1,158 @@
+"""Shared template for native (local, in-process) parser engines.
+
+``NativeParserBase.parse`` fixes the common local-parse flow once:
+
+    resolve + validate source → compute parsed_dir/asset_dir
+    → pre-clean (rmtree parsed_dir + mkdir + mkdir asset_dir, with rollback)
+    → extract() in a thread → build_ir() → write_sidecar(clean_parsed_dir=False)
+    → persist full_docs (lightrag) → archive source
+
+Subclasses implement ``extract`` (sync, runs in a thread) and ``build_ir``.
+Currently only :class:`NativeDocxParser`; xlsx/pptx/md land later as new
+subclasses implementing the same two hooks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import time
+from abc import abstractmethod
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from lightrag.constants import FULL_DOCS_FORMAT_LIGHTRAG
+from lightrag.parser.base import BaseParser, ParseContext, ParseResult
+
+if TYPE_CHECKING:
+    from lightrag.sidecar.ir import IRDoc
+
+
+class NativeParserBase(BaseParser):
+    """Base for engines that parse a file locally into a sidecar."""
+
+    # ``write_sidecar`` block_drawing_path_style; docx keeps the legacy
+    # "basename_only" shape for byte-equivalence.
+    sidecar_path_style: str = "with_prefix"
+    # Prefix used in the "empty content" error message.
+    empty_content_label: str = "Native"
+
+    # --- engine-private hooks ------------------------------------------------
+    def validate_source(self, source: Path, file_path: str) -> None:
+        """Validate the resolved source (default: must be an existing file)."""
+        if not (source.exists() and source.is_file()):
+            raise FileNotFoundError(
+                f"{self.engine_name} source file not found: {source}"
+            )
+
+    @abstractmethod
+    def extract(
+        self, source: Path, *, parsed_dir: Path, asset_dir: Path, base_name: str
+    ) -> tuple[list[dict[str, Any]], dict[str, Any], dict[str, Any]]:
+        """Extract ``(blocks, warnings, metadata)`` (sync; runs in a thread).
+
+        ``parsed_dir`` and ``asset_dir`` are pre-created by the template; the
+        hook may write side artifacts (e.g. image bytes) into ``asset_dir``
+        before :func:`write_sidecar` runs with ``clean_parsed_dir=False``.
+        """
+        ...
+
+    @abstractmethod
+    def build_ir(
+        self,
+        blocks: list[dict[str, Any]],
+        *,
+        document_name: str,
+        asset_dir_name: str,
+        metadata: dict[str, Any],
+    ) -> "IRDoc": ...
+
+    def surface_warnings(
+        self, warnings: dict[str, Any], source: Path
+    ) -> dict[str, Any] | None:
+        """Map parser warnings to the ``parse_warnings`` result field (opt)."""
+        return None
+
+    # --- template ------------------------------------------------------------
+    async def parse(self, ctx: ParseContext) -> ParseResult:
+        from lightrag.sidecar import write_sidecar
+        from lightrag.utils_pipeline import (
+            archive_source_after_full_docs_sync,
+            make_lightrag_doc_content,
+            sidecar_uri_for,
+        )
+
+        rs = ctx.resolve(self.engine_name)
+        source = rs.source_path
+        self.validate_source(source, ctx.file_path)
+
+        document_name = rs.document_name
+        base_name = Path(document_name).stem or document_name
+        parsed_dir = rs.parsed_dir
+        asset_dir = parsed_dir / f"{base_name}.blocks.assets"
+
+        def _extract_sync():
+            # Pre-clean parsed_dir and pre-create asset_dir so the extractor
+            # can write image bytes BEFORE write_sidecar (clean_parsed_dir=False
+            # then keeps them). parsed_artifact_dir_for returns a unique dir per
+            # source, so this rmtree only clobbers a prior attempt's artifacts.
+            if parsed_dir.exists():
+                shutil.rmtree(parsed_dir)
+            parsed_dir.mkdir(parents=True, exist_ok=True)
+            asset_dir.mkdir(parents=True, exist_ok=True)
+            return self.extract(
+                source, parsed_dir=parsed_dir, asset_dir=asset_dir, base_name=base_name
+            )
+
+        try:
+            blocks, warnings, metadata = await asyncio.to_thread(_extract_sync)
+        except BaseException:
+            # Roll back the pre-created (possibly partial) dirs on any failure.
+            if parsed_dir.exists():
+                shutil.rmtree(parsed_dir, ignore_errors=True)
+            raise
+        if not blocks:
+            if parsed_dir.exists():
+                shutil.rmtree(parsed_dir, ignore_errors=True)
+            raise ValueError(
+                f"{self.empty_content_label} parser returned empty content "
+                f"for {ctx.file_path}"
+            )
+
+        parse_warnings = self.surface_warnings(warnings, source)
+        ir = self.build_ir(
+            blocks,
+            document_name=document_name,
+            asset_dir_name=asset_dir.name,
+            metadata=metadata,
+        )
+        parsed_data = write_sidecar(
+            ir,
+            parsed_dir=parsed_dir,
+            doc_id=ctx.doc_id,
+            engine=self.engine_name,
+            clean_parsed_dir=False,  # asset dir pre-populated above
+            block_drawing_path_style=self.sidecar_path_style,
+        )
+
+        await ctx.rag._persist_parsed_full_docs(
+            ctx.doc_id,
+            {
+                "content": make_lightrag_doc_content(parsed_data["content"]),
+                "file_path": ctx.file_path,
+                "parse_format": FULL_DOCS_FORMAT_LIGHTRAG,
+                "sidecar_location": sidecar_uri_for(parsed_dir),
+                "parse_engine": self.engine_name,
+                "update_time": int(time.time()),
+            },
+        )
+        await archive_source_after_full_docs_sync(str(source))
+        return ParseResult(
+            doc_id=ctx.doc_id,
+            file_path=ctx.file_path,
+            parse_format=FULL_DOCS_FORMAT_LIGHTRAG,
+            content=parsed_data["content"],
+            blocks_path=parsed_data["blocks_path"],
+            parse_engine=self.engine_name,
+            parse_warnings=parse_warnings,
+        )

--- a/lightrag/parser/native_base.py
+++ b/lightrag/parser/native_base.py
@@ -77,7 +77,6 @@ class NativeParserBase(BaseParser):
     async def parse(self, ctx: ParseContext) -> ParseResult:
         from lightrag.sidecar import write_sidecar
         from lightrag.utils_pipeline import (
-            archive_source_after_full_docs_sync,
             make_lightrag_doc_content,
             sidecar_uri_for,
         )
@@ -146,7 +145,7 @@ class NativeParserBase(BaseParser):
                 "update_time": int(time.time()),
             },
         )
-        await archive_source_after_full_docs_sync(str(source))
+        await ctx.archive_source(str(source))
         return ParseResult(
             doc_id=ctx.doc_id,
             file_path=ctx.file_path,

--- a/lightrag/parser/noop.py
+++ b/lightrag/parser/noop.py
@@ -1,0 +1,67 @@
+"""No-op format handlers for the two "nothing to parse" document formats.
+
+These are internal (``user_selectable=False``) parsers dispatched by *format*,
+not by a user engine choice:
+
+- :class:`ReuseParser` handles ``lightrag`` rows — a document already parsed
+  by some engine whose sidecar exists.  Reached only on resume/retry (a doc
+  that finished parsing but failed/interrupted at a later stage and is pulled
+  back through the parse queue).  Re-uses the stored content + sidecar
+  instead of re-parsing (the original source may already be archived).
+- :class:`PassthroughParser` handles ``raw`` rows — content supplied verbatim
+  at insert time (e.g. ``ainsert`` of a plain string).
+
+Both mirror the corresponding branches of the former ``parse_native`` exactly
+(no disk writes, ``parse_stage_skipped=True``, no ``parse_engine`` key).
+"""
+
+from __future__ import annotations
+
+from lightrag.constants import FULL_DOCS_FORMAT_LIGHTRAG, FULL_DOCS_FORMAT_RAW
+from lightrag.parser.base import BaseParser, ParseContext, ParseResult
+
+
+class ReuseParser(BaseParser):
+    """Reuse an already-parsed (``lightrag``-format) document's sidecar."""
+
+    engine_name = "reuse"
+
+    async def parse(self, ctx: ParseContext) -> ParseResult:
+        from lightrag.utils_pipeline import (
+            sidecar_blocks_path,
+            strip_lightrag_doc_prefix,
+        )
+
+        doc_format = ctx.content_data.get("parse_format", FULL_DOCS_FORMAT_LIGHTRAG)
+        merged_text = strip_lightrag_doc_prefix(
+            ctx.content_data.get("content"), doc_format
+        )
+        # ``sidecar_location`` may be absent on historical/abnormal rows; tolerate
+        # it (blocks_path="") rather than failing or re-routing to extraction.
+        blocks_path = (
+            sidecar_blocks_path(ctx.content_data.get("sidecar_location")) or ""
+        )
+        return ParseResult(
+            doc_id=ctx.doc_id,
+            file_path=ctx.file_path,
+            parse_format=doc_format,
+            content=merged_text,
+            blocks_path=blocks_path,
+            parse_stage_skipped=True,
+        )
+
+
+class PassthroughParser(BaseParser):
+    """Pass ``raw``-format content through verbatim (no parser ran)."""
+
+    engine_name = "passthrough"
+
+    async def parse(self, ctx: ParseContext) -> ParseResult:
+        return ParseResult(
+            doc_id=ctx.doc_id,
+            file_path=ctx.file_path,
+            parse_format=FULL_DOCS_FORMAT_RAW,
+            content=ctx.content_data.get("content", ""),
+            blocks_path="",
+            parse_stage_skipped=True,
+        )

--- a/lightrag/parser/plugins.py
+++ b/lightrag/parser/plugins.py
@@ -1,0 +1,66 @@
+"""Third-party parser engine discovery (``lightrag.parsers`` entry points).
+
+A third-party package exposes parser engines by declaring an entry point in
+the ``lightrag.parsers`` group::
+
+    # pyproject.toml of the third-party package
+    [project.entry-points."lightrag.parsers"]
+    myengine = "my_pkg.lightrag_plugin:register"
+
+Each entry point must resolve to a **zero-argument callable** that performs
+its own :func:`lightrag.parser.registry.register_parser` call(s).  The
+callable should be import-cheap: defer the parser implementation import to
+the ``ParserSpec.impl`` string (the registry already loads it lazily).
+
+:func:`load_third_party_parsers` is invoked once per process by both
+entrypoints that drive parsers — the API server (``create_app``, before
+routing-rule validation so ``LIGHTRAG_PARSER`` may reference third-party
+engine names) and the debug CLI (``lightrag.parser.cli.main``, before
+``--engine`` choices are built).  Library users embedding LightRAG directly
+can call it themselves before constructing pipelines.
+
+See ``docs/ThirdPartyParser-zh.md`` for the full plugin authoring guide.
+"""
+
+from __future__ import annotations
+
+import logging
+from importlib.metadata import entry_points
+
+ENTRY_POINT_GROUP = "lightrag.parsers"
+
+logger = logging.getLogger("lightrag")
+
+_loaded = False
+
+
+def load_third_party_parsers(*, force: bool = False) -> list[str]:
+    """Discover and run all ``lightrag.parsers`` entry points.
+
+    Idempotent per process (``force=True`` re-runs, for tests).  Returns the
+    names of the entry points that loaded successfully.  A failing plugin is
+    logged with its origin and skipped — one broken third-party package must
+    not take down server startup or the debug CLI; the built-in engines are
+    registered statically and are never affected.
+    """
+    global _loaded
+    if _loaded and not force:
+        return []
+    _loaded = True
+
+    loaded: list[str] = []
+    for ep in entry_points(group=ENTRY_POINT_GROUP):
+        try:
+            register = ep.load()
+            register()
+        except Exception as e:
+            logger.error(
+                "[parser-plugins] failed to load parser plugin %r (%s): %s",
+                ep.name,
+                ep.value,
+                e,
+            )
+            continue
+        loaded.append(ep.name)
+        logger.info("[parser-plugins] loaded parser plugin %r (%s)", ep.name, ep.value)
+    return loaded

--- a/lightrag/parser/registry.py
+++ b/lightrag/parser/registry.py
@@ -272,6 +272,39 @@ def supported_parser_engines(
     )
 
 
+# Engines shipped with LightRAG. Used to tell third-party registrations apart
+# (e.g. the API upload allowlist is a curated subset of the BUILT-IN engines'
+# suffixes — mineru's image suffixes are deliberately not uploadable — while
+# a third-party engine's suffixes are admitted automatically).
+BUILTIN_PARSER_ENGINES = frozenset(
+    {
+        PARSER_ENGINE_NATIVE,
+        PARSER_ENGINE_LEGACY,
+        PARSER_ENGINE_MINERU,
+        PARSER_ENGINE_DOCLING,
+        PARSER_ENGINE_REUSE,
+        PARSER_ENGINE_PASSTHROUGH,
+    }
+)
+
+
+def third_party_engine_suffixes(
+    specs: dict[str, ParserSpec] | None = None,
+) -> frozenset[str]:
+    """Suffixes (lowercase, no dot) of user-selectable non-built-in engines.
+
+    The API layer unions these into ``DocumentManager.supported_extensions``
+    so a pip-installed parser plugin's file types become uploadable and
+    scannable without LightRAG code changes — while the curated built-in
+    allowlist stays untouched.
+    """
+    out: set[str] = set()
+    for name, spec in _table(specs).items():
+        if spec.user_selectable and name not in BUILTIN_PARSER_ENGINES:
+            out |= spec.suffixes
+    return frozenset(out)
+
+
 def suffix_capabilities(
     engine: str, specs: dict[str, ParserSpec] | None = None
 ) -> frozenset[str]:

--- a/lightrag/parser/registry.py
+++ b/lightrag/parser/registry.py
@@ -21,9 +21,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Callable
 
 from lightrag.constants import (
-    DEFAULT_MAX_PARALLEL_PARSE_DOCLING,
-    DEFAULT_MAX_PARALLEL_PARSE_MINERU,
-    DEFAULT_MAX_PARALLEL_PARSE_NATIVE,
     PARSER_ENGINE_DOCLING,
     PARSER_ENGINE_LEGACY,
     PARSER_ENGINE_MINERU,
@@ -81,8 +78,13 @@ class ParserSpec:
     suffixes: frozenset[str]
     user_selectable: bool = True
     queue_group: str = PARSER_ENGINE_NATIVE
-    concurrency_env: str | None = None
-    default_concurrency: int | None = None
+    # Worker count for this spec's queue_group. The registrant bakes in any
+    # env override at registration time (e.g.
+    # ``concurrency=int(os.getenv("MAX_PARALLEL_PARSE_MYENGINE", "3"))``),
+    # mirroring how the built-in ``max_parallel_parse_*`` LightRAG fields read
+    # their env. ``None`` means this spec does not own its group's concurrency
+    # (built-in groups are sized by the LightRAG instance field instead).
+    concurrency: int | None = None
     endpoint_configured: Callable[[], bool] = field(default=lambda: True)
     endpoint_requirement: Callable[[], str | None] = field(default=lambda: None)
 
@@ -178,8 +180,9 @@ _REGISTRY: dict[str, ParserSpec] = {
         impl="lightrag.parser.docx.parser:NativeDocxParser",
         suffixes=frozenset({"docx"}),
         queue_group=PARSER_ENGINE_NATIVE,
-        concurrency_env="MAX_PARALLEL_PARSE_NATIVE",
-        default_concurrency=DEFAULT_MAX_PARALLEL_PARSE_NATIVE,
+        # Built-in groups are sized by the LightRAG ``max_parallel_parse_*``
+        # instance field (supports constructor override), so no spec-level
+        # ``concurrency`` here.
     ),
     PARSER_ENGINE_LEGACY: ParserSpec(
         engine_name=PARSER_ENGINE_LEGACY,
@@ -191,9 +194,7 @@ _REGISTRY: dict[str, ParserSpec] = {
         engine_name=PARSER_ENGINE_MINERU,
         impl="lightrag.parser.external.mineru.parser:MinerUParser",
         suffixes=_MINERU_SUFFIXES,
-        queue_group=PARSER_ENGINE_MINERU,
-        concurrency_env="MAX_PARALLEL_PARSE_MINERU",
-        default_concurrency=DEFAULT_MAX_PARALLEL_PARSE_MINERU,
+        queue_group=PARSER_ENGINE_MINERU,  # sized by max_parallel_parse_mineru
         endpoint_configured=_mineru_endpoint_configured,
         endpoint_requirement=_mineru_endpoint_requirement,
     ),
@@ -201,9 +202,7 @@ _REGISTRY: dict[str, ParserSpec] = {
         engine_name=PARSER_ENGINE_DOCLING,
         impl="lightrag.parser.external.docling.parser:DoclingParser",
         suffixes=_DOCLING_SUFFIXES,
-        queue_group=PARSER_ENGINE_DOCLING,
-        concurrency_env="MAX_PARALLEL_PARSE_DOCLING",
-        default_concurrency=DEFAULT_MAX_PARALLEL_PARSE_DOCLING,
+        queue_group=PARSER_ENGINE_DOCLING,  # sized by max_parallel_parse_docling
         endpoint_configured=_env_endpoint_configured("DOCLING_ENDPOINT"),
         endpoint_requirement=lambda: "DOCLING_ENDPOINT",
     ),
@@ -227,17 +226,7 @@ _INSTANCE_CACHE: dict[tuple[str, str], "BaseParser"] = {}
 
 
 def register_parser(spec: ParserSpec) -> None:
-    """Register (or override) a parser engine spec.
-
-    A spec that declares ``concurrency_env`` must also provide a
-    ``default_concurrency`` so the pipeline never evaluates ``int(None)``
-    when the env var is unset.
-    """
-    if spec.concurrency_env and spec.default_concurrency is None:
-        raise ValueError(
-            f"ParserSpec {spec.engine_name!r} sets concurrency_env="
-            f"{spec.concurrency_env!r} but no default_concurrency"
-        )
+    """Register (or override) a parser engine spec."""
     _REGISTRY[spec.engine_name] = spec
 
 

--- a/lightrag/parser/registry.py
+++ b/lightrag/parser/registry.py
@@ -272,35 +272,22 @@ def supported_parser_engines(
     )
 
 
-# Engines shipped with LightRAG. Used to tell third-party registrations apart
-# (e.g. the API upload allowlist is a curated subset of the BUILT-IN engines'
-# suffixes — mineru's image suffixes are deliberately not uploadable — while
-# a third-party engine's suffixes are admitted automatically).
-BUILTIN_PARSER_ENGINES = frozenset(
-    {
-        PARSER_ENGINE_NATIVE,
-        PARSER_ENGINE_LEGACY,
-        PARSER_ENGINE_MINERU,
-        PARSER_ENGINE_DOCLING,
-        PARSER_ENGINE_REUSE,
-        PARSER_ENGINE_PASSTHROUGH,
-    }
-)
-
-
-def third_party_engine_suffixes(
+def available_engine_suffixes(
     specs: dict[str, ParserSpec] | None = None,
 ) -> frozenset[str]:
-    """Suffixes (lowercase, no dot) of user-selectable non-built-in engines.
+    """Suffixes (lowercase, no dot) parseable by a *currently usable* engine.
 
-    The API layer unions these into ``DocumentManager.supported_extensions``
-    so a pip-installed parser plugin's file types become uploadable and
-    scannable without LightRAG code changes — while the curated built-in
-    allowlist stays untouched.
+    Union over user-selectable engines whose ``endpoint_configured()`` gate
+    passes. This is the single source for the API upload allowlist and the
+    input-directory scan (``DocumentManager.supported_extensions``): in a
+    default deployment (no external endpoints) it equals the local engines'
+    suffixes (legacy ∪ native); configuring e.g. ``MINERU_LOCAL_ENDPOINT``
+    admits mineru's image/office suffixes; a registered third-party engine's
+    suffixes join automatically (subject to its own endpoint gate).
     """
     out: set[str] = set()
-    for name, spec in _table(specs).items():
-        if spec.user_selectable and name not in BUILTIN_PARSER_ENGINES:
+    for spec in _table(specs).values():
+        if spec.user_selectable and spec.endpoint_configured():
             out |= spec.suffixes
     return frozenset(out)
 

--- a/lightrag/parser/registry.py
+++ b/lightrag/parser/registry.py
@@ -1,0 +1,304 @@
+"""Central registry for parser engines (mirrors the storage-layer convention).
+
+Like :data:`lightrag.kg.STORAGES` / ``STORAGE_IMPLEMENTATIONS``, this module
+holds a module-level literal table of lightweight :class:`ParserSpec`
+metadata.  Loading this module imports **no** parser implementation, so
+capability queries (suffixes / endpoint / supported engines) never trigger a
+heavy ``mineru``/``docling`` facade import (which would pull ``httpx`` etc.).
+The implementation class is imported lazily — only when a document is
+actually parsed — via :func:`get_parser`.
+
+Capability data lives here (single source of truth); behaviour lives in the
+parser classes.  ``constants.PARSER_ENGINE_*`` keeps only the bare name
+strings used as identifiers / registry keys.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Callable
+
+from lightrag.constants import (
+    DEFAULT_MAX_PARALLEL_PARSE_DOCLING,
+    DEFAULT_MAX_PARALLEL_PARSE_MINERU,
+    DEFAULT_MAX_PARALLEL_PARSE_NATIVE,
+    PARSER_ENGINE_DOCLING,
+    PARSER_ENGINE_LEGACY,
+    PARSER_ENGINE_MINERU,
+    PARSER_ENGINE_NATIVE,
+)
+
+if TYPE_CHECKING:
+    from lightrag.parser.base import BaseParser
+
+# Internal format-handler engine keys (not user-selectable).
+PARSER_ENGINE_REUSE = "reuse"
+PARSER_ENGINE_PASSTHROUGH = "passthrough"
+
+_VALID_MINERU_API_MODES = {"official", "local"}
+
+
+# ---------------------------------------------------------------------------
+# Endpoint capability closures (env-only; no network).  Canonical home —
+# routing.py delegates here.
+# ---------------------------------------------------------------------------
+def _mineru_endpoint_configured() -> bool:
+    mode = os.getenv("MINERU_API_MODE", "local").strip().lower()
+    if mode == "official":
+        return bool(os.getenv("MINERU_API_TOKEN", "").strip())
+    if mode == "local":
+        return bool(os.getenv("MINERU_LOCAL_ENDPOINT", "").strip())
+    return False
+
+
+def _mineru_endpoint_requirement() -> str | None:
+    mode = os.getenv("MINERU_API_MODE", "local").strip().lower()
+    if mode == "official":
+        return "MINERU_API_TOKEN"
+    if mode == "local":
+        return "MINERU_LOCAL_ENDPOINT"
+    allowed = ", ".join(sorted(_VALID_MINERU_API_MODES))
+    return f"valid MINERU_API_MODE ({allowed})"
+
+
+def _env_endpoint_configured(env_name: str) -> Callable[[], bool]:
+    return lambda: bool(os.getenv(env_name, "").strip())
+
+
+@dataclass(frozen=True)
+class ParserSpec:
+    """Lightweight, import-cheap metadata for one parser engine.
+
+    Holds everything the pipeline needs to *route* and *gate* a document
+    without importing the parser implementation.  ``impl`` is a
+    ``"module:Class"`` string imported lazily by :func:`get_parser`.
+    """
+
+    engine_name: str
+    impl: str
+    suffixes: frozenset[str]
+    user_selectable: bool = True
+    queue_group: str = PARSER_ENGINE_NATIVE
+    concurrency_env: str | None = None
+    default_concurrency: int | None = None
+    endpoint_configured: Callable[[], bool] = field(default=lambda: True)
+    endpoint_requirement: Callable[[], str | None] = field(default=lambda: None)
+
+
+# ---------------------------------------------------------------------------
+# Suffix capabilities (single source of truth; replaces
+# constants.PARSER_ENGINE_SUFFIX_CAPABILITIES).
+# ---------------------------------------------------------------------------
+_LEGACY_SUFFIXES = frozenset(
+    {
+        "txt",
+        "md",
+        "mdx",
+        "pdf",
+        "docx",
+        "pptx",
+        "xlsx",
+        "rtf",
+        "odt",
+        "tex",
+        "epub",
+        "html",
+        "htm",
+        "csv",
+        "json",
+        "xml",
+        "yaml",
+        "yml",
+        "log",
+        "conf",
+        "ini",
+        "properties",
+        "sql",
+        "bat",
+        "sh",
+        "c",
+        "h",
+        "cpp",
+        "hpp",
+        "py",
+        "java",
+        "js",
+        "ts",
+        "swift",
+        "go",
+        "rb",
+        "php",
+        "css",
+        "scss",
+        "less",
+    }
+)
+_MINERU_SUFFIXES = frozenset(
+    {
+        "pdf",
+        "doc",
+        "docx",
+        "ppt",
+        "pptx",
+        "xls",
+        "xlsx",
+        "png",
+        "jpg",
+        "jpeg",
+        "jp2",
+        "webp",
+        "gif",
+        "bmp",
+    }
+)
+_DOCLING_SUFFIXES = frozenset(
+    {
+        "pdf",
+        "docx",
+        "pptx",
+        "xlsx",
+        "md",
+        "html",
+        "xhtml",
+        "png",
+        "jpg",
+        "jpeg",
+        "tiff",
+        "webp",
+        "bmp",
+    }
+)
+
+
+_REGISTRY: dict[str, ParserSpec] = {
+    PARSER_ENGINE_NATIVE: ParserSpec(
+        engine_name=PARSER_ENGINE_NATIVE,
+        impl="lightrag.parser.docx.parser:NativeDocxParser",
+        suffixes=frozenset({"docx"}),
+        queue_group=PARSER_ENGINE_NATIVE,
+        concurrency_env="MAX_PARALLEL_PARSE_NATIVE",
+        default_concurrency=DEFAULT_MAX_PARALLEL_PARSE_NATIVE,
+    ),
+    PARSER_ENGINE_LEGACY: ParserSpec(
+        engine_name=PARSER_ENGINE_LEGACY,
+        impl="lightrag.parser.legacy.parser:LegacyParser",
+        suffixes=_LEGACY_SUFFIXES,
+        queue_group=PARSER_ENGINE_NATIVE,  # shares native pool (local, no network)
+    ),
+    PARSER_ENGINE_MINERU: ParserSpec(
+        engine_name=PARSER_ENGINE_MINERU,
+        impl="lightrag.parser.external.mineru.parser:MinerUParser",
+        suffixes=_MINERU_SUFFIXES,
+        queue_group=PARSER_ENGINE_MINERU,
+        concurrency_env="MAX_PARALLEL_PARSE_MINERU",
+        default_concurrency=DEFAULT_MAX_PARALLEL_PARSE_MINERU,
+        endpoint_configured=_mineru_endpoint_configured,
+        endpoint_requirement=_mineru_endpoint_requirement,
+    ),
+    PARSER_ENGINE_DOCLING: ParserSpec(
+        engine_name=PARSER_ENGINE_DOCLING,
+        impl="lightrag.parser.external.docling.parser:DoclingParser",
+        suffixes=_DOCLING_SUFFIXES,
+        queue_group=PARSER_ENGINE_DOCLING,
+        concurrency_env="MAX_PARALLEL_PARSE_DOCLING",
+        default_concurrency=DEFAULT_MAX_PARALLEL_PARSE_DOCLING,
+        endpoint_configured=_env_endpoint_configured("DOCLING_ENDPOINT"),
+        endpoint_requirement=lambda: "DOCLING_ENDPOINT",
+    ),
+    PARSER_ENGINE_REUSE: ParserSpec(
+        engine_name=PARSER_ENGINE_REUSE,
+        impl="lightrag.parser.noop:ReuseParser",
+        suffixes=frozenset(),
+        user_selectable=False,
+    ),
+    PARSER_ENGINE_PASSTHROUGH: ParserSpec(
+        engine_name=PARSER_ENGINE_PASSTHROUGH,
+        impl="lightrag.parser.noop:PassthroughParser",
+        suffixes=frozenset(),
+        user_selectable=False,
+    ),
+}
+
+# (engine_name, impl) -> instance.  Keyed on impl so a re-registration with a
+# different implementation is not served a stale cached instance.
+_INSTANCE_CACHE: dict[tuple[str, str], "BaseParser"] = {}
+
+
+def register_parser(spec: ParserSpec) -> None:
+    """Register (or override) a parser engine spec.
+
+    A spec that declares ``concurrency_env`` must also provide a
+    ``default_concurrency`` so the pipeline never evaluates ``int(None)``
+    when the env var is unset.
+    """
+    if spec.concurrency_env and spec.default_concurrency is None:
+        raise ValueError(
+            f"ParserSpec {spec.engine_name!r} sets concurrency_env="
+            f"{spec.concurrency_env!r} but no default_concurrency"
+        )
+    _REGISTRY[spec.engine_name] = spec
+
+
+def parser_specs_snapshot() -> dict[str, ParserSpec]:
+    """Return a shallow snapshot of the registry.
+
+    The pipeline takes one snapshot at batch start and threads it through
+    queue construction, routing and the parse workers so a concurrent
+    ``register_parser`` cannot change the engine set mid-batch.
+    """
+    return dict(_REGISTRY)
+
+
+def _table(specs: dict[str, ParserSpec] | None) -> dict[str, ParserSpec]:
+    return specs if specs is not None else _REGISTRY
+
+
+def get_parser(engine: str, *, specs: dict[str, ParserSpec] | None = None):
+    """Return a (cached) parser instance for ``engine`` or ``None``.
+
+    Imports the implementation lazily via ``importlib`` — only here does the
+    heavy engine package (and e.g. ``httpx``) get pulled in.
+    """
+    spec = _table(specs).get(engine)
+    if spec is None:
+        return None
+    cache_key = (engine, spec.impl)
+    inst = _INSTANCE_CACHE.get(cache_key)
+    if inst is None:
+        module_path, _, cls_name = spec.impl.partition(":")
+        cls = getattr(importlib.import_module(module_path), cls_name)
+        inst = cls()
+        _INSTANCE_CACHE[cache_key] = inst
+    return inst
+
+
+def supported_parser_engines(
+    specs: dict[str, ParserSpec] | None = None,
+) -> frozenset[str]:
+    """User-selectable engine names (replaces SUPPORTED_PARSER_ENGINES)."""
+    return frozenset(
+        name for name, spec in _table(specs).items() if spec.user_selectable
+    )
+
+
+def suffix_capabilities(
+    engine: str, specs: dict[str, ParserSpec] | None = None
+) -> frozenset[str]:
+    spec = _table(specs).get(engine)
+    return spec.suffixes if spec is not None else frozenset()
+
+
+def engine_endpoint_configured(
+    engine: str, specs: dict[str, ParserSpec] | None = None
+) -> bool:
+    spec = _table(specs).get(engine)
+    return spec.endpoint_configured() if spec is not None else True
+
+
+def engine_endpoint_requirement(
+    engine: str, specs: dict[str, ParserSpec] | None = None
+) -> str | None:
+    spec = _table(specs).get(engine)
+    return spec.endpoint_requirement() if spec is not None else None

--- a/lightrag/parser/routing.py
+++ b/lightrag/parser/routing.py
@@ -14,11 +14,7 @@ from lightrag.constants import (
     FULL_DOCS_FORMAT_LIGHTRAG,
     FULL_DOCS_FORMAT_PENDING_PARSE,
     FULL_DOCS_FORMAT_RAW,
-    PARSER_ENGINE_DOCLING,
     PARSER_ENGINE_LEGACY,
-    PARSER_ENGINE_MINERU,
-    PARSER_ENGINE_NATIVE,
-    PARSER_ENGINE_SUFFIX_CAPABILITIES,
     PROCESS_OPTION_CHUNK_CHARS,
     PROCESS_OPTION_CHUNK_FIXED,
     PROCESS_OPTION_CHUNK_VECTOR,
@@ -29,8 +25,15 @@ from lightrag.constants import (
     PROCESS_OPTION_SKIP_KG,
     PROCESS_OPTION_TABLES,
     ProcessChunkingOption,
-    SUPPORTED_PARSER_ENGINES,
     SUPPORTED_PROCESS_OPTIONS,
+)
+from lightrag.parser.registry import (
+    PARSER_ENGINE_PASSTHROUGH,
+    PARSER_ENGINE_REUSE,
+    engine_endpoint_configured,
+    engine_endpoint_requirement,
+    supported_parser_engines,
+    suffix_capabilities,
 )
 from lightrag.utils import logger, parse_optional_float
 
@@ -39,10 +42,6 @@ from collections.abc import Mapping
 from copy import deepcopy
 
 _PARSER_RULE_SPLIT_RE = re.compile(r"[;,]")
-_PARSER_ENGINE_ENDPOINT_ENV = {
-    PARSER_ENGINE_DOCLING: "DOCLING_ENDPOINT",
-}
-_VALID_MINERU_API_MODES = {"official", "local"}
 
 # Trailing parser-hint pattern: matches ``.[engine].ext`` at end of basename.
 # Group 1 captures the raw engine token (still needs normalize_parser_engine
@@ -459,12 +458,12 @@ def split_engine_and_options(bracket_inner: str) -> tuple[str | None, str]:
     if "-" in inner:
         head, _, tail = inner.partition("-")
         engine_candidate = normalize_parser_engine(head)
-        if engine_candidate in SUPPORTED_PARSER_ENGINES:
+        if engine_candidate in supported_parser_engines():
             return engine_candidate, tail.strip()
         return None, ""
 
     engine_candidate = normalize_parser_engine(inner)
-    if engine_candidate in SUPPORTED_PARSER_ENGINES:
+    if engine_candidate in supported_parser_engines():
         return engine_candidate, ""
     return None, ""
 
@@ -474,35 +473,16 @@ def parser_suffix(file_path: str | Path) -> str:
 
 
 def parser_engine_supports_suffix(engine: str, suffix: str) -> bool:
-    return suffix.lower().lstrip(".") in PARSER_ENGINE_SUFFIX_CAPABILITIES.get(
-        engine, frozenset()
-    )
+    return suffix.lower().lstrip(".") in suffix_capabilities(engine)
 
 
 def parser_engine_endpoint_configured(engine: str) -> bool:
-    if engine == PARSER_ENGINE_MINERU:
-        mode = os.getenv("MINERU_API_MODE", "local").strip().lower()
-        if mode == "official":
-            return bool(os.getenv("MINERU_API_TOKEN", "").strip())
-        if mode == "local":
-            return bool(os.getenv("MINERU_LOCAL_ENDPOINT", "").strip())
-        return False
-    endpoint_env = _PARSER_ENGINE_ENDPOINT_ENV.get(engine)
-    if endpoint_env:
-        return bool(os.getenv(endpoint_env, "").strip())
-    return True
+    # Endpoint capability lives on the registry ParserSpec (single source).
+    return engine_endpoint_configured(engine)
 
 
 def parser_engine_endpoint_requirement(engine: str) -> str | None:
-    if engine == PARSER_ENGINE_MINERU:
-        mode = os.getenv("MINERU_API_MODE", "local").strip().lower()
-        if mode == "official":
-            return "MINERU_API_TOKEN"
-        if mode == "local":
-            return "MINERU_LOCAL_ENDPOINT"
-        allowed = ", ".join(sorted(_VALID_MINERU_API_MODES))
-        return f"valid MINERU_API_MODE ({allowed})"
-    return _PARSER_ENGINE_ENDPOINT_ENV.get(engine)
+    return engine_endpoint_requirement(engine)
 
 
 def _engine_is_usable(
@@ -511,7 +491,7 @@ def _engine_is_usable(
     *,
     require_external_endpoint: bool,
 ) -> bool:
-    if engine not in SUPPORTED_PARSER_ENGINES:
+    if engine not in supported_parser_engines():
         return False
     if not parser_engine_supports_suffix(engine, suffix):
         return False
@@ -554,7 +534,7 @@ def _filename_hint_match(
                 f"{basename!r}: {'; '.join(option_errors)}"
             )
             return None
-    if engine in SUPPORTED_PARSER_ENGINES:
+    if engine in supported_parser_engines():
         return m, engine, options
     if engine is None and options:
         return m, "", options
@@ -598,8 +578,8 @@ def _validate_filename_hint_for_resolution(
     elif "-" in inner:
         engine_name, _, options = inner.partition("-")
         engine = normalize_parser_engine(engine_name)
-        if engine not in SUPPORTED_PARSER_ENGINES:
-            supported = ", ".join(sorted(SUPPORTED_PARSER_ENGINES))
+        if engine not in supported_parser_engines():
+            supported = ", ".join(sorted(supported_parser_engines()))
             errors.append(
                 f"filename hint {m.group(0)!r} uses unsupported parser engine "
                 f"{engine_name.strip()!r}; supported engines: {supported}"
@@ -615,8 +595,8 @@ def _validate_filename_hint_for_resolution(
             )
     else:
         engine = normalize_parser_engine(inner)
-        if engine not in SUPPORTED_PARSER_ENGINES:
-            supported = ", ".join(sorted(SUPPORTED_PARSER_ENGINES))
+        if engine not in supported_parser_engines():
+            supported = ", ".join(sorted(supported_parser_engines()))
             message = (
                 f"filename hint {m.group(0)!r} uses unsupported parser engine "
                 f"{inner.strip()!r}; supported engines: {supported}"
@@ -628,12 +608,10 @@ def _validate_filename_hint_for_resolution(
                 )
             errors.append(message)
 
-    if engine in SUPPORTED_PARSER_ENGINES:
+    if engine in supported_parser_engines():
         suffix = parser_suffix(file_path)
         if not parser_engine_supports_suffix(engine, suffix):
-            supported_suffixes = ", ".join(
-                sorted(PARSER_ENGINE_SUFFIX_CAPABILITIES.get(engine, frozenset()))
-            )
+            supported_suffixes = ", ".join(sorted(suffix_capabilities(engine)))
             errors.append(
                 f"filename hint {m.group(0)!r} uses parser engine {engine!r} "
                 f"for unsupported suffix {suffix!r}; supported suffixes: "
@@ -712,7 +690,7 @@ def _iter_parser_rule_items(rules: str) -> list[tuple[int, str]]:
 
 
 def _rule_pattern_matches_engine_capability(pattern: str, engine: str) -> bool:
-    supported_suffixes = PARSER_ENGINE_SUFFIX_CAPABILITIES.get(engine, frozenset())
+    supported_suffixes = suffix_capabilities(engine)
     return any(fnmatch.fnmatch(suffix, pattern) for suffix in supported_suffixes)
 
 
@@ -756,17 +734,15 @@ def validate_parser_routing_config(parser_rules: str | None = None) -> None:
         if not engine_hint:
             errors.append(f"{label} has an empty parser engine")
             continue
-        if engine not in SUPPORTED_PARSER_ENGINES:
-            supported = ", ".join(sorted(SUPPORTED_PARSER_ENGINES))
+        if engine not in supported_parser_engines():
+            supported = ", ".join(sorted(supported_parser_engines()))
             errors.append(
                 f"{label} uses unsupported parser engine {engine_hint!r}; "
                 f"supported engines: {supported}"
             )
             continue
         if not _rule_pattern_matches_engine_capability(pattern, engine):
-            supported_suffixes = ", ".join(
-                sorted(PARSER_ENGINE_SUFFIX_CAPABILITIES.get(engine, frozenset()))
-            )
+            supported_suffixes = ", ".join(sorted(suffix_capabilities(engine)))
             errors.append(
                 f"{label} does not match any suffix supported by {engine}; "
                 f"supported suffixes: {supported_suffixes}"
@@ -888,11 +864,6 @@ def resolve_stored_document_parser_engine(
     raises and never filters an unknown stored engine — the parse worker
     decides fallback/validation (so its warning path actually fires).
     """
-    from lightrag.parser.registry import (
-        PARSER_ENGINE_PASSTHROUGH,
-        PARSER_ENGINE_REUSE,
-    )
-
     if content_data:
         doc_format = content_data.get("parse_format", FULL_DOCS_FORMAT_RAW)
         # All lightrag rows reuse the already-parsed sidecar (sidecar optional;

--- a/lightrag/parser/routing.py
+++ b/lightrag/parser/routing.py
@@ -881,21 +881,32 @@ def resolve_stored_document_parser_engine(
     file_path: str | Path,
     content_data: dict[str, Any] | None,
 ) -> str:
-    """Resolve parser engine for a full_docs row during pipeline processing."""
+    """Resolve the parser engine key for a full_docs row during processing.
+
+    Returns a registry key: the internal ``reuse``/``passthrough`` handlers for
+    the no-op formats, or a real engine name for ``pending_parse``.  Never
+    raises and never filters an unknown stored engine — the parse worker
+    decides fallback/validation (so its warning path actually fires).
+    """
+    from lightrag.parser.registry import (
+        PARSER_ENGINE_PASSTHROUGH,
+        PARSER_ENGINE_REUSE,
+    )
+
     if content_data:
         doc_format = content_data.get("parse_format", FULL_DOCS_FORMAT_RAW)
-        if doc_format == FULL_DOCS_FORMAT_LIGHTRAG and content_data.get(
-            "sidecar_location"
-        ):
-            return PARSER_ENGINE_NATIVE
+        # All lightrag rows reuse the already-parsed sidecar (sidecar optional;
+        # ReuseParser tolerates a missing one). Reached on resume/retry.
+        if doc_format == FULL_DOCS_FORMAT_LIGHTRAG:
+            return PARSER_ENGINE_REUSE
+        # Anything not pending is already-extracted content (raw direct-insert
+        # or legacy-extracted RAW) -> pass through verbatim.
         if doc_format != FULL_DOCS_FORMAT_PENDING_PARSE:
-            return PARSER_ENGINE_LEGACY
-
-        suffix = parser_suffix(file_path)
+            return PARSER_ENGINE_PASSTHROUGH
+        # PENDING_PARSE: honour the stored engine verbatim; fall back to
+        # filename rules only when it is absent.
         pending_engine = normalize_parser_engine(content_data.get("parse_engine"))
-        if pending_engine in SUPPORTED_PARSER_ENGINES and parser_engine_supports_suffix(
-            pending_engine, suffix
-        ):
+        if pending_engine:
             return pending_engine
 
     return resolve_file_parser_engine(file_path)

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -46,7 +46,15 @@ from lightrag.exceptions import (
 )
 from lightrag.kg.shared_storage import get_namespace_data, get_namespace_lock
 from lightrag.operate import merge_nodes_and_edges
+from lightrag.parser.base import ParseContext
+from lightrag.parser.registry import (
+    get_parser,
+    parser_specs_snapshot,
+    supported_parser_engines,
+    suffix_capabilities,
+)
 from lightrag.parser.routing import (
+    parser_suffix,
     resolve_file_parser_directives,
     resolve_stored_document_parser_engine,
 )
@@ -198,9 +206,12 @@ class _BatchRunContext:
     pipeline_status_lock: Any
     semaphore: asyncio.Semaphore
     total_files: int
-    q_native: asyncio.Queue
-    q_mineru: asyncio.Queue
-    q_docling: asyncio.Queue
+    # Parse queues are dynamic: one per ParserSpec.queue_group (always at
+    # least "native"). ``parser_specs`` is the batch snapshot threaded through
+    # routing + the parse workers so a mid-batch register_parser cannot change
+    # the engine set for this run.
+    parse_queues: dict[str, asyncio.Queue]
+    parser_specs: dict
     q_analyze: asyncio.Queue
     q_process: asyncio.Queue
     processed_count: int = 0
@@ -1238,31 +1249,56 @@ class _PipelineMixin:
             to_process_docs, total_files
         )
 
+        # Lock one registry snapshot for the whole batch; build one parse
+        # queue per distinct queue_group (always includes "native").
+        parser_specs = parser_specs_snapshot()
+        queue_groups = {spec.queue_group for spec in parser_specs.values()}
+        parse_queues = {
+            group: asyncio.Queue(maxsize=self.queue_size_parse)
+            for group in queue_groups
+        }
+
         ctx = _BatchRunContext(
             pipeline_status=pipeline_status,
             pipeline_status_lock=pipeline_status_lock,
             semaphore=asyncio.Semaphore(self.max_parallel_insert),
             total_files=total_files,
-            q_native=asyncio.Queue(maxsize=self.queue_size_parse),
-            q_mineru=asyncio.Queue(maxsize=self.queue_size_parse),
-            q_docling=asyncio.Queue(maxsize=self.queue_size_parse),
+            parse_queues=parse_queues,
+            parser_specs=parser_specs,
             q_analyze=asyncio.Queue(maxsize=self.queue_size_analyze),
             q_process=asyncio.Queue(maxsize=self.queue_size_insert),
         )
 
+        def _group_concurrency(group: str) -> int:
+            # Built-in groups keep their existing LightRAG fields (env +
+            # programmatic overrides preserved). Third-party groups read the
+            # owner spec's concurrency_env; an unowned group shares native's.
+            field_name = f"max_parallel_parse_{group}"
+            if hasattr(self, field_name):
+                return getattr(self, field_name)
+            owners = [
+                s
+                for s in parser_specs.values()
+                if s.queue_group == group and s.concurrency_env
+            ]
+            if len(owners) > 1:
+                raise ValueError(
+                    f"queue_group {group!r} has multiple concurrency owners: "
+                    f"{[s.engine_name for s in owners]}"
+                )
+            if owners:
+                owner = owners[0]
+                return int(
+                    os.getenv(owner.concurrency_env, owner.default_concurrency)
+                )
+            return self.max_parallel_parse_native
+
         workers: list[asyncio.Task] = []
-        for _ in range(max(1, self.max_parallel_parse_native)):
-            workers.append(
-                asyncio.create_task(self._parse_worker("native", ctx.q_native, ctx))
-            )
-        for _ in range(max(1, self.max_parallel_parse_mineru)):
-            workers.append(
-                asyncio.create_task(self._parse_worker("mineru", ctx.q_mineru, ctx))
-            )
-        for _ in range(max(1, self.max_parallel_parse_docling)):
-            workers.append(
-                asyncio.create_task(self._parse_worker("docling", ctx.q_docling, ctx))
-            )
+        for group, queue in parse_queues.items():
+            for _ in range(max(1, _group_concurrency(group))):
+                workers.append(
+                    asyncio.create_task(self._parse_worker(group, queue, ctx))
+                )
         for _ in range(max(1, self.max_parallel_analyze)):
             workers.append(asyncio.create_task(self._analyze_worker(ctx)))
         for _ in range(max(1, self.max_parallel_insert)):
@@ -1305,19 +1341,21 @@ class _PipelineMixin:
                         pipeline_status_lock=pipeline_status_lock,
                     )
                     continue
-                engine = resolve_stored_document_parser_engine(
+                # Select the concurrency pool by the engine's queue_group
+                # (snapshot). The worker re-resolves the actual parser per-doc;
+                # this only picks which queue/pool the doc waits in. Unknown
+                # group -> native pool (defensive; never KeyError).
+                key = resolve_stored_document_parser_engine(
                     file_path=file_path,
                     content_data=content_data,
                 )
-                if engine == "mineru":
-                    await ctx.q_mineru.put((doc_id, status_doc))
-                elif engine == "docling":
-                    await ctx.q_docling.put((doc_id, status_doc))
-                else:
-                    await ctx.q_native.put((doc_id, status_doc))
+                spec = parser_specs.get(key)
+                group = spec.queue_group if spec is not None else "native"
+                queue = ctx.parse_queues.get(group, ctx.parse_queues["native"])
+                await queue.put((doc_id, status_doc))
 
             await asyncio.gather(
-                ctx.q_native.join(), ctx.q_mineru.join(), ctx.q_docling.join()
+                *(q.join() for q in ctx.parse_queues.values())
             )
             await ctx.q_analyze.join()
             await ctx.q_process.join()
@@ -1646,18 +1684,51 @@ class _PipelineMixin:
                     logger.info(log_message)
                     ctx.pipeline_status["latest_message"] = log_message
                     ctx.pipeline_status["history_messages"].append(log_message)
-                if engine == "mineru":
-                    parsed_data_w = await self.parse_mineru(
-                        doc_id_w, file_path_w, content_data_w
+                # Resolve the actual parser per-doc from the batch snapshot
+                # (snapshot-consistent: a mid-batch register_parser cannot be
+                # picked up here). ``engine`` is only the queue-group/pool id.
+                specs = ctx.parser_specs
+                doc_format_w = content_data_w.get(
+                    "parse_format", FULL_DOCS_FORMAT_RAW
+                )
+                key = resolve_stored_document_parser_engine(
+                    file_path=file_path_w, content_data=content_data_w
+                )
+                # PENDING_PARSE must resolve to a real (user-selectable) engine;
+                # an internal key (reuse/passthrough) wrongly stored as
+                # parse_engine is corrupt -> fail just this doc.
+                if doc_format_w == FULL_DOCS_FORMAT_PENDING_PARSE:
+                    key_spec = specs.get(key)
+                    if key_spec is not None and not key_spec.user_selectable:
+                        raise ValueError(
+                            f"internal parser {key!r} is not a valid "
+                            f"PENDING_PARSE engine: doc_id={doc_id_w}"
+                        )
+                parser = get_parser(key, specs=specs)
+                if parser is None:
+                    logger.warning(
+                        "[parse] engine %r not registered; falling back to legacy",
+                        key,
                     )
-                elif engine == "docling":
-                    parsed_data_w = await self.parse_docling(
-                        doc_id_w, file_path_w, content_data_w
+                effective_key = key if parser is not None else "legacy"
+                parser = parser or get_parser("legacy", specs=specs)
+                # Suffix gate only for real engines on a PENDING_PARSE parse;
+                # reuse/passthrough (raw/lightrag/unknown_source) are skipped.
+                if (
+                    doc_format_w == FULL_DOCS_FORMAT_PENDING_PARSE
+                    and effective_key in supported_parser_engines(specs)
+                ):
+                    suffix_w = parser_suffix(file_path_w)
+                    if suffix_w not in suffix_capabilities(effective_key, specs):
+                        raise ValueError(
+                            f"engine {effective_key!r} does not support "
+                            f".{suffix_w or '<no suffix>'}: doc_id={doc_id_w}"
+                        )
+                parsed_data_w = (
+                    await parser.parse(
+                        ParseContext(self, doc_id_w, file_path_w, content_data_w)
                     )
-                else:
-                    parsed_data_w = await self.parse_native(
-                        doc_id_w, file_path_w, content_data_w
-                    )
+                ).to_dict()
 
                 # Mirror non-fatal parser warnings (e.g. legacy docx tables
                 # missing w14:paraId) onto the in-memory status_doc so the
@@ -2897,436 +2968,47 @@ class _PipelineMixin:
     async def parse_native(
         self, doc_id: str, file_path: str, content_data: dict[str, Any]
     ) -> dict[str, Any]:
-        """Phase 1 parse for native/raw, lightrag and pending_parse formats."""
+        """Deprecated thin wrapper; the pipeline dispatches via the registry.
+
+        Kept for the CLI / debug entrypoints. Maps the document *format* to a
+        handler (raw -> passthrough, lightrag -> reuse, pending_parse ->
+        native) so direct ``parse_native`` callers keep the historical
+        "native means native for a pending docx" semantics.
+        """
+        from lightrag.parser.registry import (
+            PARSER_ENGINE_PASSTHROUGH,
+            PARSER_ENGINE_REUSE,
+        )
+
         doc_format = content_data.get("parse_format", FULL_DOCS_FORMAT_RAW)
         if doc_format == FULL_DOCS_FORMAT_LIGHTRAG:
-            # full_docs.content carries the merged text with the {{LRdoc}}
-            # marker; strip it so the chunking path is identical to raw.
-            # blocks_path is still resolved for downstream multimodal
-            # sidecar reads (_build_mm_chunks_from_sidecars).
-            # No re-parse happens here — content + sidecar are reused from a
-            # prior parse, so this is semantically a cache-hit and mirrors
-            # the parse_mineru / parse_docling raw-bundle skip path by
-            # setting ``parse_stage_skipped``.
-            merged_text = strip_lightrag_doc_prefix(
-                content_data.get("content"), doc_format
-            )
-            blocks_path = (
-                sidecar_blocks_path(content_data.get("sidecar_location")) or ""
-            )
-
-            return {
-                "doc_id": doc_id,
-                "file_path": file_path,
-                "parse_format": doc_format,
-                "content": merged_text,
-                "blocks_path": blocks_path,
-                "parse_stage_skipped": True,
-            }
-
-        if doc_format == FULL_DOCS_FORMAT_PENDING_PARSE:
-            source_path = _call_source_file_resolver(
-                self,
-                file_path,
-                source_file=_read_source_file(content_data),
-                parser_engine=PARSER_ENGINE_NATIVE,
-            )
-            p = Path(source_path)
-            if not (p.exists() and p.is_file() and p.suffix.lower() == ".docx"):
-                raise ValueError(
-                    f"Native parser does not support pending file: {file_path}"
-                )
-
-            # Lazy imports keep this module import-cheap and avoid pulling
-            # the docx parser into call paths that never touch the native
-            # engine (mirrors parse_mineru).
-            from lightrag.parser.docx.drawing_image_extractor import (
-                DrawingExtractionContext,
-                load_relationships,
-            )
-            from lightrag.parser.docx.parse_document import (
-                extract_docx_blocks,
-            )
-            from lightrag.parser.docx.ir_builder import NativeDocxIRBuilder
-            from lightrag.sidecar import write_sidecar
-
-            # ``file_path`` is canonical at the worker layer; canonicalize
-            # again defensively so direct callers (tests, CLI) may pass
-            # absolute paths or hint-bearing names.
-            document_name = normalize_document_file_path(file_path)
-            if document_name == "unknown_source":
-                document_name = p.name or f"{doc_id}.bin"
-            base_name = Path(document_name).stem or document_name
-            parsed_dir = parsed_artifact_dir_for(document_name, parent_hint=p.parent)
-            asset_dir = parsed_dir / f"{base_name}.blocks.assets"
-
-            def _extract_blocks_sync() -> (
-                tuple[list[dict[str, Any]], dict[str, Any], dict[str, Any]]
-            ):
-                # Pre-clean parsed_dir and pre-create the asset dir so the
-                # drawing extractor can write image bytes BEFORE write_sidecar
-                # runs (which is then called with clean_parsed_dir=False to
-                # keep those bytes). ``parsed_artifact_dir_for`` returns
-                # a unique dir per source (with ``_001``/``_002`` suffixes on
-                # collision), so the rmtree here only ever clobbers stale
-                # artifacts from a previous attempt at the same doc_id.
-                if parsed_dir.exists():
-                    shutil.rmtree(parsed_dir)
-                parsed_dir.mkdir(parents=True, exist_ok=True)
-                asset_dir.mkdir(parents=True, exist_ok=True)
-                ctx = DrawingExtractionContext(
-                    docx_path=p,
-                    blocks_output_path=parsed_dir / f"{base_name}.blocks.jsonl",
-                    export_dir_name=asset_dir.name,
-                    export_dir_path=asset_dir,
-                )
-                load_relationships(ctx)
-                warnings: dict[str, Any] = {}
-                metadata: dict[str, Any] = {}
-                extracted = extract_docx_blocks(
-                    str(p),
-                    debug=False,
-                    fixlevel=0,
-                    drawing_context=ctx,
-                    parse_warnings=warnings,
-                    parse_metadata=metadata,
-                )
-                return extracted, warnings, metadata
-
-            try:
-                blocks, parse_warnings, parse_metadata = await asyncio.to_thread(
-                    _extract_blocks_sync
-                )
-            except BaseException:
-                # ``_extract_blocks_sync`` pre-creates ``parsed_dir`` and
-                # ``asset_dir`` before invoking the extractor; if extraction
-                # raises, those (possibly partially-populated) dirs would be
-                # left on disk. Roll them back so the next attempt starts clean.
-                if parsed_dir.exists():
-                    shutil.rmtree(parsed_dir, ignore_errors=True)
-                raise
-            if not blocks:
-                # Same cleanup path for the "extractor returned []" case —
-                # ``write_sidecar`` would never run, so without this the
-                # pre-created (empty) dirs would persist.
-                if parsed_dir.exists():
-                    shutil.rmtree(parsed_dir, ignore_errors=True)
-                raise ValueError(f"DOCX parser returned empty content for {file_path}")
-
-            missing_paraid_count = int(
-                parse_warnings.get("missing_paraid_count", 0) or 0
-            )
-            if missing_paraid_count > 0:
-                # Surface once per document — the parser may encounter many
-                # missing paraIds (legacy / non-Word authors omit
-                # ``w14:paraId``), but a single warning with the count is
-                # enough. Affected blocks emit
-                # ``positions: [{"type": "paraid", "range": null}]``.
-                logger.warning(
-                    "[parse_native] %s: %d paragraphs lack paraId; "
-                    "Re-saving file in Word 2013+ to regenerate ids.",
-                    p.name,
-                    missing_paraid_count,
-                )
-
-            ir = NativeDocxIRBuilder().normalize(
-                blocks,
-                document_name=document_name,
-                asset_dir_name=asset_dir.name,
-                parse_metadata=parse_metadata,
-            )
-            parsed_data = write_sidecar(
-                ir,
-                parsed_dir=parsed_dir,
-                doc_id=doc_id,
-                engine=PARSER_ENGINE_NATIVE,
-                clean_parsed_dir=False,  # we pre-populated the asset dir
-                block_drawing_path_style="basename_only",  # legacy native shape
-            )
-
-            await self._persist_parsed_full_docs(
-                doc_id,
-                {
-                    "content": make_lightrag_doc_content(parsed_data["content"]),
-                    "file_path": file_path,
-                    "parse_format": FULL_DOCS_FORMAT_LIGHTRAG,
-                    "sidecar_location": sidecar_uri_for(parsed_dir),
-                    "parse_engine": PARSER_ENGINE_NATIVE,
-                    "update_time": int(time.time()),
-                },
-            )
-            await archive_docx_source_after_full_docs_sync(str(p))
-            logger.info(
-                f"[parse_native] pending_parse completed for {file_path} "
-                f"via parser/docx"
-            )
-            result: dict[str, Any] = {
-                "doc_id": doc_id,
-                "file_path": file_path,
-                "parse_format": FULL_DOCS_FORMAT_LIGHTRAG,
-                "parse_engine": PARSER_ENGINE_NATIVE,
-                "content": parsed_data["content"],
-                "blocks_path": parsed_data["blocks_path"],
-            }
-            if missing_paraid_count > 0:
-                # Pipeline reads this from the parsed_data dict and writes it
-                # to ``doc_status.metadata.parse_warnings`` so admin/list APIs
-                # can surface the issue alongside the document record.
-                result["parse_warnings"] = {
-                    "missing_paraid_count": missing_paraid_count
-                }
-            return result
-
-        # FULL_DOCS_FORMAT_RAW: no parser ran — the content was supplied
-        # at insert time and we pass it through verbatim. Mark as skipped
-        # so post-mortem doesn't credit the worker with a synthetic parse
-        # duration (mirrors the LIGHTRAG-format branch above).
-        return {
-            "doc_id": doc_id,
-            "file_path": file_path,
-            "parse_format": FULL_DOCS_FORMAT_RAW,
-            "content": content_data.get("content", ""),
-            "blocks_path": "",
-            "parse_stage_skipped": True,
-        }
+            handler = PARSER_ENGINE_REUSE
+        elif doc_format == FULL_DOCS_FORMAT_PENDING_PARSE:
+            handler = PARSER_ENGINE_NATIVE
+        else:
+            handler = PARSER_ENGINE_PASSTHROUGH
+        parser = get_parser(handler)
+        return (
+            await parser.parse(ParseContext(self, doc_id, file_path, content_data))
+        ).to_dict()
 
     async def parse_mineru(
         self, doc_id: str, file_path: str, content_data: dict[str, Any]
     ) -> dict[str, Any]:
-        """Parse a document through MinerU and emit a spec-compliant sidecar.
-
-        Layout produced under ``inputs/<space>/__parsed__/``:
-
-        - ``<base>.parsed/``       — sidecar (blocks.jsonl + per-modality JSONs + assets)
-        - ``<base>.mineru_raw/``   — preserved MinerU bundle (content_list.json,
-          full.md, middle.json, images/, ...) plus ``_manifest.json``
-
-        The raw bundle is kept on disk so subsequent re-parses with the same
-        source content can skip the upload+poll+download round trip. It is
-        cleaned only when the user explicitly deletes the document with the
-        "also delete original file" option; see
-        :func:`lightrag.api.routers.document_routes.delete_file_variants_by_file_path`.
-        """
-        # Lazy imports keep this module import-cheap and avoid pulling httpx
-        # into call paths that never touch the MinerU engine.
-        from lightrag.parser.external.mineru import (
-            MinerUIRBuilder,
-            MinerURawClient,
-            clear_dir_contents,
-            is_bundle_valid,
-            raw_dir_for_parsed_dir,
-        )
-        from lightrag.sidecar import write_sidecar
-
-        source_file_path = Path(
-            _call_source_file_resolver(
-                self,
-                file_path,
-                source_file=_read_source_file(content_data),
-                parser_engine=PARSER_ENGINE_MINERU,
-            )
-        )
-        if not source_file_path.is_file():
-            raise FileNotFoundError(f"MinerU source file not found: {source_file_path}")
-
-        # Canonicalize defensively so direct callers (tests, CLI) may pass
-        # absolute paths or hint-bearing names.
-        document_name = normalize_document_file_path(file_path)
-        if document_name == "unknown_source":
-            document_name = source_file_path.name or f"{doc_id}.bin"
-        parsed_dir = parsed_artifact_dir_for(
-            document_name, parent_hint=source_file_path.parent
-        )
-        raw_dir = raw_dir_for_parsed_dir(parsed_dir)
-
-        force_reparse = os.getenv("LIGHTRAG_FORCE_REPARSE_MINERU", "").lower() in {
-            "1",
-            "true",
-            "yes",
-            "on",
-        }
-
-        parse_stage_skipped = False
-        if not force_reparse and is_bundle_valid(raw_dir, source_file_path):
-            # Cache hit: keep the path purely local so a re-parse still
-            # succeeds if MinerU credentials/endpoint are temporarily
-            # unavailable (key rotation, debugging, etc.). Network config
-            # is only required on cache miss below.
-            parse_stage_skipped = True
-            logger.info("[parse_mineru] raw cache hit doc_id=%s", doc_id)
-        else:
-            if force_reparse and raw_dir.exists():
-                logger.info(
-                    "[parse_mineru] LIGHTRAG_FORCE_REPARSE_MINERU set; "
-                    "discarding bundle at %s",
-                    raw_dir,
-                )
-            raw_dir.mkdir(parents=True, exist_ok=True)
-            clear_dir_contents(raw_dir)
-            client = MinerURawClient()
-            logger.info(
-                "[MinerU] Parsing %s %s (may take a few minutes)",
-                doc_id,
-                source_file_path.name,
-            )
-            await client.download_into(
-                raw_dir,
-                source_file_path,
-                upload_name=document_name,
-            )
-
-        ir_builder = MinerUIRBuilder()
-        ir = ir_builder.normalize_from_workdir(raw_dir, document_name=document_name)
-        parsed_data = write_sidecar(
-            ir,
-            parsed_dir=parsed_dir,
-            doc_id=doc_id,
-            engine=PARSER_ENGINE_MINERU,
-        )
-
-        # Keep full_docs in sync so restart/reprocess can directly use the
-        # sidecar (matches the native_docx and content_list paths).
-        await self._persist_parsed_full_docs(
-            doc_id,
-            {
-                "content": make_lightrag_doc_content(parsed_data["content"]),
-                "file_path": file_path,
-                "parse_format": FULL_DOCS_FORMAT_LIGHTRAG,
-                "sidecar_location": sidecar_uri_for(parsed_dir),
-                "parse_engine": PARSER_ENGINE_MINERU,
-                "update_time": int(time.time()),
-            },
-        )
-        await archive_docx_source_after_full_docs_sync(str(source_file_path))
-        return {
-            "doc_id": doc_id,
-            "file_path": file_path,
-            "parse_format": FULL_DOCS_FORMAT_LIGHTRAG,
-            "parse_engine": PARSER_ENGINE_MINERU,
-            "content": parsed_data["content"],
-            "blocks_path": parsed_data["blocks_path"],
-            "parse_stage_skipped": parse_stage_skipped,
-        }
+        """Deprecated thin wrapper; the pipeline dispatches via the registry."""
+        parser = get_parser(PARSER_ENGINE_MINERU)
+        return (
+            await parser.parse(ParseContext(self, doc_id, file_path, content_data))
+        ).to_dict()
 
     async def parse_docling(
         self, doc_id: str, file_path: str, content_data: dict[str, Any]
     ) -> dict[str, Any]:
-        """Parse a document through Docling Serve and emit a spec-compliant sidecar.
-
-        Produces the same dual-directory layout as ``parse_mineru``:
-
-        - ``<base>.parsed/``       — sidecar (blocks.jsonl + per-modality JSONs + assets)
-        - ``<base>.docling_raw/``  — preserved Docling bundle (``<stem>.json``,
-          ``<stem>.md``, ``artifacts/``) plus ``_manifest.json``
-
-        The raw bundle is kept so subsequent re-parses with the same source
-        bytes skip the upload + poll + download round trip.
-        """
-        # Lazy imports keep this module import-cheap and avoid pulling httpx
-        # into call paths that never touch the Docling engine.
-        from lightrag.parser.external.docling import (
-            DoclingIRBuilder,
-            DoclingRawClient,
-            clear_dir_contents,
-            is_bundle_valid,
-            raw_dir_for_parsed_dir,
-        )
-        from lightrag.sidecar import write_sidecar
-
-        source_file_path = Path(
-            _call_source_file_resolver(
-                self,
-                file_path,
-                source_file=_read_source_file(content_data),
-                parser_engine=PARSER_ENGINE_DOCLING,
-            )
-        )
-        if not source_file_path.is_file():
-            raise FileNotFoundError(
-                f"Docling source file not found: {source_file_path}"
-            )
-
-        document_name = normalize_document_file_path(file_path)
-        if document_name == "unknown_source":
-            document_name = source_file_path.name or f"{doc_id}.bin"
-        parsed_dir = parsed_artifact_dir_for(
-            document_name, parent_hint=source_file_path.parent
-        )
-        raw_dir = raw_dir_for_parsed_dir(parsed_dir)
-
-        force_reparse = os.getenv("LIGHTRAG_FORCE_REPARSE_DOCLING", "").lower() in {
-            "1",
-            "true",
-            "yes",
-            "on",
-        }
-
-        parse_stage_skipped = False
-        if not force_reparse and is_bundle_valid(raw_dir, source_file_path):
-            # Cache hit: keep purely local so re-parses still work when the
-            # docling-serve endpoint is temporarily unavailable.
-            parse_stage_skipped = True
-            logger.info("[parse_docling] raw cache hit doc_id=%s", doc_id)
-        else:
-            if force_reparse and raw_dir.exists():
-                logger.info(
-                    "[parse_docling] LIGHTRAG_FORCE_REPARSE_DOCLING set; "
-                    "discarding bundle at %s",
-                    raw_dir,
-                )
-            # ``download_into`` mkdir's the raw_dir itself; we only need to
-            # wipe the existing contents (manifest + stale bundle files).
-            clear_dir_contents(raw_dir)
-            client = DoclingRawClient()
-            logger.info(
-                "[Docling] Parsing %s %s (may take a few minutes)",
-                doc_id,
-                source_file_path.name,
-            )
-            # Pass the canonical (hint-stripped) name so docling-serve names
-            # the bundle's main JSON ``<canonical_stem>.json`` instead of
-            # ``<hinted_stem>.json``. Otherwise the IR builder — which only sees
-            # the canonical ``document_name`` — cannot locate the bundle JSON
-            # via the preferred-path lookup.
-            await client.download_into(
-                raw_dir, source_file_path, upload_filename=document_name
-            )
-
-        ir_builder = DoclingIRBuilder()
-        ir = ir_builder.normalize_from_workdir(raw_dir, document_name=document_name)
-        if not ir.blocks:
-            raise ValueError(
-                f"Docling IR builder produced zero blocks for {file_path} "
-                f"(raw_dir={raw_dir})"
-            )
-        parsed_data = write_sidecar(
-            ir,
-            parsed_dir=parsed_dir,
-            doc_id=doc_id,
-            engine=PARSER_ENGINE_DOCLING,
-        )
-
-        await self._persist_parsed_full_docs(
-            doc_id,
-            {
-                "content": make_lightrag_doc_content(parsed_data["content"]),
-                "file_path": file_path,
-                "parse_format": FULL_DOCS_FORMAT_LIGHTRAG,
-                "sidecar_location": sidecar_uri_for(parsed_dir),
-                "parse_engine": PARSER_ENGINE_DOCLING,
-                "update_time": int(time.time()),
-            },
-        )
-        await archive_docx_source_after_full_docs_sync(str(source_file_path))
-        return {
-            "doc_id": doc_id,
-            "file_path": file_path,
-            "parse_format": FULL_DOCS_FORMAT_LIGHTRAG,
-            "parse_engine": PARSER_ENGINE_DOCLING,
-            "content": parsed_data["content"],
-            "blocks_path": parsed_data["blocks_path"],
-            "parse_stage_skipped": parse_stage_skipped,
-        }
+        """Deprecated thin wrapper; the pipeline dispatches via the registry."""
+        parser = get_parser(PARSER_ENGINE_DOCLING)
+        return (
+            await parser.parse(ParseContext(self, doc_id, file_path, content_data))
+        ).to_dict()
 
     # ============================================================
     # Parser internals

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1299,7 +1299,20 @@ class _PipelineMixin:
                 )
             if owners:
                 owner = owners[0]
-                return int(os.getenv(owner.concurrency_env, owner.default_concurrency))
+                raw_value = os.getenv(owner.concurrency_env)
+                if raw_value is not None:
+                    try:
+                        return int(raw_value)
+                    except ValueError:
+                        # A malformed third-party env var must not abort the
+                        # whole batch; fall back to the spec default.
+                        logger.warning(
+                            "[parse] invalid %s=%r; using default %d",
+                            owner.concurrency_env,
+                            raw_value,
+                            owner.default_concurrency,
+                        )
+                return owner.default_concurrency
             return self.max_parallel_parse_native
 
         workers: list[asyncio.Task] = []

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1315,9 +1315,18 @@ class _PipelineMixin:
                 return owner.default_concurrency
             return self.max_parallel_parse_native
 
+        # Resolve every group's worker count BEFORE spawning any task:
+        # _group_concurrency can still raise (a queue_group with multiple
+        # concurrency owners). Raising here — while zero workers exist — avoids
+        # orphaning already-spawned workers outside the try/finally below (they
+        # would block forever on an empty queue, never cancelled).
+        group_worker_counts = {
+            group: max(1, _group_concurrency(group)) for group in parse_queues
+        }
+
         workers: list[asyncio.Task] = []
         for group, queue in parse_queues.items():
-            for _ in range(max(1, _group_concurrency(group))):
+            for _ in range(group_worker_counts[group]):
                 workers.append(
                     asyncio.create_task(self._parse_worker(group, queue, ctx))
                 )

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1299,9 +1299,7 @@ class _PipelineMixin:
                 )
             if owners:
                 owner = owners[0]
-                return int(
-                    os.getenv(owner.concurrency_env, owner.default_concurrency)
-                )
+                return int(os.getenv(owner.concurrency_env, owner.default_concurrency))
             return self.max_parallel_parse_native
 
         workers: list[asyncio.Task] = []
@@ -1365,9 +1363,7 @@ class _PipelineMixin:
                 queue = ctx.parse_queues.get(group, ctx.parse_queues["native"])
                 await queue.put((doc_id, status_doc))
 
-            await asyncio.gather(
-                *(q.join() for q in ctx.parse_queues.values())
-            )
+            await asyncio.gather(*(q.join() for q in ctx.parse_queues.values()))
             await ctx.q_analyze.join()
             await ctx.q_process.join()
         finally:
@@ -1699,9 +1695,7 @@ class _PipelineMixin:
                 # (snapshot-consistent: a mid-batch register_parser cannot be
                 # picked up here). ``engine`` is only the queue-group/pool id.
                 specs = ctx.parser_specs
-                doc_format_w = content_data_w.get(
-                    "parse_format", FULL_DOCS_FORMAT_RAW
-                )
+                doc_format_w = content_data_w.get("parse_format", FULL_DOCS_FORMAT_RAW)
                 key = resolve_stored_document_parser_engine(
                     file_path=file_path_w, content_data=content_data_w
                 )

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1284,6 +1284,24 @@ class _PipelineMixin:
             # override at registration); an unowned group shares native's.
             field_name = f"max_parallel_parse_{group}"
             if hasattr(self, field_name):
+                # A spec declaring ``concurrency`` on a built-in group is a
+                # plugin-author misconfig: the pool is sized by the instance
+                # field, so surface the ignored value instead of silently
+                # dropping it.
+                ignored = [
+                    s.engine_name
+                    for s in parser_specs.values()
+                    if s.queue_group == group and s.concurrency is not None
+                ]
+                if ignored:
+                    logger.warning(
+                        "[parse] queue_group %r is built-in (sized by %s=%d); "
+                        "spec-level concurrency from %s is ignored",
+                        group,
+                        field_name,
+                        getattr(self, field_name),
+                        ignored,
+                    )
                 return getattr(self, field_name)
             owners = [
                 s

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -35,9 +35,6 @@ from lightrag.constants import (
     FULL_DOCS_FORMAT_PENDING_PARSE,
     FULL_DOCS_FORMAT_RAW,
     PARSED_DIR_NAME,
-    PARSER_ENGINE_DOCLING,
-    PARSER_ENGINE_MINERU,
-    PARSER_ENGINE_NATIVE,
 )
 from lightrag.exceptions import (
     MultimodalAnalysisError,
@@ -2974,55 +2971,6 @@ class _PipelineMixin:
             },
             metadata_extra=metadata_extra,
         )
-
-    # ============================================================
-    # Parser engines (also called by tests directly)
-    # ============================================================
-
-    async def parse_native(
-        self, doc_id: str, file_path: str, content_data: dict[str, Any]
-    ) -> dict[str, Any]:
-        """Deprecated thin wrapper; the pipeline dispatches via the registry.
-
-        Kept for the CLI / debug entrypoints. Maps the document *format* to a
-        handler (raw -> passthrough, lightrag -> reuse, pending_parse ->
-        native) so direct ``parse_native`` callers keep the historical
-        "native means native for a pending docx" semantics.
-        """
-        from lightrag.parser.registry import (
-            PARSER_ENGINE_PASSTHROUGH,
-            PARSER_ENGINE_REUSE,
-        )
-
-        doc_format = content_data.get("parse_format", FULL_DOCS_FORMAT_RAW)
-        if doc_format == FULL_DOCS_FORMAT_LIGHTRAG:
-            handler = PARSER_ENGINE_REUSE
-        elif doc_format == FULL_DOCS_FORMAT_PENDING_PARSE:
-            handler = PARSER_ENGINE_NATIVE
-        else:
-            handler = PARSER_ENGINE_PASSTHROUGH
-        parser = get_parser(handler)
-        return (
-            await parser.parse(ParseContext(self, doc_id, file_path, content_data))
-        ).to_dict()
-
-    async def parse_mineru(
-        self, doc_id: str, file_path: str, content_data: dict[str, Any]
-    ) -> dict[str, Any]:
-        """Deprecated thin wrapper; the pipeline dispatches via the registry."""
-        parser = get_parser(PARSER_ENGINE_MINERU)
-        return (
-            await parser.parse(ParseContext(self, doc_id, file_path, content_data))
-        ).to_dict()
-
-    async def parse_docling(
-        self, doc_id: str, file_path: str, content_data: dict[str, Any]
-    ) -> dict[str, Any]:
-        """Deprecated thin wrapper; the pipeline dispatches via the registry."""
-        parser = get_parser(PARSER_ENGINE_DOCLING)
-        return (
-            await parser.parse(ParseContext(self, doc_id, file_path, content_data))
-        ).to_dict()
 
     # ============================================================
     # Parser internals

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1282,15 +1282,16 @@ class _PipelineMixin:
 
         def _group_concurrency(group: str) -> int:
             # Built-in groups keep their existing LightRAG fields (env +
-            # programmatic overrides preserved). Third-party groups read the
-            # owner spec's concurrency_env; an unowned group shares native's.
+            # programmatic overrides preserved). Third-party groups use the
+            # owner spec's ``concurrency`` (the registrant baked in any env
+            # override at registration); an unowned group shares native's.
             field_name = f"max_parallel_parse_{group}"
             if hasattr(self, field_name):
                 return getattr(self, field_name)
             owners = [
                 s
                 for s in parser_specs.values()
-                if s.queue_group == group and s.concurrency_env
+                if s.queue_group == group and s.concurrency is not None
             ]
             if len(owners) > 1:
                 raise ValueError(
@@ -1298,21 +1299,7 @@ class _PipelineMixin:
                     f"{[s.engine_name for s in owners]}"
                 )
             if owners:
-                owner = owners[0]
-                raw_value = os.getenv(owner.concurrency_env)
-                if raw_value is not None:
-                    try:
-                        return int(raw_value)
-                    except ValueError:
-                        # A malformed third-party env var must not abort the
-                        # whole batch; fall back to the spec default.
-                        logger.warning(
-                            "[parse] invalid %s=%r; using default %d",
-                            owner.concurrency_env,
-                            raw_value,
-                            owner.default_concurrency,
-                        )
-                return owner.default_concurrency
+                return owners[0].concurrency
             return self.max_parallel_parse_native
 
         # Resolve every group's worker count BEFORE spawning any task:

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -375,6 +375,17 @@ class _PipelineMixin:
             file_paths = ["unknown_source"] * len(input)
 
         is_lightrag_format = docs_format == FULL_DOCS_FORMAT_LIGHTRAG
+        if is_lightrag_format or lightrag_document_paths is not None:
+            # DEPRECATED ingestion entrypoint: no production caller enqueues a
+            # pre-existing sidecar this way (the upper layer doesn't know the
+            # backend sidecar layout). Scheduled for removal; the lightrag
+            # resume/reuse path (post-parse persist -> ReuseParser) is
+            # unaffected. See the unified-parser plan §11.
+            logger.warning(
+                "[apipeline_enqueue_documents] docs_format='lightrag' / "
+                "lightrag_document_paths is deprecated and will be removed in a "
+                "future release; it has no production caller."
+            )
         if is_lightrag_format and lightrag_document_paths is not None:
             if len(lightrag_document_paths) != len(input):
                 raise ValueError(

--- a/tests/api/routes/test_document_routes_docx_archive.py
+++ b/tests/api/routes/test_document_routes_docx_archive.py
@@ -1990,3 +1990,39 @@ def test_upload_allowlist_subset_of_registry_suffixes(tmp_path):
     allowlist = {ext.lower() for ext in dm.supported_extensions}
     missing = allowlist - all_suffixes
     assert not missing, f"upload allowlist has unparseable extensions: {missing}"
+
+
+def test_third_party_engine_suffixes_join_allowlist_and_scan(tmp_path):
+    """A registered third-party engine's suffixes become uploadable
+    (is_supported_file) and scannable (directory glob) live — while built-in
+    engines' non-curated suffixes (e.g. mineru's images) stay excluded."""
+    from lightrag.parser import registry
+
+    dm = DocumentManager(str(tmp_path))
+
+    # Before registration: .foo rejected by upload and invisible to scan.
+    assert not dm.is_supported_file("sample.foo")
+    (dm.input_dir / "sample.foo").write_text("x", encoding="utf-8")
+    assert not [p for p in dm.scan_directory_for_new_files() if p.suffix == ".foo"]
+
+    registry.register_parser(
+        registry.ParserSpec(
+            engine_name="allowlist-test-engine",
+            impl="x:Y",
+            suffixes=frozenset({"foo"}),
+            queue_group="allowlist-test-engine",
+            concurrency=1,
+        )
+    )
+    try:
+        assert dm.is_supported_file("sample.foo")
+        assert ".foo" in dm.supported_extensions
+        scanned = dm.scan_directory_for_new_files()
+        assert [p for p in scanned if p.suffix == ".foo"]
+        # Curated guard: built-in mineru supports png, but images must NOT
+        # leak into the upload allowlist through the dynamic union.
+        assert "png" in registry.suffix_capabilities("mineru")
+        assert ".png" not in dm.supported_extensions
+    finally:
+        registry._REGISTRY.pop("allowlist-test-engine", None)
+    assert not dm.is_supported_file("sample.foo")

--- a/tests/api/routes/test_document_routes_docx_archive.py
+++ b/tests/api/routes/test_document_routes_docx_archive.py
@@ -1976,26 +1976,43 @@ def test_lightrag_document_reprocess_uses_full_docs_without_reparse():
     assert engine == "reuse"
 
 
-def test_upload_allowlist_subset_of_registry_suffixes(tmp_path):
-    """Every extension the upload endpoint accepts must be parseable by at
-    least one registered engine (directional; the allowlist is curated and is
-    NOT required to cover every engine suffix)."""
+def test_default_allowlist_equals_local_engine_suffixes(tmp_path, monkeypatch):
+    """With no external endpoints configured, the registry-derived allowlist
+    must equal the local engines' (legacy ∪ native) suffixes — i.e. exactly
+    the historical hardcoded upload allowlist."""
     from lightrag.parser import registry
 
-    dm = DocumentManager(str(tmp_path))
-    all_suffixes = set()
-    for engine in registry.supported_parser_engines():
-        all_suffixes |= {f".{s}" for s in registry.suffix_capabilities(engine)}
+    for var in ("MINERU_LOCAL_ENDPOINT", "MINERU_API_TOKEN", "DOCLING_ENDPOINT"):
+        monkeypatch.delenv(var, raising=False)
 
-    allowlist = {ext.lower() for ext in dm.supported_extensions}
-    missing = allowlist - all_suffixes
-    assert not missing, f"upload allowlist has unparseable extensions: {missing}"
+    dm = DocumentManager(str(tmp_path))
+    local = {f".{s}" for s in registry.suffix_capabilities("legacy")} | {
+        f".{s}" for s in registry.suffix_capabilities("native")
+    }
+    assert set(dm.supported_extensions) == local
+    # External-only suffixes stay out while their endpoints are unset.
+    assert ".png" not in dm.supported_extensions
+    assert ".doc" not in dm.supported_extensions
+
+
+def test_configured_endpoint_admits_engine_suffixes(tmp_path, monkeypatch):
+    """Configuring an external engine's endpoint admits its suffixes into the
+    upload allowlist live (the gate is ParserSpec.endpoint_configured)."""
+    monkeypatch.delenv("DOCLING_ENDPOINT", raising=False)
+    monkeypatch.setenv("MINERU_API_MODE", "local")
+    monkeypatch.setenv("MINERU_LOCAL_ENDPOINT", "http://fake-mineru")
+
+    dm = DocumentManager(str(tmp_path))
+    assert dm.is_supported_file("scan.png")
+    assert ".doc" in dm.supported_extensions
+    # docling-only suffixes stay out (its endpoint is still unset).
+    assert ".xhtml" not in dm.supported_extensions
 
 
 def test_third_party_engine_suffixes_join_allowlist_and_scan(tmp_path):
     """A registered third-party engine's suffixes become uploadable
-    (is_supported_file) and scannable (directory glob) live — while built-in
-    engines' non-curated suffixes (e.g. mineru's images) stay excluded."""
+    (is_supported_file) and scannable (directory glob) live, and revert on
+    unregister."""
     from lightrag.parser import registry
 
     dm = DocumentManager(str(tmp_path))
@@ -2019,10 +2036,6 @@ def test_third_party_engine_suffixes_join_allowlist_and_scan(tmp_path):
         assert ".foo" in dm.supported_extensions
         scanned = dm.scan_directory_for_new_files()
         assert [p for p in scanned if p.suffix == ".foo"]
-        # Curated guard: built-in mineru supports png, but images must NOT
-        # leak into the upload allowlist through the dynamic union.
-        assert "png" in registry.suffix_capabilities("mineru")
-        assert ".png" not in dm.supported_extensions
     finally:
         registry._REGISTRY.pop("allowlist-test-engine", None)
     assert not dm.is_supported_file("sample.foo")

--- a/tests/api/routes/test_document_routes_docx_archive.py
+++ b/tests/api/routes/test_document_routes_docx_archive.py
@@ -16,6 +16,8 @@ _base = importlib.import_module("lightrag.base")
 _constants = importlib.import_module("lightrag.constants")
 _utils = importlib.import_module("lightrag.utils")
 _parser_routing = importlib.import_module("lightrag.parser.routing")
+_parser_registry = importlib.import_module("lightrag.parser.registry")
+_parser_base = importlib.import_module("lightrag.parser.base")
 sys.argv = _original_argv
 
 DocStatus = _base.DocStatus
@@ -29,6 +31,18 @@ LightRAG = _lightrag.LightRAG
 resolve_stored_document_parser_engine = (
     _parser_routing.resolve_stored_document_parser_engine
 )
+get_parser = _parser_registry.get_parser
+ParseContext = _parser_base.ParseContext
+
+
+async def _parse_via_registry(rag, engine, doc_id, file_path, content_data):
+    """Drive a parser the way the pipeline worker does (registry dispatch)."""
+    result = await get_parser(engine).parse(
+        ParseContext(rag, doc_id, file_path, content_data)
+    )
+    return result.to_dict()
+
+
 pipeline_index_file = _document_routes.pipeline_index_file
 pipeline_index_files = _document_routes.pipeline_index_files
 pipeline_index_texts = _document_routes.pipeline_index_texts
@@ -1841,8 +1855,9 @@ async def test_parse_native_archives_docx_after_full_docs_sync(tmp_path, monkeyp
         _fake_extract,
     )
 
-    result = await LightRAG.parse_native(
+    result = await _parse_via_registry(
         rag,
+        "native",
         "doc-test",
         str(source_path),
         {"parse_format": FULL_DOCS_FORMAT_PENDING_PARSE, "content": ""},
@@ -1909,8 +1924,9 @@ async def test_parse_native_docx_content_list_failure_raises_without_fallback(
     )
 
     with pytest.raises(RuntimeError, match="content list boom"):
-        await LightRAG.parse_native(
+        await _parse_via_registry(
             rag,
+            "native",
             "doc-test",
             str(source_path),
             {"parse_format": FULL_DOCS_FORMAT_PENDING_PARSE, "content": ""},
@@ -1933,8 +1949,9 @@ async def test_parse_native_docx_empty_content_list_result_raises_without_fallba
     )
 
     with pytest.raises(ValueError, match="empty content"):
-        await LightRAG.parse_native(
+        await _parse_via_registry(
             rag,
+            "native",
             "doc-test",
             str(source_path),
             {"parse_format": FULL_DOCS_FORMAT_PENDING_PARSE, "content": ""},

--- a/tests/api/routes/test_document_routes_docx_archive.py
+++ b/tests/api/routes/test_document_routes_docx_archive.py
@@ -1965,4 +1965,6 @@ def test_lightrag_document_reprocess_uses_full_docs_without_reparse():
         },
     )
 
-    assert engine == "native"
+    # All lightrag rows route to the internal reuse handler (reuse the stored
+    # sidecar without re-parsing) regardless of the originating engine.
+    assert engine == "reuse"

--- a/tests/api/routes/test_document_routes_docx_archive.py
+++ b/tests/api/routes/test_document_routes_docx_archive.py
@@ -1007,6 +1007,33 @@ async def test_upload_rejects_parser_hinted_filesystem_duplicate(tmp_path, monke
     assert not (tmp_path / "existing.[native].docx").exists()
 
 
+async def test_upload_rejects_malformed_hint_with_detail(tmp_path, monkeypatch):
+    """A malformed filename hint fails the upload synchronously with the
+    detailed hint error in the 400 body (it used to be accepted and only
+    surface later as an error document)."""
+    monkeypatch.setattr(
+        _document_routes, "global_args", SimpleNamespace(max_upload_size=None)
+    )
+    doc_manager = DocumentManager(str(tmp_path))
+    rag = _DuplicateUploadRag({})
+    router = create_document_routes(rag, doc_manager)
+    upload_endpoint = [
+        route.endpoint
+        for route in router.routes
+        if getattr(route, "name", "") == "upload_to_input_dir"
+    ][-1]
+    upload_file = _document_routes.UploadFile(
+        # F and R are two chunking modes -> invalid hint combination.
+        filename="bad.[native-FR].docx",
+        file=BytesIO(b"docx bytes"),
+    )
+
+    with pytest.raises(_document_routes.HTTPException) as excinfo:
+        await upload_endpoint(_document_routes.BackgroundTasks(), upload_file)
+    assert excinfo.value.status_code == 400
+    assert "multiple chunking modes" in excinfo.value.detail
+
+
 async def test_upload_succeeds_concurrent_with_pipeline_busy(tmp_path, monkeypatch):
     """Under the new contract, ``busy=True`` no longer blocks uploads.
     The upload reserves a pending-enqueue slot, schedules its bg task,
@@ -1977,12 +2004,17 @@ def test_lightrag_document_reprocess_uses_full_docs_without_reparse():
 
 
 def test_default_allowlist_equals_local_engine_suffixes(tmp_path, monkeypatch):
-    """With no external endpoints configured, the registry-derived allowlist
-    must equal the local engines' (legacy ∪ native) suffixes — i.e. exactly
-    the historical hardcoded upload allowlist."""
+    """With no external endpoints and no routing rules, the registry-derived
+    allowlist must equal the local engines' (legacy ∪ native) suffixes —
+    i.e. exactly the historical hardcoded upload allowlist."""
     from lightrag.parser import registry
 
-    for var in ("MINERU_LOCAL_ENDPOINT", "MINERU_API_TOKEN", "DOCLING_ENDPOINT"):
+    for var in (
+        "MINERU_LOCAL_ENDPOINT",
+        "MINERU_API_TOKEN",
+        "DOCLING_ENDPOINT",
+        "LIGHTRAG_PARSER",
+    ):
         monkeypatch.delenv(var, raising=False)
 
     dm = DocumentManager(str(tmp_path))
@@ -1995,47 +2027,68 @@ def test_default_allowlist_equals_local_engine_suffixes(tmp_path, monkeypatch):
     assert ".doc" not in dm.supported_extensions
 
 
-def test_configured_endpoint_admits_engine_suffixes(tmp_path, monkeypatch):
-    """Configuring an external engine's endpoint admits its suffixes into the
-    upload allowlist live (the gate is ParserSpec.endpoint_configured)."""
+def test_unroutable_suffix_needs_rule_or_hint(tmp_path, monkeypatch):
+    """An endpoint-configured engine's suffix is accepted only when routing
+    actually reaches that engine: a bare filename needs a LIGHTRAG_PARSER
+    rule; a per-file hint works without one. Otherwise the file would pass
+    upload only to fail the parse worker's legacy suffix gate."""
     monkeypatch.delenv("DOCLING_ENDPOINT", raising=False)
+    monkeypatch.delenv("LIGHTRAG_PARSER", raising=False)
     monkeypatch.setenv("MINERU_API_MODE", "local")
     monkeypatch.setenv("MINERU_LOCAL_ENDPOINT", "http://fake-mineru")
 
     dm = DocumentManager(str(tmp_path))
+    # Capable (endpoint up) but unroutable: bare png defaults to legacy.
+    assert ".png" not in dm.supported_extensions
+    assert not dm.is_supported_file("scan.png")
+    # A per-file hint routes this specific name to mineru.
+    assert dm.is_supported_file("scan.[mineru].png")
+    # A routing rule makes the bare suffix routable (and advertised).
+    monkeypatch.setenv("LIGHTRAG_PARSER", "png:mineru")
+    assert ".png" in dm.supported_extensions
     assert dm.is_supported_file("scan.png")
-    assert ".doc" in dm.supported_extensions
-    # docling-only suffixes stay out (its endpoint is still unset).
+    # docling-only suffixes stay out (endpoint unset), rule or not.
     assert ".xhtml" not in dm.supported_extensions
 
 
-def test_third_party_engine_suffixes_join_allowlist_and_scan(tmp_path):
-    """A registered third-party engine's suffixes become uploadable
-    (is_supported_file) and scannable (directory glob) live, and revert on
-    unregister."""
+def test_third_party_engine_suffixes_join_allowlist_and_scan(tmp_path, monkeypatch):
+    """A registered third-party engine's suffixes become uploadable and
+    scannable once routable (rule for bare names, hint for individual
+    files), and revert on unregister."""
     from lightrag.parser import registry
 
+    monkeypatch.delenv("LIGHTRAG_PARSER", raising=False)
     dm = DocumentManager(str(tmp_path))
 
     # Before registration: .foo rejected by upload and invisible to scan.
     assert not dm.is_supported_file("sample.foo")
     (dm.input_dir / "sample.foo").write_text("x", encoding="utf-8")
+    (dm.input_dir / "hinted.[fooengine].foo").write_text("x", encoding="utf-8")
     assert not [p for p in dm.scan_directory_for_new_files() if p.suffix == ".foo"]
 
     registry.register_parser(
         registry.ParserSpec(
-            engine_name="allowlist-test-engine",
+            engine_name="fooengine",
             impl="x:Y",
             suffixes=frozenset({"foo"}),
-            queue_group="allowlist-test-engine",
+            queue_group="fooengine",
             concurrency=1,
         )
     )
     try:
-        assert dm.is_supported_file("sample.foo")
+        # Registered but bare .foo is still unroutable (defaults to legacy).
+        assert not dm.is_supported_file("sample.foo")
+        # The hinted file routes to fooengine: uploadable AND discoverable
+        # by scan (glob covers the capability surface, filter is per-name).
+        assert dm.is_supported_file("hinted.[fooengine].foo")
+        scanned = {p.name for p in dm.scan_directory_for_new_files()}
+        assert "hinted.[fooengine].foo" in scanned
+        assert "sample.foo" not in scanned
+        # A routing rule makes the bare suffix routable.
+        monkeypatch.setenv("LIGHTRAG_PARSER", "foo:fooengine")
         assert ".foo" in dm.supported_extensions
-        scanned = dm.scan_directory_for_new_files()
-        assert [p for p in scanned if p.suffix == ".foo"]
+        assert dm.is_supported_file("sample.foo")
+        assert "sample.foo" in {p.name for p in dm.scan_directory_for_new_files()}
     finally:
-        registry._REGISTRY.pop("allowlist-test-engine", None)
+        registry._REGISTRY.pop("fooengine", None)
     assert not dm.is_supported_file("sample.foo")

--- a/tests/api/routes/test_document_routes_docx_archive.py
+++ b/tests/api/routes/test_document_routes_docx_archive.py
@@ -337,13 +337,10 @@ async def test_pipeline_enqueue_lightrag_document_docx_does_not_move_source(
     assert rag.enqueued[0]["parse_engine"] == "native"
 
 
-async def test_pipeline_enqueue_docx_plain_text_extracts_before_enqueue(
-    tmp_path, monkeypatch
-):
+async def test_pipeline_enqueue_docx_defers_to_legacy_parser(tmp_path, monkeypatch):
+    # Legacy now defers extraction to the worker stage; enqueue just records a
+    # PENDING_PARSE row with parse_engine=legacy (no eager extraction here).
     monkeypatch.setenv("LIGHTRAG_PARSER", "docx:legacy")
-    monkeypatch.setattr(
-        _document_routes, "_extract_docx", lambda file_bytes: "plain docx content"
-    )
     file_path = tmp_path / "plain.docx"
     file_path.write_bytes(b"docx bytes")
     rag = _FakeRag()
@@ -356,21 +353,23 @@ async def test_pipeline_enqueue_docx_plain_text_extracts_before_enqueue(
     assert returned_track_id == "track-docx"
     assert rag.enqueued == [
         {
-            "input": "plain docx content",
-            "file_path": file_path.name,
+            "input": "",
+            "file_path": str(file_path),
             "track_id": "track-docx",
-            "docs_format": None,
+            "docs_format": FULL_DOCS_FORMAT_PENDING_PARSE,
             "parse_engine": "legacy",
             "process_options": PROCESS_OPTION_CHUNK_FIXED,
             "chunk_options": None,
             "from_scan": False,
         }
     ]
-    assert not file_path.exists()
-    assert (tmp_path / PARSED_DIR_NAME / file_path.name).exists()
+    # Deferred: the source stays in place until the worker archives it.
+    assert file_path.exists()
 
 
-async def test_pipeline_enqueue_md_moves_after_enqueue(tmp_path, monkeypatch):
+async def test_pipeline_enqueue_md_defers_to_legacy_parser(tmp_path, monkeypatch):
+    # Unhinted .md defaults to the legacy engine and now defers extraction to
+    # the worker stage (PENDING_PARSE), like every other engine.
     monkeypatch.delenv("LIGHTRAG_PARSER", raising=False)
     file_path = tmp_path / "notes.md"
     file_path.write_text("# Notes\n\nmarkdown content", encoding="utf-8")
@@ -382,18 +381,18 @@ async def test_pipeline_enqueue_md_moves_after_enqueue(tmp_path, monkeypatch):
     assert returned_track_id == "track-md"
     assert rag.enqueued == [
         {
-            "input": "# Notes\n\nmarkdown content",
-            "file_path": file_path.name,
+            "input": "",
+            "file_path": str(file_path),
             "track_id": "track-md",
-            "docs_format": None,
+            "docs_format": FULL_DOCS_FORMAT_PENDING_PARSE,
             "parse_engine": "legacy",
             "process_options": PROCESS_OPTION_CHUNK_FIXED,
             "chunk_options": None,
             "from_scan": False,
         }
     ]
-    assert not file_path.exists()
-    assert (tmp_path / PARSED_DIR_NAME / file_path.name).exists()
+    # Deferred: the source stays in place until the worker archives it.
+    assert file_path.exists()
 
 
 async def test_pipeline_enqueue_legacy_duplicate_archives_with_unique_name(
@@ -427,10 +426,8 @@ async def test_pipeline_enqueue_parser_routed_pdf_defers_without_extraction(
     monkeypatch.setenv("MINERU_API_MODE", "local")
     monkeypatch.setenv("MINERU_LOCAL_ENDPOINT", "http://fake-mineru")
 
-    def _fail_pdf_extract(*args, **kwargs):
-        raise AssertionError("parser-routed PDF should not be extracted before enqueue")
-
-    monkeypatch.setattr(_document_routes, "_extract_pdf_pypdf", _fail_pdf_extract)
+    # Extraction is always deferred now (no enqueue-stage extraction for any
+    # engine), so the pdf simply enqueues as PENDING_PARSE for mineru.
     file_path = tmp_path / "paper.pdf"
     file_path.write_bytes(b"fake-pdf")
     rag = _FakeRag()
@@ -1906,14 +1903,10 @@ async def test_parse_native_docx_content_list_failure_raises_without_fallback(
     def _raise_parser(file_path, fixlevel=None, drawing_context=None, **kwargs):
         raise RuntimeError("content list boom")
 
-    def _fail_fallback(file_bytes):
-        raise AssertionError("plain text fallback should not run")
-
     monkeypatch.setattr(
         "lightrag.parser.docx.parse_document.extract_docx_blocks",
         _raise_parser,
     )
-    monkeypatch.setattr(_document_routes, "_extract_docx", _fail_fallback)
 
     with pytest.raises(RuntimeError, match="content list boom"):
         await LightRAG.parse_native(
@@ -1934,14 +1927,10 @@ async def test_parse_native_docx_empty_content_list_result_raises_without_fallba
     source_path.write_bytes(b"docx bytes")
     rag = _ParseRag(tmp_path / "work", source_path)
 
-    def _fail_fallback(file_bytes):
-        raise AssertionError("plain text fallback should not run")
-
     monkeypatch.setattr(
         "lightrag.parser.docx.parse_document.extract_docx_blocks",
         lambda *args, **kwargs: [],
     )
-    monkeypatch.setattr(_document_routes, "_extract_docx", _fail_fallback)
 
     with pytest.raises(ValueError, match="empty content"):
         await LightRAG.parse_native(
@@ -1968,3 +1957,19 @@ def test_lightrag_document_reprocess_uses_full_docs_without_reparse():
     # All lightrag rows route to the internal reuse handler (reuse the stored
     # sidecar without re-parsing) regardless of the originating engine.
     assert engine == "reuse"
+
+
+def test_upload_allowlist_subset_of_registry_suffixes(tmp_path):
+    """Every extension the upload endpoint accepts must be parseable by at
+    least one registered engine (directional; the allowlist is curated and is
+    NOT required to cover every engine suffix)."""
+    from lightrag.parser import registry
+
+    dm = DocumentManager(str(tmp_path))
+    all_suffixes = set()
+    for engine in registry.supported_parser_engines():
+        all_suffixes |= {f".{s}" for s in registry.suffix_capabilities(engine)}
+
+    allowlist = {ext.lower() for ext in dm.supported_extensions}
+    missing = allowlist - all_suffixes
+    assert not missing, f"upload allowlist has unparseable extensions: {missing}"

--- a/tests/chunker/test_chunking_raw_lightrag_parity.py
+++ b/tests/chunker/test_chunking_raw_lightrag_parity.py
@@ -595,6 +595,7 @@ def test_pending_parse_lightrag_summary_populated_after_processed(
                 "",
                 file_paths="summary.docx",
                 docs_format=FULL_DOCS_FORMAT_PENDING_PARSE,
+                parse_engine="native",
                 track_id="track-summary",
             )
 

--- a/tests/parser/docx/test_native_docx_golden.py
+++ b/tests/parser/docx/test_native_docx_golden.py
@@ -26,10 +26,12 @@ if str(HERE) not in sys.path:
     sys.path.insert(0, str(HERE))
 
 from _native_docx_fixtures import SCENARIOS, Scenario  # noqa: E402
+from lightrag.parser.base import ParseContext  # noqa: E402
 from lightrag.parser.debug import (  # noqa: E402
     FrozenDateTime,
     build_debug_rag,
 )
+from lightrag.parser.registry import get_parser  # noqa: E402
 
 GOLDEN_ROOT = HERE / "golden" / "native_docx"
 
@@ -96,13 +98,16 @@ def _run_new_path(
     ):
 
         async def _go() -> None:
-            await rag.parse_native(
-                scenario.doc_id,
-                str(source_path),
-                {
-                    "parse_format": FULL_DOCS_FORMAT_PENDING_PARSE,
-                    "content": "",
-                },
+            await get_parser("native").parse(
+                ParseContext(
+                    rag,
+                    scenario.doc_id,
+                    str(source_path),
+                    {
+                        "parse_format": FULL_DOCS_FORMAT_PENDING_PARSE,
+                        "content": "",
+                    },
+                )
             )
 
         asyncio.run(_go())

--- a/tests/parser/external/docling/test_parse_docling_sidecar.py
+++ b/tests/parser/external/docling/test_parse_docling_sidecar.py
@@ -38,7 +38,17 @@ from lightrag.parser.external.docling.cache import (
     snapshot_tunable_env,
 )
 from lightrag.parser.external.docling.client import FIXED_CONSTANTS
+from lightrag.parser.base import ParseContext
+from lightrag.parser.registry import get_parser
 from lightrag.utils import EmbeddingFunc, Tokenizer
+
+
+async def _parse_via_registry(rag, engine, doc_id, file_path, content_data):
+    """Drive a parser the way the pipeline worker does (registry dispatch)."""
+    result = await get_parser(engine).parse(
+        ParseContext(rag, doc_id, file_path, content_data)
+    )
+    return result.to_dict()
 
 
 class _SimpleTokenizerImpl:
@@ -288,7 +298,9 @@ def test_parse_docling_emits_compliant_sidecar(
             doc_id = "doc-abcdef0123456789abcdef0123456789"
             await _seed_doc_status(rag, doc_id)
 
-            parsed = await rag.parse_docling(
+            parsed = await _parse_via_registry(
+                rag,
+                "docling",
                 doc_id=doc_id,
                 file_path="demo.pdf",
                 content_data={},
@@ -373,14 +385,18 @@ def test_parse_docling_cache_hit_skips_download(
             doc_id = "doc-abcdef0123456789abcdef0123456789"
             await _seed_doc_status(rag, doc_id)
 
-            await rag.parse_docling(
+            await _parse_via_registry(
+                rag,
+                "docling",
                 doc_id=doc_id,
                 file_path="demo.pdf",
                 content_data={},
             )
             assert counters["calls"] == 1
 
-            await rag.parse_docling(
+            await _parse_via_registry(
+                rag,
+                "docling",
                 doc_id=doc_id,
                 file_path="demo.pdf",
                 content_data={},
@@ -388,7 +404,9 @@ def test_parse_docling_cache_hit_skips_download(
             assert counters["calls"] == 1, "cache hit must not re-download"
 
             monkeypatch.setenv("LIGHTRAG_FORCE_REPARSE_DOCLING", "true")
-            await rag.parse_docling(
+            await _parse_via_registry(
+                rag,
+                "docling",
                 doc_id=doc_id,
                 file_path="demo.pdf",
                 content_data={},
@@ -420,7 +438,9 @@ def test_parse_docling_cache_invalidates_on_source_change(
             doc_id = "doc-abcdef0123456789abcdef0123456789"
             await _seed_doc_status(rag, doc_id)
 
-            await rag.parse_docling(
+            await _parse_via_registry(
+                rag,
+                "docling",
                 doc_id=doc_id,
                 file_path="demo.pdf",
                 content_data={},
@@ -430,7 +450,9 @@ def test_parse_docling_cache_invalidates_on_source_change(
             data = src.read_bytes()
             src.write_bytes(b"\x00" + data[1:])
 
-            await rag.parse_docling(
+            await _parse_via_registry(
+                rag,
+                "docling",
                 doc_id=doc_id,
                 file_path="demo.pdf",
                 content_data={},
@@ -462,7 +484,9 @@ def test_parse_docling_options_signature_invalidates_cache(
             doc_id = "doc-abcdef0123456789abcdef0123456789"
             await _seed_doc_status(rag, doc_id)
 
-            await rag.parse_docling(
+            await _parse_via_registry(
+                rag,
+                "docling",
                 doc_id=doc_id,
                 file_path="demo.pdf",
                 content_data={},
@@ -471,7 +495,9 @@ def test_parse_docling_options_signature_invalidates_cache(
 
             # Flip an env var that participates in the options signature
             monkeypatch.setenv("DOCLING_OCR_LANG", "en,zh")
-            await rag.parse_docling(
+            await _parse_via_registry(
+                rag,
+                "docling",
                 doc_id=doc_id,
                 file_path="demo.pdf",
                 content_data={},
@@ -505,7 +531,9 @@ def test_parse_docling_endpoint_signature_invalidates_cache(
             doc_id = "doc-abcdef0123456789abcdef0123456789"
             await _seed_doc_status(rag, doc_id)
 
-            await rag.parse_docling(
+            await _parse_via_registry(
+                rag,
+                "docling",
                 doc_id=doc_id,
                 file_path="demo.pdf",
                 content_data={},
@@ -515,7 +543,9 @@ def test_parse_docling_endpoint_signature_invalidates_cache(
             # Pointing at a different docling-serve instance must not silently
             # reuse a bundle that was produced by the previous one.
             monkeypatch.setenv("DOCLING_ENDPOINT", "http://docling-other.test")
-            await rag.parse_docling(
+            await _parse_via_registry(
+                rag,
+                "docling",
                 doc_id=doc_id,
                 file_path="demo.pdf",
                 content_data={},
@@ -617,7 +647,9 @@ def test_parse_docling_zero_blocks_raises(
             await _seed_doc_status(rag, doc_id)
 
             with pytest.raises(ValueError, match="zero blocks"):
-                await rag.parse_docling(
+                await _parse_via_registry(
+                    rag,
+                    "docling",
                     doc_id=doc_id,
                     file_path="demo.pdf",
                     content_data={},

--- a/tests/parser/external/mineru/test_parse_mineru_sidecar.py
+++ b/tests/parser/external/mineru/test_parse_mineru_sidecar.py
@@ -32,7 +32,17 @@ from lightrag.parser.external.mineru.manifest import (
     ManifestFile,
     write_manifest,
 )
+from lightrag.parser.base import ParseContext
+from lightrag.parser.registry import get_parser
 from lightrag.utils import EmbeddingFunc, Tokenizer
+
+
+async def _parse_via_registry(rag, engine, doc_id, file_path, content_data):
+    """Drive a parser the way the pipeline worker does (registry dispatch)."""
+    result = await get_parser(engine).parse(
+        ParseContext(rag, doc_id, file_path, content_data)
+    )
+    return result.to_dict()
 
 
 class _SimpleTokenizerImpl:
@@ -204,7 +214,9 @@ def test_parse_mineru_emits_compliant_sidecar(
                 lambda _p: str(src),
             )
 
-            parsed = await rag.parse_mineru(
+            parsed = await _parse_via_registry(
+                rag,
+                "mineru",
                 doc_id=doc_id,
                 file_path="demo.pdf",
                 content_data={},
@@ -357,7 +369,9 @@ def test_parse_mineru_cache_hit_skips_download(
             )
 
             # First call: cache miss → download once.
-            await rag.parse_mineru(
+            await _parse_via_registry(
+                rag,
+                "mineru",
                 doc_id=doc_id,
                 file_path="demo.pdf",
                 content_data={},
@@ -365,7 +379,9 @@ def test_parse_mineru_cache_hit_skips_download(
             assert counters["calls"] == 1
 
             # Second call: should hit cache.
-            await rag.parse_mineru(
+            await _parse_via_registry(
+                rag,
+                "mineru",
                 doc_id=doc_id,
                 file_path="demo.pdf",
                 content_data={},
@@ -374,7 +390,9 @@ def test_parse_mineru_cache_hit_skips_download(
 
             # Third call with force-reparse: cache invalidated.
             monkeypatch.setenv("LIGHTRAG_FORCE_REPARSE_MINERU", "true")
-            await rag.parse_mineru(
+            await _parse_via_registry(
+                rag,
+                "mineru",
                 doc_id=doc_id,
                 file_path="demo.pdf",
                 content_data={},
@@ -430,7 +448,9 @@ def test_parse_mineru_upload_name_strips_parser_hint(
                 lambda _p: str(src),
             )
 
-            parsed = await rag.parse_mineru(
+            parsed = await _parse_via_registry(
+                rag,
+                "mineru",
                 doc_id=doc_id,
                 file_path=src.name,
                 content_data={},
@@ -506,7 +526,9 @@ def test_parse_mineru_cache_invalidates_on_source_change(
                 lambda _p: str(src),
             )
 
-            await rag.parse_mineru(
+            await _parse_via_registry(
+                rag,
+                "mineru",
                 doc_id=doc_id,
                 file_path="demo.pdf",
                 content_data={},
@@ -517,7 +539,9 @@ def test_parse_mineru_cache_invalidates_on_source_change(
             data = src.read_bytes()
             src.write_bytes(b"\x00" + data[1:])
 
-            await rag.parse_mineru(
+            await _parse_via_registry(
+                rag,
+                "mineru",
                 doc_id=doc_id,
                 file_path="demo.pdf",
                 content_data={},

--- a/tests/parser/test_legacy_parser.py
+++ b/tests/parser/test_legacy_parser.py
@@ -1,0 +1,121 @@
+"""Unit tests for the legacy engine adapter (lightrag.parser.legacy.parser).
+
+Covers the worker-stage extraction contract directly: success path
+(persist + archive + RAW ParseResult), the unsupported-suffix gate, the
+whitespace-only extraction guard (scanned-PDF case) and the
+``PDF_DECRYPT_PASSWORD`` plumbing.
+"""
+
+import pytest
+
+import lightrag.pipeline as _pipeline
+from lightrag.constants import FULL_DOCS_FORMAT_RAW
+from lightrag.parser.base import ParseContext
+from lightrag.parser.legacy.extractors import LegacyExtractionError
+from lightrag.parser.legacy.parser import LegacyParser
+
+pytestmark = pytest.mark.offline
+
+
+class _FakeRag:
+    def __init__(self):
+        self.persisted = []
+
+    async def _persist_parsed_full_docs(self, doc_id, payload):
+        self.persisted.append((doc_id, payload))
+
+    def _resolve_source_file_for_parser(
+        self, file_path, *, source_file=None, parser_engine=None
+    ):
+        return file_path
+
+
+@pytest.fixture
+def archived(monkeypatch):
+    """Record archive calls instead of moving files into __parsed__."""
+    calls = []
+
+    async def _record(source_path):
+        calls.append(source_path)
+        return source_path
+
+    monkeypatch.setattr(_pipeline, "archive_docx_source_after_full_docs_sync", _record)
+    return calls
+
+
+def _ctx(rag, source_path):
+    return ParseContext(rag, "doc-legacy", str(source_path), {})
+
+
+async def test_legacy_parse_txt_persists_and_archives(tmp_path, archived):
+    source = tmp_path / "notes.txt"
+    source.write_text("plain text body", encoding="utf-8")
+    rag = _FakeRag()
+
+    result = await LegacyParser().parse(_ctx(rag, source))
+
+    assert result.parse_format == FULL_DOCS_FORMAT_RAW
+    assert result.content == "plain text body"
+    assert result.parse_engine == "legacy"
+    assert result.blocks_path == ""
+    doc_id, payload = rag.persisted[0]
+    assert doc_id == "doc-legacy"
+    assert payload["content"] == "plain text body"
+    assert payload["parse_format"] == FULL_DOCS_FORMAT_RAW
+    assert archived == [str(source)]
+    # to_dict stays byte-compatible: no spurious skip/warning keys.
+    assert "parse_stage_skipped" not in result.to_dict()
+
+
+async def test_legacy_parse_unsupported_suffix_raises(tmp_path, archived):
+    source = tmp_path / "image.xyz"
+    source.write_bytes(b"not parseable")
+    rag = _FakeRag()
+
+    with pytest.raises(ValueError, match=r"does not support \.xyz"):
+        await LegacyParser().parse(_ctx(rag, source))
+
+    assert rag.persisted == []
+    assert archived == []
+
+
+async def test_legacy_parse_whitespace_only_extraction_raises(
+    tmp_path, archived, monkeypatch
+):
+    # A scanned PDF (no text layer) extracts to pure whitespace; the parser
+    # must fail the doc instead of persisting an empty document.
+    monkeypatch.setattr(
+        "lightrag.parser.legacy.extractors.extract_text",
+        lambda file_bytes, suffix, *, pdf_password=None: "\n \n\t\n",
+    )
+    source = tmp_path / "scanned.pdf"
+    source.write_bytes(b"%PDF-fake")
+    rag = _FakeRag()
+
+    with pytest.raises(LegacyExtractionError, match="no usable text"):
+        await LegacyParser().parse(_ctx(rag, source))
+
+    assert rag.persisted == []
+    assert archived == []
+
+
+async def test_legacy_parse_passes_pdf_password_from_env(
+    tmp_path, archived, monkeypatch
+):
+    seen = {}
+
+    def _capture(file_bytes, suffix, *, pdf_password=None):
+        seen["suffix"] = suffix
+        seen["pdf_password"] = pdf_password
+        return "decrypted text"
+
+    monkeypatch.setattr("lightrag.parser.legacy.extractors.extract_text", _capture)
+    monkeypatch.setenv("PDF_DECRYPT_PASSWORD", "s3cret")
+    source = tmp_path / "locked.pdf"
+    source.write_bytes(b"%PDF-fake")
+    rag = _FakeRag()
+
+    result = await LegacyParser().parse(_ctx(rag, source))
+
+    assert seen == {"suffix": "pdf", "pdf_password": "s3cret"}
+    assert result.content == "decrypted text"

--- a/tests/parser/test_parse_native_lightrag_e2e.py
+++ b/tests/parser/test_parse_native_lightrag_e2e.py
@@ -23,7 +23,17 @@ from lightrag.constants import (
     FULL_DOCS_FORMAT_PENDING_PARSE,
     PARSED_DIR_NAME,
 )
+from lightrag.parser.base import ParseContext
+from lightrag.parser.registry import get_parser
 from lightrag.utils import Tokenizer, TokenizerInterface, compute_args_hash
+
+
+async def _parse_via_registry(rag, engine, doc_id, file_path, content_data):
+    """Drive a parser the way the pipeline worker does (registry dispatch)."""
+    result = await get_parser(engine).parse(
+        ParseContext(rag, doc_id, file_path, content_data)
+    )
+    return result.to_dict()
 
 
 def _block(content, *, heading="", level=0, parent=None, uuid="p1"):
@@ -122,8 +132,9 @@ def test_native_lightrag_path_produces_stable_merged_text(tmp_path, monkeypatch)
         # ---- First parse ----
         # parse_native archives the source after writing, so re-create it
         # before the second parse for a fair comparison.
-        result1 = await LightRAG.parse_native(
+        result1 = await _parse_via_registry(
             rag,
+            "native",
             "doc-stable",
             str(source_path),
             {"parse_format": FULL_DOCS_FORMAT_PENDING_PARSE, "content": ""},
@@ -143,8 +154,9 @@ def test_native_lightrag_path_produces_stable_merged_text(tmp_path, monkeypatch)
 
             shutil.rmtree(parsed_artifact_dir)
 
-        result2 = await LightRAG.parse_native(
+        result2 = await _parse_via_registry(
             rag,
+            "native",
             "doc-stable",
             str(source_path),
             {"parse_format": FULL_DOCS_FORMAT_PENDING_PARSE, "content": ""},
@@ -198,8 +210,9 @@ def test_native_lightrag_path_writes_blocks_jsonl_and_skips_meta_on_load(
         )
 
         rag = _MiniRag(tmp_path / "work")
-        result = await LightRAG.parse_native(
+        result = await _parse_via_registry(
             rag,
+            "native",
             "doc-skip",
             str(source_path),
             {"parse_format": FULL_DOCS_FORMAT_PENDING_PARSE, "content": ""},
@@ -239,8 +252,9 @@ def test_native_lightrag_path_leaves_unknown_table_caption_empty(tmp_path, monke
         )
 
         rag = _MiniRag(tmp_path / "work")
-        result = await LightRAG.parse_native(
+        result = await _parse_via_registry(
             rag,
+            "native",
             "doc-table",
             str(source_path),
             {"parse_format": FULL_DOCS_FORMAT_PENDING_PARSE, "content": ""},
@@ -311,8 +325,9 @@ def test_analyze_entrypoint_backfills_surrounding_for_all_sidecars(
         )
 
         rag = _MiniRag(tmp_path / "work")
-        result = await LightRAG.parse_native(
+        result = await _parse_via_registry(
             rag,
+            "native",
             "doc-mm",
             str(source_path),
             {"parse_format": FULL_DOCS_FORMAT_PENDING_PARSE, "content": ""},
@@ -390,8 +405,9 @@ def test_native_lightrag_path_writes_image_assets_to_blocks_assets_dir(
         )
 
         rag = _MiniRag(tmp_path / "work")
-        result = await LightRAG.parse_native(
+        result = await _parse_via_registry(
             rag,
+            "native",
             "doc-pic",
             str(source_path),
             {"parse_format": FULL_DOCS_FORMAT_PENDING_PARSE, "content": ""},

--- a/tests/parser/test_parser_cli.py
+++ b/tests/parser/test_parser_cli.py
@@ -217,6 +217,23 @@ def test_cli_rejects_suffix_engine_mismatch(
     assert "docx" in err  # supported suffix list mentions docx
 
 
+def test_cli_legacy_engine_prints_raw_summary(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # legacy is registry-selectable and emits plain content with no sidecar
+    # (blocks_path=""). The CLI must summarize the content instead of trying
+    # to open a non-existent blocks file.
+    source = tmp_path / "notes.txt"
+    source.write_text("hello world\nsecond line\n", encoding="utf-8")
+
+    rc = main([str(source), "--engine", "legacy"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "engine     : legacy" in out
+    assert "format     : raw" in out
+    assert "hello world" in out
+
+
 def test_cli_direct_script_native_does_not_shadow_python_docx(
     tmp_path: Path,
 ) -> None:

--- a/tests/parser/test_plugins.py
+++ b/tests/parser/test_plugins.py
@@ -1,0 +1,132 @@
+"""Unit tests for third-party parser discovery (lightrag.parser.plugins)."""
+
+import pytest
+
+from lightrag.parser import plugins, registry
+
+
+class _FakeEntryPoint:
+    """Stand-in for importlib.metadata.EntryPoint (name/value/load)."""
+
+    def __init__(self, name, value, fn):
+        self.name = name
+        self.value = value
+        self._fn = fn
+
+    def load(self):
+        if isinstance(self._fn, Exception):
+            raise self._fn
+        return self._fn
+
+
+@pytest.fixture(autouse=True)
+def _reset_loaded_flag(monkeypatch):
+    """Each test starts from the not-yet-loaded state."""
+    monkeypatch.setattr(plugins, "_loaded", False)
+
+
+@pytest.fixture
+def third_party_cleanup():
+    """Remove engines a test registered so the module-level registry stays
+    clean for other tests."""
+    names = []
+    yield names
+    for name in names:
+        registry._REGISTRY.pop(name, None)
+
+
+def _install_eps(monkeypatch, eps):
+    def _fake_entry_points(*, group):
+        assert group == plugins.ENTRY_POINT_GROUP
+        return list(eps)
+
+    monkeypatch.setattr(plugins, "entry_points", _fake_entry_points)
+
+
+def test_load_discovers_and_registers(monkeypatch, third_party_cleanup):
+    def _register():
+        registry.register_parser(
+            registry.ParserSpec(
+                engine_name="plug-engine",
+                impl="x:Y",
+                suffixes=frozenset({"foo"}),
+                queue_group="plug-engine",
+                concurrency=1,
+            )
+        )
+
+    _install_eps(monkeypatch, [_FakeEntryPoint("plug", "pkg.mod:register", _register)])
+    third_party_cleanup.append("plug-engine")
+
+    assert plugins.load_third_party_parsers() == ["plug"]
+    assert "plug-engine" in registry.supported_parser_engines()
+
+
+def test_load_is_idempotent_per_process(monkeypatch):
+    calls = {"n": 0}
+
+    def _register():
+        calls["n"] += 1
+
+    _install_eps(monkeypatch, [_FakeEntryPoint("plug", "pkg.mod:register", _register)])
+
+    assert plugins.load_third_party_parsers() == ["plug"]
+    # Second call is a no-op (server lifespan + CLI may both call it).
+    assert plugins.load_third_party_parsers() == []
+    assert calls["n"] == 1
+    # force=True re-runs (test escape hatch).
+    assert plugins.load_third_party_parsers(force=True) == ["plug"]
+    assert calls["n"] == 2
+
+
+def test_broken_plugin_is_skipped_not_fatal(monkeypatch, third_party_cleanup):
+    def _good_register():
+        registry.register_parser(
+            registry.ParserSpec(
+                engine_name="good-engine",
+                impl="x:Y",
+                suffixes=frozenset({"bar"}),
+                queue_group="good-engine",
+                concurrency=1,
+            )
+        )
+
+    _install_eps(
+        monkeypatch,
+        [
+            _FakeEntryPoint("broken", "bad.mod:register", ImportError("boom")),
+            _FakeEntryPoint("good", "ok.mod:register", _good_register),
+        ],
+    )
+    third_party_cleanup.append("good-engine")
+
+    # The broken plugin is logged + skipped; the good one still loads.
+    assert plugins.load_third_party_parsers() == ["good"]
+    assert "good-engine" in registry.supported_parser_engines()
+
+
+def test_cli_sees_entry_point_engine(monkeypatch, third_party_cleanup):
+    """End-to-end: a plugin-registered engine becomes a valid --engine choice
+    in the debug CLI (which calls load_third_party_parsers in main)."""
+    from lightrag.parser import cli
+
+    def _register():
+        registry.register_parser(
+            registry.ParserSpec(
+                engine_name="cli-plug-engine",
+                impl="x:Y",
+                suffixes=frozenset({"baz"}),
+                queue_group="cli-plug-engine",
+                concurrency=1,
+            )
+        )
+
+    _install_eps(
+        monkeypatch, [_FakeEntryPoint("cliplug", "pkg.mod:register", _register)]
+    )
+    third_party_cleanup.append("cli-plug-engine")
+
+    # Missing input file -> exit 1 AFTER argparse accepted the engine choice
+    # (an unknown engine would exit 2 from argparse instead).
+    rc = cli.main(["/nonexistent/x.baz", "--engine", "cli-plug-engine"])
+    assert rc == 1

--- a/tests/parser/test_registry.py
+++ b/tests/parser/test_registry.py
@@ -3,7 +3,6 @@
 import subprocess
 import sys
 
-import pytest
 
 from lightrag.parser import registry
 
@@ -32,15 +31,24 @@ def test_get_parser_instances_are_cached():
     assert a is b and a is not None
 
 
-def test_register_parser_requires_default_concurrency_with_env():
-    bad = registry.ParserSpec(
-        engine_name="bad-engine",
+def test_register_parser_roundtrips_concurrency():
+    # The registrant bakes any env override into a concrete ``concurrency``
+    # value at registration; the spec carries it verbatim.
+    spec = registry.ParserSpec(
+        engine_name="third-party-engine",
         impl="x:Y",
-        suffixes=frozenset(),
-        concurrency_env="MAX_PARALLEL_PARSE_BAD",
+        suffixes=frozenset({"foo"}),
+        queue_group="third-party-engine",
+        concurrency=7,
     )
-    with pytest.raises(ValueError):
-        registry.register_parser(bad)
+    try:
+        registry.register_parser(spec)
+        snapshot = registry.parser_specs_snapshot()
+        assert snapshot["third-party-engine"].concurrency == 7
+        assert snapshot["third-party-engine"].queue_group == "third-party-engine"
+    finally:
+        # Keep the module-level registry clean for other tests.
+        registry._REGISTRY.pop("third-party-engine", None)
 
 
 def test_mineru_endpoint_requirement_tracks_api_mode(monkeypatch):

--- a/tests/parser/test_registry.py
+++ b/tests/parser/test_registry.py
@@ -1,0 +1,67 @@
+"""Unit tests for the parser registry (lightrag.parser.registry)."""
+
+import subprocess
+import sys
+
+import pytest
+
+from lightrag.parser import registry
+
+
+def test_supported_engines_are_user_selectable_only():
+    engines = registry.supported_parser_engines()
+    assert engines == frozenset({"native", "legacy", "mineru", "docling"})
+    # Internal format handlers are registered but not user-selectable.
+    assert "reuse" not in engines
+    assert "passthrough" not in engines
+
+
+def test_suffix_capabilities_lookup():
+    assert "pdf" in registry.suffix_capabilities("mineru")
+    assert registry.suffix_capabilities("native") == frozenset({"docx"})
+    assert registry.suffix_capabilities("unknown-engine") == frozenset()
+
+
+def test_get_parser_unknown_returns_none():
+    assert registry.get_parser("does-not-exist") is None
+
+
+def test_get_parser_instances_are_cached():
+    a = registry.get_parser("native")
+    b = registry.get_parser("native")
+    assert a is b and a is not None
+
+
+def test_register_parser_requires_default_concurrency_with_env():
+    bad = registry.ParserSpec(
+        engine_name="bad-engine",
+        impl="x:Y",
+        suffixes=frozenset(),
+        concurrency_env="MAX_PARALLEL_PARSE_BAD",
+    )
+    with pytest.raises(ValueError):
+        registry.register_parser(bad)
+
+
+def test_mineru_endpoint_requirement_tracks_api_mode(monkeypatch):
+    monkeypatch.setenv("MINERU_API_MODE", "official")
+    assert registry.engine_endpoint_requirement("mineru") == "MINERU_API_TOKEN"
+    monkeypatch.setenv("MINERU_API_MODE", "local")
+    assert registry.engine_endpoint_requirement("mineru") == "MINERU_LOCAL_ENDPOINT"
+
+
+def test_capability_queries_do_not_import_parser_impls():
+    """Importing the registry + querying capabilities must not pull a parser
+    implementation (and therefore httpx). Run in a clean subprocess so other
+    tests' imports don't pollute sys.modules."""
+    code = (
+        "import sys; import lightrag.parser.registry as r; "
+        "r.supported_parser_engines(); r.suffix_capabilities('mineru'); "
+        "r.engine_endpoint_configured('docling'); "
+        "assert 'httpx' not in sys.modules, 'httpx leaked'; "
+        "assert 'lightrag.parser.external.mineru.parser' not in sys.modules; "
+        "print('clean')"
+    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    assert "clean" in proc.stdout

--- a/tests/pipeline/test_pipeline_analyze_multimodal.py
+++ b/tests/pipeline/test_pipeline_analyze_multimodal.py
@@ -618,6 +618,7 @@ async def test_analyze_worker_marks_doc_failed_on_multimodal_error(tmp_path):
     from dataclasses import asdict
     from lightrag.base import DocProcessingStatus, DocStatus
     from lightrag.pipeline import _BatchRunContext
+    from lightrag.parser.registry import parser_specs_snapshot
 
     async def vlm_func(prompt, **kwargs):
         return ""
@@ -656,9 +657,12 @@ async def test_analyze_worker_marks_doc_failed_on_multimodal_error(tmp_path):
             pipeline_status_lock=asyncio.Lock(),
             semaphore=asyncio.Semaphore(1),
             total_files=1,
-            q_native=asyncio.Queue(),
-            q_mineru=asyncio.Queue(),
-            q_docling=asyncio.Queue(),
+            parse_queues={
+                "native": asyncio.Queue(),
+                "mineru": asyncio.Queue(),
+                "docling": asyncio.Queue(),
+            },
+            parser_specs=parser_specs_snapshot(),
             q_analyze=asyncio.Queue(),
             q_process=asyncio.Queue(),
         )

--- a/tests/pipeline/test_pipeline_cancellation.py
+++ b/tests/pipeline/test_pipeline_cancellation.py
@@ -36,6 +36,7 @@ from lightrag.base import DocProcessingStatus, DocStatus
 from lightrag.exceptions import MultimodalAnalysisError, PipelineCancelledException
 from lightrag.kg.shared_storage import get_namespace_data, get_namespace_lock
 from lightrag.pipeline import _BatchRunContext
+from lightrag.parser.registry import parser_specs_snapshot
 from lightrag.utils import EmbeddingFunc, Tokenizer
 
 
@@ -128,9 +129,12 @@ async def _make_ctx(rag: LightRAG) -> tuple[_BatchRunContext, dict, Any]:
         pipeline_status_lock=pipeline_status_lock,
         semaphore=asyncio.Semaphore(2),
         total_files=0,
-        q_native=asyncio.Queue(),
-        q_mineru=asyncio.Queue(),
-        q_docling=asyncio.Queue(),
+        parse_queues={
+            "native": asyncio.Queue(),
+            "mineru": asyncio.Queue(),
+            "docling": asyncio.Queue(),
+        },
+        parser_specs=parser_specs_snapshot(),
         q_analyze=asyncio.Queue(),
         q_process=asyncio.Queue(),
     )
@@ -199,14 +203,14 @@ async def test_parse_worker_drains_queue_when_cancelled_before_start(tmp_path):
                     }
                 }
             )
-            await ctx.q_native.put((doc_id, _make_status_doc(doc_id)))
+            await ctx.parse_queues["native"].put((doc_id, _make_status_doc(doc_id)))
 
         pipeline_status["cancellation_requested"] = True
 
         start = time.monotonic()
         await _run_worker_until_drained(
-            lambda: rag._parse_worker("native", ctx.q_native, ctx),
-            ctx.q_native,
+            lambda: rag._parse_worker("native", ctx.parse_queues["native"], ctx),
+            ctx.parse_queues["native"],
         )
         elapsed = time.monotonic() - start
 

--- a/tests/pipeline/test_pipeline_cancellation.py
+++ b/tests/pipeline/test_pipeline_cancellation.py
@@ -26,7 +26,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import numpy as np
 import pytest
@@ -172,7 +172,9 @@ async def _run_worker_until_drained(
 
 
 @pytest.mark.asyncio
-async def test_parse_worker_drains_queue_when_cancelled_before_start(tmp_path):
+async def test_parse_worker_drains_queue_when_cancelled_before_start(
+    tmp_path, monkeypatch
+):
     """Cancellation set BEFORE the worker pulls any item: parser must not
     run, every queued doc is FAILED with a friendly message, q.join()
     returns quickly."""
@@ -181,9 +183,10 @@ async def test_parse_worker_drains_queue_when_cancelled_before_start(tmp_path):
     try:
         ctx, pipeline_status, _ = await _make_ctx(rag)
 
-        rag.parse_native = AsyncMock(
-            side_effect=AssertionError("parse_native must not be called")
-        )
+        # The worker resolves its parser via the registry; if the boundary
+        # cancellation check works, get_parser is never reached.
+        get_parser_spy = Mock(side_effect=AssertionError("parser must not be resolved"))
+        monkeypatch.setattr("lightrag.pipeline.get_parser", get_parser_spy)
 
         for i in range(3):
             doc_id = f"doc-{i}"
@@ -215,7 +218,7 @@ async def test_parse_worker_drains_queue_when_cancelled_before_start(tmp_path):
         elapsed = time.monotonic() - start
 
         assert elapsed < 1.0, f"queue drain should be fast, took {elapsed:.2f}s"
-        assert rag.parse_native.await_count == 0
+        assert get_parser_spy.call_count == 0
 
         cancel_messages = [
             m

--- a/tests/pipeline/test_pipeline_content_reread.py
+++ b/tests/pipeline/test_pipeline_content_reread.py
@@ -34,6 +34,7 @@ from lightrag.constants import (
 )
 from lightrag.kg.shared_storage import get_namespace_data, get_namespace_lock
 from lightrag.pipeline import _BatchRunContext
+from lightrag.parser.registry import parser_specs_snapshot
 from lightrag.utils import EmbeddingFunc, Tokenizer, get_content_summary
 from lightrag.utils_pipeline import make_lightrag_doc_content
 
@@ -94,9 +95,12 @@ async def _make_ctx(rag: LightRAG) -> _BatchRunContext:
         pipeline_status_lock=pipeline_status_lock,
         semaphore=asyncio.Semaphore(2),
         total_files=1,
-        q_native=asyncio.Queue(),
-        q_mineru=asyncio.Queue(),
-        q_docling=asyncio.Queue(),
+        parse_queues={
+            "native": asyncio.Queue(),
+            "mineru": asyncio.Queue(),
+            "docling": asyncio.Queue(),
+        },
+        parser_specs=parser_specs_snapshot(),
         q_analyze=asyncio.Queue(),
         q_process=asyncio.Queue(),
     )
@@ -158,13 +162,13 @@ async def test_parse_worker_drops_body_and_sets_summary_length(tmp_path):
             }
         )
         await _seed_doc_status(rag, doc_id)
-        await ctx.q_native.put(
+        await ctx.parse_queues["native"].put(
             (doc_id, _make_status_doc(doc_id, content_hash="hash-raw"))
         )
 
-        worker = asyncio.create_task(rag._parse_worker("native", ctx.q_native, ctx))
+        worker = asyncio.create_task(rag._parse_worker("native", ctx.parse_queues["native"], ctx))
         try:
-            await asyncio.wait_for(ctx.q_native.join(), timeout=2.0)
+            await asyncio.wait_for(ctx.parse_queues["native"].join(), timeout=2.0)
         finally:
             worker.cancel()
             await asyncio.gather(worker, return_exceptions=True)

--- a/tests/pipeline/test_pipeline_content_reread.py
+++ b/tests/pipeline/test_pipeline_content_reread.py
@@ -166,7 +166,9 @@ async def test_parse_worker_drops_body_and_sets_summary_length(tmp_path):
             (doc_id, _make_status_doc(doc_id, content_hash="hash-raw"))
         )
 
-        worker = asyncio.create_task(rag._parse_worker("native", ctx.parse_queues["native"], ctx))
+        worker = asyncio.create_task(
+            rag._parse_worker("native", ctx.parse_queues["native"], ctx)
+        )
         try:
             await asyncio.wait_for(ctx.parse_queues["native"].join(), timeout=2.0)
         finally:

--- a/tests/pipeline/test_pipeline_internal_abort.py
+++ b/tests/pipeline/test_pipeline_internal_abort.py
@@ -37,6 +37,7 @@ from lightrag.base import DocProcessingStatus, DocStatus
 from lightrag.exceptions import PipelineCancelledException
 from lightrag.kg.shared_storage import get_namespace_data, get_namespace_lock
 from lightrag.pipeline import _BatchRunContext
+from lightrag.parser.registry import parser_specs_snapshot
 from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
 
 pytestmark = pytest.mark.offline
@@ -353,9 +354,12 @@ async def _make_ctx(rag: LightRAG) -> tuple[_BatchRunContext, dict, Any]:
         pipeline_status_lock=pipeline_status_lock,
         semaphore=asyncio.Semaphore(2),
         total_files=1,
-        q_native=asyncio.Queue(),
-        q_mineru=asyncio.Queue(),
-        q_docling=asyncio.Queue(),
+        parse_queues={
+            "native": asyncio.Queue(),
+            "mineru": asyncio.Queue(),
+            "docling": asyncio.Queue(),
+        },
+        parser_specs=parser_specs_snapshot(),
         q_analyze=asyncio.Queue(),
         q_process=asyncio.Queue(),
     )

--- a/tests/pipeline/test_pipeline_release_closure.py
+++ b/tests/pipeline/test_pipeline_release_closure.py
@@ -98,9 +98,11 @@ def test_parse_engine_routing_by_filename_and_env(monkeypatch):
     monkeypatch.setenv("MINERU_LOCAL_ENDPOINT", "http://fake-mineru")
     monkeypatch.setenv("LIGHTRAG_PARSER", "pdf:mineru-iet,*:native")
     assert resolve_stored_document_parser_engine("paper.pdf", {}) == "mineru"
+    # A row that is not pending_parse is already-extracted content -> the
+    # passthrough handler (legacy now means worker-stage extraction).
     assert (
         resolve_stored_document_parser_engine("paper.pdf", {"parse_engine": "native"})
-        == "legacy"
+        == "passthrough"
     )
 
 

--- a/tests/pipeline/test_pipeline_release_closure.py
+++ b/tests/pipeline/test_pipeline_release_closure.py
@@ -25,12 +25,22 @@ from lightrag.parser.routing import (
     resolve_stored_document_parser_engine,
     validate_parser_routing_config,
 )
+from lightrag.parser.base import ParseContext
+from lightrag.parser.registry import get_parser
 from lightrag.utils import (
     EmbeddingFunc,
     Tokenizer,
     compute_mdhash_id,
     safe_vdb_operation_with_exception,
 )
+
+
+async def _parse_via_registry(rag, engine, doc_id, file_path, content_data):
+    """Drive a parser the way the pipeline worker does (registry dispatch)."""
+    result = await get_parser(engine).parse(
+        ParseContext(rag, doc_id, file_path, content_data)
+    )
+    return result.to_dict()
 
 
 class _SimpleTokenizerImpl:
@@ -2268,22 +2278,15 @@ def test_three_phase_status_flow(tmp_path, monkeypatch):
         async def _fake_merge(*args, **kwargs):
             return None
 
-        async def _fake_parse_native(doc_id, file_path, content_data):
-            return {
-                "doc_id": doc_id,
-                "file_path": file_path,
-                "parse_format": "raw",
-                "content": "hello world",
-                "blocks_path": "",
-            }
-
         async def _fake_analyze(doc_id, file_path, parsed_data, **kwargs):
             parsed_data["multimodal_processed"] = True
             return parsed_data
 
         monkeypatch.setattr(rag, "_process_extract_entities", _fake_extract)
         monkeypatch.setattr("lightrag.pipeline.merge_nodes_and_edges", _fake_merge)
-        monkeypatch.setattr(rag, "parse_native", _fake_parse_native)
+        # "sample text" enqueues as RAW; the worker dispatches it to the
+        # PassthroughParser (no parse_* wrapper involved), so no parse stub is
+        # needed — the status-flow assertions below exercise the real path.
         monkeypatch.setattr(rag, "analyze_multimodal", _fake_analyze)
 
         status_seq: list[str] = []
@@ -2943,7 +2946,9 @@ def test_parse_mineru_to_lightrag_document(tmp_path, monkeypatch):
         monkeypatch.setattr(MinerURawClient, "download_into", _fake_download)
         monkeypatch.setenv("MINERU_LOCAL_ENDPOINT", "http://fake-mineru")
 
-        parsed = await rag.parse_mineru(
+        parsed = await _parse_via_registry(
+            rag,
+            "mineru",
             doc_id="doc-1",
             file_path=str(src_file),
             content_data={"content": ""},
@@ -3061,7 +3066,9 @@ def test_parse_mineru_uses_hint_source_and_canonical_upload_name(tmp_path, monke
         assert content_data is not None
         content_data["source_file"] = status["metadata"]["source_file"]
 
-        parsed = await rag.parse_mineru(
+        parsed = await _parse_via_registry(
+            rag,
+            "mineru",
             doc_id=doc_id,
             file_path=status["file_path"],
             content_data=content_data,
@@ -3357,7 +3364,9 @@ def test_parse_mineru_empty_service_result_raises_without_fallback(
         monkeypatch.setenv("MINERU_LOCAL_ENDPOINT", "http://fake")
 
         with pytest.raises(FileNotFoundError, match="content_list.json"):
-            await rag.parse_mineru(
+            await _parse_via_registry(
+                rag,
+                "mineru",
                 doc_id="doc-local-1",
                 file_path=str(src_file),
                 content_data={"content": "native fallback content"},


### PR DESCRIPTION
## Description

Introduces a unified `BaseParser` contract and a central engine registry so every parser engine (native docx, mineru, docling, legacy) is dispatched the same way, replacing the two `if engine == …` chains and the per-engine special cases. Reshapes/supersedes the `BaseExternalParser` sketch from #3207 — its three-method contract becomes an *internal* template of the External family, while the top-level contract is a single `parse(ctx)` that also fits Native.

Capability metadata (suffixes, queue group, endpoint requirements) lives in one lightweight `ParserSpec` table in `lightrag/parser/registry.py` (mirroring the `lightrag/kg` storage-registry convention) — the single source of truth. Capability queries never import a parser implementation, so they don't pull `httpx`; the impl class is imported lazily only when a document is actually parsed.

Third-party engines are first-class: a pip-installed package declaring a `lightrag.parsers` entry point is auto-discovered by both the API server and the debug CLI — no LightRAG code changes needed. See `docs/ThirdPartyParser-zh.md` for the authoring guide.

## Related Issues

RFC #3197. Supersedes #3207.

## Changes Made

- **Contract + registry**: `parser/base.py` (`BaseParser` / `ParseContext` / `ParseResult.to_dict` omits unset fields for byte-equivalent dicts) and `parser/registry.py` (`ParserSpec` table, `get_parser(specs=)` with impl-aware caching, `parser_specs_snapshot`, `supported_parser_engines` / `suffix_capabilities` / `engine_endpoint_*`). Each spec carries a concrete `concurrency` value; the registrant bakes in any env override at registration time (`concurrency=int(os.getenv("MAX_PARALLEL_PARSE_X", "3"))`), mirroring how the built-in `max_parallel_parse_*` LightRAG fields read their env — so the registered value is authoritative and env is just its default source.
- **Third-party plugin discovery**: `parser/plugins.py` — `load_third_party_parsers()` runs every `lightrag.parsers` entry point (a zero-arg callable that calls `register_parser`). Idempotent per process; a broken plugin is logged + skipped, never fatal. Invoked by the server (`create_app`, *before* routing-rule validation so `LIGHTRAG_PARSER` may reference third-party engine names) and by the debug CLI (`main`, before `--engine` choices are built).
- **External**: `parser/external/_base.py` template (fixes the #3207 gaps — runs `clear_dir_contents` on cache miss; normalises the per-engine upload-name divergence to one `upload_name` hook) + MinerU/Docling hook adapters.
- **Native**: `parser/native_base.py` template + `parser/docx/parser.py` (`NativeDocxParser`).
- **Legacy**: extractors moved from the API layer to `parser/legacy/extractors.py`; `LegacyParser` extracts at the worker stage (RAW output, archives on success, env-driven PDF password), and is the dispatch fallback engine (unknown/unsupported → raise; empty *or whitespace-only* extraction — e.g. a scanned PDF with no text layer — raises instead of persisting an empty document).
- **No-op handlers**: `ReuseParser` (lightrag resume) / `PassthroughParser` (raw direct-insert).
- **Pipeline**: registry-driven dispatch at both sites; `_BatchRunContext` carries `parse_queues: dict` (one queue per `ParserSpec.queue_group`, worker counts resolved before any worker is spawned so a queue-group misconfig can't orphan workers) + a per-batch registry snapshot threaded through routing/workers; per-doc parser re-resolution with warn+fallback-to-legacy. The legacy `parse_native`/`parse_mineru`/`parse_docling` LightRAG methods are **removed** — both the pipeline worker and the debug CLI dispatch through `get_parser(engine).parse(ParseContext(...))`, so a third-party engine registered via `register_parser` is driven with no special-casing.
- **Debug CLI**: `--engine` choices come from `supported_parser_engines()` (plugins loaded first) and dispatch goes through the registry, so any registered engine (including third-party) is selectable. Raw-bundle handling derives from the resolved parser (`isinstance(ExternalParserBase)` / `raw_dir_suffix` / instance-level `is_bundle_valid`), and engines without a sidecar (legacy / non-sidecar third-party) get a plain-content summary instead of a blocks-file summary.
- **enqueue unification**: `pipeline_enqueue_file` defers every engine uniformly (save file + enqueue `PENDING_PARSE`); legacy no longer extracts eagerly at enqueue.
- **Metadata consolidation**: delete `SUPPORTED_PARSER_ENGINES` / `PARSER_ENGINE_SUFFIX_CAPABILITIES` from `constants.py`; routing/cli consume the registry; endpoint checks delegate to the registry closures.
- **Deprecation**: warn on the `docs_format="lightrag"` / `lightrag_document_paths` enqueue entrypoint (no production caller).
- **Docs**: new `docs/ThirdPartyParser-zh.md` (contract, the three base-class paths, `ParserSpec` fields + concurrency model, entry-point registration, routing, CLI debugging, testing notes); `ParserDebugCLI` zh/en refreshed for registry dispatch (4 built-ins + third-party, no-sidecar output, `ExternalParserBase`-scoped `--force-reparse`).

## Behavior changes (intentional)

- **Legacy deferral**: legacy files now extract at the worker (`LegacyParser`) instead of eagerly at API enqueue; extraction errors surface as a parse-stage `doc_status` FAILED instead of an enqueue-time error document, and the source is archived after a successful `full_docs` sync (failure leaves it in place for retry).
- An unhinted file's default engine is `legacy` (unchanged from production enqueue defaults); an unhinted `.docx` therefore routes to legacy, not native, unless `[native]`/`LIGHTRAG_PARSER`/`parse_engine` selects it.

## Checklist

- [x] Changes tested locally — full suite **2261 passed, 34 skipped, 0 failed**
- [x] Code reviewed
- [x] Documentation updated — new `docs/ThirdPartyParser-zh.md`; `docs/ParserDebugCLI-zh.md` / `docs/ParserDebugCLI.md` refreshed
- [x] Unit tests added — registry tests (capability queries don't import impls/httpx, get_parser/None, `ParserSpec` concurrency roundtrip, mineru endpoint mode) + plugin-discovery tests (entry-point loading, per-process idempotence, broken-plugin isolation, CLI sees a plugin engine) + directional upload-allowlist ⊆ registry-suffixes test + direct `LegacyParser` tests (success / unsupported-suffix / whitespace-only / PDF-password) + a legacy debug-CLI test; existing parser/pipeline/api/chunker tests updated for the new registry dispatch + deferral

## Additional Notes

Follow-ups (not in this PR): remove the deprecated `docs_format="lightrag"` entrypoint next release; optional mapping of legacy parse-failure fields (`content_summary`/`error_type`) for UI parity; English translation of `ThirdPartyParser-zh.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
