### PR TITLE
feat(api): server-side multi-workspace pools with HTTP routing and va…

### DIFF
--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -238,6 +238,49 @@ def get_binding_env_value(env_key: str, default: str) -> str:
     return normalize_binding_name(get_env_value(env_key, default)) or default
 
 
+_WORKSPACE_NAME_RE = re.compile(
+    r"^[A-Za-z0-9_.\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff-]+$"
+)
+
+
+def validate_workspace_name(name: str) -> str:
+    """Validate and normalize a workspace name. Returns stripped name or raises.
+
+    Allowed characters: ``[A-Za-z0-9_.-]`` plus Chinese (\\u4e00-\\u9fff) and
+    Japanese kana.  Dots (``.``) are allowed (useful for versioned names like
+    ``v1.0``) because path-traversal is already blocked by the explicit ``..``
+    check below.
+
+    This is a rejection-based whitelist validator — unlike the old
+    substitution-based approach (``re.sub``), different invalid inputs are
+    NOT silently mapped to the same output.  The operator is told exactly
+    what to fix.
+
+    Args:
+        name: Raw workspace name from header or CLI.
+
+    Returns:
+        Validated, stripped workspace name.
+
+    Raises:
+        HTTPException(400): Invalid or empty workspace name.
+    """
+    from fastapi import HTTPException
+
+    name = name.strip()
+    if not name:
+        raise HTTPException(400, "LIGHTRAG-WORKSPACE header must not be empty")
+    if len(name) > 128:
+        raise HTTPException(400, "LIGHTRAG-WORKSPACE name too long (max 128 chars)")
+    if name in (".", ".."):
+        raise HTTPException(400, f"Invalid workspace name: {name}")
+    if "/" in name or "\\" in name:
+        raise HTTPException(400, f"Invalid workspace name: {name}")
+    if not _WORKSPACE_NAME_RE.match(name):
+        raise HTTPException(400, f"Workspace name contains invalid characters: {name}")
+    return name
+
+
 def parse_args() -> argparse.Namespace:
     """
     Parse command line arguments with environment variable fallback
@@ -736,16 +779,9 @@ def parse_args() -> argparse.Namespace:
     ollama_server_infos.LIGHTRAG_NAME = args.simulated_model_name
     ollama_server_infos.LIGHTRAG_TAG = args.simulated_model_tag
 
-    # Sanitize workspace: only alphanumeric characters and underscores are allowed
+    # Validate workspace name (rejection-based whitelist)
     if args.workspace:
-        sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", args.workspace)
-        if sanitized != args.workspace:
-            logging.warning(
-                f"Workspace name '{args.workspace}' contains invalid characters. "
-                f"It has been sanitized to '{sanitized}'. "
-                "Only alphanumeric characters and underscores are allowed."
-            )
-            args.workspace = sanitized
+        args.workspace = validate_workspace_name(args.workspace)
 
     validate_auth_configuration(args)
     validate_bedrock_auth_configuration(args)

--- a/lightrag/api/document_manager.py
+++ b/lightrag/api/document_manager.py
@@ -1,0 +1,117 @@
+"""Document manager for LightRAG API — per-workspace input-directory management.
+
+Extracted from ``lightrag/api/routers/document_routes.py`` so that
+``workspace_pool.py`` can import ``DocumentManager`` without creating a
+circular import with the router module.
+"""
+
+from pathlib import Path
+from typing import List
+
+from lightrag.utils import logger, validate_workspace
+
+
+class DocumentManager:
+    def __init__(
+        self,
+        input_dir: str,
+        workspace: str = "",  # New parameter for workspace isolation
+    ):
+        # Reject path traversal before using workspace in the upload path
+        validate_workspace(workspace)
+        # Store the base input directory and workspace
+        self.base_input_dir = Path(input_dir)
+        self.workspace = workspace
+        self.indexed_files = set()
+
+        # Create workspace-specific input directory
+        # If workspace is provided, create a subdirectory for data isolation
+        if workspace:
+            self.input_dir = self.base_input_dir / workspace
+        else:
+            self.input_dir = self.base_input_dir
+
+        # Create input directory if it doesn't exist
+        self.input_dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def supported_extensions(self) -> tuple:
+        """Suffixes accepted for an unhinted filename, derived live.
+
+        A suffix is advertised only when it is *routable without extra
+        directives*: the engine that ``resolve_file_parser_engine`` picks for
+        a bare ``x.<suffix>`` (filename hint absent; ``LIGHTRAG_PARSER``
+        rules + default apply) must itself support the suffix. This keeps
+        "uploadable" aligned with "will actually parse": e.g. mineru's
+        ``png`` joins only when its endpoint is configured AND a routing
+        rule (or per-file hint, see ``is_supported_file``) sends pngs to it
+        — otherwise the default ``legacy`` engine would fail the suffix gate
+        at the parse stage. A default deployment equals the local engines'
+        (legacy ∪ native) types; no hardcoded list to keep in sync.
+        """
+        from lightrag.parser.registry import available_engine_suffixes
+        from lightrag.parser.routing import (
+            parser_engine_supports_suffix,
+            resolve_file_parser_engine,
+        )
+
+        out = []
+        for s in sorted(available_engine_suffixes()):
+            engine = resolve_file_parser_engine(f"x.{s}")
+            if parser_engine_supports_suffix(engine, s):
+                out.append(f".{s}")
+        return tuple(out)
+
+    def scan_directory_for_new_files(self) -> List[Path]:
+        """Scan input directory for new, routable files.
+
+        Globs over every *available* engine suffix (capability surface, so a
+        hint-carrying file like ``img.[mineru].png`` is discoverable even
+        when bare ``.png`` is not advertised), then keeps only files whose
+        resolved engine actually supports them (``is_supported_file``).
+        """
+        from lightrag.parser.registry import available_engine_suffixes
+        from lightrag.parser.routing import FilenameParserHintError
+
+        new_files = []
+        for s in sorted(available_engine_suffixes()):
+            ext = f".{s}"
+            logger.debug(f"Scanning for {ext} files in {self.input_dir}")
+            for file_path in self.input_dir.glob(f"*{ext}"):
+                if file_path in self.indexed_files:
+                    continue
+                try:
+                    if not self.is_supported_file(file_path.name):
+                        continue
+                except FilenameParserHintError:
+                    # Malformed hint: pass the file through — the enqueue
+                    # path reports a detailed error document, instead of the
+                    # scan silently ignoring the user's file.
+                    pass
+                new_files.append(file_path)
+        return new_files
+
+    def mark_as_indexed(self, file_path: Path):
+        self.indexed_files.add(file_path)
+
+    def is_supported_file(self, filename: str) -> bool:
+        """True when THIS filename routes to an engine that can parse it.
+
+        Resolves the engine for the concrete name — so a per-file hint
+        (``img.[mineru].png``) is honoured — and checks the resolved engine
+        supports the suffix. A bare suffix that would fall through to the
+        default ``legacy`` engine is rejected here instead of failing later
+        at the parse worker's suffix gate.
+
+        Raises :class:`FilenameParserHintError` for a malformed hint —
+        callers surface it (upload → HTTP 400 with the detailed message;
+        scan passes the file through so enqueue emits an error document).
+        """
+        from lightrag.parser.routing import (
+            parser_engine_supports_suffix,
+            parser_suffix,
+            resolve_file_parser_engine,
+        )
+
+        engine = resolve_file_parser_engine(filename)
+        return parser_engine_supports_suffix(engine, parser_suffix(filename))

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -59,6 +59,7 @@ from lightrag.api.routers.query_routes import create_query_routes
 from lightrag.api.routers.graph_routes import create_graph_routes
 from lightrag.api.routers.ollama_api import OllamaAPI
 from lightrag.api.workspace_pool import RagPool, DocManagerPool
+from lightrag.exceptions import PipelineNotInitializedError
 
 from lightrag.utils import logger, set_verbose_debug
 from lightrag.kg.shared_storage import (
@@ -66,6 +67,7 @@ from lightrag.kg.shared_storage import (
     set_default_workspace,
     cleanup_keyed_lock,
     finalize_share_data,
+    initialize_share_data,
 )
 from fastapi.security import OAuth2PasswordRequestForm
 from lightrag.api.auth import auth_handler
@@ -1270,7 +1272,10 @@ def create_app(args):
         # Store background tasks
         app.state.background_tasks = set()
 
-        # No pre-initialization — workspaces are created lazily by RagPool.
+        # Initialize shared dictionaries early — the /health endpoint needs
+        # them even though workspaces are created lazily by RagPool.
+        initialize_share_data()
+
         try:
             yield
         finally:
@@ -2268,22 +2273,30 @@ def create_app(args):
         """
         try:
             ws = get_workspace_from_request(request, default_workspace=args.workspace)
-            pipeline_status = await get_namespace_data("pipeline_status", workspace=ws)
-
-            pipeline_busy = bool(pipeline_status.get("busy", False))
-            pipeline_scanning = bool(pipeline_status.get("scanning", False))
-            pipeline_destructive_busy = bool(
-                pipeline_status.get("destructive_busy", False)
-            )
-            pipeline_pending_enqueues = int(
-                pipeline_status.get("pending_enqueues", 0) or 0
-            )
-            pipeline_active = (
-                pipeline_busy
-                or pipeline_scanning
-                or pipeline_destructive_busy
-                or pipeline_pending_enqueues > 0
-            )
+            try:
+                pipeline_status = await get_namespace_data("pipeline_status", workspace=ws)
+            except PipelineNotInitializedError:
+                # Workspace hasn't been created yet (lazy init) — pipeline is idle.
+                pipeline_busy = False
+                pipeline_scanning = False
+                pipeline_destructive_busy = False
+                pipeline_pending_enqueues = 0
+                pipeline_active = False
+            else:
+                pipeline_busy = bool(pipeline_status.get("busy", False))
+                pipeline_scanning = bool(pipeline_status.get("scanning", False))
+                pipeline_destructive_busy = bool(
+                    pipeline_status.get("destructive_busy", False)
+                )
+                pipeline_pending_enqueues = int(
+                    pipeline_status.get("pending_enqueues", 0) or 0
+                )
+                pipeline_active = (
+                    pipeline_busy
+                    or pipeline_scanning
+                    or pipeline_destructive_busy
+                    or pipeline_pending_enqueues > 0
+                )
 
             if not auth_configured:
                 auth_mode = "disabled"

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -11,7 +11,6 @@ from fastapi.openapi.docs import (
 )
 import json
 import os
-import re
 import logging
 import logging.config
 import sys
@@ -29,6 +28,7 @@ from dotenv import load_dotenv
 from lightrag.api.utils_api import (
     get_combined_auth_dependency,
     get_auth_status_dependency,
+    get_workspace_from_request,
     display_splash_screen,
     check_env_file,
 )
@@ -40,7 +40,7 @@ from .config import (
     PREFIX_ASYMMETRIC_EMBEDDING_BINDINGS,
 )
 from lightrag.utils import get_env_value
