### PR TITLE
fix: repair LaTeX escape damage in LLM JSON responses (multimodal analysis & entity extraction)

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -19,6 +19,7 @@ from lightrag.utils import (
     is_float_regex,
     sanitize_and_normalize_extracted_text,
     sanitize_text_for_encoding,
+    repair_vlm_json_escape_damage_nested,
     pack_user_ass_to_openai_messages,
     split_string_by_multi_markers,
     truncate_list_by_token_size,
@@ -745,6 +746,13 @@ async def _process_json_extraction_result(
             f"{chunk_key}: JSON extraction result is not a dict, got {type(parsed).__name__}"
         )
         return dict(maybe_nodes), dict(maybe_edges)
+
+    # Models quoting LaTeX in descriptions routinely under-escape backslashes
+    # ("\frac" is valid JSON meaning form feed + "rac"); restore the zero-risk
+    # cases before sanitization would otherwise delete the control characters
+    # and leave a maimed formula. Covers initial extraction, gleaning, and
+    # cache-rebuild — all three flow through this parser.
+    parsed = repair_vlm_json_escape_damage_nested(parsed, context=chunk_key)
 
     # Process entities
     entities_list = parsed.get("entities", [])

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -68,7 +68,7 @@ from lightrag.utils import (
     get_llm_cache_identity,
     handle_cache,
     logger,
-    repair_vlm_json_escape_damage,
+    repair_vlm_json_escape_damage_nested,
     sanitize_text_for_encoding,
     save_to_cache,
     serialize_llm_cache_identity,
@@ -3899,7 +3899,7 @@ class _PipelineMixin:
                 try:
                     obj = json_repair.loads(candidate)
                     if isinstance(obj, dict):
-                        return _repair_parsed_values(obj)
+                        return repair_vlm_json_escape_damage_nested(obj)
                 except Exception:
                     pass
                 m = re.search(r"\{[\s\S]*\}", candidate)
@@ -3907,30 +3907,10 @@ class _PipelineMixin:
                     try:
                         obj = json_repair.loads(m.group(0))
                         if isinstance(obj, dict):
-                            return _repair_parsed_values(obj)
+                            return repair_vlm_json_escape_damage_nested(obj)
                     except Exception:
                         pass
                 return {}
-
-            def _repair_parsed_values(obj: dict[str, Any]) -> dict[str, Any]:
-                """Repair LaTeX escape damage in every string the analysis
-                consumes (top-level strings and strings inside lists)."""
-                repaired: dict[str, Any] = {}
-                for key, value in obj.items():
-                    if isinstance(value, str):
-                        repaired[key] = repair_vlm_json_escape_damage(
-                            value, context=key
-                        )
-                    elif isinstance(value, list):
-                        repaired[key] = [
-                            repair_vlm_json_escape_damage(v, context=key)
-                            if isinstance(v, str)
-                            else v
-                            for v in value
-                        ]
-                    else:
-                        repaired[key] = value
-                return repaired
 
             def _normalize_text(value: Any) -> str:
                 if value is None:

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -68,6 +68,7 @@ from lightrag.utils import (
     get_llm_cache_identity,
     handle_cache,
     logger,
+    repair_vlm_json_escape_damage,
     sanitize_text_for_encoding,
     save_to_cache,
     serialize_llm_cache_identity,
@@ -3877,6 +3878,13 @@ class _PipelineMixin:
                 3. Fall back to a greedy ``{...}`` regex slice for outputs
                    that wrap the JSON object in prose, then re-run
                    ``json_repair.loads`` on the slice.
+
+                String values in the recovered object are passed through
+                ``repair_vlm_json_escape_damage``: models writing LaTeX
+                inside JSON strings routinely under-escape backslashes
+                (``"\\frac"`` is valid JSON meaning form feed + ``rac``),
+                and this is the single choke point both fresh responses
+                and cache hits flow through.
                 """
                 if not text:
                     return {}
@@ -3891,7 +3899,7 @@ class _PipelineMixin:
                 try:
                     obj = json_repair.loads(candidate)
                     if isinstance(obj, dict):
-                        return obj
+                        return _repair_parsed_values(obj)
                 except Exception:
                     pass
                 m = re.search(r"\{[\s\S]*\}", candidate)
@@ -3899,10 +3907,30 @@ class _PipelineMixin:
                     try:
                         obj = json_repair.loads(m.group(0))
                         if isinstance(obj, dict):
-                            return obj
+                            return _repair_parsed_values(obj)
                     except Exception:
                         pass
                 return {}
+
+            def _repair_parsed_values(obj: dict[str, Any]) -> dict[str, Any]:
+                """Repair LaTeX escape damage in every string the analysis
+                consumes (top-level strings and strings inside lists)."""
+                repaired: dict[str, Any] = {}
+                for key, value in obj.items():
+                    if isinstance(value, str):
+                        repaired[key] = repair_vlm_json_escape_damage(
+                            value, context=key
+                        )
+                    elif isinstance(value, list):
+                        repaired[key] = [
+                            repair_vlm_json_escape_damage(v, context=key)
+                            if isinstance(v, str)
+                            else v
+                            for v in value
+                        ]
+                    else:
+                        repaired[key] = value
+                return repaired
 
             def _normalize_text(value: Any) -> str:
                 if value is None:

--- a/lightrag/prompt.py
+++ b/lightrag/prompt.py
@@ -213,6 +213,8 @@ You are a Knowledge Graph Specialist responsible for extracting entities and rel
 
 7. **JSON Contract:**
   - Return one valid JSON object with `entities` and `relationships` arrays only.
+  - All string values must be properly escaped JSON strings (escape `"` as `\\"`, escape backslashes as `\\\\`, newlines as `\\n`).
+  - Any LaTeX quoted inside a string value must use double-escaped backslashes (e.g. `\\frac` is written as `"\\\\frac"` in the JSON).
   - If the record limit is reached, stop adding new objects immediately and return the JSON object with the allowed items only.
 
 8. **Output Format Template Safety:**

--- a/lightrag/prompt_multimodal.py
+++ b/lightrag/prompt_multimodal.py
@@ -133,7 +133,8 @@ MULTIMODAL_PROMPTS[
 6. OUTPUT RULES
    - Return ONE valid JSON object only.
    - No surrounding markdown, no code fences, no preamble, no explanation.
-   - All string values must be properly escaped JSON strings (escape `"` as `\\"`, newlines as `\\n`).
+   - All string values must be properly escaped JSON strings (escape `"` as `\\"`, escape backslashes as `\\\\`, newlines as `\\n`).
+   - Any LaTeX inside a string value must use double-escaped backslashes (e.g. `\\frac{{a}}{{b}}` is written as `"\\\\frac{{a}}{{b}}"` in the JSON).
    - The output values for the JSON fields `name` and `description` must be written in `{language}`.
 
 ================ ADDITIONAL CONTEXT ================
@@ -212,7 +213,8 @@ MULTIMODAL_PROMPTS[
 5. OUTPUT RULES
    - Return ONE valid JSON object only.
    - No surrounding markdown, no code fences, no preamble, no explanation.
-   - All string values must be properly escaped JSON strings (escape `"` as `\\"`, newlines as `\\n`).
+   - All string values must be properly escaped JSON strings (escape `"` as `\\"`, escape backslashes as `\\\\`, newlines as `\\n`).
+   - Any LaTeX inside a string value (e.g. formulas quoted from table cells) must use double-escaped backslashes (e.g. `\\frac{{a}}{{b}}` is written as `"\\\\frac{{a}}{{b}}"` in the JSON).
    - The output values for the JSON fields `name` and `description` must be written in `{language}`.
 
 ================ TABLE CONTENT ================

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -2994,6 +2994,71 @@ def sanitize_text_for_encoding(text: str, replacement_char: str = "") -> str:
     return text.strip()
 
 
+# LLMs emitting LaTeX inside JSON strings routinely under-escape backslashes:
+# "\frac" is *valid* JSON meaning form feed + "rac", so JSON parsers
+# (including json_repair) silently decode it and the LaTeX command is
+# destroyed. Form feed (\x0c) and backspace (\x08) followed by a letter have
+# no legitimate use in LLM-generated prose, so restoring the backslash is
+# unconditionally safe. The other three decodable escapes (\t, \n, \r) map to
+# legitimate whitespace and cannot be restored without guessing; they are only
+# *detected* (see _WS_LATEX_SUSPECT_PATTERN) so real-world frequency can be
+# observed before deciding on heuristic restoration.
+_FORMFEED_LATEX_PATTERN = re.compile(r"\x0c(?=[A-Za-z])")
+_BACKSPACE_LATEX_PATTERN = re.compile(r"\x08(?=[A-Za-z])")
+# Whitespace + residue spelling that completes a common LaTeX command whose
+# remainder collides with no English word ("eq"/"o"/"exists" are deliberately
+# absent: "eq." abbreviations, the word "o"/"exists" would false-positive).
+_WS_LATEX_SUSPECT_PATTERN = re.compile(
+    r"\t(?=(?:au|heta|imes|ext|ilde|herefore|riangle)\b)"
+    r"|\r(?=(?:ho|ight|angle|ceil)\b)"
+    r"|\n(?=(?:abla|otin)\b)"
+)
+
+
+def repair_vlm_json_escape_damage(text: str, *, context: str = "") -> str:
+    """Restore LaTeX backslashes destroyed by JSON escape decoding.
+
+    Applied to string values parsed out of VLM/LLM JSON responses, where an
+    un-doubled LaTeX command like ``"\\frac"`` arrives as ``\\x0c`` + ``rac``.
+    Only the two zero-risk cases are repaired:
+
+    - form feed + letter  -> ``\\f`` + letter (``\\frac``, ``\\forall``, ...)
+    - backspace + letter  -> ``\\b`` + letter (``\\beta``, ``\\bar``, ...)
+
+    Isolated control characters (not followed by a letter) are left alone for
+    downstream sanitization to drop. Whitespace-class damage (``\\tau`` ->
+    tab + ``au`` etc.) is ambiguous with legitimate whitespace and is only
+    logged at WARNING level, never rewritten.
+
+    Args:
+        text: Parsed string value to repair.
+        context: Optional label (e.g. ``"table/t1.description"``) included in
+            the detection log line.
+    """
+    if not text:
+        return text
+
+    repaired = _FORMFEED_LATEX_PATTERN.sub(r"\\f", text)
+    repaired = _BACKSPACE_LATEX_PATTERN.sub(r"\\b", repaired)
+    if repaired != text:
+        logger.warning(
+            "Repaired LaTeX escape damage (\\f/\\b decoded by JSON parser)%s",
+            f" in {context}" if context else "",
+        )
+
+    suspect = _WS_LATEX_SUSPECT_PATTERN.search(repaired)
+    if suspect:
+        snippet = repaired[max(0, suspect.start() - 30) : suspect.start() + 30]
+        logger.warning(
+            "Suspected whitespace-class LaTeX escape damage%s "
+            "(not auto-repaired): %r",
+            f" in {context}" if context else "",
+            snippet,
+        )
+
+    return repaired
+
+
 def check_storage_env_vars(storage_name: str) -> None:
     """Check if all required environment variables for storage implementation exist
 

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -3059,6 +3059,31 @@ def repair_vlm_json_escape_damage(text: str, *, context: str = "") -> str:
     return repaired
 
 
+def repair_vlm_json_escape_damage_nested(obj: Any, *, context: str = "") -> Any:
+    """Apply :func:`repair_vlm_json_escape_damage` to every string inside a
+    parsed JSON structure (dicts / lists nested arbitrarily).
+
+    Used on the output of ``json_repair.loads`` for LLM responses that may
+    quote LaTeX — multimodal analysis objects and entity-extraction results
+    (``{"entities": [{...}], "relationships": [{...}]}``). Non-string leaves
+    are returned untouched.
+    """
+    if isinstance(obj, str):
+        return repair_vlm_json_escape_damage(obj, context=context)
+    if isinstance(obj, dict):
+        return {
+            key: repair_vlm_json_escape_damage_nested(
+                value, context=f"{context}.{key}" if context else str(key)
+            )
+            for key, value in obj.items()
+        }
+    if isinstance(obj, list):
+        return [
+            repair_vlm_json_escape_damage_nested(item, context=context) for item in obj
+        ]
+    return obj
+
+
 def check_storage_env_vars(storage_name: str) -> None:
     """Check if all required environment variables for storage implementation exist
 

--- a/tests/llm/test_vlm_json_escape_repair.py
+++ b/tests/llm/test_vlm_json_escape_repair.py
@@ -121,3 +121,49 @@ def test_prompts_require_double_escaped_backslashes():
         assert (
             "escape backslashes" in template or "double-escaped" in template
         ), f"{key}: missing backslash escaping rule in OUTPUT RULES"
+
+
+@pytest.mark.offline
+def test_extraction_system_prompt_requires_double_escaped_backslashes():
+    """The JSON entity-extraction system prompt governs both the initial
+    round and the gleaning round (same system prompt is passed to the
+    gleaning call), so the escaping rule lives there — the user prompts
+    deliberately carry no copy."""
+    from lightrag.prompt import PROMPTS
+
+    template = PROMPTS["entity_extraction_json_system_prompt"]
+    assert "escape backslashes" in template and "double-escaped" in template, (
+        "entity_extraction_json_system_prompt: missing backslash escaping "
+        "rule in JSON Contract"
+    )
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_extraction_json_result_repairs_latex_escape_damage():
+    """Wiring regression for the extraction side: a raw LLM response with
+    single-escaped LaTeX must yield entity/relation descriptions carrying
+    the intact command — covers initial extraction, gleaning, and rebuild,
+    which all parse through _process_json_extraction_result."""
+    from lightrag.operate import _process_json_extraction_result
+
+    raw_response = (
+        '{"entities": [{"name": "LightRAG", "type": "Other", '
+        '"description": "成本为 $\\frac{610}{C}$ 次调用"}], '
+        '"relationships": [{"source": "LightRAG", "target": "GraphRAG", '
+        '"keywords": "cost", '
+        '"description": "比较 $\\frac{a}{b}$ 与 $\\\\times$ 系数"}]}'
+    )
+
+    nodes, edges = await _process_json_extraction_result(
+        raw_response, chunk_key="chunk-test", timestamp=0
+    )
+
+    (entity_list,) = [nodes[k] for k in nodes if k == "LightRAG"]
+    assert "\\frac{610}{C}" in entity_list[0]["description"]
+    assert "\x0c" not in entity_list[0]["description"]
+
+    (edge_list,) = list(edges.values())
+    assert "\\frac{a}{b}" in edge_list[0]["description"]
+    assert "\\times" in edge_list[0]["description"]
+    assert "\x0c" not in edge_list[0]["description"]

--- a/tests/llm/test_vlm_json_escape_repair.py
+++ b/tests/llm/test_vlm_json_escape_repair.py
@@ -1,0 +1,123 @@
+"""Regression tests: LaTeX escape damage repair for VLM JSON responses.
+
+Models writing LaTeX inside JSON strings routinely under-escape
+backslashes: ``"\\frac"`` is *valid* JSON meaning form feed + ``rac``, so
+``json_repair.loads`` silently decodes it and the LaTeX command is
+destroyed (``$\\frac{...}$`` -> ``$\\x0crac{...}$``). The damage surface
+is exactly the five decodable escape letters b/f/n/r/t — json_repair
+preserves invalid escapes like ``\\alpha`` verbatim.
+
+``repair_vlm_json_escape_damage`` restores the two zero-risk cases
+(form feed / backspace + letter: no legitimate use in LLM prose) and
+only *logs* the ambiguous whitespace-class cases (tab/CR/newline also
+appear as legitimate whitespace and cannot be restored without
+guessing).
+"""
+
+import json_repair
+import logging
+
+import pytest
+
+from lightrag.utils import repair_vlm_json_escape_damage
+
+
+@pytest.fixture
+def _propagate_lightrag_logger(monkeypatch):
+    """``lightrag.utils.logger`` sets ``propagate = False``; restore
+    propagation locally so ``caplog`` can capture WARNING records."""
+    monkeypatch.setattr(logging.getLogger("lightrag"), "propagate", True)
+
+
+@pytest.mark.offline
+def test_formfeed_followed_by_letter_restores_backslash_f():
+    assert repair_vlm_json_escape_damage("$\x0crac{610}{C}$") == r"$\frac{610}{C}$"
+
+
+@pytest.mark.offline
+def test_backspace_followed_by_letter_restores_backslash_b():
+    assert (
+        repair_vlm_json_escape_damage("$\x08eta + \x08ar{x}$") == r"$\beta + \bar{x}$"
+    )
+
+
+@pytest.mark.offline
+def test_isolated_control_chars_left_for_sanitization():
+    """Form feed / backspace NOT followed by a letter are junk, not LaTeX —
+    leave them untouched so downstream sanitization drops them."""
+    text = "before\x0c after\x08."
+    assert repair_vlm_json_escape_damage(text) == text
+
+
+@pytest.mark.offline
+def test_clean_text_is_unchanged_and_idempotent():
+    """Correctly double-escaped LaTeX decodes to real backslash sequences;
+    repair must not touch them, and repairing twice equals repairing once."""
+    clean = r"$\frac{a}{b}$ and \beta with plain text"
+    assert repair_vlm_json_escape_damage(clean) == clean
+    damaged = "$\x0crac{a}{b}$"
+    once = repair_vlm_json_escape_damage(damaged)
+    assert repair_vlm_json_escape_damage(once) == once
+
+
+@pytest.mark.offline
+def test_whitespace_class_damage_is_logged_not_rewritten(
+    caplog, _propagate_lightrag_logger
+):
+    """Tab + "imes" (destroyed ``\\times``) is ambiguous with legitimate
+    whitespace: detection must warn but never modify the text."""
+    # NOTE: "\t" in this source literal IS a real tab — exactly what a
+    # destroyed "\times" looks like post-parse: tab + "imes" + boundary.
+    damaged = "area is $a \times b$"
+    with caplog.at_level(logging.WARNING, logger="lightrag"):
+        result = repair_vlm_json_escape_damage(damaged, context="table/t1")
+    assert result == damaged
+    assert any(
+        "whitespace-class LaTeX escape damage" in rec.message
+        and "table/t1" in rec.getMessage()
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.offline
+def test_legitimate_whitespace_is_not_flagged(caplog, _propagate_lightrag_logger):
+    """Whitespace followed by ordinary words (no whitelist residue with a
+    word boundary) must not trigger the detection warning."""
+    legit = "col1\tauthor list\nablation studies follow\nexists in the table"
+    with caplog.at_level(logging.WARNING, logger="lightrag"):
+        result = repair_vlm_json_escape_damage(legit)
+    assert result == legit
+    assert not caplog.records
+
+
+@pytest.mark.offline
+def test_mixed_escaping_real_world_response():
+    """Pin the real-world shape that crashed ingestion: within ONE response
+    the model double-escaped ``\\times``/``\\text`` but single-escaped
+    ``\\frac``. After json_repair + repair, the formula is whole again."""
+    raw_response = (
+        '{"name": "成本对比", '
+        '"description": "GraphRAG消耗$\\frac{610 \\\\times 1,000}{C_{\\\\text{max}}}$次调用"}'
+    )
+    parsed = json_repair.loads(raw_response)
+    assert isinstance(parsed, dict)
+    description = parsed["description"]
+    assert isinstance(description, str)
+    assert "\x0c" in description  # damage confirmed pre-repair
+
+    repaired = repair_vlm_json_escape_damage(description)
+    assert "$\\frac{610 \\times 1,000}{C_{\\text{max}}}$" in repaired
+    assert "\x0c" not in repaired
+
+
+@pytest.mark.offline
+def test_prompts_require_double_escaped_backslashes():
+    """All three modality prompts must instruct double-escaping; the
+    equation prompt had this rule first, image/table were aligned to it."""
+    from lightrag.prompt_multimodal import MULTIMODAL_PROMPTS
+
+    for key in ("image_analysis", "table_analysis", "equation_analysis"):
+        template = MULTIMODAL_PROMPTS[key]
+        assert (
+            "escape backslashes" in template or "double-escaped" in template
+        ), f"{key}: missing backslash escaping rule in OUTPUT RULES"

--- a/tests/pipeline/test_pipeline_analyze_multimodal.py
+++ b/tests/pipeline/test_pipeline_analyze_multimodal.py
@@ -521,6 +521,45 @@ async def test_invalid_vlm_response_hard_fails(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_latex_escape_damage_repaired_before_sidecar_write(tmp_path):
+    """Regression: a VLM that under-escapes LaTeX in its JSON response
+    (``"\\frac"`` — valid JSON meaning form feed + ``rac``) must not leave
+    control characters in the persisted ``llm_analyze_result``.
+    ``_json_extract`` repairs the parsed values via
+    ``repair_vlm_json_escape_damage`` so the sidecar carries the intact
+    ``\\frac`` command."""
+    call_log: list[dict] = []
+
+    async def vlm_func(prompt, **kwargs):
+        call_log.append({"prompt": prompt, "kwargs": dict(kwargs)})
+        # Raw response text exactly as a sloppy model emits it: \frac
+        # single-escaped (decodes to \x0c + "rac"), \times correctly
+        # double-escaped — mirrors the mixed escaping observed in the wild.
+        return (
+            '{"name": "cost-formula", "type": "Chart", '
+            '"description": "calls $\\frac{610 \\\\times 1000}{C}$ shown"}'
+        )
+
+    rag = _build_rag(tmp_path, vlm_process_enable=True, vlm_func=vlm_func)
+    await rag.initialize_storages()
+    try:
+        doc_id, parsed_data, sidecar_path = _write_sidecar_fixtures(tmp_path)
+        await rag.analyze_multimodal(
+            doc_id=doc_id,
+            file_path="fixture.pdf",
+            parsed_data=parsed_data,
+            process_options="i",
+        )
+        payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        result = payload["drawings"]["im-001"]["llm_analyze_result"]
+        assert result["status"] == "success"
+        assert result["description"] == "calls $\\frac{610 \\times 1000}{C}$ shown"
+        assert "\x0c" not in result["description"]
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
 async def test_table_routes_to_extract_role_not_vlm(tmp_path):
     """Per design §3.1 tables (and equations) must hit the EXTRACT role,
     not VLM. The mocks below assert exactly that."""


### PR DESCRIPTION
## Description

Companion to #3237. That PR stops the GraphML crash by *deleting* XML-illegal control characters; this PR restores the LaTeX those characters used to be, at the point where the damage happens.

**Root cause**: models writing LaTeX inside JSON strings routinely under-escape backslashes. `"\frac"` is *valid* JSON meaning form feed + `rac`, so `json_repair.loads` silently decodes it and the command is destroyed (`$\frac{...}$` → `$\x0crac{...}$` → after sanitization `$rac{...}$`). Empirical evidence from a real ingestion cache shows the escaping is inconsistent **within a single response** (`\frac` single-escaped right next to correctly double-escaped `\\times`), so prompt rules alone cannot prevent it.

The damage surface is precisely the five decodable JSON escape letters **b/f/n/r/t** — verified against json_repair 0.59.9, which preserves invalid escapes (`\alpha`, `\sum`) verbatim.

## Related Issues

Follow-up to #3237 (GraphML flush crash on control characters).

## Changes Made

- **`repair_vlm_json_escape_damage` (utils.py)** — restores the two zero-risk cases: form feed / backspace followed by a letter have no legitimate use in LLM prose, so `\x0c`+`rac` → `\frac` and `\x08`+`eta` → `\beta` unconditionally. Isolated control characters (no letter following) are left for downstream sanitization to drop.
- **Whitespace-class damage is detected, not rewritten** — `\tau`/`\rho`/`\nabla` decode to tab/CR/newline, which are ambiguous with legitimate whitespace. A curated residue whitelist (word-boundary guarded; collision-prone residues like `eq` ("eq." abbreviation), `o`, `exists` deliberately excluded) triggers a WARNING log only. This collects real-world frequency data before deciding whether heuristic restoration is worth its false-positive risk.
- **`_json_extract` (pipeline.py)** — parsed string values pass through the repair at this single choke point, covering all three modalities (drawing/table/equation), both call sites, and **cache hits** (the analysis cache stores raw response text and re-parses on retrieval). Existing analysis caches stay valid; previously damaged sidecars self-heal on the next analyze pass (`llm_analyze_result` is recomputed each run).
- **Prompts (prompt_multimodal.py)** — image/table analysis prompts gain the backslash double-escaping OUTPUT RULE the equation prompt already had. ⚠️ This changes the prompt hash, so existing analysis cache entries for those two modalities will miss once and re-analyze on the next reprocess.
- **Extraction side (second commit)** — the entity-extraction path has the identical damage surface: `_process_json_extraction_result` also parses with `json_repair`, and a model quoting a formula into a `description` suffers the same corruption. Parsed results now pass through `repair_vlm_json_escape_damage_nested` (recursive variant, also replacing the local helper in `_json_extract`) before field-level sanitization — one choke point covering initial extraction, gleaning, and cache-rebuild, with no cache invalidation. `entity_extraction_json_system_prompt` gains the double-escaping rule in its JSON Contract section (the same system prompt governs the gleaning round, so the user prompts deliberately carry no copy). ⚠️ The system prompt participates in extraction cache keys, so existing extraction cache entries miss once after this change.
- **Tests** — `tests/llm/test_vlm_json_escape_repair.py` (10 cases: restoration, isolation, idempotency, detection logging, false-positive guards, the real-world mixed-escaping sample, extraction-side wiring, and prompt contracts for all four prompts) plus an end-to-end wiring test in `tests/pipeline/test_pipeline_analyze_multimodal.py` asserting the persisted sidecar carries intact `\frac` and no control characters.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

- Ordering: repair runs in the analyze phase (before sidecar write), so the restored `\frac` is plain text by the time any sanitization layer (#3237) sees it — the two PRs compose without interaction.
- All new tests verified to fail with the repair reverted (including both wiring tests — multimodal and extraction); `tests/llm/ + tests/extraction/ + tests/pipeline/ + tests/sidecar/` — 571 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


