### PR TITLE
feat(api): rate-limit /login to stop brute-force attacks (GHSA-frch-4w6v-q5xx)

### DIFF
--- a/env.example
+++ b/env.example
@@ -88,6 +88,16 @@ OLLAMA_EMULATING_MODEL_TAG=latest
 # TOKEN_EXPIRE_HOURS=48
 # GUEST_TOKEN_EXPIRE_HOURS=24
 
+### Login brute-force protection (POST /login).
+### After LOGIN_MAX_FAILED_ATTEMPTS failed attempts from the same client IP for
+### the same username within LOGIN_LOCKOUT_WINDOW_SECONDS, further attempts are
+### rejected with HTTP 429 until the window passes; a successful login resets it.
+### Set LOGIN_MAX_FAILED_ATTEMPTS=0 to disable. Counters are per server process
+### (in-memory): under gunicorn with N workers the effective limit is N x the
+### value below; use a reverse-proxy / WAF rate limit for strict enforcement.
+# LOGIN_MAX_FAILED_ATTEMPTS=5
+# LOGIN_LOCKOUT_WINDOW_SECONDS=300
+
 ### Token Auto-Renewal Configuration (Sliding Window Expiration)
 ### Enable automatic token renewal to prevent active users from being logged out
 ### When enabled, tokens will be automatically renewed when remaining time < threshold

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -651,6 +651,14 @@ def parse_args() -> argparse.Namespace:
     args.token_auto_renew = get_env_value("TOKEN_AUTO_RENEW", True, bool)
     args.token_renew_threshold = get_env_value("TOKEN_RENEW_THRESHOLD", 0.5, float)
 
+    # Login brute-force protection: max failed /login attempts per client IP +
+    # username within the window before further attempts are rejected with HTTP
+    # 429. Set LOGIN_MAX_FAILED_ATTEMPTS=0 to disable (CWE-307).
+    args.login_max_failed_attempts = get_env_value("LOGIN_MAX_FAILED_ATTEMPTS", 5, int)
+    args.login_lockout_window_seconds = get_env_value(
+        "LOGIN_LOCKOUT_WINDOW_SECONDS", 300, float
+    )
+
     # Rerank model configuration
     args.rerank_model = get_env_value("RERANK_MODEL", None)
     args.rerank_binding_host = get_env_value("RERANK_BINDING_HOST", None)

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -2307,26 +2307,29 @@ def create_app(args):
 
         # Reserve this attempt BEFORE the bcrypt await. verify runs on a worker
         # thread, so without pre-reserving, many concurrent requests would all
-        # pass the check above (count still below the limit) before any of them
-        # recorded a failure, bypassing the limit and the "no bcrypt once locked"
-        # guarantee (TOCTOU). retry_after + reserve here are synchronous with no
-        # await between them, so the counter is consistent at decision time.
+        # pass the check above before any resolved, bypassing the limit (TOCTOU).
+        # retry_after + reserve here are synchronous with no await between them,
+        # so the decision is consistent. The reservation is always released in
+        # the finally; only a confirmed wrong password becomes a real failure.
         login_rate_limiter.reserve_attempt(rate_limit_key)
+        try:
+            # verify_password runs a CPU-bound bcrypt for every attempt (incl.
+            # unknown usernames, to equalize timing). Run it in a worker thread
+            # so a login flood cannot block the event loop and starve the whole
+            # API (unauthenticated DoS).
+            password_ok = await asyncio.to_thread(
+                auth_handler.verify_password, username, form_data.password
+            )
+        finally:
+            login_rate_limiter.release(rate_limit_key)
 
-        # verify_password runs a CPU-bound bcrypt for every attempt (including
-        # unknown usernames, to equalize timing). Run it in a worker thread so a
-        # flood of login requests cannot block the event loop and starve the
-        # whole API (unauthenticated DoS).
-        password_ok = await asyncio.to_thread(
-            auth_handler.verify_password, username, form_data.password
-        )
         if not password_ok:
-            # Confirm the reserved attempt as a real failure (this is what emits
-            # the lockout alert, so a correct password on the Nth try does not).
+            # Confirmed failure -> count it (and emit the lockout alert only here,
+            # so a correct password on the Nth attempt never raises a false one).
             login_rate_limiter.commit_failure(rate_limit_key)
             raise HTTPException(status_code=401, detail="Incorrect credentials")
 
-        # Success: clear the reserved attempt and any earlier failures.
+        # Success clears the key's earlier failures.
         login_rate_limiter.reset(rate_limit_key)
 
         # Regular user login

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -2320,17 +2320,19 @@ def create_app(args):
             password_ok = await asyncio.to_thread(
                 auth_handler.verify_password, username, form_data.password
             )
+            # Record the outcome BEFORE releasing the reservation, so the entry
+            # still carries the failure (release removes a now-idle entry).
+            if not password_ok:
+                # Confirmed failure -> count it (and emit the lockout alert only
+                # here, so a correct password on the Nth attempt never does).
+                login_rate_limiter.commit_failure(rate_limit_key)
+                raise HTTPException(status_code=401, detail="Incorrect credentials")
+            # Success clears the key's earlier failures.
+            login_rate_limiter.reset(rate_limit_key)
         finally:
+            # Always drop the in-flight reservation (also frees the slot once the
+            # key is fully idle, e.g. after a successful login).
             login_rate_limiter.release(rate_limit_key)
-
-        if not password_ok:
-            # Confirmed failure -> count it (and emit the lockout alert only here,
-            # so a correct password on the Nth attempt never raises a false one).
-            login_rate_limiter.commit_failure(rate_limit_key)
-            raise HTTPException(status_code=401, detail="Incorrect credentials")
-
-        # Success clears the key's earlier failures.
-        login_rate_limiter.reset(rate_limit_key)
 
         # Regular user login
         user_token = auth_handler.create_token(

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -2309,10 +2309,9 @@ def create_app(args):
         # thread, so without pre-reserving, many concurrent requests would all
         # pass the check above (count still below the limit) before any of them
         # recorded a failure, bypassing the limit and the "no bcrypt once locked"
-        # guarantee (TOCTOU). retry_after + record here are synchronous with no
-        # await between them, so the counter is consistent at decision time; a
-        # successful login clears it below.
-        login_rate_limiter.record_failure(rate_limit_key)
+        # guarantee (TOCTOU). retry_after + reserve here are synchronous with no
+        # await between them, so the counter is consistent at decision time.
+        login_rate_limiter.reserve_attempt(rate_limit_key)
 
         # verify_password runs a CPU-bound bcrypt for every attempt (including
         # unknown usernames, to equalize timing). Run it in a worker thread so a
@@ -2322,6 +2321,9 @@ def create_app(args):
             auth_handler.verify_password, username, form_data.password
         )
         if not password_ok:
+            # Confirm the reserved attempt as a real failure (this is what emits
+            # the lockout alert, so a correct password on the Nth try does not).
+            login_rate_limiter.commit_failure(rate_limit_key)
             raise HTTPException(status_code=401, detail="Incorrect credentials")
 
         # Success: clear the reserved attempt and any earlier failures.

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -77,6 +77,7 @@ from lightrag.kg.shared_storage import (
 )
 from fastapi.security import OAuth2PasswordRequestForm
 from lightrag.api.auth import auth_handler
+from lightrag.api.login_rate_limit import LoginRateLimiter
 
 # use the .env that is inside the current folder
 # allows to use different .env file for each lightrag instance
@@ -2261,8 +2262,16 @@ def create_app(args):
             "webui_description": webui_description,
         }
 
+    # Brute-force protection for /login (CWE-307): throttle failed attempts per
+    # client IP + username. Checked before the bcrypt verification, so a locked
+    # key is also rejected without paying the bcrypt cost.
+    login_rate_limiter = LoginRateLimiter(
+        max_attempts=args.login_max_failed_attempts,
+        window_seconds=args.login_lockout_window_seconds,
+    )
+
     @app.post("/login")
-    async def login(form_data: OAuth2PasswordRequestForm = Depends()):
+    async def login(request: Request, form_data: OAuth2PasswordRequestForm = Depends()):
         if not auth_handler.accounts:
             # Authentication not configured, return guest token
             guest_token = auth_handler.create_token(
@@ -2279,15 +2288,33 @@ def create_app(args):
                 "webui_description": webui_description,
             }
         username = form_data.username
+        # Rate-limit key is client IP + username. X-Forwarded-For is NOT trusted
+        # (spoofable); behind a reverse proxy all clients may share the proxy IP,
+        # so buckets are separated by username to avoid one attacker locking out
+        # unrelated accounts. request.client can be None for some transports.
+        client_ip = request.client.host if request.client else "unknown"
+        rate_limit_key = f"{client_ip}:{username}"
+
+        retry_after = login_rate_limiter.retry_after(rate_limit_key)
+        if retry_after is not None:
+            raise HTTPException(
+                status_code=429,
+                detail="Too many failed login attempts. Please try again later.",
+                headers={"Retry-After": str(int(retry_after) + 1)},
+            )
+
         # verify_password runs a CPU-bound bcrypt for every attempt (including
         # unknown usernames, to equalize timing). Run it in a worker thread so a
         # flood of login requests cannot block the event loop and starve the
-        # whole API (unauthenticated DoS). Login rate limiting is still advisable.
+        # whole API (unauthenticated DoS).
         password_ok = await asyncio.to_thread(
             auth_handler.verify_password, username, form_data.password
         )
         if not password_ok:
+            login_rate_limiter.record_failure(rate_limit_key)
             raise HTTPException(status_code=401, detail="Incorrect credentials")
+
+        login_rate_limiter.reset(rate_limit_key)
 
         # Regular user login
         user_token = auth_handler.create_token(

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -2265,9 +2265,11 @@ def create_app(args):
     # Brute-force protection for /login (CWE-307): throttle failed attempts per
     # client IP + username. Checked before the bcrypt verification, so a locked
     # key is also rejected without paying the bcrypt cost.
+    # getattr defaults keep create_app working for callers that build args
+    # programmatically (e.g. tests, embedding) without these newer fields.
     login_rate_limiter = LoginRateLimiter(
-        max_attempts=args.login_max_failed_attempts,
-        window_seconds=args.login_lockout_window_seconds,
+        max_attempts=getattr(args, "login_max_failed_attempts", 5),
+        window_seconds=getattr(args, "login_lockout_window_seconds", 300.0),
     )
 
     @app.post("/login")
@@ -2303,6 +2305,15 @@ def create_app(args):
                 headers={"Retry-After": str(int(retry_after) + 1)},
             )
 
+        # Reserve this attempt BEFORE the bcrypt await. verify runs on a worker
+        # thread, so without pre-reserving, many concurrent requests would all
+        # pass the check above (count still below the limit) before any of them
+        # recorded a failure, bypassing the limit and the "no bcrypt once locked"
+        # guarantee (TOCTOU). retry_after + record here are synchronous with no
+        # await between them, so the counter is consistent at decision time; a
+        # successful login clears it below.
+        login_rate_limiter.record_failure(rate_limit_key)
+
         # verify_password runs a CPU-bound bcrypt for every attempt (including
         # unknown usernames, to equalize timing). Run it in a worker thread so a
         # flood of login requests cannot block the event loop and starve the
