### PR TITLE
feat(documents): add crash-safe deferred batch deletion

### DIFF
--- a/docs/LightRAG-API-Server.md
+++ b/docs/LightRAG-API-Server.md
@@ -1150,3 +1150,37 @@ This endpoint provides comprehensive status information including:
 * Content summary and metadata
 * Error messages if processing failed
 * Timestamps for creation and updates
+
+## Durable Deferred Batch Deletion Recovery
+
+`DELETE /documents/delete_document` records a durable journal before it begins a multi-document destructive delete. The journal is stored under `<working_dir>/deletion_journals/<workspace>/`; therefore `working_dir` must be persistent and shared with the server instance that will perform recovery. Do not use an ephemeral container filesystem if operators must be able to resume a failed deletion after restart.
+
+For a batch delete, LightRAG first prepares every document, performs **one** rebuild of the affected graph targets, verifies the rebuild, and only then removes source metadata. If any step fails, the journal remains unfinished and no failed batch is reported as a successful delete. The lifecycle stages are:
+
+- `PREPARED` — durable intent and source metadata snapshot exist; document preparation may still be resumed.
+- `REBUILD_PENDING` — all documents are prepared; the single aggregate rebuild is required.
+- `FINALIZATION_PENDING` — rebuild completed; source metadata finalization is required.
+- `FAILED_RETRYABLE` — an operator must explicitly resume the stored recovery stage.
+- `COMMITTED` — rebuild and metadata verification completed. Committed journals are not returned by the unfinished-batch list.
+
+All endpoints use the normal document API authentication (for example, `X-API-Key`). They expose no retained source-document metadata:
+
+```bash
+# List unfinished batches in the active workspace.
+curl -H "X-API-Key: $LIGHTRAG_API_KEY" \
+  http://localhost:9621/documents/delete_document/deferred
+
+# Inspect the stage, document IDs, error, and aggregate rebuild targets.
+curl -H "X-API-Key: $LIGHTRAG_API_KEY" \
+  http://localhost:9621/documents/delete_document/deferred/<batch_id>
+
+# Explicitly retry one batch after resolving its underlying storage/cache error.
+curl -X POST -H "X-API-Key: $LIGHTRAG_API_KEY" \
+  http://localhost:9621/documents/delete_document/<batch_id>/resume
+```
+
+The list response contains `batch_id`, stage, progress index, attempt count, error detail, and aggregate-target counts. The detail response additionally includes document IDs, `delete_llm_cache`, and the aggregate entity/relation rebuild targets. Unknown batch IDs return `404`; a resume may return `status="busy"` when another destructive pipeline job owns the workspace.
+
+Resume runs as a destructive pipeline job and restores the pipeline busy state before continuing. It is intentionally **not** automatic at process startup: inspect the error and restore the dependency that failed (such as cache or storage availability), then issue the explicit `POST .../resume` request. Concurrent resumes for the same batch are serialized, and a committed batch is not rebuilt again.
+
+When the original delete request used `delete_file=true`, the journal retains the normalized source-file paths. LightRAG performs best-effort source file cleanup only after `COMMITTED`, for both the initial completion and a later resume; duplicate paths are cleaned at most once per batch.

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -30,6 +30,14 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from lightrag import LightRAG
 from lightrag.base import DocProcessingStatus, DocStatus
