### PR TITLE
test(pipeline): cover audit_kg_integrity's orphan detection path

### DIFF
--- a/tests/pipeline/test_fault_injection_matrix.py
+++ b/tests/pipeline/test_fault_injection_matrix.py
@@ -333,60 +333,120 @@ async def test_audit_tool_detects_and_repairs_missing_anchor(tmp_path):
         await rag.finalize_storages()
 
 
+def _wire_fake_extraction_with_relation(rag: LightRAG) -> None:
+    """Test-local extraction override: ALICE, BOB, and an edge between them
+    per chunk.
+
+    Overrides ``rag._process_extract_entities`` AFTER ``_build_rag`` has
+    already wired the shared ``_wire_fake_extraction`` (single-entity, no
+    relations) default. This function is applied only by the test below and
+    never mutates ``_wire_fake_extraction`` itself, so every sibling test in
+    this file that calls ``_build_rag`` keeps its original one-entity,
+    zero-relation wiring and is unaffected.
+    """
+
+    async def fake_extract(chunks, *args, **kwargs):
+        results = []
+        for chunk_id in chunks:
+            nodes = {
+                "ALICE": [
+                    {
+                        "entity_name": "ALICE",
+                        "entity_type": "person",
+                        "description": "ALICE description",
+                        "source_id": chunk_id,
+                        "file_path": "d.txt",
+                        "timestamp": 1,
+                    }
+                ],
+                "BOB": [
+                    {
+                        "entity_name": "BOB",
+                        "entity_type": "person",
+                        "description": "BOB description",
+                        "source_id": chunk_id,
+                        "file_path": "d.txt",
+                        "timestamp": 1,
+                    }
+                ],
+            }
+            edges = {
+                ("ALICE", "BOB"): [
+                    {
+                        "src_id": "ALICE",
+                        "tgt_id": "BOB",
+                        "description": "ALICE knows BOB",
+                        "keywords": "acquaintance",
+                        "source_id": chunk_id,
+                        "file_path": "d.txt",
+                        "weight": 1.0,
+                        "timestamp": 1,
+                    }
+                ]
+            }
+            results.append((nodes, edges))
+        return results
+
+    rag._process_extract_entities = fake_extract
+
+
 @pytest.mark.asyncio
 async def test_audit_tool_detects_true_orphan_after_anchor_loss_and_purge(tmp_path):
-    """Coverage for ``audit_kg_integrity``'s orphan-*detection* path itself.
+    """Coverage for ``audit_kg_integrity``'s orphan-*detection* path itself,
+    for BOTH the entity and relation classification branches.
 
     This is NOT a regression test for the test above
     (``test_audit_tool_detects_and_repairs_missing_anchor``): that test's
     entity is *unanchored* but still resolvable — its source chunk survives,
     so the audit tool reports it under ``missing_entity_anchors`` and repairs
