### PR TITLE
fix(llm): do not cache token-limit-truncated LLM responses

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -3492,7 +3492,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     enable_cot=True,
                     stream=param.stream,
                 )
-                if type(response) is str:
+                # isinstance, not exact type: a truncated non-streaming
+                # response arrives as TruncatedResponse (a str subclass) and
+                # must not be misclassified as a streaming iterator.
+                if isinstance(response, str):
                     return {
                         "status": "success",
                         "message": "Bypass mode LLM non streaming response",

--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -29,6 +29,7 @@ from lightrag.utils import (
     wrap_embedding_func_with_attrs,
     safe_unicode_decode,
     logger,
+    TruncatedResponse,
 )
 
 from lightrag.api import __api_version__
@@ -222,7 +223,9 @@ def create_openai_async_client(
         return AsyncOpenAI(**merged_configs)
 
 
-# TODO LengthFinishReasonError should not persist into LLM cache
+# Token-limit-truncated completions (finish_reason == "length") are returned
+# wrapped in TruncatedResponse so the cache layer skips persisting incomplete
+# output. See the "Note on truncated structured output" in the docstring below.
 @retry(
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=4, max=10),
@@ -271,12 +274,13 @@ async def openai_complete_if_cache(
     - ``keyword_extraction`` is deprecated; prefer
       ``response_format={"type": "json_object"}`` instead.
 
-    Note on truncated structured output: when the OpenAI SDK raises
-    `LengthFinishReasonError`, callers may still receive partial raw JSON from
-    `completion.choices[0].message.content`. That payload should be treated as
-    best-effort recovery only. If the JSON was truncated or repaired after
-    truncation, it is safer not to persist it into the LLM cache because later
-    runs with a higher token budget could otherwise keep reusing incomplete data.
+    Note on truncated structured output: when a completion stops with
+    `finish_reason == "length"`, callers may still receive partial raw JSON from
+    `completion.choices[0].message.content`. That payload is returned unchanged
+    for best-effort recovery, but wrapped in `TruncatedResponse` (a `str`
+    subclass) so the cache layer can detect and skip persisting it. This
+    prevents later runs — even with a higher token budget — from reusing the
+    incomplete data. See `is_truncated_response` in `lightrag.utils`.
 
     Note on `reasoning_content`: This feature relies on a Deepseek Style `reasoning_content`
     in the API response, which may be provided by OpenAI-compatible endpoints that support
@@ -797,6 +801,18 @@ async def openai_complete_if_cache(
             # Apply Unicode decoding to final content if needed
             if r"\u" in final_content:
                 final_content = safe_unicode_decode(final_content.encode("utf-8"))
+
+            # Flag token-limit truncation so the cache layer skips persisting
+            # partial output. The content is still returned unchanged for
+            # best-effort salvage (e.g. tolerant JSON parsing); TruncatedResponse
+            # is a str subclass, so downstream processing is unaffected.
+            if getattr(response.choices[0], "finish_reason", None) == "length":
+                logger.warning(
+                    "OpenAI response truncated by token limit "
+                    f"(finish_reason=length, content_len={len(final_content)}); "
+                    "returning partial content but not caching it"
+                )
+                final_content = TruncatedResponse(final_content)
 
             if token_tracker and hasattr(response, "usage"):
                 token_counts = {

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -29,6 +29,7 @@ from lightrag.utils import (
     handle_cache,
     save_to_cache,
     CacheData,
+    is_truncated_response,
     use_llm_func_with_cache,
     get_env_value,
     get_llm_cache_identity,
@@ -4196,7 +4197,11 @@ async def kg_query(
             stream=query_param.stream,
         )
 
-        if hashing_kv and hashing_kv.global_config.get("enable_llm_cache"):
+        if (
+            hashing_kv
+            and hashing_kv.global_config.get("enable_llm_cache")
+            and not is_truncated_response(response)
+        ):
             queryparam_dict = {
                 "mode": query_param.mode,
                 "response_type": query_param.response_type,
@@ -4473,7 +4478,10 @@ async def extract_keywords_only(
     _, hl_keywords, ll_keywords = _parse_keywords_payload(result)
 
     # 6. Cache only the processed keywords with cache type
-    if hl_keywords or ll_keywords:
+    #    Skip caching when the LLM response was truncated by the token limit:
+    #    the parsed keyword set may be incomplete, and caching it would replay
+    #    the partial result on every later run.
+    if (hl_keywords or ll_keywords) and not is_truncated_response(result):
         cache_data = {
             "high_level_keywords": hl_keywords,
             "low_level_keywords": ll_keywords,
@@ -6216,7 +6224,11 @@ async def naive_query(
             stream=query_param.stream,
         )
 
-        if hashing_kv and hashing_kv.global_config.get("enable_llm_cache"):
+        if (
+            hashing_kv
+            and hashing_kv.global_config.get("enable_llm_cache")
+            and not is_truncated_response(response)
+        ):
             queryparam_dict = {
                 "mode": query_param.mode,
                 "response_type": query_param.response_type,

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -3597,6 +3597,32 @@ async def update_chunk_cache_list(
         )
 
 
+class TruncatedResponse(str):
+    """An LLM response that was cut off by the model's output token limit.
+
+    Behaves exactly like ``str`` so every downstream consumer — tolerant JSON
+    parsing, text sanitization, entity/relation extraction — keeps working on
+    the partial content unchanged. The only added meaning is a signal to the
+    LLM cache layer: a truncated response must NOT be persisted, because a
+    cached partial payload (e.g. cut-off extraction JSON) would be replayed on
+    every later run, even when a larger token budget would have produced the
+    complete output. See ``is_truncated_response`` and the cache-write guards
+    in ``use_llm_func_with_cache`` and ``lightrag.operate``.
+    """
+
+    __slots__ = ()
+
+
+def is_truncated_response(value: Any) -> bool:
+    """Return True if ``value`` is an LLM response flagged as token-limit truncated.
+
+    Safe for any input: non-string values (e.g. streaming async iterators) and
+    plain ``str`` responses from providers that do not emit the marker return
+    False, so callers degrade to the pre-existing "cache everything" behavior.
+    """
+    return isinstance(value, TruncatedResponse)
+
+
 def remove_think_tags(text: str) -> str:
     """Remove <think>...</think> tags and their content from the text.
 
@@ -3744,26 +3770,39 @@ async def use_llm_func_with_cache(
             safe_user_prompt, system_prompt=safe_system_prompt, **kwargs
         )
 
+        # Capture the token-limit truncation flag before remove_think_tags
+        # rebuilds a plain str and drops the TruncatedResponse marker.
+        res_truncated = is_truncated_response(res)
+
         res = remove_think_tags(res)
 
         # Generate timestamp for cache miss (LLM call completion time)
         current_timestamp = int(time.time())
 
         if llm_response_cache.global_config.get("enable_llm_cache_for_entity_extract"):
-            await save_to_cache(
-                llm_response_cache,
-                CacheData(
-                    args_hash=arg_hash,
-                    content=res,
-                    prompt=_prompt,
-                    cache_type=cache_type,
-                    chunk_id=chunk_id,
-                ),
-            )
+            if res_truncated:
+                # Do not persist truncated extraction output: a cached partial
+                # payload would be replayed on every later run, even when a
+                # larger token budget would have completed the extraction.
+                logger.warning(
+                    f"Skipping LLM cache write for truncated {cache_type} response "
+                    f"(finish_reason=length, chunk_id={chunk_id})"
+                )
+            else:
+                await save_to_cache(
+                    llm_response_cache,
+                    CacheData(
+                        args_hash=arg_hash,
+                        content=res,
+                        prompt=_prompt,
+                        cache_type=cache_type,
+                        chunk_id=chunk_id,
+                    ),
+                )
 
-            # Add cache key to collector if provided
-            if cache_keys_collector is not None:
-                cache_keys_collector.append(cache_key)
+                # Add cache key to collector if provided
+                if cache_keys_collector is not None:
+                    cache_keys_collector.append(cache_key)
 
         return res, current_timestamp
 

--- a/tests/llm/openai_impl/test_openai_length_finish_reason.py
+++ b/tests/llm/openai_impl/test_openai_length_finish_reason.py
@@ -4,7 +4,11 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from lightrag.llm.openai import InvalidResponseError, openai_complete_if_cache
+from lightrag.llm.openai import (
+    InvalidResponseError,
+    azure_openai_complete_if_cache,
+    openai_complete_if_cache,
+)
 from lightrag.utils import is_truncated_response
 
 
@@ -157,6 +161,34 @@ async def test_stop_finish_reason_is_not_marked_truncated():
 
     assert result == raw_json
     assert is_truncated_response(result) is False
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_azure_length_finish_reason_marks_result_truncated():
+    """Azure shares the unified non-streaming path, so it emits the marker too.
+
+    ``azure_openai_complete_if_cache`` delegates to ``openai_complete_if_cache``
+    (with ``use_azure=True`` affecting only client construction). This test
+    pins that delegation: if Azure ever grows its own completion path, the
+    truncation marker must move with it.
+    """
+    raw_json = '{"entities":[{"name":"Alice","type":"Person"'
+    completion = _make_completion(raw_json, finish_reason="length")
+    fake_client = _make_fake_client(completion)
+
+    with patch(
+        "lightrag.llm.openai.create_openai_async_client",
+        return_value=fake_client,
+    ):
+        result = await azure_openai_complete_if_cache(
+            model="test-deployment",
+            prompt="Extract entities",
+            response_format={"type": "json_object"},
+        )
+
+    assert result == raw_json
+    assert is_truncated_response(result) is True
 
 
 @pytest.mark.offline

--- a/tests/llm/openai_impl/test_openai_length_finish_reason.py
+++ b/tests/llm/openai_impl/test_openai_length_finish_reason.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from lightrag.llm.openai import InvalidResponseError, openai_complete_if_cache
+from lightrag.utils import is_truncated_response
 
 
 def _make_completion(
@@ -108,6 +109,54 @@ async def test_length_finish_reason_returns_raw_content():
     assert result == raw_json
     fake_client.chat.completions.create.assert_awaited_once()
     fake_client.close.assert_awaited_once()
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_length_finish_reason_marks_result_truncated():
+    """Truncated content is returned but flagged so the cache layer skips it.
+
+    The partial payload is still usable (str equality holds for salvage), but
+    ``is_truncated_response`` reports True so callers do not persist it.
+    """
+    raw_json = '{"entities":[{"name":"Alice","type":"Person"'
+    completion = _make_completion(raw_json, finish_reason="length")
+    fake_client = _make_fake_client(completion)
+
+    with patch(
+        "lightrag.llm.openai.create_openai_async_client",
+        return_value=fake_client,
+    ):
+        result = await openai_complete_if_cache(
+            model="test-model",
+            prompt="Extract entities",
+            response_format={"type": "json_object"},
+        )
+
+    assert result == raw_json
+    assert is_truncated_response(result) is True
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_stop_finish_reason_is_not_marked_truncated():
+    """A normally-completed response is not flagged and remains cacheable."""
+    raw_json = '{"entities":[],"relationships":[]}'
+    completion = _make_completion(raw_json, finish_reason="stop")
+    fake_client = _make_fake_client(completion)
+
+    with patch(
+        "lightrag.llm.openai.create_openai_async_client",
+        return_value=fake_client,
+    ):
+        result = await openai_complete_if_cache(
+            model="test-model",
+            prompt="Extract entities",
+            response_format={"type": "json_object"},
+        )
+
+    assert result == raw_json
+    assert is_truncated_response(result) is False
 
 
 @pytest.mark.offline

--- a/tests/llm/test_bypass_truncated_response.py
+++ b/tests/llm/test_bypass_truncated_response.py
@@ -1,0 +1,76 @@
+import pytest
+
+from lightrag import LightRAG
+from lightrag.base import QueryParam
+from lightrag.utils import TruncatedResponse
+
+
+class _FakeRAG:
+    """Minimal stand-in exposing only what the bypass branch touches."""
+
+    def __init__(self, llm_func):
+        self._llm = llm_func
+
+    def _build_global_config(self):
+        return {"role_llm_funcs": {"query": self._llm}}
+
+
+def _make_llm(response):
+    async def llm(prompt, **_kwargs):
+        return response
+
+    return llm
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_bypass_truncated_response_is_not_misclassified_as_streaming():
+    """A TruncatedResponse (str subclass) must stay on the non-streaming branch.
+
+    The bypass branch distinguishes a plain string from a streaming iterator;
+    an exact ``type(response) is str`` check would push the truncated string
+    into the streaming branch, handing callers a bare str as
+    ``response_iterator``.
+    """
+    rag = _FakeRAG(_make_llm(TruncatedResponse("partial answer")))
+
+    result = await LightRAG.aquery_llm(
+        rag, "question", param=QueryParam(mode="bypass", stream=False)
+    )
+
+    llm_response = result["llm_response"]
+    assert llm_response["is_streaming"] is False
+    assert llm_response["content"] == "partial answer"
+    assert llm_response["response_iterator"] is None
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_bypass_plain_string_stays_non_streaming():
+    rag = _FakeRAG(_make_llm("complete answer"))
+
+    result = await LightRAG.aquery_llm(
+        rag, "question", param=QueryParam(mode="bypass", stream=False)
+    )
+
+    llm_response = result["llm_response"]
+    assert llm_response["is_streaming"] is False
+    assert llm_response["content"] == "complete answer"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_bypass_iterator_stays_streaming():
+    async def _chunks():
+        yield "part"
+
+    iterator = _chunks()
+    rag = _FakeRAG(_make_llm(iterator))
+
+    result = await LightRAG.aquery_llm(
+        rag, "question", param=QueryParam(mode="bypass", stream=True)
+    )
+
+    llm_response = result["llm_response"]
+    assert llm_response["is_streaming"] is True
+    assert llm_response["response_iterator"] is iterator

--- a/tests/llm/test_query_truncated_response_not_cached.py
+++ b/tests/llm/test_query_truncated_response_not_cached.py
@@ -1,0 +1,92 @@
+import pytest
+
+from lightrag.base import QueryParam
+from lightrag.operate import naive_query
+from lightrag.utils import TruncatedResponse
+
+
+class _FakeTokenizer:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(token) for token in tokens)
+
+
+class _FakeKVStorage:
+    def __init__(self):
+        self.global_config = {"enable_llm_cache": True}
+        self._store = {}
+
+    async def get_by_id(self, key):
+        return self._store.get(key)
+
+    async def upsert(self, entries):
+        self._store.update(entries)
+
+
+class _FakeChunksVDB:
+    cosine_better_than_threshold = 0.0
+
+    async def query(self, *_args, **_kwargs):
+        return [
+            {
+                "id": "chunk-1",
+                "content": "Truncated response cache guard test chunk.",
+                "file_path": "test.md",
+            }
+        ]
+
+
+def _query_global_config(llm_func) -> dict:
+    return {
+        "tokenizer": _FakeTokenizer(),
+        "role_llm_funcs": {"query": llm_func},
+        "min_rerank_score": 0.0,
+        "max_total_tokens": 4096,
+    }
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_naive_query_truncated_answer_not_cached():
+    """A token-limit-truncated answer is returned but never enters the query cache.
+
+    The next identical query must reach the LLM again instead of replaying the
+    partial answer; a subsequent complete answer is then cached as usual.
+    """
+    cache = _FakeKVStorage()
+    chunks_vdb = _FakeChunksVDB()
+    responses = [
+        TruncatedResponse("partial ans"),
+        "complete answer",
+    ]
+    calls = 0
+
+    async def query_model(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        return responses[calls - 1]
+
+    param = QueryParam(mode="naive", enable_rerank=False)
+
+    first = await naive_query(
+        "same query",
+        chunks_vdb,
+        param,
+        _query_global_config(query_model),
+        hashing_kv=cache,
+    )
+    assert first.content == "partial ans"
+    assert cache._store == {}
+
+    second = await naive_query(
+        "same query",
+        chunks_vdb,
+        param,
+        _query_global_config(query_model),
+        hashing_kv=cache,
+    )
+    assert second.content == "complete answer"
+    assert calls == 2
+    assert len(cache._store) == 1

--- a/tests/llm/test_utils_llm_cache.py
+++ b/tests/llm/test_utils_llm_cache.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from lightrag.utils import use_llm_func_with_cache
+from lightrag.utils import TruncatedResponse, use_llm_func_with_cache
 
 
 class _FakeKVStorage:
@@ -74,6 +74,68 @@ async def test_use_llm_func_with_cache_partitions_cache_by_llm_identity():
     assert second_result == "model-b"
     assert llm_func.await_count == 2
     assert len(cache._store) == 2
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_use_llm_func_with_cache_skips_caching_truncated_response():
+    """A token-limit-truncated response is returned but never persisted.
+
+    Caching a partial extraction payload would replay the incomplete data on
+    every later run, even once a larger token budget would have produced the
+    complete output. The content is still returned for best-effort salvage.
+    """
+    cache = _FakeKVStorage()
+    truncated = TruncatedResponse('{"entities":[{"name":"Ali')
+    llm_func = AsyncMock(return_value=truncated)
+
+    result, _ = await use_llm_func_with_cache(
+        "extract prompt",
+        llm_func,
+        llm_response_cache=cache,
+        response_format={"type": "json_object"},
+    )
+
+    # Content is returned to the caller for tolerant parsing/salvage...
+    assert result == '{"entities":[{"name":"Ali'
+    # ...but nothing was written to the cache.
+    assert cache._store == {}
+    llm_func.assert_awaited_once()
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_use_llm_func_with_cache_truncated_response_is_not_reused():
+    """A skipped truncated write means the next call re-invokes the LLM.
+
+    First call truncates (not cached); a retry with more budget must reach the
+    LLM again and then cache the complete result.
+    """
+    cache = _FakeKVStorage()
+    llm_func = AsyncMock(
+        side_effect=[
+            TruncatedResponse('{"entities":[{"name":"Ali'),
+            '{"entities":[{"name":"Alice"}]}',
+        ]
+    )
+
+    first, _ = await use_llm_func_with_cache(
+        "same prompt",
+        llm_func,
+        llm_response_cache=cache,
+    )
+    second, _ = await use_llm_func_with_cache(
+        "same prompt",
+        llm_func,
+        llm_response_cache=cache,
+    )
+
+    assert first == '{"entities":[{"name":"Ali'
+    assert second == '{"entities":[{"name":"Alice"}]}'
+    # Both calls hit the LLM (the truncated first result was not cached);
+    # only the complete second result is now persisted.
+    assert llm_func.await_count == 2
+    assert len(cache._store) == 1
 
 
 @pytest.mark.offline


### PR DESCRIPTION
## Description

Truncated LLM responses were being written to the LLM cache. When an OpenAI(-compatible) completion stops with `finish_reason == "length"`, the adapter still returns the partial content so tolerant JSON parsing can salvage it — but that same partial payload was then persisted to the cache. On every later run the cache would replay the incomplete data (e.g. cut-off entity-extraction JSON), **even when a larger token budget would have produced the complete output**, silently degrading extraction quality.

This resolves the long-standing `# TODO LengthFinishReasonError should not persist into LLM cache` in `lightrag/llm/openai.py`.

## Related Issues

Resolves the in-code TODO in `lightrag/llm/openai.py` (caching of length-truncated responses). No external issue number.

## Changes Made

- **New marker** `TruncatedResponse` (a `str` subclass) plus `is_truncated_response()` helper in `lightrag/utils.py`. Because it *is* a `str`, all downstream text processing, sanitization, and tolerant JSON parsing keep working on the partial content unchanged — the only added meaning is "do not cache me."
- **OpenAI adapter** (`lightrag/llm/openai.py`): non-streaming completions that stop with `finish_reason == "length"` are wrapped in `TruncatedResponse` (with a warning log). The content is still returned unchanged for best-effort salvage.
- **Cache-write guards** skip persisting a truncated response:
  - `use_llm_func_with_cache` (entity/relation extraction) — the primary case from the TODO. The flag is captured *before* `remove_think_tags` rebuilds a plain `str` and drops the marker.
  - keyword-extraction cache and the `kg_query` / `naive_query` answer caches in `lightrag/operate.py`.
- Updated the resolved TODO comment and the adapter docstring note.

**Safety / backward-compat:** providers that don't emit the marker, and streaming responses, return `False` from `is_truncated_response` and therefore keep the previous "cache everything" behavior. The change is purely additive — it can never cache *less-correct* data than before, only avoid caching known-incomplete data.

## What could break

Nothing under normal operation. The only behavioral change is that a completion truncated by the token limit is no longer cached, so the next identical call re-invokes the LLM instead of replaying a partial result. That is the intended fix. Out of scope (noted for a follow-up): the multimodal/VLM cache path in `pipeline.py` (it has its own JSON-conformance retry loop and calls `str(result_text)`, which strips the marker — so no behavior change there), and emitting the marker from non-OpenAI providers.

## Additional Notes

Added regression tests:

- `tests/llm/openai_impl/test_openai_length_finish_reason.py` — the adapter flags a `finish_reason == "length"` result as truncated (and does **not** flag a normal `stop` result), while still returning the raw content.
- `tests/llm/test_utils_llm_cache.py` — `use_llm_func_with_cache` returns a truncated response to the caller but never writes it to the cache, and a subsequent call re-invokes the LLM (proving the partial result wasn't cached) and then caches the complete result.

Verification: `ruff check .` clean; `ruff format --check` clean on touched files; the targeted offline tests pass (19 in the two files above), and broader offline runs pass (`442 passed` in extraction/pipeline, `135 passed` in llm). The only failures in those wider runs are pre-existing missing-optional-dependency import errors (aioboto3, ollama, qdrant_client), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
