### PR TITLE
Fix description accumulation on reprocess in merge_nodes_and_edges

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -2016,18 +2016,37 @@ def _combine_descriptions_dedup(
     fragment on every reprocess or resume (issue #3367); it also collapses any
     legacy duplicate fragments already stored. Returns the combined list and the
     count of surviving stored fragments, used for accurate merge accounting.
+
+    Fragments are compared and stored *after* ``sanitize_text_for_encoding``:
+    stored descriptions were already sanitized before being persisted (the
+    single-description return and the join in ``_handle_entity_relation_summary``
+    both sanitize), while a freshly re-extracted description is still raw.
+    Comparing raw-vs-sanitized would miss the duplicate whenever sanitization
+    changed the string (e.g. an XML-illegal control char was stripped), so
+    "dirty" descriptions would keep accumulating across reprocess. Sanitizing
+    here is idempotent, so the later sanitize calls are unaffected. Fragments
+    that sanitize to empty are dropped (they carry no information and would only
+    inflate the fragment count / emit ``<sep><sep>`` artifacts on join).
+
+    The two-phase walk is deliberate: ``already_fragment`` is captured after the
+    stored pass so it stays an accurate count of surviving stored fragments. Do
+    NOT collapse both phases into a single ``dict.fromkeys`` over the
+    concatenation — that loses the stored/new boundary the merge accounting log
+    depends on.
     """
     combined: list[str] = []
     seen: set[str] = set()
-    for desc in already_description:
-        if desc not in seen:
-            seen.add(desc)
-            combined.append(desc)
+
+    def _add_sanitized(descriptions: list[str]) -> None:
+        for desc in descriptions:
+            sanitized = sanitize_text_for_encoding(desc)
+            if sanitized and sanitized not in seen:
+                seen.add(sanitized)
+                combined.append(sanitized)
+
+    _add_sanitized(already_description)
     already_fragment = len(combined)
-    for desc in new_descriptions:
-        if desc not in seen:
-            seen.add(desc)
-            combined.append(desc)
+    _add_sanitized(new_descriptions)
     return combined, already_fragment
 
 

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -2005,6 +2005,32 @@ async def _rebuild_single_relationship(
             pipeline_status["history_messages"].append(status_message)
 
 
+def _combine_descriptions_dedup(
+    already_description: list[str], new_descriptions: list[str]
+) -> tuple[list[str], int]:
+    """Merge stored and newly-extracted descriptions, dropping exact duplicates.
+
+    Stored fragments come first (preserving prior order), then new fragments not
+    already present. Deduplicating across stored *and* new (not only within the
+    new batch) prevents a re-extracted description from appending a duplicate
+    fragment on every reprocess or resume (issue #3367); it also collapses any
+    legacy duplicate fragments already stored. Returns the combined list and the
+    count of surviving stored fragments, used for accurate merge accounting.
+    """
+    combined: list[str] = []
+    seen: set[str] = set()
+    for desc in already_description:
+        if desc not in seen:
+            seen.add(desc)
+            combined.append(desc)
+    already_fragment = len(combined)
+    for desc in new_descriptions:
+        if desc not in seen:
+            seen.add(desc)
+            combined.append(desc)
+    return combined, already_fragment
+
+
 async def _merge_nodes_then_upsert(
     entity_name: str,
     nodes_data: list[dict],
@@ -2163,8 +2189,11 @@ async def _merge_nodes_then_upsert(
         )
         sorted_descriptions = [dp["description"] for dp in sorted_nodes]
 
-        # Combine already_description with sorted new sorted descriptions
-        description_list = already_description + sorted_descriptions
+        # Combine stored and new descriptions, deduplicating across both so a
+        # re-extracted description does not accumulate on reprocess (issue #3367)
+        description_list, already_fragment = _combine_descriptions_dedup(
+            already_description, sorted_descriptions
+        )
         if not description_list:
             fallback_description = f"Entity {entity_name}"
             logger.warning(
@@ -2249,7 +2278,6 @@ async def _merge_nodes_then_upsert(
 
         # 10.Log based on actual LLM usage
         num_fragment = len(description_list)
-        already_fragment = len(already_description)
         if llm_was_used:
             status_message = f"LLMmrg: `{entity_name}` | {already_fragment}+{num_fragment - already_fragment}"
         else:
@@ -2521,8 +2549,11 @@ async def _merge_edges_then_upsert(
         )
         sorted_descriptions = [dp["description"] for dp in sorted_edges]
 
-        # Combine already_description with sorted new descriptions
-        description_list = already_description + sorted_descriptions
+        # Combine stored and new descriptions, deduplicating across both so a
+        # re-extracted description does not accumulate on reprocess (issue #3367)
+        description_list, already_fragment = _combine_descriptions_dedup(
+            already_description, sorted_descriptions
+        )
         if not description_list:
             logger.error(f"Relation {src_id}~{tgt_id} has no description")
             raise ValueError(f"Relation {src_id}~{tgt_id} has no description")
@@ -2602,7 +2633,6 @@ async def _merge_edges_then_upsert(
 
         # 10. Log based on actual LLM usage
         num_fragment = len(description_list)
-        already_fragment = len(already_description)
         if llm_was_used:
             status_message = f"LLMmrg: `{src_id}`~`{tgt_id}` | {already_fragment}+{num_fragment - already_fragment}"
         else:

--- a/tests/extraction/test_merge_description_dedup.py
+++ b/tests/extraction/test_merge_description_dedup.py
@@ -108,7 +108,68 @@ def test_combine_descriptions_dedup_preserves_distinct():
     assert already == 1
 
 
+def test_combine_descriptions_dedup_sanitizes_before_compare():
+    # A re-extracted description carrying an XML-illegal control char (\x08)
+    # sanitizes to a fragment already stored, so it must NOT accumulate on
+    # reprocess (issue #3367 P3c; aligns with #3373's dirty-char case). A raw
+    # comparison would treat the two as distinct and grow the fragment count.
+    stored = ["Alice is a software engineer at Acme."]
+    dirty_new = ["Alice\x08 is a software engineer at Acme."]
+    combined, already = _combine_descriptions_dedup(stored, dirty_new)
+    assert combined == ["Alice is a software engineer at Acme."]
+    assert already == 1
+
+
+def test_combine_descriptions_dedup_collapses_dirty_stored_fragments():
+    # Legacy dirty stored fragments (written before sanitization) collapse
+    # against a clean re-extraction; the surviving stored count reflects the
+    # sanitized fragment, not the raw duplicate.
+    combined, already = _combine_descriptions_dedup(
+        ["Bob\x08 builds pipelines.", "Bob builds pipelines."],
+        ["Bob builds pipelines."],
+    )
+    assert combined == ["Bob builds pipelines."]
+    assert already == 1
+
+
+def test_combine_descriptions_dedup_drops_empty_after_sanitize():
+    # A fragment that is only control chars sanitizes to "" and is dropped, so
+    # it neither inflates already_fragment nor emits a <sep><sep> artifact.
+    combined, already = _combine_descriptions_dedup(["A", "\x08"], ["\x00", "B"])
+    assert combined == ["A", "B"]
+    assert already == 1
+
+
 # --- node merge round-trip --------------------------------------------------
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_node_reprocess_with_dirty_char_does_not_accumulate():
+    """Round-trip twin of the helper test (aligns with #3373 test #2): a
+    re-extracted description with an XML-illegal control char must dedup against
+    the sanitized stored copy instead of accumulating on reprocess (#3367)."""
+    graph = _MemGraph()
+    cfg = _config()
+    clean = "Alice is a software engineer at Acme."
+    dirty = "Alice\x08 is a software engineer at Acme."
+    base = {
+        "entity_name": "ALICE",
+        "entity_type": "person",
+        "source_id": "chunk-1",
+        "file_path": "doc1.txt",
+        "timestamp": 1,
+    }
+
+    await _merge_nodes_then_upsert(
+        "ALICE", [dict(base, description=clean)], graph, None, cfg
+    )
+    # Reprocess with a dirty variant of the SAME description.
+    await _merge_nodes_then_upsert(
+        "ALICE", [dict(base, description=dirty, timestamp=2)], graph, None, cfg
+    )
+
+    assert _node_fragments(graph, "ALICE") == [clean]
 
 
 @pytest.mark.offline

--- a/tests/extraction/test_merge_description_dedup.py
+++ b/tests/extraction/test_merge_description_dedup.py
@@ -1,0 +1,211 @@
+"""Regression tests: merge must not accumulate duplicate description fragments
+across reprocess/resume (issue #3367).
+
+``_merge_nodes_then_upsert`` / ``_merge_edges_then_upsert`` combine the stored
+node/edge description (read back from the graph) with the newly extracted
+descriptions. Before the fix this was ``already_description + sorted_descriptions``,
+which deduplicated only *within* the new batch, not *between* stored and new.
+So re-running merge for an entity/relation that already exists (any reprocess or
+resume) re-appended the same description, growing the stored fragment count by
+one copy per reprocess (N -> N+1).
+
+These drive the real merge round-trip (``get_node``/``get_edge`` -> merge ->
+``upsert_node``/``upsert_edge``) against an in-memory graph, no DB or LLM.
+"""
+
+import pytest
+
+from lightrag.constants import GRAPH_FIELD_SEP
+from lightrag.operate import (
+    SOURCE_IDS_LIMIT_METHOD_KEEP,
+    _combine_descriptions_dedup,
+    _merge_edges_then_upsert,
+    _merge_nodes_then_upsert,
+)
+from lightrag.utils import Tokenizer, TokenizerInterface
+
+
+class _DummyTokenizer(TokenizerInterface):
+    """1:1 char-to-token mapping; keeps summary thresholds easy to reason about."""
+
+    def encode(self, content: str):
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens):
+        return "".join(chr(token) for token in tokens)
+
+
+class _MemGraph:
+    """Minimal in-memory graph: real read-back + write round-trip."""
+
+    def __init__(self):
+        self.nodes = {}
+        self.edges = {}
+
+    async def get_node(self, name):
+        return self.nodes.get(name)
+
+    async def upsert_node(self, name, node_data):
+        self.nodes[name] = dict(node_data)
+
+    async def has_node(self, name):
+        return name in self.nodes
+
+    async def has_edge(self, src, tgt):
+        return (src, tgt) in self.edges
+
+    async def get_edge(self, src, tgt):
+        return self.edges.get((src, tgt))
+
+    async def upsert_edge(self, src, tgt, edge_data):
+        self.edges[(src, tgt)] = dict(edge_data)
+
+
+def _config():
+    # Summary limits kept slack so the no-LLM join path is always taken:
+    # the accumulation bug lives in fragment assembly, not summarization.
+    return {
+        "tokenizer": Tokenizer("dummy", _DummyTokenizer()),
+        "summary_context_size": 1_000_000,
+        "summary_max_tokens": 1_000_000,
+        "force_llm_summary_on_merge": 6,
+        "source_ids_limit_method": SOURCE_IDS_LIMIT_METHOD_KEEP,
+        "max_source_ids_per_entity": 10_000,
+        "max_source_ids_per_relation": 10_000,
+        "max_file_paths": 100,
+        "file_path_more_placeholder": "...",
+    }
+
+
+def _node_fragments(graph, name):
+    return graph.nodes[name]["description"].split(GRAPH_FIELD_SEP)
+
+
+def _edge_fragments(graph, src, tgt):
+    return graph.edges[(src, tgt)]["description"].split(GRAPH_FIELD_SEP)
+
+
+# --- direct unit tests of the dedup helper ---------------------------------
+
+
+def test_combine_descriptions_dedup_cross_boundary():
+    combined, already = _combine_descriptions_dedup(["A", "B"], ["B", "C"])
+    # Stored first, then only genuinely new fragments; "B" is not re-appended.
+    assert combined == ["A", "B", "C"]
+    assert already == 2
+
+
+def test_combine_descriptions_dedup_collapses_legacy_stored_duplicates():
+    # Stored data that already accumulated duplicates self-heals on next merge.
+    combined, already = _combine_descriptions_dedup(["A", "A", "A"], ["A"])
+    assert combined == ["A"]
+    assert already == 1
+
+
+def test_combine_descriptions_dedup_preserves_distinct():
+    combined, already = _combine_descriptions_dedup(["A"], ["B", "C"])
+    assert combined == ["A", "B", "C"]
+    assert already == 1
+
+
+# --- node merge round-trip --------------------------------------------------
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_node_reprocess_does_not_accumulate_description():
+    graph = _MemGraph()
+    cfg = _config()
+    batch = {
+        "entity_name": "ALICE",
+        "entity_type": "person",
+        "description": "Alice is a software engineer at Acme.",
+        "source_id": "chunk-1",
+        "file_path": "doc1.txt",
+        "timestamp": 1,
+    }
+
+    counts = []
+    for _ in range(3):  # 3 reprocesses of the SAME description, no purge between
+        await _merge_nodes_then_upsert("ALICE", [dict(batch)], graph, None, cfg)
+        counts.append(len(_node_fragments(graph, "ALICE")))
+
+    # Before the fix this was [1, 2, 3]; the stored description must stay single.
+    assert counts == [1, 1, 1]
+    assert _node_fragments(graph, "ALICE") == ["Alice is a software engineer at Acme."]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_node_merge_keeps_distinct_descriptions():
+    """Negative twin: genuinely different descriptions are still accumulated."""
+    graph = _MemGraph()
+    cfg = _config()
+    base = {
+        "entity_name": "ALICE",
+        "entity_type": "person",
+        "source_id": "chunk-1",
+        "file_path": "doc1.txt",
+        "timestamp": 1,
+    }
+
+    await _merge_nodes_then_upsert(
+        "ALICE", [dict(base, description="Alice is an engineer.")], graph, None, cfg
+    )
+    await _merge_nodes_then_upsert(
+        "ALICE",
+        [dict(base, description="Alice leads the platform team.", timestamp=2)],
+        graph,
+        None,
+        cfg,
+    )
+
+    frags = _node_fragments(graph, "ALICE")
+    assert set(frags) == {
+        "Alice is an engineer.",
+        "Alice leads the platform team.",
+    }
+    assert len(frags) == 2
+
+
+# --- edge merge round-trip --------------------------------------------------
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_edge_reprocess_does_not_accumulate_description():
+    graph = _MemGraph()
+    # Endpoints already exist so the edge path does not synthesize new nodes.
+    graph.nodes["ALICE"] = {
+        "entity_type": "person",
+        "description": "x",
+        "source_id": "chunk-1",
+        "file_path": "doc1.txt",
+    }
+    graph.nodes["ACME"] = {
+        "entity_type": "organization",
+        "description": "y",
+        "source_id": "chunk-1",
+        "file_path": "doc1.txt",
+    }
+    cfg = _config()
+    batch = {
+        "src_id": "ALICE",
+        "tgt_id": "ACME",
+        "description": "Alice works at Acme.",
+        "keywords": "employment",
+        "weight": 1.0,
+        "source_id": "chunk-1",
+        "file_path": "doc1.txt",
+        "timestamp": 1,
+    }
+
+    counts = []
+    for _ in range(3):
+        await _merge_edges_then_upsert(
+            "ALICE", "ACME", [dict(batch)], graph, None, None, cfg
+        )
+        counts.append(len(_edge_fragments(graph, "ALICE", "ACME")))
+
+    assert counts == [1, 1, 1]
+    assert _edge_fragments(graph, "ALICE", "ACME") == ["Alice works at Acme."]


### PR DESCRIPTION
## Summary

`_merge_nodes_then_upsert` and `_merge_edges_then_upsert` combine the stored description read back from the graph with the newly extracted descriptions via `already_description + sorted_descriptions` (`operate.py`), which deduplicates only *within* the new batch (the `unique_nodes` / `unique_edges` step), not *between* stored and new.

So re-running merge for an entity/relation that already exists (any reprocess or resume) re-appends the same description. Each reprocess reads the full stored description back into `already_description` and adds one more copy, so the stored fragment count grows by one per reprocess (N -> N+1): a single failed-then-retried entity goes 1 -> 2 (looks like a doubling), and repeated retries accumulate linearly. Both purge paths (`_purge_stale_extraction_if_resuming`, `_purge_doc_chunks_and_kg`) discover targets via the `full_entities`/`full_relations` indexes, which merge only writes in its final phase, so a merge that wrote partial graph state then failed leaves no index row and the retry accumulates.

`source_id`/`file_path` are already deduplicated and safe; only descriptions accumulate. It is bounded (later re-summarization collapses it) but silently inflates entity/relation descriptions and does extra token work on every subsequent merge, across the file pipeline, `ainsert`, and `ainsert_custom_chunks` alike (all share `merge_nodes_and_edges`).

Fixes #3367.

## Fix

Add `_combine_descriptions_dedup`, a single order-preserving cross-dedup used at both merge sites: stored fragments first (preserving prior order), then only new fragments not already present. It also collapses any legacy duplicate fragments already stored, and returns the surviving stored-fragment count so the merge accounting log (`already+new`, `dd N`) stays accurate.

## Test plan

New `tests/extraction/test_merge_description_dedup.py`, driving the real merge round-trip (`get_node`/`get_edge` -> merge -> `upsert_node`/`upsert_edge`) against an in-memory graph, no DB or LLM:

- node reprocess of the same description stays single-fragment (was 1 -> 2 -> 3)
- relation reprocess of the same description stays single-fragment
- distinct descriptions are still accumulated (negative twin)
- `_combine_descriptions_dedup` cross-boundary dedup, legacy-duplicate collapse, and distinct-preservation

Verified the new tests fail on `main` (reproduce the `[1, 2, 3]` accumulation) and pass with the fix. `tests/extraction/` (110) and the merge-touching `tests/pipeline/` tests (107) pass; `ruff check` and `ruff format` clean.
