### PR TITLE
fix(rerank): raise ValueError for max_tokens < 1

### DIFF
--- a/env.example
+++ b/env.example
@@ -185,6 +185,8 @@ RERANK_BINDING=null
 # # RERANK_BINDING_HOST=https://api.cohere.com/v2/rerank
 # # RERANK_BINDING_API_KEY=your_rerank_api_key_here
 ### Cohere rerank chunking configuration (useful for models with token limits like ColBERT)
+### RERANK_MAX_TOKENS_PER_DOC must be an integer >= 1; the server refuses to start otherwise.
+### Defaults to 4096 (Cohere rerank-v3.5) when unset; 480 shown below suits 512-token models.
 # RERANK_ENABLE_CHUNKING=true
 # RERANK_MAX_TOKENS_PER_DOC=480
 

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -1964,7 +1964,13 @@ def create_app(args):
     # Configure rerank function based on args.rerank_bindingparameter
     rerank_model_func = None
     if args.rerank_binding != "null":
-        from lightrag.rerank import cohere_rerank, jina_rerank, ali_rerank
+        from lightrag.rerank import (
+            cohere_rerank,
+            jina_rerank,
+            ali_rerank,
+            DEFAULT_RERANK_MAX_TOKENS_PER_DOC,
+            MIN_PRACTICAL_RERANK_MAX_TOKENS,
+        )
 
         # Map rerank binding to corresponding function
         rerank_functions = {
@@ -1995,6 +2001,39 @@ def create_app(args):
                 if default_base_url != inspect.Parameter.empty:
                     args.rerank_binding_host = default_base_url
 
+        # Cohere binding supports optional document chunking (useful for models with
+        # token limits like ColBERT). Parse and validate its config ONCE at startup so a
+        # misconfigured RERANK_MAX_TOKENS_PER_DOC fails fast here instead of surfacing on
+        # the first user query, and so the value is not re-parsed on every rerank call.
+        rerank_enable_chunking = False
+        rerank_max_tokens_per_doc = DEFAULT_RERANK_MAX_TOKENS_PER_DOC
+        if args.rerank_binding == "cohere":
+            rerank_enable_chunking = (
+                os.getenv("RERANK_ENABLE_CHUNKING", "false").lower() == "true"
+            )
+            raw_max_tokens = os.getenv(
+                "RERANK_MAX_TOKENS_PER_DOC", str(DEFAULT_RERANK_MAX_TOKENS_PER_DOC)
+            )
+            try:
+                rerank_max_tokens_per_doc = int(raw_max_tokens)
+            except ValueError as e:
+                raise ValueError(
+                    f"RERANK_MAX_TOKENS_PER_DOC must be an integer, got {raw_max_tokens!r}"
+                ) from e
+            if rerank_max_tokens_per_doc < 1:
+                raise ValueError(
+                    f"RERANK_MAX_TOKENS_PER_DOC must be >= 1, got {rerank_max_tokens_per_doc}"
+                )
+            if (
+                rerank_enable_chunking
+                and rerank_max_tokens_per_doc < MIN_PRACTICAL_RERANK_MAX_TOKENS
+            ):
+                logger.warning(
+                    f"RERANK_MAX_TOKENS_PER_DOC={rerank_max_tokens_per_doc} is below the "
+                    f"practical minimum ({MIN_PRACTICAL_RERANK_MAX_TOKENS}); chunking will "
+                    f"split each document into many tiny, low-signal chunks."
+                )
+
         async def server_rerank_func(
             query: str, documents: list, top_n: int = None, extra_body: dict = None
         ):
@@ -2009,15 +2048,10 @@ def create_app(args):
                 "base_url": args.rerank_binding_host,
             }
 
-            # Add Cohere-specific parameters if using cohere binding
+            # Add Cohere-specific parameters if using cohere binding (validated at startup)
             if args.rerank_binding == "cohere":
-                # Enable chunking if configured (useful for models with token limits like ColBERT)
-                kwargs["enable_chunking"] = (
-                    os.getenv("RERANK_ENABLE_CHUNKING", "false").lower() == "true"
-                )
-                kwargs["max_tokens_per_doc"] = int(
-                    os.getenv("RERANK_MAX_TOKENS_PER_DOC", "4096")
-                )
+                kwargs["enable_chunking"] = rerank_enable_chunking
+                kwargs["max_tokens_per_doc"] = rerank_max_tokens_per_doc
 
             return await selected_rerank_func(**kwargs, extra_body=extra_body)
 

