### PR TITLE
fix: strip null bytes from extracted text to prevent PostgreSQL encoding errors

### DIFF
--- a/lightrag/parser/legacy/extractors.py
+++ b/lightrag/parser/legacy/extractors.py
@@ -167,6 +167,17 @@ def _decode_text(file_bytes: bytes) -> str:
     return content
 
 
+def _strip_null_bytes(text: str) -> str:
+    """Remove NUL characters that cause PostgreSQL encoding errors.
+
+    PDF extractors (pypdf) can produce text containing ``\\x00`` bytes,
+    which PostgreSQL rejects with ``invalid byte sequence for encoding
+    "UTF8": 0x00``.  Stripping them is safe — NUL carries no semantic
+    content in natural-language text.
+    """
+    return text.replace("\x00", "")
+
+
 def extract_text(
     file_bytes: bytes, suffix: str, *, pdf_password: str | None = None
 ) -> str:
@@ -179,7 +190,7 @@ def extract_text(
     suffix = suffix.lower().lstrip(".")
     extractor = _BINARY_EXTRACTORS.get(suffix)
     if extractor is _extract_pdf_pypdf:
-        return _extract_pdf_pypdf(file_bytes, pdf_password)
+        return _strip_null_bytes(_extract_pdf_pypdf(file_bytes, pdf_password))
     if extractor is not None:
-        return extractor(file_bytes)
-    return _decode_text(file_bytes)
+        return _strip_null_bytes(extractor(file_bytes))
+    return _strip_null_bytes(_decode_text(file_bytes))

--- a/tests/parser/test_legacy_parser.py
+++ b/tests/parser/test_legacy_parser.py
@@ -119,3 +119,14 @@ async def test_legacy_parse_passes_pdf_password_from_env(
 
     assert seen == {"suffix": "pdf", "pdf_password": "s3cret"}
     assert result.content == "decrypted text"
+
+
+async def test_extract_text_strips_null_bytes(tmp_path):
+    """Null bytes from PDF extractors must be stripped to avoid PostgreSQL
+    ``invalid byte sequence for encoding "UTF8": 0x00`` errors (#3308)."""
+    from lightrag.parser.legacy.extractors import _strip_null_bytes
+
+    assert _strip_null_bytes("hello\x00world") == "helloworld"
+    assert _strip_null_bytes("\x00\x00") == ""
+    assert _strip_null_bytes("no nulls") == "no nulls"
+    assert _strip_null_bytes("") == ""


### PR DESCRIPTION
## Problem

When ingesting certain PDF files, the parse worker crashes with:

```
ERROR: Parse worker failed (native): invalid byte sequence for encoding "UTF8": 0x00
```

PDF text extractors (pypdf) can produce strings containing NUL characters (`\x00`). PostgreSQL does not support null bytes in `TEXT` or `VARCHAR` fields, so inserting this text fails.

Fixes #3308

## Solution

Added a `_strip_null_bytes()` sanitizer in the legacy `extract_text()` entry point. All extraction paths — binary formats (PDF, DOCX, PPTX, XLSX) and the text decode path — pass through this sanitizer before returning.

The fix is minimal (1 function + 3 call-site changes) and has zero performance impact on clean text.

## Testing

- Added unit tests for `_strip_null_bytes()` covering: embedded nulls, all-null input, clean text, and empty string.
- All 5 existing tests in `tests/parser/test_legacy_parser.py` continue to pass.
- The sanitizer is a pure `str.replace("\x00", "")` — no regex, no external deps.

## Scope

- `lightrag/parser/legacy/extractors.py`: +`_strip_null_bytes()` helper, wrap all 3 return paths in `extract_text()`.
- `tests/parser/test_legacy_parser.py`: +1 test function for the sanitizer.