### PR TITLE
feat(shared-storage): dead-worker recovery for multiprocess keyed locks

### DIFF
--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -1670,6 +1670,15 @@ def _process_alive(pid: Optional[int], start_id: Optional[str]) -> bool:
     if pid is None:
         return True  # no owner identity recorded → cannot declare dead
     if pid == os.getpid():
+        # Our own PID. Genuinely us only if the recorded start id matches ours:
+        # a record carrying our PID but a DIFFERENT start id was written by a
+        # dead predecessor whose PID the OS reused for us — that owner is dead,
+        # so we must NOT treat the lease as "still alive (me)" or it would never
+        # be reclaimed. If either start id is unknown (non-Linux / no /proc), we
+        # cannot confirm reuse and conservatively report alive.
+        mine = _my_start_id()
+        if start_id is not None and mine is not None and start_id != mine:
+            return False
         return True
     if not _pid_alive(pid):
         return False

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -2,6 +2,7 @@ import os
 import sys
 import asyncio
 import multiprocessing as mp
+import random
 import uuid
 from multiprocessing.synchronize import Lock as ProcessLock
 from multiprocessing import Manager
@@ -66,10 +67,18 @@ _workers = None
 _manager = None
 
 # Global singleton data for multi-process keyed locks
-_lock_registry: Optional[Dict[str, mp.synchronize.Lock]] = None
+_lock_registry: Optional[Dict[str, Any]] = None
 _lock_registry_count: Optional[Dict[str, int]] = None
 _lock_cleanup_data: Optional[Dict[str, time.time]] = None
 _registry_guard = None
+# Holder records for multi-process keyed locks (dead-worker recovery). Maps a
+# combined key to {owner_pid, process_start_id, lease_id} while the lock is held;
+# the record IS the lock (replaces manager.Lock()), so a SIGKILLed holder can be
+# reclaimed by a live worker instead of deadlocking every process.
+_keyed_lock_holders: Optional[Dict[str, Any]] = None
+# Keyed-lock lease poll backoff bounds (seconds).
+_KEYED_LEASE_POLL_BASE = 0.02
+_KEYED_LEASE_POLL_MAX = 0.5
 # Timeout for keyed locks in seconds (Default 300)
 CLEANUP_KEYED_LOCKS_AFTER_SECONDS = 300
 # Cleanup pending list threshold for triggering cleanup (Default 500)
@@ -182,6 +191,7 @@ class UnifiedLock(Generic[T]):
         name: str = "unnamed",
         enable_logging: bool = True,
         async_lock: Optional[asyncio.Lock] = None,
+        mp_is_lease: bool = False,
     ):
         self._lock = lock
         self._is_async = is_async
@@ -189,6 +199,10 @@ class UnifiedLock(Generic[T]):
         self._name = name  # for debug only
         self._enable_logging = enable_logging  # for debug only
         self._async_lock = async_lock  # auxiliary lock for coroutine synchronization
