### PR TITLE
fix: handle docling JSON result envelopes

### DIFF
--- a/lightrag/parser/external/docling/client.py
+++ b/lightrag/parser/external/docling/client.py
@@ -15,6 +15,12 @@ Pipeline constants (``pipeline``, ``target_type``, ``to_formats``,
 ``image_export_mode``) are intentionally **not** env-driven — the sidecar
 flow depends on them — and are recorded inside the manifest so a future
 code change automatically invalidates pre-existing caches.
+
+Some docling-serve deployments return a JSON ``ConvertDocumentResponse``
+envelope from the result endpoint even when the client requests a zip. When
+that happens, the client materializes the nested ``document`` object as the
+main ``<stem>.json`` and writes ``document.md_content`` beside it as
+``<stem>.md``. The response envelope itself is not treated as document content.
 """
 
 from __future__ import annotations
@@ -158,9 +164,9 @@ class DoclingRawClient:
                 client, source_file_path, filename=effective_filename
             )
             await self._poll_until_done(client, task_id)
-            payload = await self._download_zip_bytes(client, task_id)
-
-        safe_extract_zip(payload, raw_dir)
+            await self._download_result_into(
+                client, task_id, raw_dir, effective_filename
+            )
         # Defensive: confirm the main JSON exists before anyone reads the
         # bundle. Look it up by the *uploaded* filename's stem — that's
         # what docling-serve uses to name the JSON inside the zip.
@@ -279,22 +285,27 @@ class DoclingRawClient:
 
         raise TimeoutError(f"Docling task {task_id} polling timeout")
 
-    async def _download_zip_bytes(
+    async def _download_result_into(
         self,
         client: "httpx.AsyncClient",
         task_id: str,
-    ) -> bytes:
+        raw_dir: Path,
+        upload_filename: str,
+    ) -> None:
         encoded_task_id = quote(task_id, safe="")
         url = f"{self.endpoint}{RESULT_PATH.format(task_id=encoded_task_id)}"
         resp = await client.get(url)
         raise_for_status_with_detail(resp, f"Docling result {task_id} download")
         ctype = resp.headers.get("content-type", "")
         if "zip" not in ctype.lower():
+            if _is_json_result(resp, ctype):
+                _materialize_json_result(resp, raw_dir, upload_filename)
+                return
             raise RuntimeError(
                 f"Docling result {task_id} returned non-zip content-type "
                 f"{ctype!r}; body prefix={resp.text[:400]!r}"
             )
-        return resp.content
+        safe_extract_zip(resp.content, raw_dir)
 
 
 # ---------------------------------------------------------------------------
@@ -320,6 +331,52 @@ def _parse_ocr_lang(raw: str) -> list[str]:
     if isinstance(parsed, list):
         return [str(x).strip() for x in parsed if str(x).strip()]
     return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def _is_json_result(resp: Any, content_type: str) -> bool:
+    ctype = content_type.lower()
+    if "json" in ctype:
+        return True
+    return resp.content.lstrip().startswith((b"{", b"["))
+
+
+def _materialize_json_result(resp: Any, raw_dir: Path, upload_filename: str) -> None:
+    try:
+        payload = resp.json() if resp.text else json.loads(resp.content)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            "Docling result returned JSON content-type but the body is not valid JSON"
+        ) from exc
+
+    document, markdown = _extract_document_payload(payload)
+    stem = Path(upload_filename).stem
+    (raw_dir / f"{stem}.json").write_text(
+        json.dumps(document, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    if markdown is not None:
+        (raw_dir / f"{stem}.md").write_text(str(markdown), encoding="utf-8")
+
+
+def _extract_document_payload(payload: Any) -> tuple[dict[str, Any], Any | None]:
+    if not isinstance(payload, dict):
+        raise RuntimeError("Docling JSON result is not an object")
+
+    nested = payload.get("document")
+    if isinstance(nested, dict):
+        return nested, nested.get("md_content")
+
+    if _looks_like_docling_document(payload):
+        return payload, payload.get("md_content")
+
+    keys = ", ".join(sorted(str(k) for k in payload.keys())[:20])
+    raise RuntimeError(
+        f"Docling JSON result missing document object; top-level keys=[{keys}]"
+    )
+
+
+def _looks_like_docling_document(payload: dict[str, Any]) -> bool:
+    return any(key in payload for key in ("schema_name", "body", "texts", "tables"))
 
 
 def _format_failure(task_id: str, status: str, payload: Any) -> str:

--- a/lightrag/parser/external/docling/client.py
+++ b/lightrag/parser/external/docling/client.py
@@ -18,9 +18,10 @@ code change automatically invalidates pre-existing caches.
 
 Some docling-serve deployments return a JSON ``ConvertDocumentResponse``
 envelope from the result endpoint even when the client requests a zip. When
-that happens, the client materializes the nested ``document`` object as the
-main ``<stem>.json`` and writes ``document.md_content`` beside it as
-``<stem>.md``. The response envelope itself is not treated as document content.
+that happens, the client materializes the nested ``document.json_content``
+(the actual ``DoclingDocument``) as the main ``<stem>.json`` and writes
+``document.md_content`` beside it as ``<stem>.md``. The response envelope and
+its ``ExportDocumentResponse`` wrapper are not treated as document content.
 """
 
 from __future__ import annotations
