### PR TITLE
fix(milvus): bound data-node memory during schema migration (OOM mitigation)

### DIFF
--- a/env.example
+++ b/env.example
@@ -908,6 +908,15 @@ MILVUS_DB_NAME=lightrag
 # MILVUS_MIGRATION_RETRY_MAX_BACKOFF=60
 # MILVUS_MIGRATION_ITERATOR_BATCH_SIZE=2000
 
+### Milvus schema-migration memory back-pressure (enabled by default)
+### During the bulk copy, flush the temp collection every N migrated rows to
+### bound the Milvus data-node insert buffer and apply back-pressure (0 to
+### disable and rely on auto-flush). Optionally sleep between iterator batches
+### on a memory-constrained server (0 to disable). For high-dimension vectors or
+### large content fields, also lower MILVUS_MIGRATION_ITERATOR_BATCH_SIZE above.
+# MILVUS_MIGRATION_FLUSH_INTERVAL_ROWS=50000
+# MILVUS_MIGRATION_BATCH_SLEEP=0
+
 ### Milvus Vector Index Configuration
 ### Index type: AUTOINDEX (default), HNSW, HNSW_SQ, HNSW_PQ, IVF_FLAT, IVF_SQ8, DISKANN
 # MILVUS_INDEX_TYPE=AUTOINDEX

--- a/lightrag/kg/milvus_impl.py
+++ b/lightrag/kg/milvus_impl.py
@@ -78,6 +78,20 @@ DEFAULT_MILVUS_MIGRATION_RETRY_MAX_BACKOFF_SECONDS = 60.0
 MILVUS_MIGRATION_RETRY_BACKOFF_MULTIPLIER = 3.0
 DEFAULT_MILVUS_MIGRATION_ITERATOR_BATCH_SIZE = 2000
 
+# Schema-migration memory back-pressure. The bulk copy inserts the whole source
+# collection into the temp collection with no client-side throttle, so the
+# Milvus data node accumulates growing insert-buffer segments until its own
+# auto-flush catches up; under a large migration this can exhaust server memory
+# (the temp collection is not loaded, so query-node memory is already bounded —
+# this is the data-node write buffer). Flushing every N migrated rows seals
+# those segments to object storage and blocks until the flush returns, giving
+# the server natural back-pressure. 0 disables periodic flush (rely on Milvus
+# auto-flush). The interval is kept coarse so it does not spawn many tiny
+# segments (which would burden later compaction). An optional per-batch sleep
+# lets a small server breathe between batches; 0 disables it.
+DEFAULT_MILVUS_MIGRATION_FLUSH_INTERVAL_ROWS = 50000
+DEFAULT_MILVUS_MIGRATION_BATCH_SLEEP_SECONDS = 0.0
+
 # Substrings that mark an exception as a transient connection failure (worth a
 # retry with a rebuilt client) rather than a schema/parameter error.
 MILVUS_RETRYABLE_CONNECTION_ERROR_MARKERS = (
@@ -1535,6 +1549,7 @@ class MilvusVectorDBStorage(BaseVectorStorage):
 
             total_migrated = 0
             batch_number = 1
+            rows_since_flush = 0
 
             while True:
                 try:
@@ -1566,12 +1581,31 @@ class MilvusVectorDBStorage(BaseVectorStorage):
                                 data=records_batch,
                             )
                         total_migrated += len(batch_data)
+                        rows_since_flush += len(batch_data)
 
                         logger.info(
                             f"[{self.workspace}] Iterator batch {batch_number}: "
                             f"processed {len(batch_data)} records, total migrated: {total_migrated}"
                         )
                         batch_number += 1
+
+                        # Seal the accumulated insert buffer to bound the
+                        # data-node memory and block until the flush returns,
+                        # giving the server back-pressure during a large copy.
+                        if (
+                            self._migration_flush_interval_rows > 0
+                            and rows_since_flush >= self._migration_flush_interval_rows
+                        ):
+                            logger.info(
+                                f"[{self.workspace}] Flushing temp collection after "
+                                f"{rows_since_flush} rows (total migrated: {total_migrated})"
+                            )
+                            self._client.flush(temp_collection_name)
+                            rows_since_flush = 0
+
+                        # Optional throttle to let a small server breathe.
+                        if self._migration_batch_sleep > 0:
+                            time.sleep(self._migration_batch_sleep)
 
                     except Exception as batch_error:
                         logger.error(
@@ -1584,6 +1618,14 @@ class MilvusVectorDBStorage(BaseVectorStorage):
                         f"[{self.workspace}] Iterator next() failed at batch {batch_number}: {next_error}"
                     )
                     raise
