### PR TITLE
fix(mineru): surface backend transport failures in doc_status error_msg

### DIFF
--- a/lightrag/parser/external/mineru/client.py
+++ b/lightrag/parser/external/mineru/client.py
@@ -203,15 +203,30 @@ class MinerURawClient:
         resolved_upload_name = _resolve_upload_name(upload_name, source_file_path)
 
         timeout = httpx.Timeout(120.0, connect=30.0)
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            if self.api_mode == "official":
-                task_id = await self._download_official(
-                    client, source_file_path, raw_dir, resolved_upload_name
-                )
-            else:
-                task_id = await self._download_local(
-                    client, source_file_path, raw_dir, resolved_upload_name
-                )
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                if self.api_mode == "official":
+                    task_id = await self._download_official(
+                        client, source_file_path, raw_dir, resolved_upload_name
+                    )
+                else:
+                    task_id = await self._download_local(
+                        client, source_file_path, raw_dir, resolved_upload_name
+                    )
+        except httpx.RequestError as exc:
+            # Transport-level failures (connection refused/reset, server
+            # disconnect, read/connect timeout) bubble up from httpx with an
+            # opaque, sometimes empty message like "All connection attempts
+            # failed" that gives no hint the parse engine was MinerU. HTTP
+            # status errors and protocol errors already raise context-rich
+            # RuntimeErrors via raise_for_status_with_detail, so they stay
+            # untouched. Re-raise with the engine + endpoint and the exception
+            # class name so the doc_status error_msg is always non-empty and
+            # clearly attributable to the MinerU backend.
+            raise RuntimeError(
+                f"MinerU {self.api_mode} backend request failed "
+                f"(endpoint={self.endpoint}): {type(exc).__name__}: {exc}"
+            ) from exc
 
         self._normalize_raw_bundle(raw_dir, source_file_path, resolved_upload_name)
         return self._build_and_write_manifest(

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1800,8 +1800,15 @@ class _PipelineMixin:
                         extra_fields=extra_fields_w,
                         metadata_extra=metadata_extra_w,
                     )
-                except Exception:
-                    pass
+                except Exception as upsert_err:
+                    # The storage backend may be unavailable too (e.g. the same
+                    # outage that failed the parse). Don't re-raise — that would
+                    # take down the worker — but log so the doc stuck in PARSING
+                    # is diagnosable instead of failing silently.
+                    logger.error(
+                        f"Failed to record FAILED status for {doc_id_w}: "
+                        f"{upsert_err}"
+                    )
             finally:
                 in_q.task_done()
 
@@ -1924,8 +1931,14 @@ class _PipelineMixin:
                         file_path=getattr(status_doc_w, "file_path", "unknown_source"),
                         extra_fields={"error_msg": str(e)},
                     )
