### PR TITLE
chore: bump pre-commit hooks (ruff v0.6.4 → v0.15.17) and reformat

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# Revisions listed here are skipped by 'git blame' (mechanical, repo-wide
+# reformats with no logic changes). Enable locally with:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# style: apply ruff 0.15 formatting across repo
+21f4e698e555ace903ffc725e2914fe57b660bb1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         exclude: ^lightrag/api/webui/
@@ -11,7 +11,7 @@ repos:
 
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.4
+    rev: v0.15.17
     hooks:
       - id: ruff-format
         exclude: ^lightrag/api/webui/
@@ -21,7 +21,7 @@ repos:
 
 
   - repo: https://github.com/mgedmin/check-manifest
-    rev: "0.49"
+    rev: "0.51"
     hooks:
       - id: check-manifest
         stages: [manual]

--- a/lightrag/_version.py
+++ b/lightrag/_version.py
@@ -1,4 +1,4 @@
 """Lightweight version definitions shared by packaging and runtime code."""
 
 __version__ = "1.5.3"
-__api_version__ = "0310"
+__api_version__ = "0311"

--- a/lightrag/addon_params.py
+++ b/lightrag/addon_params.py
@@ -72,8 +72,7 @@ def normalize_addon_params(addon_params: Mapping[str, Any] | None) -> dict[str, 
         }
     else:
         raise TypeError(
-            "addon_params must be a Mapping or None, got "
-            f"{type(addon_params).__name__}"
+            f"addon_params must be a Mapping or None, got {type(addon_params).__name__}"
         )
 
     # When the caller supplies addon_params explicitly, the dataclass

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -2053,7 +2053,7 @@ async def run_scanning_process(
                 ):
                     # File is already PROCESSED, skip it with warning and archive it.
                     processed_files.append(filename)
-                    warning = f"Skipping already processed file: " f"{filename}"
+                    warning = f"Skipping already processed file: {filename}"
                     await record_scan_warning(rag, warning)
                     try:
                         await move_file_to_parsed_dir(file_path)

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -6917,9 +6917,9 @@ class PGGraphStorage(BaseGraphStorage):
         ]
         batches = _chunk_by_budget(
             normalized,
-            lambda pair: len(pair[0].encode("utf-8"))
-            + len(pair[1].encode("utf-8"))
-            + 8,
+            lambda pair: (
+                len(pair[0].encode("utf-8")) + len(pair[1].encode("utf-8")) + 8
+            ),
             self._max_upsert_payload_bytes,
             self._max_delete_records_per_batch,
         )

