### PR TITLE
fix(api): remove parsed outputs during document clear

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -3212,6 +3212,20 @@ def create_document_routes(
                     except Exception as e:
                         logger.error(f"Error deleting file {file_path}: {str(e)}")
                         file_errors_count += 1
+            parsed_dir = doc_manager.input_dir / PARSED_DIR_NAME
+            if parsed_dir.is_dir():
+                for artifact_path in parsed_dir.iterdir():
+                    try:
+                        if artifact_path.is_dir() and not artifact_path.is_symlink():
+                            shutil.rmtree(artifact_path)
+                        else:
+                            artifact_path.unlink()
+                        deleted_files_count += 1
+                    except Exception as e:
+                        logger.error(
+                            f"Error deleting parsed artifact {artifact_path}: {str(e)}"
+                        )
+                        file_errors_count += 1
 
             # Log file deletion results
             if "history_messages" in pipeline_status:

--- a/tests/api/routes/test_document_routes_docx_archive.py
+++ b/tests/api/routes/test_document_routes_docx_archive.py
@@ -2168,3 +2168,46 @@ async def test_clear_documents_succeeds_when_all_drops_succeed(tmp_path):
     response = await _clear_endpoint(router)()
 
     assert response.status == "success"
+
+
+async def test_clear_documents_removes_parsed_artifacts_but_preserves_user_subdirs(
+    tmp_path,
+):
+    """Full clear removes LightRAG-managed parsed artifacts without deleting
+    unrelated user-created subdirectories under the input directory.
+    """
+    import importlib
+
+    root_file = tmp_path / "demo.pdf"
+    root_file.write_bytes(b"source")
+    user_file = tmp_path / "user_notes" / "keep.txt"
+    user_file.parent.mkdir()
+    user_file.write_text("keep", encoding="utf-8")
+
+    parsed_dir = tmp_path / PARSED_DIR_NAME
+    parsed_dir.mkdir()
+    (parsed_dir / "demo.pdf").write_bytes(b"archived source")
+    sidecar_dir = parsed_dir / "demo.pdf.parsed"
+    sidecar_dir.mkdir()
+    (sidecar_dir / "demo.blocks.jsonl").write_text("{}\n", encoding="utf-8")
+    mineru_raw = parsed_dir / "demo.pdf.mineru_raw"
+    mineru_raw.mkdir()
+    (mineru_raw / "content_list.json").write_text("[]", encoding="utf-8")
+    docling_raw = parsed_dir / "demo.pdf.docling_raw"
+    docling_raw.mkdir()
+    (docling_raw / "demo.json").write_text("{}", encoding="utf-8")
+
+    doc_manager = DocumentManager(str(tmp_path))
+    rag = _ClearRag(chunks_drop_result={"status": "success", "message": "data dropped"})
+
+    shared_storage = importlib.import_module("lightrag.kg.shared_storage")
+    await shared_storage.initialize_pipeline_status(workspace=rag.workspace)
+
+    router = create_document_routes(rag, doc_manager)
+    response = await _clear_endpoint(router)()
+
+    assert response.status == "success"
+    assert not root_file.exists()
+    assert parsed_dir.is_dir()
+    assert list(parsed_dir.iterdir()) == []
+    assert user_file.read_text(encoding="utf-8") == "keep"


### PR DESCRIPTION
## Description

This fixes an incomplete filesystem cleanup path in `DELETE /documents`.

`DELETE /documents` is the full-clear API for removing documents from a LightRAG workspace. From a user's perspective, once this operation succeeds, the document records and the local files managed by LightRAG for those documents should no longer remain available through the workspace. The endpoint already drops the document-related storages and removes regular files directly under the configured input directory.

However, LightRAG also creates and manages parsed output under `INPUT_DIR/__parsed__/`. That directory can contain archived source files and parser-generated artifacts such as sidecar `*.parsed/` directories, MinerU raw bundles, and Docling raw bundles. The current cleanup loop only deletes regular files at the input directory root:

```python
for file_path in doc_manager.input_dir.glob("*"):
    if file_path.is_file():
        file_path.unlink()
```

Because subdirectories are skipped, `__parsed__/` can survive a successful document clear. That makes the API result misleading: storage records are cleared, but local parsed copies or intermediate artifacts for the cleared documents can remain on disk.

This is a data cleanup / privacy residual risk rather than a parsing or retrieval behavior change. The cleanup boundary should stay narrow, so this PR clears the contents of `doc_manager.input_dir / PARSED_DIR_NAME` while preserving unrelated user-created subdirectories such as `user_notes/` or `manual_uploads/`.

## Changes Made

- Continue deleting regular files directly under `doc_manager.input_dir`.
- Also clear the contents of the LightRAG-managed `__parsed__/` directory.
- Preserve the `__parsed__/` directory itself so later parsing flows can reuse the expected directory layout.
- Preserve unrelated user-created subdirectories under the input directory.
- Add focused coverage for parsed-output cleanup and user-subdirectory preservation.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Evidence:

The issue can be reproduced at the local filesystem cleanup layer. This local console reproduction creates a temporary input directory, applies the previous cleanup behavior to one copy, and applies the fixed cleanup behavior to another copy. It does not start the API server.

```text
LightRAG clear_documents parsed output cleanup evidence demo
Scope: local filesystem reproduction; no API server is started.
demo root: C:\Users\MiaoXing\AppData\Local\Temp\lightrag-clear-documents-evidence

Initial demo tree:
  __parsed__\
  __parsed__\demo.pdf
  __parsed__\demo.pdf.docling_raw\
  __parsed__\demo.pdf.docling_raw\demo.json
  __parsed__\demo.pdf.mineru_raw\
  __parsed__\demo.pdf.mineru_raw\content_list.json
  __parsed__\demo.pdf.parsed\
  __parsed__\demo.pdf.parsed\demo.blocks.jsonl
  demo.pdf
  user_notes\
  user_notes\keep.txt

Before fix result (root files deleted, parsed outputs remain):
  __parsed__\
  __parsed__\demo.pdf
  __parsed__\demo.pdf.docling_raw\
  __parsed__\demo.pdf.docling_raw\demo.json
  __parsed__\demo.pdf.mineru_raw\
  __parsed__\demo.pdf.mineru_raw\content_list.json
  __parsed__\demo.pdf.parsed\
  __parsed__\demo.pdf.parsed\demo.blocks.jsonl
  user_notes\
  user_notes\keep.txt
before fix parsed outputs remain? True
before fix user file preserved? True

After fix result (__parsed__ contents removed, user dirs preserved):
  __parsed__\
  user_notes\
  user_notes\keep.txt
after fix __parsed__ dir exists? True
after fix parsed outputs remain? False
after fix user file preserved? True
```

<table>
  <tr>
    <td><img src="https://img.vectorpeak.cn/obsidian/2026/05-06/20260624212703877.png?imageSlim" alt="clear documents parsed output cleanup evidence" /></td>
  </tr>
</table>

The focused test added in this PR covers the same boundary: root input files are removed, LightRAG-managed `__parsed__/` contents are removed, the `__parsed__/` directory remains available, and an unrelated `user_notes/keep.txt` file is preserved.

Possible call chain / impact:

```text
DELETE /documents
  -> clear_documents()
  -> drop document, chunk, graph, vector, and doc_status storages
  -> delete regular files directly under doc_manager.input_dir
  -> previous behavior left doc_manager.input_dir / "__parsed__" untouched

Document flows that can populate __parsed__:
  -> archived source files moved under INPUT_DIR/__parsed__/
  -> sidecar output directories: <source>.parsed/
  -> MinerU raw bundles: <source>.mineru_raw/
  -> Docling raw bundles: <source>.docling_raw/
```

This PR only changes the full-clear filesystem cleanup boundary for LightRAG-managed parsed artifacts. It does not change upload behavior, document parsing, indexing, per-document deletion, retrieval, storage dropping, or unrelated user-created directories under the input directory.

Validation:

- `.\\.venv\\Scripts\\python.exe -m pytest tests\\api\\routes\\test_document_routes_docx_archive.py -k "clear_documents"` - passed, 5 tests
- `.\\.venv\\Scripts\\python.exe -m ruff check lightrag\\api\\routers\\document_routes.py tests\\api\\routes\\test_document_routes_docx_archive.py` - passed
- `.\\.venv\\Scripts\\python.exe -m pre_commit run --files lightrag\\api\\routers\\document_routes.py tests\\api\\routes\\test_document_routes_docx_archive.py` - passed
- `git diff --check` - passed
