### PR TITLE
Fix docs links and environment typos

### DIFF
--- a/docs/InteractiveSetup.md
+++ b/docs/InteractiveSetup.md
@@ -200,7 +200,7 @@ make env-security-check
 - If the stack uses Docker, recreate the LightRAG service with your compose file
 - If the stack runs on the host, restart `lightrag-server`
 
-For broader deployment guidance, see [DockerDeployment.md](/Users/ydh/mycode/ai/paper-RAG/docs/DockerDeployment.md).
+For broader deployment guidance, see [DockerDeployment.md](./DockerDeployment.md).
 
 ## Validate, Audit, And Backup
 
@@ -266,7 +266,7 @@ The base `docker-compose.yml` remains the general project compose file. The gene
 - If you need to fully rebuild wizard-managed compose services from the current bundled templates, use `make env-base-rewrite` or `make env-storage-rewrite`.
 - If you switch between host-oriented and Docker-oriented workflows, rerun the relevant setup step instead of trying to manually merge old settings.
 - If the generated stack includes local Milvus, make sure `MINIO_ACCESS_KEY_ID` and `MINIO_SECRET_ACCESS_KEY` are available before running `docker compose -f docker-compose.final.yml up -d`.
-- For Docker deployment details beyond the interactive wizard, see [DockerDeployment.md](/Users/ydh/mycode/ai/paper-RAG/docs/DockerDeployment.md).
+- For Docker deployment details beyond the interactive wizard, see [DockerDeployment.md](./DockerDeployment.md).
 
 ## Typical Command Sequences
 

--- a/docs/LightRAG-API-Server-zh.md
+++ b/docs/LightRAG-API-Server-zh.md
@@ -519,7 +519,7 @@ lightrag-gunicorn --workers 2
 从示例文件 `lightrag.service.example` 创建您的服务文件 `lightrag.service`。修改服务文件中的服务启动定义：
 
 ```text
-# Set Enviroment to your Python virtual enviroment
+# Set environment to your Python virtual environment
 Environment="PATH=/home/netman/lightrag-xyj/venv/bin"
 WorkingDirectory=/home/netman/lightrag-xyj
 # ExecStart=/home/netman/lightrag-xyj/venv/bin/lightrag-server

--- a/docs/LightRAG-API-Server.md
+++ b/docs/LightRAG-API-Server.md
@@ -457,7 +457,7 @@ server {
 
 ### Offline Deployment
 
-Official LightRAG Docker images are fully compatible with offline or air-gapped environments. If you want to build up you own  offline enviroment, please refer to [Offline Deployment Guide](./OfflineDeployment.md).
+Official LightRAG Docker images are fully compatible with offline or air-gapped environments. If you want to build up your own offline environment, please refer to [Offline Deployment Guide](./OfflineDeployment.md).
 
 ### Starting Multiple LightRAG Instances
 
@@ -519,7 +519,7 @@ lightrag-gunicorn --workers 2
 Create your service file `lightrag.service` from the sample file: `lightrag.service.example`. Modify the start options the service file:
 
 ```text
-# Set Enviroment to your Python virtual enviroment
+# Set environment to your Python virtual environment
 Environment="PATH=/home/netman/lightrag-xyj/venv/bin"
 WorkingDirectory=/home/netman/lightrag-xyj
 # ExecStart=/home/netman/lightrag-xyj/venv/bin/lightrag-server


### PR DESCRIPTION
Summary:
- Replaces local absolute DockerDeployment links with relative documentation links.
- Fixes `Enviroment/enviroment` spelling in API server docs.

Testing:
- Verified the linked docs files exist in `docs/`.
- Documentation-only change; project tests were not run.

AI assistance: This documentation fix was prepared with AI assistance and reviewed before submission.