### PR TITLE
Add workspace path traversal validation

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -7,7 +7,12 @@ import re
 import shutil
 import time
 from uuid import uuid4
-from lightrag.utils import logger, get_pinyin_sort_key, performance_timing_log
+from lightrag.utils import (
+    logger,
+    get_pinyin_sort_key,
+    performance_timing_log,
+    validate_workspace,
+)
 import aiofiles
 import traceback
 from datetime import datetime, timezone
@@ -969,6 +974,8 @@ class DocumentManager:
         input_dir: str,
         workspace: str = "",  # New parameter for workspace isolation
     ):
+        # Reject path traversal before using workspace in the upload path
+        validate_workspace(workspace)
         # Store the base input directory and workspace
         self.base_input_dir = Path(input_dir)
         self.workspace = workspace

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -200,6 +200,8 @@ class FaissVectorDBStorage(BaseVectorStorage):
     """
 
     def __post_init__(self):
+        # Reject path traversal before using workspace in a file path
+        validate_workspace(self.workspace)
         self._validate_embedding_func()
         # Grab config values if available
         kwargs = self.global_config.get("vector_db_storage_cls_kwargs", {})
@@ -213,8 +215,6 @@ class FaissVectorDBStorage(BaseVectorStorage):
         # Where to save index file if you want persistent storage
         working_dir = self.global_config["working_dir"]
         if self.workspace:
-            # Reject path traversal before using workspace in a file path
-            validate_workspace(self.workspace)
             # Include workspace in the file path for data isolation
             workspace_dir = os.path.join(working_dir, self.workspace)
 

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -8,7 +8,7 @@ import numpy as np
 from dataclasses import dataclass
 
 from lightrag.file_atomic import atomic_write, reap_orphan_tmp_files
-from lightrag.utils import logger, compute_mdhash_id
+from lightrag.utils import logger, compute_mdhash_id, validate_workspace
 from lightrag.base import BaseVectorStorage
 from lightrag.constants import DEFAULT_QUERY_PRIORITY
 
@@ -213,6 +213,8 @@ class FaissVectorDBStorage(BaseVectorStorage):
         # Where to save index file if you want persistent storage
         working_dir = self.global_config["working_dir"]
         if self.workspace:
+            # Reject path traversal before using workspace in a file path
+            validate_workspace(self.workspace)
             # Include workspace in the file path for data isolation
             workspace_dir = os.path.join(working_dir, self.workspace)
 

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -76,10 +76,10 @@ class JsonDocStatusStorage(DocStatusStorage):
     """
 
     def __post_init__(self):
+        # Reject path traversal before using workspace in a file path
+        validate_workspace(self.workspace)
         working_dir = self.global_config["working_dir"]
         if self.workspace:
-            # Reject path traversal before using workspace in a file path
-            validate_workspace(self.workspace)
             # Include workspace in the file path for data isolation
             workspace_dir = os.path.join(working_dir, self.workspace)
         else:

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -12,6 +12,7 @@ from lightrag.utils import (
     _cooperative_yield,
     load_json,
     logger,
+    validate_workspace,
     write_json,
     get_pinyin_sort_key,
 )
@@ -77,6 +78,8 @@ class JsonDocStatusStorage(DocStatusStorage):
     def __post_init__(self):
         working_dir = self.global_config["working_dir"]
         if self.workspace:
+            # Reject path traversal before using workspace in a file path
+            validate_workspace(self.workspace)
             # Include workspace in the file path for data isolation
             workspace_dir = os.path.join(working_dir, self.workspace)
         else:

--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -133,10 +133,10 @@ class JsonKVStorage(BaseKVStorage):
     """
 
     def __post_init__(self):
+        # Reject path traversal before using workspace in a file path
+        validate_workspace(self.workspace)
         working_dir = self.global_config["working_dir"]
         if self.workspace:
-            # Reject path traversal before using workspace in a file path
-            validate_workspace(self.workspace)
             # Include workspace in the file path for data isolation
             workspace_dir = os.path.join(working_dir, self.workspace)
         else:

--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -10,6 +10,7 @@ from lightrag.utils import (
     _cooperative_yield,
     load_json,
     logger,
+    validate_workspace,
     write_json,
 )
 from lightrag.exceptions import StorageNotInitializedError
@@ -134,6 +135,8 @@ class JsonKVStorage(BaseKVStorage):
     def __post_init__(self):
         working_dir = self.global_config["working_dir"]
         if self.workspace:
+            # Reject path traversal before using workspace in a file path
+            validate_workspace(self.workspace)
             # Include workspace in the file path for data isolation
             workspace_dir = os.path.join(working_dir, self.workspace)
         else:

--- a/lightrag/kg/memgraph_impl.py
+++ b/lightrag/kg/memgraph_impl.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import final
 import configparser
 
-from ..utils import logger
+from ..utils import logger, validate_workspace
 from ..base import BaseGraphStorage
 from ..types import KnowledgeGraph, KnowledgeGraphNode, KnowledgeGraphEdge
 from ..kg.shared_storage import get_data_init_lock
@@ -49,6 +49,7 @@ class MemgraphStorage(BaseGraphStorage):
             global_config=global_config,
             embedding_func=embedding_func,
         )
+        validate_workspace(self.workspace)
 
         # Log after super().__init__() to ensure self.workspace is initialized
         if memgraph_workspace and memgraph_workspace.strip():

--- a/lightrag/kg/milvus_impl.py
+++ b/lightrag/kg/milvus_impl.py
@@ -4,7 +4,12 @@ import os
 from typing import Any, final, Optional, Dict
 from dataclasses import dataclass, fields
 import numpy as np
-from lightrag.utils import logger, compute_mdhash_id, _cooperative_yield
+from lightrag.utils import (
+    logger,
+    compute_mdhash_id,
+    _cooperative_yield,
+    validate_workspace,
+)
 from ..base import BaseVectorStorage
 from ..constants import DEFAULT_MAX_FILE_PATH_LENGTH, DEFAULT_QUERY_PRIORITY
 from ..kg.shared_storage import get_data_init_lock, get_namespace_lock
@@ -1358,6 +1363,7 @@ class MilvusVectorDBStorage(BaseVectorStorage):
                 raise
 
     def __post_init__(self):
+        validate_workspace(self.workspace)
         self._validate_embedding_func()
 
         # Extract MilvusIndexConfig parameters from vector_db_storage_cls_kwargs

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -17,7 +17,13 @@ from ..base import (
     DocStatus,
     DocStatusStorage,
 )
-from ..utils import logger, compute_mdhash_id, _cooperative_yield, merge_source_ids
+from ..utils import (
+    logger,
+    compute_mdhash_id,
+    _cooperative_yield,
+    merge_source_ids,
+    validate_workspace,
+)
 from ..types import KnowledgeGraph, KnowledgeGraphNode, KnowledgeGraphEdge
 from ..constants import GRAPH_FIELD_SEP, DEFAULT_QUERY_PRIORITY
 from .._version import __version__
@@ -326,6 +332,7 @@ class MongoKVStorage(BaseKVStorage):
         self.__post_init__()
 
     def __post_init__(self):
+        validate_workspace(self.workspace)
         # Check for MONGODB_WORKSPACE environment variable first (higher priority)
         # This allows administrators to force a specific workspace for all MongoDB storage instances
         mongodb_workspace = os.environ.get("MONGODB_WORKSPACE")
@@ -574,6 +581,7 @@ class MongoDocStatusStorage(DocStatusStorage):
         self.__post_init__()
 
     def __post_init__(self):
+        validate_workspace(self.workspace)
         # Check for MONGODB_WORKSPACE environment variable first (higher priority)
         # This allows administrators to force a specific workspace for all MongoDB storage instances
         mongodb_workspace = os.environ.get("MONGODB_WORKSPACE")
@@ -1084,6 +1092,7 @@ class MongoGraphStorage(BaseGraphStorage):
             global_config=global_config,
             embedding_func=embedding_func,
         )
+        validate_workspace(self.workspace)
         # Check for MONGODB_WORKSPACE environment variable first (higher priority)
         # This allows administrators to force a specific workspace for all MongoDB storage instances
         mongodb_workspace = os.environ.get("MONGODB_WORKSPACE")
@@ -2845,6 +2854,7 @@ class MongoVectorDBStorage(BaseVectorStorage):
         self.__post_init__()
 
     def __post_init__(self):
+        validate_workspace(self.workspace)
         self._validate_embedding_func()
 
         # Check for MONGODB_WORKSPACE environment variable first (higher priority)

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -151,6 +151,8 @@ class NanoVectorDBStorage(BaseVectorStorage):
     """
 
     def __post_init__(self):
