### PR TITLE
test: stabilize pytest isolation and spaCy model gating

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,12 +39,20 @@ def _hermetic_mineru_env(monkeypatch):
     ``test_invalid_when_local_parser_options_change`` toggles each option
     and expects the change to invalidate a bundle recorded with defaults).
 
-    ``DOCX_SMART_HEADING`` is stripped likewise: it is a live-env
-    parser-routing knob (``routing.smart_heading_default_enabled``), so a
-    developer ``.env`` that sets ``DOCX_SMART_HEADING=true`` seeds
+    ``DOCX_SMART_HEADING`` is pinned to ``"false"`` (not merely deleted):
+    it is a live-env parser-routing knob (``routing.smart_heading_default_enabled``),
+    so a developer ``.env`` that sets ``DOCX_SMART_HEADING=true`` seeds
     ``native(smart_heading=true)`` into the persisted ``parse_engine`` on
     every .docx enqueue, breaking baseline routing tests that expect a bare
-    ``native``.
+    ``native`` — and it also makes ``create_app`` fail-fast on missing spaCy
+    models (``validate_smart_heading_dependencies``), taking down otherwise
+    unrelated API tests. ``delenv`` alone did not hold: the api-module
+    import/reload path re-runs ``load_dotenv(".env", override=False)``, and
+    because ``override=False`` only fills *unset* names, a deleted var is
+    silently repopulated from ``.env``. An explicit ``"false"`` survives that
+    repopulation. The developer's real opt-in is still honored for spaCy test
+    selection — captured once in ``pytest_configure`` before this runs (see
+    ``requires_spacy_models``), independent of this per-test neutralization.
 
     Strip these variables globally; tests that need a specific mode can
     still ``monkeypatch.setenv(...)`` themselves and monkeypatch will
@@ -60,11 +68,21 @@ def _hermetic_mineru_env(monkeypatch):
     monkeypatch.delenv("MINERU_LOCAL_START_PAGE_ID", raising=False)
     monkeypatch.delenv("LIGHTRAG_PARSER", raising=False)
     monkeypatch.delenv("DOCLING_ENDPOINT", raising=False)
-    monkeypatch.delenv("DOCX_SMART_HEADING", raising=False)
+    monkeypatch.setenv("DOCX_SMART_HEADING", "false")
+
+
+#: Populated in ``pytest_configure`` and read by ``requires_spacy_models`` /
+#: ``pytest_terminal_summary``. Two independent facts:
+#: - which pinned spaCy models are missing (empty tuple == all present);
+#: - whether the developer opted into smart_heading (``DOCX_SMART_HEADING``),
+#:   captured BEFORE the per-test ``_hermetic_mineru_env`` fixture pins the var
+#:   to "false" — so opt-in drives spaCy test selection while routing/API tests
+#:   still see a neutral value.
+_SPACY_DOWNLOAD_HINT = "lightrag-download-cache --spacy --spacy-install"
 
 
 def pytest_configure(config):
-    """Register custom markers for LightRAG tests."""
+    """Register custom markers and capture the spaCy model / opt-in state."""
     config.addinivalue_line(
         "markers", "offline: marks tests as offline (no external dependencies)"
     )
@@ -76,6 +94,76 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "requires_api: marks tests requiring LightRAG API server"
     )