@@ -2311,9 +2322,9 @@ def create_app(args):
             auth_handler.verify_password, username, form_data.password
         )
         if not password_ok:
-            login_rate_limiter.record_failure(rate_limit_key)
             raise HTTPException(status_code=401, detail="Incorrect credentials")
 
+        # Success: clear the reserved attempt and any earlier failures.
         login_rate_limiter.reset(rate_limit_key)
 
         # Regular user login

--- a/lightrag/api/login_rate_limit.py
+++ b/lightrag/api/login_rate_limit.py
@@ -13,11 +13,16 @@ enforcement is required.
 All access happens on a single worker's event-loop thread, so no locking is
 needed (mirrors the token-renewal cache in ``utils_api.py``).
 
-The number of tracked keys is capped at ``max_tracked_keys`` with least-recently-
-active eviction, so a flood of unique IP/username pairs cannot grow the map
-without bound (the map would otherwise be its own memory-exhaustion DoS). This
-is a basic in-process safety bound only; defending against large-scale or
-distributed attacks is the job of an upstream reverse proxy / WAF.
+The number of tracked keys is capped at ``max_tracked_keys`` so a flood of
+unique IP/username pairs cannot grow the map without bound (the map would
+otherwise be its own memory-exhaustion DoS). When at capacity, only keys whose
+failures have already aged out of the window are evicted; a key that is still
+in-window (possibly an active lockout) is never evicted -- otherwise an attacker
+could clear a lockout by flooding unique keys. If every tracked key is in-window,
+a brand-new key is simply not tracked until a slot frees. This is a basic
+in-process safety bound only; defending against large-scale or distributed
+attacks (including a sustained flood that keeps the table full of live keys) is
+the job of an upstream reverse proxy / WAF.
 """
 
 import time
@@ -85,13 +90,31 @@ class LoginRateLimiter:
         now = self._clock()
         dq = self._recent_failures(key, now)
         if dq is None:
-            # New key: evict the least-recently-active one when at capacity so a
-            # flood of unique keys cannot grow the map without bound.
-            if len(self._failures) >= self.max_tracked_keys:
-                self._failures.popitem(last=False)
+            if not self._make_room(now):
+                # Table is full of in-window records. Do NOT evict a live record
+                # to make space -- that would let an attacker clear an active
+                # lockout by flooding unique keys. Skip tracking this brand-new
+                # key instead; a slot frees once existing records age out.
+                return
             dq = self._failures[key] = deque()
         dq.append(now)
         self._failures.move_to_end(key)  # mark most-recently-active
+
+    def _make_room(self, now: float) -> bool:
+        """Ensure there is room for one new key; return True if a slot is free.
+
+        Evicts only keys whose most recent failure has aged out of the window.
+        Keys are ordered least-recently-active first, so once the front key is
+        still in-window every remaining key is too, and nothing more can be
+        evicted (returns False without touching any live record).
+        """
+        cutoff = now - self.window_seconds
+        while len(self._failures) >= self.max_tracked_keys:
+            _key, dq = next(iter(self._failures.items()))  # least-recently-active
+            if dq and dq[-1] > cutoff:
+                return False  # oldest key is live -> so are all others
+            self._failures.popitem(last=False)  # fully expired -> reclaim
+        return True
 
     def reset(self, key: str) -> None:
         """Clear all recorded failures for ``key`` (called on successful login)."""

--- a/lightrag/api/login_rate_limit.py
+++ b/lightrag/api/login_rate_limit.py
@@ -140,12 +140,17 @@ class LoginRateLimiter:
         entry = self._live_entry(key, now)
         if entry is None:
             return None
-        if len(entry.failures) + entry.pending < self.max_attempts:
+        confirmed = len(entry.failures)
+        if confirmed + entry.pending < self.max_attempts:
             return None
-        if entry.failures:
+        if confirmed >= self.max_attempts:
+            # Genuine failure lockout: advise waiting until the oldest confirmed
+            # failure ages out of the window.
             return max(0.0, self.window_seconds - (now - entry.failures[0]))
-        # Blocked only by in-flight reservations (no confirmed failures yet);
-        # they resolve quickly, so advise a short retry.
+        # Blocked only because in-flight reservations push the total to the
+        # limit (confirmed failures are still below it). Those resolve in well
+        # under a second and may all succeed -- clearing the failures -- so
+        # advise a short retry rather than the full window.
         return _PENDING_RETRY_AFTER_SECONDS
 
     def reserve_attempt(self, key: str) -> None:

--- a/lightrag/api/login_rate_limit.py
+++ b/lightrag/api/login_rate_limit.py
@@ -41,6 +41,21 @@ DEFAULT_MAX_TRACKED_KEYS = 10_000
 DEFAULT_ALERT_INTERVAL_SECONDS = 60.0
 
 
+def _safe_log_value(value: str, max_length: int = 200) -> str:
+    """Make an untrusted value (e.g. an attacker-supplied username embedded in a
+    rate-limit key) safe to put in a log line.
+
+    Replaces non-printable characters -- notably CR/LF, which could otherwise be
+    used to forge extra log lines (log injection) -- with '?' and truncates
+    over-long values. Only the *logged* value is sanitized; the limiter's
+    internal key is left untouched so counting is unaffected.
+    """
+    sanitized = "".join(ch if ch.isprintable() else "?" for ch in value)
+    if len(sanitized) > max_length:
+        sanitized = sanitized[:max_length] + "…(truncated)"
+    return sanitized
+
+
 class LoginRateLimiter:
     def __init__(
         self,
@@ -96,8 +111,14 @@ class LoginRateLimiter:
         # Locked until the oldest in-window failure ages out.
         return max(0.0, self.window_seconds - (now - dq[0]))
 
-    def record_failure(self, key: str) -> None:
-        """Record one failed attempt for ``key``."""
+    def reserve_attempt(self, key: str) -> None:
+        """Reserve one attempt for ``key`` *before* password verification.
+
+        Counts toward the limit so that many concurrent requests cannot all pass
+        ``retry_after`` while bcrypt is in flight (TOCTOU). Does NOT alert -- the
+        attempt may still succeed. Call ``commit_failure`` after a confirmed
+        wrong password, or ``reset`` after a successful login.
+        """
         if not self.enabled:
             return
         now = self._clock()
@@ -112,16 +133,26 @@ class LoginRateLimiter:
             dq = self._failures[key] = deque()
         dq.append(now)
         self._failures.move_to_end(key)  # mark most-recently-active
-        if len(dq) == self.max_attempts:
-            # This attempt just tripped the lockout (the count reaches the limit
-            # exactly once per lockout cycle, so this does not fire on every
-            # subsequent rejected request).
+
+    def commit_failure(self, key: str) -> None:
+        """Confirm a reserved attempt as a genuine failure (wrong password).
+
+        Emits the throttled lockout alert if this failure has tripped the limit.
+        Because it runs only after the password is verified *wrong*, a correct
+        password on the Nth attempt no longer produces a false lockout alert.
+        """
+        if not self.enabled:
+            return
+        now = self._clock()
+        dq = self._recent_failures(key, now)
+        if dq is not None and len(dq) >= self.max_attempts:
             self._alert(
                 now,
                 "lockout",
-                f"Login rate limit tripped for '{key}': {self.max_attempts} "
-                f"failed attempts within {self.window_seconds:.0f}s; "
-                f"further attempts are blocked (HTTP 429)",
+                f"Login rate limit tripped for '{_safe_log_value(key)}': "
+                f"{self.max_attempts} failed attempts within "
+                f"{self.window_seconds:.0f}s; further attempts are blocked "
+                f"(HTTP 429)",
             )
 
     def _alert(self, now: float, category: str, message: str) -> None:

--- a/lightrag/api/login_rate_limit.py
+++ b/lightrag/api/login_rate_limit.py
@@ -1,28 +1,39 @@
 """In-process brute-force protection for the /login endpoint (CWE-307).
 
-A sliding-window limiter that counts *failed* login attempts per key (client
-IP + username) and rejects further attempts once the count reaches
-``max_attempts`` within ``window_seconds``. A successful login clears the key.
+A sliding-window limiter, keyed by client IP + username, that blocks further
+login attempts once a key accumulates too many failures.
+
+Each key tracks two distinct kinds of state, which must not be conflated:
+
+* ``confirmed`` -- timestamps of attempts verified as *wrong* passwords.
+* ``pending``  -- in-flight reservations: requests that have passed the check
+  and are running bcrypt but whose result is not yet known.
+
+The **rate-limit decision** uses ``confirmed + pending`` so that many
+simultaneous requests cannot all pass the check while bcrypt is in flight
+(TOCTOU concurrency bypass). The **lockout alert** uses ``confirmed`` only, so a
+correct password (or a burst of correct passwords) resolving alongside one wrong
+one never produces a false "account locked" alert.
+
+Lifecycle per request: ``reserve_attempt`` (before bcrypt) -> exactly one of
+``commit_failure`` (wrong password) / ``reset`` (correct password), and always
+``release`` (drop the in-flight reservation, typically in a ``finally``).
 
 State is in-memory and per-process. The API server runs single-worker under
 uvicorn (``config.update_uvicorn_mode_config`` forces workers=1); under gunicorn
 with N workers the effective limit is N x ``max_attempts``, which still defeats
-wordlist brute force. Use a shared store (e.g. Redis) if strict cross-worker
-enforcement is required.
+wordlist brute force. Use a shared store (e.g. Redis) for strict cross-worker
+enforcement. All access happens on a single worker's event-loop thread, so no
+locking is needed (mirrors the token-renewal cache in ``utils_api.py``).
 
