### PR TITLE
feat(concurrency): make MAX_ASYNC a true cross-worker limit under gunicorn + aggregated queue stats

### DIFF
--- a/env.example
+++ b/env.example
@@ -495,7 +495,12 @@ LLM_MODEL=gpt-5.4-mini
 ###       cap: the provider never sees more than MAX_ASYNC concurrent calls
 ###       in total, exactly like single-process mode. Slots held by crashed
 ###       workers (kill -9 / OOM) are reclaimed automatically via lease
-###       heartbeats. For globally capped groups, MAX_QUEUE_SIZE-style
+###       heartbeats. This cross-worker cap is best-effort, not a hard
+###       guarantee: if a worker's event loop stalls for ~40s while running
+###       a call, its slot may be reclaimed and the true total briefly reach
+###       the cap + 1; under normal operation (every worker renews its 5s
+###       heartbeat) the cap holds exactly. For globally capped groups,
+###       MAX_QUEUE_SIZE-style
 ###       admission counts only live QUEUED tasks (running tasks and
 ###       cancelled requests are excluded), matching the bounded-queue
 ###       semantics of single-process mode.

--- a/env.example
+++ b/env.example
@@ -490,30 +490,19 @@ LLM_MODEL=gpt-5.4-mini
 ### Max concurrency requests of LLM
 ### MAX_ASYNC is still accepted as a deprecated alias
 ### NOTE: with gunicorn multi-worker (lightrag-gunicorn --workers N) every
-###       MAX_ASYNC_* / *_MAX_ASYNC_* setting is a PER-WORKER-PROCESS limit,
-###       so the real total concurrency is ~ MAX_ASYNC x WORKERS.
+###       MAX_ASYNC_* / *_MAX_ASYNC_* setting (LLM roles, embedding, rerank)
+###       is enforced BOTH per worker process AND as a cross-worker global
+###       cap: the provider never sees more than MAX_ASYNC concurrent calls
+###       in total, exactly like single-process mode. Slots held by crashed
+###       workers (kill -9 / OOM) are reclaimed automatically via lease
+###       heartbeats. For globally capped groups, MAX_QUEUE_SIZE-style
+###       admission counts only live QUEUED tasks (running tasks and
+###       cancelled requests are excluded), matching the bounded-queue
+###       semantics of single-process mode.
+###       Runtime caveat: changing a role's max_async through the API
+###       updates only that worker's local limit — the cross-worker cap
+###       keeps the value read at startup.
 MAX_ASYNC_LLM=4
-
-###########################################################################
-### Cross-worker GLOBAL concurrency limits (gunicorn multi-worker only)
-### *_GLOBAL_* variables cap the TOTAL in-flight calls across ALL gunicorn
-### workers for one call group (per LLM role / embedding / rerank), on top
-### of the per-worker MAX_ASYNC limits. Set them to
-###     <= WORKERS x per-worker max_async
-### Unset (default) means no global gate: behavior is unchanged.
-### Self-healing: slots held by crashed workers (kill -9 / OOM) are
-### reclaimed automatically via lease heartbeats.
-### Queue capacity note: for globally limited groups MAX_QUEUE_SIZE-style
-### admission counts only live QUEUED tasks (running tasks and cancelled
-### requests are excluded), matching the bounded-queue semantics of
-### non-limited groups.
-###########################################################################
-# EXTRACT_GLOBAL_MAX_ASYNC_LLM=8
-# KEYWORD_GLOBAL_MAX_ASYNC_LLM=8
-# QUERY_GLOBAL_MAX_ASYNC_LLM=8
-# VLM_GLOBAL_MAX_ASYNC_LLM=8
-# EMBEDDING_FUNC_GLOBAL_MAX_ASYNC=16
-# GLOBAL_MAX_ASYNC_RERANK=8
 
 ###########################################################################
 ### Role-specific LLM/VLM overrides

--- a/env.example
+++ b/env.example
@@ -492,18 +492,13 @@ LLM_MODEL=gpt-5.4-mini
 ### NOTE: with gunicorn multi-worker (lightrag-gunicorn --workers N) every
 ###       MAX_ASYNC_* / *_MAX_ASYNC_* setting (LLM roles, embedding, rerank)
 ###       is enforced BOTH per worker process AND as a cross-worker global
-###       cap: the provider never sees more than MAX_ASYNC concurrent calls
-###       in total, exactly like single-process mode. Slots held by crashed
-###       workers (kill -9 / OOM) are reclaimed automatically via lease
-###       heartbeats. This cross-worker cap is best-effort, not a hard
-###       guarantee: if a worker's event loop stalls for ~40s while running
-###       a call, its slot may be reclaimed and the true total briefly reach
-###       the cap + 1; under normal operation (every worker renews its 5s
-###       heartbeat) the cap holds exactly. For globally capped groups,
-###       MAX_QUEUE_SIZE-style
-###       admission counts only live QUEUED tasks (running tasks and
-###       cancelled requests are excluded), matching the bounded-queue
-###       semantics of single-process mode.
+###       cap. Under normal operation this keeps total in-process provider
+###       calls clamped to MAX_ASYNC, similar to single-process mode. Slots
+###       held by crashed workers (kill -9 / OOM) are reclaimed automatically
+###       via lease heartbeats; if a worker is terminated externally while its
+###       provider request is still pending, replacement work may briefly make
+###       provider-side concurrency exceed the cap until the abandoned request
+###       times out or closes. 
 ###       Runtime caveat: changing a role's max_async through the API
 ###       updates only that worker's local limit — the cross-worker cap
 ###       keeps the value read at startup.

--- a/env.example
+++ b/env.example
@@ -489,7 +489,31 @@ LLM_MODEL=gpt-5.4-mini
 
 ### Max concurrency requests of LLM
 ### MAX_ASYNC is still accepted as a deprecated alias
+### NOTE: with gunicorn multi-worker (lightrag-gunicorn --workers N) every
+###       MAX_ASYNC_* / *_MAX_ASYNC_* setting is a PER-WORKER-PROCESS limit,
+###       so the real total concurrency is ~ MAX_ASYNC x WORKERS.
 MAX_ASYNC_LLM=4
+
+###########################################################################
+### Cross-worker GLOBAL concurrency limits (gunicorn multi-worker only)
+### *_GLOBAL_* variables cap the TOTAL in-flight calls across ALL gunicorn
+### workers for one call group (per LLM role / embedding / rerank), on top
+### of the per-worker MAX_ASYNC limits. Set them to
+###     <= WORKERS x per-worker max_async
+### Unset (default) means no global gate: behavior is unchanged.
+### Self-healing: slots held by crashed workers (kill -9 / OOM) are
+### reclaimed automatically via lease heartbeats.
+### Queue capacity note: for globally limited groups MAX_QUEUE_SIZE-style
+### admission counts only live QUEUED tasks (running tasks and cancelled
+### requests are excluded), matching the bounded-queue semantics of
+### non-limited groups.
+###########################################################################
+# EXTRACT_GLOBAL_MAX_ASYNC_LLM=8
+# KEYWORD_GLOBAL_MAX_ASYNC_LLM=8
+# QUERY_GLOBAL_MAX_ASYNC_LLM=8
+# VLM_GLOBAL_MAX_ASYNC_LLM=8
+# EMBEDDING_FUNC_GLOBAL_MAX_ASYNC=16
+# GLOBAL_MAX_ASYNC_RERANK=8
 
 ###########################################################################
 ### Role-specific LLM/VLM overrides

--- a/env.example
+++ b/env.example
@@ -498,7 +498,7 @@ LLM_MODEL=gpt-5.4-mini
 ###       via lease heartbeats; if a worker is terminated externally while its
 ###       provider request is still pending, replacement work may briefly make
 ###       provider-side concurrency exceed the cap until the abandoned request
-###       times out or closes. 
+###       times out or closes.
 ###       Runtime caveat: changing a role's max_async through the API
 ###       updates only that worker's local limit — the cross-worker cap
 ###       keeps the value read at startup.

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -560,7 +560,6 @@ def parse_args() -> argparse.Namespace:
         host_key = f"{prefix}_LLM_BINDING_HOST"
         apikey_key = f"{prefix}_LLM_BINDING_API_KEY"
         max_async_key = f"{prefix}_MAX_ASYNC_LLM"
