### PR TITLE
Fix Qdrant/PostgreSQL resurrecting cleared data: clear workspace's legacy rows on drop

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -3107,6 +3107,18 @@ def create_document_routes(
                     errors.append(error_msg)
                     logger.error(error_msg)
                     storage_error_count += 1
+                elif isinstance(result, dict) and result.get("status") != "success":
+                    # drop() reports a non-raising failure as {"status": "error"}
+                    # (e.g. a backend that could not safely clear a kept legacy
+                    # store). Honor it so the clear is not counted as successful
+                    # while stale data remains and could be re-migrated/resurface.
+                    error_msg = (
+                        f"Error dropping {storage_name}: "
+                        f"{result.get('message', 'unknown error')}"
+                    )
+                    errors.append(error_msg)
+                    logger.error(error_msg)
+                    storage_error_count += 1
                 else:
                     namespace = storages[i].namespace
                     workspace = storages[i].workspace

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -4684,6 +4684,17 @@ class PGVectorStorage(BaseVectorStorage):
         upserts/deletes against rows that are about to disappear are
         meaningless).
 
+        The same workspace-scoped delete is also issued against the kept
+        legacy table (the un-suffixed table that the model-suffix
+        migration leaves behind as a backup), when it still exists. The
+        legacy->suffixed migration only runs while the suffixed table has
+        no rows for the workspace; if a deliberate clear left this
+        workspace's data behind in legacy, the next startup would migrate
+        it back into the freshly-emptied suffixed table (resurrection).
+        Only this workspace's legacy rows are removed, so other
+        workspaces' legacy data and their pending one-time migration stay
+        intact.
+
         Concurrency contract:
             ``_flush_lock`` guards same-process flush / upsert / delete
             races only. Cross-worker buffered writes are NOT covered —
@@ -4714,6 +4725,22 @@ class PGVectorStorage(BaseVectorStorage):
                     table_name=self.table_name
                 )
                 await self.db.execute(drop_sql, {"workspace": self.workspace})
