### PR TITLE
chore(deps): add httpx2 test dependency for starlette testclient

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[api]"
-          pip install pytest pytest-asyncio httpx
+          pip install pytest pytest-asyncio httpx2
 
       - name: Create minimal frontend stub for Copilot agent
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
         # anthropic, boto3, etc.). Without them, importorskip falls back
         # and the tests are silently skipped.
         pip install -e ".[api,offline-storage,offline-llm]"
-        pip install pytest pytest-asyncio
+        pip install pytest pytest-asyncio httpx2
 
     - name: Run offline tests
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ pytest = [
     "pytest-asyncio>=1.2.0",
     "pre-commit",
     "ruff",
+    "httpx2>=2.0.0",  # starlette>=1.3 testclient prefers httpx2 over httpx
 ]
 
 api = [
@@ -142,6 +143,7 @@ test = [
     "pytest-asyncio>=1.2.0",
     "pre-commit",
     "ruff",
+    "httpx2>=2.0.0",  # starlette>=1.3 testclient prefers httpx2 over httpx
 ]
 
 evaluation = [

--- a/uv.lock
+++ b/uv.lock
@@ -1558,6 +1558,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/5c12df521b5322fb1114a83d46911b2fbcb8855ddb3a635f11c01a214af5/httpcore2-2.5.0.tar.gz", hash = "sha256:88aa170137c17328d5ac44234f9fd10706466d5fb347f3edac4d39b91137b09d", size = 64808, upload-time = "2026-06-25T14:16:56.472Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/a1/7564199d1a8728fe737b0a72e5b3f8d92dfe085a74ddf7cdd83bce5f206d/httpcore2-2.5.0-py3-none-any.whl", hash = "sha256:5ce35188de461d31e8d000bfb8ef8bf22c6c16587a211e5571deaa5e9bdf842a", size = 80330, upload-time = "2026-06-25T14:16:53.634Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1584,6 +1597,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/e2/b5dedc0cf35aa65de5f541ccd30d2bc1fd7f1d43c9ab09f8ed9a7342317b/httpx2-2.5.0.tar.gz", hash = "sha256:e2df9cb4611021527ff8a675b1c320b610a2ec397acc8d6fe6e91df2d9b33c29", size = 83121, upload-time = "2026-06-25T14:16:57.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/22/859d8252dad9bc9adee34b52e62cde621ece07b042ccb2ab4da1be46695f/httpx2-2.5.0-py3-none-any.whl", hash = "sha256:3d2d4d9cf4b61f1a1f46a95947cfdb47e80cb56a2f91c6256ac8f58e4891df41", size = 76652, upload-time = "2026-06-25T14:16:55.23Z" },
 ]
 
 [[package]]
@@ -1626,11 +1655,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -2276,6 +2305,7 @@ offline-storage = [
     { name = "redis" },
 ]
 pytest = [
+    { name = "httpx2" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -2297,6 +2327,7 @@ test = [
     { name = "gunicorn" },
     { name = "httpcore" },
     { name = "httpx" },
+    { name = "httpx2" },
     { name = "jiter" },
     { name = "json-repair" },
     { name = "langchain-experimental" },
@@ -2363,6 +2394,8 @@ requires-dist = [
     { name = "gunicorn", marker = "extra == 'api'" },
     { name = "httpcore", marker = "extra == 'api'" },
     { name = "httpx", marker = "extra == 'api'", specifier = ">=0.28.1" },
+    { name = "httpx2", marker = "extra == 'pytest'", specifier = ">=2.0.0" },
+    { name = "httpx2", marker = "extra == 'test'", specifier = ">=2.0.0" },
     { name = "jiter", marker = "extra == 'api'" },
     { name = "json-repair" },
     { name = "json-repair", marker = "extra == 'api'" },
@@ -5255,6 +5288,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Fix the `StarletteDeprecationWarning` emitted during the test run: `starlette>=1.3` `testclient` now prefers the new `httpx2` package and warns when falling back to the legacy `httpx`. This PR adds `httpx2` to the test dependency groups and CI workflows so the test suite runs warning-free.

Production code intentionally keeps `httpx`: it is still a hard requirement of `openai`, `anthropic`, `google-genai`, `ollama`, `qdrant-client` and other SDKs in the dependency tree. The two packages live in separate namespaces (`httpx` / `httpx2`, `httpcore` / `httpcore2`) and coexist without conflicts, so this is the standard incremental-migration path until upstream SDKs move to `httpx2`.

## Related Issues

N/A — small test-dependency fix, no tracking issue.

## Changes Made

- `pyproject.toml`: add `httpx2>=2.0.0` to the `pytest` and `test` optional-dependency groups.
- `uv.lock`: re-lock (adds `httpx2` 2.5.0, `httpcore2` 2.5.0, `truststore`; bumps `idna` 3.15 → 3.18).
- `.github/workflows/tests.yml`: install `httpx2` alongside `pytest`/`pytest-asyncio` (this workflow installs test tooling manually instead of via the `[test]` extra).
- `.github/workflows/copilot-setup-steps.yml`: replace the explicit `httpx` install with `httpx2` (its purpose was the TestClient backend; legacy `httpx` still arrives transitively via `[api]` SDKs).

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

Verification: `tests/api` was run with `-W error::DeprecationWarning` (248 passed, no warning triggered), then the full suite passed clean — 2833 passed, 34 skipped, and the previous `1 warning` summary line is gone. No test-code changes were needed; TestClient usage in the suite is limited to standard `.status_code`/`.json()` access, and LLM mock tests keep using the same legacy `httpx` (`httpx.MockTransport`) as production code, so tested semantics are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