+        # When True, ``_lock`` is a _KeyedLeaseLock whose acquire() is an async
+        # holder-record poll (dead-only reclaim) rather than a blocking
+        # manager.Lock() acquire offloaded to an executor thread.
+        self._mp_is_lease = mp_is_lease
 
     async def _acquire_mp_lock_in_executor(self) -> None:
         """Acquire the multiprocess lock without blocking the event loop.
@@ -233,6 +247,12 @@ class UnifiedLock(Generic[T]):
             # Note: self._lock should never be None here as the check has been moved
             # to get_internal_lock() and get_data_init_lock() functions
             if self._is_async:
+                await self._lock.acquire()
+            elif self._mp_is_lease:
+                # Holder-record lease: an async poll that reclaims a confirmed-
+                # dead owner's lease and never blocks the event loop (no executor
+                # thread). The async gate above already caps this process to one
+                # poller per key.
                 await self._lock.acquire()
             else:
                 # A Manager lock proxy blocks the calling thread until every
@@ -341,7 +361,7 @@ class UnifiedLock(Generic[T]):
     def __enter__(self) -> "UnifiedLock[T]":
         """For backward compatibility"""
         try:
-            if self._is_async:
+            if self._is_async or self._mp_is_lease:
                 raise RuntimeError("Use 'async with' for shared_storage lock")
 
             # Acquire the main lock
@@ -524,10 +544,90 @@ def _perform_lock_cleanup(
         return 0, earliest_cleanup_time, last_cleanup_time
 
 
+def _keyed_lease_backoff(attempt: int) -> float:
+    """Exponential backoff with jitter for the keyed-lock lease poll.
+
+    The per-process async gate already caps concurrent pollers to one per process
+    per key, so this only spaces out *cross-process* contention; jitter avoids a
+    thundering herd when a lease is released."""
+    base = min(_KEYED_LEASE_POLL_MAX, _KEYED_LEASE_POLL_BASE * (2 ** min(attempt, 5)))
+    return base * (0.5 + random.random() * 0.5)
+
+
+class _KeyedLeaseLock:
+    """Multiprocess keyed lock backed by a holder record, not a manager.Lock().
+
+    The record IS the lock: acquiring writes
+    ``_keyed_lock_holders[combined_key] = {owner_pid, process_start_id,
+    lease_id}`` under ``_registry_guard`` (a single manager.dict write, atomic);
+    releasing pops it iff we still own ``lease_id``. A record whose owner process
+    is *confirmed dead* (:func:`_process_alive` — PID gone or start-id mismatch)
+    is reclaimed lazily on the next acquire, so a SIGKILLed holder can no longer
+    deadlock every other worker. Dead-only: a live (merely slow) owner is never
+    preempted, so no fencing token is needed.
+
+    Per-process, per-acquire — each instance holds its own ``lease_id``; the only
+    shared state is ``_keyed_lock_holders``. The liveness probe runs OUTSIDE the
+    guard so ``os.kill`` / ``/proc`` reads never widen the (otherwise µs-scale)
+    guard window.
+    """
+
+    __slots__ = ("_combined_key", "_lease_id")
+
+    def __init__(self, combined_key: str) -> None:
+        self._combined_key = combined_key
+        self._lease_id: Optional[str] = None
+
+    async def acquire(self) -> None:
+        attempt = 0
+        while True:
+            with _registry_guard:
+                holder = _keyed_lock_holders.get(self._combined_key)
+                if holder is None:
+                    lease_id = uuid.uuid4().hex
+                    _keyed_lock_holders[self._combined_key] = {
+                        "owner_pid": os.getpid(),
+                        "process_start_id": _my_start_id(),
+                        "lease_id": lease_id,
+                    }
+                    self._lease_id = lease_id
+                    return
+                snap = dict(holder)
+            # Probe liveness outside the guard (os.kill / /proc can be slow).
+            if not _process_alive(snap.get("owner_pid"), snap.get("process_start_id")):
+                with _registry_guard:
+                    cur = _keyed_lock_holders.get(self._combined_key)
+                    # Recheck the SAME lease_id so a holder that changed between
+                    # the probe and the reclaim is never clobbered.
+                    if cur is not None and cur.get("lease_id") == snap.get("lease_id"):
+                        _keyed_lock_holders.pop(self._combined_key, None)
+                continue  # retry the claim immediately
+            # Live owner → back off (this is the only cancellation point; no
+            # lease is held here, so a cancel simply abandons the wait).
+            await asyncio.sleep(_keyed_lease_backoff(attempt))
+            attempt += 1
+
+    def release(self) -> None:
+        lease_id = self._lease_id
+        if lease_id is None:
+            return
+        self._lease_id = None
+        with _registry_guard:
+            holder = _keyed_lock_holders.get(self._combined_key)
+            if holder is not None and holder.get("lease_id") == lease_id:
+                _keyed_lock_holders.pop(self._combined_key, None)
+
+
 def _get_or_create_shared_raw_mp_lock(
     factory_name: str, key: str
-) -> Optional[mp.synchronize.Lock]:
-    """Return the *singleton* manager.Lock() proxy for keyed lock, creating if needed."""
+) -> Optional["_KeyedLeaseLock"]:
+    """Return a fresh holder-lease lock for a keyed lock (multiprocess only).
+
+    Refcount + idle-cleanup bookkeeping is preserved (``_lock_registry`` now holds
+    a presence sentinel rather than a manager.Lock); the actual mutual exclusion
+    lives in ``_keyed_lock_holders`` via :class:`_KeyedLeaseLock`. A FRESH lease
+    object is returned per call — each acquisition owns its own ``lease_id``.
+    """
     if not _is_multiprocess:
         return None
 
@@ -536,8 +636,7 @@ def _get_or_create_shared_raw_mp_lock(
         raw = _lock_registry.get(combined_key)
         count = _lock_registry_count.get(combined_key)
         if raw is None:
-            raw = _manager.Lock()
-            _lock_registry[combined_key] = raw
+            _lock_registry[combined_key] = True  # presence sentinel (bookkeeping)
             count = 0
         else:
             if count is None:
@@ -550,7 +649,7 @@ def _get_or_create_shared_raw_mp_lock(
                 _lock_cleanup_data.pop(combined_key)
         count += 1
         _lock_registry_count[combined_key] = count
-        return raw
+        return _KeyedLeaseLock(combined_key)
 
 
 def _release_shared_raw_mp_lock(factory_name: str, key: str):
@@ -721,10 +820,11 @@ class KeyedUnifiedLock:
         if is_multiprocess:
             return UnifiedLock(
                 lock=raw_lock,
-                is_async=False,  # manager.Lock is synchronous
+                is_async=False,  # holder-lease acquire is driven explicitly
                 name=combined_key,
                 enable_logging=enable_logging,
                 async_lock=async_lock,  # prevents event‑loop blocking
+                mp_is_lease=True,  # raw_lock is a _KeyedLeaseLock (async poll)
             )
         else:
             return UnifiedLock(
@@ -1324,6 +1424,7 @@ def initialize_share_data(
         _lock_registry_count, \
         _lock_cleanup_data, \
         _registry_guard, \
+        _keyed_lock_holders, \
         _internal_lock, \
         _data_init_lock, \
         _shared_dicts, \
@@ -1370,6 +1471,7 @@ def initialize_share_data(
         _lock_registry_count = _manager.dict()
         _lock_cleanup_data = _manager.dict()
         _registry_guard = _manager.RLock()
+        _keyed_lock_holders = _manager.dict()
         _internal_lock = _manager.Lock()
         _data_init_lock = _manager.Lock()
         _shared_dicts = _manager.dict()
@@ -1392,6 +1494,7 @@ def initialize_share_data(
         _is_multiprocess = False
         _internal_lock = asyncio.Lock()
         _data_init_lock = asyncio.Lock()
+        _keyed_lock_holders = None  # multiprocess-only; unused single-process
         _shared_dicts = {}
         _init_flags = {}
         _update_flags = {}
@@ -1509,14 +1612,72 @@ async def initialize_pipeline_status(workspace: str | None = None):
 # so this module is self-contained and behaves as "no dead-owner reclaim".
 
 
-def _my_start_id() -> Optional[str]:
-    """Opaque per-process start identifier used to detect PID reuse.
+_MY_START_ID_CACHE: Optional[str] = None
+_MY_START_ID_COMPUTED: bool = False
 
