### PR TITLE
feat(pipeline): has_work-only atomic exit + cancellation/recovery closure (ingress Phase 3)

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -3616,6 +3616,7 @@ def create_document_routes(
         from lightrag.kg.shared_storage import (
             get_namespace_data,
             get_namespace_lock,
+            get_pipeline_ingress,
         )
 
         # Get pipeline status and lock
@@ -3667,6 +3668,32 @@ def create_document_routes(
                 del pipeline_status["history_messages"][:]
                 pipeline_status["history_messages"].append(
                     "Starting document clearing process"
+                )
+
+            # We own busy+destructive: every document the mailbox refers to is
+            # about to be dropped, so clear the ingress alongside the
+            # ``request_pending`` reset above — un-ACKed manual retry requests
+            # are retired as CANCELLED_BY_CLEAR (a delayed replay of the same
+            # request id is refused), and the document/auto channels are
+            # emptied.  ``destructive_busy`` already refuses new enqueues, so
+            # nothing repopulates the mailbox during the drop.  Clearing
+            # BEFORE the drops means a later partial drop failure has already
+            # retired manual requests for still-live FAILED docs — acceptable
+            # under the destructive intent and surfaced via partial_success.
+            # A failure here only degrades: residual stale messages are
+            # compacted by the next run's consumption idempotence, and a
+            # surviving sticky request strict-scans the emptied doc_status and
+            # ACKs harmlessly.
+            try:
+                ingress = await get_pipeline_ingress(rag.workspace)
+                ingress.clear()
+            except Exception as ingress_clear_error:
+                logger.warning(
+                    "/documents/clear: failed to clear the pipeline ingress "
+                    "mailbox; safe to continue — residual document messages "
+                    "are compacted by the next run and a surviving manual "
+                    "retry request ACKs harmlessly against the emptied "
+                    f"doc_status: {ingress_clear_error}"
                 )
 
             # Use drop method to clear all data

--- a/lightrag/kg/pipeline_ingress.py
+++ b/lightrag/kg/pipeline_ingress.py
@@ -178,6 +178,8 @@ class PipelineIngress(Protocol):
 
     def put_document(self, msg: PipelineIngressMessage) -> None: ...
 
+    def put_documents(self, msgs: List[PipelineIngressMessage]) -> None: ...
+
     def request_auto_rescan(self) -> None: ...
 
     def consume_auto_rescan(self) -> bool: ...
@@ -241,12 +243,31 @@ class PipelineIngressMailbox:
         """
         _validate_document_message(msg)
         with self._cond:
-            if len(self._documents) >= self._document_capacity:
-                self._document_overflows += 1
-                self._auto_rescan_pending = True
-            else:
-                self._documents.append(msg)
+            self._put_document_locked(msg)
             self._cond.notify_all()
+
+    def put_documents(self, msgs: List[PipelineIngressMessage]) -> None:
+        """Publish a batch of document notifications in ONE server-side call.
+
+        Exists so a producer can publish inside the same
+        ``pipeline_status_lock`` critical section that the consumer's atomic
+        exit decision runs under, without holding that lock across N Manager
+        RPCs.  Per-message semantics are identical to :meth:`put_document`
+        (validation, overflow coalescing into the auto-rescan flag).
+        """
+        for msg in msgs:
+            _validate_document_message(msg)
+        with self._cond:
+            for msg in msgs:
+                self._put_document_locked(msg)
+            self._cond.notify_all()
+
+    def _put_document_locked(self, msg: PipelineIngressMessage) -> None:
+        if len(self._documents) >= self._document_capacity:
+            self._document_overflows += 1
+            self._auto_rescan_pending = True
+        else:
+            self._documents.append(msg)
 
     def request_auto_rescan(self) -> None:
         with self._cond:
@@ -438,6 +459,11 @@ class PipelineIngressHub:
     def put_document(self, namespace: str, msg: PipelineIngressMessage) -> None:
         self._mailbox(namespace).put_document(msg)
 
+    def put_documents(
+        self, namespace: str, msgs: List[PipelineIngressMessage]
+    ) -> None:
+        self._mailbox(namespace).put_documents(msgs)
+
     def request_auto_rescan(self, namespace: str) -> None:
         self._mailbox(namespace).request_auto_rescan()
 
@@ -494,6 +520,7 @@ class _PipelineIngressHubProxy(BaseProxy):
 
     _exposed_ = (
         "put_document",
+        "put_documents",
         "request_auto_rescan",
         "request_manual_retry",
         "consume_auto_rescan",
@@ -510,6 +537,11 @@ class _PipelineIngressHubProxy(BaseProxy):
 
     def put_document(self, namespace: str, msg: PipelineIngressMessage) -> None:
         self._callmethod("put_document", (namespace, msg))
+
+    def put_documents(
+        self, namespace: str, msgs: List[PipelineIngressMessage]
+    ) -> None:
+        self._callmethod("put_documents", (namespace, msgs))
 
     def request_auto_rescan(self, namespace: str) -> None:
         self._callmethod("request_auto_rescan", (namespace,))
@@ -569,6 +601,11 @@ class ManagerPipelineIngress:
     def put_document(self, msg: PipelineIngressMessage) -> None:
         _validate_document_message(msg)  # fail at the call site, pre-RPC
         self._hub.put_document(self.namespace, msg)
+
+    def put_documents(self, msgs: List[PipelineIngressMessage]) -> None:
+        for msg in msgs:
+            _validate_document_message(msg)  # fail at the call site, pre-RPC
+        self._hub.put_documents(self.namespace, msgs)
 
     def request_auto_rescan(self) -> None:
         self._hub.request_auto_rescan(self.namespace)
@@ -679,6 +716,18 @@ class AsyncioPipelineIngress:
         else:
             self.document_messages.put_nowait(msg)
         self.work_event.set()
+
+    def put_documents(self, msgs: List[PipelineIngressMessage]) -> None:
+        """Batch variant of :meth:`put_document` (same per-message semantics).
+
+        Single-process publishing is same-loop synchronous, so this is pure
+        API symmetry with the Manager-backed flavor's single-RPC batch —
+        including whole-batch validation before anything is enqueued.
+        """
+        for msg in msgs:
+            _validate_document_message(msg)
+        for msg in msgs:
+            self.put_document(msg)
 
     def request_auto_rescan(self) -> None:
         self._auto_rescan_pending = True

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -96,6 +96,7 @@ from lightrag.kg.shared_storage import (
     get_default_workspace,
     set_default_workspace,
     get_namespace_lock,
+    get_pipeline_ingress,
     get_storage_keyed_lock,
     with_reservation_lock,
 )
@@ -1989,6 +1990,27 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             # pending buffers — doing so could commit or tear down another
             # running job's in-flight index ops.
             if busy_acquired:
+                # The handoff decision consults the ingress mailbox alongside
+                # the transitional ``request_pending`` flag: work that arrived
+                # while we held busy may live only in the mailbox (a document
+                # message, the auto-rescan flag, or a sticky manual retry
+                # request that was refused a drive because WE were the busy
+                # holder).  A resolve/probe failure fails TOWARD handoff: the
+                # driven run re-probes the mailbox itself, so a transient
+                # flake self-heals, and a persistent failure raises inside
+                # that run whose finally releases busy — never a wedge, while
+                # releasing here instead would silently defer a committed
+                # manual retry or an enqueued document to the next unrelated
+                # trigger.
+                try:
+                    handoff_ingress = await get_pipeline_ingress(self.workspace)
+                except Exception as ingress_error:
+                    handoff_ingress = None
+                    logger.warning(
+                        "custom-chunks exit: pipeline ingress unavailable; "
+                        "failing toward handoff so mailbox-only work is not "
+                        f"silently deferred: {ingress_error}"
+                    )
 
                 def _exit_action(status):
                     # Clear cancellation (mirroring the processing loop) and
@@ -2007,7 +2029,20 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         "cancellation_reason": None,
                         "cancellation_detail": None,
                     }
-                    if status.get("request_pending"):
+                    if handoff_ingress is None:
+                        ingress_has_work = True  # fail toward handoff
+                    else:
+                        try:
+                            ingress_has_work = handoff_ingress.has_work()
+                        except Exception as probe_error:
+                            ingress_has_work = True  # fail toward handoff
+                            logger.warning(
+                                "custom-chunks exit: ingress has_work probe "
+                                "failed; handing off so a committed manual "
+                                "retry or enqueued document is not silently "
+                                f"deferred: {probe_error}"
+                            )
+                    if status.get("request_pending") or ingress_has_work:
                         status.update(updates)
                         return "handoff"  # keep busy (owner stays ours)
                     updates.update({"busy": False, "busy_owner": None})

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -159,6 +159,15 @@ class PipelineNextStep(Enum):
     RELEASED = "released"
     CONTINUE_AUTO = "continue_auto"
     CONTINUE_MANUAL = "continue_manual"
+    # Document messages still resident in the mailbox at quiescence (e.g. an
+    # enqueue that landed after the batch's feeder stopped, or a stale
+    # notification for a doc that has since reached a terminal state).  The
+    # refetch drains a bounded chunk and lets the strict scan decide: live
+    # docs come back as the next batch, provably-stale messages are dropped.
+    CONTINUE_DOCUMENT = "continue_document"
+    # Cancellation pending: the run must stop WITHOUT consuming any wake-up
+    # signal — the ingress is fully retained for the next explicit trigger.
+    CANCELLED = "cancelled"
 
 
 @dataclass(frozen=True)
@@ -167,6 +176,9 @@ class PipelineNextDecision:
     # Set only for CONTINUE_MANUAL: the sticky request this continuation
     # serves; ACKed after the FAILED→PENDING reset persists.
     manual_request_id: str | None = None
+    # Set only for CANCELLED: True when the cancellation is an internal-error
+    # abort, whose exit path surfaces the actionable halt message.
+    internal_error: bool = False
 
 
 @lru_cache(maxsize=64)
@@ -1169,11 +1181,18 @@ class _PipelineMixin:
         the no-work path, on a get-docs failure, and via the loop's finally —
         so a handoff can never wedge the pipeline as permanently busy.
         """
+        # Workspace snapshot: status, lock and ingress all resolve through the
+        # value captured at entry, so one run can never straddle two
+        # coordination namespaces if ``self.workspace`` were reassigned
+        # mid-run.  This pins the coordination layer only — the storages were
+        # bound at init and switching workspaces on a live instance stays
+        # unsupported.
+        run_workspace = self.workspace
         pipeline_status = await get_namespace_data(
-            "pipeline_status", workspace=self.workspace
+            "pipeline_status", workspace=run_workspace
         )
         pipeline_status_lock = get_namespace_lock(
-            "pipeline_status", workspace=self.workspace
+            "pipeline_status", workspace=run_workspace
         )
 
         # Owner token for this run's ``busy`` reservation. A handed-off run
@@ -1253,7 +1272,7 @@ class _PipelineMixin:
             # manual request pending, this run IS the rescan: absorb the
             # auto-rescan dirty flag so quiescence doesn't re-trigger for work
             # this very scan already picks up.
-            ingress = await get_pipeline_ingress(self.workspace)
+            ingress = await get_pipeline_ingress(run_workspace)
             pending_manual_ack: str | None = None
             manual_msg = ingress.peek_next_manual_retry()
             if manual_msg is not None:
@@ -1297,6 +1316,11 @@ class _PipelineMixin:
                 if decision.step is PipelineNextStep.RELEASED:
                     # No pending work: slot released silently, finally is a no-op.
                     holds_busy = False
+                    return
+                if decision.step is PipelineNextStep.CANCELLED:
+                    # Nothing was processed and nothing was consumed: stop —
+                    # the finally resets the cancellation state (surfacing the
+                    # internal halt when applicable) and releases the slot.
                     return
                 # A wake-up signal was pending: re-fetch per the decision and
                 # fall through into the loop to process it.
@@ -1359,6 +1383,10 @@ class _PipelineMixin:
                     if decision.step is PipelineNextStep.RELEASED:
                         busy_released_in_loop = True
                         break
+                    if decision.step is PipelineNextStep.CANCELLED:
+                        if decision.internal_error:
+                            break  # finally surfaces the actionable halt
+                        continue  # loop-top handler does the cancel bookkeeping
                     (
                         to_process_docs,
                         pending_manual_ack,
@@ -1393,6 +1421,10 @@ class _PipelineMixin:
                     if decision.step is PipelineNextStep.RELEASED:
                         busy_released_in_loop = True
                         break
+                    if decision.step is PipelineNextStep.CANCELLED:
+                        if decision.internal_error:
+                            break  # finally surfaces the actionable halt
+                        continue  # loop-top handler does the cancel bookkeeping
                     (
                         to_process_docs,
                         pending_manual_ack,
@@ -1415,20 +1447,34 @@ class _PipelineMixin:
                     to_process_docs,
                     pipeline_status=pipeline_status,
                     pipeline_status_lock=pipeline_status_lock,
+                    ingress=ingress,
                 )
 
                 # Atomic exit handoff: if a wake-up signal arrived during this
-                # batch (a manual retry request, the auto-rescan flag, or a
-                # request_pending set by a concurrent enqueue while busy=True),
-                # consume it and refetch.  Otherwise release ``busy`` under
-                # the SAME lock so a concurrent publisher cannot squeeze a
-                # signal past us into a now-stranded state.
+                # batch (a manual retry request, the auto-rescan flag, resident
+                # document messages, or a request_pending set by a concurrent
+                # enqueue while busy=True), consume it and refetch.  Otherwise
+                # release ``busy`` under the SAME lock so a concurrent
+                # publisher cannot squeeze a signal past us into a
+                # now-stranded state.  A cancellation observed during the batch
+                # (user cancel or internal-error abort) wins INSIDE the same
+                # critical section and consumes nothing: cancellation stops the
+                # WHOLE run — no new epoch — with the ingress fully retained
+                # for the next explicit trigger.
                 decision = await self._decide_pipeline_next_step(
                     pipeline_status, pipeline_status_lock, ingress
                 )
                 if decision.step is PipelineNextStep.RELEASED:
                     busy_released_in_loop = True
                     break
+                if decision.step is PipelineNextStep.CANCELLED:
+                    if decision.internal_error:
+                        # Break to the finally, whose bookkeeping surfaces the
+                        # actionable halt message and resets the state.
+                        break
+                    # Loop back into the loop-top handler for its "Pipeline
+                    # cancelled" bookkeeping.
+                    continue
 
                 log_message = "Processing additional documents due to pending request"
                 logger.info(log_message)
@@ -1453,9 +1499,9 @@ class _PipelineMixin:
                 if not holds_busy:
                     return
                 logger.info(stopped_message)
-                lock = get_namespace_lock("pipeline_status", workspace=self.workspace)
+                lock = get_namespace_lock("pipeline_status", workspace=run_workspace)
                 status = await get_namespace_data(
-                    "pipeline_status", workspace=self.workspace
+                    "pipeline_status", workspace=run_workspace
                 )
                 async with lock:
                     status_snapshot = status.copy()
@@ -1590,7 +1636,7 @@ class _PipelineMixin:
             ctx.routing_doc_ids.discard(doc_id)
             ctx.inflight_doc_ids.add(doc_id)
 
-    def _republish_documents(self, ingress, messages) -> None:
+    def _republish_documents(self, ingress, messages, *, source: str = "feeder") -> None:
         """Best-effort re-publish of drained-but-unresolved document messages.
 
         The document channel drain is destructive (``drain_documents`` removes
@@ -1601,13 +1647,20 @@ class _PipelineMixin:
         would wait for an unrelated future trigger instead of the next run.  A
         multiprocess ``put_document`` is a Manager RPC; swallow failures — the
         docs are PENDING and still recovered by the next initial scan.
+
+        ``source`` selects the log level: the feeder path stays at debug (its
+        drops are per-message noise backed by request_pending / auto-rescan),
+        while the supervisor's quiescence compensation (``"quiescence"``) logs
+        a warning — there a swallowed drop is one of the last lines that can
+        attribute why a doc waited for an unrelated trigger.
         """
+        log = logger.debug if source == "feeder" else logger.warning
         for msg in messages:
             try:
                 ingress.put_document(msg)
             except Exception as republish_error:
-                logger.debug(
-                    "[feeder] document re-publish failed for "
+                log(
+                    f"[{source}] document re-publish failed for "
                     f"{getattr(msg, 'doc_id', None)}: {republish_error}"
                 )
 
@@ -1773,6 +1826,7 @@ class _PipelineMixin:
         *,
         pipeline_status: dict,
         pipeline_status_lock,
+        ingress,
     ) -> None:
         """Run one batch of pending documents through the parse → analyze →
         process queues.
@@ -1890,9 +1944,10 @@ class _PipelineMixin:
         for _ in range(max(1, self.max_parallel_insert)):
             workers.append(asyncio.create_task(self._process_worker(ctx)))
 
-        # In-batch feeder (Phase 2): resolved before the try so its cancellation
-        # is guaranteed by the finally alongside the workers.
-        ingress = await get_pipeline_ingress(self.workspace)
+        # In-batch feeder (Phase 2): ``ingress`` comes from the caller — the
+        # run resolves it once against its workspace snapshot — so a batch can
+        # never straddle two coordination namespaces; its cancellation is
+        # guaranteed by the finally alongside the workers.
         feeder_task: asyncio.Task | None = None
 
         # The workers above are live asyncio tasks; their cancellation MUST be
@@ -2225,6 +2280,13 @@ class _PipelineMixin:
         (mailbox calls are single in-memory/Manager RPCs; storage queries
         happen strictly outside, in :meth:`_refetch_for_decision`):
 
+        0. **Cancellation** (consumes NOTHING): checked first, INSIDE this
+           critical section — the cancel endpoint sets the flag under the same
+           lock, so a cancel can never land between its own check and a
+           consuming step below.  The run stops with the ingress fully
+           retained; the caller routes an internal-error abort to the finally
+           (which surfaces the halt message) and a user cancel to the loop-top
+           handler (its "Pipeline cancelled" bookkeeping).
         1. **Manual retry** (peeked, NOT consumed): earliest sticky request,
            at most one per quiescence cycle; ACKed only after its
            FAILED→PENDING resets persist, so crashing anywhere in between
@@ -2234,14 +2296,36 @@ class _PipelineMixin:
            :meth:`_refetch_for_decision` — without consumption here,
            ``has_work()`` would stay true forever and ``busy`` could never
            release.
-        3. **request_pending** (transitional dual-write fallback, removed in
+        3. **Document channel non-empty** (peeked via ``counts``, NOT drained):
+           a message published after this batch's feeder stopped, or a stale
+           notification for a doc that has since reached a terminal state.
+           The run stays busy and the CONTINUE_DOCUMENT refetch resolves it —
+           live docs become the next batch, provably-stale messages are
+           compacted (see :meth:`_refetch_for_decision`).  Without this check
+           a doc published into a quiescing run with no other signal would
+           strand in PENDING until an unrelated trigger (transitionally masked
+           by the dual-written ``request_pending``, gone in Phase 4).
+        4. **request_pending** (transitional dual-write fallback, removed in
            Phase 4): consumed with the same CONTINUE_AUTO semantics.
-        4. Nothing pending: release the slot together with its owner token so
-           a later owner-checked release (the finally, or a fresh acquirer)
-           sees the slot as free and unowned — RELEASED, caller breaks and
-           skips clearing ``busy`` in its finally block.
+        5. Nothing pending — ``has_work()`` is false and no transitional flag
+           is set: release the slot together with its owner token so a later
+           owner-checked release (the finally, or a fresh acquirer) sees the
+           slot as free and unowned — RELEASED, caller breaks and skips
+           clearing ``busy`` in its finally block.
+
+        Boundary (documented, not solved here): this closes every
+        published-but-missed handoff, but an enqueue that crashes BETWEEN its
+        doc_status persist and its publish leaves no signal at all — that doc
+        is recovered by the next run's initial strict scan, never by this
+        decision.
         """
         async with pipeline_status_lock:
+            if pipeline_status.get("cancellation_requested", False):
+                return PipelineNextDecision(
+                    PipelineNextStep.CANCELLED,
+                    internal_error=pipeline_status.get("cancellation_reason")
+                    == "internal_error",
+                )
             manual_msg = ingress.peek_next_manual_retry()
             if manual_msg is not None:
                 return PipelineNextDecision(
@@ -2250,6 +2334,8 @@ class _PipelineMixin:
                 )
             if ingress.consume_auto_rescan():
                 return PipelineNextDecision(PipelineNextStep.CONTINUE_AUTO)
+            if ingress.counts().get("documents"):
+                return PipelineNextDecision(PipelineNextStep.CONTINUE_DOCUMENT)
             if pipeline_status.get("request_pending", False):
                 pipeline_status.update({"request_pending": False})
                 return PipelineNextDecision(PipelineNextStep.CONTINUE_AUTO)
@@ -2270,6 +2356,24 @@ class _PipelineMixin:
         signal was already consumed in the decision), while a manual request
         was only peeked and stays sticky on its own.
 
+        CONTINUE_DOCUMENT resolves resident document messages with the same
+        drain→verify protocol the feeder uses, at the supervisor's quiescence
+        point: a bounded destructive drain FIRST, then the strict scan.  The
+        order is the correctness anchor — every drained message's doc that is
+        still live (its PENDING row persisted before its publish, which
+        preceded the drain) is necessarily in the scan result and comes back
+        as the next batch, so a drained message never needs re-publishing;
+        one absent from the scan is PROVABLY stale (terminal/FAILED/deleted —
+        FAILED is manual-only by ruling) and is compacted, which is what
+        keeps a stale notification from holding ``busy`` forever (the
+        has_work-only exit would otherwise livelock on it).  Messages
+        published after the drain stay in the mailbox for the next decision.
+        Crash/failure safety mirrors the feeder's drain: a strict-scan
+        failure re-publishes the drained messages and arms auto-rescan as a
+        backstop before propagating; a SIGKILL — or a Manager response lost
+        AFTER the server executed the drain (at-most-once RPC) — loses only
+        messages whose PENDING rows the next run's initial scan recovers.
+
         Returns ``(docs, pending_manual_ack)`` where ``pending_manual_ack``
         is the request id the caller must ACK once the FAILED→PENDING resets
         persist (post-validation), or immediately on a legitimately-empty
@@ -2279,13 +2383,38 @@ class _PipelineMixin:
             statuses = _MANUAL_RETRY_DOC_STATUSES
         else:
             statuses = _AUTO_RESUME_DOC_STATUSES
+        drained: list[PipelineIngressMessage] = []
+        if decision.step is PipelineNextStep.CONTINUE_DOCUMENT:
+            # Drain BEFORE the scan (see docstring proof). Bounded: a deeper
+            # backlog re-triggers CONTINUE_DOCUMENT on the next decision.
+            drained = ingress.drain_documents(limit=_FEEDER_DRAIN_LIMIT)
         try:
             docs = await self.doc_status.get_docs_by_statuses(
                 list(statuses), strict=True
             )
-        except Exception:
-            if decision.step is PipelineNextStep.CONTINUE_AUTO:
-                ingress.request_auto_rescan()
+        except BaseException:
+            # Compensations must not raise over the original error (multiproc
+            # mailbox calls are RPCs; BaseException here so even an interrupt
+            # in a compensation call cannot displace it): the docs behind a
+            # lost signal are still PENDING rows, recovered by the next run's
+            # initial scan.
+            try:
+                if decision.step is PipelineNextStep.CONTINUE_AUTO:
+                    ingress.request_auto_rescan()
+                elif drained:
+                    self._republish_documents(ingress, drained, source="quiescence")
+                    # Backstop for re-publishes swallowed above: the strict
+                    # rescan behind the flag recovers those PENDING docs.
+                    ingress.request_auto_rescan()
+            except BaseException as compensation_error:
+                logger.warning(
+                    "[pipeline] failed to restore the consumed wake-up signal "
+                    f"after a strict refetch failure ({len(drained)} drained "
+                    f"document message(s), first ids "
+                    f"{[m.doc_id for m in drained[:8]]}); the docs stay "
+                    "PENDING and are recovered by the NEXT explicit trigger, "
+                    f"not automatically: {compensation_error}"
+                )
             raise
         return docs, decision.manual_request_id
 

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1219,6 +1219,19 @@ class _PipelineMixin:
         # sees busy=False and starts a new loop via its own process_enqueue).
         busy_released_in_loop = False
 
+        # Ownership of a consumed-but-not-yet-committed wake-up signal: True
+        # while a destructively-consumed signal (the entry absorb of the auto
+        # flag, or a CONTINUE_AUTO/CONTINUE_DOCUMENT quiescence consumption)
+        # has produced docs that NO batch has taken over yet.  The finally's
+        # cancellation-resistant bookkeeping re-arms auto-rescan whenever the
+        # run exits with this still set — a cancel, a validation failure, or
+        # ANY other escape in that window would otherwise strand the docs:
+        # they are PENDING rows whose channel entries were already drained, so
+        # no other signal is left.  Initialized (with the ingress handle)
+        # BEFORE the try so the finally can always read them.
+        uncommitted_wakeup = False
+        ingress = None
+
         try:
             # Acquire the processing slot BEFORE reading doc_status. The queue
             # read and all downstream work MUST run under ``busy`` so a concurrent
@@ -1300,20 +1313,13 @@ class _PipelineMixin:
                     ingress.request_auto_rescan()
                 raise
 
-            # Ownership of a consumed-but-not-yet-committed wake-up signal.
-            # True while a destructively-consumed signal (the absorbed auto
-            # flag here, or a CONTINUE_AUTO/CONTINUE_DOCUMENT consumption at a
-            # quiescence decision) has produced docs that NO batch has taken
-            # over yet: a cancellation landing in that window exits through
-            # the loop-top handler, which re-arms auto-rescan so the cancel
-            # leaves the ingress as if the run had stopped before consuming
-            # (drained document messages are represented by their PENDING
-            # rows; the auto flag is the canonical lost-notification recovery
-            # signal, same as channel overflow).  Cleared once the consistency
-            # validator has taken the docs over — from there the batch, its
-            # feeder teardown and the PENDING rows own recovery.  An empty
-            # strict result clears it too: a complete scan with nothing to do
-            # means the signal was fully served, not lost.
+            # Take ownership of the absorbed entry signal (see the definition
+            # above the try): restored by the finally on ANY exit until the
+            # consistency validator takes the docs over.  An empty strict
+            # result means the signal was fully served, not lost — the auto
+            # flag is the canonical lost-notification recovery signal and the
+            # drained document messages are represented by their PENDING rows,
+            # same as channel overflow.
             uncommitted_wakeup = absorbed_auto_rescan and bool(to_process_docs)
 
             if not to_process_docs:
@@ -1387,22 +1393,11 @@ class _PipelineMixin:
                         )
                         status_snapshot["history_messages"].append(log_message)
 
-                        # A signal the immediately-preceding decision (or the
-                        # entry absorb) consumed was never handed to a batch:
-                        # restore it so this cancel leaves the ingress as if
-                        # the run had stopped before consuming it.  Failure
-                        # only degrades — the docs are PENDING rows recovered
-                        # by the next explicit trigger's initial scan.
-                        if uncommitted_wakeup:
-                            try:
-                                ingress.request_auto_rescan()
-                            except Exception as restore_error:
-                                logger.warning(
-                                    "[pipeline] failed to restore the consumed "
-                                    "wake-up signal on cancellation (docs stay "
-                                    "PENDING until the next explicit trigger): "
-                                    f"{restore_error}"
-                                )
+                        # A signal consumed by the immediately-preceding
+                        # decision (or the entry absorb) that no batch took
+                        # over is restored by the finally's bookkeeping — one
+                        # restore point covers this exit and every non-cancel
+                        # escape (e.g. a validation failure) alike.
 
                         # Exit directly, skipping request_pending check
                         return
@@ -1561,6 +1556,25 @@ class _PipelineMixin:
                     "pipeline_status", workspace=run_workspace
                 )
                 async with lock:
+                    # Restore a wake-up signal a decision consumed but no
+                    # batch took over — regardless of WHY the run is exiting
+                    # (user cancel, a validation failure, any escape): the
+                    # docs behind it are PENDING rows whose channel entries
+                    # were already drained, so without this they would wait
+                    # for an unrelated trigger.  Before the release below, so
+                    # the next acquirer observes the signal; failure only
+                    # degrades to next-explicit-trigger recovery.
+                    if uncommitted_wakeup and ingress is not None:
+                        try:
+                            ingress.request_auto_rescan()
+                        except Exception as restore_error:
+                            logger.warning(
+                                "[pipeline] failed to restore the consumed "
+                                "wake-up signal on exit (docs stay PENDING "
+                                "until the next explicit trigger): "
+                                f"{restore_error}"
+                            )
+
                     status_snapshot = status.copy()
                     current_owner = _reservation_owner_token(
                         status_snapshot.get("busy_owner")

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1048,38 +1048,41 @@ class _PipelineMixin:
             raise status_upsert_error
 
         # Notify any in-flight processing loop that new work has arrived.
-        # ``request_pending`` (set under the lock) is the correctness anchor: a
-        # busy loop checks it after each batch and re-queries doc_status for
-        # these PENDING rows. Without it a caller that does not subsequently
-        # call ``apipeline_process_enqueue_documents`` (or whose call races with
-        # the loop's just-finished batch) could strand the new docs.
+        # The document publish happens INSIDE the same critical section that
+        # sets ``request_pending``: the consumer's atomic exit decision
+        # (:meth:`_decide_pipeline_next_step`) checks the mailbox and releases
+        # ``busy`` under this very lock, so publishing outside it would let a
+        # quiescing run observe an empty mailbox, release, and only then see
+        # the messages land — stranding an enqueue-only doc in an idle mailbox
+        # once Phase 4 removes the transitional flag.  Serialized on the lock,
+        # a publish either lands before the decision (which then sees it) or
+        # after the release (busy already False — the designed idle-enqueue
+        # case).  ``put_documents`` is ONE server-side batch call, so the lock
+        # is never held across N Manager RPCs; overflow past the bounded
+        # channel coalesces into the auto-rescan flag server-side.
+        #
+        # A droppable accelerator side-effect must never fail an enqueue that
+        # already durably committed doc_status: a multiprocess batch publish
+        # is a Manager RPC that can raise on a Manager outage, so swallow-and-
+        # log — ``request_pending`` (set first, infallible in-process) remains
+        # the transitional recovery anchor for exactly this window until
+        # Phase 4 revisits the publish-failure path.
         async with pipeline_status_lock:
             if pipeline_status.get("busy"):
                 pipeline_status["request_pending"] = True
-
-        # Phase 2 dual-write: publish a document notification per new doc so a
-        # running batch's feeder routes it immediately (the latency win).
-        # Published AFTER releasing the lock so a large batch never holds
-        # pipeline_status_lock across N ingress RPCs; the feeder is best-effort,
-        # and a notification the feeder misses is still a PENDING row recovered
-        # by request_pending above. Overflow past the bounded channel coalesces
-        # into the auto-rescan flag inside put_document.
-        #
-        # A droppable accelerator side-effect must never fail an enqueue that
-        # already durably committed doc_status and armed request_pending: a
-        # multiprocess ``put_document`` is a Manager RPC that can raise on a
-        # Manager outage, so swallow-and-log rather than escalate a successful
-        # upload into a caller-visible error (the docs are recovered regardless).
-        try:
-            for doc_id in new_docs:
-                ingress.put_document(
-                    PipelineIngressMessage(kind="document", doc_id=doc_id)
+            try:
+                ingress.put_documents(
+                    [
+                        PipelineIngressMessage(kind="document", doc_id=doc_id)
+                        for doc_id in new_docs
+                    ]
                 )
-        except Exception as publish_error:
-            logger.warning(
-                "Ingress document notification failed after a successful enqueue "
-                f"(request_pending still recovers the docs): {publish_error}"
-            )
+            except Exception as publish_error:
+                logger.warning(
+                    "Ingress document notification failed after a successful "
+                    f"enqueue (request_pending still recovers the docs): "
+                    f"{publish_error}"
+                )
 
         return track_id
 
@@ -1297,6 +1300,22 @@ class _PipelineMixin:
                     ingress.request_auto_rescan()
                 raise
 
+            # Ownership of a consumed-but-not-yet-committed wake-up signal.
+            # True while a destructively-consumed signal (the absorbed auto
+            # flag here, or a CONTINUE_AUTO/CONTINUE_DOCUMENT consumption at a
+            # quiescence decision) has produced docs that NO batch has taken
+            # over yet: a cancellation landing in that window exits through
+            # the loop-top handler, which re-arms auto-rescan so the cancel
+            # leaves the ingress as if the run had stopped before consuming
+            # (drained document messages are represented by their PENDING
+            # rows; the auto flag is the canonical lost-notification recovery
+            # signal, same as channel overflow).  Cleared once the consistency
+            # validator has taken the docs over — from there the batch, its
+            # feeder teardown and the PENDING rows own recovery.  An empty
+            # strict result clears it too: a complete scan with nothing to do
+            # means the signal was fully served, not lost.
+            uncommitted_wakeup = absorbed_auto_rescan and bool(to_process_docs)
+
             if not to_process_docs:
                 # Empty queue — a complete strict result, so a pending manual
                 # request is satisfied (nothing to retry) and can be ACKed.
@@ -1327,6 +1346,10 @@ class _PipelineMixin:
                 to_process_docs, pending_manual_ack = await self._refetch_for_decision(
                     decision, ingress
                 )
+                uncommitted_wakeup = decision.step in (
+                    PipelineNextStep.CONTINUE_AUTO,
+                    PipelineNextStep.CONTINUE_DOCUMENT,
+                ) and bool(to_process_docs)
 
             # Process documents until no more documents or requests
             while True:
@@ -1364,6 +1387,23 @@ class _PipelineMixin:
                         )
                         status_snapshot["history_messages"].append(log_message)
 
+                        # A signal the immediately-preceding decision (or the
+                        # entry absorb) consumed was never handed to a batch:
+                        # restore it so this cancel leaves the ingress as if
+                        # the run had stopped before consuming it.  Failure
+                        # only degrades — the docs are PENDING rows recovered
+                        # by the next explicit trigger's initial scan.
+                        if uncommitted_wakeup:
+                            try:
+                                ingress.request_auto_rescan()
+                            except Exception as restore_error:
+                                logger.warning(
+                                    "[pipeline] failed to restore the consumed "
+                                    "wake-up signal on cancellation (docs stay "
+                                    "PENDING until the next explicit trigger): "
+                                    f"{restore_error}"
+                                )
+
                         # Exit directly, skipping request_pending check
                         return
 
@@ -1391,12 +1431,21 @@ class _PipelineMixin:
                         to_process_docs,
                         pending_manual_ack,
                     ) = await self._refetch_for_decision(decision, ingress)