--- a/lightrag/multimodal_context.py
+++ b/lightrag/multimodal_context.py
@@ -340,9 +340,7 @@ def _row_trim_table_trailing(
         attrs_str, rows = parsed
         for k in range(len(rows) - 1, 0, -1):
             candidate = (
-                f"<table {attrs_str}>"
-                f"{json.dumps(rows[:k], ensure_ascii=False)}"
-                f"</table>"
+                f"<table {attrs_str}>{json.dumps(rows[:k], ensure_ascii=False)}</table>"
             )
             if _count_tokens(tokenizer, candidate) <= max_tokens:
                 return candidate

--- a/lightrag/parser/cli.py
+++ b/lightrag/parser/cli.py
@@ -136,9 +136,7 @@ def _print_summary(blocks_path: Path, raw_dir: Path | None, preview: int) -> Non
             heading = row.get("heading") or ""
             content = (row.get("content") or "").replace("\n", " ")
             snippet = content if len(content) <= 80 else content[:77] + "..."
-            print(
-                f"  [{row.get('blockid', '')[:8]}] " f"heading={heading!r} :: {snippet}"
-            )
+            print(f"  [{row.get('blockid', '')[:8]}] heading={heading!r} :: {snippet}")
 
 
 def _print_raw_summary(result: dict, preview: int) -> None:

--- a/lightrag/parser/docx/numbering_resolver.py
+++ b/lightrag/parser/docx/numbering_resolver.py
@@ -67,29 +67,29 @@ class NumberingResolver:
 
                 # Parse abstractNum definitions
                 for abstract in root.findall(".//w:abstractNum", NSMAP):
-                    abstract_id = abstract.get(f'{{{NSMAP["w"]}}}abstractNumId')
+                    abstract_id = abstract.get(f"{{{NSMAP['w']}}}abstractNumId")
                     levels = {}
 
                     for lvl in abstract.findall("w:lvl", NSMAP):
-                        ilvl = int(lvl.get(f'{{{NSMAP["w"]}}}ilvl'))
+                        ilvl = int(lvl.get(f"{{{NSMAP['w']}}}ilvl"))
 
                         start_elem = lvl.find("w:start", NSMAP)
                         start = (
-                            int(start_elem.get(f'{{{NSMAP["w"]}}}val'))
+                            int(start_elem.get(f"{{{NSMAP['w']}}}val"))
                             if start_elem is not None
                             else 1
                         )
 
                         num_fmt_elem = lvl.find("w:numFmt", NSMAP)
                         num_fmt = (
-                            num_fmt_elem.get(f'{{{NSMAP["w"]}}}val')
+                            num_fmt_elem.get(f"{{{NSMAP['w']}}}val")
                             if num_fmt_elem is not None
                             else "decimal"
                         )
 
                         lvl_text_elem = lvl.find("w:lvlText", NSMAP)
                         lvl_text = (
-                            lvl_text_elem.get(f'{{{NSMAP["w"]}}}val')
+                            lvl_text_elem.get(f"{{{NSMAP['w']}}}val")
                             if lvl_text_elem is not None
                             else "%1."
                         )
@@ -97,7 +97,7 @@ class NumberingResolver:
                         is_lgl_elem = lvl.find("w:isLgl", NSMAP)
                         is_lgl = False
                         if is_lgl_elem is not None:
-                            val = is_lgl_elem.get(f'{{{NSMAP["w"]}}}val')
+                            val = is_lgl_elem.get(f"{{{NSMAP['w']}}}val")
                             is_lgl = val is None or val not in ("0", "false")
 
                         levels[ilvl] = {
@@ -111,19 +111,19 @@ class NumberingResolver:
 
                 # Parse num -> abstractNum mapping and startOverride
                 for num in root.findall(".//w:num", NSMAP):
-                    num_id = num.get(f'{{{NSMAP["w"]}}}numId')
+                    num_id = num.get(f"{{{NSMAP['w']}}}numId")
                     abstract_ref = num.find("w:abstractNumId", NSMAP)
                     if abstract_ref is not None:
                         self.num_to_abstract[num_id] = abstract_ref.get(
-                            f'{{{NSMAP["w"]}}}val'
+                            f"{{{NSMAP['w']}}}val"
                         )
 
                     # Parse lvlOverride/startOverride for this num
                     for lvl_override in num.findall("w:lvlOverride", NSMAP):
-                        ilvl = int(lvl_override.get(f'{{{NSMAP["w"]}}}ilvl'))
+                        ilvl = int(lvl_override.get(f"{{{NSMAP['w']}}}ilvl"))
                         start_override = lvl_override.find("w:startOverride", NSMAP)
                         if start_override is not None:
-                            start_val = int(start_override.get(f'{{{NSMAP["w"]}}}val'))
+                            start_val = int(start_override.get(f"{{{NSMAP['w']}}}val"))
                             if num_id not in self.start_overrides:
                                 self.start_overrides[num_id] = {}
                             self.start_overrides[num_id][ilvl] = start_val
@@ -143,14 +143,14 @@ class NumberingResolver:
 
                 # Parse style definitions
                 for style in root.findall(".//w:style", NSMAP):
-                    style_id = style.get(f'{{{NSMAP["w"]}}}styleId')
+                    style_id = style.get(f"{{{NSMAP['w']}}}styleId")
                     if not style_id:
                         continue
 
                     # Check for basedOn (style inheritance)
                     based_on = style.find("w:basedOn", NSMAP)
                     if based_on is not None:
-                        parent_id = based_on.get(f'{{{NSMAP["w"]}}}val')
+                        parent_id = based_on.get(f"{{{NSMAP['w']}}}val")
                         if parent_id:
                             self.style_based_on[style_id] = parent_id
 
@@ -163,9 +163,9 @@ class NumberingResolver:
                             ilvl_elem = numPr.find("w:ilvl", NSMAP)
 
                             if num_id_elem is not None:
-                                num_id = num_id_elem.get(f'{{{NSMAP["w"]}}}val')
+                                num_id = num_id_elem.get(f"{{{NSMAP['w']}}}val")
                                 ilvl = (
-                                    int(ilvl_elem.get(f'{{{NSMAP["w"]}}}val'))
+                                    int(ilvl_elem.get(f"{{{NSMAP['w']}}}val"))
                                     if ilvl_elem is not None
                                     else 0
                                 )
@@ -239,7 +239,7 @@ class NumberingResolver:
             Rendered label string (e.g., "1.1", "a)", "第一章") or empty string
         """
         try:
-            pPr = para_element.find(f'{{{NSMAP["w"]}}}pPr')
+            pPr = para_element.find(f"{{{NSMAP['w']}}}pPr")
             if pPr is None:
                 return ""
 
@@ -248,20 +248,20 @@ class NumberingResolver:
             style_id = None
 
             # Get pStyle (if present)
-            pStyle = pPr.find(f'{{{NSMAP["w"]}}}pStyle')
+            pStyle = pPr.find(f"{{{NSMAP['w']}}}pStyle")
             if pStyle is not None:
-                style_id = pStyle.get(f'{{{NSMAP["w"]}}}val')
+                style_id = pStyle.get(f"{{{NSMAP['w']}}}val")
 
             # Check for direct numPr in paragraph
-            numPr = pPr.find(f'{{{NSMAP["w"]}}}numPr')
+            numPr = pPr.find(f"{{{NSMAP['w']}}}numPr")
             if numPr is not None:
-                num_id_elem = numPr.find(f'{{{NSMAP["w"]}}}numId')
-                ilvl_elem = numPr.find(f'{{{NSMAP["w"]}}}ilvl')
+                num_id_elem = numPr.find(f"{{{NSMAP['w']}}}numId")
+                ilvl_elem = numPr.find(f"{{{NSMAP['w']}}}ilvl")
 
                 if num_id_elem is not None:
-                    num_id = num_id_elem.get(f'{{{NSMAP["w"]}}}val')
+                    num_id = num_id_elem.get(f"{{{NSMAP['w']}}}val")
                     ilvl = (
-                        int(ilvl_elem.get(f'{{{NSMAP["w"]}}}val'))
+                        int(ilvl_elem.get(f"{{{NSMAP['w']}}}val"))
                         if ilvl_elem is not None
                         else 0
                     )
@@ -373,7 +373,7 @@ class NumberingResolver:
                     count = self.counters[num_id][i]
                     converter = self.FORMAT_CONVERTERS.get(num_fmt, lambda n: str(n))
                     formatted = converter(count)
-                    result = result.replace(f"%{i+1}", formatted)
+                    result = result.replace(f"%{i + 1}", formatted)
 
             return result
         except Exception:

--- a/lightrag/parser/docx/parse_document.py
+++ b/lightrag/parser/docx/parse_document.py
@@ -523,7 +523,7 @@ def split_table_with_heading(
             else:
                 chunk_heading = f"{current_heading} [{TABLE_CHUNK_SUFFIX_LABEL}{chunk['suffix_number']}]"
             print(
-                f"  Chunk {i+1}: heading=\"{chunk_heading}\", {len(chunk['rows'])} rows, {len(chunk_json)} chars",
+                f'  Chunk {i + 1}: heading="{chunk_heading}", {len(chunk["rows"])} rows, {len(chunk_json)} chars',
                 file=sys.stderr,
             )
 
@@ -963,7 +963,7 @@ def merge_small_blocks(blocks: list, debug: bool = False) -> tuple:
             )
             for info in oversized_blocks:
                 print(
-                    f"  Block #{info['index']}: level={info['level']}, tokens={info['tokens']}, heading=\"{info['heading']}\"",
+                    f'  Block #{info["index"]}: level={info["level"]}, tokens={info["tokens"]}, heading="{info["heading"]}"',
                     file=sys.stderr,
                 )
 
@@ -1212,7 +1212,7 @@ def split_long_block(
                     format_error(
                         "Cannot re-split oversized block (internal error)",
                         f"A block exceeded MAX_BLOCK_CONTENT_TOKENS but paragraph metadata was lost.\n\n"
-                        f"Location: Under heading \"{preview}\"\n"
+                        f'Location: Under heading "{preview}"\n'
                         f"Block size: ~{block_tokens} tokens ({len(block['content'])} characters)",
                         "This is an internal error. Please report this issue.",
                     )

--- a/lightrag/parser/legacy/parser.py
+++ b/lightrag/parser/legacy/parser.py
@@ -54,8 +54,7 @@ class LegacyParser(BaseParser):
         # instead of persisting an empty document into chunking.
         if not text.strip():
             raise LegacyExtractionError(
-                f"extracted no usable text from {ctx.file_path} "
-                f"(doc_id={ctx.doc_id})"
+                f"extracted no usable text from {ctx.file_path} (doc_id={ctx.doc_id})"
             )
 
         await ctx.rag._persist_parsed_full_docs(

--- a/lightrag/parser/routing.py
+++ b/lightrag/parser/routing.py
@@ -624,8 +624,7 @@ def _validate_filename_hint_for_resolution(
             and not parser_engine_endpoint_configured(engine)
         ):
             errors.append(
-                f"filename hint {m.group(0)!r} requires {endpoint_req} "
-                "to be configured"
+                f"filename hint {m.group(0)!r} requires {endpoint_req} to be configured"
             )
 
     if errors:

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1806,8 +1806,7 @@ class _PipelineMixin:
                     # take down the worker — but log so the doc stuck in PARSING
                     # is diagnosable instead of failing silently.
                     logger.error(
-                        f"Failed to record FAILED status for {doc_id_w}: "
-                        f"{upsert_err}"
+                        f"Failed to record FAILED status for {doc_id_w}: {upsert_err}"
                     )
             finally:
                 in_q.task_done()
@@ -1936,8 +1935,7 @@ class _PipelineMixin:
                     # storage write failure leaves the doc stuck in ANALYZING
                     # with a diagnosable trail rather than silently.
                     logger.error(
-                        f"Failed to record FAILED status for {doc_id_w}: "
-                        f"{upsert_err}"
+                        f"Failed to record FAILED status for {doc_id_w}: {upsert_err}"
                     )
             finally:
                 ctx.q_analyze.task_done()
@@ -2855,7 +2853,7 @@ class _PipelineMixin:
             # during <stage>" rather than "User cancelled during <stage>".
             raw = str(error)
             if raw.startswith("User cancelled"):
-                doc_error_msg = f"{cancel_label}{raw[len('User cancelled'):]}"
+                doc_error_msg = f"{cancel_label}{raw[len('User cancelled') :]}"
             elif raw:
                 doc_error_msg = f"{cancel_label}: {raw}"
             else:
@@ -3579,8 +3577,7 @@ class _PipelineMixin:
                 ):
                     return (
                         _skipped_result(
-                            f"image width or height is smaller than "
-                            f"{min_image_pixel}px"
+                            f"image width or height is smaller than {min_image_pixel}px"
                         ),
                         None,
                     )

--- a/lightrag/sidecar/writer.py
+++ b/lightrag/sidecar/writer.py
@@ -409,7 +409,7 @@ def _materialize_assets(
             src_path = Path(spec.source)
             if not src_path.exists():
                 logger.warning(
-                    "[sidecar] asset source missing for ref=%s (%s); " "skipping copy",
+                    "[sidecar] asset source missing for ref=%s (%s); skipping copy",
                     spec.ref,
                     src_path,
                 )
@@ -424,7 +424,7 @@ def _materialize_assets(
             # missing.
             if not target_path.exists():
                 logger.warning(
-                    "[sidecar] asset ref=%s declared in place but %s " "is absent",
+                    "[sidecar] asset ref=%s declared in place but %s is absent",
                     spec.ref,
                     target_path,
                 )

--- a/lightrag/tools/rebuild_vdb.py
+++ b/lightrag/tools/rebuild_vdb.py
@@ -609,9 +609,7 @@ class RebuildTool:
             )
         except ImportError as e:
             print(f"\n⚠️  Could not import the LightRAG API package: {e}")
-            print(
-                "   Rebuild requires the api extra: " 'pip install "lightrag-hku[api]"'
-            )
+            print('   Rebuild requires the api extra: pip install "lightrag-hku[api]"')
             print("   Continuing in CHECK-ONLY mode (no embedding available).")
             return None
 

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -1494,8 +1494,8 @@ async def _merge_entities_impl(
         }
         try:
             await safe_vdb_operation_with_exception(
-                operation=lambda payload=relation_data_for_vdb: relationships_vdb.upsert(
-                    payload
+                operation=lambda payload=relation_data_for_vdb: (
+                    relationships_vdb.upsert(payload)
                 ),
                 operation_name="merge_relation_upsert",
                 entity_name=f"{normalized_src}-{normalized_tgt}",

--- a/tests/api/routes/test_query_stream_routes.py
+++ b/tests/api/routes/test_query_stream_routes.py
@@ -72,12 +72,12 @@ class TestQueryRouteJsonOnly:
         content = ok_resp.get("content", {})
 
         # The /query endpoint must declare application/json — NOT ndjson
-        assert (
-            "application/json" in content
-        ), "/query must declare application/json in OpenAPI spec"
-        assert (
-            "application/x-ndjson" not in content
-        ), "/query must NOT declare application/x-ndjson — streaming belongs to /query/stream"
+        assert "application/json" in content, (
+            "/query must declare application/json in OpenAPI spec"
+        )
+        assert "application/x-ndjson" not in content, (
+            "/query must NOT declare application/x-ndjson — streaming belongs to /query/stream"
+        )
 
     def test_query_route_exists_and_accepts_post(self):
         client = _build_client()
@@ -109,9 +109,9 @@ class TestQueryStreamRoute:
         content = ok_resp.get("content", {})
 
         # The /query/stream endpoint must declare application/x-ndjson
-        assert (
-            "application/x-ndjson" in content
-        ), "/query/stream must declare application/x-ndjson in OpenAPI spec"
+        assert "application/x-ndjson" in content, (
+            "/query/stream must declare application/x-ndjson in OpenAPI spec"
+        )
 
     def test_stream_route_exists_and_accepts_post(self):
         client = _build_client()
@@ -167,8 +167,8 @@ class TestQueryStreamResponseContentType:
                 },
             )
             content_type = response.headers.get("content-type", "")
-            assert (
-                "application/x-ndjson" in content_type
-            ), f"/query/stream must return application/x-ndjson, got: {content_type}"
+            assert "application/x-ndjson" in content_type, (
+                f"/query/stream must return application/x-ndjson, got: {content_type}"
+            )
         finally:
             sys.argv = original_argv

--- a/tests/api/test_path_prefixes.py
+++ b/tests/api/test_path_prefixes.py
@@ -193,12 +193,12 @@ class TestOpenAPISpecIntegration:
 
             # Servers URL should include the prefix
             servers = spec.get("servers", [])
-            assert (
-                len(servers) > 0
-            ), "OpenAPI spec should have servers entry when root_path is set"
-            assert (
-                servers[0].get("url") == "/test-api"
-            ), f"Expected servers URL to be exactly /test-api, got: {servers[0].get('url')}"
+            assert len(servers) > 0, (
+                "OpenAPI spec should have servers entry when root_path is set"
+            )
+            assert servers[0].get("url") == "/test-api", (
+                f"Expected servers URL to be exactly /test-api, got: {servers[0].get('url')}"
+            )
 
     def test_openapi_spec_no_servers_without_prefix(self, mock_args_no_prefix):
         """Test OpenAPI spec has no servers entry when no root_path."""
@@ -234,9 +234,9 @@ class TestOpenAPISpecIntegration:
             for path in paths:
                 if path == "/":
                     continue
-                assert not path.startswith(
-                    "/test-api/"
-                ), f"Path {path} should not be prefixed with /test-api/ in root_path mode"
+                assert not path.startswith("/test-api/"), (
+                    f"Path {path} should not be prefixed with /test-api/ in root_path mode"
+                )
 
 
 class TestWebUIPrefixIntegration:

--- a/tests/chunker/test_chunk_options_persistence.py
+++ b/tests/chunker/test_chunk_options_persistence.py
@@ -216,9 +216,9 @@ def test_caller_supplied_chunk_options_reach_chunker(tmp_path, monkeypatch):
 
     asyncio.run(_run())
 
-    assert (
-        captured.get("chunk_token_size") == 100
-    ), f"R chunker must receive caller-supplied chunk_token_size; got {captured!r}"
+    assert captured.get("chunk_token_size") == 100, (
+        f"R chunker must receive caller-supplied chunk_token_size; got {captured!r}"
+    )
     assert captured["kwargs"]["separators"] == ["|", ""]
     assert captured["kwargs"]["chunk_overlap_token_size"] == 0
 
@@ -1073,9 +1073,9 @@ def test_addon_params_strategy_wins_over_strategy_env(tmp_path, monkeypatch):
 
     row = asyncio.run(_run())
     chunk_opts = row["chunk_options"]
-    assert (
-        chunk_opts["recursive_character"]["chunk_overlap_token_size"] == 999
-    ), "addon_params explicit value must beat strategy-specific env."
+    assert chunk_opts["recursive_character"]["chunk_overlap_token_size"] == 999, (
+        "addon_params explicit value must beat strategy-specific env."
+    )
 
 
 @pytest.mark.offline

--- a/tests/chunker/test_chunking_raw_lightrag_parity.py
+++ b/tests/chunker/test_chunking_raw_lightrag_parity.py
@@ -222,9 +222,9 @@ def test_chunking_input_parity_raw_vs_lightrag(tmp_path):
             "chunking_func received different inputs for raw vs lightrag; "
             f"raw={spy_raw['input']!r}\nlr={spy_lr['input']!r}"
         )
-        assert not spy_lr["input"].startswith(
-            LIGHTRAG_DOC_CONTENT_PREFIX
-        ), "{{LRdoc}} marker leaked into chunking_func input"
+        assert not spy_lr["input"].startswith(LIGHTRAG_DOC_CONTENT_PREFIX), (
+            "{{LRdoc}} marker leaked into chunking_func input"
+        )
 
     asyncio.run(_run())
 
@@ -362,9 +362,9 @@ def test_extraction_meta_records_lightrag_parse_format(tmp_path, monkeypatch):
                 if isinstance(status_doc, dict)
                 else getattr(status_doc, "metadata", None)
             )
-            assert isinstance(
-                metadata, dict
-            ), f"doc_status.metadata should be a dict, got {type(metadata)!r}"
+            assert isinstance(metadata, dict), (
+                f"doc_status.metadata should be a dict, got {type(metadata)!r}"
+            )
             assert metadata.get("parse_format") == FULL_DOCS_FORMAT_LIGHTRAG, (
                 f"doc_status.metadata.parse_format="
                 f"{metadata.get('parse_format')!r}; "
@@ -561,11 +561,11 @@ def test_explicit_V_dispatches_to_semantic_vector(tmp_path, monkeypatch):
             await rag.finalize_storages()
 
         assert captured["calls"] >= 1, "V must route to chunking_by_semantic_vector"
-        assert (
-            captured.get("embedding_func") is rag.embedding_func
-        ), "dispatcher must hand the LightRAG embedding_func to the V chunker"
+        assert captured.get("embedding_func") is rag.embedding_func, (
+            "dispatcher must hand the LightRAG embedding_func to the V chunker"
+        )
         assert legacy_spy["calls"] == 0, (
-            "explicit process_options selector must bypass legacy " "chunking_func"
+            "explicit process_options selector must bypass legacy chunking_func"
         )
 
     asyncio.run(_run())
@@ -647,8 +647,7 @@ def test_pending_parse_lightrag_summary_populated_after_processed(
                 "refresh did not propagate"
             )
             assert not final_summary.startswith(LIGHTRAG_DOC_CONTENT_PREFIX), (
-                f"{{LRdoc}} marker leaked into doc_status summary: "
-                f"{final_summary!r}"
+                f"{{LRdoc}} marker leaked into doc_status summary: {final_summary!r}"
             )
             # The parser stub produces these paragraphs verbatim; the
             # blocks.jsonl writer joins them with a blank line, so the
@@ -709,8 +708,8 @@ def test_raw_text_starting_with_marker_chunked_verbatim(tmp_path):
             "chunking_func received corrupted input: "
             f"got {spy['input']!r}, expected {body_with_marker!r}"
         )
-        assert spy["input"].startswith(
-            LIGHTRAG_DOC_CONTENT_PREFIX
-        ), "literal marker prefix lost at chunking boundary"
+        assert spy["input"].startswith(LIGHTRAG_DOC_CONTENT_PREFIX), (
+            "literal marker prefix lost at chunking boundary"
+        )
 
     asyncio.run(_run())

--- a/tests/chunker/test_paragraph_semantic_merge_and_fallback.py
+++ b/tests/chunker/test_paragraph_semantic_merge_and_fallback.py
@@ -309,9 +309,9 @@ def test_paragraph_semantic_fallback_passes_configured_recursive_overlap(monkeyp
         chunk_overlap_token_size=37,
     )
 
-    assert (
-        captured.get("chunk_overlap_token_size") == 37
-    ), "P→R fallback must pass the configured chunk_overlap_token_size"
+    assert captured.get("chunk_overlap_token_size") == 37, (
+        "P→R fallback must pass the configured chunk_overlap_token_size"
+    )
     assert captured.get("chunk_token_size") == 500
 
 

--- a/tests/chunker/test_paragraph_semantic_table_split.py
+++ b/tests/chunker/test_paragraph_semantic_table_split.py
@@ -146,21 +146,21 @@ def test_expand_block_assigns_first_and_last_roles_to_glued_blocks():
     roles = [b["table_chunk_role"] for b in out]
     assert roles[0] == "first", f"expected leading block role=first, got {roles}"
     assert roles[-1] == "last", f"expected trailing block role=last, got {roles}"
-    assert all(
-        r == "middle" for r in roles[1:-1]
-    ), f"expected middle slices between first/last, got {roles}"
+    assert all(r == "middle" for r in roles[1:-1]), (
+        f"expected middle slices between first/last, got {roles}"
+    )
 
     # Boundary glue still works: leading text sits inside the first block,
     # trailing text sits inside the last block.
-    assert any(
-        p["text"] == "lead paragraph" for p in out[0]["paragraphs"]
-    ), "leading paragraph must glue with the first table slice"
-    assert any(
-        p["text"] == "trailing paragraph" for p in out[-1]["paragraphs"]
-    ), "trailing paragraph must glue with the last table slice"
-    assert all(
-        "表格片段" not in b["heading"] for b in out
-    ), "TableRowSplit should not expose legacy table-fragment heading suffixes"
+    assert any(p["text"] == "lead paragraph" for p in out[0]["paragraphs"]), (
+        "leading paragraph must glue with the first table slice"
+    )
+    assert any(p["text"] == "trailing paragraph" for p in out[-1]["paragraphs"]), (
+        "trailing paragraph must glue with the last table slice"
+    )
+    assert all("表格片段" not in b["heading"] for b in out), (
+        "TableRowSplit should not expose legacy table-fragment heading suffixes"
+    )
 
 
 @pytest.mark.offline
@@ -205,9 +205,9 @@ def test_expand_block_two_oversized_tables_separates_last_and_first_roles():
     # The transition: there must be a "last" immediately followed by a
     # "first" somewhere in the middle of the role sequence.
     transitions = list(zip(roles, roles[1:]))
-    assert (
-        ("last", "first") in transitions
-    ), f"expected a last->first boundary between the two split tables, got {roles}"
+    assert ("last", "first") in transitions, (
+        f"expected a last->first boundary between the two split tables, got {roles}"
+    )
 
 
 @pytest.mark.offline
@@ -660,9 +660,9 @@ def test_expand_block_single_row_table_no_longer_left_intact():
     assert len(out) >= 2
     # First/last role protection still fires when the table was reduced.
     roles = [b["table_chunk_role"] for b in out]
-    assert (
-        "first" in roles or "last" in roles
-    ), f"expected first/last role assignment after table split, got {roles}"
+    assert "first" in roles or "last" in roles, (
+        f"expected first/last role assignment after table split, got {roles}"
+    )
 
 
 @pytest.mark.offline
@@ -698,9 +698,9 @@ def test_split_long_block_table_dominant_no_anchor_keeps_some_table_markup():
     # At least one sub-block keeps an unbroken <table> fragment somewhere
     # in its content (proof that row-boundary preservation kicked in).
     contents = [b["content"] for b in sub_blocks]
-    assert any(
-        ("<table " in c and "</table>" in c) for c in contents
-    ), "expected at least one sub-block to retain a legal <table> fragment"
+    assert any(("<table " in c and "</table>" in c) for c in contents), (
+        "expected at least one sub-block to retain a legal <table> fragment"
+    )
 
 
 @pytest.mark.offline
@@ -929,8 +929,7 @@ def test_full_pipeline_injects_html_thead_into_split_html_table(tmp_path):
     whose tables.json carries a raw <thead> header has that header re-injected
     (verbatim, spans preserved) into every non-first table chunk."""
     html_header = (
-        '<thead><tr><th rowspan="2">Metric</th>'
-        '<th colspan="2">Group</th></tr></thead>'
+        '<thead><tr><th rowspan="2">Metric</th><th colspan="2">Group</th></tr></thead>'
     )
     head_row = '<tr><th rowspan="2">Metric</th><th colspan="2">Group</th></tr>'
     data_rows = "".join(f"<tr><td>{'d' * 160}{i}</td></tr>" for i in range(6))

--- a/tests/extraction/test_entity_extraction_stability.py
+++ b/tests/extraction/test_entity_extraction_stability.py
@@ -239,9 +239,9 @@ def test_default_entity_types_guidance_covers_all_types():
         "NaturalObject",
     ]
     for t in expected_types:
-        assert (
-            t in guidance
-        ), f"Expected entity type '{t}' missing from default_entity_types_guidance"
+        assert t in guidance, (
+            f"Expected entity type '{t}' missing from default_entity_types_guidance"
+        )
 
 
 @pytest.mark.offline
@@ -362,9 +362,9 @@ def test_default_entity_types_removed_from_constants():
     """DEFAULT_ENTITY_TYPES must no longer exist in lightrag.constants."""
     import lightrag.constants as constants
 
-    assert not hasattr(
-        constants, "DEFAULT_ENTITY_TYPES"
-    ), "DEFAULT_ENTITY_TYPES should have been removed from constants.py"
+    assert not hasattr(constants, "DEFAULT_ENTITY_TYPES"), (
+        "DEFAULT_ENTITY_TYPES should have been removed from constants.py"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/kg/json_impl/test_write_json_optimization.py
+++ b/tests/kg/json_impl/test_write_json_optimization.py
@@ -66,9 +66,9 @@ class TestWriteJsonOptimization:
             assert loaded_data is not None, "Data should be written"
             assert loaded_data["number"] == 123, "Clean fields should remain unchanged"
             # Surrogate character should be removed
-            assert (
-                "\ud800" not in loaded_data["text"]
-            ), "Surrogate character should be removed"
+            assert "\ud800" not in loaded_data["text"], (
+                "Surrogate character should be removed"
+            )
         finally:
             os.unlink(temp_file)
 
@@ -125,9 +125,9 @@ class TestWriteJsonOptimization:
 
             # Verify list items are sanitized
             list_items = loaded_data["level1"]["level2"]["list"]
-            assert (
-                "\ud801" not in list_items[1]
-            ), "List item surrogates should be removed"
+            assert "\ud801" not in list_items[1], (
+                "List item surrogates should be removed"
+            )
         finally:
             os.unlink(temp_file)
 
@@ -171,9 +171,9 @@ class TestWriteJsonOptimization:
 
         try:
             needs_reload = write_json(mixed_data, temp_file)
-            assert (
-                needs_reload
-            ), "Mixed data with dirty fields should trigger sanitization"
+            assert needs_reload, (
+                "Mixed data with dirty fields should trigger sanitization"
+            )
 
             loaded_data = load_json(temp_file)
 
@@ -206,9 +206,9 @@ class TestWriteJsonOptimization:
 
         try:
             needs_reload = write_json(data, temp_file)
-            assert (
-                not needs_reload
-            ), "Clean empty values should not trigger sanitization"
+            assert not needs_reload, (
+                "Clean empty values should not trigger sanitization"
+            )
 
             loaded_data = load_json(temp_file)
             assert loaded_data == data, "Empty/None values should be preserved"
@@ -237,9 +237,9 @@ class TestWriteJsonOptimization:
             loaded_data = load_json(temp_file)
             assert loaded_data is not None
             assert "\udc9a" not in loaded_data["text"], "\\udc9a should be removed"
-            assert (
-                loaded_data["clean_field"] == "Normal text"
-            ), "Clean fields should remain"
+            assert loaded_data["clean_field"] == "Normal text", (
+                "Clean fields should remain"
+            )
         finally:
             os.unlink(temp_file)
 
@@ -282,17 +282,17 @@ class TestWriteJsonOptimization:
             assert loaded_data is not None
 
             # The data should be sanitized
-            assert (
-                "\ud800" not in loaded_data["cache_entry_1"]["return"]
-            ), "Surrogate in return should be removed"
-            assert (
-                "\udc9a" not in loaded_data["cache_entry_1"]["original_prompt"]
-            ), "Surrogate in prompt should be removed"
+            assert "\ud800" not in loaded_data["cache_entry_1"]["return"], (
+                "Surrogate in return should be removed"
+            )
+            assert "\udc9a" not in loaded_data["cache_entry_1"]["original_prompt"], (
+                "Surrogate in prompt should be removed"
+            )
 
             # Clean data should remain unchanged
-            assert (
-                loaded_data["cache_entry_2"]["return"] == "Clean result"
-            ), "Clean data should remain"
+            assert loaded_data["cache_entry_2"]["return"] == "Clean result", (
+                "Clean data should remain"
+            )
 
         finally:
             os.unlink(temp_file)
@@ -339,9 +339,9 @@ class TestWriteJsonOptimization:
             reloaded_empty = load_json(temp_file)
             assert reloaded_empty is not None, "Empty dict should not be None"
             assert reloaded_empty == {}, "Empty dict should remain empty"
-            assert (
-                not reloaded_empty
-            ), "Empty dict evaluates to False (the critical check)"
+            assert not reloaded_empty, (
+                "Empty dict evaluates to False (the critical check)"
+            )
 
         finally:
             os.unlink(temp_file)

--- a/tests/kg/nano_impl/test_atomic_write_nano.py
+++ b/tests/kg/nano_impl/test_atomic_write_nano.py
@@ -92,8 +92,8 @@ def test_nano_save_failure_inside_save_restores_storage_file(tmp_path):
         with pytest.raises(RuntimeError, match="boom"):
             _save_atomic(client, target)
 
-    assert (
-        client.storage_file == target
-    ), "Inner save failure must still restore storage_file to the real path"
+    assert client.storage_file == target, (
+        "Inner save failure must still restore storage_file to the real path"
+    )
     leftovers = [p for p in os.listdir(tmp_path) if ".tmp." in p]
     assert leftovers == [], f"save failure must clean tmp, got {leftovers}"

--- a/tests/kg/neo4j_impl/test_neo4j_fulltext_index.py
+++ b/tests/kg/neo4j_impl/test_neo4j_fulltext_index.py
@@ -86,9 +86,9 @@ async def test_fulltext_index_creation(neo4j_storage):
 
         # Check if the workspace-specific index exists
         index_names = [idx["name"] for idx in indexes]
-        assert (
-            expected_index_name in index_names
-        ), f"Expected index '{expected_index_name}' not found. Found indexes: {index_names}"
+        assert expected_index_name in index_names, (
+            f"Expected index '{expected_index_name}' not found. Found indexes: {index_names}"
+        )
 
         # Check if the legacy index doesn't exist (should be migrated if it was there)
         legacy_index_name = "entity_id_fulltext_idx"
@@ -147,9 +147,9 @@ async def test_search_labels_with_workspace_index(neo4j_storage):
 
     # Should find nodes with "Learning" in them
     assert len(results) > 0, "search_labels should return results for 'Learning'"
-    assert any(
-        "Learning" in result for result in results
-    ), "Results should contain 'Learning'"
+    assert any("Learning" in result for result in results), (
+        "Results should contain 'Learning'"
+    )
 
     # Test case-insensitive search
     results_lower = await storage.search_labels("learning", limit=10)
@@ -157,12 +157,12 @@ async def test_search_labels_with_workspace_index(neo4j_storage):
 
     # Test partial match
     results_partial = await storage.search_labels("Intelli", limit=10)
-    assert (
-        len(results_partial) > 0
-    ), "search_labels should support partial matching with wildcard"
-    assert any(
-        "Intelligence" in result for result in results_partial
-    ), "Should find 'Artificial Intelligence'"
+    assert len(results_partial) > 0, (
+        "search_labels should support partial matching with wildcard"
+    )
+    assert any("Intelligence" in result for result in results_partial), (
+        "Should find 'Artificial Intelligence'"
+    )
 
 
 @pytest.mark.integration
@@ -194,18 +194,18 @@ async def test_search_labels_with_hyphen(neo4j_storage):
 
     # The reported bug: a trailing hyphen previously cleared the dropdown.
     results_hyphen = await storage.search_labels("tb-", limit=10)
-    assert (
-        "tb-alpha" in results_hyphen
-    ), f"'tb-' should match 'tb-alpha', got {results_hyphen}"
-    assert (
-        "tb-beta" in results_hyphen
-    ), f"'tb-' should match 'tb-beta', got {results_hyphen}"
+    assert "tb-alpha" in results_hyphen, (
+        f"'tb-' should match 'tb-alpha', got {results_hyphen}"
+    )
+    assert "tb-beta" in results_hyphen, (
+        f"'tb-' should match 'tb-beta', got {results_hyphen}"
+    )
 
     # An exact hyphenated label resolves to itself.
     results_exact = await storage.search_labels("tb-alpha", limit=10)
-    assert (
-        "tb-alpha" in results_exact
-    ), f"'tb-alpha' should match itself, got {results_exact}"
+    assert "tb-alpha" in results_exact, (
+        f"'tb-alpha' should match itself, got {results_exact}"
+    )
 
 
 @pytest.mark.integration
@@ -249,9 +249,9 @@ async def test_search_labels_chinese_text(neo4j_storage):
 
     # Should find nodes with "学习" in them
     assert len(results) > 0, "search_labels should return results for Chinese text"
-    assert any(
-        "学习" in result for result in results
-    ), "Results should contain Chinese characters '学习'"
+    assert any("学习" in result for result in results), (
+        "Results should contain Chinese characters '学习'"
+    )
 
 
 @pytest.mark.integration
@@ -333,12 +333,12 @@ async def test_multiple_workspaces_have_separate_indexes(neo4j_storage):
                 f"entity_id_fulltext_idx_{storage2._get_workspace_label()}"
             )
 
-            assert (
-                workspace1_index in index_names
-            ), f"Workspace 1 index '{workspace1_index}' should exist"
-            assert (
-                workspace2_index in index_names
-            ), f"Workspace 2 index '{workspace2_index}' should exist"
+            assert workspace1_index in index_names, (
+                f"Workspace 1 index '{workspace1_index}' should exist"
+            )
+            assert workspace2_index in index_names, (
+                f"Workspace 2 index '{workspace2_index}' should exist"
+            )
 
     finally:
         # Clean up: drop the fulltext index created for workspace 2 to prevent accumulation

--- a/tests/kg/networkx_impl/test_networkx_atomic_write.py
+++ b/tests/kg/networkx_impl/test_networkx_atomic_write.py
@@ -132,9 +132,9 @@ def test_reap_orphan_tmp_files_respects_age_threshold(tmp_path):
 
     assert not os.path.exists(old_tmp), "Aged orphan should have been reaped"
     assert os.path.exists(young_tmp), "Fresh tmp may be in-flight — must not be reaped"
-    assert os.path.exists(
-        unrelated
-    ), "Unrelated path must not be touched by this reaper"
+    assert os.path.exists(unrelated), (
+        "Unrelated path must not be touched by this reaper"
+    )
 
 
 @pytest.mark.offline
@@ -155,9 +155,9 @@ def test_write_nx_graph_preserves_existing_file_mode(tmp_path):
     # Second write — mode must survive.
     g.add_node("b")
     NetworkXStorage.write_nx_graph(g, dst, workspace="mode")
-    assert (
-        stat.S_IMODE(os.stat(dst).st_mode) == 0o600
-    ), "atomic write must preserve dst permissions across the rename"
+    assert stat.S_IMODE(os.stat(dst).st_mode) == 0o600, (
+        "atomic write must preserve dst permissions across the rename"
+    )
 
     # And content was actually updated.
     assert nx.read_graphml(dst).number_of_nodes() == 2
@@ -186,9 +186,9 @@ def test_reap_orphan_tmp_files_handles_glob_metacharacters(tmp_path):
 
     reap_orphan_tmp_files(dst, workspace="meta")
 
-    assert not os.path.exists(
-        real_orphan
-    ), "Reaper must match the real orphan even when path contains '['"
-    assert os.path.exists(
-        decoy
-    ), "Reaper must not match tmp files belonging to unrelated paths"
+    assert not os.path.exists(real_orphan), (
+        "Reaper must match the real orphan even when path contains '['"
+    )
+    assert os.path.exists(decoy), (
+        "Reaper must not match tmp files belonging to unrelated paths"
+    )

--- a/tests/kg/opensearch_impl/test_cwe89_opensearch_injection.py
+++ b/tests/kg/opensearch_impl/test_cwe89_opensearch_injection.py
@@ -138,12 +138,12 @@ class TestWildcardInjection:
         # but the inner user-provided * and ? must be escaped
         # Expected: *test\*\?foo* (with the user's * and ? escaped)
         inner_value = wildcard_clause[1:-1]  # strip leading and trailing *
-        assert (
-            "\\*" in inner_value
-        ), f"User's '*' should be escaped as '\\*' in wildcard, got: {wildcard_clause}"
-        assert (
-            "\\?" in inner_value
-        ), f"User's '?' should be escaped as '\\?' in wildcard, got: {wildcard_clause}"
+        assert "\\*" in inner_value, (
+            f"User's '*' should be escaped as '\\*' in wildcard, got: {wildcard_clause}"
+        )
+        assert "\\?" in inner_value, (
+            f"User's '?' should be escaped as '\\?' in wildcard, got: {wildcard_clause}"
+        )
 
     @pytest.mark.asyncio
     async def test_wildcard_heavy_pattern_not_exploitable(self, graph_storage):
@@ -170,9 +170,9 @@ class TestWildcardInjection:
         inner = wildcard_clause[1:-1]
         # Count unescaped ? (i.e., ? not preceded by \)
         unescaped_q = re.findall(r"(?<!\\)\?", inner)
-        assert (
-            len(unescaped_q) == 0
-        ), f"Found {len(unescaped_q)} unescaped '?' in wildcard pattern: {wildcard_clause}"
+        assert len(unescaped_q) == 0, (
+            f"Found {len(unescaped_q)} unescaped '?' in wildcard pattern: {wildcard_clause}"
+        )
 
     @pytest.mark.asyncio
     async def test_backslash_escaped_in_wildcard(self, graph_storage):
@@ -196,9 +196,9 @@ class TestWildcardInjection:
         # The backslash should be escaped first, then the * — so we get \\\\\\*
         # In the final pattern between outer *...*, user's \ becomes \\ and * becomes \*
         inner = wildcard_clause[1:-1]
-        assert (
-            "\\\\" in inner or "\\*" in inner
-        ), f"Backslash and * from user should be escaped in wildcard: {wildcard_clause}"
+        assert "\\\\" in inner or "\\*" in inner, (
+            f"Backslash and * from user should be escaped in wildcard: {wildcard_clause}"
+        )
 
 
 class TestPPLInjection:
@@ -207,9 +207,9 @@ class TestPPLInjection:
     def test_escape_ppl_basic_quote(self, graph_storage):
         """Single quotes should be escaped."""
         result = graph_storage._escape_ppl("it's a test")
-        assert "'" not in result.replace(
-            "\\'", ""
-        ), f"Unescaped quote found in: {result}"
+        assert "'" not in result.replace("\\'", ""), (
+            f"Unescaped quote found in: {result}"
+        )
 
     def test_escape_ppl_backslash(self, graph_storage):
         """Backslashes should be escaped."""

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -1187,9 +1187,9 @@ class TestKVStorageBatching:
                 drop_task = asyncio.create_task(s.drop())
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not drop_delete_started.is_set()
-                ), "indices.delete should be blocked behind the flush lock"
+                assert not drop_delete_started.is_set(), (
+                    "indices.delete should be blocked behind the flush lock"
+                )
                 assert not drop_task.done()
                 flush_can_finish.set()
                 await flush_task
