### PR TITLE
docs(rerank): document qwen3-rerank via cohere binding (flat format)

### DIFF
--- a/docs/LightRAG-API-Server-zh.md
+++ b/docs/LightRAG-API-Server-zh.md
@@ -881,12 +881,21 @@ RERANK_BINDING_HOST=http://localhost:8000/rerank
 RERANK_BINDING_API_KEY=your_rerank_api_key_here
 ```
 
-以下是使用阿里云提供的 Reranker 服务的示例配置：
+以下是使用阿里云提供的 Reranker 服务的示例配置（`gte-rerank-*` 和 `qwen3-vl-rerank`，它们使用嵌套的 `input`/`parameters` 报文格式）：
 
 ```
 RERANK_BINDING=aliyun
 RERANK_MODEL=gte-rerank-v2
 RERANK_BINDING_HOST=https://dashscope.aliyuncs.com/api/v1/services/rerank/text-rerank/text-rerank
+RERANK_BINDING_API_KEY=your_rerank_api_key_here
+```
+
+> **阿里云 `qwen3-rerank` 系列：** 与 `gte-rerank-*`、`qwen3-vl-rerank` 不同，`qwen3-rerank` 模型使用扁平的 Cohere 风格报文（`{"model", "query", "documents", "top_n", ...}`），返回顶层的 `results`，并且使用**不同的** Cohere 兼容 endpoint —— `/compatible-api/v1/reranks`，而非上面 `gte`/`vl` 所用的 `.../text-rerank/text-rerank` 路径。由于格式与标准 Cohere 完全一致，因此使用 `RERANK_BINDING=cohere`（而非 `aliyun`）即可，无需单独的 binding。请将 `{WorkspaceId}` 与地域替换为你自己的（参见 [阿里云文本排序 API 文档](https://help.aliyun.com/zh/model-studio/text-rerank-api)）：
+
+```
+RERANK_BINDING=cohere
+RERANK_MODEL=qwen3-rerank
+RERANK_BINDING_HOST=https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com/compatible-api/v1/reranks
 RERANK_BINDING_API_KEY=your_rerank_api_key_here
 ```
 

--- a/docs/LightRAG-API-Server.md
+++ b/docs/LightRAG-API-Server.md
@@ -881,12 +881,21 @@ RERANK_BINDING_HOST=http://localhost:8000/rerank
 RERANK_BINDING_API_KEY=your_rerank_api_key_here
 ```
 
