### PR TITLE
fix(core): make ainsert_custom_chunks respect the pipeline busy contract (#3352)

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1640,6 +1640,15 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         "Wait for the scan to finish and retry."
                     )
                 pipeline_status["busy"] = True
+                # Start clean, mirroring the processing loop's acquire: clear any
+                # stale cancellation left by a previously cancelled job. The
+                # cancel endpoint sets cancellation_requested whenever busy=True
+                # (it can't tell this path from the loop); without clearing it
+                # here a leftover flag would immediately abort the extract/merge
+                # below via PipelineCancelledException.
+                pipeline_status["cancellation_requested"] = False
+                pipeline_status["cancellation_reason"] = None
+                pipeline_status["cancellation_detail"] = None
             busy_acquired = True
 
             # Stage 1 (barrier): persist chunks BEFORE extraction. Extraction
@@ -1701,6 +1710,14 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 finally:
                     async with pipeline_status_lock:
                         pipeline_status["busy"] = False
+                        # Clear cancellation as part of releasing the slot
+                        # (mirroring the processing loop's finally): a cancel
+                        # that targeted THIS job, or arrived after it finished,
+                        # must not wedge the next ainsert_custom_chunks with a
+                        # stale PipelineCancelledException.
+                        pipeline_status["cancellation_requested"] = False
+                        pipeline_status["cancellation_reason"] = None
+                        pipeline_status["cancellation_detail"] = None
                         # An enqueue that arrived while we held busy set
                         # request_pending but had no running loop to consume it.
                         # Note whether to kick processing so those PENDING docs

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1714,7 +1714,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             # pending buffers — doing so could commit or tear down another
             # running job's in-flight index ops.
             if busy_acquired:
-                drain_pending = False
+                hand_off = False
                 # Flush first (while still busy so no other writer starts
                 # mid-flush), then release the slot even if the flush raises —
                 # otherwise the pipeline would stay wedged as busy forever.
@@ -1722,7 +1722,6 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     await self._insert_done_with_cleanup()
                 finally:
                     async with pipeline_status_lock:
-                        pipeline_status["busy"] = False
                         # Clear cancellation as part of releasing the slot
                         # (mirroring the processing loop's finally): a cancel
                         # that targeted THIS job, or arrived after it finished,
@@ -1731,24 +1730,32 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         pipeline_status["cancellation_requested"] = False
                         pipeline_status["cancellation_reason"] = None
                         pipeline_status["cancellation_detail"] = None
-                        # An enqueue that arrived while we held busy set
-                        # request_pending but had no running loop to consume it.
-                        # Note whether to kick processing so those PENDING docs
-                        # are not stranded. request_pending is left set (not
-                        # cleared here) so the drain — or, if a concurrent writer
-                        # wins the slot first, the next trigger — still sees it.
-                        drain_pending = bool(pipeline_status.get("request_pending"))
-                    if drain_pending:
-                        # Best-effort: apipeline_process_enqueue_documents
-                        # re-acquires busy atomically and clears request_pending
-                        # itself. Runs inside the finally so it happens whether
-                        # or not the body raised, and busy is already released.
+                        if pipeline_status.get("request_pending"):
+                            # A doc was enqueued while we held busy. Hand the
+                            # slot to a processing run WITHOUT releasing busy
+                            # (keep it True) — releasing here first would open a
+                            # busy=False + request_pending window in which a
+                            # clear/delete/scan reservation (which check busy /
+                            # scanning / pending_enqueues but NOT request_pending)
+                            # could start and drop the accepted-but-unprocessed
+                            # document. The handoff run below consumes
+                            # request_pending and releases busy atomically at its
+                            # own exit, mirroring the loop's
+                            # _atomic_release_busy_or_consume_pending.
+                            hand_off = True
+                        else:
+                            pipeline_status["busy"] = False
+                    if hand_off:
+                        # busy is still True; the handoff takes over the slot and
+                        # always releases it (no-work / error / normal exit).
                         try:
-                            await self.apipeline_process_enqueue_documents()
+                            await self.apipeline_process_enqueue_documents(
+                                _holding_busy=True
+                            )
                         except Exception as drain_error:
                             logger.warning(
-                                "Failed to drain queued documents after "
-                                f"custom-chunks insert: {drain_error}"
+                                "Failed to process queued documents handed off "
+                                f"from a custom-chunks insert: {drain_error}"
                             )
 
     async def _process_extract_entities(

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1560,6 +1560,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         self, full_text: str, text_chunks: list[str], doc_id: str | None = None
     ) -> None:
         update_storage = False
+        busy_acquired = False
+        process_after_release = False
+        pipeline_status = None
+        pipeline_status_lock = None
         try:
             # Clean input texts
             full_text = sanitize_text_for_encoding(full_text)
@@ -1613,6 +1617,34 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 "pipeline_status", workspace=self.workspace
             )
 
