### PR TITLE
fix(parser): fall back when CHUNK_* size/overlap envs are empty

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -832,7 +832,9 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             if self.chunk_token_size is not None:
                 chunker_cfg["chunk_token_size"] = self.chunk_token_size
             else:
-                chunker_cfg["chunk_token_size"] = int(os.getenv("CHUNK_SIZE", 1200))
+                chunker_cfg["chunk_token_size"] = get_env_value(
+                    "CHUNK_SIZE", 1200, int
+                )
 
         # Per-strategy chunk_overlap_token_size — strategy env (if set)
         # already lives in the sub-dict.  Slots still missing fall back
@@ -840,7 +842,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         if self.chunk_overlap_token_size is not None:
             legacy_overlap_default = self.chunk_overlap_token_size
         else:
-            legacy_overlap_default = int(os.getenv("CHUNK_OVERLAP_SIZE", 100))
+            legacy_overlap_default = get_env_value("CHUNK_OVERLAP_SIZE", 100, int)
         for strategy_key in (
             "fixed_token",
             "recursive_character",
@@ -869,10 +871,9 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         # explicit value the caller did provide; the env read here
         # mirrors ``default_chunker_config`` so partial-addon-params
         # callers still pick up env overrides.
-        p_size_raw = os.getenv("CHUNK_P_SIZE")
         chunker_cfg["paragraph_semantic"].setdefault(
             "chunk_token_size",
-            int(p_size_raw) if p_size_raw is not None else DEFAULT_CHUNK_P_SIZE,
+            get_env_value("CHUNK_P_SIZE", DEFAULT_CHUNK_P_SIZE, int),
         )
 
         # Per-strategy F/R/V chunk_token_size from strategy env
@@ -891,14 +892,14 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             ("recursive_character", "CHUNK_R_SIZE"),
             ("semantic_vector", "CHUNK_V_SIZE"),
         ):
-            size_raw = os.getenv(size_env)
-            if size_raw is None:
+            size_val = get_env_value(size_env, None, int)
+            if size_val is None:
                 continue
             sub = chunker_cfg.get(strategy_key)
             if not isinstance(sub, dict):
                 sub = {}
                 chunker_cfg[strategy_key] = sub
-            sub.setdefault("chunk_token_size", int(size_raw))
+            sub.setdefault("chunk_token_size", size_val)
 
         # Back-fill legacy instance fields → always int afterwards.
         # Overlap mirrors the F-strategy resolved value, matching the

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -82,6 +82,7 @@ from lightrag.constants import (
     DEFAULT_FILE_PATH_MORE_PLACEHOLDER,
 )
 from lightrag.utils import get_env_value
