### PR TITLE
fix(mineru): drop page_number items from blocks content

### DIFF
--- a/lightrag/parser/external/mineru/ir_builder.py
+++ b/lightrag/parser/external/mineru/ir_builder.py
@@ -273,6 +273,15 @@ class MinerUIRBuilder:
                 continue
             item_type = str(item.get("type") or item.get("label") or "").lower()
 
+            # Page numbers are layout noise, not document body. MinerU emits a
+            # ``page_number`` item per page; skip it entirely so it never enters
+            # the block content nor leaks its page_idx into block positions.
+            # (Empty-text page numbers were already dropped by the fallback's
+            # _append_text guard; this also drops page numbers that carry real
+            # text like "12" / "iii".)
+            if item_type == "page_number":
+                continue
+
             heading_text, heading_level = _detect_heading(item, item_type)
             if heading_text:
                 clean_heading = strip_heading_markdown_prefix(heading_text)

--- a/tests/parser/external/mineru/test_ir_builder.py
+++ b/tests/parser/external/mineru/test_ir_builder.py
@@ -519,6 +519,39 @@ def test_adapter_empty_table_dropped(tmp_path: Path) -> None:
 
 
 @pytest.mark.offline
+def test_adapter_page_number_dropped(tmp_path: Path) -> None:
+    """``page_number`` items are layout noise and MUST NOT enter the IR.
+
+    MinerU emits a ``page_number`` item per page. Empty-text page numbers were
+    already dropped by the fallback's _append_text guard, but page numbers that
+    carry real text (``"12"``, ``"iii"``) previously leaked into block content
+    and contaminated the block's positions with their page_idx. The IR builder
+    now skips them outright regardless of text.
+    """
+    raw = _write_bundle(
+        tmp_path,
+        [
+            {"type": "text", "text": "kept", "page_idx": 0},
+            # Page number carrying real text — the regression case.
+            {"type": "page_number", "text": "12", "page_idx": 7},
+            # Roman-numeral page number.
+            {"type": "page_number", "text": "iii", "page_idx": 8},
+            # Blank/whitespace page number.
+            {"type": "page_number", "text": "- ", "page_idx": 9},
+        ],
+    )
+    ir = MinerUIRBuilder().normalize_from_workdir(raw, document_name="p.pdf")
+    joined = "\n".join(b.content_template for b in ir.blocks)
+    assert "12" not in joined
+    assert "iii" not in joined
+    assert "kept" in joined
+    # The page_idx of skipped page numbers must not leak into block positions.
+    # Anchors are 1-based strings, so page_idx 7/8/9 would surface as 8/9/10.
+    anchors = {pos.anchor for b in ir.blocks for pos in b.positions}
+    assert anchors.isdisjoint({"8", "9", "10"})
+
+
+@pytest.mark.offline
 def test_adapter_bbox_attributes_default_and_override(tmp_path: Path) -> None:
     raw = _write_bundle(tmp_path, [{"type": "text", "text": "x"}])
     adapter = MinerUIRBuilder()


### PR DESCRIPTION
## Description

MinerU emits one `content_list.json` item with `type == "page_number"` per page (e.g. `{"type": "page_number", "text": "12", "page_idx": 1}`). These are layout noise — page numbers, not document body — and should not appear in `blocks.json` content.

The IR builder (`_normalize_content_list()`) had no explicit handling for `page_number`, so such items fell through to the unknown-type fallback that serializes items as plain text:

- When the page-number `text` is empty/whitespace (e.g. `"- "`, `""`), `_append_text` returns `False` and the item is coincidentally dropped — no problem.
- But when `text` carries real characters (e.g. `"12"`, `"iii"`), the page number **was appended to the current block's content and leaked its `page_idx` into the block's positions**, contaminating `blocks.json`.

This PR skips `page_number` items outright regardless of their text.

## Related Issues

N/A

## Changes Made

- `lightrag/parser/external/mineru/ir_builder.py`: in `_normalize_content_list()`, after computing `item_type` and before heading detection, `continue` on `item_type == "page_number"`. Safe placement — a page number is never a heading — and matches the existing skip pattern used for empty equations/tables.
- `tests/parser/external/mineru/test_ir_builder.py`: add `test_adapter_page_number_dropped` covering page numbers with real text (`"12"`, `"iii"`) and whitespace, asserting they enter neither block content nor block position anchors, while a normal text item is preserved.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Scope is intentionally limited to `page_number`. Other ancillary types (`header`, `footer`, `ref_text`, `page_footnote`, `aside_text`) keep their existing fallback behaviour.

Verification:
- `python -m pytest tests/parser/external/mineru/test_ir_builder.py -q` → 33 passed (incl. new case, no regressions)
- `pre-commit run ruff-format` → Passed
