### PR TITLE
test(pipeline): mark pipeline tests offline for CI

### DIFF
--- a/tests/pipeline/test_content_hash_normalization.py
+++ b/tests/pipeline/test_content_hash_normalization.py
@@ -10,10 +10,14 @@ and post-parse dedup fires.
 
 from __future__ import annotations
 
+import pytest
+
 from lightrag.utils_pipeline import (
     compute_text_content_hash,
     normalize_merged_text_for_hash,
 )
+
+pytestmark = pytest.mark.offline
 
 
 def _render(doc_hash: str, base_name: str) -> str:

--- a/tests/pipeline/test_document_file_path_normalization.py
+++ b/tests/pipeline/test_document_file_path_normalization.py
@@ -14,6 +14,8 @@ from lightrag.base import DocStatus  # noqa: E402
 from lightrag.constants import PROCESS_OPTION_CHUNK_FIXED  # noqa: E402
 from lightrag.pipeline import _PipelineMixin  # noqa: E402
 
+pytestmark = pytest.mark.offline
+
 
 class DummyRAG:
     def __init__(self):

--- a/tests/pipeline/test_graph_keyed_locks.py
+++ b/tests/pipeline/test_graph_keyed_locks.py
@@ -20,10 +20,31 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def single_process_shared_data():
+    """Initialize the single-process shared_storage singleton.
+
+    ``LightRAG.ainsert_custom_kg`` calls ``_raise_if_recovery_required``,
+    which reads the ``pipeline_status`` namespace via ``get_namespace_data``.
+    That call raises ``ValueError`` if ``initialize_share_data()`` was never
+    called at all (as it never is running this file standalone), but is a
+    documented no-op — via a caught ``PipelineNotInitializedError`` — when
+    shared data is initialized yet ``pipeline_status`` itself was not. So we
+    only need ``initialize_share_data()`` here, not
+    ``initialize_pipeline_status()``. Mirrors the fixture in
+    ``tests/kg/test_shared_storage_rpc_counts.py``.
+    """
+    finalize_share_data()
+    initialize_share_data(1)
+    yield
+    finalize_share_data()
 
 
 def _make_keyed_lock_spy():
@@ -235,7 +256,9 @@ class _LockCaptured(RuntimeError):
 
 
 @pytest.mark.asyncio
