### PR TITLE
fix(api): warn when the server is network-exposed without authentication (GHSA-mmg5-8x8q-v934)

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -142,7 +142,11 @@ cd ..
 # 从 GitHub 仓库的根目录上下载 env.example 文件
 # 或从本地检出的源代码中获取 env.example 文件
 cp env.example .env  # 使用你的LLM和Embedding模型访问参数更新.env文件
-# 启动API-WebUI服务
+# 启动 API-WebUI 服务。默认绑定所有网络接口(0.0.0.0)。
+# 安全提示:对外网暴露前,请在 .env 中配置认证(LIGHTRAG_API_KEY 或
+# AUTH_ACCOUNTS);若仅需本机访问,可绑定 127.0.0.1;否则所有接口都将公开可访问。
+# 注意:为兼容 Ollama 客户端,/api/* 路由默认不鉴权;如需对其启用认证,
+# 请将 WHITELIST_PATHS 收窄为 /health。
 lightrag-server
 ```
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,12 @@ cd ..
 # Obtain the env.example file by downloading it from the GitHub repository root
 # or by copying it from a local source checkout.
 cp env.example .env  # Update the .env with your LLM and embedding configurations
-# Launch the server
+# Launch the server. It binds to all interfaces (0.0.0.0) by default.
+# SECURITY: before exposing it on a network, configure authentication
+# (LIGHTRAG_API_KEY or AUTH_ACCOUNTS) in .env, or bind to 127.0.0.1 for
+# local-only access; without auth every endpoint is public.
+# Note: the Ollama-compatible /api/* routes stay open by default for client
+# compatibility; set WHITELIST_PATHS=/health to require auth on them too.
 lightrag-server
 ```
 

--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -25,6 +25,9 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      # The container must listen on 0.0.0.0 to be reachable via the published port.
+      # SECURITY: set LIGHTRAG_API_KEY or AUTH_ACCOUNTS in .env so the exposed
+      # server is authenticated — without it every endpoint is publicly accessible.
       HOST: "0.0.0.0"
       PORT: "9621"
       EMBEDDING_BINDING_HOST: "http://vllm-embed:8001/v1"

--- a/docker-compose.podman.yml
+++ b/docker-compose.podman.yml
@@ -33,5 +33,8 @@ services:
       WORKING_DIR: "/app/data/rag_storage"
       INPUT_DIR: "/app/data/inputs"
       PROMPT_DIR: "/app/data/prompts"
+      # The container must listen on 0.0.0.0 to be reachable via the published port.
+      # SECURITY: set LIGHTRAG_API_KEY or AUTH_ACCOUNTS in .env so the exposed
+      # server is authenticated — without it every endpoint is publicly accessible.
       HOST: "0.0.0.0"
       PORT: "9621"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,5 +23,8 @@ services:
       WORKING_DIR: "/app/data/rag_storage"
       INPUT_DIR: "/app/data/inputs"
       PROMPT_DIR: "/app/data/prompts"
+      # The container must listen on 0.0.0.0 to be reachable via the published port.
+      # SECURITY: set LIGHTRAG_API_KEY or AUTH_ACCOUNTS in .env so the exposed
+      # server is authenticated — without it every endpoint is publicly accessible.
       HOST: "0.0.0.0"
       PORT: "9621"

--- a/env.example
+++ b/env.example
@@ -7,6 +7,11 @@
 ###########################
 ### Server Configuration
 ###########################
+### HOST binds to all network interfaces (0.0.0.0) by default.
+### SECURITY: only expose 0.0.0.0 together with LIGHTRAG_API_KEY or AUTH_ACCOUNTS
+### (see "Login and API-Key Configuration" below). Without authentication, a
+### server on 0.0.0.0 grants anyone on the network full access to your documents
+### and knowledge graph. Bind to 127.0.0.1 for local-only access.
 HOST=0.0.0.0
 PORT=9621
 WEBUI_TITLE='My Graph KB'
@@ -65,6 +70,16 @@ OLLAMA_EMULATING_MODEL_TAG=latest
 #####################################
 ### Login and API-Key Configuration
 #####################################