-    Filled in by the dead-process recovery layer (Linux ``/proc`` start time).
-    Here it is a placeholder so callers can store it harmlessly; ``None`` where
-    dead-owner reclaim is not active.
+
+def _read_proc_starttime(pid: int) -> Optional[str]:
+    """Return a stable per-process start token (field 22 of ``/proc/<pid>/stat``)
+    used to detect PID reuse, or ``None`` when unavailable (non-Linux, the
+    process is gone, or the stat file is unreadable).
+
+    A live PID whose start time differs from a previously recorded token is a
+    DIFFERENT process that reused the PID. ``None`` means "cannot tell" — callers
+    must treat that as *not reused* so a live owner is never reclaimed.
     """
-    return None
+    if not sys.platform.startswith("linux"):
+        return None
+    try:
+        with open(f"/proc/{pid}/stat", "rb") as fh:
+            data = fh.read()
+    except (FileNotFoundError, ProcessLookupError):
+        return None  # process is gone (liveness is decided by _pid_alive)
+    except OSError:
+        return None  # unreadable → unknown, make no reuse claim
+    try:
+        # comm (field 2) is wrapped in parentheses and may itself contain spaces
+        # or ')' — everything after the LAST ')' is the space-separated tail
+        # starting at field 3 (state). starttime is field 22 → tail index 19.
+        rparen = data.rindex(b")")
+        tail = data[rparen + 1 :].split()
+        return tail[19].decode("ascii")
+    except (ValueError, IndexError):
+        return None
+
+
+def _my_start_id() -> Optional[str]:
+    """This process's start token (see :func:`_read_proc_starttime`), computed
+    once and cached. ``None`` on non-Linux / when ``/proc`` is unavailable, in
+    which case PID-reuse detection is disabled (dead-only reclaim still works via
+    :func:`_pid_alive`)."""
+    global _MY_START_ID_CACHE, _MY_START_ID_COMPUTED
+    if not _MY_START_ID_COMPUTED:
+        _MY_START_ID_CACHE = _read_proc_starttime(os.getpid())
+        _MY_START_ID_COMPUTED = True
+    return _MY_START_ID_CACHE
+
+
+def _process_alive(pid: Optional[int], start_id: Optional[str]) -> bool:
+    """Dead-only liveness for lock / reservation owners.
+
+    Returns ``False`` ONLY when the owner is *confirmed* dead: the PID is gone,
+    or the PID is alive but its start time differs from ``start_id`` (PID reuse =
+    a different process now holds that PID). Every uncertainty — no recorded
+    identity, no permission to probe, non-Linux, unreadable ``/proc`` — is
+    treated as ALIVE, so a live (merely slow) owner is never reclaimed. Shared by
+    the keyed-lock and pipeline-reservation dead-owner reclaim layers.
+    """
+    if pid is None:
+        return True  # no owner identity recorded → cannot declare dead
+    if pid == os.getpid():
+        return True
+    if not _pid_alive(pid):
+        return False
+    if start_id is not None:
+        current = _read_proc_starttime(pid)
+        if current is not None and current != start_id:
+            return False  # PID reused by a different process
+    return True
 
 
 def reconcile_dead_pipeline_reservations(pipeline_status: Dict[str, Any]) -> None:

