### PR TITLE
fix(storage): handle set ids in delete (Issue #3286)

### DIFF
--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -780,6 +780,9 @@ class MongoDocStatusStorage(DocStatusStorage):
             return {"status": "error", "message": str(e)}
 
     async def delete(self, ids: list[str]) -> None:
+        # Convert to list if it's a set (MongoDB BSON cannot encode sets)
+        if isinstance(ids, set):
+            ids = list(ids)
         await self._data.delete_many({"_id": {"$in": ids}})
 
     async def create_and_migrate_indexes_if_not_exists(self):

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -3186,6 +3186,8 @@ class PGKVStorage(BaseKVStorage):
         """
         if not ids:
             return
+        if isinstance(ids, set):
+            ids = list(ids)
 
         table_name = namespace_to_table_name(self.namespace)
         if not table_name:
@@ -5609,6 +5611,8 @@ class PGDocStatusStorage(DocStatusStorage):
         """
         if not ids:
             return
+        if isinstance(ids, set):
+            ids = list(ids)
 
         table_name = namespace_to_table_name(self.namespace)
         if not table_name:

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -2692,7 +2692,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     async def _purge_doc_chunks_and_kg(
         self,
         doc_id: str,
-        chunk_ids: set[str],
+        chunk_ids: list[str],
         *,
         pipeline_status: dict,
         pipeline_status_lock: Any,
@@ -2743,6 +2743,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         """
         if not chunk_ids:
             return
+
+        # Set view for membership/intersection checks below (chunk_ids stays a list
+        # so it satisfies the storage delete contract: ``delete(ids: list[str])``).
+        chunk_ids_set = set(chunk_ids)
 
         # ---- 1. Analyze affected entities/relations from full_entities/full_relations ----
         entities_to_delete: set[str] = set()
@@ -2829,7 +2833,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
 
                 remaining_sources = subtract_source_ids(existing_sources, chunk_ids)
                 graph_references_deleted_chunks = bool(
-                    graph_sources and set(graph_sources) & chunk_ids
+                    graph_sources and set(graph_sources) & chunk_ids_set
                 )
 
                 if not remaining_sources:
@@ -2893,7 +2897,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
 
                 remaining_sources = subtract_source_ids(existing_sources, chunk_ids)
                 graph_references_deleted_chunks = bool(
-                    graph_sources and set(graph_sources) & chunk_ids
+                    graph_sources and set(graph_sources) & chunk_ids_set
                 )
 
                 if not remaining_sources:
@@ -3269,12 +3273,18 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 metadata.get("deletion_llm_cache_ids", []),
                 context=f"doc {doc_id} metadata.deletion_llm_cache_ids",
             )
-            chunk_ids = set(
-                normalize_string_list(
-                    doc_status_data.get("chunks_list", []),
-                    context=f"doc {doc_id} chunks_list",
+            # Order-preserving dedup so chunk_ids stays a list and satisfies the
+            # storage delete contract (``delete(ids: list[str])``); a set view is
+            # built below for membership/intersection checks.
+            chunk_ids = list(
+                dict.fromkeys(
+                    normalize_string_list(
+                        doc_status_data.get("chunks_list", []),
+                        context=f"doc {doc_id} chunks_list",
+                    )
                 )
             )
+            chunk_ids_set = set(chunk_ids)
 
             if not chunk_ids:
                 logger.warning(f"No chunks found for document {doc_id}")
@@ -3364,9 +3374,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     )
                 else:
                     try:
-                        chunk_data_list = await self.text_chunks.get_by_ids(
-                            list(chunk_ids)
-                        )
+                        chunk_data_list = await self.text_chunks.get_by_ids(chunk_ids)
                         seen_cache_ids: set[str] = set(doc_llm_cache_ids)
                         for chunk_data in chunk_data_list:
                             if not chunk_data or not isinstance(chunk_data, dict):
@@ -3528,7 +3536,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     # rebuild/delete so the graph metadata gets synchronized instead of being
                     # left untouched with orphaned source references.
                     graph_references_deleted_chunks = bool(
-                        graph_sources and set(graph_sources) & chunk_ids
+                        graph_sources and set(graph_sources) & chunk_ids_set
                     )
 
                     if not remaining_sources:
@@ -3603,7 +3611,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     # chunk deleted in this attempt. Treat that as an affected relation so retry
                     # deletion can repair the graph metadata rather than skipping it as "untouched".
                     graph_references_deleted_chunks = bool(
-                        graph_sources and set(graph_sources) & chunk_ids
+                        graph_sources and set(graph_sources) & chunk_ids_set
                     )
 
                     if not remaining_sources:

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -2718,11 +2718,15 @@ class _PipelineMixin:
                 pipeline_status["latest_message"] = log_message
                 pipeline_status["history_messages"].append(log_message)
 
-        stored_chunk_ids = {
-            chunk_id
-            for chunk_id in (status_doc.chunks_list or [])
-            if isinstance(chunk_id, str) and chunk_id
-        }
+        # Order-preserving dedup; keep a list so it satisfies the storage delete
+        # contract (``delete(ids: list[str])``) when passed down to purge.
+        stored_chunk_ids = list(
+            dict.fromkeys(
+                chunk_id
+                for chunk_id in (status_doc.chunks_list or [])
+                if isinstance(chunk_id, str) and chunk_id
+            )
+        )
         if not stored_chunk_ids:
             return
 

--- a/tests/kg/postgres_impl/test_postgres_delete_set_ids.py
+++ b/tests/kg/postgres_impl/test_postgres_delete_set_ids.py
@@ -1,0 +1,98 @@
+"""Regression test for Issue #3286.
+
+``adelete_by_doc_id`` / ``_purge_doc_chunks_and_kg`` historically passed
+``chunk_ids`` as a ``set`` to ``PGKVStorage.delete`` / ``PGDocStatusStorage.delete``.
+After delete-batching was introduced, the chunked path slices the id collection
+(``ids[i : i + chunk]``); slicing a ``set`` raises ``'set' object is not
+subscriptable``, which the broad ``except Exception`` in ``delete`` then swallows
+as a log line -- so the records were silently NOT deleted.
+
+These tests feed a ``set`` straight into ``delete`` with a positive batch cap
+(forcing the chunked path) and assert that every id is actually handed to the
+SQL layer. Asserting "no exception" alone is insufficient because the bug is
+swallowed; we must assert the records really got deleted.
+"""
+
+import pytest
+
+pytest.importorskip("asyncpg")
+
+from lightrag.kg.postgres_impl import (  # noqa: E402
+    PGDocStatusStorage,
+    PGKVStorage,
+)
+from lightrag.namespace import NameSpace  # noqa: E402
+
+
+class _FakeTransaction:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _RecordingConnection:
+    """Captures the id-array argument of each ``execute`` call."""
+
+    def __init__(self):
+        self.deleted_id_batches: list[list[str]] = []
+
+    def transaction(self):
+        return _FakeTransaction()
+
+    async def execute(self, sql, workspace, id_slice):
+        # The chunked path slices ids; a slice of a list is a list. Record it.
+        assert isinstance(id_slice, list)
+        self.deleted_id_batches.append(id_slice)
+
+
+class _FakeDB:
+    def __init__(self, connection):
+        self._connection = connection
+
+    async def _run_with_retry(self, operation):
+        # Mirror the real helper: invoke the closure against a live connection.
+        return await operation(self._connection)
+
+
+def _make_storage(cls, namespace, batch_cap):
+    """Build a storage instance exercising only the attributes ``delete`` reads."""
+    storage = object.__new__(cls)
+    storage.namespace = namespace
+    storage.workspace = "test_ws"
+    storage._max_delete_records_per_batch = batch_cap
+    connection = _RecordingConnection()
+    storage.db = _FakeDB(connection)
+    return storage, connection
+
+
+@pytest.mark.asyncio
+async def test_pgkv_delete_accepts_set_and_chunks_all_ids():
+    ids = {f"chunk-{i}" for i in range(5)}
+    # Positive cap < len(ids) forces the chunked slicing path that broke on sets.
+    storage, connection = _make_storage(
+        PGKVStorage, NameSpace.KV_STORE_TEXT_CHUNKS, batch_cap=2
+    )
+
+    await storage.delete(ids)
+
+    flattened = [cid for batch in connection.deleted_id_batches for cid in batch]
+    assert set(flattened) == ids
+    assert len(flattened) == len(ids)  # no duplicates / drops
+    assert all(len(batch) <= 2 for batch in connection.deleted_id_batches)
+
+
+@pytest.mark.asyncio
+async def test_pgdocstatus_delete_accepts_set_and_chunks_all_ids():
+    ids = {f"doc-{i}" for i in range(5)}
+    storage, connection = _make_storage(
+        PGDocStatusStorage, NameSpace.DOC_STATUS, batch_cap=2
+    )
+
+    await storage.delete(ids)
+
+    flattened = [did for batch in connection.deleted_id_batches for did in batch]
+    assert set(flattened) == ids
+    assert len(flattened) == len(ids)
+    assert all(len(batch) <= 2 for batch in connection.deleted_id_batches)

--- a/tests/pipeline/test_pipeline_release_closure.py
+++ b/tests/pipeline/test_pipeline_release_closure.py
@@ -718,7 +718,7 @@ def test_apipeline_enqueue_persists_process_options(tmp_path):
 
 @pytest.mark.offline
 def test_purge_doc_chunks_and_kg_is_noop_for_empty_chunks(tmp_path):
-    """``_purge_doc_chunks_and_kg`` with an empty chunk_ids set must be a
+    """``_purge_doc_chunks_and_kg`` with an empty chunk_ids list must be a
     no-op so callers (including the resume branch) can invoke it
     unconditionally without first checking for non-empty chunks_list.
     """
@@ -738,10 +738,10 @@ def test_purge_doc_chunks_and_kg_is_noop_for_empty_chunks(tmp_path):
             pipeline_status_lock = get_namespace_lock(
                 "pipeline_status", workspace=rag.workspace
             )
-            # Empty set: must return immediately without touching storage.
+            # Empty list: must return immediately without touching storage.
             await rag._purge_doc_chunks_and_kg(
                 "doc-empty",
-                set(),
+                [],
                 pipeline_status=pipeline_status,
                 pipeline_status_lock=pipeline_status_lock,
             )
@@ -749,7 +749,7 @@ def test_purge_doc_chunks_and_kg_is_noop_for_empty_chunks(tmp_path):
             # since the helper is idempotent on the empty input.
             await rag._purge_doc_chunks_and_kg(
                 "doc-empty",
-                set(),
+                [],
                 pipeline_status=pipeline_status,
                 pipeline_status_lock=pipeline_status_lock,
             )
@@ -826,7 +826,7 @@ def test_purge_doc_chunks_and_kg_clears_chunks_for_unknown_doc(tmp_path):
 
             await rag._purge_doc_chunks_and_kg(
                 "doc-X",
-                {"doc-X-chunk-0", "doc-X-chunk-1"},
+                ["doc-X-chunk-0", "doc-X-chunk-1"],
                 pipeline_status=pipeline_status,
                 pipeline_status_lock=pipeline_status_lock,
             )


### PR DESCRIPTION
## Problem

Fixes #3286 — `'set' object is not subscriptable` while deleting records from `text_chunks`.

`adelete_by_doc_id` and `_purge_doc_chunks_and_kg` build `chunk_ids` as a **set** and pass it straight into `text_chunks.delete(chunk_ids)`. Since delete-batching was introduced in `ee79e20b`, `PGKVStorage.delete` / `PGDocStatusStorage.delete` slice the id collection:

```python
for i in range(0, len(ids), chunk):
    await connection.execute(delete_sql, self.workspace, ids[i : i + chunk])
```

Subscript-slicing a `set` raises `'set' object is not subscriptable`. The broad `except Exception` in `delete()` then **swallows** it as a log line, so the chunks were silently **not** deleted (matching the issue's "the log shows ..." symptom).

The same commit added a `set -> list` guard to `PGVectorStorage.delete` but not to the KV / DocStatus paths — which is why the error surfaced on `text_chunks` (KV) and not `chunks_vdb` (Vector).

## Fix (two layers)

**1. Backend guard (symmetric with the existing vector-storage guard)**
- `PGKVStorage.delete` / `PGDocStatusStorage.delete`: convert `set -> list` at entry, matching `PGVectorStorage.delete`.
- `MongoDocStatusStorage.delete`: add the same guard for symmetry with `MongoKVStorage.delete` (BSON cannot encode sets).

**2. Upstream normalization (honor the `delete(ids: list[str])` contract)**
- `adelete_by_doc_id`, `_purge_doc_chunks_and_kg` (lightrag.py) and the resume path (pipeline.py): build `chunk_ids` as an **order-preserving list** via `dict.fromkeys(...)`, and keep a local `chunk_ids_set` for membership/intersection checks.
- `_purge_doc_chunks_and_kg` param type `set[str]` -> `list[str]`.

## Compatibility

All KV / DocStatus backends now safely accept either type:

| Backend | Status |
|---|---|
| PostgreSQL KV / DocStatus | **fixed** (guard added) |
| MongoDB DocStatus | **fixed** (guard added; KV already had it) |
| OpenSearch (KV/DocStatus/Vector), Qdrant, Milvus | already guarded |
| Redis, JSON KV | iterate only, no slicing — set-safe |

PostgreSQL KV/DocStatus were the only `delete` methods slicing the **input** `ids` directly; other backends slice an already-listified internal variable.

## Tests

- New `tests/kg/postgres_impl/test_postgres_delete_set_ids.py` drives the chunked slicing path (positive batch cap) with a **set** input and asserts every id reaches the SQL layer. Asserting "no exception" alone is insufficient because the bug is swallowed, so the test asserts the records are actually deleted.
- Verified the test **fails without the guard** with the exact `'set' object is not subscriptable` error, and passes with it.
- `test_postgres_delete_set_ids` + `test_postgres_batch_limits` + `test_doc_status_chunk_preservation`: 41 passed. `ruff` / `ruff-format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)