@@ -364,8 +365,27 @@ def _extract_document_payload(payload: Any) -> tuple[dict[str, Any], Any | None]
 
     nested = payload.get("document")
     if isinstance(nested, dict):
-        return nested, nested.get("md_content")
+        # ``ConvertDocumentResponse.document`` is an ``ExportDocumentResponse``
+        # wrapper (``filename`` / ``md_content`` / ``json_content`` / ...); the
+        # actual ``DoclingDocument`` lives under ``json_content``. Storing the
+        # wrapper as ``<stem>.json`` would leave the root without
+        # ``body`` / ``texts`` / ``tables``, and the IR builder would produce
+        # zero blocks. Extract ``json_content`` and keep ``md_content`` as the
+        # markdown twin.
+        json_content = nested.get("json_content")
+        if isinstance(json_content, dict):
+            return json_content, nested.get("md_content")
+        # Defensive: some deployments may place the ``DoclingDocument`` directly
+        # under ``document`` with no ``json_content`` wrapper.
+        if _looks_like_docling_document(nested):
+            return nested, nested.get("md_content")
+        keys = ", ".join(sorted(str(k) for k in nested)[:20])
+        raise RuntimeError(
+            f"Docling result 'document' has no DoclingDocument (json_content); "
+            f"keys=[{keys}]"
+        )
 
+    # No envelope: the endpoint returned the DoclingDocument at the top level.
     if _looks_like_docling_document(payload):
         return payload, payload.get("md_content")
 

--- a/lightrag/parser/external/docling/client.py
+++ b/lightrag/parser/external/docling/client.py
@@ -21,7 +21,9 @@ envelope from the result endpoint even when the client requests a zip. When
 that happens, the client materializes the nested ``document.json_content``
 (the actual ``DoclingDocument``) as the main ``<stem>.json`` and writes
 ``document.md_content`` beside it as ``<stem>.md``. The response envelope and
-its ``ExportDocumentResponse`` wrapper are not treated as document content.
+its ``ExportDocumentResponse`` wrapper are not treated as document content. A
+JSON envelope whose own conversion ``status`` is not ``success`` is rejected
+rather than materialized, so a partial conversion never becomes a cache hit.
 """
 
 from __future__ import annotations
@@ -300,7 +302,7 @@ class DoclingRawClient:
         ctype = resp.headers.get("content-type", "")
         if "zip" not in ctype.lower():
             if _is_json_result(resp, ctype):
-                _materialize_json_result(resp, raw_dir, upload_filename)
+                _materialize_json_result(resp, task_id, raw_dir, upload_filename)
                 return
             raise RuntimeError(
                 f"Docling result {task_id} returned non-zip content-type "
@@ -341,13 +343,37 @@ def _is_json_result(resp: Any, content_type: str) -> bool:
     return resp.content.lstrip().startswith((b"{", b"["))
 
 
-def _materialize_json_result(resp: Any, raw_dir: Path, upload_filename: str) -> None:
+def _result_envelope_status(payload: Any) -> str:
+    """Conversion status carried by a JSON result envelope, lower-cased.
+
+    Mirrors ``_poll_until_done``'s field lookup (``task_status`` first, then
+    ``status``). Returns ``""`` when neither is present — e.g. a bare
+    ``DoclingDocument`` payload — so the caller can skip the status gate.
+    """
+    if not isinstance(payload, dict):
+        return ""
+    return str(payload.get("task_status") or payload.get("status") or "").lower()
+
+
+def _materialize_json_result(
+    resp: Any, task_id: str, raw_dir: Path, upload_filename: str
+) -> None:
     try:
         payload = resp.json() if resp.text else json.loads(resp.content)
     except json.JSONDecodeError as exc:
         raise RuntimeError(
             "Docling result returned JSON content-type but the body is not valid JSON"
         ) from exc
+
+    # A JSON ``ConvertDocumentResponse`` envelope carries its own conversion
+    # ``status``. ``_poll_until_done`` only checked the async *task* status, and
+    # the manifest is written after this returns — so honouring the envelope
+    # status here is what stops a ``partial_success`` / ``failure`` result from
+    # being cached as a successful bundle. (Bare DoclingDocument payloads have
+    # no status field; those skip the check.)
+    status = _result_envelope_status(payload)
+    if status and status not in SUCCESS_STATES:
+        raise RuntimeError(_format_failure(task_id, status, payload))
 
     document, markdown = _extract_document_payload(payload)
     stem = Path(upload_filename).stem

--- a/lightrag/parser/external/docling/client.py
+++ b/lightrag/parser/external/docling/client.py
@@ -24,6 +24,10 @@ that happens, the client materializes the nested ``document.json_content``
 its ``ExportDocumentResponse`` wrapper are not treated as document content. A
 JSON envelope whose own conversion ``status`` is not ``success`` is rejected
 rather than materialized, so a partial conversion never becomes a cache hit.
+Because the JSON path cannot deliver the ``artifacts/`` files that
+``image_export_mode=referenced`` produces, a ``json_content`` that references
+external images (rather than embedding them as ``data:`` URIs) is rejected too,
+so silent image loss can't hide behind a success manifest.
 """
 
 from __future__ import annotations
