### PR TITLE
fix(external): prevent task ID URL path injection

### DIFF
--- a/lightrag/parser/external/docling/client.py
+++ b/lightrag/parser/external/docling/client.py
@@ -26,6 +26,7 @@ import time
 from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 
 from lightrag.parser.external._common import (
     env_bool,
@@ -241,7 +242,8 @@ class DoclingRawClient:
         client: "httpx.AsyncClient",
         task_id: str,
     ) -> None:
-        url = f"{self.endpoint}{POLL_PATH.format(task_id=task_id)}"
+        encoded_task_id = quote(task_id, safe="")
+        url = f"{self.endpoint}{POLL_PATH.format(task_id=encoded_task_id)}"
         params = {"wait": self.poll_wait_seconds}
         for _ in range(self.max_poll_attempts):
             iteration_started = time.monotonic()
@@ -282,7 +284,8 @@ class DoclingRawClient:
         client: "httpx.AsyncClient",
         task_id: str,
     ) -> bytes:
-        url = f"{self.endpoint}{RESULT_PATH.format(task_id=task_id)}"
+        encoded_task_id = quote(task_id, safe="")
+        url = f"{self.endpoint}{RESULT_PATH.format(task_id=encoded_task_id)}"
         resp = await client.get(url)
         raise_for_status_with_detail(resp, f"Docling result {task_id} download")
         ctype = resp.headers.get("content-type", "")

--- a/lightrag/parser/external/mineru/client.py
+++ b/lightrag/parser/external/mineru/client.py
@@ -26,7 +26,7 @@ from collections.abc import AsyncIterator, Mapping
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 from lightrag.parser.external._common import raise_for_status_with_detail
 from lightrag.parser.external.mineru.cache import (
@@ -314,7 +314,10 @@ class MinerURawClient:
         batch_id: str,
         upload_name: str,
     ) -> str:
-        poll_url = f"{self.official_endpoint}/api/v4/extract-results/batch/{batch_id}"
+        encoded_batch_id = quote(batch_id, safe="")
+        poll_url = (
+            f"{self.official_endpoint}/api/v4/extract-results/batch/{encoded_batch_id}"
+        )
         for _ in range(self.max_polls):
             await asyncio.sleep(self.poll_interval)
             resp = await client.get(poll_url, headers=self._official_headers())
@@ -403,10 +406,11 @@ class MinerURawClient:
                 f"MinerU local /tasks response missing task_id: {payload}"
             )
 
-        await self._poll_local_task(client, task_id)
+        encoded_task_id = quote(task_id, safe="")
+        await self._poll_local_task(client, task_id, encoded_task_id=encoded_task_id)
         await self._download_zip(
             client,
-            f"{self.local_endpoint}/tasks/{task_id}/result",
+            f"{self.local_endpoint}/tasks/{encoded_task_id}/result",
             raw_dir,
         )
         return task_id
@@ -415,8 +419,11 @@ class MinerURawClient:
         self,
         client: "httpx.AsyncClient",
         task_id: str,
+        encoded_task_id: str | None = None,
     ) -> None:
-        poll_url = f"{self.local_endpoint}/tasks/{task_id}"
+        poll_url = (
+            f"{self.local_endpoint}/tasks/{encoded_task_id or quote(task_id, safe='')}"
+        )
         for _ in range(self.max_polls):
             await asyncio.sleep(self.poll_interval)
             resp = await client.get(poll_url)

--- a/lightrag/parser/external/mineru/client.py
+++ b/lightrag/parser/external/mineru/client.py
@@ -406,11 +406,10 @@ class MinerURawClient:
                 f"MinerU local /tasks response missing task_id: {payload}"
             )
 
-        encoded_task_id = quote(task_id, safe="")
-        await self._poll_local_task(client, task_id, encoded_task_id=encoded_task_id)
+        await self._poll_local_task(client, task_id)
         await self._download_zip(
             client,
-            f"{self.local_endpoint}/tasks/{encoded_task_id}/result",
+            f"{self.local_endpoint}/tasks/{quote(task_id, safe='')}/result",
             raw_dir,
         )
         return task_id
@@ -419,11 +418,11 @@ class MinerURawClient:
         self,
         client: "httpx.AsyncClient",
         task_id: str,
