### PR TITLE
fix: preserve cached xlsx formula values

### DIFF
--- a/lightrag/parser/legacy/extractors.py
+++ b/lightrag/parser/legacy/extractors.py
@@ -98,8 +98,8 @@ def _extract_xlsx(file_bytes: bytes) -> str:
     """Extract XLSX content in tab-delimited format with sheet separators."""
     from openpyxl import load_workbook  # type: ignore
 
-    xlsx_file = BytesIO(file_bytes)
-    wb = load_workbook(xlsx_file)
+    wb_values = load_workbook(BytesIO(file_bytes), data_only=True)
+    wb_formulas = load_workbook(BytesIO(file_bytes), data_only=False)
 
     def escape_cell(cell_value: str | int | float | None) -> str:
         if cell_value is None:
@@ -119,20 +119,31 @@ def _extract_xlsx(file_bytes: bytes) -> str:
     content_parts: list[str] = []
     sheet_separator = "=" * 20
 
-    for idx, sheet in enumerate(wb):
+    for idx, sheet in enumerate(wb_values):
         if idx > 0:
             content_parts.append("")
         safe_title = escape_sheet_title(sheet.title)
         content_parts.append(f"{sheet_separator} Sheet: {safe_title} {sheet_separator}")
-        max_columns = sheet.max_column if sheet.max_column else 0
-        for row in sheet.iter_rows(values_only=True):
+        formula_sheet = wb_formulas[sheet.title]
+        max_rows = max(sheet.max_row or 0, formula_sheet.max_row or 0)
+        max_columns = max(sheet.max_column or 0, formula_sheet.max_column or 0)
+        value_rows = sheet.iter_rows(
+            min_row=1, max_row=max_rows, max_col=max_columns, values_only=True
+        )
+        formula_rows = formula_sheet.iter_rows(
+            min_row=1, max_row=max_rows, max_col=max_columns, values_only=True
+        )
+        for value_row, formula_row in zip(value_rows, formula_rows):
             row_parts = []
-            for col_idx in range(max_columns):
-                if col_idx < len(row):
-                    row_parts.append(escape_cell(row[col_idx]))
-                else:
-                    row_parts.append("")
-            if all(part == "" for part in row_parts):
+            row_has_content = False
+            for cell_value, formula_value in zip(value_row, formula_row):
+                if cell_value is None:
+                    cell_value = formula_value
+                cell_text = escape_cell(cell_value)
+                row_parts.append(cell_text)
+                if cell_text:
+                    row_has_content = True
+            if not row_has_content:
                 content_parts.append("")
             else:
                 content_parts.append("\t".join(row_parts))

--- a/lightrag/parser/legacy/extractors.py
+++ b/lightrag/parser/legacy/extractors.py
@@ -95,7 +95,16 @@ def _extract_pptx(file_bytes: bytes) -> str:
 
 
 def _extract_xlsx(file_bytes: bytes) -> str:
-    """Extract XLSX content in tab-delimited format with sheet separators."""
+    """Extract XLSX content in tab-delimited format with sheet separators.
+
+    Formula cells are indexed by their cached calculated value when the workbook
+    carries one, falling back to the formula text when it does not. openpyxl
+    fixes ``data_only`` at load time, so the workbook is deliberately loaded
+    twice -- ``data_only=True`` for values, ``data_only=False`` for formulas.
+    This doubles peak memory/parse cost but is required to have both views;
+    ``read_only=True`` is not a safe optimization here because it can report
+    ``max_row``/``max_column`` as ``None`` and collapse the iteration range.
+    """
     from openpyxl import load_workbook  # type: ignore
 
     wb_values = load_workbook(BytesIO(file_bytes), data_only=True)

