### PR TITLE
feat(tools): add offline VDB rebuild for vector drift recovery

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -628,6 +628,410 @@ _PROVIDER_LOG_LABELS = {
 }
 
 
+def create_optimized_embedding_function(
+    config_cache: LLMConfigCache,
+    binding,
+    model,
+    host,
+    api_key,
+    args,
+    document_prefix=None,
+    query_prefix=None,
+) -> EmbeddingFunc:
+    """
+    Create optimized embedding function and return an EmbeddingFunc instance
+    with proper max_token_size inheritance from provider defaults.
+
+    This function:
+    1. Imports the provider embedding function
+    2. Extracts max_token_size and embedding_dim from provider if it's an EmbeddingFunc
+    3. Creates an optimized wrapper that calls the underlying function directly (avoiding double-wrapping)
+    4. Returns a properly configured EmbeddingFunc instance
+
+    Configuration Rules:
+    - When EMBEDDING_MODEL is not set: Uses provider's default model and dimension
+      (e.g., jina-embeddings-v4 with 2048 dims, text-embedding-3-small with 1536 dims)
+    - When EMBEDDING_MODEL is set to a custom model: User MUST also set EMBEDDING_DIM
+      to match the custom model's dimension (e.g., for jina-embeddings-v3, set EMBEDDING_DIM=1024)
+
+    Note: The embedding_dim parameter is automatically injected by EmbeddingFunc wrapper
+    when send_dimensions=True (enabled for Jina and Gemini bindings). This wrapper calls
+    the underlying provider function directly (.func) to avoid double-wrapping, so we must
+    explicitly pass embedding_dim to the provider's underlying function.
+    """
+
+    # Step 1: Import provider function and extract default attributes
+    provider_func = None
+    provider_max_token_size = None
+    provider_embedding_dim = None
+    provider_supports_asymmetric = False
+
+    try:
+        if binding == "openai":
+            from lightrag.llm.openai import openai_embed
+
+            provider_func = openai_embed
+        elif binding == "ollama":
+            from lightrag.llm.ollama import ollama_embed
+
+            provider_func = ollama_embed
+        elif binding == "gemini":
+            from lightrag.llm.gemini import gemini_embed
+
+            provider_func = gemini_embed
+        elif binding == "jina":
+            from lightrag.llm.jina import jina_embed
+
+            provider_func = jina_embed
+        elif binding == "azure_openai":
+            from lightrag.llm.azure_openai import azure_openai_embed
+
+            provider_func = azure_openai_embed
+        elif binding == "bedrock":
+            from lightrag.llm.bedrock import bedrock_embed
+
+            provider_func = bedrock_embed
+        elif binding == "lollms":
+            from lightrag.llm.lollms import lollms_embed
+
+            provider_func = lollms_embed
+        elif binding == "voyageai":
+            from lightrag.llm.voyageai import voyageai_embed
+
+            provider_func = voyageai_embed
+        # Extract attributes if provider is an EmbeddingFunc
+        if provider_func and isinstance(provider_func, EmbeddingFunc):
+            provider_max_token_size = provider_func.max_token_size
+            provider_embedding_dim = provider_func.embedding_dim
+            provider_supports_asymmetric = provider_func.supports_asymmetric
+            logger.debug(
+                f"Extracted from {binding} provider: "
+                f"max_token_size={provider_max_token_size}, "
+                f"embedding_dim={provider_embedding_dim}, "
+                f"supports_asymmetric={provider_supports_asymmetric}"
+            )
+    except ImportError as e:
+        logger.warning(f"Could not import provider function for {binding}: {e}")
+
+    # Step 2: Apply priority (user config > provider default)
+    # For max_token_size: explicit env var > provider default > None
+    final_max_token_size = args.embedding_token_limit or provider_max_token_size
+    # For embedding_dim: user config (always has value) takes priority
+    # Only use provider default if user config is explicitly None (which shouldn't happen)
+    final_embedding_dim = (
+        args.embedding_dim if args.embedding_dim else provider_embedding_dim
+    )
+    # Asymmetric embedding is explicit opt-in only. Provider-specific
+    # validation decides whether task parameters or prefixes are required.
+    asymmetric_opt_in = resolve_asymmetric_embedding_opt_in(
+        binding=binding,
+        embedding_asymmetric=args.embedding_asymmetric,
+        embedding_asymmetric_configured=args.embedding_asymmetric_configured,
+        query_prefix=query_prefix,
+        document_prefix=document_prefix,
+        query_prefix_configured=args.embedding_query_prefix_configured,
+        document_prefix_configured=args.embedding_document_prefix_configured,
+    )
+
+    # Step 3: Create optimized embedding function (calls underlying function directly)
+    # Note: When model is None, each binding will use its own default model
+    async def optimized_embedding_function(
+        texts, embedding_dim=None, context="document"
+    ):
+        try:
+            if binding == "lollms":
+                from lightrag.llm.lollms import lollms_embed
+
+                # Get real function, skip EmbeddingFunc wrapper if present
+                actual_func = (
+                    lollms_embed.func
+                    if isinstance(lollms_embed, EmbeddingFunc)
+                    else lollms_embed
+                )
+                # lollms embed_model is not used (server uses configured vectorizer)
+                # Only pass base_url and api_key
+                return await actual_func(texts, base_url=host, api_key=api_key)
+            elif binding == "ollama":
+                from lightrag.llm.ollama import ollama_embed
+
+                # Get real function, skip EmbeddingFunc wrapper if present
+                actual_func = (
+                    ollama_embed.func
+                    if isinstance(ollama_embed, EmbeddingFunc)
+                    else ollama_embed
+                )
+
+                # Use pre-processed configuration if available
+                if config_cache.ollama_embedding_options is not None:
+                    ollama_options = config_cache.ollama_embedding_options
+                else:
+                    from lightrag.llm.binding_options import OllamaEmbeddingOptions
+
+                    ollama_options = OllamaEmbeddingOptions.options_dict(args)
+
+                # Pass embed_model only if provided, let function use its default (bge-m3:latest)
+                kwargs = {
+                    "texts": texts,
+                    "host": host,
+                    "api_key": api_key,
+                    "options": ollama_options,
+                }
+                if provider_supports_asymmetric and asymmetric_opt_in:
+                    kwargs["context"] = context
+                    if query_prefix:
+                        kwargs["query_prefix"] = query_prefix
+                    if document_prefix:
+                        kwargs["document_prefix"] = document_prefix
+                if model:
+                    kwargs["embed_model"] = model
+                return await actual_func(**kwargs)
+            elif binding == "azure_openai":
+                from lightrag.llm.azure_openai import azure_openai_embed
+
+                actual_func = (
+                    azure_openai_embed.func
+                    if isinstance(azure_openai_embed, EmbeddingFunc)
+                    else azure_openai_embed
+                )
+                # Pass model only if provided, let function use its default otherwise
+                kwargs = {
+                    "texts": texts,
+                    "api_key": api_key,
+                    "embedding_dim": embedding_dim,
+                }
+                if model:
+                    kwargs["model"] = model
+                if provider_supports_asymmetric and asymmetric_opt_in:
+                    kwargs["context"] = context
+                    if query_prefix:
+                        kwargs["query_prefix"] = query_prefix
+                    if document_prefix:
+                        kwargs["document_prefix"] = document_prefix
+                return await actual_func(**kwargs)
+            elif binding == "bedrock":
+                from lightrag.llm.bedrock import bedrock_embed
+
+                actual_func = (
+                    bedrock_embed.func
+                    if isinstance(bedrock_embed, EmbeddingFunc)
+                    else bedrock_embed
+                )
+                # Pass model only if provided, let function use its default otherwise
+                kwargs = {
+                    "texts": texts,
+                    "aws_region": getattr(args, "aws_region", None),
+                    "aws_access_key_id": getattr(args, "aws_access_key_id", None),
+                    "aws_secret_access_key": getattr(
+                        args, "aws_secret_access_key", None
+                    ),
+                    "aws_session_token": getattr(args, "aws_session_token", None),
+                }
+                if host is not None:
+                    kwargs["endpoint_url"] = host
+                if model:
+                    kwargs["model"] = model
+                return await actual_func(**kwargs)
+            elif binding == "jina":
+                from lightrag.llm.jina import jina_embed
+
+                actual_func = (
+                    jina_embed.func
+                    if isinstance(jina_embed, EmbeddingFunc)
+                    else jina_embed
+                )
+                # Pass model only if provided, let function use its default (jina-embeddings-v4)
+                kwargs = {
+                    "texts": texts,
+                    "embedding_dim": embedding_dim,
+                    "base_url": host,
+                    "api_key": api_key,
+                }
+                if model:
+                    kwargs["model"] = model
+                if provider_supports_asymmetric and asymmetric_opt_in:
+                    kwargs["context"] = context
+                    kwargs["task"] = None
+                return await actual_func(**kwargs)
+            elif binding == "gemini":
+                from lightrag.llm.gemini import gemini_embed
+
+                actual_func = (
+                    gemini_embed.func
+                    if isinstance(gemini_embed, EmbeddingFunc)
+                    else gemini_embed
+                )
+
+                # Use pre-processed configuration if available
+                if config_cache.gemini_embedding_options is not None:
+                    gemini_options = config_cache.gemini_embedding_options
+                else:
+                    from lightrag.llm.binding_options import GeminiEmbeddingOptions
+
+                    gemini_options = GeminiEmbeddingOptions.options_dict(args)
+                # Pass model only if provided, let function use its default (gemini-embedding-001)
+                kwargs = {
+                    "texts": texts,
+                    "base_url": host,
+                    "api_key": api_key,
+                    "embedding_dim": embedding_dim,
+                }
+                if model:
+                    kwargs["model"] = model
+                task_type = gemini_options.get("task_type")
+                if task_type is not None:
+                    kwargs["task_type"] = task_type
+                if provider_supports_asymmetric and asymmetric_opt_in:
+                    kwargs["context"] = context
+                return await actual_func(**kwargs)
+            elif binding == "voyageai":
+                from lightrag.llm.voyageai import voyageai_embed
+
+                actual_func = (
+                    voyageai_embed.func
+                    if isinstance(voyageai_embed, EmbeddingFunc)
+                    else voyageai_embed
+                )
+                kwargs = {
+                    "texts": texts,
+                    "api_key": api_key,
+                    "embedding_dim": embedding_dim,
+                }
+                if model:
+                    kwargs["model"] = model
+                if provider_supports_asymmetric and asymmetric_opt_in:
+                    kwargs["context"] = context
+                return await actual_func(**kwargs)
+            else:  # openai and compatible
+                from lightrag.llm.openai import openai_embed
+
+                actual_func = (
+                    openai_embed.func
+                    if isinstance(openai_embed, EmbeddingFunc)
+                    else openai_embed
+                )
+                # Pass model only if provided, let function use its default (text-embedding-3-small)
+                kwargs = {
+                    "texts": texts,
+                    "base_url": host,
+                    "api_key": api_key,
+                    "embedding_dim": embedding_dim,
+                }
+                if model:
+                    kwargs["model"] = model
+                if provider_supports_asymmetric and asymmetric_opt_in:
+                    kwargs["context"] = context
+                    if query_prefix:
+                        kwargs["query_prefix"] = query_prefix
+                    if document_prefix:
+                        kwargs["document_prefix"] = document_prefix
+                return await actual_func(**kwargs)
+        except ImportError as e:
+            raise Exception(f"Failed to import {binding} embedding: {e}")
+
+    # Step 4: Wrap in EmbeddingFunc and return
+    embedding_func_instance = EmbeddingFunc(
+        embedding_dim=final_embedding_dim,
+        func=optimized_embedding_function,
+        max_token_size=final_max_token_size,
+        send_dimensions=False,  # Will be set later based on binding requirements
+        model_name=model,
+        supports_asymmetric=provider_supports_asymmetric and asymmetric_opt_in,
+    )
+
+    # Log final embedding configuration. Only include prefix info when
+    # prefixes will actually be applied (prefix-based asymmetric mode).
+    prefix_info = ""
+    if (
+        asymmetric_opt_in
+        and binding in PREFIX_ASYMMETRIC_EMBEDDING_BINDINGS
+        and (document_prefix or query_prefix)
+    ):
+        prefix_info = f" document_prefix={repr(document_prefix)} query_prefix={repr(query_prefix)}"
+    logger.info(
+        f"Embedding config: binding={binding} model={model} "
+        f"embedding_dim={final_embedding_dim} max_token_size={final_max_token_size}{prefix_info}"
+    )
+
+    return embedding_func_instance
+
+
+def create_embedding_function_from_args(
+    args, config_cache: LLMConfigCache | None = None
+) -> EmbeddingFunc:
+    """Build the fully configured EmbeddingFunc used by the LightRAG server.
+
+    Combines the provider embedding factory with the send_dimensions policy
+    so that offline tools (e.g. lightrag-rebuild-vdb) can embed in exactly
+    the same vector space as the running server.
+    """
+    import inspect
+
+    if config_cache is None:
+        config_cache = LLMConfigCache(args)
+
+    # Create the EmbeddingFunc instance (now returns complete EmbeddingFunc with max_token_size)
+    embedding_func = create_optimized_embedding_function(
+        config_cache=config_cache,
+        binding=args.embedding_binding,
+        model=args.embedding_model,
+        host=args.embedding_binding_host,
+        api_key=None
+        if args.embedding_binding == "bedrock"
+        else args.embedding_binding_api_key,
+        args=args,
+        document_prefix=args.embedding_document_prefix,
+        query_prefix=args.embedding_query_prefix,
+    )
+
+    # Get embedding_send_dim from centralized configuration
+    embedding_send_dim = args.embedding_send_dim
+
+    # Check if the underlying function signature has embedding_dim parameter
+    sig = inspect.signature(embedding_func.func)
+    has_embedding_dim_param = "embedding_dim" in sig.parameters
+
+    # Determine send_dimensions value based on binding type
+    # Jina and Gemini REQUIRE dimension parameter (forced to True)
+    # OpenAI and others: controlled by EMBEDDING_SEND_DIM environment variable
+    if args.embedding_binding in ["jina", "gemini"]:
+        # Jina and Gemini APIs require dimension parameter - always send it
+        send_dimensions = has_embedding_dim_param
+        dimension_control = f"forced by {args.embedding_binding.title()} API"
+    else:
+        # For OpenAI and other bindings, respect EMBEDDING_SEND_DIM setting
+        send_dimensions = embedding_send_dim and has_embedding_dim_param
+        if send_dimensions or not embedding_send_dim:
+            dimension_control = "by env var"
+        else:
+            dimension_control = "by not hasparam"
+
+    # Set send_dimensions on the EmbeddingFunc instance
+    embedding_func.send_dimensions = send_dimensions
+
+    logger.info(
+        f"Send embedding dimension: {send_dimensions} {dimension_control} "
+        f"(dimensions={embedding_func.embedding_dim}, has_param={has_embedding_dim_param}, "
+        f"binding={args.embedding_binding})"
+    )
+
+    # Log max_token_size source
+    if embedding_func.max_token_size:
+        source = (
+            "env variable"
+            if args.embedding_token_limit
+            else f"{args.embedding_binding} provider default"
+        )
+        logger.info(
+            f"Embedding max_token_size: {embedding_func.max_token_size} (from {source})"
+        )
+    else:
+        logger.info(
+            "Embedding max_token_size: None (Embedding token limit is disabled)."
+        )
+
+    return embedding_func
+
+
 def _provider_log_label(binding: Any) -> str:
     binding_name = str(binding)
     return _PROVIDER_LOG_LABELS.get(
@@ -1472,332 +1876,6 @@ def create_app(args):
         _ = override_meta
         return {}
 
-    def create_optimized_embedding_function(
-        config_cache: LLMConfigCache,
-        binding,
-        model,
-        host,
-        api_key,
-        args,
-        document_prefix=None,
-        query_prefix=None,
-    ) -> EmbeddingFunc:
-        """
-        Create optimized embedding function and return an EmbeddingFunc instance
-        with proper max_token_size inheritance from provider defaults.
-
-        This function:
-        1. Imports the provider embedding function
-        2. Extracts max_token_size and embedding_dim from provider if it's an EmbeddingFunc
-        3. Creates an optimized wrapper that calls the underlying function directly (avoiding double-wrapping)
-        4. Returns a properly configured EmbeddingFunc instance
-
-        Configuration Rules:
-        - When EMBEDDING_MODEL is not set: Uses provider's default model and dimension
-          (e.g., jina-embeddings-v4 with 2048 dims, text-embedding-3-small with 1536 dims)
-        - When EMBEDDING_MODEL is set to a custom model: User MUST also set EMBEDDING_DIM
-          to match the custom model's dimension (e.g., for jina-embeddings-v3, set EMBEDDING_DIM=1024)
-
-        Note: The embedding_dim parameter is automatically injected by EmbeddingFunc wrapper
-        when send_dimensions=True (enabled for Jina and Gemini bindings). This wrapper calls
-        the underlying provider function directly (.func) to avoid double-wrapping, so we must
-        explicitly pass embedding_dim to the provider's underlying function.
-        """
-
-        # Step 1: Import provider function and extract default attributes
-        provider_func = None
-        provider_max_token_size = None
-        provider_embedding_dim = None
-        provider_supports_asymmetric = False
-
-        try:
-            if binding == "openai":
-                from lightrag.llm.openai import openai_embed
-
-                provider_func = openai_embed
-            elif binding == "ollama":
-                from lightrag.llm.ollama import ollama_embed
-
-                provider_func = ollama_embed
-            elif binding == "gemini":
-                from lightrag.llm.gemini import gemini_embed
-
-                provider_func = gemini_embed
-            elif binding == "jina":
-                from lightrag.llm.jina import jina_embed
-
-                provider_func = jina_embed
-            elif binding == "azure_openai":
-                from lightrag.llm.azure_openai import azure_openai_embed
-
-                provider_func = azure_openai_embed
-            elif binding == "bedrock":
-                from lightrag.llm.bedrock import bedrock_embed
-
-                provider_func = bedrock_embed
-            elif binding == "lollms":
-                from lightrag.llm.lollms import lollms_embed
-
-                provider_func = lollms_embed
-            elif binding == "voyageai":
-                from lightrag.llm.voyageai import voyageai_embed
-
-                provider_func = voyageai_embed
-            # Extract attributes if provider is an EmbeddingFunc
-            if provider_func and isinstance(provider_func, EmbeddingFunc):
-                provider_max_token_size = provider_func.max_token_size
-                provider_embedding_dim = provider_func.embedding_dim
-                provider_supports_asymmetric = provider_func.supports_asymmetric
-                logger.debug(
-                    f"Extracted from {binding} provider: "
-                    f"max_token_size={provider_max_token_size}, "
-                    f"embedding_dim={provider_embedding_dim}, "
-                    f"supports_asymmetric={provider_supports_asymmetric}"
-                )
-        except ImportError as e:
-            logger.warning(f"Could not import provider function for {binding}: {e}")
-
-        # Step 2: Apply priority (user config > provider default)
-        # For max_token_size: explicit env var > provider default > None
-        final_max_token_size = args.embedding_token_limit or provider_max_token_size
-        # For embedding_dim: user config (always has value) takes priority
-        # Only use provider default if user config is explicitly None (which shouldn't happen)
-        final_embedding_dim = (
-            args.embedding_dim if args.embedding_dim else provider_embedding_dim
-        )
-        # Asymmetric embedding is explicit opt-in only. Provider-specific
-        # validation decides whether task parameters or prefixes are required.
-        asymmetric_opt_in = resolve_asymmetric_embedding_opt_in(
-            binding=binding,
-            embedding_asymmetric=args.embedding_asymmetric,
-            embedding_asymmetric_configured=args.embedding_asymmetric_configured,
-            query_prefix=query_prefix,
-            document_prefix=document_prefix,
-            query_prefix_configured=args.embedding_query_prefix_configured,
-            document_prefix_configured=args.embedding_document_prefix_configured,
-        )
-
-        # Step 3: Create optimized embedding function (calls underlying function directly)
-        # Note: When model is None, each binding will use its own default model
-        async def optimized_embedding_function(
-            texts, embedding_dim=None, context="document"
-        ):
-            try:
-                if binding == "lollms":
-                    from lightrag.llm.lollms import lollms_embed
-
-                    # Get real function, skip EmbeddingFunc wrapper if present
-                    actual_func = (
-                        lollms_embed.func
-                        if isinstance(lollms_embed, EmbeddingFunc)
-                        else lollms_embed
-                    )
-                    # lollms embed_model is not used (server uses configured vectorizer)
-                    # Only pass base_url and api_key
-                    return await actual_func(texts, base_url=host, api_key=api_key)
-                elif binding == "ollama":
-                    from lightrag.llm.ollama import ollama_embed
-
-                    # Get real function, skip EmbeddingFunc wrapper if present
-                    actual_func = (
-                        ollama_embed.func
-                        if isinstance(ollama_embed, EmbeddingFunc)
-                        else ollama_embed
-                    )
-
-                    # Use pre-processed configuration if available
-                    if config_cache.ollama_embedding_options is not None:
-                        ollama_options = config_cache.ollama_embedding_options
-                    else:
-                        from lightrag.llm.binding_options import OllamaEmbeddingOptions
-
-                        ollama_options = OllamaEmbeddingOptions.options_dict(args)
-
-                    # Pass embed_model only if provided, let function use its default (bge-m3:latest)
-                    kwargs = {
-                        "texts": texts,
-                        "host": host,
-                        "api_key": api_key,
-                        "options": ollama_options,
-                    }
-                    if provider_supports_asymmetric and asymmetric_opt_in:
-                        kwargs["context"] = context
-                        if query_prefix:
-                            kwargs["query_prefix"] = query_prefix
-                        if document_prefix:
-                            kwargs["document_prefix"] = document_prefix
-                    if model:
-                        kwargs["embed_model"] = model
-                    return await actual_func(**kwargs)
-                elif binding == "azure_openai":
-                    from lightrag.llm.azure_openai import azure_openai_embed
-
-                    actual_func = (
-                        azure_openai_embed.func
-                        if isinstance(azure_openai_embed, EmbeddingFunc)
-                        else azure_openai_embed
-                    )
-                    # Pass model only if provided, let function use its default otherwise
-                    kwargs = {
-                        "texts": texts,
-                        "api_key": api_key,
-                        "embedding_dim": embedding_dim,
-                    }
-                    if model:
-                        kwargs["model"] = model
-                    if provider_supports_asymmetric and asymmetric_opt_in:
-                        kwargs["context"] = context
-                        if query_prefix:
-                            kwargs["query_prefix"] = query_prefix
-                        if document_prefix:
-                            kwargs["document_prefix"] = document_prefix
-                    return await actual_func(**kwargs)
-                elif binding == "bedrock":
-                    from lightrag.llm.bedrock import bedrock_embed
-
-                    actual_func = (
-                        bedrock_embed.func
-                        if isinstance(bedrock_embed, EmbeddingFunc)
-                        else bedrock_embed
-                    )
-                    # Pass model only if provided, let function use its default otherwise
-                    kwargs = {
-                        "texts": texts,
-                        "aws_region": getattr(args, "aws_region", None),
-                        "aws_access_key_id": getattr(args, "aws_access_key_id", None),
-                        "aws_secret_access_key": getattr(
-                            args, "aws_secret_access_key", None
-                        ),
-                        "aws_session_token": getattr(args, "aws_session_token", None),
-                    }
-                    if host is not None:
-                        kwargs["endpoint_url"] = host
-                    if model:
-                        kwargs["model"] = model
-                    return await actual_func(**kwargs)
-                elif binding == "jina":
-                    from lightrag.llm.jina import jina_embed
-
-                    actual_func = (
-                        jina_embed.func
-                        if isinstance(jina_embed, EmbeddingFunc)
-                        else jina_embed
-                    )
-                    # Pass model only if provided, let function use its default (jina-embeddings-v4)
-                    kwargs = {
-                        "texts": texts,
-                        "embedding_dim": embedding_dim,
-                        "base_url": host,
-                        "api_key": api_key,
-                    }
-                    if model:
-                        kwargs["model"] = model
-                    if provider_supports_asymmetric and asymmetric_opt_in:
-                        kwargs["context"] = context
-                        kwargs["task"] = None
-                    return await actual_func(**kwargs)
-                elif binding == "gemini":
-                    from lightrag.llm.gemini import gemini_embed
-
-                    actual_func = (
-                        gemini_embed.func
-                        if isinstance(gemini_embed, EmbeddingFunc)
-                        else gemini_embed
-                    )
-
-                    # Use pre-processed configuration if available
-                    if config_cache.gemini_embedding_options is not None:
-                        gemini_options = config_cache.gemini_embedding_options
-                    else:
-                        from lightrag.llm.binding_options import GeminiEmbeddingOptions
-
-                        gemini_options = GeminiEmbeddingOptions.options_dict(args)
-                    # Pass model only if provided, let function use its default (gemini-embedding-001)
-                    kwargs = {
-                        "texts": texts,
-                        "base_url": host,
-                        "api_key": api_key,
-                        "embedding_dim": embedding_dim,
-                    }
-                    if model:
-                        kwargs["model"] = model
-                    task_type = gemini_options.get("task_type")
-                    if task_type is not None:
-                        kwargs["task_type"] = task_type
-                    if provider_supports_asymmetric and asymmetric_opt_in:
-                        kwargs["context"] = context
-                    return await actual_func(**kwargs)
-                elif binding == "voyageai":
-                    from lightrag.llm.voyageai import voyageai_embed
-
-                    actual_func = (
-                        voyageai_embed.func
-                        if isinstance(voyageai_embed, EmbeddingFunc)
-                        else voyageai_embed
-                    )
-                    kwargs = {
-                        "texts": texts,
-                        "api_key": api_key,
-                        "embedding_dim": embedding_dim,
-                    }
-                    if model:
-                        kwargs["model"] = model
-                    if provider_supports_asymmetric and asymmetric_opt_in:
-                        kwargs["context"] = context
-                    return await actual_func(**kwargs)
-                else:  # openai and compatible
-                    from lightrag.llm.openai import openai_embed
-
-                    actual_func = (
-                        openai_embed.func
-                        if isinstance(openai_embed, EmbeddingFunc)
-                        else openai_embed
-                    )
-                    # Pass model only if provided, let function use its default (text-embedding-3-small)
-                    kwargs = {
-                        "texts": texts,
-                        "base_url": host,
-                        "api_key": api_key,
-                        "embedding_dim": embedding_dim,
-                    }
-                    if model:
-                        kwargs["model"] = model
-                    if provider_supports_asymmetric and asymmetric_opt_in:
-                        kwargs["context"] = context
-                        if query_prefix:
-                            kwargs["query_prefix"] = query_prefix
-                        if document_prefix:
-                            kwargs["document_prefix"] = document_prefix
-                    return await actual_func(**kwargs)
-            except ImportError as e:
-                raise Exception(f"Failed to import {binding} embedding: {e}")
-
-        # Step 4: Wrap in EmbeddingFunc and return
-        embedding_func_instance = EmbeddingFunc(
-            embedding_dim=final_embedding_dim,
-            func=optimized_embedding_function,
-            max_token_size=final_max_token_size,
-            send_dimensions=False,  # Will be set later based on binding requirements
-            model_name=model,
-            supports_asymmetric=provider_supports_asymmetric and asymmetric_opt_in,
-        )
-
-        # Log final embedding configuration. Only include prefix info when
-        # prefixes will actually be applied (prefix-based asymmetric mode).
-        prefix_info = ""
-        if (
-            asymmetric_opt_in
-            and binding in PREFIX_ASYMMETRIC_EMBEDDING_BINDINGS
-            and (document_prefix or query_prefix)
-        ):
-            prefix_info = f" document_prefix={repr(document_prefix)} query_prefix={repr(query_prefix)}"
-        logger.info(
-            f"Embedding config: binding={binding} model={model} "
-            f"embedding_dim={final_embedding_dim} max_token_size={final_max_token_size}{prefix_info}"
-        )
-
-        return embedding_func_instance
-
     llm_timeout = args.llm_timeout
     embedding_timeout = args.embedding_timeout
 
@@ -1835,65 +1913,7 @@ def create_app(args):
     # Create embedding function with optimized configuration and max_token_size inheritance
     import inspect
 
-    # Create the EmbeddingFunc instance (now returns complete EmbeddingFunc with max_token_size)
-    embedding_func = create_optimized_embedding_function(
-        config_cache=config_cache,
-        binding=args.embedding_binding,
-        model=args.embedding_model,
-        host=args.embedding_binding_host,
-        api_key=None
-        if args.embedding_binding == "bedrock"
-        else args.embedding_binding_api_key,
-        args=args,
-        document_prefix=args.embedding_document_prefix,
-        query_prefix=args.embedding_query_prefix,
-    )
-
-    # Get embedding_send_dim from centralized configuration
-    embedding_send_dim = args.embedding_send_dim
-
-    # Check if the underlying function signature has embedding_dim parameter
-    sig = inspect.signature(embedding_func.func)
-    has_embedding_dim_param = "embedding_dim" in sig.parameters
-
-    # Determine send_dimensions value based on binding type
-    # Jina and Gemini REQUIRE dimension parameter (forced to True)
-    # OpenAI and others: controlled by EMBEDDING_SEND_DIM environment variable
-    if args.embedding_binding in ["jina", "gemini"]:
-        # Jina and Gemini APIs require dimension parameter - always send it
-        send_dimensions = has_embedding_dim_param
-        dimension_control = f"forced by {args.embedding_binding.title()} API"
-    else:
-        # For OpenAI and other bindings, respect EMBEDDING_SEND_DIM setting
-        send_dimensions = embedding_send_dim and has_embedding_dim_param
-        if send_dimensions or not embedding_send_dim:
-            dimension_control = "by env var"
-        else:
-            dimension_control = "by not hasparam"
-
-    # Set send_dimensions on the EmbeddingFunc instance
-    embedding_func.send_dimensions = send_dimensions
-
-    logger.info(
-        f"Send embedding dimension: {send_dimensions} {dimension_control} "
-        f"(dimensions={embedding_func.embedding_dim}, has_param={has_embedding_dim_param}, "
-        f"binding={args.embedding_binding})"
-    )
-
-    # Log max_token_size source
-    if embedding_func.max_token_size:
-        source = (
-            "env variable"
-            if args.embedding_token_limit
-            else f"{args.embedding_binding} provider default"
-        )
-        logger.info(
-            f"Embedding max_token_size: {embedding_func.max_token_size} (from {source})"
-        )
-    else:
-        logger.info(
-            "Embedding max_token_size: None (Embedding token limit is disabled)."
-        )
+    embedding_func = create_embedding_function_from_args(args, config_cache)
 
     # Configure rerank function based on args.rerank_bindingparameter
     rerank_model_func = None

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -1496,9 +1496,18 @@ class MongoGraphStorage(BaseGraphStorage):
 
     async def get_node(self, node_id: str) -> dict[str, str] | None:
         """
-        Return the full node document, or None if missing.
+        Return the node properties, or None if missing.
+
+        The Mongo-managed ``_id`` (which holds the entity name) is stripped so
+        the returned dict carries only node properties, matching the contract
+        honored by the other backends. Leaving it in lets callers that re-upsert
+        a fetched node (e.g. entity rename) push ``_id`` into ``$set``, which
+        MongoDB rejects as a modification of the immutable ``_id``.
         """
-        return await self.collection.find_one({"_id": node_id})
+        doc = await self.collection.find_one({"_id": node_id})
+        if doc is not None:
+            doc.pop("_id", None)
+        return doc
 
     async def get_edge(
         self, source_node_id: str, target_node_id: str
@@ -1506,9 +1515,15 @@ class MongoGraphStorage(BaseGraphStorage):
         # Canonical (edge_lo, edge_hi) point lookup served by the compound unique
         # index (see has_edge); the fail-fast migration guarantees the endpoints.
         edge_lo, edge_hi = _canonical_edge_endpoints(source_node_id, target_node_id)
-        return await self.edge_collection.find_one(
+        doc = await self.edge_collection.find_one(
             {"edge_lo": edge_lo, "edge_hi": edge_hi}
         )
+        if doc is not None:
+            # Strip the Mongo-managed ``_id`` so re-upserting a fetched edge
+            # (e.g. relation rewrite during entity rename) cannot push ``_id``
+            # into ``$set`` and trip the immutable-field error.
+            doc.pop("_id", None)
+        return doc
 
     async def get_node_edges(self, source_node_id: str) -> list[tuple[str, str]] | None:
         """
@@ -1539,7 +1554,8 @@ class MongoGraphStorage(BaseGraphStorage):
         result = {}
 
         async for doc in self.collection.find({"_id": {"$in": node_ids}}):
-            result[doc.get("_id")] = doc
+            node_id = doc.pop("_id")
+            result[node_id] = doc
         return result
 
     async def node_degrees_batch(self, node_ids: list[str]) -> dict[str, int]:

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -3156,7 +3156,6 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 if k
                 not in (
                     "_id",
-                    "entity_id",
                     "source_ids",
                     "connected_edges",
                     "edge_count",

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -4438,18 +4438,18 @@ class PGVectorStorage(BaseVectorStorage):
     async def get_by_id(self, id: str) -> dict[str, Any] | None:
         """Get vector data by its ID with read-your-writes against the buffer.
 
-        ``__vector__`` and ``__id__`` are stripped from buffered results to
-        match the other vector backends; callers needing embeddings must use
-        ``get_vectors_by_ids``.
+        The embedding column is stripped from BOTH the buffered and the
+        SQL-fallback result (``__vector__``/``__id__`` from the buffer,
+        ``content_vector`` from the row) so the shapes match each other and
+        the other vector backends. The raw ``content_vector`` is a pgvector
+        value that the asyncpg codec returns as a numpy array, which is not
+        JSON-serializable and would break callers that return this dict in an
+        API response (e.g. ``/graph/entity/edit``). Callers needing embeddings
+        must use ``get_vectors_by_ids``.
 
         Response shape:
-            Buffered hits return ``{"id", "content", <payload fields>,
-            "created_at"}`` only — no embedding column. SQL-fallback hits
-            return the full row including ``content_vector`` (and any
-            namespace-specific columns such as ``entity_name`` or
-            ``source_id``). Callers that only read documented payload
-            fields (``content``, ``id``, ``created_at``) are unaffected;
-            consumers iterating over all keys must tolerate both shapes.
+            ``{"id", "content", <payload fields>, "created_at"}`` — no
+            embedding column, from either path.
         """
         async with self._flush_lock:
             if id in self._pending_vector_deletes:
@@ -4472,7 +4472,11 @@ class PGVectorStorage(BaseVectorStorage):
         try:
             result = await self.db.query(query, [self.workspace, id])
             if result:
-                return dict(result)
+                row = dict(result)
+                # Drop the embedding column: it is a numpy array (pgvector
+                # codec) and not JSON-serializable; matches the buffered shape.
+                row.pop("content_vector", None)
+                return row
             return None
         except Exception as e:
             logger.error(
@@ -4528,6 +4532,9 @@ class PGVectorStorage(BaseVectorStorage):
                     if record is None:
                         continue
                     record_dict = dict(record)
+                    # Drop the (numpy / non-JSON-serializable) embedding column
+                    # so the SQL shape matches the buffered shape.
+                    record_dict.pop("content_vector", None)
                     row_id = record_dict.get("id")
                     if row_id is not None:
                         id_map[str(row_id)] = record_dict

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -3974,7 +3974,24 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     async def get_entity_info(
         self, entity_name: str, include_vector_data: bool = False
     ) -> dict[str, str | None | dict[str, str]]:
-        """Get detailed information of an entity"""
+        """Get detailed information of an entity.
+
+        Args:
+            entity_name: Name of the entity to look up.
+            include_vector_data: DEPRECATED. Attaches a ``vector_data`` field
+                read from the entity vector store. The vector store no longer
+                returns the embedding, so this payload is derived from the
+                graph node (the authoritative source) and duplicates
+                ``graph_data``; the only signal it adds is whether a VDB record
+                exists at all. No LightRAG code path sets this — it is kept for
+                backward compatibility only and may be removed in a future
+                release. For graph/VDB consistency, use the offline
+                ``lightrag-rebuild-vdb`` check instead.
+
+        Returns:
+            ``{"entity_name", "source_id", "graph_data"}`` (plus a redundant
+            ``"vector_data"`` when ``include_vector_data`` is True).
+        """
         from lightrag.utils_graph import get_entity_info
 
         return await get_entity_info(
@@ -3987,7 +4004,25 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     async def get_relation_info(
         self, src_entity: str, tgt_entity: str, include_vector_data: bool = False
     ) -> dict[str, str | None | dict[str, str]]:
-        """Get detailed information of a relationship"""
+        """Get detailed information of a relationship.
+
+        Args:
+            src_entity: Source entity name.
+            tgt_entity: Target entity name.
+            include_vector_data: DEPRECATED. Attaches a ``vector_data`` field
+                read from the relationship vector store. The vector store no
+                longer returns the embedding, so this payload is derived from
+                the graph edge (the authoritative source) and duplicates
+                ``graph_data``; the only signal it adds is whether a VDB record
+                exists at all. No LightRAG code path sets this — it is kept for
+                backward compatibility only and may be removed in a future
+                release. For graph/VDB consistency, use the offline
+                ``lightrag-rebuild-vdb`` check instead.
+
+        Returns:
+            ``{"src_entity", "tgt_entity", "source_id", "graph_data"}`` (plus a
+            redundant ``"vector_data"`` when ``include_vector_data`` is True).
+        """
         from lightrag.utils_graph import get_relation_info
 
         return await get_relation_info(

--- a/lightrag/tools/README_REBUILD_VDB.md
+++ b/lightrag/tools/README_REBUILD_VDB.md
@@ -1,0 +1,99 @@
+# Offline Vector Storage (VDB) Rebuild Tool
+
+`lightrag-rebuild-vdb` restores consistency between LightRAG's authoritative
+data sources and its vector storages by dropping each vector storage and
+rebuilding it from scratch:
+
+| Vector storage | Authoritative source |
+|---|---|
+| `entities_vdb` | graph nodes |
+| `relationships_vdb` | graph edges |
+| `chunks_vdb` | `text_chunks` KV store |
+
+## When do I need this?
+
+LightRAG performs multi-step writes (graph + vector storage). If a vector
+storage write fails at runtime — embedder outage, network timeout, context
+overflow on a high-degree entity — the graph and the vector storage drift
+apart. The most common symptom is the edge-count drift reported in issue
+[#2917](https://github.com/HKUDS/LightRAG/issues/2917): graph edges with no
+vector counterpart, so `local`/`hybrid` queries miss relations that exist in
+the graph.
+
+Since v(next), `amerge_entities` raises `VectorStorageConsistencyError` when
+this happens, with a pointer to this tool. No data is lost in this situation:
+the graph and the `text_chunks` KV store hold everything needed to rebuild
+the vectors.
+
+A full drop + rebuild also clears *reverse* orphans (records present in the
+vector storage but absent from the graph), which incremental repair cannot
+reliably do.
+
+## Usage
+
+```bash
+# Stop the LightRAG Server first!
+lightrag-rebuild-vdb
+# or
+python -m lightrag.tools.rebuild_vdb
+```
+
+The tool reads the same `.env` / environment configuration as the server
+(`LIGHTRAG_GRAPH_STORAGE`, `LIGHTRAG_VECTOR_STORAGE`, `LIGHTRAG_KV_STORAGE`,
+`WORKSPACE`, `WORKING_DIR`, `EMBEDDING_*`, backend connection settings) and
+builds its embedding function through the exact factory the server uses —
+run it with the same `.env` so rebuilt vectors live in the same embedding
+space the server queries against.
+
+Menu options:
+
+1. **Consistency check (read-only)** — probes every graph entity/relation
+   for a vector counterpart and reports what is missing. Run this first to
+   decide whether a rebuild is worth the embedding cost. The check covers
+   the graph → VDB direction only; reverse orphans can only be cleared by a
+   full rebuild. Legacy reverse-order relation ids (from old custom-KG
+   imports) are recognized and not misreported as missing.
+2. **Rebuild entities + relationships VDB** — sufficient for the #2917
+   merge-failure scenario.
+3. **Rebuild chunks VDB**.
+4. **Rebuild ALL vector storages**.
+
+## Important notes
+
+- **Stop the server first.** The tool drops and rewrites vector storages;
+  concurrent writers (any backend, not just file-based ones) can corrupt
+  data or lose updates.
+- **Embedding cost.** A rebuild re-embeds every affected record. On large
+  datasets this means real API cost and time. Use the check mode first, and
+  rebuild only the storages that need it.
+- **Idempotent / crash-safe.** Sources (graph, `text_chunks`) are never
+  modified. If the tool crashes between drop and rewrite, just re-run it.
+- **`__created_at__` reset.** Backends that store creation timestamps in
+  vector records (nano, faiss) will show fresh timestamps after a rebuild.
+  No query logic depends on them.
+- **Custom-KG placeholder entities.** `UNKNOWN` placeholder nodes created by
+  `ainsert_custom_kg` are rebuilt faithfully from the graph; they may gain a
+  vector record they previously lacked (improving their retrievability).
+- **Chunk enumeration is backend-specific.** `BaseKVStorage` has no key
+  enumeration API, so the tool scans each KV backend directly (JsonKV,
+  Redis, PostgreSQL, MongoDB, OpenSearch). When a new KV backend is added,
+  `enumerate_kv_keys()` in `rebuild_vdb.py` must be extended.
+
+## Library usage
+
+The core rebuild/check functions are plain async functions that accept your
+own initialized storage instances:
+
+```python
+from lightrag.tools.rebuild_vdb import (
+    check_vdb_consistency,
+    rebuild_chunks_vdb,
+    rebuild_entities_vdb,
+    rebuild_relationships_vdb,
+)
+
+report = await check_vdb_consistency(graph, entities_vdb, relationships_vdb)
+if not report["consistent"]:
+    await rebuild_entities_vdb(graph, entities_vdb, global_config)
+    await rebuild_relationships_vdb(graph, relationships_vdb, global_config)
+```

--- a/lightrag/tools/README_REBUILD_VDB.md
+++ b/lightrag/tools/README_REBUILD_VDB.md
@@ -29,6 +29,15 @@ A full drop + rebuild also clears *reverse* orphans (records present in the
 vector storage but absent from the graph), which incremental repair cannot
 reliably do.
 
+You can also use this tool after changing the embedding model or embedding
+dimension. Existing vector records were generated in the old embedding space
+(and some vector backends bind collections/tables to the configured dimension),
+so run the tool with the updated `.env` and choose **Rebuild ALL vector
+storages** to regenerate `entities_vdb`, `relationships_vdb`, and `chunks_vdb`
+from the authoritative graph/KV sources. The consistency check is not enough
+for this case because it only detects missing graph → VDB records, not vectors
+that exist but were embedded with a previous model or dimension.
+
 ## Usage
 
 ```bash
@@ -64,13 +73,18 @@ Menu options:
 2. **Rebuild entities + relationships VDB** — sufficient for the #2917
    merge-failure scenario.
 3. **Rebuild chunks VDB**.
-4. **Rebuild ALL vector storages**.
+4. **Rebuild ALL vector storages** — use this after changing the embedding
+   model or embedding dimension.
 
 ## Important notes
 
 - **Stop the server first.** The tool drops and rewrites vector storages;
   concurrent writers (any backend, not just file-based ones) can corrupt
   data or lose updates.
+- **Embedding model/dimension changes.** Run the tool with the new embedding
+  configuration and rebuild all vector storages. A consistency check can still
+  pass when every vector record exists but was created with the old embedding
+  model or dimension.
 - **Embedding cost.** A rebuild re-embeds every affected record. On large
   datasets this means real API cost and time. Use the check mode first, and
   rebuild only the storages that need it.

--- a/lightrag/tools/README_REBUILD_VDB.md
+++ b/lightrag/tools/README_REBUILD_VDB.md
@@ -53,10 +53,14 @@ Menu options:
    the graph → VDB direction only; reverse orphans can only be cleared by a
    full rebuild. Legacy reverse-order relation ids (from old custom-KG
    imports) are recognized and not misreported as missing. The check issues
-   read queries only and never drops or rewrites vector data — but it is not
-   strictly side-effect-free: connecting initializes each storage, and some
-   backends (e.g. Qdrant) create an empty collection or payload index on
-   first connect. It never drops, rewrites, or deletes existing records.
+   read queries only and does not run a rebuild (no drop + re-embed). It is
+   **not** strictly side-effect-free, though: the tool initializes every
+   storage on startup — exactly as the server does — and for some backends
+   that includes schema/DDL setup and one-time legacy migrations (e.g. Qdrant
+   upserts into the new collection, PostgreSQL batch-inserts into the new
+   table, Milvus may create a temp collection and drop/rename the original).
+   Treat running the tool — even just for a check — like starting the server:
+   stop other writers first.
 2. **Rebuild entities + relationships VDB** — sufficient for the #2917
    merge-failure scenario.
 3. **Rebuild chunks VDB**.

--- a/lightrag/tools/README_REBUILD_VDB.md
+++ b/lightrag/tools/README_REBUILD_VDB.md
@@ -47,12 +47,16 @@ space the server queries against.
 
 Menu options:
 
-1. **Consistency check (read-only)** — probes every graph entity/relation
+1. **Consistency check (diagnose only)** — probes every graph entity/relation
    for a vector counterpart and reports what is missing. Run this first to
    decide whether a rebuild is worth the embedding cost. The check covers
    the graph → VDB direction only; reverse orphans can only be cleared by a
    full rebuild. Legacy reverse-order relation ids (from old custom-KG
-   imports) are recognized and not misreported as missing.
+   imports) are recognized and not misreported as missing. The check issues
+   read queries only and never drops or rewrites vector data — but it is not
+   strictly side-effect-free: connecting initializes each storage, and some
+   backends (e.g. Qdrant) create an empty collection or payload index on
+   first connect. It never drops, rewrites, or deletes existing records.
 2. **Rebuild entities + relationships VDB** — sufficient for the #2917
    merge-failure scenario.
 3. **Rebuild chunks VDB**.

--- a/lightrag/tools/rebuild_vdb.py
+++ b/lightrag/tools/rebuild_vdb.py
@@ -612,6 +612,15 @@ class RebuildTool:
     def build_global_config(self) -> Dict[str, Any]:
         global_config: Dict[str, Any] = {
             "working_dir": os.getenv("WORKING_DIR", "./rag_storage"),
+            # Backend selection, mirroring LightRAG._build_global_config. PG
+            # storages derive enable_vector from global_config["vector_storage"]
+            # (ClientManager.get_config defaults enable_vector=True when it is
+            # absent), so a legal mixed config like PGGraphStorage +
+            # QdrantVectorDBStorage would otherwise make the tool wrongly try to
+            # initialize pgvector. Keep all three names for parity.
+            "kv_storage": self.storage_names["kv"],
+            "vector_storage": self.storage_names["vector"],
+            "graph_storage": self.storage_names["graph"],
             "embedding_batch_num": get_env_value(
                 "EMBEDDING_BATCH_NUM", DEFAULT_EMBEDDING_BATCH_NUM, int
             ),

--- a/lightrag/tools/rebuild_vdb.py
+++ b/lightrag/tools/rebuild_vdb.py
@@ -915,7 +915,8 @@ class RebuildTool:
             )
         ]
 
-    def report_rebuild(self, all_stats: List[Dict[str, Any]]):
+    def report_rebuild(self, all_stats: List[Dict[str, Any]]) -> bool:
+        """Print the rebuild report and return True if any batch/flush failed."""
         print("\n" + "=" * 60)
         print("📊 Rebuild Report")
         print("=" * 60)
@@ -929,8 +930,18 @@ class RebuildTool:
             print("   Sources were not modified - re-run this tool to retry.")
         else:
             print(f"{BOLD_GREEN}✓ Rebuild completed successfully.{RESET}")
+        return had_errors
 
-    async def run(self):
+    async def run(self) -> bool:
+        """Run the interactive tool. Returns True on success, False on failure.
+
+        Failure (-> non-zero exit) covers storage-init failure, any unhandled
+        exception, interruption, and a rebuild that finished with batch/flush
+        errors. A clean user cancellation (server not stopped) is a success.
+        This is a disaster-recovery entry point, so a partial rebuild after the
+        target VDB was already dropped must NOT look like a clean recovery.
+        """
+        success = True
         try:
             # Initialize shared storage (REQUIRED for storage classes to work)
             from lightrag.kg.shared_storage import initialize_share_data
@@ -939,10 +950,10 @@ class RebuildTool:
 
             self.print_header()
             if not self.confirm_server_stopped():
-                return
+                return True  # deliberate user cancellation, not a failure
 
             if not await self.setup_storages():
-                return
+                return False
 
             while True:
                 print("\n=== Rebuild Options ===")
@@ -958,7 +969,7 @@ class RebuildTool:
                 choice = input("\nSelect option: ").strip()
                 if choice == "" or choice == "0":
                     print("\n✓ Exiting")
-                    return
+                    return success
                 if choice == "1":
                     await self.run_check()
                     continue
@@ -992,16 +1003,22 @@ class RebuildTool:
                     all_stats.extend(await self.run_rebuild_entities_relations())
                 if include_chunks:
                     all_stats.extend(await self.run_rebuild_chunks())
-                self.report_rebuild(all_stats)
+                # Sticky: once any rebuild reports errors the session is a
+                # failure, even if a later retry succeeds (a partial rebuild
+                # after a drop must surface a non-zero exit to automation).
+                if self.report_rebuild(all_stats):
+                    success = False
                 print(f"(rebuild took {time.time() - start:.1f}s)")
 
         except KeyboardInterrupt:
             print("\n\n✗ Interrupted by user")
+            return False
         except Exception as e:
             print(f"\n✗ Rebuild tool failed: {e}")
             import traceback
 
             traceback.print_exc()
+            return False
         finally:
             for storage in self.all_storages():
                 if storage is not None:
@@ -1017,18 +1034,25 @@ class RebuildTool:
                 pass
 
 
-async def async_main():
-    """Async main entry point"""
+async def async_main() -> bool:
+    """Async main entry point. Returns True on success, False on failure."""
     tool = RebuildTool()
-    await tool.run()
+    return await tool.run()
 
 
 def main():
-    """Synchronous entry point for CLI command"""
+    """Synchronous entry point for CLI command.
+
+    Exits non-zero on failure (storage-init failure, unhandled error,
+    interruption, or a rebuild that finished with errors) so automation and
+    operators do not mistake a partial/failed recovery for a clean one.
+    """
     # Load environment and configure logging only when run as a tool, never on import.
     load_dotenv(dotenv_path=".env", override=False)
     setup_logger("lightrag", level="INFO")
-    asyncio.run(async_main())
+    success = asyncio.run(async_main())
+    if not success:
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/lightrag/tools/rebuild_vdb.py
+++ b/lightrag/tools/rebuild_vdb.py
@@ -669,9 +669,15 @@ class RebuildTool:
                     'Install the api extra: pip install "lightrag-hku[api]"'
                 )
 
+            # model_name must match the server's embedding function: Qdrant /
+            # PostgreSQL derive the collection/table name from
+            # model_name + embedding_dim. Omitting it falls back to the legacy
+            # name, so check-only mode would probe the wrong collection (and
+            # could create an empty legacy one) and misreport records as missing.
             self.embedding_func = EmbeddingFunc(
                 embedding_dim=get_env_value("EMBEDDING_DIM", 1024, int),
                 func=_no_embedding,
+                model_name=get_env_value("EMBEDDING_MODEL", None, special_none=True),
             )
 
         self.global_config = self.build_global_config()

--- a/lightrag/tools/rebuild_vdb.py
+++ b/lightrag/tools/rebuild_vdb.py
@@ -800,6 +800,17 @@ class RebuildTool:
 
         return _print_progress
 
+    def print_rebuild_section(self, label: str) -> None:
+        """Visually separate each vector storage's rebuild output.
+
+        The per-storage drop/flush logs (and the progress bar) otherwise run
+        together across entities/relationships/chunks; this header marks where
+        one storage's rebuild starts.
+        """
+        print(f"\n{BOLD_CYAN}{'─' * 60}{RESET}")
+        print(f"{BOLD_CYAN}▶ Rebuilding {label} vector storage{RESET}")
+        print(f"{BOLD_CYAN}{'─' * 60}{RESET}")
+
     def print_rebuild_stats(self, stats: Dict[str, Any]):
         print(f"\n  {BOLD_CYAN}{stats['label']}{RESET}:")
         print(f"    Source records:  {stats['source_total']:,}")
@@ -885,6 +896,7 @@ class RebuildTool:
 
     async def run_rebuild_entities_relations(self) -> List[Dict[str, Any]]:
         all_stats = []
+        self.print_rebuild_section("entities")
         all_stats.append(
             await rebuild_entities_vdb(
                 self.graph,
@@ -894,6 +906,7 @@ class RebuildTool:
                 progress_callback=self.make_progress_printer("entities"),
             )
         )
+        self.print_rebuild_section("relationships")
         all_stats.append(
             await rebuild_relationships_vdb(
                 self.graph,
@@ -906,6 +919,7 @@ class RebuildTool:
         return all_stats
 
     async def run_rebuild_chunks(self) -> List[Dict[str, Any]]:
+        self.print_rebuild_section("chunks")
         return [
             await rebuild_chunks_vdb(
                 self.text_chunks,

--- a/lightrag/tools/rebuild_vdb.py
+++ b/lightrag/tools/rebuild_vdb.py
@@ -60,11 +60,9 @@ from lightrag.utils import (
     setup_logger,
 )
 
-# Load environment variables
-load_dotenv(dotenv_path=".env", override=False)
-
-# Setup logger
-setup_logger("lightrag", level="INFO")
+# NOTE: .env loading and logger setup are deferred to main() so that importing
+# this module as a library (see README "Library usage") has no side effects on
+# the caller's environment or logging configuration.
 
 DEFAULT_BATCH_SIZE = 500
 
@@ -107,6 +105,11 @@ def _new_stats(label: str, source_total: int) -> Dict[str, Any]:
         "source_total": source_total,
         "prepared": 0,
         "rebuilt": 0,
+        # Records upserted but not yet confirmed flushed to disk. For
+        # deferred-embedding backends (nano/faiss) the embedding+persist
+        # happens in index_done_callback, so a record only counts as
+        # "rebuilt" once a flush succeeds.
+        "staged": 0,
         "skipped": 0,
         "duplicates": 0,
         "batches": 0,
@@ -120,6 +123,39 @@ async def _drop_vdb(vdb, label: str) -> None:
     if not isinstance(drop_result, dict) or drop_result.get("status") != "success":
         raise RuntimeError(f"Failed to drop {label} vector storage: {drop_result}")
     logger.info(f"Dropped {label} vector storage")
+
+
+async def _flush(vdb, stats: Dict[str, Any]) -> None:
+    """Flush staged records to disk and credit them as rebuilt.
+
+    Deferred-embedding backends (nano/faiss) compute embeddings and persist
+    inside ``index_done_callback``, so an embedder outage surfaces here rather
+    than in ``upsert``. Treat such a failure the same way as a failed upsert
+    batch: record it, drop the staged count, and continue (sources are never
+    modified, so the user can re-run). ``rebuilt`` is only incremented after a
+    flush succeeds, so it never overstates what was actually persisted.
+    """
+    if stats["staged"] == 0:
+        return
+    label = stats["label"]
+    try:
+        await vdb.index_done_callback()
+        stats["rebuilt"] += stats["staged"]
+    except Exception as e:
+        logger.error(
+            f"Rebuild {label}: flush of {stats['staged']} staged record(s) failed: {e}"
+        )
+        stats["failed_batches"] += 1
+        stats["errors"].append(
+            {
+                "batch": f"flush@batch-{stats['batches']}",
+                "records_lost": stats["staged"],
+                "error_type": type(e).__name__,
+                "error_msg": str(e),
+            }
+        )
+    finally:
+        stats["staged"] = 0
 
 
 async def _upsert_batch(
@@ -139,7 +175,7 @@ async def _upsert_batch(
             max_retries=3,
             retry_delay=0.2,
         )
-        stats["rebuilt"] += len(batch_payload)
+        stats["staged"] += len(batch_payload)
     except Exception as e:
         logger.error(f"Rebuild {label}: batch {batch_no}/{total_batches} failed: {e}")
         stats["failed_batches"] += 1
@@ -153,7 +189,7 @@ async def _upsert_batch(
         )
     stats["batches"] += 1
     if stats["batches"] % FLUSH_EVERY_N_BATCHES == 0:
-        await vdb.index_done_callback()
+        await _flush(vdb, stats)
 
 
 async def _drop_and_upsert(
@@ -176,7 +212,7 @@ async def _drop_and_upsert(
             progress_callback(batch_no, total_batches)
 
     # Final flush persists any remaining deferred embeddings
-    await vdb.index_done_callback()
+    await _flush(vdb, stats)
     return stats
 
 
@@ -223,6 +259,7 @@ async def rebuild_entities_vdb(
             "entity_type": node.get("entity_type") or "",
             "content": entity_content,
             "source_id": node.get("source_id") or "",
+            "description": description,
             "file_path": node.get("file_path") or "",
         }
 
@@ -411,7 +448,7 @@ async def rebuild_chunks_vdb(
         if progress_callback:
             progress_callback(batch_no, total_batches)
 
-    await chunks_vdb.index_done_callback()
+    await _flush(chunks_vdb, stats)
     return stats
 
 
@@ -966,6 +1003,9 @@ async def async_main():
 
 def main():
     """Synchronous entry point for CLI command"""
+    # Load environment and configure logging only when run as a tool, never on import.
+    load_dotenv(dotenv_path=".env", override=False)
+    setup_logger("lightrag", level="INFO")
     asyncio.run(async_main())
 
 

--- a/lightrag/tools/rebuild_vdb.py
+++ b/lightrag/tools/rebuild_vdb.py
@@ -4,7 +4,7 @@ Offline Vector Storage (VDB) Rebuild Tool for LightRAG
 
 The knowledge graph and the text_chunks KV store are the authoritative data
 sources in LightRAG. If a vector storage write fails at runtime (e.g. during
-an entity merge, see issue #2917), graph and vector storage drift apart:
+an entity editing with WebUI), graph and vector storage drift apart:
 graph records lose their vector counterparts (and stale vector records may
 remain). This tool restores consistency by dropping each vector storage and
 rebuilding it from scratch from its authoritative source:
@@ -12,6 +12,11 @@ rebuilding it from scratch from its authoritative source:
     entities_vdb       <- graph nodes
     relationships_vdb  <- graph edges
     chunks_vdb         <- text_chunks KV store
+
+It can also be used after changing the embedding model or embedding
+dimension. Run it with the updated embedding configuration and rebuild all
+vector storages so stored vectors match the embedding space the server will
+query.
 
 A diagnostic consistency check mode is also provided so users can decide
 whether a (potentially expensive, full re-embedding) rebuild is needed. The

--- a/lightrag/tools/rebuild_vdb.py
+++ b/lightrag/tools/rebuild_vdb.py
@@ -15,10 +15,14 @@ rebuilding it from scratch from its authoritative source:
 
 A diagnostic consistency check mode is also provided so users can decide
 whether a (potentially expensive, full re-embedding) rebuild is needed. The
-check itself only issues read queries and never drops or rewrites vector
-data, but note that connecting initializes each storage: for some backends
-(e.g. Qdrant) that can create an empty collection or payload index on first
-connect. It never drops, rewrites, or deletes existing records.
+check itself only issues read queries and does not run a rebuild (no drop +
+re-embed). It is NOT, however, strictly side-effect-free: the tool
+initializes every storage on startup — the same initialization the server
+performs — and for some backends that includes schema/DDL setup and one-time
+legacy migrations (e.g. Qdrant upserts data into the new collection,
+PostgreSQL batch-inserts into the new table, Milvus may create a temp
+collection and drop/rename the original). Run it like a server startup, not
+like a pure read.
 
 IMPORTANT: Shut down the LightRAG Server (and any other writers) before
 running this tool.
@@ -868,10 +872,7 @@ class RebuildTool:
     # ------------------------------------------------------------------
 
     async def run_check(self):
-        print(
-            "\nRunning consistency check "
-            "(read queries only; never drops or rewrites vectors)..."
-        )
+        print("\nRunning consistency check (read queries only; no rebuild)...")
         start = time.time()
         report = await check_vdb_consistency(
             self.graph,
@@ -945,7 +946,7 @@ class RebuildTool:
 
             while True:
                 print("\n=== Rebuild Options ===")
-                print("[1] Consistency check (diagnose only; no drop/rewrite)")
+                print("[1] Consistency check (diagnose only; no rebuild)")
                 if self.embedding_available:
                     print("[2] Rebuild entities + relationships VDB")
                     print("[3] Rebuild chunks VDB")

--- a/lightrag/tools/rebuild_vdb.py
+++ b/lightrag/tools/rebuild_vdb.py
@@ -411,12 +411,15 @@ async def rebuild_chunks_vdb(
     because ainsert_custom_kg writes chunks without a doc_status record.
     The ingestion pipeline upserts the full chunk record into chunks_vdb,
     so each KV record is passed through as the payload.
+
+    Every key in the text_chunks namespace is a chunk record, and chunks use
+    several id schemes that no single prefix matches — ``chunk-<hash>``
+    (custom KG), ``{doc_id}-chunk-{order}`` (text pipeline), and
+    ``{doc_id}-mm-<modality>-{order}`` (multimodal). Rather than pattern-match
+    keys (and silently drop a scheme), all keys are enumerated and the
+    per-record ``content`` check below is the only filter.
     """
-    chunk_ids = [
-        str(key)
-        for key in await enumerate_kv_keys(text_chunks_kv)
-        if str(key).startswith("chunk-")
-    ]
+    chunk_ids = [str(key) for key in await enumerate_kv_keys(text_chunks_kv)]
     stats = _new_stats("chunks", len(chunk_ids))
 
     await _drop_vdb(chunks_vdb, "chunks")
@@ -825,11 +828,7 @@ class RebuildTool:
             print(f"  Graph nodes: {len(nodes):,}")
             print(f"  Graph edges: {len(edges):,} (before deduplication)")
         if include_chunks:
-            chunk_ids = [
-                key
-                for key in await enumerate_kv_keys(self.text_chunks)
-                if str(key).startswith("chunk-")
-            ]
+            chunk_ids = await enumerate_kv_keys(self.text_chunks)
             print(f"  Text chunks: {len(chunk_ids):,}")
 
     def confirm_rebuild(self, targets: str) -> bool:

--- a/lightrag/tools/rebuild_vdb.py
+++ b/lightrag/tools/rebuild_vdb.py
@@ -1,0 +1,973 @@
+#!/usr/bin/env python3
+"""
+Offline Vector Storage (VDB) Rebuild Tool for LightRAG
+
+The knowledge graph and the text_chunks KV store are the authoritative data
+sources in LightRAG. If a vector storage write fails at runtime (e.g. during
+an entity merge, see issue #2917), graph and vector storage drift apart:
+graph records lose their vector counterparts (and stale vector records may
+remain). This tool restores consistency by dropping each vector storage and
+rebuilding it from scratch from its authoritative source:
+
+    entities_vdb       <- graph nodes
+    relationships_vdb  <- graph edges
+    chunks_vdb         <- text_chunks KV store
+
+A read-only consistency check mode is also provided so users can decide
+whether a (potentially expensive, full re-embedding) rebuild is needed.
+
+IMPORTANT: Shut down the LightRAG Server (and any other writers) before
+running this tool.
+
+Usage:
+    lightrag-rebuild-vdb
+    # or
+    python -m lightrag.tools.rebuild_vdb
+
+Configuration is read from .env / environment variables, exactly like the
+LightRAG server (LIGHTRAG_GRAPH_STORAGE, LIGHTRAG_VECTOR_STORAGE,
+LIGHTRAG_KV_STORAGE, WORKSPACE, WORKING_DIR, EMBEDDING_* ...). The embedding
+function is constructed through the same factory the server uses, so rebuilt
+vectors live in exactly the same embedding space.
+"""
+
+import asyncio
+import os
+import sys
+import time
+from typing import Any, Callable, Dict, List
+
+from dotenv import load_dotenv
+
+# Add project root to path for imports
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+
+from lightrag.constants import (
+    DEFAULT_COSINE_THRESHOLD,
+    DEFAULT_EMBEDDING_BATCH_NUM,
+)
+from lightrag.kg import STORAGE_ENV_REQUIREMENTS
+from lightrag.namespace import NameSpace
+from lightrag.utils import (
+    EmbeddingFunc,
+    compute_mdhash_id,
+    get_env_value,
+    logger,
+    make_relation_vdb_ids,
+    safe_vdb_operation_with_exception,
+    setup_logger,
+)
+
+# Load environment variables
+load_dotenv(dotenv_path=".env", override=False)
+
+# Setup logger
+setup_logger("lightrag", level="INFO")
+
+DEFAULT_BATCH_SIZE = 500
+
+# Flush deferred-embedding backends (nano/faiss compute embeddings in
+# index_done_callback) every N batches to bound memory usage.
+FLUSH_EVERY_N_BATCHES = 10
+
+# Cap for listing missing items in the consistency report
+MAX_REPORTED_MISSING = 20
+
+# ANSI color codes for terminal output
+BOLD_CYAN = "\033[1;36m"
+BOLD_RED = "\033[1;31m"
+BOLD_GREEN = "\033[1;32m"
+RESET = "\033[0m"
+
+ProgressCallback = Callable[[int, int], None]
+
+
+def _strip_agtype_quotes(value: Any) -> Any:
+    """Strip surrounding double quotes from PostgreSQL/AGE agtype text casts.
+
+    PGGraphStorage.get_all_edges() extracts entity ids via an
+    ``agtype::text`` cast, which leaves string values wrapped in double
+    quotes (e.g. ``'"Alice"'``). Other backends return plain strings.
+    """
+    if (
+        isinstance(value, str)
+        and len(value) >= 2
+        and value[0] == '"'
+        and value[-1] == '"'
+    ):
+        return value[1:-1]
+    return value
+
+
+def _new_stats(label: str, source_total: int) -> Dict[str, Any]:
+    return {
+        "label": label,
+        "source_total": source_total,
+        "prepared": 0,
+        "rebuilt": 0,
+        "skipped": 0,
+        "duplicates": 0,
+        "batches": 0,
+        "failed_batches": 0,
+        "errors": [],
+    }
+
+
+async def _drop_vdb(vdb, label: str) -> None:
+    drop_result = await vdb.drop()
+    if not isinstance(drop_result, dict) or drop_result.get("status") != "success":
+        raise RuntimeError(f"Failed to drop {label} vector storage: {drop_result}")
+    logger.info(f"Dropped {label} vector storage")
+
+
+async def _upsert_batch(
+    vdb,
+    batch_payload: Dict[str, Dict[str, Any]],
+    batch_no: int,
+    total_batches: int,
+    stats: Dict[str, Any],
+) -> None:
+    """Upsert one batch; collect the error and continue on persistent failure."""
+    label = stats["label"]
+    try:
+        await safe_vdb_operation_with_exception(
+            operation=lambda payload=batch_payload: vdb.upsert(payload),
+            operation_name=f"rebuild_{label}_upsert",
+            entity_name=f"batch {batch_no}/{total_batches}",
+            max_retries=3,
+            retry_delay=0.2,
+        )
+        stats["rebuilt"] += len(batch_payload)
+    except Exception as e:
+        logger.error(f"Rebuild {label}: batch {batch_no}/{total_batches} failed: {e}")
+        stats["failed_batches"] += 1
+        stats["errors"].append(
+            {
+                "batch": batch_no,
+                "records_lost": len(batch_payload),
+                "error_type": type(e).__name__,
+                "error_msg": str(e),
+            }
+        )
+    stats["batches"] += 1
+    if stats["batches"] % FLUSH_EVERY_N_BATCHES == 0:
+        await vdb.index_done_callback()
+
+
+async def _drop_and_upsert(
+    vdb,
+    payloads: Dict[str, Dict[str, Any]],
+    stats: Dict[str, Any],
+    *,
+    batch_size: int,
+    progress_callback: ProgressCallback | None = None,
+) -> Dict[str, Any]:
+    """Drop the VDB, then upsert ``payloads`` in batches with periodic flushes."""
+    await _drop_vdb(vdb, stats["label"])
+
+    items = list(payloads.items())
+    total_batches = (len(items) + batch_size - 1) // batch_size
+    for batch_no, start in enumerate(range(0, len(items), batch_size), start=1):
+        batch_payload = dict(items[start : start + batch_size])
+        await _upsert_batch(vdb, batch_payload, batch_no, total_batches, stats)
+        if progress_callback:
+            progress_callback(batch_no, total_batches)
+
+    # Final flush persists any remaining deferred embeddings
+    await vdb.index_done_callback()
+    return stats
+
+
+async def rebuild_entities_vdb(
+    graph,
+    entities_vdb,
+    global_config: Dict[str, Any],
+    *,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    progress_callback: ProgressCallback | None = None,
+) -> Dict[str, Any]:
+    """Rebuild the entities vector storage from graph nodes (authoritative source).
+
+    Payloads mirror the authoritative write point in
+    operate._merge_nodes_then_upsert field for field.
+    """
+    from lightrag.operate import _truncate_vdb_content
+
+    nodes = await graph.get_all_nodes()
+    stats = _new_stats("entities", len(nodes))
+
+    payloads: Dict[str, Dict[str, Any]] = {}
+    for node in nodes:
+        entity_name = _strip_agtype_quotes(node.get("entity_id") or node.get("id"))
+        if entity_name is None or not str(entity_name).strip():
+            stats["skipped"] += 1
+            logger.warning(
+                f"Rebuild entities: skipping graph node without entity id: {node!r}"
+            )
+            continue
+        entity_name = str(entity_name)
+        description = node.get("description") or ""
+        entity_content = _truncate_vdb_content(
+            f"{entity_name}\n{description}",
+            global_config,
+            f"entity:{entity_name}",
+        )
+        entity_vdb_id = compute_mdhash_id(entity_name, prefix="ent-")
+        if entity_vdb_id in payloads:
+            stats["duplicates"] += 1
+            continue
+        payloads[entity_vdb_id] = {
+            "entity_name": entity_name,
+            "entity_type": node.get("entity_type") or "",
+            "content": entity_content,
+            "source_id": node.get("source_id") or "",
+            "file_path": node.get("file_path") or "",
+        }
+
+    stats["prepared"] = len(payloads)
+    return await _drop_and_upsert(
+        entities_vdb,
+        payloads,
+        stats,
+        batch_size=batch_size,
+        progress_callback=progress_callback,
+    )
+
+
+async def rebuild_relationships_vdb(
+    graph,
+    relationships_vdb,
+    global_config: Dict[str, Any],
+    *,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    progress_callback: ProgressCallback | None = None,
+) -> Dict[str, Any]:
+    """Rebuild the relationships vector storage from graph edges (authoritative source).
+
+    Payloads mirror the authoritative write point in
+    operate._merge_edges_then_upsert field for field: endpoints are sorted and
+    the VDB id is the normalized ``rel-`` hash. Backends that return each
+    undirected edge once per direction (e.g. Neo4j, Memgraph) are deduplicated
+    by that normalized id.
+    """
+    from lightrag.operate import _truncate_vdb_content
+
+    edges = await graph.get_all_edges()
+    stats = _new_stats("relationships", len(edges))
+
+    payloads: Dict[str, Dict[str, Any]] = {}
+    for edge in edges:
+        src = _strip_agtype_quotes(edge.get("source"))
+        tgt = _strip_agtype_quotes(edge.get("target"))
+        if src is None or tgt is None or not str(src).strip() or not str(tgt).strip():
+            stats["skipped"] += 1
+            logger.warning(
+                f"Rebuild relationships: skipping graph edge without endpoints: {edge!r}"
+            )
+            continue
+        src_id, tgt_id = str(src), str(tgt)
+        # Sort src_id and tgt_id to ensure consistent ordering (smaller string first)
+        if src_id > tgt_id:
+            src_id, tgt_id = tgt_id, src_id
+
+        rel_vdb_id = compute_mdhash_id(src_id + tgt_id, prefix="rel-")
+        if rel_vdb_id in payloads:
+            stats["duplicates"] += 1
+            continue
+
+        description = edge.get("description") or ""
+        keywords = edge.get("keywords") or ""
+        try:
+            weight = float(edge.get("weight", 1.0))
+        except (TypeError, ValueError):
+            weight = 1.0
+        rel_content = _truncate_vdb_content(
+            f"{keywords}\t{src_id}\n{tgt_id}\n{description}",
+            global_config,
+            f"relationship:{src_id}-{tgt_id}",
+        )
+        payloads[rel_vdb_id] = {
+            "src_id": src_id,
+            "tgt_id": tgt_id,
+            "source_id": edge.get("source_id") or "",
+            "content": rel_content,
+            "keywords": keywords,
+            "description": description,
+            "weight": weight,
+            "file_path": edge.get("file_path") or "",
+        }
+
+    stats["prepared"] = len(payloads)
+    return await _drop_and_upsert(
+        relationships_vdb,
+        payloads,
+        stats,
+        batch_size=batch_size,
+        progress_callback=progress_callback,
+    )
+
+
+async def enumerate_kv_keys(kv) -> List[str]:
+    """List all keys of a KV storage instance.
+
+    BaseKVStorage has no enumeration API, so this uses backend-specific
+    scans (same patterns as lightrag/tools/clean_llm_query_cache.py).
+    When a new KV backend is added, this function must be extended.
+    """
+    storage_name = type(kv).__name__
+
+    if storage_name == "JsonKVStorage":
+        async with kv._storage_lock:
+            return list(kv._data.keys())
+
+    if storage_name == "RedisKVStorage":
+        keys: List[str] = []
+        prefix = f"{kv.final_namespace}:"
+        async with kv._get_redis_connection() as redis:
+            cursor = 0
+            while True:
+                cursor, batch = await redis.scan(cursor, match=f"{prefix}*", count=1000)
+                for key in batch:
+                    if isinstance(key, bytes):
+                        key = key.decode("utf-8")
+                    keys.append(key[len(prefix) :] if key.startswith(prefix) else key)
+                if cursor == 0:
+                    break
+        return keys
+
+    if storage_name == "PGKVStorage":
+        from lightrag.kg.postgres_impl import namespace_to_table_name
+
+        table_name = namespace_to_table_name(kv.namespace)
+        query = f"SELECT id FROM {table_name} WHERE workspace = $1"
+        rows = await kv.db.query(query, [kv.workspace], multirows=True)
+        return [row["id"] for row in (rows or [])]
+
+    if storage_name == "MongoKVStorage":
+        keys = []
+        cursor = kv._data.find({}, {"_id": 1})
+        async for doc in cursor:
+            keys.append(doc["_id"])
+        return keys
+
+    if storage_name == "OpenSearchKVStorage":
+        keys = []
+        async for hits in kv._iter_raw_docs(batch_size=1000):
+            keys.extend(hit["_id"] for hit in hits)
+        return keys
+
+    raise ValueError(f"Unsupported KV storage type for key enumeration: {storage_name}")
+
+
+async def rebuild_chunks_vdb(
+    text_chunks_kv,
+    chunks_vdb,
+    *,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    progress_callback: ProgressCallback | None = None,
+) -> Dict[str, Any]:
+    """Rebuild the chunks vector storage from the text_chunks KV store.
+
+    The KV store is enumerated directly (not via doc_status.chunks_list)
+    because ainsert_custom_kg writes chunks without a doc_status record.
+    The ingestion pipeline upserts the full chunk record into chunks_vdb,
+    so each KV record is passed through as the payload.
+    """
+    chunk_ids = [
+        str(key)
+        for key in await enumerate_kv_keys(text_chunks_kv)
+        if str(key).startswith("chunk-")
+    ]
+    stats = _new_stats("chunks", len(chunk_ids))
+
+    await _drop_vdb(chunks_vdb, "chunks")
+
+    total_batches = (len(chunk_ids) + batch_size - 1) // batch_size
+    for batch_no, start in enumerate(range(0, len(chunk_ids), batch_size), start=1):
+        batch_ids = chunk_ids[start : start + batch_size]
+        records = await text_chunks_kv.get_by_ids(batch_ids)
+
+        batch_payload: Dict[str, Dict[str, Any]] = {}
+        for chunk_id, record in zip(batch_ids, records):
+            if not isinstance(record, dict) or not record.get("content"):
+                stats["skipped"] += 1
+                logger.warning(
+                    f"Rebuild chunks: skipping chunk without content: {chunk_id}"
+                )
+                continue
+            payload = dict(record)
+            payload.pop("_id", None)
+            payload.setdefault("full_doc_id", "")
+            payload.setdefault("file_path", "")
+            batch_payload[chunk_id] = payload
+
+        stats["prepared"] += len(batch_payload)
+        if batch_payload:
+            await _upsert_batch(
+                chunks_vdb, batch_payload, batch_no, total_batches, stats
+            )
+        if progress_callback:
+            progress_callback(batch_no, total_batches)
+
+    await chunks_vdb.index_done_callback()
+    return stats
+
+
+async def check_vdb_consistency(
+    graph,
+    entities_vdb,
+    relationships_vdb,
+    *,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+) -> Dict[str, Any]:
+    """Read-only diagnosis: find graph records with no vector counterpart.
+
+    Only the graph -> VDB direction is covered; stale reverse orphans
+    (records present in the VDB but absent from the graph) can only be
+    eliminated by a full rebuild. Relations are probed with both candidate
+    ids from make_relation_vdb_ids so legacy reverse-order ids are not
+    misreported as missing.
+    """
+    report: Dict[str, Any] = {
+        "graph_entities": 0,
+        "graph_relations": 0,
+        "missing_entities": 0,
+        "missing_relations": 0,
+        "missing_entity_names": [],
+        "missing_relation_pairs": [],
+        "skipped_nodes": 0,
+        "skipped_edges": 0,
+    }
+
+    # Entities: one candidate id per graph node
+    nodes = await graph.get_all_nodes()
+    entity_items: List[tuple] = []
+    seen_entity_ids: set = set()
+    for node in nodes:
+        entity_name = _strip_agtype_quotes(node.get("entity_id") or node.get("id"))
+        if entity_name is None or not str(entity_name).strip():
+            report["skipped_nodes"] += 1
+            continue
+        entity_name = str(entity_name)
+        entity_vdb_id = compute_mdhash_id(entity_name, prefix="ent-")
+        if entity_vdb_id in seen_entity_ids:
+            continue
+        seen_entity_ids.add(entity_vdb_id)
+        entity_items.append((entity_vdb_id, entity_name))
+
+    report["graph_entities"] = len(entity_items)
+    for start in range(0, len(entity_items), batch_size):
+        batch = entity_items[start : start + batch_size]
+        results = await entities_vdb.get_by_ids([vdb_id for vdb_id, _ in batch])
+        for (vdb_id, entity_name), record in zip(batch, results):
+            if record is None:
+                report["missing_entities"] += 1
+                if len(report["missing_entity_names"]) < MAX_REPORTED_MISSING:
+                    report["missing_entity_names"].append(entity_name)
+
+    # Relations: both candidate ids (normalized + legacy reverse) per edge
+    edges = await graph.get_all_edges()
+    relation_items: List[tuple] = []
+    seen_relation_ids: set = set()
+    for edge in edges:
+        src = _strip_agtype_quotes(edge.get("source"))
+        tgt = _strip_agtype_quotes(edge.get("target"))
+        if src is None or tgt is None or not str(src).strip() or not str(tgt).strip():
+            report["skipped_edges"] += 1
+            continue
+        candidate_ids = make_relation_vdb_ids(str(src), str(tgt))
+        if candidate_ids[0] in seen_relation_ids:
+            continue
+        seen_relation_ids.add(candidate_ids[0])
+        relation_items.append((candidate_ids, f"{src} ~ {tgt}"))
+
+    report["graph_relations"] = len(relation_items)
+    for start in range(0, len(relation_items), batch_size):
+        batch = relation_items[start : start + batch_size]
+        flat_ids: List[str] = []
+        for candidate_ids, _ in batch:
+            flat_ids.extend(candidate_ids)
+        results = await relationships_vdb.get_by_ids(flat_ids)
+
+        offset = 0
+        for candidate_ids, pair_label in batch:
+            candidate_records = results[offset : offset + len(candidate_ids)]
+            offset += len(candidate_ids)
+            if all(record is None for record in candidate_records):
+                report["missing_relations"] += 1
+                if len(report["missing_relation_pairs"]) < MAX_REPORTED_MISSING:
+                    report["missing_relation_pairs"].append(pair_label)
+
+    report["consistent"] = (
+        report["missing_entities"] == 0 and report["missing_relations"] == 0
+    )
+    return report
+
+
+class RebuildTool:
+    """Interactive CLI for the offline VDB rebuild."""
+
+    def __init__(self):
+        self.graph = None
+        self.entities_vdb = None
+        self.relationships_vdb = None
+        self.chunks_vdb = None
+        self.text_chunks = None
+        self.global_config: Dict[str, Any] = {}
+        self.embedding_func: EmbeddingFunc | None = None
+        self.embedding_available = False
+        self.workspace = ""
+        self.batch_size = DEFAULT_BATCH_SIZE
+        self.storage_names: Dict[str, str] = {}
+
+    # ------------------------------------------------------------------
+    # Configuration / setup
+    # ------------------------------------------------------------------
+
+    def resolve_storage_names(self) -> Dict[str, str]:
+        return {
+            "graph": os.getenv("LIGHTRAG_GRAPH_STORAGE", "NetworkXStorage"),
+            "vector": os.getenv("LIGHTRAG_VECTOR_STORAGE", "NanoVectorDBStorage"),
+            "kv": os.getenv("LIGHTRAG_KV_STORAGE", "JsonKVStorage"),
+        }
+
+    def check_env_vars(self, storage_name: str) -> None:
+        """Warn about missing env vars (initialization is the real validation)."""
+        required_vars = STORAGE_ENV_REQUIREMENTS.get(storage_name, [])
+        missing_vars = [var for var in required_vars if var not in os.environ]
+        if missing_vars:
+            print(
+                f"⚠️  Warning: {storage_name} normally requires: "
+                f"{', '.join(missing_vars)} (may be provided via config.ini)"
+            )
+
+    def build_embedding_func(self) -> EmbeddingFunc | None:
+        """Build the embedding function through the server's factory.
+
+        Returns None when the api extra is unavailable; check-only mode
+        still works without it.
+        """
+        try:
+            from lightrag.api.config import global_args
+            from lightrag.api.lightrag_server import (
+                create_embedding_function_from_args,
+            )
+        except ImportError as e:
+            print(f"\n⚠️  Could not import the LightRAG API package: {e}")
+            print(
+                "   Rebuild requires the api extra: " 'pip install "lightrag-hku[api]"'
+            )
+            print("   Continuing in CHECK-ONLY mode (no embedding available).")
+            return None
+
+        embedding_func = create_embedding_function_from_args(global_args)
+        print(
+            f"- Embedding: binding={global_args.embedding_binding} "
+            f"model={embedding_func.model_name} dim={embedding_func.embedding_dim}"
+        )
+        return embedding_func
+
+    def build_global_config(self) -> Dict[str, Any]:
+        global_config: Dict[str, Any] = {
+            "working_dir": os.getenv("WORKING_DIR", "./rag_storage"),
+            "embedding_batch_num": get_env_value(
+                "EMBEDDING_BATCH_NUM", DEFAULT_EMBEDDING_BATCH_NUM, int
+            ),
+            "vector_db_storage_cls_kwargs": {
+                "cosine_better_than_threshold": get_env_value(
+                    "COSINE_THRESHOLD", DEFAULT_COSINE_THRESHOLD, float
+                )
+            },
+            "embedding_func": self.embedding_func,
+        }
+
+        # Content truncation parity with the server pipeline
+        # (_truncate_vdb_content is a no-op when these keys are absent)
+        max_token_size = getattr(self.embedding_func, "max_token_size", None)
+        if max_token_size:
+            try:
+                from lightrag.utils import TiktokenTokenizer
+
+                global_config["tokenizer"] = TiktokenTokenizer(
+                    os.getenv("TIKTOKEN_MODEL_NAME", "gpt-4o-mini")
+                )
+                global_config["embedding_token_limit"] = max_token_size
+            except Exception as e:
+                logger.warning(f"Tokenizer unavailable, skipping truncation: {e}")
+        return global_config
+
+    async def setup_storages(self) -> bool:
+        """Instantiate and initialize all storages. Returns False on failure."""
+        from lightrag.kg.factory import get_storage_class
+
+        self.storage_names = self.resolve_storage_names()
+        self.workspace = os.getenv("WORKSPACE", "")
+
+        print("\nChecking configuration...")
+        for storage_name in set(self.storage_names.values()):
+            self.check_env_vars(storage_name)
+
+        self.embedding_func = self.build_embedding_func()
+        self.embedding_available = self.embedding_func is not None
+        if not self.embedding_available:
+            # Vector storages require an embedding_func even for read paths;
+            # use a stub that fails loudly if an embedding is ever requested.
+            async def _no_embedding(*_args, **_kwargs):
+                raise RuntimeError(
+                    "Embedding is not available in check-only mode. "
+                    'Install the api extra: pip install "lightrag-hku[api]"'
+                )
+
+            self.embedding_func = EmbeddingFunc(
+                embedding_dim=get_env_value("EMBEDDING_DIM", 1024, int),
+                func=_no_embedding,
+            )
+
+        self.global_config = self.build_global_config()
+
+        graph_cls = get_storage_class(self.storage_names["graph"])
+        vector_cls = get_storage_class(self.storage_names["vector"])
+        kv_cls = get_storage_class(self.storage_names["kv"])
+
+        # Namespaces and meta_fields must match LightRAG's own storage setup
+        self.graph = graph_cls(
+            namespace=NameSpace.GRAPH_STORE_CHUNK_ENTITY_RELATION,
+            workspace=self.workspace,
+            global_config=self.global_config,
+            embedding_func=self.embedding_func,
+        )
+        self.entities_vdb = vector_cls(
+            namespace=NameSpace.VECTOR_STORE_ENTITIES,
+            workspace=self.workspace,
+            global_config=self.global_config,
+            embedding_func=self.embedding_func,
+            meta_fields={"entity_name", "source_id", "content", "file_path"},
+        )
+        self.relationships_vdb = vector_cls(
+            namespace=NameSpace.VECTOR_STORE_RELATIONSHIPS,
+            workspace=self.workspace,
+            global_config=self.global_config,
+            embedding_func=self.embedding_func,
+            meta_fields={"src_id", "tgt_id", "source_id", "content", "file_path"},
+        )
+        self.chunks_vdb = vector_cls(
+            namespace=NameSpace.VECTOR_STORE_CHUNKS,
+            workspace=self.workspace,
+            global_config=self.global_config,
+            embedding_func=self.embedding_func,
+            meta_fields={"full_doc_id", "content", "file_path"},
+        )
+        self.text_chunks = kv_cls(
+            namespace=NameSpace.KV_STORE_TEXT_CHUNKS,
+            workspace=self.workspace,
+            global_config=self.global_config,
+            embedding_func=self.embedding_func,
+        )
+
+        print("\nInitializing storages...")
+        try:
+            for storage in self.all_storages():
+                await storage.initialize()
+        except Exception as e:
+            print(f"✗ Storage initialization failed: {e}")
+            for storage_name in set(self.storage_names.values()):
+                required = STORAGE_ENV_REQUIREMENTS.get(storage_name, [])
+                if required:
+                    print(f"  {storage_name} requires: {', '.join(required)}")
+            return False
+
+        print(f"- Graph Storage:  {self.storage_names['graph']}")
+        print(f"- Vector Storage: {self.storage_names['vector']}")
+        print(f"- KV Storage:     {self.storage_names['kv']}")
+        print(f"- Workspace:      {self.workspace if self.workspace else '(default)'}")
+        print(f"- Working Dir:    {self.global_config['working_dir']}")
+        print("- Connection Status: ✓ Success")
+        return True
+
+    def all_storages(self):
+        return [
+            self.graph,
+            self.entities_vdb,
+            self.relationships_vdb,
+            self.chunks_vdb,
+            self.text_chunks,
+        ]
+
+    # ------------------------------------------------------------------
+    # CLI helpers
+    # ------------------------------------------------------------------
+
+    def print_header(self):
+        print("\n" + "=" * 60)
+        print(f"{BOLD_CYAN}LightRAG Offline Vector Storage Rebuild Tool{RESET}")
+        print("=" * 60)
+        print("\nAuthoritative sources: graph storage + text_chunks KV store")
+        print("Targets: entities_vdb, relationships_vdb, chunks_vdb")
+        print("\n" + "=" * 60)
+        print(f"{BOLD_RED}⚠️  IMPORTANT: STOP THE LIGHTRAG SERVER FIRST{RESET}")
+        print("=" * 60)
+        print("\nThis tool drops and rewrites vector storages. Running it while")
+        print("the LightRAG Server (or any other writer) is active can corrupt")
+        print("data or silently lose concurrent updates - for ALL backends.")
+
+    def confirm_server_stopped(self) -> bool:
+        confirm = (
+            input("\nHas the LightRAG Server been shut down? (yes/no): ")
+            .strip()
+            .lower()
+        )
+        if confirm != "yes":
+            print("\n✓ Operation cancelled - please shut down the server first")
+            return False
+        return True
+
+    def make_progress_printer(self, label: str) -> ProgressCallback:
+        def _print_progress(done: int, total: int):
+            total = max(total, 1)
+            bar_length = 40
+            filled = int(bar_length * done / total)
+            bar = "█" * filled + "░" * (bar_length - filled)
+            print(
+                f"\r  {label}: [{bar}] {done}/{total} batches",
+                end="" if done < total else "\n",
+                flush=True,
+            )
+
+        return _print_progress
+
+    def print_rebuild_stats(self, stats: Dict[str, Any]):
+        print(f"\n  {BOLD_CYAN}{stats['label']}{RESET}:")
+        print(f"    Source records:  {stats['source_total']:,}")
+        print(f"    Rebuilt:         {stats['rebuilt']:,}")
+        if stats["skipped"]:
+            print(f"    Skipped (dirty): {stats['skipped']:,}")
+        if stats["duplicates"]:
+            print(f"    Deduplicated:    {stats['duplicates']:,}")
+        if stats["errors"]:
+            print(f"    {BOLD_RED}Failed batches:  {stats['failed_batches']}{RESET}")
+            for err in stats["errors"][:5]:
+                print(
+                    f"      - batch {err['batch']}: {err['error_type']}: "
+                    f"{err['error_msg'][:120]}"
+                )
+            if len(stats["errors"]) > 5:
+                print(f"      ... and {len(stats['errors']) - 5} more")
+
+    def print_check_report(self, report: Dict[str, Any]):
+        print("\n" + "=" * 60)
+        print("📊 Consistency Report (graph -> vector storage)")
+        print("=" * 60)
+        print(f"  Graph entities:    {report['graph_entities']:,}")
+        print(f"  Graph relations:   {report['graph_relations']:,}")
+        print(f"  Missing entities:  {report['missing_entities']:,}")
+        print(f"  Missing relations: {report['missing_relations']:,}")
+        if report["missing_entity_names"]:
+            print("\n  Missing entities (first few):")
+            for name in report["missing_entity_names"]:
+                print(f"    - {name}")
+        if report["missing_relation_pairs"]:
+            print("\n  Missing relations (first few):")
+            for pair in report["missing_relation_pairs"]:
+                print(f"    - {pair}")
+        if report["consistent"]:
+            print(f"\n{BOLD_GREEN}✓ No missing vector records detected.{RESET}")
+            print("  Note: this check only covers the graph -> VDB direction; stale")
+            print(
+                "  VDB-only records (reverse orphans) require a full rebuild to clear."
+            )
+        else:
+            print(f"\n{BOLD_RED}✗ Inconsistencies detected.{RESET}")
+            print("  Run a rebuild (menu options 2-4) to restore consistency.")
+
+    async def print_source_counts(self, include_graph: bool, include_chunks: bool):
+        if include_graph:
+            nodes = await self.graph.get_all_nodes()
+            edges = await self.graph.get_all_edges()
+            print(f"  Graph nodes: {len(nodes):,}")
+            print(f"  Graph edges: {len(edges):,} (before deduplication)")
+        if include_chunks:
+            chunk_ids = [
+                key
+                for key in await enumerate_kv_keys(self.text_chunks)
+                if str(key).startswith("chunk-")
+            ]
+            print(f"  Text chunks: {len(chunk_ids):,}")
+
+    def confirm_rebuild(self, targets: str) -> bool:
+        print("\n" + "=" * 60)
+        print(f"{BOLD_RED}⚠️  WARNING: {targets} will be DROPPED and rebuilt!{RESET}")
+        print("=" * 60)
+        print("\nAll affected records will be re-embedded, which may incur")
+        print("significant embedding API cost and time on large datasets.")
+        print("If interrupted, simply re-run this tool (sources are read-only).")
+        confirm = input("\nProceed with the rebuild? (yes/no): ").strip().lower()
+        if confirm != "yes":
+            print("\n✓ Rebuild cancelled")
+            return False
+        return True
+
+    # ------------------------------------------------------------------
+    # Menu actions
+    # ------------------------------------------------------------------
+
+    async def run_check(self):
+        print("\nRunning read-only consistency check...")
+        start = time.time()
+        report = await check_vdb_consistency(
+            self.graph,
+            self.entities_vdb,
+            self.relationships_vdb,
+            batch_size=self.batch_size,
+        )
+        self.print_check_report(report)
+        print(f"\n(check took {time.time() - start:.1f}s)")
+
+    async def run_rebuild_entities_relations(self) -> List[Dict[str, Any]]:
+        all_stats = []
+        all_stats.append(
+            await rebuild_entities_vdb(
+                self.graph,
+                self.entities_vdb,
+                self.global_config,
+                batch_size=self.batch_size,
+                progress_callback=self.make_progress_printer("entities"),
+            )
+        )
+        all_stats.append(
+            await rebuild_relationships_vdb(
+                self.graph,
+                self.relationships_vdb,
+                self.global_config,
+                batch_size=self.batch_size,
+                progress_callback=self.make_progress_printer("relationships"),
+            )
+        )
+        return all_stats
+
+    async def run_rebuild_chunks(self) -> List[Dict[str, Any]]:
+        return [
+            await rebuild_chunks_vdb(
+                self.text_chunks,
+                self.chunks_vdb,
+                batch_size=self.batch_size,
+                progress_callback=self.make_progress_printer("chunks"),
+            )
+        ]
+
+    def report_rebuild(self, all_stats: List[Dict[str, Any]]):
+        print("\n" + "=" * 60)
+        print("📊 Rebuild Report")
+        print("=" * 60)
+        had_errors = False
+        for stats in all_stats:
+            self.print_rebuild_stats(stats)
+            had_errors = had_errors or bool(stats["errors"])
+        print()
+        if had_errors:
+            print(f"{BOLD_RED}⚠️  Rebuild finished with errors (see above).{RESET}")
+            print("   Sources were not modified - re-run this tool to retry.")
+        else:
+            print(f"{BOLD_GREEN}✓ Rebuild completed successfully.{RESET}")
+
+    async def run(self):
+        try:
+            # Initialize shared storage (REQUIRED for storage classes to work)
+            from lightrag.kg.shared_storage import initialize_share_data
+
+            initialize_share_data(workers=1)
+
+            self.print_header()
+            if not self.confirm_server_stopped():
+                return
+
+            if not await self.setup_storages():
+                return
+
+            while True:
+                print("\n=== Rebuild Options ===")
+                print("[1] Consistency check (read-only)")
+                if self.embedding_available:
+                    print("[2] Rebuild entities + relationships VDB")
+                    print("[3] Rebuild chunks VDB")
+                    print("[4] Rebuild ALL vector storages")
+                else:
+                    print("[2-4] (unavailable - embedding requires the api extra)")
+                print("[0] Exit")
+
+                choice = input("\nSelect option: ").strip()
+                if choice == "" or choice == "0":
+                    print("\n✓ Exiting")
+                    return
+                if choice == "1":
+                    await self.run_check()
+                    continue
+                if choice not in ("2", "3", "4"):
+                    print("✗ Invalid choice. Please enter 0, 1, 2, 3 or 4")
+                    continue
+                if not self.embedding_available:
+                    print(
+                        "✗ Rebuild unavailable in check-only mode. "
+                        'Install the api extra: pip install "lightrag-hku[api]"'
+                    )
+                    continue
+
+                include_graph = choice in ("2", "4")
+                include_chunks = choice in ("3", "4")
+                targets = {
+                    "2": "entities_vdb + relationships_vdb",
+                    "3": "chunks_vdb",
+                    "4": "ALL vector storages",
+                }[choice]
+
+                print("\nCounting source records...")
+                await self.print_source_counts(include_graph, include_chunks)
+
+                if not self.confirm_rebuild(targets):
+                    continue
+
+                start = time.time()
+                all_stats: List[Dict[str, Any]] = []
+                if include_graph:
+                    all_stats.extend(await self.run_rebuild_entities_relations())
+                if include_chunks:
+                    all_stats.extend(await self.run_rebuild_chunks())
+                self.report_rebuild(all_stats)
+                print(f"(rebuild took {time.time() - start:.1f}s)")
+
+        except KeyboardInterrupt:
+            print("\n\n✗ Interrupted by user")
+        except Exception as e:
+            print(f"\n✗ Rebuild tool failed: {e}")
+            import traceback
+
+            traceback.print_exc()
+        finally:
+            for storage in self.all_storages():
+                if storage is not None:
+                    try:
+                        await storage.finalize()
+                    except Exception:
+                        pass
+            try:
+                from lightrag.kg.shared_storage import finalize_share_data
+
+                finalize_share_data()
+            except Exception:
+                pass
+
+
+async def async_main():
+    """Async main entry point"""
+    tool = RebuildTool()
+    await tool.run()
+
+
+def main():
+    """Synchronous entry point for CLI command"""
+    asyncio.run(async_main())
+
+
+if __name__ == "__main__":
+    main()

--- a/lightrag/tools/rebuild_vdb.py
+++ b/lightrag/tools/rebuild_vdb.py
@@ -13,8 +13,12 @@ rebuilding it from scratch from its authoritative source:
     relationships_vdb  <- graph edges
     chunks_vdb         <- text_chunks KV store
 
-A read-only consistency check mode is also provided so users can decide
-whether a (potentially expensive, full re-embedding) rebuild is needed.
+A diagnostic consistency check mode is also provided so users can decide
+whether a (potentially expensive, full re-embedding) rebuild is needed. The
+check itself only issues read queries and never drops or rewrites vector
+data, but note that connecting initializes each storage: for some backends
+(e.g. Qdrant) that can create an empty collection or payload index on first
+connect. It never drops, rewrites, or deletes existing records.
 
 IMPORTANT: Shut down the LightRAG Server (and any other writers) before
 running this tool.
@@ -864,7 +868,10 @@ class RebuildTool:
     # ------------------------------------------------------------------
 
     async def run_check(self):
-        print("\nRunning read-only consistency check...")
+        print(
+            "\nRunning consistency check "
+            "(read queries only; never drops or rewrites vectors)..."
+        )
         start = time.time()
         report = await check_vdb_consistency(
             self.graph,
@@ -938,7 +945,7 @@ class RebuildTool:
 
             while True:
                 print("\n=== Rebuild Options ===")
-                print("[1] Consistency check (read-only)")
+                print("[1] Consistency check (diagnose only; no drop/rewrite)")
                 if self.embedding_available:
                     print("[2] Rebuild entities + relationships VDB")
                     print("[3] Rebuild chunks VDB")

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -834,6 +834,19 @@ class QueueFullError(Exception):
     pass
 
 
+class VectorStorageConsistencyError(Exception):
+    """Raised when a vector storage write fails after the graph has already been updated.
+
+    The knowledge graph (plus the text_chunks KV store) is the authoritative data
+    source, so no data is lost — but the vector storage no longer mirrors the graph
+    and query results may be incomplete until it is rebuilt. Stop the LightRAG
+    server and run the offline rebuild tool (``lightrag-rebuild-vdb``) to restore
+    consistency.
+    """
+
+    pass
+
+
 class WorkerTimeoutError(Exception):
     """Worker-level timeout exception with specific timeout information"""
 

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -695,6 +695,18 @@ async def aedit_entity(
                         )
                         return {**merge_result, "operation_summary": operation_summary}
 
+                    except VectorStorageConsistencyError:
+                        # Fail-loud: the graph was updated but the vector storage
+                        # could not be persisted. This must reach the caller (mapped
+                        # to a 500 with rebuild guidance by the route), NOT be folded
+                        # into a partial-success summary that returns HTTP 200.
+                        logger.error(
+                            f"Entity Edit: merge of '{entity_name}' into "
+                            f"'{new_entity_name}' left graph and vector storage "
+                            "inconsistent; re-raising VectorStorageConsistencyError"
+                        )
+                        raise
+
                     except Exception as merge_error:
                         # Merge failed, but update may have succeeded
                         logger.error(f"Entity Edit: merge failed: {merge_error}")

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -7,7 +7,13 @@ from typing import Any, cast
 from .base import DeletionResult
 from .kg.shared_storage import get_storage_keyed_lock
 from .constants import GRAPH_FIELD_SEP
-from .utils import compute_mdhash_id, logger, make_relation_vdb_ids
+from .utils import (
+    VectorStorageConsistencyError,
+    compute_mdhash_id,
+    logger,
+    make_relation_vdb_ids,
+    safe_vdb_operation_with_exception,
+)
 from .base import StorageNameSpace
 
 
@@ -1229,6 +1235,15 @@ async def _merge_entities_impl(
     Note:
         Caller must acquire appropriate locks before calling this function.
         All source entities and the target entity should be locked together.
+
+    Failure semantics:
+        The knowledge graph is the authoritative data source. If a vector
+        storage upsert fails after retries (steps 7/8), this function raises
+        VectorStorageConsistencyError instead of attempting any rollback: the
+        graph already holds the merged state, no data is lost, and the source
+        entities have NOT been deleted yet (step 10 is never reached). The
+        vector storage may then lag behind the graph; running the offline
+        rebuild tool (``lightrag-rebuild-vdb``) restores full consistency.
     """
     # Default merge strategy for entities
     default_entity_merge_strategy = {
@@ -1388,7 +1403,7 @@ async def _merge_entities_impl(
             }
 
     # Apply relationship updates
-    logger.info(f"Entity Merge: updatign {len(relation_updates)} relations")
+    logger.info(f"Entity Merge: updating {len(relation_updates)} relations")
     for rel_data in relation_updates.values():
         await chunk_entity_relation_graph.upsert_edge(
             rel_data["graph_src"], rel_data["graph_tgt"], rel_data["data"]
@@ -1447,7 +1462,25 @@ async def _merge_entities_impl(
                 "file_path": edge_data.get("file_path", ""),
             }
         }
-        await relationships_vdb.upsert(relation_data_for_vdb)
+        try:
+            await safe_vdb_operation_with_exception(
+                operation=lambda payload=relation_data_for_vdb: relationships_vdb.upsert(
+                    payload
+                ),
+                operation_name="merge_relation_upsert",
+                entity_name=f"{normalized_src}-{normalized_tgt}",
+                max_retries=3,
+                retry_delay=0.2,
+            )
+        except Exception as e:
+            raise VectorStorageConsistencyError(
+                f"Vector storage upsert failed for relation `{normalized_src}`~`{normalized_tgt}` "
+                f"while merging entities into '{target_entity}': {e}. "
+                "The knowledge graph was updated but the vector storage was not, so they may "
+                "now be inconsistent. No data is lost (the graph is the authoritative source "
+                "and the source entities were not deleted). Stop the LightRAG server and run "
+                "the offline rebuild tool (lightrag-rebuild-vdb) to restore consistency."
+            ) from e
         logger.debug(
             f"Entity Merge: updating vdb `{normalized_src}`~`{normalized_tgt}`"
         )
@@ -1471,7 +1504,22 @@ async def _merge_entities_impl(
             "file_path": merged_entity_data.get("file_path", ""),
         }
     }
-    await entities_vdb.upsert(entity_data_for_vdb)
+    try:
+        await safe_vdb_operation_with_exception(
+            operation=lambda payload=entity_data_for_vdb: entities_vdb.upsert(payload),
+            operation_name="merge_entity_upsert",
+            entity_name=target_entity,
+            max_retries=3,
+            retry_delay=0.2,
+        )
+    except Exception as e:
+        raise VectorStorageConsistencyError(
+            f"Vector storage upsert failed for entity '{target_entity}' during entity merge: {e}. "
+            "The knowledge graph was updated but the vector storage was not, so they may "
+            "now be inconsistent. No data is lost (the graph is the authoritative source "
+            "and the source entities were not deleted). Stop the LightRAG server and run "
+            "the offline rebuild tool (lightrag-rebuild-vdb) to restore consistency."
+        ) from e
     logger.info(f"Entity Merge: updating vdb `{target_entity}`")
 
     # 9. Merge entity chunk tracking (source entities first, then target entity)

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -527,7 +527,7 @@ async def _edit_entity_impl(
         chunk_entity_relation_graph,
         entities_vdb,
         entity_name,
-        include_vector_data=True,
+        include_vector_data=False,
     )
 
 
@@ -730,7 +730,7 @@ async def aedit_entity(
                             chunk_entity_relation_graph,
                             entities_vdb,
                             entity_name,
-                            include_vector_data=True,
+                            include_vector_data=False,
                         )
                         return {**entity_info, "operation_summary": operation_summary}
 
@@ -932,7 +932,7 @@ async def aedit_relation(
                 relationships_vdb,
                 source_entity,
                 target_entity,
-                include_vector_data=True,
+                include_vector_data=False,
             )
         except Exception as e:
             logger.error(
@@ -1052,7 +1052,7 @@ async def acreate_entity(
                 chunk_entity_relation_graph,
                 entities_vdb,
                 entity_name,
-                include_vector_data=True,
+                include_vector_data=False,
             )
         except Exception as e:
             logger.error(f"Error while creating entity '{entity_name}': {e}")
@@ -1204,7 +1204,7 @@ async def acreate_relation(
                 relationships_vdb,
                 source_entity,
                 target_entity,
-                include_vector_data=True,
+                include_vector_data=False,
             )
         except Exception as e:
             logger.error(
@@ -1701,7 +1701,7 @@ async def _merge_entities_impl(
         chunk_entity_relation_graph,
         entities_vdb,
         target_entity,
-        include_vector_data=True,
+        include_vector_data=False,
     )
 
 

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -1446,7 +1446,25 @@ async def _merge_entities_impl(
     logger.debug(
         f"Entity Merge: deleting {len(relations_to_delete)} relations from vdb"
     )
-    await relationships_vdb.delete(relations_to_delete)
+    if relations_to_delete:
+        try:
+            await safe_vdb_operation_with_exception(
+                operation=lambda ids=relations_to_delete: relationships_vdb.delete(ids),
+                operation_name="merge_relation_delete",
+                entity_name=target_entity,
+                max_retries=3,
+                retry_delay=0.2,
+            )
+        except Exception as e:
+            raise VectorStorageConsistencyError(
+                f"Vector storage delete of {len(relations_to_delete)} stale relation "
+                f"record(s) failed while merging entities into '{target_entity}': {e}. "
+                "The knowledge graph was updated but the vector storage was not, so they "
+                "may now be inconsistent. No data is lost (the graph is the authoritative "
+                "source and the source entities were not deleted). Stop the LightRAG server "
+                "and run the offline rebuild tool (lightrag-rebuild-vdb) to restore "
+                "consistency."
+            ) from e
 
     for rel_data in relation_updates.values():
         edge_data = rel_data["data"]

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -1522,6 +1522,41 @@ async def _merge_entities_impl(
         ) from e
     logger.info(f"Entity Merge: updating vdb `{target_entity}`")
 
+    # 8b. Persist the graph and vector storages now — before any source-entity
+    # deletion (step 10). Deferred-embedding backends (e.g. nano/faiss) do NOT
+    # call the embedder inside upsert(); they embed and persist in
+    # index_done_callback, so an embedder outage surfaces only at flush time,
+    # outside the upsert try/except above. Flushing here, while the source
+    # entities are still intact, keeps the fail-loud guarantee true for those
+    # backends: on failure we raise VectorStorageConsistencyError before
+    # deleting anything, and the error message ("source entities not deleted")
+    # remains accurate. The graph is flushed first so it is the authoritative
+    # on-disk source the offline rebuild tool can recover from.
+    await chunk_entity_relation_graph.index_done_callback()
+    try:
+        await safe_vdb_operation_with_exception(
+            operation=relationships_vdb.index_done_callback,
+            operation_name="merge_relation_flush",
+            entity_name=target_entity,
+            max_retries=3,
+            retry_delay=0.2,
+        )
+        await safe_vdb_operation_with_exception(
+            operation=entities_vdb.index_done_callback,
+            operation_name="merge_entity_flush",
+            entity_name=target_entity,
+            max_retries=3,
+            retry_delay=0.2,
+        )
+    except Exception as e:
+        raise VectorStorageConsistencyError(
+            f"Vector storage flush failed after merging entities into '{target_entity}': {e}. "
+            "The knowledge graph was updated but the vector storage embeddings could not be "
+            "persisted, so they may now be inconsistent. No data is lost (the graph is the "
+            "authoritative source and the source entities were not deleted). Stop the LightRAG "
+            "server and run the offline rebuild tool (lightrag-rebuild-vdb) to restore consistency."
+        ) from e
+
     # 9. Merge entity chunk tracking (source entities first, then target entity)
     if entity_chunks_storage is not None:
         all_chunk_id_lists = []

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -1652,18 +1652,47 @@ async def _merge_entities_impl(
         # Delete entity node and related edges from knowledge graph
         await chunk_entity_relation_graph.delete_node(entity_name)
 
-        # Delete entity record from vector database
+        # Delete entity record from vector database. The graph node is already
+        # gone, so on failure the message must NOT claim the source entity still
+        # exists — only that a stale vector record may remain.
         entity_id = compute_mdhash_id(entity_name, prefix="ent-")
-        await entities_vdb.delete([entity_id])
+        try:
+            await safe_vdb_operation_with_exception(
+                operation=lambda eid=entity_id: entities_vdb.delete([eid]),
+                operation_name="merge_source_entity_delete",
+                entity_name=entity_name,
+                max_retries=3,
+                retry_delay=0.2,
+            )
+        except Exception as e:
+            raise VectorStorageConsistencyError(
+                f"Vector storage delete of merged-away source entity '{entity_name}' "
+                f"failed while finalizing the merge into '{target_entity}': {e}. "
+                "The source entity was already removed from the knowledge graph (the "
+                "authoritative source); only a stale vector record may remain, so no "
+                "data is lost. Stop the LightRAG server and run the offline rebuild "
+                "tool (lightrag-rebuild-vdb) to clear the stale record and restore "
+                "consistency."
+            ) from e
 
     # 11. Save changes
-    await _persist_graph_updates(
-        entities_vdb=entities_vdb,
-        relationships_vdb=relationships_vdb,
-        chunk_entity_relation_graph=chunk_entity_relation_graph,
-        entity_chunks_storage=entity_chunks_storage,
-        relation_chunks_storage=relation_chunks_storage,
-    )
+    try:
+        await _persist_graph_updates(
+            entities_vdb=entities_vdb,
+            relationships_vdb=relationships_vdb,
+            chunk_entity_relation_graph=chunk_entity_relation_graph,
+            entity_chunks_storage=entity_chunks_storage,
+            relation_chunks_storage=relation_chunks_storage,
+        )
+    except Exception as e:
+        raise VectorStorageConsistencyError(
+            f"Persisting the merged state failed while finalizing the merge into "
+            f"'{target_entity}': {e}. The merge has been applied to the knowledge graph "
+            "(the authoritative source) and the source entities were removed, but the "
+            "vector storage may not be fully persisted, so they may now be inconsistent. "
+            "No data is lost. Stop the LightRAG server and run the offline rebuild tool "
+            "(lightrag-rebuild-vdb) to restore consistency."
+        ) from e
 
     logger.info(
         f"Entity Merge: successfully merged {len(source_entities)} entities into '{target_entity}'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,7 @@ lightrag-gunicorn = "lightrag.api.run_with_gunicorn:main"
 lightrag-hash-password = "lightrag.tools.hash_password:main"
 lightrag-download-cache = "lightrag.tools.download_cache:main"
 lightrag-clean-llmqc = "lightrag.tools.clean_llm_query_cache:main"
+lightrag-rebuild-vdb = "lightrag.tools.rebuild_vdb:main"
 
 [project.urls]
 Homepage = "https://github.com/HKUDS/LightRAG"

--- a/tests/api/routes/test_description_api_validation.py
+++ b/tests/api/routes/test_description_api_validation.py
@@ -9,6 +9,7 @@ from lightrag.operate import (
     _handle_single_relationship_extraction,
 )
 from lightrag import utils_graph
+from lightrag.utils import VectorStorageConsistencyError
 
 
 class DummyGraphStorage:
@@ -315,3 +316,55 @@ async def test_merge_entities_preserves_file_path_in_vector_updates(monkeypatch)
         "alias.md",
         "canonical.md",
     }
+
+
+@pytest.mark.asyncio
+async def test_aedit_entity_merge_propagates_consistency_error(monkeypatch):
+    """rename-with-merge must surface VectorStorageConsistencyError, not swallow it.
+
+    The graph is updated during the merge, then the (deferred) vector-store
+    flush fails. aedit_entity used to fold every merge exception into a
+    partial-success summary and return normally, so the /graph/entity/edit
+    route reported HTTP 200 "success" and hid the consistency failure that the
+    fail-loud merge path exists to surface. It must re-raise instead.
+    """
+    graph = DummyMergeGraphStorage()
+    entities_vdb = DummyVectorStorage()
+    relationships_vdb = DummyVectorStorage()
+
+    # Deferred-embedding flush failure: upsert buffers, index_done_callback raises.
+    async def _boom():
+        raise RuntimeError("embedder down")
+
+    relationships_vdb.index_done_callback = _boom
+
+    # Single-attempt VDB wrapper (no retry delays) + a no-op storage lock.
+    async def _single_attempt(operation, **kwargs):
+        await operation()
+
+    monkeypatch.setattr(
+        utils_graph, "safe_vdb_operation_with_exception", _single_attempt
+    )
+    monkeypatch.setattr(
+        utils_graph, "get_storage_keyed_lock", lambda *a, **k: DummyAsyncContext()
+    )
+
+    async def fake_get_entity_info(*args, **kwargs):
+        return {"entity_name": "Canonical"}
+
+    monkeypatch.setattr(utils_graph, "get_entity_info", fake_get_entity_info)
+
+    with pytest.raises(VectorStorageConsistencyError) as excinfo:
+        await utils_graph.aedit_entity(
+            chunk_entity_relation_graph=graph,
+            entities_vdb=entities_vdb,
+            relationships_vdb=relationships_vdb,
+            entity_name="Alias",
+            updated_data={"entity_name": "Canonical"},
+            allow_rename=True,
+            allow_merge=True,
+        )
+
+    assert "lightrag-rebuild-vdb" in str(excinfo.value)
+    # Fail-loud happened before source deletion: 'Alias' is still in the graph.
+    assert "Alias" in graph.nodes

--- a/tests/api/routes/test_description_api_validation.py
+++ b/tests/api/routes/test_description_api_validation.py
@@ -319,6 +319,39 @@ async def test_merge_entities_preserves_file_path_in_vector_updates(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_merge_response_is_built_from_graph_without_reading_vdb():
+    # The merge response is built from graph data only. Reading the vector
+    # store is redundant (the graph is authoritative) and previously leaked a
+    # non-JSON-serializable embedding (pgvector -> numpy) into the API
+    # response, causing a 500 on /graph/entity/edit with all-PostgreSQL.
+    graph = DummyMergeGraphStorage()
+    entities_vdb = DummyVectorStorage()
+    relationships_vdb = DummyVectorStorage()
+
+    vdb_reads = []
+    inner_get_by_id = entities_vdb.get_by_id
+
+    async def _tracked_get_by_id(id_):
+        vdb_reads.append(id_)
+        return await inner_get_by_id(id_)
+
+    entities_vdb.get_by_id = _tracked_get_by_id
+
+    result = await utils_graph._merge_entities_impl(
+        chunk_entity_relation_graph=graph,
+        entities_vdb=entities_vdb,
+        relationships_vdb=relationships_vdb,
+        source_entities=["Alias", "Canonical"],
+        target_entity="Canonical",
+    )
+
+    assert "graph_data" in result
+    assert "vector_data" not in result
+    # The response did not read the entity vector store.
+    assert vdb_reads == []
+
+
+@pytest.mark.asyncio
 async def test_aedit_entity_merge_propagates_consistency_error(monkeypatch):
     """rename-with-merge must surface VectorStorageConsistencyError, not swallow it.
 

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -3278,7 +3278,10 @@ class TestGraphStorage:
         assert node.id == "Alice"
         assert "entity_type" in node.properties
         assert "_id" not in node.properties
-        assert "entity_id" not in node.properties
+        # entity_id must be preserved in properties: the WebUI reads
+        # properties['entity_id'] to render the node's "Name" row and the
+        # neighbour/edge-endpoint labels. Stripping it left the panel nameless.
+        assert node.properties["entity_id"] == "Alice"
 
     @pytest.mark.asyncio
     async def test_construct_graph_edge(self, global_config, embed_func):

--- a/tests/kg/postgres_impl/test_postgres_vector_payload_strips_embedding.py
+++ b/tests/kg/postgres_impl/test_postgres_vector_payload_strips_embedding.py
@@ -1,0 +1,85 @@
+"""PGVectorStorage.get_by_id/get_by_ids must not leak the embedding column.
+
+The SQL-fallback path used ``SELECT *`` and returned ``content_vector`` — a
+pgvector value the asyncpg codec materializes as a numpy array, which is not
+JSON-serializable. ``get_entity_info(include_vector_data=True)`` puts that row
+into the API response, so ``POST /graph/entity/edit`` raised a 500 during
+response serialization when every storage was PostgreSQL. Both read paths must
+strip ``content_vector`` to match the buffered shape and the other vector
+backends.
+"""
+
+import asyncio
+
+import numpy as np
+import pytest
+from unittest.mock import AsyncMock
+
+from lightrag.kg.postgres_impl import PGVectorStorage
+from lightrag.namespace import NameSpace
+from lightrag.utils import EmbeddingFunc
+
+pytestmark = pytest.mark.offline
+
+
+async def _embed(texts, **kwargs):
+    return np.array([[0.0, 0.0, 0.0] for _ in texts], dtype=np.float32)
+
+
+def _make_storage(row):
+    storage = PGVectorStorage(
+        namespace=NameSpace.VECTOR_STORE_ENTITIES,
+        workspace="ws",
+        global_config={
+            "embedding_batch_num": 10,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.5},
+        },
+        embedding_func=EmbeddingFunc(
+            embedding_dim=3, func=_embed, model_name="test_model"
+        ),
+    )
+
+    async def _query(sql, params, multirows=False):
+        return [row] if multirows else row
+
+    storage.db = AsyncMock()
+    storage.db.query = AsyncMock(side_effect=_query)
+    storage._flush_lock = asyncio.Lock()
+    return storage
+
+
+def _row():
+    # content_vector is a numpy array in production (pgvector codec).
+    return {
+        "id": "ent-1",
+        "content": "Alice\ndescription",
+        "entity_name": "Alice",
+        "source_id": "chunk-1",
+        "file_path": "doc.txt",
+        "content_vector": np.array([0.1, 0.2, 0.3], dtype=np.float32),
+        "created_at": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_strips_content_vector():
+    storage = _make_storage(_row())
+
+    result = await storage.get_by_id("ent-1")
+
+    assert result is not None
+    assert "content_vector" not in result
+    assert result["content"] == "Alice\ndescription"
+    assert result["id"] == "ent-1"
+
+
+@pytest.mark.asyncio
+async def test_get_by_ids_strips_content_vector():
+    storage = _make_storage(_row())
+
+    results = await storage.get_by_ids(["ent-1"])
+
+    assert len(results) == 1
+    assert results[0] is not None
+    assert "content_vector" not in results[0]
+    assert results[0]["content"] == "Alice\ndescription"

--- a/tests/kg/test_graph_storage.py
+++ b/tests/kg/test_graph_storage.py
@@ -457,6 +457,16 @@ async def test_graph_advanced(storage):
             len(kg.edges) == 2
         ), f"The knowledge graph should have 2 edges, but got {len(kg.edges)}"
 
+        # 6.1 Every returned node must carry its entity_id in properties: the
+        # WebUI reads properties['entity_id'] to render the node "Name" row and
+        # neighbour/edge-endpoint labels. A backend that strips it leaves the
+        # property panel nameless (regression guard for all backends).
+        expected_ids = {node1_id, node2_id, node3_id}
+        for kg_node in kg.nodes:
+            assert (
+                kg_node.properties.get("entity_id") in expected_ids
+            ), f"Node {kg_node.id} is missing entity_id in properties: {kg_node.properties}"
+
         # 7. Test delete_node - delete a node
         print(f"== Testing delete_node: {node3_id}")
         await storage.delete_node(node3_id)

--- a/tests/tools/test_rebuild_vdb.py
+++ b/tests/tools/test_rebuild_vdb.py
@@ -1,0 +1,584 @@
+"""Tests for the offline VDB rebuild tool and the fail-loud merge semantics.
+
+Covers:
+- rebuild: payload fidelity against the authoritative write points,
+  bidirectional edge dedup, AGE quote stripping, dirty-data skipping,
+  drop-before-upsert ordering, batching with periodic flushes, and
+  error collection on persistently failing batches.
+- check: consistent stores, missing-record detection, legacy reverse
+  relation ids not being misreported, and batching.
+- merge: _merge_entities_impl raising VectorStorageConsistencyError on
+  persistent VDB failure without deleting source entities.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+import lightrag.tools.rebuild_vdb as rebuild_vdb
+from lightrag.tools.rebuild_vdb import (
+    _strip_agtype_quotes,
+    check_vdb_consistency,
+    rebuild_chunks_vdb,
+    rebuild_entities_vdb,
+    rebuild_relationships_vdb,
+)
+from lightrag.utils import (
+    VectorStorageConsistencyError,
+    compute_mdhash_id,
+    make_relation_vdb_ids,
+)
+
+pytestmark = pytest.mark.offline
+
+
+# ---------------------------------------------------------------------------
+# Mocks
+# ---------------------------------------------------------------------------
+
+
+class MockVDB:
+    """Vector storage mock: records upserts, aligned-None get_by_ids."""
+
+    def __init__(self):
+        self.global_config = {}  # no tokenizer -> _truncate_vdb_content is a no-op
+        self.records = {}
+        self.call_order = []
+
+        async def _drop():
+            self.call_order.append("drop")
+            self.records.clear()
+            return {"status": "success", "message": "data dropped"}
+
+        async def _upsert(payload):
+            self.call_order.append("upsert")
+            self.records.update(payload)
+
+        async def _get_by_ids(ids):
+            return [self.records.get(i) for i in ids]
+
+        self.drop = AsyncMock(side_effect=_drop)
+        self.upsert = AsyncMock(side_effect=_upsert)
+        self.get_by_ids = AsyncMock(side_effect=_get_by_ids)
+        self.delete = AsyncMock()
+        self.index_done_callback = AsyncMock()
+
+
+def make_graph(nodes=None, edges=None):
+    graph = MagicMock()
+    graph.get_all_nodes = AsyncMock(return_value=nodes or [])
+    graph.get_all_edges = AsyncMock(return_value=edges or [])
+    return graph
+
+
+class _FakeLock:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class JsonKVStorage:
+    """Minimal stand-in; the class NAME drives enumerate_kv_keys dispatch."""
+
+    def __init__(self, data):
+        self._data = data
+        self._storage_lock = _FakeLock()
+
+    async def get_by_ids(self, ids):
+        return [self._data.get(i) for i in ids]
+
+
+def node(name, **overrides):
+    data = {
+        "entity_id": name,
+        "description": f"description of {name}",
+        "entity_type": "person",
+        "source_id": "chunk-abc",
+        "file_path": "doc.txt",
+    }
+    data.update(overrides)
+    return data
+
+
+def edge(src, tgt, **overrides):
+    data = {
+        "source": src,
+        "target": tgt,
+        "description": f"{src} knows {tgt}",
+        "keywords": "knows",
+        "source_id": "chunk-abc",
+        "weight": 2.0,
+        "file_path": "doc.txt",
+    }
+    data.update(overrides)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Rebuild: entities
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rebuild_entities_payload_matches_authoritative_format():
+    graph = make_graph(nodes=[node("Alice")])
+    vdb = MockVDB()
+
+    stats = await rebuild_entities_vdb(graph, vdb, {})
+
+    entity_id = compute_mdhash_id("Alice", prefix="ent-")
+    assert stats["rebuilt"] == 1
+    assert stats["skipped"] == 0
+    assert vdb.records == {
+        entity_id: {
+            "entity_name": "Alice",
+            "entity_type": "person",
+            "content": "Alice\ndescription of Alice",
+            "source_id": "chunk-abc",
+            "file_path": "doc.txt",
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_rebuild_entities_handles_missing_optional_fields():
+    graph = make_graph(
+        nodes=[{"id": "Bob"}]  # only "id", no entity_id, no optional fields
+    )
+    vdb = MockVDB()
+
+    await rebuild_entities_vdb(graph, vdb, {})
+
+    record = vdb.records[compute_mdhash_id("Bob", prefix="ent-")]
+    assert record["entity_name"] == "Bob"
+    assert record["content"] == "Bob\n"
+    assert record["entity_type"] == ""
+    assert record["source_id"] == ""
+    assert record["file_path"] == ""
+
+
+@pytest.mark.asyncio
+async def test_rebuild_entities_skips_dirty_nodes():
+    graph = make_graph(nodes=[node("Alice"), {"description": "no id"}, node("  ")])
+    vdb = MockVDB()
+
+    stats = await rebuild_entities_vdb(graph, vdb, {})
+
+    assert stats["source_total"] == 3
+    assert stats["rebuilt"] == 1
+    assert stats["skipped"] == 2
+    assert list(vdb.records) == [compute_mdhash_id("Alice", prefix="ent-")]
+
+
+@pytest.mark.asyncio
+async def test_rebuild_drops_once_before_any_upsert():
+    graph = make_graph(nodes=[node("Alice"), node("Bob")])
+    vdb = MockVDB()
+
+    await rebuild_entities_vdb(graph, vdb, {}, batch_size=1)
+
+    assert vdb.drop.await_count == 1
+    assert vdb.call_order[0] == "drop"
+    assert vdb.call_order.count("upsert") == 2
+
+
+@pytest.mark.asyncio
+async def test_rebuild_batches_and_periodic_flush():
+    graph = make_graph(nodes=[node(f"E{i:03d}") for i in range(25)])
+    vdb = MockVDB()
+
+    stats = await rebuild_entities_vdb(graph, vdb, {}, batch_size=1)
+
+    assert stats["batches"] == 25
+    assert vdb.upsert.await_count == 25
+    # periodic flush at batches 10 and 20, plus the final flush
+    assert vdb.index_done_callback.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_rebuild_collects_batch_errors_and_continues(monkeypatch):
+    # Single-attempt wrapper: no retry delays in tests
+    async def _single_attempt(operation, **kwargs):
+        await operation()
+
+    monkeypatch.setattr(
+        rebuild_vdb, "safe_vdb_operation_with_exception", _single_attempt
+    )
+
+    graph = make_graph(nodes=[node("Alice"), node("Bob"), node("Carol")])
+    vdb = MockVDB()
+    poisoned_id = compute_mdhash_id("Bob", prefix="ent-")
+
+    async def _failing_upsert(payload):
+        if poisoned_id in payload:
+            raise RuntimeError("embedder down")
+        vdb.records.update(payload)
+
+    vdb.upsert = AsyncMock(side_effect=_failing_upsert)
+
+    stats = await rebuild_entities_vdb(graph, vdb, {}, batch_size=1)
+
+    assert stats["rebuilt"] == 2
+    assert stats["failed_batches"] == 1
+    assert len(stats["errors"]) == 1
+    assert stats["errors"][0]["error_msg"] == "embedder down"
+    assert poisoned_id not in vdb.records
+    assert len(vdb.records) == 2
+
+
+# ---------------------------------------------------------------------------
+# Rebuild: relationships
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rebuild_relationships_payload_normalized():
+    # Endpoints arrive in reverse lexicographic order; payload must be sorted
+    graph = make_graph(edges=[edge("Bob", "Alice")])
+    vdb = MockVDB()
+
+    stats = await rebuild_relationships_vdb(graph, vdb, {})
+
+    rel_id = compute_mdhash_id("Alice" + "Bob", prefix="rel-")
+    assert stats["rebuilt"] == 1
+    assert vdb.records == {
+        rel_id: {
+            "src_id": "Alice",
+            "tgt_id": "Bob",
+            "source_id": "chunk-abc",
+            "content": "knows\tAlice\nBob\nBob knows Alice",
+            "keywords": "knows",
+            "description": "Bob knows Alice",
+            "weight": 2.0,
+            "file_path": "doc.txt",
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_rebuild_relationships_weight_fallback():
+    graph = make_graph(edges=[edge("A", "B", weight="3"), edge("C", "D", weight=None)])
+    vdb = MockVDB()
+
+    await rebuild_relationships_vdb(graph, vdb, {})
+
+    assert vdb.records[compute_mdhash_id("AB", prefix="rel-")]["weight"] == 3.0
+    assert vdb.records[compute_mdhash_id("CD", prefix="rel-")]["weight"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_rebuild_relationships_dedupes_bidirectional_edges():
+    # Neo4j/Memgraph return each undirected edge once per direction
+    graph = make_graph(edges=[edge("Alice", "Bob"), edge("Bob", "Alice")])
+    vdb = MockVDB()
+
+    stats = await rebuild_relationships_vdb(graph, vdb, {})
+
+    assert stats["source_total"] == 2
+    assert stats["rebuilt"] == 1
+    assert stats["duplicates"] == 1
+
+
+@pytest.mark.asyncio
+async def test_rebuild_relationships_strips_age_quotes():
+    # PG/AGE agtype::text casts wrap endpoint strings in double quotes
+    graph = make_graph(edges=[edge('"Alice"', '"Bob"')])
+    vdb = MockVDB()
+
+    await rebuild_relationships_vdb(graph, vdb, {})
+
+    rel_id = compute_mdhash_id("AliceBob", prefix="rel-")
+    assert vdb.records[rel_id]["src_id"] == "Alice"
+    assert vdb.records[rel_id]["tgt_id"] == "Bob"
+
+
+@pytest.mark.asyncio
+async def test_rebuild_relationships_skips_edges_without_endpoints():
+    graph = make_graph(edges=[edge("Alice", "Bob"), {"description": "no endpoints"}])
+    vdb = MockVDB()
+
+    stats = await rebuild_relationships_vdb(graph, vdb, {})
+
+    assert stats["rebuilt"] == 1
+    assert stats["skipped"] == 1
+
+
+def test_strip_agtype_quotes():
+    assert _strip_agtype_quotes('"Alice"') == "Alice"
+    assert _strip_agtype_quotes("Alice") == "Alice"
+    assert _strip_agtype_quotes('"') == '"'
+    assert _strip_agtype_quotes(None) is None
+    assert _strip_agtype_quotes(3) == 3
+
+
+# ---------------------------------------------------------------------------
+# Rebuild: chunks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rebuild_chunks_payload_from_kv_records():
+    kv = JsonKVStorage(
+        {
+            "chunk-1": {
+                "content": "chunk text",
+                "full_doc_id": "doc-1",
+                "file_path": "doc.txt",
+                "tokens": 3,
+                "chunk_order_index": 0,
+            },
+            "doc-1": {"content": "not a chunk record"},  # non-chunk key ignored
+        }
+    )
+    vdb = MockVDB()
+
+    stats = await rebuild_chunks_vdb(kv, vdb)
+
+    assert stats["source_total"] == 1
+    assert stats["rebuilt"] == 1
+    record = vdb.records["chunk-1"]
+    assert record["content"] == "chunk text"
+    assert record["full_doc_id"] == "doc-1"
+    assert record["file_path"] == "doc.txt"
+    # extra pipeline fields pass through, as in the authoritative upsert
+    assert record["tokens"] == 3
+    assert record["chunk_order_index"] == 0
+    assert vdb.drop.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_rebuild_chunks_skips_records_without_content():
+    kv = JsonKVStorage(
+        {
+            "chunk-1": {"content": "ok", "full_doc_id": "doc-1"},
+            "chunk-2": {"full_doc_id": "doc-1"},  # no content
+        }
+    )
+    vdb = MockVDB()
+
+    stats = await rebuild_chunks_vdb(kv, vdb)
+
+    assert stats["rebuilt"] == 1
+    assert stats["skipped"] == 1
+    assert "chunk-2" not in vdb.records
+
+
+# ---------------------------------------------------------------------------
+# Consistency check
+# ---------------------------------------------------------------------------
+
+
+def seeded_vdbs(nodes, edges):
+    """Build entity/relation VDB mocks already containing all graph records."""
+    entities_vdb = MockVDB()
+    for n in nodes:
+        entities_vdb.records[compute_mdhash_id(n["entity_id"], prefix="ent-")] = {
+            "entity_name": n["entity_id"]
+        }
+    relationships_vdb = MockVDB()
+    for e in edges:
+        src, tgt = sorted([e["source"], e["target"]])
+        relationships_vdb.records[compute_mdhash_id(src + tgt, prefix="rel-")] = {
+            "src_id": src,
+            "tgt_id": tgt,
+        }
+    return entities_vdb, relationships_vdb
+
+
+@pytest.mark.asyncio
+async def test_check_all_consistent():
+    nodes = [node("Alice"), node("Bob")]
+    edges = [edge("Alice", "Bob")]
+    graph = make_graph(nodes=nodes, edges=edges)
+    entities_vdb, relationships_vdb = seeded_vdbs(nodes, edges)
+
+    report = await check_vdb_consistency(graph, entities_vdb, relationships_vdb)
+
+    assert report["consistent"] is True
+    assert report["graph_entities"] == 2
+    assert report["graph_relations"] == 1
+    assert report["missing_entities"] == 0
+    assert report["missing_relations"] == 0
+
+
+@pytest.mark.asyncio
+async def test_check_detects_missing_records():
+    nodes = [node("Alice"), node("Bob")]
+    edges = [edge("Alice", "Bob"), edge("Bob", "Carol")]
+    graph = make_graph(nodes=nodes, edges=edges)
+    entities_vdb, relationships_vdb = seeded_vdbs(nodes[:1], edges[:1])
+
+    report = await check_vdb_consistency(graph, entities_vdb, relationships_vdb)
+
+    assert report["consistent"] is False
+    assert report["missing_entities"] == 1
+    assert report["missing_entity_names"] == ["Bob"]
+    assert report["missing_relations"] == 1
+    assert report["missing_relation_pairs"] == ["Bob ~ Carol"]
+
+
+@pytest.mark.asyncio
+async def test_check_accepts_legacy_reverse_relation_id():
+    # Legacy custom-KG imports hashed the relation in original endpoint
+    # order; the VDB holds only the reverse-order id. Not an inconsistency.
+    graph = make_graph(edges=[edge("Bob", "Alice")])
+    entities_vdb = MockVDB()
+    relationships_vdb = MockVDB()
+    reverse_id = make_relation_vdb_ids("Bob", "Alice")[1]
+    relationships_vdb.records[reverse_id] = {"src_id": "Bob", "tgt_id": "Alice"}
+
+    report = await check_vdb_consistency(graph, entities_vdb, relationships_vdb)
+
+    assert report["missing_relations"] == 0
+    assert report["consistent"] is True
+
+
+@pytest.mark.asyncio
+async def test_check_batches_requests():
+    nodes = [node(f"E{i:03d}") for i in range(5)]
+    graph = make_graph(nodes=nodes)
+    entities_vdb, relationships_vdb = seeded_vdbs(nodes, [])
+
+    report = await check_vdb_consistency(
+        graph, entities_vdb, relationships_vdb, batch_size=2
+    )
+
+    assert report["consistent"] is True
+    assert entities_vdb.get_by_ids.await_count == 3  # ceil(5 / 2)
+    assert all(
+        len(call.args[0]) <= 2 for call in entities_vdb.get_by_ids.await_args_list
+    )
+
+
+# ---------------------------------------------------------------------------
+# Merge: fail-loud semantics in _merge_entities_impl
+# ---------------------------------------------------------------------------
+
+
+def make_merge_graph():
+    """Graph mock for merging source 'Bob' into new target 'Alice'.
+
+    Bob has one edge to Carol; Alice does not exist yet.
+    """
+    graph = MagicMock()
+    graph.has_node = AsyncMock(side_effect=lambda name: name == "Bob")
+    graph.get_node = AsyncMock(
+        return_value={
+            "entity_id": "Bob",
+            "description": "desc",
+            "entity_type": "person",
+            "source_id": "chunk-abc",
+            "file_path": "doc.txt",
+        }
+    )
+    graph.get_node_edges = AsyncMock(return_value=[("Bob", "Carol")])
+    graph.get_edge = AsyncMock(
+        return_value={
+            "description": "knows",
+            "keywords": "kw",
+            "source_id": "chunk-abc",
+            "weight": 1.0,
+            "file_path": "doc.txt",
+        }
+    )
+    graph.upsert_node = AsyncMock()
+    graph.upsert_edge = AsyncMock()
+    graph.delete_node = AsyncMock()
+    return graph
+
+
+@pytest.fixture
+def single_attempt_vdb_ops(monkeypatch):
+    """Replace the retry wrapper with a single attempt to keep tests fast."""
+    import lightrag.utils_graph as utils_graph
+
+    async def _single_attempt(operation, **kwargs):
+        await operation()
+
+    monkeypatch.setattr(
+        utils_graph, "safe_vdb_operation_with_exception", _single_attempt
+    )
+
+
+@pytest.mark.asyncio
+async def test_merge_relation_vdb_failure_raises_consistency_error(
+    single_attempt_vdb_ops,
+):
+    from lightrag.utils_graph import _merge_entities_impl
+
+    graph = make_merge_graph()
+    entities_vdb = MockVDB()
+    relationships_vdb = MockVDB()
+    relationships_vdb.upsert = AsyncMock(side_effect=RuntimeError("embedder down"))
+
+    with pytest.raises(VectorStorageConsistencyError) as excinfo:
+        await _merge_entities_impl(
+            graph, entities_vdb, relationships_vdb, ["Bob"], "Alice"
+        )
+
+    # Fail-loud guidance in the message
+    assert "lightrag-rebuild-vdb" in str(excinfo.value)
+    # Graph state was written and is kept (no rollback)
+    graph.upsert_edge.assert_awaited()
+    # Source entities were NOT deleted (step 10 never reached)
+    graph.delete_node.assert_not_awaited()
+    entities_vdb.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_merge_entity_vdb_failure_raises_consistency_error(
+    single_attempt_vdb_ops,
+):
+    from lightrag.utils_graph import _merge_entities_impl
+
+    graph = make_merge_graph()
+    entities_vdb = MockVDB()
+    relationships_vdb = MockVDB()
+    entities_vdb.upsert = AsyncMock(side_effect=RuntimeError("embedder down"))
+
+    with pytest.raises(VectorStorageConsistencyError) as excinfo:
+        await _merge_entities_impl(
+            graph, entities_vdb, relationships_vdb, ["Bob"], "Alice"
+        )
+
+    assert "lightrag-rebuild-vdb" in str(excinfo.value)
+    # Relation VDB write succeeded before the entity failure
+    relationships_vdb.upsert.assert_awaited()
+    graph.delete_node.assert_not_awaited()
+    entities_vdb.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_merge_success_path_unaffected(single_attempt_vdb_ops):
+    import lightrag.utils_graph as utils_graph
+    from lightrag.utils_graph import _merge_entities_impl
+
+    graph = make_merge_graph()
+    entities_vdb = MockVDB()
+    relationships_vdb = MockVDB()
+
+    async def _noop_persist(**kwargs):
+        return None
+
+    async def _entity_info(*args, **kwargs):
+        return {"entity_name": "Alice"}
+
+    # Avoid index_done_callback/inspection helpers needing full storages
+    orig_persist = utils_graph._persist_graph_updates
+    orig_info = utils_graph.get_entity_info
+    utils_graph._persist_graph_updates = _noop_persist
+    utils_graph.get_entity_info = _entity_info
+    try:
+        result = await _merge_entities_impl(
+            graph, entities_vdb, relationships_vdb, ["Bob"], "Alice"
+        )
+    finally:
+        utils_graph._persist_graph_updates = orig_persist
+        utils_graph.get_entity_info = orig_info
+
+    assert result == {"entity_name": "Alice"}
+    # Both VDB writes happened and the source entity was deleted
+    relationships_vdb.upsert.assert_awaited()
+    entities_vdb.upsert.assert_awaited()
+    graph.delete_node.assert_awaited_with("Bob")

--- a/tests/tools/test_rebuild_vdb.py
+++ b/tests/tools/test_rebuild_vdb.py
@@ -752,3 +752,73 @@ async def test_merge_entity_deferred_flush_failure_raises_before_delete(
     entities_vdb.index_done_callback.assert_awaited()
     graph.delete_node.assert_not_awaited()
     entities_vdb.delete.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Setup: check-only (no api extra) stub embedding function
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_only_stub_carries_embedding_model_name(monkeypatch):
+    # When the api extra is unavailable the tool runs check-only with a stub
+    # embedding function. Qdrant/PostgreSQL locate the collection/table from
+    # model_name + embedding_dim, so the stub must carry the configured
+    # EMBEDDING_MODEL — otherwise check-only probes the legacy-named collection
+    # and misreports records as missing.
+    import lightrag.kg.factory as kg_factory
+    from lightrag.tools.rebuild_vdb import RebuildTool
+
+    monkeypatch.setenv("EMBEDDING_MODEL", "text-embedding-3-large")
+    monkeypatch.setenv("EMBEDDING_DIM", "3072")
+
+    captured_funcs = []
+
+    class _DummyStorage:
+        def __init__(self, *, embedding_func, **kwargs):
+            captured_funcs.append(embedding_func)
+
+        async def initialize(self):
+            return None
+
+    monkeypatch.setattr(kg_factory, "get_storage_class", lambda name: _DummyStorage)
+
+    tool = RebuildTool()
+    # Simulate the api extra being unavailable (check-only mode).
+    monkeypatch.setattr(tool, "build_embedding_func", lambda: None)
+
+    ok = await tool.setup_storages()
+
+    assert ok is True
+    assert tool.embedding_available is False
+    assert tool.embedding_func.model_name == "text-embedding-3-large"
+    assert tool.embedding_func.embedding_dim == 3072
+    # Every storage received the stub carrying the configured model name.
+    assert captured_funcs
+    assert all(f.model_name == "text-embedding-3-large" for f in captured_funcs)
+
+
+@pytest.mark.asyncio
+async def test_check_only_stub_model_name_none_when_unset(monkeypatch):
+    # EMBEDDING_MODEL unset -> model_name None (provider default), matching the
+    # server factory; "None" literal is also treated as unset.
+    import lightrag.kg.factory as kg_factory
+    from lightrag.tools.rebuild_vdb import RebuildTool
+
+    monkeypatch.delenv("EMBEDDING_MODEL", raising=False)
+
+    class _DummyStorage:
+        def __init__(self, **kwargs):
+            pass
+
+        async def initialize(self):
+            return None
+
+    monkeypatch.setattr(kg_factory, "get_storage_class", lambda name: _DummyStorage)
+
+    tool = RebuildTool()
+    monkeypatch.setattr(tool, "build_embedding_func", lambda: None)
+
+    await tool.setup_storages()
+
+    assert tool.embedding_func.model_name is None

--- a/tests/tools/test_rebuild_vdb.py
+++ b/tests/tools/test_rebuild_vdb.py
@@ -822,3 +822,124 @@ async def test_check_only_stub_model_name_none_when_unset(monkeypatch):
     await tool.setup_storages()
 
     assert tool.embedding_func.model_name is None
+
+
+# ---------------------------------------------------------------------------
+# CLI exit-code semantics: run() must report success/failure
+# ---------------------------------------------------------------------------
+
+
+def _runnable_tool(monkeypatch, inputs):
+    """A RebuildTool with shared-storage init/finalize and prompts stubbed."""
+    import lightrag.kg.shared_storage as shared
+
+    monkeypatch.setattr(shared, "initialize_share_data", lambda workers=1: None)
+    monkeypatch.setattr(shared, "finalize_share_data", lambda: None)
+    monkeypatch.setattr("builtins.input", lambda *a: next(inputs))
+
+    tool = rebuild_vdb.RebuildTool()
+    monkeypatch.setattr(tool, "print_header", lambda: None)
+    monkeypatch.setattr(tool, "confirm_server_stopped", lambda: True)
+    return tool
+
+
+@pytest.mark.asyncio
+async def test_run_returns_true_on_user_cancel(monkeypatch):
+    tool = _runnable_tool(monkeypatch, iter([]))
+    monkeypatch.setattr(tool, "confirm_server_stopped", lambda: False)
+    tool.setup_storages = AsyncMock(return_value=True)
+
+    assert await tool.run() is True
+    tool.setup_storages.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_returns_false_on_setup_failure(monkeypatch):
+    tool = _runnable_tool(monkeypatch, iter([]))
+    tool.setup_storages = AsyncMock(return_value=False)
+
+    assert await tool.run() is False
+
+
+@pytest.mark.asyncio
+async def test_run_returns_false_on_unhandled_exception(monkeypatch):
+    tool = _runnable_tool(monkeypatch, iter([]))
+    tool.setup_storages = AsyncMock(side_effect=RuntimeError("db down"))
+
+    assert await tool.run() is False
+
+
+@pytest.mark.asyncio
+async def test_run_returns_false_when_rebuild_has_errors(monkeypatch):
+    tool = _runnable_tool(monkeypatch, iter(["2", "0"]))
+    tool.setup_storages = AsyncMock(return_value=True)
+    tool.embedding_available = True
+    tool.print_source_counts = AsyncMock()
+    monkeypatch.setattr(tool, "confirm_rebuild", lambda targets: True)
+
+    failed = rebuild_vdb._new_stats("entities", 3)
+    failed["failed_batches"] = 1
+    failed["errors"] = [
+        {
+            "batch": 1,
+            "records_lost": 3,
+            "error_type": "RuntimeError",
+            "error_msg": "embedder down",
+        }
+    ]
+    tool.run_rebuild_entities_relations = AsyncMock(return_value=[failed])
+
+    assert await tool.run() is False
+
+
+@pytest.mark.asyncio
+async def test_run_returns_true_on_clean_rebuild(monkeypatch):
+    tool = _runnable_tool(monkeypatch, iter(["2", "0"]))
+    tool.setup_storages = AsyncMock(return_value=True)
+    tool.embedding_available = True
+    tool.print_source_counts = AsyncMock()
+    monkeypatch.setattr(tool, "confirm_rebuild", lambda targets: True)
+
+    ok = rebuild_vdb._new_stats("entities", 3)
+    ok["rebuilt"] = 3
+    tool.run_rebuild_entities_relations = AsyncMock(return_value=[ok])
+
+    assert await tool.run() is True
+
+
+@pytest.mark.asyncio
+async def test_run_check_only_exits_true(monkeypatch):
+    tool = _runnable_tool(monkeypatch, iter(["1", "0"]))
+    tool.setup_storages = AsyncMock(return_value=True)
+    tool.embedding_available = False
+    tool.run_check = AsyncMock()
+
+    assert await tool.run() is True
+    tool.run_check.assert_awaited()
+
+
+def test_main_exits_nonzero_on_failure(monkeypatch):
+    monkeypatch.setattr(rebuild_vdb, "load_dotenv", lambda **k: None)
+    monkeypatch.setattr(rebuild_vdb, "setup_logger", lambda *a, **k: None)
+
+    async def _fail():
+        return False
+
+    monkeypatch.setattr(rebuild_vdb, "async_main", _fail)
+
+    with pytest.raises(SystemExit) as excinfo:
+        rebuild_vdb.main()
+    assert excinfo.value.code == 1
+
+
+def test_main_exits_zero_on_success(monkeypatch):
+    monkeypatch.setattr(rebuild_vdb, "load_dotenv", lambda **k: None)
+    monkeypatch.setattr(rebuild_vdb, "setup_logger", lambda *a, **k: None)
+
+    async def _ok():
+        return True
+
+    monkeypatch.setattr(rebuild_vdb, "async_main", _ok)
+
+    # No SystemExit on success.
+    rebuild_vdb.main()

--- a/tests/tools/test_rebuild_vdb.py
+++ b/tests/tools/test_rebuild_vdb.py
@@ -608,6 +608,61 @@ async def test_merge_entity_vdb_failure_raises_consistency_error(
 
 
 @pytest.mark.asyncio
+async def test_merge_source_entity_delete_failure_raises_consistency_error(
+    single_attempt_vdb_ops,
+):
+    # Step 10 deletes the source node from the graph first, then its vector
+    # record. A delete failure here happens AFTER the graph node is gone, so it
+    # must fail loud with a message that does not claim the source still exists.
+    from lightrag.utils_graph import _merge_entities_impl
+
+    graph = make_merge_graph()
+    entities_vdb = MockVDB()
+    relationships_vdb = MockVDB()
+    entities_vdb.delete = AsyncMock(side_effect=RuntimeError("vdb delete down"))
+
+    with pytest.raises(VectorStorageConsistencyError) as excinfo:
+        await _merge_entities_impl(
+            graph, entities_vdb, relationships_vdb, ["Bob"], "Alice"
+        )
+
+    message = str(excinfo.value)
+    assert "lightrag-rebuild-vdb" in message
+    # The source node was already removed; the message must not claim otherwise.
+    graph.delete_node.assert_awaited_with("Bob")
+    assert "were not deleted" not in message
+    entities_vdb.delete.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_merge_final_persist_failure_raises_consistency_error(
+    single_attempt_vdb_ops,
+):
+    # The step-11 _persist_graph_updates flush runs after source deletion; a
+    # failure there must also fail loud (not a raw exception swallowed upstream).
+    from lightrag.utils_graph import _merge_entities_impl
+
+    graph = make_merge_graph()
+    entities_vdb = MockVDB()
+    relationships_vdb = MockVDB()
+    # Succeed at the 8b flush, fail at the final persist flush (step 11).
+    entities_vdb.index_done_callback = AsyncMock(
+        side_effect=[None, RuntimeError("flush down")]
+    )
+
+    with pytest.raises(VectorStorageConsistencyError) as excinfo:
+        await _merge_entities_impl(
+            graph, entities_vdb, relationships_vdb, ["Bob"], "Alice"
+        )
+
+    message = str(excinfo.value)
+    assert "lightrag-rebuild-vdb" in message
+    # Source deletion already happened before the final persist.
+    graph.delete_node.assert_awaited_with("Bob")
+    assert "were not deleted" not in message
+
+
+@pytest.mark.asyncio
 async def test_merge_success_path_unaffected(single_attempt_vdb_ops):
     import lightrag.utils_graph as utils_graph
     from lightrag.utils_graph import _merge_entities_impl

--- a/tests/tools/test_rebuild_vdb.py
+++ b/tests/tools/test_rebuild_vdb.py
@@ -136,6 +136,7 @@ async def test_rebuild_entities_payload_matches_authoritative_format():
             "entity_type": "person",
             "content": "Alice\ndescription of Alice",
             "source_id": "chunk-abc",
+            "description": "description of Alice",
             "file_path": "doc.txt",
         }
     }
@@ -485,6 +486,7 @@ def make_merge_graph():
     graph.upsert_node = AsyncMock()
     graph.upsert_edge = AsyncMock()
     graph.delete_node = AsyncMock()
+    graph.index_done_callback = AsyncMock()
     return graph
 
 
@@ -582,3 +584,60 @@ async def test_merge_success_path_unaffected(single_attempt_vdb_ops):
     relationships_vdb.upsert.assert_awaited()
     entities_vdb.upsert.assert_awaited()
     graph.delete_node.assert_awaited_with("Bob")
+
+
+@pytest.mark.asyncio
+async def test_merge_deferred_flush_failure_raises_before_delete(
+    single_attempt_vdb_ops,
+):
+    # Deferred-embedding backends (nano/faiss) buffer in upsert() and only embed
+    # in index_done_callback, so an embedder outage surfaces at flush time. The
+    # fail-loud guarantee must still hold: raise before deleting source entities.
+    from lightrag.utils_graph import _merge_entities_impl
+
+    graph = make_merge_graph()
+    entities_vdb = MockVDB()
+    relationships_vdb = MockVDB()
+    # upsert succeeds (buffers); the embedding failure happens at flush.
+    relationships_vdb.index_done_callback = AsyncMock(
+        side_effect=RuntimeError("embedder down")
+    )
+
+    with pytest.raises(VectorStorageConsistencyError) as excinfo:
+        await _merge_entities_impl(
+            graph, entities_vdb, relationships_vdb, ["Bob"], "Alice"
+        )
+
+    assert "lightrag-rebuild-vdb" in str(excinfo.value)
+    # upsert succeeded; the failure is the deferred flush
+    relationships_vdb.upsert.assert_awaited()
+    relationships_vdb.index_done_callback.assert_awaited()
+    # Source entities NOT deleted (step 10 never reached), so the message holds
+    graph.delete_node.assert_not_awaited()
+    entities_vdb.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_merge_entity_deferred_flush_failure_raises_before_delete(
+    single_attempt_vdb_ops,
+):
+    from lightrag.utils_graph import _merge_entities_impl
+
+    graph = make_merge_graph()
+    entities_vdb = MockVDB()
+    relationships_vdb = MockVDB()
+    entities_vdb.index_done_callback = AsyncMock(
+        side_effect=RuntimeError("embedder down")
+    )
+
+    with pytest.raises(VectorStorageConsistencyError) as excinfo:
+        await _merge_entities_impl(
+            graph, entities_vdb, relationships_vdb, ["Bob"], "Alice"
+        )
+
+    assert "lightrag-rebuild-vdb" in str(excinfo.value)
+    # Relation flush succeeded before the entity flush failed
+    relationships_vdb.index_done_callback.assert_awaited()
+    entities_vdb.index_done_callback.assert_awaited()
+    graph.delete_node.assert_not_awaited()
+    entities_vdb.delete.assert_not_awaited()

--- a/tests/tools/test_rebuild_vdb.py
+++ b/tests/tools/test_rebuild_vdb.py
@@ -329,7 +329,6 @@ async def test_rebuild_chunks_payload_from_kv_records():
                 "tokens": 3,
                 "chunk_order_index": 0,
             },
-            "doc-1": {"content": "not a chunk record"},  # non-chunk key ignored
         }
     )
     vdb = MockVDB()
@@ -363,6 +362,38 @@ async def test_rebuild_chunks_skips_records_without_content():
     assert stats["rebuilt"] == 1
     assert stats["skipped"] == 1
     assert "chunk-2" not in vdb.records
+
+
+@pytest.mark.asyncio
+async def test_rebuild_chunks_covers_all_id_schemes():
+    # Chunks live under several id schemes that no single prefix matches:
+    # custom KG ("chunk-<hash>"), the text pipeline ("{doc_id}-chunk-{order}",
+    # which does NOT start with "chunk-"), and multimodal
+    # ("{doc_id}-mm-<modality>-{order}"). A prefix-only filter dropped the
+    # pipeline/multimodal chunks and rebuilt to zero. All schemes must rebuild.
+    kv = JsonKVStorage(
+        {
+            "chunk-deadbeef": {"content": "custom kg", "full_doc_id": "doc-xyz"},
+            "doc-abc123-chunk-000": {"content": "first", "full_doc_id": "doc-abc123"},
+            "doc-abc123-chunk-001": {"content": "second", "full_doc_id": "doc-abc123"},
+            "doc-abc123-mm-drawing-000": {
+                "content": "image caption",
+                "full_doc_id": "doc-abc123",
+            },
+        }
+    )
+    vdb = MockVDB()
+
+    stats = await rebuild_chunks_vdb(kv, vdb)
+
+    assert stats["source_total"] == 4
+    assert stats["rebuilt"] == 4
+    assert set(vdb.records) == {
+        "chunk-deadbeef",
+        "doc-abc123-chunk-000",
+        "doc-abc123-chunk-001",
+        "doc-abc123-mm-drawing-000",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_rebuild_vdb.py
+++ b/tests/tools/test_rebuild_vdb.py
@@ -535,6 +535,31 @@ def single_attempt_vdb_ops(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_merge_relation_vdb_delete_failure_raises_consistency_error(
+    single_attempt_vdb_ops,
+):
+    # The step-7 delete of stale relation records runs after the graph is
+    # updated; a failure there must fail loud (and not be swallowed upstream).
+    from lightrag.utils_graph import _merge_entities_impl
+
+    graph = make_merge_graph()
+    entities_vdb = MockVDB()
+    relationships_vdb = MockVDB()
+    relationships_vdb.delete = AsyncMock(side_effect=RuntimeError("vdb delete down"))
+
+    with pytest.raises(VectorStorageConsistencyError) as excinfo:
+        await _merge_entities_impl(
+            graph, entities_vdb, relationships_vdb, ["Bob"], "Alice"
+        )
+
+    assert "lightrag-rebuild-vdb" in str(excinfo.value)
+    relationships_vdb.delete.assert_awaited()
+    # Failure is before source-entity deletion (step 10)
+    graph.delete_node.assert_not_awaited()
+    entities_vdb.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_merge_relation_vdb_failure_raises_consistency_error(
     single_attempt_vdb_ops,
 ):


### PR DESCRIPTION
## Summary

Adds `lightrag-rebuild-vdb`, an offline recovery and maintenance tool that rebuilds LightRAG vector storages from authoritative graph/KV data. The PR also makes graph-edit/merge VDB write failures fail loudly with `VectorStorageConsistencyError`, so operators get a clear recovery path instead of silent graph/vector drift.

The tool is useful for:

- recovering after embedder outages, network timeouts, or backend errors leave graph records without vector counterparts;
- clearing stale VDB-only records that no longer exist in the graph;
- rebuilding all vector storages after changing the embedding model or embedding dimension;
- diagnosing graph -> VDB gaps before paying the cost of a full re-embedding.

## Offline VDB rebuild tool

`lightrag-rebuild-vdb` drops and rebuilds the selected vector storages from the data LightRAG already treats as authoritative:

| Vector storage | Rebuilt from |
| --- | --- |
| `entities_vdb` | graph nodes |
| `relationships_vdb` | graph edges |
| `chunks_vdb` | `text_chunks` KV store |

Key behavior:

- uses the same `.env` and embedding factory as the server, including `EMBEDDING_*`, model name, dimension, workspace, and backend config;
- provides a consistency-check mode that reports missing graph -> VDB entity/relation records without running a rebuild;
- supports full rebuilds for entities, relationships, and chunks, including all chunk id schemes used by custom KG, the text pipeline, and multimodal content;
- handles backend-specific details such as PG/AGE quoted endpoints, Neo4j/Memgraph duplicate edge directions, deferred embedding backends (nano/faiss), and KV key enumeration for JsonKV/Redis/PG/Mongo/OpenSearch;
- is safe to rerun because authoritative graph/KV sources are never modified, and exits non-zero if storage init, interruption, or any batch/flush fails.

Operational notes:

- stop the LightRAG server and other writers before running it, even for check mode, because storage initialization can run schema setup or legacy migrations;
- a rebuild re-embeds every affected record, so it can incur embedding API cost;
- after changing the embedding model or dimension, run with the updated `.env` and choose **Rebuild ALL vector storages**. Check mode can pass when vectors exist but were embedded in the old space.

## Fail-loud recovery path

- Wraps graph merge/edit VDB writes, deletes, and flushes in retrying safe operations.
- Raises `VectorStorageConsistencyError` with `lightrag-rebuild-vdb` guidance when consistency may be compromised.
- Ensures edit-with-merge does not swallow these errors as partial-success HTTP 200 responses.
- Keeps mutation responses based on authoritative graph data and marks `include_vector_data` as deprecated for entity/relation info helpers.

## Supporting fixes

- Extracts the server embedding factory so offline tools build vectors in the same embedding space as the running server.
- Strips PostgreSQL `content_vector` from SQL fallback `get_by_id(s)` results to avoid JSON serialization failures.
- Strips Mongo-managed `_id` from graph node/edge reads to avoid immutable-field re-upsert errors.
- Adds the `lightrag-rebuild-vdb` entry point and `lightrag/tools/README_REBUILD_VDB.md`.

## Tests

Added/updated coverage for:

- VDB rebuild payload fidelity, batching, deduplication, dirty-data skipping, drop-before-upsert ordering, deferred flush failures, and non-zero exit behavior;
- consistency check behavior, including legacy reverse relation ids;
- fail-loud merge/edit paths and mutation responses;
- PostgreSQL vector payload serialization shape;
- API description validation coverage touched by this branch.

## Related issues

- Fixes #2917
- Supersedes #2941