-        global_max_async_key = f"{prefix}_GLOBAL_MAX_ASYNC_LLM"
         timeout_key = f"{prefix}_LLM_TIMEOUT"
 
         role_binding = normalize_binding_name(
@@ -570,12 +569,6 @@ def parse_args() -> argparse.Namespace:
         role_host = get_env_value(host_key, None, special_none=True)
         role_apikey = get_env_value(apikey_key, None, special_none=True)
         role_max_async = get_env_value(max_async_key, None, int, special_none=True)
-        # Cross-worker global concurrency cap for this role (gunicorn
-        # multi-worker). None means no global gate — only the per-worker
-        # max_async applies.
-        role_global_max_async = get_env_value(
-            global_max_async_key, None, int, special_none=True
-        )
         role_timeout = get_env_value(timeout_key, None, int, special_none=True)
         role_aws_region = get_env_value(f"{prefix}_AWS_REGION", None, special_none=True)
         role_aws_access_key_id = get_env_value(
@@ -593,7 +586,6 @@ def parse_args() -> argparse.Namespace:
         setattr(args, f"{attr_prefix}_llm_binding_host", role_host)
         setattr(args, f"{attr_prefix}_llm_binding_api_key", role_apikey)
         setattr(args, f"{attr_prefix}_llm_max_async", role_max_async)
-        setattr(args, f"{attr_prefix}_llm_global_max_async", role_global_max_async)
         setattr(args, f"{attr_prefix}_llm_timeout", role_timeout)
         setattr(args, f"{attr_prefix}_aws_region", role_aws_region)
         setattr(args, f"{attr_prefix}_aws_access_key_id", role_aws_access_key_id)
@@ -679,10 +671,6 @@ def parse_args() -> argparse.Namespace:
     # Rerank async/timeout configuration (independent from base LLM)
     # rerank_max_async falls back to MAX_ASYNC_LLM; rerank_timeout has its own default.
     args.rerank_max_async = get_env_value("MAX_ASYNC_RERANK", args.max_async, int)
-    # Cross-worker global rerank concurrency cap (gunicorn multi-worker).
-    args.rerank_global_max_async = get_env_value(
-        "GLOBAL_MAX_ASYNC_RERANK", None, int, special_none=True
-    )
     args.rerank_timeout = get_env_value("RERANK_TIMEOUT", DEFAULT_RERANK_TIMEOUT, int)
 
     # Query configuration
@@ -710,10 +698,6 @@ def parse_args() -> argparse.Namespace:
     )
     args.embedding_func_max_async = get_env_value(
         "EMBEDDING_FUNC_MAX_ASYNC", DEFAULT_EMBEDDING_FUNC_MAX_ASYNC, int
-    )
-    # Cross-worker global embedding concurrency cap (gunicorn multi-worker).
-    args.embedding_func_global_max_async = get_env_value(
-        "EMBEDDING_FUNC_GLOBAL_MAX_ASYNC", None, int, special_none=True
     )
     args.embedding_batch_num = get_env_value(
         "EMBEDDING_BATCH_NUM", DEFAULT_EMBEDDING_BATCH_NUM, int

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -560,6 +560,7 @@ def parse_args() -> argparse.Namespace:
         host_key = f"{prefix}_LLM_BINDING_HOST"
         apikey_key = f"{prefix}_LLM_BINDING_API_KEY"
         max_async_key = f"{prefix}_MAX_ASYNC_LLM"
+        global_max_async_key = f"{prefix}_GLOBAL_MAX_ASYNC_LLM"
         timeout_key = f"{prefix}_LLM_TIMEOUT"
 
         role_binding = normalize_binding_name(
@@ -569,6 +570,12 @@ def parse_args() -> argparse.Namespace:
         role_host = get_env_value(host_key, None, special_none=True)
         role_apikey = get_env_value(apikey_key, None, special_none=True)
         role_max_async = get_env_value(max_async_key, None, int, special_none=True)
+        # Cross-worker global concurrency cap for this role (gunicorn
+        # multi-worker). None means no global gate — only the per-worker
+        # max_async applies.
+        role_global_max_async = get_env_value(
+            global_max_async_key, None, int, special_none=True
+        )
         role_timeout = get_env_value(timeout_key, None, int, special_none=True)
         role_aws_region = get_env_value(f"{prefix}_AWS_REGION", None, special_none=True)
         role_aws_access_key_id = get_env_value(
@@ -586,6 +593,7 @@ def parse_args() -> argparse.Namespace:
         setattr(args, f"{attr_prefix}_llm_binding_host", role_host)
         setattr(args, f"{attr_prefix}_llm_binding_api_key", role_apikey)
         setattr(args, f"{attr_prefix}_llm_max_async", role_max_async)
+        setattr(args, f"{attr_prefix}_llm_global_max_async", role_global_max_async)
         setattr(args, f"{attr_prefix}_llm_timeout", role_timeout)
         setattr(args, f"{attr_prefix}_aws_region", role_aws_region)
         setattr(args, f"{attr_prefix}_aws_access_key_id", role_aws_access_key_id)
@@ -671,6 +679,10 @@ def parse_args() -> argparse.Namespace:
     # Rerank async/timeout configuration (independent from base LLM)
     # rerank_max_async falls back to MAX_ASYNC_LLM; rerank_timeout has its own default.
     args.rerank_max_async = get_env_value("MAX_ASYNC_RERANK", args.max_async, int)
+    # Cross-worker global rerank concurrency cap (gunicorn multi-worker).
+    args.rerank_global_max_async = get_env_value(
+        "GLOBAL_MAX_ASYNC_RERANK", None, int, special_none=True
+    )
     args.rerank_timeout = get_env_value("RERANK_TIMEOUT", DEFAULT_RERANK_TIMEOUT, int)
 
     # Query configuration
@@ -698,6 +710,10 @@ def parse_args() -> argparse.Namespace:
     )
     args.embedding_func_max_async = get_env_value(
         "EMBEDDING_FUNC_MAX_ASYNC", DEFAULT_EMBEDDING_FUNC_MAX_ASYNC, int
+    )
+    # Cross-worker global embedding concurrency cap (gunicorn multi-worker).
+    args.embedding_func_global_max_async = get_env_value(
+        "EMBEDDING_FUNC_GLOBAL_MAX_ASYNC", None, int, special_none=True
     )
     args.embedding_batch_num = get_env_value(
         "EMBEDDING_BATCH_NUM", DEFAULT_EMBEDDING_BATCH_NUM, int

--- a/lightrag/api/routers/ollama_api.py
+++ b/lightrag/api/routers/ollama_api.py
@@ -9,6 +9,7 @@ from enum import Enum
 from fastapi.responses import StreamingResponse
 import asyncio
 from lightrag import LightRAG, QueryParam
+from lightrag.constants import DEFAULT_QUERY_PRIORITY
 from lightrag.utils import TiktokenTokenizer
 from lightrag.api.utils_api import get_combined_auth_dependency
 from fastapi import Depends
@@ -309,7 +310,10 @@ class OllamaAPI:
 
                 if request.stream:
                     response = await (self.rag.role_llm_funcs["query"])(
-                        query, stream=True, **role_kwargs
+                        query,
+                        stream=True,
+                        _priority=DEFAULT_QUERY_PRIORITY,
+                        **role_kwargs,
                     )
 
                     async def stream_generator():
@@ -434,7 +438,10 @@ class OllamaAPI:
                 else:
                     first_chunk_time = time.time_ns()
                     response_text = await (self.rag.role_llm_funcs["query"])(
-                        query, stream=False, **role_kwargs
+                        query,
+                        stream=False,
+                        _priority=DEFAULT_QUERY_PRIORITY,
+                        **role_kwargs,
                     )
                     last_chunk_time = time.time_ns()
 
@@ -531,6 +538,7 @@ class OllamaAPI:
                             cleaned_query,
                             stream=True,
                             history_messages=conversation_history,
+                            _priority=DEFAULT_QUERY_PRIORITY,
                             **role_kwargs,
                         )
                     else:
@@ -699,6 +707,7 @@ class OllamaAPI:
                             cleaned_query,
                             stream=False,
                             history_messages=conversation_history,
+                            _priority=DEFAULT_QUERY_PRIORITY,
                             **role_kwargs,
                         )
                     else:

--- a/lightrag/api/run_with_gunicorn.py
+++ b/lightrag/api/run_with_gunicorn.py
@@ -30,24 +30,30 @@ def check_and_install_dependencies():
 
 
 def _build_global_concurrency_limits(args) -> dict:
-    """Assemble cross-worker concurrency limits from parsed configuration.
+    """Derive cross-worker concurrency limits from the MAX_ASYNC settings.
 
+    Under gunicorn multi-worker, every MAX_ASYNC value keeps its documented
+    meaning — the maximum number of concurrent provider calls — by acting
+    BOTH as each worker's local limit and as the cross-worker global cap
+    (without the gate the real total would be ~ MAX_ASYNC x workers).
     Group names must match the ``concurrency_group`` values passed to
-    ``priority_limit_async_func_call``: ``llm:{role}`` for the four LLM
-    roles, plus ``embedding`` and ``rerank``. Unset env vars yield no entry
-    (that group stays unlimited and keeps the original per-process path).
+    ``priority_limit_async_func_call``: ``llm:{role}`` for the LLM roles,
+    plus ``embedding`` and ``rerank``. Role fallbacks mirror the runtime
+    resolution in ``_get_effective_role_llm_max_async``.
     """
     from lightrag.llm_roles import ROLES
 
     limits = {}
     for spec in ROLES:
-        role_limit = getattr(args, f"{spec.name}_llm_global_max_async", None)
+        role_limit = getattr(args, f"{spec.name}_llm_max_async", None)
+        if role_limit is None:
+            role_limit = args.max_async
         if role_limit is not None and role_limit > 0:
             limits[f"llm:{spec.name}"] = role_limit
-    embedding_limit = getattr(args, "embedding_func_global_max_async", None)
+    embedding_limit = getattr(args, "embedding_func_max_async", None)
     if embedding_limit is not None and embedding_limit > 0:
         limits["embedding"] = embedding_limit
-    rerank_limit = getattr(args, "rerank_global_max_async", None)
+    rerank_limit = getattr(args, "rerank_max_async", None)
     if rerank_limit is not None and rerank_limit > 0:
         limits["rerank"] = rerank_limit
     return limits
@@ -97,8 +103,7 @@ def main():
             f"{_PROCESS_START_OBJC_FORK_SAFETY or 'NOT SET'}"
         )
         print(
-            "  - Environment After .env Load: "
-            f"{current_objc_fork_safety or 'NOT SET'}"
+            f"  - Environment After .env Load: {current_objc_fork_safety or 'NOT SET'}"
         )
         if current_objc_fork_safety == "YES":
             print("\nNote:")
@@ -272,20 +277,21 @@ def main():
     # Create the application
     app = GunicornApp("")
 
-    # Cross-worker global concurrency limits (read-only after this point;
-    # forked workers inherit them as module globals).
-    global_concurrency_limits = _build_global_concurrency_limits(global_args)
-
     # Force workers to be an integer and greater than 1 for multi-process mode
     workers_count = global_args.workers
     if workers_count > 1:
         # Set a flag to indicate we're in the main process
         os.environ["LIGHTRAG_MAIN_PROCESS"] = "1"
+        # Cross-worker global concurrency limits derived from MAX_ASYNC
+        # (read-only after this point; forked workers inherit them as
+        # module globals). Single-worker mode needs no cross-process gate —
+        # the per-process max_async already IS the total limit there.
         initialize_share_data(
-            workers_count, global_concurrency_limits=global_concurrency_limits
+            workers_count,
+            global_concurrency_limits=_build_global_concurrency_limits(global_args),
         )
     else:
-        initialize_share_data(1, global_concurrency_limits=global_concurrency_limits)
+        initialize_share_data(1)
 
     # Run the application
     print("\nStarting Gunicorn with direct Python API...")

--- a/lightrag/api/run_with_gunicorn.py
+++ b/lightrag/api/run_with_gunicorn.py
@@ -29,6 +29,30 @@ def check_and_install_dependencies():
             print(f"{package} installed successfully")
 
 
+def _build_global_concurrency_limits(args) -> dict:
+    """Assemble cross-worker concurrency limits from parsed configuration.
+
+    Group names must match the ``concurrency_group`` values passed to
+    ``priority_limit_async_func_call``: ``llm:{role}`` for the four LLM
+    roles, plus ``embedding`` and ``rerank``. Unset env vars yield no entry
+    (that group stays unlimited and keeps the original per-process path).
+    """
+    from lightrag.llm_roles import ROLES
+
+    limits = {}
+    for spec in ROLES:
+        role_limit = getattr(args, f"{spec.name}_llm_global_max_async", None)
+        if role_limit is not None and role_limit > 0:
+            limits[f"llm:{spec.name}"] = role_limit
+    embedding_limit = getattr(args, "embedding_func_global_max_async", None)
+    if embedding_limit is not None and embedding_limit > 0:
+        limits["embedding"] = embedding_limit
+    rerank_limit = getattr(args, "rerank_global_max_async", None)
+    if rerank_limit is not None and rerank_limit > 0:
+        limits["rerank"] = rerank_limit
+    return limits
+
+
 def main():
     from lightrag.api.utils_api import display_splash_screen, check_env_file
     from lightrag.api.config import global_args, initialize_config
@@ -248,14 +272,20 @@ def main():
     # Create the application
     app = GunicornApp("")
 
+    # Cross-worker global concurrency limits (read-only after this point;
+    # forked workers inherit them as module globals).
+    global_concurrency_limits = _build_global_concurrency_limits(global_args)
+
     # Force workers to be an integer and greater than 1 for multi-process mode
     workers_count = global_args.workers
     if workers_count > 1:
         # Set a flag to indicate we're in the main process
         os.environ["LIGHTRAG_MAIN_PROCESS"] = "1"
-        initialize_share_data(workers_count)
+        initialize_share_data(
+            workers_count, global_concurrency_limits=global_concurrency_limits
+        )
     else:
-        initialize_share_data(1)
+        initialize_share_data(1, global_concurrency_limits=global_concurrency_limits)
 
     # Run the application
     print("\nStarting Gunicorn with direct Python API...")

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -283,8 +283,19 @@ DEFAULT_RERANK_TIMEOUT = 30
 DEFAULT_GLOBAL_SLOT_HEARTBEAT_TTL = 20.0  # ~4x the 5s health-check heartbeat
 DEFAULT_GLOBAL_SLOT_SUSPECT_GRACE = 20.0  # ~1x heartbeat TTL
 # Polling backoff bounds while a worker waits for a free global slot.
+# The first acquisition attempt is always immediate (backoff applies only
+# after a failure). The longest-waiting live process keeps polling at the
+# MIN interval so it usually claims the next freed slot (soft FIFO across
+# workers); other waiters back off exponentially up to the DEFERRED cap.
+# The cap stays small on purpose: when the favored waiter leaves, the
+# promoted one is asleep at most one deferred period, bounding slot idling.
 DEFAULT_GLOBAL_SLOT_POLL_MIN = 0.05
-DEFAULT_GLOBAL_SLOT_POLL_MAX = 0.2
+DEFAULT_GLOBAL_SLOT_POLL_DEFERRED_MAX = 0.4
+# Waiter records not refreshed within this TTL are ignored for the
+# longest-waiter ranking and reaped: a crashed or stalled poller must not
+# keep occupying the favored seat (which would push every live waiter onto
+# the deferred backoff and waste slots). Keep > 2x the deferred poll cap.
+DEFAULT_GLOBAL_SLOT_WAITER_STALE_TTL = 1.0
 # Max consecutive zombie (cancelled) queue entries a worker drains while
 # holding a global slot before returning the slot to other processes.
 DEFAULT_GLOBAL_SLOT_DRAIN_LIMIT = 16

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -276,6 +276,29 @@ DEFAULT_EMBEDDING_TIMEOUT = 30
 DEFAULT_RERANK_MAX_ASYNC = DEFAULT_MAX_ASYNC
 DEFAULT_RERANK_TIMEOUT = 30
 
+# Cross-worker global concurrency gate (gunicorn multi-worker) defaults.
+# A lease whose heartbeat is older than the TTL marks its owner as suspect;
+# a suspect lease is reclaimed only after the additional grace elapses while
+# the owner PID is still alive (dead PIDs are reclaimed immediately).
+DEFAULT_GLOBAL_SLOT_HEARTBEAT_TTL = 20.0  # ~4x the 5s health-check heartbeat
+DEFAULT_GLOBAL_SLOT_SUSPECT_GRACE = 20.0  # ~1x heartbeat TTL
+# Polling backoff bounds while a worker waits for a free global slot.
+DEFAULT_GLOBAL_SLOT_POLL_MIN = 0.05
+DEFAULT_GLOBAL_SLOT_POLL_MAX = 0.2
+# Max consecutive zombie (cancelled) queue entries a worker drains while
+# holding a global slot before returning the slot to other processes.
+DEFAULT_GLOBAL_SLOT_DRAIN_LIMIT = 16
+# Physical queue compaction (global-limit mode only): triggered when the
+# estimated zombie count exceeds the threshold; each maintenance pass
+# processes at most the batch limit to keep the event loop responsive.
+DEFAULT_ZOMBIE_COMPACT_THRESHOLD = 64
+DEFAULT_COMPACT_BATCH_LIMIT = 512
+# Cross-worker queue stats: snapshots older than the stale TTL (and entries
+# owned by dead PIDs) are reaped during aggregation; publishes triggered by
+# counter updates are debounced to the min interval.
+DEFAULT_QUEUE_STATS_STALE_TTL = 15.0
+DEFAULT_QUEUE_STATS_MIN_PUBLISH_INTERVAL = 0.1
+
 # Logging configuration defaults
 DEFAULT_LOG_MAX_BYTES = 10485760  # Default 10MB
 DEFAULT_LOG_BACKUP_COUNT = 5  # Default 5 backups

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -1991,11 +1991,24 @@ def _reap_gate_state(state: Dict[str, Any], now: float) -> tuple[int, bool]:
     live = 0
     changed = False
     reclaimed_pids = set()
+    # Liveness is constant within this synchronous pass (no await, fixed
+    # ``now``), so memoize the probe: a PID holding many leases of this group
+    # is checked once instead of once per lease. NEVER cache across calls —
+    # PID reuse and staleness could reclaim a live owner's lease.
+    alive_cache: Dict[int, bool] = {}
+
+    def _alive(pid: int) -> bool:
+        cached = alive_cache.get(pid)
+        if cached is None:
+            cached = _pid_alive(pid)
+            alive_cache[pid] = cached
+        return cached
+
     for lease_id in list(leases.keys()):
         lease = leases[lease_id]
         pid = lease.get("pid")
         updated_at = lease.get("updated_at", 0.0)
-        if pid is None or not _pid_alive(pid):
+        if pid is None or not _alive(pid):
             leases.pop(lease_id)
             changed = True
             if pid is not None:
@@ -2026,7 +2039,7 @@ def _reap_gate_state(state: Dict[str, Any], now: float) -> tuple[int, bool]:
         if (
             pid is None
             or pid in reclaimed_pids
-            or not _pid_alive(pid)
+            or not _alive(pid)
             or now - last_poll > _waiter_stale_ttl
         ):
             waiters.pop(pid_key)

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -2,13 +2,19 @@ import os
 import sys
 import asyncio
 import multiprocessing as mp
+import uuid
 from multiprocessing.synchronize import Lock as ProcessLock
 from multiprocessing import Manager
 import time
 import logging
 from contextvars import ContextVar
-from typing import Any, Dict, List, Optional, Union, TypeVar, Generic
+from typing import Any, Dict, List, Mapping, Optional, Union, TypeVar, Generic
 
+from lightrag.constants import (
+    DEFAULT_GLOBAL_SLOT_HEARTBEAT_TTL,
+    DEFAULT_GLOBAL_SLOT_SUSPECT_GRACE,
+    DEFAULT_QUEUE_STATS_STALE_TTL,
+)
 from lightrag.exceptions import PipelineNotInitializedError
 
 DEBUG_LOCKS = False
@@ -94,6 +100,36 @@ _storage_keyed_lock: Optional["KeyedUnifiedLock"] = None
 _async_locks: Optional[Dict[str, asyncio.Lock]] = None
 
 _debug_n_locks_acquired: int = 0
+
+# --- Cross-worker global concurrency gate + queue stats aggregation ---
+#
+# Read-only configuration set once by the FIRST initialize_share_data() call
+# (the gunicorn master, before fork — workers inherit it as a module global).
+# Later no-arg calls (e.g. LightRAG.__post_init__) hit the `_initialized`
+# guard and never overwrite it.
+_global_concurrency_limits: Optional[Dict[str, int]] = None
+
+# Separator between the group/queue name and the per-lease / per-pid suffix
+# in shared namespace keys. \x1f (ASCII unit separator) cannot appear in
+# group names or queue names.
+KEY_SEP = "\x1f"
+
+_CONCURRENCY_LEASE_NAMESPACE = "concurrency_leases"
+_QUEUE_STATS_NAMESPACE = "queue_stats"
+
+# Heartbeat / staleness parameters (module-level so tests can monkeypatch).
+_heartbeat_ttl: float = DEFAULT_GLOBAL_SLOT_HEARTBEAT_TTL
+_suspect_grace: float = DEFAULT_GLOBAL_SLOT_SUSPECT_GRACE
+_queue_stats_stale_ttl: float = DEFAULT_QUEUE_STATS_STALE_TTL
+
+# Per-process cached namespace references (avoid the internal lock on every
+# publish). Reset by initialize_share_data()/finalize_share_data().
+_lease_ns_cache: Optional[Dict[str, Any]] = None
+_queue_stats_ns_cache: Optional[Dict[str, Any]] = None
+
+# Rate limiting for acquire-failure warnings (fail-closed path).
+_ACQUIRE_FAILURE_LOG_INTERVAL = 30.0
+_last_acquire_failure_log: float = 0.0
 
 
 def get_final_namespace(namespace: str, workspace: str | None = None):
@@ -1173,7 +1209,10 @@ def get_keyed_lock_status() -> Dict[str, Any]:
     return status
 
 
-def initialize_share_data(workers: int = 1):
+def initialize_share_data(
+    workers: int = 1,
+    global_concurrency_limits: Optional[Mapping[str, int]] = None,
+):
     """
     Initialize shared storage data for single or multi-process mode.
 
@@ -1190,6 +1229,11 @@ def initialize_share_data(workers: int = 1):
     Args:
         workers (int): Number of worker processes. If 1, single-process mode is used.
                       If > 1, multi-process mode with shared memory is used.
+        global_concurrency_limits: Optional mapping of concurrency group name
+                      (e.g. "llm:extract", "embedding", "rerank") to the
+                      cross-worker global max concurrency for that group.
+                      Read-only after initialization; later calls (which hit
+                      the already-initialized guard) never overwrite it.
     """
     global \
         _manager, \
@@ -1208,7 +1252,10 @@ def initialize_share_data(workers: int = 1):
         _async_locks, \
         _storage_keyed_lock, \
         _earliest_mp_cleanup_time, \
-        _last_mp_cleanup_time
+        _last_mp_cleanup_time, \
+        _global_concurrency_limits, \
+        _lease_ns_cache, \
+        _queue_stats_ns_cache
 
     # Check if already initialized
     if _initialized:
@@ -1218,6 +1265,22 @@ def initialize_share_data(workers: int = 1):
         return
 
     _workers = workers
+    _global_concurrency_limits = (
+        {
+            str(group): int(limit)
+            for group, limit in global_concurrency_limits.items()
+            if limit is not None and int(limit) > 0
+        }
+        if global_concurrency_limits
+        else {}
+    )
+    _lease_ns_cache = None
+    _queue_stats_ns_cache = None
+    if _global_concurrency_limits:
+        direct_log(
+            f"Process {os.getpid()} Global concurrency limits: {_global_concurrency_limits}",
+            level="INFO",
+        )
 
     if workers > 1:
         _is_multiprocess = True
@@ -1628,7 +1691,10 @@ def finalize_share_data():
         _initialized, \
         _update_flags, \
         _async_locks, \
-        _default_workspace
+        _default_workspace, \
+        _global_concurrency_limits, \
+        _lease_ns_cache, \
+        _queue_stats_ns_cache
 
     # Check if already initialized
     if not _initialized:
@@ -1692,6 +1758,9 @@ def finalize_share_data():
     _update_flags = None
     _async_locks = None
     _default_workspace = None
+    _global_concurrency_limits = None
+    _lease_ns_cache = None
+    _queue_stats_ns_cache = None
 
     direct_log(f"Process {os.getpid()} storage data finalization complete")
 
@@ -1740,3 +1809,309 @@ def get_pipeline_status_lock(
     return get_namespace_lock(
         "pipeline_status", workspace=actual_workspace, enable_logging=enable_logging
     )
+
+
+# ---------------------------------------------------------------------------
+# Cross-worker global concurrency gate (lease + heartbeat semantics)
+# ---------------------------------------------------------------------------
+#
+# Leases live in the workspace-less "concurrency_leases" namespace as
+# ``f"{group}{KEY_SEP}{lease_id}" -> {"pid": int, "updated_at": float}``
+# plain dicts (whole-value replacement only — in multiprocess mode the
+# namespace is a Manager dict, so in-place mutation of a retrieved value
+# would NOT persist across processes).
+#
+# Self-healing: holders refresh ``updated_at`` from their 5s health-check
+# heartbeat. A lease is reclaimed when its owner PID is dead (immediately)
+# or when its heartbeat expired AND the suspect grace elapsed (protects
+# live-but-momentarily-stalled owners from false reclamation). Long-running
+# tasks are never reclaimed as long as their owner keeps renewing.
+
+
+def is_share_data_initialized() -> bool:
+    """Return True once initialize_share_data() has run in this process."""
+    return bool(_initialized)
+
+
+def is_global_concurrency_limited(group: Optional[str]) -> bool:
+    """Synchronous, cacheable check: does ``group`` have a global limit?
+
+    Reads only the module-level read-only configuration — no IPC. Returns
+    False when shared data is not initialized, no limits were configured,
+    or the group has no positive limit.
+    """
+    if not group or not _global_concurrency_limits:
+        return False
+    limit = _global_concurrency_limits.get(group)
+    return limit is not None and limit > 0
+
+
+def get_global_concurrency_limit(group: Optional[str]) -> Optional[int]:
+    """Return the configured global limit for ``group`` (None if unlimited)."""
+    if not group or not _global_concurrency_limits:
+        return None
+    return _global_concurrency_limits.get(group)
+
+
+def _pid_alive(pid: int) -> bool:
+    """Best-effort liveness probe; errs on the side of 'alive'."""
+    if pid == os.getpid():
+        return True
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except OSError:
+        # PermissionError and friends: the process exists (or we cannot
+        # tell) — treat as alive so we never reclaim a live owner's lease.
+        return True
+    return True
+
+
+async def _get_lease_namespace() -> Dict[str, Any]:
+    global _lease_ns_cache
+    if _lease_ns_cache is None:
+        _lease_ns_cache = await get_namespace_data(
+            _CONCURRENCY_LEASE_NAMESPACE, workspace=""
+        )
+    return _lease_ns_cache
+
+
+async def _get_queue_stats_namespace() -> Dict[str, Any]:
+    global _queue_stats_ns_cache
+    if _queue_stats_ns_cache is None:
+        _queue_stats_ns_cache = await get_namespace_data(
+            _QUEUE_STATS_NAMESPACE, workspace=""
+        )
+    return _queue_stats_ns_cache
+
+
+def _reap_group_leases_locked(ns: Dict[str, Any], group: str, now: float) -> int:
+    """Reclaim dead/expired leases of ``group``; return surviving lease count.
+
+    MUST be called while holding the group's keyed lock. Suspect handling:
+    a lease whose heartbeat expired while its PID is still alive is first
+    marked with ``suspect_since`` and reclaimed only after ``_suspect_grace``
+    elapses without a renewal; a renewal (fresh ``updated_at``) clears the
+    suspect mark. Dead PIDs are reclaimed immediately. Suspect leases still
+    count toward capacity so the global limit is never exceeded.
+    """
+    prefix = f"{group}{KEY_SEP}"
+    live = 0
+    for key in [k for k in ns.keys() if k.startswith(prefix)]:
+        raw = ns.get(key)
+        if raw is None:
+            continue
+        lease = dict(raw)
+        pid = lease.get("pid")
+        updated_at = lease.get("updated_at", 0.0)
+        if pid is None or not _pid_alive(pid):
+            ns.pop(key, None)
+            continue
+        if now - updated_at > _heartbeat_ttl:
+            suspect_since = lease.get("suspect_since")
+            if suspect_since is None:
+                lease["suspect_since"] = now
+                ns[key] = lease
+                live += 1
+            elif now - suspect_since > _suspect_grace:
+                ns.pop(key, None)
+            else:
+                live += 1
+        else:
+            if "suspect_since" in lease:
+                lease.pop("suspect_since", None)
+                ns[key] = lease
+            live += 1
+    return live
+
+
+def _log_acquire_failure(group: str, error: Exception) -> None:
+    global _last_acquire_failure_log
+    now = time.time()
+    if now - _last_acquire_failure_log >= _ACQUIRE_FAILURE_LOG_INTERVAL:
+        _last_acquire_failure_log = now
+        direct_log(
+            f"Process {os.getpid()} failed to acquire global slot for group "
+            f"'{group}' (fail-closed, task stays queued): {error}",
+            level="WARNING",
+        )
+
+
+async def try_acquire_global_slot(group: str) -> Optional[str]:
+    """Try to claim one global concurrency slot for ``group`` (non-blocking).
+
+    Returns a lease id on success, or None when the group is at capacity.
+    Any shared-storage error is fail-closed: returns None (with a
+    rate-limited warning) so the caller keeps the task queued and retries —
+    capacity is never exceeded due to infrastructure errors.
+    """
+    limit = get_global_concurrency_limit(group)
+    if limit is None or limit <= 0:
+        return None
+    try:
+        ns = await _get_lease_namespace()
+        async with get_storage_keyed_lock(
+            group, namespace=_CONCURRENCY_LEASE_NAMESPACE, enable_logging=False
+        ):
+            now = time.time()
+            in_use = _reap_group_leases_locked(ns, group, now)
+            if in_use >= limit:
+                return None
+            lease_id = uuid.uuid4().hex
+            ns[f"{group}{KEY_SEP}{lease_id}"] = {
+                "pid": os.getpid(),
+                "updated_at": now,
+            }
+            return lease_id
+    except Exception as e:
+        _log_acquire_failure(group, e)
+        return None
+
+
+async def release_global_slot(group: str, lease_id: str) -> None:
+    """Release a previously acquired global slot (idempotent).
+
+    Raises on shared-storage errors — callers that must never propagate
+    (e.g. worker ``finally`` blocks) wrap this and queue the lease for a
+    later retry; the heartbeat TTL guarantees eventual reclamation anyway.
+    """
+    ns = await _get_lease_namespace()
+    async with get_storage_keyed_lock(
+        group, namespace=_CONCURRENCY_LEASE_NAMESPACE, enable_logging=False
+    ):
+        ns.pop(f"{group}{KEY_SEP}{lease_id}", None)
+
+
+async def renew_global_slots(group: str, lease_ids) -> None:
+    """Refresh the heartbeat of this process's held leases for ``group``.
+
+    A renewal rewrites the lease whole (clearing any ``suspect_since``
+    mark). Leases that have already been reclaimed are NOT resurrected —
+    re-inserting could exceed the configured limit; the suspect grace
+    exists precisely to make false reclamation unlikely.
+    """
+    lease_ids = list(lease_ids)
+    if not lease_ids:
+        return
+    ns = await _get_lease_namespace()
+    async with get_storage_keyed_lock(
+        group, namespace=_CONCURRENCY_LEASE_NAMESPACE, enable_logging=False
+    ):
+        now = time.time()
+        for lease_id in lease_ids:
+            key = f"{group}{KEY_SEP}{lease_id}"
+            if ns.get(key) is not None:
+                ns[key] = {"pid": os.getpid(), "updated_at": now}
+
+
+async def reconcile_global_slots(group: str) -> int:
+    """Run the lease reaper for ``group``; return surviving lease count."""
+    ns = await _get_lease_namespace()
+    async with get_storage_keyed_lock(
+        group, namespace=_CONCURRENCY_LEASE_NAMESPACE, enable_logging=False
+    ):
+        return _reap_group_leases_locked(ns, group, time.time())
+
+
+async def global_concurrency_in_use(group: str) -> int:
+    """Approximate count of currently held global slots for ``group``."""
+    ns = await _get_lease_namespace()
+    prefix = f"{group}{KEY_SEP}"
+    return sum(1 for k in ns.keys() if k.startswith(prefix))
+
+
+# ---------------------------------------------------------------------------
+# Cross-worker queue stats (best-effort, debounced snapshots)
+# ---------------------------------------------------------------------------
+#
+# Each worker process publishes per-queue snapshots under
+# ``f"{queue_name}{KEY_SEP}{pid}"`` in the workspace-less "queue_stats"
+# namespace (whole-value replacement). The local closure counters remain
+# the source of truth; the shared area only needs to be "fresh enough"
+# (event-triggered publishes debounced by the caller + 5s heartbeat flush).
+
+# Flat counter fields summed across workers during aggregation. These are
+# the existing get_queue_stats() fields (schema compatibility for /health
+# and the webui) plus the new global_slot_waits / physical_queued counters.
+QUEUE_STATS_SUM_FIELDS = (
+    "queued",
+    "running",
+    "in_flight",
+    "worker_count",
+    "submitted_total",
+    "completed_total",
+    "failed_total",
+    "cancelled_total",
+    "rejected_total",
+    "global_slot_waits",
+    "physical_queued",
+)
+
+
+async def publish_queue_stats(queue_name: str, snapshot: Dict[str, Any]) -> None:
+    """Publish this process's snapshot for ``queue_name`` (whole replacement).
+
+    The snapshot must carry ``pid`` and ``updated_at`` (wall-clock time) so
+    aggregation can reap stale entries. Best-effort by contract: callers
+    must tolerate exceptions.
+    """
+    if not _initialized:
+        return
+    ns = await _get_queue_stats_namespace()
+    ns[f"{queue_name}{KEY_SEP}{os.getpid()}"] = dict(snapshot)
+
+
+async def unpublish_queue_stats(queue_name: str) -> None:
+    """Remove this process's snapshot for ``queue_name`` (idempotent)."""
+    if not _initialized:
+        return
+    ns = await _get_queue_stats_namespace()
+    ns.pop(f"{queue_name}{KEY_SEP}{os.getpid()}", None)
+
+
+async def aggregate_queue_stats(queue_name: str) -> Dict[str, Any]:
+    """Aggregate all workers' published snapshots for ``queue_name``.
+
+    Sums the flat counter fields across live snapshots and returns them
+    together with ``reporting_workers`` and the raw ``per_worker`` map.
+    Entries owned by dead PIDs or older than the stale TTL are reaped —
+    re-checked under the internal lock against the previously observed
+    ``updated_at`` so a snapshot republished concurrently is never deleted.
+    """
+    ns = await _get_queue_stats_namespace()
+    now = time.time()
+    prefix = f"{queue_name}{KEY_SEP}"
+    per_worker: Dict[str, Dict[str, Any]] = {}
+    stale: List[tuple] = []
+    for key in [k for k in ns.keys() if k.startswith(prefix)]:
+        raw = ns.get(key)
+        if raw is None:
+            continue
+        snap = dict(raw)
+        pid = snap.get("pid")
+        updated_at = snap.get("updated_at", 0.0)
+        if (pid is not None and not _pid_alive(pid)) or (
+            now - updated_at > _queue_stats_stale_ttl
+        ):
+            stale.append((key, updated_at))
+            continue
+        per_worker[str(pid)] = snap
+
+    if stale:
+        async with get_internal_lock():
+            for key, seen_updated_at in stale:
+                current = ns.get(key)
+                if current is None:
+                    continue
+                if dict(current).get("updated_at", 0.0) != seen_updated_at:
+                    continue  # republished since we looked — keep it
+                ns.pop(key, None)
+
+    aggregated: Dict[str, Any] = {
+        field: sum(int(snap.get(field, 0) or 0) for snap in per_worker.values())
+        for field in QUEUE_STATS_SUM_FIELDS
+    }
+    aggregated["reporting_workers"] = len(per_worker)
+    aggregated["per_worker"] = per_worker
+    return aggregated

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -110,9 +110,9 @@ _debug_n_locks_acquired: int = 0
 # guard and never overwrite it.
 _global_concurrency_limits: Optional[Dict[str, int]] = None
 
-# Separator between the group/queue name and the per-lease / per-pid suffix
-# in shared namespace keys. \x1f (ASCII unit separator) cannot appear in
-# group names or queue names.
+# Separator between the queue name and the per-pid suffix in queue-stats
+# namespace keys. \x1f (ASCII unit separator) cannot appear in queue names.
+# (Concurrency gate state needs no separator: one key per group.)
 KEY_SEP = "\x1f"
 
 _CONCURRENCY_LEASE_NAMESPACE = "concurrency_leases"
@@ -123,11 +123,6 @@ _heartbeat_ttl: float = DEFAULT_GLOBAL_SLOT_HEARTBEAT_TTL
 _suspect_grace: float = DEFAULT_GLOBAL_SLOT_SUSPECT_GRACE
 _queue_stats_stale_ttl: float = DEFAULT_QUEUE_STATS_STALE_TTL
 _waiter_stale_ttl: float = DEFAULT_GLOBAL_SLOT_WAITER_STALE_TTL
-
-# Marker segment distinguishing per-process waiter records from lease
-# entries inside the same group prefix of the lease namespace:
-# ``f"{group}{KEY_SEP}{_WAITER_MARK}{KEY_SEP}{pid}"``.
-_WAITER_MARK = "_waiter"
 
 # Per-process cached namespace references (avoid the internal lock on every
 # publish). Reset by initialize_share_data()/finalize_share_data().
@@ -195,11 +190,39 @@ class UnifiedLock(Generic[T]):
         self._enable_logging = enable_logging  # for debug only
         self._async_lock = async_lock  # auxiliary lock for coroutine synchronization
 
+    async def _acquire_mp_lock_in_executor(self) -> None:
+        """Acquire the multiprocess lock without blocking the event loop.
+
+        Cancellation safety: if this coroutine is cancelled while the
+        executor thread is still blocked inside ``acquire()``, the thread
+        cannot be interrupted and WILL take the lock eventually — with no
+        owner left to release it, every process would deadlock. The shield +
+        done-callback below returns such an orphaned acquisition immediately.
+        """
+        loop = asyncio.get_running_loop()
+        acquire_future = loop.run_in_executor(None, self._lock.acquire)
+        try:
+            await asyncio.shield(acquire_future)
+        except asyncio.CancelledError:
+
+            def _release_orphaned_acquire(f) -> None:
+                if f.cancelled() or f.exception() is not None:
+                    return
+                try:
+                    self._lock.release()
+                except Exception:
+                    pass
+
+            acquire_future.add_done_callback(_release_orphaned_acquire)
+            raise
+
     async def __aenter__(self) -> "UnifiedLock[T]":
+        async_gate_acquired = False
         try:
             # If in multiprocess mode and async lock exists, acquire it first
             if not self._is_async and self._async_lock is not None:
                 await self._async_lock.acquire()
+                async_gate_acquired = True
                 direct_log(
                     f"== Lock == Process {self._pid}: Acquired async lock '{self._name}",
                     level="DEBUG",
@@ -212,7 +235,13 @@ class UnifiedLock(Generic[T]):
             if self._is_async:
                 await self._lock.acquire()
             else:
-                self._lock.acquire()
+                # A Manager lock proxy blocks the calling thread until every
+                # other PROCESS ahead of us releases — unbounded. Offload to
+                # the default executor so this process's event loop keeps
+                # serving while we wait (the async gate above already
+                # serializes this process's coroutines, so at most one
+                # executor thread per lock key is ever parked here).
+                await self._acquire_mp_lock_in_executor()
 
             direct_log(
                 f"== Lock == Process {self._pid}: Acquired lock {self._name} (async={self._is_async})",
@@ -220,13 +249,23 @@ class UnifiedLock(Generic[T]):
                 enable_output=self._enable_logging,
             )
             return self
+        except asyncio.CancelledError:
+            # Cancellation can arrive while awaiting the executor-offloaded
+            # mp acquire (any orphaned acquisition is returned inside
+            # _acquire_mp_lock_in_executor). Roll back the per-process gate
+            # we already hold so this process's other coroutines never
+            # deadlock on it.
+            if async_gate_acquired:
+                self._async_lock.release()
+            direct_log(
+                f"== Lock == Process {self._pid}: Lock acquisition cancelled '{self._name}'",
+                level="WARNING",
+                enable_output=self._enable_logging,
+            )
+            raise
         except Exception as e:
             # If main lock acquisition fails, release the async lock if it was acquired
-            if (
-                not self._is_async
-                and self._async_lock is not None
-                and self._async_lock.locked()
-            ):
+            if async_gate_acquired:
                 self._async_lock.release()
 
             direct_log(
@@ -1822,11 +1861,23 @@ def get_pipeline_status_lock(
 # Cross-worker global concurrency gate (lease + heartbeat semantics)
 # ---------------------------------------------------------------------------
 #
-# Leases live in the workspace-less "concurrency_leases" namespace as
-# ``f"{group}{KEY_SEP}{lease_id}" -> {"pid": int, "updated_at": float}``
-# plain dicts (whole-value replacement only — in multiprocess mode the
-# namespace is a Manager dict, so in-place mutation of a retrieved value
-# would NOT persist across processes).
+# Each group's whole gate state lives under a SINGLE key of the
+# workspace-less "concurrency_leases" namespace::
+#
+#     ns[group] = {
+#         "leases":  {lease_id: {"pid": int, "updated_at": float,
+#                                ("suspect_since": float)}},
+#         "waiters": {str(pid): {"pid": int, "wait_start": float,
+#                                "last_poll": float}},
+#     }
+#
+# Whole-value replacement only — in multiprocess mode the namespace is a
+# Manager dict, so in-place mutation of a retrieved value would NOT persist
+# across processes. The single-key layout is deliberate: every proxy access
+# is one IPC round trip to the manager process, so an acquire attempt under
+# the group's keyed lock costs exactly one read (plus at most one write)
+# instead of scanning per-lease keys. Reaping, capacity counting and waiter
+# ranking all run on the local copy.
 #
 # Self-healing: holders refresh ``updated_at`` from their 5s health-check
 # heartbeat. A lease is reclaimed when its owner PID is dead (immediately)
@@ -1893,23 +1944,41 @@ async def _get_queue_stats_namespace() -> Dict[str, Any]:
     return _queue_stats_ns_cache
 
 
-def _waiter_key(group: str, pid: int) -> str:
-    return f"{group}{KEY_SEP}{_WAITER_MARK}{KEY_SEP}{pid}"
+def _empty_gate_state() -> Dict[str, Any]:
+    return {"leases": {}, "waiters": {}}
 
 
-def _waiter_prefix(group: str) -> str:
-    return f"{group}{KEY_SEP}{_WAITER_MARK}{KEY_SEP}"
+def _load_gate_state(ns: Dict[str, Any], group: str) -> Dict[str, Any]:
+    """Return a local, independently mutable copy of a group's gate state.
+
+    Exactly one proxy read. The nested dicts are copied so that mutating the
+    result never aliases the stored value (a plain dict in single-process
+    mode) — callers mutate the copy and write it back whole.
+    """
+    raw = ns.get(group)
+    if raw is None:
+        return _empty_gate_state()
+    state = dict(raw)
+    state["leases"] = {
+        lease_id: dict(lease)
+        for lease_id, lease in dict(state.get("leases") or {}).items()
+    }
+    state["waiters"] = {
+        pid_key: dict(waiter)
+        for pid_key, waiter in dict(state.get("waiters") or {}).items()
+    }
+    return state
 
 
-def _reap_group_leases_locked(ns: Dict[str, Any], group: str, now: float) -> int:
-    """Reclaim dead/expired leases of ``group``; return surviving lease count.
+def _reap_gate_state(state: Dict[str, Any], now: float) -> tuple[int, bool]:
+    """Reclaim dead/expired leases on a local state copy (no IPC).
 
-    MUST be called while holding the group's keyed lock. Suspect handling:
-    a lease whose heartbeat expired while its PID is still alive is first
-    marked with ``suspect_since`` and reclaimed only after ``_suspect_grace``
-    elapses without a renewal; a renewal (fresh ``updated_at``) clears the
-    suspect mark. Dead PIDs are reclaimed immediately. Suspect leases still
-    count toward capacity so the global limit is never exceeded.
+    Returns ``(live_lease_count, changed)``. Suspect handling: a lease whose
+    heartbeat expired while its PID is still alive is first marked with
+    ``suspect_since`` and reclaimed only after ``_suspect_grace`` elapses
+    without a renewal; a renewal (fresh ``updated_at``) clears the suspect
+    mark. Dead PIDs are reclaimed immediately. Suspect leases still count
+    toward capacity so the global limit is never exceeded.
 
     Waiter records are reaped in the same pass: a process whose lease was
     just reclaimed (timed out / died), whose PID is dead, or whose record
@@ -1917,21 +1986,18 @@ def _reap_group_leases_locked(ns: Dict[str, Any], group: str, now: float) -> int
     occupying the longest-waiter seat — a ghost favored waiter would push
     every live waiter onto the deferred backoff and waste freed slots.
     """
-    prefix = f"{group}{KEY_SEP}"
-    waiter_prefix = _waiter_prefix(group)
+    leases: Dict[str, Any] = state["leases"]
+    waiters: Dict[str, Any] = state["waiters"]
     live = 0
+    changed = False
     reclaimed_pids = set()
-    for key in [
-        k for k in ns.keys() if k.startswith(prefix) and not k.startswith(waiter_prefix)
-    ]:
-        raw = ns.get(key)
-        if raw is None:
-            continue
-        lease = dict(raw)
+    for lease_id in list(leases.keys()):
+        lease = leases[lease_id]
         pid = lease.get("pid")
         updated_at = lease.get("updated_at", 0.0)
         if pid is None or not _pid_alive(pid):
-            ns.pop(key, None)
+            leases.pop(lease_id)
+            changed = True
             if pid is not None:
                 reclaimed_pids.add(pid)
             continue
@@ -1939,24 +2005,22 @@ def _reap_group_leases_locked(ns: Dict[str, Any], group: str, now: float) -> int
             suspect_since = lease.get("suspect_since")
             if suspect_since is None:
                 lease["suspect_since"] = now
-                ns[key] = lease
+                changed = True
                 live += 1
             elif now - suspect_since > _suspect_grace:
-                ns.pop(key, None)
+                leases.pop(lease_id)
                 reclaimed_pids.add(pid)
+                changed = True
             else:
                 live += 1
         else:
             if "suspect_since" in lease:
                 lease.pop("suspect_since", None)
-                ns[key] = lease
+                changed = True
             live += 1
 
-    for key in [k for k in ns.keys() if k.startswith(waiter_prefix)]:
-        raw = ns.get(key)
-        if raw is None:
-            continue
-        waiter = dict(raw)
+    for pid_key in list(waiters.keys()):
+        waiter = waiters[pid_key]
         pid = waiter.get("pid")
         last_poll = waiter.get("last_poll", 0.0)
         if (
@@ -1965,8 +2029,9 @@ def _reap_group_leases_locked(ns: Dict[str, Any], group: str, now: float) -> int
             or not _pid_alive(pid)
             or now - last_poll > _waiter_stale_ttl
         ):
-            ns.pop(key, None)
-    return live
+            waiters.pop(pid_key)
+            changed = True
+    return live, changed
 
 
 def _log_acquire_failure(group: str, error: Exception) -> None:
@@ -1981,22 +2046,16 @@ def _log_acquire_failure(group: str, error: Exception) -> None:
         )
 
 
-def _is_longest_live_waiter_locked(
-    ns: Dict[str, Any], group: str, pid: int, now: float
-) -> bool:
-    """Is ``pid`` the longest-waiting live poller of ``group``?
+def _is_longest_live_waiter(state: Dict[str, Any], pid: int, now: float) -> bool:
+    """Is ``pid`` the longest-waiting live poller in this gate state?
 
-    MUST be called while holding the group's keyed lock, after the reap
-    pass has dropped dead/stale waiter records — every remaining record
-    belongs to a live, actively polling process.
+    Operates on a local state copy after the reap pass has dropped
+    dead/stale waiter records — every remaining record belongs to a live,
+    actively polling process.
     """
     my_start = None
     others_min = None
-    for key in [k for k in ns.keys() if k.startswith(_waiter_prefix(group))]:
-        raw = ns.get(key)
-        if raw is None:
-            continue
-        waiter = dict(raw)
+    for waiter in state["waiters"].values():
         wait_start = waiter.get("wait_start", now)
         if waiter.get("pid") == pid:
             my_start = wait_start
@@ -2017,6 +2076,10 @@ async def _acquire_global_slot(
     (``wait_start`` set once per waiting episode, ``last_poll`` refreshed on
     every attempt) and reports whether this process is the longest-waiting
     live poller; a successful attempt always clears the record.
+
+    IPC budget under the keyed lock: one state read, plus one write only
+    when something changed (reap effects, waiter registration, or a new
+    lease) — a plain failed attempt on an unchanged gate writes nothing.
     """
     limit = get_global_concurrency_limit(group)
     if limit is None or limit <= 0:
@@ -2027,29 +2090,31 @@ async def _acquire_global_slot(
             group, namespace=_CONCURRENCY_LEASE_NAMESPACE, enable_logging=False
         ):
             now = time.time()
-            in_use = _reap_group_leases_locked(ns, group, now)
+            state = _load_gate_state(ns, group)
+            in_use, changed = _reap_gate_state(state, now)
             pid = os.getpid()
-            wkey = _waiter_key(group, pid)
+            pid_key = str(pid)
             if in_use >= limit:
                 if not track_wait:
+                    if changed:
+                        ns[group] = state
                     return None, False
-                raw = ns.get(wkey)
-                waiter = (
-                    dict(raw) if raw is not None else {"pid": pid, "wait_start": now}
-                )
+                waiter = state["waiters"].get(pid_key) or {
+                    "pid": pid,
+                    "wait_start": now,
+                }
                 waiter["last_poll"] = now
-                ns[wkey] = waiter
-                return None, _is_longest_live_waiter_locked(ns, group, pid, now)
+                state["waiters"][pid_key] = waiter
+                ns[group] = state
+                return None, _is_longest_live_waiter(state, pid, now)
             lease_id = uuid.uuid4().hex
-            ns[f"{group}{KEY_SEP}{lease_id}"] = {
-                "pid": pid,
-                "updated_at": now,
-            }
+            state["leases"][lease_id] = {"pid": pid, "updated_at": now}
             # Got a slot: this process is no longer waiting. Resetting here
             # (rather than keeping seniority) is what de-prioritizes a
             # backlog-heavy process after each win, yielding approximate
             # round-robin across processes under sustained contention.
-            ns.pop(wkey, None)
+            state["waiters"].pop(pid_key, None)
+            ns[group] = state
             return lease_id, True
     except Exception as e:
         _log_acquire_failure(group, e)
@@ -2100,7 +2165,9 @@ async def clear_slot_waiter(group: str) -> None:
     async with get_storage_keyed_lock(
         group, namespace=_CONCURRENCY_LEASE_NAMESPACE, enable_logging=False
     ):
-        ns.pop(_waiter_key(group, os.getpid()), None)
+        state = _load_gate_state(ns, group)
+        if state["waiters"].pop(str(os.getpid()), None) is not None:
+            ns[group] = state
 
 
 async def global_slot_waiters(group: str) -> List[Dict[str, Any]]:
@@ -2114,12 +2181,9 @@ async def global_slot_waiters(group: str) -> List[Dict[str, Any]]:
         return []
     ns = await _get_lease_namespace()
     now = time.time()
+    state = _load_gate_state(ns, group)
     waiters = []
-    for key in [k for k in ns.keys() if k.startswith(_waiter_prefix(group))]:
-        raw = ns.get(key)
-        if raw is None:
-            continue
-        waiter = dict(raw)
+    for waiter in state["waiters"].values():
         if now - waiter.get("last_poll", 0.0) > _waiter_stale_ttl:
             continue
         waiters.append(
@@ -2142,7 +2206,9 @@ async def release_global_slot(group: str, lease_id: str) -> None:
     async with get_storage_keyed_lock(
         group, namespace=_CONCURRENCY_LEASE_NAMESPACE, enable_logging=False
     ):
-        ns.pop(f"{group}{KEY_SEP}{lease_id}", None)
+        state = _load_gate_state(ns, group)
+        if state["leases"].pop(lease_id, None) is not None:
+            ns[group] = state
 
 
 async def renew_global_slots(group: str, lease_ids) -> None:
@@ -2161,10 +2227,14 @@ async def renew_global_slots(group: str, lease_ids) -> None:
         group, namespace=_CONCURRENCY_LEASE_NAMESPACE, enable_logging=False
     ):
         now = time.time()
+        state = _load_gate_state(ns, group)
+        changed = False
         for lease_id in lease_ids:
-            key = f"{group}{KEY_SEP}{lease_id}"
-            if ns.get(key) is not None:
-                ns[key] = {"pid": os.getpid(), "updated_at": now}
+            if lease_id in state["leases"]:
+                state["leases"][lease_id] = {"pid": os.getpid(), "updated_at": now}
+                changed = True
+        if changed:
+            ns[group] = state
 
 
 async def reconcile_global_slots(group: str) -> int:
@@ -2173,17 +2243,20 @@ async def reconcile_global_slots(group: str) -> int:
     async with get_storage_keyed_lock(
         group, namespace=_CONCURRENCY_LEASE_NAMESPACE, enable_logging=False
     ):
-        return _reap_group_leases_locked(ns, group, time.time())
+        state = _load_gate_state(ns, group)
+        live, changed = _reap_gate_state(state, time.time())
+        if changed:
+            ns[group] = state
+        return live
 
 
 async def global_concurrency_in_use(group: str) -> int:
-    """Approximate count of currently held global slots for ``group``."""
+    """Approximate count of currently held global slots for ``group``.
+
+    Lock-free single read — intended for observability.
+    """
     ns = await _get_lease_namespace()
-    prefix = f"{group}{KEY_SEP}"
-    waiter_prefix = _waiter_prefix(group)
-    return sum(
-        1 for k in ns.keys() if k.startswith(prefix) and not k.startswith(waiter_prefix)
-    )
+    return len(_load_gate_state(ns, group)["leases"])
 
 
 # ---------------------------------------------------------------------------

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -1885,16 +1885,18 @@ def get_pipeline_status_lock(
 # live-but-momentarily-stalled owners from false reclamation). Long-running
 # tasks are never reclaimed as long as their owner keeps renewing.
 #
-# Best-effort cap, NOT a hard guarantee: the limit is enforced exactly as
-# long as every holder renews on time. If an owner's event loop stalls past
-# the heartbeat TTL + suspect grace (~40s with the defaults, i.e. ~8 missed
-# 5s heartbeats) while still running its provider call, another process may
-# reclaim that still-in-use slot and hand it out, briefly pushing the true
-# total to limit+1. A reclaimed lease is never resurrected (renew_global_slots
-# refuses to re-insert a popped lease, which would otherwise permanently
-# exceed the limit). This soft-cap window is the accepted trade-off of
-# lease-based coordination on a single host; callers must not rely on the
-# global cap as a strict invariant.
+# Best-effort cap, not a strict provider-side invariant: the lease table is
+# the admission source of truth, so the cap is exact while holders keep
+# renewing. A slot is reclaimed only when its owner PID is gone or its
+# heartbeat has expired beyond the suspect grace. That prevents permanent
+# capacity leaks after kill -9 / OOM and similar external termination, but
+# the provider may still be finishing the abandoned HTTP request until its
+# own timeout/connection close. During that window, a newly admitted caller
+# can overlap with the abandoned provider-side call. Long event-loop stalls
+# have the same shape after heartbeat TTL + suspect grace, though normal long
+# calls are protected by regular renewal. A reclaimed lease is never
+# resurrected (renew_global_slots refuses to re-insert a popped lease), which
+# keeps the internal gate self-healing.
 
 
 def is_share_data_initialized() -> bool:

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Mapping, Optional, Union, TypeVar, Generic
 from lightrag.constants import (
     DEFAULT_GLOBAL_SLOT_HEARTBEAT_TTL,
     DEFAULT_GLOBAL_SLOT_SUSPECT_GRACE,
+    DEFAULT_GLOBAL_SLOT_WAITER_STALE_TTL,
     DEFAULT_QUEUE_STATS_STALE_TTL,
 )
 from lightrag.exceptions import PipelineNotInitializedError
@@ -121,6 +122,12 @@ _QUEUE_STATS_NAMESPACE = "queue_stats"
 _heartbeat_ttl: float = DEFAULT_GLOBAL_SLOT_HEARTBEAT_TTL
 _suspect_grace: float = DEFAULT_GLOBAL_SLOT_SUSPECT_GRACE
 _queue_stats_stale_ttl: float = DEFAULT_QUEUE_STATS_STALE_TTL
+_waiter_stale_ttl: float = DEFAULT_GLOBAL_SLOT_WAITER_STALE_TTL
+
+# Marker segment distinguishing per-process waiter records from lease
+# entries inside the same group prefix of the lease namespace:
+# ``f"{group}{KEY_SEP}{_WAITER_MARK}{KEY_SEP}{pid}"``.
+_WAITER_MARK = "_waiter"
 
 # Per-process cached namespace references (avoid the internal lock on every
 # publish). Reset by initialize_share_data()/finalize_share_data().
@@ -1886,6 +1893,14 @@ async def _get_queue_stats_namespace() -> Dict[str, Any]:
     return _queue_stats_ns_cache
 
 
+def _waiter_key(group: str, pid: int) -> str:
+    return f"{group}{KEY_SEP}{_WAITER_MARK}{KEY_SEP}{pid}"
+
+
+def _waiter_prefix(group: str) -> str:
+    return f"{group}{KEY_SEP}{_WAITER_MARK}{KEY_SEP}"
+
+
 def _reap_group_leases_locked(ns: Dict[str, Any], group: str, now: float) -> int:
     """Reclaim dead/expired leases of ``group``; return surviving lease count.
 
@@ -1895,10 +1910,20 @@ def _reap_group_leases_locked(ns: Dict[str, Any], group: str, now: float) -> int
     elapses without a renewal; a renewal (fresh ``updated_at``) clears the
     suspect mark. Dead PIDs are reclaimed immediately. Suspect leases still
     count toward capacity so the global limit is never exceeded.
+
+    Waiter records are reaped in the same pass: a process whose lease was
+    just reclaimed (timed out / died), whose PID is dead, or whose record
+    has not been refreshed within ``_waiter_stale_ttl`` must not keep
+    occupying the longest-waiter seat — a ghost favored waiter would push
+    every live waiter onto the deferred backoff and waste freed slots.
     """
     prefix = f"{group}{KEY_SEP}"
+    waiter_prefix = _waiter_prefix(group)
     live = 0
-    for key in [k for k in ns.keys() if k.startswith(prefix)]:
+    reclaimed_pids = set()
+    for key in [
+        k for k in ns.keys() if k.startswith(prefix) and not k.startswith(waiter_prefix)
+    ]:
         raw = ns.get(key)
         if raw is None:
             continue
@@ -1907,6 +1932,8 @@ def _reap_group_leases_locked(ns: Dict[str, Any], group: str, now: float) -> int
         updated_at = lease.get("updated_at", 0.0)
         if pid is None or not _pid_alive(pid):
             ns.pop(key, None)
+            if pid is not None:
+                reclaimed_pids.add(pid)
             continue
         if now - updated_at > _heartbeat_ttl:
             suspect_since = lease.get("suspect_since")
@@ -1916,6 +1943,7 @@ def _reap_group_leases_locked(ns: Dict[str, Any], group: str, now: float) -> int
                 live += 1
             elif now - suspect_since > _suspect_grace:
                 ns.pop(key, None)
+                reclaimed_pids.add(pid)
             else:
                 live += 1
         else:
@@ -1923,6 +1951,21 @@ def _reap_group_leases_locked(ns: Dict[str, Any], group: str, now: float) -> int
                 lease.pop("suspect_since", None)
                 ns[key] = lease
             live += 1
+
+    for key in [k for k in ns.keys() if k.startswith(waiter_prefix)]:
+        raw = ns.get(key)
+        if raw is None:
+            continue
+        waiter = dict(raw)
+        pid = waiter.get("pid")
+        last_poll = waiter.get("last_poll", 0.0)
+        if (
+            pid is None
+            or pid in reclaimed_pids
+            or not _pid_alive(pid)
+            or now - last_poll > _waiter_stale_ttl
+        ):
+            ns.pop(key, None)
     return live
 
 
@@ -1938,17 +1981,46 @@ def _log_acquire_failure(group: str, error: Exception) -> None:
         )
 
 
-async def try_acquire_global_slot(group: str) -> Optional[str]:
-    """Try to claim one global concurrency slot for ``group`` (non-blocking).
+def _is_longest_live_waiter_locked(
+    ns: Dict[str, Any], group: str, pid: int, now: float
+) -> bool:
+    """Is ``pid`` the longest-waiting live poller of ``group``?
 
-    Returns a lease id on success, or None when the group is at capacity.
-    Any shared-storage error is fail-closed: returns None (with a
-    rate-limited warning) so the caller keeps the task queued and retries —
-    capacity is never exceeded due to infrastructure errors.
+    MUST be called while holding the group's keyed lock, after the reap
+    pass has dropped dead/stale waiter records — every remaining record
+    belongs to a live, actively polling process.
+    """
+    my_start = None
+    others_min = None
+    for key in [k for k in ns.keys() if k.startswith(_waiter_prefix(group))]:
+        raw = ns.get(key)
+        if raw is None:
+            continue
+        waiter = dict(raw)
+        wait_start = waiter.get("wait_start", now)
+        if waiter.get("pid") == pid:
+            my_start = wait_start
+        elif others_min is None or wait_start < others_min:
+            others_min = wait_start
+    if my_start is None:
+        return False
+    return others_min is None or my_start <= others_min
+
+
+async def _acquire_global_slot(
+    group: str, track_wait: bool
+) -> tuple[Optional[str], bool]:
+    """Shared implementation for the two acquire entry points.
+
+    Returns ``(lease_id, is_priority_waiter)``. When ``track_wait`` is set,
+    a failed attempt registers/refreshes this process's waiter record
+    (``wait_start`` set once per waiting episode, ``last_poll`` refreshed on
+    every attempt) and reports whether this process is the longest-waiting
+    live poller; a successful attempt always clears the record.
     """
     limit = get_global_concurrency_limit(group)
     if limit is None or limit <= 0:
-        return None
+        return None, False
     try:
         ns = await _get_lease_namespace()
         async with get_storage_keyed_lock(
@@ -1956,17 +2028,107 @@ async def try_acquire_global_slot(group: str) -> Optional[str]:
         ):
             now = time.time()
             in_use = _reap_group_leases_locked(ns, group, now)
+            pid = os.getpid()
+            wkey = _waiter_key(group, pid)
             if in_use >= limit:
-                return None
+                if not track_wait:
+                    return None, False
+                raw = ns.get(wkey)
+                waiter = (
+                    dict(raw) if raw is not None else {"pid": pid, "wait_start": now}
+                )
+                waiter["last_poll"] = now
+                ns[wkey] = waiter
+                return None, _is_longest_live_waiter_locked(ns, group, pid, now)
             lease_id = uuid.uuid4().hex
             ns[f"{group}{KEY_SEP}{lease_id}"] = {
-                "pid": os.getpid(),
+                "pid": pid,
                 "updated_at": now,
             }
-            return lease_id
+            # Got a slot: this process is no longer waiting. Resetting here
+            # (rather than keeping seniority) is what de-prioritizes a
+            # backlog-heavy process after each win, yielding approximate
+            # round-robin across processes under sustained contention.
+            ns.pop(wkey, None)
+            return lease_id, True
     except Exception as e:
         _log_acquire_failure(group, e)
-        return None
+        return None, False
+
+
+async def try_acquire_global_slot(group: str) -> Optional[str]:
+    """Try to claim one global concurrency slot for ``group`` (non-blocking).
+
+    Returns a lease id on success, or None when the group is at capacity.
+    Any shared-storage error is fail-closed: returns None (with a
+    rate-limited warning) so the caller keeps the task queued and retries —
+    capacity is never exceeded due to infrastructure errors.
+
+    This plain variant never registers waiter records — use
+    :func:`try_acquire_global_slot_tracked` from polling loops that want
+    longest-waiter fairness.
+    """
+    lease_id, _ = await _acquire_global_slot(group, track_wait=False)
+    return lease_id
+
+
+async def try_acquire_global_slot_tracked(group: str) -> tuple[Optional[str], bool]:
+    """Acquire variant for polling loops: ``(lease_id, is_priority_waiter)``.
+
+    On failure the caller's waiter record is registered/refreshed and the
+    second element reports whether this process is currently the
+    longest-waiting live poller of the group. Pollers should keep the
+    fastest poll interval when favored and back off (bounded) otherwise —
+    a soft FIFO across worker processes with no hard gate: any poller that
+    finds a free slot still takes it, so a sleeping favored waiter can
+    never leave capacity idle indefinitely. Fail-closed errors report
+    ``(None, False)``.
+    """
+    return await _acquire_global_slot(group, track_wait=True)
+
+
+async def clear_slot_waiter(group: str) -> None:
+    """Drop this process's waiter record for ``group`` (idempotent).
+
+    Called when a wrapper shuts down so a no-longer-polling process never
+    lingers in the longest-waiter seat; the stale TTL and the reap pass
+    cover crashes where this cleanup never runs.
+    """
+    if not _initialized:
+        return
+    ns = await _get_lease_namespace()
+    async with get_storage_keyed_lock(
+        group, namespace=_CONCURRENCY_LEASE_NAMESPACE, enable_logging=False
+    ):
+        ns.pop(_waiter_key(group, os.getpid()), None)
+
+
+async def global_slot_waiters(group: str) -> List[Dict[str, Any]]:
+    """Snapshot of processes actively polling for a slot of ``group``.
+
+    Returns ``[{"pid": ..., "waited": seconds}, ...]`` sorted by descending
+    wait time; stale records (not refreshed within the waiter TTL) are
+    skipped. Read-only and lock-free — intended for observability.
+    """
+    if not _initialized:
+        return []
+    ns = await _get_lease_namespace()
+    now = time.time()
+    waiters = []
+    for key in [k for k in ns.keys() if k.startswith(_waiter_prefix(group))]:
+        raw = ns.get(key)
+        if raw is None:
+            continue
+        waiter = dict(raw)
+        if now - waiter.get("last_poll", 0.0) > _waiter_stale_ttl:
+            continue
+        waiters.append(
+            {
+                "pid": waiter.get("pid"),
+                "waited": max(0.0, now - waiter.get("wait_start", now)),
+            }
+        )
+    return sorted(waiters, key=lambda w: -w["waited"])
 
 
 async def release_global_slot(group: str, lease_id: str) -> None:
@@ -2018,7 +2180,10 @@ async def global_concurrency_in_use(group: str) -> int:
     """Approximate count of currently held global slots for ``group``."""
     ns = await _get_lease_namespace()
     prefix = f"{group}{KEY_SEP}"
-    return sum(1 for k in ns.keys() if k.startswith(prefix))
+    waiter_prefix = _waiter_prefix(group)
+    return sum(
+        1 for k in ns.keys() if k.startswith(prefix) and not k.startswith(waiter_prefix)
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -1884,6 +1884,17 @@ def get_pipeline_status_lock(
 # or when its heartbeat expired AND the suspect grace elapsed (protects
 # live-but-momentarily-stalled owners from false reclamation). Long-running
 # tasks are never reclaimed as long as their owner keeps renewing.
+#
+# Best-effort cap, NOT a hard guarantee: the limit is enforced exactly as
+# long as every holder renews on time. If an owner's event loop stalls past
+# the heartbeat TTL + suspect grace (~40s with the defaults, i.e. ~8 missed
+# 5s heartbeats) while still running its provider call, another process may
+# reclaim that still-in-use slot and hand it out, briefly pushing the true
+# total to limit+1. A reclaimed lease is never resurrected (renew_global_slots
+# refuses to re-insert a popped lease, which would otherwise permanently
+# exceed the limit). This soft-cap window is the accepted trade-off of
+# lease-based coordination on a single host; callers must not rely on the
+# global cap as a strict invariant.
 
 
 def is_share_data_initialized() -> bool:

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -953,6 +953,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 self.rerank_model_max_async,
                 llm_timeout=self.default_rerank_timeout,
                 queue_name="Rerank func",
+                concurrency_group="rerank",
             )(self.rerank_model_func)
 
         # Init Embedding
@@ -983,6 +984,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 self.embedding_func_max_async,
                 llm_timeout=self.default_embedding_timeout,
                 queue_name="Embedding func",
+                concurrency_group="embedding",
             )(self.embedding_func.func)
             # Use dataclasses.replace() to create a new instance, leaving the original unchanged
             self.embedding_func = replace(self.embedding_func, func=wrapped_func)

--- a/lightrag/llm_roles.py
+++ b/lightrag/llm_roles.py
@@ -185,6 +185,7 @@ class _RoleLLMMixin:
             max_async,
             llm_timeout=timeout,
             queue_name=spec.queue_name,
+            concurrency_group=f"llm:{role_name}",
         )(
             partial(
                 raw_func,
@@ -535,7 +536,13 @@ class _RoleLLMMixin:
     ) -> dict[str, Any]:
         if func is None:
             return {"available": False}
-        get_stats = getattr(func, "get_queue_stats", None)
+        # Prefer the cross-worker aggregated view (sums every gunicorn
+        # worker's published snapshot; falls back to the local snapshot
+        # internally on any shared-storage failure, so "available" keeps
+        # meaning "this wrapper exists", never "aggregation succeeded").
+        get_stats = getattr(func, "get_aggregated_queue_stats", None)
+        if not callable(get_stats):
+            get_stats = getattr(func, "get_queue_stats", None)
         if not callable(get_stats):
             return {"available": False}
         stats = get_stats()

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -47,7 +47,7 @@ from lightrag.constants import (
     SOURCE_IDS_LIMIT_METHOD_FIFO,
     PARSED_DIR_NAME,
     DEFAULT_GLOBAL_SLOT_POLL_MIN,
-    DEFAULT_GLOBAL_SLOT_POLL_MAX,
+    DEFAULT_GLOBAL_SLOT_POLL_DEFERRED_MAX,
     DEFAULT_GLOBAL_SLOT_DRAIN_LIMIT,
     DEFAULT_ZOMBIE_COMPACT_THRESHOLD,
     DEFAULT_COMPACT_BATCH_LIMIT,
@@ -1066,18 +1066,26 @@ def priority_limit_async_func_call(
             async with admission_cond:
                 admission_cond.notify_all()
 
-        async def _try_acquire_slot() -> str | None:
-            """Non-blocking global slot acquisition (fail-closed on errors)."""
+        async def _try_acquire_slot() -> tuple[str | None, bool]:
+            """Non-blocking global slot acquisition (fail-closed on errors).
+
+            Returns ``(lease_id, is_priority_waiter)``: on failure the
+            second element reports whether this process is the
+            longest-waiting live poller of the group, which drives the
+            adaptive poll backoff below.
+            """
             try:
-                lease_id = await shared.try_acquire_global_slot(concurrency_group)
+                lease_id, is_priority = await shared.try_acquire_global_slot_tracked(
+                    concurrency_group
+                )
             except Exception as e:
-                # try_acquire_global_slot is fail-closed internally; this
-                # guard keeps the worker alive even if it ever raises.
+                # try_acquire_global_slot_tracked is fail-closed internally;
+                # this guard keeps the worker alive even if it ever raises.
                 logger.debug(f"{queue_name}: global slot acquisition error: {e}")
-                return None
+                return None, False
             if lease_id is not None:
                 held_leases.add(lease_id)
-            return lease_id
+            return lease_id, is_priority
 
         async def _release_lease_safely(lease_id: str) -> None:
             """Release a global slot without raising (safe in finally blocks).
@@ -1333,14 +1341,24 @@ def priority_limit_async_func_call(
                         # tasks must remain queued (and cancellable) while
                         # all slots are busy. Fail-closed errors land here
                         # too, as a None lease.
-                        lease_id = await _try_acquire_slot()
+                        lease_id, is_priority_waiter = await _try_acquire_slot()
                         if lease_id is None:
                             global_slot_waits += 1
                             _mark_stats_dirty()
+                            # Soft FIFO across processes: the longest-waiting
+                            # live process keeps the fastest poll rate so it
+                            # usually claims the next freed slot; everyone
+                            # else backs off, bounded by the deferred cap so
+                            # a freed slot is never left idle for long when
+                            # the favored waiter is gone (promotion lag).
+                            if is_priority_waiter:
+                                poll_delay = DEFAULT_GLOBAL_SLOT_POLL_MIN
+                            else:
+                                poll_delay = min(
+                                    poll_delay * 2,
+                                    DEFAULT_GLOBAL_SLOT_POLL_DEFERRED_MAX,
+                                )
                             await asyncio.sleep(poll_delay)
-                            poll_delay = min(
-                                poll_delay * 2, DEFAULT_GLOBAL_SLOT_POLL_MAX
-                            )
                             continue
                         poll_delay = DEFAULT_GLOBAL_SLOT_POLL_MIN
 
@@ -1670,6 +1688,11 @@ def priority_limit_async_func_call(
                     result["global_in_use"] = await shared.global_concurrency_in_use(
                         concurrency_group
                     )
+                    waiters = await shared.global_slot_waiters(concurrency_group)
+                    result["global_waiting_workers"] = len(waiters)
+                    result["global_longest_wait"] = (
+                        round(waiters[0]["waited"], 3) if waiters else 0.0
+                    )
                 return result
             except Exception as e:
                 logger.debug(
@@ -1768,6 +1791,13 @@ def priority_limit_async_func_call(
                         await shared.release_global_slot(concurrency_group, lease_id)
                     except Exception:
                         pass
+                # Our workers stop polling now: drop the waiter record so
+                # this process never lingers in the longest-waiter seat
+                # (the stale TTL covers crashes where this never runs).
+                try:
+                    await shared.clear_slot_waiter(concurrency_group)
+                except Exception:
+                    pass
             if publish_stats:
                 try:
                     await shared.unpublish_queue_stats(queue_name)

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -1256,7 +1256,7 @@ def priority_limit_async_func_call(
                             task_state.worker_started = True
                             # Record execution start time when worker actually begins processing
                             task_state.execution_start_time = (
-                                asyncio.get_event_loop().time()
+                                asyncio.get_running_loop().time()
                             )
 
                         # Check if task was cancelled before worker started
@@ -1433,7 +1433,7 @@ def priority_limit_async_func_call(
                                     else:
                                         task_state.worker_started = True
                                         task_state.execution_start_time = (
-                                            asyncio.get_event_loop().time()
+                                            asyncio.get_running_loop().time()
                                         )
                                         live_queued -= 1
                                         notify_needed = True
@@ -1573,7 +1573,7 @@ def priority_limit_async_func_call(
                 while not shutdown_event.is_set():
                     await asyncio.sleep(5)  # Check every 5 seconds
 
-                    current_time = asyncio.get_event_loop().time()
+                    current_time = asyncio.get_running_loop().time()
 
                     # Detect and handle stuck tasks based on execution start time
                     if max_task_duration is not None:
@@ -1953,10 +1953,12 @@ def priority_limit_async_func_call(
             nonlocal counter, submitted_total, completed_total, cancelled_total
             nonlocal failed_total, rejected_total, live_queued
 
-            task_id = f"{id(asyncio.current_task())}_{asyncio.get_event_loop().time()}"
+            task_id = (
+                f"{id(asyncio.current_task())}_{asyncio.get_running_loop().time()}"
+            )
             future = asyncio.Future()
             task_state = TaskState(
-                future=future, start_time=asyncio.get_event_loop().time()
+                future=future, start_time=asyncio.get_running_loop().time()
             )
 
             def _admission_open() -> bool:
@@ -2035,10 +2037,10 @@ def priority_limit_async_func_call(
                     if not future.done():
                         future.cancel()
 
-                    cleanup_start = asyncio.get_event_loop().time()
+                    cleanup_start = asyncio.get_running_loop().time()
                     while (
                         task_id in task_states
-                        and asyncio.get_event_loop().time() - cleanup_start
+                        and asyncio.get_running_loop().time() - cleanup_start
                         < cleanup_timeout
                     ):
                         await asyncio.sleep(0.1)
@@ -2114,12 +2116,14 @@ def priority_limit_async_func_call(
                 )
 
             # Generate unique task ID
-            task_id = f"{id(asyncio.current_task())}_{asyncio.get_event_loop().time()}"
+            task_id = (
+                f"{id(asyncio.current_task())}_{asyncio.get_running_loop().time()}"
+            )
             future = asyncio.Future()
 
             # Create task state
             task_state = TaskState(
-                future=future, start_time=asyncio.get_event_loop().time()
+                future=future, start_time=asyncio.get_running_loop().time()
             )
 
             try:
@@ -2184,10 +2188,10 @@ def priority_limit_async_func_call(
                         future.cancel()
 
                     # Wait for worker cleanup with timeout
-                    cleanup_start = asyncio.get_event_loop().time()
+                    cleanup_start = asyncio.get_running_loop().time()
                     while (
                         task_id in task_states
-                        and asyncio.get_event_loop().time() - cleanup_start
+                        and asyncio.get_running_loop().time() - cleanup_start
                         < cleanup_timeout
                     ):
                         await asyncio.sleep(0.1)

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -975,7 +975,14 @@ def priority_limit_async_func_call(
             DEFAULT_ZOMBIE_COMPACT_THRESHOLD,
             max_queue_size if max_queue_size > 0 else 0,
         )
-        stats_dirty = False
+        # Slot pump machinery (global-limit mode): ONE coroutine per process
+        # acquires global slots and hands (lease, task) pairs to executor
+        # workers through dispatch_queue. executing counts tasks picked up
+        # by workers; worker_free wakes the pump when one finishes.
+        dispatch_queue: asyncio.Queue | None = None
+        pump_task: asyncio.Task | None = None
+        executing = 0
+        worker_free = asyncio.Event()
         last_publish_time = 0.0
         last_release_warn_time = 0.0
         last_renew_warn_time = 0.0
@@ -1036,13 +1043,16 @@ def priority_limit_async_func_call(
                 "updated_at": time.time(),
             }
 
-        def _mark_stats_dirty() -> None:
-            nonlocal stats_dirty
-            stats_dirty = True
-
         async def _publish_stats(force: bool = False) -> None:
-            """Best-effort, debounced publish of the local stats snapshot."""
-            nonlocal stats_dirty, last_publish_time
+            """Best-effort, debounced publish of the local stats snapshot.
+
+            Called from counter-update points (debounced to the min publish
+            interval) and force-flushed by the 5s maintenance pass, which
+            also propagates any counter change that happened between
+            debounced publishes and keeps the snapshot ahead of the
+            aggregation stale TTL.
+            """
+            nonlocal last_publish_time
             if not publish_stats:
                 return
             now = time.time()
@@ -1053,14 +1063,9 @@ def priority_limit_async_func_call(
                 return
             try:
                 await shared.publish_queue_stats(queue_name, _snapshot())
-                stats_dirty = False
                 last_publish_time = now
             except Exception as e:
                 logger.debug(f"{queue_name}: queue stats publish failed: {e}")
-
-        async def _mark_dirty_and_maybe_publish() -> None:
-            _mark_stats_dirty()
-            await _publish_stats()
 
         async def _notify_admission() -> None:
             async with admission_cond:
@@ -1168,7 +1173,6 @@ def priority_limit_async_func_call(
                 work_available.set()
             if notify_needed:
                 await _notify_admission()
-            _mark_stats_dirty()
 
         async def _run_maintenance() -> None:
             """One heartbeat pass of cross-worker upkeep (never raises).
@@ -1306,16 +1310,23 @@ def priority_limit_async_func_call(
             finally:
                 logger.debug(f"{queue_name}: Worker exiting")
 
-        async def limited_worker():
-            """Worker for global-limit mode: slot-first, drain-second.
+        async def slot_pump():
+            """Single per-process slot acquirer for global-limit mode.
 
-            The worker acquires a cross-process slot BEFORE consuming the
-            local queue, so while slots are saturated tasks stay queued:
-            user-level timeouts/cancellations during the wait never reach
-            the provider, local priority order is preserved (the queue head
-            is taken only once a slot is held), and execution timing starts
-            only when a live task is actually picked up (slot waits are
-            never misjudged as stuck tasks).
+            Slot-first, drain-second: the pump acquires a cross-process slot
+            BEFORE consuming the local queue, so while slots are saturated
+            tasks stay queued (cancellable, never misjudged as running) and
+            local priority order is preserved — the queue head is committed
+            only once a slot is held, so a later high-priority arrival can
+            still overtake. Centralizing acquisition in ONE coroutine
+            (instead of max_size polling workers) divides the cross-process
+            poll/IPC rate by max_size, and a slot is requested only when
+            there is BOTH physically queued work and an idle worker to run
+            it immediately — the worker herd can no longer grab slots it
+            cannot use (which inflated global_in_use and reset this
+            process's waiter seniority on every no-op acquire). Residual
+            churn: queued items may all turn out to be zombies after the
+            slot is acquired (drained bounded, slot returned right away).
             """
             nonlocal live_queued, global_slot_waits
             poll_delay = DEFAULT_GLOBAL_SLOT_POLL_MIN
@@ -1337,6 +1348,20 @@ def priority_limit_async_func_call(
                                     pass
                                 continue
 
+                        # Never hold a slot no local worker could service
+                        # immediately: undelivered dispatches plus running
+                        # executions already saturate max_size.
+                        if dispatch_queue.qsize() + executing >= max_size:
+                            worker_free.clear()
+                            if dispatch_queue.qsize() + executing >= max_size:
+                                try:
+                                    await asyncio.wait_for(
+                                        worker_free.wait(), timeout=1.0
+                                    )
+                                except asyncio.TimeoutError:
+                                    pass
+                                continue
+
                         # Acquire a global slot before touching the queue —
                         # tasks must remain queued (and cancellable) while
                         # all slots are busy. Fail-closed errors land here
@@ -1344,7 +1369,6 @@ def priority_limit_async_func_call(
                         lease_id, is_priority_waiter = await _try_acquire_slot()
                         if lease_id is None:
                             global_slot_waits += 1
-                            _mark_stats_dirty()
                             # Soft FIFO across processes: the longest-waiting
                             # live process keeps the fastest poll rate so it
                             # usually claims the next freed slot; everyone
@@ -1363,6 +1387,7 @@ def priority_limit_async_func_call(
                         poll_delay = DEFAULT_GLOBAL_SLOT_POLL_MIN
 
                         live_task = None
+                        dispatched = False
                         try:
                             # Take the queue head, draining zombies (bounded
                             # by the drain limit so a zombie-heavy process
@@ -1373,8 +1398,9 @@ def priority_limit_async_func_call(
                                 try:
                                     item = queue.get_nowait()
                                 except asyncio.QueueEmpty:
-                                    # Benign race (another worker got it):
-                                    # return the slot immediately.
+                                    # All queued items were zombies (or
+                                    # compaction holds them): return the
+                                    # slot immediately.
                                     break
                                 task_id, args, kwargs = item[2], item[3], item[4]
                                 is_zombie = False
@@ -1414,56 +1440,106 @@ def priority_limit_async_func_call(
                                         >= DEFAULT_GLOBAL_SLOT_DRAIN_LIMIT
                                     ):
                                         break
+                            if live_task is not None:
+                                # No suspension points between claiming the
+                                # live task above and this put_nowait, so a
+                                # claimed task is always dispatched (the
+                                # admission check guaranteed a free worker).
+                                dispatch_queue.put_nowait((lease_id, *live_task))
+                                dispatched = True
                             if notify_needed:
                                 await _notify_admission()
-                            if live_task is None:
-                                continue  # finally returns the slot
-
-                            task_id, task_state, args, kwargs = live_task
-                            await _mark_dirty_and_maybe_publish()
-                            try:
-                                # Same execution / timeout / exception
-                                # semantics as the default worker.
-                                if max_execution_timeout is not None:
-                                    result = await asyncio.wait_for(
-                                        func(*args, **kwargs),
-                                        timeout=max_execution_timeout,
-                                    )
-                                else:
-                                    result = await func(*args, **kwargs)
-
-                                if not task_state.future.done():
-                                    task_state.future.set_result(result)
-
-                            except asyncio.TimeoutError:
-                                logger.warning(
-                                    f"{queue_name}: Worker timeout for task {task_id} after {max_execution_timeout}s"
-                                )
-                                if not task_state.future.done():
-                                    task_state.future.set_exception(
-                                        WorkerTimeoutError(
-                                            max_execution_timeout, "execution"
-                                        )
-                                    )
-                            except asyncio.CancelledError:
-                                if not task_state.future.done():
-                                    task_state.future.cancel()
-                                logger.debug(
-                                    f"{queue_name}: Task {task_id} cancelled during execution"
-                                )
-                            except Exception as e:
-                                logger.error(
-                                    f"{queue_name}: Error in decorated function for task {task_id}: {str(e)}"
-                                )
-                                if not task_state.future.done():
-                                    task_state.future.set_exception(e)
-                            finally:
-                                async with task_states_lock:
-                                    task_states.pop(task_id, None)
-                                queue.task_done()
-                                await _mark_dirty_and_maybe_publish()
+                            await _publish_stats()
                         finally:
+                            if not dispatched:
+                                await _release_lease_safely(lease_id)
+
+                    except Exception as e:
+                        logger.error(
+                            f"{queue_name}: Critical error in slot pump: {str(e)}"
+                        )
+                        await asyncio.sleep(0.1)
+            finally:
+                logger.debug(f"{queue_name}: Slot pump exiting")
+
+        async def limited_worker():
+            """Executor worker for global-limit mode.
+
+            Runs tasks handed over by the slot pump together with their
+            already-held global slot; execution/timeout/exception semantics
+            match the default worker. The lease travels with the task and is
+            always released here (or by the shutdown drain for undelivered
+            dispatch entries).
+            """
+            nonlocal executing
+            try:
+                while not shutdown_event.is_set():
+                    try:
+                        try:
+                            (
+                                lease_id,
+                                task_id,
+                                task_state,
+                                args,
+                                kwargs,
+                            ) = await asyncio.wait_for(
+                                dispatch_queue.get(), timeout=1.0
+                            )
+                        except asyncio.TimeoutError:
+                            continue
+
+                        executing += 1
+                        try:
+                            # Re-check: the task may have been cancelled in
+                            # the (tiny) window between dispatch and pickup.
+                            if (
+                                task_state.cancellation_requested
+                                or task_state.future.cancelled()
+                                or task_state.future.done()
+                            ):
+                                continue  # finally cleans up + returns slot
+
+                            if max_execution_timeout is not None:
+                                result = await asyncio.wait_for(
+                                    func(*args, **kwargs),
+                                    timeout=max_execution_timeout,
+                                )
+                            else:
+                                result = await func(*args, **kwargs)
+
+                            if not task_state.future.done():
+                                task_state.future.set_result(result)
+
+                        except asyncio.TimeoutError:
+                            logger.warning(
+                                f"{queue_name}: Worker timeout for task {task_id} after {max_execution_timeout}s"
+                            )
+                            if not task_state.future.done():
+                                task_state.future.set_exception(
+                                    WorkerTimeoutError(
+                                        max_execution_timeout, "execution"
+                                    )
+                                )
+                        except asyncio.CancelledError:
+                            if not task_state.future.done():
+                                task_state.future.cancel()
+                            logger.debug(
+                                f"{queue_name}: Task {task_id} cancelled during execution"
+                            )
+                        except Exception as e:
+                            logger.error(
+                                f"{queue_name}: Error in decorated function for task {task_id}: {str(e)}"
+                            )
+                            if not task_state.future.done():
+                                task_state.future.set_exception(e)
+                        finally:
+                            executing -= 1
+                            worker_free.set()
+                            async with task_states_lock:
+                                task_states.pop(task_id, None)
+                            queue.task_done()
                             await _release_lease_safely(lease_id)
+                            await _publish_stats()
 
                     except Exception as e:
                         logger.error(
@@ -1480,7 +1556,7 @@ def priority_limit_async_func_call(
 
         async def enhanced_health_check():
             """Enhanced health check with stuck task detection and recovery"""
-            nonlocal initialized
+            nonlocal initialized, pump_task
             try:
                 while not shutdown_event.is_set():
                     await asyncio.sleep(5)  # Check every 5 seconds
@@ -1542,6 +1618,12 @@ def priority_limit_async_func_call(
                             task.add_done_callback(tasks.discard)
                         tasks.update(new_tasks)
 
+                    # Pump recovery: without it no slot is ever acquired and
+                    # the whole limited queue stalls.
+                    if use_global_limit and (pump_task is None or pump_task.done()):
+                        logger.warning(f"{queue_name}: Recreating dead slot pump")
+                        pump_task = asyncio.create_task(slot_pump())
+
                     # Cross-worker upkeep: lease heartbeat / reaping, zombie
                     # compaction, stats flush. Internally best-effort — each
                     # step isolates its own failures so the health check
@@ -1557,7 +1639,7 @@ def priority_limit_async_func_call(
         async def ensure_workers():
             """Ensure worker system is initialized with enhanced error handling"""
             nonlocal initialized, worker_health_check_task, tasks, reinit_count
-            nonlocal queue, use_global_limit
+            nonlocal queue, use_global_limit, dispatch_queue, pump_task
 
             if initialized:
                 return
@@ -1575,6 +1657,7 @@ def priority_limit_async_func_call(
                 if queue is None:
                     if use_global_limit:
                         queue = asyncio.PriorityQueue()
+                        dispatch_queue = asyncio.Queue()
                     else:
                         queue = asyncio.PriorityQueue(maxsize=max_queue_size)
 
@@ -1603,6 +1686,11 @@ def priority_limit_async_func_call(
                     task = _create_worker_task()
                     tasks.add(task)
                     task.add_done_callback(tasks.discard)
+
+                # Start the slot pump (kept out of `tasks` so the worker
+                # recovery count never mistakes it for an executor worker).
+                if use_global_limit and (pump_task is None or pump_task.done()):
+                    pump_task = asyncio.create_task(slot_pump())
 
                 # Start enhanced health check
                 worker_health_check_task = asyncio.create_task(enhanced_health_check())
@@ -1710,6 +1798,7 @@ def priority_limit_async_func_call(
             cancellation so shutdown never blocks indefinitely.
             """
             nonlocal accepting_new_tasks, initialized, worker_health_check_task
+            nonlocal pump_task
             logger.info(f"{queue_name}: Shutting down priority queue workers")
 
             if use_global_limit:
@@ -1761,6 +1850,16 @@ def priority_limit_async_func_call(
 
             shutdown_event.set()
 
+            # Cancel the slot pump first so no new dispatch entries appear
+            # while workers drain below.
+            if pump_task is not None and not pump_task.done():
+                pump_task.cancel()
+                try:
+                    await pump_task
+                except asyncio.CancelledError:
+                    pass
+            pump_task = None
+
             # Cancel worker tasks
             for task in list(tasks):
                 if not task.done():
@@ -1769,6 +1868,26 @@ def priority_limit_async_func_call(
             # Wait for all tasks to complete
             if tasks:
                 await asyncio.gather(*tasks, return_exceptions=True)
+
+            # Drain undelivered dispatch entries: each one was already
+            # popped from the physical queue and carries a held lease.
+            while dispatch_queue is not None:
+                try:
+                    (
+                        lease_id,
+                        task_id,
+                        task_state,
+                        _args,
+                        _kwargs,
+                    ) = dispatch_queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+                if not task_state.future.done():
+                    task_state.future.cancel()
+                async with task_states_lock:
+                    task_states.pop(task_id, None)
+                queue.task_done()
+                await _release_lease_safely(lease_id)
 
             # Cancel health check task
             if worker_health_check_task and not worker_health_check_task.done():
@@ -1835,7 +1954,6 @@ def priority_limit_async_func_call(
             async with admission_cond:
                 if not accepting_new_tasks:
                     rejected_total += 1
-                    _mark_stats_dirty()
                     raise RuntimeError(f"{queue_name}: Queue is shutting down")
                 if max_queue_size > 0 and live_queued >= max_queue_size:
                     try:
@@ -1847,14 +1965,12 @@ def priority_limit_async_func_call(
                         else:
                             await admission_cond.wait_for(_admission_open)
                     except asyncio.TimeoutError:
-                        _mark_stats_dirty()
                         raise QueueFullError(
                             f"{queue_name}: Queue full, timeout after {_queue_timeout} seconds"
                         )
                     if not accepting_new_tasks:
                         # Woken by shutdown's notify_all.
                         rejected_total += 1
-                        _mark_stats_dirty()
                         raise RuntimeError(f"{queue_name}: Queue is shutting down")
                 live_queued += 1
 
@@ -1885,7 +2001,7 @@ def priority_limit_async_func_call(
                 queue.put_nowait((_priority, current_count, task_id, args, kwargs))
                 submitted_total += 1
                 work_available.set()
-                await _mark_dirty_and_maybe_publish()
+                await _publish_stats()
 
                 # Wait for result with the same semantics as the default path
                 try:
@@ -1894,7 +2010,7 @@ def priority_limit_async_func_call(
                     else:
                         result = await future
                     completed_total += 1
-                    await _mark_dirty_and_maybe_publish()
+                    await _publish_stats()
                     return result
                 except asyncio.TimeoutError:
                     # User-level timeout: the task may still be queued (e.g.
@@ -1916,25 +2032,20 @@ def priority_limit_async_func_call(
                         await asyncio.sleep(0.1)
 
                     cancelled_total += 1
-                    _mark_stats_dirty()
                     raise TimeoutError(
                         f"{queue_name}: User timeout after {_timeout} seconds"
                     )
                 except WorkerTimeoutError as e:
                     failed_total += 1
-                    _mark_stats_dirty()
                     raise TimeoutError(f"{queue_name}: {str(e)}")
                 except HealthCheckTimeoutError as e:
                     failed_total += 1
-                    _mark_stats_dirty()
                     raise TimeoutError(f"{queue_name}: {str(e)}")
                 except asyncio.CancelledError:
                     cancelled_total += 1
-                    _mark_stats_dirty()
                     raise
                 except Exception:
                     failed_total += 1
-                    _mark_stats_dirty()
                     raise
 
             finally:
@@ -1950,7 +2061,6 @@ def priority_limit_async_func_call(
                 if notify_needed:
                     async with admission_cond:
                         admission_cond.notify_all()
-                _mark_stats_dirty()
 
         @wraps(func)
         async def wait_func(
@@ -1982,7 +2092,6 @@ def priority_limit_async_func_call(
             nonlocal rejected_total
             if not accepting_new_tasks:
                 rejected_total += 1
-                _mark_stats_dirty()
                 raise RuntimeError(f"{queue_name}: Queue is shutting down")
 
             await ensure_workers()
@@ -2031,7 +2140,7 @@ def priority_limit_async_func_call(
                             (_priority, current_count, task_id, args, kwargs)
                         )
                     submitted_total += 1
-                    await _mark_dirty_and_maybe_publish()
+                    await _publish_stats()
                 except asyncio.TimeoutError:
                     raise QueueFullError(
                         f"{queue_name}: Queue full, timeout after {_queue_timeout} seconds"
@@ -2049,7 +2158,7 @@ def priority_limit_async_func_call(
                     else:
                         result = await future
                     completed_total += 1
-                    await _mark_dirty_and_maybe_publish()
+                    await _publish_stats()
                     return result
                 except asyncio.TimeoutError:
                     # This is user-level timeout (asyncio.wait_for caused)
@@ -2072,27 +2181,22 @@ def priority_limit_async_func_call(
                         await asyncio.sleep(0.1)
 
                     cancelled_total += 1
-                    _mark_stats_dirty()
                     raise TimeoutError(
                         f"{queue_name}: User timeout after {_timeout} seconds"
                     )
                 except WorkerTimeoutError as e:
                     # This is Worker-level timeout, directly propagate exception information
                     failed_total += 1
-                    _mark_stats_dirty()
                     raise TimeoutError(f"{queue_name}: {str(e)}")
                 except HealthCheckTimeoutError as e:
                     # This is Health Check-level timeout, directly propagate exception information
                     failed_total += 1
-                    _mark_stats_dirty()
                     raise TimeoutError(f"{queue_name}: {str(e)}")
                 except asyncio.CancelledError:
                     cancelled_total += 1
-                    _mark_stats_dirty()
                     raise
                 except Exception:
                     failed_total += 1
-                    _mark_stats_dirty()
                     raise
 
             finally:
@@ -3780,8 +3884,7 @@ def repair_vlm_json_escape_damage(text: str, *, context: str = "") -> str:
     if suspect:
         snippet = repaired[max(0, suspect.start() - 30) : suspect.start() + 30]
         logger.warning(
-            "Suspected whitespace-class LaTeX escape damage%s "
-            "(not auto-repaired): %r",
+            "Suspected whitespace-class LaTeX escape damage%s (not auto-repaired): %r",
             f" in {context}" if context else "",
             snippet,
         )

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -907,9 +907,14 @@ def priority_limit_async_func_call(
             cross-worker slot (lease with heartbeat self-healing) before
             executing, capping total in-flight calls across all gunicorn
             workers; the group's queue stats are also published for /health
-            aggregation. When None, or when no global limit is configured,
-            behavior is identical to the original per-process decorator and
-            shared storage is never touched for slot acquisition.
+            aggregation. With no global limit configured for the group
+            (single-process / embedded usage) the slot gate is bypassed —
+            execution behavior matches the original per-process decorator —
+            but queue stats are still published to shared storage so the
+            aggregated /health view works; in single-process mode that is a
+            cheap local-dict write (no IPC, no slot acquisition). Only
+            concurrency_group=None is fully self-contained: shared storage is
+            never touched at all (no slot gate AND no stats publishing).
 
     Returns:
         Decorator function
@@ -979,6 +984,13 @@ def priority_limit_async_func_call(
         # acquires global slots and hands (lease, task) pairs to executor
         # workers through dispatch_queue. executing counts tasks picked up
         # by workers; worker_free wakes the pump when one finishes.
+        # NOTE: dispatch_queue deliberately never gets task_done()/join() —
+        # the join()-based graceful drain tracks the PHYSICAL queue only (a
+        # dispatched item's physical-queue task_done() is deferred to the
+        # worker), and shutdown empties any undelivered dispatch entries with
+        # a get_nowait() loop. So dispatch_queue.unfinished_tasks grows
+        # unbounded by design; it is never read. Don't add a join() here
+        # without also adding matching task_done() calls.
         dispatch_queue: asyncio.Queue | None = None
         pump_task: asyncio.Task | None = None
         executing = 0

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -46,6 +46,12 @@ from lightrag.constants import (
     VALID_SOURCE_IDS_LIMIT_METHODS,
     SOURCE_IDS_LIMIT_METHOD_FIFO,
     PARSED_DIR_NAME,
+    DEFAULT_GLOBAL_SLOT_POLL_MIN,
+    DEFAULT_GLOBAL_SLOT_POLL_MAX,
+    DEFAULT_GLOBAL_SLOT_DRAIN_LIMIT,
+    DEFAULT_ZOMBIE_COMPACT_THRESHOLD,
+    DEFAULT_COMPACT_BATCH_LIMIT,
+    DEFAULT_QUEUE_STATS_MIN_PUBLISH_INTERVAL,
 )
 
 # Precompile regex pattern for JSON sanitization (module-level, compiled once)
@@ -875,6 +881,7 @@ def priority_limit_async_func_call(
     max_queue_size: int = 1000,
     cleanup_timeout: float = 2.0,
     queue_name: str = "limit_async",
+    concurrency_group: str | None = None,
 ):
     """
     Enhanced priority-limited asynchronous function call decorator with robust timeout handling
@@ -884,6 +891,7 @@ def priority_limit_async_func_call(
     - Task state tracking to prevent race conditions
     - Enhanced health check system with stuck task detection
     - Proper resource cleanup and error recovery
+    - Optional cross-process global concurrency gating (gunicorn multi-worker)
 
     Args:
         max_size: Maximum number of concurrent calls
@@ -893,6 +901,15 @@ def priority_limit_async_func_call(
         max_task_duration: Maximum time before health check intervenes (defaults to llm_timeout + 60s)
         cleanup_timeout: Maximum time to wait for cleanup operations (defaults to 2.0s)
         queue_name: Optional queue name for logging identification (defaults to "limit_async")
+        concurrency_group: Optional cross-process concurrency group name (e.g.
+            "llm:extract", "embedding", "rerank"). When shared storage was
+            initialized with a global limit for this group, workers acquire a
+            cross-worker slot (lease with heartbeat self-healing) before
+            executing, capping total in-flight calls across all gunicorn
+            workers; the group's queue stats are also published for /health
+            aggregation. When None, or when no global limit is configured,
+            behavior is identical to the original per-process decorator and
+            shared storage is never touched for slot acquisition.
 
     Returns:
         Decorator function
@@ -915,7 +932,11 @@ def priority_limit_async_func_call(
                     llm_timeout * 2 + 15
                 )  # Reserved timeout buffer for health check phase
 
-        queue = asyncio.PriorityQueue(maxsize=max_queue_size)
+        # The queue is created lazily in ensure_workers(): the default path
+        # keeps the bounded queue, while global-limit mode needs an unbounded
+        # physical queue (admission is enforced logically via live_queued so
+        # cancelled-but-not-yet-drained tuples can never wedge the queue).
+        queue: asyncio.PriorityQueue | None = None
         tasks = set()
         initialization_lock = asyncio.Lock()
         counter = 0
@@ -934,6 +955,256 @@ def priority_limit_async_func_call(
         failed_total = 0
         cancelled_total = 0
         rejected_total = 0
+
+        # --- Cross-worker global concurrency gate state (global-limit mode) ---
+        # Tri-state: None until resolved on first ensure_workers() (which runs
+        # after initialize_share_data() in every supported flow).
+        use_global_limit: bool | None = None
+        publish_stats = False
+        shared = None  # lazily imported lightrag.kg.shared_storage module
+        work_available = asyncio.Event()
+        admission_cond = asyncio.Condition()
+        # Logical queued count: live tasks waiting in the queue (excludes
+        # running tasks and cancelled zombies) — same capacity semantics as
+        # the bounded queue's maxsize in the default path.
+        live_queued = 0
+        held_leases: set[str] = set()
+        pending_release: set[str] = set()
+        global_slot_waits = 0
+        zombie_compact_threshold = max(
+            DEFAULT_ZOMBIE_COMPACT_THRESHOLD,
+            max_queue_size if max_queue_size > 0 else 0,
+        )
+        stats_dirty = False
+        last_publish_time = 0.0
+        last_release_warn_time = 0.0
+        last_renew_warn_time = 0.0
+
+        def _resolve_mode() -> bool:
+            """Resolve global-limit / stats-publishing mode from shared storage.
+
+            Returns True when the resolution is final. Never imports or
+            touches shared storage when concurrency_group is None
+            (standalone decorator usage stays fully self-contained).
+            """
+            nonlocal use_global_limit, publish_stats, shared
+            if use_global_limit is not None:
+                return True
+            if concurrency_group is None:
+                use_global_limit = False
+                publish_stats = False
+                return True
+            if shared is None:
+                from lightrag.kg import shared_storage as shared_module
+
+                shared = shared_module
+            if not shared.is_share_data_initialized():
+                return False  # not final yet — caller decides how to commit
+            use_global_limit = shared.is_global_concurrency_limited(concurrency_group)
+            publish_stats = True
+            return True
+
+        def _snapshot() -> dict:
+            """Synchronous snapshot of local state for cross-worker publishing.
+
+            Reads counters without locks: all mutations happen on the event
+            loop between awaits, so a synchronous read is always consistent.
+            """
+            running = sum(
+                1
+                for task_state in task_states.values()
+                if task_state.worker_started and not task_state.future.done()
+            )
+            physical_queued = queue.qsize() if queue is not None else 0
+            return {
+                "queue_name": queue_name,
+                "max_async": max_size,
+                "max_queue_size": max_queue_size,
+                "queued": live_queued if use_global_limit else physical_queued,
+                "physical_queued": physical_queued,
+                "running": running,
+                "in_flight": len(task_states),
+                "worker_count": len([task for task in tasks if not task.done()]),
+                "initialized": initialized,
+                "submitted_total": submitted_total,
+                "completed_total": completed_total,
+                "failed_total": failed_total,
+                "cancelled_total": cancelled_total,
+                "rejected_total": rejected_total,
+                "global_slot_waits": global_slot_waits,
+                "pid": os.getpid(),
+                "updated_at": time.time(),
+            }
+
+        def _mark_stats_dirty() -> None:
+            nonlocal stats_dirty
+            stats_dirty = True
+
+        async def _publish_stats(force: bool = False) -> None:
+            """Best-effort, debounced publish of the local stats snapshot."""
+            nonlocal stats_dirty, last_publish_time
+            if not publish_stats:
+                return
+            now = time.time()
+            if (
+                not force
+                and now - last_publish_time < DEFAULT_QUEUE_STATS_MIN_PUBLISH_INTERVAL
+            ):
+                return
+            try:
+                await shared.publish_queue_stats(queue_name, _snapshot())
+                stats_dirty = False
+                last_publish_time = now
+            except Exception as e:
+                logger.debug(f"{queue_name}: queue stats publish failed: {e}")
+
+        async def _mark_dirty_and_maybe_publish() -> None:
+            _mark_stats_dirty()
+            await _publish_stats()
+
+        async def _notify_admission() -> None:
+            async with admission_cond:
+                admission_cond.notify_all()
+
+        async def _try_acquire_slot() -> str | None:
+            """Non-blocking global slot acquisition (fail-closed on errors)."""
+            try:
+                lease_id = await shared.try_acquire_global_slot(concurrency_group)
+            except Exception as e:
+                # try_acquire_global_slot is fail-closed internally; this
+                # guard keeps the worker alive even if it ever raises.
+                logger.debug(f"{queue_name}: global slot acquisition error: {e}")
+                return None
+            if lease_id is not None:
+                held_leases.add(lease_id)
+            return lease_id
+
+        async def _release_lease_safely(lease_id: str) -> None:
+            """Release a global slot without raising (safe in finally blocks).
+
+            A failed release is parked in pending_release: it is no longer
+            renewed, the health check retries it, and even if every retry
+            fails the heartbeat TTL guarantees any process eventually
+            reclaims the slot — capacity never leaks permanently.
+            """
+            nonlocal last_release_warn_time
+            held_leases.discard(lease_id)
+            try:
+                await shared.release_global_slot(concurrency_group, lease_id)
+                pending_release.discard(lease_id)
+            except asyncio.CancelledError:
+                pending_release.add(lease_id)
+                raise
+            except Exception as e:
+                pending_release.add(lease_id)
+                now = time.time()
+                if now - last_release_warn_time >= 30.0:
+                    last_release_warn_time = now
+                    logger.warning(
+                        f"{queue_name}: failed to release global slot lease "
+                        f"(queued for retry; heartbeat expiry guarantees "
+                        f"reclamation): {e}"
+                    )
+
+        async def _compact_physical_queue() -> None:
+            """Drain zombie tuples that accumulate while no slot is available.
+
+            Without this, a long fail-closed period (shared storage errors)
+            or externally saturated slots would let cancelled tasks pile up
+            in the unbounded physical queue with no consumer. Bounded batches
+            keep the event loop responsive; every popped tuple gets exactly
+            one task_done() (live tuples are re-queued first, adding a fresh
+            unfinished count) so queue.join() in shutdown never wedges.
+            """
+            nonlocal live_queued
+            if queue is None or not use_global_limit:
+                return
+            if queue.qsize() - live_queued <= zombie_compact_threshold:
+                return
+            survivors = []
+            scanned = 0
+            notify_needed = False
+            while scanned < DEFAULT_COMPACT_BATCH_LIMIT:
+                try:
+                    item = queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+                scanned += 1
+                task_id = item[2]
+                is_zombie = False
+                # Classify under task_states_lock so we serialize with the
+                # wait_func timeout cleanup path (never judge by a stale
+                # snapshot taken outside the lock).
+                async with task_states_lock:
+                    task_state = task_states.get(task_id)
+                    if (
+                        task_state is None
+                        or task_state.cancellation_requested
+                        or task_state.future.cancelled()
+                        or task_state.future.done()
+                    ):
+                        is_zombie = True
+                        if task_state is not None:
+                            task_states.pop(task_id, None)
+                            if not task_state.worker_started:
+                                live_queued -= 1
+                                notify_needed = True
+                if is_zombie:
+                    queue.task_done()
+                else:
+                    survivors.append(item)
+            for item in survivors:
+                queue.put_nowait(item)
+                queue.task_done()
+            if survivors:
+                work_available.set()
+            if notify_needed:
+                await _notify_admission()
+            _mark_stats_dirty()
+
+        async def _run_maintenance() -> None:
+            """One heartbeat pass of cross-worker upkeep (never raises).
+
+            Runs every health-check tick: lease renewal (correctness path —
+            failures get a rate-limited WARNING, the suspect grace absorbs
+            short outages), pending-release retries, lease reaping, zombie
+            compaction, and a forced stats flush (which also keeps this
+            worker's snapshot from going stale in the aggregation view).
+            """
+            nonlocal last_renew_warn_time
+            if use_global_limit:
+                try:
+                    await shared.renew_global_slots(
+                        concurrency_group, tuple(held_leases)
+                    )
+                except Exception as e:
+                    now = time.time()
+                    if now - last_renew_warn_time >= 30.0:
+                        last_renew_warn_time = now
+                        logger.warning(
+                            f"{queue_name}: global slot lease renewal failed "
+                            f"(leases may be reclaimed after the suspect "
+                            f"grace if this persists): {e}"
+                        )
+                for lease_id in tuple(pending_release):
+                    try:
+                        await shared.release_global_slot(concurrency_group, lease_id)
+                        pending_release.discard(lease_id)
+                    except Exception as e:
+                        logger.debug(
+                            f"{queue_name}: pending lease release retry failed: {e}"
+                        )
+                        break  # shared area still unhealthy; retry next pass
+                try:
+                    await shared.reconcile_global_slots(concurrency_group)
+                except Exception as e:
+                    logger.debug(f"{queue_name}: global slot reconcile failed: {e}")
+                try:
+                    await _compact_physical_queue()
+                except Exception as e:
+                    logger.warning(f"{queue_name}: queue compaction failed: {e}")
+            if publish_stats:
+                await _publish_stats(force=True)
 
         async def worker():
             """Enhanced worker that processes tasks with proper timeout and state management"""
@@ -1027,6 +1298,168 @@ def priority_limit_async_func_call(
             finally:
                 logger.debug(f"{queue_name}: Worker exiting")
 
+        async def limited_worker():
+            """Worker for global-limit mode: slot-first, drain-second.
+
+            The worker acquires a cross-process slot BEFORE consuming the
+            local queue, so while slots are saturated tasks stay queued:
+            user-level timeouts/cancellations during the wait never reach
+            the provider, local priority order is preserved (the queue head
+            is taken only once a slot is held), and execution timing starts
+            only when a live task is actually picked up (slot waits are
+            never misjudged as stuck tasks).
+            """
+            nonlocal live_queued, global_slot_waits
+            poll_delay = DEFAULT_GLOBAL_SLOT_POLL_MIN
+            try:
+                while not shutdown_event.is_set():
+                    try:
+                        # Idle wait on an event instead of qsize polling. The
+                        # clear-then-recheck ordering has no await in between,
+                        # so a concurrent put+set can never be lost; the 1.0s
+                        # timeout only preserves the shutdown check.
+                        if queue.qsize() == 0:
+                            work_available.clear()
+                            if queue.qsize() == 0:
+                                try:
+                                    await asyncio.wait_for(
+                                        work_available.wait(), timeout=1.0
+                                    )
+                                except asyncio.TimeoutError:
+                                    pass
+                                continue
+
+                        # Acquire a global slot before touching the queue —
+                        # tasks must remain queued (and cancellable) while
+                        # all slots are busy. Fail-closed errors land here
+                        # too, as a None lease.
+                        lease_id = await _try_acquire_slot()
+                        if lease_id is None:
+                            global_slot_waits += 1
+                            _mark_stats_dirty()
+                            await asyncio.sleep(poll_delay)
+                            poll_delay = min(
+                                poll_delay * 2, DEFAULT_GLOBAL_SLOT_POLL_MAX
+                            )
+                            continue
+                        poll_delay = DEFAULT_GLOBAL_SLOT_POLL_MIN
+
+                        live_task = None
+                        try:
+                            # Take the queue head, draining zombies (bounded
+                            # by the drain limit so a zombie-heavy process
+                            # doesn't hog a scarce slot for local cleanup).
+                            zombies_drained = 0
+                            notify_needed = False
+                            while live_task is None:
+                                try:
+                                    item = queue.get_nowait()
+                                except asyncio.QueueEmpty:
+                                    # Benign race (another worker got it):
+                                    # return the slot immediately.
+                                    break
+                                task_id, args, kwargs = item[2], item[3], item[4]
+                                is_zombie = False
+                                async with task_states_lock:
+                                    task_state = task_states.get(task_id)
+                                    if (
+                                        task_state is None
+                                        or task_state.cancellation_requested
+                                        or task_state.future.cancelled()
+                                        or task_state.future.done()
+                                    ):
+                                        is_zombie = True
+                                        if task_state is not None:
+                                            task_states.pop(task_id, None)
+                                            if not task_state.worker_started:
+                                                live_queued -= 1
+                                                notify_needed = True
+                                    else:
+                                        task_state.worker_started = True
+                                        task_state.execution_start_time = (
+                                            asyncio.get_event_loop().time()
+                                        )
+                                        live_queued -= 1
+                                        notify_needed = True
+                                        live_task = (
+                                            task_id,
+                                            task_state,
+                                            args,
+                                            kwargs,
+                                        )
+                                if is_zombie:
+                                    # Never call the provider for a zombie.
+                                    queue.task_done()
+                                    zombies_drained += 1
+                                    if (
+                                        zombies_drained
+                                        >= DEFAULT_GLOBAL_SLOT_DRAIN_LIMIT
+                                    ):
+                                        break
+                            if notify_needed:
+                                await _notify_admission()
+                            if live_task is None:
+                                continue  # finally returns the slot
+
+                            task_id, task_state, args, kwargs = live_task
+                            await _mark_dirty_and_maybe_publish()
+                            try:
+                                # Same execution / timeout / exception
+                                # semantics as the default worker.
+                                if max_execution_timeout is not None:
+                                    result = await asyncio.wait_for(
+                                        func(*args, **kwargs),
+                                        timeout=max_execution_timeout,
+                                    )
+                                else:
+                                    result = await func(*args, **kwargs)
+
+                                if not task_state.future.done():
+                                    task_state.future.set_result(result)
+
+                            except asyncio.TimeoutError:
+                                logger.warning(
+                                    f"{queue_name}: Worker timeout for task {task_id} after {max_execution_timeout}s"
+                                )
+                                if not task_state.future.done():
+                                    task_state.future.set_exception(
+                                        WorkerTimeoutError(
+                                            max_execution_timeout, "execution"
+                                        )
+                                    )
+                            except asyncio.CancelledError:
+                                if not task_state.future.done():
+                                    task_state.future.cancel()
+                                logger.debug(
+                                    f"{queue_name}: Task {task_id} cancelled during execution"
+                                )
+                            except Exception as e:
+                                logger.error(
+                                    f"{queue_name}: Error in decorated function for task {task_id}: {str(e)}"
+                                )
+                                if not task_state.future.done():
+                                    task_state.future.set_exception(e)
+                            finally:
+                                async with task_states_lock:
+                                    task_states.pop(task_id, None)
+                                queue.task_done()
+                                await _mark_dirty_and_maybe_publish()
+                        finally:
+                            await _release_lease_safely(lease_id)
+
+                    except Exception as e:
+                        logger.error(
+                            f"{queue_name}: Critical error in worker: {str(e)}"
+                        )
+                        await asyncio.sleep(0.1)
+            finally:
+                logger.debug(f"{queue_name}: Worker exiting")
+
+        def _create_worker_task() -> asyncio.Task:
+            return asyncio.create_task(
+                limited_worker() if use_global_limit else worker()
+            )
+
         async def enhanced_health_check():
             """Enhanced health check with stuck task detection and recovery"""
             nonlocal initialized
@@ -1086,10 +1519,16 @@ def priority_limit_async_func_call(
                         )
                         new_tasks = set()
                         for _ in range(workers_needed):
-                            task = asyncio.create_task(worker())
+                            task = _create_worker_task()
                             new_tasks.add(task)
                             task.add_done_callback(tasks.discard)
                         tasks.update(new_tasks)
+
+                    # Cross-worker upkeep: lease heartbeat / reaping, zombie
+                    # compaction, stats flush. Internally best-effort — each
+                    # step isolates its own failures so the health check
+                    # loop never exits because of shared-storage errors.
+                    await _run_maintenance()
 
             except Exception as e:
                 logger.error(f"{queue_name}: Error in enhanced health check: {str(e)}")
@@ -1100,6 +1539,7 @@ def priority_limit_async_func_call(
         async def ensure_workers():
             """Ensure worker system is initialized with enhanced error handling"""
             nonlocal initialized, worker_health_check_task, tasks, reinit_count
+            nonlocal queue, use_global_limit
 
             if initialized:
                 return
@@ -1107,6 +1547,18 @@ def priority_limit_async_func_call(
             async with initialization_lock:
                 if initialized:
                     return
+
+                # Resolve the concurrency mode once (cached for the lifetime
+                # of the wrapper) and lazily create the matching queue. When
+                # shared storage is not initialized at this point (standalone
+                # usage), commit to the default unlimited path.
+                if use_global_limit is None and not _resolve_mode():
+                    use_global_limit = False
+                if queue is None:
+                    if use_global_limit:
+                        queue = asyncio.PriorityQueue()
+                    else:
+                        queue = asyncio.PriorityQueue(maxsize=max_queue_size)
 
                 if reinit_count > 0:
                     reinit_count += 1
@@ -1130,7 +1582,7 @@ def priority_limit_async_func_call(
                 # Create worker tasks
                 workers_needed = max_size - active_tasks_count
                 for _ in range(workers_needed):
-                    task = asyncio.create_task(worker())
+                    task = _create_worker_task()
                     tasks.add(task)
                     task.add_done_callback(tasks.discard)
 
@@ -1165,11 +1617,15 @@ def priority_limit_async_func_call(
                 in_flight = len(task_states)
 
             active_workers = len([task for task in tasks if not task.done()])
-            return {
+            physical_queued = queue.qsize() if queue is not None else 0
+            stats = {
                 "queue_name": queue_name,
                 "max_async": max_size,
                 "max_queue_size": max_queue_size,
-                "queued": queue.qsize(),
+                # Global-limit mode reports the logical queued count (live
+                # tasks only — cancelled zombies still physically present in
+                # the unbounded queue are excluded).
+                "queued": live_queued if use_global_limit else physical_queued,
                 "running": running,
                 "in_flight": in_flight,
                 "worker_count": active_workers,
@@ -1180,6 +1636,47 @@ def priority_limit_async_func_call(
                 "cancelled_total": cancelled_total,
                 "rejected_total": rejected_total,
             }
+            if use_global_limit:
+                stats["physical_queued"] = physical_queued
+                stats["global_slot_waits"] = global_slot_waits
+            return stats
+
+        async def get_aggregated_queue_stats():
+            """Local stats merged with every worker process's published snapshot.
+
+            Publishes this process's fresh snapshot first, then sums the flat
+            counter fields across all live snapshots (schema-compatible with
+            get_queue_stats so /health consumers and the webui need no
+            changes), adding ``reporting_workers`` / ``per_worker`` and — in
+            global-limit mode — ``global_limit`` / ``global_in_use``. Any
+            shared-storage failure falls back to the local snapshot.
+            """
+            local = await get_queue_stats()
+            if not _resolve_mode() or not publish_stats:
+                return local
+            try:
+                await shared.publish_queue_stats(queue_name, _snapshot())
+                aggregated = await shared.aggregate_queue_stats(queue_name)
+                result = dict(local)
+                for field_name in shared.QUEUE_STATS_SUM_FIELDS:
+                    if field_name in aggregated:
+                        result[field_name] = aggregated[field_name]
+                result["reporting_workers"] = aggregated["reporting_workers"]
+                result["per_worker"] = aggregated["per_worker"]
+                if use_global_limit:
+                    result["global_limit"] = shared.get_global_concurrency_limit(
+                        concurrency_group
+                    )
+                    result["global_in_use"] = await shared.global_concurrency_in_use(
+                        concurrency_group
+                    )
+                return result
+            except Exception as e:
+                logger.debug(
+                    f"{queue_name}: queue stats aggregation failed, "
+                    f"falling back to local snapshot: {e}"
+                )
+                return local
 
         async def shutdown(graceful: bool = True, timeout: float | None = None):
             """Shut down workers and cleanup resources.
@@ -1192,10 +1689,19 @@ def priority_limit_async_func_call(
             nonlocal accepting_new_tasks, initialized, worker_health_check_task
             logger.info(f"{queue_name}: Shutting down priority queue workers")
 
-            accepting_new_tasks = False
+            if use_global_limit:
+                # Stop accepting and wake admission waiters inside the same
+                # Condition critical section: a request sleeping on admission
+                # (no _queue_timeout) must observe the flag flip and raise
+                # the shutdown rejection instead of sleeping forever.
+                async with admission_cond:
+                    accepting_new_tasks = False
+                    admission_cond.notify_all()
+            else:
+                accepting_new_tasks = False
 
             drain_timed_out = False
-            if graceful:
+            if graceful and queue is not None:
                 effective_timeout = timeout
                 if effective_timeout is None:
                     effective_timeout = (
@@ -1223,7 +1729,7 @@ def priority_limit_async_func_call(
                             task_state.future.cancel()
                     task_states.clear()
 
-                while True:
+                while queue is not None:
                     try:
                         queue.get_nowait()
                         queue.task_done()
@@ -1251,7 +1757,170 @@ def priority_limit_async_func_call(
             worker_health_check_task = None
             initialized = False
 
+            # Return any global slots still held (worker cancellation may
+            # have interrupted a release) and retract our published stats.
+            # Best-effort: heartbeat expiry reclaims anything left behind.
+            if use_global_limit:
+                for lease_id in list(held_leases | pending_release):
+                    held_leases.discard(lease_id)
+                    pending_release.discard(lease_id)
+                    try:
+                        await shared.release_global_slot(concurrency_group, lease_id)
+                    except Exception:
+                        pass
+            if publish_stats:
+                try:
+                    await shared.unpublish_queue_stats(queue_name)
+                except Exception:
+                    pass
+
             logger.info(f"{queue_name}: Priority queue workers shutdown complete")
+
+        async def _limited_wait(args, kwargs, _priority, _timeout, _queue_timeout):
+            """wait_func body for global-limit mode (logical admission).
+
+            Admission reserves logical capacity (live_queued) BEFORE the
+            task state is registered, with the same semantics as the bounded
+            queue in the default path: only live queued tasks count toward
+            max_queue_size (running tasks and cancelled zombies do not),
+            _queue_timeout bounds the wait with QueueFullError, and
+            max_queue_size <= 0 means unlimited admission. The reservation
+            is released exactly once — by the worker when the task turns
+            running (worker_started flip), or by the cleanup below when the
+            task dies while still queued.
+            """
+            nonlocal counter, submitted_total, completed_total, cancelled_total
+            nonlocal failed_total, rejected_total, live_queued
+
+            task_id = f"{id(asyncio.current_task())}_{asyncio.get_event_loop().time()}"
+            future = asyncio.Future()
+            task_state = TaskState(
+                future=future, start_time=asyncio.get_event_loop().time()
+            )
+
+            def _admission_open() -> bool:
+                return live_queued < max_queue_size or not accepting_new_tasks
+
+            # --- Admission: reserve capacity before registering ---
+            async with admission_cond:
+                if not accepting_new_tasks:
+                    rejected_total += 1
+                    _mark_stats_dirty()
+                    raise RuntimeError(f"{queue_name}: Queue is shutting down")
+                if max_queue_size > 0 and live_queued >= max_queue_size:
+                    try:
+                        if _queue_timeout is not None:
+                            await asyncio.wait_for(
+                                admission_cond.wait_for(_admission_open),
+                                timeout=_queue_timeout,
+                            )
+                        else:
+                            await admission_cond.wait_for(_admission_open)
+                    except asyncio.TimeoutError:
+                        _mark_stats_dirty()
+                        raise QueueFullError(
+                            f"{queue_name}: Queue full, timeout after {_queue_timeout} seconds"
+                        )
+                    if not accepting_new_tasks:
+                        # Woken by shutdown's notify_all.
+                        rejected_total += 1
+                        _mark_stats_dirty()
+                        raise RuntimeError(f"{queue_name}: Queue is shutting down")
+                live_queued += 1
+
+            # Reservation window: until the task state is registered, any
+            # exception/cancellation must hand the reservation back or this
+            # slot of logical capacity would be occupied forever.
+            try:
+                async with task_states_lock:
+                    task_states[task_id] = task_state
+            except BaseException:
+                async with admission_cond:
+                    live_queued -= 1
+                    admission_cond.notify_all()
+                raise
+            # From here the reservation belongs to the exactly-once rule
+            # (worker_started transfer, or the finally cleanup below).
+
+            try:
+                active_futures.add(future)
+
+                # Get counter for FIFO ordering
+                async with initialization_lock:
+                    current_count = counter
+                    counter += 1
+
+                # Unbounded physical queue: put_nowait never blocks, and the
+                # (priority, count, ...) tuple keeps heap ordering intact.
+                queue.put_nowait((_priority, current_count, task_id, args, kwargs))
+                submitted_total += 1
+                work_available.set()
+                await _mark_dirty_and_maybe_publish()
+
+                # Wait for result with the same semantics as the default path
+                try:
+                    if _timeout is not None:
+                        result = await asyncio.wait_for(future, _timeout)
+                    else:
+                        result = await future
+                    completed_total += 1
+                    await _mark_dirty_and_maybe_publish()
+                    return result
+                except asyncio.TimeoutError:
+                    # User-level timeout: the task may still be queued (e.g.
+                    # waiting for a global slot) — mark it cancelled so no
+                    # worker ever calls the provider for it.
+                    async with task_states_lock:
+                        if task_id in task_states:
+                            task_states[task_id].cancellation_requested = True
+
+                    if not future.done():
+                        future.cancel()
+
+                    cleanup_start = asyncio.get_event_loop().time()
+                    while (
+                        task_id in task_states
+                        and asyncio.get_event_loop().time() - cleanup_start
+                        < cleanup_timeout
+                    ):
+                        await asyncio.sleep(0.1)
+
+                    cancelled_total += 1
+                    _mark_stats_dirty()
+                    raise TimeoutError(
+                        f"{queue_name}: User timeout after {_timeout} seconds"
+                    )
+                except WorkerTimeoutError as e:
+                    failed_total += 1
+                    _mark_stats_dirty()
+                    raise TimeoutError(f"{queue_name}: {str(e)}")
+                except HealthCheckTimeoutError as e:
+                    failed_total += 1
+                    _mark_stats_dirty()
+                    raise TimeoutError(f"{queue_name}: {str(e)}")
+                except asyncio.CancelledError:
+                    cancelled_total += 1
+                    _mark_stats_dirty()
+                    raise
+                except Exception:
+                    failed_total += 1
+                    _mark_stats_dirty()
+                    raise
+
+            finally:
+                active_futures.discard(future)
+                notify_needed = False
+                async with task_states_lock:
+                    popped = task_states.pop(task_id, None)
+                    if popped is not None and not popped.worker_started:
+                        # Died while still queued: release the reservation
+                        # here — the worker never will (exactly-once).
+                        live_queued -= 1
+                        notify_needed = True
+                if notify_needed:
+                    async with admission_cond:
+                        admission_cond.notify_all()
+                _mark_stats_dirty()
 
         @wraps(func)
         async def wait_func(
@@ -1283,9 +1952,15 @@ def priority_limit_async_func_call(
             nonlocal rejected_total
             if not accepting_new_tasks:
                 rejected_total += 1
+                _mark_stats_dirty()
                 raise RuntimeError(f"{queue_name}: Queue is shutting down")
 
             await ensure_workers()
+
+            if use_global_limit:
+                return await _limited_wait(
+                    args, kwargs, _priority, _timeout, _queue_timeout
+                )
 
             # Generate unique task ID
             task_id = f"{id(asyncio.current_task())}_{asyncio.get_event_loop().time()}"
@@ -1326,6 +2001,7 @@ def priority_limit_async_func_call(
                             (_priority, current_count, task_id, args, kwargs)
                         )
                     submitted_total += 1
+                    await _mark_dirty_and_maybe_publish()
                 except asyncio.TimeoutError:
                     raise QueueFullError(
                         f"{queue_name}: Queue full, timeout after {_queue_timeout} seconds"
@@ -1343,6 +2019,7 @@ def priority_limit_async_func_call(
                     else:
                         result = await future
                     completed_total += 1
+                    await _mark_dirty_and_maybe_publish()
                     return result
                 except asyncio.TimeoutError:
                     # This is user-level timeout (asyncio.wait_for caused)
@@ -1365,22 +2042,27 @@ def priority_limit_async_func_call(
                         await asyncio.sleep(0.1)
 
                     cancelled_total += 1
+                    _mark_stats_dirty()
                     raise TimeoutError(
                         f"{queue_name}: User timeout after {_timeout} seconds"
                     )
                 except WorkerTimeoutError as e:
                     # This is Worker-level timeout, directly propagate exception information
                     failed_total += 1
+                    _mark_stats_dirty()
                     raise TimeoutError(f"{queue_name}: {str(e)}")
                 except HealthCheckTimeoutError as e:
                     # This is Health Check-level timeout, directly propagate exception information
                     failed_total += 1
+                    _mark_stats_dirty()
                     raise TimeoutError(f"{queue_name}: {str(e)}")
                 except asyncio.CancelledError:
                     cancelled_total += 1
+                    _mark_stats_dirty()
                     raise
                 except Exception:
                     failed_total += 1
+                    _mark_stats_dirty()
                     raise
 
             finally:
@@ -1392,6 +2074,11 @@ def priority_limit_async_func_call(
         # Add shutdown method to decorated function
         wait_func.shutdown = shutdown
         wait_func.get_queue_stats = get_queue_stats
+        wait_func.get_aggregated_queue_stats = get_aggregated_queue_stats
+        # One upkeep pass (lease renewal / pending releases / reaping /
+        # compaction / stats flush). The health check runs it every 5s;
+        # exposed for tests and operational tooling.
+        wait_func.run_maintenance = _run_maintenance
 
         return wait_func
 

--- a/tests/kg/test_global_concurrency_slots.py
+++ b/tests/kg/test_global_concurrency_slots.py
@@ -1,0 +1,284 @@
+"""Offline tests for the cross-worker global concurrency gate and queue
+stats aggregation primitives in lightrag.kg.shared_storage.
+
+All tests run in single-process mode (workers=1): the lease namespace and
+keyed locks degrade to in-process primitives, exercising the same code paths
+used under gunicorn multi-worker mode.
+"""
+
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+from lightrag.kg import shared_storage as ss
+
+pytestmark = pytest.mark.offline
+
+
+GROUP = "llm:test"
+
+
+@pytest.fixture(autouse=True)
+def clean_shared_storage():
+    """Each test starts from a non-initialized shared storage."""
+    ss.finalize_share_data()
+    yield
+    ss.finalize_share_data()
+
+
+def _init(limits=None):
+    ss.initialize_share_data(1, global_concurrency_limits=limits)
+
+
+def _dead_pid() -> int:
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait()
+    return proc.pid
+
+
+async def _lease_ns():
+    return await ss._get_lease_namespace()
+
+
+# ---------------------------------------------------------------------------
+# Configuration semantics
+# ---------------------------------------------------------------------------
+
+
+def test_limits_unset_means_not_limited():
+    _init()
+    assert ss.is_global_concurrency_limited(GROUP) is False
+    assert ss.get_global_concurrency_limit(GROUP) is None
+    assert ss.is_global_concurrency_limited(None) is False
+
+
+def test_limits_not_limited_before_initialization():
+    assert ss.is_share_data_initialized() is False
+    assert ss.is_global_concurrency_limited(GROUP) is False
+
+
+def test_first_init_sets_limits_and_later_calls_do_not_overwrite():
+    _init({GROUP: 3})
+    assert ss.is_global_concurrency_limited(GROUP) is True
+    assert ss.get_global_concurrency_limit(GROUP) == 3
+
+    # Subsequent no-arg call (e.g. LightRAG.__post_init__) hits the
+    # already-initialized guard and must not clear the configuration.
+    ss.initialize_share_data()
+    assert ss.is_global_concurrency_limited(GROUP) is True
+    assert ss.get_global_concurrency_limit(GROUP) == 3
+
+
+def test_finalize_resets_limits():
+    _init({GROUP: 3})
+    ss.finalize_share_data()
+    assert ss.is_global_concurrency_limited(GROUP) is False
+
+
+def test_non_positive_limits_are_ignored():
+    _init({GROUP: 0, "other": -1})
+    assert ss.is_global_concurrency_limited(GROUP) is False
+    assert ss.is_global_concurrency_limited("other") is False
+
+
+# ---------------------------------------------------------------------------
+# Slot acquisition / release
+# ---------------------------------------------------------------------------
+
+
+async def test_acquire_up_to_limit_then_release():
+    _init({GROUP: 2})
+
+    lease1 = await ss.try_acquire_global_slot(GROUP)
+    lease2 = await ss.try_acquire_global_slot(GROUP)
+    assert lease1 is not None and lease2 is not None
+    assert lease1 != lease2
+    assert await ss.global_concurrency_in_use(GROUP) == 2
+
+    # Capacity exhausted
+    assert await ss.try_acquire_global_slot(GROUP) is None
+
+    await ss.release_global_slot(GROUP, lease1)
+    assert await ss.global_concurrency_in_use(GROUP) == 1
+    lease3 = await ss.try_acquire_global_slot(GROUP)
+    assert lease3 is not None
+
+    # Idempotent release
+    await ss.release_global_slot(GROUP, lease1)
+    await ss.release_global_slot(GROUP, lease2)
+    await ss.release_global_slot(GROUP, lease3)
+    assert await ss.global_concurrency_in_use(GROUP) == 0
+
+
+async def test_acquire_for_unlimited_group_returns_none():
+    _init({GROUP: 1})
+    assert await ss.try_acquire_global_slot("unconfigured") is None
+
+
+async def test_groups_are_independent():
+    _init({GROUP: 1, "embedding": 1})
+    lease = await ss.try_acquire_global_slot(GROUP)
+    assert lease is not None
+    assert await ss.try_acquire_global_slot(GROUP) is None
+    other = await ss.try_acquire_global_slot("embedding")
+    assert other is not None
+
+
+# ---------------------------------------------------------------------------
+# Self-healing: dead PID, heartbeat expiry, suspect grace
+# ---------------------------------------------------------------------------
+
+
+async def test_dead_pid_lease_reclaimed_immediately():
+    _init({GROUP: 1})
+    ns = await _lease_ns()
+    ns[f"{GROUP}{ss.KEY_SEP}deadbeef"] = {"pid": _dead_pid(), "updated_at": time.time()}
+
+    # The dead owner's slot is reclaimed during acquire — capacity is free.
+    lease = await ss.try_acquire_global_slot(GROUP)
+    assert lease is not None
+    assert f"{GROUP}{ss.KEY_SEP}deadbeef" not in list(ns.keys())
+
+
+async def test_expired_lease_with_live_pid_gets_suspect_grace(monkeypatch):
+    monkeypatch.setattr(ss, "_heartbeat_ttl", 1.0)
+    monkeypatch.setattr(ss, "_suspect_grace", 1.0)
+    _init({GROUP: 1})
+    ns = await _lease_ns()
+    key = f"{GROUP}{ss.KEY_SEP}stalled"
+    # Live PID (our own) with an expired heartbeat.
+    ns[key] = {"pid": os.getpid(), "updated_at": time.time() - 5.0}
+
+    # First pass: marked suspect, still counts toward capacity.
+    assert await ss.reconcile_global_slots(GROUP) == 1
+    assert "suspect_since" in dict(ns[key])
+    assert await ss.try_acquire_global_slot(GROUP) is None
+
+    # Within the grace: still not reclaimed.
+    assert await ss.reconcile_global_slots(GROUP) == 1
+
+    # After the grace elapses without a renewal: reclaimed.
+    lease = dict(ns[key])
+    lease["suspect_since"] = time.time() - 2.0
+    ns[key] = lease
+    assert await ss.reconcile_global_slots(GROUP) == 0
+    assert await ss.try_acquire_global_slot(GROUP) is not None
+
+
+async def test_renewal_clears_suspect_and_protects_long_tasks(monkeypatch):
+    monkeypatch.setattr(ss, "_heartbeat_ttl", 1.0)
+    monkeypatch.setattr(ss, "_suspect_grace", 1.0)
+    _init({GROUP: 1})
+    lease = await ss.try_acquire_global_slot(GROUP)
+    ns = await _lease_ns()
+    key = f"{GROUP}{ss.KEY_SEP}{lease}"
+
+    # Simulate a momentary renewal outage: heartbeat expires, suspect set.
+    stale = dict(ns[key])
+    stale["updated_at"] = time.time() - 5.0
+    ns[key] = stale
+    await ss.reconcile_global_slots(GROUP)
+    assert "suspect_since" in dict(ns[key])
+
+    # Owner recovers and renews: suspect cleared, lease survives — a legal
+    # long-running task is never reclaimed while renewals continue.
+    await ss.renew_global_slots(GROUP, [lease])
+    refreshed = dict(ns[key])
+    assert "suspect_since" not in refreshed
+    assert time.time() - refreshed["updated_at"] < 1.0
+    assert await ss.reconcile_global_slots(GROUP) == 1
+
+
+async def test_renew_does_not_resurrect_reclaimed_lease():
+    _init({GROUP: 1})
+    lease = await ss.try_acquire_global_slot(GROUP)
+    await ss.release_global_slot(GROUP, lease)
+    await ss.renew_global_slots(GROUP, [lease])
+    assert await ss.global_concurrency_in_use(GROUP) == 0
+
+
+async def test_acquire_fail_closed_on_shared_error(monkeypatch):
+    _init({GROUP: 2})
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("manager down")
+
+    monkeypatch.setattr(ss, "get_storage_keyed_lock", boom)
+    assert await ss.try_acquire_global_slot(GROUP) is None
+
+
+# ---------------------------------------------------------------------------
+# Queue stats publish / aggregate
+# ---------------------------------------------------------------------------
+
+
+def _snapshot(pid: int, *, queued=1, running=2, completed_total=3, updated_at=None):
+    return {
+        "queue_name": "agg test",
+        "max_async": 4,
+        "pid": pid,
+        "updated_at": updated_at if updated_at is not None else time.time(),
+        "queued": queued,
+        "running": running,
+        "in_flight": queued + running,
+        "worker_count": 4,
+        "submitted_total": 10,
+        "completed_total": completed_total,
+        "failed_total": 1,
+        "cancelled_total": 1,
+        "rejected_total": 0,
+        "global_slot_waits": 5,
+        "physical_queued": queued,
+    }
+
+
+async def test_aggregate_sums_flat_fields_across_workers():
+    _init()
+    ns = await ss._get_queue_stats_namespace()
+    await ss.publish_queue_stats("agg test", _snapshot(os.getpid()))
+    # PID 1 (init) exists and os.kill(1, 0) raises PermissionError — treated
+    # as alive, standing in for a second worker process.
+    ns[f"agg test{ss.KEY_SEP}1"] = _snapshot(1, queued=2, running=1, completed_total=7)
+
+    agg = await ss.aggregate_queue_stats("agg test")
+    assert agg["reporting_workers"] == 2
+    assert agg["queued"] == 3
+    assert agg["running"] == 3
+    assert agg["completed_total"] == 10
+    assert agg["global_slot_waits"] == 10
+    assert set(agg["per_worker"]) == {str(os.getpid()), "1"}
+    # Schema: every flat counter field is present.
+    for field in ss.QUEUE_STATS_SUM_FIELDS:
+        assert field in agg
+
+
+async def test_aggregate_reaps_dead_pid_and_stale_entries():
+    _init()
+    ns = await ss._get_queue_stats_namespace()
+    await ss.publish_queue_stats("agg test", _snapshot(os.getpid()))
+    ns[f"agg test{ss.KEY_SEP}99999999"] = _snapshot(_dead_pid())
+    ns[f"agg test{ss.KEY_SEP}1"] = _snapshot(
+        1, updated_at=time.time() - ss._queue_stats_stale_ttl - 5
+    )
+
+    agg = await ss.aggregate_queue_stats("agg test")
+    assert agg["reporting_workers"] == 1
+    assert f"agg test{ss.KEY_SEP}99999999" not in list(ns.keys())
+    assert f"agg test{ss.KEY_SEP}1" not in list(ns.keys())
+
+
+async def test_unpublish_removes_own_entry():
+    _init()
+    await ss.publish_queue_stats("agg test", _snapshot(os.getpid()))
+    await ss.unpublish_queue_stats("agg test")
+    agg = await ss.aggregate_queue_stats("agg test")
+    assert agg["reporting_workers"] == 0
+
+
+async def test_publish_is_noop_when_uninitialized():
+    # Best-effort contract: never raises before initialization.
+    await ss.publish_queue_stats("agg test", _snapshot(os.getpid()))
+    await ss.unpublish_queue_stats("agg test")

--- a/tests/kg/test_global_concurrency_slots.py
+++ b/tests/kg/test_global_concurrency_slots.py
@@ -211,6 +211,118 @@ async def test_acquire_fail_closed_on_shared_error(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Waiter tracking (soft FIFO: longest live waiter gets the fast poll rate)
+# ---------------------------------------------------------------------------
+
+
+async def test_tracked_acquire_registers_waiter_and_clears_on_success():
+    _init({GROUP: 1})
+    external = await ss.try_acquire_global_slot(GROUP)
+    ns = await _lease_ns()
+    wkey = ss._waiter_key(GROUP, os.getpid())
+
+    # Failure registers the waiter; sole waiter is the priority one.
+    lease, is_priority = await ss.try_acquire_global_slot_tracked(GROUP)
+    assert lease is None and is_priority is True
+    first_start = dict(ns[wkey])["wait_start"]
+
+    # Repeated polls refresh last_poll but keep the waiting episode start.
+    await ss.try_acquire_global_slot_tracked(GROUP)
+    assert dict(ns[wkey])["wait_start"] == first_start
+
+    # Success clears the record (seniority resets after every win).
+    await ss.release_global_slot(GROUP, external)
+    lease, is_priority = await ss.try_acquire_global_slot_tracked(GROUP)
+    assert lease is not None and is_priority is True
+    assert wkey not in list(ns.keys())
+
+    # Waiter records never count as held slots.
+    assert await ss.global_concurrency_in_use(GROUP) == 1
+
+
+async def test_plain_acquire_never_registers_waiter():
+    _init({GROUP: 1})
+    await ss.try_acquire_global_slot(GROUP)
+    assert await ss.try_acquire_global_slot(GROUP) is None  # at capacity
+    ns = await _lease_ns()
+    assert ss._waiter_key(GROUP, os.getpid()) not in list(ns.keys())
+
+
+async def test_longest_live_waiter_gets_priority():
+    _init({GROUP: 1})
+    await ss.try_acquire_global_slot(GROUP)  # saturate
+    ns = await _lease_ns()
+    now = time.time()
+    # PID 1 (alive) has been waiting longer and is actively polling.
+    ns[ss._waiter_key(GROUP, 1)] = {"pid": 1, "wait_start": now - 10, "last_poll": now}
+
+    _, is_priority = await ss.try_acquire_global_slot_tracked(GROUP)
+    assert is_priority is False  # pid 1 outranks us
+
+    # When pid 1 stops polling (stale last_poll), it loses the favored seat:
+    # the rank ignores it and the reap pass removes its record entirely.
+    stale = dict(ns[ss._waiter_key(GROUP, 1)])
+    stale["last_poll"] = now - ss._waiter_stale_ttl - 5
+    ns[ss._waiter_key(GROUP, 1)] = stale
+    _, is_priority = await ss.try_acquire_global_slot_tracked(GROUP)
+    assert is_priority is True
+    assert ss._waiter_key(GROUP, 1) not in list(ns.keys())
+
+
+async def test_waiter_records_reaped_with_their_process(monkeypatch):
+    """A process reclaimed by the reaper (dead PID or lease heartbeat
+    timeout) must not keep occupying the longest-waiter seat: its waiter
+    records are cleaned in the same reap pass."""
+    monkeypatch.setattr(ss, "_heartbeat_ttl", 1.0)
+    monkeypatch.setattr(ss, "_suspect_grace", 1.0)
+    _init({GROUP: 2})
+    ns = await _lease_ns()
+    now = time.time()
+
+    # Case 1: dead PID — lease and waiter record reclaimed together.
+    dead = _dead_pid()
+    ns[f"{GROUP}{ss.KEY_SEP}deadlease"] = {"pid": dead, "updated_at": now}
+    ns[ss._waiter_key(GROUP, dead)] = {
+        "pid": dead,
+        "wait_start": now - 60,
+        "last_poll": now,  # fresh, but the owner is gone
+    }
+    await ss.reconcile_global_slots(GROUP)
+    assert f"{GROUP}{ss.KEY_SEP}deadlease" not in list(ns.keys())
+    assert ss._waiter_key(GROUP, dead) not in list(ns.keys())
+
+    # Case 2: live PID whose lease timed out past the suspect grace —
+    # the process is deemed lost; its waiter record goes with the lease.
+    ns[f"{GROUP}{ss.KEY_SEP}stalledlease"] = {
+        "pid": 1,
+        "updated_at": now - 60,
+        "suspect_since": now - 30,
+    }
+    ns[ss._waiter_key(GROUP, 1)] = {
+        "pid": 1,
+        "wait_start": now - 60,
+        "last_poll": now,
+    }
+    await ss.reconcile_global_slots(GROUP)
+    assert f"{GROUP}{ss.KEY_SEP}stalledlease" not in list(ns.keys())
+    assert ss._waiter_key(GROUP, 1) not in list(ns.keys())
+
+
+async def test_clear_slot_waiter_and_waiter_snapshot():
+    _init({GROUP: 1})
+    await ss.try_acquire_global_slot(GROUP)  # saturate
+    await ss.try_acquire_global_slot_tracked(GROUP)  # register ourselves
+
+    waiters = await ss.global_slot_waiters(GROUP)
+    assert [w["pid"] for w in waiters] == [os.getpid()]
+    assert waiters[0]["waited"] >= 0.0
+
+    await ss.clear_slot_waiter(GROUP)
+    assert await ss.global_slot_waiters(GROUP) == []
+    await ss.clear_slot_waiter(GROUP)  # idempotent
+
+
+# ---------------------------------------------------------------------------
 # Queue stats publish / aggregate
 # ---------------------------------------------------------------------------
 

--- a/tests/kg/test_global_concurrency_slots.py
+++ b/tests/kg/test_global_concurrency_slots.py
@@ -43,6 +43,15 @@ async def _lease_ns():
     return await ss._get_lease_namespace()
 
 
+def _gate(ns, group=GROUP):
+    """Local copy of a group's single-key gate state."""
+    return ss._load_gate_state(ns, group)
+
+
+def _put_gate(ns, state, group=GROUP):
+    ns[group] = state
+
+
 # ---------------------------------------------------------------------------
 # Configuration semantics
 # ---------------------------------------------------------------------------
@@ -135,12 +144,14 @@ async def test_groups_are_independent():
 async def test_dead_pid_lease_reclaimed_immediately():
     _init({GROUP: 1})
     ns = await _lease_ns()
-    ns[f"{GROUP}{ss.KEY_SEP}deadbeef"] = {"pid": _dead_pid(), "updated_at": time.time()}
+    state = _gate(ns)
+    state["leases"]["deadbeef"] = {"pid": _dead_pid(), "updated_at": time.time()}
+    _put_gate(ns, state)
 
     # The dead owner's slot is reclaimed during acquire — capacity is free.
     lease = await ss.try_acquire_global_slot(GROUP)
     assert lease is not None
-    assert f"{GROUP}{ss.KEY_SEP}deadbeef" not in list(ns.keys())
+    assert "deadbeef" not in _gate(ns)["leases"]
 
 
 async def test_expired_lease_with_live_pid_gets_suspect_grace(monkeypatch):
@@ -148,22 +159,23 @@ async def test_expired_lease_with_live_pid_gets_suspect_grace(monkeypatch):
     monkeypatch.setattr(ss, "_suspect_grace", 1.0)
     _init({GROUP: 1})
     ns = await _lease_ns()
-    key = f"{GROUP}{ss.KEY_SEP}stalled"
+    state = _gate(ns)
     # Live PID (our own) with an expired heartbeat.
-    ns[key] = {"pid": os.getpid(), "updated_at": time.time() - 5.0}
+    state["leases"]["stalled"] = {"pid": os.getpid(), "updated_at": time.time() - 5.0}
+    _put_gate(ns, state)
 
     # First pass: marked suspect, still counts toward capacity.
     assert await ss.reconcile_global_slots(GROUP) == 1
-    assert "suspect_since" in dict(ns[key])
+    assert "suspect_since" in _gate(ns)["leases"]["stalled"]
     assert await ss.try_acquire_global_slot(GROUP) is None
 
     # Within the grace: still not reclaimed.
     assert await ss.reconcile_global_slots(GROUP) == 1
 
     # After the grace elapses without a renewal: reclaimed.
-    lease = dict(ns[key])
-    lease["suspect_since"] = time.time() - 2.0
-    ns[key] = lease
+    state = _gate(ns)
+    state["leases"]["stalled"]["suspect_since"] = time.time() - 2.0
+    _put_gate(ns, state)
     assert await ss.reconcile_global_slots(GROUP) == 0
     assert await ss.try_acquire_global_slot(GROUP) is not None
 
@@ -174,19 +186,18 @@ async def test_renewal_clears_suspect_and_protects_long_tasks(monkeypatch):
     _init({GROUP: 1})
     lease = await ss.try_acquire_global_slot(GROUP)
     ns = await _lease_ns()
-    key = f"{GROUP}{ss.KEY_SEP}{lease}"
 
     # Simulate a momentary renewal outage: heartbeat expires, suspect set.
-    stale = dict(ns[key])
-    stale["updated_at"] = time.time() - 5.0
-    ns[key] = stale
+    state = _gate(ns)
+    state["leases"][lease]["updated_at"] = time.time() - 5.0
+    _put_gate(ns, state)
     await ss.reconcile_global_slots(GROUP)
-    assert "suspect_since" in dict(ns[key])
+    assert "suspect_since" in _gate(ns)["leases"][lease]
 
     # Owner recovers and renews: suspect cleared, lease survives — a legal
     # long-running task is never reclaimed while renewals continue.
     await ss.renew_global_slots(GROUP, [lease])
-    refreshed = dict(ns[key])
+    refreshed = _gate(ns)["leases"][lease]
     assert "suspect_since" not in refreshed
     assert time.time() - refreshed["updated_at"] < 1.0
     assert await ss.reconcile_global_slots(GROUP) == 1
@@ -219,22 +230,22 @@ async def test_tracked_acquire_registers_waiter_and_clears_on_success():
     _init({GROUP: 1})
     external = await ss.try_acquire_global_slot(GROUP)
     ns = await _lease_ns()
-    wkey = ss._waiter_key(GROUP, os.getpid())
+    pid_key = str(os.getpid())
 
     # Failure registers the waiter; sole waiter is the priority one.
     lease, is_priority = await ss.try_acquire_global_slot_tracked(GROUP)
     assert lease is None and is_priority is True
-    first_start = dict(ns[wkey])["wait_start"]
+    first_start = _gate(ns)["waiters"][pid_key]["wait_start"]
 
     # Repeated polls refresh last_poll but keep the waiting episode start.
     await ss.try_acquire_global_slot_tracked(GROUP)
-    assert dict(ns[wkey])["wait_start"] == first_start
+    assert _gate(ns)["waiters"][pid_key]["wait_start"] == first_start
 
     # Success clears the record (seniority resets after every win).
     await ss.release_global_slot(GROUP, external)
     lease, is_priority = await ss.try_acquire_global_slot_tracked(GROUP)
     assert lease is not None and is_priority is True
-    assert wkey not in list(ns.keys())
+    assert pid_key not in _gate(ns)["waiters"]
 
     # Waiter records never count as held slots.
     assert await ss.global_concurrency_in_use(GROUP) == 1
@@ -245,7 +256,29 @@ async def test_plain_acquire_never_registers_waiter():
     await ss.try_acquire_global_slot(GROUP)
     assert await ss.try_acquire_global_slot(GROUP) is None  # at capacity
     ns = await _lease_ns()
-    assert ss._waiter_key(GROUP, os.getpid()) not in list(ns.keys())
+    assert _gate(ns)["waiters"] == {}
+
+
+async def test_plain_failed_acquire_on_unchanged_gate_writes_nothing():
+    """IPC budget contract: a failed untracked attempt against a healthy,
+    saturated gate must not write the state back (one read, zero writes)."""
+    _init({GROUP: 1})
+    await ss.try_acquire_global_slot(GROUP)  # saturate
+    ns = await _lease_ns()
+
+    class SpyDict(dict):
+        def __init__(self, *args_, **kwargs_):
+            super().__init__(*args_, **kwargs_)
+            self.writes = 0
+
+        def __setitem__(self, key, value):
+            self.writes += 1
+            super().__setitem__(key, value)
+
+    spy = SpyDict(ns)
+    ss._lease_ns_cache = spy
+    assert await ss.try_acquire_global_slot(GROUP) is None
+    assert spy.writes == 0
 
 
 async def test_longest_live_waiter_gets_priority():
@@ -254,19 +287,21 @@ async def test_longest_live_waiter_gets_priority():
     ns = await _lease_ns()
     now = time.time()
     # PID 1 (alive) has been waiting longer and is actively polling.
-    ns[ss._waiter_key(GROUP, 1)] = {"pid": 1, "wait_start": now - 10, "last_poll": now}
+    state = _gate(ns)
+    state["waiters"]["1"] = {"pid": 1, "wait_start": now - 10, "last_poll": now}
+    _put_gate(ns, state)
 
     _, is_priority = await ss.try_acquire_global_slot_tracked(GROUP)
     assert is_priority is False  # pid 1 outranks us
 
     # When pid 1 stops polling (stale last_poll), it loses the favored seat:
     # the rank ignores it and the reap pass removes its record entirely.
-    stale = dict(ns[ss._waiter_key(GROUP, 1)])
-    stale["last_poll"] = now - ss._waiter_stale_ttl - 5
-    ns[ss._waiter_key(GROUP, 1)] = stale
+    state = _gate(ns)
+    state["waiters"]["1"]["last_poll"] = now - ss._waiter_stale_ttl - 5
+    _put_gate(ns, state)
     _, is_priority = await ss.try_acquire_global_slot_tracked(GROUP)
     assert is_priority is True
-    assert ss._waiter_key(GROUP, 1) not in list(ns.keys())
+    assert "1" not in _gate(ns)["waiters"]
 
 
 async def test_waiter_records_reaped_with_their_process(monkeypatch):
@@ -281,31 +316,37 @@ async def test_waiter_records_reaped_with_their_process(monkeypatch):
 
     # Case 1: dead PID — lease and waiter record reclaimed together.
     dead = _dead_pid()
-    ns[f"{GROUP}{ss.KEY_SEP}deadlease"] = {"pid": dead, "updated_at": now}
-    ns[ss._waiter_key(GROUP, dead)] = {
+    state = _gate(ns)
+    state["leases"]["deadlease"] = {"pid": dead, "updated_at": now}
+    state["waiters"][str(dead)] = {
         "pid": dead,
         "wait_start": now - 60,
         "last_poll": now,  # fresh, but the owner is gone
     }
+    _put_gate(ns, state)
     await ss.reconcile_global_slots(GROUP)
-    assert f"{GROUP}{ss.KEY_SEP}deadlease" not in list(ns.keys())
-    assert ss._waiter_key(GROUP, dead) not in list(ns.keys())
+    state = _gate(ns)
+    assert "deadlease" not in state["leases"]
+    assert str(dead) not in state["waiters"]
 
     # Case 2: live PID whose lease timed out past the suspect grace —
     # the process is deemed lost; its waiter record goes with the lease.
-    ns[f"{GROUP}{ss.KEY_SEP}stalledlease"] = {
+    state = _gate(ns)
+    state["leases"]["stalledlease"] = {
         "pid": 1,
         "updated_at": now - 60,
         "suspect_since": now - 30,
     }
-    ns[ss._waiter_key(GROUP, 1)] = {
+    state["waiters"]["1"] = {
         "pid": 1,
         "wait_start": now - 60,
         "last_poll": now,
     }
+    _put_gate(ns, state)
     await ss.reconcile_global_slots(GROUP)
-    assert f"{GROUP}{ss.KEY_SEP}stalledlease" not in list(ns.keys())
-    assert ss._waiter_key(GROUP, 1) not in list(ns.keys())
+    state = _gate(ns)
+    assert "stalledlease" not in state["leases"]
+    assert "1" not in state["waiters"]
 
 
 async def test_clear_slot_waiter_and_waiter_snapshot():

--- a/tests/llm/test_global_concurrency_queue.py
+++ b/tests/llm/test_global_concurrency_queue.py
@@ -43,6 +43,30 @@ async def _wait_until(predicate, timeout=5.0, interval=0.01):
         await asyncio.sleep(interval)
 
 
+async def _wait_drained(wrapped, timeout=5.0, interval=0.01):
+    """Poll until the wrapper's accounting fully quiesces to zero.
+
+    Asserts the live_queued exactly-once invariant at its strongest point:
+    once every task has drained, the logical reservation counter
+    (``queued`` == live_queued), the physical queue, and task_states
+    (``in_flight``) must all be back to zero. A leaked reservation
+    (up-drift) leaves ``queued`` stuck above zero forever; a leaked
+    task_states entry leaves ``in_flight`` stuck. Returns the final stats.
+    """
+    deadline = asyncio.get_event_loop().time() + timeout
+    while True:
+        stats = await wrapped.get_queue_stats()
+        if (
+            stats["queued"] == 0
+            and stats["in_flight"] == 0
+            and stats.get("physical_queued", 0) == 0
+        ):
+            return stats
+        if asyncio.get_event_loop().time() > deadline:
+            raise AssertionError(f"queue did not drain to zero: {stats}")
+        await asyncio.sleep(interval)
+
+
 # ---------------------------------------------------------------------------
 # Core: global cap on in-flight executions
 # ---------------------------------------------------------------------------
@@ -584,6 +608,11 @@ async def test_worker_drains_zombie_backlog_then_runs_live_task():
         # reached the provider.
         assert await asyncio.wait_for(live, timeout=5.0) == "live"
         assert calls == ["live"]
+
+        # live_queued invariant: after the 40 zombies drained and the live
+        # task completed, the reservation counter and task_states must be
+        # fully back to zero (no leaked reservation, no orphaned tuple).
+        await _wait_drained(wrapped)
     finally:
         await wrapped.shutdown(graceful=False)
 
@@ -614,10 +643,18 @@ async def test_compaction_bounds_physical_queue_and_keeps_join_working(monkeypat
         stats = await wrapped.get_queue_stats()
         assert stats["physical_queued"] == 80
         assert stats["queued"] == 0
+        # All 80 timed-out tasks already returned their reservations and
+        # popped task_states in their finally blocks; only the physical
+        # tuples linger.
+        assert stats["in_flight"] == 0
 
         await wrapped.run_maintenance()  # triggers compaction
         stats = await wrapped.get_queue_stats()
         assert stats["physical_queued"] == 0
+        # Compaction must not perturb the logical accounting: live_queued
+        # and task_states stay at zero (it only drains dead physical tuples).
+        assert stats["queued"] == 0
+        assert stats["in_flight"] == 0
 
         # task_done bookkeeping must be exact: graceful shutdown relies on
         # queue.join() and must complete promptly (not hit the drain timeout).
@@ -650,9 +687,20 @@ async def test_compaction_keeps_live_tasks(monkeypatch):
         stats = await wrapped.get_queue_stats()
         assert stats["queued"] == 1  # live survived compaction
         assert stats["physical_queued"] == 1
+        # live_queued invariant at a held steady state: the external slot
+        # blocks pickup, so the one live task is queued-not-started
+        # (running == 0) and is the only task_states entry (in_flight == 1).
+        # live_queued must therefore equal in_flight - running, i.e. exactly
+        # the count of not-yet-started tasks, with no phantom reservation.
+        assert stats["running"] == 0
+        assert stats["in_flight"] == 1
+        assert stats["queued"] == stats["in_flight"] - stats["running"]
 
         await ss.release_global_slot(GROUP, external)
         assert await asyncio.wait_for(live, timeout=5.0) == "live"
+
+        # And once it runs and drains, accounting returns fully to zero.
+        await _wait_drained(wrapped)
     finally:
         await wrapped.shutdown(graceful=False)
 

--- a/tests/llm/test_global_concurrency_queue.py
+++ b/tests/llm/test_global_concurrency_queue.py
@@ -11,7 +11,12 @@ import asyncio
 import pytest
 
 from lightrag.kg import shared_storage as ss
-from lightrag.utils import QueueFullError, priority_limit_async_func_call
+
+# Accessed via the module (not ``from``-imports) on purpose: another test in
+# the suite reloads lightrag.utils in place, which would leave from-imported
+# class references (e.g. QueueFullError) pointing at the pre-reload class and
+# break pytest.raises identity checks when run in the same xdist worker.
+from lightrag import utils as lr_utils
 
 pytestmark = pytest.mark.offline
 
@@ -56,7 +61,7 @@ async def test_global_limit_caps_inflight_executions():
         inflight -= 1
         return value
 
-    wrapped = priority_limit_async_func_call(
+    wrapped = lr_utils.priority_limit_async_func_call(
         10, queue_name="cap test", concurrency_group=GROUP
     )(slow_func)
     try:
@@ -83,10 +88,10 @@ async def test_limit_shared_across_wrappers_of_same_group():
         inflight -= 1
         return value
 
-    wrapped_a = priority_limit_async_func_call(
+    wrapped_a = lr_utils.priority_limit_async_func_call(
         4, queue_name="share a", concurrency_group=GROUP
     )(slow_func)
-    wrapped_b = priority_limit_async_func_call(
+    wrapped_b = lr_utils.priority_limit_async_func_call(
         4, queue_name="share b", concurrency_group=GROUP
     )(slow_func)
     try:
@@ -126,7 +131,7 @@ async def test_no_global_limit_keeps_original_path(monkeypatch):
     async def fast_func(value):
         return value
 
-    wrapped = priority_limit_async_func_call(
+    wrapped = lr_utils.priority_limit_async_func_call(
         2, queue_name="plain test", concurrency_group=GROUP
     )(fast_func)
     try:
@@ -151,7 +156,9 @@ async def test_standalone_group_none_never_touches_shared_storage(monkeypatch):
     async def fast_func(value):
         return value
 
-    wrapped = priority_limit_async_func_call(2, queue_name="standalone test")(fast_func)
+    wrapped = lr_utils.priority_limit_async_func_call(2, queue_name="standalone test")(
+        fast_func
+    )
     try:
         assert await wrapped("ok") == "ok"
         stats = await wrapped.get_aggregated_queue_stats()
@@ -174,7 +181,7 @@ async def test_user_timeout_while_waiting_for_slot_never_calls_func():
         calls.append(value)
         return value
 
-    wrapped = priority_limit_async_func_call(
+    wrapped = lr_utils.priority_limit_async_func_call(
         2,
         queue_name="slot wait test",
         concurrency_group=GROUP,
@@ -208,7 +215,7 @@ async def test_priority_overtakes_within_process():
         order.append(value)
         return value
 
-    wrapped = priority_limit_async_func_call(
+    wrapped = lr_utils.priority_limit_async_func_call(
         2, queue_name="priority test", concurrency_group=GROUP
     )(func)
     try:
@@ -240,7 +247,7 @@ async def test_admission_counts_only_live_queued_tasks():
         await release.wait()
         return value
 
-    wrapped = priority_limit_async_func_call(
+    wrapped = lr_utils.priority_limit_async_func_call(
         2,
         queue_name="admission test",
         concurrency_group=GROUP,
@@ -264,7 +271,7 @@ async def test_admission_counts_only_live_queued_tasks():
         assert stats["queued"] == 2  # both fit: running not counted
 
         # The third queued request exceeds capacity -> QueueFullError.
-        with pytest.raises(QueueFullError):
+        with pytest.raises(lr_utils.QueueFullError):
             await wrapped("overflow", _queue_timeout=0.2)
 
         release.set()
@@ -281,7 +288,7 @@ async def test_zombies_do_not_consume_admission_capacity():
     async def func(value):
         return value
 
-    wrapped = priority_limit_async_func_call(
+    wrapped = lr_utils.priority_limit_async_func_call(
         2,
         queue_name="zombie admission test",
         concurrency_group=GROUP,
@@ -321,7 +328,7 @@ async def test_max_queue_size_zero_means_unlimited_admission():
         await asyncio.sleep(0.01)
         return value
 
-    wrapped = priority_limit_async_func_call(
+    wrapped = lr_utils.priority_limit_async_func_call(
         2,
         queue_name="unlimited admission test",
         concurrency_group=GROUP,
@@ -341,7 +348,7 @@ async def test_shutdown_wakes_admission_waiters():
     async def func(value):
         return value
 
-    wrapped = priority_limit_async_func_call(
+    wrapped = lr_utils.priority_limit_async_func_call(
         2,
         queue_name="shutdown wake test",
         concurrency_group=GROUP,
@@ -388,7 +395,7 @@ async def test_fail_closed_acquire_keeps_task_queued_until_recovery(monkeypatch)
     async def func(value):
         return value
 
-    wrapped = priority_limit_async_func_call(
+    wrapped = lr_utils.priority_limit_async_func_call(
         2, queue_name="fail closed test", concurrency_group=GROUP
     )(func)
     try:
@@ -420,7 +427,7 @@ async def test_release_failure_preserves_result_and_retries_later(monkeypatch):
             raise ValueError("business error")
         return value
 
-    wrapped = priority_limit_async_func_call(
+    wrapped = lr_utils.priority_limit_async_func_call(
         2, queue_name="release fail test", concurrency_group=GROUP
     )(func)
     try:
@@ -458,7 +465,7 @@ async def test_stats_failures_never_break_calls(monkeypatch):
     async def func(value):
         return value
 
-    wrapped = priority_limit_async_func_call(
+    wrapped = lr_utils.priority_limit_async_func_call(
         2, queue_name="best effort test", concurrency_group=GROUP
     )(func)
     try:
@@ -486,7 +493,7 @@ async def test_worker_drains_zombie_backlog_then_runs_live_task():
         calls.append(value)
         return value
 
-    wrapped = priority_limit_async_func_call(
+    wrapped = lr_utils.priority_limit_async_func_call(
         2,
         queue_name="drain test",
         concurrency_group=GROUP,
@@ -523,7 +530,7 @@ async def test_compaction_bounds_physical_queue_and_keeps_join_working(monkeypat
     async def func(value):
         return value
 
-    wrapped = priority_limit_async_func_call(
+    wrapped = lr_utils.priority_limit_async_func_call(
         2,
         queue_name="compaction test",
         concurrency_group=GROUP,
@@ -557,7 +564,7 @@ async def test_compaction_keeps_live_tasks(monkeypatch):
     async def func(value):
         return value
 
-    wrapped = priority_limit_async_func_call(
+    wrapped = lr_utils.priority_limit_async_func_call(
         2,
         queue_name="compaction live test",
         concurrency_group=GROUP,
@@ -594,7 +601,7 @@ async def test_aggregated_stats_schema_and_global_fields():
             raise ValueError("x")
         return value
 
-    wrapped = priority_limit_async_func_call(
+    wrapped = lr_utils.priority_limit_async_func_call(
         3, queue_name="agg schema test", concurrency_group=GROUP
     )(func)
     try:
@@ -649,7 +656,7 @@ async def test_shutdown_clears_waiter_record():
     async def func(value):
         return value
 
-    wrapped = priority_limit_async_func_call(
+    wrapped = lr_utils.priority_limit_async_func_call(
         2, queue_name="waiter cleanup test", concurrency_group=GROUP
     )(func)
     pending = asyncio.create_task(wrapped("stuck"))
@@ -674,7 +681,7 @@ async def test_aggregated_stats_report_slot_waiters():
     async def func(value):
         return value
 
-    wrapped = priority_limit_async_func_call(
+    wrapped = lr_utils.priority_limit_async_func_call(
         2, queue_name="waiter stats test", concurrency_group=GROUP
     )(func)
     task = asyncio.create_task(wrapped("waiting"))
@@ -706,7 +713,7 @@ async def test_maintenance_renews_held_leases(monkeypatch):
         await release.wait()
         return value
 
-    wrapped = priority_limit_async_func_call(
+    wrapped = lr_utils.priority_limit_async_func_call(
         2, queue_name="renew test", concurrency_group=GROUP
     )(long_func)
     try:

--- a/tests/llm/test_global_concurrency_queue.py
+++ b/tests/llm/test_global_concurrency_queue.py
@@ -109,13 +109,19 @@ async def test_no_global_limit_keeps_original_path(monkeypatch):
     _init()  # initialized, but no limits configured
 
     calls = []
-    original = ss.try_acquire_global_slot
+    original_plain = ss.try_acquire_global_slot
+    original_tracked = ss.try_acquire_global_slot_tracked
 
-    async def spy(group):
+    async def spy_plain(group):
         calls.append(group)
-        return await original(group)
+        return await original_plain(group)
 
-    monkeypatch.setattr(ss, "try_acquire_global_slot", spy)
+    async def spy_tracked(group):
+        calls.append(group)
+        return await original_tracked(group)
+
+    monkeypatch.setattr(ss, "try_acquire_global_slot", spy_plain)
+    monkeypatch.setattr(ss, "try_acquire_global_slot_tracked", spy_tracked)
 
     async def fast_func(value):
         return value
@@ -138,6 +144,7 @@ async def test_standalone_group_none_never_touches_shared_storage(monkeypatch):
         raise AssertionError("shared_storage API must not be called")
 
     monkeypatch.setattr(ss, "try_acquire_global_slot", boom)
+    monkeypatch.setattr(ss, "try_acquire_global_slot_tracked", boom)
     monkeypatch.setattr(ss, "publish_queue_stats", boom)
     monkeypatch.setattr(ss, "aggregate_queue_stats", boom)
 
@@ -369,14 +376,14 @@ async def test_fail_closed_acquire_keeps_task_queued_until_recovery(monkeypatch)
     _init({GROUP: 2})
 
     fail = True
-    original = ss.try_acquire_global_slot
+    original = ss.try_acquire_global_slot_tracked
 
     async def flaky(group):
         if fail:
             raise RuntimeError("manager down")
         return await original(group)
 
-    monkeypatch.setattr(ss, "try_acquire_global_slot", flaky)
+    monkeypatch.setattr(ss, "try_acquire_global_slot_tracked", flaky)
 
     async def func(value):
         return value
@@ -511,7 +518,7 @@ async def test_compaction_bounds_physical_queue_and_keeps_join_working(monkeypat
     async def acquire_always_fails(_group):
         raise RuntimeError("manager down")  # permanent fail-closed
 
-    monkeypatch.setattr(ss, "try_acquire_global_slot", acquire_always_fails)
+    monkeypatch.setattr(ss, "try_acquire_global_slot_tracked", acquire_always_fails)
 
     async def func(value):
         return value
@@ -631,6 +638,58 @@ async def test_aggregated_stats_schema_and_global_fields():
         assert list(stats["per_worker"])
         assert stats["global_limit"] == 2
         assert stats["global_in_use"] == 0
+    finally:
+        await wrapped.shutdown()
+
+
+async def test_shutdown_clears_waiter_record():
+    _init({GROUP: 1})
+    await ss.try_acquire_global_slot(GROUP)  # saturate so workers poll
+
+    async def func(value):
+        return value
+
+    wrapped = priority_limit_async_func_call(
+        2, queue_name="waiter cleanup test", concurrency_group=GROUP
+    )(func)
+    pending = asyncio.create_task(wrapped("stuck"))
+    try:
+        # Wait until a polling worker registers this process as a waiter.
+        deadline = asyncio.get_event_loop().time() + 5.0
+        while not await ss.global_slot_waiters(GROUP):
+            assert asyncio.get_event_loop().time() < deadline
+            await asyncio.sleep(0.01)
+    finally:
+        await wrapped.shutdown(graceful=False, timeout=0.1)
+    with pytest.raises(asyncio.CancelledError):
+        await pending
+    # No-longer-polling process must not linger in the longest-waiter seat.
+    assert await ss.global_slot_waiters(GROUP) == []
+
+
+async def test_aggregated_stats_report_slot_waiters():
+    _init({GROUP: 1})
+    external = await ss.try_acquire_global_slot(GROUP)
+
+    async def func(value):
+        return value
+
+    wrapped = priority_limit_async_func_call(
+        2, queue_name="waiter stats test", concurrency_group=GROUP
+    )(func)
+    task = asyncio.create_task(wrapped("waiting"))
+    try:
+        deadline = asyncio.get_event_loop().time() + 5.0
+        while not await ss.global_slot_waiters(GROUP):
+            assert asyncio.get_event_loop().time() < deadline
+            await asyncio.sleep(0.01)
+
+        stats = await wrapped.get_aggregated_queue_stats()
+        assert stats["global_waiting_workers"] == 1
+        assert stats["global_longest_wait"] >= 0.0
+
+        await ss.release_global_slot(GROUP, external)
+        assert await asyncio.wait_for(task, timeout=5.0) == "waiting"
     finally:
         await wrapped.shutdown()
 

--- a/tests/llm/test_global_concurrency_queue.py
+++ b/tests/llm/test_global_concurrency_queue.py
@@ -36,9 +36,9 @@ def _init(limits=None):
 
 
 async def _wait_until(predicate, timeout=5.0, interval=0.01):
-    deadline = asyncio.get_event_loop().time() + timeout
+    deadline = asyncio.get_running_loop().time() + timeout
     while not predicate():
-        if asyncio.get_event_loop().time() > deadline:
+        if asyncio.get_running_loop().time() > deadline:
             raise AssertionError("condition not met within timeout")
         await asyncio.sleep(interval)
 
@@ -53,7 +53,7 @@ async def _wait_drained(wrapped, timeout=5.0, interval=0.01):
     (up-drift) leaves ``queued`` stuck above zero forever; a leaked
     task_states entry leaves ``in_flight`` stuck. Returns the final stats.
     """
-    deadline = asyncio.get_event_loop().time() + timeout
+    deadline = asyncio.get_running_loop().time() + timeout
     while True:
         stats = await wrapped.get_queue_stats()
         if (
@@ -62,7 +62,7 @@ async def _wait_drained(wrapped, timeout=5.0, interval=0.01):
             and stats.get("physical_queued", 0) == 0
         ):
             return stats
-        if asyncio.get_event_loop().time() > deadline:
+        if asyncio.get_running_loop().time() > deadline:
             raise AssertionError(f"queue did not drain to zero: {stats}")
         await asyncio.sleep(interval)
 
@@ -355,9 +355,9 @@ async def test_admission_counts_only_live_queued_tasks():
         async def _queued_count():
             return (await wrapped.get_queue_stats())["queued"]
 
-        deadline = asyncio.get_event_loop().time() + 5.0
+        deadline = asyncio.get_running_loop().time() + 5.0
         while await _queued_count() != 2:
-            assert asyncio.get_event_loop().time() < deadline
+            assert asyncio.get_running_loop().time() < deadline
             await asyncio.sleep(0.01)
 
         stats = await wrapped.get_queue_stats()
@@ -732,9 +732,9 @@ async def test_aggregated_stats_schema_and_global_fields():
         async def _in_use_zero():
             return await ss.global_concurrency_in_use(GROUP) == 0
 
-        deadline = asyncio.get_event_loop().time() + 2.0
+        deadline = asyncio.get_running_loop().time() + 2.0
         while not await _in_use_zero():
-            assert asyncio.get_event_loop().time() < deadline
+            assert asyncio.get_running_loop().time() < deadline
             await asyncio.sleep(0.01)
 
         stats = await wrapped.get_aggregated_queue_stats()
@@ -779,9 +779,9 @@ async def test_shutdown_clears_waiter_record():
     pending = asyncio.create_task(wrapped("stuck"))
     try:
         # Wait until a polling worker registers this process as a waiter.
-        deadline = asyncio.get_event_loop().time() + 5.0
+        deadline = asyncio.get_running_loop().time() + 5.0
         while not await ss.global_slot_waiters(GROUP):
-            assert asyncio.get_event_loop().time() < deadline
+            assert asyncio.get_running_loop().time() < deadline
             await asyncio.sleep(0.01)
     finally:
         await wrapped.shutdown(graceful=False, timeout=0.1)
@@ -803,9 +803,9 @@ async def test_aggregated_stats_report_slot_waiters():
     )(func)
     task = asyncio.create_task(wrapped("waiting"))
     try:
-        deadline = asyncio.get_event_loop().time() + 5.0
+        deadline = asyncio.get_running_loop().time() + 5.0
         while not await ss.global_slot_waiters(GROUP):
-            assert asyncio.get_event_loop().time() < deadline
+            assert asyncio.get_running_loop().time() < deadline
             await asyncio.sleep(0.01)
 
         stats = await wrapped.get_aggregated_queue_stats()

--- a/tests/llm/test_global_concurrency_queue.py
+++ b/tests/llm/test_global_concurrency_queue.py
@@ -1,0 +1,667 @@
+"""Offline tests for priority_limit_async_func_call's cross-worker global
+concurrency mode (concurrency_group + shared-storage gating).
+
+Single-process shared storage exercises the exact code paths used under
+gunicorn multi-worker mode (namespaces and keyed locks degrade to in-process
+primitives).
+"""
+
+import asyncio
+
+import pytest
+
+from lightrag.kg import shared_storage as ss
+from lightrag.utils import QueueFullError, priority_limit_async_func_call
+
+pytestmark = pytest.mark.offline
+
+
+GROUP = "llm:test"
+
+
+@pytest.fixture(autouse=True)
+def clean_shared_storage():
+    ss.finalize_share_data()
+    yield
+    ss.finalize_share_data()
+
+
+def _init(limits=None):
+    ss.initialize_share_data(1, global_concurrency_limits=limits)
+
+
+async def _wait_until(predicate, timeout=5.0, interval=0.01):
+    deadline = asyncio.get_event_loop().time() + timeout
+    while not predicate():
+        if asyncio.get_event_loop().time() > deadline:
+            raise AssertionError("condition not met within timeout")
+        await asyncio.sleep(interval)
+
+
+# ---------------------------------------------------------------------------
+# Core: global cap on in-flight executions
+# ---------------------------------------------------------------------------
+
+
+async def test_global_limit_caps_inflight_executions():
+    _init({GROUP: 3})
+    inflight = 0
+    peak = 0
+
+    async def slow_func(value):
+        nonlocal inflight, peak
+        inflight += 1
+        peak = max(peak, inflight)
+        await asyncio.sleep(0.05)
+        inflight -= 1
+        return value
+
+    wrapped = priority_limit_async_func_call(
+        10, queue_name="cap test", concurrency_group=GROUP
+    )(slow_func)
+    try:
+        results = await asyncio.gather(*(wrapped(i) for i in range(10)))
+        assert sorted(results) == list(range(10))
+        assert peak <= 3
+        # Slots all returned after completion.
+        assert await ss.global_concurrency_in_use(GROUP) == 0
+    finally:
+        await wrapped.shutdown()
+
+
+async def test_limit_shared_across_wrappers_of_same_group():
+    """Two wrappers (≈ two processes / instances) share one global gate."""
+    _init({GROUP: 1})
+    inflight = 0
+    peak = 0
+
+    async def slow_func(value):
+        nonlocal inflight, peak
+        inflight += 1
+        peak = max(peak, inflight)
+        await asyncio.sleep(0.05)
+        inflight -= 1
+        return value
+
+    wrapped_a = priority_limit_async_func_call(
+        4, queue_name="share a", concurrency_group=GROUP
+    )(slow_func)
+    wrapped_b = priority_limit_async_func_call(
+        4, queue_name="share b", concurrency_group=GROUP
+    )(slow_func)
+    try:
+        results = await asyncio.gather(
+            *(wrapped_a(i) for i in range(3)), *(wrapped_b(i) for i in range(3))
+        )
+        assert len(results) == 6
+        assert peak == 1
+    finally:
+        await wrapped_a.shutdown()
+        await wrapped_b.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Unconfigured / standalone paths stay untouched
+# ---------------------------------------------------------------------------
+
+
+async def test_no_global_limit_keeps_original_path(monkeypatch):
+    _init()  # initialized, but no limits configured
+
+    calls = []
+    original = ss.try_acquire_global_slot
+
+    async def spy(group):
+        calls.append(group)
+        return await original(group)
+
+    monkeypatch.setattr(ss, "try_acquire_global_slot", spy)
+
+    async def fast_func(value):
+        return value
+
+    wrapped = priority_limit_async_func_call(
+        2, queue_name="plain test", concurrency_group=GROUP
+    )(fast_func)
+    try:
+        assert await asyncio.gather(*(wrapped(i) for i in range(5))) == list(range(5))
+        assert calls == []  # slot acquisition never touched
+        stats = await wrapped.get_queue_stats()
+        assert "physical_queued" not in stats  # bounded-queue (default) mode
+    finally:
+        await wrapped.shutdown()
+
+
+async def test_standalone_group_none_never_touches_shared_storage(monkeypatch):
+    # Shared storage NOT initialized at all (library-external usage).
+    def boom(*_args, **_kwargs):
+        raise AssertionError("shared_storage API must not be called")
+
+    monkeypatch.setattr(ss, "try_acquire_global_slot", boom)
+    monkeypatch.setattr(ss, "publish_queue_stats", boom)
+    monkeypatch.setattr(ss, "aggregate_queue_stats", boom)
+
+    async def fast_func(value):
+        return value
+
+    wrapped = priority_limit_async_func_call(2, queue_name="standalone test")(fast_func)
+    try:
+        assert await wrapped("ok") == "ok"
+        stats = await wrapped.get_aggregated_queue_stats()
+        assert stats["completed_total"] == 1
+    finally:
+        await wrapped.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Slot waiting: cancellation, stuck detection, priority
+# ---------------------------------------------------------------------------
+
+
+async def test_user_timeout_while_waiting_for_slot_never_calls_func():
+    _init({GROUP: 1})
+    external = await ss.try_acquire_global_slot(GROUP)  # saturate the gate
+    calls = []
+
+    async def func(value):
+        calls.append(value)
+        return value
+
+    wrapped = priority_limit_async_func_call(
+        2,
+        queue_name="slot wait test",
+        concurrency_group=GROUP,
+        cleanup_timeout=0.1,
+    )(func)
+    try:
+        with pytest.raises(TimeoutError, match="User timeout"):
+            await wrapped("never", _timeout=0.3)
+        assert calls == []
+        # The lease count is unchanged — the cancelled task never held one.
+        assert await ss.global_concurrency_in_use(GROUP) == 1
+
+        stats = await wrapped.get_queue_stats()
+        assert stats["running"] == 0  # never misjudged as running/stuck
+        assert stats["cancelled_total"] == 1
+
+        # Once the external holder releases, new requests get the slot.
+        await ss.release_global_slot(GROUP, external)
+        assert await wrapped("now") == "now"
+        assert calls == ["now"]
+    finally:
+        await wrapped.shutdown()
+
+
+async def test_priority_overtakes_within_process():
+    _init({GROUP: 1})
+    external = await ss.try_acquire_global_slot(GROUP)
+    order = []
+
+    async def func(value):
+        order.append(value)
+        return value
+
+    wrapped = priority_limit_async_func_call(
+        2, queue_name="priority test", concurrency_group=GROUP
+    )(func)
+    try:
+        low = [asyncio.create_task(wrapped(f"low{i}", _priority=10)) for i in range(3)]
+        await asyncio.sleep(0.05)
+        high = asyncio.create_task(wrapped("high", _priority=1))
+        await asyncio.sleep(0.05)
+
+        await ss.release_global_slot(GROUP, external)
+        await asyncio.gather(high, *low)
+        assert order[0] == "high"
+    finally:
+        await wrapped.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Admission semantics (live_queued)
+# ---------------------------------------------------------------------------
+
+
+async def test_admission_counts_only_live_queued_tasks():
+    """max_queue_size limits QUEUED tasks; running tasks don't consume it."""
+    _init({GROUP: 1})
+    release = asyncio.Event()
+    started = asyncio.Event()
+
+    async def gated(value):
+        started.set()
+        await release.wait()
+        return value
+
+    wrapped = priority_limit_async_func_call(
+        2,
+        queue_name="admission test",
+        concurrency_group=GROUP,
+        max_queue_size=2,
+    )(gated)
+    try:
+        running = asyncio.create_task(wrapped("running"))
+        await started.wait()  # now running (holds the only slot), not queued
+
+        queued = [asyncio.create_task(wrapped(f"q{i}")) for i in range(2)]
+
+        async def _queued_count():
+            return (await wrapped.get_queue_stats())["queued"]
+
+        deadline = asyncio.get_event_loop().time() + 5.0
+        while await _queued_count() != 2:
+            assert asyncio.get_event_loop().time() < deadline
+            await asyncio.sleep(0.01)
+
+        stats = await wrapped.get_queue_stats()
+        assert stats["queued"] == 2  # both fit: running not counted
+
+        # The third queued request exceeds capacity -> QueueFullError.
+        with pytest.raises(QueueFullError):
+            await wrapped("overflow", _queue_timeout=0.2)
+
+        release.set()
+        assert await running == "running"
+        assert sorted(await asyncio.gather(*queued)) == ["q0", "q1"]
+    finally:
+        await wrapped.shutdown()
+
+
+async def test_zombies_do_not_consume_admission_capacity():
+    _init({GROUP: 1})
+    external = await ss.try_acquire_global_slot(GROUP)
+
+    async def func(value):
+        return value
+
+    wrapped = priority_limit_async_func_call(
+        2,
+        queue_name="zombie admission test",
+        concurrency_group=GROUP,
+        max_queue_size=2,
+        cleanup_timeout=0.05,
+    )(func)
+    try:
+        # Fill the queue, then let both requests time out -> zombies.
+        for i in range(2):
+            with pytest.raises(TimeoutError):
+                await wrapped(f"dead{i}", _timeout=0.1)
+
+        stats = await wrapped.get_queue_stats()
+        assert stats["queued"] == 0  # logical count excludes zombies
+        assert stats["physical_queued"] == 2  # tuples still in the queue
+
+        # New requests are admitted despite the zombie tuples...
+        new_tasks = [
+            asyncio.create_task(wrapped(f"new{i}", _queue_timeout=1.0))
+            for i in range(2)
+        ]
+        await asyncio.sleep(0.05)
+        assert all(not t.done() for t in new_tasks)  # admitted, waiting for slot
+
+        # ...and run fine once a slot frees up; zombies are drained without
+        # ever calling the provider for them.
+        await ss.release_global_slot(GROUP, external)
+        assert sorted(await asyncio.gather(*new_tasks)) == ["new0", "new1"]
+    finally:
+        await wrapped.shutdown(graceful=False)
+
+
+async def test_max_queue_size_zero_means_unlimited_admission():
+    _init({GROUP: 2})
+
+    async def func(value):
+        await asyncio.sleep(0.01)
+        return value
+
+    wrapped = priority_limit_async_func_call(
+        2,
+        queue_name="unlimited admission test",
+        concurrency_group=GROUP,
+        max_queue_size=0,
+    )(func)
+    try:
+        results = await asyncio.gather(*(wrapped(i) for i in range(20)))
+        assert len(results) == 20
+    finally:
+        await wrapped.shutdown()
+
+
+async def test_shutdown_wakes_admission_waiters():
+    _init({GROUP: 1})
+    await ss.try_acquire_global_slot(GROUP)  # saturate so nothing dequeues
+
+    async def func(value):
+        return value
+
+    wrapped = priority_limit_async_func_call(
+        2,
+        queue_name="shutdown wake test",
+        concurrency_group=GROUP,
+        max_queue_size=1,
+    )(func)
+    try:
+        filler = asyncio.create_task(wrapped("filler"))
+        await asyncio.sleep(0.05)
+        # No _queue_timeout: sleeps on the admission condition.
+        waiter = asyncio.create_task(wrapped("waiter"))
+        await asyncio.sleep(0.05)
+        assert not waiter.done()
+
+        shutdown_task = asyncio.create_task(
+            wrapped.shutdown(graceful=False, timeout=0.1)
+        )
+        with pytest.raises(RuntimeError, match="Queue is shutting down"):
+            await asyncio.wait_for(waiter, timeout=2.0)
+        await shutdown_task
+        with pytest.raises(asyncio.CancelledError):
+            await filler
+    finally:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Failure policy: fail-closed acquire, safe release, best-effort stats
+# ---------------------------------------------------------------------------
+
+
+async def test_fail_closed_acquire_keeps_task_queued_until_recovery(monkeypatch):
+    _init({GROUP: 2})
+
+    fail = True
+    original = ss.try_acquire_global_slot
+
+    async def flaky(group):
+        if fail:
+            raise RuntimeError("manager down")
+        return await original(group)
+
+    monkeypatch.setattr(ss, "try_acquire_global_slot", flaky)
+
+    async def func(value):
+        return value
+
+    wrapped = priority_limit_async_func_call(
+        2, queue_name="fail closed test", concurrency_group=GROUP
+    )(func)
+    try:
+        task = asyncio.create_task(wrapped("delayed"))
+        await asyncio.sleep(0.3)
+        assert not task.done()  # never let through while acquire fails
+
+        fail = False
+        assert await asyncio.wait_for(task, timeout=2.0) == "delayed"
+    finally:
+        await wrapped.shutdown()
+
+
+async def test_release_failure_preserves_result_and_retries_later(monkeypatch):
+    _init({GROUP: 1})
+
+    fail_release = True
+    original_release = ss.release_global_slot
+
+    async def flaky_release(group, lease_id):
+        if fail_release:
+            raise RuntimeError("release boom")
+        return await original_release(group, lease_id)
+
+    monkeypatch.setattr(ss, "release_global_slot", flaky_release)
+
+    async def func(value):
+        if value == "explode":
+            raise ValueError("business error")
+        return value
+
+    wrapped = priority_limit_async_func_call(
+        2, queue_name="release fail test", concurrency_group=GROUP
+    )(func)
+    try:
+        # Result passes through even though the lease release failed; the
+        # lease is parked for retry (still occupying its slot until then).
+        assert await wrapped("ok") == "ok"
+        assert await ss.global_concurrency_in_use(GROUP) >= 1
+        fail_release = False
+        await wrapped.run_maintenance()  # health-check retry frees the slot
+        assert await ss.global_concurrency_in_use(GROUP) == 0
+
+        # Same for a failing call: the original business exception is never
+        # masked by the release failure.
+        fail_release = True
+        with pytest.raises(ValueError, match="business error"):
+            await wrapped("explode")
+        assert await ss.global_concurrency_in_use(GROUP) >= 1
+        fail_release = False
+        await wrapped.run_maintenance()
+        assert await ss.global_concurrency_in_use(GROUP) == 0
+    finally:
+        await wrapped.shutdown()
+
+
+async def test_stats_failures_never_break_calls(monkeypatch):
+    _init({GROUP: 2})
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("stats backend down")
+
+    monkeypatch.setattr(ss, "publish_queue_stats", boom)
+    monkeypatch.setattr(ss, "aggregate_queue_stats", boom)
+    monkeypatch.setattr(ss, "reconcile_global_slots", boom)
+
+    async def func(value):
+        return value
+
+    wrapped = priority_limit_async_func_call(
+        2, queue_name="best effort test", concurrency_group=GROUP
+    )(func)
+    try:
+        assert await wrapped("fine") == "fine"
+        await wrapped.run_maintenance()  # must not raise
+        # Aggregation failure falls back to the local snapshot.
+        stats = await wrapped.get_aggregated_queue_stats()
+        assert stats["completed_total"] == 1
+        assert "reporting_workers" not in stats
+    finally:
+        await wrapped.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Zombie drain & physical queue compaction
+# ---------------------------------------------------------------------------
+
+
+async def test_worker_drains_zombie_backlog_then_runs_live_task():
+    _init({GROUP: 1})
+    external = await ss.try_acquire_global_slot(GROUP)
+    calls = []
+
+    async def func(value):
+        calls.append(value)
+        return value
+
+    wrapped = priority_limit_async_func_call(
+        2,
+        queue_name="drain test",
+        concurrency_group=GROUP,
+        max_queue_size=0,
+        cleanup_timeout=0.05,
+    )(func)
+    try:
+        # Pile up zombies well past the per-slot drain limit (16).
+        zombies = [wrapped(f"dead{i}", _priority=1, _timeout=0.05) for i in range(40)]
+        results = await asyncio.gather(*zombies, return_exceptions=True)
+        assert all(isinstance(r, TimeoutError) for r in results)
+
+        live = asyncio.create_task(wrapped("live", _priority=5))
+        await asyncio.sleep(0.05)
+        await ss.release_global_slot(GROUP, external)
+
+        # The worker drains zombies in bounded batches (releasing the slot
+        # in between) and the live task still completes; no zombie ever
+        # reached the provider.
+        assert await asyncio.wait_for(live, timeout=5.0) == "live"
+        assert calls == ["live"]
+    finally:
+        await wrapped.shutdown(graceful=False)
+
+
+async def test_compaction_bounds_physical_queue_and_keeps_join_working(monkeypatch):
+    _init({GROUP: 1})
+
+    async def acquire_always_fails(_group):
+        raise RuntimeError("manager down")  # permanent fail-closed
+
+    monkeypatch.setattr(ss, "try_acquire_global_slot", acquire_always_fails)
+
+    async def func(value):
+        return value
+
+    wrapped = priority_limit_async_func_call(
+        2,
+        queue_name="compaction test",
+        concurrency_group=GROUP,
+        max_queue_size=0,  # threshold = 64
+        cleanup_timeout=0.05,
+    )(func)
+    try:
+        zombies = [wrapped(f"dead{i}", _timeout=0.05) for i in range(80)]
+        results = await asyncio.gather(*zombies, return_exceptions=True)
+        assert all(isinstance(r, TimeoutError) for r in results)
+
+        stats = await wrapped.get_queue_stats()
+        assert stats["physical_queued"] == 80
+        assert stats["queued"] == 0
+
+        await wrapped.run_maintenance()  # triggers compaction
+        stats = await wrapped.get_queue_stats()
+        assert stats["physical_queued"] == 0
+
+        # task_done bookkeeping must be exact: graceful shutdown relies on
+        # queue.join() and must complete promptly (not hit the drain timeout).
+        await asyncio.wait_for(wrapped.shutdown(graceful=True, timeout=5.0), 10.0)
+    finally:
+        pass
+
+
+async def test_compaction_keeps_live_tasks(monkeypatch):
+    _init({GROUP: 1})
+    external = await ss.try_acquire_global_slot(GROUP)
+
+    async def func(value):
+        return value
+
+    wrapped = priority_limit_async_func_call(
+        2,
+        queue_name="compaction live test",
+        concurrency_group=GROUP,
+        max_queue_size=0,
+        cleanup_timeout=0.05,
+    )(func)
+    try:
+        zombies = [wrapped(f"dead{i}", _timeout=0.05) for i in range(70)]
+        await asyncio.gather(*zombies, return_exceptions=True)
+        live = asyncio.create_task(wrapped("live"))
+        await asyncio.sleep(0.05)
+
+        await wrapped.run_maintenance()
+        stats = await wrapped.get_queue_stats()
+        assert stats["queued"] == 1  # live survived compaction
+        assert stats["physical_queued"] == 1
+
+        await ss.release_global_slot(GROUP, external)
+        assert await asyncio.wait_for(live, timeout=5.0) == "live"
+    finally:
+        await wrapped.shutdown(graceful=False)
+
+
+# ---------------------------------------------------------------------------
+# Stats publishing & aggregation through the wrapper
+# ---------------------------------------------------------------------------
+
+
+async def test_aggregated_stats_schema_and_global_fields():
+    _init({GROUP: 2})
+
+    async def func(value):
+        if value == "fail":
+            raise ValueError("x")
+        return value
+
+    wrapped = priority_limit_async_func_call(
+        3, queue_name="agg schema test", concurrency_group=GROUP
+    )(func)
+    try:
+        await wrapped("a")
+        await wrapped("b")
+        with pytest.raises(ValueError):
+            await wrapped("fail")
+
+        # The worker releases its lease in a finally block right after the
+        # future resolves; wait for the release before checking in_use.
+        async def _in_use_zero():
+            return await ss.global_concurrency_in_use(GROUP) == 0
+
+        deadline = asyncio.get_event_loop().time() + 2.0
+        while not await _in_use_zero():
+            assert asyncio.get_event_loop().time() < deadline
+            await asyncio.sleep(0.01)
+
+        stats = await wrapped.get_aggregated_queue_stats()
+        # Original flat schema intact (webui/health compatibility).
+        for field in (
+            "queue_name",
+            "max_async",
+            "max_queue_size",
+            "queued",
+            "running",
+            "in_flight",
+            "worker_count",
+            "initialized",
+            "submitted_total",
+            "completed_total",
+            "failed_total",
+            "cancelled_total",
+            "rejected_total",
+        ):
+            assert field in stats
+        assert stats["completed_total"] == 2
+        assert stats["failed_total"] == 1
+        # Aggregation extras.
+        assert stats["reporting_workers"] == 1
+        assert list(stats["per_worker"])
+        assert stats["global_limit"] == 2
+        assert stats["global_in_use"] == 0
+    finally:
+        await wrapped.shutdown()
+
+
+async def test_maintenance_renews_held_leases(monkeypatch):
+    monkeypatch.setattr(ss, "_heartbeat_ttl", 0.2)
+    monkeypatch.setattr(ss, "_suspect_grace", 0.2)
+    _init({GROUP: 1})
+    release = asyncio.Event()
+    started = asyncio.Event()
+
+    async def long_func(value):
+        started.set()
+        await release.wait()
+        return value
+
+    wrapped = priority_limit_async_func_call(
+        2, queue_name="renew test", concurrency_group=GROUP
+    )(long_func)
+    try:
+        task = asyncio.create_task(wrapped("long"))
+        await started.wait()
+
+        # Run well past the heartbeat TTL, renewing like the health check.
+        for _ in range(5):
+            await asyncio.sleep(0.1)
+            await wrapped.run_maintenance()
+
+        # The legal long task's lease was never reclaimed.
+        assert await ss.global_concurrency_in_use(GROUP) == 1
+        release.set()
+        assert await task == "long"
+    finally:
+        await wrapped.shutdown()

--- a/tests/llm/test_global_concurrency_queue.py
+++ b/tests/llm/test_global_concurrency_queue.py
@@ -232,6 +232,75 @@ async def test_priority_overtakes_within_process():
 
 
 # ---------------------------------------------------------------------------
+# Slot pump: one acquirer per process, no speculative slot grabs
+# ---------------------------------------------------------------------------
+
+
+async def test_pump_acquires_only_for_live_work(monkeypatch):
+    """Idle workers must not grab slots speculatively: with one task and
+    many local workers, exactly one slot acquisition succeeds (the herd
+    used to acquire-and-release, inflating global_in_use and resetting the
+    process's waiter seniority)."""
+    _init({GROUP: 4})
+    successes = 0
+    original = ss.try_acquire_global_slot_tracked
+
+    async def counting(group):
+        nonlocal successes
+        lease, is_priority = await original(group)
+        if lease is not None:
+            successes += 1
+        return lease, is_priority
+
+    monkeypatch.setattr(ss, "try_acquire_global_slot_tracked", counting)
+
+    async def func(value):
+        return value
+
+    wrapped = lr_utils.priority_limit_async_func_call(
+        4, queue_name="pump only-live test", concurrency_group=GROUP
+    )(func)
+    try:
+        assert await wrapped("only") == "only"
+        await asyncio.sleep(0.3)  # idle period: nothing else may be acquired
+        assert successes == 1
+        assert await ss.global_concurrency_in_use(GROUP) == 0
+    finally:
+        await wrapped.shutdown()
+
+
+async def test_pump_never_holds_slots_without_free_worker():
+    """A slot is requested only when an idle local worker can run the task
+    immediately — scarce global capacity is never parked behind a busy
+    process."""
+    _init({GROUP: 4})
+    release = asyncio.Event()
+    started = asyncio.Event()
+
+    async def gated(value):
+        started.set()
+        await release.wait()
+        return value
+
+    wrapped = lr_utils.priority_limit_async_func_call(
+        1, queue_name="pump no-hoard test", concurrency_group=GROUP
+    )(gated)
+    try:
+        first = asyncio.create_task(wrapped("a"))
+        await started.wait()
+        others = [asyncio.create_task(wrapped(f"b{i}")) for i in range(3)]
+        await asyncio.sleep(0.3)
+        # Only the running task holds a slot; the queued tasks wait for the
+        # single local worker, not for global slots.
+        assert await ss.global_concurrency_in_use(GROUP) == 1
+        release.set()
+        assert await first == "a"
+        assert sorted(await asyncio.gather(*others)) == ["b0", "b1", "b2"]
+    finally:
+        await wrapped.shutdown()
+
+
+# ---------------------------------------------------------------------------
 # Admission semantics (live_queued)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
# Summary

Under gunicorn multi-worker, `priority_limit_async_func_call` enforces concurrency **per process**: with `MAX_ASYNC_LLM=4` and `--workers 4` the provider actually sees ~16 concurrent calls, and `/health` only reports whichever worker happened to answer (1/N view). This PR fixes both, reusing the existing `shared_storage` namespace + keyed-lock machinery (no Redis, no new Manager registries):

1. **MAX_ASYNC becomes a true total limit.** Under `lightrag-gunicorn --workers N`, every existing `MAX_ASYNC_*` setting (per LLM role / embedding / rerank) now acts BOTH as each worker's local limit and as a cross-worker global cap — the provider never sees more than MAX_ASYNC concurrent calls in total, exactly like single-process mode. **No new env vars**: the gunicorn master derives the per-group caps (`llm:extract` / `llm:keyword` / `llm:query` / `llm:vlm` / `embedding` / `rerank`) from the already-parsed MAX_ASYNC values before fork. Crash self-healing (lease + heartbeat + reaper) and longest-waiter-first soft fairness across workers included.
2. **Near-realtime cross-worker queue stats**: each worker publishes debounced snapshots; `/health` aggregates all workers. Existing flat field names are preserved — **zero webui changes**.

Unchanged paths: single-worker mode (`workers=1`, uvicorn or gunicorn) passes no limits — the per-process max_async already IS the total there; standalone decorator usage (no `concurrency_group`) never touches shared storage; embedded library users are unaffected.

> ⚠️ **Behavior change for existing multi-worker deployments**: effective provider concurrency drops from ~`MAX_ASYNC × workers` to `MAX_ASYNC`. This restores MAX_ASYNC's documented meaning; deployments that relied on the multiplication should raise `MAX_ASYNC_*` accordingly. Runtime caveat (**gunicorn multi-worker only**, documented in env.example): changing a role's max_async through the API rebuilds only the receiving worker's local wrapper — the cross-worker cap keeps the value read at startup, so raising it cannot push the total above the startup cap, and lowering it only shrinks that one worker's share. In single-process mode (uvicorn or `--workers 1`) there is no separate cap: the wrapper's max_size IS the global limit, and an API update rebuilds the wrapper and takes full effect immediately.

# How the global gate works

- **One slot pump per process**: a single coroutine per process acquires cross-process slots and hands `(lease, task)` pairs to executor workers — not `max_size` polling workers — dividing the cross-process poll/IPC rate by `max_size`. A slot is requested only when there is BOTH physically queued work and an idle local worker to run it immediately, so the worker herd can never grab slots it cannot use (no `global_in_use` inflation, no waiter-seniority churn from no-op acquires, and scarce global capacity is never parked behind a busy process).
- **Slot-first, drain-second**: the pump acquires a slot *before* consuming the local queue. While slots are saturated, tasks stay queued and cancellable — user timeouts/cancellations never reach the provider, local priority order is preserved (query can still overtake ingestion within a process), and execution timing starts only at dispatch, so slot waits are never misjudged as stuck tasks.
- **Single-key gate state, O(1) IPC per attempt**: each group's whole gate state (leases + waiters) lives under ONE key of the Manager-dict namespace with whole-value replacement. An acquire attempt under the group's keyed lock costs exactly one proxy read plus at most one write — a failed attempt against a healthy, saturated gate writes nothing (covered by a write-counting test). Reaping, capacity counting and waiter ranking all run on the local copy.
- **Event loop never blocks on cross-process locks**: `UnifiedLock` now acquires the Manager lock proxy through the default executor, so waiting for another process's critical section no longer freezes this worker's event loop (HTTP serving, heartbeats and other queues keep running). Cancellation while parked in the executor is safe: an orphaned acquisition is released by a done-callback (otherwise every process would deadlock), and the per-process async gate is rolled back (previously a `CancelledError` could leak it).
- **Leases with heartbeat self-healing**: each held slot is a lease (`pid`, `updated_at`) renewed by the existing 5s health check. Dead owners (kill -9 / OOM) are reclaimed immediately via PID probe; heartbeat-expired-but-alive owners get a suspect grace before reclamation, so a momentarily stalled event loop or transient renewal failure never falsely reclaims a live long-running task.
- **Longest-waiter-first adaptive polling (soft FIFO across workers)**: on every failed attempt the pump registers/refreshes its process's waiter record (`wait_start`, `last_poll`) inside the same critical section and learns whether it is the longest-waiting *live* poller: the favored process keeps the fastest poll interval (0.05s), everyone else backs off exponentially up to a small bounded cap (0.4s). There is **no hard gate** — any poller that finds a free slot takes it — so no head-of-line blocking, and a freed slot idles at most ~one deferred period. A successful acquire resets the winner's seniority, yielding approximate round-robin under sustained contention. Ghost-waiter guardrails: waiter records are reaped **in the same pass as leases**, stale-poll records are ignored for ranking and reaped, wrapper shutdown clears its record, and the first acquisition attempt is always immediate.
- **Fail-closed**: any shared-storage error during acquisition returns "no slot" (rate-limited warning) — capacity is never exceeded due to infrastructure failures. Failed releases are parked for health-check retry; heartbeat expiry guarantees eventual reclamation either way.
- **Logical admission instead of a bounded queue** (limited groups only): the physical queue becomes unbounded and `max_queue_size` is enforced against `live_queued` — live queued tasks only, exactly matching the bounded-queue semantics of unlimited groups (running tasks and cancelled zombies don't consume capacity, `max_queue_size<=0` = unlimited). Reservations are released exactly once (`worker_started` transfer rule). Zombie tuples are drained in bounded batches while holding a slot, and a batched health-check compaction bounds the physical queue even during prolonged fail-closed periods — with exact `task_done()` bookkeeping so `queue.join()`-based graceful shutdown never wedges (shutdown also drains undelivered dispatch entries, returning their leases). Shutdown wakes admission sleepers so no request hangs forever.

# Observability

- Counter-update points publish debounced snapshots (0.1s min interval); the 5s health check force-flushes (also keeping snapshots ahead of the 15s stale TTL).
- New `get_aggregated_queue_stats()` on wrappers: publishes a fresh local snapshot, sums all live workers' flat counters, and adds `reporting_workers` / `per_worker` / `global_limit` / `global_in_use` / `global_slot_waits` / `global_waiting_workers` / `global_longest_wait`. Any failure falls back to the local snapshot — `available` keeps meaning "wrapper exists", an idle queue can never turn unavailable.
- In limited mode `queued` = live queued count (zombies excluded); `physical_queued` exposes the raw queue length for debugging.

# Configuration

None added. Under gunicorn multi-worker the existing settings double as the cross-worker totals:

```
EXTRACT_MAX_ASYNC_LLM / KEYWORD_… / QUERY_… / VLM_…  (fallback: MAX_ASYNC_LLM)   # llm:{role}
EMBEDDING_FUNC_MAX_ASYNC                                                          # embedding
MAX_ASYNC_RERANK                                                                  # rerank
```

`lightrag-gunicorn` assembles these into `initialize_share_data(workers, global_concurrency_limits=...)` in the master before fork (read-only module config inherited by workers; the library-internal no-arg `initialize_share_data()` call hits the already-initialized guard and never overwrites it). env.example documents the new semantics, the self-healing behavior, the admission-counting rule, and the runtime-update caveat.

# What's changed

- `lightrag/kg/shared_storage.py`: single-key per-group gate state (`{"leases": ..., "waiters": ...}`, whole-value replacement; write-only-when-changed); `try_acquire_global_slot` / `try_acquire_global_slot_tracked` / `release_global_slot` / `renew_global_slots` / `reconcile_global_slots` / `global_concurrency_in_use` / `clear_slot_waiter` / `global_slot_waiters`; `publish/unpublish/aggregate_queue_stats` (stale reaping re-checks `updated_at` under the internal lock); sync `is_global_concurrency_limited` (no IPC). `UnifiedLock`: executor-offloaded mp acquire with cancellation safety (orphaned-acquire release + async-gate rollback on `CancelledError`).
- `lightrag/utils.py`: `concurrency_group` parameter; mode resolved once at first `ensure_workers()` with lazy queue creation; `slot_pump` (single per-process acquirer: slot-first + bounded zombie drain + waiter-rank-driven adaptive backoff + idle-worker gating) dispatching to `limited_worker` executors; reservation-based admission; per-tick maintenance (renew / pending-release retry / reconcile / compaction / stats flush, each failure-isolated, exposed as `run_maintenance`); `get_aggregated_queue_stats`.
- `lightrag/llm_roles.py`: roles pass `concurrency_group="llm:{role}"`; queue status methods prefer the aggregated view with local fallback.
- `lightrag/lightrag.py`: embedding/rerank wrappers pass their group names.
- `lightrag/api/run_with_gunicorn.py`: derives the global limits from MAX_ASYNC (multi-worker only).
- `lightrag/constants.py`, `env.example`: gate tuning defaults + docs.

# Tests

45 offline tests (single-process shared storage exercises the same logical code paths as multi-worker):

- `tests/kg/test_global_concurrency_slots.py` (23): limit config first-init/no-overwrite/finalize-reset; acquire-to-capacity/release/idempotency/group isolation; dead-PID immediate reclaim; heartbeat-expiry suspect grace (live PID never falsely reclaimed; renewal clears suspect; no resurrection); fail-closed acquire; **zero-write contract for failed attempts on an unchanged gate**; waiter tracking (register on failure / clear on success, longest-live-waiter ranking, stale-poll records ignored and reaped, waiter records cleaned in the same reap pass as their process's timed-out lease, plain acquire never registers); stats aggregation sums/schema, dead-PID + stale reaping, unpublish.
- `tests/llm/test_global_concurrency_queue.py` (22): in-flight peak ≤ global limit (incl. two wrappers sharing one gate); unconfigured group keeps original path with acquire-never-called mock assertion; standalone (`group=None`) never touches shared storage; **pump acquires exactly once for a single task regardless of worker count**; **no slot hoarding while all local workers are busy**; user timeout during slot wait never calls the provider; in-process priority overtake; admission counts only live queued tasks; zombies don't consume admission capacity nor reach the provider; shutdown wakes admission sleepers and clears the waiter record; fail-closed acquire holds tasks until recovery; release failure preserves the original result/exception and retries via maintenance; stats failures never break calls; bounded zombie drain; compaction bounds the physical queue and `queue.join()` shutdown completes promptly; aggregated stats schema + global fields; long tasks survive past heartbeat TTL via renewal.

Multiprocess-path verification (real Manager, which single-process tests cannot exercise): executor-offloaded lock stays responsive under contention, 10 consecutive cancellations never poison the lock, and an end-to-end pump run over Manager-backed storage holds peak ≤ limit with all leases returned.

Full suite: **1640 passed**; the remaining failures/collection errors are pre-existing environment issues (tiktoken BPE download blocked by the sandbox network policy, webui asset 307s, missing optional backend deps) and are **byte-for-byte identical to the failure set on the base commit**. `ruff check` and `ruff format` are clean.

# Out of scope (matching the design plan)

- Redis / multi-machine coordination (single host only).
- Strict cross-process FIFO/priority ordering (the longest-waiter bias is soft — bounded unfairness by design; priority applies strictly within each process's queue).
- Strong consistency for aggregated stats (debounced snapshots, ≤ ~0.1s + heartbeat lag; the responding worker's own entry is always fresh).
- A global-limit entry point for embedded (non-API) library users.
- Propagating runtime max_async updates to the cross-worker cap under gunicorn multi-worker (startup value wins; documented — single-process mode is fully dynamic).

https://claude.ai/code/session_017rbHanRTbEVv3Rt2X6gTMz
https://claude.ai/code/session_01Tdaqf3H4T6d9JqFytDveor