### PR TITLE
fix(api): reject whitespace-only graph entity names

### DIFF
--- a/lightrag/api/routers/graph_routes.py
+++ b/lightrag/api/routers/graph_routes.py
@@ -5,7 +5,7 @@ This module contains all graph-related routes for the LightRAG API.
 from typing import Optional, Dict, Any
 import traceback
 from fastapi import APIRouter, Depends, Query, HTTPException
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from lightrag.base import DeletionResult
 from lightrag.utils import logger
@@ -30,6 +30,17 @@ class EntityUpdateRequest(BaseModel):
     @classmethod
     def validate_entity_name(cls, entity_name: str) -> str:
         return _require_nonempty_entity_name(entity_name)
+
+    @model_validator(mode="after")
+    def validate_rename_target_name(self) -> "EntityUpdateRequest":
+        # Rename payloads put the new name in updated_data["entity_name"].
+        if "entity_name" not in self.updated_data:
+            return self
+        new_name = self.updated_data["entity_name"]
+        if not isinstance(new_name, str):
+            raise ValueError("Entity name cannot be empty")
+        self.updated_data["entity_name"] = _require_nonempty_entity_name(new_name)
+        return self
 
 
 class RelationUpdateRequest(BaseModel):

--- a/lightrag/api/routers/graph_routes.py
+++ b/lightrag/api/routers/graph_routes.py
@@ -13,17 +13,34 @@ from ..utils_api import get_combined_auth_dependency, internal_server_error
 from .document_routes import check_pipeline_busy_or_raise
 
 
+def _require_nonempty_entity_name(entity_name: str) -> str:
+    """Strip and reject blank names so create/update match delete routes."""
+    if not entity_name or not entity_name.strip():
+        raise ValueError("Entity name cannot be empty")
+    return entity_name.strip()
+
+
 class EntityUpdateRequest(BaseModel):
     entity_name: str
     updated_data: Dict[str, Any]
     allow_rename: bool = False
     allow_merge: bool = False
 
+    @field_validator("entity_name", mode="after")
+    @classmethod
+    def validate_entity_name(cls, entity_name: str) -> str:
+        return _require_nonempty_entity_name(entity_name)
+
 
 class RelationUpdateRequest(BaseModel):
     source_id: str
     target_id: str
     updated_data: Dict[str, Any]
+
+    @field_validator("source_id", "target_id", mode="after")
+    @classmethod
+    def validate_endpoint_names(cls, entity_name: str) -> str:
+        return _require_nonempty_entity_name(entity_name)
 
 
 class EntityMergeRequest(BaseModel):
@@ -39,6 +56,16 @@ class EntityMergeRequest(BaseModel):
         min_length=1,
         examples=["Elon Musk"],
     )
+
+    @field_validator("entities_to_change", mode="after")
+    @classmethod
+    def validate_entities_to_change(cls, entities: list[str]) -> list[str]:
+        return [_require_nonempty_entity_name(name) for name in entities]
+
+    @field_validator("entity_to_change_into", mode="after")
+    @classmethod
+    def validate_entity_to_change_into(cls, entity_name: str) -> str:
+        return _require_nonempty_entity_name(entity_name)
 
 
 class EntityCreateRequest(BaseModel):
@@ -59,6 +86,11 @@ class EntityCreateRequest(BaseModel):
         ],
     )
 
+    @field_validator("entity_name", mode="after")
+    @classmethod
+    def validate_entity_name(cls, entity_name: str) -> str:
+        return _require_nonempty_entity_name(entity_name)
+
 
 class DeleteEntityRequest(BaseModel):
     entity_name: str = Field(..., description="The name of the entity to delete.")
@@ -66,9 +98,7 @@ class DeleteEntityRequest(BaseModel):
     @field_validator("entity_name", mode="after")
     @classmethod
     def validate_entity_name(cls, entity_name: str) -> str:
-        if not entity_name or not entity_name.strip():
-            raise ValueError("Entity name cannot be empty")
-        return entity_name.strip()
+        return _require_nonempty_entity_name(entity_name)
 
 
 class DeleteRelationRequest(BaseModel):
@@ -78,9 +108,7 @@ class DeleteRelationRequest(BaseModel):
     @field_validator("source_entity", "target_entity", mode="after")
     @classmethod
     def validate_entity_names(cls, entity_name: str) -> str:
-        if not entity_name or not entity_name.strip():
-            raise ValueError("Entity name cannot be empty")
-        return entity_name.strip()
+        return _require_nonempty_entity_name(entity_name)
 
 
 class RelationCreateRequest(BaseModel):
