### PR TITLE
📝 docs(contributing): require English for Git commit messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,7 +309,7 @@ See `env.example` for comprehensive template.
 ## Code Style
 
 ### Language
-Comments, backend code, and log messages in English. Frontend uses i18next for multi-language support.
+Comments, backend code, log messages, and Git commit messages in English. Frontend uses i18next for multi-language support.
 
 ### Python
 - Follow PEP 8 with 4-space indentation
@@ -328,3 +328,4 @@ Comments, backend code, and log messages in English. Frontend uses i18next for m
 
 - If this repo is a fork of `HKUDS/LightRAG`. Target to `HKUDS/LightRAG` when creating PRs, not the fork's own repo.
 - PR descriptions should include: summary, motivation, linked issues if applyed, what's changed, what's broken and how it works.
+- Write commit messages (subject and body) in English. Commit messages are repository artifacts — like code comments and log messages — not conversational replies, so they follow the English code-style rule above regardless of any per-conversation working language. This keeps history consistent with the `HKUDS/LightRAG` target.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,4 +328,4 @@ Comments, backend code, log messages, and Git commit messages in English. Fronte
 
 - If this repo is a fork of `HKUDS/LightRAG`. Target to `HKUDS/LightRAG` when creating PRs, not the fork's own repo.
 - PR descriptions should include: summary, motivation, linked issues if applyed, what's changed, what's broken and how it works.
-- Write commit messages (subject and body) in English. Commit messages are repository artifacts — like code comments and log messages — not conversational replies, so they follow the English code-style rule above regardless of any per-conversation working language. This keeps history consistent with the `HKUDS/LightRAG` target.
+- Write commit messages (subject and body) in English. Commit messages are repository artifacts — like code comments and log messages — not conversational replies, so they follow the English code-style rule above regardless of any per-conversation working language.


### PR DESCRIPTION
## Summary

Make it an explicit rule that **Git commit messages (subject and body) are written in English**.

## Motivation

`Code Style > Language` scoped the "in English" rule to *comments, backend code, and log messages* only, and the *Commit and Pull Request Guidance* section said nothing about commit-message language. That gap let a per-conversation working language drive commit generation, producing inconsistent history on feature branches (some commits English, some not). Since PRs target the English `HKUDS/LightRAG` upstream, English commit messages are the reasonable expectation — this codifies it.

## What's changed

- `Code Style > Language`: add "Git commit messages" to the English scope.
- `Commit and Pull Request Guidance`: add a bullet stating commit messages (subject and body) are English. It frames commit messages as **repository artifacts** — like code comments and log messages — rather than conversational replies, so the existing English code-style rule applies regardless of the working language.

Docs-only change; no code impact.