### PR TITLE
docs(README): add optional HVTracker trust badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
     </p>
     <p>
       <a href="https://pepy.tech/projects/lightrag-hku"><img src="https://static.pepy.tech/personalized-badge/lightrag-hku?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads"></a>
+      <a href="https://hvtracker.net/agents/lightrag/"><img src="https://hvtracker.net/badge/lightrag.svg"></a>
     </p>
   </div>
 </div>


### PR DESCRIPTION
## Summary

Adds the optional HVTracker trust badge to the README badge row, as requested in #3313. The badge displays LightRAG's externally-computed trust score and links to the live evaluation page.

```markdown
<a href="https://hvtracker.net/agents/lightrag/"><img src="https://hvtracker.net/badge/lightrag.svg"></a>
```

## Details

- Single-line addition next to the existing PyPI downloads badge.
- The score is computed by HVTracker (an independent registry) from OSSF Scorecard, commit signing, build provenance, licensing, maintenance, and adoption metrics.
- Purely a documentation change — no code paths affected.

Closes #3313

🤖 Generated with [Claude Code](https://claude.com/claude-code)