### PR TITLE
feat(webui): inject two one-time system-suggested user prompts

### DIFF
--- a/lightrag_webui/src/lib/constants.ts
+++ b/lightrag_webui/src/lib/constants.ts
@@ -92,3 +92,10 @@ export const SiteInfo = {
   home: '/',
   github: 'https://github.com/HKUDS/LightRAG'
 }
+
+// One-time system-suggested user prompts, injected once into userPromptHistory
+// (for both fresh installs and upgrades). See settings store version 20 migration.
+export const suggestedUserPrompts: string[] = [
+  'Ignore the `References Section Format` instruction in the system prompt, and do not include a `References` section in the response.',
+  'For inline citations, use the footnote marker syntax `[^1]`, where the `^` preceding the identifier indicates a footnote reference. When multiple citations are required at a single location, each ID should be enclosed in separate footnote markers (e.g., `[^1][^2][^3]`).'
+]

--- a/lightrag_webui/src/stores/settings.ts
+++ b/lightrag_webui/src/stores/settings.ts
@@ -343,11 +343,13 @@ const useSettingsStoreBase = create<SettingsState>()(
         }
         if (version < 20) {
           // One-time injection of system-suggested prompts; append after any existing
-          // history so user's own prompts keep priority. version monotonicity makes
-          // this run at most once.
+          // history so user's own prompts keep priority. Skip any prompt already
+          // present to avoid duplicate dropdown entries (matches the de-duping in
+          // addUserPromptToHistory). version monotonicity makes this run at most once.
+          const existing = state.userPromptHistory ?? []
           state.userPromptHistory = [
-            ...(state.userPromptHistory ?? []),
-            ...suggestedUserPrompts
+            ...existing,
+            ...suggestedUserPrompts.filter((p: string) => !existing.includes(p))
           ]
         }
         return state

--- a/lightrag_webui/src/stores/settings.ts
+++ b/lightrag_webui/src/stores/settings.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { createSelectors } from '@/lib/utils'
-import { defaultQueryLabel } from '@/lib/constants'
+import { defaultQueryLabel, suggestedUserPrompts } from '@/lib/constants'
 import { Message, QueryRequest } from '@/api/lightrag'
 
 type Theme = 'dark' | 'light' | 'system'
@@ -119,7 +119,7 @@ const useSettingsStoreBase = create<SettingsState>()(
       documentsPageSize: 10,
 
       retrievalHistory: [],
-      userPromptHistory: [],
+      userPromptHistory: [...suggestedUserPrompts],
 
       querySettings: {
         mode: 'global',
@@ -238,7 +238,7 @@ const useSettingsStoreBase = create<SettingsState>()(
     {
       name: 'settings-storage',
       storage: createJSONStorage(() => localStorage),
-      version: 19,
+      version: 20,
       migrate: (state: any, version: number) => {
         if (version < 2) {
           state.showEdgeLabel = false
@@ -340,6 +340,15 @@ const useSettingsStoreBase = create<SettingsState>()(
           if (state.querySettings) {
             delete state.querySettings.response_type
           }
+        }
+        if (version < 20) {
+          // One-time injection of system-suggested prompts; append after any existing
+          // history so user's own prompts keep priority. version monotonicity makes
+          // this run at most once.
+          state.userPromptHistory = [
+            ...(state.userPromptHistory ?? []),
+            ...suggestedUserPrompts
+          ]
         }
         return state
       }


### PR DESCRIPTION
## Summary

Seed the user prompt history (`UserPromptInputWithHistory` in the retrieval panel) with two recommended prompts **exactly once**, for both fresh installs and users upgrading from older versions. After the one-time injection, future upgrades/redeploys never re-add them.

The two suggested prompts (fixed order):

1. `Ignore the `References Section Format` instruction in the system prompt, and do not include a `References` section in the response.`
2. `For inline citations, use the footnote marker syntax `[^1]`, where the `^` preceding the identifier indicates a footnote reference. When multiple citations are required at a single location, each ID should be enclosed in separate footnote markers (e.g., `[^1][^2][^3]`).`

## How it works

zustand `persist`'s `migrate(persistedState, version)` only runs when there is an **existing** persisted state with a lower version — so it covers upgrading users but **not** fresh installs. The two cases are handled separately:

- **Fresh install** (no `settings-storage` in localStorage): migrate does not run, so the initial `userPromptHistory` default seeds the two prompts directly.
- **Upgrading user** (persisted `version < 20`): a new `version < 20` migration branch appends the prompts **after** any existing history, keeping the user's own prompts at higher priority.

**One-time guarantee** comes from version monotonicity (same pattern as the file's existing 19 migrations): once a user crosses version 20, the `< 20` branch never fires again; fresh users start at version 20 and never enter any `< 20` branch. The two paths cannot stack — on rehydration the persisted (already-migrated) `userPromptHistory` overrides the initial default.

## Changes

- `lightrag_webui/src/lib/constants.ts`: add `suggestedUserPrompts` constant (single source of truth for both paths).
- `lightrag_webui/src/stores/settings.ts`: import the constant; seed the initial default; bump persist `version` 19 → 20; add the `version < 20` migration branch.

No changes needed to `UserPromptInputWithHistory.tsx` / `QuerySettings.tsx` — they render `props.history` as-is.

## Verification

- `bunx tsc --noEmit` ✅
- `eslint` on changed files ✅
- Manual (DevTools → Application → Local Storage):
  - Fresh install: clear `settings-storage`, reload → exactly the 2 suggested prompts; stored `version` is 20.
  - Upgrade w/o history: write `{version:19, userPromptHistory:[]}`, reload → 2 prompts appended.
  - Upgrade w/ history: write `{version:19, userPromptHistory:["my old prompt"]}`, reload → `["my old prompt", <suggested1>, <suggested2>]`.
  - One-time: reload again → no further additions; deleting a suggested item does not bring it back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)