-All access happens on a single worker's event-loop thread, so no locking is
-needed (mirrors the token-renewal cache in ``utils_api.py``).
-
-The number of tracked keys is capped at ``max_tracked_keys`` so a flood of
-unique IP/username pairs cannot grow the map without bound (the map would
-otherwise be its own memory-exhaustion DoS). When at capacity, only keys whose
-failures have already aged out of the window are evicted; a key that is still
-in-window (possibly an active lockout) is never evicted -- otherwise an attacker
-could clear a lockout by flooding unique keys. If every tracked key is in-window,
-a brand-new key is simply not tracked until a slot frees. This is a basic
-in-process safety bound only; defending against large-scale or distributed
-attacks (including a sustained flood that keeps the table full of live keys) is
-the job of an upstream reverse proxy / WAF.
+The number of tracked keys is capped at ``max_tracked_keys``. When at capacity,
+only keys that are neither in-window nor in-flight are evicted; a live record
+(active lockout or pending request) is never evicted -- otherwise an attacker
+could clear a lockout by flooding unique keys. If every tracked key is live, a
+brand-new key is simply not tracked until a slot frees. This is a basic
+in-process safety bound; large-scale or distributed attacks (including a
+sustained flood that keeps the table full of live keys) are the job of an
+upstream reverse proxy / WAF.
 """
 
 import time
@@ -31,14 +42,18 @@ from typing import Callable, Optional
 
 from ..utils import logger
 
-# Upper bound on distinct keys held in memory (see module docstring). Each key
-# holds at most ``max_attempts`` timestamps, so total memory stays small.
+# Upper bound on distinct keys held in memory (see module docstring).
 DEFAULT_MAX_TRACKED_KEYS = 10_000
 
 # Minimum seconds between two WARNING logs of the same category. Attack traffic
 # is high-volume, so alerts are throttled (with a suppressed-count summary) to
 # keep them from filling the log.
 DEFAULT_ALERT_INTERVAL_SECONDS = 60.0
+
+# Retry hint (seconds) returned when a key is blocked purely by in-flight
+# reservations rather than confirmed failures: those resolve in well under a
+# second (bcrypt), so the caller may retry shortly.
+_PENDING_RETRY_AFTER_SECONDS = 1.0
 
 
 def _safe_log_value(value: str, max_length: int = 200) -> str:
@@ -56,6 +71,16 @@ def _safe_log_value(value: str, max_length: int = 200) -> str:
     return sanitized
 
 
+class _Entry:
+    """Per-key state: confirmed-failure timestamps and in-flight reservations."""
+
+    __slots__ = ("failures", "pending")
+
+    def __init__(self) -> None:
+        self.failures: deque = deque()  # confirmed wrong-password times, oldest first
+        self.pending: int = 0  # reservations whose result is not yet known
+
+
 class LoginRateLimiter:
     def __init__(
         self,
@@ -70,11 +95,9 @@ class LoginRateLimiter:
         self.max_tracked_keys = max_tracked_keys
         self.alert_interval_seconds = alert_interval_seconds
         self._clock = clock
-        # key -> timestamps of recent failed attempts (oldest first). Ordered so
-        # the least-recently-active key can be evicted in O(1) when at capacity.
-        self._failures: "OrderedDict[str, deque]" = OrderedDict()
-        # Per-category throttle state for _alert: last emit time and how many
-        # alerts have been suppressed since then.
+        # Ordered so the least-recently-active key can be evicted in O(1).
+        self._entries: "OrderedDict[str, _Entry]" = OrderedDict()
+        # Per-category throttle state for _alert.
         self._alert_last: dict[str, float] = {}
         self._alert_suppressed: dict[str, int] = {}
 
@@ -83,69 +106,91 @@ class LoginRateLimiter:
         """Rate limiting is off when either bound is non-positive."""
         return self.max_attempts > 0 and self.window_seconds > 0
 
-    def _recent_failures(self, key: str, now: float) -> Optional[deque]:
-        """Return the in-window failures for ``key``, pruning expired ones.
-
-        Drops the key entirely (and returns None) once nothing is in-window, so
-        the map does not grow without bound.
-        """
-        dq = self._failures.get(key)
-        if dq is None:
-            return None
+    def _prune(self, entry: _Entry, now: float) -> None:
+        """Drop ``entry``'s confirmed failures that have aged out of the window."""
         cutoff = now - self.window_seconds
+        dq = entry.failures
         while dq and dq[0] <= cutoff:
             dq.popleft()
-        if not dq:
-            del self._failures[key]
+
+    def _live_entry(self, key: str, now: float) -> Optional[_Entry]:
+        """Return ``key``'s entry after pruning, dropping it if fully dead.
+
+        An entry is dead once it has no in-window failures and no in-flight
+        reservation, so idle keys do not accumulate.
+        """
+        entry = self._entries.get(key)
+        if entry is None:
             return None
-        return dq
+        self._prune(entry, now)
+        if not entry.failures and entry.pending == 0:
+            del self._entries[key]
+            return None
+        return entry
 
     def retry_after(self, key: str) -> Optional[float]:
-        """Seconds the caller must wait before retrying, or None if allowed."""
+        """Seconds the caller must wait before attempting, or None if allowed.
+
+        Uses confirmed failures + in-flight reservations so a burst of concurrent
+        requests cannot all slip through before their results are known.
+        """
         if not self.enabled:
             return None
         now = self._clock()
-        dq = self._recent_failures(key, now)
-        if dq is None or len(dq) < self.max_attempts:
+        entry = self._live_entry(key, now)
+        if entry is None:
             return None
-        # Locked until the oldest in-window failure ages out.
-        return max(0.0, self.window_seconds - (now - dq[0]))
+        if len(entry.failures) + entry.pending < self.max_attempts:
+            return None
+        if entry.failures:
+            return max(0.0, self.window_seconds - (now - entry.failures[0]))
+        # Blocked only by in-flight reservations (no confirmed failures yet);
+        # they resolve quickly, so advise a short retry.
+        return _PENDING_RETRY_AFTER_SECONDS
 
     def reserve_attempt(self, key: str) -> None:
-        """Reserve one attempt for ``key`` *before* password verification.
+        """Reserve one in-flight attempt for ``key`` *before* password verification.
 
-        Counts toward the limit so that many concurrent requests cannot all pass
-        ``retry_after`` while bcrypt is in flight (TOCTOU). Does NOT alert -- the
-        attempt may still succeed. Call ``commit_failure`` after a confirmed
-        wrong password, or ``reset`` after a successful login.
+        Counts toward the limit (via ``pending``) so concurrent requests cannot
+        bypass the check while bcrypt runs. Pair every call with exactly one
+        ``release`` (typically in a ``finally``). Never alerts.
         """
         if not self.enabled:
             return
         now = self._clock()
-        dq = self._recent_failures(key, now)
-        if dq is None:
+        entry = self._live_entry(key, now)
+        if entry is None:
             if not self._make_room(now):
-                # Table is full of in-window records. Do NOT evict a live record
-                # to make space -- that would let an attacker clear an active
-                # lockout by flooding unique keys. Skip tracking this brand-new
-                # key instead; a slot frees once existing records age out.
+                # Table is full of live records. Do NOT evict one to make room --
+                # that could clear an active lockout. Leave this key untracked;
+                # release/commit/reset below all no-op safely for a missing key.
                 return
-            dq = self._failures[key] = deque()
-        dq.append(now)
-        self._failures.move_to_end(key)  # mark most-recently-active
+            entry = self._entries[key] = _Entry()
+        entry.pending += 1
+        self._entries.move_to_end(key)
+
+    def release(self, key: str) -> None:
+        """Drop one in-flight reservation for ``key`` (call once per reserve)."""
+        entry = self._entries.get(key)
+        if entry is not None and entry.pending > 0:
+            entry.pending -= 1
 
     def commit_failure(self, key: str) -> None:
-        """Confirm a reserved attempt as a genuine failure (wrong password).
+        """Record a confirmed failure (call only after a verified wrong password).
 
-        Emits the throttled lockout alert if this failure has tripped the limit.
-        Because it runs only after the password is verified *wrong*, a correct
-        password on the Nth attempt no longer produces a false lockout alert.
+        Emits the throttled lockout alert once, exactly when confirmed failures
+        reach the limit -- never on a reservation and never on success.
         """
         if not self.enabled:
             return
         now = self._clock()
-        dq = self._recent_failures(key, now)
-        if dq is not None and len(dq) >= self.max_attempts:
+        entry = self._entries.get(key)
+        if entry is None:
+            return  # untracked (table was full when the attempt was reserved)
+        self._prune(entry, now)
+        entry.failures.append(now)
+        self._entries.move_to_end(key)
+        if len(entry.failures) == self.max_attempts:
             self._alert(
                 now,
                 "lockout",
@@ -154,6 +199,40 @@ class LoginRateLimiter:
                 f"{self.window_seconds:.0f}s; further attempts are blocked "
                 f"(HTTP 429)",
             )
+
+    def reset(self, key: str) -> None:
+        """Clear confirmed failures for ``key`` (call on a successful login).
+
+        In-flight reservations for other concurrent requests are left untouched.
+        """
+        entry = self._entries.get(key)
+        if entry is not None:
+            entry.failures.clear()
+
+    def _make_room(self, now: float) -> bool:
+        """Ensure there is room for one new key; return True if a slot is free.
+
+        Evicts only dead keys (no in-window failures, no in-flight reservation).
+        Keys are ordered least-recently-active first, so once the front key is
+        live every remaining key is too and nothing more can be evicted.
+        """
+        while len(self._entries) >= self.max_tracked_keys:
+            key, entry = next(iter(self._entries.items()))  # least-recently-active
+            self._prune(entry, now)
+            if entry.failures or entry.pending > 0:
+                # Capacity exhausted by live records: a likely flood. New keys go
+                # untracked until a slot frees, so warn (throttled).
+                self._alert(
+                    now,
+                    "table_full",
+                    f"Login rate-limit table is full ({self.max_tracked_keys} "
+                    f"active keys); new client/username pairs are temporarily "
+                    f"not rate-limited -- possible flood, consider an upstream "
+                    f"reverse proxy / WAF rate limit",
+                )
+                return False
+            del self._entries[key]  # dead -> reclaim
+        return True
 
     def _alert(self, now: float, category: str, message: str) -> None:
         """Emit a throttled WARNING for ``category``.
@@ -173,34 +252,3 @@ class LoginRateLimiter:
         if suppressed:
             message += f" ({suppressed} more since last alert)"
         logger.warning(message)
-
-    def _make_room(self, now: float) -> bool:
-        """Ensure there is room for one new key; return True if a slot is free.
-
-        Evicts only keys whose most recent failure has aged out of the window.
-        Keys are ordered least-recently-active first, so once the front key is
-        still in-window every remaining key is too, and nothing more can be
-        evicted (returns False without touching any live record).
-        """
-        cutoff = now - self.window_seconds
-        while len(self._failures) >= self.max_tracked_keys:
-            _key, dq = next(iter(self._failures.items()))  # least-recently-active
-            if dq and dq[-1] > cutoff:
-                # Oldest key is live -> so are all others. Capacity is exhausted
-                # by in-window records: a likely flood. New keys go untracked
-                # until a slot frees, so warn (throttled) to surface it.
-                self._alert(
-                    now,
-                    "table_full",
-                    f"Login rate-limit table is full ({self.max_tracked_keys} "
-                    f"active keys); new client/username pairs are temporarily "
-                    f"not rate-limited -- possible flood, consider an upstream "
-                    f"reverse proxy / WAF rate limit",
-                )
-                return False
-            self._failures.popitem(last=False)  # fully expired -> reclaim
-        return True
-
-    def reset(self, key: str) -> None:
-        """Clear all recorded failures for ``key`` (called on successful login)."""
-        self._failures.pop(key, None)

--- a/lightrag/api/login_rate_limit.py
+++ b/lightrag/api/login_rate_limit.py
@@ -29,9 +29,16 @@ import time
 from collections import OrderedDict, deque
 from typing import Callable, Optional
 
+from ..utils import logger
+
 # Upper bound on distinct keys held in memory (see module docstring). Each key
 # holds at most ``max_attempts`` timestamps, so total memory stays small.
 DEFAULT_MAX_TRACKED_KEYS = 10_000
+
+# Minimum seconds between two WARNING logs of the same category. Attack traffic
+# is high-volume, so alerts are throttled (with a suppressed-count summary) to
+# keep them from filling the log.
+DEFAULT_ALERT_INTERVAL_SECONDS = 60.0
 
 
 class LoginRateLimiter:
@@ -41,14 +48,20 @@ class LoginRateLimiter:
         window_seconds: float = 300.0,
         clock: Callable[[], float] = time.monotonic,
         max_tracked_keys: int = DEFAULT_MAX_TRACKED_KEYS,
+        alert_interval_seconds: float = DEFAULT_ALERT_INTERVAL_SECONDS,
     ) -> None:
         self.max_attempts = max_attempts
         self.window_seconds = window_seconds
         self.max_tracked_keys = max_tracked_keys
+        self.alert_interval_seconds = alert_interval_seconds
         self._clock = clock
         # key -> timestamps of recent failed attempts (oldest first). Ordered so
         # the least-recently-active key can be evicted in O(1) when at capacity.
         self._failures: "OrderedDict[str, deque]" = OrderedDict()
+        # Per-category throttle state for _alert: last emit time and how many
+        # alerts have been suppressed since then.
+        self._alert_last: dict[str, float] = {}
+        self._alert_suppressed: dict[str, int] = {}
 
     @property
     def enabled(self) -> bool:
@@ -99,6 +112,36 @@ class LoginRateLimiter:
             dq = self._failures[key] = deque()
         dq.append(now)
         self._failures.move_to_end(key)  # mark most-recently-active
+        if len(dq) == self.max_attempts:
+            # This attempt just tripped the lockout (the count reaches the limit
+            # exactly once per lockout cycle, so this does not fire on every
+            # subsequent rejected request).
+            self._alert(
+                now,
+                "lockout",
+                f"Login rate limit tripped for '{key}': {self.max_attempts} "
+                f"failed attempts within {self.window_seconds:.0f}s; "
+                f"further attempts are blocked (HTTP 429)",
+            )
+
+    def _alert(self, now: float, category: str, message: str) -> None:
+        """Emit a throttled WARNING for ``category``.
+
+        At most one WARNING per ``alert_interval_seconds`` per category is
+        logged; alerts arriving inside that window are counted and reported as a
+        summary on the next emitted line, so an attack cannot flood the log.
+        """
+        last = self._alert_last.get(category)
+        if last is not None and now - last < self.alert_interval_seconds:
+            self._alert_suppressed[category] = (
+                self._alert_suppressed.get(category, 0) + 1
+            )
+            return
+        suppressed = self._alert_suppressed.pop(category, 0)
+        self._alert_last[category] = now
+        if suppressed:
+            message += f" ({suppressed} more since last alert)"
+        logger.warning(message)
 
     def _make_room(self, now: float) -> bool:
         """Ensure there is room for one new key; return True if a slot is free.
