### PR TITLE
refactor(shared_storage): drop idle-cache of async keyed locks, delete entries on release

### DIFF
--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -81,12 +81,6 @@ _keyed_holder_table = None
 # Keyed-lock lease poll backoff bounds (seconds).
 _KEYED_LEASE_POLL_BASE = 0.02
 _KEYED_LEASE_POLL_MAX = 0.5
-# Timeout for keyed locks in seconds (Default 300)
-CLEANUP_KEYED_LOCKS_AFTER_SECONDS = 300
-# Cleanup pending list threshold for triggering cleanup (Default 500)
-CLEANUP_THRESHOLD = 500
-# Minimum interval between cleanup operations in seconds (Default 30)
-MIN_CLEANUP_INTERVAL_SECONDS = 30
 
 _initialized = None
 
@@ -426,131 +420,6 @@ class UnifiedLock(Generic[T]):
 def _get_combined_key(factory_name: str, key: str) -> str:
     """Return the combined key for the factory and key."""
     return f"{factory_name}:{key}"
-
-
-def _perform_lock_cleanup(
-    lock_type: str,
-    cleanup_data: Dict[str, float],
-    lock_registry: Optional[Dict[str, Any]],
-    lock_count: Optional[Dict[str, int]],
-    earliest_cleanup_time: Optional[float],
-    last_cleanup_time: Optional[float],
-    current_time: float,
-    threshold_check: bool = True,
-) -> tuple[int, Optional[float], Optional[float]]:
-    """
-    Generic idle-lock cleanup for the per-process async keyed locks.
-
-    (Historically shared with the multiprocess lock registry; the multiprocess
-    keyed lock is now a server-side holder table with no idle bookkeeping to
-    clean, so only the async side calls this.)
-
-    Args:
-        lock_type: Lock type identifier (only "async" in production)
-        cleanup_data: Cleanup data dictionary
-        lock_registry: Lock registry dictionary
-        lock_count: Lock count dictionary
-        earliest_cleanup_time: Earliest cleanup time
-        last_cleanup_time: Last cleanup time
-        current_time: Current time
-        threshold_check: Whether to check threshold condition (default True, set to False in cleanup_expired_locks)
-
-    Returns:
-        tuple: (cleaned_count, new_earliest_time, new_last_cleanup_time)
-    """
-    if len(cleanup_data) == 0:
-        return 0, earliest_cleanup_time, last_cleanup_time
-
-    # If threshold check is needed and threshold not reached, return directly
-    if threshold_check and len(cleanup_data) < CLEANUP_THRESHOLD:
-        return 0, earliest_cleanup_time, last_cleanup_time
-
-    # Time rollback detection
-    if last_cleanup_time is not None and current_time < last_cleanup_time:
-        direct_log(
-            f"== {lock_type} Lock == Time rollback detected, resetting cleanup time",
-            level="WARNING",
-            enable_output=False,
-        )
-        last_cleanup_time = None
-
-    # Check cleanup conditions
-    has_expired_locks = (
-        earliest_cleanup_time is not None
-        and current_time - earliest_cleanup_time > CLEANUP_KEYED_LOCKS_AFTER_SECONDS
-    )
-
-    interval_satisfied = (
-        last_cleanup_time is None
-        or current_time - last_cleanup_time > MIN_CLEANUP_INTERVAL_SECONDS
-    )
-
-    if not (has_expired_locks and interval_satisfied):
-        return 0, earliest_cleanup_time, last_cleanup_time
-
-    try:
-        cleaned_count = 0
-        new_earliest_time = None
-
-        # Calculate total count before cleanup
-        total_cleanup_len = len(cleanup_data)
-
-        # Perform cleanup operation
-        for cleanup_key, cleanup_time in list(cleanup_data.items()):
-            if current_time - cleanup_time > CLEANUP_KEYED_LOCKS_AFTER_SECONDS:
-                # Remove from cleanup data
-                cleanup_data.pop(cleanup_key, None)
-
-                # Remove from lock registry if exists
-                if lock_registry is not None:
-                    lock_registry.pop(cleanup_key, None)
-                if lock_count is not None:
-                    lock_count.pop(cleanup_key, None)
-
-                cleaned_count += 1
-            else:
-                # Track the earliest time among remaining locks
-                if new_earliest_time is None or cleanup_time < new_earliest_time:
-                    new_earliest_time = cleanup_time
-
-        # Update state only after successful cleanup
-        if cleaned_count > 0:
-            new_last_cleanup_time = current_time
-
-            # Log cleanup results
-            next_cleanup_in = max(
-                (new_earliest_time + CLEANUP_KEYED_LOCKS_AFTER_SECONDS - current_time)
-                if new_earliest_time
-                else float("inf"),
-                MIN_CLEANUP_INTERVAL_SECONDS,
-            )
-
-            if lock_type == "async":
-                direct_log(
-                    f"== {lock_type} Lock == Cleaned up {cleaned_count}/{total_cleanup_len} expired {lock_type} locks, "
-                    f"next cleanup in {next_cleanup_in:.1f}s",
-                    enable_output=False,
-                    level="INFO",
-                )
-            else:
-                direct_log(
-                    f"== {lock_type} Lock == Cleaned up {cleaned_count}/{total_cleanup_len} expired locks, "
-                    f"next cleanup in {next_cleanup_in:.1f}s",
-                    enable_output=False,
-                    level="INFO",
-                )
-
-            return cleaned_count, new_earliest_time, new_last_cleanup_time
-        else:
-            return 0, earliest_cleanup_time, last_cleanup_time
-
-    except Exception as e:
-        direct_log(
-            f"== {lock_type} Lock == Cleanup failed: {e}",
-            level="ERROR",
-            enable_output=True,
-        )
-        return 0, earliest_cleanup_time, last_cleanup_time
 
 
 # ============================================================================