--- a/tests/kg/test_keyed_lock_dead_worker_recovery.py
+++ b/tests/kg/test_keyed_lock_dead_worker_recovery.py
@@ -14,6 +14,7 @@ holder records.
 """
 
 import asyncio
+import os
 import subprocess
 import sys
 
@@ -167,24 +168,32 @@ async def test_lease_release_is_owner_checked():
 @pytest.mark.offline
 async def test_lease_reclaims_on_pid_reuse():
     """A live PID whose start time differs from the recorded one is a DIFFERENT
-    process that reused the PID → reclaim."""
+    process that reused the PID → reclaim.
+
+    The recorded PID must be another live process, NOT our own: _process_alive
+    short-circuits ``pid == os.getpid()`` to alive (a process is always alive to
+    itself), so a self-PID record could never look reused.
+    """
     finalize_share_data()
     initialize_share_data(2)
+    # A live OTHER process whose recorded start id is wrong = a different process
+    # reused this PID.
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
     try:
-        import os
-
         key = _get_combined_key("ns", "reuse")
-        # Our PID is alive, but the recorded start id is wrong → PID reuse.
         _holders()[key] = {
-            "owner_pid": os.getpid(),
-            "process_start_id": "definitely-not-our-start-time",
+            "owner_pid": proc.pid,
+            "process_start_id": "definitely-not-its-real-start-time",
             "lease_id": "stale",
         }