+from lightrag.deferred_delete import (
+    resume_deferred_batch_delete,
+    run_deferred_batch_delete,
+)
+from lightrag.deletion_journal import (
+    DeferredDeletionJournalStore,
+    DeferredDeletionStage,
+)
 from lightrag.constants import (
     FILE_EXTRACTION_SUMMARY_PREFIX,
     FULL_DOCS_FORMAT_PENDING_PARSE,
@@ -972,6 +980,52 @@ class PipelineStatusResponse(BaseModel):
         return format_datetime(value)
 
     model_config = ConfigDict(extra="allow")
+
+
+class DeferredDeletionJournalSummaryResponse(BaseModel):
+    """Operator-safe progress summary for one durable deletion batch."""
+
+    batch_id: str
+    stage: DeferredDeletionStage
+    document_count: int
+    current_document_index: int
+    attempt_count: int
+    error_detail: Optional[str]
+    entities_to_rebuild_count: int
+    relationships_to_rebuild_count: int
+    created_at: str
+    updated_at: str
+
+
+class DeferredDeletionJournalListResponse(BaseModel):
+    """All unfinished durable deletion batches in the current workspace."""
+
+    journals: List[DeferredDeletionJournalSummaryResponse]
+    total_count: int
+
+
+class DeferredDeletionJournalDetailResponse(DeferredDeletionJournalSummaryResponse):
+    """Read-only batch detail excluding retained source-document metadata."""
+
+    document_ids: List[str]
+    delete_llm_cache: bool
+    entities_to_rebuild: Dict[str, List[str]]
+    relationships_to_rebuild: List[Dict[str, Any]]
+
+
+def _deferred_deletion_summary(journal) -> dict[str, Any]:
+    return {
+        "batch_id": journal.batch_id,
+        "stage": journal.stage,
+        "document_count": len(journal.document_ids),
+        "current_document_index": journal.current_document_index,
+        "attempt_count": journal.attempt_count,
+        "error_detail": journal.error_detail,
+        "entities_to_rebuild_count": len(journal.entities_to_rebuild),
+        "relationships_to_rebuild_count": len(journal.relationships_to_rebuild),
+        "created_at": journal.created_at,
+        "updated_at": journal.updated_at,
+    }
 
 
 class DocumentManager:
@@ -2275,6 +2329,44 @@ async def background_delete_documents(
             )
 
     try:
+        # Production LightRAG has a persistent working directory. Retain the
+        # old direct path only for compatibility with minimal in-process test
+        # doubles and third-party subclasses that have not adopted it yet.
+        if hasattr(rag, "working_dir"):
+            batch_result = await run_deferred_batch_delete(
+                rag,
+                doc_ids,
+                delete_llm_cache=delete_llm_cache,
+                delete_file=delete_file,
+            )
+            if batch_result.stage is DeferredDeletionStage.COMMITTED:
+                await cleanup_deferred_delete_files(
+                    rag, doc_manager, batch_result.batch_id
+                )
+                successful_deletions.extend(doc_ids)
+                completion_detail = (
+                    f"Deferred batch {batch_result.batch_id} committed after one rebuild "
+                    "and metadata verification"
+                )
+                logger.info(completion_detail)
+                async with pipeline_status_lock:
+                    pipeline_status["latest_message"] = completion_detail
+                    pipeline_status["history_messages"].append(completion_detail)
+            else:
+                # Do not report a partial destructive operation as success. The
+                # durable journal survives restart and is the source of truth for a
+                # future explicit resume action.
+                failed_deletions.extend(doc_ids)
+                retry_detail = (
+                    f"Deferred batch {batch_result.batch_id} is "
+                    f"{batch_result.stage.value}: {batch_result.error_detail}"
+                )
+                logger.error(retry_detail)
+                async with pipeline_status_lock:
+                    pipeline_status["latest_message"] = retry_detail
+                    pipeline_status["history_messages"].append(retry_detail)
+            return
+
         # Loop through each document ID and delete them one by one
         for i, doc_id in enumerate(doc_ids, 1):
             # Check for cancellation at the start of each document deletion
@@ -2423,6 +2515,105 @@ async def background_delete_documents(
                 await rag.apipeline_process_enqueue_documents()
             except Exception as e:
                 logger.error(f"Error processing pending documents after deletion: {e}")
+
+
+async def cleanup_deferred_delete_files(
+    rag: LightRAG, doc_manager: DocumentManager, batch_id: str
+) -> None:
+    """Delete durable source-file snapshots after a committed batch, including resume."""
+    store = DeferredDeletionJournalStore(rag.working_dir, rag.workspace)
+    async with store.batch_lock(batch_id):
+        journal = store.load(batch_id)
+        if (
+            not journal
+            or not journal.delete_file
+            or journal.source_file_cleanup_claimed
+        ):
+            return
+        # Claim before touching the filesystem. Retrying after an uncertain
+        # crash could otherwise delete a newly recreated source file.
+        journal.source_file_cleanup_claimed = True
+        store.save(journal)
+    source_file_paths = journal.source_file_paths or {
+        doc_id: (journal.document_metadata.get(doc_id, {}).get("doc_status") or {}).get(
+            "file_path"
+        )
+        for doc_id in journal.document_ids
+    }
+    # A batch can contain multiple document records originating from the same
+    # file. Cleanup is post-commit and intentionally best-effort, but each
+    # canonical source path must be attempted once, whether this is the initial
+    # completion or an explicit restart/resume.
+    for file_path in dict.fromkeys(source_file_paths.values()):
+        if not file_path or file_path == UNKNOWN_FILE_SOURCE:
+            continue
+        try:
+            deleted_files, file_delete_errors = delete_file_variants_by_file_path(
+                doc_manager.input_dir, file_path
+            )
+            for file_delete_error in file_delete_errors:
+                logger.warning(file_delete_error)
+            if deleted_files:
+                logger.info(
+                    "Successfully deleted source files: %s", ", ".join(deleted_files)
+                )
+        except Exception as file_error:
+            logger.error(
+                "Failed to delete file %s after batch %s: %s",
+                file_path,
+                batch_id,
+                file_error,
+            )
+
+
+async def background_resume_deferred_delete(
+    rag: LightRAG, doc_manager: DocumentManager, batch_id: str
+) -> None:
+    """Resume one durable delete journal after an operator-approved retry."""
+    from lightrag.kg.shared_storage import get_namespace_data, get_namespace_lock
+
+    pipeline_status = await get_namespace_data(
+        "pipeline_status", workspace=rag.workspace
+    )
+    pipeline_status_lock = get_namespace_lock(
+        "pipeline_status", workspace=rag.workspace
+    )
+    journal = DeferredDeletionJournalStore(rag.working_dir, rag.workspace).load(
+        batch_id
+    )
+    total_docs = len(journal.document_ids) if journal else 1
+    async with pipeline_status_lock:
+        pipeline_status.update(
+            {
+                "busy": True,
+                "destructive_busy": True,
+                "job_name": f"Deleting {total_docs} Documents",
+                "job_start": datetime.now().isoformat(),
+                "docs": total_docs,
+                "batchs": total_docs,
+                "cur_batch": 0,
+                "latest_message": "Resuming deferred document deletion process",
+            }
+        )
+        pipeline_status.setdefault("history_messages", []).append(
+            "Resuming deferred document deletion process"
+        )
+    try:
+        result = await resume_deferred_batch_delete(rag, batch_id)
+        if result.stage is DeferredDeletionStage.COMMITTED:
+            await cleanup_deferred_delete_files(rag, doc_manager, batch_id)
+        message = f"Deferred batch {batch_id} resumed as {result.stage.value}"
+        if result.error_detail:
+            message = f"{message}: {result.error_detail}"
+        async with pipeline_status_lock:
+            pipeline_status["latest_message"] = message
+            pipeline_status["history_messages"].append(message)
+    finally:
+        async with pipeline_status_lock:
+            pipeline_status["busy"] = False
+            pipeline_status["destructive_busy"] = False
+            pipeline_status["pending_requests"] = False
+            pipeline_status["cancellation_requested"] = False
 
 
 def create_document_routes(
@@ -3564,6 +3755,118 @@ def create_document_routes(
             # so the next reservation / scan / enqueue can proceed.
             if slot_acquired:
                 await _release_destructive_busy(rag)
+
+    @router.get(
+        "/delete_document/deferred",
+        response_model=DeferredDeletionJournalListResponse,
+        dependencies=[Depends(combined_auth)],
+        summary="List unfinished durable deferred document deletion batches.",
+    )
+    async def list_deferred_document_deletions() -> DeferredDeletionJournalListResponse:
+        if not hasattr(rag, "working_dir"):
+            raise HTTPException(
+                status_code=503,
+                detail="Deferred deletion journals require a persistent working directory",
+            )
+        journals = DeferredDeletionJournalStore(
+            rag.working_dir, rag.workspace
+        ).list_unfinished()
+        summaries = [
+            DeferredDeletionJournalSummaryResponse(
+                **_deferred_deletion_summary(journal)
+            )
+            for journal in journals
+        ]
+        return DeferredDeletionJournalListResponse(
+            journals=summaries, total_count=len(summaries)
+        )
+
+    @router.get(
+        "/delete_document/deferred/{batch_id}",
+        response_model=DeferredDeletionJournalDetailResponse,
+        dependencies=[Depends(combined_auth)],
+        summary="Get read-only status and rebuild targets for a deferred deletion batch.",
+    )
+    async def get_deferred_document_deletion(
+        batch_id: str,
+    ) -> DeferredDeletionJournalDetailResponse:
+        if not hasattr(rag, "working_dir"):
+            raise HTTPException(
+                status_code=503,
+                detail="Deferred deletion journals require a persistent working directory",
+            )
+        journal = DeferredDeletionJournalStore(rag.working_dir, rag.workspace).load(
+            batch_id
+        )
+        if journal is None:
+            raise HTTPException(
+                status_code=404, detail="Deferred deletion batch was not found"
+            )
+        detail = _deferred_deletion_summary(journal)
+        detail.update(
+            document_ids=journal.document_ids,
+            delete_llm_cache=journal.delete_llm_cache,
+            entities_to_rebuild=journal.entities_to_rebuild,
+            relationships_to_rebuild=[
+                {"source": source, "target": target, "chunk_ids": chunk_ids}
+                for (
+                    source,
+                    target,
+                ), chunk_ids in journal.relationships_to_rebuild.items()
+            ],
+        )
+        return DeferredDeletionJournalDetailResponse(**detail)
+
+    class ResumeDeferredDeleteResponse(BaseModel):
+        status: Literal["resume_started", "busy"]
+        message: str
+        batch_id: str
+
+    @router.post(
+        "/delete_document/{batch_id}/resume",
+        response_model=ResumeDeferredDeleteResponse,
+        dependencies=[Depends(combined_auth)],
+        summary="Resume a durable deferred document deletion batch.",
+    )
+    async def resume_delete_document(
+        batch_id: str, background_tasks: BackgroundTasks
+    ) -> ResumeDeferredDeleteResponse:
+        if not hasattr(rag, "working_dir"):
+            raise HTTPException(
+                status_code=503,
+                detail="Deferred deletion journals require a persistent working directory",
+            )
+        try:
+            journal = DeferredDeletionJournalStore(rag.working_dir, rag.workspace).load(
+                batch_id
+            )
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=404, detail="Deferred deletion batch was not found"
+            ) from exc
+        if journal is None:
+            raise HTTPException(
+                status_code=404, detail="Deferred deletion batch was not found"
+            )
+        acquired, reason = await _acquire_destructive_busy(rag)
+        if not acquired:
+            return ResumeDeferredDeleteResponse(
+                status="busy",
+                message=reason or "Cannot resume deletion while pipeline is busy",
+                batch_id=batch_id,
+            )
+        try:
+            background_tasks.add_task(
+                background_resume_deferred_delete, rag, doc_manager, batch_id
+            )
+        except Exception:
+            await _release_destructive_busy(rag)
+            raise
+        return ResumeDeferredDeleteResponse(
+            status="resume_started",
+            message="Deferred deletion resume has been scheduled in the background.",
+            batch_id=batch_id,
+        )
 
     @router.post(
         "/clear_cache",

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -2333,11 +2333,17 @@ async def background_delete_documents(
         # old direct path only for compatibility with minimal in-process test
         # doubles and third-party subclasses that have not adopted it yet.
         if hasattr(rag, "working_dir"):
+
+            async def cancellation_requested() -> bool:
+                async with pipeline_status_lock:
+                    return pipeline_status.get("cancellation_requested", False)
+
             batch_result = await run_deferred_batch_delete(
                 rag,
                 doc_ids,
                 delete_llm_cache=delete_llm_cache,
                 delete_file=delete_file,
+                cancellation_requested=cancellation_requested,
             )
             if batch_result.stage is DeferredDeletionStage.COMMITTED:
                 await cleanup_deferred_delete_files(

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -1001,6 +1001,10 @@ class DeletionResult:
     message: str
     status_code: int = 200
     file_path: str | None = None
+    # Deferred batch deletion returns affected targets to its coordinator so it
+    # can execute one rebuild for the entire batch.
+    entities_to_rebuild: dict[str, list[str]] | None = None
+    relationships_to_rebuild: dict[tuple[str, str], list[str]] | None = None
 
 
 # Unified Query Result Data Structures for Reference List Support

--- a/lightrag/deferred_delete.py
+++ b/lightrag/deferred_delete.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 from uuid import uuid4
@@ -114,7 +115,9 @@ async def _rebuild_once(rag: Any, journal: DeferredDeletionJournal) -> None:
 
 
 async def _continue(
-    rag: Any, journal: DeferredDeletionJournal
+    rag: Any,
+    journal: DeferredDeletionJournal,
+    cancellation_requested: Callable[[], Awaitable[bool]] | None = None,
 ) -> DeferredDeletionResult:
     store = _store(rag)
     if journal.stage is DeferredDeletionStage.FAILED_RETRYABLE:
@@ -139,6 +142,12 @@ async def _continue(
         }
         while journal.current_document_index < len(journal.document_ids):
             doc_id = journal.document_ids[journal.current_document_index]
+            if cancellation_requested is not None and await cancellation_requested():
+                journal.mark_failed_retryable("document deletion cancelled by user")
+                store.save(journal)
+                return DeferredDeletionResult(
+                    journal.batch_id, journal.stage, journal.error_detail
+                )
             checkpoint = journal.document_delete_checkpoints.get(doc_id)
             if checkpoint is not None:
                 if checkpoint.get("state") == "INTENT":
@@ -181,7 +190,7 @@ async def _continue(
                 return DeferredDeletionResult(
                     journal.batch_id, journal.stage, journal.error_detail
                 )
-            if result.status != "success":
+            if result.status not in {"success", "not_found"}:
                 journal.mark_failed_retryable(result.message)
                 store.save(journal)
                 return DeferredDeletionResult(
@@ -189,8 +198,12 @@ async def _continue(
                 )
             journal.record_document_delete_completed(
                 doc_id,
-                entities=result.entities_to_rebuild or {},
-                relationships=result.relationships_to_rebuild or {},
+                entities=(result.entities_to_rebuild or {})
+                if result.status == "success"
+                else {},
+                relationships=(result.relationships_to_rebuild or {})
+                if result.status == "success"
+                else {},
             )
             journal.current_document_index += 1
             store.save(journal)
@@ -229,6 +242,7 @@ async def run_deferred_batch_delete(
     document_ids: list[str],
     delete_llm_cache: bool = False,
     delete_file: bool = False,
+    cancellation_requested: Callable[[], Awaitable[bool]] | None = None,
 ) -> DeferredDeletionResult:
     """Record intent before destructive work, then delete/rebuild/finalize once."""
     journal = DeferredDeletionJournal.new(
@@ -245,7 +259,7 @@ async def run_deferred_batch_delete(
         persisted = store.load(journal.batch_id)
         if persisted is None:  # defensive: an external operator removed intent
             raise RuntimeError(f"deletion journal {journal.batch_id!r} disappeared")
-        return await _continue(rag, persisted)
+        return await _continue(rag, persisted, cancellation_requested)
 
 
 async def resume_deferred_batch_delete(

--- a/lightrag/deferred_delete.py
+++ b/lightrag/deferred_delete.py
@@ -1,0 +1,264 @@
+"""Deferred batch deletion coordinator with restart-safe recovery semantics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from uuid import uuid4
+
+from lightrag.deletion_journal import (
+    DeferredDeletionJournal,
+    DeferredDeletionJournalStore,
+    DeferredDeletionStage,
+)
+from lightrag.kg.shared_storage import get_namespace_data, get_namespace_lock
+from lightrag.operate import rebuild_knowledge_from_chunks
+
+
+@dataclass
+class DeferredDeletionResult:
+    batch_id: str
+    stage: DeferredDeletionStage
+    error_detail: str | None = None
+
+
+def _store(rag: Any) -> DeferredDeletionJournalStore:
+    return DeferredDeletionJournalStore(rag.working_dir, rag.workspace)
+
+
+async def _snapshot_document_metadata(rag: Any, doc_id: str) -> dict[str, Any]:
+    """Persist enough source metadata to finish cleanup after a restart."""
+    return {
+        "doc_status": await rag.doc_status.get_by_id(doc_id),
+        "full_doc": await rag.full_docs.get_by_id(doc_id),
+        "full_entities": await rag.full_entities.get_by_id(doc_id),
+        "full_relations": await rag.full_relations.get_by_id(doc_id),
+    }
+
+
+async def _finalize_metadata(rag: Any, journal: DeferredDeletionJournal) -> None:
+    doc_ids = journal.document_ids
+    if journal.delete_llm_cache:
+        cache_ids = set()
+        for doc_id in doc_ids:
+            snapshot = journal.document_metadata.get(doc_id, {})
+            snapshot_status = snapshot.get("doc_status") or {}
+            snapshot_metadata = snapshot_status.get("metadata")
+            if isinstance(snapshot_metadata, dict):
+                cache_ids.update(snapshot_metadata.get("deletion_llm_cache_ids", []))
+            doc_status = await rag.doc_status.get_by_id(doc_id)
+            if not doc_status:
+                continue
+            # The regular deletion path persists retryable cache IDs in nested
+            # status metadata. Keep the legacy top-level lookup for journals
+            # created by earlier versions.
+            cache_ids.update(doc_status.get("deletion_llm_cache_ids", []))
+            metadata = doc_status.get("metadata")
+            if isinstance(metadata, dict):
+                cache_ids.update(metadata.get("deletion_llm_cache_ids", []))
+        if cache_ids:
+            if not rag.llm_response_cache:
+                raise RuntimeError("LLM cache storage is unavailable for finalization")
+            await rag.llm_response_cache.delete(sorted(cache_ids))
+            remaining = await rag._get_existing_llm_cache_ids(sorted(cache_ids))
+            if remaining:
+                raise RuntimeError("LLM cache entries remain after finalization")
+    await rag.full_entities.delete(doc_ids)
+    await rag.full_relations.delete(doc_ids)
+    await rag.doc_status.delete(doc_ids)
+    await rag.full_docs.delete(doc_ids)
+    await rag._insert_done()
+
+    remaining = await asyncio_gather_get_by_id(
+        rag,
+        doc_ids,
+        (rag.full_entities, rag.full_relations, rag.doc_status, rag.full_docs),
+    )
+    if any(value is not None for value in remaining):
+        raise RuntimeError(
+            "document metadata remains after deferred deletion finalization"
+        )
+
+
+async def asyncio_gather_get_by_id(
+    rag: Any, doc_ids: list[str], stores: tuple[Any, ...]
+) -> list[Any]:
+    import asyncio
+
+    return await asyncio.gather(
+        *(store.get_by_id(doc_id) for store in stores for doc_id in doc_ids)
+    )
+
+
+async def _rebuild_once(rag: Any, journal: DeferredDeletionJournal) -> None:
+    pipeline_status = await get_namespace_data(
+        "pipeline_status", workspace=rag.workspace
+    )
+    pipeline_status_lock = get_namespace_lock(
+        "pipeline_status", workspace=rag.workspace
+    )
+    await rebuild_knowledge_from_chunks(
+        entities_to_rebuild=journal.entities_to_rebuild,
+        relationships_to_rebuild=journal.relationships_to_rebuild,
+        knowledge_graph_inst=rag.chunk_entity_relation_graph,
+        entities_vdb=rag.entities_vdb,
+        relationships_vdb=rag.relationships_vdb,
+        text_chunks_storage=rag.text_chunks,
+        llm_response_cache=rag.llm_response_cache,
+        global_config=rag._build_global_config(),
+        pipeline_status=pipeline_status,
+        pipeline_status_lock=pipeline_status_lock,
+        entity_chunks_storage=rag.entity_chunks,
+        relation_chunks_storage=rag.relation_chunks,
+    )
+
+
+async def _continue(
+    rag: Any, journal: DeferredDeletionJournal
+) -> DeferredDeletionResult:
+    store = _store(rag)
+    if journal.stage is DeferredDeletionStage.FAILED_RETRYABLE:
+        journal.stage = journal.recovery_stage or DeferredDeletionStage.PREPARED
+
+    if journal.stage is DeferredDeletionStage.PREPARED:
+        for doc_id in journal.document_ids:
+            if doc_id not in journal.document_metadata:
+                journal.document_metadata[doc_id] = await _snapshot_document_metadata(
+                    rag, doc_id
+                )
+                file_path = (
+                    journal.document_metadata[doc_id].get("doc_status") or {}
+                ).get("file_path")
+                if isinstance(file_path, str):
+                    journal.source_file_paths[doc_id] = file_path
+                store.save(journal)
+        batch_chunk_ids = {
+            chunk_id
+            for metadata in journal.document_metadata.values()
+            for chunk_id in (metadata.get("doc_status") or {}).get("chunks_list", [])
+        }
+        while journal.current_document_index < len(journal.document_ids):
+            doc_id = journal.document_ids[journal.current_document_index]
+            checkpoint = journal.document_delete_checkpoints.get(doc_id)
+            if checkpoint is not None:
+                if checkpoint.get("state") == "INTENT":
+                    # A process may have died before or after the storage call.
+                    # No transaction spans this filesystem journal and arbitrary
+                    # storage backends, so retrying risks a second delete.
+                    journal.mark_failed_retryable(
+                        "document deletion outcome is unknown after durable intent; "
+                        "refusing to repeat destructive deletion"
+                    )
+                    store.save(journal)
+                    return DeferredDeletionResult(
+                        journal.batch_id, journal.stage, journal.error_detail
+                    )
+                if checkpoint.get("state") != "COMPLETED":
+                    journal.mark_failed_retryable(
+                        f"invalid document deletion checkpoint for {doc_id!r}"
+                    )
+                    store.save(journal)
+                    return DeferredDeletionResult(
+                        journal.batch_id, journal.stage, journal.error_detail
+                    )
+                # A completed result and index are persisted together. Support
+                # a future/partially-written journal which has only the result.
+                journal.current_document_index += 1
+                store.save(journal)
+                continue
+            journal.mark_document_delete_intent(doc_id)
+            store.save(journal)
+            try:
+                result = await rag.adelete_by_doc_id(
+                    doc_id,
+                    delete_llm_cache=journal.delete_llm_cache,
+                    skip_rebuild=True,
+                    batch_chunk_ids=batch_chunk_ids,
+                )
+            except Exception as exc:
+                journal.mark_failed_retryable(f"document deletion failed: {exc}")
+                store.save(journal)
+                return DeferredDeletionResult(
+                    journal.batch_id, journal.stage, journal.error_detail
+                )
+            if result.status != "success":
+                journal.mark_failed_retryable(result.message)
+                store.save(journal)
+                return DeferredDeletionResult(
+                    journal.batch_id, journal.stage, journal.error_detail
+                )
+            journal.record_document_delete_completed(
+                doc_id,
+                entities=result.entities_to_rebuild or {},
+                relationships=result.relationships_to_rebuild or {},
+            )
+            journal.current_document_index += 1
+            store.save(journal)
+        journal.mark_rebuild_pending()
+        store.save(journal)
+
+    if journal.stage is DeferredDeletionStage.REBUILD_PENDING:
+        try:
+            await _rebuild_once(rag, journal)
+        except Exception as exc:
+            journal.mark_failed_retryable(f"rebuild failed: {exc}")
+            store.save(journal)
+            return DeferredDeletionResult(
+                journal.batch_id, journal.stage, journal.error_detail
+            )
+        journal.mark_finalization_pending()
+        store.save(journal)
+
+    if journal.stage is DeferredDeletionStage.FINALIZATION_PENDING:
+        try:
+            await _finalize_metadata(rag, journal)
+        except Exception as exc:
+            journal.mark_failed_retryable(f"metadata finalization failed: {exc}")
+            store.save(journal)
+            return DeferredDeletionResult(
+                journal.batch_id, journal.stage, journal.error_detail
+            )
+        journal.mark_committed()
+        store.save(journal)
+
+    return DeferredDeletionResult(journal.batch_id, journal.stage, journal.error_detail)
+
+
+async def run_deferred_batch_delete(
+    rag: Any,
+    document_ids: list[str],
+    delete_llm_cache: bool = False,
+    delete_file: bool = False,
+) -> DeferredDeletionResult:
+    """Record intent before destructive work, then delete/rebuild/finalize once."""
+    journal = DeferredDeletionJournal.new(
+        batch_id=str(uuid4()),
+        document_ids=document_ids,
+        delete_llm_cache=delete_llm_cache,
+        delete_file=delete_file,
+    )
+    store = _store(rag)
+    # Persist intent before taking destructive action. The per-batch lock then
+    # covers every state transition through finalization, including rebuild.
+    store.save(journal)
+    async with store.batch_lock(journal.batch_id):
+        persisted = store.load(journal.batch_id)
+        if persisted is None:  # defensive: an external operator removed intent
+            raise RuntimeError(f"deletion journal {journal.batch_id!r} disappeared")
+        return await _continue(rag, persisted)
+
+
+async def resume_deferred_batch_delete(
+    rag: Any, batch_id: str
+) -> DeferredDeletionResult:
+    """Resume a failed batch from durable state; never silently report success."""
+    store = _store(rag)
+    # Load *inside* the lock: a concurrent resume may have completed the
+    # journal while this caller was waiting, in which case it must not rebuild.
+    async with store.batch_lock(batch_id):
+        journal = store.load(batch_id)
+        if journal is None:
+            raise ValueError(f"deletion journal {batch_id!r} was not found")
+        if journal.stage is DeferredDeletionStage.COMMITTED:
+            return DeferredDeletionResult(journal.batch_id, journal.stage)
+        return await _continue(rag, journal)

--- a/lightrag/deletion_journal.py
+++ b/lightrag/deletion_journal.py
@@ -1,0 +1,510 @@
+"""Crash-safe journal for deferred batch document deletion.
+
+The journal intentionally lives under ``working_dir`` rather than in a
+particular KV backend.  LightRAG deployments may mix PostgreSQL, JSON, Redis,
+or another graph store, while ``working_dir`` is the shared persistent state
+location already required by the application.  Writes use replace-after-fsync
+so a container restart can only observe the previous complete journal or the
+new complete journal, never a partial JSON document.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import stat
+import tempfile
+import threading
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+# ``flock``/``msvcrt.locking`` protect separate server processes. The asyncio
+# lock closes the same-process hole because POSIX advisory locks are process-
+# scoped and may otherwise let two tasks in one worker re-enter the same lock.
+_in_process_batch_locks: dict[str, asyncio.Lock] = {}
+_in_process_batch_locks_guard = threading.Lock()
+
+
+class DeferredDeletionStage(str, Enum):
+    PREPARED = "PREPARED"
+    REBUILD_PENDING = "REBUILD_PENDING"
+    FINALIZATION_PENDING = "FINALIZATION_PENDING"
+    COMMITTED = "COMMITTED"
+    FAILED_RETRYABLE = "FAILED_RETRYABLE"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _canonical_relation_key(source: str, target: str) -> tuple[str, str]:
+    return (source, target) if source <= target else (target, source)
+
+
+def _ordered_union(existing: list[str], incoming: list[str]) -> list[str]:
+    return list(dict.fromkeys([*existing, *incoming]))
+
+
+_WINDOWS_RESERVED_COMPONENT_BASENAMES = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    "CLOCK$",
+    *(f"COM{number}" for number in range(1, 10)),
+    *(f"LPT{number}" for number in range(1, 10)),
+}
+_WINDOWS_INVALID_COMPONENT_CHARACTERS = frozenset('<>:"/\\\\|?*')
+
+
+def _is_windows_reserved_component(component: str) -> bool:
+    """Return whether a path component aliases a Windows device name.
+
+    Win32 treats device basenames as reserved even when an extension follows
+    (for example ``CON.json`` and ``LPT9.backup``), and strips a trailing space
+    from that basename. Validate before adding our ``.json``/``.lock`` suffixes.
+    """
+    basename = component.split(".", 1)[0].rstrip(" ").upper()
+    return basename in _WINDOWS_RESERVED_COMPONENT_BASENAMES
+
+
+def _workspace_component(workspace: str) -> str:
+    """Return a deterministic workspace directory name valid on Windows and POSIX."""
+    workspace = workspace or "default"
+    is_safe_component = (
+        workspace not in {".", ".."}
+        and not workspace.endswith((".", " "))
+        and not _is_windows_reserved_component(workspace)
+        and not any(
+            character in _WINDOWS_INVALID_COMPONENT_CHARACTERS or ord(character) < 32
+            for character in workspace
+        )
+    )
+    if is_safe_component:
+        return workspace
+
+    digest = hashlib.sha256(workspace.encode("utf-8")).hexdigest()
+    return f"workspace-{digest}"
+
+
+@dataclass
+class DeferredDeletionJournal:
+    """All state needed to safely resume a deferred deletion rebuild."""
+
+    batch_id: str
+    document_ids: list[str]
+    delete_llm_cache: bool
+    delete_file: bool = False
+    source_file_paths: dict[str, str] = field(default_factory=dict)
+    # Claimed durably before best-effort source cleanup. This intentionally
+    # provides at-most-once semantics after crashes.
+    source_file_cleanup_claimed: bool = False
+    stage: DeferredDeletionStage = DeferredDeletionStage.PREPARED
+    entities_to_rebuild: dict[str, list[str]] = field(default_factory=dict)
+    relationships_to_rebuild: dict[tuple[str, str], list[str]] = field(
+        default_factory=dict
+    )
+    document_metadata: dict[str, dict[str, Any]] = field(default_factory=dict)
+    # Save INTENT before calling storage and COMPLETED plus its rebuild result
+    # afterwards. An interrupted INTENT has an unknowable outcome and must not
+    # be retried as another destructive document delete.
+    document_delete_checkpoints: dict[str, dict[str, Any]] = field(default_factory=dict)
+    current_document_index: int = 0
+    attempt_count: int = 0
+    error_detail: str | None = None
+    recovery_stage: DeferredDeletionStage | None = None
+    created_at: str = field(default_factory=_utc_now)
+    updated_at: str = field(default_factory=_utc_now)
+
+    @classmethod
+    def new(
+        cls,
+        batch_id: str,
+        document_ids: list[str],
+        delete_llm_cache: bool,
+        delete_file: bool = False,
+    ) -> "DeferredDeletionJournal":
+        if not batch_id:
+            raise ValueError("batch_id is required")
+        if not document_ids:
+            raise ValueError("document_ids is required")
+        return cls(
+            batch_id=batch_id,
+            document_ids=list(dict.fromkeys(document_ids)),
+            delete_llm_cache=delete_llm_cache,
+            delete_file=delete_file,
+        )
+
+    def aggregate_targets(
+        self,
+        *,
+        entities: dict[str, list[str]],
+        relationships: dict[tuple[str, str], list[str]],
+    ) -> None:
+        for entity_name, chunk_ids in entities.items():
+            self.entities_to_rebuild[entity_name] = _ordered_union(
+                self.entities_to_rebuild.get(entity_name, []), chunk_ids
+            )
+        for (source, target), chunk_ids in relationships.items():
+            relation_key = _canonical_relation_key(source, target)
+            self.relationships_to_rebuild[relation_key] = _ordered_union(
+                self.relationships_to_rebuild.get(relation_key, []), chunk_ids
+            )
+        self.updated_at = _utc_now()
+
+    def mark_document_delete_intent(self, doc_id: str) -> None:
+        if doc_id in self.document_delete_checkpoints:
+            raise ValueError(
+                f"document deletion checkpoint already exists for {doc_id!r}"
+            )
+        self.document_delete_checkpoints[doc_id] = {"state": "INTENT"}
+        self.updated_at = _utc_now()
+
+    def record_document_delete_completed(
+        self,
+        doc_id: str,
+        *,
+        entities: dict[str, list[str]],
+        relationships: dict[tuple[str, str], list[str]],
+    ) -> None:
+        checkpoint = self.document_delete_checkpoints.get(doc_id)
+        if checkpoint != {"state": "INTENT"}:
+            raise ValueError(f"document deletion intent is missing for {doc_id!r}")
+        self.document_delete_checkpoints[doc_id] = {
+            "state": "COMPLETED",
+            "entities_to_rebuild": {
+                name: list(chunk_ids) for name, chunk_ids in entities.items()
+            },
+            "relationships_to_rebuild": [
+                {"source": source, "target": target, "chunk_ids": list(chunk_ids)}
+                for (source, target), chunk_ids in relationships.items()
+            ],
+        }
+        self.aggregate_targets(entities=entities, relationships=relationships)
+
+    def mark_rebuild_pending(self) -> None:
+        if self.stage not in {
+            DeferredDeletionStage.PREPARED,
+            DeferredDeletionStage.FAILED_RETRYABLE,
+        }:
+            raise ValueError(f"cannot move {self.stage} to REBUILD_PENDING")
+        self.stage = DeferredDeletionStage.REBUILD_PENDING
+        self.error_detail = None
+        self.updated_at = _utc_now()
+
+    def mark_failed_retryable(self, error_detail: str) -> None:
+        if self.stage is not DeferredDeletionStage.FAILED_RETRYABLE:
+            self.recovery_stage = self.stage
+        self.stage = DeferredDeletionStage.FAILED_RETRYABLE
+        self.error_detail = error_detail
+        self.attempt_count += 1
+        self.updated_at = _utc_now()
+
+    def mark_finalization_pending(self) -> None:
+        if self.stage is not DeferredDeletionStage.REBUILD_PENDING:
+            raise ValueError("journal must be REBUILD_PENDING before finalization")
+        self.stage = DeferredDeletionStage.FINALIZATION_PENDING
+        self.error_detail = None
+        self.updated_at = _utc_now()
+
+    def mark_committed(self) -> None:
+        if self.stage is not DeferredDeletionStage.FINALIZATION_PENDING:
+            raise ValueError("journal must be FINALIZATION_PENDING before COMMITTED")
+        self.stage = DeferredDeletionStage.COMMITTED
+        self.error_detail = None
+        self.updated_at = _utc_now()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "batch_id": self.batch_id,
+            "document_ids": self.document_ids,
+            "delete_llm_cache": self.delete_llm_cache,
+            "delete_file": self.delete_file,
+            "source_file_paths": self.source_file_paths,
+            "source_file_cleanup_claimed": self.source_file_cleanup_claimed,
+            "stage": self.stage.value,
+            "entities_to_rebuild": self.entities_to_rebuild,
+            "relationships_to_rebuild": [
+                {"source": source, "target": target, "chunk_ids": chunk_ids}
+                for (source, target), chunk_ids in self.relationships_to_rebuild.items()
+            ],
+            "document_metadata": self.document_metadata,
+            "document_delete_checkpoints": self.document_delete_checkpoints,
+            "current_document_index": self.current_document_index,
+            "attempt_count": self.attempt_count,
+            "error_detail": self.error_detail,
+            "recovery_stage": self.recovery_stage.value
+            if self.recovery_stage
+            else None,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "DeferredDeletionJournal":
+        relationships = {
+            _canonical_relation_key(entry["source"], entry["target"]): list(
+                entry.get("chunk_ids", [])
+            )
+            for entry in data.get("relationships_to_rebuild", [])
+        }
+        return cls(
+            batch_id=data["batch_id"],
+            document_ids=list(data["document_ids"]),
+            delete_llm_cache=bool(data["delete_llm_cache"]),
+            delete_file=bool(data.get("delete_file", False)),
+            source_file_paths={
+                doc_id: file_path
+                for doc_id, file_path in data.get("source_file_paths", {}).items()
+                if isinstance(file_path, str)
+            },
+            source_file_cleanup_claimed=bool(
+                data.get("source_file_cleanup_claimed", False)
+            ),
+            stage=DeferredDeletionStage(data["stage"]),
+            entities_to_rebuild={
+                name: list(chunk_ids)
+                for name, chunk_ids in data.get("entities_to_rebuild", {}).items()
+            },
+            relationships_to_rebuild=relationships,
+            document_metadata=dict(data.get("document_metadata", {})),
+            document_delete_checkpoints={
+                doc_id: dict(checkpoint)
+                for doc_id, checkpoint in data.get(
+                    "document_delete_checkpoints", {}
+                ).items()
+                if isinstance(doc_id, str) and isinstance(checkpoint, dict)
+            },
+            current_document_index=int(data.get("current_document_index", 0)),
+            attempt_count=int(data.get("attempt_count", 0)),
+            error_detail=data.get("error_detail"),
+            recovery_stage=(
+                DeferredDeletionStage(data["recovery_stage"])
+                if data.get("recovery_stage")
+                else None
+            ),
+            created_at=data["created_at"],
+            updated_at=data["updated_at"],
+        )
+
+
+def _is_windows() -> bool:
+    """Small seam for platform-specific locking and its non-Windows test coverage."""
+    return os.name == "nt"
+
+
+class DeferredDeletionJournalStore:
+    """Atomic filesystem persistence for deferred deletion journals."""
+
+    def __init__(self, working_dir: str | Path, workspace: str) -> None:
+        journal_root = (Path(working_dir).resolve() / "deletion_journals").resolve()
+        directory = journal_root / _workspace_component(workspace)
+        if not directory.resolve().is_relative_to(journal_root):
+            raise ValueError("workspace journal directory escapes working_dir")
+        self.directory = directory
+
+    def _path(self, batch_id: str) -> Path:
+        if (
+            not batch_id
+            or batch_id in {".", ".."}
+            or batch_id.endswith((".", " "))
+            or _is_windows_reserved_component(batch_id)
+            or any(
+                character in _WINDOWS_INVALID_COMPONENT_CHARACTERS
+                or ord(character) < 32
+                for character in batch_id
+            )
+        ):
+            raise ValueError("invalid batch_id")
+        return self.directory / f"{batch_id}.json"
+
+    def _lock_path(self, batch_id: str) -> Path:
+        self._path(batch_id)  # validate before constructing another filesystem name
+        return self.directory / f".{batch_id}.lock"
+
+    @staticmethod
+    def _in_process_lock(lock_path: Path) -> asyncio.Lock:
+        key = str(lock_path.resolve())
+        with _in_process_batch_locks_guard:
+            return _in_process_batch_locks.setdefault(key, asyncio.Lock())
+
+    @staticmethod
+    def _acquire_os_lock(lock_path: Path) -> int:
+        """Acquire an advisory lock released automatically when the process dies.
+
+        POSIX uses ``flock``. Windows uses a one-byte ``msvcrt.locking`` lock.
+        Both are OS-owned file locks, so a process crash closes the descriptor
+        and releases the lock rather than requiring a stale-lease timeout.
+        """
+        flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(lock_path, flags, 0o600)
+        try:
+            if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+                raise OSError(
+                    f"deletion journal lock is not a regular file: {lock_path}"
+                )
+            if not _is_windows():
+                os.fchmod(descriptor, 0o600)
+            if _is_windows():
+                import msvcrt
+
+                os.lseek(descriptor, 0, os.SEEK_SET)
+                getattr(msvcrt, "locking")(descriptor, getattr(msvcrt, "LK_LOCK"), 1)
+            else:
+                import fcntl
+
+                fcntl.flock(descriptor, fcntl.LOCK_EX)
+            return descriptor
+        except BaseException:
+            os.close(descriptor)
+            raise
+
+    @staticmethod
+    def _release_os_lock(descriptor: int) -> None:
+        try:
+            if _is_windows():
+                import msvcrt
+
+                os.lseek(descriptor, 0, os.SEEK_SET)
+                getattr(msvcrt, "locking")(descriptor, getattr(msvcrt, "LK_UNLCK"), 1)
+            else:
+                import fcntl
+
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+        finally:
+            os.close(descriptor)
+
+    @asynccontextmanager
+    async def batch_lock(self, batch_id: str):
+        """Serialize one batch across tasks and processes for run/resume.
+
+        The lock file is intentionally retained: it contains no journal state,
+        and retaining it avoids an unlink/recreate race. Its advisory lock is
+        released by the OS on normal close *and on process crash* on POSIX and
+        Windows, so a restart cannot deadlock on an abandoned lease.
+        """
+        self.directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+        os.chmod(self.directory, 0o700)
+        lock_path = self._lock_path(batch_id)
+        async with self._in_process_lock(lock_path):
+            # ``to_thread`` cannot be cancelled once its worker started.  Keep
+            # a done callback so cancellation while waiting for a contended
+            # OS lock cannot orphan a descriptor that acquires later.
+            acquire_task = asyncio.create_task(
+                asyncio.to_thread(self._acquire_os_lock, lock_path)
+            )
+            acquisition_abandoned = False
+            release_scheduled = False
+
+            def release_if_unclaimed(task: asyncio.Task[int]) -> None:
+                nonlocal release_scheduled
+                if not acquisition_abandoned or release_scheduled or task.cancelled():
+                    return
+                try:
+                    descriptor = task.result()
+                except BaseException:
+                    return
+                release_scheduled = True
+                asyncio.create_task(
+                    asyncio.to_thread(self._release_os_lock, descriptor)
+                )
+
+            acquire_task.add_done_callback(release_if_unclaimed)
+            try:
+                descriptor = await asyncio.shield(acquire_task)
+            except BaseException:
+                # A cancellation can race with a successful worker result. Mark
+                # the acquisition abandoned and invoke the callback directly
+                # when it already completed; otherwise its done callback will
+                # release the descriptor after flock/msvcrt returns.
+                acquisition_abandoned = True
+                if acquire_task.done():
+                    release_if_unclaimed(acquire_task)
+                raise
+            try:
+                yield
+            finally:
+                await asyncio.to_thread(self._release_os_lock, descriptor)
+
+    def save(self, journal: DeferredDeletionJournal) -> None:
+        self.directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+        os.chmod(self.directory, 0o700)
+        destination = self._path(journal.batch_id)
+        payload = json.dumps(journal.to_dict(), sort_keys=True, separators=(",", ":"))
+        descriptor, temporary_name = tempfile.mkstemp(
+            dir=self.directory, prefix=f".{journal.batch_id}.", suffix=".tmp"
+        )
+        temporary = Path(temporary_name)
+        try:
+            if os.name != "nt":
+                os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                descriptor = -1
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, destination)
+            os.chmod(destination, 0o600)
+        finally:
+            if descriptor != -1:
+                os.close(descriptor)
+            try:
+                temporary.unlink()
+            except FileNotFoundError:
+                pass
+        # POSIX requires syncing the directory entry after replace. Windows has
+        # no directory file descriptor equivalent; ``os.replace`` + file fsync
+        # still provides an atomic complete-file journal there.
+        if os.name != "nt":
+            directory_fd = os.open(self.directory, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+
+    def load(self, batch_id: str) -> DeferredDeletionJournal | None:
+        path = self._path(batch_id)
+        try:
+            if path.is_symlink():
+                raise OSError(f"refusing symlinked deletion journal: {path}")
+            flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+            descriptor = os.open(path, flags)
+            with os.fdopen(descriptor, encoding="utf-8") as handle:
+                if not stat.S_ISREG(os.fstat(handle.fileno()).st_mode):
+                    raise OSError(f"deletion journal is not a regular file: {path}")
+                return DeferredDeletionJournal.from_dict(json.load(handle))
+        except FileNotFoundError:
+            return None
+
+    def delete(self, batch_id: str) -> None:
+        try:
+            self._path(batch_id).unlink()
+        except FileNotFoundError:
+            return
+
+    def list_unfinished(self) -> list[DeferredDeletionJournal]:
+        """Return durable journals that require an explicit operator decision."""
+        if not self.directory.exists():
+            return []
+        journals = []
+        for path in sorted(self.directory.glob("*.json")):
+            try:
+                # Reuse the secure no-follow loader rather than opening the
+                # glob result directly; operator list endpoints must not follow
+                # a journal-shaped symlink planted in working_dir.
+                journal = self.load(path.stem)
+            except (OSError, ValueError, json.JSONDecodeError):
+                continue
+            if (
+                journal is not None
+                and journal.stage is not DeferredDeletionStage.COMMITTED
+            ):
+                journals.append(journal)
+        return journals

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -3109,7 +3109,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             ) from e
 
     async def adelete_by_doc_id(
-        self, doc_id: str, delete_llm_cache: bool = False
+        self,
+        doc_id: str,
+        delete_llm_cache: bool = False,
+        skip_rebuild: bool = False,
+        batch_chunk_ids: set[str] | None = None,
     ) -> DeletionResult:
         """Delete a document and all its related data, including chunks, graph elements.
 
@@ -3142,6 +3146,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             doc_id (str): The unique identifier of the document to be deleted.
             delete_llm_cache (bool): Whether to delete cached LLM extraction results
                 associated with the document. Defaults to False.
+            skip_rebuild (bool): Internal batch-coordinator mode. It removes this
+                document's derived data but retains source metadata and returns
+                affected rebuild targets. The coordinator must rebuild and verify
+                before it finalizes the metadata deletion.
 
         Returns:
             DeletionResult: An object containing the outcome of the deletion process.
@@ -3285,8 +3293,17 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 )
             )
             chunk_ids_set = set(chunk_ids)
+            source_chunk_ids_to_remove = batch_chunk_ids or chunk_ids_set
 
             if not chunk_ids:
+                if skip_rebuild:
+                    return DeletionResult(
+                        status="success",
+                        doc_id=doc_id,
+                        message=f"Document {doc_id} prepared for deferred finalization",
+                        status_code=202,
+                        file_path=file_path,
+                    )
                 logger.warning(f"No chunks found for document {doc_id}")
                 # Mark that deletion operations have started
                 deletion_operations_started = True
@@ -3529,14 +3546,12 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         entity_chunk_updates[node_label] = []
                         continue
 
-                    remaining_sources = subtract_source_ids(existing_sources, chunk_ids)
-                    # `existing_sources` comes from chunk-tracking storage when available, but
-                    # graph `source_id` can still be stale after a failed prior delete. If the
-                    # graph still references any chunk being deleted in this attempt, force a
-                    # rebuild/delete so the graph metadata gets synchronized instead of being
-                    # left untouched with orphaned source references.
+                    remaining_sources = subtract_source_ids(
+                        existing_sources, source_chunk_ids_to_remove
+                    )
                     graph_references_deleted_chunks = bool(
-                        graph_sources and set(graph_sources) & chunk_ids_set
+                        graph_sources
+                        and set(graph_sources) & source_chunk_ids_to_remove
                     )
 
                     if not remaining_sources:
@@ -3605,13 +3620,12 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         relation_chunk_updates[edge_tuple] = []
                         continue
 
-                    remaining_sources = subtract_source_ids(existing_sources, chunk_ids)
-                    # Same as the entity path above: even when relation chunk-tracking is already
-                    # correct, the graph edge may still carry a stale `source_id` that mentions a
-                    # chunk deleted in this attempt. Treat that as an affected relation so retry
-                    # deletion can repair the graph metadata rather than skipping it as "untouched".
+                    remaining_sources = subtract_source_ids(
+                        existing_sources, source_chunk_ids_to_remove
+                    )
                     graph_references_deleted_chunks = bool(
-                        graph_sources and set(graph_sources) & chunk_ids_set
+                        graph_sources
+                        and set(graph_sources) & source_chunk_ids_to_remove
                     )
 
                     if not remaining_sources:
@@ -3836,6 +3850,27 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             except Exception as e:
                 logger.error(f"Failed to persist pre-rebuild changes: {e}")
                 raise Exception(f"Failed to persist pre-rebuild changes: {e}") from e
+
+            if skip_rebuild:
+                # A durable batch journal has already recorded the document
+                # metadata and will aggregate these targets across all documents.
+                # Do not claim final success or delete source metadata until the
+                # coordinator completes its single rebuild and verification.
+                return DeletionResult(
+                    status="success",
+                    doc_id=doc_id,
+                    message=f"Document {doc_id} prepared for deferred batch rebuild",
+                    status_code=202,
+                    file_path=file_path,
+                    entities_to_rebuild={
+                        entity: list(chunk_ids)
+                        for entity, chunk_ids in entities_to_rebuild.items()
+                    },
+                    relationships_to_rebuild={
+                        relation: list(chunk_ids)
+                        for relation, chunk_ids in relationships_to_rebuild.items()
+                    },
+                )
 
             # 8. Rebuild entities and relationships from remaining chunks
             if entities_to_rebuild or relationships_to_rebuild:

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -965,13 +965,29 @@ async def rebuild_knowledge_from_chunks(
     )
 
     if not cached_results:
+        # A rebuild is the safety barrier before deferred source metadata can be
+        # finalized.  Returning successfully here would allow the coordinator to
+        # commit a destructive batch without rebuilding its surviving graph data.
         status_message = "No cached extraction results found, cannot rebuild"
-        logger.warning(status_message)
+        logger.error(status_message)
         if pipeline_status is not None and pipeline_status_lock is not None:
             async with pipeline_status_lock:
                 pipeline_status["latest_message"] = status_message
                 pipeline_status["history_messages"].append(status_message)
-        return
+        raise RuntimeError(status_message)
+
+    missing_cache_chunk_ids = all_referenced_chunk_ids.difference(cached_results)
+    if missing_cache_chunk_ids:
+        status_message = (
+            "Missing cached extraction results for chunk IDs: "
+            + ", ".join(sorted(missing_cache_chunk_ids))
+        )
+        logger.error(status_message)
+        if pipeline_status is not None and pipeline_status_lock is not None:
+            async with pipeline_status_lock:
+                pipeline_status["latest_message"] = status_message
+                pipeline_status["history_messages"].append(status_message)
+        raise RuntimeError(status_message)
 
     # Process cached results to get entities and relationships for each chunk
     chunk_entities = {}  # chunk_id -> {entity_name: [entity_data]}
@@ -1190,6 +1206,8 @@ async def rebuild_knowledge_from_chunks(
         async with pipeline_status_lock:
             pipeline_status["latest_message"] = status_message
             pipeline_status["history_messages"].append(status_message)
+    if failed_entities_count > 0 or failed_relationships_count > 0:
+        raise RuntimeError(status_message)
 
 
 async def _get_cached_extraction_results(

--- a/tests/api/routes/test_deferred_delete_routes.py
+++ b/tests/api/routes/test_deferred_delete_routes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import sys
 from types import SimpleNamespace
+from typing import Awaitable, Callable, cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -204,6 +205,56 @@ async def test_initial_commit_uses_the_same_durable_file_cleanup_helper_once(tmp
         )
 
     cleanup.assert_awaited_once_with(rag, doc_manager, "initial-commit")
+
+
+@pytest.mark.asyncio
+async def test_deferred_batch_observes_pipeline_cancellation_between_documents(
+    tmp_path,
+):
+    rag = _Rag(str(tmp_path))
+    doc_manager = SimpleNamespace(input_dir=tmp_path / "input")
+    pipeline_status = {
+        "busy": True,
+        "destructive_busy": True,
+        "history_messages": [],
+        "cancellation_requested": False,
+        "request_pending": False,
+    }
+
+    cancellation_check = None
+
+    async def deferred_delete_with_cancellation(_rag, _doc_ids, **kwargs):
+        nonlocal cancellation_check
+        cancellation_check = kwargs.get("cancellation_requested")
+        return SimpleNamespace(
+            batch_id="cancelled-batch",
+            stage=DeferredDeletionStage.FAILED_RETRYABLE,
+            error_detail="document deletion cancelled by user",
+        )
+
+    with (
+        patch(
+            "lightrag.kg.shared_storage.get_namespace_data",
+            new=AsyncMock(return_value=pipeline_status),
+        ),
+        patch(
+            "lightrag.kg.shared_storage.get_namespace_lock",
+            return_value=__import__("asyncio").Lock(),
+        ),
+        patch(
+            "lightrag.api.routers.document_routes.run_deferred_batch_delete",
+            side_effect=deferred_delete_with_cancellation,
+        ) as deferred_delete,
+    ):
+        await _document_routes.background_delete_documents(
+            rag, doc_manager, ["doc-a", "doc-b"]
+        )
+
+    deferred_delete.assert_awaited_once()
+    assert cancellation_check is not None
+    pipeline_status["cancellation_requested"] = True
+    cancellation_check = cast(Callable[[], Awaitable[bool]], cancellation_check)
+    assert await cancellation_check() is True
 
 
 @pytest.mark.asyncio

--- a/tests/api/routes/test_deferred_delete_routes.py
+++ b/tests/api/routes/test_deferred_delete_routes.py
@@ -1,0 +1,246 @@
+"""Read-only operator discovery for durable deferred deletion journals."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from lightrag.deletion_journal import (
+    DeferredDeletionJournal,
+    DeferredDeletionJournalStore,
+    DeferredDeletionStage,
+)
+
+_original_argv = sys.argv[:]
+sys.argv = [sys.argv[0]]
+_document_routes = importlib.import_module("lightrag.api.routers.document_routes")
+sys.argv = _original_argv
+
+
+class _Rag:
+    workspace = "default"
+
+    def __init__(self, working_dir: str) -> None:
+        self.working_dir = working_dir
+
+
+def _client(tmp_path) -> TestClient:
+    app = FastAPI()
+    app.include_router(
+        _document_routes.create_document_routes(
+            _Rag(str(tmp_path)), SimpleNamespace(), api_key="test-key"
+        )
+    )
+    return TestClient(app)
+
+
+def test_deferred_delete_list_and_status_expose_only_operator_safe_details(tmp_path):
+    store = DeferredDeletionJournalStore(tmp_path, "default")
+    retryable = DeferredDeletionJournal.new("retryable-001", ["doc-a", "doc-b"], True)
+    retryable.aggregate_targets(
+        entities={"Shared": ["chunk-a"]},
+        relationships={("Shared", "Other"): ["chunk-a"]},
+    )
+    retryable.mark_rebuild_pending()
+    retryable.mark_failed_retryable("cache evidence unavailable")
+    store.save(retryable)
+
+    committed = DeferredDeletionJournal.new("committed-001", ["doc-c"], False)
+    committed.mark_rebuild_pending()
+    committed.mark_finalization_pending()
+    committed.mark_committed()
+    store.save(committed)
+
+    client = _client(tmp_path)
+    headers = {"X-API-Key": "test-key"}
+    listed = client.get("/documents/delete_document/deferred", headers=headers)
+    assert listed.status_code == 200
+    assert listed.json()["total_count"] == 1
+    assert listed.json()["journals"] == [
+        {
+            "attempt_count": 1,
+            "batch_id": "retryable-001",
+            "created_at": retryable.created_at,
+            "current_document_index": 0,
+            "document_count": 2,
+            "entities_to_rebuild_count": 1,
+            "error_detail": "cache evidence unavailable",
+            "relationships_to_rebuild_count": 1,
+            "stage": "FAILED_RETRYABLE",
+            "updated_at": retryable.updated_at,
+        }
+    ]
+
+    detail = client.get(
+        "/documents/delete_document/deferred/retryable-001", headers=headers
+    )
+    assert detail.status_code == 200
+    assert detail.json()["document_ids"] == ["doc-a", "doc-b"]
+    assert detail.json()["delete_llm_cache"] is True
+    assert detail.json()["entities_to_rebuild"] == {"Shared": ["chunk-a"]}
+    assert detail.json()["relationships_to_rebuild"] == [
+        {"chunk_ids": ["chunk-a"], "source": "Other", "target": "Shared"}
+    ]
+    assert "document_metadata" not in detail.json()
+
+    missing = client.get(
+        "/documents/delete_document/deferred/missing-001", headers=headers
+    )
+    assert missing.status_code == 404
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("get", "/documents/delete_document/deferred"),
+        ("get", "/documents/delete_document/deferred/missing-001"),
+        ("post", "/documents/delete_document/missing-001/resume"),
+    ],
+)
+def test_deferred_delete_operator_endpoints_require_auth(tmp_path, method, path):
+    response = getattr(_client(tmp_path), method)(path)
+
+    assert response.status_code in {401, 403}
+
+
+def test_deferred_delete_resume_returns_404_without_scheduling_unknown_batch(tmp_path):
+    response = _client(tmp_path).post(
+        "/documents/delete_document/missing-001/resume",
+        headers={"X-API-Key": "test-key"},
+    )
+
+    assert response.status_code == 404
+
+
+def test_deferred_delete_routes_appear_in_openapi_with_response_models(tmp_path):
+    spec = _client(tmp_path).get("/openapi.json").json()
+
+    list_path = spec["paths"]["/documents/delete_document/deferred"]["get"]
+    detail_path = spec["paths"]["/documents/delete_document/deferred/{batch_id}"]["get"]
+    resume_path = spec["paths"]["/documents/delete_document/{batch_id}/resume"]["post"]
+    assert list_path["responses"]["200"]["content"]["application/json"]["schema"][
+        "$ref"
+    ].endswith("DeferredDeletionJournalListResponse")
+    assert detail_path["responses"]["200"]["content"]["application/json"]["schema"][
+        "$ref"
+    ].endswith("DeferredDeletionJournalDetailResponse")
+    assert resume_path["responses"]["200"]["content"]["application/json"]["schema"][
+        "$ref"
+    ].endswith("ResumeDeferredDeleteResponse")
+
+
+@pytest.mark.asyncio
+async def test_resumed_commit_cleans_persisted_source_paths_when_requested(tmp_path):
+    rag = _Rag(str(tmp_path))
+    store = DeferredDeletionJournalStore(tmp_path, "default")
+    journal = DeferredDeletionJournal.new("cleanup-on-resume", ["doc-a"], False, True)
+    journal.source_file_paths = {"doc-a": "uploads/a.pdf"}
+    journal.mark_rebuild_pending()
+    journal.mark_finalization_pending()
+    journal.mark_committed()
+    store.save(journal)
+    doc_manager = SimpleNamespace(input_dir=tmp_path / "input")
+
+    with patch(
+        "lightrag.api.routers.document_routes.delete_file_variants_by_file_path",
+        return_value=(["uploads/a.pdf"], []),
+    ) as delete_variants:
+        await _document_routes.cleanup_deferred_delete_files(
+            rag, doc_manager, journal.batch_id
+        )
+        # A repeated resume of the committed batch must not touch the path
+        # again: it may now refer to a newly recreated user file.
+        await _document_routes.cleanup_deferred_delete_files(
+            rag, doc_manager, journal.batch_id
+        )
+
+    delete_variants.assert_called_once_with(doc_manager.input_dir, "uploads/a.pdf")
+    persisted = store.load(journal.batch_id)
+    assert persisted is not None
+    assert persisted.source_file_cleanup_claimed is True
+
+
+@pytest.mark.asyncio
+async def test_initial_commit_uses_the_same_durable_file_cleanup_helper_once(tmp_path):
+    rag = _Rag(str(tmp_path))
+    doc_manager = SimpleNamespace(input_dir=tmp_path / "input")
+    pipeline_status = {
+        "busy": True,
+        "destructive_busy": True,
+        "history_messages": [],
+        "request_pending": False,
+    }
+
+    with (
+        patch(
+            "lightrag.kg.shared_storage.get_namespace_data",
+            new=AsyncMock(return_value=pipeline_status),
+        ),
+        patch(
+            "lightrag.kg.shared_storage.get_namespace_lock",
+            return_value=__import__("asyncio").Lock(),
+        ),
+        patch(
+            "lightrag.api.routers.document_routes.run_deferred_batch_delete",
+            new=AsyncMock(
+                return_value=SimpleNamespace(
+                    batch_id="initial-commit", stage=DeferredDeletionStage.COMMITTED
+                )
+            ),
+        ),
+        patch(
+            "lightrag.api.routers.document_routes.cleanup_deferred_delete_files",
+            new=AsyncMock(),
+        ) as cleanup,
+    ):
+        await _document_routes.background_delete_documents(
+            rag, doc_manager, ["doc-a"], delete_file=True
+        )
+
+    cleanup.assert_awaited_once_with(rag, doc_manager, "initial-commit")
+
+
+@pytest.mark.asyncio
+async def test_resume_restores_deletion_pipeline_job_state_before_continuing(tmp_path):
+    rag = _Rag(str(tmp_path))
+    doc_manager = SimpleNamespace(input_dir=tmp_path / "input")
+    pipeline_status = {
+        "busy": False,
+        "destructive_busy": False,
+        "job_name": "",
+        "history_messages": [],
+    }
+
+    async def resume_with_pipeline_guard(_rag, _batch_id):
+        assert pipeline_status["busy"] is True
+        assert pipeline_status["destructive_busy"] is True
+        assert pipeline_status["job_name"] == "Deleting 1 Documents"
+        return SimpleNamespace(stage=DeferredDeletionStage.COMMITTED, error_detail=None)
+
+    with (
+        patch(
+            "lightrag.kg.shared_storage.get_namespace_data",
+            new=AsyncMock(return_value=pipeline_status),
+        ),
+        patch(
+            "lightrag.kg.shared_storage.get_namespace_lock",
+            return_value=__import__("asyncio").Lock(),
+        ),
+        patch(
+            "lightrag.api.routers.document_routes.resume_deferred_batch_delete",
+            side_effect=resume_with_pipeline_guard,
+        ),
+        patch(
+            "lightrag.api.routers.document_routes.cleanup_deferred_delete_files",
+            new=AsyncMock(),
+        ),
+    ):
+        await _document_routes.background_resume_deferred_delete(
+            rag, doc_manager, "resume-after-restart"
+        )

--- a/tests/test_deferred_batch_delete.py
+++ b/tests/test_deferred_batch_delete.py
@@ -137,6 +137,93 @@ async def test_two_document_batch_runs_one_rebuild_then_finalizes_metadata(tmp_p
 
 
 @pytest.mark.asyncio
+async def test_not_found_document_is_checkpointed_and_batch_still_rebuilds(tmp_path):
+    """A stale ID is a completed no-op, not an ambiguous destructive failure."""
+    from lightrag.deferred_delete import run_deferred_batch_delete
+
+    rag = _rag(tmp_path)
+    rag.doc_status.get_by_id = AsyncMock(
+        side_effect=[
+            {"file_path": "a.pdf", "chunks_list": ["chunk-a"]},
+            None,
+        ]
+    )
+    rag.adelete_by_doc_id = AsyncMock(
+        side_effect=[
+            DeletionResult(
+                status="success",
+                doc_id="doc-a",
+                message="prepared",
+                entities_to_rebuild={"Shared": ["chunk-a"]},
+                relationships_to_rebuild={},
+            ),
+            DeletionResult(
+                status="not_found",
+                doc_id="stale-doc",
+                message="Document stale-doc not found.",
+                status_code=404,
+            ),
+        ]
+    )
+
+    with (
+        patch(
+            "lightrag.deferred_delete.get_namespace_data",
+            new_callable=AsyncMock,
+            return_value=_pipeline_status(),
+        ),
+        patch(
+            "lightrag.deferred_delete.get_namespace_lock",
+            return_value=asyncio.Lock(),
+        ),
+        patch(
+            "lightrag.deferred_delete.rebuild_knowledge_from_chunks",
+            new_callable=AsyncMock,
+        ) as rebuild,
+    ):
+        result = await run_deferred_batch_delete(rag, ["doc-a", "stale-doc"])
+
+    assert result.stage is DeferredDeletionStage.COMMITTED
+    rebuild.assert_awaited_once()
+    journal = DeferredDeletionJournalStore(tmp_path, "default").load(result.batch_id)
+    assert journal is not None
+    assert journal.current_document_index == 2
+    assert journal.entities_to_rebuild == {"Shared": ["chunk-a"]}
+    assert journal.document_delete_checkpoints["stale-doc"]["state"] == "COMPLETED"
+
+
+@pytest.mark.asyncio
+async def test_cancellation_stops_before_next_destructive_delete(tmp_path):
+    from lightrag.deferred_delete import run_deferred_batch_delete
+
+    rag = _rag(tmp_path)
+    rag.doc_status.get_by_id = AsyncMock(
+        side_effect=[
+            {"file_path": "a.pdf", "chunks_list": ["chunk-a"]},
+            {"file_path": "b.pdf", "chunks_list": ["chunk-b"]},
+        ]
+    )
+    checks = iter([False, True])
+
+    async def cancellation_requested() -> bool:
+        return next(checks)
+
+    result = await run_deferred_batch_delete(
+        rag,
+        ["doc-a", "doc-b"],
+        cancellation_requested=cancellation_requested,
+    )
+
+    assert result.stage is DeferredDeletionStage.FAILED_RETRYABLE
+    assert result.error_detail == "document deletion cancelled by user"
+    rag.adelete_by_doc_id.assert_awaited_once()
+    journal = DeferredDeletionJournalStore(tmp_path, "default").load(result.batch_id)
+    assert journal is not None
+    assert journal.current_document_index == 1
+    assert "doc-b" not in journal.document_delete_checkpoints
+
+
+@pytest.mark.asyncio
 async def test_finalization_deletes_cache_ids_persisted_in_status_metadata(tmp_path):
     """The deferred path must honor LightRAG's durable retry-state schema."""
     from lightrag.deferred_delete import run_deferred_batch_delete

--- a/tests/test_deferred_batch_delete.py
+++ b/tests/test_deferred_batch_delete.py
@@ -1,0 +1,494 @@
+"""Behavioral tests for production-safe deferred batch deletion orchestration."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from lightrag.base import DeletionResult
+from lightrag.deletion_journal import (
+    DeferredDeletionJournal,
+    DeferredDeletionJournalStore,
+    DeferredDeletionStage,
+)
+
+pytestmark = pytest.mark.offline
+
+
+def _pipeline_status() -> dict:
+    return {"busy": True, "destructive_busy": True, "history_messages": []}
+
+
+def _rag(tmp_path):
+    rag = MagicMock()
+    rag.working_dir = str(tmp_path)
+    rag.workspace = "default"
+    rag.full_docs = AsyncMock()
+    rag.full_entities = AsyncMock()
+    rag.full_relations = AsyncMock()
+    rag.doc_status = AsyncMock()
+    rag.entity_chunks = AsyncMock()
+    rag.relation_chunks = AsyncMock()
+    rag.chunk_entity_relation_graph = AsyncMock()
+    rag.entities_vdb = AsyncMock()
+    rag.relationships_vdb = AsyncMock()
+    rag.text_chunks = AsyncMock()
+    rag.text_chunks.get_by_ids = AsyncMock(return_value=[])
+    rag.llm_response_cache = AsyncMock()
+    rag.llm_response_cache.delete = AsyncMock()
+    rag._build_global_config.return_value = {}
+    rag._insert_done = AsyncMock()
+    rag.full_docs.get_by_id = AsyncMock(return_value=None)
+    rag.full_entities.get_by_id = AsyncMock(return_value=None)
+    rag.full_relations.get_by_id = AsyncMock(return_value=None)
+
+    def make_delete(storage):
+        async def clear_metadata_after_delete(doc_ids):
+            """Model the post-delete reads a real storage backend would return."""
+            storage.get_by_id = AsyncMock(return_value=None)
+
+        return clear_metadata_after_delete
+
+    for storage in (
+        rag.full_docs,
+        rag.full_entities,
+        rag.full_relations,
+        rag.doc_status,
+    ):
+        storage.delete.side_effect = make_delete(storage)
+    rag.adelete_by_doc_id = AsyncMock(
+        side_effect=[
+            DeletionResult(
+                status="success",
+                doc_id="doc-a",
+                message="prepared",
+                entities_to_rebuild={"Shared": ["chunk-b"]},
+                relationships_to_rebuild={("Shared", "Other"): ["chunk-b"]},
+            ),
+            DeletionResult(
+                status="success",
+                doc_id="doc-b",
+                message="prepared",
+                entities_to_rebuild={"Shared": ["chunk-c"]},
+                relationships_to_rebuild={("Other", "Shared"): ["chunk-c"]},
+            ),
+        ]
+    )
+    return rag
+
+
+@pytest.mark.asyncio
+async def test_two_document_batch_runs_one_rebuild_then_finalizes_metadata(tmp_path):
+    from lightrag.deferred_delete import run_deferred_batch_delete
+
+    rag = _rag(tmp_path)
+    rag.doc_status.get_by_id = AsyncMock(
+        side_effect=[
+            {"file_path": "a.pdf", "chunks_list": ["chunk-a"]},
+            {"file_path": "b.pdf", "chunks_list": ["chunk-b"]},
+        ]
+    )
+    status = _pipeline_status()
+    lock = asyncio.Lock()
+
+    with (
+        patch(
+            "lightrag.deferred_delete.get_namespace_data",
+            new_callable=AsyncMock,
+            return_value=status,
+        ),
+        patch(
+            "lightrag.deferred_delete.get_namespace_lock",
+            return_value=lock,
+        ),
+        patch(
+            "lightrag.deferred_delete.rebuild_knowledge_from_chunks",
+            new_callable=AsyncMock,
+        ) as rebuild,
+    ):
+        result = await run_deferred_batch_delete(rag, ["doc-a", "doc-b"])
+
+    assert result.stage is DeferredDeletionStage.COMMITTED
+    rebuild.assert_awaited_once()
+    rag.adelete_by_doc_id.assert_has_awaits(
+        [
+            call(
+                "doc-a",
+                delete_llm_cache=False,
+                skip_rebuild=True,
+                batch_chunk_ids={"chunk-a", "chunk-b"},
+            ),
+            call(
+                "doc-b",
+                delete_llm_cache=False,
+                skip_rebuild=True,
+                batch_chunk_ids={"chunk-a", "chunk-b"},
+            ),
+        ]
+    )
+    rag.full_entities.delete.assert_awaited_once_with(["doc-a", "doc-b"])
+    rag.full_relations.delete.assert_awaited_once_with(["doc-a", "doc-b"])
+    rag.doc_status.delete.assert_awaited_once_with(["doc-a", "doc-b"])
+    rag.full_docs.delete.assert_awaited_once_with(["doc-a", "doc-b"])
+    persisted = DeferredDeletionJournalStore(tmp_path, "default").load(result.batch_id)
+    assert persisted is not None and persisted.stage is DeferredDeletionStage.COMMITTED
+
+
+@pytest.mark.asyncio
+async def test_finalization_deletes_cache_ids_persisted_in_status_metadata(tmp_path):
+    """The deferred path must honor LightRAG's durable retry-state schema."""
+    from lightrag.deferred_delete import run_deferred_batch_delete
+
+    rag = _rag(tmp_path)
+    rag.doc_status.get_by_id = AsyncMock(
+        return_value={
+            "file_path": "a.pdf",
+            "chunks_list": ["chunk-a"],
+            "metadata": {"deletion_llm_cache_ids": ["cache-a"]},
+        }
+    )
+    rag._get_existing_llm_cache_ids = AsyncMock(return_value=[])
+    status = _pipeline_status()
+    lock = asyncio.Lock()
+
+    with (
+        patch(
+            "lightrag.deferred_delete.get_namespace_data",
+            new_callable=AsyncMock,
+            return_value=status,
+        ),
+        patch("lightrag.deferred_delete.get_namespace_lock", return_value=lock),
+        patch(
+            "lightrag.deferred_delete.rebuild_knowledge_from_chunks",
+            new_callable=AsyncMock,
+        ),
+    ):
+        result = await run_deferred_batch_delete(rag, ["doc-a"], delete_llm_cache=True)
+
+    assert result.stage is DeferredDeletionStage.COMMITTED
+    rag.llm_response_cache.delete.assert_awaited_once_with(["cache-a"])
+    rag._get_existing_llm_cache_ids.assert_awaited_once_with(["cache-a"])
+
+
+@pytest.mark.asyncio
+async def test_rebuild_failure_is_failed_retryable_and_keeps_journal(tmp_path):
+    from lightrag.deferred_delete import run_deferred_batch_delete
+
+    rag = _rag(tmp_path)
+    rag.doc_status.get_by_id = AsyncMock(
+        side_effect=[
+            {"file_path": "a.pdf", "chunks_list": ["chunk-a"]},
+            {"file_path": "b.pdf", "chunks_list": ["chunk-b"]},
+        ]
+    )
+    status = _pipeline_status()
+    lock = asyncio.Lock()
+
+    with (
+        patch(
+            "lightrag.deferred_delete.get_namespace_data",
+            new_callable=AsyncMock,
+            return_value=status,
+        ),
+        patch(
+            "lightrag.deferred_delete.get_namespace_lock",
+            return_value=lock,
+        ),
+        patch(
+            "lightrag.deferred_delete.rebuild_knowledge_from_chunks",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("forced rebuild failure"),
+        ),
+    ):
+        result = await run_deferred_batch_delete(rag, ["doc-a", "doc-b"])
+
+    assert result.stage is DeferredDeletionStage.FAILED_RETRYABLE
+    assert "forced rebuild failure" in result.error_detail
+    rag.doc_status.delete.assert_not_awaited()
+    journal = DeferredDeletionJournalStore(tmp_path, "default").load(result.batch_id)
+    assert journal is not None
+    assert journal.stage is DeferredDeletionStage.FAILED_RETRYABLE
+
+
+@pytest.mark.asyncio
+async def test_document_delete_exception_is_persisted_as_retryable(tmp_path):
+    from lightrag.deferred_delete import run_deferred_batch_delete
+
+    rag = _rag(tmp_path)
+    rag.doc_status.get_by_id = AsyncMock(return_value={"file_path": "a.pdf"})
+    rag.adelete_by_doc_id = AsyncMock(side_effect=RuntimeError("storage unavailable"))
+
+    result = await run_deferred_batch_delete(rag, ["doc-a"])
+
+    assert result.stage is DeferredDeletionStage.FAILED_RETRYABLE
+    assert "storage unavailable" in (result.error_detail or "")
+    journal = DeferredDeletionJournalStore(tmp_path, "default").load(result.batch_id)
+    assert journal is not None
+    assert journal.recovery_stage is DeferredDeletionStage.PREPARED
+
+
+@pytest.mark.asyncio
+async def test_failed_batch_persists_delete_file_intent_and_snapshot_paths(tmp_path):
+    from lightrag.deferred_delete import run_deferred_batch_delete
+
+    rag = _rag(tmp_path)
+    rag.doc_status.get_by_id = AsyncMock(
+        return_value={"file_path": "uploads/a.pdf", "chunks_list": ["chunk-a"]}
+    )
+    rag.adelete_by_doc_id = AsyncMock(side_effect=RuntimeError("forced failure"))
+
+    result = await run_deferred_batch_delete(rag, ["doc-a"], delete_file=True)
+
+    assert result.stage is DeferredDeletionStage.FAILED_RETRYABLE
+    persisted = DeferredDeletionJournalStore(tmp_path, "default").load(result.batch_id)
+    assert persisted is not None
+    assert persisted.delete_file is True
+    assert persisted.source_file_paths == {"doc-a": "uploads/a.pdf"}
+
+
+@pytest.mark.asyncio
+async def test_resume_uses_persisted_targets_without_calling_document_delete(tmp_path):
+    from lightrag.deferred_delete import resume_deferred_batch_delete
+    from lightrag.deletion_journal import DeferredDeletionJournal
+
+    rag = _rag(tmp_path)
+    journal = DeferredDeletionJournal.new("resume-001", ["doc-a"], False)
+    journal.document_metadata = {"doc-a": {"chunks_list": ["chunk-a"]}}
+    journal.aggregate_targets(
+        entities={"Shared": ["chunk-b"]},
+        relationships={("Shared", "Other"): ["chunk-b"]},
+    )
+    journal.mark_rebuild_pending()
+    journal.mark_failed_retryable("crashed")
+    DeferredDeletionJournalStore(tmp_path, "default").save(journal)
+    status = _pipeline_status()
+    lock = asyncio.Lock()
+
+    with (
+        patch(
+            "lightrag.deferred_delete.get_namespace_data",
+            new_callable=AsyncMock,
+            return_value=status,
+        ),
+        patch(
+            "lightrag.deferred_delete.get_namespace_lock",
+            return_value=lock,
+        ),
+        patch(
+            "lightrag.deferred_delete.rebuild_knowledge_from_chunks",
+            new_callable=AsyncMock,
+        ) as rebuild,
+    ):
+        result = await resume_deferred_batch_delete(rag, journal.batch_id)
+
+    assert result.stage is DeferredDeletionStage.COMMITTED
+    rebuild.assert_awaited_once()
+    rag.adelete_by_doc_id.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_restart_from_prepared_resumes_actual_document_deletion_in_batch_mode(
+    tmp_path,
+):
+    """A restart at PREPARED must retain the no-per-document-rebuild guard."""
+    from lightrag.deferred_delete import resume_deferred_batch_delete
+
+    rag = _rag(tmp_path)
+    rag.doc_status.get_by_id = AsyncMock(
+        return_value={"file_path": "a.pdf", "chunks_list": ["chunk-a"]}
+    )
+    journal = DeferredDeletionJournal.new("restart-prepared-001", ["doc-a"], False)
+    DeferredDeletionJournalStore(tmp_path, "default").save(journal)
+    status = _pipeline_status()
+    lock = asyncio.Lock()
+
+    with (
+        patch(
+            "lightrag.deferred_delete.get_namespace_data",
+            new_callable=AsyncMock,
+            return_value=status,
+        ),
+        patch("lightrag.deferred_delete.get_namespace_lock", return_value=lock),
+        patch(
+            "lightrag.deferred_delete.rebuild_knowledge_from_chunks",
+            new_callable=AsyncMock,
+        ) as rebuild,
+    ):
+        result = await resume_deferred_batch_delete(rag, journal.batch_id)
+
+    assert result.stage is DeferredDeletionStage.COMMITTED
+    rag.adelete_by_doc_id.assert_awaited_once_with(
+        "doc-a",
+        delete_llm_cache=False,
+        skip_rebuild=True,
+        batch_chunk_ids={"chunk-a"},
+    )
+    rebuild.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_crash_after_document_delete_before_result_checkpoint_never_repeats_delete(
+    tmp_path,
+):
+    """An intent left without a durable result is ambiguous, never retryable."""
+    from lightrag.deferred_delete import (
+        resume_deferred_batch_delete,
+        run_deferred_batch_delete,
+    )
+
+    rag = _rag(tmp_path)
+    rag.doc_status.get_by_id = AsyncMock(
+        return_value={"file_path": "a.pdf", "chunks_list": ["chunk-a"]}
+    )
+    original_save = DeferredDeletionJournalStore.save
+
+    def crash_before_completed_checkpoint(store, journal):
+        checkpoint = journal.document_delete_checkpoints.get("doc-a", {})
+        if checkpoint.get("state") == "COMPLETED":
+            raise SystemExit("simulated process crash")
+        original_save(store, journal)
+
+    with patch.object(
+        DeferredDeletionJournalStore,
+        "save",
+        new=crash_before_completed_checkpoint,
+    ):
+        with pytest.raises(SystemExit, match="simulated process crash"):
+            await run_deferred_batch_delete(rag, ["doc-a"])
+
+    journal_path = next((tmp_path / "deletion_journals" / "default").glob("*.json"))
+    journal = DeferredDeletionJournalStore(tmp_path, "default").load(journal_path.stem)
+    assert journal is not None
+    assert journal.document_delete_checkpoints == {"doc-a": {"state": "INTENT"}}
+
+    result = await resume_deferred_batch_delete(rag, journal.batch_id)
+
+    assert result.stage is DeferredDeletionStage.FAILED_RETRYABLE
+    assert "outcome is unknown" in (result.error_detail or "")
+    rag.adelete_by_doc_id.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_resume_serializes_same_batch_and_rebuilds_once(tmp_path):
+    """A second operator/process must observe the first committed outcome."""
+    from lightrag.deferred_delete import resume_deferred_batch_delete
+
+    rag = _rag(tmp_path)
+    journal = DeferredDeletionJournal.new("resume-lock-001", ["doc-a"], False)
+    journal.aggregate_targets(entities={"Shared": ["chunk-a"]}, relationships={})
+    journal.mark_rebuild_pending()
+    DeferredDeletionJournalStore(tmp_path, "default").save(journal)
+    status = _pipeline_status()
+    lock = asyncio.Lock()
+    rebuild_started = asyncio.Event()
+    let_rebuild_finish = asyncio.Event()
+
+    async def blocked_rebuild(*_args, **_kwargs):
+        rebuild_started.set()
+        await let_rebuild_finish.wait()
+
+    with (
+        patch(
+            "lightrag.deferred_delete.get_namespace_data",
+            new_callable=AsyncMock,
+            return_value=status,
+        ),
+        patch("lightrag.deferred_delete.get_namespace_lock", return_value=lock),
+        patch(
+            "lightrag.deferred_delete.rebuild_knowledge_from_chunks",
+            side_effect=blocked_rebuild,
+        ) as rebuild,
+    ):
+        first = asyncio.create_task(resume_deferred_batch_delete(rag, journal.batch_id))
+        await rebuild_started.wait()
+        second = asyncio.create_task(
+            resume_deferred_batch_delete(rag, journal.batch_id)
+        )
+        await asyncio.sleep(0)
+        assert not second.done()
+        let_rebuild_finish.set()
+        first_result, second_result = await asyncio.gather(first, second)
+
+    assert first_result.stage is DeferredDeletionStage.COMMITTED
+    assert second_result.stage is DeferredDeletionStage.COMMITTED
+    rebuild.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resume_finalization_retry_does_not_repeat_completed_rebuild(tmp_path):
+    """A crash after rebuild resumes only metadata finalization, not a second rebuild."""
+    from lightrag.deferred_delete import resume_deferred_batch_delete
+
+    rag = _rag(tmp_path)
+    journal = DeferredDeletionJournal.new("finalization-retry-001", ["doc-a"], False)
+    journal.mark_rebuild_pending()
+    journal.mark_finalization_pending()
+    journal.mark_failed_retryable("process crashed after rebuild")
+    DeferredDeletionJournalStore(tmp_path, "default").save(journal)
+
+    with patch(
+        "lightrag.deferred_delete.rebuild_knowledge_from_chunks",
+        new_callable=AsyncMock,
+    ) as rebuild:
+        result = await resume_deferred_batch_delete(rag, journal.batch_id)
+
+    assert result.stage is DeferredDeletionStage.COMMITTED
+    rebuild.assert_not_awaited()
+    rag.adelete_by_doc_id.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "store_name", ["full_entities", "full_relations", "doc_status"]
+)
+async def test_finalization_requires_every_metadata_store_to_be_empty(
+    tmp_path, store_name
+):
+    from lightrag.deferred_delete import resume_deferred_batch_delete
+
+    rag = _rag(tmp_path)
+    journal = DeferredDeletionJournal.new("verify-all-stores", ["doc-a"], False)
+    journal.mark_rebuild_pending()
+    journal.mark_finalization_pending()
+    DeferredDeletionJournalStore(tmp_path, "default").save(journal)
+    getattr(rag, store_name).get_by_id = AsyncMock(return_value={"still": "here"})
+    # Simulate a storage backend silently ignoring this delete; the coordinator
+    # must reject it instead of treating the awaited delete call as success.
+    getattr(rag, store_name).delete = AsyncMock()
+
+    result = await resume_deferred_batch_delete(rag, journal.batch_id)
+
+    assert result.stage is DeferredDeletionStage.FAILED_RETRYABLE
+    assert "metadata remains" in (result.error_detail or "")
+    persisted = DeferredDeletionJournalStore(tmp_path, "default").load(journal.batch_id)
+    assert persisted is not None
+    assert persisted.stage is DeferredDeletionStage.FAILED_RETRYABLE
+
+
+@pytest.mark.asyncio
+async def test_finalization_retry_is_idempotent_after_partial_metadata_deletion(
+    tmp_path,
+):
+    from lightrag.deferred_delete import resume_deferred_batch_delete
+
+    rag = _rag(tmp_path)
+    journal = DeferredDeletionJournal.new("partial-finalization", ["doc-a"], False)
+    journal.mark_rebuild_pending()
+    journal.mark_finalization_pending()
+    DeferredDeletionJournalStore(tmp_path, "default").save(journal)
+    rag.doc_status.get_by_id = AsyncMock(side_effect=[{"still": "here"}, None])
+    rag.doc_status.delete = AsyncMock()
+
+    first = await resume_deferred_batch_delete(rag, journal.batch_id)
+
+    async def clear_doc_status(_doc_ids):
+        rag.doc_status.get_by_id = AsyncMock(return_value=None)
+
+    rag.doc_status.delete.side_effect = clear_doc_status
+    second = await resume_deferred_batch_delete(rag, journal.batch_id)
+
+    assert first.stage is DeferredDeletionStage.FAILED_RETRYABLE
+    assert second.stage is DeferredDeletionStage.COMMITTED
+    assert rag.full_docs.delete.await_count == 2

--- a/tests/test_deferred_deletion_journal.py
+++ b/tests/test_deferred_deletion_journal.py
@@ -1,0 +1,321 @@
+"""Durable state for deferred batch document deletion.
+
+These tests deliberately use the filesystem-backed journal because it is the
+least-common-denominator durable store across LightRAG's supported backends.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from lightrag.deletion_journal import (
+    DeferredDeletionJournal,
+    DeferredDeletionJournalStore,
+    DeferredDeletionStage,
+)
+
+
+def _journal() -> DeferredDeletionJournal:
+    return DeferredDeletionJournal.new(
+        batch_id="batch-test-001",
+        document_ids=["doc-a", "doc-b"],
+        delete_llm_cache=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "workspace",
+    [r"..\escaped", "..", "../escaped"],
+)
+def test_workspace_directory_cannot_escape_journal_root(tmp_path: Path, workspace: str):
+    store = DeferredDeletionJournalStore(tmp_path, workspace=workspace)
+    journal_root = (tmp_path / "deletion_journals").resolve()
+
+    assert (
+        store.directory
+        == DeferredDeletionJournalStore(tmp_path, workspace=workspace).directory
+    )
+    assert store.directory.resolve().is_relative_to(journal_root)
+    assert "\\" not in store.directory.name
+    assert store.directory.name not in {".", ".."}
+
+
+def test_workspace_directory_preserves_safe_workspace_name(tmp_path: Path):
+    store = DeferredDeletionJournalStore(tmp_path, workspace="team-alpha")
+
+    assert store.directory == tmp_path / "deletion_journals" / "team-alpha"
+
+
+@pytest.mark.parametrize(
+    "batch_id",
+    [
+        "CON",
+        "nul",
+        "COM1",
+        "LPT9",
+        "CON.txt",
+        "com1.json",
+        "LPT9.foo",
+        "CLOCK$",
+        "clock$.json",
+        "a:b",
+        "a*",
+        "a?b",
+        "batch.",
+        "batch ",
+    ],
+)
+def test_batch_id_rejects_windows_unsafe_path_components(tmp_path: Path, batch_id: str):
+    store = DeferredDeletionJournalStore(tmp_path, workspace="default")
+
+    with pytest.raises(ValueError, match="invalid batch_id"):
+        store.load(batch_id)
+
+
+def test_journal_round_trip_survives_store_recreation(tmp_path: Path):
+    store = DeferredDeletionJournalStore(tmp_path, workspace="default")
+    journal = _journal()
+    journal.aggregate_targets(
+        entities={"Shared": ["chunk-a", "chunk-b"]},
+        relationships={("Shared", "Other"): ["chunk-a"]},
+    )
+    journal.mark_rebuild_pending()
+
+    store.save(journal)
+
+    recovered = DeferredDeletionJournalStore(tmp_path, workspace="default").load(
+        journal.batch_id
+    )
+    assert recovered is not None
+    assert recovered.stage is DeferredDeletionStage.REBUILD_PENDING
+    assert recovered.document_ids == ["doc-a", "doc-b"]
+    assert recovered.entities_to_rebuild == {"Shared": ["chunk-a", "chunk-b"]}
+    assert recovered.relationships_to_rebuild == {("Other", "Shared"): ["chunk-a"]}
+
+
+def test_journal_persists_delete_file_intent_and_snapshot_source_paths(tmp_path: Path):
+    store = DeferredDeletionJournalStore(tmp_path, workspace="default")
+    journal = DeferredDeletionJournal.new(
+        "delete-source-files", ["doc-a"], False, delete_file=True
+    )
+    journal.source_file_paths = {"doc-a": "originals/a.pdf"}
+    store.save(journal)
+
+    recovered = DeferredDeletionJournalStore(tmp_path, workspace="default").load(
+        journal.batch_id
+    )
+
+    assert recovered is not None
+    assert recovered.delete_file is True
+    assert recovered.source_file_paths == {"doc-a": "originals/a.pdf"}
+
+
+def test_journal_aggregates_shared_targets_as_a_union(tmp_path: Path):
+    journal = _journal()
+
+    journal.aggregate_targets(
+        entities={"Shared": ["chunk-a", "chunk-b"], "First": ["chunk-a"]},
+        relationships={("Shared", "Other"): ["chunk-a"]},
+    )
+    journal.aggregate_targets(
+        entities={"Shared": ["chunk-b", "chunk-c"], "Second": ["chunk-c"]},
+        relationships={("Other", "Shared"): ["chunk-b", "chunk-c"]},
+    )
+
+    assert journal.entities_to_rebuild == {
+        "Shared": ["chunk-a", "chunk-b", "chunk-c"],
+        "First": ["chunk-a"],
+        "Second": ["chunk-c"],
+    }
+    assert journal.relationships_to_rebuild == {
+        ("Other", "Shared"): ["chunk-a", "chunk-b", "chunk-c"]
+    }
+
+
+def test_failed_rebuild_is_retryable_and_keeps_recovery_metadata(tmp_path: Path):
+    store = DeferredDeletionJournalStore(tmp_path, workspace="default")
+    journal = _journal()
+    journal.document_metadata = {
+        "doc-a": {"file_path": "a.pdf", "chunks_list": ["chunk-a"]}
+    }
+    journal.mark_rebuild_pending()
+    store.save(journal)
+
+    journal.mark_failed_retryable("rebuild failed")
+    store.save(journal)
+
+    recovered = store.load(journal.batch_id)
+    assert recovered is not None
+    assert recovered.stage is DeferredDeletionStage.FAILED_RETRYABLE
+    assert recovered.error_detail == "rebuild failed"
+    assert recovered.attempt_count == 1
+    assert recovered.document_metadata["doc-a"]["chunks_list"] == ["chunk-a"]
+
+
+def test_commit_is_only_valid_after_rebuild_pending():
+    journal = _journal()
+
+    with pytest.raises(ValueError, match="FINALIZATION_PENDING"):
+        journal.mark_committed()
+
+    journal.mark_rebuild_pending()
+    journal.mark_finalization_pending()
+    journal.mark_committed()
+    assert journal.stage is DeferredDeletionStage.COMMITTED
+
+
+def test_store_lists_only_unfinished_journals(tmp_path: Path):
+    store = DeferredDeletionJournalStore(tmp_path, workspace="default")
+    committed = DeferredDeletionJournal.new("committed", ["doc-a"], False)
+    committed.mark_rebuild_pending()
+    committed.mark_finalization_pending()
+    committed.mark_committed()
+    retryable = DeferredDeletionJournal.new("retryable", ["doc-b"], False)
+    retryable.mark_failed_retryable("rebuild failed")
+    store.save(committed)
+    store.save(retryable)
+
+    assert [journal.batch_id for journal in store.list_unfinished()] == ["retryable"]
+
+
+def test_store_uses_private_regular_files_and_rejects_symlinked_journals(
+    tmp_path: Path,
+):
+    store = DeferredDeletionJournalStore(tmp_path, workspace="default")
+    journal = _journal()
+    store.save(journal)
+    path = store._path(journal.batch_id)
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+    target = tmp_path / "target.json"
+    target.write_text("{}", encoding="utf-8")
+    path.unlink()
+    os.symlink(target, path)
+    with pytest.raises(OSError, match="symlink"):
+        store.load(journal.batch_id)
+
+
+@pytest.mark.asyncio
+async def test_batch_lock_is_released_after_lock_holder_process_crashes(tmp_path: Path):
+    """OS-owned lock releases on process death; retained lock file is harmless."""
+    store = DeferredDeletionJournalStore(tmp_path, workspace="default")
+    store.save(_journal())
+    script = """
+import asyncio
+import sys
+from lightrag.deletion_journal import DeferredDeletionJournalStore
+
+async def main():
+    store = DeferredDeletionJournalStore(sys.argv[1], "default")
+    async with store.batch_lock("batch-test-001"):
+        print("LOCKED", flush=True)
+        await asyncio.sleep(60)
+
+asyncio.run(main())
+"""
+    process = subprocess.Popen(
+        [sys.executable, "-c", script, str(tmp_path)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert process.stdout is not None
+        assert process.stdout.readline().strip() == "LOCKED"
+    finally:
+        process.terminate()
+        process.wait(timeout=10)
+
+    async def acquire_after_crash() -> None:
+        async with store.batch_lock("batch-test-001"):
+            return None
+
+    await asyncio.wait_for(acquire_after_crash(), timeout=3)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_contended_lock_acquisition_does_not_orphan_descriptor(
+    tmp_path: Path,
+):
+    """Cancelling a waiter cannot leave a later-acquired OS lock held forever."""
+    store = DeferredDeletionJournalStore(tmp_path, workspace="default")
+    store.save(_journal())
+    script = """
+import asyncio
+import sys
+from lightrag.deletion_journal import DeferredDeletionJournalStore
+
+async def main():
+    store = DeferredDeletionJournalStore(sys.argv[1], "default")
+    async with store.batch_lock("batch-test-001"):
+        print("LOCKED", flush=True)
+        await asyncio.sleep(60)
+
+asyncio.run(main())
+"""
+    process = subprocess.Popen(
+        [sys.executable, "-c", script, str(tmp_path)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert process.stdout is not None
+        assert process.stdout.readline().strip() == "LOCKED"
+
+        async def wait_for_lock() -> None:
+            async with store.batch_lock("batch-test-001"):
+                return None
+
+        waiter = asyncio.create_task(wait_for_lock())
+        await asyncio.sleep(0.05)
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+    finally:
+        process.terminate()
+        process.wait(timeout=10)
+
+    async def acquire_after_cancelled_waiter() -> None:
+        async with store.batch_lock("batch-test-001"):
+            return None
+
+    await asyncio.wait_for(acquire_after_cancelled_waiter(), timeout=3)
+
+
+def test_windows_lock_path_uses_msvcrt_lock_and_unlock_when_available(
+    tmp_path, monkeypatch
+):
+    """Exercise the Windows branch without requiring a Windows CI worker."""
+    import lightrag.deletion_journal as journal_module
+
+    calls = []
+
+    class FakeMsvcrt:
+        LK_LOCK = 1
+        LK_UNLCK = 2
+
+        @staticmethod
+        def locking(descriptor, operation, length):
+            calls.append((descriptor, operation, length))
+
+    monkeypatch.setattr(journal_module, "_is_windows", lambda: True)
+    monkeypatch.setitem(sys.modules, "msvcrt", FakeMsvcrt)
+    store = DeferredDeletionJournalStore(tmp_path, workspace="default")
+    lock_path = tmp_path / "deletion_journals" / "default" / ".windows-lock.lock"
+    lock_path.parent.mkdir(parents=True)
+
+    descriptor = store._acquire_os_lock(lock_path)
+    store._release_os_lock(descriptor)
+
+    assert [operation for _, operation, _ in calls] == [
+        FakeMsvcrt.LK_LOCK,
+        FakeMsvcrt.LK_UNLCK,
+    ]

--- a/tests/test_rebuild_fail_closed.py
+++ b/tests/test_rebuild_fail_closed.py
@@ -1,0 +1,72 @@
+"""Regression coverage for fail-closed cached-knowledge rebuilds."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lightrag.operate import rebuild_knowledge_from_chunks
+
+pytestmark = pytest.mark.offline
+
+
+@pytest.mark.asyncio
+async def test_rebuild_raises_when_no_cached_extraction_results_exist():
+    """Deletion finalization must not proceed if required cache evidence is absent."""
+    with patch(
+        "lightrag.operate._get_cached_extraction_results",
+        new_callable=AsyncMock,
+        return_value={},
+    ):
+        with pytest.raises(RuntimeError, match="No cached extraction results found"):
+            await rebuild_knowledge_from_chunks(
+                entities_to_rebuild={"ENTITY": ["chunk-a"]},
+                relationships_to_rebuild={},
+                knowledge_graph_inst=MagicMock(),
+                entities_vdb=MagicMock(),
+                relationships_vdb=MagicMock(),
+                text_chunks_storage=AsyncMock(),
+                llm_response_cache=AsyncMock(),
+                global_config={},
+            )
+
+
+@pytest.mark.asyncio
+async def test_rebuild_raises_when_a_worker_failure_is_captured():
+    """Worker exceptions caught for status reporting still fail the caller closed."""
+
+    @asynccontextmanager
+    async def keyed_lock(*_args, **_kwargs):
+        yield
+
+    with (
+        patch(
+            "lightrag.operate._get_cached_extraction_results",
+            new_callable=AsyncMock,
+            return_value={"chunk-a": [("cached result", 1)]},
+        ),
+        patch(
+            "lightrag.operate._rebuild_from_extraction_result",
+            new_callable=AsyncMock,
+            return_value=({}, {}),
+        ),
+        patch("lightrag.operate.get_storage_keyed_lock", keyed_lock),
+        patch(
+            "lightrag.operate._rebuild_single_entity",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("storage write failed"),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="Failed: 1 entities"):
+            await rebuild_knowledge_from_chunks(
+                entities_to_rebuild={"ENTITY": ["chunk-a"]},
+                relationships_to_rebuild={},
+                knowledge_graph_inst=MagicMock(),
+                entities_vdb=MagicMock(),
+                relationships_vdb=MagicMock(),
+                text_chunks_storage=AsyncMock(),
+                llm_response_cache=AsyncMock(),
+                global_config={},
+            )


### PR DESCRIPTION
## Summary

- persist deferred multi-document deletion intent in an atomic filesystem journal before destructive work
- perform one validated aggregate graph rebuild per batch, then verified metadata finalization
- support explicit crash/restart recovery with per-batch cross-process locking and read-only status endpoints
- preserve `delete_file` and LLM-cache cleanup intent across retries with at-most-once source-file cleanup
- reject unsafe workspace/batch path components on POSIX and Windows

This is a production-safety hardening/superset of the deferred-rebuild direction in #2819.

## Recovery API

- `GET /documents/delete_document/deferred`
- `GET /documents/delete_document/deferred/{batch_id}`
- `POST /documents/delete_document/{batch_id}/resume`

Operator behavior and lifecycle stages are documented in `docs/LightRAG-API-Server.md`.

## Verification

- focused deferred-delete regression suite: `53 passed`
- full CI-style offline suite: `2069 passed, 815 deselected`
- `ruff check`: passed
- `ruff format --check`: passed
- `git diff --check`: passed
- repeated independent adversarial review: final `PASS`

Full offline command:

```bash
PATH=/opt/homebrew/bin:$PATH \
  /tmp/lightrag-fulltest-venv/bin/python -m pytest tests/ -m offline -q
```

## Safety notes

- no automatic destructive resume at startup
- journals remain under persistent `working_dir/deletion_journals/<workspace>`
- `COMMITTED` requires successful rebuild and verification of every finalized metadata store
- uncertain document-delete outcomes and source-file cleanup are fail-closed / at-most-once