@@ -962,7 +831,14 @@ class KeyedUnifiedLock:
     """
     Manager for unified keyed locks, supporting both single and multi-process
 
-    • Keeps only a table of async keyed locks locally
+    • Keeps only a table of async keyed locks locally, alive exactly while
+      referenced: an entry exists ⟺ its refcount ≥ 1 (some coroutine holds or
+      awaits it) and is dropped on the release that takes the count to 0 — no
+      idle cache, no deferred cleanup. Same-key coroutines MUST share one
+      ``asyncio.Lock`` while any of them is active (that is the mutual
+      exclusion in single-process mode and the per-process RPC-poll gate in
+      multiprocess mode); recreating the lock for a later, non-overlapping
+      acquisition is safe and costs only the object allocation.
     • In multiprocess mode, builds a fresh per-acquire ``_KeyedLeaseLock``
       driving the server-side holder table (no shared lock objects to manage)
     • Builds a fresh `UnifiedLock` each time, so `enable_logging`
@@ -976,15 +852,6 @@ class KeyedUnifiedLock:
         self._async_lock_count: Dict[
             str, int
         ] = {}  # local keyed locks referenced count
-        self._async_lock_cleanup_data: Dict[
-            str, time.time
-        ] = {}  # local keyed locks timeout
-        self._earliest_async_cleanup_time: Optional[float] = (
-            None  # track earliest async cleanup time
-        )
-        self._last_async_cleanup_time: Optional[float] = (
-            None  # track last async cleanup time for minimum interval
-        )
 
     def __call__(
         self, namespace: str, keys: list[str], *, enable_logging: Optional[bool] = None
@@ -1005,49 +872,51 @@ class KeyedUnifiedLock:
         )
 
     def _get_or_create_async_lock(self, combined_key: str) -> asyncio.Lock:
+        """Take a reference on the per-process async lock for ``combined_key``.
+
+        Runs synchronously on the event loop, so lookup + refcount increment
+        is atomic with respect to other coroutines.
+        """
         async_lock = self._async_lock.get(combined_key)
-        count = self._async_lock_count.get(combined_key, 0)
         if async_lock is None:
             async_lock = asyncio.Lock()
             self._async_lock[combined_key] = async_lock
-        elif count == 0 and combined_key in self._async_lock_cleanup_data:
-            self._async_lock_cleanup_data.pop(combined_key)
-        count += 1
-        self._async_lock_count[combined_key] = count
+        self._async_lock_count[combined_key] = (
+            self._async_lock_count.get(combined_key, 0) + 1
+        )
         return async_lock
 
     def _release_async_lock(self, combined_key: str):
-        count = self._async_lock_count.get(combined_key, 0)
+        """Drop one reference; delete the entry when the count reaches 0.
+
+        count == 0 means no holder AND no waiter (every waiter increments
+        before awaiting, and a cancelled waiter's rollback releases its
+        reference), so the entry can be dropped immediately. An unmatched
+        release is a caller bug: logged, never applied, so it can neither
+        underflow the count nor resurrect a deleted entry.
+        """
+        count = self._async_lock_count.get(combined_key)
+        if count is None:
+            direct_log(
+                f"== Lock == Process {os.getpid()}: release without matching "
+                f"acquire for async keyed lock '{combined_key}'",
+                level="ERROR",
+                enable_output=True,
+            )
+            return
         count -= 1
-
-        current_time = time.time()
-        if count == 0:
-            self._async_lock_cleanup_data[combined_key] = current_time
-
-            # Update earliest async cleanup time (only when earlier)
-            if (
-                self._earliest_async_cleanup_time is None
-                or current_time < self._earliest_async_cleanup_time
-            ):
-                self._earliest_async_cleanup_time = current_time
-        self._async_lock_count[combined_key] = count
-
-        # Use generic cleanup function
-        cleaned_count, new_earliest_time, new_last_cleanup_time = _perform_lock_cleanup(
-            lock_type="async",
-            cleanup_data=self._async_lock_cleanup_data,
-            lock_registry=self._async_lock,
-            lock_count=self._async_lock_count,
-            earliest_cleanup_time=self._earliest_async_cleanup_time,
-            last_cleanup_time=self._last_async_cleanup_time,
-            current_time=current_time,
-            threshold_check=True,
-        )
-
-        # Update instance state if cleanup was performed
-        if cleaned_count > 0:
-            self._earliest_async_cleanup_time = new_earliest_time
-            self._last_async_cleanup_time = new_last_cleanup_time
+        if count <= 0:
+            if count < 0:
+                direct_log(
+                    f"== Lock == Process {os.getpid()}: async keyed lock "
+                    f"'{combined_key}' over-released (count {count})",
+                    level="ERROR",
+                    enable_output=True,
+                )
+            self._async_lock_count.pop(combined_key, None)
+            self._async_lock.pop(combined_key, None)
+        else:
+            self._async_lock_count[combined_key] = count
 
     def _get_lock_for_key(
         self, namespace: str, key: str, enable_logging: bool = False
@@ -1085,84 +954,27 @@ class KeyedUnifiedLock:
         combined_key = _get_combined_key(namespace, key)
         self._release_async_lock(combined_key)
 
-    def cleanup_expired_locks(self) -> Dict[str, Any]:
-        """
-        Cleanup expired ASYNC keyed locks (the per-process asyncio.Lock table).
-
-        Multiprocess keyed locks need no cleanup: the server-side holder table
-        holds a record only while a lock is HELD (release/reclaim pops it), so
-        there is nothing idle to expire. The ``mp_cleaned`` key is preserved
-        for response-schema compatibility and is always 0.
-
-        Returns:
-            Dict containing cleanup statistics and current status:
-            {
-                "process_id": 12345,
-                "cleanup_performed": {
-                    "mp_cleaned": 0,
-                    "async_cleaned": 3
-                },
-                "current_status": {
-                    "total_mp_locks": 10,
-                    "pending_mp_cleanup": 0,
-                    "total_async_locks": 8,
-                    "pending_async_cleanup": 1
-                }
-            }
-        """
-        cleanup_stats = {"mp_cleaned": 0, "async_cleaned": 0}
-
-        current_time = time.time()
-
-        # Cleanup async locks using generic function
-        try:
-            # Use generic cleanup function without threshold check
-            cleaned_count, new_earliest_time, new_last_cleanup_time = (
-                _perform_lock_cleanup(
-                    lock_type="async",
-                    cleanup_data=self._async_lock_cleanup_data,
-                    lock_registry=self._async_lock,
-                    lock_count=self._async_lock_count,
-                    earliest_cleanup_time=self._earliest_async_cleanup_time,
-                    last_cleanup_time=self._last_async_cleanup_time,
-                    current_time=current_time,
-                    threshold_check=False,  # Force cleanup in cleanup_expired_locks
-                )
-            )
-
-            # Update instance state if cleanup was performed
-            if cleaned_count > 0:
-                self._earliest_async_cleanup_time = new_earliest_time
-                self._last_async_cleanup_time = new_last_cleanup_time
-                cleanup_stats["async_cleaned"] = cleaned_count
-
-        except Exception as e:
-            direct_log(
-                f"Error during async lock cleanup: {e}",
-                level="ERROR",
-                enable_output=True,
-            )
-
-        # 3. Get current status after cleanup
-        current_status = self.get_lock_status()
-
-        return {
-            "process_id": os.getpid(),
-            "cleanup_performed": cleanup_stats,
-            "current_status": current_status,
-        }
-
     def get_lock_status(self) -> Dict[str, int]:
         """
         Get current status of both async and multiprocess keyed locks.
 
