### PR TITLE
fix(webui): show instantaneous lock counts as m_lock/a_lock in status card

### DIFF
--- a/lightrag_webui/src/components/status/StatusCard.tsx
+++ b/lightrag_webui/src/components/status/StatusCard.tsx
@@ -237,8 +237,8 @@ const StatusCard = ({ status }: { status: LightragStatus | null }) => {
                     {' | '}
                   </>
                 )}
-                mp {status.keyed_locks.current_status.pending_mp_cleanup}/{status.keyed_locks.current_status.total_mp_locks} |
-                async {status.keyed_locks.current_status.pending_async_cleanup}/{status.keyed_locks.current_status.total_async_locks}
+                m_lock {status.keyed_locks.current_status.total_mp_locks} |
+                a_lock {status.keyed_locks.current_status.total_async_locks}
                 (pid: {status.keyed_locks.process_id})
               </span>
             </>


### PR DESCRIPTION
## Description

Follow-up to #3439. The `/health` lock-status fields `pending_mp_cleanup` and `pending_async_cleanup` are now fixed at 0 — neither the multiprocess holder table nor the async keyed-lock registry has a deferred cleanup queue anymore (mp: a record exists only while held, #3436; async: entries are dropped on the release that takes the refcount to 0, #3439). The keys remain in the response purely for schema compatibility.

The status card still rendered the lock status as `mp pending/total | async pending/total`, so the numerator was permanently 0 and the fraction format only added noise. This PR switches the display to the two meaningful instantaneous counts, one plain number each:

- **`m_lock`** — `total_mp_locks`: keys currently held in the cross-worker holder table (global, waiters excluded)
- **`a_lock`** — `total_async_locks`: keys held or awaited in the answering worker process (per-worker, waiters included)

`(pid: ...)` and the server-mode prefix are unchanged.

## Related Issues

Display follow-up to #3439 (and #3436, which introduced the instantaneous `total_mp_locks` semantics).

## Changes Made

- `lightrag_webui/src/components/status/StatusCard.tsx`: render `m_lock {total_mp_locks} | a_lock {total_async_locks}` instead of the two always-zero-numerator fractions (2-line change).
- The response types in `src/api/lightrag.ts` are deliberately unchanged: the backend still sends the `pending_*` fields, they are just no longer displayed.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary) — n/a
- [x] Unit tests added (if applicable) — n/a (display-only; StatusCard has no test coverage)

## Additional Notes

Verified with `bun run lint` (clean), `bun run build` (vite build succeeds), and `bun test` (64 pass / 0 fail). Built assets are not committed (excluded from git since be9e6d16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)