### PR TITLE
fix(pipeline): retry malformed multimodal analysis JSON

### DIFF
--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -3865,31 +3865,28 @@ class _PipelineMixin:
                 fresh response can overwrite the same cache key after success.
                 """
 
-                last_error: _MMJSONConformanceError | None = None
-                for attempt_index in range(2):
-                    use_cached_response = attempt_index == 0 and cached is not None
-                    if use_cached_response:
-                        result_text = cached[0]
-                        fresh = False
-                    else:
-                        result_text = await call_model_once()
-                        fresh = True
+                def _attempt(raw: Any, fresh: bool) -> tuple[dict[str, str], str, bool]:
+                    text = str(raw)
+                    return validate_result(_json_extract(text)), text, fresh
 
-                    try:
-                        parsed = _json_extract(str(result_text))
-                        return validate_result(parsed), str(result_text), fresh
-                    except _MMJSONConformanceError as exc:
-                        last_error = exc
-                        if attempt_index == 0:
-                            source = "cache" if use_cached_response else "model"
-                            logger.warning(
-                                f"[analyze_multimodal] {prefix}: invalid JSON "
-                                f"schema from {source}; retrying once: {exc}"
-                            )
-                            continue
-                        raise MultimodalAnalysisError(str(exc)) from exc
+                use_cached_response = cached is not None
+                first_text = (
+                    cached[0] if use_cached_response else await call_model_once()
+                )
+                try:
+                    return _attempt(first_text, fresh=not use_cached_response)
+                except _MMJSONConformanceError as exc:
+                    source = "cache" if use_cached_response else "model"
+                    logger.warning(
+                        f"[analyze_multimodal] {prefix}: invalid JSON schema "
+                        f"from {source}; retrying once: {exc} "
+                        f"(response snippet: {str(first_text)[:200]!r})"
+                    )
 
-                raise MultimodalAnalysisError(str(last_error)) from last_error
+                try:
+                    return _attempt(await call_model_once(), fresh=True)
+                except _MMJSONConformanceError as exc:
+                    raise MultimodalAnalysisError(str(exc)) from exc
 
             def _normalize_text(value: Any) -> str:
                 if value is None:

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -3810,6 +3810,89 @@ class _PipelineMixin:
                         pass
                 return {}
 
+            class _MMJSONConformanceError(Exception):
+                """Raised only when an LLM/VLM response violates MM JSON schema."""
+
+            def _required_json_string(
+                parsed: dict[str, Any], prefix: str, field: str
+            ) -> str:
+                value = parsed.get(field)
+                if not isinstance(value, str) or not value.strip():
+                    raise _MMJSONConformanceError(
+                        f"{prefix}: missing or invalid field '{field}'"
+                    )
+                return value.strip()
+
+            def _validate_drawing_analysis(
+                item_id: str, parsed: dict[str, Any]
+            ) -> dict[str, str]:
+                prefix = f"drawings/{item_id}"
+                name = _required_json_string(parsed, prefix, "name")
+                description = _required_json_string(parsed, prefix, "description")
+                type_value = _required_json_string(parsed, prefix, "type")
+                if type_value not in _IMAGE_TYPE_VALUES:
+                    type_value = IMAGE_TYPE_FALLBACK
+                return {
+                    "name": name,
+                    "type": type_value,
+                    "description": description,
+                }
+
+            def _validate_text_analysis(
+                kind: str, item_id: str, parsed: dict[str, Any]
+            ) -> dict[str, str]:
+                prefix = f"{kind}/{item_id}"
+                result_obj = {
+                    "name": _required_json_string(parsed, prefix, "name"),
+                    "description": _required_json_string(
+                        parsed, prefix, "description"
+                    ),
+                }
+                if kind == "equation":
+                    result_obj["equation"] = _required_json_string(
+                        parsed, prefix, "equation"
+                    )
+                return result_obj
+
+            async def _run_json_conformance_retry(
+                prefix: str,
+                cached: tuple[str, int] | None,
+                call_model_once,
+                validate_result,
+            ) -> tuple[dict[str, str], str, bool]:
+                """Retry once only for JSON/schema conformance failures.
+
+                The first attempt may use the analysis cache.  If that cached
+                response is malformed, bypass the cache on the retry so a good
+                fresh response can overwrite the same cache key after success.
+                """
+
+                last_error: _MMJSONConformanceError | None = None
+                for attempt_index in range(2):
+                    use_cached_response = attempt_index == 0 and cached is not None
+                    if use_cached_response:
+                        result_text = cached[0]
+                        fresh = False
+                    else:
+                        result_text = await call_model_once()
+                        fresh = True
+
+                    try:
+                        parsed = _json_extract(str(result_text))
+                        return validate_result(parsed), str(result_text), fresh
+                    except _MMJSONConformanceError as exc:
+                        last_error = exc
+                        if attempt_index == 0:
+                            source = "cache" if use_cached_response else "model"
+                            logger.warning(
+                                f"[analyze_multimodal] {prefix}: invalid JSON "
+                                f"schema from {source}; retrying once: {exc}"
+                            )
+                            continue
+                        raise MultimodalAnalysisError(str(exc)) from exc
+
+                raise MultimodalAnalysisError(str(last_error)) from last_error
+
             def _normalize_text(value: Any) -> str:
                 if value is None:
                     return ""
@@ -3956,40 +4039,31 @@ class _PipelineMixin:
                     mode="default",
                     cache_type="analysis",
                 )
-                if cached is not None:
-                    result_text = cached[0]
-                    fresh = False
-                else:
+
+                async def _call_vlm_once() -> str:
                     try:
-                        result_text = await use_vlm_func(
+                        return await use_vlm_func(
                             prompt,
                             stream=False,
                             image_inputs=[img_payload],
+                            response_format={"type": "json_object"},
                             _priority=DEFAULT_MM_ANALYSIS_PRIORITY,
                         )
+                    except PipelineCancelledException:
+                        raise
                     except Exception as exc:
                         raise MultimodalAnalysisError(
                             f"drawings/{item_id}: VLM call failed: {exc}"
                         ) from exc
-                    fresh = True
-                parsed = _json_extract(str(result_text))
-                name = parsed.get("name")
-                type_value = parsed.get("type")
-                description = parsed.get("description")
-                if not isinstance(name, str) or not name.strip():
-                    raise MultimodalAnalysisError(
-                        f"drawings/{item_id}: missing or invalid field 'name'"
+
+                analysis_fields, result_text, fresh = (
+                    await _run_json_conformance_retry(
+                        f"drawings/{item_id}",
+                        cached,
+                        _call_vlm_once,
+                        lambda parsed: _validate_drawing_analysis(item_id, parsed),
                     )
-                if not isinstance(description, str) or not description.strip():
-                    raise MultimodalAnalysisError(
-                        f"drawings/{item_id}: missing or invalid field 'description'"
-                    )
-                if not isinstance(type_value, str) or not type_value.strip():
-                    raise MultimodalAnalysisError(
-                        f"drawings/{item_id}: missing or invalid field 'type'"
-                    )
-                if type_value not in _IMAGE_TYPE_VALUES:
-                    type_value = IMAGE_TYPE_FALLBACK
+                )
                 cache_id_to_attach: str | None = None
                 if fresh and analysis_cache_enabled:
                     audit_blob = image_audit_metadata(normalized_images)
@@ -4018,9 +4092,9 @@ class _PipelineMixin:
                     cache_id_to_attach = cache_id
                 return (
                     {
-                        "name": name.strip(),
-                        "type": type_value,
-                        "description": description.strip(),
+                        "name": analysis_fields["name"],
+                        "type": analysis_fields["type"],
+                        "description": analysis_fields["description"],
                         "analyze_time": int(time.time()),
                         "status": "success",
                         "message": "",
@@ -4170,50 +4244,41 @@ class _PipelineMixin:
                     mode="default",
                     cache_type="analysis",
                 )
-                if cached is not None:
-                    result_text = cached[0]
-                    fresh = False
-                else:
+
+                async def _call_extract_once() -> str:
                     try:
-                        result_text = await use_extract_func(
+                        return await use_extract_func(
                             prompt,
                             stream=False,
                             response_format={"type": "json_object"},
                             _priority=DEFAULT_MM_ANALYSIS_PRIORITY,
                         )
+                    except PipelineCancelledException:
+                        raise
                     except Exception as exc:
                         raise MultimodalAnalysisError(
                             f"{kind}/{item_id}: EXTRACT call failed: {exc}"
                         ) from exc
-                    fresh = True
-                parsed = _json_extract(str(result_text))
-                name = parsed.get("name")
-                description = parsed.get("description")
-                if not isinstance(name, str) or not name.strip():
-                    raise MultimodalAnalysisError(
-                        f"{kind}/{item_id}: missing or invalid field 'name'"
+
+                analysis_fields, result_text, fresh = (
+                    await _run_json_conformance_retry(
+                        f"{kind}/{item_id}",
+                        cached,
+                        _call_extract_once,
+                        lambda parsed: _validate_text_analysis(
+                            kind, item_id, parsed
+                        ),
                     )
-                if not isinstance(description, str) or not description.strip():
-                    raise MultimodalAnalysisError(
-                        f"{kind}/{item_id}: missing or invalid field 'description'"
-                    )
+                )
                 result_obj: dict[str, Any] = {
-                    "name": name.strip(),
-                    "description": description.strip(),
+                    "name": analysis_fields["name"],
+                    "description": analysis_fields["description"],
                     "analyze_time": int(time.time()),
                     "status": "success",
                     "message": "",
                 }
                 if kind == "equation":
-                    equation_value = parsed.get("equation")
-                    if (
-                        not isinstance(equation_value, str)
-                        or not equation_value.strip()
-                    ):
-                        raise MultimodalAnalysisError(
-                            f"equation/{item_id}: missing or invalid field 'equation'"
-                        )
-                    result_obj["equation"] = equation_value.strip()
+                    result_obj["equation"] = analysis_fields["equation"]
                 cache_id_to_attach: str | None = None
                 if fresh and analysis_cache_enabled:
                     await save_to_cache(

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -3844,9 +3844,7 @@ class _PipelineMixin:
                 prefix = f"{kind}/{item_id}"
                 result_obj = {
                     "name": _required_json_string(parsed, prefix, "name"),
-                    "description": _required_json_string(
-                        parsed, prefix, "description"
-                    ),
+                    "description": _required_json_string(parsed, prefix, "description"),
                 }
                 if kind == "equation":
                     result_obj["equation"] = _required_json_string(
@@ -4056,13 +4054,11 @@ class _PipelineMixin:
                             f"drawings/{item_id}: VLM call failed: {exc}"
                         ) from exc
 
-                analysis_fields, result_text, fresh = (
-                    await _run_json_conformance_retry(
-                        f"drawings/{item_id}",
-                        cached,
-                        _call_vlm_once,
-                        lambda parsed: _validate_drawing_analysis(item_id, parsed),
-                    )
+                analysis_fields, result_text, fresh = await _run_json_conformance_retry(
+                    f"drawings/{item_id}",
+                    cached,
+                    _call_vlm_once,
+                    lambda parsed: _validate_drawing_analysis(item_id, parsed),
                 )
                 cache_id_to_attach: str | None = None
                 if fresh and analysis_cache_enabled:
@@ -4260,15 +4256,11 @@ class _PipelineMixin:
                             f"{kind}/{item_id}: EXTRACT call failed: {exc}"
                         ) from exc
 
-                analysis_fields, result_text, fresh = (
-                    await _run_json_conformance_retry(
-                        f"{kind}/{item_id}",
-                        cached,
-                        _call_extract_once,
-                        lambda parsed: _validate_text_analysis(
-                            kind, item_id, parsed
-                        ),
-                    )
+                analysis_fields, result_text, fresh = await _run_json_conformance_retry(
+                    f"{kind}/{item_id}",
+                    cached,
+                    _call_extract_once,
+                    lambda parsed: _validate_text_analysis(kind, item_id, parsed),
                 )
                 result_obj: dict[str, Any] = {
                     "name": analysis_fields["name"],

--- a/tests/pipeline/test_pipeline_analyze_multimodal.py
+++ b/tests/pipeline/test_pipeline_analyze_multimodal.py
@@ -522,6 +522,76 @@ async def test_invalid_vlm_response_retries_once_then_succeeds(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_malformed_cached_analysis_bypassed_and_overwritten(tmp_path):
+    """A malformed analysis cache entry (e.g. persisted by an older version)
+    is served on the first attempt, bypassed on the retry, and the fresh
+    successful response overwrites the same cache key."""
+    call_log: list[dict] = []
+
+    async def vlm_func(prompt, **kwargs):
+        call_log.append({"prompt": prompt, "kwargs": dict(kwargs)})
+        name = "seed-fig" if len(call_log) == 1 else "fresh-fig"
+        return json.dumps(
+            {
+                "name": name,
+                "type": "Chart",
+                "description": "concise figure description",
+            }
+        )
+
+    rag = _build_rag(tmp_path, vlm_process_enable=True, vlm_func=vlm_func)
+    await rag.initialize_storages()
+    try:
+        doc_id, parsed_data, sidecar_path = _write_sidecar_fixtures(tmp_path)
+
+        # First run populates the analysis cache with a valid response.
+        await rag.analyze_multimodal(
+            doc_id=doc_id,
+            file_path="fixture.pdf",
+            parsed_data=parsed_data,
+            process_options="i",
+        )
+        assert len(call_log) == 1
+
+        # Corrupt the cache entry in place: same key, malformed body.
+        # JsonKVStorage shares one in-process store per (namespace,
+        # workspace), so go through the storage API rather than the file.
+        await rag.llm_response_cache.index_done_callback()
+        cache_file = (
+            Path(rag.working_dir) / rag.workspace / "kv_store_llm_response_cache.json"
+        )
+        cache_blob = json.loads(cache_file.read_text(encoding="utf-8"))
+        analysis_keys = [k for k in cache_blob if k.startswith("default:analysis:")]
+        assert len(analysis_keys) == 1
+        cache_key = analysis_keys[0]
+        corrupted_entry = dict(cache_blob[cache_key])
+        corrupted_entry["return"] = "not-json"
+        await rag.llm_response_cache.upsert({cache_key: corrupted_entry})
+
+        # Re-run: the first attempt consumes the malformed cache entry
+        # without a model call; the retry bypasses the cache and calls the
+        # VLM exactly once.
+        await rag.analyze_multimodal(
+            doc_id=doc_id,
+            file_path="fixture.pdf",
+            parsed_data=parsed_data,
+            process_options="i",
+        )
+        assert len(call_log) == 2
+        payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        result = payload["drawings"]["im-001"]["llm_analyze_result"]
+        assert result["status"] == "success"
+        assert result["name"] == "fresh-fig"
+
+        # The fresh response overwrote the malformed entry under the same key.
+        overwritten = await rag.llm_response_cache.get_by_id(cache_key)
+        assert overwritten is not None
+        assert json.loads(overwritten["return"])["name"] == "fresh-fig"
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
 async def test_invalid_vlm_response_hard_fails(tmp_path):
     """Invalid model JSON propagates MultimodalAnalysisError and lands a
     status=failure marker after one retry so re-runs don't silently