+    config.addinivalue_line(
+        "markers",
+        "requires_spacy_models: needs the pinned spaCy language models "
+        f"(install with `{_SPACY_DOWNLOAD_HINT}`)",
+    )
+
+    # Mirror the server's own .env load so DOCX_SMART_HEADING reflects the
+    # developer's real configuration here, before _hermetic_mineru_env pins it.
+    from dotenv import load_dotenv
+
+    load_dotenv(dotenv_path=".env", override=False)
+
+    from lightrag.parser.docx.smart_heading import nlp
+
+    config._missing_spacy_models = tuple(nlp.missing_spacy_models())
+
+    try:
+        from lightrag.parser.routing import smart_heading_default_enabled
+
+        config._smart_heading_opted_in = smart_heading_default_enabled()
+    except Exception:
+        # A malformed DOCX_SMART_HEADING value surfaces at server startup, not
+        # here — default to the gentle (skip, not fail) path for missing models.
+        config._smart_heading_opted_in = False
+
+
+def pytest_runtest_setup(item):
+    """Gate ``@pytest.mark.requires_spacy_models`` tests on model availability.
+
+    Single source of truth for every smart_heading test that needs the real
+    pinned spaCy models, replacing per-file ad-hoc probes/skip messages:
+
+    - models present -> run;
+    - models missing + developer opted into smart_heading
+      (``DOCX_SMART_HEADING=true``) -> FAIL loudly with the install command,
+      because they have declared they use the feature;
+    - models missing + not opted in -> skip, so contributors who never touch
+      smart_heading are not forced to download the models.
+
+    Either way ``pytest_terminal_summary`` restates the command at the end.
+    """
+    if item.get_closest_marker("requires_spacy_models") is None:
+        return
+    missing = getattr(item.config, "_missing_spacy_models", ())
+    if not missing:
+        return
+    detail = (
+        f"pinned spaCy model(s) not installed ({', '.join(missing)}); "
+        f"install with: {_SPACY_DOWNLOAD_HINT}"
+    )
+    if getattr(item.config, "_smart_heading_opted_in", False):
+        pytest.fail(f"DOCX_SMART_HEADING is enabled but {detail}", pytrace=False)
+    pytest.skip(detail)
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    """Tell the developer how to get the spaCy models after the run finishes."""
+    missing = getattr(config, "_missing_spacy_models", ())
+    if not missing:
+        return
+    opted_in = getattr(config, "_smart_heading_opted_in", False)
+    tr = terminalreporter
+    tr.write_sep("=", "spaCy language models not installed", yellow=True, bold=True)
+    tr.write_line(f"Missing model(s): {', '.join(missing)}")
+    tr.write_line(
+        "smart_heading (docx) tests that need them were "
+        + ("FAILED (DOCX_SMART_HEADING is on)." if opted_in else "skipped.")
+    )
+    tr.write_line("To run them, install the pinned models:")
+    tr.write_line(f"    {_SPACY_DOWNLOAD_HINT}")
 
 
 def pytest_addoption(parser):

--- a/tests/kg/postgres_impl/test_postgres_performance_timing.py
+++ b/tests/kg/postgres_impl/test_postgres_performance_timing.py
@@ -1,4 +1,4 @@
-import importlib
+import importlib.util
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -118,21 +118,35 @@ async def test_graph_upsert_edge_passes_timing_label():
     )
 
 
