### PR TITLE
feat(kg): workspace-scoped pipeline ingress infrastructure (Phase 1 of request_pending replacement)

### DIFF
--- a/lightrag/kg/pipeline_ingress.py
+++ b/lightrag/kg/pipeline_ingress.py
@@ -1,0 +1,551 @@
+"""Workspace-scoped pipeline ingress: the notification channel that replaces
+``request_pending``.
+
+One ingress instance exists per workspace (see ``shared_storage.
+get_pipeline_ingress``).  It carries three channels with three distinct
+reliability grades — deliberately NOT a single destructive FIFO:
+
+* **document** — ephemeral doc-id notifications published by enqueue after the
+  ``doc_status`` row is persisted.  Messages may be lost or duplicated freely:
+  ``doc_status`` is the source of truth and the next processing run's initial
+  scan rebuilds anything dropped.  Consumers re-read storage by id and skip
+  stale/terminal/duplicate ids.
+* **auto rescan** — a single dirty flag.  Publishers that cannot name precise
+  doc ids (busy-refused processing requests, partial doc-status commits,
+  recovery paths) set it; the pipeline supervisor is the only consumer and
+  resets it atomically via :meth:`consume_auto_rescan`.
+* **manual retry** — sticky FIFO requests carrying user intent from
+  ``/documents/scan`` and ``/documents/reprocess_failed``.  A request stays in
+  the mailbox until explicitly ACKed *after* the FAILED→PENDING reset has been
+  persisted, so a consumer crash at any point either leaves the request sticky
+  (re-executed by the next run) or leaves the documents already PENDING
+  (recovered by the automatic paths).  Terminal request ids (ACKED or
+  CANCELLED_BY_CLEAR) are remembered in a bounded FIFO set so a delayed replay
+  of the same id is refused — a *bounded-window* idempotency guarantee, not an
+  indefinite exactly-once (ids are server-generated UUIDs, so eviction of very
+  old ids is harmless in practice).
+
+Waiting primitives are split by consumer role: a feeder that only routes
+documents must wait on the document channel alone (``wait_for_documents`` /
+:meth:`AsyncioPipelineIngress.get_document`); waiting on all three channels
+(``wait_for_items``) is reserved for a supervisor that actually consumes the
+control channels — otherwise a pending manual/auto entry keeps ``has_work()``
+true and turns the wait into a busy loop.
+
+This module is dependency-free on purpose: :mod:`lightrag.kg.shared_storage`
+imports it to register :class:`PipelineIngressMailbox` on the LightRAG
+``SyncManager`` subclass and to build the per-workspace registry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections import OrderedDict, deque
+from dataclasses import dataclass
+from multiprocessing.managers import BaseProxy
+from typing import Any, Dict, List, Literal, Optional, Protocol, runtime_checkable
+
+# Terminal states for manual retry request ids.
+MANUAL_RETRY_ACKED = "acked"
+MANUAL_RETRY_CANCELLED_BY_CLEAR = "cancelled_by_clear"
+
+# Capacity of the bounded terminal-request-id set (FIFO eviction, oldest id
+# first).  Sizing note: ids enter this set only via explicit human actions
+# (one per /scan or /reprocess_failed call), so 4096 covers any realistic
+# replay window; after eviction an extremely old id could in theory be
+# accepted again — the documented bounded-window limit of the idempotency
+# guarantee.
+TERMINAL_MANUAL_REQUEST_IDS_CAPACITY = 4096
+
+# Hard ceiling for one mailbox wait RPC.  A Manager server runs each client
+# connection on its own thread; a client SIGKILLed while a wait_for_* call is
+# blocked server-side is NOT detected until the wait returns (the thread is
+# parked on the condition, not in recv(), so the EOF path never fires).  A
+# bounded wait caps that stranded window; waiters needing longer horizons
+# simply loop.
+MAX_MAILBOX_WAIT_SECONDS = 30.0
+
+
+@dataclass(frozen=True)
+class PipelineIngressMessage:
+    """One ingress notification.
+
+    ``document`` messages carry only the ``doc_id`` — never the status row
+    itself — so consumers re-read storage and stay idempotent.  ``rescan``
+    messages request a full status re-query: automatic ones
+    (``retry_failed=False``) travel through the auto-rescan dirty flag, manual
+    ones (``retry_failed=True``) through the sticky manual-retry channel keyed
+    by ``request_id``.
+    """
+
+    kind: Literal["document", "rescan"]
+    doc_id: str | None = None
+    retry_failed: bool = False
+    request_id: str | None = None
+
+
+class _BoundedTerminalIds:
+    """Insertion-ordered ``request_id -> terminal state`` map with FIFO eviction.
+
+    NOT thread-safe on its own — every access happens under the owning
+    container's lock (the mailbox condition, or the asyncio single-thread
+    guarantee).
+    """
+
+    def __init__(self, capacity: int = TERMINAL_MANUAL_REQUEST_IDS_CAPACITY):
+        self._capacity = max(1, int(capacity))
+        self._ids: OrderedDict[str, str] = OrderedDict()
+
+    def add(self, request_id: str, state: str) -> None:
+        # Re-adding refreshes neither order nor state: the first terminal
+        # state wins so a late ACK cannot overwrite CANCELLED_BY_CLEAR.
+        if request_id in self._ids:
+            return
+        self._ids[request_id] = state
+        while len(self._ids) > self._capacity:
+            self._ids.popitem(last=False)
+
+    def __contains__(self, request_id: str) -> bool:
+        return request_id in self._ids
+
+    def get(self, request_id: str) -> Optional[str]:
+        return self._ids.get(request_id)
+
+    def __len__(self) -> int:
+        return len(self._ids)
+
+
+def _validate_manual_request(request_id: str, msg: PipelineIngressMessage) -> None:
+    if not request_id:
+        raise ValueError("manual retry requires a non-empty request_id")
+    if msg.kind != "rescan" or not msg.retry_failed or msg.request_id != request_id:
+        raise ValueError(
+            "manual retry message must be kind='rescan' with retry_failed=True "
+            f"and a matching request_id (got {msg!r} for {request_id!r})"
+        )
+
+
+@runtime_checkable
+class PipelineIngress(Protocol):
+    """Surface shared by the single-process and Manager-backed implementations.
+
+    Waiting primitives are intentionally NOT part of the protocol — they differ
+    by mode (``await get_document()`` on :class:`AsyncioPipelineIngress`;
+    ``wait_for_documents(timeout)`` bridged via ``asyncio.to_thread`` on the
+    Manager proxy) and Phase 2's feeder branches on the mode anyway.
+    """
+
+    def put_document(self, msg: PipelineIngressMessage) -> None: ...
+
+    def request_auto_rescan(self) -> None: ...
+
+    def consume_auto_rescan(self) -> bool: ...
+
+    def request_manual_retry(
+        self, request_id: str, msg: PipelineIngressMessage
+    ) -> bool: ...
+
+    def drain_documents(
+        self, limit: Optional[int] = None
+    ) -> List[PipelineIngressMessage]: ...
+
+    def has_work(self) -> bool: ...
+
+    def peek_next_manual_retry(self) -> Optional[PipelineIngressMessage]: ...
+
+    def snapshot_manual_retries(self) -> List[PipelineIngressMessage]: ...
+
+    def ack_manual_retry(self, request_id: str) -> bool: ...
+
+    def clear(self) -> None: ...
+
+    def counts(self) -> Dict[str, Any]: ...
+
+
+class PipelineIngressMailbox:
+    """Server-side ingress for multi-process mode.
+
+    The instance lives in the Manager SERVER process; workers only hold a
+    :class:`_PipelineIngressMailboxProxy`, so it survives any worker's death
+    (including SIGKILL) as long as the Manager server itself is alive.  Every
+    proxy method is exactly one RPC and is atomic server-side under one
+    ``threading.Condition``; only the two ``wait_for_*`` calls block, each
+    occupying just its own client connection's server thread while sleeping on
+    the condition (never while holding it across an RPC boundary).
+
+    ``clear()`` is reserved for destructive operations: it tombstones every
+    still-pending manual request id as ``CANCELLED_BY_CLEAR`` *before* wiping
+    the three active channels, so a delayed replay of an already-accepted
+    request cannot re-enter the mailbox.  The terminal-id set itself is never
+    cleared here — only workspace teardown (dropping the whole mailbox) or
+    FIFO capacity eviction retires entries.
+    """
+
+    def __init__(self) -> None:
+        self._cond = threading.Condition()
+        self._documents: deque[PipelineIngressMessage] = deque()
+        self._auto_rescan_pending = False
+        self._manual_retries: OrderedDict[str, PipelineIngressMessage] = OrderedDict()
+        self._terminal_ids = _BoundedTerminalIds()
+
+    # -- publishing -----------------------------------------------------
+
+    def put_document(self, msg: PipelineIngressMessage) -> None:
+        with self._cond:
+            self._documents.append(msg)
+            self._cond.notify_all()
+
+    def request_auto_rescan(self) -> None:
+        with self._cond:
+            self._auto_rescan_pending = True
+            self._cond.notify_all()
+
+    def request_manual_retry(
+        self, request_id: str, msg: PipelineIngressMessage
+    ) -> bool:
+        """Sticky-register a manual retry request; False iff refused.
+
+        Refusal happens only for ids already in the terminal set (ACKED or
+        CANCELLED_BY_CLEAR) — the bounded-window replay guard.  Re-requesting
+        an id that is still pending is an idempotent no-op (True) and does not
+        change its FIFO position.
+        """
+        _validate_manual_request(request_id, msg)
+        with self._cond:
+            if request_id in self._terminal_ids:
+                return False
+            if request_id not in self._manual_retries:
+                self._manual_retries[request_id] = msg
+                self._cond.notify_all()
+            return True
+
+    # -- consuming ------------------------------------------------------
+
+    def consume_auto_rescan(self) -> bool:
+        """Atomic exchange: return the dirty flag and reset it.
+
+        The supervisor is the sole caller.  If the strict follow-up query
+        fails, the caller MUST re-arm via :meth:`request_auto_rescan` before
+        propagating, otherwise the request is lost.
+        """
+        with self._cond:
+            pending = self._auto_rescan_pending
+            self._auto_rescan_pending = False
+            return pending
+
+    def drain_documents(
+        self, limit: Optional[int] = None
+    ) -> List[PipelineIngressMessage]:
+        with self._cond:
+            if limit is None or limit >= len(self._documents):
+                drained = list(self._documents)
+                self._documents.clear()
+            else:
+                drained = [self._documents.popleft() for _ in range(max(0, limit))]
+            return drained
+
+    def peek_next_manual_retry(self) -> Optional[PipelineIngressMessage]:
+        """Earliest pending manual request WITHOUT removal (FIFO).
+
+        The consumption primitive: one request per quiescence cycle, ACKed only
+        after its FAILED→PENDING reset is persisted.
+        """
+        with self._cond:
+            for msg in self._manual_retries.values():
+                return msg
+            return None
+
+    def snapshot_manual_retries(self) -> List[PipelineIngressMessage]:
+        """Read-only FIFO copy of pending manual requests (diagnostics/tests)."""
+        with self._cond:
+            return list(self._manual_retries.values())
+
+    def ack_manual_retry(self, request_id: str) -> bool:
+        """Retire ``request_id`` as ACKED; idempotent, always True.
+
+        Valid only after the reset-to-PENDING write for this request has been
+        persisted.  Unknown ids are recorded as ACKED too — ids are
+        server-generated UUIDs, so this only makes crash-retried ACKs
+        idempotent and can never poison a future request.
+        """
+        with self._cond:
+            self._manual_retries.pop(request_id, None)
+            self._terminal_ids.add(request_id, MANUAL_RETRY_ACKED)
+            return True
+
+    def clear(self) -> None:
+        with self._cond:
+            for request_id in self._manual_retries:
+                self._terminal_ids.add(request_id, MANUAL_RETRY_CANCELLED_BY_CLEAR)
+            self._manual_retries.clear()
+            self._documents.clear()
+            self._auto_rescan_pending = False
+
+    # -- observing ------------------------------------------------------
+
+    def has_work(self) -> bool:
+        with self._cond:
+            return bool(
+                self._documents or self._auto_rescan_pending or self._manual_retries
+            )
+
+    def counts(self) -> Dict[str, Any]:
+        with self._cond:
+            return {
+                "documents": len(self._documents),
+                "auto_rescan_pending": self._auto_rescan_pending,
+                "manual_retries": len(self._manual_retries),
+                "terminal_manual_request_ids": len(self._terminal_ids),
+            }
+
+    @staticmethod
+    def _bounded_wait(timeout: float) -> float:
+        """Clamp a wait to :data:`MAX_MAILBOX_WAIT_SECONDS`.
+
+        ``timeout`` is required and bounded by design: an unbounded wait would
+        park this connection's server thread forever if the waiting client is
+        SIGKILLed (see :data:`MAX_MAILBOX_WAIT_SECONDS`).  Callers loop for
+        longer horizons.
+        """
+        return min(max(0.0, float(timeout)), MAX_MAILBOX_WAIT_SECONDS)
+
+    def wait_for_documents(self, timeout: float) -> bool:
+        """Block until the DOCUMENT channel is non-empty; never dequeues.
+
+        The feeder's only waiting primitive: its predicate deliberately
+        ignores the control channels, so a pending manual/auto entry (owned by
+        the supervisor) cannot wake — let alone busy-loop — the feeder.  A
+        cancelled/timed-out waiter has observed nothing and can never steal a
+        message.  ``timeout`` is required and clamped (see :meth:`_bounded_wait`).
+        """
+        with self._cond:
+            return self._cond.wait_for(
+                lambda: bool(self._documents), self._bounded_wait(timeout)
+            )
+
+    def wait_for_items(self, timeout: float) -> bool:
+        """Block until ANY channel has work; supervisor/diagnostics only.
+
+        Never hand this to a consumer that does not consume the control
+        channels — their pending entries keep the predicate true and the wait
+        degenerates into a busy loop.  ``timeout`` is required and clamped
+        (see :meth:`_bounded_wait`).
+        """
+        with self._cond:
+            return self._cond.wait_for(
+                self._has_work_locked, self._bounded_wait(timeout)
+            )
+
+    def _has_work_locked(self) -> bool:
+        return bool(
+            self._documents or self._auto_rescan_pending or self._manual_retries
+        )
+
+
+class _PipelineIngressMailboxProxy(BaseProxy):
+    """Explicit proxy for :class:`PipelineIngressMailbox`.
+
+    ``BaseProxy`` has no dynamic ``__getattr__`` — declaring ``_exposed_``
+    alone would NOT make the methods callable, so each one gets an explicit
+    ``_callmethod`` wrapper (deterministic, unlike AutoProxy).  A feeder
+    blocking in ``wait_for_documents`` should hold its own proxy instance:
+    calls on one proxy serialize on its connection.
+    """
+
+    _exposed_ = (
+        "put_document",
+        "request_auto_rescan",
+        "request_manual_retry",
+        "consume_auto_rescan",
+        "drain_documents",
+        "peek_next_manual_retry",
+        "snapshot_manual_retries",
+        "ack_manual_retry",
+        "clear",
+        "has_work",
+        "counts",
+        "wait_for_documents",
+        "wait_for_items",
+    )
+
+    def put_document(self, msg: PipelineIngressMessage) -> None:
+        self._callmethod("put_document", (msg,))
+
+    def request_auto_rescan(self) -> None:
+        self._callmethod("request_auto_rescan")
+
+    def request_manual_retry(
+        self, request_id: str, msg: PipelineIngressMessage
+    ) -> bool:
+        return self._callmethod("request_manual_retry", (request_id, msg))
+
+    def consume_auto_rescan(self) -> bool:
+        return self._callmethod("consume_auto_rescan")
+
+    def drain_documents(
+        self, limit: Optional[int] = None
+    ) -> List[PipelineIngressMessage]:
+        return self._callmethod("drain_documents", (limit,))
+
+    def peek_next_manual_retry(self) -> Optional[PipelineIngressMessage]:
+        return self._callmethod("peek_next_manual_retry")
+
+    def snapshot_manual_retries(self) -> List[PipelineIngressMessage]:
+        return self._callmethod("snapshot_manual_retries")
+
+    def ack_manual_retry(self, request_id: str) -> bool:
+        return self._callmethod("ack_manual_retry", (request_id,))
+
+    def clear(self) -> None:
+        self._callmethod("clear")
+
+    def has_work(self) -> bool:
+        return self._callmethod("has_work")
+
+    def counts(self) -> Dict[str, Any]:
+        return self._callmethod("counts")
+
+    def wait_for_documents(self, timeout: float) -> bool:
+        return self._callmethod("wait_for_documents", (timeout,))
+
+    def wait_for_items(self, timeout: float) -> bool:
+        return self._callmethod("wait_for_items", (timeout,))
+
+
+class AsyncioPipelineIngress:
+    """Single-process ingress: pure asyncio, event-driven, zero polling.
+
+    The document channel is a real ``asyncio.Queue`` (feeders simply
+    ``await get_document()``); manual/auto state lives in plain containers.
+    Every synchronous mutation happens on the owning event loop's thread, so
+    ``work_event.set()/clear()`` need no await and no extra locking.  The
+    instance is bound to the loop it was created on — cross-loop use is a
+    bug the registry rejects via :attr:`owning_loop`.
+
+    Unlike the Manager mailbox, a process-level SIGKILL loses this instance
+    (and any sticky manual request in it) with the process — the documented
+    single-process persistence boundary; ``doc_status`` plus the next run's
+    initial scan recover the document backlog.
+    """
+
+    def __init__(self) -> None:
+        self.owning_loop = asyncio.get_running_loop()
+        self.document_messages: asyncio.Queue[PipelineIngressMessage] = asyncio.Queue()
+        self._auto_rescan_pending = False
+        self._manual_retries: OrderedDict[str, PipelineIngressMessage] = OrderedDict()
+        self._terminal_ids = _BoundedTerminalIds()
+        self.work_event = asyncio.Event()
+
+    # -- publishing -----------------------------------------------------
+
+    def put_document(self, msg: PipelineIngressMessage) -> None:
+        self.document_messages.put_nowait(msg)
+        self.work_event.set()
+
+    def request_auto_rescan(self) -> None:
+        self._auto_rescan_pending = True
+        self.work_event.set()
+
+    def request_manual_retry(
+        self, request_id: str, msg: PipelineIngressMessage
+    ) -> bool:
+        _validate_manual_request(request_id, msg)
+        if request_id in self._terminal_ids:
+            return False
+        if request_id not in self._manual_retries:
+            self._manual_retries[request_id] = msg
+            self.work_event.set()
+        return True
+
+    # -- consuming ------------------------------------------------------
+
+    def consume_auto_rescan(self) -> bool:
+        pending = self._auto_rescan_pending
+        self._auto_rescan_pending = False
+        self._maybe_clear_event()
+        return pending
+
+    async def get_document(self) -> PipelineIngressMessage:
+        """Await the next document message (the single-process feeder wait).
+
+        ``task_done()`` is paired immediately — no await separates the
+        ``get()`` from it, so cancellation can never leave the queue's
+        unfinished counter inflated.  A consumer that re-publishes the message
+        creates a NEW queue item; this one is already accounted for.
+        """
+        msg = await self.document_messages.get()
+        self.document_messages.task_done()
+        self._maybe_clear_event()
+        return msg
+
+    def drain_documents(
+        self, limit: Optional[int] = None
+    ) -> List[PipelineIngressMessage]:
+        drained: List[PipelineIngressMessage] = []
+        while limit is None or len(drained) < limit:
+            try:
+                msg = self.document_messages.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            self.document_messages.task_done()
+            drained.append(msg)
+        self._maybe_clear_event()
+        return drained
+
+    def peek_next_manual_retry(self) -> Optional[PipelineIngressMessage]:
+        for msg in self._manual_retries.values():
+            return msg
+        return None
+
+    def snapshot_manual_retries(self) -> List[PipelineIngressMessage]:
+        return list(self._manual_retries.values())
+
+    def ack_manual_retry(self, request_id: str) -> bool:
+        self._manual_retries.pop(request_id, None)
+        self._terminal_ids.add(request_id, MANUAL_RETRY_ACKED)
+        self._maybe_clear_event()
+        return True
+
+    def clear(self) -> None:
+        for request_id in self._manual_retries:
+            self._terminal_ids.add(request_id, MANUAL_RETRY_CANCELLED_BY_CLEAR)
+        self._manual_retries.clear()
+        self.drain_documents()
+        self._auto_rescan_pending = False
+        self._maybe_clear_event()
+
+    # -- observing ------------------------------------------------------
+
+    def has_work(self) -> bool:
+        return bool(
+            not self.document_messages.empty()
+            or self._auto_rescan_pending
+            or self._manual_retries
+        )
+
+    def counts(self) -> Dict[str, Any]:
+        return {
+            "documents": self.document_messages.qsize(),
+            "auto_rescan_pending": self._auto_rescan_pending,
+            "manual_retries": len(self._manual_retries),
+            "terminal_manual_request_ids": len(self._terminal_ids),
+        }
+
+    async def wait_for_items(self) -> None:
+        """Wait until ANY channel has work; supervisor/diagnostics only.
+
+        Same caveat as the mailbox variant: a waiter that does not consume the
+        control channels busy-loops on their pending entries.  Double-check
+        after ``clear()`` — all state changes are same-loop synchronous, so no
+        await separates the checks and a stale-set event cannot spin.
+        """
+        while not self.has_work():
+            self.work_event.clear()
+            if self.has_work():
+                break
+            await self.work_event.wait()
+
+    def _maybe_clear_event(self) -> None:
+        if not self.has_work():
+            self.work_event.clear()

--- a/lightrag/kg/pipeline_ingress.py
+++ b/lightrag/kg/pipeline_ingress.py
@@ -409,7 +409,16 @@ class PipelineIngressHub:
     hub proxy, so no refcount can reclaim one and no discovery entry can
     dangle).  A destructive workspace wipe empties a mailbox via
     ``clear(namespace)``; dropping entries is intentionally not offered until
-    a real cross-worker teardown protocol exists.
+    a real cross-worker teardown/fencing protocol exists.  Accepted lifecycle
+    trade-off: a deployment churning many short-lived workspaces accumulates
+    (small, emptied) mailboxes in the server until Manager shutdown — a
+    future workspace-deletion feature must pair entry removal with that
+    protocol.
+
+    Sharing topology follows the shared-storage architecture: the hub proxy
+    is created pre-fork and inherited by Gunicorn workers.  Handing the proxy
+    to a ``spawn`` child also works (plain pickled-proxy rebuild — the tests
+    do this), but pre-fork inheritance is the supported production boundary.
     """
 
     def __init__(self) -> None:

--- a/lightrag/kg/pipeline_ingress.py
+++ b/lightrag/kg/pipeline_ingress.py
@@ -1,19 +1,21 @@
 """Workspace-scoped pipeline ingress: the notification channel that replaces
 ``request_pending``.
 
-One ingress instance exists per workspace (see ``shared_storage.
+One logical ingress exists per workspace (see ``shared_storage.
 get_pipeline_ingress``).  It carries three channels with three distinct
 reliability grades — deliberately NOT a single destructive FIFO:
 
 * **document** — ephemeral doc-id notifications published by enqueue after the
   ``doc_status`` row is persisted.  Messages may be lost or duplicated freely:
   ``doc_status`` is the source of truth and the next processing run's initial
-  scan rebuilds anything dropped.  Consumers re-read storage by id and skip
-  stale/terminal/duplicate ids.
+  scan rebuilds anything dropped.  The channel is bounded; an overflow
+  *coalesces* into the auto-rescan dirty flag instead of growing memory or
+  blocking the producer ("notifications are droppable, state is not").
 * **auto rescan** — a single dirty flag.  Publishers that cannot name precise
   doc ids (busy-refused processing requests, partial doc-status commits,
-  recovery paths) set it; the pipeline supervisor is the only consumer and
-  resets it atomically via :meth:`consume_auto_rescan`.
+  recovery paths, document-channel overflow) set it; the pipeline supervisor
+  is the only consumer and resets it atomically via
+  :meth:`~PipelineIngressMailbox.consume_auto_rescan`.
 * **manual retry** — sticky FIFO requests carrying user intent from
   ``/documents/scan`` and ``/documents/reprocess_failed``.  A request stays in
   the mailbox until explicitly ACKed *after* the FAILED→PENDING reset has been
@@ -32,9 +34,18 @@ documents must wait on the document channel alone (``wait_for_documents`` /
 control channels — otherwise a pending manual/auto entry keeps ``has_work()``
 true and turns the wait into a busy loop.
 
+Multiprocess topology mirrors ``KeyedHolderTable``: ONE server-side
+:class:`PipelineIngressHub` (created pre-fork in ``initialize_share_data``,
+inherited by every worker as a proxy) owns the ``{namespace: mailbox}`` map.
+Workers never hold client-side locks and never create per-workspace proxies —
+every operation is a single hub RPC that is atomic server-side, so a client
+SIGKILLed at any point can neither strand a lock nor split-brain the
+workspace.  :class:`ManagerPipelineIngress` is the thin per-workspace client
+view binding a namespace to the hub proxy.
+
 This module is dependency-free on purpose: :mod:`lightrag.kg.shared_storage`
-imports it to register :class:`PipelineIngressMailbox` on the LightRAG
-``SyncManager`` subclass and to build the per-workspace registry.
+imports it to register the hub on the LightRAG ``SyncManager`` subclass and to
+build the per-process registry.
 """
 
 from __future__ import annotations
@@ -57,6 +68,14 @@ MANUAL_RETRY_CANCELLED_BY_CLEAR = "cancelled_by_clear"
 # accepted again — the documented bounded-window limit of the idempotency
 # guarantee.
 TERMINAL_MANUAL_REQUEST_IDS_CAPACITY = 4096
