### PR TITLE
fix(parser): block IPv6-transition SSRF bypass of native-md image guard

### DIFF
--- a/lightrag/parser/markdown/parser.py
+++ b/lightrag/parser/markdown/parser.py
@@ -238,15 +238,66 @@ def _allowed_non_public_networks() -> list:
     return nets
 
 
+def _unwrap_embedded_ipv4(ip):
+    """Return the IPv4 embedded in an IPv6 transition wrapper so it is judged by
+    IPv4 rules; otherwise return ``ip`` unchanged.
+
+    ``ipaddress.is_global`` is evaluated on the literal address, and CPython
+    classifies several IPv6 wrappers that embed an *internal* IPv4 as globally
+    routable, so a bare ``is_global`` check passes them. On a host with
+    NAT64/DNS64 (or 6to4) routing the request is then delivered to the embedded
+    internal target (loopback / RFC1918 / cloud metadata). We therefore decode
+    the embedded IPv4 and classify by *that* before the ``is_global`` gate.
+
+    Handled wrappers: IPv4-mapped (``::ffff:0:0/96``), IPv4-compatible
+    (``::/96``, minus ``::``/``::1``), the NAT64 well-known prefix
+    (``64:ff9b::/96``, RFC 6052) and the RFC 8215 local-use prefix
+    (``64:ff9b:1::/48``), and 6to4 (``2002::/16``). A NAT64-wrapped *public*
+    IPv4 (e.g. ``64:ff9b::808:808`` = 8.8.8.8) still resolves to a global IPv4
+    and is left allowed; genuine native global IPv6 is returned untouched.
+
+    Boundary: a NAT64 deployment using a *custom*, globally-routable Network-
+    Specific Prefix (RFC 6052 permits any /32../96) is not recognised here — the
+    prefix is deployment-specific and indistinguishable from ordinary global
+    IPv6. Such operators should pin the download egress or use
+    ``NATIVE_MD_IMAGE_ALLOWED_NON_PUBLIC_CIDRS`` deliberately.
+    """
+    if ip.version != 6:
+        return ip
+    if ip.ipv4_mapped is not None:
+        return ip.ipv4_mapped
+    if getattr(ip, "sixtofour", None) is not None:
+        return ip.sixtofour
+    b = ip.packed
+    # IPv4-compatible ``::a.b.c.d`` (top 96 bits zero), excluding ``::`` and
+    # ``::1`` which are not IPv4 wrappers (and are non-global anyway).
+    if b[:12] == b"\x00" * 12 and b[12:] not in (
+        b"\x00\x00\x00\x00",
+        b"\x00\x00\x00\x01",
+    ):
+        return ip_address(b[12:])
+    # NAT64 well-known prefix ``64:ff9b::/96`` — IPv4 in the low 32 bits.
+    if b[:12] == b"\x00\x64\xff\x9b" + b"\x00" * 8:
+        return ip_address(b[12:])
+    # RFC 8215 local-use NAT64 ``64:ff9b:1::/48``.
+    if b[:6] == b"\x00\x64\xff\x9b\x00\x01":
+        return ip_address(b[12:])
+    return ip
+
+
 def _validated_addresses(host: str) -> list[str]:
     """Resolve ``host`` and return its addresses iff ALL are safe to fetch.
 
-    Default-deny: an address is accepted only when ``ip.is_global`` (so SSRF to
-    loopback / private / link-local / reserved / CGNAT ``100.64.0.0/10`` /
-    TEST-NET and any other non-globally-routable range is blocked) or it matches
-    the operator-configured ``NATIVE_MD_IMAGE_ALLOWED_NON_PUBLIC_CIDRS`` escape
-    hatch. Returns ``[]`` when resolution fails or *any* resolved address is
-    non-public — so a single poisoned A/AAAA record rejects the whole host.
+    Default-deny: an address is accepted only when it is globally routable (so
+    SSRF to loopback / private / link-local / reserved / CGNAT ``100.64.0.0/10``
+    / TEST-NET and any other non-globally-routable range is blocked) or it
+    matches the operator-configured ``NATIVE_MD_IMAGE_ALLOWED_NON_PUBLIC_CIDRS``
+    escape hatch. The ``is_global`` verdict is taken on the IPv4 embedded in any
+    IPv6 transition wrapper (see :func:`_unwrap_embedded_ipv4`) so a NAT64 /
+    6to4 / IPv4-compatible literal that wraps an internal IPv4 cannot smuggle
+    past the gate. Returns ``[]`` when resolution fails or *any* resolved
+    address is non-public — so a single poisoned A/AAAA record rejects the whole
+    host.
 
     The returned addresses are what the connection actually dials (see
     :class:`_GuardedHTTPConnection`): validating and connecting share one
@@ -265,7 +316,8 @@ def _validated_addresses(host: str) -> list[str]:
             ip = ip_address(addr)
         except ValueError:
             return []
-        if not (ip.is_global or any(ip in net for net in allow)):
+        judged = _unwrap_embedded_ipv4(ip)
+        if not (judged.is_global or any(ip in net for net in allow)):
             return []
         addrs.append(addr)
     return addrs

--- a/lightrag/parser/markdown/parser.py
+++ b/lightrag/parser/markdown/parser.py
@@ -238,6 +238,17 @@ def _allowed_non_public_networks() -> list:
     return nets
 
 
+# IPv6 blocks judged non-globally-routable regardless of the interpreter's
+# ``is_global`` table. RFC 8215's local-use NAT64 prefix ``64:ff9b:1::/48`` is
+# technology-agnostic — the embedded-IPv4 position within it is NOT guaranteed
+# (RFC 8215 §5), so we must not decode it by any fixed offset; IANA also marks
+# the whole /48 not-globally-reachable. We therefore default-deny the entire
+# block (older CPython, pre gh-113171, mis-classified it as global). An operator
+# who genuinely runs a local NAT64 there can still opt in via
+# ``NATIVE_MD_IMAGE_ALLOWED_NON_PUBLIC_CIDRS``.
+_FORCE_NON_GLOBAL_V6 = (ip_network("64:ff9b:1::/48"),)
+
+
 def _unwrap_embedded_ipv4(ip):
     """Return the IPv4 embedded in an IPv6 transition wrapper so it is judged by
     IPv4 rules; otherwise return ``ip`` unchanged.
