### PR TITLE
Improve shared-storage state atomicity and organization

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -2487,8 +2487,7 @@ async def background_delete_documents(
 
                 start_msg = f"Deleting document {i}/{total_docs}: {doc_id}"
                 logger.info(start_msg)
-                pipeline_status["cur_batch"] = i
-                pipeline_status["latest_message"] = start_msg
+                pipeline_status.update({"cur_batch": i, "latest_message": start_msg})
                 pipeline_status["history_messages"].append(start_msg)
 
             file_path = "#"
@@ -2599,6 +2598,7 @@ async def background_delete_documents(
         # cancellation-resistant so a cancel here cannot wedge the slot or
         # clobber a later holder. Returns whether an indexing request is pending.
         def _delete_release(status):
+            completion_msg = f"Deletion completed: {len(successful_deletions)} successful, {len(failed_deletions)} failed"
             status.update(
                 {
                     "busy": False,
@@ -2606,10 +2606,9 @@ async def background_delete_documents(
                     "busy_owner": None,
                     "operation_record": None,
                     "cancellation_requested": False,
+                    "latest_message": completion_msg,
                 }
             )
-            completion_msg = f"Deletion completed: {len(successful_deletions)} successful, {len(failed_deletions)} failed"
-            status["latest_message"] = completion_msg
             status["history_messages"].append(completion_msg)
             return status.get("request_pending", False)
 
@@ -3596,16 +3595,16 @@ def create_document_routes(
             from lightrag.kg.shared_storage import with_reservation_lock
 
             def _clear_release(status):
+                completion_msg = "Document clearing process completed"
                 status.update(
                     {
                         "busy": False,
                         "destructive_busy": False,
                         "busy_owner": None,
                         "operation_record": None,
+                        "latest_message": completion_msg,
                     }
                 )
-                completion_msg = "Document clearing process completed"
-                status["latest_message"] = completion_msg
                 if "history_messages" in status:
                     status["history_messages"].append(completion_msg)
 
@@ -4495,10 +4494,14 @@ def create_document_routes(
                     )
 
                 # Set cancellation flag
-                pipeline_status["cancellation_requested"] = True
                 cancel_msg = "Pipeline cancellation requested by user"
                 logger.info(cancel_msg)
-                pipeline_status["latest_message"] = cancel_msg
+                pipeline_status.update(
+                    {
+                        "cancellation_requested": True,
+                        "latest_message": cancel_msg,
+                    }
+                )
                 pipeline_status["history_messages"].append(cancel_msg)
 
             return CancelPipelineResponse(

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -544,6 +544,102 @@ def _perform_lock_cleanup(
         return 0, earliest_cleanup_time, last_cleanup_time
 
 
+# ============================================================================
+# Process identity and liveness helpers
+# ============================================================================
+
+_MY_START_ID_CACHE: Optional[str] = None
+_MY_START_ID_COMPUTED: bool = False
+
+
+def _pid_alive(pid: int) -> bool:
+    """Best-effort liveness probe; errs on the side of 'alive'."""
+    if pid == os.getpid():
+        return True
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except OSError:
+        # PermissionError and friends: the process exists (or we cannot
+        # tell) — treat as alive so we never reclaim a live owner's lease.
+        return True
+    return True
+
+
+def _read_proc_starttime(pid: int) -> Optional[str]:
+    """Return a stable per-process start token (field 22 of ``/proc/<pid>/stat``)
+    used to detect PID reuse, or ``None`` when unavailable (non-Linux, the
+    process is gone, or the stat file is unreadable).
+
+    A live PID whose start time differs from a previously recorded token is a
+    DIFFERENT process that reused the PID. ``None`` means "cannot tell" — callers
+    must treat that as *not reused* so a live owner is never reclaimed.
+    """
+    if not sys.platform.startswith("linux"):
+        return None
+    try:
+        with open(f"/proc/{pid}/stat", "rb") as fh:
+            data = fh.read()
+    except (FileNotFoundError, ProcessLookupError):
+        return None  # process is gone (liveness is decided by _pid_alive)
+    except OSError:
+        return None  # unreadable → unknown, make no reuse claim
+    try:
+        # comm (field 2) is wrapped in parentheses and may itself contain spaces
+        # or ')' — everything after the LAST ')' is the space-separated tail
+        # starting at field 3 (state). starttime is field 22 → tail index 19.
+        rparen = data.rindex(b")")
+        tail = data[rparen + 1 :].split()
+        return tail[19].decode("ascii")
+    except (ValueError, IndexError):
+        return None
+
+
+def _my_start_id() -> Optional[str]:
+    """This process's start token (see :func:`_read_proc_starttime`), computed
+    once and cached. ``None`` on non-Linux / when ``/proc`` is unavailable, in
+    which case PID-reuse detection is disabled (dead-only reclaim still works via
+    :func:`_pid_alive`)."""
+    global _MY_START_ID_CACHE, _MY_START_ID_COMPUTED
+    if not _MY_START_ID_COMPUTED:
+        _MY_START_ID_CACHE = _read_proc_starttime(os.getpid())
+        _MY_START_ID_COMPUTED = True
+    return _MY_START_ID_CACHE
+
+
+def _process_alive(pid: Optional[int], start_id: Optional[str]) -> bool:
+    """Dead-only liveness for lock / reservation owners.
+
+    Returns ``False`` ONLY when the owner is *confirmed* dead: the PID is gone,
+    or the PID is alive but its start time differs from ``start_id`` (PID reuse =
+    a different process now holds that PID). Every uncertainty — no recorded
+    identity, no permission to probe, non-Linux, unreadable ``/proc`` — is
+    treated as ALIVE, so a live (merely slow) owner is never reclaimed. Shared by
+    the keyed-lock and pipeline-reservation dead-owner reclaim layers.
+    """
+    if pid is None:
+        return True  # no owner identity recorded → cannot declare dead
+    if pid == os.getpid():
+        # Our own PID. Genuinely us only if the recorded start id matches ours:
+        # a record carrying our PID but a DIFFERENT start id was written by a
+        # dead predecessor whose PID the OS reused for us — that owner is dead,
+        # so we must NOT treat the lease as "still alive (me)" or it would never
+        # be reclaimed. If either start id is unknown (non-Linux / no /proc), we
+        # cannot confirm reuse and conservatively report alive.
+        mine = _my_start_id()
+        if start_id is not None and mine is not None and start_id != mine:
+            return False
+        return True
+    if not _pid_alive(pid):
+        return False
+    if start_id is not None:
+        current = _read_proc_starttime(pid)
+        if current is not None and current != start_id:
+            return False  # PID reused by a different process
+    return True
+
+
 def _keyed_lease_backoff(attempt: int) -> float:
     """Exponential backoff with jitter for the keyed-lock lease poll.
 
@@ -1616,83 +1712,6 @@ async def initialize_pipeline_status(workspace: str | None = None):
 # its state; see ``_reservation_recovery_enabled``).
 
 
-_MY_START_ID_CACHE: Optional[str] = None
-_MY_START_ID_COMPUTED: bool = False
-
-
-def _read_proc_starttime(pid: int) -> Optional[str]:
-    """Return a stable per-process start token (field 22 of ``/proc/<pid>/stat``)
-    used to detect PID reuse, or ``None`` when unavailable (non-Linux, the
-    process is gone, or the stat file is unreadable).
-
-    A live PID whose start time differs from a previously recorded token is a
-    DIFFERENT process that reused the PID. ``None`` means "cannot tell" — callers
-    must treat that as *not reused* so a live owner is never reclaimed.
-    """
-    if not sys.platform.startswith("linux"):
-        return None
-    try:
-        with open(f"/proc/{pid}/stat", "rb") as fh:
-            data = fh.read()
-    except (FileNotFoundError, ProcessLookupError):
-        return None  # process is gone (liveness is decided by _pid_alive)
-    except OSError:
-        return None  # unreadable → unknown, make no reuse claim
-    try:
-        # comm (field 2) is wrapped in parentheses and may itself contain spaces
-        # or ')' — everything after the LAST ')' is the space-separated tail
-        # starting at field 3 (state). starttime is field 22 → tail index 19.
-        rparen = data.rindex(b")")
-        tail = data[rparen + 1 :].split()
-        return tail[19].decode("ascii")
-    except (ValueError, IndexError):
-        return None
-
-
-def _my_start_id() -> Optional[str]:
-    """This process's start token (see :func:`_read_proc_starttime`), computed
-    once and cached. ``None`` on non-Linux / when ``/proc`` is unavailable, in
-    which case PID-reuse detection is disabled (dead-only reclaim still works via
-    :func:`_pid_alive`)."""
-    global _MY_START_ID_CACHE, _MY_START_ID_COMPUTED
-    if not _MY_START_ID_COMPUTED:
-        _MY_START_ID_CACHE = _read_proc_starttime(os.getpid())
-        _MY_START_ID_COMPUTED = True
-    return _MY_START_ID_CACHE
-
-
-def _process_alive(pid: Optional[int], start_id: Optional[str]) -> bool:
-    """Dead-only liveness for lock / reservation owners.
-
-    Returns ``False`` ONLY when the owner is *confirmed* dead: the PID is gone,
-    or the PID is alive but its start time differs from ``start_id`` (PID reuse =
-    a different process now holds that PID). Every uncertainty — no recorded
-    identity, no permission to probe, non-Linux, unreadable ``/proc`` — is
-    treated as ALIVE, so a live (merely slow) owner is never reclaimed. Shared by
-    the keyed-lock and pipeline-reservation dead-owner reclaim layers.
-    """
-    if pid is None:
-        return True  # no owner identity recorded → cannot declare dead
-    if pid == os.getpid():
-        # Our own PID. Genuinely us only if the recorded start id matches ours:
-        # a record carrying our PID but a DIFFERENT start id was written by a
-        # dead predecessor whose PID the OS reused for us — that owner is dead,
-        # so we must NOT treat the lease as "still alive (me)" or it would never
-        # be reclaimed. If either start id is unknown (non-Linux / no /proc), we
-        # cannot confirm reuse and conservatively report alive.
-        mine = _my_start_id()
-        if start_id is not None and mine is not None and start_id != mine:
-            return False
-        return True
-    if not _pid_alive(pid):
-        return False
-    if start_id is not None:
-        current = _read_proc_starttime(pid)
-        if current is not None and current != start_id:
-            return False  # PID reused by a different process
-    return True
-
-
 # pipeline_status fields that are internal bookkeeping for reservation ownership
 # / dead-process recovery — never surfaced on the /pipeline_status response.
 _INTERNAL_PIPELINE_STATUS_FIELDS = (
@@ -2662,21 +2681,6 @@ def get_global_concurrency_limit(group: Optional[str]) -> Optional[int]:
     if not group or not _global_concurrency_limits:
         return None
     return _global_concurrency_limits.get(group)
-
-
-def _pid_alive(pid: int) -> bool:
-    """Best-effort liveness probe; errs on the side of 'alive'."""
-    if pid == os.getpid():
-        return True
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except OSError:
-        # PermissionError and friends: the process exists (or we cannot
-        # tell) — treat as alive so we never reclaim a live owner's lease.
-        return True
-    return True
 
 
 async def _get_lease_namespace() -> Dict[str, Any]:

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -4313,16 +4313,16 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 # Owner-checked release (+ cancellation reset + completion log),
                 # applied atomically. Runs via with_reservation_lock so it is
                 # cancellation-resistant and cannot clobber a later holder.
+                completion_msg = f"Deletion process completed for document: {doc_id}"
                 status.update(
                     {
                         "busy": False,
                         "busy_owner": None,
                         "operation_record": None,
                         "cancellation_requested": False,
+                        "latest_message": completion_msg,
                     }
                 )
-                completion_msg = f"Deletion process completed for document: {doc_id}"
-                status["latest_message"] = completion_msg
                 status["history_messages"].append(completion_msg)
                 logger.info(completion_msg)
 

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1131,8 +1131,6 @@ class _PipelineMixin:
                             == "internal_error"
                         )
                         label = self._cancellation_label(pipeline_status)
-                        pipeline_status["request_pending"] = False
-                        pipeline_status["cancellation_requested"] = False
 
                         if is_internal:
                             # Unrecoverable storage error: halting is intentional
@@ -1146,10 +1144,16 @@ class _PipelineMixin:
                         else:
                             log_message = f"Pipeline cancelled ({label})"
                             logger.info(log_message)
-                        pipeline_status["latest_message"] = log_message
+                        pipeline_status.update(
+                            {
+                                "request_pending": False,
+                                "cancellation_requested": False,
+                                "cancellation_reason": None,
+                                "cancellation_detail": None,
+                                "latest_message": log_message,
+                            }
+                        )
                         pipeline_status["history_messages"].append(log_message)
-                        pipeline_status["cancellation_reason"] = None
-                        pipeline_status["cancellation_detail"] = None
 
                         # Exit directly, skipping request_pending check
                         return
@@ -1193,10 +1197,14 @@ class _PipelineMixin:
 
                 log_message = f"Processing {len(to_process_docs)} document(s)"
                 logger.info(log_message)
-                pipeline_status["docs"] = len(to_process_docs)
-                pipeline_status["batchs"] = len(to_process_docs)
-                pipeline_status["cur_batch"] = 0
-                pipeline_status["latest_message"] = log_message
+                pipeline_status.update(
+                    {
+                        "docs": len(to_process_docs),
+                        "batchs": len(to_process_docs),
+                        "cur_batch": 0,
+                        "latest_message": log_message,
+                    }
+                )
                 pipeline_status["history_messages"].append(log_message)
 
                 await self._run_pipeline_batch(
@@ -2240,10 +2248,14 @@ class _PipelineMixin:
                 logger.error(f"Unhandled error in process worker; aborting batch: {e}")
                 logger.error(traceback.format_exc())
                 async with ctx.pipeline_status_lock:
-                    ctx.pipeline_status["cancellation_requested"] = True
-                    ctx.pipeline_status["cancellation_reason"] = "internal_error"
-                    ctx.pipeline_status["cancellation_detail"] = (
-                        f"process worker unhandled error: {e}"
+                    ctx.pipeline_status.update(
+                        {
+                            "cancellation_requested": True,
+                            "cancellation_reason": "internal_error",
+                            "cancellation_detail": (
+                                f"process worker unhandled error: {e}"
+                            ),
+                        }
                     )
             finally:
                 ctx.q_process.task_done()
@@ -2310,18 +2322,22 @@ class _PipelineMixin:
                 async with ctx.pipeline_status_lock:
                     ctx.processed_count += 1
                     current_file_number = ctx.processed_count
-                    ctx.pipeline_status["cur_batch"] = ctx.processed_count
 
-                    log_message = (
+                    extraction_message = (
                         f"Extracting stage {current_file_number}/"
                         f"{ctx.total_files}: {file_path}"
                     )
-                    logger.info(log_message)
-                    ctx.pipeline_status["history_messages"].append(log_message)
-                    log_message = f"Processing d-id: {doc_id}"
-                    logger.info(log_message)
-                    ctx.pipeline_status["latest_message"] = log_message
-                    ctx.pipeline_status["history_messages"].append(log_message)
+                    logger.info(extraction_message)
+                    processing_message = f"Processing d-id: {doc_id}"
+                    logger.info(processing_message)
+                    ctx.pipeline_status.update(
+                        {
+                            "cur_batch": ctx.processed_count,
+                            "latest_message": processing_message,
+                        }
+                    )
+                    ctx.pipeline_status["history_messages"].append(extraction_message)
+                    ctx.pipeline_status["history_messages"].append(processing_message)
 
                     # Prevent memory growth: keep only latest 5000 messages
                     # when exceeding 10000.  Trim in place so Manager.list-
@@ -2856,12 +2872,15 @@ class _PipelineMixin:
                     # and root cause so it is distinguishable from a user cancel.
                     if isinstance(e, IndexFlushError):
                         async with ctx.pipeline_status_lock:
-                            ctx.pipeline_status["cancellation_requested"] = True
-                            ctx.pipeline_status["cancellation_reason"] = (
-                                "internal_error"
-                            )
-                            ctx.pipeline_status["cancellation_detail"] = (
-                                f"{e.storage_name}[{e.namespace}]: {e.__cause__}"
+                            ctx.pipeline_status.update(
+                                {
+                                    "cancellation_requested": True,
+                                    "cancellation_reason": "internal_error",
+                                    "cancellation_detail": (
+                                        f"{e.storage_name}[{e.namespace}]: "
+                                        f"{e.__cause__}"
+                                    ),
+                                }
                             )
                         logger.error(
                             f"Aborting pipeline batch due to storage flush error: {e}"


### PR DESCRIPTION
## Description

Improve shared-storage reliability and maintainability by batching logically related `pipeline_status` DictProxy mutations and colocating reusable process-liveness helpers ahead of their first consumer.

## Related Issues

n/a

## Changes Made

- Atomically publish cancellation request, reason, and detail state.
- Batch pipeline batch/progress metadata updates into single Manager RPCs.
- Include completion messages in deletion and clear reservation release updates.
- Keep `history_messages` mutations separate because it remains a Manager list proxy.
- Move process identity and liveness helpers, including `_pid_alive`, into a shared section before `_KeyedLeaseLock`.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

No public API or runtime behavior changes.

Validation:
- Pipeline/API regression selection: 157 passed.
- Keyed-lock, reservation recovery, global concurrency, and queue tests: 75 passed, 1 skipped.
- Ruff check and format check passed for all changed files.