@@ -376,6 +380,25 @@ def _materialize_json_result(
         raise RuntimeError(_format_failure(task_id, status, payload))
 
     document, markdown = _extract_document_payload(payload)
+
+    # ``image_export_mode=referenced`` makes docling reference picture bytes by
+    # relative ``artifacts/...`` path. Those files ship inside the zip, never
+    # inside the JSON envelope — so the JSON path, which writes only
+    # ``<stem>.json`` (+ optional markdown), cannot deliver them. The IR builder
+    # would then silently drop every such picture yet the bundle would still be
+    # cached as a success. Fail loudly instead so image loss can't hide behind a
+    # cache hit. Embedded (``data:``) and remote (``http(s)://``) images carry
+    # their own bytes and are unaffected.
+    referenced = _referenced_image_uris(document)
+    if referenced:
+        sample = ", ".join(referenced[:5])
+        raise RuntimeError(
+            f"Docling JSON result references external image artifacts the JSON "
+            f"result path cannot deliver (only <stem>.json/<stem>.md are "
+            f"written): {sample}. Configure docling-serve to return a zip bundle "
+            f"or embed images as data URIs for this deployment."
+        )
+
     stem = Path(upload_filename).stem
     (raw_dir / f"{stem}.json").write_text(
         json.dumps(document, ensure_ascii=False, indent=2),
@@ -423,6 +446,31 @@ def _extract_document_payload(payload: Any) -> tuple[dict[str, Any], Any | None]
 
 def _looks_like_docling_document(payload: dict[str, Any]) -> bool:
     return any(key in payload for key in ("schema_name", "body", "texts", "tables"))
+
+
+def _referenced_image_uris(document: dict[str, Any]) -> list[str]:
+    """Relative picture image URIs in a ``DoclingDocument`` — i.e. neither
+    ``data:`` nor ``http(s)://``. These name companion ``artifacts/`` files the
+    JSON result path never writes, so their presence means images would be lost.
+
+    Mirrors the IR builder's URI classification (``_build_ir_drawing``): only a
+    non-empty, non-data, non-remote ``image.uri`` needs a local file.
+    """
+    pictures = document.get("pictures")
+    if not isinstance(pictures, list):
+        return []
+    referenced: list[str] = []
+    for pic in pictures:
+        if not isinstance(pic, dict):
+            continue
+        image = pic.get("image")
+        if not isinstance(image, dict):
+            continue
+        uri = str(image.get("uri") or "")
+        if not uri or uri.startswith(("data:", "http://", "https://")):
+            continue
+        referenced.append(uri)
+    return referenced
 
 
 def _format_failure(task_id: str, status: str, payload: Any) -> str:

--- a/tests/parser/external/docling/test_client.py
+++ b/tests/parser/external/docling/test_client.py
@@ -73,6 +73,8 @@ class _Recorder:
         poll_text: str | None = None,
         result_status_code: int = 200,
         result_text: str | None = None,
+        result_content: bytes | None = None,
+        result_content_type: str = "application/zip",
     ) -> None:
         self.terminal_status = terminal_status
         self.zip_bytes = zip_bytes
@@ -83,6 +85,8 @@ class _Recorder:
         self.poll_text = poll_text
         self.result_status_code = result_status_code
         self.result_text = result_text
+        self.result_content = result_content
+        self.result_content_type = result_content_type
 
         self.post_calls: list[dict] = []
         self.get_calls: list[dict] = []
@@ -165,8 +169,8 @@ class _FakeAsyncClient:
                 )
             return _FakeResponse(
                 status_code=200,
-                content=recorder.zip_bytes,
-                headers={"content-type": "application/zip"},
+                content=recorder.result_content or recorder.zip_bytes,
+                headers={"content-type": recorder.result_content_type},
             )
         raise AssertionError(f"unexpected GET {url}")
 