--- a/tests/parser/test_legacy_extractors.py
+++ b/tests/parser/test_legacy_extractors.py
@@ -1,0 +1,77 @@
+"""Tests for legacy text extraction helpers."""
+
+from __future__ import annotations
+
+from io import BytesIO
+from zipfile import ZIP_DEFLATED, ZipFile
+from xml.etree import ElementTree as ET
+
+import pytest
+from openpyxl import Workbook
+
+from lightrag.parser.legacy.extractors import extract_text
+
+
+def _make_xlsx_bytes(*, cached_formula_value: str | int | float | None) -> bytes:
+    """Build a minimal workbook with one formula cell.
+
+    ``openpyxl`` writes the formula expression, but not a cached calculated
+    value. We patch the worksheet XML so the extractor can exercise both the
+    ``data_only=True`` path and the formula fallback path.
+    """
+
+    bio = BytesIO()
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+    ws["A1"] = 1
+    ws["A2"] = 2
+    ws["B1"] = "=SUM(A1:A2)"
+    wb.save(bio)
+
+    if cached_formula_value is None:
+        return bio.getvalue()
+
+    source = BytesIO(bio.getvalue())
+    patched = BytesIO()
+    ns = {"main": "http://schemas.openxmlformats.org/spreadsheetml/2006/main"}
+
+    with ZipFile(source, "r") as zin, ZipFile(patched, "w", ZIP_DEFLATED) as zout:
+        for item in zin.infolist():
+            data = zin.read(item.filename)
+            if item.filename == "xl/worksheets/sheet1.xml":
+                root = ET.fromstring(data)
+                for cell in root.findall(".//main:c", ns):
+                    if cell.attrib.get("r") != "B1":
+                        continue
+                    value_node = cell.find("main:v", ns)
+                    if value_node is None:
+                        value_node = ET.SubElement(
+                            cell,
+                            "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}v",
+                        )
+                    value_node.text = str(cached_formula_value)
+                    break
+                data = ET.tostring(root, encoding="utf-8", xml_declaration=False)
+            zout.writestr(item, data)
+
+    return patched.getvalue()
+
+
+@pytest.mark.offline
+def test_extract_text_xlsx_uses_cached_formula_value():
+    file_bytes = _make_xlsx_bytes(cached_formula_value=3)
+
+    text = extract_text(file_bytes, "xlsx")
+
+    assert "3" in text
+    assert "=SUM(A1:A2)" not in text
+
+
+@pytest.mark.offline
+def test_extract_text_xlsx_falls_back_to_formula_text_when_cache_missing():
+    file_bytes = _make_xlsx_bytes(cached_formula_value=None)
+
+    text = extract_text(file_bytes, "xlsx")
+
+    assert "=SUM(A1:A2)" in text

--- a/tests/parser/test_legacy_extractors.py
+++ b/tests/parser/test_legacy_extractors.py
@@ -12,12 +12,62 @@ from openpyxl import Workbook
 from lightrag.parser.legacy.extractors import extract_text
 
 
+_NS_URI = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+_NS = {"main": _NS_URI}
+
+
+def _inject_cached_value(
+    data: bytes, cell_ref: str, cached_value: str | int | float
+) -> bytes:
+    """Patch a worksheet's XML so ``cell_ref`` carries a cached ``<v>`` value.
+
+    ``openpyxl`` writes formula expressions but never a cached calculated value,
+    so we inject one to exercise the ``data_only=True`` read path. String results
+    are tagged ``t="str"`` to match how Excel records a text-valued formula.
+    """
+
+    root = ET.fromstring(data)
+    for cell in root.findall(".//main:c", _NS):
+        if cell.attrib.get("r") != cell_ref:
+            continue
+        if isinstance(cached_value, str):
+            cell.set("t", "str")
+        value_node = cell.find("main:v", _NS)
+        if value_node is None:
+            value_node = ET.SubElement(cell, f"{{{_NS_URI}}}v")
+        value_node.text = str(cached_value)
+        break
+    return ET.tostring(root, encoding="utf-8", xml_declaration=False)
+
+
+def _patch_xlsx(
+    file_bytes: bytes, injections: dict[str, tuple[str, str | int | float]]
+) -> bytes:
+    """Rewrite worksheet parts in ``file_bytes`` with cached formula values.
+
+    ``injections`` maps a worksheet part name (e.g. ``xl/worksheets/sheet1.xml``)
+    to a ``(cell_ref, cached_value)`` pair.
+    """
+
+    source = BytesIO(file_bytes)
+    patched = BytesIO()
+    with ZipFile(source, "r") as zin, ZipFile(patched, "w", ZIP_DEFLATED) as zout:
+        for item in zin.infolist():
+            data = zin.read(item.filename)
+            if item.filename in injections:
+                cell_ref, cached_value = injections[item.filename]
+                data = _inject_cached_value(data, cell_ref, cached_value)
+            zout.writestr(item, data)
+    return patched.getvalue()
+
+
 def _make_xlsx_bytes(*, cached_formula_value: str | int | float | None) -> bytes:
-    """Build a minimal workbook with one formula cell.
+    """Build a minimal single-sheet workbook with one formula cell.
 
     ``openpyxl`` writes the formula expression, but not a cached calculated
