### PR TITLE
fix(api): stop guest tokens from bypassing X-API-Key auth

### DIFF
--- a/lightrag/api/utils_api.py
+++ b/lightrag/api/utils_api.py
@@ -211,18 +211,29 @@ def get_combined_auth_dependency(api_key: Optional[str] = None):
                             logger.warning(f"Token auto-renew failed: {e}")
                 # ========== End of Token Auto-Renewal Logic ==========
 
-                # Accept guest token if no auth is configured
+                # A token only authenticates when it matches the configured auth mode:
+                #   - password auth (AUTH_ACCOUNTS set): accept non-guest user tokens
+                #   - fully open (no AUTH_ACCOUNTS, no API key): accept guest tokens
+                # In the API-key-only profile (API key set, no AUTH_ACCOUNTS) a guest
+                # token must NOT authenticate: anyone can obtain one (via /auth-status,
+                # /login, or by signing it with the public default secret), so honoring
+                # it here would let a forged guest token bypass the X-API-Key check
+                # below (GHSA-f4vv-55c2-5789 / GHSA-xr5c-v5r6-c9f9). Instead, fall
+                # through so the API key stays mandatory in that mode.
                 if not auth_configured and token_info.get("role") == "guest":
+                    if not api_key_configured:
+                        return
+                    # API-key-only mode: ignore the guest token; the X-API-Key check
+                    # below is the sole authority. Fall through (no return, no raise).
+                elif auth_configured and token_info.get("role") != "guest":
+                    # Accept non-guest token if password auth is configured
                     return
-                # Accept non-guest token if auth is configured
-                if auth_configured and token_info.get("role") != "guest":
-                    return
-
-                # Token validation failed, immediately return 401 error
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Invalid token. Please login again.",
-                )
+                else:
+                    # Token present but not valid for the configured auth mode.
+                    raise HTTPException(
+                        status_code=status.HTTP_401_UNAUTHORIZED,
+                        detail="Invalid token. Please login again.",
+                    )
             except HTTPException as e:
                 # If already a 401 error, re-raise it
                 if e.status_code == status.HTTP_401_UNAUTHORIZED:

--- a/tests/api/auth/test_auth.py
+++ b/tests/api/auth/test_auth.py
@@ -4,6 +4,8 @@ from types import SimpleNamespace
 
 import bcrypt
 import pytest
+from fastapi import HTTPException
+from starlette.status import HTTP_403_FORBIDDEN
 
 from lightrag.api.passwords import BCRYPT_PASSWORD_PREFIX, hash_password
 from lightrag.tools.hash_password import main as hash_password_main
@@ -151,6 +153,103 @@ def test_guest_tokens_fall_back_to_default_secret_when_token_secret_missing(
     )
 
     sys.modules.pop("lightrag.api.auth", None)
+
+
+def _load_api_key_only_modules(monkeypatch):
+    """Import auth + utils_api in the API-key-only profile.
+
+    API-key-only = an API key is set but AUTH_ACCOUNTS is empty, so
+    ``auth_configured`` is False and AuthHandler falls back to the public
+    DEFAULT_TOKEN_SECRET. Returns (config, auth, utils_api).
+    """
+    config = import_real_api_module("lightrag.api.config")
+
+    mock_global_args = SimpleNamespace(
+        token_secret=None,  # -> AuthHandler falls back to DEFAULT_TOKEN_SECRET
+        jwt_algorithm="HS256",
+        token_expire_hours=48,
+        guest_token_expire_hours=24,
+        auth_accounts="",  # no password accounts -> auth_configured is False
+        whitelist_paths="/health",  # consumed by utils_api at import time
+        token_auto_renew=False,
+    )
+    monkeypatch.setattr(config, "global_args", mock_global_args)
+
+    auth = import_real_api_module("lightrag.api.auth")
+    auth = importlib.reload(auth)
+    utils_api = import_real_api_module("lightrag.api.utils_api")
+    return config, auth, utils_api
+
+
+async def test_combined_auth_rejects_guest_token_in_api_key_mode(monkeypatch):
+    """A forged/obtained guest token must not bypass the X-API-Key check.
+
+    Regression for GHSA-f4vv-55c2-5789 / GHSA-xr5c-v5r6-c9f9: in the
+    API-key-only profile an anonymous caller can mint a guest JWT with the
+    public default secret (or fetch one from /auth-status) and previously
+    short-circuited authorization before the API key was ever checked.
+    """
+    config, auth, utils_api = _load_api_key_only_modules(monkeypatch)
+    try:
+        assert utils_api.auth_configured is False
+        assert auth.auth_handler.secret == config.DEFAULT_TOKEN_SECRET
+
+        forged_guest = auth.auth_handler.create_token(username="guest", role="guest")
+
+        api_key = "operator-secret-key"
+        dependency = utils_api.get_combined_auth_dependency(api_key=api_key)
+
+        request = SimpleNamespace(url=SimpleNamespace(path="/documents"), scope={})
+        response = SimpleNamespace(headers={})
+
+        # Forged guest token, no API key -> rejected (was HTTP 200 before the fix).
+        with pytest.raises(HTTPException) as rejected:
+            await dependency(
+                request=request,
+                response=response,
+                token=forged_guest,
+                api_key_header_value=None,
+            )
+        assert rejected.value.status_code == HTTP_403_FORBIDDEN
+
+        # Guest token together with the real API key -> allowed (the WebUI sends
+        # both Authorization and X-API-Key headers).
+        result = await dependency(
+            request=request,
+            response=response,
+            token=forged_guest,
+            api_key_header_value=api_key,
+        )
+        assert result is None
+    finally:
+        sys.modules.pop("lightrag.api.utils_api", None)
+        sys.modules.pop("lightrag.api.auth", None)
+
+
+async def test_combined_auth_allows_guest_token_when_fully_open(monkeypatch):
+    """Fully-open mode (no API key, no AUTH_ACCOUNTS) keeps accepting guest tokens.
+
+    Guards against over-fixing: the bypass fix must not break zero-config guest
+    access, which is the intended convenience mode.
+    """
+    _config, auth, utils_api = _load_api_key_only_modules(monkeypatch)
+    try:
+        guest_token = auth.auth_handler.create_token(username="guest", role="guest")
+
+        dependency = utils_api.get_combined_auth_dependency(api_key=None)
+        request = SimpleNamespace(url=SimpleNamespace(path="/documents"), scope={})
+        response = SimpleNamespace(headers={})
+
+        result = await dependency(
+            request=request,
+            response=response,
+            token=guest_token,
+            api_key_header_value=None,
+        )
+        assert result is None
+    finally:
+        sys.modules.pop("lightrag.api.utils_api", None)
+        sys.modules.pop("lightrag.api.auth", None)
 
 
 def test_hash_password_returns_prefixed_value(auth_module):


