### PR TITLE
feat(chunker): add drop_references option to P chunking strategy

### DIFF
--- a/docs/FileProcessingPipeline-zh.md
+++ b/docs/FileProcessingPipeline-zh.md
@@ -133,10 +133,13 @@ LIGHTRAG_PARSER=pdf:legacy-R(chunk_ts=800,chunk_ol=80);*:legacy-R  # 规则
 | --- | --- | --- | --- | --- |
 | `chunk_token_size` | `chunk_ts` | F / R / V / P | int（≥ 1） | 各策略的块大小 |
 | `chunk_overlap_token_size` | `chunk_ol` | F / R / P | int（≥ 0） | 块间重叠（V 无重叠） |
+| `drop_references` | `drop_rf` | P | bool | 分块前丢弃文末参考文献节，如 `paper.[-P(drop_rf=true)].pdf`|
 
 - `process_options` 仍是纯选择符字符串；每个参数会写入该策略的 `chunk_options`（见 §3），策略其它来自环境变量的参数保持不变。别名在内部统一归一化为全称。
 - 合并优先级：选择符仍遵循“文件名 hint 的非空选项整体覆盖规则选项”；参数按**同一策略**叠加——先规则参数，再文件名 hint 参数（同一键以文件名为准）。
 - 启动期（`LIGHTRAG_PARSER`）与上传期（文件名 hint）均严格校验：未知参数、类型错误、取值越界、把参数加到不支持的策略（如 `V` 上的 `chunk_ol`）都会给出友好报错。
+
+> `drop_references` 检测调参 `CHUNK_P_REFERENCES_TAIL_N`（默认 2）/ `CHUNK_P_REFERENCES_HEADINGS`（竖线分隔，默认 `Reference\|References\|Bibliography\|参考文献`）仅经环境变量、运行时实时读取。drop_references可以通过环境变量 `CHUNK_P_DROP_REFERENCES` 设置为全局默认值.
 
 #### 为解析引擎附加参数
 

--- a/docs/FileProcessingPipeline-zh.md
+++ b/docs/FileProcessingPipeline-zh.md
@@ -133,7 +133,7 @@ LIGHTRAG_PARSER=pdf:legacy-R(chunk_ts=800,chunk_ol=80);*:legacy-R  # 规则
 | --- | --- | --- | --- | --- |
 | `chunk_token_size` | `chunk_ts` | F / R / V / P | int（≥ 1） | 各策略的块大小 |
 | `chunk_overlap_token_size` | `chunk_ol` | F / R / P | int（≥ 0） | 块间重叠（V 无重叠） |
-| `drop_references` | `drop_rf` | P | bool | 分块前丢弃文末参考文献节，如 `paper.[-P(drop_rf=true)].pdf`|
+| `drop_references` | `drop_rf` | P | bool | 分块前丢弃文末参考文献节，如 `paper.[-P(drop_rf=true)].pdf`；布尔参数可省略取值，`paper.[-P(drop_rf)].pdf` 等价于 `drop_rf=true` |
 
 - `process_options` 仍是纯选择符字符串；每个参数会写入该策略的 `chunk_options`（见 §3），策略其它来自环境变量的参数保持不变。别名在内部统一归一化为全称。
 - 合并优先级：选择符仍遵循“文件名 hint 的非空选项整体覆盖规则选项”；参数按**同一策略**叠加——先规则参数，再文件名 hint 参数（同一键以文件名为准）。

--- a/docs/FileProcessingPipeline.md
+++ b/docs/FileProcessingPipeline.md
@@ -133,10 +133,13 @@ Currently supported parameters (canonical name / short alias):
 | --- | --- | --- | --- | --- |
 | `chunk_token_size` | `chunk_ts` | F / R / V / P | int (≥ 1) | Per-strategy chunk size |
 | `chunk_overlap_token_size` | `chunk_ol` | F / R / P | int (≥ 0) | Overlap between chunks (V has no overlap) |
+| `drop_references` | `drop_rf` | P | bool | Drop the trailing reference section before chunking, e.g. `paper.[-P(drop_rf=true)].pdf` |
 
 - `process_options` stays a pure selector string; each parameter is applied to that strategy's `chunk_options` (see §3) while the strategy's other env-derived parameters are kept. Aliases are normalized to their canonical name internally.
 - Merge priority: the selector still follows "a non-empty filename-hint options string wholesale-overrides the rule options"; parameters overlay **per strategy** — rule parameters first, then filename-hint parameters (filename wins on a shared key).
 - Validation is strict both at startup (`LIGHTRAG_PARSER`) and at upload (filename hint): an unknown parameter, a wrong type, an out-of-range value, or a parameter on a strategy that does not support it (e.g. `chunk_ol` on `V`) all raise a friendly error.
+
+> `drop_references` detection knobs `CHUNK_P_REFERENCES_TAIL_N` (default 2) / `CHUNK_P_REFERENCES_HEADINGS` (pipe-separated, default `Reference\|References\|Bibliography\|参考文献`) are env-only and read live at run time. Global default can be set via env var `CHUNK_P_DROP_REFERENCES`.
 
 #### Attaching engine parameters
 

--- a/docs/FileProcessingPipeline.md
+++ b/docs/FileProcessingPipeline.md
@@ -133,7 +133,7 @@ Currently supported parameters (canonical name / short alias):
 | --- | --- | --- | --- | --- |
 | `chunk_token_size` | `chunk_ts` | F / R / V / P | int (≥ 1) | Per-strategy chunk size |
 | `chunk_overlap_token_size` | `chunk_ol` | F / R / P | int (≥ 0) | Overlap between chunks (V has no overlap) |
-| `drop_references` | `drop_rf` | P | bool | Drop the trailing reference section before chunking, e.g. `paper.[-P(drop_rf=true)].pdf` |
+| `drop_references` | `drop_rf` | P | bool | Drop the trailing reference section before chunking, e.g. `paper.[-P(drop_rf=true)].pdf`. As a boolean it may be written bare: `paper.[-P(drop_rf)].pdf` means `drop_rf=true` |
 
 - `process_options` stays a pure selector string; each parameter is applied to that strategy's `chunk_options` (see §3) while the strategy's other env-derived parameters are kept. Aliases are normalized to their canonical name internally.
 - Merge priority: the selector still follows "a non-empty filename-hint options string wholesale-overrides the rule options"; parameters overlay **per strategy** — rule parameters first, then filename-hint parameters (filename wins on a shared key).

--- a/docs/ParagraphSemanticChunking-zh.md
+++ b/docs/ParagraphSemanticChunking-zh.md
@@ -315,9 +315,14 @@ P chunker 直接读取 `.blocks.jsonl`，每个 content 行作为后续 TableRow
 | `.tables.json`（隐式） | 由 `blocks_path` 推导（`<base>.blocks.jsonl` → `<base>.tables.json`） | HeaderRecovery（§3.3.3）的表头数据源；缺失时静默跳过表头注入 |
 | `chunk_token_size` | `chunk_options.chunk_token_size` / `CHUNK_P_SIZE` | 目标硬上限 N，默认 `2000` |
 | `chunk_overlap_token_size` | `CHUNK_P_OVERLAP_SIZE` / `chunk_overlap_token_size` | 同一内容行内长正文 fallback 与表格桥接预算的上限，默认 `100` |
+| `drop_references` | hint `drop_references`（别名 `drop_rf`）/ `CHUNK_P_DROP_REFERENCES` | 是否在分块前丢弃文末参考文献块，默认 `False`；**入队冻结进 `chunk_options`，并记录到 `doc_status.metadata['chunk_opts']`**（开启时记为 `drop_rf=True`） |
+| `references_tail_n` | `CHUNK_P_REFERENCES_TAIL_N` | 参考文献块只在文末最后 N 个内容块内才被丢弃（安全窗口），默认 `2`；**运行时实时读 env，不快照、不进 metadata** |
+| `references_headings` | `CHUNK_P_REFERENCES_HEADINGS`（竖线分隔） | 参考文献标题前缀，默认 `Reference\|References\|Bibliography\|参考文献`；英文按单词边界、大小写不敏感匹配，`参考文献` 按前缀匹配；**运行时实时读 env，不快照、不进 metadata** |
 | `tokenizer` | LightRAG 已解析好的 tokenizer | 所有 token 计数与文本 overlap 截取的基准 |
 
 P 策略**不接收** `split_by_character` / `split_by_character_only`，因为正常路径由标题和段落结构驱动。