-                except Exception:
-                    pass
+                except Exception as upsert_err:
+                    # Mirror _parse_worker: log instead of swallowing so a
+                    # storage write failure leaves the doc stuck in ANALYZING
+                    # with a diagnosable trail rather than silently.
+                    logger.error(
+                        f"Failed to record FAILED status for {doc_id_w}: "
+                        f"{upsert_err}"
+                    )
             finally:
                 ctx.q_analyze.task_done()
 

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -424,6 +424,11 @@ def doc_status_parse_failure_fields(
     ``status_doc.metadata``; an existing value always wins via carry-over.
     """
     error_text = str(error)
+    if not error_text.strip():
+        # Some exceptions (e.g. certain httpx transport errors) stringify to
+        # an empty message; fall back to the class name so the WebUI never
+        # drops the Error Message row for a FAILED document.
+        error_text = type(error).__name__
     extra_fields: dict[str, Any] = {"error_msg": error_text}
     current_summary = str(
         doc_status_field(status_doc, "content_summary", "") or ""

--- a/tests/parser/external/mineru/test_client.py
+++ b/tests/parser/external/mineru/test_client.py
@@ -129,6 +129,14 @@ async def _collect_async_bytes(stream: Any) -> bytes:
 # ---------------------------------------------------------------------------
 
 
+class _FakeRequestError(Exception):
+    """Stand-in for ``httpx.RequestError`` (transport-level base)."""
+
+
+class _FakeConnectError(_FakeRequestError):
+    """Stand-in for ``httpx.ConnectError``."""
+
+
 @pytest.fixture
 def fake_httpx(monkeypatch: pytest.MonkeyPatch) -> type:
     import lightrag.parser.external.mineru.client as mod
@@ -139,6 +147,8 @@ def fake_httpx(monkeypatch: pytest.MonkeyPatch) -> type:
         {
             "AsyncClient": _FakeAsyncClient,
             "Timeout": lambda *a, **k: None,
+            "RequestError": _FakeRequestError,
+            "ConnectError": _FakeConnectError,
         },
     )
     monkeypatch.setattr(mod, "httpx", fake)
@@ -640,6 +650,70 @@ async def test_client_local_bad_request_preserves_response_body(
     assert "HTTP 400" in message
     assert "unsupported file type" in message
     assert "demo.xlsx" in message
+
+
+class _LocalConnectErrorDispatcher(_Dispatcher):
+    """Backend is down: every request fails at the transport layer."""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+
+    def post(self, url: str, **_: Any) -> _FakeResponse:
+        raise _FakeConnectError(self.message)
+
+
+@pytest.mark.offline
+async def test_client_connection_error_is_wrapped_with_engine_context(
+    tmp_path: Path,
+    fake_httpx: type,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transport-level failure (e.g. backend restart) must surface as a
+    RuntimeError that names MinerU + the endpoint, so the doc_status error_msg
+    is attributable instead of an opaque ``All connection attempts failed``."""
+    monkeypatch.setenv("MINERU_API_MODE", "local")
+    monkeypatch.setenv("MINERU_LOCAL_ENDPOINT", "http://127.0.0.1:8000")
+
+    src = tmp_path / "demo.pdf"
+    src.write_bytes(b"PDFBYTES" * 200)
+    raw = tmp_path / "demo.mineru_raw"
+    raw.mkdir()
+
+    _CURRENT.dispatcher = _LocalConnectErrorDispatcher("All connection attempts failed")
+    with pytest.raises(RuntimeError) as exc_info:
+        await MinerURawClient().download_into(raw, src)
+
+    message = str(exc_info.value)
+    assert "MinerU local backend request failed" in message
+    assert "http://127.0.0.1:8000" in message
+    assert "_FakeConnectError" in message
+    assert "All connection attempts failed" in message
+
+
+@pytest.mark.offline
+async def test_client_connection_error_with_empty_message_stays_non_empty(
+    tmp_path: Path,
+    fake_httpx: type,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Some transport errors stringify to an empty message; the wrapped
+    RuntimeError must still carry the exception class name and context."""
+    monkeypatch.setenv("MINERU_API_MODE", "local")
+    monkeypatch.setenv("MINERU_LOCAL_ENDPOINT", "http://127.0.0.1:8000")
+
+    src = tmp_path / "demo.pdf"
+    src.write_bytes(b"PDFBYTES" * 200)
+    raw = tmp_path / "demo.mineru_raw"
+    raw.mkdir()
+
+    _CURRENT.dispatcher = _LocalConnectErrorDispatcher("")
+    with pytest.raises(RuntimeError) as exc_info:
+        await MinerURawClient().download_into(raw, src)
+
+    message = str(exc_info.value)
+    assert message.strip()
+    assert "MinerU local backend request failed" in message
+    assert "_FakeConnectError" in message
 
 
 @pytest.mark.offline

--- a/tests/pipeline/test_parse_failure_doc_status_fields.py
+++ b/tests/pipeline/test_parse_failure_doc_status_fields.py
@@ -23,6 +23,7 @@ external / native / third-party):
 from __future__ import annotations
 
 import asyncio
+import logging
 import sys
 import types
 from uuid import uuid4
@@ -53,6 +54,17 @@ def test_empty_summary_gets_error_description():
     assert extra["content_summary"] == "[File Extraction]boom"
     assert meta["error_type"] == "file_extraction_error"
     assert meta["error_stage"] == "parse"
+
+
+def test_empty_error_message_falls_back_to_class_name():
+    """Some exceptions (e.g. httpx transport errors) stringify to an empty
+    message; error_msg must stay non-empty so the WebUI keeps the Error
+    Message row instead of dropping it for a falsy empty string."""
+    extra, _meta = doc_status_parse_failure_fields(
+        ConnectionError(""), status_doc={"content_summary": "", "metadata": {}}
+    )
+    assert extra["error_msg"] == "ConnectionError"
+    assert extra["content_summary"] == "[File Extraction]ConnectionError"
 
 
 def test_existing_summary_is_not_overwritten():
@@ -378,4 +390,72 @@ async def test_raw_document_failure_keeps_real_summary(tmp_path, monkeypatch):
         assert status["metadata"]["error_type"] == "file_extraction_error"
         assert status["metadata"]["error_stage"] == "parse"
     finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_parse_worker_logs_when_failed_upsert_itself_fails(
+    tmp_path, monkeypatch, caplog
+):
+    """When the FAILED-status upsert raises (e.g. the storage backend is down
+    during the same outage that failed the parse), the worker must log instead
+    of swallowing silently, so the doc stuck in PARSING is diagnosable."""
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    monkeypatch.setenv("INPUT_DIR", str(input_dir))
+
+    class _BoomParser:
+        engine_name = "boomengine"
+
+        async def parse(self, ctx):
+            raise RuntimeError("boom engine exploded")
+
+    fake_mod = types.ModuleType("_test_boom_upsert_mod")
+    fake_mod.BoomParser = _BoomParser
+    monkeypatch.setitem(sys.modules, "_test_boom_upsert_mod", fake_mod)
+    registry.register_parser(
+        registry.ParserSpec(
+            engine_name="boomengine",
+            impl="_test_boom_upsert_mod:BoomParser",
+            suffixes=frozenset({"txt"}),
+            queue_group="native",
+        )
+    )
+    rag = await _build_rag(tmp_path)
+    try:
+        source_path = input_dir / "doc.txt"
+        source_path.write_text("some body")
+        await rag.apipeline_enqueue_documents(
+            "",
+            file_paths=str(source_path),
+            docs_format=FULL_DOCS_FORMAT_PENDING_PARSE,
+            parse_engine="boomengine",
+        )
+
+        # Fail the FAILED-status transition specifically (PARSING etc. still
+        # succeed), reproducing a storage write failure on the error path.
+        orig_upsert = rag._upsert_doc_status_transition
+
+        async def _flaky_upsert(*args, status=None, **kwargs):
+            if status == DocStatus.FAILED:
+                raise RuntimeError("doc_status backend unavailable")
+            return await orig_upsert(*args, status=status, **kwargs)
+
+        monkeypatch.setattr(rag, "_upsert_doc_status_transition", _flaky_upsert)
+
+        # lightrag logger has propagate=False; enable it so caplog captures.
+        lightrag_logger = logging.getLogger("lightrag")
+        monkeypatch.setattr(lightrag_logger, "propagate", True)
+        with caplog.at_level(logging.ERROR, logger="lightrag"):
+            await rag.apipeline_process_enqueue_documents()
+
+        assert any(
+            "Failed to record FAILED status" in record.getMessage()
+            for record in caplog.records
+        )
+    finally:
+        registry._REGISTRY.pop("boomengine", None)
+        registry._INSTANCE_CACHE.pop(
+            ("boomengine", "_test_boom_upsert_mod:BoomParser"), None
+        )
         await rag.finalize_storages()


### PR DESCRIPTION
## Description

When the MinerU backend service restarts or becomes unreachable, in-flight documents land in `doc_status` `FAILED`, but the recorded error was hard to act on in two ways:

1. **Missing Error Message** — `metadata` carried `error_type` / `error_stage` / `parse_engine`, yet the WebUI showed no Error Message row. Some httpx transport exceptions stringify to an empty message, and the front-end (`DocumentManager.tsx`, `if (doc.error_msg)`) treats an empty string as falsy, so the row was dropped.
2. **Not attributable to MinerU** — when a message did appear (`All connection attempts failed`), it was the raw httpx text with no hint that the failure originated in the MinerU engine/backend.

Root cause: the MinerU client only wrapped HTTP-status errors (`raise_for_status_with_detail`); transport-level connection errors (`httpx.RequestError` subclasses: `ConnectError`, `ConnectTimeout`, `ReadError`, `RemoteProtocolError`, …) propagated raw to the parse worker.

## Related Issues

N/A

## Changes Made

- **`lightrag/parser/external/mineru/client.py`** — `download_into()` now wraps `httpx.RequestError` raised inside the `async with httpx.AsyncClient(...)` block into a `RuntimeError` that names the engine, `api_mode`, `endpoint`, and the exception class (e.g. `MinerU local backend request failed (endpoint=...): ConnectError: All connection attempts failed`). HTTP-status and protocol errors already raise context-rich `RuntimeError`s and are deliberately left untouched.
- **`lightrag/utils_pipeline.py`** — `doc_status_parse_failure_fields()` falls back to the exception class name when `str(error)` is blank, so no FAILED document ever carries an empty `error_msg`. This is engine-agnostic defense-in-depth.
- **`lightrag/pipeline.py`** — the parse and analyze workers no longer swallow a failing FAILED-status upsert with a bare `except Exception: pass`; they now log it, so a document stuck in PARSING/ANALYZING during a concurrent storage outage is diagnosable.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Tests (`pytest tests/parser/external/mineru/test_client.py tests/pipeline/test_parse_failure_doc_status_fields.py` — 29 passed):

- client: connection error is wrapped with engine + endpoint + class context; empty-message transport error still yields a non-empty wrapped message.
- pipeline: blank `str(error)` falls back to the class name in `error_msg`; a failing FAILED-status upsert emits a `"Failed to record FAILED status"` log instead of failing silently.

Out of scope (noted, not changed here): the analyze worker's FAILED upsert writes `error_msg` only, not `metadata.error_type` / `error_stage` — unlike the parse worker. The reported symptoms are all parse-stage, so this is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