@@ -112,7 +155,18 @@ class LoginRateLimiter:
         while len(self._failures) >= self.max_tracked_keys:
             _key, dq = next(iter(self._failures.items()))  # least-recently-active
             if dq and dq[-1] > cutoff:
-                return False  # oldest key is live -> so are all others
+                # Oldest key is live -> so are all others. Capacity is exhausted
+                # by in-window records: a likely flood. New keys go untracked
+                # until a slot frees, so warn (throttled) to surface it.
+                self._alert(
+                    now,
+                    "table_full",
+                    f"Login rate-limit table is full ({self.max_tracked_keys} "
+                    f"active keys); new client/username pairs are temporarily "
+                    f"not rate-limited -- possible flood, consider an upstream "
+                    f"reverse proxy / WAF rate limit",
+                )
+                return False
             self._failures.popitem(last=False)  # fully expired -> reclaim
         return True
 

--- a/lightrag/api/login_rate_limit.py
+++ b/lightrag/api/login_rate_limit.py
@@ -170,10 +170,20 @@ class LoginRateLimiter:
         self._entries.move_to_end(key)
 
     def release(self, key: str) -> None:
-        """Drop one in-flight reservation for ``key`` (call once per reserve)."""
+        """Drop one in-flight reservation for ``key`` (call once per reserve).
+
+        Removes the entry as soon as it is fully idle (no reservation and no
+        confirmed failures) so successful logins do not leave dead entries
+        occupying capacity. Keeping the map free of idle entries is also what
+        lets ``_make_room`` trust that a live front implies a live table.
+        """
         entry = self._entries.get(key)
-        if entry is not None and entry.pending > 0:
+        if entry is None:
+            return
+        if entry.pending > 0:
             entry.pending -= 1
+        if entry.pending == 0 and not entry.failures:
+            del self._entries[key]
 
     def commit_failure(self, key: str) -> None:
         """Record a confirmed failure (call only after a verified wrong password).
@@ -203,11 +213,15 @@ class LoginRateLimiter:
     def reset(self, key: str) -> None:
         """Clear confirmed failures for ``key`` (call on a successful login).
 
-        In-flight reservations for other concurrent requests are left untouched.
+        In-flight reservations for other concurrent requests are left untouched;
+        the entry is removed once it has neither a reservation nor a failure.
         """
         entry = self._entries.get(key)
-        if entry is not None:
-            entry.failures.clear()
+        if entry is None:
+            return
+        entry.failures.clear()
+        if entry.pending == 0:
+            del self._entries[key]
 
     def _make_room(self, now: float) -> bool:
         """Ensure there is room for one new key; return True if a slot is free.

--- a/lightrag/api/login_rate_limit.py
+++ b/lightrag/api/login_rate_limit.py
@@ -12,11 +12,21 @@ enforcement is required.
 
 All access happens on a single worker's event-loop thread, so no locking is
 needed (mirrors the token-renewal cache in ``utils_api.py``).
+
+The number of tracked keys is capped at ``max_tracked_keys`` with least-recently-
+active eviction, so a flood of unique IP/username pairs cannot grow the map
+without bound (the map would otherwise be its own memory-exhaustion DoS). This
+is a basic in-process safety bound only; defending against large-scale or
+distributed attacks is the job of an upstream reverse proxy / WAF.
 """
 
 import time
-from collections import deque
+from collections import OrderedDict, deque
 from typing import Callable, Optional
+
+# Upper bound on distinct keys held in memory (see module docstring). Each key
+# holds at most ``max_attempts`` timestamps, so total memory stays small.
+DEFAULT_MAX_TRACKED_KEYS = 10_000
 
 
 class LoginRateLimiter:
@@ -25,12 +35,15 @@ class LoginRateLimiter:
         max_attempts: int = 5,
         window_seconds: float = 300.0,
         clock: Callable[[], float] = time.monotonic,
+        max_tracked_keys: int = DEFAULT_MAX_TRACKED_KEYS,
     ) -> None:
         self.max_attempts = max_attempts
         self.window_seconds = window_seconds
+        self.max_tracked_keys = max_tracked_keys
         self._clock = clock
-        # key -> timestamps of recent failed attempts (oldest first)
-        self._failures: dict[str, deque] = {}
+        # key -> timestamps of recent failed attempts (oldest first). Ordered so
+        # the least-recently-active key can be evicted in O(1) when at capacity.
+        self._failures: "OrderedDict[str, deque]" = OrderedDict()
 
     @property
     def enabled(self) -> bool:
@@ -69,7 +82,16 @@ class LoginRateLimiter:
         """Record one failed attempt for ``key``."""
         if not self.enabled:
             return
-        self._failures.setdefault(key, deque()).append(self._clock())
+        now = self._clock()
+        dq = self._recent_failures(key, now)
+        if dq is None:
+            # New key: evict the least-recently-active one when at capacity so a
+            # flood of unique keys cannot grow the map without bound.
+            if len(self._failures) >= self.max_tracked_keys:
+                self._failures.popitem(last=False)
+            dq = self._failures[key] = deque()
+        dq.append(now)
+        self._failures.move_to_end(key)  # mark most-recently-active
 
     def reset(self, key: str) -> None:
         """Clear all recorded failures for ``key`` (called on successful login)."""

--- a/lightrag/api/login_rate_limit.py
+++ b/lightrag/api/login_rate_limit.py
@@ -1,0 +1,76 @@
+"""In-process brute-force protection for the /login endpoint (CWE-307).
+
+A sliding-window limiter that counts *failed* login attempts per key (client
+IP + username) and rejects further attempts once the count reaches
+``max_attempts`` within ``window_seconds``. A successful login clears the key.
+
+State is in-memory and per-process. The API server runs single-worker under
+uvicorn (``config.update_uvicorn_mode_config`` forces workers=1); under gunicorn
+with N workers the effective limit is N x ``max_attempts``, which still defeats
+wordlist brute force. Use a shared store (e.g. Redis) if strict cross-worker
+enforcement is required.
+
+All access happens on a single worker's event-loop thread, so no locking is
+needed (mirrors the token-renewal cache in ``utils_api.py``).
+"""
+
+import time
+from collections import deque
+from typing import Callable, Optional
+
+
+class LoginRateLimiter:
+    def __init__(
+        self,
+        max_attempts: int = 5,
+        window_seconds: float = 300.0,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.max_attempts = max_attempts
+        self.window_seconds = window_seconds
+        self._clock = clock
+        # key -> timestamps of recent failed attempts (oldest first)
+        self._failures: dict[str, deque] = {}
+
+    @property
+    def enabled(self) -> bool:
+        """Rate limiting is off when either bound is non-positive."""
+        return self.max_attempts > 0 and self.window_seconds > 0
+
+    def _recent_failures(self, key: str, now: float) -> Optional[deque]:
+        """Return the in-window failures for ``key``, pruning expired ones.
+
+        Drops the key entirely (and returns None) once nothing is in-window, so
+        the map does not grow without bound.
+        """
+        dq = self._failures.get(key)
+        if dq is None:
+            return None
+        cutoff = now - self.window_seconds
+        while dq and dq[0] <= cutoff:
+            dq.popleft()
+        if not dq:
+            del self._failures[key]
+            return None
+        return dq
+
+    def retry_after(self, key: str) -> Optional[float]:
+        """Seconds the caller must wait before retrying, or None if allowed."""
+        if not self.enabled:
+            return None
+        now = self._clock()
+        dq = self._recent_failures(key, now)
+        if dq is None or len(dq) < self.max_attempts:
+            return None
+        # Locked until the oldest in-window failure ages out.
+        return max(0.0, self.window_seconds - (now - dq[0]))
+
+    def record_failure(self, key: str) -> None:
+        """Record one failed attempt for ``key``."""
+        if not self.enabled:
+            return
+        self._failures.setdefault(key, deque()).append(self._clock())
+
+    def reset(self, key: str) -> None:
+        """Clear all recorded failures for ``key`` (called on successful login)."""
+        self._failures.pop(key, None)

--- a/tests/api/auth/test_login_rate_limit.py
+++ b/tests/api/auth/test_login_rate_limit.py
@@ -3,7 +3,11 @@
 from types import SimpleNamespace
 
 import lightrag.api.login_rate_limit as lrl_module
-from lightrag.api.login_rate_limit import LoginRateLimiter, _safe_log_value
+from lightrag.api.login_rate_limit import (
+    _PENDING_RETRY_AFTER_SECONDS,
+    LoginRateLimiter,
+    _safe_log_value,
+)
 
 
 def _capture_warnings(monkeypatch):
@@ -128,7 +132,39 @@ def test_pending_reservations_block_without_confirmed_failures():
     limiter.reserve_attempt(key)
     limiter.reserve_attempt(key)  # 2 in-flight, none resolved yet
 
-    assert limiter.retry_after(key) is not None  # blocked by pending
+    # Blocked, but only by pending -> short retry hint, not the full window.
+    assert limiter.retry_after(key) == _PENDING_RETRY_AFTER_SECONDS
+
+
+def test_retry_after_is_short_when_block_is_only_from_pending():
+    """A request blocked only because in-flight reservations push the total to
+    the limit (confirmed failures still below it) should get the short pending
+    hint, not the full window -- those reservations may resolve as successes.
+    """
+    limiter, _clock = _make(max_attempts=5, window_seconds=300)
+    key = "1.2.3.4:admin"
+
+    _fail(limiter, key)  # 1 confirmed failure (< max)
+    for _ in range(4):
+        limiter.reserve_attempt(key)  # 4 in-flight -> total 5 reaches the limit
+
+    assert limiter.retry_after(key) == _PENDING_RETRY_AFTER_SECONDS
+
+
+def test_retry_after_is_full_window_on_genuine_failure_lockout():
+    """Once confirmed failures alone reach the limit, the retry hint is the time
+    until the oldest failure ages out (close to the full window).
+    """
+    limiter, _clock = _make(max_attempts=3, window_seconds=300)
+    key = "1.2.3.4:admin"
+
+    for _ in range(3):
+        _fail(limiter, key)  # 3 confirmed failures == max
+
+    retry_after = limiter.retry_after(key)
+    assert retry_after is not None
+    assert retry_after > _PENDING_RETRY_AFTER_SECONDS
+    assert 299 <= retry_after <= 300
 
 
 def test_tracked_keys_are_bounded():

--- a/tests/api/auth/test_login_rate_limit.py
+++ b/tests/api/auth/test_login_rate_limit.py
@@ -1,6 +1,16 @@
 """Unit tests for LoginRateLimiter (brute-force protection, CWE-307)."""
 
+from types import SimpleNamespace
+
+import lightrag.api.login_rate_limit as lrl_module
 from lightrag.api.login_rate_limit import LoginRateLimiter
+
+
+def _capture_warnings(monkeypatch):
+    """Redirect the module logger's WARNING output into a list for assertions."""
+    messages: list[str] = []
+    monkeypatch.setattr(lrl_module, "logger", SimpleNamespace(warning=messages.append))
+    return messages
 
 
 class _FakeClock:
@@ -145,3 +155,55 @@ def test_active_lockout_survives_flood_of_unique_keys():
 
     assert limiter.retry_after(admin) is not None  # lockout preserved
     assert len(limiter._failures) <= 3  # still bounded
+
+
+def test_lockout_emits_warning(monkeypatch):
+    messages = _capture_warnings(monkeypatch)
+    limiter, _clock = _make(max_attempts=2, window_seconds=300)
+    key = "1.2.3.4:admin"
+
+    limiter.record_failure(key)
+    assert messages == []  # one failure -> not yet locked, no alert
+
+    limiter.record_failure(key)  # trips the lockout
+    assert len(messages) == 1
+    assert "tripped" in messages[0]
+    assert key in messages[0]
+
+
+def test_lockout_alerts_are_throttled_with_suppressed_count(monkeypatch):
+    """A burst of lockouts must not flood the log: only one WARNING per interval,
+    with the suppressed count reported on the next emitted line.
+    """
+    messages = _capture_warnings(monkeypatch)
+    clock = _FakeClock()
+    limiter = LoginRateLimiter(
+        max_attempts=1, window_seconds=300, clock=clock, alert_interval_seconds=60
+    )
+
+    for i in range(5):  # each distinct key locks on its first failure
+        limiter.record_failure(f"10.0.0.{i}:admin")
+    assert len(messages) == 1  # first emitted; the other 4 suppressed
+
+    clock.advance(61)  # interval elapsed
+    limiter.record_failure("10.0.0.9:admin")
+    assert len(messages) == 2
+    assert "4 more since last alert" in messages[1]
+
+
+def test_table_full_emits_throttled_warning(monkeypatch):
+    messages = _capture_warnings(monkeypatch)
+    clock = _FakeClock()
+    limiter = LoginRateLimiter(
+        max_attempts=5, window_seconds=300, clock=clock, max_tracked_keys=1
+    )
+
+    limiter.record_failure("a")  # fills the table, not locked (max_attempts=5)
+    assert messages == []
+
+    limiter.record_failure("b")  # table full of live keys -> refuse + warn
+    assert len(messages) == 1
+    assert "table is full" in messages[0]
+
+    limiter.record_failure("c")  # still full, within interval -> suppressed
+    assert len(messages) == 1

--- a/tests/api/auth/test_login_rate_limit.py
+++ b/tests/api/auth/test_login_rate_limit.py
@@ -92,3 +92,38 @@ def test_keys_are_independent():
 
     assert limiter.retry_after(admin) is not None  # admin locked
     assert limiter.retry_after(bob) is None  # different key, own bucket
+
+
+def test_tracked_keys_are_bounded_by_lru_eviction():
+    """A flood of unique keys must not grow the map without bound; the oldest
+    (least-recently-active) keys are evicted so memory stays capped.
+    """
+    clock = _FakeClock()
+    limiter = LoginRateLimiter(
+        max_attempts=5, window_seconds=300, clock=clock, max_tracked_keys=3
+    )
+
+    for i in range(10):
+        limiter.record_failure(f"10.0.0.{i}:admin")
+
+    assert len(limiter._failures) <= 3
+    assert "10.0.0.9:admin" in limiter._failures  # most recent retained
+    assert "10.0.0.0:admin" not in limiter._failures  # oldest evicted
+
+
+def test_active_key_survives_a_flood_of_unique_keys():
+    """A key that keeps failing stays most-recently-active and is not evicted by
+    a flood of one-off keys, so a real brute-force target keeps its counter.
+    """
+    clock = _FakeClock()
+    limiter = LoginRateLimiter(
+        max_attempts=5, window_seconds=300, clock=clock, max_tracked_keys=3
+    )
+    target = "1.2.3.4:admin"
+
+    for i in range(10):
+        limiter.record_failure(f"flood:{i}")
+        limiter.record_failure(target)  # touched every round -> stays hot
+
+    assert len(limiter._failures) <= 3
+    assert target in limiter._failures

--- a/tests/api/auth/test_login_rate_limit.py
+++ b/tests/api/auth/test_login_rate_limit.py
@@ -94,36 +94,54 @@ def test_keys_are_independent():
     assert limiter.retry_after(bob) is None  # different key, own bucket
 
 
-def test_tracked_keys_are_bounded_by_lru_eviction():
-    """A flood of unique keys must not grow the map without bound; the oldest
-    (least-recently-active) keys are evicted so memory stays capped.
-    """
+def test_tracked_keys_are_bounded():
+    """A flood of unique keys must not grow the map beyond the cap."""
     clock = _FakeClock()
     limiter = LoginRateLimiter(
         max_attempts=5, window_seconds=300, clock=clock, max_tracked_keys=3
     )
 
-    for i in range(10):
+    for i in range(100):
         limiter.record_failure(f"10.0.0.{i}:admin")
 
     assert len(limiter._failures) <= 3
