### PR TITLE
fix(auth): constant-time plaintext password comparison (GHSA-c759-cx9p-mrwq)

### DIFF
--- a/lightrag/api/auth.py
+++ b/lightrag/api/auth.py
@@ -7,12 +7,26 @@ from pydantic import BaseModel
 
 from ..utils import logger
 from .config import DEFAULT_TOKEN_SECRET, global_args
-from .passwords import verify_password
+from .passwords import BCRYPT_PASSWORD_PREFIX, verify_password
 
 # use the .env that is inside the current folder
 # allows to use different .env file for each lightrag instance
 # the OS environment variables take precedence over the .env file
 load_dotenv(dotenv_path=".env", override=False)
+
+# A syntactically valid bcrypt spec used only to equalize the timing of the
+# "unknown username" path (see AuthHandler.verify_password). It is a bcrypt
+# hash of a throwaway value that never matches any real password, and it is not
+# a secret. Running a full verification against it when the username is unknown
+# keeps the response time close to the known-user bcrypt path, so an attacker
+# cannot enumerate valid usernames from the ~100 ms bcrypt delay (CWE-208).
+# Note: this equalizes against the bcrypt cost. Deployments that store only
+# plaintext passwords still respond faster for known accounts; the robust fix
+# for such deployments is to switch to {bcrypt} values (see GHSA-c759-cx9p-mrwq).
+_DUMMY_VERIFY_SPEC = (
+    BCRYPT_PASSWORD_PREFIX
+    + "$2b$12$ilI0sY2jGfy4h0AVtn6WuutU6BFwzZq5MVvrQYY9fbyQ59NI2NBKa"
+)
 
 
 class TokenPayload(BaseModel):
@@ -74,10 +88,15 @@ class AuthHandler:
         Returns:
             bool: True if password is correct, False otherwise
         """
-        if username not in self.accounts:
+        stored_password = self.accounts.get(username)
+        if stored_password is None:
+            # Unknown username: still run a full verification against a dummy
+            # spec so the response time matches the known-user path, then fail.
+            # This prevents username enumeration via the bcrypt timing delta
+            # (CWE-208). The dummy never matches, so the result is always False.
+            verify_password(plain_password, _DUMMY_VERIFY_SPEC)
             return False
 
-        stored_password = self.accounts[username]
         return verify_password(plain_password, stored_password)
 
     def create_token(

--- a/lightrag/api/auth.py
+++ b/lightrag/api/auth.py
@@ -14,15 +14,18 @@ from .passwords import BCRYPT_PASSWORD_PREFIX, verify_password
 # the OS environment variables take precedence over the .env file
 load_dotenv(dotenv_path=".env", override=False)
 
-# A syntactically valid bcrypt spec used only to equalize the timing of the
-# "unknown username" path (see AuthHandler.verify_password). It is a bcrypt
-# hash of a throwaway value that never matches any real password, and it is not
-# a secret. Running a full verification against it when the username is unknown
-# keeps the response time close to the known-user bcrypt path, so an attacker
-# cannot enumerate valid usernames from the ~100 ms bcrypt delay (CWE-208).
-# Note: this equalizes against the bcrypt cost. Deployments that store only
-# plaintext passwords still respond faster for known accounts; the robust fix
-# for such deployments is to switch to {bcrypt} values (see GHSA-c759-cx9p-mrwq).
+# A syntactically valid bcrypt spec used only to equalize login timing (see
+# AuthHandler.verify_password). It is a bcrypt hash of a throwaway value that
+# never matches any real password, and it is not a secret. Every login path
+# runs exactly one bcrypt verification (a real one for {bcrypt} accounts, this
+# dummy for unknown usernames and for plaintext accounts) so response time does
+# not reveal whether an account exists or whether it is stored as plaintext
+# (username enumeration via the ~100 ms bcrypt delay, CWE-208).
+#
+# The cost factor is 12, matching hash_password()/bcrypt.gensalt() defaults.
+# Accounts stored with a hand-chosen, different bcrypt cost will still differ
+# somewhat; fully closing that gap requires enforcing a uniform cost (or
+# dropping plaintext support altogether). See GHSA-c759-cx9p-mrwq.
 _DUMMY_VERIFY_SPEC = (
     BCRYPT_PASSWORD_PREFIX
     + "$2b$12$ilI0sY2jGfy4h0AVtn6WuutU6BFwzZq5MVvrQYY9fbyQ59NI2NBKa"
@@ -88,15 +91,25 @@ class AuthHandler:
         Returns:
             bool: True if password is correct, False otherwise
         """
