### PR TITLE
fix: expose thinking token budget in role config

### DIFF
--- a/lightrag/llm_roles.py
+++ b/lightrag/llm_roles.py
@@ -114,6 +114,7 @@ class _RoleLLMMixin:
         "auth",
         "session",
     )
+    _SAFE_PROVIDER_OPTION_KEYS = {"thinking_token_budget"}
 
     @staticmethod
     def _normalize_llm_role(role: str) -> str:
@@ -443,6 +444,8 @@ class _RoleLLMMixin:
     @classmethod
     def _is_secret_key(cls, key: str) -> bool:
         lowered = key.lower()
+        if lowered in cls._SAFE_PROVIDER_OPTION_KEYS:
+            return False
         return any(marker in lowered for marker in cls._SECRET_MARKERS)
 
     def _scrubbed_llm_metadata(self, metadata: dict[str, Any]) -> dict[str, Any]:

--- a/tests/llm/test_llm_role_runtime.py
+++ b/tests/llm/test_llm_role_runtime.py
@@ -336,6 +336,7 @@ def test_role_llm_config_logs_once_on_init_with_metadata(
                         "provider_options": {
                             "temperature": 0.1,
                             "token": "nested-token",
+                            "thinking_token_budget": 2000,
                         },
                         "bedrock_aws_options": {
                             "region_name": "us-east-1",
@@ -352,6 +353,8 @@ def test_role_llm_config_logs_once_on_init_with_metadata(
     assert snapshot["host"] == "https://api.example.com/v1"
     assert snapshot["max_async"] == 7
     assert snapshot["timeout"] == 42
+    assert snapshot["metadata"]["provider_options"]["thinking_token_budget"] == 2000
+    assert "token" not in snapshot["metadata"]["provider_options"]
 
     headers = _role_config_headers(caplog)
     assert len(headers) == 1


### PR DESCRIPTION
## Description

`thinking_token_budget` was removed from the sanitized role configuration because its name contains `token`, making startup logs incorrectly show that the vLLM sampling option was ignored. This preserves that exact non-secret option while continuing to strip real token fields.

## Related Issues

Fixes #3404

## Changes Made

- Allow `thinking_token_budget` in sanitized provider options.
- Cover the safe option and an actual secret `token` together in the regression test.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

`tests/llm/test_llm_role_runtime.py`: 35 passed; Ruff check and format passed.
