### PR TITLE
perf(shared_storage): cut Manager RPCs in update flags, namespace lookup, status API

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -3745,10 +3745,12 @@ def create_document_routes(
             # Add processed update_status to the status dictionary
             status_dict["update_status"] = processed_update_status
 
-            # Convert history_messages to a regular list if it's a Manager.list
-            # and limit to latest 1000 entries with truncation message if needed
+            # Materialize history_messages to a regular list if it's a Manager
+            # ListProxy, then limit to latest 1000 with a truncation banner. A
+            # slice is one Manager RPC; list(proxy) walks the sequence protocol
+            # with one __getitem__ RPC per element (history can hold 10k lines).
             if "history_messages" in status_dict:
-                history_list = list(status_dict["history_messages"])
+                history_list = status_dict["history_messages"][:]
                 total_count = len(history_list)
 
                 if total_count > 1000:

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -235,9 +235,12 @@ class JsonDocStatusStorage(DocStatusStorage):
         """
         async with self._storage_lock:
             if self.storage_updated.value:
-                data_dict = (
-                    dict(self._data) if hasattr(self._data, "_getvalue") else self._data
-                )
+                # DictProxy.copy() is a single Manager RPC that marshals the
+                # whole mapping server-side; dict(proxy) would walk the mapping
+                # protocol and fetch every value with its own RPC. Plain dicts
+                # (single-process mode) copy cheaply and identically — write_json
+                # only reads its argument, so the shallow copy is safe there too.
+                data_dict = self._data.copy()
                 logger.debug(
                     f"[{self.workspace}] Process {os.getpid()} doc status writting {len(data_dict)} records to {self.namespace}"
                 )

--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -223,9 +223,12 @@ class JsonKVStorage(BaseKVStorage):
         """
         async with self._storage_lock:
             if self.storage_updated.value:
-                data_dict = (
-                    dict(self._data) if hasattr(self._data, "_getvalue") else self._data
-                )
+                # DictProxy.copy() is a single Manager RPC that marshals the
+                # whole mapping server-side; dict(proxy) would walk the mapping
+                # protocol and fetch every value with its own RPC. Plain dicts
+                # (single-process mode) copy cheaply and identically — write_json
+                # only reads its argument, so the shallow copy is safe there too.
+                data_dict = self._data.copy()
 
                 # Calculate data count - all data is now flattened
                 data_count = len(data_dict)

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -140,6 +140,13 @@ _waiter_stale_ttl: float = DEFAULT_GLOBAL_SLOT_WAITER_STALE_TTL
 _lease_ns_cache: Optional[Dict[str, Any]] = None
 _queue_stats_ns_cache: Optional[Dict[str, Any]] = None
 
+# Per-process cache of get_namespace_data() results, keyed by final namespace.
+# The underlying shared dict for a namespace is created once and never removed
+# at runtime (the only clear is in finalize_share_data), so a hot-path hit can
+# safely skip the internal lock and the __contains__/__getitem__ RPCs. Reset by
+# initialize_share_data()/finalize_share_data() to preserve workspace isolation.
+_namespace_data_cache: Optional[Dict[str, Any]] = None
+
 # Rate limiting for acquire-failure warnings (fail-closed path).
 _ACQUIRE_FAILURE_LOG_INTERVAL = 30.0
 _last_acquire_failure_log: float = 0.0
@@ -1535,7 +1542,8 @@ def initialize_share_data(
         _last_mp_cleanup_time, \
         _global_concurrency_limits, \
         _lease_ns_cache, \
-        _queue_stats_ns_cache
+        _queue_stats_ns_cache, \
+        _namespace_data_cache
 
     # Check if already initialized
     if _initialized:
@@ -1556,6 +1564,7 @@ def initialize_share_data(
     )
     _lease_ns_cache = None
     _queue_stats_ns_cache = None
+    _namespace_data_cache = {}
     if _global_concurrency_limits:
         direct_log(
             f"Process {os.getpid()} Global concurrency limits: {_global_concurrency_limits}",
@@ -2556,9 +2565,12 @@ async def set_all_update_flags(namespace: str, workspace: str | None = None):
     async with get_internal_lock():
         if final_namespace not in _update_flags:
             raise ValueError(f"Namespace {final_namespace} not found in update flags")
-        # Update flags for both modes
-        for i in range(len(_update_flags[final_namespace])):
-            _update_flags[final_namespace][i].value = True
+        # Snapshot the ListProxy handles once with a slice (one Manager RPC)
+        # instead of re-indexing the DictProxy+ListProxy on every iteration.
+        # Setting .value on each returned ValueProxy still writes through to
+        # the shared object; the internal lock excludes concurrent appends.
+        for flag in _update_flags[final_namespace][:]:
+            flag.value = True
 
 
 async def clear_all_update_flags(namespace: str, workspace: str | None = None):
@@ -2572,9 +2584,9 @@ async def clear_all_update_flags(namespace: str, workspace: str | None = None):
     async with get_internal_lock():
         if final_namespace not in _update_flags:
             raise ValueError(f"Namespace {final_namespace} not found in update flags")
-        # Update flags for both modes
-        for i in range(len(_update_flags[final_namespace])):
-            _update_flags[final_namespace][i].value = False
+        # See set_all_update_flags: one slice RPC to snapshot the flag handles.
+        for flag in _update_flags[final_namespace][:]:
+            flag.value = False
 
 
 async def get_all_update_flags_status(workspace: str | None = None) -> Dict[str, list]:
@@ -2607,8 +2619,11 @@ async def get_all_update_flags_status(workspace: str | None = None) -> Dict[str,
                 if workspace:
                     continue
 
+            # flags is a ListProxy in multiprocess mode; iterating it directly
+            # would cost one getitem RPC per element. Slice once to a local list
+            # of ValueProxy handles, then read each .value.
             worker_statuses = []
-            for flag in flags:
+            for flag in flags[:]:
                 if _is_multiprocess:
                     worker_statuses.append(flag.value)
                 else:
@@ -2667,6 +2682,16 @@ async def get_namespace_data(
 
     final_namespace = get_final_namespace(namespace, workspace)
 
+    # Hot path: a namespace dict, once created, is a stable shared object for the
+    # life of the shared data, so a cached reference is safe to return without
+    # the internal lock or the __contains__/__getitem__ RPCs. The cache only ever
+    # holds already-created namespaces, so the PipelineNotInitializedError guard
+    # below (a miss) is unaffected.
+    if _namespace_data_cache is not None:
+        cached = _namespace_data_cache.get(final_namespace)
+        if cached is not None:
+            return cached
+
     async with get_internal_lock():
         if final_namespace not in _shared_dicts:
             # Special handling for pipeline_status namespace
@@ -2684,7 +2709,12 @@ async def get_namespace_data(
             else:
                 _shared_dicts[final_namespace] = {}
 
-    return _shared_dicts[final_namespace]
+        namespace_data = _shared_dicts[final_namespace]
+
+    if _namespace_data_cache is not None:
+        _namespace_data_cache[final_namespace] = namespace_data
+
+    return namespace_data
 
 
 class NamespaceLock:
@@ -2815,7 +2845,8 @@ def finalize_share_data():
         _default_workspace, \
         _global_concurrency_limits, \
         _lease_ns_cache, \
-        _queue_stats_ns_cache
+        _queue_stats_ns_cache, \
+        _namespace_data_cache
 
     # Check if already initialized
     if not _initialized:
@@ -2882,6 +2913,7 @@ def finalize_share_data():
     _global_concurrency_limits = None
     _lease_ns_cache = None
     _queue_stats_ns_cache = None
+    _namespace_data_cache = None
 
     direct_log(f"Process {os.getpid()} storage data finalization complete")
 

--- a/tests/kg/json_impl/test_json_storage_rpc_counts.py
+++ b/tests/kg/json_impl/test_json_storage_rpc_counts.py
@@ -1,0 +1,203 @@
+"""RPC-count regression tests for the JSON storage persistence snapshot.
+
+``index_done_callback`` snapshots the whole shared namespace before writing it
+to disk. Under multi-worker mode ``self._data`` is a ``multiprocessing.Manager``
+DictProxy, so the snapshot method matters: ``DictProxy.copy()`` is a single
+Manager RPC, whereas ``dict(proxy)`` walks the mapping protocol and fetches
+every value with its own RPC. These tests pin the storage to exactly one
+``copy()`` and zero per-key reads via a counting DictProxy stand-in (the same
+technique as ``tests/kg/test_reservation_primitives.py``), plus a real-Manager
+end-to-end check that the on-disk content is correct with a genuine proxy.
+"""
+
+import json
+
+import pytest
+
+from lightrag.base import DocStatus
+from lightrag.kg.json_doc_status_impl import JsonDocStatusStorage
+from lightrag.kg.json_kv_impl import JsonKVStorage
+from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
+from lightrag.namespace import NameSpace
+
+pytestmark = pytest.mark.offline
+
+
+class _CountingDict(dict):
+    """DictProxy-shaped fake that counts remote-style method calls.
+
+    ``copy()`` returns a plain ``dict`` (as a real ``DictProxy.copy()`` marshals
+    a plain dict back to the client), so any ``len``/iteration the caller does on
+    the snapshot is NOT counted against the proxy — only proxy-level access is.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.copy_calls = 0
+        self.getitem_calls = 0
+        self.keys_calls = 0
+        self.contains_calls = 0
+
+    def copy(self):
+        self.copy_calls += 1
+        return dict(self)
+
+    def __getitem__(self, key):
+        self.getitem_calls += 1
+        return super().__getitem__(key)
+
+    def keys(self):
+        self.keys_calls += 1
+        return super().keys()
+
+    def __contains__(self, key):
+        self.contains_calls += 1
+        return super().__contains__(key)
+
+
+class _DummyEmbeddingFunc:
+    embedding_dim = 1
+    max_token_size = 1
+
+    async def __call__(self, texts, **kwargs):
+        return [[0.0] for _ in texts]
+
+
+def _doc(status: str, file_path: str) -> dict:
+    return {
+        "content_summary": f"{status} summary",
+        "content_length": 10,
+        "file_path": file_path,
+        "status": status,
+        "created_at": "2024-01-01T00:00:00+00:00",
+        "updated_at": "2024-01-01T00:00:00+00:00",
+        "metadata": {},
+        "error_msg": None,
+        "chunks_list": [],
+    }
+
+
+@pytest.fixture
+def single_process_shared_data():
+    finalize_share_data()
+    initialize_share_data(1)
+    yield
+    finalize_share_data()
+
+
+# ---------------------------------------------------------------------------
+# Counting-proxy assertions: exactly one copy(), zero per-key reads
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kv_index_done_callback_snapshots_with_single_copy(
+    tmp_path, single_process_shared_data
+):
+    storage = JsonKVStorage(
+        namespace=NameSpace.KV_STORE_TEXT_CHUNKS,
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=_DummyEmbeddingFunc(),
+        workspace="test",
+    )
+    await storage.initialize()
+
+    counting = _CountingDict({f"chunk-{i}": {"content": str(i)} for i in range(50)})
+    storage._data = counting
+    storage.storage_updated.value = True
+
+    await storage.index_done_callback()
+
+    assert counting.copy_calls == 1
+    assert counting.getitem_calls == 0
+    assert counting.keys_calls == 0
+
+    with open(storage._file_name) as f:
+        on_disk = json.load(f)
+    assert len(on_disk) == 50
+
+
+@pytest.mark.asyncio
+async def test_doc_status_index_done_callback_snapshots_with_single_copy(
+    tmp_path, single_process_shared_data
+):
+    storage = JsonDocStatusStorage(
+        namespace=NameSpace.DOC_STATUS,
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=_DummyEmbeddingFunc(),
+        workspace="test",
+    )
+    await storage.initialize()
+
+    counting = _CountingDict(
+        {f"doc-{i}": _doc("processed", f"{i}.pdf") for i in range(20)}
+    )
+    storage._data = counting
+    storage.storage_updated.value = True
+
+    await storage.index_done_callback()
+
+    assert counting.copy_calls == 1
+    assert counting.getitem_calls == 0
+    assert counting.keys_calls == 0
+
+
+# ---------------------------------------------------------------------------
+# Real Manager end-to-end: genuine DictProxy.copy() persists correct content
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kv_index_done_callback_real_manager_persists(tmp_path):
+    # A real 2-worker Manager makes self._data a genuine DictProxy, exercising
+    # the actual copy() RPC path (not the single-process plain-dict shortcut).
+    finalize_share_data()
+    initialize_share_data(2)
+    try:
+        storage = JsonKVStorage(
+            namespace=NameSpace.KV_STORE_TEXT_CHUNKS,
+            global_config={"working_dir": str(tmp_path)},
+            embedding_func=_DummyEmbeddingFunc(),
+            workspace="test",
+        )
+        await storage.initialize()
+
+        await storage.upsert(
+            {
+                "chunk-a": {"content": "alpha"},
+                "chunk-b": {"content": "beta"},
+            }
+        )
+        await storage.index_done_callback()
+
+        with open(storage._file_name) as f:
+            on_disk = json.load(f)
+        assert set(on_disk.keys()) == {"chunk-a", "chunk-b"}
+        assert on_disk["chunk-a"]["content"] == "alpha"
+        assert on_disk["chunk-b"]["content"] == "beta"
+    finally:
+        finalize_share_data()
+
+
+@pytest.mark.asyncio
+async def test_doc_status_upsert_real_manager_persists(tmp_path):
+    finalize_share_data()
+    initialize_share_data(2)
+    try:
+        storage = JsonDocStatusStorage(
+            namespace=NameSpace.DOC_STATUS,
+            global_config={"working_dir": str(tmp_path)},
+            embedding_func=_DummyEmbeddingFunc(),
+            workspace="test",
+        )
+        await storage.initialize()
+
+        # DocStatus.upsert flushes synchronously via index_done_callback.
+        await storage.upsert({"doc-1": _doc("processed", "a.pdf")})
+
+        with open(storage._file_name) as f:
+            on_disk = json.load(f)
+        assert on_disk["doc-1"]["status"] == DocStatus.PROCESSED.value
+        assert on_disk["doc-1"]["file_path"] == "a.pdf"
+    finally:
+        finalize_share_data()

--- a/tests/kg/test_shared_storage_rpc_counts.py
+++ b/tests/kg/test_shared_storage_rpc_counts.py
@@ -1,0 +1,294 @@
+"""RPC-count regression tests for the shared_storage Manager-proxy reductions.
+
+Covers three optimizations, all of which collapse per-element proxy access to a
+single slice/snapshot under multi-worker mode:
+
+- ``set_all_update_flags`` / ``clear_all_update_flags`` slice the flag ListProxy
+  once instead of re-indexing DictProxy+ListProxy per flag.
+- ``get_namespace_data`` caches the created namespace dict per process, so a
+  hot-path hit skips the internal lock and the __contains__/__getitem__ RPCs.
+- The pipeline_status endpoint materializes ``history_messages`` with a slice
+  (verified via a real Manager end-to-end + cross-fork cache lifetime).
+
+Counting stand-ins mirror the ``tests/kg/test_reservation_primitives.py``
+technique. Single-process mode exercises the same code paths with plain
+containers (0 RPC); the real-Manager cases pin genuine proxy behavior.
+"""
+
+import os
+import sys
+
+import pytest
+
+import lightrag.kg.shared_storage as ss
+from lightrag.exceptions import PipelineNotInitializedError
+from lightrag.kg.shared_storage import (
+    clear_all_update_flags,
+    finalize_share_data,
+    get_final_namespace,
+    get_namespace_data,
+    get_update_flag,
+    initialize_pipeline_status,
+    initialize_share_data,
+    set_all_update_flags,
+)
+
+pytestmark = pytest.mark.offline
+
+
+# ---------------------------------------------------------------------------
+# Counting stand-ins
+# ---------------------------------------------------------------------------
+
+
+class _CountingValue:
+    """ValueProxy-shaped fake counting .value get/set."""
+
+    def __init__(self, initial=False):
+        self._v = initial
+        self.get_calls = 0
+        self.set_calls = 0
+
+    @property
+    def value(self):
+        self.get_calls += 1
+        return self._v
+
+    @value.setter
+    def value(self, v):
+        self.set_calls += 1
+        self._v = v
+
+
+class _CountingList(list):
+    """ListProxy-shaped fake distinguishing slice vs index getitem."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.slice_getitem_calls = 0
+        self.index_getitem_calls = 0
+        self.len_calls = 0
+
+    def __getitem__(self, key):
+        if isinstance(key, slice):
+            self.slice_getitem_calls += 1
+        else:
+            self.index_getitem_calls += 1
+        return super().__getitem__(key)
+
+    def __len__(self):
+        self.len_calls += 1
+        return super().__len__()
+
+
+class _CountingDict(dict):
+    """DictProxy-shaped fake counting contains/getitem/setitem."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.contains_calls = 0
+        self.getitem_calls = 0
+        self.setitem_calls = 0
+
+    def __contains__(self, key):
+        self.contains_calls += 1
+        return super().__contains__(key)
+
+    def __getitem__(self, key):
+        self.getitem_calls += 1
+        return super().__getitem__(key)
+
+    def __setitem__(self, key, value):
+        self.setitem_calls += 1
+        return super().__setitem__(key, value)
+
+
+@pytest.fixture
+def single_process_shared_data():
+    finalize_share_data()
+    initialize_share_data(1)
+    yield
+    finalize_share_data()
+
+
+# ---------------------------------------------------------------------------
+# update flags: one slice, no per-index getitem, no __len__
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_all_update_flags_slices_once(single_process_shared_data):
+    ws = "w"
+    await get_update_flag("ns", workspace=ws)
+    await get_update_flag("ns", workspace=ws)
+    await get_update_flag("ns", workspace=ws)
+
+    final_ns = get_final_namespace("ns", ws)
+    values = [_CountingValue(), _CountingValue(), _CountingValue()]
+    ss._update_flags[final_ns] = _CountingList(values)
+    counting_list = ss._update_flags[final_ns]
+
+    await set_all_update_flags("ns", workspace=ws)
+
+    assert counting_list.slice_getitem_calls == 1
+    assert counting_list.index_getitem_calls == 0
+    assert counting_list.len_calls == 0
+    assert all(v.set_calls == 1 for v in values)
+    assert all(v._v is True for v in values)
+
+
+@pytest.mark.asyncio
+async def test_clear_all_update_flags_slices_once(single_process_shared_data):
+    ws = "w"
+    await get_update_flag("ns", workspace=ws)
+    await get_update_flag("ns", workspace=ws)
+
+    final_ns = get_final_namespace("ns", ws)
+    values = [_CountingValue(True), _CountingValue(True)]
+    ss._update_flags[final_ns] = _CountingList(values)
+    counting_list = ss._update_flags[final_ns]
+
+    await clear_all_update_flags("ns", workspace=ws)
+
+    assert counting_list.slice_getitem_calls == 1
+    assert counting_list.index_getitem_calls == 0
+    assert counting_list.len_calls == 0
+    assert all(v.set_calls == 1 for v in values)
+    assert all(v._v is False for v in values)
+
+
+# ---------------------------------------------------------------------------
+# get_namespace_data: cold create, hot hit skips shared-dict access
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_namespace_cache_hot_hit_skips_shared_dict(single_process_shared_data):
+    counting = _CountingDict()
+    ss._shared_dicts = counting
+
+    first = await get_namespace_data("ns", workspace="w")
+    # cold path: one contains (miss) + one setitem (create) + one getitem (read)
+    assert counting.contains_calls == 1
+    assert counting.setitem_calls == 1
+
+    counting.contains_calls = 0
+    counting.getitem_calls = 0
+    counting.setitem_calls = 0
+
+    second = await get_namespace_data("ns", workspace="w")
+    assert second is first
+    # hot path: served entirely from the per-process cache
+    assert counting.contains_calls == 0
+    assert counting.getitem_calls == 0
+    assert counting.setitem_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_namespace_cache_isolates_workspaces(single_process_shared_data):
+    a = await get_namespace_data("ns", workspace="w1")
+    b = await get_namespace_data("ns", workspace="w2")
+    assert a is not b
+    assert ss._namespace_data_cache[get_final_namespace("ns", "w1")] is a
+    assert ss._namespace_data_cache[get_final_namespace("ns", "w2")] is b
+
+
+@pytest.mark.asyncio
+async def test_namespace_cache_preserves_pipeline_not_initialized(
+    single_process_shared_data,
+):
+    # Uncreated pipeline_status must still raise (cache only holds created NS).
+    with pytest.raises(PipelineNotInitializedError):
+        await get_namespace_data("pipeline_status", workspace="w")
+
+    # After init it resolves and is cached.
+    await initialize_pipeline_status(workspace="w")
+    ps = await get_namespace_data("pipeline_status", workspace="w")
+    assert ss._namespace_data_cache[get_final_namespace("pipeline_status", "w")] is ps
+
+
+@pytest.mark.asyncio
+async def test_namespace_cache_rebuilt_after_finalize():
+    finalize_share_data()
+    initialize_share_data(1)
+    try:
+        old = await get_namespace_data("ns", workspace="w")
+    finally:
+        finalize_share_data()
+    assert ss._namespace_data_cache is None
+
+    initialize_share_data(1)
+    try:
+        assert ss._namespace_data_cache == {}
+        new = await get_namespace_data("ns", workspace="w")
+        assert new is not old
+    finally:
+        finalize_share_data()
+
+
+# ---------------------------------------------------------------------------
+# Real Manager: genuine ListProxy slice + cross-fork cache lifetime
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_history_messages_slice_real_manager(tmp_path):
+    finalize_share_data()
+    initialize_share_data(2)
+    try:
+        await initialize_pipeline_status(workspace="w")
+        ps = await get_namespace_data("pipeline_status", workspace="w")
+        async with ss.get_internal_lock():
+            ps["history_messages"].extend([f"line {i}" for i in range(5)])
+
+        # Mirror the endpoint transform: one copy() then a slice on the nested
+        # ListProxy (not list(proxy)).
+        snapshot = ps.copy()
+        history = snapshot["history_messages"][:]
+        assert history == [f"line {i}" for i in range(5)]
+        assert isinstance(history, list)
+    finally:
+        finalize_share_data()
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "fork"), reason="cross-fork cache test requires os.fork"
+)
+@pytest.mark.filterwarnings("ignore:.*fork.*may lead to deadlocks:DeprecationWarning")
+@pytest.mark.asyncio
+async def test_namespace_cache_survives_fork_real_manager():
+    # Simulate gunicorn master-preload -> worker-fork: parent warms the cache,
+    # a forked child writes through the *cached* proxy, parent sees the write.
+    # The child touches the proxy synchronously (a DictProxy setitem needs no
+    # event loop); multiprocessing's ForkAwareLocal re-establishes the child's
+    # own Manager connection on first use after the fork.
+    finalize_share_data()
+    initialize_share_data(2)
+    try:
+        final_ns = get_final_namespace("fork_ns", "w")
+        ns = await get_namespace_data("fork_ns", workspace="w")
+        ns["seed"] = "parent"  # ensure the namespace exists server-side
+        assert ss._namespace_data_cache[final_ns] is ns
+
+        pid = os.fork()
+        if pid == 0:  # child
+            code = 0
+            try:
+                cached = ss._namespace_data_cache[final_ns]
+                cached["child_key"] = "child_wrote"
+            except Exception:
+                code = 1
+            finally:
+                os._exit(code)
+
+        _, status = os.waitpid(pid, 0)
+        assert os.waitstatus_to_exitcode(status) == 0
+
+        parent_ns = await get_namespace_data("fork_ns", workspace="w")
+        assert parent_ns.get("child_key") == "child_wrote"
+    finally:
+        finalize_share_data()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Description

Three independent reductions of per-element `multiprocessing.Manager` proxy access. Under multi-worker mode (`--workers N`) every proxy method call is one round-trip RPC to the Manager process; single-process mode uses plain containers and is unaffected. Stacks conceptually with #3433 (JSON storage snapshot) but touches disjoint code.

The unifying principle: collapse "loop that re-fetches a proxy handle and indexes it per element" into a single slice/snapshot.

## Changes Made

**1. update flags — slice the ListProxy once**
- `set_all_update_flags` / `clear_all_update_flags` iterated `range(len(...))` and re-indexed `_update_flags[ns][i]` each step (DictProxy getitem + ListProxy getitem + ValueProxy set per flag). Now they slice the flag list once (`_update_flags[ns][:]`, one RPC) and set `.value` on each returned ValueProxy handle. For N worker flags: ~`(1 + 2 + 3N)` RPCs → `(2 + N)`. Writes still propagate (the slice returns the same referents), and the internal lock excludes concurrent appends.
- `get_all_update_flags_status` sliced each namespace's flag list once instead of iterating the ListProxy element-by-element (which costs one getitem RPC per element via the sequence protocol).

**2. get_namespace_data — per-process namespace cache**
- A namespace's shared dict is created once and never removed at runtime (the only `clear` is in `finalize_share_data`). Added `_namespace_data_cache` keyed by final namespace so a hot-path hit returns the cached reference **without the internal lock or the `__contains__`/`__getitem__` RPCs**.
- The cache only ever holds already-created namespaces, so the `PipelineNotInitializedError` guard (which fires on a *miss*) and workspace isolation are unchanged. Reset in `initialize_share_data` (`{}`) / `finalize_share_data` (`None`) alongside the existing `_lease_ns_cache` / `_queue_stats_ns_cache`. Verified `_shared_dicts` has no runtime writer outside `get_namespace_data`, so the cache is the sole creation path.

**3. pipeline_status endpoint — slice history, don't list() it**
- `list(status_dict["history_messages"])` walked the sequence protocol with one `__getitem__` RPC per element (history caps at ~10k lines). Changed to `[:]` (one RPC). The single `pipeline_status.copy()` under the lock is unchanged; the read-side truncation-to-latest-1000 is untouched.

## Tests

New `tests/kg/test_shared_storage_rpc_counts.py` (`@pytest.mark.offline`):
- counting proxy stand-ins asserting `set_all`/`clear_all` do **exactly one slice, zero per-index getitem, zero `__len__`**;
- namespace cache: cold-create then hot hit touches the shared dict **zero** times; workspace-key isolation; uninitialized `pipeline_status` still raises `PipelineNotInitializedError`; cache rebuilt (not reused) after finalize→reinit;
- real-Manager (`initialize_share_data(2)`): genuine nested ListProxy slice returns correct content; **cross-fork** test that a cached namespace proxy survives master-preload → worker-fork and the child's write is visible to the parent (the gunicorn preload scenario; skipped where `os.fork` is unavailable).

## Verification

- `./scripts/test.sh tests/kg tests/api tests/pipeline tests/workspace` — 1679 passed, 35 skipped.
- `pre-commit run ruff-format/ruff --files …` — passed.

## Scope notes (intentionally NOT in this PR)

- queue-stats aggregation (`aggregate_queue_stats`) is left as-is pending a real multi-queue Manager benchmark: a blanket `ns.copy()` per queue could trade one RPC for a larger serialization cost across a `/health` sweep.
- keyed-lock registry bookkeeping RPCs are a separate concern (deferred).

## Checklist

- [x] Changes tested locally
- [x] Unit tests added