+from lightrag.parser.routing import _chunk_env_int
 
 from lightrag.kg import (
     verify_storage_implementation,
@@ -832,15 +833,14 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             if self.chunk_token_size is not None:
                 chunker_cfg["chunk_token_size"] = self.chunk_token_size
             else:
-                chunker_cfg["chunk_token_size"] = get_env_value("CHUNK_SIZE", 1200, int)
-
+                chunker_cfg["chunk_token_size"] = _chunk_env_int("CHUNK_SIZE", 1200)
         # Per-strategy chunk_overlap_token_size — strategy env (if set)
         # already lives in the sub-dict.  Slots still missing fall back
         # to the legacy ctor field, then CHUNK_OVERLAP_SIZE env.
         if self.chunk_overlap_token_size is not None:
             legacy_overlap_default = self.chunk_overlap_token_size
         else:
-            legacy_overlap_default = get_env_value("CHUNK_OVERLAP_SIZE", 100, int)
+            legacy_overlap_default = _chunk_env_int("CHUNK_OVERLAP_SIZE", 100)
         for strategy_key in (
             "fixed_token",
             "recursive_character",
@@ -871,9 +871,8 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         # callers still pick up env overrides.
         chunker_cfg["paragraph_semantic"].setdefault(
             "chunk_token_size",
-            get_env_value("CHUNK_P_SIZE", DEFAULT_CHUNK_P_SIZE, int),
+            _chunk_env_int("CHUNK_P_SIZE", DEFAULT_CHUNK_P_SIZE),
         )
-
         # Per-strategy F/R/V chunk_token_size from strategy env
         # (CHUNK_F_SIZE / CHUNK_R_SIZE / CHUNK_V_SIZE).  Same rationale as the
         # P backfill above: ``default_chunker_config`` seeds these when it
@@ -890,7 +889,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             ("recursive_character", "CHUNK_R_SIZE"),
             ("semantic_vector", "CHUNK_V_SIZE"),
         ):
-            size_val = get_env_value(size_env, None, int)
+            size_val = _chunk_env_int(size_env, None)
             if size_val is None:
                 continue
             sub = chunker_cfg.get(strategy_key)

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -832,9 +832,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             if self.chunk_token_size is not None:
                 chunker_cfg["chunk_token_size"] = self.chunk_token_size
             else:
-                chunker_cfg["chunk_token_size"] = get_env_value(
-                    "CHUNK_SIZE", 1200, int
-                )
+                chunker_cfg["chunk_token_size"] = get_env_value("CHUNK_SIZE", 1200, int)
 
         # Per-strategy chunk_overlap_token_size — strategy env (if set)
         # already lives in the sub-dict.  Slots still missing fall back

--- a/lightrag/parser/routing.py
+++ b/lightrag/parser/routing.py
@@ -46,7 +46,7 @@ from lightrag.parser.param_schema import (
     split_top_level,
     take_paren_block,
 )
-from lightrag.utils import logger, parse_optional_float
+from lightrag.utils import get_env_value, logger, parse_optional_float
 
 import json
 from collections.abc import Mapping
@@ -317,9 +317,8 @@ def slim_chunk_options(
     result[key] = deepcopy(dict(src.get(key) or {}))
     if key == "paragraph_semantic":
         if "chunk_token_size" not in result[key]:
-            p_size_raw = os.getenv("CHUNK_P_SIZE")
-            result[key]["chunk_token_size"] = (
-                int(p_size_raw) if p_size_raw is not None else DEFAULT_CHUNK_P_SIZE
+            result[key]["chunk_token_size"] = get_env_value(
+                "CHUNK_P_SIZE", DEFAULT_CHUNK_P_SIZE, int
             )
         # Mirror the CHUNK_P_DROP_REFERENCES env default for the drop-references
         # switch here — this is the single chokepoint every enqueue path runs
@@ -433,48 +432,47 @@ def default_chunker_config() -> dict[str, Any]:
     }
 
     # Strategy-specific overlap envs only — leave the slot absent when
-    # unset so overlay can detect provenance and fill from the legacy
+    # unset/empty so overlay can detect provenance and fill from the legacy
     # tier (constructor field → CHUNK_OVERLAP_SIZE env).
-    f_overlap_raw = os.getenv("CHUNK_F_OVERLAP_SIZE")
-    if f_overlap_raw is not None:
-        config["fixed_token"]["chunk_overlap_token_size"] = int(f_overlap_raw)
-    r_overlap_raw = os.getenv("CHUNK_R_OVERLAP_SIZE")
-    if r_overlap_raw is not None:
-        config["recursive_character"]["chunk_overlap_token_size"] = int(r_overlap_raw)
-    p_overlap_raw = os.getenv("CHUNK_P_OVERLAP_SIZE")
-    if p_overlap_raw is not None:
-        config["paragraph_semantic"]["chunk_overlap_token_size"] = int(p_overlap_raw)
+    f_overlap = get_env_value("CHUNK_F_OVERLAP_SIZE", None, int)
+    if f_overlap is not None:
+        config["fixed_token"]["chunk_overlap_token_size"] = f_overlap
+    r_overlap = get_env_value("CHUNK_R_OVERLAP_SIZE", None, int)
+    if r_overlap is not None:
+        config["recursive_character"]["chunk_overlap_token_size"] = r_overlap
+    p_overlap = get_env_value("CHUNK_P_OVERLAP_SIZE", None, int)
+    if p_overlap is not None:
+        config["paragraph_semantic"]["chunk_overlap_token_size"] = p_overlap
 
     # P strategy carries its own ``chunk_token_size`` override so the
     # paragraph-semantic merge target can diverge from the global
     # ``CHUNK_SIZE`` (e.g. heading-aligned chunks may want a larger
     # ceiling).  Unlike R/V, the slot is ALWAYS populated — when
-    # ``CHUNK_P_SIZE`` is unset we use ``DEFAULT_CHUNK_P_SIZE`` (2000)
+    # ``CHUNK_P_SIZE`` is unset/empty we use ``DEFAULT_CHUNK_P_SIZE`` (2000)
     # rather than letting the dispatcher fall back to the global
     # ``CHUNK_SIZE`` (1200): paragraph-semantic merging needs more
     # headroom than the global default to keep related paragraphs
     # together, and silently inheriting the smaller global ceiling
     # defeats the strategy's purpose.
-    p_size_raw = os.getenv("CHUNK_P_SIZE")
-    config["paragraph_semantic"]["chunk_token_size"] = (
-        int(p_size_raw) if p_size_raw is not None else DEFAULT_CHUNK_P_SIZE
+    config["paragraph_semantic"]["chunk_token_size"] = get_env_value(
+        "CHUNK_P_SIZE", DEFAULT_CHUNK_P_SIZE, int
     )
 
     # F/R/V strategies likewise carry their own optional ``chunk_token_size``
     # overrides (fixed-token may want a deployment-specific window, recursive
     # character splitting a smaller target, semantic-vector clustering a larger
     # advisory ceiling).  Same slot-absent convention as P: leave the slot
-    # absent when the env is unset so the strategy inherits the top-level
+    # absent when the env is unset/empty so the strategy inherits the top-level
     # ``chunk_token_size`` fallback at consumption time.
-    f_size_raw = os.getenv("CHUNK_F_SIZE")
-    if f_size_raw is not None:
-        config["fixed_token"]["chunk_token_size"] = int(f_size_raw)
-    r_size_raw = os.getenv("CHUNK_R_SIZE")
-    if r_size_raw is not None:
-        config["recursive_character"]["chunk_token_size"] = int(r_size_raw)
-    v_size_raw = os.getenv("CHUNK_V_SIZE")
-    if v_size_raw is not None:
-        config["semantic_vector"]["chunk_token_size"] = int(v_size_raw)
+    f_size = get_env_value("CHUNK_F_SIZE", None, int)
+    if f_size is not None:
+        config["fixed_token"]["chunk_token_size"] = f_size
+    r_size = get_env_value("CHUNK_R_SIZE", None, int)
+    if r_size is not None:
+        config["recursive_character"]["chunk_token_size"] = r_size
+    v_size = get_env_value("CHUNK_V_SIZE", None, int)
+    if v_size is not None:
+        config["semantic_vector"]["chunk_token_size"] = v_size
 
     return config
 

--- a/lightrag/parser/routing.py
+++ b/lightrag/parser/routing.py
@@ -46,7 +46,7 @@ from lightrag.parser.param_schema import (
     split_top_level,
     take_paren_block,
 )
-from lightrag.utils import get_env_value, logger, parse_optional_float
+from lightrag.utils import logger, parse_optional_float
 
 import json
 from collections.abc import Mapping
@@ -317,8 +317,8 @@ def slim_chunk_options(
     result[key] = deepcopy(dict(src.get(key) or {}))
     if key == "paragraph_semantic":
         if "chunk_token_size" not in result[key]:
-            result[key]["chunk_token_size"] = get_env_value(
-                "CHUNK_P_SIZE", DEFAULT_CHUNK_P_SIZE, int
+            result[key]["chunk_token_size"] = _chunk_env_int(
+                "CHUNK_P_SIZE", DEFAULT_CHUNK_P_SIZE
             )
         # Mirror the CHUNK_P_DROP_REFERENCES env default for the drop-references
         # switch here — this is the single chokepoint every enqueue path runs
@@ -343,6 +343,27 @@ def _env_optional_str(key: str) -> str | None:
     if not stripped or stripped.lower() == "none":
         return None
     return raw
+
+
+def _chunk_env_int(env_key: str, default: int | None) -> int | None:
+    """Read a chunk size/overlap env as int.
+
+    Unset, empty, whitespace, and literal ``None`` fall back to ``default``
+    (empty ``.env`` / Compose slots). Non-empty malformed values raise so a
+    typo like ``20OO`` does not silently change retrieval defaults.
+    """
+    raw = os.getenv(env_key)
+    if raw is None:
+        return default
+    stripped = raw.strip()
+    if not stripped or stripped.lower() == "none":
+        return default
+    try:
+        return int(stripped)
+    except ValueError as exc:
+        raise ValueError(
+            f"Environment variable {env_key}={raw!r} is not a valid integer"
+        ) from exc
 
 
 def _env_r_separators() -> list[str]:
@@ -434,13 +455,13 @@ def default_chunker_config() -> dict[str, Any]:
     # Strategy-specific overlap envs only — leave the slot absent when
     # unset/empty so overlay can detect provenance and fill from the legacy
     # tier (constructor field → CHUNK_OVERLAP_SIZE env).
-    f_overlap = get_env_value("CHUNK_F_OVERLAP_SIZE", None, int)
+    f_overlap = _chunk_env_int("CHUNK_F_OVERLAP_SIZE", None)
     if f_overlap is not None:
         config["fixed_token"]["chunk_overlap_token_size"] = f_overlap
-    r_overlap = get_env_value("CHUNK_R_OVERLAP_SIZE", None, int)
+    r_overlap = _chunk_env_int("CHUNK_R_OVERLAP_SIZE", None)
     if r_overlap is not None:
         config["recursive_character"]["chunk_overlap_token_size"] = r_overlap
-    p_overlap = get_env_value("CHUNK_P_OVERLAP_SIZE", None, int)
+    p_overlap = _chunk_env_int("CHUNK_P_OVERLAP_SIZE", None)
     if p_overlap is not None:
         config["paragraph_semantic"]["chunk_overlap_token_size"] = p_overlap
 
@@ -454,8 +475,8 @@ def default_chunker_config() -> dict[str, Any]:
     # headroom than the global default to keep related paragraphs
     # together, and silently inheriting the smaller global ceiling
     # defeats the strategy's purpose.
-    config["paragraph_semantic"]["chunk_token_size"] = get_env_value(
-        "CHUNK_P_SIZE", DEFAULT_CHUNK_P_SIZE, int
+    config["paragraph_semantic"]["chunk_token_size"] = _chunk_env_int(
+        "CHUNK_P_SIZE", DEFAULT_CHUNK_P_SIZE
     )
 
     # F/R/V strategies likewise carry their own optional ``chunk_token_size``
@@ -464,13 +485,13 @@ def default_chunker_config() -> dict[str, Any]:
     # advisory ceiling).  Same slot-absent convention as P: leave the slot
     # absent when the env is unset/empty so the strategy inherits the top-level
     # ``chunk_token_size`` fallback at consumption time.
-    f_size = get_env_value("CHUNK_F_SIZE", None, int)
+    f_size = _chunk_env_int("CHUNK_F_SIZE", None)
     if f_size is not None:
         config["fixed_token"]["chunk_token_size"] = f_size
-    r_size = get_env_value("CHUNK_R_SIZE", None, int)
+    r_size = _chunk_env_int("CHUNK_R_SIZE", None)
     if r_size is not None:
         config["recursive_character"]["chunk_token_size"] = r_size
-    v_size = get_env_value("CHUNK_V_SIZE", None, int)
+    v_size = _chunk_env_int("CHUNK_V_SIZE", None)
     if v_size is not None:
         config["semantic_vector"]["chunk_token_size"] = v_size
 

--- a/tests/parser/test_chunk_size_empty_env.py
+++ b/tests/parser/test_chunk_size_empty_env.py
@@ -57,6 +57,28 @@ def test_valid_chunk_f_size_is_honored(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.offline
+@pytest.mark.parametrize(
+    "env_key",
+    [
+        "CHUNK_P_SIZE",
+        "CHUNK_F_SIZE",
+        "CHUNK_R_SIZE",
+        "CHUNK_V_SIZE",
+        "CHUNK_F_OVERLAP_SIZE",
+        "CHUNK_R_OVERLAP_SIZE",
+        "CHUNK_P_OVERLAP_SIZE",
+    ],
+)
+@pytest.mark.parametrize("env_value", ["20OO", "1.5", "abc"])
+def test_malformed_chunk_size_envs_raise(
+    env_key: str, env_value: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(env_key, env_value)
+    with pytest.raises(ValueError, match=env_key):
+        default_chunker_config()
+
+
+@pytest.mark.offline
 @pytest.mark.parametrize("env_value", ["", "  "])
 def test_empty_chunk_size_env_does_not_crash_lightrag_init(
     env_value: str, tmp_path: Path

--- a/tests/parser/test_chunk_size_empty_env.py
+++ b/tests/parser/test_chunk_size_empty_env.py
@@ -1,0 +1,94 @@
+"""Empty CHUNK_* size/overlap envs must not crash chunker defaults.
+
+Follow-up to CHUNK_R_SEPARATORS / empty int field defaults: bare
+``int(os.getenv(...))`` still crashed when size/overlap knobs were present
+but empty (common in ``.env`` / Compose). Route through ``get_env_value``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from lightrag.constants import DEFAULT_CHUNK_P_SIZE
+from lightrag.parser.routing import default_chunker_config
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize("env_value", ["", "  ", "\t"])
+@pytest.mark.parametrize(
+    ("env_key", "strategy", "field", "expected"),
+    [
+        ("CHUNK_P_SIZE", "paragraph_semantic", "chunk_token_size", DEFAULT_CHUNK_P_SIZE),
+        ("CHUNK_F_SIZE", "fixed_token", "chunk_token_size", None),
+        ("CHUNK_R_SIZE", "recursive_character", "chunk_token_size", None),
+        ("CHUNK_V_SIZE", "semantic_vector", "chunk_token_size", None),
+        ("CHUNK_F_OVERLAP_SIZE", "fixed_token", "chunk_overlap_token_size", None),
+        ("CHUNK_R_OVERLAP_SIZE", "recursive_character", "chunk_overlap_token_size", None),
+        ("CHUNK_P_OVERLAP_SIZE", "paragraph_semantic", "chunk_overlap_token_size", None),
+    ],
+)
+def test_empty_strategy_chunk_envs_fall_back(
+    env_key: str,
+    strategy: str,
+    field: str,
+    expected: int | None,
+    env_value: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(env_key, env_value)
+    cfg = default_chunker_config()[strategy]
+    if expected is None:
+        assert field not in cfg
+    else:
+        assert cfg[field] == expected
+
+
+@pytest.mark.offline
+def test_valid_chunk_f_size_is_honored(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CHUNK_F_SIZE", "900")
+    assert default_chunker_config()["fixed_token"]["chunk_token_size"] == 900
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize("env_value", ["", "  "])
+def test_empty_chunk_size_env_does_not_crash_lightrag_init(
+    env_value: str, tmp_path: Path
+) -> None:
+    env = os.environ.copy()
+    env["CHUNK_SIZE"] = env_value
+    env["CHUNK_OVERLAP_SIZE"] = env_value
+    env["PYTHONPATH"] = str(REPO_ROOT) + (
+        os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else ""
+    )
+    script = f"""
+from lightrag.utils import EmbeddingFunc
+import numpy as np
+from lightrag.lightrag import LightRAG
+
+async def emb(texts):
+    return np.zeros((len(texts), 8))
+
+rag = LightRAG(
+    working_dir={str(tmp_path / "wd")!r},
+    embedding_func=EmbeddingFunc(embedding_dim=8, max_token_size=100, func=emb),
+    llm_model_func=lambda *a, **k: "ok",
+)
+print(rag.chunk_token_size, rag.chunk_overlap_token_size)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "1200 100"

--- a/tests/parser/test_chunk_size_empty_env.py
+++ b/tests/parser/test_chunk_size_empty_env.py
@@ -7,9 +7,7 @@ but empty (common in ``.env`` / Compose). Route through ``get_env_value``.
 
 from __future__ import annotations
 
-import os
-import subprocess
-import sys
+import numpy as np
 from pathlib import Path
 
 import pytest
@@ -96,36 +94,78 @@ def test_malformed_chunk_size_envs_raise(
 @pytest.mark.offline
 @pytest.mark.parametrize("env_value", ["", "  "])
 def test_empty_chunk_size_env_does_not_crash_lightrag_init(
-    env_value: str, tmp_path: Path
+    env_value: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    env = os.environ.copy()
-    env["CHUNK_SIZE"] = env_value
-    env["CHUNK_OVERLAP_SIZE"] = env_value
-    env["PYTHONPATH"] = str(REPO_ROOT) + (
-        os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else ""
+    monkeypatch.setenv("CHUNK_SIZE", env_value)
+    monkeypatch.setenv("CHUNK_OVERLAP_SIZE", env_value)
+    monkeypatch.setattr(
+        "lightrag.lightrag.verify_storage_implementation", lambda *a: None
     )
-    script = f"""
-from lightrag.utils import EmbeddingFunc
-import numpy as np
-from lightrag.lightrag import LightRAG
+    monkeypatch.setattr("lightrag.lightrag.check_storage_env_vars", lambda *a: None)
 
-async def emb(texts):
-    return np.zeros((len(texts), 8))
+    class DummyStorage:
+        def __init__(self, *a, **k):
+            pass
 
-rag = LightRAG(
-    working_dir={str(tmp_path / "wd")!r},
-    embedding_func=EmbeddingFunc(embedding_dim=8, max_token_size=100, func=emb),
-    llm_model_func=lambda *a, **k: "ok",
+    monkeypatch.setattr(
+        "lightrag.lightrag.get_storage_class", lambda *a, **k: DummyStorage
+    )
+
+    async def emb(texts: list[str]) -> np.ndarray:
+        return np.zeros((len(texts), 8))
+
+    from lightrag.lightrag import LightRAG
+    from lightrag.utils import EmbeddingFunc
+
+    rag = LightRAG(
+        working_dir=str(tmp_path / "wd"),
+        embedding_func=EmbeddingFunc(embedding_dim=8, max_token_size=100, func=emb),
+        llm_model_func=lambda *a, **k: "ok",
+    )
+    assert rag.chunk_token_size == 1200
+    assert rag.chunk_overlap_token_size == 100
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize(
+    "env_key",
+    [
+        "CHUNK_SIZE",
+        "CHUNK_OVERLAP_SIZE",
+        "CHUNK_P_SIZE",
+        "CHUNK_F_SIZE",
+        "CHUNK_R_SIZE",
+        "CHUNK_V_SIZE",
+    ],
 )
-print(rag.chunk_token_size, rag.chunk_overlap_token_size)
-"""
-    result = subprocess.run(
-        [sys.executable, "-c", script],
-        cwd=REPO_ROOT,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
+def test_malformed_chunk_size_envs_raise_in_lightrag_init(
+    env_key: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Malformed non-empty env values must raise ValueError on LightRAG init."""
+    monkeypatch.setenv(env_key, "20OO")
+    monkeypatch.setattr(
+        "lightrag.lightrag.verify_storage_implementation", lambda *a: None
     )
-    assert result.returncode == 0, result.stderr
-    assert result.stdout.strip() == "1200 100"
+    monkeypatch.setattr("lightrag.lightrag.check_storage_env_vars", lambda *a: None)
+
+    class DummyStorage:
+        def __init__(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(
+        "lightrag.lightrag.get_storage_class", lambda *a, **k: DummyStorage
+    )
+
+    async def emb(texts: list[str]) -> np.ndarray:
+        return np.zeros((len(texts), 8))
+
+    from lightrag.lightrag import LightRAG
+    from lightrag.utils import EmbeddingFunc
+
+    with pytest.raises(ValueError, match=env_key):
+        LightRAG(
+            working_dir=str(tmp_path / "wd"),
+            addon_params={"chunker": {"paragraph_semantic": {}}},
+            embedding_func=EmbeddingFunc(embedding_dim=8, max_token_size=100, func=emb),
+            llm_model_func=lambda *a, **k: "ok",
+        )

--- a/tests/parser/test_chunk_size_empty_env.py
+++ b/tests/parser/test_chunk_size_empty_env.py
@@ -25,13 +25,28 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 @pytest.mark.parametrize(
     ("env_key", "strategy", "field", "expected"),
     [
-        ("CHUNK_P_SIZE", "paragraph_semantic", "chunk_token_size", DEFAULT_CHUNK_P_SIZE),
+        (
+            "CHUNK_P_SIZE",
+            "paragraph_semantic",
+            "chunk_token_size",
+            DEFAULT_CHUNK_P_SIZE,
+        ),
         ("CHUNK_F_SIZE", "fixed_token", "chunk_token_size", None),
         ("CHUNK_R_SIZE", "recursive_character", "chunk_token_size", None),
         ("CHUNK_V_SIZE", "semantic_vector", "chunk_token_size", None),
         ("CHUNK_F_OVERLAP_SIZE", "fixed_token", "chunk_overlap_token_size", None),
-        ("CHUNK_R_OVERLAP_SIZE", "recursive_character", "chunk_overlap_token_size", None),
-        ("CHUNK_P_OVERLAP_SIZE", "paragraph_semantic", "chunk_overlap_token_size", None),
+        (
+            "CHUNK_R_OVERLAP_SIZE",
+            "recursive_character",
+            "chunk_overlap_token_size",
+            None,
+        ),
+        (
+            "CHUNK_P_OVERLAP_SIZE",
+            "paragraph_semantic",
+            "chunk_overlap_token_size",
+            None,
+        ),
     ],
 )
 def test_empty_strategy_chunk_envs_fall_back(


### PR DESCRIPTION
Clearing documented knobs like `CHUNK_SIZE=` or `CHUNK_P_SIZE=` in `.env` still crashed LightRAG init and `default_chunker_config` via bare `int(os.getenv)`.

Route those reads through `get_env_value` like the other empty-env fixes.