### PR TITLE
fix(utils): keep spaced <|> out of tuple delimiter repair

### DIFF
--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4820,9 +4820,9 @@ def fix_tuple_delimiter_corruption(
         record,
     )
 
-    # Fix: <|> -> <|#|>, <||> -> <|#|>
+    # Fix: <|> -> <|#|>, <||> -> <|#|> (glued only; keep free-text "a <|> b")
     record = re.sub(
-        r"<\|+>",
+        r"(?<=\S)<\|+>(?=\S)",
         tuple_delimiter,
         record,
     )
@@ -4869,9 +4869,9 @@ def fix_tuple_delimiter_corruption(
         record,
     )
 
-    # Fix: <|| -> <|#|>
+    # Fix: <|| -> <|#|> (glued only; keep free-text/code "x <|| y")
     record = re.sub(
-        r"<\|\|(?!>)",
+        r"(?<=\S)<\|\|(?!>)",
         tuple_delimiter,
         record,
     )

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4870,6 +4870,10 @@ def fix_tuple_delimiter_corruption(
     )
 
     # Fix: <|| -> <|#|> (glued only; keep free-text/code "x <|| y")
+    # Anchor the left side only: "<||" is an unterminated separator whose right
+    # side is the next field's raw content, so a right-hand \S anchor would add
+    # nothing while risking a boundary miss. The left \S is what distinguishes a
+    # glued corruption (name<||type) from a spaced free-text mention (x <|| y).
     record = re.sub(
         r"(?<=\S)<\|\|(?!>)",
         tuple_delimiter,

--- a/tests/extraction/test_fix_tuple_delimiter_free_text.py
+++ b/tests/extraction/test_fix_tuple_delimiter_free_text.py
@@ -2,7 +2,10 @@
 
 import pytest
 
-from lightrag.operate import _handle_single_entity_extraction
+from lightrag.operate import (
+    _handle_single_entity_extraction,
+    _handle_single_relationship_extraction,
+)
 from lightrag.utils import fix_tuple_delimiter_corruption, split_string_by_multi_markers
 
 pytestmark = pytest.mark.offline
@@ -34,6 +37,40 @@ def test_spaced_double_pipe_in_description_does_not_split_entity():
     entity = _handle_single_entity_extraction(attrs, "chunk-2", 1, "docs.md")
     assert entity is not None
     assert "<||" in entity["description"]
+
+
+def test_spaced_angle_pipe_in_relationship_does_not_split_relation():
+    """Same guard for the 5-field relationship record shape (description field)."""
+    description = "Explains the shell redirect form a <|> b shared by both tools"
+    record = (
+        f"relation{_DELIM}ToolA{_DELIM}ToolB{_DELIM}pipeline,redirect{_DELIM}"
+        f"{description}"
+    )
+    fixed = fix_tuple_delimiter_corruption(record, _CORE, _DELIM)
+    attrs = split_string_by_multi_markers(fixed, [_DELIM])
+    assert len(attrs) == 5
+    relation = _handle_single_relationship_extraction(attrs, "chunk-4", 1, "docs.md")
+    assert relation is not None
+    assert relation["src_id"] == "ToolA"
+    assert relation["tgt_id"] == "ToolB"
+    assert "<|>" in relation["description"]
+
+
+def test_glued_missing_core_delimiter_in_relationship_still_repaired():
+    """Glued missing-core separators still repair the 5-field relationship shape."""
+    broken = "relation<|>ToolA<|>ToolB<|>pipeline<|>Kept relation description"
+    fixed = fix_tuple_delimiter_corruption(broken, _CORE, _DELIM)
+    attrs = split_string_by_multi_markers(fixed, [_DELIM])
+    assert attrs == [
+        "relation",
+        "ToolA",
+        "ToolB",
+        "pipeline",
+        "Kept relation description",
+    ]
+    relation = _handle_single_relationship_extraction(attrs, "chunk-5", 1, "docs.md")
+    assert relation is not None
+    assert relation["description"] == "Kept relation description"
 
 
 def test_glued_missing_core_delimiter_still_repaired():

--- a/tests/extraction/test_fix_tuple_delimiter_free_text.py
+++ b/tests/extraction/test_fix_tuple_delimiter_free_text.py
@@ -1,0 +1,52 @@
+"""Regression: delimiter repair must not forge separators inside free text."""
+
+import pytest
+
+from lightrag.operate import _handle_single_entity_extraction
+from lightrag.utils import fix_tuple_delimiter_corruption, split_string_by_multi_markers
+
+pytestmark = pytest.mark.offline
+
+_DELIM = "<|#|>"
+_CORE = "#"
+
+
+def test_spaced_angle_pipe_in_description_does_not_split_entity():
+    """Prose that mentions shell ``<|>`` must stay one description field."""
+    description = "Documents the shell redirect form a <|> b used in pipelines"
+    record = f"entity{_DELIM}ShellRedirect{_DELIM}concept{_DELIM}{description}"
+    fixed = fix_tuple_delimiter_corruption(record, _CORE, _DELIM)
+    attrs = split_string_by_multi_markers(fixed, [_DELIM])
+    assert len(attrs) == 4
+    entity = _handle_single_entity_extraction(attrs, "chunk-1", 1, "docs.md")
+    assert entity is not None
+    assert entity["entity_name"] == "ShellRedirect"
+    assert "<|>" in entity["description"]
+
+
+def test_spaced_double_pipe_in_description_does_not_split_entity():
+    """Prose/code that mentions ``<||`` must not become an extra delimiter."""
+    description = "Pseudocode guard: if (x <|| y) then skip"
+    record = f"entity{_DELIM}Guard{_DELIM}concept{_DELIM}{description}"
+    fixed = fix_tuple_delimiter_corruption(record, _CORE, _DELIM)
+    attrs = split_string_by_multi_markers(fixed, [_DELIM])
+    assert len(attrs) == 4
+    entity = _handle_single_entity_extraction(attrs, "chunk-2", 1, "docs.md")
+    assert entity is not None
+    assert "<||" in entity["description"]
+
+
+def test_glued_missing_core_delimiter_still_repaired():
+    """LLM field separators with a missing core (entity<|>name) still repair."""
+    broken = "entity<|>ShellRedirect<|>concept<|>Kept description"
+    fixed = fix_tuple_delimiter_corruption(broken, _CORE, _DELIM)
+    attrs = split_string_by_multi_markers(fixed, [_DELIM])
+    assert attrs == [
+        "entity",
+        "ShellRedirect",
+        "concept",
+        "Kept description",
+    ]
+    entity = _handle_single_entity_extraction(attrs, "chunk-3", 1, "docs.md")
+    assert entity is not None
+    assert entity["description"] == "Kept description"


### PR DESCRIPTION
Entity descriptions that mention shell/prose forms like `a <|> b` were rewritten into `<|#|>` during delimiter repair, which then split the row into too many fields and dropped the entity.

Repair now only rewrites missing-core delimiters when they are glued to neighboring field text.

## Scope

The same starvation applies to relationship records (`<|>` in the 5-field description); both record shapes are now covered by regression tests.

## Known limitation

This is a heuristic that keys on whitespace: it preserves the common **spaced** free-text form (`a <|> b`, `x <|| y`) but a **glued** mention with no surrounding whitespace (`a<|>b`) is still indistinguishable from a real corrupted separator and will be repaired. For corpora with delimiter-heavy content (code, shell), the structural fix is JSON-structured extraction — set `ENTITY_EXTRACTION_USE_JSON=true`, which avoids the delimiter channel entirely. This PR hardens the default text path and the JSON→text fallback.