### PR TITLE
fix(llm): close AsyncOpenAI client in nvidia_openai_embed

### DIFF
--- a/lightrag/llm/nvidia_openai.py
+++ b/lightrag/llm/nvidia_openai.py
@@ -59,10 +59,14 @@ async def nvidia_openai_embed(
     openai_async_client = (
         AsyncOpenAI() if base_url is None else AsyncOpenAI(base_url=base_url)
     )
-    response = await openai_async_client.embeddings.create(
-        model=model,
-        input=texts,
-        encoding_format=encode,
-        extra_body={"input_type": input_type, "truncate": trunc},
-    )
-    return np.array([dp.embedding for dp in response.data])
+    # Hold the client in an async-with so its httpx connection pool is
+    # released on every exit path (success, error, and each @retry attempt),
+    # instead of leaking one pool per call until GC. Mirrors ``openai_embed``.
+    async with openai_async_client:
+        response = await openai_async_client.embeddings.create(
+            model=model,
+            input=texts,
+            encoding_format=encode,
+            extra_body={"input_type": input_type, "truncate": trunc},
+        )
+        return np.array([dp.embedding for dp in response.data])

--- a/tests/llm/nvidia_impl/test_nvidia_client_cleanup.py
+++ b/tests/llm/nvidia_impl/test_nvidia_client_cleanup.py
@@ -1,0 +1,69 @@
+"""Regression tests for nvidia_openai_embed AsyncOpenAI cleanup.
+
+Mirrors the cleanup contract established for the Anthropic backend
+(``tests/llm/anthropic_impl/test_anthropic_client_cleanup.py``, PR #3261):
+the per-call ``AsyncOpenAI`` client must be released on both the success and
+error paths so its httpx connection pool does not leak one pool per call.
+
+``nvidia_openai_embed`` now holds the client in an ``async with`` (matching
+``openai_embed``); these tests pin that behavior. The raw function is invoked
+via ``.func.__wrapped__`` to bypass the ``EmbeddingFunc`` and tenacity
+``@retry`` wrappers.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from lightrag.llm.nvidia_openai import nvidia_openai_embed
+
+
+class _FakeAsyncOpenAI:
+    """Mimics ``AsyncOpenAI`` as an async context manager.
+
+    The real SDK's ``__aexit__`` closes the client; this fake does the same so
+    the test can assert on ``close()``.
+    """
+
+    def __init__(self, *, create):
+        self.embeddings = SimpleNamespace(create=create)
+        self.close = AsyncMock()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.close()
+
+
+def _make_response(embedding=(0.1, 0.2, 0.3)):
+    return SimpleNamespace(data=[SimpleNamespace(embedding=list(embedding))])
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_client_closed_after_success():
+    """Successful embed: client.close() runs after the result is returned."""
+    fake = _FakeAsyncOpenAI(create=AsyncMock(return_value=_make_response()))
+
+    with patch("lightrag.llm.nvidia_openai.AsyncOpenAI", return_value=fake):
+        result = await nvidia_openai_embed.func.__wrapped__(texts=["hello"])
+
+    assert result.tolist() == [[0.1, 0.2, 0.3]]
+    fake.embeddings.create.assert_awaited_once()
+    fake.close.assert_awaited()
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_client_closed_on_error():
+    """API error: client.close() runs before the error propagates."""
+    fake = _FakeAsyncOpenAI(create=AsyncMock(side_effect=RuntimeError("boom")))
+
+    with patch("lightrag.llm.nvidia_openai.AsyncOpenAI", return_value=fake):
+        with pytest.raises(RuntimeError, match="boom"):
+            await nvidia_openai_embed.func.__wrapped__(texts=["hello"])
+
+    fake.embeddings.create.assert_awaited_once()
+    fake.close.assert_awaited()


### PR DESCRIPTION
## Problem

`nvidia_openai_embed` creates an `AsyncOpenAI` client per call but never closes it (`lightrag/llm/nvidia_openai.py:59-68`):

```python
openai_async_client = AsyncOpenAI(base_url=base_url)
response = await openai_async_client.embeddings.create(...)
return np.array([dp.embedding for dp in response.data])
```

Each embedding call therefore leaks the client's `httpx` connection pool until garbage collection. Over a long-running process (e.g. a busy ingest worker calling `embed` thousands of times) this accumulates one leaked pool per call.

## Root cause

The function constructs the client inline and uses it without an `async with` / `finally close`. The sibling embedding function already does it correctly — `openai_embed` holds its client in `async with openai_async_client:` (`lightrag/llm/openai.py:1006`) — and PR #3261 fixed the same class of leak for the Anthropic backend. `nvidia_openai_embed` was simply never updated to match.

## Changes

- Wrap the call body in `async with openai_async_client:` so the client is released on every exit path: success, error, **and each `@retry` attempt** (the client is created inside the function body, so tenacity re-creates and closes it on each retry). +4 / -3 lines in `nvidia_openai.py`; the returned embedding array is unchanged.

## Side effect analysis

- Default value: not changed
- Backward compatibility: no API or runtime behavior change; the embedding result is byte-identical. The only new effect is that the httpx pool is released eagerly instead of waiting for GC.
- Downstream consumers: none affected
- Security boundary: none opened (closes a connection; opens no path)

## Validation

- `python -m pytest tests/llm/nvidia_impl/test_nvidia_client_cleanup.py -v` → **2 passed** (client closed on success and on error, mirroring `test_anthropic_client_cleanup.py`)
- `ruff check` / `ruff format --check` on the changed files → clean
- CI green: pending — fork PRs require maintainer approval to run workflows

## AI assistance

**Tool(s) used:** Claude Code
**How:** AI audited LLM backends for the same per-call client leak fixed in #3261, identified the missing close in `nvidia_openai_embed`, applied the `async with` pattern already used by `openai_embed`, and wrote regression tests mirroring the Anthropic cleanup suite. I reviewed every line and ran the tests to confirm.
- [x] I have read and understand every line of this change and take responsibility for it.