+
+**丢弃参考文献（`drop_references`）**：开启后，在 HeadingBlocks 之后、TableRowSplit/AnchorSplit/LevelMerge 之前，对从 `blocks.jsonl` 读出的有序内容块做过滤——**同时满足**「位于最后 `references_tail_n` 个块」且「`heading` 命中参考文献前缀」的块被丢弃。只有开关 `drop_references` 可经 per-file hint 设定并冻结进快照/metadata；`references_tail_n` / `references_headings` 是纯 env 调参，由 chunker 每次运行时实时读取当前环境变量——改 env 即可即时影响已入队文档的重跑。若丢弃后没有任何含内容的块剩余，则放弃丢弃并告警，避免产出空文档。
 
 ### 4.2 `.blocks.jsonl` 约定
 

--- a/env.example
+++ b/env.example
@@ -452,8 +452,23 @@ DOCLING_DO_FORMULA_ENRICHMENT=false
 ###       headroom than the global default to keep related paragraphs together).
 ###     CHUNK_P_OVERLAP_SIZE: overlap for prose fallback and table-bridge context;
 ###                           falls back to CHUNK_OVERLAP_SIZE when unset
+###     CHUNK_P_DROP_REFERENCES: drop the trailing reference section before chunking.
+###       Global default switch; overridable per-file via the hint param
+###       drop_references (alias drop_rf), e.g. paper.[-P(drop_rf=true)].pdf. Frozen
+###       into the document's chunk_options at enqueue and recorded in
+###       doc_status.metadata['chunk_opts'].
+###     CHUNK_P_REFERENCES_TAIL_N: a reference block is only dropped when it sits in
+###       the last N content blocks (safety window; default 2).
+###     CHUNK_P_REFERENCES_HEADINGS: pipe-separated reference heading prefixes
+###       (default Reference|References|Bibliography|参考文献). English words match
+###       case-insensitively at a word boundary; 参考文献 matches as a prefix.
+###     NOTE: TAIL_N / HEADINGS are read live by the chunker at run time (NOT
+###       snapshotted) — editing them changes the behaviour of re-runs.
 # CHUNK_P_SIZE=2000
 # CHUNK_P_OVERLAP_SIZE=100
+# CHUNK_P_DROP_REFERENCES=false
+# CHUNK_P_REFERENCES_TAIL_N=2
+# CHUNK_P_REFERENCES_HEADINGS=Reference|References|Bibliography|参考文献
 
 ### Number of summary segments or tokens to trigger LLM summary on entity/relation merge (at least 3 is recommended)
 # FORCE_LLM_SUMMARY_ON_MERGE=8

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -295,7 +295,11 @@ class RecursiveCharacterChunkParams(_OverlapChunkParams):
 
 
 class ParagraphSemanticChunkParams(_OverlapChunkParams):
-    pass
+    # Drop the trailing reference section before chunking. ``None`` means
+    # "not supplied — inherit the addon_params/env default at process time".
+    # Detection-tuning knobs (tail window / heading prefixes) are env-only and
+    # read live by the chunker, so they are intentionally not exposed here.
+    drop_references: Optional[bool] = None
 
 
 class SemanticVectorChunkParams(_StrictChunkParams):

--- a/lightrag/chunker/paragraph_semantic.py
+++ b/lightrag/chunker/paragraph_semantic.py
@@ -1965,6 +1965,7 @@ def chunking_by_paragraph_semantic(
     drop_references: bool = False,
     references_tail_n: int | None = None,
     references_headings: Sequence[str] | None = None,
+    doc_id: str | None = None,
 ) -> list[dict[str, Any]]:
     """Paragraph Semantic Chunking — the ``chunking="P"`` strategy.
 
@@ -2036,6 +2037,8 @@ def chunking_by_paragraph_semantic(
             :data:`DEFAULT_P_REFERENCES_HEADINGS`"; a kwarg is only passed by
             tests. Neither knob is snapshotted, so editing the env changes the
             behaviour of re-runs without re-enqueueing.
+        doc_id: Document id, used only to attribute the drop_references log
+            line to a document; ``None`` renders as ``"unknown"``.
 
     Returns:
         Ordered list of chunk dicts, each shaped::
@@ -2163,19 +2166,19 @@ def chunking_by_paragraph_semantic(
                 (row.get("content") or "").strip() for row in kept
             ):
                 logger.info(
-                    "[paragraph_semantic] drop_references: removed %d reference "
-                    "block(s) %s from the last %d block(s)",
+                    "[paragraph_semantic] removed %d reference block(s) %s "
+                    "from doc_id: %s",
                     len(dropped_headings),
                     _format_dropped_headings(dropped_headings),
-                    tail_n,
+                    doc_id or "unknown",
                 )
                 rows = kept
             elif dropped_headings:
                 logger.warning(
-                    "[paragraph_semantic] drop_references: dropping reference "
-                    "block(s) %s would leave no content; keeping them to avoid an "
-                    "empty document",
+                    "[paragraph_semantic] dropping reference block(s) %s would "
+                    "leave no content; keeping them from doc_id: %s",
                     _format_dropped_headings(dropped_headings),
+                    doc_id or "unknown",
                 )
 
     # Build initial blocks (HeadingBlocks output, already persisted).

--- a/lightrag/chunker/paragraph_semantic.py
+++ b/lightrag/chunker/paragraph_semantic.py
@@ -241,6 +241,26 @@ def _references_headings() -> list[str]:
     return [seg.strip() for seg in raw.split("|") if seg.strip()]
 
 
+def _format_dropped_headings(
+    headings: Sequence[str], *, max_each: int = 60, max_items: int = 5
+) -> str:
+    """Render dropped reference headings as a compact, length-bounded string.
+
+    Each heading is truncated to ``max_each`` chars and at most ``max_items``
+    are listed (the rest collapse to ``(+N more)``) so the log line stays
+    scannable even with a large ``references_tail_n`` or an unusually long
+    heading field.
+    """
+    shown = [
+        (h[:max_each] + "…") if len(h) > max_each else h for h in headings[:max_items]
+    ]
+    rendered = ", ".join(repr(h) for h in shown)
+    extra = len(headings) - max_items
+    if extra > 0:
+        rendered += f" (+{extra} more)"
+    return rendered
+
+
 def _is_reference_heading(heading: str, prefixes: Sequence[str]) -> bool:
     """Whether ``heading`` marks a reference section per ``prefixes``.
 
@@ -2146,7 +2166,7 @@ def chunking_by_paragraph_semantic(
                     "[paragraph_semantic] drop_references: removed %d reference "
                     "block(s) %s from the last %d block(s)",
                     len(dropped_headings),
-                    dropped_headings,
+                    _format_dropped_headings(dropped_headings),
                     tail_n,
                 )
                 rows = kept
@@ -2155,7 +2175,7 @@ def chunking_by_paragraph_semantic(
                     "[paragraph_semantic] drop_references: dropping reference "
                     "block(s) %s would leave no content; keeping them to avoid an "
                     "empty document",
-                    dropped_headings,
+                    _format_dropped_headings(dropped_headings),
                 )
 
     # Build initial blocks (HeadingBlocks output, already persisted).

--- a/lightrag/chunker/paragraph_semantic.py
+++ b/lightrag/chunker/paragraph_semantic.py
@@ -2126,31 +2126,36 @@ def chunking_by_paragraph_semantic(
         )
         if tail_n:
             start = max(0, len(rows) - tail_n)