+                    uncommitted_wakeup = decision.step in (
+                        PipelineNextStep.CONTINUE_AUTO,
+                        PipelineNextStep.CONTINUE_DOCUMENT,
+                    ) and bool(to_process_docs)
                     continue
 
                 # Validate document data consistency and fix any issues
                 to_process_docs = await self._validate_and_fix_document_consistency(
                     to_process_docs, pipeline_status, pipeline_status_lock
                 )
+                # The validator has taken the docs over (its FAILED→PENDING
+                # resets are persisted): the consumed signal is committed, and
+                # from here the batch/feeder teardown and the PENDING rows own
+                # recovery — a later cancel must NOT re-arm.
+                uncommitted_wakeup = False
 
                 # ACK point for a manual retry request: the validation above
                 # persisted every FAILED→PENDING reset, and no worker has
@@ -1429,6 +1478,10 @@ class _PipelineMixin:
                         to_process_docs,
                         pending_manual_ack,
                     ) = await self._refetch_for_decision(decision, ingress)
+                    uncommitted_wakeup = decision.step in (
+                        PipelineNextStep.CONTINUE_AUTO,
+                        PipelineNextStep.CONTINUE_DOCUMENT,
+                    ) and bool(to_process_docs)
                     continue
 
                 log_message = f"Processing {len(to_process_docs)} document(s)"
