### PR TITLE
Fixed typo (Dokcer -> Docker)

### DIFF
--- a/env.docker-compose-full
+++ b/env.docker-compose-full
@@ -1,7 +1,7 @@
 ### All configurable environment variable must show up in this sample file in active or comment out status
 ### Setup tool `make env-*` uses this file to generate final .env file
 
-### Target environment of this env file: host/compose (compose is for Dokcer or Kubernetes)
+### Target environment of this env file: host/compose (compose is for Docker or Kubernetes)
 LIGHTRAG_RUNTIME_TARGET=compose
 
 ###########################

--- a/env.example
+++ b/env.example
@@ -1,7 +1,7 @@
 ### All configurable environment variable must show up in this sample file in active or comment out status
 ### Setup tool `make env-*` uses this file to generate final .env file
 
-### Target environment of this env file: host/compose (compose is for Dokcer or Kubernetes)
+### Target environment of this env file: host/compose (compose is for Docker or Kubernetes)
 # LIGHTRAG_RUNTIME_TARGET=host
 
 ###########################


### PR DESCRIPTION
Fixed a typo in `env.example` and `‎env.docker-compose-full` files (`Dokcer` -> `Docker`).