### PR TITLE
feat: support graph-first ingestion with deferred vector indexing

### DIFF
--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -619,6 +619,7 @@ OpenSearchGraphStorage   OpenSearch
 
 **VECTOR_STORAGE**
 ```
+NoopVectorDBStorage         Disabled (graph-only ingestion)
 NanoVectorDBStorage         NanoVector (default)
 PGVectorStorage             Postgres
 MilvusVectorDBStorage       Milvus
@@ -627,6 +628,79 @@ QdrantVectorDBStorage       Qdrant
 MongoVectorDBStorage        MongoDB
 OpenSearchVectorDBStorage   OpenSearch
 ```
+
+#### Graph-only ingestion
+
+`NoopVectorDBStorage` is intended for an initial or offline corpus backfill
+where the graph and KV stores are authoritative and vector indexes can be
+materialized once from the final state. It avoids embedding and persisting
+intermediate entity, relationship, and chunk revisions during ingestion.
+
+Do not use this workflow when newly inserted documents must become queryable
+immediately. Normal incremental ingestion should use the intended persistent
+vector backend from the beginning.
+
+Configure the backfill process with the no-op backend. `embedding_func=None` is
+supported when no other configured component requires embeddings:
+
+```python
+rag = LightRAG(
+    working_dir=WORKING_DIR,
+    llm_model_func=llm_model_func,
+    embedding_func=None,
+    vector_storage="NoopVectorDBStorage",
+)
+```
+
+The backend accepts vector mutations without calling the embedding function or
+persisting vectors. Graph, full-document, text-chunk, LLM-cache, document-status,
+and graph-recovery writes continue normally.
+
+While `NoopVectorDBStorage` is active, only `bypass` queries are available.
+`local`, `global`, `hybrid`, `mix`, and `naive` modes require vector indexes and
+raise an error that points to `lightrag-rebuild-vdb`.
+
+If the semantic-vector (`V`) chunker is selected while `embedding_func=None`,
+it logs a warning and falls back to recursive-character chunking. Configure an
+embedding function during ingestion if semantic-vector chunk boundaries are
+required; this is separate from whether vectors are persisted.
+
+##### Switching to persistent vectors
+
+After the backfill, stop the server and all ingestion writers. Keep
+`WORKING_DIR`, `WORKSPACE`, graph storage, KV storage, and their connection
+settings unchanged. For example, switch from Noop to NanoVector with an OpenAI
+embedding model while pointing to the same graph and KV sources:
+
+```bash
+export WORKING_DIR=/data/lightrag/rag_storage
+export WORKSPACE=project_a
+export LIGHTRAG_GRAPH_STORAGE=NetworkXStorage
+export LIGHTRAG_KV_STORAGE=JsonKVStorage
+export LIGHTRAG_VECTOR_STORAGE=NanoVectorDBStorage
+export EMBEDDING_BINDING=openai
+export EMBEDDING_MODEL=text-embedding-3-small
+export EMBEDDING_DIM=1536
+
+lightrag-rebuild-vdb  # Select "Rebuild ALL vector storages"
+```
+
+Replace all example values with the backfill's actual storage settings and the
+production embedding model, dimension, host, and credentials. Backend-specific
+connection variables must remain available. If the same `.env` already contains
+these values, only the vector and embedding entries need to change. Run this in
+a new process or after a restart, then keep the persistent configuration for
+later queries and incremental ingestion.
+
+Rebuild cost and memory grow with the final graph and chunk data. If rebuilding
+fails or is interrupted, keep writers stopped and rerun it with the same
+configuration; the graph and KV sources remain unchanged. Start the server only
+after the tool reports a successful rebuild, for example with
+`lightrag-server`, because LightRAG has no persisted vector-index readiness
+marker.
+
+See `lightrag/tools/README_REBUILD_VDB.md` for rebuild options and operational
+details.
 
 **DOC_STATUS_STORAGE**
 ```

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -225,20 +225,23 @@ class StorageNameSpace(ABC):
 
 @dataclass
 class BaseVectorStorage(StorageNameSpace, ABC):
-    embedding_func: EmbeddingFunc
+    requires_embedding_func: ClassVar[bool] = True
+
+    embedding_func: EmbeddingFunc | None
     cosine_better_than_threshold: float = field(default=0.2)
     meta_fields: set[str] = field(default_factory=set)
 
     def _validate_embedding_func(self):
-        """Validate that embedding_func is provided.
+        """Validate the backend's embedding function requirement.
 
         This method should be called at the beginning of __post_init__
-        in all vector storage implementations.
+        in all vector storage implementations. Backends that never materialize
+        vectors may set ``requires_embedding_func`` to ``False``.
 
         Raises:
-            ValueError: If embedding_func is None
+            ValueError: If the backend requires embedding_func and it is None
         """
-        if self.embedding_func is None:
+        if self.requires_embedding_func and self.embedding_func is None:
             raise ValueError(
                 "embedding_func is required for vector storage. "
                 "Please provide a valid EmbeddingFunc instance."

--- a/lightrag/kg/__init__.py
+++ b/lightrag/kg/__init__.py
@@ -22,6 +22,7 @@ STORAGE_IMPLEMENTATIONS = {
     },
     "VECTOR_STORAGE": {
         "implementations": [
+            "NoopVectorDBStorage",
             "NanoVectorDBStorage",
             "MilvusVectorDBStorage",
             "PGVectorStorage",
@@ -74,6 +75,7 @@ STORAGE_ENV_REQUIREMENTS: dict[str, list[str]] = {
         "POSTGRES_DATABASE",
     ],
     # Vector Storage Implementations
+    "NoopVectorDBStorage": [],
     "NanoVectorDBStorage": [],
     "MilvusVectorDBStorage": [
         "MILVUS_URI",
@@ -115,6 +117,7 @@ STORAGES = {
     "NetworkXStorage": ".kg.networkx_impl",
     "JsonKVStorage": ".kg.json_kv_impl",
     "NanoVectorDBStorage": ".kg.nano_vector_db_impl",
+    "NoopVectorDBStorage": ".kg.noop_vector_db_impl",
     "JsonDocStatusStorage": ".kg.json_doc_status_impl",
     "Neo4JStorage": ".kg.neo4j_impl",
     "MilvusVectorDBStorage": ".kg.milvus_impl",

--- a/lightrag/kg/noop_vector_db_impl.py
+++ b/lightrag/kg/noop_vector_db_impl.py
@@ -1,0 +1,66 @@
+"""No-op vector storage for graph-only ingestion workflows."""
+
+from dataclasses import dataclass
+from typing import Any, ClassVar, final
+
+from lightrag.base import BaseVectorStorage
+from lightrag.exceptions import StorageCapabilityError
+
+
+@final
+@dataclass
+class NoopVectorDBStorage(BaseVectorStorage):
+    """Accept vector storage mutations without embedding or persistence.
+
+    Use this backend when ingestion should build only the graph and KV stores.
+    Configure a persistent vector backend and run ``lightrag-rebuild-vdb``
+    before using retrieval modes that query vector indexes.
+    """
+
+    requires_embedding_func: ClassVar[bool] = False
+    persists_vectors: ClassVar[bool] = False
+
+    def __post_init__(self) -> None:
+        self._validate_embedding_func()
+
+    async def query(
+        self,
+        query: str,
+        top_k: int,
+        query_embedding: list[float] | None = None,
+    ) -> list[dict[str, Any]]:
+        raise StorageCapabilityError(
+            "Vector retrieval is disabled by NoopVectorDBStorage. "
+            "Configure a persistent vector storage and run "
+            "`lightrag-rebuild-vdb` before querying."
+        )
+
+    async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
+        return None
+
+    async def delete(self, ids: list[str]) -> None:
+        return None
+
+    async def delete_entity(self, entity_name: str) -> None:
+        return None
+
+    async def delete_entity_relation(self, entity_name: str) -> None:
+        return None
+
+    async def get_by_id(self, id: str) -> dict[str, Any] | None:
+        return None
+
+    async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any] | None]:
+        return [None] * len(ids)
+
+    async def get_vectors_by_ids(self, ids: list[str]) -> dict[str, list[float]]:
+        return {}
+
+    async def index_done_callback(self) -> None:
+        return None
+
+    async def drop(self) -> dict[str, str]:
+        return {
+            "status": "success",
+            "message": "Noop vector storage contains no data",
+        }

--- a/lightrag/tools/README_REBUILD_VDB.md
+++ b/lightrag/tools/README_REBUILD_VDB.md
@@ -38,6 +38,15 @@ from the authoritative graph/KV sources. The consistency check is not enough
 for this case because it only detects missing graph → VDB records, not vectors
 that exist but were embedded with a previous model or dimension.
 
+The tool also completes a graph-only backfill performed with
+`NoopVectorDBStorage`. Stop every writer, preserve the same working directory,
+workspace, graph storage, and KV storage, switch to the intended persistent
+vector backend, configure the production embedding model and dimension, and
+select **Rebuild ALL vector storages**. Create a new `LightRAG` instance or
+restart the process after changing the vector backend. Do not start the server
+until the rebuild succeeds; there is currently no persisted vector-index
+readiness marker.
+
 ## Usage
 
 ```bash