@@ -1485,6 +1538,10 @@ class _PipelineMixin:
                 to_process_docs, pending_manual_ack = await self._refetch_for_decision(
                     decision, ingress
                 )
+                uncommitted_wakeup = decision.step in (
+                    PipelineNextStep.CONTINUE_AUTO,
+                    PipelineNextStep.CONTINUE_DOCUMENT,
+                ) and bool(to_process_docs)
 
         finally:
             stopped_message = "Enqueued document processing pipeline stopped"

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1298,28 +1298,27 @@ class _PipelineMixin:
             else:
                 initial_statuses = _AUTO_RESUME_DOC_STATUSES
                 absorbed_auto_rescan = ingress.consume_auto_rescan()
+            # Own the absorbed signal from the INSTANT of consumption (see the
+            # definition above the try): if the strict scan below raises —
+            # Exception, CancelledError, any BaseException — the finally's
+            # bookkeeping re-arms the flag; a task cancellation delivered
+            # inside the scan would slip past any local `except Exception`
+            # compensation, so there is none.  (A manual request was only
+            # peeked and stays sticky on its own.)
+            uncommitted_wakeup = absorbed_auto_rescan
 
-            try:
-                to_process_docs: dict[
-                    str, DocProcessingStatus
-                ] = await self.doc_status.get_docs_by_statuses(
-                    list(initial_statuses), strict=True
-                )
-            except Exception:
-                # The strict scan failed AFTER a wake-up signal may have been
-                # consumed: re-arm the absorbed auto flag before propagating
-                # (a manual request was only peeked and stays sticky).
-                if absorbed_auto_rescan:
-                    ingress.request_auto_rescan()
-                raise
+            to_process_docs: dict[
+                str, DocProcessingStatus
+            ] = await self.doc_status.get_docs_by_statuses(
+                list(initial_statuses), strict=True
+            )
 
-            # Take ownership of the absorbed entry signal (see the definition
-            # above the try): restored by the finally on ANY exit until the
-            # consistency validator takes the docs over.  An empty strict
-            # result means the signal was fully served, not lost — the auto
-            # flag is the canonical lost-notification recovery signal and the
-            # drained document messages are represented by their PENDING rows,
-            # same as channel overflow.
+            # The scan is complete: an empty result means the signal was fully
+            # SERVED, not lost — release ownership.  A non-empty result keeps
+            # it owned until the consistency validator takes the docs over
+            # (the auto flag is the canonical lost-notification recovery
+            # signal and drained document messages are represented by their
+            # PENDING rows, same as channel overflow).
             uncommitted_wakeup = absorbed_auto_rescan and bool(to_process_docs)
 
             if not to_process_docs:

--- a/tests/api/routes/test_clear_documents_ingress.py
+++ b/tests/api/routes/test_clear_documents_ingress.py
@@ -1,0 +1,142 @@
+"""``/documents/clear`` clears the pipeline ingress mailbox (Phase 3).
+
+The clear endpoint owns busy+destructive while it drops every storage: the
+documents the mailbox refers to cease to exist, so the mailbox is cleared in
+the same window — un-ACKed manual retry requests are retired as
+CANCELLED_BY_CLEAR (a delayed replay of the same request id is refused), and
+the document/auto channels are emptied.
+"""
+
+import importlib
+import sys
+from uuid import uuid4
+
+import pytest
+
+_original_argv = sys.argv[:]
+sys.argv = [sys.argv[0]]
+_document_routes = importlib.import_module("lightrag.api.routers.document_routes")
+sys.argv = _original_argv
+
+from lightrag.kg.pipeline_ingress import PipelineIngressMessage  # noqa: E402
+from lightrag.kg.shared_storage import get_pipeline_ingress  # noqa: E402
+
+DocumentManager = _document_routes.DocumentManager
+create_document_routes = _document_routes.create_document_routes
+
+pytestmark = pytest.mark.offline
+
+
+class _NoopStorage:
+    """Minimal storage the clear endpoint can ``drop()`` and report on."""
+
+    namespace = "noop"
+
+    async def drop(self):
+        return {"status": "success", "message": "data dropped"}
+
+
+class _ClearRag:
+    def __init__(self, workspace: str):
+        self.workspace = workspace
+        storage = _NoopStorage()
+        storage.workspace = workspace
+        # The eleven storage attributes the clear endpoint iterates over.
+        self.text_chunks = storage
+        self.full_docs = storage
+        self.full_entities = storage
+        self.full_relations = storage
+        self.entity_chunks = storage
+        self.relation_chunks = storage
+        self.entities_vdb = storage
+        self.relationships_vdb = storage
+        self.chunks_vdb = storage
+        self.chunk_entity_relation_graph = storage
+        self.doc_status = storage
+
+    async def aclear_cache(self, modes=None):
+        return None
+
+
+async def test_clear_documents_clears_ingress_and_refuses_replay(tmp_path):
+    """All three active mailbox channels are emptied under the destructive
+    reservation, and the retired manual request id cannot be replayed into the
+    fresh (empty) workspace."""
+    workspace = f"clear-ingress-{uuid4().hex[:8]}"
+    shared_storage = importlib.import_module("lightrag.kg.shared_storage")
+    # Idempotent within a process; a unique workspace keeps this test isolated
+    # even when the shared dicts already exist from a sibling test.
+    shared_storage.initialize_share_data()
+    await shared_storage.initialize_pipeline_status(workspace=workspace)
+
+    ingress = await get_pipeline_ingress(workspace)
+    ingress.put_document(PipelineIngressMessage(kind="document", doc_id="doc-x"))
+    ingress.request_auto_rescan()
+    manual_msg = PipelineIngressMessage(
+        kind="rescan", retry_failed=True, request_id="req-cleared"
+    )
+    assert ingress.request_manual_retry("req-cleared", manual_msg) is True
+
+    rag = _ClearRag(workspace)
+    router = create_document_routes(rag, DocumentManager(str(tmp_path)))
+    clear_endpoint = [
+        route.endpoint
+        for route in router.routes
+        if getattr(route, "name", "") == "clear_documents"
+    ][-1]
+
+    response = await clear_endpoint()
+    assert response.status in ("success", "partial_success")
+
+    counts = ingress.counts()
+    assert counts["documents"] == 0
+    assert counts["auto_rescan_pending"] is False
+    assert counts["manual_retries"] == 0
+    assert ingress.has_work() is False
+
+    # CANCELLED_BY_CLEAR is terminal: a delayed replay of the same id must be
+    # refused instead of re-entering the now-empty workspace.
+    assert ingress.request_manual_retry("req-cleared", manual_msg) is False
+    assert ingress.snapshot_manual_retries() == []
+
+    pipeline_status = await shared_storage.get_namespace_data(
+        "pipeline_status", workspace=workspace
+    )
+    assert pipeline_status.get("busy") is False
+    assert pipeline_status.get("destructive_busy") is False
+
+
+async def test_clear_documents_survives_ingress_clear_failure(tmp_path):
+    """An ingress ``clear()`` failure must not fail the clear operation: the
+    degradation is safe (residual messages are compacted by consumption
+    idempotence; a surviving sticky request ACKs against the emptied
+    doc_status) and the destructive reservation is still released."""
+    workspace = f"clear-ingress-fail-{uuid4().hex[:8]}"
+    shared_storage = importlib.import_module("lightrag.kg.shared_storage")
+    shared_storage.initialize_share_data()
+    await shared_storage.initialize_pipeline_status(workspace=workspace)
+
+    ingress = await get_pipeline_ingress(workspace)
+    ingress.put_document(PipelineIngressMessage(kind="document", doc_id="doc-x"))
+
+    def dead_clear():
+        raise RuntimeError("manager down: clear")
+
+    ingress.clear = dead_clear
+
+    rag = _ClearRag(workspace)
+    router = create_document_routes(rag, DocumentManager(str(tmp_path)))
+    clear_endpoint = [
+        route.endpoint
+        for route in router.routes
+        if getattr(route, "name", "") == "clear_documents"
+    ][-1]
+
+    response = await clear_endpoint()
+    assert response.status in ("success", "partial_success")
+
+    pipeline_status = await shared_storage.get_namespace_data(
+        "pipeline_status", workspace=workspace
+    )
+    assert pipeline_status.get("busy") is False
+    assert pipeline_status.get("destructive_busy") is False