-        SEMANTIC NOTE: ``total_mp_locks`` counts the keys currently HELD in
-        the server-side holder table (one ``holder_count()`` RPC returning an
-        int). It previously counted lock objects kept alive in the (now
-        removed) registry, including idle ones awaiting cleanup — same key,
-        new value semantics. ``pending_mp_cleanup`` is always 0 (there is no
-        deferred multiprocess cleanup queue anymore); the key is preserved for
-        response-schema compatibility.
+        SEMANTIC NOTE — the two counts are instantaneous but differ in both
+        scope and criterion:
+
+        * ``total_mp_locks``: keys currently HELD in the server-side holder
+          table (one ``holder_count()`` RPC returning an int) — GLOBAL across
+          all workers, waiters not included.
+        * ``total_async_locks``: keys with at least one active local
+          reference (held OR awaited by a coroutine) — per THIS worker
+          process only. It previously counted cached entries including ones
+          idle for up to 300s awaiting cleanup; entries are now dropped on
+          the release that takes their refcount to 0, so an idle process
+          reports ~0 and a persistently non-zero value means a key is being
+          continuously held or waited on. Same key, new value semantics.
+
+        ``pending_mp_cleanup`` and ``pending_async_cleanup`` are always 0
+        (neither side has a deferred cleanup queue anymore); the keys are
+        preserved for response-schema compatibility.
 
         Returns:
             Dict containing lock counts:
@@ -1170,7 +982,7 @@ class KeyedUnifiedLock:
                 "total_mp_locks": 10,
                 "pending_mp_cleanup": 0,
                 "total_async_locks": 8,
-                "pending_async_cleanup": 1
+                "pending_async_cleanup": 0
             }
         """
         status = {
@@ -1185,9 +997,8 @@ class KeyedUnifiedLock:
             if _is_multiprocess and _keyed_holder_table is not None:
                 status["total_mp_locks"] = _keyed_holder_table.holder_count()
 
-            # Count async locks
+            # Count async locks (locally held or awaited keys)
             status["total_async_locks"] = len(self._async_lock_count)
-            status["pending_async_cleanup"] = len(self._async_lock_cleanup_data)
 
         except Exception as e:
             direct_log(
@@ -1540,42 +1351,52 @@ def get_data_init_lock(enable_logging: bool = False) -> UnifiedLock:
 
 def cleanup_keyed_lock() -> Dict[str, Any]:
     """
-    Force cleanup of expired ASYNC keyed locks and return status information.
+    Report keyed-lock status; kept as a status shell for schema compatibility.
 
-    Multiprocess keyed locks are a server-side holder table with no idle
-    bookkeeping to clean; the ``mp_cleaned`` key in the response is preserved
-    for compatibility and is always 0.
+    There is nothing left to clean on either side: multiprocess locks live in
+    the server-side holder table only while HELD, and async locks are dropped
+    on the release that takes their refcount to 0. The ``cleanup_performed``
+    counters (``mp_cleaned`` / ``async_cleaned``) are preserved for
+    response-schema compatibility and are always 0.
 
     Returns:
-        Same as cleanup_expired_locks in KeyedUnifiedLock
+        {
+            "process_id": <pid of the answering worker>,
+            "cleanup_performed": {"mp_cleaned": 0, "async_cleaned": 0},
+            "current_status": <get_lock_status() dict>
+        }
     """
     global _storage_keyed_lock
 
-    # Check if shared storage is initialized
     if not _initialized or _storage_keyed_lock is None:
-        return {
-            "process_id": os.getpid(),
-            "cleanup_performed": {"mp_cleaned": 0, "async_cleaned": 0},
-            "current_status": {
-                "total_mp_locks": 0,
-                "pending_mp_cleanup": 0,
-                "total_async_locks": 0,
-                "pending_async_cleanup": 0,
-            },
+        current_status = {
+            "total_mp_locks": 0,
+            "pending_mp_cleanup": 0,
+            "total_async_locks": 0,
+            "pending_async_cleanup": 0,
         }
+    else:
+        current_status = _storage_keyed_lock.get_lock_status()
 
-    return _storage_keyed_lock.cleanup_expired_locks()
+    return {
+        "process_id": os.getpid(),
+        "cleanup_performed": {"mp_cleaned": 0, "async_cleaned": 0},
+        "current_status": current_status,
+    }
 
 
 def get_keyed_lock_status() -> Dict[str, Any]:
     """
-    Get current status of keyed locks without performing cleanup.
+    Get current status of keyed locks.
 
-    This function provides a read-only view of the current lock counts
-    for both multiprocess and async locks, including pending cleanup counts.
+    Read-only view of the instantaneous lock counts: global holders
+    (``total_mp_locks``) and this worker's locally held-or-awaited keys
+    (``total_async_locks``) — see ``KeyedUnifiedLock.get_lock_status`` for the
+    scope/criterion distinction. The ``pending_*_cleanup`` keys are always 0
+    (schema compatibility).
 
     Returns:
-        Same as get_lock_status in KeyedUnifiedLock
+        Same as get_lock_status in KeyedUnifiedLock, plus ``process_id``
     """
     global _storage_keyed_lock
 

--- a/tests/kg/test_keyed_lock_async_registry.py
+++ b/tests/kg/test_keyed_lock_async_registry.py
@@ -71,6 +71,9 @@ async def test_entry_dropped_immediately_on_release():
 
 @pytest.mark.offline
 async def test_waiter_keeps_entry_alive_and_mutual_exclusion_holds():
+    """Event-gated choreography (no wall-clock windows): the holder cannot
+    release until the test has finished asserting, so the count == 2 state is
+    observed deterministically even if the test process stalls."""
     finalize_share_data()
     initialize_share_data(1)
     try:
@@ -78,22 +81,38 @@ async def test_waiter_keeps_entry_alive_and_mutual_exclusion_holds():
         combined = _get_combined_key("ns", "contended")
         active = 0
         max_active = 0
+        holder_entered = asyncio.Event()
+        release_holder = asyncio.Event()
 
-        async def worker():
+        async def holder():
             nonlocal active, max_active
             async with get_storage_keyed_lock("contended", namespace="ns"):
                 active += 1
                 max_active = max(max_active, active)
-                await asyncio.sleep(0.01)
+                holder_entered.set()
+                await release_holder.wait()  # held until the test opens the gate
                 active -= 1
 
-        a = asyncio.ensure_future(worker())
-        b = asyncio.ensure_future(worker())
+        async def waiter():
+            nonlocal active, max_active
+            async with get_storage_keyed_lock("contended", namespace="ns"):
+                active += 1
+                max_active = max(max_active, active)
+                await asyncio.sleep(0)  # yield once inside the critical section
+                active -= 1
+
+        a = asyncio.ensure_future(holder())
+        await asyncio.wait_for(holder_entered.wait(), timeout=1.0)
+        b = asyncio.ensure_future(waiter())
+        # _settle is loop iterations, not wall time: the waiter registers its
+        # reference synchronously before its first await, so this is enough.
         await _settle()
 
-        # One holds, one waits: the entry is alive with both references.
+        # One demonstrably holds (gated), one waits: entry alive, both counted.
         assert keyed._async_lock_count[combined] == 2
+        assert combined in keyed._async_lock
 
+        release_holder.set()
         await asyncio.gather(a, b)
         assert max_active == 1  # never two holders at once
         assert combined not in keyed._async_lock

--- a/tests/kg/test_keyed_lock_async_registry.py
+++ b/tests/kg/test_keyed_lock_async_registry.py
@@ -1,0 +1,259 @@
+"""Behavior pins for the async keyed-lock registry: delete-on-release.
+
+The per-process async lock table (``KeyedUnifiedLock._async_lock`` /
+``_async_lock_count``) is refcount-live only: an entry exists ⟺ some
+coroutine holds or awaits that key (count ≥ 1), and the release that takes
+the count to 0 drops the entry immediately. The former idle cache (entries
+parked at count 0 for up to 300s awaiting a throttled cleanup pass) is gone
+— it was designed for the removed multiprocess lock registry, where caching
+a ``manager.Lock()`` proxy saved RPCs; for local ``asyncio.Lock`` objects a
+cache hit saves only a sub-microsecond allocation.
+
+These tests pin the new invariant on the normal, contended, cancelled and
+defensive paths, plus the /health schema compatibility of the status shells.
+"""
+
+import asyncio
+
+import pytest
+
+import lightrag.kg.shared_storage as shared_storage
+from lightrag.kg.shared_storage import (
+    _get_combined_key,
+    cleanup_keyed_lock,
+    finalize_share_data,
+    get_keyed_lock_status,
+    get_storage_keyed_lock,
+    initialize_share_data,
+)
+
+pytestmark = pytest.mark.offline
+
+STATUS_KEYS = {
+    "total_mp_locks",
+    "pending_mp_cleanup",
+    "total_async_locks",
+    "pending_async_cleanup",
+}
+
+
+def _registry():
+    return shared_storage._storage_keyed_lock
+
+
+async def _settle(ticks: int = 5):
+    """Let already-started coroutines run up to their next await point."""
+    for _ in range(ticks):
+        await asyncio.sleep(0)
+
+
+@pytest.mark.offline
+async def test_entry_dropped_immediately_on_release():
+    finalize_share_data()
+    initialize_share_data(1)
+    try:
+        keyed = _registry()
+        combined = _get_combined_key("ns", "k")
+
+        async with get_storage_keyed_lock("k", namespace="ns"):
+            assert combined in keyed._async_lock
+            assert keyed._async_lock_count[combined] == 1
+            assert keyed.get_lock_status()["total_async_locks"] == 1
+
+        # No idle cache: the exit that dropped the count to 0 removed the
+        # entry from BOTH tables at once.
+        assert combined not in keyed._async_lock
+        assert combined not in keyed._async_lock_count
+        assert keyed.get_lock_status()["total_async_locks"] == 0
+    finally:
+        finalize_share_data()
+
+
+@pytest.mark.offline
+async def test_waiter_keeps_entry_alive_and_mutual_exclusion_holds():
+    finalize_share_data()
+    initialize_share_data(1)
+    try:
+        keyed = _registry()
+        combined = _get_combined_key("ns", "contended")
+        active = 0
+        max_active = 0
+
+        async def worker():
+            nonlocal active, max_active
+            async with get_storage_keyed_lock("contended", namespace="ns"):
+                active += 1
+                max_active = max(max_active, active)
+                await asyncio.sleep(0.01)
+                active -= 1
+
+        a = asyncio.ensure_future(worker())
+        b = asyncio.ensure_future(worker())
+        await _settle()
+
+        # One holds, one waits: the entry is alive with both references.
+        assert keyed._async_lock_count[combined] == 2
+
+        await asyncio.gather(a, b)
+        assert max_active == 1  # never two holders at once
+        assert combined not in keyed._async_lock
+        assert combined not in keyed._async_lock_count
+    finally:
+        finalize_share_data()
+
+
+@pytest.mark.offline
+async def test_cancelled_waiter_rolls_back_reference_without_deleting_entry():
+    """The invariant's key exception branch: a WAITER cancelled mid-acquire
+    must roll back exactly its own reference — the holder's entry survives as
+    the SAME lock object (deleting it would let a later acquirer mint a fresh
+    lock and run concurrently with the holder), and only the holder's release
+    finally drops the entry."""
+    finalize_share_data()
+    initialize_share_data(1)
+    try:
+        keyed = _registry()
+        combined = _get_combined_key("ns", "cancelwait")
+
+        holder_ctx = get_storage_keyed_lock("cancelwait", namespace="ns")
+        await holder_ctx.__aenter__()
+        try:
+            lock_obj = keyed._async_lock[combined]
+
+            async def waiter():
+                async with get_storage_keyed_lock("cancelwait", namespace="ns"):
+                    pass  # pragma: no cover - never acquires in this test
+
+            wtask = asyncio.ensure_future(waiter())
+            await _settle()
+            assert keyed._async_lock_count[combined] == 2
+
+            wtask.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await wtask
+
+            # Rollback decremented the waiter's reference only; the holder's
+            # entry is intact and is the very same asyncio.Lock object.
+            assert keyed._async_lock_count[combined] == 1
+            assert keyed._async_lock[combined] is lock_obj
+        finally:
+            await holder_ctx.__aexit__(None, None, None)
+
+        # The holder's release was the last reference: entry fully gone.
+        assert combined not in keyed._async_lock
+        assert combined not in keyed._async_lock_count
+    finally:
+        finalize_share_data()
+
+
+@pytest.mark.offline
+async def test_reacquire_after_full_release_uses_fresh_lock():
+    finalize_share_data()
+    initialize_share_data(1)
+    try:
+        keyed = _registry()
+        combined = _get_combined_key("ns", "again")
+
+        async with get_storage_keyed_lock("again", namespace="ns"):
+            first = keyed._async_lock[combined]
+
+        # A later, non-overlapping acquisition simply mints a fresh lock.
+        async with get_storage_keyed_lock("again", namespace="ns"):
+            second = keyed._async_lock[combined]
+            assert second is not first
+
+        assert combined not in keyed._async_lock
+    finally:
+        finalize_share_data()
+
+
+@pytest.mark.offline
+async def test_unmatched_release_is_ignored_and_leaves_no_phantom():
+    """Regression: the old implementation wrote ``count - 1`` back
+    unconditionally, so releasing an absent key created a phantom entry with
+    count -1. An unmatched release must now be a logged no-op."""
+    finalize_share_data()
+    initialize_share_data(1)
+    try:
+        keyed = _registry()
+        combined = _get_combined_key("ns", "never-acquired")
+
+        keyed._release_async_lock(combined)  # must not raise
+
+        assert combined not in keyed._async_lock_count
+        assert combined not in keyed._async_lock
+        assert keyed.get_lock_status()["total_async_locks"] == 0
+    finally:
+        finalize_share_data()
+
+
+@pytest.mark.offline
+async def test_distinct_keys_do_not_accumulate():
+    """The conservation guarantee that replaces the deleted periodic cleanup:
+    N distinct keys leave nothing behind, so unbounded key spaces (entity
+    names) can never grow the registry."""
+    finalize_share_data()
+    initialize_share_data(1)
+    try:
+        keyed = _registry()
+        for i in range(500):
+            async with get_storage_keyed_lock(f"entity-{i}", namespace="idx"):
+                pass
+        assert keyed._async_lock == {}
+        assert keyed._async_lock_count == {}
+    finally:
+        finalize_share_data()
+
+
+@pytest.mark.offline
+async def test_multiprocess_gate_entry_dropped_immediately_too():
+    """In multiprocess mode the registry entry is the per-process RPC-poll
+    gate paired with the server-side lease; it follows the same
+    delete-on-release lifecycle."""
+    finalize_share_data()
+    initialize_share_data(2)
+    try:
+        keyed = _registry()
+        combined = _get_combined_key("ns", "mp")
+
+        async with get_storage_keyed_lock("mp", namespace="ns"):
+            assert combined in keyed._async_lock
+            assert keyed._async_lock_count[combined] == 1
+
+        assert combined not in keyed._async_lock
+        assert combined not in keyed._async_lock_count
+    finally:
+        finalize_share_data()
+
+
+@pytest.mark.offline
+async def test_status_shells_keep_health_schema():
+    finalize_share_data()
+    initialize_share_data(1)
+    try:
+        async with get_storage_keyed_lock("k", namespace="ns"):
+            info = cleanup_keyed_lock()
+            assert info["cleanup_performed"] == {"mp_cleaned": 0, "async_cleaned": 0}
+            assert set(info["current_status"]) == STATUS_KEYS
+            assert info["current_status"]["total_async_locks"] == 1
+            assert info["current_status"]["pending_async_cleanup"] == 0
+
+            public = get_keyed_lock_status()
+            assert set(public) == STATUS_KEYS | {"process_id"}
+            assert public["pending_async_cleanup"] == 0
+
+        # Idle: instantaneous count back to zero, still full schema.
+        info = cleanup_keyed_lock()
+        assert set(info["current_status"]) == STATUS_KEYS
+        assert info["current_status"]["total_async_locks"] == 0
+        assert info["current_status"]["pending_async_cleanup"] == 0
+    finally:
+        finalize_share_data()
+
+    # Uninitialized shared data: both shells still answer with the full schema.
+    info = cleanup_keyed_lock()
+    assert info["cleanup_performed"] == {"mp_cleaned": 0, "async_cleaned": 0}
+    assert set(info["current_status"]) == STATUS_KEYS
+    assert all(v == 0 for v in info["current_status"].values())
+    public = get_keyed_lock_status()
+    assert set(public) == STATUS_KEYS | {"process_id"}

--- a/tests/kg/test_keyed_lock_cancel_safety.py
+++ b/tests/kg/test_keyed_lock_cancel_safety.py
@@ -166,8 +166,13 @@ async def test_keyed_lock_real_release_and_reacquire_after_cancel():
         async with await asyncio.wait_for(_acquire_ctx(namespace, "k"), timeout=1.0):
             pass
 
+        # Immediate-delete invariant: once the last reference is released —
+        # including via the cancellation path — the registry entry is GONE,
+        # not parked at count 0. (`.get(combined, 0) == 0` would pass for
+        # both implementations; absence is the discriminating assertion.)
         keyed = shared_storage._storage_keyed_lock
-        assert keyed._async_lock_count.get(combined, 0) == 0
+        assert combined not in keyed._async_lock_count
+        assert combined not in keyed._async_lock
     finally:
         finalize_share_data()
 


### PR DESCRIPTION
## Description

Follow-up to #3436. The per-process **async** keyed-lock table (`KeyedUnifiedLock._async_lock` / `_async_lock_count`) kept released entries alive for up to 300s behind a throttled cleanup pass (`_perform_lock_cleanup`). That idle-cache structure was designed for the **multiprocess lock registry that #3436 removed** — there, caching a `manager.Lock()` proxy saved real Manager RPCs. For local `asyncio.Lock` objects, a measured cache hit saves only the object allocation:

| measured | cost |
|---|---|
| `asyncio.Lock()` allocation (what a cache hit saves) | **0.09 µs** |
| full single-process keyed-lock cycle | ~19 µs (cache benefit ≈ 2%) |
| full multiprocess cycle (2 Manager RPCs) | ~247 µs (cache benefit ≈ 0.2%) |

With the mp registry gone, the async table was the cleanup machinery's only remaining user — the cache had no measurable benefit left, but simply deleting the *cleanup* alone would let unbounded key spaces (entity names) grow the table forever. So this PR replaces the idle cache with **refcount-only liveness**: an entry exists ⟺ its refcount ≥ 1 (some coroutine holds **or awaits** the key), and the release that takes the count to 0 drops the entry immediately. Net −180 lines in `shared_storage.py`.

**Correctness of delete-at-zero:** count == 0 implies no holder AND no waiter — every waiter increments before awaiting (lookup + increment run synchronously on the event loop, so they are atomic w.r.t. other coroutines), and a cancelled waiter's rollback (`_KeyedLockContext._rollback_acquired_locks`) releases exactly its own reference. Same-key coroutines therefore always share one `asyncio.Lock` while any of them is active — the single-process mutual exclusion and the multiprocess per-process RPC-poll gate are unaffected; recreating the lock for a later, non-overlapping acquisition is safe by construction.

## Related Issues

Continuation of the shared-storage keyed-lock line: #3433 / #3434 (RPC reduction), #3436 (server-side holder table; removed the mp registry that this cache structure was built for).

## Changes Made

**`lightrag/kg/shared_storage.py`**

- `_release_async_lock`: drop one reference; on count → 0, pop the entry from both tables immediately. An unmatched release (absent key) is now a **logged no-op** — the old code wrote `count - 1` back unconditionally, so releasing an absent key created a phantom entry with count −1.
- `_get_or_create_async_lock`: simplified (no cleanup-list resurrection branch); documents the atomicity argument.
- **Deleted**: `_perform_lock_cleanup` (~120 lines), constants `CLEANUP_KEYED_LOCKS_AFTER_SECONDS` / `CLEANUP_THRESHOLD` / `MIN_CLEANUP_INTERVAL_SECONDS`, the `_async_lock_cleanup_data` / `_earliest_async_cleanup_time` / `_last_async_cleanup_time` bookkeeping, and the internal `KeyedUnifiedLock.cleanup_expired_locks` method (all confined to this module — repo-wide grep confirms no external references).
- `cleanup_keyed_lock()` (public, used by authenticated `/health`) is kept as a **status shell**: it now builds its response directly with the exact same shape — there is nothing left to clean on either side (mp locks exist only while held; async entries are dropped on release).
- Docstrings updated: `KeyedUnifiedLock` states the new invariant (*entry exists ⟺ refcount ≥ 1*); `get_lock_status` spells out that the two counts are both instantaneous but **differ in scope and criterion** (see below).

## Health/diagnostics semantic change (explicit)

Response keys are unchanged (WebUI types require them); values are redefined:

| field | old | new |
|---|---|---|
| `total_async_locks` | cached entries incl. ones idle ≤300s (slowly-decaying curve under /health polling) | keys with an active local reference — held **or awaited** — in the answering worker; ~0 when idle |
| `pending_async_cleanup` | entries awaiting cleanup | always 0 (schema compat) |
| `async_cleaned` | entries cleaned this call | always 0 (schema compat) |

Note the deliberate asymmetry with `total_mp_locks` (#3436): both are now instantaneous counts, but **`total_async_locks` = local active references (per worker, waiters included)** while **`total_mp_locks` = global holders (cross-worker, waiters excluded)**. A persistently non-zero `total_async_locks` means a key is being continuously held *or waited on* in that worker.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary) — docstrings; semantics declared here
- [x] Unit tests added (if applicable)

## Additional Notes

**Tests**

- New `tests/kg/test_keyed_lock_async_registry.py` (8 tests, offline): delete-on-release on the normal path; waiter keeps the entry alive + mutual exclusion under contention; **cancelled-waiter rollback** (A holds, B waits → count 2; cancel B → count 1 and the registry still maps to the *same* lock object A is using — identity-asserted; A's exit drops the entry from both tables); fresh-lock reacquisition; unmatched-release leaves no phantom (regression for the −1 write-back); 500 distinct keys leave the registry empty (the conservation guarantee replacing periodic cleanup); the multiprocess gate follows the same lifecycle; `cleanup_keyed_lock()` / `get_keyed_lock_status()` keep the full schema in initialized, idle and uninitialized states.
- `tests/kg/test_keyed_lock_cancel_safety.py`: the post-cancel assertion now checks **entry absence** instead of `count == 0` (which passed under both old and new implementations and had no discriminating power).

**Verification**: `./scripts/test.sh tests/kg tests/api tests/pipeline tests/workspace` → **1712 passed, 36 skipped, 0 failed** (macOS; skips are Linux-only /proc cases). Pinned pre-commit `ruff-format` / `ruff` hooks and repo-wide `ruff check .` pass. The 4 existing tests that monkeypatch `cleanup_keyed_lock` are unaffected (they stub past the real implementation), and the WebUI needs no change (all schema fields remain present as numbers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)