@@ -1289,9 +1289,9 @@ class TestKVStorageBatching:
                 )
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not concurrent_task.done()
-                ), "concurrent upsert should be blocked by the flush lock"
+                assert not concurrent_task.done(), (
+                    "concurrent upsert should be blocked by the flush lock"
+                )
                 assert "k2" not in s._pending_upserts
 
                 flush_can_finish.set()
@@ -4693,9 +4693,9 @@ class TestVectorStorageBatching:
                 # embedding computation and arrive at the lock.
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not concurrent_task.done()
-                ), "concurrent upsert should be blocked by the flush lock"
+                assert not concurrent_task.done(), (
+                    "concurrent upsert should be blocked by the flush lock"
+                )
                 # v2 must not be visible in the buffer yet.
                 assert "v2" not in s._pending_vector_docs
 
@@ -4744,9 +4744,9 @@ class TestVectorStorageBatching:
                 delete_task = asyncio.create_task(s.delete(["v1"]))
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not delete_task.done()
-                ), "concurrent delete should be blocked by the flush lock"
+                assert not delete_task.done(), (
+                    "concurrent delete should be blocked by the flush lock"
+                )
 
                 flush_can_finish.set()
                 await flush_task
@@ -4945,9 +4945,9 @@ class TestVectorStorageBatching:
                 rel_task = asyncio.create_task(s.delete_entity_relation("Alice"))
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not delete_started.is_set()
-                ), "delete_by_query should be blocked behind the flush lock"
+                assert not delete_started.is_set(), (
+                    "delete_by_query should be blocked behind the flush lock"
+                )
                 assert not rel_task.done()
 
                 flush_can_finish.set()