--- a/tests/kg/test_pipeline_ingress.py
+++ b/tests/kg/test_pipeline_ingress.py
@@ -376,6 +376,38 @@ async def test_document_overflow_coalesces_into_auto_rescan():
     assert not mailbox.has_work()
 
 
+async def test_put_documents_batch_matches_sequential_semantics():
+    """The single-call batch publish (one server-side RPC, so a producer can
+    publish inside the pipeline_status critical section) must behave exactly
+    like N sequential put_document calls: FIFO order, per-message validation
+    before anything is enqueued, and overflow coalescing into auto-rescan."""
+    mailbox = PipelineIngressMailbox(document_capacity=2)
+    mailbox.put_documents([_doc("d1"), _doc("d2"), _doc("d3")])  # d3 overflows
+    counts = mailbox.counts()
+    assert counts["documents"] == 2
+    assert counts["document_overflows"] == 1
+    assert counts["auto_rescan_pending"] is True
+    assert [m.doc_id for m in mailbox.drain_documents()] == ["d1", "d2"]
+
+    # Validation covers the WHOLE batch before any message is enqueued.
+    mailbox2 = PipelineIngressMailbox()
+    with pytest.raises(ValueError, match="kind='document'"):
+        mailbox2.put_documents([_doc("ok"), PipelineIngressMessage(kind="rescan")])
+    assert mailbox2.counts()["documents"] == 0
+
+    # Asyncio flavor behaves identically (including whole-batch validation).
+    ingress = AsyncioPipelineIngress(document_capacity=2)
+    ingress.put_documents([_doc("a1"), _doc("a2"), _doc("a3")])
+    counts = ingress.counts()
+    assert counts["documents"] == 2
+    assert counts["document_overflows"] == 1
+    assert counts["auto_rescan_pending"] is True
+    assert [m.doc_id for m in ingress.drain_documents()] == ["a1", "a2"]
+    with pytest.raises(ValueError, match="kind='document'"):
+        ingress.put_documents([_doc("ok"), PipelineIngressMessage(kind="rescan")])
+    assert ingress.counts()["documents"] == 0
+
+
 def test_bounded_terminal_ids_fifo_eviction():
     ids = _BoundedTerminalIds(capacity=2)
     ids.add("a", MANUAL_RETRY_ACKED)

--- a/tests/pipeline/test_pipeline_cancellation.py
+++ b/tests/pipeline/test_pipeline_cancellation.py
@@ -34,7 +34,11 @@ import pytest
 from lightrag import LightRAG, ROLES, RoleLLMConfig
 from lightrag.base import DocProcessingStatus, DocStatus
 from lightrag.exceptions import MultimodalAnalysisError, PipelineCancelledException
-from lightrag.kg.shared_storage import get_namespace_data, get_namespace_lock
+from lightrag.kg.shared_storage import (
+    get_namespace_data,
+    get_namespace_lock,
+    get_pipeline_ingress,
+)
 from lightrag.pipeline import _BatchRunContext
 from lightrag.parser.llm_bridge import LLMBridgePipelineCancelled, SyncLLMBridge
 from lightrag.parser.registry import parser_specs_snapshot
@@ -303,6 +307,7 @@ async def test_pipeline_cancel_interrupts_inflight_native_parser_llm(
                 {doc_id: status_doc},
                 pipeline_status=pipeline_status,
                 pipeline_status_lock=pipeline_status_lock,
+                ingress=await get_pipeline_ingress(rag.workspace),
             )
         )
         await asyncio.wait_for(submit_started.wait(), timeout=1.0)

--- a/tests/pipeline/test_pipeline_ingress_exit.py
+++ b/tests/pipeline/test_pipeline_ingress_exit.py
@@ -257,6 +257,61 @@ async def test_refetch_document_failure_republishes_and_arms_auto(tmp_path):
         await rag.finalize_storages()
 
 
+async def test_enqueue_publishes_documents_inside_status_lock(tmp_path, monkeypatch):
+    """Fix-proof (atomic producer handoff): the document publish must happen
+    INSIDE the pipeline_status critical section that sets ``request_pending``
+    — the consumer's exit decision reads the mailbox and releases ``busy``
+    under the same lock, so a publish outside it can land just after a
+    quiescing run released, stranding an enqueue-only doc in an idle mailbox
+    once Phase 4 removes the transitional flag.  Serialization is the lock's,
+    flavor-independent; the probe records whether the enqueue task holds the
+    pipeline_status namespace lock at the moment it publishes."""
+    import lightrag.kg.shared_storage as shared_storage_module
+
+    rag = await _build_rag(tmp_path, _MarkerExtract())
+    try:
+        held: dict = {}
+        orig_aenter = shared_storage_module.NamespaceLock.__aenter__
+        orig_aexit = shared_storage_module.NamespaceLock.__aexit__
+
+        async def tracing_aenter(self):
+            result = await orig_aenter(self)
+            held.setdefault(asyncio.current_task(), set()).add(self._namespace)
+            return result
+
+        async def tracing_aexit(self, *args):
+            held.get(asyncio.current_task(), set()).discard(self._namespace)
+            return await orig_aexit(self, *args)
+
+        monkeypatch.setattr(
+            shared_storage_module.NamespaceLock, "__aenter__", tracing_aenter
+        )
+        monkeypatch.setattr(
+            shared_storage_module.NamespaceLock, "__aexit__", tracing_aexit
+        )
+
+        ingress = await get_pipeline_ingress(rag.workspace)
+        publish_lock_states: list[bool] = []
+        published_ids: list[str] = []
+        orig_put = ingress.put_documents
+
+        def probing_put(msgs):
+            namespaces = held.get(asyncio.current_task(), set())
+            publish_lock_states.append("pipeline_status" in namespaces)
+            published_ids.extend(m.doc_id for m in msgs)
+            return orig_put(msgs)
+
+        ingress.put_documents = probing_put
+
+        await rag.apipeline_enqueue_documents(input="AAAA body", file_paths="a.txt")
+
+        a_id = compute_mdhash_id("a.txt", prefix="doc-")
+        assert published_ids == [a_id]
+        assert publish_lock_states == [True]
+    finally:
+        await rag.finalize_storages()
+
+
 async def test_refetch_compensation_failure_does_not_mask_original_error(tmp_path):
     """When even the compensation RPCs fail (Manager outage), the ORIGINAL
     strict-scan failure must still propagate — the compensation error is
@@ -317,6 +372,129 @@ async def test_user_cancel_preserves_ingress_and_stops_run(tmp_path):
         assert status.get("cancellation_requested") is False  # bookkeeping ran
         # No new epoch consumed the flag on the way out: it waits for the next
         # explicit trigger, ingress fully retained.
+        assert ingress.counts()["auto_rescan_pending"] is True
+    finally:
+        extract.release.set()
+        await rag.finalize_storages()
+
+
+async def test_cancel_after_auto_decision_restores_consumed_signal(tmp_path):
+    """Fix-proof (consume-then-discard closure): a cancel landing AFTER the
+    decision consumed the auto-rescan flag but BEFORE its refetched docs enter
+    a batch must not lose the signal — the loop-top cancel exit re-arms it, so
+    the cancel leaves the ingress as if the run had stopped before consuming."""
+    extract = _MarkerExtract()
+    extract.block_marker = "AAAA"
+    rag = await _build_rag(tmp_path, extract)
+    try:
+        status, lock = await _pipeline_ns(rag)
+        await rag.apipeline_enqueue_documents(input="AAAA body", file_paths="a.txt")
+        b_id = compute_mdhash_id("b.txt", prefix="doc-")
+        ingress = await get_pipeline_ingress(rag.workspace)
+
+        orig_batch = rag._run_pipeline_batch
+        injected = False
+
+        async def batch_then_arm_auto(to_process_docs, **kwargs):
+            nonlocal injected
+            await orig_batch(to_process_docs, **kwargs)
+            if not injected:
+                injected = True
+                # A PENDING doc whose ONLY remaining signal is the auto flag.
+                await rag.apipeline_enqueue_documents(
+                    input="BBBB body", file_paths="b.txt"
+                )
+                ingress.drain_documents()
+                async with lock:
+                    status["request_pending"] = False
+                ingress.request_auto_rescan()
+
+        rag._run_pipeline_batch = batch_then_arm_auto
+
+        orig_decide = rag._decide_pipeline_next_step
+        cancelled_after = []
+
+        async def decide_then_cancel(ps, ps_lock, ing):
+            decision = await orig_decide(ps, ps_lock, ing)
+            if decision.step is PipelineNextStep.CONTINUE_AUTO and not cancelled_after:
+                cancelled_after.append(True)
+                # Lands in the exact window: decision consumed the flag, the
+                # refetched docs have not reached a batch yet.
+                async with ps_lock:
+                    ps["cancellation_requested"] = True
+            return decision
+
+        rag._decide_pipeline_next_step = decide_then_cancel
+
+        extract.release.set()
+        await asyncio.wait_for(rag.apipeline_process_enqueue_documents(), timeout=10)
+
+        assert cancelled_after  # the window was exercised
+        assert status.get("busy") is False
+        assert _status_text(await rag.doc_status.get_by_id(b_id)) == "pending"
+        # The consumed flag was restored on the cancel exit.
+        assert ingress.counts()["auto_rescan_pending"] is True
+    finally:
+        extract.release.set()
+        await rag.finalize_storages()
+
+
+async def test_cancel_after_document_decision_restores_consumed_signal(tmp_path):
+    """Same window for CONTINUE_DOCUMENT: the refetch destructively drained
+    the doc's notification; a cancel before the batch takes the docs over must
+    leave a recovery signal — the drained message is represented by its
+    PENDING row and the restored auto-rescan flag (the canonical
+    lost-notification signal, as for channel overflow)."""
+    extract = _MarkerExtract()
+    extract.block_marker = "AAAA"
+    rag = await _build_rag(tmp_path, extract)
+    try:
+        status, lock = await _pipeline_ns(rag)
+        await rag.apipeline_enqueue_documents(input="AAAA body", file_paths="a.txt")
+        b_id = compute_mdhash_id("b.txt", prefix="doc-")
+        ingress = await get_pipeline_ingress(rag.workspace)
+
+        orig_batch = rag._run_pipeline_batch
+        injected = False
+
+        async def batch_then_inject(to_process_docs, **kwargs):
+            nonlocal injected
+            await orig_batch(to_process_docs, **kwargs)
+            if not injected:
+                injected = True
+                # A PENDING doc whose ONLY signal is its resident message.
+                await rag.apipeline_enqueue_documents(
+                    input="BBBB body", file_paths="b.txt"
+                )
+                async with lock:
+                    status["request_pending"] = False
+
+        rag._run_pipeline_batch = batch_then_inject
+
+        orig_decide = rag._decide_pipeline_next_step
+        cancelled_after = []
+
+        async def decide_then_cancel(ps, ps_lock, ing):
+            decision = await orig_decide(ps, ps_lock, ing)
+            if (
+                decision.step is PipelineNextStep.CONTINUE_DOCUMENT
+                and not cancelled_after
+            ):
+                cancelled_after.append(True)
+                async with ps_lock:
+                    ps["cancellation_requested"] = True
+            return decision
+
+        rag._decide_pipeline_next_step = decide_then_cancel
+
+        extract.release.set()
+        await asyncio.wait_for(rag.apipeline_process_enqueue_documents(), timeout=10)
+
+        assert cancelled_after
+        assert status.get("busy") is False
+        assert _status_text(await rag.doc_status.get_by_id(b_id)) == "pending"
+        # The message was drained by the refetch; the restored flag is the
+        # recovery signal that survives the cancel.
         assert ingress.counts()["auto_rescan_pending"] is True
     finally:
         extract.release.set()

--- a/tests/pipeline/test_pipeline_ingress_exit.py
+++ b/tests/pipeline/test_pipeline_ingress_exit.py
@@ -501,6 +501,33 @@ async def test_cancel_after_document_decision_restores_consumed_signal(tmp_path)
         await rag.finalize_storages()
 
 
+async def test_initial_scan_cancellation_restores_absorbed_auto_signal(tmp_path):
+    """Fix-proof (entry-window closure): the entry consumes the auto-rescan
+    flag BEFORE its strict scan, and a task cancellation delivered inside that
+    scan is a ``BaseException`` that slips past any ``except Exception``
+    compensation — ownership must therefore start at the instant of
+    consumption, so the finally re-arms the flag: busy released, signal
+    intact for the next explicit trigger."""
+    rag = await _build_rag(tmp_path, _MarkerExtract())
+    try:
+        status, _lock = await _pipeline_ns(rag)
+        ingress = await get_pipeline_ingress(rag.workspace)
+        ingress.request_auto_rescan()
+
+        async def cancelled_scan(*args, **kwargs):
+            raise asyncio.CancelledError()
+
+        rag.doc_status.get_docs_by_statuses = cancelled_scan
+
+        with pytest.raises(asyncio.CancelledError):
+            await rag.apipeline_process_enqueue_documents()
+
+        assert status.get("busy") is False
+        assert ingress.counts()["auto_rescan_pending"] is True  # re-armed
+    finally:
+        await rag.finalize_storages()
+
+
 async def test_validation_failure_after_document_decision_restores_signal(tmp_path):
     """Fix-proof (non-cancel escape closure): a transient validation failure
     landing AFTER a CONTINUE_DOCUMENT refetch destructively drained the doc's