-    it. A "true" orphan (``report["orphan_entities"]``) is stronger: a node
-    whose ``source_id`` points ONLY at chunks that no longer exist anywhere,
-    so no document can be determined at all. Every orphan assertion
-    elsewhere in this suite and in ``test_purge_primitive.py`` is
-    ``== []`` — none of them ever puts a real orphan in front of the tool.
-    If ``audit_kg_integrity``'s orphan-detection logic silently broke (e.g.
-    stopped flagging nodes with unresolvable ``source_id``), no test would
-    fail. This test exists solely to guard that path.
+    it. A "true" orphan (``report["orphan_entities"]`` /
+    ``report["orphan_relations"]``) is stronger: a node or edge whose
+    ``source_id`` points ONLY at chunks that no longer exist anywhere, so no
+    document can be determined at all. Every orphan assertion elsewhere in
+    this suite and in ``test_purge_primitive.py`` is ``== []`` — none of them
+    ever puts a real orphan in front of the tool. If ``audit_kg_integrity``'s
+    orphan-detection logic silently broke for either branch (e.g. stopped
+    flagging nodes/edges with an unresolvable ``source_id``, or either the
+    ``orphan_entities.append(...)`` or the ``orphan_relations.append(...)``
+    call in ``kg_integrity_repair.py`` were deleted), no test would fail.
+    This test exists solely to guard both paths at once.
 
     Construction (matches the tool's own module docstring: "installations
     that ingested documents BEFORE the write-ahead recovery anchors landed
     may hold graph data that full_entities / full_relations do not
-    reference"): delete the ``full_entities`` anchor row out from under an
-    already-ingested document, then run the ordinary whole-document purge.
-    With the anchor gone, ``_purge_kg_contributions``'s candidate discovery
-    (``full_entities.get_by_id(doc_id)``) resolves to an empty candidate
-    set, so entity-node removal is skipped — but chunk deletion proceeds
-    regardless, leaving the ALICE node's ``source_id`` pointing at a chunk
-    that no longer resolves to any document.
+    reference"): this test wires a test-local extraction override
+    (``_wire_fake_extraction_with_relation``) that produces ALICE, BOB, and
+    an edge between them per chunk — unlike the shared
+    ``_wire_fake_extraction`` default (ALICE only, no relations) every other
+    test in this file uses. After an ordinary ingest, BOTH the
+    ``full_entities`` AND ``full_relations`` anchor rows are deleted out
+    from under the already-ingested document, then the ordinary
+    whole-document purge runs. With both anchors gone,
+    ``_purge_kg_contributions``'s candidate discovery
+    (``full_entities.get_by_id(doc_id)`` / ``full_relations.get_by_id(doc_id)``)
+    resolves to an empty candidate set on both sides, so neither entity-node
+    removal nor edge removal happens — but chunk deletion proceeds
+    regardless, leaving ALICE, BOB, and the edge between them all pointing
+    at a chunk id that no longer resolves to any document.
 
-    IMPORTANT: this test asserts the AUDIT TOOL detects the orphan it was
-    built to find — it does NOT assert that purge leaving the node behind is
-    correct or desired behavior. It is a known, documented gap (see the
-    module docstring of ``kg_integrity_repair.py``), and this test merely
-    exploits that documented gap to get a real orphan on the board so the
-    detection path is exercised. If a future change closes the gap (e.g.
-    ``_purge_kg_contributions`` learns to discover entities from the graph
-    itself when the anchor row is missing, rather than only from the
-    anchor), ALICE would stop being orphaned and this test's
-    ``orphan_entities == ["ALICE"]`` assertion would need to be deliberately
-    updated — that is an intentional signal this test is designed to raise,
-    not a regression to work around.
-
-    Asymmetry note: only ``full_entities`` is dropped here; ``full_relations``
-    is left intact. ``_wire_fake_extraction`` (used by ``_build_rag``) only
-    ever produces the ALICE entity with no relations, so this fixture can't
-    observe the asymmetry either way. For a fixture with relations, leaving
-    ``full_relations`` alone would let the relation candidate-discovery path
-    run normally — it would still find and remove the doc's edges via the
-    (intact) anchor row, which is the correct/patched behavior. Only the
-    entity path is being routed through the pre-#3400 gap here, deliberately.
+    IMPORTANT: this test asserts the AUDIT TOOL detects the orphans it was
+    built to find — it does NOT assert that purge leaving the nodes/edge
+    behind is correct or desired behavior. It is a known, documented gap
+    (see the module docstring of ``kg_integrity_repair.py``), and this test
+    merely exploits that documented gap to get real orphans on the board so
+    both detection paths are exercised. If a future change closes the gap
+    (e.g. ``_purge_kg_contributions`` learns to discover entities/relations
+    from the graph itself when the anchor row is missing, rather than only
+    from the anchor), ALICE/BOB/their edge would stop being orphaned and
+    this test's ``orphan_entities`` / ``orphan_relations`` assertions would
+    need to be deliberately updated — that is an intentional signal this
+    test is designed to raise, not a regression to work around.
     """
     workspace = f"fim-true-orphan-{uuid4().hex[:8]}"
     doc_id = compute_mdhash_id("orphan.txt", prefix="doc-")
 
     rag = await _build_rag(tmp_path, workspace)
+    _wire_fake_extraction_with_relation(rag)
     try:
         await rag.apipeline_enqueue_documents(
             input="orphan doc", file_paths="orphan.txt"
@@ -401,10 +461,10 @@ async def test_audit_tool_detects_true_orphan_after_anchor_loss_and_purge(tmp_pa
         )
         assert chunk_ids, "fixture must produce at least one chunk to purge"
 
-        # Simulate a pre-#3400 installation: the entity recovery anchor was
-        # never written for this document. See the asymmetry note above for
-        # why full_relations is left alone.
+        # Simulate a pre-#3400 installation: BOTH recovery anchors were
+        # never written for this document.
         await rag.full_entities.delete([doc_id])
+        await rag.full_relations.delete([doc_id])
 
         status = {"latest_message": "", "history_messages": []}
         lock = asyncio.Lock()
@@ -413,13 +473,18 @@ async def test_audit_tool_detects_true_orphan_after_anchor_loss_and_purge(tmp_pa
         )
 
         # The purge "succeeded" (no exception, chunk gone) but never
-        # discovered ALICE as a delete candidate: the node survives, now
-        # pointing at a chunk id that no longer resolves to any document.
+        # discovered ALICE, BOB, or their edge as delete candidates: both
+        # nodes and the edge survive, now pointing at a chunk id that no
+        # longer resolves to any document.
         assert await rag.chunk_entity_relation_graph.get_node("ALICE") is not None
+        assert await rag.chunk_entity_relation_graph.get_node("BOB") is not None
+        assert (
+            await rag.chunk_entity_relation_graph.get_edge("ALICE", "BOB") is not None
+        )
         assert await rag.text_chunks.get_by_id(chunk_ids[0]) is None
 
         report = await audit_kg_integrity(rag)
-        assert report["orphan_entities"] == ["ALICE"]
-        assert report["orphan_relations"] == []
+        assert report["orphan_entities"] == ["ALICE", "BOB"]
+        assert report["orphan_relations"] == [["ALICE", "BOB"]]
     finally:
         await rag.finalize_storages()

--- a/tests/pipeline/test_fault_injection_matrix.py
+++ b/tests/pipeline/test_fault_injection_matrix.py
@@ -15,6 +15,7 @@ matrix; immediate-write backends are covered by the mock-based unit suites.
 
 from __future__ import annotations
 
+import asyncio
 from uuid import uuid4
 
 import numpy as np
@@ -328,5 +329,97 @@ async def test_audit_tool_detects_and_repairs_missing_anchor(tmp_path):
 
         report = await audit_kg_integrity(rag)
         assert report["missing_entity_anchors"] == {}
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_audit_tool_detects_true_orphan_after_anchor_loss_and_purge(tmp_path):
+    """Coverage for ``audit_kg_integrity``'s orphan-*detection* path itself.
+
+    This is NOT a regression test for the test above
+    (``test_audit_tool_detects_and_repairs_missing_anchor``): that test's
+    entity is *unanchored* but still resolvable — its source chunk survives,
+    so the audit tool reports it under ``missing_entity_anchors`` and repairs
+    it. A "true" orphan (``report["orphan_entities"]``) is stronger: a node
+    whose ``source_id`` points ONLY at chunks that no longer exist anywhere,
+    so no document can be determined at all. Every orphan assertion
+    elsewhere in this suite and in ``test_purge_primitive.py`` is
+    ``== []`` — none of them ever puts a real orphan in front of the tool.
+    If ``audit_kg_integrity``'s orphan-detection logic silently broke (e.g.
+    stopped flagging nodes with unresolvable ``source_id``), no test would
+    fail. This test exists solely to guard that path.
+
+    Construction (matches the tool's own module docstring: "installations
+    that ingested documents BEFORE the write-ahead recovery anchors landed
+    may hold graph data that full_entities / full_relations do not
+    reference"): delete the ``full_entities`` anchor row out from under an
+    already-ingested document, then run the ordinary whole-document purge.
+    With the anchor gone, ``_purge_kg_contributions``'s candidate discovery
+    (``full_entities.get_by_id(doc_id)``) resolves to an empty candidate
+    set, so entity-node removal is skipped — but chunk deletion proceeds
+    regardless, leaving the ALICE node's ``source_id`` pointing at a chunk
+    that no longer resolves to any document.
+
+    IMPORTANT: this test asserts the AUDIT TOOL detects the orphan it was
+    built to find — it does NOT assert that purge leaving the node behind is
+    correct or desired behavior. It is a known, documented gap (see the
+    module docstring of ``kg_integrity_repair.py``), and this test merely
+    exploits that documented gap to get a real orphan on the board so the
+    detection path is exercised. If a future change closes the gap (e.g.
+    ``_purge_kg_contributions`` learns to discover entities from the graph
+    itself when the anchor row is missing, rather than only from the
+    anchor), ALICE would stop being orphaned and this test's
+    ``orphan_entities == ["ALICE"]`` assertion would need to be deliberately
+    updated — that is an intentional signal this test is designed to raise,
+    not a regression to work around.
+
+    Asymmetry note: only ``full_entities`` is dropped here; ``full_relations``
+    is left intact. ``_wire_fake_extraction`` (used by ``_build_rag``) only
+    ever produces the ALICE entity with no relations, so this fixture can't
+    observe the asymmetry either way. For a fixture with relations, leaving
+    ``full_relations`` alone would let the relation candidate-discovery path
+    run normally — it would still find and remove the doc's edges via the
+    (intact) anchor row, which is the correct/patched behavior. Only the
+    entity path is being routed through the pre-#3400 gap here, deliberately.
+    """
+    workspace = f"fim-true-orphan-{uuid4().hex[:8]}"
+    doc_id = compute_mdhash_id("orphan.txt", prefix="doc-")
+
+    rag = await _build_rag(tmp_path, workspace)
+    try:
+        await rag.apipeline_enqueue_documents(
+            input="orphan doc", file_paths="orphan.txt"
+        )
+        await rag.apipeline_process_enqueue_documents()
+
+        row = await rag.doc_status.get_by_id(doc_id)
+        chunk_ids = list(
+            dict.fromkeys(
+                c for c in (row.get("chunks_list") or []) if isinstance(c, str) and c
+            )
+        )
+        assert chunk_ids, "fixture must produce at least one chunk to purge"
+
+        # Simulate a pre-#3400 installation: the entity recovery anchor was
+        # never written for this document. See the asymmetry note above for
+        # why full_relations is left alone.
+        await rag.full_entities.delete([doc_id])
+
+        status = {"latest_message": "", "history_messages": []}
+        lock = asyncio.Lock()
+        await rag._purge_doc_chunks_and_kg(
+            doc_id, chunk_ids, pipeline_status=status, pipeline_status_lock=lock
+        )
+
+        # The purge "succeeded" (no exception, chunk gone) but never
+        # discovered ALICE as a delete candidate: the node survives, now
+        # pointing at a chunk id that no longer resolves to any document.
+        assert await rag.chunk_entity_relation_graph.get_node("ALICE") is not None
+        assert await rag.text_chunks.get_by_id(chunk_ids[0]) is None
+
+        report = await audit_kg_integrity(rag)
+        assert report["orphan_entities"] == ["ALICE"]
+        assert report["orphan_relations"] == []
     finally:
         await rag.finalize_storages()


### PR DESCRIPTION
### Gap

`audit_kg_integrity` reports graph contributions whose source chunks no longer resolve as `orphan_entities` / `orphan_relations`, and `README_KG_INTEGRITY_REPAIR.md` documents that class as the reason the tool exists:

> reports **irrecoverable orphans** (contributions whose source chunks no longer exist) — these are never modified automatically

But every orphan assertion in the suite is `== []`:

- `tests/pipeline/test_fault_injection_matrix.py:117-118, 262, 302`
- the orphan assertions in `tests/pipeline/test_purge_primitive.py`

No test ever puts a real orphan in front of the tool. If the orphan-detection logic silently regressed — stopped flagging nodes with an unresolvable `source_id` — nothing would fail.

The three nearest tests each miss it in a different direction:

| test | why it doesn't cover this |
|---|---|
| `test_absent_candidates_are_idempotent_noops` | reverse case — candidates present, nodes absent (superset safety) |
| `test_reprocess_with_fewer_candidates_overwrites_stale_anchor` | staleness at *write* time; never purges |
| `test_audit_tool_detects_and_repairs_missing_anchor` | entity is unanchored but still *resolvable* — lands in `missing_entity_anchors`, not `orphan_entities` |

That last one is the closest and the distinction matters: a "true" orphan is strictly stronger — a node whose `source_id` points only at chunks that no longer exist anywhere, so no owning document can be determined and the tool deliberately refuses to repair it.

### Change

One test, `test_audit_tool_detects_true_orphan_after_anchor_loss_and_purge`, added to the existing `tests/pipeline/test_fault_injection_matrix.py` (which already carries the `offline` marker).

It constructs true orphans exactly the way `kg_integrity_repair.py`'s module docstring describes a pre-write-ahead-anchor installation:

1. ingest a document normally, so the graph and both anchors exist — the fixture produces two entities and an edge between them
2. drop **both** the `full_entities` and `full_relations` anchor rows for it
3. run the ordinary whole-document purge — candidate discovery resolves to an empty set for each, so node and edge removal are both skipped, while chunk deletion proceeds
4. assert `audit_kg_integrity` reports the surviving nodes *and* the surviving edge by name

Asserted on the names and the exact edge pair rather than counts, so partial degradation in detection fails loudly.

Both classification branches are covered deliberately: `orphan_entities` and `orphan_relations` are separate code paths (`kg_integrity_repair.py:122` and `:132`), so a test that only produces an entity orphan leaves the relation branch free to regress silently — which would have reproduced the very `== []` non-coverage this PR is about.

The fixture wiring for the relation is test-local and layered on top of the shared default, so the other tests in this file keep their existing single-entity, zero-relation extraction.

### Scope — what this test does and does not claim

It asserts **the audit tool detects the orphan it was built to find**. It does *not* assert that purge leaving the node behind is correct or desired; that is a documented gap, and the test merely exploits it to get a real orphan on the board.

The docstring records this explicitly: if a future change closes the gap — e.g. `_purge_kg_contributions` learns to discover entities from the graph when the anchor row is missing — the entity would stop being orphaned and this test's assertion would need to be updated deliberately. That is an intended signal, not a regression to work around.

### Verification

Full offline suite before/after on one checkout, both Python versions CI uses:

| | py3.12 | py3.14 |
|---|---|---|
| before | 3005 passed, 44 skipped, 910 deselected | 3005 passed, 44 skipped, 910 deselected |
| after | 3006 passed, 44 skipped, 910 deselected | 3006 passed, 44 skipped, 910 deselected |

**+1 passed**, nothing else moved. Collected under `-m offline` (verified with `--collect-only`, not assumed), and passes both standalone and inside the full suite — no collection-order dependency.

Mutation-checked independently on each branch, since that is the whole point:

| mutation | result |
|---|---|
| neuter `orphan_entities.append(...)` (`:122`) | entity assertion **fails** |
| neuter `orphan_relations.append(...)` (`:132`) | relation assertion **fails**, entity assertion still passes |

The second row is what makes the two assertions independently load-bearing. A coverage test that cannot fail would not be worth adding.

`pre-commit run` passes at the pinned `ruff` rev.