-    assert "10.0.0.9:admin" in limiter._failures  # most recent retained
-    assert "10.0.0.0:admin" not in limiter._failures  # oldest evicted
 
 
-def test_active_key_survives_a_flood_of_unique_keys():
-    """A key that keeps failing stays most-recently-active and is not evicted by
-    a flood of one-off keys, so a real brute-force target keeps its counter.
+def test_expired_keys_are_reclaimed_for_new_keys():
+    """Once tracked keys age out of the window their slots are reclaimed, so new
+    keys can be tracked again after a full-but-stale table self-heals.
     """
     clock = _FakeClock()
     limiter = LoginRateLimiter(
-        max_attempts=5, window_seconds=300, clock=clock, max_tracked_keys=3
+        max_attempts=5, window_seconds=60, clock=clock, max_tracked_keys=2
     )
-    target = "1.2.3.4:admin"
+    limiter.record_failure("a")
+    limiter.record_failure("b")  # table full
+    assert len(limiter._failures) == 2
 
-    for i in range(10):
-        limiter.record_failure(f"flood:{i}")
-        limiter.record_failure(target)  # touched every round -> stays hot
+    clock.advance(61)  # "a" and "b" age out of the window
+    limiter.record_failure("c")  # expired slot reclaimed -> "c" is tracked
 
-    assert len(limiter._failures) <= 3
-    assert target in limiter._failures
+    assert "c" in limiter._failures
+    assert len(limiter._failures) <= 2
+
+
+def test_active_lockout_survives_flood_of_unique_keys():
+    """An in-window lockout must NOT be evicted to make room for new keys: an
+    attacker could otherwise lock 'admin', then flood the same IP with unique
+    fake usernames to push admin's record out and reset its counter.
+    """
+    clock = _FakeClock()
+    limiter = LoginRateLimiter(
+        max_attempts=2, window_seconds=300, clock=clock, max_tracked_keys=3
+    )
+    admin = "1.2.3.4:admin"
+    limiter.record_failure(admin)
+    limiter.record_failure(admin)  # admin now locked, in-window
+    assert limiter.retry_after(admin) is not None
+
+    for i in range(100):  # flood unique usernames from the same IP
+        limiter.record_failure(f"1.2.3.4:user{i}")
+
+    assert limiter.retry_after(admin) is not None  # lockout preserved
+    assert len(limiter._failures) <= 3  # still bounded

--- a/tests/api/auth/test_login_rate_limit.py
+++ b/tests/api/auth/test_login_rate_limit.py
@@ -1,0 +1,94 @@
+"""Unit tests for LoginRateLimiter (brute-force protection, CWE-307)."""
+
+from lightrag.api.login_rate_limit import LoginRateLimiter
+
+
+class _FakeClock:
+    """Deterministic monotonic clock so window behavior is testable without sleep."""
+
+    def __init__(self, start: float = 1000.0):
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _make(max_attempts=3, window_seconds=60.0):
+    clock = _FakeClock()
+    return LoginRateLimiter(max_attempts, window_seconds, clock=clock), clock
+
+
+def test_allows_up_to_max_then_locks():
+    limiter, _clock = _make(max_attempts=3, window_seconds=60)
+    key = "1.2.3.4:admin"
+
+    for _ in range(3):
+        assert limiter.retry_after(key) is None
+        limiter.record_failure(key)
+
+    retry_after = limiter.retry_after(key)
+    assert retry_after is not None
+    assert 0 < retry_after <= 60
+
+
+def test_reset_clears_failures():
+    limiter, _clock = _make(max_attempts=3, window_seconds=60)
+    key = "1.2.3.4:admin"
+
+    for _ in range(3):
+        limiter.record_failure(key)
+    assert limiter.retry_after(key) is not None
+
+    limiter.reset(key)
+    assert limiter.retry_after(key) is None
+
+
+def test_window_expiry_allows_again_and_prunes():
+    limiter, clock = _make(max_attempts=3, window_seconds=60)
+    key = "1.2.3.4:admin"
+
+    for _ in range(3):
+        limiter.record_failure(key)
+    assert limiter.retry_after(key) is not None
+
+    clock.advance(61)  # every recorded failure ages out of the window
+    assert limiter.retry_after(key) is None
+    # The key is dropped once nothing is in-window (bounded memory).
+    assert key not in limiter._failures
+
+
+def test_retry_after_counts_down_as_window_passes():
+    limiter, clock = _make(max_attempts=2, window_seconds=60)
+    key = "1.2.3.4:admin"
+
+    limiter.record_failure(key)  # t = 1000
+    clock.advance(10)
+    limiter.record_failure(key)  # t = 1010, now locked (oldest at 1000)
+
+    retry_after = limiter.retry_after(key)  # 60 - (1010 - 1000) = 50
+    assert 49 <= retry_after <= 50
+
+
+def test_disabled_when_max_attempts_zero():
+    limiter, _clock = _make(max_attempts=0, window_seconds=60)
+    assert not limiter.enabled
+    key = "1.2.3.4:admin"
+
+    for _ in range(10):
+        limiter.record_failure(key)
+    assert limiter.retry_after(key) is None
+
+
+def test_keys_are_independent():
+    limiter, _clock = _make(max_attempts=2, window_seconds=60)
+    admin = "1.2.3.4:admin"
+    bob = "1.2.3.4:bob"
+
+    for _ in range(2):
+        limiter.record_failure(admin)
+
+    assert limiter.retry_after(admin) is not None  # admin locked
+    assert limiter.retry_after(bob) is None  # different key, own bucket

--- a/tests/api/auth/test_login_rate_limit.py
+++ b/tests/api/auth/test_login_rate_limit.py
@@ -26,15 +26,23 @@ class _FakeClock:
         self.now += seconds
 
 
-def _make(max_attempts=3, window_seconds=60.0):
+def _make(max_attempts=3, window_seconds=60.0, **kwargs):
     clock = _FakeClock()
-    return LoginRateLimiter(max_attempts, window_seconds, clock=clock), clock
+    return LoginRateLimiter(max_attempts, window_seconds, clock=clock, **kwargs), clock
 
 
 def _fail(limiter, key):
-    """Mirror the route: reserve the attempt, then confirm it as a failure."""
+    """One full failed-attempt lifecycle: reserve -> confirm failure -> release."""
     limiter.reserve_attempt(key)
     limiter.commit_failure(key)
+    limiter.release(key)
+
+
+def _succeed(limiter, key):
+    """One full successful-attempt lifecycle: reserve -> reset -> release."""
+    limiter.reserve_attempt(key)
+    limiter.reset(key)
+    limiter.release(key)
 
 
 def test_allows_up_to_max_then_locks():
@@ -43,7 +51,7 @@ def test_allows_up_to_max_then_locks():
 
     for _ in range(3):
         assert limiter.retry_after(key) is None
-        limiter.reserve_attempt(key)
+        _fail(limiter, key)
 
     retry_after = limiter.retry_after(key)
     assert retry_after is not None
@@ -55,7 +63,7 @@ def test_reset_clears_failures():
     key = "1.2.3.4:admin"
 
     for _ in range(3):
-        limiter.reserve_attempt(key)
+        _fail(limiter, key)
     assert limiter.retry_after(key) is not None
 
     limiter.reset(key)
@@ -67,22 +75,22 @@ def test_window_expiry_allows_again_and_prunes():
     key = "1.2.3.4:admin"
 
     for _ in range(3):
-        limiter.reserve_attempt(key)
+        _fail(limiter, key)
     assert limiter.retry_after(key) is not None
 
-    clock.advance(61)  # every recorded attempt ages out of the window
+    clock.advance(61)  # every confirmed failure ages out of the window
     assert limiter.retry_after(key) is None
     # The key is dropped once nothing is in-window (bounded memory).
-    assert key not in limiter._failures
+    assert key not in limiter._entries
 
 
 def test_retry_after_counts_down_as_window_passes():
     limiter, clock = _make(max_attempts=2, window_seconds=60)
     key = "1.2.3.4:admin"
 
-    limiter.reserve_attempt(key)  # t = 1000
+    _fail(limiter, key)  # t = 1000
     clock.advance(10)
-    limiter.reserve_attempt(key)  # t = 1010, now locked (oldest at 1000)
+    _fail(limiter, key)  # t = 1010, now locked (oldest failure at 1000)
 
     retry_after = limiter.retry_after(key)  # 60 - (1010 - 1000) = 50
     assert 49 <= retry_after <= 50
@@ -94,7 +102,7 @@ def test_disabled_when_max_attempts_zero():
     key = "1.2.3.4:admin"
 
     for _ in range(10):
-        limiter.reserve_attempt(key)
+        _fail(limiter, key)
     assert limiter.retry_after(key) is None
 
 
@@ -104,42 +112,47 @@ def test_keys_are_independent():
     bob = "1.2.3.4:bob"
 
     for _ in range(2):
-        limiter.reserve_attempt(admin)
+        _fail(limiter, admin)
 
     assert limiter.retry_after(admin) is not None  # admin locked
     assert limiter.retry_after(bob) is None  # different key, own bucket
 
 
+def test_pending_reservations_block_without_confirmed_failures():
+    """In-flight reservations alone must block (concurrency guard), even before
+    any result is confirmed.
+    """
+    limiter, _clock = _make(max_attempts=2, window_seconds=300)
+    key = "1.2.3.4:admin"
+
+    limiter.reserve_attempt(key)
+    limiter.reserve_attempt(key)  # 2 in-flight, none resolved yet
+
+    assert limiter.retry_after(key) is not None  # blocked by pending
+
+
 def test_tracked_keys_are_bounded():
     """A flood of unique keys must not grow the map beyond the cap."""
-    clock = _FakeClock()
-    limiter = LoginRateLimiter(
-        max_attempts=5, window_seconds=300, clock=clock, max_tracked_keys=3
-    )
+    limiter, _clock = _make(max_attempts=5, window_seconds=300, max_tracked_keys=3)
 
     for i in range(100):
-        limiter.reserve_attempt(f"10.0.0.{i}:admin")
+        _fail(limiter, f"10.0.0.{i}:admin")
 
-    assert len(limiter._failures) <= 3
+    assert len(limiter._entries) <= 3
 
 
 def test_expired_keys_are_reclaimed_for_new_keys():
-    """Once tracked keys age out of the window their slots are reclaimed, so new
-    keys can be tracked again after a full-but-stale table self-heals.
-    """
-    clock = _FakeClock()
-    limiter = LoginRateLimiter(
-        max_attempts=5, window_seconds=60, clock=clock, max_tracked_keys=2
-    )
-    limiter.reserve_attempt("a")
-    limiter.reserve_attempt("b")  # table full
-    assert len(limiter._failures) == 2
+    """Once tracked keys age out of the window their slots are reclaimed."""
+    limiter, clock = _make(max_attempts=5, window_seconds=60, max_tracked_keys=2)
+    _fail(limiter, "a")
+    _fail(limiter, "b")  # table full
+    assert len(limiter._entries) == 2
 
     clock.advance(61)  # "a" and "b" age out of the window
-    limiter.reserve_attempt("c")  # expired slot reclaimed -> "c" is tracked
+    _fail(limiter, "c")  # expired slot reclaimed -> "c" is tracked
 
-    assert "c" in limiter._failures
-    assert len(limiter._failures) <= 2
+    assert "c" in limiter._entries
+    assert len(limiter._entries) <= 2
 
 
 def test_active_lockout_survives_flood_of_unique_keys():
@@ -147,54 +160,80 @@ def test_active_lockout_survives_flood_of_unique_keys():
     attacker could otherwise lock 'admin', then flood the same IP with unique
     fake usernames to push admin's record out and reset its counter.
     """
-    clock = _FakeClock()
-    limiter = LoginRateLimiter(
-        max_attempts=2, window_seconds=300, clock=clock, max_tracked_keys=3
-    )
+    limiter, _clock = _make(max_attempts=2, window_seconds=300, max_tracked_keys=3)
     admin = "1.2.3.4:admin"
-    limiter.reserve_attempt(admin)
-    limiter.reserve_attempt(admin)  # admin now locked, in-window
+    _fail(limiter, admin)
+    _fail(limiter, admin)  # admin now locked, in-window
     assert limiter.retry_after(admin) is not None
 
     for i in range(100):  # flood unique usernames from the same IP
-        limiter.reserve_attempt(f"1.2.3.4:user{i}")
+        _fail(limiter, f"1.2.3.4:user{i}")
 
     assert limiter.retry_after(admin) is not None  # lockout preserved
-    assert len(limiter._failures) <= 3  # still bounded
+    assert len(limiter._entries) <= 3  # still bounded
 
 
-def test_reserve_does_not_alert_but_commit_does(monkeypatch):
-    """The lockout alert must fire only after a *confirmed* failure, not at
-    reservation time -- otherwise a correct password on the Nth attempt (which
-    reserves, verifies OK, then resets) would emit a false lockout alert.
+def test_reservation_alone_never_alerts(monkeypatch):
+    """Reserving (and succeeding) must never emit a lockout alert, even when the
+    reservation count reaches the limit -- only confirmed failures can.
     """
     messages = _capture_warnings(monkeypatch)
     limiter, _clock = _make(max_attempts=2, window_seconds=300)
     key = "1.2.3.4:admin"
 
-    # Four earlier failures would be reserved+committed; here simulate reaching
-    # the limit purely by reservation and then succeeding.
-    limiter.reserve_attempt(key)  # 1st reservation, no alert
-    limiter.reserve_attempt(key)  # 2nd reservation reaches the limit, still no alert
-    assert messages == []  # reservation alone never alerts
+    limiter.reserve_attempt(key)
+    limiter.reserve_attempt(key)  # count reaches the limit purely by reservation
+    assert messages == []
 
-    limiter.reset(key)  # success clears everything
+    limiter.reset(key)
+    limiter.release(key)
+    limiter.release(key)
     assert messages == []
     assert limiter.retry_after(key) is None
 
 
-def test_lockout_alert_emitted_on_confirmed_failure(monkeypatch):
+def test_concurrent_mixed_results_do_not_false_alert(monkeypatch):
+    """Five concurrent attempts, one wrong and four correct, must NOT log a
+    lockout: only one attempt is a real failure. Regression for the deque that
+    conflated in-flight reservations with confirmed failures.
+    """
     messages = _capture_warnings(monkeypatch)
-    limiter, _clock = _make(max_attempts=2, window_seconds=300)
+    limiter, _clock = _make(max_attempts=5, window_seconds=300)
     key = "1.2.3.4:admin"
 
-    _fail(limiter, key)  # confirmed failure #1 -> not yet locked
-    assert messages == []
+    for _ in range(5):  # 5 requests reserve before any bcrypt resolves
+        limiter.reserve_attempt(key)
+    assert limiter.retry_after(key) is not None  # gate blocks a 6th (pending)
 
-    _fail(limiter, key)  # confirmed failure #2 -> trips the lockout
-    assert len(messages) == 1
-    assert "tripped" in messages[0]
-    assert key in messages[0]
+    limiter.commit_failure(key)  # A: wrong password
+    limiter.release(key)
+    for _ in range(4):  # B-E: correct password
+        limiter.reset(key)
+        limiter.release(key)
+
+    assert messages == []  # only one real failure -> no false lockout alert
+    assert limiter.retry_after(key) is None  # not locked
+
+
+def test_concurrent_all_failures_alert_exactly_once(monkeypatch):
+    """When all concurrent attempts are genuine failures, the lockout alert is
+    logged exactly once (not once per resolving request).
+    """
+    messages = _capture_warnings(monkeypatch)
+    # alert_interval_seconds=0 disables throttle collapsing, so a per-commit
+    # alert bug would show as multiple messages.
+    limiter, _clock = _make(
+        max_attempts=5, window_seconds=300, alert_interval_seconds=0
+    )
+    key = "1.2.3.4:admin"
+
+    for _ in range(5):
+        limiter.reserve_attempt(key)
+    for _ in range(5):
+        limiter.commit_failure(key)
+        limiter.release(key)
+
+    assert len(messages) == 1  # exactly one lockout alert
 
 
 def test_lockout_alerts_are_throttled_with_suppressed_count(monkeypatch):
@@ -202,9 +241,8 @@ def test_lockout_alerts_are_throttled_with_suppressed_count(monkeypatch):
     with the suppressed count reported on the next emitted line.
     """
     messages = _capture_warnings(monkeypatch)
