### PR TITLE
🐛 fix(mongo): close MongoClient on ClientManager release

### DIFF
--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -277,7 +277,7 @@ async def _run_batched_bulk_write(
 
 
 class ClientManager:
-    _instances = {"db": None, "ref_count": 0}
+    _instances: dict = {"client": None, "db": None, "ref_count": 0}
     _lock = asyncio.Lock()
 
     @classmethod
@@ -301,6 +301,7 @@ class ClientManager:
                     driver=DriverInfo(name="LightRAG", version=__version__),
                 )
                 db = client.get_database(database_name)
+                cls._instances["client"] = client
                 cls._instances["db"] = db
                 cls._instances["ref_count"] = 0
             cls._instances["ref_count"] += 1
@@ -313,6 +314,10 @@ class ClientManager:
                 if db is cls._instances["db"]:
                     cls._instances["ref_count"] -= 1
                     if cls._instances["ref_count"] == 0:
+                        client = cls._instances.get("client")
+                        if client is not None:
+                            await client.close()
+                        cls._instances["client"] = None
                         cls._instances["db"] = None
 
 

--- a/tests/kg/mongo_impl/test_client_manager_lifecycle.py
+++ b/tests/kg/mongo_impl/test_client_manager_lifecycle.py
@@ -1,0 +1,100 @@
+"""Tests for ClientManager connection lifecycle (no MongoDB instance required).
+
+These tests verify that ClientManager properly closes the underlying
+AsyncMongoClient when all references are released, and keeps it alive
+while references remain.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+pytest.importorskip(
+    "pymongo",
+    reason="pymongo is required for Mongo ClientManager tests",
+)
+
+from lightrag.kg.mongo_impl import ClientManager
+
+
+class TestClientManagerLifecycle:
+    """Verify ClientManager connection open/close behavior."""
+
+    def _reset_manager(self):
+        """Reset ClientManager class state between tests."""
+        ClientManager._instances = {"client": None, "db": None, "ref_count": 0}
+
+    def teardown_method(self):
+        self._reset_manager()
+
+    @pytest.mark.asyncio
+    async def test_release_client_closes_connection_when_ref_count_zero(self):
+        """When ref_count drops to 0, the MongoClient should be closed and cleared."""
+        mock_client = AsyncMock()
+        mock_db = MagicMock()
+
+        ClientManager._instances = {
+            "client": mock_client,
+            "db": mock_db,
+            "ref_count": 1,
+        }
+
+        await ClientManager.release_client(mock_db)
+
+        mock_client.close.assert_awaited_once()
+        assert ClientManager._instances["client"] is None
+        assert ClientManager._instances["db"] is None
+        assert ClientManager._instances["ref_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_release_client_keeps_connection_with_multiple_refs(self):
+        """When other references exist, the MongoClient must NOT be closed."""
+        mock_client = AsyncMock()
+        mock_db = MagicMock()
+
+        ClientManager._instances = {
+            "client": mock_client,
+            "db": mock_db,
+            "ref_count": 3,
+        }
+
+        await ClientManager.release_client(mock_db)
+
+        mock_client.close.assert_not_awaited()
+        assert ClientManager._instances["ref_count"] == 2
+        assert ClientManager._instances["client"] is mock_client
+        assert ClientManager._instances["db"] is mock_db
+
+    @pytest.mark.asyncio
+    async def test_release_client_noop_for_wrong_db(self):
+        """Releasing a db that is not the tracked instance should do nothing."""
+        mock_client = AsyncMock()
+        mock_db = MagicMock()
+        other_db = MagicMock()
+
+        ClientManager._instances = {
+            "client": mock_client,
+            "db": mock_db,
+            "ref_count": 1,
+        }
+
+        await ClientManager.release_client(other_db)
+
+        mock_client.close.assert_not_awaited()
+        assert ClientManager._instances["ref_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_release_client_noop_for_none(self):
+        """Releasing None should be a safe no-op."""
+        mock_client = AsyncMock()
+        mock_db = MagicMock()
+
+        ClientManager._instances = {
+            "client": mock_client,
+            "db": mock_db,
+            "ref_count": 1,
+        }
+
+        await ClientManager.release_client(None)
+
+        mock_client.close.assert_not_awaited()
+        assert ClientManager._instances["ref_count"] == 1


### PR DESCRIPTION
## Problem

`ClientManager.get_client()` creates an `AsyncMongoClient` but only stores the database reference (`client.get_database()`). The original client object is lost after `get_client()` returns, so `release_client()` can never close the underlying connection — it only sets the db reference to `None`.

`AsyncMongoClient.__del__` does **not** close connections — it only emits a warning (`Unclosed AsyncMongoClient`). Connections in the pool remain open until Python GC happens, which is non-deterministic in long-running server processes.

Under repeated init/finalize cycles (common in web servers), MongoDB connections accumulate and can eventually hit the server connection limit.

## Fix

- Store the `AsyncMongoClient` alongside the db in `_instances`
- In `release_client()`, call `client.close()` when ref_count reaches 0
- Clear both client and db references after closing

## Changes

- `lightrag/kg/mongo_impl.py` — 5 lines added
- `tests/kg/mongo_impl/test_client_manager_lifecycle.py` — 4 new unit tests (all mock-based, no MongoDB instance required)

## Test Results

```
tests/kg/mongo_impl/test_client_manager_lifecycle.py::TestClientManagerLifecycle::test_release_client_closes_connection_when_ref_count_zero PASSED
tests/kg/mongo_impl/test_client_manager_lifecycle.py::TestClientManagerLifecycle::test_release_client_keeps_connection_with_multiple_refs PASSED
tests/kg/mongo_impl/test_client_manager_lifecycle.py::TestClientManagerLifecycle::test_release_client_noop_for_wrong_db PASSED
tests/kg/mongo_impl/test_client_manager_lifecycle.py::TestClientManagerLifecycle::test_release_client_noop_for_none PASSED
4 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)