### PR TITLE
fix(rerank): support flat payload format for Aliyun qwen3-rerank models

### DIFF
--- a/env.example
+++ b/env.example
@@ -189,6 +189,8 @@ RERANK_BINDING=null
 # RERANK_MAX_TOKENS_PER_DOC=480
 
 ### Aliyun Dashscope
+### qwen3-rerank series models use a flat payload format (auto-detected from model name)
+### and require the corresponding flat-format endpoint as RERANK_BINDING_HOST
 # # RERANK_MODEL=gte-rerank-v2
 # # RERANK_BINDING_HOST=https://dashscope.aliyuncs.com/api/v1/services/rerank/text-rerank/text-rerank
 # # RERANK_BINDING_API_KEY=your_rerank_api_key_here

--- a/lightrag/rerank.py
+++ b/lightrag/rerank.py
@@ -171,6 +171,32 @@ def aggregate_chunk_scores(
     return aggregated_results
 
 
+def is_aliyun_flat_rerank_model(model: str) -> bool:
+    """
+    Check whether an Aliyun DashScope rerank model uses the flat (standard)
+    request/response format instead of the nested input/parameters format.
+
+    Aliyun's qwen3-rerank series expects a flat payload
+    {"model", "query", "documents", "top_n", ...} and returns top-level
+    {"results": [...]}, while gte-rerank-* and qwen3-vl-rerank use the nested
+    {"model", "input": {...}, "parameters": {...}} payload and return
+    {"output": {"results": [...]}}.
+    Reference: https://help.aliyun.com/zh/model-studio/text-rerank-api
+
+    Args:
+        model: Rerank model name
+
+    Returns:
+        True if the model uses the flat (standard) format
+    """
+    model_lower = model.lower()
+    return (
+        model_lower.startswith("qwen")
+        and "rerank" in model_lower
+        and "-vl-" not in model_lower
+    )
+
+
 @retry(
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=4, max=60),
@@ -240,6 +266,15 @@ async def generic_rerank_api(
                 f"Chunking enabled: disabled API-level top_n={top_n} to ensure complete document coverage"
             )
             top_n = None
+
+    # Aliyun qwen3-rerank series models use the flat (standard) request and
+    # response format instead of the nested input/parameters format used by
+    # gte-rerank-* and qwen3-vl-rerank, so fall back to the standard branch
+    if request_format == "aliyun" and is_aliyun_flat_rerank_model(model):
+        request_format = "standard"
+        response_format = "standard"
+        # The flat Aliyun endpoint doesn't support return_documents
+        return_documents = None
 
     # Build request payload based on request format
     if request_format == "aliyun":
@@ -483,6 +518,10 @@ async def ali_rerank(
 ) -> List[Dict[str, Any]]:
     """
     Rerank documents using Aliyun DashScope API.
+
+    Supports both the nested payload format (gte-rerank-*, qwen3-vl-rerank)
+    and the flat payload format (qwen3-rerank series), auto-detected from
+    the model name.
 
     Args:
         query: The search query

--- a/tests/rerank/test_aliyun_rerank_format.py
+++ b/tests/rerank/test_aliyun_rerank_format.py
@@ -1,0 +1,234 @@
+"""
+Unit tests for Aliyun DashScope rerank request/response format handling.
+
+Aliyun serves two incompatible rerank API formats depending on the model:
+- gte-rerank-* and qwen3-vl-rerank use the nested format:
+  request {"model", "input": {"query", "documents"}, "parameters": {...}}
+  response {"output": {"results": [...]}}
+- qwen3-rerank series use the flat (standard) format:
+  request {"model", "query", "documents", "top_n", ...}
+  response {"results": [...]}
+
+Reference: https://help.aliyun.com/zh/model-studio/text-rerank-api
+Regression tests for https://github.com/HKUDS/LightRAG/issues/3084
+"""
+
+import pytest
+from unittest.mock import Mock, AsyncMock, patch
+from lightrag.rerank import ali_rerank, is_aliyun_flat_rerank_model
+
+
+def make_mock_session(response_json, captured_payload):
+    """Create a mock aiohttp.ClientSession that captures the request payload"""
+    mock_response = Mock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value=response_json)
+    mock_response.request_info = None
+    mock_response.history = None
+    mock_response.headers = {}
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+
+    def capture_post(*args, **kwargs):
+        captured_payload.update(kwargs.get("json", {}))
+        return mock_response
+
+    mock_session = Mock()
+    mock_session.post = Mock(side_effect=capture_post)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+    return mock_session
+
+
+class TestIsAliyunFlatRerankModel:
+    """Test suite for the flat-format model detection helper"""
+
+    def test_qwen3_rerank_is_flat(self):
+        assert is_aliyun_flat_rerank_model("qwen3-rerank") is True
+
+    def test_qwen3_rerank_variant_is_flat(self):
+        assert is_aliyun_flat_rerank_model("qwen3-rerank-8b") is True
+
+    def test_detection_is_case_insensitive(self):
+        assert is_aliyun_flat_rerank_model("Qwen3-Rerank") is True
+
+    def test_qwen3_vl_rerank_is_nested(self):
+        assert is_aliyun_flat_rerank_model("qwen3-vl-rerank") is False
+
+    def test_gte_rerank_v2_is_nested(self):
+        assert is_aliyun_flat_rerank_model("gte-rerank-v2") is False
+
+    def test_gte_rerank_is_nested(self):
+        assert is_aliyun_flat_rerank_model("gte-rerank") is False
+
+
+@pytest.mark.offline
+class TestAliyunNestedFormat:
+    """Tests for the nested input/parameters format (gte-rerank-*, qwen3-vl-rerank)"""
+
+    @pytest.mark.asyncio
+    async def test_gte_rerank_v2_uses_nested_payload(self):
+        """gte-rerank-v2 should send nested input/parameters payload"""
+        captured_payload = {}
+        response_json = {
+            "output": {
+                "results": [
+                    {"index": 1, "relevance_score": 0.9},
+                    {"index": 0, "relevance_score": 0.3},
+                ]
+            }
+        }
+        mock_session = make_mock_session(response_json, captured_payload)
+
+        with patch("lightrag.rerank.aiohttp.ClientSession", return_value=mock_session):
+            result = await ali_rerank(
+                query="test query",
+                documents=["doc1", "doc2"],
+                model="gte-rerank-v2",
+                api_key="test-key",
+                top_n=2,
+            )
+
+        # Request: nested format with input/parameters objects
+        assert captured_payload["model"] == "gte-rerank-v2"
+        assert captured_payload["input"] == {
+            "query": "test query",
+            "documents": ["doc1", "doc2"],
+        }
+        assert captured_payload["parameters"]["top_n"] == 2
+        assert "query" not in captured_payload
+        assert "documents" not in captured_payload
+        assert "top_n" not in captured_payload
+
+        # Response: results parsed from output.results
+        assert result == [
+            {"index": 1, "relevance_score": 0.9},
+            {"index": 0, "relevance_score": 0.3},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_qwen3_vl_rerank_uses_nested_payload(self):
+        """qwen3-vl-rerank shares the nested format with gte-rerank-v2"""
+        captured_payload = {}
+        response_json = {"output": {"results": [{"index": 0, "relevance_score": 0.8}]}}
+        mock_session = make_mock_session(response_json, captured_payload)
+
+        with patch("lightrag.rerank.aiohttp.ClientSession", return_value=mock_session):
+            result = await ali_rerank(
+                query="test query",
+                documents=["doc1"],
+                model="qwen3-vl-rerank",
+                api_key="test-key",
+                top_n=1,
+            )
+
+        assert captured_payload["input"] == {
+            "query": "test query",
+            "documents": ["doc1"],
+        }
+        assert captured_payload["parameters"]["top_n"] == 1
+        assert "query" not in captured_payload
+        assert result == [{"index": 0, "relevance_score": 0.8}]
+
+    @pytest.mark.asyncio
+    async def test_nested_format_puts_extra_body_in_parameters(self):
+        """extra_body should be merged into the parameters object"""
+        captured_payload = {}
+        response_json = {"output": {"results": [{"index": 0, "relevance_score": 0.8}]}}
+        mock_session = make_mock_session(response_json, captured_payload)
+
+        with patch("lightrag.rerank.aiohttp.ClientSession", return_value=mock_session):
+            await ali_rerank(
+                query="test query",
+                documents=["doc1"],
+                model="gte-rerank-v2",
+                api_key="test-key",
+                extra_body={"custom_param": "value"},
+            )
+
+        assert captured_payload["parameters"]["custom_param"] == "value"
+        assert "custom_param" not in captured_payload
+
+
+@pytest.mark.offline
+class TestAliyunFlatFormat:
+    """Tests for the flat format used by qwen3-rerank series (issue #3084)"""
+
+    @pytest.mark.asyncio
+    async def test_qwen3_rerank_uses_flat_payload(self):
+        """qwen3-rerank should send the flat payload with top-level query/documents"""
+        captured_payload = {}
+        response_json = {
+            "results": [
+                {"index": 1, "relevance_score": 0.9},
+                {"index": 0, "relevance_score": 0.3},
+            ]
+        }
+        mock_session = make_mock_session(response_json, captured_payload)
+
+        with patch("lightrag.rerank.aiohttp.ClientSession", return_value=mock_session):
+            result = await ali_rerank(
+                query="test query",
+                documents=["doc1", "doc2"],
+                model="qwen3-rerank",
+                api_key="test-key",
+                top_n=2,
+            )
+
+        # Request: flat format without input/parameters nesting
+        assert captured_payload["model"] == "qwen3-rerank"
+        assert captured_payload["query"] == "test query"
+        assert captured_payload["documents"] == ["doc1", "doc2"]
+        assert captured_payload["top_n"] == 2
+        assert "input" not in captured_payload
+        assert "parameters" not in captured_payload
+        # The flat endpoint doesn't support return_documents
+        assert "return_documents" not in captured_payload
+
+        # Response: results parsed from top-level results
+        assert result == [
+            {"index": 1, "relevance_score": 0.9},
+            {"index": 0, "relevance_score": 0.3},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_qwen3_rerank_flat_response_not_parsed_as_nested(self):
+        """Flat responses must not be looked up under output.results (issue #3084)"""
+        captured_payload = {}
+        # A flat response has no "output" key; the old nested-only parsing
+        # returned an empty result list for it
+        response_json = {
+            "object": "list",
+            "results": [{"index": 0, "relevance_score": 0.95}],
+            "usage": {"total_tokens": 79},
+        }
+        mock_session = make_mock_session(response_json, captured_payload)
+
+        with patch("lightrag.rerank.aiohttp.ClientSession", return_value=mock_session):
+            result = await ali_rerank(
+                query="test query",
+                documents=["doc1"],
+                model="qwen3-rerank",
+                api_key="test-key",
+            )
+
+        assert result == [{"index": 0, "relevance_score": 0.95}]
+
+    @pytest.mark.asyncio
+    async def test_flat_format_puts_extra_body_at_top_level(self):
+        """extra_body (e.g. instruct) should be merged into the flat payload"""
+        captured_payload = {}
+        response_json = {"results": [{"index": 0, "relevance_score": 0.9}]}
+        mock_session = make_mock_session(response_json, captured_payload)
+
+        with patch("lightrag.rerank.aiohttp.ClientSession", return_value=mock_session):
+            await ali_rerank(
+                query="test query",
+                documents=["doc1"],
+                model="qwen3-rerank",
+                api_key="test-key",
+                extra_body={"instruct": "Retrieve relevant passages."},
+            )
+
+        assert captured_payload["instruct"] == "Retrieve relevant passages."
+        assert "parameters" not in captured_payload


### PR DESCRIPTION
## Summary

Fixes #3084

The Aliyun DashScope rerank endpoint serves two incompatible API formats depending on the model (see the [Text Rerank API docs](https://help.aliyun.com/zh/model-studio/text-rerank-api)):

- **gte-rerank-\*** and **qwen3-vl-rerank** use a nested request body `{"model", "input": {"query", "documents"}, "parameters": {"top_n", ...}}` and return results under `output.results`.
- The **qwen3-rerank** series uses a flat, Cohere-style request body `{"model", "query", "documents", "top_n", "instruct"}` and returns top-level `results`.

`generic_rerank_api` hard-wired `request_format="aliyun"` to the nested shape, so using `RERANK_BINDING=aliyun` with `qwen3-rerank` failed (the request body is rejected / results come back empty because the flat response has no `output` key). The issue (reported in Chinese) also notes that Aliyun plans to retire gte-rerank-v2 and recommends qwen3-rerank as its replacement, and that the only workaround was misusing `RERANK_BINDING=cohere`.

## What's changed

- Added `is_aliyun_flat_rerank_model()`: detects the qwen3-rerank family by model name (case-insensitive, matches `qwen*rerank*` but excludes `qwen3-vl-rerank`, which keeps the nested format per the docs).
- In `generic_rerank_api`, when `request_format == "aliyun"` and the model is flat-format, fall back to the standard request builder and response parser, and drop the unsupported `return_documents` parameter.
- `env.example`: documented that qwen3-rerank uses the flat format (auto-detected) and needs the corresponding flat-format endpoint as `RERANK_BINDING_HOST`.
- Added `tests/rerank/test_aliyun_rerank_format.py`: 12 mocked-HTTP regression tests covering both model families (request payload shape assertions and response parsing).

## How it works

`RERANK_BINDING=aliyun` keeps working unchanged for gte-rerank-v2 and qwen3-vl-rerank; with `RERANK_MODEL=qwen3-rerank` the flat payload/response format is now selected automatically. Note the qwen3-rerank endpoint path differs from the gte one, so `RERANK_BINDING_HOST` must point at the flat (compatible) rerank endpoint.

## Tests

`python -m pytest tests/rerank/test_aliyun_rerank_format.py tests/chunker/test_rerank_chunking.py -v` — 31 passed. The 3 flat-format tests fail without the fix, reproducing the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)