### PR TITLE
test: isolate Bedrock health auth env

### DIFF
--- a/tests/api/test_health_auth.py
+++ b/tests/api/test_health_auth.py
@@ -46,6 +46,10 @@ def _isolate_env(monkeypatch):
     """Keep tests hermetic from developer-local .env and global config state."""
     for var in _ENV_VARS_TO_ISOLATE:
         monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("AUTH_ACCOUNTS", "")
+    monkeypatch.setenv("LIGHTRAG_API_KEY", "")
+    monkeypatch.setenv("TOKEN_SECRET", "")
+    monkeypatch.setenv("WHITELIST_PATHS", "/health,/api/*")
     monkeypatch.setenv("LLM_BINDING", "ollama")
     monkeypatch.setenv("EMBEDDING_BINDING", "ollama")
 

--- a/tests/llm/bedrock_impl/test_bedrock_llm.py
+++ b/tests/llm/bedrock_impl/test_bedrock_llm.py
@@ -3,7 +3,7 @@ import logging
 import os
 import sys
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import APIRouter
@@ -15,9 +15,22 @@ from lightrag.llm.bedrock import (
     bedrock_embed,
 )
 
+_API_ENV_VARS_TO_ISOLATE = (
+    "AUTH_ACCOUNTS",
+    "LIGHTRAG_API_KEY",
+    "TOKEN_SECRET",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_api_auth_env(monkeypatch):
+    """Keep API app tests independent from developer-local .env auth settings."""
+    for var in _API_ENV_VARS_TO_ISOLATE:
+        monkeypatch.setenv(var, "")
+
 
 def _reload_api_modules_if_mocked() -> None:
-    """Drop Mock-replaced lightrag.api entries so importlib reloads the real modules.
+    """Drop cached lightrag.api entries so importlib reloads with isolated env.
 
     Other test files (e.g. test_token_auto_renewal.py) replace
     ``sys.modules["lightrag.api.config"]`` with a Mock at import time. When
@@ -27,11 +40,11 @@ def _reload_api_modules_if_mocked() -> None:
     """
     for modname in (
         "lightrag.api.lightrag_server",
+        "lightrag.api.utils_api",
         "lightrag.api.auth",
         "lightrag.api.config",
     ):
-        if isinstance(sys.modules.get(modname), Mock):
-            sys.modules.pop(modname, None)
+        sys.modules.pop(modname, None)
 
 
 class _FakeBedrockClient:


### PR DESCRIPTION
## Description

Fix test hermeticity for Bedrock health/API app tests when a developer-local `.env` configures authentication settings.

## Related Issues

N/A

## Changes Made

- Add an autouse fixture in Bedrock LLM tests to shadow auth-related environment variables before API modules are imported.
- Reload cached `lightrag.api` modules for Bedrock API app tests so auth state is rebuilt from the isolated environment.
- Shadow local `.env` auth values in `/health` auth tests to keep open-mode assertions stable.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Local validation:

- `./scripts/test.sh tests/api/test_health_auth.py tests/llm/bedrock_impl`
- `uv run ruff check tests/llm/bedrock_impl/test_bedrock_llm.py tests/api/test_health_auth.py`

`gh auth status` reports invalid local tokens in this shell, so this PR was created with the GitHub connector after pushing the branch with SSH.