### PR TITLE
fix(milvus): load source collection before migration query_iterator

### DIFF
--- a/lightrag/kg/milvus_impl.py
+++ b/lightrag/kg/milvus_impl.py
@@ -1494,6 +1494,10 @@ class MilvusVectorDBStorage(BaseVectorStorage):
         # collection holds the only migrated copy and must not be dropped by
         # the failure cleanup below — a later attempt or startup recovers it.
         commit_phase = False
+        # True once we explicitly loaded a suffix migration's legacy source, so
+        # the failure cleanup can release it again (in-place sources are the
+        # active collection and are left as-is).
+        source_loaded = False
 
         try:
             logger.info(
@@ -1542,6 +1546,9 @@ class MilvusVectorDBStorage(BaseVectorStorage):
             # (idempotent); on a successful migration the source becomes the
             # backup and is released again from memory at the end.
             self._client.load_collection(source_collection_name)
+            # Only track suffix loads: an in-place source is the active
+            # collection and must not be released on failure.
+            source_loaded = not is_inplace
 
             try:
                 iterator = self._client.query_iterator(
@@ -1756,6 +1763,22 @@ class MilvusVectorDBStorage(BaseVectorStorage):
                     logger.warning(
                         f"[{self.workspace}] Failed to cleanup temporary collection: {cleanup_error}. "
                         f"The leftover temp collection will be dropped on the next migration attempt or startup"
+                    )
+
+            # Release the suffix source we loaded above so a failed startup or
+            # retry does not leave a full backup resident in query-node memory.
+            # In-place sources are the active collection and are left as-is.
+            if source_loaded:
+                try:
+                    self._client.release_collection(source_collection_name)
+                    logger.info(
+                        f"[{self.workspace}] Released source collection "
+                        f"{source_collection_name} from memory after failed migration"
+                    )
+                except Exception as release_error:
+                    logger.warning(
+                        f"[{self.workspace}] Failed to release source collection "
+                        f"{source_collection_name}: {release_error}"
                     )
 
             raise RuntimeError(

--- a/lightrag/kg/milvus_impl.py
+++ b/lightrag/kg/milvus_impl.py
@@ -1534,6 +1534,15 @@ class MilvusVectorDBStorage(BaseVectorStorage):
                 f"[{self.workspace}] Step 2: Copying data using query_iterator from: {source_collection_name}"
             )
 
+            # query_iterator issues a server-side query, which requires the
+            # source collection to be loaded. An in-place source is the active
+            # collection and is already loaded, but a legacy/suffix source is
+            # typically NOT loaded (it is an old backup), so the iterator setup
+            # fails with "collection not loaded" (code 101). Load it explicitly
+            # (idempotent); on a successful migration the source becomes the
+            # backup and is released again from memory at the end.
+            self._client.load_collection(source_collection_name)
+
             try:
                 iterator = self._client.query_iterator(
                     collection_name=source_collection_name,

--- a/tests/kg/milvus_impl/test_milvus_migration_retry.py
+++ b/tests/kg/milvus_impl/test_milvus_migration_retry.py
@@ -339,8 +339,45 @@ class TestMigrationMemoryFootprint:
                 target_collection_name=storage.final_namespace,
             )
 
-        client.load_collection.assert_not_called()
+        # The source must be loaded (query_iterator requires it), but the temp
+        # collection must never be loaded during the bulk copy.
+        loaded = [call.args[0] for call in client.load_collection.call_args_list]
+        assert f"{storage.final_namespace}_temp" not in loaded
+        assert storage.legacy_namespace in loaded
         assert storage.final_namespace in collections
+
+    def test_source_is_loaded_before_query_iterator(self):
+        # query_iterator runs a server-side query that needs the source loaded;
+        # an unloaded legacy/suffix source otherwise fails with code 101
+        # "collection not loaded". The source must be loaded before the
+        # iterator is created.
+        storage = _make_model_storage()
+        collections = {storage.legacy_namespace}
+        client = _wire_collection_state(storage, collections)
+
+        order = []
+        client.load_collection.side_effect = lambda name, **kw: order.append(
+            ("load", name)
+        )
+
+        def make_iterator(**kwargs):
+            order.append(("query_iterator", kwargs["collection_name"]))
+            iterator = MagicMock()
+            iterator.next.side_effect = [_rows(), []]
+            return iterator
+
+        client.query_iterator.side_effect = make_iterator
+
+        with patch.object(storage, "_create_indexes_after_collection"):
+            storage._migrate_collection_schema(
+                source_collection_name=storage.legacy_namespace,
+                target_collection_name=storage.final_namespace,
+            )
+
+        assert ("load", storage.legacy_namespace) in order
+        assert order.index(("load", storage.legacy_namespace)) < order.index(
+            ("query_iterator", storage.legacy_namespace)
+        )
 
     def test_suffix_migration_releases_legacy_backup(self):
         storage = _make_model_storage()

--- a/tests/kg/milvus_impl/test_milvus_migration_retry.py
+++ b/tests/kg/milvus_impl/test_milvus_migration_retry.py
@@ -379,6 +379,40 @@ class TestMigrationMemoryFootprint:
             ("query_iterator", storage.legacy_namespace)
         )
 
+    def test_failed_suffix_migration_releases_loaded_source(self):
+        # The source we loaded for a suffix migration must be released again on
+        # failure, so a failed startup/retry does not leave a full backup
+        # resident in query-node memory.
+        storage = _make_model_storage()
+        collections = {storage.legacy_namespace}
+        client = _wire_collection_state(storage, collections)
+        _wire_fresh_iterator_per_attempt(client)
+        client.insert.side_effect = RuntimeError("insert failed")  # non-retryable
+
+        with patch.object(storage, "_create_indexes_after_collection"):
+            with pytest.raises(RuntimeError, match="Iterator-based migration failed"):
+                storage._migrate_collection_schema(
+                    source_collection_name=storage.legacy_namespace,
+                    target_collection_name=storage.final_namespace,
+                )
+
+        client.release_collection.assert_any_call(storage.legacy_namespace)
+
+    def test_failed_inplace_migration_does_not_release_active_source(self):
+        # An in-place source is the live active collection; it must not be
+        # released on a pre-commit failure.
+        storage = _make_model_storage()
+        collections = {storage.final_namespace}
+        client = _wire_collection_state(storage, collections)
+        _wire_fresh_iterator_per_attempt(client)
+        client.insert.side_effect = RuntimeError("insert failed")  # non-retryable
+
+        with patch.object(storage, "_create_indexes_after_collection"):
+            with pytest.raises(RuntimeError, match="Iterator-based migration failed"):
+                storage._migrate_collection_schema()  # in-place
+
+        client.release_collection.assert_not_called()
+
     def test_suffix_migration_releases_legacy_backup(self):
         storage = _make_model_storage()
         collections = {storage.legacy_namespace}


### PR DESCRIPTION
## Problem

A real suffix migration fails at startup before any data is copied:

```
INFO: [space1] Step 2: Copying data using query_iterator from: space1_entities
[ERROR] RPC error: [query], MilvusException: (code=101, message=failed to query: collection not loaded[...])
ERROR: [space1] Failed to create query iterator: ... collection not loaded
ERROR: [space1] Failed to initialize Milvus collection 'entities': ...
ERROR: Application startup failed. Exiting.
```

`query_iterator` issues a server-side `query` (to set up its timestamp checkpoint), which requires the source collection to be **loaded**. For an in-place migration the source is the active collection and is already loaded, but for a **legacy/suffix migration** (`space1_entities` → `space1_entities_baai_bge_m3_1024d`) the source is an unloaded old backup, so the iterator setup throws `code=101 "collection not loaded"` and the worker crashes.

This has existed since the iterator-based migration was introduced; it only surfaces when the legacy source is not already loaded.

## Fix

Load the source collection (idempotent) before creating the iterator in Step 2. On a successful migration the source becomes the backup and is released from memory again at the end (suffix: the legacy is released; in-place: the renamed `_old` is released), so this adds no steady-state memory — it only ensures the source is queryable for the duration of the copy.

## Tests

`tests/kg/milvus_impl/test_milvus_migration_retry.py`:
- New `test_source_is_loaded_before_query_iterator`: asserts `load_collection(source)` runs before `query_iterator(source)`.
- Updated `test_temp_collection_is_not_loaded_during_migration`: the assertion now correctly targets the temp name (temp not loaded) while allowing the required source load, instead of asserting `load_collection` is never called.

`tests/kg/milvus_impl/` offline suite: 165 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)