### PR TITLE
feat(api): add document source file download endpoint

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -26,6 +26,7 @@ from fastapi import (
     Request,
     UploadFile,
 )
+from fastapi.responses import FileResponse
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from lightrag import LightRAG
@@ -1203,6 +1204,16 @@ def get_doc_track_id(doc_status: Any) -> str:
     return str(track_id or "")
 
 
+def get_doc_file_path(doc_status: Any) -> str:
+    """Read file_path from dict or DocProcessingStatus-like objects."""
+    file_path = (
+        doc_status.get("file_path")
+        if isinstance(doc_status, dict)
+        else getattr(doc_status, "file_path", None)
+    )
+    return normalize_file_path(str(file_path or ""))
+
+
 async def get_existing_doc_by_file_path_candidates(
     doc_status: Any, file_path: Path | str
 ) -> dict[str, Any] | None:
@@ -1582,6 +1593,29 @@ def find_existing_file_by_file_path(input_dir: Path, file_path: str) -> Path | N
             if not candidate.is_file():
                 continue
             if normalize_file_path(candidate.name) == file_path:
+                return candidate
+    except FileNotFoundError:
+        return None
+    return None
+
+
+def find_document_source_file(input_dir: Path, file_path: str) -> Path | None:
+    """Find a document source in the input directory or its archive."""
+    source = find_existing_file_by_file_path(input_dir, file_path)
+    if source is not None:
+        return source
+
+    parsed_dir = input_dir / PARSED_DIR_NAME
+    try:
+        for candidate in parsed_dir.iterdir():
+            if not candidate.is_file():
+                continue
+            if (
+                canonicalize_archived_file_variant_basename(
+                    candidate.name, strip_archive_suffix=True
+                )
+                == file_path
+            ):
                 return candidate
     except FileNotFoundError:
         return None
@@ -4055,6 +4089,26 @@ def create_document_routes(
             logger.error(f"Error clearing cache: {str(e)}")
             logger.error(traceback.format_exc())
             raise internal_server_error(e)
+
+    @router.get(
+        "/{doc_id}/file",
+        response_class=FileResponse,
+        dependencies=[Depends(combined_auth)],
+    )
+    async def download_document_file(doc_id: str) -> FileResponse:
+        """Download the original source file associated with a document."""
+        doc_status = await rag.doc_status.get_by_id(doc_id)
+        if doc_status is None:
+            raise HTTPException(status_code=404, detail="Document not found")
+
+        file_path = get_doc_file_path(doc_status)
+        source_file = find_document_source_file(doc_manager.input_dir, file_path)
+        if source_file is None:
+            raise HTTPException(
+                status_code=404, detail="Document source file not found"
+            )
+
+        return FileResponse(path=source_file, filename=file_path)
 
     @router.get(
         "/track_status/{track_id}",

--- a/tests/api/routes/test_document_routes_docx_archive.py
+++ b/tests/api/routes/test_document_routes_docx_archive.py
@@ -950,6 +950,69 @@ async def test_scan_resume_runs_when_all_new_files_fail_to_enqueue(
     assert new_file.exists()
 
 
+async def test_download_document_file_from_input_dir(tmp_path):
+    source = tmp_path / "report.pdf"
+    source.write_bytes(b"original pdf")
+    rag = _FakeRag()
+    rag.doc_status.docs["doc-report"] = {"file_path": "report.pdf"}
+    router = create_document_routes(rag, DocumentManager(str(tmp_path)))
+    endpoint = [
+        route.endpoint
+        for route in router.routes
+        if getattr(route, "name", "") == "download_document_file"
+    ][-1]
+
+    response = await endpoint("doc-report")
+
+    assert Path(response.path) == source
+    assert 'filename="report.pdf"' in response.headers["content-disposition"]
+
+
+async def test_download_document_file_from_parsed_archive(tmp_path):
+    parsed_dir = tmp_path / PARSED_DIR_NAME
+    parsed_dir.mkdir()
+    source = parsed_dir / "report_001.pdf"
+    source.write_bytes(b"archived pdf")
+    rag = _FakeRag()
+    rag.doc_status.docs["doc-report"] = SimpleNamespace(file_path="report.pdf")
+    router = create_document_routes(rag, DocumentManager(str(tmp_path)))
+    endpoint = [
+        route.endpoint
+        for route in router.routes
+        if getattr(route, "name", "") == "download_document_file"
+    ][-1]
+
+    response = await endpoint("doc-report")
+
+    assert Path(response.path) == source
+    assert 'filename="report.pdf"' in response.headers["content-disposition"]
+
+
+@pytest.mark.parametrize(
+    ("doc_status", "detail"),
+    [
+        (None, "Document not found"),
+        ({"file_path": "missing.pdf"}, "Document source file not found"),
+    ],
+)
+async def test_download_document_file_returns_404(tmp_path, doc_status, detail):
+    rag = _FakeRag()
+    if doc_status is not None:
+        rag.doc_status.docs["doc-missing"] = doc_status
+    router = create_document_routes(rag, DocumentManager(str(tmp_path)))
+    endpoint = [
+        route.endpoint
+        for route in router.routes
+        if getattr(route, "name", "") == "download_document_file"
+    ][-1]
+
+    with pytest.raises(_document_routes.HTTPException) as excinfo:
+        await endpoint("doc-missing")
+
+    assert excinfo.value.status_code == 404
+    assert excinfo.value.detail == detail
+
+
 async def test_upload_rejects_same_name_failed_doc_status_without_full_docs(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Description

Add an authenticated API endpoint for downloading the original source file associated with a document.

Uploaded source files may remain in the workspace input directory or be moved to the `__parsed__` archive after processing. The endpoint resolves both locations and returns the file using its canonical original filename.

## Related Issues

Closes #3363.

## Changes Made

- Add `GET /documents/{doc_id}/file`.
- Resolve the document source filename from `DOC_STATUS_STORAGE`.
- Support files in both the workspace input directory and the `__parsed__` archive.
- Support archived filename collision suffixes such as `_001`.
- Preserve the canonical original filename in the download response.
- Return HTTP 404 when the document record does not exist or its source file is missing.
- Reuse the existing authentication configured for document routes.
- Add regression tests covering active files, archived files, missing documents, and missing source files.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (not necessary)
- [x] Unit tests added

## Additional Notes

Validation completed locally:

- `69 passed` in `tests/api/routes/test_document_routes_docx_archive.py`
- Ruff lint passed
- Ruff format check passed
- `git diff --check` passed