### PR TITLE
feat(api): expose supported file types + parser capability matrix to WebUI

### DIFF
--- a/lightrag/_version.py
+++ b/lightrag/_version.py
@@ -1,4 +1,4 @@
 """Lightweight version definitions shared by packaging and runtime code."""
 
 __version__ = "1.5.5"
-__api_version__ = "0320"
+__api_version__ = "0321"

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -24,6 +24,7 @@ from fastapi import (
     File,
     HTTPException,
     Request,
+    Response,
     UploadFile,
 )
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -983,6 +984,37 @@ class StatusCountsResponse(BaseModel):
     )
 
 
+class SupportedFileTypesResponse(BaseModel):
+    """Response model for the upload allowlist and parser capability matrix
+
+    Attributes:
+        supported_extensions: Dotted lowercase suffixes accepted for a bare
+            (unhinted) filename under the current parser routing rules
+        engines: Usable parser engine -> dotted suffixes it can parse, for
+            pre-validating filenames that carry a ``[engine]`` hint
+    """
+
+    supported_extensions: List[str] = Field(
+        description="Suffixes accepted for an unhinted filename (dotted, lowercase)"
+    )
+    engines: Dict[str, List[str]] = Field(
+        description="Usable parser engine -> dotted suffixes it can parse"
+    )
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "supported_extensions": [".jpg", ".md", ".pdf", ".txt"],
+                "engines": {
+                    "legacy": [".md", ".pdf", ".txt"],
+                    "mineru": [".jpg", ".pdf", ".png"],
+                    "native": [".docx", ".md", ".textpack"],
+                },
+            }
+        }
+    )
+
+
 class PipelineStatusResponse(BaseModel):
     """Response model for pipeline status
 
@@ -1071,6 +1103,27 @@ class DocumentManager:
             if parser_engine_supports_suffix(engine, s):
                 out.append(f".{s}")
         return tuple(out)
+
+    @property
+    def engine_capabilities(self) -> Dict[str, List[str]]:
+        """Usable engine -> dotted suffixes it can parse, derived live.
+
+        Covers user-selectable engines whose endpoint (if any) is configured
+        — the same gate ``resolve_parser_directives`` applies to a filename
+        hint. Lets the WebUI pre-validate hinted names (``img.[mineru].png``)
+        locally instead of uploading the file only to receive a 400.
+        """
+        from lightrag.parser.registry import (
+            engine_endpoint_configured,
+            suffix_capabilities,
+            supported_parser_engines,
+        )
+
+        return {
+            engine: [f".{s}" for s in sorted(suffix_capabilities(engine))]
+            for engine in sorted(supported_parser_engines())
+            if engine_endpoint_configured(engine)
+        }
 
     def scan_directory_for_new_files(self) -> List[Path]:
         """Scan input directory for new, routable files.
