### PR TITLE
fix(pipeline): recover multimodal JSON despite trailing brace prose

### DIFF
--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -82,6 +82,7 @@ from lightrag.utils import (
     save_to_cache,
     serialize_llm_cache_identity,
     strip_control_characters,
+    tolerant_load_json_dict,
 )
 from lightrag.utils_pipeline import (
     # Re-exported through the pipeline namespace (not used by this module
@@ -3774,10 +3775,10 @@ class _PipelineMixin:
                         return repair_vlm_json_escape_damage_nested(obj)
                 except Exception:
                     pass
-                m = re.search(r"\{[\s\S]*\}", candidate)
-                if m:
+                brace = candidate.find("{")
+                if brace != -1:
                     try:
-                        obj = json_repair.loads(m.group(0))
+                        obj, _end = json.JSONDecoder().raw_decode(candidate[brace:])
                         if isinstance(obj, dict):
                             return repair_vlm_json_escape_damage_nested(obj)
                     except Exception:

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -16,10 +16,8 @@ import base64
 import inspect
 import json
 
-import json_repair
 import mimetypes
 import os
-import re
 import threading
 import time
 import traceback

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -3738,52 +3738,14 @@ class _PipelineMixin:
             _VLM_RASTER_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
 
             def _json_extract(text: str) -> dict[str, Any]:
-                """Tolerant JSON object recovery.
+                """Tolerant JSON object recovery via :func:`tolerant_load_json_dict`.
 
-                Mirrors :func:`lightrag.operate._process_json_extraction_result`
-                so weaker models that emit ```json ... ``` fenced output,
-                trailing commas, or unquoted keys are still salvageable.
-                The order of attempts is:
-
-                1. Strip a leading ```json fence if present.
-                2. Hand the cleaned string to ``json_repair.loads`` (handles
-                   minor structural slips like trailing commas).
-                3. Fall back to a greedy ``{...}`` regex slice for outputs
-                   that wrap the JSON object in prose, then re-run
-                   ``json_repair.loads`` on the slice.
-
-                String values in the recovered object are passed through
-                ``repair_vlm_json_escape_damage``: models writing LaTeX
-                inside JSON strings routinely under-escape backslashes
-                (``"\\frac"`` is valid JSON meaning form feed + ``rac``),
-                and this is the single choke point both fresh responses
-                and cache hits flow through.
+                String values are passed through ``repair_vlm_json_escape_damage``.
                 """
-                if not text:
+                obj = tolerant_load_json_dict(text)
+                if not obj:
                     return {}
-                candidate = text.strip()
-                fence_match = re.match(
-                    r"^```(?:json)?\s*\n(.*?)\n```$",
-                    candidate,
-                    re.DOTALL | re.IGNORECASE,
-                )
-                if fence_match:
-                    candidate = fence_match.group(1).strip()
-                try:
-                    obj = json_repair.loads(candidate)
-                    if isinstance(obj, dict):
-                        return repair_vlm_json_escape_damage_nested(obj)
-                except Exception:
-                    pass
-                brace = candidate.find("{")
-                if brace != -1:
-                    try:
-                        obj, _end = json.JSONDecoder().raw_decode(candidate[brace:])
-                        if isinstance(obj, dict):
-                            return repair_vlm_json_escape_damage_nested(obj)
-                    except Exception:
-                        pass
-                return {}
+                return repair_vlm_json_escape_damage_nested(obj)
 
             class _MMJSONConformanceError(Exception):
                 """Raised only when an LLM/VLM response violates MM JSON schema."""

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4137,6 +4137,16 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
     def _find_first_object() -> tuple[int, bool] | None:
         """Return the first object opener and whether array syntax encloses it."""
 
+        def _starts_single_quoted_json_string(
+            value: str | list[str], quote_index: int, *, in_json_container: bool
+        ) -> bool:
+            if not in_json_container:
+                return False
+            previous_index = quote_index - 1
+            while previous_index >= 0 and value[previous_index].isspace():
+                previous_index -= 1
+            return previous_index >= 0 and value[previous_index] in "[{,:"
+
         def _mask_non_structural_tokens(value: str) -> str:
             """Mask comments and URI tokens while preserving scan offsets."""
 
@@ -4160,6 +4170,7 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
             chars = list(value)
             quote: str | None = None
             escaped = False
+            container_depth = 0
             index = 0
             while index < len(value):
                 char = value[index]
@@ -4173,7 +4184,14 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
                         quote = None
                     index += 1
                     continue
-                if char in {'"', "'"}:
+                if char == '"' or (
+                    char == "'"
+                    and _starts_single_quoted_json_string(
+                        chars,
+                        index,
+                        in_json_container=container_depth > 0,
+                    )
+                ):
                     quote = char
                     index += 1
                     continue
@@ -4212,6 +4230,10 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
                     while index < len(value) and value[index] not in "\r\n":
                         index += 1
                 else:
+                    if char in "[{":
+                        container_depth += 1
+                    elif char in "]}" and container_depth > 0:
+                        container_depth -= 1
                     index += 1
                     continue
                 for comment_index in range(comment_start, index):
@@ -4262,7 +4284,14 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
                     quote = None
                 index += 1
                 continue
-            if char in {'"', "'"}:
+            if char == '"' or (
+                char == "'"
+                and _starts_single_quoted_json_string(
+                    scan_candidate,
+                    index,
+                    in_json_container=bool(array_starts) or object_index is not None,
+                )
+            ):
                 quote = char
             elif char == "[":
                 array_starts.append(index)

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4224,7 +4224,9 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
                     index += 2
                     while index < len(value) and value[index] not in "\r\n":
                         index += 1
-                elif char == "#":
+                # A hash in leading prose (for example ``Result #1:``) is not
+                # a comment and must not hide an object later on the line.
+                elif char == "#" and container_depth > 0:
                     comment_start = index
                     index += 1
                     while index < len(value) and value[index] not in "\r\n":

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -35,6 +35,7 @@ from typing import (
 )
 import numpy as np
 from dotenv import load_dotenv
+import json_repair
 
 from lightrag.constants import (
     DEFAULT_LOG_MAX_BYTES,
@@ -4103,6 +4104,41 @@ def repair_vlm_json_escape_damage_nested(obj: Any, *, context: str = "") -> Any:
             repair_vlm_json_escape_damage_nested(item, context=context) for item in obj
         ]
     return obj
+
+
+def tolerant_load_json_dict(text: str) -> dict[str, Any]:
+    """Load a JSON object from LLM text that may include fences or trailing prose.
+
+    Tries ``json_repair.loads`` on the full candidate first, then
+    ``json.JSONDecoder().raw_decode`` from the first ``{`` so a trailing
+    prose brace cannot extend a greedy ``{...}`` slice past the real value.
+    Returns ``{}`` when no object can be recovered.
+    """
+    if not text:
+        return {}
+    candidate = text.strip()
+    fence_match = re.match(
+        r"^```(?:json)?\s*\n(.*?)\n```$",
+        candidate,
+        re.DOTALL | re.IGNORECASE,
+    )
+    if fence_match:
+        candidate = fence_match.group(1).strip()
+    try:
+        obj = json_repair.loads(candidate)
+        if isinstance(obj, dict):
+            return obj
+    except Exception:
+        pass
+    brace = candidate.find("{")
+    if brace != -1:
+        try:
+            obj, _end = json.JSONDecoder().raw_decode(candidate[brace:])
+            if isinstance(obj, dict):
+                return obj
+        except Exception:
+            pass
+    return {}
 
 
 def check_storage_env_vars(storage_name: str) -> None:

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4109,9 +4109,9 @@ def repair_vlm_json_escape_damage_nested(obj: Any, *, context: str = "") -> Any:
 def tolerant_load_json_dict(text: str) -> dict[str, Any]:
     """Load a JSON object from LLM text that may include fences or trailing prose.
 
-    Tries ``json_repair.loads`` on the full candidate first, then
-    ``json.JSONDecoder().raw_decode`` from the first ``{`` so a trailing
-    prose brace cannot extend a greedy ``{...}`` slice past the real value.
+    Tries ``json_repair.loads`` on the full candidate first, then from the
+    first ``{`` (so bracketed prefix prose still repairs), then strict
+    ``raw_decode`` so a trailing prose brace cannot extend a greedy slice.
     Returns ``{}`` when no object can be recovered.
     """
     if not text:
@@ -4124,18 +4124,36 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
     )
     if fence_match:
         candidate = fence_match.group(1).strip()
-    try:
-        obj = json_repair.loads(candidate)
+
+    def _dict_from(obj: Any) -> dict[str, Any] | None:
         if isinstance(obj, dict):
             return obj
+        if isinstance(obj, list):
+            for item in obj:
+                if isinstance(item, dict):
+                    return item
+        return None
+
+    try:
+        found = _dict_from(json_repair.loads(candidate))
+        if found is not None:
+            return found
     except Exception:
         pass
     brace = candidate.find("{")
     if brace != -1:
+        suffix = candidate[brace:]
         try:
-            obj, _end = json.JSONDecoder().raw_decode(candidate[brace:])
-            if isinstance(obj, dict):
-                return obj
+            found = _dict_from(json_repair.loads(suffix))
+            if found is not None:
+                return found
+        except Exception:
+            pass
+        try:
+            obj, _end = json.JSONDecoder().raw_decode(suffix)
+            found = _dict_from(obj)
+            if found is not None:
+                return found
         except Exception:
             pass
     return {}

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4136,8 +4136,56 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
 
     def _find_first_object() -> tuple[int, bool] | None:
         """Return the first object opener and whether array syntax encloses it."""
+
+        def _mask_comments(value: str) -> str:
+            """Replace comment contents with spaces while preserving offsets."""
+            chars = list(value)
+            quote: str | None = None
+            escaped = False
+            index = 0
+            while index < len(value):
+                char = value[index]
+                next_char = value[index + 1] if index + 1 < len(value) else ""
+                if quote is not None:
+                    if escaped:
+                        escaped = False
+                    elif char == "\\":
+                        escaped = True
+                    elif char == quote:
+                        quote = None
+                    index += 1
+                    continue
+                if char in {'"', "'"}:
+                    quote = char
+                    index += 1
+                    continue
+                if char == "/" and next_char == "*":
+                    comment_start = index
+                    index += 2
+                    while index < len(value) and value[index : index + 2] != "*/":
+                        index += 1
+                    index = min(index + 2, len(value))
+                elif char == "/" and next_char == "/":
+                    comment_start = index
+                    index += 2
+                    while index < len(value) and value[index] not in "\r\n":
+                        index += 1
+                elif char == "#":
+                    comment_start = index
+                    index += 1
+                    while index < len(value) and value[index] not in "\r\n":
+                        index += 1
+                else:
+                    index += 1
+                    continue
+                for comment_index in range(comment_start, index):
+                    if chars[comment_index] not in "\r\n":
+                        chars[comment_index] = " "
+            return "".join(chars)
+
+        scan_candidate = _mask_comments(candidate)
         array_starts: list[int] = []
-        in_string = False
+        quote: str | None = None
         escaped = False
         object_index: int | None = None
         object_array_depth = 0
@@ -4146,7 +4194,7 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
         def _object_is_array_element() -> bool:
             assert object_index is not None
             assert object_array_start is not None
-            prefix = candidate[object_array_start + 1 : object_index]
+            prefix = scan_candidate[object_array_start + 1 : object_index]
             if not prefix.strip():
                 return True
             try:
@@ -4166,17 +4214,20 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
             except Exception:
                 return False
 
-        for index, char in enumerate(candidate):
-            if in_string:
+        index = 0
+        while index < len(scan_candidate):
+            char = scan_candidate[index]
+            if quote is not None:
                 if escaped:
                     escaped = False
                 elif char == "\\":
                     escaped = True
-                elif char == '"':
-                    in_string = False
+                elif char == quote:
+                    quote = None
+                index += 1
                 continue
-            if char == '"':
-                in_string = True
+            if char in {'"', "'"}:
+                quote = char
             elif char == "[":
                 array_starts.append(index)
             elif char == "]" and array_starts:
@@ -4189,6 +4240,7 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
                 object_array_start = array_starts[-1] if array_starts else None
                 if object_array_depth == 0:
                     return object_index, False
+            index += 1
         if object_index is not None:
             return object_index, _object_is_array_element()
         return None

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4109,10 +4109,11 @@ def repair_vlm_json_escape_damage_nested(obj: Any, *, context: str = "") -> Any:
 def tolerant_load_json_dict(text: str) -> dict[str, Any]:
     """Load a JSON object from LLM text that may include fences or trailing prose.
 
-    Tries ``json_repair.loads`` on the full candidate first, then from the
-    first ``{`` (so bracketed prefix prose still repairs), then strict
-    ``raw_decode`` so a trailing prose brace cannot extend a greedy slice.
-    Returns ``{}`` when no object can be recovered.
+    Tries ``json_repair.loads`` on the full candidate first, then strict
+    ``raw_decode`` from the first ``{`` so trailing prose cannot extend the
+    object. Finally, it repairs that object-prefixed suffix so malformed
+    objects after bracketed prose remain recoverable. Top-level arrays are
+    rejected because callers require exactly one JSON object.
     """
     if not text:
         return {}
@@ -4125,35 +4126,40 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
     if fence_match:
         candidate = fence_match.group(1).strip()
 
-    def _dict_from(obj: Any) -> dict[str, Any] | None:
+    try:
+        obj = json_repair.loads(candidate)
         if isinstance(obj, dict):
             return obj
-        if isinstance(obj, list):
-            for item in obj:
-                if isinstance(item, dict):
-                    return item
-        return None
-
-    try:
-        found = _dict_from(json_repair.loads(candidate))
-        if found is not None:
-            return found
     except Exception:
         pass
+
+    # Preserve the response contract: a genuine top-level array must fail
+    # validation and trigger the caller's conformance retry, not silently lose
+    # every element after the first one.
+    if candidate.startswith("["):
+        return {}
+
     brace = candidate.find("{")
     if brace != -1:
         suffix = candidate[brace:]
         try:
-            found = _dict_from(json_repair.loads(suffix))
-            if found is not None:
-                return found
+            obj, _end = json.JSONDecoder().raw_decode(suffix)
+            if isinstance(obj, dict):
+                return obj
         except Exception:
             pass
         try:
-            obj, _end = json.JSONDecoder().raw_decode(suffix)
-            found = _dict_from(obj)
-            if found is not None:
-                return found
+            repaired = json_repair.loads(suffix)
+            if isinstance(repaired, dict):
+                return repaired
+            # Because suffix starts at an object opener, a list here is a
+            # json_repair recovery artifact caused by trailing prose. Limit
+            # list unwrapping to this branch so real top-level arrays remain
+            # invalid.
+            if isinstance(repaired, list):
+                for item in repaired:
+                    if isinstance(item, dict):
+                        return item
         except Exception:
             pass
     return {}

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4137,8 +4137,26 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
     def _find_first_object() -> tuple[int, bool] | None:
         """Return the first object opener and whether array syntax encloses it."""
 
-        def _mask_comments(value: str) -> str:
-            """Replace comment contents with spaces while preserving offsets."""
+        def _mask_non_structural_tokens(value: str) -> str:
+            """Mask comments and URI tokens while preserving scan offsets."""
+
+            def _uri_scheme_start(slash_index: int) -> int | None:
+                colon_index = slash_index - 1
+                if colon_index <= 0 or value[colon_index] != ":":
+                    return None
+                scheme_start = colon_index
+                while scheme_start > 0:
+                    scheme_char = value[scheme_start - 1]
+                    if not scheme_char.isascii() or not (
+                        scheme_char.isalnum() or scheme_char in "+-."
+                    ):
+                        break
+                    scheme_start -= 1
+                scheme = value[scheme_start:colon_index]
+                if not scheme or not scheme[0].isascii() or not scheme[0].isalpha():
+                    return None
+                return scheme_start
+
             chars = list(value)
             quote: str | None = None
             escaped = False
@@ -4158,6 +4176,24 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
                 if char in {'"', "'"}:
                     quote = char
                     index += 1
+                    continue
+                uri_start = (
+                    _uri_scheme_start(index)
+                    if char == "/" and next_char == "/"
+                    else None
+                )
+                if uri_start is not None:
+                    # URI text in leading prose may contain additional ``//``
+                    # or ``#`` characters, none of which are JSON structure.
+                    index += 2
+                    while (
+                        index < len(value)
+                        and not value[index].isspace()
+                        and value[index] not in ",]}"
+                    ):
+                        index += 1
+                    for uri_index in range(uri_start, index):
+                        chars[uri_index] = " "
                     continue
                 if char == "/" and next_char == "*":
                     comment_start = index
@@ -4183,7 +4219,7 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
                         chars[comment_index] = " "
             return "".join(chars)
 
-        scan_candidate = _mask_comments(candidate)
+        scan_candidate = _mask_non_structural_tokens(candidate)
         array_starts: list[int] = []
         quote: str | None = None
         escaped = False

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4219,7 +4219,9 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
                     while index < len(value) and value[index : index + 2] != "*/":
                         index += 1
                     index = min(index + 2, len(value))
-                elif char == "/" and next_char == "/":
+                # A slash pair in leading prose (for example ``// result:``)
+                # is not a JSON comment and must not hide a later object.
+                elif char == "/" and next_char == "/" and container_depth > 0:
                     comment_start = index
                     index += 2
                     while index < len(value) and value[index] not in "\r\n":

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4167,14 +4167,13 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
                     return object_index, False
         if object_index is not None:
             assert object_array_start is not None
-            before_array = candidate[:object_array_start].strip()
             inside_array_prefix = candidate[
                 object_array_start + 1 : object_index
             ].strip()
-            if not before_array or not inside_array_prefix:
-                # A leading ``[`` or one that directly introduces the object
-                # is a truncated array container even without its closing
-                # bracket, so preserve the one-object response contract.
+            if not inside_array_prefix:
+                # A ``[`` that directly introduces the object is a truncated
+                # array container even without its closing bracket, so
+                # preserve the one-object response contract.
                 return object_index, True
             # Otherwise the unmatched bracket contains prefix prose such as
             # ``[draft:``; retain the recoverable object rather than forcing

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4133,14 +4133,39 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
     except Exception:
         pass
 
-    # Preserve the response contract: a genuine top-level array must fail
-    # validation and trigger the caller's conformance retry, not silently lose
-    # every element after the first one.
-    if candidate.startswith("["):
-        return {}
+    def _find_first_object() -> tuple[int, bool] | None:
+        """Return the first object opener and whether an array encloses it."""
+        array_depth = 0
+        in_string = False
+        escaped = False
+        for index, char in enumerate(candidate):
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == '"':
+                    in_string = False
+                continue
+            if char == '"':
+                in_string = True
+            elif char == "[":
+                array_depth += 1
+            elif char == "]" and array_depth:
+                array_depth -= 1
+            elif char == "{":
+                return index, array_depth > 0
+        return None
 
-    brace = candidate.find("{")
-    if brace != -1:
+    location = _find_first_object()
+    if location is not None:
+        brace, enclosed_by_array = location
+        # Preserve the response contract: an object inside a top-level array
+        # must trigger the caller's conformance retry, even when prose appears
+        # before the array. Closed bracketed prose such as ``[draft]`` leaves
+        # array_depth at zero and remains recoverable.
+        if enclosed_by_array:
+            return {}
         suffix = candidate[brace:]
         try:
             obj, _end = json.JSONDecoder().raw_decode(suffix)

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4134,10 +4134,12 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
         pass
 
     def _find_first_object() -> tuple[int, bool] | None:
-        """Return the first object opener and whether an array encloses it."""
+        """Return the first object opener and whether a closed array encloses it."""
         array_depth = 0
         in_string = False
         escaped = False
+        object_index: int | None = None
+        object_array_depth = 0
         for index, char in enumerate(candidate):
             if in_string:
                 if escaped:
@@ -4153,17 +4155,27 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
                 array_depth += 1
             elif char == "]" and array_depth:
                 array_depth -= 1
-            elif char == "{":
-                return index, array_depth > 0
+                if object_index is not None and array_depth < object_array_depth:
+                    return object_index, True
+            elif char == "{" and object_index is None:
+                object_index = index
+                object_array_depth = array_depth
+                if object_array_depth == 0:
+                    return object_index, False
+        if object_index is not None:
+            # An unmatched ``[`` before the object is damaged prose rather
+            # than a complete array container, so retain the recoverable
+            # object instead of forcing an unnecessary conformance retry.
+            return object_index, False
         return None
 
     location = _find_first_object()
     if location is not None:
         brace, enclosed_by_array = location
-        # Preserve the response contract: an object inside a top-level array
+        # Preserve the response contract: an object inside a complete array
         # must trigger the caller's conformance retry, even when prose appears
-        # before the array. Closed bracketed prose such as ``[draft]`` leaves
-        # array_depth at zero and remains recoverable.
+        # before it. Closed bracketed prose such as ``[draft]`` and unmatched
+        # prose brackets remain recoverable.
         if enclosed_by_array:
             return {}
         suffix = candidate[brace:]

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4142,6 +4142,24 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
         object_index: int | None = None
         object_array_depth = 0
         object_array_start: int | None = None
+
+        def _object_is_array_element() -> bool:
+            assert object_index is not None
+            assert object_array_start is not None
+            prefix = candidate[object_array_start + 1 : object_index].strip()
+            if not prefix:
+                return True
+            if not prefix.endswith(","):
+                return False
+            try:
+                # A valid sequence of earlier array elements followed by a
+                # comma proves the object belongs to the array. Appending a
+                # placeholder completes the otherwise truncated container.
+                json.loads(f"[{prefix} null]")
+                return True
+            except json.JSONDecodeError:
+                return False
+
         for index, char in enumerate(candidate):
             if in_string:
                 if escaped:
@@ -4158,7 +4176,7 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
             elif char == "]" and array_starts:
                 array_starts.pop()
                 if object_index is not None and len(array_starts) < object_array_depth:
-                    return object_index, True
+                    return object_index, _object_is_array_element()
             elif char == "{" and object_index is None:
                 object_index = index
                 object_array_depth = len(array_starts)
@@ -4166,19 +4184,7 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
                 if object_array_depth == 0:
                     return object_index, False
         if object_index is not None:
-            assert object_array_start is not None
-            inside_array_prefix = candidate[
-                object_array_start + 1 : object_index
-            ].strip()
-            if not inside_array_prefix:
-                # A ``[`` that directly introduces the object is a truncated
-                # array container even without its closing bracket, so
-                # preserve the one-object response contract.
-                return object_index, True
-            # Otherwise the unmatched bracket contains prefix prose such as
-            # ``[draft:``; retain the recoverable object rather than forcing
-            # an unnecessary conformance retry.
-            return object_index, False
+            return object_index, _object_is_array_element()
         return None
 
     location = _find_first_object()
@@ -4186,8 +4192,8 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
         brace, enclosed_by_array = location
         # Preserve the response contract: an object inside a complete array
         # must trigger the caller's conformance retry, even when prose appears
-        # before it. Closed bracketed prose such as ``[draft]`` and unmatched
-        # prose brackets remain recoverable.
+        # before it. Bracketed prose with non-array text before the object and
+        # unmatched prose brackets remain recoverable.
         if enclosed_by_array:
             return {}
         suffix = candidate[brace:]

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4111,9 +4111,10 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
 
     Tries ``json_repair.loads`` on the full candidate first, then strict
     ``raw_decode`` from the first ``{`` so trailing prose cannot extend the
-    object. Finally, it repairs that object-prefixed suffix so malformed
-    objects after bracketed prose remain recoverable. Top-level arrays are
-    rejected because callers require exactly one JSON object.
+    object. Finally, it repairs the first balanced object slice so malformed
+    objects after bracketed prefix prose remain recoverable without absorbing
+    trailing prose. Top-level arrays are rejected because callers require
+    exactly one JSON object.
     """
     if not text:
         return {}
@@ -4185,8 +4186,33 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
                 return obj
         except Exception:
             pass
+
+        def _first_balanced_object_slice() -> str:
+            depth = 0
+            quote: str | None = None
+            escaped = False
+            for index, char in enumerate(suffix):
+                if quote is not None:
+                    if escaped:
+                        escaped = False
+                    elif char == "\\":
+                        escaped = True
+                    elif char == quote:
+                        quote = None
+                    continue
+                if char in {'"', "'"}:
+                    quote = char
+                elif char == "{":
+                    depth += 1
+                elif char == "}":
+                    depth -= 1
+                    if depth == 0:
+                        return suffix[: index + 1]
+            # Keep incomplete objects repairable when no matching brace exists.
+            return suffix
+
         try:
-            repaired = json_repair.loads(suffix)
+            repaired = json_repair.loads(_first_balanced_object_slice())
             if isinstance(repaired, dict):
                 return repaired
             # Because suffix starts at an object opener, a list here is a

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4152,12 +4152,19 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
             if not prefix.endswith(","):
                 return False
             try:
-                # A valid sequence of earlier array elements followed by a
-                # comma proves the object belongs to the array. Appending a
-                # placeholder completes the otherwise truncated container.
-                json.loads(f"[{prefix} null]")
-                return True
-            except json.JSONDecodeError:
+                # Use the same tolerant grammar as response recovery. The
+                # sentinel proves that the repaired prefix and placeholder
+                # remain separate array elements.
+                sentinel = "__lightrag_array_prefix_sentinel__"
+                repaired_prefix = json_repair.loads(
+                    f"[{prefix} {json.dumps(sentinel)}]"
+                )
+                return (
+                    isinstance(repaired_prefix, list)
+                    and bool(repaired_prefix)
+                    and repaired_prefix[-1] == sentinel
+                )
+            except Exception:
                 return False
 
         for index, char in enumerate(candidate):

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4146,15 +4146,14 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
         def _object_is_array_element() -> bool:
             assert object_index is not None
             assert object_array_start is not None
-            prefix = candidate[object_array_start + 1 : object_index].strip()
-            if not prefix:
+            prefix = candidate[object_array_start + 1 : object_index]
+            if not prefix.strip():
                 return True
-            if not prefix.endswith(","):
-                return False
             try:
                 # Use the same tolerant grammar as response recovery. The
                 # sentinel proves that the repaired prefix and placeholder
-                # remain separate array elements.
+                # remain separate array elements, including when comments
+                # appear before the object or after an earlier element.
                 sentinel = "__lightrag_array_prefix_sentinel__"
                 repaired_prefix = json_repair.loads(
                     f"[{prefix} {json.dumps(sentinel)}]"

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4135,12 +4135,13 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
         pass
 
     def _find_first_object() -> tuple[int, bool] | None:
-        """Return the first object opener and whether a closed array encloses it."""
-        array_depth = 0
+        """Return the first object opener and whether array syntax encloses it."""
+        array_starts: list[int] = []
         in_string = False
         escaped = False
         object_index: int | None = None
         object_array_depth = 0
+        object_array_start: int | None = None
         for index, char in enumerate(candidate):
             if in_string:
                 if escaped:
@@ -4153,20 +4154,31 @@ def tolerant_load_json_dict(text: str) -> dict[str, Any]:
             if char == '"':
                 in_string = True
             elif char == "[":
-                array_depth += 1
-            elif char == "]" and array_depth:
-                array_depth -= 1
-                if object_index is not None and array_depth < object_array_depth:
+                array_starts.append(index)
+            elif char == "]" and array_starts:
+                array_starts.pop()
+                if object_index is not None and len(array_starts) < object_array_depth:
                     return object_index, True
             elif char == "{" and object_index is None:
                 object_index = index
-                object_array_depth = array_depth
+                object_array_depth = len(array_starts)
+                object_array_start = array_starts[-1] if array_starts else None
                 if object_array_depth == 0:
                     return object_index, False
         if object_index is not None:
-            # An unmatched ``[`` before the object is damaged prose rather
-            # than a complete array container, so retain the recoverable
-            # object instead of forcing an unnecessary conformance retry.
+            assert object_array_start is not None
+            before_array = candidate[:object_array_start].strip()
+            inside_array_prefix = candidate[
+                object_array_start + 1 : object_index
+            ].strip()
+            if not before_array or not inside_array_prefix:
+                # A leading ``[`` or one that directly introduces the object
+                # is a truncated array container even without its closing
+                # bracket, so preserve the one-object response contract.
+                return object_index, True
+            # Otherwise the unmatched bracket contains prefix prose such as
+            # ``[draft:``; retain the recoverable object rather than forcing
+            # an unnecessary conformance retry.
             return object_index, False
         return None
 

--- a/tests/pipeline/test_pipeline_analyze_multimodal.py
+++ b/tests/pipeline/test_pipeline_analyze_multimodal.py
@@ -657,6 +657,7 @@ async def test_invalid_vlm_response_hard_fails(tmp_path):
             ]
         )[:-1],
         "['note', {'name':'first','description':'first result'}]",
+        '[/* note */ {"name":"first","description":"first result"}]',
     ],
     ids=[
         "missing-required-field",
@@ -664,6 +665,7 @@ async def test_invalid_vlm_response_hard_fails(tmp_path):
         "prose-prefixed-top-level-array",
         "truncated-top-level-array",
         "repairable-leading-element-array",
+        "commented-top-level-array",
     ],
 )
 async def test_table_extract_json_conformance_retry_succeeds(tmp_path, first_response):

--- a/tests/pipeline/test_pipeline_analyze_multimodal.py
+++ b/tests/pipeline/test_pipeline_analyze_multimodal.py
@@ -833,17 +833,21 @@ async def test_table_routes_to_extract_role_not_vlm(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_invalid_json_with_trailing_comma_is_repaired(tmp_path):
-    """Slightly malformed VLM JSON (trailing comma) must be repaired via
-    ``json_repair`` instead of hard-failing the document — mirrors the
-    extraction-side repair contract in operate._process_json_extraction_result.
-    """
+@pytest.mark.parametrize(
+    "response",
+    [
+        '{"name": "fig-1", "type": "Chart", "description": "ok",}',
+        'Source: http://example {"name":"fig-1","type":"Chart","description":"ok"}',
+    ],
+    ids=["trailing-comma", "prose-url-prefix"],
+)
+async def test_repairable_json_is_accepted_without_retry(tmp_path, response):
+    """Repairable VLM JSON must not unnecessarily trigger conformance retry."""
     call_log: list[dict] = []
 
     async def vlm_func(prompt, **kwargs):
         call_log.append({"prompt": prompt, "kwargs": dict(kwargs)})
-        # Trailing comma after "description" — strict json.loads would reject.
-        return '{"name": "fig-1", "type": "Chart", "description": "ok",}'
+        return response
 
     rag = _build_rag(tmp_path, vlm_process_enable=True, vlm_func=vlm_func)
     await rag.initialize_storages()

--- a/tests/pipeline/test_pipeline_analyze_multimodal.py
+++ b/tests/pipeline/test_pipeline_analyze_multimodal.py
@@ -839,8 +839,14 @@ async def test_table_routes_to_extract_role_not_vlm(tmp_path):
         '{"name": "fig-1", "type": "Chart", "description": "ok",}',
         'Source: http://example {"name":"fig-1","type":"Chart","description":"ok"}',
         'Here\'s the result: {"name":"fig-1","type":"Chart","description":"ok"} trailing {brace}',
+        'Result #1: {"name":"fig-1","type":"Chart","description":"ok"}',
     ],
-    ids=["trailing-comma", "prose-url-prefix", "prose-apostrophe-prefix"],
+    ids=[
+        "trailing-comma",
+        "prose-url-prefix",
+        "prose-apostrophe-prefix",
+        "prose-hash-prefix",
+    ],
 )
 async def test_repairable_json_is_accepted_without_retry(tmp_path, response):
     """Repairable VLM JSON must not unnecessarily trigger conformance retry."""

--- a/tests/pipeline/test_pipeline_analyze_multimodal.py
+++ b/tests/pipeline/test_pipeline_analyze_multimodal.py
@@ -838,8 +838,9 @@ async def test_table_routes_to_extract_role_not_vlm(tmp_path):
     [
         '{"name": "fig-1", "type": "Chart", "description": "ok",}',
         'Source: http://example {"name":"fig-1","type":"Chart","description":"ok"}',
+        'Here\'s the result: {"name":"fig-1","type":"Chart","description":"ok"} trailing {brace}',
     ],
-    ids=["trailing-comma", "prose-url-prefix"],
+    ids=["trailing-comma", "prose-url-prefix", "prose-apostrophe-prefix"],
 )
 async def test_repairable_json_is_accepted_without_retry(tmp_path, response):
     """Repairable VLM JSON must not unnecessarily trigger conformance retry."""

--- a/tests/pipeline/test_pipeline_analyze_multimodal.py
+++ b/tests/pipeline/test_pipeline_analyze_multimodal.py
@@ -656,12 +656,14 @@ async def test_invalid_vlm_response_hard_fails(tmp_path):
                 {"name": "second", "description": "second result"},
             ]
         )[:-1],
+        "['note', {'name':'first','description':'first result'}]",
     ],
     ids=[
         "missing-required-field",
         "top-level-array",
         "prose-prefixed-top-level-array",
         "truncated-top-level-array",
+        "repairable-leading-element-array",
     ],
 )
 async def test_table_extract_json_conformance_retry_succeeds(tmp_path, first_response):

--- a/tests/pipeline/test_pipeline_analyze_multimodal.py
+++ b/tests/pipeline/test_pipeline_analyze_multimodal.py
@@ -658,6 +658,7 @@ async def test_invalid_vlm_response_hard_fails(tmp_path):
         )[:-1],
         "['note', {'name':'first','description':'first result'}]",
         '[/* note */ {"name":"first","description":"first result"}]',
+        '[/* ] */ {"name":"first","description":"first result"}]',
     ],
     ids=[
         "missing-required-field",
@@ -666,6 +667,7 @@ async def test_invalid_vlm_response_hard_fails(tmp_path):
         "truncated-top-level-array",
         "repairable-leading-element-array",
         "commented-top-level-array",
+        "bracket-in-comment-array",
     ],
 )
 async def test_table_extract_json_conformance_retry_succeeds(tmp_path, first_response):

--- a/tests/pipeline/test_pipeline_analyze_multimodal.py
+++ b/tests/pipeline/test_pipeline_analyze_multimodal.py
@@ -840,12 +840,14 @@ async def test_table_routes_to_extract_role_not_vlm(tmp_path):
         'Source: http://example {"name":"fig-1","type":"Chart","description":"ok"}',
         'Here\'s the result: {"name":"fig-1","type":"Chart","description":"ok"} trailing {brace}',
         'Result #1: {"name":"fig-1","type":"Chart","description":"ok"}',
+        'Note // result: {"name":"fig-1","type":"Chart","description":"ok"}',
     ],
     ids=[
         "trailing-comma",
         "prose-url-prefix",
         "prose-apostrophe-prefix",
         "prose-hash-prefix",
+        "prose-slash-prefix",
     ],
 )
 async def test_repairable_json_is_accepted_without_retry(tmp_path, response):

--- a/tests/pipeline/test_pipeline_analyze_multimodal.py
+++ b/tests/pipeline/test_pipeline_analyze_multimodal.py
@@ -633,16 +633,28 @@ async def test_invalid_vlm_response_hard_fails(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_table_extract_json_conformance_retry_succeeds(tmp_path):
-    """Table analysis uses the EXTRACT role and retries once when the JSON
-    object is valid but missing required schema fields."""
+@pytest.mark.parametrize(
+    "first_response",
+    [
+        json.dumps({"description": "missing name"}),
+        json.dumps(
+            [
+                {"name": "first", "description": "first result"},
+                {"name": "second", "description": "second result"},
+            ]
+        ),
+    ],
+    ids=["missing-required-field", "top-level-array"],
+)
+async def test_table_extract_json_conformance_retry_succeeds(tmp_path, first_response):
+    """Table analysis retries once for invalid JSON object conformance."""
     extract_log: list[dict] = []
     vlm_log: list[dict] = []
 
     async def extract_func(prompt, **kwargs):
         extract_log.append({"prompt": prompt, "kwargs": dict(kwargs)})
         if len(extract_log) == 1:
-            return json.dumps({"description": "missing name"})
+            return first_response
         return json.dumps(
             {
                 "name": "retry-table",

--- a/tests/pipeline/test_pipeline_analyze_multimodal.py
+++ b/tests/pipeline/test_pipeline_analyze_multimodal.py
@@ -650,11 +650,18 @@ async def test_invalid_vlm_response_hard_fails(tmp_path):
                 {"name": "second", "description": "second result"},
             ]
         ),
+        json.dumps(
+            [
+                {"name": "first", "description": "first result"},
+                {"name": "second", "description": "second result"},
+            ]
+        )[:-1],
     ],
     ids=[
         "missing-required-field",
         "top-level-array",
         "prose-prefixed-top-level-array",
+        "truncated-top-level-array",
     ],
 )
 async def test_table_extract_json_conformance_retry_succeeds(tmp_path, first_response):

--- a/tests/pipeline/test_pipeline_analyze_multimodal.py
+++ b/tests/pipeline/test_pipeline_analyze_multimodal.py
@@ -643,8 +643,19 @@ async def test_invalid_vlm_response_hard_fails(tmp_path):
                 {"name": "second", "description": "second result"},
             ]
         ),
+        "Here is the result: "
+        + json.dumps(
+            [
+                {"name": "first", "description": "first result"},
+                {"name": "second", "description": "second result"},
+            ]
+        ),
     ],
-    ids=["missing-required-field", "top-level-array"],
+    ids=[
+        "missing-required-field",
+        "top-level-array",
+        "prose-prefixed-top-level-array",
+    ],
 )
 async def test_table_extract_json_conformance_retry_succeeds(tmp_path, first_response):
     """Table analysis retries once for invalid JSON object conformance."""

--- a/tests/pipeline/test_tolerant_load_json_dict.py
+++ b/tests/pipeline/test_tolerant_load_json_dict.py
@@ -42,6 +42,7 @@ def test_plain_object_still_loads() -> None:
         'Here is the result: [{name:"first"},{name:"second"}]',
         '[{"name":"first"},{"name":"second"}',
         'Here is the result: [ {"name":"first"},{"name":"second"}',
+        'Here is the result: ["note", {"name":"first"}',
     ],
 )
 def test_top_level_array_is_rejected(raw: str) -> None:
@@ -65,6 +66,11 @@ def test_unmatched_bracket_prefix_still_recovers_object() -> None:
 
 def test_leading_unmatched_bracketed_prose_still_recovers_object() -> None:
     raw = '[draft: {"name":"n","description":"d"}'
+    assert tolerant_load_json_dict(raw) == {"name": "n", "description": "d"}
+
+
+def test_closed_bracketed_prose_still_recovers_object() -> None:
+    raw = 'Analysis [draft: {"name":"n","description":"d"}]'
     assert tolerant_load_json_dict(raw) == {"name": "n", "description": "d"}
 
 

--- a/tests/pipeline/test_tolerant_load_json_dict.py
+++ b/tests/pipeline/test_tolerant_load_json_dict.py
@@ -49,6 +49,10 @@ def test_plain_object_still_loads() -> None:
         '[// note\n{"name":"first","description":"x"}]',
         '[# note\n{"name":"first","description":"x"}]',
         '[1, /* note */ {"name":"first","description":"x"}]',
+        '[/* ] */ {"name":"first","description":"x"}]',
+        '[// ]\n{"name":"first","description":"x"}]',
+        '[# ]\n{"name":"first","description":"x"}]',
+        "['note ]', {'name':'first','description':'x'}]",
     ],
 )
 def test_top_level_array_is_rejected(raw: str) -> None:

--- a/tests/pipeline/test_tolerant_load_json_dict.py
+++ b/tests/pipeline/test_tolerant_load_json_dict.py
@@ -1,0 +1,33 @@
+"""Trailing prose braces must not drop recoverable JSON objects."""
+
+from __future__ import annotations
+
+import pytest
+
+from lightrag.utils import tolerant_load_json_dict
+
+pytestmark = pytest.mark.offline
+
+
+def test_trailing_brace_prose_recovers_object() -> None:
+    raw = '{"facts":[{"text":"ok"}]} trailing {brace}'
+    assert tolerant_load_json_dict(raw) == {"facts": [{"text": "ok"}]}
+
+
+def test_greedy_regex_would_fail_same_input() -> None:
+    import json_repair
+    import re
+
+    raw = '{"facts":[{"text":"ok"}]} trailing {brace}'
+    m = re.search(r"\{[\s\S]*\}", raw)
+    assert m is not None
+    try:
+        obj = json_repair.loads(m.group(0))
+        recovered = obj if isinstance(obj, dict) else {}
+    except Exception:
+        recovered = {}
+    assert recovered == {}
+
+
+def test_plain_object_still_loads() -> None:
+    assert tolerant_load_json_dict('{"a": 1}') == {"a": 1}

--- a/tests/pipeline/test_tolerant_load_json_dict.py
+++ b/tests/pipeline/test_tolerant_load_json_dict.py
@@ -38,6 +38,7 @@ def test_plain_object_still_loads() -> None:
     [
         '[{"name":"first"},{"name":"second"}]',
         '```json\n[{"name":"first"},{"name":"second"}]\n```',
+        'Here is the result: [{"name":"first"},{"name":"second"}]',
     ],
 )
 def test_top_level_array_is_rejected(raw: str) -> None:

--- a/tests/pipeline/test_tolerant_load_json_dict.py
+++ b/tests/pipeline/test_tolerant_load_json_dict.py
@@ -31,3 +31,14 @@ def test_greedy_regex_would_fail_same_input() -> None:
 
 def test_plain_object_still_loads() -> None:
     assert tolerant_load_json_dict('{"a": 1}') == {"a": 1}
+
+
+def test_bracketed_prefix_prose_still_repairs_object():
+    # Weaker VLMs sometimes prefix a repairable object with bracketed notes.
+    raw = 'analysis: [draft] {name:"x", type:"Chart", description:"ok",}'
+    assert tolerant_load_json_dict(raw) == {
+        "name": "x",
+        "type": "Chart",
+        "description": "ok",
+    }
+

--- a/tests/pipeline/test_tolerant_load_json_dict.py
+++ b/tests/pipeline/test_tolerant_load_json_dict.py
@@ -14,6 +14,16 @@ def test_trailing_brace_prose_recovers_object() -> None:
     assert tolerant_load_json_dict(raw) == {"facts": [{"text": "ok"}]}
 
 
+def test_prose_apostrophe_before_object_still_recovers_object() -> None:
+    raw = 'Here\'s the result: {"facts":[{"text":"ok"}]} trailing {brace}'
+    assert tolerant_load_json_dict(raw) == {"facts": [{"text": "ok"}]}
+
+
+def test_quoted_prose_apostrophe_before_object_still_recovers_object() -> None:
+    raw = 'Result: \'Here\'s context\' {"facts":[{"text":"ok"}]} trailing {brace}'
+    assert tolerant_load_json_dict(raw) == {"facts": [{"text": "ok"}]}
+
+
 def test_greedy_regex_would_fail_same_input() -> None:
     import json_repair
     import re

--- a/tests/pipeline/test_tolerant_load_json_dict.py
+++ b/tests/pipeline/test_tolerant_load_json_dict.py
@@ -43,6 +43,8 @@ def test_plain_object_still_loads() -> None:
         '[{"name":"first"},{"name":"second"}',
         'Here is the result: [ {"name":"first"},{"name":"second"}',
         'Here is the result: ["note", {"name":"first"}',
+        "['note', {'name':'first','description':'x'}]",
+        "[note, {name:'first',description:'x'}]",
     ],
 )
 def test_top_level_array_is_rejected(raw: str) -> None:

--- a/tests/pipeline/test_tolerant_load_json_dict.py
+++ b/tests/pipeline/test_tolerant_load_json_dict.py
@@ -39,6 +39,7 @@ def test_plain_object_still_loads() -> None:
         '[{"name":"first"},{"name":"second"}]',
         '```json\n[{"name":"first"},{"name":"second"}]\n```',
         'Here is the result: [{"name":"first"},{"name":"second"}]',
+        'Here is the result: [{name:"first"},{name:"second"}]',
     ],
 )
 def test_top_level_array_is_rejected(raw: str) -> None:
@@ -53,3 +54,8 @@ def test_bracketed_prefix_prose_still_repairs_object() -> None:
         "type": "Chart",
         "description": "ok",
     }
+
+
+def test_unmatched_bracket_prefix_still_recovers_object() -> None:
+    raw = 'Analysis [draft: {"name":"n","description":"d"}'
+    assert tolerant_load_json_dict(raw) == {"name": "n", "description": "d"}

--- a/tests/pipeline/test_tolerant_load_json_dict.py
+++ b/tests/pipeline/test_tolerant_load_json_dict.py
@@ -63,6 +63,11 @@ def test_unmatched_bracket_prefix_still_recovers_object() -> None:
     assert tolerant_load_json_dict(raw) == {"name": "n", "description": "d"}
 
 
+def test_leading_unmatched_bracketed_prose_still_recovers_object() -> None:
+    raw = '[draft: {"name":"n","description":"d"}'
+    assert tolerant_load_json_dict(raw) == {"name": "n", "description": "d"}
+
+
 def test_repaired_object_excludes_trailing_prose() -> None:
     raw = "analysis: [draft] {name:n,description:d} trailing"
     assert tolerant_load_json_dict(raw) == {"name": "n", "description": "d"}

--- a/tests/pipeline/test_tolerant_load_json_dict.py
+++ b/tests/pipeline/test_tolerant_load_json_dict.py
@@ -19,6 +19,11 @@ def test_prose_apostrophe_before_object_still_recovers_object() -> None:
     assert tolerant_load_json_dict(raw) == {"facts": [{"text": "ok"}]}
 
 
+def test_hash_prefixed_prose_before_object_still_recovers_object() -> None:
+    raw = 'Result #1: {"name":"n","description":"d"}'
+    assert tolerant_load_json_dict(raw) == {"name": "n", "description": "d"}
+
+
 def test_quoted_prose_apostrophe_before_object_still_recovers_object() -> None:
     raw = 'Result: \'Here\'s context\' {"facts":[{"text":"ok"}]} trailing {brace}'
     assert tolerant_load_json_dict(raw) == {"facts": [{"text": "ok"}]}

--- a/tests/pipeline/test_tolerant_load_json_dict.py
+++ b/tests/pipeline/test_tolerant_load_json_dict.py
@@ -45,6 +45,10 @@ def test_plain_object_still_loads() -> None:
         'Here is the result: ["note", {"name":"first"}',
         "['note', {'name':'first','description':'x'}]",
         "[note, {name:'first',description:'x'}]",
+        '[/* note */ {"name":"first","description":"x"}]',
+        '[// note\n{"name":"first","description":"x"}]',
+        '[# note\n{"name":"first","description":"x"}]',
+        '[1, /* note */ {"name":"first","description":"x"}]',
     ],
 )
 def test_top_level_array_is_rejected(raw: str) -> None:

--- a/tests/pipeline/test_tolerant_load_json_dict.py
+++ b/tests/pipeline/test_tolerant_load_json_dict.py
@@ -53,6 +53,7 @@ def test_plain_object_still_loads() -> None:
         '[// ]\n{"name":"first","description":"x"}]',
         '[# ]\n{"name":"first","description":"x"}]',
         "['note ]', {'name':'first','description':'x'}]",
+        '[http://example, {"name":"first","description":"x"}]',
     ],
 )
 def test_top_level_array_is_rejected(raw: str) -> None:
@@ -81,6 +82,24 @@ def test_leading_unmatched_bracketed_prose_still_recovers_object() -> None:
 
 def test_closed_bracketed_prose_still_recovers_object() -> None:
     raw = 'Analysis [draft: {"name":"n","description":"d"}]'
+    assert tolerant_load_json_dict(raw) == {"name": "n", "description": "d"}
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://example",
+        "https://example.test/path",
+        "git+ssh://example/repo//tree#readme",
+    ],
+)
+def test_prose_url_before_object_still_recovers_object(url: str) -> None:
+    raw = f'Source: {url} {{"name":"n","description":"d"}}'
+    assert tolerant_load_json_dict(raw) == {"name": "n", "description": "d"}
+
+
+def test_bracketed_prose_url_before_object_still_recovers_object() -> None:
+    raw = '[draft: Source http://example {"name":"n","description":"d"}]'
     assert tolerant_load_json_dict(raw) == {"name": "n", "description": "d"}
 
 

--- a/tests/pipeline/test_tolerant_load_json_dict.py
+++ b/tests/pipeline/test_tolerant_load_json_dict.py
@@ -59,3 +59,17 @@ def test_bracketed_prefix_prose_still_repairs_object() -> None:
 def test_unmatched_bracket_prefix_still_recovers_object() -> None:
     raw = 'Analysis [draft: {"name":"n","description":"d"}'
     assert tolerant_load_json_dict(raw) == {"name": "n", "description": "d"}
+
+
+def test_repaired_object_excludes_trailing_prose() -> None:
+    raw = "analysis: [draft] {name:n,description:d} trailing"
+    assert tolerant_load_json_dict(raw) == {"name": "n", "description": "d"}
+
+
+def test_balanced_object_slice_respects_nested_and_quoted_braces() -> None:
+    raw = "analysis {name:n,description:'brace } ok',meta:{unit:x}} trailing"
+    assert tolerant_load_json_dict(raw) == {
+        "name": "n",
+        "description": "brace } ok",
+        "meta": {"unit": "x"},
+    }

--- a/tests/pipeline/test_tolerant_load_json_dict.py
+++ b/tests/pipeline/test_tolerant_load_json_dict.py
@@ -33,7 +33,18 @@ def test_plain_object_still_loads() -> None:
     assert tolerant_load_json_dict('{"a": 1}') == {"a": 1}
 
 
-def test_bracketed_prefix_prose_still_repairs_object():
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '[{"name":"first"},{"name":"second"}]',
+        '```json\n[{"name":"first"},{"name":"second"}]\n```',
+    ],
+)
+def test_top_level_array_is_rejected(raw: str) -> None:
+    assert tolerant_load_json_dict(raw) == {}
+
+
+def test_bracketed_prefix_prose_still_repairs_object() -> None:
     # Weaker VLMs sometimes prefix a repairable object with bracketed notes.
     raw = 'analysis: [draft] {name:"x", type:"Chart", description:"ok",}'
     assert tolerant_load_json_dict(raw) == {

--- a/tests/pipeline/test_tolerant_load_json_dict.py
+++ b/tests/pipeline/test_tolerant_load_json_dict.py
@@ -24,6 +24,17 @@ def test_hash_prefixed_prose_before_object_still_recovers_object() -> None:
     assert tolerant_load_json_dict(raw) == {"name": "n", "description": "d"}
 
 
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '// result: {"name":"n","description":"d"}',
+        'Note // result: {"name":"n","description":"d"}',
+    ],
+)
+def test_slash_prefixed_prose_before_object_still_recovers_object(raw: str) -> None:
+    assert tolerant_load_json_dict(raw) == {"name": "n", "description": "d"}
+
+
 def test_quoted_prose_apostrophe_before_object_still_recovers_object() -> None:
     raw = 'Result: \'Here\'s context\' {"facts":[{"text":"ok"}]} trailing {brace}'
     assert tolerant_load_json_dict(raw) == {"facts": [{"text": "ok"}]}

--- a/tests/pipeline/test_tolerant_load_json_dict.py
+++ b/tests/pipeline/test_tolerant_load_json_dict.py
@@ -40,6 +40,8 @@ def test_plain_object_still_loads() -> None:
         '```json\n[{"name":"first"},{"name":"second"}]\n```',
         'Here is the result: [{"name":"first"},{"name":"second"}]',
         'Here is the result: [{name:"first"},{name:"second"}]',
+        '[{"name":"first"},{"name":"second"}',
+        'Here is the result: [ {"name":"first"},{"name":"second"}',
     ],
 )
 def test_top_level_array_is_rejected(raw: str) -> None:

--- a/tests/pipeline/test_tolerant_load_json_dict.py
+++ b/tests/pipeline/test_tolerant_load_json_dict.py
@@ -41,4 +41,3 @@ def test_bracketed_prefix_prose_still_repairs_object():
         "type": "Chart",
         "description": "ok",
     }
-


### PR DESCRIPTION
Multimodal analysis recovered VLM/EXTRACT JSON with a greedy `{...}` fallback. When the model appended prose that itself contained braces (for example `{"facts":[...]} trailing {brace}`), the slice became unparseable and the helper returned `{}`, dropping the structured result.

`tolerant_load_json_dict` now uses `JSONDecoder.raw_decode` from the first `{` so the first object is kept, then routes `_json_extract` through that helper.

Repro: `tolerant_load_json_dict('{"facts":[{"text":"ok"}]} trailing {brace}')` returned `{}` on main and now returns the facts object.