### PR TITLE
fix(llm): honor LLM_TIMEOUT in Bedrock driver and server wiring

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -1839,6 +1839,9 @@ def create_app(args):
                 ) -> str:
                     if history_messages is None:
                         history_messages = []
+                    # Server-configured timeout overrides any caller-passed value,
+                    # matching the OpenAI/Azure/Gemini role wrappers.
+                    kwargs["timeout"] = role_timeout
                     if role_provider_options:
                         kwargs = {**role_provider_options, **kwargs}
                     return await bedrock_complete_if_cache(
@@ -1966,6 +1969,9 @@ def create_app(args):
         # which drops them and emits deprecation warnings when booleans are set.
         if config_cache.bedrock_llm_options:
             kwargs = {**config_cache.bedrock_llm_options, **kwargs}
+        # Server-configured timeout overrides any caller-passed value, matching
+        # the OpenAI wrapper (create_optimized_openai_llm_func).
+        kwargs["timeout"] = llm_timeout
 
         return await bedrock_complete_if_cache(
             args.llm_model,

--- a/lightrag/llm/bedrock.py
+++ b/lightrag/llm/bedrock.py
@@ -10,6 +10,9 @@ if not pm.is_installed("aioboto3"):
     pm.install("aioboto3")
 import aioboto3
 import numpy as np
+
+# botocore is a hard dependency of aioboto3, so this import is always safe.
+from botocore.config import Config as BotocoreConfig
 from tenacity import (
     retry,
     stop_after_attempt,
@@ -74,8 +77,14 @@ def _bedrock_client_kwargs(
     aws_access_key_id: str | None = None,
     aws_secret_access_key: str | None = None,
     aws_session_token: str | None = None,
+    timeout: int | None = None,
 ) -> dict:
-    """Build kwargs for aioboto3 ``session.client("bedrock-runtime", ...)``."""
+    """Build kwargs for aioboto3 ``session.client("bedrock-runtime", ...)``.
+
+    ``timeout`` (seconds) maps to botocore ``connect_timeout``/``read_timeout``,
+    mirroring how the OpenAI driver applies one scalar timeout to every request
+    phase. When None, botocore's defaults (60s each) stay in effect.
+    """
     client_kwargs: dict = {"region_name": region}
     if endpoint_url is not None:
         client_kwargs["endpoint_url"] = endpoint_url
@@ -85,6 +94,11 @@ def _bedrock_client_kwargs(
         client_kwargs["aws_secret_access_key"] = aws_secret_access_key
     if aws_session_token:
         client_kwargs["aws_session_token"] = aws_session_token
+    if timeout is not None:
+        client_kwargs["config"] = BotocoreConfig(
+            connect_timeout=timeout,
+            read_timeout=timeout,
+        )
     return client_kwargs
 
 
@@ -181,6 +195,7 @@ async def bedrock_complete_if_cache(
     api_key: str | None = None,
     endpoint_url: str | None = None,
     image_inputs: list[Any] | None = None,
+    timeout: int | None = None,
     **kwargs,
 ) -> Union[str, AsyncIterator[str]]:
     """Call Amazon Bedrock Converse API with LightRAG-compatible shims.
@@ -206,6 +221,12 @@ async def bedrock_complete_if_cache(
     - ``endpoint_url`` overrides the default regional Bedrock endpoint. Pass
       ``None``, an empty string, or the sentinel ``DEFAULT_BEDROCK_ENDPOINT``
       to let the AWS SDK select its default endpoint.
+
+    Timeout note:
+    - ``timeout`` is in seconds and maps to botocore ``connect_timeout`` and
+      ``read_timeout``; ``None`` keeps botocore's defaults (60s each).
+    - For streaming responses the read timeout bounds the wait for the next
+      chunk of network data, not the total duration of the whole response.
     """
     if enable_cot:
         logging.debug(
@@ -329,6 +350,7 @@ async def bedrock_complete_if_cache(
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
             aws_session_token=aws_session_token,
+            timeout=timeout,
         )
 
         # Define the generator function that will manage the client lifecycle
@@ -393,6 +415,7 @@ async def bedrock_complete_if_cache(
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
             aws_session_token=aws_session_token,
+            timeout=timeout,
         ),
     ) as bedrock_async_client:
         try:

--- a/tests/llm/bedrock_impl/test_bedrock_llm.py
+++ b/tests/llm/bedrock_impl/test_bedrock_llm.py
@@ -394,6 +394,97 @@ async def test_bedrock_complete_forwards_explicit_sigv4_client_kwargs(monkeypatc
     }
 
 
+class _FakeStreamingBedrockClient(_FakeBedrockClient):
+    async def converse_stream(self, **kwargs):
+        self._captured_calls.append(kwargs)
+
+        async def _events():
+            yield {"contentBlockDelta": {"delta": {"text": "chunk"}}}
+            yield {"messageStop": {}}
+
+        return {"stream": _events()}
+
+
+class _FakeStreamingSession(_FakeSession):
+    def client(self, *_args, **kwargs):
+        self._client_kwargs_calls.append(dict(kwargs))
+        return _FakeStreamingBedrockClient(self._captured_calls)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_bedrock_timeout_maps_to_botocore_client_config(monkeypatch):
+    """timeout must reach the aioboto3 client as botocore connect/read timeouts.
+
+    Before the fix nothing consumed ``timeout``, so botocore's 60s defaults
+    applied and long generations failed with "Read timeout on endpoint URL"
+    regardless of LLM_TIMEOUT.
+    """
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    captured_calls: list[dict] = []
+    client_kwargs_calls: list[dict] = []
+
+    with patch(
+        "lightrag.llm.bedrock.aioboto3.Session",
+        return_value=_FakeSession(captured_calls, client_kwargs_calls),
+    ):
+        await bedrock_complete_if_cache(
+            model="bedrock-model",
+            prompt="hello",
+            timeout=240,
+        )
+
+    config = client_kwargs_calls[-1]["config"]
+    assert config.connect_timeout == 240
+    assert config.read_timeout == 240
+    # timeout is not a Converse API parameter and must never leak into the call.
+    assert "timeout" not in captured_calls[-1]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_bedrock_stream_timeout_maps_to_botocore_client_config(monkeypatch):
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    captured_calls: list[dict] = []
+    client_kwargs_calls: list[dict] = []
+
+    with patch(
+        "lightrag.llm.bedrock.aioboto3.Session",
+        return_value=_FakeStreamingSession(captured_calls, client_kwargs_calls),
+    ):
+        stream = await bedrock_complete_if_cache(
+            model="bedrock-model",
+            prompt="hello",
+            stream=True,
+            timeout=240,
+        )
+        chunks = [chunk async for chunk in stream]
+
+    assert chunks == ["chunk"]
+    config = client_kwargs_calls[-1]["config"]
+    assert config.connect_timeout == 240
+    assert config.read_timeout == 240
+    assert "timeout" not in captured_calls[-1]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_bedrock_no_timeout_keeps_botocore_defaults(monkeypatch):
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    client_kwargs_calls: list[dict] = []
+
+    with patch(
+        "lightrag.llm.bedrock.aioboto3.Session",
+        return_value=_FakeSession([], client_kwargs_calls),
+    ):
+        await bedrock_complete_if_cache(
+            model="bedrock-model",
+            prompt="hello",
+        )
+
+    assert "config" not in client_kwargs_calls[-1]
+
+
 @pytest.mark.offline
 @pytest.mark.asyncio
 async def test_bedrock_extra_fields_maps_to_additional_model_request_fields(
@@ -736,6 +827,116 @@ async def test_create_app_bedrock_query_role_uses_role_sigv4_credentials(
     assert mocked_bedrock.await_args.kwargs["aws_access_key_id"] == "query-akid"
     assert mocked_bedrock.await_args.kwargs["aws_secret_access_key"] == "query-secret"
     assert mocked_bedrock.await_args.kwargs["aws_session_token"] == "query-session"
+
+
+def _setup_bedrock_app_modules(monkeypatch, args):
+    """Prepare an isolated lightrag_server module for create_app tests."""
+    _reload_api_modules_if_mocked()
+    monkeypatch.setattr(sys, "argv", ["pytest"])
+    config = importlib.import_module("lightrag.api.config")
+    config.initialize_config(args, force=True)
+    lightrag_server = importlib.import_module("lightrag.api.lightrag_server")
+    monkeypatch.setattr(lightrag_server, "LightRAG", _FakeLightRAG)
+    monkeypatch.setattr(lightrag_server, "check_frontend_build", lambda: (True, False))
+    monkeypatch.setattr(
+        lightrag_server, "create_document_routes", lambda *_args, **_kwargs: APIRouter()
+    )
+    monkeypatch.setattr(
+        lightrag_server, "create_query_routes", lambda *_args, **_kwargs: APIRouter()
+    )
+    monkeypatch.setattr(
+        lightrag_server, "create_graph_routes", lambda *_args, **_kwargs: APIRouter()
+    )
+    monkeypatch.setattr(lightrag_server, "OllamaAPI", _FakeOllamaAPI)
+    return lightrag_server
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_create_app_bedrock_base_llm_func_passes_global_timeout(
+    tmp_path, monkeypatch
+):
+    """LLM_TIMEOUT must reach the Bedrock driver through the base llm_model_func.
+
+    This proves the server-layer wiring: the driver-level timeout tests pass
+    even if lightrag_server.py forgets to forward args.llm_timeout.
+    """
+    args = _make_args(tmp_path)
+    lightrag_server = _setup_bedrock_app_modules(monkeypatch, args)
+
+    with patch(
+        "lightrag.llm.bedrock.bedrock_complete_if_cache",
+        AsyncMock(return_value="bedrock-ok"),
+    ) as mocked_bedrock:
+        lightrag_server.create_app(args)
+        base_func = _FakeLightRAG.last_init_kwargs["llm_model_func"]
+        await base_func("hello")
+
+    assert mocked_bedrock.await_args.kwargs["timeout"] == 180
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_create_app_bedrock_query_role_inherits_global_timeout(
+    tmp_path, monkeypatch
+):
+    args = _make_args(tmp_path)
+    lightrag_server = _setup_bedrock_app_modules(monkeypatch, args)
+
+    with patch(
+        "lightrag.llm.bedrock.bedrock_complete_if_cache",
+        AsyncMock(return_value="bedrock-ok"),
+    ) as mocked_bedrock:
+        lightrag_server.create_app(args)
+        query_func = _FakeLightRAG.last_init_kwargs["role_llm_configs"]["query"].func
+        await query_func("hello")
+
+    assert mocked_bedrock.await_args.kwargs["timeout"] == 180
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_create_app_bedrock_query_role_uses_role_specific_timeout(
+    tmp_path, monkeypatch
+):
+    args = _make_args(tmp_path)
+    args.query_llm_timeout = 99
+    lightrag_server = _setup_bedrock_app_modules(monkeypatch, args)
+
+    with patch(
+        "lightrag.llm.bedrock.bedrock_complete_if_cache",
+        AsyncMock(return_value="bedrock-ok"),
+    ) as mocked_bedrock:
+        lightrag_server.create_app(args)
+        query_func = _FakeLightRAG.last_init_kwargs["role_llm_configs"]["query"].func
+        await query_func("hello")
+
+    assert mocked_bedrock.await_args.kwargs["timeout"] == 99
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_create_app_bedrock_server_timeout_overrides_caller_value(
+    tmp_path, monkeypatch
+):
+    """Caller-passed timeout must not raise a duplicate-keyword TypeError and is
+    overridden by the server-configured value, matching the OpenAI wrappers."""
+    args = _make_args(tmp_path)
+    lightrag_server = _setup_bedrock_app_modules(monkeypatch, args)
+
+    with patch(
+        "lightrag.llm.bedrock.bedrock_complete_if_cache",
+        AsyncMock(return_value="bedrock-ok"),
+    ) as mocked_bedrock:
+        lightrag_server.create_app(args)
+        base_func = _FakeLightRAG.last_init_kwargs["llm_model_func"]
+        query_func = _FakeLightRAG.last_init_kwargs["role_llm_configs"]["query"].func
+
+        await base_func("hello", timeout=5)
+        assert mocked_bedrock.await_args.kwargs["timeout"] == 180
+
+        await query_func("hello", timeout=5)
+        assert mocked_bedrock.await_args.kwargs["timeout"] == 180
 
 
 @pytest.mark.offline


### PR DESCRIPTION
## Description

The Bedrock binding ignored `LLM_TIMEOUT` entirely: nothing in the driver or the API server ever consumed a timeout value, so every `converse` / `converse_stream` call ran with botocore's default **60s** connect/read timeouts (`botocore.endpoint.DEFAULT_TIMEOUT = 60`). Any generation longer than 60 seconds (long extraction prompts, large `max_tokens`, reasoning models) failed with:

```
ERROR:root:Bedrock converse timeout error: Read timeout on endpoint URL
```

regardless of how large `LLM_TIMEOUT` was set, while the OpenAI binding honored it correctly (`kwargs["timeout"]` → `AsyncOpenAI`).

Note that the timeout could not simply be passed through `**kwargs`: `bedrock_complete_if_cache` forwards kwargs into `client.converse(**args, **kwargs)`, and `timeout` is not a Converse API parameter (it would raise `ParamValidationError`). The driver has to consume it explicitly and translate it into a botocore client `Config`.

## Related Issues

N/A (reported via Bedrock deployment: `LLM_TIMEOUT=240` but requests timed out after ~60s)

## Changes Made

- **`lightrag/llm/bedrock.py`**
  - `bedrock_complete_if_cache()` gains an explicit `timeout: int | None = None` parameter (seconds).
  - `_bedrock_client_kwargs()` maps it to `botocore.config.Config(connect_timeout=timeout, read_timeout=timeout)` — equivalent to how the OpenAI driver's scalar timeout applies to every httpx request phase. `None` keeps botocore defaults (no `config` injected), so direct library callers are unaffected.
  - Applied on both the streaming and non-streaming client constructions; docstring documents the unit and that the streaming read timeout bounds the wait for the next chunk, not the whole response.
- **`lightrag/api/lightrag_server.py`**
  - `bedrock_model_complete` now passes the global `LLM_TIMEOUT` and `role_bedrock_complete` passes the role timeout (including `<ROLE>_LLM_TIMEOUT` overrides), via `kwargs["timeout"] = ...` — same pattern as the OpenAI/Azure/Gemini wrappers, so the server-configured value overrides caller-passed ones without duplicate-keyword `TypeError`s.
- **`tests/llm/bedrock_impl/test_bedrock_llm.py`** — 7 new regression tests
  - Driver level: timeout maps to client `Config` (non-stream + stream via a new `_FakeStreamingBedrockClient` that actually consumes the async stream), timeout never leaks into Converse parameters, and no `config` is injected when timeout is absent.
  - Server level (`create_app` wiring): base `llm_model_func` passes `args.llm_timeout`, roles inherit the global timeout, role-specific timeout wins, and a caller-passed `timeout` is overridden without raising.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

- Fix-proof verified: with the source changes stashed, all 6 wiring/config tests fail on the old code (the backward-compat test passes by design); restored, the full file passes (36 passed) plus `tests/llm` + `tests/api/config/test_api_config_bedrock.py` (267 passed) and pinned ruff/ruff-format via pre-commit.
- Out of scope, noted for a follow-up discussion: botocore's default retry mode nests with the driver's outer tenacity retry (5 attempts); collapsing it via `Config(retries={"max_attempts": 1})` would be a behavior change and is intentionally not part of this bug fix. Embedding timeouts are also untouched — no provider currently receives `EMBEDDING_TIMEOUT`, so that would be a separate cross-provider change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
