### PR TITLE
fix: centralize sync-wrapper event-loop guard with accurate errors

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -4379,9 +4379,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             include_vector_data: Whether to include data from the vector database.
         """
         _run_sync(
-            lambda: self.aexport_data(
-                output_path, file_format, include_vector_data
-            ),
+            lambda: self.aexport_data(output_path, file_format, include_vector_data),
             sync_name="export_data",
             async_name="aexport_data",
         )

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -166,43 +166,48 @@ def _run_sync(
     *,
     sync_name: str,
     async_name: str,
+    owning_loop: Optional[asyncio.AbstractEventLoop] = None,
 ) -> _SyncResultT:
     """Drive an async coroutine to completion from a synchronous wrapper.
 
     The synchronous wrappers (``insert``, ``query``, ``delete_by_entity``,
     …) all share the same shape: acquire an event loop and call
-    ``loop.run_until_complete()``.  That call is only valid when **no** event
-    loop is already running on the current thread:
+    ``loop.run_until_complete()``.  That call is only valid when the current
+    thread has **no** running loop *and* the loop it ends up driving is the
+    same one the instance's storages were initialized on.  Two misuse modes
+    break this, and both have the same fix — use the ``a*`` coroutine from
+    async code:
 
-    * Called from within a running loop on the same thread (e.g. directly
-      inside an ``async def`` / FastAPI handler), ``run_until_complete()``
-      raises ``RuntimeError: This event loop is already running``.  This is a
-      fail-fast error, not a deadlock — but the message gives no hint about
-      the fix.
-    * Pushed onto another thread's loop (e.g. ``loop.run_in_executor(None,
-      rag.insert, …)``), it runs on a *different* loop than the one the
-      storage backends were initialized on.  The shared ``asyncio.Lock``
-      objects in ``lightrag.kg.shared_storage`` bind to the first loop that
-      acquires them, so a second loop raises ``RuntimeError: <Lock> is bound
-      to a different event loop`` or stalls waiting on a callback scheduled
-      on an idle loop.
+    * **Same thread, inside a running loop** (e.g. directly inside an
+      ``async def`` / FastAPI handler): ``run_until_complete()`` would raise
+      ``RuntimeError: This event loop is already running``.  Detected up front
+      via :func:`asyncio.get_running_loop`.
+    * **A different loop than the storages bound to** (e.g.
+      ``loop.run_in_executor(None, rag.insert, …)`` runs the wrapper on a pool
+      thread with no loop, or an asyncio loop runs on another thread): the
+      shared ``asyncio.Lock`` objects in ``lightrag.kg.shared_storage`` are
+      bound to ``owning_loop``, so acquiring them from a second loop raises
+      ``RuntimeError: <Lock> is bound to a different event loop`` or stalls on
+      a callback scheduled on an idle loop.  Detected by comparing the loop we
+      are about to drive against ``owning_loop``.
 
-    Both failure modes have the same correct fix: use the ``a*`` coroutine
-    directly from async code.  This helper detects a running loop up front and
-    raises one clear, actionable error pointing at the async alternative.  The
-    coroutine is created lazily via ``coro_factory`` so the guard never leaves
-    an un-awaited coroutine behind when it raises.
+    The coroutine is created lazily via ``coro_factory`` so neither guard ever
+    leaves an un-awaited coroutine behind when it raises.
 
     Args:
         coro_factory: Zero-arg callable returning the coroutine to run.
         sync_name: Name of the sync wrapper, used in the error message.
         async_name: Name of the async method to recommend instead.
+        owning_loop: The loop the instance's storages were initialized on
+            (``LightRAG._owning_loop``). ``None`` when storages have not been
+            initialized yet, in which case the cross-loop check is skipped.
 
     Returns:
         The result of awaiting the coroutine.
 
     Raises:
-        RuntimeError: if called from within a running asyncio event loop.
+        RuntimeError: if called from within a running asyncio event loop, or
+            from a different loop than the one the storages were bound to.
     """
     try:
         asyncio.get_running_loop()
@@ -213,11 +218,21 @@ def _run_sync(
             f"{sync_name}() cannot be called from within a running asyncio "
             f"event loop. Synchronous wrappers internally call "
             f"loop.run_until_complete(), which Python forbids while a loop is "
-            f"already running on this thread (and which binds storage locks "
-            f"to the wrong loop when pushed onto another thread). "
+            f"already running on this thread. "
             f"Use `await {async_name}(...)` from async code instead."
         )
     loop = always_get_an_event_loop()
+    if owning_loop is not None and (loop is not owning_loop or owning_loop.is_closed()):
+        raise RuntimeError(
+            f"{sync_name}() must run on the same event loop this LightRAG "
+            f"instance was initialized on, but it is being driven from a "
+            f"different loop — typically `loop.run_in_executor(None, "
+            f"rag.{sync_name}, ...)`, or an asyncio loop running on another "
+            f"thread. LightRAG's shared storage locks are bound to the original "
+            f"loop, so running here would raise '<Lock> is bound to a different "
+            f"event loop' or stall. "
+            f"Use `await {async_name}(...)` on the original loop instead."
+        )
     return loop.run_until_complete(coro_factory())
 
 
@@ -703,6 +718,16 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     """Configuration for Ollama server information."""
 
     _storages_status: StoragesStatus = field(default=StoragesStatus.NOT_CREATED)
+
+    _owning_loop: Optional[asyncio.AbstractEventLoop] = field(default=None)
+    """The event loop this instance's storages were initialized on.
+
+    Captured in :meth:`initialize_storages`. The shared ``asyncio.Lock`` objects
+    in ``lightrag.kg.shared_storage`` bind to this loop, so every synchronous
+    wrapper must drive its coroutine on the *same* loop. ``_run_sync`` fails fast
+    when asked to run on a different one (e.g. ``loop.run_in_executor(None,
+    rag.insert, …)`` or an asyncio loop running on another thread).
+    """
 
     def _mark_addon_params_dirty(self) -> None:
         self._addon_params_dirty = True
@@ -1222,6 +1247,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     async def initialize_storages(self):
         """Storage initialization must be called one by one to prevent deadlock"""
         if self._storages_status == StoragesStatus.CREATED:
+            # Record the loop the storages (and their shared_storage locks) bind
+            # to, so the synchronous wrappers can fail fast if later driven from a
+            # different loop (run_in_executor / a loop on another thread).
+            self._owning_loop = asyncio.get_running_loop()
+
             # Set the first initialized workspace will set the default workspace
             # Allows namespace operation without specifying workspace for backward compatibility
             default_workspace = get_default_workspace()
@@ -1373,6 +1403,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             ),
             sync_name="insert",
             async_name="ainsert",
+            owning_loop=self._owning_loop,
         )
 
     async def ainsert(
@@ -1455,6 +1486,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             lambda: self.ainsert_custom_chunks(full_text, text_chunks, doc_id),
             sync_name="insert_custom_chunks",
             async_name="ainsert_custom_chunks",
+            owning_loop=self._owning_loop,
         )
 
     # TODO: deprecated, use ainsert instead
@@ -1729,6 +1761,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             lambda: self.ainsert_custom_kg(custom_kg, full_doc_id),
             sync_name="insert_custom_kg",
             async_name="ainsert_custom_kg",
+            owning_loop=self._owning_loop,
         )
 
     async def ainsert_custom_kg(
@@ -2019,6 +2052,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             lambda: self.aquery(query, param, system_prompt),
             sync_name="query",
             async_name="aquery",
+            owning_loop=self._owning_loop,
         )
 
     async def aquery(
@@ -2076,6 +2110,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             lambda: self.aquery_data(query, param),
             sync_name="query_data",
             async_name="aquery_data",
+            owning_loop=self._owning_loop,
         )
 
     async def aquery_data(
@@ -2449,6 +2484,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             lambda: self.aquery_llm(query, param, system_prompt),
             sync_name="query_llm",
             async_name="aquery_llm",
+            owning_loop=self._owning_loop,
         )
 
     async def _query_done(self):
@@ -2557,6 +2593,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             lambda: self.aclear_cache(),
             sync_name="clear_cache",
             async_name="aclear_cache",
+            owning_loop=self._owning_loop,
         )
 
     async def get_docs_by_status(
@@ -3996,6 +4033,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             lambda: self.adelete_by_entity(entity_name),
             sync_name="delete_by_entity",
             async_name="adelete_by_entity",
+            owning_loop=self._owning_loop,
         )
 
     async def adelete_by_relation(
@@ -4035,6 +4073,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             lambda: self.adelete_by_relation(source_entity, target_entity),
             sync_name="delete_by_relation",
             async_name="adelete_by_relation",
+            owning_loop=self._owning_loop,
         )
 
     async def get_processing_status(self) -> dict[str, int]:
@@ -4168,6 +4207,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             ),
             sync_name="edit_entity",
             async_name="aedit_entity",
+            owning_loop=self._owning_loop,
         )
 
     async def aedit_relation(
@@ -4205,6 +4245,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             lambda: self.aedit_relation(source_entity, target_entity, updated_data),
             sync_name="edit_relation",
             async_name="aedit_relation",
+            owning_loop=self._owning_loop,
         )
 
     async def acreate_entity(
@@ -4238,6 +4279,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             lambda: self.acreate_entity(entity_name, entity_data),
             sync_name="create_entity",
             async_name="acreate_entity",
+            owning_loop=self._owning_loop,
         )
 
     async def acreate_relation(
@@ -4273,6 +4315,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             lambda: self.acreate_relation(source_entity, target_entity, relation_data),
             sync_name="create_relation",
             async_name="acreate_relation",
+            owning_loop=self._owning_loop,
         )
 
     async def amerge_entities(
@@ -4329,6 +4372,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             ),
             sync_name="merge_entities",
             async_name="amerge_entities",
+            owning_loop=self._owning_loop,
         )
 
     async def aexport_data(
@@ -4382,6 +4426,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             lambda: self.aexport_data(output_path, file_format, include_vector_data),
             sync_name="export_data",
             async_name="aexport_data",
+            owning_loop=self._owning_loop,
         )
 
 

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -200,6 +200,13 @@ def _run_sync(
     fresh loop, preserving the long-standing behavior (any lock still bound to
     the closed loop is handled by ``asyncio.Lock`` itself, exactly as before).
 
+    These synchronous wrappers are compatibility conveniences for simple,
+    single-threaded scripts. SDK integrations, async applications, and
+    concurrent workloads should prefer the ``a*`` coroutine APIs. The wrappers
+    are not cross-thread-safe entry points for concurrent calls against the same
+    ``LightRAG`` instance; callers that must invoke them from multiple threads
+    need to serialize access externally or route work through one event loop.
+
     The coroutine is created lazily via ``coro_factory`` so neither guard ever
     leaves an un-awaited coroutine behind when it raises.
 

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -19,7 +19,9 @@ from typing import (
     AsyncIterator,
     Awaitable,
     Callable,
+    Coroutine,
     Iterator,
+    TypeVar,
     cast,
     final,
     Literal,
@@ -155,6 +157,68 @@ from lightrag.storage_migrations import _StorageMigrationMixin
 # allows to use different .env file for each lightrag instance
 # the OS environment variables take precedence over the .env file
 load_dotenv(dotenv_path=".env", override=False)
+
+_SyncResultT = TypeVar("_SyncResultT")
+
+
+def _run_sync(
+    coro_factory: Callable[[], Coroutine[Any, Any, _SyncResultT]],
+    *,
+    sync_name: str,
+    async_name: str,
+) -> _SyncResultT:
+    """Drive an async coroutine to completion from a synchronous wrapper.
+
+    The synchronous wrappers (``insert``, ``query``, ``delete_by_entity``,
+    …) all share the same shape: acquire an event loop and call
+    ``loop.run_until_complete()``.  That call is only valid when **no** event
+    loop is already running on the current thread:
+
+    * Called from within a running loop on the same thread (e.g. directly
+      inside an ``async def`` / FastAPI handler), ``run_until_complete()``
+      raises ``RuntimeError: This event loop is already running``.  This is a
+      fail-fast error, not a deadlock — but the message gives no hint about
+      the fix.
+    * Pushed onto another thread's loop (e.g. ``loop.run_in_executor(None,
+      rag.insert, …)``), it runs on a *different* loop than the one the
+      storage backends were initialized on.  The shared ``asyncio.Lock``
+      objects in ``lightrag.kg.shared_storage`` bind to the first loop that
+      acquires them, so a second loop raises ``RuntimeError: <Lock> is bound
+      to a different event loop`` or stalls waiting on a callback scheduled
+      on an idle loop.
+
+    Both failure modes have the same correct fix: use the ``a*`` coroutine
+    directly from async code.  This helper detects a running loop up front and
+    raises one clear, actionable error pointing at the async alternative.  The
+    coroutine is created lazily via ``coro_factory`` so the guard never leaves
+    an un-awaited coroutine behind when it raises.
+
+    Args:
+        coro_factory: Zero-arg callable returning the coroutine to run.
+        sync_name: Name of the sync wrapper, used in the error message.
+        async_name: Name of the async method to recommend instead.
+
+    Returns:
+        The result of awaiting the coroutine.
+
+    Raises:
+        RuntimeError: if called from within a running asyncio event loop.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        pass  # No running loop on this thread — safe to drive our own.
+    else:
+        raise RuntimeError(
+            f"{sync_name}() cannot be called from within a running asyncio "
+            f"event loop. Synchronous wrappers internally call "
+            f"loop.run_until_complete(), which Python forbids while a loop is "
+            f"already running on this thread (and which binds storage locks "
+            f"to the wrong loop when pushed onto another thread). "
+            f"Use `await {async_name}(...)` from async code instead."
+        )
+    loop = always_get_an_event_loop()
+    return loop.run_until_complete(coro_factory())
 
 
 @final
