### PR TITLE
🔒 fix(api): gate /health configuration disclosure behind authentication (#3294)

### DIFF
--- a/docs/LightRAG-API-Server-zh.md
+++ b/docs/LightRAG-API-Server-zh.md
@@ -598,7 +598,7 @@ LIGHTRAG_API_KEY=your-secure-api-key-here
 WHITELIST_PATHS=/health,/api/*
 ```
 
-> 健康检查和 Ollama 模拟端点默认不进行 API 密钥检查。为了安全原因，如果不需要提供Ollama服务，应该把`/api/*`从WHITELIST_PATHS中移除。
+> 健康检查和 Ollama 模拟端点默认不进行 API 密钥检查。为了安全原因，如果不需要提供Ollama服务，应该把`/api/*`从WHITELIST_PATHS中移除。`/health` 仍保留在白名单中用作存活探针，但其完整配置仅返回给已认证调用方——未认证请求只会得到存活信号。
 
 API Key使用的请求头是 `X-API-Key` 。以下是使用API访问LightRAG Server的一个例子：
 
@@ -1130,7 +1130,7 @@ notes.[-R].md
 4. 使用查询端点查询系统
 5. 如果在输入目录中放入新文件，触发文档扫描
 
-`/health` 端点会返回运行状态和关键配置，包括角色 LLM 配置、LLM/embedding/rerank 队列状态、workspace/storage workspace 映射、VLM 是否启用、rerank 是否启用，以及流水线 busy/scanning/destructive 状态。
+`/health` 端点会返回运行状态和关键配置，包括角色 LLM 配置、LLM/embedding/rerank 队列状态、workspace/storage workspace 映射、VLM 是否启用、rerank 是否启用，以及流水线 busy/scanning/destructive 状态。该端点始终返回 HTTP 200 以便用作存活探针，但配置与运行诊断信息**仅返回给已认证调用方**（携带有效 JWT 或 `X-API-Key`）。未认证调用方只会收到存活信号（`status`、`auth_mode`、`core_version`、`api_version`、`pipeline_busy`/`pipeline_active`，以及 WebUI 标题/可用性等字段——这些要么同样由未认证的 `/auth-status` 端点公开，要么只是布尔值）。需携带凭证才能取得完整内容，例如 `curl -H "X-API-Key: <key>" http://localhost:9621/health`。
 
 ## 异步文档索引与进度跟踪
 

--- a/docs/LightRAG-API-Server.md
+++ b/docs/LightRAG-API-Server.md
@@ -598,7 +598,7 @@ LIGHTRAG_API_KEY=your-secure-api-key-here
 WHITELIST_PATHS=/health,/api/*
 ```
 
-> Health check and Ollama emulation endpoints are excluded from API Key check by default. For security reasons, remove `/api/*` from `WHITELIST_PATHS` if the Ollama service is not required.
+> Health check and Ollama emulation endpoints are excluded from API Key check by default. For security reasons, remove `/api/*` from `WHITELIST_PATHS` if the Ollama service is not required. `/health` stays whitelisted as a liveness probe but only returns its full configuration to authenticated callers — unauthenticated requests get liveness signals only.
 
 The API key is passed using the request header `X-API-Key`. Below is an example of accessing the LightRAG Server via API:
 
@@ -1130,7 +1130,7 @@ You can test the API endpoints using the provided curl commands or through the S
 4. Query the system using the query endpoints
 5. Trigger document scan if new files are put into the inputs directory
 
-The `/health` endpoint reports operational state and selected configuration, including role LLM configuration, LLM/embedding/rerank queue status, workspace/storage workspace mapping, VLM enablement, rerank enablement, and pipeline busy/scanning/destructive status.
+The `/health` endpoint reports operational state and selected configuration, including role LLM configuration, LLM/embedding/rerank queue status, workspace/storage workspace mapping, VLM enablement, rerank enablement, and pipeline busy/scanning/destructive status. It always returns HTTP 200 so it stays usable as a liveness probe, but the configuration and operational diagnostics are returned **only to authenticated callers** (valid JWT or `X-API-Key`). Unauthenticated callers receive only liveness signals (`status`, `auth_mode`, `core_version`, `api_version`, `pipeline_busy`/`pipeline_active`, and the WebUI title/availability fields — all of which are also exposed by the unauthenticated `/auth-status` endpoint or are plain booleans). Provide credentials to retrieve the full payload, e.g. `curl -H "X-API-Key: <key>" http://localhost:9621/health`.
 
 ## Asynchronous Document Indexing with Progress Tracking
 

--- a/env.example
+++ b/env.example
@@ -113,6 +113,11 @@ OLLAMA_EMULATING_MODEL_TAG=latest
 ### Default keeps /api/* open for Ollama-client compatibility (Ollama is
 ### unauthenticated by default). To require auth on the Ollama routes too when
 ### the server is network-exposed, narrow this to /health.
+### NOTE: /health stays whitelisted as a liveness probe, but it no longer leaks
+### configuration to unauthenticated callers: anonymous requests get only
+### liveness signals (status/versions/auth_mode/pipeline_busy), while the full
+### runtime configuration is returned only to authenticated callers (valid JWT
+### or X-API-Key).
 # WHITELIST_PATHS=/health,/api/*
 
 ######################################################################################

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -28,6 +28,7 @@ from contextlib import asynccontextmanager
 from dotenv import load_dotenv
 from lightrag.api.utils_api import (
     get_combined_auth_dependency,
+    get_auth_status_dependency,
     display_splash_screen,
     check_env_file,
 )
@@ -1412,6 +1413,9 @@ def create_app(args):
 
     # Create combined auth dependency for all endpoints
     combined_auth = get_combined_auth_dependency(api_key)
+    # Non-enforcing dependency: reports whether the caller is authenticated so
+    # /health can stay a public liveness probe while gating sensitive config.
+    auth_status = get_auth_status_dependency(api_key)
 
     def get_workspace_from_request(request: Request) -> str | None:
         """
@@ -2220,8 +2224,13 @@ def create_app(args):
         "/health",
         dependencies=[Depends(combined_auth)],
         summary="Get system health and configuration status",
-        description="Returns comprehensive system status including WebUI availability, configuration, and operational metrics",
-        response_description="System health status with configuration details",
+        description=(
+            "Always reachable as a liveness probe (HTTP 200). Unauthenticated "
+            "callers receive only liveness signals (status, versions, auth_mode, "
+            "pipeline_busy). The full configuration and operational metrics are "
+            "returned only to authenticated callers (valid JWT or X-API-Key)."
+        ),
+        response_description="System health status; configuration included only when authenticated",
         responses={
             200: {
                 "description": "Successful response with system status",
@@ -2272,8 +2281,13 @@ def create_app(args):
             }
         },
     )
-    async def get_status(request: Request):
-        """Get current system status including WebUI availability"""
+    async def get_status(request: Request, authenticated: bool = Depends(auth_status)):
+        """Get current system status including WebUI availability.
+
+        Stays a public liveness probe: unauthenticated callers receive only
+        liveness signals; sensitive configuration is returned only when the
+        caller is authenticated (see get_auth_status_dependency).
+        """
         try:
             workspace = get_workspace_from_request(request)
             default_workspace = get_default_workspace()
@@ -2303,81 +2317,104 @@ def create_app(args):
             else:
                 auth_mode = "enabled"
 
+            # Liveness payload — always returned, even to unauthenticated
+            # callers, so /health stays a usable liveness probe (HTTP 200).
+            # Every field here is either a pure liveness signal or is already
+            # exposed by the unauthenticated /auth-status endpoint, so it leaks
+            # nothing new.
+            status_data = {
+                "status": "healthy",
+                "auth_mode": auth_mode,
+                "core_version": core_version,
+                "api_version": api_version_display,
+                "webui_available": webui_assets_exist,
+                "webui_title": webui_title,
+                "webui_description": webui_description,
+                "pipeline_busy": pipeline_busy,
+                "pipeline_active": pipeline_active,
+            }
+
+            # Sensitive runtime configuration and operational diagnostics
+            # (filesystem paths, LLM/embedding provider + model + host, storage
+            # backends, queue status, keyed locks, ...) are revealed only to
+            # authenticated callers — see Issue #3294. The skipped queue-status
+            # and keyed-lock-cleanup calls also keep unauthenticated probes cheap.
+            if not authenticated:
+                return status_data
+
             # Cleanup expired keyed locks and get status
             keyed_lock_info = cleanup_keyed_lock()
 
-            return {
-                "status": "healthy",
-                "webui_available": webui_assets_exist,
-                "working_directory": str(args.working_dir),
-                "input_directory": str(args.input_dir),
-                "configuration": {
-                    # LLM configuration binding/host address (if applicable)/model (if applicable)
-                    "llm_binding": args.llm_binding,
-                    "llm_binding_host": args.llm_binding_host,
-                    "llm_model": args.llm_model,
-                    # embedding model configuration binding/host address (if applicable)/model (if applicable)
-                    "embedding_binding": args.embedding_binding,
-                    "embedding_binding_host": args.embedding_binding_host,
-                    "embedding_model": args.embedding_model,
-                    "summary_max_tokens": args.summary_max_tokens,
-                    "summary_context_size": args.summary_context_size,
-                    "kv_storage": args.kv_storage,
-                    "doc_status_storage": args.doc_status_storage,
-                    "graph_storage": args.graph_storage,
-                    "vector_storage": args.vector_storage,
-                    "enable_llm_cache_for_extract": args.enable_llm_cache_for_extract,
-                    "enable_llm_cache": args.enable_llm_cache,
-                    "vlm_process_enable": args.vlm_process_enable,
-                    "workspace": default_workspace,
-                    "storage_workspaces": _get_storage_workspaces(rag),
-                    "max_graph_nodes": args.max_graph_nodes,
-                    # Rerank configuration
-                    "enable_rerank": rerank_model_func is not None,
-                    "rerank_binding": args.rerank_binding,
-                    "rerank_model": args.rerank_model if rerank_model_func else None,
-                    "rerank_binding_host": args.rerank_binding_host
-                    if rerank_model_func
-                    else None,
-                    "rerank_max_async": args.rerank_max_async,
-                    "rerank_timeout": args.rerank_timeout,
-                    # Environment variable status (requested configuration)
-                    "summary_language": args.summary_language,
-                    "force_llm_summary_on_merge": args.force_llm_summary_on_merge,
-                    "max_parallel_insert": args.max_parallel_insert,
-                    "cosine_threshold": args.cosine_threshold,
-                    "min_rerank_score": args.min_rerank_score,
-                    "related_chunk_number": args.related_chunk_number,
-                    "max_async": args.max_async,
-                    "llm_timeout": args.llm_timeout,
-                    "embedding_func_max_async": args.embedding_func_max_async,
-                    "embedding_batch_num": args.embedding_batch_num,
-                    "embedding_timeout": args.embedding_timeout,
-                    "role_llm_config": rag.get_llm_role_config(),
-                    # Parser routing snapshot — surfaced in the WebUI status card
-                    "parser_routing": parser_rules_from_env(),
-                    "mineru": _build_mineru_status(),
-                    "docling": _build_docling_status(),
-                },
-                "auth_mode": auth_mode,
-                "server_mode": "gunicorn"
-                if os.environ.get("LIGHTRAG_GUNICORN_MODE")
-                else "uvicorn",
-                "workers": getattr(args, "workers", 1),
-                "pipeline_busy": pipeline_busy,
-                "pipeline_active": pipeline_active,
-                "pipeline_scanning": pipeline_scanning,
-                "pipeline_destructive_busy": pipeline_destructive_busy,
-                "pipeline_pending_enqueues": pipeline_pending_enqueues,
-                "keyed_locks": keyed_lock_info,
-                "llm_queue_status": await rag.get_llm_queue_status(include_base=True),
-                "embedding_queue_status": await rag.get_embedding_queue_status(),
-                "rerank_queue_status": await rag.get_rerank_queue_status(),
-                "core_version": core_version,
-                "api_version": api_version_display,
-                "webui_title": webui_title,
-                "webui_description": webui_description,
-            }
+            status_data.update(
+                {
+                    "working_directory": str(args.working_dir),
+                    "input_directory": str(args.input_dir),
+                    "configuration": {
+                        # LLM configuration binding/host address (if applicable)/model (if applicable)
+                        "llm_binding": args.llm_binding,
+                        "llm_binding_host": args.llm_binding_host,
+                        "llm_model": args.llm_model,
+                        # embedding model configuration binding/host address (if applicable)/model (if applicable)
+                        "embedding_binding": args.embedding_binding,
+                        "embedding_binding_host": args.embedding_binding_host,
+                        "embedding_model": args.embedding_model,
+                        "summary_max_tokens": args.summary_max_tokens,
+                        "summary_context_size": args.summary_context_size,
+                        "kv_storage": args.kv_storage,
+                        "doc_status_storage": args.doc_status_storage,
+                        "graph_storage": args.graph_storage,
+                        "vector_storage": args.vector_storage,
+                        "enable_llm_cache_for_extract": args.enable_llm_cache_for_extract,
+                        "enable_llm_cache": args.enable_llm_cache,
+                        "vlm_process_enable": args.vlm_process_enable,
+                        "workspace": default_workspace,
+                        "storage_workspaces": _get_storage_workspaces(rag),
+                        "max_graph_nodes": args.max_graph_nodes,
+                        # Rerank configuration
+                        "enable_rerank": rerank_model_func is not None,
+                        "rerank_binding": args.rerank_binding,
+                        "rerank_model": args.rerank_model
+                        if rerank_model_func
+                        else None,
+                        "rerank_binding_host": args.rerank_binding_host
+                        if rerank_model_func
+                        else None,
+                        "rerank_max_async": args.rerank_max_async,
+                        "rerank_timeout": args.rerank_timeout,
+                        # Environment variable status (requested configuration)
+                        "summary_language": args.summary_language,
+                        "force_llm_summary_on_merge": args.force_llm_summary_on_merge,
+                        "max_parallel_insert": args.max_parallel_insert,
+                        "cosine_threshold": args.cosine_threshold,
+                        "min_rerank_score": args.min_rerank_score,
+                        "related_chunk_number": args.related_chunk_number,
+                        "max_async": args.max_async,
+                        "llm_timeout": args.llm_timeout,
+                        "embedding_func_max_async": args.embedding_func_max_async,
+                        "embedding_batch_num": args.embedding_batch_num,
+                        "embedding_timeout": args.embedding_timeout,
+                        "role_llm_config": rag.get_llm_role_config(),
+                        # Parser routing snapshot — surfaced in the WebUI status card
+                        "parser_routing": parser_rules_from_env(),
+                        "mineru": _build_mineru_status(),
+                        "docling": _build_docling_status(),
+                    },
+                    "server_mode": "gunicorn"
+                    if os.environ.get("LIGHTRAG_GUNICORN_MODE")
+                    else "uvicorn",
+                    "workers": getattr(args, "workers", 1),
+                    "pipeline_scanning": pipeline_scanning,
+                    "pipeline_destructive_busy": pipeline_destructive_busy,
+                    "pipeline_pending_enqueues": pipeline_pending_enqueues,
+                    "keyed_locks": keyed_lock_info,
+                    "llm_queue_status": await rag.get_llm_queue_status(
+                        include_base=True
+                    ),
+                    "embedding_queue_status": await rag.get_embedding_queue_status(),
+                    "rerank_queue_status": await rag.get_rerank_queue_status(),
+                }
+            )
+            return status_data
         except Exception as e:
             logger.error(f"Error getting health status: {str(e)}")
             raise HTTPException(status_code=500, detail=str(e))

--- a/lightrag/api/utils_api.py
+++ b/lightrag/api/utils_api.py
@@ -284,6 +284,68 @@ def get_combined_auth_dependency(api_key: Optional[str] = None):
     return combined_dependency
 
 
+def get_auth_status_dependency(api_key: Optional[str] = None):
+    """Create a dependency that reports whether the request carries accepted
+    credentials, WITHOUT enforcing authentication (it never raises).
+
+    Used by endpoints such as ``/health`` that must stay reachable for
+    unauthenticated liveness probes (always HTTP 200) while only revealing
+    sensitive configuration to authenticated callers. The acceptance rules
+    mirror ``get_combined_auth_dependency`` exactly:
+
+      - fully open (no AUTH_ACCOUNTS, no API key): nothing is protected
+        anywhere, so the request is treated as authenticated.
+      - password auth (AUTH_ACCOUNTS set): a valid non-guest token, or a
+        valid API key when one is configured, authenticates.
+      - API-key-only (API key set, no AUTH_ACCOUNTS): only a valid API key
+        authenticates; a guest token is forgeable and must NOT count
+        (GHSA-f4vv-55c2-5789 / GHSA-xr5c-v5r6-c9f9).
+    """
+    api_key_configured = bool(api_key)
+    oauth2_scheme = OAuth2PasswordBearer(
+        tokenUrl="login", auto_error=False, description="OAuth2 Password Authentication"
+    )
+    api_key_header = None
+    if api_key_configured:
+        api_key_header = APIKeyHeader(
+            name="X-API-Key", auto_error=False, description="API Key Authentication"
+        )
+
+    async def auth_status_dependency(
+        token: str = Security(oauth2_scheme),
+        api_key_header_value: Optional[str] = None
+        if api_key_header is None
+        else Security(api_key_header),
+    ) -> bool:
+        # Fully-open mode: nothing is protected anywhere, so reveal config too.
+        if not auth_configured and not api_key_configured:
+            return True
+
+        # A valid API key authenticates in any mode where one is configured.
+        if (
+            api_key_configured
+            and api_key_header_value
+            and api_key_header_value == api_key
+        ):
+            return True
+
+        if token:
+            try:
+                token_info = auth_handler.validate_token(token)
+            except Exception:
+                token_info = None
+            if token_info:
+                role = token_info.get("role")
+                # Password auth: accept a non-guest token. A guest token never
+                # authenticates here (in API-key-only mode it is forgeable).
+                if auth_configured and role != "guest":
+                    return True
+
+        return False
+
+    return auth_status_dependency
+
+
 def whitelist_exposes_api_routes(whitelist_paths: str) -> bool:
     """Return True if WHITELIST_PATHS exempts any Ollama-compatible /api route.
 

--- a/tests/api/test_health_auth.py
+++ b/tests/api/test_health_auth.py
@@ -242,3 +242,27 @@ def test_api_key_mode_valid_key_unlocks_config(monkeypatch):
 
     assert resp.status_code == 200
     _assert_full_config(resp.json())
+
+
+# --------------------------------------------------------------------------- #
+# Combined mode (AUTH_ACCOUNTS + LIGHTRAG_API_KEY): either a valid JWT or a
+# valid X-API-Key unlocks the configuration; an anonymous probe gets liveness.
+# --------------------------------------------------------------------------- #
+def test_combined_mode_anonymous_gets_liveness_only(monkeypatch):
+    client = _build_client(monkeypatch, api_key="secret-key")
+    _set_auth_mode(monkeypatch, auth_configured=True)
+
+    resp = client.get("/health")
+
+    assert resp.status_code == 200
+    _assert_liveness_only(resp.json())
+
+
+def test_combined_mode_valid_api_key_unlocks_config(monkeypatch):
+    client = _build_client(monkeypatch, api_key="secret-key")
+    _set_auth_mode(monkeypatch, auth_configured=True)
+
+    resp = client.get("/health", headers={"X-API-Key": "secret-key"})
+
+    assert resp.status_code == 200
+    _assert_full_config(resp.json())

--- a/tests/api/test_health_auth.py
+++ b/tests/api/test_health_auth.py
@@ -1,0 +1,244 @@
+"""Tests for credential-gated configuration disclosure on ``GET /health``.
+
+Issue #3294: ``/health`` is whitelisted by default so it answers unauthenticated
+liveness probes (HTTP 200). It must therefore reveal sensitive runtime
+configuration (filesystem paths, LLM/embedding provider + model + host, storage
+backends, queue status, ...) ONLY to authenticated callers. These tests pin
+that behavior across the three authentication modes:
+
+- fully open (no AUTH_ACCOUNTS, no API key): everything is open anyway, so the
+  full configuration is returned to every caller.
+- password auth (AUTH_ACCOUNTS): only a valid non-guest JWT (or a configured
+  API key) unlocks the configuration; anonymous probes get liveness only.
+- API-key-only: only a valid X-API-Key unlocks the configuration.
+
+In every case ``/health`` returns HTTP 200 so external liveness probes keep
+working.
+"""
+
+import sys
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import APIRouter
+from fastapi.testclient import TestClient
+
+# Fields that must NEVER appear in an unauthenticated response.
+_SENSITIVE_TOP_LEVEL = ("working_directory", "input_directory", "configuration")
+# Liveness fields that must always be present (safe; already exposed by the
+# unauthenticated /auth-status endpoint or pure liveness signals).
+_LIVENESS_FIELDS = ("status", "auth_mode", "core_version", "api_version")
+
+
+_ENV_VARS_TO_ISOLATE = (
+    "LLM_BINDING",
+    "EMBEDDING_BINDING",
+    "AUTH_ACCOUNTS",
+    "TOKEN_SECRET",
+    "LIGHTRAG_API_KEY",
+    "WHITELIST_PATHS",
+    "LIGHTRAG_API_PREFIX",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    """Keep tests hermetic from developer-local .env and global config state."""
+    for var in _ENV_VARS_TO_ISOLATE:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("LLM_BINDING", "ollama")
+    monkeypatch.setenv("EMBEDDING_BINDING", "ollama")
+
+    import lightrag.api.config as config
+
+    config._global_args = None
+    config._initialized = False
+    yield
+    config._global_args = None
+    config._initialized = False
+
+
+class _FakeLightRAG:
+    """Minimal stand-in implementing the async surface /health touches."""
+
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    def register_role_llm_builder(self, _builder):
+        return None
+
+    def set_role_llm_metadata(self, _role, **_metadata):
+        return None
+
+    def get_llm_role_config(self):
+        return {}
+
+    async def get_llm_queue_status(self, include_base=True):
+        return {}
+
+    async def get_embedding_queue_status(self):
+        return {}
+
+    async def get_rerank_queue_status(self):
+        return {}
+
+
+class _FakeOllamaAPI:
+    def __init__(self, *_args, **_kwargs):
+        self.router = APIRouter()
+
+
+def _build_client(monkeypatch, *, api_key=None):
+    """Build a /health-capable TestClient with all backend I/O mocked out."""
+    from lightrag.api.config import parse_args, initialize_config
+
+    original_argv = sys.argv.copy()
+    try:
+        sys.argv = ["lightrag-server"]
+        args = parse_args()
+    finally:
+        sys.argv = original_argv
+    if api_key is not None:
+        args.key = api_key
+    initialize_config(args, force=True)
+
+    import lightrag.api.lightrag_server as lightrag_server
+
+    monkeypatch.setattr(lightrag_server, "LightRAG", _FakeLightRAG)
+    monkeypatch.setattr(lightrag_server, "check_frontend_build", lambda: (True, False))
+    monkeypatch.setattr(
+        lightrag_server, "create_document_routes", lambda *_a, **_k: APIRouter()
+    )
+    monkeypatch.setattr(
+        lightrag_server, "create_query_routes", lambda *_a, **_k: APIRouter()
+    )
+    monkeypatch.setattr(
+        lightrag_server, "create_graph_routes", lambda *_a, **_k: APIRouter()
+    )
+    monkeypatch.setattr(lightrag_server, "OllamaAPI", _FakeOllamaAPI)
+    monkeypatch.setattr(
+        lightrag_server, "get_namespace_data", AsyncMock(return_value={"busy": False})
+    )
+    monkeypatch.setattr(lightrag_server, "get_default_workspace", lambda: "default")
+    monkeypatch.setattr(
+        lightrag_server,
+        "cleanup_keyed_lock",
+        lambda: {"cleanup_performed": {}, "current_status": {}},
+    )
+
+    app = lightrag_server.create_app(args)
+    return TestClient(app)
+
+
+def _set_auth_mode(monkeypatch, *, auth_configured):
+    """Override the module-level auth flags the /health gate reads at runtime.
+
+    Also pin a whitelist that exempts /health so combined_auth keeps returning
+    200 for anonymous callers (the gate, not combined_auth, hides the config).
+    """
+    import lightrag.api.utils_api as utils_api
+
+    monkeypatch.setattr(utils_api, "auth_configured", auth_configured)
+    monkeypatch.setattr(
+        utils_api, "whitelist_patterns", [("/health", False), ("/api", True)]
+    )
+
+
+def _assert_liveness_only(body):
+    for field in _LIVENESS_FIELDS:
+        assert field in body, f"liveness field {field!r} missing"
+    for field in _SENSITIVE_TOP_LEVEL:
+        assert field not in body, f"sensitive field {field!r} leaked"
+
+
+def _assert_full_config(body):
+    assert "configuration" in body
+    assert "working_directory" in body
+    assert "llm_binding" in body["configuration"]
+
+
+# --------------------------------------------------------------------------- #
+# Fully open mode: everything is open, so config is returned to everyone.
+# --------------------------------------------------------------------------- #
+def test_open_mode_returns_full_config_to_anonymous(monkeypatch):
+    client = _build_client(monkeypatch)
+    _set_auth_mode(monkeypatch, auth_configured=False)
+
+    resp = client.get("/health")
+
+    assert resp.status_code == 200
+    _assert_full_config(resp.json())
+
+
+# --------------------------------------------------------------------------- #
+# Password auth: anonymous gets liveness only; a valid token unlocks config.
+# --------------------------------------------------------------------------- #
+def test_password_mode_anonymous_gets_liveness_only(monkeypatch):
+    client = _build_client(monkeypatch)
+    _set_auth_mode(monkeypatch, auth_configured=True)
+
+    resp = client.get("/health")
+
+    assert resp.status_code == 200  # liveness probe must stay green
+    _assert_liveness_only(resp.json())
+
+
+def test_password_mode_valid_token_unlocks_config(monkeypatch):
+    import lightrag.api.utils_api as utils_api
+
+    client = _build_client(monkeypatch)
+    _set_auth_mode(monkeypatch, auth_configured=True)
+    monkeypatch.setattr(
+        utils_api.auth_handler,
+        "validate_token",
+        lambda token: (
+            {"username": "admin", "role": "user"}
+            if token == "valid-user-token"
+            else (_ for _ in ()).throw(ValueError("bad token"))
+        ),
+    )
+
+    resp = client.get("/health", headers={"Authorization": "Bearer valid-user-token"})
+
+    assert resp.status_code == 200
+    _assert_full_config(resp.json())
+
+
+def test_password_mode_guest_token_stays_liveness_only(monkeypatch):
+    import lightrag.api.utils_api as utils_api
+
+    client = _build_client(monkeypatch)
+    _set_auth_mode(monkeypatch, auth_configured=True)
+    monkeypatch.setattr(
+        utils_api.auth_handler,
+        "validate_token",
+        lambda token: {"username": "guest", "role": "guest"},
+    )
+
+    resp = client.get("/health", headers={"Authorization": "Bearer guest-token"})
+
+    assert resp.status_code == 200
+    _assert_liveness_only(resp.json())
+
+
+# --------------------------------------------------------------------------- #
+# API-key-only mode: only a valid X-API-Key unlocks the configuration.
+# --------------------------------------------------------------------------- #
+def test_api_key_mode_anonymous_gets_liveness_only(monkeypatch):
+    client = _build_client(monkeypatch, api_key="secret-key")
+    _set_auth_mode(monkeypatch, auth_configured=False)
+
+    resp = client.get("/health")
+
+    assert resp.status_code == 200
+    _assert_liveness_only(resp.json())
+
+
+def test_api_key_mode_valid_key_unlocks_config(monkeypatch):
+    client = _build_client(monkeypatch, api_key="secret-key")
+    _set_auth_mode(monkeypatch, auth_configured=False)
+
+    resp = client.get("/health", headers={"X-API-Key": "secret-key"})
+
+    assert resp.status_code == 200
+    _assert_full_config(resp.json())


### PR DESCRIPTION
## Description

The `/health` endpoint is whitelisted by default (`WHITELIST_PATHS=/health,/api/*`), so `combined_auth` lets it answer **unauthenticated** liveness probes (HTTP 200). The handler, however, returned the full runtime configuration to every caller — including on instances with authentication fully enabled. This is an information-disclosure issue (Issue #3294): the response leaked the LLM provider/model and self-hosted host address, the embedding + rerank config, the absolute `working_directory` / `input_directory` paths (which attribute the operator), per-role LLM config, and internal queue/lock diagnostics.

This PR keeps `/health` reachable as a liveness probe (still whitelisted, still always HTTP 200) but only reveals the sensitive configuration to **authenticated** callers.

## Related Issues

Fixes #3294

## Changes Made

- **`lightrag/api/utils_api.py`** — Add `get_auth_status_dependency(api_key)`: a non-raising FastAPI dependency that returns a `bool` indicating whether the request carries accepted credentials. Its acceptance rules mirror `get_combined_auth_dependency` exactly:
  - fully open (no `AUTH_ACCOUNTS`, no API key): nothing is protected anywhere, so the caller is treated as authenticated;
  - password auth: a valid non-guest JWT, or a valid API key when configured;
  - API-key-only: only a valid `X-API-Key` — a guest token is forgeable and must not count (GHSA-f4vv-55c2-5789).
- **`lightrag/api/lightrag_server.py`** — `/health` now injects this dependency. Unauthenticated callers receive only liveness signals (`status`, `auth_mode`, `core_version`, `api_version`, `pipeline_busy`/`pipeline_active`, and the WebUI title/availability fields — all already exposed by the unauthenticated `/auth-status` endpoint or plain booleans). Authenticated callers additionally get `working_directory`, `input_directory`, the full `configuration{}`, `server_mode`/`workers`, the remaining pipeline counters, `keyed_locks`, and the queue-status blocks. The endpoint stays whitelisted and always returns HTTP 200.
- **Docs / `env.example`** — Document that `/health` no longer leaks configuration to unauthenticated callers.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

- **No WebUI change required.** The WebUI's axios interceptor always attaches `Authorization: Bearer` and/or `X-API-Key`, and the health poll only runs inside the authenticated app shell, so the WebUI always receives the full payload exactly as before. Login-page version/title continue to come from the unauthenticated `/auth-status`.
- **Liveness probes unaffected.** `/health` still returns HTTP 200 without credentials, so existing k8s/docker `curl -f .../health` healthchecks keep working.
- **Open mode is intentionally unchanged.** With neither `AUTH_ACCOUNTS` nor an API key configured, every endpoint is open by design, so `/health` continues to return the full payload to all callers in that mode.
- New tests in `tests/api/test_health_auth.py` cover all three auth modes (anonymous vs. credentialed) and assert `/health` returns 200 in every case. `tests/api/` (246 passed), the bedrock `/health` tests, and the CORS tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
