### PR TITLE
fix(security): remove /health from default WHITELIST_PATHS

### DIFF
--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -638,7 +638,7 @@ def parse_args() -> argparse.Namespace:
     # Add environment variables that were previously read directly
     args.cors_origins = get_env_value("CORS_ORIGINS", "*")
     args.summary_language = get_env_value("SUMMARY_LANGUAGE", DEFAULT_SUMMARY_LANGUAGE)
-    args.whitelist_paths = get_env_value("WHITELIST_PATHS", "/health,/api/*")
+    args.whitelist_paths = get_env_value("WHITELIST_PATHS", "/api/*")
 
     # For JWT Auth
     args.auth_accounts = get_env_value("AUTH_ACCOUNTS", "")


### PR DESCRIPTION
Fixes #3294

## Summary

The `/health` endpoint is whitelisted by default (`WHITELIST_PATHS=/health,/api/*`), bypassing authentication even when `AUTH_ACCOUNTS` or `LIGHTRAG_API_KEY` is configured. The response exposes LLM provider details, model names, and filesystem paths.

## What changed

- `lightrag/api/config.py`: Default `WHITELIST_PATHS` changed from `/health,/api/*` to `/api/*`

## How this works

- **No auth configured**: `/health` remains accessible (combined_auth passes through)
- **Auth configured**: `/health` now requires authentication
- **Load balancers**: Users can re-add `/health` via `WHITELIST_PATHS` env var

## Verification

All 67 setup tests pass after the change.
