### PR TITLE
Add LM Studio LLM and embedding provider

### DIFF
--- a/docs/InteractiveSetup.md
+++ b/docs/InteractiveSetup.md
@@ -61,7 +61,7 @@ make env-base
 
 - LLM provider, model, endpoint, and API key
 - Whether the embedding model should run locally via Docker
-- If embedding stays remote: embedding provider, model, dimension, endpoint, and API key
+- If embedding stays remote: embedding provider, model, dimension, endpoint, and API key (LM Studio: dimension is not prompted — auto-probed at startup; see [LM Studio setup](LMSTUDIO_SETUP.md))
 - Whether reranking should be enabled
 - If reranking is enabled: whether the rerank service should run locally via Docker
 - If reranking stays remote: rerank provider, model, endpoint, and API key

--- a/docs/LMSTUDIO_SETUP.md
+++ b/docs/LMSTUDIO_SETUP.md
@@ -1,0 +1,103 @@
+# LM Studio Setup Guide
+
+Use this guide when running LightRAG against a local [LM Studio](https://lmstudio.ai/) server (OpenAI-compatible API on port 1234 by default).
+
+## Fastest path: interactive setup wizard
+
+The setup wizard applies LM Studio–specific fixes that are easy to get wrong when copying from `env.example`:
+
+```bash
+make env-base
+```
+
+Choose **lmstudio** as the LLM provider (embeddings default to LM Studio as well). When the wizard finishes:
+
+1. **Does not set `EMBEDDING_DIM`** — LightRAG probes the vector size from your loaded embedding model at server startup.
+2. **Prompts for single-threaded concurrency** — LM Studio often crashes under parallel load; the wizard explains this and asks whether to apply safe limits (`MAX_ASYNC_LLM=1`, `EMBEDDING_BATCH_NUM=16`, etc.). Default answer is **yes**.
+3. **Defaults models** to `any-available` (resolved to the model loaded in LM Studio).
+
+Re-run `make env-base` (not `env-storage` or `env-server`) to change LM Studio concurrency after you switch providers or want to re-answer the prompt.
+
+## Before you start LightRAG
+
+1. Start LM Studio and enable the **local server** (default `http://localhost:1234`).
+2. Load a **chat** model and an **embedding** model (or one multimodal model if you only use chat).
+3. Keep LM Studio running while `lightrag-server` is up.
+
+## Recommended `.env` bindings
+
+```bash
+LLM_BINDING=lmstudio
+LLM_BINDING_HOST=http://localhost:1234/v1
+LLM_BINDING_API_KEY=lm-studio
+LLM_MODEL=any-available
+
+EMBEDDING_BINDING=lmstudio
+EMBEDDING_BINDING_HOST=http://localhost:1234/v1
+EMBEDDING_BINDING_API_KEY=lm-studio
+EMBEDDING_MODEL=any-available
+# EMBEDDING_DIM unset — auto-probed at startup (do not copy a value from env.example)
+
+KEYWORD_LLM_MODEL=any-available
+QUERY_LLM_MODEL=any-available
+```
+
+Leave `EMBEDDING_DIM` unset or commented out unless you intentionally override auto-probe and know the exact dimension of your embedding model.
+
+## Why concurrency is limited
+
+LM Studio loads one (or few) models in process. Parallel LLM or embedding requests often trigger:
+
+- `The model has crashed without additional information`
+- Timeouts during entity extraction
+- Embedding batch size mismatches
+
+The wizard’s defaults trade speed for stability. After you have a stable setup on a larger GPU, you can raise limits gradually (see tuning below).
+
+## Changing embedding models
+
+If you load a different embedding model in LM Studio:
+
+1. Stop LightRAG.
+2. Clear vector storage for your workspace (wrong dimensions or mixed embeddings break retrieval):
+   ```bash
+   rm -rf rag_storage/*
+   ```
+3. Restart LM Studio (reload the new embedding model).
+4. Restart `lightrag-server` — dimension and resolved model id are picked up at startup.
+
+## Manual tuning (after stable runs)
+
+Increase one setting at a time and watch LM Studio logs:
+
+| Setting | Wizard default | Notes |
+|--------|----------------|-------|
+| `MAX_ASYNC_LLM` | `1` | Global LLM cap; EXTRACT role uses this when not overridden |
+| `KEYWORD_MAX_ASYNC_LLM` | `1` | Keyword-extraction stage |
+| `QUERY_MAX_ASYNC_LLM` | `1` | Query / answer generation |
+| `MAX_PARALLEL_INSERT` | `1` | Parallel documents in the ingestion pipeline |
+| `EMBEDDING_FUNC_MAX_ASYNC` | `1` | Parallel embedding API calls |
+| `EMBEDDING_BATCH_NUM` | `16` | Chunks per embedding request; lower if you see vector count errors |
+
+## Start the server
+
+```bash
+uv sync --extra api
+uv run lightrag-server
+```
+
+Or, with an existing venv: `.venv/bin/lightrag-server`
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|--------|----------------|-----|
+| Embedding dimension mismatch | Stale `EMBEDDING_DIM` in `.env` or old vectors | Run `make env-base` with lmstudio, clear `rag_storage/*`, restart |
+| Model crash under ingest | Too much parallelism | Re-run wizard or set concurrency defaults from this doc |
+| Fewer vectors than chunks | Large `EMBEDDING_BATCH_NUM` | Set `EMBEDDING_BATCH_NUM=16` or lower |
+| `any-available` not resolving | No model loaded in LM Studio | Load chat/embedding model in LM Studio UI |
+
+## Related docs
+
+- [LightRAG API Server](LightRAG-API-Server.md) — full server configuration
+- [Interactive Setup](InteractiveSetup.md) — wizard overview (`make env-base`)

--- a/env.example
+++ b/env.example
@@ -531,7 +531,7 @@ EMBEDDING_BATCH_NUM=32
 
 ###########################################################################
 ### Gloabal LLM Configuration
-###   LLM_BINDING type: openai, ollama, lollms, azure_openai, bedrock, gemini
+###   LLM_BINDING type: openai, lmstudio, ollama, lollms, azure_openai, bedrock, gemini
 ###   LLM_BINDING_HOST: Service endpoint (left empty if using the provider SDK default endpoint)
 ###   LLM_BINDING_API_KEY: api key
 ### If LightRAG deployed in Docker:
@@ -701,9 +701,24 @@ OLLAMA_LLM_NUM_CTX=32768
 # OLLAMA_LLM_TEMPERATURE=0.85
 # OLLAMA_LLM_STOP='["</s>", "<|EOT|>"]'
 
+### LM Studio Specific Parameters (OpenAI-compatible local server):
+###     Start LM Studio, load a model, and enable the local server (default port 1234).
+###     LLM_MODEL / EMBEDDING_MODEL can be blank or any-available to use the loaded model.
+###     Or set an explicit id from GET /v1/models.
+###     LLM_BINDING=lmstudio
+###     LLM_BINDING_HOST=http://localhost:1234/v1
+###     LLM_BINDING_API_KEY=lm-studio
+###     LLM_MODEL=any-available
+###     EMBEDDING_BINDING=lmstudio
+###     EMBEDDING_BINDING_HOST=http://localhost:1234/v1
+###     EMBEDDING_BINDING_API_KEY=lm-studio
+###     EMBEDDING_MODEL=any-available
+###     EMBEDDING_DIM unset (auto-probed at startup) or set explicitly to match the model
+### If LightRAG deployed in Docker, use host.docker.internal instead of localhost.
+
 #######################################################################################
 ### Embedding Configuration (Should not be changed after the first file processed)
-### EMBEDDING_BINDING: ollama, openai, azure_openai, jina, lollms, bedrock
+### EMBEDDING_BINDING: ollama, openai, lmstudio, azure_openai, jina, lollms, bedrock
 ### EMBEDDING_BINDING_HOST: Service endpoint (left empty if using default endpoint provided by openai or gemini SDK)
 ### EMBEDDING_BINDING_API_KEY: api key
 ### If LightRAG deployed in Docker:

--- a/env.example
+++ b/env.example
@@ -713,7 +713,9 @@ OLLAMA_LLM_NUM_CTX=32768
 ###     EMBEDDING_BINDING_HOST=http://localhost:1234/v1
 ###     EMBEDDING_BINDING_API_KEY=lm-studio
 ###     EMBEDDING_MODEL=any-available
-###     EMBEDDING_DIM unset (auto-probed at startup) or set explicitly to match the model
+###     EMBEDDING_DIM unset (auto-probed at startup) — do not copy env.example values
+###     Wizard (make env-base) leaves EMBEDDING_DIM unset and applies safe concurrency; see docs/LMSTUDIO_SETUP.md
+###     EMBEDDING_BATCH_NUM=16 (LM Studio may return fewer vectors than requested for large batches)
 ### If LightRAG deployed in Docker, use host.docker.internal instead of localhost.
 
 #######################################################################################

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -540,9 +540,7 @@ def parse_args() -> argparse.Namespace:
 
     # Inject model configuration
     default_llm_model = (
-        "any-available"
-        if args.llm_binding == "lmstudio"
-        else "mistral-nemo:latest"
+        "any-available" if args.llm_binding == "lmstudio" else "mistral-nemo:latest"
     )
     args.llm_model = get_env_value("LLM_MODEL", default_llm_model)
     default_embedding_model = (

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -58,7 +58,12 @@ ollama_server_infos = OllamaServerInfos()
 DEFAULT_TOKEN_SECRET = "lightrag-jwt-default-secret-key!"
 NO_PREFIX_SENTINEL = "NO_PREFIX"
 PROVIDER_ASYMMETRIC_EMBEDDING_BINDINGS = {"gemini", "jina", "voyageai"}
-PREFIX_ASYMMETRIC_EMBEDDING_BINDINGS = {"azure_openai", "ollama", "openai"}
+PREFIX_ASYMMETRIC_EMBEDDING_BINDINGS = {
+    "azure_openai",
+    "lmstudio",
+    "ollama",
+    "openai",
+}
 
 
 class DefaultRAGStorageConfig:
@@ -80,6 +85,7 @@ def get_default_host(binding_type: str) -> str:
         # Let google-genai pick the correct default endpoint/version unless the
         # user explicitly overrides LLM_BINDING_HOST / EMBEDDING_BINDING_HOST.
         "gemini": os.getenv("LLM_BINDING_HOST", "DEFAULT_GEMINI_ENDPOINT"),
+        "lmstudio": os.getenv("LLM_BINDING_HOST", "http://localhost:1234/v1"),
     }
     return default_hosts.get(
         binding_type, os.getenv("LLM_BINDING_HOST", "http://localhost:11434")
@@ -403,6 +409,7 @@ def parse_args() -> argparse.Namespace:
             "ollama",
             "openai",
             "openai-ollama",
+            "lmstudio",
             "azure_openai",
             "bedrock",
             "gemini",
@@ -417,6 +424,7 @@ def parse_args() -> argparse.Namespace:
             "lollms",
             "ollama",
             "openai",
+            "lmstudio",
             "azure_openai",
             "bedrock",
             "jina",
@@ -454,7 +462,7 @@ def parse_args() -> argparse.Namespace:
     # Add LLM binding options based on determined value
     if llm_binding_value == "ollama":
         OllamaLLMOptions.add_args(parser)
-    elif llm_binding_value in ["openai", "azure_openai"]:
+    elif llm_binding_value in ["openai", "azure_openai", "lmstudio"]:
         OpenAILLMOptions.add_args(parser)
     elif llm_binding_value == "gemini":
         GeminiLLMOptions.add_args(parser)
@@ -531,10 +539,20 @@ def parse_args() -> argparse.Namespace:
     args.aws_session_token = get_env_value("AWS_SESSION_TOKEN", None, special_none=True)
 
     # Inject model configuration
-    args.llm_model = get_env_value("LLM_MODEL", "mistral-nemo:latest")
+    default_llm_model = (
+        "any-available"
+        if args.llm_binding == "lmstudio"
+        else "mistral-nemo:latest"
+    )
+    args.llm_model = get_env_value("LLM_MODEL", default_llm_model)
+    default_embedding_model = (
+        "any-available" if args.embedding_binding == "lmstudio" else None
+    )
     # EMBEDDING_MODEL defaults to None - each binding will use its own default model
     # e.g., OpenAI uses "text-embedding-3-small", Jina uses "jina-embeddings-v4"
-    args.embedding_model = get_env_value("EMBEDDING_MODEL", None, special_none=True)
+    args.embedding_model = get_env_value(
+        "EMBEDDING_MODEL", default_embedding_model, special_none=True
+    )
     # EMBEDDING_DIM defaults to None - each binding will use its own default dimension
     # Value is inherited from provider defaults via wrap_embedding_func_with_attrs decorator
     args.embedding_dim = get_env_value("EMBEDDING_DIM", None, int, special_none=True)
@@ -632,7 +650,7 @@ def parse_args() -> argparse.Namespace:
                 f"VLM_PROCESS_ENABLE=true but the effective VLM binding "
                 f"'{effective_vlm_binding}' does not support image inputs. "
                 "Configure VLM_LLM_BINDING (or LLM_BINDING) to one of: "
-                "openai, azure_openai, gemini, bedrock, ollama."
+                "openai, lmstudio, azure_openai, gemini, bedrock, ollama."
             )
 
     # Add environment variables that were previously read directly

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -654,8 +654,9 @@ def create_optimized_embedding_function(
       (e.g., jina-embeddings-v4 with 2048 dims, text-embedding-3-small with 1536 dims)
     - When EMBEDDING_MODEL is set to a custom model: User MUST also set EMBEDDING_DIM
       to match the custom model's dimension (e.g., for jina-embeddings-v3, set EMBEDDING_DIM=1024)
-    - When EMBEDDING_BINDING=lmstudio and EMBEDDING_DIM is unset, dimension is probed once
-      at startup via a test embedding against the resolved LM Studio model.
+    - When EMBEDDING_BINDING=lmstudio and EMBEDDING_MODEL is blank/any-available, the
+      concrete model is resolved at startup and stored on args.embedding_model for vector
+      namespace isolation. When EMBEDDING_DIM is unset, dimension is probed at the same time.
 
     Note: The embedding_dim parameter is automatically injected by EmbeddingFunc wrapper
     when send_dimensions=True (enabled for Jina and Gemini bindings). This wrapper calls
@@ -721,23 +722,37 @@ def create_optimized_embedding_function(
         logger.warning(f"Could not import provider function for {binding}: {e}")
 
     if binding == "lmstudio":
+        import asyncio
+
         from lightrag.llm.lmstudio import (
+            is_any_available_model,
             is_auto_embedding_dim,
             probe_lmstudio_embedding_dim,
+            resolve_lmstudio_model,
         )
 
-        if is_auto_embedding_dim(args.embedding_dim):
-            import asyncio
-
-            probed_dim = asyncio.run(
-                probe_lmstudio_embedding_dim(
-                    model=model,
-                    base_url=host,
-                    api_key=api_key,
+        if is_any_available_model(model):
+            if is_auto_embedding_dim(args.embedding_dim):
+                probed_dim, resolved_model = asyncio.run(
+                    probe_lmstudio_embedding_dim(
+                        model=model,
+                        base_url=host,
+                        api_key=api_key,
+                    )
                 )
-            )
-            args.embedding_dim = probed_dim
-            provider_embedding_dim = probed_dim
+                args.embedding_dim = probed_dim
+                provider_embedding_dim = probed_dim
+            else:
+                resolved_model = asyncio.run(
+                    resolve_lmstudio_model(
+                        model,
+                        base_url=host,
+                        api_key=api_key,
+                        purpose="embedding",
+                    )
+                )
+            model = resolved_model
+            args.embedding_model = resolved_model
 
     # Step 2: Apply priority (user config > provider default)
     # For max_token_size: explicit env var > provider default > None

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -552,7 +552,7 @@ class LLMConfigCache:
         self.bedrock_llm_options = None
 
         # Only initialize and log OpenAI options when using OpenAI-related bindings
-        if args.llm_binding in ["openai", "azure_openai"]:
+        if args.llm_binding in ["openai", "azure_openai", "lmstudio"]:
             from lightrag.llm.binding_options import OpenAILLMOptions
 
             self.openai_llm_options = OpenAILLMOptions.options_dict(args)
@@ -622,6 +622,7 @@ _PROVIDER_LOG_LABELS = {
     "azure_openai": "Azure OpenAI",
     "bedrock": "Bedrock",
     "gemini": "Gemini",
+    "lmstudio": "LM Studio",
     "lollms": "Lollms",
     "ollama": "Ollama",
     "openai": "OpenAI",
@@ -653,6 +654,8 @@ def create_optimized_embedding_function(
       (e.g., jina-embeddings-v4 with 2048 dims, text-embedding-3-small with 1536 dims)
     - When EMBEDDING_MODEL is set to a custom model: User MUST also set EMBEDDING_DIM
       to match the custom model's dimension (e.g., for jina-embeddings-v3, set EMBEDDING_DIM=1024)
+    - When EMBEDDING_BINDING=lmstudio and EMBEDDING_DIM is unset, dimension is probed once
+      at startup via a test embedding against the resolved LM Studio model.
 
     Note: The embedding_dim parameter is automatically injected by EmbeddingFunc wrapper
     when send_dimensions=True (enabled for Jina and Gemini bindings). This wrapper calls
@@ -671,6 +674,10 @@ def create_optimized_embedding_function(
             from lightrag.llm.openai import openai_embed
 
             provider_func = openai_embed
+        elif binding == "lmstudio":
+            from lightrag.llm.lmstudio import lmstudio_embed
+
+            provider_func = lmstudio_embed
         elif binding == "ollama":
             from lightrag.llm.ollama import ollama_embed
 
@@ -712,6 +719,25 @@ def create_optimized_embedding_function(
             )
     except ImportError as e:
         logger.warning(f"Could not import provider function for {binding}: {e}")
+
+    if binding == "lmstudio":
+        from lightrag.llm.lmstudio import (
+            is_auto_embedding_dim,
+            probe_lmstudio_embedding_dim,
+        )
+
+        if is_auto_embedding_dim(args.embedding_dim):
+            import asyncio
+
+            probed_dim = asyncio.run(
+                probe_lmstudio_embedding_dim(
+                    model=model,
+                    base_url=host,
+                    api_key=api_key,
+                )
+            )
+            args.embedding_dim = probed_dim
+            provider_embedding_dim = probed_dim
 
     # Step 2: Apply priority (user config > provider default)
     # For max_token_size: explicit env var > provider default > None
@@ -900,6 +926,29 @@ def create_optimized_embedding_function(
                     kwargs["model"] = model
                 if provider_supports_asymmetric and asymmetric_opt_in:
                     kwargs["context"] = context
+                return await actual_func(**kwargs)
+            elif binding == "lmstudio":
+                from lightrag.llm.lmstudio import lmstudio_embed
+
+                actual_func = (
+                    lmstudio_embed.func
+                    if isinstance(lmstudio_embed, EmbeddingFunc)
+                    else lmstudio_embed
+                )
+                kwargs = {
+                    "texts": texts,
+                    "base_url": host,
+                    "api_key": api_key,
+                    "embedding_dim": embedding_dim,
+                }
+                if model:
+                    kwargs["model"] = model
+                if provider_supports_asymmetric and asymmetric_opt_in:
+                    kwargs["context"] = context
+                    if query_prefix:
+                        kwargs["query_prefix"] = query_prefix
+                    if document_prefix:
+                        kwargs["document_prefix"] = document_prefix
                 return await actual_func(**kwargs)
             else:  # openai and compatible
                 from lightrag.llm.openai import openai_embed
@@ -1222,6 +1271,7 @@ def create_app(args):
         "lollms",
         "ollama",
         "openai",
+        "lmstudio",
         "azure_openai",
         "bedrock",
         "gemini",
@@ -1232,6 +1282,7 @@ def create_app(args):
         "lollms",
         "ollama",
         "openai",
+        "lmstudio",
         "azure_openai",
         "bedrock",
         "jina",
@@ -1531,6 +1582,38 @@ def create_app(args):
 
         return optimized_gemini_model_complete
 
+    def create_optimized_lmstudio_llm_func(
+        config_cache: LLMConfigCache, args, llm_timeout: int
+    ):
+        """Create optimized LM Studio LLM function with pre-processed configuration."""
+
+        async def optimized_lmstudio_model_complete(
+            prompt,
+            system_prompt=None,
+            history_messages=None,
+            **kwargs,
+        ) -> str:
+            from lightrag.llm.lmstudio import lmstudio_complete_if_cache
+
+            if history_messages is None:
+                history_messages = []
+
+            kwargs["timeout"] = llm_timeout
+            if config_cache.openai_llm_options:
+                kwargs.update(config_cache.openai_llm_options)
+
+            return await lmstudio_complete_if_cache(
+                args.llm_model,
+                prompt,
+                system_prompt=system_prompt,
+                history_messages=history_messages,
+                base_url=args.llm_binding_host,
+                api_key=args.llm_binding_api_key,
+                **kwargs,
+            )
+
+        return optimized_lmstudio_model_complete
+
     def create_llm_model_func(binding: str):
         """
         Create LLM model function based on binding type.
@@ -1554,6 +1637,10 @@ def create_app(args):
                 )
             elif binding == "gemini":
                 return create_optimized_gemini_llm_func(config_cache, args, llm_timeout)
+            elif binding == "lmstudio":
+                return create_optimized_lmstudio_llm_func(
+                    config_cache, args, llm_timeout
+                )
             else:  # openai and compatible
                 # Use optimized function with pre-processed configuration
                 return create_optimized_openai_llm_func(config_cache, args, llm_timeout)
@@ -1625,7 +1712,7 @@ def create_app(args):
 
         role_provider_options = override_meta.get("provider_options")
         if role_provider_options is None:
-            if role_binding in ["openai", "azure_openai"]:
+            if role_binding in ["openai", "azure_openai", "lmstudio"]:
                 from lightrag.llm.binding_options import OpenAILLMOptions
 
                 role_provider_options = OpenAILLMOptions.options_dict_for_role(
@@ -1835,6 +1922,32 @@ def create_app(args):
                     )
 
                 return role_gemini_complete
+
+            if role_binding == "lmstudio":
+                from lightrag.llm.lmstudio import lmstudio_complete_if_cache
+
+                async def role_lmstudio_complete(
+                    prompt,
+                    system_prompt=None,
+                    history_messages=None,
+                    **kwargs,
+                ) -> str:
+                    if history_messages is None:
+                        history_messages = []
+                    kwargs["timeout"] = role_timeout
+                    if role_provider_options:
+                        kwargs.update(role_provider_options)
+                    return await lmstudio_complete_if_cache(
+                        role_model,
+                        prompt,
+                        system_prompt=system_prompt,
+                        history_messages=history_messages,
+                        base_url=role_host,
+                        api_key=role_apikey,
+                        **kwargs,
+                    )
+
+                return role_lmstudio_complete
 
             from lightrag.llm.openai import openai_complete_if_cache
 

--- a/lightrag/llm/lmstudio.py
+++ b/lightrag/llm/lmstudio.py
@@ -19,7 +19,7 @@ _ANY_AVAILABLE_ALIASES = frozenset(
 _LLM_MODEL_TYPES = frozenset({"llm", "vlm"})
 _EMBEDDING_MODEL_TYPES = frozenset({"embeddings", "embedding"})
 _MODEL_RESOLUTION_CACHE: dict[tuple[str, str], str] = {}
-_EMBEDDING_DIM_CACHE: dict[str, int] = {}
+_EMBEDDING_DIM_CACHE: dict[str, tuple[int, str]] = {}
 
 
 def is_any_available_model(model: str | None) -> bool:
@@ -237,7 +237,7 @@ async def probe_lmstudio_embedding_dim(
         )
 
     embedding_dim = int(vectors.shape[1])
-    _EMBEDDING_DIM_CACHE[resolved_host] = embedding_dim
+    _EMBEDDING_DIM_CACHE[resolved_host] = (embedding_dim, resolved_model)
     logger.info(
         "LM Studio probed embedding dimension %d for model '%s' at %s",
         embedding_dim,

--- a/lightrag/llm/lmstudio.py
+++ b/lightrag/llm/lmstudio.py
@@ -129,9 +129,7 @@ async def _resolve_via_v1_models(
         await client.close()
 
     if not model_ids:
-        raise APIConnectionError(
-            f"LM Studio returned no models from {base_url}/models"
-        )
+        raise APIConnectionError(f"LM Studio returned no models from {base_url}/models")
 
     if purpose == "embedding":
         for model_id in model_ids:
@@ -212,8 +210,8 @@ async def probe_lmstudio_embedding_dim(
     model: str | None = None,
     base_url: str | None = None,
     api_key: str | None = None,
-) -> int:
-    """Probe LM Studio once to learn the embedding vector size for the resolved model."""
+) -> tuple[int, str]:
+    """Probe LM Studio once for embedding dimension and resolved model id."""
     resolved_host = _resolve_host(base_url)
     resolved_api_key = _resolve_api_key(api_key)
     if resolved_host in _EMBEDDING_DIM_CACHE:
@@ -246,7 +244,7 @@ async def probe_lmstudio_embedding_dim(
         resolved_model,
         resolved_host,
     )
-    return embedding_dim
+    return embedding_dim, resolved_model
 
 
 async def lmstudio_complete_if_cache(

--- a/lightrag/llm/lmstudio.py
+++ b/lightrag/llm/lmstudio.py
@@ -1,0 +1,344 @@
+"""LM Studio bindings via its OpenAI-compatible local API."""
+
+import os
+from collections.abc import AsyncIterator
+from typing import Literal, Union
+
+import httpx
+import numpy as np
+
+from lightrag.exceptions import APIConnectionError
+from lightrag.llm.openai import openai_complete_if_cache, openai_embed
+from lightrag.utils import logger, wrap_embedding_func_with_attrs
+
+_DEFAULT_HOST = "http://localhost:1234/v1"
+_DEFAULT_API_KEY = "lm-studio"
+_ANY_AVAILABLE_ALIASES = frozenset(
+    {"", "any-available", "any_available", "auto", "*", "any"}
+)
+_LLM_MODEL_TYPES = frozenset({"llm", "vlm"})
+_EMBEDDING_MODEL_TYPES = frozenset({"embeddings", "embedding"})
+_MODEL_RESOLUTION_CACHE: dict[tuple[str, str], str] = {}
+_EMBEDDING_DIM_CACHE: dict[str, int] = {}
+
+
+def is_any_available_model(model: str | None) -> bool:
+    """Return True when the model id should be resolved from LM Studio."""
+    if model is None:
+        return True
+    return model.strip().lower() in _ANY_AVAILABLE_ALIASES
+
+
+def is_auto_embedding_dim(embedding_dim: int | str | None) -> bool:
+    """Return True when embedding dimension should be probed from LM Studio."""
+    if embedding_dim is None:
+        return True
+    if isinstance(embedding_dim, str):
+        return is_any_available_model(embedding_dim)
+    return False
+
+
+def clear_lmstudio_model_cache() -> None:
+    """Clear cached any-available model resolutions (mainly for tests)."""
+    _MODEL_RESOLUTION_CACHE.clear()
+    _EMBEDDING_DIM_CACHE.clear()
+
+
+def _resolve_host(base_url: str | None) -> str:
+    if base_url:
+        return base_url
+    return os.getenv("LLM_BINDING_HOST", _DEFAULT_HOST)
+
+
+def _resolve_api_key(api_key: str | None) -> str:
+    if api_key:
+        return api_key
+    for env_var in (
+        "LMSTUDIO_API_KEY",
+        "EMBEDDING_BINDING_API_KEY",
+        "LLM_BINDING_API_KEY",
+        "OPENAI_API_KEY",
+    ):
+        value = os.getenv(env_var)
+        if value:
+            return value
+    return _DEFAULT_API_KEY
+
+
+def _v0_api_base(base_url: str) -> str:
+    normalized = base_url.rstrip("/")
+    if normalized.endswith("/v1"):
+        return normalized[:-3] + "/api/v0"
+    return f"{normalized}/api/v0"
+
+
+def _pick_model_from_v0_entries(
+    entries: list[dict],
+    purpose: Literal["llm", "embedding"],
+) -> str | None:
+    allowed_types = _LLM_MODEL_TYPES if purpose == "llm" else _EMBEDDING_MODEL_TYPES
+
+    for entry in entries:
+        entry_type = str(entry.get("type", "")).lower()
+        if entry_type not in allowed_types:
+            continue
+        loaded_instances = entry.get("loaded_instances") or []
+        if loaded_instances:
+            instance_id = loaded_instances[0].get("id")
+            if instance_id:
+                return str(instance_id)
+
+    for entry in entries:
+        entry_type = str(entry.get("type", "")).lower()
+        if entry_type not in allowed_types:
+            continue
+        for field in ("id", "key", "selected_variant"):
+            candidate = entry.get(field)
+            if candidate:
+                return str(candidate)
+    return None
+
+
+async def _list_v0_models(base_url: str, api_key: str) -> list[dict]:
+    url = f"{_v0_api_base(base_url)}/models"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.get(url, headers=headers)
+        response.raise_for_status()
+        payload = response.json()
+
+    if isinstance(payload, dict) and isinstance(payload.get("data"), list):
+        return payload["data"]
+    if isinstance(payload, list):
+        return payload
+    return []
+
+
+async def _resolve_via_v1_models(
+    base_url: str,
+    api_key: str,
+    purpose: Literal["llm", "embedding"],
+) -> str:
+    from openai import AsyncOpenAI
+
+    client = AsyncOpenAI(base_url=base_url, api_key=api_key)
+    try:
+        page = await client.models.list()
+        model_ids = [model.id for model in page.data if model.id]
+    finally:
+        await client.close()
+
+    if not model_ids:
+        raise APIConnectionError(
+            f"LM Studio returned no models from {base_url}/models"
+        )
+
+    if purpose == "embedding":
+        for model_id in model_ids:
+            if "embed" in model_id.lower():
+                return model_id
+
+    return model_ids[0]
+
+
+async def resolve_lmstudio_model(
+    model: str | None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+    purpose: Literal["llm", "embedding"] = "llm",
+) -> str:
+    """Resolve a concrete LM Studio model id, including any-available aliases."""
+    if not is_any_available_model(model):
+        return str(model).strip()
+
+    resolved_host = _resolve_host(base_url)
+    resolved_api_key = _resolve_api_key(api_key)
+    cache_key = (resolved_host, purpose)
+    if cache_key in _MODEL_RESOLUTION_CACHE:
+        return _MODEL_RESOLUTION_CACHE[cache_key]
+
+    resolved_model: str | None = None
+    try:
+        v0_entries = await _list_v0_models(resolved_host, resolved_api_key)
+        resolved_model = _pick_model_from_v0_entries(v0_entries, purpose)
+    except (httpx.HTTPError, ValueError, TypeError) as exc:
+        logger.debug(
+            "LM Studio v0 model listing failed for %s (%s); falling back to /v1/models",
+            resolved_host,
+            exc,
+        )
+
+    if resolved_model is None:
+        resolved_model = await _resolve_via_v1_models(
+            resolved_host, resolved_api_key, purpose
+        )
+
+    _MODEL_RESOLUTION_CACHE[cache_key] = resolved_model
+    logger.info(
+        "LM Studio resolved %s model '%s' to '%s' at %s",
+        purpose,
+        model or "<blank>",
+        resolved_model,
+        resolved_host,
+    )
+    return resolved_model
+
+
+def _normalize_lmstudio_response_format(kwargs: dict) -> None:
+    """Translate OpenAI response_format values for LM Studio's stricter API."""
+    response_format = kwargs.get("response_format")
+    if response_format is None:
+        return
+    if not isinstance(response_format, dict):
+        return
+
+    response_type = response_format.get("type")
+    if response_type == "json_object":
+        kwargs["response_format"] = {"type": "text"}
+        logger.debug(
+            "LM Studio does not support response_format json_object; using type=text"
+        )
+        return
+
+    if response_type not in ("json_schema", "text"):
+        logger.warning(
+            "LM Studio unsupported response_format type '%s'; using type=text",
+            response_type,
+        )
+        kwargs["response_format"] = {"type": "text"}
+
+
+async def probe_lmstudio_embedding_dim(
+    model: str | None = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+) -> int:
+    """Probe LM Studio once to learn the embedding vector size for the resolved model."""
+    resolved_host = _resolve_host(base_url)
+    resolved_api_key = _resolve_api_key(api_key)
+    if resolved_host in _EMBEDDING_DIM_CACHE:
+        return _EMBEDDING_DIM_CACHE[resolved_host]
+
+    resolved_model = await resolve_lmstudio_model(
+        model,
+        base_url=resolved_host,
+        api_key=resolved_api_key,
+        purpose="embedding",
+    )
+    vectors = await openai_embed.func(
+        ["dimension probe"],
+        model=resolved_model,
+        base_url=resolved_host,
+        api_key=resolved_api_key,
+        embedding_dim=None,
+    )
+    if vectors.ndim != 2 or vectors.shape[0] == 0:
+        raise APIConnectionError(
+            f"LM Studio embedding probe at {resolved_host} returned invalid shape "
+            f"{vectors.shape} for model '{resolved_model}'"
+        )
+
+    embedding_dim = int(vectors.shape[1])
+    _EMBEDDING_DIM_CACHE[resolved_host] = embedding_dim
+    logger.info(
+        "LM Studio probed embedding dimension %d for model '%s' at %s",
+        embedding_dim,
+        resolved_model,
+        resolved_host,
+    )
+    return embedding_dim
+
+
+async def lmstudio_complete_if_cache(
+    model,
+    prompt,
+    system_prompt=None,
+    history_messages=[],
+    api_key: str | None = None,
+    base_url: str | None = None,
+    **kwargs,
+) -> Union[str, AsyncIterator[str]]:
+    resolved_host = _resolve_host(base_url)
+    resolved_api_key = _resolve_api_key(api_key)
+    resolved_model = await resolve_lmstudio_model(
+        model,
+        base_url=resolved_host,
+        api_key=resolved_api_key,
+        purpose="llm",
+    )
+    _normalize_lmstudio_response_format(kwargs)
+    return await openai_complete_if_cache(
+        resolved_model,
+        prompt,
+        system_prompt=system_prompt,
+        history_messages=history_messages,
+        api_key=resolved_api_key,
+        base_url=resolved_host,
+        **kwargs,
+    )
+
+
+async def lmstudio_model_complete(
+    prompt,
+    system_prompt=None,
+    history_messages=None,
+    enable_cot: bool = False,
+    keyword_extraction=False,
+    entity_extraction=False,
+    **kwargs,
+) -> Union[str, AsyncIterator[str]]:
+    if history_messages is None:
+        history_messages = []
+    if keyword_extraction:
+        kwargs.setdefault("keyword_extraction", True)
+    if entity_extraction:
+        kwargs.setdefault("entity_extraction", True)
+    model_name = kwargs["hashing_kv"].global_config["llm_model_name"]
+    return await lmstudio_complete_if_cache(
+        model_name,
+        prompt,
+        system_prompt=system_prompt,
+        history_messages=history_messages,
+        enable_cot=enable_cot,
+        **kwargs,
+    )
+
+
+@wrap_embedding_func_with_attrs(
+    embedding_dim=1536,
+    max_token_size=8192,
+    model_name="any-available",
+    supports_asymmetric=True,
+)
+async def lmstudio_embed(
+    texts: list[str],
+    model: str | None = "any-available",
+    base_url: str | None = None,
+    api_key: str | None = None,
+    embedding_dim: int | None = None,
+    max_token_size: int | None = None,
+    context: str = "document",
+    query_prefix: str | None = None,
+    document_prefix: str | None = None,
+    **kwargs,
+) -> np.ndarray:
+    resolved_host = _resolve_host(base_url)
+    resolved_api_key = _resolve_api_key(api_key)
+    resolved_model = await resolve_lmstudio_model(
+        model,
+        base_url=resolved_host,
+        api_key=resolved_api_key,
+        purpose="embedding",
+    )
+    return await openai_embed.func(
+        texts,
+        model=resolved_model,
+        base_url=resolved_host,
+        api_key=resolved_api_key,
+        embedding_dim=embedding_dim,
+        max_token_size=max_token_size,
+        context=context,
+        query_prefix=query_prefix,
+        document_prefix=document_prefix,
+        **kwargs,
+    )

--- a/scripts/setup/lib/file_ops.sh
+++ b/scripts/setup/lib/file_ops.sh
@@ -352,7 +352,10 @@ generate_env_file() {
     if [[ "$line" =~ ^[A-Za-z0-9_]+= ]]; then
       key="${line%%=*}"
       if [[ -z "${written_keys[$key]+set}" ]]; then
-        if [[ -n "${ENV_VALUES[$key]+set}" ]]; then
+        if [[ -n "${ENV_SUPPRESS_ACTIVE_KEYS[$key]+set}" ]]; then
+          printf '# %s  # unset for LM Studio (auto-probed at server startup)\n' "$line" >> "$tmp_file"
+          written_keys["$key"]=1
+        elif [[ -n "${ENV_VALUES[$key]+set}" ]]; then
           value="${ENV_VALUES[$key]}"
           local _fmt_active_val
           _fmt_active_val="$(format_env_value "$value" "$key")"

--- a/scripts/setup/lib/validation.sh
+++ b/scripts/setup/lib/validation.sh
@@ -42,7 +42,7 @@ validate_api_key() {
   fi
 
   case "$provider" in
-    openai|openrouter)
+    openai|openrouter|lmstudio)
       return 0; ;;
     *)
       [[ ${#key} -ge 8 ]]

--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -1799,6 +1799,36 @@ provider_default_or_existing() {
   printf '%s' "$default_value"
 }
 
+is_lmstudio_auto_model_value() {
+  local value="${1:-}"
+  value="${value// }"
+  case "${value,,}" in
+    ""|local-model|local_model|any-available|any_available|auto|any|\*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+model_default_for_binding() {
+  local binding="$1"
+  local existing_binding="${2:-}"
+  local existing_value="${3:-}"
+  local default_value="${4:-}"
+
+  if [[ "$binding" == "lmstudio" ]]; then
+    if [[ "$binding" == "$existing_binding" && -n "$existing_value" ]] \
+      && ! is_lmstudio_auto_model_value "$existing_value"; then
+      printf '%s' "$existing_value"
+      return 0
+    fi
+    printf '%s' "$default_value"
+    return 0
+  fi
+
+  provider_default_or_existing "$binding" "$existing_binding" "$existing_value" "$default_value"
+}
+
 default_llm_model_for_binding() {
   local binding="$1"
 
@@ -1808,6 +1838,9 @@ default_llm_model_for_binding() {
       ;;
     ollama|lollms|openai-ollama)
       printf 'mistral-nemo:latest'
+      ;;
+    lmstudio)
+      printf 'any-available'
       ;;
     gemini)
       printf 'gemini-flash-latest'
@@ -1828,8 +1861,8 @@ default_embedding_model_for_binding() {
     openai|azure_openai)
       printf 'text-embedding-3-large'
       ;;
-    ollama)
-      printf 'bge-m3:latest'
+    ollama|lmstudio)
+      printf 'any-available'
       ;;
     jina)
       printf 'jina-embeddings-v4'
@@ -1859,6 +1892,9 @@ default_embedding_dim_for_binding() {
     ollama|bedrock|lollms)
       printf '1024'
       ;;
+    lmstudio)
+      printf ''
+      ;;
     jina)
       printf '2048'
       ;;
@@ -1872,13 +1908,16 @@ default_embedding_dim_for_binding() {
 }
 
 collect_llm_config() {
-  local options=("openai" "azure_openai" "ollama" "openai-ollama" "lollms" "gemini" "bedrock")
+  local options=("openai" "azure_openai" "ollama" "openai-ollama" "lmstudio" "lollms" "gemini" "bedrock")
   local current_binding="${ENV_VALUES[LLM_BINDING]:-openai}"
   local binding model model_default host host_default api_key
 
   binding="$(prompt_choice "LLM provider" "$current_binding" "${options[@]}")"
-  model_default="$(provider_default_or_existing "$binding" "$current_binding" "${ENV_VALUES[LLM_MODEL]:-}" "$(default_llm_model_for_binding "$binding")")"
-  model="$(prompt_with_default "LLM model" "$model_default")"
+  model_default="$(model_default_for_binding "$binding" "$current_binding" "${ENV_VALUES[LLM_MODEL]:-}" "$(default_llm_model_for_binding "$binding")")"
+  model="$(prompt_with_default "LLM model (blank = any-available)" "$model_default")"
+  if [[ "$binding" == "lmstudio" && -z "${model// }" ]]; then
+    model="any-available"
+  fi
 
   case "$binding" in
     ollama)
@@ -1890,6 +1929,11 @@ collect_llm_config() {
       host_default="$(provider_default_or_existing "$binding" "$current_binding" "${ENV_VALUES[LLM_BINDING_HOST]:-}" "$(default_loopback_url 11434 "/v1")")"
       host="$(prompt_with_default "OpenAI-compatible Ollama endpoint" "$host_default")"
       api_key="$(prompt_secret_until_valid_with_default "LLM API key: " "${ENV_VALUES[LLM_BINDING_API_KEY]:-}" validate_api_key openai)"
+      ;;
+    lmstudio)
+      host_default="$(provider_default_or_existing "$binding" "$current_binding" "${ENV_VALUES[LLM_BINDING_HOST]:-}" "$(default_loopback_url 1234 "/v1")")"
+      host="$(prompt_with_default "LM Studio endpoint" "$host_default")"
+      api_key="$(prompt_with_default "LM Studio API key" "${ENV_VALUES[LLM_BINDING_API_KEY]:-lm-studio}")"
       ;;
     lollms)
       host_default="$(provider_default_or_existing "$binding" "$current_binding" "${ENV_VALUES[LLM_BINDING_HOST]:-}" "http://localhost:9600")"
@@ -1934,7 +1978,7 @@ collect_llm_config() {
 }
 
 collect_embedding_config() {
-  local options=("openai" "azure_openai" "ollama" "jina" "lollms" "gemini" "bedrock")
+  local options=("openai" "azure_openai" "ollama" "lmstudio" "jina" "lollms" "gemini" "bedrock")
   local current_binding="${ENV_VALUES[EMBEDDING_BINDING]:-openai}"
   local binding model model_default host host_default api_key dim dim_default
 
@@ -1943,13 +1987,23 @@ collect_embedding_config() {
     if [[ "$current_binding" != "ollama" ]]; then
       log_info "openai-ollama uses Ollama embeddings. Forcing embedding provider to ollama."
     fi
+  elif [[ "${ENV_VALUES[LLM_BINDING]:-}" == "lmstudio" && "$current_binding" != "lmstudio" ]]; then
+    binding="lmstudio"
+    log_info "LM Studio LLM selected. Defaulting embedding provider to lmstudio."
   else
     binding="$(prompt_choice "Embedding provider" "$current_binding" "${options[@]}")"
   fi
-  model_default="$(provider_default_or_existing "$binding" "$current_binding" "${ENV_VALUES[EMBEDDING_MODEL]:-}" "$(default_embedding_model_for_binding "$binding")")"
+  model_default="$(model_default_for_binding "$binding" "$current_binding" "${ENV_VALUES[EMBEDDING_MODEL]:-}" "$(default_embedding_model_for_binding "$binding")")"
   dim_default="$(provider_default_or_existing "$binding" "$current_binding" "${ENV_VALUES[EMBEDDING_DIM]:-}" "$(default_embedding_dim_for_binding "$binding")")"
-  model="$(prompt_with_default "Embedding model" "$model_default")"
-  dim="$(prompt_with_default "Embedding dimension" "$dim_default")"
+  model="$(prompt_with_default "Embedding model (blank = any-available)" "$model_default")"
+  if [[ "$binding" == "lmstudio" && -z "${model// }" ]]; then
+    model="any-available"
+  fi
+  if [[ "$binding" == "lmstudio" ]]; then
+    dim="$(prompt_with_default "Embedding dimension (blank = auto-probe)" "$dim_default")"
+  else
+    dim="$(prompt_with_default "Embedding dimension" "$dim_default")"
+  fi
 
   local llm_host_fallback="" llm_api_key_default=""
   if [[ "$binding" == "${ENV_VALUES[LLM_BINDING]:-}" ]]; then
@@ -1967,6 +2021,11 @@ collect_embedding_config() {
       host_default="$(provider_default_or_existing "$binding" "$current_binding" "${ENV_VALUES[EMBEDDING_BINDING_HOST]:-}" "${llm_host_fallback:-http://localhost:9600}")"
       host="$(prompt_with_default "LoLLMs embedding host" "$host_default")"
       api_key=""
+      ;;
+    lmstudio)
+      host_default="$(provider_default_or_existing "$binding" "$current_binding" "${ENV_VALUES[EMBEDDING_BINDING_HOST]:-}" "${llm_host_fallback:-$(default_loopback_url 1234 "/v1")}")"
+      host="$(prompt_with_default "LM Studio embedding endpoint" "$host_default")"
+      api_key="$(prompt_with_default "LM Studio API key" "${ENV_VALUES[EMBEDDING_BINDING_API_KEY]:-${llm_api_key_default:-lm-studio}}")"
       ;;
     azure_openai)
       host_default="$(provider_default_or_existing "$binding" "$current_binding" "${ENV_VALUES[EMBEDDING_BINDING_HOST]:-}" "${llm_host_fallback:-https://example.openai.azure.com/}")"
@@ -1997,7 +2056,11 @@ collect_embedding_config() {
 
   ENV_VALUES["EMBEDDING_BINDING"]="$binding"
   ENV_VALUES["EMBEDDING_MODEL"]="$model"
-  ENV_VALUES["EMBEDDING_DIM"]="$dim"
+  if [[ "$binding" == "lmstudio" && -z "${dim// }" ]]; then
+    unset 'ENV_VALUES[EMBEDDING_DIM]'
+  else
+    ENV_VALUES["EMBEDDING_DIM"]="$dim"
+  fi
   ENV_VALUES["EMBEDDING_BINDING_HOST"]="$host"
   store_optional_env_value "EMBEDDING_BINDING_API_KEY" "$api_key"
   # User chose a remote provider — clear the Docker deployment marker.

--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -15,6 +15,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 declare -A ENV_VALUES
 declare -A ORIGINAL_ENV_VALUES
+declare -A ENV_SUPPRESS_ACTIVE_KEYS
 declare -A COMPOSE_ENV_OVERRIDES
 declare -A COMPOSE_REWRITE_SERVICE_SET
 declare -A COMPOSE_SERVICE_IMAGE_OVERRIDES
@@ -102,6 +103,7 @@ init_colors() {
 reset_state() {
   ENV_VALUES=()
   ORIGINAL_ENV_VALUES=()
+  ENV_SUPPRESS_ACTIVE_KEYS=()
   COMPOSE_ENV_OVERRIDES=()
   COMPOSE_REWRITE_SERVICE_SET=()
   COMPOSE_SERVICE_IMAGE_OVERRIDES=()
@@ -1861,7 +1863,10 @@ default_embedding_model_for_binding() {
     openai|azure_openai)
       printf 'text-embedding-3-large'
       ;;
-    ollama|lmstudio)
+    ollama)
+      printf 'bge-m3:latest'
+      ;;
+    lmstudio)
       printf 'any-available'
       ;;
     jina)
@@ -1907,6 +1912,86 @@ default_embedding_dim_for_binding() {
   esac
 }
 
+apply_lmstudio_llm_concurrency_defaults() {
+  log_info "LM Studio: setting LLM concurrency limits."
+  log_info "  MAX_ASYNC_LLM=1, KEYWORD_MAX_ASYNC_LLM=1, QUERY_MAX_ASYNC_LLM=1, MAX_PARALLEL_INSERT=1"
+  ENV_VALUES["MAX_ASYNC_LLM"]="1"
+  ENV_VALUES["KEYWORD_MAX_ASYNC_LLM"]="1"
+  ENV_VALUES["QUERY_MAX_ASYNC_LLM"]="1"
+  ENV_VALUES["MAX_PARALLEL_INSERT"]="1"
+}
+
+apply_lmstudio_embedding_concurrency_defaults() {
+  log_info "LM Studio: setting embedding concurrency limits."
+  log_info "  EMBEDDING_FUNC_MAX_ASYNC=1, EMBEDDING_BATCH_NUM=16"
+  ENV_VALUES["EMBEDDING_FUNC_MAX_ASYNC"]="1"
+  ENV_VALUES["EMBEDDING_BATCH_NUM"]="16"
+}
+
+prompt_lmstudio_single_threaded_defaults() {
+  echo "LM Studio often runs short on resources and can crash when configured for"
+  echo "concurrent LLM or embedding requests (env.example defaults use MAX_ASYNC_LLM=4"
+  echo "and larger embedding batches)."
+  echo "Single-threaded limits (MAX_ASYNC_LLM=1, EMBEDDING_BATCH_NUM=16, etc.) improve"
+  echo "stability on typical local hardware."
+  if confirm_default_yes "Use single-threaded LM Studio concurrency limits?"; then
+    return 0
+  fi
+  log_info "Keeping concurrency settings from env.example or your existing .env."
+  log_info "See docs/LMSTUDIO_SETUP.md if LM Studio crashes under load."
+  return 1
+}
+
+normalize_lmstudio_env_state() {
+  # apply_runtime_defaults:
+  #   no    — env-storage/env-server: only keep EMBEDDING_DIM out of generated .env
+  #   yes   — apply safe concurrency limits without prompting (tests)
+  #   prompt — env-base: ask before applying concurrency limits
+  # When EMBEDDING_BINDING=lmstudio, EMBEDDING_DIM is always kept out of generated .env.
+  local apply_runtime_defaults="${1:-no}"
+  local llm_lmstudio="no"
+  local embed_lmstudio="no"
+  local should_apply_defaults="no"
+
+  if [[ "${ENV_VALUES[LLM_BINDING]:-}" == "lmstudio" ]]; then
+    llm_lmstudio="yes"
+  fi
+  if [[ "${ENV_VALUES[EMBEDDING_BINDING]:-}" == "lmstudio" ]]; then
+    embed_lmstudio="yes"
+  fi
+
+  if [[ "$llm_lmstudio" != "yes" && "$embed_lmstudio" != "yes" ]]; then
+    unset 'ENV_SUPPRESS_ACTIVE_KEYS[EMBEDDING_DIM]'
+    return 0
+  fi
+
+  if [[ "$apply_runtime_defaults" == "yes" ]]; then
+    should_apply_defaults="yes"
+  elif [[ "$apply_runtime_defaults" == "prompt" ]]; then
+    if prompt_lmstudio_single_threaded_defaults; then
+      should_apply_defaults="yes"
+    fi
+  fi
+
+  if [[ "$embed_lmstudio" == "yes" ]]; then
+    unset 'ENV_VALUES[EMBEDDING_DIM]'
+    ENV_SUPPRESS_ACTIVE_KEYS["EMBEDDING_DIM"]=1
+    if [[ "$should_apply_defaults" == "yes" ]]; then
+      apply_lmstudio_embedding_concurrency_defaults
+    fi
+  else
+    unset 'ENV_SUPPRESS_ACTIVE_KEYS[EMBEDDING_DIM]'
+  fi
+
+  if [[ "$llm_lmstudio" == "yes" && "$should_apply_defaults" == "yes" ]]; then
+    apply_lmstudio_llm_concurrency_defaults
+  fi
+
+  if [[ "$should_apply_defaults" == "yes" ]]; then
+    log_info "LM Studio tuning guide: docs/LMSTUDIO_SETUP.md"
+  fi
+}
+
 collect_llm_config() {
   local options=("openai" "azure_openai" "ollama" "openai-ollama" "lmstudio" "lollms" "gemini" "bedrock")
   local current_binding="${ENV_VALUES[LLM_BINDING]:-openai}"
@@ -1934,6 +2019,7 @@ collect_llm_config() {
       host_default="$(provider_default_or_existing "$binding" "$current_binding" "${ENV_VALUES[LLM_BINDING_HOST]:-}" "$(default_loopback_url 1234 "/v1")")"
       host="$(prompt_with_default "LM Studio endpoint" "$host_default")"
       api_key="$(prompt_with_default "LM Studio API key" "${ENV_VALUES[LLM_BINDING_API_KEY]:-lm-studio}")"
+      log_info "LM Studio: safe concurrency limits can be applied when the wizard writes .env (see docs/LMSTUDIO_SETUP.md)."
       ;;
     lollms)
       host_default="$(provider_default_or_existing "$binding" "$current_binding" "${ENV_VALUES[LLM_BINDING_HOST]:-}" "http://localhost:9600")"
@@ -1994,14 +2080,14 @@ collect_embedding_config() {
     binding="$(prompt_choice "Embedding provider" "$current_binding" "${options[@]}")"
   fi
   model_default="$(model_default_for_binding "$binding" "$current_binding" "${ENV_VALUES[EMBEDDING_MODEL]:-}" "$(default_embedding_model_for_binding "$binding")")"
-  dim_default="$(provider_default_or_existing "$binding" "$current_binding" "${ENV_VALUES[EMBEDDING_DIM]:-}" "$(default_embedding_dim_for_binding "$binding")")"
   model="$(prompt_with_default "Embedding model (blank = any-available)" "$model_default")"
   if [[ "$binding" == "lmstudio" && -z "${model// }" ]]; then
     model="any-available"
   fi
   if [[ "$binding" == "lmstudio" ]]; then
-    dim="$(prompt_with_default "Embedding dimension (blank = auto-probe)" "$dim_default")"
+    log_info "LM Studio: EMBEDDING_DIM is not set — LightRAG probes vector size at server startup."
   else
+    dim_default="$(provider_default_or_existing "$binding" "$current_binding" "${ENV_VALUES[EMBEDDING_DIM]:-}" "$(default_embedding_dim_for_binding "$binding")")"
     dim="$(prompt_with_default "Embedding dimension" "$dim_default")"
   fi
 
@@ -2056,7 +2142,7 @@ collect_embedding_config() {
 
   ENV_VALUES["EMBEDDING_BINDING"]="$binding"
   ENV_VALUES["EMBEDDING_MODEL"]="$model"
-  if [[ "$binding" == "lmstudio" && -z "${dim// }" ]]; then
+  if [[ "$binding" == "lmstudio" ]]; then
     unset 'ENV_VALUES[EMBEDDING_DIM]'
   else
     ENV_VALUES["EMBEDDING_DIM"]="$dim"
@@ -2654,6 +2740,7 @@ finalize_base_setup() {
   fi
 
   clear_deprecated_vllm_dtype_state
+  normalize_lmstudio_env_state prompt
   set_runtime_target "$runtime_target" || return 1
   generate_env_file "${REPO_ROOT}/env.example" "${REPO_ROOT}/.env"
   log_success "Wrote .env"
@@ -2785,6 +2872,7 @@ finalize_storage_setup() {
   fi
 
   clear_deprecated_vllm_dtype_state
+  normalize_lmstudio_env_state no
   set_runtime_target "$runtime_target" || return 1
   generate_env_file "${REPO_ROOT}/env.example" "${REPO_ROOT}/.env"
   log_success "Wrote .env"
@@ -2929,6 +3017,7 @@ finalize_server_setup() {
   fi
 
   clear_deprecated_vllm_dtype_state
+  normalize_lmstudio_env_state no
   set_runtime_target "$runtime_target" || return 1
   generate_env_file "${REPO_ROOT}/env.example" "${REPO_ROOT}/.env"
   log_success "Wrote .env"

--- a/tests/api/config/test_api_config_lmstudio.py
+++ b/tests/api/config/test_api_config_lmstudio.py
@@ -1,0 +1,42 @@
+import sys
+
+import pytest
+
+from lightrag.api.config import get_default_host, parse_args
+
+pytestmark = pytest.mark.offline
+
+
+def test_get_default_host_lmstudio(monkeypatch):
+    monkeypatch.delenv("LLM_BINDING_HOST", raising=False)
+
+    assert get_default_host("lmstudio") == "http://localhost:1234/v1"
+
+
+def test_get_default_host_lmstudio_custom_host(monkeypatch):
+    monkeypatch.setenv("LLM_BINDING_HOST", "http://127.0.0.1:8080/v1")
+
+    assert get_default_host("lmstudio") == "http://127.0.0.1:8080/v1"
+
+
+def test_parse_args_accepts_lmstudio_llm_binding(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+    monkeypatch.delenv("LLM_BINDING", raising=False)
+    monkeypatch.delenv("EMBEDDING_BINDING", raising=False)
+    monkeypatch.setenv("LLM_BINDING", "lmstudio")
+    monkeypatch.setenv("EMBEDDING_BINDING", "lmstudio")
+    monkeypatch.setenv("LLM_BINDING_HOST", "http://127.0.0.1:1234/v1")
+    monkeypatch.setenv("EMBEDDING_BINDING_HOST", "http://127.0.0.1:1234/v1")
+    monkeypatch.setenv("LLM_MODEL", "any-available")
+    monkeypatch.setenv("EMBEDDING_MODEL", "any-available")
+    monkeypatch.delenv("EMBEDDING_DIM", raising=False)
+
+    args = parse_args()
+
+    assert args.llm_binding == "lmstudio"
+    assert args.embedding_binding == "lmstudio"
+    assert args.llm_binding_host == "http://127.0.0.1:1234/v1"
+    assert args.embedding_binding_host == "http://127.0.0.1:1234/v1"
+    assert args.llm_model == "any-available"
+    assert args.embedding_model == "any-available"
+    assert args.embedding_dim is None

--- a/tests/llm/lmstudio_impl/test_lmstudio_model_resolution.py
+++ b/tests/llm/lmstudio_impl/test_lmstudio_model_resolution.py
@@ -130,6 +130,46 @@ async def test_probe_lmstudio_embedding_dim(monkeypatch):
     assert resolved_model == "loaded-embed-model"
 
 
+@pytest.mark.asyncio
+async def test_probe_lmstudio_embedding_dim_cache_returns_tuple(monkeypatch):
+    clear_lmstudio_model_cache()
+
+    call_count = 0
+
+    async def fake_resolve(model, base_url=None, api_key=None, purpose="llm"):
+        nonlocal call_count
+        call_count += 1
+        assert purpose == "embedding"
+        return "loaded-embed-model"
+
+    async def fake_embed(texts, model, base_url=None, api_key=None, embedding_dim=None):
+        return np.array([[0.1, 0.2, 0.3, 0.4]], dtype=np.float32)
+
+    monkeypatch.setattr(
+        "lightrag.llm.lmstudio.resolve_lmstudio_model",
+        fake_resolve,
+    )
+    monkeypatch.setattr(
+        "lightrag.llm.lmstudio.openai_embed.func",
+        fake_embed,
+    )
+
+    first = await probe_lmstudio_embedding_dim(
+        "any-available",
+        base_url="http://localhost:1234/v1",
+        api_key="lm-studio",
+    )
+    second = await probe_lmstudio_embedding_dim(
+        "any-available",
+        base_url="http://localhost:1234/v1",
+        api_key="lm-studio",
+    )
+
+    assert first == (4, "loaded-embed-model")
+    assert second == (4, "loaded-embed-model")
+    assert call_count == 1
+
+
 def test_normalize_lmstudio_response_format_maps_json_object_to_text():
     kwargs: dict = {"response_format": {"type": "json_object"}}
     _normalize_lmstudio_response_format(kwargs)

--- a/tests/llm/lmstudio_impl/test_lmstudio_model_resolution.py
+++ b/tests/llm/lmstudio_impl/test_lmstudio_model_resolution.py
@@ -120,13 +120,14 @@ async def test_probe_lmstudio_embedding_dim(monkeypatch):
         fake_embed,
     )
 
-    dim = await probe_lmstudio_embedding_dim(
+    dim, resolved_model = await probe_lmstudio_embedding_dim(
         "any-available",
         base_url="http://localhost:1234/v1",
         api_key="lm-studio",
     )
 
     assert dim == 4
+    assert resolved_model == "loaded-embed-model"
 
 
 def test_normalize_lmstudio_response_format_maps_json_object_to_text():

--- a/tests/llm/lmstudio_impl/test_lmstudio_model_resolution.py
+++ b/tests/llm/lmstudio_impl/test_lmstudio_model_resolution.py
@@ -1,0 +1,145 @@
+import numpy as np
+import pytest
+
+from lightrag.llm.lmstudio import (
+    clear_lmstudio_model_cache,
+    is_any_available_model,
+    is_auto_embedding_dim,
+    probe_lmstudio_embedding_dim,
+    resolve_lmstudio_model,
+    _normalize_lmstudio_response_format,
+)
+
+pytestmark = pytest.mark.offline
+
+
+def test_is_any_available_model_aliases():
+    assert is_any_available_model(None)
+    assert is_any_available_model("")
+    assert is_any_available_model("   ")
+    assert is_any_available_model("any-available")
+    assert is_any_available_model("ANY_AVAILABLE")
+    assert is_any_available_model("auto")
+    assert not is_any_available_model("meta-llama-3.1-8b-instruct")
+
+
+@pytest.mark.asyncio
+async def test_resolve_lmstudio_model_uses_loaded_v0_instance(monkeypatch):
+    clear_lmstudio_model_cache()
+
+    async def fake_list_v0(base_url, api_key):
+        assert base_url == "http://localhost:1234/v1"
+        assert api_key == "lm-studio"
+        return [
+            {
+                "type": "llm",
+                "id": "meta-llama-3.1-8b-instruct",
+                "loaded_instances": [{"id": "loaded-chat-model"}],
+            },
+            {
+                "type": "embeddings",
+                "id": "text-embedding-nomic-embed-text-v1.5",
+                "loaded_instances": [{"id": "loaded-embed-model"}],
+            },
+        ]
+
+    monkeypatch.setattr(
+        "lightrag.llm.lmstudio._list_v0_models",
+        fake_list_v0,
+    )
+
+    llm_model = await resolve_lmstudio_model(
+        "any-available",
+        base_url="http://localhost:1234/v1",
+        api_key="lm-studio",
+        purpose="llm",
+    )
+    embed_model = await resolve_lmstudio_model(
+        "",
+        base_url="http://localhost:1234/v1",
+        api_key="lm-studio",
+        purpose="embedding",
+    )
+
+    assert llm_model == "loaded-chat-model"
+    assert embed_model == "loaded-embed-model"
+
+
+@pytest.mark.asyncio
+async def test_resolve_lmstudio_model_returns_explicit_id_without_lookup(monkeypatch):
+    clear_lmstudio_model_cache()
+    called = False
+
+    async def fake_list_v0(base_url, api_key):
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr(
+        "lightrag.llm.lmstudio._list_v0_models",
+        fake_list_v0,
+    )
+
+    resolved = await resolve_lmstudio_model(
+        "my-explicit-model",
+        base_url="http://localhost:1234/v1",
+        api_key="lm-studio",
+        purpose="llm",
+    )
+
+    assert resolved == "my-explicit-model"
+    assert called is False
+
+
+def test_is_auto_embedding_dim_aliases():
+    assert is_auto_embedding_dim(None)
+    assert is_auto_embedding_dim("")
+    assert is_auto_embedding_dim("auto")
+    assert not is_auto_embedding_dim(768)
+
+
+@pytest.mark.asyncio
+async def test_probe_lmstudio_embedding_dim(monkeypatch):
+    clear_lmstudio_model_cache()
+
+    async def fake_resolve(model, base_url=None, api_key=None, purpose="llm"):
+        assert purpose == "embedding"
+        return "loaded-embed-model"
+
+    async def fake_embed(texts, model, base_url=None, api_key=None, embedding_dim=None):
+        assert model == "loaded-embed-model"
+        assert embedding_dim is None
+        return np.array([[0.1, 0.2, 0.3, 0.4]], dtype=np.float32)
+
+    monkeypatch.setattr(
+        "lightrag.llm.lmstudio.resolve_lmstudio_model",
+        fake_resolve,
+    )
+    monkeypatch.setattr(
+        "lightrag.llm.lmstudio.openai_embed.func",
+        fake_embed,
+    )
+
+    dim = await probe_lmstudio_embedding_dim(
+        "any-available",
+        base_url="http://localhost:1234/v1",
+        api_key="lm-studio",
+    )
+
+    assert dim == 4
+
+
+def test_normalize_lmstudio_response_format_maps_json_object_to_text():
+    kwargs: dict = {"response_format": {"type": "json_object"}}
+    _normalize_lmstudio_response_format(kwargs)
+    assert kwargs["response_format"] == {"type": "text"}
+
+
+def test_normalize_lmstudio_response_format_preserves_json_schema():
+    schema = {
+        "type": "json_schema",
+        "json_schema": {"name": "test", "schema": {"type": "object"}},
+    }
+    kwargs = {"response_format": schema}
+    _normalize_lmstudio_response_format(kwargs)
+    assert kwargs["response_format"] == schema

--- a/tests/setup/test_collect.py
+++ b/tests/setup/test_collect.py
@@ -907,6 +907,35 @@ printf 'QUERY_LLM_MODEL=%s\\n' "${{ENV_VALUES[QUERY_LLM_MODEL]}}\"
     assert values["QUERY_LLM_MODEL"] == "custom-query-model"
 
 
+def test_collect_llm_config_lmstudio_defaults_any_available_over_legacy_local_model(
+    tmp_path: Path,
+) -> None:
+    write_text_lines(
+        tmp_path / ".env",
+        [
+            "LLM_BINDING=lmstudio",
+            "LLM_MODEL=local-model",
+            "LLM_BINDING_HOST=http://localhost:1234/v1",
+        ],
+    )
+    output = run_bash(f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+reset_state
+load_existing_env_if_present
+
+prompt_choice() {{ printf 'lmstudio'; }}
+prompt_with_default() {{ printf '%s' "$2"; }}
+
+collect_llm_config
+
+printf 'LLM_MODEL=%s\\n' "${{ENV_VALUES[LLM_MODEL]}}"
+""")
+    values = parse_lines(output)
+    assert values["LLM_MODEL"] == "any-available"
+
+
 def test_collect_rerank_config_preserves_api_key_when_disabled(tmp_path: Path) -> None:
     """Disabling reranking should preserve credentials so they survive re-enable."""
     write_text_lines(

--- a/tests/setup/test_collect.py
+++ b/tests/setup/test_collect.py
@@ -1916,3 +1916,135 @@ collect_opensearch_config "yes"
 printf 'PASSWORD_VALIDATOR=%s\\n' "$(cat "$validator_file")\"
 """)
     assert values["PASSWORD_VALIDATOR"] == "validate_opensearch_password_strength"
+
+
+def test_collect_embedding_config_lmstudio_skips_embedding_dim() -> None:
+    """LM Studio embeddings should not set EMBEDDING_DIM in wizard state."""
+    output = run_bash(f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+reset_state
+
+ENV_VALUES[LLM_BINDING]="lmstudio"
+ENV_VALUES[LLM_BINDING_HOST]="http://localhost:1234/v1"
+
+prompt_choice() {{ printf 'lmstudio'; }}
+prompt_with_default() {{ printf '%s' "$2"; }}
+
+collect_embedding_config
+
+printf 'EMBEDDING_DIM_SET=%s\\n' "${{ENV_VALUES[EMBEDDING_DIM]+set}}"
+printf 'EMBEDDING_MODEL=%s\\n' "${{ENV_VALUES[EMBEDDING_MODEL]}}"
+""")
+    values = parse_lines(output)
+    assert values["EMBEDDING_DIM_SET"] == ""
+    assert values["EMBEDDING_MODEL"] == "any-available"
+
+
+def test_normalize_lmstudio_env_state_applies_concurrency_defaults() -> None:
+    """LM Studio wizard normalization should apply safe concurrency defaults."""
+    output = run_bash(f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+reset_state
+
+ENV_VALUES[LLM_BINDING]="lmstudio"
+ENV_VALUES[EMBEDDING_BINDING]="lmstudio"
+
+normalize_lmstudio_env_state yes
+
+printf 'MAX_ASYNC_LLM=%s\\n' "${{ENV_VALUES[MAX_ASYNC_LLM]}}"
+printf 'KEYWORD_MAX_ASYNC_LLM=%s\\n' "${{ENV_VALUES[KEYWORD_MAX_ASYNC_LLM]}}"
+printf 'QUERY_MAX_ASYNC_LLM=%s\\n' "${{ENV_VALUES[QUERY_MAX_ASYNC_LLM]}}"
+printf 'MAX_PARALLEL_INSERT=%s\\n' "${{ENV_VALUES[MAX_PARALLEL_INSERT]}}"
+printf 'EMBEDDING_FUNC_MAX_ASYNC=%s\\n' "${{ENV_VALUES[EMBEDDING_FUNC_MAX_ASYNC]}}"
+printf 'EMBEDDING_BATCH_NUM=%s\\n' "${{ENV_VALUES[EMBEDDING_BATCH_NUM]}}"
+printf 'EMBEDDING_DIM_SET=%s\\n' "${{ENV_VALUES[EMBEDDING_DIM]+set}}"
+printf 'SUPPRESS_EMBEDDING_DIM=%s\\n' "${{ENV_SUPPRESS_ACTIVE_KEYS[EMBEDDING_DIM]+set}}"
+""")
+    values = parse_lines(output)
+    assert values["MAX_ASYNC_LLM"] == "1"
+    assert values["KEYWORD_MAX_ASYNC_LLM"] == "1"
+    assert values["QUERY_MAX_ASYNC_LLM"] == "1"
+    assert values["MAX_PARALLEL_INSERT"] == "1"
+    assert values["EMBEDDING_FUNC_MAX_ASYNC"] == "1"
+    assert values["EMBEDDING_BATCH_NUM"] == "16"
+    assert values["EMBEDDING_DIM_SET"] == ""
+    assert values["SUPPRESS_EMBEDDING_DIM"] == "set"
+
+
+def test_normalize_lmstudio_env_state_prompt_declined_preserves_concurrency() -> None:
+    """Declining the single-threaded prompt should not overwrite concurrency."""
+    output = run_bash(f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+reset_state
+
+ENV_VALUES[LLM_BINDING]="lmstudio"
+ENV_VALUES[EMBEDDING_BINDING]="lmstudio"
+ENV_VALUES[MAX_ASYNC_LLM]="4"
+ENV_VALUES[EMBEDDING_BATCH_NUM]="32"
+
+confirm_default_yes() {{ return 1; }}
+
+normalize_lmstudio_env_state prompt
+
+printf 'MAX_ASYNC_LLM=%s\\n' "${{ENV_VALUES[MAX_ASYNC_LLM]}}"
+printf 'EMBEDDING_BATCH_NUM=%s\\n' "${{ENV_VALUES[EMBEDDING_BATCH_NUM]}}"
+printf 'EMBEDDING_DIM_SET=%s\\n' "${{ENV_VALUES[EMBEDDING_DIM]+set}}"
+printf 'SUPPRESS_EMBEDDING_DIM=%s\\n' "${{ENV_SUPPRESS_ACTIVE_KEYS[EMBEDDING_DIM]+set}}"
+""")
+    values = parse_lines(output)
+    assert values["MAX_ASYNC_LLM"] == "4"
+    assert values["EMBEDDING_BATCH_NUM"] == "32"
+    assert values["EMBEDDING_DIM_SET"] == ""
+    assert values["SUPPRESS_EMBEDDING_DIM"] == "set"
+
+
+def test_normalize_lmstudio_env_state_prompt_accepted_applies_defaults() -> None:
+    """Accepting the single-threaded prompt should apply safe concurrency limits."""
+    output = run_bash(f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+reset_state
+
+ENV_VALUES[LLM_BINDING]="lmstudio"
+ENV_VALUES[EMBEDDING_BINDING]="lmstudio"
+ENV_VALUES[MAX_ASYNC_LLM]="4"
+
+confirm_default_yes() {{ return 0; }}
+
+normalize_lmstudio_env_state prompt
+
+printf 'MAX_ASYNC_LLM=%s\\n' "${{ENV_VALUES[MAX_ASYNC_LLM]}}"
+printf 'EMBEDDING_BATCH_NUM=%s\\n' "${{ENV_VALUES[EMBEDDING_BATCH_NUM]}}"
+""")
+    values = parse_lines(output)
+    assert values["MAX_ASYNC_LLM"] == "1"
+    assert values["EMBEDDING_BATCH_NUM"] == "16"
+
+
+def test_normalize_lmstudio_env_state_without_apply_preserves_concurrency() -> None:
+    """env-storage/env-server should suppress EMBEDDING_DIM but not reset concurrency."""
+    output = run_bash(f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+reset_state
+
+ENV_VALUES[LLM_BINDING]="lmstudio"
+ENV_VALUES[EMBEDDING_BINDING]="lmstudio"
+ENV_VALUES[MAX_ASYNC_LLM]="4"
+ENV_VALUES[EMBEDDING_BATCH_NUM]="32"
+
+normalize_lmstudio_env_state no
+
+printf 'MAX_ASYNC_LLM=%s\\n' "${{ENV_VALUES[MAX_ASYNC_LLM]}}"
+printf 'EMBEDDING_BATCH_NUM=%s\\n' "${{ENV_VALUES[EMBEDDING_BATCH_NUM]}}"
+printf 'EMBEDDING_DIM_SET=%s\\n' "${{ENV_VALUES[EMBEDDING_DIM]+set}}"
+printf 'SUPPRESS_EMBEDDING_DIM=%s\\n' "${{ENV_SUPPRESS_ACTIVE_KEYS[EMBEDDING_DIM]+set}}"
+""")
+    values = parse_lines(output)
+    assert values["MAX_ASYNC_LLM"] == "4"
+    assert values["EMBEDDING_BATCH_NUM"] == "32"
+    assert values["EMBEDDING_DIM_SET"] == ""
+    assert values["SUPPRESS_EMBEDDING_DIM"] == "set"

--- a/tests/setup/test_collect.py
+++ b/tests/setup/test_collect.py
@@ -853,7 +853,7 @@ reset_state
 prompt_choice() {{ printf 'openai'; }}
 prompt_with_default() {{
   case "$1" in
-    "LLM model") printf 'gpt-4o' ;;
+    "LLM model (blank = any-available)") printf 'gpt-4o' ;;
     *) printf '%s' "$2" ;;
   esac
 }}

--- a/tests/setup/test_generate.py
+++ b/tests/setup/test_generate.py
@@ -726,6 +726,37 @@ generate_env_file "{REPO_ROOT}/env.example" "$REPO_ROOT/.env\"
     assert "# EMBEDDING_BINDING=openai" in generated_env
 
 
+def test_generate_env_file_suppresses_active_embedding_dim_for_lmstudio(
+    tmp_path: Path,
+) -> None:
+    """LM Studio setups should not write an active EMBEDDING_DIM from env.example."""
+    write_text_lines(
+        tmp_path / "env.example",
+        (REPO_ROOT / "env.example").read_text(encoding="utf-8").splitlines(),
+    )
+    run_bash(f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+reset_state
+
+ENV_VALUES[LLM_BINDING]="lmstudio"
+ENV_VALUES[EMBEDDING_BINDING]="lmstudio"
+ENV_VALUES[EMBEDDING_MODEL]="any-available"
+ENV_VALUES[LLM_BINDING_HOST]="http://localhost:1234/v1"
+ENV_VALUES[EMBEDDING_BINDING_HOST]="http://localhost:1234/v1"
+
+normalize_lmstudio_env_state no
+generate_env_file "$REPO_ROOT/env.example" "$REPO_ROOT/.env"
+""")
+    generated_env = (tmp_path / ".env").read_text(encoding="utf-8").splitlines()
+    assert not any(line.startswith("EMBEDDING_DIM=") for line in generated_env)
+    assert any(
+        line.startswith("# EMBEDDING_DIM=") and "auto-probed" in line
+        for line in generated_env
+    )
+
+
 def test_generate_env_file_preserves_custom_variables_not_declared_in_template(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Description

Adds an LM Studio binding for LightRAG OpenAI-compatible local API, with setup wizard support and safer defaults for single-machine use.

## Related Issues

None.

## Changes Made

- New lightrag/llm/lmstudio.py with any-available model resolution, embedding dimension probing, and LM Studio-compatible response formats.
- Server/config registration and Codex review fixes: restore Ollama embedding wizard default (bge-m3:latest), record resolved embedding model id for vector namespace isolation.
- Setup wizard: leave EMBEDDING_DIM unset for LM Studio, optional single-threaded concurrency prompt on make env-base, and docs/LMSTUDIO_SETUP.md.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

- Run uv sync --extra test then uv run pre-commit run --all-files before pushing (see CONTRIBUTING.md).
- Wizard applies concurrency limits only when the user accepts the single-threaded prompt during make env-base; env-storage / env-server do not reset tuned values.