### PR TITLE
fix(neo4j): bind APOC labelFilter as parameter to prevent Cypher injection

### DIFF
--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -103,6 +103,18 @@ class Neo4JStorage(BaseGraphStorage):
 
         self._driver = None
 
+    def _get_raw_workspace_label(self) -> str:
+        """Return the actual Neo4j label name for this workspace (no escaping).
+
+        This is the un-escaped label as it is stored on nodes. It is safe to
+        bind as a query parameter (for example, APOC ``labelFilter``), where
+        Neo4j handles the value without string interpolation and therefore
+        without any risk of Cypher injection. It must NOT be interpolated
+        directly into a query string.
+        """
+        workspace = self.workspace.strip()
+        return workspace if workspace else "base"
+
     def _get_workspace_label(self) -> str:
         """Return sanitized workspace label safe for use as a backtick-quoted identifier in Cypher queries.
 
@@ -111,11 +123,12 @@ class Neo4JStorage(BaseGraphStorage):
         for all other characters. The returned value is intended to be used
         inside backticks (for example, MATCH (n:`{label}`)) and is not
         validated as a standalone unquoted identifier.
+
+        For string-literal contexts (such as the APOC ``labelFilter`` config),
+        do NOT interpolate this value; bind ``_get_raw_workspace_label()`` as a
+        query parameter instead.
         """
-        workspace = self.workspace.strip()
-        if not workspace:
-            return "base"
-        return workspace.replace("`", "``")
+        return self._get_raw_workspace_label().replace("`", "``")
 
     def _normalize_index_suffix(self, workspace_label: str) -> str:
         """Normalize workspace label for safe use in index names."""
@@ -1294,6 +1307,9 @@ class Neo4JStorage(BaseGraphStorage):
             max_nodes = min(max_nodes, self.global_config.get("max_graph_nodes", 1000))
 
         workspace_label = self._get_workspace_label()
+        # Raw (un-escaped) label bound as a query parameter for APOC labelFilter,
+        # which lives inside a Cypher string literal and must not be interpolated.
+        workspace_label_raw = self._get_raw_workspace_label()
         result = KnowledgeGraph()
         seen_nodes = set()
         seen_edges = set()