-            kept = [
-                row
-                for idx, row in enumerate(rows)
-                if not (
-                    idx >= start
-                    and _is_reference_heading(row.get("heading", "") or "", prefixes)
-                )
-            ]
-            dropped = len(rows) - len(kept)
+            kept: list[dict[str, Any]] = []
+            dropped_headings: list[str] = []
+            for idx, row in enumerate(rows):
+                if idx >= start and _is_reference_heading(
+                    row.get("heading", "") or "", prefixes
+                ):
+                    dropped_headings.append((row.get("heading") or "").strip())
+                else:
+                    kept.append(row)
             # Protect against an empty document: base the guard on rows that
             # still carry content (the loop below skips blank-content rows), so
             # a pathological sidecar whose only kept rows are empty does not
             # silently produce zero chunks.
-            if dropped and any((row.get("content") or "").strip() for row in kept):
+            if dropped_headings and any(
+                (row.get("content") or "").strip() for row in kept
+            ):
                 logger.info(
-                    "[paragraph_semantic] dropped %d reference block(s) from the "
-                    "last %d block(s)",
-                    dropped,
+                    "[paragraph_semantic] drop_references: removed %d reference "
+                    "block(s) %s from the last %d block(s)",
+                    len(dropped_headings),
+                    dropped_headings,
                     tail_n,
                 )
                 rows = kept
-            elif dropped:
+            elif dropped_headings:
                 logger.warning(
-                    "[paragraph_semantic] dropping references would leave no "
-                    "content; keeping them to avoid an empty document"
+                    "[paragraph_semantic] drop_references: dropping reference "
+                    "block(s) %s would leave no content; keeping them to avoid an "
+                    "empty document",
+                    dropped_headings,
                 )
 
     # Build initial blocks (HeadingBlocks output, already persisted).

--- a/lightrag/chunker/paragraph_semantic.py
+++ b/lightrag/chunker/paragraph_semantic.py
@@ -50,10 +50,16 @@ from __future__ import annotations
 
 import json
 import math
+import os
 import re
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, Callable
 
