### PR TITLE
feat(kg): add LanceDB unified storage backend

### DIFF
--- a/docs/LightRAG-API-Server.md
+++ b/docs/LightRAG-API-Server.md
@@ -531,8 +531,9 @@ The command-line `workspace` argument and the `WORKSPACE` environment variable i
 - **For relational databases, data isolation is achieved by adding a `workspace` field to the tables for logical data separation:** `PGKVStorage`, `PGVectorStorage`, `PGDocStatusStorage`.
 - **For graph databases, logical data isolation is achieved through labels:** `Neo4JStorage`, `MemgraphStorage`
 - **For OpenSearch, data isolation is achieved through index name prefixes:** `OpenSearchKVStorage`, `OpenSearchDocStatusStorage`, `OpenSearchGraphStorage`, `OpenSearchVectorDBStorage`
+- **For LanceDB (embedded), data isolation is achieved through table name prefixes:** `LanceDBKVStorage`, `LanceDBDocStatusStorage`, `LanceDBGraphStorage`, `LanceDBVectorStorage`
 
-To maintain compatibility with legacy data, the default workspace for PostgreSQL is `default` and for Neo4j is `base` when no workspace is configured. For all external storages, the system provides dedicated workspace environment variables to override the common `WORKSPACE` environment variable configuration. These storage-specific workspace environment variables are: `REDIS_WORKSPACE`, `MILVUS_WORKSPACE`, `QDRANT_WORKSPACE`, `MONGODB_WORKSPACE`, `POSTGRES_WORKSPACE`, `NEO4J_WORKSPACE`, `MEMGRAPH_WORKSPACE`, `OPENSEARCH_WORKSPACE`.
+To maintain compatibility with legacy data, the default workspace for PostgreSQL is `default` and for Neo4j is `base` when no workspace is configured. For all external storages, the system provides dedicated workspace environment variables to override the common `WORKSPACE` environment variable configuration. These storage-specific workspace environment variables are: `REDIS_WORKSPACE`, `MILVUS_WORKSPACE`, `QDRANT_WORKSPACE`, `MONGODB_WORKSPACE`, `POSTGRES_WORKSPACE`, `NEO4J_WORKSPACE`, `MEMGRAPH_WORKSPACE`, `OPENSEARCH_WORKSPACE`, `LANCEDB_WORKSPACE`.
 
 ### Multiple workers for Gunicorn + Uvicorn
 

--- a/docs/OfflineDeployment.md
+++ b/docs/OfflineDeployment.md
@@ -24,7 +24,7 @@ LightRAG uses dynamic package installation (`pipmaster`) for optional features b
 
 LightRAG dynamically installs packages for:
 
-- **Storage Backends**: `redis`, `neo4j`, `pymilvus`, `pymongo`, `asyncpg`, `qdrant-client`
+- **Storage Backends**: `redis`, `neo4j`, `pymilvus`, `pymongo`, `asyncpg`, `qdrant-client`, `lancedb`
 - **LLM Providers**: `openai`, `anthropic`, `ollama`, `zhipuai`, `aioboto3`, `voyageai`, `llama-index`, `lmdeploy`, `transformers`, `torch`
 - **Tiktoken Models**: BPE encoding models downloaded from OpenAI CDN
 

--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -69,10 +69,10 @@ Notes:
 | -------------- | ---------- | ----------------- | ------------- |
 | **working_dir** | `str` | Directory where the cache will be stored | `lightrag_cache+timestamp` |
 | **workspace** | str | Workspace name for data isolation between different LightRAG Instances | |
-| **kv_storage** | `str` | Storage type for documents and text chunks. Supported types: `JsonKVStorage`,`PGKVStorage`,`RedisKVStorage`,`MongoKVStorage`,`OpenSearchKVStorage` | `JsonKVStorage` |
-| **vector_storage** | `str` | Storage type for embedding vectors. Supported types: `NanoVectorDBStorage`,`PGVectorStorage`,`MilvusVectorDBStorage`,`ChromaVectorDBStorage`,`FaissVectorDBStorage`,`MongoVectorDBStorage`,`QdrantVectorDBStorage`,`OpenSearchVectorDBStorage` | `NanoVectorDBStorage` |
-| **graph_storage** | `str` | Storage type for graph edges and nodes. Supported types: `NetworkXStorage`,`Neo4JStorage`,`PGGraphStorage`,`AGEStorage`,`OpenSearchGraphStorage` | `NetworkXStorage` |
-| **doc_status_storage** | `str` | Storage type for documents process status. Supported types: `JsonDocStatusStorage`,`PGDocStatusStorage`,`MongoDocStatusStorage`,`OpenSearchDocStatusStorage` | `JsonDocStatusStorage` |
+| **kv_storage** | `str` | Storage type for documents and text chunks. Supported types: `JsonKVStorage`,`PGKVStorage`,`RedisKVStorage`,`MongoKVStorage`,`OpenSearchKVStorage`,`LanceDBKVStorage` | `JsonKVStorage` |
+| **vector_storage** | `str` | Storage type for embedding vectors. Supported types: `NanoVectorDBStorage`,`PGVectorStorage`,`MilvusVectorDBStorage`,`ChromaVectorDBStorage`,`FaissVectorDBStorage`,`MongoVectorDBStorage`,`QdrantVectorDBStorage`,`OpenSearchVectorDBStorage`,`LanceDBVectorStorage` | `NanoVectorDBStorage` |
+| **graph_storage** | `str` | Storage type for graph edges and nodes. Supported types: `NetworkXStorage`,`Neo4JStorage`,`PGGraphStorage`,`AGEStorage`,`OpenSearchGraphStorage`,`LanceDBGraphStorage` | `NetworkXStorage` |
+| **doc_status_storage** | `str` | Storage type for documents process status. Supported types: `JsonDocStatusStorage`,`PGDocStatusStorage`,`MongoDocStatusStorage`,`OpenSearchDocStatusStorage`,`LanceDBDocStatusStorage` | `JsonDocStatusStorage` |
 | **chunk_token_size** | `int` | Maximum token size per chunk when splitting documents | `1200` |
 | **chunk_overlap_token_size** | `int` | Overlap token size between two chunks when splitting documents | `100` |
 | **tokenizer** | `Tokenizer` | The function used to convert text into tokens (numbers) and back using .encode() and .decode() functions following `TokenizerInterface` protocol. If you don't specify one, it will use the default Tiktoken tokenizer. | `TiktokenTokenizer` |
@@ -608,6 +608,7 @@ PGKVStorage          Postgres
 RedisKVStorage       Redis
 MongoKVStorage       MongoDB
 OpenSearchKVStorage  OpenSearch
+LanceDBKVStorage     LanceDB (embedded)
 ```
 
 **GRAPH_STORAGE**
@@ -617,6 +618,7 @@ Neo4JStorage             Neo4J
 PGGraphStorage           PostgreSQL with AGE plugin
 MemgraphStorage          Memgraph
 OpenSearchGraphStorage   OpenSearch
+LanceDBGraphStorage      LanceDB (embedded)
 ```
 
 > Testing has shown that Neo4J delivers superior performance in production environments compared to PostgreSQL with AGE plugin.
@@ -630,6 +632,7 @@ FaissVectorDBStorage        Faiss
 QdrantVectorDBStorage       Qdrant
 MongoVectorDBStorage        MongoDB
 OpenSearchVectorDBStorage   OpenSearch
+LanceDBVectorStorage        LanceDB (embedded)
 ```
 
 **DOC_STATUS_STORAGE**
@@ -638,6 +641,7 @@ JsonDocStatusStorage        JsonFile (default)
 PGDocStatusStorage          Postgres
 MongoDocStatusStorage       MongoDB
 OpenSearchDocStatusStorage  OpenSearch
+LanceDBDocStatusStorage     LanceDB (embedded)
 ```
 
 Example connection configurations for each storage type can be found in the repository's `env.example` file. The database instance in the connection string must be created beforehand — LightRAG only creates tables within the instance, not the instance itself.