+
+# Bound of the document notification channel per workspace.  Overflow never
+# blocks or fails the producer: the notification is dropped and coalesced into
+# the auto-rescan dirty flag, and the consumer recovers the missed work from
+# doc_status (the authoritative store).  In multiprocess mode the channel
+# lives in the Manager server process, so the bound also protects a shared
+# resource from one stalled workspace's feeder.
+DOCUMENT_CHANNEL_CAPACITY = 4096
 
 # Hard ceiling for one mailbox wait RPC.  A Manager server runs each client
 # connection on its own thread; a client SIGKILLed while a wait_for_* call is
@@ -116,6 +135,26 @@ class _BoundedTerminalIds:
         return len(self._ids)
 
 
+def _validate_document_message(msg: PipelineIngressMessage) -> None:
+    """Reject malformed document notifications AT the publisher.
+
+    Without this, a ``rescan`` or empty-``doc_id`` message rides the document
+    queue and only surfaces at the feeder — as a confusing defer/requeue loop
+    instead of an immediate error at the call site.  Both backends share this
+    single validator so they fail identically.
+    """
+    if msg.kind != "document" or not msg.doc_id:
+        raise ValueError(
+            "document channel requires kind='document' with a non-empty "
+            f"doc_id (got {msg!r})"
+        )
+    if msg.retry_failed or msg.request_id is not None:
+        raise ValueError(
+            "document messages must not carry control fields "
+            f"(retry_failed/request_id): {msg!r}"
+        )
+
+
 def _validate_manual_request(request_id: str, msg: PipelineIngressMessage) -> None:
     if not request_id:
         raise ValueError("manual retry requires a non-empty request_id")
@@ -132,8 +171,9 @@ class PipelineIngress(Protocol):
 
     Waiting primitives are intentionally NOT part of the protocol — they differ
     by mode (``await get_document()`` on :class:`AsyncioPipelineIngress`;
-    ``wait_for_documents(timeout)`` bridged via ``asyncio.to_thread`` on the
-    Manager proxy) and Phase 2's feeder branches on the mode anyway.
+    ``wait_for_documents(timeout)`` bridged via ``asyncio.to_thread`` on
+    :class:`ManagerPipelineIngress`) and Phase 2's feeder branches on the mode
+    anyway.
     """
 
     def put_document(self, msg: PipelineIngressMessage) -> None: ...
@@ -164,27 +204,28 @@ class PipelineIngress(Protocol):
 
 
 class PipelineIngressMailbox:
-    """Server-side ingress for multi-process mode.
+    """One workspace's ingress state (three channels + terminal ids).
 
-    The instance lives in the Manager SERVER process; workers only hold a
-    :class:`_PipelineIngressMailboxProxy`, so it survives any worker's death
-    (including SIGKILL) as long as the Manager server itself is alive.  Every
-    proxy method is exactly one RPC and is atomic server-side under one
-    ``threading.Condition``; only the two ``wait_for_*`` calls block, each
-    occupying just its own client connection's server thread while sleeping on
-    the condition (never while holding it across an RPC boundary).
+    In multiprocess mode instances live ONLY inside the Manager server as
+    values of :class:`PipelineIngressHub` — they are never proxied
+    individually, so no client refcount can reclaim one and no discovery
+    entry can dangle.  Thread-safe under one ``threading.Condition``; the
+    ``wait_for_*`` methods are the only blocking calls and sleep on the
+    condition without holding it.
 
     ``clear()`` is reserved for destructive operations: it tombstones every
     still-pending manual request id as ``CANCELLED_BY_CLEAR`` *before* wiping
     the three active channels, so a delayed replay of an already-accepted
-    request cannot re-enter the mailbox.  The terminal-id set itself is never
-    cleared here — only workspace teardown (dropping the whole mailbox) or
-    FIFO capacity eviction retires entries.
+    request cannot re-enter.  The terminal-id set itself is never cleared here
+    — only dropping the whole mailbox or FIFO capacity eviction retires
+    entries.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, document_capacity: int = DOCUMENT_CHANNEL_CAPACITY) -> None:
         self._cond = threading.Condition()
+        self._document_capacity = max(1, int(document_capacity))
         self._documents: deque[PipelineIngressMessage] = deque()
+        self._document_overflows = 0
         self._auto_rescan_pending = False
         self._manual_retries: OrderedDict[str, PipelineIngressMessage] = OrderedDict()
         self._terminal_ids = _BoundedTerminalIds()
@@ -192,8 +233,19 @@ class PipelineIngressMailbox:
     # -- publishing -----------------------------------------------------
 
     def put_document(self, msg: PipelineIngressMessage) -> None:
+        """Publish a document notification; never blocks, never fails on load.
+
+        At capacity the notification is coalesced into the auto-rescan dirty
+        flag: the consumer's next strict rescan recovers the doc from
+        doc_status, which is exactly the lossy-notification contract.
+        """
+        _validate_document_message(msg)
         with self._cond:
-            self._documents.append(msg)
+            if len(self._documents) >= self._document_capacity:
+                self._document_overflows += 1
+                self._auto_rescan_pending = True
+            else:
+                self._documents.append(msg)
             self._cond.notify_all()
 
     def request_auto_rescan(self) -> None:
@@ -286,14 +338,13 @@ class PipelineIngressMailbox:
 
     def has_work(self) -> bool:
         with self._cond:
-            return bool(
-                self._documents or self._auto_rescan_pending or self._manual_retries
-            )
+            return self._has_work_locked()
 
     def counts(self) -> Dict[str, Any]:
         with self._cond:
             return {
                 "documents": len(self._documents),
+                "document_overflows": self._document_overflows,
                 "auto_rescan_pending": self._auto_rescan_pending,
                 "manual_retries": len(self._manual_retries),
                 "terminal_manual_request_ids": len(self._terminal_ids),
@@ -343,14 +394,93 @@ class PipelineIngressMailbox:
         )
 
 
-class _PipelineIngressMailboxProxy(BaseProxy):
-    """Explicit proxy for :class:`PipelineIngressMailbox`.
+class PipelineIngressHub:
+    """Server-side ``{namespace: PipelineIngressMailbox}`` map — the ONE
+    Manager-registered ingress object (same topology as ``KeyedHolderTable``).
+
+    A mailbox is created lazily on first use, atomically under the hub lock —
+    entirely inside one server-side dispatch, so no client ever holds a
+    creation lock across RPCs and a SIGKILLed client can neither strand the
+    registry nor race a duplicate mailbox into existence.  The hub lock is
+    held only for the dict lookup; blocking waits happen on the target
+    mailbox's own condition after the hub lock is released.
+
+    Mailboxes live for the Manager server's lifetime (workers only hold the
+    hub proxy, so no refcount can reclaim one and no discovery entry can
+    dangle).  A destructive workspace wipe empties a mailbox via
+    ``clear(namespace)``; dropping entries is intentionally not offered until
+    a real cross-worker teardown protocol exists.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._mailboxes: Dict[str, PipelineIngressMailbox] = {}
+
+    def _mailbox(self, namespace: str) -> PipelineIngressMailbox:
+        with self._lock:
+            mailbox = self._mailboxes.get(namespace)
+            if mailbox is None:
+                mailbox = PipelineIngressMailbox()
+                self._mailboxes[namespace] = mailbox
+            return mailbox
+
+    # One delegating method per mailbox operation: each is a single RPC.
+
+    def put_document(self, namespace: str, msg: PipelineIngressMessage) -> None:
+        self._mailbox(namespace).put_document(msg)
+
+    def request_auto_rescan(self, namespace: str) -> None:
+        self._mailbox(namespace).request_auto_rescan()
+
+    def request_manual_retry(
+        self, namespace: str, request_id: str, msg: PipelineIngressMessage
+    ) -> bool:
+        return self._mailbox(namespace).request_manual_retry(request_id, msg)
+
+    def consume_auto_rescan(self, namespace: str) -> bool:
+        return self._mailbox(namespace).consume_auto_rescan()
+
+    def drain_documents(
+        self, namespace: str, limit: Optional[int] = None
+    ) -> List[PipelineIngressMessage]:
+        return self._mailbox(namespace).drain_documents(limit)
+
+    def peek_next_manual_retry(
+        self, namespace: str
+    ) -> Optional[PipelineIngressMessage]:
+        return self._mailbox(namespace).peek_next_manual_retry()
+
+    def snapshot_manual_retries(self, namespace: str) -> List[PipelineIngressMessage]:
+        return self._mailbox(namespace).snapshot_manual_retries()
+
+    def ack_manual_retry(self, namespace: str, request_id: str) -> bool:
+        return self._mailbox(namespace).ack_manual_retry(request_id)
+
+    def clear(self, namespace: str) -> None:
+        self._mailbox(namespace).clear()
+
+    def has_work(self, namespace: str) -> bool:
+        return self._mailbox(namespace).has_work()
+
+    def counts(self, namespace: str) -> Dict[str, Any]:
+        return self._mailbox(namespace).counts()
+
+    def wait_for_documents(self, namespace: str, timeout: float) -> bool:
+        return self._mailbox(namespace).wait_for_documents(timeout)
+
+    def wait_for_items(self, namespace: str, timeout: float) -> bool:
+        return self._mailbox(namespace).wait_for_items(timeout)
+
+
+class _PipelineIngressHubProxy(BaseProxy):
+    """Explicit proxy for :class:`PipelineIngressHub`.
 
     ``BaseProxy`` has no dynamic ``__getattr__`` — declaring ``_exposed_``
     alone would NOT make the methods callable, so each one gets an explicit