+from lightrag.constants import (
+    DEFAULT_P_REFERENCES_HEADINGS,
+    DEFAULT_P_REFERENCES_TAIL_N,
+)
 from lightrag.table_markup import (
     TABLE_TAG_RE as _TABLE_TAG_RE,
     detect_table_format as _detect_table_format,
@@ -199,6 +205,66 @@ def _load_blocks_from_jsonl(blocks_path: str) -> list[dict[str, Any]]:
             if isinstance(obj, dict) and obj.get("type") == "content":
                 rows.append(obj)
     return rows
+
+
+def _references_tail_n() -> int:
+    """Trailing-block window for reference detection (live from env).
+
+    Read at chunk time (NOT snapshotted) so changing
+    ``CHUNK_P_REFERENCES_TAIL_N`` takes effect on re-runs of already-enqueued
+    documents.  Falls back to :data:`DEFAULT_P_REFERENCES_TAIL_N`.
+    """
+    raw = os.getenv("CHUNK_P_REFERENCES_TAIL_N")
+    if raw is None:
+        return DEFAULT_P_REFERENCES_TAIL_N
+    try:
+        return max(int(raw), 0)
+    except ValueError:
+        logger.warning(
+            "[paragraph_semantic] invalid CHUNK_P_REFERENCES_TAIL_N=%r; "
+            "using default %d",
+            raw,
+            DEFAULT_P_REFERENCES_TAIL_N,
+        )
+        return DEFAULT_P_REFERENCES_TAIL_N
+
+
+def _references_headings() -> list[str]:
+    """Reference heading prefixes (live from env), pipe-separated.
+
+    Read at chunk time (NOT snapshotted), mirroring :func:`_references_tail_n`.
+    Falls back to :data:`DEFAULT_P_REFERENCES_HEADINGS`.
+    """
+    raw = os.getenv("CHUNK_P_REFERENCES_HEADINGS")
+    if raw is None:
+        return list(DEFAULT_P_REFERENCES_HEADINGS)
+    return [seg.strip() for seg in raw.split("|") if seg.strip()]
+
+
+def _is_reference_heading(heading: str, prefixes: Sequence[str]) -> bool:
+    """Whether ``heading`` marks a reference section per ``prefixes``.
+
+    ASCII prefixes (``References``/``Bibliography``) match case-insensitively at
+    a word boundary, so ``Referenced work`` does NOT match.  Non-ASCII prefixes
+    (the Chinese ``参考文献``) match as a plain prefix — CJK has no word boundary,
+    so ``参考文献列表`` still matches.
+    """
+    low = (heading or "").strip().casefold()
+    if not low:
+        return False
+    for prefix in prefixes:
+        pref = (prefix or "").strip()
+        if not pref:
+            continue
+        pl = pref.casefold()
+        if not low.startswith(pl):
+            continue
+        if pref.isascii():
+            rest = low[len(pl) :]
+            if rest and rest[0].isalnum():
+                continue  # e.g. "Referenced" — not a standalone word
+        return True
+    return False
 
 
 def _tables_sidecar_path(blocks_path: str) -> str | None:
@@ -1876,6 +1942,9 @@ def chunking_by_paragraph_semantic(
     *,
     blocks_path: str | None = None,
     chunk_overlap_token_size: int = 100,
+    drop_references: bool = False,
+    references_tail_n: int | None = None,
+    references_headings: Sequence[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Paragraph Semantic Chunking — the ``chunking="P"`` strategy.
 
@@ -1931,6 +2000,22 @@ def chunking_by_paragraph_semantic(
             and as the per-side budget for duplicating text between two
             adjacent oversized table chunks. Structural table row splits
             remain row-bounded and non-overlapping.
+        drop_references: When ``True``, drop the trailing reference section
+            (e.g. "References" / "参考文献") before splitting/merging. A block
+            is removed only when it BOTH sits within the last
+            ``references_tail_n`` content blocks AND its heading matches a
+            reference prefix. This is the only reference knob that is
+            snapshotted into ``chunk_options`` (it may come from a per-file
+            hint) and recorded in ``doc_status.metadata['chunk_opts']``.
+        references_tail_n: Trailing-block window for the detection above.
+            ``None`` (the normal pipeline value) means "read
+            ``CHUNK_P_REFERENCES_TAIL_N`` env live at run time, default
+            ``DEFAULT_P_REFERENCES_TAIL_N``"; a kwarg is only passed by tests.
+        references_headings: Reference heading prefixes. ``None`` means "read
+            ``CHUNK_P_REFERENCES_HEADINGS`` env live at run time, default
+            :data:`DEFAULT_P_REFERENCES_HEADINGS`"; a kwarg is only passed by
+            tests. Neither knob is snapshotted, so editing the env changes the
+            behaviour of re-runs without re-enqueueing.
 
     Returns:
         Ordered list of chunk dicts, each shaped::
@@ -2021,6 +2106,52 @@ def chunking_by_paragraph_semantic(
             target_max,
             chunk_overlap_token_size=overlap,
         )
+
+    # Drop the trailing reference section before any split/merge runs (operates
+    # on the raw blocks.jsonl content rows — one heading == one block).  A block
+    # is dropped only when it BOTH sits within the last ``tail_n`` rows AND its
+    # heading matches a reference prefix; the tail window is a safety guard so a
+    # mid-document "References" subsection is never removed.  Detection knobs are
+    # read live from env (NOT snapshotted) unless injected via kwargs (tests).
+    if drop_references and rows:
+        prefixes = (
+            list(references_headings)
+            if references_headings is not None
+            else _references_headings()
+        )
+        tail_n = (
+            max(int(references_tail_n), 0)
+            if references_tail_n is not None
+            else _references_tail_n()
+        )
+        if tail_n:
+            start = max(0, len(rows) - tail_n)
+            kept = [
+                row
+                for idx, row in enumerate(rows)
+                if not (
+                    idx >= start
+                    and _is_reference_heading(row.get("heading", "") or "", prefixes)
+                )
+            ]
+            dropped = len(rows) - len(kept)
+            # Protect against an empty document: base the guard on rows that
+            # still carry content (the loop below skips blank-content rows), so
+            # a pathological sidecar whose only kept rows are empty does not
+            # silently produce zero chunks.
+            if dropped and any((row.get("content") or "").strip() for row in kept):
+                logger.info(
+                    "[paragraph_semantic] dropped %d reference block(s) from the "
+                    "last %d block(s)",
+                    dropped,
+                    tail_n,
+                )
+                rows = kept
+            elif dropped:
+                logger.warning(
+                    "[paragraph_semantic] dropping references would leave no "
+                    "content; keeping them to avoid an empty document"
+                )
 
     # Build initial blocks (HeadingBlocks output, already persisted).
     initial: list[dict[str, Any]] = []

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -127,6 +127,18 @@ DEFAULT_SENTENCE_SPLIT_REGEX = r"(?<=[.?!])\s+|(?<=[。？！])"
 # the strategy's purpose.
 DEFAULT_CHUNK_P_SIZE = 2000
 
+# Paragraph-semantic "drop references" detection defaults (the chunking="P"
+# drop_references option).  DEFAULT_P_REFERENCES_TAIL_N: a reference block is
+# only dropped when it sits within the last N content blocks of the document
+# (a safety window so a mid-document "References" subsection is not removed).
+# DEFAULT_P_REFERENCES_HEADINGS: heading prefixes that mark a reference
+# section — English words matched case-insensitively at a word boundary,
+# the Chinese "参考文献" matched as a plain prefix.  Both are tunable via env
+# (CHUNK_P_REFERENCES_TAIL_N / CHUNK_P_REFERENCES_HEADINGS, the latter
+# pipe-separated) read live by the chunker at run time.
+DEFAULT_P_REFERENCES_TAIL_N = 2
+DEFAULT_P_REFERENCES_HEADINGS = ("Reference", "References", "Bibliography", "参考文献")
+
 # LightRAG Document pipeline
 FULL_DOCS_FORMAT_RAW = "raw"  # content in full_docs["content"]
 # Post-parse persistence marker: full_docs rows written by the parsers carry

--- a/lightrag/parser/docx/parser.py
+++ b/lightrag/parser/docx/parser.py
@@ -14,6 +14,14 @@ if TYPE_CHECKING:
 
 
 class NativeDocxParser(NativeParserBase):
+    """Native DOCX parser for LightRAG's production parsing path.
+
+    Keep ``extract_docx_blocks(..., fixlevel=0)`` here.  ``fixlevel=0`` splits
+    at every real DOCX heading while disabling the ``fixlevel=None`` smart
+    long-block anchor splitting path, preserving the one-heading-one-block
+    sidecar contract consumed by paragraph-semantic chunking.
+    """
+
     engine_name = PARSER_ENGINE_NATIVE
     sidecar_path_style = "basename_only"  # legacy native docx convention
     empty_content_label = "DOCX"
@@ -29,6 +37,8 @@ class NativeDocxParser(NativeParserBase):
     def extract(
         self, source: Path, *, parsed_dir: Path, asset_dir: Path, base_name: str
     ) -> tuple[list[dict[str, Any]], dict[str, Any], dict[str, Any]]:
+        """Extract DOCX blocks; production native parsing requires ``fixlevel=0``."""
+
         from lightrag.parser.docx.drawing_image_extractor import (
             DrawingExtractionContext,
             load_relationships,

--- a/lightrag/parser/param_schema.py
+++ b/lightrag/parser/param_schema.py
@@ -15,13 +15,13 @@ Design (see ``docs/FileProcessingPipeline.md``):
 * Parameters are declared per *target* (a chunk selector char ``F``/``R``/``V``/
   ``P``) with a type and the set of selectors they apply to.
 
-Phase 1 scope (intentionally minimal — the foundation supports more):
-only ``chunk_token_size`` (alias ``chunk_ts``) and
-``chunk_overlap_token_size`` (alias ``chunk_ol``), both integers, flowing
-through the existing per-document ``chunk_options`` channel.  Engine-level
-parameters and flag/enum/float parameters are **not** accepted yet and are
-rejected with a friendly error; adding them later is a matter of registering
-new :class:`ParamSpec` entries.
+Chunk-parameter scope: the integer ``chunk_token_size`` (alias ``chunk_ts``)
+and ``chunk_overlap_token_size`` (alias ``chunk_ol``), plus the boolean
+``drop_references`` (alias ``drop_rf``, paragraph-semantic only), all flowing
+through the existing per-document ``chunk_options`` channel.  Float/enum chunk
+parameters are still rejected with a friendly error; adding them is a matter of
+registering new :class:`ParamSpec` entries and an extra ``kind`` branch in
+:func:`parse_chunk_params`.
 
 This module is import-cheap and has no dependency on
 :mod:`lightrag.parser.routing` so it can be reused without import cycles.
@@ -108,10 +108,11 @@ def take_paren_block(text: str, i: int) -> tuple[str | None, int]:
 class ParamSpec:
     """Declares one tunable hint parameter for a set of chunk selectors.
 
-    ``kind`` is ``"int"`` for every Phase 1 parameter; the field exists so
-    future types (``float``/``enum``/``flag``/``range_list``) slot in without
-    a structural change.  ``targets`` is the set of chunk selector chars the
-    parameter is valid for (e.g. overlap is invalid for ``V``).
+    ``kind`` is ``"int"`` or ``"bool"`` today; the field exists so future
+    types (``float``/``enum``/``range_list``) slot in without a structural
+    change.  ``targets`` is the set of chunk selector chars the parameter is
+    valid for (e.g. overlap is invalid for ``V``, ``drop_references`` only
+    applies to ``P``).
     """
 
     canonical: str
@@ -158,6 +159,15 @@ _CHUNK_PARAM_SPECS: tuple[ParamSpec, ...] = (
             }
         ),
         min_value=0,
+    ),
+    # Paragraph-semantic only: drop the trailing reference section before
+    # chunking.  Detection-tuning knobs (tail window / heading prefixes) are
+    # env-only and read live by the chunker, so only the switch is a hint param.
+    ParamSpec(
+        canonical="drop_references",
+        aliases=frozenset({"drop_rf"}),
+        kind="bool",
+        targets=frozenset({PROCESS_OPTION_CHUNK_PARAGRAH}),
     ),
 )
 
@@ -248,7 +258,16 @@ def parse_chunk_params(
                 )
                 continue
             result[spec.canonical] = parsed
-        else:  # pragma: no cover - no non-int kinds registered in Phase 1
+        elif spec.kind == "bool":
+            parsed_bool = _parse_bool(value)
+            if parsed_bool is None:
+                errors.append(
+                    f"{label}: value for {spec.canonical!r} must be a boolean "
+                    f"(true/false), got {value!r}"
+                )
+                continue
+            result[spec.canonical] = parsed_bool
+        else:  # pragma: no cover - only int/bool kinds registered today
             errors.append(
                 f"{label}: parameter {spec.canonical!r} has unsupported type "
                 f"{spec.kind!r}"

--- a/lightrag/parser/param_schema.py
+++ b/lightrag/parser/param_schema.py
@@ -199,6 +199,10 @@ def parse_chunk_params(
     attached to (``F``/``R``/``V``/``P``).  Returns ``(canonical_dict,
     errors)``; ``errors`` is empty iff the block is fully valid.  Aliases are
     normalised to their canonical name in the returned dict.
+
+    A boolean parameter may be written bare as a flag — ``P(drop_rf)`` is
+    shorthand for ``P(drop_rf=true)``.  Non-boolean parameters still require
+    the explicit ``key=value`` form.
     """
     result: dict[str, Any] = {}
     errors: list[str] = []
@@ -209,15 +213,17 @@ def parse_chunk_params(
         if not segment:
             errors.append(f"{label}: empty parameter")
             continue
-        if "=" not in segment:
-            errors.append(
-                f"{label}: parameter {segment!r} must be written as 'key=value' "
-                "(flag parameters are not supported yet)"
-            )
-            continue
-        key, _, value = segment.partition("=")
-        key = key.strip()
-        value = value.strip()
+        if "=" in segment:
+            key, _, value = segment.partition("=")
+            key = key.strip()
+            value = value.strip()
+            flag_form = False
+        else:
+            # Bare flag form, e.g. ``drop_rf``.  Only valid for boolean
+            # parameters, where it is shorthand for ``drop_rf=true``.
+            key = segment
+            value = ""
+            flag_form = True
 
         spec = _CHUNK_PARAM_BY_NAME.get(key)
         if spec is None:
@@ -232,6 +238,14 @@ def parse_chunk_params(
                 f"chunk strategy {selector!r}"
             )
             continue
+        if flag_form:
+            if spec.kind != "bool":
+                errors.append(
+                    f"{label}: parameter {spec.canonical!r} must be written as "
+                    "'key=value'; only boolean flags may be written bare"
+                )
+                continue
+            value = "true"  # bare boolean flag means True
         if any(ch in _VALUE_FORBIDDEN for ch in value):
             errors.append(
                 f"{label}: value for {spec.canonical!r} may not contain any of "

--- a/lightrag/parser/routing.py
+++ b/lightrag/parser/routing.py
@@ -312,11 +312,23 @@ def slim_chunk_options(
     if "chunk_token_size" in src:
         result["chunk_token_size"] = deepcopy(src["chunk_token_size"])
     result[key] = deepcopy(dict(src.get(key) or {}))
-    if key == "paragraph_semantic" and "chunk_token_size" not in result[key]:
-        p_size_raw = os.getenv("CHUNK_P_SIZE")
-        result[key]["chunk_token_size"] = (
-            int(p_size_raw) if p_size_raw is not None else DEFAULT_CHUNK_P_SIZE
-        )
+    if key == "paragraph_semantic":
+        if "chunk_token_size" not in result[key]:
+            p_size_raw = os.getenv("CHUNK_P_SIZE")
+            result[key]["chunk_token_size"] = (
+                int(p_size_raw) if p_size_raw is not None else DEFAULT_CHUNK_P_SIZE
+            )
+        # Mirror the CHUNK_P_DROP_REFERENCES env default for the drop-references
+        # switch here — this is the single chokepoint every enqueue path runs
+        # through, so a runtime ``addon_params`` mutation or an explicit
+        # ``chunk_options=`` that omits the slot still picks up the env default.
+        # ``setdefault`` keeps any caller-supplied value (hint/addon/kwarg).  The
+        # detection-tuning knobs (tail window / heading prefixes) are NOT
+        # snapshotted — the chunker reads them live from env at run time.
+        if os.getenv("CHUNK_P_DROP_REFERENCES") is not None:
+            result[key].setdefault(
+                "drop_references", _env_bool("CHUNK_P_DROP_REFERENCES")
+            )
     return result
 
 

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -2218,6 +2218,7 @@ class _PipelineMixin:
                             content,
                             p_chunk_size,
                             blocks_path=p_blocks_path,
+                            doc_id=doc_id,
                             **p_opts,
                         )
                     elif strategy == "R":

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -161,6 +161,7 @@ _CHUNK_LOG_KEY_ALIASES: dict[str, str] = {
     "split_by_character_only": "split_only",
     "separators": "seps",
     "sentence_split_regex": "regex",
+    "drop_references": "drop_rf",
 }
 
 

--- a/tests/api/routes/test_document_routes_chunking.py
+++ b/tests/api/routes/test_document_routes_chunking.py
@@ -302,6 +302,27 @@ def test_resolve_split_by_character_only_false_overrides_env(monkeypatch):
     assert chunk_options["fixed_token"]["split_by_character_only"] is False
 
 
+def test_resolve_drop_references_request_false_overrides_env_true(monkeypatch):
+    # The JSON text API can express an explicit ``drop_references=False`` that
+    # overrides ``CHUNK_P_DROP_REFERENCES=true`` (resolved via slim_chunk_options
+    # then overlaid by the request params). Mirrors the split_by_character_only
+    # override above for the paragraph-semantic switch.
+    monkeypatch.setenv("CHUNK_P_DROP_REFERENCES", "true")
+    cfg = TextChunkingConfig.model_validate(
+        {"strategy": "paragraph_semantic", "params": {"drop_references": False}}
+    )
+    _, chunk_options = _resolve_text_chunking(cfg, _stub_rag())
+    assert chunk_options["paragraph_semantic"]["drop_references"] is False
+
+
+def test_resolve_drop_references_env_true_without_request_param(monkeypatch):
+    # No request param → the env-true default survives into the snapshot.
+    monkeypatch.setenv("CHUNK_P_DROP_REFERENCES", "true")
+    cfg = TextChunkingConfig.model_validate({"strategy": "paragraph_semantic"})
+    _, chunk_options = _resolve_text_chunking(cfg, _stub_rag())
+    assert chunk_options["paragraph_semantic"]["drop_references"] is True
+
+
 def test_resolve_rejects_size_below_inherited_overlap(monkeypatch):
     # Overlap is inherited from addon_params (not in the request), so the
     # request model can't catch it — _resolve_text_chunking must.

--- a/tests/chunker/test_chunk_options_persistence.py
+++ b/tests/chunker/test_chunk_options_persistence.py
@@ -1552,3 +1552,118 @@ def test_partial_chunker_config_no_size_env_leaves_slot_absent(tmp_path, monkeyp
     chunker = rag.addon_params["chunker"]
     assert "chunk_token_size" not in chunker["recursive_character"]
     assert "chunk_token_size" not in chunker["fixed_token"]
+
+
+# --------------------------------------------------------------------------- #
+# drop_references: switch is snapshotted (+ recorded in chunk_opts metadata);
+# detection knobs (tail/headings) are NOT snapshotted (read live by chunker).
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.offline
+def test_drop_references_env_snapshotted_but_knobs_not(tmp_path, monkeypatch):
+    """``CHUNK_P_DROP_REFERENCES`` flows into the persisted snapshot and reaches
+    the chunker even on a partial ``addon_params`` (runtime-mutation path that
+    bypasses ``_apply_chunk_size_overlay``).  The detection knobs
+    ``CHUNK_P_REFERENCES_TAIL_N`` / ``CHUNK_P_REFERENCES_HEADINGS`` must NOT be
+    snapshotted — the chunker reads them live."""
+    monkeypatch.setenv("CHUNK_P_DROP_REFERENCES", "true")
+    monkeypatch.setenv("CHUNK_P_REFERENCES_TAIL_N", "3")
+    monkeypatch.setenv("CHUNK_P_REFERENCES_HEADINGS", "Foo|Bar")
+
+    import lightrag.chunker as chunker_pkg
+
+    captured: dict = {}
+
+    def _p_spy(tokenizer, content, chunk_token_size, *, blocks_path=None, **kwargs):
+        captured.update(kwargs)
+        return [{"tokens": 5, "content": "stub", "chunk_order_index": 0}]
+
+    monkeypatch.setattr(chunker_pkg, "chunking_by_paragraph_semantic", _p_spy)
+
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+        try:
+            # Runtime mutation bypasses _apply_chunk_size_overlay, so this
+            # exercises the slim_chunk_options chokepoint.
+            rag.addon_params["chunker"] = {"paragraph_semantic": {}}
+            await rag.apipeline_enqueue_documents(
+                "drop references body",
+                ids=["doc-drop-rf"],
+                file_paths="ctor.[native-P].txt",
+                track_id="track-p-drop-rf",
+                process_options="P",
+            )
+            row = await rag.full_docs.get_by_id("doc-drop-rf")
+            await rag.apipeline_process_enqueue_documents()
+        finally:
+            await rag.finalize_storages()
+        return row
+
+    row = asyncio.run(_run())
+    assert row is not None
+    p_opts = row["chunk_options"]["paragraph_semantic"]
+    # Switch is snapshotted ...
+    assert p_opts.get("drop_references") is True
+    # ... but the detection knobs are NOT.
+    assert "references_tail_n" not in p_opts
+    assert "references_headings" not in p_opts
+    # The switch reaches the chunker; the knobs do not (chunker reads env).
+    assert captured.get("drop_references") is True
+    assert "references_tail_n" not in captured
+    assert "references_headings" not in captured
+
+
+@pytest.mark.offline
+def test_explicit_drop_references_false_overrides_env_true(tmp_path, monkeypatch):
+    """An explicit ``drop_references=False`` in a caller-supplied
+    ``chunk_options`` wins over ``CHUNK_P_DROP_REFERENCES=true`` (setdefault
+    in ``slim_chunk_options`` never clobbers a present value)."""
+    monkeypatch.setenv("CHUNK_P_DROP_REFERENCES", "true")
+
+    import lightrag.chunker as chunker_pkg
+    from lightrag.parser.routing import resolve_chunk_options
+
+    captured: dict = {}
+
+    def _p_spy(tokenizer, content, chunk_token_size, *, blocks_path=None, **kwargs):
+        captured.update(kwargs)
+        return [{"tokens": 5, "content": "stub", "chunk_order_index": 0}]
+
+    monkeypatch.setattr(chunker_pkg, "chunking_by_paragraph_semantic", _p_spy)
+
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+        try:
+            opts = resolve_chunk_options(rag.addon_params, process_options="P")
+            # Env put drop_references=True here; explicit override to False.
+            assert opts["paragraph_semantic"]["drop_references"] is True
+            opts["paragraph_semantic"]["drop_references"] = False
+            await rag.apipeline_enqueue_documents(
+                "explicit override body",
+                file_paths="ctor.[native-P].txt",
+                track_id="track-p-drop-rf-false",
+                process_options="P",
+                chunk_options=opts,
+            )
+            await rag.apipeline_process_enqueue_documents()
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+    assert captured.get("drop_references") is False
+
+
+@pytest.mark.offline
+def test_chunk_opts_metadata_records_only_drop_rf():
+    """``_format_chunking_params`` renders ``drop_references`` under the short
+    ``drop_rf`` alias (what lands in ``doc_status.metadata['chunk_opts']``) and
+    never the env-only detection knobs."""
+    from lightrag.pipeline import _format_chunking_params
+
+    line = _format_chunking_params(2000, {"drop_references": True})
+    assert "drop_rf=True" in line
+    assert "drop_references" not in line  # aliased, not the verbose name
+    assert "rf_tail" not in line and "rf_heads" not in line

--- a/tests/chunker/test_paragraph_semantic_drop_references.py
+++ b/tests/chunker/test_paragraph_semantic_drop_references.py
@@ -1,0 +1,250 @@
+"""Tests for the paragraph-semantic ``drop_references`` option (chunking=P).
+
+A reference block is dropped only when it BOTH sits within the last
+``references_tail_n`` content blocks AND its heading matches a reference prefix.
+The switch is the only knob that flows through ``chunk_options``; the tail
+window and heading prefixes are read live from env at chunk time (verified here
+by mutating env between calls, proving they are NOT snapshotted).
+
+Assertions check the *content* of the emitted chunks (each block carries a
+distinctive marker) rather than heading names, because LevelMerge may merge
+small blocks and rewrite the surviving heading.
+"""
+
+import json
+
+import pytest
+
+from lightrag.chunker.paragraph_semantic import (
+    _is_reference_heading,
+    chunking_by_paragraph_semantic,
+)
+from lightrag.constants import DEFAULT_P_REFERENCES_HEADINGS
+from lightrag.utils import Tokenizer, TokenizerInterface
+
+
+class _CharTokenizer(TokenizerInterface):
+    """1:1 character-to-token mapping — keeps math obvious in assertions."""
+
+    def encode(self, content: str):
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens):
+        return "".join(chr(t) for t in tokens)
+
+
+def _make_tokenizer() -> Tokenizer:
+    return Tokenizer(model_name="char", tokenizer=_CharTokenizer())
+
+
+def _row(heading: str, content: str, *, level: int = 1) -> dict:
+    return {
+        "type": "content",
+        "blockid": heading or "blk",
+        "format": "plain_text",
+        "content": content,
+        "heading": heading,
+        "parent_headings": [],
+        "level": level,
+        "session_type": "body",
+        "table_slice": "none",
+        "positions": [],
+    }
+
+
+def _write_blocks_jsonl(tmp_path, rows: list[dict]) -> str:
+    path = tmp_path / "doc.blocks.jsonl"
+    path.write_text(
+        "\n".join(json.dumps(row, ensure_ascii=False) for row in rows),
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def _all_content(chunks: list[dict]) -> str:
+    return "\n".join(c["content"] for c in chunks)
+
+
+# --------------------------------------------------------------------------- #
+# _is_reference_heading (word boundary vs. plain CJK prefix)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "heading,expected",
+    [
+        ("References", True),
+        ("references", True),  # case-insensitive
+        ("REFERENCES", True),
+        ("Reference", True),
+        ("Bibliography", True),
+        ("References [1-50]", True),  # word boundary: next char is non-alnum
+        ("参考文献", True),
+        ("参考文献列表", True),  # CJK: plain prefix, no word boundary
+        ("Referenced work", False),  # ASCII word boundary excludes this
+        ("Related Work", False),
+        ("", False),
+    ],
+)
+def test_is_reference_heading(heading, expected):
+    assert _is_reference_heading(heading, DEFAULT_P_REFERENCES_HEADINGS) is expected
+
+
+# --------------------------------------------------------------------------- #
+# Filtering behaviour (assert on content markers, robust to LevelMerge)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.offline
+def test_drops_trailing_reference_block(tmp_path):
+    tokenizer = _make_tokenizer()
+    rows = [
+        _row("Introduction", "INTRO_MARKER intro body"),
+        _row("Method", "METHOD_MARKER method body"),
+        _row("References", "REF_MARKER [1] Foo. [2] Bar."),
+    ]
+    blocks_path = _write_blocks_jsonl(tmp_path, rows)
+
+    body = _all_content(
+        chunking_by_paragraph_semantic(
+            tokenizer, "", 2000, blocks_path=blocks_path, drop_references=True
+        )
+    )
+    assert "REF_MARKER" not in body
+    assert "INTRO_MARKER" in body and "METHOD_MARKER" in body
+
+
+@pytest.mark.offline
+def test_default_keeps_reference_block(tmp_path):
+    tokenizer = _make_tokenizer()
+    rows = [
+        _row("Introduction", "INTRO_MARKER intro body"),
+        _row("References", "REF_MARKER [1] Foo."),
+    ]
+    blocks_path = _write_blocks_jsonl(tmp_path, rows)
+
+    # drop_references defaults to False — references survive.
+    body = _all_content(
+        chunking_by_paragraph_semantic(tokenizer, "", 2000, blocks_path=blocks_path)
+    )
+    assert "REF_MARKER" in body
+
+
+@pytest.mark.offline
+def test_mid_document_reference_section_outside_window_kept(tmp_path):
+    tokenizer = _make_tokenizer()
+    # A "References" heading mid-document, with two non-reference blocks after
+    # it, so it falls outside the last-2 window and must NOT be dropped.
+    rows = [
+        _row("Introduction", "INTRO_MARKER intro body"),
+        _row("References", "REF_MARKER discusses references"),
+        _row("Method", "METHOD_MARKER method body"),
+        _row("Results", "RESULTS_MARKER results body"),
+    ]
+    blocks_path = _write_blocks_jsonl(tmp_path, rows)
+
+    body = _all_content(
+        chunking_by_paragraph_semantic(
+            tokenizer,
+            "",
+            2000,
+            blocks_path=blocks_path,
+            drop_references=True,
+            references_tail_n=2,
+        )
+    )
+    assert "REF_MARKER" in body
+
+
+@pytest.mark.offline
+def test_word_boundary_keeps_referenced(tmp_path):
+    tokenizer = _make_tokenizer()
+    rows = [
+        _row("Introduction", "INTRO_MARKER intro body"),
+        _row("参考文献列表", "CJKREF_MARKER [1] Foo."),
+        _row("Referenced datasets", "DATASET_MARKER dataset details"),
+    ]
+    blocks_path = _write_blocks_jsonl(tmp_path, rows)
+
+    body = _all_content(
+        chunking_by_paragraph_semantic(
+            tokenizer, "", 2000, blocks_path=blocks_path, drop_references=True
+        )
+    )
+    # CJK prefix block dropped; "Referenced ..." kept (ASCII word boundary).
+    assert "CJKREF_MARKER" not in body
+    assert "DATASET_MARKER" in body
+
+
+@pytest.mark.offline
+def test_all_blocks_match_keeps_to_avoid_empty(tmp_path):
+    tokenizer = _make_tokenizer()
+    rows = [
+        _row("References", "REF1_MARKER [1] Foo."),
+        _row("Bibliography", "REF2_MARKER [2] Bar."),
+    ]
+    blocks_path = _write_blocks_jsonl(tmp_path, rows)
+
+    # Both blocks match within the last-2 window; dropping all would leave no
+    # content, so the chunker keeps them and warns instead.
+    chunks = chunking_by_paragraph_semantic(
+        tokenizer, "", 2000, blocks_path=blocks_path, drop_references=True
+    )
+    body = _all_content(chunks)
+    assert chunks  # not an empty document
+    assert "REF1_MARKER" in body and "REF2_MARKER" in body
+
+
+# --------------------------------------------------------------------------- #
+# Detection knobs are read LIVE from env (not snapshotted)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.offline
+def test_tail_n_read_live_from_env(tmp_path, monkeypatch):
+    tokenizer = _make_tokenizer()
+    rows = [
+        _row("Introduction", "INTRO_MARKER intro body"),
+        _row("References", "REF_MARKER [1] Foo."),
+        _row("Appendix", "APPENDIX_MARKER appendix body"),
+    ]
+    blocks_path = _write_blocks_jsonl(tmp_path, rows)
+
+    # tail_n=1: only the last block ("Appendix") is in the window → References
+    # is outside it and survives.
+    monkeypatch.setenv("CHUNK_P_REFERENCES_TAIL_N", "1")
+    body = _all_content(
+        chunking_by_paragraph_semantic(
+            tokenizer, "", 2000, blocks_path=blocks_path, drop_references=True
+        )
+    )
+    assert "REF_MARKER" in body
+
+    # Widen the window to 2 → References now falls inside and is dropped. Same
+    # call, only the env changed: proves the knob is read live, not snapshotted.
+    monkeypatch.setenv("CHUNK_P_REFERENCES_TAIL_N", "2")
+    body = _all_content(
+        chunking_by_paragraph_semantic(
+            tokenizer, "", 2000, blocks_path=blocks_path, drop_references=True
+        )
+    )
+    assert "REF_MARKER" not in body
+
+
+@pytest.mark.offline
+def test_headings_read_live_from_env(tmp_path, monkeypatch):
+    tokenizer = _make_tokenizer()
+    rows = [
+        _row("Introduction", "INTRO_MARKER intro body"),
+        _row("Literature", "LIT_MARKER [1] Foo. [2] Bar."),
+    ]
+    blocks_path = _write_blocks_jsonl(tmp_path, rows)
+
+    # Custom prefix list makes "Literature" a reference heading.
+    monkeypatch.setenv("CHUNK_P_REFERENCES_HEADINGS", "Literature|参考文献")
+    body = _all_content(
+        chunking_by_paragraph_semantic(
+            tokenizer, "", 2000, blocks_path=blocks_path, drop_references=True
+        )
+    )
+    assert "LIT_MARKER" not in body

--- a/tests/chunker/test_paragraph_semantic_drop_references.py
+++ b/tests/chunker/test_paragraph_semantic_drop_references.py
@@ -12,6 +12,7 @@ small blocks and rewrite the surviving heading.
 """
 
 import json
+import logging
 
 import pytest
 
@@ -20,7 +21,7 @@ from lightrag.chunker.paragraph_semantic import (
     chunking_by_paragraph_semantic,
 )
 from lightrag.constants import DEFAULT_P_REFERENCES_HEADINGS
-from lightrag.utils import Tokenizer, TokenizerInterface
+from lightrag.utils import Tokenizer, TokenizerInterface, logger as _lightrag_logger
 
 
 class _CharTokenizer(TokenizerInterface):
@@ -229,6 +230,33 @@ def test_tail_n_read_live_from_env(tmp_path, monkeypatch):
         )
     )
     assert "REF_MARKER" not in body
+
+
+@pytest.mark.offline
+def test_drop_references_emits_info_log(tmp_path, caplog):
+    tokenizer = _make_tokenizer()
+    rows = [
+        _row("Introduction", "INTRO_MARKER intro body"),
+        _row("References", "REF_MARKER [1] Foo."),
+    ]
+    blocks_path = _write_blocks_jsonl(tmp_path, rows)
+
+    # The lightrag logger sets propagate=False, so caplog can't see it by
+    # default — enable propagation for the duration of the call.
+    original_propagate = _lightrag_logger.propagate
+    _lightrag_logger.propagate = True
+    try:
+        with caplog.at_level(logging.INFO, logger=_lightrag_logger.name):
+            chunking_by_paragraph_semantic(
+                tokenizer, "", 2000, blocks_path=blocks_path, drop_references=True
+            )
+    finally:
+        _lightrag_logger.propagate = original_propagate
+
+    info_msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.INFO]
+    assert any("drop_references" in m and "References" in m for m in info_msgs), (
+        info_msgs
+    )
 
 
 @pytest.mark.offline

--- a/tests/chunker/test_paragraph_semantic_drop_references.py
+++ b/tests/chunker/test_paragraph_semantic_drop_references.py
@@ -17,6 +17,7 @@ import logging
 import pytest
 
 from lightrag.chunker.paragraph_semantic import (
+    _format_dropped_headings,
     _is_reference_heading,
     chunking_by_paragraph_semantic,
 )
@@ -89,6 +90,32 @@ def _all_content(chunks: list[dict]) -> str:
 )
 def test_is_reference_heading(heading, expected):
     assert _is_reference_heading(heading, DEFAULT_P_REFERENCES_HEADINGS) is expected