-async def test_ainsert_custom_kg_locks_every_entity_and_endpoint():
+async def test_ainsert_custom_kg_locks_every_entity_and_endpoint(
+    single_process_shared_data,
+):
     """ainsert_custom_kg must hold a single coarse-grained keyed lock whose
     key set covers every entity name plus every relationship endpoint in the
     batch — sharing the doc-ingest namespace so concurrent callers on
@@ -314,7 +337,9 @@ async def test_ainsert_custom_kg_locks_every_entity_and_endpoint():
 
 
 @pytest.mark.asyncio
-async def test_ainsert_custom_kg_empty_batch_skips_keyed_lock():
+async def test_ainsert_custom_kg_empty_batch_skips_keyed_lock(
+    single_process_shared_data,
+):
     """A custom_kg with no entities or relationships has nothing for the
     business-layer keyed lock to serialise on — no lock is acquired and the
     chunk-only path still completes."""

--- a/tests/pipeline/test_graph_keyed_locks.py
+++ b/tests/pipeline/test_graph_keyed_locks.py
@@ -22,6 +22,8 @@ import pytest
 
 from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
 
+pytestmark = pytest.mark.offline
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Problem

CI runs `pytest tests/ -m offline` (`.github/workflows/tests.yml`), and `tests/conftest.py` does not apply the `offline` marker automatically — its `pytest_collection_modifyitems` only adds `skip_integration`. Three files under `tests/pipeline/` declare no marker, so CI collects zero tests from them:

| file | tests |
|---|---|
| `tests/pipeline/test_content_hash_normalization.py` | 4 |
| `tests/pipeline/test_document_file_path_normalization.py` | 16 |
| `tests/pipeline/test_graph_keyed_locks.py` | 5 |

```
$ pytest tests/pipeline/test_document_file_path_normalization.py -m offline --collect-only
no tests collected (16 deselected)

$ pytest tests/pipeline/test_document_file_path_normalization.py
16 passed
```

The 16 in `test_document_file_path_normalization.py` include the custom-chunk regression tests added by #3394, #3401 and #3402 — `test_custom_chunks_merge_extracted_entities_into_kg`, `test_custom_chunks_persist_before_extraction`, `test_custom_chunks_rejects_when_pipeline_busy`, `test_custom_chunks_handoff_runs_even_when_flush_errors`, and others. #3416 substantially restructured that path, so those guardrails have not been running in CI.

### Change

Two commits:

1. **`test(pipeline): make graph keyed-lock tests self-sufficient`** — two tests in `test_graph_keyed_locks.py` call `ainsert_custom_kg`, which reads the `pipeline_status` namespace via `get_namespace_data` and raises `ValueError: Shared dictionaries not initialized` when `initialize_share_data()` was never called in the process. They passed only because other files collected earlier happened to initialize the singleton; run standalone the file failed 2/5. They now bracket their own `initialize_share_data(1)` / `finalize_share_data()` via a fixture mirroring `tests/kg/test_shared_storage_rpc_counts.py`. Doing this before adding the marker avoids handing CI an order-dependent test.

   (`initialize_pipeline_status()` is deliberately not called — `_raise_if_recovery_required` already treats a missing `pipeline_status` as a documented no-op via `PipelineNotInitializedError`; only the shared-data singleton is required.)

2. **`test(pipeline): mark pipeline tests offline for CI`** — adds `pytestmark = pytest.mark.offline` to the three files, following the precedent in `7aa5324c` ("test(utils): mark parse_optional_float tests offline for CI").

All three files need no network, database, or API credentials — every dependency is a hand-written fake or a `monkeypatch`/`unittest.mock` stub.

### Verification

CI on this branch is green on both Python versions, and reports the same counts on each:

```
3007 passed, 42 skipped, 910 deselected      # py3.12 and py3.14
```

The number this PR moves is `deselected`: **935 → 910**, i.e. the 25 tests listed above now run.

Measured locally before/after on one checkout, so the delta is attributable:

| | before | after |
|---|---|---|
| passed | 2972 | 2997 (**+25**) |
| skipped | 44 | 44 (**unchanged**) |
| deselected | 935 | 910 (**-25**) |

`skipped` staying flat is the check that the new `finalize_share_data()` teardown does not leak state into later-collected tests — no test moved from passed to skipped. 2972 + 25 = 2997 exactly, so nothing else shifted either.

(The local totals are lower than CI's because they were taken on macOS at an earlier base — macOS skips two tests Linux runs, and upstream has since added tests. The delta and the `deselected` figure are the load-bearing numbers.)

Order-independence confirmed after commit 1:

```
$ pytest tests/pipeline/test_graph_keyed_locks.py -m offline -q
5 passed                       # was: 2 failed, 3 passed

$ pytest tests/pipeline/test_graph_keyed_locks.py::test_ainsert_custom_kg_locks_every_entity_and_endpoint -q
1 passed                       # single test, alone
```

`pre-commit run --all-files` passes at the pinned `ruff` rev (`v0.15.17`).

### Note on scope

This is not limited to `tests/pipeline/` — repo-wide, 935 of 3929 tests are deselected by `-m offline`, and other directories have files in the same state (e.g. `tests/parser/test_hint_params.py`, `tests/kg/milvus_impl/test_milvus_index_config.py`). I kept this PR to `tests/pipeline/` so it stays reviewable; happy to open a separate issue for a repo-wide marker audit if that would be useful, since some of those files may genuinely not be offline-safe and would need checking individually rather than a blanket marker.
