### PR TITLE
fix(utils): treat empty JSON store files as missing

### DIFF
--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -2401,15 +2401,11 @@ def load_json(file_name):
         return None
     with open(file_name, encoding="utf-8-sig") as f:
         content = f.read()
-    # Empty/whitespace after crash or partial write: same contract as missing.
+    # Empty/whitespace existing file: same contract as missing (callers use or {}).
     if not content.strip():
         logger.warning("Empty JSON file treated as missing: %s", file_name)
         return None
-    try:
-        return json.loads(content)
-    except json.JSONDecodeError:
-        logger.warning("Invalid JSON file treated as missing: %s", file_name)
-        return None
+    return json.loads(content)
 
 
 def _sanitize_string_for_json(text: str) -> str:

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -2400,7 +2400,16 @@ def load_json(file_name):
     if not os.path.exists(file_name):
         return None
     with open(file_name, encoding="utf-8-sig") as f:
-        return json.load(f)
+        content = f.read()
+    # Empty/whitespace after crash or partial write: same contract as missing.
+    if not content.strip():
+        logger.warning("Empty JSON file treated as missing: %s", file_name)
+        return None
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError:
+        logger.warning("Invalid JSON file treated as missing: %s", file_name)
+        return None
 
 
 def _sanitize_string_for_json(text: str) -> str:

--- a/tests/utils/test_load_json.py
+++ b/tests/utils/test_load_json.py
@@ -1,0 +1,42 @@
+"""load_json: empty or invalid store files must match the missing-file contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lightrag.utils import load_json
+
+pytestmark = pytest.mark.offline
+
+
+def test_missing_file_returns_none(tmp_path: Path) -> None:
+    assert load_json(str(tmp_path / "no-such.json")) is None
+
+
+@pytest.mark.parametrize("payload", [b"", b"   \n\t  "])
+def test_empty_or_whitespace_file_returns_none(tmp_path: Path, payload: bytes) -> None:
+    path = tmp_path / "kv.json"
+    path.write_bytes(payload)
+    assert load_json(str(path)) is None
+    assert (load_json(str(path)) or {}) == {}
+
+
+def test_invalid_json_file_returns_none(tmp_path: Path) -> None:
+    path = tmp_path / "kv.json"
+    path.write_text("{not json", encoding="utf-8")
+    assert load_json(str(path)) is None
+    assert (load_json(str(path)) or {}) == {}
+
+
+def test_valid_json_still_loads(tmp_path: Path) -> None:
+    path = tmp_path / "kv.json"
+    path.write_text('{"a": 1}', encoding="utf-8")
+    assert load_json(str(path)) == {"a": 1}
+
+
+def test_empty_object_json_is_not_none(tmp_path: Path) -> None:
+    path = tmp_path / "kv.json"
+    path.write_text("{}", encoding="utf-8")
+    assert load_json(str(path)) == {}

--- a/tests/utils/test_load_json.py
+++ b/tests/utils/test_load_json.py
@@ -1,7 +1,8 @@
-"""load_json: empty or invalid store files must match the missing-file contract."""
+"""load_json: empty store files must match the missing-file contract."""
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -23,11 +24,11 @@ def test_empty_or_whitespace_file_returns_none(tmp_path: Path, payload: bytes) -
     assert (load_json(str(path)) or {}) == {}
 
 
-def test_invalid_json_file_returns_none(tmp_path: Path) -> None:
+def test_invalid_json_still_raises(tmp_path: Path) -> None:
     path = tmp_path / "kv.json"
     path.write_text("{not json", encoding="utf-8")
-    assert load_json(str(path)) is None
-    assert (load_json(str(path)) or {}) == {}
+    with pytest.raises(json.JSONDecodeError):
+        load_json(str(path))
 
 
 def test_valid_json_still_loads(tmp_path: Path) -> None:


### PR DESCRIPTION
A zero-byte `kv_store_*.json` raised `JSONDecodeError` on startup while a missing file already returned `None` for `load_json(...) or {}`.

Treat empty/whitespace files like missing; corrupt JSON still raises.