-def test_performance_timing_logs_reads_new_env_only(monkeypatch):
-    with monkeypatch.context() as m:
-        m.setenv("LIGHTRAG_DOC_QUERY_TIMING_LOGS", "false")
-        m.setenv("LIGHTRAG_PERFORMANCE_TIMING_LOGS", "true")
-        reloaded = importlib.reload(utils_module)
-        assert reloaded.PERFORMANCE_TIMING_LOGS is True
+def _read_performance_timing_flag() -> bool:
+    """Re-evaluate ``PERFORMANCE_TIMING_LOGS`` from the current environment.
 
-    importlib.reload(utils_module)
+    ``importlib.reload(utils_module)`` would rebind *every* class in
+    ``lightrag.utils`` to a brand-new object in the shared, in-place module,
+    silently breaking ``isinstance`` identity for the many modules that do
+    ``from lightrag.utils import X`` — most visibly the LLM providers' shared
+    ``TruncatedResponse`` marker, whose ``is_truncated_response`` check would
+    then return False for every test running after this one.
+
+    Executing a throwaway copy of the module in isolation re-runs its top-level
+    env parsing while leaving ``sys.modules['lightrag.utils']`` — and everyone's
+    by-value imports — untouched.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "lightrag.utils", utils_module.__file__
+    )
+    probe = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(probe)
+    return probe.PERFORMANCE_TIMING_LOGS
+
+
+def test_performance_timing_logs_reads_new_env_only(monkeypatch):
+    monkeypatch.setenv("LIGHTRAG_DOC_QUERY_TIMING_LOGS", "false")
+    monkeypatch.setenv("LIGHTRAG_PERFORMANCE_TIMING_LOGS", "true")
+    assert _read_performance_timing_flag() is True
 
 
 def test_performance_timing_logs_ignores_old_env(monkeypatch):
-    with monkeypatch.context() as m:
-        m.setenv("LIGHTRAG_DOC_QUERY_TIMING_LOGS", "true")
-        m.setenv("LIGHTRAG_PERFORMANCE_TIMING_LOGS", "false")
-        reloaded = importlib.reload(utils_module)
-        assert reloaded.PERFORMANCE_TIMING_LOGS is False
-
-    importlib.reload(utils_module)
+    monkeypatch.setenv("LIGHTRAG_DOC_QUERY_TIMING_LOGS", "true")
+    monkeypatch.setenv("LIGHTRAG_PERFORMANCE_TIMING_LOGS", "false")
+    assert _read_performance_timing_flag() is False

--- a/tests/kg/test_pipeline_status_logger.py
+++ b/tests/kg/test_pipeline_status_logger.py
@@ -261,6 +261,10 @@ def _child_logs(status_logger, message):
 
 
 @_skip_no_fork
+@pytest.mark.filterwarnings(
+    r"ignore:This process .* is multi-threaded, use of fork\(\) may lead "
+    r"to deadlocks in the child\.:DeprecationWarning"
+)
 def test_fork_inherited_cached_proxy_writes_visible_in_parent():
     """A logger whose history handle was cached BEFORE the fork keeps working
     in the child (BaseProxy re-registers its connection after fork) and the
@@ -289,6 +293,10 @@ def _mp_cached_writer(status, prefix, n):
 
 
 @_skip_no_fork
+@pytest.mark.filterwarnings(
+    r"ignore:This process .* is multi-threaded, use of fork\(\) may lead "
+    r"to deadlocks in the child\.:DeprecationWarning"
+)
 def test_concurrent_cached_writers_lose_no_messages_and_groups_stay_intact():
     """Concurrent multi-message ``extend`` on cached ListProxies from several
     processes never drops a message NOR tears a group."""

--- a/tests/parser/docx/test_smart_heading_e2e.py
+++ b/tests/parser/docx/test_smart_heading_e2e.py
@@ -11,7 +11,6 @@ tests skip when the pinned models are absent (see test_smart_heading_guards).
 
 from __future__ import annotations
 
-import importlib.util
 import io
 import json
 import re
@@ -22,22 +21,9 @@ import pytest
 FIXTURE_ROOT = Path(__file__).resolve().parent / "golden" / "smart_heading"
 
 
-def _models_available() -> bool:
-    if importlib.util.find_spec("spacy") is None:
-        return False
-    import spacy.util
-
-    return spacy.util.is_package("zh_core_web_sm") and spacy.util.is_package(
-        "en_core_web_sm"
-    )
-
-
 pytestmark = [
     pytest.mark.offline,
-    pytest.mark.skipif(
-        not _models_available(),
-        reason="pinned spaCy models not installed (lightrag-download-cache --spacy)",
-    ),
+    pytest.mark.requires_spacy_models,
 ]
 
 

--- a/tests/parser/docx/test_smart_heading_flow.py
+++ b/tests/parser/docx/test_smart_heading_flow.py
@@ -432,6 +432,7 @@ def test_subtree_demotion_ignores_plain_anchored_child() -> None:
     assert "subtree_demoted" in child.rule_trail
 
 
