### PR TITLE
fix(api): reject whitespace-only insert text bodies

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -422,8 +422,7 @@ class InsertTextRequest(BaseModel):
     @field_validator("text", mode="after")
     @classmethod
     def strip_text_after(cls, text: str) -> str:
-        # min_length runs before strip; reject whitespace-only bodies so empty
-        # documents are not enqueued after a 200 response.
+        # min_length runs before strip; reject whitespace-only so empty docs are not enqueued.
         stripped = text.strip()
         if not stripped:
             raise ValueError("text cannot be empty or whitespace-only")

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -422,7 +422,12 @@ class InsertTextRequest(BaseModel):
     @field_validator("text", mode="after")
     @classmethod
     def strip_text_after(cls, text: str) -> str:
-        return text.strip()
+        # min_length runs before strip; reject whitespace-only bodies so empty
+        # documents are not enqueued after a 200 response.
+        stripped = text.strip()
+        if not stripped:
+            raise ValueError("text cannot be empty or whitespace-only")
+        return stripped
 
     @field_validator("file_source", mode="before")
     @classmethod
@@ -471,7 +476,10 @@ class InsertTextsRequest(BaseModel):
     @field_validator("texts", mode="after")
     @classmethod
     def strip_texts_after(cls, texts: list[str]) -> list[str]:
-        return [text.strip() for text in texts]
+        stripped = [text.strip() for text in texts]
+        if any(not text for text in stripped):
+            raise ValueError("texts cannot contain empty or whitespace-only entries")
+        return stripped
 
     @field_validator("file_sources", mode="before")
     @classmethod

--- a/tests/api/routes/test_insert_text_whitespace.py
+++ b/tests/api/routes/test_insert_text_whitespace.py
@@ -1,0 +1,46 @@
+"""Insert text bodies must stay non-empty after stripping whitespace."""
+
+import importlib
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+_original_argv = sys.argv[:]
+sys.argv = [sys.argv[0]]
+_dr = importlib.import_module("lightrag.api.routers.document_routes")
+sys.argv = _original_argv
+
+InsertTextRequest = _dr.InsertTextRequest
+InsertTextsRequest = _dr.InsertTextsRequest
+
+pytestmark = pytest.mark.offline
+
+
+@pytest.mark.parametrize("text", ["  ", "\n\n", "\t"])
+def test_insert_text_rejects_whitespace_only(text):
+    with pytest.raises(ValidationError):
+        InsertTextRequest(text=text)
+
+
+def test_insert_text_strips_surrounding_whitespace():
+    req = InsertTextRequest(text="  hello  ")
+    assert req.text == "hello"
+
+
+@pytest.mark.parametrize(
+    "texts",
+    [
+        ["  "],
+        ["ok", "  "],
+        ["\n\n", "hi"],
+    ],
+)
+def test_insert_texts_rejects_whitespace_only_entries(texts):
+    with pytest.raises(ValidationError):
+        InsertTextsRequest(texts=texts)
+
+
+def test_insert_texts_strips_surrounding_whitespace():
+    req = InsertTextsRequest(texts=["  a  ", " b "])
+    assert req.texts == ["a", "b"]


### PR DESCRIPTION
Insert text requests accepted whitespace-only bodies that became empty after strip, so empty documents were enqueued.

Reject whitespace-only text after strip.