### PR TITLE
fix(core): build KG from ainsert_custom_chunks extraction (#3352)

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -123,6 +123,7 @@ from lightrag.utils import (
     EmbeddingFunc,
     always_get_an_event_loop,
     compute_mdhash_id,
+    get_content_summary,
     priority_limit_async_func_call,
     sanitize_text_for_encoding,
     check_storage_env_vars,
@@ -1514,27 +1515,40 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         self, full_text: str, text_chunks: list[str], doc_id: str | None = None
     ) -> None:
         update_storage = False
+        # Bound before the try so the except-block failure handler can always
+        # reference them regardless of where a failure occurs.
+        doc_key: str = ""
+        doc_status_base: dict[str, Any] = {}
         try:
             # Clean input texts
             full_text = sanitize_text_for_encoding(full_text)
             text_chunks = [sanitize_text_for_encoding(chunk) for chunk in text_chunks]
             file_path = normalize_document_file_path("")
 
-            # Process cleaned texts
             if doc_id is None:
                 doc_key = compute_mdhash_id(full_text, prefix="doc-")
             else:
                 doc_key = doc_id
-            new_docs = {doc_key: {"content": full_text, "file_path": file_path}}
 
-            _add_doc_keys = await self.full_docs.filter_keys({doc_key})
-            new_docs = {k: v for k, v in new_docs.items() if k in _add_doc_keys}
-            if not len(new_docs):
-                logger.warning("This document is already in the storage.")
+            # Not serialized: concurrent inserts with the same doc_id can
+            # interleave (no per-doc lock; the file pipeline serializes via its
+            # enqueue locks). Single-writer use only — a known limitation of this
+            # deprecated path.
+            #
+            # Gate reprocessing on doc_status, not on full_docs/text_chunks
+            # presence (mirroring the file pipeline, which lets a FAILED or
+            # crashed-PROCESSING doc rebuild in place — see
+            # pipeline._validate_and_fix_document_consistency). A PROCESSED doc
+            # is a no-op; anything else (absent / FAILED / interrupted
+            # PROCESSING) is rebuilt. On a rebuild the prior attempt's chunks and
+            # KG are purged first (below) so re-extraction starts fresh instead
+            # of accumulating duplicate descriptions over a surviving partial KG.
+            existing_status = await self.doc_status.get_by_id(doc_key)
+            if existing_status and existing_status.get("status") == DocStatus.PROCESSED:
+                logger.warning("This document is already processed.")
                 return
 
-            update_storage = True
-            logger.info(f"Inserting {len(new_docs)} docs")
+            new_docs = {doc_key: {"content": full_text, "file_path": file_path}}
 
             inserting_chunks: dict[str, Any] = {}
             for index, chunk_text in enumerate(text_chunks):
@@ -1548,15 +1562,21 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     "file_path": file_path,
                 }
 
-            doc_ids = set(inserting_chunks.keys())
-            add_chunk_keys = await self.text_chunks.filter_keys(doc_ids)
-            inserting_chunks = {
-                k: v for k, v in inserting_chunks.items() if k in add_chunk_keys
+            # doc_status record fields (mirroring _initial_doc_status in
+            # pipeline.py). created_at is preserved across retries so the
+            # document keeps its original creation time.
+            now = datetime.now(timezone.utc).isoformat()
+            doc_status_base = {
+                "content_summary": get_content_summary(full_text),
+                "content_length": len(full_text),
+                "file_path": file_path,
+                "created_at": (existing_status or {}).get("created_at", now),
+                "updated_at": now,
+                "track_id": (existing_status or {}).get("track_id"),
+                "chunks_count": len(inserting_chunks),
+                "chunks_list": list(inserting_chunks.keys()),
+                "metadata": {},
             }
-            if not len(inserting_chunks):
-                logger.warning("All chunks are already in the storage.")
-                return
-
             pipeline_status = await get_namespace_data(
                 "pipeline_status", workspace=self.workspace
             )
@@ -1564,10 +1584,60 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 "pipeline_status", workspace=self.workspace
             )
 