@@ -249,12 +260,15 @@ def _unwrap_embedded_ipv4(ip):
     internal target (loopback / RFC1918 / cloud metadata). We therefore decode
     the embedded IPv4 and classify by *that* before the ``is_global`` gate.
 
-    Handled wrappers: IPv4-mapped (``::ffff:0:0/96``), IPv4-compatible
-    (``::/96``, minus ``::``/``::1``), the NAT64 well-known prefix
-    (``64:ff9b::/96``, RFC 6052) and the RFC 8215 local-use prefix
-    (``64:ff9b:1::/48``), and 6to4 (``2002::/16``). A NAT64-wrapped *public*
-    IPv4 (e.g. ``64:ff9b::808:808`` = 8.8.8.8) still resolves to a global IPv4
-    and is left allowed; genuine native global IPv6 is returned untouched.
+    Only wrappers whose embedded-IPv4 position is fixed by spec are decoded:
+    IPv4-mapped (``::ffff:0:0/96``), IPv4-compatible (``::/96``, minus
+    ``::``/``::1``), the NAT64 well-known prefix (``64:ff9b::/96``, RFC 6052
+    §2.2 — IPv4 in the low 32 bits) and 6to4 (``2002::/16``). A wrapper of a
+    *public* IPv4 (e.g. ``64:ff9b::808:808`` = 8.8.8.8) still resolves to a
+    global IPv4 and is left allowed; genuine native global IPv6 is returned
+    untouched. The RFC 8215 local-use prefix ``64:ff9b:1::/48`` is deliberately
+    NOT decoded here — its embedded-IPv4 position is not guaranteed, so it is
+    default-denied via :data:`_FORCE_NON_GLOBAL_V6` instead.
 
     Boundary: a NAT64 deployment using a *custom*, globally-routable Network-
     Specific Prefix (RFC 6052 permits any /32../96) is not recognised here — the
@@ -279,10 +293,21 @@ def _unwrap_embedded_ipv4(ip):
     # NAT64 well-known prefix ``64:ff9b::/96`` — IPv4 in the low 32 bits.
     if b[:12] == b"\x00\x64\xff\x9b" + b"\x00" * 8:
         return ip_address(b[12:])
-    # RFC 8215 local-use NAT64 ``64:ff9b:1::/48``.
-    if b[:6] == b"\x00\x64\xff\x9b\x00\x01":
-        return ip_address(b[12:])
     return ip
+
+
+def _is_globally_routable(ip) -> bool:
+    """True iff ``ip`` is safe to fetch (globally routable public address).
+
+    Takes the ``is_global`` verdict on the IPv4 embedded in any IPv6 transition
+    wrapper (see :func:`_unwrap_embedded_ipv4`) so a NAT64 / 6to4 /
+    IPv4-compatible literal that wraps an internal IPv4 is judged by that
+    internal IPv4. Blocks that are non-global irrespective of the interpreter's
+    classification are force-denied via :data:`_FORCE_NON_GLOBAL_V6`.
+    """
+    if ip.version == 6 and any(ip in net for net in _FORCE_NON_GLOBAL_V6):
+        return False
+    return _unwrap_embedded_ipv4(ip).is_global
 
 
 def _validated_addresses(host: str) -> list[str]:
@@ -292,8 +317,8 @@ def _validated_addresses(host: str) -> list[str]:
     SSRF to loopback / private / link-local / reserved / CGNAT ``100.64.0.0/10``
     / TEST-NET and any other non-globally-routable range is blocked) or it
     matches the operator-configured ``NATIVE_MD_IMAGE_ALLOWED_NON_PUBLIC_CIDRS``