--- a/tests/pipeline/test_pipeline_ingress_exit.py
+++ b/tests/pipeline/test_pipeline_ingress_exit.py
@@ -1,0 +1,485 @@
+"""has_work-only atomic exit + cancellation/recovery closure (Phase 3).
+
+The quiescence decision now covers the document channel: a message resident in
+the mailbox at a batch boundary keeps the run busy (CONTINUE_DOCUMENT) and the
+refetch resolves it with the feeder's drain→strict-verify protocol — live docs
+come back as the next batch, provably-stale notifications are compacted so a
+has_work-only exit can neither livelock on them nor strand a doc behind a
+released ``busy``.  Cancellation (user or internal error) exits BEFORE the
+decision so the ingress is fully retained for the next explicit trigger, and
+the custom-chunks exit handoff consults ``has_work()`` alongside the
+transitional ``request_pending`` flag.
+
+All on a real LightRAG with in-memory JSON storages (offline).
+"""
+
+import asyncio
+from collections import Counter
+from uuid import uuid4
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG
+from lightrag.kg.pipeline_ingress import PipelineIngressMessage
+from lightrag.kg.shared_storage import (
+    get_namespace_data,
+    get_namespace_lock,
+    get_pipeline_ingress,
+)
+from lightrag.pipeline import PipelineNextDecision, PipelineNextStep
+from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
+from lightrag.utils_pipeline import CUSTOM_CHUNK_PATCH_METADATA_KEY
+
+pytestmark = pytest.mark.offline
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _dummy_embedding(texts: list[str]) -> np.ndarray:
+    return np.ones((len(texts), 8), dtype=float)
+
+
+async def _dummy_llm(*args, **kwargs) -> str:
+    return "ok"
+
+
+def _chunking(tokenizer, content, *args) -> list[dict]:
+    return [{"tokens": 1, "content": f"{content}::chunk1", "chunk_order_index": 0}]
+
+
+class _MarkerExtract:
+    """Process-layer extraction that counts calls per document marker and can
+    block whichever marker is armed until released."""
+
+    def __init__(self):
+        self.calls: Counter = Counter()
+        self.block_marker: str | None = None
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def __call__(self, chunks, *args, **kwargs):
+        content = " ".join(str(v.get("content", "")) for v in chunks.values())
+        marker = content.split(" ", 1)[0] if content else ""
+        self.calls[marker] += 1
+        if self.block_marker and self.block_marker in content:
+            self.started.set()
+            await self.release.wait()
+        return [({}, {}) for _ in chunks]
+
+
+async def _build_rag(tmp_path, extract, *, max_parallel_insert: int = 1) -> LightRAG:
+    rag = LightRAG(
+        working_dir=str(tmp_path / "wd"),
+        workspace=f"exit-{uuid4().hex[:8]}",
+        llm_model_func=_dummy_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8, max_token_size=8192, func=_dummy_embedding
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        chunking_func=_chunking,
+        max_parallel_insert=max_parallel_insert,
+    )
+    await rag.initialize_storages()
+    rag._process_extract_entities = extract
+    return rag
+
+
+def _status_text(row) -> str:
+    status = row["status"]
+    return getattr(status, "value", str(status)).replace("DocStatus.", "").lower()
+
+
+async def _pipeline_ns(rag):
+    status = await get_namespace_data("pipeline_status", workspace=rag.workspace)
+    lock = get_namespace_lock("pipeline_status", workspace=rag.workspace)
+    return status, lock
+
+
+def _doc_msg(doc_id: str) -> PipelineIngressMessage:
+    return PipelineIngressMessage(kind="document", doc_id=doc_id)
+
+
+def _manual_msg(request_id: str) -> PipelineIngressMessage:
+    return PipelineIngressMessage(
+        kind="rescan", retry_failed=True, request_id=request_id
+    )
+
+
+async def test_decision_priority_and_consumption_semantics(tmp_path):
+    """Priority is manual > auto > document > request_pending > release, and
+    each step consumes ONLY its own signal: manual is peeked (nothing removed),
+    auto is an atomic exchange, the document check never drains (the refetch
+    does), request_pending is the transitional fallback, and RELEASED clears
+    busy/busy_owner in the same critical section."""
+    rag = await _build_rag(tmp_path, _MarkerExtract())
+    try:
+        status, lock = await _pipeline_ns(rag)
+        ingress = await get_pipeline_ingress(rag.workspace)
+
+        ingress.request_manual_retry("req-1", _manual_msg("req-1"))
+        ingress.request_auto_rescan()
+        ingress.put_document(_doc_msg("doc-x"))
+        async with lock:
+            status.update({"busy": True, "busy_owner": None, "request_pending": True})
+
+        d1 = await rag._decide_pipeline_next_step(status, lock, ingress)
+        assert d1.step is PipelineNextStep.CONTINUE_MANUAL
+        assert d1.manual_request_id == "req-1"
+        counts = ingress.counts()
+        # Manual wins and consumes nothing: every other signal is intact.
+        assert counts["manual_retries"] == 1
+        assert counts["auto_rescan_pending"] is True
+        assert counts["documents"] == 1
+        assert status.get("request_pending") is True
+
+        ingress.ack_manual_retry("req-1")
+        d2 = await rag._decide_pipeline_next_step(status, lock, ingress)
+        assert d2.step is PipelineNextStep.CONTINUE_AUTO
+        counts = ingress.counts()
+        assert counts["auto_rescan_pending"] is False  # atomically consumed
+        assert counts["documents"] == 1  # untouched
+
+        d3 = await rag._decide_pipeline_next_step(status, lock, ingress)
+        assert d3.step is PipelineNextStep.CONTINUE_DOCUMENT
+        # The decision only PEEKS the channel; draining belongs to the refetch.
+        assert ingress.counts()["documents"] == 1
+        assert status.get("request_pending") is True  # not consumed by document
+
+        ingress.drain_documents()
+        d4 = await rag._decide_pipeline_next_step(status, lock, ingress)
+        assert d4.step is PipelineNextStep.CONTINUE_AUTO
+        assert status.get("request_pending") is False  # transitional consumed
+
+        d5 = await rag._decide_pipeline_next_step(status, lock, ingress)
+        assert d5.step is PipelineNextStep.RELEASED
+        assert status.get("busy") is False
+        assert status.get("busy_owner") is None
+    finally:
+        await rag.finalize_storages()
+
+
+async def test_document_published_at_quiescence_starts_next_batch(tmp_path):
+    """Fix-proof (has_work-only exit): a document whose ONLY signal is its
+    mailbox message — published after the batch's feeder stopped, with the
+    transitional ``request_pending`` flag cleared to simulate the Phase 4
+    world — must keep the run busy (CONTINUE_DOCUMENT) and be processed as the
+    next batch.  Without the document-channel check the decision releases
+    ``busy`` and the doc strands in PENDING with its message resident."""
+    extract = _MarkerExtract()
+    rag = await _build_rag(tmp_path, extract)
+    try:
+        status, lock = await _pipeline_ns(rag)
+        await rag.apipeline_enqueue_documents(input="AAAA body", file_paths="a.txt")
+        b_id = compute_mdhash_id("b.txt", prefix="doc-")
+
+        orig_batch = rag._run_pipeline_batch
+        injected = False
+
+        async def batch_then_inject(to_process_docs, **kwargs):
+            nonlocal injected
+            await orig_batch(to_process_docs, **kwargs)
+            if not injected:
+                injected = True
+                # Lands AFTER this batch's feeder was cancelled and BEFORE the
+                # quiescence decision — the only window the feeder cannot see.
+                await rag.apipeline_enqueue_documents(
+                    input="BBBB body", file_paths="b.txt"
+                )
+                async with lock:
+                    status["request_pending"] = False  # kill the dual-write mask
+
+        rag._run_pipeline_batch = batch_then_inject
+
+        await asyncio.wait_for(rag.apipeline_process_enqueue_documents(), timeout=10)
+
+        assert _status_text(await rag.doc_status.get_by_id(b_id)) == "processed"
+        assert extract.calls["BBBB"] == 1
+        assert status.get("busy") is False
+        ingress = await get_pipeline_ingress(rag.workspace)
+        assert ingress.counts()["documents"] == 0  # message resolved, not resident
+    finally:
+        await rag.finalize_storages()
+
+
+async def test_stale_document_message_is_compacted_and_released(tmp_path):
+    """Fix-proof (no livelock, no stranding): a notification for a doc with no
+    live doc_status row — an enqueue-only doc deleted before any run, or a
+    notification that outlived its doc — is drained, proven stale by the
+    complete strict scan, and dropped; the run then releases ``busy`` instead
+    of looping CONTINUE_DOCUMENT forever on a message nothing else consumes."""
+    rag = await _build_rag(tmp_path, _MarkerExtract())
+    try:
+        status, _lock = await _pipeline_ns(rag)
+        ingress = await get_pipeline_ingress(rag.workspace)
+        ingress.put_document(_doc_msg("doc-stale-ghost"))
+
+        await asyncio.wait_for(rag.apipeline_process_enqueue_documents(), timeout=10)
+
+        assert status.get("busy") is False
+        assert ingress.counts()["documents"] == 0  # compacted, not resident
+        assert ingress.has_work() is False
+    finally:
+        await rag.finalize_storages()
+
+
+async def test_refetch_document_failure_republishes_and_arms_auto(tmp_path):
+    """Compensation: the CONTINUE_DOCUMENT refetch drains destructively BEFORE
+    its strict scan, so a scan failure must restore the drained messages to
+    the mailbox and arm auto-rescan as the backstop before propagating —
+    otherwise the drained notifications die with the exception."""
+    rag = await _build_rag(tmp_path, _MarkerExtract())
+    try:
+        ingress = await get_pipeline_ingress(rag.workspace)
+        ingress.consume_auto_rescan()
+        ingress.put_document(_doc_msg("doc-a"))
+        ingress.put_document(_doc_msg("doc-b"))
+
+        async def dead_scan(*args, **kwargs):
+            raise ConnectionError("doc_status backend transient failure")
+
+        rag.doc_status.get_docs_by_statuses = dead_scan
+
+        decision = PipelineNextDecision(PipelineNextStep.CONTINUE_DOCUMENT)
+        with pytest.raises(ConnectionError):
+            await rag._refetch_for_decision(decision, ingress)
+
+        republished = {m.doc_id for m in ingress.drain_documents()}
+        assert republished == {"doc-a", "doc-b"}
+        assert ingress.counts()["auto_rescan_pending"] is True
+    finally:
+        await rag.finalize_storages()
+
+
+async def test_refetch_compensation_failure_does_not_mask_original_error(tmp_path):
+    """When even the compensation RPCs fail (Manager outage), the ORIGINAL
+    strict-scan failure must still propagate — the compensation error is
+    logged, never raised over it.  The drained messages are lost to the
+    outage, but their docs are PENDING rows recovered by the next trigger."""
+    rag = await _build_rag(tmp_path, _MarkerExtract())
+    try:
+        ingress = await get_pipeline_ingress(rag.workspace)
+        ingress.put_document(_doc_msg("doc-a"))
+
+        async def dead_scan(*args, **kwargs):
+            raise ConnectionError("original strict-scan failure")
+
+        def dead_put(msg):
+            raise RuntimeError("manager down: put_document")
+
+        def dead_arm():
+            raise RuntimeError("manager down: request_auto_rescan")
+
+        rag.doc_status.get_docs_by_statuses = dead_scan
+        ingress.put_document = dead_put
+        ingress.request_auto_rescan = dead_arm
+
+        decision = PipelineNextDecision(PipelineNextStep.CONTINUE_DOCUMENT)
+        with pytest.raises(ConnectionError, match="original strict-scan failure"):
+            await rag._refetch_for_decision(decision, ingress)
+    finally:
+        await rag.finalize_storages()
+
+
+async def test_user_cancel_preserves_ingress_and_stops_run(tmp_path):
+    """Fix-proof (cancel checked BEFORE the decision): cancellation stops the
+    whole run and leaves the ingress fully retained — the auto-rescan flag
+    armed during the batch must survive to the next explicit trigger.  Without
+    the post-batch cancellation check the quiescence decision consumes the
+    flag (CONTINUE_AUTO), the loop-top handler then discards the refetch on
+    its way out, and the wake-up is lost."""
+    extract = _MarkerExtract()
+    extract.block_marker = "AAAA"
+    rag = await _build_rag(tmp_path, extract)
+    try:
+        status, lock = await _pipeline_ns(rag)
+        await rag.apipeline_enqueue_documents(input="AAAA body", file_paths="a.txt")
+
+        proc = asyncio.create_task(rag.apipeline_process_enqueue_documents())
+        await asyncio.wait_for(extract.started.wait(), timeout=5)  # A mid-flight
+
+        async with lock:
+            status["cancellation_requested"] = True
+        ingress = await get_pipeline_ingress(rag.workspace)
+        ingress.consume_auto_rescan()  # clear enqueue-era noise
+        ingress.request_auto_rescan()  # the signal that must survive the cancel
+
+        extract.release.set()
+        await asyncio.wait_for(proc, timeout=10)
+
+        assert status.get("busy") is False
+        assert status.get("cancellation_requested") is False  # bookkeeping ran
+        # No new epoch consumed the flag on the way out: it waits for the next
+        # explicit trigger, ingress fully retained.
+        assert ingress.counts()["auto_rescan_pending"] is True
+    finally:
+        extract.release.set()
+        await rag.finalize_storages()
+
+
+async def test_internal_error_halt_preserves_ingress_and_surfaces_reason(tmp_path):
+    """An internal-error abort exits like a cancel — no new epoch, ingress
+    retained — but surfaces the actionable halt message instead of a plain
+    stop, so the operator knows processing halted on a storage error."""
+    extract = _MarkerExtract()
+    extract.block_marker = "AAAA"
+    rag = await _build_rag(tmp_path, extract)
+    try:
+        status, lock = await _pipeline_ns(rag)
+        await rag.apipeline_enqueue_documents(input="AAAA body", file_paths="a.txt")
+
+        proc = asyncio.create_task(rag.apipeline_process_enqueue_documents())
+        await asyncio.wait_for(extract.started.wait(), timeout=5)
+
+        async with lock:
+            status.update(
+                {
+                    "cancellation_requested": True,
+                    "cancellation_reason": "internal_error",
+                    "cancellation_detail": "storage boom sentinel",
+                }
+            )
+        ingress = await get_pipeline_ingress(rag.workspace)
+        ingress.consume_auto_rescan()
+        ingress.request_auto_rescan()
+
+        extract.release.set()
+        await asyncio.wait_for(proc, timeout=10)
+
+        assert status.get("busy") is False
+        assert status.get("cancellation_requested") is False
+        assert ingress.counts()["auto_rescan_pending"] is True  # retained
+        assert "Pipeline halted on internal storage error" in status.get(
+            "latest_message", ""
+        )
+        assert "storage boom sentinel" in status.get("latest_message", "")
+    finally:
+        extract.release.set()
+        await rag.finalize_storages()
+
+
+async def test_journaled_pending_doc_does_not_hold_busy(tmp_path):
+    """A journaled custom-chunk doc is owned by the scan/custom-chunk recovery
+    flow: its PENDING row keeps being stripped by the consistency validator,
+    so its resident notification must be compacted (the strict scan proves the
+    row exists but the validator owns it) and the run must release ``busy`` —
+    not bounce CONTINUE_DOCUMENT forever between the two."""
+    rag = await _build_rag(tmp_path, _MarkerExtract())
+    try:
+        status, lock = await _pipeline_ns(rag)
+        await rag.apipeline_enqueue_documents(input="JJJJ body", file_paths="j.txt")
+        j_id = compute_mdhash_id("j.txt", prefix="doc-")
+
+        row = await rag.doc_status.get_by_id(j_id)
+        row["metadata"] = {
+            **(row.get("metadata") or {}),
+            CUSTOM_CHUNK_PATCH_METADATA_KEY: {"phase": "staged"},
+        }
+        await rag.doc_status.upsert({j_id: row})
+        async with lock:
+            status["request_pending"] = False  # isolate the document channel
+
+        await asyncio.wait_for(rag.apipeline_process_enqueue_documents(), timeout=10)
+
+        assert status.get("busy") is False
+        row = await rag.doc_status.get_by_id(j_id)
+        assert _status_text(row) == "pending"  # untouched by the pipeline
+        assert (row.get("metadata") or {}).get(CUSTOM_CHUNK_PATCH_METADATA_KEY) == {
+            "phase": "staged"
+        }
+        ingress = await get_pipeline_ingress(rag.workspace)
+        assert ingress.counts()["documents"] == 0
+    finally:
+        await rag.finalize_storages()
+
+
+async def test_custom_chunks_exit_hands_off_on_ingress_only_work(tmp_path):
+    """Fix-proof (handoff dual-check): a document enqueued while
+    ``ainsert_custom_chunks`` holds ``busy`` may be visible ONLY through the
+    ingress mailbox once the transitional flag is cleared.  The exit decision
+    consults ``has_work()`` alongside ``request_pending`` and hands the slot
+    to a processing run; flag-only (Phase 2) would release and strand the doc
+    in PENDING behind an idle pipeline."""
+    extract = _MarkerExtract()
+    rag = await _build_rag(tmp_path, extract)
+    try:
+        status, lock = await _pipeline_ns(rag)
+        b_id = compute_mdhash_id("b.txt", prefix="doc-")
+
+        orig_cleanup = rag._insert_done_with_cleanup
+        injected = False
+
+        async def cleanup_then_inject():
+            nonlocal injected
+            if not injected:
+                injected = True
+                await rag.apipeline_enqueue_documents(
+                    input="BBBB body", file_paths="b.txt"
+                )
+                async with lock:
+                    status["request_pending"] = False  # kill the dual-write mask
+            await orig_cleanup()
+
+        rag._insert_done_with_cleanup = cleanup_then_inject
+
+        await asyncio.wait_for(
+            rag.ainsert_custom_chunks("base text", ["alice is here"], doc_id="doc-cc"),
+            timeout=10,
+        )
+
+        assert _status_text(await rag.doc_status.get_by_id(b_id)) == "processed"
+        assert extract.calls["BBBB"] == 1
+        assert status.get("busy") is False
+    finally:
+        await rag.finalize_storages()
+
+
+async def test_custom_chunks_exit_hands_off_when_probe_fails(tmp_path):
+    """A has_work probe failure fails TOWARD handoff: the driven run re-probes
+    the mailbox itself, so a transient flake self-heals and the enqueued doc
+    still processes — releasing instead would silently defer it (and any
+    committed manual retry) to the next unrelated trigger."""
+    extract = _MarkerExtract()
+    rag = await _build_rag(tmp_path, extract)
+    try:
+        status, lock = await _pipeline_ns(rag)
+        b_id = compute_mdhash_id("b.txt", prefix="doc-")
+        ingress = await get_pipeline_ingress(rag.workspace)
+
+        orig_cleanup = rag._insert_done_with_cleanup
+        orig_has_work = ingress.has_work
+        injected = False
+
+        def flaky_has_work():
+            ingress.has_work = orig_has_work  # one transient flake
+            raise RuntimeError("manager down: has_work")
+
+        async def cleanup_then_inject():
+            nonlocal injected
+            if not injected:
+                injected = True
+                await rag.apipeline_enqueue_documents(
+                    input="BBBB body", file_paths="b.txt"
+                )
+                async with lock:
+                    status["request_pending"] = False  # kill the dual-write mask
+                ingress.has_work = flaky_has_work  # trip the exit probe
+            await orig_cleanup()
+
+        rag._insert_done_with_cleanup = cleanup_then_inject
+
+        await asyncio.wait_for(
+            rag.ainsert_custom_chunks("base text", ["alice is here"], doc_id="doc-cc"),
+            timeout=10,
+        )
+
+        assert _status_text(await rag.doc_status.get_by_id(b_id)) == "processed"
+        assert status.get("busy") is False
+    finally:
+        await rag.finalize_storages()