+        # Every branch performs exactly one bcrypt verification so response time
+        # cannot be used to enumerate usernames or distinguish plaintext from
+        # bcrypt accounts (CWE-208). See _DUMMY_VERIFY_SPEC.
         stored_password = self.accounts.get(username)
+
         if stored_password is None:
-            # Unknown username: still run a full verification against a dummy
-            # spec so the response time matches the known-user path, then fail.
-            # This prevents username enumeration via the bcrypt timing delta
-            # (CWE-208). The dummy never matches, so the result is always False.
+            # Unknown username: run the dummy bcrypt, then fail.
             verify_password(plain_password, _DUMMY_VERIFY_SPEC)
             return False
 
+        if not stored_password.startswith(BCRYPT_PASSWORD_PREFIX):
+            # Known plaintext account: the constant-time plaintext compare is
+            # only microseconds, so add one dummy bcrypt to match the cost of an
+            # unknown username and a {bcrypt} account. Keep the real result.
+            password_matches = verify_password(plain_password, stored_password)
+            verify_password(plain_password, _DUMMY_VERIFY_SPEC)
+            return password_matches
+
+        # Known {bcrypt} account: the real verification already costs one bcrypt.
         return verify_password(plain_password, stored_password)
 
     def create_token(

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -9,6 +9,7 @@ from fastapi.openapi.docs import (
     get_swagger_ui_html,
     get_swagger_ui_oauth2_redirect_html,
 )
+import asyncio
 import json
 import os
 import re
@@ -2278,7 +2279,14 @@ def create_app(args):
                 "webui_description": webui_description,
             }
         username = form_data.username
-        if not auth_handler.verify_password(username, form_data.password):
+        # verify_password runs a CPU-bound bcrypt for every attempt (including
+        # unknown usernames, to equalize timing). Run it in a worker thread so a
+        # flood of login requests cannot block the event loop and starve the
+        # whole API (unauthenticated DoS). Login rate limiting is still advisable.
+        password_ok = await asyncio.to_thread(
+            auth_handler.verify_password, username, form_data.password
+        )
+        if not password_ok:
             raise HTTPException(status_code=401, detail="Incorrect credentials")
 
         # Regular user login

--- a/lightrag/api/passwords.py
+++ b/lightrag/api/passwords.py
@@ -1,3 +1,5 @@
+import hmac
+
 import bcrypt
 
 BCRYPT_PASSWORD_PREFIX = "{bcrypt}"
@@ -23,4 +25,10 @@ def verify_password(plain_password: str, stored_password: str) -> bool:
         except ValueError:
             return False
 
-    return stored_password == plain_password
+    # Constant-time comparison for plaintext specs. A plain ``==`` short-circuits
+    # on the first mismatched byte, leaking password length and content through
+    # response timing (CWE-208, GHSA-c759-cx9p-mrwq). compare_digest runs in time
+    # independent of where the first difference occurs.
+    return hmac.compare_digest(
+        stored_password.encode("utf-8"), plain_password.encode("utf-8")
+    )

--- a/tests/api/auth/test_auth.py
+++ b/tests/api/auth/test_auth.py
@@ -72,6 +72,55 @@ def test_plaintext_password_with_bcrypt_prefix_stays_plaintext(auth_module):
     assert not handler.verify_password("user", "anything-else")
 
 