-    value. We patch the worksheet XML so the extractor can exercise both the
-    ``data_only=True`` path and the formula fallback path.
+    value. When ``cached_formula_value`` is given we patch the worksheet XML so
+    the extractor exercises the ``data_only=True`` path; when it is ``None`` the
+    workbook carries no cache and the formula-text fallback path is exercised.
     """
 
     bio = BytesIO()
@@ -32,30 +82,38 @@ def _make_xlsx_bytes(*, cached_formula_value: str | int | float | None) -> bytes
     if cached_formula_value is None:
         return bio.getvalue()
 
-    source = BytesIO(bio.getvalue())
-    patched = BytesIO()
-    ns = {"main": "http://schemas.openxmlformats.org/spreadsheetml/2006/main"}
+    return _patch_xlsx(
+        bio.getvalue(), {"xl/worksheets/sheet1.xml": ("B1", cached_formula_value)}
+    )
 
-    with ZipFile(source, "r") as zin, ZipFile(patched, "w", ZIP_DEFLATED) as zout:
-        for item in zin.infolist():
-            data = zin.read(item.filename)
-            if item.filename == "xl/worksheets/sheet1.xml":
-                root = ET.fromstring(data)
-                for cell in root.findall(".//main:c", ns):
-                    if cell.attrib.get("r") != "B1":
-                        continue
-                    value_node = cell.find("main:v", ns)
-                    if value_node is None:
-                        value_node = ET.SubElement(
-                            cell,
-                            "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}v",
-                        )
-                    value_node.text = str(cached_formula_value)
-                    break
-                data = ET.tostring(root, encoding="utf-8", xml_declaration=False)
-            zout.writestr(item, data)
 
-    return patched.getvalue()
+def _make_multi_sheet_xlsx_bytes() -> bytes:
+    """Two sheets of differing shape, each with a cached formula result.
+
+    Exercises the per-sheet title matching (``wb_formulas[sheet.title]``), the
+    cross-view dimension union, and a string-valued cached result.
+    """
+
+    bio = BytesIO()
+    wb = Workbook()
+    numbers = wb.active
+    numbers.title = "Numbers"
+    numbers["A1"] = 1
+    numbers["A2"] = 2
+    numbers["B1"] = "=SUM(A1:A2)"
+
+    words = wb.create_sheet("Words")
+    words["A1"] = "foo"
+    words["B1"] = '=A1&"bar"'
+    wb.save(bio)
+
+    return _patch_xlsx(
+        bio.getvalue(),
+        {
+            "xl/worksheets/sheet1.xml": ("B1", 3),
+            "xl/worksheets/sheet2.xml": ("B1", "foobar"),
+        },
+    )
 
 
 @pytest.mark.offline
@@ -75,3 +133,20 @@ def test_extract_text_xlsx_falls_back_to_formula_text_when_cache_missing():
     text = extract_text(file_bytes, "xlsx")
 
     assert "=SUM(A1:A2)" in text
+
+
+@pytest.mark.offline
+def test_extract_text_xlsx_handles_multiple_sheets_and_string_results():
+    file_bytes = _make_multi_sheet_xlsx_bytes()
+
+    text = extract_text(file_bytes, "xlsx")
+
+    # Both sheets are emitted, matched to their own formula view by title.
+    assert "Sheet: Numbers" in text
+    assert "Sheet: Words" in text
+    # Numeric cached result preferred over the SUM formula text.
+    assert "3" in text
+    assert "=SUM(A1:A2)" not in text
+    # String cached result preferred over the concatenation formula text.
+    assert "foobar" in text
+    assert '=A1&"bar"' not in text


### PR DESCRIPTION
## Description

Improve XLSX extraction so formula cells preserve their indexable content.

Previously, formula cells could be indexed as the formula text itself (e.g. `=SUM(A1:A10)`) instead of the computed value when parsing spreadsheets. This meant documents containing formulas sometimes lost meaningful searchable content if the workbook values weren't handled correctly.

This change makes the extractor prefer cached calculated values when they are available, while falling back to the formula text when a workbook has not been recalculated and no cached value exists.


## Related Issues

None.

## Changes Made

- Updated `_extract_xlsx` to read cached workbook values and formula text together.
- Added regression coverage for cached-formula and no-cache XLSX cases.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

On same files - graph before fix
<img width="1615" height="1079" alt="Screenshot 2026-07-07 at 22 29 10" src="https://github.com/user-attachments/assets/2b845ad3-0a43-403f-b793-dd759e31961e" />

Chat before fix
<img width="1421" height="189" alt="image" src="https://github.com/user-attachments/assets/a326e99f-6249-470c-a092-a88701ee3958" />


Graph after fix

<img width="1426" height="996" alt="Screenshot 2026-07-07 at 22 18 52" src="https://github.com/user-attachments/assets/564f3604-d57f-4b96-9c5c-58bdce495a12" />

Chat after fix

<img width="1396" height="362" alt="image" src="https://github.com/user-attachments/assets/e700eb72-1516-4f78-92b0-01909502cade" />
