### PR TITLE
fix(api): reject query text that strips below min_length

### DIFF
--- a/lightrag/api/routers/query_routes.py
+++ b/lightrag/api/routers/query_routes.py
@@ -123,8 +123,7 @@ class QueryRequest(BaseModel):
     @field_validator("query", mode="after")
     @classmethod
     def query_strip_after(cls, query: str) -> str:
-        # min_length runs before strip; re-check so whitespace-only pads cannot
-        # shrink the query below the documented 3-character floor.
+        # min_length runs before strip; re-check so pads cannot shrink below 3 chars.
         stripped = query.strip()
         if len(stripped) < 3:
             raise ValueError("query must be at least 3 characters after stripping")

--- a/lightrag/api/routers/query_routes.py
+++ b/lightrag/api/routers/query_routes.py
@@ -123,7 +123,12 @@ class QueryRequest(BaseModel):
     @field_validator("query", mode="after")
     @classmethod
     def query_strip_after(cls, query: str) -> str:
-        return query.strip()
+        # min_length runs before strip; re-check so whitespace-only pads cannot
+        # shrink the query below the documented 3-character floor.
+        stripped = query.strip()
+        if len(stripped) < 3:
+            raise ValueError("query must be at least 3 characters after stripping")
+        return stripped
 
     @field_validator("conversation_history", mode="after")
     @classmethod

--- a/tests/api/routes/test_query_request_strip.py
+++ b/tests/api/routes/test_query_request_strip.py
@@ -1,0 +1,27 @@
+"""QueryRequest must keep min_length=3 after stripping whitespace."""
+
+import importlib
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+_original_argv = sys.argv[:]
+sys.argv = [sys.argv[0]]
+_qr = importlib.import_module("lightrag.api.routers.query_routes")
+sys.argv = _original_argv
+
+QueryRequest = _qr.QueryRequest
+
+pytestmark = pytest.mark.offline
+
+
+@pytest.mark.parametrize("query", ["   ", "\t\t\t", "  a  ", "ab ", " a "])
+def test_query_request_rejects_whitespace_that_shrinks_below_min_length(query):
+    with pytest.raises(ValidationError):
+        QueryRequest(query=query)
+
+
+def test_query_request_strips_surrounding_whitespace_when_still_long_enough():
+    req = QueryRequest(query="  abc  ")
+    assert req.query == "abc"


### PR DESCRIPTION
`QueryRequest` enforced `min_length=3` before strip, so values like `"  a  "` or whitespace-padded shorts passed validation and then shrank below the floor.

Validate length after strip.