@@ -1356,7 +1372,7 @@ class Neo4JStorage(BaseGraphStorage):
                     WITH start
                     CALL apoc.path.subgraphAll(start, {{
                         relationshipFilter: '',
-                        labelFilter: '{workspace_label}',
+                        labelFilter: $label_filter,
                         minLevel: 0,
                         maxLevel: $max_depth,
                         bfs: true
@@ -1376,6 +1392,7 @@ class Neo4JStorage(BaseGraphStorage):
                             {
                                 "entity_id": node_label,
                                 "max_depth": max_depth,
+                                "label_filter": workspace_label_raw,
                             },
                         )
                         full_record = await full_result.single()
@@ -1410,7 +1427,7 @@ class Neo4JStorage(BaseGraphStorage):
                             WITH start
                             CALL apoc.path.subgraphAll(start, {{
                                 relationshipFilter: '',
-                                labelFilter: '{workspace_label}',
+                                labelFilter: $label_filter,
                                 minLevel: 0,
                                 maxLevel: $max_depth,
                                 limit: $max_nodes,
@@ -1429,6 +1446,7 @@ class Neo4JStorage(BaseGraphStorage):
                                         "entity_id": node_label,
                                         "max_depth": max_depth,
                                         "max_nodes": max_nodes,
+                                        "label_filter": workspace_label_raw,
                                     },
                                 )
                                 record = await result_set.single()

--- a/tests/kg/neo4j_impl/test_workspace_label_injection.py
+++ b/tests/kg/neo4j_impl/test_workspace_label_injection.py
@@ -132,9 +132,7 @@ class _FakeSession:
         self.calls.append((query, params or {}))
         # total_nodes within limit -> the full result is used directly and the
         # truncated/limited branch is never taken (a single run call).
-        return _FakeResult(
-            {"total_nodes": 0, "node_info": [], "relationships": []}
-        )
+        return _FakeResult({"total_nodes": 0, "node_info": [], "relationships": []})
 
     async def __aenter__(self):
         return self
@@ -168,9 +166,7 @@ async def test_label_filter_is_parameterized_not_interpolated():
     await storage.get_knowledge_graph(node_label="some-entity", max_depth=2)
 
     # The subgraphAll query is the one carrying labelFilter.
-    subgraph_calls = [
-        (q, p) for q, p in session.calls if "apoc.path.subgraphAll" in q
-    ]
+    subgraph_calls = [(q, p) for q, p in session.calls if "apoc.path.subgraphAll" in q]
     assert subgraph_calls, "expected an apoc.path.subgraphAll query"
 
     for query, params in subgraph_calls:

--- a/tests/kg/neo4j_impl/test_workspace_label_injection.py
+++ b/tests/kg/neo4j_impl/test_workspace_label_injection.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python
+"""
+Unit tests guarding against Cypher injection through the workspace label.
+
+The workspace label is interpolated into two different syntactic contexts in
+``neo4j_impl.py``:
+
+1. Backtick-quoted identifiers, e.g. ``MATCH (n:`{label}`)`` — here backticks
+   must be doubled and all other characters (including single quotes) are
+   literal.
+2. The APOC ``labelFilter`` config, which lives inside a single-quoted Cypher
+   string literal. Cypher string literals are NOT escaped by doubling quotes
+   (that is SQL); they use backslash escaping. Rather than escape by hand, the
+   label is bound as a query parameter so Neo4j handles it safely.
+
+These tests run without a live Neo4j instance.
+"""
+
+import os
+import sys
+
+import pytest
+
+# Add the project root directory to the Python path
+sys.path.append(
+    os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    )
+)
+
+from lightrag.kg.neo4j_impl import Neo4JStorage
+
+
+def _make_storage(workspace: str) -> Neo4JStorage:
+    """Create a Neo4JStorage with a given workspace (no connection)."""
+    return Neo4JStorage(
+        namespace="test",
+        global_config={},
+        embedding_func=None,
+        workspace=workspace if workspace else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _get_workspace_label: backtick-identifier context
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "workspace, expected",
+    [
+        # Normal names pass through unchanged.
+        ("my-project", "my-project"),
+        ("base", "base"),
+        ("workspace_123", "workspace_123"),
+        # Whitespace is stripped; empty falls back to "base".
+        ("  trimmed  ", "trimmed"),
+        ("", "base"),
+        ("   ", "base"),
+        # Backticks are doubled for identifier context.
+        ("ws`name", "ws``name"),
+        ("a`b`c", "a``b``c"),
+        ("ws`} RETURN 0", "ws``} RETURN 0"),
+        # Single quotes are NOT touched here: inside backticks they are literal,
+        # so doubling them would corrupt the label name.
+        ("ws'name", "ws'name"),
+        ("team'a", "team'a"),
+        ("base' OR 1=1", "base' OR 1=1"),
+        # Mixed: only backticks are escaped.
+        ("ws'`name", "ws'``name"),
+    ],
+)
+def test_get_workspace_label(workspace, expected):
+    storage = _make_storage(workspace)
+    assert storage._get_workspace_label() == expected
+
+
+def test_label_safe_in_backtick_identifier():
+    """The returned label cannot break out of a backtick-quoted identifier."""
+    storage = _make_storage("ws`} OR 1=1")
+    identifier = f"`{storage._get_workspace_label()}`"
+    # Every ` in the label was doubled to ``, so the quoting stays balanced.
+    assert identifier.count("`") % 2 == 0
+
+
+# ---------------------------------------------------------------------------
+# _get_raw_workspace_label: the actual label name, bound as a parameter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "workspace, expected",
+    [
+        ("my-project", "my-project"),
+        ("  trimmed  ", "trimmed"),
+        ("", "base"),
+        ("   ", "base"),
+        # No escaping of any kind: the raw value is bound, never interpolated.
+        ("ws`name", "ws`name"),
+        ("team'a", "team'a"),
+        ("x'); CALL apoc.util.sleep(1);", "x'); CALL apoc.util.sleep(1);"),
+    ],
+)
+def test_get_raw_workspace_label(workspace, expected):
+    storage = _make_storage(workspace)
+    assert storage._get_raw_workspace_label() == expected
+
+
+# ---------------------------------------------------------------------------
+# get_knowledge_graph: labelFilter must be parameterized, never interpolated
+# ---------------------------------------------------------------------------
+
+
+class _FakeResult:
+    def __init__(self, record):
+        self._record = record
+
+    async def single(self):
+        return self._record
+
+    async def consume(self):
+        return None
+
+
+class _FakeSession:
+    """Records every (query, params) pair passed to ``run``."""
+
+    def __init__(self):
+        self.calls = []
+
+    async def run(self, query, params=None):
+        self.calls.append((query, params or {}))
+        # total_nodes within limit -> the full result is used directly and the
+        # truncated/limited branch is never taken (a single run call).
+        return _FakeResult(
+            {"total_nodes": 0, "node_info": [], "relationships": []}
+        )
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeDriver:
+    def __init__(self, session):
+        self._session = session
+
+    def session(self, **kwargs):
+        return self._session
+
+
+@pytest.mark.asyncio
+async def test_label_filter_is_parameterized_not_interpolated():
+    """A malicious workspace must reach APOC labelFilter as a bound parameter.
+
+    If the label were string-interpolated (the old behaviour), a single quote
+    would close the string literal and inject Cypher. Binding it as a parameter
+    makes interpolation — and therefore injection — impossible by construction.
+    """
+    payload = "x'); CALL apoc.util.sleep(1);"
+    storage = _make_storage(payload)
+    session = _FakeSession()
+    storage._driver = _FakeDriver(session)
+    storage._DATABASE = None
+
+    await storage.get_knowledge_graph(node_label="some-entity", max_depth=2)
+
+    # The subgraphAll query is the one carrying labelFilter.
+    subgraph_calls = [
+        (q, p) for q, p in session.calls if "apoc.path.subgraphAll" in q
+    ]
+    assert subgraph_calls, "expected an apoc.path.subgraphAll query"
+
+    for query, params in subgraph_calls:
+        # labelFilter is bound, not interpolated: there is no single-quoted
+        # string literal for the payload to break out of.
+        assert "labelFilter: $label_filter" in query
+        assert "labelFilter: '" not in query
+        # The raw (un-escaped) label is passed as the bound value.
+        assert params.get("label_filter") == payload

--- a/tests/workspace/test_workspace_sanitization.py
+++ b/tests/workspace/test_workspace_sanitization.py
@@ -35,9 +35,11 @@ def get_actual_sanitization_logic():
     for file_path in files:
         with open(file_path, "r", encoding="utf-8") as f:
             content = f.read()
-            # Find the _get_workspace_label method body
-            # We look for the specific line: return workspace.replace("`", "``")
-            match = re.search(r"return workspace\.replace\(\"`\", \"``\"\)", content)
+            # Find the _get_workspace_label method body. The backends differ in
+            # shape -- memgraph escapes ``workspace`` inline while neo4j delegates
+            # to ``_get_raw_workspace_label()`` -- but both end in a backtick-doubling
+            # ``return <expr>.replace("`", "``")`` line.
+            match = re.search(r"return .+?\.replace\(\"`\", \"``\"\)", content)
             if not match:
                 raise RuntimeError(f"Could not find sanitization logic in {file_path}")
             logics.append(file_path)


### PR DESCRIPTION
## Summary

The workspace label is interpolated into the APOC `labelFilter` **single-quoted string literal** at two `get_knowledge_graph` sites (`lightrag/kg/neo4j_impl.py`, formerly lines 1359 and 1413):

```cypher
labelFilter: '{workspace_label}',
```

A workspace name containing a single quote (e.g. `team'a`, which passes `validate_workspace` since it has no path separators) could close the string literal and inject arbitrary Cypher via the `LIGHTRAG-WORKSPACE` header.

This PR supersedes #3255, which attempted to fix the same injection point by doubling single quotes (`'` → `''`) inside the shared `_get_workspace_label()`.

## Motivation

The approach in #3255 is incorrect:

- **Cypher does not escape string literals by doubling quotes** (that is SQL). Cypher uses backslash escaping (`\'`), so `'team''a'` is not the string `team'a` — it parses as two adjacent string literals (a syntax error).
- The same value is used in **two different syntactic contexts** — backtick-quoted identifiers (`` MATCH (n:`{label}`) ``) and single-quoted string literals (`labelFilter: '{label}'`). In backtick context, single quotes are literal and must **not** be escaped; doubling them corrupts the label. A single shared escape value therefore cannot be correct in both contexts.

This matches the automated review comment on #3255 (P2), which is technically correct.

## What Changed

- **`lightrag/kg/neo4j_impl.py`**
  - Added `_get_raw_workspace_label()` returning the un-escaped label (with `strip()` + `"base"` fallback). This is the actual Neo4j label name, safe to bind as a query parameter.
  - `_get_workspace_label()` now derives its backtick-escaped form from the raw label (behaviour unchanged for backtick contexts).
  - Both `apoc.path.subgraphAll` sites now bind `labelFilter: $label_filter` instead of interpolating the label into a string literal. The same config map already binds `$max_depth`/`$max_nodes`, so parameter binding here is valid and behaviour-preserving for normal labels — and injection-proof by construction.
- **`tests/kg/neo4j_impl/test_workspace_label_injection.py`** — New tests:
  - `_get_workspace_label`: backtick escaping; single quotes preserved 1-to-1 (not doubled).
  - `_get_raw_workspace_label`: no escaping; `strip`/`base` fallback.
  - A functional test mocking the Neo4j driver to assert that for a malicious workspace the label is bound as the `label_filter` parameter and the query contains no interpolated `labelFilter: '...'` literal.

## What is Broken

Nothing. Parameter binding produces the same APOC `labelFilter` value as before for normal workspace names; only the injection vector is removed.

## How it Works

Cypher evaluates the config map (including bound parameters) before passing it to the APOC procedure, so a parameterized `labelFilter` value can never be parsed as query text. There is no string literal for a single quote to break out of, regardless of the workspace name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ep21KfAQXmMiFtLp6HBdaz)_