@@ -1298,16 +1362,17 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         Returns:
             str: tracking ID for monitoring processing status
         """
-        loop = always_get_an_event_loop()
-        return loop.run_until_complete(
-            self.ainsert(
+        return _run_sync(
+            lambda: self.ainsert(
                 input,
                 split_by_character,
                 split_by_character_only,
                 ids,
                 file_paths,
                 track_id,
-            )
+            ),
+            sync_name="insert",
+            async_name="ainsert",
         )
 
     async def ainsert(
@@ -1386,9 +1451,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         text_chunks: list[str],
         doc_id: str | list[str] | None = None,
     ) -> None:
-        loop = always_get_an_event_loop()
-        loop.run_until_complete(
-            self.ainsert_custom_chunks(full_text, text_chunks, doc_id)
+        _run_sync(
+            lambda: self.ainsert_custom_chunks(full_text, text_chunks, doc_id),
+            sync_name="insert_custom_chunks",
+            async_name="ainsert_custom_chunks",
         )
 
     # TODO: deprecated, use ainsert instead
@@ -1659,8 +1725,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     def insert_custom_kg(
         self, custom_kg: dict[str, Any], full_doc_id: str = None
     ) -> None:
-        loop = always_get_an_event_loop()
-        loop.run_until_complete(self.ainsert_custom_kg(custom_kg, full_doc_id))
+        _run_sync(
+            lambda: self.ainsert_custom_kg(custom_kg, full_doc_id),
+            sync_name="insert_custom_kg",
+            async_name="ainsert_custom_kg",
+        )
 
     async def ainsert_custom_kg(
         self,
@@ -1946,9 +2015,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         Returns:
             str: The result of the query execution.
         """