@@ -4987,9 +4987,9 @@ class TestVectorStorageBatching:
                 drop_task = asyncio.create_task(s.drop())
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not drop_delete_started.is_set()
-                ), "indices.delete should be blocked behind the flush lock"
+                assert not drop_delete_started.is_set(), (
+                    "indices.delete should be blocked behind the flush lock"
+                )
                 assert not drop_task.done()
 
                 flush_can_finish.set()
@@ -5032,9 +5032,9 @@ class TestVectorStorageBatching:
                 drop_task = asyncio.create_task(s.drop())
                 for _ in range(5):
                     await asyncio.sleep(0)
-                assert (
-                    not drop_delete_started.is_set()
-                ), "indices.delete should be blocked during deferred embedding"
+                assert not drop_delete_started.is_set(), (
+                    "indices.delete should be blocked during deferred embedding"
+                )
                 assert not drop_task.done()
 
                 embedding_can_finish.set()

--- a/tests/kg/postgres_impl/test_postgres_index_name.py
+++ b/tests/kg/postgres_impl/test_postgres_index_name.py
@@ -129,9 +129,9 @@ class TestSafeIndexName:
             result = _safe_index_name(table_name, suffix)
 
             # Critical: must be within PostgreSQL's 63-byte limit
-            assert (
-                len(result.encode("utf-8")) <= 63
-            ), f"Index name too long: {result} for table {table_name}"
+            assert len(result.encode("utf-8")) <= 63, (
+                f"Index name too long: {result} for table {table_name}"
+            )
 
             # Must have consistent format
             assert result.startswith("idx_"), f"Missing idx_ prefix: {result}"
@@ -178,9 +178,9 @@ class TestIndexNameIntegration:
 
         # The key fix: our generated name should equal the stored name
         # because it's already within the 63-byte limit