-        async with asyncio.timeout(2):
+        async with asyncio.timeout(5):
             async with get_storage_keyed_lock("reuse", namespace="ns"):
-                assert _holders()[key]["lease_id"] != "stale"
+                assert _holders()[key]["lease_id"] != "stale"  # reclaimed by us
+                assert _holders()[key]["owner_pid"] == os.getpid()
         assert key not in _holders()
     finally:
+        proc.kill()
+        proc.wait()
         finalize_share_data()
 
 

--- a/tests/kg/test_keyed_lock_dead_worker_recovery.py
+++ b/tests/kg/test_keyed_lock_dead_worker_recovery.py
@@ -161,39 +161,51 @@ async def test_lease_release_is_owner_checked():
         finalize_share_data()
 
 
+def test_process_alive_detects_self_pid_reuse(monkeypatch):
+    """_process_alive must NOT blindly treat a record carrying our own PID as
+    alive: a dead predecessor whose PID the OS reused for us leaves a record with
+    our PID but a different start id, and reporting it alive would wedge the lock
+    forever (no other worker competes for the key). This is the exact deadlock a
+    naive ``pid == os.getpid() -> True`` short-circuit causes. Monkeypatching
+    ``_my_start_id`` exercises the branch without needing real /proc reuse."""
+    monkeypatch.setattr(shared_storage, "_my_start_id", lambda: "our-start-id")
+    mypid = os.getpid()
+    # Same PID, DIFFERENT start id = a dead predecessor that reused our PID.
+    assert shared_storage._process_alive(mypid, "predecessor-start-id") is False
+    # Same PID + matching start id = genuinely us → alive.
+    assert shared_storage._process_alive(mypid, "our-start-id") is True
+    # Same PID, no recorded start id = cannot confirm reuse → conservatively alive.
+    assert shared_storage._process_alive(mypid, None) is True
+    # Our start id unknown (non-Linux) = cannot confirm reuse → alive.
+    monkeypatch.setattr(shared_storage, "_my_start_id", lambda: None)
+    assert shared_storage._process_alive(mypid, "predecessor-start-id") is True
+
+
 @pytest.mark.skipif(
     not sys.platform.startswith("linux"),
     reason="PID-reuse detection needs Linux /proc start time",
 )
 @pytest.mark.offline
-async def test_lease_reclaims_on_pid_reuse():
-    """A live PID whose start time differs from the recorded one is a DIFFERENT
-    process that reused the PID → reclaim.
-
-    The recorded PID must be another live process, NOT our own: _process_alive
-    short-circuits ``pid == os.getpid()`` to alive (a process is always alive to
-    itself), so a self-PID record could never look reused.
-    """
+async def test_lease_reclaims_on_self_pid_reuse():
+    """The real dead-worker-with-PID-reuse deadlock: the reclaiming worker was
+    handed the dead owner's very PID by the OS. The stale holder therefore
+    carries OUR pid but the predecessor's start id — the lease must still be
+    reclaimed (our start id differs from the recorded one)."""
     finalize_share_data()
     initialize_share_data(2)
-    # A live OTHER process whose recorded start id is wrong = a different process
-    # reused this PID.
-    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
     try:
         key = _get_combined_key("ns", "reuse")
+        # Our PID, but a start id that is not ours = we reused a dead worker's PID.
         _holders()[key] = {
-            "owner_pid": proc.pid,
-            "process_start_id": "definitely-not-its-real-start-time",
+            "owner_pid": os.getpid(),
+            "process_start_id": "predecessor-start-id",
             "lease_id": "stale",
         }
         async with asyncio.timeout(5):
             async with get_storage_keyed_lock("reuse", namespace="ns"):
                 assert _holders()[key]["lease_id"] != "stale"  # reclaimed by us