--- a/lightrag/rerank.py
+++ b/lightrag/rerank.py
@@ -39,6 +39,10 @@ def chunk_documents_for_rerank(
         - chunked_documents: List of document chunks (may be more than input)
         - original_doc_indices: Maps each chunk back to its original document index
     """
+    if max_tokens < 1:
+        # max_tokens=0 makes the chunk window zero-width and the loop never advances
+        raise ValueError(f"max_tokens must be >= 1, got {max_tokens}")
+
     # Clamp overlap_tokens to ensure the loop always advances
     # If overlap_tokens >= max_tokens, the chunking loop would hang
     if overlap_tokens >= max_tokens:

--- a/lightrag/rerank.py
+++ b/lightrag/rerank.py
@@ -18,6 +18,18 @@ from dotenv import load_dotenv
 # the OS environment variables take precedence over the .env file
 load_dotenv(dotenv_path=".env", override=False)
 
+# Default per-document token budget when chunking for rerank.
+# 4096 matches Cohere rerank-v3.5; smaller models (e.g. ColBERT, 512-token limit)
+# should override this to leave margin below their hard limit.
+DEFAULT_RERANK_MAX_TOKENS_PER_DOC = 4096
+
+# Practical lower bound for a rerank chunk window. Below this the loop still
+# terminates (guaranteed by the max_tokens >= 1 guard and the overlap clamp), but
+# every document explodes into many tiny, low-signal chunks — inflating the request
+# payload and the number of scores to aggregate. Configured values below this are
+# accepted but warned about at startup rather than silently degrading query latency.
+MIN_PRACTICAL_RERANK_MAX_TOKENS = 64
+
 
 def chunk_documents_for_rerank(
     documents: List[str],
@@ -43,13 +55,14 @@ def chunk_documents_for_rerank(
         # max_tokens=0 makes the chunk window zero-width and the loop never advances
         raise ValueError(f"max_tokens must be >= 1, got {max_tokens}")
 
-    # Clamp overlap_tokens to ensure the loop always advances
-    # If overlap_tokens >= max_tokens, the chunking loop would hang
+    # Clamp overlap_tokens to ensure the loop always advances.
+    # If overlap_tokens >= max_tokens the loop would never progress. Recover by
+    # clamping to max_tokens // 2 rather than max_tokens - 1: the latter leaves an
+    # advance of a single token per step, exploding a document into O(tokens) chunks.
+    # Halving keeps the advance at ~half the window (0 overlap when max_tokens == 1).
     if overlap_tokens >= max_tokens:
         original_overlap = overlap_tokens
-        # Ensure overlap is at least 1 token less than max to guarantee progress
-        # For very small max_tokens (e.g., 1), set overlap to 0
-        overlap_tokens = max(0, max_tokens - 1)
+        overlap_tokens = max_tokens // 2
         logger.warning(
             f"overlap_tokens ({original_overlap}) must be less than max_tokens ({max_tokens}). "
             f"Clamping to {overlap_tokens} to prevent infinite loop."

--- a/tests/chunker/test_rerank_chunking.py
+++ b/tests/chunker/test_rerank_chunking.py
@@ -17,6 +17,17 @@ from lightrag.rerank import (
 class TestChunkDocumentsForRerank:
     """Test suite for chunk_documents_for_rerank function"""
 
+    def test_zero_max_tokens_raises(self):
+        """max_tokens < 1 must raise, not hang in a zero-width chunk loop."""
+        with pytest.raises(ValueError, match="max_tokens"):
+            chunk_documents_for_rerank(["hello world longer text"], max_tokens=0)
+        with pytest.raises(ValueError, match="max_tokens"):
+            chunk_documents_for_rerank(["hello"], max_tokens=-1)
+        # Valid size still works
+        docs, idxs = chunk_documents_for_rerank(["short"], max_tokens=100)
+        assert docs == ["short"]
+        assert idxs == [0]
+
     def test_no_chunking_needed_for_short_docs(self):
         """Documents shorter than max_tokens should not be chunked"""
         documents = [

--- a/tests/chunker/test_rerank_chunking.py
+++ b/tests/chunker/test_rerank_chunking.py
@@ -28,6 +28,20 @@ class TestChunkDocumentsForRerank:
         assert docs == ["short"]
         assert idxs == [0]
 
+    def test_max_tokens_one_terminates(self):
+        """max_tokens=1 is the boundary: overlap must clamp so the loop still terminates.
+
+        With the default overlap (32 >= 1) the clamp kicks in; the call must return a
+        bounded set of chunks all mapping back to the single input document rather than
+        hanging (this test would time out if the loop failed to advance).
+        """
+        docs, idxs = chunk_documents_for_rerank(
+            ["one two three four five"], max_tokens=1, overlap_tokens=32
+        )
+        assert len(docs) >= 1
+        assert len(docs) == len(idxs)
+        assert all(i == 0 for i in idxs)
+
     def test_no_chunking_needed_for_short_docs(self):
         """Documents shorter than max_tokens should not be chunked"""
         documents = [


### PR DESCRIPTION
chunk_documents_for_rerank clamps overlap when overlap >= max_tokens, but max_tokens=0 still leaves a zero-width window and the chunk loop never advances. Raise ValueError when max_tokens < 1.