-        assert (
-            index_name == stored_name
-        ), "Index name would be truncated by PostgreSQL, causing lookup failures!"
+        assert index_name == stored_name, (
+            "Index name would be truncated by PostgreSQL, causing lookup failures!"
+        )
 
     def test_backward_compatibility_short_names(self):
         """
@@ -205,6 +205,6 @@ class TestIndexNameIntegration:
 
                 # Short names should remain unchanged for backward compatibility
                 if len(expected.encode("utf-8")) <= 63:
-                    assert (
-                        result == expected
-                    ), f"Short name changed unexpectedly: {result} != {expected}"
+                    assert result == expected, (
+                        f"Short name changed unexpectedly: {result} != {expected}"
+                    )

--- a/tests/kg/postgres_impl/test_postgres_migration.py
+++ b/tests/kg/postgres_impl/test_postgres_migration.py
@@ -543,9 +543,9 @@ async def test_case1_empty_legacy_auto_cleanup(
         assert len(delete_calls) >= 1, "Empty legacy table should be auto-deleted"
         # Check if legacy table was dropped
         dropped_table = storage.legacy_table_name
-        assert any(
-            dropped_table in str(call) for call in delete_calls
-        ), f"Expected to drop empty legacy table '{dropped_table}'"
+        assert any(dropped_table in str(call) for call in delete_calls), (
+            f"Expected to drop empty legacy table '{dropped_table}'"
+        )
 
         print(
             f"✅ Case 1a: Empty legacy table '{dropped_table}' auto-deleted successfully"
@@ -752,9 +752,9 @@ async def test_case1_sequential_workspace_migration(
 
     print("✅ Step 1: Workspace A initialized")
     # Verify migration was executed via _run_with_retry (batch migration uses executemany)
-    assert (
-        len(migration_a_executed) > 0
-    ), "Migration should have been executed for workspace_a"
+    assert len(migration_a_executed) > 0, (
+        "Migration should have been executed for workspace_a"
+    )
     print(f"✅ Step 1: Migration executed {len(migration_a_executed)} batch(es)")
 
     # Step 2: Simulate workspace_b initialization (Case 3 - both exist, but legacy has B's data)
@@ -846,9 +846,9 @@ async def test_case1_sequential_workspace_migration(
 
     # Verify workspace_b migration happens when new table has no workspace_b data
     # but legacy table still has workspace_b data.
-    assert (
-        len(migration_b_executed) > 0
-    ), "Migration should have been executed for workspace_b"
+    assert len(migration_b_executed) > 0, (
+        "Migration should have been executed for workspace_b"
+    )
     print("✅ Step 2: Migration executed for workspace_b")
 
     print("\n🎉 Case 1c: Sequential workspace migration verification complete!")

--- a/tests/kg/postgres_impl/test_postgres_retry_integration.py
+++ b/tests/kg/postgres_impl/test_postgres_retry_integration.py
@@ -144,9 +144,9 @@ class TestPostgresRetryIntegration:
             ):
                 await db.initdb()
 
-            assert (
-                attempt_count["value"] == 3
-            ), f"Expected 3 attempts, got {attempt_count['value']}"
+            assert attempt_count["value"] == 3, (
+                f"Expected 3 attempts, got {attempt_count['value']}"
+            )
             assert db.pool is not None, "Pool should be initialized after retries"
 
             # Verify database is actually working
@@ -240,9 +240,9 @@ class TestPostgresRetryIntegration:
             print(f"  → Completed in {elapsed:.2f}s")
             print(f"  → Results: {successful} successful, {failed} failed")
 
-            assert (
-                successful == num_queries
-            ), f"All {num_queries} queries should succeed"
+            assert successful == num_queries, (
+                f"All {num_queries} queries should succeed"
+            )
             assert failed == 0, "No queries should fail"
 
             print("\n✅ Test passed: All concurrent queries succeeded, no deadlocks")
@@ -275,9 +275,9 @@ class TestPostgresRetryIntegration:
 
             print(f"  ✓ Pool reset completed in {elapsed:.2f}s")
             assert db.pool is None, "Pool should be None after reset"
-            assert (
-                elapsed < db.pool_close_timeout + 1
-            ), "Reset should complete within timeout"
+            assert elapsed < db.pool_close_timeout + 1, (
+                "Reset should complete within timeout"
+            )
 
             print("\n✅ Test passed: Pool reset handled correctly")
             print("=" * 80)

--- a/tests/kg/postgres_impl/test_postgres_upsert.py
+++ b/tests/kg/postgres_impl/test_postgres_upsert.py
@@ -358,12 +358,12 @@ async def test_upsert_full_docs_sql_protects_partial_writes():
         "process_options",
         "parse_engine",
     ):
-        assert (
-            f"coalesce( nullif(excluded.{col}, '')" in normalized
-        ), f"upsert_doc_full must guard {col} via COALESCE+NULLIF"
-        assert (
-            f"lightrag_doc_full.{col}" in normalized
-        ), f"upsert_doc_full must preserve existing {col} on partial write"
+        assert f"coalesce( nullif(excluded.{col}, '')" in normalized, (
+            f"upsert_doc_full must guard {col} via COALESCE+NULLIF"
+        )
+        assert f"lightrag_doc_full.{col}" in normalized, (
+            f"upsert_doc_full must preserve existing {col} on partial write"
+        )
 
     # chunk_options (JSONB) is guarded via CASE on NULL/empty-object literal
     assert "excluded.chunk_options is null" in normalized

--- a/tests/kg/postgres_impl/test_postgres_upsert_edge_cypher.py
+++ b/tests/kg/postgres_impl/test_postgres_upsert_edge_cypher.py
@@ -94,9 +94,9 @@ async def test_upsert_edge_uses_delete_create_not_set():
 
     # The new query must not contain any SET-based edge update — those silently
     # fail against AGE. All edge props live inline in the CREATE clause.
-    assert (
-        "SET r" not in cypher_sql
-    ), f"Edge SET clauses are silently dropped by AGE: {cypher_sql}"
+    assert "SET r" not in cypher_sql, (
+        f"Edge SET clauses are silently dropped by AGE: {cypher_sql}"
+    )
     assert "ON CREATE SET" not in cypher_sql
     assert "ON MATCH SET" not in cypher_sql
 

--- a/tests/kg/postgres_impl/test_postgres_vector_deferred.py
+++ b/tests/kg/postgres_impl/test_postgres_vector_deferred.py
@@ -646,9 +646,9 @@ async def test_delete_entity_serializes_against_in_flight_flush():
     # Give the event loop a few turns to confirm delete_entity is blocked.
     for _ in range(5):
         await asyncio.sleep(0)
-    assert (
-        not delete_task.done()
-    ), "delete_entity should be waiting on _flush_lock while flush holds it"
+    assert not delete_task.done(), (
+        "delete_entity should be waiting on _flush_lock while flush holds it"
+    )
 
     # Unblock the flush; both should complete.
     embed.gate.set()

--- a/tests/kg/qdrant_impl/test_qdrant_migration.py
+++ b/tests/kg/qdrant_impl/test_qdrant_migration.py
@@ -498,9 +498,9 @@ async def test_case1_empty_legacy_auto_cleanup(mock_qdrant_client, mock_embeddin
         if delete_calls[0][0]
         else delete_calls[0].kwargs.get("collection_name")
     )
-    assert (
-        deleted_collection == legacy_collection
-    ), f"Expected to delete '{legacy_collection}', but deleted '{deleted_collection}'"
+    assert deleted_collection == legacy_collection, (
+        f"Expected to delete '{legacy_collection}', but deleted '{deleted_collection}'"
+    )
 
     print(
         f"✅ Case 1a: Empty legacy collection '{legacy_collection}' auto-deleted successfully"

--- a/tests/kg/test_batch_graph_operations.py
+++ b/tests/kg/test_batch_graph_operations.py
@@ -491,12 +491,12 @@ class TestAinsertCustomKgBatchPath:
             await rag.ainsert_custom_kg(custom_kg)
 
             graph = rag.chunk_entity_relation_graph
-            assert await graph.has_node(
-                "ImplicitNode"
-            ), "Implicit node should be created"
-            assert await graph.has_node(
-                "AnotherImplicit"
-            ), "Implicit node should be created"
+            assert await graph.has_node("ImplicitNode"), (
+                "Implicit node should be created"
+            )
+            assert await graph.has_node("AnotherImplicit"), (
+                "Implicit node should be created"
+            )
 
             await rag.finalize_storages()
 

--- a/tests/kg/test_graph_storage.py
+++ b/tests/kg/test_graph_storage.py
@@ -216,15 +216,15 @@ async def test_graph_basic(storage):
             print(f"Node type: {node1_props.get('entity_type', 'No type')}")
             print(f"Node keywords: {node1_props.get('keywords', 'No keywords')}")
             # Verify that the returned properties are correct
-            assert (
-                node1_props.get("entity_id") == node1_id
-            ), f"Node ID mismatch: expected {node1_id}, got {node1_props.get('entity_id')}"
-            assert (
-                node1_props.get("description") == node1_data["description"]
-            ), "Node description mismatch"
-            assert (
-                node1_props.get("entity_type") == node1_data["entity_type"]
-            ), "Node type mismatch"
+            assert node1_props.get("entity_id") == node1_id, (
+                f"Node ID mismatch: expected {node1_id}, got {node1_props.get('entity_id')}"
+            )
+            assert node1_props.get("description") == node1_data["description"], (
+                "Node description mismatch"
+            )
+            assert node1_props.get("entity_type") == node1_data["entity_type"], (
+                "Node type mismatch"
+            )
         else:
             print(f"Failed to read node properties: {node1_id}")
             assert False, f"Failed to read node properties: {node1_id}"
@@ -242,15 +242,15 @@ async def test_graph_basic(storage):
             )
             print(f"Edge weight: {edge_props.get('weight', 'No weight')}")
             # Verify that the returned properties are correct
-            assert (
-                edge_props.get("relationship") == edge_data["relationship"]
-            ), "Edge relationship mismatch"
-            assert (
-                edge_props.get("description") == edge_data["description"]
-            ), "Edge description mismatch"
-            assert (
-                edge_props.get("weight") == edge_data["weight"]
-            ), "Edge weight mismatch"
+            assert edge_props.get("relationship") == edge_data["relationship"], (
+                "Edge relationship mismatch"
+            )
+            assert edge_props.get("description") == edge_data["description"], (
+                "Edge description mismatch"
+            )
+            assert edge_props.get("weight") == edge_data["weight"], (
+                "Edge weight mismatch"
+            )
         else:
             print(f"Failed to read edge properties: {node1_id} -> {node2_id}")
             assert False, f"Failed to read edge properties: {node1_id} -> {node2_id}"
@@ -272,15 +272,17 @@ async def test_graph_basic(storage):
                 f"Reverse edge weight: {reverse_edge_props.get('weight', 'No weight')}"
             )
             # Verify that forward and reverse edge properties are the same
-            assert (
-                edge_props == reverse_edge_props
-            ), "Forward and reverse edge properties are not consistent, undirected graph property verification failed"
+            assert edge_props == reverse_edge_props, (
+                "Forward and reverse edge properties are not consistent, undirected graph property verification failed"
+            )
             print(
                 "Undirected graph property verification successful: forward and reverse edge properties are consistent"
             )
         else:
             print(f"Failed to read reverse edge properties: {node2_id} -> {node1_id}")
-            assert False, f"Failed to read reverse edge properties: {node2_id} -> {node1_id}, undirected graph property verification failed"
+            assert False, (
+                f"Failed to read reverse edge properties: {node2_id} -> {node1_id}, undirected graph property verification failed"
+            )
 
         print("Basic tests completed, data is preserved in the database.")
         return True
@@ -362,9 +364,9 @@ async def test_graph_advanced(storage):
         print(f"== Testing node_degree: {node1_id}")
         node1_degree = await storage.node_degree(node1_id)
         print(f"Degree of node {node1_id}: {node1_degree}")
-        assert (
-            node1_degree == 1
-        ), f"Degree of node {node1_id} should be 1, but got {node1_degree}"
+        assert node1_degree == 1, (
+            f"Degree of node {node1_id} should be 1, but got {node1_degree}"
+        )
 
         # 2.1 Test degrees of all nodes
         print("== Testing degrees of all nodes")
@@ -372,28 +374,28 @@ async def test_graph_advanced(storage):
         node3_degree = await storage.node_degree(node3_id)
         print(f"Degree of node {node2_id}: {node2_degree}")
         print(f"Degree of node {node3_id}: {node3_degree}")
-        assert (
-            node2_degree == 2
-        ), f"Degree of node {node2_id} should be 2, but got {node2_degree}"
-        assert (
-            node3_degree == 1
-        ), f"Degree of node {node3_id} should be 1, but got {node3_degree}"
+        assert node2_degree == 2, (
+            f"Degree of node {node2_id} should be 2, but got {node2_degree}"
+        )
+        assert node3_degree == 1, (
+            f"Degree of node {node3_id} should be 1, but got {node3_degree}"
+        )
 
         # 3. Test edge_degree - get the degree of an edge
         print(f"== Testing edge_degree: {node1_id} -> {node2_id}")
         edge_degree = await storage.edge_degree(node1_id, node2_id)
         print(f"Degree of edge {node1_id} -> {node2_id}: {edge_degree}")
-        assert (
-            edge_degree == 3
-        ), f"Degree of edge {node1_id} -> {node2_id} should be 3, but got {edge_degree}"
+        assert edge_degree == 3, (
+            f"Degree of edge {node1_id} -> {node2_id} should be 3, but got {edge_degree}"
+        )
 
         # 3.1 Test reverse edge degree - verify undirected graph property
         print(f"== Testing reverse edge degree: {node2_id} -> {node1_id}")
         reverse_edge_degree = await storage.edge_degree(node2_id, node1_id)
         print(f"Degree of reverse edge {node2_id} -> {node1_id}: {reverse_edge_degree}")
-        assert (
-            edge_degree == reverse_edge_degree
-        ), "Degrees of forward and reverse edges are not consistent, undirected graph property verification failed"
+        assert edge_degree == reverse_edge_degree, (
+            "Degrees of forward and reverse edges are not consistent, undirected graph property verification failed"
+        )
         print(
             "Undirected graph property verification successful: degrees of forward and reverse edges are consistent"
         )
@@ -402,9 +404,9 @@ async def test_graph_advanced(storage):
         print(f"== Testing get_node_edges: {node2_id}")
         node2_edges = await storage.get_node_edges(node2_id)
         print(f"All edges of node {node2_id}: {node2_edges}")
-        assert (
-            len(node2_edges) == 2
-        ), f"Node {node2_id} should have 2 edges, but got {len(node2_edges)}"
+        assert len(node2_edges) == 2, (
+            f"Node {node2_id} should have 2 edges, but got {len(node2_edges)}"
+        )
 
         # 4.1 Verify undirected graph property of node edges
         print("== Verifying undirected graph property of node edges")
@@ -423,12 +425,12 @@ async def test_graph_advanced(storage):
             ):
                 has_connection_with_node3 = True
 
-        assert (
-            has_connection_with_node1
-        ), f"Edge list of node {node2_id} should include a connection with {node1_id}"
-        assert (
-            has_connection_with_node3
-        ), f"Edge list of node {node2_id} should include a connection with {node3_id}"
+        assert has_connection_with_node1, (
+            f"Edge list of node {node2_id} should include a connection with {node1_id}"
+        )
+        assert has_connection_with_node3, (
+            f"Edge list of node {node2_id} should include a connection with {node3_id}"
+        )
         print(
             f"Undirected graph property verification successful: edge list of node {node2_id} contains all relevant edges"
         )
@@ -447,15 +449,15 @@ async def test_graph_advanced(storage):
         kg = await storage.get_knowledge_graph("*", max_depth=2, max_nodes=10)
         print(f"Number of nodes in knowledge graph: {len(kg.nodes)}")
         print(f"Number of edges in knowledge graph: {len(kg.edges)}")
-        assert isinstance(
-            kg, KnowledgeGraph
-        ), "The returned result should be of type KnowledgeGraph"
-        assert (
-            len(kg.nodes) == 3
-        ), f"The knowledge graph should have 3 nodes, but got {len(kg.nodes)}"
-        assert (
-            len(kg.edges) == 2
-        ), f"The knowledge graph should have 2 edges, but got {len(kg.edges)}"
+        assert isinstance(kg, KnowledgeGraph), (
+            "The returned result should be of type KnowledgeGraph"
+        )
+        assert len(kg.nodes) == 3, (
+            f"The knowledge graph should have 3 nodes, but got {len(kg.nodes)}"
+        )
+        assert len(kg.edges) == 2, (
+            f"The knowledge graph should have 2 edges, but got {len(kg.edges)}"
+        )
 
         # 6.1 Every returned node must carry its entity_id in properties: the
         # WebUI reads properties['entity_id'] to render the node "Name" row and
@@ -463,9 +465,9 @@ async def test_graph_advanced(storage):
         # property panel nameless (regression guard for all backends).
         expected_ids = {node1_id, node2_id, node3_id}
         for kg_node in kg.nodes:
-            assert (
-                kg_node.properties.get("entity_id") in expected_ids
-            ), f"Node {kg_node.id} is missing entity_id in properties: {kg_node.properties}"
+            assert kg_node.properties.get("entity_id") in expected_ids, (
+                f"Node {kg_node.id} is missing entity_id in properties: {kg_node.properties}"
+            )
 
         # 7. Test delete_node - delete a node
         print(f"== Testing delete_node: {node3_id}")
@@ -485,9 +487,9 @@ async def test_graph_advanced(storage):
         print(
             f"Querying edge properties after deletion {node2_id} -> {node3_id}: {edge_props}"
         )
-        assert (
-            edge_props is None
-        ), f"Edge {node2_id} -> {node3_id} should have been deleted"
+        assert edge_props is None, (
+            f"Edge {node2_id} -> {node3_id} should have been deleted"
+        )
 
         # 8.1 Verify undirected graph property of edge deletion
         print(
@@ -497,9 +499,9 @@ async def test_graph_advanced(storage):
         print(
             f"Querying reverse edge properties after deletion {node3_id} -> {node2_id}: {reverse_edge_props}"
         )
-        assert (
-            reverse_edge_props is None
-        ), f"Reverse edge {node3_id} -> {node2_id} should also be deleted, undirected graph property verification failed"
+        assert reverse_edge_props is None, (
+            f"Reverse edge {node3_id} -> {node2_id} should also be deleted, undirected graph property verification failed"
+        )
         print(
             "Undirected graph property verification successful: deleting an edge in one direction also deletes the reverse edge"
         )
@@ -662,44 +664,44 @@ async def test_graph_batch_operations(storage):
         assert node1_id in nodes_dict, f"{node1_id} should be in the result"
         assert node2_id in nodes_dict, f"{node2_id} should be in the result"
         assert node3_id in nodes_dict, f"{node3_id} should be in the result"
-        assert (
-            nodes_dict[node1_id]["description"] == node1_data["description"]
-        ), f"{node1_id} description mismatch"
-        assert (
-            nodes_dict[node2_id]["description"] == node2_data["description"]
-        ), f"{node2_id} description mismatch"
-        assert (
-            nodes_dict[node3_id]["description"] == node3_data["description"]
-        ), f"{node3_id} description mismatch"
+        assert nodes_dict[node1_id]["description"] == node1_data["description"], (
+            f"{node1_id} description mismatch"
+        )
+        assert nodes_dict[node2_id]["description"] == node2_data["description"], (
+            f"{node2_id} description mismatch"
+        )
+        assert nodes_dict[node3_id]["description"] == node3_data["description"], (
+            f"{node3_id} description mismatch"
+        )
 
         # 3. Test node_degrees_batch - batch get degrees of multiple nodes
         print("== Testing node_degrees_batch")
         node_degrees = await storage.node_degrees_batch(node_ids)
         print(f"Batch get node degrees result: {node_degrees}")
-        assert (
-            len(node_degrees) == 3
-        ), f"Should return degrees of 3 nodes, but got {len(node_degrees)}"
+        assert len(node_degrees) == 3, (
+            f"Should return degrees of 3 nodes, but got {len(node_degrees)}"
+        )
         assert node1_id in node_degrees, f"{node1_id} should be in the result"
         assert node2_id in node_degrees, f"{node2_id} should be in the result"
         assert node3_id in node_degrees, f"{node3_id} should be in the result"
-        assert (
-            node_degrees[node1_id] == 3
-        ), f"Degree of {node1_id} should be 3, but got {node_degrees[node1_id]}"
-        assert (
-            node_degrees[node2_id] == 2
-        ), f"Degree of {node2_id} should be 2, but got {node_degrees[node2_id]}"
-        assert (
-            node_degrees[node3_id] == 3
-        ), f"Degree of {node3_id} should be 3, but got {node_degrees[node3_id]}"
+        assert node_degrees[node1_id] == 3, (
+            f"Degree of {node1_id} should be 3, but got {node_degrees[node1_id]}"
+        )
+        assert node_degrees[node2_id] == 2, (
+            f"Degree of {node2_id} should be 2, but got {node_degrees[node2_id]}"
+        )
+        assert node_degrees[node3_id] == 3, (
+            f"Degree of {node3_id} should be 3, but got {node_degrees[node3_id]}"
+        )
 
         # 4. Test edge_degrees_batch - batch get degrees of multiple edges
         print("== Testing edge_degrees_batch")
         edges = [(node1_id, node2_id), (node2_id, node3_id), (node3_id, node4_id)]
         edge_degrees = await storage.edge_degrees_batch(edges)
         print(f"Batch get edge degrees result: {edge_degrees}")
-        assert (
-            len(edge_degrees) == 3
-        ), f"Should return degrees of 3 edges, but got {len(edge_degrees)}"
+        assert len(edge_degrees) == 3, (
+            f"Should return degrees of 3 edges, but got {len(edge_degrees)}"
+        )
         assert (
             node1_id,
             node2_id,
@@ -713,15 +715,15 @@ async def test_graph_batch_operations(storage):
             node4_id,
         ) in edge_degrees, f"Edge {node3_id} -> {node4_id} should be in the result"
         # Verify edge degrees (sum of source and target node degrees)
-        assert (
-            edge_degrees[(node1_id, node2_id)] == 5
-        ), f"Degree of edge {node1_id} -> {node2_id} should be 5, but got {edge_degrees[(node1_id, node2_id)]}"
-        assert (
-            edge_degrees[(node2_id, node3_id)] == 5
-        ), f"Degree of edge {node2_id} -> {node3_id} should be 5, but got {edge_degrees[(node2_id, node3_id)]}"
-        assert (
-            edge_degrees[(node3_id, node4_id)] == 5
-        ), f"Degree of edge {node3_id} -> {node4_id} should be 5, but got {edge_degrees[(node3_id, node4_id)]}"
+        assert edge_degrees[(node1_id, node2_id)] == 5, (
+            f"Degree of edge {node1_id} -> {node2_id} should be 5, but got {edge_degrees[(node1_id, node2_id)]}"
+        )
+        assert edge_degrees[(node2_id, node3_id)] == 5, (
+            f"Degree of edge {node2_id} -> {node3_id} should be 5, but got {edge_degrees[(node2_id, node3_id)]}"
+        )
+        assert edge_degrees[(node3_id, node4_id)] == 5, (
+            f"Degree of edge {node3_id} -> {node4_id} should be 5, but got {edge_degrees[(node3_id, node4_id)]}"
+        )
 
         # 5. Test get_edges_batch - batch get properties of multiple edges
         print("== Testing get_edges_batch")
@@ -729,9 +731,9 @@ async def test_graph_batch_operations(storage):
         edge_dicts = [{"src": src, "tgt": tgt} for src, tgt in edges]
         edges_dict = await storage.get_edges_batch(edge_dicts)
         print(f"Batch get edge properties result: {edges_dict.keys()}")
-        assert (
-            len(edges_dict) == 3
-        ), f"Should return properties of 3 edges, but got {len(edges_dict)}"
+        assert len(edges_dict) == 3, (
+            f"Should return properties of 3 edges, but got {len(edges_dict)}"
+        )
         assert (
             node1_id,
             node2_id,
@@ -763,22 +765,21 @@ async def test_graph_batch_operations(storage):
         reverse_edge_dicts = [{"src": tgt, "tgt": src} for src, tgt in edges]
         reverse_edges_dict = await storage.get_edges_batch(reverse_edge_dicts)
         print(f"Batch get reverse edge properties result: {reverse_edges_dict.keys()}")
-        assert (
-            len(reverse_edges_dict) == 3
-        ), f"Should return properties of 3 reverse edges, but got {len(reverse_edges_dict)}"
+        assert len(reverse_edges_dict) == 3, (
+            f"Should return properties of 3 reverse edges, but got {len(reverse_edges_dict)}"
+        )
 
         # Verify that properties of forward and reverse edges are consistent
         for (src, tgt), props in edges_dict.items():
             assert (
-                (
-                    tgt,
-                    src,
-                )
-                in reverse_edges_dict
-            ), f"Reverse edge {tgt} -> {src} should be in the result"
-            assert (
-                props == reverse_edges_dict[(tgt, src)]
-            ), f"Properties of edge {src} -> {tgt} and reverse edge {tgt} -> {src} are inconsistent"
+                tgt,
+                src,
+            ) in reverse_edges_dict, (
+                f"Reverse edge {tgt} -> {src} should be in the result"
+            )
+            assert props == reverse_edges_dict[(tgt, src)], (
+                f"Properties of edge {src} -> {tgt} and reverse edge {tgt} -> {src} are inconsistent"
+            )
 
         print(
             "Undirected graph property verification successful: properties of batch-retrieved forward and reverse edges are consistent"
@@ -788,17 +789,17 @@ async def test_graph_batch_operations(storage):
         print("== Testing get_nodes_edges_batch")
         nodes_edges = await storage.get_nodes_edges_batch([node1_id, node3_id])
         print(f"Batch get node edges result: {nodes_edges.keys()}")
-        assert (
-            len(nodes_edges) == 2
-        ), f"Should return edges for 2 nodes, but got {len(nodes_edges)}"
+        assert len(nodes_edges) == 2, (
+            f"Should return edges for 2 nodes, but got {len(nodes_edges)}"
+        )
         assert node1_id in nodes_edges, f"{node1_id} should be in the result"
         assert node3_id in nodes_edges, f"{node3_id} should be in the result"
-        assert (
-            len(nodes_edges[node1_id]) == 3
-        ), f"{node1_id} should have 3 edges, but has {len(nodes_edges[node1_id])}"
-        assert (
-            len(nodes_edges[node3_id]) == 3
-        ), f"{node3_id} should have 3 edges, but has {len(nodes_edges[node3_id])}"
+        assert len(nodes_edges[node1_id]) == 3, (
+            f"{node1_id} should have 3 edges, but has {len(nodes_edges[node1_id])}"
+        )
+        assert len(nodes_edges[node3_id]) == 3, (
+            f"{node3_id} should have 3 edges, but has {len(nodes_edges[node3_id])}"
+        )
 
         # 6.1 Verify undirected property of batch-retrieved node edges
         print("== Verifying undirected property of batch-retrieved node edges")
@@ -818,15 +819,15 @@ async def test_graph_batch_operations(storage):
         has_edge_to_node4 = any(tgt == node4_id for _, tgt in node1_outgoing_edges)
         has_edge_to_node5 = any(tgt == node5_id for _, tgt in node1_outgoing_edges)
 
-        assert (
-            has_edge_to_node2
-        ), f"Edge list of node {node1_id} should include an edge to {node2_id}"
-        assert (
-            has_edge_to_node4
-        ), f"Edge list of node {node1_id} should include an edge to {node4_id}"
-        assert (
-            has_edge_to_node5
-        ), f"Edge list of node {node1_id} should include an edge to {node5_id}"
+        assert has_edge_to_node2, (
+            f"Edge list of node {node1_id} should include an edge to {node2_id}"
+        )
+        assert has_edge_to_node4, (
+            f"Edge list of node {node1_id} should include an edge to {node4_id}"
+        )
+        assert has_edge_to_node5, (
+            f"Edge list of node {node1_id} should include an edge to {node5_id}"
+        )
 
         # Check if node 3's edges include all relevant edges (regardless of direction)
         node3_outgoing_edges = [
@@ -855,15 +856,15 @@ async def test_graph_batch_operations(storage):
             for src, tgt in nodes_edges[node3_id]
         )
 
-        assert (
-            has_connection_with_node2
-        ), f"Edge list of node {node3_id} should include a connection with {node2_id}"
-        assert (
-            has_connection_with_node4
-        ), f"Edge list of node {node3_id} should include a connection with {node4_id}"
-        assert (
-            has_connection_with_node5
-        ), f"Edge list of node {node3_id} should include a connection with {node5_id}"
+        assert has_connection_with_node2, (
+            f"Edge list of node {node3_id} should include a connection with {node2_id}"
+        )
+        assert has_connection_with_node4, (
+            f"Edge list of node {node3_id} should include a connection with {node4_id}"
+        )
+        assert has_connection_with_node5, (
+            f"Edge list of node {node3_id} should include a connection with {node5_id}"
+        )
 
         print(
             "Undirected graph property verification successful: batch-retrieved node edges include all relevant edges (regardless of direction)"
@@ -917,9 +918,9 @@ async def test_graph_batch_upsert(storage):
 
         # 2. All five distinct nodes exist; has_node / has_nodes_batch.
         for nid in ["E1", "E2", "E3", "E4", "E5"]:
-            assert await storage.has_node(
-                nid
-            ), f"{nid} should exist after upsert_nodes_batch"
+            assert await storage.has_node(nid), (
+                f"{nid} should exist after upsert_nodes_batch"
+            )
         existing = await storage.has_nodes_batch(["E1", "E3", "E5", "DOES_NOT_EXIST"])
         assert existing == {
             "E1",
@@ -929,9 +930,9 @@ async def test_graph_batch_upsert(storage):
 
         # Last-write-wins: the second E1 in the batch wins.
         e1 = await storage.get_node("E1")
-        assert (
-            e1 is not None and e1["description"] == "first-updated"
-        ), "Same-batch node dedup should keep the last write"
+        assert e1 is not None and e1["description"] == "first-updated", (
+            "Same-batch node dedup should keep the last write"
+        )
 
         # Batch read-back of the rest.
         nodes_dict = await storage.get_nodes_batch(["E2", "E3", "E4", "E5"])
@@ -1024,9 +1025,9 @@ async def test_graph_query_helpers(storage):
         print("== Testing get_all_edges")
         all_edges = await storage.get_all_edges()
         assert isinstance(all_edges, list)
-        assert (
-            len(all_edges) == 3
-        ), f"get_all_edges should return 3 edges, got {len(all_edges)}"
+        assert len(all_edges) == 3, (
+            f"get_all_edges should return 3 edges, got {len(all_edges)}"
+        )
         edge_pairs = {frozenset((e["source"], e["target"])) for e in all_edges}
         assert edge_pairs == {frozenset(p) for p in star_edges}
 
@@ -1035,18 +1036,18 @@ async def test_graph_query_helpers(storage):
         popular = await storage.get_popular_labels(limit=2)
         assert isinstance(popular, list)
         assert len(popular) <= 2
-        assert (
-            popular and popular[0] == "Alpha"
-        ), f"highest-degree label should be 'Alpha', got {popular}"
+        assert popular and popular[0] == "Alpha", (
+            f"highest-degree label should be 'Alpha', got {popular}"
+        )
 
         # 4. search_labels - substring / prefix match, and a clear miss
         print("== Testing search_labels")
         gamma_hits = await storage.search_labels("Gam")
         assert "Gamma" in gamma_hits, f"search 'Gam' should find 'Gamma': {gamma_hits}"
         alpha_hits = await storage.search_labels("Alpha")
-        assert (
-            "Alpha" in alpha_hits
-        ), f"search 'Alpha' should find 'Alpha': {alpha_hits}"
+        assert "Alpha" in alpha_hits, (
+            f"search 'Alpha' should find 'Alpha': {alpha_hits}"
+        )
         misses = await storage.search_labels("NoSuchEntityXYZ")
         assert "Alpha" not in misses and "Gamma" not in misses
 
@@ -1136,14 +1137,14 @@ async def test_graph_special_characters(storage):
                 )
 
                 # Verify node ID is saved correctly
-                assert (
-                    node_props.get("entity_id") == node_id
-                ), f"Node ID mismatch: expected {node_id}, got {node_props.get('entity_id')}"
+                assert node_props.get("entity_id") == node_id, (
+                    f"Node ID mismatch: expected {node_id}, got {node_props.get('entity_id')}"
+                )
 
                 # Verify description is saved correctly
-                assert (
-                    node_props.get("description") == original_data["description"]
-                ), f"Node description mismatch: expected {original_data['description']}, got {node_props.get('description')}"
+                assert node_props.get("description") == original_data["description"], (
+                    f"Node description mismatch: expected {original_data['description']}, got {node_props.get('description')}"
+                )
 
                 print(f"Node {node_id} special character verification successful")
             else:
@@ -1163,14 +1164,14 @@ async def test_graph_special_characters(storage):
             )
 
             # Verify edge relationship is saved correctly
-            assert (
-                edge1_props.get("relationship") == edge1_data["relationship"]
-            ), f"Edge relationship mismatch: expected {edge1_data['relationship']}, got {edge1_props.get('relationship')}"
+            assert edge1_props.get("relationship") == edge1_data["relationship"], (
+                f"Edge relationship mismatch: expected {edge1_data['relationship']}, got {edge1_props.get('relationship')}"
+            )
 
             # Verify edge description is saved correctly
-            assert (
-                edge1_props.get("description") == edge1_data["description"]
-            ), f"Edge description mismatch: expected {edge1_data['description']}, got {edge1_props.get('description')}"
+            assert edge1_props.get("description") == edge1_data["description"], (
+                f"Edge description mismatch: expected {edge1_data['description']}, got {edge1_props.get('description')}"
+            )
 
             print(
                 f"Edge {node1_id} -> {node2_id} special character verification successful"
@@ -1190,14 +1191,14 @@ async def test_graph_special_characters(storage):
             )
 
             # Verify edge relationship is saved correctly
-            assert (
-                edge2_props.get("relationship") == edge2_data["relationship"]
-            ), f"Edge relationship mismatch: expected {edge2_data['relationship']}, got {edge2_props.get('relationship')}"
+            assert edge2_props.get("relationship") == edge2_data["relationship"], (
+                f"Edge relationship mismatch: expected {edge2_data['relationship']}, got {edge2_props.get('relationship')}"
+            )
 
             # Verify edge description is saved correctly
-            assert (
-                edge2_props.get("description") == edge2_data["description"]
-            ), f"Edge description mismatch: expected {edge2_data['description']}, got {edge2_props.get('description')}"
+            assert edge2_props.get("description") == edge2_data["description"], (
+                f"Edge description mismatch: expected {edge2_data['description']}, got {edge2_props.get('description')}"
+            )
 
             print(
                 f"Edge {node2_id} -> {node3_id} special character verification successful"
@@ -1305,15 +1306,15 @@ async def test_graph_string_escaping_regressions(storage):
 
     center_edges = await storage.get_node_edges(center_id)
     assert center_edges is not None
-    assert connects(
-        center_edges, center_id, backslash_id
-    ), f"center_edges should contain connection to {backslash_id}"
-    assert connects(
-        center_edges, center_id, mixed_id
-    ), f"center_edges should contain connection to {mixed_id}"
-    assert connects(
-        center_edges, center_id, single_quote_id
-    ), f"center_edges should contain connection to {single_quote_id}"
+    assert connects(center_edges, center_id, backslash_id), (
+        f"center_edges should contain connection to {backslash_id}"
+    )
+    assert connects(center_edges, center_id, mixed_id), (
+        f"center_edges should contain connection to {mixed_id}"
+    )
+    assert connects(center_edges, center_id, single_quote_id), (
+        f"center_edges should contain connection to {single_quote_id}"
+    )
 
     batch_edges = await storage.get_nodes_edges_batch(
         [center_id, mixed_id, backslash_id, single_quote_id]
@@ -1331,9 +1332,9 @@ async def test_graph_string_escaping_regressions(storage):
     for (src_id, tgt_id), payload in edge_payloads.items():
         fwd = await storage.get_edge(src_id, tgt_id)
         rev = await storage.get_edge(tgt_id, src_id)
-        assert (
-            fwd is not None
-        ), f"get_edge({src_id!r}, {tgt_id!r}) returned None after insertion"
+        assert fwd is not None, (
+            f"get_edge({src_id!r}, {tgt_id!r}) returned None after insertion"
+        )
         assert rev is not None, (
             f"get_edge({tgt_id!r}, {src_id!r}) returned None — "
             f"storage is not treating the edge as undirected"
@@ -1356,9 +1357,9 @@ async def test_graph_string_escaping_regressions(storage):
     # --- Undirected property: has_edge in both directions ---
     print("\n== Verifying undirected property: has_edge forward and reverse")
     for src_id, tgt_id in edge_payloads:
-        assert await storage.has_edge(
-            src_id, tgt_id
-        ), f"has_edge({src_id!r}, {tgt_id!r}) returned False after insertion"
+        assert await storage.has_edge(src_id, tgt_id), (
+            f"has_edge({src_id!r}, {tgt_id!r}) returned False after insertion"
+        )
         assert await storage.has_edge(tgt_id, src_id), (
             f"has_edge({tgt_id!r}, {src_id!r}) returned False — "
             f"storage is not treating the edge as undirected"
@@ -1382,9 +1383,9 @@ async def test_graph_string_escaping_regressions(storage):
         assert forward_edges[pair]["relationship"] == payload["relationship"]
         assert forward_edges[pair]["description"] == payload["description"]
         reverse_pair = (pair[1], pair[0])
-        assert (
-            reverse_pair in reverse_edges
-        ), f"get_edges_batch did not return reverse pair {reverse_pair!r}"
+        assert reverse_pair in reverse_edges, (
+            f"get_edges_batch did not return reverse pair {reverse_pair!r}"
+        )
         assert reverse_edges[reverse_pair]["relationship"] == payload["relationship"]
         assert reverse_edges[reverse_pair]["description"] == payload["description"]
     print(
@@ -1395,18 +1396,18 @@ async def test_graph_string_escaping_regressions(storage):
     # --- Undirected property: edge deletion removes both directions ---
     print("\n== Verifying undirected property: edge deletion removes both directions")
     await storage.remove_edges([(center_id, mixed_id)])
-    assert (
-        await storage.get_edge(center_id, mixed_id) is None
-    ), f"Forward edge ({center_id!r} -> {mixed_id!r}) should be deleted"
+    assert await storage.get_edge(center_id, mixed_id) is None, (
+        f"Forward edge ({center_id!r} -> {mixed_id!r}) should be deleted"
+    )
     assert await storage.get_edge(mixed_id, center_id) is None, (
         f"Reverse edge ({mixed_id!r} -> {center_id!r}) should also be deleted "
         f"— storage is not treating deletion as undirected"
     )
     remaining_center_edges = await storage.get_node_edges(center_id)
     assert remaining_center_edges is not None
-    assert not connects(
-        remaining_center_edges, center_id, mixed_id
-    ), "Edge between center and mixed_id should have been removed"
+    assert not connects(remaining_center_edges, center_id, mixed_id), (
+        "Edge between center and mixed_id should have been removed"
+    )
     print(
         "Undirected property verification successful: "
         "deleting an edge removes it in both directions"
@@ -1481,21 +1482,21 @@ async def test_graph_undirected_property(storage):
         # Verify forward query
         forward_edge = await storage.get_edge(node1_id, node2_id)
         print(f"Forward edge properties: {forward_edge}")
-        assert (
-            forward_edge is not None
-        ), f"Failed to read forward edge properties: {node1_id} -> {node2_id}"
+        assert forward_edge is not None, (
+            f"Failed to read forward edge properties: {node1_id} -> {node2_id}"
+        )
 
         # Verify reverse query
         reverse_edge = await storage.get_edge(node2_id, node1_id)
         print(f"Reverse edge properties: {reverse_edge}")
-        assert (
-            reverse_edge is not None
-        ), f"Failed to read reverse edge properties: {node2_id} -> {node1_id}"
+        assert reverse_edge is not None, (
+            f"Failed to read reverse edge properties: {node2_id} -> {node1_id}"
+        )
 
         # Verify that forward and reverse edge properties are consistent
-        assert (
-            forward_edge == reverse_edge
-        ), "Forward and reverse edge properties are inconsistent, undirected property verification failed"
+        assert forward_edge == reverse_edge, (
+            "Forward and reverse edge properties are inconsistent, undirected property verification failed"
+        )
         print(
             "Undirected property verification successful: forward and reverse edge properties are consistent"
         )
@@ -1517,9 +1518,9 @@ async def test_graph_undirected_property(storage):
         reverse_degree = await storage.edge_degree(node2_id, node1_id)
         print(f"Degree of forward edge {node1_id} -> {node2_id}: {forward_degree}")
         print(f"Degree of reverse edge {node2_id} -> {node1_id}: {reverse_degree}")
-        assert (
-            forward_degree == reverse_degree
-        ), "Degrees of forward and reverse edges are inconsistent, undirected property verification failed"
+        assert forward_degree == reverse_degree, (
+            "Degrees of forward and reverse edges are inconsistent, undirected property verification failed"
+        )
         print(
             "Undirected property verification successful: degrees of forward and reverse edges are consistent"
         )
@@ -1536,18 +1537,18 @@ async def test_graph_undirected_property(storage):
         print(
             f"Querying forward edge properties after deletion {node1_id} -> {node2_id}: {forward_edge}"
         )
-        assert (
-            forward_edge is None
-        ), f"Edge {node1_id} -> {node2_id} should have been deleted"
+        assert forward_edge is None, (
+            f"Edge {node1_id} -> {node2_id} should have been deleted"
+        )
 
         # Verify reverse edge is also deleted
         reverse_edge = await storage.get_edge(node2_id, node1_id)
         print(
             f"Querying reverse edge properties after deletion {node2_id} -> {node1_id}: {reverse_edge}"
         )
-        assert (
-            reverse_edge is None
-        ), f"Reverse edge {node2_id} -> {node1_id} should also be deleted, undirected property verification failed"
+        assert reverse_edge is None, (
+            f"Reverse edge {node2_id} -> {node1_id} should also be deleted, undirected property verification failed"
+        )
         print(
             "Undirected property verification successful: deleting an edge in one direction also deletes the reverse edge"
         )
@@ -1577,15 +1578,14 @@ async def test_graph_undirected_property(storage):
         # Verify that properties of forward and reverse edges are consistent
         for (src, tgt), props in edges_dict.items():
             assert (
-                (
-                    tgt,
-                    src,
-                )
-                in reverse_edges_dict
-            ), f"Reverse edge {tgt} -> {src} should be in the result"
-            assert (
-                props == reverse_edges_dict[(tgt, src)]
-            ), f"Properties of edge {src} -> {tgt} and reverse edge {tgt} -> {src} are inconsistent"
+                tgt,
+                src,
+            ) in reverse_edges_dict, (
+                f"Reverse edge {tgt} -> {src} should be in the result"
+            )
+            assert props == reverse_edges_dict[(tgt, src)], (
+                f"Properties of edge {src} -> {tgt} and reverse edge {tgt} -> {src} are inconsistent"
+            )
 
         print(
             "Undirected property verification successful: properties of batch-retrieved forward and reverse edges are consistent"
@@ -1609,12 +1609,12 @@ async def test_graph_undirected_property(storage):
             (src == node1_id and tgt == node3_id) for src, tgt in node1_edges
         )
 
-        assert (
-            has_edge_to_node2
-        ), f"Edge list of node {node1_id} should include an edge to {node2_id}"
-        assert (
-            has_edge_to_node3
-        ), f"Edge list of node {node1_id} should include an edge to {node3_id}"
+        assert has_edge_to_node2, (
+            f"Edge list of node {node1_id} should include an edge to {node2_id}"
+        )
+        assert has_edge_to_node3, (
+            f"Edge list of node {node1_id} should include an edge to {node3_id}"
+        )
 
         # Check if node 2 has a connection with node 1
         has_edge_to_node1 = any(
@@ -1622,9 +1622,9 @@ async def test_graph_undirected_property(storage):
             or (src == node1_id and tgt == node2_id)
             for src, tgt in node2_edges
         )
-        assert (
-            has_edge_to_node1
-        ), f"Edge list of node {node2_id} should include a connection with {node1_id}"
+        assert has_edge_to_node1, (
+            f"Edge list of node {node2_id} should include a connection with {node1_id}"
+        )
 
         print(
             "Undirected property verification successful: batch-retrieved node edges include all relevant edges (regardless of direction)"

--- a/tests/kg/test_unified_lock_safety.py
+++ b/tests/kg/test_unified_lock_safety.py
@@ -114,9 +114,9 @@ class TestUnifiedLockSafety:
             assert "Async lock release failed" in str(e)
 
         # Verify async_lock.release() was called only ONCE, not twice
-        assert (
-            release_call_count == 1
-        ), f"async_lock.release() should be called only once, but was called {release_call_count} times"
+        assert release_call_count == 1, (
+            f"async_lock.release() should be called only once, but was called {release_call_count} times"
+        )
 
         # Main lock should have been released successfully
         main_lock.release.assert_called_once()

--- a/tests/llm/test_batch_embeddings.py
+++ b/tests/llm/test_batch_embeddings.py
@@ -71,9 +71,9 @@ async def test_hybrid_mode_batches_embeddings():
     )
 
     # The embedding function should be called exactly once with all 3 texts batched
-    assert (
-        embed_func.call_count == 1
-    ), f"Expected 1 batched embedding call, got {embed_func.call_count}"
+    assert embed_func.call_count == 1, (
+        f"Expected 1 batched embedding call, got {embed_func.call_count}"
+    )
     call_args = embed_func.call_args[0][0]
     assert len(call_args) == 3, f"Expected 3 texts in batch, got {len(call_args)}"
     assert call_args == ["test query", "entity1, entity2", "theme1, theme2"]
@@ -109,20 +109,20 @@ async def test_hybrid_mode_passes_embeddings_to_vdbs():
     assert entities_call is not None, "entities_vdb.query was not called"
     ll_embedding = entities_call.kwargs.get("query_embedding")
     assert ll_embedding is not None, "ll_embedding was not passed to entities_vdb.query"
-    assert np.all(
-        ll_embedding == 2.0
-    ), f"Expected ll_embedding=[2,2,...], got {ll_embedding[:3]}"
+    assert np.all(ll_embedding == 2.0), (
+        f"Expected ll_embedding=[2,2,...], got {ll_embedding[:3]}"
+    )
 
     # relationships_vdb.query should receive hl_embedding (index 2 → all 3s)
     rel_call = relationships_vdb.query.call_args
     assert rel_call is not None, "relationships_vdb.query was not called"
     hl_embedding = rel_call.kwargs.get("query_embedding")
-    assert (
-        hl_embedding is not None
-    ), "hl_embedding was not passed to relationships_vdb.query"
-    assert np.all(
-        hl_embedding == 3.0
-    ), f"Expected hl_embedding=[3,3,...], got {hl_embedding[:3]}"
+    assert hl_embedding is not None, (
+        "hl_embedding was not passed to relationships_vdb.query"
+    )
+    assert np.all(hl_embedding == 3.0), (
+        f"Expected hl_embedding=[3,3,...], got {hl_embedding[:3]}"
+    )
 
 
 @pytest.mark.offline

--- a/tests/llm/test_no_model_suffix_safety.py
+++ b/tests/llm/test_no_model_suffix_safety.py
@@ -121,9 +121,9 @@ class TestNoModelSuffixSafety:
             for call in db.execute.call_args_list
             if call[0][0] and "DROP TABLE" in call[0][0]
         ]
-        assert (
-            len(drop_calls) == 0
-        ), "Should not drop table when new and legacy are the same"
+        assert len(drop_calls) == 0, (
+            "Should not drop table when new and legacy are the same"
+        )
 
         # Note: COUNT queries for workspace data are expected behavior in Case 1
         # (for logging/warning purposes when workspace data is empty).

--- a/tests/llm/test_vlm_json_escape_repair.py
+++ b/tests/llm/test_vlm_json_escape_repair.py
@@ -118,9 +118,9 @@ def test_prompts_require_double_escaped_backslashes():
 
     for key in ("image_analysis", "table_analysis", "equation_analysis"):
         template = MULTIMODAL_PROMPTS[key]
-        assert (
-            "escape backslashes" in template or "double-escaped" in template
-        ), f"{key}: missing backslash escaping rule in OUTPUT RULES"
+        assert "escape backslashes" in template or "double-escaped" in template, (
+            f"{key}: missing backslash escaping rule in OUTPUT RULES"
+        )
 
 
 @pytest.mark.offline

--- a/tests/llm/voyageai_impl/test_voyageai_embed.py
+++ b/tests/llm/voyageai_impl/test_voyageai_embed.py
@@ -159,6 +159,6 @@ def test_anthropic_embed_deprecation_shim():
         if hasattr(coro, "close"):
             coro.close()
 
-    assert any(
-        issubclass(w.category, DeprecationWarning) for w in caught
-    ), "anthropic_embed should warn DeprecationWarning"
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught), (
+        "anthropic_embed should warn DeprecationWarning"
+    )

--- a/tests/parser/docx/test_ir_builder_security.py
+++ b/tests/parser/docx/test_ir_builder_security.py
@@ -27,7 +27,7 @@ def _build_ir(content: str):
 @pytest.mark.offline
 def test_native_docx_ir_accepts_safe_local_drawing_asset() -> None:
     ir = _build_ir(
-        '<drawing id="1" name="fig" format="png" ' 'path="doc.blocks.assets/fig.png" />'
+        '<drawing id="1" name="fig" format="png" path="doc.blocks.assets/fig.png" />'
     )
 
     drawing = ir.blocks[0].drawings[0]
@@ -60,7 +60,7 @@ def test_native_docx_ir_rejects_unsafe_local_drawing_asset(path: str) -> None:
 @pytest.mark.offline
 def test_native_docx_ir_preserves_non_asset_external_drawing_path() -> None:
     ir = _build_ir(
-        '<drawing id="1" name="fig" format="gif" ' 'path="../images/legacy.gif" />'
+        '<drawing id="1" name="fig" format="gif" path="../images/legacy.gif" />'
     )
 
     drawing = ir.blocks[0].drawings[0]

--- a/tests/parser/docx/test_native_docx_golden.py
+++ b/tests/parser/docx/test_native_docx_golden.py
@@ -161,6 +161,6 @@ def test_native_docx_migration_is_byte_equivalent(
         produced_path = produced_files[rel]
         if _read_bytes(produced_path) != _read_bytes(expected_path):
             mismatches.append(str(rel))
-    assert (
-        not mismatches
-    ), f"byte mismatch in scenario {scenario.name!r} for files: {mismatches}"
+    assert not mismatches, (
+        f"byte mismatch in scenario {scenario.name!r} for files: {mismatches}"
+    )

--- a/tests/parser/external/docling/test_parse_docling_sidecar.py
+++ b/tests/parser/external/docling/test_parse_docling_sidecar.py
@@ -502,9 +502,9 @@ def test_parse_docling_options_signature_invalidates_cache(
                 file_path="demo.pdf",
                 content_data={},
             )
-            assert (
-                counters["calls"] == 2
-            ), "DOCLING_OCR_LANG change must invalidate the bundle cache"
+            assert counters["calls"] == 2, (
+                "DOCLING_OCR_LANG change must invalidate the bundle cache"
+            )
         finally:
             await rag.finalize_storages()
 
@@ -550,9 +550,9 @@ def test_parse_docling_endpoint_signature_invalidates_cache(
                 file_path="demo.pdf",
                 content_data={},
             )
-            assert (
-                counters["calls"] == 2
-            ), "DOCLING_ENDPOINT change must invalidate the bundle cache"
+            assert counters["calls"] == 2, (
+                "DOCLING_ENDPOINT change must invalidate the bundle cache"
+            )
         finally:
             await rag.finalize_storages()
 
@@ -659,9 +659,9 @@ def test_parse_docling_zero_blocks_raises(
             # only after the zero-blocks check, so no ``*.blocks.jsonl`` may
             # exist anywhere under the workspace.
             blocks_files = list(tmp_path.rglob("*.blocks.jsonl"))
-            assert (
-                not blocks_files
-            ), f"sidecar emitted despite zero-blocks failure: {blocks_files}"
+            assert not blocks_files, (
+                f"sidecar emitted despite zero-blocks failure: {blocks_files}"
+            )
         finally:
             await rag.finalize_storages()
 

--- a/tests/pipeline/test_doc_status_chunk_preservation.py
+++ b/tests/pipeline/test_doc_status_chunk_preservation.py
@@ -1338,13 +1338,13 @@ async def test_delete_doc_entries_guard_prevents_zombie_record(tmp_path, monkeyp
         # _update_delete_retry_state (which would upsert the record with
         # deletion_failed=True) when deletion_stage is "delete_doc_entries".
         status_record = await rag.doc_status.get_by_id(doc_id)
-        assert (
-            status_record is not None
-        ), "doc_status should still exist (delete failed)"
+        assert status_record is not None, (
+            "doc_status should still exist (delete failed)"
+        )
         metadata = status_record.get("metadata", {})
-        assert not metadata.get(
-            "deletion_failed"
-        ), "guard failed: zombie record written with deletion_failed=True"
+        assert not metadata.get("deletion_failed"), (
+            "guard failed: zombie record written with deletion_failed=True"
+        )
     finally:
         await rag.finalize_storages()
 
@@ -1593,9 +1593,9 @@ async def test_deletion_fully_completed_prevents_success_override_in_finally(
 
             result = await rag.adelete_by_doc_id(doc_id)
 
-            assert (
-                result.status == "success"
-            ), f"[{scenario}] expected success but got {result.status}: {result.message}"
+            assert result.status == "success", (
+                f"[{scenario}] expected success but got {result.status}: {result.message}"
+            )
         finally:
             monkeypatch.undo()
             await rag.finalize_storages()

--- a/tests/pipeline/test_pipeline_analyze_multimodal.py
+++ b/tests/pipeline/test_pipeline_analyze_multimodal.py
@@ -623,9 +623,9 @@ async def test_invalid_vlm_response_hard_fails(tmp_path):
             analysis_keys = [
                 k for k in cache_blob.keys() if k.startswith("default:analysis:")
             ]
-            assert (
-                analysis_keys == []
-            ), f"invalid VLM response was cached: {analysis_keys}"
+            assert analysis_keys == [], (
+                f"invalid VLM response was cached: {analysis_keys}"
+            )
         payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
         item = payload["drawings"]["im-001"]
         assert item["llm_analyze_result"]["status"] == "failure"
@@ -808,7 +808,7 @@ async def test_invalid_json_with_trailing_comma_is_repaired(tmp_path):
     async def vlm_func(prompt, **kwargs):
         call_log.append({"prompt": prompt, "kwargs": dict(kwargs)})
         # Trailing comma after "description" — strict json.loads would reject.
-        return '{"name": "fig-1", "type": "Chart", ' '"description": "ok",}'
+        return '{"name": "fig-1", "type": "Chart", "description": "ok",}'
 
     rag = _build_rag(tmp_path, vlm_process_enable=True, vlm_func=vlm_func)
     await rag.initialize_storages()
@@ -1126,9 +1126,9 @@ async def test_max_extract_input_tokens_env_var_lowers_cap_and_logs_warning(
             and "tb-mid" in r.getMessage()
             and "content trimmed" in r.getMessage()
         ]
-        assert (
-            warning_records
-        ), "expected a WARNING-level log line announcing content truncation"
+        assert warning_records, (
+            "expected a WARNING-level log line announcing content truncation"
+        )
     finally:
         await rag.finalize_storages()
 
@@ -1173,8 +1173,7 @@ async def test_extract_cap_below_prompt_frame_fails_item_without_llm_call(
                         "tb-tight": {
                             "format": "json",
                             "content": (
-                                '<table id="tb-tight" format="json">'
-                                '[["A","B"]]</table>'
+                                '<table id="tb-tight" format="json">[["A","B"]]</table>'
                             ),
                         }
                     }

--- a/tests/pipeline/test_pipeline_release_closure.py
+++ b/tests/pipeline/test_pipeline_release_closure.py
@@ -660,9 +660,9 @@ def test_stage_end_outcomes_persist_within_their_own_stage(tmp_path):
             (i for i, (s, _) in enumerate(calls) if s == "processing"), None
         )
         assert first_analyzing is not None, f"no ANALYZING upsert; sequence: {calls!r}"
-        assert (
-            first_processing is not None
-        ), f"no PROCESSING upsert; sequence: {calls!r}"
+        assert first_processing is not None, (
+            f"no PROCESSING upsert; sequence: {calls!r}"
+        )
 
         assert any(
             s == "parsing" and "parse_stage_skipped" in keys
@@ -984,9 +984,9 @@ def test_resume_skips_purge_when_chunks_list_empty(tmp_path):
                 # was NOT called for an empty chunks_list.
                 pass
 
-            assert (
-                calls == []
-            ), "purge helper should not be called when chunks_list is empty"
+            assert calls == [], (
+                "purge helper should not be called when chunks_list is empty"
+            )
         finally:
             await rag.finalize_storages()
 

--- a/tests/setup/test_env.py
+++ b/tests/setup/test_env.py
@@ -937,11 +937,11 @@ set -euo pipefail
 source "{REPO_ROOT}/scripts/setup/setup.sh"
 REPO_ROOT="{case_dir}"
 
-{case['prompt_choice']}
+{case["prompt_choice"]}
 prompt_with_default() {{ printf '%s' "$2"; }}
 prompt_until_valid() {{ printf '%s' "$2"; }}
 prompt_secret_with_default() {{ printf '%s' "$2"; }}
-{case['prompt_secret']}
+{case["prompt_secret"]}
 confirm_default_no() {{
   case "$1" in
     "Run embedding model locally via Docker (vLLM)?") return 1 ;;

--- a/tests/workspace/test_workspace_isolation.py
+++ b/tests/workspace/test_workspace_isolation.py
@@ -174,9 +174,9 @@ async def test_pipeline_status_isolation():
     data2 = await get_namespace_data("pipeline_status", workspace=workspace2)
 
     # Verify they are independent objects
-    assert (
-        data1 is not data2
-    ), "Pipeline status data objects are the same (should be different)"
+    assert data1 is not data2, (
+        "Pipeline status data objects are the same (should be different)"
+    )
 
     # Modify workspace1's data and verify workspace2 is not affected
     data1["test_key"] = "workspace1_value"
@@ -186,12 +186,12 @@ async def test_pipeline_status_isolation():
     data2_check = await get_namespace_data("pipeline_status", workspace=workspace2)
 
     assert "test_key" in data1_check, "test_key not found in workspace1"
-    assert (
-        data1_check["test_key"] == "workspace1_value"
-    ), f"workspace1 test_key value incorrect: {data1_check.get('test_key')}"
-    assert (
-        "test_key" not in data2_check
-    ), f"test_key leaked to workspace2: {data2_check.get('test_key')}"
+    assert data1_check["test_key"] == "workspace1_value", (
+        f"workspace1 test_key value incorrect: {data1_check.get('test_key')}"
+    )
+    assert "test_key" not in data2_check, (
+        f"test_key leaked to workspace2: {data2_check.get('test_key')}"
+    )
 
     print("✅ PASSED: Pipeline Status Isolation")
     print("   Different workspaces have isolated pipeline status")
@@ -313,9 +313,9 @@ async def test_backward_compatibility():
     final_ns_empty = get_final_namespace("pipeline_status", workspace=None)
     expected_empty = "pipeline_status"  # Should be just the namespace without ':'
 
-    assert (
-        final_ns_empty == expected_empty
-    ), f"Expected '{expected_empty}', got '{final_ns_empty}'"
+    assert final_ns_empty == expected_empty, (
+        f"Expected '{expected_empty}', got '{final_ns_empty}'"
+    )
 
     print("✅ PASSED: Backward Compatibility - empty workspace")
     print(f"   Empty workspace handled correctly: '{final_ns_empty}'")
@@ -331,9 +331,9 @@ async def test_backward_compatibility():
         "pipeline_status", workspace="compat_test_workspace"
     )
 
-    assert (
-        data is not None
-    ), "Failed to initialize pipeline status with default workspace"
+    assert data is not None, (
+        "Failed to initialize pipeline status with default workspace"
+    )
 
     print("✅ PASSED: Backward Compatibility - pipeline init with None")
     print("   Pipeline status initialized with default workspace")
@@ -410,12 +410,12 @@ async def test_multi_workspace_concurrency():
         expected_key = f"{ws}_key"
         expected_value = f"{ws}_value"
 
-        assert (
-            expected_key in data
-        ), f"Data not properly isolated for {ws}: missing {expected_key}"
-        assert (
-            data[expected_key] == expected_value
-        ), f"Data not properly isolated for {ws}: {expected_key}={data[expected_key]} (expected {expected_value})"
+        assert expected_key in data, (
+            f"Data not properly isolated for {ws}: missing {expected_key}"
+        )
+        assert data[expected_key] == expected_value, (
+            f"Data not properly isolated for {ws}: {expected_key}={data[expected_key]} (expected {expected_value})"
+        )
         print(f"   [{ws}] Data correctly isolated: {expected_key}={data[expected_key]}")
 
     print("✅ PASSED: Multi-Workspace Concurrency - Data Isolation")
@@ -485,9 +485,9 @@ async def test_namespace_lock_reentrance():
 
     # Both coroutines should have completed
     expected_entries = 4  # 2 starts + 2 ends
-    assert (
-        len(concurrent_results) == expected_entries
-    ), f"Expected {expected_entries} entries, got {len(concurrent_results)}"
+    assert len(concurrent_results) == expected_entries, (
+        f"Expected {expected_entries} entries, got {len(concurrent_results)}"
+    )
 
     print("✅ PASSED: NamespaceLock Concurrent Reuse")
     print(
@@ -626,12 +626,12 @@ async def test_update_flags_workspace_isolation():
     await set_all_update_flags(test_namespace, workspace=workspace1)
 
     # Check that only workspace1's flags are set
-    assert (
-        flag1_obj.value is True
-    ), f"Flag1 should be True after set_all_update_flags, got {flag1_obj.value}"
-    assert (
-        flag2_obj.value is False
-    ), f"Flag2 should still be False, got {flag2_obj.value}"
+    assert flag1_obj.value is True, (
+        f"Flag1 should be True after set_all_update_flags, got {flag1_obj.value}"
+    )
+    assert flag2_obj.value is False, (
+        f"Flag2 should still be False, got {flag2_obj.value}"
+    )
 
     print("✅ PASSED: Update Flags - set_all_update_flags Isolation")
     print(
@@ -653,9 +653,9 @@ async def test_update_flags_workspace_isolation():
     await clear_all_update_flags(test_namespace, workspace=workspace1)
 
     # Check that only workspace1's flags are cleared
-    assert (
-        flag1_obj.value is False
-    ), f"Flag1 should be False after clear, got {flag1_obj.value}"
+    assert flag1_obj.value is False, (
+        f"Flag1 should be False after clear, got {flag1_obj.value}"
+    )
     assert flag2_obj.value is True, f"Flag2 should still be True, got {flag2_obj.value}"
 
     print("✅ PASSED: Update Flags - clear_all_update_flags Isolation")
@@ -686,12 +686,12 @@ async def test_update_flags_workspace_isolation():
     workspace1_keys = [k for k in status1.keys() if workspace1 in k]
     workspace2_keys = [k for k in status1.keys() if workspace2 in k]
 
-    assert (
-        len(workspace1_keys) > 0
-    ), f"workspace1 keys should be present, got {len(workspace1_keys)}"
-    assert (
-        len(workspace2_keys) == 0
-    ), f"workspace2 keys should not be present, got {len(workspace2_keys)}"
+    assert len(workspace1_keys) > 0, (
+        f"workspace1 keys should be present, got {len(workspace1_keys)}"
+    )
+    assert len(workspace2_keys) == 0, (
+        f"workspace2 keys should not be present, got {len(workspace2_keys)}"
+    )
     for key, values in status1.items():
         assert all(values), f"All flags in {key} should be True, got {values}"
 
@@ -701,9 +701,9 @@ async def test_update_flags_workspace_isolation():
         f"{workspace2}:{test_namespace}",
         f"{workspace2}:ns_c",
     }
-    assert (
-        set(status2.keys()) == expected_ws2_keys
-    ), f"Unexpected namespaces for workspace2: {status2.keys()}"
+    assert set(status2.keys()) == expected_ws2_keys, (
+        f"Unexpected namespaces for workspace2: {status2.keys()}"
+    )
     for key, values in status2.items():
         assert all(values), f"All flags in {key} should be True, got {values}"
 
@@ -737,9 +737,9 @@ async def test_empty_workspace_standardization():
     final_ns = get_final_namespace("test_namespace", workspace=None)
 
     # Should be just "test_namespace" without colon prefix
-    assert (
-        final_ns == "test_namespace"
-    ), f"Unexpected namespace format: '{final_ns}' (expected 'test_namespace')"
+    assert final_ns == "test_namespace", (
+        f"Unexpected namespace format: '{final_ns}' (expected 'test_namespace')"
+    )
 
     print("✅ PASSED: Empty Workspace Standardization - Format")
     print(f"   Empty workspace creates correct namespace: '{final_ns}'")
@@ -758,9 +758,9 @@ async def test_empty_workspace_standardization():
     data_nonempty = await get_namespace_data("pipeline_status", workspace="test_ws")
 
     # They should be different objects
-    assert (
-        data_empty is not data_nonempty
-    ), "Empty and non-empty workspaces share data (should be independent)"
+    assert data_empty is not data_nonempty, (
+        "Empty and non-empty workspaces share data (should be independent)"
+    )
 
     print("✅ PASSED: Empty Workspace Standardization - Behavior")
     print("   Empty and non-empty workspaces have independent data")
@@ -896,9 +896,9 @@ async def test_json_kv_storage_workspace_isolation(keep_test_artifacts):
         assert result1_entity2 is not None, "Storage1 entity2 should not be None"
         assert result2_entity1 is not None, "Storage2 entity1 should not be None"
         assert result2_entity2 is not None, "Storage2 entity2 should not be None"
-        assert (
-            result1_entity1.get("content") == "Data from workspace1 - AI Research"
-        ), "Storage1 entity1 content mismatch"
+        assert result1_entity1.get("content") == "Data from workspace1 - AI Research", (
+            "Storage1 entity1 content mismatch"
+        )
         assert (
             result1_entity2.get("content") == "Data from workspace1 - Machine Learning"
         ), "Storage1 entity2 content mismatch"
@@ -908,12 +908,12 @@ async def test_json_kv_storage_workspace_isolation(keep_test_artifacts):
         assert (
             result2_entity2.get("content") == "Data from workspace2 - Neural Networks"
         ), "Storage2 entity2 content mismatch"
-        assert result1_entity1.get("content") != result2_entity1.get(
-            "content"
-        ), "Storage1 and Storage2 entity1 should have different content"
-        assert result1_entity2.get("content") != result2_entity2.get(
-            "content"
-        ), "Storage1 and Storage2 entity2 should have different content"
+        assert result1_entity1.get("content") != result2_entity1.get("content"), (
+            "Storage1 and Storage2 entity1 should have different content"
+        )
+        assert result1_entity2.get("content") != result2_entity2.get("content"), (
+            "Storage1 and Storage2 entity2 should have different content"
+        )
 
         print("✅ PASSED: JsonKVStorage - Data Isolation")
         print(
@@ -1129,38 +1129,38 @@ relation<|#|>Deep Learning<|#|>Neural Networks<|#|>uses, composed of<|#|>Deep Le
             print(f"   project_b doc count: {len(docs_b_content)}")
 
             # Verify they contain different data
-            assert (
-                docs_a_content != docs_b_content
-            ), "Document storage not properly isolated"
+            assert docs_a_content != docs_b_content, (
+                "Document storage not properly isolated"
+            )
 
             # Verify each workspace contains its own text content
             docs_a_str = json.dumps(docs_a_content)
             docs_b_str = json.dumps(docs_b_content)
 
             # Check project_a contains its text and NOT project_b's text
-            assert (
-                "Artificial Intelligence" in docs_a_str
-            ), "project_a should contain 'Artificial Intelligence'"
-            assert (
-                "Machine Learning" in docs_a_str
-            ), "project_a should contain 'Machine Learning'"
-            assert (
-                "Deep Learning" not in docs_a_str
-            ), "project_a should NOT contain 'Deep Learning' from project_b"
-            assert (
-                "Neural Networks" not in docs_a_str
-            ), "project_a should NOT contain 'Neural Networks' from project_b"
+            assert "Artificial Intelligence" in docs_a_str, (
+                "project_a should contain 'Artificial Intelligence'"
+            )
+            assert "Machine Learning" in docs_a_str, (
+                "project_a should contain 'Machine Learning'"
+            )
+            assert "Deep Learning" not in docs_a_str, (
+                "project_a should NOT contain 'Deep Learning' from project_b"
+            )
+            assert "Neural Networks" not in docs_a_str, (
+                "project_a should NOT contain 'Neural Networks' from project_b"
+            )
 
             # Check project_b contains its text and NOT project_a's text
-            assert (
-                "Deep Learning" in docs_b_str
-            ), "project_b should contain 'Deep Learning'"
-            assert (
-                "Neural Networks" in docs_b_str
-            ), "project_b should contain 'Neural Networks'"
-            assert (
-                "Artificial Intelligence" not in docs_b_str
-            ), "project_b should NOT contain 'Artificial Intelligence' from project_a"
+            assert "Deep Learning" in docs_b_str, (
+                "project_b should contain 'Deep Learning'"
+            )
+            assert "Neural Networks" in docs_b_str, (
+                "project_b should contain 'Neural Networks'"
+            )
+            assert "Artificial Intelligence" not in docs_b_str, (
+                "project_b should NOT contain 'Artificial Intelligence' from project_a"
+            )
             # Note: "Machine Learning" might appear in project_b's text, so we skip that check
 
             print("✅ PASSED: LightRAG E2E - Data Isolation")

--- a/tests/workspace/test_workspace_migration_isolation.py
+++ b/tests/workspace/test_workspace_migration_isolation.py
@@ -144,9 +144,9 @@ class TestWorkspaceMigrationIsolation:
         )
 
         # Verify the migration was triggered
-        assert (
-            len(migration_executed) > 0
-        ), "Migration should have been executed for workspace_a"
+        assert len(migration_executed) > 0, (
+            "Migration should have been executed for workspace_a"
+        )
 
     async def test_migration_without_workspace_raises_error(self):
         """