-    clock = _FakeClock()
-    limiter = LoginRateLimiter(
-        max_attempts=1, window_seconds=300, clock=clock, alert_interval_seconds=60
+    limiter, clock = _make(
+        max_attempts=1, window_seconds=300, alert_interval_seconds=60
     )
 
     for i in range(5):  # each distinct key locks on its first confirmed failure
@@ -219,12 +257,9 @@ def test_lockout_alerts_are_throttled_with_suppressed_count(monkeypatch):
 
 def test_table_full_emits_throttled_warning(monkeypatch):
     messages = _capture_warnings(monkeypatch)
-    clock = _FakeClock()
-    limiter = LoginRateLimiter(
-        max_attempts=5, window_seconds=300, clock=clock, max_tracked_keys=1
-    )
+    limiter, _clock = _make(max_attempts=5, window_seconds=300, max_tracked_keys=1)
 
-    limiter.reserve_attempt("a")  # fills the table, not locked (max_attempts=5)
+    _fail(limiter, "a")  # fills the table (not locked; max_attempts=5)
     assert messages == []
 
     limiter.reserve_attempt("b")  # table full of live keys -> refuse + warn

--- a/tests/api/auth/test_login_rate_limit.py
+++ b/tests/api/auth/test_login_rate_limit.py
@@ -3,7 +3,7 @@
 from types import SimpleNamespace
 
 import lightrag.api.login_rate_limit as lrl_module
-from lightrag.api.login_rate_limit import LoginRateLimiter
+from lightrag.api.login_rate_limit import LoginRateLimiter, _safe_log_value
 
 
 def _capture_warnings(monkeypatch):
@@ -31,13 +31,19 @@ def _make(max_attempts=3, window_seconds=60.0):
     return LoginRateLimiter(max_attempts, window_seconds, clock=clock), clock
 
 
+def _fail(limiter, key):
+    """Mirror the route: reserve the attempt, then confirm it as a failure."""
+    limiter.reserve_attempt(key)
+    limiter.commit_failure(key)
+
+
 def test_allows_up_to_max_then_locks():
     limiter, _clock = _make(max_attempts=3, window_seconds=60)
     key = "1.2.3.4:admin"
 
     for _ in range(3):
         assert limiter.retry_after(key) is None
-        limiter.record_failure(key)
+        limiter.reserve_attempt(key)
 
     retry_after = limiter.retry_after(key)
     assert retry_after is not None
@@ -49,7 +55,7 @@ def test_reset_clears_failures():
     key = "1.2.3.4:admin"
 
     for _ in range(3):
-        limiter.record_failure(key)
+        limiter.reserve_attempt(key)
     assert limiter.retry_after(key) is not None
 
     limiter.reset(key)
@@ -61,10 +67,10 @@ def test_window_expiry_allows_again_and_prunes():
     key = "1.2.3.4:admin"
 
     for _ in range(3):
-        limiter.record_failure(key)
+        limiter.reserve_attempt(key)
     assert limiter.retry_after(key) is not None
 
-    clock.advance(61)  # every recorded failure ages out of the window
+    clock.advance(61)  # every recorded attempt ages out of the window
     assert limiter.retry_after(key) is None
     # The key is dropped once nothing is in-window (bounded memory).
     assert key not in limiter._failures
@@ -74,9 +80,9 @@ def test_retry_after_counts_down_as_window_passes():
     limiter, clock = _make(max_attempts=2, window_seconds=60)
     key = "1.2.3.4:admin"
 
-    limiter.record_failure(key)  # t = 1000
+    limiter.reserve_attempt(key)  # t = 1000
     clock.advance(10)
-    limiter.record_failure(key)  # t = 1010, now locked (oldest at 1000)
+    limiter.reserve_attempt(key)  # t = 1010, now locked (oldest at 1000)
 
     retry_after = limiter.retry_after(key)  # 60 - (1010 - 1000) = 50
     assert 49 <= retry_after <= 50
@@ -88,7 +94,7 @@ def test_disabled_when_max_attempts_zero():
     key = "1.2.3.4:admin"
 
     for _ in range(10):
-        limiter.record_failure(key)
+        limiter.reserve_attempt(key)
     assert limiter.retry_after(key) is None
 
 
@@ -98,7 +104,7 @@ def test_keys_are_independent():
     bob = "1.2.3.4:bob"
 
     for _ in range(2):
-        limiter.record_failure(admin)
+        limiter.reserve_attempt(admin)
 
     assert limiter.retry_after(admin) is not None  # admin locked
     assert limiter.retry_after(bob) is None  # different key, own bucket
@@ -112,7 +118,7 @@ def test_tracked_keys_are_bounded():
     )
 
     for i in range(100):
-        limiter.record_failure(f"10.0.0.{i}:admin")
+        limiter.reserve_attempt(f"10.0.0.{i}:admin")
 
     assert len(limiter._failures) <= 3
 
@@ -125,12 +131,12 @@ def test_expired_keys_are_reclaimed_for_new_keys():
     limiter = LoginRateLimiter(
         max_attempts=5, window_seconds=60, clock=clock, max_tracked_keys=2
     )
-    limiter.record_failure("a")
-    limiter.record_failure("b")  # table full
+    limiter.reserve_attempt("a")
+    limiter.reserve_attempt("b")  # table full
     assert len(limiter._failures) == 2
 
     clock.advance(61)  # "a" and "b" age out of the window
-    limiter.record_failure("c")  # expired slot reclaimed -> "c" is tracked
+    limiter.reserve_attempt("c")  # expired slot reclaimed -> "c" is tracked
 
     assert "c" in limiter._failures
     assert len(limiter._failures) <= 2
@@ -146,26 +152,46 @@ def test_active_lockout_survives_flood_of_unique_keys():
         max_attempts=2, window_seconds=300, clock=clock, max_tracked_keys=3
     )
     admin = "1.2.3.4:admin"
-    limiter.record_failure(admin)
-    limiter.record_failure(admin)  # admin now locked, in-window
+    limiter.reserve_attempt(admin)
+    limiter.reserve_attempt(admin)  # admin now locked, in-window
     assert limiter.retry_after(admin) is not None
 
     for i in range(100):  # flood unique usernames from the same IP
-        limiter.record_failure(f"1.2.3.4:user{i}")
+        limiter.reserve_attempt(f"1.2.3.4:user{i}")
 
     assert limiter.retry_after(admin) is not None  # lockout preserved
     assert len(limiter._failures) <= 3  # still bounded
 
 
-def test_lockout_emits_warning(monkeypatch):
+def test_reserve_does_not_alert_but_commit_does(monkeypatch):
+    """The lockout alert must fire only after a *confirmed* failure, not at
+    reservation time -- otherwise a correct password on the Nth attempt (which
+    reserves, verifies OK, then resets) would emit a false lockout alert.
+    """
     messages = _capture_warnings(monkeypatch)
     limiter, _clock = _make(max_attempts=2, window_seconds=300)
     key = "1.2.3.4:admin"
 
-    limiter.record_failure(key)
-    assert messages == []  # one failure -> not yet locked, no alert
+    # Four earlier failures would be reserved+committed; here simulate reaching
+    # the limit purely by reservation and then succeeding.
+    limiter.reserve_attempt(key)  # 1st reservation, no alert
+    limiter.reserve_attempt(key)  # 2nd reservation reaches the limit, still no alert
+    assert messages == []  # reservation alone never alerts
 
-    limiter.record_failure(key)  # trips the lockout
+    limiter.reset(key)  # success clears everything
+    assert messages == []
+    assert limiter.retry_after(key) is None
+
+
+def test_lockout_alert_emitted_on_confirmed_failure(monkeypatch):
+    messages = _capture_warnings(monkeypatch)
+    limiter, _clock = _make(max_attempts=2, window_seconds=300)
+    key = "1.2.3.4:admin"
+
+    _fail(limiter, key)  # confirmed failure #1 -> not yet locked
+    assert messages == []
+
+    _fail(limiter, key)  # confirmed failure #2 -> trips the lockout
     assert len(messages) == 1
     assert "tripped" in messages[0]
     assert key in messages[0]
@@ -181,12 +207,12 @@ def test_lockout_alerts_are_throttled_with_suppressed_count(monkeypatch):
         max_attempts=1, window_seconds=300, clock=clock, alert_interval_seconds=60
     )
 
-    for i in range(5):  # each distinct key locks on its first failure
-        limiter.record_failure(f"10.0.0.{i}:admin")
+    for i in range(5):  # each distinct key locks on its first confirmed failure
+        _fail(limiter, f"10.0.0.{i}:admin")
     assert len(messages) == 1  # first emitted; the other 4 suppressed
 
     clock.advance(61)  # interval elapsed
-    limiter.record_failure("10.0.0.9:admin")
+    _fail(limiter, "10.0.0.9:admin")
     assert len(messages) == 2
     assert "4 more since last alert" in messages[1]
 
@@ -198,12 +224,35 @@ def test_table_full_emits_throttled_warning(monkeypatch):
         max_attempts=5, window_seconds=300, clock=clock, max_tracked_keys=1
     )
 
-    limiter.record_failure("a")  # fills the table, not locked (max_attempts=5)
+    limiter.reserve_attempt("a")  # fills the table, not locked (max_attempts=5)
     assert messages == []
 
-    limiter.record_failure("b")  # table full of live keys -> refuse + warn
+    limiter.reserve_attempt("b")  # table full of live keys -> refuse + warn
     assert len(messages) == 1
     assert "table is full" in messages[0]
 
-    limiter.record_failure("c")  # still full, within interval -> suppressed
+    limiter.reserve_attempt("c")  # still full, within interval -> suppressed
     assert len(messages) == 1
+
+
+def test_lockout_alert_sanitizes_injected_username(monkeypatch):
+    """An attacker-supplied username must not forge extra log lines (CRLF log
+    injection) via the alert message.
+    """
+    messages = _capture_warnings(monkeypatch)
+    limiter, _clock = _make(max_attempts=1, window_seconds=300)
+    key = "127.0.0.1:admin\nCRITICAL forged second line"
+
+    _fail(limiter, key)
+
+    assert len(messages) == 1
+    assert "\n" not in messages[0]  # newline neutralized -> no injected line
+    assert "admin?CRITICAL" in messages[0]  # control char replaced with '?'
+
+
+def test_safe_log_value_strips_control_chars_and_truncates():
+    assert _safe_log_value("a\r\nb") == "a??b"
+
+    long = _safe_log_value("x" * 500, max_length=100)
+    assert long.startswith("x" * 100)
+    assert "truncated" in long

