### PR TITLE
fix(base): fall back when QueryParam env-backed ints are empty

### DIFF
--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -15,7 +15,7 @@ from typing import (
     List,
     AsyncIterator,
 )
-from .utils import EmbeddingFunc
+from .utils import EmbeddingFunc, get_env_value
 from .types import KnowledgeGraph
 from .constants import (
     DEFAULT_TOP_K,
@@ -104,26 +104,26 @@ class QueryParam:
     stream: bool = False
     """If True, enables streaming output for real-time responses."""
 
-    top_k: int = int(os.getenv("TOP_K", str(DEFAULT_TOP_K)))
+    top_k: int = get_env_value("TOP_K", DEFAULT_TOP_K, int)
     """Number of top items to retrieve. Represents entities in 'local' mode and relationships in 'global' mode."""
 
-    chunk_top_k: int = int(os.getenv("CHUNK_TOP_K", str(DEFAULT_CHUNK_TOP_K)))
+    chunk_top_k: int = get_env_value("CHUNK_TOP_K", DEFAULT_CHUNK_TOP_K, int)
     """Number of text chunks to retrieve initially from vector search and keep after reranking.
     If None, defaults to top_k value.
     """
 
-    max_entity_tokens: int = int(
-        os.getenv("MAX_ENTITY_TOKENS", str(DEFAULT_MAX_ENTITY_TOKENS))
+    max_entity_tokens: int = get_env_value(
+        "MAX_ENTITY_TOKENS", DEFAULT_MAX_ENTITY_TOKENS, int
     )
     """Maximum number of tokens allocated for entity context in unified token control system."""
 
-    max_relation_tokens: int = int(
-        os.getenv("MAX_RELATION_TOKENS", str(DEFAULT_MAX_RELATION_TOKENS))
+    max_relation_tokens: int = get_env_value(
+        "MAX_RELATION_TOKENS", DEFAULT_MAX_RELATION_TOKENS, int
     )
     """Maximum number of tokens allocated for relationship context in unified token control system."""
 
-    max_total_tokens: int = int(
-        os.getenv("MAX_TOTAL_TOKENS", str(DEFAULT_MAX_TOTAL_TOKENS))
+    max_total_tokens: int = get_env_value(
+        "MAX_TOTAL_TOKENS", DEFAULT_MAX_TOTAL_TOKENS, int
     )
     """Maximum total tokens budget for the entire query context (entities + relations + chunks + system prompt)."""
 

--- a/tests/test_queryparam_empty_int_env.py
+++ b/tests/test_queryparam_empty_int_env.py
@@ -1,0 +1,60 @@
+"""Empty env-backed QueryParam int defaults must not crash import.
+
+``QueryParam`` field defaults previously used bare ``int(os.getenv(...))``,
+which raises when the variable is present but empty (common in ``.env`` /
+Compose). Sibling ``LightRAG`` knobs already go through ``get_env_value``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _import_queryparam_field_default(
+    env_key: str, env_value: str, field_name: str
+) -> str:
+    env = os.environ.copy()
+    env[env_key] = env_value
+    env["PYTHONPATH"] = str(REPO_ROOT) + (
+        os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else ""
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from lightrag.base import QueryParam; "
+            f"print(QueryParam.__dataclass_fields__[{field_name!r}].default)",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize("env_value", ["", "  ", "\t"])
+@pytest.mark.parametrize(
+    "env_key,field_name,expected",
+    [
+        ("TOP_K", "top_k", "40"),
+        ("CHUNK_TOP_K", "chunk_top_k", "20"),
+        ("MAX_ENTITY_TOKENS", "max_entity_tokens", "6000"),
+        ("MAX_RELATION_TOKENS", "max_relation_tokens", "8000"),
+        ("MAX_TOTAL_TOKENS", "max_total_tokens", "30000"),
+    ],
+)
+def test_empty_queryparam_int_env_falls_back_on_import(
+    env_value: str, env_key: str, field_name: str, expected: str
+) -> None:
+    assert _import_queryparam_field_default(env_key, env_value, field_name) == expected


### PR DESCRIPTION
Clearing `TOP_K=` (or the other QueryParam int knobs) crashed import because field defaults used bare `int(os.getenv)`.

Route those defaults through `get_env_value` like the LightRAG field defaults.