### PR TITLE
fix(sidecar): prevent path traversal in asset materialization

### DIFF
--- a/lightrag/sidecar/writer.py
+++ b/lightrag/sidecar/writer.py
@@ -414,6 +414,15 @@ def _materialize_assets(
     for spec in assets:
         target_name = _allocate_unique_name(spec.suggested_name, used_names)
         target_path = assets_dir / target_name
+        try:
+            target_path.resolve().relative_to(assets_dir.resolve())
+        except ValueError:
+            logger.warning(
+                "[sidecar] unsafe asset target for ref=%s (%s); skipping",
+                spec.ref,
+                spec.suggested_name,
+            )
+            continue
         if isinstance(spec.source, (str, Path)):
             src_path = Path(spec.source)
             if not src_path.exists():
@@ -453,6 +462,7 @@ def _materialize_assets(
 
 def _allocate_unique_name(suggested: str, used: set[str]) -> str:
     """Make ``suggested`` unique within ``used``: ``foo.png`` → ``foo-2.png``."""
+    suggested = _safe_asset_filename(suggested)
     if suggested not in used:
         return suggested
     stem = Path(suggested).stem
@@ -463,6 +473,13 @@ def _allocate_unique_name(suggested: str, used: set[str]) -> str:
         if cand not in used:
             return cand
         n += 1
+
+
+def _safe_asset_filename(suggested: str) -> str:
+    """Collapse parser-suggested asset names to a safe filename."""
+    name = Path(str(suggested).replace("\\", "/")).name
+    name = "".join(c for c in name.strip() if ord(c) >= 32 and c != "\x7f").strip(".")
+    return name or "asset"
 
 
 def _render_block_content(

--- a/tests/sidecar/test_writer.py
+++ b/tests/sidecar/test_writer.py
@@ -23,6 +23,12 @@ from lightrag.sidecar import (
     IRTable,
     write_sidecar,
 )
+from lightrag.sidecar import writer as _writer
+from lightrag.sidecar.writer import (
+    _allocate_unique_name,
+    _materialize_assets,
+    _safe_asset_filename,
+)
 
 
 def _load_jsonl(path: Path) -> tuple[dict, list[dict]]:
@@ -639,6 +645,141 @@ def test_writer_asset_name_collision_suffixed(tmp_path: Path) -> None:
     body = _load_jsonl(parsed / "c.blocks.jsonl")[1][0]["content"]
     assert 'path="c.blocks.assets/img.png"' in body
     assert 'path="c.blocks.assets/img-2.png"' in body
+
+
+# --- Path-traversal boundary for sidecar asset materialization (PR #3316) ---
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize(
+    "suggested, expected",
+    [
+        ("evil.png", "evil.png"),
+        ("../evil.png", "evil.png"),
+        ("../../etc/passwd", "passwd"),
+        ("..\\evil.png", "evil.png"),
+        ("dir\\sub\\evil.png", "evil.png"),
+        ("a/b/c/evil.png", "evil.png"),
+        ("/abs/evil.png", "evil.png"),
+        ("C:\\Windows\\evil.png", "evil.png"),
+        ("  spaced.png  ", "spaced.png"),
+    ],
+)
+def test_safe_asset_filename_collapses_to_basename(
+    suggested: str, expected: str
+) -> None:
+    """Parser-suggested names are reduced to a bare basename regardless of the
+    path separators they carry, so they can never steer the output path out of
+    the assets dir. ``\\`` is normalised first so Windows-style payloads on a
+    POSIX host still collapse rather than surviving as a single filename."""
+    assert _safe_asset_filename(suggested) == expected
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize("suggested", ["", "   ", "..", "...", "/", "\\", "\x00\x1f"])
+def test_safe_asset_filename_falls_back_when_empty(suggested: str) -> None:
+    """Names that strip down to nothing (pure dots/separators/control chars)
+    yield the ``asset`` fallback rather than an empty or dot-only filename."""
+    assert _safe_asset_filename(suggested) == "asset"
+
+
+@pytest.mark.offline
+def test_safe_asset_filename_drops_control_chars() -> None:
+    """C0 control chars and DEL are stripped out of the basename so they can't
+    smuggle separators or break the on-disk name."""
+    assert _safe_asset_filename("ev\x00i\x7fl\x1f.png") == "evil.png"
+
+
+@pytest.mark.offline
+def test_allocate_unique_name_sanitises_before_suffixing() -> None:
+    """``_allocate_unique_name`` sanitises first, then applies collision
+    suffixes — a traversal payload and a plain basename that collapse to the
+    same name still get distinct, contained filenames."""
+    used: set[str] = set()
+    first = _allocate_unique_name("../evil.png", used)
+    used.add(first)
+    second = _allocate_unique_name("dir/evil.png", used)
+    assert first == "evil.png"
+    assert second == "evil-2.png"
+
+
+@pytest.mark.offline
+def test_materialize_assets_keeps_traversal_payload_inside_assets_dir(
+    tmp_path: Path,
+) -> None:
+    """End-to-end: a parser-controlled ``../`` asset name must not write bytes
+    outside the assets dir. The byte payload lands at the collapsed basename
+    inside ``assets_dir`` and the sibling traversal target stays absent."""
+    assets_dir = tmp_path / "doc.blocks.assets"
+    out = _materialize_assets(
+        [AssetSpec(ref="r1", suggested_name="../evil.png", source=b"\x89PNG")],
+        assets_dir,
+    )
+    assert out == {"r1": "evil.png"}
+    assert (assets_dir / "evil.png").read_bytes() == b"\x89PNG"
+    # The traversal target one level up must never be created.
+    assert not (tmp_path / "evil.png").exists()
+
+
+@pytest.mark.offline
+def test_writer_traversal_asset_name_stays_in_assets_dir(tmp_path: Path) -> None:
+    """Through the public ``write_sidecar`` path: a drawing whose asset uses a
+    traversal ``suggested_name`` is materialised inside ``*.blocks.assets/`` and
+    the rendered/drawing path is the contained basename, with nothing written
+    to the parent ``parsed`` dir."""
+    parsed = tmp_path / "trav.parsed"
+    ir = IRDoc(
+        document_name="trav.pdf",
+        document_format="pdf",
+        doc_title="trav",
+        split_option={},
+        blocks=[
+            IRBlock(
+                content_template="see {{IMG:i1}}",
+                drawings=[IRDrawing(placeholder_key="i1", asset_ref="img1", fmt="png")],
+            )
+        ],
+        assets=[
+            AssetSpec(ref="img1", suggested_name="../../evil.png", source=b"\x89PNG")
+        ],
+    )
+    write_sidecar(ir, parsed_dir=parsed, doc_id="doc-trav", engine="mineru")
+
+    assert (parsed / "trav.blocks.assets" / "evil.png").read_bytes() == b"\x89PNG"
+    assert not (tmp_path / "evil.png").exists()
+    assert not (parsed.parent / "evil.png").exists()
+
+    body = _load_jsonl(parsed / "trav.blocks.jsonl")[1][0]["content"]
+    assert 'path="trav.blocks.assets/evil.png"' in body
+    drawings = json.loads((parsed / "trav.drawings.json").read_text())["drawings"]
+    assert drawings["im-trav-0001"]["path"] == "trav.blocks.assets/evil.png"
+
+
+@pytest.mark.offline
+def test_materialize_assets_containment_check_skips_escaping_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Defense-in-depth: even if name sanitisation were bypassed and a target
+    resolved outside the assets dir, the ``relative_to`` containment guard skips
+    the write (no bytes escape) and the ref is dropped from the output map."""
+    assets_dir = tmp_path / "doc.blocks.assets"
+
+    # Force the allocator to hand back an escaping relative name, simulating a
+    # sanitisation gap so the second-layer containment check is exercised.
+    monkeypatch.setattr(_writer, "_allocate_unique_name", lambda *_: "../escape.png")
+
+    import logging
+
+    monkeypatch.setattr(_writer.logger, "propagate", True)
+    with caplog.at_level(logging.WARNING, logger=_writer.logger.name):
+        out = _materialize_assets(
+            [AssetSpec(ref="r1", suggested_name="ok.png", source=b"\x89PNG")],
+            assets_dir,
+        )
+
+    assert out == {}
+    assert not (tmp_path / "escape.png").exists()
+    assert "unsafe asset target" in caplog.text
 
 
 @pytest.mark.offline


### PR DESCRIPTION
## Description

This fixes a path traversal risk in sidecar asset materialization, where parser-provided asset names were used to build filesystem output paths before copying or writing asset bytes.

The vulnerable path is built from an asset directory plus a parser/adaptor-controlled suggested name:

```python
target_name = _allocate_unique_name(spec.suggested_name, used_names)
target_path = assets_dir / target_name
```

`AssetSpec.suggested_name` is not itself a trusted filesystem boundary. If a current or future parser/adaptor supplies a path-like name such as `../evil.png`, `..\evil.png`, or an absolute path, the filesystem path resolver can interpret that value as path structure rather than a plain filename. Since the same `target_path` is then passed to `shutil.copyfile()` or `write_bytes()`, crafted asset metadata could cause LightRAG to copy or write asset bytes outside the intended `<base>.blocks.assets/` directory.

The concrete impact is file creation or overwrite within the LightRAG process permissions when the target parent directories already exist. That can corrupt generated sidecar output, replace adjacent files, or place attacker-controlled asset bytes in another reachable location. The issue is therefore a path traversal / output path boundary bug at the final sidecar asset write sink.

The sidecar writer is the correct place to enforce this boundary because it is the component that materializes parser-produced assets on disk. Relying on every parser/adaptor to always provide a basename leaves the final write path too permissive.

## Changes Made

- Collapse parser-suggested asset names to safe basenames before output filename allocation.
- Preserve existing duplicate-name handling after filename normalization.
- Add a resolved-path containment check before any sidecar asset copy or byte write.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

Evidence:

The issue can be reproduced at the path-construction layer with crafted asset names. This local console reproduction only resolves paths; it does not write files.

```text
LightRAG sidecar asset path traversal evidence demo
Scope: local console path-resolution reproduction; no files are written.
intended assets dir: C:\Users\MiaoXing\AppData\Local\Temp\lightrag-sidecar-demo\demo.pdf.parsed\demo.blocks.assets

payload        : ../evil.png
before target  : C:\Users\MiaoXing\AppData\Local\Temp\lightrag-sidecar-demo\demo.pdf.parsed\evil.png
before inside? : False
safe basename  : evil.png
after target   : C:\Users\MiaoXing\AppData\Local\Temp\lightrag-sidecar-demo\demo.pdf.parsed\demo.blocks.assets\evil.png
after inside?  : True
---
payload        : ..\evil.png
before target  : C:\Users\MiaoXing\AppData\Local\Temp\lightrag-sidecar-demo\demo.pdf.parsed\evil.png
before inside? : False
safe basename  : evil.png
after target   : C:\Users\MiaoXing\AppData\Local\Temp\lightrag-sidecar-demo\demo.pdf.parsed\demo.blocks.assets\evil.png
after inside?  : True
```

<table>
  <tr>
    <td><img src="https://img.vectorpeak.cn/obsidian/2026/05-06/20260624111545850.png?imageSlim" alt="path traversal evidence before fix" /></td>
    <td><img src="https://img.vectorpeak.cn/obsidian/2026/05-06/20260624111615104.png?imageSlim" alt="path traversal evidence after fix" /></td>
  </tr>
</table>

Possible call chain / impact:

```text
lightrag/parser/external/_base.py
  -> BaseExternalParser.parse(...)
  -> self.build_ir(raw_dir, rs.document_name)
  -> write_sidecar(ir, parsed_dir=rs.parsed_dir, ...)
  -> _materialize_assets(ir.assets, assets_dir)
  -> shutil.copyfile(src_path, target_path) / target_path.write_bytes(...)

lightrag/parser/native_base.py
  -> NativeParserBase.parse(...)
  -> self.build_ir(...)
  -> write_sidecar(ir, parsed_dir=parsed_dir, clean_parsed_dir=False, ...)
  -> _materialize_assets(ir.assets, assets_dir)
```

This PR only changes the final asset output-name boundary in the sidecar writer. It does not change document parsing, chunking, embedding, retrieval, or normal sidecar asset paths for basename-only asset names.

Validation:

- `.\.venv\Scripts\python.exe -m ruff check lightrag\sidecar\writer.py` - passed
- `pre-commit run --files lightrag\sidecar\writer.py` - passed
- `git diff --check upstream/main...HEAD` - passed