+
+            # Final flush so the last unsealed insert buffer is persisted and
+            # released before the collection is promoted and loaded.
+            if self._migration_flush_interval_rows > 0 and total_migrated > 0:
+                logger.info(
+                    f"[{self.workspace}] Final flush of temp collection ({total_migrated} rows migrated)"
+                )
+                self._client.flush(temp_collection_name)
 
             if total_migrated > 0:
                 logger.info(
@@ -2120,6 +2162,25 @@ class MilvusVectorDBStorage(BaseVectorStorage):
         self._migration_iterator_batch_size = _get_env_int(
             "MILVUS_MIGRATION_ITERATOR_BATCH_SIZE",
             DEFAULT_MILVUS_MIGRATION_ITERATOR_BATCH_SIZE,
+        )
+
+        # Schema-migration memory back-pressure knobs (see the
+        # DEFAULT_MILVUS_MIGRATION_FLUSH_*/_BATCH_SLEEP_* constants).
+        self._migration_flush_interval_rows = max(
+            0,
+            _get_env_int(
+                "MILVUS_MIGRATION_FLUSH_INTERVAL_ROWS",
+                DEFAULT_MILVUS_MIGRATION_FLUSH_INTERVAL_ROWS,
+            ),
+        )
+        self._migration_batch_sleep = max(
+            0.0,
+            float(
+                os.getenv(
+                    "MILVUS_MIGRATION_BATCH_SLEEP",
+                    str(DEFAULT_MILVUS_MIGRATION_BATCH_SLEEP_SECONDS),
+                )
+            ),
         )
         self._initialized = False
 

--- a/tests/kg/milvus_impl/test_milvus_migration_memory.py
+++ b/tests/kg/milvus_impl/test_milvus_migration_memory.py
@@ -1,0 +1,217 @@
+"""
+Tests for Milvus schema-migration memory back-pressure.
+
+The bulk copy inserts the whole source collection into a temp collection with
+no client-side throttle, so the Milvus data node accumulates insert-buffer
+segments until its auto-flush catches up — a large migration can exhaust
+server memory. These tests cover the periodic/final flush that bounds that
+buffer and the optional inter-batch throttle.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from pymilvus import MilvusException
+
+from lightrag.kg.milvus_impl import MilvusVectorDBStorage
+
+
+class _EmbeddingFunc:
+    def __init__(self, dim=128, model_name="text-embedding-3-small"):
+        self.embedding_dim = dim
+        self.model_name = model_name
+
+
+def _make_model_storage(namespace="entities", workspace="test_workspace", dim=128):
+    return MilvusVectorDBStorage(
+        namespace=namespace,
+        workspace=workspace,
+        global_config={
+            "embedding_batch_num": 100,
+            "vector_db_storage_cls_kwargs": {
+                "cosine_better_than_threshold": 0.3,
+            },
+        },
+        embedding_func=_EmbeddingFunc(dim=dim),
+        meta_fields=set(),
+    )
+
+
+def _wire_collection_state(storage, collections):
+    storage._client = MagicMock()
+
+    def has_collection(collection_name):
+        return collection_name in collections
+
+    def create_collection(collection_name, schema):
+        collections.add(collection_name)
+
+    def drop_collection(collection_name):
+        collections.discard(collection_name)
+
+    def rename_collection(source, target):
+        collections.discard(source)
+        collections.add(target)
+
+    storage._client.has_collection.side_effect = has_collection
+    storage._client.create_collection.side_effect = create_collection
+    storage._client.drop_collection.side_effect = drop_collection
+    storage._client.rename_collection.side_effect = rename_collection
+    return storage._client
+
+
+def _wire_iterator(client, batches):
+    """query_iterator yields the given list of row-batches then []."""
+
+    def make_iterator(**kwargs):
+        iterator = MagicMock()
+        iterator.next.side_effect = list(batches) + [[]]
+        return iterator
+
+    client.query_iterator.side_effect = make_iterator
+
+
+def _rows(n, start=0):
+    return [
+        {"id": f"ent-{i}", "vector": [0.0] * 128, "content": "body"}
+        for i in range(start, start + n)
+    ]
+
+
+@pytest.mark.offline
+class TestMigrationFlushBackpressure:
+    def test_periodic_and_final_flush_by_row_interval(self):
+        storage = _make_model_storage()
+        storage._migration_flush_interval_rows = 3
+        collections = {storage.legacy_namespace}
+        client = _wire_collection_state(storage, collections)
+        temp = f"{storage.final_namespace}_temp"
+        # Three iterator batches of 2 rows: cumulative 2, 4, 6.
+        # Periodic flush trips once (at 4 >= 3), then a final flush at the end.
+        _wire_iterator(client, [_rows(2), _rows(2, 2), _rows(2, 4)])
+
+        with patch.object(storage, "_create_indexes_after_collection"):
+            storage._migrate_collection_schema(
+                source_collection_name=storage.legacy_namespace,
+                target_collection_name=storage.final_namespace,
+            )
+
+        flush_targets = [call.args[0] for call in client.flush.call_args_list]
+        assert flush_targets == [temp, temp]  # one periodic + one final
+        assert storage.final_namespace in collections
+
+    def test_flush_disabled_when_interval_zero(self):
+        storage = _make_model_storage()
+        storage._migration_flush_interval_rows = 0
+        collections = {storage.legacy_namespace}
+        client = _wire_collection_state(storage, collections)
+        _wire_iterator(client, [_rows(2), _rows(2, 2)])
+
+        with patch.object(storage, "_create_indexes_after_collection"):
+            storage._migrate_collection_schema(
+                source_collection_name=storage.legacy_namespace,
+                target_collection_name=storage.final_namespace,
+            )
+
+        client.flush.assert_not_called()
+        assert storage.final_namespace in collections
+
+    def test_no_final_flush_for_empty_source(self):
+        storage = _make_model_storage()
+        storage._migration_flush_interval_rows = 50000
+        collections = {storage.legacy_namespace}
+        client = _wire_collection_state(storage, collections)
+        _wire_iterator(client, [])  # empty source
+
+        with patch.object(storage, "_create_indexes_after_collection"):
+            storage._migrate_collection_schema(
+                source_collection_name=storage.legacy_namespace,
+                target_collection_name=storage.final_namespace,
+            )
+
+        client.flush.assert_not_called()
+
+    def test_flush_connection_error_is_retryable(self):
+        # A flush failing with a connection error must be retried like any other
+        # connection-class migration failure (rebuild client, restart attempt).
+        storage = _make_model_storage()
+        storage._migration_flush_interval_rows = 1
+        collections = {storage.legacy_namespace}
+        client = _wire_collection_state(storage, collections)
+        _wire_iterator(client, [_rows(2)])
+
+        flush_calls = {"n": 0}
+
+        def flush(collection_name, **kwargs):
+            flush_calls["n"] += 1
+            if flush_calls["n"] == 1:
+                raise MilvusException(
+                    code=2, message="Fail connecting to server on host:19530"
+                )
+
+        client.flush.side_effect = flush
+
+        with patch.object(storage, "_create_indexes_after_collection"):
+            with patch.object(storage, "_rebuild_milvus_client") as rebuild:
+                with patch("lightrag.kg.milvus_impl.time.sleep"):
+                    storage._migrate_collection_schema(
+                        source_collection_name=storage.legacy_namespace,
+                        target_collection_name=storage.final_namespace,
+                    )
+
+        rebuild.assert_called_once()
+        assert storage.final_namespace in collections
+
+
+@pytest.mark.offline
+class TestMigrationBatchThrottle:
+    def test_batch_sleep_throttles_between_batches(self):
+        storage = _make_model_storage()
+        storage._migration_flush_interval_rows = 0
+        storage._migration_batch_sleep = 0.05
+        collections = {storage.legacy_namespace}
+        client = _wire_collection_state(storage, collections)
+        _wire_iterator(client, [_rows(2), _rows(2, 2)])
+
+        with patch.object(storage, "_create_indexes_after_collection"):
+            with patch("lightrag.kg.milvus_impl.time.sleep") as sleep:
+                storage._migrate_collection_schema(
+                    source_collection_name=storage.legacy_namespace,
+                    target_collection_name=storage.final_namespace,
+                )
+
+        # One sleep per non-empty iterator batch, none for the terminating [].
+        assert [call.args[0] for call in sleep.call_args_list] == [0.05, 0.05]
+
+    def test_no_sleep_when_disabled(self):
+        storage = _make_model_storage()
+        storage._migration_flush_interval_rows = 0
+        storage._migration_batch_sleep = 0.0
+        collections = {storage.legacy_namespace}
+        client = _wire_collection_state(storage, collections)
+        _wire_iterator(client, [_rows(2)])
+
+        with patch.object(storage, "_create_indexes_after_collection"):
+            with patch("lightrag.kg.milvus_impl.time.sleep") as sleep:
+                storage._migrate_collection_schema(
+                    source_collection_name=storage.legacy_namespace,
+                    target_collection_name=storage.final_namespace,
+                )
+
+        sleep.assert_not_called()
+
+
+@pytest.mark.offline
+class TestMigrationBackpressureConfig:
+    def test_env_overrides(self, monkeypatch):
+        monkeypatch.setenv("MILVUS_MIGRATION_FLUSH_INTERVAL_ROWS", "1234")
+        monkeypatch.setenv("MILVUS_MIGRATION_BATCH_SLEEP", "0.25")
+        storage = _make_model_storage()
+        assert storage._migration_flush_interval_rows == 1234
+        assert storage._migration_batch_sleep == 0.25
+
+    def test_negative_values_clamped(self, monkeypatch):
+        monkeypatch.setenv("MILVUS_MIGRATION_FLUSH_INTERVAL_ROWS", "-5")
+        monkeypatch.setenv("MILVUS_MIGRATION_BATCH_SLEEP", "-1")
+        storage = _make_model_storage()
+        assert storage._migration_flush_interval_rows == 0
+        assert storage._migration_batch_sleep == 0.0


### PR DESCRIPTION
## Problem

Follow-up to #3258. In the production incident that motivated #3258, the Milvus **host itself ran out of memory and crashed** mid-migration (`docker ps` hung — the host was swapping), and the `ping timeout` at batch 92 is the signature of a server already starved for memory before it died.

#3258 hardened the migration against transient connection failures and removed two *query-node* memory amplifiers (the temp collection is no longer loaded during the copy; the backup is released afterwards). But the **data-node insert buffer was still unbounded**: the bulk copy inserts the whole source collection into the temp collection with no client-side throttle, so the data node accumulates growing insert-buffer segments until its own auto-flush catches up. On a large migration (180k relationship rows, each carrying a full vector plus up to 64KB varchar fields) this buffer can balloon and exhaust server memory.

Loading the temp collection only affects query-node memory; inserts go through the data node regardless. So "don't load temp" did **not** bound the write buffer — this PR does.

## Changes

- **Periodic + final flush of the temp collection** during the copy, every `MILVUS_MIGRATION_FLUSH_INTERVAL_ROWS` rows (default `50000`; `0` disables and relies on Milvus auto-flush). `flush()` seals the buffered segments to object storage and blocks until it returns, so it both caps data-node memory and applies natural back-pressure to the client. The interval is deliberately coarse so it doesn't spawn many tiny segments (which would burden later compaction). A final flush runs after the copy so the last unsealed buffer is persisted before the collection is promoted and loaded.
- **Optional inter-batch throttle** `MILVUS_MIGRATION_BATCH_SLEEP` (default `0`, disabled) to let a memory-constrained server breathe between iterator batches.
- A flush that fails with a connection error is caught by the existing migration retry loop from #3258 (rebuild client, restart attempt from scratch).

For high-dimension vectors or large `content` fields, `MILVUS_MIGRATION_ITERATOR_BATCH_SIZE` (added in #3258) can also be lowered to cut the per-batch peak on both client and server — noted in `env.example`.

New env knobs (defaults documented in `env.example`): `MILVUS_MIGRATION_FLUSH_INTERVAL_ROWS`, `MILVUS_MIGRATION_BATCH_SLEEP`.

## Tests

`tests/kg/milvus_impl/test_milvus_migration_memory.py` (8 cases, offline/mock-client): periodic flush trips at the row interval + final flush; flush disabled at interval 0; no final flush for an empty source; flush connection-error is retried via client rebuild; batch sleep throttles once per non-empty batch and is off by default; env overrides and negative-value clamping.

`tests/kg/milvus_impl/` offline suite: 164 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)