+@pytest.mark.requires_spacy_models
 def test_source_multisentence_gate_real_spacy_end_to_end(monkeypatch) -> None:
     """test11 regression through real NLP and the block assembler, now via the
     source-level multi-sentence gate in ``strong_body_reason`` (a spaCy ≥2 vote
@@ -450,11 +451,9 @@ def test_source_multisentence_gate_real_spacy_end_to_end(monkeypatch) -> None:
     import json
 
     from lightrag.parser.docx.parse_document import _assemble_blocks_smart
-    from lightrag.parser.docx.smart_heading import guardrails, nlp
+    from lightrag.parser.docx.smart_heading import guardrails
     from lightrag.parser.docx.smart_heading.heading_flow import run_smart_heading
 
-    if nlp.missing_spacy_models():
-        pytest.skip("spaCy models not installed")
     monkeypatch.setenv("DOCX_SMART_MIN_TOKENS", "10")
 
     target = "2.3   投标单位廉洁自律承诺书"

--- a/tests/parser/docx/test_smart_heading_guardrails.py
+++ b/tests/parser/docx/test_smart_heading_guardrails.py
@@ -136,17 +136,14 @@ def test_explicit_internal_sentence_boundary(text: str, expected: bool) -> None:
     assert has_explicit_internal_sentence_boundary(text) is expected
 
 
+@pytest.mark.requires_spacy_models
 def test_strong_body_spares_multi_level_numbered_heading() -> None:
     """Regression: zh spaCy splits a dotted multi-level number ("3.1.1 X" →
     "3.1." | "1 X") into two pseudo-sentences, which falsely demoted numbered
     headings as multi-sentence body. strong_body_reason must judge the title
     prose (label stripped), so a numbered heading is spared while genuine body
     still trips."""
-    from lightrag.parser.docx.smart_heading import nlp
     from lightrag.parser.docx.smart_heading.guardrails import strong_body_reason
-
-    if nlp.missing_spacy_models():
-        pytest.skip("spaCy models not installed")
 
     assert strong_body_reason("3.1.1 桌面及办公设备运维服务") is None
     assert strong_body_reason("3.1.2 政务信息化基础设施运维服务") is None
@@ -155,6 +152,7 @@ def test_strong_body_spares_multi_level_numbered_heading() -> None:
     assert strong_body_reason("本节介绍运维范围。") == "strong_body_sentence_end"
 
 
+@pytest.mark.requires_spacy_models
 def test_strong_body_spares_heading_with_nbsp_separator() -> None:
     """Regression (test8 应急管理部令第11号): an NBSP after the numbering label
     survived the separator strip, and zh spaCy counted the leading \\xa0 as its
@@ -164,9 +162,6 @@ def test_strong_body_spares_heading_with_nbsp_separator() -> None:
     from lightrag.parser.docx.smart_heading import nlp
     from lightrag.parser.docx.smart_heading.guardrails import strong_body_reason
 
-    if nlp.missing_spacy_models():
-        pytest.skip("spaCy models not installed")
-
     assert strong_body_reason("第二章 \xa0列入条件和管理措施") is None
     assert strong_body_reason("第三章 \xa0列入和移出程序") is None
     # A whitespace-only pseudo-sentence never inflates the count on its own.
@@ -175,6 +170,7 @@ def test_strong_body_spares_heading_with_nbsp_separator() -> None:
     assert strong_body_reason("本节介绍列入条件。") == "strong_body_sentence_end"
 
 
