### PR TITLE
refactor(concurrency): use asyncio.get_running_loop().time() in async contexts

### DIFF
--- a/env.example
+++ b/env.example
@@ -498,7 +498,7 @@ LLM_MODEL=gpt-5.4-mini
 ###       via lease heartbeats; if a worker is terminated externally while its
 ###       provider request is still pending, replacement work may briefly make
 ###       provider-side concurrency exceed the cap until the abandoned request
-###       times out or closes. 
+###       times out or closes.
 ###       Runtime caveat: changing a role's max_async through the API
 ###       updates only that worker's local limit — the cross-worker cap
 ###       keeps the value read at startup.

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -1256,7 +1256,7 @@ def priority_limit_async_func_call(
                             task_state.worker_started = True
                             # Record execution start time when worker actually begins processing
                             task_state.execution_start_time = (
-                                asyncio.get_event_loop().time()
+                                asyncio.get_running_loop().time()
                             )
 
                         # Check if task was cancelled before worker started
@@ -1433,7 +1433,7 @@ def priority_limit_async_func_call(
                                     else:
                                         task_state.worker_started = True
                                         task_state.execution_start_time = (
-                                            asyncio.get_event_loop().time()
+                                            asyncio.get_running_loop().time()
                                         )
                                         live_queued -= 1
                                         notify_needed = True
@@ -1573,7 +1573,7 @@ def priority_limit_async_func_call(
                 while not shutdown_event.is_set():
                     await asyncio.sleep(5)  # Check every 5 seconds
 
-                    current_time = asyncio.get_event_loop().time()
+                    current_time = asyncio.get_running_loop().time()
 
                     # Detect and handle stuck tasks based on execution start time
                     if max_task_duration is not None:
@@ -1953,10 +1953,12 @@ def priority_limit_async_func_call(
             nonlocal counter, submitted_total, completed_total, cancelled_total
             nonlocal failed_total, rejected_total, live_queued
 
-            task_id = f"{id(asyncio.current_task())}_{asyncio.get_event_loop().time()}"
+            task_id = (
+                f"{id(asyncio.current_task())}_{asyncio.get_running_loop().time()}"
+            )
             future = asyncio.Future()
             task_state = TaskState(
-                future=future, start_time=asyncio.get_event_loop().time()
+                future=future, start_time=asyncio.get_running_loop().time()
             )
 
             def _admission_open() -> bool:
@@ -2035,10 +2037,10 @@ def priority_limit_async_func_call(
                     if not future.done():
                         future.cancel()
 
-                    cleanup_start = asyncio.get_event_loop().time()
+                    cleanup_start = asyncio.get_running_loop().time()
                     while (
                         task_id in task_states
-                        and asyncio.get_event_loop().time() - cleanup_start
+                        and asyncio.get_running_loop().time() - cleanup_start
                         < cleanup_timeout
                     ):
                         await asyncio.sleep(0.1)
@@ -2114,12 +2116,14 @@ def priority_limit_async_func_call(
                 )
 
             # Generate unique task ID
-            task_id = f"{id(asyncio.current_task())}_{asyncio.get_event_loop().time()}"
+            task_id = (
+                f"{id(asyncio.current_task())}_{asyncio.get_running_loop().time()}"
+            )
             future = asyncio.Future()
 
             # Create task state
             task_state = TaskState(
-                future=future, start_time=asyncio.get_event_loop().time()
+                future=future, start_time=asyncio.get_running_loop().time()
             )
 
             try:
@@ -2184,10 +2188,10 @@ def priority_limit_async_func_call(
                         future.cancel()
 
                     # Wait for worker cleanup with timeout
-                    cleanup_start = asyncio.get_event_loop().time()
+                    cleanup_start = asyncio.get_running_loop().time()
                     while (
                         task_id in task_states
-                        and asyncio.get_event_loop().time() - cleanup_start
+                        and asyncio.get_running_loop().time() - cleanup_start
                         < cleanup_timeout
                     ):
                         await asyncio.sleep(0.1)

--- a/tests/llm/test_global_concurrency_queue.py
+++ b/tests/llm/test_global_concurrency_queue.py
@@ -36,9 +36,9 @@ def _init(limits=None):
 
 
 async def _wait_until(predicate, timeout=5.0, interval=0.01):
-    deadline = asyncio.get_event_loop().time() + timeout
+    deadline = asyncio.get_running_loop().time() + timeout
     while not predicate():
-        if asyncio.get_event_loop().time() > deadline:
+        if asyncio.get_running_loop().time() > deadline:
             raise AssertionError("condition not met within timeout")
         await asyncio.sleep(interval)
 
@@ -53,7 +53,7 @@ async def _wait_drained(wrapped, timeout=5.0, interval=0.01):
     (up-drift) leaves ``queued`` stuck above zero forever; a leaked
     task_states entry leaves ``in_flight`` stuck. Returns the final stats.
     """
-    deadline = asyncio.get_event_loop().time() + timeout
+    deadline = asyncio.get_running_loop().time() + timeout
     while True:
         stats = await wrapped.get_queue_stats()
         if (
@@ -62,7 +62,7 @@ async def _wait_drained(wrapped, timeout=5.0, interval=0.01):
             and stats.get("physical_queued", 0) == 0
         ):
             return stats
-        if asyncio.get_event_loop().time() > deadline:
+        if asyncio.get_running_loop().time() > deadline:
             raise AssertionError(f"queue did not drain to zero: {stats}")
         await asyncio.sleep(interval)
 
@@ -355,9 +355,9 @@ async def test_admission_counts_only_live_queued_tasks():
         async def _queued_count():
             return (await wrapped.get_queue_stats())["queued"]
 
-        deadline = asyncio.get_event_loop().time() + 5.0
+        deadline = asyncio.get_running_loop().time() + 5.0
         while await _queued_count() != 2:
-            assert asyncio.get_event_loop().time() < deadline
+            assert asyncio.get_running_loop().time() < deadline
             await asyncio.sleep(0.01)
 
         stats = await wrapped.get_queue_stats()
@@ -732,9 +732,9 @@ async def test_aggregated_stats_schema_and_global_fields():
         async def _in_use_zero():
             return await ss.global_concurrency_in_use(GROUP) == 0
 
-        deadline = asyncio.get_event_loop().time() + 2.0
+        deadline = asyncio.get_running_loop().time() + 2.0
         while not await _in_use_zero():
-            assert asyncio.get_event_loop().time() < deadline
+            assert asyncio.get_running_loop().time() < deadline
             await asyncio.sleep(0.01)
 
         stats = await wrapped.get_aggregated_queue_stats()
@@ -779,9 +779,9 @@ async def test_shutdown_clears_waiter_record():
     pending = asyncio.create_task(wrapped("stuck"))
     try:
         # Wait until a polling worker registers this process as a waiter.
-        deadline = asyncio.get_event_loop().time() + 5.0
+        deadline = asyncio.get_running_loop().time() + 5.0
         while not await ss.global_slot_waiters(GROUP):
-            assert asyncio.get_event_loop().time() < deadline
+            assert asyncio.get_running_loop().time() < deadline
             await asyncio.sleep(0.01)
     finally:
         await wrapped.shutdown(graceful=False, timeout=0.1)
@@ -803,9 +803,9 @@ async def test_aggregated_stats_report_slot_waiters():
     )(func)
     task = asyncio.create_task(wrapped("waiting"))
     try:
-        deadline = asyncio.get_event_loop().time() + 5.0
+        deadline = asyncio.get_running_loop().time() + 5.0
         while not await ss.global_slot_waiters(GROUP):
-            assert asyncio.get_event_loop().time() < deadline
+            assert asyncio.get_running_loop().time() < deadline
             await asyncio.sleep(0.01)
 
         stats = await wrapped.get_aggregated_queue_stats()


### PR DESCRIPTION
## Summary

Replaces the deprecated `asyncio.get_event_loop().time()` with `asyncio.get_running_loop().time()` in async contexts. This is "Issue 3" from the review of #3253, deferred from that PR to keep it focused.

`asyncio.get_event_loop()` is deprecated since Python 3.10 when no loop is running and is slated for removal. Every `.time()` call in these files runs inside an `async def` (always under a running loop), so `get_running_loop().time()` is a **semantically identical drop-in** — it reads the same loop monotonic clock. No behavior change.

> **Note:** this PR is stacked on top of #3253 (base branch `claude/happy-davinci-bph42e`) because several of the converted call sites (`slot_pump`, `_limited_wait`, and the concurrency test file) only exist on that branch. GitHub will auto-retarget the base to `main` once #3253 merges.

## Scope

- **Converted (23 sites):** `lightrag/utils.py` (11 — `worker`, `slot_pump`, `enhanced_health_check`, `_limited_wait`, `wait_func`) and `tests/llm/test_global_concurrency_queue.py` (12 — async deadline helpers).
- **Intentionally left unchanged (3 sites):** the synchronous get-or-create-a-loop entry points — `always_get_an_event_loop()`, `export_data()` (`utils.py`), and `LightRAG.export_data()` (`lightrag.py`). These must work with **no** running loop, so `get_running_loop()` would raise; they keep the `try/except get_event_loop → new_event_loop` pattern.

The replacement targeted the exact literal `asyncio.get_event_loop().time()`, which provably appears only inside `async def`, so the sync entry points were never at risk.

## Verification

- `grep` confirms zero residual `get_event_loop().time()` and the 3 sync sites intact.
- `ruff check` and `ruff format --check` clean (two f-string lines re-wrapped since the new name is 2 chars longer).
- `pytest tests/llm/test_global_concurrency_queue.py tests/kg/test_global_concurrency_slots.py` → **45 passed**.

https://claude.ai/code/session_01QCfrYUDM5Xkuqi6YDeFwGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCfrYUDM5Xkuqi6YDeFwGv)_