--- a/tests/pipeline/test_pipeline_analyze_multimodal.py
+++ b/tests/pipeline/test_pipeline_analyze_multimodal.py
@@ -262,6 +262,7 @@ async def test_vlm_call_carries_image_inputs(tmp_path):
         kwargs = call_log[0]["kwargs"]
         assert kwargs.get("stream") is False
         assert kwargs.get("image_inputs") is not None
+        assert kwargs.get("response_format") == {"type": "json_object"}
         assert "messages" not in kwargs
         # _priority is consumed by the wrapper (see lightrag.utils
         # priority_limit_async_func_call); not observable on the raw mock.
@@ -479,9 +480,51 @@ async def test_tiny_image_writes_skipped_without_vlm_call(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_invalid_vlm_response_retries_once_then_succeeds(tmp_path):
+    """A transient malformed VLM JSON response should be retried once in the
+    item analysis layer, then persist the successful second response."""
+    call_log: list[dict] = []
+
+    async def vlm_func(prompt, **kwargs):
+        call_log.append({"prompt": prompt, "kwargs": dict(kwargs)})
+        if len(call_log) == 1:
+            return "not-json"
+        return json.dumps(
+            {
+                "name": "retry-fig",
+                "type": "Chart",
+                "description": "valid after retry",
+            }
+        )
+
+    rag = _build_rag(tmp_path, vlm_process_enable=True, vlm_func=vlm_func)
+    await rag.initialize_storages()
+    try:
+        doc_id, parsed_data, sidecar_path = _write_sidecar_fixtures(tmp_path)
+        await rag.analyze_multimodal(
+            doc_id=doc_id,
+            file_path="fixture.pdf",
+            parsed_data=parsed_data,
+            process_options="i",
+        )
+        assert len(call_log) == 2
+        assert all(
+            call["kwargs"].get("response_format") == {"type": "json_object"}
+            for call in call_log
+        )
+        payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        result = payload["drawings"]["im-001"]["llm_analyze_result"]
+        assert result["status"] == "success"
+        assert result["name"] == "retry-fig"
+        assert result["description"] == "valid after retry"
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
 async def test_invalid_vlm_response_hard_fails(tmp_path):
     """Invalid model JSON propagates MultimodalAnalysisError and lands a
-    status=failure marker on the sidecar so re-runs don't silently
+    status=failure marker after one retry so re-runs don't silently
     consume the failure."""
     call_log: list[dict] = []
 
@@ -500,7 +543,7 @@ async def test_invalid_vlm_response_hard_fails(tmp_path):
                 parsed_data=parsed_data,
                 process_options="i",
             )
