### PR TITLE
docs(webui): document Bun 'bin metadata file' error on WSL

### DIFF
--- a/lightrag_webui/README.md
+++ b/lightrag_webui/README.md
@@ -75,6 +75,39 @@ npm install
 npm run build
 ```
 
+### `could not open bin metadata file` / `corrupted node_modules directory` (WSL)
+
+```
+error: could not open bin metadata file
+
+Bun failed to remap this bin to its proper location within node_modules.
+This is an indication of a corrupted node_modules directory.
+```
+
+This is a [known Bun issue](https://github.com/oven-sh/bun/issues) that surfaces on WSL. Bun installs package binaries by remapping them into `node_modules/.bin`, and that step fails when `node_modules` lives on a Windows-mounted drive (a path under `/mnt/c`, `/mnt/d`, etc.). WSL exposes those drives through the `drvfs`/`9p` filesystem, which does not support the link/metadata operations Bun relies on, so the `.bin` entries end up corrupted even right after a successful `bun install`.
+
+Fixes, in order of preference:
+
+1. **Move the project into the Linux filesystem.** Clone/copy LightRAG somewhere under your WSL home (e.g. `~/LightRAG`) instead of `/mnt/c/...`, then reinstall:
+
+    ```bash
+    rm -rf node_modules
+    bun install --frozen-lockfile
+    bun run build
+    ```
+
+    This is the recommended fix — building from a Windows-mounted path is slow and fragile regardless of this specific error.
+
+2. **If you must stay on the mounted drive, use Node.js/npm instead of Bun** (see *Using Node.js / npm* above):
+
+    ```bash
+    rm -rf node_modules
+    npm install
+    npm run build
+    ```
+
+3. **Make sure Bun is up to date** (`bun upgrade`) — older Bun releases hit this remapping bug more often.
+
 ### `Cannot find package '@/lib'`
 
 This error occurred in older versions when the Vite config used a TypeScript path alias (`@/`) that only Bun could resolve at config load time. This has been fixed by using a relative import in `vite.config.ts`.


### PR DESCRIPTION
Add a troubleshooting entry for the 'could not open bin metadata file / corrupted node_modules directory' error that occurs when running 'bun run build' on WSL, with the project located on a Windows-mounted drive (/mnt/c, etc.). Bun's bin remapping into node_modules/.bin fails on the drvfs/9p filesystem. Documents the recommended fix (move the project into the Linux filesystem) plus the npm fallback and bun upgrade.

Fixes #3338