-            # Persist chunks/docs first so text_chunks exists before extraction
-            # reads it, then extract, then merge the extracted entities and
-            # relationships into the KG (mirroring the file pipeline in
-            # pipeline.py). Without this merge step the extraction result is
+            # Purge the prior attempt's chunks + KG before rebuilding, mirroring
+            # the pipeline's resume path (_purge_stale_extraction_if_resuming).
+            # This lets a retry of a doc whose prior merge COMPLETED (its
+            # full_entities / full_relations index rows were written — e.g. the
+            # merge finished but the doc was never marked PROCESSED, or the
+            # success-path flush failed) rebuild cleanly instead of re-appending
+            # entity/relation descriptions, and reclaims the prior chunks so they
+            # are not orphaned.
+            #
+            # Known limitation, shared with the file pipeline: purge discovers
+            # what to clean via full_entities / full_relations, which
+            # merge_nodes_and_edges writes only in its FINAL phase. A merge that
+            # wrote partial graph state and then failed leaves no index row, so
+            # purge cannot find those partial nodes; the retry re-merges over them
+            # and descriptions accumulate (bounded, and collapsed by later
+            # re-summarization). This is a merge_nodes_and_edges property, not
+            # specific to this path — the pipeline's resume purge has the same
+            # blind spot. Fixing it belongs in merge (cross-dedup of stored vs
+            # new descriptions), tracked separately.
+            #
+            # Purge is a no-op when nothing was stored before, and deterministic
+            # to re-run (identical text -> identical chunk ids -> idempotent
+            # deletes).
+            prior_chunks = [
+                c
+                for c in ((existing_status or {}).get("chunks_list") or [])
+                if isinstance(c, str)
+            ]
+            if prior_chunks:
+                await self._purge_doc_chunks_and_kg(
+                    doc_key,
+                    prior_chunks,
+                    pipeline_status=pipeline_status,
+                    pipeline_status_lock=pipeline_status_lock,
+                )
+
+            # Mark PROCESSING with the NEW chunks_list only AFTER purging the
+            # prior attempt. Doing it before purge would overwrite the prior
+            # chunks_list in doc_status, so if purge then failed the old chunks/KG
+            # would be stranded — a later retry would purge by the new ids and
+            # never reach the old ones. Purging first keeps the prior chunks_list
+            # intact for the next retry (mirroring the pipeline, which purges
+            # before writing the new state). doc_status is immediate-write, so a
+            # crash mid-merge leaves a resumable state (reprocessed via the gate).
+            await self.doc_status.upsert(
+                {doc_key: {**doc_status_base, "status": DocStatus.PROCESSING}}
+            )
+            update_storage = True
+            logger.info(f"Inserting custom chunks for doc {doc_key}")
+
+            # Persist chunks/docs first (idempotent upsert) so text_chunks exists
+            # before extraction reads it, then extract, then merge the extracted
+            # entities and relationships into the KG (mirroring the file pipeline
+            # in pipeline.py). Without this merge step the extraction result is
             # discarded and the graph / entity+relationship vector stores stay
             # empty, so KG-dependent query modes return nothing.
             await asyncio.gather(
@@ -1597,9 +1667,52 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     file_path=file_path,
                 )
 
-        finally:
+        except Exception as exc:
             if update_storage:
+                # Failure path (mirroring the file pipeline): mark the doc FAILED
+                # — doc_status is immediate-write, so the FAILED row survives the
+                # discard below — then DISCARD the pending KG/base buffers rather
+                # than flushing them. We do NOT delete chunks or full_docs here:
+                # any partial KG merge already wrote keeps its source_id pointing
+                # at a live chunk (never dangling); the retry purges and rebuilds
+                # it fresh. FAILED-mark and discard are guarded independently so a
+                # failure in one still runs the other, and neither masks the
+                # original error (always re-raised).
+                try:
+                    await self.doc_status.upsert(
+                        {
+                            doc_key: {
+                                **doc_status_base,
+                                "status": DocStatus.FAILED,
+                                "error_msg": str(exc),
+                            }
+                        }
+                    )
+                except Exception as status_err:
+                    logger.error(
+                        f"Failed to mark custom-chunks doc {doc_key} FAILED: "
+                        f"{status_err}"
+                    )
+                try:
+                    await self._discard_pending_index_ops(skip_enqueue_owned=False)
+                except Exception as discard_err:
+                    logger.error(
+                        f"Failed to discard pending ops for {doc_key}: {discard_err}"
+                    )
+            raise
+        else:
+            if update_storage:
+                # Flush the KG/chunks FIRST, then mark PROCESSED. If the flush
+                # raises (IndexFlushError on a server backend), the doc stays
+                # PROCESSING (written up front) — which the reprocess gate treats
+                # as rebuildable — instead of being left PROCESSED with its KG
+                # discarded and never rebuilt. Mirrors the file pipeline's
+                # flush-failure recovery, where a PROCESSED-before-flush error is
+                # caught and downgraded to a non-terminal status.
                 await self._insert_done_with_cleanup()