+
+
+# --------------------------------------------------------------------------- #
+# _format_dropped_headings (length-bounded log rendering)
+# --------------------------------------------------------------------------- #
+
+
+def test_format_dropped_headings_short_list():
+    assert _format_dropped_headings(["References"]) == "'References'"
+    assert (
+        _format_dropped_headings(["References", "Bibliography"])
+        == "'References', 'Bibliography'"
+    )
+
+
+def test_format_dropped_headings_truncates_long_heading():
+    out = _format_dropped_headings(["X" * 200], max_each=60)
+    # 60 kept chars + an ellipsis, all within one repr'd string.
+    assert "X" * 60 + "…" in out
+    assert "X" * 61 not in out
+
+
+def test_format_dropped_headings_caps_item_count():
+    out = _format_dropped_headings([f"H{i}" for i in range(12)], max_items=5)
+    assert out.count("'H") == 5  # only 5 listed
+    assert "(+7 more)" in out
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/chunker/test_paragraph_semantic_drop_references.py
+++ b/tests/chunker/test_paragraph_semantic_drop_references.py
@@ -275,13 +275,19 @@ def test_drop_references_emits_info_log(tmp_path, caplog):
     try:
         with caplog.at_level(logging.INFO, logger=_lightrag_logger.name):
             chunking_by_paragraph_semantic(
-                tokenizer, "", 2000, blocks_path=blocks_path, drop_references=True
+                tokenizer,
+                "",
+                2000,
+                blocks_path=blocks_path,
+                drop_references=True,
+                doc_id="doc-xyz",
             )
     finally:
         _lightrag_logger.propagate = original_propagate
 
     info_msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.INFO]