@@ -446,6 +450,41 @@ async def test_docling_client_result_http_error_preserves_response_body(
     assert "Docling result task-abc download" in message
     assert "HTTP 500" in message
     assert "zip artifact missing" in message
+
+
+async def test_docling_client_materializes_json_result_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    source_pdf: Path,
+) -> None:
+    document = {
+        "schema_name": "DoclingDocument",
+        "md_content": "# Extracted markdown\n\nOnly this text should be markdown.",
+        "body": {"children": []},
+    }
+    envelope = {
+        "task_id": "task-abc",
+        "task_status": "success",
+        "document": document,
+    }
+    recorder = _Recorder(
+        terminal_status="success",
+        zip_bytes=b"",
+        result_content=json_dump(envelope).encode("utf-8"),
+        result_content_type="application/json",
+    )
+    _CURRENT["recorder"] = recorder
+    _install_fake_httpx(monkeypatch)
+
+    raw_dir = tmp_path / "demo.docling_raw"
+    manifest = await DoclingRawClient().download_into(raw_dir, source_pdf)
+
+    stored = json.loads((raw_dir / "demo.json").read_text(encoding="utf-8"))
+    assert stored == document
+    assert "task_status" not in stored
+    assert (raw_dir / "demo.md").read_text(encoding="utf-8") == document["md_content"]
+    assert manifest.critical_file.path == "demo.json"
+    assert {f.path for f in manifest.files} == {"demo.md"}
 
 
 async def test_docling_client_encodes_task_id_into_url_path_segment(

--- a/tests/parser/external/docling/test_client.py
+++ b/tests/parser/external/docling/test_client.py
@@ -452,20 +452,60 @@ async def test_docling_client_result_http_error_preserves_response_body(
     assert "zip artifact missing" in message
 
 
+def _docling_document_with_one_block() -> dict:
+    """A minimal but real ``DoclingDocument`` that yields one IR block.
+
+    Mirrors the shape docling-serve nests under
+    ``ConvertDocumentResponse.document.json_content``: a ``body`` referencing
+    one ``texts`` entry so the IR builder produces a non-empty parse.
+    """
+    return {
+        "schema_name": "DoclingDocument",
+        "version": "1.10.0",
+        "origin": {"filename": "demo.pdf", "mimetype": "application/pdf"},
+        "body": {
+            "self_ref": "#/body",
+            "children": [{"$ref": "#/texts/0"}],
+            "content_layer": "body",
+            "label": "unspecified",
+        },
+        "groups": [],
+        "texts": [
+            {
+                "self_ref": "#/texts/0",
+                "label": "title",
+                "text": "Only this text should be extracted.",
+                "orig": "Only this text should be extracted.",
+                "content_layer": "body",
+                "prov": [],
+            }
+        ],
+        "pictures": [],
+        "tables": [],
+        "key_value_items": [],
+        "form_items": [],
+    }
+
+
 async def test_docling_client_materializes_json_result_envelope(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     source_pdf: Path,
 ) -> None:
-    document = {
-        "schema_name": "DoclingDocument",
-        "md_content": "# Extracted markdown\n\nOnly this text should be markdown.",
-        "body": {"children": []},
-    }
+    # Real ConvertDocumentResponse shape: the DoclingDocument lives under
+    # ``document.json_content``; ``md_content`` is its sibling. The stored
+    # ``<stem>.json`` must be the inner DoclingDocument, NOT the response
+    # envelope or the ExportDocumentResponse wrapper.
+    json_content = _docling_document_with_one_block()
+    markdown = "# Extracted markdown\n\nOnly this text should be markdown."
     envelope = {
         "task_id": "task-abc",
         "task_status": "success",
-        "document": document,
+        "document": {
+            "filename": "demo.pdf",
+            "md_content": markdown,
+            "json_content": json_content,
+        },
     }
     recorder = _Recorder(
         terminal_status="success",
@@ -480,11 +520,50 @@ async def test_docling_client_materializes_json_result_envelope(
     manifest = await DoclingRawClient().download_into(raw_dir, source_pdf)
 
     stored = json.loads((raw_dir / "demo.json").read_text(encoding="utf-8"))
-    assert stored == document
+    assert stored == json_content
+    # Neither the envelope nor the ExportDocumentResponse wrapper leaks in.
     assert "task_status" not in stored
-    assert (raw_dir / "demo.md").read_text(encoding="utf-8") == document["md_content"]
+    assert "json_content" not in stored
+    assert "md_content" not in stored
+    assert (raw_dir / "demo.md").read_text(encoding="utf-8") == markdown
     assert manifest.critical_file.path == "demo.json"
     assert {f.path for f in manifest.files} == {"demo.md"}
+
+
+async def test_docling_client_json_envelope_is_parseable_by_ir_builder(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    source_pdf: Path,
+) -> None:
+    """End-to-end guard for #2996: a materialized JSON envelope must feed the
+    IR builder and yield non-empty blocks (storing the wrapper would produce
+    zero blocks and fail ``validate_ir``)."""
+    from lightrag.parser.external.docling.ir_builder import DoclingIRBuilder
+
+    envelope = {
+        "task_id": "task-abc",
+        "task_status": "success",
+        "document": {
+            "filename": "demo.pdf",
+            "md_content": "# Extracted markdown\n",
+            "json_content": _docling_document_with_one_block(),
+        },
+    }
+    recorder = _Recorder(
+        terminal_status="success",
+        zip_bytes=b"",
+        result_content=json_dump(envelope).encode("utf-8"),
+        result_content_type="application/json",
+    )
+    _CURRENT["recorder"] = recorder
+    _install_fake_httpx(monkeypatch)
+
+    raw_dir = tmp_path / "demo.docling_raw"
+    await DoclingRawClient().download_into(raw_dir, source_pdf)
+
+    ir = DoclingIRBuilder().normalize_from_workdir(raw_dir, document_name="demo.pdf")
+    assert ir.blocks, "materialized JSON envelope produced zero IR blocks"
+    assert ir.doc_title == "Only this text should be extracted."
 
 
 async def test_docling_client_encodes_task_id_into_url_path_segment(

--- a/tests/parser/external/docling/test_client.py
+++ b/tests/parser/external/docling/test_client.py
@@ -566,6 +566,43 @@ async def test_docling_client_json_envelope_is_parseable_by_ir_builder(
     assert ir.doc_title == "Only this text should be extracted."
 
 
+async def test_docling_client_rejects_non_success_json_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    source_pdf: Path,
+) -> None:
+    """A JSON result envelope whose own status is not ``success`` must abort
+    instead of caching a partial conversion as a successful bundle — even when
+    the async poll reported success and the envelope still carries a document."""
+    envelope = {
+        "task_id": "task-abc",
+        "task_status": "partial_success",
+        "document": {
+            "filename": "demo.pdf",
+            "md_content": "# Partial\n",
+            "json_content": _docling_document_with_one_block(),
+        },
+    }
+    recorder = _Recorder(
+        terminal_status="success",  # async task poll succeeds ...
+        zip_bytes=b"",
+        result_content=json_dump(envelope).encode("utf-8"),
+        result_content_type="application/json",
+    )
+    _CURRENT["recorder"] = recorder
+    _install_fake_httpx(monkeypatch)
+
+    raw_dir = tmp_path / "demo.docling_raw"
+    with pytest.raises(RuntimeError) as excinfo:
+        await DoclingRawClient().download_into(raw_dir, source_pdf)
+
+    assert "partial_success" in str(excinfo.value)
+    # Nothing was materialized: no document, no markdown, no manifest.
+    assert not (raw_dir / "demo.json").exists()
+    assert not (raw_dir / "demo.md").exists()
+    assert not (raw_dir / "_manifest.json").exists()
+
+
 async def test_docling_client_encodes_task_id_into_url_path_segment(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/parser/external/docling/test_client.py
+++ b/tests/parser/external/docling/test_client.py
@@ -487,6 +487,23 @@ def _docling_document_with_one_block() -> dict:
     }
 
 
+def _docling_document_with_picture(uri: str) -> dict:
+    """``_docling_document_with_one_block`` plus one picture referencing ``uri``."""
+    doc = _docling_document_with_one_block()
+    doc["body"]["children"].append({"$ref": "#/pictures/0"})
+    doc["pictures"] = [
+        {
+            "self_ref": "#/pictures/0",
+            "label": "picture",
+            "content_layer": "body",
+            "prov": [],
+            "children": [],
+            "image": {"uri": uri, "mimetype": "image/png"},
+        }
+    ]
+    return doc
+
+
 async def test_docling_client_materializes_json_result_envelope(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -601,6 +618,79 @@ async def test_docling_client_rejects_non_success_json_envelope(
     assert not (raw_dir / "demo.json").exists()
     assert not (raw_dir / "demo.md").exists()
     assert not (raw_dir / "_manifest.json").exists()
+
+
+async def test_docling_client_rejects_referenced_image_artifacts_in_json_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    source_pdf: Path,
+) -> None:
+    """A JSON envelope whose DoclingDocument references ``artifacts/`` images
+    must abort: the JSON path cannot deliver those files, so materializing would
+    silently drop the pictures and still cache the bundle as a success."""
+    envelope = {
+        "task_id": "task-abc",
+        "task_status": "success",
+        "document": {
+            "filename": "demo.pdf",
+            "md_content": "# md\n",
+            "json_content": _docling_document_with_picture("artifacts/image_000.png"),
+        },
+    }
+    recorder = _Recorder(
+        terminal_status="success",
+        zip_bytes=b"",
+        result_content=json_dump(envelope).encode("utf-8"),
+        result_content_type="application/json",
+    )
+    _CURRENT["recorder"] = recorder
+    _install_fake_httpx(monkeypatch)
+
+    raw_dir = tmp_path / "demo.docling_raw"
+    with pytest.raises(RuntimeError) as excinfo:
+        await DoclingRawClient().download_into(raw_dir, source_pdf)
+
+    assert "artifacts/image_000.png" in str(excinfo.value)
+    assert not (raw_dir / "demo.json").exists()
+    assert not (raw_dir / "demo.md").exists()
+    assert not (raw_dir / "_manifest.json").exists()
+
+
+async def test_docling_client_json_result_preserves_embedded_image(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    source_pdf: Path,
+) -> None:
+    """Embedded (``data:``) images carry their own bytes, so the guard is a
+    no-op and the base64 is preserved verbatim in the stored ``<stem>.json``
+    (the IR builder decodes it into the sidecar assets dir downstream)."""
+    data_uri = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgAB"
+    json_content = _docling_document_with_picture(data_uri)
+    envelope = {
+        "task_id": "task-abc",
+        "task_status": "success",
+        "document": {
+            "filename": "demo.pdf",
+            "md_content": "# md\n",
+            "json_content": json_content,
+        },
+    }
+    recorder = _Recorder(
+        terminal_status="success",
+        zip_bytes=b"",
+        result_content=json_dump(envelope).encode("utf-8"),
+        result_content_type="application/json",
+    )
+    _CURRENT["recorder"] = recorder
+    _install_fake_httpx(monkeypatch)
+
+    raw_dir = tmp_path / "demo.docling_raw"
+    manifest = await DoclingRawClient().download_into(raw_dir, source_pdf)
+
+    stored = json.loads((raw_dir / "demo.json").read_text(encoding="utf-8"))
+    assert stored == json_content
+    assert stored["pictures"][0]["image"]["uri"] == data_uri
+    assert manifest.critical_file.path == "demo.json"
 
 
 async def test_docling_client_encodes_task_id_into_url_path_segment(


### PR DESCRIPTION
Fixes #2996

Summary:
- Keep the existing zip result path unchanged.
- When docling-serve returns a JSON `ConvertDocumentResponse`, materialize the nested `document` as the raw bundle's main JSON instead of storing the response envelope as document content.
- Write `document.md_content` to the companion markdown file when present.
- Add a regression test that checks the stored JSON excludes outer fields such as `task_status`.

Validation:
- `./scripts/test.sh tests/parser/external/docling` - 65 passed, 2 deprecation warnings from langchain packages.
- `.venv/bin/ruff check lightrag/parser/external/docling/client.py tests/parser/external/docling/test_client.py` - passed.
- `.venv/bin/ruff format --check lightrag/parser/external/docling/client.py tests/parser/external/docling/test_client.py` - passed.

Not run:
- Full repository test suite.