@@ -107,6 +135,11 @@ class RelationCreateRequest(BaseModel):
             }
         ],
     )
+
+    @field_validator("source_entity", "target_entity", mode="after")
+    @classmethod
+    def validate_entity_names(cls, entity_name: str) -> str:
+        return _require_nonempty_entity_name(entity_name)
 
 
 def create_graph_routes(rag, api_key: Optional[str] = None):

--- a/tests/api/routes/test_graph_entity_name_whitespace.py
+++ b/tests/api/routes/test_graph_entity_name_whitespace.py
@@ -38,6 +38,25 @@ def test_entity_update_rejects_whitespace_only_name(name):
         EntityUpdateRequest(entity_name=name, updated_data={"description": "x"})
 
 
+@pytest.mark.parametrize("name", ["  ", "\t", "\n"])
+def test_entity_update_rejects_whitespace_only_rename_target(name):
+    with pytest.raises(ValidationError):
+        EntityUpdateRequest(
+            entity_name="Tesla",
+            updated_data={"entity_name": name},
+            allow_rename=True,
+        )
+
+
+def test_entity_update_strips_rename_target_name():
+    req = EntityUpdateRequest(
+        entity_name="Tesla",
+        updated_data={"entity_name": "  Elon Musk  "},
+        allow_rename=True,
+    )
+    assert req.updated_data["entity_name"] == "Elon Musk"
+
+
 @pytest.mark.parametrize(
     "kwargs",
     [

--- a/tests/api/routes/test_graph_entity_name_whitespace.py
+++ b/tests/api/routes/test_graph_entity_name_whitespace.py
@@ -1,0 +1,80 @@
+"""Graph create/update/merge reject whitespace-only entity names like delete."""
+
+import importlib
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+_original_argv = sys.argv[:]
+sys.argv = [sys.argv[0]]
+_gr = importlib.import_module("lightrag.api.routers.graph_routes")
+sys.argv = _original_argv
+
+EntityCreateRequest = _gr.EntityCreateRequest
+EntityUpdateRequest = _gr.EntityUpdateRequest
+EntityMergeRequest = _gr.EntityMergeRequest
+RelationCreateRequest = _gr.RelationCreateRequest
+RelationUpdateRequest = _gr.RelationUpdateRequest
+DeleteEntityRequest = _gr.DeleteEntityRequest
+
+pytestmark = pytest.mark.offline
+
+
+@pytest.mark.parametrize("name", ["  ", "\t", "\n"])
+def test_entity_create_rejects_whitespace_only_name(name):
+    with pytest.raises(ValidationError):
+        EntityCreateRequest(entity_name=name, entity_data={"description": "x"})
+
+
+def test_entity_create_strips_surrounding_whitespace():
+    req = EntityCreateRequest(entity_name="  Tesla  ", entity_data={"description": "x"})
+    assert req.entity_name == "Tesla"
+
+
+@pytest.mark.parametrize("name", ["  ", "\t"])
+def test_entity_update_rejects_whitespace_only_name(name):
+    with pytest.raises(ValidationError):
+        EntityUpdateRequest(entity_name=name, updated_data={"description": "x"})
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"entities_to_change": ["  "], "entity_to_change_into": "Keep"},
+        {"entities_to_change": ["Keep"], "entity_to_change_into": "  "},
+        {"entities_to_change": ["A", "  "], "entity_to_change_into": "Keep"},
+    ],
+)
+def test_entity_merge_rejects_whitespace_only_names(kwargs):
+    with pytest.raises(ValidationError):
+        EntityMergeRequest(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"source_entity": "  ", "target_entity": "B", "relation_data": {"weight": 1.0}},
+        {"source_entity": "A", "target_entity": "  ", "relation_data": {"weight": 1.0}},
+    ],
+)
+def test_relation_create_rejects_whitespace_only_endpoints(kwargs):
+    with pytest.raises(ValidationError):
+        RelationCreateRequest(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"source_id": "  ", "target_id": "B", "updated_data": {"weight": 1.0}},
+        {"source_id": "A", "target_id": "\t", "updated_data": {"weight": 1.0}},
+    ],
+)
+def test_relation_update_rejects_whitespace_only_endpoints(kwargs):
+    with pytest.raises(ValidationError):
+        RelationUpdateRequest(**kwargs)
+
+
+def test_delete_entity_still_rejects_whitespace_only_name():
+    with pytest.raises(ValidationError):
+        DeleteEntityRequest(entity_name="  ")


### PR DESCRIPTION
Graph create/update/merge accepted whitespace-only entity names while delete already strip-rejects them.

Reject whitespace-only names on the write paths too.