### PR TITLE
fix(chunker): reject chunk_overlap >= chunk_size in token windowing

### DIFF
--- a/lightrag/chunker/token_size.py
+++ b/lightrag/chunker/token_size.py
@@ -111,6 +111,22 @@ def _make_chunk(
     return item
 
 
+def _window_step(chunk_token_size: int, chunk_overlap_token_size: int) -> int:
+    """Token-window stride for the sliding-window chunk loops.
+
+    When overlap >= size the stride is <= 0, which makes ``range()`` yield an
+    empty sequence (dropping the whole segment silently) or raise the opaque
+    ``range() arg 3 must not be zero``. Fail closed with the same invariant the
+    API-boundary validators enforce.
+    """
+    if chunk_overlap_token_size >= chunk_token_size:
+        raise ValueError(
+            f"chunk_overlap_token_size ({chunk_overlap_token_size}) must be < "
+            f"chunk_token_size ({chunk_token_size})"
+        )
+    return chunk_token_size - chunk_overlap_token_size
+
+
 def chunking_by_token_size(
     tokenizer: Tokenizer,
     content: str,
@@ -167,7 +183,9 @@ def chunking_by_token_size(
                     # below), so it resets per split-by-character segment.
                     anchor = (0, 0)
                     for start in range(
-                        0, len(_tokens), chunk_token_size - chunk_overlap_token_size
+                        0,
+                        len(_tokens),
+                        _window_step(chunk_token_size, chunk_overlap_token_size),
                     ):
                         end_token = min(start + chunk_token_size, len(_tokens))
                         chunk_content = tokenizer.decode(_tokens[start:end_token])
@@ -213,7 +231,11 @@ def chunking_by_token_size(
     else:
         anchor = (0, 0)
         for index, start in enumerate(
-            range(0, len(tokens), chunk_token_size - chunk_overlap_token_size)
+            range(
+                0,
+                len(tokens),
+                _window_step(chunk_token_size, chunk_overlap_token_size),
+            )
         ):
             end = min(start + chunk_token_size, len(tokens))
             chunk_content = tokenizer.decode(tokens[start:end])

--- a/tests/chunker/test_chunking.py
+++ b/tests/chunker/test_chunking.py
@@ -310,6 +310,46 @@ def test_split_very_large_text():
 
 
 @pytest.mark.offline
+def test_overlap_greater_than_chunk_size_raises():
+    """Overlap larger than chunk size makes the stride negative, which yields an
+    empty range and silently drops the entire document. Fail closed instead."""
+    tokenizer = make_tokenizer()
+    content = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+    with pytest.raises(ValueError) as excinfo:
+        chunking_by_token_size(
+            tokenizer,
+            content,
+            chunk_token_size=50,
+            chunk_overlap_token_size=100,
+        )
+
+    message = str(excinfo.value)
+    assert "chunk_overlap_token_size (100)" in message
+    assert "chunk_token_size (50)" in message
+
+
+@pytest.mark.offline
+def test_overlap_equal_to_chunk_size_raises():
+    """Overlap equal to chunk size makes the stride zero, which otherwise raises
+    an opaque ``range() arg 3 must not be zero``. Raise a clear message instead."""
+    tokenizer = make_tokenizer()
+    content = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+    with pytest.raises(ValueError) as excinfo:
+        chunking_by_token_size(
+            tokenizer,
+            content,
+            chunk_token_size=10,
+            chunk_overlap_token_size=10,
+        )
+
+    message = str(excinfo.value)
+    assert "chunk_overlap_token_size (10)" in message
+    assert "chunk_token_size (10)" in message
+
+
+@pytest.mark.offline
 def test_empty_content():
     """Test chunking with empty content."""
     tokenizer = make_tokenizer()


### PR DESCRIPTION
### Problem

`chunking_by_token_size` (the default `chunking_func`, and the target of `chunking_by_fixed_token`) derives its sliding-window stride from `chunk_token_size - chunk_overlap_token_size`:

```python
range(0, len(tokens), chunk_token_size - chunk_overlap_token_size)
```

When `chunk_overlap_token_size >= chunk_token_size` that stride is `<= 0`, and the two failure modes are:

- **overlap > size** → the stride is negative → `range()` is empty → **the whole document is silently dropped** (zero chunks, no error, content lost).
- **overlap == size** → the stride is zero → `ValueError: range() arg 3 must not be zero` raised deep inside the chunker mid-insert.

The invariant `overlap < size` is already enforced at the API boundaries (`parser/param_schema.py`, `api/routers/document_routes.py`), but the library entry point is not covered: `LightRAG(chunk_token_size=..., chunk_overlap_token_size=...)` back-fills the pair in `_normalize_chunker_config` without validating it, so a direct library caller reaches the core chunker with a bad pair.

### Reproduction (offline, deterministic, no services)

```python
from lightrag.utils import Tokenizer, TokenizerInterface
from lightrag.chunker import chunking_by_token_size

class Dummy(TokenizerInterface):
    def encode(self, c): return [ord(x) for x in c]
    def decode(self, t): return "".join(chr(x) for x in t)

tk = Tokenizer(model_name="dummy", tokenizer=Dummy())
content = "abcdefghijklmnopqrstuvwxyz0123456789"

# overlap > size: silent content loss
print(len(chunking_by_token_size(tk, content, chunk_overlap_token_size=100, chunk_token_size=50)))
# -> 0   (document vanished, no error)

# overlap == size: opaque crash
chunking_by_token_size(tk, content, chunk_overlap_token_size=10, chunk_token_size=10)
# -> ValueError: range() arg 3 must not be zero
```

### Fix

Guard the stride at its single computation point via a small `_window_step` helper, raising the same message the boundary validators use:

```python
def _window_step(chunk_token_size, chunk_overlap_token_size):
    if chunk_overlap_token_size >= chunk_token_size:
        raise ValueError(
            f"chunk_overlap_token_size ({chunk_overlap_token_size}) must be < "
            f"chunk_token_size ({chunk_token_size})"
        )
    return chunk_token_size - chunk_overlap_token_size
```

Both windowing loops call it, so the primitive fails closed instead of losing content or crashing opaquely. The `split_by_character_only` path, where overlap is not applied and the stride is never used, is intentionally left unaffected (existing tests exercise `size=10, overlap=100` there).

### Tests

Added to `tests/chunker/test_chunking.py`, matching the file's `make_tokenizer()` / `pytest.raises` style:

- `test_overlap_greater_than_chunk_size_raises` — was silent 0 chunks, now asserts a clear `ValueError`.
- `test_overlap_equal_to_chunk_size_raises` — was `range() arg 3 must not be zero`, now asserts the clear message.

Full `tests/chunker/test_chunking.py` passes (39 tests).