-Here is an example configuration for utilizing the Reranker service provided by Aliyun:
+Here is an example configuration for utilizing the Reranker service provided by Aliyun (`gte-rerank-*` and `qwen3-vl-rerank`, which use the nested `input`/`parameters` payload format):
 
 ```
 RERANK_BINDING=aliyun
 RERANK_MODEL=gte-rerank-v2
 RERANK_BINDING_HOST=https://dashscope.aliyuncs.com/api/v1/services/rerank/text-rerank/text-rerank
+RERANK_BINDING_API_KEY=your_rerank_api_key_here
+```
+
+> **Aliyun `qwen3-rerank` series:** Unlike `gte-rerank-*` and `qwen3-vl-rerank`, the `qwen3-rerank` models use a flat, Cohere-style payload (`{"model", "query", "documents", "top_n", ...}`), return top-level `results`, and are served from a **different**, Cohere-compatible endpoint — `/compatible-api/v1/reranks`, not the `.../text-rerank/text-rerank` path used above. Because the format is identical to standard Cohere, configure them with `RERANK_BINDING=cohere` (not `aliyun`); no dedicated binding is needed. Replace `{WorkspaceId}` and the region with your own (see the [Aliyun Text Rerank API docs](https://help.aliyun.com/zh/model-studio/text-rerank-api)):
+
+```
+RERANK_BINDING=cohere
+RERANK_MODEL=qwen3-rerank
+RERANK_BINDING_HOST=https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com/compatible-api/v1/reranks
 RERANK_BINDING_API_KEY=your_rerank_api_key_here
 ```
 

--- a/env.example
+++ b/env.example
@@ -188,9 +188,23 @@ RERANK_BINDING=null
 # RERANK_ENABLE_CHUNKING=true
 # RERANK_MAX_TOKENS_PER_DOC=480
 
-### Aliyun Dashscope
+### Aliyun Dashscope (gte-rerank-*, qwen3-vl-rerank) — nested input/parameters format
+# # RERANK_BINDING=aliyun
 # # RERANK_MODEL=gte-rerank-v2
 # # RERANK_BINDING_HOST=https://dashscope.aliyuncs.com/api/v1/services/rerank/text-rerank/text-rerank
+# # RERANK_BINDING_API_KEY=your_rerank_api_key_here
+
+### Aliyun Dashscope qwen3-rerank series — flat (Cohere-style) payload format
+### The qwen3-rerank models expect a flat body {"model", "query", "documents", "top_n", ...}
+### and return top-level "results", identical to the standard Cohere format. They are also served
+### from a DIFFERENT, Cohere-compatible endpoint (/compatible-api/v1/reranks) — NOT the
+### .../text-rerank/text-rerank path used by gte-rerank-*/qwen3-vl-rerank above.
+### So use RERANK_BINDING=cohere (NOT aliyun) and point RERANK_BINDING_HOST at that endpoint.
+### Replace {WorkspaceId} and the region with your own; see the Aliyun Text Rerank API docs:
+### https://help.aliyun.com/zh/model-studio/text-rerank-api
+# # RERANK_BINDING=cohere
+# # RERANK_MODEL=qwen3-rerank
+# # RERANK_BINDING_HOST=https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com/compatible-api/v1/reranks
 # # RERANK_BINDING_API_KEY=your_rerank_api_key_here
 
 ### Jina AI


### PR DESCRIPTION
## Description

Documents how to use Aliyun DashScope's `qwen3-rerank` series with LightRAG, without adding any new code path. Aliyun serves two incompatible rerank API surfaces, and `qwen3-rerank` happens to use a Cohere-compatible one — so the existing `cohere` binding already handles it correctly once pointed at the right endpoint.

| Model family | Endpoint | Payload format |
|---|---|---|
| `gte-rerank-v2`, `qwen3-vl-rerank` | `.../api/v1/services/rerank/text-rerank/text-rerank` | DashScope-native, nested `input`/`parameters` → `RERANK_BINDING=aliyun` |
| `qwen3-rerank` series | `.../compatible-api/v1/reranks` | Cohere-compatible, flat `{model, query, documents, top_n, instruct}` with top-level `results` → `RERANK_BINDING=cohere` |

Because the `qwen3-rerank` request/response is byte-for-byte the standard Cohere format that `cohere_rerank`/`generic_rerank_api` already produce, no model-name detection or duplicate flat-format branch inside the `aliyun` binding is needed — this is purely a documentation gap.

## Related Issues

Closes #3084. Alternative (docs-only) resolution to #3365.

## Changes Made

- `env.example`: split the Aliyun rerank section into the nested `gte-rerank-*`/`qwen3-vl-rerank` config and a new `qwen3-rerank` config that uses `RERANK_BINDING=cohere` against the `/compatible-api/v1/reranks` endpoint.
- `docs/LightRAG-API-Server.md` and `docs/LightRAG-API-Server-zh.md`: added a note + example next to the existing Aliyun rerank example explaining the two formats/endpoints and which binding to use.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable) — docs-only change, no code paths added

## Additional Notes

Verified locally (mocked HTTP) that `cohere_rerank` emits exactly the flat `qwen3-rerank` payload documented in #3084 (`model`/`query`/`documents`/`top_n`/`instruct`, no `input`/`parameters` nesting, no `return_documents`) and parses the top-level `results`. Live verification against Aliyun was not possible from the CI/sandbox network (egress policy blocks `*.aliyuncs.com`), but the issue reporter already confirmed the `cohere` binding works.

The `{WorkspaceId}`/region in the `qwen3-rerank` endpoint must be substituted by the user per the [Aliyun Text Rerank API docs](https://help.aliyun.com/zh/model-studio/text-rerank-api).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaMgTohgezJ7vDC9JkAteo)_