--- a/tests/api/auth/test_login_rate_limit.py
+++ b/tests/api/auth/test_login_rate_limit.py
@@ -173,6 +173,25 @@ def test_active_lockout_survives_flood_of_unique_keys():
     assert len(limiter._entries) <= 3  # still bounded
 
 
+def test_successful_login_frees_its_slot(monkeypatch):
+    """A successful login must not leave a dead (empty) entry occupying a slot.
+
+    Regression: previously reset() cleared the failures but kept the entry, so
+    with the table at capacity a prior success sitting behind a live lockout
+    made _make_room falsely report 'table full' and refuse a new key.
+    """
+    messages = _capture_warnings(monkeypatch)
+    limiter, _clock = _make(max_attempts=3, window_seconds=300, max_tracked_keys=2)
+
+    _fail(limiter, "1.1.1.1:a")  # A: live lockout candidate (stays at the front)
+    _succeed(limiter, "2.2.2.2:b")  # B: success -> entry removed, slot freed
+    assert "2.2.2.2:b" not in limiter._entries
+
+    _fail(limiter, "3.3.3.3:c")  # C must still be trackable
+    assert "3.3.3.3:c" in limiter._entries
+    assert not any("table is full" in m for m in messages)
+
+
 def test_reservation_alone_never_alerts(monkeypatch):
     """Reserving (and succeeding) must never emit a lockout alert, even when the
     reservation count reaches the limit -- only confirmed failures can.

--- a/tests/api/routes/test_login_route.py
+++ b/tests/api/routes/test_login_route.py
@@ -180,3 +180,84 @@ def test_login_offloads_verification_to_thread(monkeypatch):
 
     assert resp.status_code == 200
     assert "verify_password" in offloaded
+
+
+def test_login_locks_out_after_max_failed_attempts(monkeypatch):
+    monkeypatch.setenv("LOGIN_MAX_FAILED_ATTEMPTS", "3")
+    monkeypatch.setenv("LOGIN_LOCKOUT_WINDOW_SECONDS", "300")
+    _server, client = _client_with_account(monkeypatch)
+
+    for _ in range(3):
+        resp = client.post("/login", data={"username": "admin", "password": "bad"})
+        assert resp.status_code == 401
+
+    locked = client.post("/login", data={"username": "admin", "password": "bad"})
+    assert locked.status_code == 429
+    assert int(locked.headers["Retry-After"]) >= 1
+
+
+def test_login_lockout_returns_429_without_bcrypt(monkeypatch):
+    """A locked-out attempt must be rejected before the bcrypt verification, so
+    lockout also caps the CPU/DoS cost of a login flood.
+    """
+    monkeypatch.setenv("LOGIN_MAX_FAILED_ATTEMPTS", "2")
+    lightrag_server, app = _build_server(monkeypatch)
+    monkeypatch.setattr(
+        lightrag_server.auth_handler, "accounts", {"admin": "s3cret-plain"}
+    )
+
+    verify_calls = []
+    real_to_thread = asyncio.to_thread
+
+    async def spy(func, *args, **kwargs):
+        verify_calls.append(getattr(func, "__name__", func))
+        return await real_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(lightrag_server.asyncio, "to_thread", spy)
+
+    client = TestClient(app)
+    for _ in range(2):
+        client.post("/login", data={"username": "admin", "password": "bad"})
+    calls_before_lockout = len(verify_calls)
+
+    resp = client.post("/login", data={"username": "admin", "password": "bad"})
+    assert resp.status_code == 429
+    assert len(verify_calls) == calls_before_lockout  # no bcrypt on the locked call
+
+
+def test_login_success_resets_lockout(monkeypatch):
+    """A successful login clears the failure counter. With max=2, the sequence
+    fail, success, fail, fail must stay 401 throughout; without the reset the
+    last attempt would be 429.
+    """
+    monkeypatch.setenv("LOGIN_MAX_FAILED_ATTEMPTS", "2")
+    _server, client = _client_with_account(monkeypatch)
+
+    def status(password):
+        return client.post(
+            "/login", data={"username": "admin", "password": password}
+        ).status_code
+
+    assert status("bad") == 401
+    assert status("s3cret-plain") == 200  # resets the counter
+    assert status("bad") == 401
+    assert status("bad") == 401  # would be 429 if the success had not reset
+
+
+def test_login_lockout_is_per_username(monkeypatch):
+    """Locking one username must not lock a different one from the same IP."""
+    monkeypatch.setenv("LOGIN_MAX_FAILED_ATTEMPTS", "2")
+    _server, client = _client_with_account(monkeypatch)  # only "admin" configured
+
+    for _ in range(2):
+        client.post("/login", data={"username": "admin", "password": "bad"})
+    assert (
+        client.post("/login", data={"username": "admin", "password": "bad"}).status_code
+        == 429
+    )
+
+    # A different username has its own bucket and is still only rejected as 401.
+    assert (
+        client.post("/login", data={"username": "bob", "password": "bad"}).status_code
+        == 401
+    )

--- a/tests/api/routes/test_login_route.py
+++ b/tests/api/routes/test_login_route.py
@@ -14,6 +14,7 @@ import asyncio
 import sys
 from unittest.mock import AsyncMock
 
+import httpx
 import pytest
 from fastapi import APIRouter
 from fastapi.testclient import TestClient
@@ -261,3 +262,31 @@ def test_login_lockout_is_per_username(monkeypatch):
         client.post("/login", data={"username": "bob", "password": "bad"}).status_code
         == 401
     )
+
+
+async def test_login_concurrent_attempts_cannot_bypass_limit(monkeypatch):
+    """Many simultaneous wrong-password requests must not all slip past the
+    limiter while bcrypt is in flight (TOCTOU): at most max_attempts may reach
+    verification, the rest must be rejected with 429.
+    """
+    monkeypatch.setenv("LOGIN_MAX_FAILED_ATTEMPTS", "5")
+    lightrag_server, app = _build_server(monkeypatch)
+    monkeypatch.setattr(
+        lightrag_server.auth_handler, "accounts", {"admin": "s3cret-plain"}
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        responses = await asyncio.gather(
+            *(
+                client.post("/login", data={"username": "admin", "password": "bad"})
+                for _ in range(40)
+            )
+        )
+
+    codes = [r.status_code for r in responses]
+    # At most max_attempts guesses reach bcrypt (401); everyone else is locked
+    # out (429). Before the pre-reservation fix all 40 returned 401.
+    assert codes.count(401) <= 5
+    assert codes.count(429) >= 35
+    assert codes.count(401) + codes.count(429) == 40


### PR DESCRIPTION
> **Stacked on #3423** (base branch = `fix/constant-time-password-comparison`). Review/merge #3423 first; this PR then retargets to `main` automatically. The two touch the same `/login` route for consecutive advisories from the same reporter.

## Background

Security advisory [GHSA-frch-4w6v-q5xx](https://github.com/HKUDS/LightRAG/security/advisories/GHSA-frch-4w6v-q5xx) (CWE-307, **Critical / CVSS 9.1**) reports that `POST /login` has no rate limiting, lockout, or backoff. A network-reachable attacker can submit unlimited password guesses at full speed and brute-force any account, then gain full authenticated access. This also completes the "login rate limiting is still advisable" follow-up from #3423.

## Change

New `lightrag/api/login_rate_limit.py` — an in-process sliding-window `LoginRateLimiter`, wired into `/login`.

- **Key = client IP + username.** After `LOGIN_MAX_FAILED_ATTEMPTS` confirmed failures within `LOGIN_LOCKOUT_WINDOW_SECONDS` (defaults **5 / 300s**), further attempts return **HTTP 429** with a `Retry-After` header until the oldest in-window failure ages out. A successful login clears the key. `LOGIN_MAX_FAILED_ATTEMPTS=0` disables it.
- **Keyed on IP + username** so one attacker cannot lock out unrelated accounts sharing a proxy IP. `X-Forwarded-For` is deliberately **not** trusted (spoofable).

### Correctness details (each addresses a review finding)

- **Concurrency (TOCTOU).** bcrypt runs on a worker thread, so a naive check-then-record would let many simultaneous requests all pass the check before any recorded a failure. The route reserves the attempt **synchronously before** the `await` (`reserve_attempt`); check + reserve have no `await` between them, so at most `max_attempts` requests reach bcrypt, the rest get 429.
- **No false lockout alert.** Reservation ≠ failure. `commit_failure` (which emits the lockout alert) runs **only after a confirmed wrong password**; a correct password on the Nth attempt reserves, verifies OK, then `reset`s — no alert. (`reserve_attempt` / `commit_failure` / `reset` are separate.)
- **Bounded memory that never drops a live lockout.** The map is capped at `max_tracked_keys` (default 10k). At capacity it evicts **only keys whose failures have aged out**; an in-window record (possible active lockout) is never evicted — otherwise an attacker could lock `admin`, then flood unique fake usernames from one IP to push admin's record out and reset it. When every tracked key is in-window, a brand-new key is simply not tracked until a slot frees.
- **Checked before bcrypt**, so a locked key is rejected without paying the bcrypt cost (also bounds the login-flood CPU surface from #3423).

### Observability (throttled, injection-safe)

- `WARNING` on **lockout tripped** (once per lockout, on confirmed failure) and on **table full** (capacity exhausted by live keys → new pairs temporarily untracked, likely flood).
- Alerts are **throttled** to one per `alert_interval_seconds` (default 60s) per category; suppressed alerts are counted and summarized on the next line (`N more since last alert`), so attack traffic can't flood the log.
- The attacker-controlled username in the log message is sanitized (`_safe_log_value`: strip non-printable chars, truncate) to prevent CRLF log injection / oversized lines. The limiter's internal key stays raw, so counting is unaffected.

### Limitations (documented in code + env.example)

- **Per-process state.** Under uvicorn the server forces a single worker (exact). Under gunicorn with N workers the effective limit is `N × max_attempts` — still defeats wordlist brute force. Large-scale / distributed attacks (incl. a sustained flood that keeps the table full of live keys) are the job of an upstream reverse proxy / WAF, or a shared store (Redis) as a follow-up.
- `getattr` defaults keep `create_app` working for callers that build `args` programmatically (tests, embedding) without the new fields.

## Config

```env
# LOGIN_MAX_FAILED_ATTEMPTS=5        # 0 disables
# LOGIN_LOCKOUT_WINDOW_SECONDS=300
```

## Tests

`tests/api/auth/test_login_rate_limit.py` (unit, injectable clock, logger captured — no sleeps): lock/reset/window-expiry+prune; `Retry-After` countdown; disabled; key independence; **bounded memory**; **active lockout survives a unique-key flood**; **reserve does not alert, commit does**; lockout alert on confirmed failure; **alert throttling with suppressed count**; table-full alert; **CRLF/oversize log sanitization**.

`tests/api/routes/test_login_route.py` (endpoint): correct/wrong/unknown creds; bcrypt offloaded to a thread; lockout after max (429 + `Retry-After`); locked attempt does not invoke bcrypt; success resets; per-username lockout; **concurrent attempts cannot bypass the limit** (httpx AsyncClient).

Full `tests/api` + `tests/llm`: **539 passed, 14 skipped**. `ruff` format + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)