### PR TITLE
perf(operate): tokenize each description once in entity/relation summary map-reduce

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -313,8 +313,13 @@ async def _handle_entity_relation_summary(
         # Calculate total tokens in current list while periodically yielding so
         # a large merge does not monopolize the event loop in single-worker mode.
         total_tokens = 0
+        # Tokenize each description once; the chunk-building pass below
+        # reuses these counts instead of re-encoding the same strings.
+        desc_token_counts = []
         for i, desc in enumerate(current_list, start=1):
-            total_tokens += len(tokenizer.encode(desc))
+            tokens = len(tokenizer.encode(desc))
+            desc_token_counts.append(tokens)
+            total_tokens += tokens
             await _cooperative_yield(i, every=32)
 
         # If total length is within limits, perform final summarization
@@ -352,9 +357,12 @@ async def _handle_entity_relation_summary(
         current_chunk = []
         current_tokens = 0
 
-        # Currently least 3 descriptions in current_list
-        for i, desc in enumerate(current_list, start=1):
-            desc_tokens = len(tokenizer.encode(desc))
+        # Currently least 3 descriptions in current_list.
+        # Reuse the per-description token counts computed above instead of
+        # re-encoding every description a second time.
+        for i, (desc, desc_tokens) in enumerate(
+            zip(current_list, desc_token_counts), start=1
+        ):
             await _cooperative_yield(i, every=32)
 
             # If adding current description would exceed limit, finalize current chunk

--- a/tests/extraction/test_summary_map_reduce_perf.py
+++ b/tests/extraction/test_summary_map_reduce_perf.py
@@ -1,0 +1,115 @@
+"""Regression tests for the map-reduce chunking path of
+``_handle_entity_relation_summary``.
+
+The map phase tokenizes every description to decide (a) whether the list
+needs splitting and (b) where to cut the chunks. Historically the same
+description was encoded twice per map-reduce iteration — once to sum the
+total token count and again while building the chunks — which doubled the
+tiktoken BPE cost on every entity/edge merge. The counts from the first
+pass are now memoized and reused by the second.
+
+These tests guard:
+
+* the chunking output is unchanged (behavioral), and
+* each description is encoded exactly once per map-reduce iteration
+  (the perf property the fix introduced).
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lightrag.utils import Tokenizer, TokenizerInterface
+
+
+class _CountingTokenizer(TokenizerInterface):
+    """1:1 character-to-token mapping that records every ``encode`` input."""
+
+    def __init__(self) -> None:
+        self.encoded: list[str] = []
+
+    def encode(self, content: str):
+        self.encoded.append(content)
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens):
+        return "".join(chr(token) for token in tokens)
+
+
+def _make_chunking_config(mock_extract) -> tuple[dict, _CountingTokenizer]:
+    """``global_config`` whose ``summary_context_size`` forces the map-reduce
+    chunking path (4 five-token descriptions vs. a 10-token window)."""
+    counter = _CountingTokenizer()
+    tokenizer = Tokenizer("dummy", counter)
+    global_config = {
+        "role_llm_funcs": {"extract": mock_extract},
+        "addon_params": {},
+        "_resolved_summary_language": "English",
+        "summary_length_recommended": 100,
+        # 4 descriptions x 5 tokens = 20 tokens > 10-token window → chunking
+        "summary_context_size": 10,
+        "summary_max_tokens": 100_000,
+        "force_llm_summary_on_merge": 10,
+        "tokenizer": tokenizer,
+    }
+    return global_config, counter
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_map_reduce_chunking_is_preserved():
+    """Forcing the chunking path must still split the descriptions into groups,
+    summarize each via the LLM, and join the results — i.e. memoizing the
+    token counts must not change the chunk boundaries or the final output."""
+    from lightrag.operate import _handle_entity_relation_summary
+
+    # Distinct summaries per reduce call so the joined result reflects the
+    # number of chunks produced.
+    mock_extract = AsyncMock(side_effect=["SUM_ONE", "SUM_TWO", "SUM_THREE"])
+    global_config, _ = _make_chunking_config(mock_extract)
+
+    description, llm_was_used = await _handle_entity_relation_summary(
+        "Entity",
+        "TEST_ENTITY",
+        ["alpha", "beta", "gamma", "delta"],
+        "<SEP>",
+        global_config,
+        llm_response_cache=None,
+    )
+
+    # Reduce phase ran (the LLM was used to summarize at least one chunk).
+    assert llm_was_used is True
+    # 4 five-token descriptions under a 10-token window → 2 chunks → 2 summaries
+    # joined in the next iteration (len == 2 takes the no-LLM join exit).
+    assert description == "SUM_ONE<SEP>SUM_TWO"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_map_phase_encodes_each_description_once():
+    """The map phase must tokenize each description exactly once per
+    map-reduce iteration. Pre-fix the chunk-building pass re-encoded every
+    description, so each of the 4 inputs appeared 2x in the first iteration;
+    post-fix it appears exactly once (the second pass reuses the counts)."""
+    from lightrag.operate import _handle_entity_relation_summary
+
+    mock_extract = AsyncMock(side_effect=["SUM_ONE", "SUM_TWO", "SUM_THREE"])
+    global_config, counter = _make_chunking_config(mock_extract)
+    inputs = ["alpha", "beta", "gamma", "delta"]
+
+    await _handle_entity_relation_summary(
+        "Entity",
+        "TEST_ENTITY",
+        inputs,
+        "<SEP>",
+        global_config,
+        llm_response_cache=None,
+    )
+
+    # In the first (chunking) iteration each input description must be encoded
+    # exactly once by the map phase. Pre-fix this was 2 per description.
+    for desc in inputs:
+        assert counter.encoded.count(desc) == 1, (
+            f"description {desc!r} was encoded {counter.encoded.count(desc)} "
+            f"time(s) by the map phase; expected exactly 1 (memoized counts)"
+        )


### PR DESCRIPTION
## Why

`_handle_entity_relation_summary` runs the map-reduce description merge for **every entity and every edge** during ingestion (it is invoked once per entity from `_merge_nodes_then_upsert` and once per edge from `_merge_edges_then_upsert`, both fanned out as N concurrent tasks under a semaphore in `extract_entities`). On each map-reduce iteration it tokenized every description **twice** — once to compute `total_tokens`, then again while building chunks — doubling the tiktoken BPE cost on the hottest CPU op in the merge stage. For a 1000-entity merge with a handful of descriptions each, that is thousands of redundant encodes per ingestion batch.

(Self-discovered while profiling the ingestion path; no tracking issue.)

## Root cause

`lightrag/operate.py`, function `_handle_entity_relation_summary`. Two passes walk the **same** `current_list` in the same `while` iteration:

```python
# Pass 1 — sum total tokens (operate.py:316-318)
for i, desc in enumerate(current_list, start=1):
    total_tokens += len(tokenizer.encode(desc))   # encode #1 per desc

# ... (no mutation of current_list between the passes) ...

# Pass 2 — build chunks (operate.py:356-357)
for i, desc in enumerate(current_list, start=1):
    desc_tokens = len(tokenizer.encode(desc))      # encode #2, same desc
```

`current_list` is unchanged between the two passes (Pass 2 is only reached when the list does not fit the context window), so the per-description counts computed in Pass 1 are simply discarded and recomputed in Pass 2.

## What changed

- Pass 1 now records each `len(tokenizer.encode(desc))` into a `desc_token_counts` list while summing `total_tokens`.
- Pass 2 iterates `zip(current_list, desc_token_counts)` and reuses the counts instead of re-encoding.

Externally observable behavior is **unchanged** — same input list, same iteration order, identical chunk boundaries and `current_tokens` arithmetic. No core runtime (pipeline / shared_storage) semantics touched; the `_cooperative_yield` cadence is preserved in both passes.

## Side effect analysis

- Default value: not changed
- Backward compatibility: output is byte-identical (verified by the regression test)
- Downstream consumers: none affected
- Security boundary: none (pure compute refactor)

## Validation

- `python -m pytest tests/extraction/test_summary_map_reduce_perf.py -v` → **2 passed** (one asserts the chunking output is preserved; one asserts each description is encoded exactly once per map-reduce iteration)
- `python -m pytest tests/extraction/test_summary_sanitization.py tests/extraction/test_summary_map_reduce_perf.py -v` → **6 passed** (no regression in the existing summary tests)
- `ruff check lightrag/operate.py` → All checks passed
- `ruff format --check lightrag/operate.py` → clean
- CI green: pending — fork PRs require maintainer approval to run workflows

## AI assistance

**Tool(s) used:** Claude Code
**How:** AI profiled the ingestion path, located the double-encode, implemented the memoization, and wrote the regression test. I reviewed every line and verified the diff is behavior-preserving.
- [x] I have read and understand every line of this change and take responsibility for it.