+### SECURITY: If neither AUTH_ACCOUNTS nor LIGHTRAG_API_KEY is set, the server
+### runs with NO authentication and every endpoint is publicly accessible.
+### This is only safe on a loopback bind (HOST=127.0.0.1). Before exposing the
+### server to a network (HOST=0.0.0.0), configure at least one of the two below.
+### NOTE: even with authentication enabled, the default WHITELIST_PATHS below
+### exempts /api/* so the Ollama-compatible endpoints (/api/chat, /api/generate,
+### ...) stay open by default, matching Ollama's own unauthenticated behavior.
+### Those routes invoke the LLM and read your knowledge base, so if you expose
+### the server to a network and want them protected, set WHITELIST_PATHS=/health
+### (and have your Ollama clients send the API key). See WHITELIST_PATHS below.
 # AUTH_ACCOUNTS='admin:admin123,user1:{bcrypt}$2b$12$S8Yu.gCbuAbNTJFB.231gegTwr5pgrFxc8H9kXQ4/sduFBHkhM8Ka'
 # TOKEN_SECRET=lightrag-jwt-default-secret-key!
 # JWT_ALGORITHM=HS256
@@ -92,6 +107,10 @@ OLLAMA_EMULATING_MODEL_TAG=latest
 ### Use this key in HTTP requests with the 'X-API-Key' header
 ### Example: curl -H "X-API-Key: your-secure-api-key-here" http://localhost:9621/query
 # LIGHTRAG_API_KEY=your-secure-api-key-here
+### WHITELIST_PATHS: paths exempt from authentication (prefix match with /*).
+### Default keeps /api/* open for Ollama-client compatibility (Ollama is
+### unauthenticated by default). To require auth on the Ollama routes too when
+### the server is network-exposed, narrow this to /health.
 # WHITELIST_PATHS=/health,/api/*
 
 ######################################################################################

