### PR TITLE
feat(llm): extend truncation marker to gemini/ollama/bedrock and the multimodal analysis cache

### DIFF
--- a/lightrag/llm/bedrock.py
+++ b/lightrag/llm/bedrock.py
@@ -20,7 +20,11 @@ from tenacity import (
 from collections.abc import AsyncIterator
 from typing import Any, Union
 
-from lightrag.utils import wrap_embedding_func_with_attrs
+from lightrag.utils import (
+    TruncatedResponse,
+    logger,
+    wrap_embedding_func_with_attrs,
+)
 
 # Import botocore exceptions for proper exception handling
 try:
@@ -419,6 +423,16 @@ async def bedrock_complete_if_cache(
 
             if not content or content.strip() == "":
                 raise BedrockError("Received empty content from Bedrock API")
+
+            # Flag token-limit truncation (Converse API stopReason ==
+            # "max_tokens") so the cache layer skips persisting partial output.
+            if response.get("stopReason") == "max_tokens":
+                logger.warning(
+                    "Bedrock response truncated by token limit "
+                    f"(stopReason=max_tokens, content_len={len(content)}); "
+                    "returning partial content but not caching it"
+                )
+                content = TruncatedResponse(content)
 
             return content
 

--- a/lightrag/llm/gemini.py
+++ b/lightrag/llm/gemini.py
@@ -24,6 +24,7 @@ from tenacity import (
 )
 
 from lightrag.utils import (
+    TruncatedResponse,
     logger,
     remove_think_tags,
     safe_unicode_decode,
@@ -542,6 +543,21 @@ async def gemini_complete_if_cache(
         final_text = safe_unicode_decode(final_text.encode("utf-8"))
 
     final_text = remove_think_tags(final_text)
+
+    # Flag token-limit truncation so the cache layer skips persisting partial
+    # output. Must stay the last transformation of final_text: any later
+    # string operation would rebuild a plain str and drop the marker.
+    candidates = getattr(response, "candidates", None)
+    finish_reason = (
+        getattr(candidates[0], "finish_reason", None) if candidates else None
+    )
+    if finish_reason == types.FinishReason.MAX_TOKENS:
+        logger.warning(
+            "Gemini response truncated by token limit "
+            f"(finish_reason=MAX_TOKENS, content_len={len(final_text)}); "
+            "returning partial content but not caching it"
+        )
+        final_text = TruncatedResponse(final_text)
 
     usage = getattr(response, "usage_metadata", None)
     if token_tracker and usage:

--- a/lightrag/llm/ollama.py
+++ b/lightrag/llm/ollama.py
@@ -27,6 +27,7 @@ from lightrag.api import __api_version__
 import numpy as np
 from typing import Any, Optional, Union
 from lightrag.utils import (
+    TruncatedResponse,
     wrap_embedding_func_with_attrs,
     logger,
 )
@@ -196,6 +197,19 @@ async def _ollama_model_if_cache(
             this information is not needed for the final
             response and can simply be trimmed.
             """
+
+            # Flag token-limit truncation (done_reason == "length", num_predict
+            # exhausted) so the cache layer skips persisting partial output.
+            # .get works on both the raw dict (ollama<0.4) and the
+            # SubscriptableBaseModel ChatResponse (ollama>=0.4); a missing key
+            # returns None and keeps the previous cache-everything behavior.
+            if response.get("done_reason") == "length":
+                logger.warning(
+                    "Ollama response truncated by token limit "
+                    f"(done_reason=length, content_len={len(model_response)}); "
+                    "returning partial content but not caching it"
+                )
+                model_response = TruncatedResponse(model_response)
 
             return model_response
     except Exception as e:

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -76,6 +76,7 @@ from lightrag.utils import (
     get_env_value,
     get_llm_cache_identity,
     handle_cache,
+    is_truncated_response,
     logger,
     repair_vlm_json_escape_damage_nested,
     sanitize_text_for_encoding,
@@ -3859,7 +3860,10 @@ class _PipelineMixin:
                 """
 
                 def _attempt(raw: Any, fresh: bool) -> tuple[dict[str, str], str, bool]:
-                    text = str(raw)
+                    # Keep str input as-is: str(raw) would rebuild a plain str
+                    # and drop the TruncatedResponse marker the cache guards
+                    # below need to observe.
+                    text = raw if isinstance(raw, str) else str(raw)
                     return validate_result(_json_extract(text)), text, fresh
 
                 use_cached_response = cached is not None
@@ -4051,26 +4055,37 @@ class _PipelineMixin:
                 )
                 cache_id_to_attach: str | None = None
                 if fresh and analysis_cache_enabled:
-                    audit_blob = image_audit_metadata(normalized_images)
-                    original_prompt = prompt + (
-                        f"\n<vlm_images>"
-                        f"{json.dumps(audit_blob, ensure_ascii=False)}"
-                        "</vlm_images>"
-                        if audit_blob
-                        else ""
-                    )
-                    await save_to_cache(
-                        self.llm_response_cache,
-                        CacheData(
-                            args_hash=args_hash,
-                            content=str(result_text),
-                            prompt=original_prompt,
-                            mode="default",
-                            cache_type="analysis",
-                            chunk_id=None,
-                        ),
-                    )
-                    cache_id_to_attach = cache_id
+                    if is_truncated_response(result_text):
+                        # A token-limit-truncated VLM response that still
+                        # parsed must not be persisted: the cache would replay
+                        # the partial analysis on every later run, even once a
+                        # larger token budget would have completed it.
+                        logger.warning(
+                            f"[analyze_multimodal] drawings/{item_id}: skipping "
+                            "analysis cache write for token-limit-truncated "
+                            "VLM response"
+                        )
+                    else:
+                        audit_blob = image_audit_metadata(normalized_images)
+                        original_prompt = prompt + (
+                            f"\n<vlm_images>"
+                            f"{json.dumps(audit_blob, ensure_ascii=False)}"
+                            "</vlm_images>"
+                            if audit_blob
+                            else ""
+                        )
+                        await save_to_cache(
+                            self.llm_response_cache,
+                            CacheData(
+                                args_hash=args_hash,
+                                content=str(result_text),
+                                prompt=original_prompt,
+                                mode="default",
+                                cache_type="analysis",
+                                chunk_id=None,
+                            ),
+                        )
+                        cache_id_to_attach = cache_id
                 elif not fresh:
                     # Cache hit: the entry exists, so attaching its id is
                     # safe (and necessary for document-delete cleanup).
@@ -4262,18 +4277,25 @@ class _PipelineMixin:
                     result_obj["equation"] = analysis_fields["equation"]
                 cache_id_to_attach: str | None = None
                 if fresh and analysis_cache_enabled:
-                    await save_to_cache(
-                        self.llm_response_cache,
-                        CacheData(
-                            args_hash=args_hash,
-                            content=str(result_text),
-                            prompt=prompt,
-                            mode="default",
-                            cache_type="analysis",
-                            chunk_id=None,
-                        ),
-                    )
-                    cache_id_to_attach = cache_id
+                    if is_truncated_response(result_text):
+                        logger.warning(
+                            f"[analyze_multimodal] {kind}/{item_id}: skipping "
+                            "analysis cache write for token-limit-truncated "
+                            "EXTRACT response"
+                        )
+                    else:
+                        await save_to_cache(
+                            self.llm_response_cache,
+                            CacheData(
+                                args_hash=args_hash,
+                                content=str(result_text),
+                                prompt=prompt,
+                                mode="default",
+                                cache_type="analysis",
+                                chunk_id=None,
+                            ),
+                        )
+                        cache_id_to_attach = cache_id
                 elif not fresh:
                     # Cache hit path (handle_cache already gated by flag):
                     # safe to surface the existing cache_id for cleanup.

--- a/tests/llm/bedrock_impl/test_bedrock_llm.py
+++ b/tests/llm/bedrock_impl/test_bedrock_llm.py
@@ -965,3 +965,67 @@ def test_health_pipeline_active_derivation(
         pipeline_state.get("pending_enqueues", 0)
     )
     assert body["pipeline_active"] is expected_active
+
+
+class _FakeTruncatedClient(_FakeBedrockClient):
+    def __init__(self, captured_calls: list[dict], stop_reason: str):
+        super().__init__(captured_calls)
+        self._stop_reason = stop_reason
+
+    async def converse(self, **kwargs):
+        self._captured_calls.append(kwargs)
+        return {
+            "output": {"message": {"content": [{"text": '{"entities":[{"name":"Ali'}]}},
+            "stopReason": self._stop_reason,
+        }
+
+
+class _FakeTruncatedSession(_FakeSession):
+    def __init__(self, captured_calls, client_kwargs_calls, stop_reason):
+        super().__init__(captured_calls, client_kwargs_calls)
+        self._stop_reason = stop_reason
+
+    def client(self, *_args, **kwargs):
+        self._client_kwargs_calls.append(dict(kwargs))
+        return _FakeTruncatedClient(self._captured_calls, self._stop_reason)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_bedrock_max_tokens_stop_reason_marks_result_truncated(monkeypatch):
+    """Converse stopReason == "max_tokens" flags the response as uncacheable."""
+    from lightrag.utils import is_truncated_response
+
+    monkeypatch.delenv("AWS_REGION", raising=False)
+
+    with patch(
+        "lightrag.llm.bedrock.aioboto3.Session",
+        return_value=_FakeTruncatedSession([], [], "max_tokens"),
+    ):
+        result = await bedrock_complete_if_cache(
+            model="bedrock-model",
+            prompt="Extract entities",
+        )
+
+    assert result == '{"entities":[{"name":"Ali'
+    assert is_truncated_response(result) is True
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_bedrock_end_turn_stop_reason_is_not_marked_truncated(monkeypatch):
+    from lightrag.utils import is_truncated_response
+
+    monkeypatch.delenv("AWS_REGION", raising=False)
+
+    with patch(
+        "lightrag.llm.bedrock.aioboto3.Session",
+        return_value=_FakeTruncatedSession([], [], "end_turn"),
+    ):
+        result = await bedrock_complete_if_cache(
+            model="bedrock-model",
+            prompt="Extract entities",
+        )
+
+    assert result == '{"entities":[{"name":"Ali'
+    assert is_truncated_response(result) is False

--- a/tests/llm/gemini_impl/test_gemini_llm.py
+++ b/tests/llm/gemini_impl/test_gemini_llm.py
@@ -22,6 +22,10 @@ def _load_gemini_module(monkeypatch, request):
     fake_types = SimpleNamespace(
         GenerateContentConfig=FakeGenerateContentConfig,
         HttpOptions=FakeHttpOptions,
+        # gemini.py compares candidates[0].finish_reason against this enum on
+        # the non-streaming path (truncation marker); string sentinels stand in
+        # for the real google.genai enum members.
+        FinishReason=SimpleNamespace(MAX_TOKENS="MAX_TOKENS", STOP="STOP"),
     )
     fake_genai = SimpleNamespace(Client=lambda **kwargs: SimpleNamespace(kwargs=kwargs))
     fake_google_module = ModuleType("google")
@@ -76,7 +80,7 @@ def _load_gemini_module(monkeypatch, request):
     return importlib.import_module("lightrag.llm.gemini")
 
 
-def _make_fake_gemini_response(regular_text="", thought_text=""):
+def _make_fake_gemini_response(regular_text="", thought_text="", finish_reason=None):
     parts = []
     if thought_text:
         parts.append(SimpleNamespace(text=thought_text, thought=True))
@@ -85,7 +89,10 @@ def _make_fake_gemini_response(regular_text="", thought_text=""):
 
     return SimpleNamespace(
         candidates=[
-            SimpleNamespace(content=SimpleNamespace(parts=parts)),
+            SimpleNamespace(
+                content=SimpleNamespace(parts=parts),
+                finish_reason=finish_reason,
+            ),
         ],
         usage_metadata=SimpleNamespace(
             prompt_token_count=1,
@@ -231,3 +238,61 @@ async def test_gemini_streaming_structured_output_disables_cot(monkeypatch, requ
         chunks.append(chunk)
 
     assert "".join(chunks) == '{"answer":"ok"}'
+
+
+def _make_nonstreaming_client(fake_response):
+    async def _fake_generate_content(**kwargs):
+        return fake_response
+
+    return SimpleNamespace(
+        aio=SimpleNamespace(
+            models=SimpleNamespace(generate_content=_fake_generate_content)
+        )
+    )
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_gemini_max_tokens_finish_reason_marks_result_truncated(
+    monkeypatch, request
+):
+    """MAX_TOKENS truncation is returned for salvage but flagged uncacheable."""
+    gemini_module = _load_gemini_module(monkeypatch, request)
+    from lightrag.utils import is_truncated_response
+
+    raw_json = '{"entities":[{"name":"Ali'
+    fake_client = _make_nonstreaming_client(
+        _make_fake_gemini_response(regular_text=raw_json, finish_reason="MAX_TOKENS")
+    )
+    monkeypatch.setattr(gemini_module, "_get_gemini_client", lambda *args: fake_client)
+
+    result = await gemini_module.gemini_complete_if_cache(
+        model="gemini-model",
+        prompt="Extract entities",
+        api_key="test-key",
+    )
+
+    assert result == raw_json
+    assert is_truncated_response(result) is True
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_gemini_stop_finish_reason_is_not_marked_truncated(monkeypatch, request):
+    gemini_module = _load_gemini_module(monkeypatch, request)
+    from lightrag.utils import is_truncated_response
+
+    raw_json = '{"entities":[]}'
+    fake_client = _make_nonstreaming_client(
+        _make_fake_gemini_response(regular_text=raw_json, finish_reason="STOP")
+    )
+    monkeypatch.setattr(gemini_module, "_get_gemini_client", lambda *args: fake_client)
+
+    result = await gemini_module.gemini_complete_if_cache(
+        model="gemini-model",
+        prompt="Extract entities",
+        api_key="test-key",
+    )
+
+    assert result == raw_json
+    assert is_truncated_response(result) is False

--- a/tests/llm/ollama_impl/test_ollama_truncation.py
+++ b/tests/llm/ollama_impl/test_ollama_truncation.py
@@ -1,0 +1,63 @@
+"""Offline tests: token-limit-truncated Ollama responses carry the marker."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from lightrag.llm.ollama import _ollama_model_if_cache
+from lightrag.utils import is_truncated_response
+
+pytestmark = pytest.mark.offline
+
+
+def _make_fake_client(response: dict):
+    return SimpleNamespace(
+        chat=AsyncMock(return_value=response),
+        _client=SimpleNamespace(aclose=AsyncMock()),
+    )
+
+
+@pytest.mark.asyncio
+async def test_ollama_length_done_reason_marks_result_truncated():
+    """done_reason == "length" (num_predict exhausted) flags the response.
+
+    The raw-dict response shape mirrors ollama<0.4; ollama>=0.4 returns a
+    ChatResponse whose .get behaves identically (SubscriptableBaseModel).
+    """
+    raw_json = '{"entities":[{"name":"Ali'
+    fake_client = _make_fake_client(
+        {"message": {"content": raw_json}, "done_reason": "length"}
+    )
+
+    with patch("lightrag.llm.ollama.ollama.AsyncClient", return_value=fake_client):
+        result = await _ollama_model_if_cache(model="test-model", prompt="Extract")
+
+    assert result == raw_json
+    assert is_truncated_response(result) is True
+
+
+@pytest.mark.asyncio
+async def test_ollama_stop_done_reason_is_not_marked_truncated():
+    raw_json = '{"entities":[]}'
+    fake_client = _make_fake_client(
+        {"message": {"content": raw_json}, "done_reason": "stop"}
+    )
+
+    with patch("lightrag.llm.ollama.ollama.AsyncClient", return_value=fake_client):
+        result = await _ollama_model_if_cache(model="test-model", prompt="Extract")
+
+    assert result == raw_json
+    assert is_truncated_response(result) is False
+
+
+@pytest.mark.asyncio
+async def test_ollama_missing_done_reason_is_not_marked_truncated():
+    """Older servers may omit done_reason; degrade to cache-everything."""
+    fake_client = _make_fake_client({"message": {"content": "answer"}})
+
+    with patch("lightrag.llm.ollama.ollama.AsyncClient", return_value=fake_client):
+        result = await _ollama_model_if_cache(model="test-model", prompt="Q")
+
+    assert result == "answer"
+    assert is_truncated_response(result) is False

--- a/tests/pipeline/test_pipeline_analyze_multimodal.py
+++ b/tests/pipeline/test_pipeline_analyze_multimodal.py
@@ -1309,3 +1309,67 @@ async def test_table_missing_format_hard_fails(tmp_path):
             content="<table><tr><td>A</td></tr></table>",
         )
     assert "tb-001" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_truncated_vlm_response_not_cached_and_recomputed(tmp_path):
+    """A token-limit-truncated VLM analysis is used but never cached.
+
+    Even when the truncated payload still parses as valid analysis JSON, the
+    cache write must be skipped (no entry, no ``llm_cache_list`` write-back)
+    so a later run re-invokes the VLM instead of replaying the partial result.
+    """
+    from lightrag.utils import TruncatedResponse
+
+    call_log: list[int] = []
+
+    async def truncated_vlm(prompt, **kwargs):
+        call_log.append(1)
+        return TruncatedResponse(
+            json.dumps(
+                {
+                    "name": "fig-1",
+                    "type": "Chart",
+                    "description": "partial but parseable description",
+                }
+            )
+        )
+
+    rag = _build_rag(tmp_path, vlm_process_enable=True, vlm_func=truncated_vlm)
+    await rag.initialize_storages()
+    try:
+        doc_id, parsed_data, sidecar_path = _write_sidecar_fixtures(tmp_path)
+
+        await rag.analyze_multimodal(
+            doc_id=doc_id,
+            file_path="fixture.pdf",
+            parsed_data=parsed_data,
+            process_options="i",
+        )
+        assert len(call_log) == 1
+
+        # The salvaged partial analysis is still used for this run...
+        payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        item = payload["drawings"]["im-001"]
+        assert item["llm_analyze_result"]["status"] == "success"
+        # ...but no cache entry exists and no cache id was written back.
+        assert not item.get("llm_cache_list")
+        cache_file = (
+            Path(rag.working_dir) / rag.workspace / "kv_store_llm_response_cache.json"
+        )
+        if cache_file.exists():
+            cache_blob = json.loads(cache_file.read_text(encoding="utf-8"))
+            assert not [
+                k for k in cache_blob.keys() if k.startswith("default:analysis:")
+            ]
+
+        # Re-run: no cache hit, so the VLM must be invoked again.
+        await rag.analyze_multimodal(
+            doc_id=doc_id,
+            file_path="fixture.pdf",
+            parsed_data=parsed_data,
+            process_options="i",
+        )
+        assert len(call_log) == 2
+    finally:
+        await rag.finalize_storages()


### PR DESCRIPTION
## Description

**Stacked on #3446** — this branch contains #3446's commits plus one new commit ([`46bf2f6`](https://github.com/danielaskdd/LightRAG/commit/46bf2f61)); merge #3446 first, after which this PR's diff reduces to the new commit.

Extends the `TruncatedResponse` no-cache marker from the unified OpenAI/Azure adapter to every server binding whose API exposes a truncation signal, and implements the multimodal follow-up declared in #3446.

## Changes Made

**Driver markers** (non-streaming paths, each wrapped as the last transformation before return):

| Binding | Signal | Notes |
|---|---|---|
| gemini | `candidates[0].finish_reason == FinishReason.MAX_TOKENS` | wrapped after `remove_think_tags` |
| ollama | `done_reason == "length"` | `.get` works on both the raw dict (`ollama<0.4`) and `SubscriptableBaseModel` `ChatResponse` (`>=0.4`, verified on 0.6.2); missing key → previous behavior |
| bedrock | Converse API `stopReason == "max_tokens"` | top-level dict field per AWS contract |
| lollms | — | **not coverable**: `/lollms_generate` returns bare text with no finish-reason metadata |

**Multimodal analysis cache** (`pipeline.py`):
- `_run_json_conformance_retry` kept `str(raw)`, which rebuilt a plain str and dropped the marker before the cache write could observe it; str input is now passed through as-is.
- Both `save_to_cache` sites (VLM drawings, EXTRACT text/equation) skip persisting a truncated analysis (warning logged) and leave `llm_cache_list` untouched, so document-delete cleanup never references a cache entry that was never written, and the next run re-invokes the model.

All changes stay fail-open: a driver that doesn't emit the marker, a missing signal field, or streaming responses keep the previous cache-everything behavior.

## Additional Notes

Tests (all offline):
- Marker/no-marker pairs per driver; the gemini fake `types` namespace gained `FinishReason` (the real enum exists since `google-genai>=1.0.0`, the declared floor), and an ollama missing-`done_reason` degradation case.
- End-to-end multimodal case: a truncated-but-parseable VLM analysis is used for the current run, writes no `default:analysis:` cache entry, writes no cache id back to the sidecar, and the next run re-invokes the VLM. Verified to fail against the pre-guard behavior (fix-proof).

Verification: `tests/llm` + `tests/pipeline` offline suites pass (502 passed); pre-commit (ruff format + ruff) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)