-    escape hatch. The ``is_global`` verdict is taken on the IPv4 embedded in any
-    IPv6 transition wrapper (see :func:`_unwrap_embedded_ipv4`) so a NAT64 /
+    escape hatch. Global-routability is decided by :func:`_is_globally_routable`,
+    which judges the IPv4 embedded in any IPv6 transition wrapper so a NAT64 /
     6to4 / IPv4-compatible literal that wraps an internal IPv4 cannot smuggle
     past the gate. Returns ``[]`` when resolution fails or *any* resolved
     address is non-public — so a single poisoned A/AAAA record rejects the whole
@@ -316,8 +341,7 @@ def _validated_addresses(host: str) -> list[str]:
             ip = ip_address(addr)
         except ValueError:
             return []
-        judged = _unwrap_embedded_ipv4(ip)
-        if not (judged.is_global or any(ip in net for net in allow)):
+        if not (_is_globally_routable(ip) or any(ip in net for net in allow)):
             return []
         addrs.append(addr)
     return addrs

--- a/lightrag/parser/markdown/parser.py
+++ b/lightrag/parser/markdown/parser.py
@@ -243,11 +243,15 @@ def _allowed_non_public_networks() -> list:
 #   - ``64:ff9b:1::/48`` — RFC 8215 local-use NAT64. Technology-agnostic; the
 #     embedded-IPv4 position is not guaranteed (RFC 8215 §5), so a fixed-offset
 #     decode is itself bypassable. IANA marks the whole /48 not-globally-reachable.
-#   - ``2002::/16`` — 6to4 (deprecated, RFC 7526). IANA global-reachability N/A;
-#     CPython 3.13+ / the gh-113171 backports treat it as private.
+#   - ``2002::/16`` — 6to4. IANA marks its global-reachability N/A and CPython
+#     3.13+ / the gh-113171 backports treat the whole block as private, so a
+#     decode of the embedded IPv4 must not re-permit it. (RFC 7526 deprecated
+#     only the 6to4 *anycast relay* path, 192.88.99.0/24; basic unicast 6to4 and
+#     the 2002::/16 prefix itself are not deprecated — but the block is still not
+#     globally reachable.)
 # Both are default-denied as whole blocks, independent of the interpreter, so we
-# never decode past them. An operator who genuinely runs a local NAT64 / legacy
-# 6to4 there can still opt in via ``NATIVE_MD_IMAGE_ALLOWED_NON_PUBLIC_CIDRS``.
+# never decode past them. An operator who genuinely runs a local NAT64 / 6to4
+# there can still opt in via ``NATIVE_MD_IMAGE_ALLOWED_NON_PUBLIC_CIDRS``.
 _FORCE_NON_GLOBAL_V6 = (ip_network("64:ff9b:1::/48"), ip_network("2002::/16"))
 
 

--- a/lightrag/parser/markdown/parser.py
+++ b/lightrag/parser/markdown/parser.py
@@ -238,37 +238,38 @@ def _allowed_non_public_networks() -> list:
     return nets
 
 
