### PR TITLE
fix: respect LIGHTRAG-WORKSPACE header in /query endpoints (#2904)

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -9,6 +9,7 @@ from fastapi.openapi.docs import (
     get_swagger_ui_html,
     get_swagger_ui_oauth2_redirect_html,
 )
+import asyncio
 import json
 import os
 import re
@@ -29,6 +30,7 @@ from dotenv import load_dotenv
 from lightrag.api.utils_api import (
     get_combined_auth_dependency,
     get_auth_status_dependency,
+    parse_workspace_header,
     display_splash_screen,
     check_env_file,
 )
@@ -1418,34 +1420,12 @@ def create_app(args):
     auth_status = get_auth_status_dependency(api_key)
 
     def get_workspace_from_request(request: Request) -> str | None:
+        """Extract workspace from the LIGHTRAG-WORKSPACE header.
+
+        Delegates to the shared ``parse_workspace_header`` utility so the
+        sanitisation logic is not duplicated.
         """
-        Extract workspace from HTTP request header or use default.
-
-        This enables multi-workspace API support by checking the custom
-        'LIGHTRAG-WORKSPACE' header. If not present, falls back to the
-        server's default workspace configuration.
-
-        Args:
-            request: FastAPI Request object
-
-        Returns:
-            Workspace identifier (may be empty string for global namespace)
-        """
-        # Check custom header first
-        workspace = request.headers.get("LIGHTRAG-WORKSPACE", "").strip()
-
-        if not workspace:
-            workspace = None
-        else:
-            sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", workspace)
-            if sanitized != workspace:
-                logger.warning(
-                    f"Workspace header '{workspace}' contains invalid characters. "
-                    f"Sanitized to '{sanitized}'."
-                )
-                workspace = sanitized
-
-        return workspace
+        return parse_workspace_header(request)
 
     # Create working directory if it doesn't exist
     Path(args.working_dir).mkdir(parents=True, exist_ok=True)
@@ -2032,85 +2012,126 @@ def create_app(args):
         for spec in ROLES
     }
 
-    # Initialize RAG with unified configuration
-    try:
-        rag = LightRAG(
-            working_dir=args.working_dir,
-            workspace=args.workspace,
-            llm_model_func=create_llm_model_func(args.llm_binding),
-            llm_model_name=args.llm_model,
-            llm_model_max_async=args.max_async,
-            summary_max_tokens=args.summary_max_tokens,
-            summary_context_size=args.summary_context_size,
-            chunk_token_size=int(args.chunk_size),
-            chunk_overlap_token_size=int(args.chunk_overlap_size),
-            llm_model_kwargs=create_llm_model_kwargs(
-                args.llm_binding, args, llm_timeout
-            ),
-            embedding_func=embedding_func,
-            default_llm_timeout=llm_timeout,
-            default_embedding_timeout=embedding_timeout,
-            kv_storage=args.kv_storage,
-            graph_storage=args.graph_storage,
-            vector_storage=args.vector_storage,
-            doc_status_storage=args.doc_status_storage,
-            vector_db_storage_cls_kwargs={
-                "cosine_better_than_threshold": args.cosine_threshold
-            },
-            enable_llm_cache_for_entity_extract=args.enable_llm_cache_for_extract,
-            enable_llm_cache=args.enable_llm_cache,
-            vlm_process_enable=args.vlm_process_enable,
-            rerank_model_func=rerank_model_func,
-            rerank_model_max_async=args.rerank_max_async,
-            default_rerank_timeout=args.rerank_timeout,
-            max_parallel_insert=args.max_parallel_insert,
-            max_graph_nodes=args.max_graph_nodes,
-            addon_params=addon_params,
-            ollama_server_infos=ollama_server_infos,
-            role_llm_configs={
-                spec.name: RoleLLMConfig(
-                    func=role_llm_configs[spec.name]["func"],
-                    kwargs=role_llm_configs[spec.name]["kwargs"],
-                    max_async=role_llm_configs[spec.name]["max_async"],
-                    timeout=role_llm_configs[spec.name]["timeout"],
-                    metadata={
-                        "base_binding": args.llm_binding,
-                        "binding": role_llm_configs[spec.name]["binding"],
-                        "model": role_llm_configs[spec.name]["model"],
-                        "host": role_llm_configs[spec.name]["host"],
-                        "api_key": role_llm_configs[spec.name]["api_key"],
-                        "provider_options": role_llm_configs[spec.name][
-                            "provider_options"
-                        ],
-                        "bedrock_aws_options": role_llm_configs[spec.name][
-                            "bedrock_aws_options"
-                        ],
-                        "is_cross_provider": role_llm_configs[spec.name][
-                            "is_cross_provider"
-                        ],
-                    },
-                )
-                for spec in ROLES
-            },
+    # Collect RAG construction kwargs so workspace-scoped instances can be
+    # created on demand with identical configuration.
+    _rag_base_kwargs: dict[str, Any] = {
+        "working_dir": args.working_dir,
+        "llm_model_func": create_llm_model_func(args.llm_binding),
+        "llm_model_name": args.llm_model,
+        "llm_model_max_async": args.max_async,
+        "summary_max_tokens": args.summary_max_tokens,
+        "summary_context_size": args.summary_context_size,
+        "chunk_token_size": int(args.chunk_size),
+        "chunk_overlap_token_size": int(args.chunk_overlap_size),
+        "llm_model_kwargs": create_llm_model_kwargs(
+            args.llm_binding, args, llm_timeout
+        ),
+        "embedding_func": embedding_func,
+        "default_llm_timeout": llm_timeout,
+        "default_embedding_timeout": embedding_timeout,
+        "kv_storage": args.kv_storage,
+        "graph_storage": args.graph_storage,
+        "vector_storage": args.vector_storage,
+        "doc_status_storage": args.doc_status_storage,
+        "vector_db_storage_cls_kwargs": {
+            "cosine_better_than_threshold": args.cosine_threshold
+        },
+        "enable_llm_cache_for_entity_extract": args.enable_llm_cache_for_extract,
+        "enable_llm_cache": args.enable_llm_cache,
+        "vlm_process_enable": args.vlm_process_enable,
+        "rerank_model_func": rerank_model_func,
+        "rerank_model_max_async": args.rerank_max_async,
+        "default_rerank_timeout": args.rerank_timeout,
+        "max_parallel_insert": args.max_parallel_insert,
+        "max_graph_nodes": args.max_graph_nodes,
+        "addon_params": addon_params,
+        "ollama_server_infos": ollama_server_infos,
+        "role_llm_configs": {
+            spec.name: RoleLLMConfig(
+                func=role_llm_configs[spec.name]["func"],
+                kwargs=role_llm_configs[spec.name]["kwargs"],
+                max_async=role_llm_configs[spec.name]["max_async"],
+                timeout=role_llm_configs[spec.name]["timeout"],
+                metadata={
+                    "base_binding": args.llm_binding,
+                    "binding": role_llm_configs[spec.name]["binding"],
+                    "model": role_llm_configs[spec.name]["model"],
+                    "host": role_llm_configs[spec.name]["host"],
+                    "api_key": role_llm_configs[spec.name]["api_key"],
+                    "provider_options": role_llm_configs[spec.name][
+                        "provider_options"
+                    ],
+                    "bedrock_aws_options": role_llm_configs[spec.name][
+                        "bedrock_aws_options"
+                    ],
+                    "is_cross_provider": role_llm_configs[spec.name][
+                        "is_cross_provider"
+                    ],
+                },
+            )
+            for spec in ROLES
+        },
+    }
+
+    def _register_role_builder(rag_instance: LightRAG) -> None:
+        rag_instance.register_role_llm_builder(
+            lambda role, meta: (
+                create_role_llm_func(role, meta),
+                create_role_llm_model_kwargs(role, meta),
+            )
         )
+
+    # Initialize the default RAG instance
+    try:
+        rag = LightRAG(workspace=args.workspace, **_rag_base_kwargs)
     except Exception as e:
         logger.error(f"Failed to initialize LightRAG: {e}")
         raise
 
     _log_role_provider_options(rag)
+    _register_role_builder(rag)
 
-    rag.register_role_llm_builder(
-        lambda role, meta: (
-            create_role_llm_func(role, meta),
-            create_role_llm_model_kwargs(role, meta),
-        )
-    )
+    # Workspace-scoped RAG instance pool.
+    # Keyed by workspace name; the default instance is pre-seeded.
+    _workspace_rag_pool: dict[str, LightRAG] = {args.workspace or "": rag}
+    _workspace_pool_lock = asyncio.Lock()
+
+    async def resolve_workspace_rag(request: Request) -> LightRAG:
+        """Return the RAG instance scoped to the workspace in the request header.
+
+        Falls back to the default instance when the header is absent.
+        New instances are created, initialized, and cached on first access.
+        """
+        workspace = parse_workspace_header(request)
+        default_ws = args.workspace or ""
+        effective_ws = workspace if workspace is not None else default_ws
+
+        cached = _workspace_rag_pool.get(effective_ws)
+        if cached is not None:
+            return cached
+
+        async with _workspace_pool_lock:
+            # Double-check after acquiring lock
+            cached = _workspace_rag_pool.get(effective_ws)
+            if cached is not None:
+                return cached
+
+            logger.info(f"Creating RAG instance for workspace '{effective_ws}'")
+            new_rag = LightRAG(workspace=effective_ws, **_rag_base_kwargs)
+            await new_rag.initialize_storages()
+            _register_role_builder(new_rag)
+            _workspace_rag_pool[effective_ws] = new_rag
+            return new_rag
 
     # Add routes
     # root_path is set on the app for reverse proxy support;
     # routes stay at their natural paths and are prefixed by the proxy or uvicorn --root-path
     app.include_router(create_document_routes(rag, doc_manager, api_key))
-    app.include_router(create_query_routes(rag, api_key, args.top_k))
+    app.include_router(
+        create_query_routes(
+            rag, api_key, args.top_k, resolve_workspace_rag=resolve_workspace_rag
+        )
+    )
     app.include_router(create_graph_routes(rag, api_key))
 
     # Add Ollama API routes

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -1267,6 +1267,12 @@ def create_app(args):
     # Initialize document manager with workspace support for data isolation
     doc_manager = DocumentManager(args.input_dir, workspace=args.workspace)
 
+    # Workspace-scoped RAG instance pool.
+    # Declared before lifespan so the shutdown handler can iterate it.
+    # The default instance is seeded after construction below.
+    _workspace_rag_pool: dict[str, LightRAG] = {}
+    _workspace_pool_lock = asyncio.Lock()
+
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         """Lifespan context manager for startup and shutdown events"""
@@ -1286,8 +1292,13 @@ def create_app(args):
             yield
 
         finally:
-            # Clean up database connections
-            await rag.finalize_storages()
+            # Clean up database connections for all workspace-scoped instances
+            for ws, ws_rag in _workspace_rag_pool.items():
+                try:
+                    await ws_rag.finalize_storages()
+                except Exception as e:
+                    logger.error(f"Failed to finalize storages for workspace '{ws}': {e}")
+            _workspace_rag_pool.clear()
 
             if "LIGHTRAG_GUNICORN_MODE" not in os.environ:
                 # Only perform cleanup in Uvicorn single-process mode
@@ -2091,10 +2102,8 @@ def create_app(args):
     _log_role_provider_options(rag)
     _register_role_builder(rag)
 
-    # Workspace-scoped RAG instance pool.
-    # Keyed by workspace name; the default instance is pre-seeded.
-    _workspace_rag_pool: dict[str, LightRAG] = {args.workspace or "": rag}
-    _workspace_pool_lock = asyncio.Lock()
+    # Seed the default instance into the pool declared above.
+    _workspace_rag_pool[args.workspace or ""] = rag
 
     async def resolve_workspace_rag(request: Request) -> LightRAG:
         """Return the RAG instance scoped to the workspace in the request header.

--- a/lightrag/api/routers/query_routes.py
+++ b/lightrag/api/routers/query_routes.py
@@ -3,8 +3,8 @@ This module contains all query-related routes for the LightRAG API.
 """
 
 import json
-from typing import Any, Dict, List, Literal, Optional
-from fastapi import APIRouter, Depends, HTTPException
+from typing import Any, Awaitable, Callable, Dict, List, Literal, Optional
+from fastapi import APIRouter, Depends, HTTPException, Request
 from lightrag.base import QueryParam
 from lightrag.api.utils_api import get_combined_auth_dependency
 from lightrag.utils import logger
@@ -188,7 +188,13 @@ class StreamChunkResponse(BaseModel):
     )
 
 
-def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
+def create_query_routes(
+    rag,
+    api_key: Optional[str] = None,
+    top_k: int = 60,
+    *,
+    resolve_workspace_rag: Optional[Callable[[Request], Awaitable[Any]]] = None,
+):
     # Fresh router per call. A module-level instance would accumulate
     # duplicate routes when the factory is invoked more than once in the
     # same process (e.g. across tests), which triggers FastAPI's
@@ -196,6 +202,12 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
     router = APIRouter(tags=["query"])
 
     combined_auth = get_combined_auth_dependency(api_key)
+
+    async def _get_rag(request: Request):
+        """Resolve the workspace-scoped RAG instance for this request."""
+        if resolve_workspace_rag is not None:
+            return await resolve_workspace_rag(request)
+        return rag
 
     @router.post(
         "/query",
@@ -326,7 +338,7 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
             },
         },
     )
-    async def query_text(request: QueryRequest):
+    async def query_text(request: QueryRequest, raw_request: Request):
         """
         Comprehensive RAG query endpoint with non-streaming response. Parameter "stream" is ignored.
 
@@ -403,13 +415,14 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
                 - 500: Internal processing error (e.g., LLM service unavailable)
         """
         try:
+            workspace_rag = await _get_rag(raw_request)
             param = request.to_query_params(
                 False
             )  # Ensure stream=False for non-streaming endpoint
             # Force stream=False for /query endpoint regardless of include_references setting
             param.stream = False
             # Unified approach: always use aquery_llm for both cases
-            result = await rag.aquery_llm(request.query, param=param)
+            result = await workspace_rag.aquery_llm(request.query, param=param)
 
             # Extract LLM response and references from unified result
             llm_response = result.get("llm_response", {})
@@ -596,7 +609,7 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
             },
         },
     )
-    async def query_text_stream(request: QueryRequest):
+    async def query_text_stream(request: QueryRequest, raw_request: Request):
         """
         Advanced RAG query endpoint with flexible streaming response.
 
@@ -724,6 +737,7 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
             Use streaming mode for real-time interfaces and non-streaming for batch processing.
         """
         try:
+            workspace_rag = await _get_rag(raw_request)
             # Use the stream parameter from the request, defaulting to True if not specified
             stream_mode = request.stream if request.stream is not None else True
             param = request.to_query_params(stream_mode)
@@ -731,7 +745,7 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
             from fastapi.responses import StreamingResponse
 
             # Unified approach: always use aquery_llm for all cases
-            result = await rag.aquery_llm(request.query, param=param)
+            result = await workspace_rag.aquery_llm(request.query, param=param)
             stream_gen = _build_stream_generator(
                 result=result,
                 include_references=request.include_references,
@@ -1048,7 +1062,7 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
             },
         },
     )
-    async def query_data(request: QueryRequest):
+    async def query_data(request: QueryRequest, raw_request: Request):
         """
         Advanced data retrieval endpoint for structured RAG analysis.
 
@@ -1152,8 +1166,9 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
             as structured data analysis typically requires source attribution.
         """
         try:
+            workspace_rag = await _get_rag(raw_request)
             param = request.to_query_params(False)  # No streaming for data endpoint
-            response = await rag.aquery_data(request.query, param=param)
+            response = await workspace_rag.aquery_data(request.query, param=param)
 
             # aquery_data returns the new format with status, message, data, and metadata
             if isinstance(response, dict):

--- a/lightrag/api/utils_api.py
+++ b/lightrag/api/utils_api.py
@@ -3,6 +3,7 @@ Utility functions for the LightRAG API.
 """
 
 import os
+import re
 import argparse
 from typing import Optional, List, Tuple
 import sys
@@ -86,6 +87,24 @@ for path in whitelist_paths:
 
 # Global authentication configuration
 auth_configured = bool(auth_handler.accounts)
+
+
+def parse_workspace_header(request: Request) -> str | None:
+    """Extract and sanitize workspace identifier from the LIGHTRAG-WORKSPACE header.
+
+    Returns None when the header is absent or empty, signalling the caller
+    should fall back to the server's default workspace.
+    """
+    workspace = request.headers.get("LIGHTRAG-WORKSPACE", "").strip()
+    if not workspace:
+        return None
+    sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", workspace)
+    if sanitized != workspace:
+        logger.warning(
+            f"Workspace header '{workspace}' contains invalid characters. "
+            f"Sanitized to '{sanitized}'."
+        )
+    return sanitized
 
 
 def get_combined_auth_dependency(api_key: Optional[str] = None):

--- a/tests/api/routes/test_query_workspace.py
+++ b/tests/api/routes/test_query_workspace.py
@@ -1,0 +1,166 @@
+"""
+Regression test for #2904: /query endpoints must respect LIGHTRAG-WORKSPACE header.
+
+Verifies that the three query endpoints (/query, /query/stream, /query/data)
+route to workspace-scoped RAG instances based on the LIGHTRAG-WORKSPACE header,
+and fall back to the default instance when the header is absent.
+"""
+
+import sys
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+
+_ENV_VARS_TO_ISOLATE = (
+    "LLM_BINDING",
+    "EMBEDDING_BINDING",
+    "LLM_BINDING_HOST",
+    "LLM_BINDING_API_KEY",
+    "LLM_MODEL",
+    "EMBEDDING_BINDING_HOST",
+    "EMBEDDING_BINDING_API_KEY",
+    "EMBEDDING_MODEL",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    for var in _ENV_VARS_TO_ISOLATE:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("LLM_BINDING", "ollama")
+    monkeypatch.setenv("EMBEDDING_BINDING", "ollama")
+
+
+def _make_mock_rag(workspace: str = "") -> MagicMock:
+    """Create a mock RAG instance tagged with its workspace."""
+    mock = MagicMock()
+    mock.workspace = workspace
+    mock.aquery_llm = AsyncMock(
+        return_value={
+            "llm_response": {"content": f"answer from {workspace or 'default'}"},
+            "data": {"references": []},
+        }
+    )
+    mock.aquery_data = AsyncMock(
+        return_value={
+            "status": "success",
+            "message": "ok",
+            "data": {
+                "entities": [],
+                "relationships": [],
+                "chunks": [],
+                "references": [],
+            },
+            "metadata": {},
+        }
+    )
+    return mock
+
+
+def _build_workspace_client():
+    """Build a TestClient with workspace-aware query routing."""
+    original_argv = sys.argv.copy()
+    try:
+        sys.argv = ["lightrag-server"]
+        from fastapi import FastAPI, Request
+        from fastapi.testclient import TestClient
+        from lightrag.api.routers.query_routes import create_query_routes
+        from lightrag.api.utils_api import parse_workspace_header
+
+        default_rag = _make_mock_rag("default")
+        tenant_a_rag = _make_mock_rag("tenant_a")
+        pool = {"default": default_rag, "tenant_a": tenant_a_rag}
+
+        async def resolve_workspace_rag(request: Request):
+            ws = parse_workspace_header(request)
+            return pool.get(ws or "default", default_rag)
+
+        app = FastAPI()
+        router = create_query_routes(
+            default_rag,
+            resolve_workspace_rag=resolve_workspace_rag,
+        )
+        app.include_router(router)
+        return TestClient(app), default_rag, tenant_a_rag
+    finally:
+        sys.argv = original_argv
+
+
+class TestQueryWorkspaceRouting:
+    """The /query endpoints must route to the correct workspace RAG instance."""
+
+    def test_query_without_header_uses_default(self):
+        client, default_rag, tenant_a_rag = _build_workspace_client()
+        resp = client.post("/query", json={"query": "test question", "mode": "naive"})
+        assert resp.status_code == 200
+        default_rag.aquery_llm.assert_called_once()
+        tenant_a_rag.aquery_llm.assert_not_called()
+
+    def test_query_with_header_routes_to_workspace(self):
+        client, default_rag, tenant_a_rag = _build_workspace_client()
+        resp = client.post(
+            "/query",
+            json={"query": "test question", "mode": "naive"},
+            headers={"LIGHTRAG-WORKSPACE": "tenant_a"},
+        )
+        assert resp.status_code == 200
+        tenant_a_rag.aquery_llm.assert_called_once()
+        default_rag.aquery_llm.assert_not_called()
+
+    def test_query_stream_with_header_routes_to_workspace(self):
+        client, default_rag, tenant_a_rag = _build_workspace_client()
+        resp = client.post(
+            "/query/stream",
+            json={"query": "test question", "mode": "naive"},
+            headers={"LIGHTRAG-WORKSPACE": "tenant_a"},
+        )
+        assert resp.status_code == 200
+        tenant_a_rag.aquery_llm.assert_called_once()
+        default_rag.aquery_llm.assert_not_called()
+
+    def test_query_data_with_header_routes_to_workspace(self):
+        client, default_rag, tenant_a_rag = _build_workspace_client()
+        resp = client.post(
+            "/query/data",
+            json={"query": "test question", "mode": "naive"},
+            headers={"LIGHTRAG-WORKSPACE": "tenant_a"},
+        )
+        assert resp.status_code == 200
+        tenant_a_rag.aquery_data.assert_called_once()
+        default_rag.aquery_data.assert_not_called()
+
+    def test_workspace_header_sanitized(self):
+        client, default_rag, _ = _build_workspace_client()
+        resp = client.post(
+            "/query",
+            json={"query": "test question", "mode": "naive"},
+            headers={"LIGHTRAG-WORKSPACE": "bad-name!"},
+        )
+        # Sanitized to "bad_name_" which is not in pool -> falls back to default
+        assert resp.status_code == 200
+        default_rag.aquery_llm.assert_called_once()
+
+    def test_no_resolver_falls_back_to_closure_rag(self):
+        """When resolve_workspace_rag is None, endpoints use the default rag."""
+        original_argv = sys.argv.copy()
+        try:
+            sys.argv = ["lightrag-server"]
+            from fastapi import FastAPI
+            from fastapi.testclient import TestClient
+            from lightrag.api.routers.query_routes import create_query_routes
+
+            default_rag = _make_mock_rag("default")
+            app = FastAPI()
+            router = create_query_routes(default_rag)
+            app.include_router(router)
+            client = TestClient(app)
+
+            resp = client.post(
+                "/query",
+                json={"query": "test question", "mode": "naive"},
+                headers={"LIGHTRAG-WORKSPACE": "anything"},
+            )
+            assert resp.status_code == 200
+            default_rag.aquery_llm.assert_called_once()
+        finally:
+            sys.argv = original_argv


### PR DESCRIPTION
## Summary

Fixes #2904

The three query endpoints /query, /query/stream and /query/data ignored the LIGHTRAG-WORKSPACE header entirely. All queries were routed to the default workspace regardless of what the client specified, which breaks multi-tenant deployments.

## Root Cause

create_query_routes received a single rag instance bound to the default workspace at server startup. All query handlers used this instance directly without ever reading the request header, so workspace-scoped storage backends were never consulted.

## What Changed

Extracted parse_workspace_header as a shared utility in utils_api.py to eliminate the duplicated header parsing logic in the health endpoint.

In lightrag_server.py the RAG construction kwargs are now stored for reuse. A workspace-scoped instance pool with async double-checked locking creates initializes and caches RAG instances on first access per workspace.

In query_routes.py create_query_routes accepts an optional resolve_workspace_rag callable. All three query endpoints resolve the workspace-scoped RAG instance from the request header before querying. Fully backward compatible when no resolver is provided the default rag from the closure is used as before.

## Checklist

- [x] 本地测试更改
- [x] 代码已审核
- [x] 添加单元测试（如适用）

## Test Plan

- 6 new regression tests in tests/api/routes/test_query_workspace.py
- No header uses default workspace
- Header present routes to correct workspace
- Covers all three query endpoints
- Header sanitization for invalid characters
- Backward compatibility when no resolver is passed
- All existing query route tests pass with zero regressions