-    assert any("drop_references" in m and "References" in m for m in info_msgs), (
+    # Log names the dropped heading and attributes it to the doc_id.
+    assert any("References" in m and "doc_id: doc-xyz" in m for m in info_msgs), (
         info_msgs
     )
 

--- a/tests/parser/test_hint_params.py
+++ b/tests/parser/test_hint_params.py
@@ -108,6 +108,14 @@ def test_parse_chunk_params_drop_references_invalid_bool():
     assert errors and "must be a boolean" in errors[0]
 
 
+@pytest.mark.parametrize("block", ["drop_rf", "drop_references"])
+def test_parse_chunk_params_drop_references_bare_flag_is_true(block):
+    # A bare boolean flag is shorthand for ``=true``.
+    parsed, errors = parse_chunk_params(block, selector="P", label="x")
+    assert errors == []
+    assert parsed == {"drop_references": True}
+
+
 @pytest.mark.parametrize("selector", ["F", "R", "V"])
 def test_parse_chunk_params_drop_references_rejected_off_paragraph(selector):
     parsed, errors = parse_chunk_params("drop_rf=true", selector=selector, label="x")
@@ -121,6 +129,13 @@ def test_filename_hint_drop_references_extracted():
     assert d.chunk_params == {"P": {"drop_references": True}}
 
 
+def test_filename_hint_drop_references_bare_flag():
+    # ``P(drop_rf)`` with no value is shorthand for ``drop_rf=true``.
+    d = resolve_parser_directives("notes.[-P(drop_rf)].md", parser_rules="")
+    assert d.process_options == "P"
+    assert d.chunk_params == {"P": {"drop_references": True}}
+
+
 @pytest.mark.parametrize(
     "block,needle",
     [
@@ -128,7 +143,9 @@ def test_filename_hint_drop_references_extracted():
         ("chunk_ts=0", "must be >= 1"),
         ("foo=1", "unknown parameter 'foo'"),
         ("chunk_ts=1,chunk_ts=2", "may not be repeated"),
-        ("correct_tl", "flag parameters are not supported"),
+        ("correct_tl", "unknown parameter 'correct_tl'"),
+        # A non-boolean parameter cannot be written bare (only flags can).
+        ("chunk_ts", "must be written as 'key=value'"),
         ("", "empty parameter"),
         # Cross-field invariant: explicit overlap >= size is rejected here, so
         # both rule and filename-hint validation reject it (not just enqueue).

--- a/tests/parser/test_hint_params.py
+++ b/tests/parser/test_hint_params.py
@@ -87,6 +87,41 @@ def test_parse_chunk_params_overlap_rejected_for_vector():
 
 
 @pytest.mark.parametrize(
+    "block,expected",
+    [
+        ("drop_rf=true", True),
+        ("drop_references=true", True),
+        ("drop_rf=false", False),
+        ("drop_rf=yes", True),
+        ("drop_rf=0", False),
+    ],
+)
+def test_parse_chunk_params_drop_references_bool(block, expected):
+    parsed, errors = parse_chunk_params(block, selector="P", label="x")
+    assert errors == []
+    assert parsed == {"drop_references": expected}
+
+
+def test_parse_chunk_params_drop_references_invalid_bool():
+    parsed, errors = parse_chunk_params("drop_rf=maybe", selector="P", label="x")
+    assert parsed == {}
+    assert errors and "must be a boolean" in errors[0]
+
+
+@pytest.mark.parametrize("selector", ["F", "R", "V"])
+def test_parse_chunk_params_drop_references_rejected_off_paragraph(selector):
+    parsed, errors = parse_chunk_params("drop_rf=true", selector=selector, label="x")
+    assert parsed == {}
+    assert errors and f"not supported for chunk strategy {selector!r}" in errors[0]
+
+
+def test_filename_hint_drop_references_extracted():
+    d = resolve_parser_directives("notes.[-P(drop_rf=true)].md", parser_rules="")
+    assert d.process_options == "P"  # pure selector, no params
+    assert d.chunk_params == {"P": {"drop_references": True}}
+
+
+@pytest.mark.parametrize(
     "block,needle",
     [
         ("chunk_ts=abc", "must be an integer"),


### PR DESCRIPTION
## Description

Add an opt-in `drop_references` option to the **P (paragraph-semantic) chunking strategy**. When enabled, the trailing reference section of a paper (References / Bibliography / 参考文献) is filtered out of the `blocks.jsonl` sidecar **before** chunking, so it never reaches KG extraction or the vector store — references add noise to retrieval and waste tokens.

A `blocks.jsonl` content block is treated as a reference block only when it **both**:
1. sits within the last **N** content blocks of the document (N default 2 — a safety window so a mid-document "References" subsection is never removed), **and**
2. has a `heading` matching a reference prefix: an English word `Reference`/`References`/`Bibliography` (case-insensitive, word-boundary), or the Chinese `参考文献` (plain prefix).

## Related Issues

N/A

## Changes Made

- **Switch `drop_references` (alias `drop_rf`, P only)**
  - Per-file via filename hint / `LIGHTRAG_PARSER` rule, e.g. `paper.[-P(drop_rf=true)].pdf` (`lightrag/parser/param_schema.py` — new `ParamSpec` + `bool` kind in `parse_chunk_params`).
  - Globally via `CHUNK_P_DROP_REFERENCES` env, applied at the single `slim_chunk_options` chokepoint (`lightrag/parser/routing.py`) so it survives runtime `addon_params` mutation and explicit `chunk_options=`.
  - Snapshotted into the document's `chunk_options` and recorded in `doc_status.metadata['chunk_opts']` as `drop_rf` (`lightrag/pipeline.py` log alias).
  - Exposed on the `/documents/text` JSON API via `ParagraphSemanticChunkParams.drop_references` (`lightrag/api/routers/document_routes.py`).
- **Env-only detection knobs (read live at run time, NOT snapshotted)** so editing them affects re-runs of already-enqueued docs:
  - `CHUNK_P_REFERENCES_TAIL_N` (default 2)
  - `CHUNK_P_REFERENCES_HEADINGS` (pipe-separated, default `Reference|References|Bibliography|参考文献`)
- **Filtering + helpers** in `lightrag/chunker/paragraph_semantic.py`: `_is_reference_heading` (ASCII word-boundary vs. CJK prefix), `_references_tail_n` / `_references_headings` (live env reads), filter applied to raw rows before split/merge, with an empty-document guard (keeps blocks when dropping would leave no content).
- **Constants** `DEFAULT_P_REFERENCES_TAIL_N` / `DEFAULT_P_REFERENCES_HEADINGS` (`lightrag/constants.py`).
- **Docs**: `env.example`, `docs/ParagraphSemanticChunking-zh.md`, `docs/FileProcessingPipeline.md` (+ `-zh`).

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

- New tests: `tests/chunker/test_paragraph_semantic_drop_references.py` (18 cases: word boundary, AND tail window, CJK, empty-document guard, live-env reads). Extended `tests/parser/test_hint_params.py` (hint bool parsing + per-strategy rejection), `tests/chunker/test_chunk_options_persistence.py` (switch snapshotted + reaches chunker on partial addon_params; explicit `False` overrides env `True`; knobs NOT snapshotted; `chunk_opts` records only `drop_rf`), and `tests/api/routes/test_document_routes_chunking.py` (JSON API override).
- Full related suites pass: `tests/parser/ tests/chunker/ tests/api/routes/test_document_routes_chunking.py` → **708 passed**. `ruff` + `ruff-format` clean.
- Default behaviour unchanged: `drop_references` defaults to `False`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
