### PR TITLE
fix(utils): close compute_args_hash cache-key collision via length-prefixed encoding

### DIFF
--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -643,9 +643,29 @@ def compute_args_hash(*args: Any) -> str:
         *args: Arguments to hash
     Returns:
         str: Hash string
+
+    Note:
+        - **Single-argument calls preserve the original algorithm** (plain
+          ``str(arg)``) so that ``compute_mdhash_id(content)`` keeps producing
+          the same document IDs across upgrades. Existing persisted IDs stay valid.
+        - **Two or more arguments** use length-prefixed encoding
+          (``"{len}:{str(arg)}"`` joined without separators) so that adjacent
+          field boundaries are unambiguously recoverable. This prevents the
+          cache-key collisions that the delimiter-less join could produce
+          (e.g. ``("abc","x")`` vs ``("ab","cx")`` both hashed to the same MD5).
+          Length-prefixing is used instead of a sentinel character because
+          query text and free-form fields can contain arbitrary characters,
+          so any fixed delimiter could still be constructed to collide.
     """
-    # Convert all arguments to strings and join them
-    args_str = "".join([str(arg) for arg in args])
+    if len(args) <= 1:
+        # Single-arg (or no-arg) path: keep the legacy behavior unchanged so
+        # compute_mdhash_id(content) document IDs remain stable.
+        args_str = "".join([str(arg) for arg in args])
+    else:
+        # Multi-arg path: length-prefix each field to make boundaries unique.
+        # Format: "3:abc1:x2:10" — the leading length makes the field extent
+        # unambiguous regardless of the field content.
+        args_str = "".join(f"{len(s)}:{s}" for s in (str(arg) for arg in args))
 
     # Use 'replace' error handling to safely encode problematic Unicode characters
     # This replaces invalid characters with Unicode replacement character (U+FFFD)

--- a/tests/utils/test_compute_args_hash.py
+++ b/tests/utils/test_compute_args_hash.py
@@ -1,0 +1,126 @@
+"""Regression tests for ``compute_args_hash`` cache-key collision.
+
+Verifies the length-prefixed encoding closes the delimiter-less join bug
+reported in issue #3392, where adjacent field boundaries could shift a
+character and produce identical MD5 cache keys for semantically distinct
+argument tuples.
+
+Coverage:
+- The two collision cases from the issue now produce distinct hashes.
+- Inputs containing the ``"\\x1e"`` record-separator (or any delimiter a
+  sentinel-based fix might have chosen) still do not collide.
+- Identical argument tuples still hash identically (cache HIT preserved).
+- Single-argument calls preserve the legacy hash value verbatim, so
+  ``compute_mdhash_id`` document IDs remain stable across upgrades.
+- Surrogate / invalid Unicode handling does not regress.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from lightrag.utils import compute_args_hash, compute_mdhash_id
+
+
+pytestmark = pytest.mark.offline
+
+
+# ---------------------------------------------------------------------------
+# Collision cases from issue #3392 — must now produce DISTINCT hashes.
+# ---------------------------------------------------------------------------
+
+
+def test_adjacent_text_field_boundary_does_not_collide():
+    """Reproduces issue case 1: (query, response_type) boundary shift."""
+    a = compute_args_hash("hybrid", "abc", "x", 10, 20, 6000, 8000, 30000)
+    b = compute_args_hash("hybrid", "ab", "cx", 10, 20, 6000, 8000, 30000)
+    assert a != b, (
+        f"Adjacent free-text boundary shift must not collide, both hashed to {a}"
+    )
+
+
+def test_adjacent_integer_field_boundary_does_not_collide():
+    """Reproduces issue case 2: (top_k, chunk_top_k) boundary shift."""
+    c = compute_args_hash("hybrid", "q", "text", 1, 20, 6000, 8000, 30000)
+    d = compute_args_hash("hybrid", "q", "text", 12, 0, 6000, 8000, 30000)
+    assert c != d, (
+        f"Adjacent integer boundary shift must not collide, both hashed to {c}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sentinel robustness: even inputs containing a would-be delimiter character
+# must not collide, because the encoding is length-based, not delimiter-based.
+# ---------------------------------------------------------------------------
+
+
+def test_inputs_containing_record_separator_do_not_collide():
+    """A sentinel-based fix would still be vulnerable to inputs that contain
+    the sentinel character. Length-prefixing must be immune."""
+    e = compute_args_hash("a\x1eb", "c")
+    f = compute_args_hash("a", "b\x1ec")
+    assert e != f, "Inputs containing the record-separator character must not collide"
+
+
+# ---------------------------------------------------------------------------
+# Cache HIT preserved: identical tuples still hash identically.
+# ---------------------------------------------------------------------------
+
+
+def test_identical_arguments_hash_identically():
+    g = compute_args_hash("hybrid", "abc", "x", 10, 20, 6000, 8000, 30000)
+    h = compute_args_hash("hybrid", "abc", "x", 10, 20, 6000, 8000, 30000)
+    assert g == h, "Identical argument tuples must hash identically (cache HIT)"
+
+
+# ---------------------------------------------------------------------------
+# Single-argument stability: document IDs (compute_mdhash_id) must not change,
+# otherwise persisted storage records break on upgrade.
+# ---------------------------------------------------------------------------
+
+
+def test_single_argument_preserves_legacy_hash():
+    """``compute_mdhash_id`` builds document IDs via single-arg
+    ``compute_args_hash(content)``. Those IDs are persisted in KV/vector/graph
+    storage, so the single-arg hash value must remain the raw MD5 of the
+    content string — unchanged across this fix."""
+    content = "hello world test content"
+    expected_raw_md5 = hashlib.md5(content.encode("utf-8")).hexdigest()
+
+    # No prefix
+    assert compute_mdhash_id(content) == expected_raw_md5, (
+        "Single-arg compute_args_hash must equal raw MD5 of the content"
+    )
+    # With prefix (document / entity / relation IDs)
+    assert compute_mdhash_id(content, prefix="doc-") == "doc-" + expected_raw_md5
+
+
+def test_single_argument_empty_string_preserves_legacy_hash():
+    """Empty content must still hash to the well-known empty-MD5 value."""
+    empty_md5 = hashlib.md5(b"").hexdigest()
+    assert compute_args_hash("") == empty_md5
+    assert compute_mdhash_id("") == empty_md5
+
+
+# ---------------------------------------------------------------------------
+# Unicode safety: surrogate / invalid characters must not raise and must still
+# produce a stable hash (regression guard for the 'replace' error handler).
+# ---------------------------------------------------------------------------
+
+
+def test_surrogate_unicode_does_not_raise_and_is_stable():
+    # lone surrogate that cannot encode as UTF-8 directly
+    bad = "before\udcffafter"
+    h1 = compute_args_hash(bad, "field2")
+    h2 = compute_args_hash(bad, "field2")
+    assert isinstance(h1, str) and len(h1) == 32, "must return a 32-char MD5 hex"
+    assert h1 == h2, "same surrogate input must produce a stable hash"
+
+
+def test_two_args_with_surrogate_still_distinguishable():
+    """The 'replace' error handler must not erase field distinctions."""
+    a = compute_args_hash("ab\udcff", "xy")
+    b = compute_args_hash("ab", "\udcffxy")
+    assert a != b, "Surrogate replacement must not collapse distinct fields"


### PR DESCRIPTION
Closes #3392

## Summary

Fixes a cache-key collision bug in `compute_args_hash` where adjacent field boundaries could shift a character and produce identical MD5 keys for semantically distinct argument tuples, causing the LLM response cache to return the wrong answer for a different query.

## Root Cause

`compute_args_hash(*args)` in `lightrag/utils.py` joined the string form of every argument with no delimiter (`''.join([str(arg) for arg in args])`). Adjacent fields lose their boundary: `('abc','x')` and `('ab','cx')` both produce `'abcx'`, hence the same MD5. Since `handle_cache` looks up purely by `{mode}:{cache_type}:{args_hash}` without comparing the incoming query text, a colliding key returns the cached LLM response for a different query.

The issue (#3392) confirmed two concrete collision families: (query, response_type) free-text boundary, and (top_k, chunk_top_k) integer boundary.

## Fix

- **Multi-argument calls use length-prefixed encoding** (`'{len}:{value}'` joined without separators), so each field's extent is unambiguously recoverable. `('abc','x')` -> `'3:abc1:x'`; `('ab','cx')` -> `'2:ab2:cx'` (distinct).
- **Single-argument (and zero-arg) calls preserve the legacy plain-str algorithm**, so `compute_mdhash_id(content)` — used to mint document/entity/relation IDs persisted across KV/vector/graph storage — keeps producing identical IDs across the upgrade.

### Why length-prefixing over a sentinel character?

The issue proposed two options (a `'\x1e'` join, or per-site sentinels). A control-character delimiter can still be constructed to collide because query text and free-form fields (`response_type`, `user_prompt`) can contain arbitrary characters. Length-prefixing is provably collision-free regardless of input content — it does not depend on any 'this character never appears' assumption, and it covers every current and future call site in one place.

## Backward Compatibility & Upgrade Note

This is **not** an API break and requires **no data migration** — persisted storage stays fully readable. The only upgrade-time effect is a one-time invalidation of the LLM response cache.

- **Persisted IDs — unchanged.** `compute_args_hash(content)` (single-arg) is verified byte-identical to raw `md5(content)`, so the `compute_mdhash_id` document/entity/relation IDs persisted across KV/vector/graph storage stay valid. No stored record breaks.
- **LLM response cache — one-time cold start.** Multi-arg hash values change, so existing cache entries no longer match their new keys. Two effects on upgrade, both benign:
  1. The first round of queries after upgrade re-hits the LLM and repopulates the cache — a one-time token/latency cost, largest for deployments carrying a big warm cache.
  2. Old-key entries become orphaned rows in the KV cache: never read again, no correctness impact, and reclaimable by clearing the LLM response cache if the extra storage matters.

No operator action is required; clearing the LLM cache is optional. The correctness risk of a wrong cache hit (returning another query's answer) far outweighs this one-time cold start.

## Validation

New regression tests in `tests/utils/test_compute_args_hash.py` (8 cases, modeled on `tests/llm/test_vlm_cache_key.py`):

- Issue case 1 (query/response_type boundary) now distinct
- Issue case 2 (top_k/chunk_top_k boundary) now distinct
- Inputs containing `'\x1e'` still distinct (immune to sentinel-based fix)
- Identical tuples still hash identically (cache HIT preserved)
- Single-arg hash equals raw MD5 — document IDs stable
- Empty-string edge case
- Surrogate Unicode handling does not regress
- Surrogate replacement does not collapse distinct fields

Existing VLM cache-key tests (`test_vlm_cache_key.py`, `test_llm_cache_identity.py`) continue to pass.

- `ruff check` + `ruff format --check`: pass
- New tests: 8 passed
- Existing cache tests: 9 passed (no regression)