@@ -4337,6 +4390,38 @@ def create_document_routes(
             logger.error(f"Error getting document status counts: {str(e)}")
             logger.error(traceback.format_exc())
             raise internal_server_error(e)
+
+    @router.get(
+        "/supported_file_types",
+        response_model=SupportedFileTypesResponse,
+        dependencies=[Depends(combined_auth)],
+    )
+    async def get_supported_file_types(
+        response: Response,
+    ) -> SupportedFileTypesResponse:
+        """
+        Get the upload allowlist and the parser capability matrix.
+
+        ``supported_extensions`` is the live allowlist for bare (unhinted)
+        filenames — derived from the parser registry plus the current
+        ``LIGHTRAG_PARSER`` routing rules, the same source the upload
+        endpoint's 400 detail quotes. ``engines`` maps every usable engine
+        (user-selectable, endpoint configured) to the suffixes it can parse,
+        so the WebUI can pre-validate hinted filenames like
+        ``img.[mineru].png`` without uploading the file first.
+
+        Derived from process-level configuration today; when per-workspace
+        parser rules land, this endpoint resolves the ``LIGHTRAG-WORKSPACE``
+        header internally — the response contract stays unchanged (hence the
+        ``Vary`` header, declared ahead of time so caches never reuse a
+        response across workspaces).
+        """
+        response.headers["Cache-Control"] = "no-store"
+        response.headers["Vary"] = "LIGHTRAG-WORKSPACE"
+        return SupportedFileTypesResponse(
+            supported_extensions=list(doc_manager.supported_extensions),
+            engines=doc_manager.engine_capabilities,
+        )
 
     @router.post(
         "/reprocess_failed",

--- a/lightrag_webui/src/api/lightrag.ts
+++ b/lightrag_webui/src/api/lightrag.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosError } from 'axios'
 import { backendBaseUrl, popularLabelsDefaultLimit, searchLabelsDefaultLimit } from '@/lib/constants'
+import type { SupportedFileTypes } from '@/lib/fileTypes'
 import { errorMessage } from '@/lib/utils'
 import { useSettingsStore } from '@/stores/settings'
 import { useAuthStore } from '@/stores/state'
@@ -576,6 +577,11 @@ export const checkHealth = async (): Promise<
 
 export const getDocuments = async (): Promise<DocsStatusesResponse> => {
   const response = await axiosInstance.get('/documents')
+  return response.data
+}
+
+export const getSupportedFileTypes = async (signal?: AbortSignal): Promise<SupportedFileTypes> => {
+  const response = await axiosInstance.get('/documents/supported_file_types', { signal })
   return response.data
 }
 

--- a/lightrag_webui/src/components/documents/UploadDocumentsDialog.tsx
+++ b/lightrag_webui/src/components/documents/UploadDocumentsDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { FileRejection } from 'react-dropzone'
 import Button from '@/components/ui/Button'
 import {
@@ -11,8 +11,16 @@ import {
 } from '@/components/ui/Dialog'
 import FileUploader from '@/components/ui/FileUploader'
 import { toast } from 'sonner'
+import { supportedFileTypes } from '@/lib/constants'
+import {
+  deriveUploaderInputs,
+  flattenAcceptExtensions,
+  formatFileTypesLabel,
+  normalizeSupportedFileTypes,
+  type FileTypesState
+} from '@/lib/fileTypes'
 import { errorMessage } from '@/lib/utils'
-import { uploadDocument } from '@/api/lightrag'
+import { getSupportedFileTypes, uploadDocument } from '@/api/lightrag'
 
 import { UploadIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -36,6 +44,29 @@ export default function UploadDocumentsDialog({
   const [isUploading, setIsUploading] = useState(false)
   const [progresses, setProgresses] = useState<Record<string, number>>({})
   const [fileErrors, setFileErrors] = useState<Record<string, string>>({})
+  const [fileTypes, setFileTypes] = useState<FileTypesState>({ status: 'idle' })
+
+  // Fetch the live allowlist + engine capability matrix while the dialog is
+  // open. `loading` is entered synchronously in onOpenChange (not here) so
+  // the very first open render already has the uploader disabled.
+  useEffect(() => {
+    if (!open) return
+    const controller = new AbortController()
+    getSupportedFileTypes(controller.signal)
+      .then((res) => {
+        if (controller.signal.aborted) return
+        const data = normalizeSupportedFileTypes(res)
+        setFileTypes(data ? { status: 'ready', data } : { status: 'fallback' })
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return
+        // Old backend (404) or transient failure: fall back to the static
+        // allowlist and let the server judge hinted filenames.
+        console.warn('Failed to fetch supported file types:', errorMessage(err))
+        setFileTypes({ status: 'fallback' })
+      })
+    return () => controller.abort()
+  }, [open])
 
   const handleRejectedFiles = useCallback(
     (rejectedFiles: FileRejection[]) => {
@@ -203,18 +234,26 @@ export default function UploadDocumentsDialog({
     [setIsUploading, setProgresses, setFileErrors, t, onDocumentsUploaded, onUploadBatchAccepted]
   )
 
+  const uploaderInputs = deriveUploaderInputs(fileTypes)
+
   return (
     <Dialog
       open={open}
-      onOpenChange={(open) => {
+      onOpenChange={(nextOpen) => {
         if (isUploading) {
           return
         }
-        if (!open) {
+        if (nextOpen) {
+          // Enter loading synchronously so the first open render already has
+          // the uploader disabled — no window where a hinted file could start
+          // uploading before the capability matrix arrives.
+          setFileTypes({ status: 'loading' })
+        } else {
           setProgresses({})
           setFileErrors({})
+          setFileTypes({ status: 'idle' })
         }
-        setOpen(open)
+        setOpen(nextOpen)
       }}
     >
       <DialogTrigger asChild>
@@ -232,12 +271,18 @@ export default function UploadDocumentsDialog({
         <FileUploader
           maxFileCount={Infinity}
           maxSize={200 * 1024 * 1024}
-          description={t('documentPanel.uploadDocuments.fileTypes')}
+          description={t('documentPanel.uploadDocuments.fileTypes', {
+            types: formatFileTypesLabel(
+              uploaderInputs.acceptedExtensions ?? flattenAcceptExtensions(supportedFileTypes)
+            )
+          })}
           onUpload={handleDocumentsUpload}
           onReject={handleRejectedFiles}
           progresses={progresses}
           fileErrors={fileErrors}
-          disabled={isUploading}
+          disabled={isUploading || uploaderInputs.disabled}
+          acceptedExtensions={uploaderInputs.acceptedExtensions}
+          engineCapabilities={uploaderInputs.engineCapabilities}
         />
       </DialogContent>
     </Dialog>

--- a/lightrag_webui/src/components/ui/FileUploader.tsx
+++ b/lightrag_webui/src/components/ui/FileUploader.tsx
@@ -13,6 +13,11 @@ import { useControllableState } from '@radix-ui/react-use-controllable-state'
 import Button from '@/components/ui/Button'
 import { ScrollArea } from '@/components/ui/ScrollArea'
 import { supportedFileTypes } from '@/lib/constants'
+import {
+  flattenAcceptExtensions,
+  formatFileTypesLabel,
+  isAcceptedFilename
+} from '@/lib/fileTypes'
 
 interface FileUploaderProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
@@ -64,15 +69,31 @@ interface FileUploaderProps extends React.HTMLAttributes<HTMLDivElement> {
   fileErrors?: Record<string, string>
 
   /**
-   * Accepted file types for the uploader.
+   * Accepted file types for the uploader. Static fallback source; only its
+   * extensions matter (validation is extension-based, MIME keys are ignored).
    * @type { [key: string]: string[]}
-   * @default
-   * ```ts
-   * { "text/*": [] }
-   * ```
-   * @example accept={["text/plain", "application/pdf"]}
+   * @default supportedFileTypes
    */
   accept?: DropzoneProps['accept']
+
+  /**
+   * Backend-provided allowlist for bare (unhinted) filenames, dotted
+   * lowercase. Overrides the extensions derived from `accept` when set.
+   * @type string[]
+   * @default undefined
+   * @example acceptedExtensions={['.md', '.pdf']}
+   */
+  acceptedExtensions?: string[]
+
+  /**
+   * Backend-provided parser capability matrix (engine -> dotted suffixes)
+   * used to pre-validate `[engine]`-hinted filenames locally. When absent,
+   * hinted filenames pass through for the server to judge.
+   * @type Record<string, string[]>
+   * @default undefined
+   * @example engineCapabilities={{ mineru: ['.png', '.pdf'] }}
+   */
+  engineCapabilities?: Record<string, string[]>
 
   /**
    * Maximum file size for the uploader.
@@ -137,6 +158,8 @@ function FileUploader(props: FileUploaderProps) {
     progresses,
     fileErrors,
     accept = supportedFileTypes,
+    acceptedExtensions,
+    engineCapabilities,
     maxSize = 1024 * 1024 * 200,
     maxFileCount = 1,
     multiple = false,
@@ -145,6 +168,12 @@ function FileUploader(props: FileUploaderProps) {
     className,
     ...dropzoneProps
   } = props
+
+  const acceptedExts = React.useMemo(
+    () => new Set(acceptedExtensions ?? flattenAcceptExtensions(accept)),
+    [acceptedExtensions, accept]
+  )
+  const engineMatrix = engineCapabilities ?? null
 
   const [files, setFiles] = useControllableState<File[]>({
     prop: valueProp,
@@ -212,11 +241,8 @@ function FileUploader(props: FileUploaderProps) {
             return false;
           }
 
-          // Check if file type is accepted
-          const fileExt = `.${file.name.split('.').pop()?.toLowerCase() || ''}`;
-          const isAccepted = Object.entries(accept || {}).some(([mimeType, extensions]) => {
-            return file.type === mimeType || (Array.isArray(extensions) && extensions.includes(fileExt));
-          });
+          // Same verdict as the dropzone validator (extension-based, hint-aware)
+          const isAccepted = isAcceptedFilename(file.name, acceptedExts, engineMatrix);
 
           // Check file size
           const isSizeValid = file.size <= maxSize;
@@ -229,7 +255,7 @@ function FileUploader(props: FileUploaderProps) {
         }
       }
     },
-    [files, maxFileCount, multiple, onUpload, onReject, setFiles, t, accept, maxSize]
+    [files, maxFileCount, multiple, onUpload, onReject, setFiles, t, acceptedExts, engineMatrix, maxSize]
   )
 
   function onRemove(index: number) {
@@ -275,14 +301,9 @@ function FileUploader(props: FileUploaderProps) {
             };
           }
 
-          // Safely extract file extension
-          const fileExt = `.${file.name.split('.').pop()?.toLowerCase() || ''}`;
-
-          // Ensure accept object exists and has correct format
-          const isAccepted = Object.entries(accept || {}).some(([mimeType, extensions]) => {
-            // Ensure extensions is an array before calling includes
-            return file.type === mimeType || (Array.isArray(extensions) && extensions.includes(fileExt));
-          });
+          // Extension-based verdict aligned with the backend (MIME is never
+          // consulted — the server routes purely on the suffix and hint)
+          const isAccepted = isAcceptedFilename(file.name, acceptedExts, engineMatrix);
 
           if (!isAccepted) {
             return {
@@ -342,7 +363,9 @@ function FileUploader(props: FileUploaderProps) {
                         isMultiple: maxFileCount === Infinity,
                         maxSize: formatBytes(maxSize)
                       })}
-                      {t('documentPanel.uploadDocuments.fileTypes')}
+                      {t('documentPanel.uploadDocuments.fileTypes', {
+                        types: formatFileTypesLabel([...acceptedExts])
+                      })}
                     </p>
                   )}
                 </div>

--- a/lightrag_webui/src/lib/fileTypes.test.ts
+++ b/lightrag_webui/src/lib/fileTypes.test.ts
@@ -1,0 +1,179 @@
+/// <reference types="bun" />
+import { describe, expect, test } from 'bun:test'
+import { supportedFileTypes } from './constants'
+import {
+  deriveUploaderInputs,
+  extractFileExtension,
+  flattenAcceptExtensions,
+  formatFileTypesLabel,
+  isAcceptedFilename,
+  normalizeParserEngine,
+  normalizeSupportedFileTypes,
+  type FileTypesState
+} from './fileTypes'
+
+const allowlist = new Set(['.md', '.txt', '.pdf', '.jpg'])
+const matrix = {
+  mineru: ['.png', '.jpg', '.pdf'],
+  legacy: ['.md', '.txt', '.pdf'],
+  native: ['.docx', '.md', '.textpack']
+}
+
+describe('extractFileExtension', () => {
+  test('aligns with Python Path.suffix: no-dot, dotfile and trailing-dot names have none', () => {
+    expect(extractFileExtension('README')).toBe('')
+    expect(extractFileExtension('.bashrc')).toBe('')
+    expect(extractFileExtension('file.')).toBe('')
+  })
+
+  test('returns the dotted lowercase last suffix', () => {
+    expect(extractFileExtension('file.txt')).toBe('.txt')
+    expect(extractFileExtension('file.PDF')).toBe('.pdf')
+    expect(extractFileExtension('archive.tar.gz')).toBe('.gz')
+    expect(extractFileExtension('img.[mineru].png')).toBe('.png')
+  })
+})
+
+describe('normalizeParserEngine', () => {
+  test('mirrors the backend: cut at "(", take segment before first "-", lowercase', () => {
+    expect(normalizeParserEngine('mineru')).toBe('mineru')
+    expect(normalizeParserEngine('MinerU')).toBe('mineru')
+    expect(normalizeParserEngine('mineru-iteP(drop_rf)')).toBe('mineru')
+    expect(normalizeParserEngine('mineru(page_range=1-3)')).toBe('mineru')
+    expect(normalizeParserEngine('legacy-R(chunk_ts=800)')).toBe('legacy')
+  })
+})
+
+describe('isAcceptedFilename — bare filenames', () => {
+  test('accepts by allowlist extension, never by MIME', () => {
+    expect(isAcceptedFilename('a.md', allowlist, matrix)).toBe(true)
+    expect(isAcceptedFilename('a.rst', allowlist, matrix)).toBe(false)
+  })
+
+  test('uppercase suffix is normalized', () => {
+    expect(isAcceptedFilename('file.PDF', allowlist, matrix)).toBe(true)
+  })
+
+  test('extensionless names are rejected', () => {
+    expect(isAcceptedFilename('README', allowlist, matrix)).toBe(false)
+  })
+
+  test('empty allowlist rejects every bare filename', () => {
+    expect(isAcceptedFilename('a.md', new Set<string>(), matrix)).toBe(false)
+  })
+})
+
+describe('isAcceptedFilename — hinted filenames', () => {
+  test('engine present in matrix: verdict follows its suffix capabilities', () => {
+    expect(isAcceptedFilename('img.[mineru].png', allowlist, matrix)).toBe(true)
+    expect(isAcceptedFilename('img.[mineru].txt', allowlist, matrix)).toBe(false)
+  })
+
+  test('engine missing from matrix (endpoint not configured) is rejected', () => {
+    expect(isAcceptedFilename('img.[mineru].png', allowlist, { legacy: ['.md'] })).toBe(false)
+  })
+
+  test('matrix keys are authoritative — dynamic third-party engines pass', () => {
+    expect(isAcceptedFilename('doc.[fooengine].foo', allowlist, { fooengine: ['.foo'] })).toBe(true)
+  })
+
+  test('case and parameter blocks are normalized before the matrix lookup', () => {
+    expect(isAcceptedFilename('img.[MinerU].png', allowlist, matrix)).toBe(true)
+    expect(isAcceptedFilename('img.[mineru-iteP(drop_rf)].png', allowlist, matrix)).toBe(true)
+    expect(isAcceptedFilename('r.[legacy-R(chunk_ts=800)].pdf', allowlist, matrix)).toBe(true)
+  })
+
+  test('unknown engine and empty hint are rejected (backend would 400)', () => {
+    expect(isAcceptedFilename('img.[nonexistent].png', allowlist, matrix)).toBe(false)
+    expect(isAcceptedFilename('img.[].png', allowlist, matrix)).toBe(false)
+  })
+
+  test('options-only hint routes like a bare filename', () => {
+    expect(isAcceptedFilename('doc.[-P].pdf', allowlist, matrix)).toBe(true)
+    expect(isAcceptedFilename('doc.[-P].rst', allowlist, matrix)).toBe(false)
+  })
+
+  test('unclosed bracket is not a hint — the name validates as bare', () => {
+    expect(isAcceptedFilename('img.[mineru.png', allowlist, matrix)).toBe(false)
+    expect(isAcceptedFilename('img.[mineru.jpg', allowlist, matrix)).toBe(true)
+  })
+
+  test('hint still validates against an empty allowlist via the matrix', () => {
+    expect(isAcceptedFilename('img.[mineru].png', new Set<string>(), matrix)).toBe(true)
+  })
+})
+
+describe('isAcceptedFilename — degraded mode (no matrix)', () => {
+  test('hinted filenames pass through for the server to judge', () => {
+    expect(isAcceptedFilename('img.[mineru].png', allowlist, null)).toBe(true)
+    expect(isAcceptedFilename('img.[nonexistent].png', allowlist, null)).toBe(true)
+  })
+
+  test('bare filenames still follow the allowlist', () => {
+    expect(isAcceptedFilename('a.rst', allowlist, null)).toBe(false)
+    expect(isAcceptedFilename('a.md', allowlist, null)).toBe(true)
+  })
+})
+
+describe('normalizeSupportedFileTypes', () => {
+  test('valid payload passes through, including an empty allowlist', () => {
+    const valid = { supported_extensions: ['.md'], engines: { legacy: ['.md'] } }
+    expect(normalizeSupportedFileTypes(valid)).toEqual(valid)
+    const empty = { supported_extensions: [], engines: {} }
+    expect(normalizeSupportedFileTypes(empty)).toEqual(empty)
+  })
+
+  test('invalid shapes collapse to null', () => {
+    expect(normalizeSupportedFileTypes(undefined)).toBeNull()
+    expect(normalizeSupportedFileTypes('x')).toBeNull()
+    expect(normalizeSupportedFileTypes({})).toBeNull()
+    expect(normalizeSupportedFileTypes({ supported_extensions: [null], engines: {} })).toBeNull()
+    expect(normalizeSupportedFileTypes({ supported_extensions: ['.md'] })).toBeNull()
+    expect(
+      normalizeSupportedFileTypes({ supported_extensions: ['.md'], engines: { legacy: [1] } })
+    ).toBeNull()
+    expect(
+      normalizeSupportedFileTypes({ supported_extensions: ['.md'], engines: ['.md'] })
+    ).toBeNull()
+  })
+})
+
+describe('flattenAcceptExtensions', () => {
+  test('flattens the static fallback map into its full extension list', () => {
+    const flat = flattenAcceptExtensions(supportedFileTypes)
+    const expected = [...new Set(Object.values(supportedFileTypes).flat())].sort()
+    expect(flat).toEqual(expected)
+    expect(flat).toContain('.md')
+    expect(flat).toContain('.pdf')
+  })
+})
+
+describe('formatFileTypesLabel', () => {
+  test('renders dotted extensions as an uppercase comma list', () => {
+    expect(formatFileTypesLabel(['.jpg', '.md'])).toBe('JPG, MD')
+    expect(formatFileTypesLabel([])).toBe('')
+  })
+})
+
+describe('deriveUploaderInputs', () => {
+  test('idle and loading keep the uploader disabled', () => {
+    expect(deriveUploaderInputs({ status: 'idle' })).toEqual({ disabled: true })
+    expect(deriveUploaderInputs({ status: 'loading' })).toEqual({ disabled: true })
+  })
+
+  test('ready enables the uploader with backend data', () => {
+    const state: FileTypesState = {
+      status: 'ready',
+      data: { supported_extensions: ['.md'], engines: { legacy: ['.md'] } }
+    }
+    expect(deriveUploaderInputs(state)).toEqual({
+      disabled: false,
+      acceptedExtensions: ['.md'],
+      engineCapabilities: { legacy: ['.md'] }
+    })
+  })
+
+  test('fallback enables the uploader without backend data (static allowlist, hints deferred)', () => {
+    expect(deriveUploaderInputs({ status: 'fallback' })).toEqual({ disabled: false })
+  })
+})

--- a/lightrag_webui/src/lib/fileTypes.ts
+++ b/lightrag_webui/src/lib/fileTypes.ts
@@ -1,0 +1,162 @@
+import type { DropzoneProps } from 'react-dropzone'
+
+/**
+ * Response of GET /documents/supported_file_types.
+ *
+ * `supported_extensions` is the allowlist for bare (unhinted) filenames,
+ * derived server-side from the parser registry + LIGHTRAG_PARSER routing.
+ * `engines` maps every usable parser engine to the dotted suffixes it can
+ * parse, enabling local pre-validation of `[engine]`-hinted filenames.
+ */
+export interface SupportedFileTypes {
+  supported_extensions: string[]
+  engines: Record<string, string[]>
+}
+
+/** Lifecycle of the supported-file-types fetch inside the upload dialog. */
+export type FileTypesState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'ready'; data: SupportedFileTypes }
+  | { status: 'fallback' }
+
+export interface UploaderInputs {
+  disabled: boolean
+  acceptedExtensions?: string[]
+  engineCapabilities?: Record<string, string[]>
+}
+
+/**
+ * Filename parser hint, e.g. `img.[mineru].png`. Must stay byte-identical to
+ * the backend's `_PARSER_HINT_RE` (lightrag/parser/routing.py) — any drift
+ * makes the local pre-check disagree with the server's verdict.
+ */
+export const PARSER_HINT_RE = /\.\[([^\]]*)\](\.[^.]+)$/
+
+/**
+ * Dotted lowercase extension, aligned with Python's `Path.suffix` (the
+ * backend's suffix source): `README`, `.bashrc` and `file.` all have none.
+ */
+export function extractFileExtension(filename: string): string {
+  const i = filename.lastIndexOf('.')
+  return i > 0 && i < filename.length - 1 ? filename.slice(i).toLowerCase() : ''
+}
+
+/** Flatten a react-dropzone accept map into sorted unique dotted extensions. */
+export function flattenAcceptExtensions(accept: NonNullable<DropzoneProps['accept']>): string[] {
+  const out = new Set<string>()
+  for (const extensions of Object.values(accept)) {
+    for (const ext of extensions) {
+      out.add(ext.toLowerCase())
+    }
+  }
+  return [...out].sort()
+}
+
+/**
+ * Engine-name candidate from a hint's bracket content. Mirrors the backend's
+ * `normalize_parser_engine`: cut at `(`, take the segment before the first
+ * `-`, trim, lowercase. Validity is decided by the capability matrix keys,
+ * never by a hardcoded engine set (third-party engines register dynamically).
+ */
+export function normalizeParserEngine(token: string): string {
+  let text = token.trim()
+  const paren = text.indexOf('(')
+  if (paren !== -1) {
+    text = text.slice(0, paren)
+  }
+  return text.split('-', 1)[0].trim().toLowerCase()
+}
+
+/**
+ * Engine + suffix pre-check, the single verdict shared by the dropzone
+ * validator and the onDrop re-filter.
+ *
+ * Bare filenames are checked against the allowlist. Hinted filenames are
+ * checked against the engine capability matrix; with no matrix available
+ * (old backend / fetch failed) they pass through for the server to judge.
+ * Option/parameter syntax inside the hint is NOT validated here — a
+ * malformed hint the matrix cannot see still gets a 400 from the backend's
+ * full validation.
+ */
+export function isAcceptedFilename(
+  filename: string,
+  allowlist: Set<string>,
+  engineMatrix: Record<string, string[]> | null
+): boolean {
+  const ext = extractFileExtension(filename)
+  const m = PARSER_HINT_RE.exec(filename)
+  if (!m) {
+    return allowlist.has(ext)
+  }
+  if (engineMatrix === null) {
+    return true
+  }
+  const inner = m[1].trim()
+  if (inner === '') {
+    return false
+  }
+  if (inner.startsWith('-')) {
+    // Options-only hint carries no engine; routing follows the bare suffix.
+    return allowlist.has(ext)
+  }
+  const engine = normalizeParserEngine(inner)
+  if (Object.prototype.hasOwnProperty.call(engineMatrix, engine)) {
+    return engineMatrix[engine].includes(ext)
+  }
+  return false
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string')
+}
+
+/**
+ * Validate an untrusted response into SupportedFileTypes, or null when the
+ * shape is invalid. An empty `supported_extensions` array is a legitimate
+ * authoritative answer (no bare suffix is routable), not a failure.
+ */
+export function normalizeSupportedFileTypes(data: unknown): SupportedFileTypes | null {
+  if (typeof data !== 'object' || data === null) {
+    return null
+  }
+  const { supported_extensions, engines } = data as Record<string, unknown>
+  if (!isStringArray(supported_extensions)) {
+    return null
+  }
+  if (typeof engines !== 'object' || engines === null || Array.isArray(engines)) {
+    return null
+  }
+  for (const suffixes of Object.values(engines)) {
+    if (!isStringArray(suffixes)) {
+      return null
+    }
+  }
+  return { supported_extensions, engines: engines as Record<string, string[]> }
+}
+
+/** Human-readable list for the i18n `fileTypes` interpolation: ".md" -> "MD". */
+export function formatFileTypesLabel(exts: string[]): string {
+  return exts.map((ext) => ext.replace(/^\./, '').toUpperCase()).join(', ')
+}
+
+/**
+ * Map the fetch state to FileUploader inputs. Uploading stays disabled until
+ * the fetch settles so a hinted file can never start uploading before the
+ * capability matrix is known; `fallback` enables the static allowlist and
+ * defers hinted files to the server.
+ */
+export function deriveUploaderInputs(state: FileTypesState): UploaderInputs {
+  switch (state.status) {
+    case 'ready':
+      return {
+        disabled: false,
+        acceptedExtensions: state.data.supported_extensions,
+        engineCapabilities: state.data.engines
+      }
+    case 'fallback':
+      return { disabled: false }
+    default:
+      return { disabled: true }
+  }
+}

--- a/lightrag_webui/src/locales/ar.json
+++ b/lightrag_webui/src/locales/ar.json
@@ -99,7 +99,7 @@
         "error": "فشل رفع بعض الملفات"
       },
       "generalError": "فشل الرفع\n{{error}}",
-      "fileTypes": "الأنواع المدعومة: TXT، MD، TEXTPACK، MDX، DOCX، PDF، PPTX، XLSX، RTF، ODT، EPUB، HTML، HTM، TEX، JSON، XML، YAML، YML، CSV، LOG، CONF، INI، PROPERTIES، SQL، BAT، SH، C، H، CPP، HPP، PY، JAVA، JS، TS، SWIFT، GO، RB، PHP، CSS، SCSS، LESS",
+      "fileTypes": "الأنواع المدعومة: {{types}}",
       "fileUploader": {
         "singleFileLimit": "لا يمكن رفع أكثر من ملف واحد في المرة الواحدة",
         "maxFilesLimit": "لا يمكن رفع أكثر من {{count}} ملفات",

--- a/lightrag_webui/src/locales/de.json
+++ b/lightrag_webui/src/locales/de.json
@@ -99,7 +99,7 @@
         "error": "Einige Dateien konnten nicht hochgeladen werden"
       },
       "generalError": "Upload fehlgeschlagen\n{{error}}",
-      "fileTypes": "Unterstützte Typen: TXT, MD, TEXTPACK, MDX, DOCX, PDF, PPTX, XLSX, RTF, ODT, EPUB, HTML, HTM, TEX, JSON, XML, YAML, YML, CSV, LOG, CONF, INI, PROPERTIES, SQL, BAT, SH, C, H, CPP, HPP, PY, JAVA, JS, TS, SWIFT, GO, RB, PHP, CSS, SCSS, LESS",
+      "fileTypes": "Unterstützte Typen: {{types}}",
       "fileUploader": {
         "singleFileLimit": "Es kann nicht mehr als 1 Datei gleichzeitig hochgeladen werden",
         "maxFilesLimit": "Es können nicht mehr als {{count}} Dateien hochgeladen werden",

--- a/lightrag_webui/src/locales/en.json
+++ b/lightrag_webui/src/locales/en.json
@@ -99,7 +99,7 @@
         "error": "Some files failed to upload"
       },
       "generalError": "Upload Failed\n{{error}}",
-      "fileTypes": "Supported types: TXT, MD, TEXTPACK, MDX, DOCX, PDF, PPTX, XLSX, RTF, ODT, EPUB, HTML, HTM, TEX, JSON, XML, YAML, YML, CSV, LOG, CONF, INI, PROPERTIES, SQL, BAT, SH, C, H, CPP, HPP, PY, JAVA, JS, TS, SWIFT, GO, RB, PHP, CSS, SCSS, LESS",
+      "fileTypes": "Supported types: {{types}}",
       "fileUploader": {
         "singleFileLimit": "Cannot upload more than 1 file at a time",
         "maxFilesLimit": "Cannot upload more than {{count}} files",

--- a/lightrag_webui/src/locales/fr.json
+++ b/lightrag_webui/src/locales/fr.json
@@ -99,7 +99,7 @@
         "error": "Certains fichiers n'ont pas pu être téléchargés"
       },
       "generalError": "Échec du téléchargement\n{{error}}",
-      "fileTypes": "Types pris en charge : TXT, MD, TEXTPACK, MDX, DOCX, PDF, PPTX, XLSX, RTF, ODT, EPUB, HTML, HTM, TEX, JSON, XML, YAML, YML, CSV, LOG, CONF, INI, PROPERTIES, SQL, BAT, SH, C, H, CPP, HPP, PY, JAVA, JS, TS, SWIFT, GO, RB, PHP, CSS, SCSS, LESS",
+      "fileTypes": "Types pris en charge : {{types}}",
       "fileUploader": {
         "singleFileLimit": "Impossible de télécharger plus d'un fichier à la fois",
         "maxFilesLimit": "Impossible de télécharger plus de {{count}} fichiers",

--- a/lightrag_webui/src/locales/ja.json
+++ b/lightrag_webui/src/locales/ja.json
@@ -99,7 +99,7 @@
         "error": "一部のファイルのアップロードに失敗しました"
       },
       "generalError": "アップロード失敗\n{{error}}",
-      "fileTypes": "サポートされている形式: TXT, MD, TEXTPACK, MDX, DOCX, PDF, PPTX, XLSX, RTF, ODT, EPUB, HTML, HTM, TEX, JSON, XML, YAML, YML, CSV, LOG, CONF, INI, PROPERTIES, SQL, BAT, SH, C, H, CPP, HPP, PY, JAVA, JS, TS, SWIFT, GO, RB, PHP, CSS, SCSS, LESS",
+      "fileTypes": "サポートされている形式: {{types}}",
       "fileUploader": {
         "singleFileLimit": "一度に1つ以上のファイルをアップロードできません",
         "maxFilesLimit": "{{count}}個を超えるファイルをアップロードできません",

--- a/lightrag_webui/src/locales/ko.json
+++ b/lightrag_webui/src/locales/ko.json
@@ -99,7 +99,7 @@
         "error": "일부 파일 업로드 실패"
       },
       "generalError": "업로드 실패\n{{error}}",
-      "fileTypes": "지원되는 유형: TXT, MD, TEXTPACK, MDX, DOCX, PDF, PPTX, XLSX, RTF, ODT, EPUB, HTML, HTM, TEX, JSON, XML, YAML, YML, CSV, LOG, CONF, INI, PROPERTIES, SQL, BAT, SH, C, CPP, H, HPP, PY, JAVA, JS, TS, SWIFT, GO, RB, PHP, CSS, SCSS, LESS",
+      "fileTypes": "지원되는 유형: {{types}}",
       "fileUploader": {
         "singleFileLimit": "한 번에 1개의 파일만 업로드할 수 있습니다",
         "maxFilesLimit": "{{count}}개 이상의 파일은 업로드할 수 없습니다",

--- a/lightrag_webui/src/locales/ru.json
+++ b/lightrag_webui/src/locales/ru.json
@@ -99,7 +99,7 @@
         "error": "Некоторые файлы не удалось загрузить"
       },
       "generalError": "Ошибка загрузки\n{{error}}",
-      "fileTypes": "Поддерживаемые типы: TXT, MD, TEXTPACK, MDX, DOCX, PDF, PPTX, XLSX, RTF, ODT, EPUB, HTML, HTM, TEX, JSON, XML, YAML, YML, CSV, LOG, CONF, INI, PROPERTIES, SQL, BAT, SH, C, CPP, H, HPP, PY, JAVA, JS, TS, SWIFT, GO, RB, PHP, CSS, SCSS, LESS",
+      "fileTypes": "Поддерживаемые типы: {{types}}",
       "fileUploader": {
         "singleFileLimit": "Нельзя загрузить более 1 файла за раз",
         "maxFilesLimit": "Нельзя загрузить более {{count}} файлов",

--- a/lightrag_webui/src/locales/uk.json
+++ b/lightrag_webui/src/locales/uk.json
@@ -99,7 +99,7 @@
         "error": "Деякі файли не вдалося завантажити"
       },
       "generalError": "Завантаження не вдалося\n{{error}}",
-      "fileTypes": "Підтримувані типи: TXT, MD, TEXTPACK, MDX, DOCX, PDF, PPTX, XLSX, RTF, ODT, EPUB, HTML, HTM, TEX, JSON, XML, YAML, YML, CSV, LOG, CONF, INI, PROPERTIES, SQL, BAT, SH, C, CPP, H, HPP, PY, JAVA, JS, TS, SWIFT, GO, RB, PHP, CSS, SCSS, LESS",
+      "fileTypes": "Підтримувані типи: {{types}}",
       "fileUploader": {
         "singleFileLimit": "Не можна завантажити більше 1 файлу одночасно",
         "maxFilesLimit": "Не можна завантажити більше {{count}} файлів",

--- a/lightrag_webui/src/locales/vi.json
+++ b/lightrag_webui/src/locales/vi.json
@@ -99,7 +99,7 @@
         "error": "Một số tệp tải lên thất bại"
       },
       "generalError": "Tải Lên Thất Bại\n{{error}}",
-      "fileTypes": "Các loại được hỗ trợ: TXT, MD, TEXTPACK, MDX, DOCX, PDF, PPTX, XLSX, RTF, ODT, EPUB, HTML, HTM, TEX, JSON, XML, YAML, YML, CSV, LOG, CONF, INI, PROPERTIES, SQL, BAT, SH, C, H, CPP, HPP, PY, JAVA, JS, TS, SWIFT, GO, RB, PHP, CSS, SCSS, LESS",
+      "fileTypes": "Các loại được hỗ trợ: {{types}}",
       "fileUploader": {
         "singleFileLimit": "Không thể tải lên nhiều hơn 1 tệp một lần",
         "maxFilesLimit": "Không thể tải lên nhiều hơn {{count}} tệp",

--- a/lightrag_webui/src/locales/zh.json
+++ b/lightrag_webui/src/locales/zh.json
@@ -99,7 +99,7 @@
         "error": "部分文件上传失败"
       },
       "generalError": "上传失败\n{{error}}",
-      "fileTypes": "支持的文件类型：TXT, MD, TEXTPACK, MDX, DOCX, PDF, PPTX, XLSX, RTF, ODT, EPUB, HTML, HTM, TEX, JSON, XML, YAML, YML, CSV, LOG, CONF, INI, PROPERTIES, SQL, BAT, SH, C, CPP, H, HPP, PY, JAVA, JS, TS, SWIFT, GO, RB, PHP, CSS, SCSS, LESS",
+      "fileTypes": "支持的文件类型：{{types}}",
       "fileUploader": {
         "singleFileLimit": "一次只能上传一个文件",
         "maxFilesLimit": "最多只能上传 {{count}} 个文件",

--- a/lightrag_webui/src/locales/zh_TW.json
+++ b/lightrag_webui/src/locales/zh_TW.json
@@ -99,7 +99,7 @@
         "error": "部分檔案上傳失敗"
       },
       "generalError": "上傳失敗\n{{error}}",
-      "fileTypes": "支援的檔案類型：TXT, MD, TEXTPACK, MDX, DOCX, PDF, PPTX, XLSX, RTF, ODT, EPUB, HTML, HTM, TEX, JSON, XML, YAML, YML, CSV, LOG, CONF, INI, PROPERTIES, SQL, BAT, SH, C, CPP, H, HPP, PY, JAVA, JS, TS, SWIFT, GO, RB, PHP, CSS, SCSS, LESS",
+      "fileTypes": "支援的檔案類型：{{types}}",
       "fileUploader": {
         "singleFileLimit": "一次只能上傳一個檔案",
         "maxFilesLimit": "最多只能上傳 {{count}} 個檔案",

--- a/tests/api/routes/test_supported_file_types_endpoint.py
+++ b/tests/api/routes/test_supported_file_types_endpoint.py
@@ -1,0 +1,119 @@
+"""HTTP contract for ``GET /documents/supported_file_types``.
+
+The endpoint exposes the live upload allowlist
+(``DocumentManager.supported_extensions``) plus the parser capability matrix
+(``DocumentManager.engine_capabilities``) so the WebUI can pre-validate
+filenames — including ``[engine]``-hinted ones — without uploading the file
+first. Allowlist/routing *behaviour* is covered by the registry and routing
+suites (e.g. ``test_supported_extensions_markdown.py``); these tests pin the
+HTTP layer: auth, serialization, cache headers, and that the matrix follows
+the dynamic registry instead of a hardcoded engine set.
+"""
+
+import importlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# document_routes parses argv at import time; guard it like the sibling tests.
+_original_argv = sys.argv[:]
+sys.argv = [sys.argv[0]]
+_document_routes = importlib.import_module("lightrag.api.routers.document_routes")
+_registry = importlib.import_module("lightrag.parser.registry")
+sys.argv = _original_argv
+
+create_document_routes = _document_routes.create_document_routes
+DocumentManager = _document_routes.DocumentManager
+
+pytestmark = pytest.mark.offline
+
+_HEADERS = {"X-API-Key": "test-key"}
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    """TestClient over a fresh app; parser env cleared for a default deployment."""
+    for var in (
+        "LIGHTRAG_PARSER",
+        "MINERU_API_MODE",
+        "MINERU_LOCAL_ENDPOINT",
+        "MINERU_API_TOKEN",
+        "DOCLING_ENDPOINT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    app = FastAPI()
+    app.include_router(
+        create_document_routes(
+            SimpleNamespace(),
+            DocumentManager(str(tmp_path)),
+            api_key="test-key",
+        )
+    )
+    return TestClient(app)
+
+
+def test_default_deployment_contract(client):
+    resp = client.get("/documents/supported_file_types", headers=_HEADERS)
+    assert resp.status_code == 200
+
+    body = resp.json()
+    exts = body["supported_extensions"]
+    assert isinstance(exts, list) and exts
+    assert all(e.startswith(".") and e == e.lower() for e in exts)
+    assert ".md" in exts and ".txt" in exts
+
+    engines = body["engines"]
+    assert set(engines) >= {"native", "legacy"}
+    # External engines only join once their endpoint is configured.
+    assert "mineru" not in engines and "docling" not in engines
+    # Internal (non-user-selectable) engines are never advertised.
+    assert "reuse" not in engines and "passthrough" not in engines
+    assert engines["native"] == [".docx", ".md", ".textpack"]
+    for suffixes in engines.values():
+        assert all(s.startswith(".") and s == s.lower() for s in suffixes)
+
+
+def test_requires_auth(client):
+    resp = client.get("/documents/supported_file_types")
+    assert resp.status_code in (401, 403)
+
+
+def test_cache_headers(client):
+    resp = client.get("/documents/supported_file_types", headers=_HEADERS)
+    assert resp.headers["Cache-Control"] == "no-store"
+    assert resp.headers["Vary"] == "LIGHTRAG-WORKSPACE"
+
+
+def test_mineru_routing_splits_allowlist_and_matrix(client, monkeypatch):
+    """A hint-only suffix appears in the matrix but not the bare allowlist."""
+    monkeypatch.setenv("MINERU_API_MODE", "local")
+    monkeypatch.setenv("MINERU_LOCAL_ENDPOINT", "http://localhost:8888")
+    monkeypatch.setenv("LIGHTRAG_PARSER", "jpg:mineru;*:legacy-R")
+
+    body = client.get("/documents/supported_file_types", headers=_HEADERS).json()
+
+    # Bare .jpg routes to mineru via the rule; bare .png falls through to
+    # legacy which cannot parse it, so only the matrix advertises png.
+    assert ".jpg" in body["supported_extensions"]
+    assert ".png" not in body["supported_extensions"]
+    assert ".png" in body["engines"]["mineru"]
+    assert ".jpg" in body["engines"]["mineru"]
+
+
+def test_matrix_tracks_dynamic_registry(client):
+    """Third-party engines registered at runtime appear without code changes."""
+    spec = _registry.ParserSpec(
+        engine_name="fooengine",
+        impl="x:Y",
+        suffixes=frozenset({"foo"}),
+        queue_group="fooengine",
+    )
+    try:
+        _registry.register_parser(spec)
+        body = client.get("/documents/supported_file_types", headers=_HEADERS).json()
+        assert body["engines"]["fooengine"] == [".foo"]
+    finally:
+        _registry._REGISTRY.pop("fooengine", None)


### PR DESCRIPTION
## Description

The WebUI upload dialog validates file extensions against a hardcoded list, while the backend derives its accepted suffixes dynamically from the parser registry + `LIGHTRAG_PARSER` routing rules. The two drift: with e.g. `LIGHTRAG_PARSER=*:native-iteP(drop_rf);xlsx:legacy-R;*:mineru-iteP(drop_rf);*:legacy-R` and a configured MinerU endpoint, the server accepts `.jpg` uploads but the WebUI rejects them client-side.

This PR makes the backend the single source of truth. A new endpoint returns both the bare-filename allowlist and a per-engine capability matrix, and the upload dialog fetches them when it opens — so the WebUI also pre-validates `[engine]`-hinted filenames (e.g. `img.[mineru].png`) locally instead of uploading the whole file only to receive a 400.

## Related Issues

N/A (frontend/backend upload allowlist inconsistency observed with MinerU routing configurations).

## Changes Made

**Backend**

- New `GET /documents/supported_file_types` (mandatory `combined_auth`, same as `/upload`) returning:
  - `supported_extensions` — the live bare-filename allowlist (`DocumentManager.supported_extensions`, same source the upload 400 detail quotes);
  - `engines` — new `DocumentManager.engine_capabilities`: usable engine (user-selectable + endpoint configured) → dotted suffixes, following the dynamic registry so third-party parsers registered via `lightrag.parsers` entry points are included automatically.
- Responses carry `Cache-Control: no-store` and `Vary: LIGHTRAG-WORKSPACE`, declared ahead of future per-workspace parser routing (the response contract will not change; a `/health` field was rejected for exactly that reason).

**WebUI**

- New pure module `src/lib/fileTypes.ts`: hint regex and engine-name normalization mirror `lightrag/parser/routing.py` byte for byte; extension extraction aligns with Python's `Path.suffix` (`README`, `.bashrc`, `file.` have none); `isAcceptedFilename` is the single verdict shared by the dropzone validator and the onDrop re-filter. Engine validity is decided by the matrix keys — no hardcoded engine set.
- Upload dialog fetches the data on open with an explicit `idle | loading | ready | fallback` state machine: `loading` is entered synchronously in `onOpenChange` (uploader disabled from the very first open render), fetch aborts on close, and only a failed/404/invalid response falls back to the static list (hinted names then defer to the server). An empty `supported_extensions` array is honored as authoritative.
- `FileUploader` validation is now purely extension-based; the previous MIME-equality bypass is removed (it admitted files the backend would always 400). New `acceptedExtensions` / `engineCapabilities` props; `onDrop` deps updated accordingly.
- All 11 locale `fileTypes` strings now interpolate `{{types}}` from the live list (note: the Arabic list separator changes from `،` to `,`).

**Scope note**: the client-side hint pre-check covers engine + suffix only. Malformed option/parameter syntax inside a hint (e.g. `[native-Q]`, `[native-FR]`) is intentionally not replicated client-side and still receives the backend's detailed 400.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

- Backend: `tests/api/routes/test_supported_file_types_endpoint.py` (5 tests — contract, auth, cache headers, MinerU routing split between allowlist and matrix, dynamic `fooengine` registration). Full `tests/api/routes/` + `test_health_auth.py` regression: 192 passed, 4 skipped.
- WebUI: `src/lib/fileTypes.test.ts` (24 tests — bare/hinted/degraded verdicts, `Path.suffix` edge cases, response validation, uploader state machine). `bun test` 88/88, `bun run lint` and `bun run build` clean.
- Compatibility: old WebUI + new backend keeps current behavior (endpoint unused); new WebUI + old backend gets a 404 and falls back to the static list without errors; `[engine]`-hinted files then pass through for the server to judge, matching today's behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
