### PR TITLE
fix(bedrock): use modelId for Cohere embeddings invoke_model call

### DIFF
--- a/lightrag/llm/bedrock.py
+++ b/lightrag/llm/bedrock.py
@@ -567,13 +567,13 @@ async def bedrock_embed(
                     )
 
                     response = await bedrock_async_client.invoke_model(
-                        model=model,
+                        modelId=model,
                         body=body,
                         accept="application/json",
                         contentType="application/json",
                     )
 
-                    response_body = json.loads(response.get("body").read())
+                    response_body = await response.get("body").json()
 
                     # Validate response structure
                     if not response_body or "embeddings" not in response_body:

--- a/tests/llm/bedrock_impl/test_bedrock_llm.py
+++ b/tests/llm/bedrock_impl/test_bedrock_llm.py
@@ -299,6 +299,58 @@ async def test_bedrock_embed_empty_endpoint_url_uses_sdk_default(monkeypatch):
     assert client_kwargs_calls[-1] == {"region_name": None}
 
 
+class _FakeCohereEmbeddingBody:
+    async def json(self):
+        return {"embeddings": [[0.1] * 1024]}
+
+
+class _FakeCohereEmbeddingResponse:
+    def get(self, key):
+        assert key == "body"
+        return _FakeCohereEmbeddingBody()
+
+
+class _FakeCohereEmbeddingClient(_FakeBedrockClient):
+    async def invoke_model(self, **kwargs):
+        self._captured_calls.append(kwargs)
+        return _FakeCohereEmbeddingResponse()
+
+
+class _FakeCohereEmbeddingSession(_FakeSession):
+    def client(self, *_args, **kwargs):
+        self._client_kwargs_calls.append(dict(kwargs))
+        return _FakeCohereEmbeddingClient(self._captured_calls)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_bedrock_embed_cohere_passes_modelid_to_invoke_model(monkeypatch):
+    """Cohere embeddings must call invoke_model with ``modelId`` (not ``model``).
+
+    boto3's bedrock-runtime ``invoke_model`` only accepts ``modelId``; passing
+    ``model`` raises botocore ``ParamValidationError`` before any request, so
+    the whole Cohere embedding path used to fail. This mirrors the sibling
+    amazon branch, which already uses ``modelId``.
+    """
+    captured_calls: list[dict] = []
+    client_kwargs_calls: list[dict] = []
+    monkeypatch.delenv("AWS_REGION", raising=False)
+
+    with patch(
+        "lightrag.llm.bedrock.aioboto3.Session",
+        return_value=_FakeCohereEmbeddingSession(captured_calls, client_kwargs_calls),
+    ):
+        await bedrock_embed(
+            texts=["hello"],
+            model="cohere.embed-english-v3",
+        )
+
+    assert captured_calls, "invoke_model was not called"
+    invoke_kwargs = captured_calls[-1]
+    assert invoke_kwargs["modelId"] == "cohere.embed-english-v3"
+    assert "model" not in invoke_kwargs
+
+
 @pytest.mark.offline
 @pytest.mark.asyncio
 async def test_bedrock_complete_forwards_explicit_sigv4_client_kwargs(monkeypatch):


### PR DESCRIPTION
Thanks for LightRAG and the Bedrock embedding support. This is a minimal fix that brings the Cohere embedding branch to parity with the already-correct amazon branch in the same function.

### Summary / Motivation

In `lightrag/llm/bedrock.py`, `bedrock_embed`'s Cohere branch calls `invoke_model(model=...)`. The `bedrock-runtime` `InvokeModel` API has no `model` parameter — it requires `modelId`. botocore validates kwargs locally, so the call raises `ParamValidationError` before any request, making the entire Cohere embedding path unusable. The sibling amazon/Titan branch a few lines above already uses `modelId=` correctly; this PR fills in that one missing piece. Fixes #<ISSUE>.

### What's changed

`lightrag/llm/bedrock.py` (Cohere branch only, mirroring the amazon branch):

| Item | Before | After |
|------|--------|-------|
| Cohere `invoke_model` model arg | `model=model` -> `ParamValidationError` (never reaches AWS) | `modelId=model` (valid `InvokeModel` param) |
| Cohere response body read | `json.loads(response.get("body").read())` (sync `.read()` on async body) | `await response.get("body").json()` (matches amazon branch) |
| amazon/Titan branch | `modelId=` + `await ...json()` | Unchanged |
| `bedrock_embed` signature / public API / args | — | Unchanged |
| Returned ndarray shape / ordering | — | Unchanged |

### Verification (boto3 fact, no AWS account)

`InvokeModel` accepts `modelId`, not `model` (botocore 1.40.61):

```python
import botocore.session
op = botocore.session.get_session().get_service_model("bedrock-runtime").operation_model("InvokeModel")
print(list(op.input_shape.members))
# ['body', 'contentType', 'accept', 'modelId', 'trace', 'guardrailIdentifier', ...]  # no 'model'
```

Calling each kwarg against a real (dummy-credential) client:

```text
invoke_model(model=...)   -> ParamValidationError: Unknown parameter in input: "model"   # fails before network
invoke_model(modelId=...) -> ValidationException (reaches AWS; only because dummy body lacks the cohere schema)
```

### Regression test (offline, mock-based)

Added `test_bedrock_embed_cohere_passes_modelid_to_invoke_model` to `tests/llm/bedrock_impl/test_bedrock_llm.py`, reusing the file's existing `_FakeBedrockClient` / `_FakeSession` pattern (`patch("lightrag.llm.bedrock.aioboto3.Session", ...)`). It captures the `invoke_model` kwargs and asserts `modelId` is passed and `model` is not. The fake response body uses the async `json()` interface (same as the amazon-path fake), so the test also exercises the body-read parity fix.

**Before (fix reverted, test kept):**
```text
lightrag/llm/bedrock.py:594: in bedrock_embed
    _handle_bedrock_exception(e, "Bedrock embedding (cohere)")
E   lightrag.llm.bedrock.BedrockError: Unexpected error: '_FakeCohereEmbeddingBody' object has no attribute 'read'
FAILED tests/llm/bedrock_impl/test_bedrock_llm.py::test_bedrock_embed_cohere_passes_modelid_to_invoke_model
```

**After (fix applied):**
```text
tests/llm/bedrock_impl/test_bedrock_llm.py::test_bedrock_embed_cohere_passes_modelid_to_invoke_model PASSED
27 passed, 3 warnings in 0.90s
```

Local checks: `pytest tests/llm/bedrock_impl/test_bedrock_llm.py -m offline` (27 passed); `ruff format --check` and `ruff check --ignore=E402` on both changed files (clean).

### Scope / follow-up

Intentionally minimal: only the Cohere branch is touched, matching the existing amazon branch. No public API, arguments, or return shape change.

---
This contribution was prepared with the help of an AI agent (Claude Code); a human reviewed the change, the reasoning, and the test results before submitting.