+
+                # Also clear this workspace's rows from the kept legacy table so
+                # the next startup does not re-migrate the just-cleared data
+                # back into the suffixed table. Skip when there is no separate
+                # legacy table (no model suffix) or it no longer exists.
+                if (
+                    self.legacy_table_name
+                    and self.legacy_table_name.lower() != self.table_name.lower()
+                    and await self.db.check_table_exists(self.legacy_table_name)
+                ):
+                    legacy_drop_sql = SQL_TEMPLATES[
+                        "drop_specifiy_table_workspace"
+                    ].format(table_name=self.legacy_table_name)
+                    await self.db.execute(
+                        legacy_drop_sql, {"workspace": self.workspace}
+                    )
             return {"status": "success", "message": "data dropped"}
         except Exception as e:
             logger.error(

--- a/lightrag/kg/qdrant_impl.py
+++ b/lightrag/kg/qdrant_impl.py
@@ -126,6 +126,36 @@ def _find_legacy_collection(
     return None
 
 
+def _legacy_collection_has_workspace_field(
+    client: QdrantClient, collection_name: str
+) -> bool:
+    """Return True when the legacy collection tags its points with workspace_id.
+
+    Mirrors the detection in ``setup_collection``: trust the payload schema for
+    indexed fields, otherwise sample a few points (payload_schema only reflects
+    INDEXED fields). When workspace_id is absent the legacy data is untagged
+    (pre-isolation), so ``setup_collection`` migrates ALL of it with no
+    workspace filter — a workspace-filtered delete would miss those points.
+    """
+    try:
+        legacy_info = client.get_collection(collection_name)
+    except Exception:
+        return False
+
+    if WORKSPACE_ID_FIELD in (legacy_info.payload_schema or {}):
+        return True
+
+    sample_points, _ = client.scroll(
+        collection_name=collection_name,
+        limit=10,
+        with_payload=True,
+        with_vectors=False,
+    )
+    return any(
+        point.payload and WORKSPACE_ID_FIELD in point.payload for point in sample_points
+    )
+
+
 @final
 @dataclass
 class QdrantVectorDBStorage(BaseVectorStorage):
@@ -1344,7 +1374,7 @@ class QdrantVectorDBStorage(BaseVectorStorage):
                     wait=True,
                 )
 
-                # Also clear this workspace's points from the kept legacy
+                # Also clear this workspace's data from the kept legacy
                 # collection so the next startup does not re-migrate the
                 # just-cleared data back into the suffixed collection.
                 legacy_collection = _find_legacy_collection(
@@ -1354,11 +1384,28 @@ class QdrantVectorDBStorage(BaseVectorStorage):
                     self.model_suffix,
                 )
                 if legacy_collection and legacy_collection != self.final_namespace:
-                    self._client.delete(
-                        collection_name=legacy_collection,
-                        points_selector=workspace_selector,
-                        wait=True,
-                    )
+                    if _legacy_collection_has_workspace_field(
+                        self._client, legacy_collection
+                    ):
+                        # Workspace-tagged legacy: remove only this workspace's points.
+                        self._client.delete(
+                            collection_name=legacy_collection,
+                            points_selector=workspace_selector,
+                            wait=True,
+                        )
+                    else:
+                        # Untagged (pre-isolation) legacy: setup_collection migrates
+                        # ALL of its points into this workspace with no workspace
+                        # filter, so a workspace-filtered delete would miss them.
+                        # Drop the whole legacy collection to remove the migration
+                        # source.
+                        self._client.delete_collection(
+                            collection_name=legacy_collection
+                        )
+                        logger.info(
+                            f"[{self.workspace}] Dropped untagged legacy Qdrant collection "
+                            f"'{legacy_collection}' on workspace clear"
+                        )
 
             logger.info(
                 f"[{self.workspace}] Process {os.getpid()} dropped workspace data from Qdrant collection {self.namespace}"

--- a/lightrag/kg/qdrant_impl.py
+++ b/lightrag/kg/qdrant_impl.py
@@ -128,29 +128,39 @@ def _find_legacy_collection(
 
 def _legacy_collection_has_workspace_field(
     client: QdrantClient, collection_name: str
-) -> bool:
-    """Return True when the legacy collection tags its points with workspace_id.
+) -> bool | None:
+    """Return whether the legacy collection tags its points with workspace_id.
 
     Mirrors the detection in ``setup_collection``: trust the payload schema for
     indexed fields, otherwise sample a few points (payload_schema only reflects
-    INDEXED fields). When workspace_id is absent the legacy data is untagged
-    (pre-isolation), so ``setup_collection`` migrates ALL of it with no
-    workspace filter — a workspace-filtered delete would miss those points.
+    INDEXED fields).
+
+    Returns:
+        ``True``  - workspace_id present (workspace-tagged legacy).
+        ``False`` - confidently absent (untagged, pre-isolation legacy):
+                    ``setup_collection`` migrates ALL of it with no workspace
+                    filter, so the whole collection is the migration source.
+        ``None``  - tagging could not be determined (metadata / scroll error).
+                    Callers MUST NOT treat this as untagged: dropping an
+                    actually-tagged, shared legacy collection would delete other
+                    workspaces' migration source.
     """
     try:
         legacy_info = client.get_collection(collection_name)
-    except Exception:
-        return False
-
-    if WORKSPACE_ID_FIELD in (legacy_info.payload_schema or {}):
-        return True
-
-    sample_points, _ = client.scroll(
-        collection_name=collection_name,
-        limit=10,
-        with_payload=True,
-        with_vectors=False,
-    )
+        if WORKSPACE_ID_FIELD in (legacy_info.payload_schema or {}):
+            return True
+        sample_points, _ = client.scroll(
+            collection_name=collection_name,
+            limit=10,
+            with_payload=True,
+            with_vectors=False,
+        )
+    except Exception as e:
+        logger.warning(
+            f"Qdrant: could not determine workspace tagging of legacy collection "
+            f"'{collection_name}': {e}"
+        )
+        return None
     return any(
         point.payload and WORKSPACE_ID_FIELD in point.payload for point in sample_points
     )
@@ -1384,9 +1394,20 @@ class QdrantVectorDBStorage(BaseVectorStorage):
                     self.model_suffix,
                 )
                 if legacy_collection and legacy_collection != self.final_namespace:
-                    if _legacy_collection_has_workspace_field(
+                    legacy_has_workspace = _legacy_collection_has_workspace_field(
                         self._client, legacy_collection
-                    ):
+                    )
+                    if legacy_has_workspace is None:
+                        # Tagging undetermined (transient metadata / scroll error):
+                        # skip legacy cleanup rather than risk dropping an
+                        # actually-tagged, shared legacy collection and deleting
+                        # other workspaces' migration source.
+                        logger.warning(
+                            f"[{self.workspace}] Skipped legacy collection "
+                            f"'{legacy_collection}' cleanup on workspace clear: "
+                            f"workspace tagging could not be determined"
+                        )
+                    elif legacy_has_workspace:
                         # Workspace-tagged legacy: remove only this workspace's points.
                         self._client.delete(
                             collection_name=legacy_collection,

--- a/lightrag/kg/qdrant_impl.py
+++ b/lightrag/kg/qdrant_impl.py
@@ -1399,13 +1399,19 @@ class QdrantVectorDBStorage(BaseVectorStorage):
                     )
                     if legacy_has_workspace is None:
                         # Tagging undetermined (transient metadata / scroll error):
-                        # skip legacy cleanup rather than risk dropping an
-                        # actually-tagged, shared legacy collection and deleting
-                        # other workspaces' migration source.
-                        logger.warning(
-                            f"[{self.workspace}] Skipped legacy collection "
-                            f"'{legacy_collection}' cleanup on workspace clear: "
-                            f"workspace tagging could not be determined"
+                        # do NOT drop the collection (it may be an actually-tagged,
+                        # shared legacy and we'd delete other workspaces' migration
+                        # source). But the legacy data is left untouched, so the
+                        # next startup would re-migrate this workspace's cleared
+                        # points back — the clear is NOT durable. Abort with an
+                        # error so the caller can retry instead of reporting a
+                        # success that does not survive a restart.
+                        raise RuntimeError(
+                            f"Could not determine workspace tagging of legacy "
+                            f"collection '{legacy_collection}'; aborting clear of "
+                            f"'{self.namespace}' to avoid leaving stale legacy data "
+                            f"that would resurrect on restart. Retry once Qdrant "
+                            f"metadata is reachable."
                         )
                     elif legacy_has_workspace:
                         # Workspace-tagged legacy: remove only this workspace's points.

--- a/lightrag/kg/qdrant_impl.py
+++ b/lightrag/kg/qdrant_impl.py
@@ -1289,6 +1289,17 @@ class QdrantVectorDBStorage(BaseVectorStorage):
         index are NOT recreated — they were provisioned at
         ``initialize()`` and remain in place.
 
+        The same workspace-scoped delete is also issued against the kept
+        legacy collection (the un-suffixed collection that the model-suffix
+        migration leaves behind as a backup), when one is found. The
+        legacy->suffixed migration only runs while the suffixed collection
+        has no points for the workspace; if a deliberate clear left this
+        workspace's data behind in legacy, the next startup would migrate
+        it back into the freshly-emptied suffixed collection (resurrection).
+        Only this workspace's legacy points are removed, so other
+        workspaces' legacy data and their pending one-time migration stay
+        intact.
+
         MUST only be called when ``pipeline_status`` is idle (see the
         Pipeline concurrency contract in ``AGENTS.md``); the only
         in-tree caller ``clear_documents`` enforces this.
@@ -1322,15 +1333,32 @@ class QdrantVectorDBStorage(BaseVectorStorage):
                 self._pending_vector_deletes.clear()
 
                 # Delete all points for the current workspace
+                workspace_selector = models.FilterSelector(
+                    filter=models.Filter(
+                        must=[workspace_filter_condition(self.effective_workspace)]
+                    )
+                )
                 self._client.delete(
                     collection_name=self.final_namespace,
-                    points_selector=models.FilterSelector(
-                        filter=models.Filter(
-                            must=[workspace_filter_condition(self.effective_workspace)]
-                        )
-                    ),
+                    points_selector=workspace_selector,
                     wait=True,
                 )
+
+                # Also clear this workspace's points from the kept legacy
+                # collection so the next startup does not re-migrate the
+                # just-cleared data back into the suffixed collection.
+                legacy_collection = _find_legacy_collection(
+                    self._client,
+                    self.namespace,
+                    self.effective_workspace,
+                    self.model_suffix,
+                )
+                if legacy_collection and legacy_collection != self.final_namespace:
+                    self._client.delete(
+                        collection_name=legacy_collection,
+                        points_selector=workspace_selector,
+                        wait=True,
+                    )
 
             logger.info(
                 f"[{self.workspace}] Process {os.getpid()} dropped workspace data from Qdrant collection {self.namespace}"

--- a/tests/api/routes/test_document_routes_docx_archive.py
+++ b/tests/api/routes/test_document_routes_docx_archive.py
@@ -2092,3 +2092,84 @@ def test_third_party_engine_suffixes_join_allowlist_and_scan(tmp_path, monkeypat
     finally:
         registry._REGISTRY.pop("fooengine", None)
     assert not dm.is_supported_file("sample.foo")
+
+
+class _DropStorage:
+    """Minimal storage stub whose drop() returns a preset result dict."""
+
+    def __init__(self, drop_result, namespace="ns", workspace="clear-test"):
+        self._drop_result = drop_result
+        self.namespace = namespace
+        self.workspace = workspace
+
+    async def drop(self):
+        return self._drop_result
+
+
+class _ClearRag:
+    """Mock LightRAG exposing the storages that clear_documents drops."""
+
+    def __init__(self, chunks_drop_result):
+        self.workspace = "clear-test"
+        ok = {"status": "success", "message": "data dropped"}
+        self.text_chunks = _DropStorage(ok, "text_chunks")
+        self.full_docs = _DropStorage(ok, "full_docs")
+        self.full_entities = _DropStorage(ok, "full_entities")
+        self.full_relations = _DropStorage(ok, "full_relations")
+        self.entity_chunks = _DropStorage(ok, "entity_chunks")
+        self.relation_chunks = _DropStorage(ok, "relation_chunks")
+        self.entities_vdb = _DropStorage(ok, "entities")
+        self.relationships_vdb = _DropStorage(ok, "relationships")
+        # The storage under test: drop() result is configurable.
+        self.chunks_vdb = _DropStorage(chunks_drop_result, "chunks")
+        self.chunk_entity_relation_graph = _DropStorage(ok, "graph")
+        self.doc_status = _DropStorage(ok, "doc_status")
+
+
+def _clear_endpoint(router):
+    return [
+        route.endpoint
+        for route in router.routes
+        if getattr(route, "name", "") == "clear_documents"
+    ][-1]
+
+
+async def test_clear_documents_honors_drop_error_status(tmp_path):
+    """A storage whose drop() returns {"status": "error"} (without raising) must
+    NOT be counted as a success: the clear is reported as partial_success so the
+    caller knows it is incomplete and can retry, instead of a misleading success.
+    """
+    import importlib
+
+    doc_manager = DocumentManager(str(tmp_path))
+    rag = _ClearRag(
+        chunks_drop_result={
+            "status": "error",
+            "message": "legacy tagging undetermined",
+        }
+    )
+
+    shared_storage = importlib.import_module("lightrag.kg.shared_storage")
+    await shared_storage.initialize_pipeline_status(workspace=rag.workspace)
+
+    router = create_document_routes(rag, doc_manager)
+    response = await _clear_endpoint(router)()
+
+    assert response.status == "partial_success"
+
+
+async def test_clear_documents_succeeds_when_all_drops_succeed(tmp_path):
+    """Baseline: when every storage drop() returns success the clear reports
+    success."""
+    import importlib
+
+    doc_manager = DocumentManager(str(tmp_path))
+    rag = _ClearRag(chunks_drop_result={"status": "success", "message": "data dropped"})
+
+    shared_storage = importlib.import_module("lightrag.kg.shared_storage")
+    await shared_storage.initialize_pipeline_status(workspace=rag.workspace)
+
+    router = create_document_routes(rag, doc_manager)
+    response = await _clear_endpoint(router)()
+
+    assert response.status == "success"

--- a/tests/kg/postgres_impl/test_postgres_vector_deferred.py
+++ b/tests/kg/postgres_impl/test_postgres_vector_deferred.py
@@ -86,6 +86,9 @@ def _make_storage(
     # db.execute is used by delete_entity, delete_entity_relation, drop.
     db.execute = AsyncMock(return_value=None)
     db.query = AsyncMock(return_value=[])
+    # drop() probes the legacy table to clear its workspace rows; default to
+    # "no legacy table" so unrelated tests see a single workspace delete.
+    db.check_table_exists = AsyncMock(return_value=False)
     db.workspace = "test_ws"
 
     embedding = embed or CountingEmbed()
@@ -440,6 +443,28 @@ async def test_drop_clears_buffers_and_runs_delete():
     assert storage._pending_vector_docs == {}
     assert storage._pending_vector_deletes == set()
     storage.db.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_drop_also_clears_workspace_rows_from_legacy_table():
+    """drop() must also delete this workspace's rows from the kept legacy table,
+    so a later startup does not re-migrate the cleared rows back into the
+    suffixed table (resurrection)."""
+    storage = _make_storage()
+    # Legacy table exists (kept after migration); suffixed table != legacy.
+    storage.db.check_table_exists = AsyncMock(return_value=True)
+    assert storage.legacy_table_name.lower() != storage.table_name.lower()
+
+    result = await storage.drop()
+    assert result["status"] == "success"
+
+    deleted_tables = [
+        call.args[0] for call in storage.db.execute.await_args_list if call.args
+    ]
+    # Both the active suffixed table and the legacy table are cleared for the
+    # workspace.
+    assert any(storage.table_name in sql for sql in deleted_tables)
+    assert any(storage.legacy_table_name in sql for sql in deleted_tables)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/kg/qdrant_impl/test_qdrant_deferred_embedding.py
+++ b/tests/kg/qdrant_impl/test_qdrant_deferred_embedding.py
@@ -416,17 +416,19 @@ async def test_drop_clears_pending_buffers():
 
 
 @pytest.mark.asyncio
-async def test_drop_also_clears_workspace_points_from_legacy_collection():
-    """drop() must also delete this workspace's points from the kept legacy
-    collection, so a later startup does not re-migrate the cleared data back
-    into the suffixed collection (resurrection)."""
+async def test_drop_clears_workspace_points_from_workspace_tagged_legacy():
+    """drop() removes only this workspace's points from a workspace-tagged legacy
+    collection, so the next startup does not re-migrate the cleared data back."""
     embed = CountingEmbeddingFunc()
     s = _make_storage(embed)
     legacy_collection = f"lightrag_vdb_{s.namespace}"
-    # Legacy collection exists (kept after migration); new suffixed != legacy.
     s._client.collection_exists = MagicMock(
         side_effect=lambda name: name == legacy_collection
     )
+    # Legacy is workspace-tagged: workspace_id present in the payload schema.
+    legacy_info = MagicMock()
+    legacy_info.payload_schema = {"workspace_id": MagicMock()}
+    s._client.get_collection = MagicMock(return_value=legacy_info)
 
     result = await s.drop()
     assert result["status"] == "success"
@@ -434,9 +436,41 @@ async def test_drop_also_clears_workspace_points_from_legacy_collection():
     deleted_collections = [
         call.kwargs.get("collection_name") for call in s._client.delete.call_args_list
     ]
-    # Both the active suffixed collection and the legacy collection are cleared.
+    # Both the active suffixed collection and the legacy collection are cleared
+    # via a workspace-filtered delete; the legacy collection itself is kept.
     assert s.final_namespace in deleted_collections
     assert legacy_collection in deleted_collections
+    s._client.delete_collection.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_drop_drops_untagged_legacy_collection():
+    """For an untagged (pre-isolation) legacy collection, setup_collection would
+    migrate ALL of its points back with no workspace filter, so a filtered delete
+    misses them. drop() must drop the whole legacy collection instead."""
+    embed = CountingEmbeddingFunc()
+    s = _make_storage(embed)
+    legacy_collection = f"lightrag_vdb_{s.namespace}"
+    s._client.collection_exists = MagicMock(
+        side_effect=lambda name: name == legacy_collection
+    )
+    # Legacy is untagged: no workspace_id in schema and none in sampled payloads.
+    legacy_info = MagicMock()
+    legacy_info.payload_schema = {}
+    s._client.get_collection = MagicMock(return_value=legacy_info)
+    s._client.scroll = MagicMock(return_value=([], None))
+
+    result = await s.drop()
+    assert result["status"] == "success"
+
+    # The whole untagged legacy collection is dropped (not a filtered delete).
+    s._client.delete_collection.assert_called_once_with(
+        collection_name=legacy_collection
+    )
+    filtered_deletes = [
+        call.kwargs.get("collection_name") for call in s._client.delete.call_args_list
+    ]
+    assert legacy_collection not in filtered_deletes
 
 
 @pytest.mark.offline

--- a/tests/kg/qdrant_impl/test_qdrant_deferred_embedding.py
+++ b/tests/kg/qdrant_impl/test_qdrant_deferred_embedding.py
@@ -473,6 +473,34 @@ async def test_drop_drops_untagged_legacy_collection():
     assert legacy_collection not in filtered_deletes
 
 
+@pytest.mark.asyncio
+async def test_drop_skips_legacy_cleanup_when_tagging_undetermined():
+    """If the legacy collection's workspace tagging cannot be determined (a
+    transient metadata error), drop() must skip legacy cleanup rather than drop
+    the whole collection — that could delete other workspaces' migration source
+    from an actually-tagged, shared legacy collection."""
+    embed = CountingEmbeddingFunc()
+    s = _make_storage(embed)
+    legacy_collection = f"lightrag_vdb_{s.namespace}"
+    s._client.collection_exists = MagicMock(
+        side_effect=lambda name: name == legacy_collection
+    )
+    # Metadata lookup fails -> tagging undetermined.
+    s._client.get_collection = MagicMock(side_effect=RuntimeError("qdrant unavailable"))
+
+    result = await s.drop()
+    assert result["status"] == "success"
+
+    # The suffixed collection is still cleared, but legacy is left untouched:
+    # neither a filtered delete nor a whole-collection drop.
+    deleted_collections = [
+        call.kwargs.get("collection_name") for call in s._client.delete.call_args_list
+    ]
+    assert s.final_namespace in deleted_collections
+    assert legacy_collection not in deleted_collections
+    s._client.delete_collection.assert_not_called()
+
+
 @pytest.mark.offline
 @pytest.mark.asyncio
 async def test_drop_pending_index_ops_clears_buffers():

--- a/tests/kg/qdrant_impl/test_qdrant_deferred_embedding.py
+++ b/tests/kg/qdrant_impl/test_qdrant_deferred_embedding.py
@@ -474,11 +474,12 @@ async def test_drop_drops_untagged_legacy_collection():
 
 
 @pytest.mark.asyncio
-async def test_drop_skips_legacy_cleanup_when_tagging_undetermined():
+async def test_drop_reports_error_when_legacy_tagging_undetermined():
     """If the legacy collection's workspace tagging cannot be determined (a
-    transient metadata error), drop() must skip legacy cleanup rather than drop
-    the whole collection — that could delete other workspaces' migration source
-    from an actually-tagged, shared legacy collection."""
+    transient metadata error), drop() must NOT drop the whole collection (that
+    could delete other workspaces' migration source) AND must report an error:
+    leaving legacy untouched means the clear would not survive a restart, so the
+    caller must be able to retry instead of seeing a misleading success."""
     embed = CountingEmbeddingFunc()
     s = _make_storage(embed)
     legacy_collection = f"lightrag_vdb_{s.namespace}"
