### PR TITLE
fix(parser): fall back when CHUNK_R_SEPARATORS env is empty

### DIFF
--- a/lightrag/parser/routing.py
+++ b/lightrag/parser/routing.py
@@ -346,6 +346,20 @@ def _env_optional_str(key: str) -> str | None:
     return raw
 
 
+def _env_r_separators() -> list[str]:
+    """Load CHUNK_R_SEPARATORS; empty/invalid JSON falls back to defaults."""
+    raw = os.getenv("CHUNK_R_SEPARATORS")
+    if not raw or not str(raw).strip():
+        return list(DEFAULT_R_SEPARATORS)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return list(DEFAULT_R_SEPARATORS)
+    if isinstance(parsed, list) and all(isinstance(s, str) for s in parsed):
+        return parsed
+    return list(DEFAULT_R_SEPARATORS)
+
+
 def _env_bool(key: str, default: bool = False) -> bool:
     raw = os.getenv(key)
     if raw is None:
@@ -397,9 +411,7 @@ def default_chunker_config() -> dict[str, Any]:
             # boundaries instead of falling through to character-level
             # splitting.  See ``constants.DEFAULT_R_SEPARATORS`` for
             # cascade order rationale.
-            "separators": json.loads(
-                os.getenv("CHUNK_R_SEPARATORS", json.dumps(list(DEFAULT_R_SEPARATORS)))
-            ),
+            "separators": _env_r_separators(),
         },
         "semantic_vector": {
             "breakpoint_threshold_type": os.getenv(

--- a/tests/parser/test_chunk_r_separators_env.py
+++ b/tests/parser/test_chunk_r_separators_env.py
@@ -1,0 +1,30 @@
+"""Empty CHUNK_R_SEPARATORS must not crash default_chunker_config.
+
+``default_chunker_config`` previously used bare ``json.loads(os.getenv(...))``,
+which raises ``JSONDecodeError`` when the variable is present but empty.
+Sibling ``load_chunk_separators`` already falls back to defaults.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lightrag.constants import DEFAULT_R_SEPARATORS
+from lightrag.parser.routing import default_chunker_config
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize("env_value", ["", "  ", "\t", "not-json", "[1,2]"])
+def test_empty_or_invalid_chunk_r_separators_falls_back(
+    env_value: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CHUNK_R_SEPARATORS", env_value)
+    separators = default_chunker_config()["recursive_character"]["separators"]
+    assert separators == list(DEFAULT_R_SEPARATORS)
+
+
+@pytest.mark.offline
+def test_valid_chunk_r_separators_are_honored(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CHUNK_R_SEPARATORS", '["\\n\\n", "\\n", " "]')
+    separators = default_chunker_config()["recursive_character"]["separators"]
+    assert separators == ["\n\n", "\n", " "]


### PR DESCRIPTION
Setting `CHUNK_R_SEPARATORS=` in `.env` or Compose crashes LightRAG startup because `default_chunker_config` used bare `json.loads(os.getenv(...))`.

Fall back to `DEFAULT_R_SEPARATORS` on empty or invalid JSON, matching the multimodal sibling path.