+@pytest.mark.requires_spacy_models
 def test_strong_body_multi_sentence_needs_explicit_terminator() -> None:
     """Regression (test13 事故调查报告): the pinned zh model's parser
     hallucinates a mid-word sentence break on short title fragments — a cover
@@ -189,9 +185,6 @@ def test_strong_body_multi_sentence_needs_explicit_terminator() -> None:
         has_explicit_internal_sentence_boundary,
         strong_body_reason,
     )
-
-    if nlp.missing_spacy_models():
-        pytest.skip("spaCy models not installed")
 
     lead_in = "广州市增城区“7.19”索菲亚定制家居项目"
     phrase = "投标单位廉洁自律承诺书"
@@ -906,14 +899,11 @@ def test_truncate_to_heading_length_raw_ceiling_above_cap(monkeypatch) -> None:
     assert out.endswith("...")
 
 
+@pytest.mark.requires_spacy_models
 def test_strong_body_length_floors_tiny_cap(monkeypatch) -> None:
     """strong_body_reason shares heading_max_chars: a nonsensical cap<3 must
     not demote an ordinary short heading via the length rule."""
-    from lightrag.parser.docx.smart_heading import nlp
     from lightrag.parser.docx.smart_heading.guardrails import strong_body_reason
-
-    if nlp.missing_spacy_models():
-        pytest.skip("spaCy models not installed")
 
     monkeypatch.setenv("DOCX_SMART_HEADING_MAX_CHARS", "2")
     # Weighted 30 (10 CJK); with the floor (180) the length rule spares it.

--- a/tests/parser/docx/test_smart_heading_guards.py
+++ b/tests/parser/docx/test_smart_heading_guards.py
@@ -8,8 +8,6 @@ models are absent (e.g. a bare CI). The missing-model hard-error contract
 
 from __future__ import annotations
 
-import importlib.util
-
 import pytest
 
 from lightrag.parser.docx.smart_heading.style_key import classify_numbering
@@ -17,20 +15,7 @@ from lightrag.parser.docx.smart_heading.style_key import classify_numbering
 pytestmark = pytest.mark.offline
 
 
-def _models_available() -> bool:
-    if importlib.util.find_spec("spacy") is None:
-        return False
-    import spacy.util
-
-    return spacy.util.is_package("zh_core_web_sm") and spacy.util.is_package(
-        "en_core_web_sm"
-    )
-
-
-requires_models = pytest.mark.skipif(
-    not _models_available(),
-    reason="pinned spaCy models not installed (lightrag-download-cache --spacy)",
-)
+requires_models = pytest.mark.requires_spacy_models
 
 
 # route_language is a pure function (no model load), so it always runs.

--- a/tests/parser/docx/test_smart_heading_title_block.py
+++ b/tests/parser/docx/test_smart_heading_title_block.py
@@ -88,6 +88,7 @@ def test_multi_window_requires_two_paragraphs_and_big_line() -> None:
     assert _find(records) == []
 
 
+@pytest.mark.requires_spacy_models
 def test_two_line_cover_with_decimal_lead_in_forms_window() -> None:
     """Regression (test13 事故调查报告): a two-line 22pt cover whose first line
     is a lead-in carrying a decimal (广州市增城区"7.19"…) must form ONE
@@ -101,11 +102,6 @@ def test_two_line_cover_with_decimal_lead_in_forms_window() -> None:
     never marks the (short, non-terminated) lead-in strong, so it cannot
     reproduce the bug and would pass against the old implementation too.
     """
-    from lightrag.parser.docx.smart_heading import nlp
-
-    if nlp.missing_spacy_models():
-        pytest.skip("spaCy models not installed")
-
     records = [
         _para("广州市增城区“7.19”索菲亚定制家居项目", size=22.0),  # lead-in (引题)
         _para("建筑工地塔式起重机坍塌较大事故调查报告", size=22.0),  # main title


### PR DESCRIPTION
## Description

Stabilize the pytest environment by isolating environment-sensitive tests, centralizing pinned spaCy model gating, and suppressing the expected Python 3.12 fork warning only where fork semantics are explicitly under test.

## Related Issues

No related issue.

## Changes Made

- Evaluate performance-timing environment flags through an isolated module copy to avoid mutating shared class identities with `importlib.reload`.
- Add a shared `requires_spacy_models` marker that consistently skips or fails smart-heading tests based on model availability and explicit feature opt-in.
- Keep parser and API tests hermetic when a developer's local `.env` enables smart heading.
- Filter the expected multi-threaded `fork()` deprecation warning only in the two tests that intentionally validate fork inheritance.
- Replace duplicated per-test spaCy availability checks with the shared pytest hooks.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

- Full suite: 4045 passed, 36 skipped.
- Focused verification: all 474 selected tests passed; the 15 multiprocessing logger tests were also rerun with local socket permissions and emitted no fork warnings.