--- a/tests/pipeline/test_pipeline_ingress_exit.py
+++ b/tests/pipeline/test_pipeline_ingress_exit.py
@@ -501,6 +501,110 @@ async def test_cancel_after_document_decision_restores_consumed_signal(tmp_path)
         await rag.finalize_storages()
 
 
+async def test_validation_failure_after_document_decision_restores_signal(tmp_path):
+    """Fix-proof (non-cancel escape closure): a transient validation failure
+    landing AFTER a CONTINUE_DOCUMENT refetch destructively drained the doc's
+    notification — but BEFORE a batch took the docs over — must not strand the
+    doc: the finally's bookkeeping re-arms auto-rescan on ANY exit with an
+    uncommitted consumption, not just on a cancel."""
+    extract = _MarkerExtract()
+    extract.block_marker = "AAAA"
+    rag = await _build_rag(tmp_path, extract)
+    try:
+        status, lock = await _pipeline_ns(rag)
+        await rag.apipeline_enqueue_documents(input="AAAA body", file_paths="a.txt")
+        b_id = compute_mdhash_id("b.txt", prefix="doc-")
+        ingress = await get_pipeline_ingress(rag.workspace)
+
+        orig_batch = rag._run_pipeline_batch
+        orig_validate = rag._validate_and_fix_document_consistency
+        injected = False
+
+        async def failing_validate(*args, **kwargs):
+            raise ConnectionError("full_docs transient failure in validation")
+
+        async def batch_then_inject(to_process_docs, **kwargs):
+            nonlocal injected
+            await orig_batch(to_process_docs, **kwargs)
+            if not injected:
+                injected = True
+                # A PENDING doc whose ONLY signal is its resident message —
+                # and a validator that fails once that message is drained.
+                await rag.apipeline_enqueue_documents(
+                    input="BBBB body", file_paths="b.txt"
+                )
+                async with lock:
+                    status["request_pending"] = False
+                rag._validate_and_fix_document_consistency = failing_validate
+
+        rag._run_pipeline_batch = batch_then_inject
+
+        extract.release.set()
+        with pytest.raises(ConnectionError):
+            await asyncio.wait_for(
+                rag.apipeline_process_enqueue_documents(), timeout=10
+            )
+
+        rag._validate_and_fix_document_consistency = orig_validate
+        assert status.get("busy") is False
+        assert _status_text(await rag.doc_status.get_by_id(b_id)) == "pending"
+        # The drained notification survives the escape as the restored flag.
+        assert ingress.counts()["auto_rescan_pending"] is True
+    finally:
+        extract.release.set()
+        await rag.finalize_storages()
+
+
+async def test_validation_failure_after_auto_decision_restores_signal(tmp_path):
+    """Same escape for CONTINUE_AUTO: the decision consumed the auto flag;
+    a validation failure before the batch takes over must re-arm it."""
+    extract = _MarkerExtract()
+    extract.block_marker = "AAAA"
+    rag = await _build_rag(tmp_path, extract)
+    try:
+        status, lock = await _pipeline_ns(rag)
+        await rag.apipeline_enqueue_documents(input="AAAA body", file_paths="a.txt")
+        b_id = compute_mdhash_id("b.txt", prefix="doc-")
+        ingress = await get_pipeline_ingress(rag.workspace)
+
+        orig_batch = rag._run_pipeline_batch
+        orig_validate = rag._validate_and_fix_document_consistency
+        injected = False
+
+        async def failing_validate(*args, **kwargs):
+            raise ConnectionError("full_docs transient failure in validation")
+
+        async def batch_then_arm_auto(to_process_docs, **kwargs):
+            nonlocal injected
+            await orig_batch(to_process_docs, **kwargs)
+            if not injected:
+                injected = True
+                await rag.apipeline_enqueue_documents(
+                    input="BBBB body", file_paths="b.txt"
+                )
+                ingress.drain_documents()
+                async with lock:
+                    status["request_pending"] = False
+                ingress.request_auto_rescan()
+                rag._validate_and_fix_document_consistency = failing_validate
+
+        rag._run_pipeline_batch = batch_then_arm_auto
+
+        extract.release.set()
+        with pytest.raises(ConnectionError):
+            await asyncio.wait_for(
+                rag.apipeline_process_enqueue_documents(), timeout=10
+            )
+
+        rag._validate_and_fix_document_consistency = orig_validate
+        assert status.get("busy") is False
+        assert _status_text(await rag.doc_status.get_by_id(b_id)) == "pending"
+        assert ingress.counts()["auto_rescan_pending"] is True  # re-armed
+    finally:
+        extract.release.set()
+        await rag.finalize_storages()
+
+
 async def test_internal_error_halt_preserves_ingress_and_surfaces_reason(tmp_path):
     """An internal-error abort exits like a cancel — no new epoch, ingress
     retained — but surfaces the actionable halt message instead of a plain


### PR DESCRIPTION
Phase 3 of the pipeline-ingress migration. Stacked on #3465 (Phase 2, base of this PR); the stack is #3458 (Phase 1) → #3459 (Phase 0) → #3465 (Phase 2) → this.

## What this closes

Phase 2 left the ingress as a pure accelerator: anything the feeder missed was recovered by the transitional `request_pending` dual-write. Phase 3 makes the quiescence exit correct **on the mailbox alone**, so Phase 4 can delete `request_pending`:

1. **A doc published into a quiescing run is no longer maskable.** The atomic exit decision now covers the document channel: `_decide_pipeline_next_step` peeks `counts()["documents"]` (never drains under the lock) and returns `CONTINUE_DOCUMENT`.
2. **A stale notification can no longer hold `busy` forever.** The `CONTINUE_DOCUMENT` refetch resolves resident messages with the feeder's own drain→verify protocol at the supervisor level: **bounded destructive drain first, then the strict scan**. Proof: an enqueue persists the PENDING `doc_status` row *before* publishing, and the run holds `busy` (no other mutator), so any drained message whose doc is still live necessarily appears in the complete strict scan and comes back as the next batch — while a message absent from the scan is *provably* stale (terminal/FAILED-manual-only/deleted) and is compacted. Messages published after the drain stay in the mailbox for the next decision. On scan failure the drained messages are re-published and auto-rescan is armed; compensation failures log the drained ids and never displace the original error (`BaseException` symmetric on both sides).
3. **Cancellation = stop the whole run, ingress fully retained.** The cancellation check moved *inside* the decision's critical section (the cancel endpoint sets the flag under the same lock), checked **before** any signal consumption — a cancel can no longer race the decision into consuming an auto-rescan flag that then dies on the way out. `internal_error` aborts break to the finally (actionable halt message surfaced, per the existing `_finalize` contract); user cancels route to the loop-top handler. No new epoch either way; the backlog waits for the next explicit trigger.
4. **`ainsert_custom_chunks` exit hands off on mailbox-only work**: `request_pending OR ingress.has_work()`. Resolve/probe failures fail **toward handoff** — the driven run re-probes the mailbox itself; a transient flake self-heals, a persistent failure raises inside that run whose finally releases `busy`. Never a wedge, and never a silently deferred committed manual retry (manual requests never dual-write `request_pending`, so failing toward release would strand them until an unrelated trigger).
5. **`/documents/clear` clears the mailbox** while holding busy+destructive: un-ACKed manual requests retire as `CANCELLED_BY_CLEAR` (same-id replay refused), document/auto channels emptied. Failure degrades safely (residual messages are compacted by consumption idempotence; a surviving sticky request ACKs against the emptied doc_status).
6. **Workspace snapshot**: `run_workspace` captured at run entry; status/lock/ingress — including `_finalize` and the batch feeder — resolve through it. Coordination layer only; storages stay init-bound (documented boundary).

## Plan-item mapping (rev3 Phase 3)

- *Entry does not pre-drain*: already true since Phase 0/2 (peek protocol + strict initial scan; the feeder consumes backlog) — covered by tests here, no code change.
- *Quiescence reconciliation flag* (`new_work_since_last_reconcile`): structurally subsumed — every "published but missed" message either still sits in a channel at the decision (→ `CONTINUE_DOCUMENT`), or armed auto-rescan (feeder SKIP / overflow / partial upsert), or was fully resolved. The one remaining gap (crash *between* doc_status persist and publish) is documented on the decision as recoverable only by the next run's initial scan — the plan's declared boundary.
- *Supervisor destructive drain*: the ruling's failure mode (drain-then-release losing live messages) cannot occur here — release requires a subsequent decision with `has_work()` false and nothing in hand; live drained docs are returned by the strict scan; crash safety is identical to the feeder's drain (PENDING rows + next initial scan). Flagging explicitly for review since the plan's letter says "messages never leave the mailbox at exit": without a bounded compaction, a genuinely-stale message (enqueue-only doc deleted while idle) livelocks a `has_work`-only exit — this is the minimal protocol that resolves that contradiction with a proof, and it reuses the feeder's exact drain semantics.

## Tests (12 new; 4 fix-proofed by disabling the fix and watching them fail)

`tests/pipeline/test_pipeline_ingress_exit.py`:
- decision priority + per-step consumption semantics (manual peek consumes nothing; auto atomic; document peek doesn't drain; RELEASED clears busy/owner);
- **fix-proof** doc published at quiescence (dual-write mask killed) → processed as next batch;
- **fix-proof** stale message compacted, run releases (no livelock, no residency);
- refetch compensation (scan failure → messages republished + auto armed) and compensation-failure (original error still propagates);
- **fix-proof** user cancel preserves the armed auto-rescan flag (decision consumes nothing on the way out); internal_error same + halt message surfaced;
- journaled custom-chunk doc doesn't hold busy (notification compacted, journal intact);
- **fix-proof** custom-chunks handoff on ingress-only work; handoff when the has_work probe flakes.

`tests/api/routes/test_clear_documents_ingress.py`: all three channels cleared + CANCELLED_BY_CLEAR replay refusal; clear survives an ingress failure.

Adversarial self-review ran (code-reviewer + silent-failure-hunter agents): the drain-before-scan proof, cancel bookkeeping and clear degradation were verified sound; their findings (atomic in-decision cancel check, fail-toward-handoff, compensation observability, F401) are incorporated above.

Full suite: **4169 passed, 36 skipped**; pinned ruff (pre-commit) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)