-                assert _holders()[key]["owner_pid"] == os.getpid()
         assert key not in _holders()
     finally:
-        proc.kill()
-        proc.wait()
         finalize_share_data()
 
 

--- a/tests/kg/test_keyed_lock_dead_worker_recovery.py
+++ b/tests/kg/test_keyed_lock_dead_worker_recovery.py
@@ -1,0 +1,234 @@
+"""Layer-2 dead-worker recovery for multiprocess keyed locks.
+
+The multiprocess keyed lock is backed by a holder record in
+``_keyed_lock_holders`` (``{owner_pid, process_start_id, lease_id}``) instead of
+a ``manager.Lock()``. A SIGKILLed holder used to leave the manager mutex locked
+forever, deadlocking every other worker; now the record is reclaimed lazily on
+the next acquire IFF the owner process is *confirmed dead* (PID gone, or a
+Linux ``/proc`` start-time mismatch = PID reuse). A live-but-slow owner is never
+preempted (dead-only), so no fencing token is needed.
+
+These tests run with real multiprocess shared data (``initialize_share_data(2)``
+creates a Manager) and drive the reclaim paths deterministically by seeding
+holder records.
+"""
+
+import asyncio
+import subprocess
+import sys
+
+import pytest
+
+import lightrag.kg.shared_storage as shared_storage
+from lightrag.kg.shared_storage import (
+    _get_combined_key,
+    _my_start_id,
+    _pid_alive,
+    finalize_share_data,
+    get_storage_keyed_lock,
+    initialize_share_data,
+)
+
+pytestmark = pytest.mark.offline
+
+
+def _holders():
+    return shared_storage._keyed_lock_holders
+
+
+def _dead_pid() -> int:
+    """A confirmed-dead PID: spawn a child, SIGKILL it, reap it."""
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+    pid = proc.pid
+    proc.kill()
+    proc.wait()
+    return pid
+
+
+@pytest.mark.offline
+async def test_lease_records_and_releases_holder():
+    finalize_share_data()
+    initialize_share_data(2)
+    try:
+        key = _get_combined_key("ns", "k")
+        assert key not in _holders()
+
+        async with get_storage_keyed_lock("k", namespace="ns"):
+            rec = _holders().get(key)
+            assert rec is not None
+            import os
+
+            assert rec["owner_pid"] == os.getpid()
+            assert rec["lease_id"]  # a lease id was stamped
+
+        # Released → holder record popped.
+        assert key not in _holders()
+    finally:
+        finalize_share_data()
+
+
+@pytest.mark.offline
+async def test_lease_reclaims_confirmed_dead_holder():
+    """The core guarantee: a holder whose owner was SIGKILLed is reclaimed by the
+    next acquirer instead of deadlocking it."""
+    finalize_share_data()
+    initialize_share_data(2)
+    try:
+        key = _get_combined_key("ns", "dead")
+        dead = _dead_pid()
+        assert _pid_alive(dead) is False
+
+        # Seed a stale holder as if a now-dead worker still held the lock.
+        _holders()[key] = {
+            "owner_pid": dead,
+            "process_start_id": "gone",
+            "lease_id": "stale",
+        }
+
+        # Must acquire promptly (reclaim), not deadlock.
+        async with asyncio.timeout(2):
+            async with get_storage_keyed_lock("dead", namespace="ns"):
+                rec = _holders().get(key)
+                import os
+
+                assert rec["owner_pid"] == os.getpid()  # reclaimed by us
+                assert rec["lease_id"] != "stale"
+
+        assert key not in _holders()
+    finally:
+        finalize_share_data()
+
+
+@pytest.mark.offline
+async def test_lease_does_not_reclaim_live_owner():
+    """A live (merely slow) owner must NEVER be reclaimed — dead-only."""
+    finalize_share_data()
+    initialize_share_data(2)
+    try:
+        import os
+
+        key = _get_combined_key("ns", "live")
+        # A live owner: our own PID + matching start id, but a DIFFERENT lease
+        # (as if another coroutine/process legitimately holds it).
+        _holders()[key] = {
+            "owner_pid": os.getpid(),
+            "process_start_id": _my_start_id(),
+            "lease_id": "held-by-someone-else",
+        }
+
+        async def _try_acquire():
+            async with get_storage_keyed_lock("live", namespace="ns"):
+                pass
+
+        # The acquire must keep polling (never reclaim a live owner) → times out.
+        with pytest.raises((asyncio.TimeoutError, TimeoutError)):
+            await asyncio.wait_for(_try_acquire(), timeout=0.5)
+
+        # The live owner's record is untouched.
+        assert _holders().get(key, {}).get("lease_id") == "held-by-someone-else"
+        _holders().pop(key, None)  # cleanup
+    finally:
+        finalize_share_data()
+
+
+@pytest.mark.offline
+async def test_lease_release_is_owner_checked():
+    """Releasing must only pop OUR lease — a record taken over by a new owner
+    (after a reclaim) must not be clobbered by a stale releaser."""
+    finalize_share_data()
+    initialize_share_data(2)
+    try:
+        import os
+
+        key = _get_combined_key("ns", "ownercheck")
+        lock = get_storage_keyed_lock("ownercheck", namespace="ns")
+        await lock.__aenter__()
+        assert _holders()[key]["owner_pid"] == os.getpid()
+
+        # Simulate a new owner taking the slot while we still think we hold it.
+        _holders()[key] = {
+            "owner_pid": os.getpid(),
+            "process_start_id": _my_start_id(),
+            "lease_id": "new-owner",
+        }
+
+        # Our release is owner-checked by lease_id → must NOT pop the new owner.
+        await lock.__aexit__(None, None, None)
+        assert _holders().get(key, {}).get("lease_id") == "new-owner"
+        _holders().pop(key, None)  # cleanup
+    finally:
+        finalize_share_data()
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="PID-reuse detection needs Linux /proc start time",
+)
+@pytest.mark.offline
+async def test_lease_reclaims_on_pid_reuse():
+    """A live PID whose start time differs from the recorded one is a DIFFERENT
+    process that reused the PID → reclaim."""
+    finalize_share_data()
+    initialize_share_data(2)
+    try:
+        import os
+
+        key = _get_combined_key("ns", "reuse")
+        # Our PID is alive, but the recorded start id is wrong → PID reuse.
+        _holders()[key] = {
+            "owner_pid": os.getpid(),
+            "process_start_id": "definitely-not-our-start-time",
+            "lease_id": "stale",
+        }
+        async with asyncio.timeout(2):
+            async with get_storage_keyed_lock("reuse", namespace="ns"):
+                assert _holders()[key]["lease_id"] != "stale"
+        assert key not in _holders()
+    finally:
+        finalize_share_data()
+
+
+@pytest.mark.offline
+async def test_namespace_lock_reclaims_dead_holder():
+    """The pipeline_status lock (NamespaceLock → keyed lock) recovers from a
+    SIGKILLed holder through the full stack (NamespaceLock → _KeyedLockContext →
+    UnifiedLock → holder lease)."""
+    finalize_share_data()
+    initialize_share_data(2)
+    try:
+        import os
+        from lightrag.kg.shared_storage import (
+            get_final_namespace,
+            get_namespace_lock,
+        )
+
+        final_ns = get_final_namespace("pipeline_status", "ws")
+        key = _get_combined_key(final_ns, "default_key")
+        dead = _dead_pid()
+        _holders()[key] = {
+            "owner_pid": dead,
+            "process_start_id": "gone",
+            "lease_id": "stale",
+        }
+
+        lock = get_namespace_lock("pipeline_status", workspace="ws")
+        async with asyncio.timeout(2):
+            async with lock:
+                assert _holders()[key]["owner_pid"] == os.getpid()  # reclaimed
+        assert key not in _holders()
+    finally:
+        finalize_share_data()
+
+
+@pytest.mark.offline
+async def test_single_process_keyed_lock_has_no_holder_records():
+    """Single-process mode keeps the asyncio.Lock path — no holder records, no
+    dead-owner machinery."""
+    finalize_share_data()
+    initialize_share_data(1)
+    try:
+        assert shared_storage._keyed_lock_holders is None
+        async with get_storage_keyed_lock("k", namespace="ns"):
+            pass  # works without any holder-record bookkeeping
+    finally:
+        finalize_share_data()


