### PR TITLE
fix(lightrag): fall back when COSINE_THRESHOLD env is empty

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -752,7 +752,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     """If True, lightrag will automatically calls initialize_storages and finalize_storages at the appropriate times."""
 
     cosine_better_than_threshold: float = field(
-        default=float(os.getenv("COSINE_THRESHOLD", 0.2))
+        default=get_env_value("COSINE_THRESHOLD", DEFAULT_COSINE_THRESHOLD, float)
     )
 
     ollama_server_infos: Optional[OllamaServerInfos] = field(default=None)

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -340,11 +340,6 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     )
     """Maximum total tokens in context (including system prompt, entities, relations and chunks)."""
 
-    cosine_threshold: int = field(
-        default=get_env_value("COSINE_THRESHOLD", DEFAULT_COSINE_THRESHOLD, int)
-    )
-    """Cosine threshold of vector DB retrieval for entities, relations and chunks."""
-
     related_chunk_number: int = field(
         default=get_env_value("RELATED_CHUNK_NUMBER", DEFAULT_RELATED_CHUNK_NUMBER, int)
     )

--- a/tests/test_cosine_threshold_env.py
+++ b/tests/test_cosine_threshold_env.py
@@ -1,0 +1,43 @@
+"""Empty COSINE_THRESHOLD must not crash LightRAG class construction.
+
+``cosine_better_than_threshold`` previously used bare ``float(os.getenv(...))``,
+which raises ``ValueError`` when the variable is present but empty (common in
+``.env`` / Docker Compose). Sibling knobs already go through ``get_env_value``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize("env_value", ["", "  ", "\t"])
+def test_empty_cosine_threshold_env_falls_back_on_import(env_value: str) -> None:
+    env = os.environ.copy()
+    env["COSINE_THRESHOLD"] = env_value
+    env["PYTHONPATH"] = str(REPO_ROOT) + (
+        os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else ""
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from lightrag.lightrag import LightRAG; "
+            "print(LightRAG.__dataclass_fields__"
+            "['cosine_better_than_threshold'].default)",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "0.2"


### PR DESCRIPTION
Setting `COSINE_THRESHOLD=` in `.env` or Compose (present but empty) crashes `from lightrag.lightrag import LightRAG` because the field default used bare `float(os.getenv(...))`.

Use `get_env_value` like the other LightRAG env defaults so empty/whitespace falls back to `DEFAULT_COSINE_THRESHOLD` (0.2).