### PR TITLE
fix(utils): return 0.0 for cosine_similarity on zero vectors

### DIFF
--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -2914,7 +2914,11 @@ def cosine_similarity(v1, v2):
     dot_product = np.dot(v1, v2)
     norm1 = np.linalg.norm(v1)
     norm2 = np.linalg.norm(v2)
-    return dot_product / (norm1 * norm2)
+    denom = norm1 * norm2
+    # Zero vectors are orthogonal to everything in ranking use; avoid NaN.
+    if denom == 0:
+        return 0.0
+    return float(dot_product / denom)
 
 
 async def handle_cache(

--- a/tests/test_cosine_similarity.py
+++ b/tests/test_cosine_similarity.py
@@ -1,0 +1,31 @@
+"""Regression tests for :func:`lightrag.utils.cosine_similarity`."""
+
+import numpy as np
+import pytest
+
+from lightrag.utils import cosine_similarity
+
+pytestmark = pytest.mark.offline
+
+
+def test_zero_vectors_return_zero_not_nan():
+    score = cosine_similarity(np.zeros(3), np.zeros(3))
+    assert score == 0.0
+    assert not np.isnan(score)
+
+
+def test_zero_against_nonzero_returns_zero():
+    score = cosine_similarity(np.zeros(2), np.array([1.0, 0.0]))
+    assert score == 0.0
+    assert not np.isnan(score)
+
+
+def test_identical_unit_vectors_return_one():
+    v = np.array([1.0, 0.0, 0.0])
+    assert cosine_similarity(v, v) == pytest.approx(1.0)
+
+
+def test_orthogonal_unit_vectors_return_zero():
+    assert cosine_similarity(
+        np.array([1.0, 0.0]), np.array([0.0, 1.0])
+    ) == pytest.approx(0.0)


### PR DESCRIPTION
cosine_similarity divides by the product of norms, so a zero vector yields NaN. Return 0.0 when the denominator is zero.