### PR TITLE
refactor(pipeline)!: remove the deprecated docs_format="lightrag" enqueue entrypoint

### DIFF
--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -129,6 +129,9 @@ DEFAULT_CHUNK_P_SIZE = 2000
 
 # LightRAG Document pipeline
 FULL_DOCS_FORMAT_RAW = "raw"  # content in full_docs["content"]
+# Post-parse persistence marker: full_docs rows written by the parsers carry
+# this parse_format; on resume/retry they route to ReuseParser. Not a valid
+# enqueue docs_format (the 'lightrag' ingestion entrypoint was removed).
 FULL_DOCS_FORMAT_LIGHTRAG = "lightrag"  # content in LightRAG Document files
 FULL_DOCS_FORMAT_PENDING_PARSE = (
     "pending_parse"  # file saved but not yet parsed; parse_native will read from disk

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -86,7 +86,6 @@ from lightrag.utils_pipeline import (
     get_existing_doc_by_file_basename,
     has_known_document_source,
     input_dir_path,
-    load_lightrag_document_content,
     make_lightrag_doc_content,
     normalize_document_file_path,
     doc_status_metadata_has_attempt_fields,
@@ -95,7 +94,6 @@ from lightrag.utils_pipeline import (
     read_source_file_basename,
     resolve_doc_file_path,
     resolve_doc_status_parse_engine,
-    sidecar_blocks_path,
     sidecar_uri_for,
     strip_lightrag_doc_prefix,
 )
@@ -236,7 +234,6 @@ class _PipelineMixin:
         file_paths: str | list[str] | None = None,
         track_id: str | None = None,
         docs_format: str = FULL_DOCS_FORMAT_RAW,
-        lightrag_document_paths: str | list[str] | None = None,
         parse_engine: str | list[str] | None = None,
         process_options: str | list[str] | None = None,
         chunk_options: dict | list[dict] | None = None,
@@ -245,18 +242,19 @@ class _PipelineMixin:
         """
         Pipeline for Processing Documents
 
-        1. Validate ids if provided or generate MD5 hash IDs and remove duplicate contents (skip content dedup when format is lightrag)
+        1. Validate ids if provided or generate MD5 hash IDs and remove duplicate contents
         2. Generate document initial status
         3. Filter out already processed documents
         4. Enqueue document in status
 
         Args:
-            input: Single document string or list of document strings (can be empty when docs_format is lightrag)
-            ids: list of unique document IDs, if not provided, MD5 hash IDs will be generated (from content or file_path when lightrag)
+            input: Single document string or list of document strings (can be empty when docs_format is pending_parse)
+            ids: list of unique document IDs, if not provided, MD5 hash IDs will be generated (from content or file_path)
             file_paths: list of file paths corresponding to each document, used for citation
             track_id: tracking ID for monitoring processing status
-            docs_format: "raw" (default) or "lightrag"; when "lightrag" content may be empty and content-dedup is skipped
-            lightrag_document_paths: paths to LightRAG Document (e.g. .blocks.jsonl dir or base path), when docs_format is lightrag
+            docs_format: "raw" (default) or "pending_parse"; "pending_parse" defers
+                extraction to the parse worker (content may be empty and
+                content-dedup happens after parsing)
             parse_engine: file extraction engine already used or target engine for pending_parse
             process_options: per-document processing options string (i/t/e/!/F/R/V/P);
                 accepted as a single string broadcast to every input or as a list
@@ -346,10 +344,6 @@ class _PipelineMixin:
             ids = [ids]
         if isinstance(file_paths, str):
             file_paths = [file_paths]
-        if isinstance(lightrag_document_paths, str):
-            lightrag_document_paths = (
-                [lightrag_document_paths] if lightrag_document_paths else None
-            )
         if isinstance(parse_engine, str):
             parse_engine = [parse_engine] * len(input)
         if isinstance(process_options, str):
@@ -372,23 +366,14 @@ class _PipelineMixin:
         else:
             file_paths = ["unknown_source"] * len(input)
 
-        is_lightrag_format = docs_format == FULL_DOCS_FORMAT_LIGHTRAG
-        if is_lightrag_format or lightrag_document_paths is not None:
-            # DEPRECATED ingestion entrypoint: no production caller enqueues a
-            # pre-existing sidecar this way (the upper layer doesn't know the
-            # backend sidecar layout). Scheduled for removal; the lightrag
-            # resume/reuse path (post-parse persist -> ReuseParser) is
-            # unaffected. See the unified-parser plan §11.
-            logger.warning(
-                "[apipeline_enqueue_documents] docs_format='lightrag' / "
-                "lightrag_document_paths is deprecated and will be removed in a "
-                "future release; it has no production caller."
+        if docs_format not in (FULL_DOCS_FORMAT_RAW, FULL_DOCS_FORMAT_PENDING_PARSE):
+            raise ValueError(
+                f"Unsupported docs_format {docs_format!r}; expected "
+                f"{FULL_DOCS_FORMAT_RAW!r} or {FULL_DOCS_FORMAT_PENDING_PARSE!r}. "
+                "The 'lightrag' enqueue format was removed; already-parsed "
+                "documents are resumed via the full_docs parse_format marker "
+                "and ReuseParser."
             )
-        if is_lightrag_format and lightrag_document_paths is not None:
-            if len(lightrag_document_paths) != len(input):
-                raise ValueError(
-                    "Number of lightrag_document_paths must match the number of documents"
-                )
         if parse_engine is not None and len(parse_engine) != len(input):
             raise ValueError(
                 "Number of parse engines must match the number of documents"
@@ -464,36 +449,20 @@ class _PipelineMixin:
         source_to_doc_id: dict[str, str] = {}
         content_hash_to_doc_id: dict[str, str] = {}
         duplicate_attempts: list[dict[str, Any]] = []
-        # Per-doc I/O failures from the lightrag-format branch.  Populated when
-        # ``load_lightrag_document_content`` cannot read the user-supplied
-        # blocks.jsonl; flushed as FAILED stubs via
-        # ``apipeline_enqueue_error_documents`` inside the critical section so
-        # the UI surfaces the root cause instead of a silent empty document.
-        lightrag_load_errors: list[dict[str, Any]] = []
 
         def _add_content(
             index: int,
             content: str,
             doc_format: str,
-            *,
-            sidecar_location: str | None = None,
         ) -> None:
             file_path_canonical = file_paths_canonical[index]
 
-            # Body length excludes the {{LRdoc}} marker so duplicate-attempt
-            # bookkeeping reports the same units as raw documents.
-            # strip_lightrag_doc_prefix is a no-op for non-lightrag formats.
-            body_length = len(strip_lightrag_doc_prefix(content, doc_format))
+            body_length = len(content)
 
             # Compute content hash: skip for pending_parse (content extracted later).
-            # RAW and LIGHTRAG both hash the bare merged text so the same body
-            # carried by different envelopes (raw text vs sidecar) dedupes
-            # against itself across formats.
             content_hash: str | None = None
-            if doc_format in (FULL_DOCS_FORMAT_RAW, FULL_DOCS_FORMAT_LIGHTRAG):
-                content_hash = compute_text_content_hash(
-                    strip_lightrag_doc_prefix(content or "", doc_format)
-                )
+            if doc_format == FULL_DOCS_FORMAT_RAW:
+                content_hash = compute_text_content_hash(content or "")
 
             known_source = has_known_document_source(file_path_canonical)
             if ids is not None:
@@ -502,8 +471,6 @@ class _PipelineMixin:
                 doc_id = compute_mdhash_id(file_path_canonical, prefix="doc-")
             elif doc_format == FULL_DOCS_FORMAT_RAW:
                 doc_id = compute_mdhash_id(content or "", prefix="doc-")
-            elif content_hash:
-                doc_id = compute_mdhash_id(content_hash, prefix="doc-")
             else:
                 doc_id = compute_mdhash_id(
                     f"{file_path_canonical}-{track_id}-{index}", prefix="doc-"
@@ -549,8 +516,6 @@ class _PipelineMixin:
             }
             if content_hash:
                 content_data["content_hash"] = content_hash
-            if sidecar_location:
-                content_data["sidecar_location"] = sidecar_location
             if engine := _parse_engine_at(index):
                 content_data["parse_engine"] = engine
             if doc_format == FULL_DOCS_FORMAT_PENDING_PARSE:
@@ -567,70 +532,7 @@ class _PipelineMixin:
             content_data["chunk_options"] = _chunk_options_at(index)
             contents[doc_id] = content_data
 
-        if is_lightrag_format:
-            # LightRAG Document: no content hash dedup; content may be empty
-            for i in range(len(file_paths)):
-                path = file_paths[i]
-                raw_path = (
-                    lightrag_document_paths[i] if lightrag_document_paths else ""
-                ) or path
-                # Resolve to an absolute path so the sidecar URI carries
-                # full location info; relative paths are interpreted under
-                # input_dir.
-                p = Path(raw_path)
-                if not p.is_absolute():
-                    p = input_dir_path() / p
-                # The user may point at the ``*.blocks.jsonl`` file itself
-                # or at its containing ``*.parsed/`` directory.  Sidecars
-                # are addressed by directory, so step up when given a file.
-                sidecar_dir = (
-                    p.parent
-                    if p.suffix == ".jsonl" and p.name.endswith(".blocks.jsonl")
-                    else p
-                )
-                sidecar_location = sidecar_uri_for(sidecar_dir)
-                # Per docs/FileProcessingConfiguration-zh.md, full_docs.content
-                # for format=lightrag must be "{{LRdoc}}" + the merged body.
-                # If the blocks file cannot be read (permission, truncation,
-                # invalid JSON line), recording an empty body would let an
-                # untrue "{{LRdoc}}" record land in full_docs and desync from
-                # the on-disk blocks.jsonl.  Instead, skip this doc and flush
-                # a FAILED stub via apipeline_enqueue_error_documents after
-                # the critical section so /documents surfaces the cause and
-                # /documents/scan retries cleanly once the file is fixed.
-                try:
-                    merged_text, _ = await load_lightrag_document_content(
-                        sidecar_location
-                    )
-                except Exception as exc:
-                    error_msg = f"load_lightrag_document_content failed: {exc}"
-                    logger.warning(f"[apipeline_enqueue] {error_msg} ({raw_path})")
-                    file_size = 0
-                    blocks_path_str = sidecar_blocks_path(sidecar_location)
-                    if blocks_path_str:
-                        try:
-                            file_size = Path(blocks_path_str).stat().st_size
-                        except OSError:
-                            file_size = 0
-                    lightrag_load_errors.append(
-                        {
-                            "file_path": path,
-                            "error_description": (
-                                "Failed to load LightRAG Document blocks"
-                            ),
-                            "original_error": error_msg,
-                            "file_size": file_size,
-                        }
-                    )
-                    continue
-                summary_content = make_lightrag_doc_content(merged_text)
-                _add_content(
-                    i,
-                    summary_content,
-                    FULL_DOCS_FORMAT_LIGHTRAG,
-                    sidecar_location=sidecar_location,
-                )
-        elif ids is not None:
+        if ids is not None:
             for i, doc in enumerate(input):
                 cleaned_content = sanitize_text_for_encoding(doc)
                 _add_content(
@@ -652,16 +554,7 @@ class _PipelineMixin:
 
         # 2. Generate document initial status (without content)
         def _initial_doc_status(content_data: dict[str, Any]) -> dict[str, Any]:
-            # For lightrag-format full_docs the persisted content carries the
-            # ``{{LRdoc}}`` marker; strip it so summary/length match raw
-            # semantics (the marker is full_docs internal bookkeeping and
-            # must not leak into doc_status).  strip_lightrag_doc_prefix
-            # internally checks parse_format, so non-lightrag formats pass
-            # through untouched.
-            body_text = strip_lightrag_doc_prefix(
-                content_data.get("content", ""),
-                content_data.get("parse_format"),
-            )
+            body_text = content_data.get("content", "")
             base: dict[str, Any] = {
                 "status": DocStatus.PENDING,
                 "content_summary": get_content_summary(body_text),
@@ -865,16 +758,6 @@ class _PipelineMixin:
                         f"Created {len(duplicate_docs)} duplicate document records with track_id: {track_id}"
                     )
 
-            # Flush lightrag-format I/O failures as FAILED stubs.  Done
-            # inside the critical section so concurrent enqueues either see
-            # the failure rows in full or not at all, and so a subsequent
-            # /documents/scan finds the stub-without-full_docs combination
-            # that document_routes treats as "delete and re-extract".
-            if lightrag_load_errors:
-                await self.apipeline_enqueue_error_documents(
-                    lightrag_load_errors, track_id=track_id
-                )
-
             # Filter new_docs to only include documents with unique IDs
             new_docs = {
                 doc_id: new_docs[doc_id]
@@ -884,13 +767,6 @@ class _PipelineMixin:
 
             if not new_docs:
                 logger.warning("No new unique documents were found.")
-                # If FAILED stubs were just flushed (lightrag-format I/O
-                # errors), the caller needs the track_id to query their
-                # status; a bare ``return None`` would also be interpreted
-                # by document_routes upload paths as "all duplicate —
-                # archive the source", silently hiding the failure.
-                if lightrag_load_errors:
-                    return track_id
                 return
 
             # 4. Store document content in full_docs and status in doc_status
@@ -908,10 +784,6 @@ class _PipelineMixin:
                 if contents[doc_id].get("content_hash"):
                     full_docs_data[doc_id]["content_hash"] = contents[doc_id][
                         "content_hash"
-                    ]
-                if contents[doc_id].get("sidecar_location"):
-                    full_docs_data[doc_id]["sidecar_location"] = contents[doc_id][
-                        "sidecar_location"
                     ]
                 if contents[doc_id].get("parse_engine"):
                     full_docs_data[doc_id]["parse_engine"] = contents[doc_id][

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -249,12 +249,19 @@ class _PipelineMixin:
 
         Args:
             input: Single document string or list of document strings (can be empty when docs_format is pending_parse)
-            ids: list of unique document IDs, if not provided, MD5 hash IDs will be generated (from content or file_path)
+            ids: list of unique document IDs, if not provided, MD5 hash IDs will be generated (from content or file_path).
+                **Providing ``ids`` marks the SDK raw direct-insert path**
+                (:meth:`LightRAG.ainsert`) and takes precedence over
+                ``docs_format``: the documents are always enqueued as RAW
+                — sanitized verbatim content, no parse-worker deferral —
+                by design, not as an oversight. ``pending_parse`` is the
+                server upload path, which never passes ``ids``.
             file_paths: list of file paths corresponding to each document, used for citation
             track_id: tracking ID for monitoring processing status
             docs_format: "raw" (default) or "pending_parse"; "pending_parse" defers
                 extraction to the parse worker (content may be empty and
-                content-dedup happens after parsing)
+                content-dedup happens after parsing). Ignored when ``ids``
+                is provided (see ``ids`` above).
             parse_engine: file extraction engine already used or target engine for pending_parse
             process_options: per-document processing options string (i/t/e/!/F/R/V/P);
                 accepted as a single string broadcast to every input or as a list
@@ -532,6 +539,10 @@ class _PipelineMixin:
             content_data["chunk_options"] = _chunk_options_at(index)
             contents[doc_id] = content_data
 
+        # ``ids`` outranks ``docs_format`` by design: explicit ids mark the
+        # SDK raw direct-insert path (ainsert), which always enqueues the
+        # sanitized body as RAW. pending_parse (server upload) never passes
+        # ids, so the two never legitimately combine.
         if ids is not None:
             for i, doc in enumerate(input):
                 cleaned_content = sanitize_text_for_encoding(doc)

--- a/tests/chunker/test_chunking_raw_lightrag_parity.py
+++ b/tests/chunker/test_chunking_raw_lightrag_parity.py
@@ -6,12 +6,17 @@ result into the same ``chunking_func`` used by raw documents.  These tests
 guard the contract end-to-end:
 
 * T1: identical input text produces identical chunking inputs whether it
-  arrives as raw or as a lightrag ``.blocks.jsonl``.
-* T2: ``full_docs.content`` for lightrag carries the *full* merged text
-  with the ``{{LRdoc}}`` marker, while ``doc_status`` reports the bare
-  body length / summary (no marker leakage).
+  arrives as raw or as an already-parsed lightrag full_docs row pulled
+  back through the parse queue on resume (ReuseParser) — the only
+  production path for lightrag rows now that the ``docs_format="lightrag"``
+  enqueue entrypoint is removed (the in-run parse → chunk path is T6).
+* T2: after a pending_parse document is parsed by the native engine,
+  ``full_docs.content`` carries the *full* merged text with the
+  ``{{LRdoc}}`` marker (written by ``_persist_parsed_full_docs``), while
+  ``doc_status`` reports the bare body length / summary (no marker
+  leakage).
 * T3: ``extraction_meta["parse_format"]`` (surfaced via
-  ``doc_status.metadata``) is now ``"lightrag"`` for lightrag docs —
+  ``doc_status.metadata``) is ``"lightrag"`` for natively-parsed docs —
   previously a structured-parse fallback always tagged ``raw`` and
   silently mislabelled the persisted record.
 * T4: a raw document whose body coincidentally *looks* like structured
@@ -50,6 +55,7 @@ from lightrag.utils import (
     compute_mdhash_id,
     get_content_summary,
 )
+from lightrag.utils_pipeline import make_lightrag_doc_content
 
 
 # ---------------------------------------------------------------------------
@@ -129,43 +135,49 @@ def _attach_chunking_spy(rag: LightRAG) -> dict:
     return captured
 
 
-def _write_lightrag_blocks(blocks_path: Path, body_paragraphs: list[str]) -> None:
-    """Write a minimal valid LightRAG ``.blocks.jsonl`` with body paragraphs."""
-    lines = [
-        json.dumps(
-            {
-                "type": "meta",
-                "format": "lightrag",
-                "version": "1.0",
-                "format_version": "1.0",
-            },
-            ensure_ascii=False,
-        )
-    ]
-    for i, para in enumerate(body_paragraphs):
-        lines.append(
-            json.dumps(
-                {
-                    "type": "content",
-                    "blockid": f"b{i}",
-                    "format": "plain_text",
-                    "content": para,
-                },
-                ensure_ascii=False,
-            )
-        )
-    blocks_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-
 # ---------------------------------------------------------------------------
 # T1 — parity: raw vs lightrag produce identical chunking input
 # ---------------------------------------------------------------------------
 
 
+async def _seed_lightrag_row(rag: LightRAG, doc_id: str, *, body: str, file_path: str):
+    """Seed an already-parsed lightrag full_docs row + a PENDING doc_status.
+
+    Mirrors how lightrag-format rows exist in production: written by the
+    parsers (``_persist_parsed_full_docs``) and pulled back through the
+    parse queue (→ ReuseParser) only on resume/retry.
+    """
+    from datetime import datetime, timezone
+
+    await rag.full_docs.upsert(
+        {
+            doc_id: {
+                "content": make_lightrag_doc_content(body),
+                "file_path": file_path,
+                "parse_format": FULL_DOCS_FORMAT_LIGHTRAG,
+            }
+        }
+    )
+    now = datetime.now(timezone.utc).isoformat()
+    await rag.doc_status.upsert(
+        {
+            doc_id: {
+                "status": "pending",
+                "content_summary": get_content_summary(body),
+                "content_length": len(body),
+                "file_path": file_path,
+                "created_at": now,
+                "updated_at": now,
+                "track_id": "track-lr",
+            }
+        }
+    )
+
+
 @pytest.mark.offline
-def test_chunking_input_parity_raw_vs_lightrag(tmp_path, monkeypatch):
-    """Same body text in raw and lightrag formats must reach
-    ``chunking_func`` with byte-identical input."""
+def test_chunking_input_parity_raw_vs_lightrag(tmp_path):
+    """Same body text must reach ``chunking_func`` with byte-identical input
+    whether it arrives as raw or as a resumed lightrag full_docs row."""
 
     paragraphs = [
         "Alpha paragraph with enough words to make it look real.",
@@ -189,25 +201,16 @@ def test_chunking_input_parity_raw_vs_lightrag(tmp_path, monkeypatch):
         finally:
             await rag_raw.finalize_storages()
 
-        # ---- LIGHTRAG path ----
-        input_dir = tmp_path / "lr-input"
-        parsed_dir = input_dir / "__parsed__"
-        parsed_dir.mkdir(parents=True)
-        monkeypatch.setenv("INPUT_DIR", str(input_dir))
-
-        blocks_path = parsed_dir / "parity.blocks.jsonl"
-        _write_lightrag_blocks(blocks_path, paragraphs)
-
+        # ---- LIGHTRAG path (resume: seeded parsed row → ReuseParser) ----
         rag_lr = _new_rag(tmp_path / "lr")
         await rag_lr.initialize_storages()
         spy_lr = _attach_chunking_spy(rag_lr)
         try:
-            await rag_lr.apipeline_enqueue_documents(
-                "",
-                file_paths="parity.lightrag",
-                docs_format=FULL_DOCS_FORMAT_LIGHTRAG,
-                lightrag_document_paths="__parsed__/parity.blocks.jsonl",
-                track_id="track-lr",
+            await _seed_lightrag_row(
+                rag_lr,
+                "doc-parity-lr",
+                body=expected_merged,
+                file_path="parity.lightrag",
             )
             await rag_lr.apipeline_process_enqueue_documents()
         finally:
@@ -231,37 +234,69 @@ def test_chunking_input_parity_raw_vs_lightrag(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+def _stub_docx_blocks(monkeypatch, body_paragraphs: list[str]) -> None:
+    """Stub the docx extractor so native parse yields deterministic blocks;
+    the adapter still writes the canonical .blocks.jsonl + sidecars and
+    persists the lightrag-format full_docs row."""
+
+    def _stub_extract(file_path, fixlevel=None, drawing_context=None, **kwargs):
+        return [
+            {
+                "uuid": f"para-{i}",
+                "uuid_end": f"para-{i}",
+                "heading": "",
+                "content": para,
+                "type": "text",
+                "parent_headings": [],
+                "level": 0,
+                "table_chunk_role": "none",
+            }
+            for i, para in enumerate(body_paragraphs)
+        ]
+
+    monkeypatch.setattr(
+        "lightrag.parser.docx.parse_document.extract_docx_blocks",
+        _stub_extract,
+    )
+
+
 @pytest.mark.offline
 def test_full_docs_content_carries_full_merged_text(tmp_path, monkeypatch):
+    """After the native engine parses a pending_parse upload,
+    ``_persist_parsed_full_docs`` stores the *full* merged text with the
+    ``{{LRdoc}}`` marker while doc_status reports bare-body semantics."""
+
     body = "x" * 5000  # single paragraph, 5000 chars
-    paragraphs = [body]
 
     async def _run():
         input_dir = tmp_path / "input"
-        parsed_dir = input_dir / "__parsed__"
-        parsed_dir.mkdir(parents=True)
+        input_dir.mkdir()
         monkeypatch.setenv("INPUT_DIR", str(input_dir))
-
-        blocks_path = parsed_dir / "big.blocks.jsonl"
-        _write_lightrag_blocks(blocks_path, paragraphs)
+        (input_dir / "big.docx").write_bytes(b"fake docx bytes")
+        _stub_docx_blocks(monkeypatch, [body])
 
         rag = _new_rag(tmp_path / "work")
         await rag.initialize_storages()
         try:
             await rag.apipeline_enqueue_documents(
                 "",
-                file_paths="big.lightrag",
-                docs_format=FULL_DOCS_FORMAT_LIGHTRAG,
-                lightrag_document_paths="__parsed__/big.blocks.jsonl",
+                file_paths="big.docx",
+                docs_format=FULL_DOCS_FORMAT_PENDING_PARSE,
+                parse_engine="native",
                 track_id="track-big",
             )
+            await rag.apipeline_process_enqueue_documents()
 
-            doc_id = compute_mdhash_id("big.lightrag", prefix="doc-")
+            doc_id = compute_mdhash_id("big.docx", prefix="doc-")
             full_doc = await rag.full_docs.get_by_id(doc_id)
             assert full_doc is not None
             # full_docs preserves the marker AND the full merged text.
             assert full_doc["content"] == LIGHTRAG_DOC_CONTENT_PREFIX + body
             assert full_doc.get("parse_format") == FULL_DOCS_FORMAT_LIGHTRAG
+            assert full_doc.get("sidecar_location"), (
+                "native parse must record the sidecar_location on the "
+                "lightrag full_docs row"
+            )
 
             # doc_status reports body-length semantics (no marker leakage).
             status_doc = await rag.doc_status.get_by_id(doc_id)
@@ -294,18 +329,17 @@ def test_extraction_meta_records_lightrag_parse_format(tmp_path, monkeypatch):
     """Before the unification, a structured-parse fallback tagged
     ``extraction_meta.parse_format = raw`` for lightrag docs, silently
     mislabelling them in ``doc_status.metadata``.  Assert the tag now
-    reflects the persisted format end-to-end."""
+    reflects the persisted format end-to-end (pending_parse upload →
+    native parse → lightrag full_docs row)."""
 
     paragraphs = ["Body paragraph for parse_format tagging test."]
 
     async def _run():
         input_dir = tmp_path / "input"
-        parsed_dir = input_dir / "__parsed__"
-        parsed_dir.mkdir(parents=True)
+        input_dir.mkdir()
         monkeypatch.setenv("INPUT_DIR", str(input_dir))
-
-        blocks_path = parsed_dir / "tag.blocks.jsonl"
-        _write_lightrag_blocks(blocks_path, paragraphs)
+        (input_dir / "tag.docx").write_bytes(b"fake docx bytes")
+        _stub_docx_blocks(monkeypatch, paragraphs)
 
         rag = _new_rag(tmp_path / "work")
         await rag.initialize_storages()
@@ -313,14 +347,14 @@ def test_extraction_meta_records_lightrag_parse_format(tmp_path, monkeypatch):
         try:
             await rag.apipeline_enqueue_documents(
                 "",
-                file_paths="tag.lightrag",
-                docs_format=FULL_DOCS_FORMAT_LIGHTRAG,
-                lightrag_document_paths="__parsed__/tag.blocks.jsonl",
+                file_paths="tag.docx",
+                docs_format=FULL_DOCS_FORMAT_PENDING_PARSE,
+                parse_engine="native",
                 track_id="track-tag",
             )
             await rag.apipeline_process_enqueue_documents()
 
-            doc_id = compute_mdhash_id("tag.lightrag", prefix="doc-")
+            doc_id = compute_mdhash_id("tag.docx", prefix="doc-")
             status_doc = await rag.doc_status.get_by_id(doc_id)
             assert status_doc is not None
             metadata = (
@@ -565,28 +599,7 @@ def test_pending_parse_lightrag_summary_populated_after_processed(
 
         source_path = input_dir / "summary.docx"
         source_path.write_bytes(b"fake docx bytes")
-
-        # Stub the docx extractor so the parsed blocks are deterministic;
-        # the adapter still writes the canonical .blocks.jsonl + sidecars.
-        def _stub_extract(file_path, fixlevel=None, drawing_context=None, **kwargs):
-            return [
-                {
-                    "uuid": f"para-{i}",
-                    "uuid_end": f"para-{i}",
-                    "heading": "",
-                    "content": para,
-                    "type": "text",
-                    "parent_headings": [],
-                    "level": 0,
-                    "table_chunk_role": "none",
-                }
-                for i, para in enumerate(body_paragraphs)
-            ]
-
-        monkeypatch.setattr(
-            "lightrag.parser.docx.parse_document.extract_docx_blocks",
-            _stub_extract,
-        )
+        _stub_docx_blocks(monkeypatch, body_paragraphs)
 
         rag = _new_rag(tmp_path / "work")
         await rag.initialize_storages()

--- a/tests/pipeline/test_parse_engine_early_persist.py
+++ b/tests/pipeline/test_parse_engine_early_persist.py
@@ -23,7 +23,7 @@ These tests pin the new contract:
 """
 
 import asyncio
-import json
+from datetime import datetime, timezone
 from pathlib import Path
 
 import numpy as np
@@ -44,6 +44,7 @@ from lightrag.utils_pipeline import (
     _DOC_STATUS_METADATA_CARRY_OVER_KEYS,
     doc_status_metadata_carry_over,
     doc_status_reset_metadata,
+    make_lightrag_doc_content,
     resolve_doc_status_parse_engine,
 )
 
@@ -253,57 +254,50 @@ def test_raw_doc_records_legacy_engine_at_parsing(tmp_path):
     asyncio.run(_run())
 
 
-def _write_lightrag_blocks(blocks_path: Path, body_paragraphs: list[str]) -> None:
-    lines = [
-        json.dumps(
-            {
-                "type": "meta",
-                "format": "lightrag",
-                "version": "1.0",
-                "format_version": "1.0",
-            },
-            ensure_ascii=False,
-        )
-    ]
-    for i, para in enumerate(body_paragraphs):
-        lines.append(
-            json.dumps(
-                {
-                    "type": "content",
-                    "blockid": f"b{i}",
-                    "format": "plain_text",
-                    "content": para,
-                },
-                ensure_ascii=False,
-            )
-        )
-    blocks_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+def test_lightrag_doc_records_native_engine_at_parsing(tmp_path):
+    """A lightrag-format doc on resume (already-parsed full_docs row pulled
+    back through the parse queue → ReuseParser cache-hit, parser does not
+    re-persist): parse_engine resolves to ``native`` and is stamped at
+    PARSING, identical through PROCESSED.
 
-
-def test_lightrag_doc_records_native_engine_at_parsing(tmp_path, monkeypatch):
-    """A lightrag-format doc (cache-hit, parser does not re-persist):
-    parse_engine resolves to ``native`` and is stamped at PARSING, identical
-    through PROCESSED."""
+    The row is seeded directly (full_docs ``parse_format=lightrag`` +
+    PENDING doc_status), mirroring how such rows exist in production now
+    that the ``docs_format="lightrag"`` enqueue entrypoint is removed:
+    they are written by the parsers and re-enter the queue only on
+    resume/retry."""
 
     async def _run():
-        input_dir = tmp_path / "input"
-        parsed_dir = input_dir / "__parsed__"
-        parsed_dir.mkdir(parents=True)
-        monkeypatch.setenv("INPUT_DIR", str(input_dir))
-
-        blocks_path = parsed_dir / "early.blocks.jsonl"
-        _write_lightrag_blocks(blocks_path, ["Body paragraph for lightrag doc."])
-
         rag = _new_rag(tmp_path / "work")
         await rag.initialize_storages()
         records = _attach_transition_spy(rag)
         try:
-            await rag.apipeline_enqueue_documents(
-                "",
-                file_paths="early.lightrag",
-                docs_format=FULL_DOCS_FORMAT_LIGHTRAG,
-                lightrag_document_paths="__parsed__/early.blocks.jsonl",
-                track_id="track-lr",
+            doc_id = "doc-early-lr"
+            body = "Body paragraph for lightrag doc."
+            now = datetime.now(timezone.utc).isoformat()
+            await rag.full_docs.upsert(
+                {
+                    doc_id: {
+                        # Stored WITH the marker, as the parsers persist
+                        # lightrag rows. No parse_engine → the format-based
+                        # fallback resolves to native.
+                        "content": make_lightrag_doc_content(body),
+                        "file_path": "early.lightrag",
+                        "parse_format": FULL_DOCS_FORMAT_LIGHTRAG,
+                    }
+                }
+            )
+            await rag.doc_status.upsert(
+                {
+                    doc_id: {
+                        "status": DocStatus.PENDING.value,
+                        "content_summary": body,
+                        "content_length": len(body),
+                        "file_path": "early.lightrag",
+                        "created_at": now,
+                        "updated_at": now,
+                        "track_id": "track-lr",
+                    }
+                }
             )
             await rag.apipeline_process_enqueue_documents()
 

--- a/tests/pipeline/test_pipeline_release_closure.py
+++ b/tests/pipeline/test_pipeline_release_closure.py
@@ -1895,55 +1895,37 @@ def test_content_hash_lookup_via_storage(tmp_path):
 
 
 @pytest.mark.offline
-def test_lightrag_format_uses_blocks_file_hash(tmp_path, monkeypatch):
-    async def _run():
-        input_dir = tmp_path / "input"
-        parsed_dir = input_dir / "__parsed__"
-        parsed_dir.mkdir(parents=True)
-        monkeypatch.setenv("INPUT_DIR", str(input_dir))
+def test_enqueue_rejects_removed_or_unknown_docs_format(tmp_path):
+    """The 'lightrag' ingestion entrypoint was removed: enqueue accepts only
+    raw / pending_parse and raises explicitly for anything else (previously
+    an unknown value was silently treated as raw)."""
 
-        rag = _new_rag(tmp_path / "work")
-        rag.workspace = "test-pending-parse-duplicate"
+    async def _run():
+        rag = _new_rag(tmp_path)
         await rag.initialize_storages()
         try:
-            blocks_path = parsed_dir / "doc.blocks.jsonl"
-            blocks_path.write_text(
-                json.dumps({"type": "header"})
-                + "\n"
-                + json.dumps({"type": "content", "text": "hello"})
-                + "\n",
-                encoding="utf-8",
-            )
-
-            # Enqueue twice with different filenames pointing at the same
-            # blocks file: the second one must be rejected as content_hash dup.
-            # ``content`` arg is ignored on the LIGHTRAG path — the LightRAG
-            # Document file is read to derive both content_hash and the
-            # ``{{LRdoc}}`` summary — so any string here is fine.
-            await rag.apipeline_enqueue_documents(
-                "",
-                file_paths="first.lightrag",
-                docs_format="lightrag",
-                lightrag_document_paths="__parsed__/doc.blocks.jsonl",
-                track_id="track-a",
-            )
-            await rag.apipeline_enqueue_documents(
-                "",
-                file_paths="second.lightrag",
-                docs_format="lightrag",
-                lightrag_document_paths="__parsed__/doc.blocks.jsonl",
-                track_id="track-b",
-            )
-            second_id = compute_mdhash_id("second.lightrag", prefix="doc-")
-            assert await rag.full_docs.get_by_id(second_id) is None
-
+            with pytest.raises(ValueError, match="Unsupported docs_format"):
+                await rag.apipeline_enqueue_documents(
+                    "",
+                    file_paths="first.lightrag",
+                    docs_format="lightrag",
+                )
+            with pytest.raises(ValueError, match="Unsupported docs_format"):
+                await rag.apipeline_enqueue_documents(
+                    "some content",
+                    file_paths="doc.txt",
+                    docs_format="bogus",
+                )
+            # The companion parameter is gone entirely (no compat shim).
+            with pytest.raises(TypeError):
+                await rag.apipeline_enqueue_documents(  # type: ignore[call-arg]
+                    "",
+                    file_paths="first.lightrag",
+                    lightrag_document_paths="__parsed__/doc.blocks.jsonl",
+                )
+            # Nothing was enqueued by the rejected calls.
             failed = await rag.doc_status.get_docs_by_status(DocStatus.FAILED)
-            kinds = {
-                getattr(doc, "metadata", {}).get("duplicate_kind")
-                for doc in failed.values()
-                if getattr(doc, "metadata", {}).get("is_duplicate")
-            }
-            assert "content_hash" in kinds
+            assert failed == {}
         finally:
             await rag.finalize_storages()
 


### PR DESCRIPTION
## Description

Follow-up of #3235 ("remove the deprecated `docs_format=\"lightrag\"` entrypoint next release").

#3235 deprecated the `docs_format="lightrag"` / `lightrag_document_paths` ingestion path with a runtime warning — no production caller enqueues a pre-existing sidecar this way (the upper layer doesn't know the backend sidecar layout). This PR removes it outright, per the no-compat-shim convention for internal APIs.

## Related Issues

Follow-up of #3235 (RFC #3197).

## Changes Made

- **`apipeline_enqueue_documents`**:
  - drops the `lightrag_document_paths` parameter entirely — passing it now raises `TypeError` (no shim);
  - validates `docs_format` explicitly: anything other than `"raw"` / `"pending_parse"` raises `ValueError` with the accepted values. This also fixes a latent bug where an *unknown* `docs_format` value was silently treated as `raw`;
  - the enqueue-side lightrag branch dies with it: sidecar resolution + blocks loading, the `lightrag_load_errors` FAILED-stub flushing, `sidecar_location` passthrough on `_add_content` / `full_docs_data`, the blocks-file `content_hash` doc_id branch, and the now-no-op `{{LRdoc}}` stripping in `_add_content` / `_initial_doc_status`.
- **`constants.py`**: `FULL_DOCS_FORMAT_LIGHTRAG` now documents that it is the *post-parse persistence / resume* marker, not an enqueue input format.

## What is intentionally NOT touched (resume path)

The lightrag *format* itself is unaffected: `FULL_DOCS_FORMAT_LIGHTRAG` remains the marker written by the parsers (`_persist_parsed_full_docs` / native / external / sidecar writer), and already-parsed rows still resume through `resolve_stored_document_parser_engine` → `ReuseParser`. `load_lightrag_document_content` stays in `utils_pipeline` (sidecar/backfill + tests use it); only `pipeline.py`'s enqueue-side imports are dropped.

## Test changes

The three suites that exercised the removed entrypoint are rewritten against the surviving production paths:

- `tests/chunker/test_chunking_raw_lightrag_parity.py` — T1 (raw vs lightrag chunking parity) seeds an already-parsed lightrag full_docs row + PENDING doc_status (the resume path → ReuseParser); parity assertions unchanged. T2/T3 drive the real `pending_parse` → native-parse pipeline with a stubbed docx extractor and assert the `_persist_parsed_full_docs` output (full `{{LRdoc}}` + merged text, `sidecar_location`, bare-body doc_status semantics, `metadata.parse_format`); the stub harness is shared with T6 via `_stub_docx_blocks`.
- `tests/pipeline/test_parse_engine_early_persist.py` — the lightrag early-persist case seeds the resume row the same way; `_assert_early_and_stable` assertions unchanged.
- `tests/pipeline/test_pipeline_release_closure.py` — the blocks-file-hash dedup test is deleted (its semantics died with the entrypoint) and replaced by negative tests pinning the new contract: `docs_format="lightrag"` → `ValueError`, unknown `docs_format` → `ValueError`, `lightrag_document_paths=...` → `TypeError`.

## Checklist

- [x] Changes tested locally — full suite **2280 passed, 34 skipped, 0 failed**
- [x] Code reviewed
- [ ] Documentation updated (no docs referenced the removed parameters)
- [x] Unit tests added — negative validation tests for the removed/unknown `docs_format` values

## Additional Notes

**Dispatch-precedence note (by design, unchanged by this PR):** the enqueue dispatch chain checks `ids is not None` *before* `docs_format == "pending_parse"` (pipeline.py:535), so passing both enqueues the documents as RAW. This is intentional: `ids` marks the SDK raw direct-insert path — `LightRAG.ainsert` passes `(input, ids, file_paths, track_id)` and relies on the `ids` branch sanitizing the body and enqueueing it as RAW regardless of other flags. `docs_format="pending_parse"` is the server upload path, which never passes `ids`.

Marked `!` (breaking) for any out-of-tree caller of the removed parameter, though there is no known production caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