+        # Reject path traversal before using workspace in a file path
+        validate_workspace(self.workspace)
         self._validate_embedding_func()
         # Initialize basic attributes
         self._client = None
@@ -168,8 +170,6 @@ class NanoVectorDBStorage(BaseVectorStorage):
 
         working_dir = self.global_config["working_dir"]
         if self.workspace:
-            # Reject path traversal before using workspace in a file path
-            validate_workspace(self.workspace)
             # Include workspace in the file path for data isolation
             workspace_dir = os.path.join(working_dir, self.workspace)
             self.final_namespace = f"{self.workspace}_{self.namespace}"

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -11,6 +11,7 @@ from lightrag.file_atomic import atomic_write, reap_orphan_tmp_files
 from lightrag.utils import (
     logger,
     compute_mdhash_id,
+    validate_workspace,
 )
 
 from lightrag.base import BaseVectorStorage
@@ -167,6 +168,8 @@ class NanoVectorDBStorage(BaseVectorStorage):
 
         working_dir = self.global_config["working_dir"]
         if self.workspace:
+            # Reject path traversal before using workspace in a file path
+            validate_workspace(self.workspace)
             # Include workspace in the file path for data isolation
             workspace_dir = os.path.join(working_dir, self.workspace)
             self.final_namespace = f"{self.workspace}_{self.namespace}"

--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -15,7 +15,7 @@ from tenacity import (
 )
 
 import logging
-from ..utils import logger
+from ..utils import logger, validate_workspace
 from ..base import BaseGraphStorage
 from ..types import KnowledgeGraph, KnowledgeGraphNode, KnowledgeGraphEdge
 from ..kg.shared_storage import get_data_init_lock
@@ -93,6 +93,7 @@ class Neo4JStorage(BaseGraphStorage):
             global_config=global_config,
             embedding_func=embedding_func,
         )
+        validate_workspace(self.workspace)
 
         # Log after super().__init__() to ensure self.workspace is initialized
         if neo4j_workspace and neo4j_workspace.strip():

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -139,10 +139,10 @@ class NetworkXStorage(BaseGraphStorage):
         )
 
     def __post_init__(self):
+        # Reject path traversal before using workspace in a file path
+        validate_workspace(self.workspace)
         working_dir = self.global_config["working_dir"]
         if self.workspace:
-            # Reject path traversal before using workspace in a file path
-            validate_workspace(self.workspace)
             # Include workspace in the file path for data isolation
             workspace_dir = os.path.join(working_dir, self.workspace)
         else:

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -5,7 +5,7 @@ from typing import final
 
 from lightrag.file_atomic import atomic_write, reap_orphan_tmp_files
 from lightrag.types import KnowledgeGraph, KnowledgeGraphNode, KnowledgeGraphEdge