### PR DESCRIPTION
## Summary

In the **API-key-only** deployment profile (`LIGHTRAG_API_KEY` set, `AUTH_ACCOUNTS` unset — the documented "simple API-Key authentication" mode), `combined_dependency` accepted any valid **guest** token and returned access **before** ever checking `X-API-Key`.

Because that mode has no `AUTH_ACCOUNTS`, `AuthHandler` falls back to the public `DEFAULT_TOKEN_SECRET`. An unauthenticated attacker can therefore mint a guest JWT (offline, or simply fetch one from the open `/auth-status` / `/login` endpoints) and call every protected endpoint **without the API key** — read/write/delete documents, mutate the KG, burn LLM credits.

The bypass is unambiguous on the same instance:

| Request to `/documents` | Before |
|---|---|
| no token, no key (anonymous) | **403** (correctly blocked) |
| forged/obtained **guest** JWT, no key | **200** (bypass) |

So this is a genuine authentication bypass, not the "open by design" guest mode it can be mistaken for — in fully-open mode the anonymous request would itself be 200, but here it is 403.

Reported in **GHSA-f4vv-55c2-5789** and **GHSA-xr5c-v5r6-c9f9**.

## Root cause

`lightrag/api/utils_api.py` — the guest short-circuit fires whenever `auth_configured` is false, but `auth_configured = bool(auth_handler.accounts)` ignores whether an API key is configured:

```python
if not auth_configured and token_info.get("role") == "guest":
    return  # short-circuits ahead of the X-API-Key check
```

This is the same hardcoded-secret invariant CVE-2026-30762 already enforced for the `AUTH_ACCOUNTS` path — it was just never extended to the API-key-only path.

## Fix

Accept guest tokens **only when neither password auth nor an API key is configured** (the genuinely fully-open profile). When an API key is set, a guest token is ignored and the request **falls through** to the mandatory `X-API-Key` check — deliberately *not* a hard 401, so the WebUI (which sends both `Authorization` and `X-API-Key`) keeps working and simply prompts for the key via the existing `ApiKeyAlert` flow.

All other branches are byte-for-byte preserved:
- password mode + non-guest token → accept
- password mode + guest token → 401 (unchanged)
- fully-open + guest token → accept (unchanged)

## Tests

Added two regression tests in `tests/api/auth/test_auth.py` that drive `combined_dependency` directly:
- `test_combined_auth_rejects_guest_token_in_api_key_mode` — forged guest token + no key → **403**; same token + real key → allowed. *Verified failing on the pre-fix code (`DID NOT RAISE`), passing after.*
- `test_combined_auth_allows_guest_token_when_fully_open` — guards against over-fixing: zero-config guest access still works.

```
11 passed in 3.75s
```

## Note on `/auth-status` & `/login`

These still hand out a guest token in API-key mode, but it is now inert (cannot bypass the key). Gating them too is reasonable defense-in-depth but was left out to keep this fix minimal and avoid changing the WebUI bootstrap; happy to add it as a follow-up if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)