### PR TITLE
fix(webui): restore edges after a drag that ends without camera animation

### DIFF
--- a/lightrag_webui/src/components/graph/GraphControl.tsx
+++ b/lightrag_webui/src/components/graph/GraphControl.tsx
@@ -172,11 +172,18 @@ const GraphControl = ({ disableHoverEffect }: { disableHoverEffect?: boolean }) 
    * interaction (the "edges vanish after a small pan and don't come back" bug;
    * a stage click doesn't help because it isn't a drag, but a hover re-renders).
    *
-   * Watch the camera's `updated` event and, once it goes quiet, refresh ONLY
-   * when sigma is truly idle. We mirror sigma's exact `moving` condition
-   * (camera.isAnimated() || mouse.isMoving || draggedEvents || wheelDirection);
-   * if any is still set when the timer fires, we re-arm and wait, so the refresh
-   * always lands on a frame where edges are actually drawn.
+   * Watch the camera's `updated` event AND the mouse captor's `mouseup`, and
+   * once things go quiet, refresh ONLY when sigma is truly idle. We mirror
+   * sigma's exact `moving` condition (camera.isAnimated() || mouse.isMoving ||
+   * draggedEvents || wheelDirection); if any is still set when the timer fires,
+   * we re-arm and wait, so the refresh always lands on a frame where edges are
+   * actually drawn. The mouseup trigger only fires when the release ends a drag
+   * (draggedEvents > 0): a plain click never hides edges, so refreshing on it
+   * would be a wasted full re-indexation. Between them, the camera path covers
+   * every camera-animation-driven move (pan inertia, zoom, moveToSelectedNode)
+   * and the mouseup path covers drags with no post-release animation, so any
+   * selection-change render that lands on a "moving" frame is recovered by
+   * whichever of the two is concurrently active.
    */
   useEffect(() => {
     if (!sigma) return
@@ -203,10 +210,19 @@ const GraphControl = ({ disableHoverEffect }: { disableHoverEffect?: boolean }) 
         }
       }, 80)
     }
+    // Only let a *drag* release re-trigger the idle refresh. A plain click never
+    // hides edges (no movement), so refreshing on it is pure wasted full
+    // re-indexation. draggedEvents is still set at this point — sigma resets it
+    // in its own post-mouseup setTimeout(0), which runs after this handler.
+    const refreshOnDragEnd = () => {
+      if (mouse.draggedEvents > 0) refreshWhenIdle()
+    }
     camera.on('updated', refreshWhenIdle)
+    mouse.on('mouseup', refreshOnDragEnd)
     return () => {
       if (timer !== null) window.clearTimeout(timer)
       camera.removeListener('updated', refreshWhenIdle)
+      mouse.removeListener('mouseup', refreshOnDragEnd)
     }
   }, [sigma])
 


### PR DESCRIPTION
## Problem

With `hideEdgesOnMove`, edges are skipped while the view is moving. The existing recovery (commit 9456ae6) watches the camera's `updated` event and re-refreshes once sigma is truly idle — but that only fires for **camera-animation-driven** moves (pan inertia, zoom, `moveToSelectedNode`).

A drag that settles **without inertia** emits no post-release camera `updated` event, so its final render can land on a frame sigma still considers "moving" and leave **all edges hidden until the next interaction**.

## Fix

Also listen to the mouse captor's `mouseup`, guarded on `draggedEvents > 0`:

- Only an actual **drag** re-triggers the idle refresh; a **plain click** never hides edges, so refreshing on it would be a wasted full re-indexation (`sigma.refresh()` rebuilds all node/edge indices).
- `draggedEvents` is still set at `mouseup` time — sigma only resets it in its own post-mouseup `setTimeout(0)`, which runs after this handler.
- The existing idle-guard (mirror sigma's exact `moving` condition and re-arm until quiet) still ensures the refresh lands on a frame where edges are actually drawn.

Together the two paths cover all "moving" sources: the **camera** path handles every camera-animation move, the **mouseup** path handles drags with no post-release animation.

## Testing

Manual smoke test in the graph viewer:
1. Pan with inertia, then click empty stage to deselect — edges remain visible.
2. Click a node to select (triggers center animation) — edges restore.
3. Slow drag that ends without inertia — edges reappear on their own without needing another click/hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)