### PR TITLE
✨ feat(pipeline): Phase 2 — in-batch feeder (route mid-batch arrivals without the barrier)

### DIFF
--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1576,90 +1576,131 @@ class _PipelineMixin:
             ctx.routing_doc_ids.discard(doc_id)
             ctx.inflight_doc_ids.add(doc_id)
 
+    def _republish_documents(self, ingress, messages) -> None:
+        """Best-effort re-publish of drained-but-unresolved document messages.
+
+        The document channel drain is destructive (``drain_documents`` removes
+        the messages).  On a teardown — user cancel, internal error, or the
+        exception backoff — the drained messages this feeder had not yet routed
+        or confirmed stale/terminal must go back to the mailbox: a user cancel
+        clears ``request_pending``, so without the restore those PENDING docs
+        would wait for an unrelated future trigger instead of the next run.  A
+        multiprocess ``put_document`` is a Manager RPC; swallow failures — the
+        docs are PENDING and still recovered by the next initial scan.
+        """
+        for msg in messages:
+            try:
+                ingress.put_document(msg)
+            except Exception as republish_error:
+                logger.debug(
+                    "[feeder] document re-publish failed for "
+                    f"{getattr(msg, 'doc_id', None)}: {republish_error}"
+                )
+
+    async def _route_one(
+        self,
+        ctx: "_BatchRunContext",
+        msg: "PipelineIngressMessage",
+        pending: dict,
+    ) -> bool:
+        """Resolve one fed document message.
+
+        Returns True when the message is fully RESOLVED — admitted into a parse
+        queue, or a confirmed stale/terminal / duplicate / journaled doc that is
+        correctly dropped — and False when it was only SKIPPED for now (full_docs
+        not yet visible, or a transient read) and so should be re-published if
+        the batch tears down before request_pending can recover it.
+        """
+        doc_id = msg.doc_id
+        if not doc_id:
+            return True  # malformed notification: nothing to route
+        async with ctx.pipeline_status_lock:
+            duplicate = doc_id in ctx.routing_doc_ids or doc_id in ctx.inflight_doc_ids
+        if duplicate:
+            return True  # already routing/inflight — dedup
+        status_doc = pending.get(doc_id)
+        if status_doc is None:
+            return True  # not PENDING (processed/failed/deleted) — stale/terminal
+        if doc_status_custom_chunk_patch(status_doc) is not None:
+            return True  # journaled → scan/custom-chunk recovery owns it
+        try:
+            full_doc = await self.full_docs.get_by_id(doc_id)
+        except Exception as read_error:
+            logger.debug(
+                f"[feeder] full_docs read failed for {doc_id}, deferring "
+                f"(request_pending recovers): {read_error}"
+            )
+            return False  # transient → skip, re-publish on teardown
+        if not full_doc:
+            return False  # not yet visible (ryw lag) → skip, re-publish on teardown
+        await self._admit_fed_document(ctx, doc_id, status_doc)
+        return True  # admitted
+
     async def _pipeline_feeder(self, ctx: "_BatchRunContext", ingress) -> None:
         """Route documents that arrive DURING a batch into its parse queues so
         they process without waiting for the batch barrier.
 
         Pure accelerator (Phase 2): every message it discards or skips is a
         PENDING ``doc_status`` row that ``request_pending`` — dual-written by
-        enqueue on the same busy pipeline — recovers on the next batch.  So the
-        feeder never writes ``doc_status`` and never has to re-publish a skipped
-        message; correctness is anchored by the existing request_pending loop,
-        and the feeder only removes latency.
+        enqueue on the same busy pipeline — recovers on the next batch.  The
+        feeder never writes ``doc_status``; correctness is anchored by the
+        existing request_pending loop and the feeder only removes latency.
 
-        Per drained message, three outcomes:
-          * ROUTED — PENDING, not already routing/inflight, full_docs visible →
-            two-stage admission into the parse queue;
-          * STALE/TERMINAL — not PENDING (processed/failed/deleted), a
-            duplicate of a routing/inflight id, or a journaled custom-chunk doc
-            (owned by scan/custom-chunk recovery) → dropped;
-          * NEEDS_RECONCILIATION — full_docs not yet visible (read-your-writes
-            lag) or a transient read error → skipped this batch, recovered by
-            request_pending (Phase 3 will reconcile these in-batch instead).
+        Per drained message: ROUTED (admitted), STALE/TERMINAL (dropped), or
+        SKIPPED (full_docs not yet visible / a transient read — recovered by
+        request_pending; re-published on a teardown, see ``_route_one`` and
+        ``_republish_documents``).
 
-        Stopped by cancellation; see :meth:`_feeder_next_batch`.  Any OTHER
-        per-iteration failure (the wait RPC, engine routing, an admission read)
-        is logged and skipped rather than left to silently kill the accelerator
-        for the rest of the batch — the affected docs stay PENDING and are
-        recovered by request_pending exactly like an intentional skip.
+        **Bounded liveness (yields to control signals):** the feeder stops
+        admitting — returns so the batch drains to its quiescence point — when
+        cancellation is requested (otherwise ``/cancel_pipeline`` could never
+        complete under a sustained upload stream that keeps the parse queue
+        non-empty) or when a sticky manual retry request is waiting (it is only
+        consumed at the batch boundary, so an unbounded batch would starve it).
+        It deliberately does NOT wait on ``has_work()`` — that would busy-loop on
+        a pending manual/auto signal (the document-only wait is the point).
+
+        An unexpected per-iteration failure (the wait RPC, engine routing, an
+        admission read) is logged, its unresolved messages re-published, and the
+        feeder backs off and continues rather than silently dying for the rest
+        of the batch.
         """
         while True:
+            # Yield to control signals BEFORE draining more work.
+            if (
+                ctx.pipeline_cancel_event is not None
+                and ctx.pipeline_cancel_event.is_set()
+            ):
+                return
+            if ingress.peek_next_manual_retry() is not None:
+                return
+
+            batch: list = []
+            reached = 0
+            undecided: list = []
             try:
                 batch = await self._feeder_next_batch(ingress)
-                doc_ids = [msg.doc_id for msg in batch if msg.doc_id]
-                if not doc_ids:
-                    continue
-                try:
+                if any(msg.doc_id for msg in batch):
                     pending = await self.doc_status.get_docs_by_statuses(
                         [DocStatus.PENDING], strict=True
                     )
-                except Exception as read_error:
-                    # Transient doc_status read: drop this drain (its messages
-                    # are committed PENDING rows recovered by request_pending on
-                    # the next batch). Logged so a persistent fault silently
-                    # zeroing feeder throughput stays diagnosable.
-                    logger.debug(
-                        "[feeder] doc_status read failed, dropping drain of "
-                        f"{len(doc_ids)} doc(s) (request_pending recovers): "
-                        f"{read_error}"
-                    )
-                    continue
-                for doc_id in doc_ids:
-                    async with ctx.pipeline_status_lock:
-                        duplicate = (
-                            doc_id in ctx.routing_doc_ids
-                            or doc_id in ctx.inflight_doc_ids
-                        )
-                    if duplicate:
-                        continue
-                    status_doc = pending.get(doc_id)
-                    if status_doc is None:
-                        continue  # not PENDING (processed/failed/deleted) — stale
-                    if doc_status_custom_chunk_patch(status_doc) is not None:
-                        continue  # journaled → scan/custom-chunk recovery owns it
-                    try:
-                        full_doc = await self.full_docs.get_by_id(doc_id)
-                    except Exception as read_error:
-                        logger.debug(
-                            f"[feeder] full_docs read failed for {doc_id}, "
-                            f"skipping (request_pending recovers): {read_error}"
-                        )
-                        continue
-                    if not full_doc:
-                        continue  # not yet visible (ryw lag); request_pending recovers
-                    await self._admit_fed_document(ctx, doc_id, status_doc)
+                    for reached, msg in enumerate(batch):
+                        if not await self._route_one(ctx, msg, pending):
+                            undecided.append(msg)  # SKIP — carry for re-publish
+                reached = len(batch)  # every message reached a decision
             except asyncio.CancelledError:
-                raise  # cooperative stop (quiescence or teardown)
+                # Teardown/quiescence stop: restore the messages this drain
+                # removed but did not resolve (unreached tail + skipped). On a
+                # normal quiescence stop the feeder is parked between drains, so
+                # both are empty and this restores nothing.
+                self._republish_documents(ingress, [*batch[reached:], *undecided])
+                raise
             except Exception as feeder_error:
-                # A wait-RPC failure, an engine-routing error, or an admission
-                # read fault must not silently disable the accelerator for the
-                # rest of the batch. Log, back off (so a persistent fault does
-                # not tight-loop), and continue; the docs stay PENDING and are
-                # recovered by request_pending.
                 logger.warning(
                     "[feeder] in-batch feeder iteration failed (batch continues; "
                     f"request_pending recovers docs): {feeder_error}"
                 )
+                self._republish_documents(ingress, [*batch[reached:], *undecided])
                 await asyncio.sleep(_FEEDER_POLL_SECONDS)
 
     async def _run_pipeline_batch(

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -22,7 +22,7 @@ import threading
 import time
 import traceback
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from functools import lru_cache
@@ -51,6 +51,7 @@ from lightrag.kg.shared_storage import (
     get_pipeline_ingress,
     run_to_completion,
 )
+from lightrag.kg.pipeline_ingress import PipelineIngressMessage
 from lightrag.operate import merge_nodes_and_edges
 from lightrag.parser.base import ParseContext
 from lightrag.parser.llm_bridge import LLMBridgePipelineCancelled
@@ -135,6 +136,13 @@ _AUTO_RESUME_DOC_STATUSES = (
 # after their reset-to-PENDING persists — so a doc that fails AGAIN inside
 # that run stays FAILED until the next explicit human request (no retry loop).
 _MANUAL_RETRY_DOC_STATUSES = (*_AUTO_RESUME_DOC_STATUSES, DocStatus.FAILED)
+
+# Multiprocess feeder poll interval: the Manager-backed ingress has no async
+# ``get_document``, so the feeder blocks a worker thread in
+# ``wait_for_documents(timeout)`` and re-checks between polls. Bounded by the
+# mailbox's own MAX_MAILBOX_WAIT_SECONDS clamp; the single-process feeder is
+# fully event-driven (``await get_document()``) and never polls.
+_FEEDER_POLL_SECONDS = 0.5
 
 
 class PipelineNextStep(Enum):
@@ -300,6 +308,19 @@ class _BatchRunContext:
     # lock directly while waiting on an LLM response.
     pipeline_cancel_event: threading.Event | None = None
     processed_count: int = 0
+    # Phase 2 in-batch feeder bookkeeping (all read/written ONLY under
+    # ``pipeline_status_lock``):
+    #  * ``inflight_doc_ids`` — every doc_id currently routed into or moving
+    #    through the queues. The initial batch is pre-registered before the
+    #    feeder starts; the feeder adds an id right after its parse-queue put
+    #    succeeds.
+    #  * ``routing_doc_ids`` — ids being admitted right now (added before the
+    #    ``put``, moved to inflight after it with no ``await`` between the two
+    #    mutations) so the feeder's dedup sees an id the instant admission
+    #    begins — there is never a window where an admitting id is in neither
+    #    set.
+    inflight_doc_ids: set = field(default_factory=set)
+    routing_doc_ids: set = field(default_factory=set)
 
 
 class _PipelineMixin:
@@ -908,6 +929,13 @@ class _PipelineMixin:
                 logger.warning("No new unique documents were found.")
                 return
 
+            # Ingress handle for the Phase 2 dual-write below: a document
+            # notification per newly-stored doc (the feeder's accelerator) and
+            # an auto-rescan flag on a partial doc_status commit. request_pending
+            # stays as the correctness fallback — the ingress only removes
+            # latency, so anything it drops is still recovered by request_pending.
+            ingress = await get_pipeline_ingress(self.workspace)
+
             # 4. Store document content in full_docs and status in doc_status
             full_docs_data = {
                 doc_id: {
@@ -956,10 +984,17 @@ class _PipelineMixin:
                 # always re-raised.
                 try:
                     async with pipeline_status_lock:
+                        # Partial commit: some PENDING rows may have landed.
+                        # Arm the INFALLIBLE in-process anchor FIRST so a failing
+                        # ingress RPC below can never leave the committed rows
+                        # with no wake-up signal at all; THEN arm the auto-rescan
+                        # flag (consumed at the next quiescence point under this
+                        # same lock) as the ingress-side accelerator.
                         if pipeline_status.get("busy"):
                             pipeline_status["request_pending"] = True
                         else:
                             process_after_status_error = True
+                        ingress.request_auto_rescan()
                 except Exception as wake_error:
                     logger.warning(
                         "Failed to wake document processing after enqueue "
@@ -994,15 +1029,38 @@ class _PipelineMixin:
             raise status_upsert_error
 
         # Notify any in-flight processing loop that new work has arrived.
-        # The loop checks ``request_pending`` after each batch and will
-        # re-query doc_status to pick up these PENDING rows.  Without
-        # this nudge a caller that does not subsequently call
-        # ``apipeline_process_enqueue_documents`` (or whose call races
-        # with the loop's just-finished batch) could leave the new docs
-        # stranded until the next unrelated trigger.
+        # ``request_pending`` (set under the lock) is the correctness anchor: a
+        # busy loop checks it after each batch and re-queries doc_status for
+        # these PENDING rows. Without it a caller that does not subsequently
+        # call ``apipeline_process_enqueue_documents`` (or whose call races with
+        # the loop's just-finished batch) could strand the new docs.
         async with pipeline_status_lock:
             if pipeline_status.get("busy"):
                 pipeline_status["request_pending"] = True
+
+        # Phase 2 dual-write: publish a document notification per new doc so a
+        # running batch's feeder routes it immediately (the latency win).
+        # Published AFTER releasing the lock so a large batch never holds
+        # pipeline_status_lock across N ingress RPCs; the feeder is best-effort,
+        # and a notification the feeder misses is still a PENDING row recovered
+        # by request_pending above. Overflow past the bounded channel coalesces
+        # into the auto-rescan flag inside put_document.
+        #
+        # A droppable accelerator side-effect must never fail an enqueue that
+        # already durably committed doc_status and armed request_pending: a
+        # multiprocess ``put_document`` is a Manager RPC that can raise on a
+        # Manager outage, so swallow-and-log rather than escalate a successful
+        # upload into a caller-visible error (the docs are recovered regardless).
+        try:
+            for doc_id in new_docs:
+                ingress.put_document(
+                    PipelineIngressMessage(kind="document", doc_id=doc_id)
+                )
+        except Exception as publish_error:
+            logger.warning(
+                "Ingress document notification failed after a successful enqueue "
+                f"(request_pending still recovers the docs): {publish_error}"
+            )
 
         return track_id
 
@@ -1443,6 +1501,167 @@ class _PipelineMixin:
     # Pipeline orchestration
     # ============================================================
 
+    async def _feeder_next_batch(self, ingress) -> list[PipelineIngressMessage]:
+        """Block until at least one document message is available, then return
+        every message currently in the channel.
+
+        Two ingress flavors (see :mod:`lightrag.kg.pipeline_ingress`):
+
+        * single-process ``AsyncioPipelineIngress`` — fully event-driven:
+          ``await get_document()`` returns one message (pairing ``task_done``),
+          then a non-blocking ``drain_documents`` sweeps the rest.
+        * multiprocess ``ManagerPipelineIngress`` — no async get; block a
+          worker thread in ``wait_for_documents(timeout)`` (a WAIT that never
+          dequeues, so a cancelled/timed-out thread cannot steal a message),
+          then ``drain_documents``.  An empty poll returns ``[]`` and the
+          feeder loops.
+
+        Cancellation stops the feeder: it propagates out of the ``await`` here
+        (nothing dequeued yet) or out of the admission below.  A message that
+        was already drained but not yet routed when cancellation lands is NOT
+        returned to the mailbox — it is recovered by request_pending (the
+        dual-write anchor), exactly as ``_admit_fed_document`` documents.  The
+        two-stage rollback only reverts routing bookkeeping/counters; it never
+        re-publishes.
+        """
+        if hasattr(ingress, "get_document"):
+            first = await ingress.get_document()
+            return [first, *ingress.drain_documents()]
+        await asyncio.to_thread(ingress.wait_for_documents, _FEEDER_POLL_SECONDS)
+        return ingress.drain_documents()
+
+    async def _admit_fed_document(
+        self, ctx: "_BatchRunContext", doc_id: str, status_doc: DocProcessingStatus
+    ) -> None:
+        """Two-stage admission of a feeder-routed document into its parse queue.
+
+        Fixes the ghost-inflight window: the id is registered in
+        ``routing_doc_ids`` (and the batch counters bumped) UNDER the lock
+        BEFORE the bounded-queue ``put`` — which may block and be cancelled —
+        and is only moved into ``inflight_doc_ids`` AFTER the put succeeds, with
+        no ``await`` between the discard and the add.  A cancelled/failed put
+        rolls the registration and counters back so the document is neither
+        double-counted nor permanently shadowed from re-admission; the message
+        itself is recovered by ``request_pending`` (dual-written by enqueue).
+        """
+        file_path = getattr(status_doc, "file_path", "unknown_source")
+        content_data = await self.full_docs.get_by_id(doc_id) or {}
+        key = resolve_stored_document_parser_engine(
+            file_path=file_path, content_data=content_data
+        )
+        spec = ctx.parser_specs.get(key)
+        group = spec.queue_group if spec is not None else "native"
+        queue = ctx.parse_queues.get(group, ctx.parse_queues["native"])
+
+        async with ctx.pipeline_status_lock:
+            ctx.routing_doc_ids.add(doc_id)
+            ctx.total_files += 1
+            ctx.pipeline_status["docs"] = ctx.pipeline_status.get("docs", 0) + 1
+            ctx.pipeline_status["batchs"] = ctx.pipeline_status.get("batchs", 0) + 1
+        try:
+            await queue.put((doc_id, status_doc))
+        except BaseException:
+            async with ctx.pipeline_status_lock:
+                ctx.routing_doc_ids.discard(doc_id)
+                ctx.total_files = max(0, ctx.total_files - 1)
+                ctx.pipeline_status["docs"] = max(
+                    0, ctx.pipeline_status.get("docs", 0) - 1
+                )
+                ctx.pipeline_status["batchs"] = max(
+                    0, ctx.pipeline_status.get("batchs", 0) - 1
+                )
+            raise
+        async with ctx.pipeline_status_lock:
+            # No await between these two mutations: dedup never sees a gap.
+            ctx.routing_doc_ids.discard(doc_id)
+            ctx.inflight_doc_ids.add(doc_id)
+
+    async def _pipeline_feeder(self, ctx: "_BatchRunContext", ingress) -> None:
+        """Route documents that arrive DURING a batch into its parse queues so
+        they process without waiting for the batch barrier.
+
+        Pure accelerator (Phase 2): every message it discards or skips is a
+        PENDING ``doc_status`` row that ``request_pending`` — dual-written by
+        enqueue on the same busy pipeline — recovers on the next batch.  So the
+        feeder never writes ``doc_status`` and never has to re-publish a skipped
+        message; correctness is anchored by the existing request_pending loop,
+        and the feeder only removes latency.
+
+        Per drained message, three outcomes:
+          * ROUTED — PENDING, not already routing/inflight, full_docs visible →
+            two-stage admission into the parse queue;
+          * STALE/TERMINAL — not PENDING (processed/failed/deleted), a
+            duplicate of a routing/inflight id, or a journaled custom-chunk doc
+            (owned by scan/custom-chunk recovery) → dropped;
+          * NEEDS_RECONCILIATION — full_docs not yet visible (read-your-writes
+            lag) or a transient read error → skipped this batch, recovered by
+            request_pending (Phase 3 will reconcile these in-batch instead).
+
+        Stopped by cancellation; see :meth:`_feeder_next_batch`.  Any OTHER
+        per-iteration failure (the wait RPC, engine routing, an admission read)
+        is logged and skipped rather than left to silently kill the accelerator
+        for the rest of the batch — the affected docs stay PENDING and are
+        recovered by request_pending exactly like an intentional skip.
+        """
+        while True:
+            try:
+                batch = await self._feeder_next_batch(ingress)
+                doc_ids = [msg.doc_id for msg in batch if msg.doc_id]
+                if not doc_ids:
+                    continue
+                try:
+                    pending = await self.doc_status.get_docs_by_statuses(
+                        [DocStatus.PENDING], strict=True
+                    )
+                except Exception as read_error:
+                    # Transient doc_status read: drop this drain (its messages
+                    # are committed PENDING rows recovered by request_pending on
+                    # the next batch). Logged so a persistent fault silently
+                    # zeroing feeder throughput stays diagnosable.
+                    logger.debug(
+                        "[feeder] doc_status read failed, dropping drain of "
+                        f"{len(doc_ids)} doc(s) (request_pending recovers): "
+                        f"{read_error}"
+                    )
+                    continue
+                for doc_id in doc_ids:
+                    async with ctx.pipeline_status_lock:
+                        duplicate = (
+                            doc_id in ctx.routing_doc_ids
+                            or doc_id in ctx.inflight_doc_ids
+                        )
+                    if duplicate:
+                        continue
+                    status_doc = pending.get(doc_id)
+                    if status_doc is None:
+                        continue  # not PENDING (processed/failed/deleted) — stale
+                    if doc_status_custom_chunk_patch(status_doc) is not None:
+                        continue  # journaled → scan/custom-chunk recovery owns it
+                    try:
+                        full_doc = await self.full_docs.get_by_id(doc_id)
+                    except Exception as read_error:
+                        logger.debug(
+                            f"[feeder] full_docs read failed for {doc_id}, "
+                            f"skipping (request_pending recovers): {read_error}"
+                        )
+                        continue
+                    if not full_doc:
+                        continue  # not yet visible (ryw lag); request_pending recovers
+                    await self._admit_fed_document(ctx, doc_id, status_doc)
+            except asyncio.CancelledError:
+                raise  # cooperative stop (quiescence or teardown)
+            except Exception as feeder_error:
+                # A wait-RPC failure, an engine-routing error, or an admission
+                # read fault must not silently disable the accelerator for the
+                # rest of the batch. Log, back off (so a persistent fault does
+                # not tight-loop), and continue; the docs stay PENDING and are
+                # recovered by request_pending.
+                logger.warning(
+                    "[feeder] in-batch feeder iteration failed (batch continues; "
+                    f"request_pending recovers docs): {feeder_error}"
+                )
+                await asyncio.sleep(_FEEDER_POLL_SECONDS)
+
     async def _run_pipeline_batch(
         self,
         to_process_docs: dict[str, DocProcessingStatus],
@@ -1482,6 +1701,10 @@ class _PipelineMixin:
             q_analyze=asyncio.Queue(maxsize=self.queue_size_analyze),
             q_process=asyncio.Queue(maxsize=self.queue_size_insert),
             pipeline_cancel_event=threading.Event(),
+            # Pre-register the whole initial batch as inflight BEFORE the feeder
+            # starts, so a document message that echoes an initial-batch doc is
+            # deduplicated the moment the feeder runs.
+            inflight_doc_ids=set(to_process_docs.keys()),
         )
 
         async def _watch_pipeline_cancellation() -> None:
@@ -1562,6 +1785,11 @@ class _PipelineMixin:
         for _ in range(max(1, self.max_parallel_insert)):
             workers.append(asyncio.create_task(self._process_worker(ctx)))
 
+        # In-batch feeder (Phase 2): resolved before the try so its cancellation
+        # is guaranteed by the finally alongside the workers.
+        ingress = await get_pipeline_ingress(self.workspace)
+        feeder_task: asyncio.Task | None = None
+
         # The workers above are live asyncio tasks; their cancellation MUST be
         # guaranteed even if enqueuing or a queue join raises (e.g. an orchestrator-
         # level storage call fails during a backend outage). Without this try/finally
@@ -1598,6 +1826,11 @@ class _PipelineMixin:
                         pipeline_status=pipeline_status,
                         pipeline_status_lock=pipeline_status_lock,
                     )
+                    # This pre-registered doc failed before routing — drop it
+                    # from inflight so the feeder's dedup does not shadow a
+                    # later re-enqueue of the same id.
+                    async with pipeline_status_lock:
+                        ctx.inflight_doc_ids.discard(doc_id)
                     continue
                 # Select the concurrency pool by the engine's queue_group
                 # (snapshot). The worker re-resolves the actual parser per-doc;
@@ -1612,6 +1845,25 @@ class _PipelineMixin:
                 queue = ctx.parse_queues.get(group, ctx.parse_queues["native"])
                 await queue.put((doc_id, status_doc))
 
+            # Start the in-batch feeder now that the initial batch is queued: it
+            # routes documents that arrive DURING this batch straight into the
+            # parse queues (the latency win), so the joins below wait on both
+            # the initial batch and everything the feeder adds.
+            feeder_task = asyncio.create_task(self._pipeline_feeder(ctx, ingress))
+
+            await asyncio.gather(*(q.join() for q in ctx.parse_queues.values()))
+            await ctx.q_analyze.join()
+            await ctx.q_process.join()
+
+            # Queues drained. Stop the feeder (cancel = cooperative stop; a
+            # cancelled parse-queue put rolls back in _admit_fed_document), then
+            # run one more join cascade to absorb anything it routed in the stop
+            # window. With the feeder stopped no new items enter, so this second
+            # cascade is stable. A document message still sitting in the mailbox
+            # stays there and is recovered by request_pending on the next batch.
+            feeder_task.cancel()
+            await asyncio.gather(feeder_task, return_exceptions=True)
+            feeder_task = None
             await asyncio.gather(*(q.join() for q in ctx.parse_queues.values()))
             await ctx.q_analyze.join()
             await ctx.q_process.join()
@@ -1621,9 +1873,14 @@ class _PipelineMixin:
             # response even if task cancellation reaches run_in_executor first.
             ctx.pipeline_cancel_event.set()
             cancellation_watcher.cancel()
+            if feeder_task is not None:
+                feeder_task.cancel()
             for w in workers:
                 w.cancel()
-            await asyncio.gather(*workers, cancellation_watcher, return_exceptions=True)
+            teardown_tasks: list[asyncio.Task] = [*workers, cancellation_watcher]
+            if feeder_task is not None:
+                teardown_tasks.append(feeder_task)
+            await asyncio.gather(*teardown_tasks, return_exceptions=True)
 
         # If the batch aborted on an internal storage error, the shared
         # cross-file flush buffers may still hold records from the documents

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1651,17 +1651,34 @@ class _PipelineMixin:
         return True  # admitted
 
     @staticmethod
-    def _feeder_should_yield(ctx: "_BatchRunContext", ingress) -> bool:
+    def _feeder_should_yield(
+        ctx: "_BatchRunContext", ingress, *, check_auto: bool
+    ) -> bool:
         """True when the feeder must stop admitting and let the batch reach its
-        quiescence point: cancellation requested (so ``/cancel_pipeline`` can
-        complete) or a sticky manual retry request waiting (so an unbounded batch
-        does not starve it). Checked before the drain AND before every single
-        admission, so the yield latency is one admission — not a whole drain.
-        NOT ``has_work()`` — that would busy-loop on a pending manual/auto signal.
+        quiescence point:
+
+        * cancellation requested (so ``/cancel_pipeline`` can complete);
+        * a sticky manual retry request waiting (so an unbounded batch does not
+          starve it) — both re-checked before every single admission, so the
+          yield latency is one admission, not a whole drain;
+        * (``check_auto``, at the top of each drain) the auto-rescan flag is
+          dirty — a document-channel overflow dropped notifications, a partial
+          upsert landed, or one of this feeder's own skips armed it. Yielding
+          hands the batch to its boundary, where the supervisor consumes the
+          flag and its strict rescan recovers those dropped/deferred PENDING
+          docs; without it a sustained stream that never lets the batch reach a
+          boundary would starve them. The feeder only PEEKS the flag (via
+          ``counts``); the supervisor remains its sole consumer.
+
+        NOT ``has_work()`` — that would busy-loop on a pending manual/auto entry.
         """
         if ctx.pipeline_cancel_event is not None and ctx.pipeline_cancel_event.is_set():
             return True
-        return ingress.peek_next_manual_retry() is not None
+        if ingress.peek_next_manual_retry() is not None:
+            return True
+        if check_auto and ingress.counts().get("auto_rescan_pending"):
+            return True
+        return False
 
     async def _pipeline_feeder(self, ctx: "_BatchRunContext", ingress) -> None:
         """Route documents that arrive DURING a batch into its parse queues so
@@ -1703,23 +1720,37 @@ class _PipelineMixin:
         deferred: list = []
         try:
             while True:
-                if self._feeder_should_yield(ctx, ingress):
-                    return
                 batch: list = []
                 reached = 0
                 try:
+                    # Top-of-drain yield check is INSIDE the try so a transient
+                    # manual-peek / counts RPC failure (multiprocess) is logged
+                    # and retried, not left to silently kill the feeder. Includes
+                    # the auto-rescan flag (overflow / partial upsert / this
+                    # feeder's own skips) so a sustained stream still reaches a
+                    # boundary where the supervisor's rescan recovers the dropped
+                    # PENDING docs.
+                    if self._feeder_should_yield(ctx, ingress, check_auto=True):
+                        return
                     batch = await self._feeder_next_batch(ingress)
                     if any(msg.doc_id for msg in batch):
                         pending = await self.doc_status.get_docs_by_statuses(
                             [DocStatus.PENDING], strict=True
                         )
                         for reached, msg in enumerate(batch):
-                            # Honor an in-flight cancel/manual WITHIN one doc.
-                            if self._feeder_should_yield(ctx, ingress):
+                            # Honor an in-flight cancel/manual WITHIN one doc
+                            # (auto-rescan is coarser — checked per drain above).
+                            if self._feeder_should_yield(
+                                ctx, ingress, check_auto=False
+                            ):
                                 deferred.extend(batch[reached:])  # unprocessed tail
                                 return
                             if not await self._route_one(ctx, msg, pending):
                                 deferred.append(msg)  # SKIP — survives to teardown
+                                # Arm the recovery signal so the skip is picked up
+                                # by the supervisor's next rescan even if this
+                                # feeder never otherwise reaches a boundary.
+                                ingress.request_auto_rescan()
                     reached = len(batch)  # every message reached a decision
                 except asyncio.CancelledError:
                     deferred.extend(batch[reached:])  # unprocessed tail → finally

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -144,6 +144,13 @@ _MANUAL_RETRY_DOC_STATUSES = (*_AUTO_RESUME_DOC_STATUSES, DocStatus.FAILED)
 # fully event-driven (``await get_document()``) and never polls.
 _FEEDER_POLL_SECONDS = 0.5
 
+# Max documents the feeder drains (and admits) per iteration before returning
+# to its top-of-loop control check. Bounds the destructive-drain re-publish
+# burst on a teardown; cancellation and a pending manual request are ALSO
+# re-checked before every single admission, so the per-signal yield latency is
+# one admission, not a whole drain.
+_FEEDER_DRAIN_LIMIT = 256
+
 
 class PipelineNextStep(Enum):
     """Outcome of the atomic quiescence decision (see
@@ -1503,35 +1510,39 @@ class _PipelineMixin:
 
     async def _feeder_next_batch(self, ingress) -> list[PipelineIngressMessage]:
         """Block until at least one document message is available, then return
-        every message currently in the channel.
+        up to ``_FEEDER_DRAIN_LIMIT`` messages from the channel.
 
         Two ingress flavors (see :mod:`lightrag.kg.pipeline_ingress`):
 
         * single-process ``AsyncioPipelineIngress`` — fully event-driven:
           ``await get_document()`` returns one message (pairing ``task_done``),
-          then a non-blocking ``drain_documents`` sweeps the rest.
+          then a bounded non-blocking ``drain_documents`` sweeps up to the
+          remaining limit.
         * multiprocess ``ManagerPipelineIngress`` — no async get; block a
           worker thread in ``wait_for_documents(timeout)`` (a WAIT that never
           dequeues, so a cancelled/timed-out thread cannot steal a message),
-          then ``drain_documents``.  An empty poll returns ``[]`` and the
-          feeder loops.
+          then a bounded ``drain_documents``.  An empty poll returns ``[]`` and
+          the feeder loops.
 
-        Cancellation stops the feeder: it propagates out of the ``await`` here
-        (nothing dequeued yet) or out of the admission below.  A message that
-        was already drained but not yet routed when cancellation lands is NOT
-        returned to the mailbox — it is recovered by request_pending (the
-        dual-write anchor), exactly as ``_admit_fed_document`` documents.  The
-        two-stage rollback only reverts routing bookkeeping/counters; it never
-        re-publishes.
+        The drain is bounded so the feeder returns to its control-signal check
+        instead of draining the whole 4096-deep channel in one pass, and so a
+        teardown re-publish never has to restore more than one bounded drain.
+        Cancellation propagates out of the ``await`` here (nothing dequeued
+        yet); a message drained but not routed is carried in the feeder's
+        deferred set and re-published on teardown.
         """
         if hasattr(ingress, "get_document"):
             first = await ingress.get_document()
-            return [first, *ingress.drain_documents()]
+            return [first, *ingress.drain_documents(limit=_FEEDER_DRAIN_LIMIT - 1)]
         await asyncio.to_thread(ingress.wait_for_documents, _FEEDER_POLL_SECONDS)
-        return ingress.drain_documents()
+        return ingress.drain_documents(limit=_FEEDER_DRAIN_LIMIT)
 
     async def _admit_fed_document(
-        self, ctx: "_BatchRunContext", doc_id: str, status_doc: DocProcessingStatus
+        self,
+        ctx: "_BatchRunContext",
+        doc_id: str,
+        status_doc: DocProcessingStatus,
+        content_data: dict,
     ) -> None:
         """Two-stage admission of a feeder-routed document into its parse queue.
 
@@ -1543,11 +1554,14 @@ class _PipelineMixin:
         rolls the registration and counters back so the document is neither
         double-counted nor permanently shadowed from re-admission; the message
         itself is recovered by ``request_pending`` (dual-written by enqueue).
+
+        ``content_data`` is the full_docs row the caller (``_route_one``) already
+        read for its visibility check, reused here for engine routing so
+        admission does not issue a second full_docs read.
         """
         file_path = getattr(status_doc, "file_path", "unknown_source")
-        content_data = await self.full_docs.get_by_id(doc_id) or {}
         key = resolve_stored_document_parser_engine(
-            file_path=file_path, content_data=content_data
+            file_path=file_path, content_data=content_data or {}
         )
         spec = ctx.parser_specs.get(key)
         group = spec.queue_group if spec is not None else "native"
@@ -1633,8 +1647,21 @@ class _PipelineMixin:
             return False  # transient → skip, re-publish on teardown
         if not full_doc:
             return False  # not yet visible (ryw lag) → skip, re-publish on teardown
-        await self._admit_fed_document(ctx, doc_id, status_doc)
+        await self._admit_fed_document(ctx, doc_id, status_doc, full_doc)
         return True  # admitted
+
+    @staticmethod
+    def _feeder_should_yield(ctx: "_BatchRunContext", ingress) -> bool:
+        """True when the feeder must stop admitting and let the batch reach its
+        quiescence point: cancellation requested (so ``/cancel_pipeline`` can
+        complete) or a sticky manual retry request waiting (so an unbounded batch
+        does not starve it). Checked before the drain AND before every single
+        admission, so the yield latency is one admission — not a whole drain.
+        NOT ``has_work()`` — that would busy-loop on a pending manual/auto signal.
+        """
+        if ctx.pipeline_cancel_event is not None and ctx.pipeline_cancel_event.is_set():
+            return True
+        return ingress.peek_next_manual_retry() is not None
 
     async def _pipeline_feeder(self, ctx: "_BatchRunContext", ingress) -> None:
         """Route documents that arrive DURING a batch into its parse queues so
@@ -1657,51 +1684,57 @@ class _PipelineMixin:
         complete under a sustained upload stream that keeps the parse queue
         non-empty) or when a sticky manual retry request is waiting (it is only
         consumed at the batch boundary, so an unbounded batch would starve it).
-        It deliberately does NOT wait on ``has_work()`` — that would busy-loop on
-        a pending manual/auto signal (the document-only wait is the point).
+        This is re-checked before the drain AND before EVERY admission
+        (:meth:`_feeder_should_yield`), so a signal that lands while the feeder
+        is admitting a full drain is honored within one admission, not after up
+        to ``_FEEDER_DRAIN_LIMIT`` more.  It deliberately does NOT wait on
+        ``has_work()`` — that would busy-loop on a pending manual/auto signal.
 
-        An unexpected per-iteration failure (the wait RPC, engine routing, an
-        admission read) is logged, its unresolved messages re-published, and the
-        feeder backs off and continues rather than silently dying for the rest
-        of the batch.
+        **Deferred survives the whole feeder:** SKIPPED messages and a drain's
+        unrouted tail accumulate in a feeder-lifetime ``deferred`` list and are
+        re-published to the mailbox on ANY exit (the ``finally``) — a cancel
+        clears request_pending, so a skip forgotten from an earlier iteration
+        would otherwise be lost.  An unexpected per-iteration failure logs,
+        re-publishes just that drain's tail for retry, backs off, and continues
+        rather than silently dying for the rest of the batch.
         """
-        while True:
-            # Yield to control signals BEFORE draining more work.
-            if (
-                ctx.pipeline_cancel_event is not None
-                and ctx.pipeline_cancel_event.is_set()
-            ):
-                return
-            if ingress.peek_next_manual_retry() is not None:
-                return
-
-            batch: list = []
-            reached = 0
-            undecided: list = []
-            try:
-                batch = await self._feeder_next_batch(ingress)
-                if any(msg.doc_id for msg in batch):
-                    pending = await self.doc_status.get_docs_by_statuses(
-                        [DocStatus.PENDING], strict=True
+        # Feeder-lifetime set: SKIPs (full_docs not yet visible / transient read)
+        # and any drained-but-unrouted tail. Restored to the mailbox on exit.
+        deferred: list = []
+        try:
+            while True:
+                if self._feeder_should_yield(ctx, ingress):
+                    return
+                batch: list = []
+                reached = 0
+                try:
+                    batch = await self._feeder_next_batch(ingress)
+                    if any(msg.doc_id for msg in batch):
+                        pending = await self.doc_status.get_docs_by_statuses(
+                            [DocStatus.PENDING], strict=True
+                        )
+                        for reached, msg in enumerate(batch):
+                            # Honor an in-flight cancel/manual WITHIN one doc.
+                            if self._feeder_should_yield(ctx, ingress):
+                                deferred.extend(batch[reached:])  # unprocessed tail
+                                return
+                            if not await self._route_one(ctx, msg, pending):
+                                deferred.append(msg)  # SKIP — survives to teardown
+                    reached = len(batch)  # every message reached a decision
+                except asyncio.CancelledError:
+                    deferred.extend(batch[reached:])  # unprocessed tail → finally
+                    raise
+                except Exception as feeder_error:
+                    logger.warning(
+                        "[feeder] in-batch feeder iteration failed (batch "
+                        f"continues; request_pending recovers docs): {feeder_error}"
                     )
-                    for reached, msg in enumerate(batch):
-                        if not await self._route_one(ctx, msg, pending):
-                            undecided.append(msg)  # SKIP — carry for re-publish
-                reached = len(batch)  # every message reached a decision
-            except asyncio.CancelledError:
-                # Teardown/quiescence stop: restore the messages this drain
-                # removed but did not resolve (unreached tail + skipped). On a
-                # normal quiescence stop the feeder is parked between drains, so
-                # both are empty and this restores nothing.
-                self._republish_documents(ingress, [*batch[reached:], *undecided])
-                raise
-            except Exception as feeder_error:
-                logger.warning(
-                    "[feeder] in-batch feeder iteration failed (batch continues; "
-                    f"request_pending recovers docs): {feeder_error}"
-                )
-                self._republish_documents(ingress, [*batch[reached:], *undecided])
-                await asyncio.sleep(_FEEDER_POLL_SECONDS)
+                    # Retry just this drain's unprocessed tail; the accumulated
+                    # deferred skips are restored on exit, not bounced each error.
+                    self._republish_documents(ingress, batch[reached:])
+                    await asyncio.sleep(_FEEDER_POLL_SECONDS)
+        finally:
+            self._republish_documents(ingress, deferred)
 
     async def _run_pipeline_batch(
         self,

--- a/tests/pipeline/test_pipeline_ingress_feed.py
+++ b/tests/pipeline/test_pipeline_ingress_feed.py
@@ -310,11 +310,14 @@ def test_feeder_teardown_republishes_undrained_messages(tmp_path):
                 )
 
             # Block the feeder mid-route (in full_docs.get_by_id) so its drained
-            # messages are still unresolved when it is cancelled.
+            # messages are still unresolved when cancelled. Deterministic: the
+            # gate SIGNALS when the feeder has actually entered the read.
+            entered = asyncio.Event()
             gate = asyncio.Event()
             orig_get = rag.full_docs.get_by_id
 
             async def blocking_get(doc_id):
+                entered.set()
                 await gate.wait()
                 return await orig_get(doc_id)
 
@@ -322,7 +325,7 @@ def test_feeder_teardown_republishes_undrained_messages(tmp_path):
 
             ctx = _make_feeder_ctx()
             feeder = asyncio.create_task(rag._pipeline_feeder(ctx, ingress))
-            await asyncio.sleep(0.15)  # feeder drained all 3, blocked on the first
+            await asyncio.wait_for(entered.wait(), timeout=3)  # drained all 3, in route
             feeder.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await feeder
@@ -330,6 +333,107 @@ def test_feeder_teardown_republishes_undrained_messages(tmp_path):
             # All three drained-but-unresolved messages were re-published.
             republished = {m.doc_id for m in ingress.drain_documents()}
             assert republished == ids
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_feeder_republishes_earlier_iteration_skip_on_teardown(tmp_path):
+    """Finding: a SKIP (full_docs not yet visible) from one feeder iteration must
+    survive to a LATER teardown — the deferred set is feeder-lifetime, not
+    per-iteration. Here doc B is skipped (not visible), the feeder then parks on
+    the next wait, and only then is it cancelled; B must still be re-published so
+    a cancel clearing request_pending does not strand it."""
+
+    async def _run():
+        rag = await _build_rag(tmp_path, _MarkerExtract(), max_parallel_insert=1)
+        try:
+            await rag.apipeline_enqueue_documents(input="BODYB", file_paths="b.txt")
+            b_id = compute_mdhash_id("b.txt", prefix="doc-")
+
+            ingress = await get_pipeline_ingress(rag.workspace)
+            ingress.drain_documents()
+            ingress.put_document(PipelineIngressMessage(kind="document", doc_id=b_id))
+
+            # First feeder read: report B not-yet-visible (SKIP) exactly once;
+            # afterwards behave normally so the feeder parks on the next wait.
+            entered = asyncio.Event()
+            orig_get = rag.full_docs.get_by_id
+            skipped_once = {"done": False}
+
+            async def flaky_get(doc_id):
+                if doc_id == b_id and not skipped_once["done"]:
+                    skipped_once["done"] = True
+                    entered.set()
+                    return None  # not visible → _route_one returns False (SKIP)
+                return await orig_get(doc_id)
+
+            rag.full_docs.get_by_id = flaky_get
+
+            ctx = _make_feeder_ctx()
+            feeder = asyncio.create_task(rag._pipeline_feeder(ctx, ingress))
+            await asyncio.wait_for(entered.wait(), timeout=3)  # B skipped this round
+            await asyncio.sleep(0.05)  # feeder parks on the next get_document
+            feeder.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await feeder
+
+            # B — skipped in the earlier iteration — is still re-published.
+            republished = {m.doc_id for m in ingress.drain_documents()}
+            assert b_id in republished
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_feeder_yields_within_one_admission_on_mid_drain_cancel(tmp_path):
+    """Finding: control signals are re-checked before EVERY admission, so a
+    cancel that lands while the feeder is admitting a large drain is honored
+    within one document — not after the whole drain. Here the feeder drains
+    many notifications, admits the first, and a cancel set before the second is
+    honored immediately; the unadmitted tail is re-published."""
+
+    async def _run():
+        rag = await _build_rag(tmp_path, _MarkerExtract(), max_parallel_insert=1)
+        try:
+            # Real PENDING docs so the feeder would route them one by one.
+            n = 8
+            for i in range(n):
+                await rag.apipeline_enqueue_documents(
+                    input=f"BODY{i}", file_paths=f"m{i}.txt"
+                )
+            ids = {compute_mdhash_id(f"m{i}.txt", prefix="doc-") for i in range(n)}
+
+            ingress = await get_pipeline_ingress(rag.workspace)
+            ingress.drain_documents()
+            for doc_id in ids:
+                ingress.put_document(
+                    PipelineIngressMessage(kind="document", doc_id=doc_id)
+                )
+
+            ctx = _make_feeder_ctx()
+            # Trip cancellation the moment the first admission's put happens, so
+            # the per-admission check fires before the second doc.
+            orig_put = ctx.parse_queues["native"].put
+
+            async def cancel_after_first_put(item):
+                await orig_put(item)
+                ctx.pipeline_cancel_event.set()
+
+            ctx.parse_queues["native"].put = cancel_after_first_put
+
+            await asyncio.wait_for(rag._pipeline_feeder(ctx, ingress), timeout=3)
+
+            # Yielded after exactly one admission (fix-proof: without the
+            # per-admission check the feeder would admit all n before its next
+            # top-of-loop check), and the unadmitted tail was re-published so
+            # nothing is lost.
+            admitted = ctx.parse_queues["native"].qsize()
+            assert admitted == 1
+            republished = {m.doc_id for m in ingress.drain_documents()}
+            assert admitted + len(republished) == n
         finally:
             await rag.finalize_storages()
 

--- a/tests/pipeline/test_pipeline_ingress_feed.py
+++ b/tests/pipeline/test_pipeline_ingress_feed.py
@@ -11,6 +11,7 @@ signals are pending), all on a real LightRAG with in-memory JSON storages.
 """
 
 import asyncio
+import threading
 from collections import Counter
 from uuid import uuid4
 
@@ -20,9 +21,25 @@ import pytest
 from lightrag import LightRAG
 from lightrag.kg.pipeline_ingress import PipelineIngressMessage
 from lightrag.kg.shared_storage import get_pipeline_ingress
+from lightrag.pipeline import _BatchRunContext
 from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
 
 pytestmark = pytest.mark.offline
+
+
+def _make_feeder_ctx() -> _BatchRunContext:
+    """Minimal batch context for driving _pipeline_feeder directly."""
+    return _BatchRunContext(
+        pipeline_status={"docs": 0, "batchs": 0, "cur_batch": 0},
+        pipeline_status_lock=asyncio.Lock(),
+        semaphore=asyncio.Semaphore(1),
+        total_files=0,
+        parse_queues={"native": asyncio.Queue()},
+        parser_specs={},
+        q_analyze=asyncio.Queue(),
+        q_process=asyncio.Queue(),
+        pipeline_cancel_event=threading.Event(),
+    )
 
 
 class _SimpleTokenizerImpl:
@@ -201,6 +218,118 @@ def test_pending_manual_signal_does_not_busy_loop_the_feeder(tmp_path):
             await rag.apipeline_process_enqueue_documents()
             assert _status_text(await rag.doc_status.get_by_id(a_id)) == "processed"
             assert extract.calls["AAAA"] == 1
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_feeder_yields_on_cancellation(tmp_path):
+    """Finding: the feeder must STOP admitting when cancellation is requested,
+    or a sustained document stream keeps the parse queue non-empty, the join
+    cascade never returns, and /cancel_pipeline can never complete. With the
+    cancel-event check the feeder returns before draining, letting the batch
+    reach its quiescence point.
+
+    Fix-proof: without the check the feeder drains + loops forever on the mailbox
+    and never returns (this would time out)."""
+
+    async def _run():
+        rag = await _build_rag(tmp_path, _MarkerExtract(), max_parallel_insert=1)
+        try:
+            ingress = await get_pipeline_ingress(rag.workspace)
+            for i in range(50):
+                ingress.put_document(
+                    PipelineIngressMessage(kind="document", doc_id=f"doc-{i}")
+                )
+            ctx = _make_feeder_ctx()
+            ctx.pipeline_cancel_event.set()  # cancellation requested
+
+            await asyncio.wait_for(rag._pipeline_feeder(ctx, ingress), timeout=3)
+
+            # Yielded before draining: nothing admitted, the stream is untouched.
+            assert ctx.parse_queues["native"].qsize() == 0
+            assert ingress.has_work()
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_feeder_yields_when_manual_request_pending(tmp_path):
+    """The feeder stops admitting when a sticky manual retry request is waiting,
+    so an unbounded batch cannot starve it — it is consumed at the batch
+    boundary the feeder now lets the run reach."""
+
+    async def _run():
+        rag = await _build_rag(tmp_path, _MarkerExtract(), max_parallel_insert=1)
+        try:
+            ingress = await get_pipeline_ingress(rag.workspace)
+            for i in range(20):
+                ingress.put_document(
+                    PipelineIngressMessage(kind="document", doc_id=f"doc-{i}")
+                )
+            ingress.request_manual_retry(
+                "req-y",
+                PipelineIngressMessage(
+                    kind="rescan", retry_failed=True, request_id="req-y"
+                ),
+            )
+            ctx = _make_feeder_ctx()
+
+            await asyncio.wait_for(rag._pipeline_feeder(ctx, ingress), timeout=3)
+
+            assert ctx.parse_queues["native"].qsize() == 0  # yielded, admitted nothing
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_feeder_teardown_republishes_undrained_messages(tmp_path):
+    """The document drain is destructive: on a teardown (cancel), messages the
+    feeder had drained but not yet routed or confirmed stale/terminal must go
+    back to the mailbox — a user cancel clears request_pending, so without the
+    restore those PENDING docs would wait for an unrelated future trigger."""
+
+    async def _run():
+        rag = await _build_rag(tmp_path, _MarkerExtract(), max_parallel_insert=1)
+        try:
+            # Three real PENDING rows so the feeder's pending-scan sees them.
+            for i in range(3):
+                await rag.apipeline_enqueue_documents(
+                    input=f"BODY{i}", file_paths=f"d{i}.txt"
+                )
+            ids = {compute_mdhash_id(f"d{i}.txt", prefix="doc-") for i in range(3)}
+
+            ingress = await get_pipeline_ingress(rag.workspace)
+            ingress.drain_documents()  # clear enqueue's own notifications
+            for doc_id in ids:
+                ingress.put_document(
+                    PipelineIngressMessage(kind="document", doc_id=doc_id)
+                )
+
+            # Block the feeder mid-route (in full_docs.get_by_id) so its drained
+            # messages are still unresolved when it is cancelled.
+            gate = asyncio.Event()
+            orig_get = rag.full_docs.get_by_id
+
+            async def blocking_get(doc_id):
+                await gate.wait()
+                return await orig_get(doc_id)
+
+            rag.full_docs.get_by_id = blocking_get
+
+            ctx = _make_feeder_ctx()
+            feeder = asyncio.create_task(rag._pipeline_feeder(ctx, ingress))
+            await asyncio.sleep(0.15)  # feeder drained all 3, blocked on the first
+            feeder.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await feeder
+
+            # All three drained-but-unresolved messages were re-published.
+            republished = {m.doc_id for m in ingress.drain_documents()}
+            assert republished == ids
         finally:
             await rag.finalize_storages()
 

--- a/tests/pipeline/test_pipeline_ingress_feed.py
+++ b/tests/pipeline/test_pipeline_ingress_feed.py
@@ -339,12 +339,13 @@ def test_feeder_teardown_republishes_undrained_messages(tmp_path):
     asyncio.run(_run())
 
 
-def test_feeder_republishes_earlier_iteration_skip_on_teardown(tmp_path):
-    """Finding: a SKIP (full_docs not yet visible) from one feeder iteration must
-    survive to a LATER teardown — the deferred set is feeder-lifetime, not
-    per-iteration. Here doc B is skipped (not visible), the feeder then parks on
-    the next wait, and only then is it cancelled; B must still be re-published so
-    a cancel clearing request_pending does not strand it."""
+def test_feeder_arms_auto_rescan_and_republishes_on_skip(tmp_path):
+    """Finding: a SKIP (full_docs not yet visible) must not be able to starve
+    under a sustained stream that never otherwise reaches a boundary. Skipping B
+    arms the auto-rescan recovery flag (so the supervisor's rescan will pick it
+    up) and, because the flag is now dirty, the feeder yields to the boundary;
+    the feeder-lifetime deferred set re-publishes B on the way out. The feeder
+    only PEEKS auto-rescan — it stays pending for the supervisor to consume."""
 
     async def _run():
         rag = await _build_rag(tmp_path, _MarkerExtract(), max_parallel_insert=1)
@@ -354,34 +355,60 @@ def test_feeder_republishes_earlier_iteration_skip_on_teardown(tmp_path):
 
             ingress = await get_pipeline_ingress(rag.workspace)
             ingress.drain_documents()
+            ingress.consume_auto_rescan()  # clear any flag from enqueue
             ingress.put_document(PipelineIngressMessage(kind="document", doc_id=b_id))
 
-            # First feeder read: report B not-yet-visible (SKIP) exactly once;
-            # afterwards behave normally so the feeder parks on the next wait.
-            entered = asyncio.Event()
+            # B reports not-yet-visible (ryw lag) → _route_one SKIPs it.
             orig_get = rag.full_docs.get_by_id
-            skipped_once = {"done": False}
 
-            async def flaky_get(doc_id):
-                if doc_id == b_id and not skipped_once["done"]:
-                    skipped_once["done"] = True
-                    entered.set()
-                    return None  # not visible → _route_one returns False (SKIP)
-                return await orig_get(doc_id)
+            async def not_visible(doc_id):
+                return None if doc_id == b_id else await orig_get(doc_id)
 
-            rag.full_docs.get_by_id = flaky_get
+            rag.full_docs.get_by_id = not_visible
 
             ctx = _make_feeder_ctx()
-            feeder = asyncio.create_task(rag._pipeline_feeder(ctx, ingress))
-            await asyncio.wait_for(entered.wait(), timeout=3)  # B skipped this round
-            await asyncio.sleep(0.05)  # feeder parks on the next get_document
-            feeder.cancel()
-            with pytest.raises(asyncio.CancelledError):
-                await feeder
+            # Returns on its own: the skip arms auto-rescan, the next top-of-drain
+            # check sees the dirty flag and yields.
+            await asyncio.wait_for(rag._pipeline_feeder(ctx, ingress), timeout=3)
 
-            # B — skipped in the earlier iteration — is still re-published.
+            assert ctx.parse_queues["native"].qsize() == 0  # nothing routed
+            assert (
+                ingress.counts()["auto_rescan_pending"] is True
+            )  # armed, not consumed
             republished = {m.doc_id for m in ingress.drain_documents()}
-            assert b_id in republished
+            assert b_id in republished  # deferred restored on exit
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_feeder_yields_when_auto_rescan_pending(tmp_path):
+    """Finding: a document-channel overflow drops notifications and sets
+    auto_rescan_pending — the recovery signal for those dropped PENDING docs.
+    The feeder must yield on it so the batch reaches a boundary where the
+    supervisor consumes the flag and rescans; otherwise a sustained stream
+    starves the dropped docs. Fix-proof: without the auto check the feeder
+    would drain the (non-PENDING) notifications and then block forever."""
+
+    async def _run():
+        rag = await _build_rag(tmp_path, _MarkerExtract(), max_parallel_insert=1)
+        try:
+            ingress = await get_pipeline_ingress(rag.workspace)
+            for i in range(10):
+                ingress.put_document(
+                    PipelineIngressMessage(kind="document", doc_id=f"doc-{i}")
+                )
+            ingress.request_auto_rescan()  # stand in for the overflow signal
+
+            ctx = _make_feeder_ctx()
+            await asyncio.wait_for(rag._pipeline_feeder(ctx, ingress), timeout=3)
+
+            # Yielded at the top before draining; the flag is left for the
+            # supervisor (the feeder only peeks it).
+            assert ctx.parse_queues["native"].qsize() == 0
+            assert ingress.counts()["auto_rescan_pending"] is True
+            assert ingress.has_work()  # the notifications are untouched
         finally:
             await rag.finalize_storages()
 

--- a/tests/pipeline/test_pipeline_ingress_feed.py
+++ b/tests/pipeline/test_pipeline_ingress_feed.py
@@ -1,0 +1,207 @@
+"""In-batch feeder (Phase 2): documents that arrive DURING a running batch are
+routed into that batch's parse queues instead of waiting for the per-batch
+barrier.
+
+The feeder is a pure accelerator — anything it drops/skips is a PENDING
+``doc_status`` row that ``request_pending`` (dual-written by enqueue on the
+same busy pipeline) recovers on the next batch — so these tests pin the
+latency win (fed doc completes while an earlier doc is still stuck) and the
+safety invariants (dedup against inflight, no busy loop when only manual/auto
+signals are pending), all on a real LightRAG with in-memory JSON storages.
+"""
+
+import asyncio
+from collections import Counter
+from uuid import uuid4
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG
+from lightrag.kg.pipeline_ingress import PipelineIngressMessage
+from lightrag.kg.shared_storage import get_pipeline_ingress
+from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
+
+pytestmark = pytest.mark.offline
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _dummy_embedding(texts: list[str]) -> np.ndarray:
+    return np.ones((len(texts), 8), dtype=float)
+
+
+async def _dummy_llm(*args, **kwargs) -> str:
+    return "ok"
+
+
+def _chunking(tokenizer, content, *args) -> list[dict]:
+    return [{"tokens": 1, "content": f"{content}::chunk1", "chunk_order_index": 0}]
+
+
+class _MarkerExtract:
+    """Process-layer extraction that counts calls per document marker and can
+    block whichever marker is armed until released."""
+
+    def __init__(self):
+        self.calls: Counter = Counter()
+        self.block_marker: str | None = None
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def __call__(self, chunks, *args, **kwargs):
+        content = " ".join(str(v.get("content", "")) for v in chunks.values())
+        marker = content.split(" ", 1)[0] if content else ""
+        self.calls[marker] += 1
+        if self.block_marker and self.block_marker in content:
+            self.started.set()
+            await self.release.wait()
+        return [({}, {}) for _ in chunks]
+
+
+async def _build_rag(tmp_path, extract, *, max_parallel_insert: int) -> LightRAG:
+    rag = LightRAG(
+        working_dir=str(tmp_path / "wd"),
+        workspace=f"feed-{uuid4().hex[:8]}",
+        llm_model_func=_dummy_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8, max_token_size=8192, func=_dummy_embedding
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        chunking_func=_chunking,
+        max_parallel_insert=max_parallel_insert,
+    )
+    await rag.initialize_storages()
+    rag._process_extract_entities = extract
+    return rag
+
+
+def _status_text(row) -> str:
+    status = row["status"]
+    return getattr(status, "value", str(status)).replace("DocStatus.", "").lower()
+
+
+async def _wait_status(rag, doc_id, target: str, timeout: float = 5.0) -> None:
+    async def _poll():
+        while True:
+            row = await rag.doc_status.get_by_id(doc_id)
+            if row and _status_text(row) == target:
+                return
+            await asyncio.sleep(0.02)
+
+    await asyncio.wait_for(_poll(), timeout=timeout)
+
+
+def test_document_arriving_mid_batch_is_fed_without_waiting(tmp_path):
+    """Fix-proof: doc A blocks in the process stage; doc B enqueued DURING A's
+    batch is routed by the feeder and reaches PROCESSED while A is still stuck.
+
+    Without the feeder, B would only be picked up after A's batch finishes
+    (request_pending → next batch), but A's batch cannot finish while A is
+    blocked — so B would never complete and this would time out."""
+
+    async def _run():
+        extract = _MarkerExtract()
+        extract.block_marker = "AAAA"
+        # Two process workers so A blocking one does not starve B.
+        rag = await _build_rag(tmp_path, extract, max_parallel_insert=2)
+        try:
+            await rag.apipeline_enqueue_documents(input="AAAA body", file_paths="a.txt")
+            a_id = compute_mdhash_id("a.txt", prefix="doc-")
+            b_id = compute_mdhash_id("b.txt", prefix="doc-")
+
+            proc = asyncio.create_task(rag.apipeline_process_enqueue_documents())
+            await asyncio.wait_for(extract.started.wait(), timeout=5)  # A blocked
+
+            # Enqueue B while A's batch is running and busy.
+            await rag.apipeline_enqueue_documents(input="BBBB body", file_paths="b.txt")
+
+            # The feeder routes B into A's running batch; B finishes without
+            # waiting for A.
+            await _wait_status(rag, b_id, "processed")
+            a_row = await rag.doc_status.get_by_id(a_id)
+            assert _status_text(a_row) != "processed"  # A still stuck
+
+            extract.release.set()
+            await asyncio.wait_for(proc, timeout=5)
+            assert _status_text(await rag.doc_status.get_by_id(a_id)) == "processed"
+            assert extract.calls["AAAA"] == 1
+            assert extract.calls["BBBB"] == 1
+        finally:
+            extract.release.set()
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_feeder_deduplicates_inflight_document_message(tmp_path):
+    """A document message that echoes an id already inflight (the initial batch
+    doc, or one the feeder already routed) is dropped, not re-routed — the doc
+    is extracted exactly once."""
+
+    async def _run():
+        extract = _MarkerExtract()
+        extract.block_marker = "AAAA"
+        rag = await _build_rag(tmp_path, extract, max_parallel_insert=2)
+        try:
+            await rag.apipeline_enqueue_documents(input="AAAA body", file_paths="a.txt")
+            a_id = compute_mdhash_id("a.txt", prefix="doc-")
+
+            proc = asyncio.create_task(rag.apipeline_process_enqueue_documents())
+            await asyncio.wait_for(extract.started.wait(), timeout=5)  # A inflight
+
+            # Publish a stale document notification for A (already inflight).
+            ingress = await get_pipeline_ingress(rag.workspace)
+            ingress.put_document(PipelineIngressMessage(kind="document", doc_id=a_id))
+            # Let the feeder observe and drop it.
+            await asyncio.sleep(0.1)
+
+            extract.release.set()
+            await asyncio.wait_for(proc, timeout=5)
+            assert _status_text(await rag.doc_status.get_by_id(a_id)) == "processed"
+            assert extract.calls["AAAA"] == 1  # not double-routed
+        finally:
+            extract.release.set()
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_pending_manual_signal_does_not_busy_loop_the_feeder(tmp_path):
+    """The feeder waits ONLY on the document channel: a sticky manual-retry
+    request pending on the ingress must not spin the feeder (which would starve
+    the event loop). A's batch still completes normally and its extract runs
+    exactly once — a busy loop would inflate the count or stall A."""
+
+    async def _run():
+        extract = _MarkerExtract()  # no block marker: A flows straight through
+        rag = await _build_rag(tmp_path, extract, max_parallel_insert=1)
+        try:
+            await rag.apipeline_enqueue_documents(input="AAAA body", file_paths="a.txt")
+            a_id = compute_mdhash_id("a.txt", prefix="doc-")
+
+            # Arm a sticky manual retry request on the ingress. It sets the
+            # work_event; a feeder that waited on has_work() (three channels)
+            # would busy-loop on it. The feeder waits document-only, so it stays
+            # parked and A completes.
+            ingress = await get_pipeline_ingress(rag.workspace)
+            ingress.request_manual_retry(
+                "req-x",
+                PipelineIngressMessage(
+                    kind="rescan", retry_failed=True, request_id="req-x"
+                ),
+            )
+
+            await rag.apipeline_process_enqueue_documents()
+            assert _status_text(await rag.doc_status.get_by_id(a_id)) == "processed"
+            assert extract.calls["AAAA"] == 1
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())


### PR DESCRIPTION
Stacked on #3459 (Phase 0). Third phase of the `request_pending` → workspace ingress migration (order 1 → 0 → **2** → 3 → 4).

## Problem
`_run_pipeline_batch` routed a **fixed snapshot** of docs into the parse→analyze→process queues then `await`ed `q.join()` on each. A large doc blocked every doc enqueued afterward until the whole batch finished — the original defect this migration targets.

## Fix: in-batch feeder (pure accelerator)
An in-batch feeder coroutine routes documents that arrive **during** a running batch straight into its parse queues, so they process without waiting for the barrier. **`request_pending` (still dual-written by enqueue on a busy pipeline) remains the correctness anchor** — anything the feeder drops/skips/loses is a PENDING `doc_status` row recovered by the existing `request_pending → _decide_pipeline_next_step → next-batch` loop. The feeder never writes `doc_status`.

- **enqueue dual-write** — after `doc_status.upsert`, publish one document notification per new doc (after releasing `pipeline_status_lock`, so a large batch never holds it across N ingress RPCs); keep `request_pending`; arm `request_auto_rescan` on a partial commit (infallible anchor set *before* the fragile RPC).
- **`_admit_fed_document`** two-stage admission — register routing + bump counters under the lock BEFORE the bounded-queue `put`, move routing→inflight AFTER it with no `await` between (no dedup gap), roll both back on a cancelled/failed put (no ghost inflight, no double count).
- **`_pipeline_feeder`** waits ONLY on the document channel (single-process `get_document` / multiprocess `wait_for_documents`+`drain` via `to_thread`), so a pending manual/auto signal can't busy-loop it; three-way admission ROUTED / STALE-or-terminal / skip-and-recover.
- **`_run_pipeline_batch`** handshake — route initial batch → spawn feeder → join cascade → cancel feeder → second (stable) join cascade → finally cancels workers + feeder.

Deferred to **Phase 3** (needs the has_work-only exit): explicit in-batch reconciliation of skipped docs and a `CONTINUE_DOCUMENT` quiescence branch — in Phase 2 `request_pending` covers both.

## Self-review
Ran code-reviewer + silent-failure-hunter adversarially. **Both found the core correctness sound — no state-corrupting or stranding defect on any traced interleaving** (handshake, two-stage admission, dedup, dual-write ordering). Applied their observability hardening:
- feeder loop guarded — an unexpected per-iteration fault (wait RPC, engine routing, an admission read) logs + backs off + continues instead of silently killing the accelerator for the rest of the batch;
- the two safe read swallows log at debug so a persistent fault zeroing feeder throughput is diagnosable;
- `put_document` publish wrapped — a Manager-RPC failure no longer escalates a fully-committed enqueue into a caller-visible error;
- fixed a docstring that misstated the recovery contract (rollback does not re-publish; `request_pending` recovers).

## Tests
`tests/pipeline/test_pipeline_ingress_feed.py`:
- **fix-proof** — doc B enqueued while doc A blocks reaches PROCESSED without waiting for A (verified to time out with the feeder disabled, pass with it enabled);
- inflight dedup — a stale notification for an inflight doc is dropped, doc extracted once;
- document-only wait — a pending sticky manual request does not busy-loop the feeder.

Full suite: **4151 passed, 36 skipped**. Ruff format/check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)