### PR TITLE
fix(api): reject non-finite semantic breakpoint amounts

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -5,6 +5,7 @@ This module contains all document-related routes for the LightRAG API.
 import asyncio
 import base64
 import binascii
+import math
 import re
 import shutil
 import sqlite3
@@ -543,6 +544,9 @@ class SemanticVectorChunkParams(_StrictChunkParams):
         amt = self.breakpoint_threshold_amount
         if amt is None:
             return self
+        # nan comparisons are always False, so reject non-finite before <= / > checks.
+        if not math.isfinite(amt):
+            raise ValueError("breakpoint_threshold_amount must be a finite number")
         # ``> 0`` is type-independent (every threshold type wants a positive
         # magnitude), so it is safe to enforce at parse time.
         if amt <= 0:

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -539,6 +539,17 @@ class SemanticVectorChunkParams(_StrictChunkParams):
             ) from exc
         return v
 
+    @field_validator("breakpoint_threshold_amount", mode="before")
+    @classmethod
+    def _reject_nonfinite_amount(cls, v: Any) -> Any:
+        # JSON decoders may deliver nan/inf as floats. Raising while leaving
+        # those values in ValidationError.input makes FastAPI's JSONResponse
+        # fail (non-compliant floats) and turn the 422 into a 500. Replace
+        # with a JSON-safe marker so strict float typing rejects cleanly.
+        if isinstance(v, float) and not math.isfinite(v):
+            return "non-finite"
+        return v
+
     @model_validator(mode="after")
     def _amount_in_range(self) -> "SemanticVectorChunkParams":
         amt = self.breakpoint_threshold_amount

--- a/tests/api/routes/test_document_routes_chunking.py
+++ b/tests/api/routes/test_document_routes_chunking.py
@@ -105,6 +105,21 @@ _ALL_STRATEGY_KEYS = {
             },
         },
         {
+            # nan bypasses ``amt <= 0`` / ``amt > 100``; reject before chunker.
+            "strategy": "semantic_vector",
+            "params": {
+                "breakpoint_threshold_type": "percentile",
+                "breakpoint_threshold_amount": float("nan"),
+            },
+        },
+        {
+            "strategy": "semantic_vector",
+            "params": {
+                "breakpoint_threshold_type": "percentile",
+                "breakpoint_threshold_amount": float("inf"),
+            },
+        },
+        {
             # malformed regex must be compiled/rejected at parse time
             "strategy": "semantic_vector",
             "params": {"sentence_split_regex": "("},

--- a/tests/api/routes/test_document_routes_chunking.py
+++ b/tests/api/routes/test_document_routes_chunking.py
@@ -580,6 +580,34 @@ def test_insert_text_returns_422_on_malformed_chunking_without_scheduling(monkey
     assert captured == {}
 
 
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_insert_text_returns_422_on_nonfinite_breakpoint_amount(monkeypatch, bad):
+    """Non-finite amounts must 422 on the HTTP path, not 500 via JSONResponse."""
+    import json
+
+    client, captured = _make_client(monkeypatch)
+    payload = {
+        "text": "hello",
+        "file_source": "a.md",
+        "chunking": {
+            "strategy": "semantic_vector",
+            "params": {
+                "breakpoint_threshold_type": "percentile",
+                "breakpoint_threshold_amount": bad,
+            },
+        },
+    }
+    resp = client.post(
+        "/documents/text",
+        headers={**_HEADERS, "Content-Type": "application/json"},
+        content=json.dumps(payload, allow_nan=True),
+    )
+    assert resp.status_code == 422
+    body = resp.json()
+    assert "detail" in body
+    assert captured == {}
+
+
 def test_insert_text_returns_422_when_size_below_inherited_overlap(monkeypatch):
     # chunk_token_size=50 in the request, overlap=100 inherited from the
     # rag's addon_params (not in the request). The model can't catch this;


### PR DESCRIPTION
`breakpoint_threshold_amount=nan` bypassed the `<=0` / `>100` checks and later crashed percentile work in the background.

Reject non-finite amounts up front.