+            # Reserve the pipeline busy slot before doing any extraction/merge.
+            # This path now writes the KG (Stage 3), so it must be mutually
+            # exclusive with the processing loop, destructive ops, and another
+            # custom-chunks insert — the single-writer contract the file
+            # pipeline enforces via ``busy``. Entity-keyed locks already keep
+            # the graph data consistent under concurrency, but without this a
+            # second merger would still run: LLM concurrency doubles past
+            # ``llm_model_max_async``, ``pipeline_status`` misreports idle, and
+            # the shared ``cancellation_requested`` flag cross-cancels. Reject
+            # (rather than queue) when the slot is taken, mirroring
+            # ``_acquire_destructive_busy``; ``destructive_busy`` implies
+            # ``busy`` so a running clear/delete is covered too.
+            async with pipeline_status_lock:
+                if pipeline_status.get("busy"):
+                    raise RuntimeError(
+                        "Pipeline is busy with another operation; "
+                        "ainsert_custom_chunks cannot run concurrently. "
+                        "Wait for it to finish and retry."
+                    )
+                if pipeline_status.get("scanning"):
+                    raise RuntimeError(
+                        "A document scan is in progress; "
+                        "ainsert_custom_chunks cannot run concurrently. "
+                        "Wait for the scan to finish and retry."
+                    )
+                pipeline_status["busy"] = True
+            busy_acquired = True
+
             # Stage 1 (barrier): persist chunks BEFORE extraction. Extraction
             # records per-chunk LLM cache references (update_chunk_cache_list ->
             # text_chunks) keyed by chunk id and reads chunks back via
@@ -1657,8 +1689,32 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 )
 
         finally:
-            if update_storage:
-                await self._insert_done_with_cleanup()
+            # Release the busy slot even if the flush below raises, otherwise
+            # the pipeline would stay wedged as busy forever. Flush first (while
+            # still busy) so no other writer starts mid-flush, then release.
+            try:
+                if update_storage:
+                    await self._insert_done_with_cleanup()
+            finally:
+                if busy_acquired:
+                    async with pipeline_status_lock:
+                        pipeline_status["busy"] = False
+                        # An enqueue that arrived while we held busy set
+                        # request_pending (it has no running loop to consume
+                        # it). Drain it below so those PENDING docs are not
+                        # stranded until an unrelated trigger.
+                        if pipeline_status.get("request_pending"):
+                            pipeline_status["request_pending"] = False
+                            process_after_release = True
+
+        if process_after_release:
+            try:
+                await self.apipeline_process_enqueue_documents()
+            except Exception as drain_error:
+                logger.warning(
+                    "Failed to drain queued documents after custom-chunks "
+                    f"insert: {drain_error}"
+                )
 
     async def _process_extract_entities(
         self, chunk: dict[str, Any], pipeline_status=None, pipeline_status_lock=None

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1640,6 +1640,15 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         "Wait for the scan to finish and retry."
                     )
                 pipeline_status["busy"] = True
+                # Record ownership INSIDE the locked section, immediately after
+                # taking the slot and before any await. Exiting the
+                # ``async with`` awaits the lock's __aexit__ (which awaits an
+                # asyncio.shield), a point at which task cancellation can be
+                # delivered; if busy_acquired were set only after the block, a
+                # cancel there would leave busy=True but busy_acquired=False and
+                # the finally would skip the release, wedging the workspace busy
+                # forever. Mirrors adelete_by_doc_id's we_acquired_pipeline.
+                busy_acquired = True
                 # Stamp our own job identity, mirroring every other acquirer
                 # (processing loop -> "Default Job", deletes -> "...document...").
                 # Critical: flipping busy without overwriting job_name would leave
@@ -1662,7 +1671,6 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 pipeline_status["cancellation_requested"] = False
                 pipeline_status["cancellation_reason"] = None
                 pipeline_status["cancellation_detail"] = None
-            busy_acquired = True
 
             # Stage 1 (barrier): persist chunks BEFORE extraction. Extraction
             # records per-chunk LLM cache references (update_chunk_cache_list ->

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1559,9 +1559,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     async def ainsert_custom_chunks(
         self, full_text: str, text_chunks: list[str], doc_id: str | None = None
     ) -> None:
-        update_storage = False
         busy_acquired = False
-        process_after_release = False
         pipeline_status = None
         pipeline_status_lock = None
         try:
@@ -1583,7 +1581,6 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 logger.warning("This document is already in the storage.")
                 return
 
-            update_storage = True
             logger.info(f"Inserting {len(new_docs)} docs")
 
             inserting_chunks: dict[str, Any] = {}
@@ -1689,32 +1686,40 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 )
 
         finally:
-            # Release the busy slot even if the flush below raises, otherwise
-            # the pipeline would stay wedged as busy forever. Flush first (while
-            # still busy) so no other writer starts mid-flush, then release.
-            try:
-                if update_storage:
+            # Everything here is gated on busy_acquired. If we rejected
+            # (busy/scanning) or returned before acquiring, we neither own the
+            # slot nor wrote any data, so we must NOT flush/discard the SHARED
+            # pending buffers — doing so could commit or tear down another
+            # running job's in-flight index ops.
+            if busy_acquired:
+                drain_pending = False
+                # Flush first (while still busy so no other writer starts
+                # mid-flush), then release the slot even if the flush raises —
+                # otherwise the pipeline would stay wedged as busy forever.
+                try:
                     await self._insert_done_with_cleanup()
-            finally:
-                if busy_acquired:
+                finally:
                     async with pipeline_status_lock:
                         pipeline_status["busy"] = False
                         # An enqueue that arrived while we held busy set
-                        # request_pending (it has no running loop to consume
-                        # it). Drain it below so those PENDING docs are not
-                        # stranded until an unrelated trigger.
-                        if pipeline_status.get("request_pending"):
-                            pipeline_status["request_pending"] = False
-                            process_after_release = True
-
-        if process_after_release:
-            try:
-                await self.apipeline_process_enqueue_documents()
-            except Exception as drain_error:
-                logger.warning(
-                    "Failed to drain queued documents after custom-chunks "
-                    f"insert: {drain_error}"
-                )
+                        # request_pending but had no running loop to consume it.
+                        # Note whether to kick processing so those PENDING docs
+                        # are not stranded. request_pending is left set (not
+                        # cleared here) so the drain — or, if a concurrent writer
+                        # wins the slot first, the next trigger — still sees it.
+                        drain_pending = bool(pipeline_status.get("request_pending"))
+                    if drain_pending:
+                        # Best-effort: apipeline_process_enqueue_documents
+                        # re-acquires busy atomically and clears request_pending
+                        # itself. Runs inside the finally so it happens whether
+                        # or not the body raised, and busy is already released.
+                        try:
+                            await self.apipeline_process_enqueue_documents()
+                        except Exception as drain_error:
+                            logger.warning(
+                                "Failed to drain queued documents after "
+                                f"custom-chunks insert: {drain_error}"
+                            )
 
     async def _process_extract_entities(
         self, chunk: dict[str, Any], pipeline_status=None, pipeline_status_lock=None

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1640,6 +1640,19 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         "Wait for the scan to finish and retry."
                     )
                 pipeline_status["busy"] = True
+                # Stamp our own job identity, mirroring every other acquirer
+                # (processing loop -> "Default Job", deletes -> "...document...").
+                # Critical: flipping busy without overwriting job_name would leave
+                # a stale name from the previous holder. After a batch delete,
+                # background_delete_documents releases busy but leaves
+                # job_name="Deleting N Documents"; adelete_by_doc_id treats
+                # busy + a "deleting...document" job_name as "a batch delete is
+                # running, join it" and proceeds WITHOUT acquiring — so a
+                # concurrent delete could run against our KG/vector writes. A
+                # non-deletion job_name makes that guard correctly reject.
+                pipeline_status["job_name"] = "Custom chunks insert"
+                pipeline_status["job_start"] = datetime.now(timezone.utc).isoformat()
+                pipeline_status["latest_message"] = "Inserting custom chunks"
                 # Start clean, mirroring the processing loop's acquire: clear any
                 # stale cancellation left by a previously cancelled job. The
                 # cancel endpoint sets cancellation_requested whenever busy=True

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -989,7 +989,9 @@ class _PipelineMixin:
                     f"File processing error: - ID: {doc_id} {error_doc['file_path']}"
                 )
 
-    async def apipeline_process_enqueue_documents(self) -> None:
+    async def apipeline_process_enqueue_documents(
+        self, _holding_busy: bool = False
+    ) -> None:
         """
         Process pending documents by splitting them into chunks, processing
         each chunk for entity and relation extraction, and updating the
@@ -1000,6 +1002,16 @@ class _PipelineMixin:
         3. Split document content into chunks
         4. Process each chunk for entity and relation extraction
         5. Update the document status
+
+        ``_holding_busy`` (internal): when True the caller already owns the
+        ``busy`` slot and hands it to this run atomically — used by
+        ``ainsert_custom_chunks`` to drain a ``request_pending`` that arrived
+        while it held ``busy``, without ever dropping ``busy`` to False (which
+        would open a window for a clear/delete/scan reservation to start and
+        drop the accepted-but-unprocessed document). This run takes over the
+        existing slot instead of re-acquiring it, and always releases it — on
+        the no-work path, on a get-docs failure, and via the loop's finally —
+        so a handoff can never wedge the pipeline as permanently busy.
         """
         pipeline_status = await get_namespace_data(
             "pipeline_status", workspace=self.workspace
@@ -1009,15 +1021,29 @@ class _PipelineMixin:
         )
 
         async with pipeline_status_lock:
-            # Ensure only one worker is processing documents
-            if not pipeline_status.get("busy", False):
-                to_process_docs: dict[
-                    str, DocProcessingStatus
-                ] = await self.doc_status.get_docs_by_statuses(
-                    list(_INFLIGHT_DOC_STATUSES)
-                )
+            # Ensure only one worker is processing documents. ``_holding_busy``
+            # means the slot was handed to us already owned, so take it over
+            # rather than treating busy=True as "someone else is running".
+            if _holding_busy or not pipeline_status.get("busy", False):
+                try:
+                    to_process_docs: dict[
+                        str, DocProcessingStatus
+                    ] = await self.doc_status.get_docs_by_statuses(
+                        list(_INFLIGHT_DOC_STATUSES)
+                    )
+                except Exception:
+                    # A handed-off slot is already busy=True; release it so a
+                    # failure here does not wedge the pipeline permanently busy.
+                    # A normal call has not set busy yet, so nothing to release.
+                    if _holding_busy:
+                        pipeline_status["busy"] = False
+                    raise
 
                 if not to_process_docs:
+                    # Release the handed-off slot (a normal call never set busy
+                    # on this path).
+                    if _holding_busy:
+                        pipeline_status["busy"] = False
                     logger.info("No documents to process")
                     return
 