-# IPv6 blocks judged non-globally-routable regardless of the interpreter's
-# ``is_global`` table. RFC 8215's local-use NAT64 prefix ``64:ff9b:1::/48`` is
-# technology-agnostic — the embedded-IPv4 position within it is NOT guaranteed
-# (RFC 8215 §5), so we must not decode it by any fixed offset; IANA also marks
-# the whole /48 not-globally-reachable. We therefore default-deny the entire
-# block (older CPython, pre gh-113171, mis-classified it as global). An operator
-# who genuinely runs a local NAT64 there can still opt in via
-# ``NATIVE_MD_IMAGE_ALLOWED_NON_PUBLIC_CIDRS``.
-_FORCE_NON_GLOBAL_V6 = (ip_network("64:ff9b:1::/48"),)
+# IPv6 blocks that older CPython (pre gh-113171) classified as globally routable
+# but that are not, and whose embedded-IPv4 position we must NOT trust:
+#   - ``64:ff9b:1::/48`` — RFC 8215 local-use NAT64. Technology-agnostic; the
+#     embedded-IPv4 position is not guaranteed (RFC 8215 §5), so a fixed-offset
+#     decode is itself bypassable. IANA marks the whole /48 not-globally-reachable.
+#   - ``2002::/16`` — 6to4 (deprecated, RFC 7526). IANA global-reachability N/A;
+#     CPython 3.13+ / the gh-113171 backports treat it as private.
+# Both are default-denied as whole blocks, independent of the interpreter, so we
+# never decode past them. An operator who genuinely runs a local NAT64 / legacy
+# 6to4 there can still opt in via ``NATIVE_MD_IMAGE_ALLOWED_NON_PUBLIC_CIDRS``.
+_FORCE_NON_GLOBAL_V6 = (ip_network("64:ff9b:1::/48"), ip_network("2002::/16"))
 
 
 def _unwrap_embedded_ipv4(ip):
     """Return the IPv4 embedded in an IPv6 transition wrapper so it is judged by
     IPv4 rules; otherwise return ``ip`` unchanged.
 
-    ``ipaddress.is_global`` is evaluated on the literal address, and CPython
-    classifies several IPv6 wrappers that embed an *internal* IPv4 as globally
-    routable, so a bare ``is_global`` check passes them. On a host with
-    NAT64/DNS64 (or 6to4) routing the request is then delivered to the embedded
-    internal target (loopback / RFC1918 / cloud metadata). We therefore decode
-    the embedded IPv4 and classify by *that* before the ``is_global`` gate.
+    Some IPv6 wrappers embed an internal IPv4 yet the *literal* is classified
+    globally routable, so a bare ``is_global`` check on the literal passes them.
+    On a host with NAT64/DNS64 routing the request is then delivered to the
+    embedded internal target (loopback / RFC1918 / cloud metadata). We therefore
+    decode the embedded IPv4 so the caller can *additionally* require it to be
+    global (see :func:`_is_globally_routable`).
 
     Only wrappers whose embedded-IPv4 position is fixed by spec are decoded:
     IPv4-mapped (``::ffff:0:0/96``), IPv4-compatible (``::/96``, minus
-    ``::``/``::1``), the NAT64 well-known prefix (``64:ff9b::/96``, RFC 6052
-    §2.2 — IPv4 in the low 32 bits) and 6to4 (``2002::/16``). A wrapper of a
-    *public* IPv4 (e.g. ``64:ff9b::808:808`` = 8.8.8.8) still resolves to a
-    global IPv4 and is left allowed; genuine native global IPv6 is returned
-    untouched. The RFC 8215 local-use prefix ``64:ff9b:1::/48`` is deliberately
-    NOT decoded here — its embedded-IPv4 position is not guaranteed, so it is
-    default-denied via :data:`_FORCE_NON_GLOBAL_V6` instead.
+    ``::``/``::1``), and the NAT64 well-known prefix (``64:ff9b::/96``, RFC 6052
+    §2.2 — IPv4 in the low 32 bits). 6to4 (``2002::/16``) and the RFC 8215
+    local-use NAT64 prefix (``64:ff9b:1::/48``) are deliberately NOT decoded
+    here — they are default-denied as whole blocks via
+    :data:`_FORCE_NON_GLOBAL_V6` (the /48's embedded-IPv4 position is not
+    guaranteed, and both are non-globally-reachable per IANA).
 
     Boundary: a NAT64 deployment using a *custom*, globally-routable Network-
     Specific Prefix (RFC 6052 permits any /32../96) is not recognised here — the
@@ -280,8 +281,6 @@ def _unwrap_embedded_ipv4(ip):
         return ip
     if ip.ipv4_mapped is not None:
         return ip.ipv4_mapped
-    if getattr(ip, "sixtofour", None) is not None:
-        return ip.sixtofour
     b = ip.packed
     # IPv4-compatible ``::a.b.c.d`` (top 96 bits zero), excluding ``::`` and
     # ``::1`` which are not IPv4 wrappers (and are non-global anyway).
@@ -297,17 +296,26 @@ def _unwrap_embedded_ipv4(ip):
 
 
 def _is_globally_routable(ip) -> bool:
-    """True iff ``ip`` is safe to fetch (globally routable public address).
+    """True iff ``ip`` is safe to fetch (a globally routable public address).
 
-    Takes the ``is_global`` verdict on the IPv4 embedded in any IPv6 transition
-    wrapper (see :func:`_unwrap_embedded_ipv4`) so a NAT64 / 6to4 /
-    IPv4-compatible literal that wraps an internal IPv4 is judged by that
-    internal IPv4. Blocks that are non-global irrespective of the interpreter's
-    classification are force-denied via :data:`_FORCE_NON_GLOBAL_V6`.
+    Starts from the stdlib's ``is_global`` verdict on the literal address and
+    only ever *tightens* it — the guard is never more permissive than
+    ``ipaddress`` itself. On top of that: force-denied blocks
+    (:data:`_FORCE_NON_GLOBAL_V6`) are always rejected, and a fixed-position
+    IPv6 transition wrapper (:func:`_unwrap_embedded_ipv4`) whose embedded IPv4
+    is not itself global is rejected — so a NAT64 / IPv4-compatible literal that
+    wraps an internal IPv4 (e.g. ``64:ff9b::7f00:1``) is blocked even though the
+    literal is globally routable, while a NAT64 wrapper of a public IPv4
+    (``64:ff9b::808:808`` = 8.8.8.8) still passes.
     """
-    if ip.version == 6 and any(ip in net for net in _FORCE_NON_GLOBAL_V6):
+    if not ip.is_global:
         return False
-    return _unwrap_embedded_ipv4(ip).is_global
+    if ip.version == 6:
+        if any(ip in net for net in _FORCE_NON_GLOBAL_V6):
+            return False
+        if not _unwrap_embedded_ipv4(ip).is_global:
+            return False
+    return True
 
 
 def _validated_addresses(host: str) -> list[str]:

--- a/tests/parser/markdown/test_parser.py
+++ b/tests/parser/markdown/test_parser.py
@@ -22,6 +22,7 @@ from lightrag.parser.markdown.parser import (
     _image_ext_from_magic,
     _looks_like_svg,
     _pin_socket,
+    _unwrap_embedded_ipv4,
 )
 
 # A 1x1 transparent PNG.
@@ -157,6 +158,59 @@ def test_host_is_public_rejects_internal(monkeypatch):
     assert _host_is_public("100.64.0.1") is False
     # TEST-NET (192.0.2.0/24) is likewise non-global.
     assert _host_is_public("192.0.2.1") is False
+
+
+def test_host_is_public_rejects_ipv6_transition_wrapped_internal(monkeypatch):
+    # GHSA-vv3m-f8x4-7377: an internal IPv4 smuggled inside an IPv6 transition
+    # wrapper must be judged by its embedded IPv4, not the wrapper's own
+    # ``is_global``. On a NAT64/DNS64 host these literals route to the internal
+    # target, so every wrapped form of a non-public IPv4 must be blocked.
+    monkeypatch.delenv("NATIVE_MD_IMAGE_ALLOWED_NON_PUBLIC_CIDRS", raising=False)
+    # 127.0.0.1 (loopback) wrapped four ways.
+    assert _host_is_public("64:ff9b::7f00:1") is False  # NAT64 well-known /96
+    assert _host_is_public("64:ff9b:1::7f00:1") is False  # RFC 8215 /48
+    assert _host_is_public("::7f00:1") is False  # IPv4-compatible ::a.b.c.d
+    assert _host_is_public("2002:7f00:1::") is False  # 6to4 2002::/16
+    # IPv4-mapped form of the same loopback (already blocked pre-fix).
+    assert _host_is_public("::ffff:7f00:1") is False
+    # Cloud instance-metadata endpoint (169.254.169.254) via NAT64.
+    assert _host_is_public("64:ff9b::a9fe:a9fe") is False
+    # RFC1918 host (10.66.0.2) via NAT64 and via IPv4-compatible.
+    assert _host_is_public("64:ff9b::a42:2") is False
+    assert _host_is_public("::a42:2") is False
+
+
+def test_host_is_public_allows_genuine_and_nat64_wrapped_public(monkeypatch):
+    # The fix must not create false positives: genuine global IPv6 and a NAT64
+    # wrapper of a *public* IPv4 both resolve to a globally routable address and
+    # must still be fetchable.
+    monkeypatch.delenv("NATIVE_MD_IMAGE_ALLOWED_NON_PUBLIC_CIDRS", raising=False)
+    assert _host_is_public("2606:4700:4700::1111") is True  # Cloudflare DNS
+    assert _host_is_public("2001:4860:4860::8888") is True  # Google DNS
+    assert _host_is_public("64:ff9b::808:808") is True  # NAT64 of 8.8.8.8
+
+
+def test_unwrap_embedded_ipv4_isolated():
+    from ipaddress import ip_address
+
+    # Internal IPv4 wrappers decode to the embedded (non-global) IPv4.
+    assert _unwrap_embedded_ipv4(ip_address("64:ff9b::7f00:1")) == ip_address(
+        "127.0.0.1"
+    )
+    assert _unwrap_embedded_ipv4(ip_address("::7f00:1")) == ip_address("127.0.0.1")
+    assert _unwrap_embedded_ipv4(ip_address("2002:7f00:1::")) == ip_address("127.0.0.1")
+    assert _unwrap_embedded_ipv4(ip_address("::ffff:7f00:1")) == ip_address("127.0.0.1")
+    # NAT64 of a public IPv4 decodes to that public IPv4 (still global).
+    assert _unwrap_embedded_ipv4(ip_address("64:ff9b::808:808")) == ip_address(
+        "8.8.8.8"
+    )
+    # ``::`` and ``::1`` are not IPv4 wrappers — left untouched.
+    assert _unwrap_embedded_ipv4(ip_address("::1")) == ip_address("::1")
+    assert _unwrap_embedded_ipv4(ip_address("::")) == ip_address("::")
+    # Genuine global IPv6 and plain IPv4 pass through unchanged.
+    genuine = ip_address("2606:4700:4700::1111")
+    assert _unwrap_embedded_ipv4(genuine) == genuine
+    assert _unwrap_embedded_ipv4(ip_address("8.8.8.8")) == ip_address("8.8.8.8")
 
 
 def test_allowlist_permits_configured_non_public(monkeypatch):

--- a/tests/parser/markdown/test_parser.py
+++ b/tests/parser/markdown/test_parser.py
@@ -166,8 +166,9 @@ def test_host_is_public_rejects_ipv6_transition_wrapped_internal(monkeypatch):
     # ``is_global``. On a NAT64/DNS64 host these literals route to the internal
     # target, so every wrapped form of a non-public IPv4 must be blocked.
     monkeypatch.delenv("NATIVE_MD_IMAGE_ALLOWED_NON_PUBLIC_CIDRS", raising=False)