-        assert len(call_log) == 1
+        assert len(call_log) == 2
         await rag.llm_response_cache.index_done_callback()
         cache_file = (
             Path(rag.working_dir) / rag.workspace / "kv_store_llm_response_cache.json"
@@ -516,6 +559,76 @@ async def test_invalid_vlm_response_hard_fails(tmp_path):
         payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
         item = payload["drawings"]["im-001"]
         assert item["llm_analyze_result"]["status"] == "failure"
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_table_extract_json_conformance_retry_succeeds(tmp_path):
+    """Table analysis uses the EXTRACT role and retries once when the JSON
+    object is valid but missing required schema fields."""
+    extract_log: list[dict] = []
+    vlm_log: list[dict] = []
+
+    async def extract_func(prompt, **kwargs):
+        extract_log.append({"prompt": prompt, "kwargs": dict(kwargs)})
+        if len(extract_log) == 1:
+            return json.dumps({"description": "missing name"})
+        return json.dumps(
+            {
+                "name": "retry-table",
+                "description": "valid table summary",
+            }
+        )
+
+    rag = _build_rag(
+        tmp_path,
+        vlm_process_enable=True,
+        vlm_func=_make_vlm_mock(vlm_log),
+        extract_func=extract_func,
+    )
+    await rag.initialize_storages()
+    try:
+        parsed_dir = tmp_path / "parsed"
+        parsed_dir.mkdir()
+        blocks_path = parsed_dir / "doc.blocks.jsonl"
+        blocks_path.write_text(
+            json.dumps({"type": "meta", "doc_id": "doc-1"}) + "\n",
+            encoding="utf-8",
+        )
+        tables_path = parsed_dir / "doc.tables.json"
+        tables_path.write_text(
+            json.dumps(
+                {
+                    "tables": {
+                        "tb-001": {
+                            "caption": "Table 1",
+                            "format": "html",
+                            "content": "<table><tr><td>A</td></tr></table>",
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        await rag.analyze_multimodal(
+            doc_id="doc-1",
+            file_path="fixture.pdf",
+            parsed_data={"blocks_path": str(blocks_path)},
+            process_options="t",
+        )
+        assert vlm_log == []
+        assert len(extract_log) == 2
+        assert all(
+            call["kwargs"].get("response_format") == {"type": "json_object"}
+            for call in extract_log
+        )
+        payload = json.loads(tables_path.read_text(encoding="utf-8"))
+        result = payload["tables"]["tb-001"]["llm_analyze_result"]
+        assert result["status"] == "success"
+        assert result["name"] == "retry-table"
+        assert result["description"] == "valid table summary"
     finally:
         await rag.finalize_storages()
 

--- a/tests/pipeline/test_pipeline_release_closure.py
+++ b/tests/pipeline/test_pipeline_release_closure.py
@@ -2380,8 +2380,8 @@ def test_analyze_multimodal_invalid_json_hard_fails(tmp_path):
 
         drawings_payload = json.loads(drawings.read_text(encoding="utf-8"))
         result = drawings_payload["drawings"]["id1"]["llm_analyze_result"]
-        # No retry: VLM mock called exactly once.
-        assert calls["n"] == 1
+        # One JSON conformance retry, then the hard failure surfaces.
+        assert calls["n"] == 2
         # Sidecar carries a failure marker so a re-run sees the prior failure
         # and does not silently consume it.
         assert result["status"] == "failure"


### PR DESCRIPTION
## Description

Adds a single business-layer retry for transient malformed JSON/schema responses during multimodal sidecar analysis. The retry is scoped to VLM/EXTRACT responses that fail JSON conformance or required-field validation; non-transient pipeline errors continue to fail without retry.

## Related Issues

#XXXX

## Changes Made

- Added one JSON conformance retry for drawing, table, and equation analysis results before surfacing `MultimodalAnalysisError`.
- Bypasses malformed analysis cache entries on retry so a successful fresh response can overwrite the same cache key.
- Sends `response_format={"type": "json_object"}` with image VLM analysis calls to match table/equation analysis behavior. The drawing cache hash already included the `json_object` variant, so existing cache entries remain valid.
- Behavior fix: `PipelineCancelledException` raised mid-VLM/EXTRACT call is now re-raised as-is instead of being wrapped into `MultimodalAnalysisError` by the generic `except Exception` handler. Previously a user cancel during a model call would land a `status="failure"` marker on the sidecar instead of `status="cancelled"`.
- The retry warning log includes a truncated (200-char) snippet of the malformed response to aid diagnosing persistently bad model output.
- Added regression tests for transient VLM JSON recovery, repeated VLM JSON failure, table EXTRACT schema retry, and malformed-cache bypass with same-key overwrite.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Local validation:

- `./scripts/test.sh tests/pipeline/test_pipeline_analyze_multimodal.py`
- `./scripts/test.sh tests/pipeline/test_pipeline_release_closure.py -k analyze`
- `pre-commit run ruff-format ruff --files lightrag/pipeline.py tests/pipeline/test_pipeline_analyze_multimodal.py`