--- a/tests/workspace/test_workspace_sanitization.py
+++ b/tests/workspace/test_workspace_sanitization.py
@@ -182,6 +182,6 @@ class TestWorkspaceLabelSanitization:
             backtick_sequences = re.findall(r"`+", result)
             for seq in backtick_sequences:
                 # Any sequence of backticks should have an EVEN length because each ` becomes ``
-                assert (
-                    len(seq) % 2 == 0
-                ), f"Unescaped backtick found in result '{result}' for input '{inp}'"
+                assert len(seq) % 2 == 0, (
+                    f"Unescaped backtick found in result '{result}' for input '{inp}'"
+                )


### PR DESCRIPTION
## Summary
Bumps the `.pre-commit-config.yaml` hooks to current releases and applies the resulting formatter changes.

| Hook | Old | New |
|---|---|---|
| `astral-sh/ruff-pre-commit` | v0.6.4 | **v0.15.17** |
| `pre-commit/pre-commit-hooks` | v5.0.0 | **v6.0.0** |
| `mgedmin/check-manifest` | 0.49 | **0.51** |

## Why
The pinned ruff (v0.6.4, Sept 2024) is ~9 minor versions behind. Contributors running a recent ruff locally produce formatting that disagrees with the pinned gate (e.g. `assert (...)` wrapping), causing spurious "format check failed" noise. Bumping the pin realigns local and CI behaviour.

## Commits (kept reviewable)
1. **`chore: bump pre-commit hooks`** — config-only version bumps.
2. **`style: apply ruff 0.15 formatting across repo`** — mechanical reformat from `pre-commit run --all-files`. **50 files, formatting only** (string-concat joins, call/lambda wrapping, assert reflow). No logic changes.
3. **`chore: add .git-blame-ignore-revs`** — lists the reformat commit so `git blame` can skip it.

## Risk / verification
- `ruff check` (legacy alias, same `--ignore=E402`): **zero new violations** — All checks passed.
- `trailing-whitespace` / `end-of-file-fixer` / `requirements-txt-fixer`: no changes.
- `pre-commit run --all-files` is **idempotent** after the reformat (second run all-green).
- All 50 changed files `py_compile`-clean; spot-checked diffs are pure reflow.
- The reformat is isolated in commit 2; reviewers can focus on commit 1 (config) and trust commit 2 as machine output.

## Activating blame-ignore locally
```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

## Test plan
- [x] `pre-commit run --all-files` green (idempotent)
- [x] `ruff check` zero violations
- [x] changed files compile
- [ ] CI `linting.yaml` green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