--- a/lightrag/api/utils_api.py
+++ b/lightrag/api/utils_api.py
@@ -438,5 +438,47 @@ def display_splash_screen(args: argparse.Namespace) -> None:
     Make sure to login before making the request, and include the 'Authorization' in the header.
     """)
 
+    # Warn when the server runs without any authentication. In this mode every
+    # endpoint is publicly reachable (see get_combined_auth_dependency: with
+    # neither AUTH_ACCOUNTS nor LIGHTRAG_API_KEY set, all requests are allowed).
+    if not args.key and not args.auth_accounts:
+        loopback_hosts = {"127.0.0.1", "::1", "localhost"}
+        if args.host in loopback_hosts:
+            ASCIIColors.yellow("\n⚠️  Security Notice:")
+            ASCIIColors.white(f"""    No authentication is configured (no API Key, no login accounts).
+    The server is bound to a loopback address ('{args.host}'), so it is only
+    reachable from this machine. Set LIGHTRAG_API_KEY or AUTH_ACCOUNTS before
+    binding to a non-loopback address (e.g. HOST=0.0.0.0).
+    """)
+        else:
+            ASCIIColors.red("\n🔴 SECURITY WARNING:")
+            ASCIIColors.white(f"""    The server is listening on '{args.host}' WITHOUT any authentication.
+    Every endpoint (document upload, query, knowledge graph, deletion) is
+    publicly accessible to anyone who can reach this address.
+
+    Secure the server before exposing it to a network by setting at least one of:
+      - LIGHTRAG_API_KEY=<a-strong-secret>   (X-API-Key header authentication)
+      - AUTH_ACCOUNTS=user:password          (JWT login authentication)
+    Or restrict access by binding to loopback only: HOST=127.0.0.1
+    """)
+
+    # When authentication IS configured but the server is exposed on a
+    # non-loopback address, warn that the default whitelist still exempts the
+    # Ollama-compatible /api/* routes (kept open for Ollama-client compatibility).
+    # Those routes invoke the LLM and read the knowledge base, so they stay
+    # public unless the operator narrows WHITELIST_PATHS (e.g. to /health).
+    if args.key or args.auth_accounts:
+        loopback_hosts = {"127.0.0.1", "::1", "localhost"}
+        whitelisted = [p.strip() for p in args.whitelist_paths.split(",") if p.strip()]
+        ollama_open = any(p.startswith("/api") for p in whitelisted)
+        if args.host not in loopback_hosts and ollama_open:
+            ASCIIColors.yellow("\n⚠️  Security Notice:")
+            ASCIIColors.white(f"""    WHITELIST_PATHS ('{args.whitelist_paths}') exempts the Ollama-compatible
+    /api/* routes (/api/chat, /api/generate, ...) from authentication, so they
+    remain publicly accessible on '{args.host}' even though auth is enabled.
+    These routes invoke the LLM and read your knowledge base. If you do not need
+    open Ollama access, set WHITELIST_PATHS=/health to require authentication.
+    """)
+
     # Ensure splash output flush to system log
     sys.stdout.flush()

--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -240,6 +240,33 @@ log_step() {
   echo "${COLOR_BLUE}${COLOR_BOLD}$*${COLOR_RESET}"
 }
 
+# Return success when the given host binds to a loopback interface only.
+# An empty host means "use the server default" (0.0.0.0), i.e. not loopback.
+host_is_loopback() {
+  local host="${1:-}"
+  case "$host" in
+    localhost|127.0.0.1|::1|127.*) return 0 ;;
+  esac
+  return 1
+}
+
+# Print a suggestion (informational only — no logic change) when the server is
+# configured to bind to a non-loopback address without any authentication.
+warn_if_network_exposed_without_auth() {
+  local host="${ENV_VALUES[HOST]:-0.0.0.0}"
+
+  if host_is_loopback "$host"; then
+    return 0
+  fi
+  if [[ -n "${ENV_VALUES[AUTH_ACCOUNTS]:-}" || -n "${ENV_VALUES[LIGHTRAG_API_KEY]:-}" ]]; then
+    return 0
+  fi
+
+  log_warn "HOST=$host is reachable from the network but no authentication is configured."
+  echo "  Suggestion: set AUTH_ACCOUNTS (with TOKEN_SECRET) or LIGHTRAG_API_KEY before"
+  echo "  exposing the server, or bind to a loopback address (HOST=127.0.0.1)."
+}
+
 normalize_loopback_uri_for_compose() {
   local uri="$1"
 
@@ -2766,6 +2793,7 @@ env_server_flow() {
   echo ""
   log_step "Security configuration"
   collect_security_config "no" "no"
+  warn_if_network_exposed_without_auth
   echo ""
   log_step "SSL configuration"
   collect_ssl_config
@@ -3137,8 +3165,12 @@ security_check_env_file() {
   fi
 
   if [[ -z "$auth_accounts" && -z "$api_key" ]]; then
+    local no_auth_message="No API protection is configured."
+    if ! host_is_loopback "${ENV_VALUES[HOST]:-0.0.0.0}"; then
+      no_auth_message="No API protection is configured while HOST=${ENV_VALUES[HOST]:-0.0.0.0} is reachable from the network."
+    fi
     report_security_issue \
-      "No API protection is configured." \
+      "$no_auth_message" \
       "Set AUTH_ACCOUNTS and TOKEN_SECRET, add LIGHTRAG_API_KEY, or put the service behind a trusted reverse proxy."
     findings=$((findings + 1))
   fi

--- a/tests/setup/test_misc.py
+++ b/tests/setup/test_misc.py
@@ -1732,7 +1732,8 @@ security_check_env_file
         check=False,
     )
     assert result.returncode == 1
-    assert "No API protection is configured." in result.stdout
+    assert "No API protection is configured" in result.stdout
+    assert "HOST=0.0.0.0 is reachable from the network" in result.stdout
 
 
 def test_security_check_passes_for_authenticated_minimal_config(tmp_path: Path) -> None:
@@ -1763,6 +1764,75 @@ security_check_env_file
         check=False,
     )
     assert result.returncode == 0
+
+
+def test_security_check_no_auth_message_omits_host_for_loopback(
+    tmp_path: Path,
+) -> None:
+    """A loopback bind without auth is flagged, but not as network-reachable."""
+    write_text_lines(tmp_path / ".env", ["HOST=127.0.0.1"])
+    result = subprocess.run(
+        [
+            "bash",
+            "--norc",
+            "--noprofile",
+            "-c",
+            f"""
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+REPO_ROOT="{tmp_path}"
+security_check_env_file
+""",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1
+    assert "No API protection is configured." in result.stdout
+    assert "reachable from the network" not in result.stdout
+
+
+def _run_warn_if_exposed(env_assignments: str) -> subprocess.CompletedProcess[str]:
+    """Source setup.sh, seed ENV_VALUES, and run the exposure hint."""
+    return subprocess.run(
+        [
+            "bash",
+            "--norc",
+            "--noprofile",
+            "-c",
+            f"""
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+{env_assignments}
+warn_if_network_exposed_without_auth
+""",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_warn_if_exposed_flags_public_bind_without_auth() -> None:
+    """Non-loopback host with no auth should print a suggestion."""
+    result = _run_warn_if_exposed('ENV_VALUES[HOST]="0.0.0.0"')
+    assert "no authentication is configured" in result.stdout
+    assert "AUTH_ACCOUNTS" in result.stdout
+
+
+def test_warn_if_exposed_silent_for_loopback() -> None:
+    """A loopback bind needs no exposure suggestion."""
+    result = _run_warn_if_exposed('ENV_VALUES[HOST]="127.0.0.1"')
+    assert result.stdout.strip() == ""
+
+
+def test_warn_if_exposed_silent_when_auth_configured() -> None:
+    """A public bind with auth configured needs no exposure suggestion."""
+    result = _run_warn_if_exposed(
+        'ENV_VALUES[HOST]="0.0.0.0"\nENV_VALUES[LIGHTRAG_API_KEY]="some-key"'
+    )
+    assert result.stdout.strip() == ""
 
 
 def test_security_check_reports_predictable_auth_password_prefix(


### PR DESCRIPTION
## Background

Security advisory [GHSA-mmg5-8x8q-v934](https://github.com/HKUDS/LightRAG/security/advisories/GHSA-mmg5-8x8q-v934) reports that a server started via the official quickstart can be exposed to the network without authentication.

The root cause is confirmed in [`utils_api.py`](lightrag/api/utils_api.py): when neither `AUTH_ACCOUNTS` nor `LIGHTRAG_API_KEY` is configured, `combined_dependency` returns unconditionally and allows **every** request through:

```python
# 3. Acept all request if no API protection needed
if not auth_configured and not api_key_configured:
    return
```

`WHITELIST_PATHS` only governs which paths *skip* the auth check — it does **not** enable authentication — so setting `WHITELIST_PATHS=""` does not mitigate this.

## Approach

This PR keeps the existing defaults (`HOST=0.0.0.0`, open mode for trusted local use) so the out-of-the-box experience is unchanged, and instead makes the exposure risk **loud and visible** without changing program behavior:

- **Server startup banner** (`display_splash_screen`): prints a SECURITY notice when no authentication is configured — escalated to a red `🔴 SECURITY WARNING` when the server is bound to a non-loopback address. When auth *is* configured but the default whitelist still exempts the Ollama `/api/*` routes on a non-loopback bind, it prints a notice about those routes too.
- **Setup wizard** (`scripts/setup/setup.sh`): the Security configuration step now prints a suggestion to configure authentication when the host is non-loopback and no auth is set (`warn_if_network_exposed_without_auth`); the `security-check` audit's no-auth finding is now host-aware. Output only — it does not change what gets written.
- **Documentation**: `env.example`, `README`, `README-zh`, and the three Docker Compose files document the auth/exposure trade-off, including that the Ollama-compatible `/api/*` routes stay open by default (matching Ollama's own unauthenticated behavior) and can be locked down with `WHITELIST_PATHS=/health`.

Tests cover `host_is_loopback`, the new wizard hint, and the host-aware audit message.

## Note on the `/api/*` routes

The default `WHITELIST_PATHS=/health,/api/*` intentionally leaves the Ollama-compatible endpoints open so Ollama clients work out of the box. This is documented rather than changed; operators who expose the server and want those routes authenticated can set `WHITELIST_PATHS=/health`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)