@@ -105,6 +114,10 @@ Menu options:
 
 The core rebuild/check functions are plain async functions that accept your
 own initialized storage instances:
+
+Rebuild targets must persist a queryable vector index. Passing a graph-only
+backend such as `NoopVectorDBStorage` raises before source records are read or
+the target is dropped; configure a persistent vector backend first.
 
 ```python
 from lightrag.tools.rebuild_vdb import (

--- a/lightrag/tools/rebuild_vdb.py
+++ b/lightrag/tools/rebuild_vdb.py
@@ -61,6 +61,7 @@ from lightrag.constants import (
     DEFAULT_COSINE_THRESHOLD,
     DEFAULT_EMBEDDING_BATCH_NUM,
 )
+from lightrag.exceptions import StorageCapabilityError
 from lightrag.kg import STORAGE_ENV_REQUIREMENTS
 from lightrag.namespace import NameSpace
 from lightrag.utils import (
@@ -129,6 +130,16 @@ def _new_stats(label: str, source_total: int) -> Dict[str, Any]:
         "failed_batches": 0,
         "errors": [],
     }
+
+
+def _ensure_vector_rebuild_supported(vdb) -> None:
+    if not getattr(vdb, "persists_vectors", True):
+        storage_name = type(vdb).__name__
+        raise StorageCapabilityError(
+            f"{storage_name} does not persist vectors and cannot be used as a "
+            "rebuild target. Configure a persistent vector storage before "
+            "calling the rebuild library API."
+        )
 
 
 async def _drop_vdb(vdb, label: str) -> None:
@@ -242,6 +253,7 @@ async def rebuild_entities_vdb(
     Payloads mirror the authoritative write point in
     operate._merge_nodes_then_upsert field for field.
     """
+    _ensure_vector_rebuild_supported(entities_vdb)
     from lightrag.operate import _truncate_vdb_content
 
     nodes = await graph.get_all_nodes()
@@ -302,6 +314,7 @@ async def rebuild_relationships_vdb(
     undirected edge once per direction (e.g. Neo4j, Memgraph) are deduplicated
     by that normalized id.
     """
+    _ensure_vector_rebuild_supported(relationships_vdb)
     from lightrag.operate import _truncate_vdb_content
 
     edges = await graph.get_all_edges()
@@ -432,6 +445,7 @@ async def rebuild_chunks_vdb(
     keys (and silently drop a scheme), all keys are enumerated and the
     per-record ``content`` check below is the only filter.
     """
+    _ensure_vector_rebuild_supported(chunks_vdb)
     chunk_ids = [str(key) for key in await enumerate_kv_keys(text_chunks_kv)]
     stats = _new_stats("chunks", len(chunk_ids))
 

--- a/tests/kg/noop_impl/test_noop_vector_storage.py
+++ b/tests/kg/noop_impl/test_noop_vector_storage.py
@@ -1,0 +1,241 @@
+from unittest.mock import AsyncMock
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG, QueryParam
+from lightrag.base import DocStatus
+from lightrag.kg import STORAGE_IMPLEMENTATIONS, STORAGES
+from lightrag.kg.factory import get_storage_class
+from lightrag.kg.noop_vector_db_impl import NoopVectorDBStorage
+from lightrag.tools.rebuild_vdb import (
+    rebuild_chunks_vdb,
+    rebuild_entities_vdb,
+    rebuild_relationships_vdb,
+)
+from lightrag.utils import EmbeddingFunc, compute_mdhash_id
+
+
+EXTRACTION_RESULT = "\n".join(
+    [
+        "entity<|#|>Alice<|#|>person<|#|>A person",
+        "entity<|#|>Bob<|#|>person<|#|>Another person",
+        "relation<|#|>Alice<|#|>Bob<|#|>knows<|#|>Alice knows Bob",
+        "<|COMPLETE|>",
+    ]
+)
+
+
+class FailingEmbedding:
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    async def __call__(self, texts: list[str], **_: object) -> np.ndarray:
+        self.call_count += 1
+        raise AssertionError("NoopVectorDBStorage must not call embedding_func")
+
+
+class DeterministicEmbedding:
+    async def __call__(self, texts: list[str], **_: object) -> np.ndarray:
+        vector = np.arange(1, 9, dtype=np.float32)
+        return np.tile(vector, (len(texts), 1))
+
+
+def make_storage(embedding: FailingEmbedding) -> NoopVectorDBStorage:
+    return NoopVectorDBStorage(
+        namespace="test_vectors",
+        workspace="test_workspace",
+        global_config={},
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8,
+            max_token_size=512,
+            func=embedding,
+        ),
+        meta_fields={"content"},
+    )
+
+
+def test_noop_vector_storage_is_registered() -> None:
+    assert (
+        "NoopVectorDBStorage"
+        in STORAGE_IMPLEMENTATIONS["VECTOR_STORAGE"]["implementations"]
+    )
+    assert STORAGES["NoopVectorDBStorage"] == ".kg.noop_vector_db_impl"
+    assert get_storage_class("NoopVectorDBStorage") is NoopVectorDBStorage
+    assert NoopVectorDBStorage.requires_embedding_func is False
+    assert NoopVectorDBStorage.persists_vectors is False
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_noop_vector_storage_contract_never_embeds() -> None:
+    embedding = FailingEmbedding()
+    storage = make_storage(embedding)
+
+    await storage.initialize()
+    await storage.upsert({"id-1": {"content": "alpha"}})
+    await storage.delete(["id-1"])
+    await storage.delete_entity("Entity")
+    await storage.delete_entity_relation("Entity")
+    await storage.index_done_callback()
+    await storage.drop_pending_index_ops()
+
+    assert await storage.get_by_id("id-1") is None
+    assert await storage.get_by_ids(["id-1", "id-2"]) == [None, None]
+    assert await storage.get_vectors_by_ids(["id-1"]) == {}
+    assert await storage.drop() == {
+        "status": "success",
+        "message": "Noop vector storage contains no data",
+    }
+    assert embedding.call_count == 0
+
+    with pytest.raises(RuntimeError, match="lightrag-rebuild-vdb"):
+        await storage.query("question", top_k=5)
+
+    await storage.finalize()
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_graph_only_lightrag_initializes_without_embedding_func(tmp_path) -> None:
+    rag = LightRAG(
+        working_dir=str(tmp_path),
+        vector_storage="NoopVectorDBStorage",
+        llm_model_func=AsyncMock(return_value=""),
+        embedding_func=None,
+    )
+
+    await rag.initialize_storages()
+
+    assert isinstance(rag.entities_vdb, NoopVectorDBStorage)
+    assert isinstance(rag.relationships_vdb, NoopVectorDBStorage)
+    assert isinstance(rag.chunks_vdb, NoopVectorDBStorage)
+
+    await rag.finalize_storages()
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_graph_only_query_reports_vector_storage_failure(tmp_path) -> None:
+    rag = LightRAG(
+        working_dir=str(tmp_path),
+        vector_storage="NoopVectorDBStorage",
+        llm_model_func=AsyncMock(return_value=""),
+        embedding_func=None,
+    )
+    await rag.initialize_storages()
+
+    result = await rag.aquery_llm("question", QueryParam(mode="naive"))
+
+    assert result["status"] == "failure"
+    assert "NoopVectorDBStorage" in result["message"]
+    assert "persistent vector storage" in result["message"]
+    assert "lightrag-rebuild-vdb" in result["message"]
+    await rag.finalize_storages()
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_graph_only_bypass_query_remains_available(tmp_path) -> None:
+    rag = LightRAG(
+        working_dir=str(tmp_path),
+        vector_storage="NoopVectorDBStorage",
+        llm_model_func=AsyncMock(return_value="direct answer"),
+        embedding_func=None,
+    )
+    await rag.initialize_storages()
+
+    result = await rag.aquery_llm(
+        "question",
+        QueryParam(mode="bypass", stream=False),
+    )
+
+    assert result["llm_response"]["content"] == "direct answer"
+    await rag.finalize_storages()
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_graph_only_normal_ingestion_rebuilds_into_nano_vector_storage(
+    tmp_path,
+) -> None:
+    workspace = f"graph-only-{tmp_path.name}"
+    failing_embedding = FailingEmbedding()
+    graph_only_rag = LightRAG(
+        working_dir=str(tmp_path),
+        workspace=workspace,
+        vector_storage="NoopVectorDBStorage",
+        llm_model_func=AsyncMock(return_value=EXTRACTION_RESULT),
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8,
+            max_token_size=512,
+            func=failing_embedding,
+        ),
+        entity_extract_max_gleaning=0,
+    )
+    await graph_only_rag.initialize_storages()
+    await graph_only_rag.ainsert("Alice knows Bob.", file_paths="example.txt")
+
+    processed_docs = await graph_only_rag.doc_status.get_docs_by_status(
+        DocStatus.PROCESSED
+    )
+    assert len(processed_docs) == 1
+    doc_id, doc_status = next(iter(processed_docs.items()))
+    chunk_ids = doc_status.chunks_list
+    assert await graph_only_rag.full_docs.get_by_id(doc_id) is not None
+    assert len(chunk_ids) == 1
+    assert await graph_only_rag.text_chunks.get_by_id(chunk_ids[0]) is not None
+    assert await graph_only_rag.chunk_entity_relation_graph.has_node("Alice")
+    assert await graph_only_rag.chunk_entity_relation_graph.has_node("Bob")
+    assert await graph_only_rag.chunk_entity_relation_graph.has_edge("Alice", "Bob")
+    assert failing_embedding.call_count == 0
+    await graph_only_rag.finalize_storages()
+
+    indexed_rag = LightRAG(
+        working_dir=str(tmp_path),
+        workspace=workspace,
+        vector_storage="NanoVectorDBStorage",
+        llm_model_func=AsyncMock(return_value=""),
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8,
+            max_token_size=512,
+            func=DeterministicEmbedding(),
+        ),
+    )
+    await indexed_rag.initialize_storages()
+
+    entity_stats = await rebuild_entities_vdb(
+        indexed_rag.chunk_entity_relation_graph,
+        indexed_rag.entities_vdb,
+        indexed_rag._build_global_config(),
+    )
+    relationship_stats = await rebuild_relationships_vdb(
+        indexed_rag.chunk_entity_relation_graph,
+        indexed_rag.relationships_vdb,
+        indexed_rag._build_global_config(),
+    )
+    chunk_stats = await rebuild_chunks_vdb(
+        indexed_rag.text_chunks,
+        indexed_rag.chunks_vdb,
+    )
+
+    entity_ids = [
+        compute_mdhash_id("Alice", prefix="ent-"),
+        compute_mdhash_id("Bob", prefix="ent-"),
+    ]
+    relationship_id = compute_mdhash_id("AliceBob", prefix="rel-")
+    reopened_docs = await indexed_rag.doc_status.get_docs_by_status(DocStatus.PROCESSED)
+
+    assert doc_id in reopened_docs
+    assert reopened_docs[doc_id].chunks_list == chunk_ids
+    assert entity_stats["rebuilt"] == 2
+    assert relationship_stats["rebuilt"] == 1
+    assert chunk_stats["rebuilt"] == 1
+    assert all(
+        record is not None
+        for record in await indexed_rag.entities_vdb.get_by_ids(entity_ids)
+    )
+    assert await indexed_rag.relationships_vdb.get_by_id(relationship_id) is not None
+    assert await indexed_rag.chunks_vdb.get_by_id(chunk_ids[0]) is not None
+
+    await indexed_rag.finalize_storages()

--- a/tests/tools/test_rebuild_vdb.py
+++ b/tests/tools/test_rebuild_vdb.py
@@ -12,9 +12,11 @@ Covers:
 """
 
 import pytest
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import lightrag.tools.rebuild_vdb as rebuild_vdb
+from lightrag.kg.noop_vector_db_impl import NoopVectorDBStorage
 from lightrag.tools.rebuild_vdb import (
     _strip_agtype_quotes,
     check_vdb_consistency,
@@ -34,6 +36,32 @@ pytestmark = pytest.mark.offline
 # ---------------------------------------------------------------------------
 # Mocks
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_library_rebuild_rejects_noop_vector_storage_before_source_reads():
+    noop_vdb = NoopVectorDBStorage(
+        namespace="test_vectors",
+        workspace="",
+        global_config={},
+        embedding_func=None,
+    )
+    graph = SimpleNamespace(
+        get_all_nodes=AsyncMock(),
+        get_all_edges=AsyncMock(),
+    )
+    text_chunks = SimpleNamespace()
+    error_match = "NoopVectorDBStorage.*persistent vector storage"
+
+    with pytest.raises(RuntimeError, match=error_match):
+        await rebuild_entities_vdb(graph, noop_vdb, {})
+    with pytest.raises(RuntimeError, match=error_match):
+        await rebuild_relationships_vdb(graph, noop_vdb, {})
+    with pytest.raises(RuntimeError, match=error_match):
+        await rebuild_chunks_vdb(text_chunks, noop_vdb)
+
+    graph.get_all_nodes.assert_not_awaited()
+    graph.get_all_edges.assert_not_awaited()
 
 
 class MockVDB:


### PR DESCRIPTION
## Description

Add an opt-in graph-first ingestion workflow for initial or offline corpus
backfills. `NoopVectorDBStorage` lets the normal LightRAG ingestion pipeline
persist the authoritative graph, KV stores, text chunks, and document status
without embedding or writing intermediate vector revisions. After the backfill,
users switch to a persistent vector backend and rebuild the final entity,
relationship, and chunk indexes from the stored graph/KV state.

This separates expensive extraction from rebuildable vector materialization.
It is intended for backfills where query availability is not required until the
final rebuild completes; normal incremental ingestion should continue using a
persistent vector backend from the beginning.

## Related Issues

- Closes #3472.
- Related: #1363, #2686, #2785.

## Changes Made

- Add and register `NoopVectorDBStorage` without external service requirements.
- Accept vector mutations without calling the embedding function or persisting
  vectors, while leaving graph/KV/document-status ingestion unchanged.
- Raise an actionable storage-capability error when a vector-backed query
  reaches Noop; `bypass` remains available because it does not use VDB storage.
- Make the embedding requirement explicit through the base/backend capability
  contract, allowing Noop to initialize with `embedding_func=None`.
- Mark Noop as non-persistent and reject it as a rebuild target before reading
  source records or dropping the target, preventing false-success rebuilds.
- Document the complete handoff: stop writers, retain the same working
  directory/workspace/graph/KV configuration, switch to a persistent VDB,
  configure the production embedding model and dimension, rebuild all indexes,
  and only then restart the server.
- Add normal `ainsert` coverage for the Noop-to-Nano handoff, plus bypass,
  capability-contract, backend-registration, query, and rebuild-guard tests.

## Benchmark

The benchmark isolates graph/vector materialization through the public storage
path; LLM extraction is excluded. It therefore supports claims about embedding
and vector-write amplification, not general extraction speed.

| Workload | Persistent vectors | Graph-first + rebuild | Result |
|---|---:|---:|---:|
| 100 documents, elapsed time | 42.646 s | 34.380 s | -19.4% |
| 100 documents, embedded texts | 60,100 | 20,500 | -65.9% |
| 200 high-overlap documents, elapsed time | 169.020 s | 131.930 s | -21.9% |
| 200 high-overlap documents, embedded texts | 200,200 | 41,000 | -79.5% |
| 200 high-overlap documents, embedding calls | 3,400 | 650 | -80.9% |
| 200 high-overlap documents, vector write amplification | 4.88x | 1.00x | -79.5% |

Both modes produced identical final graph and vector record counts. The
graph-first 200-document run used more peak memory (471 MiB vs 303 MiB) because
the current rebuild utilities prepare graph records and payloads before batched
writes; the documentation calls out this scalability boundary.

## Test Plan

- `47 passed`: Noop backend, normal ingestion handoff, rebuild APIs, and bypass
  regression tests.
- `3972 passed, 42 skipped, 1063 deselected`: full Python 3.12 offline suite
  with the API extra on `upstream/main@73046a7e`.
- `uvx pre-commit run --all-files`: all hooks passed.
- `git diff --check`: passed.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated
- [x] Unit tests added

## Additional Notes

- No changes are made to `lightrag/lightrag.py`; query failure behavior remains
  backend-local.
- Noop is not intended for normal online incremental ingestion or vector-backed
  queries.
- This PR does not add external database integrations or migrate existing local
  graph/KV data to external stores.