@@ -871,6 +875,49 @@ OPENAI_API_KEY=your-api-key \
 lightrag-server
 ```
 
+#### Using LanceDB Storage
+
+LanceDB provides a unified storage solution for all four LightRAG storage types (KV, Vector, Graph, DocStatus) in a single embedded database — no external server, no Docker. All data lives in one local directory using the Lance columnar format, with brute-force (exact) cosine vector search and a CJK-friendly BM25 full-text index on chunk content.
+
+**Requirements**: `pip install lancedb` (installed automatically on first use, or via `pip install lightrag-hku[offline-storage]`). Python 3.10+.
+
+**Configuration** (all optional, see `env.example` for the full list):
+```bash
+export LANCEDB_URI=./lancedb                # defaults to <working_dir>/lancedb
+export LANCEDB_ENABLE_FTS=true              # BM25 index on vector-storage content
+export LANCEDB_FTS_TOKENIZER=ngram          # CJK-friendly bigram tokenizer (default)
+```
+
+**Usage**:
+```python
+rag = LightRAG(
+    working_dir=WORKING_DIR,
+    llm_model_func=your_llm_func,
+    embedding_func=your_embed_func,
+    kv_storage="LanceDBKVStorage",
+    doc_status_storage="LanceDBDocStatusStorage",
+    graph_storage="LanceDBGraphStorage",
+    vector_storage="LanceDBVectorStorage",
+)
+```
+
+**Notes**:
+- All data is derived and rebuildable: if the database is ever corrupted, delete the LanceDB directory and re-index the source documents.
+- Vector tables are suffixed with the embedding model name and dimension, so switching embedding models creates fresh tables instead of corrupting existing vectors.
+- Single-process deployments only (embedded database); use a server-based backend with multi-worker gunicorn.
+
+See `docs/lancedb.md` for the full setup and configuration guide.
+
+**Testing**:
+```bash
+# Unit + integration tests (no external services, real embedded LanceDB)
+python -m pytest tests/kg/lancedb_impl -v
+# Cross-backend graph storage conformance suite
+LIGHTRAG_GRAPH_STORAGE=LanceDBGraphStorage python -m pytest tests/kg/test_graph_storage.py --run-integration -v
+# Demo
+python examples/lightrag_lancedb_demo.py
+```
+
 
 ## Data Isolation Between LightRAG Instances
 
@@ -884,10 +931,11 @@ The `workspace` parameter ensures data isolation between different LightRAG inst
 | `PGKVStorage`, `PGVectorStorage`, `PGDocStatusStorage` | `workspace` field in tables |
 | `Neo4JStorage` | Labels |
 | `OpenSearch*` | Index name prefixes |
+| `LanceDB*` | Table name prefixes |
 
 **Legacy compatibility**: Default workspace for PostgreSQL non-graph storage is `default`; for PostgreSQL AGE graph storage is null; for Neo4j graph storage is `base`.
 
-Storage-specific workspace environment variables override the common `WORKSPACE` variable: `REDIS_WORKSPACE`, `MILVUS_WORKSPACE`, `QDRANT_WORKSPACE`, `MONGODB_WORKSPACE`, `POSTGRES_WORKSPACE`, `NEO4J_WORKSPACE`, `OPENSEARCH_WORKSPACE`.
+Storage-specific workspace environment variables override the common `WORKSPACE` variable: `REDIS_WORKSPACE`, `MILVUS_WORKSPACE`, `QDRANT_WORKSPACE`, `MONGODB_WORKSPACE`, `POSTGRES_WORKSPACE`, `NEO4J_WORKSPACE`, `OPENSEARCH_WORKSPACE`, `LANCEDB_WORKSPACE`.
 
 For a practical demonstration of managing multiple isolated knowledge bases, see [Workspace Demo](examples/lightrag_gemini_workspace_demo.py).
 

--- a/docs/lancedb.md
+++ b/docs/lancedb.md
@@ -109,7 +109,7 @@ Rows written after index creation are still searchable (LanceDB scans the uninde
 - **Single-process only.** The embedded database and its per-table write locks live in one process. `lightrag-gunicorn` refuses to start with multiple workers when a LanceDB backend is selected; use PostgreSQL/MongoDB/OpenSearch for multi-worker deployments.
 - **`fork` multiprocessing is unsupported** by LanceDB's Rust runtime — use the `spawn` start method if you must create subprocesses.
 - Old table versions are retained for MVCC; the periodic auto-optimize (`LANCEDB_OPTIMIZE_THRESHOLD`) compacts fragments and prunes old versions.
-- The standalone maintenance tools (`lightrag.tools.rebuild_vdb`, `clean_llm_query_cache`, `migrate_llm_cache`) do not support LanceDB yet. Since all LanceDB data is derived, the equivalent of a rebuild is deleting the LanceDB directory and re-indexing.
+- The standalone maintenance tools (`lightrag.tools.rebuild_vdb`, `clean_llm_query_cache`, `migrate_llm_cache`) support LanceDB. Because LanceDB is single-process, **stop the LightRAG Server (and any other writer) before running a tool** against the same LanceDB directory. (All LanceDB data is still derived, so deleting the LanceDB directory and re-indexing remains a valid alternative to a rebuild.)
 
 ## Testing
 

--- a/docs/lancedb.md
+++ b/docs/lancedb.md
@@ -1,0 +1,132 @@
+# LanceDB Storage Backend
+
+## Overview
+
+LanceDB is an embedded, serverless vector database built on the Lance columnar format. The LanceDB backend implements **all four LightRAG storage types in a single local directory** — no PostgreSQL, no Docker, no external services:
+
+| LightRAG storage type | Class | What it stores |
+|---|---|---|
+| `KV_STORAGE` | `LanceDBKVStorage` | Full docs, text chunks, LLM response cache, entity/relation bookkeeping |
+| `VECTOR_STORAGE` | `LanceDBVectorStorage` | Entity/relationship/chunk embeddings |
+| `GRAPH_STORAGE` | `LanceDBGraphStorage` | Entity-relation knowledge graph (nodes + undirected edges) |
+| `DOC_STATUS_STORAGE` | `LanceDBDocStatusStorage` | Document processing status |
+
+Highlights:
+
+- **Zero external dependencies** — everything is stored in one directory; `pip install lancedb` is the only requirement (auto-installed on first use).
+- **Native async** — implemented on `lancedb.connect_async()`; no thread-pool bridging.
+- **CJK-friendly full-text search** — a BM25 index with a bigram tokenizer is created on vector-storage content by default, so Chinese/Japanese/Korean text is searchable out of the box (exposed via `LanceDBVectorStorage.full_text_search()`).
+- **Deferred embedding** — vector upserts buffer records and embed them in batches of `embedding_batch_num` at flush time, minimizing embedding API round-trips.
+- **Embedding-model isolation** — vector table names carry the embedding model name and dimension (e.g. `demo_chunks_text_embedding_3_large_3072d`), so switching models starts clean tables instead of mixing incompatible vectors.
+- **Rebuildable by design** — all data is derived from your source documents. If anything corrupts, delete the LanceDB directory and re-index.
+
+## Installation
+
+```bash
+pip install lancedb          # or: pip install lightrag-hku[offline-storage]
+```
+
+Python 3.10+ is required. Wheels bundle the native Rust core for macOS arm64, Linux x86_64/aarch64, and Windows x64.
+
+## Configuration
+
+### Selecting the backend
+
+```python
+from lightrag import LightRAG
+
+rag = LightRAG(
+    working_dir="./rag_storage",
+    llm_model_func=your_llm_func,
+    embedding_func=your_embedding_func,
+    kv_storage="LanceDBKVStorage",
+    vector_storage="LanceDBVectorStorage",
+    graph_storage="LanceDBGraphStorage",
+    doc_status_storage="LanceDBDocStatusStorage",
+)
+await rag.initialize_storages()   # REQUIRED
+```
+
+Or via environment variables (API server):
+
+```bash
+LIGHTRAG_KV_STORAGE=LanceDBKVStorage
+LIGHTRAG_VECTOR_STORAGE=LanceDBVectorStorage
+LIGHTRAG_GRAPH_STORAGE=LanceDBGraphStorage
+LIGHTRAG_DOC_STATUS_STORAGE=LanceDBDocStatusStorage
+```
+
+### Environment variables
+
+All variables are optional; they can also be placed in a `[lancedb]` section of `config.ini` (env vars take precedence).
+
+| Variable | Default | Description |
+|---|---|---|
+| `LANCEDB_URI` | `<working_dir>/lancedb` | Database directory path |
+| `LANCEDB_WORKSPACE` | — | Force a workspace name, overriding the instance `workspace` (compatibility escape hatch; normally leave unset) |
+| `LANCEDB_READ_CONSISTENCY_INTERVAL` | `0` | Seconds between table-version checks; `0` = strong consistency |
+| `LANCEDB_ENABLE_FTS` | `true` | Create a BM25 full-text index on vector-storage `content` |
+| `LANCEDB_FTS_TOKENIZER` | `ngram` | `ngram` (CJK-friendly bigrams), `simple`, `whitespace`, or `jieba/default` / `lindera/*` (require [Lance language models](https://lancedb.github.io/lancedb/fts/) downloaded locally) |
+| `LANCEDB_OPTIMIZE_THRESHOLD` | `64` | Compact a table after this many write operations; `0` disables auto-optimize |
+
+### Workspace isolation
+
+Each `LightRAG(workspace=...)` gets its own set of tables via name prefixes (e.g. `projecta_chunks`, `projecta_doc_status`), the same model used by the collection-based backends. Multiple workspaces share one LanceDB directory.
+
+## Table layout
+
+For a workspace `demo`, the directory contains one Lance table per namespace:
+
+```
+demo_full_docs, demo_text_chunks, demo_llm_response_cache, ...   # KV (id, payload JSON, timestamps)
+demo_entities_<model>_<dim>d, demo_relationships_..., demo_chunks_...  # vectors
+demo_chunk_entity_relation_nodes / _edges                        # graph
+demo_doc_status                                                  # doc status
+```
+
+Records are stored as JSON strings in a `payload` column for full fidelity; fields used in SQL filters (`id`, `src_id`/`tgt_id`, `status`, `file_path`, `content_hash`, ...) are typed columns. Undirected graph edges are stored once under a canonical id derived from the sorted endpoint pair.
+
+## Full-text search (CJK support)
+
+`LanceDBVectorStorage` exposes an extra method beyond the standard LightRAG contract:
+
+```python
+hits = await rag.chunks_vdb.full_text_search("朱元璋", top_k=10)
+# [{"id": "chunk-...", "content": "...", "score": 5.1, ...}, ...]
+```
+
+The default `ngram` tokenizer indexes character bigrams, which handles Chinese/Japanese/Korean text without external language models while still matching Latin-script terms. For dictionary-based Chinese segmentation, install the Lance jieba language model and set `LANCEDB_FTS_TOKENIZER=jieba/default`.
+
+Rows written after index creation are still searchable (LanceDB scans the unindexed tail automatically); the periodic auto-optimize folds them into the index.
+
+## Vector search behavior
+
+- Searches are exact (brute-force) cosine kNN — no ANN index is created, which is the recommended configuration below ~100k vectors per table and avoids recall loss.
+- `query()` returns results filtered by `cosine_better_than_threshold` (configured through `vector_db_storage_cls_kwargs`, default 0.2), with the LightRAG-standard result shape: meta fields plus `id`, `created_at`, and `distance` (which carries cosine **similarity**, matching every other LightRAG backend).
+
+## Limitations
+
+- **Single-process only.** The embedded database and its per-table write locks live in one process. `lightrag-gunicorn` refuses to start with multiple workers when a LanceDB backend is selected; use PostgreSQL/MongoDB/OpenSearch for multi-worker deployments.
+- **`fork` multiprocessing is unsupported** by LanceDB's Rust runtime — use the `spawn` start method if you must create subprocesses.
+- Old table versions are retained for MVCC; the periodic auto-optimize (`LANCEDB_OPTIMIZE_THRESHOLD`) compacts fragments and prunes old versions.
+- The standalone maintenance tools (`lightrag.tools.rebuild_vdb`, `clean_llm_query_cache`, `migrate_llm_cache`) do not support LanceDB yet. Since all LanceDB data is derived, the equivalent of a rebuild is deleting the LanceDB directory and re-indexing.
+
+## Testing
+
+```bash
+# Unit + integration tests (offline, real embedded LanceDB in tmp dirs)
+python -m pytest tests/kg/lancedb_impl -v
+
+# Cross-backend graph storage conformance suite
+LIGHTRAG_GRAPH_STORAGE=LanceDBGraphStorage \
+python -m pytest tests/kg/test_graph_storage.py --run-integration -v
+
+# Runnable demo (no API keys or services needed)
+python examples/lightrag_lancedb_demo.py
+```
+
+## References
+
+- LanceDB documentation: https://lancedb.github.io/lancedb/
+- Lance columnar format: https://github.com/lancedb/lance
+- Backend-specific setup section in `docs/ProgramingWithCore.md`

--- a/env.example
+++ b/env.example
@@ -1303,6 +1303,21 @@ MEMGRAPH_DATABASE=memgraph
 ### DB specific workspace should not be set, keep for compatible only
 # MEMGRAPH_WORKSPACE=forced_workspace_name
 
+### LanceDB Configuration (embedded, no external service required)
+### Database directory path (defaults to <working_dir>/lancedb)
+# LANCEDB_URI=./lancedb
+### Read consistency interval in seconds (0 = strong consistency)
+# LANCEDB_READ_CONSISTENCY_INTERVAL=0
+### Full-text search index on vector storage content (CJK-friendly by default)
+# LANCEDB_ENABLE_FTS=true
+### FTS tokenizer: ngram (CJK bigram, default) | simple | whitespace | jieba/default
+### jieba/lindera tokenizers require Lance language models downloaded locally (see docs/lancedb.md)
+# LANCEDB_FTS_TOKENIZER=ngram
+### Compact tables after this many write operations (0 disables auto-optimize)
+# LANCEDB_OPTIMIZE_THRESHOLD=64
+### DB specific workspace should not be set, keep for compatible only
+# LANCEDB_WORKSPACE=forced_workspace_name
+
 ###########################################################
 ### Langfuse Observability Configuration
 ### Only works with LLM provided by OpenAI compatible API

--- a/examples/lightrag_lancedb_demo.py
+++ b/examples/lightrag_lancedb_demo.py
@@ -1,0 +1,194 @@
+"""
+LanceDB unified storage backend demo for LightRAG.
+
+LanceDB is an embedded database — this demo needs NO external services and
+no API keys. It exercises all four storage types against a local directory:
+
+- KV Storage:        CRUD, filter_keys, timestamps
+- Vector Storage:    deferred-embedding upsert, cosine query, CJK full-text search
+- Graph Storage:     nodes, edges, degrees, BFS subgraph, label search
+- DocStatus Storage: CRUD, status counts, pagination
+
+Usage:
+    python examples/lightrag_lancedb_demo.py
+
+To use LanceDB as the storage backend of a real LightRAG instance:
+
+    rag = LightRAG(
+        working_dir="./rag_storage",
+        llm_model_func=gpt_4o_mini_complete,
+        embedding_func=openai_embed,
+        kv_storage="LanceDBKVStorage",
+        vector_storage="LanceDBVectorStorage",
+        graph_storage="LanceDBGraphStorage",
+        doc_status_storage="LanceDBDocStatusStorage",
+    )
+    await rag.initialize_storages()
+
+or via environment variables for the API server:
+
+    LIGHTRAG_KV_STORAGE=LanceDBKVStorage
+    LIGHTRAG_VECTOR_STORAGE=LanceDBVectorStorage
+    LIGHTRAG_GRAPH_STORAGE=LanceDBGraphStorage
+    LIGHTRAG_DOC_STATUS_STORAGE=LanceDBDocStatusStorage
+    LANCEDB_URI=./lancedb_data
+"""
+
+import asyncio
+import hashlib
+import shutil
+import tempfile
+
+import numpy as np
+
+from lightrag.base import DocStatus
+from lightrag.kg.lancedb_impl import (
+    LanceDBDocStatusStorage,
+    LanceDBGraphStorage,
+    LanceDBKVStorage,
+    LanceDBVectorStorage,
+)
+from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
+from lightrag.utils import EmbeddingFunc
+
+DIM = 64
+
+
+async def mock_embed(texts, **kwargs):
+    """Deterministic mock embedding (replace with a real model in production)."""
+
+    def vec(text):
+        seed = int.from_bytes(hashlib.md5(text.encode()).digest()[:4], "little")
+        return np.random.default_rng(seed).standard_normal(DIM).astype(np.float32)
+
+    return np.array([vec(t) for t in texts])
+
+
+async def main():
+    working_dir = tempfile.mkdtemp(prefix="lightrag_lancedb_demo_")
+    print(f"LanceDB directory: {working_dir}/lancedb\n")
+    initialize_share_data()
+
+    global_config = {
+        "working_dir": working_dir,
+        "embedding_batch_num": 16,
+        "max_graph_nodes": 1000,
+        "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+    }
+    embedding_func = EmbeddingFunc(
+        embedding_dim=DIM, max_token_size=8192, func=mock_embed
+    )
+
+    # ------------------------------------------------------------- KV storage
+    print("=== KV Storage ===")
+    kv = LanceDBKVStorage(
+        namespace="text_chunks",
+        workspace="demo",
+        global_config=global_config,
+        embedding_func=embedding_func,
+    )
+    await kv.initialize()
+    await kv.upsert(
+        {"chunk-1": {"content": "LightRAG combines knowledge graphs with RAG."}}
+    )
+    record = await kv.get_by_id("chunk-1")
+    print(f"get_by_id -> content={record['content']!r}")
+    print(f"filter_keys -> missing={await kv.filter_keys({'chunk-1', 'chunk-2'})}\n")
+
+    # --------------------------------------------------------- Vector storage
+    print("=== Vector Storage (with CJK full-text search) ===")
+    vdb = LanceDBVectorStorage(
+        namespace="chunks",
+        workspace="demo",
+        global_config=global_config,
+        embedding_func=embedding_func,
+        meta_fields={"full_doc_id", "content", "file_path"},
+    )
+    await vdb.initialize()
+    contents = {
+        "chunk-1": "朱元璋是明朝的開國皇帝，定都南京。",
+        "chunk-2": "康熙皇帝是清朝在位時間最長的皇帝。",
+        "chunk-3": "LightRAG supports graph-based retrieval augmented generation.",
+    }
+    await vdb.upsert(
+        {
+            chunk_id: {"content": text, "full_doc_id": "doc-1", "file_path": "demo.txt"}
+            for chunk_id, text in contents.items()
+        }
+    )
+    await vdb.index_done_callback()  # flush: embeds in batches and persists
+
+    hits = await vdb.query(contents["chunk-3"], top_k=3)
+    print(f"vector query   -> top hit: {hits[0]['id']} (similarity={hits[0]['distance']:.3f})")
+    fts_hits = await vdb.full_text_search("皇帝", top_k=5)
+    print(f"FTS query 皇帝 -> {[hit['id'] for hit in fts_hits]}")
+    fts_hits = await vdb.full_text_search("graph retrieval", top_k=5)
+    print(f"FTS query en   -> {[hit['id'] for hit in fts_hits]}\n")
+
+    # ---------------------------------------------------------- Graph storage
+    print("=== Graph Storage ===")
+    graph = LanceDBGraphStorage(
+        namespace="chunk_entity_relation",
+        workspace="demo",
+        global_config=global_config,
+        embedding_func=embedding_func,
+    )
+    await graph.initialize()
+    await graph.upsert_node(
+        "朱元璋",
+        {"entity_id": "朱元璋", "entity_type": "person", "description": "明朝開國皇帝"},
+    )
+    await graph.upsert_node(
+        "明朝",
+        {"entity_id": "明朝", "entity_type": "organization", "description": "中國朝代"},
+    )
+    await graph.upsert_edge(
+        "朱元璋", "明朝", {"weight": 1.0, "description": "建立", "keywords": "founder"}
+    )
+    print(f"has_edge(明朝, 朱元璋) [undirected] -> {await graph.has_edge('明朝', '朱元璋')}")
+    print(f"node_degree(朱元璋) -> {await graph.node_degree('朱元璋')}")
+    print(f"search_labels('朱') -> {await graph.search_labels('朱')}")
+    subgraph = await graph.get_knowledge_graph("朱元璋", max_depth=2)
+    print(
+        f"get_knowledge_graph -> {len(subgraph.nodes)} nodes, {len(subgraph.edges)} edges\n"
+    )
+
+    # ------------------------------------------------------ DocStatus storage
+    print("=== DocStatus Storage ===")
+    doc_status = LanceDBDocStatusStorage(
+        namespace="doc_status",
+        workspace="demo",
+        global_config=global_config,
+        embedding_func=None,
+    )
+    await doc_status.initialize()
+    await doc_status.upsert(
+        {
+            "doc-1": {
+                "status": DocStatus.PROCESSED,
+                "content_summary": "Ming dynasty history",
+                "content_length": 120,
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:01:00+00:00",
+                "file_path": "demo.txt",
+                "content_hash": "demo-hash",
+                "metadata": {},
+                "chunks_count": 3,
+                "chunks_list": list(contents.keys()),
+            }
+        }
+    )
+    print(f"status counts -> {await doc_status.get_all_status_counts()}")
+    page, total = await doc_status.get_docs_paginated(page=1, page_size=10)
+    print(f"paginated -> total={total}, first={page[0][0]}\n")
+
+    # ----------------------------------------------------------------- Cleanup
+    for storage in (kv, vdb, graph, doc_status):
+        await storage.finalize()
+    finalize_share_data()
+    shutil.rmtree(working_dir, ignore_errors=True)
+    print("Demo finished successfully.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/lightrag_lancedb_demo.py
+++ b/examples/lightrag_lancedb_demo.py
@@ -119,7 +119,9 @@ async def main():
     await vdb.index_done_callback()  # flush: embeds in batches and persists
 
     hits = await vdb.query(contents["chunk-3"], top_k=3)
-    print(f"vector query   -> top hit: {hits[0]['id']} (similarity={hits[0]['distance']:.3f})")
+    print(
+        f"vector query   -> top hit: {hits[0]['id']} (similarity={hits[0]['distance']:.3f})"
+    )
     fts_hits = await vdb.full_text_search("皇帝", top_k=5)
     print(f"FTS query 皇帝 -> {[hit['id'] for hit in fts_hits]}")
     fts_hits = await vdb.full_text_search("graph retrieval", top_k=5)
@@ -145,7 +147,9 @@ async def main():
     await graph.upsert_edge(
         "朱元璋", "明朝", {"weight": 1.0, "description": "建立", "keywords": "founder"}
     )
-    print(f"has_edge(明朝, 朱元璋) [undirected] -> {await graph.has_edge('明朝', '朱元璋')}")
+    print(
+        f"has_edge(明朝, 朱元璋) [undirected] -> {await graph.has_edge('明朝', '朱元璋')}"
+    )
     print(f"node_degree(朱元璋) -> {await graph.node_degree('朱元璋')}")
     print(f"search_labels('朱') -> {await graph.search_labels('朱')}")
     subgraph = await graph.get_knowledge_graph("朱元璋", max_depth=2)

--- a/lightrag/api/run_with_gunicorn.py
+++ b/lightrag/api/run_with_gunicorn.py
@@ -122,11 +122,13 @@ def main():
         print("=" * 80 + "\n")
         sys.exit(1)
 
-    # LanceDB is an embedded database whose write serialization is
-    # per-process; concurrent writers from multiple gunicorn workers can
-    # commit duplicate rows. Refuse to start multi-worker with it.
+    # Embedded backends listed in MULTIPROCESS_UNSAFE_STORAGES serialize
+    # writes per-process; concurrent writers from multiple gunicorn workers
+    # can commit duplicate rows. Refuse to start multi-worker with them.
     if global_args.workers > 1:
-        lancedb_storages = [
+        from lightrag.kg import MULTIPROCESS_UNSAFE_STORAGES
+
+        unsafe_storages = [
             name
             for name in (
                 global_args.kv_storage,
@@ -134,17 +136,17 @@ def main():
                 global_args.graph_storage,
                 global_args.vector_storage,
             )
-            if name.startswith("LanceDB")
+            if name in MULTIPROCESS_UNSAFE_STORAGES
         ]
-        if lancedb_storages:
+        if unsafe_storages:
             print("\n" + "=" * 80)
-            print("❌ ERROR: LanceDB storage does not support multi-worker mode!")
+            print("❌ ERROR: Configured storage does not support multi-worker mode!")
             print("=" * 80)
             print(
-                f"\nConfigured LanceDB storages: {', '.join(sorted(set(lancedb_storages)))}"
+                f"\nSingle-process storages: {', '.join(sorted(set(unsafe_storages)))}"
             )
             print(f"Workers: {global_args.workers}")
-            print("\nLanceDB is an embedded database; its write serialization is")
+            print("\nThese are embedded databases; their write serialization is")
             print("per-process, so concurrent gunicorn workers could commit")
             print("duplicate rows to the same tables.")
             print("\nHow to fix:")

--- a/lightrag/api/run_with_gunicorn.py
+++ b/lightrag/api/run_with_gunicorn.py
@@ -122,6 +122,39 @@ def main():
         print("=" * 80 + "\n")
         sys.exit(1)
 
+    # LanceDB is an embedded database whose write serialization is
+    # per-process; concurrent writers from multiple gunicorn workers can
+    # commit duplicate rows. Refuse to start multi-worker with it.
+    if global_args.workers > 1:
+        lancedb_storages = [
+            name
+            for name in (
+                global_args.kv_storage,
+                global_args.doc_status_storage,
+                global_args.graph_storage,
+                global_args.vector_storage,
+            )
+            if name.startswith("LanceDB")
+        ]
+        if lancedb_storages:
+            print("\n" + "=" * 80)
+            print("❌ ERROR: LanceDB storage does not support multi-worker mode!")
+            print("=" * 80)
+            print(
+                f"\nConfigured LanceDB storages: {', '.join(sorted(set(lancedb_storages)))}"
+            )
+            print(f"Workers: {global_args.workers}")
+            print("\nLanceDB is an embedded database; its write serialization is")
+            print("per-process, so concurrent gunicorn workers could commit")
+            print("duplicate rows to the same tables.")
+            print("\nHow to fix:")
+            print("  Option 1 - Use single worker mode:")
+            print("     lightrag-server (or lightrag-gunicorn --workers 1)")
+            print("  Option 2 - Use a server-based backend for multi-worker mode")
+            print("     (PostgreSQL, MongoDB, OpenSearch, ...)")
+            print("=" * 80 + "\n")
+            sys.exit(1)
+
     # Check and install dependencies
     check_and_install_dependencies()
 

--- a/lightrag/kg/__init__.py
+++ b/lightrag/kg/__init__.py
@@ -6,6 +6,7 @@ STORAGE_IMPLEMENTATIONS = {
             "PGKVStorage",
             "MongoKVStorage",
             "OpenSearchKVStorage",
+            "LanceDBKVStorage",
         ],
         "required_methods": ["get_by_id", "upsert"],
     },
@@ -17,6 +18,7 @@ STORAGE_IMPLEMENTATIONS = {
             "MongoGraphStorage",
             "MemgraphStorage",
             "OpenSearchGraphStorage",
+            "LanceDBGraphStorage",
         ],
         "required_methods": ["upsert_node", "upsert_edge"],
     },
@@ -29,6 +31,7 @@ STORAGE_IMPLEMENTATIONS = {
             "QdrantVectorDBStorage",
             "MongoVectorDBStorage",
             "OpenSearchVectorDBStorage",
+            "LanceDBVectorStorage",
             # "ChromaVectorDBStorage",
         ],
         "required_methods": ["query", "upsert"],
@@ -40,6 +43,7 @@ STORAGE_IMPLEMENTATIONS = {
             "PGDocStatusStorage",
             "MongoDocStatusStorage",
             "OpenSearchDocStatusStorage",
+            "LanceDBDocStatusStorage",
         ],
         "required_methods": ["get_docs_by_status"],
     },
@@ -108,6 +112,12 @@ STORAGE_ENV_REQUIREMENTS: dict[str, list[str]] = {
     "OpenSearchVectorDBStorage": [
         "OPENSEARCH_HOSTS",
     ],
+    # LanceDB Storage Implementations (embedded, no required env vars;
+    # LANCEDB_URI defaults to <working_dir>/lancedb)
+    "LanceDBKVStorage": [],
+    "LanceDBVectorStorage": [],
+    "LanceDBGraphStorage": [],
+    "LanceDBDocStatusStorage": [],
 }
 
 # Storage implementation module mapping
@@ -137,6 +147,10 @@ STORAGES = {
     "OpenSearchDocStatusStorage": ".kg.opensearch_impl",
     "OpenSearchGraphStorage": ".kg.opensearch_impl",
     "OpenSearchVectorDBStorage": ".kg.opensearch_impl",
+    "LanceDBKVStorage": ".kg.lancedb_impl",
+    "LanceDBVectorStorage": ".kg.lancedb_impl",
+    "LanceDBGraphStorage": ".kg.lancedb_impl",
+    "LanceDBDocStatusStorage": ".kg.lancedb_impl",
 }
 
 

--- a/lightrag/kg/__init__.py
+++ b/lightrag/kg/__init__.py
@@ -153,6 +153,16 @@ STORAGES = {
     "LanceDBDocStatusStorage": ".kg.lancedb_impl",
 }
 
+# Embedded storages whose write serialization is per-process; running them
+# under multiple workers (gunicorn) can commit duplicate rows. Launchers
+# check membership here instead of hard-coding implementation names.
+MULTIPROCESS_UNSAFE_STORAGES = {
+    "LanceDBKVStorage",
+    "LanceDBVectorStorage",
+    "LanceDBGraphStorage",
+    "LanceDBDocStatusStorage",
+}
+
 
 def verify_storage_implementation(storage_type: str, storage_name: str) -> None:
     """Verify if storage implementation is compatible with specified storage type

--- a/lightrag/kg/lancedb_impl.py
+++ b/lightrag/kg/lancedb_impl.py
@@ -227,8 +227,10 @@ def _doc_status_schema() -> pa.Schema:
 
 
 def _canonical_edge_id(source_node_id: str, target_node_id: str) -> str:
-    lo, hi = sorted((source_node_id, target_node_id))
-    return compute_mdhash_id(f"{lo}-{hi}", prefix="edge-")
+    # JSON-encode the sorted endpoints so IDs containing the separator
+    # (e.g. ("A-B", "C") vs ("A", "B-C")) cannot collide.
+    endpoints = json.dumps(sorted((source_node_id, target_node_id)))
+    return compute_mdhash_id(endpoints, prefix="edge-")
 
 
 class LanceDBClient:
@@ -401,7 +403,9 @@ async def _fetch_rows_by_ids(
         return []
     rows: list[dict[str, Any]] = []
     for chunk in _iter_chunks(ids):
-        rows.extend(await _fetch_rows(table, where=_sql_in(id_column, chunk), columns=columns))
+        rows.extend(
+            await _fetch_rows(table, where=_sql_in(id_column, chunk), columns=columns)
+        )
     return rows
 
 
@@ -460,7 +464,10 @@ class LanceDBKVStorage(BaseKVStorage):
 
     async def get_by_id(self, id: str) -> dict[str, Any] | None:
         rows = await _fetch_rows(
-            self._table(), where=f"id = {_sql_quote(id)}", columns=["id", "payload"], limit=1
+            self._table(),
+            where=f"id = {_sql_quote(id)}",
+            columns=["id", "payload"],
+            limit=1,
         )
         if not rows:
             return None
@@ -545,7 +552,9 @@ class LanceDBKVStorage(BaseKVStorage):
                     await table.delete(_sql_in("id", chunk))
                 self._client.bump_writes(self._table_name)
         except Exception as e:
-            logger.error(f"[{self.workspace}] Failed to delete from {self._table_name}: {e}")
+            logger.error(
+                f"[{self.workspace}] Failed to delete from {self._table_name}: {e}"
+            )
             raise
 
     async def is_empty(self) -> bool:
@@ -778,7 +787,9 @@ class LanceDBVectorStorage(BaseVectorStorage):
         snapshot = list(self._pending_docs.items())
         to_embed = [(doc_id, doc) for doc_id, doc in snapshot if doc.vector is None]
         if to_embed:
-            embeddings = await self._embed_contents([doc.content for _, doc in to_embed])
+            embeddings = await self._embed_contents(
+                [doc.content for _, doc in to_embed]
+            )
             for (_, doc), embedding in zip(to_embed, embeddings):
                 doc.vector = embedding.astype(np.float32).tolist()
         rows: list[dict[str, Any]] = []
@@ -865,7 +876,9 @@ class LanceDBVectorStorage(BaseVectorStorage):
             results.append(record)
         return results
 
-    async def full_text_search(self, query: str, top_k: int = 10) -> list[dict[str, Any]]:
+    async def full_text_search(
+        self, query: str, top_k: int = 10
+    ) -> list[dict[str, Any]]:
         """BM25 full-text search over the content column (extra capability).
 
         Not part of the LightRAG storage contract; requires the FTS index
@@ -945,7 +958,9 @@ class LanceDBVectorStorage(BaseVectorStorage):
                     result[record_id] = doc.vector
                 else:
                     remaining.append(record_id)
-        rows = await _fetch_rows_by_ids(self._table(), remaining, columns=["id", "vector"])
+        rows = await _fetch_rows_by_ids(
+            self._table(), remaining, columns=["id", "vector"]
+        )
         for row in rows:
             vector = row.get("vector")
             if vector is not None:
@@ -1086,9 +1101,7 @@ class LanceDBGraphStorage(BaseGraphStorage):
 
     async def node_degree(self, node_id: str) -> int:
         quoted = _sql_quote(node_id)
-        return await self._edges_table().count_rows(
-            f"src = {quoted} OR tgt = {quoted}"
-        )
+        return await self._edges_table().count_rows(f"src = {quoted} OR tgt = {quoted}")
 
     async def edge_degree(self, src_id: str, tgt_id: str) -> int:
         src_degree, tgt_degree = await asyncio.gather(
@@ -1329,9 +1342,7 @@ class LanceDBGraphStorage(BaseGraphStorage):
 
     async def get_all_nodes(self) -> list[dict]:
         rows = await _fetch_rows(self._nodes_table())
-        return [
-            {**_json_loads(row.get("payload")), "id": row["id"]} for row in rows
-        ]
+        return [{**_json_loads(row.get("payload")), "id": row["id"]} for row in rows]
 
     async def get_all_edges(self) -> list[dict]:
         rows = await _fetch_rows(self._edges_table())
@@ -1380,7 +1391,9 @@ class LanceDBGraphStorage(BaseGraphStorage):
         return [label for label, _ in matches[:limit]]
 
     @staticmethod
-    def _construct_graph_node(node_id: str, node_data: dict[str, Any]) -> KnowledgeGraphNode:
+    def _construct_graph_node(
+        node_id: str, node_data: dict[str, Any]
+    ) -> KnowledgeGraphNode:
         return KnowledgeGraphNode(
             id=node_id, labels=[node_id], properties=dict(node_data)
         )
@@ -1498,7 +1511,9 @@ class LanceDBGraphStorage(BaseGraphStorage):
             await self._client.drop_and_recreate_table(
                 self._edges_table_name, _graph_edge_schema()
             )
-            logger.info(f"[{self.workspace}] Dropped graph tables {self.final_namespace}")
+            logger.info(
+                f"[{self.workspace}] Dropped graph tables {self.final_namespace}"
+            )
             return {"status": "success", "message": "data dropped"}
         except Exception as e:
             logger.error(f"[{self.workspace}] Failed to drop graph tables: {e}")
@@ -1781,7 +1796,9 @@ class LanceDBDocStatusStorage(DocStatusStorage):
             await self._client.drop_and_recreate_table(
                 self._table_name, _doc_status_schema()
             )
-            logger.info(f"[{self.workspace}] Dropped doc status table {self._table_name}")
+            logger.info(
+                f"[{self.workspace}] Dropped doc status table {self._table_name}"
+            )
             return {"status": "success", "message": "data dropped"}
         except Exception as e:
             logger.error(f"[{self.workspace}] Failed to drop {self._table_name}: {e}")

--- a/lightrag/kg/lancedb_impl.py
+++ b/lightrag/kg/lancedb_impl.py
@@ -975,10 +975,10 @@ class LanceDBVectorStorage(BaseVectorStorage):
             async with self._buffer_lock:
                 for record_id in ids:
                     self._pending_docs.pop(record_id, None)
-            async with self._client.table_lock(self._table_name):
-                for chunk in _iter_chunks(list(ids)):
-                    await table.delete(_sql_in("id", chunk))
-                self._client.bump_writes(self._table_name)
+                async with self._client.table_lock(self._table_name):
+                    for chunk in _iter_chunks(list(ids)):
+                        await table.delete(_sql_in("id", chunk))
+                    self._client.bump_writes(self._table_name)
         except Exception as e:
             logger.error(
                 f"[{self.workspace}] Failed to delete {len(ids)} vectors from {self._table_name}: {e}"
@@ -993,9 +993,6 @@ class LanceDBVectorStorage(BaseVectorStorage):
         quoted = _sql_quote(entity_name)
         table = self._table()
         try:
-            async with self._client.table_lock(self._table_name):
-                await table.delete(f"src_id = {quoted} OR tgt_id = {quoted}")
-                self._client.bump_writes(self._table_name)
             async with self._buffer_lock:
                 stale = [
                     doc_id
@@ -1005,6 +1002,9 @@ class LanceDBVectorStorage(BaseVectorStorage):
                 ]
                 for doc_id in stale:
                     self._pending_docs.pop(doc_id, None)
+                async with self._client.table_lock(self._table_name):
+                    await table.delete(f"src_id = {quoted} OR tgt_id = {quoted}")
+                    self._client.bump_writes(self._table_name)
         except Exception as e:
             logger.error(
                 f"[{self.workspace}] Failed to delete relations of {entity_name}: {e}"

--- a/lightrag/kg/lancedb_impl.py
+++ b/lightrag/kg/lancedb_impl.py
@@ -482,6 +482,17 @@ class LanceDBKVStorage(BaseKVStorage):
         rows = await _fetch_rows_by_ids(self._table(), list(keys), columns=["id"])
         return keys - {row["id"] for row in rows}
 
+    async def get_all_keys(self) -> list[str]:
+        """List every id in this namespace's table.
+
+        BaseKVStorage has no enumeration contract; the offline maintenance
+        tools (rebuild_vdb / clean_llm_query_cache / migrate_llm_cache) rely
+        on this backend-specific scan. The table name is workspace-prefixed,
+        so a plain scan already returns only this workspace's ids.
+        """
+        rows = await _fetch_rows(self._table(), columns=["id"])
+        return [row["id"] for row in rows]
+
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
         if not data:
             return

--- a/lightrag/kg/lancedb_impl.py
+++ b/lightrag/kg/lancedb_impl.py
@@ -109,7 +109,9 @@ def _resolve_workspace(workspace: str) -> str:
     """LANCEDB_WORKSPACE env override beats the constructor parameter."""
     env_workspace = _get_lancedb_env("LANCEDB_WORKSPACE")
     if env_workspace and env_workspace.strip():
-        return env_workspace.strip()
+        # Validate like the constructor path; _sanitize_table_name alone
+        # would silently fold path-traversal names instead of failing fast.
+        return validate_workspace(env_workspace.strip())
     return workspace or ""
 
 
@@ -294,10 +296,7 @@ class LanceDBClient:
         return table
 
     def table_lock(self, name: str) -> asyncio.Lock:
-        lock = self._table_locks.get(name)
-        if lock is None:
-            lock = self._table_locks.setdefault(name, asyncio.Lock())
-        return lock
+        return self._table_locks.setdefault(name, asyncio.Lock())
 
     async def get_or_create_table(self, name: str, schema: pa.Schema):
         table = self._tables.get(name)
@@ -313,11 +312,15 @@ class LanceDBClient:
         return table
 
     async def drop_and_recreate_table(self, name: str, schema: pa.Schema):
-        async with self._creation_lock:
-            await self._connection.drop_table(name, ignore_missing=True)
-            table = await self._connection.create_table(name, schema=schema)
-            self._tables[name] = table
-            self._writes_since_optimize[name] = 0
+        # table_lock waits out in-flight writers so the drop cannot yank the
+        # table from under a merge_insert; creation_lock serializes with
+        # get_or_create_table. Nothing acquires these in the reverse order.
+        async with self.table_lock(name):
+            async with self._creation_lock:
+                await self._connection.drop_table(name, ignore_missing=True)
+                table = await self._connection.create_table(name, schema=schema)
+                self._tables[name] = table
+                self._writes_since_optimize[name] = 0
         return table
 
     def bump_writes(self, name: str) -> None:
@@ -401,12 +404,13 @@ async def _fetch_rows_by_ids(
 ) -> list[dict[str, Any]]:
     if not ids:
         return []
-    rows: list[dict[str, Any]] = []
-    for chunk in _iter_chunks(ids):
-        rows.extend(
-            await _fetch_rows(table, where=_sql_in(id_column, chunk), columns=columns)
-        )
-    return rows
+    chunk_rows = await asyncio.gather(
+        *[
+            _fetch_rows(table, where=_sql_in(id_column, chunk), columns=columns)
+            for chunk in _iter_chunks(ids)
+        ]
+    )
+    return [row for rows in chunk_rows for row in rows]
 
 
 @final
@@ -414,22 +418,8 @@ async def _fetch_rows_by_ids(
 class LanceDBKVStorage(BaseKVStorage):
     """Key-value storage: JSON payload per id, workspace-prefixed table."""
 
-    def __init__(
-        self,
-        namespace: str,
-        global_config: dict[str, Any],
-        embedding_func=None,
-        workspace: str | None = None,
-    ):
-        super().__init__(
-            namespace=namespace,
-            workspace=workspace or "",
-            global_config=global_config,
-            embedding_func=embedding_func,
-        )
-        self.__post_init__()
-
     def __post_init__(self):
+        self.workspace = self.workspace or ""
         validate_workspace(self.workspace)
         self.workspace, self.final_namespace, self._table_name = _build_table_name(
             self.workspace, self.namespace
@@ -598,24 +588,8 @@ class LanceDBVectorStorage(BaseVectorStorage):
     records; ``query()`` only sees flushed data.
     """
 
-    def __init__(
-        self,
-        namespace: str,
-        global_config: dict[str, Any],
-        embedding_func=None,
-        workspace: str | None = None,
-        meta_fields: set[str] | None = None,
-    ):
-        super().__init__(
-            namespace=namespace,
-            workspace=workspace or "",
-            global_config=global_config,
-            embedding_func=embedding_func,
-            meta_fields=meta_fields or set(),
-        )
-        self.__post_init__()
-
     def __post_init__(self):
+        self.workspace = self.workspace or ""
         validate_workspace(self.workspace)
         self._validate_embedding_func()
         self.workspace, self.final_namespace, base_table_name = _build_table_name(
@@ -640,7 +614,14 @@ class LanceDBVectorStorage(BaseVectorStorage):
         self._buffer_lock = None
         self._pending_docs: dict[str, _PendingLanceVectorDoc] = {}
         fts_enabled_raw = _get_lancedb_env("LANCEDB_ENABLE_FTS", "true") or "true"
-        self._fts_enabled = fts_enabled_raw.strip().lower() == "true"
+        # Same truthy set as utils.get_env_value so LANCEDB_ENABLE_FTS=1/yes work.
+        self._fts_enabled = fts_enabled_raw.strip().lower() in (
+            "true",
+            "1",
+            "yes",
+            "t",
+            "on",
+        )
         self._fts_tokenizer = (
             _get_lancedb_env("LANCEDB_FTS_TOKENIZER", "ngram") or "ngram"
         ).strip()
@@ -834,7 +815,8 @@ class LanceDBVectorStorage(BaseVectorStorage):
             raise StorageNotInitializedError(type(self).__name__)
         async with self._buffer_lock:
             await self._flush_pending_locked()
-        await self._client.maybe_optimize(self._table_name)
+        if self._client is not None:
+            await self._client.maybe_optimize(self._table_name)
 
     async def drop_pending_index_ops(self) -> None:
         if self._buffer_lock is None:
@@ -884,6 +866,11 @@ class LanceDBVectorStorage(BaseVectorStorage):
         Not part of the LightRAG storage contract; requires the FTS index
         (enabled by default, CJK-friendly bigram tokenizer).
         """
+        if not self._fts_enabled:
+            raise RuntimeError(
+                "full_text_search requires the FTS index; it is disabled via "
+                "LANCEDB_ENABLE_FTS"
+            )
         table = self._table()
         rows = await (
             table.query()
@@ -1015,12 +1002,17 @@ class LanceDBVectorStorage(BaseVectorStorage):
         try:
             if self._client is None:
                 raise StorageNotInitializedError(type(self).__name__)
-            if self._buffer_lock is not None:
-                async with self._buffer_lock:
-                    self._pending_docs.clear()
-            table = await self._client.drop_and_recreate_table(
-                self._table_name, _vector_schema(self.embedding_func.embedding_dim)
-            )
+            if self._buffer_lock is None:
+                raise StorageNotInitializedError(type(self).__name__)
+            # Hold _buffer_lock across the recreate so an in-flight flush
+            # cannot re-persist pending docs between the clear and the drop
+            # (same serialization as delete/delete_entity_relation).
+            async with self._buffer_lock:
+                self._pending_docs.clear()
+                table = await self._client.drop_and_recreate_table(
+                    self._table_name,
+                    _vector_schema(self.embedding_func.embedding_dim),
+                )
             await self._ensure_fts_index(table)
             logger.info(f"[{self.workspace}] Dropped vector table {self._table_name}")
             return {"status": "success", "message": "data dropped"}
@@ -1040,22 +1032,8 @@ class LanceDBGraphStorage(BaseGraphStorage):
     payload (NetworkX/Mongo semantics).
     """
 
-    def __init__(
-        self,
-        namespace: str,
-        global_config: dict[str, Any],
-        embedding_func=None,
-        workspace: str | None = None,
-    ):
-        super().__init__(
-            namespace=namespace,
-            workspace=workspace or "",
-            global_config=global_config,
-            embedding_func=embedding_func,
-        )
-        self.__post_init__()
-
     def __post_init__(self):
+        self.workspace = self.workspace or ""
         validate_workspace(self.workspace)
         self.workspace, self.final_namespace, base_table_name = _build_table_name(
             self.workspace, self.namespace
@@ -1153,12 +1131,18 @@ class LanceDBGraphStorage(BaseGraphStorage):
         return {row["id"] for row in rows}
 
     async def _edges_touching(self, node_ids: list[str]) -> list[dict[str, Any]]:
-        """All edge rows with any endpoint in ``node_ids`` (deduped by id)."""
+        """Edge (id, src, tgt) rows with any endpoint in ``node_ids``, deduped by id.
+
+        Selects only the key columns — degree counting and BFS never need the
+        payload, which dominates row width.
+        """
         edges: dict[str, dict[str, Any]] = {}
         table = self._edges_table()
         for chunk in _iter_chunks(node_ids):
             rows = await _fetch_rows(
-                table, where=f"{_sql_in('src', chunk)} OR {_sql_in('tgt', chunk)}"
+                table,
+                where=f"{_sql_in('src', chunk)} OR {_sql_in('tgt', chunk)}",
+                columns=["id", "src", "tgt"],
             )
             for row in rows:
                 edges[row["id"]] = row
@@ -1525,22 +1509,8 @@ class LanceDBGraphStorage(BaseGraphStorage):
 class LanceDBDocStatusStorage(DocStatusStorage):
     """Document status storage with typed columns for status/dedup lookups."""
 
-    def __init__(
-        self,
-        namespace: str,
-        global_config: dict[str, Any],
-        embedding_func=None,
-        workspace: str | None = None,
-    ):
-        super().__init__(
-            namespace=namespace,
-            workspace=workspace or "",
-            global_config=global_config,
-            embedding_func=embedding_func,
-        )
-        self.__post_init__()
-
     def __post_init__(self):
+        self.workspace = self.workspace or ""
         validate_workspace(self.workspace)
         self.workspace, self.final_namespace, self._table_name = _build_table_name(
             self.workspace, self.namespace

--- a/lightrag/kg/lancedb_impl.py
+++ b/lightrag/kg/lancedb_impl.py
@@ -1,0 +1,1777 @@
+"""LanceDB unified storage backend for LightRAG.
+
+Implements all four storage types on top of a single embedded LanceDB
+database directory:
+
+- ``LanceDBKVStorage``        (BaseKVStorage)
+- ``LanceDBVectorStorage``    (BaseVectorStorage)
+- ``LanceDBGraphStorage``     (BaseGraphStorage)
+- ``LanceDBDocStatusStorage`` (DocStatusStorage)
+
+LanceDB is an embedded, serverless vector database built on the Lance
+columnar format. This backend keeps vectors, the knowledge graph, KV data
+and document status in one local directory with no external service.
+
+Storage layout (one Lance table per namespace, workspace-prefixed):
+
+- KV:         ``{workspace}_{namespace}``            (id, payload, create_time, update_time)
+- Vector:     ``{workspace}_{namespace}[_{model}]``  (id, vector, content, src_id, tgt_id, created_at, payload)
+- Graph:      ``{workspace}_{namespace}_nodes``      (id, payload)
+              ``{workspace}_{namespace}_edges``      (id, src, tgt, payload)
+- Doc status: ``{workspace}_{namespace}``            (id, status, file_path, track_id, content_hash, payload)
+
+Full-fidelity records are stored as JSON strings in the ``payload`` column;
+columns that need SQL filtering (ids, src/tgt, status, ...) are typed.
+
+Concurrency model: all storage instances in a process share one
+``AsyncConnection`` (and one ``AsyncTable`` handle per table) through
+``ClientManager``. Writes to a table are serialized with a per-table
+``asyncio.Lock`` because concurrent ``merge_insert`` calls with overlapping
+keys can commit duplicate rows under LanceDB's optimistic concurrency.
+Multi-process deployments (e.g. gunicorn workers) are not recommended with
+this backend; use a server-based backend for those.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import configparser
+import hashlib
+import json
+import os
+import re
+import time
+from dataclasses import dataclass
+from datetime import timedelta
+from enum import Enum
+from typing import Any, Iterable, Iterator, final
+
+import numpy as np
+
+from ..base import (
+    BaseGraphStorage,
+    BaseKVStorage,
+    BaseVectorStorage,
+    DocProcessingStatus,
+    DocStatus,
+    DocStatusStorage,
+)
+from ..constants import DEFAULT_QUERY_PRIORITY
+from ..exceptions import StorageNotInitializedError
+from ..kg.shared_storage import get_data_init_lock, get_namespace_lock
+from ..types import KnowledgeGraph, KnowledgeGraphEdge, KnowledgeGraphNode
+from ..utils import (
+    _cooperative_yield,
+    compute_mdhash_id,
+    get_pinyin_sort_key,
+    logger,
+    validate_workspace,
+)
+
+import pipmaster as pm
+
+if not pm.is_installed("lancedb"):
+    pm.install("lancedb")
+
+import lancedb  # noqa: E402
+import pyarrow as pa  # noqa: E402
+from lancedb.index import FTS  # noqa: E402
+
+config = configparser.ConfigParser()
+config.read("config.ini", "utf-8")
+
+# Max number of ids per SQL IN (...) clause; larger sets are chunked.
+_SQL_IN_CHUNK = 500
+
+
+def _get_lancedb_env(key: str, fallback: str | None = None) -> str | None:
+    """Env var first, then [lancedb] section of config.ini, then fallback."""
+    cfg_key = key.replace("LANCEDB_", "").lower()
+    return os.environ.get(key, config.get("lancedb", cfg_key, fallback=fallback))
+
+
+def _resolve_lancedb_uri(global_config: dict[str, Any]) -> str:
+    uri = _get_lancedb_env("LANCEDB_URI")
+    if uri and uri.strip():
+        uri = uri.strip()
+    else:
+        working_dir = global_config.get("working_dir") or "."
+        uri = os.path.join(working_dir, "lancedb")
+    # Normalize local paths so different spellings of the same directory
+    # share one client (and its per-table write locks). Leave remote URIs
+    # (s3://, az://, ...) untouched.
+    if "://" not in uri:
+        uri = os.path.abspath(uri)
+    return uri
+
+
+def _resolve_workspace(workspace: str) -> str:
+    """LANCEDB_WORKSPACE env override beats the constructor parameter."""
+    env_workspace = _get_lancedb_env("LANCEDB_WORKSPACE")
+    if env_workspace and env_workspace.strip():
+        return env_workspace.strip()
+    return workspace or ""
+
+
+def _build_table_name(workspace: str, namespace: str) -> tuple[str, str, str]:
+    """Return (effective_workspace, final_namespace, sanitized_table_name)."""
+    effective = _resolve_workspace(workspace)
+    final_namespace = f"{effective}_{namespace}" if effective else namespace
+    return effective, final_namespace, _sanitize_table_name(final_namespace)
+
+
+def _sanitize_table_name(name: str) -> str:
+    # Lowercase to avoid case-only collisions on case-insensitive filesystems
+    # (LanceDB tables are directories).
+    sanitized = re.sub(r"[^a-z0-9_-]", "_", name.lower())
+    if sanitized and sanitized[0] in "-_":
+        sanitized = "x" + sanitized
+    # Folding is lossy: distinct names like "TeamA" and "teama" (both valid
+    # workspaces) would otherwise share a table. Disambiguate any name the
+    # folding changed with a short hash of the original.
+    if sanitized != name:
+        digest = hashlib.md5(name.encode("utf-8")).hexdigest()[:8]
+        sanitized = f"{sanitized}_{digest}"
+    return sanitized
+
+
+def _sql_quote(value: Any) -> str:
+    """Quote a value as a SQL string literal (single quotes doubled)."""
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+def _sql_in(column: str, values: Iterable[Any]) -> str:
+    return f"{column} IN ({', '.join(_sql_quote(v) for v in values)})"
+
+
+def _iter_chunks(values: list[Any], size: int = _SQL_IN_CHUNK) -> Iterator[list[Any]]:
+    for i in range(0, len(values), size):
+        yield values[i : i + size]
+
+
+def _json_dumps(data: dict[str, Any]) -> str:
+    try:
+        return json.dumps(data, ensure_ascii=False)
+    except TypeError as e:
+        raise TypeError(
+            f"LanceDB storage requires JSON-serializable records: {e}"
+        ) from e
+
+
+def _json_loads(payload: str | None) -> dict[str, Any]:
+    if not payload:
+        return {}
+    return json.loads(payload)
+
+
+def _status_value(status: Any) -> str:
+    return status.value if isinstance(status, Enum) else str(status)
+
+
+def _kv_schema() -> pa.Schema:
+    return pa.schema(
+        [
+            pa.field("id", pa.string()),
+            pa.field("payload", pa.string()),
+            pa.field("create_time", pa.int64()),
+            pa.field("update_time", pa.int64()),
+        ]
+    )
+
+
+def _vector_schema(dim: int) -> pa.Schema:
+    return pa.schema(
+        [
+            pa.field("id", pa.string()),
+            pa.field("vector", pa.list_(pa.float32(), dim)),
+            pa.field("content", pa.string()),
+            pa.field("src_id", pa.string()),
+            pa.field("tgt_id", pa.string()),
+            pa.field("created_at", pa.int64()),
+            pa.field("payload", pa.string()),
+        ]
+    )
+
+
+def _graph_node_schema() -> pa.Schema:
+    return pa.schema(
+        [
+            pa.field("id", pa.string()),
+            pa.field("payload", pa.string()),
+        ]
+    )
+
+
+def _graph_edge_schema() -> pa.Schema:
+    return pa.schema(
+        [
+            pa.field("id", pa.string()),
+            pa.field("src", pa.string()),
+            pa.field("tgt", pa.string()),
+            pa.field("payload", pa.string()),
+        ]
+    )
+
+
+def _doc_status_schema() -> pa.Schema:
+    return pa.schema(
+        [
+            pa.field("id", pa.string()),
+            pa.field("status", pa.string()),
+            pa.field("file_path", pa.string()),
+            pa.field("track_id", pa.string()),
+            pa.field("content_hash", pa.string()),
+            pa.field("payload", pa.string()),
+        ]
+    )
+
+
+def _canonical_edge_id(source_node_id: str, target_node_id: str) -> str:
+    lo, hi = sorted((source_node_id, target_node_id))
+    return compute_mdhash_id(f"{lo}-{hi}", prefix="edge-")
+
+
+class LanceDBClient:
+    """Shared per-URI LanceDB connection with table-handle cache and locks.
+
+    All storage instances pointing at the same database directory share one
+    connection and one ``AsyncTable`` handle per table so that writes made
+    through one storage are immediately visible to the others. Per-table
+    ``asyncio.Lock``s serialize writes: concurrent ``merge_insert`` calls
+    with the same keys would otherwise commit duplicate rows.
+    """
+
+    def __init__(self, uri: str):
+        self.uri = uri
+        self._connection = None
+        self._tables: dict[str, Any] = {}
+        self._table_locks: dict[str, asyncio.Lock] = {}
+        self._creation_lock = asyncio.Lock()
+        self._writes_since_optimize: dict[str, int] = {}
+        interval_raw = _get_lancedb_env("LANCEDB_READ_CONSISTENCY_INTERVAL", "0")
+        try:
+            self._read_consistency_interval = timedelta(seconds=float(interval_raw))
+        except (TypeError, ValueError):
+            logger.warning(
+                f"Invalid LANCEDB_READ_CONSISTENCY_INTERVAL={interval_raw!r}, using 0"
+            )
+            self._read_consistency_interval = timedelta(0)
+        threshold_raw = _get_lancedb_env("LANCEDB_OPTIMIZE_THRESHOLD", "64")
+        try:
+            self.optimize_threshold = int(threshold_raw)
+        except (TypeError, ValueError):
+            logger.warning(
+                f"Invalid LANCEDB_OPTIMIZE_THRESHOLD={threshold_raw!r}, using 64"
+            )
+            self.optimize_threshold = 64
+
+    async def connect(self) -> None:
+        if self._connection is None:
+            # Only makedirs for local paths; remote URIs (s3://, az://, ...)
+            # are managed by LanceDB and must not be created on the local FS
+            # (os.makedirs would otherwise make a bogus "s3:" dir in the cwd).
+            if "://" not in self.uri:
+                os.makedirs(self.uri, exist_ok=True)
+            self._connection = await lancedb.connect_async(
+                self.uri,
+                read_consistency_interval=self._read_consistency_interval,
+            )
+            logger.info(f"LanceDB connected: {self.uri}")
+
+    async def close(self) -> None:
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None
+        self._tables.clear()
+        self._writes_since_optimize.clear()
+
+    def table(self, name: str):
+        table = self._tables.get(name)
+        if table is None:
+            raise StorageNotInitializedError(f"LanceDB table {name}")
+        return table
+
+    def table_lock(self, name: str) -> asyncio.Lock:
+        lock = self._table_locks.get(name)
+        if lock is None:
+            lock = self._table_locks.setdefault(name, asyncio.Lock())
+        return lock
+
+    async def get_or_create_table(self, name: str, schema: pa.Schema):
+        table = self._tables.get(name)
+        if table is not None:
+            return table
+        async with self._creation_lock:
+            table = self._tables.get(name)
+            if table is None:
+                table = await self._connection.create_table(
+                    name, schema=schema, exist_ok=True
+                )
+                self._tables[name] = table
+        return table
+
+    async def drop_and_recreate_table(self, name: str, schema: pa.Schema):
+        async with self._creation_lock:
+            await self._connection.drop_table(name, ignore_missing=True)
+            table = await self._connection.create_table(name, schema=schema)
+            self._tables[name] = table
+            self._writes_since_optimize[name] = 0
+        return table
+
+    def bump_writes(self, name: str) -> None:
+        self._writes_since_optimize[name] = self._writes_since_optimize.get(name, 0) + 1
+
+    async def maybe_optimize(self, name: str) -> None:
+        """Compact fragments and fold new rows into indexes periodically.
+
+        Every LanceDB write commits a new table version; without periodic
+        optimize() small fragments accumulate and slow scans down.
+        Best-effort: failures are logged, never raised.
+        """
+        if self.optimize_threshold <= 0:
+            return
+        if self._writes_since_optimize.get(name, 0) < self.optimize_threshold:
+            return
+        try:
+            table = self._tables.get(name)
+            if table is not None:
+                await table.optimize()
+                self._writes_since_optimize[name] = 0
+        except Exception as e:
+            logger.warning(f"LanceDB optimize failed for table {name}: {e}")
+
+
+class ClientManager:
+    """Reference-counted shared LanceDB clients, keyed by database URI."""
+
+    _instances: dict[str, dict[str, Any]] = {}
+    _lock = asyncio.Lock()
+
+    @classmethod
+    async def get_client(cls, uri: str) -> LanceDBClient:
+        async with cls._lock:
+            entry = cls._instances.get(uri)
+            if entry is None:
+                client = LanceDBClient(uri)
+                await client.connect()
+                entry = {"client": client, "ref_count": 0}
+                cls._instances[uri] = entry
+            entry["ref_count"] += 1
+            return entry["client"]
+
+    @classmethod
+    async def release_client(cls, client: LanceDBClient | None) -> None:
+        if client is None:
+            return
+        async with cls._lock:
+            entry = cls._instances.get(client.uri)
+            if entry is None or entry["client"] is not client:
+                await client.close()
+                return
+            entry["ref_count"] -= 1
+            if entry["ref_count"] <= 0:
+                await client.close()
+                del cls._instances[client.uri]
+
+
+async def _fetch_rows(
+    table,
+    where: str | None = None,
+    columns: list[str] | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """Run a plain (non-vector) scan; plain scans return all rows by default."""
+    query = table.query()
+    if where:
+        query = query.where(where)
+    if columns is not None:
+        query = query.select(columns)
+    if limit is not None:
+        query = query.limit(limit)
+    return await query.to_list()
+
+
+async def _fetch_rows_by_ids(
+    table,
+    ids: list[str],
+    columns: list[str] | None = None,
+    id_column: str = "id",
+) -> list[dict[str, Any]]:
+    if not ids:
+        return []
+    rows: list[dict[str, Any]] = []
+    for chunk in _iter_chunks(ids):
+        rows.extend(await _fetch_rows(table, where=_sql_in(id_column, chunk), columns=columns))
+    return rows
+
+
+@final
+@dataclass
+class LanceDBKVStorage(BaseKVStorage):
+    """Key-value storage: JSON payload per id, workspace-prefixed table."""
+
+    def __init__(
+        self,
+        namespace: str,
+        global_config: dict[str, Any],
+        embedding_func=None,
+        workspace: str | None = None,
+    ):
+        super().__init__(
+            namespace=namespace,
+            workspace=workspace or "",
+            global_config=global_config,
+            embedding_func=embedding_func,
+        )
+        self.__post_init__()
+
+    def __post_init__(self):
+        validate_workspace(self.workspace)
+        self.workspace, self.final_namespace, self._table_name = _build_table_name(
+            self.workspace, self.namespace
+        )
+        self._client: LanceDBClient | None = None
+
+    async def initialize(self):
+        async with get_data_init_lock():
+            if self._client is None:
+                self._client = await ClientManager.get_client(
+                    _resolve_lancedb_uri(self.global_config)
+                )
+            await self._client.get_or_create_table(self._table_name, _kv_schema())
+
+    async def finalize(self):
+        if self._client is not None:
+            await ClientManager.release_client(self._client)
+            self._client = None
+
+    def _table(self):
+        if self._client is None:
+            raise StorageNotInitializedError(type(self).__name__)
+        return self._client.table(self._table_name)
+
+    @staticmethod
+    def _format_record(record_id: str, payload: str | None) -> dict[str, Any]:
+        record = _json_loads(payload)
+        record.setdefault("create_time", 0)
+        record.setdefault("update_time", 0)
+        record["_id"] = record_id
+        return record
+
+    async def get_by_id(self, id: str) -> dict[str, Any] | None:
+        rows = await _fetch_rows(
+            self._table(), where=f"id = {_sql_quote(id)}", columns=["id", "payload"], limit=1
+        )
+        if not rows:
+            return None
+        return self._format_record(id, rows[0].get("payload"))
+
+    async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
+        if not ids:
+            return []
+        rows = await _fetch_rows_by_ids(self._table(), ids, columns=["id", "payload"])
+        by_id = {row["id"]: row.get("payload") for row in rows}
+        return [
+            self._format_record(rid, by_id[rid]) if rid in by_id else None
+            for rid in ids
+        ]
+
+    async def filter_keys(self, keys: set[str]) -> set[str]:
+        if not keys:
+            return set()
+        rows = await _fetch_rows_by_ids(self._table(), list(keys), columns=["id"])
+        return keys - {row["id"] for row in rows}
+
+    async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
+        if not data:
+            return
+        table = self._table()
+        async with self._client.table_lock(self._table_name):
+            existing_rows = await _fetch_rows_by_ids(
+                table, list(data.keys()), columns=["id", "create_time"]
+            )
+            existing_create_times = {
+                row["id"]: row.get("create_time") for row in existing_rows
+            }
+            current_time = int(time.time())
+            rows: list[dict[str, Any]] = []
+            for i, (key, value) in enumerate(data.items(), 1):
+                record = dict(value)
+                if self.namespace.endswith("text_chunks"):
+                    record.setdefault("llm_cache_list", [])
+                create_time = (
+                    record.get("create_time")
+                    or existing_create_times.get(key)
+                    or current_time
+                )
+                record["create_time"] = create_time
+                record["update_time"] = current_time
+                record["_id"] = key
+                rows.append(
+                    {
+                        "id": key,
+                        "payload": _json_dumps(record),
+                        "create_time": create_time,
+                        "update_time": current_time,
+                    }
+                )
+                await _cooperative_yield(i)
+            await (
+                table.merge_insert("id")
+                .when_matched_update_all()
+                .when_not_matched_insert_all()
+                .execute(rows)
+            )
+            self._client.bump_writes(self._table_name)
+
+    async def delete(self, ids: list[str]) -> None:
+        if not ids:
+            return
+        table = self._table()
+        try:
+            async with self._client.table_lock(self._table_name):
+                for chunk in _iter_chunks(list(ids)):
+                    await table.delete(_sql_in("id", chunk))
+                self._client.bump_writes(self._table_name)
+        except Exception as e:
+            logger.error(f"[{self.workspace}] Failed to delete from {self._table_name}: {e}")
+            raise
+
+    async def is_empty(self) -> bool:
+        return await self._table().count_rows() == 0
+
+    async def index_done_callback(self) -> None:
+        # Writes are committed immediately; just compact periodically.
+        if self._client is not None:
+            await self._client.maybe_optimize(self._table_name)
+
+    async def drop(self) -> dict[str, str]:
+        try:
+            if self._client is None:
+                raise StorageNotInitializedError(type(self).__name__)
+            await self._client.drop_and_recreate_table(self._table_name, _kv_schema())
+            logger.info(f"[{self.workspace}] Dropped KV table {self._table_name}")
+            return {"status": "success", "message": "data dropped"}
+        except Exception as e:
+            logger.error(f"[{self.workspace}] Failed to drop {self._table_name}: {e}")
+            return {"status": "error", "message": str(e)}
+
+
+@dataclass
+class _PendingLanceVectorDoc:
+    """Buffered vector upsert awaiting embedding at flush time."""
+
+    source: dict[str, Any]  # {"created_at": int, **meta_fields}
+    content: str
+    vector: list[float] | None = None
+
+
+@final
+@dataclass
+class LanceDBVectorStorage(BaseVectorStorage):
+    """Vector storage with deferred embedding and optional CJK-friendly FTS.
+
+    ``upsert()`` buffers records without embedding them; the flush in
+    ``index_done_callback()`` embeds all pending contents in batches of
+    ``embedding_batch_num`` and writes them in one ``merge_insert``. Reads
+    (``get_by_id``/``get_by_ids``/``get_vectors_by_ids``) see pending
+    records; ``query()`` only sees flushed data.
+    """
+
+    def __init__(
+        self,
+        namespace: str,
+        global_config: dict[str, Any],
+        embedding_func=None,
+        workspace: str | None = None,
+        meta_fields: set[str] | None = None,
+    ):
+        super().__init__(
+            namespace=namespace,
+            workspace=workspace or "",
+            global_config=global_config,
+            embedding_func=embedding_func,
+            meta_fields=meta_fields or set(),
+        )
+        self.__post_init__()
+
+    def __post_init__(self):
+        validate_workspace(self.workspace)
+        self._validate_embedding_func()
+        self.workspace, self.final_namespace, base_table_name = _build_table_name(
+            self.workspace, self.namespace
+        )
+        kwargs = self.global_config.get("vector_db_storage_cls_kwargs", {})
+        cosine_threshold = kwargs.get("cosine_better_than_threshold")
+        if cosine_threshold is None:
+            raise ValueError(
+                "cosine_better_than_threshold must be specified in vector_db_storage_cls_kwargs"
+            )
+        self.cosine_better_than_threshold = cosine_threshold
+        self._max_batch_size = self.global_config["embedding_batch_num"]
+        # Embedding-model suffix isolates tables across embedding models/dims,
+        # since a Lance fixed-size vector column cannot change dimension.
+        model_suffix = self._generate_collection_suffix()
+        if model_suffix:
+            self._table_name = _sanitize_table_name(f"{base_table_name}_{model_suffix}")
+        else:
+            self._table_name = base_table_name
+        self._client: LanceDBClient | None = None
+        self._buffer_lock = None
+        self._pending_docs: dict[str, _PendingLanceVectorDoc] = {}
+        fts_enabled_raw = _get_lancedb_env("LANCEDB_ENABLE_FTS", "true") or "true"
+        self._fts_enabled = fts_enabled_raw.strip().lower() == "true"
+        self._fts_tokenizer = (
+            _get_lancedb_env("LANCEDB_FTS_TOKENIZER", "ngram") or "ngram"
+        ).strip()
+
+    async def initialize(self):
+        async with get_data_init_lock():
+            if self._buffer_lock is None:
+                self._buffer_lock = get_namespace_lock(
+                    self.namespace, workspace=self.workspace
+                )
+            if self._client is None:
+                self._client = await ClientManager.get_client(
+                    _resolve_lancedb_uri(self.global_config)
+                )
+            dim = self.embedding_func.embedding_dim
+            table = await self._client.get_or_create_table(
+                self._table_name, _vector_schema(dim)
+            )
+            await self._check_vector_dim(table, dim)
+            await self._ensure_fts_index(table)
+
+    async def finalize(self):
+        flush_error: Exception | None = None
+        try:
+            if self._client is not None and self._pending_docs:
+                async with self._buffer_lock:
+                    await self._flush_pending_locked()
+        except Exception as e:
+            flush_error = e
+        if self._client is not None:
+            await ClientManager.release_client(self._client)
+            self._client = None
+        if flush_error is not None:
+            raise RuntimeError(
+                f"[{self.workspace}] LanceDB vector flush failed during finalize: {flush_error}"
+            ) from flush_error
+
+    def _table(self):
+        if self._client is None:
+            raise StorageNotInitializedError(type(self).__name__)
+        return self._client.table(self._table_name)
+
+    async def _check_vector_dim(self, table, dim: int) -> None:
+        schema = await table.schema()
+        vector_field = schema.field("vector")
+        stored_dim = getattr(vector_field.type, "list_size", None)
+        if stored_dim is not None and stored_dim != dim:
+            raise ValueError(
+                f"Vector dimension mismatch for table {self._table_name}: "
+                f"stored={stored_dim}, embedding_func={dim}. "
+                "Clear the LanceDB directory or use a different table/model suffix."
+            )
+
+    def _fts_config(self) -> FTS:
+        if self._fts_tokenizer == "ngram":
+            # Bigram tokenization handles CJK text without external language
+            # models while still matching Latin-script terms.
+            return FTS(
+                base_tokenizer="ngram",
+                ngram_min_length=2,
+                ngram_max_length=2,
+                stem=False,
+                remove_stop_words=False,
+                ascii_folding=True,
+                lower_case=True,
+            )
+        return FTS(base_tokenizer=self._fts_tokenizer)
+
+    async def _ensure_fts_index(self, table) -> None:
+        """Best-effort FTS index on content; vector contract works without it."""
+        if not self._fts_enabled:
+            return
+        try:
+            indices = await table.list_indices()
+            for index in indices:
+                columns = getattr(index, "columns", None) or []
+                if "content" in columns:
+                    return
+            await table.create_index("content", config=self._fts_config())
+        except Exception as e:
+            logger.warning(
+                f"[{self.workspace}] Failed to create FTS index on {self._table_name}: {e}"
+            )
+
+    @staticmethod
+    def _row_to_record(row: dict[str, Any]) -> dict[str, Any]:
+        record = _json_loads(row.get("payload"))
+        record["content"] = row.get("content")
+        if row.get("src_id") is not None:
+            record["src_id"] = row["src_id"]
+        if row.get("tgt_id") is not None:
+            record["tgt_id"] = row["tgt_id"]
+        record["id"] = row["id"]
+        record["created_at"] = row.get("created_at")
+        return record
+
+    _NON_VECTOR_COLUMNS = ["id", "content", "src_id", "tgt_id", "created_at", "payload"]
+
+    async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
+        if not data:
+            return
+        if self._buffer_lock is None:
+            raise StorageNotInitializedError(type(self).__name__)
+        current_time = int(time.time())
+        pending: dict[str, _PendingLanceVectorDoc] = {}
+        for i, (key, value) in enumerate(data.items(), 1):
+            content = value["content"]
+            source = {
+                "created_at": current_time,
+                **{k: v for k, v in value.items() if k in self.meta_fields},
+            }
+            pending[key] = _PendingLanceVectorDoc(source=source, content=content)
+            await _cooperative_yield(i)
+        async with self._buffer_lock:
+            self._pending_docs.update(pending)
+        logger.debug(
+            f"[{self.workspace}] Buffered {len(pending)} vector docs for {self.final_namespace}"
+        )
+
+    async def _embed_contents(self, contents: list[str]) -> np.ndarray:
+        batches = [
+            contents[i : i + self._max_batch_size]
+            for i in range(0, len(contents), self._max_batch_size)
+        ]
+        embeddings_list = await asyncio.gather(
+            *[self.embedding_func(batch, context="document") for batch in batches]
+        )
+        embeddings = np.concatenate(embeddings_list)
+        if len(embeddings) != len(contents):
+            raise RuntimeError(
+                f"Embedding count mismatch: expected {len(contents)}, got {len(embeddings)}"
+            )
+        return embeddings
+
+    async def _flush_pending_locked(self) -> None:
+        """Embed and persist pending docs; caller holds ``_buffer_lock``.
+
+        On failure the pending buffer is kept intact so the next
+        ``index_done_callback`` retries, and the error propagates so the
+        pipeline can abort instead of marking documents processed.
+        """
+        if not self._pending_docs:
+            return
+        snapshot = list(self._pending_docs.items())
+        to_embed = [(doc_id, doc) for doc_id, doc in snapshot if doc.vector is None]
+        if to_embed:
+            embeddings = await self._embed_contents([doc.content for _, doc in to_embed])
+            for (_, doc), embedding in zip(to_embed, embeddings):
+                doc.vector = embedding.astype(np.float32).tolist()
+        rows: list[dict[str, Any]] = []
+        for i, (doc_id, doc) in enumerate(snapshot, 1):
+            meta = dict(doc.source)
+            created_at = meta.pop("created_at", None)
+            content = meta.pop("content", doc.content)
+            src_id = meta.pop("src_id", None)
+            tgt_id = meta.pop("tgt_id", None)
+            rows.append(
+                {
+                    "id": doc_id,
+                    "vector": doc.vector,
+                    "content": content,
+                    "src_id": src_id,
+                    "tgt_id": tgt_id,
+                    "created_at": created_at,
+                    "payload": _json_dumps(meta),
+                }
+            )
+            await _cooperative_yield(i)
+        table = self._table()
+        async with self._client.table_lock(self._table_name):
+            await (
+                table.merge_insert("id")
+                .when_matched_update_all()
+                .when_not_matched_insert_all()
+                .execute(rows)
+            )
+            self._client.bump_writes(self._table_name)
+        # Only drop the exact entries we flushed; a re-upsert that landed
+        # while embedding was in flight must survive for the next flush.
+        for doc_id, doc in snapshot:
+            if self._pending_docs.get(doc_id) is doc:
+                self._pending_docs.pop(doc_id, None)
+        logger.info(
+            f"[{self.workspace}] Flushed {len(rows)} vector docs to {self._table_name}"
+        )
+
+    async def index_done_callback(self) -> None:
+        if self._buffer_lock is None:
+            raise StorageNotInitializedError(type(self).__name__)
+        async with self._buffer_lock:
+            await self._flush_pending_locked()
+        await self._client.maybe_optimize(self._table_name)
+
+    async def drop_pending_index_ops(self) -> None:
+        if self._buffer_lock is None:
+            return
+        async with self._buffer_lock:
+            self._pending_docs.clear()
+
+    async def query(
+        self, query: str, top_k: int, query_embedding: list[float] = None
+    ) -> list[dict[str, Any]]:
+        if query_embedding is not None:
+            query_vector = (
+                query_embedding.tolist()
+                if hasattr(query_embedding, "tolist")
+                else list(query_embedding)
+            )
+        else:
+            embeddings = await self.embedding_func(
+                [query], context="query", _priority=DEFAULT_QUERY_PRIORITY
+            )
+            query_vector = embeddings[0].tolist()
+        table = self._table()
+        rows = await (
+            table.query()
+            .nearest_to(query_vector)
+            .distance_type("cosine")
+            .limit(top_k)
+            .select(self._NON_VECTOR_COLUMNS + ["_distance"])
+            .to_list()
+        )
+        results = []
+        for row in rows:
+            # LanceDB returns cosine distance; LightRAG thresholds similarity.
+            similarity = 1.0 - row["_distance"]
+            if similarity < self.cosine_better_than_threshold:
+                continue
+            record = self._row_to_record(row)
+            record["distance"] = similarity
+            results.append(record)
+        return results
+
+    async def full_text_search(self, query: str, top_k: int = 10) -> list[dict[str, Any]]:
+        """BM25 full-text search over the content column (extra capability).
+
+        Not part of the LightRAG storage contract; requires the FTS index
+        (enabled by default, CJK-friendly bigram tokenizer).
+        """
+        table = self._table()
+        rows = await (
+            table.query()
+            .nearest_to_text(query)
+            .limit(top_k)
+            .select(self._NON_VECTOR_COLUMNS + ["_score"])
+            .to_list()
+        )
+        results = []
+        for row in rows:
+            record = self._row_to_record(row)
+            record["score"] = row.get("_score")
+            results.append(record)
+        return results
+
+    async def get_by_id(self, id: str) -> dict[str, Any] | None:
+        async with self._buffer_lock:
+            pending = self._pending_docs.get(id)
+            if pending is not None:
+                return {**pending.source, "id": id}
+        rows = await _fetch_rows(
+            self._table(),
+            where=f"id = {_sql_quote(id)}",
+            columns=self._NON_VECTOR_COLUMNS,
+            limit=1,
+        )
+        if not rows:
+            return None
+        return self._row_to_record(rows[0])
+
+    async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
+        if not ids:
+            return []
+        found: dict[str, dict[str, Any]] = {}
+        remaining: list[str] = []
+        async with self._buffer_lock:
+            for record_id in ids:
+                pending = self._pending_docs.get(record_id)
+                if pending is not None:
+                    found[record_id] = {**pending.source, "id": record_id}
+                else:
+                    remaining.append(record_id)
+        rows = await _fetch_rows_by_ids(
+            self._table(), remaining, columns=self._NON_VECTOR_COLUMNS
+        )
+        for row in rows:
+            found[row["id"]] = self._row_to_record(row)
+        return [found.get(record_id) for record_id in ids]
+
+    async def get_vectors_by_ids(self, ids: list[str]) -> dict[str, list[float]]:
+        if not ids:
+            return {}
+        result: dict[str, list[float]] = {}
+        remaining: list[str] = []
+        async with self._buffer_lock:
+            pending_to_embed = [
+                (record_id, doc)
+                for record_id in ids
+                if (doc := self._pending_docs.get(record_id)) is not None
+                and doc.vector is None
+            ]
+            if pending_to_embed:
+                embeddings = await self._embed_contents(
+                    [doc.content for _, doc in pending_to_embed]
+                )
+                for (_, doc), embedding in zip(pending_to_embed, embeddings):
+                    # Cache on the pending doc so the flush reuses it.
+                    doc.vector = embedding.astype(np.float32).tolist()
+            for record_id in ids:
+                doc = self._pending_docs.get(record_id)
+                if doc is not None and doc.vector is not None:
+                    result[record_id] = doc.vector
+                else:
+                    remaining.append(record_id)
+        rows = await _fetch_rows_by_ids(self._table(), remaining, columns=["id", "vector"])
+        for row in rows:
+            vector = row.get("vector")
+            if vector is not None:
+                result[row["id"]] = list(vector)
+        return result
+
+    async def delete(self, ids: list[str]):
+        if not ids:
+            return
+        table = self._table()
+        try:
+            async with self._buffer_lock:
+                for record_id in ids:
+                    self._pending_docs.pop(record_id, None)
+            async with self._client.table_lock(self._table_name):
+                for chunk in _iter_chunks(list(ids)):
+                    await table.delete(_sql_in("id", chunk))
+                self._client.bump_writes(self._table_name)
+        except Exception as e:
+            logger.error(
+                f"[{self.workspace}] Failed to delete {len(ids)} vectors from {self._table_name}: {e}"
+            )
+            raise
+
+    async def delete_entity(self, entity_name: str) -> None:
+        entity_id = compute_mdhash_id(entity_name, prefix="ent-")
+        await self.delete([entity_id])
+
+    async def delete_entity_relation(self, entity_name: str) -> None:
+        quoted = _sql_quote(entity_name)
+        table = self._table()
+        try:
+            async with self._client.table_lock(self._table_name):
+                await table.delete(f"src_id = {quoted} OR tgt_id = {quoted}")
+                self._client.bump_writes(self._table_name)
+            async with self._buffer_lock:
+                stale = [
+                    doc_id
+                    for doc_id, doc in self._pending_docs.items()
+                    if doc.source.get("src_id") == entity_name
+                    or doc.source.get("tgt_id") == entity_name
+                ]
+                for doc_id in stale:
+                    self._pending_docs.pop(doc_id, None)
+        except Exception as e:
+            logger.error(
+                f"[{self.workspace}] Failed to delete relations of {entity_name}: {e}"
+            )
+            raise
+
+    async def drop(self) -> dict[str, str]:
+        try:
+            if self._client is None:
+                raise StorageNotInitializedError(type(self).__name__)
+            if self._buffer_lock is not None:
+                async with self._buffer_lock:
+                    self._pending_docs.clear()
+            table = await self._client.drop_and_recreate_table(
+                self._table_name, _vector_schema(self.embedding_func.embedding_dim)
+            )
+            await self._ensure_fts_index(table)
+            logger.info(f"[{self.workspace}] Dropped vector table {self._table_name}")
+            return {"status": "success", "message": "data dropped"}
+        except Exception as e:
+            logger.error(f"[{self.workspace}] Failed to drop {self._table_name}: {e}")
+            return {"status": "error", "message": str(e)}
+
+
+@final
+@dataclass
+class LanceDBGraphStorage(BaseGraphStorage):
+    """Graph storage: nodes and edges tables with canonical undirected edges.
+
+    Each undirected edge is stored once under a canonical id derived from
+    the sorted endpoint pair; the ``src``/``tgt`` columns keep the latest
+    call direction. Node/edge upserts merge properties into the existing
+    payload (NetworkX/Mongo semantics).
+    """
+
+    def __init__(
+        self,
+        namespace: str,
+        global_config: dict[str, Any],
+        embedding_func=None,
+        workspace: str | None = None,
+    ):
+        super().__init__(
+            namespace=namespace,
+            workspace=workspace or "",
+            global_config=global_config,
+            embedding_func=embedding_func,
+        )
+        self.__post_init__()
+
+    def __post_init__(self):
+        validate_workspace(self.workspace)
+        self.workspace, self.final_namespace, base_table_name = _build_table_name(
+            self.workspace, self.namespace
+        )
+        self._nodes_table_name = f"{base_table_name}_nodes"
+        self._edges_table_name = f"{base_table_name}_edges"
+        self._client: LanceDBClient | None = None
+
+    async def initialize(self):
+        async with get_data_init_lock():
+            if self._client is None:
+                self._client = await ClientManager.get_client(
+                    _resolve_lancedb_uri(self.global_config)
+                )
+            await self._client.get_or_create_table(
+                self._nodes_table_name, _graph_node_schema()
+            )
+            await self._client.get_or_create_table(
+                self._edges_table_name, _graph_edge_schema()
+            )
+
+    async def finalize(self):
+        if self._client is not None:
+            await ClientManager.release_client(self._client)
+            self._client = None
+
+    def _nodes_table(self):
+        if self._client is None:
+            raise StorageNotInitializedError(type(self).__name__)
+        return self._client.table(self._nodes_table_name)
+
+    def _edges_table(self):
+        if self._client is None:
+            raise StorageNotInitializedError(type(self).__name__)
+        return self._client.table(self._edges_table_name)
+
+    async def has_node(self, node_id: str) -> bool:
+        return await self._nodes_table().count_rows(f"id = {_sql_quote(node_id)}") > 0
+
+    async def has_edge(self, source_node_id: str, target_node_id: str) -> bool:
+        edge_id = _canonical_edge_id(source_node_id, target_node_id)
+        return await self._edges_table().count_rows(f"id = {_sql_quote(edge_id)}") > 0
+
+    async def node_degree(self, node_id: str) -> int:
+        quoted = _sql_quote(node_id)
+        return await self._edges_table().count_rows(
+            f"src = {quoted} OR tgt = {quoted}"
+        )
+
+    async def edge_degree(self, src_id: str, tgt_id: str) -> int:
+        src_degree, tgt_degree = await asyncio.gather(
+            self.node_degree(src_id), self.node_degree(tgt_id)
+        )
+        return src_degree + tgt_degree
+
+    async def get_node(self, node_id: str) -> dict[str, str] | None:
+        rows = await _fetch_rows(
+            self._nodes_table(), where=f"id = {_sql_quote(node_id)}", limit=1
+        )
+        if not rows:
+            return None
+        return _json_loads(rows[0].get("payload"))
+
+    async def get_edge(
+        self, source_node_id: str, target_node_id: str
+    ) -> dict[str, str] | None:
+        edge_id = _canonical_edge_id(source_node_id, target_node_id)
+        rows = await _fetch_rows(
+            self._edges_table(), where=f"id = {_sql_quote(edge_id)}", limit=1
+        )
+        if not rows:
+            return None
+        return _json_loads(rows[0].get("payload"))
+
+    async def get_node_edges(self, source_node_id: str) -> list[tuple[str, str]] | None:
+        if not await self.has_node(source_node_id):
+            return None
+        quoted = _sql_quote(source_node_id)
+        rows = await _fetch_rows(
+            self._edges_table(),
+            where=f"src = {quoted} OR tgt = {quoted}",
+            columns=["src", "tgt"],
+        )
+        # Queried node first in every tuple (NetworkX semantics) — callers
+        # like amerge_entities filter on tuple[0] == entity_name.
+        return [
+            (source_node_id, row["tgt"] if row["src"] == source_node_id else row["src"])
+            for row in rows
+        ]
+
+    async def get_nodes_batch(self, node_ids: list[str]) -> dict[str, dict]:
+        rows = await _fetch_rows_by_ids(self._nodes_table(), node_ids)
+        return {row["id"]: _json_loads(row.get("payload")) for row in rows}
+
+    async def has_nodes_batch(self, node_ids: list[str]) -> set[str]:
+        rows = await _fetch_rows_by_ids(self._nodes_table(), node_ids, columns=["id"])
+        return {row["id"] for row in rows}
+
+    async def _edges_touching(self, node_ids: list[str]) -> list[dict[str, Any]]:
+        """All edge rows with any endpoint in ``node_ids`` (deduped by id)."""
+        edges: dict[str, dict[str, Any]] = {}
+        table = self._edges_table()
+        for chunk in _iter_chunks(node_ids):
+            rows = await _fetch_rows(
+                table, where=f"{_sql_in('src', chunk)} OR {_sql_in('tgt', chunk)}"
+            )
+            for row in rows:
+                edges[row["id"]] = row
+        return list(edges.values())
+
+    async def node_degrees_batch(self, node_ids: list[str]) -> dict[str, int]:
+        result = {node_id: 0 for node_id in node_ids}
+        requested = set(node_ids)
+        for row in await self._edges_touching(node_ids):
+            if row["src"] in requested:
+                result[row["src"]] += 1
+            # A self-loop counts once, matching count_rows on src OR tgt.
+            if row["tgt"] in requested and row["tgt"] != row["src"]:
+                result[row["tgt"]] += 1
+        return result
+
+    async def edge_degrees_batch(
+        self, edge_pairs: list[tuple[str, str]]
+    ) -> dict[tuple[str, str], int]:
+        node_ids = list({node for pair in edge_pairs for node in pair})
+        degrees = await self.node_degrees_batch(node_ids)
+        return {
+            (src, tgt): degrees.get(src, 0) + degrees.get(tgt, 0)
+            for src, tgt in edge_pairs
+        }
+
+    async def get_edges_batch(
+        self, pairs: list[dict[str, str]]
+    ) -> dict[tuple[str, str], dict]:
+        if not pairs:
+            return {}
+        id_to_pairs: dict[str, list[tuple[str, str]]] = {}
+        for pair in pairs:
+            edge_id = _canonical_edge_id(pair["src"], pair["tgt"])
+            id_to_pairs.setdefault(edge_id, []).append((pair["src"], pair["tgt"]))
+        rows = await _fetch_rows_by_ids(self._edges_table(), list(id_to_pairs.keys()))
+        result: dict[tuple[str, str], dict] = {}
+        for row in rows:
+            payload = _json_loads(row.get("payload"))
+            for requested_pair in id_to_pairs.get(row["id"], []):
+                result[requested_pair] = dict(payload)
+        return result
+
+    async def get_nodes_edges_batch(
+        self, node_ids: list[str]
+    ) -> dict[str, list[tuple[str, str]]]:
+        result: dict[str, list[tuple[str, str]]] = {node_id: [] for node_id in node_ids}
+        requested = set(node_ids)
+        for row in await self._edges_touching(node_ids):
+            # Queried node first in each tuple, matching get_node_edges.
+            if row["src"] in requested:
+                result[row["src"]].append((row["src"], row["tgt"]))
+            if row["tgt"] in requested and row["tgt"] != row["src"]:
+                result[row["tgt"]].append((row["tgt"], row["src"]))
+        return result
+
+    async def _merge_upsert_nodes_locked(
+        self, nodes: list[tuple[str, dict[str, str]]]
+    ) -> None:
+        """Merge node properties into existing payloads; caller holds lock."""
+        table = self._nodes_table()
+        node_ids = list({node_id for node_id, _ in nodes})
+        rows = await _fetch_rows_by_ids(table, node_ids)
+        merged: dict[str, dict[str, Any]] = {
+            row["id"]: _json_loads(row.get("payload")) for row in rows
+        }
+        for i, (node_id, node_data) in enumerate(nodes, 1):
+            current = merged.setdefault(node_id, {})
+            current.update(node_data)
+            await _cooperative_yield(i)
+        await (
+            table.merge_insert("id")
+            .when_matched_update_all()
+            .when_not_matched_insert_all()
+            .execute(
+                [
+                    {"id": node_id, "payload": _json_dumps(payload)}
+                    for node_id, payload in merged.items()
+                ]
+            )
+        )
+        self._client.bump_writes(self._nodes_table_name)
+
+    async def upsert_node(self, node_id: str, node_data: dict[str, str]) -> None:
+        async with self._client.table_lock(self._nodes_table_name):
+            await self._merge_upsert_nodes_locked([(node_id, node_data)])
+
+    async def upsert_nodes_batch(self, nodes: list[tuple[str, dict[str, str]]]) -> None:
+        if not nodes:
+            return
+        async with self._client.table_lock(self._nodes_table_name):
+            await self._merge_upsert_nodes_locked(nodes)
+
+    async def _ensure_source_nodes(self, source_ids: list[str]) -> None:
+        existing = await self.has_nodes_batch(source_ids)
+        missing = [node_id for node_id in source_ids if node_id not in existing]
+        if missing:
+            await self.upsert_nodes_batch([(node_id, {}) for node_id in missing])
+
+    async def upsert_edge(
+        self, source_node_id: str, target_node_id: str, edge_data: dict[str, str]
+    ) -> None:
+        await self.upsert_edges_batch([(source_node_id, target_node_id, edge_data)])
+
+    async def upsert_edges_batch(
+        self, edges: list[tuple[str, str, dict[str, str]]]
+    ) -> None:
+        if not edges:
+            return
+        await self._ensure_source_nodes(list({src for src, _, _ in edges}))
+        # Deduplicate by canonical id within the batch: apply in call order so
+        # later writes win field-by-field, matching sequential upsert_edge.
+        deduped: dict[str, tuple[str, str, dict[str, str]]] = {}
+        for src, tgt, edge_data in edges:
+            edge_id = _canonical_edge_id(src, tgt)
+            if edge_id in deduped:
+                _, _, merged_data = deduped[edge_id]
+                merged_data = {**merged_data, **edge_data}
+            else:
+                merged_data = dict(edge_data)
+            deduped[edge_id] = (src, tgt, merged_data)
+        table = self._edges_table()
+        async with self._client.table_lock(self._edges_table_name):
+            rows = await _fetch_rows_by_ids(table, list(deduped.keys()))
+            existing = {row["id"]: _json_loads(row.get("payload")) for row in rows}
+            out_rows = []
+            for i, (edge_id, (src, tgt, edge_data)) in enumerate(deduped.items(), 1):
+                payload = existing.get(edge_id, {})
+                payload.update(edge_data)
+                payload["source_node_id"] = src
+                payload["target_node_id"] = tgt
+                out_rows.append(
+                    {
+                        "id": edge_id,
+                        "src": src,
+                        "tgt": tgt,
+                        "payload": _json_dumps(payload),
+                    }
+                )
+                await _cooperative_yield(i)
+            await (
+                table.merge_insert("id")
+                .when_matched_update_all()
+                .when_not_matched_insert_all()
+                .execute(out_rows)
+            )
+            self._client.bump_writes(self._edges_table_name)
+
+    async def delete_node(self, node_id: str) -> None:
+        await self.remove_nodes([node_id])
+
+    async def remove_nodes(self, nodes: list[str]):
+        if not nodes:
+            return
+        edges_table = self._edges_table()
+        nodes_table = self._nodes_table()
+        async with self._client.table_lock(self._edges_table_name):
+            for chunk in _iter_chunks(nodes):
+                await edges_table.delete(
+                    f"{_sql_in('src', chunk)} OR {_sql_in('tgt', chunk)}"
+                )
+            self._client.bump_writes(self._edges_table_name)
+        async with self._client.table_lock(self._nodes_table_name):
+            for chunk in _iter_chunks(nodes):
+                await nodes_table.delete(_sql_in("id", chunk))
+            self._client.bump_writes(self._nodes_table_name)
+
+    async def remove_edges(self, edges: list[tuple[str, str]]):
+        if not edges:
+            return
+        edge_ids = list({_canonical_edge_id(src, tgt) for src, tgt in edges})
+        table = self._edges_table()
+        async with self._client.table_lock(self._edges_table_name):
+            for chunk in _iter_chunks(edge_ids):
+                await table.delete(_sql_in("id", chunk))
+            self._client.bump_writes(self._edges_table_name)
+
+    async def get_all_labels(self) -> list[str]:
+        rows = await _fetch_rows(self._nodes_table(), columns=["id"])
+        return sorted(row["id"] for row in rows)
+
+    async def get_all_nodes(self) -> list[dict]:
+        rows = await _fetch_rows(self._nodes_table())
+        return [
+            {**_json_loads(row.get("payload")), "id": row["id"]} for row in rows
+        ]
+
+    async def get_all_edges(self) -> list[dict]:
+        rows = await _fetch_rows(self._edges_table())
+        return [
+            {
+                **_json_loads(row.get("payload")),
+                "source": row["src"],
+                "target": row["tgt"],
+            }
+            for row in rows
+        ]
+
+    async def get_popular_labels(self, limit: int = 300) -> list[str]:
+        node_rows = await _fetch_rows(self._nodes_table(), columns=["id"])
+        degrees = {row["id"]: 0 for row in node_rows}
+        edge_rows = await _fetch_rows(self._edges_table(), columns=["src", "tgt"])
+        for row in edge_rows:
+            if row["src"] in degrees:
+                degrees[row["src"]] += 1
+            if row["tgt"] in degrees and row["tgt"] != row["src"]:
+                degrees[row["tgt"]] += 1
+        ranked = sorted(degrees.items(), key=lambda item: (-item[1], item[0]))
+        return [label for label, _ in ranked[:limit]]
+
+    async def search_labels(self, query: str, limit: int = 50) -> list[str]:
+        query_lower = query.lower().strip()
+        if not query_lower:
+            return []
+        rows = await _fetch_rows(self._nodes_table(), columns=["id"])
+        matches: list[tuple[str, int]] = []
+        for row in rows:
+            label = str(row["id"])
+            label_lower = label.lower()
+            if query_lower not in label_lower:
+                continue
+            if label_lower == query_lower:
+                score = 1000
+            elif label_lower.startswith(query_lower):
+                score = 500
+            else:
+                score = 100 - len(label)
+                if f" {query_lower}" in label_lower or f"_{query_lower}" in label_lower:
+                    score += 50
+            matches.append((label, score))
+        matches.sort(key=lambda item: (-item[1], item[0]))
+        return [label for label, _ in matches[:limit]]
+
+    @staticmethod
+    def _construct_graph_node(node_id: str, node_data: dict[str, Any]) -> KnowledgeGraphNode:
+        return KnowledgeGraphNode(
+            id=node_id, labels=[node_id], properties=dict(node_data)
+        )
+
+    @staticmethod
+    def _construct_graph_edge(row: dict[str, Any]) -> KnowledgeGraphEdge:
+        payload = _json_loads(row.get("payload"))
+        return KnowledgeGraphEdge(
+            id=f"{row['src']}-{row['tgt']}",
+            type=payload.get("relationship", ""),
+            source=row["src"],
+            target=row["tgt"],
+            properties={
+                k: v
+                for k, v in payload.items()
+                if k not in ("source_node_id", "target_node_id", "relationship")
+            },
+        )
+
+    async def _append_edges_between(
+        self, node_ids: set[str], result: KnowledgeGraph
+    ) -> None:
+        seen_edges: set[str] = set()
+        table = self._edges_table()
+        for chunk in _iter_chunks(list(node_ids)):
+            rows = await _fetch_rows(table, where=_sql_in("src", chunk))
+            for row in rows:
+                if row["tgt"] not in node_ids or row["id"] in seen_edges:
+                    continue
+                seen_edges.add(row["id"])
+                result.edges.append(self._construct_graph_edge(row))
+
+    async def get_knowledge_graph(
+        self, node_label: str, max_depth: int = 3, max_nodes: int = 1000
+    ) -> KnowledgeGraph:
+        global_max = self.global_config.get("max_graph_nodes", 1000)
+        max_nodes = global_max if max_nodes is None else min(max_nodes, global_max)
+        if node_label == "*":
+            return await self._get_knowledge_graph_all(max_nodes)
+        return await self._get_knowledge_graph_bfs(node_label, max_depth, max_nodes)
+
+    async def _get_knowledge_graph_all(self, max_nodes: int) -> KnowledgeGraph:
+        result = KnowledgeGraph()
+        total = await self._nodes_table().count_rows()
+        if total > max_nodes:
+            result.is_truncated = True
+            selected = set(await self.get_popular_labels(limit=max_nodes))
+            nodes = await self.get_nodes_batch(list(selected))
+        else:
+            rows = await _fetch_rows(self._nodes_table())
+            nodes = {row["id"]: _json_loads(row.get("payload")) for row in rows}
+            selected = set(nodes.keys())
+        for node_id, node_data in nodes.items():
+            result.nodes.append(self._construct_graph_node(node_id, node_data))
+        await self._append_edges_between(selected, result)
+        return result
+
+    async def _get_knowledge_graph_bfs(
+        self, node_label: str, max_depth: int, max_nodes: int
+    ) -> KnowledgeGraph:
+        result = KnowledgeGraph()
+        start_node = await self.get_node(node_label)
+        if start_node is None:
+            logger.warning(f"[{self.workspace}] Graph node not found: {node_label}")
+            return result
+        result.nodes.append(self._construct_graph_node(node_label, start_node))
+        seen: set[str] = {node_label}
+        result_ids: set[str] = {node_label}
+        frontier: list[str] = [node_label]
+        truncated = False
+        for _ in range(max_depth):
+            if not frontier:
+                break
+            neighbor_ids: list[str] = []
+            for row in await self._edges_touching(frontier):
+                for endpoint in (row["src"], row["tgt"]):
+                    if endpoint in seen:
+                        continue
+                    if len(seen) >= max_nodes:
+                        # A reachable neighbor exists but the cap keeps it out.
+                        truncated = True
+                        break
+                    seen.add(endpoint)
+                    neighbor_ids.append(endpoint)
+                if truncated:
+                    break
+            if truncated or not neighbor_ids:
+                break
+            fetched = await self.get_nodes_batch(neighbor_ids)
+            next_frontier = []
+            for node_id in neighbor_ids:
+                node_data = fetched.get(node_id)
+                if node_data is None:
+                    continue  # edge endpoint without node row — skip
+                result.nodes.append(self._construct_graph_node(node_id, node_data))
+                result_ids.add(node_id)
+                next_frontier.append(node_id)
+            frontier = next_frontier
+        await self._append_edges_between(result_ids, result)
+        result.is_truncated = truncated
+        return result
+
+    async def index_done_callback(self) -> None:
+        if self._client is not None:
+            await self._client.maybe_optimize(self._nodes_table_name)
+            await self._client.maybe_optimize(self._edges_table_name)
+
+    async def drop(self) -> dict[str, str]:
+        try:
+            if self._client is None:
+                raise StorageNotInitializedError(type(self).__name__)
+            await self._client.drop_and_recreate_table(
+                self._nodes_table_name, _graph_node_schema()
+            )
+            await self._client.drop_and_recreate_table(
+                self._edges_table_name, _graph_edge_schema()
+            )
+            logger.info(f"[{self.workspace}] Dropped graph tables {self.final_namespace}")
+            return {"status": "success", "message": "data dropped"}
+        except Exception as e:
+            logger.error(f"[{self.workspace}] Failed to drop graph tables: {e}")
+            return {"status": "error", "message": str(e)}
+
+
+@final
+@dataclass
+class LanceDBDocStatusStorage(DocStatusStorage):
+    """Document status storage with typed columns for status/dedup lookups."""
+
+    def __init__(
+        self,
+        namespace: str,
+        global_config: dict[str, Any],
+        embedding_func=None,
+        workspace: str | None = None,
+    ):
+        super().__init__(
+            namespace=namespace,
+            workspace=workspace or "",
+            global_config=global_config,
+            embedding_func=embedding_func,
+        )
+        self.__post_init__()
+
+    def __post_init__(self):
+        validate_workspace(self.workspace)
+        self.workspace, self.final_namespace, self._table_name = _build_table_name(
+            self.workspace, self.namespace
+        )
+        self._client: LanceDBClient | None = None
+
+    async def initialize(self):
+        async with get_data_init_lock():
+            if self._client is None:
+                self._client = await ClientManager.get_client(
+                    _resolve_lancedb_uri(self.global_config)
+                )
+            await self._client.get_or_create_table(
+                self._table_name, _doc_status_schema()
+            )
+
+    async def finalize(self):
+        if self._client is not None:
+            await ClientManager.release_client(self._client)
+            self._client = None
+
+    def _table(self):
+        if self._client is None:
+            raise StorageNotInitializedError(type(self).__name__)
+        return self._client.table(self._table_name)
+
+    async def get_by_id(self, id: str) -> dict[str, Any] | None:
+        rows = await _fetch_rows(
+            self._table(),
+            where=f"id = {_sql_quote(id)}",
+            columns=["id", "payload"],
+            limit=1,
+        )
+        if not rows:
+            return None
+        return _json_loads(rows[0].get("payload"))
+
+    async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
+        if not ids:
+            return []
+        rows = await _fetch_rows_by_ids(self._table(), ids, columns=["id", "payload"])
+        by_id = {row["id"]: _json_loads(row.get("payload")) for row in rows}
+        return [by_id.get(record_id) for record_id in ids]
+
+    async def filter_keys(self, keys: set[str]) -> set[str]:
+        if not keys:
+            return set()
+        rows = await _fetch_rows_by_ids(self._table(), list(keys), columns=["id"])
+        return keys - {row["id"] for row in rows}
+
+    async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
+        if not data:
+            return
+        table = self._table()
+        rows: list[dict[str, Any]] = []
+        for i, (key, value) in enumerate(data.items(), 1):
+            record = dict(value)
+            record.setdefault("chunks_list", [])
+            rows.append(
+                {
+                    "id": key,
+                    "status": _status_value(record.get("status")),
+                    # Normalize like _prepare_doc_status_data's read path so the
+                    # typed column agrees with the payload's normalized file_path.
+                    "file_path": record.get("file_path") or "no-file-path",
+                    "track_id": record.get("track_id"),
+                    "content_hash": record.get("content_hash"),
+                    "payload": _json_dumps(record),
+                }
+            )
+            await _cooperative_yield(i)
+        async with self._client.table_lock(self._table_name):
+            await (
+                table.merge_insert("id")
+                .when_matched_update_all()
+                .when_not_matched_insert_all()
+                .execute(rows)
+            )
+            self._client.bump_writes(self._table_name)
+
+    async def delete(self, ids: list[str]) -> None:
+        if not ids:
+            return
+        table = self._table()
+        try:
+            async with self._client.table_lock(self._table_name):
+                for chunk in _iter_chunks(list(ids)):
+                    await table.delete(_sql_in("id", chunk))
+                self._client.bump_writes(self._table_name)
+        except Exception as e:
+            logger.error(f"[{self.workspace}] Failed to delete doc status rows: {e}")
+            raise
+
+    async def is_empty(self) -> bool:
+        return await self._table().count_rows() == 0
+
+    @staticmethod
+    def _prepare_doc_status_data(doc: dict[str, Any]) -> dict[str, Any]:
+        data = doc.copy()
+        data.pop("content", None)  # deprecated field
+        if not data.get("file_path"):
+            data["file_path"] = "no-file-path"
+        data.setdefault("metadata", {})
+        data.setdefault("error_msg", None)
+        if "error" in data:  # legacy field rename
+            if not data.get("error_msg"):
+                data["error_msg"] = data.pop("error")
+            else:
+                data.pop("error", None)
+        return data
+
+    def _build_doc_status(
+        self, doc_id: str, payload: str | None
+    ) -> DocProcessingStatus | None:
+        try:
+            data = self._prepare_doc_status_data(_json_loads(payload))
+            return DocProcessingStatus(**data)
+        except (KeyError, TypeError) as e:
+            logger.error(f"[{self.workspace}] Invalid doc status record {doc_id}: {e}")
+            return None
+
+    def _rows_to_statuses(
+        self, rows: list[dict[str, Any]]
+    ) -> dict[str, DocProcessingStatus]:
+        result: dict[str, DocProcessingStatus] = {}
+        for row in rows:
+            status = self._build_doc_status(row["id"], row.get("payload"))
+            if status is not None:
+                result[row["id"]] = status
+        return result
+
+    async def get_status_counts(self) -> dict[str, int]:
+        counts = {status.value: 0 for status in DocStatus}
+        rows = await _fetch_rows(self._table(), columns=["status"])
+        for row in rows:
+            status = row.get("status")
+            if status is not None:
+                counts[status] = counts.get(status, 0) + 1
+        return counts
+
+    async def get_all_status_counts(self) -> dict[str, int]:
+        counts = await self.get_status_counts()
+        counts["all"] = sum(counts.values())
+        return counts
+
+    async def get_docs_by_status(
+        self, status: DocStatus
+    ) -> dict[str, DocProcessingStatus]:
+        return await self.get_docs_by_statuses([status])
+
+    async def get_docs_by_statuses(
+        self, statuses: list[DocStatus]
+    ) -> dict[str, DocProcessingStatus]:
+        if not statuses:
+            return {}
+        where = _sql_in("status", [_status_value(status) for status in statuses])
+        rows = await _fetch_rows(self._table(), where=where, columns=["id", "payload"])
+        return self._rows_to_statuses(rows)
+
+    async def get_docs_by_track_id(
+        self, track_id: str
+    ) -> dict[str, DocProcessingStatus]:
+        rows = await _fetch_rows(
+            self._table(),
+            where=f"track_id = {_sql_quote(track_id)}",
+            columns=["id", "payload"],
+        )
+        return self._rows_to_statuses(rows)
+
+    async def get_docs_paginated(
+        self,
+        status_filter: DocStatus | None = None,
+        status_filters: list[DocStatus] | None = None,
+        page: int = 1,
+        page_size: int = 50,
+        sort_field: str = "updated_at",
+        sort_direction: str = "desc",
+    ) -> tuple[list[tuple[str, DocProcessingStatus]], int]:
+        page = max(1, page)
+        page_size = max(10, min(200, page_size))
+        if sort_field not in ("created_at", "updated_at", "id", "file_path"):
+            sort_field = "updated_at"
+        reverse = sort_direction.lower() != "asc"
+        status_values = self.resolve_status_filter_values(
+            status_filter=status_filter, status_filters=status_filters
+        )
+        where = _sql_in("status", sorted(status_values)) if status_values else None
+        rows = await _fetch_rows(self._table(), where=where, columns=["id", "payload"])
+        docs = list(self._rows_to_statuses(rows).items())
+
+        def sort_key(item: tuple[str, DocProcessingStatus]):
+            doc_id, status = item
+            if sort_field == "id":
+                return doc_id
+            if sort_field == "file_path":
+                return get_pinyin_sort_key(getattr(status, sort_field, "") or "")
+            return getattr(status, sort_field, "") or ""
+
+        docs.sort(key=sort_key, reverse=reverse)
+        total_count = len(docs)
+        start = (page - 1) * page_size
+        return docs[start : start + page_size], total_count
+
+    async def get_doc_by_file_path(self, file_path: str) -> dict[str, Any] | None:
+        rows = await _fetch_rows(
+            self._table(),
+            where=f"file_path = {_sql_quote(file_path)}",
+            columns=["id", "payload"],
+            limit=1,
+        )
+        if not rows:
+            return None
+        return _json_loads(rows[0].get("payload"))
+
+    async def get_doc_by_file_basename(
+        self, basename: str
+    ) -> tuple[str, dict[str, Any]] | None:
+        if not basename or basename == "unknown_source":
+            return None
+        rows = await _fetch_rows(
+            self._table(),
+            where=f"file_path = {_sql_quote(basename)}",
+            columns=["id", "payload"],
+            limit=1,
+        )
+        if not rows:
+            return None
+        return rows[0]["id"], _json_loads(rows[0].get("payload"))
+
+    async def get_doc_by_content_hash(
+        self, content_hash: str
+    ) -> tuple[str, dict[str, Any]] | None:
+        if not content_hash:
+            return None
+        rows = await _fetch_rows(
+            self._table(),
+            where=f"content_hash = {_sql_quote(content_hash)}",
+            columns=["id", "payload"],
+            limit=1,
+        )
+        if not rows:
+            return None
+        return rows[0]["id"], _json_loads(rows[0].get("payload"))
+
+    async def index_done_callback(self) -> None:
+        if self._client is not None:
+            await self._client.maybe_optimize(self._table_name)
+
+    async def drop(self) -> dict[str, str]:
+        try:
+            if self._client is None:
+                raise StorageNotInitializedError(type(self).__name__)
+            await self._client.drop_and_recreate_table(
+                self._table_name, _doc_status_schema()
+            )
+            logger.info(f"[{self.workspace}] Dropped doc status table {self._table_name}")
+            return {"status": "success", "message": "data dropped"}
+        except Exception as e:
+            logger.error(f"[{self.workspace}] Failed to drop {self._table_name}: {e}")
+            return {"status": "error", "message": str(e)}

--- a/lightrag/kg/lancedb_impl.py
+++ b/lightrag/kg/lancedb_impl.py
@@ -1623,21 +1623,25 @@ class LanceDBDocStatusStorage(DocStatusStorage):
         return data
 
     def _build_doc_status(
-        self, doc_id: str, payload: str | None
+        self, doc_id: str, payload: str | None, strict: bool = False
     ) -> DocProcessingStatus | None:
         try:
             data = self._prepare_doc_status_data(_json_loads(payload))
             return DocProcessingStatus(**data)
         except (KeyError, TypeError) as e:
             logger.error(f"[{self.workspace}] Invalid doc status record {doc_id}: {e}")
+            if strict:
+                raise
             return None
 
     def _rows_to_statuses(
-        self, rows: list[dict[str, Any]]
+        self, rows: list[dict[str, Any]], strict: bool = False
     ) -> dict[str, DocProcessingStatus]:
         result: dict[str, DocProcessingStatus] = {}
         for row in rows:
-            status = self._build_doc_status(row["id"], row.get("payload"))
+            status = self._build_doc_status(
+                row["id"], row.get("payload"), strict=strict
+            )
             if status is not None:
                 result[row["id"]] = status
         return result
@@ -1662,13 +1666,20 @@ class LanceDBDocStatusStorage(DocStatusStorage):
         return await self.get_docs_by_statuses([status])
 
     async def get_docs_by_statuses(
-        self, statuses: list[DocStatus]
+        self, statuses: list[DocStatus], strict: bool = False
     ) -> dict[str, DocProcessingStatus]:
+        """Get all documents matching any of the given statuses.
+
+        The scan is a single ``to_list()``, so a transport failure always
+        propagates (there is no partial-page path to swallow); ``strict=True``
+        additionally raises on any record that cannot be converted
+        (complete-or-raise scheduling contract, see base class).
+        """
         if not statuses:
             return {}
         where = _sql_in("status", [_status_value(status) for status in statuses])
         rows = await _fetch_rows(self._table(), where=where, columns=["id", "payload"])
-        return self._rows_to_statuses(rows)
+        return self._rows_to_statuses(rows, strict=strict)
 
     async def get_docs_by_track_id(
         self, track_id: str

--- a/lightrag/kg/lancedb_impl.py
+++ b/lightrag/kg/lancedb_impl.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import asyncio
 import configparser
 import hashlib
+import heapq
 import json
 import os
 import re
@@ -44,20 +45,38 @@ import time
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
-from typing import Any, Iterable, Iterator, final
+from typing import Any, ClassVar, Iterable, Iterator, Sequence, final
 
 import numpy as np
 
 from ..base import (
+    CURSOR_END,
+    CURSOR_START,
     BaseGraphStorage,
     BaseKVStorage,
     BaseVectorStorage,
+    CursorAfter,
+    CursorPosition,
     DocProcessingStatus,
+    DocSchedulingRecord,
     DocStatus,
+    DocStatusPage,
     DocStatusStorage,
+    SourceAbsent,
+    SourceConflict,
+    SourceConflictPage,
+    SourceConflictRepairResult,
+    SourceConflictSummary,
+    SourceResolution,
+    SourceUnique,
 )
-from ..constants import DEFAULT_QUERY_PRIORITY
-from ..exceptions import StorageNotInitializedError
+from ..constants import CUSTOM_CHUNK_PATCH_METADATA_KEY, DEFAULT_QUERY_PRIORITY
+from ..exceptions import (
+    SourceConflictRepairCASError,
+    StorageControlPlaneError,
+    StorageNotInitializedError,
+    StorageRecordNotFoundError,
+)
 from ..kg.shared_storage import get_data_init_lock, get_namespace_lock
 from ..types import KnowledgeGraph, KnowledgeGraphEdge, KnowledgeGraphNode
 from ..utils import (
@@ -418,6 +437,10 @@ async def _fetch_rows_by_ids(
 class LanceDBKVStorage(BaseKVStorage):
     """Key-value storage: JSON payload per id, workspace-prefixed table."""
 
+    # Every read goes straight to the embedded table with no error-swallowing
+    # path: a miss is a confirmed absence and any I/O failure propagates.
+    supports_strict_point_reads: ClassVar[bool] = True
+
     def __post_init__(self):
         self.workspace = self.workspace or ""
         validate_workspace(self.workspace)
@@ -462,6 +485,15 @@ class LanceDBKVStorage(BaseKVStorage):
         if not rows:
             return None
         return self._format_record(id, rows[0].get("payload"))
+
+    async def get_by_id_strict(self, id: str) -> dict[str, Any] | None:
+        """Strict point read: complete-or-raise (base contract).
+
+        ``get_by_id`` is already strict on this backend — the scan has no
+        ``except`` that could turn an I/O failure into a miss — so the strict
+        surface is the same call rather than a separate code path.
+        """
+        return await self.get_by_id(id)
 
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
         if not ids:
@@ -1509,6 +1541,11 @@ class LanceDBGraphStorage(BaseGraphStorage):
 class LanceDBDocStatusStorage(DocStatusStorage):
     """Document status storage with typed columns for status/dedup lookups."""
 
+    # Same rationale as LanceDBKVStorage: reads have no error-swallowing path.
+    supports_strict_point_reads: ClassVar[bool] = True
+
+    _CONFLICT_SAMPLE_CAP: ClassVar[int] = 32
+
     def __post_init__(self):
         self.workspace = self.workspace or ""
         validate_workspace(self.workspace)
@@ -1561,6 +1598,25 @@ class LanceDBDocStatusStorage(DocStatusStorage):
         rows = await _fetch_rows_by_ids(self._table(), list(keys), columns=["id"])
         return keys - {row["id"] for row in rows}
 
+    @staticmethod
+    def _status_row(doc_id: str, record: dict[str, Any]) -> dict[str, Any]:
+        """Project a full record into one table row.
+
+        The typed columns are a projection of the payload and every write path
+        MUST build them here — a column that drifts from the payload silently
+        corrupts the pushed-down status/file_path/content_hash filters.
+        """
+        return {
+            "id": doc_id,
+            "status": _status_value(record.get("status")),
+            # Normalize like _prepare_doc_status_data's read path so the
+            # typed column agrees with the payload's normalized file_path.
+            "file_path": record.get("file_path") or "no-file-path",
+            "track_id": record.get("track_id"),
+            "content_hash": record.get("content_hash"),
+            "payload": _json_dumps(record),
+        }
+
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
         if not data:
             return
@@ -1569,18 +1625,7 @@ class LanceDBDocStatusStorage(DocStatusStorage):
         for i, (key, value) in enumerate(data.items(), 1):
             record = dict(value)
             record.setdefault("chunks_list", [])
-            rows.append(
-                {
-                    "id": key,
-                    "status": _status_value(record.get("status")),
-                    # Normalize like _prepare_doc_status_data's read path so the
-                    # typed column agrees with the payload's normalized file_path.
-                    "file_path": record.get("file_path") or "no-file-path",
-                    "track_id": record.get("track_id"),
-                    "content_hash": record.get("content_hash"),
-                    "payload": _json_dumps(record),
-                }
-            )
+            rows.append(self._status_row(key, record))
             await _cooperative_yield(i)
         async with self._client.table_lock(self._table_name):
             await (
@@ -1680,6 +1725,432 @@ class LanceDBDocStatusStorage(DocStatusStorage):
         where = _sql_in("status", [_status_value(status) for status in statuses])
         rows = await _fetch_rows(self._table(), where=where, columns=["id", "payload"])
         return self._rows_to_statuses(rows, strict=strict)
+
+    # ------------------------------------------------------------------
+    # Bounded scheduling contract (keyset pages, strict batch reads and
+    # typed source resolution). See DocStatusStorage for the contracts.
+    # ------------------------------------------------------------------
+
+    async def get_by_id_strict(self, id: str) -> dict[str, Any] | None:
+        """Strict point read: complete-or-raise (base contract).
+
+        ``get_by_id`` has no ``except`` that could mask an I/O failure as a
+        miss, so it already satisfies the strict contract.
+        """
+        return await self.get_by_id(id)
+
+    @staticmethod
+    def _row_sort_key(doc_id: str, record: dict[str, Any]) -> tuple[str, str]:
+        """(created_at, id) keyset key. A missing/non-string created_at sorts
+        deterministically first as "" — such legacy rows stay reachable and are
+        consumed (skipped or raised per strictness) without moving mid-sweep."""
+        created = record.get("created_at")
+        return (created if isinstance(created, str) else "", doc_id)
+
+    @staticmethod
+    def _encode_cursor(key: tuple[str, str]) -> str:
+        return json.dumps(list(key), ensure_ascii=False)
+
+    @staticmethod
+    def _decode_cursor(opaque: str) -> tuple[str, str]:
+        try:
+            created, doc_id = json.loads(opaque)
+            if not isinstance(created, str) or not isinstance(doc_id, str):
+                raise ValueError("cursor fields must be strings")
+        except (ValueError, TypeError) as e:
+            raise StorageControlPlaneError(
+                f"Malformed scheduling cursor for LanceDBDocStatusStorage: {e}"
+            ) from e
+        return (created, doc_id)
+
+    @staticmethod
+    def _is_duplicate_record(record: Any) -> bool:
+        """True for duplicate-attempt marker rows: ``metadata.is_duplicate``."""
+        if not isinstance(record, dict):
+            return False
+        metadata = record.get("metadata")
+        return bool(isinstance(metadata, dict) and metadata.get("is_duplicate"))
+
+    def _scheduling_record_from_payload(
+        self, doc_id: str, record: dict[str, Any], *, strict: bool
+    ) -> DocSchedulingRecord | None:
+        """Project one decoded payload; strict raises on an unusable row while
+        relaxed returns None (the caller still counts the row as consumed)."""
+        try:
+            raw_status = record["status"]
+            status = (
+                raw_status
+                if isinstance(raw_status, DocStatus)
+                else DocStatus(raw_status)
+            )
+            created_at = record["created_at"]
+            updated_at = record.get("updated_at", created_at)
+            if not isinstance(created_at, str) or not isinstance(updated_at, str):
+                raise TypeError("created_at/updated_at must be strings")
+            metadata = record.get("metadata")
+            return DocSchedulingRecord(
+                id=doc_id,
+                status=status,
+                created_at=created_at,
+                updated_at=updated_at,
+                file_path=record.get("file_path") or "no-file-path",
+                track_id=record.get("track_id"),
+                has_custom_chunk_journal=isinstance(metadata, dict)
+                and isinstance(metadata.get(CUSTOM_CHUNK_PATCH_METADATA_KEY), dict),
+            )
+        except (KeyError, TypeError, ValueError) as e:
+            logger.error(f"[{self.workspace}] Unusable scheduling row {doc_id}: {e}")
+            if strict:
+                raise
+            return None
+
+    async def get_docs_by_statuses_page(
+        self,
+        statuses: list[DocStatus],
+        *,
+        limit: int,
+        position: CursorPosition = CURSOR_START,
+        strict: bool = False,
+    ) -> DocStatusPage:
+        """Bounded keyset page over the requested statuses.
+
+        The status filter is pushed into the scan (``status`` is a typed
+        column), but ``created_at`` lives inside the JSON ``payload`` and is
+        therefore not a filterable column: candidate selection re-scans the
+        matching rows each page and bounds the page with a heap
+        (``heapq.nsmallest``), so page memory is O(limit) while the candidate
+        scan is O(rows in the swept statuses) — the same documented boundary
+        the JSON backend carries, and the reason this backend is embedded-scale.
+
+        Consumed-position contract: every selected candidate is consumed —
+        returned, or skipped as unusable in relaxed mode — so the cursor
+        advances past a fully-filtered page instead of re-reading it; fewer
+        candidates than ``limit`` proves exhaustion (CURSOR_END).
+        """
+        if limit <= 0:
+            raise ValueError(f"page limit must be positive, got {limit}")
+        if not statuses or position is CURSOR_END:
+            return DocStatusPage(docs={}, next_position=CURSOR_END)
+        table = self._table()
+        last_key: tuple[str, str] | None = None
+        if isinstance(position, CursorAfter):
+            last_key = self._decode_cursor(position.opaque)
+        where = _sql_in("status", [_status_value(status) for status in statuses])
+        rows = await _fetch_rows(table, where=where, columns=["id", "payload"])
+
+        def _candidates():
+            for row in rows:
+                doc_id = row["id"]
+                record = _json_loads(row.get("payload"))
+                key = self._row_sort_key(doc_id, record)
+                if last_key is not None and key <= last_key:
+                    continue
+                yield key, doc_id, record
+
+        selected = heapq.nsmallest(limit, _candidates(), key=lambda t: t[0])
+        docs: dict[str, DocSchedulingRecord] = {}
+        for _key, doc_id, record in selected:
+            scheduling_record = self._scheduling_record_from_payload(
+                doc_id, record, strict=strict
+            )
+            if scheduling_record is not None:
+                docs[doc_id] = scheduling_record  # relaxed skip is still consumed
+        if len(selected) < limit:
+            next_position: CursorPosition = CURSOR_END
+        else:
+            next_position = CursorAfter(self._encode_cursor(selected[-1][0]))
+        return DocStatusPage(docs=docs, next_position=next_position)
+
+    async def get_docs_by_ids(
+        self,
+        doc_ids: Sequence[str],
+        *,
+        strict: bool = False,
+    ) -> dict[str, DocSchedulingRecord]:
+        """Batch strict read of scheduling records (see base contract).
+
+        ``_fetch_rows_by_ids`` gathers every id chunk and re-raises on any
+        chunk failure, so a partial mapping can never be returned; an id that
+        is simply absent from the result is a confirmed absence.
+        """
+        if not doc_ids:
+            return {}
+        rows = await _fetch_rows_by_ids(
+            self._table(), list(doc_ids), columns=["id", "payload"]
+        )
+        result: dict[str, DocSchedulingRecord] = {}
+        for row in rows:
+            doc_id = row["id"]
+            record = self._scheduling_record_from_payload(
+                doc_id, _json_loads(row.get("payload")), strict=strict
+            )
+            if record is not None:
+                result[doc_id] = record
+        return result
+
+    async def get_full_docs_by_ids(
+        self,
+        doc_ids: Sequence[str],
+        *,
+        strict: bool = False,
+    ) -> dict[str, DocProcessingStatus]:
+        """Batch hydration to FULL DocProcessingStatus (see base contract).
+
+        Reuses ``_build_doc_status`` — the same raw → status normalisation as
+        ``get_docs_by_statuses`` — so a row hydrates identically on both paths.
+        """
+        if not doc_ids:
+            return {}
+        rows = await _fetch_rows_by_ids(
+            self._table(), list(doc_ids), columns=["id", "payload"]
+        )
+        return self._rows_to_statuses(rows, strict=strict)
+
+    async def count_docs_by_statuses(
+        self, statuses: list[DocStatus], *, strict: bool = True
+    ) -> int:
+        """Fail-closed status count, pushed down to ``count_rows``.
+
+        Admission control treats an error as "refuse", never as "capacity
+        available", so the count either is accurate or the call raises.
+        """
+        if not statuses:
+            return 0
+        where = _sql_in("status", [_status_value(status) for status in statuses])
+        return await self._table().count_rows(where)
+
+    async def update_doc_status_fields(
+        self,
+        doc_id: str,
+        fields: dict[str, Any],
+        *,
+        missing_ok: bool = False,
+    ) -> None:
+        """Targeted field update that keeps the typed columns in step.
+
+        The typed columns are a projection of the payload, so they are
+        recomputed from the merged record inside the table lock — otherwise a
+        status update would leave the ``status`` column disagreeing with the
+        payload and corrupt every pushed-down filter.
+        """
+        if "created_at" in fields:
+            raise ValueError(
+                "created_at is an immutable scheduling sort key and cannot "
+                "be changed via update_doc_status_fields"
+            )
+        table = self._table()
+        async with self._client.table_lock(self._table_name):
+            rows = await _fetch_rows(
+                table,
+                where=f"id = {_sql_quote(doc_id)}",
+                columns=["id", "payload"],
+                limit=1,
+            )
+            if not rows:
+                if missing_ok:
+                    return
+                raise StorageRecordNotFoundError(doc_id)
+            merged = {**_json_loads(rows[0].get("payload")), **fields}
+            merged.pop("_id", None)
+            await (
+                table.merge_insert("id")
+                .when_matched_update_all()
+                .execute([self._status_row(doc_id, merged)])
+            )
+            self._client.bump_writes(self._table_name)
+
+    async def _primary_candidates(self, canonical_source_key: str) -> list[str]:
+        """Sorted primary (non-duplicate) doc IDs for a canonical source key.
+
+        ``file_path`` is a typed column, so the candidate set is narrowed by
+        the scan and only the duplicate-marker test needs the payload.
+        """
+        rows = await _fetch_rows(
+            self._table(),
+            where=f"file_path = {_sql_quote(canonical_source_key)}",
+            columns=["id", "payload"],
+        )
+        return sorted(
+            row["id"]
+            for row in rows
+            if not self._is_duplicate_record(_json_loads(row.get("payload")))
+        )
+
+    async def resolve_doc_source_strict(
+        self, canonical_source_key: str
+    ) -> SourceResolution:
+        """Typed source resolution (see base contract).
+
+        Fail-closed by construction: the scan raises on any I/O failure rather
+        than reporting ``SourceAbsent``, which enqueue would read as "confirmed
+        new" and use to mint a duplicate row.
+        """
+        if not canonical_source_key or canonical_source_key == "unknown_source":
+            return SourceAbsent()
+        rows = await _fetch_rows(
+            self._table(),
+            where=f"file_path = {_sql_quote(canonical_source_key)}",
+            columns=["id", "payload"],
+        )
+        candidates: list[tuple[str, dict[str, Any]]] = []
+        for row in rows:
+            record = _json_loads(row.get("payload"))
+            if self._is_duplicate_record(record):
+                continue
+            candidates.append((row["id"], record))
+            if len(candidates) >= 2:
+                break  # "at least two" is all a Conflict needs
+        if not candidates:
+            return SourceAbsent()
+        if len(candidates) == 1:
+            doc_id, record = candidates[0]
+            return SourceUnique(
+                doc_id=doc_id,
+                doc=self._scheduling_record_from_raw(doc_id, record),
+            )
+        return SourceConflict(
+            candidate_count=None,
+            sample_doc_ids=tuple(sorted(doc_id for doc_id, _ in candidates)),
+        )
+
+    @staticmethod
+    def _decode_conflict_cursor(opaque: str) -> str:
+        try:
+            key = json.loads(opaque)
+            if not isinstance(key, str):
+                raise ValueError("conflict cursor must be a string")
+        except (ValueError, TypeError) as e:
+            raise StorageControlPlaneError(
+                f"Malformed source-conflict cursor for LanceDBDocStatusStorage: {e}"
+            ) from e
+        return key
+
+    async def list_source_conflicts_page(
+        self,
+        *,
+        limit: int,
+        position: CursorPosition = CURSOR_START,
+    ) -> SourceConflictPage:
+        """Page canonical source keys with >1 primary candidate (see base)."""
+        if limit <= 0:
+            raise ValueError(f"page limit must be positive, got {limit}")
+        if position is CURSOR_END:
+            return SourceConflictPage(conflicts=(), next_position=CURSOR_END)
+        last_key: str | None = None
+        if isinstance(position, CursorAfter):
+            last_key = self._decode_conflict_cursor(position.opaque)
+        rows = await _fetch_rows(self._table(), columns=["id", "file_path", "payload"])
+        groups: dict[str, list[str]] = {}
+        for row in rows:
+            file_path = row.get("file_path")
+            if not isinstance(file_path, str) or file_path in (
+                "",
+                "unknown_source",
+                "no-file-path",
+            ):
+                continue
+            if self._is_duplicate_record(_json_loads(row.get("payload"))):
+                continue
+            groups.setdefault(file_path, []).append(row["id"])
+        conflict_keys = sorted(k for k, v in groups.items() if len(v) >= 2)
+        page_keys = [k for k in conflict_keys if last_key is None or k > last_key][
+            :limit
+        ]
+        conflicts = tuple(
+            SourceConflictSummary(
+                canonical_source_key=k,
+                candidate_count=len(groups[k]),
+                sample_doc_ids=tuple(sorted(groups[k])[: self._CONFLICT_SAMPLE_CAP]),
+            )
+            for k in page_keys
+        )
+        if len(page_keys) < limit:
+            next_position: CursorPosition = CURSOR_END
+        else:
+            next_position = CursorAfter(json.dumps(page_keys[-1], ensure_ascii=False))
+        return SourceConflictPage(conflicts=conflicts, next_position=next_position)
+
+    @staticmethod
+    def _conflict_fingerprint(sorted_doc_ids: list[str]) -> str:
+        """Deterministic digest over candidate doc IDs in stable sort order."""
+        digest = hashlib.sha256()
+        for doc_id in sorted_doc_ids:
+            digest.update(doc_id.encode("utf-8"))
+            digest.update(b"\x00")
+        return digest.hexdigest()
+
+    async def repair_source_conflict(
+        self,
+        canonical_source_key: str,
+        *,
+        primary_doc_id: str,
+        expected_candidate_count: int,
+        expected_candidate_fingerprint: str,
+        dry_run: bool = True,
+    ) -> SourceConflictRepairResult:
+        """Demote all-but-one primary to duplicate, CAS-guarded (see base).
+
+        The per-table write lock makes the re-read + CAS + demotion atomic
+        against other writers in this process. It does NOT exclude a brand-new
+        primary for the same key — that phantom is the caller's to serialize
+        (see the base contract's note on ``source_conflict_repair_lock``).
+        """
+        table = self._table()
+        async with self._client.table_lock(self._table_name):
+            rows = await _fetch_rows(
+                table,
+                where=f"file_path = {_sql_quote(canonical_source_key)}",
+                columns=["id", "payload"],
+            )
+            records = {
+                row["id"]: record
+                for row in rows
+                if not self._is_duplicate_record(
+                    record := _json_loads(row.get("payload"))
+                )
+            }
+            candidates = sorted(records)
+            count = len(candidates)
+            fingerprint = self._conflict_fingerprint(candidates)
+            if primary_doc_id not in records:
+                raise ValueError(
+                    f"primary_doc_id {primary_doc_id!r} is not a current primary "
+                    f"candidate for {canonical_source_key!r}"
+                )
+            demoted = [d for d in candidates if d != primary_doc_id]
+            if not dry_run:
+                if (
+                    count != expected_candidate_count
+                    or fingerprint != expected_candidate_fingerprint
+                ):
+                    raise SourceConflictRepairCASError(
+                        f"[{self.workspace}] source-conflict repair CAS failed for "
+                        f"{canonical_source_key!r}: candidate set changed "
+                        f"(count {count} vs {expected_candidate_count})"
+                    )
+                updates = []
+                for doc_id in demoted:
+                    record = dict(records[doc_id])
+                    metadata = dict(record.get("metadata") or {})
+                    metadata["is_duplicate"] = True
+                    metadata["original_doc_id"] = primary_doc_id
+                    record["metadata"] = metadata
+                    updates.append(self._status_row(doc_id, record))
+                if updates:
+                    await (
+                        table.merge_insert("id")
+                        .when_matched_update_all()
+                        .execute(updates)
+                    )
+                    self._client.bump_writes(self._table_name)
+        return SourceConflictRepairResult(
+            canonical_source_key=canonical_source_key,
+            primary_doc_id=primary_doc_id,
+            candidate_count=count,
+            fingerprint=fingerprint,
+            demoted_sample_doc_ids=tuple(demoted[: self._CONFLICT_SAMPLE_CAP]),
+            committed=not dry_run,
+        )
 
     async def get_docs_by_track_id(
         self, track_id: str

--- a/lightrag/tools/README_CLEAN_LLM_QUERY_CACHE.md
+++ b/lightrag/tools/README_CLEAN_LLM_QUERY_CACHE.md
@@ -11,6 +11,7 @@ This tool cleans up LightRAG's LLM query cache from KV storage implementations. 
 3. **PGKVStorage** - PostgreSQL database storage
 4. **MongoKVStorage** - MongoDB database storage
 5. **OpenSearchKVStorage** - OpenSearch index storage
+6. **LanceDBKVStorage** - Embedded LanceDB storage (single-process: shut the LightRAG Server down before running this tool)
 
 ## Cache Types
 
@@ -304,6 +305,7 @@ The tool retrieves workspace in the following priority order:
    - MongoKVStorage: `MONGODB_WORKSPACE`
    - RedisKVStorage: `REDIS_WORKSPACE`
    - OpenSearchKVStorage: `OPENSEARCH_WORKSPACE`
+   - LanceDBKVStorage: `LANCEDB_WORKSPACE`
 
 2. **Generic workspace environment variable**
    - `WORKSPACE`

--- a/lightrag/tools/README_MIGRATE_LLM_CACHE.md
+++ b/lightrag/tools/README_MIGRATE_LLM_CACHE.md
@@ -11,6 +11,7 @@ This tool migrates LightRAG's LLM response cache between different KV storage im
 3. **PGKVStorage** - PostgreSQL database storage
 4. **MongoKVStorage** - MongoDB database storage
 5. **OpenSearchKVStorage** - OpenSearch index storage
+6. **LanceDBKVStorage** - Embedded LanceDB storage (single-process: shut the LightRAG Server down before running this tool)
 
 ## Cache Types
 
@@ -221,6 +222,7 @@ The tool retrieves workspace in the following priority order:
    - MongoKVStorage: `MONGODB_WORKSPACE`
    - RedisKVStorage: `REDIS_WORKSPACE`
    - OpenSearchKVStorage: `OPENSEARCH_WORKSPACE`
+   - LanceDBKVStorage: `LANCEDB_WORKSPACE`
 
 2. **Generic workspace environment variable**
    - `WORKSPACE`

--- a/lightrag/tools/README_REBUILD_VDB.md
+++ b/lightrag/tools/README_REBUILD_VDB.md
@@ -98,8 +98,11 @@ Menu options:
   vector record they previously lacked (improving their retrievability).
 - **Chunk enumeration is backend-specific.** `BaseKVStorage` has no key
   enumeration API, so the tool scans each KV backend directly (JsonKV,
-  Redis, PostgreSQL, MongoDB, OpenSearch). When a new KV backend is added,
-  `enumerate_kv_keys()` in `rebuild_vdb.py` must be extended.
+  Redis, PostgreSQL, MongoDB, OpenSearch, LanceDB). When a new KV backend is
+  added, `enumerate_kv_keys()` in `rebuild_vdb.py` must be extended.
+- **LanceDB is single-process.** The embedded LanceDB backend is fully
+  supported, but stop the LightRAG Server (and any other writer) before
+  running this tool against the same LanceDB directory.
 
 ## Library usage
 

--- a/lightrag/tools/clean_llm_query_cache.py
+++ b/lightrag/tools/clean_llm_query_cache.py
@@ -16,6 +16,7 @@ Supported KV Storage Types:
     - PGKVStorage
     - MongoKVStorage
     - OpenSearchKVStorage
+    - LanceDBKVStorage (embedded, single-process: shut the server down first)
 """
 
 import asyncio
@@ -49,6 +50,7 @@ STORAGE_TYPES = {
     "3": "PGKVStorage",
     "4": "MongoKVStorage",
     "5": "OpenSearchKVStorage",
+    "6": "LanceDBKVStorage",
 }
 
 # Workspace environment variable mapping
@@ -57,6 +59,7 @@ WORKSPACE_ENV_MAP = {
     "MongoKVStorage": "MONGODB_WORKSPACE",
     "RedisKVStorage": "REDIS_WORKSPACE",
     "OpenSearchKVStorage": "OPENSEARCH_WORKSPACE",
+    "LanceDBKVStorage": "LANCEDB_WORKSPACE",
 }
 
 # Query cache modes. Must cover every QueryParam.mode that reaches the LLM cache,
@@ -177,6 +180,10 @@ class CleanupTool:
                 )
             elif storage_name == "OpenSearchKVStorage":
                 return config.has_option("opensearch", "hosts")
+            elif storage_name == "LanceDBKVStorage":
+                # Embedded backend: works out of the box from working_dir,
+                # so no config.ini section is required.
+                return True
 
             return False
         except Exception:
@@ -245,6 +252,10 @@ class CleanupTool:
             from lightrag.kg.opensearch_impl import OpenSearchKVStorage
 
             return OpenSearchKVStorage
+        elif storage_name == "LanceDBKVStorage":
+            from lightrag.kg.lancedb_impl import LanceDBKVStorage
+
+            return LanceDBKVStorage
         else:
             raise ValueError(f"Unsupported storage type: {storage_name}")
 
@@ -422,6 +433,27 @@ class CleanupTool:
 
         return counts
 
+    async def count_query_caches_lancedb(self, storage) -> Dict[str, Dict[str, int]]:
+        """Count query caches in LanceDBKVStorage by mode and cache_type."""
+        counts = {mode: {"query": 0, "keywords": 0} for mode in QUERY_MODES}
+
+        print("Scanning LanceDB records...", end="", flush=True)
+        start_time = time.time()
+
+        for key in await storage.get_all_keys():
+            for mode in QUERY_MODES:
+                if key.startswith(f"{mode}:query:"):
+                    counts[mode]["query"] += 1
+                elif key.startswith(f"{mode}:keywords:"):
+                    counts[mode]["keywords"] += 1
+
+        elapsed = time.time() - start_time
+        if elapsed > 1:
+            print(f" (took {elapsed:.1f}s)", end="")
+        print()
+
+        return counts
+
     async def count_query_caches(
         self, storage, storage_name: str
     ) -> Dict[str, Dict[str, int]]:
@@ -444,6 +476,8 @@ class CleanupTool:
             return await self.count_query_caches_mongo(storage)
         elif storage_name == "OpenSearchKVStorage":
             return await self.count_query_caches_opensearch(storage)
+        elif storage_name == "LanceDBKVStorage":
+            return await self.count_query_caches_lancedb(storage)
         else:
             raise ValueError(f"Unsupported storage type: {storage_name}")
 
@@ -762,6 +796,66 @@ class CleanupTool:
                     f"{type(e).__name__}: {str(e)}"
                 )
 
+    async def delete_query_caches_lancedb(
+        self, storage, cleanup_type: str, stats: CleanupStats
+    ):
+        """Delete query caches from LanceDBKVStorage."""
+        keys_to_delete = []
+
+        for key in await storage.get_all_keys():
+            should_delete = False
+            for mode in QUERY_MODES:
+                if cleanup_type == "all":
+                    if key.startswith(f"{mode}:query:") or key.startswith(
+                        f"{mode}:keywords:"
+                    ):
+                        should_delete = True
+                elif cleanup_type == "query":
+                    if key.startswith(f"{mode}:query:"):
+                        should_delete = True
+                elif cleanup_type == "keywords":
+                    if key.startswith(f"{mode}:keywords:"):
+                        should_delete = True
+
+            if should_delete:
+                keys_to_delete.append(key)
+
+        total_keys = len(keys_to_delete)
+        stats.total_batches = (total_keys + self.batch_size - 1) // self.batch_size
+
+        print("\n=== Starting Cleanup ===")
+        print(
+            f"💡 Processing {self.batch_size:,} records at a time from LanceDBKVStorage\n"
+        )
+
+        for batch_idx in range(stats.total_batches):
+            start_idx = batch_idx * self.batch_size
+            end_idx = min((batch_idx + 1) * self.batch_size, total_keys)
+            batch_keys = keys_to_delete[start_idx:end_idx]
+
+            try:
+                await storage.delete(batch_keys)
+                stats.successful_batches += 1
+                stats.successfully_deleted += len(batch_keys)
+
+                progress = (stats.successfully_deleted / total_keys) * 100
+                bar_length = 20
+                filled_length = int(
+                    bar_length * stats.successfully_deleted // total_keys
+                )
+                bar = "█" * filled_length + "░" * (bar_length - filled_length)
+
+                print(
+                    f"Batch {batch_idx + 1}/{stats.total_batches}: {bar} "
+                    f"{stats.successfully_deleted:,}/{total_keys:,} ({progress:.1f}%) ✓"
+                )
+            except Exception as e:
+                stats.add_error(batch_idx + 1, e, len(batch_keys))
+                print(
+                    f"Batch {batch_idx + 1}/{stats.total_batches}: ✗ FAILED - "
+                    f"{type(e).__name__}: {str(e)}"
+                )
+
     async def delete_query_caches(
         self, storage, storage_name: str, cleanup_type: str, stats: CleanupStats
     ):
@@ -783,6 +877,8 @@ class CleanupTool:
             await self.delete_query_caches_mongo(storage, cleanup_type, stats)
         elif storage_name == "OpenSearchKVStorage":
             await self.delete_query_caches_opensearch(storage, cleanup_type, stats)
+        elif storage_name == "LanceDBKVStorage":
+            await self.delete_query_caches_lancedb(storage, cleanup_type, stats)
         else:
             raise ValueError(f"Unsupported storage type: {storage_name}")
 
@@ -978,13 +1074,17 @@ class CleanupTool:
 
         storage_name = STORAGE_TYPES[choice]
 
-        # Special warning for JsonKVStorage about concurrent access
-        if storage_name == "JsonKVStorage":
+        # Special warning for single-process backends about concurrent access.
+        # JsonKVStorage (in-memory) and LanceDBKVStorage (embedded) both write
+        # to local files that a running server cannot share safely.
+        if storage_name in ("JsonKVStorage", "LanceDBKVStorage"):
             print("\n" + "=" * 60)
-            print(f"{BOLD_RED}⚠️  IMPORTANT WARNING - JsonKVStorage Concurrency{RESET}")
+            print(
+                f"{BOLD_RED}⚠️  IMPORTANT WARNING - {storage_name} Concurrency{RESET}"
+            )
             print("=" * 60)
-            print("\nJsonKVStorage is an in-memory database that does NOT support")
-            print("concurrent access to the same file by multiple programs.")
+            print(f"\n{storage_name} is a single-process backend that does NOT")
+            print("support concurrent access to the same files by multiple programs.")
             print("\nBefore proceeding, please ensure that:")
             print("  • LightRAG Server is completely shut down")
             print("  • No other programs are accessing the storage files")
@@ -1001,7 +1101,7 @@ class CleanupTool:
                 )
                 return None, None, None
 
-            print("✓ Proceeding with JsonKVStorage cleanup...")
+            print(f"✓ Proceeding with {storage_name} cleanup...")
 
         # Check configuration (warnings only, doesn't block)
         print("\nChecking configuration...")
@@ -1047,6 +1147,9 @@ class CleanupTool:
             elif storage_name == "OpenSearchKVStorage":
                 print("     [opensearch]")
                 print("     hosts = localhost:9200")
+            elif storage_name == "LanceDBKVStorage":
+                print("     [lancedb]")
+                print("     uri = ./rag_storage/lancedb  # optional; defaults to WORKING_DIR/lancedb")
 
             return None, None, None
 

--- a/lightrag/tools/clean_llm_query_cache.py
+++ b/lightrag/tools/clean_llm_query_cache.py
@@ -1079,9 +1079,7 @@ class CleanupTool:
         # to local files that a running server cannot share safely.
         if storage_name in ("JsonKVStorage", "LanceDBKVStorage"):
             print("\n" + "=" * 60)
-            print(
-                f"{BOLD_RED}⚠️  IMPORTANT WARNING - {storage_name} Concurrency{RESET}"
-            )
+            print(f"{BOLD_RED}⚠️  IMPORTANT WARNING - {storage_name} Concurrency{RESET}")
             print("=" * 60)
             print(f"\n{storage_name} is a single-process backend that does NOT")
             print("support concurrent access to the same files by multiple programs.")
@@ -1149,7 +1147,9 @@ class CleanupTool:
                 print("     hosts = localhost:9200")
             elif storage_name == "LanceDBKVStorage":
                 print("     [lancedb]")
-                print("     uri = ./rag_storage/lancedb  # optional; defaults to WORKING_DIR/lancedb")
+                print(
+                    "     uri = ./rag_storage/lancedb  # optional; defaults to WORKING_DIR/lancedb"
+                )
 
             return None, None, None
 

--- a/lightrag/tools/migrate_llm_cache.py
+++ b/lightrag/tools/migrate_llm_cache.py
@@ -1259,7 +1259,9 @@ class MigrationTool:
                 print("     hosts = localhost:9200")
             elif storage_name == "LanceDBKVStorage":
                 print("     [lancedb]")
-                print("     uri = ./rag_storage/lancedb  # optional; defaults to WORKING_DIR/lancedb")
+                print(
+                    "     uri = ./rag_storage/lancedb  # optional; defaults to WORKING_DIR/lancedb"
+                )
 
             return None, None, None, 0
 

--- a/lightrag/tools/migrate_llm_cache.py
+++ b/lightrag/tools/migrate_llm_cache.py
@@ -17,6 +17,7 @@ Supported KV Storage Types:
     - PGKVStorage
     - MongoKVStorage
     - OpenSearchKVStorage
+    - LanceDBKVStorage (embedded, single-process: shut the server down first)
 """
 
 import asyncio
@@ -52,6 +53,7 @@ STORAGE_TYPES = {
     "3": "PGKVStorage",
     "4": "MongoKVStorage",
     "5": "OpenSearchKVStorage",
+    "6": "LanceDBKVStorage",
 }
 
 # Workspace environment variable mapping
@@ -60,6 +62,7 @@ WORKSPACE_ENV_MAP = {
     "MongoKVStorage": "MONGODB_WORKSPACE",
     "RedisKVStorage": "REDIS_WORKSPACE",
     "OpenSearchKVStorage": "OPENSEARCH_WORKSPACE",
+    "LanceDBKVStorage": "LANCEDB_WORKSPACE",
 }
 
 # Default batch size for migration
@@ -186,6 +189,10 @@ class MigrationTool:
                 )
             elif storage_name == "OpenSearchKVStorage":
                 return config.has_option("opensearch", "hosts")
+            elif storage_name == "LanceDBKVStorage":
+                # Embedded backend: works out of the box from working_dir,
+                # so no config.ini section is required.
+                return True
 
             return False
         except Exception:
@@ -282,6 +289,10 @@ class MigrationTool:
             from lightrag.kg.opensearch_impl import OpenSearchKVStorage
 
             return OpenSearchKVStorage
+        elif storage_name == "LanceDBKVStorage":
+            from lightrag.kg.lancedb_impl import LanceDBKVStorage
+
+            return LanceDBKVStorage
         else:
             raise ValueError(f"Unsupported storage type: {storage_name}")
 
@@ -530,6 +541,34 @@ class MigrationTool:
 
         return cache_data
 
+    async def get_default_caches_lancedb(
+        self, storage, batch_size: int = 1000
+    ) -> Dict[str, Any]:
+        """Get default caches from LanceDBKVStorage.
+
+        The table name is workspace-prefixed, so enumerating ids already
+        scopes the scan to this workspace. The synthetic ``_id`` field added
+        on read is stripped so it is not carried into the target payload.
+        """
+        cache_data = {}
+
+        keys = [
+            key
+            for key in await storage.get_all_keys()
+            if key.startswith("default:extract:") or key.startswith("default:summary:")
+        ]
+
+        for offset in range(0, len(keys), batch_size):
+            batch_keys = keys[offset : offset + batch_size]
+            records = await storage.get_by_ids(batch_keys)
+            for key, record in zip(batch_keys, records):
+                if record is not None:
+                    entry = dict(record)
+                    entry.pop("_id", None)
+                    cache_data[key] = entry
+
+        return cache_data
+
     async def get_default_caches(self, storage, storage_name: str) -> Dict[str, Any]:
         """Get default caches from any storage type
 
@@ -550,6 +589,8 @@ class MigrationTool:
             return await self.get_default_caches_mongo(storage)
         elif storage_name == "OpenSearchKVStorage":
             return await self.get_default_caches_opensearch(storage)
+        elif storage_name == "LanceDBKVStorage":
+            return await self.get_default_caches_lancedb(storage)
         else:
             raise ValueError(f"Unsupported storage type: {storage_name}")
 
@@ -674,6 +715,24 @@ class MigrationTool:
 
         return count
 
+    async def count_default_caches_lancedb(self, storage) -> int:
+        """Count default caches in LanceDBKVStorage."""
+        print("Scanning LanceDB records...", end="", flush=True)
+        start_time = time.time()
+
+        count = sum(
+            1
+            for key in await storage.get_all_keys()
+            if key.startswith("default:extract:") or key.startswith("default:summary:")
+        )
+
+        elapsed = time.time() - start_time
+        if elapsed > 1:
+            print(f" (took {elapsed:.1f}s)", end="")
+        print()
+
+        return count
+
     async def count_default_caches(self, storage, storage_name: str) -> int:
         """Count default caches from any storage type efficiently
 
@@ -694,6 +753,8 @@ class MigrationTool:
             return await self.count_default_caches_mongo(storage)
         elif storage_name == "OpenSearchKVStorage":
             return await self.count_default_caches_opensearch(storage)
+        elif storage_name == "LanceDBKVStorage":
+            return await self.count_default_caches_lancedb(storage)
         else:
             raise ValueError(f"Unsupported storage type: {storage_name}")
 
@@ -912,6 +973,34 @@ class MigrationTool:
         if batch:
             yield batch
 
+    async def stream_default_caches_lancedb(self, storage, batch_size: int):
+        """Stream default caches from LanceDBKVStorage - yields batches.
+
+        The synthetic ``_id`` field added on read is stripped so it is not
+        carried into the target payload.
+        """
+        keys = [
+            key
+            for key in await storage.get_all_keys()
+            if key.startswith("default:extract:") or key.startswith("default:summary:")
+        ]
+
+        for offset in range(0, len(keys), batch_size):
+            batch_keys = keys[offset : offset + batch_size]
+            records = await storage.get_by_ids(batch_keys)
+
+            batch = {}
+            for key, record in zip(batch_keys, records):
+                if record is not None:
+                    entry = dict(record)
+                    entry.pop("_id", None)
+                    batch[key] = entry
+
+            if batch:
+                yield batch
+
+            await asyncio.sleep(0)
+
     async def stream_default_caches(
         self, storage, storage_name: str, batch_size: int = None
     ):
@@ -944,6 +1033,9 @@ class MigrationTool:
             async for batch in self.stream_default_caches_opensearch(
                 storage, batch_size
             ):
+                yield batch
+        elif storage_name == "LanceDBKVStorage":
+            async for batch in self.stream_default_caches_lancedb(storage, batch_size):
                 yield batch
         else:
             raise ValueError(f"Unsupported storage type: {storage_name}")
@@ -1129,6 +1221,13 @@ class MigrationTool:
                     else "config.ini or defaults"
                 )
                 print(f"- Configuration Source: {config_source}")
+            elif storage_name == "LanceDBKVStorage":
+                config_source = (
+                    "environment variable"
+                    if "LANCEDB_URI" in os.environ
+                    else "config.ini or WORKING_DIR default"
+                )
+                print(f"- Configuration Source: {config_source}")
 
         except Exception as e:
             print(f"✗ Initialization failed: {e}")
@@ -1158,6 +1257,9 @@ class MigrationTool:
             elif storage_name == "OpenSearchKVStorage":
                 print("     [opensearch]")
                 print("     hosts = localhost:9200")
+            elif storage_name == "LanceDBKVStorage":
+                print("     [lancedb]")
+                print("     uri = ./rag_storage/lancedb  # optional; defaults to WORKING_DIR/lancedb")
 
             return None, None, None, 0
 

--- a/lightrag/tools/rebuild_vdb.py
+++ b/lightrag/tools/rebuild_vdb.py
@@ -408,6 +408,11 @@ async def enumerate_kv_keys(kv) -> List[str]:
             keys.extend(hit["_id"] for hit in hits)
         return keys
 
+    if storage_name == "LanceDBKVStorage":
+        # Table name is workspace-prefixed, so this scan is already
+        # workspace-scoped. LanceDB is single-process: stop the server first.
+        return await kv.get_all_keys()
+
     raise ValueError(f"Unsupported KV storage type for key enumeration: {storage_name}")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ offline-storage = [
     "pgvector>=0.4.2,<1.0.0",
     "qdrant-client>=1.11.0,<2.0.0",
     "opensearch-py>=3.0.0,<4.0.0",
+    "lancedb>=0.34.0,<1.0.0",
 ]
 
 offline-llm = [

--- a/requirements-offline-storage.txt
+++ b/requirements-offline-storage.txt
@@ -10,6 +10,7 @@
 # Storage backend dependencies (with version constraints matching pyproject.toml)
 asyncpg>=0.31.0,<1.0.0
 faiss-cpu>=1.7.0,<2.0.0
+lancedb>=0.34.0,<1.0.0
 neo4j>=5.0.0,<7.0.0
 opensearch-py>=3.0.0,<4.0.0
 pgvector>=0.4.2,<1.0.0

--- a/requirements-offline.txt
+++ b/requirements-offline.txt
@@ -13,6 +13,7 @@ asyncpg>=0.31.0,<1.0.0
 bcrypt>=4.0.0
 google-api-core>=2.0.0,<3.0.0
 google-genai>=1.0.0,<3.0.0
+lancedb>=0.34.0,<1.0.0
 llama-index>=0.14.0,<1.0.0
 llama-index-llms-openai>=0.6.12
 neo4j>=5.0.0,<7.0.0

--- a/tests/kg/conftest_scheduling_backends.py
+++ b/tests/kg/conftest_scheduling_backends.py
@@ -96,6 +96,33 @@ def _ensure_shared_data() -> None:
     initialize_share_data()
 
 
+def _lancedb_importable() -> bool:
+    """LanceDB is embedded (no service), but it is an optional dependency."""
+    from importlib.util import find_spec
+
+    return find_spec("lancedb") is not None
+
+
+async def _build_lancedb(tmp_path) -> Any:
+    from lightrag.kg.lancedb_impl import LanceDBDocStatusStorage
+
+    _ensure_shared_data()
+
+    with _workspace_env_isolated("LANCEDB_WORKSPACE"):
+        # A per-test database directory: the contract covers deletes, source
+        # multimaps and drop(), so a shared directory would leak rows between
+        # cases exactly as a shared workspace would.
+        os.environ["LANCEDB_URI"] = str(tmp_path / "lancedb")
+        storage = LanceDBDocStatusStorage(
+            namespace="doc_status",
+            global_config={"working_dir": str(tmp_path)},
+            embedding_func=_DummyEmbeddingFunc(),
+            workspace=_unique_workspace(),
+        )
+        await storage.initialize()
+    return storage
+
+
 async def _build_json(tmp_path) -> Any:
     from lightrag.kg.json_doc_status_impl import JsonDocStatusStorage
 
@@ -225,11 +252,21 @@ _JSON_BACKEND = BackendSpec(
     unavailable_hint="never unavailable",
 )
 
+# Embedded like JSON — no service to probe — so it belongs in the default
+# offline suite; only its optional package can be missing.
+_LANCEDB_BACKEND = BackendSpec(
+    name="lancedb",
+    build=_build_lancedb,
+    probe=_lancedb_importable,
+    unavailable_hint="lancedb is not installed",
+)
+
 # Marked per PARAMETER, not per module: JSON needs no service, so it must run in
 # the default offline suite — a contract test that only executes behind
 # ``--run-integration`` would go stale between the runs that use it.
 BACKEND_PARAMS = [
     pytest.param(_JSON_BACKEND, id=_JSON_BACKEND.name),
+    pytest.param(_LANCEDB_BACKEND, id=_LANCEDB_BACKEND.name),
     *[
         pytest.param(
             spec,
@@ -240,4 +277,8 @@ BACKEND_PARAMS = [
     ],
 ]
 
-BACKEND_SPECS: tuple[BackendSpec, ...] = (_JSON_BACKEND, *_SERVICE_BACKENDS)
+BACKEND_SPECS: tuple[BackendSpec, ...] = (
+    _JSON_BACKEND,
+    _LANCEDB_BACKEND,
+    *_SERVICE_BACKENDS,
+)

--- a/tests/kg/lancedb_impl/conftest.py
+++ b/tests/kg/lancedb_impl/conftest.py
@@ -1,0 +1,100 @@
+"""Shared fixtures for LanceDB storage tests.
+
+All tests run against a real embedded LanceDB database in a pytest
+tmp_path — no mocking of the LanceDB client (same style as the other
+embedded backends: faiss/json/networkx).
+"""
+
+import hashlib
+
+import numpy as np
+import pytest
+
+lancedb = pytest.importorskip(
+    "lancedb", reason="lancedb is required for LanceDB storage tests"
+)
+
+from lightrag.kg.shared_storage import (  # noqa: E402
+    finalize_share_data,
+    initialize_share_data,
+)
+from lightrag.utils import EmbeddingFunc  # noqa: E402
+
+DIM = 16
+
+
+def text_vector(text: str, dim: int = DIM) -> np.ndarray:
+    """Deterministic direction-distinct vector per text (stable across runs).
+
+    md5-seeded so it does not depend on PYTHONHASHSEED; different texts get
+    near-orthogonal directions, identical texts identical vectors.
+    """
+    seed = int.from_bytes(hashlib.md5(text.encode("utf-8")).digest()[:4], "little")
+    rng = np.random.default_rng(seed)
+    return rng.standard_normal(dim).astype(np.float32)
+
+
+class CountingEmbed:
+    """Deterministic per-text embedding that records every call."""
+
+    def __init__(self, dim: int = DIM):
+        self.dim = dim
+        self.call_count = 0
+        self.embedded_texts: list[str] = []
+        self.document_texts: list[str] = []
+
+    async def __call__(self, texts, **kwargs):
+        self.call_count += 1
+        self.embedded_texts.extend(texts)
+        if kwargs.get("context") == "document":
+            self.document_texts.extend(texts)
+        return np.array([text_vector(t, self.dim) for t in texts])
+
+
+@pytest.fixture(autouse=True)
+def _shared_data():
+    finalize_share_data()
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
+@pytest.fixture(autouse=True)
+def _clean_lancedb_env(monkeypatch):
+    """Keep tests hermetic from developer/CI LANCEDB_* environment."""
+    for var in (
+        "LANCEDB_URI",
+        "LANCEDB_WORKSPACE",
+        "LANCEDB_READ_CONSISTENCY_INTERVAL",
+        "LANCEDB_ENABLE_FTS",
+        "LANCEDB_FTS_TOKENIZER",
+        "LANCEDB_OPTIMIZE_THRESHOLD",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture
+def counting_embed():
+    return CountingEmbed()
+
+
+@pytest.fixture
+def embedding_func(counting_embed):
+    # supports_asymmetric=True forwards the context= kwarg to CountingEmbed
+    # so tests can tell document embeddings from query embeddings apart.
+    return EmbeddingFunc(
+        embedding_dim=DIM,
+        max_token_size=512,
+        func=counting_embed,
+        supports_asymmetric=True,
+    )
+
+
+@pytest.fixture
+def global_config(tmp_path):
+    return {
+        "working_dir": str(tmp_path),
+        "embedding_batch_num": 4,
+        "max_graph_nodes": 1000,
+        "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+    }

--- a/tests/kg/lancedb_impl/test_lancedb_doc_status.py
+++ b/tests/kg/lancedb_impl/test_lancedb_doc_status.py
@@ -76,7 +76,9 @@ async def test_get_docs_by_status_returns_dataclasses(storage):
     assert isinstance(pending["doc-1"], DocProcessingStatus)
     assert pending["doc-1"].status == DocStatus.PENDING
 
-    several = await storage.get_docs_by_statuses([DocStatus.PROCESSED, DocStatus.FAILED])
+    several = await storage.get_docs_by_statuses(
+        [DocStatus.PROCESSED, DocStatus.FAILED]
+    )
     assert set(several) == {"doc-2", "doc-3"}
     assert several["doc-2"].chunks_count == 4
     assert several["doc-3"].error_msg == "boom"
@@ -176,7 +178,9 @@ async def test_get_docs_paginated(storage):
     asc, _ = await storage.get_docs_paginated(sort_direction="asc", page_size=10)
     assert asc[0][0] == "doc-0"
 
-    by_id, _ = await storage.get_docs_paginated(sort_field="id", sort_direction="asc", page_size=10)
+    by_id, _ = await storage.get_docs_paginated(
+        sort_field="id", sort_direction="asc", page_size=10
+    )
     assert by_id[0][0] == "doc-0"
     assert by_id[1][0] == "doc-1"
 

--- a/tests/kg/lancedb_impl/test_lancedb_doc_status.py
+++ b/tests/kg/lancedb_impl/test_lancedb_doc_status.py
@@ -1,0 +1,242 @@
+"""Unit tests for LanceDBDocStatusStorage."""
+
+import pytest
+
+pytest.importorskip("lancedb", reason="lancedb is required for LanceDB storage tests")
+
+from lightrag.base import DocProcessingStatus, DocStatus  # noqa: E402
+from lightrag.kg.lancedb_impl import LanceDBDocStatusStorage  # noqa: E402
+
+pytestmark = pytest.mark.offline
+
+
+def _make_storage(global_config, workspace="ws"):
+    return LanceDBDocStatusStorage(
+        namespace="doc_status",
+        workspace=workspace,
+        global_config=global_config,
+        embedding_func=None,
+    )
+
+
+def _doc(
+    status=DocStatus.PENDING,
+    file_path="doc.txt",
+    created_at="2024-01-01T00:00:00+00:00",
+    updated_at="2024-01-01T00:00:00+00:00",
+    **extra,
+):
+    return {
+        "status": status,
+        "content_summary": "summary",
+        "content_length": 100,
+        "file_path": file_path,
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "metadata": {},
+        "error_msg": None,
+        **extra,
+    }
+
+
+@pytest.fixture
+async def storage(global_config):
+    doc_status = _make_storage(global_config)
+    await doc_status.initialize()
+    yield doc_status
+    await doc_status.finalize()
+
+
+async def test_upsert_and_kv_surface(storage):
+    assert await storage.is_empty()
+    await storage.upsert({"doc-1": _doc(track_id="t1", content_hash="h1")})
+    raw = await storage.get_by_id("doc-1")
+    # get_by_id returns the RAW dict, not a DocProcessingStatus.
+    assert isinstance(raw, dict)
+    assert raw["status"] == "pending"
+    assert raw["chunks_list"] == []  # defaulted on upsert
+    records = await storage.get_by_ids(["doc-1", "missing"])
+    assert records[0]["content_summary"] == "summary"
+    assert records[1] is None
+    assert await storage.filter_keys({"doc-1", "doc-2"}) == {"doc-2"}
+    await storage.delete(["doc-1"])
+    assert await storage.get_by_id("doc-1") is None
+
+
+async def test_get_docs_by_status_returns_dataclasses(storage):
+    await storage.upsert(
+        {
+            "doc-1": _doc(status=DocStatus.PENDING),
+            "doc-2": _doc(status=DocStatus.PROCESSED, chunks_count=4),
+            "doc-3": _doc(status=DocStatus.FAILED, error_msg="boom"),
+        }
+    )
+    pending = await storage.get_docs_by_status(DocStatus.PENDING)
+    assert set(pending) == {"doc-1"}
+    assert isinstance(pending["doc-1"], DocProcessingStatus)
+    assert pending["doc-1"].status == DocStatus.PENDING
+
+    several = await storage.get_docs_by_statuses([DocStatus.PROCESSED, DocStatus.FAILED])
+    assert set(several) == {"doc-2", "doc-3"}
+    assert several["doc-2"].chunks_count == 4
+    assert several["doc-3"].error_msg == "boom"
+    assert await storage.get_docs_by_statuses([]) == {}
+
+
+async def test_doc_status_defaults_for_missing_fields(storage):
+    minimal = {
+        "status": DocStatus.PENDING,
+        "content_summary": "s",
+        "content_length": 1,
+        "created_at": "2024-01-01T00:00:00+00:00",
+        "updated_at": "2024-01-01T00:00:00+00:00",
+        # no file_path / metadata / error_msg / content (deprecated)
+        "content": "should be stripped",
+    }
+    await storage.upsert({"doc-1": minimal})
+    docs = await storage.get_docs_by_status(DocStatus.PENDING)
+    doc = docs["doc-1"]
+    assert doc.file_path == "no-file-path"
+    assert doc.metadata == {}
+    assert doc.error_msg is None
+
+
+async def test_missing_file_path_indexed_as_normalized(storage):
+    """Regression: the typed file_path column is normalized on write the same
+    way the read path normalizes it, so get_doc_by_file_path (a SQL filter on
+    the typed column) finds a doc upserted without a file_path.
+    """
+    await storage.upsert(
+        {
+            "doc-1": {
+                "status": DocStatus.PROCESSED,
+                "content_summary": "s",
+                "content_length": 1,
+                "created_at": "2024-01-01T00:00:00+00:00",
+                "updated_at": "2024-01-01T00:00:00+00:00",
+                # no file_path
+            }
+        }
+    )
+    found = await storage.get_doc_by_file_path("no-file-path")
+    assert found is not None
+    assert found["content_summary"] == "s"
+
+
+async def test_status_counts(storage):
+    await storage.upsert(
+        {
+            "doc-1": _doc(status=DocStatus.PENDING),
+            "doc-2": _doc(status=DocStatus.PENDING),
+            "doc-3": _doc(status=DocStatus.PROCESSED),
+        }
+    )
+    counts = await storage.get_status_counts()
+    assert counts["pending"] == 2
+    assert counts["processed"] == 1
+    assert counts["failed"] == 0  # all enum values present
+    all_counts = await storage.get_all_status_counts()
+    assert all_counts["all"] == 3
+
+
+async def test_get_docs_by_track_id(storage):
+    await storage.upsert(
+        {
+            "doc-1": _doc(track_id="upload-1"),
+            "doc-2": _doc(track_id="upload-1"),
+            "doc-3": _doc(track_id="upload-2"),
+        }
+    )
+    docs = await storage.get_docs_by_track_id("upload-1")
+    assert set(docs) == {"doc-1", "doc-2"}
+    assert await storage.get_docs_by_track_id("nope") == {}
+
+
+async def test_get_docs_paginated(storage):
+    await storage.upsert(
+        {
+            f"doc-{i}": _doc(
+                status=DocStatus.PENDING if i % 2 == 0 else DocStatus.PROCESSED,
+                updated_at=f"2024-01-{i + 1:02d}T00:00:00+00:00",
+                file_path=f"file-{i}.txt",
+            )
+            for i in range(15)
+        }
+    )
+    page, total = await storage.get_docs_paginated(page=1, page_size=10)
+    assert total == 15
+    assert len(page) == 10
+    # default sort: updated_at desc
+    assert page[0][0] == "doc-14"
+    assert isinstance(page[0][1], DocProcessingStatus)
+
+    page2, total = await storage.get_docs_paginated(page=2, page_size=10)
+    assert len(page2) == 5
+
+    asc, _ = await storage.get_docs_paginated(sort_direction="asc", page_size=10)
+    assert asc[0][0] == "doc-0"
+
+    by_id, _ = await storage.get_docs_paginated(sort_field="id", sort_direction="asc", page_size=10)
+    assert by_id[0][0] == "doc-0"
+    assert by_id[1][0] == "doc-1"
+
+    filtered, filtered_total = await storage.get_docs_paginated(
+        status_filter=DocStatus.PENDING, page_size=10
+    )
+    assert filtered_total == 8
+    assert all(doc.status == DocStatus.PENDING for _, doc in filtered)
+
+    multi, multi_total = await storage.get_docs_paginated(
+        status_filters=[DocStatus.PENDING, DocStatus.PROCESSED], page_size=200
+    )
+    assert multi_total == 15
+
+    # page/page_size clamping
+    clamped, _ = await storage.get_docs_paginated(page=0, page_size=1)
+    assert len(clamped) == 10  # page_size clamped up to 10
+
+
+async def test_file_path_and_content_hash_lookups(storage):
+    await storage.upsert(
+        {
+            "doc-1": _doc(file_path="report.pdf", content_hash="hash-1"),
+            "doc-2": _doc(file_path="notes.txt", content_hash="hash-2"),
+        }
+    )
+    found = await storage.get_doc_by_file_path("report.pdf")
+    assert found["content_hash"] == "hash-1"
+    assert await storage.get_doc_by_file_path("nope.pdf") is None
+
+    doc_id, doc = await storage.get_doc_by_file_basename("notes.txt")
+    assert doc_id == "doc-2"
+    assert doc["file_path"] == "notes.txt"
+    assert await storage.get_doc_by_file_basename("") is None
+    assert await storage.get_doc_by_file_basename("unknown_source") is None
+
+    doc_id, doc = await storage.get_doc_by_content_hash("hash-1")
+    assert doc_id == "doc-1"
+    assert await storage.get_doc_by_content_hash("") is None
+    assert await storage.get_doc_by_content_hash("nope") is None
+
+
+async def test_upsert_replaces_record(storage):
+    await storage.upsert({"doc-1": _doc(status=DocStatus.PENDING)})
+    await storage.upsert(
+        {"doc-1": _doc(status=DocStatus.PROCESSED, chunks_count=7, chunks_list=["c1"])}
+    )
+    raw = await storage.get_by_id("doc-1")
+    assert raw["status"] == "processed"
+    assert raw["chunks_count"] == 7
+    assert raw["chunks_list"] == ["c1"]
+    counts = await storage.get_status_counts()
+    assert counts["pending"] == 0
+    assert counts["processed"] == 1
+
+
+async def test_drop(storage):
+    await storage.upsert({"doc-1": _doc()})
+    result = await storage.drop()
+    assert result == {"status": "success", "message": "data dropped"}
+    assert await storage.is_empty()
+    await storage.upsert({"doc-2": _doc()})
+    assert await storage.get_by_id("doc-2") is not None

--- a/tests/kg/lancedb_impl/test_lancedb_doc_status.py
+++ b/tests/kg/lancedb_impl/test_lancedb_doc_status.py
@@ -244,3 +244,27 @@ async def test_drop(storage):
     assert await storage.is_empty()
     await storage.upsert({"doc-2": _doc()})
     assert await storage.get_by_id("doc-2") is not None
+
+
+async def test_get_docs_by_statuses_strict_raises_on_bad_record(storage):
+    """Strict scheduling contract: a record that cannot be converted raises;
+    the relaxed default keeps the historical skip-and-log behavior."""
+    await storage.upsert(
+        {
+            "doc-good": _doc(status=DocStatus.FAILED),
+            # Missing required fields → DocProcessingStatus(**data) raises.
+            "doc-bad": {"status": DocStatus.FAILED},
+        }
+    )
+
+    relaxed = await storage.get_docs_by_statuses([DocStatus.FAILED])
+    assert set(relaxed) == {"doc-good"}
+
+    with pytest.raises(TypeError):
+        await storage.get_docs_by_statuses([DocStatus.FAILED], strict=True)
+
+
+async def test_get_docs_by_statuses_strict_empty_is_complete(storage):
+    """A legitimately empty result is COMPLETE, not an error, under strict."""
+    await storage.upsert({"doc-1": _doc(status=DocStatus.PROCESSED)})
+    assert await storage.get_docs_by_statuses([DocStatus.FAILED], strict=True) == {}

--- a/tests/kg/lancedb_impl/test_lancedb_graph_storage.py
+++ b/tests/kg/lancedb_impl/test_lancedb_graph_storage.py
@@ -270,7 +270,7 @@ async def test_get_knowledge_graph_wildcard(storage, global_config):
 
 
 async def test_special_characters_in_ids(storage):
-    tricky = "O'Brien \"The Boss\" 朱元璋"
+    tricky = 'O\'Brien "The Boss" 朱元璋'
     other = "partner's node"
     await storage.upsert_node(tricky, _node(tricky))
     await storage.upsert_node(other, _node(other))
@@ -281,6 +281,18 @@ async def test_special_characters_in_ids(storage):
     assert await storage.node_degree(tricky) == 1
     await storage.remove_edges([(tricky, other)])
     assert not await storage.has_edge(tricky, other)
+
+
+async def test_hyphenated_ids_do_not_collide(storage):
+    # ("A-B", "C") and ("A", "B-C") must map to distinct edges even though
+    # a naive "-"-joined canonical string would be identical for both.
+    await storage.upsert_edge("A-B", "C", _edge(weight=1.0))
+    await storage.upsert_edge("A", "B-C", _edge(weight=2.0))
+    assert (await storage.get_edge("A-B", "C"))["weight"] == 1.0
+    assert (await storage.get_edge("A", "B-C"))["weight"] == 2.0
+    await storage.remove_edges([("A-B", "C")])
+    assert not await storage.has_edge("A-B", "C")
+    assert await storage.has_edge("A", "B-C")
 
 
 async def test_drop_resets_graph(storage):

--- a/tests/kg/lancedb_impl/test_lancedb_graph_storage.py
+++ b/tests/kg/lancedb_impl/test_lancedb_graph_storage.py
@@ -1,0 +1,295 @@
+"""Unit tests for LanceDBGraphStorage: undirected edges, merges, BFS."""
+
+import time
+
+import pytest
+
+pytest.importorskip("lancedb", reason="lancedb is required for LanceDB storage tests")
+
+from lightrag.kg.lancedb_impl import LanceDBGraphStorage  # noqa: E402
+from lightrag.types import KnowledgeGraph  # noqa: E402
+
+pytestmark = pytest.mark.offline
+
+
+def _make_storage(global_config, embedding_func, workspace="ws"):
+    return LanceDBGraphStorage(
+        namespace="chunk_entity_relation",
+        workspace=workspace,
+        global_config=global_config,
+        embedding_func=embedding_func,
+    )
+
+
+def _node(name, **extra):
+    return {
+        "entity_id": name,
+        "entity_type": "TEST",
+        "description": f"{name} description",
+        "source_id": "chunk-1",
+        "file_path": "test.txt",
+        "created_at": int(time.time()),
+        **extra,
+    }
+
+
+def _edge(**extra):
+    return {
+        "weight": 1.0,
+        "description": "test edge",
+        "keywords": "test",
+        "source_id": "chunk-1",
+        "file_path": "test.txt",
+        "created_at": int(time.time()),
+        **extra,
+    }
+
+
+@pytest.fixture
+async def storage(global_config, embedding_func):
+    graph = _make_storage(global_config, embedding_func)
+    await graph.initialize()
+    yield graph
+    await graph.finalize()
+
+
+async def test_node_crud_with_merge_semantics(storage):
+    assert not await storage.has_node("Alice")
+    assert await storage.get_node("Alice") is None
+    await storage.upsert_node("Alice", _node("Alice"))
+    assert await storage.has_node("Alice")
+    node = await storage.get_node("Alice")
+    assert node["entity_type"] == "TEST"
+    # Merge: unspecified fields survive, provided fields overwrite.
+    await storage.upsert_node("Alice", {"description": "updated"})
+    node = await storage.get_node("Alice")
+    assert node["description"] == "updated"
+    assert node["entity_type"] == "TEST"
+    await storage.delete_node("Alice")
+    assert not await storage.has_node("Alice")
+
+
+async def test_edges_are_undirected(storage):
+    await storage.upsert_node("A", _node("A"))
+    await storage.upsert_node("B", _node("B"))
+    await storage.upsert_edge("A", "B", _edge(weight=1.5))
+    assert await storage.has_edge("A", "B")
+    assert await storage.has_edge("B", "A")
+    assert (await storage.get_edge("A", "B"))["weight"] == 1.5
+    assert (await storage.get_edge("B", "A"))["weight"] == 1.5
+    # Upserting the reverse direction updates the SAME edge (merge).
+    await storage.upsert_edge("B", "A", {"weight": 2.5})
+    edge = await storage.get_edge("A", "B")
+    assert edge["weight"] == 2.5
+    assert edge["description"] == "test edge"
+    assert await storage.node_degree("A") == 1
+    assert await storage.node_degree("B") == 1
+
+
+async def test_upsert_edge_creates_missing_source_node(storage):
+    await storage.upsert_edge("Ghost", "AlsoGhost", _edge())
+    assert await storage.has_node("Ghost")
+    assert await storage.has_edge("Ghost", "AlsoGhost")
+
+
+async def test_degrees(storage):
+    for name in ("A", "B", "C"):
+        await storage.upsert_node(name, _node(name))
+    await storage.upsert_edge("A", "B", _edge())
+    await storage.upsert_edge("A", "C", _edge())
+    assert await storage.node_degree("A") == 2
+    assert await storage.node_degree("B") == 1
+    assert await storage.node_degree("missing") == 0
+    assert await storage.edge_degree("A", "B") == 3
+    assert await storage.edge_degree("A", "missing") == 2
+
+
+async def test_get_node_edges(storage):
+    await storage.upsert_node("A", _node("A"))
+    await storage.upsert_node("B", _node("B"))
+    await storage.upsert_edge("A", "B", _edge())
+    edges = await storage.get_node_edges("A")
+    assert edges == [("A", "B")]
+    assert await storage.get_node_edges("missing") is None
+    await storage.upsert_node("Lonely", _node("Lonely"))
+    assert await storage.get_node_edges("Lonely") == []
+
+
+async def test_get_node_edges_puts_queried_node_first(storage):
+    """Regression: amerge_entities filters on tuple[0] == entity_name, so the
+    queried node must come first even when it was stored as the edge target.
+    """
+    await storage.upsert_node("Apple", _node("Apple"))
+    await storage.upsert_node("Zebra", _node("Zebra"))
+    await storage.upsert_edge("Apple", "Zebra", _edge())
+    assert await storage.get_node_edges("Zebra") == [("Zebra", "Apple")]
+    assert await storage.get_node_edges("Apple") == [("Apple", "Zebra")]
+    batch = await storage.get_nodes_edges_batch(["Zebra", "Apple"])
+    assert batch["Zebra"] == [("Zebra", "Apple")]
+    assert batch["Apple"] == [("Apple", "Zebra")]
+
+
+async def test_batch_operations(storage):
+    await storage.upsert_nodes_batch([(name, _node(name)) for name in "ABCD"])
+    await storage.upsert_edges_batch(
+        [
+            ("A", "B", _edge(weight=1.0)),
+            ("B", "C", _edge(weight=2.0)),
+            ("C", "A", _edge(weight=3.0)),
+        ]
+    )
+    nodes = await storage.get_nodes_batch(["A", "C", "missing"])
+    assert set(nodes) == {"A", "C"}
+    assert nodes["A"]["entity_id"] == "A"
+    assert await storage.has_nodes_batch(["A", "D", "missing"]) == {"A", "D"}
+    degrees = await storage.node_degrees_batch(["A", "B", "D", "missing"])
+    assert degrees == {"A": 2, "B": 2, "D": 0, "missing": 0}
+    edge_degrees = await storage.edge_degrees_batch([("A", "B"), ("A", "missing")])
+    assert edge_degrees[("A", "B")] == 4
+    assert edge_degrees[("A", "missing")] == 2
+    edges = await storage.get_edges_batch(
+        [{"src": "B", "tgt": "A"}, {"src": "B", "tgt": "C"}, {"src": "A", "tgt": "D"}]
+    )
+    assert edges[("B", "A")]["weight"] == 1.0  # reverse order resolves
+    assert edges[("B", "C")]["weight"] == 2.0
+    assert ("A", "D") not in edges
+    node_edges = await storage.get_nodes_edges_batch(["A", "D"])
+    assert len(node_edges["A"]) == 2
+    assert node_edges["D"] == []
+
+
+async def test_edges_batch_dedupes_canonical_pairs(storage):
+    await storage.upsert_edges_batch(
+        [
+            ("A", "B", _edge(weight=1.0, description="first")),
+            ("B", "A", _edge(weight=9.0)),
+        ]
+    )
+    edge = await storage.get_edge("A", "B")
+    # Later entry wins field-by-field, like sequential upsert_edge calls.
+    assert edge["weight"] == 9.0
+    assert edge["description"] == "test edge"
+    assert await storage.node_degree("A") == 1
+
+
+async def test_remove_nodes_removes_incident_edges(storage):
+    for name in ("A", "B", "C"):
+        await storage.upsert_node(name, _node(name))
+    await storage.upsert_edge("A", "B", _edge())
+    await storage.upsert_edge("B", "C", _edge())
+    await storage.remove_nodes(["A"])
+    assert not await storage.has_node("A")
+    assert not await storage.has_edge("A", "B")
+    assert await storage.has_edge("B", "C")
+
+
+async def test_remove_edges_keeps_nodes(storage):
+    await storage.upsert_node("A", _node("A"))
+    await storage.upsert_node("B", _node("B"))
+    await storage.upsert_edge("A", "B", _edge())
+    await storage.remove_edges([("B", "A")])  # reverse order works
+    assert not await storage.has_edge("A", "B")
+    assert await storage.has_node("A")
+    assert await storage.has_node("B")
+
+
+async def test_labels_and_search(storage):
+    for name in ("Apple", "Banana", "apple pie", "Pineapple"):
+        await storage.upsert_node(name, _node(name))
+    await storage.upsert_edge("Apple", "Banana", _edge())
+    await storage.upsert_edge("Apple", "Pineapple", _edge())
+    labels = await storage.get_all_labels()
+    assert labels == sorted(["Apple", "Banana", "apple pie", "Pineapple"])
+    popular = await storage.get_popular_labels(limit=2)
+    assert popular[0] == "Apple"
+    assert len(popular) == 2
+    results = await storage.search_labels("apple")
+    assert results[0] in ("Apple", "apple pie")  # exact-insensitive first
+    assert "Pineapple" in results
+    assert await storage.search_labels("  ") == []
+    assert await storage.search_labels("zzz") == []
+
+
+async def test_get_all_nodes_and_edges(storage):
+    await storage.upsert_node("A", _node("A"))
+    await storage.upsert_node("B", _node("B"))
+    await storage.upsert_edge("A", "B", _edge())
+    nodes = await storage.get_all_nodes()
+    assert {node["id"] for node in nodes} == {"A", "B"}
+    edges = await storage.get_all_edges()
+    assert len(edges) == 1
+    assert {edges[0]["source"], edges[0]["target"]} == {"A", "B"}
+    assert edges[0]["source_id"] == "chunk-1"
+
+
+async def test_get_knowledge_graph_bfs(storage):
+    # A - B - C - D chain plus isolated E
+    for name in "ABCDE":
+        await storage.upsert_node(name, _node(name))
+    await storage.upsert_edge("A", "B", _edge())
+    await storage.upsert_edge("B", "C", _edge())
+    await storage.upsert_edge("C", "D", _edge())
+
+    kg = await storage.get_knowledge_graph("A", max_depth=2, max_nodes=100)
+    assert isinstance(kg, KnowledgeGraph)
+    ids = {node.id for node in kg.nodes}
+    assert ids == {"A", "B", "C"}  # depth 2 stops before D
+    assert not kg.is_truncated
+    edge_pairs = {(edge.source, edge.target) for edge in kg.edges}
+    assert len(edge_pairs) == 2
+
+    kg_missing = await storage.get_knowledge_graph("missing")
+    assert kg_missing.nodes == [] and kg_missing.edges == []
+
+    kg_capped = await storage.get_knowledge_graph("A", max_depth=5, max_nodes=2)
+    assert len(kg_capped.nodes) <= 2
+    assert kg_capped.is_truncated
+
+    # Exactly max_nodes reachable nodes with nothing omitted -> NOT truncated.
+    kg_exact = await storage.get_knowledge_graph("A", max_depth=5, max_nodes=4)
+    assert {node.id for node in kg_exact.nodes} == {"A", "B", "C", "D"}
+    assert not kg_exact.is_truncated
+
+
+async def test_get_knowledge_graph_wildcard(storage, global_config):
+    for name in "ABCD":
+        await storage.upsert_node(name, _node(name))
+    await storage.upsert_edge("A", "B", _edge())
+    await storage.upsert_edge("A", "C", _edge())
+
+    kg = await storage.get_knowledge_graph("*", max_nodes=100)
+    assert {node.id for node in kg.nodes} == {"A", "B", "C", "D"}
+    assert len(kg.edges) == 2
+    assert not kg.is_truncated
+
+    kg_truncated = await storage.get_knowledge_graph("*", max_nodes=2)
+    assert len(kg_truncated.nodes) == 2
+    assert kg_truncated.is_truncated
+    # Highest-degree node must be included.
+    assert "A" in {node.id for node in kg_truncated.nodes}
+
+
+async def test_special_characters_in_ids(storage):
+    tricky = "O'Brien \"The Boss\" 朱元璋"
+    other = "partner's node"
+    await storage.upsert_node(tricky, _node(tricky))
+    await storage.upsert_node(other, _node(other))
+    await storage.upsert_edge(tricky, other, _edge())
+    assert await storage.has_node(tricky)
+    assert (await storage.get_node(tricky))["entity_id"] == tricky
+    assert await storage.has_edge(other, tricky)
+    assert await storage.node_degree(tricky) == 1
+    await storage.remove_edges([(tricky, other)])
+    assert not await storage.has_edge(tricky, other)
+
+
+async def test_drop_resets_graph(storage):
+    await storage.upsert_node("A", _node("A"))
+    await storage.upsert_edge("A", "B", _edge())
+    result = await storage.drop()
+    assert result == {"status": "success", "message": "data dropped"}
+    assert await storage.get_all_labels() == []
+    assert await storage.get_all_edges() == []
+    # usable after drop
+    await storage.upsert_node("C", _node("C"))
+    assert await storage.has_node("C")

--- a/tests/kg/lancedb_impl/test_lancedb_integration.py
+++ b/tests/kg/lancedb_impl/test_lancedb_integration.py
@@ -1,0 +1,380 @@
+"""Integration tests: all four LanceDB storages sharing one database
+directory through a mini insert → query pipeline, plus CJK full-text search.
+"""
+
+import pytest
+
+pytest.importorskip("lancedb", reason="lancedb is required for LanceDB storage tests")
+
+from lightrag.base import DocStatus  # noqa: E402
+from lightrag.constants import GRAPH_FIELD_SEP  # noqa: E402
+from lightrag.kg.lancedb_impl import (  # noqa: E402
+    LanceDBDocStatusStorage,
+    LanceDBGraphStorage,
+    LanceDBKVStorage,
+    LanceDBVectorStorage,
+)
+from lightrag.utils import compute_mdhash_id  # noqa: E402
+
+pytestmark = pytest.mark.offline
+
+
+async def test_remote_uri_not_created_as_local_dir(monkeypatch, tmp_path):
+    """Regression: a remote LANCEDB_URI (s3://...) must not be os.makedirs'd into
+    a bogus local directory — only local paths get a directory created.
+    """
+    import lightrag.kg.lancedb_impl as impl
+
+    monkeypatch.chdir(tmp_path)
+    captured = {}
+
+    async def fake_connect_async(uri, **kwargs):
+        captured["uri"] = uri
+        return object()
+
+    monkeypatch.setattr(impl.lancedb, "connect_async", fake_connect_async)
+
+    client = impl.LanceDBClient("s3://bucket/prefix")
+    await client.connect()
+
+    assert captured["uri"] == "s3://bucket/prefix"
+    # The remote URI must not have been turned into a local directory.
+    assert not (tmp_path / "s3:").exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+async def test_mini_insert_query_pipeline(global_config, embedding_func):
+    """Simulate the storage-level writes of one document ingestion batch,
+    then query the data back the way the retrieval pipeline does.
+    """
+    workspace = "pipeline"
+    full_docs = LanceDBKVStorage(
+        namespace="full_docs",
+        workspace=workspace,
+        global_config=global_config,
+        embedding_func=embedding_func,
+    )
+    text_chunks = LanceDBKVStorage(
+        namespace="text_chunks",
+        workspace=workspace,
+        global_config=global_config,
+        embedding_func=embedding_func,
+    )
+    chunks_vdb = LanceDBVectorStorage(
+        namespace="chunks",
+        workspace=workspace,
+        global_config=global_config,
+        embedding_func=embedding_func,
+        meta_fields={"full_doc_id", "content", "file_path"},
+    )
+    entities_vdb = LanceDBVectorStorage(
+        namespace="entities",
+        workspace=workspace,
+        global_config=global_config,
+        embedding_func=embedding_func,
+        meta_fields={"entity_name", "source_id", "content", "file_path"},
+    )
+    relationships_vdb = LanceDBVectorStorage(
+        namespace="relationships",
+        workspace=workspace,
+        global_config=global_config,
+        embedding_func=embedding_func,
+        meta_fields={"src_id", "tgt_id", "source_id", "content", "file_path"},
+    )
+    graph = LanceDBGraphStorage(
+        namespace="chunk_entity_relation",
+        workspace=workspace,
+        global_config=global_config,
+        embedding_func=embedding_func,
+    )
+    doc_status = LanceDBDocStatusStorage(
+        namespace="doc_status",
+        workspace=workspace,
+        global_config=global_config,
+        embedding_func=None,
+    )
+    storages = [
+        full_docs,
+        text_chunks,
+        chunks_vdb,
+        entities_vdb,
+        relationships_vdb,
+        graph,
+        doc_status,
+    ]
+    for storage in storages:
+        await storage.initialize()
+    try:
+        doc_text = (
+            "Zhu Yuanzhang founded the Ming dynasty. "
+            "He made Nanjing the capital city."
+        )
+        doc_id = compute_mdhash_id(doc_text, prefix="doc-")
+        chunk_id = compute_mdhash_id(f"{doc_id}:{doc_text}", prefix="chunk-")
+
+        # 1. enqueue: doc status + full doc
+        assert await doc_status.filter_keys({doc_id}) == {doc_id}
+        await doc_status.upsert(
+            {
+                doc_id: {
+                    "status": DocStatus.PENDING,
+                    "content_summary": doc_text[:100],
+                    "content_length": len(doc_text),
+                    "created_at": "2024-01-01T00:00:00+00:00",
+                    "updated_at": "2024-01-01T00:00:00+00:00",
+                    "file_path": "ming.txt",
+                    "content_hash": "hash-ming",
+                    "metadata": {},
+                }
+            }
+        )
+        await full_docs.upsert({doc_id: {"content": doc_text, "file_path": "ming.txt"}})
+
+        # 2. chunking: KV chunks + chunk vectors
+        chunk_record = {
+            "content": doc_text,
+            "tokens": 20,
+            "chunk_order_index": 0,
+            "full_doc_id": doc_id,
+            "file_path": "ming.txt",
+        }
+        await text_chunks.upsert({chunk_id: dict(chunk_record)})
+        await chunks_vdb.upsert({chunk_id: dict(chunk_record)})
+
+        # 3. extraction: graph nodes/edges + entity/relation vectors
+        await graph.upsert_node(
+            "Zhu Yuanzhang",
+            {
+                "entity_id": "Zhu Yuanzhang",
+                "entity_type": "person",
+                "description": "Founder of the Ming dynasty",
+                "source_id": chunk_id,
+                "file_path": "ming.txt",
+            },
+        )
+        await graph.upsert_node(
+            "Ming Dynasty",
+            {
+                "entity_id": "Ming Dynasty",
+                "entity_type": "organization",
+                "description": "Chinese dynasty founded in 1368",
+                "source_id": chunk_id,
+                "file_path": "ming.txt",
+            },
+        )
+        await graph.upsert_edge(
+            "Zhu Yuanzhang",
+            "Ming Dynasty",
+            {
+                "weight": 1.0,
+                "description": "Zhu Yuanzhang founded the Ming dynasty",
+                "keywords": "founder",
+                "source_id": chunk_id,
+                "file_path": "ming.txt",
+            },
+        )
+        await entities_vdb.upsert(
+            {
+                compute_mdhash_id("Zhu Yuanzhang", prefix="ent-"): {
+                    "entity_name": "Zhu Yuanzhang",
+                    "content": "Zhu Yuanzhang\nFounder of the Ming dynasty",
+                    "source_id": chunk_id,
+                    "file_path": "ming.txt",
+                },
+                compute_mdhash_id("Ming Dynasty", prefix="ent-"): {
+                    "entity_name": "Ming Dynasty",
+                    "content": "Ming Dynasty\nChinese dynasty founded in 1368",
+                    "source_id": chunk_id,
+                    "file_path": "ming.txt",
+                },
+            }
+        )
+        src, tgt = sorted(("Zhu Yuanzhang", "Ming Dynasty"))
+        await relationships_vdb.upsert(
+            {
+                compute_mdhash_id(src + tgt, prefix="rel-"): {
+                    "src_id": src,
+                    "tgt_id": tgt,
+                    "content": "founder\tZhu Yuanzhang founded the Ming dynasty",
+                    "source_id": chunk_id,
+                    "file_path": "ming.txt",
+                }
+            }
+        )
+
+        # 4. _insert_done: flush all storages
+        for storage in storages:
+            await storage.index_done_callback()
+        await doc_status.upsert(
+            {
+                doc_id: {
+                    "status": DocStatus.PROCESSED,
+                    "content_summary": doc_text[:100],
+                    "content_length": len(doc_text),
+                    "created_at": "2024-01-01T00:00:00+00:00",
+                    "updated_at": "2024-01-01T00:01:00+00:00",
+                    "file_path": "ming.txt",
+                    "content_hash": "hash-ming",
+                    "metadata": {},
+                    "chunks_count": 1,
+                    "chunks_list": [chunk_id],
+                }
+            }
+        )
+
+        # 5. retrieval-style reads (the mock embedding is deterministic per
+        # text, so query with the exact stored content to guarantee a match)
+        chunk_hits = await chunks_vdb.query(doc_text, top_k=5)
+        assert chunk_hits and chunk_hits[0]["id"] == chunk_id
+        assert chunk_hits[0]["content"] == doc_text
+
+        entity_hits = await entities_vdb.query(
+            "Zhu Yuanzhang\nFounder of the Ming dynasty", top_k=5
+        )
+        assert entity_hits
+        assert all("entity_name" in hit for hit in entity_hits)
+
+        relation_hits = await relationships_vdb.query(
+            "founder\tZhu Yuanzhang founded the Ming dynasty", top_k=5
+        )
+        assert relation_hits
+        assert {relation_hits[0]["src_id"], relation_hits[0]["tgt_id"]} == {
+            "Zhu Yuanzhang",
+            "Ming Dynasty",
+        }
+
+        node = await graph.get_node(entity_hits[0]["entity_name"])
+        assert node is not None
+        assert node["source_id"] == chunk_id
+        chunk = await text_chunks.get_by_id(chunk_id)
+        assert chunk["content"] == doc_text
+        processed = await doc_status.get_docs_by_status(DocStatus.PROCESSED)
+        assert doc_id in processed
+        assert processed[doc_id].chunks_list == [chunk_id]
+
+        # 6. deletion flow (adelete_by_doc_id storage calls)
+        await chunks_vdb.delete([chunk_id])
+        await text_chunks.delete([chunk_id])
+        await relationships_vdb.delete(
+            [
+                compute_mdhash_id(src + tgt, prefix="rel-"),
+                compute_mdhash_id(tgt + src, prefix="rel-"),
+            ]
+        )
+        await graph.remove_edges([("Zhu Yuanzhang", "Ming Dynasty")])
+        await graph.remove_nodes(["Zhu Yuanzhang", "Ming Dynasty"])
+        await entities_vdb.delete(
+            [
+                compute_mdhash_id("Zhu Yuanzhang", prefix="ent-"),
+                compute_mdhash_id("Ming Dynasty", prefix="ent-"),
+            ]
+        )
+        await doc_status.delete([doc_id])
+        await full_docs.delete([doc_id])
+        assert await full_docs.is_empty()
+        assert await doc_status.is_empty()
+        assert await graph.get_all_labels() == []
+        assert await chunks_vdb.query(doc_text, top_k=5) == []
+    finally:
+        for storage in storages:
+            await storage.finalize()
+
+
+async def test_multiple_source_ids_round_trip(global_config, embedding_func):
+    """GRAPH_FIELD_SEP-joined fields must round-trip unchanged."""
+    graph = LanceDBGraphStorage(
+        namespace="chunk_entity_relation",
+        workspace="sep",
+        global_config=global_config,
+        embedding_func=embedding_func,
+    )
+    await graph.initialize()
+    try:
+        source_id = f"chunk-1{GRAPH_FIELD_SEP}chunk-2"
+        await graph.upsert_node(
+            "Multi", {"entity_id": "Multi", "source_id": source_id}
+        )
+        node = await graph.get_node("Multi")
+        assert node["source_id"] == source_id
+        assert node["source_id"].split(GRAPH_FIELD_SEP) == ["chunk-1", "chunk-2"]
+    finally:
+        await graph.finalize()
+
+
+async def test_cjk_full_text_search(global_config, embedding_func):
+    """Chinese text must be retrievable via the built-in FTS index."""
+    chunks_vdb = LanceDBVectorStorage(
+        namespace="chunks",
+        workspace="cjk",
+        global_config=global_config,
+        embedding_func=embedding_func,
+        meta_fields={"full_doc_id", "content", "file_path"},
+    )
+    await chunks_vdb.initialize()
+    try:
+        await chunks_vdb.upsert(
+            {
+                "chunk-zh-1": {
+                    "content": "朱元璋是明朝的開國皇帝，定都南京。",
+                    "full_doc_id": "doc-zh",
+                    "file_path": "zhu.txt",
+                },
+                "chunk-zh-2": {
+                    "content": "康熙皇帝是清朝在位時間最長的皇帝。",
+                    "full_doc_id": "doc-zh",
+                    "file_path": "zhu.txt",
+                },
+                "chunk-en-1": {
+                    "content": "The quick brown fox jumps over the lazy dog.",
+                    "full_doc_id": "doc-en",
+                    "file_path": "fox.txt",
+                },
+            }
+        )
+        await chunks_vdb.index_done_callback()
+
+        hits = await chunks_vdb.full_text_search("朱元璋", top_k=5)
+        assert [hit["id"] for hit in hits] == ["chunk-zh-1"]
+        assert hits[0]["score"] is not None
+
+        # A two-character CJK query must match (bigram tokenizer).
+        hits = await chunks_vdb.full_text_search("皇帝", top_k=5)
+        assert {hit["id"] for hit in hits} == {"chunk-zh-1", "chunk-zh-2"}
+
+        # Latin-script search still works with the same index.
+        hits = await chunks_vdb.full_text_search("fox", top_k=5)
+        assert [hit["id"] for hit in hits] == ["chunk-en-1"]
+
+        # Rows added after index creation are searchable without reindexing.
+        await chunks_vdb.upsert(
+            {
+                "chunk-zh-3": {
+                    "content": "唐朝詩人李白寫了很多著名的詩。",
+                    "full_doc_id": "doc-zh",
+                    "file_path": "zhu.txt",
+                }
+            }
+        )
+        await chunks_vdb.index_done_callback()
+        hits = await chunks_vdb.full_text_search("李白", top_k=5)
+        assert [hit["id"] for hit in hits] == ["chunk-zh-3"]
+    finally:
+        await chunks_vdb.finalize()
+
+
+async def test_cjk_vector_content_round_trip(global_config, embedding_func):
+    """CJK content must survive storage/retrieval byte-exact."""
+    kv = LanceDBKVStorage(
+        namespace="text_chunks",
+        workspace="cjk",
+        global_config=global_config,
+        embedding_func=embedding_func,
+    )
+    await kv.initialize()
+    try:
+        content = "測試中文內容：《明史》記載，朱元璋（1328年—1398年）。"
+        await kv.upsert({"chunk-1": {"content": content, "tokens": 30}})
+        record = await kv.get_by_id("chunk-1")
+        assert record["content"] == content
+    finally:
+        await kv.finalize()

--- a/tests/kg/lancedb_impl/test_lancedb_integration.py
+++ b/tests/kg/lancedb_impl/test_lancedb_integration.py
@@ -106,8 +106,7 @@ async def test_mini_insert_query_pipeline(global_config, embedding_func):
         await storage.initialize()
     try:
         doc_text = (
-            "Zhu Yuanzhang founded the Ming dynasty. "
-            "He made Nanjing the capital city."
+            "Zhu Yuanzhang founded the Ming dynasty. He made Nanjing the capital city."
         )
         doc_id = compute_mdhash_id(doc_text, prefix="doc-")
         chunk_id = compute_mdhash_id(f"{doc_id}:{doc_text}", prefix="chunk-")
@@ -291,9 +290,7 @@ async def test_multiple_source_ids_round_trip(global_config, embedding_func):
     await graph.initialize()
     try:
         source_id = f"chunk-1{GRAPH_FIELD_SEP}chunk-2"
-        await graph.upsert_node(
-            "Multi", {"entity_id": "Multi", "source_id": source_id}
-        )
+        await graph.upsert_node("Multi", {"entity_id": "Multi", "source_id": source_id})
         node = await graph.get_node("Multi")
         assert node["source_id"] == source_id
         assert node["source_id"].split(GRAPH_FIELD_SEP) == ["chunk-1", "chunk-2"]

--- a/tests/kg/lancedb_impl/test_lancedb_kv_storage.py
+++ b/tests/kg/lancedb_impl/test_lancedb_kv_storage.py
@@ -67,6 +67,47 @@ async def test_filter_keys_returns_missing_keys(global_config, embedding_func):
         await storage.finalize()
 
 
+async def test_get_all_keys_enumerates_every_id(global_config, embedding_func):
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    try:
+        assert await storage.get_all_keys() == []
+        await storage.upsert(
+            {
+                "default:extract:1": {"content": "a"},
+                "mix:query:1": {"content": "b"},
+                "hybrid:keywords:1": {"content": "c"},
+            }
+        )
+        assert set(await storage.get_all_keys()) == {
+            "default:extract:1",
+            "mix:query:1",
+            "hybrid:keywords:1",
+        }
+        await storage.delete(["mix:query:1"])
+        assert set(await storage.get_all_keys()) == {
+            "default:extract:1",
+            "hybrid:keywords:1",
+        }
+    finally:
+        await storage.finalize()
+
+
+async def test_get_all_keys_is_workspace_scoped(global_config, embedding_func):
+    ws1 = _make_storage(global_config, embedding_func, workspace="ws1")
+    ws2 = _make_storage(global_config, embedding_func, workspace="ws2")
+    await ws1.initialize()
+    await ws2.initialize()
+    try:
+        await ws1.upsert({"a": {"content": "1"}, "b": {"content": "2"}})
+        await ws2.upsert({"c": {"content": "3"}})
+        assert set(await ws1.get_all_keys()) == {"a", "b"}
+        assert set(await ws2.get_all_keys()) == {"c"}
+    finally:
+        await ws1.finalize()
+        await ws2.finalize()
+
+
 async def test_upsert_replaces_record_but_preserves_create_time(
     global_config, embedding_func
 ):

--- a/tests/kg/lancedb_impl/test_lancedb_kv_storage.py
+++ b/tests/kg/lancedb_impl/test_lancedb_kv_storage.py
@@ -232,6 +232,15 @@ async def test_lancedb_workspace_env_override(
     assert storage.final_namespace == "forced_full_docs"
 
 
+async def test_lancedb_workspace_env_override_is_validated(
+    global_config, embedding_func, monkeypatch
+):
+    """The env override must fail fast on unsafe names, like the constructor path."""
+    monkeypatch.setenv("LANCEDB_WORKSPACE", "../escape")
+    with pytest.raises(ValueError):
+        _make_storage(global_config, embedding_func, workspace="ignored")
+
+
 async def test_workspaces_differing_only_by_case_stay_isolated(
     global_config, embedding_func
 ):

--- a/tests/kg/lancedb_impl/test_lancedb_kv_storage.py
+++ b/tests/kg/lancedb_impl/test_lancedb_kv_storage.py
@@ -1,0 +1,229 @@
+"""Unit tests for LanceDBKVStorage against a real tmp-path LanceDB."""
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("lancedb", reason="lancedb is required for LanceDB storage tests")
+
+from lightrag.kg.lancedb_impl import LanceDBKVStorage  # noqa: E402
+
+pytestmark = pytest.mark.offline
+
+
+def _make_storage(global_config, embedding_func, namespace="full_docs", workspace="ws"):
+    return LanceDBKVStorage(
+        namespace=namespace,
+        workspace=workspace,
+        global_config=global_config,
+        embedding_func=embedding_func,
+    )
+
+
+async def test_upsert_and_get_by_id(global_config, embedding_func):
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    try:
+        assert await storage.is_empty()
+        await storage.upsert({"doc-1": {"content": "hello", "file_path": "a.txt"}})
+        record = await storage.get_by_id("doc-1")
+        assert record["content"] == "hello"
+        assert record["file_path"] == "a.txt"
+        assert record["_id"] == "doc-1"
+        assert record["create_time"] > 0
+        assert record["update_time"] >= record["create_time"]
+        assert not await storage.is_empty()
+        assert await storage.get_by_id("missing") is None
+    finally:
+        await storage.finalize()
+
+
+async def test_get_by_ids_preserves_order_with_none_for_missing(
+    global_config, embedding_func
+):
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    try:
+        await storage.upsert(
+            {"a": {"content": "1"}, "b": {"content": "2"}, "c": {"content": "3"}}
+        )
+        records = await storage.get_by_ids(["c", "missing", "a"])
+        assert records[0]["content"] == "3"
+        assert records[1] is None
+        assert records[2]["content"] == "1"
+        assert await storage.get_by_ids([]) == []
+    finally:
+        await storage.finalize()
+
+
+async def test_filter_keys_returns_missing_keys(global_config, embedding_func):
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    try:
+        await storage.upsert({"a": {"content": "1"}})
+        assert await storage.filter_keys({"a", "b", "c"}) == {"b", "c"}
+        assert await storage.filter_keys(set()) == set()
+    finally:
+        await storage.finalize()
+
+
+async def test_upsert_replaces_record_but_preserves_create_time(
+    global_config, embedding_func
+):
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    try:
+        await storage.upsert({"a": {"content": "v1", "stale_field": True}})
+        first = await storage.get_by_id("a")
+        await asyncio.sleep(1.1)
+        await storage.upsert({"a": {"content": "v2"}})
+        second = await storage.get_by_id("a")
+        assert second["content"] == "v2"
+        # Full-record replace: fields absent from the new record are gone.
+        assert "stale_field" not in second
+        assert second["create_time"] == first["create_time"]
+        assert second["update_time"] > first["update_time"]
+    finally:
+        await storage.finalize()
+
+
+async def test_text_chunks_defaults_llm_cache_list(global_config, embedding_func):
+    storage = _make_storage(global_config, embedding_func, namespace="text_chunks")
+    await storage.initialize()
+    try:
+        await storage.upsert(
+            {
+                "chunk-1": {"content": "c", "tokens": 3, "full_doc_id": "doc-1"},
+                "chunk-2": {"content": "c2", "llm_cache_list": ["default:extract:x"]},
+            }
+        )
+        first = await storage.get_by_id("chunk-1")
+        assert first["llm_cache_list"] == []
+        second = await storage.get_by_id("chunk-2")
+        assert second["llm_cache_list"] == ["default:extract:x"]
+    finally:
+        await storage.finalize()
+
+
+async def test_nested_records_round_trip(global_config, embedding_func):
+    storage = _make_storage(global_config, embedding_func, namespace="text_chunks")
+    await storage.initialize()
+    try:
+        record = {
+            "content": "chunk text",
+            "tokens": 42,
+            "chunk_order_index": 3,
+            "full_doc_id": "doc-1",
+            "heading": {"level": 1, "titles": ["A", "B"]},
+            "sidecar": {"images": [{"path": "x.png"}]},
+        }
+        await storage.upsert({"chunk-1": dict(record)})
+        loaded = await storage.get_by_id("chunk-1")
+        for key, value in record.items():
+            assert loaded[key] == value
+    finally:
+        await storage.finalize()
+
+
+async def test_delete_removes_rows_and_ignores_missing(global_config, embedding_func):
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    try:
+        await storage.upsert({"a": {"content": "1"}, "b": {"content": "2"}})
+        await storage.delete(["a", "not-there"])
+        assert await storage.get_by_id("a") is None
+        assert await storage.get_by_id("b") is not None
+        await storage.delete([])
+    finally:
+        await storage.finalize()
+
+
+async def test_ids_with_quotes_are_escaped(global_config, embedding_func):
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    try:
+        tricky = "doc-'; DROP TABLE x; --"
+        await storage.upsert({tricky: {"content": "quoted"}})
+        record = await storage.get_by_id(tricky)
+        assert record["content"] == "quoted"
+        assert await storage.filter_keys({tricky}) == set()
+        await storage.delete([tricky])
+        assert await storage.get_by_id(tricky) is None
+    finally:
+        await storage.finalize()
+
+
+async def test_drop_resets_storage(global_config, embedding_func):
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    try:
+        await storage.upsert({"a": {"content": "1"}})
+        result = await storage.drop()
+        assert result == {"status": "success", "message": "data dropped"}
+        assert await storage.is_empty()
+        # Storage stays usable after drop.
+        await storage.upsert({"b": {"content": "2"}})
+        assert (await storage.get_by_id("b"))["content"] == "2"
+    finally:
+        await storage.finalize()
+
+
+async def test_workspace_isolation(global_config, embedding_func):
+    ws1 = _make_storage(global_config, embedding_func, workspace="ws1")
+    ws2 = _make_storage(global_config, embedding_func, workspace="ws2")
+    await ws1.initialize()
+    await ws2.initialize()
+    try:
+        await ws1.upsert({"a": {"content": "ws1"}})
+        assert await ws2.get_by_id("a") is None
+        assert (await ws1.get_by_id("a"))["content"] == "ws1"
+    finally:
+        await ws1.finalize()
+        await ws2.finalize()
+
+
+async def test_lancedb_workspace_env_override(
+    global_config, embedding_func, monkeypatch
+):
+    monkeypatch.setenv("LANCEDB_WORKSPACE", "forced")
+    storage = _make_storage(global_config, embedding_func, workspace="ignored")
+    assert storage.workspace == "forced"
+    assert storage.final_namespace == "forced_full_docs"
+
+
+async def test_workspaces_differing_only_by_case_stay_isolated(
+    global_config, embedding_func
+):
+    """Regression: lossy table-name folding must not merge distinct workspaces."""
+    upper = _make_storage(global_config, embedding_func, workspace="TeamA")
+    lower = _make_storage(global_config, embedding_func, workspace="teama")
+    assert upper._table_name != lower._table_name
+    await upper.initialize()
+    await lower.initialize()
+    try:
+        await upper.upsert({"a": {"content": "upper"}})
+        assert await lower.get_by_id("a") is None
+        assert (await upper.get_by_id("a"))["content"] == "upper"
+    finally:
+        await upper.finalize()
+        await lower.finalize()
+
+
+async def test_concurrent_upserts_do_not_duplicate(global_config, embedding_func):
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    try:
+        await asyncio.gather(
+            *[
+                storage.upsert({f"k{i}": {"content": f"v{i}-{worker}"}})
+                for worker in range(8)
+                for i in range(5)
+            ]
+        )
+        records = await storage.get_by_ids([f"k{i}" for i in range(5)])
+        assert all(record is not None for record in records)
+        assert await storage.filter_keys({f"k{i}" for i in range(5)}) == set()
+        # Exactly one row per key even under concurrent same-key writes.
+        assert await storage._table().count_rows() == 5
+    finally:
+        await storage.finalize()

--- a/tests/kg/lancedb_impl/test_lancedb_vector_storage.py
+++ b/tests/kg/lancedb_impl/test_lancedb_vector_storage.py
@@ -1,0 +1,402 @@
+"""Unit tests for LanceDBVectorStorage: deferred embedding, query, deletes."""
+
+import pytest
+
+pytest.importorskip("lancedb", reason="lancedb is required for LanceDB storage tests")
+
+from lightrag.kg.lancedb_impl import LanceDBVectorStorage  # noqa: E402
+from lightrag.utils import EmbeddingFunc, compute_mdhash_id  # noqa: E402
+
+from .conftest import DIM, CountingEmbed  # noqa: E402
+
+pytestmark = pytest.mark.offline
+
+ENTITY_META = {"entity_name", "source_id", "content", "file_path"}
+RELATION_META = {"src_id", "tgt_id", "source_id", "content", "file_path"}
+CHUNK_META = {"full_doc_id", "content", "file_path"}
+
+
+def _make_storage(
+    global_config,
+    embedding_func,
+    namespace="entities",
+    meta_fields=ENTITY_META,
+    workspace="ws",
+):
+    return LanceDBVectorStorage(
+        namespace=namespace,
+        workspace=workspace,
+        global_config=global_config,
+        embedding_func=embedding_func,
+        meta_fields=set(meta_fields),
+    )
+
+
+def _entity(name, content, source_id="chunk-1", extra=None):
+    record = {
+        "entity_name": name,
+        "content": content,
+        "source_id": source_id,
+        "file_path": "test.txt",
+    }
+    if extra:
+        record.update(extra)
+    return record
+
+
+async def test_missing_cosine_threshold_raises(global_config, embedding_func):
+    config = dict(global_config)
+    config["vector_db_storage_cls_kwargs"] = {}
+    with pytest.raises(ValueError, match="cosine_better_than_threshold"):
+        _make_storage(config, embedding_func)
+
+
+async def test_upsert_defers_embedding_until_flush(
+    global_config, embedding_func, counting_embed
+):
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    try:
+        await storage.upsert(
+            {
+                "ent-1": _entity("Alice", "Alice description"),
+                "ent-2": _entity("Bob", "Bob description"),
+            }
+        )
+        assert counting_embed.call_count == 0
+        # query() only sees flushed data
+        assert await storage.query("Alice description", top_k=5) == []
+        await storage.index_done_callback()
+        assert sorted(counting_embed.document_texts) == [
+            "Alice description",
+            "Bob description",
+        ]
+        results = await storage.query("Alice description", top_k=5)
+        assert any(r["id"] == "ent-1" for r in results)
+    finally:
+        await storage.finalize()
+
+
+async def test_flush_batches_by_embedding_batch_num(global_config, counting_embed):
+    global_config = dict(global_config)
+    global_config["embedding_batch_num"] = 2
+    embedding_func = EmbeddingFunc(
+        embedding_dim=DIM,
+        max_token_size=512,
+        func=counting_embed,
+        supports_asymmetric=True,
+    )
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    try:
+        await storage.upsert(
+            {f"ent-{i}": _entity(f"E{i}", f"content {i}") for i in range(5)}
+        )
+        await storage.index_done_callback()
+        # 5 contents at batch size 2 -> 3 embedding calls
+        assert counting_embed.call_count == 3
+        assert len(counting_embed.document_texts) == 5
+    finally:
+        await storage.finalize()
+
+
+async def test_reupsert_same_id_embeds_latest_content_only(
+    global_config, embedding_func, counting_embed
+):
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    try:
+        await storage.upsert({"ent-1": _entity("Alice", "old content")})
+        await storage.upsert({"ent-1": _entity("Alice", "new content")})
+        await storage.index_done_callback()
+        assert counting_embed.document_texts == ["new content"]
+        record = await storage.get_by_id("ent-1")
+        assert record["content"] == "new content"
+    finally:
+        await storage.finalize()
+
+
+async def test_query_filters_by_similarity_threshold_and_orders(
+    global_config, embedding_func
+):
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    try:
+        await storage.upsert(
+            {
+                "ent-1": _entity("Alice", "target text"),
+                "ent-2": _entity("Bob", "other text"),
+            }
+        )
+        await storage.index_done_callback()
+        results = await storage.query("target text", top_k=10)
+        assert results, "identical content must beat the 0.2 threshold"
+        assert results[0]["id"] == "ent-1"
+        # distance field carries cosine SIMILARITY (LightRAG convention)
+        assert results[0]["distance"] == pytest.approx(1.0, abs=1e-5)
+        for record in results:
+            assert record["distance"] >= storage.cosine_better_than_threshold
+            assert "entity_name" in record
+            assert "created_at" in record
+            assert "vector" not in record
+    finally:
+        await storage.finalize()
+
+
+async def test_query_accepts_precomputed_embedding(
+    global_config, embedding_func, counting_embed
+):
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    try:
+        await storage.upsert({"ent-1": _entity("Alice", "some content")})
+        await storage.index_done_callback()
+        embeddings = await counting_embed(["some content"])
+        calls_before = counting_embed.call_count
+        results = await storage.query("ignored", top_k=5, query_embedding=embeddings[0])
+        assert counting_embed.call_count == calls_before  # no re-embedding
+        assert results and results[0]["id"] == "ent-1"
+    finally:
+        await storage.finalize()
+
+
+async def test_meta_fields_projection_drops_extras(global_config, embedding_func):
+    storage = _make_storage(
+        global_config, embedding_func, namespace="chunks", meta_fields=CHUNK_META
+    )
+    await storage.initialize()
+    try:
+        await storage.upsert(
+            {
+                "chunk-1": {
+                    "content": "chunk text",
+                    "full_doc_id": "doc-1",
+                    "file_path": "a.txt",
+                    "tokens": 99,
+                    "chunk_order_index": 1,
+                    "llm_cache_list": ["x"],
+                }
+            }
+        )
+        pending_view = await storage.get_by_id("chunk-1")
+        assert "tokens" not in pending_view
+        await storage.index_done_callback()
+        record = await storage.get_by_id("chunk-1")
+        assert record["full_doc_id"] == "doc-1"
+        assert record["content"] == "chunk text"
+        assert record["file_path"] == "a.txt"
+        assert "tokens" not in record
+        assert "llm_cache_list" not in record
+    finally:
+        await storage.finalize()
+
+
+async def test_read_your_writes_on_pending_buffer(global_config, embedding_func):
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    try:
+        await storage.upsert({"ent-1": _entity("Alice", "pending content")})
+        record = await storage.get_by_id("ent-1")
+        assert record is not None
+        assert record["content"] == "pending content"
+        assert record["id"] == "ent-1"
+        records = await storage.get_by_ids(["ent-1", "missing"])
+        assert records[0]["content"] == "pending content"
+        assert records[1] is None
+    finally:
+        await storage.finalize()
+
+
+async def test_get_vectors_by_ids_embeds_pending_lazily(
+    global_config, embedding_func, counting_embed
+):
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    try:
+        await storage.upsert({"ent-1": _entity("Alice", "lazy content")})
+        vectors = await storage.get_vectors_by_ids(["ent-1", "missing"])
+        assert counting_embed.call_count == 1
+        assert len(vectors["ent-1"]) == DIM
+        assert "missing" not in vectors
+        # Flush reuses the cached vector: no second embedding call.
+        await storage.index_done_callback()
+        assert counting_embed.call_count == 1
+        flushed = await storage.get_vectors_by_ids(["ent-1"])
+        assert flushed["ent-1"] == pytest.approx(vectors["ent-1"])
+    finally:
+        await storage.finalize()
+
+
+async def test_delete_cancels_pending_and_removes_rows(global_config, embedding_func):
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    try:
+        await storage.upsert({"ent-1": _entity("Alice", "a"), "ent-2": _entity("B", "b")})
+        await storage.index_done_callback()
+        await storage.upsert({"ent-3": _entity("C", "c")})
+        await storage.delete(["ent-1", "ent-3", "missing"])
+        assert await storage.get_by_id("ent-1") is None
+        assert await storage.get_by_id("ent-3") is None
+        assert await storage.get_by_id("ent-2") is not None
+        await storage.index_done_callback()
+        assert await storage.get_by_id("ent-3") is None  # pending was cancelled
+    finally:
+        await storage.finalize()
+
+
+async def test_delete_entity_uses_ent_prefixed_hash(global_config, embedding_func):
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    try:
+        entity_id = compute_mdhash_id("Alice", prefix="ent-")
+        await storage.upsert({entity_id: _entity("Alice", "Alice content")})
+        await storage.index_done_callback()
+        await storage.delete_entity("Alice")
+        assert await storage.get_by_id(entity_id) is None
+    finally:
+        await storage.finalize()
+
+
+async def test_delete_entity_relation_matches_src_and_tgt(
+    global_config, embedding_func
+):
+    storage = _make_storage(
+        global_config,
+        embedding_func,
+        namespace="relationships",
+        meta_fields=RELATION_META,
+    )
+    await storage.initialize()
+    try:
+        await storage.upsert(
+            {
+                "rel-1": {
+                    "content": "A->B",
+                    "src_id": "Alice",
+                    "tgt_id": "Bob",
+                    "source_id": "chunk-1",
+                    "file_path": "f",
+                },
+                "rel-2": {
+                    "content": "C->A",
+                    "src_id": "Carol",
+                    "tgt_id": "Alice",
+                    "source_id": "chunk-1",
+                    "file_path": "f",
+                },
+                "rel-3": {
+                    "content": "C->B",
+                    "src_id": "Carol",
+                    "tgt_id": "Bob",
+                    "source_id": "chunk-1",
+                    "file_path": "f",
+                },
+            }
+        )
+        await storage.index_done_callback()
+        # buffer one more pending relation touching Alice
+        await storage.upsert(
+            {
+                "rel-4": {
+                    "content": "A->D",
+                    "src_id": "Alice",
+                    "tgt_id": "Dave",
+                    "source_id": "chunk-1",
+                    "file_path": "f",
+                }
+            }
+        )
+        await storage.delete_entity_relation("Alice")
+        assert await storage.get_by_id("rel-1") is None
+        assert await storage.get_by_id("rel-2") is None
+        assert await storage.get_by_id("rel-4") is None  # pruned from pending
+        assert await storage.get_by_id("rel-3") is not None
+    finally:
+        await storage.finalize()
+
+
+async def test_drop_pending_index_ops_discards_buffer(
+    global_config, embedding_func, counting_embed
+):
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    try:
+        await storage.upsert({"ent-1": _entity("Alice", "abandoned")})
+        await storage.drop_pending_index_ops()
+        await storage.index_done_callback()
+        assert counting_embed.call_count == 0
+        assert await storage.get_by_id("ent-1") is None
+    finally:
+        await storage.finalize()
+
+
+async def test_flush_failure_keeps_pending_and_raises(global_config):
+    class FailingEmbed(CountingEmbed):
+        def __init__(self):
+            super().__init__()
+            self.fail_times = 1
+
+        async def __call__(self, texts, **kwargs):
+            if self.fail_times > 0:
+                self.fail_times -= 1
+                raise RuntimeError("embedding failed")
+            return await super().__call__(texts, **kwargs)
+
+    failing = FailingEmbed()
+    embedding_func = EmbeddingFunc(embedding_dim=DIM, max_token_size=512, func=failing)
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    try:
+        await storage.upsert({"ent-1": _entity("Alice", "retry me")})
+        with pytest.raises(RuntimeError, match="embedding failed"):
+            await storage.index_done_callback()
+        # Buffer intact: retry succeeds.
+        await storage.index_done_callback()
+        assert (await storage.get_by_id("ent-1"))["content"] == "retry me"
+    finally:
+        await storage.finalize()
+
+
+async def test_finalize_flushes_pending(global_config, embedding_func, counting_embed):
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    await storage.upsert({"ent-1": _entity("Alice", "flushed at finalize")})
+    await storage.finalize()
+    assert counting_embed.call_count == 1
+
+    reopened = _make_storage(global_config, embedding_func)
+    await reopened.initialize()
+    try:
+        record = await reopened.get_by_id("ent-1")
+        assert record is not None
+        assert record["content"] == "flushed at finalize"
+    finally:
+        await reopened.finalize()
+
+
+async def test_table_name_includes_model_suffix(global_config, counting_embed):
+    embedding_func = EmbeddingFunc(
+        embedding_dim=DIM,
+        max_token_size=512,
+        func=counting_embed,
+        model_name="text-embedding-3-small",
+    )
+    storage = _make_storage(global_config, embedding_func)
+    assert storage._table_name == f"ws_entities_text_embedding_3_small_{DIM}d"
+
+
+async def test_drop_recreates_empty_table(global_config, embedding_func):
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    try:
+        await storage.upsert({"ent-1": _entity("Alice", "x")})
+        await storage.index_done_callback()
+        result = await storage.drop()
+        assert result == {"status": "success", "message": "data dropped"}
+        assert await storage.query("x", top_k=5) == []
+        # usable after drop
+        await storage.upsert({"ent-2": _entity("Bob", "y")})
+        await storage.index_done_callback()
+        assert await storage.get_by_id("ent-2") is not None
+    finally:
+        await storage.finalize()

--- a/tests/kg/lancedb_impl/test_lancedb_vector_storage.py
+++ b/tests/kg/lancedb_impl/test_lancedb_vector_storage.py
@@ -231,7 +231,9 @@ async def test_delete_cancels_pending_and_removes_rows(global_config, embedding_
     storage = _make_storage(global_config, embedding_func)
     await storage.initialize()
     try:
-        await storage.upsert({"ent-1": _entity("Alice", "a"), "ent-2": _entity("B", "b")})
+        await storage.upsert(
+            {"ent-1": _entity("Alice", "a"), "ent-2": _entity("B", "b")}
+        )
         await storage.index_done_callback()
         await storage.upsert({"ent-3": _entity("C", "c")})
         await storage.delete(["ent-1", "ent-3", "missing"])

--- a/tests/kg/lancedb_impl/test_lancedb_vector_storage.py
+++ b/tests/kg/lancedb_impl/test_lancedb_vector_storage.py
@@ -1,5 +1,8 @@
 """Unit tests for LanceDBVectorStorage: deferred embedding, query, deletes."""
 
+import asyncio
+
+import numpy as np
 import pytest
 
 pytest.importorskip("lancedb", reason="lancedb is required for LanceDB storage tests")
@@ -7,7 +10,7 @@ pytest.importorskip("lancedb", reason="lancedb is required for LanceDB storage t
 from lightrag.kg.lancedb_impl import LanceDBVectorStorage  # noqa: E402
 from lightrag.utils import EmbeddingFunc, compute_mdhash_id  # noqa: E402
 
-from .conftest import DIM, CountingEmbed  # noqa: E402
+from .conftest import DIM, CountingEmbed, text_vector  # noqa: E402
 
 pytestmark = pytest.mark.offline
 
@@ -400,5 +403,84 @@ async def test_drop_recreates_empty_table(global_config, embedding_func):
         await storage.upsert({"ent-2": _entity("Bob", "y")})
         await storage.index_done_callback()
         assert await storage.get_by_id("ent-2") is not None
+    finally:
+        await storage.finalize()
+
+
+def _gated_embedding_func():
+    """EmbeddingFunc that blocks inside the embedding call until released.
+
+    Lets tests hold an index_done_callback flush mid-embedding (with
+    _buffer_lock held) while another coroutine races against it.
+    """
+    entered = asyncio.Event()
+    gate = asyncio.Event()
+
+    async def gated_embed(texts, **kwargs):
+        entered.set()
+        await gate.wait()
+        return np.array([text_vector(t) for t in texts])
+
+    func = EmbeddingFunc(embedding_dim=DIM, max_token_size=512, func=gated_embed)
+    return func, entered, gate
+
+
+async def test_delete_entity_relation_serializes_with_inflight_flush(global_config):
+    """Regression: delete_entity_relation must not leave an orphaned relation
+    vector when it overlaps an in-flight flush (it used to delete table rows
+    before pruning the pending buffer, so the flush re-persisted the doc)."""
+    embedding_func, entered, gate = _gated_embedding_func()
+    storage = _make_storage(
+        global_config,
+        embedding_func,
+        namespace="relationships",
+        meta_fields=RELATION_META,
+    )
+    await storage.initialize()
+    try:
+        await storage.upsert(
+            {
+                "rel-1": {
+                    "content": "Alice likes Bob",
+                    "src_id": "Alice",
+                    "tgt_id": "Bob",
+                    "source_id": "chunk-1",
+                    "file_path": "test.txt",
+                }
+            }
+        )
+        flush = asyncio.create_task(storage.index_done_callback())
+        await entered.wait()  # flush holds _buffer_lock, blocked in embedding
+        delete = asyncio.create_task(storage.delete_entity_relation("Alice"))
+        await asyncio.sleep(0)  # let delete start and block behind the flush
+        gate.set()
+        await asyncio.gather(flush, delete)
+        rows = await storage._table().query().to_list()
+        assert not any(
+            row["src_id"] == "Alice" or row["tgt_id"] == "Alice" for row in rows
+        )
+    finally:
+        await storage.finalize()
+
+
+async def test_drop_serializes_with_inflight_flush(global_config):
+    """drop() holds _buffer_lock across the table recreate, so an overlapping
+    flush either lands before the drop (rows removed) or sees an empty buffer
+    afterwards — never a resurrected table."""
+    embedding_func, entered, gate = _gated_embedding_func()
+    storage = _make_storage(global_config, embedding_func)
+    await storage.initialize()
+    try:
+        await storage.upsert({"ent-1": _entity("Alice", "x")})
+        flush = asyncio.create_task(storage.index_done_callback())
+        await entered.wait()
+        drop = asyncio.create_task(storage.drop())
+        await asyncio.sleep(0)
+        gate.set()
+        results = await asyncio.gather(flush, drop)
+        assert results[1] == {"status": "success", "message": "data dropped"}
+        assert await storage._table().count_rows() == 0
+        async with storage._buffer_lock:
+            assert not storage._pending_docs
     finally:
         await storage.finalize()

--- a/tests/kg/lancedb_impl/test_llm_cache_tools_lancedb.py
+++ b/tests/kg/lancedb_impl/test_llm_cache_tools_lancedb.py
@@ -1,0 +1,197 @@
+"""Offline tests for LanceDB support in the LLM cache maintenance tools.
+
+Unlike the OpenSearch tool tests (which fake the client), these run against a
+real embedded LanceDB in a tmp_path — LanceDB is single-process and cheap to
+spin up, so the tool branches are exercised end to end through the real
+``get_all_keys`` / ``get_by_ids`` / ``delete`` methods.
+"""
+
+import pytest
+
+pytest.importorskip("lancedb", reason="lancedb is required for LanceDB tool tests")
+
+from lightrag.kg.lancedb_impl import LanceDBKVStorage  # noqa: E402
+from lightrag.namespace import NameSpace  # noqa: E402
+from lightrag.tools.clean_llm_query_cache import CleanupStats, CleanupTool  # noqa: E402
+from lightrag.tools.migrate_llm_cache import MigrationTool  # noqa: E402
+from lightrag.tools.rebuild_vdb import enumerate_kv_keys  # noqa: E402
+
+pytestmark = pytest.mark.offline
+
+
+async def _make_llm_cache_storage(global_config, embedding_func, workspace="ws"):
+    storage = LanceDBKVStorage(
+        namespace=NameSpace.KV_STORE_LLM_RESPONSE_CACHE,
+        workspace=workspace,
+        global_config=global_config,
+        embedding_func=embedding_func,
+    )
+    await storage.initialize()
+    return storage
+
+
+class TestRebuildVdbLanceDB:
+    async def test_enumerate_kv_keys_lancedb(self, global_config, embedding_func):
+        storage = LanceDBKVStorage(
+            namespace=NameSpace.KV_STORE_TEXT_CHUNKS,
+            workspace="ws",
+            global_config=global_config,
+            embedding_func=embedding_func,
+        )
+        await storage.initialize()
+        try:
+            await storage.upsert(
+                {
+                    "chunk-1": {"content": "a"},
+                    "doc-0001-chunk-0": {"content": "b"},
+                }
+            )
+            keys = await enumerate_kv_keys(storage)
+            assert set(keys) == {"chunk-1", "doc-0001-chunk-0"}
+        finally:
+            await storage.finalize()
+
+
+class TestCleanupToolLanceDB:
+    def test_get_storage_class_lancedb(self):
+        assert (
+            CleanupTool().get_storage_class("LanceDBKVStorage").__name__
+            == "LanceDBKVStorage"
+        )
+
+    def test_check_config_ini_for_storage_lancedb(self):
+        # Embedded backend needs no config.ini section to be usable.
+        assert CleanupTool().check_config_ini_for_storage("LanceDBKVStorage")
+
+    async def test_count_query_caches_lancedb(self, global_config, embedding_func):
+        storage = await _make_llm_cache_storage(global_config, embedding_func)
+        try:
+            await storage.upsert(
+                {
+                    "mix:query:1": {"content": "a"},
+                    "mix:keywords:1": {"content": "b"},
+                    "hybrid:query:1": {"content": "c"},
+                    "local:keywords:1": {"content": "d"},
+                    "default:extract:1": {"content": "ignored"},
+                }
+            )
+            counts = await CleanupTool().count_query_caches(
+                storage, "LanceDBKVStorage"
+            )
+            assert counts["mix"] == {"query": 1, "keywords": 1}
+            assert counts["hybrid"] == {"query": 1, "keywords": 0}
+            assert counts["local"] == {"query": 0, "keywords": 1}
+            assert counts["global"] == {"query": 0, "keywords": 0}
+        finally:
+            await storage.finalize()
+
+    @pytest.mark.parametrize(
+        ("cleanup_type", "expected_remaining"),
+        [
+            ("all", {"default:extract:1"}),
+            ("query", {"mix:keywords:1", "default:extract:1"}),
+            ("keywords", {"mix:query:1", "default:extract:1"}),
+        ],
+    )
+    async def test_delete_query_caches_lancedb(
+        self, global_config, embedding_func, cleanup_type, expected_remaining
+    ):
+        storage = await _make_llm_cache_storage(global_config, embedding_func)
+        try:
+            await storage.upsert(
+                {
+                    "mix:query:1": {"content": "a"},
+                    "mix:keywords:1": {"content": "b"},
+                    "default:extract:1": {"content": "keep"},
+                }
+            )
+            tool = CleanupTool()
+            tool.batch_size = 1  # force multi-batch deletion path
+            stats = CleanupStats()
+            await tool.delete_query_caches(
+                storage, "LanceDBKVStorage", cleanup_type, stats
+            )
+            assert set(await storage.get_all_keys()) == expected_remaining
+            deleted = 3 - len(expected_remaining)
+            assert stats.successfully_deleted == deleted
+        finally:
+            await storage.finalize()
+
+
+class TestMigrationToolLanceDB:
+    def test_get_storage_class_lancedb(self):
+        assert (
+            MigrationTool().get_storage_class("LanceDBKVStorage").__name__
+            == "LanceDBKVStorage"
+        )
+
+    async def test_count_and_stream_default_caches_lancedb(
+        self, global_config, embedding_func
+    ):
+        storage = await _make_llm_cache_storage(global_config, embedding_func)
+        try:
+            await storage.upsert(
+                {
+                    "default:extract:1": {"return": "a"},
+                    "default:summary:1": {"return": "b"},
+                    "default:extract:2": {"return": "c"},
+                    "mix:query:1": {"return": "ignored"},
+                }
+            )
+            tool = MigrationTool()
+            count = await tool.count_default_caches(storage, "LanceDBKVStorage")
+            assert count == 3
+
+            streamed = {}
+            batch_count = 0
+            async for batch in tool.stream_default_caches(
+                storage, "LanceDBKVStorage", batch_size=2
+            ):
+                batch_count += 1
+                assert len(batch) <= 2
+                streamed.update(batch)
+
+            assert set(streamed) == {
+                "default:extract:1",
+                "default:summary:1",
+                "default:extract:2",
+            }
+            # Synthetic _id is stripped; real payload fields survive.
+            assert streamed["default:extract:1"]["return"] == "a"
+            assert "_id" not in streamed["default:extract:1"]
+            assert batch_count == 2
+        finally:
+            await storage.finalize()
+
+    async def test_migrate_round_trip_lancedb_target(
+        self, global_config, embedding_func
+    ):
+        """LanceDB as a migration target: streamed batches upsert and persist."""
+        source = await _make_llm_cache_storage(
+            global_config, embedding_func, workspace="src"
+        )
+        target = await _make_llm_cache_storage(
+            global_config, embedding_func, workspace="dst"
+        )
+        try:
+            await source.upsert(
+                {
+                    "default:extract:1": {"return": "a"},
+                    "default:summary:1": {"return": "b"},
+                }
+            )
+            tool = MigrationTool()
+            async for batch in tool.stream_default_caches(
+                source, "LanceDBKVStorage", batch_size=1000
+            ):
+                await target.upsert(batch)
+            await target.index_done_callback()
+
+            assert set(await target.get_all_keys()) == {
+                "default:extract:1",
+                "default:summary:1",
+            }
+            assert (await target.get_by_id("default:extract:1"))["return"] == "a"
+        finally:
+            await source.finalize()
+            await target.finalize()

--- a/tests/kg/lancedb_impl/test_llm_cache_tools_lancedb.py
+++ b/tests/kg/lancedb_impl/test_llm_cache_tools_lancedb.py
@@ -75,9 +75,7 @@ class TestCleanupToolLanceDB:
                     "default:extract:1": {"content": "ignored"},
                 }
             )
-            counts = await CleanupTool().count_query_caches(
-                storage, "LanceDBKVStorage"
-            )
+            counts = await CleanupTool().count_query_caches(storage, "LanceDBKVStorage")
             assert counts["mix"] == {"query": 1, "keywords": 1}
             assert counts["hybrid"] == {"query": 1, "keywords": 0}
             assert counts["local"] == {"query": 0, "keywords": 1}

--- a/tests/kg/opensearch_impl/test_llm_cache_tools_opensearch.py
+++ b/tests/kg/opensearch_impl/test_llm_cache_tools_opensearch.py
@@ -164,8 +164,10 @@ class TestMigrationToolOpenSearch:
         monkeypatch.chdir(tmp_path)
         (tmp_path / "config.ini").write_text("[opensearch]\nhosts = localhost:9200\n")
 
+        # JsonKVStorage (no config) + OpenSearchKVStorage (config.ini) +
+        # LanceDBKVStorage (embedded, no config needed) are all available.
         with patch.dict("os.environ", {}, clear=True):
-            assert MigrationTool().count_available_storage_types() == 2
+            assert MigrationTool().count_available_storage_types() == 3
 
     @pytest.mark.asyncio
     async def test_setup_storage_returns_effective_workspace(self, monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -1070,6 +1070,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecation"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
+]
+
+[[package]]
 name = "dill"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1166,7 +1178,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2007,6 +2019,55 @@ wheels = [
 ]
 
 [[package]]
+name = "lance-namespace"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lance-namespace-urllib3-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/81/4cf8d0412e1f37b2bfa70d0aeb9c7ae4ab73607534e44d60b55efb485306/lance_namespace-0.9.0.tar.gz", hash = "sha256:f738b641cc615b17323baa4eb47900f184688739ee3d2ea9fe39396b9588e53d", size = 11637, upload-time = "2026-07-01T07:42:41.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/fe/f38747c9610ade83dd9a99a0470b9432b6f21ce4e2bb5524edbe66f626fd/lance_namespace-0.9.0-py3-none-any.whl", hash = "sha256:f785ff10927e4ce0db69986576670fedd37f8a33521e8a4630c6be22db8061b2", size = 13501, upload-time = "2026-07-01T07:42:39.372Z" },
+]
+
+[[package]]
+name = "lance-namespace-urllib3-client"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/c3/32d0e2618549ace857c80a457e5915ef3e1145661baff876c8a5ec27be5b/lance_namespace_urllib3_client-0.9.0.tar.gz", hash = "sha256:cf796fa5307fa4dde91fe4bec2af28b90ba79191852d4394e8fe44276538e40f", size = 235805, upload-time = "2026-07-01T07:42:42.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/ab/c8754da0a1efc817f8480100cfe12b7e04034df834759de8ecf02beff3cc/lance_namespace_urllib3_client-0.9.0-py3-none-any.whl", hash = "sha256:be819c8cffb1e460a3a504dbf52d1ca009560a48e7202b8c4279998e4adf9fe4", size = 405586, upload-time = "2026-07-01T07:42:40.503Z" },
+]
+
+[[package]]
+name = "lancedb"
+version = "0.34.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecation" },
+    { name = "lance-namespace" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "overrides", marker = "python_full_version < '3.12'" },
+    { name = "packaging" },
+    { name = "pyarrow" },
+    { name = "pydantic" },
+    { name = "tqdm" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/f7/5262b9aa593f790757163c0165ab0da1dda054758901bea7e4f02c9cb633/lancedb-0.34.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:c462f2e6f933cad659fd0179394eaab578acbc9151fe2ef41bc29b36ecca5058", size = 52654213, upload-time = "2026-07-02T17:13:31.102Z" },
+    { url = "https://files.pythonhosted.org/packages/69/99/05ea0d32229ebea695193ff20c15d6ecae25785ad82a9d4723d98832a284/lancedb-0.34.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:48829e88e708947d0520454ab9e4f8efa35f3e3626469eadd3a6e061b89cb223", size = 55434501, upload-time = "2026-07-02T17:13:34.81Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4e/4325c13d5afa93c466428a5a0f168ad4d96f5eb4a77bbe7c5100d39c9897/lancedb-0.34.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:05ba8a5b58e064edfbe5be71b1abf2e411b4eaf295d1a173dcb1a55c5bfb5285", size = 58659359, upload-time = "2026-07-02T17:13:38.424Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/8ca165f1386caf6c4d1c515afd52f345b66432264eecfdfb7fd33eefd9af/lancedb-0.34.0-cp39-abi3-win_amd64.whl", hash = "sha256:51cbc11808f9e3332819b9367c975b3a888541447a8e7bea09c57c852a279153", size = 63530726, upload-time = "2026-07-02T17:13:41.612Z" },
+]
+
+[[package]]
 name = "langchain"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2386,6 +2447,7 @@ offline = [
     { name = "httpx" },
     { name = "jiter" },
     { name = "json-repair" },
+    { name = "lancedb" },
     { name = "langchain-experimental" },
     { name = "langchain-text-splitters" },
     { name = "llama-index" },
@@ -2446,6 +2508,7 @@ offline-llm = [
 offline-storage = [
     { name = "asyncpg" },
     { name = "faiss-cpu" },
+    { name = "lancedb" },
     { name = "neo4j" },
     { name = "opensearch-py" },
     { name = "pgvector" },
@@ -2551,6 +2614,7 @@ requires-dist = [
     { name = "jiter", marker = "extra == 'api'" },
     { name = "json-repair", specifier = ">=0.59.9,<1.0.0" },
     { name = "json-repair", marker = "extra == 'api'", specifier = ">=0.59.9,<1.0.0" },
+    { name = "lancedb", marker = "extra == 'offline-storage'", specifier = ">=0.34.0,<1.0.0" },
     { name = "langchain-experimental", marker = "extra == 'api'", specifier = ">=0.3.2,<1" },
     { name = "langchain-text-splitters", marker = "extra == 'api'", specifier = ">=0.3,<2" },
     { name = "langfuse", marker = "extra == 'observability'", specifier = ">=3.8.1" },
@@ -3728,6 +3792,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/9a/900a6b9b413e0f8a471cf07830f9cf65939af039a362204b36bd5b581d8b/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ee766d2e78251b7a63daf1cddfac36a73562d3ddef68cacfb41b2af64698033", size = 203170, upload-time = "2026-01-18T20:55:44.469Z" },
     { url = "https://files.pythonhosted.org/packages/87/4c/27a95466354606b256f24fad464d7c97ab62bce6cc529dd4673e1179b8fb/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:292410a7d23de9b40444636b9b8f1e4e4b814af7f1ef476e44887e52a123f09d", size = 212816, upload-time = "2026-01-18T20:55:23.501Z" },
     { url = "https://files.pythonhosted.org/packages/73/cd/29cee6007bddf7a834e6cd6f536754c0535fcb939d384f0f37a38b1cddb8/ormsgpack-1.12.2-cp314-cp314t-win_amd64.whl", hash = "sha256:837dd316584485b72ef451d08dd3e96c4a11d12e4963aedb40e08f89685d8ec2", size = 117232, upload-time = "2026-01-18T20:55:45.448Z" },
+]
+
+[[package]]
+name = "overrides"
+version = "7.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/86/b585f53236dec60aba864e050778b25045f857e17f6e5ea0ae95fe80edd2/overrides-7.7.0.tar.gz", hash = "sha256:55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a", size = 22812, upload-time = "2024-01-27T21:01:33.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/ab/fc8290c6a4c722e5514d80f62b2dc4c4df1a68a41d1364e625c35990fcf3/overrides-7.7.0-py3-none-any.whl", hash = "sha256:c7ed9d062f78b8e4c1a7b70bd8796b35ead4d9f510227ef9c5dc7626c60d7e49", size = 17832, upload-time = "2024-01-27T21:01:31.393Z" },
 ]
 
 [[package]]
@@ -5142,7 +5215,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -5204,7 +5277,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [


### PR DESCRIPTION
Closes #3379

## What

Implements all four LightRAG storage types on embedded LanceDB in a single local directory, with no external services:

- `LanceDBKVStorage` / `LanceDBVectorStorage` / `LanceDBGraphStorage` / `LanceDBDocStatusStorage`, on the native async API (`connect_async`) with a ref-counted shared connection, per-table write locks, strong read consistency
- Deferred-embedding vector upserts, cosine query with similarity threshold, embedding-model-suffixed tables for model isolation
- CJK-friendly BM25 full-text search (bigram tokenizer)
- Canonical undirected edge storage, client-side BFS knowledge graph; passes the cross-backend graph conformance suite
- Maintenance tools (`rebuild_vdb` / `clean_llm_query_cache` / `migrate_llm_cache`) extended to support LanceDB
- `lightrag-gunicorn` multi-worker guard; docs, `env.example`, packaging

## Testing

- 73 offline tests (`tests/kg/lancedb_impl`) on real tmp-dir LanceDB
- Cross-backend graph conformance suite (8/8)
- `ruff` clean

## Known limitations & follow-up enhancements

Deliberately deferred, tracked for future work:

1. **`get_docs_paginated` loads the full table then paginates in Python** — fine for embedded-scale `doc_status` tables (hundreds–thousands of rows), but could push pagination into the DB layer for very large sets.
2. **`LANCEDB_WORKSPACE` env override bypasses `validate_workspace`** — the value still passes through `_sanitize_table_name` (no safety risk), but validation should be consistent with the constructor path.
3. **A timestamp test uses `asyncio.sleep(1.1)`** — could mock time or use a shorter sleep + tolerance to speed up the suite.

## Notes

- Single-process only (embedded DB + per-table locks); multi-worker deployments should use PostgreSQL/MongoDB/OpenSearch. `lightrag-gunicorn` refuses to start with multiple workers when a LanceDB backend is selected.