-    # 127.0.0.1 (loopback) via the wrappers whose embedded-IPv4 position is
-    # fixed by spec (NAT64 well-known /96, IPv4-compatible, 6to4).
+    # 127.0.0.1 (loopback) via decoded wrappers whose literal is globally
+    # routable (NAT64 well-known /96, IPv4-compatible) — blocked by the embedded
+    # IPv4 — plus 6to4, blocked as a force-denied block.
     assert _host_is_public("64:ff9b::7f00:1") is False  # NAT64 well-known /96
     assert _host_is_public("::7f00:1") is False  # IPv4-compatible ::a.b.c.d
     assert _host_is_public("2002:7f00:1::") is False  # 6to4 2002::/16
@@ -178,6 +179,20 @@ def test_host_is_public_rejects_ipv6_transition_wrapped_internal(monkeypatch):
     # RFC1918 host (10.66.0.2) via NAT64 and via IPv4-compatible.
     assert _host_is_public("64:ff9b::a42:2") is False
     assert _host_is_public("::a42:2") is False
+
+
+def test_host_is_public_rejects_6to4_block_even_wrapping_public(monkeypatch):
+    # 6to4 (2002::/16) is deprecated (RFC 7526) and not globally reachable per
+    # IANA; current CPython classifies the whole block non-global. The guard must
+    # never be more permissive than the stdlib, so decoding the embedded IPv4
+    # must not re-permit it: 2002::/16 is default-denied as a whole block —
+    # including a 6to4 wrapper of a *public* IPv4 — regardless of interpreter.
+    monkeypatch.delenv("NATIVE_MD_IMAGE_ALLOWED_NON_PUBLIC_CIDRS", raising=False)
+    assert _host_is_public("2002:808:808::") is False  # 6to4 of public 8.8.8.8
+    assert _host_is_public("2002:7f00:1::") is False  # 6to4 of loopback
+    # Explicit opt-in for a legacy 6to4 deployment still works via the allowlist.
+    monkeypatch.setenv("NATIVE_MD_IMAGE_ALLOWED_NON_PUBLIC_CIDRS", "2002::/16")
+    assert _host_is_public("2002:808:808::") is True
 
 
 def test_host_is_public_rejects_rfc8215_local_use_nat64_slash48(monkeypatch):
@@ -222,12 +237,11 @@ def test_host_is_public_allows_genuine_and_nat64_wrapped_public(monkeypatch):
 def test_unwrap_embedded_ipv4_isolated():
     from ipaddress import ip_address
 
-    # Internal IPv4 wrappers decode to the embedded (non-global) IPv4.
+    # Fixed-position wrappers decode to the embedded (non-global) IPv4.
     assert _unwrap_embedded_ipv4(ip_address("64:ff9b::7f00:1")) == ip_address(
         "127.0.0.1"
     )
     assert _unwrap_embedded_ipv4(ip_address("::7f00:1")) == ip_address("127.0.0.1")
