### PR TITLE
perf(kg): close Milvus and Qdrant clients in finalize() to release connections

### DIFF
--- a/lightrag/kg/milvus_impl.py
+++ b/lightrag/kg/milvus_impl.py
@@ -2867,18 +2867,34 @@ class MilvusVectorDBStorage(BaseVectorStorage):
             return result
 
     async def finalize(self):
-        """Flush pending vector ops; surface unflushed data as RuntimeError.
+        """Flush pending vector ops, then release the Milvus gRPC channel.
 
-        Milvus has no client connection to release (the MilvusClient is
-        stateless from the storage layer's perspective), but we still need
-        to fail loudly when a transient bulk error left writes buffered —
-        the caller must not believe storage finalized cleanly.
+        Every other server-backed storage releases its client here (Neo4j
+        driver, Postgres pool, Mongo client, OpenSearch ClientManager); the
+        MilvusClient owns a gRPC channel that should be closed explicitly
+        too — ``close()`` is already used for that purpose by
+        ``_rebuild_milvus_client``. We still fail loudly when a transient
+        bulk error left writes buffered — the caller must not believe
+        storage finalized cleanly.
         """
         flush_error: Exception | None = None
         try:
             await self._flush_pending_vector_ops()
         except Exception as e:
             flush_error = e
+
+        # Release the gRPC channel after the flush so the flush can still use
+        # the client. Best-effort: close() on a dead channel is a no-op (see
+        # _rebuild_milvus_client). The connection is freed on every exit path,
+        # matching the close-on-release pattern of the other server-backed
+        # storages (Neo4j / Postgres / Mongo / OpenSearch).
+        if self._client is not None:
+            try:
+                self._client.close()
+            except Exception as close_error:
+                logger.warning(
+                    f"[{self.workspace}] Failed to close Milvus client: {close_error}"
+                )
 
         # Read the residual buffer sizes under the flush lock so the
         # snapshot is consistent with any racing late-arriving mutator

--- a/lightrag/kg/qdrant_impl.py
+++ b/lightrag/kg/qdrant_impl.py
@@ -1285,12 +1285,13 @@ class QdrantVectorDBStorage(BaseVectorStorage):
             return result
 
     async def finalize(self):
-        """Flush pending vector ops; surface unflushed data as RuntimeError.
+        """Flush pending vector ops, then release the Qdrant client.
 
-        Qdrant has no client connection that needs explicit release here
-        (the QdrantClient is held by the storage instance and torn down
-        on GC), but we still need to fail loudly when a transient bulk
-        error left writes buffered. ``_flush_pending_vector_ops`` is
+        The QdrantClient owns an HTTP/gRPC transport that should be closed
+        explicitly rather than left for GC — matching the close-on-release
+        pattern used by the other server-backed storages (Neo4j / Postgres /
+        Mongo / OpenSearch / Milvus). We still fail loudly when a transient
+        bulk error left writes buffered. ``_flush_pending_vector_ops`` is
         all-or-nothing: it either clears both buffers or raises with
         them intact, but we still defensively check both buffers after a
         successful flush in case a future refactor breaks that invariant.
@@ -1300,6 +1301,17 @@ class QdrantVectorDBStorage(BaseVectorStorage):
             await self._flush_pending_vector_ops()
         except Exception as e:
             flush_error = e
+
+        # Release the client after the flush so the flush can still use it.
+        # The transport is freed on every exit path, matching the
+        # close-on-release pattern of the other server-backed storages.
+        if self._client is not None:
+            try:
+                self._client.close()
+            except Exception as close_error:
+                logger.warning(
+                    f"[{self.workspace}] Failed to close Qdrant client: {close_error}"
+                )
 
         async with self._flush_lock:
             pending_docs = len(self._pending_vector_docs)

--- a/tests/kg/milvus_impl/test_milvus_deferred_embedding.py
+++ b/tests/kg/milvus_impl/test_milvus_deferred_embedding.py
@@ -703,3 +703,18 @@ async def test_drop_pending_index_ops_clears_buffers():
     await s.drop_pending_index_ops()
     assert not s._pending_vector_docs
     assert not s._pending_vector_deletes
+
+
+@pytest.mark.asyncio
+async def test_finalize_closes_milvus_client():
+    """finalize() must release the Milvus gRPC channel instead of leaving it
+    for GC — mirroring the close-on-release pattern of the other server-backed
+    storages and the in-file ``_rebuild_milvus_client``."""
+    s = _make_storage(MockEmbeddingFunc())
+    client = s._client
+    assert client is not None
+
+    # No pending writes → finalize must not raise.
+    await s.finalize()
+
+    client.close.assert_called_once()

--- a/tests/kg/qdrant_impl/test_qdrant_deferred_embedding.py
+++ b/tests/kg/qdrant_impl/test_qdrant_deferred_embedding.py
@@ -514,3 +514,17 @@ async def test_drop_pending_index_ops_clears_buffers():
     await s.drop_pending_index_ops()
     assert not s._pending_vector_docs
     assert not s._pending_vector_deletes
+
+
+@pytest.mark.asyncio
+async def test_finalize_closes_qdrant_client():
+    """finalize() must release the Qdrant client transport instead of leaving
+    it for GC — mirroring the close-on-release pattern of the other
+    server-backed storages."""
+    s = _make_storage(MockEmbeddingFunc())
+    client = s._client
+    assert client is not None
+
+    await s.finalize()
+
+    client.close.assert_called_once()


### PR DESCRIPTION
## Why

`MilvusVectorDBStorage.finalize()` and `QdrantVectorDBStorage.finalize()` flush pending writes but **never release the underlying client**, leaking one gRPC/HTTP transport per vector storage per process. A LightRAG instance creates 3 vector storages (`entities_vdb`, `relationships_vdb`, `chunks_vdb`), so a 4-worker Gunicorn deployment leaks 12 long-lived transports to the vector server with no close path.

Every other server-backed storage closes its client in `finalize()`: Neo4j driver (`neo4j_impl.py`), Postgres pool, Mongo client (#3251), OpenSearch `ClientManager`. This continues that pattern (#3251 Mongo, #3261 Anthropic).

## Root cause

Both `finalize()` methods flushed and surfaced unflushed-buffer errors but stopped there. Their docstrings claimed the client was safe to leave to GC:

- `lightrag/kg/milvus_impl.py:2872` — *"Milvus has no client connection to release (the MilvusClient is stateless …)"*
- `lightrag/kg/qdrant_impl.py:1290` — *"Qdrant has no client connection that needs explicit release here (… torn down on GC)"*

That claim is contradicted inside the same Milvus file: `_rebuild_milvus_client()` (milvus_impl.py:513) explicitly calls `old_client.close()` to release the gRPC channel, with its own docstring noting *"close() is best-effort — on a dead channel it is a no-op release"* — i.e. on a live channel it is a real release. So `close()` is meaningful and was simply not wired into `finalize()`.

## What changed

- After the flush (so the flush can still use the client), each `finalize()` calls `self._client.close()` best-effort, wrapped in `try/except` that logs on failure — identical to the pattern already used by `_rebuild_milvus_client()`.
- Updated both `finalize()` docstrings to reflect that the client is now released.
- `self._client` is intentionally **not** set to `None`: `close()` already releases the transport, and keeping the reference preserves post-finalize inspection (and the existing deferred-embedding tests that assert on `s._client.upsert` / `s._client.delete` after a clean flush).

Externally observable behavior during normal operation is unchanged — `finalize()` is a shutdown/teardown path; the only new effect is that the transport is released eagerly instead of waiting for GC.

## Side effect analysis

- Default value: not changed
- Backward compatibility: no API or runtime behavior change; `finalize()` still flushes first and surfaces the same `RuntimeError` on unflushed buffers (the close runs after the flush and before those checks)
- Downstream consumers: none affected
- Security boundary: none opened (closes a connection; does not open any path)
- Double-finalize safety: `close()` on an already-closed Milvus channel is a documented no-op; Qdrant failures are caught by the `try/except`

## Validation

- `python -m pytest tests/kg/milvus_impl/test_milvus_deferred_embedding.py tests/kg/qdrant_impl/test_qdrant_deferred_embedding.py -q` → **56 passed** (2 new regression tests asserting `finalize()` calls `client.close()`, plus all existing flush/upsert/drop tests unchanged)
- `ruff check` / `ruff format --check` on the 4 changed files → clean
- CI green: pending — fork PRs require maintainer approval to run workflows

## AI assistance

**Tool(s) used:** Claude Code
**How:** AI audited the storage backends for resource leaks, located the two missing `close()` calls, implemented the best-effort release + docstring updates, and wrote the regression tests. I reviewed every line and ran the full deferred-embedding suites to confirm no regression.
- [x] I have read and understand every line of this change and take responsibility for it.
