### PR TITLE
fix(core): stop reprocess accumulation of descriptions and edge weights (#3367)

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -2840,18 +2840,24 @@ async def _merge_edges_then_upsert(
                                 ),
                             }
                         }
-                    await safe_vdb_operation_with_exception(
-                        operation=lambda payload=vdb_data: entity_vdb.upsert(payload),
-                        operation_name="existing_entity_update",
-                        entity_name=f"{need_insert_id} [relation:{relation_key}]",
-                        max_retries=3,
-                        retry_delay=0.1,
-                        timeout_seconds=_get_relationship_vdb_timeout_seconds(
-                            global_config
-                        ),
-                        log_start=False,
-                        success_log_threshold_seconds=5.0,
-                    )
+                        # Inside the `entity_vdb is not None` guard: vdb_data is
+                        # only assigned there, and entity_vdb.upsert needs a real
+                        # store. Previously this call sat outside the guard, so
+                        # entity_vdb=None raised UnboundLocalError on vdb_data.
+                        await safe_vdb_operation_with_exception(
+                            operation=lambda payload=vdb_data: entity_vdb.upsert(
+                                payload
+                            ),
+                            operation_name="existing_entity_update",
+                            entity_name=f"{need_insert_id} [relation:{relation_key}]",
+                            max_retries=3,
+                            retry_delay=0.1,
+                            timeout_seconds=_get_relationship_vdb_timeout_seconds(
+                                global_config
+                            ),
+                            log_start=False,
+                            success_log_threshold_seconds=5.0,
+                        )
 
                 # 6. Log once at the end if any update occurred
                 if updated:

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -2510,12 +2510,28 @@ async def _merge_edges_then_upsert(
         # per reprocess (the #3367 sibling of description accumulation).
         # Genuinely new sources still add their weight, preserving legitimate
         # multi-document growth.
-        already_source_id_set = set(existing_full_source_ids)
+        #
+        # Filter on the EDGE's own source_ids (already_source_ids) — the same
+        # source as already_weights — NOT existing_full_source_ids, which can
+        # come from relation_chunks_storage, a SEPARATE store. relation_chunks
+        # can run ahead of the graph edge on a partial write (chunks upserted,
+        # upsert_edge not yet), so filtering on it would wrongly skip a genuinely
+        # new source (under-count), or, with no stored weight at all, recover the
+        # edge with weight 0. Filtering on already_source_ids keeps the exclusion
+        # consistent with the stored scalar: when there is no stored edge
+        # (already_source_ids empty) nothing is excluded, so a recovered edge
+        # keeps its full weight; a re-fed already-stored source is dropped.
+        # A falsy source_id is dropped from new_source_ids above (it never
+        # persists), so it must not add weight either — otherwise weight would
+        # outgrow the stored source count. Count only sources that actually
+        # persist: truthy AND not already reflected in the stored scalar.
+        already_edge_source_set = set(already_source_ids)
         weight = sum(
             [
                 dp["weight"]
                 for dp in edges_data
-                if dp.get("source_id") not in already_source_id_set
+                if dp.get("source_id")
+                and dp["source_id"] not in already_edge_source_set
             ]
             + already_weights
         )

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -292,6 +292,25 @@ async def _handle_entity_relation_summary(
     if not description_list:
         return "", False
 
+    # Drop descriptions already present (order-preserving, keep-first) so a
+    # reprocess/resume that re-merges an already-stored description does not
+    # append a duplicate. Callers build ``already_stored + newly_extracted``;
+    # keep-first preserves the stored copy and drops the re-merged duplicate.
+    # Without this, each reprocess grows the fragment count by one (#3367).
+    #
+    # Dedup on the SANITIZED text: stored descriptions were already sanitized
+    # (the single-description return and the join below both sanitize before the
+    # result is persisted), while a freshly re-extracted description is still
+    # raw. Comparing raw-vs-sanitized would miss the duplicate whenever
+    # sanitization changed the string (e.g. an XML-illegal control char was
+    # stripped), so "dirty" descriptions would keep accumulating. Sanitizing
+    # here is safe: ``sanitize_text_for_encoding`` is idempotent, so the later
+    # sanitize calls are unaffected. ``dict.fromkeys`` is the keep-first idiom
+    # already used elsewhere in this file.
+    description_list = list(
+        dict.fromkeys(sanitize_text_for_encoding(d) for d in description_list)
+    )
+
     # If only one description, return it directly (no need for LLM call)
     # Still sanitize: descriptions read back from existing graph nodes (or
     # injected by non-extraction producers) may carry XML-illegal control
@@ -2482,8 +2501,24 @@ async def _merge_edges_then_upsert(
         # 6.1 Finalize source_id
         source_id = GRAPH_FIELD_SEP.join(source_ids)
 
-        # 6.2 Finalize weight by summing new edges and existing weights
-        weight = sum([dp["weight"] for dp in edges_data] + already_weights)
+        # 6.2 Finalize weight. Each extracted relation contributes weight 1.0
+        # (or its parsed strength), so a stored edge's weight tracks the number
+        # of distinct contributing sources. On reprocess/resume the same source
+        # can be re-fed while it is already reflected in already_weights (the
+        # stored scalar), so only sum weights of edges whose source_id is NOT
+        # already stored — otherwise weight double-counts and grows 1 -> 2 -> 3
+        # per reprocess (the #3367 sibling of description accumulation).
+        # Genuinely new sources still add their weight, preserving legitimate
+        # multi-document growth.
+        already_source_id_set = set(existing_full_source_ids)
+        weight = sum(
+            [
+                dp["weight"]
+                for dp in edges_data
+                if dp.get("source_id") not in already_source_id_set
+            ]
+            + already_weights
+        )
 
         # 6.2 Finalize keywords by merging existing and new keywords
         all_keywords = set()

--- a/tests/extraction/test_summary_description_dedup.py
+++ b/tests/extraction/test_summary_description_dedup.py
@@ -14,6 +14,8 @@ are kept in first-seen order.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 import lightrag.operate as operate
@@ -21,6 +23,7 @@ from lightrag.operate import (
     _handle_entity_relation_summary,
     _merge_edges_then_upsert,
     _merge_nodes_then_upsert,
+    make_relation_chunk_key,
 )
 from lightrag.constants import GRAPH_FIELD_SEP
 
@@ -40,6 +43,9 @@ class _MemGraph:
     async def get_node(self, name):
         return self.nodes.get(name)
 
+    async def has_node(self, name):
+        return name in self.nodes
+
     async def upsert_node(self, name, node_data):
         self.nodes[name] = dict(node_data)
 
@@ -51,6 +57,16 @@ class _MemGraph:
 
     async def upsert_edge(self, s, t, edge_data):
         self.edges[(s, t)] = dict(edge_data)
+
+    async def get_nodes_batch(self, names):
+        return {n: self.nodes.get(n) for n in names}
+
+    async def get_edges_batch(self, pairs):
+        out = {}
+        for p in pairs:
+            s, t = (p["src"], p["tgt"]) if isinstance(p, dict) else p
+            out[(s, t)] = self.edges.get((s, t)) or self.edges.get((t, s))
+        return out
 
 
 class _MemVdb:
@@ -162,6 +178,34 @@ async def test_keep_first_preserves_earliest_occurrence_order():
     assert joined.split(GRAPH_FIELD_SEP) == [_D2, _D]
 
 
+async def _edge_graph_with_nodes() -> _MemGraph:
+    """A graph with endpoint nodes A, B pre-created (edge merges assume they
+    exist). Returns the graph so a test can seed a specific stored edge."""
+    g = _MemGraph()
+    for name in ("A", "B"):
+        await g.upsert_node(
+            name,
+            {
+                "entity_id": name,
+                "description": name,
+                "source_id": "c1",
+                "entity_type": "X",
+                "file_path": "f",
+            },
+        )
+    return g
+
+
+def _rel(src, weight: float = 1.0) -> dict:
+    return {
+        "weight": weight,
+        "source_id": src,
+        "description": "rel",
+        "keywords": "k",
+        "file_path": "f",
+    }
+
+
 async def _reprocess_edge_weights(sources: list[str]) -> list[float]:
     """Merge one edge per source in order; return the persisted weight after
     each merge. Endpoint nodes are pre-created; a no-op vdb sidesteps the
@@ -257,3 +301,329 @@ async def test_edge_merge_with_entity_vdb_none_does_not_crash():
         await _merge_edges_then_upsert("A", "B", [_edge(src)], g, None, None, cfg)
 
     assert await g.get_edge("A", "B") is not None
+
+
+class _MemKV:
+    """No-op-ish KV that serves get_by_id / get_by_ids from a dict."""
+
+    def __init__(self, data: dict | None = None):
+        self.data = dict(data or {})
+
+    async def get_by_id(self, key):
+        return self.data.get(key)
+
+    async def get_by_ids(self, keys):
+        return [self.data.get(k) for k in keys]
+
+    async def upsert(self, data):
+        self.data.update(data)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_edge_weight_recovers_to_one_when_edge_missing_but_chunks_stored():
+    """Partial-write recovery: relation_chunks_storage already has the source but
+    the graph edge does not exist yet (a crash between the two writes). The weight
+    filter must NOT treat those sources as already-weighted — already_weights is
+    empty, so filtering them would recover the edge with weight 0. With no stored
+    scalar, sum all contributions (weight = 1, not 0)."""
+    g = _MemGraph()
+    cfg = _cfg()
+    for name in ("A", "B"):
+        await g.upsert_node(
+            name,
+            {
+                "entity_id": name,
+                "description": name,
+                "source_id": "c1",
+                "entity_type": "X",
+                "file_path": "f",
+            },
+        )
+    rcs = _MemKV({make_relation_chunk_key("A", "B"): {"chunk_ids": ["c1"]}})
+    await _merge_edges_then_upsert(
+        "A",
+        "B",
+        [
+            {
+                "weight": 1.0,
+                "source_id": "c1",
+                "description": "rel",
+                "keywords": "k",
+                "file_path": "f",
+            }
+        ],
+        g,
+        None,
+        None,
+        cfg,
+        relation_chunks_storage=rcs,
+    )
+    edge = await g.get_edge("A", "B")
+    assert edge is not None
+    assert edge["weight"] == 1.0
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_edge_weight_adds_new_source_when_chunks_store_is_ahead():
+    """relation_chunks_storage can run AHEAD of the graph edge (chunks upserted,
+    edge not yet updated). A genuinely new source re-fed then must still add
+    weight — the filter uses the EDGE's own source_ids (consistent with the
+    stored scalar), not the chunk store, so the new source is not wrongly skipped
+    (which would under-count the weight)."""
+    g = _MemGraph()
+    cfg = _cfg()
+    for name in ("A", "B"):
+        await g.upsert_node(
+            name,
+            {
+                "entity_id": name,
+                "description": name,
+                "source_id": "c1",
+                "entity_type": "X",
+                "file_path": "f",
+            },
+        )
+    # Existing edge reflects only c1 (weight 1)...
+    g.edges[("A", "B")] = {
+        "weight": 1.0,
+        "source_id": "c1",
+        "description": "rel",
+        "keywords": "k",
+        "file_path": "f",
+    }
+    # ...but relation_chunks already lists c1 AND c2 (ahead of the edge).
+    rcs = _MemKV({make_relation_chunk_key("A", "B"): {"chunk_ids": ["c1", "c2"]}})
+    await _merge_edges_then_upsert(
+        "A",
+        "B",
+        [
+            {
+                "weight": 1.0,
+                "source_id": "c2",
+                "description": "rel",
+                "keywords": "k",
+                "file_path": "f",
+            }
+        ],
+        g,
+        None,
+        None,
+        cfg,
+        relation_chunks_storage=rcs,
+    )
+    assert (await g.get_edge("A", "B"))["weight"] == 2.0
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_edge_weight_not_double_counted_on_reversed_refeed():
+    """Undirected edge: stored as (A,B) from c1, then re-fed reversed as (B,A)
+    from the SAME c1. get_edge is symmetric, so the edge's own source_ids see c1
+    and the re-fed duplicate is dropped — weight stays 1, no direction-flip
+    double count. (Filtering on the edge's own sources, not the chunk store,
+    is what keeps this consistent regardless of endpoint order.)"""
+    g = await _edge_graph_with_nodes()
+    g.edges[("A", "B")] = _rel("c1")
+    await _merge_edges_then_upsert("B", "A", [_rel("c1")], g, None, None, _cfg())
+    assert (await g.get_edge("A", "B"))["weight"] == 1.0
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_edge_weight_stays_consistent_when_new_source_hits_id_limit():
+    """When a genuinely new source is KEEP-dropped by max_source_ids_per_relation,
+    the stored weight must still match the persisted source count (the drop path
+    short-circuits before the weight grows), so weight does not outrun the
+    sources actually kept."""
+    g = await _edge_graph_with_nodes()
+    g.edges[("A", "B")] = _rel("c1")
+    cfg = _cfg()
+    cfg["max_source_ids_per_relation"] = 1  # c1 already stored; a new c2 is dropped
+    await _merge_edges_then_upsert("A", "B", [_rel("c2")], g, None, None, cfg)
+    edge = await g.get_edge("A", "B")
+    persisted = len([s for s in edge["source_id"].split(GRAPH_FIELD_SEP) if s])
+    assert persisted == 1
+    assert edge["weight"] == 1.0
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+@pytest.mark.parametrize("falsy_source", [None, ""])
+async def test_edge_weight_ignores_falsy_source(falsy_source):
+    """A falsy source_id (None or "") is excluded from the stored source list, so
+    it must not add weight either — otherwise weight would outgrow the persisted
+    source count. Over a stored c1, a falsy-source item keeps weight at 1."""
+    g = await _edge_graph_with_nodes()
+    g.edges[("A", "B")] = _rel("c1")
+    await _merge_edges_then_upsert(
+        "A", "B", [_rel(falsy_source)], g, None, None, _cfg()
+    )
+    edge = await g.get_edge("A", "B")
+    persisted = len([s for s in edge["source_id"].split(GRAPH_FIELD_SEP) if s])
+    assert persisted == 1
+    assert edge["weight"] == 1.0
+
+
+def _node_dp(name: str, desc: str, src: str, ts: int = 1) -> dict:
+    return {
+        "entity_name": name,
+        "entity_type": "person",
+        "description": desc,
+        "source_id": src,
+        "file_path": "d.txt",
+        "timestamp": ts,
+    }
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_node_same_description_two_sources_keeps_both_sources():
+    """Node dedup guard: the SAME description text arriving from two distinct
+    sources in one merge collapses to a single fragment, but BOTH sources must
+    persist — description dedup must not silently drop a chunk's provenance."""
+    g = _MemGraph()
+    await _merge_nodes_then_upsert(
+        "E",
+        [
+            _node_dp("E", "Alice is an engineer.", "c1"),
+            _node_dp("E", "Alice is an engineer.", "c2"),
+        ],
+        g,
+        None,
+        _cfg(),
+    )
+    node = g.nodes["E"]
+    frags = [d for d in node["description"].split(GRAPH_FIELD_SEP) if d]
+    sources = sorted(s for s in node["source_id"].split(GRAPH_FIELD_SEP) if s)
+    assert frags == ["Alice is an engineer."]
+    assert sources == ["c1", "c2"]
+
+
+# --- End-to-end via the real orchestrator merge_nodes_and_edges -------------
+#
+# The tests above drive the unit _merge_*_then_upsert helpers. These drive the
+# top-level two-phase merge the pipeline actually calls (Phase 1 entities ->
+# Phase 2 relations), with in-memory stores, to prove the non-accumulation
+# invariant holds through the full reprocess path, not just the unit functions.
+
+
+async def _orchestrate(chunk_results, g, stores, cfg, doc_id="d"):
+    from lightrag.operate import merge_nodes_and_edges
+
+    await merge_nodes_and_edges(
+        chunk_results,
+        g,
+        stores["entity_vdb"],
+        stores["relationships_vdb"],
+        cfg,
+        full_entities_storage=stores["full_entities"],
+        full_relations_storage=stores["full_relations"],
+        doc_id=doc_id,
+        pipeline_status={"history_messages": []},
+        pipeline_status_lock=asyncio.Lock(),
+        entity_chunks_storage=stores["entity_chunks"],
+        relation_chunks_storage=stores["relation_chunks"],
+    )
+
+
+def _stores() -> dict:
+    return {
+        "entity_vdb": _MemVdb(),
+        "relationships_vdb": _MemVdb(),
+        "full_entities": _MemKV(),
+        "full_relations": _MemKV(),
+        "entity_chunks": _MemKV(),
+        "relation_chunks": _MemKV(),
+    }
+
+
+def _one_chunk(src: str, alice_desc: str = "Alice is an engineer."):
+    """A single extracted chunk: entities ALICE + ACME and edge ALICE~ACME,
+    all attributed to source `src`."""
+    maybe_nodes = {
+        "ALICE": [_node_dp("ALICE", alice_desc, src)],
+        "ACME": [_node_dp("ACME", "Acme is a company.", src)],
+    }
+    maybe_edges = {
+        ("ACME", "ALICE"): [
+            {
+                "src_id": "ALICE",
+                "tgt_id": "ACME",
+                "weight": 1.0,
+                "description": "rel",
+                "keywords": "k",
+                "source_id": src,
+                "file_path": "d.txt",
+                "timestamp": 1,
+            }
+        ]
+    }
+    return [(maybe_nodes, maybe_edges)]
+
+
+def _node_frag_count(g, name: str) -> int:
+    return len([d for d in g.nodes[name]["description"].split(GRAPH_FIELD_SEP) if d])
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_orchestrator_reprocess_same_doc_does_not_accumulate():
+    """Merging the SAME extracted doc twice (a reprocess/resume) must not grow
+    entity descriptions or edge weight through the real orchestrator."""
+    from lightrag.kg.shared_storage import initialize_share_data
+
+    initialize_share_data()
+    g = _MemGraph()
+    stores = _stores()
+    cfg = _cfg()
+    for _ in range(2):
+        await _orchestrate(_one_chunk("c1"), g, stores, cfg, doc_id="d1")
+    assert _node_frag_count(g, "ALICE") == 1
+    assert (await g.get_edge("ALICE", "ACME"))["weight"] == 1.0
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_orchestrator_distinct_docs_accumulate():
+    """Two DISTINCT docs (distinct sources + descriptions) legitimately grow the
+    entity description to two fragments and the edge weight to two."""
+    from lightrag.kg.shared_storage import initialize_share_data
+
+    initialize_share_data()
+    g = _MemGraph()
+    stores = _stores()
+    cfg = _cfg()
+    await _orchestrate(
+        _one_chunk("c1", "Alice is an engineer."), g, stores, cfg, doc_id="d1"
+    )
+    await _orchestrate(
+        _one_chunk("c2", "Alice leads the team."), g, stores, cfg, doc_id="d2"
+    )
+    assert _node_frag_count(g, "ALICE") == 2
+    assert (await g.get_edge("ALICE", "ACME"))["weight"] == 2.0
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_orchestrator_reprocess_after_distinct_docs_is_stable():
+    """After two distinct docs (c1, c2), reprocessing c1 again must not grow the
+    description or weight past two."""
+    from lightrag.kg.shared_storage import initialize_share_data
+
+    initialize_share_data()
+    g = _MemGraph()
+    stores = _stores()
+    cfg = _cfg()
+    await _orchestrate(
+        _one_chunk("c1", "Alice is an engineer."), g, stores, cfg, doc_id="d1"
+    )
+    await _orchestrate(
+        _one_chunk("c2", "Alice leads the team."), g, stores, cfg, doc_id="d2"
+    )
+    await _orchestrate(
+        _one_chunk("c1", "Alice is an engineer."), g, stores, cfg, doc_id="d1"
+    )
+    assert _node_frag_count(g, "ALICE") == 2
+    assert (await g.get_edge("ALICE", "ACME"))["weight"] == 2.0

--- a/tests/extraction/test_summary_description_dedup.py
+++ b/tests/extraction/test_summary_description_dedup.py
@@ -1,0 +1,223 @@
+"""Regression tests for #3367.
+
+``_handle_entity_relation_summary`` — the single choke point both
+``_merge_nodes_then_upsert`` and ``_merge_edges_then_upsert`` route their
+combined ``already_stored + newly_extracted`` description list through — used to
+join the list without cross-deduping stored vs new. So re-merging a doc whose
+entities/relations already existed (any reprocess/resume) re-appended the same
+description, growing the fragment count by one per reprocess.
+
+These tests pin: (a) a reprocess does not accumulate; (b) identical descriptions
+collapse to one; and — guarding against over-dedup — (c) distinct descriptions
+are kept in first-seen order.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import lightrag.operate as operate
+from lightrag.operate import (
+    _handle_entity_relation_summary,
+    _merge_edges_then_upsert,
+    _merge_nodes_then_upsert,
+)
+from lightrag.constants import GRAPH_FIELD_SEP
+
+
+class _FakeTokenizer:
+    def encode(self, s: str):  # token count == char count; thresholds kept slack
+        return list(range(len(s)))
+
+
+class _MemGraph:
+    """Minimal in-memory graph: real get_node/get_edge -> merge -> upsert round-trip."""
+
+    def __init__(self):
+        self.nodes: dict[str, dict] = {}
+        self.edges: dict = {}
+
+    async def get_node(self, name):
+        return self.nodes.get(name)
+
+    async def upsert_node(self, name, node_data):
+        self.nodes[name] = dict(node_data)
+
+    async def has_edge(self, s, t):
+        return (s, t) in self.edges or (t, s) in self.edges
+
+    async def get_edge(self, s, t):
+        return self.edges.get((s, t)) or self.edges.get((t, s))
+
+    async def upsert_edge(self, s, t, edge_data):
+        self.edges[(s, t)] = dict(edge_data)
+
+
+class _MemVdb:
+    """No-op vector store so the edge-merge entity-vdb path doesn't require a
+    real backend (and sidesteps the unrelated entity_vdb=None crash)."""
+
+    async def upsert(self, data):
+        pass
+
+    async def delete(self, ids):
+        pass
+
+
+def _cfg() -> dict:
+    return {
+        "tokenizer": _FakeTokenizer(),
+        "summary_context_size": 1_000_000,
+        "summary_max_tokens": 1_000_000,
+        "force_llm_summary_on_merge": 6,
+        "source_ids_limit_method": operate.SOURCE_IDS_LIMIT_METHOD_KEEP,
+        "max_source_ids_per_entity": 10_000,
+        "max_source_ids_per_relation": 10_000,
+        "max_file_paths": 100,
+        "file_path_more_placeholder": "...",
+    }
+
+
+_D = "Alice is a software engineer at Acme."
+_D2 = "Alice leads the backend team."
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_reprocess_does_not_accumulate_node_descriptions():
+    """Re-merging the same single description N times keeps one fragment, not N."""
+    g = _MemGraph()
+    cfg = _cfg()
+    batch = {
+        "entity_name": "ALICE",
+        "entity_type": "person",
+        "description": _D,
+        "source_id": "chunk-1",
+        "file_path": "doc1.txt",
+        "timestamp": 1,
+    }
+    for _ in range(3):
+        await _merge_nodes_then_upsert("ALICE", [dict(batch)], g, None, cfg)
+
+    frags = g.nodes["ALICE"]["description"].split(GRAPH_FIELD_SEP)
+    assert frags == [_D]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_reprocess_does_not_accumulate_dirty_descriptions():
+    """A description that sanitization changes (e.g. an XML-illegal control char
+    is stripped) must also not accumulate. Stored descriptions are already
+    sanitized while a re-extracted one is raw, so dedup must compare on the
+    sanitized text; a raw comparison would miss the duplicate and keep growing.
+    """
+    g = _MemGraph()
+    cfg = _cfg()
+    dirty = "Alice\x08 is a software engineer at Acme."  # \x08 is stripped by sanitize
+    batch = {
+        "entity_name": "ALICE",
+        "entity_type": "person",
+        "description": dirty,
+        "source_id": "chunk-1",
+        "file_path": "doc1.txt",
+        "timestamp": 1,
+    }
+    for _ in range(3):
+        await _merge_nodes_then_upsert("ALICE", [dict(batch)], g, None, cfg)
+
+    frags = g.nodes["ALICE"]["description"].split(GRAPH_FIELD_SEP)
+    assert len(frags) == 1
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_summary_collapses_identical_descriptions():
+    """A list of identical descriptions collapses to a single fragment."""
+    joined, llm_used = await _handle_entity_relation_summary(
+        "Relation", "ALICE~ACME", [_D, _D], GRAPH_FIELD_SEP, _cfg(), None
+    )
+    assert joined.split(GRAPH_FIELD_SEP) == [_D]
+    # dedup to one -> len==1 early return, so no LLM summary is invoked.
+    assert llm_used is False
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_distinct_descriptions_are_kept_in_first_seen_order():
+    """Over-dedup guard: distinct descriptions survive; only exact dups drop,
+    order-preserving keep-first."""
+    joined, _ = await _handle_entity_relation_summary(
+        "Relation", "X", [_D, _D2, _D], GRAPH_FIELD_SEP, _cfg(), None
+    )
+    assert joined.split(GRAPH_FIELD_SEP) == [_D, _D2]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_keep_first_preserves_earliest_occurrence_order():
+    """Keep-first: the first occurrence position wins, later dups are dropped."""
+    joined, _ = await _handle_entity_relation_summary(
+        "Relation", "X", [_D2, _D, _D2], GRAPH_FIELD_SEP, _cfg(), None
+    )
+    assert joined.split(GRAPH_FIELD_SEP) == [_D2, _D]
+
+
+async def _reprocess_edge_weights(sources: list[str]) -> list[float]:
+    """Merge one edge per source in order; return the persisted weight after
+    each merge. Endpoint nodes are pre-created; a no-op vdb sidesteps the
+    unrelated entity_vdb crash so this test isolates the weight logic."""
+    g = _MemGraph()
+    cfg = _cfg()
+    for name in ("A", "B"):
+        await g.upsert_node(
+            name,
+            {
+                "entity_id": name,
+                "description": name,
+                "source_id": "c1",
+                "entity_type": "X",
+                "file_path": "f",
+            },
+        )
+
+    def _edge(src: str) -> dict:
+        return {
+            "weight": 1.0,
+            "source_id": src,
+            "description": "rel",
+            "keywords": "k",
+            "file_path": "f",
+        }
+
+    weights: list[float] = []
+    for src in sources:
+        await _merge_edges_then_upsert(
+            "A", "B", [_edge(src)], g, _MemVdb(), _MemVdb(), cfg
+        )
+        weights.append((await g.get_edge("A", "B"))["weight"])
+    return weights
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_edge_weight_not_accumulated_on_reprocess():
+    """#3367 sibling: re-merging the same edge from the SAME source keeps weight
+    fixed. Each source contributes 1.0 and an already-reflected source is not
+    re-summed, so reprocess/resume does not inflate weight."""
+    assert await _reprocess_edge_weights(["c1", "c1", "c1"]) == [1.0, 1.0, 1.0]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_edge_weight_grows_across_distinct_sources():
+    """Over-suppress guard: distinct sources (legitimate multi-document
+    evidence) must still accumulate weight."""
+    assert await _reprocess_edge_weights(["c1", "c2", "c3"]) == [1.0, 2.0, 3.0]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_edge_weight_adds_only_the_new_source():
+    """A reprocessed source followed by a genuinely new one adds only the new
+    one's weight, not the re-fed duplicate's."""
+    assert await _reprocess_edge_weights(["c1", "c1", "c2"]) == [1.0, 1.0, 2.0]

--- a/tests/extraction/test_summary_description_dedup.py
+++ b/tests/extraction/test_summary_description_dedup.py
@@ -221,3 +221,39 @@ async def test_edge_weight_adds_only_the_new_source():
     """A reprocessed source followed by a genuinely new one adds only the new
     one's weight, not the re-fed duplicate's."""
     assert await _reprocess_edge_weights(["c1", "c1", "c2"]) == [1.0, 1.0, 2.0]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_edge_merge_with_entity_vdb_none_does_not_crash():
+    """entity_vdb=None must not raise UnboundLocalError when an edge merge adds a
+    new endpoint entity. The vdb upsert call must stay inside its `entity_vdb is
+    not None` guard (it references vdb_data, which is assigned only inside it)."""
+    g = _MemGraph()
+    cfg = _cfg()
+    for name in ("A", "B"):
+        await g.upsert_node(
+            name,
+            {
+                "entity_id": name,
+                "description": name,
+                "source_id": "c1",
+                "entity_type": "X",
+                "file_path": "f",
+            },
+        )
+
+    def _edge(src: str) -> dict:
+        return {
+            "weight": 1.0,
+            "source_id": src,
+            "description": "rel",
+            "keywords": "k",
+            "file_path": "f",
+        }
+
+    # entity_vdb=None + genuinely new sources is the path that used to crash.
+    for src in ("c1", "c2", "c3"):
+        await _merge_edges_then_upsert("A", "B", [_edge(src)], g, None, None, cfg)
+
+    assert await g.get_edge("A", "B") is not None


### PR DESCRIPTION
Fixes #3367.

Re-merging a doc whose entities/relations already exist (any reprocess or resume) accumulated state on each merge. Two independent accumulations, plus an adjacent crash found while verifying the edge path.

## Descriptions (commit 1)
`_handle_entity_relation_summary` — the single choke point both node and edge merges route their `already_stored + newly_extracted` description list through — joined without cross-deduping stored vs new, so a re-extracted description equal to a stored one was appended again (fragment count grew N -> N+1). Dedup the **sanitized** list: stored descriptions are already sanitized while a re-extracted one is raw, so a raw comparison would miss duplicates whose only difference is a stripped XML-illegal char. No-op for the rebuild callers (already deduped).

## Edge weight (commit 1)
`_merge_edges_then_upsert` summed `already_weights` with every new edge's weight, so re-feeding an already-stored source double-counted (weight grew 1 -> 2 -> 3). Each extracted relation contributes 1.0, so weight tracks the distinct-source count. Sum only weights of edges whose `source_id` is not already reflected in the stored scalar — genuinely new sources still add, preserving legitimate multi-document growth.

## entity_vdb=None crash (commit 2, separate)
In the same edge-merge path, the entity-vdb upsert for a new endpoint entity sat outside its `if entity_vdb is not None:` guard while referencing `vdb_data` (assigned only inside), so `entity_vdb=None` raised `UnboundLocalError`. Moved the call inside the guard. Kept as a separate commit — an adjacent robustness fix, not part of the accumulation bug.

## Tests
`tests/extraction/test_summary_description_dedup.py`: node/edge reprocess keep one description fragment; distinct and dirty (sanitized) descriptions handled; edge weight stays fixed on same-source reprocess, grows across distinct sources, adds only new sources on partial re-feed; edge merge with `entity_vdb=None` completes without raising.

## Scope / residual
`source_id`/`file_path` were already deduped and unaffected. Two pre-existing edge-weight over-count corners remain, unchanged by this PR (a complete fix needs per-source weight tracking, out of scope): a single batch with two entries from the same *new* source, and the fallback path under the source-id cap.