### PR TITLE
Refactor pipeline reservation recovery coordination

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -2424,14 +2424,16 @@ def create_app(args):
             pipeline_status = await get_namespace_data(
                 "pipeline_status", workspace=workspace
             )
-
-            pipeline_busy = bool(pipeline_status.get("busy", False))
-            pipeline_scanning = bool(pipeline_status.get("scanning", False))
+            # One DictProxy RPC in multi-worker mode; keep /health read-only and
+            # avoid one cross-process ``get`` per field.
+            pipeline_snapshot = pipeline_status.copy()
+            pipeline_busy = bool(pipeline_snapshot.get("busy", False))
+            pipeline_scanning = bool(pipeline_snapshot.get("scanning", False))
             pipeline_destructive_busy = bool(
-                pipeline_status.get("destructive_busy", False)
+                pipeline_snapshot.get("destructive_busy", False)
             )
             pipeline_pending_enqueues = int(
-                pipeline_status.get("pending_enqueues", 0) or 0
+                pipeline_snapshot.get("pending_enqueues", 0) or 0
             )
             pipeline_active = (
                 pipeline_busy

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -1267,15 +1267,12 @@ async def _reserve_enqueue_slot(rag: LightRAG, token: str) -> bool:
             ``pipeline_status['scanning_exclusive']`` or
             ``pipeline_status['destructive_busy']`` is set.
     """
-    import os
-
     from lightrag.exceptions import PipelineNotInitializedError
     from lightrag.kg.shared_storage import (
-        _my_start_id,
+        PipelineReservationConflict,
+        acquire_enqueue_reservation,
         get_namespace_data,
         get_namespace_lock,
-        pipeline_recovery_blocked_message,
-        reconcile_dead_pipeline_reservations,
     )
 
     try:
@@ -1287,38 +1284,31 @@ async def _reserve_enqueue_slot(rag: LightRAG, token: str) -> bool:
     pipeline_status_lock = get_namespace_lock(
         "pipeline_status", workspace=rag.workspace
     )
-    async with pipeline_status_lock:
-        # Reclaim a dead owner's slot before the checks (Linux multi-worker
-        # only). A dead custom_chunks/delete/clear owner raises
-        # recovery_required, which fences new enqueues until an explicit recovery.
-        reconcile_dead_pipeline_reservations(pipeline_status)
-        if pipeline_status.get("recovery_required"):
-            raise HTTPException(
-                status_code=503,
-                detail=pipeline_recovery_blocked_message(pipeline_status),
-            )
-        if pipeline_status.get("scanning_exclusive"):
-            raise HTTPException(
-                status_code=409,
-                detail=(
-                    "Document scan is classifying files. "
-                    "Wait for the classification phase to finish before "
-                    "submitting new work."
-                ),
-            )
-        if pipeline_status.get("destructive_busy"):
-            raise HTTPException(
-                status_code=409,
-                detail=(
-                    "Pipeline is clearing or deleting documents. "
-                    "Wait for the running job to finish before submitting "
-                    "new work."
-                ),
-            )
-        tokens = dict(pipeline_status.get("pending_enqueue_tokens", {}))
-        tokens[token] = {"pid": os.getpid(), "process_start_id": _my_start_id()}
-        pipeline_status.update(
-            {"pending_enqueue_tokens": tokens, "pending_enqueues": len(tokens)}
+    result = await acquire_enqueue_reservation(
+        pipeline_status,
+        pipeline_status_lock,
+        token=token,
+        reject_when=(
+            (
+                "scanning_exclusive",
+                "Document scan is classifying files. Wait for the classification "
+                "phase to finish before submitting new work.",
+            ),
+            (
+                "destructive_busy",
+                "Pipeline is clearing or deleting documents. Wait for the running "
+                "job to finish before submitting new work.",
+            ),
+        ),
+    )
+    if not result.acquired:
+        raise HTTPException(
+            status_code=(
+                503
+                if result.conflict is PipelineReservationConflict.RECOVERY_REQUIRED
+                else 409
+            ),
+            detail=result.message,
         )
     return True
 
@@ -1349,10 +1339,10 @@ async def check_pipeline_busy_or_raise(rag: LightRAG) -> None:
     """
     from lightrag.exceptions import PipelineNotInitializedError
     from lightrag.kg.shared_storage import (
+        PipelineReservationConflict,
+        check_pipeline_status_mutation,
         get_namespace_data,
         get_namespace_lock,
-        pipeline_recovery_blocked_message,
-        reconcile_dead_pipeline_reservations,
     )
 
     try:
@@ -1364,26 +1354,26 @@ async def check_pipeline_busy_or_raise(rag: LightRAG) -> None:
     pipeline_status_lock = get_namespace_lock(
         "pipeline_status", workspace=rag.workspace
     )
-    async with pipeline_status_lock:
-        # Reclaim a dead owner first: reconcile clears ``busy`` when it fences a
-        # dead custom_chunks/delete/clear owner, so a plain ``busy`` check would
-        # wave the graph edit through onto a possibly partially-committed store.
-        # Refuse a fenced workspace with 503 (distinct from the 409 busy case).
-        reconcile_dead_pipeline_reservations(pipeline_status)
-        if pipeline_status.get("recovery_required"):
-            raise HTTPException(
-                status_code=503,
-                detail=pipeline_recovery_blocked_message(pipeline_status),
-            )
-        if pipeline_status.get("busy"):
-            raise HTTPException(
-                status_code=409,
-                detail=(
-                    "Pipeline is busy with another operation. "
-                    "Wait for the running job to finish before editing "
-                    "the knowledge graph."
-                ),
-            )
+    result = await check_pipeline_status_mutation(
+        pipeline_status,
+        pipeline_status_lock,
+        reject_when=(
+            (
+                "busy",
+                "Pipeline is busy with another operation. Wait for the running "
+                "job to finish before editing the knowledge graph.",
+            ),
+        ),
+    )
+    if not result.acquired:
+        raise HTTPException(
+            status_code=(
+                503
+                if result.conflict is PipelineReservationConflict.RECOVERY_REQUIRED
+                else 409
+            ),
+            detail=result.message,
+        )
 
 
 async def _acquire_destructive_busy(
@@ -1429,11 +1419,9 @@ async def _acquire_destructive_busy(
     """
     from lightrag.exceptions import PipelineNotInitializedError
     from lightrag.kg.shared_storage import (
+        acquire_reservation,
         get_namespace_data,
         get_namespace_lock,
-        make_owner_record,
-        pipeline_recovery_blocked_message,
-        reconcile_dead_pipeline_reservations,
     )
 
     try:
@@ -1445,36 +1433,32 @@ async def _acquire_destructive_busy(
     pipeline_status_lock = get_namespace_lock(
         "pipeline_status", workspace=rag.workspace
     )
-    async with pipeline_status_lock:
-        # Reclaim a dead owner's slot before the conflict checks; a dead
-        # custom_chunks/delete/clear owner sets recovery_required, which fences
-        # this (and every) mutation until an explicit recovery.
-        reconcile_dead_pipeline_reservations(pipeline_status)
-        if pipeline_status.get("recovery_required"):
-            return False, pipeline_recovery_blocked_message(pipeline_status)
-        if pipeline_status.get("busy"):
-            return False, "Pipeline is busy with another operation."
-        if pipeline_status.get("scanning"):
-            return False, (
-                "Document scan is in progress. "
-                "Wait for the scan to complete before clearing or deleting."
-            )
-        if pipeline_status.get("pending_enqueues", 0) > 0:
-            return False, (
-                "Document upload/insert is being enqueued. "
-                "Wait for in-flight work to complete before clearing or "
-                "deleting."
-            )
-        # Take the slot + stamp the owner (with recovery identity) atomically.
-        pipeline_status.update(
-            {
-                "busy": True,
-                "destructive_busy": True,
-                "busy_owner": make_owner_record(token, kind),
-                "operation_record": operation_record,
-            }
-        )
-    return True, None
+    result = await acquire_reservation(
+        pipeline_status,
+        pipeline_status_lock,
+        owner_key="busy_owner",
+        owner=token,
+        owner_kind=kind,
+        flags={
+            "busy": True,
+            "destructive_busy": True,
+            "operation_record": operation_record,
+        },
+        reject_when=(
+            ("busy", "Pipeline is busy with another operation."),
+            (
+                "scanning",
+                "Document scan is in progress. Wait for the scan to complete "
+                "before clearing or deleting.",
+            ),
+            (
+                "pending_enqueues",
+                "Document upload/insert is being enqueued. Wait for in-flight "
+                "work to complete before clearing or deleting.",
+            ),
+        ),
+    )
+    return result.acquired, result.message
 
 
 def _release_destructive_action(status) -> None:
@@ -2171,7 +2155,11 @@ async def run_scanning_process(
     # test rigs), the flags were never set so there's nothing to
     # clear — track that here to skip the namespace fetch.
     from lightrag.exceptions import PipelineNotInitializedError
-    from lightrag.kg.shared_storage import get_namespace_data, get_namespace_lock
+    from lightrag.kg.shared_storage import (
+        get_namespace_data,
+        get_namespace_lock,
+        transition_scanning_reservation,
+    )
 
     pipeline_status = None
     pipeline_status_lock = None
@@ -2350,8 +2338,15 @@ async def run_scanning_process(
             # apipeline_enqueue_documents' in-batch dedup, identical to
             # the upload-during-busy case.
             if pipeline_status is not None and pipeline_status_lock is not None:
-                async with pipeline_status_lock:
-                    pipeline_status["scanning_exclusive"] = False
+                if scanning_token is not None:
+                    await transition_scanning_reservation(
+                        pipeline_status,
+                        pipeline_status_lock,
+                        token=scanning_token,
+                    )
+                else:
+                    async with pipeline_status_lock:
+                        pipeline_status["scanning_exclusive"] = False
 
             # New files take the standard enqueue + process path.  When at
             # least one new file is successfully enqueued, pipeline_index_files
@@ -2394,8 +2389,15 @@ async def run_scanning_process(
             # release ``scanning_exclusive`` before driving the queue so
             # concurrent uploads can land while process_enqueue runs.
             if pipeline_status is not None and pipeline_status_lock is not None:
-                async with pipeline_status_lock:
-                    pipeline_status["scanning_exclusive"] = False
+                if scanning_token is not None:
+                    await transition_scanning_reservation(
+                        pipeline_status,
+                        pipeline_status_lock,
+                        token=scanning_token,
+                    )
+                else:
+                    async with pipeline_status_lock:
+                        pipeline_status["scanning_exclusive"] = False
             logger.info(
                 "No upload file found, check if there are any documents in the queue..."
             )
@@ -2699,11 +2701,10 @@ def create_document_routes(
         """
         from lightrag.exceptions import PipelineNotInitializedError
         from lightrag.kg.shared_storage import (
+            PipelineReservationConflict,
+            acquire_reservation,
             get_namespace_data,
             get_namespace_lock,
-            make_owner_record,
-            pipeline_recovery_blocked_message,
-            reconcile_dead_pipeline_reservations,
             start_reserved_background_task,
         )
 
@@ -2759,74 +2760,59 @@ def create_document_routes(
         reserved = False
         handed_off = False
         try:
-            async with pipeline_status_lock:
-                # Reclaim a dead owner's slot before the skip checks (Linux
-                # multi-worker only; no-op otherwise). A dead custom_chunks/
-                # delete/clear owner raises recovery_required → refuse the scan.
-                reconcile_dead_pipeline_reservations(pipeline_status)
-                if pipeline_status.get("recovery_required"):
-                    return ScanResponse(
-                        status="scanning_skipped_pipeline_busy",
-                        message=pipeline_recovery_blocked_message(pipeline_status),
-                        track_id=track_id,
-                    )
-                if pipeline_status.get("busy"):
+            # Pre-arm owner-checked cleanup before acquire: cancellation at the
+            # helper's lock exit may occur after the reservation update but before
+            # the result is returned.
+            reserved = True
+            result = await acquire_reservation(
+                pipeline_status,
+                pipeline_status_lock,
+                owner_key="scanning_owner",
+                owner=scanning_token,
+                owner_kind="scan",
+                flags={"scanning": True, "scanning_exclusive": True},
+                reject_when=(
+                    (
+                        "busy",
+                        "Pipeline is currently busy processing documents. Wait for "
+                        "the running job to finish before triggering another scan.",
+                    ),
+                    (
+                        "scanning",
+                        "Another scan is already in progress. Wait for it to finish "
+                        "before triggering a new one.",
+                    ),
+                    (
+                        "pending_enqueues",
+                        "Document upload/insert is being enqueued. Wait for in-flight "
+                        "work to complete before triggering a scan.",
+                    ),
+                ),
+            )
+            if not result.acquired:
+                reserved = False
+                if result.conflict is PipelineReservationConflict.BUSY:
                     logger.warning(
                         "Scan request skipped: pipeline is busy processing documents"
                     )
-                    return ScanResponse(
-                        status="scanning_skipped_pipeline_busy",
-                        message=(
-                            "Pipeline is currently busy processing documents. "
-                            "Wait for the running job to finish before triggering another scan."
-                        ),
-                        track_id=track_id,
-                    )
-                if pipeline_status.get("scanning"):
+                elif result.conflict is PipelineReservationConflict.SCANNING:
                     logger.warning(
                         "Scan request skipped: another scan is already in progress"
                     )
-                    return ScanResponse(
-                        status="scanning_skipped_pipeline_busy",
-                        message=(
-                            "Another scan is already in progress. "
-                            "Wait for it to finish before triggering a new one."
-                        ),
-                        track_id=track_id,
+                elif result.conflict is PipelineReservationConflict.PENDING_ENQUEUE:
+                    pending_enqueues = (result.snapshot or {}).get(
+                        "pending_enqueues", 0
                     )
-                pending_enqueues = pipeline_status.get("pending_enqueues", 0)
-                if pending_enqueues > 0:
                     logger.warning(
                         "Scan request skipped: "
                         f"{pending_enqueues} pending enqueue(s) reserved by "
                         "upload/insert endpoints"
                     )
-                    return ScanResponse(
-                        status="scanning_skipped_pipeline_busy",
-                        message=(
-                            "Document upload/insert is being enqueued. "
-                            "Wait for in-flight work to complete before triggering a scan."
-                        ),
-                        track_id=track_id,
-                    )
-                # ``scanning`` covers the whole scan task lifecycle (used by
-                # this endpoint to refuse overlapping scans).
-                # ``scanning_exclusive`` is True only during the
-                # classification phase: run_scanning_process clears it once
-                # classification is done so concurrent uploads can land
-                # while the scan-driven processing finishes.
-                # Take both flags + stamp the owner in a single atomic update.
-                pipeline_status.update(
-                    {
-                        "scanning": True,
-                        "scanning_exclusive": True,
-                        "scanning_owner": make_owner_record(scanning_token, "scan"),
-                    }
+                return ScanResponse(
+                    status="scanning_skipped_pipeline_busy",
+                    message=result.message or "Pipeline reservation is unavailable.",
+                    track_id=track_id,
                 )
-                # Slot now owned by scanning_token; arm the finally so a
-                # cancellation before hand-off releases it. Set inside the lock,
-                # immediately after the atomic update, with no await in between.
-                reserved = True
 
             # Hand the reservation to a managed background task. The start
             # barrier guarantees the child took over (started.set) before we
@@ -3704,8 +3690,9 @@ def create_document_routes(
                 processed_update_status[namespace] = processed_flags
 
             async with pipeline_status_lock:
-                # Convert to regular dict if it's a Manager.dict
-                status_dict = dict(pipeline_status)
+                # DictProxy.copy() is one Manager RPC; dict(proxy) may fetch
+                # values individually through the mapping protocol.
+                status_dict = pipeline_status.copy()
 
             # Drop internal reservation-ownership / dead-process-recovery
             # bookkeeping: these carry raw owner tokens, PIDs and per-token sets
@@ -4344,10 +4331,9 @@ def create_document_routes(
         """
         from lightrag.exceptions import PipelineNotInitializedError
         from lightrag.kg.shared_storage import (
+            check_pipeline_status_mutation,
             get_namespace_data,
             get_namespace_lock,
-            pipeline_recovery_blocked_message,
-            reconcile_dead_pipeline_reservations,
             start_reserved_background_task,
         )
 
@@ -4362,13 +4348,9 @@ def create_document_routes(
             _ps = None
         if _ps is not None:
             _ps_lock = get_namespace_lock("pipeline_status", workspace=rag.workspace)
-            async with _ps_lock:
-                reconcile_dead_pipeline_reservations(_ps)
-                if _ps.get("recovery_required"):
-                    raise HTTPException(
-                        status_code=503,
-                        detail=pipeline_recovery_blocked_message(_ps),
-                    )
+            result = await check_pipeline_status_mutation(_ps, _ps_lock)
+            if not result.acquired:
+                raise HTTPException(status_code=503, detail=result.message)
 
         # Reprocess holds NO reservation of its own — apipeline_process_enqueue_documents
         # acquires (and releases) the busy slot itself. We only need the task to

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -2164,6 +2164,12 @@ async def run_scanning_process(
 
     pipeline_status = None
     pipeline_status_lock = None
+    # Distinguish a normal exit from a cancellation (server shutdown / task
+    # cancel): a cancelled scan MUST NOT kick off a full processing run in its
+    # finally. Shutdown is waiting for THIS task to exit, and one cancel injects
+    # CancelledError only once, so a post-release ``await`` here would otherwise
+    # run parse/LLM/index to completion and stall the shutdown.
+    was_cancelled = False
     try:
         # Fetch INSIDE the release try: the scan endpoint already reserved
         # ``scanning``/``scanning_exclusive`` before scheduling us, so a
@@ -2404,6 +2410,11 @@ async def run_scanning_process(
             )
             await rag.apipeline_process_enqueue_documents()
 
+    except asyncio.CancelledError:
+        # Shutdown / task cancel: skip the deferred drive below and leave
+        # ``scan_deferred_processing`` set for the next scan / trigger.
+        was_cancelled = True
+        raise
     except Exception as e:
         logger.error(f"Error during scanning process: {str(e)}")
         logger.error(traceback.format_exc())
@@ -2434,9 +2445,17 @@ async def run_scanning_process(
         # files or an empty scan directory, so an all-already-processed scan or a
         # classification error would strand it. Drain the queue once now that
         # scanning has fully released. The check is READ-ONLY; the drive's own
-        # acquire clears the deferred flag, so a cancelled or failed drive leaves
-        # it set for the next scan to honour. Empty queue → silent no-op.
-        if pipeline_status is not None and pipeline_status_lock is not None:
+        # acquire clears the deferred flag, so a failed drive leaves it set for
+        # the next scan to honour. Empty queue → silent no-op.
+        #
+        # Skipped on cancellation: a cancelled scan must not start a full
+        # processing run while shutdown waits for it. The flag is never checked
+        # or cleared here, so it stays set for the next scan / trigger.
+        if (
+            not was_cancelled
+            and pipeline_status is not None
+            and pipeline_status_lock is not None
+        ):
             if await has_scan_deferred_processing(
                 pipeline_status, pipeline_status_lock
             ):

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -2158,6 +2158,7 @@ async def run_scanning_process(
     from lightrag.kg.shared_storage import (
         get_namespace_data,
         get_namespace_lock,
+        has_scan_deferred_processing,
         transition_scanning_reservation,
     )
 
@@ -2426,6 +2427,25 @@ async def run_scanning_process(
                         "scanning_owner": None,
                     }
                 )
+
+        # If this scan's ``scanning_exclusive`` fence turned away a concurrent
+        # processing request that no run then picked up, its PENDING doc has no
+        # other trigger — the branches above drive the queue only for new/resume
+        # files or an empty scan directory, so an all-already-processed scan or a
+        # classification error would strand it. Drain the queue once now that
+        # scanning has fully released. The check is READ-ONLY; the drive's own
+        # acquire clears the deferred flag, so a cancelled or failed drive leaves
+        # it set for the next scan to honour. Empty queue → silent no-op.
+        if pipeline_status is not None and pipeline_status_lock is not None:
+            if await has_scan_deferred_processing(
+                pipeline_status, pipeline_status_lock
+            ):
+                try:
+                    await rag.apipeline_process_enqueue_documents()
+                except Exception as drive_error:
+                    logger.error(
+                        f"Deferred post-scan queue drive failed: {drive_error}"
+                    )
 
 
 async def background_delete_documents(

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -1722,6 +1722,7 @@ _INTERNAL_PIPELINE_STATUS_FIELDS = (
     "pending_enqueue_tokens",
     "operation_record",
     "recovery_required",
+    "scan_deferred_processing",
 )
 
 # Owner ``kind`` values whose work is safely RE-RUNNABLE after a dead-owner
@@ -1907,11 +1908,6 @@ class PipelineReservationResult:
     message: Optional[str] = None
     snapshot: Optional[Dict[str, Any]] = None
 
-    def __iter__(self):
-        """Keep the former ``(acquired, reason)`` internal unpacking contract."""
-        yield self.acquired
-        yield self.message
-
 
 def _recovery_required_result(
     snapshot: Dict[str, Any],
@@ -1925,13 +1921,21 @@ def _recovery_required_result(
 
 
 def _conflict_for_status_flag(flag_key: str) -> PipelineReservationConflict:
-    return {
-        "busy": PipelineReservationConflict.BUSY,
-        "scanning": PipelineReservationConflict.SCANNING,
-        "scanning_exclusive": PipelineReservationConflict.SCANNING,
-        "pending_enqueues": PipelineReservationConflict.PENDING_ENQUEUE,
-        "destructive_busy": PipelineReservationConflict.DESTRUCTIVE,
-    }.get(flag_key, PipelineReservationConflict.BUSY)
+    try:
+        return {
+            "busy": PipelineReservationConflict.BUSY,
+            "scanning": PipelineReservationConflict.SCANNING,
+            "scanning_exclusive": PipelineReservationConflict.SCANNING,
+            "pending_enqueues": PipelineReservationConflict.PENDING_ENQUEUE,
+            "destructive_busy": PipelineReservationConflict.DESTRUCTIVE,
+        }[flag_key]
+    except KeyError:
+        # Fail-fast on an unmapped reject_when flag: a silent BUSY fallback would
+        # mislabel the conflict (and its HTTP status) and hide the typo.
+        raise ValueError(
+            f"No reservation conflict mapping for status flag {flag_key!r}; add it "
+            "to _conflict_for_status_flag when introducing a new reject_when flag."
+        ) from None
 
 
 def _prepare_pipeline_reservation_decision(
@@ -2127,8 +2131,11 @@ async def acquire_processing_reservation(
 ) -> PipelineReservationResult:
     """Acquire/take over the single processing slot from one proxy snapshot.
 
-    A competing processor is reduced to a ``request_pending`` nudge in the same
-    update used for any recovery changes. The caller may owner-check release
+    Refuses the slot (without taking it) while a scan holds ``scanning_exclusive``
+    — its classification phase mutates doc_status — and reduces a competing
+    ``busy`` holder to a ``request_pending`` nudge, both in the same update used
+    for any recovery changes. A handed-off run (``already_held``) is exempt from
+    both: it already owns the slot. The caller may owner-check release
     unconditionally because the token is stamped atomically with ``busy``.
     """
     async with pipeline_status_lock:
@@ -2138,6 +2145,31 @@ async def acquire_processing_reservation(
         if snapshot.get("recovery_required"):
             _commit_pipeline_reservation_updates(pipeline_status, recovery_updates)
             return _recovery_required_result(snapshot)
+        # A scan's classification phase (``scanning_exclusive``) mutates
+        # doc_status; a new processor must not read/process concurrently or it
+        # races those rewrites. A handed-off run (``already_held``) took the slot
+        # before scanning could start, so it is exempt. Plain ``scanning`` (the
+        # scan's own post-classification queue drive) is NOT fenced here: the scan
+        # releases ``scanning_exclusive`` before it drives processing.
+        if not already_held and snapshot.get("scanning_exclusive"):
+            # Record the turned-away request so the scan drives the queue once it
+            # releases scanning_exclusive (run_scanning_process finally): an SDK
+            # insert's PENDING doc may have no scan-visible file and no other
+            # trigger. Cleared below when any processing run takes the slot.
+            updates = {"scan_deferred_processing": True}
+            snapshot.update(updates)
+            _commit_pipeline_reservation_updates(
+                pipeline_status, recovery_updates, updates
+            )
+            return PipelineReservationResult(
+                acquired=False,
+                conflict=PipelineReservationConflict.SCANNING,
+                message=(
+                    "Document scan is classifying files; processing resumes after "
+                    "the classification phase finishes."
+                ),
+                snapshot=snapshot,
+            )
         if not already_held and snapshot.get("busy"):
             updates = {"request_pending": True}
             snapshot.update(updates)
@@ -2156,6 +2188,10 @@ async def acquire_processing_reservation(
             {
                 "busy": True,
                 "busy_owner": make_owner_record(token, "processing"),
+                # This run drains the queue, satisfying any request the
+                # scanning_exclusive fence deferred earlier — clear the flag so the
+                # scan's post-release drive stays a no-op.
+                "scan_deferred_processing": False,
             }
         )
         snapshot.update(updates)
@@ -2189,6 +2225,31 @@ async def transition_scanning_reservation(
             return True
 
     return await run_to_completion(_run)
+
+
+async def has_scan_deferred_processing(
+    pipeline_status: Dict[str, Any],
+    pipeline_status_lock,
+) -> bool:
+    """Report whether a scan's ``scanning_exclusive`` fence deferred a processing
+    request that no run has since picked up.
+
+    Read-only ON PURPOSE — it does NOT clear the flag. ``scan_deferred_processing``
+    is set when the fence turns a request away and cleared atomically by
+    ``acquire_processing_reservation`` only when a run actually takes the ``busy``
+    slot. ``run_scanning_process`` checks this after releasing its reservation and
+    drives the queue once when True; the drive's own acquire then clears it.
+
+    Clearing HERE would reopen a cancellation race: the ``pipeline_status_lock``
+    exit awaits, so a ``CancelledError`` delivered AFTER the clear but BEFORE the
+    queue drive would lose both the request and the flag, stranding the PENDING
+    doc. Leaving the clear to the acquire means a cancelled or failed drive keeps
+    the flag set for the next scan — the handoff is only ``done`` once a run owns
+    the slot.
+    """
+    async with pipeline_status_lock:
+        snapshot = _pipeline_status_snapshot(pipeline_status)
+        return bool(snapshot.get("scan_deferred_processing"))
 
 
 async def with_reservation_lock(

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -8,6 +8,8 @@ from multiprocessing.synchronize import Lock as ProcessLock
 from multiprocessing import Manager
 import time
 import logging
+from dataclasses import dataclass
+from enum import Enum
 from contextvars import ContextVar
 from typing import Any, Dict, List, Mapping, Optional, Union, TypeVar, Generic
 
@@ -1779,12 +1781,12 @@ def make_owner_record(token: str, kind: str) -> Dict[str, Any]:
     }
 
 
-def _recover_dead_reservation(
-    pipeline_status: Dict[str, Any],
+def _dead_reservation_updates(
+    pipeline_status: Mapping[str, Any],
     owner_key: str,
     flags: tuple,
     rec: Dict[str, Any],
-) -> None:
+) -> Dict[str, Any]:
     """Reclaim a single-holder reservation whose owner is confirmed dead.
 
     processing / scan → clear flags + owner (the work is re-runnable). Everything
@@ -1803,52 +1805,156 @@ def _recover_dead_reservation(
             # snapshot of what the dead owner was doing (doc_id / scope), if any
             "operation_record": pipeline_status.get("operation_record"),
         }
-    pipeline_status.update(updates)
+    return updates
 
 
-def reconcile_dead_pipeline_reservations(pipeline_status: Dict[str, Any]) -> None:
-    """Reclaim reservations whose owning process is confirmed dead.
+def _dead_pipeline_reservation_updates(
+    status_snapshot: Mapping[str, Any],
+) -> Dict[str, Any]:
+    """Compute dead-owner recovery updates from one local status snapshot.
 
     No-op unless Linux multi-worker (:func:`_reservation_recovery_enabled`).
-    Called inside the ``pipeline_status_lock`` critical section, BEFORE conflict
-    checks, so a dead owner's slot is lazily reclaimed at the next acquire. Uses
-    a FIXED flag→owner mapping (not the generic reject_when set, which only knows
-    the acquirer's own owner_key) and only reclaims a CONFIRMED-dead owner
-    (:func:`_process_alive`); a live-but-slow owner is never preempted.
+    The input MUST be a plain local snapshot, not a Manager ``DictProxy``: all
+    field reads stay local so a reconciliation decision costs one proxy ``copy``
+    at its caller instead of one RPC per ``get``. Only confirmed-dead owners are
+    reclaimed; a live-but-slow owner is never preempted.
     """
     if not _reservation_recovery_enabled():
-        return
+        return {}
+
+    snapshot = dict(status_snapshot)
+    updates: Dict[str, Any] = {}
     # busy_owner covers busy + destructive_busy; scanning_owner covers
     # scanning + scanning_exclusive.
     for owner_key, flags in (
         ("busy_owner", ("busy", "destructive_busy")),
         ("scanning_owner", ("scanning", "scanning_exclusive")),
     ):
-        rec = pipeline_status.get(owner_key)
+        rec = snapshot.get(owner_key)
         if not isinstance(rec, dict):
             continue
-        if not any(pipeline_status.get(flag) for flag in flags):
+        if not any(snapshot.get(flag) for flag in flags):
             continue
         if _process_alive(rec.get("pid"), rec.get("process_start_id")):
             continue
-        _recover_dead_reservation(pipeline_status, owner_key, flags, rec)
+        owner_updates = _dead_reservation_updates(snapshot, owner_key, flags, rec)
+        snapshot.update(owner_updates)
+        updates.update(owner_updates)
 
     # pending_enqueues: {token: {pid, process_start_id}} — drop confirmed-dead
     # tokens (an enqueue is re-runnable: its doc sits in doc_status). Always
     # recalibrate the mirrored count, covering a crash between "dropped token"
     # and "updated count".
-    tokens = dict(pipeline_status.get("pending_enqueue_tokens", {}))
+    tokens = dict(snapshot.get("pending_enqueue_tokens", {}))
     alive = {
         token: meta
         for token, meta in tokens.items()
         if _process_alive((meta or {}).get("pid"), (meta or {}).get("process_start_id"))
     }
-    if len(alive) != len(tokens) or pipeline_status.get("pending_enqueues") != len(
-        alive
-    ):
-        pipeline_status.update(
+    if len(alive) != len(tokens) or snapshot.get("pending_enqueues") != len(alive):
+        updates.update(
             {"pending_enqueue_tokens": alive, "pending_enqueues": len(alive)}
         )
+
+    return updates
+
+
+def _pipeline_status_snapshot(
+    pipeline_status: Mapping[str, Any],
+) -> Dict[str, Any]:
+    """Return one local snapshot of a dict or Manager ``DictProxy``.
+
+    ``DictProxy.copy()`` is one Manager RPC. ``dict(proxy)`` may use the mapping
+    protocol and fetch values individually, so all reservation/status paths use
+    this helper before reading more than one field.
+    """
+    return pipeline_status.copy()
+
+
+def reconcile_dead_pipeline_reservations(
+    pipeline_status: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Reclaim dead reservations with one snapshot and at most one update.
+
+    Call only while holding ``pipeline_status_lock``. Production acquire and
+    mutation paths should use the reservation helpers below, which combine these
+    recovery updates with their own state transition. This wrapper remains for
+    focused recovery tests and compatibility with existing internal callers.
+    """
+    snapshot = _pipeline_status_snapshot(pipeline_status)
+    updates = _dead_pipeline_reservation_updates(snapshot)
+    if updates:
+        pipeline_status.update(updates)
+    return updates
+
+
+class PipelineReservationConflict(str, Enum):
+    """Structured reason why a pipeline reservation was refused."""
+
+    BUSY = "busy"
+    SCANNING = "scanning"
+    PENDING_ENQUEUE = "pending_enqueue"
+    DESTRUCTIVE = "destructive"
+    RECOVERY_REQUIRED = "recovery_required"
+
+
+@dataclass(frozen=True)
+class PipelineReservationResult:
+    """Result of an atomic reservation or mutation-fence decision."""
+
+    acquired: bool
+    conflict: Optional[PipelineReservationConflict] = None
+    message: Optional[str] = None
+    snapshot: Optional[Dict[str, Any]] = None
+
+    def __iter__(self):
+        """Keep the former ``(acquired, reason)`` internal unpacking contract."""
+        yield self.acquired
+        yield self.message
+
+
+def _recovery_required_result(
+    snapshot: Dict[str, Any],
+) -> PipelineReservationResult:
+    return PipelineReservationResult(
+        acquired=False,
+        conflict=PipelineReservationConflict.RECOVERY_REQUIRED,
+        message=pipeline_recovery_blocked_message(snapshot),
+        snapshot=snapshot,
+    )
+
+
+def _conflict_for_status_flag(flag_key: str) -> PipelineReservationConflict:
+    return {
+        "busy": PipelineReservationConflict.BUSY,
+        "scanning": PipelineReservationConflict.SCANNING,
+        "scanning_exclusive": PipelineReservationConflict.SCANNING,
+        "pending_enqueues": PipelineReservationConflict.PENDING_ENQUEUE,
+        "destructive_busy": PipelineReservationConflict.DESTRUCTIVE,
+    }.get(flag_key, PipelineReservationConflict.BUSY)
+
+
+def _prepare_pipeline_reservation_decision(
+    pipeline_status: Dict[str, Any],
+) -> tuple[Dict[str, Any], Dict[str, Any]]:
+    """Take one proxy snapshot and locally apply computed recovery updates."""
+    snapshot = _pipeline_status_snapshot(pipeline_status)
+    recovery_updates = _dead_pipeline_reservation_updates(snapshot)
+    snapshot.update(recovery_updates)
+    return snapshot, recovery_updates
+
+
+def _commit_pipeline_reservation_updates(
+    pipeline_status: Dict[str, Any],
+    recovery_updates: Mapping[str, Any],
+    operation_updates: Optional[Mapping[str, Any]] = None,
+) -> None:
+    """Commit recovery plus operation changes in at most one proxy update."""
+    updates = dict(recovery_updates)
+    if operation_updates:
+        updates.update(operation_updates)
+    if updates:
+        pipeline_status.update(updates)
 
 
 async def run_to_completion(factory, *, max_restarts: int = 3):
@@ -1898,30 +2004,46 @@ async def acquire_reservation(
     pipeline_status_lock,
     *,
     owner_key: str,
-    owner: Any,
+    owner: Any = None,
+    owner_kind: Optional[str] = None,
     flags: Dict[str, Any],
     reject_when,
-) -> tuple[bool, Optional[str]]:
+) -> PipelineReservationResult:
     """Atomically take a single-holder reservation.
 
-    ``reject_when`` is a sequence of ``(flag_key, reason)``: if any flag is set
-    the reservation is refused and ``(False, reason)`` is returned. Otherwise the
-    ``flags`` and ``pipeline_status[owner_key] = owner`` are written in a SINGLE
-    ``status.update`` (atomic against a mid-write crash) and ``(True, None)`` is
-    returned. ``owner`` may be a bare token or an owner record dict.
+    ``reject_when`` is a sequence of ``(flag_key, reason)``. The structured
+    result reports either the matching conflict or a mandatory recovery fence.
+    Otherwise ``flags`` and ``pipeline_status[owner_key] = owner`` are written in
+    one update together with any dead-owner cleanup. ``owner`` may be a bare
+    token or an owner record dict; ``owner_kind`` converts a token into a process
+    identity record inside this shared coordination layer.
 
     The caller MUST have entered its ``try`` before calling this so a cancel at
     the lock exit still runs the ``finally`` that releases ``owner`` by token.
     """
+    if owner_kind is not None:
+        owner = make_owner_record(str(owner), owner_kind)
     async with pipeline_status_lock:
-        reconcile_dead_pipeline_reservations(pipeline_status)
+        snapshot, recovery_updates = _prepare_pipeline_reservation_decision(
+            pipeline_status
+        )
+        if snapshot.get("recovery_required"):
+            _commit_pipeline_reservation_updates(pipeline_status, recovery_updates)
+            return _recovery_required_result(snapshot)
         for flag_key, reason in reject_when:
-            if pipeline_status.get(flag_key):
-                return False, reason
+            if snapshot.get(flag_key):
+                _commit_pipeline_reservation_updates(pipeline_status, recovery_updates)
+                return PipelineReservationResult(
+                    acquired=False,
+                    conflict=_conflict_for_status_flag(flag_key),
+                    message=reason,
+                    snapshot=snapshot,
+                )
         updates = dict(flags)
         updates[owner_key] = owner
-        pipeline_status.update(updates)
-    return True, None
+        snapshot.update(updates)
+        _commit_pipeline_reservation_updates(pipeline_status, recovery_updates, updates)
+    return PipelineReservationResult(acquired=True, snapshot=snapshot)
 
 
 async def acquire_enqueue_reservation(
@@ -1930,7 +2052,7 @@ async def acquire_enqueue_reservation(
     *,
     token: str,
     reject_when,
-) -> tuple[bool, Optional[str]]:
+) -> PipelineReservationResult:
     """Take one of the (concurrent) pending-enqueue reservations.
 
     ``pending_enqueue_tokens`` is a ``{token: metadata}`` set; several enqueues
@@ -1938,16 +2060,135 @@ async def acquire_enqueue_reservation(
     ``pending_enqueues`` in a single atomic update.
     """
     async with pipeline_status_lock:
-        reconcile_dead_pipeline_reservations(pipeline_status)
-        for flag_key, reason in reject_when:
-            if pipeline_status.get(flag_key):
-                return False, reason
-        tokens = dict(pipeline_status.get("pending_enqueue_tokens", {}))
-        tokens[token] = {"pid": os.getpid(), "process_start_id": _my_start_id()}
-        pipeline_status.update(
-            {"pending_enqueue_tokens": tokens, "pending_enqueues": len(tokens)}
+        snapshot, recovery_updates = _prepare_pipeline_reservation_decision(
+            pipeline_status
         )
-    return True, None
+        if snapshot.get("recovery_required"):
+            _commit_pipeline_reservation_updates(pipeline_status, recovery_updates)
+            return _recovery_required_result(snapshot)
+        for flag_key, reason in reject_when:
+            if snapshot.get(flag_key):
+                _commit_pipeline_reservation_updates(pipeline_status, recovery_updates)
+                return PipelineReservationResult(
+                    acquired=False,
+                    conflict=_conflict_for_status_flag(flag_key),
+                    message=reason,
+                    snapshot=snapshot,
+                )
+        tokens = dict(snapshot.get("pending_enqueue_tokens", {}))
+        tokens[token] = {"pid": os.getpid(), "process_start_id": _my_start_id()}
+        updates = {
+            "pending_enqueue_tokens": tokens,
+            "pending_enqueues": len(tokens),
+        }
+        snapshot.update(updates)
+        _commit_pipeline_reservation_updates(pipeline_status, recovery_updates, updates)
+    return PipelineReservationResult(acquired=True, snapshot=snapshot)
+
+
+async def check_pipeline_status_mutation(
+    pipeline_status: Dict[str, Any],
+    pipeline_status_lock,
+    *,
+    reject_when=(),
+) -> PipelineReservationResult:
+    """Reconcile and evaluate a mutation fence without taking a reservation.
+
+    The recovery fence is mandatory. Optional status conflicts are evaluated
+    from the same local snapshot, and recovery writes use at most one update.
+    """
+    async with pipeline_status_lock:
+        snapshot, recovery_updates = _prepare_pipeline_reservation_decision(
+            pipeline_status
+        )
+        if snapshot.get("recovery_required"):
+            _commit_pipeline_reservation_updates(pipeline_status, recovery_updates)
+            return _recovery_required_result(snapshot)
+        for flag_key, reason in reject_when:
+            if snapshot.get(flag_key):
+                _commit_pipeline_reservation_updates(pipeline_status, recovery_updates)
+                return PipelineReservationResult(
+                    acquired=False,
+                    conflict=_conflict_for_status_flag(flag_key),
+                    message=reason,
+                    snapshot=snapshot,
+                )
+        _commit_pipeline_reservation_updates(pipeline_status, recovery_updates)
+        return PipelineReservationResult(acquired=True, snapshot=snapshot)
+
+
+async def acquire_processing_reservation(
+    pipeline_status: Dict[str, Any],
+    pipeline_status_lock,
+    *,
+    token: str,
+    already_held: bool,
+    flags: Mapping[str, Any],
+) -> PipelineReservationResult:
+    """Acquire/take over the single processing slot from one proxy snapshot.
+
+    A competing processor is reduced to a ``request_pending`` nudge in the same
+    update used for any recovery changes. The caller may owner-check release
+    unconditionally because the token is stamped atomically with ``busy``.
+    """
+    async with pipeline_status_lock:
+        snapshot, recovery_updates = _prepare_pipeline_reservation_decision(
+            pipeline_status
+        )
+        if snapshot.get("recovery_required"):
+            _commit_pipeline_reservation_updates(pipeline_status, recovery_updates)
+            return _recovery_required_result(snapshot)
+        if not already_held and snapshot.get("busy"):
+            updates = {"request_pending": True}
+            snapshot.update(updates)
+            _commit_pipeline_reservation_updates(
+                pipeline_status, recovery_updates, updates
+            )
+            return PipelineReservationResult(
+                acquired=False,
+                conflict=PipelineReservationConflict.BUSY,
+                message="Another process is already processing the document queue.",
+                snapshot=snapshot,
+            )
+
+        updates = dict(flags)
+        updates.update(
+            {
+                "busy": True,
+                "busy_owner": make_owner_record(token, "processing"),
+            }
+        )
+        snapshot.update(updates)
+        _commit_pipeline_reservation_updates(pipeline_status, recovery_updates, updates)
+        # history_messages is a ListProxy and must remain the same shared object.
+        del snapshot["history_messages"][:]
+        return PipelineReservationResult(acquired=True, snapshot=snapshot)
+
+
+async def transition_scanning_reservation(
+    pipeline_status: Dict[str, Any],
+    pipeline_status_lock,
+    *,
+    token: str,
+) -> bool:
+    """Owner-checked transition from scan classification to processing.
+
+    The transition is cancellation-resistant and performs one snapshot plus at
+    most one update. It deliberately does not reconcile other reservations: the
+    live scan owner is only narrowing its own reservation.
+    """
+
+    async def _run() -> bool:
+        async with pipeline_status_lock:
+            snapshot = _pipeline_status_snapshot(pipeline_status)
+            if _reservation_owner_token(snapshot.get("scanning_owner")) != token:
+                return False
+            if not snapshot.get("scanning_exclusive"):
+                return True
+            pipeline_status.update({"scanning_exclusive": False})
+            return True
+
+    return await run_to_completion(_run)
 
 
 async def with_reservation_lock(
@@ -1973,7 +2214,8 @@ async def with_reservation_lock(
 
     async def _run():
         async with pipeline_status_lock:
-            if _reservation_owner_token(pipeline_status.get(owner_key)) != token:
+            snapshot = _pipeline_status_snapshot(pipeline_status)
+            if _reservation_owner_token(snapshot.get(owner_key)) != token:
                 return None
             return action(pipeline_status)
 
@@ -1999,7 +2241,8 @@ async def with_token_set_reservation_lock(
 
     async def _run():
         async with pipeline_status_lock:
-            tokens = dict(pipeline_status.get(tokens_key, {}))
+            snapshot = _pipeline_status_snapshot(pipeline_status)
+            tokens = dict(snapshot.get(tokens_key, {}))
             if token not in tokens:
                 return None
             del tokens[token]
@@ -2044,7 +2287,8 @@ async def release_owned_reservation(
             "pipeline_status", workspace=workspace
         )
         async with pipeline_status_lock:
-            if _reservation_owner_token(pipeline_status.get(owner_key)) != token:
+            snapshot = _pipeline_status_snapshot(pipeline_status)
+            if _reservation_owner_token(snapshot.get(owner_key)) != token:
                 return None
             return action(pipeline_status)
 
@@ -2079,7 +2323,8 @@ async def release_token_set_reservation(
             "pipeline_status", workspace=workspace
         )
         async with pipeline_status_lock:
-            tokens = dict(pipeline_status.get(tokens_key, {}))
+            snapshot = _pipeline_status_snapshot(pipeline_status)
+            tokens = dict(snapshot.get(tokens_key, {}))
             if token not in tokens:
                 return None
             del tokens[token]

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -87,14 +87,14 @@ from lightrag.kg import (
 
 
 from lightrag.kg.shared_storage import (
+    PipelineReservationConflict,
+    acquire_reservation,
+    check_pipeline_status_mutation,
     get_namespace_data,
     get_default_workspace,
     set_default_workspace,
     get_namespace_lock,
     get_storage_keyed_lock,
-    make_owner_record,
-    pipeline_recovery_blocked_message,
-    reconcile_dead_pipeline_reservations,
     with_reservation_lock,
 )
 
@@ -1673,64 +1673,46 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             # (rather than queue) when the slot is taken, mirroring
             # ``_acquire_destructive_busy``; ``destructive_busy`` implies
             # ``busy`` so a running clear/delete is covered too.
-            async with pipeline_status_lock:
-                # Reclaim a dead owner's slot before checking busy; a dead
-                # custom_chunks/delete/clear owner raises recovery_required, which
-                # fences all mutations until an explicit recovery.
-                reconcile_dead_pipeline_reservations(pipeline_status)
-                if pipeline_status.get("recovery_required"):
-                    raise RuntimeError(
-                        pipeline_recovery_blocked_message(pipeline_status)
-                    )
-                if pipeline_status.get("busy"):
-                    raise RuntimeError(
+            # Pre-arm owner-checked cleanup before acquire so cancellation at the
+            # helper's lock exit cannot leak the slot.
+            busy_acquired = True
+            reservation = await acquire_reservation(
+                pipeline_status,
+                pipeline_status_lock,
+                owner_key="busy_owner",
+                owner=token,
+                owner_kind="custom_chunks",
+                flags={
+                    "busy": True,
+                    "operation_record": {
+                        "kind": "custom_chunks",
+                        "doc_id": doc_key,
+                    },
+                    "job_name": "Custom chunks insert",
+                    "job_start": datetime.now(timezone.utc).isoformat(),
+                    "latest_message": "Inserting custom chunks",
+                    "cancellation_requested": False,
+                    "cancellation_reason": None,
+                    "cancellation_detail": None,
+                },
+                reject_when=(
+                    (
+                        "busy",
                         "Pipeline is busy with another operation; "
-                        "ainsert_custom_chunks cannot run concurrently. "
-                        "Wait for it to finish and retry."
-                    )
-                if pipeline_status.get("scanning"):
-                    raise RuntimeError(
-                        "A document scan is in progress; "
-                        "ainsert_custom_chunks cannot run concurrently. "
-                        "Wait for the scan to finish and retry."
-                    )
-                # Take the slot and stamp identity in a SINGLE atomic update so a
-                # crash mid-write can never leave busy=True with no owner. The
-                # ``busy_owner`` token lets the finally release the slot by owner
-                # (never clobbering a later holder). ``job_name`` must be a
-                # non-deletion name: after a batch delete, background_delete leaves
-                # job_name="Deleting N Documents", and adelete_by_doc_id treats
-                # busy + a "deleting...document" job_name as "a batch delete is
-                # running, join it" — a non-deletion name makes that guard reject.
-                # Cancellation flags are cleared here (mirroring the processing
-                # loop's acquire) so a stale flag from a previous job does not
-                # immediately abort the extract/merge below.
-                pipeline_status.update(
-                    {
-                        "busy": True,
-                        "busy_owner": make_owner_record(token, "custom_chunks"),
-                        # Snapshot for dead-owner recovery: custom_chunks may
-                        # write Stage-1 storage before the KG is built, so a dead
-                        # owner is fenced (recovery_required) rather than re-run.
-                        "operation_record": {
-                            "kind": "custom_chunks",
-                            "doc_id": doc_key,
-                        },
-                        "job_name": "Custom chunks insert",
-                        "job_start": datetime.now(timezone.utc).isoformat(),
-                        "latest_message": "Inserting custom chunks",
-                        "cancellation_requested": False,
-                        "cancellation_reason": None,
-                        "cancellation_detail": None,
-                    }
-                )
-                # Record ownership INSIDE the locked section, immediately after
-                # taking the slot and before any await (the ``async with`` exit
-                # awaits an asyncio.shield, a cancellation-delivery point). If
-                # busy_acquired were set only after the block, a cancel there
-                # would leave busy=True but busy_acquired=False and the finally
-                # would skip the release, wedging the workspace busy forever.
-                busy_acquired = True
+                        "ainsert_custom_chunks cannot run concurrently. Wait for "
+                        "it to finish and retry.",
+                    ),
+                    (
+                        "scanning",
+                        "A document scan is in progress; ainsert_custom_chunks "
+                        "cannot run concurrently. Wait for the scan to finish and "
+                        "retry.",
+                    ),
+                ),
+            )
+            if not reservation.acquired:
+                busy_acquired = False
+                raise RuntimeError(reservation.message)
 
             # Per-document keyed lock: only one custom-chunk operation may be
             # active for a document (issue #3400 §2.5). The busy reservation
@@ -4368,55 +4350,61 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         # acquire/logging lock exit — before the main try/finally is armed — still
         # releases the slot we took (owner-checked) instead of wedging it.
         try:
-            # Check and acquire pipeline if needed
-            async with pipeline_status_lock:
-                reconcile_dead_pipeline_reservations(pipeline_status)
-                if pipeline_status.get("recovery_required"):
+            # Pre-arm owner-checked cleanup before acquire so cancellation after
+            # the atomic update cannot leak this token's reservation.
+            we_acquired_pipeline = True
+            reservation = await acquire_reservation(
+                pipeline_status,
+                pipeline_status_lock,
+                owner_key="busy_owner",
+                owner=token,
+                owner_kind="delete",
+                flags={
+                    "busy": True,
+                    "operation_record": {"kind": "delete", "doc_id": doc_id},
+                    "job_name": "Single document deletion",
+                    "job_start": datetime.now(timezone.utc).isoformat(),
+                    "docs": 1,
+                    "batchs": 1,
+                    "cur_batch": 0,
+                    "request_pending": False,
+                    "cancellation_requested": False,
+                    "latest_message": f"Starting deletion for document: {doc_id}",
+                },
+                reject_when=(("busy", "Pipeline is busy with another operation."),),
+            )
+            if reservation.acquired:
+                history = (reservation.snapshot or {}).get("history_messages")
+                if history is not None:
+                    history[:] = [f"Starting deletion for document: {doc_id}"]
+            else:
+                we_acquired_pipeline = False
+                if (
+                    reservation.conflict
+                    is PipelineReservationConflict.RECOVERY_REQUIRED
+                ):
                     return DeletionResult(
                         status="not_allowed",
                         doc_id=doc_id,
-                        message=pipeline_recovery_blocked_message(pipeline_status),
+                        message=reservation.message or "Pipeline recovery is required.",
                         status_code=503,
                         file_path=None,
                     )
-                if not pipeline_status.get("busy", False):
-                    # Pipeline is idle - WE acquire it for this deletion. Take the
-                    # slot + stamp identity in a single atomic update.
-                    we_acquired_pipeline = True
-                    pipeline_status.update(
-                        {
-                            "busy": True,
-                            "busy_owner": make_owner_record(token, "delete"),
-                            "operation_record": {"kind": "delete", "doc_id": doc_id},
-                            "job_name": "Single document deletion",
-                            "job_start": datetime.now(timezone.utc).isoformat(),
-                            "docs": 1,
-                            "batchs": 1,
-                            "cur_batch": 0,
-                            "request_pending": False,
-                            "cancellation_requested": False,
-                            "latest_message": f"Starting deletion for document: {doc_id}",
-                        }
+                # Pipeline already busy - verify it's a batch deletion job.
+                snapshot = reservation.snapshot or {}
+                job_name = str(snapshot.get("job_name", "")).lower()
+                if not job_name.startswith("deleting") or "document" not in job_name:
+                    return DeletionResult(
+                        status="not_allowed",
+                        doc_id=doc_id,
+                        message=(
+                            "Deletion not allowed: current job "
+                            f"'{snapshot.get('job_name')}' is not a document deletion job"
+                        ),
+                        status_code=403,
+                        file_path=None,
                     )
-                    # Initialize history messages
-                    pipeline_status["history_messages"][:] = [
-                        f"Starting deletion for document: {doc_id}"
-                    ]
-                else:
-                    # Pipeline already busy - verify it's a deletion job
-                    job_name = pipeline_status.get("job_name", "").lower()
-                    if (
-                        not job_name.startswith("deleting")
-                        or "document" not in job_name
-                    ):
-                        return DeletionResult(
-                            status="not_allowed",
-                            doc_id=doc_id,
-                            message=f"Deletion not allowed: current job '{pipeline_status.get('job_name')}' is not a document deletion job",
-                            status_code=403,
-                            file_path=None,
-                        )
-                    # Pipeline is busy with deletion - proceed without acquiring
+                # Pipeline is busy with batch deletion - join without acquiring.
 
             deletion_operations_started = False
             deletion_fully_completed = False
@@ -5350,12 +5338,6 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         when pipeline_status was never initialised (test rigs).
         """
         from lightrag.exceptions import PipelineNotInitializedError
-        from lightrag.kg.shared_storage import (
-            get_namespace_data,
-            get_namespace_lock,
-            pipeline_recovery_blocked_message,
-            reconcile_dead_pipeline_reservations,
-        )
 
         try:
             pipeline_status = await get_namespace_data(
@@ -5366,10 +5348,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         pipeline_status_lock = get_namespace_lock(
             "pipeline_status", workspace=self.workspace
         )
-        async with pipeline_status_lock:
-            reconcile_dead_pipeline_reservations(pipeline_status)
-            if pipeline_status.get("recovery_required"):
-                raise RuntimeError(pipeline_recovery_blocked_message(pipeline_status))
+        result = await check_pipeline_status_mutation(
+            pipeline_status, pipeline_status_lock
+        )
+        if not result.acquired:
+            raise RuntimeError(result.message)
 
     async def adelete_by_entity(self, entity_name: str) -> DeletionResult:
         """Asynchronously delete an entity and all its relationships.

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -43,11 +43,10 @@ from lightrag.exceptions import (
 )
 from lightrag.kg.shared_storage import (
     _reservation_owner_token,
+    acquire_processing_reservation,
+    check_pipeline_status_mutation,
     get_namespace_data,
     get_namespace_lock,
-    make_owner_record,
-    pipeline_recovery_blocked_message,
-    reconcile_dead_pipeline_reservations,
     run_to_completion,
 )
 from lightrag.operate import merge_nodes_and_edges
@@ -346,28 +345,29 @@ class _PipelineMixin:
         pipeline_status_lock = get_namespace_lock(
             "pipeline_status", workspace=self.workspace
         )
-        async with pipeline_status_lock:
-            # Reclaim a dead owner, then fail-closed if the workspace is fenced.
-            # This is the core write path: the public ``ainsert`` and any direct
-            # caller bypass the REST ``_reserve_enqueue_slot`` guard, so a fenced
-            # workspace (a dead custom_chunks/delete/clear owner may have
-            # half-committed) must refuse HERE too, or it would write full_docs /
-            # doc_status onto a partially-committed store.
-            reconcile_dead_pipeline_reservations(pipeline_status)
-            if pipeline_status.get("recovery_required"):
-                raise RuntimeError(pipeline_recovery_blocked_message(pipeline_status))
-            if not from_scan and pipeline_status.get("scanning_exclusive"):
-                raise RuntimeError(
-                    "Cannot enqueue while scan is classifying files; "
-                    "wait for the classification phase to finish "
-                    "before retrying."
+        reject_when = []
+        if not from_scan:
+            reject_when.append(
+                (
+                    "scanning_exclusive",
+                    "Cannot enqueue while scan is classifying files; wait for the "
+                    "classification phase to finish before retrying.",
                 )
-            if pipeline_status.get("destructive_busy"):
-                raise RuntimeError(
-                    "Cannot enqueue while pipeline is clearing or "
-                    "deleting documents; wait for the running job to "
-                    "finish before retrying."
-                )
+            )
+        reject_when.append(
+            (
+                "destructive_busy",
+                "Cannot enqueue while pipeline is clearing or deleting documents; "
+                "wait for the running job to finish before retrying.",
+            )
+        )
+        mutation_result = await check_pipeline_status_mutation(
+            pipeline_status,
+            pipeline_status_lock,
+            reject_when=reject_when,
+        )
+        if not mutation_result.acquired:
+            raise RuntimeError(mutation_result.message)
 
         # Generate track_id if not provided
         if track_id is None or track_id.strip() == "":
@@ -1061,77 +1061,59 @@ class _PipelineMixin:
         busy_released_in_loop = False
 
         try:
-            async with pipeline_status_lock:
-                # Reclaim any reservation whose owner process is confirmed dead
-                # BEFORE reading busy, so a SIGKILLed worker's slot does not
-                # wedge this acquire (Linux multi-worker only; no-op otherwise).
-                reconcile_dead_pipeline_reservations(pipeline_status)
-                # Fail-closed: if reconcile fenced the workspace (a dead
-                # custom_chunks/delete/clear owner may have half-committed) it
-                # ALSO cleared ``busy``, so without this check the loop would see
-                # busy=False and immediately process documents on a possibly
-                # inconsistent store. Refuse until an explicit recovery.
-                if pipeline_status.get("recovery_required"):
-                    logger.warning(pipeline_recovery_blocked_message(pipeline_status))
-                    return
-                # Ensure only one worker is processing documents. ``_holding_busy``
-                # means the slot was handed to us already owned, so take it over
-                # rather than treating busy=True as "someone else is running".
-                if _holding_busy or not pipeline_status.get("busy", False):
-                    to_process_docs: dict[
-                        str, DocProcessingStatus
-                    ] = await self.doc_status.get_docs_by_statuses(
-                        list(_INFLIGHT_DOC_STATUSES)
-                    )
+            # Pre-arm owner-checked cleanup before acquire: cancellation at the
+            # helper's lock exit may occur after the atomic update but before its
+            # result is returned.
+            holds_busy = True
+            reservation = await acquire_processing_reservation(
+                pipeline_status,
+                pipeline_status_lock,
+                token=token,
+                already_held=_holding_busy,
+                flags={
+                    "job_name": "Default Job",
+                    "job_start": datetime.now(timezone.utc).isoformat(),
+                    "docs": 0,
+                    "batchs": 0,
+                    "cur_batch": 0,
+                    "request_pending": False,
+                    "cancellation_requested": False,
+                    "cancellation_reason": None,
+                    "cancellation_detail": None,
+                    "latest_message": "",
+                },
+            )
+            if not reservation.acquired:
+                holds_busy = False
+                if reservation.message and reservation.conflict is not None:
+                    if reservation.conflict.value == "recovery_required":
+                        logger.warning(reservation.message)
+                    else:
+                        logger.info(
+                            "Another process is already processing the document "
+                            "queue. Request queued."
+                        )
+                return
 
-                    if not to_process_docs:
-                        # Nothing to do. A handed-off slot is released by the
-                        # finally (holds_busy, owner-checked); a normal run
-                        # never took the slot, so the finally is a no-op.
-                        logger.info("No documents to process")
-                        return
-
-                    pipeline_status.update(
-                        {
-                            "busy": True,
-                            "busy_owner": make_owner_record(token, "processing"),
-                            "job_name": "Default Job",
-                            "job_start": datetime.now(timezone.utc).isoformat(),
-                            "docs": 0,
-                            "batchs": 0,  # Total number of files to be processed
-                            "cur_batch": 0,  # Number of files already processed
-                            "request_pending": False,  # Clear any previous request
-                            "cancellation_requested": False,  # Initialize cancellation flag
-                            "cancellation_reason": None,  # "internal_error" or None (user)
-                            "cancellation_detail": None,  # driver + root cause for internal
-                            "latest_message": "",
-                        }
-                    )
-                    # Cleaning history_messages without breaking it as a shared list object
-                    del pipeline_status["history_messages"][:]
-                    holds_busy = True
-                else:
-                    # Another process is busy, just set request flag and return
-                    pipeline_status["request_pending"] = True
-                    logger.info(
-                        "Another process is already processing the document queue. Request queued."
-                    )
-                    return
-            # The acquire lock exits here (an await point). Because it is INSIDE
-            # this try, a cancellation delivered at the lock exit still runs the
-            # finally, which releases ``busy`` iff we own it (holds_busy + token).
+            to_process_docs: dict[
+                str, DocProcessingStatus
+            ] = await self.doc_status.get_docs_by_statuses(list(_INFLIGHT_DOC_STATUSES))
+            if not to_process_docs:
+                logger.info("No documents to process")
+                return
 
             # Process documents until no more documents or requests
             while True:
                 # Check for cancellation request at the start of main loop
                 async with pipeline_status_lock:
-                    if pipeline_status.get("cancellation_requested", False):
+                    status_snapshot = pipeline_status.copy()
+                    if status_snapshot.get("cancellation_requested", False):
                         # Read the cause BEFORE resetting reason/detail below.
                         is_internal = (
-                            pipeline_status.get("cancellation_reason")
+                            status_snapshot.get("cancellation_reason")
                             == "internal_error"
                         )
-                        label = self._cancellation_label(pipeline_status)
+                        label = self._cancellation_label(status_snapshot)
 
                         if is_internal:
                             # Unrecoverable storage error: halting is intentional
@@ -1154,7 +1136,7 @@ class _PipelineMixin:
                                 "latest_message": log_message,
                             }
                         )
-                        pipeline_status["history_messages"].append(log_message)
+                        status_snapshot["history_messages"].append(log_message)
 
                         # Exit directly, skipping request_pending check
                         return
@@ -1252,11 +1234,15 @@ class _PipelineMixin:
                     "pipeline_status", workspace=self.workspace
                 )
                 async with lock:
-                    current_owner = _reservation_owner_token(status.get("busy_owner"))
+                    status_snapshot = status.copy()
+                    current_owner = _reservation_owner_token(
+                        status_snapshot.get("busy_owner")
+                    )
+                    updates = {}
                     # Release ``busy`` only if the loop did not already release it
                     # under the atomic exit check AND we still own the slot.
                     if not busy_released_in_loop and current_owner == token:
-                        status.update({"busy": False, "busy_owner": None})
+                        updates.update({"busy": False, "busy_owner": None})
                         current_owner = None  # slot is now free
 
                     # Bookkeeping (cancellation reset, stopped/halt messages) must
@@ -1272,12 +1258,12 @@ class _PipelineMixin:
                     # BEFORE clearing the reason/detail (read it first so
                     # _cancellation_label sees the cause).
                     internal_halt = None
-                    if status.get("cancellation_reason") == "internal_error":
+                    if status_snapshot.get("cancellation_reason") == "internal_error":
                         internal_halt = self._internal_halt_message(
-                            self._cancellation_label(status)
+                            self._cancellation_label(status_snapshot)
                         )
                         logger.error(internal_halt)
-                    status.update(
+                    updates.update(
                         {
                             "cancellation_requested": False,
                             "cancellation_reason": None,
@@ -1287,9 +1273,10 @@ class _PipelineMixin:
                             else stopped_message,
                         }
                     )
-                    status["history_messages"].append(stopped_message)
+                    status.update(updates)
+                    status_snapshot["history_messages"].append(stopped_message)
                     if internal_halt is not None:
-                        status["history_messages"].append(internal_halt)
+                        status_snapshot["history_messages"].append(internal_halt)
 
             await run_to_completion(_finalize)
 
@@ -1486,9 +1473,10 @@ class _PipelineMixin:
         # carried into the next batch — every affected document is reprocessed
         # on retry. See _discard_pending_index_ops / drop_pending_index_ops.
         async with pipeline_status_lock:
+            status_snapshot = pipeline_status.copy()
             internal_abort = (
-                pipeline_status.get("cancellation_requested", False)
-                and pipeline_status.get("cancellation_reason") == "internal_error"
+                status_snapshot.get("cancellation_requested", False)
+                and status_snapshot.get("cancellation_reason") == "internal_error"
             )
         if internal_abort:
             await self._discard_pending_index_ops()
@@ -1722,8 +1710,9 @@ class _PipelineMixin:
             continue the loop.
         """
         async with pipeline_status_lock:
-            if pipeline_status.get("request_pending", False):
-                pipeline_status["request_pending"] = False
+            status_snapshot = pipeline_status.copy()
+            if status_snapshot.get("request_pending", False):
+                pipeline_status.update({"request_pending": False})
                 return False
             # Release the slot together with its owner token so a later
             # owner-checked release (the finally, or a fresh acquirer) sees the
@@ -3163,8 +3152,9 @@ class _PipelineMixin:
         sibling tasks (e.g. successful multimodal items inside a doc that is
         being cancelled) survive a server restart.
         """
+        status_snapshot = pipeline_status.copy()
         error_msg = (
-            f"{self._cancellation_label(pipeline_status)} during "
+            f"{self._cancellation_label(status_snapshot)} during "
             f"{stage_label}: {file_path}"
         )
         logger.warning(error_msg)
@@ -3209,7 +3199,7 @@ class _PipelineMixin:
         preserves the failed chunks snapshot and processing-time metadata.
         """
         if isinstance(error, PipelineCancelledException):
-            cancel_label = self._cancellation_label(pipeline_status)
+            cancel_label = self._cancellation_label(pipeline_status.copy())
             # The cancel exceptions raised by the merge/summary stages hardcode a
             # generic "User cancelled during <stage>" message. When the batch was
             # actually aborted by an internal error (e.g. a storage outage), that

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -42,6 +42,7 @@ from lightrag.exceptions import (
     IndexFlushError,
 )
 from lightrag.kg.shared_storage import (
+    PipelineReservationConflict,
     _reservation_owner_token,
     acquire_processing_reservation,
     check_pipeline_status_mutation,
@@ -1061,9 +1062,14 @@ class _PipelineMixin:
         busy_released_in_loop = False
 
         try:
-            # Pre-arm owner-checked cleanup before acquire: cancellation at the
-            # helper's lock exit may occur after the atomic update but before its
-            # result is returned.
+            # Acquire the processing slot BEFORE reading doc_status. The queue
+            # read and all downstream work MUST run under ``busy`` so a concurrent
+            # clear/delete (which takes ``busy`` then rewrites storage) and a scan
+            # classification phase (``scanning_exclusive``, refused by
+            # acquire_processing_reservation) are held off — reading doc_status
+            # outside the reservation would race their storage rewrites. A
+            # handed-off run (``_holding_busy``) already owns the slot and takes it
+            # over rather than re-acquiring.
             holds_busy = True
             reservation = await acquire_processing_reservation(
                 pipeline_status,
@@ -1085,22 +1091,44 @@ class _PipelineMixin:
             )
             if not reservation.acquired:
                 holds_busy = False
-                if reservation.message and reservation.conflict is not None:
-                    if reservation.conflict.value == "recovery_required":
-                        logger.warning(reservation.message)
-                    else:
-                        logger.info(
-                            "Another process is already processing the document "
-                            "queue. Request queued."
-                        )
+                if (
+                    reservation.conflict
+                    is PipelineReservationConflict.RECOVERY_REQUIRED
+                ):
+                    logger.warning(reservation.message)
+                elif reservation.conflict is PipelineReservationConflict.SCANNING:
+                    logger.info(
+                        "Scan is classifying files; processing will resume once "
+                        "the classification phase finishes."
+                    )
+                else:
+                    logger.info(
+                        "Another process is already processing the document "
+                        "queue. Request queued."
+                    )
                 return
 
             to_process_docs: dict[
                 str, DocProcessingStatus
             ] = await self.doc_status.get_docs_by_statuses(list(_INFLIGHT_DOC_STATUSES))
             if not to_process_docs:
+                # Empty queue. Release the slot we just took WITHOUT the "pipeline
+                # stopped" bookkeeping — a run that did no work should record
+                # nothing — but do it through the atomic release that also consumes
+                # a ``request_pending`` set by a concurrent enqueue AFTER our read,
+                # so a doc that landed in that gap is not stranded in PENDING.
                 logger.info("No documents to process")
-                return
+                if await self._atomic_release_busy_or_consume_pending(
+                    pipeline_status, pipeline_status_lock
+                ):
+                    # No pending work: slot released silently, finally is a no-op.
+                    holds_busy = False
+                    return
+                # request_pending was set: a doc arrived after our read. Re-fetch
+                # and fall through into the loop to process it.
+                to_process_docs = await self.doc_status.get_docs_by_statuses(
+                    list(_INFLIGHT_DOC_STATUSES)
+                )
 
             # Process documents until no more documents or requests
             while True:
@@ -1222,10 +1250,11 @@ class _PipelineMixin:
 
             async def _finalize():
                 # Cancellation-resistant, owner-checked release + bookkeeping.
-                # Only runs when THIS invocation actually held the slot: a queued
-                # request, a normal no-docs return, or a get-docs failure before
-                # acquiring never entered here (holds_busy stays False), so we
-                # never touch another run's state.
+                # Only runs when THIS invocation held the slot AND did work: a
+                # rejected acquire (busy/scanning/recovery) and an empty-queue run
+                # both release their slot inline and clear holds_busy, so they skip
+                # this — no spurious stop message, and we never touch another run's
+                # state.
                 if not holds_busy:
                     return
                 logger.info(stopped_message)

--- a/tests/api/test_health_auth.py
+++ b/tests/api/test_health_auth.py
@@ -92,7 +92,7 @@ class _FakeOllamaAPI:
         self.router = APIRouter()
 
 
-def _build_client(monkeypatch, *, api_key=None):
+def _build_client(monkeypatch, *, api_key=None, pipeline_status=None):
     """Build a /health-capable TestClient with all backend I/O mocked out."""
     from lightrag.api.config import parse_args, initialize_config
 
@@ -121,7 +121,13 @@ def _build_client(monkeypatch, *, api_key=None):
     )
     monkeypatch.setattr(lightrag_server, "OllamaAPI", _FakeOllamaAPI)
     monkeypatch.setattr(
-        lightrag_server, "get_namespace_data", AsyncMock(return_value={"busy": False})
+        lightrag_server,
+        "get_namespace_data",
+        AsyncMock(
+            return_value=(
+                {"busy": False} if pipeline_status is None else pipeline_status
+            )
+        ),
     )
     monkeypatch.setattr(lightrag_server, "get_default_workspace", lambda: "default")
     monkeypatch.setattr(
@@ -172,6 +178,34 @@ def test_open_mode_returns_full_config_to_anonymous(monkeypatch):
 
     assert resp.status_code == 200
     _assert_full_config(resp.json())
+
+
+def test_health_reads_pipeline_status_with_one_snapshot(monkeypatch):
+    class SnapshotOnlyStatus(dict):
+        copy_calls = 0
+
+        def copy(self):
+            self.copy_calls += 1
+            return dict.copy(self)
+
+        def get(self, *_args, **_kwargs):
+            raise AssertionError("/health must not issue per-field proxy gets")
+
+    status = SnapshotOnlyStatus(
+        {
+            "busy": False,
+            "scanning": False,
+            "destructive_busy": False,
+            "pending_enqueues": 0,
+        }
+    )
+    client = _build_client(monkeypatch, pipeline_status=status)
+    _set_auth_mode(monkeypatch, auth_configured=False)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert status.copy_calls == 1
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/kg/test_reservation_architecture.py
+++ b/tests/kg/test_reservation_architecture.py
@@ -1,0 +1,36 @@
+"""Architecture guards for centralized pipeline reservation coordination."""
+
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+LIGHTRAG_ROOT = PROJECT_ROOT / "lightrag"
+SHARED_STORAGE = LIGHTRAG_ROOT / "kg" / "shared_storage.py"
+
+
+def _production_python_sources():
+    for path in LIGHTRAG_ROOT.rglob("*.py"):
+        if path != SHARED_STORAGE:
+            yield path
+
+
+@pytest.mark.offline
+def test_dead_reservation_reconcile_is_shared_storage_private():
+    offenders = [
+        str(path.relative_to(PROJECT_ROOT))
+        for path in _production_python_sources()
+        if "reconcile_dead_pipeline_reservations" in path.read_text()
+    ]
+    assert offenders == []
+
+
+@pytest.mark.offline
+def test_reservation_owner_records_are_created_only_in_shared_storage():
+    offenders = [
+        str(path.relative_to(PROJECT_ROOT))
+        for path in _production_python_sources()
+        if "make_owner_record(" in path.read_text()
+    ]
+    assert offenders == []

--- a/tests/kg/test_reservation_dead_process_recovery.py
+++ b/tests/kg/test_reservation_dead_process_recovery.py
@@ -14,6 +14,7 @@ the logic off-Linux. The ``recovery_required`` *guard* (refusing mutations while
 fenced) is NOT gated and is tested directly.
 """
 
+import asyncio
 import importlib
 import os
 import subprocess
@@ -400,3 +401,45 @@ async def test_pipeline_status_filters_internal_fields(tmp_path):
             assert field not in dumped, f"{field} leaked to /pipeline_status"
     finally:
         finalize_share_data()
+
+
+@pytest.mark.offline
+async def test_pipeline_status_reads_one_proxy_snapshot(monkeypatch, tmp_path):
+    class SnapshotOnlyStatus(dict):
+        copy_calls = 0
+
+        def copy(self):
+            self.copy_calls += 1
+            return dict.copy(self)
+
+        def get(self, *_args, **_kwargs):
+            raise AssertionError("pipeline status must be read from one snapshot")
+
+    status = SnapshotOnlyStatus(
+        {
+            "busy": False,
+            "history_messages": [],
+            "job_start": None,
+        }
+    )
+
+    async def fake_get_namespace_data(*_args, **_kwargs):
+        return status
+
+    async def fake_update_flags(*_args, **_kwargs):
+        return {}
+
+    monkeypatch.setattr(shared_storage, "get_namespace_data", fake_get_namespace_data)
+    monkeypatch.setattr(
+        shared_storage, "get_namespace_lock", lambda *_a, **_k: asyncio.Lock()
+    )
+    monkeypatch.setattr(
+        shared_storage, "get_all_update_flags_status", fake_update_flags
+    )
+
+    rag = _Rag()
+    router = dr.create_document_routes(rag, dr.DocumentManager(str(tmp_path)))
+    response = await _endpoint(router, "get_pipeline_status")()
+
+    assert response.busy is False
+    assert status.copy_calls == 1

--- a/tests/kg/test_reservation_dead_process_recovery.py
+++ b/tests/kg/test_reservation_dead_process_recovery.py
@@ -517,3 +517,40 @@ async def test_scan_without_deferred_flag_does_not_extra_drive():
         assert process_calls == []
     finally:
         finalize_share_data()
+
+
+class _CancelDocManager:
+    """Raises CancelledError to simulate a scan cancelled by server shutdown."""
+
+    def scan_directory_for_new_files(self):
+        raise asyncio.CancelledError()
+
+
+@pytest.mark.offline
+async def test_cancelled_scan_skips_deferred_drive():
+    """A cancelled scan (server shutdown) must NOT start a processing run in its
+    finally — shutdown is waiting for this task to exit, and one cancel injects
+    CancelledError only once, so an unguarded post-release drive would run to
+    completion and stall the shutdown. The deferred flag stays set for the next
+    scan / trigger instead of being driven or lost."""
+    finalize_share_data()
+    initialize_share_data(1)
+    try:
+        ws = "scan-cancel-ws"
+        await initialize_pipeline_status(workspace=ws)
+        ps = await get_namespace_data("pipeline_status", workspace=ws)
+        ps["scan_deferred_processing"] = True
+
+        process_calls: list[int] = []
+        with pytest.raises(asyncio.CancelledError):
+            await dr.run_scanning_process(
+                _DeferRag(ws, process_calls), _CancelDocManager(), "track-cancel"
+            )
+
+        # No processing kicked off during shutdown...
+        assert process_calls == []
+        # ...and the deferred request is preserved for the next scan / trigger.
+        ps_after = await get_namespace_data("pipeline_status", workspace=ws)
+        assert ps_after.get("scan_deferred_processing") is True
+    finally:
+        finalize_share_data()

--- a/tests/kg/test_reservation_dead_process_recovery.py
+++ b/tests/kg/test_reservation_dead_process_recovery.py
@@ -443,3 +443,77 @@ async def test_pipeline_status_reads_one_proxy_snapshot(monkeypatch, tmp_path):
 
     assert response.busy is False
     assert status.copy_calls == 1
+
+
+class _DeferRag:
+    """Minimal rag double for run_scanning_process's deferred-drive path."""
+
+    def __init__(self, workspace, process_calls):
+        self.workspace = workspace
+        self._process_calls = process_calls
+
+    async def arollback_failed_custom_chunk_patches(self, **_kwargs):
+        return None
+
+    async def apipeline_process_enqueue_documents(self):
+        self._process_calls.append(1)
+
+
+class _BoomDocManager:
+    """Raises during classification so no scan branch drives the queue."""
+
+    def scan_directory_for_new_files(self):
+        raise RuntimeError("classification boom")
+
+
+@pytest.mark.offline
+async def test_scan_drives_deferred_processing_on_error_path():
+    """A scan whose ``scanning_exclusive`` fence turned away a processing request
+    must still drive the queue once after releasing — otherwise the SDK-inserted
+    PENDING doc (no scan-visible file) is stranded. Here classification raises, so
+    only the finally's deferred-processing drive can trigger it."""
+    finalize_share_data()
+    initialize_share_data(1)
+    try:
+        ws = "scan-defer-ws"
+        await initialize_pipeline_status(workspace=ws)
+        ps = await get_namespace_data("pipeline_status", workspace=ws)
+        # The scanning_exclusive fence deferred a processing request earlier.
+        ps["scan_deferred_processing"] = True
+
+        process_calls: list[int] = []
+        await dr.run_scanning_process(
+            _DeferRag(ws, process_calls), _BoomDocManager(), "track-defer"
+        )
+
+        # The deferred request was honoured despite the classification error.
+        assert process_calls == [1]
+        # The check is read-only: the real clear happens in
+        # acquire_processing_reservation when a run takes the slot, which this
+        # mock drive skips — so the flag stays set (a live acquire would clear it).
+        ps_after = await get_namespace_data("pipeline_status", workspace=ws)
+        assert ps_after.get("scan_deferred_processing") is True
+    finally:
+        finalize_share_data()
+
+
+@pytest.mark.offline
+async def test_scan_without_deferred_flag_does_not_extra_drive():
+    """The finally's deferred drive is gated on the flag: a scan that fenced no
+    processing request must not add a spurious drive (preserves the
+    process_calls==0 contract of the all-already-processed / error paths)."""
+    finalize_share_data()
+    initialize_share_data(1)
+    try:
+        ws = "scan-nodefer-ws"
+        await initialize_pipeline_status(workspace=ws)
+        # scan_deferred_processing never set.
+
+        process_calls: list[int] = []
+        await dr.run_scanning_process(
+            _DeferRag(ws, process_calls), _BoomDocManager(), "track-nodefer"
+        )
+
+        assert process_calls == []
+    finally:
+        finalize_share_data()

--- a/tests/kg/test_reservation_primitives.py
+++ b/tests/kg/test_reservation_primitives.py
@@ -14,6 +14,7 @@ import lightrag.kg.shared_storage as shared_storage
 from lightrag.kg.shared_storage import (
     acquire_enqueue_reservation,
     acquire_reservation,
+    check_pipeline_status_mutation,
     finalize_share_data,
     get_namespace_data,
     get_namespace_lock,
@@ -25,6 +26,28 @@ from lightrag.kg.shared_storage import (
     with_reservation_lock,
     with_token_set_reservation_lock,
 )
+
+
+class _CountingStatus(dict):
+    """DictProxy-shaped fake that counts remote-style method calls."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.copy_calls = 0
+        self.get_calls = 0
+        self.update_calls = 0
+
+    def copy(self):
+        self.copy_calls += 1
+        return dict.copy(self)
+
+    def get(self, key, default=None):
+        self.get_calls += 1
+        return super().get(key, default)
+
+    def update(self, *args, **kwargs):
+        self.update_calls += 1
+        return super().update(*args, **kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -59,6 +82,100 @@ async def test_acquire_reservation_takes_atomically_and_rejects():
     )
     assert ok2 is False and reason2 == "pipeline busy"
     assert ps["busy_owner"] == "tok1"  # untouched
+
+
+@pytest.mark.offline
+async def test_mutation_check_uses_one_snapshot_and_no_update_when_idle(monkeypatch):
+    monkeypatch.setattr(shared_storage, "_reservation_recovery_enabled", lambda: False)
+    ps = _CountingStatus(
+        {
+            "busy": False,
+            "busy_owner": None,
+            "scanning_owner": None,
+            "pending_enqueue_tokens": {},
+            "pending_enqueues": 0,
+        }
+    )
+
+    result = await check_pipeline_status_mutation(ps, asyncio.Lock())
+
+    assert result.acquired is True
+    assert ps.copy_calls == 1
+    assert ps.get_calls == 0
+    assert ps.update_calls == 0
+
+
+@pytest.mark.offline
+async def test_enqueue_acquire_combines_recovery_and_reservation_update(monkeypatch):
+    monkeypatch.setattr(shared_storage, "_reservation_recovery_enabled", lambda: True)
+    monkeypatch.setattr(shared_storage, "_process_alive", lambda *_: False)
+    ps = _CountingStatus(
+        {
+            "busy": False,
+            "busy_owner": None,
+            "scanning": False,
+            "scanning_exclusive": False,
+            "scanning_owner": None,
+            "destructive_busy": False,
+            "pending_enqueue_tokens": {"dead": {"pid": 999999}},
+            "pending_enqueues": 1,
+        }
+    )
+
+    result = await acquire_enqueue_reservation(
+        ps,
+        asyncio.Lock(),
+        token="new",
+        reject_when=(("destructive_busy", "destructive"),),
+    )
+
+    assert result.acquired is True
+    assert set(ps["pending_enqueue_tokens"]) == {"new"}
+    assert ps["pending_enqueues"] == 1
+    assert ps.copy_calls == 1
+    assert ps.get_calls == 0
+    assert ps.update_calls == 1
+
+
+@pytest.mark.offline
+async def test_single_owner_acquire_always_honors_recovery_fence(monkeypatch):
+    monkeypatch.setattr(shared_storage, "_reservation_recovery_enabled", lambda: True)
+    monkeypatch.setattr(shared_storage, "_process_alive", lambda *_: False)
+    ps = _CountingStatus(
+        {
+            "busy": True,
+            "destructive_busy": True,
+            "busy_owner": {
+                "token": "dead",
+                "pid": 999999,
+                "kind": "clear",
+            },
+            "scanning_owner": None,
+            "pending_enqueue_tokens": {},
+            "pending_enqueues": 0,
+        }
+    )
+
+    result = await acquire_reservation(
+        ps,
+        asyncio.Lock(),
+        owner_key="busy_owner",
+        owner="new",
+        owner_kind="processing",
+        flags={"busy": True},
+        reject_when=(),
+    )
+
+    assert result.acquired is False
+    assert (
+        result.conflict is shared_storage.PipelineReservationConflict.RECOVERY_REQUIRED
+    )
+    assert ps["busy"] is False
+    assert ps["busy_owner"] is None
+    assert ps["recovery_required"]["kind"] == "clear"
+    assert ps.copy_calls == 1
+    assert ps.get_calls == 0
+    assert ps.update_calls == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/kg/test_reservation_primitives.py
+++ b/tests/kg/test_reservation_primitives.py
@@ -13,8 +13,10 @@ import pytest
 import lightrag.kg.shared_storage as shared_storage
 from lightrag.kg.shared_storage import (
     acquire_enqueue_reservation,
+    acquire_processing_reservation,
     acquire_reservation,
     check_pipeline_status_mutation,
+    has_scan_deferred_processing,
     finalize_share_data,
     get_namespace_data,
     get_namespace_lock,
@@ -60,7 +62,7 @@ async def test_acquire_reservation_takes_atomically_and_rejects():
     ps = {"busy": False, "scanning": False, "busy_owner": None}
     lock = asyncio.Lock()
 
-    ok, reason = await acquire_reservation(
+    result = await acquire_reservation(
         ps,
         lock,
         owner_key="busy_owner",
@@ -68,11 +70,11 @@ async def test_acquire_reservation_takes_atomically_and_rejects():
         flags={"busy": True},
         reject_when=[("busy", "pipeline busy"), ("scanning", "scanning")],
     )
-    assert ok is True and reason is None
+    assert result.acquired is True and result.message is None
     # flag and owner land together (single atomic update).
     assert ps["busy"] is True and ps["busy_owner"] == "tok1"
 
-    ok2, reason2 = await acquire_reservation(
+    result2 = await acquire_reservation(
         ps,
         lock,
         owner_key="busy_owner",
@@ -80,7 +82,7 @@ async def test_acquire_reservation_takes_atomically_and_rejects():
         flags={"busy": True},
         reject_when=[("busy", "pipeline busy")],
     )
-    assert ok2 is False and reason2 == "pipeline busy"
+    assert result2.acquired is False and result2.message == "pipeline busy"
     assert ps["busy_owner"] == "tok1"  # untouched
 
 
@@ -178,6 +180,88 @@ async def test_single_owner_acquire_always_honors_recovery_fence(monkeypatch):
     assert ps.update_calls == 1
 
 
+@pytest.mark.offline
+async def test_processing_reservation_fences_busy_and_scanning(monkeypatch):
+    """acquire_processing_reservation must NOT take the slot while a destructive
+    op holds ``busy`` or a scan holds ``scanning_exclusive``: reading/processing
+    doc_status then would race their storage rewrites. A handed-off run
+    (``already_held``) already owns the slot and is exempt from both fences.
+    """
+    monkeypatch.setattr(shared_storage, "_reservation_recovery_enabled", lambda: False)
+    lock = asyncio.Lock()
+    flags = {"job_name": "Default Job"}
+
+    # A clear/delete holds ``busy`` → processing is nudged (request_pending); the
+    # destructive slot is left untouched.
+    busy_ps = {
+        "busy": True,
+        "scanning_exclusive": False,
+        "busy_owner": {"token": "destructive", "pid": 1, "kind": "clear"},
+        "history_messages": [],
+    }
+    busy_res = await acquire_processing_reservation(
+        busy_ps, lock, token="proc", already_held=False, flags=flags
+    )
+    assert busy_res.acquired is False
+    assert busy_res.conflict is shared_storage.PipelineReservationConflict.BUSY
+    assert busy_ps["busy"] is True
+    assert busy_ps["busy_owner"]["token"] == "destructive"
+    assert busy_ps["request_pending"] is True
+
+    # A scan classification phase holds ``scanning_exclusive`` → processing is
+    # refused without flipping ``busy`` mid-classification.
+    scan_ps = {
+        "busy": False,
+        "scanning_exclusive": True,
+        "scanning_owner": {"token": "scan", "pid": 1, "kind": "scan"},
+        "history_messages": [],
+    }
+    scan_res = await acquire_processing_reservation(
+        scan_ps, lock, token="proc", already_held=False, flags=flags
+    )
+    assert scan_res.acquired is False
+    assert scan_res.conflict is shared_storage.PipelineReservationConflict.SCANNING
+    assert scan_ps["busy"] is False
+    assert scan_ps.get("busy_owner") is None
+    # The turned-away request is recorded so the scan drives the queue on release.
+    assert scan_ps["scan_deferred_processing"] is True
+
+    # A handed-off run already owns the slot: exempt from the scanning fence and
+    # takes it over (owner stamped, history cleared).
+    handoff_ps = {
+        "busy": True,
+        "scanning_exclusive": True,
+        "busy_owner": {"token": "proc", "pid": 1, "kind": "processing"},
+        "history_messages": ["stale"],
+    }
+    handoff_res = await acquire_processing_reservation(
+        handoff_ps, lock, token="proc", already_held=True, flags=flags
+    )
+    assert handoff_res.acquired is True
+    assert handoff_ps["busy"] is True
+    assert handoff_ps["busy_owner"]["token"] == "proc"
+    assert list(handoff_ps["history_messages"]) == []
+    # Taking the slot clears any deferred-processing flag: this run drains it.
+    assert handoff_ps["scan_deferred_processing"] is False
+
+
+@pytest.mark.offline
+async def test_has_scan_deferred_processing_is_read_only():
+    """The deferred-processing check reports the flag WITHOUT clearing it — the
+    clear is owned by acquire_processing_reservation when a run takes the slot, so
+    a cancelled or failed post-scan drive keeps the flag for the next scan."""
+    lock = asyncio.Lock()
+    ps = {"scan_deferred_processing": True}
+    assert await has_scan_deferred_processing(ps, lock) is True
+    assert ps["scan_deferred_processing"] is True  # NOT cleared by the check
+    # Missing / false → False.
+    assert await has_scan_deferred_processing({}, lock) is False
+    assert (
+        await has_scan_deferred_processing({"scan_deferred_processing": False}, lock)
+        is False
+    )
+
+
 # ---------------------------------------------------------------------------
 # run_to_completion
 # ---------------------------------------------------------------------------
@@ -256,7 +340,7 @@ async def test_with_reservation_lock_is_owner_checked():
         ps = await get_namespace_data("pipeline_status", workspace=ws)
         lock = get_namespace_lock("pipeline_status", workspace=ws)
 
-        ok, _ = await acquire_reservation(
+        result = await acquire_reservation(
             ps,
             lock,
             owner_key="busy_owner",
@@ -264,7 +348,7 @@ async def test_with_reservation_lock_is_owner_checked():
             flags={"busy": True},
             reject_when=[("busy", "busy")],
         )
-        assert ok
+        assert result.acquired
 
         # Correct owner → action runs and releases.
         res = await with_reservation_lock(
@@ -344,13 +428,13 @@ async def test_enqueue_token_set_acquire_and_idempotent_release():
         ps = await get_namespace_data("pipeline_status", workspace=ws)
         lock = get_namespace_lock("pipeline_status", workspace=ws)
 
-        ok1, _ = await acquire_enqueue_reservation(
+        res1 = await acquire_enqueue_reservation(
             ps, lock, token="e1", reject_when=[("destructive_busy", "d")]
         )
-        ok2, _ = await acquire_enqueue_reservation(
+        res2 = await acquire_enqueue_reservation(
             ps, lock, token="e2", reject_when=[("destructive_busy", "d")]
         )
-        assert ok1 and ok2
+        assert res1.acquired and res2.acquired
         assert ps["pending_enqueues"] == 2
         assert set(ps["pending_enqueue_tokens"]) == {"e1", "e2"}
 

--- a/tests/pipeline/test_pipeline_release_closure.py
+++ b/tests/pipeline/test_pipeline_release_closure.py
@@ -3948,3 +3948,58 @@ def test_engine_params_survive_persist_to_full_docs(tmp_path, monkeypatch):
         await rag.finalize_storages()
 
     asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_idle_trigger_releases_slot_silently_without_stop_message(
+    tmp_path, monkeypatch
+):
+    """A process trigger on an empty queue MUST take the ``busy`` slot first — so
+    the doc_status read is protected against a concurrent clear/delete/scan that
+    rewrites storage — then release it SILENTLY: a run that did no work records no
+    ``pipeline stopped`` bookkeeping.
+    """
+    import lightrag.pipeline as pipeline_mod
+    from lightrag.kg.shared_storage import get_namespace_data
+
+    calls = {"acquire": 0}
+    real_acquire = pipeline_mod.acquire_processing_reservation
+
+    async def _spy_acquire(*args, **kwargs):
+        calls["acquire"] += 1
+        return await real_acquire(*args, **kwargs)
+
+    monkeypatch.setattr(pipeline_mod, "acquire_processing_reservation", _spy_acquire)
+
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+        try:
+            # Nothing enqueued: the queue is empty.
+            await rag.apipeline_process_enqueue_documents()
+
+            assert calls["acquire"] == 1, (
+                "empty-queue run must take the slot so the doc_status read is "
+                "protected against a concurrent clear/delete/scan"
+            )
+
+            pipeline_status = await get_namespace_data(
+                "pipeline_status", workspace=rag.workspace
+            )
+            # Slot released after the empty read...
+            assert not pipeline_status.get("busy")
+            assert pipeline_status.get("busy_owner") is None
+            history = [
+                str(m).lower() for m in (pipeline_status.get("history_messages") or [])
+            ]
+            assert not any("stopped" in m for m in history), (
+                f"idle trigger emitted a stop message: {history!r}"
+            )
+            assert (
+                "stopped"
+                not in str(pipeline_status.get("latest_message") or "").lower()
+            )
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Description

Centralize pipeline reservation acquisition and dead-owner recovery so every mutation path applies the recovery fence consistently while reducing multiprocessing DictProxy RPC overhead.

## Related Issues

n/a

## Changes Made

- Compute dead-owner recovery from one local pipeline-status snapshot and merge recovery plus reservation changes into at most one shared update.
- Route enqueue, scan, processing, destructive, custom-chunk, deletion, reprocess, and graph-mutation gates through shared reservation helpers.
- Keep health and pipeline-status endpoints read-only while replacing per-field proxy reads with a single snapshot.
- Add structured reservation conflicts, owner-checked scan phase transitions, RPC-count regression tests, and architecture guards against bypassing shared coordination.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (not necessary; internal behavior and public interfaces are unchanged)
- [x] Unit tests added (if applicable)

## Additional Notes

- Public REST responses, SDK signatures, pipeline_status fields, storage formats, and environment variables are unchanged.
- Full non-integration suite: 3,869 passed, 35 skipped. Five sandbox-blocked SyncManager socket tests were rerun outside the sandbox and passed (7 passed, 1 skipped for that file).
- Ruff check and format verification pass.