### PR TITLE
Add Atlas Cloud LLM binding

### DIFF
--- a/env.example
+++ b/env.example
@@ -672,7 +672,7 @@ EMBEDDING_BATCH_NUM=32
 
 ###########################################################################
 ### Gloabal LLM Configuration
-###   LLM_BINDING type: openai, ollama, lollms, azure_openai, bedrock, gemini
+###   LLM_BINDING type: openai, atlascloud, ollama, lollms, azure_openai, bedrock, gemini
 ###   LLM_BINDING_HOST: Service endpoint (left empty if using the provider SDK default endpoint)
 ###   LLM_BINDING_API_KEY: api key
 ### If LightRAG deployed in Docker:
@@ -776,6 +776,14 @@ VLM_MIN_IMAGE_PIXEL=64
 
 ### Role-specific + Provider-sepecific LLM options
 # VLM_OPENAI_LLM_MAX_TOKENS=20000
+
+### Atlas Cloud OpenAI-compatible LLM:
+###     LLM_BINDING=atlascloud
+###     LLM_BINDING_HOST=https://api.atlascloud.ai/v1
+###     ATLASCLOUD_API_KEY=your_api_key
+###     LLM_MODEL=qwen/qwen3.5-flash
+### Atlas Cloud-specific LLM options use the ATLASCLOUD_LLM_* prefix.
+# ATLASCLOUD_LLM_TEMPERATURE=0.9
 
 ### Azure OpenAI Specific Parameters:
 ###     LLM_BINDING=azure_openai

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -10,6 +10,7 @@ from dotenv import load_dotenv
 from lightrag import ROLES
 from lightrag.utils import get_env_value, logger
 from lightrag.llm.binding_options import (
+    AtlasCloudLLMOptions,
     BedrockLLMOptions,
     GeminiEmbeddingOptions,
     GeminiLLMOptions,
@@ -59,6 +60,8 @@ DEFAULT_TOKEN_SECRET = "lightrag-jwt-default-secret-key!"
 NO_PREFIX_SENTINEL = "NO_PREFIX"
 PROVIDER_ASYMMETRIC_EMBEDDING_BINDINGS = {"gemini", "jina", "voyageai"}
 PREFIX_ASYMMETRIC_EMBEDDING_BINDINGS = {"azure_openai", "ollama", "openai"}
+DEFAULT_ATLASCLOUD_HOST = "https://api.atlascloud.ai/v1"
+DEFAULT_ATLASCLOUD_MODEL = "qwen/qwen3.5-flash"
 
 
 class DefaultRAGStorageConfig:
@@ -74,6 +77,7 @@ def get_default_host(binding_type: str) -> str:
         "lollms": os.getenv("LLM_BINDING_HOST", "http://localhost:9600"),
         "azure_openai": os.getenv("AZURE_OPENAI_ENDPOINT", "https://api.openai.com/v1"),
         "openai": os.getenv("LLM_BINDING_HOST", "https://api.openai.com/v1"),
+        "atlascloud": os.getenv("LLM_BINDING_HOST", DEFAULT_ATLASCLOUD_HOST),
         # Let boto3 select the regional Bedrock endpoint unless the user
         # explicitly overrides LLM_BINDING_HOST / EMBEDDING_BINDING_HOST.
         "bedrock": os.getenv("LLM_BINDING_HOST", "DEFAULT_BEDROCK_ENDPOINT"),
@@ -402,6 +406,7 @@ def parse_args() -> argparse.Namespace:
             "lollms",
             "ollama",
             "openai",
+            "atlascloud",
             "openai-ollama",
             "azure_openai",
             "bedrock",
@@ -456,6 +461,8 @@ def parse_args() -> argparse.Namespace:
         OllamaLLMOptions.add_args(parser)
     elif llm_binding_value in ["openai", "azure_openai"]:
         OpenAILLMOptions.add_args(parser)
+    elif llm_binding_value == "atlascloud":
+        AtlasCloudLLMOptions.add_args(parser)
     elif llm_binding_value == "gemini":
         GeminiLLMOptions.add_args(parser)
     elif llm_binding_value == "bedrock":
@@ -521,6 +528,8 @@ def parse_args() -> argparse.Namespace:
         "EMBEDDING_BINDING_HOST", get_default_host(args.embedding_binding)
     )
     args.llm_binding_api_key = get_env_value("LLM_BINDING_API_KEY", None)
+    if args.llm_binding == "atlascloud" and not args.llm_binding_api_key:
+        args.llm_binding_api_key = get_env_value("ATLASCLOUD_API_KEY", None)
     args.embedding_binding_api_key = get_env_value("EMBEDDING_BINDING_API_KEY", "")
 
     args.aws_region = get_env_value("AWS_REGION", None, special_none=True)
@@ -532,6 +541,8 @@ def parse_args() -> argparse.Namespace:
 
     # Inject model configuration
     args.llm_model = get_env_value("LLM_MODEL", "mistral-nemo:latest")