-        loop = always_get_an_event_loop()
-
-        return loop.run_until_complete(self.aquery(query, param, system_prompt))  # type: ignore
+        return _run_sync(  # type: ignore
+            lambda: self.aquery(query, param, system_prompt),
+            sync_name="query",
+            async_name="aquery",
+        )
 
     async def aquery(
         self,
@@ -2001,8 +2072,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         Returns:
             dict[str, Any]: Same structured data result as aquery_data.
         """
-        loop = always_get_an_event_loop()
-        return loop.run_until_complete(self.aquery_data(query, param))
+        return _run_sync(
+            lambda: self.aquery_data(query, param),
+            sync_name="query_data",
+            async_name="aquery_data",
+        )
 
     async def aquery_data(
         self,
@@ -2371,8 +2445,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         Returns:
             dict[str, Any]: Same complete response format as aquery_llm.
         """
-        loop = always_get_an_event_loop()
-        return loop.run_until_complete(self.aquery_llm(query, param, system_prompt))
+        return _run_sync(
+            lambda: self.aquery_llm(query, param, system_prompt),
+            sync_name="query_llm",
+            async_name="aquery_llm",
+        )
 
     async def _query_done(self):
         await self.llm_response_cache.index_done_callback()
@@ -2476,7 +2553,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
 
     def clear_cache(self) -> None:
         """Synchronous version of aclear_cache."""
-        return always_get_an_event_loop().run_until_complete(self.aclear_cache())
+        return _run_sync(
+            lambda: self.aclear_cache(),
+            sync_name="clear_cache",
+            async_name="aclear_cache",
+        )
 
     async def get_docs_by_status(
         self, status: DocStatus
@@ -3911,8 +3992,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         Returns:
             DeletionResult: An object containing the outcome of the deletion process.
         """
-        loop = always_get_an_event_loop()
-        return loop.run_until_complete(self.adelete_by_entity(entity_name))
+        return _run_sync(
+            lambda: self.adelete_by_entity(entity_name),
+            sync_name="delete_by_entity",
+            async_name="adelete_by_entity",
+        )
 
     async def adelete_by_relation(
         self, source_entity: str, target_entity: str
@@ -3947,9 +4031,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         Returns:
             DeletionResult: An object containing the outcome of the deletion process.
         """
-        loop = always_get_an_event_loop()
-        return loop.run_until_complete(
-            self.adelete_by_relation(source_entity, target_entity)
+        return _run_sync(
+            lambda: self.adelete_by_relation(source_entity, target_entity),
+            sync_name="delete_by_relation",
+            async_name="adelete_by_relation",
         )
 
     async def get_processing_status(self) -> dict[str, int]:
@@ -4077,9 +4162,12 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         allow_rename: bool = True,
         allow_merge: bool = False,
     ) -> dict[str, Any]:
-        loop = always_get_an_event_loop()
-        return loop.run_until_complete(
-            self.aedit_entity(entity_name, updated_data, allow_rename, allow_merge)
+        return _run_sync(
+            lambda: self.aedit_entity(
+                entity_name, updated_data, allow_rename, allow_merge
+            ),
+            sync_name="edit_entity",
+            async_name="aedit_entity",
         )
 
     async def aedit_relation(
@@ -4113,9 +4201,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     def edit_relation(
         self, source_entity: str, target_entity: str, updated_data: dict[str, Any]
     ) -> dict[str, Any]:
-        loop = always_get_an_event_loop()
-        return loop.run_until_complete(
-            self.aedit_relation(source_entity, target_entity, updated_data)
+        return _run_sync(
+            lambda: self.aedit_relation(source_entity, target_entity, updated_data),
+            sync_name="edit_relation",
+            async_name="aedit_relation",
         )
 
     async def acreate_entity(
@@ -4145,8 +4234,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     def create_entity(
         self, entity_name: str, entity_data: dict[str, Any]
     ) -> dict[str, Any]:
-        loop = always_get_an_event_loop()
-        return loop.run_until_complete(self.acreate_entity(entity_name, entity_data))
+        return _run_sync(
+            lambda: self.acreate_entity(entity_name, entity_data),
+            sync_name="create_entity",
+            async_name="acreate_entity",
+        )
 
     async def acreate_relation(
         self, source_entity: str, target_entity: str, relation_data: dict[str, Any]
@@ -4177,9 +4269,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     def create_relation(
         self, source_entity: str, target_entity: str, relation_data: dict[str, Any]
     ) -> dict[str, Any]:
-        loop = always_get_an_event_loop()
-        return loop.run_until_complete(
-            self.acreate_relation(source_entity, target_entity, relation_data)
+        return _run_sync(
+            lambda: self.acreate_relation(source_entity, target_entity, relation_data),
+            sync_name="create_relation",
+            async_name="acreate_relation",
         )
 
     async def amerge_entities(
@@ -4230,11 +4323,12 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         merge_strategy: dict[str, str] = None,
         target_entity_data: dict[str, Any] = None,
     ) -> dict[str, Any]:
-        loop = always_get_an_event_loop()
-        return loop.run_until_complete(
-            self.amerge_entities(
+        return _run_sync(
+            lambda: self.amerge_entities(
                 source_entities, target_entity, merge_strategy, target_entity_data
-            )
+            ),
+            sync_name="merge_entities",
+            async_name="amerge_entities",
         )
 
     async def aexport_data(
@@ -4284,14 +4378,12 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 - table: Print formatted tables to console
             include_vector_data: Whether to include data from the vector database.
         """
-        try:
-            loop = asyncio.get_event_loop()
-        except RuntimeError:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-
-        loop.run_until_complete(
-            self.aexport_data(output_path, file_format, include_vector_data)
+        _run_sync(
+            lambda: self.aexport_data(
+                output_path, file_format, include_vector_data
+            ),
+            sync_name="export_data",
+            async_name="aexport_data",
         )
 
 

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -182,14 +182,23 @@ def _run_sync(
       ``async def`` / FastAPI handler): ``run_until_complete()`` would raise
       ``RuntimeError: This event loop is already running``.  Detected up front
       via :func:`asyncio.get_running_loop`.
-    * **A different loop than the storages bound to** (e.g.
-      ``loop.run_in_executor(None, rag.insert, …)`` runs the wrapper on a pool
-      thread with no loop, or an asyncio loop runs on another thread): the
-      shared ``asyncio.Lock`` objects in ``lightrag.kg.shared_storage`` are
-      bound to ``owning_loop``, so acquiring them from a second loop raises
+    * **A different — but still alive — loop than the storages bound to**
+      (e.g. ``loop.run_in_executor(None, rag.insert, …)`` runs the wrapper on a
+      pool thread that spins up a fresh loop while the app's loop keeps
+      running, or an asyncio loop runs on another thread): the shared
+      ``asyncio.Lock`` objects in ``lightrag.kg.shared_storage`` are bound to
+      ``owning_loop``, so acquiring them from a second loop raises
       ``RuntimeError: <Lock> is bound to a different event loop`` or stalls on
       a callback scheduled on an idle loop.  Detected by comparing the loop we
       are about to drive against ``owning_loop``.
+
+    The cross-loop check only fires while ``owning_loop`` is still **open**.  A
+    *closed* ``owning_loop`` means the loop the storages were initialized on is
+    gone — e.g. the common ``rag = asyncio.run(initialize_rag())`` pattern,
+    where ``asyncio.run`` closes the loop after ``initialize_storages()`` — so
+    there is no live loop to clash with.  We let those calls through to run on a
+    fresh loop, preserving the long-standing behavior (any lock still bound to
+    the closed loop is handled by ``asyncio.Lock`` itself, exactly as before).
 
     The coroutine is created lazily via ``coro_factory`` so neither guard ever
     leaves an un-awaited coroutine behind when it raises.
@@ -200,14 +209,16 @@ def _run_sync(
         async_name: Name of the async method to recommend instead.
         owning_loop: The loop the instance's storages were initialized on
             (``LightRAG._owning_loop``). ``None`` when storages have not been
-            initialized yet, in which case the cross-loop check is skipped.
+            initialized yet, or closed, in which case the cross-loop check is
+            skipped.
 
     Returns:
         The result of awaiting the coroutine.
 
     Raises:
         RuntimeError: if called from within a running asyncio event loop, or
-            from a different loop than the one the storages were bound to.
+            from a different loop while the loop the storages were bound to is
+            still open.
     """
     try:
         asyncio.get_running_loop()
@@ -222,7 +233,11 @@ def _run_sync(
             f"Use `await {async_name}(...)` from async code instead."
         )
     loop = always_get_an_event_loop()
-    if owning_loop is not None and (loop is not owning_loop or owning_loop.is_closed()):
+    if (
+        owning_loop is not None
+        and not owning_loop.is_closed()
+        and loop is not owning_loop
+    ):
         raise RuntimeError(
             f"{sync_name}() must run on the same event loop this LightRAG "
             f"instance was initialized on, but it is being driven from a "
@@ -719,16 +734,6 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
 
     _storages_status: StoragesStatus = field(default=StoragesStatus.NOT_CREATED)
 
-    _owning_loop: Optional[asyncio.AbstractEventLoop] = field(default=None)
-    """The event loop this instance's storages were initialized on.
-
-    Captured in :meth:`initialize_storages`. The shared ``asyncio.Lock`` objects
-    in ``lightrag.kg.shared_storage`` bind to this loop, so every synchronous
-    wrapper must drive its coroutine on the *same* loop. ``_run_sync`` fails fast
-    when asked to run on a different one (e.g. ``loop.run_in_executor(None,
-    rag.insert, …)`` or an asyncio loop running on another thread).
-    """
-
     def _mark_addon_params_dirty(self) -> None:
         self._addon_params_dirty = True
 
@@ -1187,6 +1192,13 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
 
         self._llm_role_builder = None
         self._retired_llm_queue_cleanup_tasks: set[asyncio.Task] = set()
+
+        # The event loop this instance's storages bind to (set in
+        # initialize_storages). Kept off the dataclass fields so asdict() in
+        # _build_global_config() never tries to (deep)copy a live loop — that
+        # raises TypeError on Python 3.14. _run_sync uses it only as a reference
+        # for the cross-loop guard.
+        self._owning_loop: Optional[asyncio.AbstractEventLoop] = None
 
         user_role_configs = self.role_llm_configs or {}
         if not isinstance(user_role_configs, Mapping):

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -3011,25 +3011,38 @@ def always_get_an_event_loop() -> asyncio.AbstractEventLoop:
     """
     Ensure that there is always an event loop available.
 
-    This function tries to get the current event loop. If the current event loop is closed or does not exist,
-    it creates a new event loop and sets it as the current event loop.
+    Reuses the loop running on (or installed on) the current thread so that
+    repeated synchronous calls share a single loop; if none exists or it is
+    closed, creates a new one and installs it as the current loop.
 
     Returns:
         asyncio.AbstractEventLoop: The current or newly created event loop.
     """
+    # Reuse a loop actively running on this thread.
     try:
-        # Try to get the current event loop
-        current_loop = asyncio.get_event_loop()
-        if current_loop.is_closed():
-            raise RuntimeError("Event loop is closed.")
-        return current_loop
-
+        return asyncio.get_running_loop()
     except RuntimeError:
-        # If no event loop exists or it is closed, create a new one
-        logger.info("Creating a new event loop in main thread.")
-        new_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(new_loop)
-        return new_loop
+        pass
+
+    # Reuse a loop already installed on this thread, but never let
+    # asyncio.get_event_loop() lazily auto-create one — on Python 3.12+ that
+    # emits a DeprecationWarning. Promote that warning to an error so the
+    # "no current loop" case falls through to explicit creation below, while a
+    # genuinely installed (open) loop is still returned and reused.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        try:
+            current_loop = asyncio.get_event_loop()
+            if not current_loop.is_closed():
+                return current_loop
+        except (RuntimeError, DeprecationWarning):
+            pass
+
+    # No usable loop on this thread — create one and install it.
+    logger.info("Creating a new event loop in main thread.")
+    new_loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(new_loop)
+    return new_loop
 
 
 async def aexport_data(

--- a/tests/test_sync_wrapper_guard.py
+++ b/tests/test_sync_wrapper_guard.py
@@ -4,20 +4,27 @@
 ``delete_by_entity`` …) all delegate to :func:`lightrag.lightrag._run_sync`,
 which drives the matching ``a*`` coroutine via ``loop.run_until_complete()``.
 
-That call is only valid when no event loop is already running on the current
-thread.  Called from within a running loop it raises
-``RuntimeError: This event loop is already running`` — a fail-fast error, *not*
-a deadlock — and pushing it onto another thread's loop binds the shared
-``asyncio.Lock`` objects in ``lightrag.kg.shared_storage`` to the wrong loop.
-Both have the same fix: use the ``a*`` coroutine directly.
+That call is only valid when (a) no event loop is already running on the
+current thread, and (b) the loop it drives is the same one the instance's
+storages were initialized on (``LightRAG._owning_loop``).  Two misuse modes
+break this:
 
-``_run_sync`` detects a running loop up front and raises one clear, actionable
-error.  These tests pin that behaviour (and guard against regressing back to
-the misleading "deadlock" wording / un-awaited-coroutine leak). See
-HKUDS/LightRAG #1968.
+* Called from within a running loop it raises ``RuntimeError: This event loop
+  is already running`` — a fail-fast error, *not* a deadlock.
+* Driven from a different loop — e.g. ``loop.run_in_executor(None, rag.insert,
+  …)`` runs the wrapper on a pool thread that spins up a fresh loop — binds the
+  shared ``asyncio.Lock`` objects in ``lightrag.kg.shared_storage`` to the
+  wrong loop (``<Lock> is bound to a different event loop`` / a stall).
+
+Both have the same fix: use the ``a*`` coroutine directly.  ``_run_sync``
+detects the running loop up front and compares the loop it is about to drive
+against ``owning_loop``, raising one clear, actionable error for each.  These
+tests pin that behaviour (and guard against regressing back to the misleading
+"deadlock" wording / un-awaited-coroutine leak). See HKUDS/LightRAG #1968.
 """
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -82,3 +89,67 @@ def test_run_sync_does_not_create_coroutine_when_it_raises():
         asyncio.run(_inside_loop())
 
     assert calls == [], "coro_factory should not run when the guard rejects"
+
+
+@pytest.mark.offline
+def test_run_sync_runs_when_owning_loop_matches():
+    """When the loop being driven is the instance's owning loop, the coroutine
+    runs to completion — the cross-loop guard only fires on a mismatch."""
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    def factory():
+        async def _coro():
+            return 42
+
+        return _coro()
+
+    try:
+        # always_get_an_event_loop() returns the loop set above, which is the
+        # one we declare as owning -> match -> the coroutine runs.
+        result = _run_sync(
+            factory, sync_name="insert", async_name="ainsert", owning_loop=loop
+        )
+        assert result == 42
+    finally:
+        loop.close()
+        asyncio.set_event_loop(None)
+
+
+@pytest.mark.offline
+def test_run_sync_raises_when_driven_from_a_different_loop():
+    """Driving a sync wrapper from a thread with no event loop of its own
+    (the ``loop.run_in_executor(None, rag.insert, …)`` anti-pattern) lands on a
+    freshly created loop, not the instance's owning loop. The guard must fail
+    fast pointing at the async alternative, without running the coroutine."""
+
+    owning_loop = asyncio.new_event_loop()
+    calls: list[bool] = []
+
+    def factory():  # pragma: no cover - must never be reached
+        calls.append(True)
+        raise AssertionError("coro_factory must not run on the wrong loop")
+
+    def call_off_thread():
+        # No loop is set on this worker thread, so always_get_an_event_loop()
+        # creates a brand-new one — different from owning_loop.
+        return _run_sync(
+            factory,
+            sync_name="insert",
+            async_name="ainsert",
+            owning_loop=owning_loop,
+        )
+
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            with pytest.raises(RuntimeError) as exc_info:
+                executor.submit(call_off_thread).result()
+    finally:
+        owning_loop.close()
+
+    message = str(exc_info.value)
+    assert "insert()" in message
+    assert "await ainsert(" in message
+    assert "deadlock" not in message.lower()
+    assert calls == [], "coro_factory should not run on a mismatched loop"

--- a/tests/test_sync_wrapper_guard.py
+++ b/tests/test_sync_wrapper_guard.py
@@ -1,0 +1,84 @@
+"""Regression tests for the synchronous-wrapper event-loop guard.
+
+``LightRAG``'s synchronous wrappers (``insert``, ``query``,
+``delete_by_entity`` …) all delegate to :func:`lightrag.lightrag._run_sync`,
+which drives the matching ``a*`` coroutine via ``loop.run_until_complete()``.
+
+That call is only valid when no event loop is already running on the current
+thread.  Called from within a running loop it raises
+``RuntimeError: This event loop is already running`` — a fail-fast error, *not*
+a deadlock — and pushing it onto another thread's loop binds the shared
+``asyncio.Lock`` objects in ``lightrag.kg.shared_storage`` to the wrong loop.
+Both have the same fix: use the ``a*`` coroutine directly.
+
+``_run_sync`` detects a running loop up front and raises one clear, actionable
+error.  These tests pin that behaviour (and guard against regressing back to
+the misleading "deadlock" wording / un-awaited-coroutine leak). See
+HKUDS/LightRAG #1968.
+"""
+
+import asyncio
+
+import pytest
+
+from lightrag.lightrag import _run_sync
+
+
+@pytest.mark.offline
+def test_run_sync_runs_coroutine_when_no_loop_running():
+    """With no running loop, the coroutine runs to completion and returns."""
+
+    def factory():
+        async def _coro():
+            return 42
+
+        return _coro()
+
+    result = _run_sync(factory, sync_name="insert", async_name="ainsert")
+    assert result == 42
+
+
+@pytest.mark.offline
+def test_run_sync_raises_clear_error_inside_running_loop():
+    """Inside a running loop the guard raises a RuntimeError pointing at the
+    async alternative — and the message is honest (no "deadlock" claim)."""
+
+    def factory():  # pragma: no cover - must never be reached
+        raise AssertionError("coro_factory must not be called inside a loop")
+
+    async def _inside_loop():
+        return _run_sync(factory, sync_name="insert", async_name="ainsert")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(_inside_loop())
+
+    message = str(exc_info.value)
+    assert "insert()" in message
+    assert "await ainsert(" in message
+    # The previous fix (PR #3245) mislabelled this as a deadlock; it is an
+    # immediate RuntimeError.  Keep the message free of that wording.
+    assert "deadlock" not in message.lower()
+
+
+@pytest.mark.offline
+def test_run_sync_does_not_create_coroutine_when_it_raises():
+    """The factory is invoked lazily, so a guard failure never leaves an
+    un-awaited coroutine behind (which would emit a RuntimeWarning)."""
+
+    calls: list[bool] = []
+
+    def factory():
+        calls.append(True)
+
+        async def _coro():
+            return None
+
+        return _coro()
+
+    async def _inside_loop():
+        return _run_sync(factory, sync_name="query", async_name="aquery")
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(_inside_loop())
+
+    assert calls == [], "coro_factory should not run when the guard rejects"

--- a/tests/test_sync_wrapper_guard.py
+++ b/tests/test_sync_wrapper_guard.py
@@ -11,16 +11,23 @@ break this:
 
 * Called from within a running loop it raises ``RuntimeError: This event loop
   is already running`` — a fail-fast error, *not* a deadlock.
-* Driven from a different loop — e.g. ``loop.run_in_executor(None, rag.insert,
-  …)`` runs the wrapper on a pool thread that spins up a fresh loop — binds the
-  shared ``asyncio.Lock`` objects in ``lightrag.kg.shared_storage`` to the
+* Driven from a different — but still alive — loop, e.g.
+  ``loop.run_in_executor(None, rag.insert, …)`` runs the wrapper on a pool
+  thread that spins up a fresh loop while the app's loop keeps running — binds
+  the shared ``asyncio.Lock`` objects in ``lightrag.kg.shared_storage`` to the
   wrong loop (``<Lock> is bound to a different event loop`` / a stall).
 
-Both have the same fix: use the ``a*`` coroutine directly.  ``_run_sync``
-detects the running loop up front and compares the loop it is about to drive
-against ``owning_loop``, raising one clear, actionable error for each.  These
-tests pin that behaviour (and guard against regressing back to the misleading
-"deadlock" wording / un-awaited-coroutine leak). See HKUDS/LightRAG #1968.
+The cross-loop check only fires while ``owning_loop`` is still open.  A *closed*
+owning loop (the ``rag = asyncio.run(initialize_rag())`` pattern, where
+``asyncio.run`` closes the loop after ``initialize_storages()``) is let through
+to run on a fresh loop, preserving long-standing behavior.
+
+Both misuse modes have the same fix: use the ``a*`` coroutine directly.
+``_run_sync`` detects the running loop up front and compares the loop it is
+about to drive against ``owning_loop``, raising one clear, actionable error for
+each.  These tests pin that behaviour (and guard against regressing back to the
+misleading "deadlock" wording / un-awaited-coroutine leak). See
+HKUDS/LightRAG #1968.
 """
 
 import asyncio
@@ -153,3 +160,37 @@ def test_run_sync_raises_when_driven_from_a_different_loop():
     assert "await ainsert(" in message
     assert "deadlock" not in message.lower()
     assert calls == [], "coro_factory should not run on a mismatched loop"
+
+
+@pytest.mark.offline
+def test_run_sync_runs_when_owning_loop_is_closed():
+    """A *closed* owning loop means the loop the storages were initialized on is
+    gone — the common ``rag = asyncio.run(initialize_rag())`` pattern, where
+    ``asyncio.run`` closes the loop after ``initialize_storages()``. There is no
+    live loop to clash with, so the guard must let the call through and run the
+    coroutine on a fresh loop (preserving long-standing behavior), not reject
+    it."""
+
+    closed_owning_loop = asyncio.new_event_loop()
+    closed_owning_loop.close()
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    def factory():
+        async def _coro():
+            return 42
+
+        return _coro()
+
+    try:
+        result = _run_sync(
+            factory,
+            sync_name="insert",
+            async_name="ainsert",
+            owning_loop=closed_owning_loop,
+        )
+        assert result == 42
+    finally:
+        loop.close()
+        asyncio.set_event_loop(None)


### PR DESCRIPTION
## Summary

Centralizes the event-loop handling shared by all of `LightRAG`'s synchronous wrappers into a single `_run_sync()` helper, and replaces the obscure failures that occur when a sync wrapper is called against the wrong event loop with one clear, actionable error.

This is an alternative to #3245, focused only on the sync-interface improvement (the part of #3245 that had real value), implemented more completely and without its drawbacks.

## Motivation

Closes the sync-interface portion of #1968. The 15 sync wrappers (`insert`, `query`, `query_data`, `query_llm`, `insert_custom_chunks`, `insert_custom_kg`, `clear_cache`, `delete_by_entity`, `delete_by_relation`, `edit_entity`, `edit_relation`, `create_entity`, `create_relation`, `merge_entities`, `export_data`) each acquired a loop and called `loop.run_until_complete()` inline. That is only valid when the current thread has no running loop **and** the loop it drives is the one the storages were initialized on. Two misuse modes break this, with obscure failures:

- **Same thread** (directly inside an `async def` / FastAPI handler): `run_until_complete()` raises `RuntimeError: This event loop is already running`. This is a fail-fast error, **not** a deadlock, but the message gives no hint about the fix.
- **Wrong loop while the original loop is still alive** (`loop.run_in_executor(None, rag.insert, ...)` spins up a fresh loop on a pool thread while the app's loop keeps running, or an asyncio loop runs on another thread): the coroutine runs on a *different* loop than the one the storages were initialized on. The shared `asyncio.Lock` objects in `lightrag.kg.shared_storage` bind to the first loop that acquires them, so a second loop raises `RuntimeError: <Lock> is bound to a different event loop` or stalls on a callback scheduled on an idle loop.

Both have the same correct fix: use the `a*` coroutine directly from async code.

## What's changed

- New module-level `_run_sync(coro_factory, *, sync_name, async_name, owning_loop)` helper in `lightrag/lightrag.py`. It guards **both** misuse modes:
  - detects a running loop on the current thread via `asyncio.get_running_loop()` up front (same-thread case);
  - compares the loop it is about to drive against `owning_loop` and fails fast on a mismatch, but **only while `owning_loop` is still open** (wrong-loop case, covers `run_in_executor` and loops running on another thread without relying on thread-position heuristics).
  Each raises a single clear `RuntimeError` naming the correct `await a*(...)` alternative. The coroutine is built lazily through a factory, so a rejected call never leaves an un-awaited coroutine behind.
- `LightRAG._owning_loop` is captured in `initialize_storages()` as the loop the storages (and their `shared_storage` locks) bind to. It is a plain `__post_init__` instance attribute, **not** a dataclass field, so `_build_global_config()`'s `asdict(self)` never tries to (deep)copy a live event loop (which raises `TypeError: cannot pickle '_contextvars.Context'` on Python 3.14). The 15 sync wrappers pass it through to `_run_sync(...)`.
- The cross-loop check is deliberately scoped to a **still-alive** `owning_loop`. A *closed* one, such as the common `rag = asyncio.run(initialize_rag())` pattern where `asyncio.run` closes the loop after `initialize_storages()`, is let through to run on a fresh loop, preserving the long-standing behavior (any lock still bound to the closed loop is handled by `asyncio.Lock` itself, exactly as before).
- The `_run_sync()` docstring now explicitly documents the sync wrapper boundary: these wrappers are compatibility conveniences for simple, single-threaded scripts. SDK integrations, async apps, and concurrent workloads should prefer the `a*` coroutine APIs. The sync wrappers are not cross-thread-safe entry points for concurrent calls against the same `LightRAG` instance; callers that must use them from multiple threads need external serialization or a single-loop worker.
- All 15 sync wrappers now delegate to `_run_sync(...)`, removing the duplicated `always_get_an_event_loop()` / `run_until_complete()` boilerplate.
- `always_get_an_event_loop()` no longer triggers the `asyncio.get_event_loop()` auto-create `DeprecationWarning` on Python 3.12+, while preserving loop reuse (which the owning-loop guard relies on).
- Regression tests in `tests/test_sync_wrapper_guard.py` (same-thread guard, lazy-factory no-leak, matching-loop runs, live mismatched-loop fails fast, closed owning-loop runs).

## Sync wrapper scope

The synchronous API remains supported for simple single-threaded scripts and existing examples, including `rag = asyncio.run(initialize_rag()); rag.insert(...)`. It should not be treated as the preferred SDK integration surface or as a cross-thread-safe concurrency API.

For application code, especially FastAPI/Jupyter/task-queue integrations or any workload with an existing event loop, prefer `await rag.ainsert(...)`, `await rag.aquery(...)`, and the other async methods. If synchronous wrappers must be called from multiple threads, serialize those calls externally or route them through one event loop.

## How this compares to #3245

- **DRY**: one helper instead of 12 copy-pasted guard calls layered on top of the existing per-wrapper loop boilerplate.
- **More complete**: also covers `clear_cache` and `export_data` (which #3245 did not) **and** the off-thread / wrong-loop case (which neither #3245 nor the running-loop-only check caught).
- **No lint regression**: the helper is placed after all imports. #3245 inserted its function *between* import statements, which triggers ruff `E402`.
- **Accurate wording**: the same-thread condition is an immediate `RuntimeError`, not a "silent deadlock" as #3245's message stated. The new messages say so honestly and point at the async API.

This PR intentionally does **not** include #3245's "zombie chunk cleanup" change: orphaned chunks from a failed extraction are already cleaned up by the existing resume path (`_purge_stale_extraction_if_resuming`) and by `adelete_by_doc_id`, so that part was redundant.

## What's broken / how it works

No behavioral change for correct sync usage, including the `rag = asyncio.run(initialize_rag())` + sync-wrapper pattern used throughout the examples (the init loop is closed, so the guard stays out of the way). The only new behavior is a clear fail-fast `RuntimeError` (instead of an obscure one or a stall) when a sync wrapper is driven from within a running loop, or from a *different, still-alive* loop than the one the instance was initialized on (the `run_in_executor` hazard).

The sync wrappers remain a compatibility/convenience layer, not the recommended API for async or concurrent SDK integrations. The async `a*` methods are the safe default for those environments.

## Test plan

- [x] `_run_sync` runs the coroutine and returns its result when no loop is running
- [x] `_run_sync` runs the coroutine when the driven loop is the instance's owning loop
- [x] `_run_sync` raises `RuntimeError` naming the sync + async methods when called inside a running loop, with no misleading "deadlock" wording
- [x] `_run_sync` raises `RuntimeError` when driven from a different, still-alive loop (off-thread `run_in_executor` pattern), without creating the coroutine
- [x] `_run_sync` runs the coroutine when `owning_loop` is closed (the `asyncio.run(initialize_rag())` example pattern), no regression
- [x] `_run_sync` does not create (leak) a coroutine when a guard rejects
- [x] `_owning_loop` is not a dataclass field, so `asdict(self)` excludes it (Python 3.14 `asdict` no longer chokes on a live loop)
- [x] `pre-commit run ruff / ruff-format` on `lightrag/lightrag.py` and `tests/test_sync_wrapper_guard.py` pass
- [x] `pytest tests/test_sync_wrapper_guard.py -W error::DeprecationWarning` — 6 passed, no warnings

Refs #1968. Alternative to #3245.