--- a/tests/pipeline/test_document_file_path_normalization.py
+++ b/tests/pipeline/test_document_file_path_normalization.py
@@ -508,3 +508,38 @@ async def test_custom_chunks_busy_rejection_does_not_flush_shared_buffers(monkey
         await rag.ainsert_custom_chunks("full text", ["chunk text"], doc_id="doc-p1")
 
     assert cleanup["called"] is False
+
+
+@pytest.mark.asyncio
+async def test_custom_chunks_clears_stale_cancellation(monkeypatch):
+    """A stale cancellation_requested (e.g. left by a previously cancelled
+    custom-chunks job, since the cancel endpoint sets it whenever busy=True)
+    must not abort the next insert. The busy lifecycle clears the cancellation
+    fields on acquire (so extract/merge are not pre-killed) and on release (so
+    it does not leak to the next job)."""
+    status = {
+        "busy": False,
+        "history_messages": [],
+        "request_pending": False,
+        "cancellation_requested": True,  # stale from a prior cancelled job
+        "cancellation_reason": "internal_error",
+        "cancellation_detail": "stale",
+    }
+    rag = _custom_chunks_rag(monkeypatch, status)
+
+    observed = {}
+
+    async def _process_extract_entities(chunks, ps=None, pl=None):
+        # Real extract/merge raise PipelineCancelledException when this is True;
+        # it must have been cleared on acquire so this job runs.
+        observed["cancel_during"] = status.get("cancellation_requested")
+        return [({"E": [{"entity_name": "E"}]}, {})]
+
+    rag._process_extract_entities = _process_extract_entities
+
+    await rag.ainsert_custom_chunks("full text", ["chunk text"], doc_id="doc-cancel")
+
+    assert observed["cancel_during"] is False  # cleared on acquire
+    assert status["cancellation_requested"] is False  # cleared on release
+    assert status["cancellation_reason"] is None
+    assert status["cancellation_detail"] is None

--- a/tests/pipeline/test_document_file_path_normalization.py
+++ b/tests/pipeline/test_document_file_path_normalization.py
@@ -431,7 +431,7 @@ async def test_custom_chunks_rejects_when_pipeline_busy(monkeypatch):
 async def test_custom_chunks_holds_busy_during_and_releases_after(monkeypatch):
     """ainsert_custom_chunks must hold ``busy`` for the whole extract+merge so a
     concurrent pipeline sees it, and release it afterwards. A request_pending
-    that arrived while busy is drained on release."""
+    that arrived while busy triggers a best-effort drain on release."""
     status = {"busy": False, "history_messages": [], "request_pending": False}
     rag = _custom_chunks_rag(monkeypatch, status)
 
@@ -447,6 +447,9 @@ async def test_custom_chunks_holds_busy_during_and_releases_after(monkeypatch):
 
     async def _drain():
         drained["called"] = True
+        # The real apipeline_process_enqueue_documents clears request_pending
+        # atomically when it re-acquires busy; model that here.
+        status["request_pending"] = False
 
     rag._process_extract_entities = _process_extract_entities
     rag.apipeline_process_enqueue_documents = _drain
@@ -455,5 +458,53 @@ async def test_custom_chunks_holds_busy_during_and_releases_after(monkeypatch):
 
     assert observed["busy_during_extract"] is True  # held during the work
     assert status["busy"] is False  # released afterwards
-    assert status["request_pending"] is False  # drained
     assert drained["called"] is True  # processing nudged for the queued docs
+    assert status["request_pending"] is False  # consumed by the drain
+
+
+@pytest.mark.asyncio
+async def test_custom_chunks_releases_busy_without_pending(monkeypatch):
+    """With no request_pending, the busy slot is released and no drain runs."""
+    status = {"busy": False, "history_messages": [], "request_pending": False}
+    rag = _custom_chunks_rag(monkeypatch, status)
+
+    drained = {"called": False}
+
+    async def _drain():
+        drained["called"] = True
+
+    async def _process_extract_entities(chunks, ps=None, pl=None):
+        return [({"E": [{"entity_name": "E"}]}, {})]
+
+    rag._process_extract_entities = _process_extract_entities
+    rag.apipeline_process_enqueue_documents = _drain
+
+    await rag.ainsert_custom_chunks("full text", ["chunk text"], doc_id="doc-np")
+
+    assert status["busy"] is False
+    assert drained["called"] is False
+
+
+@pytest.mark.asyncio
+async def test_custom_chunks_busy_rejection_does_not_flush_shared_buffers(monkeypatch):
+    """P1: a busy rejection must NOT run _insert_done_with_cleanup. The call
+    neither acquired the slot nor wrote data, so flushing/discarding the SHARED
+    pending buffers could commit or tear down the running job's in-flight ops."""
+    status = {"busy": True, "history_messages": []}
+    rag = _custom_chunks_rag(monkeypatch, status)
+
+    cleanup = {"called": False}
+
+    async def _insert_done_with_cleanup():
+        cleanup["called"] = True
+
+    async def _process_extract_entities(chunks, ps=None, pl=None):
+        return []
+
+    rag._insert_done_with_cleanup = _insert_done_with_cleanup
+    rag._process_extract_entities = _process_extract_entities
+
+    with pytest.raises(RuntimeError, match="busy"):
+        await rag.ainsert_custom_chunks("full text", ["chunk text"], doc_id="doc-p1")
+
+    assert cleanup["called"] is False

--- a/tests/pipeline/test_document_file_path_normalization.py
+++ b/tests/pipeline/test_document_file_path_normalization.py
@@ -543,3 +543,37 @@ async def test_custom_chunks_clears_stale_cancellation(monkeypatch):
     assert status["cancellation_requested"] is False  # cleared on release
     assert status["cancellation_reason"] is None
     assert status["cancellation_detail"] is None
+
+
+@pytest.mark.asyncio
+async def test_custom_chunks_overwrites_stale_deletion_job_name(monkeypatch):
+    """A stale ``Deleting N Documents`` job_name (left by a finished batch delete,
+    which releases busy but not job_name) must be overwritten when custom-chunks
+    takes the busy slot. Otherwise a concurrent adelete_by_doc_id — which joins a
+    running delete whenever busy=True and job_name starts with 'deleting' and
+    contains 'document' — would proceed and race custom-chunks' KG/vector writes.
+    """
+    status = {
+        "busy": False,
+        "history_messages": [],
+        "request_pending": False,
+        "job_name": "Deleting 5 Documents",  # stale, from a finished batch delete
+    }
+    rag = _custom_chunks_rag(monkeypatch, status)
+
+    observed = {}
+
+    async def _process_extract_entities(chunks, ps=None, pl=None):
+        # Captured while we hold busy — this is what a concurrent
+        # adelete_by_doc_id would see and key its join-guard off.
+        observed["job_name_during"] = status["job_name"]
+        return [({"E": [{"entity_name": "E"}]}, {})]
+
+    rag._process_extract_entities = _process_extract_entities
+
+    await rag.ainsert_custom_chunks("full text", ["chunk text"], doc_id="doc-jn")
+
+    jn = observed["job_name_during"].lower()
+    # The exact adelete_by_doc_id join-guard predicate must be False while
+    # custom-chunks holds busy, so a concurrent single delete is rejected.
+    assert not (jn.startswith("deleting") and "document" in jn)

--- a/tests/pipeline/test_document_file_path_normalization.py
+++ b/tests/pipeline/test_document_file_path_normalization.py
@@ -586,3 +586,65 @@ async def test_custom_chunks_overwrites_stale_deletion_job_name(monkeypatch):
     # The exact adelete_by_doc_id join-guard predicate must be False while
     # custom-chunks holds busy, so a concurrent single delete is rejected.
     assert not (jn.startswith("deleting") and "document" in jn)
+
+
+@pytest.mark.asyncio
+async def test_custom_chunks_release_survives_cancel_at_lock_exit(monkeypatch):
+    """If cancellation is delivered while exiting the acquire's status lock —
+    its __aexit__ awaits an asyncio.shield, a real cancellation point — right
+    after busy was set, the finally must still release busy. busy_acquired is
+    recorded inside the lock (atomically with busy), so a cancel at the lock
+    boundary can't leave busy=True with busy_acquired=False and wedge the
+    workspace permanently busy.
+    """
+    from lightrag import LightRAG
+    import lightrag.lightrag as lightrag_module
+
+    status = {"busy": False, "history_messages": [], "request_pending": False}
+
+    class _CancelOnFirstExitLock:
+        """Delivers CancelledError at the FIRST __aexit__ (the acquire block's
+        exit, after busy was set); later exits (the finally's release) behave
+        normally, mirroring how asyncio.shield in the real lock re-raises a
+        cancel at the await boundary."""
+
+        def __init__(self):
+            self._exits = 0
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            self._exits += 1
+            if self._exits == 1:
+                raise asyncio.CancelledError()
+            return False
+
+    lock = _CancelOnFirstExitLock()
+
+    rag = LightRAG.__new__(LightRAG)
+    rag.full_docs = CaptureKV()
+    rag.text_chunks = CaptureKV()
+    rag.chunks_vdb = CaptureKV()
+    rag.tokenizer = type("Tokenizer", (), {"encode": lambda self, text: [text]})()
+    rag.workspace = "test-workspace"
+
+    async def _insert_done_with_cleanup():
+        return None
+
+    rag._insert_done_with_cleanup = _insert_done_with_cleanup
+
+    async def fake_namespace_data(name, workspace=None):
+        return status
+
+    def fake_namespace_lock(name, workspace=None):
+        return lock
+
+    monkeypatch.setattr(lightrag_module, "get_namespace_data", fake_namespace_data)
+    monkeypatch.setattr(lightrag_module, "get_namespace_lock", fake_namespace_lock)
+
+    with pytest.raises(asyncio.CancelledError):
+        await rag.ainsert_custom_chunks("full text", ["chunk text"], doc_id="doc-x")
+
+    # Despite the cancel at the acquire-lock exit, busy must be released.
+    assert status["busy"] is False

--- a/tests/pipeline/test_document_file_path_normalization.py
+++ b/tests/pipeline/test_document_file_path_normalization.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 
 import pytest
@@ -166,7 +167,7 @@ async def test_custom_chunks_use_canonical_unknown_source_before_upsert(monkeypa
         return {}
 
     def fake_namespace_lock(name, workspace=None):
-        return object()
+        return asyncio.Lock()
 
     monkeypatch.setattr(lightrag_module, "get_namespace_data", fake_namespace_data)
     monkeypatch.setattr(lightrag_module, "get_namespace_lock", fake_namespace_lock)
@@ -233,7 +234,7 @@ async def test_custom_chunks_merge_extracted_entities_into_kg(monkeypatch):
         return {}
 
     def fake_namespace_lock(name, workspace=None):
-        return object()
+        return asyncio.Lock()
 
     monkeypatch.setattr(lightrag_module, "merge_nodes_and_edges", fake_merge)
     monkeypatch.setattr(lightrag_module, "get_namespace_data", fake_namespace_data)
@@ -337,7 +338,7 @@ async def test_custom_chunks_persist_before_extraction(monkeypatch):
         return {}
 
     def fake_namespace_lock(name, workspace=None):
-        return object()
+        return asyncio.Lock()
 
     monkeypatch.setattr(lightrag_module, "get_namespace_data", fake_namespace_data)
     monkeypatch.setattr(lightrag_module, "get_namespace_lock", fake_namespace_lock)
@@ -345,3 +346,114 @@ async def test_custom_chunks_persist_before_extraction(monkeypatch):
     await rag.ainsert_custom_chunks("full text", ["chunk text"], doc_id="doc-3")
 
     assert events.index("text_chunks_persisted") < events.index("extract")
+
+
+def _custom_chunks_rag(monkeypatch, status):
+    """A bare LightRAG wired for ainsert_custom_chunks with a shared, mutable
+    ``status`` dict and a real asyncio lock, extraction/merge stubbed."""
+    from lightrag import LightRAG
+    import lightrag.lightrag as lightrag_module
+
+    rag = LightRAG.__new__(LightRAG)
+    rag.full_docs = CaptureKV()
+    rag.text_chunks = CaptureKV()
+    rag.chunks_vdb = CaptureKV()
+    rag.tokenizer = type("Tokenizer", (), {"encode": lambda self, text: [text]})()
+    rag.workspace = "test-workspace"
+    for attr in (
+        "chunk_entity_relation_graph",
+        "entities_vdb",
+        "relationships_vdb",
+        "full_entities",
+        "full_relations",
+        "entity_chunks",
+        "relation_chunks",
+        "llm_response_cache",
+    ):
+        setattr(rag, attr, object())
+    rag._build_global_config = lambda: {}
+
+    async def _insert_done():
+        return None
+
+    rag._insert_done = _insert_done
+
+    lock = asyncio.Lock()
+
+    async def fake_namespace_data(name, workspace=None):
+        return status
+
+    def fake_namespace_lock(name, workspace=None):
+        return lock
+
+    async def fake_merge(**kwargs):
+        return None
+
+    monkeypatch.setattr(lightrag_module, "get_namespace_data", fake_namespace_data)
+    monkeypatch.setattr(lightrag_module, "get_namespace_lock", fake_namespace_lock)
+    monkeypatch.setattr(lightrag_module, "merge_nodes_and_edges", fake_merge)
+    return rag
+
+
+@pytest.mark.asyncio
+async def test_custom_chunks_rejects_when_pipeline_busy(monkeypatch):
+    """ainsert_custom_chunks writes the KG (Stage 3), so it must not run while
+    the pipeline is busy — a second concurrent merger would double LLM
+    concurrency and desync status/cancellation. It must reject, and neither
+    extract nor merge may run."""
+    status = {"busy": True, "history_messages": []}
+    rag = _custom_chunks_rag(monkeypatch, status)
+
+    called = {"extract": False, "merge": False}
+
+    async def _process_extract_entities(chunks, ps=None, pl=None):
+        called["extract"] = True
+        return [({"E": [{"entity_name": "E"}]}, {})]
+
+    import lightrag.lightrag as lightrag_module
+
+    async def fake_merge(**kwargs):
+        called["merge"] = True
+
+    rag._process_extract_entities = _process_extract_entities
+    monkeypatch.setattr(lightrag_module, "merge_nodes_and_edges", fake_merge)
+
+    with pytest.raises(RuntimeError, match="busy"):
+        await rag.ainsert_custom_chunks("full text", ["chunk text"], doc_id="doc-b")
+
+    assert called["extract"] is False
+    assert called["merge"] is False
+    # The pre-existing busy holder's flag must be left untouched.
+    assert status["busy"] is True
+
+
+@pytest.mark.asyncio
+async def test_custom_chunks_holds_busy_during_and_releases_after(monkeypatch):
+    """ainsert_custom_chunks must hold ``busy`` for the whole extract+merge so a
+    concurrent pipeline sees it, and release it afterwards. A request_pending
+    that arrived while busy is drained on release."""
+    status = {"busy": False, "history_messages": [], "request_pending": False}
+    rag = _custom_chunks_rag(monkeypatch, status)
+
+    observed = {}
+
+    async def _process_extract_entities(chunks, ps=None, pl=None):
+        observed["busy_during_extract"] = status["busy"]
+        # Simulate a concurrent enqueue arriving while we hold busy.
+        status["request_pending"] = True
+        return [({"E": [{"entity_name": "E"}]}, {})]
+
+    drained = {"called": False}
+
+    async def _drain():
+        drained["called"] = True
+
+    rag._process_extract_entities = _process_extract_entities
+    rag.apipeline_process_enqueue_documents = _drain
+
+    await rag.ainsert_custom_chunks("full text", ["chunk text"], doc_id="doc-h")
+
+    assert observed["busy_during_extract"] is True  # held during the work
+    assert status["busy"] is False  # released afterwards
+    assert status["request_pending"] is False  # drained
+    assert drained["called"] is True  # processing nudged for the queued docs

--- a/tests/pipeline/test_document_file_path_normalization.py
+++ b/tests/pipeline/test_document_file_path_normalization.py
@@ -428,10 +428,12 @@ async def test_custom_chunks_rejects_when_pipeline_busy(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_custom_chunks_holds_busy_during_and_releases_after(monkeypatch):
-    """ainsert_custom_chunks must hold ``busy`` for the whole extract+merge so a
-    concurrent pipeline sees it, and release it afterwards. A request_pending
-    that arrived while busy triggers a best-effort drain on release."""
+async def test_custom_chunks_hands_off_busy_atomically(monkeypatch):
+    """A request_pending that arrived while custom-chunks held busy is handed
+    off to processing WITHOUT ever dropping busy to False first — otherwise a
+    clear/delete/scan reservation could start in the gap and drop the accepted
+    doc. The handoff must run with _holding_busy=True while busy is still True,
+    and the (real) processing run releases busy atomically."""
     status = {"busy": False, "history_messages": [], "request_pending": False}
     rag = _custom_chunks_rag(monkeypatch, status)
 
@@ -443,13 +445,16 @@ async def test_custom_chunks_holds_busy_during_and_releases_after(monkeypatch):
         status["request_pending"] = True
         return [({"E": [{"entity_name": "E"}]}, {})]
 
-    drained = {"called": False}
+    drained = {}
 
-    async def _drain():
+    async def _drain(_holding_busy=False):
         drained["called"] = True
-        # The real apipeline_process_enqueue_documents clears request_pending
-        # atomically when it re-acquires busy; model that here.
+        drained["holding_busy"] = _holding_busy
+        # The slot must NOT have been released before handing off (no window).
+        drained["busy_at_handoff"] = status["busy"]
+        # The real run consumes request_pending and releases busy at its exit.
         status["request_pending"] = False
+        status["busy"] = False
 
     rag._process_extract_entities = _process_extract_entities
     rag.apipeline_process_enqueue_documents = _drain
@@ -457,20 +462,23 @@ async def test_custom_chunks_holds_busy_during_and_releases_after(monkeypatch):
     await rag.ainsert_custom_chunks("full text", ["chunk text"], doc_id="doc-h")
 
     assert observed["busy_during_extract"] is True  # held during the work
-    assert status["busy"] is False  # released afterwards
-    assert drained["called"] is True  # processing nudged for the queued docs
-    assert status["request_pending"] is False  # consumed by the drain
+    assert drained["called"] is True  # queued docs handed off
+    assert drained["holding_busy"] is True  # atomic handoff, not a fresh acquire
+    assert drained["busy_at_handoff"] is True  # busy never dropped before handoff
+    assert status["request_pending"] is False  # consumed by the handoff
+    assert status["busy"] is False  # released by the handoff run
 
 
 @pytest.mark.asyncio
 async def test_custom_chunks_releases_busy_without_pending(monkeypatch):
-    """With no request_pending, the busy slot is released and no drain runs."""
+    """With no request_pending, the busy slot is released directly and no
+    handoff runs."""
     status = {"busy": False, "history_messages": [], "request_pending": False}
     rag = _custom_chunks_rag(monkeypatch, status)
 
     drained = {"called": False}
 
-    async def _drain():
+    async def _drain(_holding_busy=False):
         drained["called"] = True
 
     async def _process_extract_entities(chunks, ps=None, pl=None):
@@ -482,6 +490,7 @@ async def test_custom_chunks_releases_busy_without_pending(monkeypatch):
     await rag.ainsert_custom_chunks("full text", ["chunk text"], doc_id="doc-np")
 
     assert status["busy"] is False
+    assert drained["called"] is False
     assert drained["called"] is False
 
 

--- a/tests/pipeline/test_pipeline_release_closure.py
+++ b/tests/pipeline/test_pipeline_release_closure.py
@@ -1339,6 +1339,40 @@ def test_enqueue_status_upsert_failure_survives_wake_failure(
 
 
 @pytest.mark.offline
+def test_process_enqueue_holding_busy_releases_when_no_docs(tmp_path):
+    """apipeline_process_enqueue_documents(_holding_busy=True) takes over an
+    already-held busy slot instead of treating busy=True as "someone else is
+    running", and releases it when there is nothing to process. This is the
+    handoff ainsert_custom_chunks uses to drain a request_pending atomically; it
+    must never leave the pipeline wedged as busy on the empty path.
+    """
+
+    async def _run():
+        from lightrag.kg.shared_storage import (
+            get_namespace_data,
+            get_namespace_lock,
+        )
+
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+        try:
+            pipeline_status = await get_namespace_data(
+                "pipeline_status", workspace=rag.workspace
+            )
+            lock = get_namespace_lock("pipeline_status", workspace=rag.workspace)
+            async with lock:
+                pipeline_status["busy"] = True  # simulate a handed-off slot
+
+            # No pending docs in a fresh rag: the handoff must release the slot.
+            await rag.apipeline_process_enqueue_documents(_holding_busy=True)
+            assert pipeline_status.get("busy") is False
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
 def test_atomic_release_busy_or_consume_pending(tmp_path):
     """The loop-exit handoff is atomic via
     ``_atomic_release_busy_or_consume_pending``: the same critical


### PR DESCRIPTION
## What / Why

Follow-up to #3394. That PR made `ainsert_custom_chunks` build the KG (Stage 3 merge), but — unlike the file pipeline (`apipeline_process_enqueue_documents`) and `ainsert` — it **neither checks nor holds `pipeline_status["busy"]`**. So it can run its full extract+merge **concurrently** with the processing loop, a destructive clear/delete, or another custom-chunks insert, violating the single-writer contract.

This is **not a data-corruption bug** — `merge_nodes_and_edges` serializes graph writes with per-entity `get_storage_keyed_lock`, and reprocess merges are idempotent (#3395/#3399). But a second concurrent merger still:
- **doubles LLM concurrency** past `llm_model_max_async` (each merge builds its own semaphore),
- makes `pipeline_status` **misreport idle** (a concurrent file-pipeline trigger starts anyway), and
- shares the `cancellation_requested` flag → **cross-cancellation** between unrelated work.

## How

Reserve the busy slot before extraction, mirroring `_acquire_destructive_busy`:
- under `pipeline_status_lock`, **reject (raise)** if `busy`/`scanning` (`destructive_busy` implies `busy`, so a running clear/delete is covered);
- hold `busy` through extract+merge;
- release it in a `finally` that runs **even if the flush raises**, so the pipeline never wedges as busy;
- drain a `request_pending` that arrived while busy so a concurrent enqueue's PENDING docs are not stranded.

## Test

Two new tests (`reject-when-busy`, `hold-busy-during/release-after`), both of which **fail before the fix**; existing custom-chunks tests updated to a real `asyncio` lock (the path now enters `async with pipeline_status_lock`). Local: file green, `ruff check` + `ruff format --check` clean.

Related: #3394, #3352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)