### PR DESCRIPTION
## Problem

In multiprocess mode (`workers>1`) a keyed lock's underlying mutex is a `manager.Lock()` — an **ownerless, liveness-blind** mutex living in the Manager process. If the worker holding it is **SIGKILLed**, the Manager never notices: the lock stays locked forever and every other worker's `acquire()` **deadlocks**. This is not theoretical — KG entity/edge locks (`get_storage_keyed_lock([entity], namespace="{ws}:GraphDB")`) are held for an entire merge / LLM-extraction, so the kill window is wide.

Single-process mode uses `asyncio.Lock` (dies with the process — no cross-process orphan), so this is a **multiprocess-only** problem. There is no gunicorn per-worker-exit hook to lean on, so recovery must be intrinsic to the lock.

## Fix — holder-record lease (the record IS the lock)

Replace the `manager.Lock()` value with a holder record in a new `_keyed_lock_holders` manager.dict: `{owner_pid, process_start_id, lease_id}`.

- **acquire**: under `_registry_guard`, if unheld, write the record (a single atomic manager.dict write) and return; else snapshot and probe the owner's liveness **outside** the guard, and if the owner is *confirmed dead*, recheck the same `lease_id` and pop it, then retry. Live owner → backoff-poll.
- **release**: pop iff `lease_id` still matches (owner-checked — never clobber a reclaimer/new owner).
- **dead-only reclaim**: `_process_alive(pid, start_id)` returns `False` only when the PID is gone, or (Linux) its `/proc` start time differs from the recorded one (**PID reuse** = a different process). Any uncertainty — no permission, non-Linux, no start id — is treated as **ALIVE**. A live-but-slow owner is therefore never preempted, which is why **no fencing token is needed**: we only ever reclaim from the dead.