-    ``_callmethod`` wrapper (deterministic, unlike AutoProxy).  A feeder
-    blocking in ``wait_for_documents`` should hold its own proxy instance:
-    calls on one proxy serialize on its connection.
+    ``_callmethod`` wrapper (deterministic, unlike AutoProxy).  Connections
+    are per-thread (``BaseProxy`` keeps them in thread-local storage), so a
+    feeder blocking in ``wait_for_documents`` inside ``asyncio.to_thread``
+    never stalls the event-loop thread's calls on the same proxy.
     """
 
     _exposed_ = (
@@ -369,48 +499,108 @@ class _PipelineIngressMailboxProxy(BaseProxy):
         "wait_for_items",
     )
 
+    def put_document(self, namespace: str, msg: PipelineIngressMessage) -> None:
+        self._callmethod("put_document", (namespace, msg))
+
+    def request_auto_rescan(self, namespace: str) -> None:
+        self._callmethod("request_auto_rescan", (namespace,))
+
+    def request_manual_retry(
+        self, namespace: str, request_id: str, msg: PipelineIngressMessage
+    ) -> bool:
+        return self._callmethod("request_manual_retry", (namespace, request_id, msg))
+
+    def consume_auto_rescan(self, namespace: str) -> bool:
+        return self._callmethod("consume_auto_rescan", (namespace,))
+
+    def drain_documents(
+        self, namespace: str, limit: Optional[int] = None
+    ) -> List[PipelineIngressMessage]:
+        return self._callmethod("drain_documents", (namespace, limit))
+
+    def peek_next_manual_retry(
+        self, namespace: str
+    ) -> Optional[PipelineIngressMessage]:
+        return self._callmethod("peek_next_manual_retry", (namespace,))
+
+    def snapshot_manual_retries(self, namespace: str) -> List[PipelineIngressMessage]:
+        return self._callmethod("snapshot_manual_retries", (namespace,))
+
+    def ack_manual_retry(self, namespace: str, request_id: str) -> bool:
+        return self._callmethod("ack_manual_retry", (namespace, request_id))
+
+    def clear(self, namespace: str) -> None:
+        self._callmethod("clear", (namespace,))
+
+    def has_work(self, namespace: str) -> bool:
+        return self._callmethod("has_work", (namespace,))
+
+    def counts(self, namespace: str) -> Dict[str, Any]:
+        return self._callmethod("counts", (namespace,))
+
+    def wait_for_documents(self, namespace: str, timeout: float) -> bool:
+        return self._callmethod("wait_for_documents", (namespace, timeout))
+
+    def wait_for_items(self, namespace: str, timeout: float) -> bool:
+        return self._callmethod("wait_for_items", (namespace, timeout))
+
+
+class ManagerPipelineIngress:
+    """Per-workspace client view over the shared hub proxy.
+
+    Stateless besides the ``(hub, namespace)`` binding, so any process can
+    construct one at any time and always reaches the same server-side mailbox
+    — workspace identity is the namespace string, not a proxy lifetime.
+    """
+
+    def __init__(self, hub: Any, namespace: str) -> None:
+        self._hub = hub
+        self.namespace = namespace
+
     def put_document(self, msg: PipelineIngressMessage) -> None:
-        self._callmethod("put_document", (msg,))
+        _validate_document_message(msg)  # fail at the call site, pre-RPC
+        self._hub.put_document(self.namespace, msg)
 
     def request_auto_rescan(self) -> None:
-        self._callmethod("request_auto_rescan")
+        self._hub.request_auto_rescan(self.namespace)
 
     def request_manual_retry(
         self, request_id: str, msg: PipelineIngressMessage
     ) -> bool:
-        return self._callmethod("request_manual_retry", (request_id, msg))
+        _validate_manual_request(request_id, msg)  # fail at the call site
+        return self._hub.request_manual_retry(self.namespace, request_id, msg)
 
     def consume_auto_rescan(self) -> bool:
-        return self._callmethod("consume_auto_rescan")
+        return self._hub.consume_auto_rescan(self.namespace)
 
     def drain_documents(
         self, limit: Optional[int] = None
     ) -> List[PipelineIngressMessage]:
-        return self._callmethod("drain_documents", (limit,))
+        return self._hub.drain_documents(self.namespace, limit)
 
     def peek_next_manual_retry(self) -> Optional[PipelineIngressMessage]:
-        return self._callmethod("peek_next_manual_retry")
+        return self._hub.peek_next_manual_retry(self.namespace)
 
     def snapshot_manual_retries(self) -> List[PipelineIngressMessage]:
-        return self._callmethod("snapshot_manual_retries")
+        return self._hub.snapshot_manual_retries(self.namespace)
 
     def ack_manual_retry(self, request_id: str) -> bool:
-        return self._callmethod("ack_manual_retry", (request_id,))
+        return self._hub.ack_manual_retry(self.namespace, request_id)
 
     def clear(self) -> None:
-        self._callmethod("clear")
+        self._hub.clear(self.namespace)
 
     def has_work(self) -> bool:
-        return self._callmethod("has_work")
+        return self._hub.has_work(self.namespace)
 
     def counts(self) -> Dict[str, Any]:
-        return self._callmethod("counts")
+        return self._hub.counts(self.namespace)
 
     def wait_for_documents(self, timeout: float) -> bool:
-        return self._callmethod("wait_for_documents", (timeout,))
+        return self._hub.wait_for_documents(self.namespace, timeout)
 
     def wait_for_items(self, timeout: float) -> bool:
-        return self._callmethod("wait_for_items", (timeout,))
+        return self._hub.wait_for_items(self.namespace, timeout)
 
 
 class AsyncioPipelineIngress:
@@ -419,28 +609,66 @@ class AsyncioPipelineIngress:
     The document channel is a real ``asyncio.Queue`` (feeders simply
     ``await get_document()``); manual/auto state lives in plain containers.
     Every synchronous mutation happens on the owning event loop's thread, so
-    ``work_event.set()/clear()`` need no await and no extra locking.  The
-    instance is bound to the loop it was created on — cross-loop use is a
-    bug the registry rejects via :attr:`owning_loop`.
+    ``work_event.set()/clear()`` need no await and no extra locking.
 
-    Unlike the Manager mailbox, a process-level SIGKILL loses this instance
-    (and any sticky manual request in it) with the process — the documented
+    Loop affinity follows LightRAG's sync-wrapper convention (see
+    ``lightrag.py``: objects created under one ``asyncio.run()`` keep working
+    from later loops once the first loop closed): when the owning loop is
+    CLOSED the instance transparently rebinds to the current loop, migrating
+    every queued document, manual request, the auto flag and the terminal
+    tombstones.  Only genuine cross-loop sharing — a *live* foreign loop — is
+    rejected (by the registry's fast-fail).
+
+    Unlike the Manager hub, a process-level SIGKILL loses this instance (and
+    any sticky manual request in it) with the process — the documented
     single-process persistence boundary; ``doc_status`` plus the next run's
     initial scan recover the document backlog.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, document_capacity: int = DOCUMENT_CHANNEL_CAPACITY) -> None:
         self.owning_loop = asyncio.get_running_loop()
+        self._document_capacity = max(1, int(document_capacity))
         self.document_messages: asyncio.Queue[PipelineIngressMessage] = asyncio.Queue()
+        self._document_overflows = 0
         self._auto_rescan_pending = False
         self._manual_retries: OrderedDict[str, PipelineIngressMessage] = OrderedDict()
         self._terminal_ids = _BoundedTerminalIds()
         self.work_event = asyncio.Event()
 
+    def rebind_to_current_loop(self) -> None:
+        """In-place migration after the owning loop closed.
+
+        Rebuilds the loop-bound primitives (queue, event) on the current loop
+        and carries every message and all control state over.  In place so
+        callers that cached the instance keep a valid reference.  Must only be
+        called when ``owning_loop.is_closed()`` — the registry enforces that.
+        """
+        old_queue = self.document_messages
+        self.owning_loop = asyncio.get_running_loop()
+        self.document_messages = asyncio.Queue()
+        while True:
+            try:
+                self.document_messages.put_nowait(old_queue.get_nowait())
+            except asyncio.QueueEmpty:
+                break
+        self.work_event = asyncio.Event()
+        if self.has_work():
+            self.work_event.set()
+
     # -- publishing -----------------------------------------------------
 
     def put_document(self, msg: PipelineIngressMessage) -> None:
-        self.document_messages.put_nowait(msg)
+        """Publish a document notification; never blocks, never fails on load.
+
+        Overflow coalesces into the auto-rescan flag exactly like the mailbox
+        variant — see :meth:`PipelineIngressMailbox.put_document`.
+        """
+        _validate_document_message(msg)
+        if self.document_messages.qsize() >= self._document_capacity:
+            self._document_overflows += 1
+            self._auto_rescan_pending = True
+        else:
+            self.document_messages.put_nowait(msg)
         self.work_event.set()
 
     def request_auto_rescan(self) -> None:
@@ -527,6 +755,7 @@ class AsyncioPipelineIngress:
     def counts(self) -> Dict[str, Any]:
         return {
             "documents": self.document_messages.qsize(),
+            "document_overflows": self._document_overflows,
             "auto_rescan_pending": self._auto_rescan_pending,
             "manual_retries": len(self._manual_retries),
             "terminal_manual_request_ids": len(self._terminal_ids),

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -1663,11 +1663,15 @@ def _ensure_ingress_on_current_loop(ingress: Any, final_namespace: str) -> None:
     if owning_loop.is_closed():
         ingress.rebind_to_current_loop()
         return
+    # A stopped-but-not-closed foreign loop is also rejected: it cannot be
+    # distinguished from one that will resume, and migrating out from under a
+    # resumable loop would corrupt its waiters. asyncio.run() always closes
+    # its loop, so the standard LightRAG sync-wrapper flow never hits this.
     raise RuntimeError(
         f"pipeline ingress '{final_namespace}' belongs to another event "
-        "loop that is still running; single-process ingress objects cannot "
-        "be shared across live loops (create the LightRAG instances for one "
-        "workspace on the same loop, or run multi-worker mode)"
+        "loop that has not been closed; single-process ingress objects "
+        "cannot be shared across live loops (create the LightRAG instances "
+        "for one workspace on the same loop, or run multi-worker mode)"
     )
 
 

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -27,8 +27,9 @@ from lightrag.constants import (
 from lightrag.exceptions import PipelineNotInitializedError
 from lightrag.kg.pipeline_ingress import (
     AsyncioPipelineIngress,
-    PipelineIngressMailbox,
-    _PipelineIngressMailboxProxy,
+    ManagerPipelineIngress,
+    PipelineIngressHub,
+    _PipelineIngressHubProxy,
 )
 
 DEBUG_LOCKS = False
@@ -146,15 +147,19 @@ _namespace_data_cache: Optional[Dict[str, Any]] = None
 # Deliberately OUTSIDE pipeline_status: the status dict is serialized into API
 # responses, an ingress object must never be. Two layers:
 #   * _pipeline_ingress_local — per-process cache, final namespace -> ingress
-#     (an AsyncioPipelineIngress single-process, a mailbox proxy multiprocess).
-#   * _pipeline_ingress_proxies — multiprocess only: a Manager dict sharing the
-#     mailbox proxies across workers (the nested-proxy pattern _update_flags
-#     already uses), so every worker resolves the SAME server-side mailbox.
+#     (an AsyncioPipelineIngress single-process, a ManagerPipelineIngress view
+#     multiprocess).
+#   * _pipeline_ingress_hub — multiprocess only: the ONE hub proxy (created
+#     pre-fork like _keyed_holder_table; the server-side hub owns every
+#     workspace mailbox keyed by namespace string). Resolution is a plain
+#     namespace binding — no client-held locks, no per-workspace proxies, so
+#     a SIGKILLed client can neither strand creation nor split-brain a
+#     workspace.
 # Ownership: a mailbox belongs to the workspace, not to any LightRAG instance —
 # LightRAG.finalize_storages() must NOT touch it; only finalize_share_data(),
 # an explicit workspace teardown, or test cleanup may drop it.
 _pipeline_ingress_local: Optional[Dict[str, Any]] = None
-_pipeline_ingress_proxies: Optional[Any] = None
+_pipeline_ingress_hub: Optional[Any] = None
 
 # Rate limiting for acquire-failure warnings (fail-closed path).
 _ACQUIRE_FAILURE_LOG_INTERVAL = 30.0
@@ -790,9 +795,9 @@ _LightRAGManager.register(
     "KeyedHolderTable", KeyedHolderTable, proxytype=_HolderTableProxy
 )
 _LightRAGManager.register(
-    "PipelineIngressMailbox",
-    PipelineIngressMailbox,
-    proxytype=_PipelineIngressMailboxProxy,
+    "PipelineIngressHub",
+    PipelineIngressHub,
+    proxytype=_PipelineIngressHubProxy,
 )
 
 
@@ -1483,7 +1488,7 @@ def initialize_share_data(
         _queue_stats_ns_cache, \
         _namespace_data_cache, \
         _pipeline_ingress_local, \
-        _pipeline_ingress_proxies
+        _pipeline_ingress_hub
 
     # Check if already initialized
     if _initialized:
@@ -1525,10 +1530,11 @@ def initialize_share_data(
         _shared_dicts = _manager.dict()
         _init_flags = _manager.dict()
         _update_flags = _manager.dict()
-        # Cross-worker discovery table for workspace ingress mailboxes: values
-        # are mailbox proxies (nested-proxy pattern, like _update_flags'
-        # manager lists) so every worker reaches the same server-side object.
-        _pipeline_ingress_proxies = _manager.dict()
+        # Server-side hub owning every workspace's ingress mailbox (same
+        # pre-fork topology as _keyed_holder_table): workers inherit this one
+        # proxy and bind namespaces to it — no per-workspace proxy creation,
+        # no client-held creation lock.
+        _pipeline_ingress_hub = _manager.PipelineIngressHub()
 
         _storage_keyed_lock = KeyedUnifiedLock()
 
@@ -1550,7 +1556,7 @@ def initialize_share_data(
         _shared_dicts = {}
         _init_flags = {}
         _update_flags = {}
-        _pipeline_ingress_proxies = None  # multiprocess-only discovery table
+        _pipeline_ingress_hub = None  # multiprocess-only server-side hub
         _async_locks = None  # No need for async locks in single process mode
 
         _storage_keyed_lock = KeyedUnifiedLock()
@@ -1640,33 +1646,43 @@ async def initialize_pipeline_status(workspace: str | None = None):
         )
 
 
-def _check_ingress_owning_loop(ingress: Any, final_namespace: str) -> None:
-    """Fast-fail when a single-process ingress is used from a foreign loop.
+def _ensure_ingress_on_current_loop(ingress: Any, final_namespace: str) -> None:
+    """Bind a single-process ingress to the caller's loop, LightRAG-style.
 
-    An :class:`AsyncioPipelineIngress` is built on plain asyncio primitives
-    bound to the loop that created it; sharing it across event loops would
-    corrupt waits silently.  Multiprocess mailbox proxies are loop-agnostic.
+    Follows the sync-wrapper convention (see ``lightrag.py``: an object built
+    under one ``asyncio.run()`` keeps working from later loops once the first
+    loop closed): an ingress whose owning loop is CLOSED is migrated in place
+    to the current loop with all state preserved.  Only genuine cross-loop
+    sharing — the owning loop still running elsewhere — fast-fails, because
+    plain asyncio primitives would corrupt waits silently.  Multiprocess hub
+    views are loop-agnostic (no ``owning_loop`` attribute).
     """
     owning_loop = getattr(ingress, "owning_loop", None)
-    if owning_loop is None:
+    if owning_loop is None or owning_loop is asyncio.get_running_loop():
         return
-    if owning_loop is not asyncio.get_running_loop():
-        raise RuntimeError(
-            f"pipeline ingress '{final_namespace}' belongs to another event "
-            "loop; single-process ingress objects cannot be shared across "
-            "loops (create the LightRAG instances for one workspace on the "
-            "same loop, or run multi-worker mode)"
-        )
+    if owning_loop.is_closed():
+        ingress.rebind_to_current_loop()
+        return
+    raise RuntimeError(
+        f"pipeline ingress '{final_namespace}' belongs to another event "
+        "loop that is still running; single-process ingress objects cannot "
+        "be shared across live loops (create the LightRAG instances for one "
+        "workspace on the same loop, or run multi-worker mode)"
+    )
 
 
 async def get_pipeline_ingress(workspace: str | None = None):