+    if args.llm_binding == "atlascloud" and not os.getenv("LLM_MODEL"):
+        args.llm_model = DEFAULT_ATLASCLOUD_MODEL
     # EMBEDDING_MODEL defaults to None - each binding will use its own default model
     # e.g., OpenAI uses "text-embedding-3-small", Jina uses "jina-embeddings-v4"
     args.embedding_model = get_env_value("EMBEDDING_MODEL", None, special_none=True)
@@ -568,6 +579,8 @@ def parse_args() -> argparse.Namespace:
         role_model = get_env_value(model_key, None, special_none=True)
         role_host = get_env_value(host_key, None, special_none=True)
         role_apikey = get_env_value(apikey_key, None, special_none=True)
+        if role_binding == "atlascloud" and not role_apikey:
+            role_apikey = get_env_value("ATLASCLOUD_API_KEY", None, special_none=True)
         role_max_async = get_env_value(max_async_key, None, int, special_none=True)
         role_timeout = get_env_value(timeout_key, None, int, special_none=True)
         role_aws_region = get_env_value(f"{prefix}_AWS_REGION", None, special_none=True)
@@ -632,7 +645,7 @@ def parse_args() -> argparse.Namespace:
                 f"VLM_PROCESS_ENABLE=true but the effective VLM binding "
                 f"'{effective_vlm_binding}' does not support image inputs. "
                 "Configure VLM_LLM_BINDING (or LLM_BINDING) to one of: "
-                "openai, azure_openai, gemini, bedrock, ollama."
+                "openai, atlascloud, azure_openai, gemini, bedrock, ollama."
             )
 
     # Add environment variables that were previously read directly

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -555,10 +555,15 @@ class LLMConfigCache:
         self.bedrock_llm_options = None
 
         # Only initialize and log OpenAI options when using OpenAI-related bindings
-        if args.llm_binding in ["openai", "azure_openai"]:
-            from lightrag.llm.binding_options import OpenAILLMOptions
+        if args.llm_binding in ["openai", "azure_openai", "atlascloud"]:
+            from lightrag.llm.binding_options import AtlasCloudLLMOptions, OpenAILLMOptions
 
-            self.openai_llm_options = OpenAILLMOptions.options_dict(args)
+            options_cls = (
+                AtlasCloudLLMOptions
+                if args.llm_binding == "atlascloud"
+                else OpenAILLMOptions
+            )
+            self.openai_llm_options = options_cls.options_dict(args)
             logger.info(f"OpenAI LLM Options: {self.openai_llm_options}")
 
         if args.llm_binding == "gemini":