-    assert _unwrap_embedded_ipv4(ip_address("2002:7f00:1::")) == ip_address("127.0.0.1")
     assert _unwrap_embedded_ipv4(ip_address("::ffff:7f00:1")) == ip_address("127.0.0.1")
     # NAT64 of a public IPv4 decodes to that public IPv4 (still global).
     assert _unwrap_embedded_ipv4(ip_address("64:ff9b::808:808")) == ip_address(
@@ -236,9 +250,11 @@ def test_unwrap_embedded_ipv4_isolated():
     # ``::`` and ``::1`` are not IPv4 wrappers — left untouched.
     assert _unwrap_embedded_ipv4(ip_address("::1")) == ip_address("::1")
     assert _unwrap_embedded_ipv4(ip_address("::")) == ip_address("::")
-    # The RFC 8215 local-use /48 is deliberately NOT decoded here (its embedded
-    # IPv4 position is not guaranteed); it is force-denied at the guard instead,
-    # so the helper returns it unchanged.
+    # 6to4 (2002::/16) and the RFC 8215 local-use /48 are deliberately NOT decoded
+    # here — they are force-denied as whole blocks at the guard instead, so the
+    # helper returns them unchanged (decoding either could loosen the verdict).
+    sixtofour = ip_address("2002:7f00:1::")
+    assert _unwrap_embedded_ipv4(sixtofour) == sixtofour
     slash48 = ip_address("64:ff9b:1:7f00:0:100:808:808")
     assert _unwrap_embedded_ipv4(slash48) == slash48
     # Genuine global IPv6 and plain IPv4 pass through unchanged.

--- a/tests/parser/markdown/test_parser.py
+++ b/tests/parser/markdown/test_parser.py
@@ -182,11 +182,12 @@ def test_host_is_public_rejects_ipv6_transition_wrapped_internal(monkeypatch):
 
 
 def test_host_is_public_rejects_6to4_block_even_wrapping_public(monkeypatch):
-    # 6to4 (2002::/16) is deprecated (RFC 7526) and not globally reachable per
-    # IANA; current CPython classifies the whole block non-global. The guard must
-    # never be more permissive than the stdlib, so decoding the embedded IPv4
-    # must not re-permit it: 2002::/16 is default-denied as a whole block —
-    # including a 6to4 wrapper of a *public* IPv4 — regardless of interpreter.
+    # 6to4 (2002::/16) is not globally reachable per IANA and current CPython
+    # classifies the whole block non-global. The guard must never be more
+    # permissive than the stdlib, so decoding the embedded IPv4 must not
+    # re-permit it: 2002::/16 is default-denied as a whole block — including a
+    # 6to4 wrapper of a *public* IPv4 — regardless of interpreter. (RFC 7526
+    # deprecated only the 6to4 anycast relay path, not the 2002::/16 prefix.)
     monkeypatch.delenv("NATIVE_MD_IMAGE_ALLOWED_NON_PUBLIC_CIDRS", raising=False)
     assert _host_is_public("2002:808:808::") is False  # 6to4 of public 8.8.8.8
     assert _host_is_public("2002:7f00:1::") is False  # 6to4 of loopback

--- a/tests/parser/markdown/test_parser.py
+++ b/tests/parser/markdown/test_parser.py
@@ -166,9 +166,9 @@ def test_host_is_public_rejects_ipv6_transition_wrapped_internal(monkeypatch):
     # ``is_global``. On a NAT64/DNS64 host these literals route to the internal
     # target, so every wrapped form of a non-public IPv4 must be blocked.
     monkeypatch.delenv("NATIVE_MD_IMAGE_ALLOWED_NON_PUBLIC_CIDRS", raising=False)
-    # 127.0.0.1 (loopback) wrapped four ways.
+    # 127.0.0.1 (loopback) via the wrappers whose embedded-IPv4 position is
+    # fixed by spec (NAT64 well-known /96, IPv4-compatible, 6to4).
     assert _host_is_public("64:ff9b::7f00:1") is False  # NAT64 well-known /96
-    assert _host_is_public("64:ff9b:1::7f00:1") is False  # RFC 8215 /48
     assert _host_is_public("::7f00:1") is False  # IPv4-compatible ::a.b.c.d
     assert _host_is_public("2002:7f00:1::") is False  # 6to4 2002::/16
     # IPv4-mapped form of the same loopback (already blocked pre-fix).
@@ -178,6 +178,35 @@ def test_host_is_public_rejects_ipv6_transition_wrapped_internal(monkeypatch):
     # RFC1918 host (10.66.0.2) via NAT64 and via IPv4-compatible.
     assert _host_is_public("64:ff9b::a42:2") is False
     assert _host_is_public("::a42:2") is False
+
+
+def test_host_is_public_rejects_rfc8215_local_use_nat64_slash48(monkeypatch):
+    # The RFC 8215 local-use NAT64 prefix 64:ff9b:1::/48 is technology-agnostic:
+    # the embedded-IPv4 position is not guaranteed (RFC 8215 §5) and IANA marks
+    # the whole /48 not-globally-reachable, so the entire block is default-denied
+    # rather than decoded. A naive "low 32 bits" decode is a bypass — a proper
+    # RFC 6052 §2.2 /48 encoding carries the IPv4 in bits 48-63 + 72-87, so the
+    # low 32 bits are an attacker-chosen suffix.
+    monkeypatch.delenv("NATIVE_MD_IMAGE_ALLOWED_NON_PUBLIC_CIDRS", raising=False)
+    # RFC 6052 /48 encoding of 127.0.0.1 with a public-looking low-32 suffix
+    # (8.8.8.8) — a low-32 decode would wrongly read it as public and pass.
+    assert _host_is_public("64:ff9b:1:7f00:0:100:808:808") is False
+    # RFC 6052 /48 encoding of a *public* address (8.8.8.8) is also denied:
+    # a not-globally-reachable local-use block is off by default policy.
+    assert _host_is_public("64:ff9b:1:808:8:800::") is False
+    # The "low 32 bits" style literals in the same /48 are blocked too.
+    assert _host_is_public("64:ff9b:1::7f00:1") is False
+    assert _host_is_public("64:ff9b:1::808:808") is False
+
+
+def test_rfc8215_slash48_permitted_only_via_allowlist(monkeypatch):
+    # An operator running a genuine local NAT64 in 64:ff9b:1::/48 can still opt
+    # in explicitly; nothing outside the configured block is affected.
+    monkeypatch.setenv("NATIVE_MD_IMAGE_ALLOWED_NON_PUBLIC_CIDRS", "64:ff9b:1::/48")
+    assert _host_is_public("64:ff9b:1::808:808") is True
+    assert _host_is_public("64:ff9b:1:7f00:0:100:808:808") is True
+    # The well-known /96 (a different prefix) is unaffected by the /48 allowlist.
+    assert _host_is_public("64:ff9b::7f00:1") is False
 
 
 def test_host_is_public_allows_genuine_and_nat64_wrapped_public(monkeypatch):
@@ -207,6 +236,11 @@ def test_unwrap_embedded_ipv4_isolated():
     # ``::`` and ``::1`` are not IPv4 wrappers — left untouched.
     assert _unwrap_embedded_ipv4(ip_address("::1")) == ip_address("::1")
     assert _unwrap_embedded_ipv4(ip_address("::")) == ip_address("::")
+    # The RFC 8215 local-use /48 is deliberately NOT decoded here (its embedded
+    # IPv4 position is not guaranteed); it is force-denied at the guard instead,
+    # so the helper returns it unchanged.
+    slash48 = ip_address("64:ff9b:1:7f00:0:100:808:808")
+    assert _unwrap_embedded_ipv4(slash48) == slash48
     # Genuine global IPv6 and plain IPv4 pass through unchanged.
     genuine = ip_address("2606:4700:4700::1111")
     assert _unwrap_embedded_ipv4(genuine) == genuine


### PR DESCRIPTION
## Summary

Fixes the SSRF-guard bypass in the native markdown image-download path reported in **GHSA-vv3m-f8x4-7377** (CWE-918, CVSS 7.1).

The only SSRF guard, `_validated_addresses()` in `lightrag/parser/markdown/parser.py`, accepted a resolved host when `ip.is_global` was true — evaluated on the **literal** resolved address. CPython's `ipaddress` classifies IPv6 *transition wrappers* that embed an internal IPv4 as globally routable, so the guard passed them. On a host with **NAT64/DNS64** routing (AWS/GCP IPv6-only subnets, many mobile/corporate networks) the request is then delivered to the embedded internal target — loopback, RFC1918, or a cloud metadata endpoint (`169.254.169.254`) — and the fetched body is ingested. The download path is enabled by default (`NATIVE_MD_IMAGE_DOWNLOAD_ENABLED=true`) and reachable by any caller who can upload a markdown/textpack document.

The most important vector is the **`64:ff9b::/96` NAT64 well-known prefix** that real DNS64/NAT64 deployments actually use; it bypasses on every current CPython. (`64:ff9b:1::/48` and `2002::/16` are additionally blocked by the stdlib on CPython ≥ 3.10.14 / 3.11.9 / 3.12.3 via gh-113171, but not on older patch releases.)

## Fix

`_is_globally_routable()` decides global-routability such that it **starts from the stdlib's `is_global` verdict on the literal and only ever tightens it** — the guard is never more permissive than `ipaddress` itself. On top of that:

1. **Fixed-position transition wrappers are decoded** and the embedded IPv4 must *also* be global (`_unwrap_embedded_ipv4`): IPv4-mapped (`::ffff:0:0/96`), IPv4-compatible (`::/96`), and the NAT64 well-known prefix `64:ff9b::/96` (RFC 6052 §2.2, IPv4 in the contiguous low 32 bits). So `64:ff9b::7f00:1` (→ loopback) is blocked while `64:ff9b::808:808` (→ public 8.8.8.8) still passes.
2. **Blocks whose embedded-IPv4 position we must not trust are default-denied as whole blocks** (`_FORCE_NON_GLOBAL_V6`), independent of the interpreter:
   - `64:ff9b:1::/48` — RFC 8215 local-use NAT64. Technology-agnostic; the embedded-IPv4 position is not guaranteed (RFC 8215 §5), so a fixed-offset decode is itself bypassable (e.g. `64:ff9b:1:7f00:0:100:808:808` is a /48 encoding of `127.0.0.1` whose low 32 bits read as public `8.8.8.8`). IANA marks the whole /48 not-globally-reachable.
   - `2002::/16` — 6to4, deprecated (RFC 7526), IANA global-reachability N/A; current CPython treats it as private.

Operators running a genuine local NAT64 / legacy 6to4 in those blocks can still opt in via `NATIVE_MD_IMAGE_ALLOWED_NON_PUBLIC_CIDRS`. **Boundary:** a NAT64 deployment using a *custom*, globally-routable Network-Specific Prefix (RFC 6052 permits any /32../96) is indistinguishable from ordinary global IPv6 and is not auto-detected — such operators should pin egress or configure the allowlist deliberately.

## Tests

`tests/parser/markdown/test_parser.py`:
- `test_host_is_public_rejects_ipv6_transition_wrapped_internal` — every wrapped form of loopback/RFC1918/metadata is blocked end-to-end (through `getaddrinfo`).
- `test_host_is_public_rejects_6to4_block_even_wrapping_public` — 6to4 of a *public* IPv4 is blocked (guard never looser than the stdlib), and the allowlist opt-in still works.
- `test_host_is_public_rejects_rfc8215_local_use_nat64_slash48` — the RFC 6052 `/48` suffix bypass and the whole `/48` are blocked.
- `test_rfc8215_slash48_permitted_only_via_allowlist` — explicit opt-in works, scoped to the configured block.
- `test_host_is_public_allows_genuine_and_nat64_wrapped_public` — no false positives: genuine global IPv6 and NAT64-of-public still fetchable.
- `test_unwrap_embedded_ipv4_isolated` — the decoder in isolation, incl. the `::`/`::1` carve-outs and the deliberately-not-decoded 6to4 / `/48`.

All 35 tests in the file pass. `ruff` / `ruff-format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)