+def test_plaintext_verify_uses_constant_time_comparison():
+    """Plaintext specs must be compared with hmac.compare_digest rather than a
+    short-circuiting ``==`` that leaks length/content via timing (CWE-208,
+    GHSA-c759-cx9p-mrwq). Behavior across lengths and unicode is the regression
+    anchor for the constant-time path.
+    """
+    from lightrag.api.passwords import verify_password as verify
+
+    assert verify("secret", "secret")
+    assert not verify("secret", "secre")  # shorter guess
+    assert not verify("secret", "secretx")  # longer guess
+    assert verify("pässwörd-пароль", "pässwörd-пароль")  # unicode via utf-8
+    assert not verify("pässwörd-пароль", "wrong")
+
+
+def test_verify_password_unknown_user_runs_dummy_verification(auth_module, monkeypatch):
+    """Unknown usernames must still trigger a password verification so response
+    time does not reveal whether the account exists (username enumeration via
+    the bcrypt timing delta, CWE-208). The old code returned early without
+    comparing anything.
+    """
+    handler = auth_module.AuthHandler()
+    handler.accounts = {"admin": "admin_pass"}
+
+    calls = []
+    real_verify = auth_module.verify_password
+
+    def spy(plain, stored):
+        calls.append((plain, stored))
+        return real_verify(plain, stored)
+
+    monkeypatch.setattr(auth_module, "verify_password", spy)
+
+    assert handler.verify_password("does-not-exist", "whatever") is False
+    # Verification ran against the dummy spec instead of being skipped.
+    assert calls == [("whatever", auth_module._DUMMY_VERIFY_SPEC)]
+
+
+def test_verify_password_unicode_plaintext(auth_module):
+    """Non-ASCII plaintext passwords still verify through the utf-8 encoded
+    constant-time comparison path.
+    """
+    handler = auth_module.AuthHandler()
+    handler.accounts = {"admin": "pässw0rd-пароль"}
+
+    assert handler.verify_password("admin", "pässw0rd-пароль")
+    assert not handler.verify_password("admin", "pässw0rd-wrong")
+
+
 def test_invalid_auth_accounts_raises(monkeypatch):
     config = import_real_api_module("lightrag.api.config")
 

