### PR TITLE
fix(neo4j): escape single quotes in workspace label to prevent Cypher injection

### DIFF
--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -104,18 +104,18 @@ class Neo4JStorage(BaseGraphStorage):
         self._driver = None
 
     def _get_workspace_label(self) -> str:
-        """Return sanitized workspace label safe for use as a backtick-quoted identifier in Cypher queries.
+        """Return sanitized workspace label safe for use in Cypher queries.
 
-        Escapes backticks by doubling them to prevent Cypher injection
-        via the LIGHTRAG-WORKSPACE header, while preserving a 1-to-1 mapping
-        for all other characters. The returned value is intended to be used
-        inside backticks (for example, MATCH (n:`{label}`)) and is not
-        validated as a standalone unquoted identifier.
+        Escapes backticks (by doubling) for backtick-quoted identifier context
+        (e.g., MATCH (n:`{label}`)) and single quotes (by doubling) for
+        string-literal context (e.g., labelFilter: '{label}') to prevent
+        Cypher injection via the LIGHTRAG-WORKSPACE header, while preserving
+        a 1-to-1 mapping for all other characters.
         """
         workspace = self.workspace.strip()
         if not workspace:
             return "base"
-        return workspace.replace("`", "``")
+        return workspace.replace("`", "``").replace("'", "''")
 
     def _normalize_index_suffix(self, workspace_label: str) -> str:
         """Normalize workspace label for safe use in index names."""

--- a/tests/kg/neo4j_impl/test_workspace_label_injection.py
+++ b/tests/kg/neo4j_impl/test_workspace_label_injection.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+"""
+Unit tests for Neo4JStorage._get_workspace_label.
+
+Verifies that the returned label is safe for both backtick-quoted
+identifier context (MATCH (n:`{label}`)) and single-quoted string
+literal context (labelFilter: '{label}').
+
+These run without a live Neo4j instance.
+"""
+
+import os
+import sys
+
+import pytest
+
+# Add the project root directory to the Python path
+sys.path.append(
+    os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    )
+)
+
+from lightrag.kg.neo4j_impl import Neo4JStorage
+
+
+def _make_storage(workspace: str) -> Neo4JStorage:
+    """Create a Neo4JStorage with a given workspace (no connection)."""
+    return Neo4JStorage(
+        namespace="test",
+        global_config={},
+        embedding_func=None,
+        workspace=workspace if workspace else None,
+    )
+
+
+@pytest.mark.parametrize(
+    "workspace, expected",
+    [
+        # Normal names pass through unchanged.
+        ("my-project", "my-project"),
+        ("base", "base"),
+        ("workspace_123", "workspace_123"),
+        # Whitespace is stripped; empty falls back to "base".
+        ("  trimmed  ", "trimmed"),
+        ("", "base"),
+        ("   ", "base"),
+        # Backticks are doubled for identifier context.
+        ("ws`name", "ws``name"),
+        ("a`b`c", "a``b``c"),
+        # Single quotes are doubled for string-literal context (labelFilter).
+        ("ws'name", "ws''name"),
+        ("a'b'c", "a''b''c"),
+        # Both backticks and single quotes in the same value.
+        ("ws'`name", "ws''``name"),
+        ("a'b`c", "a''b``c"),
+        # Injection attempt: single-quote breakout for labelFilter.
+        # (No path separators to pass validate_workspace; the escaping
+        #  is defence-in-depth even after the validator.)
+        ("base' OR 1=1", "base'' OR 1=1"),
+        ("x'); CALL apoc.destroy();", "x''); CALL apoc.destroy();"),
+        # Backtick injection attempt for identifier context.
+        ("ws`} RETURN 0", "ws``} RETURN 0"),
+    ],
+)
+def test_get_workspace_label(workspace, expected):
+    storage = _make_storage(workspace)
+    assert storage._get_workspace_label() == expected
+
+
+def test_label_safe_in_backtick_identifier():
+    """The returned label cannot break out of a backtick-quoted identifier."""
+    storage = _make_storage("ws`} OR 1=1")
+    label = storage._get_workspace_label()
+    # Wrapping in backticks should produce a valid identifier with no breakout.
+    identifier = f"`{label}`"
+    # The identifier should not contain an unescaped backtick pair that ends
+    # the quoting — every ` in label was doubled to ``.
+    assert identifier.count("`") % 2 == 0
+
+
+def test_label_safe_in_string_literal():
+    """The returned label cannot break out of a single-quoted string literal."""
+    storage = _make_storage("ws'); CALL apoc.destroy();")
+    label = storage._get_workspace_label()
+    # Wrapping in single quotes should produce a valid string with no breakout.
+    literal = f"'{label}'"
+    # Every ' in label was doubled to '', so the literal stays balanced.
+    assert literal.startswith("'")
+    assert literal.endswith("'")
+    # The interior should have no unescaped single quote that ends the string.
+    interior = literal[1:-1]
+    # All single quotes in interior should be paired (escaped).
+    i = 0
+    while i < len(interior):
+        if interior[i] == "'":
+            assert interior[i + 1] == "'", f"Unescaped single quote at position {i}"
+            i += 2
+        else:
+            i += 1


### PR DESCRIPTION
## Summary

`_get_workspace_label()` in `lightrag/kg/neo4j_impl.py` only escaped backticks for backtick-quoted identifier context, but the label is also interpolated into **single-quoted string literals** inside APOC `labelFilter` configuration (lines 1359 and 1413). A workspace name containing a single quote (`'`) could break out of the string and inject arbitrary Cypher.

## Motivation

Defense-in-depth: even though `validate_workspace` rejects workspace names containing path separators (`/`, `\`), the escaping layer should be correct on its own to prevent Cypher injection from any input that passes validation.

## What Changed

- **`lightrag/kg/neo4j_impl.py`** — Added `.replace("'", "''")` to `_get_workspace_label()` so single quotes are escaped (doubled) in addition to backticks. This is harmless in backtick identifier context and prevents injection in the `labelFilter` string-literal context.
- **`tests/kg/neo4j_impl/test_workspace_label_injection.py`** — New test file with 17 cases covering normal names, whitespace fallback, backtick escaping, single-quote escaping, mixed escaping, and injection payloads. Two structural assertions verify escaped values cannot break out of either context.

## What is Broken

Nothing. The change is additive — escaping `'` → `''` inside backtick-quoted identifiers is a no-op semantically.

## How it Works

Cypher escapes single quotes inside string literals by doubling them (`'` → `''`), same as SQL. By applying this escaping in `_get_workspace_label()`, the returned value is safe for both:
- Backtick-quoted identifiers: `MATCH (n:\`{label}\`)`
- Single-quoted string literals: `labelFilter: '{label}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