+                await self.doc_status.upsert(
+                    {doc_key: {**doc_status_base, "status": DocStatus.PROCESSED}}
+                )
 
     async def _process_extract_entities(
         self, chunk: dict[str, Any], pipeline_status=None, pipeline_status_lock=None

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -110,6 +110,7 @@ from lightrag.chunker import chunking_by_token_size
 from lightrag.operate import (
     extract_entities,
     kg_query,
+    merge_nodes_and_edges,
     naive_query,
     rebuild_knowledge_from_chunks,
 )
@@ -1556,13 +1557,45 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 logger.warning("All chunks are already in the storage.")
                 return
 
-            tasks = [
+            pipeline_status = await get_namespace_data(
+                "pipeline_status", workspace=self.workspace
+            )
+            pipeline_status_lock = get_namespace_lock(
+                "pipeline_status", workspace=self.workspace
+            )
+
+            # Persist chunks/docs first so text_chunks exists before extraction
+            # reads it, then extract, then merge the extracted entities and
+            # relationships into the KG (mirroring the file pipeline in
+            # pipeline.py). Without this merge step the extraction result is
+            # discarded and the graph / entity+relationship vector stores stay
+            # empty, so KG-dependent query modes return nothing.
+            await asyncio.gather(
                 self.chunks_vdb.upsert(inserting_chunks),
-                self._process_extract_entities(inserting_chunks),
                 self.full_docs.upsert(new_docs),
                 self.text_chunks.upsert(inserting_chunks),
-            ]
-            await asyncio.gather(*tasks)
+            )
+
+            chunk_results = await self._process_extract_entities(
+                inserting_chunks, pipeline_status, pipeline_status_lock
+            )
+            if chunk_results:
+                await merge_nodes_and_edges(
+                    chunk_results=chunk_results,
+                    knowledge_graph_inst=self.chunk_entity_relation_graph,
+                    entity_vdb=self.entities_vdb,
+                    relationships_vdb=self.relationships_vdb,
+                    global_config=self._build_global_config(),
+                    full_entities_storage=self.full_entities,
+                    full_relations_storage=self.full_relations,
+                    doc_id=doc_key,
+                    pipeline_status=pipeline_status,
+                    pipeline_status_lock=pipeline_status_lock,
+                    llm_response_cache=self.llm_response_cache,
+                    entity_chunks_storage=self.entity_chunks,
+                    relation_chunks_storage=self.relation_chunks,
+                    file_path=file_path,
+                )
 
         finally:
             if update_storage:
@@ -1584,9 +1617,13 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         except Exception as e:
             error_msg = f"Failed to extract entities and relationships: {str(e)}"
             logger.error(error_msg)
-            async with pipeline_status_lock:
-                pipeline_status["latest_message"] = error_msg
-                pipeline_status["history_messages"].append(error_msg)
+            # pipeline_status / lock are optional (callers may pass None), so
+            # guard against them here — otherwise ``async with None`` raises a
+            # TypeError that masks the original extraction error.
+            if pipeline_status_lock is not None and pipeline_status is not None:
+                async with pipeline_status_lock:
+                    pipeline_status["latest_message"] = error_msg
+                    pipeline_status["history_messages"].append(error_msg)
             raise e
 
     def _index_storages(self) -> list:

--- a/tests/pipeline/test_custom_chunks_kg_merge.py
+++ b/tests/pipeline/test_custom_chunks_kg_merge.py
@@ -1,0 +1,139 @@
+"""Regression tests for issue #3352.
+
+``ainsert_custom_chunks`` must build the KG from the extracted entities and
+relationships — i.e. capture the ``_process_extract_entities`` result and pass
+it to ``merge_nodes_and_edges`` (mirroring the file pipeline) — instead of
+firing extraction inside an ``asyncio.gather`` and discarding its return value.
+
+It must also pass ``pipeline_status`` / ``pipeline_status_lock`` down to
+extraction so the ``except`` block does not attempt ``async with None`` (which
+would raise a ``TypeError`` that masks the real extraction error).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import numpy as np
+import pytest
+
+import lightrag.lightrag as lightrag_module
+from lightrag import LightRAG
+from lightrag.kg.shared_storage import initialize_pipeline_status
+from lightrag.utils import EmbeddingFunc, Tokenizer
+
+pytestmark = pytest.mark.offline
+
+CHUNKS = [
+    "Marie Curie discovered polonium and radium.",
+    "Pierre Curie collaborated with Marie Curie on radioactivity research.",
+]
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _dummy_embedding(texts: list[str]) -> np.ndarray:
+    return np.ones((len(texts), 8), dtype=float)
+
+
+async def _dummy_llm(*args, **kwargs) -> str:
+    return "ok"
+
+
+async def _build_rag(tmp_path) -> LightRAG:
+    rag = LightRAG(
+        working_dir=str(tmp_path / "wd"),
+        workspace=f"custom-{uuid4().hex[:8]}",
+        llm_model_func=_dummy_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8, max_token_size=8192, func=_dummy_embedding
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+    )
+    await rag.initialize_storages()
+    await initialize_pipeline_status(rag.workspace)
+    return rag
+
+
+@pytest.mark.asyncio
+async def test_ainsert_custom_chunks_merges_extracted_entities(tmp_path, monkeypatch):
+    """The extracted chunk_results must be handed to merge_nodes_and_edges."""
+    rag = await _build_rag(tmp_path)
+    try:
+        sentinel_results = [("nodes", "edges")]
+
+        async def _fake_extract(chunks, *args, **kwargs):
+            # A non-empty extraction result (real extraction is exercised
+            # elsewhere; here we only assert the control flow around it).
+            return sentinel_results
+
+        monkeypatch.setattr(rag, "_process_extract_entities", _fake_extract)
+        merge_spy = AsyncMock()
+        monkeypatch.setattr(lightrag_module, "merge_nodes_and_edges", merge_spy)
+
+        await rag.ainsert_custom_chunks(
+            full_text="\n\n".join(CHUNKS), text_chunks=CHUNKS, doc_id="doc-merge"
+        )
+
+        merge_spy.assert_awaited_once()
+        kwargs = merge_spy.await_args.kwargs
+        assert kwargs["chunk_results"] is sentinel_results
+        assert kwargs["doc_id"] == "doc-merge"
+        assert kwargs["knowledge_graph_inst"] is rag.chunk_entity_relation_graph
+        assert kwargs["entity_vdb"] is rag.entities_vdb
+        assert kwargs["relationships_vdb"] is rag.relationships_vdb
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_ainsert_custom_chunks_skips_merge_when_extraction_empty(
+    tmp_path, monkeypatch
+):
+    """No entities extracted -> merge_nodes_and_edges must not be called."""
+    rag = await _build_rag(tmp_path)
+    try:
+
+        async def _fake_extract(chunks, *args, **kwargs):
+            return []
+
+        monkeypatch.setattr(rag, "_process_extract_entities", _fake_extract)
+        merge_spy = AsyncMock()
+        monkeypatch.setattr(lightrag_module, "merge_nodes_and_edges", merge_spy)
+
+        await rag.ainsert_custom_chunks(
+            full_text="\n\n".join(CHUNKS), text_chunks=CHUNKS, doc_id="doc-empty"
+        )
+
+        merge_spy.assert_not_awaited()
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_process_extract_entities_surfaces_real_error_without_lock(
+    tmp_path, monkeypatch
+):
+    """Secondary defect: with pipeline_status_lock=None the except block must
+    surface the real extraction error, not a TypeError from ``async with None``.
+    """
+    rag = await _build_rag(tmp_path)
+    try:
+
+        async def _boom(*args, **kwargs):
+            raise ValueError("extraction blew up")
+
+        monkeypatch.setattr(lightrag_module, "extract_entities", _boom)
+
+        # Called with the default pipeline_status / pipeline_status_lock = None.
+        with pytest.raises(ValueError, match="extraction blew up"):
+            await rag._process_extract_entities({"chunk-1": {"content": "x"}})
+    finally:
+        await rag.finalize_storages()

--- a/tests/pipeline/test_custom_chunks_kg_merge.py
+++ b/tests/pipeline/test_custom_chunks_kg_merge.py
@@ -20,8 +20,9 @@ import pytest
 
 import lightrag.lightrag as lightrag_module
 from lightrag import LightRAG
+from lightrag.base import DocStatus
 from lightrag.kg.shared_storage import initialize_pipeline_status
-from lightrag.utils import EmbeddingFunc, Tokenizer
+from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
 
 pytestmark = pytest.mark.offline
 
@@ -113,6 +114,359 @@ async def test_ainsert_custom_chunks_skips_merge_when_extraction_empty(
         )
 
         merge_spy.assert_not_awaited()
+
+        # A no-entity doc is still completed (PROCESSED), not left PROCESSING.
+        status = await rag.doc_status.get_by_id("doc-empty")
+        assert status is not None
+        assert status["status"] == DocStatus.PROCESSED
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_ainsert_custom_chunks_retryable_after_merge_failure(
+    tmp_path, monkeypatch
+):
+    """A KG merge failure must leave the insert retryable without leaking state.
+
+    Mirroring the file pipeline, ``ainsert_custom_chunks`` marks the doc FAILED
+    and DISCARDS (never flushes) the pending KG/base buffers on failure — it
+    does not delete chunks. So:
+    - the failed attempt leaves the doc FAILED (not PROCESSED);
+    - the chunks survive (a later partial-KG source_id stays resolvable);
+    - a retry (gated on doc_status, not on full_docs presence) reaches
+      ``merge_nodes_and_edges`` again and, on success, marks the doc PROCESSED.
+    """
+    rag = await _build_rag(tmp_path)
+    try:
+
+        async def _fake_extract(chunks, *args, **kwargs):
+            return [("nodes", "edges")]
+
+        monkeypatch.setattr(rag, "_process_extract_entities", _fake_extract)
+
+        async def _boom_merge(*args, **kwargs):
+            raise RuntimeError("transient merge failure")
+
+        monkeypatch.setattr(lightrag_module, "merge_nodes_and_edges", _boom_merge)
+
+        # First attempt: the merge fails and the error surfaces to the caller.
+        with pytest.raises(RuntimeError, match="transient merge failure"):
+            await rag.ainsert_custom_chunks(
+                full_text="\n\n".join(CHUNKS),
+                text_chunks=CHUNKS,
+                doc_id="doc-retry",
+            )
+
+        # The failed attempt is recorded FAILED, not PROCESSED.
+        status = await rag.doc_status.get_by_id("doc-retry")
+        assert status is not None
+        assert status["status"] == DocStatus.FAILED
+
+        # Chunks are NOT deleted — the anti-orphan invariant. Deleting them (the
+        # old delete-rollback) is what left partial-KG source_ids dangling.
+        chunk_key = compute_mdhash_id(CHUNKS[0], prefix="chunk-")
+        assert await rag.text_chunks.get_by_id(chunk_key) is not None
+
+        # This mock wrote nothing to the graph and the failure path discards
+        # rather than flushes, so no KG node is committed here.
+        assert await rag.chunk_entity_relation_graph.get_node("Marie Curie") is None
+
+        # Second attempt with a healthy merge must actually rebuild the KG,
+        # not bail out at a duplicate check.
+        merge_spy = AsyncMock()
+        monkeypatch.setattr(lightrag_module, "merge_nodes_and_edges", merge_spy)
+
+        await rag.ainsert_custom_chunks(
+            full_text="\n\n".join(CHUNKS),
+            text_chunks=CHUNKS,
+            doc_id="doc-retry",
+        )
+
+        merge_spy.assert_awaited_once()
+
+        # A successful retry marks the doc PROCESSED.
+        status = await rag.doc_status.get_by_id("doc-retry")
+        assert status is not None
+        assert status["status"] == DocStatus.PROCESSED
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_ainsert_custom_chunks_partial_merge_is_not_orphaned(
+    tmp_path, monkeypatch
+):
+    """A merge that writes partial graph state then fails must not orphan it.
+
+    ``merge_nodes_and_edges`` does not roll back its own partial writes, so a
+    caller that deleted chunks would leave those partial nodes' ``source_id``
+    pointing at deleted chunks (the leak a Codex review confirmed on real
+    merges). The doc_status model instead keeps chunks intact: the failed
+    attempt is FAILED, the chunk survives so any partial node's ``source_id``
+    still resolves, and a healthy retry rebuilds the KG idempotently.
+
+    We deliberately do NOT assert the partial node is absent after the failure:
+    on the in-memory NetworkX backend, ``_discard_pending_index_ops`` does not
+    roll back already-materialized writes. The guarantee is "no dangling
+    source_id + idempotent reprocess (+ nothing flushed to disk)", not "zero
+    partial nodes in memory".
+    """
+    rag = await _build_rag(tmp_path)
+    try:
+
+        async def _fake_extract(chunks, *args, **kwargs):
+            return [("nodes", "edges")]
+
+        monkeypatch.setattr(rag, "_process_extract_entities", _fake_extract)
+
+        chunk_key = compute_mdhash_id(CHUNKS[0], prefix="chunk-")
+
+        async def _partial_then_boom(*args, **kwargs):
+            # Write one graph node (as a real merge would), then fail.
+            await rag.chunk_entity_relation_graph.upsert_node(
+                "ENT",
+                {
+                    "entity_id": "ENT",
+                    "entity_type": "PERSON",
+                    "description": "partial",
+                    "source_id": chunk_key,
+                    "file_path": "unknown_source",
+                },
+            )
+            raise RuntimeError("transient merge failure")
+
+        monkeypatch.setattr(
+            lightrag_module, "merge_nodes_and_edges", _partial_then_boom
+        )
+
+        with pytest.raises(RuntimeError, match="transient merge failure"):
+            await rag.ainsert_custom_chunks(
+                full_text="\n\n".join(CHUNKS),
+                text_chunks=CHUNKS,
+                doc_id="doc-partial",
+            )
+
+        # FAILED, and the chunk survives — so the partial node's source_id
+        # resolves to a live chunk instead of dangling.
+        status = await rag.doc_status.get_by_id("doc-partial")
+        assert status is not None
+        assert status["status"] == DocStatus.FAILED
+        assert await rag.text_chunks.get_by_id(chunk_key) is not None
+
+        # A healthy retry rebuilds the KG (reaches merge again).
+        merge_spy = AsyncMock()
+        monkeypatch.setattr(lightrag_module, "merge_nodes_and_edges", merge_spy)
+        await rag.ainsert_custom_chunks(
+            full_text="\n\n".join(CHUNKS),
+            text_chunks=CHUNKS,
+            doc_id="doc-partial",
+        )
+        merge_spy.assert_awaited_once()
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_ainsert_custom_chunks_retry_purges_prior_chunks_and_kg(
+    tmp_path, monkeypatch
+):
+    """Rebuilding a FAILED doc must purge the prior attempt's chunks + KG first.
+
+    The retry must call _purge_doc_chunks_and_kg with the doc's stored
+    chunks_list before re-extracting, mirroring the file pipeline's resume purge,
+    so a completed-then-not-marked-PROCESSED merge rebuilds cleanly.
+
+    Scope: this asserts purge is invoked with the right args. It does NOT cover
+    the partial-merge case (merge writes some nodes then fails before its
+    full_entities index row is written) — there purge finds no index and the
+    retry re-merges, accumulating descriptions. That is a merge_nodes_and_edges
+    limitation shared with the pipeline, tracked separately; see the note in
+    ainsert_custom_chunks.
+    """
+    rag = await _build_rag(tmp_path)
+    try:
+
+        async def _fake_extract(chunks, *args, **kwargs):
+            return [("nodes", "edges")]
+
+        monkeypatch.setattr(rag, "_process_extract_entities", _fake_extract)
+
+        async def _boom_merge(*args, **kwargs):
+            raise RuntimeError("transient merge failure")
+
+        monkeypatch.setattr(lightrag_module, "merge_nodes_and_edges", _boom_merge)
+
+        # First attempt fails and stores the doc's chunks_list under FAILED.
+        with pytest.raises(RuntimeError, match="transient merge failure"):
+            await rag.ainsert_custom_chunks(
+                full_text="\n\n".join(CHUNKS),
+                text_chunks=CHUNKS,
+                doc_id="doc-purge",
+            )
+
+        status = await rag.doc_status.get_by_id("doc-purge")
+        assert status is not None
+        assert status["status"] == DocStatus.FAILED
+        stored_chunks = status["chunks_list"]
+        assert stored_chunks
+
+        # On retry, the prior chunks_list must be purged before rebuild.
+        purge_spy = AsyncMock()
+        monkeypatch.setattr(rag, "_purge_doc_chunks_and_kg", purge_spy)
+        monkeypatch.setattr(lightrag_module, "merge_nodes_and_edges", AsyncMock())
+
+        await rag.ainsert_custom_chunks(
+            full_text="\n\n".join(CHUNKS),
+            text_chunks=CHUNKS,
+            doc_id="doc-purge",
+        )
+
+        purge_spy.assert_awaited_once()
+        called_doc_id, called_chunks = purge_spy.await_args.args
+        assert called_doc_id == "doc-purge"
+        assert set(called_chunks) == set(stored_chunks)
+
+        # And the doc completes.
+        status = await rag.doc_status.get_by_id("doc-purge")
+        assert status is not None
+        assert status["status"] == DocStatus.PROCESSED
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_ainsert_custom_chunks_purge_failure_preserves_prior_chunks_list(
+    tmp_path, monkeypatch
+):
+    """A purge failure on retry must preserve the prior chunks_list anchor.
+
+    Purge runs BEFORE the PROCESSING upsert that overwrites doc_status with the
+    new chunks_list. So if purge fails, doc_status still holds the PRIOR
+    chunks_list — the next retry can still purge the old chunks/KG. If the
+    PROCESSING write happened first (the bug), a purge failure would strand the
+    old chunks/KG (a later retry would purge by the new ids and never reach them).
+    """
+    rag = await _build_rag(tmp_path)
+    try:
+
+        async def _fake_extract(chunks, *args, **kwargs):
+            return [("nodes", "edges")]
+
+        monkeypatch.setattr(rag, "_process_extract_entities", _fake_extract)
+
+        # First attempt fails -> FAILED with its chunks_list (the "prior" anchor).
+        async def _boom_merge(*args, **kwargs):
+            raise RuntimeError("merge failure")
+
+        monkeypatch.setattr(lightrag_module, "merge_nodes_and_edges", _boom_merge)
+        with pytest.raises(RuntimeError, match="merge failure"):
+            await rag.ainsert_custom_chunks(
+                full_text="\n\n".join(CHUNKS),
+                text_chunks=CHUNKS,
+                doc_id="doc-anchor",
+            )
+        prior_status = await rag.doc_status.get_by_id("doc-anchor")
+        assert prior_status is not None
+        prior_chunks = prior_status["chunks_list"]
+        assert prior_chunks
+
+        # Retry with DIFFERENT chunk text (new chunks_list differs) and make the
+        # purge fail. The prior chunks_list must NOT be overwritten.
+        async def _boom_purge(*args, **kwargs):
+            raise RuntimeError("purge failure")
+
+        monkeypatch.setattr(rag, "_purge_doc_chunks_and_kg", _boom_purge)
+
+        new_chunks = ["An entirely different chunk about another subject."]
+        with pytest.raises(RuntimeError, match="purge failure"):
+            await rag.ainsert_custom_chunks(
+                full_text="\n\n".join(new_chunks),
+                text_chunks=new_chunks,
+                doc_id="doc-anchor",
+            )
+
+        after = await rag.doc_status.get_by_id("doc-anchor")
+        assert after is not None
+        assert after["chunks_list"] == prior_chunks
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_ainsert_custom_chunks_first_insert_does_not_purge(tmp_path, monkeypatch):
+    """A brand-new doc (no prior doc_status) must NOT call purge — there is
+    nothing to purge, and purge is skipped when chunks_list is empty/absent."""
+    rag = await _build_rag(tmp_path)
+    try:
+
+        async def _fake_extract(chunks, *args, **kwargs):
+            return []
+
+        monkeypatch.setattr(rag, "_process_extract_entities", _fake_extract)
+        monkeypatch.setattr(lightrag_module, "merge_nodes_and_edges", AsyncMock())
+
+        purge_spy = AsyncMock()
+        monkeypatch.setattr(rag, "_purge_doc_chunks_and_kg", purge_spy)
+
+        await rag.ainsert_custom_chunks(
+            full_text="\n\n".join(CHUNKS),
+            text_chunks=CHUNKS,
+            doc_id="doc-fresh",
+        )
+
+        purge_spy.assert_not_awaited()
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_ainsert_custom_chunks_flush_failure_keeps_doc_rebuildable(
+    tmp_path, monkeypatch
+):
+    """A success-path flush failure must not leave the doc PROCESSED-but-empty.
+
+    PROCESSED is marked only AFTER a clean flush, so a flush error (e.g.
+    IndexFlushError on a server backend) leaves the doc PROCESSING — which the
+    reprocess gate treats as rebuildable — and a retry completes it, instead of
+    a permanently "done but KG-missing" doc that the gate would skip forever.
+    """
+    rag = await _build_rag(tmp_path)
+    try:
+
+        async def _fake_extract(chunks, *args, **kwargs):
+            return [("nodes", "edges")]
+
+        monkeypatch.setattr(rag, "_process_extract_entities", _fake_extract)
+        monkeypatch.setattr(lightrag_module, "merge_nodes_and_edges", AsyncMock())
+
+        async def _boom_flush():
+            raise RuntimeError("flush failed")
+
+        monkeypatch.setattr(rag, "_insert_done_with_cleanup", _boom_flush)
+
+        with pytest.raises(RuntimeError, match="flush failed"):
+            await rag.ainsert_custom_chunks(
+                full_text="\n\n".join(CHUNKS),
+                text_chunks=CHUNKS,
+                doc_id="doc-flush",
+            )
+
+        # The doc must NOT be PROCESSED — the KG was never flushed.
+        status = await rag.doc_status.get_by_id("doc-flush")
+        assert status is not None
+        assert status["status"] != DocStatus.PROCESSED
+
+        # A retry with a healthy flush completes it.
+        monkeypatch.setattr(rag, "_insert_done_with_cleanup", AsyncMock())
+        await rag.ainsert_custom_chunks(
+            full_text="\n\n".join(CHUNKS),
+            text_chunks=CHUNKS,
+            doc_id="doc-flush",
+        )
+        status = await rag.doc_status.get_by_id("doc-flush")
+        assert status is not None
+        assert status["status"] == DocStatus.PROCESSED
     finally:
         await rag.finalize_storages()
 

--- a/tests/pipeline/test_document_file_path_normalization.py
+++ b/tests/pipeline/test_document_file_path_normalization.py
@@ -142,14 +142,20 @@ async def test_error_document_enqueue_canonicalizes_file_path_before_upsert():
 @pytest.mark.asyncio
 async def test_custom_chunks_use_canonical_unknown_source_before_upsert():
     from lightrag import LightRAG
+    from lightrag.kg.shared_storage import initialize_pipeline_status
 
     rag = LightRAG.__new__(LightRAG)
+    rag.workspace = ""
     rag.full_docs = CaptureKV()
     rag.text_chunks = CaptureKV()
     rag.chunks_vdb = CaptureKV()
     rag.tokenizer = type("Tokenizer", (), {"encode": lambda self, text: [text]})()
+    await initialize_pipeline_status(rag.workspace)
 
-    async def _process_extract_entities(chunks):
+    # ainsert_custom_chunks now passes pipeline_status / lock down to extraction
+    # (see #3352); accept and ignore them here. Empty results -> no KG merge, so
+    # this test still exercises only the file_path canonicalization path.
+    async def _process_extract_entities(chunks, *args, **kwargs):
         return []
 
     async def _insert_done():

--- a/tests/pipeline/test_document_file_path_normalization.py
+++ b/tests/pipeline/test_document_file_path_normalization.py
@@ -65,6 +65,9 @@ class CaptureKV:
     async def filter_keys(self, keys):
         return set(keys)
 
+    async def get_by_id(self, id):
+        return None
+
     async def upsert(self, data):
         self.upserts.append(data)
 
@@ -154,21 +157,24 @@ async def test_custom_chunks_use_canonical_unknown_source_before_upsert():
     rag.full_docs = CaptureKV()
     rag.text_chunks = CaptureKV()
     rag.chunks_vdb = CaptureKV()
+    rag.doc_status = CaptureKV()
     rag.tokenizer = type("Tokenizer", (), {"encode": lambda self, text: [text]})()
     initialize_share_data()
     await initialize_pipeline_status(rag.workspace)
 
     # ainsert_custom_chunks now passes pipeline_status / lock down to extraction
     # (see #3352); accept and ignore them here. Empty results -> no KG merge, so
-    # this test still exercises only the file_path canonicalization path.
+    # this test still exercises only the file_path canonicalization path. It also
+    # gates reprocessing on doc_status and flushes via _insert_done_with_cleanup,
+    # so stub both here.
     async def _process_extract_entities(chunks, *args, **kwargs):
         return []
 
-    async def _insert_done():
+    async def _insert_done_with_cleanup():
         return None
 
     rag._process_extract_entities = _process_extract_entities
-    rag._insert_done = _insert_done
+    rag._insert_done_with_cleanup = _insert_done_with_cleanup
 
     await rag.ainsert_custom_chunks("full text", ["chunk text"], doc_id="doc-1")
 

--- a/tests/pipeline/test_document_file_path_normalization.py
+++ b/tests/pipeline/test_document_file_path_normalization.py
@@ -13,6 +13,8 @@ from lightrag.base import DocStatus  # noqa: E402
 from lightrag.constants import PROCESS_OPTION_CHUNK_FIXED  # noqa: E402
 from lightrag.pipeline import _PipelineMixin  # noqa: E402
 
+pytestmark = pytest.mark.offline
+
 
 class DummyRAG:
     def __init__(self):
@@ -142,7 +144,10 @@ async def test_error_document_enqueue_canonicalizes_file_path_before_upsert():
 @pytest.mark.asyncio
 async def test_custom_chunks_use_canonical_unknown_source_before_upsert():
     from lightrag import LightRAG
-    from lightrag.kg.shared_storage import initialize_pipeline_status
+    from lightrag.kg.shared_storage import (
+        initialize_pipeline_status,
+        initialize_share_data,
+    )
 
     rag = LightRAG.__new__(LightRAG)
     rag.workspace = ""
@@ -150,6 +155,7 @@ async def test_custom_chunks_use_canonical_unknown_source_before_upsert():
     rag.text_chunks = CaptureKV()
     rag.chunks_vdb = CaptureKV()
     rag.tokenizer = type("Tokenizer", (), {"encode": lambda self, text: [text]})()
+    initialize_share_data()
     await initialize_pipeline_status(rag.workspace)
 
     # ainsert_custom_chunks now passes pipeline_status / lock down to extraction


### PR DESCRIPTION
## Summary

Fixes #3352.

`ainsert_custom_chunks` fires entity extraction inside an `asyncio.gather` and **discards its return value**, so `merge_nodes_and_edges` never runs. The extracted entities/relationships are dropped: the knowledge graph and `entities_vdb` / `relationships_vdb` stay empty while the extraction LLM calls (and their cost/latency) are still spent. KG-dependent query modes (`local` / `global` / `hybrid` / `mix`) then return no context.

The normal file pipeline (`lightrag/pipeline.py`) captures the extraction result and merges it via `merge_nodes_and_edges`. `ainsert_custom_chunks` omitted that step.

There is also a secondary error-masking defect: extraction is called without `pipeline_status` / `pipeline_status_lock` (both default to `None`), so if extraction raises, the `except` block runs `async with pipeline_status_lock:` on a `None` lock and raises `TypeError: 'NoneType' object does not support the asynchronous context manager protocol`, masking the real error.

## Changes

`lightrag/lightrag.py`:
- Persist chunks/docs first (so `text_chunks` exists before extraction reads it), then **capture** the `_process_extract_entities` result and pass it to `merge_nodes_and_edges` — mirroring the file pipeline. Import `merge_nodes_and_edges` from `lightrag.operate`.
- Pass `pipeline_status` / `pipeline_status_lock` down to `_process_extract_entities`, and guard its `except` block against a `None` lock so the real extraction error surfaces.

`tests/pipeline/test_custom_chunks_kg_merge.py` (new) — regression tests:
- extracted `chunk_results` are handed to `merge_nodes_and_edges` (with the right graph/vdb/doc_id);
- no entities extracted → merge is not called;
- with `pipeline_status_lock=None`, a failing extraction surfaces the real error, not a `TypeError`.

`tests/pipeline/test_document_file_path_normalization.py` — minimal update of the existing custom-chunks test for the new extraction call signature (status/lock are now passed through).

## Behavior (before → after), same instance / same text

`ainsert_custom_chunks` of two chunks about Marie/Pierre Curie:

**Before** — extraction runs, graph stays empty:
```
Chunk 1 of 2 extracted 4 Ent + 3 Rel
Chunk 2 of 2 extracted 3 Ent + 3 Rel
Writing graph with 0 nodes, 0 edges        # no merge ran
get_all_labels() -> 0
hybrid query -> [no-context]
```

**After** — extracted entities are merged, matching what `ainsert` produces for the same text:
```
Chunk N of M extracted X Ent + Y Rel
Merging stage ... / Completed merging: <N> entities, <M> relations
Writing graph with <N> nodes, <M> edges
get_all_labels() -> <N>
hybrid query -> grounded answer
```

## Test verification

- New tests pass against the fix; all three **fail against the pre-fix code** (confirming they pin the defect).
- `ruff check` clean on the changed files.
- Reproduced live end-to-end with real Gemini (`gemini-flash-lite-latest` + `gemini-embedding-001`) — details and full logs in #3352.