-from lightrag.utils import logger
+from lightrag.utils import logger, validate_workspace
 from lightrag.base import BaseGraphStorage
 import networkx as nx
 from .shared_storage import (
@@ -141,6 +141,8 @@ class NetworkXStorage(BaseGraphStorage):
     def __post_init__(self):
         working_dir = self.global_config["working_dir"]
         if self.workspace:
+            # Reject path traversal before using workspace in a file path
+            validate_workspace(self.workspace)
             # Include workspace in the file path for data isolation
             workspace_dir = os.path.join(working_dir, self.workspace)
         else:

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -27,7 +27,13 @@ from ..base import (
     DocStatus,
     DocStatusStorage,
 )
-from ..utils import logger, compute_mdhash_id, _cooperative_yield, merge_source_ids
+from ..utils import (
+    logger,
+    compute_mdhash_id,
+    _cooperative_yield,
+    merge_source_ids,
+    validate_workspace,
+)
 from ..types import KnowledgeGraph, KnowledgeGraphNode, KnowledgeGraphEdge
 from ..constants import GRAPH_FIELD_SEP, DEFAULT_QUERY_PRIORITY
 from ..kg.shared_storage import get_data_init_lock, get_namespace_lock
@@ -610,6 +616,7 @@ class OpenSearchKVStorage(BaseKVStorage):
         self.__post_init__()
 
     def __post_init__(self):
+        validate_workspace(self.workspace)
         self.workspace, self.final_namespace, self._index_name = _build_index_name(
             self.workspace, self.namespace
         )
@@ -1205,6 +1212,7 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
         self.__post_init__()
 
     def __post_init__(self):
+        validate_workspace(self.workspace)
         self.workspace, self.final_namespace, self._index_name = _build_index_name(
             self.workspace, self.namespace
         )
@@ -1843,6 +1851,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
         self.__post_init__()
 
     def __post_init__(self):
+        validate_workspace(self.workspace)
         self.workspace, self.final_namespace, base_name = _build_index_name(
             self.workspace, self.namespace
         )
@@ -3736,6 +3745,7 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
         self.__post_init__()
 
     def __post_init__(self):
+        validate_workspace(self.workspace)
         self._validate_embedding_func()
         self.workspace, self.final_namespace, self._index_name = _build_index_name(
             self.workspace, self.namespace

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -42,6 +42,7 @@ from ..utils import (
     compute_mdhash_id,
     _cooperative_yield,
     performance_timing_log,
+    validate_workspace,
 )
 from ..kg.shared_storage import get_data_init_lock, get_namespace_lock
 
@@ -2508,6 +2509,7 @@ class PGKVStorage(BaseKVStorage):
     db: PostgreSQLDB = field(default=None)
 
     def __post_init__(self):
+        validate_workspace(self.workspace)
         self._max_batch_size = 200  # DB batch size, independent of embedding batch size
         (
             self._max_upsert_payload_bytes,
@@ -3239,6 +3241,7 @@ class PGVectorStorage(BaseVectorStorage):
     db: PostgreSQLDB | None = field(default=None)
 
     def __post_init__(self):
+        validate_workspace(self.workspace)
         self._validate_embedding_func()
         self._max_batch_size = self.global_config["embedding_batch_num"]
         # DB-write batching limits (distinct from the embedding batch size above).
@@ -4754,6 +4757,7 @@ class PGDocStatusStorage(DocStatusStorage):
     db: PostgreSQLDB = field(default=None)
 
     def __post_init__(self):
+        validate_workspace(self.workspace)
         (
             self._max_upsert_payload_bytes,
             self._max_upsert_records_per_batch,
@@ -5855,6 +5859,7 @@ _GRAPH_ADVISORY_LOCK_SHARED_SQL = (
 @dataclass
 class PGGraphStorage(BaseGraphStorage):
     def __post_init__(self):
+        validate_workspace(self.workspace)
         # Graph name will be dynamically generated in initialize() based on workspace
         self.db: PostgreSQLDB | None = None
         # Chunk-level batching limits for the batch upsert / remove paths. The

--- a/lightrag/kg/qdrant_impl.py
+++ b/lightrag/kg/qdrant_impl.py
@@ -14,7 +14,7 @@ from ..base import BaseVectorStorage
 from ..constants import DEFAULT_QUERY_PRIORITY
 from ..exceptions import DataMigrationError
 from ..kg.shared_storage import get_data_init_lock, get_namespace_lock
-from ..utils import _cooperative_yield, compute_mdhash_id, logger
+from ..utils import _cooperative_yield, compute_mdhash_id, logger, validate_workspace
 
 if not pm.is_installed("qdrant-client"):
     pm.install("qdrant-client")
@@ -428,6 +428,7 @@ class QdrantVectorDBStorage(BaseVectorStorage):
             )
 
     def __post_init__(self):
+        validate_workspace(self.workspace)
         self._validate_embedding_func()
         # Check for QDRANT_WORKSPACE environment variable first (higher priority)
         # This allows administrators to force a specific workspace for all Qdrant storage instances

--- a/lightrag/kg/redis_impl.py
+++ b/lightrag/kg/redis_impl.py
@@ -13,7 +13,12 @@ if not pm.is_installed("redis"):
 # aioredis is a depricated library, replaced with redis
 from redis.asyncio import Redis, ConnectionPool  # type: ignore
 from redis.exceptions import RedisError, ConnectionError, TimeoutError  # type: ignore
-from lightrag.utils import logger, get_pinyin_sort_key, _cooperative_yield
+from lightrag.utils import (
+    logger,
+    get_pinyin_sort_key,
+    _cooperative_yield,
+    validate_workspace,
+)
 
 from lightrag.base import (
     BaseKVStorage,
@@ -126,6 +131,7 @@ class RedisConnectionManager:
 @dataclass
 class RedisKVStorage(BaseKVStorage):
     def __post_init__(self):
+        validate_workspace(self.workspace)
         # Check for REDIS_WORKSPACE environment variable first (higher priority)
         # This allows administrators to force a specific workspace for all Redis storage instances
         redis_workspace = os.environ.get("REDIS_WORKSPACE")
@@ -522,6 +528,7 @@ class RedisDocStatusStorage(DocStatusStorage):
     """Redis implementation of document status storage"""
 
     def __post_init__(self):
+        validate_workspace(self.workspace)
         # Check for REDIS_WORKSPACE environment variable first (higher priority)
         # This allows administrators to force a specific workspace for all Redis storage instances
         redis_workspace = os.environ.get("REDIS_WORKSPACE")

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4107,3 +4107,44 @@ def generate_reference_list_from_chunks(
         reference_list.append({"reference_id": str(i + 1), "file_path": file_path})
 
     return reference_list, updated_chunks
+
+
+def validate_workspace(workspace: str) -> str:
+    """Validate a workspace name used to build per-workspace directories.
+
+    File-based storages place their data in a subdirectory named after the
+    workspace under ``working_dir`` (``os.path.join(working_dir, workspace)``).
+    To prevent path traversal, the workspace must be a single path component:
+    it may not contain a path separator nor be a relative path reference.
+
+    Unlike a sanitizing approach, this validator does not rewrite the name.
+    Legitimate names containing dots (e.g. ``"v1.0"``) are accepted unchanged,
+    while unsafe names are rejected so the caller fails fast instead of
+    silently reading or writing outside the intended directory.
+
+    Args:
+        workspace: Workspace name from configuration or environment variables.
+
+    Returns:
+        The workspace name unchanged when it is valid.
+
+    Raises:
+        ValueError: If the workspace contains ``/`` or ``\\``, or is ``"."`` or
+            ``".."``.
+
+    Examples:
+        >>> validate_workspace("my_workspace")
+        'my_workspace'
+        >>> validate_workspace("v1.0")
+        'v1.0'
+        >>> validate_workspace("../../../etc")
+        Traceback (most recent call last):
+            ...
+        ValueError: Invalid workspace name '../../../etc': must not contain path separators ('/', '\\') or be a relative path reference ('.', '..')
+    """
+    if "/" in workspace or "\\" in workspace or workspace in (".", ".."):
+        raise ValueError(
+            f"Invalid workspace name {workspace!r}: must not contain path "
+            "separators ('/', '\\') or be a relative path reference ('.', '..')"
+        )
+    return workspace

--- a/tests/workspace/test_workspace_path_validation.py
+++ b/tests/workspace/test_workspace_path_validation.py
@@ -6,6 +6,8 @@ join against path traversal by rejecting any name that is not a single path
 component, while leaving legitimate names (including dotted ones) untouched.
 """
 
+from pathlib import Path
+
 import pytest
 
 from lightrag.utils import validate_workspace
@@ -82,3 +84,87 @@ class TestStorageRejectsTraversal:
             embedding_func=None,
         )
         assert storage.workspace == "v1.0"
+
+
+def _import_document_manager():
+    """Import DocumentManager with a clean argv.
+
+    Importing ``lightrag.api`` modules triggers the server's argparse against
+    ``sys.argv`` at import time, which would otherwise see pytest's arguments
+    (same workaround as tests/api/test_path_prefixes.py).
+    """
+    import sys
+
+    original_argv = sys.argv.copy()
+    try:
+        sys.argv = ["lightrag-server"]
+        from lightrag.api.routers.document_routes import DocumentManager
+
+        return DocumentManager
+    finally:
+        sys.argv = original_argv
+
+
+class TestUploadPath:
+    """DocumentManager builds the upload dir from the workspace; the same
+    validation must guard it, and the API server's own sanitizer
+    (``re.sub(r"[^a-zA-Z0-9_]", "_", ...)`` in api/config.py) must never
+    produce a value our validator rejects."""
+
+    def test_document_manager_rejects_traversal(self, tmp_path):
+        DocumentManager = _import_document_manager()
+
+        with pytest.raises(ValueError):
+            DocumentManager(str(tmp_path), workspace="../../outside")
+        assert not (tmp_path.parent.parent / "outside").exists()
+
+    def test_document_manager_creates_workspace_subdir(self, tmp_path):
+        DocumentManager = _import_document_manager()
+
+        dm = DocumentManager(str(tmp_path), workspace="space1")
+        assert dm.input_dir == tmp_path / "space1"
+        assert dm.input_dir.is_dir()
+
+    def test_document_manager_empty_workspace_uses_base_dir(self, tmp_path):
+        DocumentManager = _import_document_manager()
+
+        dm = DocumentManager(str(tmp_path), workspace="")
+        assert dm.input_dir == tmp_path
+
+    def test_api_sanitizer_output_always_accepted(self):
+        import re
+
+        for raw in [
+            "my workspace",
+            "v1.0",
+            "../../../etc",
+            "a/b",
+            "..\\win",
+            "工作区",
+            "..",
+            ".",
+        ]:
+            sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", raw)
+            assert validate_workspace(sanitized) == sanitized
+
+    def test_upload_dir_matches_storage_dir(self, tmp_path):
+        """Files uploaded to <input_dir>/<ws>/ must be resolvable against
+        storage data in <working_dir>/<ws>/ — same subdirectory name."""
+        DocumentManager = _import_document_manager()
+        from lightrag.kg.json_kv_impl import JsonKVStorage
+
+        inputs = tmp_path / "inputs"
+        working = tmp_path / "rag_storage"
+        inputs.mkdir()
+        working.mkdir()
+
+        dm = DocumentManager(str(inputs), workspace="space1")
+        kv = JsonKVStorage(
+            namespace="ns",
+            workspace="space1",
+            global_config={"working_dir": str(working)},
+            embedding_func=None,
+        )
+        upload_subdir = dm.input_dir.relative_to(inputs)
+        storage_subdir = Path(kv._file_name).parent.relative_to(working)
+        assert upload_subdir == storage_subdir

--- a/tests/workspace/test_workspace_path_validation.py
+++ b/tests/workspace/test_workspace_path_validation.py
@@ -1,0 +1,56 @@
+"""Unit tests for ``lightrag.utils.validate_workspace``.
+
+File-based storages build a per-workspace subdirectory under ``working_dir``
+via ``os.path.join(working_dir, workspace)``. ``validate_workspace`` guards that
+join against path traversal by rejecting any name that is not a single path
+component, while leaving legitimate names (including dotted ones) untouched.
+"""
+
+import pytest
+
+from lightrag.utils import validate_workspace
+
+pytestmark = pytest.mark.offline
+
+
+class TestValidWorkspaces:
+    """Names that are valid single path components pass through unchanged."""
+
+    @pytest.mark.parametrize(
+        "workspace",
+        [
+            "my_workspace",
+            "workspace-123",
+            "MyWorkSpace",
+            "12345",
+            "_",
+            "v1.0",  # dots are safe in a single path component
+            "team.alpha",
+            "a..b",  # ".." embedded in a name is not a traversal
+            "工作区_test",  # non-ASCII is fine for a directory name
+        ],
+    )
+    def test_returns_input_unchanged(self, workspace):
+        assert validate_workspace(workspace) == workspace
+
+
+class TestPathTraversalRejected:
+    """Names that could escape ``working_dir`` raise ``ValueError``."""
+
+    @pytest.mark.parametrize(
+        "workspace",
+        [
+            "..",
+            ".",
+            "../etc",
+            "../../../etc/passwd",
+            "foo/../../etc",
+            "foo/bar",  # nested path, not a single component
+            "/etc/passwd",  # absolute path would discard working_dir on join
+            "..\\..\\windows",  # Windows-style separator
+            "foo\\bar",
+        ],
+    )
+    def test_raises_value_error(self, workspace):
+        with pytest.raises(ValueError):
+            validate_workspace(workspace)

--- a/tests/workspace/test_workspace_path_validation.py
+++ b/tests/workspace/test_workspace_path_validation.py
@@ -54,3 +54,31 @@ class TestPathTraversalRejected:
     def test_raises_value_error(self, workspace):
         with pytest.raises(ValueError):
             validate_workspace(workspace)
+
+
+class TestStorageRejectsTraversal:
+    """The check is wired into storage construction, not just the helper."""
+
+    def test_json_kv_storage_rejects_traversal(self, tmp_path):
+        from lightrag.kg.json_kv_impl import JsonKVStorage
+
+        cfg = {"working_dir": str(tmp_path)}
+        with pytest.raises(ValueError):
+            JsonKVStorage(
+                namespace="ns",
+                workspace="../../../etc",
+                global_config=cfg,
+                embedding_func=None,
+            )
+
+    def test_json_kv_storage_accepts_dotted_name(self, tmp_path):
+        from lightrag.kg.json_kv_impl import JsonKVStorage
+
+        cfg = {"working_dir": str(tmp_path)}
+        storage = JsonKVStorage(
+            namespace="ns",
+            workspace="v1.0",
+            global_config=cfg,
+            embedding_func=None,
+        )
+        assert storage.workspace == "v1.0"


### PR DESCRIPTION
## Description

This PR adds a `validate_workspace()` function to prevent path traversal attacks when workspace names are used to construct file paths. The validation is integrated across all storage implementations to ensure workspace names are single path components and cannot escape the intended directory.

## Related Issues

Security hardening for file-based storage systems.  Supersedes  PR #3241

## Changes Made

- **New utility function** (`lightrag/utils.py`): Added `validate_workspace()` that rejects workspace names containing path separators (`/`, `\`) or relative path references (`.`, `..`), while accepting legitimate names including dotted ones (e.g., `v1.0`)

- **Storage implementations updated**: Integrated `validate_workspace()` calls in `__post_init__()` methods across all storage backends:
  - File-based: `json_kv_impl.py`, `json_doc_status_impl.py`, `faiss_impl.py`, `networkx_impl.py`, `nano_vector_db_impl.py`
  - Database-backed: `mongo_impl.py`, `opensearch_impl.py`, `redis_impl.py`, `postgres_impl.py`, `milvus_impl.py`, `memgraph_impl.py`, `neo4j_impl.py`, `qdrant_impl.py`
  - API layer: `document_routes.py` (DocumentManager)

- **Comprehensive test suite** (`tests/workspace/test_workspace_path_validation.py`): 
  - Tests valid workspace names (including dotted and non-ASCII names)
  - Tests rejection of path traversal attempts
  - Integration tests verifying the validation is wired into storage construction
  - Tests for DocumentManager upload path handling
  - Verification that the API's existing sanitizer output is always accepted

## Checklist

- [x] Changes tested locally (comprehensive unit tests added)
- [x] Code reviewed (validation logic is simple and clear)
- [x] Unit tests added (170 lines of test coverage)
- [x] Documentation updated (docstring with examples included)

## Additional Notes

The validator uses a rejection approach rather than sanitization, allowing legitimate names with dots to pass through unchanged while failing fast on unsafe inputs. This ensures the caller is aware of configuration issues rather than silently accepting rewritten names. The validation is applied consistently across all storage backends at initialization time.

https://claude.ai/code/session_01LnW6vKyroBSqXX5QJPgM86