-    """Get (or lazily create) the ingress for ``workspace``.
+    """Get (or lazily create) the ingress view for ``workspace``.
 
-    Same-workspace callers always resolve the SAME instance: single-process a
-    per-loop :class:`AsyncioPipelineIngress`, multiprocess a proxy to the one
-    server-side :class:`PipelineIngressMailbox` discovered through the shared
-    proxy table.  Creation is serialized by ``data_init_lock``; the per-process
-    cache makes the hot path lock- and RPC-free.
+    Same-workspace callers always reach the SAME state: single-process a
+    per-process :class:`AsyncioPipelineIngress` (migrated between loops per
+    the sync-wrapper convention), multiprocess a
+    :class:`ManagerPipelineIngress` view binding the namespace to the one
+    server-side hub.  No client-held lock anywhere: single-process the
+    check-and-insert below has no await (atomic on the loop; ``setdefault``
+    guards hypothetical multi-loop threads), multiprocess the hub creates the
+    mailbox atomically inside one server-side dispatch — a client SIGKILLed
+    at any point can neither strand creation nor race a duplicate.
     """
     if _pipeline_ingress_local is None:
         direct_log(
@@ -1677,28 +1693,21 @@ async def get_pipeline_ingress(workspace: str | None = None):
 
     final_namespace = get_final_namespace("pipeline_ingress", workspace)
 
-    cached = _pipeline_ingress_local.get(final_namespace)
-    if cached is not None:
-        _check_ingress_owning_loop(cached, final_namespace)
-        return cached
-
-    async with get_data_init_lock():
-        cached = _pipeline_ingress_local.get(final_namespace)
-        if cached is not None:
-            _check_ingress_owning_loop(cached, final_namespace)
-            return cached
-        if _is_multiprocess and _manager is not None:
-            ingress = _pipeline_ingress_proxies.get(final_namespace)
-            if ingress is None:
-                ingress = _manager.PipelineIngressMailbox()
-                _pipeline_ingress_proxies[final_namespace] = ingress
+    ingress = _pipeline_ingress_local.get(final_namespace)
+    if ingress is None:
+        if _is_multiprocess and _pipeline_ingress_hub is not None:
+            created: Any = ManagerPipelineIngress(
+                _pipeline_ingress_hub, final_namespace
+            )
         else:
-            ingress = AsyncioPipelineIngress()
-        _pipeline_ingress_local[final_namespace] = ingress
-        direct_log(
-            f"Process {os.getpid()} Pipeline ingress '{final_namespace}' resolved"
-        )
-        return ingress
+            created = AsyncioPipelineIngress()
+        ingress = _pipeline_ingress_local.setdefault(final_namespace, created)
+        if ingress is created:
+            direct_log(
+                f"Process {os.getpid()} Pipeline ingress '{final_namespace}' resolved"
+            )
+    _ensure_ingress_on_current_loop(ingress, final_namespace)
+    return ingress
 
 
 async def initialize_pipeline_ingress(workspace: str | None = None) -> None:
@@ -1715,22 +1724,17 @@ async def finalize_pipeline_ingress(workspace: str | None = None) -> None:
     notifications.  Idempotent.
 
     Single-process, this fully drops the instance (a later
-    :func:`get_pipeline_ingress` builds a fresh, empty one).  Multiprocess, it
-    clears ONLY the local proxy cache and deliberately leaves the shared
-    discovery table intact: the table's own entry does not keep the mailbox
-    alive (values stored inside a Manager container unpickle server-side as
-    ``manager_owned`` and hold no refcount), and popping it while sibling
-    workers still hold cached proxies would split-brain the workspace — the
-    next resolver would mint a NEW mailbox while old workers keep
-    publishing/consuming on the orphaned one.  The server-side mailbox is
-    reclaimed only by :func:`finalize_share_data`; a destructive workspace
-    wipe empties it via ``mailbox.clear()`` instead.
+    :func:`get_pipeline_ingress` builds a fresh, empty one).  Multiprocess,
+    only the local namespace view is dropped — the server-side mailbox keeps
+    its state inside the hub (workspace identity is the namespace string, so
+    re-resolution reaches the same mailbox) and is reclaimed only by
+    :func:`finalize_share_data`; a destructive workspace wipe empties it via
+    ``ingress.clear()`` instead.
     """
     if _pipeline_ingress_local is None:
         return
     final_namespace = get_final_namespace("pipeline_ingress", workspace)
-    async with get_data_init_lock():
-        _pipeline_ingress_local.pop(final_namespace, None)
+    _pipeline_ingress_local.pop(final_namespace, None)
 
 
 def _debug_log_failure(message: str, exc: Exception) -> None:
@@ -2999,7 +3003,7 @@ def finalize_share_data():
         _queue_stats_ns_cache, \
         _namespace_data_cache, \
         _pipeline_ingress_local, \
-        _pipeline_ingress_proxies
+        _pipeline_ingress_hub
 
     # Check if already initialized
     if not _initialized:
@@ -3043,11 +3047,6 @@ def finalize_share_data():
                 except Exception:
                     pass  # Ignore any errors during update flags cleanup
                 _update_flags.clear()
-            if _pipeline_ingress_proxies is not None:
-                try:
-                    _pipeline_ingress_proxies.clear()
-                except Exception:
-                    pass  # Manager shutdown below reclaims the mailboxes anyway
 
             # Shut down the Manager - this will automatically clean up all shared resources
             _manager.shutdown()
@@ -3075,7 +3074,7 @@ def finalize_share_data():
     _queue_stats_ns_cache = None
     _namespace_data_cache = None
     _pipeline_ingress_local = None
-    _pipeline_ingress_proxies = None
+    _pipeline_ingress_hub = None
 
     direct_log(f"Process {os.getpid()} storage data finalization complete")
 

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -25,6 +25,11 @@ from lightrag.constants import (
     DEFAULT_QUEUE_STATS_STALE_TTL,
 )
 from lightrag.exceptions import PipelineNotInitializedError
+from lightrag.kg.pipeline_ingress import (
+    AsyncioPipelineIngress,
+    PipelineIngressMailbox,
+    _PipelineIngressMailboxProxy,
+)
 
 DEBUG_LOCKS = False
 
@@ -136,6 +141,20 @@ _queue_stats_ns_cache: Optional[Dict[str, Any]] = None
 # safely skip the internal lock and the __contains__/__getitem__ RPCs. Reset by
 # initialize_share_data()/finalize_share_data() to preserve workspace isolation.
 _namespace_data_cache: Optional[Dict[str, Any]] = None
+
+# Workspace pipeline ingress registry (see lightrag.kg.pipeline_ingress).
+# Deliberately OUTSIDE pipeline_status: the status dict is serialized into API
+# responses, an ingress object must never be. Two layers:
+#   * _pipeline_ingress_local — per-process cache, final namespace -> ingress
+#     (an AsyncioPipelineIngress single-process, a mailbox proxy multiprocess).
+#   * _pipeline_ingress_proxies — multiprocess only: a Manager dict sharing the
+#     mailbox proxies across workers (the nested-proxy pattern _update_flags
+#     already uses), so every worker resolves the SAME server-side mailbox.
+# Ownership: a mailbox belongs to the workspace, not to any LightRAG instance —
+# LightRAG.finalize_storages() must NOT touch it; only finalize_share_data(),
+# an explicit workspace teardown, or test cleanup may drop it.
+_pipeline_ingress_local: Optional[Dict[str, Any]] = None
+_pipeline_ingress_proxies: Optional[Any] = None
 
 # Rate limiting for acquire-failure warnings (fail-closed path).
 _ACQUIRE_FAILURE_LOG_INTERVAL = 30.0
@@ -769,6 +788,11 @@ class _LightRAGManager(SyncManager):
 # spawn start methods.
 _LightRAGManager.register(
     "KeyedHolderTable", KeyedHolderTable, proxytype=_HolderTableProxy
+)
+_LightRAGManager.register(
+    "PipelineIngressMailbox",
+    PipelineIngressMailbox,
+    proxytype=_PipelineIngressMailboxProxy,
 )
 
 