-from lightrag import LightRAG, ROLES, RoleLLMConfig, __version__ as core_version
+from lightrag import ROLES, RoleLLMConfig, __version__ as core_version
 from lightrag.api import __api_version__
 from lightrag.utils import EmbeddingFunc
 from lightrag.constants import (
@@ -48,10 +48,7 @@ from lightrag.constants import (
     DEFAULT_LOG_BACKUP_COUNT,
     DEFAULT_LOG_FILENAME,
 )
-from lightrag.api.routers.document_routes import (
-    DocumentManager,
-    create_document_routes,
-)
+from lightrag.api.routers.document_routes import create_document_routes
 from lightrag.parser.plugins import load_third_party_parsers
 from lightrag.parser.routing import (
     parser_rules_from_env,
@@ -61,12 +58,12 @@ from lightrag.parser.external.mineru.cache import MinerUParserOptions
 from lightrag.api.routers.query_routes import create_query_routes
 from lightrag.api.routers.graph_routes import create_graph_routes
 from lightrag.api.routers.ollama_api import OllamaAPI
+from lightrag.api.workspace_pool import RagPool, DocManagerPool
 
 from lightrag.utils import logger, set_verbose_debug
 from lightrag.kg.shared_storage import (
     get_namespace_data,
-    get_default_workspace,
-    # set_default_workspace,
+    set_default_workspace,
     cleanup_keyed_lock,
     finalize_share_data,
 )
@@ -1262,8 +1259,10 @@ def create_app(args):
     # Check if API key is provided either through env var or args
     api_key = os.getenv("LIGHTRAG_API_KEY") or args.key
 
-    # Initialize document manager with workspace support for data isolation
-    doc_manager = DocumentManager(args.input_dir, workspace=args.workspace)
+    # Set the global default workspace deterministically before any pool
+    # instance is created, so pool-created instances do not race to become
+    # the global default (§14.4).
+    set_default_workspace(args.workspace)
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
@@ -1271,30 +1270,27 @@ def create_app(args):
         # Store background tasks
         app.state.background_tasks = set()
 
+        # No pre-initialization — workspaces are created lazily by RagPool.
         try:
-            # Initialize database connections
-            # Note: initialize_storages() now auto-initializes pipeline_status for rag.workspace
-            await rag.initialize_storages()
-
-            # Data migration regardless of storage implementation
-            await rag.check_and_migrate_data()
-
-            ASCIIColors.green("\nServer is ready to accept connections! 🚀\n")
-
             yield
-
         finally:
-            # Clean up database connections
-            await rag.finalize_storages()
+            # Shutdown: finalize all cached instances.  Use try/finally so
+            # that a failure in one pool does not skip the other.
+            try:
+                await rag_pool.shutdown_all()
+            finally:
+                await doc_mgr_pool.shutdown_all()
 
+            # Finalize shared multiprocessing resources (uvicorn-only).
+            # In Gunicorn mode with preload_app=True, this is handled by
+            # on_exit hooks in the master process instead.
             if "LIGHTRAG_GUNICORN_MODE" not in os.environ:
-                # Only perform cleanup in Uvicorn single-process mode
-                logger.debug("Unvicorn Mode: finalizing shared storage...")
+                logger.debug("Uvicorn Mode: finalizing shared storage...")
                 finalize_share_data()
             else:
-                # In Gunicorn mode with preload_app=True, cleanup is handled by on_exit hooks
                 logger.debug(
-                    "Gunicorn Mode: postpone shared storage finalization to master process"
+                    "Gunicorn Mode: postpone shared storage finalization "
+                    "to master process"
                 )
 
     base_description = (
@@ -1416,36 +1412,6 @@ def create_app(args):
     # Non-enforcing dependency: reports whether the caller is authenticated so
     # /health can stay a public liveness probe while gating sensitive config.
     auth_status = get_auth_status_dependency(api_key)
-
-    def get_workspace_from_request(request: Request) -> str | None:
-        """
-        Extract workspace from HTTP request header or use default.
-
-        This enables multi-workspace API support by checking the custom
-        'LIGHTRAG-WORKSPACE' header. If not present, falls back to the
-        server's default workspace configuration.
-
-        Args:
-            request: FastAPI Request object
-
-        Returns:
-            Workspace identifier (may be empty string for global namespace)
-        """
-        # Check custom header first
-        workspace = request.headers.get("LIGHTRAG-WORKSPACE", "").strip()
-
-        if not workspace:
-            workspace = None
-        else:
-            sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", workspace)
-            if sanitized != workspace:
-                logger.warning(
-                    f"Workspace header '{workspace}' contains invalid characters. "
-                    f"Sanitized to '{sanitized}'."
-                )
-                workspace = sanitized
-
-        return workspace
 
     # Create working directory if it doesn't exist
     Path(args.working_dir).mkdir(parents=True, exist_ok=True)
@@ -2016,105 +1982,117 @@ def create_app(args):
         name=args.simulated_model_name, tag=args.simulated_model_tag
     )
 
-    # LightRAG.__post_init__ normalizes addon_params and backfills env-based defaults
-    # (SUMMARY_LANGUAGE, ENTITY_TYPE_PROMPT_FILE, ...), so we only need to pass the
-    # API-level overrides here.
-    addon_params = {
-        "language": args.summary_language,
-    }
+    def build_rag_config(workspace: str) -> dict:
+        """Build a fresh LightRAG config dict for *workspace*.
 
-    role_llm_configs = {
-        spec.name: {
-            **resolve_role_llm_settings(spec.name),
-            "func": create_role_llm_func(spec.name),
-            "kwargs": create_role_llm_model_kwargs(spec.name),
-        }
-        for spec in ROLES
-    }
-
-    # Initialize RAG with unified configuration
-    try:
-        rag = LightRAG(
-            working_dir=args.working_dir,
-            workspace=args.workspace,
-            llm_model_func=create_llm_model_func(args.llm_binding),
-            llm_model_name=args.llm_model,
-            llm_model_max_async=args.max_async,
-            summary_max_tokens=args.summary_max_tokens,
-            summary_context_size=args.summary_context_size,
-            chunk_token_size=int(args.chunk_size),
-            chunk_overlap_token_size=int(args.chunk_overlap_size),
-            llm_model_kwargs=create_llm_model_kwargs(
+        Shared singletons (LLM functions, embedding functions, clients,
+        OllamaServerInfos) are captured by the closure and reused by
+        reference.  Per-workspace values (kwargs dicts, addon_params,
+        role_llm_configs) are re-constructed on every call — no deepcopy
+        needed, no risk of accidentally sharing mutable state.
+        """
+        return {
+            # ── Shared singletons (closure-captured once, safe to reuse) ──
+            "working_dir": args.working_dir,
+            "llm_model_name": args.llm_model,
+            "llm_model_max_async": args.max_async,
+            "summary_max_tokens": args.summary_max_tokens,
+            "summary_context_size": args.summary_context_size,
+            "embedding_func": embedding_func,
+            "default_llm_timeout": llm_timeout,
+            "default_embedding_timeout": embedding_timeout,
+            "kv_storage": args.kv_storage,
+            "graph_storage": args.graph_storage,
+            "vector_storage": args.vector_storage,
+            "doc_status_storage": args.doc_status_storage,
+            "enable_llm_cache_for_entity_extract": args.enable_llm_cache_for_extract,
+            "enable_llm_cache": args.enable_llm_cache,
+            "vlm_process_enable": args.vlm_process_enable,
+            "rerank_model_func": rerank_model_func,
+            "rerank_model_max_async": args.rerank_max_async,
+            "default_rerank_timeout": args.rerank_timeout,
+            "max_parallel_insert": args.max_parallel_insert,
+            "max_graph_nodes": args.max_graph_nodes,
+            "ollama_server_infos": ollama_server_infos,
+            # ── Per-workspace (freshly constructed on every call) ──
+            "workspace": workspace,
+            "llm_model_func": create_llm_model_func(args.llm_binding),
+            "chunk_token_size": int(args.chunk_size),
+            "chunk_overlap_token_size": int(args.chunk_overlap_size),
+            "llm_model_kwargs": create_llm_model_kwargs(
                 args.llm_binding, args, llm_timeout
             ),
-            embedding_func=embedding_func,
-            default_llm_timeout=llm_timeout,
-            default_embedding_timeout=embedding_timeout,
-            kv_storage=args.kv_storage,
-            graph_storage=args.graph_storage,
-            vector_storage=args.vector_storage,
-            doc_status_storage=args.doc_status_storage,
-            vector_db_storage_cls_kwargs={
-                "cosine_better_than_threshold": args.cosine_threshold
+            "vector_db_storage_cls_kwargs": {
+                "cosine_better_than_threshold": args.cosine_threshold,
             },
-            enable_llm_cache_for_entity_extract=args.enable_llm_cache_for_extract,
-            enable_llm_cache=args.enable_llm_cache,
-            vlm_process_enable=args.vlm_process_enable,
-            rerank_model_func=rerank_model_func,
-            rerank_model_max_async=args.rerank_max_async,
-            default_rerank_timeout=args.rerank_timeout,
-            max_parallel_insert=args.max_parallel_insert,
-            max_graph_nodes=args.max_graph_nodes,
-            addon_params=addon_params,
-            ollama_server_infos=ollama_server_infos,
-            role_llm_configs={
+            "addon_params": {
+                "language": args.summary_language,
+            },
+            "role_llm_configs": {
                 spec.name: RoleLLMConfig(
-                    func=role_llm_configs[spec.name]["func"],
-                    kwargs=role_llm_configs[spec.name]["kwargs"],
-                    max_async=role_llm_configs[spec.name]["max_async"],
-                    timeout=role_llm_configs[spec.name]["timeout"],
+                    func=create_role_llm_func(spec.name),
+                    kwargs=create_role_llm_model_kwargs(spec.name),
+                    max_async=resolve_role_llm_settings(spec.name)["max_async"],
+                    timeout=resolve_role_llm_settings(spec.name)["timeout"],
                     metadata={
                         "base_binding": args.llm_binding,
-                        "binding": role_llm_configs[spec.name]["binding"],
-                        "model": role_llm_configs[spec.name]["model"],
-                        "host": role_llm_configs[spec.name]["host"],
-                        "api_key": role_llm_configs[spec.name]["api_key"],
-                        "provider_options": role_llm_configs[spec.name][
+                        "binding": resolve_role_llm_settings(spec.name)["binding"],
+                        "model": resolve_role_llm_settings(spec.name)["model"],
+                        "host": resolve_role_llm_settings(spec.name)["host"],
+                        "api_key": resolve_role_llm_settings(spec.name)["api_key"],
+                        "provider_options": resolve_role_llm_settings(spec.name)[
                             "provider_options"
                         ],
-                        "bedrock_aws_options": role_llm_configs[spec.name][
+                        "bedrock_aws_options": resolve_role_llm_settings(spec.name)[
                             "bedrock_aws_options"
                         ],
-                        "is_cross_provider": role_llm_configs[spec.name][
+                        "is_cross_provider": resolve_role_llm_settings(spec.name)[
                             "is_cross_provider"
                         ],
                     },
                 )
                 for spec in ROLES
             },
-        )
-    except Exception as e:
-        logger.error(f"Failed to initialize LightRAG: {e}")
-        raise
+        }
 
-    _log_role_provider_options(rag)
-
-    rag.register_role_llm_builder(
-        lambda role, meta: (
+    def role_llm_builder(role, meta):
+        return (
             create_role_llm_func(role, meta),
             create_role_llm_model_kwargs(role, meta),
         )
+
+    rag_pool = RagPool(
+        config_factory=build_rag_config,
+        role_llm_builder=role_llm_builder,
+        on_create=_log_role_provider_options,
     )
+    doc_mgr_pool = DocManagerPool(args.input_dir)
 
     # Add routes
     # root_path is set on the app for reverse proxy support;
     # routes stay at their natural paths and are prefixed by the proxy or uvicorn --root-path
-    app.include_router(create_document_routes(rag, doc_manager, api_key))
-    app.include_router(create_query_routes(rag, api_key, args.top_k))
-    app.include_router(create_graph_routes(rag, api_key))
+    app.include_router(
+        create_document_routes(
+            rag_pool, doc_mgr_pool, api_key, default_workspace=args.workspace
+        )
+    )
+    app.include_router(
+        create_query_routes(
+            rag_pool, api_key, args.top_k, default_workspace=args.workspace
+        )
+    )
+    app.include_router(
+        create_graph_routes(rag_pool, api_key, default_workspace=args.workspace)
+    )
 
     # Add Ollama API routes
-    ollama_api = OllamaAPI(rag, top_k=args.top_k, api_key=api_key)
+    ollama_api = OllamaAPI(
+        rag_pool=rag_pool,
+        ollama_server_infos=ollama_server_infos,
+        top_k=args.top_k,
+        api_key=api_key,
+        default_workspace=args.workspace,
+    )
     app.include_router(ollama_api.router, prefix="/api")
 
     # Custom Swagger UI endpoint for offline support
@@ -2289,13 +2267,8 @@ def create_app(args):
         caller is authenticated (see get_auth_status_dependency).
         """
         try:
-            workspace = get_workspace_from_request(request)
-            default_workspace = get_default_workspace()
-            if workspace is None:
-                workspace = default_workspace
-            pipeline_status = await get_namespace_data(
-                "pipeline_status", workspace=workspace
-            )
+            ws = get_workspace_from_request(request, default_workspace=args.workspace)
+            pipeline_status = await get_namespace_data("pipeline_status", workspace=ws)
 
             pipeline_busy = bool(pipeline_status.get("busy", False))
             pipeline_scanning = bool(pipeline_status.get("scanning", False))
@@ -2345,6 +2318,8 @@ def create_app(args):
             # Cleanup expired keyed locks and get status
             keyed_lock_info = cleanup_keyed_lock()
 
+            rag = await rag_pool.get(ws)
+
             status_data.update(
                 {
                     "working_directory": str(args.working_dir),
@@ -2367,7 +2342,7 @@ def create_app(args):
                         "enable_llm_cache_for_extract": args.enable_llm_cache_for_extract,
                         "enable_llm_cache": args.enable_llm_cache,
                         "vlm_process_enable": args.vlm_process_enable,
-                        "workspace": default_workspace,
+                        "workspace": ws,
                         "storage_workspaces": _get_storage_workspaces(rag),
                         "max_graph_nodes": args.max_graph_nodes,
                         # Rerank configuration
@@ -2415,6 +2390,8 @@ def create_app(args):
                 }
             )
             return status_data
+        except HTTPException:
+            raise
         except Exception as e:
             logger.error(f"Error getting health status: {str(e)}")
             raise HTTPException(status_code=500, detail=str(e))

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -11,7 +11,6 @@ from lightrag.utils import (
     logger,
     get_pinyin_sort_key,
     performance_timing_log,
-    validate_workspace,
 )
 import aiofiles
 import traceback
@@ -54,6 +53,7 @@ from lightrag.utils import (
     generate_track_id,
     move_file_to_parsed_dir,
 )
+from lightrag.api.document_manager import DocumentManager
 from lightrag.api.utils_api import get_combined_auth_dependency
 from ..config import global_args
 
@@ -972,112 +972,6 @@ class PipelineStatusResponse(BaseModel):
         return format_datetime(value)
 
     model_config = ConfigDict(extra="allow")
-
-
-class DocumentManager:
-    def __init__(
-        self,
-        input_dir: str,
-        workspace: str = "",  # New parameter for workspace isolation
-    ):
-        # Reject path traversal before using workspace in the upload path
-        validate_workspace(workspace)
-        # Store the base input directory and workspace
-        self.base_input_dir = Path(input_dir)
-        self.workspace = workspace
-        self.indexed_files = set()
-
-        # Create workspace-specific input directory
-        # If workspace is provided, create a subdirectory for data isolation
-        if workspace:
-            self.input_dir = self.base_input_dir / workspace
-        else:
-            self.input_dir = self.base_input_dir
-
-        # Create input directory if it doesn't exist
-        self.input_dir.mkdir(parents=True, exist_ok=True)
-
-    @property
-    def supported_extensions(self) -> tuple:
-        """Suffixes accepted for an unhinted filename, derived live.
-
-        A suffix is advertised only when it is *routable without extra
-        directives*: the engine that ``resolve_file_parser_engine`` picks for
-        a bare ``x.<suffix>`` (filename hint absent; ``LIGHTRAG_PARSER``
-        rules + default apply) must itself support the suffix. This keeps
-        "uploadable" aligned with "will actually parse": e.g. mineru's
-        ``png`` joins only when its endpoint is configured AND a routing
-        rule (or per-file hint, see ``is_supported_file``) sends pngs to it
-        — otherwise the default ``legacy`` engine would fail the suffix gate
-        at the parse stage. A default deployment equals the local engines'
-        (legacy ∪ native) types; no hardcoded list to keep in sync.
-        """
-        from lightrag.parser.registry import available_engine_suffixes
-        from lightrag.parser.routing import (
-            parser_engine_supports_suffix,
-            resolve_file_parser_engine,
-        )
-
-        out = []
-        for s in sorted(available_engine_suffixes()):
-            engine = resolve_file_parser_engine(f"x.{s}")
-            if parser_engine_supports_suffix(engine, s):
-                out.append(f".{s}")
-        return tuple(out)
-
-    def scan_directory_for_new_files(self) -> List[Path]:
-        """Scan input directory for new, routable files.
-
-        Globs over every *available* engine suffix (capability surface, so a
-        hint-carrying file like ``img.[mineru].png`` is discoverable even
-        when bare ``.png`` is not advertised), then keeps only files whose
-        resolved engine actually supports them (``is_supported_file``).
-        """
-        from lightrag.parser.registry import available_engine_suffixes
-        from lightrag.parser.routing import FilenameParserHintError
-
-        new_files = []
-        for s in sorted(available_engine_suffixes()):
-            ext = f".{s}"
-            logger.debug(f"Scanning for {ext} files in {self.input_dir}")
-            for file_path in self.input_dir.glob(f"*{ext}"):
-                if file_path in self.indexed_files:
-                    continue
-                try:
-                    if not self.is_supported_file(file_path.name):
-                        continue
-                except FilenameParserHintError:
-                    # Malformed hint: pass the file through — the enqueue
-                    # path reports a detailed error document, instead of the
-                    # scan silently ignoring the user's file.
-                    pass
-                new_files.append(file_path)
-        return new_files
-
-    def mark_as_indexed(self, file_path: Path):
-        self.indexed_files.add(file_path)
-
-    def is_supported_file(self, filename: str) -> bool:
-        """True when THIS filename routes to an engine that can parse it.
-
-        Resolves the engine for the concrete name — so a per-file hint
-        (``img.[mineru].png``) is honoured — and checks the resolved engine
-        supports the suffix. A bare suffix that would fall through to the
-        default ``legacy`` engine is rejected here instead of failing later
-        at the parse worker's suffix gate.
-
-        Raises :class:`FilenameParserHintError` for a malformed hint —
-        callers surface it (upload → HTTP 400 with the detailed message;
-        scan passes the file through so enqueue emits an error document).
-        """
-        from lightrag.parser.routing import (
-            parser_engine_supports_suffix,
-            parser_suffix,
-            resolve_file_parser_engine,
-        )
-
-        engine = resolve_file_parser_engine(filename)
-        return parser_engine_supports_suffix(engine, parser_suffix(filename))
 
 
 def validate_file_path_security(file_path_str: str, base_dir: Path) -> Optional[Path]:
@@ -2426,7 +2320,10 @@ async def background_delete_documents(
 
 
 def create_document_routes(
-    rag: LightRAG, doc_manager: DocumentManager, api_key: Optional[str] = None
+    rag_pool,
+    doc_mgr_pool,
+    api_key: Optional[str] = None,
+    default_workspace: str | None = None,
 ):
     # Fresh router per call — see the note above the temp_prefix constant.
     router = APIRouter(
@@ -2435,12 +2332,25 @@ def create_document_routes(
     )
 
     # Create combined auth dependency for document routes
+    from lightrag.api.utils_api import get_workspace_from_request
+    from fastapi import Request as _FR
+
+    async def _resolve_rag(request: _FR):
+        """Resolve LightRAG instance for the workspace in *request*."""
+        ws = get_workspace_from_request(request, default_workspace=default_workspace)
+        return await rag_pool.get(ws)
+
+    async def _resolve_doc_manager(request: _FR):
+        """Resolve DocumentManager instance for the workspace in *request*."""
+        ws = get_workspace_from_request(request, default_workspace=default_workspace)
+        return await doc_mgr_pool.get(ws)
+
     combined_auth = get_combined_auth_dependency(api_key)
 
     @router.post(
         "/scan", response_model=ScanResponse, dependencies=[Depends(combined_auth)]
     )
-    async def scan_for_new_documents(background_tasks: BackgroundTasks):
+    async def scan_for_new_documents(_req: _FR, background_tasks: BackgroundTasks):
         """
         Trigger the scanning process for new documents.
 
@@ -2467,6 +2377,8 @@ def create_document_routes(
         Returns:
             ScanResponse: A response object containing the scanning status and track_id
         """
+        rag = await _resolve_rag(_req)
+        doc_manager = await _resolve_doc_manager(_req)
         from lightrag.exceptions import PipelineNotInitializedError
         from lightrag.kg.shared_storage import get_namespace_data, get_namespace_lock
 
@@ -2564,7 +2476,7 @@ def create_document_routes(
         "/upload", response_model=InsertResponse, dependencies=[Depends(combined_auth)]
     )
     async def upload_to_input_dir(
-        background_tasks: BackgroundTasks, file: UploadFile = File(...)
+        _req: _FR, background_tasks: BackgroundTasks, file: UploadFile = File(...)
     ):
         """
         Upload a file to the input directory and index it.
@@ -2638,6 +2550,8 @@ def create_document_routes(
                 conflict or scan-classifying / destructive job in
                 flight, 413 file too large, 500 other errors.
         """
+        rag = await _resolve_rag(_req)
+        doc_manager = await _resolve_doc_manager(_req)
         slot_reserved = False
         try:
             # Reject upload while a scan is in its CLASSIFICATION
@@ -2813,7 +2727,7 @@ def create_document_routes(
         "/text", response_model=InsertResponse, dependencies=[Depends(combined_auth)]
     )
     async def insert_text(
-        request: InsertTextRequest, background_tasks: BackgroundTasks
+        _req: _FR, request: InsertTextRequest, background_tasks: BackgroundTasks
     ):
         """
         Insert text into the RAG system.
@@ -2841,6 +2755,7 @@ def create_document_routes(
             HTTPException: 400 invalid file_source, 409 same-name conflict
                 or scan/destructive job in flight, 500 other errors.
         """
+        rag = await _resolve_rag(_req)
         slot_reserved = False
         try:
             # Reject text insertion while a scan is in progress AND reserve
@@ -2917,7 +2832,7 @@ def create_document_routes(
         dependencies=[Depends(combined_auth)],
     )
     async def insert_texts(
-        request: InsertTextsRequest, background_tasks: BackgroundTasks
+        _req: _FR, request: InsertTextsRequest, background_tasks: BackgroundTasks
     ):
         """
         Insert multiple texts into the RAG system.
@@ -2946,6 +2861,7 @@ def create_document_routes(
                 conflict or scan/destructive job in flight, 500 other
                 errors.
         """
+        rag = await _resolve_rag(_req)
         slot_reserved = False
         try:
             # Reject batch text insertion while a scan is in progress AND
@@ -3038,7 +2954,7 @@ def create_document_routes(
     @router.delete(
         "", response_model=ClearDocumentsResponse, dependencies=[Depends(combined_auth)]
     )
-    async def clear_documents():
+    async def clear_documents(_req: _FR):
         """
         Clear all documents from the RAG system.
 
@@ -3071,6 +2987,8 @@ def create_document_routes(
             HTTPException: Raised when a serious error occurs during the clearing process,
                           with status code 500 and error details in the detail field.
         """
+        rag = await _resolve_rag(_req)
+        doc_manager = await _resolve_doc_manager(_req)
         from lightrag.kg.shared_storage import (
             get_namespace_data,
             get_namespace_lock,
@@ -3263,7 +3181,9 @@ def create_document_routes(
         dependencies=[Depends(combined_auth)],
         response_model=PipelineStatusResponse,
     )
-    async def get_pipeline_status() -> PipelineStatusResponse:
+    async def get_pipeline_status(
+        _req: _FR,
+    ) -> PipelineStatusResponse:
         """
         Get the current status of the document indexing pipeline.
 
@@ -3288,6 +3208,7 @@ def create_document_routes(
             HTTPException: If an error occurs while retrieving pipeline status (500)
         """
         try:
+            rag = await _resolve_rag(_req)
             from lightrag.kg.shared_storage import (
                 get_namespace_data,
                 get_namespace_lock,
@@ -3362,7 +3283,9 @@ def create_document_routes(
     @router.get(
         "", response_model=DocsStatusesResponse, dependencies=[Depends(combined_auth)]
     )
-    async def documents() -> DocsStatusesResponse:
+    async def documents(
+        _req: _FR,
+    ) -> DocsStatusesResponse:
         """
         Get the status of all documents in the system. This endpoint is deprecated; use /documents/paginated instead.
         To prevent excessive resource consumption, a maximum of 1,000 records is returned.
@@ -3381,6 +3304,7 @@ def create_document_routes(
             HTTPException: If an error occurs while retrieving document statuses (500).
         """
         try:
+            rag = await _resolve_rag(_req)
             statuses = (
                 DocStatus.PENDING,
                 DocStatus.PARSING,
@@ -3478,6 +3402,7 @@ def create_document_routes(
         summary="Delete a document and all its associated data by its ID.",
     )
     async def delete_document(
+        _req: _FR,
         delete_request: DeleteDocRequest,
         background_tasks: BackgroundTasks,
     ) -> DeleteDocByIdResponse:
@@ -3514,6 +3439,8 @@ def create_document_routes(
             HTTPException:
               - 500: If an unexpected internal error occurs during initialization.
         """
+        rag = await _resolve_rag(_req)
+        doc_manager = await _resolve_doc_manager(_req)
         doc_ids = delete_request.doc_ids
 
         slot_acquired = False
@@ -3570,7 +3497,7 @@ def create_document_routes(
         response_model=ClearCacheResponse,
         dependencies=[Depends(combined_auth)],
     )
-    async def clear_cache(request: ClearCacheRequest):
+    async def clear_cache(_req: _FR, request: ClearCacheRequest):
         """
         Clear all cache data from the LLM response cache storage.
 
@@ -3586,6 +3513,7 @@ def create_document_routes(
         Raises:
             HTTPException: If an error occurs during cache clearing (500).
         """
+        rag = await _resolve_rag(_req)
         try:
             # Call the aclear_cache method (no modes parameter)
             await rag.aclear_cache()
@@ -3604,7 +3532,7 @@ def create_document_routes(
         response_model=TrackStatusResponse,
         dependencies=[Depends(combined_auth)],
     )
-    async def get_track_status(track_id: str) -> TrackStatusResponse:
+    async def get_track_status(_req: _FR, track_id: str) -> TrackStatusResponse:
         """
         Get the processing status of documents by tracking ID.
 
@@ -3613,17 +3541,9 @@ def create_document_routes(
 
         Args:
             track_id (str): The tracking ID returned from upload, text, or texts endpoints
-
-        Returns:
-            TrackStatusResponse: A response object containing:
-                - track_id: The tracking ID
-                - documents: List of documents associated with this track_id
-                - total_count: Total number of documents for this track_id
-
-        Raises:
-            HTTPException: If track_id is invalid (400) or an error occurs (500).
         """
         try:
+            rag = await _resolve_rag(_req)
             # Validate track_id
             if not track_id or not track_id.strip():
                 raise HTTPException(status_code=400, detail="Track ID cannot be empty")
@@ -3679,6 +3599,7 @@ def create_document_routes(
         dependencies=[Depends(combined_auth)],
     )
     async def get_documents_paginated(
+        _req: _FR,
         request: DocumentsRequest,
     ) -> PaginatedDocsResponse:
         """
@@ -3690,16 +3611,8 @@ def create_document_routes(
 
         Args:
             request (DocumentsRequest): The request body containing pagination parameters
-
-        Returns:
-            PaginatedDocsResponse: A response object containing:
-                - documents: List of documents for the current page
-                - pagination: Pagination information (page, total_count, etc.)
-                - status_counts: Count of documents by status for all documents
-
-        Raises:
-            HTTPException: If an error occurs while retrieving documents (500).
         """
+        rag = await _resolve_rag(_req)
         trace_id = uuid4().hex[:8]
         request_start = time.perf_counter()
         status_filter_value = (
@@ -3859,7 +3772,9 @@ def create_document_routes(
         response_model=StatusCountsResponse,
         dependencies=[Depends(combined_auth)],
     )
-    async def get_document_status_counts() -> StatusCountsResponse:
+    async def get_document_status_counts(
+        _req: _FR,
+    ) -> StatusCountsResponse:
         """
         Get counts of documents by status.
 
@@ -3873,6 +3788,7 @@ def create_document_routes(
             HTTPException: If an error occurs while retrieving status counts (500).
         """
         try:
+            rag = await _resolve_rag(_req)
             status_counts = await rag.doc_status.get_all_status_counts()
             return StatusCountsResponse(status_counts=status_counts)
 
@@ -3886,7 +3802,7 @@ def create_document_routes(
         response_model=ReprocessResponse,
         dependencies=[Depends(combined_auth)],
     )
-    async def reprocess_failed_documents(background_tasks: BackgroundTasks):
+    async def reprocess_failed_documents(_req: _FR, background_tasks: BackgroundTasks):
         """
         Reprocess failed and pending documents.
 
@@ -3911,6 +3827,7 @@ def create_document_routes(
         Raises:
             HTTPException: If an error occurs while initiating reprocessing (500).
         """
+        rag = await _resolve_rag(_req)
         try:
             # Start the reprocessing in the background
             # Note: Reprocessed documents retain their original track_id from initial upload
@@ -3932,7 +3849,7 @@ def create_document_routes(
         response_model=CancelPipelineResponse,
         dependencies=[Depends(combined_auth)],
     )
-    async def cancel_pipeline():
+    async def cancel_pipeline(_req: _FR):
         """
         Request cancellation of the currently running pipeline.
 
@@ -3953,6 +3870,7 @@ def create_document_routes(
         Raises:
             HTTPException: If an error occurs while setting cancellation flag (500).
         """
+        rag = await _resolve_rag(_req)
         try:
             from lightrag.kg.shared_storage import (
                 get_namespace_data,

--- a/lightrag/api/routers/graph_routes.py
+++ b/lightrag/api/routers/graph_routes.py
@@ -109,7 +109,23 @@ class RelationCreateRequest(BaseModel):
     )
 
 
-def create_graph_routes(rag, api_key: Optional[str] = None):
+def create_graph_routes(
+    rag_pool, api_key: Optional[str] = None, default_workspace: str | None = None
+):
+    # Fresh router per call. A module-level instance would accumulate
+    # duplicate routes when the factory is invoked more than once in the
+    # same process (e.g. across tests), which triggers FastAPI's
+    # "Duplicate Operation ID" warnings.
+    from lightrag.api.utils_api import get_workspace_from_request
+    from fastapi import Request as _FR
+
+    router = APIRouter(tags=["graph"])
+
+    async def _resolve_rag(request: _FR):
+        """Resolve LightRAG instance for the workspace in *request*."""
+        ws = get_workspace_from_request(request, default_workspace=default_workspace)
+        return await rag_pool.get(ws)
+
     # Fresh router per call. A module-level instance would accumulate
     # duplicate routes when the factory is invoked more than once in the
     # same process (e.g. across tests), which triggers FastAPI's
@@ -119,13 +135,14 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
     combined_auth = get_combined_auth_dependency(api_key)
 
     @router.get("/graph/label/list", dependencies=[Depends(combined_auth)])
-    async def get_graph_labels():
+    async def get_graph_labels(_req: _FR):
         """
         Get all graph labels
 
         Returns:
             List[str]: List of graph labels
         """
+        rag = await _resolve_rag(_req)
         try:
             return await rag.get_graph_labels()
         except Exception as e:
@@ -137,6 +154,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
 
     @router.get("/graph/label/popular", dependencies=[Depends(combined_auth)])
     async def get_popular_labels(
+        _req: _FR,
         limit: int = Query(
             300, description="Maximum number of popular labels to return", ge=1, le=1000
         ),
@@ -151,6 +169,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             List[str]: List of popular labels sorted by degree (highest first)
         """
         try:
+            rag = await _resolve_rag(_req)
             return await rag.chunk_entity_relation_graph.get_popular_labels(limit)
         except Exception as e:
             logger.error(f"Error getting popular labels: {str(e)}")
@@ -161,6 +180,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
 
     @router.get("/graph/label/search", dependencies=[Depends(combined_auth)])
     async def search_labels(
+        _req: _FR,
         q: str = Query(..., description="Search query string"),
         limit: int = Query(
             50, description="Maximum number of search results to return", ge=1, le=100
@@ -177,6 +197,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             List[str]: List of matching labels sorted by relevance
         """
         try:
+            rag = await _resolve_rag(_req)
             return await rag.chunk_entity_relation_graph.search_labels(q, limit)
         except Exception as e:
             logger.error(f"Error searching labels with query '{q}': {str(e)}")
@@ -187,6 +208,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
 
     @router.get("/graphs", dependencies=[Depends(combined_auth)])
     async def get_knowledge_graph(
+        _req: _FR,
         label: str = Query(..., description="Label to get knowledge graph for"),
         max_depth: int = Query(3, description="Maximum depth of graph", ge=1),
         max_nodes: int = Query(1000, description="Maximum nodes to return", ge=1),
@@ -206,6 +228,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             Dict[str, List[str]]: Knowledge graph for label
         """
         try:
+            rag = await _resolve_rag(_req)
             # Log the label parameter to check for leading spaces
             logger.debug(
                 f"get_knowledge_graph called with label: '{label}' (length: {len(label)}, repr: {repr(label)})"
@@ -225,6 +248,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
 
     @router.get("/graph/entity/exists", dependencies=[Depends(combined_auth)])
     async def check_entity_exists(
+        _req: _FR,
         name: str = Query(..., description="Entity name to check"),
     ):
         """
@@ -237,6 +261,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             Dict[str, bool]: Dictionary with 'exists' key indicating if entity exists
         """
         try:
+            rag = await _resolve_rag(_req)
             exists = await rag.chunk_entity_relation_graph.has_node(name)
             return {"exists": exists}
         except Exception as e:
@@ -247,7 +272,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             )
 
     @router.post("/graph/entity/edit", dependencies=[Depends(combined_auth)])
-    async def update_entity(request: EntityUpdateRequest):
+    async def update_entity(_req: _FR, request: EntityUpdateRequest):
         """
         Update an entity's properties in the knowledge graph
 
@@ -381,6 +406,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
                 }
             }
         """
+        rag = await _resolve_rag(_req)
         try:
             await check_pipeline_busy_or_raise(rag)
             result = await rag.aedit_entity(
@@ -440,7 +466,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             )
 
     @router.post("/graph/relation/edit", dependencies=[Depends(combined_auth)])
-    async def update_relation(request: RelationUpdateRequest):
+    async def update_relation(_req: _FR, request: RelationUpdateRequest):
         """Update a relation's properties in the knowledge graph
 
         Args:
@@ -449,6 +475,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
         Returns:
             Dict: Updated relation information
         """
+        rag = await _resolve_rag(_req)
         try:
             await check_pipeline_busy_or_raise(rag)
             result = await rag.aedit_relation(
@@ -478,7 +505,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             )
 
     @router.post("/graph/entity/create", dependencies=[Depends(combined_auth)])
-    async def create_entity(request: EntityCreateRequest):
+    async def create_entity(_req: _FR, request: EntityCreateRequest):
         """
         Create a new entity in the knowledge graph
 
@@ -522,6 +549,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
                 }
             }
         """
+        rag = await _resolve_rag(_req)
         try:
             await check_pipeline_busy_or_raise(rag)
             # Use the proper acreate_entity method which handles:
@@ -554,7 +582,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             )
 
     @router.post("/graph/relation/create", dependencies=[Depends(combined_auth)])
-    async def create_relation(request: RelationCreateRequest):
+    async def create_relation(_req: _FR, request: RelationCreateRequest):
         """
         Create a new relationship between two entities in the knowledge graph
 
@@ -610,6 +638,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
                 }
             }
         """
+        rag = await _resolve_rag(_req)
         try:
             await check_pipeline_busy_or_raise(rag)
             # Use the proper acreate_relation method which handles:
@@ -646,7 +675,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             )
 
     @router.post("/graph/entities/merge", dependencies=[Depends(combined_auth)])
-    async def merge_entities(request: EntityMergeRequest):
+    async def merge_entities(_req: _FR, request: EntityMergeRequest):
         """
         Merge multiple entities into a single entity, preserving all relationships
 
@@ -702,6 +731,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             - Source entities will be permanently deleted after the merge
             - This operation cannot be undone, so verify entity names before merging
         """
+        rag = await _resolve_rag(_req)
         try:
             await check_pipeline_busy_or_raise(rag)
             result = await rag.amerge_entities(
@@ -734,7 +764,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
         response_model=DeletionResult,
         dependencies=[Depends(combined_auth)],
     )
-    async def delete_entity(request: DeleteEntityRequest):
+    async def delete_entity(_req: _FR, request: DeleteEntityRequest):
         """
         Delete an entity and all its relationships from the knowledge graph.
 
@@ -747,6 +777,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
         Raises:
             HTTPException: If the entity is not found (404) or an error occurs (500).
         """
+        rag = await _resolve_rag(_req)
         try:
             await check_pipeline_busy_or_raise(rag)
             result = await rag.adelete_by_entity(entity_name=request.entity_name)
@@ -770,7 +801,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
         response_model=DeletionResult,
         dependencies=[Depends(combined_auth)],
     )
-    async def delete_relation(request: DeleteRelationRequest):
+    async def delete_relation(_req: _FR, request: DeleteRelationRequest):
         """
         Delete a relationship between two entities from the knowledge graph.
 
@@ -783,6 +814,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
         Raises:
             HTTPException: If the relation is not found (404) or an error occurs (500).
         """
+        rag = await _resolve_rag(_req)
         try:
             await check_pipeline_busy_or_raise(rag)
             result = await rag.adelete_by_relation(

--- a/lightrag/api/routers/ollama_api.py
+++ b/lightrag/api/routers/ollama_api.py
@@ -8,7 +8,7 @@ import re
 from enum import Enum
 from fastapi.responses import StreamingResponse
 import asyncio
-from lightrag import LightRAG, QueryParam
+from lightrag import QueryParam
 from lightrag.constants import DEFAULT_QUERY_PRIORITY
 from lightrag.utils import TiktokenTokenizer
 from lightrag.api.utils_api import get_combined_auth_dependency
@@ -219,17 +219,37 @@ def parse_query_mode(query: str) -> tuple[str, SearchMode, bool, Optional[str]]:
 
 
 class OllamaAPI:
-    def __init__(self, rag: LightRAG, top_k: int = 60, api_key: Optional[str] = None):
-        self.rag = rag
-        self.ollama_server_infos = rag.ollama_server_infos
+    def __init__(
+        self,
+        *,
+        rag_pool=None,
+        ollama_server_infos=None,
+        top_k: int = 60,
+        api_key: Optional[str] = None,
+        default_workspace: str | None = None,
+    ):
+        self.rag_pool = rag_pool
+        self.ollama_server_infos = ollama_server_infos
         self.top_k = top_k
         self.api_key = api_key
+        self.default_workspace = default_workspace
         self.router = APIRouter(tags=["ollama"])
         self.setup_routes()
 
     def setup_routes(self):
         # Create combined auth dependency for Ollama API routes
         combined_auth = get_combined_auth_dependency(self.api_key)
+
+        from lightrag.api.utils_api import get_workspace_from_request
+
+        default_workspace = self.default_workspace
+
+        async def _resolve_rag(request: Request):
+            """Resolve LightRAG instance for the workspace in *request*."""
+            ws = get_workspace_from_request(
+                request, default_workspace=default_workspace
+            )
+            return await self.rag_pool.get(ws)
 
         @self.router.get("/version", dependencies=[Depends(combined_auth)])
         async def get_version():
@@ -292,6 +312,7 @@ class OllamaAPI:
             and will be handled by underlying LLM model.
             Supports both application/json and application/octet-stream Content-Types.
             """
+            rag = await _resolve_rag(raw_request)
             try:
                 # Parse the request body manually
                 request = await parse_request_body(raw_request, OllamaGenerateRequest)
@@ -301,15 +322,15 @@ class OllamaAPI:
                 prompt_tokens = estimate_tokens(query)
 
                 role_kwargs = (
-                    dict(self.rag.role_llm_kwargs["query"])
-                    if self.rag.role_llm_kwargs["query"] is not None
-                    else dict(self.rag.llm_model_kwargs)
+                    dict(rag.role_llm_kwargs["query"])
+                    if rag.role_llm_kwargs["query"] is not None
+                    else dict(rag.llm_model_kwargs)
                 )
                 if request.system:
                     role_kwargs["system_prompt"] = request.system
 
                 if request.stream:
-                    response = await (self.rag.role_llm_funcs["query"])(
+                    response = await (rag.role_llm_funcs["query"])(
                         query,
                         stream=True,
                         _priority=DEFAULT_QUERY_PRIORITY,
@@ -437,7 +458,7 @@ class OllamaAPI:
                     )
                 else:
                     first_chunk_time = time.time_ns()
-                    response_text = await (self.rag.role_llm_funcs["query"])(
+                    response_text = await (rag.role_llm_funcs["query"])(
                         query,
                         stream=False,
                         _priority=DEFAULT_QUERY_PRIORITY,
@@ -480,6 +501,7 @@ class OllamaAPI:
             Detects and forwards OpenWebUI session-related requests (for meta data generation task) directly to LLM.
             Supports both application/json and application/octet-stream Content-Types.
             """
+            rag = await _resolve_rag(raw_request)
             try:
                 # Parse the request body manually
                 request = await parse_request_body(raw_request, OllamaChatRequest)
@@ -528,13 +550,13 @@ class OllamaAPI:
                     # Determine if the request is prefix with "/bypass"
                     if mode == SearchMode.bypass:
                         role_kwargs = (
-                            dict(self.rag.role_llm_kwargs["query"])
-                            if self.rag.role_llm_kwargs["query"] is not None
-                            else dict(self.rag.llm_model_kwargs)
+                            dict(rag.role_llm_kwargs["query"])
+                            if rag.role_llm_kwargs["query"] is not None
+                            else dict(rag.llm_model_kwargs)
                         )
                         if request.system:
                             role_kwargs["system_prompt"] = request.system
-                        response = await (self.rag.role_llm_funcs["query"])(
+                        response = await (rag.role_llm_funcs["query"])(
                             cleaned_query,
                             stream=True,
                             history_messages=conversation_history,
@@ -542,9 +564,7 @@ class OllamaAPI:
                             **role_kwargs,
                         )
                     else:
-                        response = await self.rag.aquery(
-                            cleaned_query, param=query_param
-                        )
+                        response = await rag.aquery(cleaned_query, param=query_param)
 
                     async def stream_generator():
                         first_chunk_time = None
@@ -696,14 +716,14 @@ class OllamaAPI:
                     )
                     if match_result or mode == SearchMode.bypass:
                         role_kwargs = (
-                            dict(self.rag.role_llm_kwargs["query"])
-                            if self.rag.role_llm_kwargs["query"] is not None
-                            else dict(self.rag.llm_model_kwargs)
+                            dict(rag.role_llm_kwargs["query"])
+                            if rag.role_llm_kwargs["query"] is not None
+                            else dict(rag.llm_model_kwargs)
                         )
                         if request.system:
                             role_kwargs["system_prompt"] = request.system
 
-                        response_text = await (self.rag.role_llm_funcs["query"])(
+                        response_text = await (rag.role_llm_funcs["query"])(
                             cleaned_query,
                             stream=False,
                             history_messages=conversation_history,
@@ -711,7 +731,7 @@ class OllamaAPI:
                             **role_kwargs,
                         )
                     else:
-                        response_text = await self.rag.aquery(
+                        response_text = await rag.aquery(
                             cleaned_query, param=query_param
                         )
 

--- a/lightrag/api/routers/query_routes.py
+++ b/lightrag/api/routers/query_routes.py
@@ -4,7 +4,7 @@ This module contains all query-related routes for the LightRAG API.
 
 import json
 from typing import Any, Dict, List, Literal, Optional
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from lightrag.base import QueryParam
 from lightrag.api.utils_api import get_combined_auth_dependency
 from lightrag.utils import logger
@@ -188,12 +188,24 @@ class StreamChunkResponse(BaseModel):
     )
 
 
-def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
+def create_query_routes(
+    rag_pool,
+    api_key: Optional[str] = None,
+    top_k: int = 60,
+    default_workspace: str | None = None,
+):
     # Fresh router per call. A module-level instance would accumulate
     # duplicate routes when the factory is invoked more than once in the
     # same process (e.g. across tests), which triggers FastAPI's
     # "Duplicate Operation ID" warnings.
+    from lightrag.api.utils_api import get_workspace_from_request
+
     router = APIRouter(tags=["query"])
+
+    async def _resolve_rag(request: Request):
+        """Resolve the LightRAG instance for the workspace in *request*."""
+        ws = get_workspace_from_request(request, default_workspace=default_workspace)
+        return await rag_pool.get(ws)
 
     combined_auth = get_combined_auth_dependency(api_key)
 
@@ -326,7 +338,7 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
             },
         },
     )
-    async def query_text(request: QueryRequest):
+    async def query_text(_req: Request, request: QueryRequest):
         """
         Comprehensive RAG query endpoint with non-streaming response. Parameter "stream" is ignored.
 
@@ -402,6 +414,7 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
                 - 400: Invalid input parameters (e.g., query too short)
                 - 500: Internal processing error (e.g., LLM service unavailable)
         """
+        rag = await _resolve_rag(_req)
         try:
             param = request.to_query_params(
                 False
@@ -596,7 +609,7 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
             },
         },
     )
-    async def query_text_stream(request: QueryRequest):
+    async def query_text_stream(_req: Request, request: QueryRequest):
         """
         Advanced RAG query endpoint with flexible streaming response.
 
@@ -723,6 +736,7 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
             This endpoint is ideal for applications requiring flexible response delivery.
             Use streaming mode for real-time interfaces and non-streaming for batch processing.
         """
+        rag = await _resolve_rag(_req)
         try:
             # Use the stream parameter from the request, defaulting to True if not specified
             stream_mode = request.stream if request.stream is not None else True
@@ -1048,7 +1062,7 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
             },
         },
     )
-    async def query_data(request: QueryRequest):
+    async def query_data(_req: Request, request: QueryRequest):
         """
         Advanced data retrieval endpoint for structured RAG analysis.
 
@@ -1151,6 +1165,7 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
             This endpoint always includes references regardless of the include_references parameter,
             as structured data analysis typically requires source attribution.
         """
+        rag = await _resolve_rag(_req)
         try:
             param = request.to_query_params(False)  # No streaming for data endpoint
             response = await rag.aquery_data(request.query, param=param)

--- a/lightrag/api/utils_api.py
+++ b/lightrag/api/utils_api.py
@@ -19,7 +19,12 @@ from fastapi import HTTPException, Security, Request, Response, status
 from fastapi.security import APIKeyHeader, OAuth2PasswordBearer
 from starlette.status import HTTP_403_FORBIDDEN
 from .auth import auth_handler
-from .config import ollama_server_infos, global_args, get_env_value
+from .config import (
+    ollama_server_infos,
+    global_args,
+    get_env_value,
+    validate_workspace_name,
+)
 
 logger = logging.getLogger("lightrag")
 
@@ -39,6 +44,49 @@ _TOKEN_RENEWAL_SKIP_PATHS = [
     "/documents/paginated",
     "/documents/pipeline_status",
 ]
+
+
+def get_workspace_from_request(
+    request: Request,
+    default_workspace: str | None = None,
+) -> str:
+    """Extract and validate workspace from HTTP request.
+
+    Priority:
+    1. ``LIGHTRAG-WORKSPACE`` header present → validate → use it.
+    2. No header + ``default_workspace`` provided → use ``default_workspace``.
+    3. Neither → HTTP 400.
+
+    Args:
+        request: FastAPI Request object.
+        default_workspace: Fallback workspace when the header is absent.
+            Typically ``args.workspace`` from server startup.
+
+    Returns:
+        A validated workspace name (always non-empty).
+
+    Raises:
+        HTTPException(400): Invalid or missing workspace.
+    """
+    raw = request.headers.get("LIGHTRAG-WORKSPACE")
+
+    if raw is not None:
+        # Header is present — even if empty or blank, the client
+        # explicitly sent it.  Do NOT silently fall back to the
+        # default workspace; a malformed multi-workspace request
+        # should not accidentally route to the wrong data.
+        workspace = raw.strip()
+        if not workspace:
+            raise HTTPException(400, "LIGHTRAG-WORKSPACE header must not be empty")
+        return validate_workspace_name(workspace)
+
+    if default_workspace:
+        return validate_workspace_name(default_workspace)
+
+    raise HTTPException(
+        400,
+        "LIGHTRAG-WORKSPACE header required (no default workspace configured)",
+    )
 
 
 def check_env_file():

--- a/lightrag/api/workspace_pool.py
+++ b/lightrag/api/workspace_pool.py
@@ -1,0 +1,229 @@
+"""Per-workspace pools for LightRAG and DocumentManager instances.
+
+Enables a single server process to serve multiple workspaces, selected
+per-request via the ``LIGHTRAG-WORKSPACE`` HTTP header.
+
+Module placement: ``lightrag/api/workspace_pool.py`` — a dedicated module
+so the pool classes can be unit-tested independently and imported without
+pulling in the ~2700-line ``lightrag_server.py``.
+"""
+
+import asyncio
+from collections.abc import Callable
+
+from lightrag import LightRAG
+from lightrag.api.document_manager import DocumentManager
+
+
+class RagPool:
+    """Lazily-initialized pool of LightRAG instances keyed by workspace.
+
+    Concurrency model (two-layer lock):
+
+    - Fast path: instance already cached → O(1) dict lookup, no lock.
+    - ``_lock_factory``: lightweight lock guarding ``_locks.setdefault()`` (µs).
+    - ``_locks[ws]``: per-workspace lock covering the full creation (including
+      ``initialize_storages()``, which may take seconds).  Only requests for
+      the *same* workspace queue here — which is correct, because they
+      depend on this initialization completing.
+
+    Configuration model (config_factory):
+
+    Instead of storing a shared ``base_config`` dict and trying to copy it
+    per workspace, the pool accepts a ``config_factory(workspace) -> dict``
+    callable.  Each call builds a fresh configuration from scratch:
+
+    - Singletons (LLM functions, clients, server-infos) are captured by the
+      factory's closure and shared by reference.
+    - Per-workspace values (kwargs dicts, addon_params, role_llm_configs)
+      are re-constructed on every call — no deepcopy needed, no risk of
+      accidentally sharing mutable state between workspaces.
+
+    Callbacks:
+
+    - *role_llm_builder*: registered on every new instance so that runtime
+      ``update_llm_role_config()`` calls work on pooled instances.
+    - *on_create*: optional hook invoked immediately after construction and
+      builder registration, but before ``initialize_storages()``.  Useful
+      for logging (e.g. ``_log_role_provider_options``) or additional setup.
+
+    Lifecycle:
+
+    ``get()`` is valid during normal request and background-task execution.
+    ``shutdown_all()`` is called only during server lifespan cleanup, after
+    the ASGI server has stopped accepting new requests and in-flight work
+    has drained.  There is no public ``evict()``, no ``_closed`` flag, and
+    no runtime draining — simplicity over premature sophistication.
+    """
+
+    def __init__(
+        self,
+        config_factory: Callable[[str], dict],
+        *,
+        role_llm_builder: Callable | None = None,
+        on_create: Callable[[LightRAG], None] | None = None,
+    ):
+        """
+        Args:
+            config_factory: Called with the workspace name to produce a
+                fresh kwargs dict for ``LightRAG(**kwargs)``.  The returned
+                dict is NOT retained or mutated by the pool.
+            role_llm_builder: Optional callback registered on every new
+                ``LightRAG`` instance via ``register_role_llm_builder()``
+                so that runtime role-LLM updates work correctly.
+            on_create: Optional callback invoked with the new ``LightRAG``
+                instance after construction and builder registration, but
+                before ``initialize_storages()``.
+        """
+        self._config_factory = config_factory
+        self._role_llm_builder = role_llm_builder
+        self._on_create = on_create
+        self._rags: dict[str, LightRAG] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
+        self._lock_factory = asyncio.Lock()
+
+    async def get(self, workspace: str) -> LightRAG:
+        """Return the LightRAG instance for *workspace*, creating it if needed."""
+        # ── Fast path: already cached, no lock ──
+        rag = self._rags.get(workspace)
+        if rag is not None:
+            return rag
+
+        # ── Layer 1: safely obtain the per-workspace lock ──
+        async with self._lock_factory:
+            ws_lock = self._locks.setdefault(workspace, asyncio.Lock())
+
+        # ── Layer 2: create under per-workspace lock ──
+        async with ws_lock:
+            # Double-check: another request may have created it while we
+            # queued for ws_lock.
+            rag = self._rags.get(workspace)
+            if rag is not None:
+                return rag
+
+            # Build fresh config — no shared mutable state between workspaces.
+            config = self._config_factory(workspace)
+            rag = LightRAG(**config)
+
+            # Register runtime LLM builder (needed for update_llm_role_config).
+            if self._role_llm_builder is not None:
+                rag.register_role_llm_builder(self._role_llm_builder)
+
+            # Pre-init hook (e.g. logging).
+            if self._on_create is not None:
+                self._on_create(rag)
+
+            try:
+                await rag.initialize_storages()
+                # Run data migration on first creation (lazy strategy).
+                await rag.check_and_migrate_data()
+            except Exception:
+                # If storages were partially opened, finalize them to
+                # avoid leaking connections (PostgreSQL pools, Neo4j
+                # sessions, Redis connections, etc.).  finalize_storages()
+                # is idempotent — safe to call even if initialization
+                # didn't complete.
+                await rag.finalize_storages()
+                raise
+            self._rags[workspace] = rag
+            return rag
+
+    async def _evict(self, workspace: str) -> None:
+        """Internal: release resources for *workspace*.  Not exposed publicly
+        in the first PR because eviction during active traffic can race with
+        in-flight requests (see §14).  Call only from ``shutdown_all()``,
+        which runs during server shutdown.
+        """
+        async with self._lock_factory:
+            lock = self._locks.pop(workspace, None)
+        if lock is not None:
+            async with lock:
+                rag = self._rags.pop(workspace, None)
+                if rag is not None:
+                    await rag.finalize_storages()
+
+    async def shutdown_all(self) -> None:
+        """Finalize all cached instances.
+
+        Called during server lifespan cleanup.  Individual finalization
+        errors are collected; a single ``RuntimeError`` is raised after
+        all workspaces have been attempted so that one failure does not
+        skip the rest.
+        """
+        async with self._lock_factory:
+            workspaces = list(self._locks.keys())
+
+        errors: list[tuple[str, Exception]] = []
+        for ws in workspaces:
+            try:
+                await self._evict(ws)
+            except Exception as exc:
+                errors.append((ws, exc))
+
+        if errors:
+            msg = "; ".join(f"{ws}: {exc}" for ws, exc in errors)
+            raise RuntimeError(
+                f"RagPool.shutdown_all: {len(errors)} workspace(s) failed "
+                f"finalization: {msg}"
+            ) from errors[0][1]
+
+
+class DocManagerPool:
+    """Per-workspace pool of DocumentManager instances.
+
+    Uses the same two-layer lock structure as RagPool for interface
+    consistency.  While ``DocumentManager.__init__`` is currently
+    near-instantaneous (path join + mkdir), the two-layer design
+    future-proofs against a heavier init and reduces cognitive overhead
+    by using one pattern everywhere.
+    """
+
+    def __init__(self, base_input_dir: str):
+        self._base_input_dir = base_input_dir
+        self._managers: dict[str, DocumentManager] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
+        self._lock_factory = asyncio.Lock()
+
+    async def get(self, workspace: str) -> DocumentManager:
+        """Return the DocumentManager for *workspace*, creating it if needed."""
+        mgr = self._managers.get(workspace)
+        if mgr is not None:
+            return mgr
+
+        async with self._lock_factory:
+            ws_lock = self._locks.setdefault(workspace, asyncio.Lock())
+
+        async with ws_lock:
+            mgr = self._managers.get(workspace)
+            if mgr is not None:
+                return mgr
+            mgr = DocumentManager(self._base_input_dir, workspace=workspace)
+            self._managers[workspace] = mgr
+            return mgr
+
+    async def _evict(self, workspace: str) -> None:
+        """Internal: see RagPool._evict docstring."""
+        async with self._lock_factory:
+            lock = self._locks.pop(workspace, None)
+        if lock is not None:
+            async with lock:
+                self._managers.pop(workspace, None)
+
+    async def shutdown_all(self) -> None:
+        """Finalize all cached managers.  Mirrors RagPool.shutdown_all()."""
+        async with self._lock_factory:
+            workspaces = list(self._locks.keys())
+
+        errors: list[tuple[str, Exception]] = []
+        for ws in workspaces:
+            try:
+                await self._evict(ws)
+            except Exception as exc:
+                errors.append((ws, exc))
+
+        if errors:
+            msg = "; ".join(f"{ws}: {exc}" for ws, exc in errors)
+            raise RuntimeError(
+                f"DocManagerPool.shutdown_all: {len(errors)} workspace(s) "
+                f"failed finalization: {msg}"
+            ) from errors[0][1]

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -346,11 +346,17 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 f"(batch_num={self._max_batch_size})"
             )
             try:
+                # Throttle concurrent embedding calls — asyncio.gather on
+                # hundreds of batches can overwhelm the embedding backend
+                # (e.g. Ollama returning 502).  Cap at 4 concurrent calls.
+                _sem = asyncio.Semaphore(4)
+
+                async def _embed_one(batch):
+                    async with _sem:
+                        return await self.embedding_func(batch, context="document")
+
                 embeddings_list = await asyncio.gather(
-                    *[
-                        self.embedding_func(batch, context="document")
-                        for batch in batches
-                    ]
+                    *[_embed_one(batch) for batch in batches]
                 )
             except Exception as e:
                 logger.error(
@@ -802,11 +808,15 @@ class NanoVectorDBStorage(BaseVectorStorage):
                     contents[i : i + self._max_batch_size]
                     for i in range(0, len(contents), self._max_batch_size)
                 ]
+                # Throttle concurrent embedding calls (see _flush_pending_locked).
+                _sem = asyncio.Semaphore(4)
+
+                async def _embed_one(batch):
+                    async with _sem:
+                        return await self.embedding_func(batch, context="document")
+
                 embeddings_list = await asyncio.gather(
-                    *[
-                        self.embedding_func(batch, context="document")
-                        for batch in batches
-                    ]
+                    *[_embed_one(batch) for batch in batches]
                 )
                 embeddings = np.concatenate(embeddings_list)
                 if len(embeddings) != len(to_embed):

--- a/lightrag/llm/ollama.py
+++ b/lightrag/llm/ollama.py
@@ -154,7 +154,9 @@ async def _ollama_model_if_cache(
 
     host = _coerce_host_for_cloud_model(host, model)
 
-    ollama_client = ollama.AsyncClient(host=host, timeout=timeout, headers=headers)
+    ollama_client = ollama.AsyncClient(
+        host=host, timeout=timeout, headers=headers, trust_env=False
+    )
 
     try:
         messages = []
@@ -309,7 +311,9 @@ async def ollama_embed(
 
     host = _coerce_host_for_cloud_model(host, embed_model)
 
-    ollama_client = ollama.AsyncClient(host=host, timeout=timeout, headers=headers)
+    ollama_client = ollama.AsyncClient(
+        host=host, timeout=timeout, headers=headers, trust_env=False
+    )
     try:
         options = kwargs.pop("options", {})
         data = await ollama_client.embed(

--- a/tests/api/routes/test_document_routes_docx_archive.py
+++ b/tests/api/routes/test_document_routes_docx_archive.py
@@ -48,7 +48,9 @@ pipeline_index_files = _document_routes.pipeline_index_files
 pipeline_index_texts = _document_routes.pipeline_index_texts
 pipeline_enqueue_file = _document_routes.pipeline_enqueue_file
 run_scanning_process = _document_routes.run_scanning_process
-DocumentManager = _document_routes.DocumentManager
+DocumentManager = importlib.import_module(
+    "lightrag.api.document_manager"
+).DocumentManager
 create_document_routes = _document_routes.create_document_routes
 
 pytestmark = pytest.mark.offline

--- a/tests/api/routes/test_supported_extensions_markdown.py
+++ b/tests/api/routes/test_supported_extensions_markdown.py
@@ -19,7 +19,9 @@ _document_routes = importlib.import_module("lightrag.api.routers.document_routes
 _parser_routing = importlib.import_module("lightrag.parser.routing")
 sys.argv = _original_argv
 
-DocumentManager = _document_routes.DocumentManager
+DocumentManager = importlib.import_module(
+    "lightrag.api.document_manager"
+).DocumentManager
 resolve_file_parser_engine = _parser_routing.resolve_file_parser_engine
 
 

--- a/tests/api/test_multi_workspace_routing.py
+++ b/tests/api/test_multi_workspace_routing.py
@@ -1,0 +1,317 @@
+"""Integration tests for multi-workspace HTTP routing.
+
+Verifies that workspace selection via the ``LIGHTRAG-WORKSPACE`` header
+behaves correctly end-to-end: header routing, fallback, path-traversal
+rejection, empty-header rejection, and cross-workspace data isolation.
+
+Tests I1–I5 exercise the HTTP layer (header → workspace extraction →
+validation) without requiring a real storage backend.  I6 (cross-workspace
+isolation) is a true integration test requiring ``--run-integration``.
+
+Uses the same ``_build_client`` / monkeypatch pattern as
+``test_health_auth.py``.
+"""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import APIRouter
+from fastapi.testclient import TestClient
+
+from lightrag.kg.shared_storage import set_default_workspace
+
+
+# ────────────────────────────────────────────────────────────────
+# Helpers — mirror test_health_auth.py patterns
+# ────────────────────────────────────────────────────────────────
+
+
+_ENV_VARS_TO_ISOLATE = (
+    "LLM_BINDING",
+    "EMBEDDING_BINDING",
+    "AUTH_ACCOUNTS",
+    "TOKEN_SECRET",
+    "LIGHTRAG_API_KEY",
+    "WHITELIST_PATHS",
+    "LIGHTRAG_API_PREFIX",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env_and_config(monkeypatch):
+    """Keep tests hermetic from developer-local .env and global config state."""
+    for var in _ENV_VARS_TO_ISOLATE:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("LLM_BINDING", "ollama")
+    monkeypatch.setenv("EMBEDDING_BINDING", "ollama")
+
+    import lightrag.api.config as config
+
+    config._global_args = None
+    config._initialized = False
+    set_default_workspace(None)
+    yield
+    config._global_args = None
+    config._initialized = False
+    set_default_workspace(None)
+
+
+class _FakeLightRAG:
+    """Minimal stand-in implementing the async surface /health touches."""
+
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    def register_role_llm_builder(self, _builder):
+        return None
+
+    def get_llm_role_config(self):
+        return {}
+
+    async def get_llm_queue_status(self, include_base=True):
+        return {}
+
+    async def get_embedding_queue_status(self):
+        return {}
+
+    async def get_rerank_queue_status(self):
+        return {}
+
+
+class _FakeOllamaAPI:
+    def __init__(self, *_args, **_kwargs):
+        self.router = APIRouter()
+
+
+class _FakeDocManagerPoolGet:
+    """A DocManagerPool stub whose .get() returns a MagicMock."""
+
+    def __init__(self, base_input_dir: str):
+        pass
+
+    async def get(self, workspace: str):
+        mgr = MagicMock()
+        mgr.workspace = workspace
+        return mgr
+
+
+class _FakeRagPool:
+    """A RagPool stub that returns a _FakeLightRAG without real init."""
+
+    def __init__(self, config_factory=None, *, role_llm_builder=None, on_create=None):
+        pass
+
+    async def get(self, workspace: str):
+        rag = _FakeLightRAG()
+        rag.workspace = workspace
+        return rag
+
+    async def shutdown_all(self):
+        pass
+
+
+def _build_client(monkeypatch, *, api_key=None, workspace="default"):
+    """Build a /health-capable TestClient with all backend I/O mocked out."""
+    from lightrag.api.config import parse_args, initialize_config
+
+    original_argv = sys.argv.copy()
+    try:
+        sys.argv = ["lightrag-server"]
+        if workspace:
+            sys.argv.extend(["--workspace", workspace])
+        args = parse_args()
+    finally:
+        sys.argv = original_argv
+    if api_key is not None:
+        args.key = api_key
+    initialize_config(args, force=True)
+
+    # ── Prevent pipmaster from auto-installing packages in tests ──
+    import pipmaster as pm
+
+    monkeypatch.setattr(pm, "is_installed", lambda pkg: True)
+    monkeypatch.setattr(pm, "install", lambda pkg, *a, **kw: None)
+
+    import lightrag.api.lightrag_server as server
+
+    monkeypatch.setattr(server, "RagPool", _FakeRagPool)
+    import lightrag.api.workspace_pool as wp
+    monkeypatch.setattr(wp, "LightRAG", _FakeLightRAG)
+    monkeypatch.setattr(server, "check_frontend_build", lambda: (True, False))
+    monkeypatch.setattr(server, "create_document_routes", lambda *_a, **_k: APIRouter())
+    monkeypatch.setattr(server, "create_query_routes", lambda *_a, **_k: APIRouter())
+    monkeypatch.setattr(server, "create_graph_routes", lambda *_a, **_k: APIRouter())
+    monkeypatch.setattr(server, "OllamaAPI", _FakeOllamaAPI)
+    monkeypatch.setattr(
+        server, "get_namespace_data", AsyncMock(return_value={"busy": False})
+    )
+    monkeypatch.setattr(
+        server,
+        "cleanup_keyed_lock",
+        lambda: {"cleanup_performed": {}, "current_status": {}},
+    )
+    # Replace the real DocManagerPool with our fake that returns MagicMocks
+    monkeypatch.setattr(server, "DocManagerPool", _FakeDocManagerPoolGet)
+
+    app = server.create_app(args)
+    return TestClient(app)
+
+
+# ────────────────────────────────────────────────────────────────
+# I1 — Workspace header selects correct workspace
+# ────────────────────────────────────────────────────────────────
+
+
+def test_workspace_header_selects_workspace(monkeypatch):
+    """I1 — a ``LIGHTRAG-WORKSPACE`` header routes to the named workspace."""
+    client = _build_client(monkeypatch, api_key="test-key")
+
+    resp = client.get(
+        "/health",
+        headers={"LIGHTRAG-WORKSPACE": "projectA", "X-API-Key": "test-key"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["configuration"]["workspace"] == "projectA"
+
+
+def test_different_workspace_headers_different_results(monkeypatch):
+    """I1-ext — different headers route to different workspaces."""
+    client = _build_client(monkeypatch, api_key="test-key")
+
+    r1 = client.get(
+        "/health",
+        headers={"LIGHTRAG-WORKSPACE": "projectA", "X-API-Key": "test-key"},
+    )
+    r2 = client.get(
+        "/health",
+        headers={"LIGHTRAG-WORKSPACE": "projectB", "X-API-Key": "test-key"},
+    )
+    assert r1.json()["configuration"]["workspace"] == "projectA"
+    assert r2.json()["configuration"]["workspace"] == "projectB"
+
+
+# ────────────────────────────────────────────────────────────────
+# I2 — No header falls back to default workspace
+# ────────────────────────────────────────────────────────────────
+
+
+def test_no_header_falls_back_to_default(monkeypatch):
+    """I2 — without header, the server's ``--workspace`` is used."""
+    client = _build_client(monkeypatch, workspace="default", api_key="test-key")
+
+    resp = client.get(
+        "/health",
+        headers={"X-API-Key": "test-key"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["configuration"]["workspace"] == "default"
+
+
+# ────────────────────────────────────────────────────────────────
+# I3 — No header and no default → HTTP 400
+# ────────────────────────────────────────────────────────────────
+
+
+def test_no_header_no_default_returns_400(monkeypatch):
+    """I3 — without header or default workspace, the request is rejected."""
+    client = _build_client(monkeypatch, workspace="", api_key="test-key")
+
+    resp = client.get(
+        "/health",
+        headers={"X-API-Key": "test-key"},
+    )
+    assert resp.status_code == 400
+    assert "required" in resp.json()["detail"].lower()
+
+
+# ────────────────────────────────────────────────────────────────
+# I4 — Path traversal rejected
+# ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "malicious_workspace",
+    [
+        "../../etc",  # Unix traversal
+        "..\\..\\Windows",  # Windows traversal
+        "../secret",  # Single-level traversal
+        "proj/../../etc",  # Mid-string traversal
+    ],
+)
+def test_path_traversal_workspace_rejected(monkeypatch, malicious_workspace):
+    """I4 — workspace names containing path separators or ``..`` are rejected."""
+    client = _build_client(monkeypatch, api_key="test-key")
+
+    resp = client.get(
+        "/health",
+        headers={
+            "LIGHTRAG-WORKSPACE": malicious_workspace,
+            "X-API-Key": "test-key",
+        },
+    )
+    assert resp.status_code == 400
+    assert (
+        "invalid" in resp.json()["detail"].lower()
+        or "workspace" in resp.json()["detail"].lower()
+    )
+
+
+# ────────────────────────────────────────────────────────────────
+# I5 — Empty workspace header rejected
+# ────────────────────────────────────────────────────────────────
+
+
+def test_empty_workspace_header_rejected(monkeypatch):
+    """I5 — an empty (or whitespace-only) header is rejected."""
+    client = _build_client(monkeypatch, api_key="test-key")
+
+    resp = client.get(
+        "/health",
+        headers={"LIGHTRAG-WORKSPACE": "", "X-API-Key": "test-key"},
+    )
+    assert resp.status_code == 400
+    assert "empty" in resp.json()["detail"].lower()
+
+
+def test_whitespace_only_workspace_header_rejected(monkeypatch):
+    """I5-ext — whitespace-only header is treated as empty and rejected."""
+    client = _build_client(monkeypatch, api_key="test-key")
+
+    resp = client.get(
+        "/health",
+        headers={"LIGHTRAG-WORKSPACE": "   ", "X-API-Key": "test-key"},
+    )
+    assert resp.status_code == 400
+    assert "empty" in resp.json()["detail"].lower()
+
+
+# ────────────────────────────────────────────────────────────────
+# I7 — /health returns 200 without workspace header (liveness probe)
+# ────────────────────────────────────────────────────────────────
+
+
+def test_health_no_workspace_header_returns_200(monkeypatch):
+    """I7 — /health is a liveness probe; returns 200 even without workspace."""
+    client = _build_client(monkeypatch, workspace="default")
+
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "healthy"
+
+
+# ────────────────────────────────────────────────────────────────
+# I6 — Cross-workspace data isolation
+# ────────────────────────────────────────────────────────────────
+# Cross-workspace isolation is tested at the RagPool level in
+# ``tests/api/test_workspace_pool.py::TestRagPoolCrossWorkspaceIsolation``.
+# That test creates real LightRAG instances (with mock LLM + embedding
+# and file-based storage) via RagPool, inserts different data into two
+# workspaces, and verifies that full_docs and storage files are fully
+# isolated between workspaces.
+#
+# A true HTTP-level integration test (upload via POST, query via POST
+# with different workspace headers) would require a running server with
+# a real LLM configured.  The pool-level test covers the same isolation
+# contract at the layer closest to the data, without the complexity of
+# injecting mock LLMs into create_app().

--- a/tests/api/test_workspace_pool.py
+++ b/tests/api/test_workspace_pool.py
@@ -1,0 +1,561 @@
+"""Unit tests for RagPool and DocManagerPool.
+
+Tests the concurrency model (two-layer lock), lazy creation, double-check
+guarding, error cleanup, and shutdown-all lifecycle.  Uses mocks — no real
+LLM calls, no real storage connections.
+"""
+
+import asyncio
+import os
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lightrag.api.workspace_pool import RagPool, DocManagerPool
+
+
+# ────────────────────────────────────────────────────────────────
+# Helpers
+# ────────────────────────────────────────────────────────────────
+
+
+def _mock_lightrag(workspace: str):
+    """Create a mock LightRAG instance with the expected async surface."""
+    rag = MagicMock()
+    rag.workspace = workspace
+    rag.initialize_storages = AsyncMock()
+    rag.check_and_migrate_data = AsyncMock()
+    rag.finalize_storages = AsyncMock()
+    rag.register_role_llm_builder = MagicMock()
+    return rag
+
+
+def _tracking_config_factory(created: list[str]):
+    """Return a factory that records which workspaces were created."""
+
+    def factory(workspace: str) -> dict:
+        created.append(workspace)
+        return {"workspace": workspace, "working_dir": "/tmp/test_rag"}
+
+    return factory
+
+
+# ────────────────────────────────────────────────────────────────
+# RagPool
+# ────────────────────────────────────────────────────────────────
+
+
+class TestRagPoolGet:
+    """T1 — basic create and cache."""
+
+    @pytest.mark.asyncio
+    async def test_get_creates_and_caches(self):
+        created = []
+        pool = RagPool(config_factory=_tracking_config_factory(created))
+
+        with patch("lightrag.api.workspace_pool.LightRAG") as MockRAG:
+            MockRAG.side_effect = lambda **kw: _mock_lightrag(kw.get("workspace"))
+
+            rag1 = await pool.get("ws_a")
+            rag2 = await pool.get("ws_a")
+
+        assert rag1 is rag2, "second get() must return the same instance"
+        assert created == ["ws_a"], "factory called exactly once"
+        rag1.initialize_storages.assert_awaited_once()
+        rag1.check_and_migrate_data.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_get_different_workspaces_independent(self):
+        created = []
+        pool = RagPool(config_factory=_tracking_config_factory(created))
+
+        with patch("lightrag.api.workspace_pool.LightRAG") as MockRAG:
+            MockRAG.side_effect = lambda **kw: _mock_lightrag(kw.get("workspace"))
+
+            rag_a = await pool.get("ws_a")
+            rag_b = await pool.get("ws_b")
+
+        assert rag_a is not rag_b
+        assert rag_a.workspace == "ws_a"
+        assert rag_b.workspace == "ws_b"
+        assert created == ["ws_a", "ws_b"]
+
+    @pytest.mark.asyncio
+    async def test_callbacks_invoked(self):
+        created = []
+        on_create_log = []
+
+        pool = RagPool(
+            config_factory=_tracking_config_factory(created),
+            role_llm_builder=lambda role, meta: ("func", "kwargs"),
+            on_create=lambda rag: on_create_log.append(rag.workspace),
+        )
+
+        with patch("lightrag.api.workspace_pool.LightRAG") as MockRAG:
+            MockRAG.side_effect = lambda **kw: _mock_lightrag(kw.get("workspace"))
+            await pool.get("ws_a")
+
+        rag = await pool.get("ws_a")
+        rag.register_role_llm_builder.assert_called_once()
+        assert on_create_log == ["ws_a"]
+
+
+class TestRagPoolConcurrency:
+    """T2-T4 — concurrent access patterns."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_same_workspace_creates_once(self):
+        """T2 — two racing requests for the same new workspace create only one instance."""
+        created = []
+        pool = RagPool(config_factory=_tracking_config_factory(created))
+
+        # Use an event so both coroutines arrive at Layer 1 before either
+        # proceeds to Layer 2.
+        barrier = asyncio.Event()
+
+        async def slow_init():
+            """Simulate slow storage initialization."""
+            barrier.set()  # signal the second coroutine
+            await asyncio.sleep(0.05)  # let second coroutine reach the lock
+
+        async def get_ws():
+            return await pool.get("ws_x")
+
+        with patch("lightrag.api.workspace_pool.LightRAG") as MockRAG:
+            mock_rag = _mock_lightrag("ws_x")
+            mock_rag.initialize_storages = AsyncMock(side_effect=slow_init)
+            MockRAG.return_value = mock_rag
+
+            # Launch both concurrently
+            async with asyncio.TaskGroup() as tg:
+                t1 = tg.create_task(get_ws())
+                await barrier.wait()  # wait for the first to start init
+                t2 = tg.create_task(get_ws())
+
+        rag1, rag2 = t1.result(), t2.result()
+        assert rag1 is rag2
+        assert created == ["ws_x"], f"expected 1 creation, got {len(created)}"
+
+    @pytest.mark.asyncio
+    async def test_different_workspaces_parallel_init(self):
+        """T3 — two new workspaces initialize in parallel."""
+        created = []
+        pool = RagPool(config_factory=_tracking_config_factory(created))
+
+        started = asyncio.Event()
+
+        async def parallel_init():
+            started.set()
+            await asyncio.sleep(0.02)
+
+        with patch("lightrag.api.workspace_pool.LightRAG") as MockRAG:
+
+            def make_rag(**kw):
+                rag = _mock_lightrag(kw.get("workspace"))
+                if kw.get("workspace") == "ws_a":
+                    rag.initialize_storages = AsyncMock(side_effect=parallel_init)
+                else:
+                    rag.initialize_storages = AsyncMock()
+                return rag
+
+            MockRAG.side_effect = make_rag
+
+            async with asyncio.TaskGroup() as tg:
+                ta = tg.create_task(pool.get("ws_a"))
+                await started.wait()  # ws_a's init has started
+                tb = tg.create_task(pool.get("ws_b"))
+
+        # Both must succeed
+        assert ta.result().workspace == "ws_a"
+        assert tb.result().workspace == "ws_b"
+        assert sorted(created) == ["ws_a", "ws_b"]
+
+    @pytest.mark.asyncio
+    async def test_existing_not_blocked_by_new_init(self):
+        """T4 — a query for existing workspace A is not blocked by C initializing."""
+        pool = RagPool(config_factory=lambda ws: {"workspace": ws})
+
+        with patch("lightrag.api.workspace_pool.LightRAG") as MockRAG:
+            MockRAG.side_effect = lambda **kw: _mock_lightrag(kw.get("workspace"))
+
+            # Pre-populate ws_a
+            rag_a = await pool.get("ws_a")
+            rag_a_cached = await pool.get("ws_a")  # fast path
+
+        assert rag_a is rag_a_cached
+
+        # Now start ws_c init and immediately query ws_a
+        ws_c_init_started = asyncio.Event()
+
+        async def slow_init_c():
+            ws_c_init_started.set()
+            await asyncio.sleep(0.1)
+
+        with patch("lightrag.api.workspace_pool.LightRAG") as MockRAG:
+            mock_c = _mock_lightrag("ws_c")
+            mock_c.initialize_storages = AsyncMock(side_effect=slow_init_c)
+            MockRAG.return_value = mock_c
+
+            async with asyncio.TaskGroup() as tg:
+                tc = tg.create_task(pool.get("ws_c"))
+                await ws_c_init_started.wait()
+                # ws_a should return immediately — not blocked by ws_c
+                rag_a_fast = await pool.get("ws_a")
+
+        assert rag_a_fast is rag_a, (
+            "existing workspace A must not be blocked by C's init"
+        )
+        assert tc.result().workspace == "ws_c"
+
+
+class TestRagPoolErrorHandling:
+    """Error cleanup and retry behaviour."""
+
+    @pytest.mark.asyncio
+    async def test_init_failure_cleans_up_and_retry_succeeds(self):
+        """If initialize_storages raises, finalize is called and next get retries."""
+        created = []
+
+        def factory(ws):
+            created.append(ws)
+            return {"workspace": ws}
+
+        pool = RagPool(config_factory=factory)
+
+        with patch("lightrag.api.workspace_pool.LightRAG") as MockRAG:
+            fail_rag = _mock_lightrag("ws_x")
+            fail_rag.initialize_storages.side_effect = RuntimeError(
+                "connection refused"
+            )
+
+            success_rag = _mock_lightrag("ws_x")
+
+            MockRAG.side_effect = [fail_rag, success_rag]
+
+            # First attempt fails
+            with pytest.raises(RuntimeError, match="connection refused"):
+                await pool.get("ws_x")
+
+            # Cleanup was called
+            fail_rag.finalize_storages.assert_awaited_once()
+
+            # Second attempt succeeds (retries from scratch)
+            rag = await pool.get("ws_x")
+
+        assert rag is success_rag
+        assert len(created) == 2, "factory called once per attempt"
+
+    @pytest.mark.asyncio
+    async def test_migration_failure_cleans_up(self):
+        """If check_and_migrate_data raises, finalize is called."""
+        pool = RagPool(config_factory=lambda ws: {"workspace": ws})
+
+        with patch("lightrag.api.workspace_pool.LightRAG") as MockRAG:
+            rag = _mock_lightrag("ws_x")
+            rag.check_and_migrate_data.side_effect = RuntimeError("migration failed")
+            MockRAG.return_value = rag
+
+            with pytest.raises(RuntimeError, match="migration failed"):
+                await pool.get("ws_x")
+
+            rag.finalize_storages.assert_awaited_once()
+
+
+class TestRagPoolLifecycle:
+    """T5 — shutdown_all lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_shutdown_all_finalizes_all(self):
+        pool = RagPool(config_factory=lambda ws: {"workspace": ws})
+
+        rags = []
+        with patch("lightrag.api.workspace_pool.LightRAG") as MockRAG:
+            MockRAG.side_effect = lambda **kw: _mock_lightrag(kw.get("workspace"))
+            rags = [await pool.get(f"ws_{i}") for i in range(3)]
+
+        await pool.shutdown_all()
+
+        for rag in rags:
+            rag.finalize_storages.assert_awaited_once()
+
+        assert pool._rags == {}, "pool must be empty after shutdown"
+
+    @pytest.mark.asyncio
+    async def test_shutdown_all_collects_errors(self):
+        """If one finalization fails, the rest still run and a RuntimeError is raised."""
+        pool = RagPool(config_factory=lambda ws: {"workspace": ws})
+
+        with patch("lightrag.api.workspace_pool.LightRAG") as MockRAG:
+            # ws_0 fails, ws_1 succeeds
+            r0 = _mock_lightrag("ws_0")
+            r0.finalize_storages.side_effect = RuntimeError("disk full")
+            r1 = _mock_lightrag("ws_1")
+
+            MockRAG.side_effect = [r0, r1]
+            await pool.get("ws_0")
+            await pool.get("ws_1")
+
+        with pytest.raises(RuntimeError, match="1 workspace.*failed.*ws_0"):
+            await pool.shutdown_all()
+
+        # ws_1 was still finalized
+        r1.finalize_storages.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_all_idempotent(self):
+        """Repeated shutdown_all is harmless."""
+        pool = RagPool(config_factory=lambda ws: {"workspace": ws})
+
+        with patch("lightrag.api.workspace_pool.LightRAG") as MockRAG:
+            MockRAG.side_effect = lambda **kw: _mock_lightrag(kw.get("workspace"))
+            await pool.get("ws_a")
+
+        await pool.shutdown_all()
+        await pool.shutdown_all()  # second call — no error
+
+
+# ────────────────────────────────────────────────────────────────
+# DocManagerPool
+# ────────────────────────────────────────────────────────────────
+
+
+class TestDocManagerPool:
+    """T6-T8 — DocManagerPool unit tests using real DocumentManager with temp dirs."""
+
+    @pytest.fixture
+    def tmp_input_dir(self):
+        with tempfile.TemporaryDirectory() as td:
+            yield td
+
+    @pytest.mark.asyncio
+    async def test_get_creates_and_caches(self, tmp_input_dir):
+        """T6 — basic create and cache."""
+        pool = DocManagerPool(tmp_input_dir)
+
+        mgr1 = await pool.get("ws_a")
+        mgr2 = await pool.get("ws_a")
+
+        assert mgr1 is mgr2, "second get() must return the same instance"
+        assert mgr1.workspace == "ws_a"
+        assert mgr1.input_dir.name == "ws_a"
+
+    @pytest.mark.asyncio
+    async def test_different_workspaces_independent(self, tmp_input_dir):
+        pool = DocManagerPool(tmp_input_dir)
+
+        mgr_a = await pool.get("ws_a")
+        mgr_b = await pool.get("ws_b")
+
+        assert mgr_a is not mgr_b
+        assert mgr_a.input_dir != mgr_b.input_dir
+
+    @pytest.mark.asyncio
+    async def test_concurrent_same_workspace_creates_once(self, tmp_input_dir):
+        """T7 — two racing requests create only one instance."""
+        pool = DocManagerPool(tmp_input_dir)
+
+        async with asyncio.TaskGroup() as tg:
+            t1 = tg.create_task(pool.get("ws_x"))
+            t2 = tg.create_task(pool.get("ws_x"))
+
+        assert t1.result() is t2.result()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_all_evicts_all(self, tmp_input_dir):
+        """T8 — shutdown clears all managers."""
+        pool = DocManagerPool(tmp_input_dir)
+
+        await pool.get("ws_a")
+        await pool.get("ws_b")
+
+        assert len(pool._managers) == 2
+        await pool.shutdown_all()
+        assert pool._managers == {}
+
+    @pytest.mark.asyncio
+    async def test_shutdown_all_idempotent(self, tmp_input_dir):
+        pool = DocManagerPool(tmp_input_dir)
+
+        await pool.get("ws_a")
+        await pool.shutdown_all()
+        await pool.shutdown_all()  # harmless
+
+
+# ────────────────────────────────────────────────────────────────
+# Combined pool interaction
+# ────────────────────────────────────────────────────────────────
+
+
+class TestPoolsIndependent:
+    """Verify RagPool and DocManagerPool do not interfere."""
+
+    @pytest.mark.asyncio
+    async def test_pools_are_isolated(self):
+        """A failure in one pool does not affect the other."""
+        rag_pool = RagPool(config_factory=lambda ws: {"workspace": ws})
+        with tempfile.TemporaryDirectory() as td:
+            doc_pool = DocManagerPool(td)
+
+            with patch("lightrag.api.workspace_pool.LightRAG") as MockRAG:
+                MockRAG.side_effect = lambda **kw: _mock_lightrag(kw.get("workspace"))
+                await rag_pool.get("ws_a")
+                await doc_pool.get("ws_a")
+
+            assert len(rag_pool._rags) == 1
+            assert len(doc_pool._managers) == 1
+
+
+# ────────────────────────────────────────────────────────────────
+# Cross-workspace data isolation (I6 — RagPool level)
+# ────────────────────────────────────────────────────────────────
+
+
+class TestRagPoolCrossWorkspaceIsolation:
+    """I6 — data inserted into workspace A must not be visible from workspace B.
+
+    Uses real LightRAG instances with mock LLM/embedding functions and
+    file-based storage (JSON + NetworkX + NanoVectorDB).  No external API
+    calls needed — follows the same pattern as
+    ``tests/workspace/test_workspace_isolation.py`` Test 11.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cross_workspace_data_isolation(self):
+        import shutil
+        import json
+        import numpy as np
+        from pathlib import Path
+
+        from lightrag.utils import EmbeddingFunc, Tokenizer
+
+        # ── Temp working directory ──
+        test_dir = tempfile.mkdtemp(prefix="test_pool_isolation_")
+        try:
+            # ── Mock embedding: 384-dim random vectors ──
+            async def mock_embedding_func(texts: list[str]) -> np.ndarray:
+                return np.random.rand(len(texts), 384)
+
+            emb_func = EmbeddingFunc(
+                embedding_dim=384,
+                max_token_size=8192,
+                func=mock_embedding_func,
+            )
+
+            # ── Simple tokenizer (char-level, no network needed) ──
+            class _SimpleTokenizerImpl:
+                def encode(self, content: str) -> list[int]:
+                    return [ord(ch) for ch in content]
+
+                def decode(self, tokens: list[int]) -> str:
+                    return "".join(chr(t) for t in tokens)
+
+            tokenizer = Tokenizer("mock-tokenizer", _SimpleTokenizerImpl())
+
+            # ── Workspace-specific mock LLMs returning distinct entities ──
+            def _make_llm(ws: str):
+                async def mock_llm(
+                    prompt, system_prompt=None, history_messages=[], **kwargs
+                ) -> str:
+                    await asyncio.sleep(0)
+                    if ws == "project_a":
+                        return (
+                            "entity<|#|>Artificial Intelligence<|#|>concept<|#|>"
+                            "AI is a field of computer science.\n"
+                            "entity<|#|>Machine Learning<|#|>concept<|#|>"
+                            "ML is a subset of AI.\n"
+                            "relation<|#|>Machine Learning<|#|>Artificial Intelligence"
+                            "<|#|>subset<|#|>ML is a subset of AI.\n"
+                            "<|COMPLETE|>"
+                        )
+                    else:
+                        return (
+                            "entity<|#|>Deep Learning<|#|>concept<|#|>"
+                            "DL uses neural networks with many layers.\n"
+                            "entity<|#|>Neural Networks<|#|>concept<|#|>"
+                            "NNs are inspired by biological brains.\n"
+                            "relation<|#|>Deep Learning<|#|>Neural Networks"
+                            "<|#|>uses<|#|>DL uses multiple layers of NNs.\n"
+                            "<|COMPLETE|>"
+                        )
+
+                return mock_llm
+
+            # ── Config factory: fresh dict per workspace ──
+            def build_config(workspace: str) -> dict:
+                return {
+                    "working_dir": test_dir,
+                    "workspace": workspace,
+                    "llm_model_func": _make_llm(workspace),
+                    "embedding_func": emb_func,
+                    "tokenizer": tokenizer,
+                }
+
+            pool = RagPool(config_factory=build_config)
+
+            # ── Pool returns distinct instances per workspace ──
+            rag_a = await pool.get("project_a")
+            rag_b = await pool.get("project_b")
+            assert rag_a is not rag_b, (
+                "RagPool must return distinct LightRAG instances per workspace"
+            )
+            assert rag_a.workspace == "project_a"
+            assert rag_b.workspace == "project_b"
+
+            # ── Insert data into both workspaces ──
+            await rag_a.ainsert(
+                "Artificial Intelligence and Machine Learning are "
+                "transforming technology."
+            )
+            await rag_b.ainsert(
+                "Deep Learning and Neural Networks power modern AI applications."
+            )
+
+            # ── Verify file-structure isolation ──
+            dir_a = Path(test_dir) / "project_a"
+            dir_b = Path(test_dir) / "project_b"
+            assert dir_a.exists(), "project_a directory should exist"
+            assert dir_b.exists(), "project_b directory should exist"
+
+            # ── Verify full_docs isolation ──
+            docs_a_path = dir_a / "kv_store_full_docs.json"
+            docs_b_path = dir_b / "kv_store_full_docs.json"
+            assert docs_a_path.exists(), "project_a full_docs should exist"
+            assert docs_b_path.exists(), "project_b full_docs should exist"
+
+            with open(docs_a_path, "r") as f:
+                docs_a = json.load(f)
+            with open(docs_b_path, "r") as f:
+                docs_b = json.load(f)
+
+            docs_a_str = json.dumps(docs_a)
+            docs_b_str = json.dumps(docs_b)
+
+            # project_a contains its own text, NOT project_b's
+            assert "Artificial Intelligence" in docs_a_str, (
+                "project_a should contain its own content"
+            )
+            assert "Deep Learning" not in docs_a_str, (
+                "project_a must NOT contain project_b content"
+            )
+
+            # project_b contains its own text, NOT project_a's
+            assert "Deep Learning" in docs_b_str, (
+                "project_b should contain its own content"
+            )
+            assert "Artificial Intelligence" not in docs_b_str, (
+                "project_b must NOT contain project_a content"
+            )
+
+            # ── Verify per-workspace storage files exist (list what's on disk) ──
+            files_a = sorted(p.name for p in dir_a.glob("*") if p.is_file())
+            files_b = sorted(p.name for p in dir_b.glob("*") if p.is_file())
+            assert len(files_a) > 0, "project_a should contain storage files"
+            assert len(files_b) > 0, "project_b should contain storage files"
+
+            # ── Cleanup ──
+            await pool.shutdown_all()
+
+        finally:
+            if os.path.exists(test_dir):
+                shutil.rmtree(test_dir, ignore_errors=True)

--- a/tests/api/test_workspace_validation.py
+++ b/tests/api/test_workspace_validation.py
@@ -1,0 +1,164 @@
+"""Unit tests for validate_workspace_name and get_workspace_from_request.
+
+Covers the rejection-based whitelist validator (§6.2) and the HTTP header
+extraction helper (§6.2 ③).  Tests V1–V16 and G1–G6 from the design doc.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+# Prevent argparse from seeing pytest flags during config import.
+_original_argv = sys.argv.copy()
+sys.argv = ["lightrag-server"]
+
+import pytest
+from fastapi import HTTPException
+
+from lightrag.api.config import validate_workspace_name
+from lightrag.api.utils_api import get_workspace_from_request
+
+sys.argv = _original_argv
+
+
+# ────────────────────────────────────────────────────────────────
+# validate_workspace_name  (V1–V16)
+# ────────────────────────────────────────────────────────────────
+
+
+class TestValidateWorkspaceNameHappy:
+    """V1–V4 — valid names pass through unchanged (after strip)."""
+
+    @pytest.mark.parametrize(
+        "name, expected",
+        [
+            ("projectA", "projectA"),  # V1
+            ("v1.0", "v1.0"),  # V2 — dots allowed
+            ("项目A", "项目A"),  # V3 — CJK allowed
+            ("テスト", "テスト"),  # Japanese kana allowed
+            ("my-project", "my-project"),  # hyphens allowed
+            ("a", "a"),  # single char
+            ("A" * 128, "A" * 128),  # V13 — 128 chars (boundary)
+        ],
+    )
+    def test_valid_names_accepted(self, name, expected):
+        assert validate_workspace_name(name) == expected
+
+    @pytest.mark.parametrize(
+        "name, expected",
+        [
+            ("  projectA  ", "projectA"),  # V4 — whitespace stripped
+            ("\t\n ws \t", "ws"),  # tabs + newlines stripped
+        ],
+    )
+    def test_whitespace_stripped(self, name, expected):
+        assert validate_workspace_name(name) == expected
+
+
+class TestValidateWorkspaceNameReject:
+    """V5–V16 — invalid names raise HTTPException(400)."""
+
+    @pytest.mark.parametrize(
+        "name, match_text",
+        [
+            ("", "empty"),  # V5 — empty string
+            ("   ", "empty"),  # V6 — whitespace only
+            (".", "Invalid workspace"),  # V7 — dot
+            ("..", "Invalid workspace"),  # V8 — double dot
+            ("a/b", "Invalid workspace"),  # V9 — slash
+            ("a\\b", "Invalid workspace"),  # V10 — backslash
+            ("../etc", "Invalid workspace"),  # V11 — path traversal
+            ("my project", "invalid characters"),  # V15 — space
+            ("name!", "invalid characters"),  # V16 — special char
+            ("na#me", "invalid characters"),  # hash
+            ("a@b", "invalid characters"),  # at sign
+            (
+                "\x00null",
+                "invalid characters",
+            ),  # null byte → caught by name.strip() > 0 or regex
+            ("A" * 129, "too long"),  # V14 — 129 chars
+        ],
+    )
+    def test_invalid_names_rejected(self, name, match_text):
+        with pytest.raises(HTTPException) as exc_info:
+            validate_workspace_name(name)
+        assert exc_info.value.status_code == 400
+        assert match_text.lower() in str(exc_info.value.detail).lower()
+
+    def test_single_dot_rejected(self):
+        """V7 explicit — single '.' is rejected."""
+        with pytest.raises(HTTPException) as exc_info:
+            validate_workspace_name(".")
+        assert exc_info.value.status_code == 400
+
+    def test_double_dot_rejected(self):
+        """V8 explicit — '..' is rejected."""
+        with pytest.raises(HTTPException) as exc_info:
+            validate_workspace_name("..")
+        assert exc_info.value.status_code == 400
+
+    def test_dots_inside_name_accepted(self):
+        """V12 — 'a..b' (dots inside, not path traversal) is OK."""
+        assert validate_workspace_name("a..b") == "a..b"
+
+
+# ────────────────────────────────────────────────────────────────
+# get_workspace_from_request  (G1–G6)
+# ────────────────────────────────────────────────────────────────
+
+
+def _make_request(header_value: str | None) -> MagicMock:
+    """Build a mock FastAPI Request with an optional LIGHTRAG-WORKSPACE header."""
+    req = MagicMock()
+    headers = {}
+    if header_value is not None:
+        headers["LIGHTRAG-WORKSPACE"] = header_value
+    req.headers.get.side_effect = lambda key, default=None: headers.get(key, default)
+    return req
+
+
+class TestGetWorkspaceFromRequest:
+    """G1–G6 — header extraction with validation and fallback."""
+
+    def test_header_present_valid(self):
+        """G1 — valid header returns the validated name."""
+        req = _make_request("projectA")
+        result = get_workspace_from_request(req)
+        assert result == "projectA"
+
+    def test_header_absent_default_provided(self):
+        """G2 — no header, default_workspace set → fallback."""
+        req = _make_request(None)
+        result = get_workspace_from_request(req, default_workspace="default")
+        assert result == "default"
+
+    def test_header_absent_no_default(self):
+        """G3 — no header, no default → HTTP 400."""
+        req = _make_request(None)
+        with pytest.raises(HTTPException) as exc_info:
+            get_workspace_from_request(req)
+        assert exc_info.value.status_code == 400
+        assert "required" in str(exc_info.value.detail).lower()
+
+    def test_header_present_empty(self):
+        """G4 — header present but empty (explicitly sent) → 400, NOT fallback."""
+        req = _make_request("")
+        with pytest.raises(HTTPException) as exc_info:
+            get_workspace_from_request(req, default_workspace="default")
+        assert exc_info.value.status_code == 400
+        assert "empty" in str(exc_info.value.detail).lower()
+
+    def test_header_whitespace_only(self):
+        """G5 — whitespace-only header → treated as empty, HTTP 400."""
+        req = _make_request("   ")
+        with pytest.raises(HTTPException) as exc_info:
+            get_workspace_from_request(req, default_workspace="default")
+        assert exc_info.value.status_code == 400
+        assert "empty" in str(exc_info.value.detail).lower()
+
+    def test_header_invalid_chars(self):
+        """G6 — header present with invalid chars → HTTP 400."""
+        req = _make_request("my project")
+        with pytest.raises(HTTPException) as exc_info:
+            get_workspace_from_request(req)
+        assert exc_info.value.status_code == 400
+        assert "invalid" in str(exc_info.value.detail).lower()

--- a/tests/workspace/test_workspace_path_validation.py
+++ b/tests/workspace/test_workspace_path_validation.py
@@ -98,7 +98,7 @@ def _import_document_manager():
     original_argv = sys.argv.copy()
     try:
         sys.argv = ["lightrag-server"]
-        from lightrag.api.routers.document_routes import DocumentManager
+        from lightrag.api.document_manager import DocumentManager
 
         return DocumentManager
     finally:


### PR DESCRIPTION
## Description

Enable a single LightRAG server process to serve multiple workspaces, selected per-request via the existing LIGHTRAG-WORKSPACE HTTP header. Previously, a server could only serve the workspace specified at startup (--workspace). This PR introduces a lazy-initialized pooling layer (RagPool + DocManagerPool) with proper concurrency control, and wires it into all API route families.

⚠No changes have been made to the frontend or WebUI. Workspace selection is available exclusively through the HTTP API — clients must set the LIGHTRAG-WORKSPACE header on each request. WebUI still operates against the default workspace only. 

## Related Issues
Issues: #2373, #2527 . 
Built on PRs #2730 , #2904 , #3374 , #2445 .
 

## Changes Made

- RagPool: Lazily-initialized pool of LightRAG instances keyed by workspace. Uses a config factory pattern (config_factory(workspace) -> dict) instead of copying a shared base config dict — shared singletons (LLM functions, embedding functions, OllamaServerInfos) are captured by closure and reused by reference; per-workspace values (kwargs dicts, addon_params, role_llm_configs) are re-constructed fresh on every call. Two-layer asyncio.Lock (per-workspace) means different workspaces initialize in parallel without blocking each other. Error cleanup: if initialize_storages() or check_and_migrate_data() raises, finalize_storages() is called before the exception propagates — no leaked connections.

- DocManagerPool: Same two-layer lock pattern for DocumentManager instances, providing per-workspace file upload isolation via inputs/<workspace>/.

- DocumentManager class extracted from lightrag/api/routers/document_routes.py into its own module. This was necessary to avoid a circular import between workspace_pool.py (which imports DocumentManager) and document_routes.py (which would import DocManagerPool). The class itself remains unchanged.

- New validate_workspace_name() in lightrag/api/config.py — a rejection-based whitelist validator replacing the old re.sub(r"[^a-zA-Z0-9_]", "_", workspace) substitution approach. Allows [A-Za-z0-9_.-] plus CJK and Japanese kana, max 128 chars, with explicit path-traversal rejection (.., /, \). Invalid inputs get a clear HTTP 400 message instead of being silently mapped to a potentially conflicting sanitized name. 

- get_workspace_from_request() extracted from lightrag_server.py closure → lightrag/api/utils_api.py so all router modules can import it. Internalizes fallback logic with an explicit default_workspace parameter; when the header is present but empty, it rejects (HTTP 400) rather than silently falling back to the default — a malformed multi-workspace request should not accidentally route to the wrong data.


- In lightrag_server.py:
   - /status endpoint now resolves rag from rag_pool per-request.

   - build_rag_config(workspace) factory defined inside create_app(), capturing singletons via closure and re-constructing per-workspace containers.
   - Workspace names containing spaces, slashes, or backslashes are now rejected at request time with HTTP 400. Deployments using --workspace "my project" must rename their directories. The old re.sub approach silently mapped "A!" and "A?" both to "A_" while the new validator fails observably and tells the operator exactly what to fix.

- All endpoints of the 4 router familiers updated. 

- 60 new tests across 3 folders can be found in the following files:
   - tests/api/test_workspace_validation.py
   - tests/api/test_multi_workspace_routing.py
   - tests/api/test_workspace_pool.py

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes
Each workspace gets its own LightRAG instance with independent priority_limit_async_func_call limiters. Harmless for stateless cloud APIs but may overwhelm a local Ollama instance.