`UnifiedLock` gains an `mp_is_lease` path (async poll, no executor thread); the `manager.Lock()` executor path stays for `internal_lock`/`data_init_lock`. **Single-process mode is unchanged**; refcount + idle-cleanup bookkeeping is preserved (`_lock_registry` now stores a presence sentinel).

## Out of scope (unchanged, by design)

- SIGKILL of the holder of `_registry_guard` / `internal_lock` — µs-scale bookkeeping locks, already an unhardened base today; true hardening needs an OS robust mutex or external coordinator.
- Poll fairness under extreme contention (backoff + jitter for now).
- A live-but-**hung** holder of a data lock — stealing it would corrupt data; that's a separate liveness problem.

## Tests

`tests/kg/test_keyed_lock_dead_worker_recovery.py` drives a **real SIGKILLed subprocess PID** plus seeded holder records: reclaim-on-confirmed-dead (incl. the pipeline_status `NamespaceLock` full stack), **no reclaim of a live owner** (times out), owner-checked release, PID-reuse (Linux-only), and single-process-unchanged.

Full offline suite: **3699 passed, 35 skipped**; ruff + ruff-format clean.

## Relation to #3402

Orthogonal to the just-merged #3402 stack (#3407/#3408/#3409), which closed cooperative-cancellation wedges (in-process flags). This closes the cross-process orphaned-lock wedge (process killed). It is also the **mutex-layer prerequisite** for a follow-up pipeline-reservation dead-process recovery layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)