### PR TITLE
fix(lightrag): fall back when env-backed int defaults are empty

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -67,6 +67,8 @@ from lightrag.constants import (
     DEFAULT_SUMMARY_LANGUAGE,
     DEFAULT_LLM_TIMEOUT,
     DEFAULT_EMBEDDING_TIMEOUT,
+    DEFAULT_EMBEDDING_BATCH_NUM,
+    DEFAULT_EMBEDDING_FUNC_MAX_ASYNC,
     DEFAULT_RERANK_TIMEOUT,
     DEFAULT_SOURCE_IDS_LIMIT_METHOD,
     DEFAULT_MAX_FILE_PATHS,
@@ -495,11 +497,15 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     embedding_token_limit: int | None = field(default=None, init=False)
     """Token limit for embedding model. Set automatically from embedding_func.max_token_size in __post_init__."""
 
-    embedding_batch_num: int = field(default=int(os.getenv("EMBEDDING_BATCH_NUM", 10)))
+    embedding_batch_num: int = field(
+        default=get_env_value("EMBEDDING_BATCH_NUM", DEFAULT_EMBEDDING_BATCH_NUM, int)
+    )
     """Batch size for embedding computations."""
 
     embedding_func_max_async: int = field(
-        default=int(os.getenv("EMBEDDING_FUNC_MAX_ASYNC", 8))
+        default=get_env_value(
+            "EMBEDDING_FUNC_MAX_ASYNC", DEFAULT_EMBEDDING_FUNC_MAX_ASYNC, int
+        )
     )
     """Maximum number of concurrent embedding function calls."""
 
@@ -517,7 +523,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     """
 
     default_embedding_timeout: int = field(
-        default=int(os.getenv("EMBEDDING_TIMEOUT", DEFAULT_EMBEDDING_TIMEOUT))
+        default=get_env_value("EMBEDDING_TIMEOUT", DEFAULT_EMBEDDING_TIMEOUT, int)
     )
 
     # LLM Configuration
@@ -541,25 +547,27 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     """Name of the LLM model used for generating responses."""
 
     summary_max_tokens: int = field(
-        default=int(os.getenv("SUMMARY_MAX_TOKENS", DEFAULT_SUMMARY_MAX_TOKENS))
+        default=get_env_value("SUMMARY_MAX_TOKENS", DEFAULT_SUMMARY_MAX_TOKENS, int)
     )
     """Maximum tokens allowed for entity/relation description."""
 
     summary_context_size: int = field(
-        default=int(os.getenv("SUMMARY_CONTEXT_SIZE", DEFAULT_SUMMARY_CONTEXT_SIZE))
+        default=get_env_value("SUMMARY_CONTEXT_SIZE", DEFAULT_SUMMARY_CONTEXT_SIZE, int)
     )
     """Maximum number of tokens allowed per LLM response."""
 
     summary_length_recommended: int = field(
-        default=int(
-            os.getenv("SUMMARY_LENGTH_RECOMMENDED", DEFAULT_SUMMARY_LENGTH_RECOMMENDED)
+        default=get_env_value(
+            "SUMMARY_LENGTH_RECOMMENDED", DEFAULT_SUMMARY_LENGTH_RECOMMENDED, int
         )
     )
     """Recommended length of LLM summary output."""
 
     llm_model_max_async: int = field(
-        default=int(
-            os.getenv("MAX_ASYNC_LLM", os.getenv("MAX_ASYNC", DEFAULT_MAX_ASYNC))
+        default=get_env_value(
+            "MAX_ASYNC_LLM",
+            get_env_value("MAX_ASYNC", DEFAULT_MAX_ASYNC, int),
+            int,
         )
     )
     """Maximum number of concurrent LLM calls."""
@@ -568,7 +576,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     """Additional keyword arguments passed to the LLM model function."""
 
     default_llm_timeout: int = field(
-        default=int(os.getenv("LLM_TIMEOUT", DEFAULT_LLM_TIMEOUT))
+        default=get_env_value("LLM_TIMEOUT", DEFAULT_LLM_TIMEOUT, int)
     )
 
     entity_extraction_use_json: bool = field(
@@ -587,11 +595,14 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     """Function for reranking retrieved documents. All rerank configurations (model name, API keys, top_k, etc.) should be included in this function. Optional."""
 
     rerank_model_max_async: int = field(
-        default=int(
-            os.getenv(
-                "MAX_ASYNC_RERANK",
-                os.getenv("MAX_ASYNC_LLM", os.getenv("MAX_ASYNC", DEFAULT_MAX_ASYNC)),
-            )
+        default=get_env_value(
+            "MAX_ASYNC_RERANK",
+            get_env_value(
+                "MAX_ASYNC_LLM",
+                get_env_value("MAX_ASYNC", DEFAULT_MAX_ASYNC, int),
+                int,
+            ),
+            int,
         )
     )
     """Maximum number of concurrent rerank calls.
@@ -599,7 +610,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     (MAX_ASYNC is still accepted as a deprecated alias)."""
 
     default_rerank_timeout: int = field(
-        default=int(os.getenv("RERANK_TIMEOUT", DEFAULT_RERANK_TIMEOUT))
+        default=get_env_value("RERANK_TIMEOUT", DEFAULT_RERANK_TIMEOUT, int)
     )
     """Rerank request timeout in seconds.
     Independent from LLM_TIMEOUT since reranker calls are much shorter
@@ -636,44 +647,36 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     # ---
 
     max_parallel_insert: int = field(
-        default=int(os.getenv("MAX_PARALLEL_INSERT", DEFAULT_MAX_PARALLEL_INSERT))
+        default=get_env_value("MAX_PARALLEL_INSERT", DEFAULT_MAX_PARALLEL_INSERT, int)
     )
     """Maximum number of parallel insert operations."""
 
     max_parallel_parse_native: int = field(
-        default=int(
-            os.getenv(
-                "MAX_PARALLEL_PARSE_NATIVE", str(DEFAULT_MAX_PARALLEL_PARSE_NATIVE)
-            )
+        default=get_env_value(
+            "MAX_PARALLEL_PARSE_NATIVE", DEFAULT_MAX_PARALLEL_PARSE_NATIVE, int
         )
     )
     max_parallel_parse_mineru: int = field(
-        default=int(
-            os.getenv(
-                "MAX_PARALLEL_PARSE_MINERU", str(DEFAULT_MAX_PARALLEL_PARSE_MINERU)
-            )
+        default=get_env_value(
+            "MAX_PARALLEL_PARSE_MINERU", DEFAULT_MAX_PARALLEL_PARSE_MINERU, int
         )
     )
     max_parallel_parse_docling: int = field(
-        default=int(
-            os.getenv(
-                "MAX_PARALLEL_PARSE_DOCLING", str(DEFAULT_MAX_PARALLEL_PARSE_DOCLING)
-            )
+        default=get_env_value(
+            "MAX_PARALLEL_PARSE_DOCLING", DEFAULT_MAX_PARALLEL_PARSE_DOCLING, int
         )
     )
     max_parallel_analyze: int = field(
-        default=int(
-            os.getenv("MAX_PARALLEL_ANALYZE", str(DEFAULT_MAX_PARALLEL_ANALYZE))
-        )
+        default=get_env_value("MAX_PARALLEL_ANALYZE", DEFAULT_MAX_PARALLEL_ANALYZE, int)
     )
     queue_size_parse: int = field(
-        default=int(os.getenv("QUEUE_SIZE_PARSE", str(DEFAULT_QUEUE_SIZE_PARSE)))
+        default=get_env_value("QUEUE_SIZE_PARSE", DEFAULT_QUEUE_SIZE_PARSE, int)
     )
     queue_size_analyze: int = field(
-        default=int(os.getenv("QUEUE_SIZE_ANALYZE", str(DEFAULT_QUEUE_SIZE_ANALYZE)))
+        default=get_env_value("QUEUE_SIZE_ANALYZE", DEFAULT_QUEUE_SIZE_ANALYZE, int)
     )
     queue_size_insert: int = field(
-        default=int(os.getenv("QUEUE_SIZE_INSERT", str(DEFAULT_QUEUE_SIZE_INSERT)))
+        default=get_env_value("QUEUE_SIZE_INSERT", DEFAULT_QUEUE_SIZE_INSERT, int)
     )
 
     max_graph_nodes: int = field(

--- a/tests/test_empty_int_env_field_defaults.py
+++ b/tests/test_empty_int_env_field_defaults.py
@@ -1,0 +1,55 @@
+"""Empty env-backed int defaults must not crash LightRAG class construction.
+
+Follow-up to the COSINE_THRESHOLD fix: several ``LightRAG`` field defaults still
+used bare ``int(os.getenv(...))``, which raises when the variable is present but
+empty (common in ``.env`` / Compose). ``env.example`` ships live
+``EMBEDDING_BATCH_NUM=32``; clearing that value previously made import fail.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _import_field_default(env_key: str, env_value: str, field_name: str) -> str:
+    env = os.environ.copy()
+    env[env_key] = env_value
+    env["PYTHONPATH"] = str(REPO_ROOT) + (
+        os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else ""
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from lightrag.lightrag import LightRAG; "
+            f"print(LightRAG.__dataclass_fields__[{field_name!r}].default)",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize("env_value", ["", "  ", "\t"])
+def test_empty_embedding_batch_num_env_falls_back_on_import(env_value: str) -> None:
+    assert (
+        _import_field_default("EMBEDDING_BATCH_NUM", env_value, "embedding_batch_num")
+        == "10"
+    )
+
+
+@pytest.mark.offline
+def test_empty_llm_timeout_env_falls_back_on_import() -> None:
+    assert _import_field_default("LLM_TIMEOUT", "", "default_llm_timeout") == "240"


### PR DESCRIPTION
Clearing a documented int knob such as `EMBEDDING_BATCH_NUM=` in `.env` or Compose crashes `from lightrag.lightrag import LightRAG` because several field defaults still used bare `int(os.getenv(...))`.

Route those defaults through `get_env_value` like the COSINE_THRESHOLD fix so empty/whitespace falls back to the documented defaults.