@@ -489,15 +490,14 @@ async def test_drop_skips_legacy_cleanup_when_tagging_undetermined():
     s._client.get_collection = MagicMock(side_effect=RuntimeError("qdrant unavailable"))
 
     result = await s.drop()
-    assert result["status"] == "success"
+    # The clear is reported as incomplete so it can be retried.
+    assert result["status"] == "error"
 
-    # The suffixed collection is still cleared, but legacy is left untouched:
-    # neither a filtered delete nor a whole-collection drop.
-    deleted_collections = [
+    # Legacy is left untouched: neither a filtered delete nor a collection drop.
+    legacy_deletes = [
         call.kwargs.get("collection_name") for call in s._client.delete.call_args_list
     ]
-    assert s.final_namespace in deleted_collections
-    assert legacy_collection not in deleted_collections
+    assert legacy_collection not in legacy_deletes
     s._client.delete_collection.assert_not_called()
 
 

--- a/tests/kg/qdrant_impl/test_qdrant_deferred_embedding.py
+++ b/tests/kg/qdrant_impl/test_qdrant_deferred_embedding.py
@@ -92,6 +92,7 @@ def _make_storage(
     storage.workspace = workspace
     storage.namespace = namespace
     storage.effective_workspace = workspace
+    storage.model_suffix = "mock"
     storage.final_namespace = f"lightrag_vdb_{namespace}_mock"
     storage.meta_fields = meta_fields
     storage.embedding_func = embed_func
@@ -105,6 +106,9 @@ def _make_storage(
     storage._client = MagicMock()
     storage._client.upsert = MagicMock()
     storage._client.delete = MagicMock()
+    # drop() looks up a legacy collection to clear its workspace points;
+    # default to "no legacy collection" so unrelated tests are unaffected.
+    storage._client.collection_exists = MagicMock(return_value=False)
     storage._client.retrieve = MagicMock(return_value=[])
     storage._client.scroll = MagicMock(return_value=([], None))
 
@@ -409,6 +413,30 @@ async def test_drop_clears_pending_buffers():
     assert result["status"] == "success"
     assert s._pending_vector_docs == {}
     assert s._pending_vector_deletes == set()
+
+
+@pytest.mark.asyncio
+async def test_drop_also_clears_workspace_points_from_legacy_collection():
+    """drop() must also delete this workspace's points from the kept legacy
+    collection, so a later startup does not re-migrate the cleared data back
+    into the suffixed collection (resurrection)."""
+    embed = CountingEmbeddingFunc()
+    s = _make_storage(embed)
+    legacy_collection = f"lightrag_vdb_{s.namespace}"
+    # Legacy collection exists (kept after migration); new suffixed != legacy.
+    s._client.collection_exists = MagicMock(
+        side_effect=lambda name: name == legacy_collection
+    )
+
+    result = await s.drop()
+    assert result["status"] == "success"
+
+    deleted_collections = [
+        call.kwargs.get("collection_name") for call in s._client.delete.call_args_list
+    ]
+    # Both the active suffixed collection and the legacy collection are cleared.
+    assert s.final_namespace in deleted_collections
+    assert legacy_collection in deleted_collections
 
 
 @pytest.mark.offline


### PR DESCRIPTION
## What

When a workspace is cleared (`clear_documents()` / `drop()`), also remove that workspace's rows/points from the **kept legacy** collection/table in **Qdrant** and **PostgreSQL**, so a later restart does not re-migrate the cleared data back.

## Why

Both backends name the vector collection/table with an embedding-model suffix and migrate data from the legacy (un-suffixed) collection/table on first setup, **keeping** the legacy store as a backup for manual deletion after verification.

The suffixed collection/table is **shared across workspaces** (isolated by the `workspace_id` payload in Qdrant / the `workspace` column in PostgreSQL — the name itself contains no workspace), and `drop()` only deletes the current workspace's rows/points while keeping both the suffixed store and the legacy backup.

The migration only runs while the suffixed store has **no rows for the workspace** and legacy still holds them. So this sequence **resurrects cleared data**:

1. Upgrade migrates the workspace's data legacy → suffixed (legacy kept).
2. `clear_documents()` empties that workspace in the suffixed store.
3. Restart → `initialize()` → `setup_collection`/`setup_table` sees "workspace empty in new + data in legacy" → migrates the cleared data **back**.

This only affects deployments upgraded from the pre-suffix naming whose legacy store has not yet been manually deleted, but in that window `clear` does not survive a restart.

This is the same root cause as the Milvus issue found while reviewing #3228, but a **different trigger**: Milvus re-migrated inside `drop()` itself; here it is the next `initialize()` after a clear.

## How

Fix at the **`drop()`** layer, not in the migration logic.

> The migration logic must stay as-is: gating it on "the suffixed store exists" was rejected, because Qdrant/PostgreSQL create the suffixed collection/table **before** copying rows (unlike Milvus, which renames a fully-populated temp collection into place). If a first-time migration crashed after the table/collection was created but before any rows were inserted, an existence check would permanently skip the retry and leave the workspace empty. So existence is **not** a reliable "migration done" marker for these backends.

Instead, `drop()` now also issues the same workspace-scoped delete against the kept legacy collection/table when it still exists:

- **Qdrant** (`QdrantVectorDBStorage.drop`): after deleting the workspace's points from `final_namespace`, look up the legacy collection (`_find_legacy_collection`) and, if found and distinct:
  - if it tags points with `workspace_id` → delete only this workspace's points;
  - if it is **untagged** (pre-isolation schema with no `workspace_id`) → drop the whole legacy collection. `setup_collection` migrates such untagged legacy collections with **no** workspace filter (detected by sampling payloads), so a workspace-filtered delete would match zero points and the untagged data would be resurrected on restart. Detection mirrors `setup_collection` via the new `_legacy_collection_has_workspace_field` helper.
- **PostgreSQL** (`PGVectorStorage.drop`): after `DELETE ... WHERE workspace=$1` on the suffixed table, run the same delete on `legacy_table_name` when it exists and differs from the suffixed table. (PostgreSQL legacy tables always carry a `workspace` column, so the filtered delete is always sufficient — no untagged case.)

Only the current workspace's legacy rows/points are removed, so:
- other workspaces' legacy data and their pending **one-time** migration stay intact;
- a first-time migration that crashed mid-way still retries on the next startup (it never went through `drop()`);
- after a deliberate clear, the workspace has no data left in either store, so nothing is migrated back.

`setup_collection` / `setup_table` (the migration logic) are **unchanged**.

## Tests

`python -m pytest tests/kg -q` → all green (offline, mocked clients; no live DB/Qdrant).

- **Qdrant** — `test_drop_clears_workspace_points_from_workspace_tagged_legacy` (filtered delete from a tagged legacy) and `test_drop_drops_untagged_legacy_collection` (whole-collection drop for an untagged legacy).
- **PostgreSQL** — `test_drop_also_clears_workspace_rows_from_legacy_table`: drop() runs the workspace-scoped delete against both the suffixed and the legacy table.
- Extend the deferred-embedding drop fixtures with the new legacy-lookup mocks, defaulting to "no legacy store" so unrelated tests still observe a single delete.

## Verification (manual, upgraded deployment)

1. First startup migrates legacy → suffixed; confirm the suffixed store has data.
2. `clear_documents()` empties a workspace.
3. Restart → logs show **no** "Migrating data from legacy", and the workspace stays empty (not resurrected).
4. Other workspaces still migrate on first touch; a migration interrupted before inserting rows still retries.