@@ -623,6 +628,7 @@ class LLMConfigCache:
 
 _PROVIDER_LOG_LABELS = {
     "azure_openai": "Azure OpenAI",
+    "atlascloud": "Atlas Cloud",
     "bedrock": "Bedrock",
     "gemini": "Gemini",
     "lollms": "Lollms",
@@ -1230,6 +1236,7 @@ def create_app(args):
         "lollms",
         "ollama",
         "openai",
+        "atlascloud",
         "azure_openai",
         "bedrock",
         "gemini",
@@ -1671,10 +1678,18 @@ def create_app(args):
 
         role_provider_options = override_meta.get("provider_options")
         if role_provider_options is None:
-            if role_binding in ["openai", "azure_openai"]:
-                from lightrag.llm.binding_options import OpenAILLMOptions
+            if role_binding in ["openai", "azure_openai", "atlascloud"]:
+                from lightrag.llm.binding_options import (
+                    AtlasCloudLLMOptions,
+                    OpenAILLMOptions,
+                )
 
-                role_provider_options = OpenAILLMOptions.options_dict_for_role(
+                options_cls = (
+                    AtlasCloudLLMOptions
+                    if role_binding == "atlascloud"
+                    else OpenAILLMOptions
+                )
+                role_provider_options = options_cls.options_dict_for_role(
                     args, role, is_cross_provider
                 )
             elif role_binding == "gemini":

--- a/lightrag/llm/binding_options.py
+++ b/lightrag/llm/binding_options.py
@@ -630,6 +630,13 @@ class OpenAILLMOptions(BindingOptions):
     }
 
 
+@dataclass
+class AtlasCloudLLMOptions(OpenAILLMOptions):
+    """Options for Atlas Cloud's OpenAI-compatible LLM API."""
+
+    _binding_name: ClassVar[str] = "atlascloud_llm"
+
+
 # =============================================================================
 # Binding Options for AWS Bedrock
 # =============================================================================

--- a/tests/api/config/test_api_config_atlascloud.py
+++ b/tests/api/config/test_api_config_atlascloud.py
@@ -1,0 +1,101 @@
+"""Offline tests for the Atlas Cloud LLM binding."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from lightrag.api.config import (
+    DEFAULT_ATLASCLOUD_HOST,
+    DEFAULT_ATLASCLOUD_MODEL,
+    parse_args,
+)
+
+
+pytestmark = pytest.mark.offline
+
+
+def _reset_atlascloud_env(monkeypatch):
+    for key in (
+        "LLM_BINDING",
+        "LLM_BINDING_HOST",
+        "LLM_BINDING_API_KEY",
+        "LLM_MODEL",
+        "ATLASCLOUD_API_KEY",
+        "VLM_PROCESS_ENABLE",
+        "VLM_LLM_BINDING",
+        "VLM_LLM_MODEL",
+        "VLM_LLM_BINDING_HOST",
+        "VLM_LLM_BINDING_API_KEY",
+        "VLM_LLM_TIMEOUT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_atlascloud_binding_uses_atlas_defaults(monkeypatch):
+    _reset_atlascloud_env(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+    monkeypatch.setenv("LLM_BINDING", "atlascloud")
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "atlas-secret")
+
+    args = parse_args()
+
+    assert args.llm_binding == "atlascloud"
+    assert args.llm_binding_host == DEFAULT_ATLASCLOUD_HOST
+    assert args.llm_binding_api_key == "atlas-secret"
+    assert args.llm_model == DEFAULT_ATLASCLOUD_MODEL
+
+
+def test_atlascloud_binding_respects_explicit_openai_compatible_settings(monkeypatch):
+    _reset_atlascloud_env(monkeypatch)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "lightrag-server",
+            "--llm-binding",
+            "atlascloud",
+            "--atlascloud-llm-temperature",
+            "0.2",
+        ],
+    )
+    monkeypatch.setenv("LLM_BINDING_HOST", "https://proxy.example/v1")
+    monkeypatch.setenv("LLM_BINDING_API_KEY", "binding-secret")
+    monkeypatch.setenv("LLM_MODEL", "deepseek-ai/deepseek-v4-pro")
+
+    args = parse_args()
+
+    assert args.llm_binding == "atlascloud"
+    assert args.llm_binding_host == "https://proxy.example/v1"
+    assert args.llm_binding_api_key == "binding-secret"
+    assert args.llm_model == "deepseek-ai/deepseek-v4-pro"
+    assert args.atlascloud_llm_temperature == 0.2
+
+
+def test_vlm_process_enable_true_with_atlascloud_passes(monkeypatch):
+    _reset_atlascloud_env(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+    monkeypatch.setenv("LLM_BINDING", "atlascloud")
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "atlas-secret")
+    monkeypatch.setenv("VLM_PROCESS_ENABLE", "true")
+
+    args = parse_args()
+
+    assert args.vlm_process_enable is True
+    assert args.llm_binding == "atlascloud"
+
+
+def test_cross_provider_role_can_use_atlascloud_api_key_fallback(monkeypatch):
+    _reset_atlascloud_env(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+    monkeypatch.setenv("LLM_BINDING", "openai")
+    monkeypatch.setenv("QUERY_LLM_BINDING", "atlascloud")
+    monkeypatch.setenv("QUERY_LLM_MODEL", DEFAULT_ATLASCLOUD_MODEL)
+    monkeypatch.setenv("QUERY_LLM_BINDING_HOST", DEFAULT_ATLASCLOUD_HOST)
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "atlas-secret")
+
+    args = parse_args()
+
+    assert args.query_llm_binding == "atlascloud"
+    assert args.query_llm_binding_api_key == "atlas-secret"


### PR DESCRIPTION
## Summary
- add an Atlas Cloud LLM binding that reuses LightRAG's existing OpenAI-compatible chat path
- default Atlas Cloud to https://api.atlascloud.ai/v1, ATLASCLOUD_API_KEY, and qwen/qwen3.5-flash when no LLM_MODEL is set
- add Atlas Cloud-specific provider options and focused config tests

## Validation
- /Users/zby/.local/bin/python3.11 -m py_compile lightrag/api/config.py lightrag/api/lightrag_server.py lightrag/llm/binding_options.py tests/api/config/test_api_config_atlascloud.py
- UV_PROJECT_ENVIRONMENT=.venv311 /Users/zby/.local/bin/uv run --python /Users/zby/.local/bin/python3.11 --with pytest pytest tests/api/config/test_api_config_atlascloud.py -q
- UV_PROJECT_ENVIRONMENT=.venv311 /Users/zby/.local/bin/uv run --python /Users/zby/.local/bin/python3.11 --with ruff ruff check lightrag/api/config.py lightrag/api/lightrag_server.py lightrag/llm/binding_options.py tests/api/config/test_api_config_atlascloud.py
- git diff --check
- Atlas Cloud live model catalog returned 118 models and confirmed qwen/qwen3.5-flash and deepseek-ai/deepseek-v4-pro

No README changes; env.example only documents the technical binding configuration.