### PR TITLE
docs(api-server): clarify X-API-Key and Authorization are mutually exclusive per request, fixes #2632

### DIFF
--- a/docs/LightRAG-API-Server-zh.md
+++ b/docs/LightRAG-API-Server-zh.md
@@ -633,6 +633,8 @@ lightrag-hash-password --username admin
 
 如果未配置账户凭证，Web 界面将以访客身份访问系统。因此，即使仅配置了 API 密钥，所有 API 仍然可以通过访客账户访问，这仍然不安全。因此，要保护 API，需要同时配置这两种认证方法。
 
+> 尽管服务器可**同时**配置 API 密钥与账户凭证，但单个请求应**只发送** `X-API-Key` **或** `Authorization: Bearer <token>` 之一，不要同时发送。当两个请求头同时存在时，服务端会优先校验 `Authorization` token；若该 token 无效或过期，即使同时附带了有效的 `X-API-Key`，请求也会以 `401 Invalid token` 被拒绝。
+
 ## Azure OpenAI 后端配置
 
 可以使用以下 Azure CLI 命令创建 Azure OpenAI API（您需要先从 [https://docs.microsoft.com/en-us/cli/azure/install-azure-cli](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) 安装 Azure CLI）：

--- a/docs/LightRAG-API-Server.md
+++ b/docs/LightRAG-API-Server.md
@@ -633,6 +633,8 @@ The command prompts for the password and prints an `admin:{bcrypt}...` entry rea
 
 If Account credentials are not configured, the Web UI will access the system as a Guest. Therefore, even if only an API Key is configured, all APIs can still be accessed through the Guest account, which remains insecure. Hence, to safeguard the API, it is necessary to configure both authentication methods simultaneously.
 
+> Although the server can be configured with **both** an API key and account credentials, a single request should send **either** `X-API-Key` **or** `Authorization: Bearer <token>` — not both. When both headers are present, the `Authorization` token is validated first; if it is invalid or expired the request is rejected with `401 Invalid token` even when a valid `X-API-Key` is also supplied.
+
 ## For Azure OpenAI Backend
 
 Azure OpenAI API can be created using the following commands in Azure CLI (you need to install Azure CLI first from [https://docs.microsoft.com/en-us/cli/azure/install-azure-cli](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)):


### PR DESCRIPTION
Fixes #2632

## Why
When both `LIGHTRAG_API_KEY` (API key) and account credentials (JWT) are configured, a client that sends **both** `X-API-Key` and `Authorization: Bearer <token>` in a single request gets `401 Invalid token` even when the API key is valid. This tripped up users — see the resolution in #2632's comments ("Do not provide both Authorization and X-API-Key in your HTTP header").

## Root cause
`lightrag/api/utils_api.py` → `get_combined_auth_dependency()` returns a dependency that reads both `Authorization` (OAuth2PasswordBearer) and `X-API-Key` (APIKeyHeader). The `Authorization` token is validated **first**; if it is invalid/expired the request is rejected with `401 Invalid token` (raised in `lightrag/api/auth.py`) before the API key is consulted.

This ordering is intentional and correct (validate the token if one is presented). The gap is purely documentary: the API Server docs recommend configuring *both* auth methods, but never state that the two headers are mutually exclusive **per request**.

## What changed
- Added a one-line `>` note right after the "configure both authentication methods" paragraph in `docs/LightRAG-API-Server.md` (EN) and `docs/LightRAG-API-Server-zh.md` (ZH), clarifying that a single request should send **either** `X-API-Key` **or** `Authorization: Bearer <token>` — not both — and that the `Authorization` token is validated first.
- Style matches the existing `>` blockquote notes in the same section.

Externally observable behavior is unchanged — **no code touched**.

## Side effect analysis
- Default value: not changed (docs only)
- Backward compatibility: no API/behavior change
- Downstream consumers: none affected
- Security boundary: none opened

## Validation
- Docs-only change; no code, so no unit tests apply.
- Verified: only 2 files changed (+4 lines), no trailing whitespace, EOF newline preserved (matches `.pre-commit-config.yaml` hooks).
- CI green: pending — fork PRs require maintainer approval to run workflows.

## AI assistance
**Tool(s) used:** Claude Code
**How:** AI located the auth dependency, confirmed the token-first ordering in `utils_api.py`, and drafted the bilingual note. I reviewed every line and verified the diff.
- [x] I have read and understand every line of this change and take responsibility for it.