@@ -1457,7 +1481,9 @@ def initialize_share_data(
         _global_concurrency_limits, \
         _lease_ns_cache, \
         _queue_stats_ns_cache, \
-        _namespace_data_cache
+        _namespace_data_cache, \
+        _pipeline_ingress_local, \
+        _pipeline_ingress_proxies
 
     # Check if already initialized
     if _initialized:
@@ -1479,6 +1505,7 @@ def initialize_share_data(
     _lease_ns_cache = None
     _queue_stats_ns_cache = None
     _namespace_data_cache = {}
+    _pipeline_ingress_local = {}
     if _global_concurrency_limits:
         direct_log(
             f"Process {os.getpid()} Global concurrency limits: {_global_concurrency_limits}",
@@ -1498,6 +1525,10 @@ def initialize_share_data(
         _shared_dicts = _manager.dict()
         _init_flags = _manager.dict()
         _update_flags = _manager.dict()
+        # Cross-worker discovery table for workspace ingress mailboxes: values
+        # are mailbox proxies (nested-proxy pattern, like _update_flags'
+        # manager lists) so every worker reaches the same server-side object.
+        _pipeline_ingress_proxies = _manager.dict()
 
         _storage_keyed_lock = KeyedUnifiedLock()
 
@@ -1519,6 +1550,7 @@ def initialize_share_data(
         _shared_dicts = {}
         _init_flags = {}
         _update_flags = {}
+        _pipeline_ingress_proxies = None  # multiprocess-only discovery table
         _async_locks = None  # No need for async locks in single process mode
 
         _storage_keyed_lock = KeyedUnifiedLock()
@@ -1606,6 +1638,99 @@ async def initialize_pipeline_status(workspace: str | None = None):
         direct_log(
             f"Process {os.getpid()} Pipeline namespace '{final_namespace}' initialized"
         )
+
+
+def _check_ingress_owning_loop(ingress: Any, final_namespace: str) -> None:
+    """Fast-fail when a single-process ingress is used from a foreign loop.
+
+    An :class:`AsyncioPipelineIngress` is built on plain asyncio primitives
+    bound to the loop that created it; sharing it across event loops would
+    corrupt waits silently.  Multiprocess mailbox proxies are loop-agnostic.
+    """
+    owning_loop = getattr(ingress, "owning_loop", None)
+    if owning_loop is None:
+        return
+    if owning_loop is not asyncio.get_running_loop():
+        raise RuntimeError(
+            f"pipeline ingress '{final_namespace}' belongs to another event "
+            "loop; single-process ingress objects cannot be shared across "
+            "loops (create the LightRAG instances for one workspace on the "
+            "same loop, or run multi-worker mode)"
+        )
+
+
+async def get_pipeline_ingress(workspace: str | None = None):
+    """Get (or lazily create) the ingress for ``workspace``.
+
+    Same-workspace callers always resolve the SAME instance: single-process a
+    per-loop :class:`AsyncioPipelineIngress`, multiprocess a proxy to the one
+    server-side :class:`PipelineIngressMailbox` discovered through the shared
+    proxy table.  Creation is serialized by ``data_init_lock``; the per-process
+    cache makes the hot path lock- and RPC-free.
+    """
+    if _pipeline_ingress_local is None:
+        direct_log(
+            f"Error: Try to get pipeline ingress before initialization, pid={os.getpid()}",
+            level="ERROR",
+        )
+        raise ValueError("Shared dictionaries not initialized")
+
+    final_namespace = get_final_namespace("pipeline_ingress", workspace)
+
+    cached = _pipeline_ingress_local.get(final_namespace)
+    if cached is not None:
+        _check_ingress_owning_loop(cached, final_namespace)
+        return cached
+
+    async with get_data_init_lock():
+        cached = _pipeline_ingress_local.get(final_namespace)
+        if cached is not None:
+            _check_ingress_owning_loop(cached, final_namespace)
+            return cached
+        if _is_multiprocess and _manager is not None:
+            ingress = _pipeline_ingress_proxies.get(final_namespace)
+            if ingress is None:
+                ingress = _manager.PipelineIngressMailbox()
+                _pipeline_ingress_proxies[final_namespace] = ingress
+        else:
+            ingress = AsyncioPipelineIngress()
+        _pipeline_ingress_local[final_namespace] = ingress
+        direct_log(
+            f"Process {os.getpid()} Pipeline ingress '{final_namespace}' resolved"
+        )
+        return ingress
+
+
+async def initialize_pipeline_ingress(workspace: str | None = None) -> None:
+    """Ensure the workspace ingress exists (idempotent)."""
+    await get_pipeline_ingress(workspace)
+
+
+async def finalize_pipeline_ingress(workspace: str | None = None) -> None:
+    """Drop the workspace ingress from THIS process's registry.
+
+    Teardown/tests ONLY.  The ingress is shared by every LightRAG instance of
+    the workspace, so ``LightRAG.finalize_storages()`` must never call this —
+    a surviving instance would lose sticky manual requests and in-flight
+    notifications.  Idempotent.
+
+    Single-process, this fully drops the instance (a later
+    :func:`get_pipeline_ingress` builds a fresh, empty one).  Multiprocess, it
+    clears ONLY the local proxy cache and deliberately leaves the shared
+    discovery table intact: the table's own entry does not keep the mailbox
+    alive (values stored inside a Manager container unpickle server-side as
+    ``manager_owned`` and hold no refcount), and popping it while sibling
+    workers still hold cached proxies would split-brain the workspace — the
+    next resolver would mint a NEW mailbox while old workers keep
+    publishing/consuming on the orphaned one.  The server-side mailbox is
+    reclaimed only by :func:`finalize_share_data`; a destructive workspace
+    wipe empties it via ``mailbox.clear()`` instead.
+    """
+    if _pipeline_ingress_local is None:
+        return
+    final_namespace = get_final_namespace("pipeline_ingress", workspace)
+    async with get_data_init_lock():
+        _pipeline_ingress_local.pop(final_namespace, None)
 
 
 def _debug_log_failure(message: str, exc: Exception) -> None:
@@ -2872,7 +2997,9 @@ def finalize_share_data():
         _global_concurrency_limits, \
         _lease_ns_cache, \
         _queue_stats_ns_cache, \
-        _namespace_data_cache
+        _namespace_data_cache, \
+        _pipeline_ingress_local, \
+        _pipeline_ingress_proxies
 
     # Check if already initialized
     if not _initialized:
@@ -2916,6 +3043,11 @@ def finalize_share_data():
                 except Exception:
                     pass  # Ignore any errors during update flags cleanup
                 _update_flags.clear()
+            if _pipeline_ingress_proxies is not None:
+                try:
+                    _pipeline_ingress_proxies.clear()
+                except Exception:
+                    pass  # Manager shutdown below reclaims the mailboxes anyway
 
             # Shut down the Manager - this will automatically clean up all shared resources
             _manager.shutdown()
@@ -2942,6 +3074,8 @@ def finalize_share_data():
     _lease_ns_cache = None
     _queue_stats_ns_cache = None
     _namespace_data_cache = None
+    _pipeline_ingress_local = None
+    _pipeline_ingress_proxies = None
 
     direct_log(f"Process {os.getpid()} storage data finalization complete")
 

--- a/tests/kg/test_pipeline_ingress.py
+++ b/tests/kg/test_pipeline_ingress.py
@@ -165,7 +165,7 @@ def test_cross_loop_access_fails_while_owner_loop_is_alive():
     thread.start()
     try:
         assert created.wait(5)
-        with pytest.raises(RuntimeError, match="still running"):
+        with pytest.raises(RuntimeError, match="has not been closed"):
             asyncio.run(get_pipeline_ingress("wsA"))
     finally:
         release.set()

--- a/tests/kg/test_pipeline_ingress.py
+++ b/tests/kg/test_pipeline_ingress.py
@@ -1,17 +1,21 @@
 """Phase 1 tests for the workspace-scoped pipeline ingress.
 
-Covers the three-channel mailbox contract (document / auto-rescan dirty flag /
-sticky manual retries with bounded terminal ids), the single-process
+Covers the three-channel contract (bounded document channel with
+overflow-to-auto-rescan coalescing / auto-rescan dirty flag / sticky manual
+retries with bounded terminal ids), the single-process
 ``AsyncioPipelineIngress`` (real ``asyncio.Queue`` document channel, paired
-``task_done``, event-driven waits, owning-loop fast fail), the Manager-backed
-multiprocess mailbox (cross-process discovery through the shared proxy table,
-sticky survival after publisher death, observe-only waiting), and the
-shared_storage registry lifecycle (workspace isolation, idempotent
-initialization, teardown-only finalize).
+``task_done``, event-driven waits, closed-loop migration per the sync-wrapper
+convention, live-cross-loop fast fail), the Manager-backed hub topology
+(single pre-fork server object, no client-held locks — resolution survives a
+SIGKILLed lock holder, cross-process publish, sticky survival after publisher
+death, observe-only waiting), and the shared_storage registry lifecycle.
 """
 
 import asyncio
 import multiprocessing as mp
+import os
+import signal
+import threading
 from pathlib import Path
 
 import pytest
@@ -20,8 +24,11 @@ import lightrag.kg.shared_storage as shared_storage
 from lightrag.kg.pipeline_ingress import (
     MANUAL_RETRY_ACKED,
     MANUAL_RETRY_CANCELLED_BY_CLEAR,
+    MAX_MAILBOX_WAIT_SECONDS,
     AsyncioPipelineIngress,
+    ManagerPipelineIngress,
     PipelineIngress,
+    PipelineIngressMailbox,
     PipelineIngressMessage,
     _BoundedTerminalIds,
 )
@@ -101,33 +108,68 @@ async def test_finalize_pipeline_ingress_drops_and_recreates(
     assert not fresh.has_work()  # teardown really dropped the sticky request
 
 
-def test_mailbox_wait_timeout_is_required_and_clamped():
-    """A SIGKILLed waiter must strand its server thread at most for the
-    bounded window — unbounded waits are rejected by construction."""
-    from lightrag.kg.pipeline_ingress import (
-        MAX_MAILBOX_WAIT_SECONDS,
-        PipelineIngressMailbox,
-    )
-
-    assert PipelineIngressMailbox._bounded_wait(999.0) == MAX_MAILBOX_WAIT_SECONDS
-    assert PipelineIngressMailbox._bounded_wait(-1.0) == 0.0
-    assert PipelineIngressMailbox._bounded_wait(0.2) == 0.2
-    mailbox = PipelineIngressMailbox()  # in-process instance, no Manager needed
-    with pytest.raises(TypeError):
-        mailbox.wait_for_documents()  # timeout is required, no None default
-    assert mailbox.wait_for_documents(0.01) is False
-    assert mailbox.wait_for_items(0.01) is False
-
-
-def test_cross_loop_access_fast_fails():
-    """A single-process ingress belongs to the loop that created it."""
+def test_closed_loop_migration_preserves_all_state():
+    """Sync-wrapper convention: an ingress created under one asyncio.run()
+    keeps working — with every channel intact — from the next loop once the
+    first one closed (e.g. ``asyncio.run(initialize_rag())`` then a sync
+    ``rag.insert(...)``)."""
     finalize_share_data()
     initialize_share_data(workers=1)
     try:
-        asyncio.run(get_pipeline_ingress("wsA"))  # created on loop A
-        with pytest.raises(RuntimeError, match="another event loop"):
-            asyncio.run(get_pipeline_ingress("wsA"))  # loop B → fast fail
+
+        async def first_loop():
+            ingress = await get_pipeline_ingress("wsA")
+            ingress.put_document(_doc("d1"))
+            ingress.request_manual_retry("r1", _manual("r1"))
+            ingress.request_auto_rescan()
+            ingress.ack_manual_retry("r0")  # terminal tombstone to carry over
+            return ingress
+
+        created = asyncio.run(first_loop())
+
+        async def second_loop():
+            ingress = await get_pipeline_ingress("wsA")
+            assert ingress is created  # migrated in place, identity preserved
+            assert ingress.owning_loop is asyncio.get_running_loop()
+            # Queued document survives and the queue works on the new loop.
+            assert (await ingress.get_document()).doc_id == "d1"
+            # Control state survives.
+            assert ingress.peek_next_manual_retry().request_id == "r1"
+            assert ingress.consume_auto_rescan() is True
+            assert ingress.request_manual_retry("r0", _manual("r0")) is False
+            # New-loop primitives are live: publish + await again.
+            ingress.put_document(_doc("d2"))
+            assert (await ingress.get_document()).doc_id == "d2"
+
+        asyncio.run(second_loop())
     finally:
+        finalize_share_data()
+
+
+def test_cross_loop_access_fails_while_owner_loop_is_alive():
+    """Only genuine cross-loop sharing (owner loop still running) is rejected."""
+    finalize_share_data()
+    initialize_share_data(workers=1)
+    created = threading.Event()
+    release = threading.Event()
+
+    def owner_thread():
+        async def main():
+            await get_pipeline_ingress("wsA")
+            created.set()
+            await asyncio.to_thread(release.wait)  # keep the owner loop alive
+
+        asyncio.run(main())
+
+    thread = threading.Thread(target=owner_thread)
+    thread.start()
+    try:
+        assert created.wait(5)
+        with pytest.raises(RuntimeError, match="still running"):
+            asyncio.run(get_pipeline_ingress("wsA"))
+    finally:
+        release.set()
+        thread.join(5)
         finalize_share_data()
 
 
@@ -154,7 +196,7 @@ async def test_single_process_document_channel_is_asyncio_queue(
     assert isinstance(ingress.document_messages, asyncio.Queue)
     # No Manager involvement in single-process mode.
     assert shared_storage._manager is None
-    assert shared_storage._pipeline_ingress_proxies is None
+    assert shared_storage._pipeline_ingress_hub is None
 
 
 async def test_get_document_event_driven_and_task_done_paired(
@@ -269,6 +311,31 @@ async def test_clear_tombstones_pending_manual_ids(single_process_share_data):
     assert ingress.counts()["terminal_manual_request_ids"] == 1
 
 
+# ---------------------------------------------------------------------------
+# Message validation and channel bounds (both backends)
+# ---------------------------------------------------------------------------
+
+
+async def test_document_message_validation(single_process_share_data):
+    ingress = await get_pipeline_ingress("wsA")
+    with pytest.raises(ValueError, match="non-empty\\s+doc_id"):
+        ingress.put_document(PipelineIngressMessage(kind="document"))
+    with pytest.raises(ValueError, match="kind='document'"):
+        ingress.put_document(PipelineIngressMessage(kind="rescan", doc_id="d1"))
+    with pytest.raises(ValueError, match="control fields"):
+        ingress.put_document(
+            PipelineIngressMessage(kind="document", doc_id="d1", retry_failed=True)
+        )
+    with pytest.raises(ValueError, match="control fields"):
+        ingress.put_document(
+            PipelineIngressMessage(kind="document", doc_id="d1", request_id="r1")
+        )
+    # The mailbox backend shares the same validator and exception type.
+    mailbox = PipelineIngressMailbox()
+    with pytest.raises(ValueError, match="kind='document'"):
+        mailbox.put_document(PipelineIngressMessage(kind="rescan", doc_id="d1"))
+
+
 async def test_manual_request_message_validation(single_process_share_data):
     ingress = await get_pipeline_ingress("wsA")
     with pytest.raises(ValueError, match="non-empty request_id"):
@@ -277,6 +344,36 @@ async def test_manual_request_message_validation(single_process_share_data):
         ingress.request_manual_retry("r1", _doc("d1"))
     with pytest.raises(ValueError, match="matching request_id"):
         ingress.request_manual_retry("r1", _manual("other"))
+
+
+async def test_document_overflow_coalesces_into_auto_rescan():
+    """Bounded channel: overflow never blocks or grows memory — it degrades
+    to the auto-rescan flag and the consumer recovers from doc_status."""
+    ingress = AsyncioPipelineIngress(document_capacity=2)
+    ingress.put_document(_doc("d1"))
+    ingress.put_document(_doc("d2"))
+    ingress.put_document(_doc("d3"))  # overflow
+    counts = ingress.counts()
+    assert counts["documents"] == 2
+    assert counts["document_overflows"] == 1
+    assert counts["auto_rescan_pending"] is True
+
+    # Recovery path: drain what survived, consume the coalesced rescan.
+    assert [m.doc_id for m in ingress.drain_documents()] == ["d1", "d2"]
+    assert ingress.consume_auto_rescan() is True
+    assert not ingress.has_work()
+
+    # Mailbox backend behaves identically.
+    mailbox = PipelineIngressMailbox(document_capacity=2)
+    for i in range(4):
+        mailbox.put_document(_doc(f"m{i}"))
+    counts = mailbox.counts()
+    assert counts["documents"] == 2
+    assert counts["document_overflows"] == 2
+    assert counts["auto_rescan_pending"] is True
+    assert len(mailbox.drain_documents()) == 2
+    assert mailbox.consume_auto_rescan() is True
+    assert not mailbox.has_work()
 
 
 def test_bounded_terminal_ids_fifo_eviction():
@@ -290,23 +387,42 @@ def test_bounded_terminal_ids_fifo_eviction():
     assert "b" in ids and "c" in ids
 
 
+def test_mailbox_wait_timeout_is_required_and_clamped():
+    """A SIGKILLed waiter must strand its server thread at most for the
+    bounded window — unbounded waits are rejected by construction."""
+    assert PipelineIngressMailbox._bounded_wait(999.0) == MAX_MAILBOX_WAIT_SECONDS
+    assert PipelineIngressMailbox._bounded_wait(-1.0) == 0.0
+    assert PipelineIngressMailbox._bounded_wait(0.2) == 0.2
+    mailbox = PipelineIngressMailbox()  # in-process instance, no Manager needed
+    with pytest.raises(TypeError):
+        mailbox.wait_for_documents()  # timeout is required, no None default
+    assert mailbox.wait_for_documents(0.01) is False
+    assert mailbox.wait_for_items(0.01) is False
+
+
 # ---------------------------------------------------------------------------
-# Manager-backed mailbox (multiprocess mode, real Manager server)
+# Manager-backed hub (multiprocess mode, real Manager server)
 # ---------------------------------------------------------------------------
 
 
-def _child_publish(proxies_dict, final_namespace):
-    """Worker-side publisher: resolves the SAME server-side mailbox through
-    the shared proxy table, publishes, then exits (its death must not affect
-    the sticky request)."""
-    mailbox = proxies_dict.get(final_namespace)
-    mailbox.put_document(PipelineIngressMessage(kind="document", doc_id="from-child"))
-    mailbox.request_manual_retry(
+def _child_publish(hub, final_namespace):
+    """Worker-side publisher: binds the SAME namespace on the shared hub,
+    publishes, then exits (its death must not affect the sticky request)."""
+    ingress = ManagerPipelineIngress(hub, final_namespace)
+    ingress.put_document(PipelineIngressMessage(kind="document", doc_id="from-child"))
+    ingress.request_manual_retry(
         "req-child",
         PipelineIngressMessage(
             kind="rescan", retry_failed=True, request_id="req-child"
         ),
     )
+
+
+def _child_hold_lock_and_die(lock):
+    """Acquire the shared Manager lock, then SIGKILL ourselves while holding
+    it — the Manager never reclaims it, simulating a crashed lock holder."""
+    lock.acquire()
+    os.kill(os.getpid(), signal.SIGKILL)
 
 
 @pytest.fixture
@@ -323,11 +439,12 @@ async def test_multiprocess_cross_process_publish_and_sticky_survival(
 ):
     ingress = await get_pipeline_ingress("wsM")
     other_ws = await get_pipeline_ingress("wsOther")
+    assert isinstance(ingress, ManagerPipelineIngress)
     final_namespace = get_final_namespace("pipeline_ingress", "wsM")
 
     child = mp.get_context("spawn").Process(
         target=_child_publish,
-        args=(shared_storage._pipeline_ingress_proxies, final_namespace),
+        args=(shared_storage._pipeline_ingress_hub, final_namespace),
     )
     child.start()
     await asyncio.to_thread(child.join, 30)
@@ -343,13 +460,37 @@ async def test_multiprocess_cross_process_publish_and_sticky_survival(
     assert ingress.peek_next_manual_retry().request_id == "req-child"
     assert ingress.counts()["manual_retries"] == 1
 
-    # ACK + bounded-window replay guard, across proxies.
+    # ACK + bounded-window replay guard, across namespace views.
     assert ingress.ack_manual_retry("req-child") is True
     assert ingress.request_manual_retry("req-child", _manual("req-child")) is False
 
-    # Same-workspace resolution from this process yields the same mailbox.
+    # Same-workspace resolution from this process reaches the same mailbox.
     again = await get_pipeline_ingress("wsM")
     assert again.counts()["terminal_manual_request_ids"] == 1
+
+
+async def test_multiprocess_resolution_survives_dead_lock_holder(
+    multiprocess_share_data,
+):
+    """Regression for the client-held-creation-lock hazard: a worker that
+    dies while holding the shared data_init lock must NOT block ingress
+    resolution — the hub creates mailboxes atomically server-side and never
+    takes client-held locks."""
+    child = mp.get_context("spawn").Process(
+        target=_child_hold_lock_and_die,
+        args=(shared_storage._data_init_lock,),
+    )
+    child.start()
+    await asyncio.to_thread(child.join, 30)
+    assert child.exitcode == -signal.SIGKILL
+
+    # The Manager lock really is stranded by the dead holder.
+    assert shared_storage._data_init_lock.acquire(timeout=0.2) is False
+
+    # Ingress resolution for brand-new workspaces is unaffected.
+    ingress = await asyncio.wait_for(get_pipeline_ingress("wsFresh"), timeout=5.0)
+    ingress.put_document(_doc("d1"))
+    assert [m.doc_id for m in ingress.drain_documents()] == ["d1"]
 
 
 async def test_multiprocess_wait_isolation_and_cancelled_waiter_steals_nothing(
@@ -380,22 +521,17 @@ async def test_multiprocess_wait_isolation_and_cancelled_waiter_steals_nothing(
     assert not ingress.has_work()
 
 
-async def test_multiprocess_finalize_keeps_discovery_table_intact(
+async def test_multiprocess_finalize_keeps_server_side_state(
     multiprocess_share_data,
 ):
-    """Per-workspace finalize in multiprocess mode only clears the LOCAL
-    proxy cache: popping the shared discovery entry while sibling workers
-    still hold cached proxies would split-brain the workspace (the entry
-    itself holds no refcount — Manager-container values unpickle
-    ``manager_owned`` — so a later resolver would mint a brand-new mailbox
-    while old workers keep using the orphaned one)."""
+    """Per-workspace finalize only drops the LOCAL namespace view; the
+    server-side mailbox keeps its state inside the hub and re-resolution
+    (workspace identity = namespace string) reaches the same mailbox — no
+    split-brain is possible by construction."""
     ingress = await get_pipeline_ingress("wsM")
     ingress.request_manual_retry("r-sticky", _manual("r-sticky"))
-    final_namespace = get_final_namespace("pipeline_ingress", "wsM")
 
     await finalize_pipeline_ingress("wsM")
-    assert final_namespace in shared_storage._pipeline_ingress_proxies
-
-    # Re-resolution reaches the SAME server-side mailbox: state preserved.
     again = await get_pipeline_ingress("wsM")
-    assert again.peek_next_manual_retry().request_id == "r-sticky"
+    assert again is not ingress  # new local view ...
+    assert again.peek_next_manual_retry().request_id == "r-sticky"  # ... same state

--- a/tests/kg/test_pipeline_ingress.py
+++ b/tests/kg/test_pipeline_ingress.py
@@ -1,0 +1,401 @@
+"""Phase 1 tests for the workspace-scoped pipeline ingress.
+
+Covers the three-channel mailbox contract (document / auto-rescan dirty flag /
+sticky manual retries with bounded terminal ids), the single-process
+``AsyncioPipelineIngress`` (real ``asyncio.Queue`` document channel, paired
+``task_done``, event-driven waits, owning-loop fast fail), the Manager-backed
+multiprocess mailbox (cross-process discovery through the shared proxy table,
+sticky survival after publisher death, observe-only waiting), and the
+shared_storage registry lifecycle (workspace isolation, idempotent
+initialization, teardown-only finalize).
+"""
+
+import asyncio
+import multiprocessing as mp
+from pathlib import Path
+
+import pytest
+
+import lightrag.kg.shared_storage as shared_storage
+from lightrag.kg.pipeline_ingress import (
+    MANUAL_RETRY_ACKED,
+    MANUAL_RETRY_CANCELLED_BY_CLEAR,
+    AsyncioPipelineIngress,
+    PipelineIngress,
+    PipelineIngressMessage,
+    _BoundedTerminalIds,
+)
+from lightrag.kg.shared_storage import (
+    finalize_pipeline_ingress,
+    finalize_share_data,
+    get_final_namespace,
+    get_pipeline_ingress,
+    initialize_pipeline_ingress,
+    initialize_share_data,
+)
+
+pytestmark = pytest.mark.offline
+
+
+def _doc(doc_id: str) -> PipelineIngressMessage:
+    return PipelineIngressMessage(kind="document", doc_id=doc_id)
+
+
+def _manual(request_id: str) -> PipelineIngressMessage:
+    return PipelineIngressMessage(
+        kind="rescan", retry_failed=True, request_id=request_id
+    )
+
+
+@pytest.fixture
+def single_process_share_data():
+    """Fresh single-process shared data per test (isolated registry/loop)."""
+    finalize_share_data()
+    initialize_share_data(workers=1)
+    yield
+    finalize_share_data()
+
+
+# ---------------------------------------------------------------------------
+# Registry lifecycle (single-process)
+# ---------------------------------------------------------------------------
+
+
+async def test_get_before_initialize_raises():
+    finalize_share_data()
+    with pytest.raises(ValueError, match="not initialized"):
+        await get_pipeline_ingress("ws")
+
+
+async def test_workspace_isolation_and_idempotent_resolution(
+    single_process_share_data,
+):
+    a1 = await get_pipeline_ingress("wsA")
+    a2 = await get_pipeline_ingress("wsA")
+    b = await get_pipeline_ingress("wsB")
+    assert a1 is a2
+    assert a1 is not b
+    assert isinstance(a1, PipelineIngress)
+
+    a1.put_document(_doc("d-a"))
+    assert a1.has_work() and not b.has_work()
+    assert [m.doc_id for m in a1.drain_documents()] == ["d-a"]
+    assert b.drain_documents() == []
+
+
+async def test_initialize_pipeline_ingress_is_idempotent(single_process_share_data):
+    await initialize_pipeline_ingress("wsA")
+    first = await get_pipeline_ingress("wsA")
+    await initialize_pipeline_ingress("wsA")
+    assert (await get_pipeline_ingress("wsA")) is first
+
+
+async def test_finalize_pipeline_ingress_drops_and_recreates(
+    single_process_share_data,
+):
+    ingress = await get_pipeline_ingress("wsA")
+    ingress.request_manual_retry("r1", _manual("r1"))
+    await finalize_pipeline_ingress("wsA")
+    fresh = await get_pipeline_ingress("wsA")
+    assert fresh is not ingress
+    assert not fresh.has_work()  # teardown really dropped the sticky request
+
+
+def test_mailbox_wait_timeout_is_required_and_clamped():
+    """A SIGKILLed waiter must strand its server thread at most for the
+    bounded window — unbounded waits are rejected by construction."""
+    from lightrag.kg.pipeline_ingress import (
+        MAX_MAILBOX_WAIT_SECONDS,
+        PipelineIngressMailbox,
+    )
+
+    assert PipelineIngressMailbox._bounded_wait(999.0) == MAX_MAILBOX_WAIT_SECONDS
+    assert PipelineIngressMailbox._bounded_wait(-1.0) == 0.0
+    assert PipelineIngressMailbox._bounded_wait(0.2) == 0.2
+    mailbox = PipelineIngressMailbox()  # in-process instance, no Manager needed
+    with pytest.raises(TypeError):
+        mailbox.wait_for_documents()  # timeout is required, no None default
+    assert mailbox.wait_for_documents(0.01) is False
+    assert mailbox.wait_for_items(0.01) is False
+
+
+def test_cross_loop_access_fast_fails():
+    """A single-process ingress belongs to the loop that created it."""
+    finalize_share_data()
+    initialize_share_data(workers=1)
+    try:
+        asyncio.run(get_pipeline_ingress("wsA"))  # created on loop A
+        with pytest.raises(RuntimeError, match="another event loop"):
+            asyncio.run(get_pipeline_ingress("wsA"))  # loop B → fast fail
+    finally:
+        finalize_share_data()
+
+
+def test_finalize_storages_never_touches_ingress():
+    """Ownership guard: the ingress is workspace-shared, so no LightRAG
+    instance teardown path may finalize it (only finalize_share_data /
+    explicit workspace teardown / tests)."""
+    lightrag_src = (
+        Path(shared_storage.__file__).parent.parent / "lightrag.py"
+    ).read_text(encoding="utf-8")
+    assert "finalize_pipeline_ingress" not in lightrag_src
+
+
+# ---------------------------------------------------------------------------
+# AsyncioPipelineIngress (single-process semantics)
+# ---------------------------------------------------------------------------
+
+
+async def test_single_process_document_channel_is_asyncio_queue(
+    single_process_share_data,
+):
+    ingress = await get_pipeline_ingress("wsA")
+    assert isinstance(ingress, AsyncioPipelineIngress)
+    assert isinstance(ingress.document_messages, asyncio.Queue)
+    # No Manager involvement in single-process mode.
+    assert shared_storage._manager is None
+    assert shared_storage._pipeline_ingress_proxies is None
+
+
+async def test_get_document_event_driven_and_task_done_paired(
+    single_process_share_data,
+):
+    ingress = await get_pipeline_ingress("wsA")
+
+    waiter = asyncio.create_task(ingress.get_document())
+    await asyncio.sleep(0)
+    assert not waiter.done()  # parked on queue.get(), no polling loop to feed
+
+    ingress.put_document(_doc("d1"))
+    msg = await asyncio.wait_for(waiter, timeout=1.0)
+    assert msg.doc_id == "d1"
+
+    # task_done() paired immediately: join() must complete at once.
+    await asyncio.wait_for(ingress.document_messages.join(), timeout=0.1)
+    assert not ingress.work_event.is_set()  # cleared once no work remains
+
+    # drain_documents pairs task_done too.
+    ingress.put_document(_doc("d2"))
+    ingress.put_document(_doc("d3"))
+    assert [m.doc_id for m in ingress.drain_documents(limit=1)] == ["d2"]
+    assert [m.doc_id for m in ingress.drain_documents()] == ["d3"]
+    await asyncio.wait_for(ingress.document_messages.join(), timeout=0.1)
+
+
+async def test_document_wait_isolated_from_control_channels(
+    single_process_share_data,
+):
+    """Pending manual/auto entries must NOT satisfy a document wait."""
+    ingress = await get_pipeline_ingress("wsA")
+    ingress.request_auto_rescan()
+    ingress.request_manual_retry("r1", _manual("r1"))
+
+    waiter = asyncio.create_task(ingress.get_document())
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(waiter), timeout=0.2)
+
+    ingress.put_document(_doc("d1"))
+    assert (await asyncio.wait_for(waiter, timeout=1.0)).doc_id == "d1"
+
+
+async def test_wait_for_items_covers_all_channels(single_process_share_data):
+    ingress = await get_pipeline_ingress("wsA")
+
+    supervisor_wait = asyncio.create_task(ingress.wait_for_items())
+    await asyncio.sleep(0)
+    assert not supervisor_wait.done()
+
+    ingress.request_auto_rescan()
+    await asyncio.wait_for(supervisor_wait, timeout=1.0)
+
+    # Consuming the only work re-arms the wait instead of spinning.
+    assert ingress.consume_auto_rescan() is True
+    rearmed = asyncio.create_task(ingress.wait_for_items())
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(rearmed), timeout=0.2)
+    ingress.request_manual_retry("r1", _manual("r1"))
+    await asyncio.wait_for(rearmed, timeout=1.0)
+
+
+async def test_consume_auto_rescan_atomic_exchange(single_process_share_data):
+    ingress = await get_pipeline_ingress("wsA")
+    assert ingress.consume_auto_rescan() is False
+    ingress.request_auto_rescan()
+    ingress.request_auto_rescan()  # idempotent set
+    assert ingress.has_work()
+    assert ingress.consume_auto_rescan() is True
+    assert ingress.consume_auto_rescan() is False
+    assert not ingress.has_work()
+    assert not ingress.work_event.is_set()
+
+
+async def test_manual_retry_fifo_ack_and_terminal_replay_guard(
+    single_process_share_data,
+):
+    ingress = await get_pipeline_ingress("wsA")
+    for rid in ("r1", "r2", "r3"):
+        assert ingress.request_manual_retry(rid, _manual(rid)) is True
+    # Re-requesting a pending id is a no-op and keeps its FIFO position.
+    assert ingress.request_manual_retry("r2", _manual("r2")) is True
+    assert [m.request_id for m in ingress.snapshot_manual_retries()] == [
+        "r1",
+        "r2",
+        "r3",
+    ]
+
+    assert ingress.peek_next_manual_retry().request_id == "r1"
+    assert ingress.peek_next_manual_retry().request_id == "r1"  # peek ≠ consume
+    assert ingress.ack_manual_retry("r1") is True
+    assert ingress.ack_manual_retry("r1") is True  # idempotent
+    assert ingress.peek_next_manual_retry().request_id == "r2"
+
+    # Terminal id refuses replay.
+    assert ingress.request_manual_retry("r1", _manual("r1")) is False
+    assert ingress.counts()["manual_retries"] == 2
+
+
+async def test_clear_tombstones_pending_manual_ids(single_process_share_data):
+    ingress = await get_pipeline_ingress("wsA")
+    ingress.put_document(_doc("d1"))
+    ingress.request_auto_rescan()
+    ingress.request_manual_retry("r1", _manual("r1"))
+
+    ingress.clear()
+    assert not ingress.has_work()
+    # The un-ACKed id was tombstoned: a delayed replay must not re-enter.
+    assert ingress.request_manual_retry("r1", _manual("r1")) is False
+    # Fresh ids keep working; the terminal set survived the clear.
+    assert ingress.request_manual_retry("r2", _manual("r2")) is True
+    assert ingress.counts()["terminal_manual_request_ids"] == 1
+
+
+async def test_manual_request_message_validation(single_process_share_data):
+    ingress = await get_pipeline_ingress("wsA")
+    with pytest.raises(ValueError, match="non-empty request_id"):
+        ingress.request_manual_retry("", _manual(""))
+    with pytest.raises(ValueError, match="retry_failed=True"):
+        ingress.request_manual_retry("r1", _doc("d1"))
+    with pytest.raises(ValueError, match="matching request_id"):
+        ingress.request_manual_retry("r1", _manual("other"))
+
+
+def test_bounded_terminal_ids_fifo_eviction():
+    ids = _BoundedTerminalIds(capacity=2)
+    ids.add("a", MANUAL_RETRY_ACKED)
+    ids.add("b", MANUAL_RETRY_CANCELLED_BY_CLEAR)
+    ids.add("a", MANUAL_RETRY_CANCELLED_BY_CLEAR)  # first terminal state wins
+    assert ids.get("a") == MANUAL_RETRY_ACKED
+    ids.add("c", MANUAL_RETRY_ACKED)  # evicts "a" (oldest)
+    assert "a" not in ids
+    assert "b" in ids and "c" in ids
+
+
+# ---------------------------------------------------------------------------
+# Manager-backed mailbox (multiprocess mode, real Manager server)
+# ---------------------------------------------------------------------------
+
+
+def _child_publish(proxies_dict, final_namespace):
+    """Worker-side publisher: resolves the SAME server-side mailbox through
+    the shared proxy table, publishes, then exits (its death must not affect
+    the sticky request)."""
+    mailbox = proxies_dict.get(final_namespace)
+    mailbox.put_document(PipelineIngressMessage(kind="document", doc_id="from-child"))
+    mailbox.request_manual_retry(
+        "req-child",
+        PipelineIngressMessage(
+            kind="rescan", retry_failed=True, request_id="req-child"
+        ),
+    )
+
+
+@pytest.fixture
+def multiprocess_share_data():
+    """Real Manager-backed shared data (workers=2); one server per test."""
+    finalize_share_data()
+    initialize_share_data(workers=2)
+    yield
+    finalize_share_data()
+
+
+async def test_multiprocess_cross_process_publish_and_sticky_survival(
+    multiprocess_share_data,
+):
+    ingress = await get_pipeline_ingress("wsM")
+    other_ws = await get_pipeline_ingress("wsOther")
+    final_namespace = get_final_namespace("pipeline_ingress", "wsM")
+
+    child = mp.get_context("spawn").Process(
+        target=_child_publish,
+        args=(shared_storage._pipeline_ingress_proxies, final_namespace),
+    )
+    child.start()
+    await asyncio.to_thread(child.join, 30)
+    assert child.exitcode == 0
+
+    # Cross-workspace isolation: the sibling workspace saw nothing.
+    assert not other_ws.has_work()
+
+    assert await asyncio.to_thread(ingress.wait_for_documents, 5.0)
+    assert [m.doc_id for m in ingress.drain_documents()] == ["from-child"]
+
+    # The publisher process is dead; the sticky request lives in the server.
+    assert ingress.peek_next_manual_retry().request_id == "req-child"
+    assert ingress.counts()["manual_retries"] == 1
+
+    # ACK + bounded-window replay guard, across proxies.
+    assert ingress.ack_manual_retry("req-child") is True
+    assert ingress.request_manual_retry("req-child", _manual("req-child")) is False
+
+    # Same-workspace resolution from this process yields the same mailbox.
+    again = await get_pipeline_ingress("wsM")
+    assert again.counts()["terminal_manual_request_ids"] == 1
+
+
+async def test_multiprocess_wait_isolation_and_cancelled_waiter_steals_nothing(
+    multiprocess_share_data,
+):
+    ingress = await get_pipeline_ingress("wsM")
+
+    # Predicate isolation: pending manual/auto must not satisfy a document wait.
+    ingress.request_auto_rescan()
+    ingress.request_manual_retry("r1", _manual("r1"))
+    assert await asyncio.to_thread(ingress.wait_for_documents, 0.3) is False
+    assert await asyncio.to_thread(ingress.wait_for_items, 0.3) is True
+
+    # A cancelled waiter's orphaned thread only OBSERVES — it can never take
+    # a message with it (wait_for_documents has no dequeue path).
+    waiter = asyncio.create_task(asyncio.to_thread(ingress.wait_for_documents, 5.0))
+    await asyncio.sleep(0.2)
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+    ingress.put_document(_doc("kept"))
+    await asyncio.sleep(0.3)  # give the orphaned thread time to wake and exit
+    assert [m.doc_id for m in ingress.drain_documents()] == ["kept"]
+
+    # clear() tombstones the pending manual id server-side as well.
+    ingress.clear()
+    assert ingress.request_manual_retry("r1", _manual("r1")) is False
+    assert not ingress.has_work()
+
+
+async def test_multiprocess_finalize_keeps_discovery_table_intact(
+    multiprocess_share_data,
+):
+    """Per-workspace finalize in multiprocess mode only clears the LOCAL
+    proxy cache: popping the shared discovery entry while sibling workers
+    still hold cached proxies would split-brain the workspace (the entry
+    itself holds no refcount — Manager-container values unpickle
+    ``manager_owned`` — so a later resolver would mint a brand-new mailbox
+    while old workers keep using the orphaned one)."""
+    ingress = await get_pipeline_ingress("wsM")
+    ingress.request_manual_retry("r-sticky", _manual("r-sticky"))
+    final_namespace = get_final_namespace("pipeline_ingress", "wsM")
+
+    await finalize_pipeline_ingress("wsM")
+    assert final_namespace in shared_storage._pipeline_ingress_proxies
+
+    # Re-resolution reaches the SAME server-side mailbox: state preserved.
+    again = await get_pipeline_ingress("wsM")
+    assert again.peek_next_manual_retry().request_id == "r-sticky"


### PR DESCRIPTION
## Summary

Phase 1 of the reviewed multi-phase design that replaces the pipeline's `request_pending` flag with a workspace-scoped **ingress mailbox**, fixing the batch-barrier defect where one long-running document blocks every later-enqueued file until the whole batch finishes. This phase lands pure infrastructure — **no pipeline behavior change; nothing consumes the ingress yet**.

### Three channels, three reliability grades (deliberately not one destructive FIFO)

| channel | semantics | crash story |
|---|---|---|
| `document` | ephemeral doc-id notifications | rebuildable from `doc_status` + next run's initial scan |
| `auto rescan` | single dirty flag, consumed atomically via `consume_auto_rescan()` | consumer must re-arm on strict-query failure |
| `manual retry` | sticky FIFO requests (`/scan`, `/reprocess_failed` intent), ACKed only after the FAILED→PENDING reset persists | survives worker SIGKILL while the Manager server lives; terminal ids (ACKED / CANCELLED_BY_CLEAR) refuse delayed replays within a bounded window |

### Implementation

- **`lightrag/kg/pipeline_ingress.py`** — `PipelineIngressMessage`, server-side `PipelineIngressMailbox` (single `threading.Condition`; every proxy method is one atomic RPC; `wait_for_documents`/`wait_for_items` **observe only, never dequeue**, so a cancelled/SIGKILLed waiter can never steal a message; waits take a **required, clamped timeout** so a dead client strands its server thread at most `MAX_MAILBOX_WAIT_SECONDS`), explicit `BaseProxy` (KeyedHolderTable pattern), and `AsyncioPipelineIngress` (real `asyncio.Queue` document channel with strictly paired `task_done`, `asyncio.Event` waits, owning-loop fast-fail).
- **`lightrag/kg/shared_storage.py`** — Manager registration, per-process registry + multiprocess Manager-dict discovery table (nested-proxy pattern like `_update_flags`), `initialize/get/finalize_pipeline_ingress`, lifecycle wiring into `initialize_share_data`/`finalize_share_data`. Multiprocess `finalize_pipeline_ingress` clears only the local cache — popping the discovery entry while sibling workers hold cached proxies would split-brain the workspace (Manager-container values unpickle `manager_owned`, holding no refcount).
- Feeder-facing waits are **document-channel-only by contract**: waiting on all three channels without consuming the control ones would busy-loop on a pending manual/auto entry.

## Tests

- `tests/kg/test_pipeline_ingress.py` — 19 tests: workspace isolation, idempotent resolution, FIFO manual retries + peek/ACK + terminal replay guard, clear-tombstone, atomic auto-rescan exchange, document-wait isolation from control channels, task_done pairing, cross-loop fast fail, bounded wait clamp, and real-Manager multiprocess coverage (cross-process publish via the discovery table, sticky survival after publisher death, cancelled waiter steals nothing, finalize keeps the discovery table intact).
- Full `tests/kg` + `tests/pipeline` regression: **1434 passed, 22 skipped**.
- storage-backend-reviewer pass done; both should-fix findings (multiprocess finalize split-brain, unbounded mailbox wait) are fixed in this PR.

Next phases (separate stacked PRs): Phase 0 (FAILED-retry semantics split + sticky manual intent), Phase 2 (in-batch feeder + dual write), Phase 3 (queue-based atomic exit + cancellation closure), Phase 4 (delete `request_pending` repo-wide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)