-        encoded_task_id: str | None = None,
     ) -> None:
-        poll_url = (
-            f"{self.local_endpoint}/tasks/{encoded_task_id or quote(task_id, safe='')}"
-        )
+        # ``task_id`` is service-returned; encode it as a single path segment so
+        # a crafted value can't break out of ``/tasks/{id}``. The raw value is
+        # kept for the error/timeout messages below where the real ID matters.
+        poll_url = f"{self.local_endpoint}/tasks/{quote(task_id, safe='')}"
         for _ in range(self.max_polls):
             await asyncio.sleep(self.poll_interval)
             resp = await client.get(poll_url)

--- a/tests/parser/external/docling/test_client.py
+++ b/tests/parser/external/docling/test_client.py
@@ -21,6 +21,7 @@ import json
 import zipfile
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 import pytest
 
@@ -139,7 +140,10 @@ class _FakeAsyncClient:
     ) -> _FakeResponse:
         recorder = _CURRENT["recorder"]
         recorder.get_calls.append({"url": url, "params": params})
-        if POLL_PATH.format(task_id=recorder.task_id) in url:
+        # Mirror production: the client encodes the task id into a single path
+        # segment, so route on the encoded form (a no-op for URL-safe ids).
+        encoded = quote(recorder.task_id, safe="")
+        if POLL_PATH.format(task_id=encoded) in url:
             if recorder.poll_status_code != 200:
                 return _FakeResponse(
                     status_code=recorder.poll_status_code,
@@ -152,7 +156,7 @@ class _FakeAsyncClient:
             if recorder.terminal_status != "success":
                 payload["error_message"] = "synthetic-failure"
             return _FakeResponse(status_code=200, text=json_dump(payload))
-        if RESULT_PATH.format(task_id=recorder.task_id) in url:
+        if RESULT_PATH.format(task_id=encoded) in url:
             recorder.result_calls += 1
             if recorder.result_status_code != 200:
                 return _FakeResponse(
@@ -442,6 +446,36 @@ async def test_docling_client_result_http_error_preserves_response_body(
     assert "Docling result task-abc download" in message
     assert "HTTP 500" in message
     assert "zip artifact missing" in message
+
+
+async def test_docling_client_encodes_task_id_into_url_path_segment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    source_pdf: Path,
+) -> None:
+    # Security regression (CWE-116): the poll/result task id is service-returned.
+    # A crafted value with ``/`` / ``?`` / ``..`` must be percent-encoded into a
+    # single path segment so it cannot escape ``/v1/status/poll/{id}`` or append
+    # a query string to the request the client issues.
+    malicious = "../admin?x=1"
+    recorder = _Recorder(
+        terminal_status="success",
+        zip_bytes=_fake_zip_with_main_json("demo"),
+        task_id=malicious,
+    )
+    _CURRENT["recorder"] = recorder
+    _install_fake_httpx(monkeypatch)
+
+    await DoclingRawClient().download_into(tmp_path / "demo.docling_raw", source_pdf)
+
+    poll_url = recorder.get_calls[0]["url"]
+    result_url = recorder.get_calls[-1]["url"]
+    for url in (poll_url, result_url):
+        # ``..`` survives (dot is unreserved) but the separators that grant
+        # request-structure control are neutralized.
+        assert "..%2Fadmin%3Fx%3D1" in url
+        assert "/admin" not in url
+        assert "?x=1" not in url
 
 
 async def test_docling_client_ocr_lang_omitted_when_empty(

--- a/tests/parser/external/mineru/test_client.py
+++ b/tests/parser/external/mineru/test_client.py
@@ -16,6 +16,7 @@ import json
 import zipfile
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 import pytest
 
@@ -923,3 +924,148 @@ async def test_client_official_polls_through_non_terminal_states(
     await MinerURawClient().download_into(raw, src)
     assert dispatcher.polls == 3
     assert (raw / "content_list.json").is_file()
+
+
+# ---------------------------------------------------------------------------
+# Security: service-returned ids are encoded into a single URL path segment
+# (CWE-116). A crafted batch_id / task_id must not break out of the intended
+# path or append a query string to the poll/result request.
+# ---------------------------------------------------------------------------
+
+
+class _OfficialInjectionDispatcher(_Dispatcher):
+    BATCH_ID = "../batch?x=1"
+
+    def __init__(self) -> None:
+        self.seen_get_urls: list[str] = []
+
+    def post(self, url: str, **_: Any) -> _FakeResponse:
+        if url == "https://mineru.net/api/v4/file-urls/batch":
+            return _FakeResponse(
+                text=json.dumps(
+                    {
+                        "code": 0,
+                        "msg": "ok",
+                        "data": {
+                            "batch_id": self.BATCH_ID,
+                            "file_urls": ["https://upload.example/demo.pdf"],
+                        },
+                    }
+                )
+            )
+        raise AssertionError(f"unexpected POST {url}")
+
+    def put(self, url: str, **_: Any) -> _FakeResponse:
+        if url == "https://upload.example/demo.pdf":
+            return _FakeResponse(status_code=200)
+        raise AssertionError(f"unexpected PUT {url}")
+
+    def get(self, url: str, **_: Any) -> _FakeResponse:
+        self.seen_get_urls.append(url)
+        encoded = quote(self.BATCH_ID, safe="")
+        if url == f"https://mineru.net/api/v4/extract-results/batch/{encoded}":
+            return _FakeResponse(
+                text=json.dumps(
+                    {
+                        "code": 0,
+                        "data": {
+                            "extract_result": [
+                                {
+                                    "file_name": "demo.pdf",
+                                    "state": "done",
+                                    "full_zip_url": "https://download.example/full.zip",
+                                }
+                            ]
+                        },
+                    }
+                )
+            )
+        if url == "https://download.example/full.zip":
+            return _FakeResponse(
+                content=_nested_mineru_zip(),
+                headers={"Content-Type": "application/zip"},
+            )
+        raise AssertionError(f"unexpected GET {url}")
+
+
+@pytest.mark.offline
+async def test_client_official_encodes_batch_id_into_url_path_segment(
+    tmp_path: Path,
+    fake_httpx: type,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MINERU_API_MODE", "official")
+    monkeypatch.setenv("MINERU_API_TOKEN", "token-123")
+    monkeypatch.setenv("MINERU_POLL_INTERVAL_SECONDS", "0")
+    monkeypatch.setenv("MINERU_MAX_POLLS", "5")
+
+    src = tmp_path / "demo.pdf"
+    src.write_bytes(b"PDFBYTES" * 200)
+    raw = tmp_path / "demo.mineru_raw"
+    raw.mkdir()
+
+    dispatcher = _OfficialInjectionDispatcher()
+    _CURRENT.dispatcher = dispatcher
+    manifest = await MinerURawClient().download_into(raw, src)
+
+    poll_urls = [u for u in dispatcher.seen_get_urls if "extract-results" in u]
+    assert poll_urls
+    for url in poll_urls:
+        assert "..%2Fbatch%3Fx%3D1" in url
+        assert "?" not in url
+    # The manifest preserves the real, unencoded id for downstream attribution.
+    assert manifest.task_id == _OfficialInjectionDispatcher.BATCH_ID
+
+
+class _LocalInjectionDispatcher(_Dispatcher):
+    TASK_ID = "../admin?x=1"
+
+    def __init__(self) -> None:
+        self.seen_get_urls: list[str] = []
+
+    def post(self, url: str, **_: Any) -> _FakeResponse:
+        if url == "http://127.0.0.1:8000/tasks":
+            return _FakeResponse(text=json.dumps({"task_id": self.TASK_ID}))
+        raise AssertionError(f"unexpected POST {url}")
+
+    def get(self, url: str, **_: Any) -> _FakeResponse:
+        self.seen_get_urls.append(url)
+        encoded = quote(self.TASK_ID, safe="")
+        if url == f"http://127.0.0.1:8000/tasks/{encoded}":
+            return _FakeResponse(
+                text=json.dumps({"task_id": self.TASK_ID, "status": "completed"})
+            )
+        if url == f"http://127.0.0.1:8000/tasks/{encoded}/result":
+            return _FakeResponse(
+                content=_nested_mineru_zip(),
+                headers={"Content-Type": "application/zip"},
+            )
+        raise AssertionError(f"unexpected GET {url}")
+
+
+@pytest.mark.offline
+async def test_client_local_encodes_task_id_into_url_path_segments(
+    tmp_path: Path,
+    fake_httpx: type,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MINERU_API_MODE", "local")
+    monkeypatch.setenv("MINERU_LOCAL_ENDPOINT", "http://127.0.0.1:8000")
+    monkeypatch.setenv("MINERU_POLL_INTERVAL_SECONDS", "0")
+
+    src = tmp_path / "demo.pdf"
+    src.write_bytes(b"PDFBYTES" * 200)
+    raw = tmp_path / "demo.mineru_raw"
+    raw.mkdir()
+
+    dispatcher = _LocalInjectionDispatcher()
+    _CURRENT.dispatcher = dispatcher
+    manifest = await MinerURawClient().download_into(raw, src)
+
+    # Both the poll URL and the result URL must carry the encoded segment.
+    assert dispatcher.seen_get_urls
+    for url in dispatcher.seen_get_urls:
+        assert "..%2Fadmin%3Fx%3D1" in url
+        assert "?" not in url
+        assert "/admin" not in url
+    assert manifest.task_id == _LocalInjectionDispatcher.TASK_ID


### PR DESCRIPTION
## Description

This fixes a request path injection risk (CWE-116: Improper Encoding or Escaping of Output) in the external parser clients, where task identifiers returned by Docling/MinerU services are interpolated directly into URL path segments before polling or result-download requests.

The affected paths are built from a configured parser endpoint plus a service-returned task identifier:

```python
url = f"{self.endpoint}{POLL_PATH.format(task_id=task_id)}"
url = f"{self.endpoint}{RESULT_PATH.format(task_id=task_id)}"

poll_url = f"{self.official_endpoint}/api/v4/extract-results/batch/{batch_id}"
poll_url = f"{self.local_endpoint}/tasks/{task_id}"
result_url = f"{self.local_endpoint}/tasks/{task_id}/result"
```

`task_id` / `batch_id` are opaque values returned by the external parser service. If a compromised, malicious, or incompatible parser service returns a value containing URL-reserved characters such as `/`, `?`, `#`, or dot-segment-like path components, the HTTP client can interpret that value as request structure rather than a single path segment.

The concrete impact is that LightRAG may send follow-up poll/result requests to an unintended path on the configured parser service origin. This does not change the configured host by itself, but it weakens the URL path boundary between LightRAG and the external parser service.

The parser client is the correct place to enforce this boundary because it is the component that consumes service-returned task identifiers and turns them into follow-up request paths. Relying on external services to always return URL-safe segment text leaves the final request construction too permissive.

## Changes Made

- Encode external parser task identifiers before inserting them into URL path segments.
- Apply the same path-segment boundary to Docling poll/result requests, MinerU official batch polling, and MinerU local poll/result requests.
- Keep existing task status handling, result download behavior, endpoint configuration, and normal URL-safe task IDs unchanged.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

Evidence:

The issue can be reproduced at the URL-construction layer with a parser-service-controlled identifier. This local reproduction uses fake parser clients only; it does not contact a real parser service.

```text
LightRAG external parser identifier path injection evidence demo
Scope: local client URL-construction reproduction; no external service is contacted.

payload task_id: ../admin?x=1#frag
payload batch_id: ../batch?x=1#frag

Docling vulnerable follow-up URLs:
GET http://parser.local/v1/status/poll/../admin?x=1#frag?wait=1
GET http://parser.local/v1/result/../admin?x=1#frag

MinerU official vulnerable follow-up URL:
GET https://mineru.net/api/v4/extract-results/batch/../batch?x=1#frag

MinerU local vulnerable follow-up URLs:
POST http://mineru.local/tasks
GET http://mineru.local/tasks/../admin?x=1#frag
GET http://mineru.local/tasks/../admin?x=1#frag/result

Expected safe path segments:
..%2Fadmin%3Fx%3D1%23frag
..%2Fbatch%3Fx%3D1%23frag
```

A local mock parser service also shows the same issue at the HTTP request-target level. The client constructs a vulnerable MinerU official polling URL with a crafted `batch_id`; the mock server records the request path it actually receives.

```python
from http.server import BaseHTTPRequestHandler, HTTPServer
from threading import Thread
from urllib.parse import quote

import httpx

PAYLOAD = "../admin?x=1#frag"

class Recorder(BaseHTTPRequestHandler):
    seen = []

    def do_GET(self):
        Recorder.seen.append(self.path)
        self.send_response(200)
        self.end_headers()
        self.wfile.write(b"ok")

    def log_message(self, *_):
        pass

server = HTTPServer(("127.0.0.1", 0), Recorder)
Thread(target=server.serve_forever, daemon=True).start()
base = f"http://127.0.0.1:{server.server_address[1]}"

vulnerable_url = f"{base}/api/v4/extract-results/batch/{PAYLOAD}"
fixed_url = f"{base}/api/v4/extract-results/batch/{quote(PAYLOAD, safe='')}"

print("payload:", PAYLOAD)
httpx.get(vulnerable_url)
print("\n[vulnerable]")
print("client requested:", vulnerable_url)
print("server saw      :", Recorder.seen[-1])

httpx.get(fixed_url)
print("\n[fixed]")
print("client requested:", fixed_url)
print("server saw      :", Recorder.seen[-1])

server.shutdown()
```

Run locally:

```powershell
.\.venv\Scripts\python.exe .\poc_task_id_path_injection.py
```

Observed output:

```text
payload: ../admin?x=1#frag

[vulnerable]
client requested: http://127.0.0.1:55881/api/v4/extract-results/batch/../admin?x=1#frag
server saw      : /api/v4/extract-results/admin?x=1
verdict         : escaped intended /batch/{id} path segment

[fixed]
client requested: http://127.0.0.1:55881/api/v4/extract-results/batch/..%2Fadmin%3Fx%3D1%23frag
server saw      : /api/v4/extract-results/batch/..%2Fadmin%3Fx%3D1%23frag
verdict         : stayed inside intended /batch/{id} path segment
```

In the vulnerable case, `../` changes the request path and `?x=1` becomes a query string. In the fixed case, `quote(..., safe="")` keeps the crafted identifier inside the intended path segment.

The fragment is included only to show that the unencoded value is parsed as URL syntax. It is not relied on as server-side evidence because URL fragments are normally not sent in HTTP requests.

<table>
  <tr>
    <td><img src="https://img.vectorpeak.cn/obsidian/2026/05-06/20260624193148900.png?imageSlim" alt="local console PoC output" /></td>
  </tr>
</table>

Possible call chain / impact:

```text
Docling:
lightrag/parser/external/docling/client.py
  -> DoclingRawClient.download_into(...)
  -> self._submit(...)
  -> task_id from Docling response
  -> self._poll_until_done(client, task_id)
  -> GET /v1/status/poll/{task_id}?wait=N
  -> self._download_zip_bytes(client, task_id)
  -> GET /v1/result/{task_id}

MinerU official:
lightrag/parser/external/mineru/client.py
  -> MinerURawClient.download_into(...)
  -> self._download_official(...)
  -> batch_id from MinerU official upload URL response
  -> self._poll_official_batch(client, batch_id, upload_name)
  -> GET /api/v4/extract-results/batch/{batch_id}

MinerU local:
lightrag/parser/external/mineru/client.py
  -> MinerURawClient.download_into(...)
  -> self._download_local(...)
  -> task_id from MinerU local /tasks response
  -> self._poll_local_task(client, task_id)
  -> GET /tasks/{task_id}
  -> self._download_zip(client, /tasks/{task_id}/result, raw_dir)
```

This PR only changes URL path-segment encoding for parser-service identifiers. It does not change parser endpoint selection, upload payloads, polling semantics, zip extraction, caching, chunking, embedding, retrieval, or normal behavior for already URL-safe task IDs.

Validation:

- `.\.venv\Scripts\python.exe -m ruff check lightrag\parser\external\docling\client.py lightrag\parser\external\mineru\client.py` - passed
- `.\.venv\Scripts\python.exe -m pre_commit run --files lightrag\parser\external\docling\client.py lightrag\parser\external\mineru\client.py` - passed
- `.\.venv\Scripts\python.exe -m pytest tests\parser\external\docling\test_client.py tests\parser\external\mineru\test_client.py` - passed, 30 tests
- `.\.venv\Scripts\python.exe -m pytest tests\parser\external` - passed, 174 tests
- `git diff --check` - passed
- GitHub CI: `Linting and Formatting`, `Offline Tests (3.12)`, and `Offline Tests (3.14)` - passed