### PR TITLE
fix(utils): reject non-finite values in parse_optional_float

### DIFF
--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -12,6 +12,7 @@ import inspect
 import json
 import logging
 import logging.handlers
+import math
 import os
 import re
 import time
@@ -243,13 +244,18 @@ def parse_optional_float(raw: str | None) -> float | None:
     the consuming code fall back to its own default.  Any other
     non-numeric value raises :class:`ValueError` so misconfigured envs
     fail loudly at parse time rather than silently downstream.
+    Non-finite values (``nan`` / ``inf``) are also rejected: they parse as
+    floats but corrupt semantic-chunker thresholds.
     """
     if raw is None:
         return None
     stripped = raw.strip()
     if not stripped or stripped.lower() == "none":
         return None
-    return float(stripped)
+    value = float(stripped)
+    if not math.isfinite(value):
+        raise ValueError(f"expected a finite float, got {raw!r}")
+    return value
 
 
 def get_env_value(

--- a/tests/test_parse_optional_float.py
+++ b/tests/test_parse_optional_float.py
@@ -1,0 +1,20 @@
+"""Regression: parse_optional_float rejects non-finite env values."""
+
+from __future__ import annotations
+
+import pytest
+
+from lightrag.utils import parse_optional_float
+
+
+@pytest.mark.parametrize("raw", ["nan", "NaN", "inf", "+inf", "-inf"])
+def test_parse_optional_float_rejects_nonfinite(raw: str):
+    with pytest.raises(ValueError, match="finite"):
+        parse_optional_float(raw)
+
+
+def test_parse_optional_float_accepts_finite_and_unset():
+    assert parse_optional_float("1.5") == 1.5
+    assert parse_optional_float(None) is None
+    assert parse_optional_float("") is None
+    assert parse_optional_float("None") is None

--- a/tests/test_parse_optional_float.py
+++ b/tests/test_parse_optional_float.py
@@ -1,10 +1,12 @@
-"""Regression: parse_optional_float rejects non-finite env values."""
+"""Regression tests for :func:`lightrag.utils.parse_optional_float`."""
 
 from __future__ import annotations
 
 import pytest
 
 from lightrag.utils import parse_optional_float
+
+pytestmark = pytest.mark.offline
 
 
 @pytest.mark.parametrize("raw", ["nan", "NaN", "inf", "+inf", "-inf"])


### PR DESCRIPTION
## Problem

`parse_optional_float` accepted env strings like `nan` / `inf` and passed them into semantic-chunker breakpoint thresholds.

## Repro

```python
from lightrag.utils import parse_optional_float

parse_optional_float("nan")  # previously returned nan
```

## Fix

Require a finite float after parsing so misconfigured knobs fail loudly at decode time.