### PR TITLE
feat(core): recoverable document mutations — write-ahead anchors, journaled custom chunks, scan rollback (#3400, all 5 phases)

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -2203,8 +2203,7 @@ async def run_scanning_process(
                 )
             except Exception as rollback_error:
                 logger.error(
-                    "Scan-time custom-chunk rollback failed: "
-                    f"{rollback_error}"
+                    f"Scan-time custom-chunk rollback failed: {rollback_error}"
                 )
 
         new_files = doc_manager.scan_directory_for_new_files()

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -2190,6 +2190,23 @@ async def run_scanning_process(
         except PipelineNotInitializedError:
             pass
 
+        # Roll back failed/stale custom-chunk operations FIRST, while the
+        # classification phase still holds ``scanning_exclusive`` (issue
+        # #3400 Phase 4). Discovery is storage-driven — SDK operations may
+        # have no scan-visible input file — and a failed rollback keeps the
+        # journal/FAILED row for the next scan without aborting this one.
+        if pipeline_status is not None and pipeline_status_lock is not None:
+            try:
+                await rag.arollback_failed_custom_chunk_patches(
+                    pipeline_status=pipeline_status,
+                    pipeline_status_lock=pipeline_status_lock,
+                )
+            except Exception as rollback_error:
+                logger.error(
+                    "Scan-time custom-chunk rollback failed: "
+                    f"{rollback_error}"
+                )
+
         new_files = doc_manager.scan_directory_for_new_files()
         total_files = len(new_files)
         logger.info(f"Found {total_files} files to index.")

--- a/lightrag/exceptions.py
+++ b/lightrag/exceptions.py
@@ -123,6 +123,18 @@ class IndexFlushError(Exception):
         super().__init__(f"{storage_name}[{namespace}] index flush failed: {cause}")
 
 
+class KGRebuildCacheMissingError(Exception):
+    """Raised by strict KG recovery when required extraction cache is absent.
+
+    ``rebuild_knowledge_from_chunks`` normally degrades to a best-effort
+    rebuild when cached extraction results are missing. Recovery paths
+    (purge/retry/rollback for issue #3400) must NOT silently succeed on
+    partial data — a lost cache would otherwise be reported as a clean
+    rebuild and the document could reach a false PROCESSED state. Strict
+    callers get this error instead and keep the document dirty/retryable.
+    """
+
+
 class ChunkTokenLimitExceededError(ValueError):
     """Raised when a chunk exceeds the configured token limit."""
 

--- a/lightrag/exceptions.py
+++ b/lightrag/exceptions.py
@@ -123,18 +123,6 @@ class IndexFlushError(Exception):
         super().__init__(f"{storage_name}[{namespace}] index flush failed: {cause}")
 
 
-class KGRebuildCacheMissingError(Exception):
-    """Raised by strict KG recovery when required extraction cache is absent.
-
-    ``rebuild_knowledge_from_chunks`` normally degrades to a best-effort
-    rebuild when cached extraction results are missing. Recovery paths
-    (purge/retry/rollback for issue #3400) must NOT silently succeed on
-    partial data — a lost cache would otherwise be reported as a clean
-    rebuild and the document could reach a false PROCESSED state. Strict
-    callers get this error instead and keep the document dirty/retryable.
-    """
-
-
 class ChunkTokenLimitExceededError(ValueError):
     """Raised when a chunk exceeds the configured token limit."""
 

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -2219,6 +2219,276 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
 
         await self._flush_storages([self.full_entities, self.full_relations])
 
+    async def arollback_failed_custom_chunk_patches(
+        self,
+        *,
+        pipeline_status: dict | None = None,
+        pipeline_status_lock: Any | None = None,
+    ) -> dict[str, list[str]]:
+        """Roll back every failed/stale custom-chunk operation (issue #3400 P4).
+
+        The administrative escape hatch invoked at the start of
+        ``/documents/scan``: while the SDK caller owns roll-forward (repeating
+        the same call resumes it), scan rolls incomplete operations BACK to
+        the previously committed document state — repeated roll-forward may
+        keep failing, and the journal row would otherwise stay dirty forever.
+
+        Discovers candidates from ``doc_status`` directly (FAILED or stale
+        PROCESSING rows carrying a ``custom_chunk_patch`` journal — SDK
+        operations may have no scan-visible input file). A PROCESSING row is
+        necessarily stale here: a live operation holds the pipeline ``busy``
+        slot, and the scan reservation refuses to start while ``busy``.
+
+        Per document, under the same per-document keyed lock the operations
+        use: staged contributions are removed/rebuilt via the candidate-driven
+        purge primitive (strict rebuild — missing recovery cache fails the
+        rollback rather than producing a false PROCESSED), operation-scoped
+        LLM cache is deleted, anchor unions are pruned where the document no
+        longer owns a contribution, and only then is the journal cleared:
+
+        - ``patch`` mode: the base document is restored to ``PROCESSED``.
+        - ``create`` mode: the document did not exist before the operation,
+          so its remaining rows (``full_docs``, ``doc_status``) are removed.
+
+        A rollback failure keeps the journal and the FAILED status — the next
+        scan retries it. Absent objects are idempotent no-ops, but success is
+        never reported merely because something was already missing.
+
+        Returns ``{"rolled_back": [...], "failed": [...]}`` doc-id lists.
+        """
+        if pipeline_status is None or pipeline_status_lock is None:
+            pipeline_status = await get_namespace_data(
+                "pipeline_status", workspace=self.workspace
+            )
+            pipeline_status_lock = get_namespace_lock(
+                "pipeline_status", workspace=self.workspace
+            )
+
+        candidates = await self.doc_status.get_docs_by_statuses(
+            [DocStatus.FAILED, DocStatus.PROCESSING]
+        )
+        journaled_ids = [
+            doc_id
+            for doc_id, status_doc in candidates.items()
+            if doc_status_custom_chunk_patch(status_doc) is not None
+        ]
+
+        rolled_back: list[str] = []
+        failed: list[str] = []
+        if not journaled_ids:
+            return {"rolled_back": rolled_back, "failed": failed}
+
+        doc_lock_namespace = (
+            f"{self.workspace}:DocPatch" if self.workspace else "DocPatch"
+        )
+        for doc_id in journaled_ids:
+            async with get_storage_keyed_lock(
+                [doc_id], namespace=doc_lock_namespace, enable_logging=False
+            ):
+                # Re-read under the lock: the SDK may have resumed (and
+                # committed) the operation between discovery and here.
+                row = await self.doc_status.get_by_id(doc_id)
+                journal = doc_status_custom_chunk_patch(row)
+                if journal is None:
+                    continue
+                try:
+                    await self._rollback_one_custom_chunk_patch(
+                        doc_id,
+                        row,
+                        journal,
+                        pipeline_status=pipeline_status,
+                        pipeline_status_lock=pipeline_status_lock,
+                    )
+                    rolled_back.append(doc_id)
+                    log_message = (
+                        f"[rollback] Rolled back custom-chunk operation "
+                        f"{journal.get('operation_id')} on {doc_id} "
+                        f"(mode: {journal.get('mode', 'patch')})"
+                    )
+                    logger.info(log_message)
+                    async with pipeline_status_lock:
+                        pipeline_status["latest_message"] = log_message
+                        pipeline_status["history_messages"].append(log_message)
+                except Exception as rollback_error:
+                    # Journal and FAILED status remain; the next scan retries.
+                    failed.append(doc_id)
+                    log_message = (
+                        f"[rollback] Failed to roll back custom-chunk "
+                        f"operation on {doc_id}: {rollback_error}"
+                    )
+                    logger.error(log_message)
+                    async with pipeline_status_lock:
+                        pipeline_status["latest_message"] = log_message
+                        pipeline_status["history_messages"].append(log_message)
+
+        return {"rolled_back": rolled_back, "failed": failed}
+
+    async def _rollback_one_custom_chunk_patch(
+        self,
+        doc_id: str,
+        row: dict[str, Any],
+        journal: dict[str, Any],
+        *,
+        pipeline_status: dict,
+        pipeline_status_lock: Any,
+    ) -> None:
+        """Roll a single journaled custom-chunk operation back (see caller)."""
+        mode = journal.get("mode") or "patch"
+        staged_chunk_ids = [
+            cid
+            for cid in (journal.get("chunk_ids") or [])
+            if isinstance(cid, str) and cid
+        ]
+        candidate_entities = [
+            name
+            for name in (journal.get("entity_names") or [])
+            if isinstance(name, str) and name
+        ]
+        candidate_relations = [
+            (pair[0], pair[1])
+            for pair in (journal.get("relation_pairs") or [])
+            if isinstance(pair, (list, tuple)) and len(pair) == 2
+        ]
+
+        # Operation-scoped LLM cache ids must be collected BEFORE the purge
+        # deletes the staged chunk rows that reference them.
+        cache_ids: list[str] = []
+        if staged_chunk_ids:
+            staged_rows = await self.text_chunks.get_by_ids(staged_chunk_ids)
+            for staged_row in staged_rows:
+                if isinstance(staged_row, dict):
+                    cache_ids.extend(
+                        cid
+                        for cid in (staged_row.get("llm_cache_list") or [])
+                        if isinstance(cid, str) and cid
+                    )
+            cache_ids = list(dict.fromkeys(cache_ids))
+
+        if staged_chunk_ids:
+            await self._purge_kg_contributions(
+                doc_id,
+                staged_chunk_ids,
+                candidate_entities=candidate_entities,
+                candidate_relations=candidate_relations,
+                patch_only=(mode == "patch"),
+                strict_rebuild=True,
+                pipeline_status=pipeline_status,
+                pipeline_status_lock=pipeline_status_lock,
+            )
+
+        if cache_ids and self.llm_response_cache:
+            await self.llm_response_cache.delete(cache_ids)
+            await self._flush_storages([self.llm_response_cache])
+
+        if mode == "create":
+            # The document did not exist before this operation: remove its
+            # body and status row entirely. The purge above (whole-document
+            # mode) already dropped the anchors.
+            await self.full_docs.delete([doc_id])
+            await self._flush_storages([self.full_docs])
+            await self.doc_status.delete([doc_id])
+            return
+
+        # Patch mode: prune anchor unions this document no longer owns (a
+        # previous attempt may have failed after the commit union), then
+        # restore the base document to PROCESSED with the journal cleared and
+        # any staged ids stripped from chunks_list.
+        staged_set = set(staged_chunk_ids)
+        base_chunk_ids = {
+            cid
+            for cid in ((row or {}).get("chunks_list") or [])
+            if isinstance(cid, str) and cid and cid not in staged_set
+        }
+        await self._prune_doc_recovery_anchors(
+            doc_id,
+            candidate_entities,
+            candidate_relations,
+            owned_chunk_ids=base_chunk_ids,
+        )
+        cleaned_chunks = [
+            cid
+            for cid in ((row or {}).get("chunks_list") or [])
+            if isinstance(cid, str) and cid and cid not in staged_set
+        ]
+        await self._upsert_custom_chunk_status(
+            doc_id,
+            DocStatus.PROCESSED,
+            base_row=row,
+            journal=None,
+            chunks_list=cleaned_chunks,
+            error_msg="",
+        )
+
+    async def _prune_doc_recovery_anchors(
+        self,
+        doc_id: str,
+        entity_names,
+        relation_pairs,
+        *,
+        owned_chunk_ids: set[str],
+    ) -> None:
+        """Prune rolled-back candidates from the document's recovery anchors.
+
+        A journal candidate stays in ``full_entities`` / ``full_relations``
+        only if the document still owns a contribution to it through one of
+        ``owned_chunk_ids`` (its committed base chunks, per the tracking
+        stores) — e.g. a patch that added a source to a base-document entity.
+        Candidates the document no longer contributes to are removed so the
+        anchors stay a faithful recovery superset. No-op for anchors/keys
+        that do not exist.
+        """
+        entity_candidates = set(entity_names or [])
+        if entity_candidates:
+            entity_row = await self.full_entities.get_by_id(doc_id)
+            if entity_row and entity_row.get("entity_names"):
+                keep: list[str] = []
+                for name in entity_row["entity_names"]:
+                    if name not in entity_candidates:
+                        keep.append(name)
+                        continue
+                    tracking = (
+                        await self.entity_chunks.get_by_id(name)
+                        if self.entity_chunks
+                        else None
+                    )
+                    sources = set((tracking or {}).get("chunk_ids") or [])
+                    if sources & owned_chunk_ids:
+                        keep.append(name)
+                await self.full_entities.upsert(
+                    {doc_id: {"entity_names": sorted(keep), "count": len(keep)}}
+                )
+
+        relation_candidates = {tuple(pair) for pair in (relation_pairs or [])}
+        if relation_candidates:
+            relation_row = await self.full_relations.get_by_id(doc_id)
+            if relation_row and relation_row.get("relation_pairs"):
+                keep_pairs: list[list[str]] = []
+                for pair in relation_row["relation_pairs"]:
+                    pair_tuple = tuple(pair)
+                    if pair_tuple not in relation_candidates:
+                        keep_pairs.append(list(pair))
+                        continue
+                    tracking = (
+                        await self.relation_chunks.get_by_id(
+                            make_relation_chunk_key(*pair_tuple)
+                        )
+                        if self.relation_chunks
+                        else None
+                    )
+                    sources = set((tracking or {}).get("chunk_ids") or [])
+                    if sources & owned_chunk_ids:
+                        keep_pairs.append(list(pair))
+                await self.full_relations.upsert(
+                    {
+                        doc_id: {
+                            "relation_pairs": sorted(keep_pairs),
+                            "count": len(keep_pairs),
+                        }
+                    }
+                )
+
+        await self._flush_storages([self.full_entities, self.full_relations])
+
     async def _process_extract_entities(
         self, chunk: dict[str, Any], pipeline_status=None, pipeline_status_lock=None
     ) -> list:

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -4554,12 +4554,43 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 doc_entities_data = await self.full_entities.get_by_id(doc_id)
                 doc_relations_data = await self.full_relations.get_by_id(doc_id)
 
+                # Candidate discovery must also cover journal-only candidates
+                # (issue #3400 Phase 3): a failed custom-chunk patch may have
+                # written graph/vector/tracking objects whose anchors live
+                # ONLY in the doc's custom_chunk_patch journal — patch mode
+                # unions them into full_entities/full_relations at commit.
+                # Without this union, deleting the document would remove the
+                # staged chunks (added to chunk_ids above) while never
+                # visiting those graph objects, leaving orphans behind.
+                entity_names = list(
+                    (doc_entities_data or {}).get("entity_names") or []
+                )
+                relation_pairs = [
+                    list(pair)
+                    for pair in ((doc_relations_data or {}).get("relation_pairs") or [])
+                ]
+                if isinstance(journal, dict):
+                    seen_names = set(entity_names)
+                    for name in journal.get("entity_names") or []:
+                        if isinstance(name, str) and name and name not in seen_names:
+                            seen_names.add(name)
+                            entity_names.append(name)
+                    seen_pairs = {tuple(pair) for pair in relation_pairs}
+                    for pair in journal.get("relation_pairs") or []:
+                        if (
+                            isinstance(pair, (list, tuple))
+                            and len(pair) == 2
+                            and tuple(pair) not in seen_pairs
+                        ):
+                            seen_pairs.add(tuple(pair))
+                            relation_pairs.append(list(pair))
+
                 affected_nodes = []
                 affected_edges = []
 
-                # Get entity data from graph storage using entity names from full_entities
-                if doc_entities_data and "entity_names" in doc_entities_data:
-                    entity_names = doc_entities_data["entity_names"]
+                # Get entity data from graph storage (candidates are a
+                # recovery superset; absent nodes are skipped below)
+                if entity_names:
                     # get_nodes_batch returns dict[str, dict], need to convert to list[dict]
                     nodes_dict = await self.chunk_entity_relation_graph.get_nodes_batch(
                         entity_names
@@ -4572,9 +4603,8 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                                 node_data["id"] = entity_name
                             affected_nodes.append(node_data)
 
-                # Get relation data from graph storage using relation pairs from full_relations
-                if doc_relations_data and "relation_pairs" in doc_relations_data:
-                    relation_pairs = doc_relations_data["relation_pairs"]
+                # Get relation data from graph storage using the candidate pairs
+                if relation_pairs:
                     edge_pairs_dicts = [
                         {"src": pair[0], "tgt": pair[1]} for pair in relation_pairs
                     ]

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1831,8 +1831,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     "relation_pairs": (existing_journal or {}).get(
                         "relation_pairs", []
                     ),
-                    "created_at": (existing_journal or {}).get("created_at")
-                    or now_iso,
+                    "created_at": (existing_journal or {}).get("created_at") or now_iso,
                     "updated_at": now_iso,
                 }
                 status_row = await self._upsert_custom_chunk_status(

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1963,10 +1963,20 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     f"{type(storage_inst).__name__}: {e}"
                 )
 
-    async def _insert_done(
-        self, pipeline_status=None, pipeline_status_lock=None
-    ) -> None:
-        storages = self._index_storages()
+    async def _flush_storages(self, storages: list) -> None:
+        """Flush the given storage instances — a narrow, named flush barrier.
+
+        Failure paths and write-ahead barriers (issue #3400) must be able to
+        flush a specific subset of storages (e.g. only the two recovery
+        indexes) instead of the unconditional all-storage ``_insert_done``,
+        which on a partially-failed operation would blindly flush partial
+        work into every store. ``_insert_done`` delegates here with the full
+        ``_index_storages()`` list.
+
+        Raises ``IndexFlushError`` (carrying driver name + namespace) for the
+        first failed flush after every flush has run to completion;
+        ``CancelledError`` propagates as-is.
+        """
 
         async def _flush_one(storage_inst) -> None:
             # Wrap each flush so a failure carries the driver name + namespace.
@@ -1989,7 +1999,8 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         # "Task exception was never retrieved" warning. Collecting all results
         # first makes teardown deterministic and lets us report every failure.
         results = await asyncio.gather(
-            *[_flush_one(inst) for inst in storages], return_exceptions=True
+            *[_flush_one(inst) for inst in storages if inst is not None],
+            return_exceptions=True,
         )
         errors = [r for r in results if isinstance(r, BaseException)]
         if errors:
@@ -2002,6 +2013,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             for extra in errors[1:]:
                 logger.error(f"Additional index flush failure: {extra}")
             raise errors[0]
+
+    async def _insert_done(
+        self, pipeline_status=None, pipeline_status_lock=None
+    ) -> None:
+        await self._flush_storages(self._index_storages())
 
         log_message = "In memory DB persist to disk"
         logger.info(log_message)
@@ -2972,6 +2988,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     ) -> None:
         """Remove a document's chunks and clean up its knowledge-graph contributions.
 
+        Thin wrapper over :py:meth:`_purge_kg_contributions` in whole-document
+        mode: candidates are discovered from the per-doc ``full_entities`` /
+        ``full_relations`` recovery rows and those rows are deleted at the
+        end. See the primitive for the detailed contract.
+
         Used by:
             - The pipeline resume branch in ``process_document`` when a
               document whose content is already extracted is re-processed
@@ -2980,10 +3001,40 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             - Future deletion paths that want a focused "purge KG only"
               operation without the LLM-cache / doc_status / full_docs
               cleanup that ``adelete_by_doc_id`` also performs.
+        """
+        await self._purge_kg_contributions(
+            doc_id,
+            chunk_ids,
+            pipeline_status=pipeline_status,
+            pipeline_status_lock=pipeline_status_lock,
+        )
+
+    async def _purge_kg_contributions(
+        self,
+        doc_id: str,
+        chunk_ids: list[str],
+        *,
+        candidate_entities: list[str] | None = None,
+        candidate_relations: list[tuple[str, str]] | None = None,
+        patch_only: bool = False,
+        strict_rebuild: bool = False,
+        pipeline_status: dict,
+        pipeline_status_lock: Any,
+    ) -> None:
+        """Candidate-driven purge/rebuild primitive (issue #3400).
+
+        Shared by whole-document purge (normal deletion / retry) and, in later
+        phases, custom-chunk patch rollback. Candidates are a recovery
+        SUPERSET — a candidate that never reached the graph is an idempotent
+        no-op; ownership is verified per candidate from the union of
+        chunk-tracking entries and graph ``source_id`` lists before anything
+        is deleted or rebuilt.
 
         What this method does:
-            1. Reads ``full_entities`` / ``full_relations`` to identify which
-               graph nodes / edges this document contributed to.
+            1. Resolves the candidate entity/relation set: the explicit
+               ``candidate_entities`` / ``candidate_relations`` arguments if
+               given, otherwise the per-doc ``full_entities`` /
+               ``full_relations`` recovery rows.
             2. For each affected entity / relation, intersects the doc's
                ``chunk_ids`` with the union of chunk-tracking entries
                (``entity_chunks`` / ``relation_chunks``) and graph
@@ -3001,9 +3052,15 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             6. Calls :func:`rebuild_knowledge_from_chunks` to rebuild any
                *rebuild* entries from their remaining chunks (so other
                documents that also contributed to the same entity /
-               relation keep their data intact).
-            7. Deletes the per-doc ``full_entities`` / ``full_relations``
-               index rows so subsequent re-extraction starts fresh.
+               relation keep their data intact). With ``strict_rebuild``,
+               missing extraction cache or a failed rebuild raises instead
+               of being logged (recovery must not silently succeed on
+               partial data).
+            7. Unless ``patch_only``: deletes the per-doc ``full_entities``
+               / ``full_relations`` index rows so subsequent re-extraction
+               starts fresh. A patch rollback must NOT drop the base
+               document's recovery rows — the document keeps owning its
+               previously committed contributions.
 
         Does NOT touch:
             - ``doc_status`` / ``full_docs`` records — caller manages those.
@@ -3012,7 +3069,8 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
               pipeline (i.e. this runs inside a pipeline run).
 
         Idempotent: passing an empty ``chunk_ids`` returns immediately
-        without touching storage.
+        without touching storage; repeating a partially-failed purge
+        converges (absent objects are skipped, remaining ones are cleaned).
         """
         if not chunk_ids:
             return
@@ -3021,7 +3079,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         # so it satisfies the storage delete contract: ``delete(ids: list[str])``).
         chunk_ids_set = set(chunk_ids)
 
-        # ---- 1. Analyze affected entities/relations from full_entities/full_relations ----
+        # ---- 1. Analyze affected entities/relations from the candidate set ----
         entities_to_delete: set[str] = set()
         entities_to_rebuild: dict[str, list[str]] = {}
         relationships_to_delete: set[tuple[str, str]] = set()
@@ -3030,33 +3088,46 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         relation_chunk_updates: dict[tuple[str, str], list[str]] = {}
 
         try:
-            doc_entities_data = await self.full_entities.get_by_id(doc_id)
-            doc_relations_data = await self.full_relations.get_by_id(doc_id)
+            if candidate_entities is None:
+                doc_entities_data = await self.full_entities.get_by_id(doc_id)
+                candidate_entities = (
+                    doc_entities_data["entity_names"]
+                    if doc_entities_data and "entity_names" in doc_entities_data
+                    else []
+                )
+            if candidate_relations is None:
+                doc_relations_data = await self.full_relations.get_by_id(doc_id)
+                candidate_relations = (
+                    doc_relations_data["relation_pairs"]
+                    if doc_relations_data and "relation_pairs" in doc_relations_data
+                    else []
+                )
 
             affected_nodes: list[dict[str, Any]] = []
             affected_edges: list[dict[str, Any]] = []
 
-            if doc_entities_data and "entity_names" in doc_entities_data:
-                entity_names = doc_entities_data["entity_names"]
+            if candidate_entities:
                 nodes_dict = await self.chunk_entity_relation_graph.get_nodes_batch(
-                    entity_names
+                    list(candidate_entities)
                 )
-                for entity_name in entity_names:
+                for entity_name in candidate_entities:
                     node_data = nodes_dict.get(entity_name)
+                    # Absent graph node: the candidate was prewritten but the
+                    # mutation never landed (or a previous purge already
+                    # removed it) — an idempotent no-op, not an error.
                     if node_data:
                         if "id" not in node_data:
                             node_data["id"] = entity_name
                         affected_nodes.append(node_data)
 
-            if doc_relations_data and "relation_pairs" in doc_relations_data:
-                relation_pairs = doc_relations_data["relation_pairs"]
+            if candidate_relations:
                 edge_pairs_dicts = [
-                    {"src": pair[0], "tgt": pair[1]} for pair in relation_pairs
+                    {"src": pair[0], "tgt": pair[1]} for pair in candidate_relations
                 ]
                 edges_dict = await self.chunk_entity_relation_graph.get_edges_batch(
                     edge_pairs_dicts
                 )
-                for pair in relation_pairs:
+                for pair in candidate_relations:
                     src, tgt = pair[0], pair[1]
                     edge_data = edges_dict.get((src, tgt))
                     if edge_data:
@@ -3364,22 +3435,26 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     pipeline_status_lock=pipeline_status_lock,
                     entity_chunks_storage=self.entity_chunks,
                     relation_chunks_storage=self.relation_chunks,
+                    strict=strict_rebuild,
                 )
             except Exception as e:
                 logger.error(f"[purge] Failed to rebuild knowledge from chunks: {e}")
                 raise Exception(f"Failed to rebuild knowledge graph: {e}") from e
 
         # ---- 8. Delete per-doc full_entities / full_relations index rows ----
-        try:
-            await self.full_entities.delete([doc_id])
-            await self.full_relations.delete([doc_id])
-        except Exception as e:
-            logger.error(
-                f"[purge] Failed to delete full_entities/full_relations rows for {doc_id}: {e}"
-            )
-            raise Exception(
-                f"Failed to delete from full_entities/full_relations: {e}"
-            ) from e
+        # Patch-only rollback keeps the base document's recovery rows: the
+        # document still owns its previously committed contributions.
+        if not patch_only:
+            try:
+                await self.full_entities.delete([doc_id])
+                await self.full_relations.delete([doc_id])
+            except Exception as e:
+                logger.error(
+                    f"[purge] Failed to delete full_entities/full_relations rows for {doc_id}: {e}"
+                )
+                raise Exception(
+                    f"Failed to delete from full_entities/full_relations: {e}"
+                ) from e
 
     async def adelete_by_doc_id(
         self, doc_id: str, delete_llm_cache: bool = False

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -2730,6 +2730,19 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         custom_kg: dict[str, Any],
         full_doc_id: str = None,
     ) -> None:
+        """Insert caller-constructed KG objects directly into the stores.
+
+        .. warning:: (issue #3400 Phase 5 — direct-writer audit)
+           This path is OUTSIDE the document-level recovery guarantee. It has
+           no durable operation journal and does not prewrite
+           ``full_entities`` / ``full_relations`` recovery anchors, so a
+           crash or partial failure mid-call can leave graph/vector/tracking
+           contributions that per-document purge, retry, and scan rollback
+           cannot discover. Use the journaled ingestion paths (``ainsert`` /
+           ``ainsert_custom_chunks``) when crash recovery matters; the
+           offline ``lightrag.tools.kg_integrity_repair`` audit can
+           reconstruct anchors for data written here after the fact.
+        """
         # Direct KG write path — refuse on a fenced workspace (recovery_required)
         # like the other SDK mutations, before touching any storage.
         await self._raise_if_recovery_required()

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -115,6 +115,7 @@ from lightrag.base import (
 from lightrag.namespace import NameSpace
 from lightrag.chunker import chunking_by_token_size
 from lightrag.operate import (
+    KGRebuildReport,
     collect_kg_merge_candidates,
     extract_entities,
     kg_query,
@@ -124,6 +125,7 @@ from lightrag.operate import (
 )
 from lightrag.utils_pipeline import (
     CUSTOM_CHUNK_PATCH_METADATA_KEY,
+    KG_RECOVERY_WARNINGS_METADATA_KEY,
     compute_text_content_hash,
     doc_status_custom_chunk_patch,
     make_custom_chunk_id,
@@ -2243,10 +2245,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
 
         Per document, under the same per-document keyed lock the operations
         use: staged contributions are removed/rebuilt via the candidate-driven
-        purge primitive (strict rebuild — missing recovery cache fails the
-        rollback rather than producing a false PROCESSED), operation-scoped
-        LLM cache is deleted, anchor unions are pruned where the document no
-        longer owns a contribution, and only then is the journal cleared:
+        purge primitive (missing recovery cache triggers structural provenance
+        repair plus a persistent warning; operational write failures retain the
+        journal), operation-scoped LLM cache is deleted, anchor unions are
+        pruned where the document no longer owns a contribution, and only then
+        is the journal cleared:
 
         - ``patch`` mode: the base document is restored to ``PROCESSED``.
         - ``create`` mode: the document did not exist before the operation,
@@ -2366,14 +2369,15 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     )
             cache_ids = list(dict.fromkeys(cache_ids))
 
+        rebuild_report = KGRebuildReport()
         if staged_chunk_ids:
-            await self._purge_kg_contributions(
+            rebuild_report = await self._purge_kg_contributions(
                 doc_id,
                 staged_chunk_ids,
                 candidate_entities=candidate_entities,
                 candidate_relations=candidate_relations,
                 patch_only=(mode == "patch"),
-                strict_rebuild=True,
+                rebuild_policy="rollback",
                 pipeline_status=pipeline_status,
                 pipeline_status_lock=pipeline_status_lock,
             )
@@ -2381,6 +2385,16 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         if cache_ids and self.llm_response_cache:
             await self.llm_response_cache.delete(cache_ids)
             await self._flush_storages([self.llm_response_cache])
+
+        warning_rows = await self._persist_custom_chunk_recovery_warning(
+            doc_id,
+            journal,
+            rebuild_report,
+            mode=mode,
+            pipeline_status=pipeline_status,
+            pipeline_status_lock=pipeline_status_lock,
+        )
+        row = warning_rows.get(doc_id, row)
 
         if mode == "create":
             # The document did not exist before this operation: remove its
@@ -2424,6 +2438,130 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             chunks_list=cleaned_chunks,
             error_msg="",
         )
+
+    async def _persist_custom_chunk_recovery_warning(
+        self,
+        doc_id: str,
+        journal: dict[str, Any],
+        report: KGRebuildReport,
+        *,
+        mode: str,
+        pipeline_status: dict,
+        pipeline_status_lock: Any,
+    ) -> dict[str, dict[str, Any]]:
+        """Persist bounded degraded-recovery warnings on surviving owners.
+
+        Patch rollback always includes the target document. Create rollback
+        removes that target entirely, so its warning is attached to documents
+        owning the surviving chunks that contributed to degraded aggregates.
+        """
+        if not report.has_warnings:
+            return {}
+
+        owner_doc_ids: set[str] = set()
+        surviving_chunk_ids = sorted(report.surviving_chunk_ids)
+        if surviving_chunk_ids:
+            chunk_rows = await self.text_chunks.get_by_ids(surviving_chunk_ids)
+            for chunk_row in chunk_rows:
+                if not isinstance(chunk_row, dict):
+                    continue
+                owner_doc_id = chunk_row.get("full_doc_id")
+                if isinstance(owner_doc_id, str) and owner_doc_id:
+                    owner_doc_ids.add(owner_doc_id)
+
+        if mode == "patch":
+            owner_doc_ids.add(doc_id)
+        else:
+            owner_doc_ids.discard(doc_id)
+
+        if not owner_doc_ids:
+            raise RuntimeError(
+                "Cannot persist degraded KG recovery warning: no surviving "
+                "owner document was found"
+            )
+
+        def _sample(values) -> dict[str, Any]:
+            ordered = sorted(set(values))
+            return {"count": len(ordered), "sample": ordered[:20]}
+
+        relationship_labels = [
+            f"{src}~{tgt}" for src, tgt in report.degraded_relationships
+        ]
+        event = {
+            "code": "degraded_custom_chunk_rollback",
+            "message": (
+                "Custom-chunk rollback completed with structural provenance "
+                "repair, but some KG semantic aggregates could not be fully "
+                "rebuilt from extraction cache."
+            ),
+            "operation_id": journal.get("operation_id"),
+            "recorded_at": datetime.now(timezone.utc).isoformat(),
+            "missing_cache_chunks": _sample(report.missing_cache_chunk_ids),
+            "unusable_cache_chunks": _sample(report.unusable_cache_chunk_ids),
+            "degraded_entities": _sample(report.degraded_entities),
+            "degraded_relationships": _sample(relationship_labels),
+            "surviving_chunks": _sample(surviving_chunk_ids),
+        }
+
+        updated_rows: dict[str, dict[str, Any]] = {}
+        missing_owner_doc_ids: list[str] = []
+        for owner_doc_id in sorted(owner_doc_ids):
+            owner_row = await self.doc_status.get_by_id(owner_doc_id)
+            if not isinstance(owner_row, dict):
+                logger.warning(
+                    "Cannot persist degraded KG recovery warning: document "
+                    "status `%s` was not found",
+                    owner_doc_id,
+                )
+                missing_owner_doc_ids.append(owner_doc_id)
+                continue
+
+            metadata = dict(owner_row.get("metadata") or {})
+            raw_warnings = metadata.get(KG_RECOVERY_WARNINGS_METADATA_KEY)
+            warnings_list = (
+                [item for item in raw_warnings if isinstance(item, dict)]
+                if isinstance(raw_warnings, list)
+                else []
+            )
+            operation_id = event.get("operation_id")
+            warnings_list = [
+                item
+                for item in warnings_list
+                if not (
+                    item.get("code") == event["code"]
+                    and item.get("operation_id") == operation_id
+                )
+            ]
+            warnings_list.append(event)
+            metadata[KG_RECOVERY_WARNINGS_METADATA_KEY] = warnings_list[-10:]
+            updated_row = {
+                **owner_row,
+                "metadata": metadata,
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            }
+            updated_rows[owner_doc_id] = updated_row
+
+        if missing_owner_doc_ids:
+            raise RuntimeError(
+                "Cannot persist degraded KG recovery warning: document status "
+                f"missing for {', '.join(missing_owner_doc_ids)}"
+            )
+
+        if updated_rows:
+            await self.doc_status.upsert(updated_rows)
+            await self._flush_storages([self.doc_status])
+
+        log_message = (
+            "[rollback] Degraded KG recovery warning for custom-chunk operation "
+            f"{journal.get('operation_id')} persisted on "
+            f"{len(updated_rows)} surviving document(s)"
+        )
+        logger.warning(log_message)
+        async with pipeline_status_lock:
+            pipeline_status["latest_message"] = log_message
+            pipeline_status["history_messages"].append(log_message)
+
+        return updated_rows
 
     async def _prune_doc_recovery_anchors(
         self,
@@ -3693,10 +3831,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         candidate_entities: list[str] | None = None,
         candidate_relations: list[tuple[str, str]] | None = None,
         patch_only: bool = False,
-        strict_rebuild: bool = False,
+        rebuild_policy: Literal["best_effort", "rollback"] = "best_effort",
         pipeline_status: dict,
         pipeline_status_lock: Any,
-    ) -> None:
+    ) -> KGRebuildReport:
         """Candidate-driven purge/rebuild primitive (issue #3400).
 
         Shared by whole-document purge (normal deletion / retry) and, in later
@@ -3724,9 +3862,9 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                *rebuild* entries from their remaining chunks (so other
                documents that also contributed to the same entity /
                relation keep their data intact), then flushes the rebuilt
-               state. With ``strict_rebuild``, missing extraction cache or
-               a failed rebuild raises instead of being logged (recovery
-               must not silently succeed on partial data).
+               state. Rollback policy repairs provenance structurally when
+               extraction data is missing, but still raises on operational
+               graph/vector/tracking failures.
             5. Only after every derived contribution is repaired/removed
                and flushed: deletes the chunks themselves from
                ``chunks_vdb`` and ``text_chunks`` and flushes them (safe
@@ -3750,7 +3888,9 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         converges (absent objects are skipped, remaining ones are cleaned).
         """
         if not chunk_ids:
-            return
+            return KGRebuildReport()
+
+        rebuild_report = KGRebuildReport()
 
         # Set view for membership/intersection checks below (chunk_ids stays a list
         # so it satisfies the storage delete contract: ``delete(ids: list[str])``).
@@ -3863,6 +4003,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 elif (
                     remaining_sources != existing_sources
                     or graph_references_deleted_chunks
+                    or rebuild_policy == "rollback"
                 ):
                     entities_to_rebuild[node_label] = remaining_sources
                     entity_chunk_updates[node_label] = remaining_sources
@@ -3927,6 +4068,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 elif (
                     remaining_sources != existing_sources
                     or graph_references_deleted_chunks
+                    or rebuild_policy == "rollback"
                 ):
                     relationships_to_rebuild[edge_tuple] = remaining_sources
                     relation_chunk_updates[edge_tuple] = remaining_sources
@@ -4084,7 +4226,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         # ---- 6. Rebuild entities/relations that still have remaining sources ----
         if entities_to_rebuild or relationships_to_rebuild:
             try:
-                await rebuild_knowledge_from_chunks(
+                rebuild_report = await rebuild_knowledge_from_chunks(
                     entities_to_rebuild=entities_to_rebuild,
                     relationships_to_rebuild=relationships_to_rebuild,
                     knowledge_graph_inst=self.chunk_entity_relation_graph,
@@ -4097,7 +4239,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     pipeline_status_lock=pipeline_status_lock,
                     entity_chunks_storage=self.entity_chunks,
                     relation_chunks_storage=self.relation_chunks,
-                    strict=strict_rebuild,
+                    rebuild_policy=rebuild_policy,
                 )
             except Exception as e:
                 logger.error(f"[purge] Failed to rebuild knowledge from chunks: {e}")
@@ -4150,6 +4292,8 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 raise Exception(
                     f"Failed to delete from full_entities/full_relations: {e}"
                 ) from e
+
+        return rebuild_report
 
     async def adelete_by_doc_id(
         self, doc_id: str, delete_llm_cache: bool = False
@@ -4569,9 +4713,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 # Without this union, deleting the document would remove the
                 # staged chunks (added to chunk_ids above) while never
                 # visiting those graph objects, leaving orphans behind.
-                entity_names = list(
-                    (doc_entities_data or {}).get("entity_names") or []
-                )
+                entity_names = list((doc_entities_data or {}).get("entity_names") or [])
                 relation_pairs = [
                     list(pair)
                     for pair in ((doc_relations_data or {}).get("relation_pairs") or [])

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -115,13 +115,19 @@ from lightrag.base import (
 from lightrag.namespace import NameSpace
 from lightrag.chunker import chunking_by_token_size
 from lightrag.operate import (
+    collect_kg_merge_candidates,
     extract_entities,
     kg_query,
     merge_nodes_and_edges,
     naive_query,
     rebuild_knowledge_from_chunks,
 )
-from lightrag.utils_pipeline import normalize_document_file_path
+from lightrag.utils_pipeline import (
+    CUSTOM_CHUNK_PATCH_METADATA_KEY,
+    compute_text_content_hash,
+    doc_status_custom_chunk_patch,
+    normalize_document_file_path,
+)
 from lightrag.constants import GRAPH_FIELD_SEP
 from lightrag.exceptions import IndexFlushError
 from lightrag.utils import (
@@ -134,6 +140,7 @@ from lightrag.utils import (
     sanitize_text_for_encoding,
     check_storage_env_vars,
     generate_track_id,
+    get_content_summary,
     convert_to_user_format,
     logger,
     make_relation_vdb_ids,
@@ -1564,6 +1571,33 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     async def ainsert_custom_chunks(
         self, full_text: str, text_chunks: list[str], doc_id: str | None = None
     ) -> None:
+        """Insert caller-chunked content as a journaled, recoverable operation.
+
+        Issue #3400 Phase 3 semantics — one invocation is one incremental
+        operation with a durable journal in ``doc_status.metadata``:
+
+        - Target document absent → **create** mode: the document is created
+          with full doc_status bookkeeping (the legacy behavior of this
+          deprecated API, now crash-discoverable).
+        - Target document ``PROCESSED`` → **patch** mode: the chunks are added
+          to the document; recovery anchors and ``chunks_list`` are unioned at
+          commit, never overwritten.
+        - Target document carrying a journal for the SAME operation (same
+          doc + same chunk set) → resume/roll-forward; for a DIFFERENT
+          operation → rejected until the original is retried or rolled back
+          by scan.
+        - Target document in any other state → rejected.
+
+        Identity is deterministic and document-scoped: chunk ids hash
+        ``(doc_id, chunk_content)`` and the operation id hashes the ordered
+        chunk-id set, so repeating the same logical input is idempotent
+        (committed → no-op; failed → resume).
+
+        On failure/cancellation after the journal is durable the document is
+        marked ``FAILED`` with the journal (and any staged data) retained —
+        the same call can be retried by the SDK caller, and ``/documents/scan``
+        can roll the operation back. Partial work is never blind-flushed.
+        """
         # Owner token for the busy reservation, generated before any await so the
         # finally always holds it and can release the slot by owner (even if the
         # acquire is cancelled at the lock exit).
@@ -1571,6 +1605,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         busy_acquired = False
         pipeline_status = None
         pipeline_status_lock = None
+        # Set when the operation fails after acquiring busy: the finally then
+        # discards partial buffers instead of flushing them (issue #3400:
+        # failure finalization must not persist partial work).
+        op_failed = False
         try:
             # Clean input texts
             full_text = sanitize_text_for_encoding(full_text)
@@ -1582,36 +1620,31 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 doc_key = compute_mdhash_id(full_text, prefix="doc-")
             else:
                 doc_key = doc_id
-            new_docs = {doc_key: {"content": full_text, "file_path": file_path}}
 
-            _add_doc_keys = await self.full_docs.filter_keys({doc_key})
-            new_docs = {k: v for k, v in new_docs.items() if k in _add_doc_keys}
-            if not len(new_docs):
-                logger.warning("This document is already in the storage.")
+            # Deterministic, document-scoped identity: chunk ids hash
+            # (doc_key, content) so identical text in two documents never
+            # shares a chunk row (a shared row's full_doc_id would be
+            # clobbered, and rollback could delete another document's chunk).
+            # The operation id hashes the ordered chunk-id set so the same
+            # logical input is the same operation across retries.
+            chunk_entries: list[tuple[str, str, str]] = []
+            seen_chunk_ids: set[str] = set()
+            for chunk_text in text_chunks:
+                if not chunk_text:
+                    continue
+                chunk_id = compute_mdhash_id(doc_key + chunk_text, prefix="chunk-")
+                if chunk_id in seen_chunk_ids:
+                    continue
+                seen_chunk_ids.add(chunk_id)
+                chunk_entries.append(
+                    (chunk_id, chunk_text, compute_text_content_hash(chunk_text))
+                )
+            if not chunk_entries:
+                logger.warning("No non-empty custom chunks to insert.")
                 return
-
-            logger.info(f"Inserting {len(new_docs)} docs")
-
-            inserting_chunks: dict[str, Any] = {}
-            for index, chunk_text in enumerate(text_chunks):
-                chunk_key = compute_mdhash_id(chunk_text, prefix="chunk-")
-                tokens = len(self.tokenizer.encode(chunk_text))
-                inserting_chunks[chunk_key] = {
-                    "content": chunk_text,
-                    "full_doc_id": doc_key,
-                    "tokens": tokens,
-                    "chunk_order_index": index,
-                    "file_path": file_path,
-                }
-
-            doc_ids = set(inserting_chunks.keys())
-            add_chunk_keys = await self.text_chunks.filter_keys(doc_ids)
-            inserting_chunks = {
-                k: v for k, v in inserting_chunks.items() if k in add_chunk_keys
-            }
-            if not len(inserting_chunks):
-                logger.warning("All chunks are already in the storage.")
-                return
+            operation_id = compute_mdhash_id(
+                doc_key + "|".join(cid for cid, _, _ in chunk_entries), prefix="op-"
+            )
 
             # pipeline_status/lock are already initialized by
             # initialize_storages() (which is idempotent), so fetch the existing
@@ -1694,48 +1727,276 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 # would skip the release, wedging the workspace busy forever.
                 busy_acquired = True
 
-            # Stage 1 (barrier): persist chunks BEFORE extraction. Extraction
-            # records per-chunk LLM cache references (update_chunk_cache_list ->
-            # text_chunks) keyed by chunk id and reads chunks back via
-            # get_by_id; running it concurrently with these upserts can observe a
-            # not-yet-persisted chunk and silently drop the cache reference.
-            # Mirror the file pipeline's Stage-1-persist / Stage-2-extract
-            # barrier (see pipeline._run_pipeline_batch).
-            await asyncio.gather(
-                self.chunks_vdb.upsert(inserting_chunks),
-                self.full_docs.upsert(new_docs),
-                self.text_chunks.upsert(inserting_chunks),
+            # Per-document keyed lock: only one custom-chunk operation may be
+            # active for a document (issue #3400 §2.5). The busy reservation
+            # already serializes writers globally; the keyed lock preserves
+            # correctness if that global policy is ever relaxed.
+            doc_lock_namespace = (
+                f"{self.workspace}:DocPatch" if self.workspace else "DocPatch"
             )
+            async with get_storage_keyed_lock(
+                [doc_key], namespace=doc_lock_namespace, enable_logging=False
+            ):
+                # ---- Resolve operation mode under the reservation ----
+                existing_row = await self.doc_status.get_by_id(doc_key)
+                existing_journal = doc_status_custom_chunk_patch(existing_row)
 
-            # Stage 2: extract now that chunks are durably persisted. Pass the
-            # real pipeline_status/lock so extraction progress and any failure
-            # are surfaced (see _process_extract_entities).
-            chunk_results = await self._process_extract_entities(
-                inserting_chunks, pipeline_status, pipeline_status_lock
-            )
+                def _row_status_text(row: dict | None) -> str:
+                    raw = (row or {}).get("status")
+                    return raw.value if isinstance(raw, DocStatus) else str(raw or "")
 
-            # Stage 3: merge the extracted entities/relationships into the
-            # knowledge graph. Without this the extraction result was discarded,
-            # so no KG was built from custom chunks (KG-dependent query modes
-            # returned nothing while the extraction LLM cost was still spent).
-            # Mirrors the file pipeline's merge stage.
-            if chunk_results:
-                await merge_nodes_and_edges(
-                    chunk_results=chunk_results,
-                    knowledge_graph_inst=self.chunk_entity_relation_graph,
-                    entity_vdb=self.entities_vdb,
-                    relationships_vdb=self.relationships_vdb,
-                    global_config=self._build_global_config(),
-                    full_entities_storage=self.full_entities,
-                    full_relations_storage=self.full_relations,
-                    doc_id=doc_key,
-                    pipeline_status=pipeline_status,
-                    pipeline_status_lock=pipeline_status_lock,
-                    llm_response_cache=self.llm_response_cache,
-                    entity_chunks_storage=self.entity_chunks,
-                    relation_chunks_storage=self.relation_chunks,
+                resume = False
+                if existing_journal is not None:
+                    if existing_journal.get("operation_id") != operation_id:
+                        raise RuntimeError(
+                            f"Document {doc_key} has an unfinished custom-chunk "
+                            f"operation {existing_journal.get('operation_id')}; "
+                            "retry that operation with its original input, or "
+                            "run /documents/scan to roll it back, before "
+                            "submitting a different one."
+                        )
+                    mode = existing_journal.get("mode") or "patch"
+                    resume = True
+                elif existing_row is None:
+                    mode = "create"
+                elif _row_status_text(existing_row) == DocStatus.PROCESSED.value:
+                    mode = "patch"
+                else:
+                    raise RuntimeError(
+                        f"Document {doc_key} is in status "
+                        f"'{_row_status_text(existing_row)}'; only PROCESSED "
+                        "documents (or the document's own unfinished "
+                        "operation) can receive a custom-chunk insert."
+                    )
+
+                if mode == "create" and not resume:
+                    # Legacy dedup: a document created by an earlier call (or
+                    # an old build without doc_status bookkeeping) is a
+                    # committed no-op, mirroring the historical behavior.
+                    missing_keys = await self.full_docs.filter_keys({doc_key})
+                    if doc_key not in missing_keys:
+                        logger.warning("This document is already in the storage.")
+                        return
+
+                if mode == "patch":
+                    # Committed-content dedup: drop chunks whose content the
+                    # base document already owns, so repeating an
+                    # already-committed patch (or re-adding base content) is
+                    # idempotent instead of double-merging contributions.
+                    committed_ids = [
+                        cid
+                        for cid in ((existing_row or {}).get("chunks_list") or [])
+                        if isinstance(cid, str) and cid
+                    ]
+                    committed_hashes: set[str] = set()
+                    if committed_ids:
+                        committed_rows = await self.text_chunks.get_by_ids(
+                            committed_ids
+                        )
+                        for row in committed_rows:
+                            if isinstance(row, dict) and row.get("content"):
+                                committed_hashes.add(
+                                    compute_text_content_hash(row["content"])
+                                )
+                    chunk_entries = [
+                        entry
+                        for entry in chunk_entries
+                        if entry[2] not in committed_hashes
+                    ]
+                    if not chunk_entries and not resume:
+                        logger.warning(
+                            "All custom chunks are already committed to this "
+                            "document; nothing to patch."
+                        )
+                        return
+
+                logger.info(
+                    f"Custom chunks {mode} for {doc_key}: "
+                    f"{len(chunk_entries)} chunk(s), operation {operation_id}"
+                    f"{' (resume)' if resume else ''}"
+                )
+
+                # ---- Journal first: durable PROCESSING + operation record
+                # BEFORE any data store is touched (discoverability before
+                # mutation). doc_status backends persist on upsert.
+                now_iso = datetime.now(timezone.utc).isoformat()
+                journal: dict[str, Any] = {
+                    "schema_version": 1,
+                    "operation_id": operation_id,
+                    "mode": mode,
+                    "chunk_ids": [cid for cid, _, _ in chunk_entries],
+                    "content_hashes": [h for _, _, h in chunk_entries],
+                    "phase": "prepared",
+                    "entity_names": (existing_journal or {}).get("entity_names", []),
+                    "relation_pairs": (existing_journal or {}).get(
+                        "relation_pairs", []
+                    ),
+                    "created_at": (existing_journal or {}).get("created_at")
+                    or now_iso,
+                    "updated_at": now_iso,
+                }
+                status_row = await self._upsert_custom_chunk_status(
+                    doc_key,
+                    DocStatus.PROCESSING,
+                    base_row=existing_row,
+                    journal=journal,
+                    full_text=full_text,
                     file_path=file_path,
                 )
+                try:
+                    # Stage 1 (barrier): persist chunks BEFORE extraction.
+                    # Extraction records per-chunk LLM cache references
+                    # (update_chunk_cache_list -> text_chunks) keyed by chunk id
+                    # and reads chunks back via get_by_id; running it
+                    # concurrently with these upserts can observe a
+                    # not-yet-persisted chunk and silently drop the cache
+                    # reference.
+                    inserting_chunks: dict[str, Any] = {
+                        chunk_id: {
+                            "content": content,
+                            "full_doc_id": doc_key,
+                            "tokens": len(self.tokenizer.encode(content)),
+                            "chunk_order_index": index,
+                            "file_path": file_path,
+                        }
+                        for index, (chunk_id, content, _) in enumerate(chunk_entries)
+                    }
+                    stage1_writes = [
+                        self.chunks_vdb.upsert(inserting_chunks),
+                        self.text_chunks.upsert(inserting_chunks),
+                    ]
+                    if mode == "create":
+                        stage1_writes.append(
+                            self.full_docs.upsert(
+                                {
+                                    doc_key: {
+                                        "content": full_text,
+                                        "file_path": file_path,
+                                    }
+                                }
+                            )
+                        )
+                    await asyncio.gather(*stage1_writes)
+
+                    # Stage 2: extract now that chunks are persisted, then make
+                    # the staged chunks AND the extraction cache durable before
+                    # any graph mutation — a resume must reuse the cached
+                    # extraction, never call the LLM again and merge a
+                    # different result into a partially applied operation.
+                    chunk_results = await self._process_extract_entities(
+                        inserting_chunks, pipeline_status, pipeline_status_lock
+                    )
+                    staging_flush = [
+                        self.text_chunks,
+                        self.chunks_vdb,
+                        self.llm_response_cache,
+                    ]
+                    if mode == "create":
+                        staging_flush.append(self.full_docs)
+                    await self._flush_storages(staging_flush)
+
+                    # Persist the complete candidate set in the journal BEFORE
+                    # merging — the write-ahead anchor for this operation.
+                    candidate_entities, candidate_relations = (
+                        collect_kg_merge_candidates(chunk_results or [])
+                    )
+                    journal = {
+                        **journal,
+                        "phase": "applying",
+                        "entity_names": sorted(candidate_entities),
+                        "relation_pairs": [
+                            list(pair) for pair in sorted(candidate_relations)
+                        ],
+                        "updated_at": datetime.now(timezone.utc).isoformat(),
+                    }
+                    status_row = await self._upsert_custom_chunk_status(
+                        doc_key,
+                        DocStatus.PROCESSING,
+                        base_row=status_row,
+                        journal=journal,
+                    )
+
+                    # Stage 3: merge into the knowledge graph. In patch mode
+                    # the merge must NOT touch the base document's
+                    # full_entities/full_relations rows (passing None skips the
+                    # merge's own anchor prewrite — the journal is this
+                    # operation's anchor); candidates are UNIONED into the base
+                    # rows only at commit. Create mode uses the merge's normal
+                    # write-ahead anchor prewrite.
+                    if chunk_results:
+                        await merge_nodes_and_edges(
+                            chunk_results=chunk_results,
+                            knowledge_graph_inst=self.chunk_entity_relation_graph,
+                            entity_vdb=self.entities_vdb,
+                            relationships_vdb=self.relationships_vdb,
+                            global_config=self._build_global_config(),
+                            full_entities_storage=(
+                                self.full_entities if mode == "create" else None
+                            ),
+                            full_relations_storage=(
+                                self.full_relations if mode == "create" else None
+                            ),
+                            doc_id=doc_key,
+                            pipeline_status=pipeline_status,
+                            pipeline_status_lock=pipeline_status_lock,
+                            llm_response_cache=self.llm_response_cache,
+                            entity_chunks_storage=self.entity_chunks,
+                            relation_chunks_storage=self.relation_chunks,
+                            file_path=file_path,
+                        )
+
+                    # ---- Commit: flush ALL derived stores, union the patch
+                    # into the base document's anchors, then write PROCESSED
+                    # (the commit record) last with the journal cleared.
+                    await self._insert_done()
+
+                    if mode == "patch":
+                        await self._union_doc_recovery_anchors(
+                            doc_key, candidate_entities, candidate_relations
+                        )
+                        base_chunks = [
+                            cid
+                            for cid in ((status_row or {}).get("chunks_list") or [])
+                            if isinstance(cid, str) and cid
+                        ]
+                        final_chunks_list = list(
+                            dict.fromkeys(base_chunks + list(inserting_chunks.keys()))
+                        )
+                    else:
+                        final_chunks_list = list(inserting_chunks.keys())
+
+                    await self._upsert_custom_chunk_status(
+                        doc_key,
+                        DocStatus.PROCESSED,
+                        base_row=status_row,
+                        journal=None,
+                        chunks_list=final_chunks_list,
+                    )
+                except BaseException as op_exc:
+                    # Journal is durable: record FAILED, keep the journal and
+                    # every staged artifact for SDK resume or scan rollback,
+                    # then re-raise. Merge siblings are already drained by
+                    # wait_tasks_with_drain inside merge_nodes_and_edges.
+                    op_failed = True
+                    try:
+                        failed_journal = {
+                            **journal,
+                            "phase": "failed",
+                            "updated_at": datetime.now(timezone.utc).isoformat(),
+                        }
+                        await self._upsert_custom_chunk_status(
+                            doc_key,
+                            DocStatus.FAILED,
+                            base_row=status_row,
+                            journal=failed_journal,
+                            error_msg=str(op_exc)[:500],
+                        )
+                    except Exception as bookkeeping_error:
+                        logger.error(
+                            "Failed to record FAILED custom-chunk journal for "
+                            f"{doc_key}: {bookkeeping_error}"
+                        )
+                    raise
 
         finally:
             # Everything here is gated on busy_acquired. If we rejected
@@ -1791,7 +2052,19 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     # outer terminal release would clear busy and strand them
                     # behind request_pending=True with no active processor.
                     try:
-                        await self._insert_done_with_cleanup()
+                        if op_failed:
+                            # Failure path: do NOT blind-flush partial work
+                            # (issue #3400 root cause 6). Persist what is
+                            # valuable (the LLM cache — handled inside the
+                            # discard helper) and drop the partial buffers;
+                            # the journal anchors whatever immediate-write
+                            # backends already committed, and the same SDK
+                            # call resumes from the staged data.
+                            await self._discard_pending_index_ops(
+                                skip_enqueue_owned=False
+                            )
+                        else:
+                            await self._insert_done_with_cleanup()
                     finally:
                         decision = await with_reservation_lock(
                             pipeline_status,
@@ -1831,6 +2104,120 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         token=token,
                         action=_terminal_release,
                     )
+
+    async def _upsert_custom_chunk_status(
+        self,
+        doc_key: str,
+        status: DocStatus,
+        *,
+        base_row: dict[str, Any] | None,
+        journal: dict[str, Any] | None,
+        full_text: str | None = None,
+        file_path: str | None = None,
+        chunks_list: list[str] | None = None,
+        error_msg: str | None = None,
+    ) -> dict[str, Any]:
+        """Upsert the doc_status row for a custom-chunk operation.
+
+        doc_status backends replace the whole record (and its ``metadata``
+        blob) on upsert, so the full field set is rebuilt from ``base_row``
+        (the previously fetched/returned record) — base-document metadata is
+        carried verbatim with only the ``custom_chunk_patch`` key added
+        (``journal``) or removed (``journal=None``, at commit). Returns the
+        upserted payload so consecutive transitions can pass it back in as
+        ``base_row`` without refetching.
+        """
+        now_iso = datetime.now(timezone.utc).isoformat()
+        if base_row:
+            metadata = dict(base_row.get("metadata") or {})
+            payload: dict[str, Any] = {
+                "status": status,
+                "content_summary": base_row.get("content_summary") or "",
+                "content_length": base_row.get("content_length") or 0,
+                "created_at": base_row.get("created_at") or now_iso,
+                "updated_at": now_iso,
+                "file_path": base_row.get("file_path")
+                or file_path
+                or normalize_document_file_path(""),
+                "track_id": base_row.get("track_id"),
+                "content_hash": base_row.get("content_hash"),
+                "metadata": metadata,
+            }
+            existing_chunks = [
+                cid
+                for cid in (base_row.get("chunks_list") or [])
+                if isinstance(cid, str) and cid
+            ]
+        else:
+            payload = {
+                "status": status,
+                "content_summary": get_content_summary(full_text or ""),
+                "content_length": len(full_text or ""),
+                "created_at": now_iso,
+                "updated_at": now_iso,
+                "file_path": file_path or normalize_document_file_path(""),
+                "track_id": generate_track_id("insert"),
+                "content_hash": compute_text_content_hash(full_text or ""),
+                "metadata": {},
+            }
+            existing_chunks = []
+
+        effective_chunks = chunks_list if chunks_list is not None else existing_chunks
+        payload["chunks_list"] = list(effective_chunks)
+        payload["chunks_count"] = len(effective_chunks)
+
+        if journal is None:
+            payload["metadata"].pop(CUSTOM_CHUNK_PATCH_METADATA_KEY, None)
+        else:
+            payload["metadata"][CUSTOM_CHUNK_PATCH_METADATA_KEY] = journal
+
+        if error_msg is not None:
+            payload["error_msg"] = error_msg
+        elif status == DocStatus.PROCESSED:
+            payload["error_msg"] = ""
+
+        await self.doc_status.upsert({doc_key: payload})
+        return payload
+
+    async def _union_doc_recovery_anchors(
+        self,
+        doc_id: str,
+        entity_names,
+        relation_pairs,
+    ) -> None:
+        """Union a patch's candidates into the document's recovery anchors.
+
+        A custom-chunk patch must never overwrite the base document's
+        ``full_entities`` / ``full_relations`` rows — the base document keeps
+        owning its previously committed contributions — so the patch
+        candidates are unioned in and both rows flushed via the narrow
+        barrier (issue #3400 Phase 3, commit step).
+        """
+        entity_row = await self.full_entities.get_by_id(doc_id) or {}
+        union_names = set(entity_row.get("entity_names") or []) | set(entity_names)
+        await self.full_entities.upsert(
+            {
+                doc_id: {
+                    "entity_names": sorted(union_names),
+                    "count": len(union_names),
+                }
+            }
+        )
+
+        relation_row = await self.full_relations.get_by_id(doc_id) or {}
+        union_pairs = {
+            tuple(pair) for pair in (relation_row.get("relation_pairs") or [])
+        } | {tuple(pair) for pair in relation_pairs}
+        await self.full_relations.upsert(
+            {
+                doc_id: {
+                    "relation_pairs": [list(pair) for pair in sorted(union_pairs)],
+                    "count": len(union_pairs),
+                }
+            }
+        )
+
+        await self._flush_storages([self.full_entities, self.full_relations])
 
     async def _process_extract_entities(
         self, chunk: dict[str, Any], pipeline_status=None, pipeline_status_lock=None
@@ -3699,13 +4086,26 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             )
             # Order-preserving dedup so chunk_ids stays a list and satisfies the
             # storage delete contract (``delete(ids: list[str])``); a set view is
-            # built below for membership/intersection checks.
+            # built below for membership/intersection checks. Staged chunks of
+            # an unfinished custom-chunk operation (issue #3400 Phase 3) live
+            # only in the journal until commit unions them into chunks_list —
+            # include them so deleting the document also cleans the staging.
+            journal = metadata.get(CUSTOM_CHUNK_PATCH_METADATA_KEY)
+            journal_chunk_ids = (
+                normalize_string_list(
+                    journal.get("chunk_ids", []),
+                    context=f"doc {doc_id} custom_chunk_patch.chunk_ids",
+                )
+                if isinstance(journal, dict)
+                else []
+            )
             chunk_ids = list(
                 dict.fromkeys(
                     normalize_string_list(
                         doc_status_data.get("chunks_list", []),
                         context=f"doc {doc_id} chunks_list",
                     )
+                    + journal_chunk_ids
                 )
             )
             chunk_ids_set = set(chunk_ids)

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -126,6 +126,8 @@ from lightrag.utils_pipeline import (
     CUSTOM_CHUNK_PATCH_METADATA_KEY,
     compute_text_content_hash,
     doc_status_custom_chunk_patch,
+    make_custom_chunk_id,
+    make_custom_chunk_operation_id,
     normalize_document_file_path,
 )
 from lightrag.constants import GRAPH_FIELD_SEP
@@ -1622,17 +1624,18 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 doc_key = doc_id
 
             # Deterministic, document-scoped identity: chunk ids hash
-            # (doc_key, content) so identical text in two documents never
-            # shares a chunk row (a shared row's full_doc_id would be
-            # clobbered, and rollback could delete another document's chunk).
-            # The operation id hashes the ordered chunk-id set so the same
-            # logical input is the same operation across retries.
+            # (doc_key, content) — length-prefixed, see make_custom_chunk_id —
+            # so identical text in two documents never shares a chunk row (a
+            # shared row's full_doc_id would be clobbered, and rollback could
+            # delete another document's chunk). The operation id hashes the
+            # ordered chunk-id set so the same logical input is the same
+            # operation across retries.
             chunk_entries: list[tuple[str, str, str]] = []
             seen_chunk_ids: set[str] = set()
             for chunk_text in text_chunks:
                 if not chunk_text:
                     continue
-                chunk_id = compute_mdhash_id(doc_key + chunk_text, prefix="chunk-")
+                chunk_id = make_custom_chunk_id(doc_key, chunk_text)
                 if chunk_id in seen_chunk_ids:
                     continue
                 seen_chunk_ids.add(chunk_id)
@@ -1642,8 +1645,8 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             if not chunk_entries:
                 logger.warning("No non-empty custom chunks to insert.")
                 return
-            operation_id = compute_mdhash_id(
-                doc_key + "|".join(cid for cid, _, _ in chunk_entries), prefix="op-"
+            operation_id = make_custom_chunk_operation_id(
+                doc_key, [cid for cid, _, _ in chunk_entries]
             )
 
             # pipeline_status/lock are already initialized by
@@ -2382,10 +2385,14 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         if mode == "create":
             # The document did not exist before this operation: remove its
             # body and status row entirely. The purge above (whole-document
-            # mode) already dropped the anchors.
+            # mode) already dropped the anchors. The doc_status delete MUST
+            # be flushed here: unlike upsert (immediate-persist), delete is
+            # deferred-commit on the JSON backend, and reporting a rollback
+            # as successful while the FAILED journal row can reappear after
+            # a crash would be a false success.
             await self.full_docs.delete([doc_id])
-            await self._flush_storages([self.full_docs])
             await self.doc_status.delete([doc_id])
+            await self._flush_storages([self.full_docs, self.doc_status])
             return
 
         # Patch mode: prune anchor unions this document no longer owns (a

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -3041,24 +3041,25 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                ``source_id`` lists, then classifies it as either
                *delete-outright* (no remaining sources) or *rebuild*
                (still references chunks from other documents).
-            3. Deletes the chunks themselves from ``chunks_vdb`` and
-               ``text_chunks``.
-            4. For *delete-outright* entries: removes the relationship /
+            3. For *delete-outright* entries: removes the relationship /
                entity from the graph storage, vector storage, and chunk
-               tracking.
-            5. Calls :py:meth:`_insert_done` to persist graph changes
-               before rebuilding (so the rebuild step sees a consistent
-               state).
-            6. Calls :func:`rebuild_knowledge_from_chunks` to rebuild any
+               tracking, then persists via :py:meth:`_insert_done`.
+            4. Calls :func:`rebuild_knowledge_from_chunks` to rebuild any
                *rebuild* entries from their remaining chunks (so other
                documents that also contributed to the same entity /
-               relation keep their data intact). With ``strict_rebuild``,
-               missing extraction cache or a failed rebuild raises instead
-               of being logged (recovery must not silently succeed on
-               partial data).
-            7. Unless ``patch_only``: deletes the per-doc ``full_entities``
-               / ``full_relations`` index rows so subsequent re-extraction
-               starts fresh. A patch rollback must NOT drop the base
+               relation keep their data intact), then flushes the rebuilt
+               state. With ``strict_rebuild``, missing extraction cache or
+               a failed rebuild raises instead of being logged (recovery
+               must not silently succeed on partial data).
+            5. Only after every derived contribution is repaired/removed
+               and flushed: deletes the chunks themselves from
+               ``chunks_vdb`` and ``text_chunks`` and flushes them (safe
+               destructive ordering — graph objects never point at deleted
+               chunks).
+            6. Unless ``patch_only``: deletes the per-doc ``full_entities``
+               / ``full_relations`` index rows LAST and flushes, so every
+               intermediate failure keeps the recovery anchors and stays
+               retryable. A patch rollback must NOT drop the base
                document's recovery rows — the document keeps owning its
                previously committed contributions.
 
@@ -3297,22 +3298,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             )
             raise Exception(f"Failed to process graph dependencies: {e}") from e
 
-        # ---- 3. Delete chunks themselves ----
-        try:
-            await self.chunks_vdb.delete(chunk_ids)
-            await self.text_chunks.delete(chunk_ids)
-            async with pipeline_status_lock:
-                log_message = (
-                    f"[purge] {doc_id}: deleted {len(chunk_ids)} chunk(s) from storage"
-                )
-                logger.info(log_message)
-                pipeline_status["latest_message"] = log_message
-                pipeline_status["history_messages"].append(log_message)
-        except Exception as e:
-            logger.error(f"[purge] Failed to delete chunks for {doc_id}: {e}")
-            raise Exception(f"Failed to delete document chunks: {e}") from e
-
-        # ---- 4. Delete relationships with no remaining sources ----
+        # ---- 3. Delete relationships with no remaining sources ----
         if relationships_to_delete:
             try:
                 rel_ids_to_delete = []
@@ -3347,7 +3333,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 )
                 raise Exception(f"Failed to delete relationships: {e}") from e
 
-        # ---- 5. Delete entities with no remaining sources ----
+        # ---- 4. Delete entities with no remaining sources ----
         if entities_to_delete:
             try:
                 nodes_edges_dict = (
@@ -3408,7 +3394,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 logger.error(f"[purge] Failed to delete entities for {doc_id}: {e}")
                 raise Exception(f"Failed to delete entities: {e}") from e
 
-        # ---- 6. Persist pre-rebuild changes ----
+        # ---- 5. Persist pre-rebuild changes ----
         # Use plain _insert_done (no discard-on-failure): the pending buffer
         # here holds DELETES, which are not regenerable by reprocessing. On a
         # flush failure they must stay buffered for a later retry, not be
@@ -3419,7 +3405,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             logger.error(f"[purge] Failed to persist pre-rebuild changes: {e}")
             raise Exception(f"Failed to persist pre-rebuild changes: {e}") from e
 
-        # ---- 7. Rebuild entities/relations that still have remaining sources ----
+        # ---- 6. Rebuild entities/relations that still have remaining sources ----
         if entities_to_rebuild or relationships_to_rebuild:
             try:
                 await rebuild_knowledge_from_chunks(
@@ -3441,13 +3427,46 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 logger.error(f"[purge] Failed to rebuild knowledge from chunks: {e}")
                 raise Exception(f"Failed to rebuild knowledge graph: {e}") from e
 
+            # Persist the rebuilt graph/vector/tracking state before the
+            # source chunks disappear — a crash after this flush leaves a
+            # fully repaired graph plus still-present chunks (retryable),
+            # never repaired-in-memory-only state.
+            try:
+                await self._insert_done()
+            except Exception as e:
+                logger.error(f"[purge] Failed to persist rebuilt knowledge: {e}")
+                raise Exception(f"Failed to persist rebuilt knowledge: {e}") from e
+
+        # ---- 7. Delete chunks themselves ----
+        # Deleted only AFTER every derived graph/vector/tracking contribution
+        # has been repaired or removed AND flushed (issue #3400: unsafe
+        # destructive ordering). A failure before this point leaves the
+        # chunks in place, so graph objects never reference deleted chunks.
+        try:
+            await self.chunks_vdb.delete(chunk_ids)
+            await self.text_chunks.delete(chunk_ids)
+            await self._flush_storages([self.chunks_vdb, self.text_chunks])
+            async with pipeline_status_lock:
+                log_message = (
+                    f"[purge] {doc_id}: deleted {len(chunk_ids)} chunk(s) from storage"
+                )
+                logger.info(log_message)
+                pipeline_status["latest_message"] = log_message
+                pipeline_status["history_messages"].append(log_message)
+        except Exception as e:
+            logger.error(f"[purge] Failed to delete chunks for {doc_id}: {e}")
+            raise Exception(f"Failed to delete document chunks: {e}") from e
+
         # ---- 8. Delete per-doc full_entities / full_relations index rows ----
-        # Patch-only rollback keeps the base document's recovery rows: the
-        # document still owns its previously committed contributions.
+        # LAST, so every intermediate purge failure keeps the recovery
+        # anchors and stays retryable. Patch-only rollback keeps the base
+        # document's recovery rows: the document still owns its previously
+        # committed contributions.
         if not patch_only:
             try:
                 await self.full_entities.delete([doc_id])
                 await self.full_relations.delete([doc_id])
+                await self._flush_storages([self.full_entities, self.full_relations])
             except Exception as e:
                 logger.error(
                     f"[purge] Failed to delete full_entities/full_relations rows for {doc_id}: {e}"

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -3159,7 +3159,9 @@ async def merge_nodes_and_edges(
         await full_relations_storage.upsert(
             {
                 doc_id: {
-                    "relation_pairs": [list(pair) for pair in sorted(candidate_relations)],
+                    "relation_pairs": [
+                        list(pair) for pair in sorted(candidate_relations)
+                    ],
                     "count": len(candidate_relations),
                 }
             }
@@ -3174,9 +3176,7 @@ async def merge_nodes_and_edges(
                 namespace = getattr(storage_inst, "final_namespace", None) or getattr(
                     storage_inst, "namespace", ""
                 )
-                raise IndexFlushError(
-                    type(storage_inst).__name__, namespace, e
-                ) from e
+                raise IndexFlushError(type(storage_inst).__name__, namespace, e) from e
 
     # Get max async tasks limit from global_config for semaphore control
     graph_max_async = global_config.get("llm_model_max_async", 4) * 2

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -10,6 +10,7 @@ from typing import Any, AsyncIterator, overload, Literal
 from collections import Counter, defaultdict
 
 from lightrag.exceptions import (
+    KGRebuildCacheMissingError,
     PipelineCancelledException,
 )
 from lightrag.utils import (
@@ -45,6 +46,7 @@ from lightrag.utils import (
     merge_source_ids,
     make_relation_chunk_key,
     _cooperative_yield,
+    wait_tasks_with_drain,
     performance_timing_log,
 )
 from lightrag.base import (
@@ -926,6 +928,7 @@ async def rebuild_knowledge_from_chunks(
     pipeline_status_lock=None,
     entity_chunks_storage: BaseKVStorage | None = None,
     relation_chunks_storage: BaseKVStorage | None = None,
+    strict: bool = False,
 ) -> None:
     """Rebuild entity and relationship descriptions from cached extraction results with parallel processing
 
@@ -946,6 +949,13 @@ async def rebuild_knowledge_from_chunks(
         pipeline_status_lock: Lock for pipeline status
         entity_chunks_storage: KV storage maintaining full chunk IDs per entity
         relation_chunks_storage: KV storage maintaining full chunk IDs per relation
+        strict: When True (recovery paths, issue #3400), missing extraction
+            cache for any referenced chunk raises
+            ``KGRebuildCacheMissingError`` and any single rebuild failure
+            propagates instead of being counted and logged. Rebuild is then a
+            strict recovery operation: silently succeeding on partial data
+            could lead to a false PROCESSED state. Default False preserves
+            the historical best-effort behavior.
     """
     if not entities_to_rebuild and not relationships_to_rebuild:
         return
@@ -971,6 +981,20 @@ async def rebuild_knowledge_from_chunks(
         all_referenced_chunk_ids,
         text_chunks_storage=text_chunks_storage,
     )
+
+    if strict:
+        # Strict recovery: every referenced chunk must have cached extraction
+        # results. Rebuilding from partial cache would silently produce
+        # degraded aggregates and let the caller report a false success.
+        missing_chunk_ids = all_referenced_chunk_ids - set(cached_results.keys())
+        if missing_chunk_ids:
+            preview = ", ".join(sorted(missing_chunk_ids)[:5])
+            if len(missing_chunk_ids) > 5:
+                preview += f", ... (+{len(missing_chunk_ids) - 5} more)"
+            raise KGRebuildCacheMissingError(
+                f"Extraction cache missing for {len(missing_chunk_ids)} of "
+                f"{len(all_referenced_chunk_ids)} referenced chunk(s): {preview}"
+            )
 
     if not cached_results:
         status_message = "No cached extraction results found, cannot rebuild"
@@ -1096,6 +1120,10 @@ async def rebuild_knowledge_from_chunks(
                         async with pipeline_status_lock:
                             pipeline_status["latest_message"] = status_message
                             pipeline_status["history_messages"].append(status_message)
+                    if strict:
+                        # Strict recovery: a single failed rebuild must fail
+                        # the whole operation, not be downgraded to a counter.
+                        raise
 
     async def _locked_rebuild_relationship(src, tgt, chunk_ids):
         nonlocal rebuilt_relationships_count, failed_relationships_count
@@ -1134,6 +1162,10 @@ async def rebuild_knowledge_from_chunks(
                         async with pipeline_status_lock:
                             pipeline_status["latest_message"] = status_message
                             pipeline_status["history_messages"].append(status_message)
+                    if strict:
+                        # Strict recovery: a single failed rebuild must fail
+                        # the whole operation, not be downgraded to a counter.
+                        raise
 
     # Create tasks for parallel processing
     tasks = []
@@ -1156,37 +1188,10 @@ async def rebuild_knowledge_from_chunks(
             pipeline_status["latest_message"] = status_message
             pipeline_status["history_messages"].append(status_message)
 
-    # Execute all tasks in parallel with semaphore control and early failure detection
-    done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
-
-    # Check if any task raised an exception and ensure all exceptions are retrieved
-    first_exception = None
-
-    for task in done:
-        try:
-            exception = task.exception()
-            if exception is not None:
-                if first_exception is None:
-                    first_exception = exception
-            else:
-                # Task completed successfully, retrieve result to mark as processed
-                task.result()
-        except Exception as e:
-            if first_exception is None:
-                first_exception = e
-
-    # If any task failed, cancel all pending tasks and raise the first exception
-    if first_exception is not None:
-        # Cancel all pending tasks
-        for pending_task in pending:
-            pending_task.cancel()
-
-        # Wait for cancellation to complete
-        if pending:
-            await asyncio.wait(pending)
-
-        # Re-raise the first exception to notify the caller
-        raise first_exception
+    # Execute all tasks in parallel with semaphore control; on any failure
+    # every sibling is cancelled and drained before the first exception
+    # propagates (no background rebuild writes survive failure handling).
+    await wait_tasks_with_drain(tasks, context="KG rebuild")
 
     # Final status report
     status_message = f"KG rebuild completed: {rebuilt_entities_count} entities and {rebuilt_relationships_count} relationships rebuilt successfully."
@@ -3007,6 +3012,43 @@ async def _merge_edges_then_upsert(
         )
 
 
+def collect_kg_merge_candidates(
+    chunk_results: list,
+) -> tuple[set[str], set[tuple[str, str]]]:
+    """Derive the full candidate entity/relation superset a merge may touch.
+
+    Recovery anchor for issue #3400: before any graph/vector/tracking
+    mutation, the caller must be able to persist a durable candidate set in
+    ``full_entities`` / ``full_relations`` so a later purge/retry can discover
+    every object the merge might have written. The superset therefore
+    includes:
+
+    - every extracted entity name;
+    - every endpoint of every extracted relation (relation processing can
+      create missing endpoint entities, see ``_merge_edges_then_upsert``);
+    - every relation pair, normalized to sorted order (undirected graph).
+
+    The result is a candidate SUPERSET, not proof of existence: purge must
+    verify source ownership per candidate and treat absent objects as no-ops.
+
+    Args:
+        chunk_results: List of ``(maybe_nodes, maybe_edges)`` tuples as
+            produced by ``extract_entities``.
+
+    Returns:
+        ``(candidate_entity_names, candidate_relation_pairs)``.
+    """
+    candidate_entities: set[str] = set()
+    candidate_relations: set[tuple[str, str]] = set()
+    for maybe_nodes, maybe_edges in chunk_results:
+        candidate_entities.update(maybe_nodes.keys())
+        for edge_key in maybe_edges:
+            pair = tuple(sorted((edge_key[0], edge_key[1])))
+            candidate_relations.add(pair)
+            candidate_entities.update(pair)
+    return candidate_entities, candidate_relations
+
+
 async def merge_nodes_and_edges(
     chunk_results: list,
     knowledge_graph_inst: BaseGraphStorage,
@@ -3154,40 +3196,14 @@ async def merge_nodes_and_edges(
         entity_tasks.append(task)
         await _cooperative_yield(i, every=16)
 
-    # Execute entity tasks with error handling
+    # Execute entity tasks; on any failure every sibling is cancelled and
+    # drained before the first exception propagates (no background writes
+    # survive failure handling — issue #3400).
     processed_entities = []
     if entity_tasks:
-        done, pending = await asyncio.wait(
-            entity_tasks, return_when=asyncio.FIRST_EXCEPTION
+        processed_entities = await wait_tasks_with_drain(
+            entity_tasks, context=f"entity merge {doc_id}"
         )
-
-        first_exception = None
-        processed_entities = []
-
-        for i, task in enumerate(done, start=1):
-            try:
-                result = task.result()
-            except BaseException as e:
-                if first_exception is None:
-                    first_exception = e
-            else:
-                processed_entities.append(result)
-            await _cooperative_yield(i, every=32)
-
-        if pending:
-            for task in pending:
-                task.cancel()
-            pending_results = await asyncio.gather(*pending, return_exceptions=True)
-            for result in pending_results:
-                if isinstance(result, BaseException):
-                    if first_exception is None:
-                        first_exception = result
-                else:
-                    processed_entities.append(result)
-
-        if first_exception is not None:
-            raise first_exception
-
         await asyncio.sleep(0)
 
     # ===== Phase 2: Process all relationships concurrently =====
@@ -3272,63 +3288,21 @@ async def merge_nodes_and_edges(
         edge_task_labels[task] = _format_relation_edge_label(edge_key)
         await _cooperative_yield(i, every=32)
 
-    # Execute relationship tasks with error handling
+    # Execute relationship tasks; failures cancel + drain every sibling
+    # before propagating (see wait_tasks_with_drain).
     processed_edges = []
     all_added_entities = []
 
     if edge_tasks:
-        done, pending = await asyncio.wait(
-            edge_tasks, return_when=asyncio.FIRST_EXCEPTION
+        edge_results = await wait_tasks_with_drain(
+            edge_tasks,
+            context=f"relation merge {doc_id}",
+            task_labels=edge_task_labels,
         )
-
-        first_exception = None
-
-        for i, task in enumerate(done, start=1):
-            try:
-                edge_data, added_entities = task.result()
-            except BaseException as e:
-                if first_exception is None:
-                    first_exception = e
-            else:
-                if edge_data is not None:
-                    processed_edges.append(edge_data)
-                all_added_entities.extend(added_entities)
-            await _cooperative_yield(i, every=32)
-
-        if pending:
-            pending_labels = [
-                edge_task_labels.get(task, "<unknown>") for task in pending
-            ]
-            preview = ", ".join(pending_labels[:10])
-            if len(pending_labels) > 10:
-                preview += f", ... (+{len(pending_labels) - 10} more)"
-            logger.warning(
-                "Phase 2 pending relation tasks for %s: %s",
-                doc_id,
-                preview or "<none>",
-            )
-            for task in pending:
-                task.cancel()
-            pending_results = await asyncio.gather(*pending, return_exceptions=True)
-            for result in pending_results:
-                if isinstance(result, BaseException):
-                    if first_exception is None:
-                        first_exception = result
-                else:
-                    edge_data, added_entities = result
-                    if edge_data is not None:
-                        processed_edges.append(edge_data)
-                    all_added_entities.extend(added_entities)
-
-            logger.info(
-                "Phase 2 pending relation tasks drained for %s: collected_edges=%d collected_added_entities=%d",
-                doc_id,
-                len(processed_edges),
-                len(all_added_entities),
-            )
-
-        if first_exception is not None:
-            raise first_exception
+        for edge_data, added_entities in edge_results:
+            if edge_data is not None:
+                processed_edges.append(edge_data)
+            all_added_entities.extend(added_entities)
 
         logger.info(
             "Phase 2 relation processing completed for %s: edges=%d added_entities=%d",

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -10,6 +10,7 @@ from typing import Any, AsyncIterator, overload, Literal
 from collections import Counter, defaultdict
 
 from lightrag.exceptions import (
+    IndexFlushError,
     KGRebuildCacheMissingError,
     PipelineCancelledException,
 )
@@ -3067,12 +3068,16 @@ async def merge_nodes_and_edges(
     total_files: int = 0,
     file_path: str = "unknown_source",
 ) -> None:
-    """Two-phase merge: process all entities first, then all relationships
+    """Merge extracted entities/relations into the KG behind write-ahead anchors.
 
-    This approach ensures data consistency by:
+    Phase order (issue #3400 — discoverability before mutation):
+    0. Phase 0: Persist the full candidate superset to ``full_entities`` /
+       ``full_relations`` and flush both BEFORE any graph mutation, so a
+       crash mid-merge always leaves a durable recovery anchor that purge /
+       retry can discover the contributions from. Both rows are written even
+       when empty; a failure here aborts the merge before mutation.
     1. Phase 1: Process all entities concurrently
     2. Phase 2: Process all relationships concurrently (may add missing entities)
-    3. Phase 3: Update full_entities and full_relations storage with final results
 
     Args:
         chunk_results: List of tuples (maybe_nodes, maybe_edges) containing extracted entities and relationships
@@ -3122,6 +3127,56 @@ async def merge_nodes_and_edges(
     async with pipeline_status_lock:
         pipeline_status["latest_message"] = log_message
         pipeline_status["history_messages"].append(log_message)
+
+    # ===== Phase 0: write-ahead recovery indexes (issue #3400) =====
+    # Persist the candidate superset BEFORE any graph/vector/tracking
+    # mutation. Candidates are a superset, not proof of existence: purge
+    # verifies ownership per candidate and skips absent objects. Empty rows
+    # are written too — a reprocess that now yields fewer (or zero)
+    # candidates must overwrite the stale anchors of the previous attempt.
+    if full_entities_storage and full_relations_storage and doc_id:
+        candidate_entities, candidate_relations = collect_kg_merge_candidates(
+            chunk_results
+        )
+        log_message = (
+            f"Phase 0: Writing recovery indexes for {doc_id}: "
+            f"{len(candidate_entities)} candidate entities, "
+            f"{len(candidate_relations)} candidate relations"
+        )
+        logger.info(log_message)
+        async with pipeline_status_lock:
+            pipeline_status["latest_message"] = log_message
+            pipeline_status["history_messages"].append(log_message)
+
+        await full_entities_storage.upsert(
+            {
+                doc_id: {
+                    "entity_names": sorted(candidate_entities),
+                    "count": len(candidate_entities),
+                }
+            }
+        )
+        await full_relations_storage.upsert(
+            {
+                doc_id: {
+                    "relation_pairs": [list(pair) for pair in sorted(candidate_relations)],
+                    "count": len(candidate_relations),
+                }
+            }
+        )
+        # Narrow flush barrier: both anchors must be durable before the first
+        # graph mutation. A failure propagates — merging without a recovery
+        # anchor would make a later partial failure undiscoverable.
+        for storage_inst in (full_entities_storage, full_relations_storage):
+            try:
+                await storage_inst.index_done_callback()
+            except Exception as e:
+                namespace = getattr(storage_inst, "final_namespace", None) or getattr(
+                    storage_inst, "namespace", ""
+                )
+                raise IndexFlushError(
+                    type(storage_inst).__name__, namespace, e
+                ) from e
 
     # Get max async tasks limit from global_config for semaphore control
     graph_max_async = global_config.get("llm_model_max_async", 4) * 2
@@ -3312,73 +3367,11 @@ async def merge_nodes_and_edges(
         )
         await asyncio.sleep(0)
 
-    # ===== Phase 3: Update full_entities and full_relations storage =====
-    if full_entities_storage and full_relations_storage and doc_id:
-        try:
-            # Merge all entities: original entities + entities added during edge processing
-            final_entity_names = set()
-
-            # Add original processed entities
-            for i, entity_data in enumerate(processed_entities, start=1):
-                if entity_data and entity_data.get("entity_name"):
-                    final_entity_names.add(entity_data["entity_name"])
-                await _cooperative_yield(i, every=32)
-
-            # Add entities that were added during relationship processing
-            for i, added_entity in enumerate(all_added_entities, start=1):
-                if added_entity and added_entity.get("entity_name"):
-                    final_entity_names.add(added_entity["entity_name"])
-                await _cooperative_yield(i, every=32)
-
-            # Collect all relation pairs
-            final_relation_pairs = set()
-            for i, edge_data in enumerate(processed_edges, start=1):
-                if edge_data:
-                    src_id = edge_data.get("src_id")
-                    tgt_id = edge_data.get("tgt_id")
-                    if src_id and tgt_id:
-                        relation_pair = tuple(sorted([src_id, tgt_id]))
-                        final_relation_pairs.add(relation_pair)
-                await _cooperative_yield(i, every=32)
-
-            log_message = f"Phase 3: Updating final {len(final_entity_names)}({len(processed_entities)}+{len(all_added_entities)}) entities and  {len(final_relation_pairs)} relations from {doc_id}"
-            logger.info(log_message)
-            async with pipeline_status_lock:
-                pipeline_status["latest_message"] = log_message
-                pipeline_status["history_messages"].append(log_message)
-
-            # Update storage
-            if final_entity_names:
-                await full_entities_storage.upsert(
-                    {
-                        doc_id: {
-                            "entity_names": list(final_entity_names),
-                            "count": len(final_entity_names),
-                        }
-                    }
-                )
-
-            if final_relation_pairs:
-                await full_relations_storage.upsert(
-                    {
-                        doc_id: {
-                            "relation_pairs": [
-                                list(pair) for pair in final_relation_pairs
-                            ],
-                            "count": len(final_relation_pairs),
-                        }
-                    }
-                )
-
-            logger.debug(
-                f"Updated entity-relation index for document {doc_id}: {len(final_entity_names)} entities (original: {len(processed_entities)}, added: {len(all_added_entities)}), {len(final_relation_pairs)} relations"
-            )
-
-        except Exception as e:
-            logger.error(
-                f"Failed to update entity-relation index for document {doc_id}: {e}"
-            )
-            # Don't raise exception to avoid affecting main flow
+    # NOTE: the recovery indexes are written (and flushed) in Phase 0, BEFORE
+    # graph mutation. The historical post-merge "Phase 3" write — which
+    # derived the rows from in-memory merge results and swallowed its own
+    # exceptions — is gone: a merge whose anchors cannot be persisted no
+    # longer mutates the graph at all (issue #3400).
 
     log_message = f"Completed merging: {len(processed_entities)} entities, {len(all_added_entities)} extra entities, {len(processed_edges)} relations"
     logger.info(log_message)

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
 
@@ -11,7 +12,6 @@ from collections import Counter, defaultdict
 
 from lightrag.exceptions import (
     IndexFlushError,
-    KGRebuildCacheMissingError,
     PipelineCancelledException,
 )
 from lightrag.utils import (
@@ -93,6 +93,52 @@ from dotenv import load_dotenv
 # allows to use different .env file for each lightrag instance
 # the OS environment variables take precedence over the .env file
 load_dotenv(dotenv_path=Path(__file__).resolve().parent / ".env", override=False)
+
+
+KGRebuildPolicy = Literal["best_effort", "rollback"]
+
+
+@dataclass
+class KGRebuildReport:
+    """Non-fatal data-quality gaps observed while rebuilding KG aggregates.
+
+    Missing or unusable extraction material degrades the semantic aggregate,
+    but rollback can still restore the hard provenance invariant by rewriting
+    graph/vector/tracking source IDs to the surviving chunks. Operational
+    storage failures are not represented here; rollback policy propagates
+    those failures so its journal remains retryable.
+    """
+
+    missing_cache_chunk_ids: set[str] = field(default_factory=set)
+    unusable_cache_chunk_ids: set[str] = field(default_factory=set)
+    referenced_chunk_ids: set[str] = field(default_factory=set)
+    degraded_entities: dict[str, list[str]] = field(default_factory=dict)
+    degraded_relationships: dict[tuple[str, str], list[str]] = field(
+        default_factory=dict
+    )
+
+    @property
+    def has_warnings(self) -> bool:
+        return bool(
+            self.missing_cache_chunk_ids
+            or self.unusable_cache_chunk_ids
+            or self.degraded_entities
+            or self.degraded_relationships
+        )
+
+    @property
+    def surviving_chunk_ids(self) -> set[str]:
+        if self.has_warnings:
+            chunk_ids = set(self.referenced_chunk_ids)
+        else:
+            chunk_ids = set()
+        chunk_ids.update(self.missing_cache_chunk_ids)
+        chunk_ids.update(self.unusable_cache_chunk_ids)
+        for ids in self.degraded_entities.values():
+            chunk_ids.update(ids)
+        for ids in self.degraded_relationships.values():
+            chunk_ids.update(ids)
+        return chunk_ids
 
 
 def _get_relationship_vdb_timeout_seconds(global_config: dict[str, Any]) -> float:
@@ -929,8 +975,8 @@ async def rebuild_knowledge_from_chunks(
     pipeline_status_lock=None,
     entity_chunks_storage: BaseKVStorage | None = None,
     relation_chunks_storage: BaseKVStorage | None = None,
-    strict: bool = False,
-) -> None:
+    rebuild_policy: KGRebuildPolicy = "best_effort",
+) -> KGRebuildReport:
     """Rebuild entity and relationship descriptions from cached extraction results with parallel processing
 
     This method uses cached LLM extraction results instead of calling LLM again,
@@ -950,16 +996,19 @@ async def rebuild_knowledge_from_chunks(
         pipeline_status_lock: Lock for pipeline status
         entity_chunks_storage: KV storage maintaining full chunk IDs per entity
         relation_chunks_storage: KV storage maintaining full chunk IDs per relation
-        strict: When True (recovery paths, issue #3400), missing extraction
-            cache for any referenced chunk raises
-            ``KGRebuildCacheMissingError`` and any single rebuild failure
-            propagates instead of being counted and logged. Rebuild is then a
-            strict recovery operation: silently succeeding on partial data
-            could lead to a false PROCESSED state. Default False preserves
-            the historical best-effort behavior.
+        rebuild_policy: ``best_effort`` preserves historical exception
+            handling for ordinary deletion. ``rollback`` treats missing or
+            unusable extraction data as a non-fatal semantic degradation and
+            structurally rewrites provenance from the surviving chunks, while
+            propagating operational graph/vector/tracking failures so the
+            rollback journal remains retryable.
     """
+    if rebuild_policy not in ("best_effort", "rollback"):
+        raise ValueError(f"Unsupported KG rebuild policy: {rebuild_policy}")
+
+    report = KGRebuildReport()
     if not entities_to_rebuild and not relationships_to_rebuild:
-        return
+        return report
 
     # Get all referenced chunk IDs
     all_referenced_chunk_ids = set()
@@ -967,6 +1016,7 @@ async def rebuild_knowledge_from_chunks(
         all_referenced_chunk_ids.update(chunk_ids)
     for chunk_ids in relationships_to_rebuild.values():
         all_referenced_chunk_ids.update(chunk_ids)
+    report.referenced_chunk_ids.update(all_referenced_chunk_ids)
 
     status_message = f"Rebuilding knowledge from {len(all_referenced_chunk_ids)} cached chunk extractions (parallel processing)"
     logger.info(status_message)
@@ -977,34 +1027,35 @@ async def rebuild_knowledge_from_chunks(
 
     # Get cached extraction results for these chunks using storage
     # cached_results： chunk_id -> [list of (extraction_result, create_time) from LLM cache sorted by create_time of the first extraction_result]
-    cached_results = await _get_cached_extraction_results(
+    cached_results, chunk_data_by_id = await _get_cached_extraction_results(
         llm_response_cache,
         all_referenced_chunk_ids,
         text_chunks_storage=text_chunks_storage,
     )
 
-    if strict:
-        # Strict recovery: every referenced chunk must have cached extraction
-        # results. Rebuilding from partial cache would silently produce
-        # degraded aggregates and let the caller report a false success.
-        missing_chunk_ids = all_referenced_chunk_ids - set(cached_results.keys())
-        if missing_chunk_ids:
-            preview = ", ".join(sorted(missing_chunk_ids)[:5])
-            if len(missing_chunk_ids) > 5:
-                preview += f", ... (+{len(missing_chunk_ids) - 5} more)"
-            raise KGRebuildCacheMissingError(
-                f"Extraction cache missing for {len(missing_chunk_ids)} of "
-                f"{len(all_referenced_chunk_ids)} referenced chunk(s): {preview}"
-            )
-
-    if not cached_results:
-        status_message = "No cached extraction results found, cannot rebuild"
+    missing_chunk_ids = all_referenced_chunk_ids - set(cached_results.keys())
+    report.missing_cache_chunk_ids.update(missing_chunk_ids)
+    if missing_chunk_ids:
+        status_message = (
+            f"Extraction cache missing for {len(missing_chunk_ids)} of "
+            f"{len(all_referenced_chunk_ids)} referenced chunk(s); "
+            "rebuild may use structural fallback"
+        )
         logger.warning(status_message)
         if pipeline_status is not None and pipeline_status_lock is not None:
             async with pipeline_status_lock:
                 pipeline_status["latest_message"] = status_message
                 pipeline_status["history_messages"].append(status_message)
-        return
+
+    if not cached_results:
+        status_message = "No cached extraction results found"
+        logger.warning(status_message)
+        if pipeline_status is not None and pipeline_status_lock is not None:
+            async with pipeline_status_lock:
+                pipeline_status["latest_message"] = status_message
+                pipeline_status["history_messages"].append(status_message)
+        if rebuild_policy == "best_effort":
+            return report
 
     # Process cached results to get entities and relationships for each chunk
     chunk_entities = {}  # chunk_id -> {entity_name: [entity_data]}
@@ -1023,6 +1074,7 @@ async def rebuild_knowledge_from_chunks(
                     chunk_id=chunk_id,
                     extraction_result=result[0],
                     timestamp=result[1],
+                    chunk_data=chunk_data_by_id.get(chunk_id),
                 )
 
                 # Merge entities and relationships from this extraction result
@@ -1073,10 +1125,11 @@ async def rebuild_knowledge_from_chunks(
                         # Otherwise keep existing version
 
         except Exception as e:
+            report.unusable_cache_chunk_ids.add(chunk_id)
             status_message = (
                 f"Failed to parse cached extraction result for chunk {chunk_id}: {e}"
             )
-            logger.info(status_message)  # Per requirement, change to info
+            logger.warning(status_message)
             if pipeline_status is not None and pipeline_status_lock is not None:
                 async with pipeline_status_lock:
                     pipeline_status["latest_message"] = status_message
@@ -1092,6 +1145,7 @@ async def rebuild_knowledge_from_chunks(
     rebuilt_relationships_count = 0
     failed_entities_count = 0
     failed_relationships_count = 0
+    structural_fallback = rebuild_policy == "rollback"
 
     async def _locked_rebuild_entity(entity_name, chunk_ids):
         nonlocal rebuilt_entities_count, failed_entities_count
@@ -1102,7 +1156,7 @@ async def rebuild_knowledge_from_chunks(
                 [entity_name], namespace=namespace, enable_logging=False
             ):
                 try:
-                    await _rebuild_single_entity(
+                    degraded = await _rebuild_single_entity(
                         knowledge_graph_inst=knowledge_graph_inst,
                         entities_vdb=entities_vdb,
                         entity_name=entity_name,
@@ -1111,8 +1165,12 @@ async def rebuild_knowledge_from_chunks(
                         llm_response_cache=llm_response_cache,
                         global_config=global_config,
                         entity_chunks_storage=entity_chunks_storage,
+                        chunk_data_by_id=chunk_data_by_id,
+                        structural_fallback=structural_fallback,
                     )
                     rebuilt_entities_count += 1
+                    if degraded:
+                        report.degraded_entities[entity_name] = list(chunk_ids)
                 except Exception as e:
                     failed_entities_count += 1
                     status_message = f"Failed to rebuild `{entity_name}`: {e}"
@@ -1121,9 +1179,9 @@ async def rebuild_knowledge_from_chunks(
                         async with pipeline_status_lock:
                             pipeline_status["latest_message"] = status_message
                             pipeline_status["history_messages"].append(status_message)
-                    if strict:
-                        # Strict recovery: a single failed rebuild must fail
-                        # the whole operation, not be downgraded to a counter.
+                    if rebuild_policy == "rollback":
+                        # A real storage/rebuild failure is retryable and must
+                        # retain the custom-chunk journal.
                         raise
 
     async def _locked_rebuild_relationship(src, tgt, chunk_ids):
@@ -1139,7 +1197,7 @@ async def rebuild_knowledge_from_chunks(
                 enable_logging=False,
             ):
                 try:
-                    await _rebuild_single_relationship(
+                    degraded = await _rebuild_single_relationship(
                         knowledge_graph_inst=knowledge_graph_inst,
                         relationships_vdb=relationships_vdb,
                         entities_vdb=entities_vdb,
@@ -1153,8 +1211,12 @@ async def rebuild_knowledge_from_chunks(
                         entity_chunks_storage=entity_chunks_storage,
                         pipeline_status=pipeline_status,
                         pipeline_status_lock=pipeline_status_lock,
+                        chunk_data_by_id=chunk_data_by_id,
+                        structural_fallback=structural_fallback,
                     )
                     rebuilt_relationships_count += 1
+                    if degraded:
+                        report.degraded_relationships[(src, tgt)] = list(chunk_ids)
                 except Exception as e:
                     failed_relationships_count += 1
                     status_message = f"Failed to rebuild `{src}`~`{tgt}`: {e}"
@@ -1163,9 +1225,9 @@ async def rebuild_knowledge_from_chunks(
                         async with pipeline_status_lock:
                             pipeline_status["latest_message"] = status_message
                             pipeline_status["history_messages"].append(status_message)
-                    if strict:
-                        # Strict recovery: a single failed rebuild must fail
-                        # the whole operation, not be downgraded to a counter.
+                    if rebuild_policy == "rollback":
+                        # A real storage/rebuild failure is retryable and must
+                        # retain the custom-chunk journal.
                         raise
 
     # Create tasks for parallel processing
@@ -1205,12 +1267,25 @@ async def rebuild_knowledge_from_chunks(
             pipeline_status["latest_message"] = status_message
             pipeline_status["history_messages"].append(status_message)
 
+    if report.has_warnings:
+        logger.warning(
+            "KG rebuild completed with degraded recovery: "
+            "missing_cache_chunks=%d unusable_cache_chunks=%d "
+            "entities=%d relationships=%d",
+            len(report.missing_cache_chunk_ids),
+            len(report.unusable_cache_chunk_ids),
+            len(report.degraded_entities),
+            len(report.degraded_relationships),
+        )
+
+    return report
+
 
 async def _get_cached_extraction_results(
     llm_response_cache: BaseKVStorage,
     chunk_ids: set[str],
     text_chunks_storage: BaseKVStorage,
-) -> dict[str, list[str]]:
+) -> tuple[dict[str, list[tuple[str, int]]], dict[str, dict[str, Any]]]:
     """Get cached extraction results for specific chunk IDs
 
     This function retrieves cached LLM extraction results for the given chunk IDs and returns
@@ -1224,19 +1299,21 @@ async def _get_cached_extraction_results(
         text_chunks_storage: Text chunks storage for retrieving chunk data and LLM cache references
 
     Returns:
-        Dict mapping chunk_id -> list of extraction_result_text, where:
-        - Keys (chunk_ids) are ordered by the create_time of their first extraction result
-        - Values (extraction results) are ordered by create_time within each chunk
+        A tuple containing the cache results grouped by chunk ID and the
+        corresponding text-chunk rows used for provenance fallback.
     """
     cached_results = {}
+    chunk_data_by_id: dict[str, dict[str, Any]] = {}
 
     # Collect all LLM cache IDs from chunks
     all_cache_ids = set()
 
     # Read from storage
-    chunk_data_list = await text_chunks_storage.get_by_ids(list(chunk_ids))
-    for chunk_data in chunk_data_list:
+    requested_chunk_ids = list(chunk_ids)
+    chunk_data_list = await text_chunks_storage.get_by_ids(requested_chunk_ids)
+    for chunk_id, chunk_data in zip(requested_chunk_ids, chunk_data_list):
         if chunk_data and isinstance(chunk_data, dict):
+            chunk_data_by_id[chunk_id] = chunk_data
             llm_cache_list = chunk_data.get("llm_cache_list", [])
             if llm_cache_list:
                 all_cache_ids.update(llm_cache_list)
@@ -1245,7 +1322,7 @@ async def _get_cached_extraction_results(
 
     if not all_cache_ids:
         logger.warning(f"No LLM cache IDs found for {len(chunk_ids)} chunk IDs")
-        return cached_results
+        return cached_results, chunk_data_by_id
 
     # Batch get LLM cache entries
     cache_data_list = await llm_response_cache.get_by_ids(list(all_cache_ids))
@@ -1293,7 +1370,8 @@ async def _get_cached_extraction_results(
     logger.info(
         f"Found {valid_entries} valid cache entries, {len(sorted_cached_results)} chunks with results"
     )
-    return sorted_cached_results  # each item: list(extraction_result, create_time)
+    # each cache item is (extraction_result, create_time)
+    return sorted_cached_results, chunk_data_by_id
 
 
 async def _process_extraction_result(
@@ -1432,6 +1510,7 @@ async def _rebuild_from_extraction_result(
     extraction_result: str,
     chunk_id: str,
     timestamp: int,
+    chunk_data: dict[str, Any] | None = None,
 ) -> tuple[dict, dict]:
     """Parse cached extraction result using the same logic as extract_entities.
 
@@ -1449,7 +1528,8 @@ async def _rebuild_from_extraction_result(
     """
 
     # Get chunk data for file_path from storage
-    chunk_data = await text_chunks_storage.get_by_id(chunk_id)
+    if chunk_data is None:
+        chunk_data = await text_chunks_storage.get_by_id(chunk_id)
     file_path = (
         chunk_data.get("file_path", "unknown_source")
         if chunk_data
@@ -1481,6 +1561,40 @@ async def _rebuild_from_extraction_result(
     )
 
 
+def _surviving_chunk_file_paths(
+    chunk_ids: list[str],
+    chunk_data_by_id: dict[str, dict[str, Any]],
+    global_config: dict[str, Any],
+) -> list[str]:
+    """Return bounded, order-preserving file paths for surviving chunks."""
+    file_paths = list(
+        dict.fromkeys(
+            str(chunk_data_by_id[chunk_id]["file_path"])
+            for chunk_id in chunk_ids
+            if chunk_id in chunk_data_by_id
+            and chunk_data_by_id[chunk_id].get("file_path")
+        )
+    )
+    max_file_paths = global_config.get("max_file_paths", DEFAULT_MAX_FILE_PATHS)
+    if len(file_paths) <= max_file_paths:
+        return file_paths
+
+    limit_method = (
+        global_config.get("source_ids_limit_method") or SOURCE_IDS_LIMIT_METHOD_KEEP
+    )
+    if limit_method == SOURCE_IDS_LIMIT_METHOD_FIFO:
+        limited = file_paths[-max_file_paths:]
+    else:
+        limited = file_paths[:max_file_paths]
+    placeholder = global_config.get(
+        "file_path_more_placeholder", DEFAULT_FILE_PATH_MORE_PLACEHOLDER
+    )
+    limited.append(
+        f"...{placeholder}...({limit_method} {max_file_paths}/{len(file_paths)})"
+    )
+    return limited
+
+
 async def _rebuild_single_entity(
     knowledge_graph_inst: BaseGraphStorage,
     entities_vdb: BaseVectorStorage,
@@ -1492,13 +1606,15 @@ async def _rebuild_single_entity(
     entity_chunks_storage: BaseKVStorage | None = None,
     pipeline_status: dict | None = None,
     pipeline_status_lock=None,
-) -> None:
+    chunk_data_by_id: dict[str, dict[str, Any]] | None = None,
+    structural_fallback: bool = False,
+) -> bool:
     """Rebuild a single entity from cached extraction results"""
 
     # Get current entity data
     current_entity = await knowledge_graph_inst.get_node(entity_name)
     if not current_entity:
-        return
+        return False
 
     # Helper function to update entity in both graph and vector storage
     async def _update_entity_storage(
@@ -1587,6 +1703,23 @@ async def _rebuild_single_entity(
             all_entity_data.extend(chunk_entities[chunk_id][entity_name])
 
     if not all_entity_data:
+        if structural_fallback:
+            logger.warning(
+                "No cached entity data found for `%s`; preserving semantic "
+                "fields while repairing provenance",
+                entity_name,
+            )
+            file_paths = _surviving_chunk_file_paths(
+                limited_chunk_ids, chunk_data_by_id or {}, global_config
+            )
+            await _update_entity_storage(
+                current_entity.get("description", ""),
+                current_entity.get("entity_type", "UNKNOWN"),
+                file_paths,
+                limited_chunk_ids,
+            )
+            return True
+
         logger.warning(
             f"No entity data found for `{entity_name}`, trying to rebuild from relationships"
         )
@@ -1595,7 +1728,7 @@ async def _rebuild_single_entity(
         edges = await knowledge_graph_inst.get_node_edges(entity_name)
         if not edges:
             logger.warning(f"No relations attached to entity `{entity_name}`")
-            return
+            return False
 
         # Collect relationship data to extract entity information
         relationship_descriptions = []
@@ -1635,7 +1768,7 @@ async def _rebuild_single_entity(
             file_paths,
             limited_chunk_ids,
         )
-        return
+        return False
 
     # Process cached entity data
     descriptions = []
@@ -1726,6 +1859,7 @@ async def _rebuild_single_entity(
         async with pipeline_status_lock:
             pipeline_status["latest_message"] = status_message
             pipeline_status["history_messages"].append(status_message)
+    return False
 
 
 async def _rebuild_single_relationship(
@@ -1742,7 +1876,9 @@ async def _rebuild_single_relationship(
     entity_chunks_storage: BaseKVStorage | None = None,
     pipeline_status: dict | None = None,
     pipeline_status_lock=None,
-) -> None:
+    chunk_data_by_id: dict[str, dict[str, Any]] | None = None,
+    structural_fallback: bool = False,
+) -> bool:
     """Rebuild a single relationship from cached extraction results
 
     Note: This function assumes the caller has already acquired the appropriate
@@ -1752,7 +1888,7 @@ async def _rebuild_single_relationship(
     # Get current relationship data
     current_relationship = await knowledge_graph_inst.get_edge(src, tgt)
     if not current_relationship:
-        return
+        return False
 
     # normalized_chunk_ids = merge_source_ids([], chunk_ids)
     normalized_chunk_ids = chunk_ids
@@ -1789,18 +1925,33 @@ async def _rebuild_single_relationship(
                         chunk_relationships[chunk_id][edge_key]
                     )
 
-    if not all_relationship_data:
+    degraded = not all_relationship_data
+    if degraded and not structural_fallback:
         logger.warning(f"No relation data found for `{src}-{tgt}`")
-        return
+        return False
+
+    if degraded:
+        logger.warning(
+            "No cached relation data found for `%s`~`%s`; preserving semantic "
+            "fields while repairing provenance",
+            src,
+            tgt,
+        )
 
     # Merge descriptions and keywords
-    descriptions = []
-    keywords = []
-    weights = []
-    file_paths_list = []
+    descriptions = [current_relationship.get("description", "")] if degraded else []
+    keywords = [current_relationship.get("keywords", "")] if degraded else []
+    weights = [current_relationship.get("weight", 1.0)] if degraded else []
+    file_paths_list = (
+        _surviving_chunk_file_paths(
+            limited_chunk_ids, chunk_data_by_id or {}, global_config
+        )
+        if degraded
+        else []
+    )
     seen_paths = set()
 
-    for rel_data in all_relationship_data:
+    for rel_data in all_relationship_data if not degraded else []:
         if rel_data.get("description"):
             descriptions.append(rel_data["description"])
         if rel_data.get("keywords"):
@@ -1849,7 +2000,9 @@ async def _rebuild_single_relationship(
     weight = sum(weights) if weights else current_relationship.get("weight", 1.0)
 
     # Generate final description from relations or fallback to current
-    if description_list:
+    if degraded:
+        final_description = current_relationship.get("description", "")
+    elif description_list:
         final_description, _ = await _handle_entity_relation_summary(
             "Relation",
             f"{src}-{tgt}",
@@ -1958,6 +2111,8 @@ async def _rebuild_single_relationship(
         try:
             await relationships_vdb.delete([rel_vdb_id, rel_vdb_id_reverse])
         except Exception as e:
+            if structural_fallback:
+                raise
             logger.debug(
                 f"Could not delete old relationship vector records {rel_vdb_id}, {rel_vdb_id_reverse}: {e}"
             )
@@ -2009,6 +2164,7 @@ async def _rebuild_single_relationship(
         async with pipeline_status_lock:
             pipeline_status["latest_message"] = status_message
             pipeline_status["history_messages"].append(status_message)
+    return degraded
 
 
 def _combine_descriptions_dedup(

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -107,6 +107,13 @@ class KGRebuildReport:
     graph/vector/tracking source IDs to the surviving chunks. Operational
     storage failures are not represented here; rollback policy propagates
     those failures so its journal remains retryable.
+
+    Known degradation semantics: a degraded relationship preserves its stored
+    ``weight`` as-is — without per-chunk extraction cache the rolled-back
+    chunk's weight contribution cannot be subtracted (#3399 precision is
+    restored only by a full reprocess). The degradation is recorded in the
+    persisted ``kg_recovery_warnings`` so operators can identify affected
+    aggregates.
     """
 
     missing_cache_chunk_ids: set[str] = field(default_factory=set)
@@ -128,17 +135,15 @@ class KGRebuildReport:
 
     @property
     def surviving_chunk_ids(self) -> set[str]:
-        if self.has_warnings:
-            chunk_ids = set(self.referenced_chunk_ids)
-        else:
-            chunk_ids = set()
-        chunk_ids.update(self.missing_cache_chunk_ids)
-        chunk_ids.update(self.unusable_cache_chunk_ids)
-        for ids in self.degraded_entities.values():
-            chunk_ids.update(ids)
-        for ids in self.degraded_relationships.values():
-            chunk_ids.update(ids)
-        return chunk_ids
+        """Chunk ids involved in a degraded rebuild (owner-lookup scope).
+
+        Every specific bucket (missing/unusable cache, degraded aggregates)
+        is a subset of ``referenced_chunk_ids`` by construction — missing =
+        referenced minus cached, unusable/degraded are recorded per rebuild
+        target — so the union is simply the full referenced set whenever any
+        degradation was recorded, and empty otherwise.
+        """
+        return set(self.referenced_chunk_ids) if self.has_warnings else set()
 
 
 def _get_relationship_vdb_timeout_seconds(global_config: dict[str, Any]) -> float:
@@ -1951,7 +1956,9 @@ async def _rebuild_single_relationship(
     )
     seen_paths = set()
 
-    for rel_data in all_relationship_data if not degraded else []:
+    # ``all_relationship_data`` is empty by definition when ``degraded``
+    # (degraded == not all_relationship_data), so no guard is needed here.
+    for rel_data in all_relationship_data:
         if rel_data.get("description"):
             descriptions.append(rel_data["description"])
         if rel_data.get("keywords"):

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -93,6 +93,7 @@ from lightrag.utils_pipeline import (
     build_chunks_dict_from_chunking_result,
     chunk_fields_from_status_doc,
     compute_text_content_hash,
+    doc_status_custom_chunk_patch,
     doc_status_field,
     doc_status_parse_failure_fields,
     doc_status_transition_metadata,
@@ -1491,6 +1492,30 @@ class _PipelineMixin:
         pipeline_status_lock: asyncio.Lock,
     ) -> dict[str, DocProcessingStatus]:
         """Validate and fix document data consistency by deleting inconsistent entries, but preserve failed documents"""
+        # Documents carrying a custom-chunk patch journal belong to an
+        # in-flight or failed ainsert_custom_chunks operation (issue #3400
+        # Phase 3). Ordinary pipeline processing must not touch them: a reset
+        # would strip the journal and rebuild the whole document, discarding
+        # the operation's recovery anchor. They are resumed by the SDK caller
+        # (same call) or rolled back by /documents/scan.
+        journaled_patch_docs = [
+            doc_id
+            for doc_id, status_doc in to_process_docs.items()
+            if doc_status_custom_chunk_patch(status_doc) is not None
+        ]
+        if journaled_patch_docs:
+            for doc_id in journaled_patch_docs:
+                to_process_docs.pop(doc_id, None)
+            async with pipeline_status_lock:
+                skip_message = (
+                    f"Skipping {len(journaled_patch_docs)} document(s) with an "
+                    "unfinished custom-chunk operation (retry the operation or "
+                    "run a scan to roll it back)"
+                )
+                logger.info(skip_message)
+                pipeline_status["latest_message"] = skip_message
+                pipeline_status["history_messages"].append(skip_message)
+
         inconsistent_docs = []
         failed_docs_to_preserve = []
         successful_deletions = 0

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -2816,6 +2816,22 @@ class _PipelineMixin:
                         ctx.pipeline_status, ctx.pipeline_status_lock
                     )
 
+                    # Flush ALL derived stores BEFORE the durable PROCESSED
+                    # write. doc_status backends persist immediately on
+                    # upsert, so writing PROCESSED first opens a crash window
+                    # where the status is durable but the graph/vector/chunk
+                    # data is not — a false PROCESSED that recovery can never
+                    # detect (issue #3400: status is the commit record).
+                    await self._insert_done()
+
+                    # A sibling document's flush error may have aborted the
+                    # batch while our flush ran; do not mark PROCESSED during
+                    # teardown — bail out so this document is FAILED and
+                    # retried on the next run.
+                    await self._raise_if_cancelled(
+                        ctx.pipeline_status, ctx.pipeline_status_lock
+                    )
+
                     process_end_time = int(time.time())
                     await self._upsert_doc_status_transition(
                         doc_id=doc_id,
@@ -2832,8 +2848,6 @@ class _PipelineMixin:
                             **extraction_meta,
                         },
                     )
-
-                    await self._insert_done()
 
                     async with ctx.pipeline_status_lock:
                         log_message = (

--- a/lightrag/tools/README_KG_INTEGRITY_REPAIR.md
+++ b/lightrag/tools/README_KG_INTEGRITY_REPAIR.md
@@ -1,0 +1,46 @@
+# KG Integrity Audit / Recovery-Anchor Repair
+
+Offline companion to the issue #3400 recoverable-mutation work.
+
+Since #3400, ingestion prewrites per-document **recovery anchors**
+(`full_entities` / `full_relations`) before mutating the graph, so purge,
+retry, and scan rollback can always discover a document's contributions.
+Installations with data ingested **before** that change (or written through
+direct KG paths like `ainsert_custom_kg`, which sit outside the
+document-level guarantee) may hold graph contributions with no anchor — such
+data is invisible to per-document cleanup and becomes orphaned when its
+document is deleted or reprocessed.
+
+This tool enumerates the whole graph (deliberately offline-only; the hot
+paths never do a graph-wide scan), maps every node/edge back to its owning
+documents via chunk `source_id` → `text_chunks` → `full_doc_id`, and:
+
+- reports per-document anchor gaps;
+- reports irrecoverable orphans (contributions whose source chunks no longer
+  exist) — these are never modified automatically;
+- with `--apply`, unions the missing entries into the anchor rows.
+
+## Usage
+
+Library (works with every configured backend combination):
+
+```python
+from lightrag.tools.kg_integrity_repair import audit_kg_integrity
+
+rag = LightRAG(...)
+await rag.initialize_storages()
+report = await audit_kg_integrity(rag)              # report only
+report = await audit_kg_integrity(rag, apply=True)  # repair anchors
+```
+
+CLI (env-driven construction — `WORKING_DIR`, `WORKSPACE`, `EMBEDDING_DIM`,
+`LIGHTRAG_*` storage selectors; never calls the LLM or embedder):
+
+```bash
+python -m lightrag.tools.kg_integrity_repair             # report
+python -m lightrag.tools.kg_integrity_repair --apply     # repair
+python -m lightrag.tools.kg_integrity_repair --verbose   # per-doc details
+```
+
+Run it while the server is stopped (or the workspace is otherwise idle):
+the audit reads a moving target if ingestion runs concurrently.

--- a/lightrag/tools/kg_integrity_repair.py
+++ b/lightrag/tools/kg_integrity_repair.py
@@ -51,7 +51,9 @@ def _split_sources(record: dict[str, Any] | None) -> list[str]:
     return [chunk_id for chunk_id in raw.split(GRAPH_FIELD_SEP) if chunk_id]
 
 
-async def _map_chunks_to_docs(rag, chunk_ids: set[str], batch_size: int) -> dict[str, str]:
+async def _map_chunks_to_docs(
+    rag, chunk_ids: set[str], batch_size: int
+) -> dict[str, str]:
     """chunk_id -> full_doc_id for every resolvable chunk."""
     mapping: dict[str, str] = {}
     ordered = sorted(chunk_ids)
@@ -244,8 +246,7 @@ def main() -> None:
     parser.add_argument(
         "--apply",
         action="store_true",
-        help="Union missing contributions into the anchor rows "
-        "(default: report only)",
+        help="Union missing contributions into the anchor rows (default: report only)",
     )
     parser.add_argument(
         "--verbose", action="store_true", help="Print per-document details"

--- a/lightrag/tools/kg_integrity_repair.py
+++ b/lightrag/tools/kg_integrity_repair.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Offline KG integrity audit / recovery-anchor repair (issue #3400 Phase 5).
+
+Installations that ingested documents BEFORE the write-ahead recovery anchors
+landed may hold graph data that ``full_entities`` / ``full_relations`` do not
+reference. Such contributions are invisible to the normal purge/retry
+discovery path: deleting or reprocessing their document leaves orphan graph
+objects behind.
+
+This tool enumerates the whole graph (expensive — deliberately OFFLINE-only;
+the ingestion/retry/delete/scan hot paths never do this), maps every node and
+edge back to its owning documents via chunk ``source_id`` → ``text_chunks`` →
+``full_doc_id``, and:
+
+- reports per-document anchor gaps (graph contributions missing from
+  ``full_entities`` / ``full_relations``);
+- reports irrecoverable orphans (contributions whose source chunks no longer
+  exist, so no document can be determined);
+- with ``apply=True``, unions the missing entries into the per-document
+  anchor rows (using the same union helper the custom-chunk commit path
+  uses) so purge/retry can discover them again. Orphans are only reported —
+  removing graph data is left to an operator decision.
+
+Usage (library — works with any configured backend combination):
+
+    rag = LightRAG(...)
+    await rag.initialize_storages()
+    report = await audit_kg_integrity(rag)              # report only
+    report = await audit_kg_integrity(rag, apply=True)  # repair anchors
+
+Usage (CLI — file-based default backends, honoring WORKING_DIR / WORKSPACE /
+LIGHTRAG_* storage env vars; server-backend deployments should prefer the
+library call from a small script wired to their own LightRAG construction):
+
+    python -m lightrag.tools.kg_integrity_repair [--apply] [--verbose]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+from typing import Any
+
+from lightrag.constants import GRAPH_FIELD_SEP
+from lightrag.utils import logger
+
+
+def _split_sources(record: dict[str, Any] | None) -> list[str]:
+    raw = (record or {}).get("source_id") or ""
+    return [chunk_id for chunk_id in raw.split(GRAPH_FIELD_SEP) if chunk_id]
+
+
+async def _map_chunks_to_docs(rag, chunk_ids: set[str], batch_size: int) -> dict[str, str]:
+    """chunk_id -> full_doc_id for every resolvable chunk."""
+    mapping: dict[str, str] = {}
+    ordered = sorted(chunk_ids)
+    for start in range(0, len(ordered), batch_size):
+        batch = ordered[start : start + batch_size]
+        rows = await rag.text_chunks.get_by_ids(batch)
+        for chunk_id, row in zip(batch, rows):
+            if isinstance(row, dict) and row.get("full_doc_id"):
+                mapping[chunk_id] = row["full_doc_id"]
+    return mapping
+
+
+async def audit_kg_integrity(
+    rag,
+    *,
+    apply: bool = False,
+    batch_size: int = 200,
+) -> dict[str, Any]:
+    """Audit (and optionally repair) per-document recovery-anchor coverage.
+
+    Returns a report dict:
+
+    - ``entities_total`` / ``relations_total``: graph object counts;
+    - ``missing_entity_anchors`` / ``missing_relation_anchors``:
+      ``{doc_id: [entity_name | [src, tgt], ...]}`` contributions absent from
+      the document's anchor row;
+    - ``orphan_entities`` / ``orphan_relations``: contributions with no
+      resolvable source chunk (reported, never modified);
+    - ``repaired_docs``: doc ids whose anchors were updated (``apply=True``).
+    """
+    graph = rag.chunk_entity_relation_graph
+
+    all_nodes = await graph.get_all_nodes()
+    all_edges = await graph.get_all_edges()
+
+    # Node/edge -> owning docs via source chunks.
+    referenced_chunks: set[str] = set()
+    node_sources: dict[str, list[str]] = {}
+    for node in all_nodes:
+        name = node.get("entity_id") or node.get("id")
+        if not name:
+            continue
+        sources = _split_sources(node)
+        node_sources[name] = sources
+        referenced_chunks.update(sources)
+
+    edge_sources: dict[tuple[str, str], list[str]] = {}
+    for edge in all_edges:
+        src, tgt = edge.get("source"), edge.get("target")
+        if not src or not tgt:
+            continue
+        pair = tuple(sorted((src, tgt)))
+        if pair in edge_sources:
+            continue  # some backends report undirected edges twice
+        sources = _split_sources(edge)
+        edge_sources[pair] = sources
+        referenced_chunks.update(sources)
+
+    chunk_to_doc = await _map_chunks_to_docs(rag, referenced_chunks, batch_size)
+
+    doc_entities: dict[str, set[str]] = {}
+    orphan_entities: list[str] = []
+    for name, sources in node_sources.items():
+        docs = {chunk_to_doc[c] for c in sources if c in chunk_to_doc}
+        if not docs:
+            orphan_entities.append(name)
+            continue
+        for doc_id in docs:
+            doc_entities.setdefault(doc_id, set()).add(name)
+
+    doc_relations: dict[str, set[tuple[str, str]]] = {}
+    orphan_relations: list[list[str]] = []
+    for pair, sources in edge_sources.items():
+        docs = {chunk_to_doc[c] for c in sources if c in chunk_to_doc}
+        if not docs:
+            orphan_relations.append(list(pair))
+            continue
+        for doc_id in docs:
+            doc_relations.setdefault(doc_id, set()).add(pair)
+
+    # Compare with the stored anchor rows.
+    missing_entity_anchors: dict[str, list[str]] = {}
+    for doc_id, names in doc_entities.items():
+        row = await rag.full_entities.get_by_id(doc_id)
+        anchored = set((row or {}).get("entity_names") or [])
+        missing = sorted(names - anchored)
+        if missing:
+            missing_entity_anchors[doc_id] = missing
+
+    missing_relation_anchors: dict[str, list[list[str]]] = {}
+    for doc_id, pairs in doc_relations.items():
+        row = await rag.full_relations.get_by_id(doc_id)
+        anchored = {tuple(p) for p in ((row or {}).get("relation_pairs") or [])}
+        missing = sorted(pairs - anchored)
+        if missing:
+            missing_relation_anchors[doc_id] = [list(p) for p in missing]
+
+    repaired_docs: list[str] = []
+    if apply and (missing_entity_anchors or missing_relation_anchors):
+        for doc_id in sorted(
+            set(missing_entity_anchors) | set(missing_relation_anchors)
+        ):
+            await rag._union_doc_recovery_anchors(
+                doc_id,
+                missing_entity_anchors.get(doc_id, []),
+                [tuple(p) for p in missing_relation_anchors.get(doc_id, [])],
+            )
+            repaired_docs.append(doc_id)
+        logger.info(
+            f"[kg-integrity] Repaired recovery anchors for {len(repaired_docs)} document(s)"
+        )
+
+    return {
+        "entities_total": len(node_sources),
+        "relations_total": len(edge_sources),
+        "missing_entity_anchors": missing_entity_anchors,
+        "missing_relation_anchors": missing_relation_anchors,
+        "orphan_entities": sorted(orphan_entities),
+        "orphan_relations": sorted(orphan_relations),
+        "repaired_docs": repaired_docs,
+    }
+
+
+def _print_report(report: dict[str, Any], verbose: bool) -> None:
+    print(
+        f"Graph: {report['entities_total']} entities, "
+        f"{report['relations_total']} relations"
+    )
+    missing_docs = set(report["missing_entity_anchors"]) | set(
+        report["missing_relation_anchors"]
+    )
+    print(f"Documents with anchor gaps: {len(missing_docs)}")
+    print(
+        f"Orphans (no resolvable source chunk): "
+        f"{len(report['orphan_entities'])} entities, "
+        f"{len(report['orphan_relations'])} relations"
+    )
+    if report["repaired_docs"]:
+        print(f"Repaired anchors for: {', '.join(report['repaired_docs'])}")
+    if verbose:
+        for doc_id, names in report["missing_entity_anchors"].items():
+            print(f"  {doc_id}: missing entity anchors: {names}")
+        for doc_id, pairs in report["missing_relation_anchors"].items():
+            print(f"  {doc_id}: missing relation anchors: {pairs}")
+        for name in report["orphan_entities"]:
+            print(f"  orphan entity: {name}")
+        for pair in report["orphan_relations"]:
+            print(f"  orphan relation: {pair}")
+
+
+async def _async_main(apply: bool, verbose: bool) -> bool:
+    import numpy as np
+
+    from lightrag import LightRAG
+    from lightrag.utils import EmbeddingFunc
+
+    async def _noop_llm(*args, **kwargs) -> str:
+        raise RuntimeError("kg_integrity_repair never calls the LLM")
+
+    async def _noop_embed(texts: list[str]) -> np.ndarray:
+        raise RuntimeError("kg_integrity_repair never embeds")
+
+    rag = LightRAG(
+        working_dir=os.getenv("WORKING_DIR", "./rag_storage"),
+        workspace=os.getenv("WORKSPACE", ""),
+        llm_model_func=_noop_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=int(os.getenv("EMBEDDING_DIM", "1024")),
+            max_token_size=8192,
+            func=_noop_embed,
+        ),
+    )
+    await rag.initialize_storages()
+    try:
+        report = await audit_kg_integrity(rag, apply=apply)
+        _print_report(report, verbose)
+        return True
+    finally:
+        await rag.finalize_storages()
+
+
+def main() -> None:
+    from dotenv import load_dotenv
+
+    load_dotenv(dotenv_path=".env", override=False)
+    parser = argparse.ArgumentParser(
+        description="Audit (and optionally repair) LightRAG per-document "
+        "recovery anchors (full_entities / full_relations)."
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Union missing contributions into the anchor rows "
+        "(default: report only)",
+    )
+    parser.add_argument(
+        "--verbose", action="store_true", help="Print per-document details"
+    )
+    args = parser.parse_args()
+    ok = asyncio.run(_async_main(apply=args.apply, verbose=args.verbose))
+    if not ok:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -3080,46 +3080,57 @@ async def wait_tasks_with_drain(
         return []
 
     ctx = f" [{context}]" if context else ""
+    results: list[Any] = []
+    first_exception: BaseException | None = None
+
     try:
         done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+
+        for i, task in enumerate(done, start=1):
+            try:
+                results.append(task.result())
+            except BaseException as e:
+                if first_exception is None:
+                    first_exception = e
+                elif not isinstance(e, asyncio.CancelledError):
+                    logger.error(f"Additional task failure{ctx}: {e}")
+            # NOTE: an await point — external cancellation delivered here is
+            # handled by the enclosing except so still-pending siblings never
+            # keep writing in the background.
+            await _cooperative_yield(i, every=32)
+
+        if pending:
+            if task_labels:
+                pending_labels = [
+                    task_labels.get(task, "<unknown>") for task in pending
+                ]
+                preview = ", ".join(pending_labels[:10])
+                if len(pending_labels) > 10:
+                    preview += f", ... (+{len(pending_labels) - 10} more)"
+                logger.warning(f"Draining pending tasks{ctx}: {preview or '<none>'}")
+            for task in pending:
+                task.cancel()
+            pending_results = await asyncio.gather(*pending, return_exceptions=True)
+            for result in pending_results:
+                if isinstance(result, BaseException):
+                    if first_exception is None:
+                        first_exception = result
+                    elif not isinstance(result, asyncio.CancelledError):
+                        logger.error(f"Additional task failure{ctx}: {result}")
+                else:
+                    results.append(result)
     except asyncio.CancelledError:
-        # External cancellation: do not leave siblings writing in the background.
+        # External cancellation of THIS waiter, delivered at ANY await point
+        # above — asyncio.wait itself, a cooperative yield while collecting
+        # done results (with siblings still pending after FIRST_EXCEPTION),
+        # or the drain gather. Cancel and drain everything before
+        # propagating so no task keeps writing in the background. Per-task
+        # CancelledError stored in a task's own result is caught by the
+        # inner handler and does NOT take this path.
         for task in tasks:
             task.cancel()
         await asyncio.gather(*tasks, return_exceptions=True)
         raise
-
-    results: list[Any] = []
-    first_exception: BaseException | None = None
-
-    for i, task in enumerate(done, start=1):
-        try:
-            results.append(task.result())
-        except BaseException as e:
-            if first_exception is None:
-                first_exception = e
-            elif not isinstance(e, asyncio.CancelledError):
-                logger.error(f"Additional task failure{ctx}: {e}")
-        await _cooperative_yield(i, every=32)
-
-    if pending:
-        if task_labels:
-            pending_labels = [task_labels.get(task, "<unknown>") for task in pending]
-            preview = ", ".join(pending_labels[:10])
-            if len(pending_labels) > 10:
-                preview += f", ... (+{len(pending_labels) - 10} more)"
-            logger.warning(f"Draining pending tasks{ctx}: {preview or '<none>'}")
-        for task in pending:
-            task.cancel()
-        pending_results = await asyncio.gather(*pending, return_exceptions=True)
-        for result in pending_results:
-            if isinstance(result, BaseException):
-                if first_exception is None:
-                    first_exception = result
-                elif not isinstance(result, asyncio.CancelledError):
-                    logger.error(f"Additional task failure{ctx}: {result}")
-            else:
-                results.append(result)
 
     if first_exception is not None:
         raise first_exception

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -3050,6 +3050,83 @@ async def _cooperative_yield(iteration: int, every: int = 64) -> None:
         await asyncio.sleep(0)
 
 
+async def wait_tasks_with_drain(
+    tasks: list[asyncio.Task],
+    *,
+    context: str = "",
+    task_labels: dict[asyncio.Task, str] | None = None,
+) -> list[Any]:
+    """Await *tasks*, guaranteeing none is left running when this returns/raises.
+
+    Concurrent multi-store writers (entity/relation merge, rebuild) must never
+    leave a sibling task writing in the background after a failure — a failed
+    ``gather``/``wait`` does not by itself imply the other write tasks stopped
+    (issue #3400, "incomplete async failure coordination").
+
+    Behavior:
+      - All tasks succeed: returns their results (completion order).
+      - Any task fails: cancels every still-pending sibling, awaits (drains)
+        them ALL so no background write survives, logs every additional
+        exception, then re-raises the FIRST exception observed.
+      - This coroutine itself is cancelled: cancels and drains all tasks
+        before propagating ``CancelledError``.
+
+    Args:
+        tasks: ``asyncio.Task`` objects (already scheduled).
+        context: Optional short label used in log messages.
+        task_labels: Optional per-task display labels for pending-task logging.
+    """
+    if not tasks:
+        return []
+
+    ctx = f" [{context}]" if context else ""
+    try:
+        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+    except asyncio.CancelledError:
+        # External cancellation: do not leave siblings writing in the background.
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
+
+    results: list[Any] = []
+    first_exception: BaseException | None = None
+
+    for i, task in enumerate(done, start=1):
+        try:
+            results.append(task.result())
+        except BaseException as e:
+            if first_exception is None:
+                first_exception = e
+            elif not isinstance(e, asyncio.CancelledError):
+                logger.error(f"Additional task failure{ctx}: {e}")
+        await _cooperative_yield(i, every=32)
+
+    if pending:
+        if task_labels:
+            pending_labels = [task_labels.get(task, "<unknown>") for task in pending]
+            preview = ", ".join(pending_labels[:10])
+            if len(pending_labels) > 10:
+                preview += f", ... (+{len(pending_labels) - 10} more)"
+            logger.warning(f"Draining pending tasks{ctx}: {preview or '<none>'}")
+        for task in pending:
+            task.cancel()
+        pending_results = await asyncio.gather(*pending, return_exceptions=True)
+        for result in pending_results:
+            if isinstance(result, BaseException):
+                if first_exception is None:
+                    first_exception = result
+                elif not isinstance(result, asyncio.CancelledError):
+                    logger.error(f"Additional task failure{ctx}: {result}")
+            else:
+                results.append(result)
+
+    if first_exception is not None:
+        raise first_exception
+
+    return results
+
+
 def always_get_an_event_loop() -> asyncio.AbstractEventLoop:
     """
     Ensure that there is always an event loop available.

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -264,6 +264,14 @@ def resolve_doc_status_parse_engine(
     )
 
 
+# Reserved doc_status.metadata key holding the custom-chunk patch journal
+# (issue #3400 Phase 3). While present, the document has an in-flight or
+# failed ainsert_custom_chunks operation: the pipeline must NOT process the
+# row as ordinary ingestion, resets must NOT strip it, and deletion must
+# include its staged chunk IDs.
+CUSTOM_CHUNK_PATCH_METADATA_KEY = "custom_chunk_patch"
+
+
 _DOC_STATUS_METADATA_CARRY_OVER_KEYS: tuple[str, ...] = (
     "process_options",
     "source_file",
@@ -281,7 +289,26 @@ _DOC_STATUS_METADATA_CARRY_OVER_KEYS: tuple[str, ...] = (
     "analyzing_start_time",
     "analyzing_end_time",
     "analyzing_stage_skipped",
+    # Custom-chunk patch journal: the durable recovery anchor for an
+    # in-flight/failed ainsert_custom_chunks operation. Must survive every
+    # status transition until the operation commits or is rolled back.
+    CUSTOM_CHUNK_PATCH_METADATA_KEY,
 )
+
+
+def doc_status_custom_chunk_patch(status_doc: Any) -> dict[str, Any] | None:
+    """Return the custom-chunk patch journal from a doc-status record, if any.
+
+    Accepts either a ``DocProcessingStatus`` object or a raw storage dict.
+    Returns ``None`` when the document carries no journal (the normal case).
+    """
+    if status_doc is None:
+        return None
+    raw_metadata = doc_status_field(status_doc, "metadata", {})
+    if not isinstance(raw_metadata, dict):
+        return None
+    journal = raw_metadata.get(CUSTOM_CHUNK_PATCH_METADATA_KEY)
+    return journal if isinstance(journal, dict) else None
 
 
 def doc_status_metadata_carry_over(status_doc: Any) -> dict[str, Any]:
@@ -333,6 +360,11 @@ def doc_status_transition_metadata(
 _DOC_STATUS_METADATA_DIRECTIVE_KEYS: tuple[str, ...] = (
     "process_options",
     "source_file",
+    # Defense in depth: journaled custom-chunk patch rows are excluded from
+    # pipeline processing/reset entirely, but if one ever reaches a reset the
+    # journal must survive — stripping it would orphan the operation's staged
+    # data with no recovery anchor (issue #3400).
+    CUSTOM_CHUNK_PATCH_METADATA_KEY,
 )
 
 

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -271,6 +271,11 @@ def resolve_doc_status_parse_engine(
 # include its staged chunk IDs.
 CUSTOM_CHUNK_PATCH_METADATA_KEY = "custom_chunk_patch"
 
+# Public, persistent audit trail for structurally successful but semantically
+# degraded KG recovery. The WebUI uses this key to distinguish a processed
+# document with recovery warnings from an ordinary informational metadata row.
+KG_RECOVERY_WARNINGS_METADATA_KEY = "kg_recovery_warnings"
+
 
 _DOC_STATUS_METADATA_CARRY_OVER_KEYS: tuple[str, ...] = (
     "process_options",
@@ -306,9 +311,7 @@ def make_custom_chunk_id(doc_key: str, chunk_text: str) -> str:
     would clobber ``full_doc_id`` and rollback/deletion of either document
     could remove the other's chunk.
     """
-    return compute_mdhash_id(
-        f"{len(doc_key)}:{doc_key}:{chunk_text}", prefix="chunk-"
-    )
+    return compute_mdhash_id(f"{len(doc_key)}:{doc_key}:{chunk_text}", prefix="chunk-")
 
 
 def make_custom_chunk_operation_id(doc_key: str, chunk_ids: list[str]) -> str:

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -296,6 +296,34 @@ _DOC_STATUS_METADATA_CARRY_OVER_KEYS: tuple[str, ...] = (
 )
 
 
+def make_custom_chunk_id(doc_key: str, chunk_text: str) -> str:
+    """Deterministic, document-scoped custom-chunk id (issue #3400 Phase 3).
+
+    The components are length-prefixed so the ``(doc, text)`` pair is
+    unambiguous: plain concatenation would give ``doc_id="a", chunk="bc"``
+    and ``doc_id="ab", chunk="c"`` the same hash input, letting two different
+    documents share one ``text_chunks``/``chunks_vdb`` row — the later upsert
+    would clobber ``full_doc_id`` and rollback/deletion of either document
+    could remove the other's chunk.
+    """
+    return compute_mdhash_id(
+        f"{len(doc_key)}:{doc_key}:{chunk_text}", prefix="chunk-"
+    )
+
+
+def make_custom_chunk_operation_id(doc_key: str, chunk_ids: list[str]) -> str:
+    """Deterministic operation id for one custom-chunk invocation.
+
+    Hashes the document key plus the ordered chunk-id set (length-prefixed
+    like :func:`make_custom_chunk_id`, so an arbitrary caller-supplied
+    ``doc_id`` cannot collide with the chunk-id list of another document).
+    The same logical input therefore maps to the same operation across
+    retries.
+    """
+    joined = "|".join(chunk_ids)
+    return compute_mdhash_id(f"{len(doc_key)}:{doc_key}:{joined}", prefix="op-")
+
+
 def doc_status_custom_chunk_patch(status_doc: Any) -> dict[str, Any] | None:
     """Return the custom-chunk patch journal from a doc-status record, if any.
 

--- a/lightrag_webui/src/features/DocumentManager.tsx
+++ b/lightrag_webui/src/features/DocumentManager.tsx
@@ -51,6 +51,7 @@ import {
   type StatusBucket,
   type StatusFilter
 } from '@/features/documentStatusFilters'
+import { hasDocumentWarning } from '@/features/documentRecoveryWarnings'
 
 type StatusDisplayConfig = {
   labelKey: string
@@ -260,7 +261,7 @@ const DocumentStatusDetailsDialog = ({ doc }: { doc: DocStatusResponse }) => {
           side="top"
           aria-label={openLabel}
         >
-          {doc.error_msg ? (
+          {hasDocumentWarning(doc) ? (
             <AlertTriangle className="h-4 w-4 text-yellow-500" />
           ) : (
             <Info className="h-4 w-4 text-blue-500" />

--- a/lightrag_webui/src/features/documentRecoveryWarnings.test.ts
+++ b/lightrag_webui/src/features/documentRecoveryWarnings.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test'
+
+import { hasDocumentWarning, hasKgRecoveryWarnings } from './documentRecoveryWarnings'
+
+describe('document recovery warning detection', () => {
+  test('detects a processed document with structured recovery warnings', () => {
+    expect(
+      hasDocumentWarning({
+        error_msg: '',
+        metadata: {
+          kg_recovery_warnings: [
+            { code: 'degraded_custom_chunk_rollback', operation_id: 'op-1' }
+          ]
+        }
+      })
+    ).toBe(true)
+  })
+
+  test('keeps error messages as warnings', () => {
+    expect(hasDocumentWarning({ error_msg: 'failed', metadata: {} })).toBe(true)
+  })
+
+  test('ignores absent, empty, and malformed recovery warnings', () => {
+    expect(hasKgRecoveryWarnings(undefined)).toBe(false)
+    expect(hasKgRecoveryWarnings({ kg_recovery_warnings: [] })).toBe(false)
+    expect(hasKgRecoveryWarnings({ kg_recovery_warnings: ['not-structured'] })).toBe(false)
+  })
+})

--- a/lightrag_webui/src/features/documentRecoveryWarnings.ts
+++ b/lightrag_webui/src/features/documentRecoveryWarnings.ts
@@ -1,0 +1,17 @@
+import type { DocStatusResponse } from '@/api/lightrag'
+
+export const KG_RECOVERY_WARNINGS_METADATA_KEY = 'kg_recovery_warnings'
+
+export const hasKgRecoveryWarnings = (
+  metadata: Record<string, any> | undefined
+): boolean => {
+  const warnings = metadata?.[KG_RECOVERY_WARNINGS_METADATA_KEY]
+  return (
+    Array.isArray(warnings) &&
+    warnings.some((warning) => warning && typeof warning === 'object')
+  )
+}
+
+export const hasDocumentWarning = (
+  doc: Pick<DocStatusResponse, 'error_msg' | 'metadata'>
+): boolean => Boolean(doc.error_msg) || hasKgRecoveryWarnings(doc.metadata)

--- a/tests/extraction/test_edge_weight_reprocess.py
+++ b/tests/extraction/test_edge_weight_reprocess.py
@@ -93,6 +93,10 @@ class _MemKV:
     async def upsert(self, data):
         self.data.update(data)
 
+    async def index_done_callback(self):
+        # In-memory store: the Phase-0 write-ahead flush barrier is a no-op.
+        pass
+
 
 def _cfg() -> dict:
     return {

--- a/tests/extraction/test_kg_recovery_primitives.py
+++ b/tests/extraction/test_kg_recovery_primitives.py
@@ -166,6 +166,57 @@ async def test_drain_external_cancellation_drains_children():
 
 @pytest.mark.offline
 @pytest.mark.asyncio
+async def test_drain_cancellation_between_wait_and_pending_cancel(monkeypatch):
+    """Codex review (PR #3416): cancellation delivered AFTER ``asyncio.wait``
+    returned but BEFORE the pending siblings were cancelled — e.g. at the
+    cooperative yield while collecting done results, with writers still
+    pending after FIRST_EXCEPTION — must still cancel and drain those
+    writers before ``CancelledError`` propagates."""
+    import lightrag.utils as utils_module
+
+    yield_entered = asyncio.Event()
+
+    async def blocking_yield(iteration: int, every: int = 64) -> None:
+        # Deterministically park the waiter INSIDE the done-results loop so
+        # the test can cancel it exactly in the reported window.
+        if iteration > 0 and iteration % every == 0:
+            yield_entered.set()
+            await asyncio.Event().wait()  # never set; only a cancel wakes it
+
+    monkeypatch.setattr(utils_module, "_cooperative_yield", blocking_yield)
+
+    async def _ok():
+        return 1
+
+    async def _fails():
+        raise RuntimeError("boom")
+
+    async def _slow_writer():
+        await asyncio.sleep(30)
+
+    # 31 completed + 1 failed = 32 done tasks -> the loop hits the yield at
+    # i=32 while the slow writer is still pending (FIRST_EXCEPTION).
+    completed = [asyncio.create_task(_ok()) for _ in range(31)]
+    failing = asyncio.create_task(_fails())
+    await asyncio.wait(completed + [failing])
+    sleeper = asyncio.create_task(_slow_writer())
+    tasks = completed + [failing, sleeper]
+
+    waiter = asyncio.create_task(wait_tasks_with_drain(tasks))
+    await yield_entered.wait()
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    assert sleeper.done(), (
+        "pending writer must be cancelled and drained when the waiter is "
+        "cancelled between wait() and the pending-cancel section"
+    )
+    assert sleeper.cancelled()
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
 async def test_drain_empty_task_list_is_noop():
     assert await wait_tasks_with_drain([]) == []
 

--- a/tests/extraction/test_kg_recovery_primitives.py
+++ b/tests/extraction/test_kg_recovery_primitives.py
@@ -1,0 +1,239 @@
+"""Phase-1 recovery primitives for issue #3400.
+
+Covers the building blocks later phases depend on:
+
+- ``collect_kg_merge_candidates``: the write-ahead candidate superset a merge
+  may touch (entities + relation endpoints + sorted relation pairs).
+- ``wait_tasks_with_drain``: sibling-task failure/cancellation must leave no
+  background task still writing.
+- ``rebuild_knowledge_from_chunks(strict=True)``: missing extraction cache is
+  an error, not a silently-logged partial success.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from lightrag.exceptions import KGRebuildCacheMissingError
+from lightrag.operate import (
+    collect_kg_merge_candidates,
+    rebuild_knowledge_from_chunks,
+)
+from lightrag.utils import wait_tasks_with_drain
+
+
+# --- collect_kg_merge_candidates -------------------------------------------
+
+
+def _chunk(nodes: dict, edges: dict):
+    return (nodes, edges)
+
+
+@pytest.mark.offline
+def test_candidates_include_entities_and_edge_endpoints():
+    """Relation processing can create missing endpoint entities, so every
+    endpoint must be in the entity candidate superset even when it was never
+    extracted as a standalone entity."""
+    chunk_results = [
+        _chunk({"ALICE": [{}]}, {("CARL", "ALICE"): [{}]}),
+        _chunk({"BOB": [{}]}, {}),
+    ]
+    entities, relations = collect_kg_merge_candidates(chunk_results)
+    assert entities == {"ALICE", "BOB", "CARL"}
+    assert relations == {("ALICE", "CARL")}
+
+
+@pytest.mark.offline
+def test_candidates_relation_pairs_are_sorted_and_deduped():
+    """Undirected graph: (B, A) and (A, B) are the same candidate pair."""
+    chunk_results = [
+        _chunk({}, {("B", "A"): [{}]}),
+        _chunk({}, {("A", "B"): [{}]}),
+    ]
+    entities, relations = collect_kg_merge_candidates(chunk_results)
+    assert relations == {("A", "B")}
+    assert entities == {"A", "B"}
+
+
+@pytest.mark.offline
+def test_candidates_empty_input_yields_empty_sets():
+    """Empty candidate sets are meaningful (a doc with no KG contribution
+    still needs its — empty — recovery rows written in later phases)."""
+    assert collect_kg_merge_candidates([]) == (set(), set())
+
+
+# --- wait_tasks_with_drain ---------------------------------------------------
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_drain_returns_all_results_on_success():
+    async def _ok(v):
+        return v
+
+    tasks = [asyncio.create_task(_ok(i)) for i in range(5)]
+    results = await wait_tasks_with_drain(tasks)
+    assert sorted(results) == [0, 1, 2, 3, 4]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_drain_on_failure_cancels_and_drains_all_siblings():
+    """After the first failure propagates, NO sibling task may still be
+    running — a still-running sibling would keep writing to storage in the
+    background (issue #3400, incomplete async failure coordination)."""
+    started = asyncio.Event()
+    cancelled_flags: list[bool] = []
+
+    async def _fails():
+        await started.wait()
+        raise RuntimeError("boom")
+
+    async def _slow_writer():
+        try:
+            await asyncio.sleep(30)
+            cancelled_flags.append(False)
+        except asyncio.CancelledError:
+            cancelled_flags.append(True)
+            raise
+
+    tasks = [asyncio.create_task(_slow_writer()) for _ in range(3)]
+    tasks.append(asyncio.create_task(_fails()))
+    started.set()
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await wait_tasks_with_drain(tasks, context="test")
+
+    # Every task has fully finished — none is left running detached.
+    assert all(t.done() for t in tasks)
+    assert cancelled_flags == [True, True, True]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_drain_raises_first_exception_not_cancellation():
+    """The ORIGINAL failure must surface, not the CancelledError of the
+    siblings that were cancelled during draining."""
+
+    async def _fails_fast():
+        raise ValueError("original failure")
+
+    async def _slow():
+        await asyncio.sleep(30)
+
+    tasks = [asyncio.create_task(_slow()), asyncio.create_task(_fails_fast())]
+    with pytest.raises(ValueError, match="original failure"):
+        await wait_tasks_with_drain(tasks)
+    assert all(t.done() for t in tasks)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_drain_external_cancellation_drains_children():
+    """Cancelling the waiter itself must also cancel + drain the children
+    before CancelledError propagates."""
+    entered = asyncio.Event()
+
+    async def _slow():
+        entered.set()
+        await asyncio.sleep(30)
+
+    children = [asyncio.create_task(_slow()) for _ in range(2)]
+
+    async def _wait():
+        await wait_tasks_with_drain(children)
+
+    waiter = asyncio.create_task(_wait())
+    await entered.wait()
+    await asyncio.sleep(0)
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+    assert all(t.done() for t in children)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_drain_empty_task_list_is_noop():
+    assert await wait_tasks_with_drain([]) == []
+
+
+# --- rebuild_knowledge_from_chunks strict mode ------------------------------
+
+
+class _KV:
+    def __init__(self, data: dict | None = None):
+        self.data = dict(data or {})
+
+    async def get_by_id(self, key):
+        return self.data.get(key)
+
+    async def get_by_ids(self, keys):
+        return [self.data.get(k) for k in keys]
+
+    async def upsert(self, data):
+        self.data.update(data)
+
+
+def _rebuild_kwargs(text_chunks: _KV, llm_cache: _KV, **overrides):
+    kwargs = dict(
+        entities_to_rebuild={"ALICE": ["c1"]},
+        relationships_to_rebuild={},
+        knowledge_graph_inst=None,  # never reached in these tests
+        entities_vdb=None,
+        relationships_vdb=None,
+        text_chunks_storage=text_chunks,
+        llm_response_cache=llm_cache,
+        global_config={"llm_model_max_async": 1},
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_strict_rebuild_raises_when_cache_missing():
+    """Strict recovery: no cached extraction for a referenced chunk must
+    raise, never silently return 'success' (which would let the caller mark
+    the document falsely PROCESSED)."""
+    text_chunks = _KV({"c1": {"content": "x", "llm_cache_list": []}})
+    with pytest.raises(KGRebuildCacheMissingError):
+        await rebuild_knowledge_from_chunks(
+            **_rebuild_kwargs(text_chunks, _KV(), strict=True)
+        )
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_strict_rebuild_raises_on_partially_missing_cache():
+    """One chunk has cache, one does not: strict mode must still fail —
+    rebuilding an aggregate from partial contributions silently degrades it."""
+    text_chunks = _KV(
+        {
+            "c1": {"content": "x", "llm_cache_list": ["k1"]},
+            "c2": {"content": "y", "llm_cache_list": []},
+        }
+    )
+    llm_cache = _KV(
+        {"k1": {"cache_type": "extract", "chunk_id": "c1", "return": "r", "create_time": 1}}
+    )
+    with pytest.raises(KGRebuildCacheMissingError):
+        await rebuild_knowledge_from_chunks(
+            **_rebuild_kwargs(
+                text_chunks,
+                llm_cache,
+                entities_to_rebuild={"ALICE": ["c1", "c2"]},
+                strict=True,
+            )
+        )
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_non_strict_rebuild_keeps_best_effort_return():
+    """Default (non-strict) behavior is unchanged: missing cache logs a
+    warning and returns without raising."""
+    text_chunks = _KV({"c1": {"content": "x", "llm_cache_list": []}})
+    await rebuild_knowledge_from_chunks(**_rebuild_kwargs(text_chunks, _KV()))

--- a/tests/extraction/test_kg_recovery_primitives.py
+++ b/tests/extraction/test_kg_recovery_primitives.py
@@ -217,7 +217,14 @@ async def test_strict_rebuild_raises_on_partially_missing_cache():
         }
     )
     llm_cache = _KV(
-        {"k1": {"cache_type": "extract", "chunk_id": "c1", "return": "r", "create_time": 1}}
+        {
+            "k1": {
+                "cache_type": "extract",
+                "chunk_id": "c1",
+                "return": "r",
+                "create_time": 1,
+            }
+        }
     )
     with pytest.raises(KGRebuildCacheMissingError):
         await rebuild_knowledge_from_chunks(

--- a/tests/extraction/test_kg_recovery_primitives.py
+++ b/tests/extraction/test_kg_recovery_primitives.py
@@ -6,22 +6,32 @@ Covers the building blocks later phases depend on:
   may touch (entities + relation endpoints + sorted relation pairs).
 - ``wait_tasks_with_drain``: sibling-task failure/cancellation must leave no
   background task still writing.
-- ``rebuild_knowledge_from_chunks(strict=True)``: missing extraction cache is
-  an error, not a silently-logged partial success.
+- ``rebuild_knowledge_from_chunks(rebuild_policy="rollback")``: missing
+  extraction cache is reported as a non-fatal degraded recovery condition.
 """
 
 from __future__ import annotations
 
 import asyncio
+from contextlib import asynccontextmanager
 
 import pytest
+import lightrag.operate as operate_module
 
-from lightrag.exceptions import KGRebuildCacheMissingError
 from lightrag.operate import (
     collect_kg_merge_candidates,
     rebuild_knowledge_from_chunks,
 )
 from lightrag.utils import wait_tasks_with_drain
+
+
+@pytest.fixture(autouse=True)
+def _storage_keyed_lock_noop(monkeypatch):
+    @asynccontextmanager
+    async def _noop_lock(*args, **kwargs):
+        yield
+
+    monkeypatch.setattr(operate_module, "get_storage_keyed_lock", _noop_lock)
 
 
 # --- collect_kg_merge_candidates -------------------------------------------
@@ -177,11 +187,16 @@ class _KV:
         self.data.update(data)
 
 
+class _AbsentGraph:
+    async def get_node(self, _name):
+        return None
+
+
 def _rebuild_kwargs(text_chunks: _KV, llm_cache: _KV, **overrides):
     kwargs = dict(
         entities_to_rebuild={"ALICE": ["c1"]},
         relationships_to_rebuild={},
-        knowledge_graph_inst=None,  # never reached in these tests
+        knowledge_graph_inst=_AbsentGraph(),
         entities_vdb=None,
         relationships_vdb=None,
         text_chunks_storage=text_chunks,
@@ -194,22 +209,19 @@ def _rebuild_kwargs(text_chunks: _KV, llm_cache: _KV, **overrides):
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_strict_rebuild_raises_when_cache_missing():
-    """Strict recovery: no cached extraction for a referenced chunk must
-    raise, never silently return 'success' (which would let the caller mark
-    the document falsely PROCESSED)."""
+async def test_rollback_rebuild_reports_when_cache_missing():
+    """Missing recovery material is reported without wedging rollback."""
     text_chunks = _KV({"c1": {"content": "x", "llm_cache_list": []}})
-    with pytest.raises(KGRebuildCacheMissingError):
-        await rebuild_knowledge_from_chunks(
-            **_rebuild_kwargs(text_chunks, _KV(), strict=True)
-        )
+    report = await rebuild_knowledge_from_chunks(
+        **_rebuild_kwargs(text_chunks, _KV(), rebuild_policy="rollback")
+    )
+    assert report.missing_cache_chunk_ids == {"c1"}
 
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_strict_rebuild_raises_on_partially_missing_cache():
-    """One chunk has cache, one does not: strict mode must still fail —
-    rebuilding an aggregate from partial contributions silently degrades it."""
+async def test_rollback_rebuild_reports_partially_missing_cache():
+    """Partial cache loss is visible in the report without failing recovery."""
     text_chunks = _KV(
         {
             "c1": {"content": "x", "llm_cache_list": ["k1"]},
@@ -226,20 +238,20 @@ async def test_strict_rebuild_raises_on_partially_missing_cache():
             }
         }
     )
-    with pytest.raises(KGRebuildCacheMissingError):
-        await rebuild_knowledge_from_chunks(
-            **_rebuild_kwargs(
-                text_chunks,
-                llm_cache,
-                entities_to_rebuild={"ALICE": ["c1", "c2"]},
-                strict=True,
-            )
+    report = await rebuild_knowledge_from_chunks(
+        **_rebuild_kwargs(
+            text_chunks,
+            llm_cache,
+            entities_to_rebuild={"ALICE": ["c1", "c2"]},
+            rebuild_policy="rollback",
         )
+    )
+    assert report.missing_cache_chunk_ids == {"c2"}
 
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_non_strict_rebuild_keeps_best_effort_return():
+async def test_default_rebuild_keeps_best_effort_return():
     """Default (non-strict) behavior is unchanged: missing cache logs a
     warning and returns without raising."""
     text_chunks = _KV({"c1": {"content": "x", "llm_cache_list": []}})

--- a/tests/extraction/test_write_ahead_indexes.py
+++ b/tests/extraction/test_write_ahead_indexes.py
@@ -1,0 +1,279 @@
+"""Write-ahead recovery indexes in ``merge_nodes_and_edges`` (issue #3400, Phase 2).
+
+The merge must persist and flush the full candidate superset to
+``full_entities`` / ``full_relations`` BEFORE the first graph mutation, so a
+crash at any later point always leaves a durable recovery anchor. The
+historical post-merge "Phase 3" write (derived from in-memory results, with
+swallowed exceptions) is gone; anchor persistence failures now abort the
+merge before it mutates anything.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import lightrag.operate as operate
+from lightrag.exceptions import IndexFlushError
+from lightrag.kg.shared_storage import initialize_share_data
+from lightrag.operate import merge_nodes_and_edges
+
+
+class _FakeTokenizer:
+    def encode(self, s: str):
+        return list(range(len(s)))
+
+
+class _OrderLog:
+    """Shared event recorder so stores can prove cross-store write ordering."""
+
+    def __init__(self):
+        self.events: list[str] = []
+
+    def add(self, event: str):
+        self.events.append(event)
+
+    def first(self, prefix: str) -> int:
+        for i, e in enumerate(self.events):
+            if e.startswith(prefix):
+                return i
+        return -1
+
+
+class _MemGraph:
+    def __init__(self, order: _OrderLog):
+        self.order = order
+        self.nodes: dict[str, dict] = {}
+        self.edges: dict = {}
+
+    async def get_node(self, name):
+        return self.nodes.get(name)
+
+    async def has_node(self, name):
+        return name in self.nodes
+
+    async def upsert_node(self, name, node_data):
+        self.order.add(f"graph.upsert_node:{name}")
+        self.nodes[name] = dict(node_data)
+
+    async def has_edge(self, s, t):
+        return (s, t) in self.edges or (t, s) in self.edges
+
+    async def get_edge(self, s, t):
+        return self.edges.get((s, t)) or self.edges.get((t, s))
+
+    async def upsert_edge(self, s, t, edge_data):
+        self.order.add(f"graph.upsert_edge:{s}~{t}")
+        self.edges[(s, t)] = dict(edge_data)
+
+
+class _MemVdb:
+    async def upsert(self, data):
+        pass
+
+    async def delete(self, ids):
+        pass
+
+
+class _MemKV:
+    def __init__(self, order: _OrderLog, name: str):
+        self.order = order
+        self.name = name
+        self.data: dict = {}
+
+    async def get_by_id(self, key):
+        return self.data.get(key)
+
+    async def get_by_ids(self, keys):
+        return [self.data.get(k) for k in keys]
+
+    async def upsert(self, data):
+        self.order.add(f"{self.name}.upsert")
+        self.data.update(data)
+
+    async def index_done_callback(self):
+        self.order.add(f"{self.name}.flush")
+
+
+def _cfg() -> dict:
+    return {
+        "tokenizer": _FakeTokenizer(),
+        "summary_context_size": 1_000_000,
+        "summary_max_tokens": 1_000_000,
+        "force_llm_summary_on_merge": 6,
+        "source_ids_limit_method": operate.SOURCE_IDS_LIMIT_METHOD_KEEP,
+        "max_source_ids_per_entity": 10_000,
+        "max_source_ids_per_relation": 10_000,
+        "max_file_paths": 100,
+        "file_path_more_placeholder": "...",
+    }
+
+
+def _node_dp(name: str, src: str) -> dict:
+    return {
+        "entity_name": name,
+        "entity_type": "person",
+        "description": f"{name} desc",
+        "source_id": src,
+        "file_path": "d.txt",
+        "timestamp": 1,
+    }
+
+
+def _chunk_results(src: str = "c1"):
+    """ALICE + ACME entities and an ALICE~ACME edge; BOB appears only as a
+    relation endpoint (never extracted standalone)."""
+    maybe_nodes = {
+        "ALICE": [_node_dp("ALICE", src)],
+        "ACME": [_node_dp("ACME", src)],
+    }
+    maybe_edges = {
+        ("ALICE", "BOB"): [
+            {
+                "src_id": "ALICE",
+                "tgt_id": "BOB",
+                "weight": 1.0,
+                "description": "rel",
+                "keywords": "k",
+                "source_id": src,
+                "file_path": "d.txt",
+                "timestamp": 1,
+            }
+        ]
+    }
+    return [(maybe_nodes, maybe_edges)]
+
+
+async def _merge(chunk_results, order: _OrderLog, **overrides):
+    initialize_share_data()
+    stores = {
+        "full_entities": _MemKV(order, "full_entities"),
+        "full_relations": _MemKV(order, "full_relations"),
+        "entity_chunks": _MemKV(order, "entity_chunks"),
+        "relation_chunks": _MemKV(order, "relation_chunks"),
+    }
+    stores.update({k: v for k, v in overrides.items() if k in stores})
+    graph = overrides.get("graph") or _MemGraph(order)
+    await merge_nodes_and_edges(
+        chunk_results,
+        graph,
+        _MemVdb(),
+        _MemVdb(),
+        _cfg(),
+        full_entities_storage=stores["full_entities"],
+        full_relations_storage=stores["full_relations"],
+        doc_id="d1",
+        pipeline_status={"history_messages": []},
+        pipeline_status_lock=asyncio.Lock(),
+        entity_chunks_storage=stores["entity_chunks"],
+        relation_chunks_storage=stores["relation_chunks"],
+    )
+    return graph, stores
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_anchors_written_and_flushed_before_first_graph_mutation():
+    order = _OrderLog()
+    await _merge(_chunk_results(), order)
+
+    first_mutation = min(
+        i
+        for i in (order.first("graph.upsert_node"), order.first("graph.upsert_edge"))
+        if i >= 0
+    )
+    for prefix in (
+        "full_entities.upsert",
+        "full_relations.upsert",
+        "full_entities.flush",
+        "full_relations.flush",
+    ):
+        idx = order.first(prefix)
+        assert idx >= 0, f"{prefix} never happened"
+        assert idx < first_mutation, (
+            f"{prefix} (at {idx}) must precede the first graph mutation "
+            f"(at {first_mutation}): {order.events}"
+        )
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_anchor_rows_contain_candidate_superset():
+    """The prewritten entity anchor includes relation endpoints (BOB) that
+    edge processing may create, and the relation anchor the sorted pair."""
+    order = _OrderLog()
+    _, stores = await _merge(_chunk_results(), order)
+
+    assert sorted(stores["full_entities"].data["d1"]["entity_names"]) == [
+        "ACME",
+        "ALICE",
+        "BOB",
+    ]
+    assert stores["full_relations"].data["d1"]["relation_pairs"] == [["ALICE", "BOB"]]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_empty_extraction_still_writes_both_anchor_rows():
+    """Zero candidates must still overwrite both rows (a reprocess yielding
+    nothing must not leave the previous attempt's stale anchors)."""
+    order = _OrderLog()
+    _, stores = await _merge([({}, {})], order)
+
+    assert stores["full_entities"].data["d1"] == {"entity_names": [], "count": 0}
+    assert stores["full_relations"].data["d1"] == {"relation_pairs": [], "count": 0}
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_reprocess_with_fewer_candidates_overwrites_stale_anchor():
+    order = _OrderLog()
+    initialize_share_data()
+    full_entities = _MemKV(order, "full_entities")
+    full_entities.data["d1"] = {"entity_names": ["STALE"], "count": 1}
+
+    _, stores = await _merge(_chunk_results(), order, full_entities=full_entities)
+    assert "STALE" not in stores["full_entities"].data["d1"]["entity_names"]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_anchor_upsert_failure_aborts_merge_before_mutation():
+    """The historical Phase-3 write swallowed exceptions; the write-ahead
+    write must propagate AND nothing may have been merged into the graph."""
+    order = _OrderLog()
+
+    class _FailingKV(_MemKV):
+        async def upsert(self, data):
+            raise RuntimeError("anchor upsert boom")
+
+    graph = _MemGraph(order)
+    with pytest.raises(RuntimeError, match="anchor upsert boom"):
+        await _merge(
+            _chunk_results(),
+            order,
+            full_entities=_FailingKV(order, "full_entities"),
+            graph=graph,
+        )
+    assert graph.nodes == {} and graph.edges == {}
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_anchor_flush_failure_aborts_merge_before_mutation():
+    order = _OrderLog()
+
+    class _FlushFailKV(_MemKV):
+        async def index_done_callback(self):
+            raise RuntimeError("anchor flush boom")
+
+    graph = _MemGraph(order)
+    with pytest.raises(IndexFlushError):
+        await _merge(
+            _chunk_results(),
+            order,
+            full_relations=_FlushFailKV(order, "full_relations"),
+            graph=graph,
+        )
+    assert graph.nodes == {} and graph.edges == {}

--- a/tests/pipeline/test_custom_chunk_patch.py
+++ b/tests/pipeline/test_custom_chunk_patch.py
@@ -24,8 +24,11 @@ import pytest
 import lightrag.lightrag as lightrag_module
 from lightrag import LightRAG
 from lightrag.base import DocStatus
-from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
-from lightrag.utils_pipeline import CUSTOM_CHUNK_PATCH_METADATA_KEY
+from lightrag.utils import EmbeddingFunc, Tokenizer
+from lightrag.utils_pipeline import (
+    CUSTOM_CHUNK_PATCH_METADATA_KEY,
+    make_custom_chunk_id,
+)
 
 pytestmark = pytest.mark.offline
 
@@ -101,7 +104,17 @@ def _journal(row: dict) -> dict | None:
 
 
 def _chunk_id(doc_key: str, content: str) -> str:
-    return compute_mdhash_id(doc_key + content, prefix="chunk-")
+    return make_custom_chunk_id(doc_key, content)
+
+
+@pytest.mark.offline
+def test_chunk_id_doc_and_text_are_unambiguous():
+    """Codex review (PR #3416): plain concatenation hashed doc_id="a" +
+    chunk="bc" and doc_id="ab" + chunk="c" identically, letting two documents
+    share (and clobber) one chunk row. The encoding must keep them distinct."""
+    assert make_custom_chunk_id("a", "bc") != make_custom_chunk_id("ab", "c")
+    # Deterministic for the same logical input.
+    assert make_custom_chunk_id("a", "bc") == make_custom_chunk_id("a", "bc")
 
 
 @pytest.mark.asyncio

--- a/tests/pipeline/test_custom_chunk_patch.py
+++ b/tests/pipeline/test_custom_chunk_patch.py
@@ -308,6 +308,52 @@ async def test_failed_create_records_failed_doc_status(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_delete_covers_journal_only_graph_candidates(tmp_path, monkeypatch):
+    """Codex review (PR #3416): a patch that fails AFTER the merge wrote graph
+    objects — but before commit unioned the anchors — leaves candidates that
+    exist only in the journal. Deleting the document must remove those graph
+    objects too, not just the staged chunks; otherwise they survive as
+    orphans pointing at deleted chunks."""
+    rag = await _build_rag(tmp_path)
+    try:
+        _fake_extraction(rag, monkeypatch)
+        await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+
+        # Merge succeeds (BOB reaches graph/vdb/tracking), then the operation
+        # fails before the commit union.
+        orig_merge = lightrag_module.merge_nodes_and_edges
+        calls = {"n": 0}
+
+        async def merge_then_boom(**kwargs):
+            result = await orig_merge(**kwargs)
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("post-merge boom")
+            return result
+
+        monkeypatch.setattr(lightrag_module, "merge_nodes_and_edges", merge_then_boom)
+        with pytest.raises(RuntimeError, match="post-merge boom"):
+            await rag.ainsert_custom_chunks("base", ["bob is there"], doc_id="doc-1")
+
+        # BOB reached the graph but is anchored ONLY in the journal.
+        assert await rag.chunk_entity_relation_graph.get_node("BOB") is not None
+        anchors = await rag.full_entities.get_by_id("doc-1")
+        assert "BOB" not in (anchors or {}).get("entity_names", [])
+
+        result = await rag.adelete_by_doc_id("doc-1")
+        assert result.status == "success"
+        assert await rag.chunk_entity_relation_graph.get_node("BOB") is None, (
+            "journal-only graph candidate must be cleaned by document deletion"
+        )
+        assert await rag.entity_chunks.get_by_id("BOB") is None
+        assert (
+            await rag.text_chunks.get_by_id(_chunk_id("doc-1", "bob is there")) is None
+        )
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
 async def test_delete_includes_staged_patch_chunks(tmp_path, monkeypatch):
     rag = await _build_rag(tmp_path)
     try:

--- a/tests/pipeline/test_custom_chunk_patch.py
+++ b/tests/pipeline/test_custom_chunk_patch.py
@@ -1,0 +1,334 @@
+"""``ainsert_custom_chunks`` as a journaled, recoverable operation (issue
+#3400, Phase 3).
+
+Drives the real LightRAG object (JSON storages, offline) with extraction
+monkeypatched to a deterministic fake (one entity per staged chunk), covering:
+
+- create mode: full doc_status bookkeeping + recovery anchors;
+- patch mode: chunks_list and anchors are UNIONED, never overwritten;
+- idempotence: repeating committed input is a no-op;
+- failure: FAILED + retained journal; the pipeline refuses to touch the row;
+  the same call resumes and commits;
+- conflict: a different operation is rejected while a journal is active;
+- deletion: staged (uncommitted) patch chunks are cleaned up by
+  ``adelete_by_doc_id``.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import numpy as np
+import pytest
+
+import lightrag.lightrag as lightrag_module
+from lightrag import LightRAG
+from lightrag.base import DocStatus
+from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
+from lightrag.utils_pipeline import CUSTOM_CHUNK_PATCH_METADATA_KEY
+
+pytestmark = pytest.mark.offline
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _dummy_embedding(texts: list[str]) -> np.ndarray:
+    return np.ones((len(texts), 8), dtype=float)
+
+
+async def _dummy_llm(*args, **kwargs) -> str:
+    return "ok"
+
+
+async def _build_rag(tmp_path) -> LightRAG:
+    rag = LightRAG(
+        working_dir=str(tmp_path / "wd"),
+        workspace=f"ccpatch-{uuid4().hex[:8]}",
+        llm_model_func=_dummy_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8, max_token_size=8192, func=_dummy_embedding
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        max_parallel_insert=1,
+    )
+    await rag.initialize_storages()
+    return rag
+
+
+def _fake_extraction(rag, monkeypatch):
+    """Deterministic extraction: one entity per staged chunk, named after the
+    chunk's first word (uppercased), attributed to the staged chunk id."""
+
+    async def fake_extract(chunks, *args, **kwargs):
+        results = []
+        for chunk_id, payload in chunks.items():
+            name = payload["content"].split()[0].upper()
+            results.append(
+                (
+                    {
+                        name: [
+                            {
+                                "entity_name": name,
+                                "entity_type": "person",
+                                "description": f"{name} description",
+                                "source_id": chunk_id,
+                                "file_path": "custom",
+                                "timestamp": 1,
+                            }
+                        ]
+                    },
+                    {},
+                )
+            )
+        return results
+
+    monkeypatch.setattr(rag, "_process_extract_entities", fake_extract)
+
+
+def _status_text(row: dict) -> str:
+    raw = row.get("status")
+    return raw.value if isinstance(raw, DocStatus) else str(raw)
+
+
+def _journal(row: dict) -> dict | None:
+    return (row.get("metadata") or {}).get(CUSTOM_CHUNK_PATCH_METADATA_KEY)
+
+
+def _chunk_id(doc_key: str, content: str) -> str:
+    return compute_mdhash_id(doc_key + content, prefix="chunk-")
+
+
+@pytest.mark.asyncio
+async def test_create_mode_writes_doc_status_and_anchors(tmp_path, monkeypatch):
+    rag = await _build_rag(tmp_path)
+    try:
+        _fake_extraction(rag, monkeypatch)
+        await rag.ainsert_custom_chunks(
+            "base document", ["alice is here"], doc_id="doc-1"
+        )
+
+        row = await rag.doc_status.get_by_id("doc-1")
+        assert row is not None, "create mode must write a doc_status row"
+        assert _status_text(row) == DocStatus.PROCESSED.value
+        assert _journal(row) is None, "journal must be cleared at commit"
+        assert row["chunks_list"] == [_chunk_id("doc-1", "alice is here")]
+
+        anchors = await rag.full_entities.get_by_id("doc-1")
+        assert anchors and anchors["entity_names"] == ["ALICE"]
+        assert await rag.full_docs.get_by_id("doc-1") is not None
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_repeating_committed_input_is_noop(tmp_path, monkeypatch):
+    rag = await _build_rag(tmp_path)
+    try:
+        _fake_extraction(rag, monkeypatch)
+        await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+        row_before = await rag.doc_status.get_by_id("doc-1")
+
+        # Same logical input again: committed no-op (content dedup).
+        await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+        row_after = await rag.doc_status.get_by_id("doc-1")
+        assert row_after["chunks_list"] == row_before["chunks_list"]
+        assert _status_text(row_after) == DocStatus.PROCESSED.value
+        assert _journal(row_after) is None
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_patch_unions_chunks_and_anchors(tmp_path, monkeypatch):
+    rag = await _build_rag(tmp_path)
+    try:
+        _fake_extraction(rag, monkeypatch)
+        await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+        await rag.ainsert_custom_chunks("base", ["bob is there"], doc_id="doc-1")
+
+        row = await rag.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.PROCESSED.value
+        assert row["chunks_list"] == [
+            _chunk_id("doc-1", "alice is here"),
+            _chunk_id("doc-1", "bob is there"),
+        ], "patch must UNION into chunks_list, preserving committed chunks"
+
+        anchors = await rag.full_entities.get_by_id("doc-1")
+        assert anchors["entity_names"] == ["ALICE", "BOB"], (
+            "patch must union anchors, not overwrite the base document's"
+        )
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_patch_rejected_on_non_processed_document(tmp_path, monkeypatch):
+    rag = await _build_rag(tmp_path)
+    try:
+        _fake_extraction(rag, monkeypatch)
+        await rag.doc_status.upsert(
+            {
+                "doc-1": {
+                    "status": DocStatus.FAILED,
+                    "content_summary": "s",
+                    "content_length": 1,
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "updated_at": "2026-01-01T00:00:00+00:00",
+                    "file_path": "f",
+                    "metadata": {},
+                }
+            }
+        )
+        with pytest.raises(RuntimeError, match="only PROCESSED documents"):
+            await rag.ainsert_custom_chunks("base", ["alice"], doc_id="doc-1")
+    finally:
+        await rag.finalize_storages()
+
+
+async def _fail_one_merge_then_restore(monkeypatch):
+    """Make lightrag.lightrag.merge_nodes_and_edges raise once, then behave."""
+    calls = {"n": 0}
+    orig_merge = lightrag_module.merge_nodes_and_edges
+
+    async def merge_boom(**kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("merge boom")
+        return await orig_merge(**kwargs)
+
+    monkeypatch.setattr(lightrag_module, "merge_nodes_and_edges", merge_boom)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_failed_patch_keeps_journal_pipeline_skips_and_resume_commits(
+    tmp_path, monkeypatch
+):
+    rag = await _build_rag(tmp_path)
+    try:
+        _fake_extraction(rag, monkeypatch)
+        await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+
+        await _fail_one_merge_then_restore(monkeypatch)
+        with pytest.raises(RuntimeError, match="merge boom"):
+            await rag.ainsert_custom_chunks("base", ["bob is there"], doc_id="doc-1")
+
+        # FAILED with the journal (and its write-ahead candidates) retained.
+        row = await rag.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.FAILED.value
+        journal = _journal(row)
+        assert journal is not None, "journal must survive the failure"
+        assert journal["entity_names"] == ["BOB"]
+        assert journal["chunk_ids"] == [_chunk_id("doc-1", "bob is there")]
+        # Committed base state is untouched.
+        assert row["chunks_list"] == [_chunk_id("doc-1", "alice is here")]
+
+        # The ordinary pipeline must not touch (reset/reprocess) the row.
+        await rag.apipeline_process_enqueue_documents()
+        row = await rag.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.FAILED.value
+        assert _journal(row) is not None
+
+        # The same SDK call resumes and commits.
+        await rag.ainsert_custom_chunks("base", ["bob is there"], doc_id="doc-1")
+        row = await rag.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.PROCESSED.value
+        assert _journal(row) is None
+        assert row["chunks_list"] == [
+            _chunk_id("doc-1", "alice is here"),
+            _chunk_id("doc-1", "bob is there"),
+        ]
+        anchors = await rag.full_entities.get_by_id("doc-1")
+        assert anchors["entity_names"] == ["ALICE", "BOB"]
+
+        # Busy slot was released through all of it.
+        from lightrag.kg.shared_storage import get_namespace_data
+
+        pipeline_status = await get_namespace_data(
+            "pipeline_status", workspace=rag.workspace
+        )
+        assert pipeline_status.get("busy") is False
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_conflicting_operation_rejected_while_journal_active(
+    tmp_path, monkeypatch
+):
+    rag = await _build_rag(tmp_path)
+    try:
+        _fake_extraction(rag, monkeypatch)
+        await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+
+        await _fail_one_merge_then_restore(monkeypatch)
+        with pytest.raises(RuntimeError, match="merge boom"):
+            await rag.ainsert_custom_chunks("base", ["bob is there"], doc_id="doc-1")
+
+        with pytest.raises(RuntimeError, match="unfinished custom-chunk"):
+            await rag.ainsert_custom_chunks(
+                "base", ["carol is elsewhere"], doc_id="doc-1"
+            )
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_failed_create_records_failed_doc_status(tmp_path, monkeypatch):
+    """The historical gap: a failed create left chunk/vector data with NO
+    doc_status row at all. Now it must leave a FAILED row with the journal."""
+    rag = await _build_rag(tmp_path)
+    try:
+        _fake_extraction(rag, monkeypatch)
+        await _fail_one_merge_then_restore(monkeypatch)
+        with pytest.raises(RuntimeError, match="merge boom"):
+            await rag.ainsert_custom_chunks(
+                "fresh doc", ["alice is here"], doc_id="doc-9"
+            )
+
+        row = await rag.doc_status.get_by_id("doc-9")
+        assert row is not None, "failed create must be discoverable in doc_status"
+        assert _status_text(row) == DocStatus.FAILED.value
+        journal = _journal(row)
+        assert journal is not None and journal["mode"] == "create"
+
+        # Resume completes the create.
+        await rag.ainsert_custom_chunks("fresh doc", ["alice is here"], doc_id="doc-9")
+        row = await rag.doc_status.get_by_id("doc-9")
+        assert _status_text(row) == DocStatus.PROCESSED.value
+        assert _journal(row) is None
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_delete_includes_staged_patch_chunks(tmp_path, monkeypatch):
+    rag = await _build_rag(tmp_path)
+    try:
+        _fake_extraction(rag, monkeypatch)
+        await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+
+        await _fail_one_merge_then_restore(monkeypatch)
+        staged_id = _chunk_id("doc-1", "bob is there")
+        with pytest.raises(RuntimeError, match="merge boom"):
+            await rag.ainsert_custom_chunks("base", ["bob is there"], doc_id="doc-1")
+        assert await rag.text_chunks.get_by_id(staged_id) is not None, (
+            "staged chunk must be durable before merge (flushed staging)"
+        )
+
+        result = await rag.adelete_by_doc_id("doc-1")
+        assert result.status == "success"
+        assert await rag.text_chunks.get_by_id(staged_id) is None, (
+            "deletion must clean staged (journal-only) patch chunks"
+        )
+        assert (
+            await rag.text_chunks.get_by_id(_chunk_id("doc-1", "alice is here")) is None
+        )
+    finally:
+        await rag.finalize_storages()

--- a/tests/pipeline/test_custom_chunk_rollback.py
+++ b/tests/pipeline/test_custom_chunk_rollback.py
@@ -18,9 +18,11 @@ import pytest
 import lightrag.lightrag as lightrag_module
 from lightrag import LightRAG
 from lightrag.base import DocStatus
+from lightrag.operate import KGRebuildReport
 from lightrag.utils import EmbeddingFunc, Tokenizer
 from lightrag.utils_pipeline import (
     CUSTOM_CHUNK_PATCH_METADATA_KEY,
+    KG_RECOVERY_WARNINGS_METADATA_KEY,
     make_custom_chunk_id,
 )
 
@@ -112,6 +114,20 @@ async def _fail_one_merge(monkeypatch):
     return calls
 
 
+async def _fail_after_one_merge(monkeypatch):
+    calls = {"n": 0}
+    orig_merge = lightrag_module.merge_nodes_and_edges
+
+    async def merge_then_boom(**kwargs):
+        calls["n"] += 1
+        await orig_merge(**kwargs)
+        if calls["n"] == 1:
+            raise RuntimeError("post-merge boom")
+
+    monkeypatch.setattr(lightrag_module, "merge_nodes_and_edges", merge_then_boom)
+    return calls
+
+
 async def _seed_base_then_fail_patch(rag, monkeypatch) -> None:
     """Base doc with ALICE committed, then a failed BOB patch left journaled."""
     _fake_extraction(rag, monkeypatch)
@@ -149,6 +165,103 @@ async def test_rollback_restores_exact_pre_patch_state(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_missing_cache_rolls_back_with_structural_warning(tmp_path, monkeypatch):
+    """Missing base extraction cache must not wedge rollback forever."""
+    rag = await _build_rag(tmp_path)
+    try:
+        _fake_extraction(rag, monkeypatch)
+        await rag.ainsert_custom_chunks("base", ["alice base"], doc_id="doc-1")
+        base_id = _chunk_id("doc-1", "alice base")
+        staged_id = _chunk_id("doc-1", "alice patch")
+
+        await _fail_after_one_merge(monkeypatch)
+        with pytest.raises(RuntimeError, match="post-merge boom"):
+            await rag.ainsert_custom_chunks("base", ["alice patch"], doc_id="doc-1")
+
+        result = await rag.arollback_failed_custom_chunk_patches()
+        assert result == {"rolled_back": ["doc-1"], "failed": []}
+
+        row = await rag.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.PROCESSED.value
+        assert _journal(row) is None
+        assert row.get("error_msg") == ""
+        warnings = row["metadata"][KG_RECOVERY_WARNINGS_METADATA_KEY]
+        assert len(warnings) == 1
+        warning = warnings[0]
+        assert warning["code"] == "degraded_custom_chunk_rollback"
+        assert warning["missing_cache_chunks"] == {
+            "count": 1,
+            "sample": [base_id],
+        }
+        assert warning["degraded_entities"] == {
+            "count": 1,
+            "sample": ["ALICE"],
+        }
+
+        node = await rag.chunk_entity_relation_graph.get_node("ALICE")
+        assert node["source_id"] == base_id
+        assert await rag.text_chunks.get_by_id(staged_id) is None
+
+        # The warning is durable before finalize_storages can mask a missing
+        # doc-status flush.
+        import json
+
+        status_files = list((tmp_path / "wd").rglob("kv_store_doc_status.json"))
+        on_disk = json.loads(status_files[0].read_text())
+        assert on_disk["doc-1"]["metadata"][KG_RECOVERY_WARNINGS_METADATA_KEY]
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_warning_persistence_failure_keeps_journal_and_retry_converges(
+    tmp_path, monkeypatch
+):
+    """A durable warning is part of rollback commit, not optional logging."""
+    rag = await _build_rag(tmp_path)
+    try:
+        _fake_extraction(rag, monkeypatch)
+        await rag.ainsert_custom_chunks("base", ["alice base"], doc_id="doc-1")
+        await _fail_after_one_merge(monkeypatch)
+        with pytest.raises(RuntimeError, match="post-merge boom"):
+            await rag.ainsert_custom_chunks("base", ["alice patch"], doc_id="doc-1")
+
+        original_upsert = rag.doc_status.upsert
+        failed = False
+
+        async def fail_warning_upsert_once(data):
+            nonlocal failed
+            has_warning = any(
+                (record.get("metadata") or {}).get(KG_RECOVERY_WARNINGS_METADATA_KEY)
+                for record in data.values()
+            )
+            if has_warning and not failed:
+                failed = True
+                raise RuntimeError("warning persistence boom")
+            return await original_upsert(data)
+
+        monkeypatch.setattr(rag.doc_status, "upsert", fail_warning_upsert_once)
+
+        result = await rag.arollback_failed_custom_chunk_patches()
+        assert result == {"rolled_back": [], "failed": ["doc-1"]}
+        row = await rag.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.FAILED.value
+        assert _journal(row) is not None
+
+        # The graph may already be structurally repaired and staged chunks may
+        # already be gone. A journal retry must still rebuild its candidates,
+        # persist the warning, and clear the journal idempotently.
+        result = await rag.arollback_failed_custom_chunk_patches()
+        assert result == {"rolled_back": ["doc-1"], "failed": []}
+        row = await rag.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.PROCESSED.value
+        assert _journal(row) is None
+        assert row["metadata"][KG_RECOVERY_WARNINGS_METADATA_KEY]
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
 async def test_rollback_of_failed_create_removes_document(tmp_path, monkeypatch):
     rag = await _build_rag(tmp_path)
     try:
@@ -180,6 +293,89 @@ async def test_rollback_of_failed_create_removes_document(tmp_path, monkeypatch)
         assert "doc-9" not in on_disk, (
             "create-rollback doc_status delete must be flushed to disk"
         )
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_create_rollback_warning_is_attached_to_surviving_owner(
+    tmp_path, monkeypatch
+):
+    rag = await _build_rag(tmp_path)
+    try:
+        _fake_extraction(rag, monkeypatch)
+        await rag.ainsert_custom_chunks("base", ["alice base"], doc_id="doc-1")
+
+        await _fail_after_one_merge(monkeypatch)
+        with pytest.raises(RuntimeError, match="post-merge boom"):
+            await rag.ainsert_custom_chunks(
+                "new", ["alice from create"], doc_id="doc-9"
+            )
+
+        result = await rag.arollback_failed_custom_chunk_patches()
+        assert result == {"rolled_back": ["doc-9"], "failed": []}
+        assert await rag.doc_status.get_by_id("doc-9") is None
+
+        owner_row = await rag.doc_status.get_by_id("doc-1")
+        warnings = owner_row["metadata"][KG_RECOVERY_WARNINGS_METADATA_KEY]
+        assert len(warnings) == 1
+        assert warnings[0]["code"] == "degraded_custom_chunk_rollback"
+        node = await rag.chunk_entity_relation_graph.get_node("ALICE")
+        assert node["source_id"] == _chunk_id("doc-1", "alice base")
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_recovery_warning_deduplicates_and_keeps_latest_ten(
+    tmp_path, monkeypatch
+):
+    rag = await _build_rag(tmp_path)
+    try:
+        _fake_extraction(rag, monkeypatch)
+        await rag.ainsert_custom_chunks("base", ["alice base"], doc_id="doc-1")
+        row = await rag.doc_status.get_by_id("doc-1")
+        metadata = dict(row.get("metadata") or {})
+        metadata[KG_RECOVERY_WARNINGS_METADATA_KEY] = [
+            {
+                "code": "degraded_custom_chunk_rollback",
+                "operation_id": f"old-{index}",
+            }
+            for index in range(10)
+        ]
+        await rag.doc_status.upsert({"doc-1": {**row, "metadata": metadata}})
+
+        report = KGRebuildReport(
+            missing_cache_chunk_ids={_chunk_id("doc-1", "alice base")},
+            degraded_entities={"ALICE": [_chunk_id("doc-1", "alice base")]},
+        )
+        status = {"latest_message": "", "history_messages": []}
+        import asyncio
+
+        lock = asyncio.Lock()
+        journal = {"operation_id": "new-op"}
+        await rag._persist_custom_chunk_recovery_warning(
+            "doc-1",
+            journal,
+            report,
+            mode="patch",
+            pipeline_status=status,
+            pipeline_status_lock=lock,
+        )
+        await rag._persist_custom_chunk_recovery_warning(
+            "doc-1",
+            journal,
+            report,
+            mode="patch",
+            pipeline_status=status,
+            pipeline_status_lock=lock,
+        )
+
+        updated = await rag.doc_status.get_by_id("doc-1")
+        warnings = updated["metadata"][KG_RECOVERY_WARNINGS_METADATA_KEY]
+        assert len(warnings) == 10
+        assert [item["operation_id"] for item in warnings].count("new-op") == 1
+        assert warnings[-1]["operation_id"] == "new-op"
     finally:
         await rag.finalize_storages()
 

--- a/tests/pipeline/test_custom_chunk_rollback.py
+++ b/tests/pipeline/test_custom_chunk_rollback.py
@@ -1,0 +1,235 @@
+"""Scan rollback of failed custom-chunk operations (issue #3400, Phase 4).
+
+``arollback_failed_custom_chunk_patches`` is scan's administrative escape
+hatch: incomplete operations are rolled BACK to the previously committed
+document state (the SDK caller owns roll-forward by repeating the call).
+
+Real LightRAG object (JSON storages, offline), extraction monkeypatched to a
+deterministic fake — same harness as test_custom_chunk_patch.py.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import numpy as np
+import pytest
+
+import lightrag.lightrag as lightrag_module
+from lightrag import LightRAG
+from lightrag.base import DocStatus
+from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
+from lightrag.utils_pipeline import CUSTOM_CHUNK_PATCH_METADATA_KEY
+
+pytestmark = pytest.mark.offline
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _dummy_embedding(texts: list[str]) -> np.ndarray:
+    return np.ones((len(texts), 8), dtype=float)
+
+
+async def _dummy_llm(*args, **kwargs) -> str:
+    return "ok"
+
+
+async def _build_rag(tmp_path) -> LightRAG:
+    rag = LightRAG(
+        working_dir=str(tmp_path / "wd"),
+        workspace=f"ccroll-{uuid4().hex[:8]}",
+        llm_model_func=_dummy_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8, max_token_size=8192, func=_dummy_embedding
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        max_parallel_insert=1,
+    )
+    await rag.initialize_storages()
+    return rag
+
+
+def _fake_extraction(rag, monkeypatch):
+    async def fake_extract(chunks, *args, **kwargs):
+        results = []
+        for chunk_id, payload in chunks.items():
+            name = payload["content"].split()[0].upper()
+            results.append(
+                (
+                    {
+                        name: [
+                            {
+                                "entity_name": name,
+                                "entity_type": "person",
+                                "description": f"{name} description",
+                                "source_id": chunk_id,
+                                "file_path": "custom",
+                                "timestamp": 1,
+                            }
+                        ]
+                    },
+                    {},
+                )
+            )
+        return results
+
+    monkeypatch.setattr(rag, "_process_extract_entities", fake_extract)
+
+
+def _status_text(row: dict) -> str:
+    raw = row.get("status")
+    return raw.value if isinstance(raw, DocStatus) else str(raw)
+
+
+def _journal(row: dict) -> dict | None:
+    return (row.get("metadata") or {}).get(CUSTOM_CHUNK_PATCH_METADATA_KEY)
+
+
+def _chunk_id(doc_key: str, content: str) -> str:
+    return compute_mdhash_id(doc_key + content, prefix="chunk-")
+
+
+async def _fail_one_merge(monkeypatch):
+    calls = {"n": 0}
+    orig_merge = lightrag_module.merge_nodes_and_edges
+
+    async def merge_boom(**kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("merge boom")
+        return await orig_merge(**kwargs)
+
+    monkeypatch.setattr(lightrag_module, "merge_nodes_and_edges", merge_boom)
+    return calls
+
+
+async def _seed_base_then_fail_patch(rag, monkeypatch) -> None:
+    """Base doc with ALICE committed, then a failed BOB patch left journaled."""
+    _fake_extraction(rag, monkeypatch)
+    await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+    await _fail_one_merge(monkeypatch)
+    with pytest.raises(RuntimeError, match="merge boom"):
+        await rag.ainsert_custom_chunks("base", ["bob is there"], doc_id="doc-1")
+
+
+@pytest.mark.asyncio
+async def test_rollback_restores_exact_pre_patch_state(tmp_path, monkeypatch):
+    rag = await _build_rag(tmp_path)
+    try:
+        await _seed_base_then_fail_patch(rag, monkeypatch)
+        staged_id = _chunk_id("doc-1", "bob is there")
+
+        result = await rag.arollback_failed_custom_chunk_patches()
+        assert result == {"rolled_back": ["doc-1"], "failed": []}
+
+        row = await rag.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.PROCESSED.value
+        assert _journal(row) is None
+        assert row["chunks_list"] == [_chunk_id("doc-1", "alice is here")]
+
+        # Staged chunk and its graph contribution are gone...
+        assert await rag.text_chunks.get_by_id(staged_id) is None
+        assert await rag.chunk_entity_relation_graph.get_node("BOB") is None
+        # ...the base contribution is untouched...
+        assert await rag.chunk_entity_relation_graph.get_node("ALICE") is not None
+        # ...and the anchors were pruned back to the base set.
+        anchors = await rag.full_entities.get_by_id("doc-1")
+        assert anchors["entity_names"] == ["ALICE"]
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_rollback_of_failed_create_removes_document(tmp_path, monkeypatch):
+    rag = await _build_rag(tmp_path)
+    try:
+        _fake_extraction(rag, monkeypatch)
+        await _fail_one_merge(monkeypatch)
+        with pytest.raises(RuntimeError, match="merge boom"):
+            await rag.ainsert_custom_chunks("fresh", ["alice is here"], doc_id="doc-9")
+
+        result = await rag.arollback_failed_custom_chunk_patches()
+        assert result == {"rolled_back": ["doc-9"], "failed": []}
+
+        assert await rag.doc_status.get_by_id("doc-9") is None
+        assert await rag.full_docs.get_by_id("doc-9") is None
+        assert await rag.text_chunks.get_by_id(_chunk_id("doc-9", "alice is here")) is None
+        assert await rag.full_entities.get_by_id("doc-9") is None
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_failed_rollback_keeps_journal_and_retries(tmp_path, monkeypatch):
+    """A rollback failure must keep FAILED + journal (never report success),
+    and a later rollback attempt succeeds."""
+    rag = await _build_rag(tmp_path)
+    try:
+        await _seed_base_then_fail_patch(rag, monkeypatch)
+
+        purge_calls = {"n": 0}
+        orig_purge = rag._purge_kg_contributions
+
+        async def purge_boom(*args, **kwargs):
+            purge_calls["n"] += 1
+            if purge_calls["n"] == 1:
+                raise RuntimeError("purge boom")
+            return await orig_purge(*args, **kwargs)
+
+        monkeypatch.setattr(rag, "_purge_kg_contributions", purge_boom)
+
+        result = await rag.arollback_failed_custom_chunk_patches()
+        assert result == {"rolled_back": [], "failed": ["doc-1"]}
+        row = await rag.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.FAILED.value
+        assert _journal(row) is not None, "journal must survive a failed rollback"
+
+        # The next scan's rollback succeeds.
+        result = await rag.arollback_failed_custom_chunk_patches()
+        assert result == {"rolled_back": ["doc-1"], "failed": []}
+        row = await rag.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.PROCESSED.value
+        assert _journal(row) is None
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_rollback_noop_without_journaled_documents(tmp_path, monkeypatch):
+    rag = await _build_rag(tmp_path)
+    try:
+        _fake_extraction(rag, monkeypatch)
+        await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+        result = await rag.arollback_failed_custom_chunk_patches()
+        assert result == {"rolled_back": [], "failed": []}
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_sdk_resume_still_possible_before_scan_rolls_back(
+    tmp_path, monkeypatch
+):
+    """Roll-forward stays the SDK caller's choice: if the same call resumes
+    and commits before a scan runs, rollback then finds nothing to do."""
+    rag = await _build_rag(tmp_path)
+    try:
+        await _seed_base_then_fail_patch(rag, monkeypatch)
+
+        # SDK retries the same input (merge restored after first boom).
+        await rag.ainsert_custom_chunks("base", ["bob is there"], doc_id="doc-1")
+        row = await rag.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.PROCESSED.value
+
+        result = await rag.arollback_failed_custom_chunk_patches()
+        assert result == {"rolled_back": [], "failed": []}
+        anchors = await rag.full_entities.get_by_id("doc-1")
+        assert anchors["entity_names"] == ["ALICE", "BOB"]
+    finally:
+        await rag.finalize_storages()

--- a/tests/pipeline/test_custom_chunk_rollback.py
+++ b/tests/pipeline/test_custom_chunk_rollback.py
@@ -18,8 +18,11 @@ import pytest
 import lightrag.lightrag as lightrag_module
 from lightrag import LightRAG
 from lightrag.base import DocStatus
-from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
-from lightrag.utils_pipeline import CUSTOM_CHUNK_PATCH_METADATA_KEY
+from lightrag.utils import EmbeddingFunc, Tokenizer
+from lightrag.utils_pipeline import (
+    CUSTOM_CHUNK_PATCH_METADATA_KEY,
+    make_custom_chunk_id,
+)
 
 pytestmark = pytest.mark.offline
 
@@ -92,7 +95,7 @@ def _journal(row: dict) -> dict | None:
 
 
 def _chunk_id(doc_key: str, content: str) -> str:
-    return compute_mdhash_id(doc_key + content, prefix="chunk-")
+    return make_custom_chunk_id(doc_key, content)
 
 
 async def _fail_one_merge(monkeypatch):
@@ -163,6 +166,20 @@ async def test_rollback_of_failed_create_removes_document(tmp_path, monkeypatch)
             await rag.text_chunks.get_by_id(_chunk_id("doc-9", "alice is here")) is None
         )
         assert await rag.full_entities.get_by_id("doc-9") is None
+
+        # Codex review (PR #3416): doc_status.delete is deferred-commit on
+        # the JSON backend — the rollback must flush it before reporting
+        # success, or a crash right after would resurrect the FAILED journal
+        # row on restart. Assert durability on DISK, before finalize (which
+        # would flush and mask the bug).
+        import json
+
+        status_files = list((tmp_path / "wd").rglob("kv_store_doc_status.json"))
+        assert status_files, "doc_status JSON file should exist"
+        on_disk = json.loads(status_files[0].read_text())
+        assert "doc-9" not in on_disk, (
+            "create-rollback doc_status delete must be flushed to disk"
+        )
     finally:
         await rag.finalize_storages()
 

--- a/tests/pipeline/test_custom_chunk_rollback.py
+++ b/tests/pipeline/test_custom_chunk_rollback.py
@@ -159,7 +159,9 @@ async def test_rollback_of_failed_create_removes_document(tmp_path, monkeypatch)
 
         assert await rag.doc_status.get_by_id("doc-9") is None
         assert await rag.full_docs.get_by_id("doc-9") is None
-        assert await rag.text_chunks.get_by_id(_chunk_id("doc-9", "alice is here")) is None
+        assert (
+            await rag.text_chunks.get_by_id(_chunk_id("doc-9", "alice is here")) is None
+        )
         assert await rag.full_entities.get_by_id("doc-9") is None
     finally:
         await rag.finalize_storages()
@@ -213,9 +215,7 @@ async def test_rollback_noop_without_journaled_documents(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_sdk_resume_still_possible_before_scan_rolls_back(
-    tmp_path, monkeypatch
-):
+async def test_sdk_resume_still_possible_before_scan_rolls_back(tmp_path, monkeypatch):
     """Roll-forward stays the SDK caller's choice: if the same call resumes
     and commits before a scan runs, rollback then finds nothing to do."""
     rag = await _build_rag(tmp_path)

--- a/tests/pipeline/test_doc_status_reset_metadata.py
+++ b/tests/pipeline/test_doc_status_reset_metadata.py
@@ -144,6 +144,20 @@ def test_reset_metadata_handles_empty_or_invalid_metadata():
     )
 
 
+def test_reset_metadata_drops_degraded_recovery_warnings():
+    """A full reprocess is the repair boundary for prior degraded rollback."""
+    assert (
+        doc_status_reset_metadata(
+            {
+                "metadata": {
+                    "kg_recovery_warnings": [{"code": "degraded_custom_chunk_rollback"}]
+                }
+            }
+        )
+        == {}
+    )
+
+
 def test_has_attempt_fields_trigger():
     assert doc_status_metadata_has_attempt_fields({"metadata": {"parse_end_time": 1}})
     assert doc_status_metadata_has_attempt_fields(

--- a/tests/pipeline/test_document_file_path_normalization.py
+++ b/tests/pipeline/test_document_file_path_normalization.py
@@ -67,6 +67,39 @@ class CaptureKV:
     async def upsert(self, data):
         self.upserts.append(data)
 
+    async def get_by_id(self, key):
+        return None
+
+    async def get_by_ids(self, keys):
+        return [None for _ in keys]
+
+    async def index_done_callback(self):
+        pass
+
+
+class _FakeKeyedLock:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+def _patch_custom_chunk_saga(monkeypatch, rag):
+    """Wire a bare LightRAG for the #3400 Phase-3 custom-chunk saga: a
+    doc_status store for the journal, a flushable llm_response_cache for the
+    staging barrier, and a stubbed per-document keyed lock (the real one
+    needs initialized shared storage)."""
+    import lightrag.lightrag as lightrag_module
+
+    rag.doc_status = CaptureKV()
+    rag.llm_response_cache = CaptureKV()
+    monkeypatch.setattr(
+        lightrag_module,
+        "get_storage_keyed_lock",
+        lambda keys, namespace="", enable_logging=False: _FakeKeyedLock(),
+    )
+
 
 @pytest.mark.asyncio
 async def test_pipeline_index_texts_rejects_missing_file_sources():
@@ -151,6 +184,7 @@ async def test_custom_chunks_use_canonical_unknown_source_before_upsert(monkeypa
     rag.chunks_vdb = CaptureKV()
     rag.tokenizer = type("Tokenizer", (), {"encode": lambda self, text: [text]})()
     rag.workspace = "test-workspace"
+    _patch_custom_chunk_saga(monkeypatch, rag)
 
     async def _process_extract_entities(
         chunks, pipeline_status=None, pipeline_status_lock=None
@@ -209,6 +243,7 @@ async def test_custom_chunks_merge_extracted_entities_into_kg(monkeypatch):
         "llm_response_cache",
     ):
         setattr(rag, attr, object())
+    _patch_custom_chunk_saga(monkeypatch, rag)
 
     extracted = [({"Entity": [{"entity_name": "Entity"}]}, {})]
 
@@ -316,6 +351,7 @@ async def test_custom_chunks_persist_before_extraction(monkeypatch):
         "llm_response_cache",
     ):
         setattr(rag, attr, object())
+    _patch_custom_chunk_saga(monkeypatch, rag)
 
     async def _process_extract_entities(
         chunks, pipeline_status=None, pipeline_status_lock=None
@@ -371,6 +407,7 @@ def _custom_chunks_rag(monkeypatch, status):
         "llm_response_cache",
     ):
         setattr(rag, attr, object())
+    _patch_custom_chunk_saga(monkeypatch, rag)
     rag._build_global_config = lambda: {}
 
     async def _insert_done():

--- a/tests/pipeline/test_fault_injection_matrix.py
+++ b/tests/pipeline/test_fault_injection_matrix.py
@@ -1,0 +1,329 @@
+"""Fault-injection matrix with restart simulation (issue #3400, Phase 5).
+
+For each persistence boundary in the ingestion saga, inject a failure, then
+simulate a process restart (finalize storages, build a FRESH LightRAG over
+the same working dir/workspace), retry, and assert convergence:
+
+- the document ends PROCESSED only after a clean run;
+- after convergence the KG has no orphan contributions and the recovery
+  anchors cover the graph (verified with the offline audit tool);
+- no failure point ever yields a durable false PROCESSED.
+
+JSON/NetworkX (buffered) backends — the buffered half of the issue's backend
+matrix; immediate-write backends are covered by the mock-based unit suites.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG
+from lightrag.base import DocStatus
+from lightrag.tools.kg_integrity_repair import audit_kg_integrity
+from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
+
+pytestmark = pytest.mark.offline
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _dummy_embedding(texts: list[str]) -> np.ndarray:
+    return np.ones((len(texts), 8), dtype=float)
+
+
+async def _dummy_llm(*args, **kwargs) -> str:
+    return "ok"
+
+
+def _deterministic_chunking(
+    tokenizer,
+    content: str,
+    split_by_character,
+    split_by_character_only: bool,
+    chunk_overlap_token_size: int,
+    chunk_token_size: int,
+) -> list[dict]:
+    return [{"tokens": 1, "content": f"{content}::chunk1", "chunk_order_index": 0}]
+
+
+def _wire_fake_extraction(rag: LightRAG) -> None:
+    """Deterministic extraction (instance-level): one ALICE entity per chunk."""
+
+    async def fake_extract(chunks, *args, **kwargs):
+        results = []
+        for chunk_id in chunks:
+            results.append(
+                (
+                    {
+                        "ALICE": [
+                            {
+                                "entity_name": "ALICE",
+                                "entity_type": "person",
+                                "description": "ALICE description",
+                                "source_id": chunk_id,
+                                "file_path": "d.txt",
+                                "timestamp": 1,
+                            }
+                        ]
+                    },
+                    {},
+                )
+            )
+        return results
+
+    rag._process_extract_entities = fake_extract
+
+
+async def _build_rag(tmp_path, workspace: str) -> LightRAG:
+    rag = LightRAG(
+        working_dir=str(tmp_path / "wd"),
+        workspace=workspace,
+        llm_model_func=_dummy_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8, max_token_size=8192, func=_dummy_embedding
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        chunking_func=_deterministic_chunking,
+        max_parallel_insert=1,
+    )
+    await rag.initialize_storages()
+    _wire_fake_extraction(rag)
+    return rag
+
+
+def _status_text(row: dict | None) -> str:
+    raw = (row or {}).get("status")
+    return raw.value if isinstance(raw, DocStatus) else str(raw or "<missing>")
+
+
+async def _assert_converged(rag: LightRAG, doc_id: str) -> None:
+    row = await rag.doc_status.get_by_id(doc_id)
+    assert _status_text(row) == DocStatus.PROCESSED.value
+
+    # Terminal-consistency invariant, checked with the offline audit tool:
+    # every graph contribution is anchored and no orphan sources exist.
+    report = await audit_kg_integrity(rag)
+    assert report["missing_entity_anchors"] == {}
+    assert report["missing_relation_anchors"] == {}
+    assert report["orphan_entities"] == []
+    assert report["orphan_relations"] == []
+    assert await rag.chunk_entity_relation_graph.get_node("ALICE") is not None
+
+
+def _fail_once(monkeypatch, obj, attr: str, exc_message: str):
+    """Wrap obj.attr (async) to raise on the FIRST call only."""
+    calls = {"n": 0}
+    original = getattr(obj, attr)
+
+    async def wrapper(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError(exc_message)
+        return await original(*args, **kwargs)
+
+    monkeypatch.setattr(obj, attr, wrapper)
+    return calls
+
+
+# Injection points: (test id, callable(rag, monkeypatch) -> None) applied to
+# the FIRST instance before the failing run.
+def _inject_anchor_prewrite_flush(rag, monkeypatch):
+    _fail_once(monkeypatch, rag.full_entities, "index_done_callback", "anchor flush boom")
+
+
+def _inject_graph_mutation(rag, monkeypatch):
+    _fail_once(
+        monkeypatch, rag.chunk_entity_relation_graph, "upsert_node", "graph mutation boom"
+    )
+
+
+def _inject_derived_flush(rag, monkeypatch):
+    _fail_once(monkeypatch, rag.entities_vdb, "index_done_callback", "vdb flush boom")
+
+
+def _inject_final_status_write(rag, monkeypatch):
+    orig_upsert = rag.doc_status.upsert
+    calls = {"boomed": False}
+
+    async def wrapper(data):
+        for record in data.values():
+            status = record.get("status")
+            status_text = status.value if isinstance(status, DocStatus) else str(status)
+            if status_text == DocStatus.PROCESSED.value and not calls["boomed"]:
+                calls["boomed"] = True
+                raise RuntimeError("status write boom")
+        return await orig_upsert(data)
+
+    monkeypatch.setattr(rag.doc_status, "upsert", wrapper)
+
+
+def _fail_once_on(rag, monkeypatch, injector_name):
+    {
+        "anchor_prewrite_flush": _inject_anchor_prewrite_flush,
+        "graph_mutation": _inject_graph_mutation,
+        "derived_store_flush": _inject_derived_flush,
+        "final_status_write": _inject_final_status_write,
+    }[injector_name](rag, monkeypatch)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "injection_point",
+    [
+        "anchor_prewrite_flush",
+        "graph_mutation",
+        "derived_store_flush",
+        "final_status_write",
+    ],
+)
+async def test_pipeline_failure_then_restart_converges(
+    tmp_path, monkeypatch, injection_point
+):
+    workspace = f"fim-{uuid4().hex[:8]}"
+    doc_id = compute_mdhash_id("matrix.txt", prefix="doc-")
+
+    rag1 = await _build_rag(tmp_path, workspace)
+    try:
+        await rag1.apipeline_enqueue_documents(
+            input="matrix doc", file_paths="matrix.txt"
+        )
+        _fail_once_on(rag1, monkeypatch, injection_point)
+        await rag1.apipeline_process_enqueue_documents()
+
+        # No failure point may leave a durable false PROCESSED...
+        row = await rag1.doc_status.get_by_id(doc_id)
+        assert _status_text(row) != DocStatus.PROCESSED.value, (
+            f"{injection_point}: PROCESSED written despite injected failure"
+        )
+    finally:
+        await rag1.finalize_storages()
+
+    # ...and after a restart, an ordinary retry converges.
+    rag2 = await _build_rag(tmp_path, workspace)
+    try:
+        await rag2.apipeline_process_enqueue_documents()
+        await _assert_converged(rag2, doc_id)
+    finally:
+        await rag2.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_custom_chunk_failure_then_restart_resume_converges(
+    tmp_path, monkeypatch
+):
+    """Custom-chunk saga across a restart: merge fails, journal survives the
+    restart, the same SDK call on a FRESH instance resumes and commits."""
+    import lightrag.lightrag as lightrag_module
+
+    workspace = f"fim-cc-{uuid4().hex[:8]}"
+
+    rag1 = await _build_rag(tmp_path, workspace)
+    try:
+        await rag1.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+
+        async def merge_boom(**kwargs):
+            raise RuntimeError("merge boom")
+
+        monkeypatch.setattr(lightrag_module, "merge_nodes_and_edges", merge_boom)
+        with pytest.raises(RuntimeError, match="merge boom"):
+            await rag1.ainsert_custom_chunks("base", ["bob is there"], doc_id="doc-1")
+    finally:
+        await rag1.finalize_storages()
+    monkeypatch.undo()
+
+    rag2 = await _build_rag(tmp_path, workspace)
+    try:
+        row = await rag2.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.FAILED.value
+        assert (row.get("metadata") or {}).get("custom_chunk_patch") is not None, (
+            "journal must survive a restart"
+        )
+
+        await rag2.ainsert_custom_chunks("base", ["bob is there"], doc_id="doc-1")
+        row = await rag2.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.PROCESSED.value
+
+        report = await audit_kg_integrity(rag2)
+        assert report["missing_entity_anchors"] == {}
+        assert report["orphan_entities"] == []
+    finally:
+        await rag2.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_custom_chunk_failure_then_restart_rollback_converges(
+    tmp_path, monkeypatch
+):
+    """Same failure, the other recovery choice: scan rollback on a fresh
+    instance restores the committed base state."""
+    import lightrag.lightrag as lightrag_module
+
+    workspace = f"fim-rb-{uuid4().hex[:8]}"
+
+    rag1 = await _build_rag(tmp_path, workspace)
+    try:
+        await rag1.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+
+        async def merge_boom(**kwargs):
+            raise RuntimeError("merge boom")
+
+        monkeypatch.setattr(lightrag_module, "merge_nodes_and_edges", merge_boom)
+        with pytest.raises(RuntimeError, match="merge boom"):
+            await rag1.ainsert_custom_chunks("base", ["bob is there"], doc_id="doc-1")
+    finally:
+        await rag1.finalize_storages()
+    monkeypatch.undo()
+
+    rag2 = await _build_rag(tmp_path, workspace)
+    try:
+        result = await rag2.arollback_failed_custom_chunk_patches()
+        assert result == {"rolled_back": ["doc-1"], "failed": []}
+
+        row = await rag2.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.PROCESSED.value
+        assert (row.get("metadata") or {}).get("custom_chunk_patch") is None
+
+        report = await audit_kg_integrity(rag2)
+        assert report["missing_entity_anchors"] == {}
+        assert report["orphan_entities"] == []
+        assert await rag2.chunk_entity_relation_graph.get_node("BOB") is None
+    finally:
+        await rag2.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_audit_tool_detects_and_repairs_missing_anchor(tmp_path):
+    """Pre-fix historical data: graph contributions whose anchor row was lost
+    are detected and, with apply=True, reconstructed."""
+    workspace = f"fim-audit-{uuid4().hex[:8]}"
+    doc_id = compute_mdhash_id("audit.txt", prefix="doc-")
+
+    rag = await _build_rag(tmp_path, workspace)
+    try:
+        await rag.apipeline_enqueue_documents(
+            input="audit doc", file_paths="audit.txt"
+        )
+        await rag.apipeline_process_enqueue_documents()
+
+        # Simulate a pre-#3400 installation: the anchor row is missing.
+        await rag.full_entities.delete([doc_id])
+
+        report = await audit_kg_integrity(rag)
+        assert report["missing_entity_anchors"] == {doc_id: ["ALICE"]}
+
+        report = await audit_kg_integrity(rag, apply=True)
+        assert report["repaired_docs"] == [doc_id]
+
+        report = await audit_kg_integrity(rag)
+        assert report["missing_entity_anchors"] == {}
+    finally:
+        await rag.finalize_storages()

--- a/tests/pipeline/test_fault_injection_matrix.py
+++ b/tests/pipeline/test_fault_injection_matrix.py
@@ -137,12 +137,17 @@ def _fail_once(monkeypatch, obj, attr: str, exc_message: str):
 # Injection points: (test id, callable(rag, monkeypatch) -> None) applied to
 # the FIRST instance before the failing run.
 def _inject_anchor_prewrite_flush(rag, monkeypatch):
-    _fail_once(monkeypatch, rag.full_entities, "index_done_callback", "anchor flush boom")
+    _fail_once(
+        monkeypatch, rag.full_entities, "index_done_callback", "anchor flush boom"
+    )
 
 
 def _inject_graph_mutation(rag, monkeypatch):
     _fail_once(
-        monkeypatch, rag.chunk_entity_relation_graph, "upsert_node", "graph mutation boom"
+        monkeypatch,
+        rag.chunk_entity_relation_graph,
+        "upsert_node",
+        "graph mutation boom",
     )
 
 
@@ -309,9 +314,7 @@ async def test_audit_tool_detects_and_repairs_missing_anchor(tmp_path):
 
     rag = await _build_rag(tmp_path, workspace)
     try:
-        await rag.apipeline_enqueue_documents(
-            input="audit doc", file_paths="audit.txt"
-        )
+        await rag.apipeline_enqueue_documents(input="audit doc", file_paths="audit.txt")
         await rag.apipeline_process_enqueue_documents()
 
         # Simulate a pre-#3400 installation: the anchor row is missing.

--- a/tests/pipeline/test_pipeline_release_closure.py
+++ b/tests/pipeline/test_pipeline_release_closure.py
@@ -383,6 +383,11 @@ def test_carry_over_keys_grouped_by_stage():
         "analyzing_start_time",
         "analyzing_end_time",
         "analyzing_stage_skipped",
+        # Custom-chunk patch journal (issue #3400 Phase 3): the durable
+        # recovery anchor for an in-flight/failed ainsert_custom_chunks
+        # operation; must survive every status transition until commit or
+        # rollback.
+        "custom_chunk_patch",
     )
 
 

--- a/tests/pipeline/test_processed_after_flush.py
+++ b/tests/pipeline/test_processed_after_flush.py
@@ -1,0 +1,159 @@
+"""PROCESSED must be the commit record (issue #3400, Phase 2).
+
+``_process_document`` historically upserted ``doc_status=PROCESSED`` (which
+doc-status backends persist immediately) BEFORE ``_insert_done()`` flushed the
+graph/vector/chunk stores — so a crash or flush failure in that window left a
+durably-PROCESSED document whose data never hit disk.
+
+These tests drive the real pipeline (JSON storages, offline) and assert the
+reordered semantics:
+
+- happy path: the PROCESSED upsert happens strictly AFTER the merge-stage
+  data flush;
+- flush failure: NO PROCESSED write ever reaches doc_status — the document
+  goes straight to FAILED.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG
+from lightrag.base import DocStatus
+from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
+
+pytestmark = pytest.mark.offline
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _dummy_embedding(texts: list[str]) -> np.ndarray:
+    return np.ones((len(texts), 8), dtype=float)
+
+
+async def _dummy_llm(*args, **kwargs) -> str:
+    return "ok"
+
+
+def _deterministic_chunking(
+    tokenizer,
+    content: str,
+    split_by_character,
+    split_by_character_only: bool,
+    chunk_overlap_token_size: int,
+    chunk_token_size: int,
+) -> list[dict]:
+    return [{"tokens": 1, "content": f"{content}::chunk1", "chunk_order_index": 0}]
+
+
+async def _build_rag(tmp_path) -> LightRAG:
+    rag = LightRAG(
+        working_dir=str(tmp_path / "wd"),
+        workspace=f"flushorder-{uuid4().hex[:8]}",
+        llm_model_func=_dummy_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8, max_token_size=8192, func=_dummy_embedding
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        chunking_func=_deterministic_chunking,
+        max_parallel_insert=1,
+    )
+    await rag.initialize_storages()
+    return rag
+
+
+def _status_value(status: object) -> str:
+    if isinstance(status, DocStatus):
+        return status.value
+    return str(status).replace("DocStatus.", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_processed_upsert_happens_after_data_flush(tmp_path, monkeypatch):
+    rag = await _build_rag(tmp_path)
+    try:
+        await rag.apipeline_enqueue_documents(input="order doc", file_paths="order.txt")
+        doc_id = compute_mdhash_id("order.txt", prefix="doc-")
+
+        events: list[str] = []
+
+        orig_insert_done = rag._insert_done
+
+        async def spy_insert_done(*a, **k):
+            events.append("insert_done")
+            await orig_insert_done(*a, **k)
+
+        monkeypatch.setattr(rag, "_insert_done", spy_insert_done)
+
+        orig_upsert = rag.doc_status.upsert
+
+        async def spy_upsert(data):
+            for rec_id, rec in data.items():
+                if rec_id == doc_id:
+                    events.append(f"status:{_status_value(rec.get('status'))}")
+            await orig_upsert(data)
+
+        monkeypatch.setattr(rag.doc_status, "upsert", spy_upsert)
+
+        await rag.apipeline_process_enqueue_documents()
+
+        doc_status = await rag.doc_status.get_by_id(doc_id)
+        assert _status_value(doc_status["status"]) == "processed"
+
+        processed_idx = events.index("status:processed")
+        flush_indexes = [i for i, e in enumerate(events) if e == "insert_done"]
+        assert flush_indexes, f"no _insert_done recorded: {events}"
+        # The merge-stage flush precedes the PROCESSED commit record.
+        assert any(i < processed_idx for i in flush_indexes), (
+            f"PROCESSED (at {processed_idx}) was written before any data "
+            f"flush: {events}"
+        )
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_flush_failure_never_writes_processed(tmp_path, monkeypatch):
+    """With the merge-stage flush failing, doc_status must never see a
+    PROCESSED write for the document — not even transiently (the old order
+    durably wrote PROCESSED first and only later corrected it to FAILED)."""
+    rag = await _build_rag(tmp_path)
+    try:
+        await rag.apipeline_enqueue_documents(input="fail doc", file_paths="fail.txt")
+        doc_id = compute_mdhash_id("fail.txt", prefix="doc-")
+
+        statuses_written: list[str] = []
+        orig_upsert = rag.doc_status.upsert
+
+        async def spy_upsert(data):
+            for rec_id, rec in data.items():
+                if rec_id == doc_id:
+                    statuses_written.append(_status_value(rec.get("status")))
+            await orig_upsert(data)
+
+        monkeypatch.setattr(rag.doc_status, "upsert", spy_upsert)
+
+        async def flush_boom():
+            raise RuntimeError("vdb flush boom")
+
+        monkeypatch.setattr(rag.entities_vdb, "index_done_callback", flush_boom)
+
+        await rag.apipeline_process_enqueue_documents()
+
+        doc_status = await rag.doc_status.get_by_id(doc_id)
+        assert _status_value(doc_status["status"]) == "failed"
+        assert "processed" not in statuses_written, (
+            f"a PROCESSED write reached doc_status despite the flush "
+            f"failure: {statuses_written}"
+        )
+    finally:
+        await rag.finalize_storages()

--- a/tests/pipeline/test_purge_primitive.py
+++ b/tests/pipeline/test_purge_primitive.py
@@ -1,0 +1,313 @@
+"""Candidate-driven purge/rebuild primitive (issue #3400, Phase 1).
+
+``_purge_kg_contributions`` is the shared lower-level primitive behind
+whole-document purge (``_purge_doc_chunks_and_kg``) and — in later phases —
+custom-chunk patch rollback. These tests drive it with in-memory fakes:
+
+- candidates may be explicit (journal/prewrite driven) or discovered from the
+  per-doc ``full_entities`` / ``full_relations`` rows;
+- a candidate absent from the graph is an idempotent no-op, never an error
+  (candidates are a recovery SUPERSET);
+- ``patch_only=True`` must keep the base document's recovery rows;
+- ``strict_rebuild=True`` propagates missing-extraction-cache errors instead
+  of silently succeeding.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from lightrag import LightRAG
+from lightrag.constants import GRAPH_FIELD_SEP
+from lightrag.exceptions import KGRebuildCacheMissingError
+from lightrag.utils import compute_mdhash_id, make_relation_chunk_key
+
+
+class _KV:
+    def __init__(self, data: dict | None = None):
+        self.data = dict(data or {})
+        self.deleted: list[str] = []
+
+    async def get_by_id(self, key):
+        return self.data.get(key)
+
+    async def get_by_ids(self, keys):
+        return [self.data.get(k) for k in keys]
+
+    async def upsert(self, data):
+        self.data.update(data)
+
+    async def delete(self, ids):
+        self.deleted.extend(ids)
+        for k in ids:
+            self.data.pop(k, None)
+
+
+class _Vdb:
+    def __init__(self):
+        self.deleted: list[str] = []
+
+    async def delete(self, ids):
+        self.deleted.extend(ids)
+
+
+class _Graph:
+    def __init__(self, nodes: dict | None = None, edges: dict | None = None):
+        self.nodes = dict(nodes or {})
+        self.edges = dict(edges or {})
+        self.removed_nodes: list[str] = []
+        self.removed_edges: list[tuple[str, str]] = []
+
+    async def get_nodes_batch(self, names):
+        return {n: dict(self.nodes[n]) if n in self.nodes else None for n in names}
+
+    async def get_edges_batch(self, pairs):
+        out = {}
+        for p in pairs:
+            s, t = p["src"], p["tgt"]
+            edge = self.edges.get((s, t)) or self.edges.get((t, s))
+            out[(s, t)] = dict(edge) if edge else None
+        return out
+
+    async def get_nodes_edges_batch(self, names):
+        return {n: [] for n in names}
+
+    async def remove_nodes(self, names):
+        self.removed_nodes.extend(names)
+        for n in names:
+            self.nodes.pop(n, None)
+
+    async def remove_edges(self, pairs):
+        self.removed_edges.extend(pairs)
+        for s, t in pairs:
+            self.edges.pop((s, t), None)
+            self.edges.pop((t, s), None)
+
+
+def _node(name: str, sources: list[str]) -> dict:
+    return {
+        "entity_id": name,
+        "description": name,
+        "source_id": GRAPH_FIELD_SEP.join(sources),
+        "entity_type": "X",
+        "file_path": "f",
+    }
+
+
+def _edge(sources: list[str]) -> dict:
+    return {
+        "description": "rel",
+        "keywords": "k",
+        "weight": 1.0,
+        "source_id": GRAPH_FIELD_SEP.join(sources),
+        "file_path": "f",
+    }
+
+
+def _make_rag(
+    *,
+    graph: _Graph,
+    full_entities: _KV | None = None,
+    full_relations: _KV | None = None,
+    entity_chunks: _KV | None = None,
+    relation_chunks: _KV | None = None,
+    text_chunks: _KV | None = None,
+    llm_cache: _KV | None = None,
+) -> LightRAG:
+    rag = LightRAG.__new__(LightRAG)
+    rag.chunk_entity_relation_graph = graph
+    rag.full_entities = full_entities if full_entities is not None else _KV()
+    rag.full_relations = full_relations if full_relations is not None else _KV()
+    rag.entity_chunks = entity_chunks if entity_chunks is not None else _KV()
+    rag.relation_chunks = relation_chunks if relation_chunks is not None else _KV()
+    rag.chunks_vdb = _Vdb()
+    rag.entities_vdb = _Vdb()
+    rag.relationships_vdb = _Vdb()
+    rag.text_chunks = text_chunks if text_chunks is not None else _KV()
+    rag.llm_response_cache = llm_cache if llm_cache is not None else _KV()
+
+    async def _noop_insert_done(*args, **kwargs):
+        return None
+
+    rag._insert_done = _noop_insert_done
+    rag._build_global_config = lambda: {"llm_model_max_async": 1}
+    return rag
+
+
+def _status():
+    return {"latest_message": "", "history_messages": []}, asyncio.Lock()
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_whole_doc_purge_from_recovery_rows():
+    """Wrapper path (regression): candidates come from the per-doc rows;
+    fully-owned entity/relation are removed from graph, vector, and tracking,
+    and the recovery rows are deleted at the end."""
+    graph = _Graph(
+        nodes={"ALICE": _node("ALICE", ["c1"]), "ACME": _node("ACME", ["c1"])},
+        edges={("ACME", "ALICE"): _edge(["c1"])},
+    )
+    rag = _make_rag(
+        graph=graph,
+        full_entities=_KV({"d1": {"entity_names": ["ALICE", "ACME"], "count": 2}}),
+        full_relations=_KV({"d1": {"relation_pairs": [["ACME", "ALICE"]], "count": 1}}),
+        entity_chunks=_KV(
+            {
+                "ALICE": {"chunk_ids": ["c1"]},
+                "ACME": {"chunk_ids": ["c1"]},
+            }
+        ),
+        relation_chunks=_KV(
+            {make_relation_chunk_key("ACME", "ALICE"): {"chunk_ids": ["c1"]}}
+        ),
+    )
+    status, lock = _status()
+
+    await rag._purge_doc_chunks_and_kg(
+        "d1", ["c1"], pipeline_status=status, pipeline_status_lock=lock
+    )
+
+    assert set(graph.removed_nodes) == {"ALICE", "ACME"}
+    assert graph.removed_edges == [("ACME", "ALICE")]
+    assert rag.chunks_vdb.deleted == ["c1"]
+    assert rag.text_chunks.deleted == ["c1"]
+    assert set(rag.entities_vdb.deleted) == {
+        compute_mdhash_id("ALICE", prefix="ent-"),
+        compute_mdhash_id("ACME", prefix="ent-"),
+    }
+    # Recovery rows removed last (whole-doc mode).
+    assert rag.full_entities.deleted == ["d1"]
+    assert rag.full_relations.deleted == ["d1"]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_explicit_candidates_bypass_recovery_rows():
+    """Explicit candidates (journal/prewrite callers) must be used verbatim —
+    the per-doc rows are not consulted for discovery."""
+    graph = _Graph(nodes={"ALICE": _node("ALICE", ["c1"])})
+
+    class _ExplodingKV(_KV):
+        async def get_by_id(self, key):  # discovery read would blow up
+            raise AssertionError("full-index row must not be read")
+
+    rag = _make_rag(
+        graph=graph,
+        full_entities=_ExplodingKV(),
+        full_relations=_ExplodingKV(),
+        entity_chunks=_KV({"ALICE": {"chunk_ids": ["c1"]}}),
+    )
+    status, lock = _status()
+
+    await rag._purge_kg_contributions(
+        "d1",
+        ["c1"],
+        candidate_entities=["ALICE"],
+        candidate_relations=[],
+        patch_only=True,
+        pipeline_status=status,
+        pipeline_status_lock=lock,
+    )
+
+    assert graph.removed_nodes == ["ALICE"]
+    # patch_only: base-document recovery rows untouched.
+    assert rag.full_entities.deleted == []
+    assert rag.full_relations.deleted == []
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_absent_candidates_are_idempotent_noops():
+    """A candidate that never reached the graph (prewritten superset, or a
+    previous partial purge already removed it) must be skipped silently."""
+    graph = _Graph()  # empty graph — nothing exists
+    rag = _make_rag(graph=graph)
+    status, lock = _status()
+
+    await rag._purge_kg_contributions(
+        "d1",
+        ["c1"],
+        candidate_entities=["GHOST"],
+        candidate_relations=[("GHOST", "PHANTOM")],
+        pipeline_status=status,
+        pipeline_status_lock=lock,
+    )
+
+    assert graph.removed_nodes == []
+    assert graph.removed_edges == []
+    # Chunks are still deleted (they are the doc's own data)...
+    assert rag.chunks_vdb.deleted == ["c1"]
+    # ...and whole-doc mode still clears the recovery rows.
+    assert rag.full_entities.deleted == ["d1"]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_empty_chunk_ids_returns_without_touching_storage():
+    graph = _Graph(nodes={"ALICE": _node("ALICE", ["c1"])})
+    rag = _make_rag(graph=graph)
+    status, lock = _status()
+
+    await rag._purge_kg_contributions(
+        "d1", [], pipeline_status=status, pipeline_status_lock=lock
+    )
+
+    assert graph.removed_nodes == []
+    assert rag.chunks_vdb.deleted == []
+    assert rag.full_entities.deleted == []
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_strict_rebuild_failure_propagates_through_purge():
+    """An entity that keeps sources from another chunk becomes a rebuild
+    target; with strict_rebuild=True and no extraction cache the purge must
+    FAIL (retaining a retryable dirty state), not silently 'succeed'."""
+    graph = _Graph(nodes={"ALICE": _node("ALICE", ["c1", "c2"])})
+    rag = _make_rag(
+        graph=graph,
+        entity_chunks=_KV({"ALICE": {"chunk_ids": ["c1", "c2"]}}),
+        # c2 survives but has no cached extraction to rebuild from.
+        text_chunks=_KV({"c2": {"content": "x", "llm_cache_list": []}}),
+    )
+    status, lock = _status()
+
+    with pytest.raises(Exception) as excinfo:
+        await rag._purge_kg_contributions(
+            "d1",
+            ["c1"],
+            candidate_entities=["ALICE"],
+            candidate_relations=[],
+            strict_rebuild=True,
+            pipeline_status=status,
+            pipeline_status_lock=lock,
+        )
+    assert isinstance(excinfo.value.__cause__, KGRebuildCacheMissingError)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_non_strict_rebuild_keeps_best_effort_behavior():
+    """Same partial-cache scenario without strict_rebuild: historical
+    best-effort behavior (warn + continue) is preserved for existing callers."""
+    graph = _Graph(nodes={"ALICE": _node("ALICE", ["c1", "c2"])})
+    rag = _make_rag(
+        graph=graph,
+        entity_chunks=_KV({"ALICE": {"chunk_ids": ["c1", "c2"]}}),
+        text_chunks=_KV({"c2": {"content": "x", "llm_cache_list": []}}),
+    )
+    status, lock = _status()
+
+    await rag._purge_kg_contributions(
+        "d1",
+        ["c1"],
+        candidate_entities=["ALICE"],
+        candidate_relations=[],
+        pipeline_status=status,
+        pipeline_status_lock=lock,
+    )
+    # Tracking narrowed to the surviving source.
+    assert rag.entity_chunks.data["ALICE"]["chunk_ids"] == ["c2"]

--- a/tests/pipeline/test_purge_primitive.py
+++ b/tests/pipeline/test_purge_primitive.py
@@ -44,6 +44,9 @@ class _KV:
         for k in ids:
             self.data.pop(k, None)
 
+    async def index_done_callback(self):
+        pass
+
 
 class _Vdb:
     def __init__(self):
@@ -51,6 +54,9 @@ class _Vdb:
 
     async def delete(self, ids):
         self.deleted.extend(ids)
+
+    async def index_done_callback(self):
+        pass
 
 
 class _Graph:
@@ -258,6 +264,119 @@ async def test_empty_chunk_ids_returns_without_touching_storage():
     assert graph.removed_nodes == []
     assert rag.chunks_vdb.deleted == []
     assert rag.full_entities.deleted == []
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_purge_deletes_chunks_only_after_graph_repair(monkeypatch):
+    """Safe destructive ordering (Phase 2): graph/vector/tracking cleanup is
+    flushed BEFORE the source chunks are deleted, and the recovery rows go
+    last — so a crash at any point leaves either the chunks or the anchors
+    (or both) for a retry."""
+    graph = _Graph(
+        nodes={"ALICE": _node("ALICE", ["c1"])},
+    )
+    rag = _make_rag(
+        graph=graph,
+        full_entities=_KV({"d1": {"entity_names": ["ALICE"], "count": 1}}),
+        full_relations=_KV({"d1": {"relation_pairs": [], "count": 0}}),
+        entity_chunks=_KV({"ALICE": {"chunk_ids": ["c1"]}}),
+    )
+    order: list[str] = []
+
+    orig_remove_nodes = graph.remove_nodes
+
+    async def spy_remove_nodes(names):
+        order.append("graph.remove_nodes")
+        await orig_remove_nodes(names)
+
+    graph.remove_nodes = spy_remove_nodes
+
+    async def spy_insert_done(*a, **k):
+        order.append("flush")
+
+    rag._insert_done = spy_insert_done
+
+    orig_chunk_delete = rag.chunks_vdb.delete
+
+    async def spy_chunk_delete(ids):
+        order.append("chunks.delete")
+        await orig_chunk_delete(ids)
+
+    monkeypatch.setattr(rag.chunks_vdb, "delete", spy_chunk_delete)
+
+    orig_fe_delete = rag.full_entities.delete
+
+    async def spy_fe_delete(ids):
+        order.append("anchors.delete")
+        await orig_fe_delete(ids)
+
+    monkeypatch.setattr(rag.full_entities, "delete", spy_fe_delete)
+
+    status, lock = _status()
+    await rag._purge_doc_chunks_and_kg(
+        "d1", ["c1"], pipeline_status=status, pipeline_status_lock=lock
+    )
+
+    assert order.index("graph.remove_nodes") < order.index("flush")
+    assert order.index("flush") < order.index("chunks.delete")
+    assert order.index("chunks.delete") < order.index("anchors.delete")
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_graph_delete_failure_keeps_chunks_and_anchors():
+    """A failure while repairing graph contributions must leave both the
+    chunks and the recovery rows untouched — fully retryable."""
+    graph = _Graph(nodes={"ALICE": _node("ALICE", ["c1"])})
+
+    async def boom(names):
+        raise RuntimeError("graph delete boom")
+
+    graph.remove_nodes = boom
+    rag = _make_rag(
+        graph=graph,
+        full_entities=_KV({"d1": {"entity_names": ["ALICE"], "count": 1}}),
+        entity_chunks=_KV({"ALICE": {"chunk_ids": ["c1"]}}),
+    )
+    status, lock = _status()
+
+    with pytest.raises(Exception, match="Failed to delete entities"):
+        await rag._purge_doc_chunks_and_kg(
+            "d1", ["c1"], pipeline_status=status, pipeline_status_lock=lock
+        )
+
+    assert rag.chunks_vdb.deleted == []
+    assert rag.text_chunks.deleted == []
+    assert rag.full_entities.deleted == []
+    assert "d1" in rag.full_entities.data
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_chunk_delete_failure_keeps_recovery_rows(monkeypatch):
+    """A failure while deleting chunks must keep the recovery rows so the
+    purge can be repeated."""
+    graph = _Graph(nodes={"ALICE": _node("ALICE", ["c1"])})
+    rag = _make_rag(
+        graph=graph,
+        full_entities=_KV({"d1": {"entity_names": ["ALICE"], "count": 1}}),
+        entity_chunks=_KV({"ALICE": {"chunk_ids": ["c1"]}}),
+    )
+
+    async def boom(ids):
+        raise RuntimeError("chunk delete boom")
+
+    monkeypatch.setattr(rag.chunks_vdb, "delete", boom)
+    status, lock = _status()
+
+    with pytest.raises(Exception, match="Failed to delete document chunks"):
+        await rag._purge_doc_chunks_and_kg(
+            "d1", ["c1"], pipeline_status=status, pipeline_status_lock=lock
+        )
+
+    assert rag.full_entities.deleted == []
+    assert "d1" in rag.full_entities.data
 
 
 @pytest.mark.offline

--- a/tests/pipeline/test_purge_primitive.py
+++ b/tests/pipeline/test_purge_primitive.py
@@ -9,20 +9,29 @@ custom-chunk patch rollback. These tests drive it with in-memory fakes:
 - a candidate absent from the graph is an idempotent no-op, never an error
   (candidates are a recovery SUPERSET);
 - ``patch_only=True`` must keep the base document's recovery rows;
-- ``strict_rebuild=True`` propagates missing-extraction-cache errors instead
-  of silently succeeding.
+- rollback rebuild structurally repairs provenance and reports missing cache.
 """
 
 from __future__ import annotations
 
 import asyncio
+from contextlib import asynccontextmanager
 
 import pytest
+import lightrag.operate as operate_module
 
 from lightrag import LightRAG
 from lightrag.constants import GRAPH_FIELD_SEP
-from lightrag.exceptions import KGRebuildCacheMissingError
 from lightrag.utils import compute_mdhash_id, make_relation_chunk_key
+
+
+@pytest.fixture(autouse=True)
+def _storage_keyed_lock_noop(monkeypatch):
+    @asynccontextmanager
+    async def _noop_lock(*args, **kwargs):
+        yield
+
+    monkeypatch.setattr(operate_module, "get_storage_keyed_lock", _noop_lock)
 
 
 class _KV:
@@ -51,9 +60,15 @@ class _KV:
 class _Vdb:
     def __init__(self):
         self.deleted: list[str] = []
+        self.data: dict = {}
 
     async def delete(self, ids):
         self.deleted.extend(ids)
+        for key in ids:
+            self.data.pop(key, None)
+
+    async def upsert(self, data):
+        self.data.update(data)
 
     async def index_done_callback(self):
         pass
@@ -79,6 +94,24 @@ class _Graph:
 
     async def get_nodes_edges_batch(self, names):
         return {n: [] for n in names}
+
+    async def get_node(self, name):
+        return self.nodes.get(name)
+
+    async def get_edge(self, src, tgt):
+        return self.edges.get((src, tgt)) or self.edges.get((tgt, src))
+
+    async def get_node_edges(self, name):
+        return [pair for pair in self.edges if name in pair]
+
+    async def has_node(self, name):
+        return name in self.nodes
+
+    async def upsert_node(self, name, node_data):
+        self.nodes[name] = dict(node_data)
+
+    async def upsert_edge(self, src, tgt, edge_data):
+        self.edges[(src, tgt)] = dict(edge_data)
 
     async def remove_nodes(self, names):
         self.removed_nodes.extend(names)
@@ -138,7 +171,14 @@ def _make_rag(
         return None
 
     rag._insert_done = _noop_insert_done
-    rag._build_global_config = lambda: {"llm_model_max_async": 1}
+    rag._build_global_config = lambda: {
+        "llm_model_max_async": 1,
+        "max_source_ids_per_entity": 100,
+        "max_source_ids_per_relation": 100,
+        "source_ids_limit_method": "KEEP",
+        "max_file_paths": 100,
+        "file_path_more_placeholder": "more",
+    }
     return rag
 
 
@@ -381,10 +421,8 @@ async def test_chunk_delete_failure_keeps_recovery_rows(monkeypatch):
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_strict_rebuild_failure_propagates_through_purge():
-    """An entity that keeps sources from another chunk becomes a rebuild
-    target; with strict_rebuild=True and no extraction cache the purge must
-    FAIL (retaining a retryable dirty state), not silently 'succeed'."""
+async def test_rollback_rebuild_repairs_provenance_when_cache_is_missing():
+    """Missing cache degrades semantics but must not retain deleted sources."""
     graph = _Graph(nodes={"ALICE": _node("ALICE", ["c1", "c2"])})
     rag = _make_rag(
         graph=graph,
@@ -394,23 +432,246 @@ async def test_strict_rebuild_failure_propagates_through_purge():
     )
     status, lock = _status()
 
-    with pytest.raises(Exception) as excinfo:
+    report = await rag._purge_kg_contributions(
+        "d1",
+        ["c1"],
+        candidate_entities=["ALICE"],
+        candidate_relations=[],
+        rebuild_policy="rollback",
+        pipeline_status=status,
+        pipeline_status_lock=lock,
+    )
+
+    assert report.missing_cache_chunk_ids == {"c2"}
+    assert report.degraded_entities == {"ALICE": ["c2"]}
+    assert graph.nodes["ALICE"]["source_id"] == "c2"
+    entity_vdb_id = compute_mdhash_id("ALICE", prefix="ent-")
+    assert rag.entities_vdb.data[entity_vdb_id]["source_id"] == "c2"
+    assert rag.entity_chunks.data["ALICE"]["chunk_ids"] == ["c2"]
+    assert rag.chunks_vdb.deleted == ["c1"]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_rollback_rebuild_storage_failure_keeps_source_chunks(monkeypatch):
+    """Operational write failures remain retryable and converge on retry."""
+    graph = _Graph(nodes={"ALICE": _node("ALICE", ["c1", "c2"])})
+    rag = _make_rag(
+        graph=graph,
+        entity_chunks=_KV({"ALICE": {"chunk_ids": ["c1", "c2"]}}),
+        text_chunks=_KV({"c2": {"content": "x", "llm_cache_list": []}}),
+    )
+
+    original_upsert = rag.entities_vdb.upsert
+
+    async def upsert_boom(data):
+        raise RuntimeError("entity vdb boom")
+
+    monkeypatch.setattr(rag.entities_vdb, "upsert", upsert_boom)
+    status, lock = _status()
+
+    with pytest.raises(Exception, match="Failed to rebuild knowledge graph"):
         await rag._purge_kg_contributions(
             "d1",
             ["c1"],
             candidate_entities=["ALICE"],
             candidate_relations=[],
-            strict_rebuild=True,
+            rebuild_policy="rollback",
             pipeline_status=status,
             pipeline_status_lock=lock,
         )
-    assert isinstance(excinfo.value.__cause__, KGRebuildCacheMissingError)
+
+    assert rag.chunks_vdb.deleted == []
+    assert rag.text_chunks.deleted == []
+
+    # The first attempt already repaired graph/tracking before the VDB write
+    # failed. Rollback policy must nevertheless rebuild journal candidates on
+    # retry, otherwise the stale VDB record would be skipped permanently.
+    monkeypatch.setattr(rag.entities_vdb, "upsert", original_upsert)
+    report = await rag._purge_kg_contributions(
+        "d1",
+        ["c1"],
+        candidate_entities=["ALICE"],
+        candidate_relations=[],
+        rebuild_policy="rollback",
+        pipeline_status=status,
+        pipeline_status_lock=lock,
+    )
+
+    assert report.degraded_entities == {"ALICE": ["c2"]}
+    entity_vdb_id = compute_mdhash_id("ALICE", prefix="ent-")
+    assert rag.entities_vdb.data[entity_vdb_id]["source_id"] == "c2"
+    assert rag.chunks_vdb.deleted == ["c1"]
 
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_non_strict_rebuild_keeps_best_effort_behavior():
-    """Same partial-cache scenario without strict_rebuild: historical
+async def test_rollback_tracking_write_failure_keeps_source_chunks(monkeypatch):
+    graph = _Graph(nodes={"ALICE": _node("ALICE", ["c1", "c2"])})
+    rag = _make_rag(
+        graph=graph,
+        entity_chunks=_KV({"ALICE": {"chunk_ids": ["c1", "c2"]}}),
+        text_chunks=_KV({"c2": {"content": "x", "llm_cache_list": []}}),
+    )
+    original_upsert = rag.entity_chunks.upsert
+
+    async def tracking_boom(data):
+        raise RuntimeError("tracking boom")
+
+    monkeypatch.setattr(rag.entity_chunks, "upsert", tracking_boom)
+    status, lock = _status()
+    with pytest.raises(Exception, match="Failed to process graph dependencies"):
+        await rag._purge_kg_contributions(
+            "d1",
+            ["c1"],
+            candidate_entities=["ALICE"],
+            candidate_relations=[],
+            rebuild_policy="rollback",
+            pipeline_status=status,
+            pipeline_status_lock=lock,
+        )
+
+    assert rag.chunks_vdb.deleted == []
+    assert rag.text_chunks.deleted == []
+
+    monkeypatch.setattr(rag.entity_chunks, "upsert", original_upsert)
+    await rag._purge_kg_contributions(
+        "d1",
+        ["c1"],
+        candidate_entities=["ALICE"],
+        candidate_relations=[],
+        rebuild_policy="rollback",
+        pipeline_status=status,
+        pipeline_status_lock=lock,
+    )
+    assert rag.entity_chunks.data["ALICE"]["chunk_ids"] == ["c2"]
+    assert rag.chunks_vdb.deleted == ["c1"]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_rollback_repairs_relation_when_cache_omits_target_object():
+    """PR #3416 review regression: a valid cache entry can omit the edge.
+
+    Rollback must preserve its semantic fields while removing the staged
+    source from graph, vector, and tracking provenance.
+    """
+    graph = _Graph(
+        nodes={
+            "ALICE": _node("ALICE", ["c1", "c2"]),
+            "BOB": _node("BOB", ["c1", "c2"]),
+        },
+        edges={("ALICE", "BOB"): _edge(["c1", "c2"])},
+    )
+    rag = _make_rag(
+        graph=graph,
+        relation_chunks=_KV(
+            {make_relation_chunk_key("ALICE", "BOB"): {"chunk_ids": ["c1", "c2"]}}
+        ),
+        text_chunks=_KV(
+            {
+                "c2": {
+                    "content": "alice only",
+                    "file_path": "base.txt",
+                    "llm_cache_list": ["cache-c2"],
+                }
+            }
+        ),
+        llm_cache=_KV(
+            {
+                "cache-c2": {
+                    "cache_type": "extract",
+                    "chunk_id": "c2",
+                    "return": '{"entities": [{"name": "ALICE", "type": "PERSON", "description": "Alice"}], "relationships": []}',
+                    "create_time": 1,
+                }
+            }
+        ),
+    )
+    status, lock = _status()
+
+    report = await rag._purge_kg_contributions(
+        "d1",
+        ["c1"],
+        candidate_entities=[],
+        candidate_relations=[("ALICE", "BOB")],
+        patch_only=True,
+        rebuild_policy="rollback",
+        pipeline_status=status,
+        pipeline_status_lock=lock,
+    )
+
+    assert report.missing_cache_chunk_ids == set()
+    assert report.degraded_relationships == {("ALICE", "BOB"): ["c2"]}
+    assert graph.edges[("ALICE", "BOB")]["source_id"] == "c2"
+    rel_vdb_id = compute_mdhash_id("ALICEBOB", prefix="rel-")
+    assert rag.relationships_vdb.data[rel_vdb_id]["source_id"] == "c2"
+    tracking_key = make_relation_chunk_key("ALICE", "BOB")
+    assert rag.relation_chunks.data[tracking_key]["chunk_ids"] == ["c2"]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_rollback_relation_vdb_delete_failure_retries_to_convergence(
+    monkeypatch,
+):
+    """Even the VDB cleanup preceding an upsert is strict in rollback mode."""
+    graph = _Graph(
+        nodes={
+            "ALICE": _node("ALICE", ["c1", "c2"]),
+            "BOB": _node("BOB", ["c1", "c2"]),
+        },
+        edges={("ALICE", "BOB"): _edge(["c1", "c2"])},
+    )
+    rag = _make_rag(
+        graph=graph,
+        relation_chunks=_KV(
+            {make_relation_chunk_key("ALICE", "BOB"): {"chunk_ids": ["c1", "c2"]}}
+        ),
+        text_chunks=_KV({"c2": {"content": "base", "llm_cache_list": []}}),
+    )
+    original_delete = rag.relationships_vdb.delete
+
+    async def delete_boom(ids):
+        raise RuntimeError("relation vdb delete boom")
+
+    monkeypatch.setattr(rag.relationships_vdb, "delete", delete_boom)
+    status, lock = _status()
+    with pytest.raises(Exception, match="Failed to rebuild knowledge graph"):
+        await rag._purge_kg_contributions(
+            "d1",
+            ["c1"],
+            candidate_entities=[],
+            candidate_relations=[("ALICE", "BOB")],
+            patch_only=True,
+            rebuild_policy="rollback",
+            pipeline_status=status,
+            pipeline_status_lock=lock,
+        )
+
+    assert rag.chunks_vdb.deleted == []
+    monkeypatch.setattr(rag.relationships_vdb, "delete", original_delete)
+    report = await rag._purge_kg_contributions(
+        "d1",
+        ["c1"],
+        candidate_entities=[],
+        candidate_relations=[("ALICE", "BOB")],
+        patch_only=True,
+        rebuild_policy="rollback",
+        pipeline_status=status,
+        pipeline_status_lock=lock,
+    )
+
+    assert report.degraded_relationships == {("ALICE", "BOB"): ["c2"]}
+    rel_vdb_id = compute_mdhash_id("ALICEBOB", prefix="rel-")
+    assert rag.relationships_vdb.data[rel_vdb_id]["source_id"] == "c2"
+    assert rag.chunks_vdb.deleted == ["c1"]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_best_effort_rebuild_keeps_historical_behavior():
+    """Same partial-cache scenario with default policy: historical
     best-effort behavior (warn + continue) is preserved for existing callers."""
     graph = _Graph(nodes={"ALICE": _node("ALICE", ["c1", "c2"])})
     rag = _make_rag(


### PR DESCRIPTION
## Description

Implements the recoverable-document-mutations plan for #3400, including the review follow-up that makes custom-chunk rollback structurally recoverable even when extraction cache data is missing, malformed, or incomplete.

LightRAG cannot provide cross-store ACID transactions across arbitrary graph, vector, KV, and document-status backends. This PR therefore treats document mutations as recoverable sagas with terminal-state consistency:

- PROCESSED is written only after all required data is durable.
- Partial work remains discoverable through write-ahead anchors or a custom-chunk journal.
- Recovery is idempotent and retryable.
- A degraded rollback guarantees structural consistency, while reporting semantic loss through persistent metadata warnings.

Current diff: **+4,601 / -353 across 22 files**.

Design discussion: https://github.com/HKUDS/LightRAG/issues/3400#issuecomment-4979799330

## Related Issues

- Implements #3400.
- Subsumes the point-fix context of #3394, #3395, #3398, and #3399.
- Builds on the busy and cancellation contract from #3401.
- Addresses the latest automated P1 review on this PR concerning cache entries that parse successfully but omit the target entity or relationship.

## Motivation

The previous mutation paths could leave graph, vector, chunk-tracking, recovery-index, and document-status stores mutually inconsistent after a crash, cancellation, or storage error. Confirmed failure modes included:

1. A durable false PROCESSED status before derived stores were flushed.
2. Graph mutations committed without durable recovery anchors.
3. Source chunks deleted before graph and vector provenance was repaired.
4. Custom-chunk operations with no journal or document-status bookkeeping.
5. Rollback blocked forever when extraction cache data was lost.
6. A valid cache entry omitting the target object could leave graph or VDB source_id pointing at a deleted staged chunk.

## Changes Made

### 1. Recovery primitives and commit ordering

- Added task draining so sibling graph writes cannot continue after the first failure or cancellation.
- Added candidate collection for the full entity and relationship superset a merge may touch.
- Prewrites and flushes recovery anchors before graph mutation.
- Writes PROCESSED only after derived stores are flushed.
- Purges in safe order: repair graph, VDB, and tracking; flush; delete chunks; delete recovery anchors last.
- Keeps absent candidates as idempotent no-ops.

### 2. Journaled custom-chunk operations

- Uses deterministic document-scoped chunk IDs and operation IDs.
- Persists a custom_chunk_patch journal before staging any mutation.
- Supports create, patch, same-operation resume, and conflict rejection.
- Keeps failed or cancelled operations in FAILED with the journal intact.
- Commits anchor unions and clears the journal only after all derived data is durable.
- Includes journal-only candidates during whole-document deletion.
- Flushes create-mode doc_status deletion before reporting rollback success.

### 3. Scan-time rollback with degraded recovery

rebuild_knowledge_from_chunks now uses an internal policy instead of the former strict flag:

- best_effort preserves ordinary deletion compatibility.
- rollback treats graph, VDB, and tracking reads or writes as strict, but treats missing recovery material as a semantic degradation rather than a permanent failure.

Under rollback policy:

- Missing, malformed, or partially available extraction cache no longer prevents rollback.
- Available cache contributions are used when possible.
- If cache data does not contain the target entity or relationship, current semantic fields are preserved.
- Surviving source_id, file_path, chunk tracking, graph records, and VDB records are rewritten.
- Existing candidates are rebuilt again on journal retry, even if an earlier partial attempt already repaired graph provenance. This allows a stale VDB or tracking write to converge on retry.
- Candidates already absent from the graph remain no-ops.
- Actual storage failures still abort rollback and retain the journal.

Successful rollback therefore leaves no graph, VDB, or tracking reference to staged or deleted chunks. It does not claim bit-identical semantic reconstruction when recovery material has been lost, and it never calls the LLM during rollback.

### 4. Persistent recovery warnings

A degraded but structurally successful custom-chunk rollback:

- Restores patch-mode documents to PROCESSED without a top-level error_msg.
- Stores structured events in metadata.kg_recovery_warnings.
- Attaches warnings to owners resolved from surviving chunk full_doc_id values.
- Also attaches patch-mode warnings to the target document.
- Allows create-mode rollback to delete the target while warning surviving related owners.
- Deduplicates by operation, keeps the latest 10 events, and limits every object or chunk sample to 20 entries with a total count.
- Treats warning persistence as part of the rollback commit. Failure retains the journal for retry.
- Clears historical recovery warnings through the existing full-document metadata reset path.

The WebUI displays a yellow AlertTriangle when either error_msg or a non-empty recovery warning list exists. The existing metadata details dialog renders the warning without a new REST field or document status enum.

### 5. Audit and repair tooling

- Adds an offline KG integrity audit and repair tool for historical pre-fix data.
- Reconstructs missing per-document anchors where ownership can be resolved.
- Reports irrecoverable orphans for operator review and never auto-deletes them.
- Documents ainsert_custom_kg as outside the document-level recovery guarantee.

## Failure Point and Recovery

| Failure point | Durable evidence | Recovery |
|---|---|---|
| Anchor prewrite or flush | status, no graph mutation | ordinary retry |
| Graph, VDB, or tracking partial write | anchors or custom journal | retry rebuilds candidates and converges |
| Derived-store flush | anchors plus non-terminal status | ordinary retry |
| Final status write | complete data plus stale journal or status | idempotent retry |
| Purge before chunk deletion | chunks and anchors remain | repeat purge |
| Purge after structural repair | journal or anchors remain | repeat purge |
| Missing or incomplete extraction cache | structured rebuild report | structural fallback plus metadata warning |
| Warning metadata persistence | custom journal remains | retry warning persistence and final commit |
| Rollback storage failure | custom journal plus FAILED | next scan retries |

## Behavioral and Compatibility Notes

1. ainsert_custom_chunks rejects a non-PROCESSED target without a matching journal and rejects a different operation while a journal is active.
2. Custom-chunk IDs are scoped by document identity, preventing identical text in different documents from sharing and overwriting one chunk row.
3. doc_status.metadata reserves custom_chunk_patch and kg_recovery_warnings.
4. Recovery anchor rows contain candidate supersets and may be empty.
5. Ordinary deletion keeps best-effort rebuild compatibility.
6. Custom rollback success guarantees structural consistency, not identical aggregate semantics after recovery material loss. In particular a degraded relationship preserves its stored weight (the rolled-back chunk's contribution cannot be subtracted without cache); a full reprocess restores exact aggregates.
7. Rollback never invokes the LLM.

## New Public Surface

- LightRAG.arollback_failed_custom_chunk_patches()
- lightrag.tools.kg_integrity_repair.audit_kg_integrity
- utils.wait_tasks_with_drain
- operate.collect_kg_merge_candidates

KGRebuildReport and the rebuild policy are internal recovery coordination details.

## Tests

Latest local validation:

- Recovery primitives, purge, custom rollback, metadata reset, and fault injection: **51 passed** (adds the post-wait cancellation drain regression).
- WebUI Bun tests: **54 passed**.
- WebUI lint and production build: passed.
- Ruff and git diff --check: passed.
- Full backend collection: **3,772 passed, 35 skipped**. Five sandbox-only local socket failures from the keyed-lock multiprocessing test were rerun with the required permission and completed as **7 passed, 1 skipped**.

Regression coverage includes:

- Full and partial cache loss.
- Cache parses but omits the target entity or relationship.
- Preservation of old semantic fields with rewritten surviving provenance.
- Graph, VDB, tracking, and warning-metadata failures retaining retry state.
- Retry convergence after a partial graph-only repair.
- Patch and create warning ownership.
- Warning durability, deduplication, sampling, and retention limits.
- Full reprocessing clearing historical recovery warnings.
- PROCESSED plus recovery warning showing a yellow WebUI icon.
- Waiter cancellation between asyncio.wait and the pending-cancel section still drains pending writers (verified to fail on the previous implementation).

## Checklist

- [x] Changes tested locally.
- [x] Regression tests added.
- [x] Recovery behavior and compatibility notes documented.
- [x] No new REST field or document status enum.
- [x] Review feedback incorporated.

## Suggested Review Order

Core phase commits remain ordered as:

1. a448b96 recovery primitives.
2. 89983e5 write-ahead anchors and commit ordering.
3. 55e339d journaled custom chunks.
4. 5e926fd scan rollback.
5. f7f7830 audit and fault-injection matrix.
6. d6cd33a, dda9d67, 122ec8b, and dfcb685 review follow-up fixes.