--- a/tests/api/auth/test_auth.py
+++ b/tests/api/auth/test_auth.py
@@ -110,6 +110,58 @@ def test_verify_password_unknown_user_runs_dummy_verification(auth_module, monke
     assert calls == [("whatever", auth_module._DUMMY_VERIFY_SPEC)]
 
 
+def test_known_plaintext_user_also_runs_dummy_bcrypt(auth_module, monkeypatch):
+    """A known plaintext account must run the dummy bcrypt in addition to the
+    microsecond-scale plaintext compare, so its timing matches the unknown-user
+    and {bcrypt} paths. Otherwise a fast response would reveal that a username
+    exists and is stored as plaintext (username enumeration, CWE-208). The real
+    comparison result must still be returned.
+    """
+    handler = auth_module.AuthHandler()
+    handler.accounts = {"alice": "password123"}
+
+    specs = []
+    real_verify = auth_module.verify_password
+
+    def spy(plain, stored):
+        specs.append(stored)
+        return real_verify(plain, stored)
+
+    monkeypatch.setattr(auth_module, "verify_password", spy)
+
+    # Correct password -> True; both the real compare and the dummy bcrypt ran.
+    assert handler.verify_password("alice", "password123") is True
+    assert specs == ["password123", auth_module._DUMMY_VERIFY_SPEC]
+
+    # Wrong password -> False, with the same two-step timing profile.
+    specs.clear()
+    assert handler.verify_password("alice", "nope") is False
+    assert specs == ["password123", auth_module._DUMMY_VERIFY_SPEC]
+
+
+def test_known_bcrypt_user_runs_single_verification(auth_module, monkeypatch):
+    """A known {bcrypt} account already costs one bcrypt; it must NOT run an
+    extra dummy bcrypt, which would make it slower than the other paths and
+    reintroduce a timing signal.
+    """
+    handler = auth_module.AuthHandler()
+    bcrypt_spec = build_bcrypt_value("user_pass")
+    handler.accounts = {"user": bcrypt_spec}
+
+    specs = []
+    real_verify = auth_module.verify_password
+
+    def spy(plain, stored):
+        specs.append(stored)
+        return real_verify(plain, stored)
+
+    monkeypatch.setattr(auth_module, "verify_password", spy)
+
+    assert handler.verify_password("user", "user_pass") is True
+    # Exactly one verification (the real bcrypt), no dummy appended.
+    assert specs == [bcrypt_spec]
+
+
 def test_verify_password_unicode_plaintext(auth_module):
     """Non-ASCII plaintext passwords still verify through the utf-8 encoded
     constant-time comparison path.

--- a/tests/api/routes/test_login_route.py
+++ b/tests/api/routes/test_login_route.py
@@ -1,0 +1,182 @@
+"""Tests for the POST /login endpoint.
+
+Focus: the endpoint runs the CPU-bound bcrypt verification off the event loop.
+
+verify_password now performs one bcrypt for *every* attempt (including unknown
+usernames, to equalize timing — GHSA-c759-cx9p-mrwq). Because /login is
+``async def``, running that bcrypt inline would block the event loop for
+~100 ms per request, so a flood of unauthenticated login attempts with random
+usernames could starve the whole API (DoS). The route must therefore offload
+verification with ``asyncio.to_thread`` and still return the correct result.
+"""
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import APIRouter
+from fastapi.testclient import TestClient
+
+_ENV_VARS_TO_ISOLATE = (
+    "LLM_BINDING",
+    "EMBEDDING_BINDING",
+    "AUTH_ACCOUNTS",
+    "TOKEN_SECRET",
+    "LIGHTRAG_API_KEY",
+    "WHITELIST_PATHS",
+    "LIGHTRAG_API_PREFIX",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    """Keep tests hermetic from developer-local .env and global config state."""
+    for var in _ENV_VARS_TO_ISOLATE:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("AUTH_ACCOUNTS", "")
+    monkeypatch.setenv("LIGHTRAG_API_KEY", "")
+    monkeypatch.setenv("TOKEN_SECRET", "")
+    monkeypatch.setenv("WHITELIST_PATHS", "/health,/api/*")
+    monkeypatch.setenv("LLM_BINDING", "ollama")
+    monkeypatch.setenv("EMBEDDING_BINDING", "ollama")
+
+    import lightrag.api.config as config
+
+    config._global_args = None
+    config._initialized = False
+    yield
+    config._global_args = None
+    config._initialized = False
+
+
+class _FakeLightRAG:
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    def register_role_llm_builder(self, _builder):
+        return None
+
+    def set_role_llm_metadata(self, _role, **_metadata):
+        return None
+
+    def get_llm_role_config(self):
+        return {}
+
+    async def get_llm_queue_status(self, include_base=True):
+        return {}
+
+    async def get_embedding_queue_status(self):
+        return {}
+
+    async def get_rerank_queue_status(self):
+        return {}
+
+
+class _FakeOllamaAPI:
+    def __init__(self, *_args, **_kwargs):
+        self.router = APIRouter()
+
+
+def _build_server(monkeypatch):
+    """Build the full app via create_app with all backend I/O mocked out.
+
+    Returns the lightrag_server module so callers can reach auth_handler.
+    """
+    from lightrag.api.config import parse_args, initialize_config
+
+    original_argv = sys.argv.copy()
+    try:
+        sys.argv = ["lightrag-server"]
+        args = parse_args()
+    finally:
+        sys.argv = original_argv
+    initialize_config(args, force=True)
+
+    import lightrag.api.lightrag_server as lightrag_server
+
+    monkeypatch.setattr(lightrag_server, "LightRAG", _FakeLightRAG)
+    monkeypatch.setattr(lightrag_server, "check_frontend_build", lambda: (True, False))
+    for factory in (
+        "create_document_routes",
+        "create_query_routes",
+        "create_graph_routes",
+    ):
+        monkeypatch.setattr(lightrag_server, factory, lambda *_a, **_k: APIRouter())
+    monkeypatch.setattr(lightrag_server, "OllamaAPI", _FakeOllamaAPI)
+    monkeypatch.setattr(
+        lightrag_server, "get_namespace_data", AsyncMock(return_value={"busy": False})
+    )
+    monkeypatch.setattr(lightrag_server, "get_default_workspace", lambda: "default")
+    monkeypatch.setattr(
+        lightrag_server,
+        "cleanup_keyed_lock",
+        lambda: {"cleanup_performed": {}, "current_status": {}},
+    )
+
+    app = lightrag_server.create_app(args)
+    return lightrag_server, app
+
+
+def _client_with_account(monkeypatch, username="admin", password="s3cret-plain"):
+    """Build a client whose auth_handler has a single configured account."""
+    lightrag_server, app = _build_server(monkeypatch)
+    monkeypatch.setattr(lightrag_server.auth_handler, "accounts", {username: password})
+    return lightrag_server, TestClient(app)
+
+
+def test_login_correct_password_returns_token(monkeypatch):
+    _server, client = _client_with_account(monkeypatch)
+
+    resp = client.post("/login", data={"username": "admin", "password": "s3cret-plain"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["access_token"]
+    assert body["auth_mode"] == "enabled"
+
+
+def test_login_wrong_password_is_401(monkeypatch):
+    """A wrong password must be rejected. This also guards the ``await``: if the
+    to_thread call were not awaited, ``password_ok`` would be a truthy coroutine
+    and the wrong password would be accepted.
+    """
+    _server, client = _client_with_account(monkeypatch)
+
+    resp = client.post("/login", data={"username": "admin", "password": "wrong"})
+
+    assert resp.status_code == 401
+
+
+def test_login_unknown_username_is_401(monkeypatch):
+    _server, client = _client_with_account(monkeypatch)
+
+    resp = client.post("/login", data={"username": "ghost", "password": "whatever"})
+
+    assert resp.status_code == 401
+
+
+def test_login_offloads_verification_to_thread(monkeypatch):
+    """The bcrypt verification must run via asyncio.to_thread so it does not
+    block the event loop (unauthenticated DoS surface, since every attempt now
+    costs one bcrypt).
+    """
+    lightrag_server, _app = _build_server(monkeypatch)
+    monkeypatch.setattr(
+        lightrag_server.auth_handler, "accounts", {"admin": "s3cret-plain"}
+    )
+
+    offloaded = []
+    real_to_thread = asyncio.to_thread
+
+    async def spy(func, *args, **kwargs):
+        offloaded.append(getattr(func, "__name__", func))
+        return await real_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(lightrag_server.asyncio, "to_thread", spy)
+
+    client = TestClient(_app)
+    resp = client.post("/login", data={"username": "admin", "password": "s3cret-plain"})
+
+    assert resp.status_code == 200
+    assert "verify_password" in offloaded


### PR DESCRIPTION
## Background

Security advisory [GHSA-c759-cx9p-mrwq](https://github.com/HKUDS/LightRAG/security/advisories/GHSA-c759-cx9p-mrwq) (CWE-208, Observable Timing Discrepancy) reports that when `AUTH_ACCOUNTS` stores a **plaintext** password, `verify_password` compares it with Python's `==`, which short-circuits on the first mismatched byte and leaks length/content through response timing. The `{bcrypt}` path was already constant-time via `bcrypt.checkpw`.

## Changes

**1. Constant-time plaintext comparison (the advisory's issue)** — `lightrag/api/passwords.py`

Replace `==` with `hmac.compare_digest`, comparing utf-8 encoded bytes so non-ASCII passwords keep working.

**2. Equalize login timing across all paths (related CWE-208, username enumeration)** — `lightrag/api/auth.py`

`AuthHandler.verify_password` previously returned early for an unknown username **without comparing anything**, so a known `{bcrypt}` account (~100 ms) was distinguishable from an unknown one (instant). Every path now performs **exactly one bcrypt verification**:

| Input | Work done | Cost |
|-------|-----------|------|
| Unknown username | dummy bcrypt, then fail | 1 bcrypt |
| Known plaintext account | `compare_digest` (µs) + dummy bcrypt | 1 bcrypt |
| Known `{bcrypt}` account | real `bcrypt.checkpw` | 1 bcrypt |

The known-plaintext branch **also** runs the dummy bcrypt; without it, plaintext accounts would answer in microseconds while unknown usernames took ~100 ms — a *stronger* enumeration signal than the original code (thanks @danielaskdd for catching this).

**Residual (documented in code):** the dummy is bcrypt cost 12, matching `hash_password()` / `bcrypt.gensalt()` defaults. Accounts with a hand-chosen, non-default cost still differ somewhat; fully closing that requires a uniform cost or dropping plaintext support (the advisory's own guidance is to use `{bcrypt}`).

**3. Run the login verification off the event loop (DoS)** — `lightrag/api/lightrag_server.py`

Because change #2 makes **every** `/login` attempt cost one bcrypt, and `/login` is `async def`, running that CPU-bound bcrypt inline would block the event loop ~100 ms per request — an unauthenticated attacker could flood random usernames and starve the whole API. The route now offloads verification with `await asyncio.to_thread(...)`. **Login rate limiting is still advisable** and is noted inline as a follow-up (thanks @danielaskdd).

## Tests

`tests/api/auth/test_auth.py` (new):
- `test_plaintext_verify_uses_constant_time_comparison` — behavior across shorter/longer/unicode guesses
- `test_verify_password_unknown_user_runs_dummy_verification` — unknown user runs the dummy verification instead of returning early
- `test_known_plaintext_user_also_runs_dummy_bcrypt` — known plaintext account runs `compare_digest` **and** the dummy bcrypt, still returning the real result
- `test_known_bcrypt_user_runs_single_verification` — known `{bcrypt}` account runs exactly one verification, no extra dummy
- `test_verify_password_unicode_plaintext` — non-ASCII plaintext still verifies

`tests/api/routes/test_login_route.py` (new):
- correct / wrong / unknown credentials through the real endpoint (the wrong-password case also guards the `await`)
- `test_login_offloads_verification_to_thread` — asserts the verification runs via `asyncio.to_thread`

`tests/api` full suite: 286 passed, 14 skipped. `ruff` format + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)