### PR TITLE
fix(parser): fall back when CHUNK_V_BUFFER_SIZE env is empty

### DIFF
--- a/lightrag/parser/routing.py
+++ b/lightrag/parser/routing.py
@@ -46,7 +46,7 @@ from lightrag.parser.param_schema import (
     split_top_level,
     take_paren_block,
 )
-from lightrag.utils import logger, parse_optional_float
+from lightrag.utils import get_env_value, logger, parse_optional_float
 
 import json
 from collections.abc import Mapping
@@ -420,7 +420,7 @@ def default_chunker_config() -> dict[str, Any]:
             "breakpoint_threshold_amount": parse_optional_float(
                 os.getenv("CHUNK_V_BREAKPOINT_THRESHOLD_AMOUNT")
             ),
-            "buffer_size": int(os.getenv("CHUNK_V_BUFFER_SIZE", "1")),
+            "buffer_size": get_env_value("CHUNK_V_BUFFER_SIZE", 1, int),
             # Default extends LangChain's English-only sentence splitter
             # with CJK terminators so SemanticChunker can actually find
             # sentence boundaries on Chinese input.  Override per

--- a/tests/parser/test_chunk_v_buffer_empty_env.py
+++ b/tests/parser/test_chunk_v_buffer_empty_env.py
@@ -1,0 +1,22 @@
+"""Empty CHUNK_V_BUFFER_SIZE must not crash default_chunker_config."""
+
+from __future__ import annotations
+
+import pytest
+
+from lightrag.parser.routing import default_chunker_config
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize("env_value", ["", "  ", "\t"])
+def test_empty_chunk_v_buffer_size_falls_back(
+    env_value: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CHUNK_V_BUFFER_SIZE", env_value)
+    assert default_chunker_config()["semantic_vector"]["buffer_size"] == 1
+
+
+@pytest.mark.offline
+def test_valid_chunk_v_buffer_size_is_honored(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CHUNK_V_BUFFER_SIZE", "3")
+    assert default_chunker_config()["semantic_vector"]["buffer_size"] == 3


### PR DESCRIPTION
Clearing `CHUNK_V_BUFFER_SIZE=` crashed `default_chunker_config` via bare `int(os.getenv)`.

Route through `get_env_value` like the other chunk env knobs.