### PR TITLE
fix(multimodal): strip XML-illegal control chars before they reach the graph

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -18,6 +18,7 @@ from lightrag.utils import (
     Tokenizer,
     is_float_regex,
     sanitize_and_normalize_extracted_text,
+    sanitize_text_for_encoding,
     pack_user_ass_to_openai_messages,
     split_string_by_multi_markers,
     truncate_list_by_token_size,
@@ -291,8 +292,11 @@ async def _handle_entity_relation_summary(
         return "", False
 
     # If only one description, return it directly (no need for LLM call)
+    # Still sanitize: descriptions read back from existing graph nodes (or
+    # injected by non-extraction producers) may carry XML-illegal control
+    # characters that would crash the GraphML flush downstream.
     if len(description_list) == 1:
-        return description_list[0], False
+        return sanitize_text_for_encoding(description_list[0]), False
 
     # Get configuration
     tokenizer: Tokenizer = global_config["tokenizer"]
@@ -319,7 +323,12 @@ async def _handle_entity_relation_summary(
                 and total_tokens < summary_max_tokens
             ):
                 # no LLM needed, just join the descriptions
-                final_description = separator.join(current_list)
+                # Sanitize for the same reason as the single-description
+                # early return above: inputs merged from pre-existing graph
+                # data are not guaranteed XML-safe.
+                final_description = sanitize_text_for_encoding(
+                    separator.join(current_list)
+                )
                 return final_description if final_description else "", llm_was_used
             else:
                 if total_tokens > summary_context_size and len(current_list) <= 2:
@@ -466,6 +475,12 @@ async def _summarize_descriptions(
         cache_type="summary",
         llm_cache_identity=get_llm_cache_identity(global_config, "extract"),
     )
+
+    # The LLM response is the only description path that bypasses
+    # extraction-time sanitization; control chars / surrogates left here
+    # would later break GraphML (XML) serialization on write. Strip them
+    # at the source, symmetric with how extracted descriptions are cleaned.
+    summary = sanitize_text_for_encoding(summary)
 
     # Check summary token length against embedding limit
     embedding_token_limit = global_config.get("embedding_token_limit")

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -4648,26 +4648,30 @@ class _PipelineMixin:
             if v is None:
                 return []
             if isinstance(v, list):
-                return [str(x).strip() for x in v if str(x).strip()]
-            s = str(v).strip()
+                cleaned = (sanitize_text_for_encoding(str(x)) for x in v)
+                return [s for s in cleaned if s]
+            s = sanitize_text_for_encoding(str(v))
             return [s] if s else []
 
         def _norm_parent_headings(value: Any) -> list[str]:
             if not isinstance(value, list):
                 return []
-            return [str(p).strip() for p in value if str(p or "").strip()]
+            cleaned = (sanitize_text_for_encoding(str(p or "")) for p in value)
+            return [p for p in cleaned if p]
 
         def _build_heading_dict(item: dict[str, Any]) -> dict[str, Any] | None:
             heading_raw = item.get("heading")
             if isinstance(heading_raw, dict):
-                heading_text = str(heading_raw.get("heading") or "").strip()
+                heading_text = sanitize_text_for_encoding(
+                    str(heading_raw.get("heading") or "")
+                )
                 parents = _norm_parent_headings(heading_raw.get("parent_headings"))
                 try:
                     level = int(heading_raw.get("level") or 0)
                 except (TypeError, ValueError):
                     level = 0
             else:
-                heading_text = str(heading_raw or "").strip()
+                heading_text = sanitize_text_for_encoding(str(heading_raw or ""))
                 parents = _norm_parent_headings(item.get("parent_headings"))
                 try:
                     level = int(item.get("level") or 0)
@@ -4745,10 +4749,21 @@ class _PipelineMixin:
                     # Treat unknown / legacy status as missing — no chunk.
                     continue
 
-                name = str(analysis.get("name") or "").strip()
-                description = str(analysis.get("description") or "").strip()
-                equation_body = str(analysis.get("equation") or "").strip()
-                image_type = str(analysis.get("type") or "").strip()
+                # Sanitize every VLM-produced field: analysis results are
+                # parsed from LLM JSON where unescaped LaTeX (e.g. "\frac")
+                # decodes into control characters ("\f" -> \x0c). These
+                # strings feed text_chunks, vector stores and — via the
+                # multimodal entity injection in operate.extract_entities —
+                # graph node/edge attributes, where XML-illegal characters
+                # crash the GraphML flush.
+                name = sanitize_text_for_encoding(str(analysis.get("name") or ""))
+                description = sanitize_text_for_encoding(
+                    str(analysis.get("description") or "")
+                )
+                equation_body = sanitize_text_for_encoding(
+                    str(analysis.get("equation") or "")
+                )
+                image_type = sanitize_text_for_encoding(str(analysis.get("type") or ""))
                 if not name:
                     raise MultimodalAnalysisError(
                         f"{root_key}/{item_id}: success result missing 'name'"

--- a/tests/extraction/test_summary_sanitization.py
+++ b/tests/extraction/test_summary_sanitization.py
@@ -1,0 +1,160 @@
+"""Regression tests: every merge-stage description outcome must be
+sanitized before it lands on graph nodes/edges.
+
+Extraction-time descriptions are cleaned by
+``sanitize_and_normalize_extracted_text``, but merge-stage descriptions
+can bypass that: LLM re-summaries, descriptions read back from existing
+graph nodes, and multimodal entity descriptions injected straight from
+chunk content. Any of them carrying control characters / surrogates
+(e.g. ``\\frac`` decoded as ``\\x0c`` + ``rac`` from unescaped LaTeX in
+VLM JSON) would break GraphML (XML) serialization on the next NetworkX
+flush with::
+
+    ValueError: All strings must be XML compatible: Unicode or ASCII,
+    no NULL bytes or control characters
+
+``_handle_entity_relation_summary`` (single / join outcomes) and
+``_summarize_descriptions`` (LLM outcome) now sanitize at every exit.
+"""
+
+from unittest.mock import AsyncMock
+
+import networkx as nx
+import pytest
+
+from lightrag.utils import Tokenizer, TokenizerInterface
+
+
+class DummyTokenizer(TokenizerInterface):
+    """Simple 1:1 character-to-token mapping for testing."""
+
+    def encode(self, content: str):
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens):
+        return "".join(chr(token) for token in tokens)
+
+
+def _make_global_config(summary_return: str) -> dict:
+    """Minimal global_config for ``_summarize_descriptions`` whose ``extract``
+    role LLM returns ``summary_return`` verbatim."""
+    tokenizer = Tokenizer("dummy", DummyTokenizer())
+    extract_func = AsyncMock(return_value=summary_return)
+    return {
+        "role_llm_funcs": {"extract": extract_func},
+        "addon_params": {},
+        "_resolved_summary_language": "English",
+        "summary_length_recommended": 100,
+        "summary_context_size": 10_000,
+        "tokenizer": tokenizer,
+    }
+
+
+# A description that the LLM "echoed" from a dirty source: NULL byte, bell,
+# unit-separator and DEL are all illegal in XML 1.0; \t and \n are legal and
+# must be preserved.
+_DIRTY_SUMMARY = "Clean text\x00with\x07control\x1fchars\x7f\tand\nnewlines"
+_EXPECTED_CLEAN = "Clean textwithcontrolchars\tand\nnewlines"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_summarize_descriptions_strips_control_chars():
+    """The LLM summary path must remove XML-incompatible control characters
+    while preserving legal whitespace."""
+    from lightrag.operate import _summarize_descriptions
+
+    global_config = _make_global_config(_DIRTY_SUMMARY)
+
+    summary = await _summarize_descriptions(
+        "Entity",
+        "TEST_ENTITY",
+        ["first description", "second description"],
+        global_config,
+        llm_response_cache=None,
+    )
+
+    assert summary == _EXPECTED_CLEAN
+    assert "\x00" not in summary
+    assert "\x07" not in summary
+    assert "\x1f" not in summary
+    assert "\x7f" not in summary
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_single_description_early_return_is_sanitized():
+    """The ``len(description_list) == 1`` early return skips the LLM
+    entirely — this is exactly the path a dirty multimodal entity
+    description (chunk content reused verbatim) takes on first insert."""
+    from lightrag.operate import _handle_entity_relation_summary
+
+    description, llm_was_used = await _handle_entity_relation_summary(
+        "Entity",
+        "TEST_ENTITY",
+        [_DIRTY_SUMMARY],
+        "<SEP>",
+        # Early return happens before any config key is read.
+        global_config={},
+        llm_response_cache=None,
+    )
+
+    assert llm_was_used is False
+    assert description == _EXPECTED_CLEAN
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_join_without_llm_is_sanitized():
+    """The no-LLM join outcome must also sanitize: descriptions read back
+    from pre-existing (dirty) graph nodes re-enter the merge here."""
+    from lightrag.operate import _handle_entity_relation_summary
+
+    tokenizer = Tokenizer("dummy", DummyTokenizer())
+    global_config = {
+        "tokenizer": tokenizer,
+        "summary_context_size": 100_000,
+        "summary_max_tokens": 100_000,
+        "force_llm_summary_on_merge": 10,
+    }
+
+    description, llm_was_used = await _handle_entity_relation_summary(
+        "Entity",
+        "TEST_ENTITY",
+        [_DIRTY_SUMMARY, "clean second description"],
+        "<SEP>",
+        global_config,
+        llm_response_cache=None,
+    )
+
+    assert llm_was_used is False
+    assert description == f"{_EXPECTED_CLEAN}<SEP>clean second description"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_summarized_description_is_graphml_writable(tmp_path):
+    """End-to-end guard: a node whose description came from the summary path
+    must serialize to GraphML without the original ValueError."""
+    from lightrag.operate import _summarize_descriptions
+
+    global_config = _make_global_config(_DIRTY_SUMMARY)
+
+    description = await _summarize_descriptions(
+        "Entity",
+        "TEST_ENTITY",
+        ["first description", "second description"],
+        global_config,
+        llm_response_cache=None,
+    )
+
+    graph = nx.Graph()
+    graph.add_node("TEST_ENTITY", description=description)
+
+    # Pre-fix, write_graphml raised:
+    # "All strings must be XML compatible: ... no NULL bytes or control characters"
+    out = tmp_path / "graph.graphml"
+    nx.write_graphml(graph, out)
+
+    reloaded = nx.read_graphml(out)
+    assert reloaded.nodes["TEST_ENTITY"]["description"] == _EXPECTED_CLEAN

--- a/tests/pipeline/test_pipeline_release_closure.py
+++ b/tests/pipeline/test_pipeline_release_closure.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import re
 from pathlib import Path
 
 import numpy as np
@@ -3182,6 +3183,82 @@ def test_mm_chunks_and_modality_relations_from_sidecars(tmp_path):
         # covers chunk assembly. The companion regression below
         # (test_parse_mm_display_name_matches_chunk_format) pins the
         # builder/consumer format contract.
+
+        await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_mm_chunks_sanitize_vlm_control_characters(tmp_path):
+    """Regression: VLM analysis fields parsed from LLM JSON can carry
+    control characters (unescaped LaTeX ``\\frac`` decodes as ``\\x0c`` +
+    ``rac``). The builder must strip them — they propagate into chunk
+    content, vector stores and graph node attributes, where XML-illegal
+    characters crash the GraphML flush with "All strings must be XML
+    compatible".
+    """
+
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+
+        blocks = tmp_path / "demo.blocks.jsonl"
+        blocks.write_text(
+            json.dumps(
+                {
+                    "type": "meta",
+                    "format": "lightrag",
+                    "version": "1.0",
+                    "doc_id": "doc-1",
+                },
+                ensure_ascii=False,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        tables = tmp_path / "demo.tables.json"
+        tables.write_text(
+            json.dumps(
+                {
+                    "version": "1.0",
+                    "tables": {
+                        "t1": {
+                            "id": "t1",
+                            "heading": "章节\x0bB",
+                            "footnotes": ["脚注\x00一"],
+                            "llm_analyze_result": {
+                                "name": "成本对比表\x00",
+                                "description": "GraphRAG消耗$\x0crac{610}{C}$次调用",
+                                "analyze_time": 1700000000,
+                                "status": "success",
+                                "message": "",
+                            },
+                        }
+                    },
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+
+        mm_chunks = rag._build_mm_chunks_from_sidecars(
+            doc_id="doc-1",
+            file_path="demo.pdf",
+            blocks_path=str(blocks),
+            base_order_index=0,
+        )
+        assert len(mm_chunks) == 1
+        chunk = mm_chunks[0]
+
+        illegal = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]")
+        assert not illegal.search(chunk["content"])
+        assert not illegal.search(chunk["heading"]["heading"])
+        # Control chars are removed, surrounding text retained.
+        assert "[Table Name]成本对比表" in chunk["content"]
+        assert "$rac{610}{C}$" in chunk["content"]
+        assert "[Table Footnotes]脚注一" in chunk["content"]
+        assert chunk["heading"]["heading"] == "章节B"
 
         await rag.finalize_storages()
 


### PR DESCRIPTION
## Description

Processing a PDF whose multimodal (table/equation/image) VLM analysis contains LaTeX crashes the entire pipeline batch at the NetworkX GraphML flush:

```
ERROR: NetworkXStorage[chunk_entity_relation] index flush failed:
All strings must be XML compatible: Unicode or ASCII, no NULL bytes or control characters
```

Root cause: VLM analysis results are parsed from LLM JSON where unescaped LaTeX decodes into control characters — `"$\frac{...}$"` becomes `$\x0crac{...}$` because JSON treats `\f` as a form-feed escape. These strings flowed **unsanitized** from sidecar files into multimodal chunk content, and then verbatim into graph node descriptions via the mm-entity injection in `extract_entities` (which reuses chunk content as the entity description). lxml rejects `\x0c` in XML 1.0, so the GraphML write raised and aborted the batch.

The main-text chunk path already sanitizes document content with `sanitize_text_for_encoding`; the multimodal path skipped it entirely. Single-description merges also skipped sanitization because the `len == 1` early return in `_handle_entity_relation_summary` never reaches the LLM summary path.

## Related Issues

N/A (found while ingesting "LightRAG - Simple and Fast RAG.pdf" with table analysis enabled)

## Changes Made

- **Source fix** — `_build_mm_chunks_from_sidecars` (pipeline.py): sanitize every VLM-produced field read from sidecars (`name`, `description`, `equation`, `type`, footnotes, heading text / parent headings) with `sanitize_text_for_encoding`, aligning the multimodal path with the main-text path. Clean LaTeX (backslash + letters) is byte-for-byte preserved; only XML-illegal control characters / surrogates are removed.
- **Defense in depth** — `_handle_entity_relation_summary` (operate.py): sanitize all three description outcomes:
  - single-description early return (the exact path a dirty mm-entity description takes on first insert),
  - no-LLM join (descriptions read back from pre-existing dirty graph nodes self-heal on the next merge instead of re-crashing the flush),
  - LLM summary output via `_summarize_descriptions` (LLM responses bypassed extraction-time sanitization entirely; cleaning happens after the cache layer so both cache hits and misses are covered).
- **Regression tests**:
  - `tests/extraction/test_summary_sanitization.py` (new): one test per outlet, plus an end-to-end guard asserting the summarized description survives `nx.write_graphml` (reproduces the original `ValueError` when the fix is reverted).
  - `tests/pipeline/test_pipeline_release_closure.py`: builder test pinning that sidecars carrying `\x00`/`\x0b`/`\x0c` (including the real-world `$\x0crac{...}$` shape) produce clean chunk content and headings.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

- All new tests were verified to **fail** with the fix reverted and pass with it applied; `tests/extraction/ + tests/pipeline/ + tests/sidecar/` (229 tests) pass.
- Sanitization removes the already-corrupted control character but cannot restore the lost LaTeX (`$\x0crac` → `$rac` — the backslash+`f` were destroyed at JSON parse time, before sanitization). Restoring formula fidelity requires escape-repair at the VLM JSON parsing layer (`analyze_multimodal` side); that is a separate follow-up.
- Dirty data already persisted by a failed run needs no manual cleanup: sidecar fields are sanitized on read, and re-processing the document overwrites the affected chunks/entities under the same IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
