### PR TITLE
feat(storage): cursor-page scheduling API + failure-generation write side (memory-bounding Phase 1)

### DIFF
--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from enum import Enum
 import os
+import uuid
 from dotenv import load_dotenv
 from dataclasses import dataclass, field
 from typing import (
     Any,
+    ClassVar,
     Literal,
     TypedDict,
     TypeVar,
@@ -15,9 +17,14 @@ from typing import (
     List,
     AsyncIterator,
 )
-from .utils import EmbeddingFunc, get_env_value
+from .utils import EmbeddingFunc, get_env_value, logger
 from .types import KnowledgeGraph
+from .exceptions import (
+    StorageCapabilityError,
+    StorageRecordNotFoundError,
+)
 from .constants import (
+    CUSTOM_CHUNK_PATCH_METADATA_KEY,
     DEFAULT_TOP_K,
     DEFAULT_CHUNK_TOP_K,
     DEFAULT_MAX_ENTITY_TOKENS,
@@ -383,9 +390,44 @@ class BaseVectorStorage(StorageNameSpace, ABC):
 class BaseKVStorage(StorageNameSpace, ABC):
     embedding_func: EmbeddingFunc
 
+    supports_strict_point_reads: ClassVar[bool] = False
+    """Class-level capability flag: the backend implements
+    :meth:`get_by_id_strict` with complete-or-raise semantics.
+
+    ``False`` (the base default, and any third-party backend that has not
+    opted in) means strict point reads are unavailable — callers that would
+    take a destructive action on "confirmed absent" (e.g. deleting a FAILED
+    doc_status stub because its full_docs entry is gone) MUST NOT act and
+    should fall back to a safe path with a warning instead.
+    """
+
     @abstractmethod
     async def get_by_id(self, id: str) -> dict[str, Any] | None:
         """Get value by id"""
+
+    async def get_by_id_strict(self, id: str) -> dict[str, Any] | None:
+        """Point read with complete-or-raise semantics.
+
+        Contract (implemented by backends that declare
+        ``supports_strict_point_reads = True``):
+
+        * ``None`` means **confirmed absent** — the backend positively
+          determined that no record with this id exists.
+        * Any transport/server error, an index/collection that is not ready,
+          or a state where absence cannot be positively confirmed (e.g. an
+          OpenSearch index that is unexpectedly missing after a restore)
+          MUST raise instead of returning ``None``.
+
+        This differs from :meth:`get_by_id`, whose implementations may treat
+        failures as a best-effort miss. The base implementation raises
+        :class:`~lightrag.exceptions.StorageCapabilityError`; callers must
+        gate on :attr:`supports_strict_point_reads` before calling.
+        """
+        raise StorageCapabilityError(
+            f"{type(self).__name__} does not support strict point reads "
+            "(supports_strict_point_reads=False); the caller must fall back "
+            "to a non-destructive path instead of trusting a miss."
+        )
 
     @abstractmethod
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
@@ -844,6 +886,27 @@ class DocProcessingStatus:
     Used together with file_path basename for duplicate detection. Empty for
     pending_parse records whose content has not been extracted yet.
     """
+    failure_generation: int | None = None
+    """Monotonic failure-cohort generation assigned when the row transitioned
+    to FAILED via ``mark_doc_failed`` (memory-bounding Phase 1).
+
+    ``None`` on legacy rows and rows that never failed — query predicates
+    treat missing as logical 0, so all history belongs to the first manual
+    cutoff. Never reset on retry; a later failure assigns a fresh, larger
+    generation.
+    """
+    processing_attempt_id: str | None = None
+    """Identity of the current processing attempt.
+
+    Minted before a brand-new attempt starts, kept across PENDING→PARSING→
+    PROCESSING and across crash recovery of the same interrupted attempt; a
+    manual retry grant mints a new one. ``mark_doc_failed`` stamps it into
+    ``failure_attempt_id`` so concurrent failure writes of the same attempt
+    collapse idempotently.
+    """
+    failure_attempt_id: str | None = None
+    """The ``processing_attempt_id`` whose failure produced the current
+    FAILED state (None when never failed / legacy)."""
     """Internal field: indicates if multimodal processing is complete. Not shown in repr() but accessible for debugging."""
 
     def __post_init__(self):
@@ -864,9 +927,135 @@ class DocProcessingStatus:
                 self.status = DocStatus.PREPROCESSED
 
 
+class FailureGenerationMode(str, Enum):
+    """Per-workspace activation state of the failure-generation machinery.
+
+    Read through :meth:`DocStatusStorage.get_failure_generation_mode`. The
+    manual-retry scheduler dispatches EXHAUSTIVELY on this enum — never with
+    a default-else — because mapping an unknown/MIGRATING state to LEGACY
+    would silently reopen the full-materialization (OOM) window:
+
+    * ``LEGACY`` — workspace data/writers not migrated: manual retry uses the
+      old single-snapshot cohort; no generation predicate.
+    * ``MIGRATING`` — migration in flight or persisted version markers
+      disagree: scheduling features that depend on migrated state must raise
+      :class:`~lightrag.exceptions.StorageMigrationInProgressError`.
+    * ``DUAL_WRITE_READY`` — writers assign generations but the read side is
+      not yet authoritative: manual retry still uses the legacy snapshot.
+    * ``ENFORCED`` — migration complete (schema version + counter epoch +
+      migration version all consistent): manual retry uses paged
+      generation-cutoff cohorts.
+    """
+
+    LEGACY = "legacy"
+    MIGRATING = "migrating"
+    DUAL_WRITE_READY = "dual_write_ready"
+    ENFORCED = "enforced"
+
+
+class CursorPosition:
+    """Sealed three-state cursor for stable keyset sweeps.
+
+    Exactly three shapes exist: the :data:`CURSOR_START` singleton, the
+    :data:`CURSOR_END` singleton, and :class:`CursorAfter` (an opaque,
+    backend-defined continuation token). ``page.next_position is CURSOR_END``
+    is the ONLY termination signal — an empty ``docs`` dict is not (a page
+    may be fully filtered yet not exhausted).
+    """
+
+    __slots__ = ()
+
+
+class _CursorSentinel(CursorPosition):
+    __slots__ = ("_name",)
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return self._name
+
+
+CURSOR_START = _CursorSentinel("CURSOR_START")
+"""Begin a sweep from the smallest ``(created_at, id)`` key."""
+
+CURSOR_END = _CursorSentinel("CURSOR_END")
+"""The sweep is exhausted; no further page exists."""
+
+
+@dataclass(frozen=True)
+class CursorAfter(CursorPosition):
+    """Opaque continuation token: resume strictly after the last CONSUMED
+    underlying record (see the consumed-position contract on
+    :meth:`DocStatusStorage.get_docs_by_statuses_page`)."""
+
+    opaque: str
+
+
+@dataclass(frozen=True)
+class DocSchedulingRecord:
+    """Lightweight scheduling projection of a doc_status row.
+
+    Deliberately excludes ``chunks_list``, large ``metadata`` blobs and full
+    error text so a page of records stays O(page_size × small constant) —
+    the pipeline hydrates full records per-document only when it actually
+    routes one.
+    """
+
+    id: str
+    status: DocStatus
+    created_at: str
+    updated_at: str
+    file_path: str
+    track_id: str | None
+    has_custom_chunk_journal: bool
+    """True when doc_status.metadata carries the custom-chunk patch journal —
+    such rows belong to scan/custom-chunk recovery, not ordinary routing."""
+
+
+@dataclass(frozen=True)
+class DocStatusPage:
+    """One page of a stable keyset sweep.
+
+    ``next_position is CURSOR_END`` terminates the sweep; any other value
+    (including with an empty ``docs``) means "call again".
+    """
+
+    docs: dict[str, DocSchedulingRecord]
+    next_position: CursorPosition
+
+
+# One-time-per-class warning registry for base-default page reads that must
+# ignore ``max_failure_generation`` (the class lacks failure-generation
+# support). Module-level so dataclass instances stay stateless.
+_PAGE_GENERATION_FILTER_WARNED: set[str] = set()
+
+
 @dataclass
 class DocStatusStorage(BaseKVStorage, ABC):
     """Base class for document status storage"""
+
+    supports_bounded_scheduling_pages: ClassVar[bool] = False
+    """The backend implements :meth:`get_docs_by_statuses_page` as a true
+    bounded keyset sweep. ``False`` (base default / third-party backends)
+    means the default single-page implementation is used, which materializes
+    ALL matching rows — correctness holds but there is NO memory-boundedness
+    guarantee. Operators can require boundedness via
+    ``PIPELINE_REQUIRE_BOUNDED_SCHEDULING`` (init fail-fast) or accept a
+    strong startup warning."""
+
+    supports_failure_generation: ClassVar[bool] = False
+    """The backend implements the failure-generation write side
+    (:meth:`reserve_failure_generation` + CAS :meth:`mark_doc_failed`).
+    Class-level implementation capability only — whether a given WORKSPACE
+    actually enforces generation cohorts is the per-workspace marker read via
+    :meth:`get_failure_generation_mode`."""
+
+    supports_strict_doc_identity_lookup: ClassVar[bool] = False
+    """The backend implements :meth:`get_doc_by_file_basename_strict` with
+    fail-closed semantics (None == confirmed absent). ``False`` means the
+    strict variant merely delegates to the legacy lookup: a ``None`` is only
+    a best-effort miss and callers must not present it as confirmation."""
 
     @staticmethod
     def resolve_status_filter_values(
@@ -997,6 +1186,278 @@ class DocStatusStorage(BaseKVStorage, ABC):
         Returns:
             (doc_id, doc_data) when a matching record exists, otherwise None.
         """
+
+    # ------------------------------------------------------------------
+    # Memory-bounding scheduling API (Phase 1). Every method below ships a
+    # concrete base default so existing third-party subclasses keep
+    # instantiating and working; built-in backends override for bounded /
+    # fail-closed behaviour and declare the matching capability flags.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _scheduling_record_from_status(
+        doc_id: str, status_doc: DocProcessingStatus
+    ) -> DocSchedulingRecord:
+        """Project a full status row into the lightweight scheduling record."""
+        metadata = status_doc.metadata if isinstance(status_doc.metadata, dict) else {}
+        return DocSchedulingRecord(
+            id=doc_id,
+            status=status_doc.status,
+            created_at=status_doc.created_at,
+            updated_at=status_doc.updated_at,
+            file_path=status_doc.file_path,
+            track_id=status_doc.track_id,
+            has_custom_chunk_journal=isinstance(
+                metadata.get(CUSTOM_CHUNK_PATCH_METADATA_KEY), dict
+            ),
+        )
+
+    async def get_docs_by_statuses_page(
+        self,
+        statuses: list[DocStatus],
+        *,
+        limit: int,
+        position: CursorPosition = CURSOR_START,
+        max_failure_generation: int | None = None,
+        strict: bool = False,
+    ) -> DocStatusPage:
+        """Read one page of a stable keyset sweep over the given statuses.
+
+        Contract for bounded implementations
+        (``supports_bounded_scheduling_pages = True``):
+
+        * **Sort (MUST)**: ``(created_at ASC, id ASC)`` keyset order across
+          ALL requested statuses combined (per-status keysets merged with a
+          bounded k-way merge where the backend cannot sort natively).
+          Live-view: the sweep observes concurrent writes; no snapshot
+          isolation is claimed. Termination is ``next_position is
+          CURSOR_END`` — never an empty ``docs``.
+        * **Immutable sort key**: ``created_at`` is written once at record
+          creation and preserved by every later transition
+          (``update_doc_status_fields`` refuses it; ``mark_doc_failed``
+          ignores a caller-supplied value for existing rows) so a record can
+          never move underneath a sweep.
+        * **Consumed-position advance**: ``next_position`` advances past the
+          last CONSUMED underlying record — records returned to the caller
+          plus records read and dropped by filtering (e.g. the
+          ``max_failure_generation`` predicate) are consumed; a record
+          prefetched for merging but NOT returned because the page filled is
+          NOT consumed (or must be encoded into the opaque cursor and
+          returned first on the next page). A fully-filtered page therefore
+          advances the cursor without terminating, never re-reads in place,
+          and never skips a prefetched head. With multiple statuses the
+          opaque cursor tracks each status stream's own consumed position.
+        * ``max_failure_generation`` (optional): return FAILED rows only when
+          ``failure_generation <= max_failure_generation`` (missing field ==
+          logical 0). Non-FAILED rows are unaffected. This is the manual
+          cohort-freeze predicate; AUTO sweeps pass ``None``.
+        * ``strict=True``: the page is complete or the call raises — on an
+          internal partial failure the implementation must raise WITHOUT
+          returning partial docs or a new cursor. All scheduling/control-plane
+          callers pass ``strict=True`` explicitly.
+
+        Base default (third-party compatibility, NOT memory-bounded):
+        ``CURSOR_START`` → delegate to ``get_docs_by_statuses(strict=True)``
+        and return everything as a single page ending the sweep (``limit`` is
+        ignored); any other position → empty terminal page. A non-``None``
+        ``max_failure_generation`` is ignored with a one-time warning because
+        the class lacks failure-generation support (missing == logical 0
+        keeps every legacy row eligible, which is the safe direction).
+        """
+        if max_failure_generation is not None and not self.supports_failure_generation:
+            cls_name = type(self).__name__
+            if cls_name not in _PAGE_GENERATION_FILTER_WARNED:
+                _PAGE_GENERATION_FILTER_WARNED.add(cls_name)
+                logger.warning(
+                    f"{cls_name} does not support failure_generation; "
+                    "max_failure_generation is ignored by the base "
+                    "single-page implementation (all FAILED rows stay "
+                    "eligible for this sweep)."
+                )
+        if position is not CURSOR_START:
+            return DocStatusPage(docs={}, next_position=CURSOR_END)
+        snapshot = await self.get_docs_by_statuses(statuses, strict=True)
+        docs = {
+            doc_id: self._scheduling_record_from_status(doc_id, status_doc)
+            for doc_id, status_doc in snapshot.items()
+        }
+        return DocStatusPage(docs=docs, next_position=CURSOR_END)
+
+    async def count_docs_by_statuses(
+        self, statuses: list[DocStatus], *, strict: bool = True
+    ) -> int:
+        """Count documents in the given statuses, fail-closed.
+
+        Unlike ``get_status_counts()`` implementations that swallow errors
+        and report zeros, this method MUST either return an accurate count or
+        raise — admission control treats an error as "refuse", never as
+        "capacity available". The base implementation raises
+        :class:`~lightrag.exceptions.StorageCapabilityError`; deployments
+        that enable ``MAX_PENDING_DOCUMENTS`` validate support at
+        initialization.
+        """
+        raise StorageCapabilityError(
+            f"{type(self).__name__} does not implement strict "
+            "count_docs_by_statuses; admission control cannot run on this "
+            "backend."
+        )
+
+    async def update_doc_status_fields(
+        self,
+        doc_id: str,
+        fields: dict[str, Any],
+        *,
+        missing_ok: bool = False,
+    ) -> None:
+        """Update only the given fields of one doc_status record.
+
+        Contract:
+
+        * Fields not present in ``fields`` are left untouched — this is the
+          targeted alternative to read-modify-write upserts that would drag
+          a huge ``chunks_list`` through memory.
+        * Implementations MUST atomically maintain every secondary index
+          affected by the updated fields (e.g. Redis per-status ZSETs and the
+          basename→primary-doc index) in the same transaction as the write.
+        * ``created_at`` is an immutable sort key: passing it raises
+          ``ValueError`` (see the keyset-sweep contract).
+        * Unknown ``doc_id`` raises
+          :class:`~lightrag.exceptions.StorageRecordNotFoundError` unless
+          ``missing_ok=True`` (best-effort callers only).
+
+        The base default performs a read-modify-write via ``get_by_id`` +
+        ``upsert`` — correct but not memory-optimal; built-in backends
+        override with native partial updates.
+        """
+        if "created_at" in fields:
+            raise ValueError(
+                "created_at is an immutable scheduling sort key and cannot "
+                "be changed via update_doc_status_fields"
+            )
+        existing = await self.get_by_id(doc_id)
+        if existing is None:
+            if missing_ok:
+                return
+            raise StorageRecordNotFoundError(doc_id)
+        merged = {**existing, **fields}
+        merged.pop("_id", None)
+        await self.upsert({doc_id: merged})
+
+    async def get_failure_generation_mode(self) -> FailureGenerationMode:
+        """Read the per-workspace failure-generation activation marker.
+
+        Built-in backends read a persisted per-workspace marker (never a
+        local config override) and MUST propagate read failures as
+        control-plane errors — a marker read failure never degrades to
+        ``LEGACY`` because LEGACY reopens the full-snapshot manual path.
+
+        The base default returns ``LEGACY``: third-party backends keep the
+        old single-snapshot manual behaviour with plain FAILED upserts.
+        """
+        return FailureGenerationMode.LEGACY
+
+    async def reserve_failure_generation(self) -> int:
+        """Atomically reserve the next failure-generation number.
+
+        Reserve-before-publish: the reservation is the linearization point of
+        a failure event; a reservation whose FAILED write later fails becomes
+        a permanent hole (never reused, never rolled back). Counter
+        durability must be no weaker than the FAILED status write itself.
+
+        Only called on ``ENFORCED`` workspaces, so the base default (no
+        generation support) raises
+        :class:`~lightrag.exceptions.StorageCapabilityError`.
+        """
+        raise StorageCapabilityError(
+            f"{type(self).__name__} does not support failure_generation "
+            "reservation (supports_failure_generation=False)."
+        )
+
+    async def mark_doc_failed(self, doc_id: str, fields: dict[str, Any]) -> int | None:
+        """Transition one document to FAILED.
+
+        This is the SINGLE funnel for FAILED writes (Phase 1 routes every
+        call site through it). Contract for generation-capable backends
+        (``supports_failure_generation = True``):
+
+        * Reserve a generation (:meth:`reserve_failure_generation`) and CAS
+          it into the row together with ``failure_attempt_id`` = the row's
+          current ``processing_attempt_id``; two concurrent failures of the
+          same attempt land exactly one effective generation (idempotent:
+          already-FAILED with the same attempt returns the existing
+          generation).
+        * For an EXISTING row a caller-supplied ``created_at`` is IGNORED —
+          the scheduling sort key is immutable.
+        * A missing row is conditionally created as FAILED (parse/enqueue
+          errors can fail before the PENDING row landed).
+        * Returns the effective failure generation.
+
+        The base default implements the LEGACY write side: a plain merge +
+        upsert with ``status=FAILED`` (no generation isolation), returning
+        ``None``.
+        """
+        existing = await self.get_by_id(doc_id)
+        if existing is None:
+            row = dict(fields)
+        else:
+            row = {**existing, **fields}
+            # Immutable sort key: never let a failure rewrite move the row.
+            if "created_at" in existing:
+                row["created_at"] = existing["created_at"]
+        row["status"] = DocStatus.FAILED
+        row.pop("_id", None)
+        await self.upsert({doc_id: row})
+        return None
+
+    async def ensure_processing_attempt_id(self, doc_id: str) -> str:
+        """Return the row's ``processing_attempt_id``, minting one if absent.
+
+        Idempotent per attempt: an interrupted call retried after a lost
+        response reuses the persisted id instead of minting a second one.
+        Used to bootstrap legacy active rows (PENDING/PARSING/ANALYZING/
+        PROCESSING without an attempt id) before recovery processing, and by
+        new documents before any step that can fail.
+
+        The base default is read-then-write (not atomic across processes);
+        built-in backends may override with a CAS variant.
+        """
+        existing = await self.get_by_id(doc_id)
+        if existing is None:
+            raise StorageRecordNotFoundError(doc_id)
+        attempt_id = existing.get("processing_attempt_id")
+        if attempt_id:
+            return str(attempt_id)
+        attempt_id = uuid.uuid4().hex
+        await self.update_doc_status_fields(
+            doc_id, {"processing_attempt_id": attempt_id}
+        )
+        return attempt_id
+
+    async def get_doc_by_file_basename_strict(
+        self, basename: str
+    ) -> tuple[str, dict[str, Any]] | None:
+        """Fail-closed variant of :meth:`get_doc_by_file_basename`.
+
+        Contract for backends declaring
+        ``supports_strict_doc_identity_lookup = True``:
+
+        * Returns the PRIMARY (non-duplicate, ``metadata.is_duplicate !=
+          true``) document row for the canonical basename, or ``None`` when
+          absence was positively confirmed.
+        * Query failures, a not-ready index, or a schema/migration version
+          mismatch raise a control-plane error instead of returning ``None``
+          — scan classification and enqueue dedup treat ``None`` as
+          "confirmed new", so a swallowed failure would mint duplicate rows.
+
+        The base default DELEGATES to the legacy
+        :meth:`get_doc_by_file_basename` (old signature untouched — never
+        call the legacy method with new kwargs, third-party overrides would
+        raise ``TypeError``). Under delegation a ``None`` is only a
+        best-effort miss with the backend's own error semantics; deployments
+        see a startup warning and status-endpoint exposure for this
+        degradation.
+        """
+        return await self.get_doc_by_file_basename(basename)
 
 
 class StoragesStatus(str, Enum):

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -272,6 +272,13 @@ PARSER_ENGINE_NATIVE = "native"
 PARSER_ENGINE_MINERU = "mineru"
 PARSER_ENGINE_DOCLING = "docling"
 PARSED_DIR_NAME = "__parsed__"  # Dir for parsed files (renamed from __enqueued__)
+# Reserved doc_status.metadata key holding the custom-chunk patch journal
+# (issue #3400 Phase 3). While present, the document has an in-flight or
+# failed ainsert_custom_chunks operation: the pipeline must NOT process the
+# row as ordinary ingestion, resets must NOT strip it, and deletion must
+# include its staged chunk IDs. Lives here (not utils_pipeline) so that
+# base.py can derive the scheduling projection without an import cycle.
+CUSTOM_CHUNK_PATCH_METADATA_KEY = "custom_chunk_patch"
 # Prefix marking a doc_status content_summary as GENERATED from a file
 # extraction error (enqueue-time error documents and parse-stage FAILED
 # upserts). Doubles as the match sentinel that lets a later failure replace

--- a/lightrag/exceptions.py
+++ b/lightrag/exceptions.py
@@ -77,6 +77,44 @@ class StorageNotInitializedError(RuntimeError):
         )
 
 
+class StorageCapabilityError(RuntimeError):
+    """Raised when a storage backend lacks a capability the caller requires.
+
+    Callers that depend on a hard guarantee (strict counting, strict point
+    reads, failure-generation cohorts, ...) must fail closed on this error —
+    never silently substitute a weaker code path.
+    """
+
+
+class StorageControlPlaneError(RuntimeError):
+    """A storage control-plane read failed (mode marker, counter, version).
+
+    Distinct from a data-plane miss: the caller cannot know the true state and
+    MUST fail closed (retry with backoff / surface 503 / keep sticky work
+    unacknowledged). Degrading to a full-materialization or destructive
+    fallback on this error is forbidden — that is exactly the OOM/corruption
+    window the control plane exists to fence off.
+    """
+
+
+class StorageMigrationInProgressError(StorageControlPlaneError):
+    """The workspace is migrating, or its persisted version markers disagree.
+
+    Features that depend on migrated state (failure-generation cohorts,
+    bounded manual sweeps) must refuse with this error instead of falling
+    back to legacy full-snapshot behaviour.
+    """
+
+
+class StorageRecordNotFoundError(KeyError):
+    """A targeted doc_status field update referenced a non-existent record.
+
+    Raised by ``update_doc_status_fields(..., missing_ok=False)`` — the
+    default — so callers cannot silently patch a record that a concurrent
+    delete already removed.
+    """
+
+
 class PipelineNotInitializedError(KeyError):
     """Raised when pipeline status is accessed before initialization."""
 

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -1,12 +1,23 @@
 from dataclasses import dataclass
+import heapq
+import json
 import os
-from typing import Any, Union, final
+import uuid
+from typing import Any, ClassVar, Union, final
 
 from lightrag.base import (
+    CURSOR_END,
+    CURSOR_START,
+    CursorAfter,
+    CursorPosition,
     DocProcessingStatus,
+    DocSchedulingRecord,
     DocStatus,
+    DocStatusPage,
     DocStatusStorage,
+    FailureGenerationMode,
 )
+from lightrag.constants import CUSTOM_CHUNK_PATCH_METADATA_KEY
 from lightrag.file_atomic import reap_orphan_tmp_files
 from lightrag.utils import (
     _cooperative_yield,
@@ -16,7 +27,11 @@ from lightrag.utils import (
     write_json,
     get_pinyin_sort_key,
 )
-from lightrag.exceptions import StorageNotInitializedError
+from lightrag.exceptions import (
+    StorageControlPlaneError,
+    StorageNotInitializedError,
+    StorageRecordNotFoundError,
+)
 from .shared_storage import (
     get_namespace_data,
     get_namespace_lock,
@@ -73,7 +88,27 @@ class JsonDocStatusStorage(DocStatusStorage):
         * ``drop`` — destructive, **not** serialized; the caller must
           hold the pipeline ``busy`` reservation (the
           ``/documents/clear`` endpoint does this).
+
+    Memory-bounding capability boundary (Phase 1): the paged scheduling
+    API below is a true keyset sweep (bounded page memory via a bounded
+    heap), but this backend inherently keeps the WHOLE store resident in
+    shared memory and rewrites the whole file on flush — that residency
+    is an independent, documented limitation, not something the page API
+    can fix. Deployments with very large doc counts should use a server
+    backend (Redis/PG/...).
     """
+
+    supports_bounded_scheduling_pages: ClassVar[bool] = True
+    supports_failure_generation: ClassVar[bool] = True
+    supports_strict_doc_identity_lookup: ClassVar[bool] = True
+    supports_strict_point_reads: ClassVar[bool] = True
+
+    # Scheduling control-plane doc (failure-generation counter + mode
+    # marker + version stamps) lives in a SEPARATE sidecar file, never in
+    # ``self._data`` — a reserved key inside the data dict would leak into
+    # every full-scan reader. Version stamps guard marker integrity: a
+    # mismatch reads as MIGRATING (never LEGACY).
+    _CTRL_SCHEMA_VERSION: ClassVar[int] = 1
 
     def __post_init__(self):
         # Reject path traversal before using workspace in a file path
@@ -89,11 +124,15 @@ class JsonDocStatusStorage(DocStatusStorage):
 
         os.makedirs(workspace_dir, exist_ok=True)
         self._file_name = os.path.join(workspace_dir, f"kv_store_{self.namespace}.json")
+        self._ctrl_file_name = os.path.join(
+            workspace_dir, f"kv_store_{self.namespace}_scheduling_ctrl.json"
+        )
         self._data = None
         self._storage_lock = None
         self.storage_updated = None
 
         reap_orphan_tmp_files(self._file_name, self.workspace or "_")
+        reap_orphan_tmp_files(self._ctrl_file_name, self.workspace or "_")
 
     async def initialize(self):
         """Bind to the shared namespace dict and load from disk on first init.
@@ -124,6 +163,50 @@ class JsonDocStatusStorage(DocStatusStorage):
                     logger.info(
                         f"[{self.workspace}] Process {os.getpid()} doc status load {self.namespace} with {len(loaded_data)} records"
                     )
+
+        # Scheduling control-plane bootstrap (Phase 1). JSON is a single-host
+        # backend whose process fleet upgrades atomically with the code, so
+        # the migrate-then-publish-ENFORCED step is safe at init time (server
+        # backends require the coordinated stop-write upgrade instead).
+        # Counter calibration runs on EVERY init: a restore-from-backup can
+        # roll the ctrl file behind persisted rows, and the reservation
+        # counter must stay monotonic — ``max(counter, max persisted)``.
+        async with self._storage_lock:
+            max_gen = 0
+            for row in self._data.values():
+                if not isinstance(row, dict):
+                    continue
+                try:
+                    gen = int(row.get("failure_generation") or 0)
+                except (TypeError, ValueError):
+                    gen = 0
+                max_gen = max(max_gen, gen)
+            ctrl = load_json(self._ctrl_file_name)
+            if not isinstance(ctrl, dict):
+                ctrl = {
+                    "schema_version": self._CTRL_SCHEMA_VERSION,
+                    "mode": FailureGenerationMode.ENFORCED.value,
+                    "failure_generation_counter": max_gen,
+                }
+                write_json(ctrl, self._ctrl_file_name)
+                logger.info(
+                    f"[{self.workspace}] Published failure-generation marker "
+                    f"(mode=enforced, counter={max_gen}) for {self.namespace}"
+                )
+            elif ctrl.get("schema_version") == self._CTRL_SCHEMA_VERSION:
+                try:
+                    counter = int(ctrl.get("failure_generation_counter") or 0)
+                except (TypeError, ValueError):
+                    counter = 0
+                if counter < max_gen:
+                    ctrl["failure_generation_counter"] = max_gen
+                    write_json(ctrl, self._ctrl_file_name)
+                    logger.warning(
+                        f"[{self.workspace}] failure-generation counter behind "
+                        f"persisted rows ({counter} < {max_gen}); recalibrated"
+                    )
+            # An unknown schema_version is left untouched: mode reads report
+            # MIGRATING (never LEGACY) until an explicit migration handles it.
 
     async def filter_keys(self, keys: set[str]) -> set[str]:
         """Return keys that should be processed (not in storage or not successfully processed)"""
@@ -489,14 +572,30 @@ class JsonDocStatusStorage(DocStatusStorage):
 
         return None
 
+    @staticmethod
+    def _is_duplicate_row(row: Any) -> bool:
+        """True for duplicate-attempt marker rows (``dup-*`` records and
+        post-parse content duplicates): ``metadata.is_duplicate == true``."""
+        if not isinstance(row, dict):
+            return False
+        metadata = row.get("metadata")
+        return bool(isinstance(metadata, dict) and metadata.get("is_duplicate"))
+
     async def get_doc_by_file_basename(
         self, basename: str
     ) -> Union[tuple[str, dict[str, Any]], None]:
-        """Find an existing record whose canonical basename matches.
+        """Find the PRIMARY record whose canonical basename matches.
 
         The caller is responsible for passing an already-canonical basename.
         Stored ``file_path`` values are canonicalized by the business layer, so
         this lookup intentionally performs an exact match only.
+
+        ``file_path`` is one-to-many (duplicate-attempt ``dup-*`` rows keep the
+        same canonical basename); this returns the single primary
+        (``metadata.is_duplicate != true``) row — callers doing identity
+        checks / dedup want the document, never a duplicate marker. When only
+        duplicate markers remain (primary deleted) the basename is free again
+        and this returns ``None``.
         """
         if not basename:
             return None
@@ -507,9 +606,35 @@ class JsonDocStatusStorage(DocStatusStorage):
             return None
         async with self._storage_lock:
             for doc_id, doc_data in self._data.items():
-                if doc_data.get("file_path") == basename:
+                if doc_data.get("file_path") == basename and not self._is_duplicate_row(
+                    doc_data
+                ):
                     return doc_id, doc_data
         return None
+
+    async def get_doc_by_file_basename_strict(
+        self, basename: str
+    ) -> Union[tuple[str, dict[str, Any]], None]:
+        """Fail-closed basename lookup (see base contract).
+
+        The in-memory scan has no transport failure surface and never
+        swallows errors, so the aligned legacy lookup already satisfies the
+        strict contract: ``None`` here IS confirmed absence (uninitialized
+        storage raises instead of returning a miss).
+        """
+        return await self.get_doc_by_file_basename(basename)
+
+    async def get_by_id_strict(self, id: str) -> Union[dict[str, Any], None]:
+        """Strict point read: complete-or-raise (base contract).
+
+        In-memory shared dict — a miss is a confirmed absence; the only
+        failure surface is uninitialized storage, which raises.
+        """
+        if self._storage_lock is None:
+            raise StorageNotInitializedError("JsonDocStatusStorage")
+        async with self._storage_lock:
+            row = self._data.get(id)
+        return row.copy() if isinstance(row, dict) else row
 
     async def get_doc_by_content_hash(
         self, content_hash: str
@@ -525,6 +650,305 @@ class JsonDocStatusStorage(DocStatusStorage):
                 if doc_data.get("content_hash") == content_hash:
                     return doc_id, doc_data
         return None
+
+    # ------------------------------------------------------------------
+    # Memory-bounding scheduling API (Phase 1)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _row_sort_key(doc_id: str, row: dict[str, Any]) -> tuple[str, str]:
+        """(created_at, id) keyset key. A missing/non-string created_at sorts
+        deterministically first as "" — such legacy rows are consumed (and
+        skipped/raised per strictness) without ever moving mid-sweep."""
+        created = row.get("created_at")
+        return (created if isinstance(created, str) else "", doc_id)
+
+    @staticmethod
+    def _encode_cursor(key: tuple[str, str]) -> str:
+        return json.dumps(list(key), ensure_ascii=False)
+
+    @staticmethod
+    def _decode_cursor(opaque: str) -> tuple[str, str]:
+        try:
+            decoded = json.loads(opaque)
+            created, doc_id = decoded
+            if not isinstance(created, str) or not isinstance(doc_id, str):
+                raise ValueError("cursor fields must be strings")
+        except (ValueError, TypeError) as e:
+            raise StorageControlPlaneError(
+                f"Malformed scheduling cursor for JsonDocStatusStorage: {e}"
+            ) from e
+        return (created, doc_id)
+
+    def _scheduling_record_from_row(
+        self, doc_id: str, row: dict[str, Any], *, strict: bool
+    ) -> DocSchedulingRecord | None:
+        """Project one raw row; strict raises on unusable rows, relaxed
+        returns None (the caller still counts the row as consumed)."""
+        try:
+            status = DocStatus(str(row["status"]))
+            created_at = row["created_at"]
+            updated_at = row.get("updated_at", created_at)
+            if not isinstance(created_at, str) or not isinstance(updated_at, str):
+                raise TypeError("created_at/updated_at must be strings")
+            metadata = row.get("metadata")
+            return DocSchedulingRecord(
+                id=doc_id,
+                status=status,
+                created_at=created_at,
+                updated_at=updated_at,
+                file_path=row.get("file_path") or "no-file-path",
+                track_id=row.get("track_id"),
+                has_custom_chunk_journal=isinstance(metadata, dict)
+                and isinstance(metadata.get(CUSTOM_CHUNK_PATCH_METADATA_KEY), dict),
+            )
+        except (KeyError, TypeError, ValueError) as e:
+            logger.error(f"[{self.workspace}] Unusable scheduling row {doc_id}: {e}")
+            if strict:
+                raise
+            return None
+
+    async def get_docs_by_statuses_page(
+        self,
+        statuses: list[DocStatus],
+        *,
+        limit: int,
+        position: CursorPosition = CURSOR_START,
+        max_failure_generation: int | None = None,
+        strict: bool = False,
+    ) -> DocStatusPage:
+        """Bounded keyset page over the in-memory store.
+
+        Selection uses a bounded heap (``heapq.nsmallest``) so page memory is
+        O(limit) even though each page re-scans the resident dict — the
+        O(total) residency itself is this backend's documented boundary.
+
+        Consumed-position contract: every selected candidate is consumed —
+        returned, dropped by the ``max_failure_generation`` predicate, or
+        skipped as unusable in relaxed mode — so the cursor advances past
+        filtered pages instead of re-reading them; fewer candidates than
+        ``limit`` proves exhaustion (CURSOR_END).
+        """
+        if self._storage_lock is None:
+            raise StorageNotInitializedError("JsonDocStatusStorage")
+        if limit <= 0:
+            raise ValueError(f"page limit must be positive, got {limit}")
+        if not statuses or position is CURSOR_END:
+            return DocStatusPage(docs={}, next_position=CURSOR_END)
+        last_key: tuple[str, str] | None = None
+        if isinstance(position, CursorAfter):
+            last_key = self._decode_cursor(position.opaque)
+        status_values = {s.value for s in statuses}
+        failed_value = DocStatus.FAILED.value
+
+        def _candidates():
+            for doc_id, row in self._data.items():
+                if not isinstance(row, dict):
+                    if strict:
+                        raise TypeError(f"doc_status record {doc_id} is not a mapping")
+                    continue
+                if str(row.get("status")) not in status_values:
+                    continue
+                key = self._row_sort_key(doc_id, row)
+                if last_key is not None and key <= last_key:
+                    continue
+                yield key, doc_id, row
+
+        async with self._storage_lock:
+            selected = heapq.nsmallest(limit, _candidates(), key=lambda t: t[0])
+            docs: dict[str, DocSchedulingRecord] = {}
+            for key, doc_id, row in selected:
+                if (
+                    max_failure_generation is not None
+                    and str(row.get("status")) == failed_value
+                ):
+                    try:
+                        generation = int(row.get("failure_generation") or 0)
+                    except (TypeError, ValueError):
+                        generation = 0
+                    if generation > max_failure_generation:
+                        continue  # consumed by the cohort predicate
+                record = self._scheduling_record_from_row(doc_id, row, strict=strict)
+                if record is None:
+                    continue  # relaxed skip is still consumed
+                docs[doc_id] = record
+        if len(selected) < limit:
+            next_position: CursorPosition = CURSOR_END
+        else:
+            next_position = CursorAfter(self._encode_cursor(selected[-1][0]))
+        return DocStatusPage(docs=docs, next_position=next_position)
+
+    async def count_docs_by_statuses(
+        self, statuses: list[DocStatus], *, strict: bool = True
+    ) -> int:
+        """Fail-closed status count (full scan — documented JSON boundary)."""
+        if self._storage_lock is None:
+            raise StorageNotInitializedError("JsonDocStatusStorage")
+        if not statuses:
+            return 0
+        status_values = {s.value for s in statuses}
+        count = 0
+        async with self._storage_lock:
+            for doc_id, row in self._data.items():
+                if not isinstance(row, dict) or "status" not in row:
+                    if strict:
+                        raise TypeError(
+                            f"doc_status record {doc_id} has no readable status"
+                        )
+                    continue
+                if str(row.get("status")) in status_values:
+                    count += 1
+        return count
+
+    async def update_doc_status_fields(
+        self,
+        doc_id: str,
+        fields: dict[str, Any],
+        *,
+        missing_ok: bool = False,
+    ) -> None:
+        """Targeted field update with an immediate flush (doc-status is the
+        pipeline's recovery anchor — same rationale as ``upsert``)."""
+        if "created_at" in fields:
+            raise ValueError(
+                "created_at is an immutable scheduling sort key and cannot "
+                "be changed via update_doc_status_fields"
+            )
+        if self._storage_lock is None:
+            raise StorageNotInitializedError("JsonDocStatusStorage")
+        async with self._storage_lock:
+            row = self._data.get(doc_id)
+            if row is None:
+                if missing_ok:
+                    return
+                raise StorageRecordNotFoundError(doc_id)
+            self._data[doc_id] = {**row, **fields}
+            await set_all_update_flags(self.namespace, workspace=self.workspace)
+        await self.index_done_callback()
+
+    # ------------------------------------------------------------------
+    # failure_generation write side (Phase 1)
+    # ------------------------------------------------------------------
+
+    def _read_ctrl_locked(self) -> dict[str, Any]:
+        """Read + validate the control-plane doc; caller holds the lock.
+
+        Raises a control-plane error instead of degrading: a missing or
+        version-mismatched marker on a workspace this backend already
+        initialized is corruption, never "new LEGACY workspace".
+        """
+        ctrl = load_json(self._ctrl_file_name)
+        if not isinstance(ctrl, dict) or ctrl.get("schema_version") != (
+            self._CTRL_SCHEMA_VERSION
+        ):
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] failure-generation marker missing or "
+                f"version-mismatched for {self.namespace}; refusing (never "
+                "degrades to LEGACY full-snapshot behaviour)"
+            )
+        return ctrl
+
+    async def get_failure_generation_mode(self) -> FailureGenerationMode:
+        if self._storage_lock is None:
+            raise StorageNotInitializedError("JsonDocStatusStorage")
+        async with self._storage_lock:
+            ctrl = load_json(self._ctrl_file_name)
+        if not isinstance(ctrl, dict):
+            return FailureGenerationMode.MIGRATING
+        if ctrl.get("schema_version") != self._CTRL_SCHEMA_VERSION:
+            return FailureGenerationMode.MIGRATING
+        try:
+            return FailureGenerationMode(str(ctrl.get("mode")))
+        except ValueError:
+            return FailureGenerationMode.MIGRATING
+
+    async def reserve_failure_generation(self) -> int:
+        if self._storage_lock is None:
+            raise StorageNotInitializedError("JsonDocStatusStorage")
+        async with self._storage_lock:
+            return self._reserve_generation_locked()
+
+    def _reserve_generation_locked(self) -> int:
+        ctrl = self._read_ctrl_locked()
+        try:
+            counter = int(ctrl.get("failure_generation_counter") or 0)
+        except (TypeError, ValueError) as e:
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] failure-generation counter corrupt: {e}"
+            ) from e
+        counter += 1
+        ctrl["failure_generation_counter"] = counter
+        # Durability no weaker than the FAILED status write: persist the
+        # reservation before any row can publish it. A crash after this
+        # write leaves a permanent hole — allowed; reuse is not.
+        write_json(ctrl, self._ctrl_file_name)
+        return counter
+
+    async def mark_doc_failed(self, doc_id: str, fields: dict[str, Any]) -> int | None:
+        """FAILED transition funnel: reserve + publish under ONE lock.
+
+        The single storage lock makes reserve-before-publish atomic here
+        (window → 0). Idempotent per attempt: an already-FAILED row whose
+        ``failure_attempt_id`` equals the current attempt keeps its
+        generation; anything else assigns a fresh one. A caller-supplied
+        ``created_at`` is ignored for existing rows (immutable sort key);
+        a missing row is conditionally created (enqueue/parse errors can
+        fail before the PENDING row landed).
+        """
+        if self._storage_lock is None:
+            raise StorageNotInitializedError("JsonDocStatusStorage")
+        async with self._storage_lock:
+            existing = self._data.get(doc_id)
+            if isinstance(existing, dict):
+                current_attempt = existing.get("processing_attempt_id") or fields.get(
+                    "processing_attempt_id"
+                )
+            else:
+                current_attempt = fields.get("processing_attempt_id")
+            if (
+                isinstance(existing, dict)
+                and str(existing.get("status")) == DocStatus.FAILED.value
+                and current_attempt
+                and existing.get("failure_attempt_id") == current_attempt
+            ):
+                try:
+                    return int(existing.get("failure_generation") or 0)
+                except (TypeError, ValueError):
+                    return 0
+            generation = self._reserve_generation_locked()
+            row = {**existing, **fields} if isinstance(existing, dict) else dict(fields)
+            if isinstance(existing, dict) and "created_at" in existing:
+                row["created_at"] = existing["created_at"]
+            row["status"] = DocStatus.FAILED.value
+            row["failure_generation"] = generation
+            if current_attempt:
+                row["failure_attempt_id"] = current_attempt
+                row.setdefault("processing_attempt_id", current_attempt)
+            if "chunks_list" not in row:
+                row["chunks_list"] = []
+            self._data[doc_id] = row
+            await set_all_update_flags(self.namespace, workspace=self.workspace)
+        await self.index_done_callback()
+        return generation
+
+    async def ensure_processing_attempt_id(self, doc_id: str) -> str:
+        """Atomic (single-lock) mint-or-reuse of the row's attempt id."""
+        if self._storage_lock is None:
+            raise StorageNotInitializedError("JsonDocStatusStorage")
+        minted = False
+        async with self._storage_lock:
+            row = self._data.get(doc_id)
+            if row is None:
+                raise StorageRecordNotFoundError(doc_id)
+            attempt = row.get("processing_attempt_id")
+            if not attempt:
+                attempt = uuid.uuid4().hex
+                self._data[doc_id] = {**row, "processing_attempt_id": attempt}
+                await set_all_update_flags(self.namespace, workspace=self.workspace)
+                minted = True
+        if minted:
+            await self.index_done_callback()
+        return str(attempt)
 
     async def drop(self) -> dict[str, str]:
         """Clear shared memory and immediately persist the empty state.

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -728,6 +728,15 @@ class JsonDocStatusStorage(DocStatusStorage):
         skipped as unusable in relaxed mode — so the cursor advances past
         filtered pages instead of re-reading them; fewer candidates than
         ``limit`` proves exhaustion (CURSOR_END).
+
+        Strict failure surface (backend divergence, by design): because this
+        backend candidate-selects by scanning the WHOLE resident dict, a
+        ``strict=True`` page raises on a malformed (non-mapping) record even
+        when that record's status is NOT part of the requested sweep —
+        server-side backends (PG/Mongo/OpenSearch/Redis) never see
+        out-of-scope rows and would not fail on the same corruption. An
+        operator whose JSON-backed sweep fails closed should inspect the
+        whole store, not just the swept statuses.
         """
         if self._storage_lock is None:
             raise StorageNotInitializedError("JsonDocStatusStorage")

--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -1,6 +1,6 @@
 import os
 from dataclasses import dataclass
-from typing import Any, final
+from typing import Any, ClassVar, final
 
 from lightrag.base import (
     BaseKVStorage,
@@ -131,6 +131,8 @@ class JsonKVStorage(BaseKVStorage):
           but consumers should still respect the pipeline gate to avoid
           interleaving with batched ingest work.
     """
+
+    supports_strict_point_reads: ClassVar[bool] = True
 
     def __post_init__(self):
         # Reject path traversal before using workspace in a file path
@@ -264,6 +266,14 @@ class JsonKVStorage(BaseKVStorage):
                 # Ensure _id field contains the clean ID
                 result["_id"] = id
             return result
+
+    async def get_by_id_strict(self, id: str) -> dict[str, Any] | None:
+        """Strict point read (base contract): the in-memory shared dict has
+        no transport failure surface — a miss is a confirmed absence, and an
+        uninitialized storage raises instead of returning one."""
+        if self._storage_lock is None:
+            raise StorageNotInitializedError("JsonKVStorage")
+        return await self.get_by_id(id)
 
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
         async with self._storage_lock:

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -1246,16 +1246,18 @@ class MongoDocStatusStorage(DocStatusStorage):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _encode_cursor(created_at: str, doc_id: str) -> str:
+    def _encode_cursor(created_at: str | None, doc_id: str) -> str:
         return json.dumps([created_at, doc_id], ensure_ascii=False)
 
     @staticmethod
-    def _decode_cursor(opaque: str) -> tuple[str, str]:
+    def _decode_cursor(opaque: str) -> tuple[str | None, str]:
         try:
             decoded = json.loads(opaque)
             created, doc_id = decoded
-            if not isinstance(created, str) or not isinstance(doc_id, str):
-                raise ValueError("cursor fields must be strings")
+            if not isinstance(doc_id, str):
+                raise ValueError("cursor id must be a string")
+            if created is not None and not isinstance(created, str):
+                raise ValueError("cursor created_at must be a string or null")
         except (ValueError, TypeError) as e:
             raise StorageControlPlaneError(
                 f"Malformed scheduling cursor for MongoDocStatusStorage: {e}"
@@ -1263,13 +1265,18 @@ class MongoDocStatusStorage(DocStatusStorage):
         return created, doc_id
 
     @staticmethod
-    def _doc_cursor_key(doc: dict[str, Any]) -> tuple[str, str]:
-        """(created_at, _id) keyset key of a RAW query-returned doc. A
-        missing/non-string created_at encodes as "" — such legacy rows sort
-        first server-side (BSON missing < strings) and are consumed on the
-        first page, never moving mid-sweep (created_at is immutable)."""
+    def _doc_cursor_key(doc: dict[str, Any]) -> tuple[str | None, str]:
+        """(created_at, _id) keyset key of a RAW query-returned doc.
+
+        A missing/null/non-string created_at encodes as ``None`` — the
+        missing/null bucket, which BSON sorts BEFORE every string. Encoding
+        it as ``""`` would break the resume filter: ``{"created_at": ""}``
+        matches neither a missing field nor a null value, so a second corrupt
+        row past the page boundary would silently fall out of the sweep. The
+        ``None`` marker resumes with the ``{"created_at": None}`` predicate,
+        which Mongo defines to match BOTH missing and null."""
         created = doc.get("created_at")
-        return (created if isinstance(created, str) else "", str(doc.get("_id")))
+        return (created if isinstance(created, str) else None, str(doc.get("_id")))
 
     def _scheduling_record_from_doc(
         self, doc: dict[str, Any], *, strict: bool
@@ -1336,14 +1343,31 @@ class MongoDocStatusStorage(DocStatusStorage):
         and_clauses: list[dict[str, Any]] = []
         if isinstance(position, CursorAfter):
             created, doc_id = self._decode_cursor(position.opaque)
-            and_clauses.append(
-                {
-                    "$or": [
-                        {"created_at": {"$gt": created}},
-                        {"created_at": created, "_id": {"$gt": doc_id}},
-                    ]
-                }
-            )
+            if created is None:
+                # Cursor inside the missing/null bucket (sorted first by
+                # BSON): continue through its remaining docs by _id —
+                # {"created_at": None} matches BOTH missing and null — then
+                # every doc with a real (non-null, existing) value.
+                and_clauses.append(
+                    {
+                        "$or": [
+                            {"created_at": None, "_id": {"$gt": doc_id}},
+                            {"created_at": {"$ne": None}},
+                        ]
+                    }
+                )
+            else:
+                # Past the missing/null bucket: string-typed $gt/$eq never
+                # match missing or null fields, which is correct — that
+                # bucket was already consumed before this cursor.
+                and_clauses.append(
+                    {
+                        "$or": [
+                            {"created_at": {"$gt": created}},
+                            {"created_at": created, "_id": {"$gt": doc_id}},
+                        ]
+                    }
+                )
         if max_failure_generation is not None:
             # Cohort predicate constrains ONLY failed rows; a missing
             # failure_generation is logical 0 and therefore always eligible.

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -2,20 +2,29 @@ import os
 import re
 import json
 import time
+import uuid
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 import numpy as np
 import configparser
 import asyncio
 
-from typing import Any, Union, final
+from typing import Any, ClassVar, Union, final
 
 from ..base import (
+    CURSOR_END,
+    CURSOR_START,
     BaseGraphStorage,
     BaseKVStorage,
     BaseVectorStorage,
+    CursorAfter,
+    CursorPosition,
     DocProcessingStatus,
+    DocSchedulingRecord,
     DocStatus,
+    DocStatusPage,
     DocStatusStorage,
+    FailureGenerationMode,
 )
 from ..utils import (
     logger,
@@ -25,7 +34,16 @@ from ..utils import (
     validate_workspace,
 )
 from ..types import KnowledgeGraph, KnowledgeGraphNode, KnowledgeGraphEdge
-from ..constants import GRAPH_FIELD_SEP, DEFAULT_QUERY_PRIORITY
+from ..constants import (
+    CUSTOM_CHUNK_PATCH_METADATA_KEY,
+    GRAPH_FIELD_SEP,
+    DEFAULT_QUERY_PRIORITY,
+)
+from ..exceptions import (
+    StorageControlPlaneError,
+    StorageNotInitializedError,
+    StorageRecordNotFoundError,
+)
 from .._version import __version__
 from ..kg.shared_storage import get_data_init_lock, get_namespace_lock
 
@@ -35,6 +53,7 @@ if not pm.is_installed("pymongo"):
     pm.install("pymongo")
 
 from pymongo import AsyncMongoClient  # type: ignore
+from pymongo import ReturnDocument  # type: ignore
 from pymongo import UpdateOne  # type: ignore
 from pymongo.asynchronous.database import AsyncDatabase  # type: ignore
 from pymongo.asynchronous.collection import AsyncCollection  # type: ignore
@@ -327,6 +346,8 @@ class MongoKVStorage(BaseKVStorage):
     db: AsyncDatabase = field(default=None)
     _data: AsyncCollection = field(default=None)
 
+    supports_strict_point_reads: ClassVar[bool] = True
+
     def __init__(self, namespace, global_config, embedding_func, workspace=None):
         super().__init__(
             namespace=namespace,
@@ -401,6 +422,15 @@ class MongoKVStorage(BaseKVStorage):
             doc.setdefault("create_time", 0)
             doc.setdefault("update_time", 0)
         return doc
+
+    async def get_by_id_strict(self, id: str) -> dict[str, Any] | None:
+        """Strict point read: complete-or-raise (base contract).
+
+        ``find_one`` either answers definitively or raises a ``PyMongoError``
+        — nothing is swallowed on this path, so a ``None`` IS a confirmed
+        absence (the FAILED-stub deletion path may act on it).
+        """
+        return await self.get_by_id(id)
 
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
         cursor = self._data.find({"_id": {"$in": ids}})
@@ -551,6 +581,21 @@ class MongoKVStorage(BaseKVStorage):
 class MongoDocStatusStorage(DocStatusStorage):
     db: AsyncDatabase = field(default=None)
     _data: AsyncCollection = field(default=None)
+    _ctrl: AsyncCollection = field(default=None)
+
+    supports_bounded_scheduling_pages: ClassVar[bool] = True
+    supports_failure_generation: ClassVar[bool] = True
+    supports_strict_doc_identity_lookup: ClassVar[bool] = True
+    supports_strict_point_reads: ClassVar[bool] = True
+
+    # Scheduling control-plane doc (failure-generation counter + mode marker
+    # + version stamp) lives in a SEPARATE per-workspace collection
+    # (``<final_namespace>_scheduling_ctrl``), never in ``self._data`` — a
+    # reserved _id inside the data collection would leak into every
+    # status/full-scan reader. The version stamp guards marker integrity: a
+    # mismatch reads as MIGRATING (never LEGACY).
+    _CTRL_SCHEMA_VERSION: ClassVar[int] = 1
+    _CTRL_DOC_ID: ClassVar[str] = "scheduling_ctrl"
 
     def _prepare_doc_status_data(self, doc: dict[str, Any]) -> dict[str, Any]:
         """Normalize and migrate a raw Mongo document to DocProcessingStatus-compatible dict."""
@@ -619,6 +664,9 @@ class MongoDocStatusStorage(DocStatusStorage):
             logger.debug(f"Final namespace (no workspace): '{self.final_namespace}'")
 
         self._collection_name = self.final_namespace
+        # Same workspace isolation as the data collection: the ctrl collection
+        # name derives from the workspace-prefixed final_namespace.
+        self._ctrl_collection_name = f"{self.final_namespace}_scheduling_ctrl"
 
     async def initialize(self):
         async with get_data_init_lock():
@@ -630,8 +678,69 @@ class MongoDocStatusStorage(DocStatusStorage):
             # Create and migrate all indexes including Chinese collation for file_path
             await self.create_and_migrate_indexes_if_not_exists()
 
+            # Scheduling control-plane bootstrap (Phase 1): publish or
+            # recalibrate the per-workspace failure-generation marker.
+            self._ctrl = await get_or_create_collection(
+                self.db, self._ctrl_collection_name
+            )
+            await self._bootstrap_scheduling_ctrl()
+
             logger.debug(
                 f"[{self.workspace}] Use MongoDB as DocStatus {self._collection_name}"
+            )
+
+    async def _bootstrap_scheduling_ctrl(self) -> None:
+        """Bootstrap/calibrate the failure-generation control-plane doc.
+
+        Runs on EVERY init (a restore-from-backup can roll the ctrl doc
+        behind persisted rows, and the reservation counter must stay
+        monotonic — ``max(counter, max persisted failure_generation)``):
+
+        * no ctrl doc → publish ``{schema_version=1, mode=enforced,
+          counter=max persisted}`` (``$setOnInsert`` upsert is idempotent
+          across racing processes);
+        * ctrl doc with the known schema_version → ``$max``-recalibrate the
+          counter against the persisted rows;
+        * unknown schema_version → left untouched; mode reads report
+          MIGRATING (never LEGACY) until an explicit migration handles it.
+        """
+        pipeline = [
+            {"$match": {"failure_generation": {"$type": "number"}}},
+            {"$group": {"_id": None, "max_gen": {"$max": "$failure_generation"}}},
+        ]
+        cursor = await self._data.aggregate(pipeline, allowDiskUse=True)
+        rows = await cursor.to_list(length=None)
+        max_gen = 0
+        if rows and rows[0].get("max_gen") is not None:
+            max_gen = int(rows[0]["max_gen"])
+
+        result = await self._ctrl.update_one(
+            {"_id": self._CTRL_DOC_ID},
+            {
+                "$setOnInsert": {
+                    "schema_version": self._CTRL_SCHEMA_VERSION,
+                    "mode": FailureGenerationMode.ENFORCED.value,
+                    "failure_generation_counter": max_gen,
+                }
+            },
+            upsert=True,
+        )
+        if result.upserted_id is not None:
+            logger.info(
+                f"[{self.workspace}] Published failure-generation marker "
+                f"(mode=enforced, counter={max_gen}) for {self._collection_name}"
+            )
+            return
+        # Counter recalibration: only touch a marker whose schema version we
+        # understand; $max never moves the counter backwards.
+        recal = await self._ctrl.update_one(
+            {"_id": self._CTRL_DOC_ID, "schema_version": self._CTRL_SCHEMA_VERSION},
+            {"$max": {"failure_generation_counter": max_gen}},
+        )
+        if recal.modified_count:
+            logger.warning(
+                f"[{self.workspace}] failure-generation counter behind persisted "
+                f"rows (< {max_gen}); recalibrated for {self._collection_name}"
             )
 
     async def finalize(self):
@@ -639,8 +748,18 @@ class MongoDocStatusStorage(DocStatusStorage):
             await ClientManager.release_client(self.db)
             self.db = None
             self._data = None
+            self._ctrl = None
 
     async def get_by_id(self, id: str) -> Union[dict[str, Any], None]:
+        return await self._data.find_one({"_id": id})
+
+    async def get_by_id_strict(self, id: str) -> Union[dict[str, Any], None]:
+        """Strict point read: complete-or-raise (base contract).
+
+        ``find_one`` either answers definitively or raises a ``PyMongoError``
+        — nothing is swallowed on this path, so a ``None`` IS a confirmed
+        absence.
+        """
         return await self._data.find_one({"_id": id})
 
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
@@ -843,6 +962,20 @@ class MongoDocStatusStorage(DocStatusStorage):
                         "content_hash": {"$exists": True, "$type": "string", "$gt": ""}
                     },
                 },
+                # Keyset sweep index for the bounded scheduling page API:
+                # matches the MUST sort of get_docs_by_statuses_page
+                # ((created_at ASC, _id ASC) within each status branch of a
+                # status $in — the server merges the per-status keysets).
+                {
+                    "name": f"{workspace_prefix}status_created_at_id_asc",
+                    "keys": [("status", 1), ("created_at", 1), ("_id", 1)],
+                },
+                # failure_generation for the manual-cohort predicate and the
+                # startup counter-calibration aggregation ($max over rows).
+                {
+                    "name": f"{workspace_prefix}failure_generation",
+                    "keys": [("failure_generation", 1)],
+                },
             ]
 
             # 2. Handle legacy index cleanup: only drop old indexes that exist in THIS collection
@@ -1044,17 +1177,38 @@ class MongoDocStatusStorage(DocStatusStorage):
         stored ``file_path`` values are canonicalized by the business layer, so
         this lookup performs an exact match only and relies on the file_path
         index created by ``create_and_migrate_indexes_if_not_exists``.
+
+        Returns the PRIMARY (``metadata.is_duplicate != true``) row only —
+        duplicate-attempt ``dup-*`` markers keep the same canonical basename
+        and must never satisfy an identity lookup. Legacy error semantics:
+        query failures are logged and read as a best-effort miss (``None``);
+        callers that need "None == confirmed absent" must use
+        :meth:`get_doc_by_file_basename_strict`.
+        """
+        try:
+            return await self.get_doc_by_file_basename_strict(basename)
+        except PyMongoError as e:
+            logger.error(f"[{self.workspace}] Error in get_doc_by_file_basename: {e}")
+            return None
+
+    async def get_doc_by_file_basename_strict(
+        self, basename: str
+    ) -> Union[tuple[str, dict[str, Any]], None]:
+        """Fail-closed basename lookup (see base contract).
+
+        Same primary-row query as the legacy method, but transport errors
+        PROPAGATE instead of being read as a miss — scan classification and
+        enqueue dedup treat ``None`` as "confirmed new", so a swallowed
+        failure here would mint duplicate primary rows.
         """
         if not basename:
             return None
         if basename == "unknown_source":
             return None
 
-        try:
-            doc = await self._data.find_one({"file_path": basename})
-        except PyMongoError as e:
-            logger.error(f"[{self.workspace}] Error in get_doc_by_file_basename: {e}")
-            return None
+        doc = await self._data.find_one(
+            {"file_path": basename, "metadata.is_duplicate": {"$ne": True}}
+        )
         if not doc:
             return None
         doc_id = doc.get("_id")
@@ -1086,6 +1240,355 @@ class MongoDocStatusStorage(DocStatusStorage):
         if doc_id is None:
             return None
         return str(doc_id), doc
+
+    # ------------------------------------------------------------------
+    # Memory-bounding scheduling API (Phase 1)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _encode_cursor(created_at: str, doc_id: str) -> str:
+        return json.dumps([created_at, doc_id], ensure_ascii=False)
+
+    @staticmethod
+    def _decode_cursor(opaque: str) -> tuple[str, str]:
+        try:
+            decoded = json.loads(opaque)
+            created, doc_id = decoded
+            if not isinstance(created, str) or not isinstance(doc_id, str):
+                raise ValueError("cursor fields must be strings")
+        except (ValueError, TypeError) as e:
+            raise StorageControlPlaneError(
+                f"Malformed scheduling cursor for MongoDocStatusStorage: {e}"
+            ) from e
+        return created, doc_id
+
+    @staticmethod
+    def _doc_cursor_key(doc: dict[str, Any]) -> tuple[str, str]:
+        """(created_at, _id) keyset key of a RAW query-returned doc. A
+        missing/non-string created_at encodes as "" — such legacy rows sort
+        first server-side (BSON missing < strings) and are consumed on the
+        first page, never moving mid-sweep (created_at is immutable)."""
+        created = doc.get("created_at")
+        return (created if isinstance(created, str) else "", str(doc.get("_id")))
+
+    def _scheduling_record_from_doc(
+        self, doc: dict[str, Any], *, strict: bool
+    ) -> DocSchedulingRecord | None:
+        """Project one raw Mongo doc; strict raises on unusable docs, relaxed
+        returns None (the caller still counts the doc as consumed)."""
+        doc_id = str(doc.get("_id"))
+        try:
+            status = DocStatus(str(doc["status"]))
+            created_at = doc["created_at"]
+            updated_at = doc.get("updated_at", created_at)
+            if not isinstance(created_at, str) or not isinstance(updated_at, str):
+                raise TypeError("created_at/updated_at must be strings")
+            metadata = doc.get("metadata")
+            return DocSchedulingRecord(
+                id=doc_id,
+                status=status,
+                created_at=created_at,
+                updated_at=updated_at,
+                file_path=doc.get("file_path") or "no-file-path",
+                track_id=doc.get("track_id"),
+                has_custom_chunk_journal=isinstance(metadata, dict)
+                and isinstance(metadata.get(CUSTOM_CHUNK_PATCH_METADATA_KEY), dict),
+            )
+        except (KeyError, TypeError, ValueError) as e:
+            logger.error(f"[{self.workspace}] Unusable scheduling row {doc_id}: {e}")
+            if strict:
+                raise
+            return None
+
+    async def get_docs_by_statuses_page(
+        self,
+        statuses: list[DocStatus],
+        *,
+        limit: int,
+        position: CursorPosition = CURSOR_START,
+        max_failure_generation: int | None = None,
+        strict: bool = False,
+    ) -> DocStatusPage:
+        """Bounded keyset page: one indexed ``find`` with ``sort`` + ``limit``.
+
+        ``created_at`` is stored as an ISO-8601 string, so the keyset
+        comparison stays string-typed end to end (cursor ↔ query ↔ sort).
+
+        Consumed-position contract: every predicate (status, keyset resume,
+        ``max_failure_generation`` cohort) is evaluated SERVER-side, so the
+        set of query-returned docs IS the set of consumed records — the
+        frontier is the last RETURNED doc's ``(created_at, _id)`` key, and
+        fewer returned docs than ``limit`` proves the sweep is exhausted
+        (CURSOR_END). A relaxed-mode conversion skip drops the doc from the
+        page but the doc was still returned by the query, hence consumed:
+        the cursor advances past it (never re-read, never terminal-by-skip).
+
+        Transport/query errors always propagate (never swallowed into a
+        partial page); ``strict=True`` additionally raises on any returned
+        doc that cannot be projected to :class:`DocSchedulingRecord`.
+        """
+        if limit <= 0:
+            raise ValueError(f"page limit must be positive, got {limit}")
+        if not statuses or position is CURSOR_END:
+            return DocStatusPage(docs={}, next_position=CURSOR_END)
+
+        query: dict[str, Any] = {"status": {"$in": sorted({s.value for s in statuses})}}
+        and_clauses: list[dict[str, Any]] = []
+        if isinstance(position, CursorAfter):
+            created, doc_id = self._decode_cursor(position.opaque)
+            and_clauses.append(
+                {
+                    "$or": [
+                        {"created_at": {"$gt": created}},
+                        {"created_at": created, "_id": {"$gt": doc_id}},
+                    ]
+                }
+            )
+        if max_failure_generation is not None:
+            # Cohort predicate constrains ONLY failed rows; a missing
+            # failure_generation is logical 0 and therefore always eligible.
+            and_clauses.append(
+                {
+                    "$or": [
+                        {"status": {"$ne": DocStatus.FAILED.value}},
+                        {"failure_generation": {"$lte": max_failure_generation}},
+                        {"failure_generation": {"$exists": False}},
+                    ]
+                }
+            )
+        if and_clauses:
+            query["$and"] = and_clauses
+
+        cursor = (
+            self._data.find(query).sort([("created_at", 1), ("_id", 1)]).limit(limit)
+        )
+        raw_docs = await cursor.to_list(length=limit)
+
+        docs: dict[str, DocSchedulingRecord] = {}
+        for doc in raw_docs:
+            record = self._scheduling_record_from_doc(doc, strict=strict)
+            if record is None:
+                continue  # relaxed skip: query-returned, hence still consumed
+            docs[record.id] = record
+
+        if len(raw_docs) < limit:
+            return DocStatusPage(docs=docs, next_position=CURSOR_END)
+        last_created, last_id = self._doc_cursor_key(raw_docs[-1])
+        return DocStatusPage(
+            docs=docs,
+            next_position=CursorAfter(self._encode_cursor(last_created, last_id)),
+        )
+
+    async def count_docs_by_statuses(
+        self, statuses: list[DocStatus], *, strict: bool = True
+    ) -> int:
+        """Fail-closed status count: accurate ``count_documents`` or raise
+        (errors propagate — admission control treats an error as "refuse")."""
+        if not statuses:
+            return 0
+        return await self._data.count_documents(
+            {"status": {"$in": sorted({s.value for s in statuses})}}
+        )
+
+    async def update_doc_status_fields(
+        self,
+        doc_id: str,
+        fields: dict[str, Any],
+        *,
+        missing_ok: bool = False,
+    ) -> None:
+        """Targeted ``$set`` of the given fields only (no read-modify-write,
+        so a huge ``chunks_list`` never travels through memory)."""
+        if "created_at" in fields:
+            raise ValueError(
+                "created_at is an immutable scheduling sort key and cannot "
+                "be changed via update_doc_status_fields"
+            )
+        if not fields:
+            # Mongo rejects an empty $set document; still honour the
+            # existence contract for a no-op update.
+            if missing_ok:
+                return
+            if await self._data.find_one({"_id": doc_id}, {"_id": 1}) is None:
+                raise StorageRecordNotFoundError(doc_id)
+            return
+        result = await self._data.update_one({"_id": doc_id}, {"$set": fields})
+        if result.matched_count == 0:
+            if missing_ok:
+                return
+            raise StorageRecordNotFoundError(doc_id)
+
+    # ------------------------------------------------------------------
+    # failure_generation write side (Phase 1)
+    # ------------------------------------------------------------------
+
+    async def get_failure_generation_mode(self) -> FailureGenerationMode:
+        """Read the per-workspace marker. Missing doc / unknown schema
+        version / invalid mode value all read as MIGRATING (never LEGACY —
+        LEGACY would reopen the full-snapshot manual path); transport errors
+        propagate as-is."""
+        if self._ctrl is None:
+            raise StorageNotInitializedError("MongoDocStatusStorage")
+        ctrl = await self._ctrl.find_one({"_id": self._CTRL_DOC_ID})
+        if not isinstance(ctrl, dict):
+            return FailureGenerationMode.MIGRATING
+        if ctrl.get("schema_version") != self._CTRL_SCHEMA_VERSION:
+            return FailureGenerationMode.MIGRATING
+        try:
+            return FailureGenerationMode(str(ctrl.get("mode")))
+        except ValueError:
+            return FailureGenerationMode.MIGRATING
+
+    async def reserve_failure_generation(self) -> int:
+        """Atomic ``$inc`` reservation on the ctrl doc.
+
+        The reservation is the linearization point of a failure event; a
+        reservation whose FAILED publish later fails becomes a permanent
+        hole (never reused, never rolled back). A missing or
+        version-mismatched ctrl doc raises a control-plane error — never a
+        silent degrade.
+        """
+        if self._ctrl is None:
+            raise StorageNotInitializedError("MongoDocStatusStorage")
+        ctrl = await self._ctrl.find_one_and_update(
+            {"_id": self._CTRL_DOC_ID, "schema_version": self._CTRL_SCHEMA_VERSION},
+            {"$inc": {"failure_generation_counter": 1}},
+            return_document=ReturnDocument.AFTER,
+        )
+        if ctrl is None:
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] failure-generation marker missing or "
+                f"version-mismatched for {self._collection_name}; refusing "
+                "(never degrades to LEGACY full-snapshot behaviour)"
+            )
+        counter = ctrl.get("failure_generation_counter")
+        if isinstance(counter, bool) or not isinstance(counter, (int, float)):
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] failure-generation counter corrupt "
+                f"({counter!r}) for {self._collection_name}"
+            )
+        return int(counter)
+
+    async def mark_doc_failed(self, doc_id: str, fields: dict[str, Any]) -> int | None:
+        """FAILED transition funnel: read → reserve → conditional publish.
+
+        Mongo keeps reserve and publish as two steps (the plan's cohort
+        semantics explicitly account for this bounded reserve→publish
+        window; a reservation whose publish loses is a permanent hole).
+
+        * Idempotent per attempt: an already-FAILED row whose
+          ``failure_attempt_id`` equals the current attempt returns its
+          existing generation without reserving a new one.
+        * CAS publish: the update is guarded against a concurrent FAILED
+          publish of the SAME attempt — losing the race surfaces as a
+          ``DuplicateKeyError`` on the guarded upsert, and the winner's
+          generation is adopted.
+        * ``created_at`` goes only into ``$setOnInsert``: an existing row's
+          scheduling sort key is immutable (a caller-supplied value is
+          ignored), while a missing row is conditionally created as FAILED
+          (enqueue/parse errors can fail before the PENDING row landed).
+        """
+        existing = await self._data.find_one({"_id": doc_id})
+        if isinstance(existing, dict):
+            current_attempt = existing.get("processing_attempt_id") or fields.get(
+                "processing_attempt_id"
+            )
+        else:
+            current_attempt = fields.get("processing_attempt_id")
+        if (
+            isinstance(existing, dict)
+            and str(existing.get("status")) == DocStatus.FAILED.value
+            and current_attempt
+            and existing.get("failure_attempt_id") == current_attempt
+        ):
+            try:
+                return int(existing.get("failure_generation") or 0)
+            except (TypeError, ValueError):
+                return 0
+
+        generation = await self.reserve_failure_generation()
+
+        set_fields = dict(fields)
+        caller_created_at = set_fields.pop("created_at", None)
+        set_fields.pop("_id", None)
+        set_fields["status"] = DocStatus.FAILED.value
+        set_fields["failure_generation"] = generation
+        if current_attempt:
+            set_fields["failure_attempt_id"] = current_attempt
+            set_fields.setdefault("processing_attempt_id", current_attempt)
+        on_insert: dict[str, Any] = {
+            "created_at": caller_created_at or datetime.now(timezone.utc).isoformat(),
+        }
+        if "chunks_list" not in set_fields:
+            on_insert["chunks_list"] = []
+
+        publish_filter: dict[str, Any] = {"_id": doc_id}
+        if current_attempt:
+            # CAS guard: never overwrite a concurrent FAILED publish of the
+            # same attempt with a second generation.
+            publish_filter["$nor"] = [
+                {
+                    "status": DocStatus.FAILED.value,
+                    "failure_attempt_id": current_attempt,
+                }
+            ]
+        try:
+            await self._data.find_one_and_update(
+                publish_filter,
+                {"$set": set_fields, "$setOnInsert": on_insert},
+                upsert=True,
+            )
+        except DuplicateKeyError:
+            # Lost the CAS race: a concurrent failure of the same attempt
+            # published between our read and write (the guarded filter
+            # matched nothing, so the upsert tried to insert a second doc
+            # with the same _id). Adopt the winner's generation; ours
+            # becomes a permanent hole.
+            winner = await self._data.find_one({"_id": doc_id})
+            if not isinstance(winner, dict):
+                raise
+            try:
+                return int(winner.get("failure_generation") or 0)
+            except (TypeError, ValueError):
+                return 0
+        return generation
+
+    async def ensure_processing_attempt_id(self, doc_id: str) -> str:
+        """Mint-or-reuse the row's attempt id via a conditional update.
+
+        Two-op conditional write (not an aggregation-pipeline update — the
+        declared pymongo/server floor makes pipeline-update support
+        uncertain): the guarded ``update_one`` only ever fires when the row
+        has no attempt id, so a lost-response retry re-reads the persisted
+        winner instead of minting a second id.
+        """
+        for _ in range(3):
+            new_id = uuid.uuid4().hex
+            result = await self._data.update_one(
+                {
+                    "_id": doc_id,
+                    "$or": [
+                        {"processing_attempt_id": {"$exists": False}},
+                        {"processing_attempt_id": {"$in": [None, ""]}},
+                    ],
+                },
+                {"$set": {"processing_attempt_id": new_id}},
+            )
+            if result.matched_count:
+                return new_id
+            doc = await self._data.find_one(
+                {"_id": doc_id}, {"processing_attempt_id": 1}
+            )
+            if doc is None:
+                raise StorageRecordNotFoundError(doc_id)
+            attempt = doc.get("processing_attempt_id")
+            if attempt:
+                return str(attempt)
+            # Row appeared (without an attempt id) between the conditional
+            # write and the read — retry the conditional write.
+        raise StorageControlPlaneError(
+            f"[{self.workspace}] could not settle processing_attempt_id for {doc_id}"
+        )
 
 
 @final

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -9,23 +9,37 @@ Requirements:
     - OpenSearch 3.x or higher with k-NN plugin enabled
 """
 
+import json
 import os
+import random
 import re
 import ssl as ssl_module
 import time
+import uuid
 import asyncio
 from dataclasses import dataclass, field
-from typing import Any, AsyncIterator, Union, final
+from typing import Any, AsyncIterator, ClassVar, Union, final
 import numpy as np
 import configparser
 
 from ..base import (
+    CURSOR_END,
+    CURSOR_START,
     BaseGraphStorage,
     BaseKVStorage,
     BaseVectorStorage,
+    CursorAfter,
+    CursorPosition,
     DocProcessingStatus,
+    DocSchedulingRecord,
     DocStatus,
+    DocStatusPage,
     DocStatusStorage,
+    FailureGenerationMode,
+)
+from ..exceptions import (
+    StorageControlPlaneError,
+    StorageRecordNotFoundError,
 )
 from ..utils import (
     logger,
@@ -35,7 +49,11 @@ from ..utils import (
     validate_workspace,
 )
 from ..types import KnowledgeGraph, KnowledgeGraphNode, KnowledgeGraphEdge
-from ..constants import GRAPH_FIELD_SEP, DEFAULT_QUERY_PRIORITY
+from ..constants import (
+    CUSTOM_CHUNK_PATCH_METADATA_KEY,
+    GRAPH_FIELD_SEP,
+    DEFAULT_QUERY_PRIORITY,
+)
 from ..kg.shared_storage import get_data_init_lock, get_namespace_lock
 
 import pipmaster as pm
@@ -200,6 +218,22 @@ DEFAULT_OPENSEARCH_DELETE_MAX_RECORDS_PER_BATCH = 1000
 # disabled (env value <= 0). async_bulk needs a positive int here, so we use a
 # large finite value in place of Mongo's float("inf").
 _OPENSEARCH_UNBOUNDED_PAYLOAD_BYTES = 1 << 62
+
+# Optimistic-concurrency (if_seq_no/if_primary_term) retry policy for the
+# scheduling control plane (failure-generation counter reservation, FAILED
+# CAS publish, attempt-id minting). Retries are bounded — exhausting them
+# raises a control-plane error instead of spinning — and each retry sleeps a
+# uniformly-jittered, linearly-growing backoff so two colliding writers
+# de-synchronize quickly.
+_SCHEDULING_CAS_MAX_RETRIES = 8
+_SCHEDULING_CAS_BACKOFF_BASE_SECONDS = 0.02
+
+
+async def _scheduling_cas_backoff(attempt: int) -> None:
+    """Jittered backoff between optimistic-concurrency retries."""
+    await asyncio.sleep(
+        random.uniform(0.0, _SCHEDULING_CAS_BACKOFF_BASE_SECONDS * (attempt + 1))
+    )
 
 
 def _resolve_bulk_batch_limits() -> tuple[int, int, int]:
@@ -658,6 +692,8 @@ async def _verify_mirrored_id_mapping(client: AsyncOpenSearch, index_name: str) 
 class OpenSearchKVStorage(BaseKVStorage):
     """Key-Value storage using OpenSearch. Uses dynamic mapping to support varied schemas."""
 
+    supports_strict_point_reads: ClassVar[bool] = True
+
     client: AsyncOpenSearch = field(default=None)
     _index_name: str = field(default="", init=False)
     _index_ready: bool = field(default=False, init=False)
@@ -901,6 +937,60 @@ class OpenSearchKVStorage(BaseKVStorage):
             # would delete a live doc_status row on a transient failure.
             logger.error(f"[{self.workspace}] Error getting document {id}: {e}")
             raise
+
+    async def get_by_id_strict(self, id: str) -> dict[str, Any] | None:
+        """Point read with complete-or-raise semantics (base contract).
+
+        Three-state contract on top of the pending buffer:
+
+        * pending delete (tombstone) → ``None`` — the delete is already
+          decided, so absence after flush is a certainty;
+        * pending upsert → the buffered doc (present);
+        * ``_index_ready=False`` → raise ``StorageControlPlaneError``: the
+          index was dropped or previously observed missing, so this class
+          CANNOT positively confirm absence (unlike ``get_by_id``, which
+          reads that state as a best-effort miss);
+        * a live ``index_not_found`` error → raise as well — after
+          ``initialize()`` the index always exists, so it vanishing mid-read
+          (restore/concurrent drop) is indistinguishable from data loss and
+          must not be presented as "confirmed absent";
+        * healthy mget with ``found=False`` → ``None`` (confirmed absent);
+        * any other transport/server or item-level error → raise.
+        """
+        async with self._flush_lock:
+            if id in self._pending_kv_deletes:
+                return None
+            pending = self._pending_upserts.get(id)
+            if pending is not None:
+                return self._materialize_pending_kv_doc(id, pending)
+            if not self._index_ready:
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] {self.namespace} index "
+                    f"'{self._index_name}' is not ready; cannot confirm "
+                    f"absence of '{id}' (strict point read)"
+                )
+        try:
+            response = await _mget_optional_doc(self.client, self._index_name, id)
+        except OpenSearchException as e:
+            if _is_missing_index_error(e):
+                self._mark_index_missing()
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] {self.namespace} index "
+                    f"'{self._index_name}' unexpectedly missing; cannot "
+                    f"confirm absence of '{id}' (strict point read)"
+                ) from e
+            logger.error(
+                f"[{self.workspace}] Error strictly getting document {id}: {e}"
+            )
+            raise
+        if response is None:
+            return None
+        doc = response["_source"]
+        doc.pop("__mirrored_id", None)
+        doc["_id"] = response["_id"]
+        doc.setdefault("create_time", 0)
+        doc.setdefault("update_time", 0)
+        return doc
 
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
         """Get multiple documents by IDs (read-your-writes), preserving order.
@@ -1295,7 +1385,44 @@ class OpenSearchKVStorage(BaseKVStorage):
 @final
 @dataclass
 class OpenSearchDocStatusStorage(DocStatusStorage):
-    """Document status storage using OpenSearch."""
+    """Document status storage using OpenSearch.
+
+    Memory-bounding scheduling API (Phase 1): implements native
+    ``search_after`` keyset pages sorted ``(created_at ASC, __mirrored_id
+    ASC)`` plus the failure-generation write side. The failure-generation
+    counter and per-workspace mode marker live in an INDEPENDENT small
+    metadata index (``<doc-status index>_scheduling_ctrl``, one ctrl doc)
+    so a reserved generation can never be lost to a doc-status bulk path,
+    and reservations use realtime GET + ``if_seq_no``/``if_primary_term``
+    optimistic CAS (bounded, jittered retries on 409).
+    """
+
+    supports_bounded_scheduling_pages: ClassVar[bool] = True
+    supports_failure_generation: ClassVar[bool] = True
+    supports_strict_doc_identity_lookup: ClassVar[bool] = True
+    supports_strict_point_reads: ClassVar[bool] = True
+
+    # Scheduling control-plane doc (failure-generation counter + mode marker
+    # + schema version). Version stamps guard marker integrity: a mismatch
+    # reads as MIGRATING (never LEGACY).
+    _CTRL_SCHEMA_VERSION: ClassVar[int] = 1
+    _CTRL_DOC_ID: ClassVar[str] = "scheduling_ctrl"
+
+    # Phase-1 fields added to the doc-status mapping. NOTE (explicit review
+    # ruling): the ``long`` mapping does NOT make a missing
+    # ``failure_generation`` read as 0 — legacy rows simply lack the field —
+    # so every cohort query must pair ``range(lte)`` with
+    # ``must_not exists(failure_generation)``. ``__mirrored_id`` is included
+    # so legacy indexes (pre-mirrored-id, only tolerated on OpenSearch
+    # >= 3.3.0) gain the keyword tiebreaker mapping for new writes; their
+    # OLD docs still lack the field VALUE and sort behind everything with an
+    # unresolved tie until rewritten (every write path re-stamps it).
+    _SCHEDULING_FIELD_MAPPINGS: ClassVar[dict[str, dict[str, str]]] = {
+        "failure_generation": {"type": "long"},
+        "processing_attempt_id": {"type": "keyword"},
+        "failure_attempt_id": {"type": "keyword"},
+        "__mirrored_id": {"type": "keyword"},
+    }
 
     client: AsyncOpenSearch = field(default=None)
     _index_name: str = field(default="", init=False)
@@ -1315,6 +1442,9 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
         self.workspace, self.final_namespace, self._index_name = _build_index_name(
             self.workspace, self.namespace
         )
+        # Workspace isolation is inherited from the doc-status index name
+        # (already workspace-prefixed), so the ctrl index is per-workspace.
+        self._ctrl_index_name = f"{self._index_name}_scheduling_ctrl"
         (
             self._max_upsert_payload_bytes,
             self._max_upsert_records_per_batch,
@@ -1338,12 +1468,23 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
         return data
 
     async def initialize(self):
-        """Initialize client connection and create doc status index."""
+        """Initialize client connection, create indexes and bootstrap the
+        scheduling control plane.
+
+        Ctrl bootstrap (Phase 1) runs on EVERY init: a missing ctrl doc is
+        seeded from a max-aggregation over persisted ``failure_generation``
+        (mode=enforced), and an existing counter that fell behind persisted
+        rows (restore-from-backup) is CAS-recalibrated so reservations stay
+        monotonic. Bootstrap failures propagate — the startup fence refuses
+        to serve rather than run with an unverified counter.
+        """
         async with get_data_init_lock():
             if self.client is None:
                 self.client = await ClientManager.get_client()
             await self._create_index_if_not_exists()
             self._index_ready = True
+            await self._create_ctrl_index_if_not_exists()
+            await self._bootstrap_scheduling_ctrl()
             logger.debug(
                 f"[{self.workspace}] OpenSearch DocStatus storage initialized: {self._index_name}"
             )
@@ -1377,6 +1518,9 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                             "content_hash": {"type": "keyword"},
                             "created_at": {"type": "date"},
                             "updated_at": {"type": "date"},
+                            "failure_generation": {"type": "long"},
+                            "processing_attempt_id": {"type": "keyword"},
+                            "failure_attempt_id": {"type": "keyword"},
                         },
                     },
                     "settings": {
@@ -1393,6 +1537,7 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
             else:
                 await _verify_mirrored_id_mapping(self.client, self._index_name)
                 await self._ensure_content_hash_mapping()
+                await self._ensure_scheduling_fields_mapping()
         except RequestError as e:
             if "resource_already_exists_exception" not in str(e):
                 raise
@@ -1432,6 +1577,301 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                 f"{self._index_name}: {e}"
             )
 
+    async def _ensure_scheduling_fields_mapping(self) -> None:
+        """Add the Phase-1 scheduling field mappings to a pre-existing index.
+
+        Same idempotent put_mapping pattern as ``_ensure_content_hash_mapping``
+        (new fields only — existing indexes need nothing else for new docs).
+        The mapping does NOT backfill legacy docs: rows that predate the
+        migration still lack ``failure_generation`` and are matched by the
+        ``must_not exists`` arm of the cohort predicate. A put failure is
+        logged rather than raised — ``dynamic: true`` maps the fields on
+        first write with the same types, and the strict page sort fails
+        loudly (never silently misorders) if ``__mirrored_id`` stays
+        unsortable.
+        """
+        try:
+            mapping = await self.client.indices.get_mapping(index=self._index_name)
+        except OpenSearchException:
+            return
+        props = (
+            mapping.get(self._index_name, {}).get("mappings", {}).get("properties", {})
+        )
+        missing = {
+            name: spec
+            for name, spec in self._SCHEDULING_FIELD_MAPPINGS.items()
+            if name not in props
+        }
+        if not missing:
+            return
+        try:
+            await self.client.indices.put_mapping(
+                index=self._index_name,
+                body={"properties": missing},
+            )
+            logger.info(
+                f"[{self.workspace}] Added scheduling field mappings "
+                f"{sorted(missing)} to {self._index_name}"
+            )
+        except OpenSearchException as e:
+            logger.warning(
+                f"[{self.workspace}] Failed to add scheduling field mappings to "
+                f"{self._index_name}: {e}"
+            )
+
+    # ------------------------------------------------------------------
+    # Scheduling control plane (failure-generation counter + mode marker)
+    # ------------------------------------------------------------------
+
+    async def _create_ctrl_index_if_not_exists(self) -> None:
+        """Create the per-workspace scheduling ctrl index (one ctrl doc)."""
+        try:
+            if not await self.client.indices.exists(index=self._ctrl_index_name):
+                body = {
+                    "mappings": {
+                        "dynamic": True,
+                        "properties": {
+                            "schema_version": {"type": "integer"},
+                            "mode": {"type": "keyword"},
+                            "failure_generation_counter": {"type": "long"},
+                        },
+                    },
+                    "settings": {
+                        "index": {
+                            # Single doc — one shard suffices; replicas follow
+                            # the doc-status index so counter durability is no
+                            # weaker than the FAILED status write itself.
+                            "number_of_shards": 1,
+                            "number_of_replicas": _get_index_number_of_replicas(),
+                        },
+                    },
+                }
+                await self.client.indices.create(index=self._ctrl_index_name, body=body)
+                logger.info(
+                    f"[{self.workspace}] Created scheduling ctrl index: "
+                    f"{self._ctrl_index_name}"
+                )
+        except RequestError as e:
+            if "resource_already_exists_exception" not in str(e):
+                raise
+
+    async def _max_persisted_failure_generation(self) -> int:
+        """Max ``failure_generation`` across persisted rows (0 when none)."""
+        body = {
+            "size": 0,
+            "aggs": {
+                "max_failure_generation": {"max": {"field": "failure_generation"}}
+            },
+        }
+        try:
+            response = await self.client.search(index=self._index_name, body=body)
+        except OpenSearchException as e:
+            if _is_missing_index_error(e):
+                return 0
+            raise
+        value = (
+            response.get("aggregations", {})
+            .get("max_failure_generation", {})
+            .get("value")
+        )
+        return int(value) if value is not None else 0
+
+    async def _bootstrap_scheduling_ctrl(self) -> None:
+        """Seed/calibrate the ctrl doc at startup (see ``initialize``).
+
+        * No ctrl doc → publish ``{schema_version, mode=enforced, counter=
+          max persisted failure_generation}`` with ``op_type=create`` so a
+          concurrent bootstrap cannot be clobbered (on 409 the winner's doc
+          is calibrated instead).
+        * Known schema + counter behind persisted rows → CAS recalibrate
+          (restore-from-backup can roll the ctrl index behind doc-status;
+          the reservation counter must stay monotonic).
+        * Unknown schema_version → left untouched; mode reads report
+          MIGRATING (never LEGACY) until an explicit migration handles it.
+        """
+        try:
+            ctrl = await self.client.get(
+                index=self._ctrl_index_name, id=self._CTRL_DOC_ID
+            )
+        except NotFoundError:
+            ctrl = None
+        if ctrl is None:
+            max_gen = await self._max_persisted_failure_generation()
+            body = {
+                "schema_version": self._CTRL_SCHEMA_VERSION,
+                "mode": FailureGenerationMode.ENFORCED.value,
+                "failure_generation_counter": max_gen,
+            }
+            try:
+                await self.client.index(
+                    index=self._ctrl_index_name,
+                    id=self._CTRL_DOC_ID,
+                    body=body,
+                    op_type="create",
+                )
+                logger.info(
+                    f"[{self.workspace}] Published failure-generation marker "
+                    f"(mode=enforced, counter={max_gen}) for {self.namespace}"
+                )
+                return
+            except ConflictError:
+                # A concurrent initialize() won the create — calibrate its doc.
+                ctrl = await self.client.get(
+                    index=self._ctrl_index_name, id=self._CTRL_DOC_ID
+                )
+
+        for attempt in range(_SCHEDULING_CAS_MAX_RETRIES):
+            source = ctrl.get("_source")
+            if (
+                not isinstance(source, dict)
+                or source.get("schema_version") != self._CTRL_SCHEMA_VERSION
+            ):
+                # Unknown/invalid marker: never rewrite it here — mode reads
+                # report MIGRATING until an explicit migration reconciles it.
+                logger.warning(
+                    f"[{self.workspace}] Scheduling ctrl doc for "
+                    f"{self.namespace} has an unknown schema; left untouched "
+                    f"(mode reads report MIGRATING)"
+                )
+                return
+            try:
+                counter = int(source.get("failure_generation_counter") or 0)
+            except (TypeError, ValueError):
+                counter = 0
+            max_gen = await self._max_persisted_failure_generation()
+            if counter >= max_gen:
+                return
+            try:
+                await self.client.index(
+                    index=self._ctrl_index_name,
+                    id=self._CTRL_DOC_ID,
+                    body={**source, "failure_generation_counter": max_gen},
+                    if_seq_no=ctrl["_seq_no"],
+                    if_primary_term=ctrl["_primary_term"],
+                )
+                logger.warning(
+                    f"[{self.workspace}] failure-generation counter behind "
+                    f"persisted rows ({counter} < {max_gen}); recalibrated"
+                )
+                return
+            except ConflictError:
+                await _scheduling_cas_backoff(attempt)
+                ctrl = await self.client.get(
+                    index=self._ctrl_index_name, id=self._CTRL_DOC_ID
+                )
+        raise StorageControlPlaneError(
+            f"[{self.workspace}] failure-generation counter recalibration for "
+            f"{self.namespace} lost {_SCHEDULING_CAS_MAX_RETRIES} consecutive "
+            f"CAS races; refusing to serve with an unverified counter"
+        )
+
+    async def _get_ctrl_doc_or_raise(self) -> dict[str, Any]:
+        """Realtime GET of the ctrl doc, validated; failures are control-plane.
+
+        A missing or version-mismatched marker on a workspace this backend
+        already initialized is corruption, never "new LEGACY workspace" —
+        raising here is what keeps a reservation from inventing a counter.
+        """
+        try:
+            ctrl = await self.client.get(
+                index=self._ctrl_index_name, id=self._CTRL_DOC_ID
+            )
+        except NotFoundError as e:
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] failure-generation marker missing for "
+                f"{self.namespace}; refusing (never degrades to LEGACY "
+                f"full-snapshot behaviour)"
+            ) from e
+        except OpenSearchException as e:
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] failure-generation marker read failed "
+                f"for {self.namespace}: {e}"
+            ) from e
+        source = ctrl.get("_source")
+        if (
+            not isinstance(source, dict)
+            or source.get("schema_version") != self._CTRL_SCHEMA_VERSION
+        ):
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] failure-generation marker version-"
+                f"mismatched for {self.namespace}; refusing (never degrades "
+                f"to LEGACY full-snapshot behaviour)"
+            )
+        return ctrl
+
+    async def get_failure_generation_mode(self) -> FailureGenerationMode:
+        """Read the per-workspace activation marker (realtime GET).
+
+        Missing doc/index, unknown schema_version and an invalid mode value
+        all read as MIGRATING (fail-closed, never LEGACY); a transport error
+        RAISES — a marker read failure must never silently reopen the
+        full-snapshot manual path.
+        """
+        try:
+            ctrl = await self.client.get(
+                index=self._ctrl_index_name, id=self._CTRL_DOC_ID
+            )
+        except NotFoundError:
+            return FailureGenerationMode.MIGRATING
+        except OpenSearchException as e:
+            logger.error(
+                f"[{self.workspace}] failure-generation mode read failed "
+                f"for {self.namespace}: {e}"
+            )
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] failure-generation mode read failed "
+                f"for {self.namespace}: {e}"
+            ) from e
+        source = ctrl.get("_source")
+        if not isinstance(source, dict):
+            return FailureGenerationMode.MIGRATING
+        if source.get("schema_version") != self._CTRL_SCHEMA_VERSION:
+            return FailureGenerationMode.MIGRATING
+        try:
+            return FailureGenerationMode(str(source.get("mode")))
+        except ValueError:
+            return FailureGenerationMode.MIGRATING
+
+    async def reserve_failure_generation(self) -> int:
+        """Atomically reserve the next failure generation (see base contract).
+
+        Realtime GET (consistent) → indexed rewrite guarded by
+        ``if_seq_no``/``if_primary_term``. A 409 means another reservation
+        won the race: re-GET and retry (bounded, jittered). The reservation
+        is durable once the index call returns (translog), i.e. no weaker
+        than the FAILED status write; a crash between reserve and publish
+        leaves a permanent hole — allowed, reuse is not.
+        """
+        last_conflict: Exception | None = None
+        for attempt in range(_SCHEDULING_CAS_MAX_RETRIES):
+            ctrl = await self._get_ctrl_doc_or_raise()
+            source = ctrl["_source"]
+            try:
+                counter = int(source.get("failure_generation_counter") or 0)
+            except (TypeError, ValueError) as e:
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] failure-generation counter corrupt "
+                    f"for {self.namespace}: {e}"
+                ) from e
+            new_counter = counter + 1
+            try:
+                await self.client.index(
+                    index=self._ctrl_index_name,
+                    id=self._CTRL_DOC_ID,
+                    body={**source, "failure_generation_counter": new_counter},
+                    if_seq_no=ctrl["_seq_no"],
+                    if_primary_term=ctrl["_primary_term"],
+                )
+                return new_counter
+            except ConflictError as e:
+                last_conflict = e
+                await _scheduling_cas_backoff(attempt)
+        raise StorageControlPlaneError(
+            f"[{self.workspace}] failure-generation reservation for "
+            f"{self.namespace} lost {_SCHEDULING_CAS_MAX_RETRIES} consecutive "
+            f"CAS races"
+        ) from last_conflict
+
     async def finalize(self):
         """Release the OpenSearch client connection."""
         if self.client is not None:
@@ -1455,6 +1895,41 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                 return None
             logger.error(f"[{self.workspace}] Error getting doc status {id}: {e}")
             return None
+
+    async def get_by_id_strict(self, id: str) -> Union[dict[str, Any], None]:
+        """Point read with complete-or-raise semantics (base contract).
+
+        Unlike ``get_by_id`` (best-effort: errors and a not-ready index read
+        as a miss), ``None`` here is only returned on a healthy mget miss —
+        ``_index_ready=False``, a live missing-index error and any transport
+        or item-level error RAISE because absence cannot be positively
+        confirmed in those states.
+        """
+        if not self._index_ready:
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] doc status index '{self._index_name}' is "
+                f"not ready; cannot confirm absence of '{id}' (strict point "
+                f"read)"
+            )
+        try:
+            response = await _mget_optional_doc(self.client, self._index_name, id)
+        except OpenSearchException as e:
+            if _is_missing_index_error(e):
+                self._mark_index_missing()
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] doc status index '{self._index_name}' "
+                    f"unexpectedly missing; cannot confirm absence of '{id}' "
+                    f"(strict point read)"
+                ) from e
+            logger.error(
+                f"[{self.workspace}] Error strictly getting doc status {id}: {e}"
+            )
+            raise
+        if response is None:
+            return None
+        doc = response["_source"]
+        doc["_id"] = response["_id"]
+        return doc
 
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
         """Get multiple document status records by IDs."""
@@ -1840,15 +2315,38 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
             logger.error(f"[{self.workspace}] Error getting doc by file_path: {e}")
             return None
 
+    @staticmethod
+    def _primary_basename_query(basename: str) -> dict[str, Any]:
+        """Exact basename match restricted to the PRIMARY row.
+
+        ``file_path`` is one-to-many (duplicate-attempt ``dup-*`` rows keep
+        the same canonical basename); ``metadata.is_duplicate == true`` rows
+        are excluded so identity checks / dedup always see the document,
+        never a duplicate marker. Legacy rows without the field are not
+        excluded (``must_not term`` matches nothing on a missing field).
+        """
+        return {
+            "query": {
+                "bool": {
+                    "filter": [{"term": {"file_path": basename}}],
+                    "must_not": [{"term": {"metadata.is_duplicate": True}}],
+                }
+            },
+            "size": 1,
+        }
+
     async def get_doc_by_file_basename(
         self, basename: str
     ) -> Union[tuple[str, dict[str, Any]], None]:
-        """Find an existing record whose canonical basename matches.
+        """Find the PRIMARY record whose canonical basename matches.
 
         The caller is responsible for passing an already-canonical basename;
         stored ``file_path`` values are canonicalized by the business layer, so
         this lookup performs an exact term query against the file_path keyword
-        field.
+        field, restricted to the primary (``metadata.is_duplicate != true``)
+        row. Legacy best-effort semantics: errors are swallowed and read as a
+        miss — dedup/identity callers that need fail-closed confirmation use
+        :meth:`get_doc_by_file_basename_strict`.
         """
         if not basename:
             return None
@@ -1857,7 +2355,7 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
         if not self._index_ready:
             return None
         try:
-            body = {"query": {"term": {"file_path": basename}}, "size": 1}
+            body = self._primary_basename_query(basename)
             response = await self.client.search(index=self._index_name, body=body)
             hits = response["hits"]["hits"]
             if not hits:
@@ -1871,6 +2369,51 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                 return None
             logger.error(f"[{self.workspace}] Error getting doc by file_basename: {e}")
             return None
+
+    async def get_doc_by_file_basename_strict(
+        self, basename: str
+    ) -> Union[tuple[str, dict[str, Any]], None]:
+        """Fail-closed basename lookup (see base contract).
+
+        Same primary-only query as :meth:`get_doc_by_file_basename`, but
+        ``None`` is only returned when absence was positively confirmed (a
+        healthy search with zero hits). ``_index_ready=False`` and a live
+        missing-index error raise ``StorageControlPlaneError`` — after
+        ``initialize()`` the index always exists, so it being missing means
+        we cannot distinguish a brand-new workspace from a lost index, and a
+        swallowed failure here would mint duplicate rows (scan/enqueue treat
+        ``None`` as "confirmed new"). Other transport errors propagate.
+        """
+        if not basename:
+            return None
+        if basename == "unknown_source":
+            return None
+        if not self._index_ready:
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] doc status index '{self._index_name}' is "
+                f"not ready; cannot confirm basename '{basename}' is absent "
+                f"(strict identity lookup)"
+            )
+        try:
+            body = self._primary_basename_query(basename)
+            response = await self.client.search(index=self._index_name, body=body)
+            hits = response["hits"]["hits"]
+        except OpenSearchException as e:
+            if _is_missing_index_error(e):
+                self._mark_index_missing()
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] doc status index '{self._index_name}' "
+                    f"unexpectedly missing; cannot confirm basename "
+                    f"'{basename}' is absent (strict identity lookup)"
+                ) from e
+            logger.error(
+                f"[{self.workspace}] Error strictly getting doc by file_basename: {e}"
+            )
+            raise
+        if not hits:
+            return None
+        hit = hits[0]
+        return hit["_id"], hit["_source"]
 
     async def get_doc_by_content_hash(
         self, content_hash: str
@@ -1901,6 +2444,423 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                 return None
             logger.error(f"[{self.workspace}] Error getting doc by content_hash: {e}")
             return None
+
+    # ------------------------------------------------------------------
+    # Memory-bounding scheduling API (Phase 1)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _decode_page_cursor(opaque: str) -> list[Any]:
+        """Decode an opaque page cursor back into ``search_after`` values.
+
+        The cursor is ``json.dumps(hits[-1]["sort"])`` — the last hit's sort
+        values verbatim, i.e. ``[created_at sort value, __mirrored_id]``.
+        Anything that does not decode to that two-element list is a corrupt
+        continuation token: raise a control-plane error instead of silently
+        restarting (or worse, mis-positioning) the sweep.
+        """
+        try:
+            decoded = json.loads(opaque)
+        except (TypeError, ValueError) as e:
+            raise StorageControlPlaneError(
+                f"Malformed scheduling cursor for OpenSearchDocStatusStorage: {e}"
+            ) from e
+        if not isinstance(decoded, list) or len(decoded) != 2:
+            raise StorageControlPlaneError(
+                "Malformed scheduling cursor for OpenSearchDocStatusStorage: "
+                f"expected a 2-element sort-values list, got {decoded!r}"
+            )
+        return decoded
+
+    @staticmethod
+    def _build_scheduling_page_query(
+        status_values: list[str], max_failure_generation: int | None
+    ) -> dict[str, Any]:
+        """Server-side page query: status terms + optional cohort predicate.
+
+        The generation predicate must pair ``range(lte)`` with a
+        ``must_not exists`` arm (explicit review ruling): legacy docs LACK
+        the ``failure_generation`` field and the ``long`` mapping alone does
+        NOT make missing read as 0 — without the exists arm every legacy
+        FAILED row would silently drop out of the first manual cohort.
+        Non-FAILED rows are unaffected (first ``should`` arm).
+        """
+        terms_clause = {"terms": {"status": sorted(status_values)}}
+        if max_failure_generation is None:
+            return terms_clause
+        generation_predicate = {
+            "bool": {
+                "should": [
+                    {
+                        "bool": {
+                            "must_not": {"term": {"status": DocStatus.FAILED.value}}
+                        }
+                    },
+                    {"range": {"failure_generation": {"lte": max_failure_generation}}},
+                    {"bool": {"must_not": {"exists": {"field": "failure_generation"}}}},
+                ],
+                "minimum_should_match": 1,
+            }
+        }
+        return {"bool": {"filter": [terms_clause, generation_predicate]}}
+
+    def _scheduling_record_from_hit(
+        self, hit: dict[str, Any], *, strict: bool
+    ) -> DocSchedulingRecord | None:
+        """Project one search hit; strict raises on unusable rows, relaxed
+        returns None (the row still counts as consumed — the cursor is the
+        last HIT's sort values, so skipped hits never re-appear)."""
+        doc_id = hit.get("_id")
+        source = hit.get("_source")
+        try:
+            if not isinstance(doc_id, str) or not isinstance(source, dict):
+                raise TypeError("malformed search hit")
+            status = DocStatus(str(source["status"]))
+            created_at = source["created_at"]
+            updated_at = source.get("updated_at", created_at)
+            if not isinstance(created_at, str) or not isinstance(updated_at, str):
+                raise TypeError("created_at/updated_at must be strings")
+            metadata = source.get("metadata")
+            return DocSchedulingRecord(
+                id=doc_id,
+                status=status,
+                created_at=created_at,
+                updated_at=updated_at,
+                file_path=source.get("file_path") or "no-file-path",
+                track_id=source.get("track_id"),
+                has_custom_chunk_journal=isinstance(metadata, dict)
+                and isinstance(metadata.get(CUSTOM_CHUNK_PATCH_METADATA_KEY), dict),
+            )
+        except (KeyError, TypeError, ValueError) as e:
+            logger.error(f"[{self.workspace}] Unusable scheduling row {doc_id}: {e}")
+            if strict:
+                raise
+            return None
+
+    async def get_docs_by_statuses_page(
+        self,
+        statuses: list[DocStatus],
+        *,
+        limit: int,
+        position: CursorPosition = CURSOR_START,
+        max_failure_generation: int | None = None,
+        strict: bool = False,
+    ) -> DocStatusPage:
+        """Bounded keyset page via native ``search_after`` (base contract).
+
+        Sort is ``(created_at ASC, __mirrored_id ASC)`` — ``_id`` is not
+        sortable in OpenSearch, so the id is tie-broken on the keyword field
+        every write path mirrors it into. Plain ``search_after`` (NO
+        point-in-time): the contract is live-view across requests, not a
+        snapshot. Filtering (status terms + generation predicate) is fully
+        server-side, so every hit is consumed by construction and
+        ``returned < limit`` proves exhaustion (CURSOR_END); a full page
+        continues with ``CursorAfter(json.dumps(hits[-1]["sort"]))`` — the
+        last hit's sort values are the natural consumed frontier (they cover
+        hits skipped as unusable in relaxed mode, too).
+
+        Strict/failure semantics: ``_index_ready=False`` raises under
+        ``strict`` (the index was dropped/lost — cannot confirm the sweep is
+        complete); a live missing-index error mirrors the existing
+        ``get_docs_by_statuses`` strict decision (legitimately empty →
+        empty terminal page); transport errors raise WITHOUT returning
+        partial docs or a new cursor; ``strict`` additionally turns
+        unusable-row skips into raises.
+        """
+        if limit <= 0:
+            raise ValueError(f"page limit must be positive, got {limit}")
+        if not statuses or position is CURSOR_END:
+            return DocStatusPage(docs={}, next_position=CURSOR_END)
+        if not self._index_ready:
+            if strict:
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] doc status index '{self._index_name}' "
+                    f"is not ready; cannot serve a complete scheduling page"
+                )
+            return DocStatusPage(docs={}, next_position=CURSOR_END)
+        search_after: list[Any] | None = None
+        if isinstance(position, CursorAfter):
+            search_after = self._decode_page_cursor(position.opaque)
+        body: dict[str, Any] = {
+            "query": self._build_scheduling_page_query(
+                [s.value for s in statuses], max_failure_generation
+            ),
+            "sort": [
+                {"created_at": {"order": "asc"}},
+                {"__mirrored_id": {"order": "asc"}},
+            ],
+            "size": limit,
+        }
+        if search_after is not None:
+            body["search_after"] = search_after
+        try:
+            response = await self.client.search(index=self._index_name, body=body)
+        except OpenSearchException as e:
+            if _is_missing_index_error(e):
+                self._mark_index_missing()
+                return DocStatusPage(docs={}, next_position=CURSOR_END)
+            # Complete-or-raise in BOTH modes: a partial page + advanced
+            # cursor would silently strand the missed documents.
+            logger.error(f"[{self.workspace}] Scheduling page query failed: {e}")
+            raise
+        hits = response["hits"]["hits"]
+        docs: dict[str, DocSchedulingRecord] = {}
+        for hit in hits:
+            record = self._scheduling_record_from_hit(hit, strict=strict)
+            if record is None:
+                continue  # relaxed skip is still consumed (see cursor note)
+            docs[record.id] = record
+        if len(hits) < limit:
+            return DocStatusPage(docs=docs, next_position=CURSOR_END)
+        return DocStatusPage(
+            docs=docs,
+            next_position=CursorAfter(json.dumps(hits[-1]["sort"])),
+        )
+
+    async def count_docs_by_statuses(
+        self, statuses: list[DocStatus], *, strict: bool = True
+    ) -> int:
+        """Fail-closed status count via the ``_count`` API (base contract).
+
+        Always accurate-or-raise regardless of ``strict`` — admission
+        control must never read an error as "capacity available".
+        ``_index_ready=False`` raises; a live missing-index error mirrors
+        the existing strict ``get_docs_by_statuses`` decision (legitimately
+        empty → 0).
+        """
+        if not statuses:
+            return 0
+        if not self._index_ready:
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] doc status index '{self._index_name}' is "
+                f"not ready; cannot produce an accurate status count"
+            )
+        body = {"query": {"terms": {"status": sorted({s.value for s in statuses})}}}
+        try:
+            response = await self.client.count(index=self._index_name, body=body)
+        except OpenSearchException as e:
+            if _is_missing_index_error(e):
+                self._mark_index_missing()
+                return 0
+            logger.error(f"[{self.workspace}] Error counting doc statuses: {e}")
+            raise
+        count = response.get("count")
+        if not isinstance(count, int):
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] OpenSearch _count returned a malformed "
+                f"response for {self.namespace}: {response!r}"
+            )
+        return count
+
+    async def update_doc_status_fields(
+        self,
+        doc_id: str,
+        fields: dict[str, Any],
+        *,
+        missing_ok: bool = False,
+    ) -> None:
+        """Targeted partial update via the ``_update`` doc-merge API.
+
+        No read-modify-write: untouched fields (including a huge
+        ``chunks_list``) never travel through memory. ``refresh="wait_for"``
+        matches the visibility of the bulk upsert path (search-based readers
+        may query immediately after). This class keeps no pending buffer for
+        doc-status writes, so the update is immediately authoritative.
+        """
+        if "created_at" in fields:
+            raise ValueError(
+                "created_at is an immutable scheduling sort key and cannot "
+                "be changed via update_doc_status_fields"
+            )
+        await self._ensure_index_ready()
+        try:
+            await self.client.update(
+                index=self._index_name,
+                id=doc_id,
+                body={"doc": fields},
+                refresh="wait_for",
+            )
+        except NotFoundError as e:
+            if _is_missing_index_error(e):
+                self._mark_index_missing()
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] doc status index '{self._index_name}' "
+                    f"unexpectedly missing while updating '{doc_id}'"
+                ) from e
+            if missing_ok:
+                return
+            raise StorageRecordNotFoundError(doc_id) from e
+        except OpenSearchException as e:
+            logger.error(
+                f"[{self.workspace}] Error updating doc status fields for {doc_id}: {e}"
+            )
+            raise
+
+    async def mark_doc_failed(self, doc_id: str, fields: dict[str, Any]) -> int | None:
+        """FAILED transition funnel: reserve → CAS publish (base contract).
+
+        Two-step by design on OpenSearch (independent ctrl index; the plan
+        accepts the reserve→publish window — cohort semantics account for
+        it):
+
+        1. Realtime GET of the row with ``seq_no``/``primary_term``.
+           Idempotency first: already-FAILED with ``failure_attempt_id`` ==
+           the current attempt returns the existing generation WITHOUT
+           touching the counter.
+        2. Reserve a generation (a publish failure leaves a permanent hole).
+        3. Publish the FAILED doc guarded by ``if_seq_no/if_primary_term``;
+           on 409 re-GET, re-check idempotency, retry (bounded). A missing
+           row is created with ``op_type=create`` so a concurrent create is
+           never clobbered (its 409 loops back into the existing-row path).
+
+        ``created_at`` of an existing row always wins over the caller's —
+        the scheduling sort key is immutable.
+        """
+        await self._ensure_index_ready()
+        for attempt in range(_SCHEDULING_CAS_MAX_RETRIES):
+            try:
+                row_resp = await self.client.get(index=self._index_name, id=doc_id)
+            except NotFoundError as e:
+                if _is_missing_index_error(e):
+                    self._mark_index_missing()
+                    await self._ensure_index_ready()
+                row_resp = None
+            existing = row_resp.get("_source") if isinstance(row_resp, dict) else None
+
+            if isinstance(existing, dict):
+                current_attempt = existing.get("processing_attempt_id") or fields.get(
+                    "processing_attempt_id"
+                )
+                if (
+                    str(existing.get("status")) == DocStatus.FAILED.value
+                    and current_attempt
+                    and existing.get("failure_attempt_id") == current_attempt
+                ):
+                    # Same attempt already published its failure: idempotent,
+                    # no counter reservation.
+                    try:
+                        return int(existing.get("failure_generation") or 0)
+                    except (TypeError, ValueError):
+                        return 0
+                generation = await self.reserve_failure_generation()
+                row = {**existing, **fields}
+                if "created_at" in existing:
+                    row["created_at"] = existing["created_at"]
+                row["status"] = DocStatus.FAILED.value
+                row["failure_generation"] = generation
+                if current_attempt:
+                    row["failure_attempt_id"] = current_attempt
+                    row.setdefault("processing_attempt_id", current_attempt)
+                row.setdefault("chunks_list", [])
+                row.pop("_id", None)
+                row["__mirrored_id"] = doc_id
+                try:
+                    await self.client.index(
+                        index=self._index_name,
+                        id=doc_id,
+                        body=row,
+                        if_seq_no=row_resp["_seq_no"],
+                        if_primary_term=row_resp["_primary_term"],
+                        refresh="wait_for",
+                    )
+                    return generation
+                except ConflictError:
+                    logger.warning(
+                        f"[{self.workspace}] mark_doc_failed CAS conflict for "
+                        f"{doc_id} (generation {generation} becomes a hole); "
+                        f"retrying"
+                    )
+                    await _scheduling_cas_backoff(attempt)
+                    continue
+
+            # Missing row: parse/enqueue errors can fail before the PENDING
+            # row landed — conditionally create the FAILED record.
+            current_attempt = fields.get("processing_attempt_id")
+            generation = await self.reserve_failure_generation()
+            row = {k: v for k, v in fields.items() if k != "_id"}
+            row["status"] = DocStatus.FAILED.value
+            row["failure_generation"] = generation
+            if current_attempt:
+                row["failure_attempt_id"] = current_attempt
+            row.setdefault("chunks_list", [])
+            row["__mirrored_id"] = doc_id
+            try:
+                await self.client.index(
+                    index=self._index_name,
+                    id=doc_id,
+                    body=row,
+                    op_type="create",
+                    refresh="wait_for",
+                )
+                return generation
+            except ConflictError:
+                # A concurrent writer created the row first: loop back into
+                # the existing-row path (this generation becomes a hole).
+                logger.warning(
+                    f"[{self.workspace}] mark_doc_failed create conflict for "
+                    f"{doc_id} (generation {generation} becomes a hole); "
+                    f"retrying against the concurrent row"
+                )
+                await _scheduling_cas_backoff(attempt)
+        raise StorageControlPlaneError(
+            f"[{self.workspace}] mark_doc_failed for {doc_id} lost "
+            f"{_SCHEDULING_CAS_MAX_RETRIES} consecutive CAS races"
+        )
+
+    async def ensure_processing_attempt_id(self, doc_id: str) -> str:
+        """Mint-or-reuse the row's attempt id with a CAS update (base contract).
+
+        Realtime GET; an existing id is returned as-is (idempotent — a lost
+        response retried reuses the persisted id). Minting uses the
+        ``_update`` API guarded by ``if_seq_no/if_primary_term``; a 409 means
+        a concurrent writer touched the row — re-GET (usually finding the
+        winner's id) and retry bounded.
+        """
+        if not self._index_ready:
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] doc status index '{self._index_name}' is "
+                f"not ready; cannot ensure processing_attempt_id for "
+                f"'{doc_id}'"
+            )
+        last_conflict: Exception | None = None
+        for attempt in range(_SCHEDULING_CAS_MAX_RETRIES):
+            try:
+                row_resp = await self.client.get(index=self._index_name, id=doc_id)
+            except NotFoundError as e:
+                if _is_missing_index_error(e):
+                    self._mark_index_missing()
+                    raise StorageControlPlaneError(
+                        f"[{self.workspace}] doc status index "
+                        f"'{self._index_name}' unexpectedly missing while "
+                        f"ensuring processing_attempt_id for '{doc_id}'"
+                    ) from e
+                raise StorageRecordNotFoundError(doc_id) from e
+            source = row_resp.get("_source")
+            attempt_id = (
+                source.get("processing_attempt_id")
+                if isinstance(source, dict)
+                else None
+            )
+            if attempt_id:
+                return str(attempt_id)
+            minted = uuid.uuid4().hex
+            try:
+                await self.client.update(
+                    index=self._index_name,
+                    id=doc_id,
+                    body={"doc": {"processing_attempt_id": minted}},
+                    if_seq_no=row_resp["_seq_no"],
+                    if_primary_term=row_resp["_primary_term"],
+                    refresh="wait_for",
+                )
+                return minted
+            except ConflictError as e:
+                last_conflict = e
+                await _scheduling_cas_backoff(attempt)
+        raise StorageControlPlaneError(
+            f"[{self.workspace}] ensure_processing_attempt_id for {doc_id} "
+            f"lost {_SCHEDULING_CAS_MAX_RETRIES} consecutive CAS races"
+        ) from last_conflict
 
     async def index_done_callback(self) -> None:
         """Refresh index to make recently indexed documents searchable."""

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -4,10 +4,11 @@ import hashlib
 import json
 import os
 import re
+import uuid
 import datetime
 from datetime import timezone
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Callable, TypeVar, Union, final
+from typing import Any, Awaitable, Callable, ClassVar, TypeVar, Union, final
 import numpy as np
 import configparser
 import ssl
@@ -27,15 +28,26 @@ from tenacity import (
 )
 
 from ..base import (
+    CURSOR_END,
+    CURSOR_START,
     BaseGraphStorage,
     BaseKVStorage,
     BaseVectorStorage,
+    CursorAfter,
+    CursorPosition,
     DocProcessingStatus,
+    DocSchedulingRecord,
     DocStatus,
+    DocStatusPage,
     DocStatusStorage,
+    FailureGenerationMode,
 )
-from ..constants import DEFAULT_QUERY_PRIORITY
-from ..exceptions import DataMigrationError
+from ..constants import CUSTOM_CHUNK_PATCH_METADATA_KEY, DEFAULT_QUERY_PRIORITY
+from ..exceptions import (
+    DataMigrationError,
+    StorageControlPlaneError,
+    StorageRecordNotFoundError,
+)
 from ..namespace import NameSpace, is_namespace
 from ..utils import (
     logger,
@@ -1566,6 +1578,129 @@ class PostgreSQLDB:
                 f"Failed to create partial content_hash index on LIGHTRAG_DOC_STATUS: {e}"
             )
 
+    async def _migrate_doc_status_add_scheduling_fields(self):
+        """Add memory-bounding scheduling columns to LIGHTRAG_DOC_STATUS (Phase 1).
+
+        * ``failure_generation`` — monotonic failure cohort stamped by
+          ``mark_doc_failed``. BIGINT NOT NULL DEFAULT 0 so legacy/never-failed
+          rows read as logical generation 0 (query predicates treat missing as
+          0; all history belongs to the first manual cutoff).
+        * ``processing_attempt_id`` / ``failure_attempt_id`` — attempt identity
+          used by the idempotent FAILED CAS funnel.
+
+        Also creates the keyset-sweep index (workspace, status, created_at, id)
+        backing ``get_docs_by_statuses_page`` and a (workspace,
+        failure_generation) index for counter recalibration (MAX scan at
+        bootstrap) and the FAILED cohort predicate. Each step is guarded
+        individually and idempotent — retried on every startup until present.
+        """
+        columns_to_add = [
+            ("failure_generation", "BIGINT NOT NULL DEFAULT 0"),
+            ("processing_attempt_id", "TEXT NULL"),
+            ("failure_attempt_id", "TEXT NULL"),
+        ]
+        try:
+            existing = await self.query(
+                """
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_name = 'lightrag_doc_status'
+                  AND column_name = ANY($1)
+                """,
+                [[c for c, _ in columns_to_add]],
+                multirows=True,
+            )
+            existing_names = {row["column_name"] for row in (existing or [])}
+        except Exception as e:
+            logger.warning(
+                f"Failed to inspect LIGHTRAG_DOC_STATUS columns for scheduling migration: {e}"
+            )
+            existing_names = set()
+
+        for col_name, col_type in columns_to_add:
+            if col_name in existing_names:
+                logger.debug(f"Column {col_name} already exists in LIGHTRAG_DOC_STATUS")
+                continue
+            try:
+                logger.info(f"Adding {col_name} column to LIGHTRAG_DOC_STATUS table")
+                await self.execute(
+                    f"ALTER TABLE LIGHTRAG_DOC_STATUS ADD COLUMN {col_name} {col_type}"
+                )
+                logger.info(
+                    f"Successfully added {col_name} column to LIGHTRAG_DOC_STATUS table"
+                )
+            except Exception as e:
+                logger.error(
+                    f"Failed to add column {col_name} to LIGHTRAG_DOC_STATUS: {e}"
+                )
+
+        # Keyset sweep index: (workspace, status, created_at, id) matches the
+        # page query's WHERE workspace/status equality prefix and its
+        # ORDER BY created_at ASC, id ASC keyset tail, so a page read is an
+        # index scan resuming at the row-value comparison — never a full-table
+        # sort. The (workspace, failure_generation) index serves the
+        # MAX(failure_generation) bootstrap calibration (failure_generation is
+        # never reset on retry, so the scan must cover all statuses).
+        indexes = [
+            (
+                "idx_lightrag_doc_status_ws_status_created_id",
+                "CREATE INDEX IF NOT EXISTS idx_lightrag_doc_status_ws_status_created_id "
+                "ON LIGHTRAG_DOC_STATUS (workspace, status, created_at, id)",
+            ),
+            (
+                "idx_lightrag_doc_status_ws_failure_generation",
+                "CREATE INDEX IF NOT EXISTS idx_lightrag_doc_status_ws_failure_generation "
+                "ON LIGHTRAG_DOC_STATUS (workspace, failure_generation)",
+            ),
+        ]
+        for index_name, create_sql in indexes:
+            try:
+                check_index_sql = """
+                SELECT indexname FROM pg_indexes
+                WHERE tablename = 'lightrag_doc_status'
+                  AND indexname = $1
+                """
+                index_info = await self.query(check_index_sql, [index_name])
+                if not index_info:
+                    logger.info(f"Creating index {index_name} on LIGHTRAG_DOC_STATUS")
+                    await self.execute(create_sql)
+            except Exception as e:
+                logger.error(
+                    f"Failed to create index {index_name} on LIGHTRAG_DOC_STATUS: {e}"
+                )
+
+    async def _migrate_create_doc_scheduling_ctrl_table(self):
+        """Create LIGHTRAG_DOC_SCHEDULING_CTRL if it doesn't exist.
+
+        One row per workspace: the failure-generation reservation counter, the
+        activation-mode marker and its schema version (see
+        PGDocStatusStorage._bootstrap_scheduling_ctrl). Deliberately NOT in the
+        TABLES dict: check_tables' generic index loop creates an ``(id)`` index
+        on every TABLES entry and this table has no ``id`` column — its key IS
+        the workspace. The row intentionally survives a workspace data drop so
+        the reservation counter never moves backwards (holes are allowed,
+        reuse is not).
+        """
+        try:
+            if await self.check_table_exists("LIGHTRAG_DOC_SCHEDULING_CTRL"):
+                logger.debug("Table LIGHTRAG_DOC_SCHEDULING_CTRL already exists")
+                return
+            logger.info("Creating table LIGHTRAG_DOC_SCHEDULING_CTRL")
+            await self.execute(
+                """CREATE TABLE LIGHTRAG_DOC_SCHEDULING_CTRL (
+                    workspace VARCHAR(255) NOT NULL,
+                    schema_version INT NOT NULL,
+                    mode VARCHAR(32) NOT NULL,
+                    failure_generation_counter BIGINT NOT NULL DEFAULT 0,
+                    update_time TIMESTAMP(0) DEFAULT CURRENT_TIMESTAMP,
+                    CONSTRAINT LIGHTRAG_DOC_SCHEDULING_CTRL_PK PRIMARY KEY (workspace)
+                    )""",
+                ignore_if_exists=True,
+            )
+            logger.info("Successfully created table LIGHTRAG_DOC_SCHEDULING_CTRL")
+        except Exception as e:
+            logger.error(f"Failed to create table LIGHTRAG_DOC_SCHEDULING_CTRL: {e}")
+
     async def _migrate_text_chunks_add_heading_sidecar(self):
         """Add heading and sidecar JSONB columns to LIGHTRAG_DOC_CHUNKS if missing."""
         columns_to_add = [
@@ -1943,6 +2078,25 @@ class PostgreSQLDB:
         except Exception as e:
             logger.error(
                 f"PostgreSQL, Failed to migrate LIGHTRAG_DOC_CHUNKS heading/sidecar fields: {e}"
+            )
+
+        # Migrate LIGHTRAG_DOC_STATUS to add memory-bounding scheduling columns
+        # (failure_generation / processing_attempt_id / failure_attempt_id) and
+        # the keyset-sweep indexes (Phase 1)
+        try:
+            await self._migrate_doc_status_add_scheduling_fields()
+        except Exception as e:
+            logger.error(
+                f"PostgreSQL, Failed to migrate LIGHTRAG_DOC_STATUS scheduling fields: {e}"
+            )
+
+        # Create the per-workspace scheduling control-plane table (failure
+        # generation counter + mode marker)
+        try:
+            await self._migrate_create_doc_scheduling_ctrl_table()
+        except Exception as e:
+            logger.error(
+                f"PostgreSQL, Failed to create LIGHTRAG_DOC_SCHEDULING_CTRL table: {e}"
             )
 
     async def _migrate_create_full_entities_relations_tables(self):
@@ -2544,6 +2698,8 @@ class ClientManager:
 class PGKVStorage(BaseKVStorage):
     db: PostgreSQLDB = field(default=None)
 
+    supports_strict_point_reads: ClassVar[bool] = True
+
     def __post_init__(self):
         validate_workspace(self.workspace)
         self._max_batch_size = 200  # DB batch size, independent of embedding batch size
@@ -2723,6 +2879,16 @@ class PGKVStorage(BaseKVStorage):
             response["update_time"] = create_time if update_time == 0 else update_time
 
         return response if response else None
+
+    async def get_by_id_strict(self, id: str) -> dict[str, Any] | None:
+        """Strict point read: complete-or-raise (base contract).
+
+        ``db.query`` propagates every asyncpg transport/server error (nothing
+        in this class swallows it), so a ``None`` from the legacy read is a
+        positively confirmed absence — safe for callers that take destructive
+        action on a miss.
+        """
+        return await self.get_by_id(id)
 
     # Query by id
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
@@ -4823,10 +4989,50 @@ def _parse_doc_status_datetime(
         return None
 
 
+# Columns that the targeted-update paths (update_doc_status_fields /
+# mark_doc_failed) may write. Column names are interpolated into SQL, so they
+# MUST come from this whitelist — unknown keys raise instead of being quoted.
+# created_at is deliberately absent: it is the immutable keyset sort key
+# (update_doc_status_fields refuses it; mark_doc_failed ignores it for
+# existing rows and only writes it on conditional row creation).
+_DOC_STATUS_UPDATABLE_COLUMNS = frozenset(
+    {
+        "content_summary",
+        "content_length",
+        "chunks_count",
+        "status",
+        "file_path",
+        "chunks_list",
+        "track_id",
+        "metadata",
+        "error_msg",
+        "content_hash",
+        "updated_at",
+        "failure_generation",
+        "processing_attempt_id",
+        "failure_attempt_id",
+    }
+)
+# JSONB columns serialized exactly like the batch upsert does (json.dumps).
+_DOC_STATUS_JSON_COLUMNS = frozenset({"chunks_list", "metadata"})
+# TIMESTAMP columns converted via _parse_doc_status_datetime like the upsert.
+_DOC_STATUS_DATETIME_COLUMNS = frozenset({"updated_at", "created_at"})
+
+
 @final
 @dataclass
 class PGDocStatusStorage(DocStatusStorage):
     db: PostgreSQLDB = field(default=None)
+
+    supports_bounded_scheduling_pages: ClassVar[bool] = True
+    supports_failure_generation: ClassVar[bool] = True
+    supports_strict_doc_identity_lookup: ClassVar[bool] = True
+    supports_strict_point_reads: ClassVar[bool] = True
+
+    # Version stamp of the LIGHTRAG_DOC_SCHEDULING_CTRL row layout. A row with
+    # a different schema_version reads as MIGRATING (never LEGACY) until an
+    # explicit migration handles it — see get_failure_generation_mode.
+    _CTRL_SCHEMA_VERSION: ClassVar[int] = 1
 
     def __post_init__(self):
         validate_workspace(self.workspace)
@@ -4869,6 +5075,72 @@ class PGDocStatusStorage(DocStatusStorage):
 
             # NOTE: Table creation is handled by PostgreSQLDB.initdb() during initialization
             # No need to create table here as it's already created in the TABLES dict
+
+            # Scheduling control-plane bootstrap (Phase 1). Errors propagate:
+            # the storage must not serve pipeline traffic behind a broken or
+            # unverifiable failure-generation marker (startup fence).
+            await self._bootstrap_scheduling_ctrl()
+
+    async def _bootstrap_scheduling_ctrl(self) -> None:
+        """Per-workspace failure-generation marker bootstrap + counter
+        recalibration (mirrors JsonDocStatusStorage.initialize).
+
+        Runs on EVERY initialize: a restore-from-backup can roll the ctrl row
+        behind persisted doc rows, and the reservation counter must stay
+        monotonic — ``max(counter, max persisted failure_generation)``.
+        Concurrent workers bootstrapping the same workspace are safe:
+        INSERT ... ON CONFLICT DO NOTHING for the first publish, GREATEST()
+        for recalibration. An unknown schema_version row is left untouched:
+        mode reads report MIGRATING (never LEGACY) until an explicit
+        migration handles it.
+        """
+        max_row = await self.db.query(
+            "SELECT COALESCE(MAX(failure_generation), 0) AS max_gen "
+            "FROM LIGHTRAG_DOC_STATUS WHERE workspace=$1",
+            [self.workspace],
+        )
+        max_gen = int(max_row["max_gen"]) if max_row else 0
+
+        ctrl = await self.db.query(
+            "SELECT schema_version, failure_generation_counter "
+            "FROM LIGHTRAG_DOC_SCHEDULING_CTRL WHERE workspace=$1",
+            [self.workspace],
+        )
+        if ctrl is None:
+            await self.db.execute(
+                """INSERT INTO LIGHTRAG_DOC_SCHEDULING_CTRL
+                       (workspace, schema_version, mode, failure_generation_counter)
+                   VALUES ($1, $2, $3, $4)
+                   ON CONFLICT (workspace) DO NOTHING""",
+                {
+                    "workspace": self.workspace,
+                    "schema_version": self._CTRL_SCHEMA_VERSION,
+                    "mode": FailureGenerationMode.ENFORCED.value,
+                    "failure_generation_counter": max_gen,
+                },
+            )
+            logger.info(
+                f"[{self.workspace}] Published failure-generation marker "
+                f"(mode=enforced, counter={max_gen}) for {self.namespace}"
+            )
+        elif ctrl.get("schema_version") == self._CTRL_SCHEMA_VERSION:
+            counter = int(ctrl.get("failure_generation_counter") or 0)
+            if counter < max_gen:
+                await self.db.execute(
+                    """UPDATE LIGHTRAG_DOC_SCHEDULING_CTRL
+                       SET failure_generation_counter =
+                           GREATEST(failure_generation_counter, $3)
+                       WHERE workspace=$1 AND schema_version=$2""",
+                    {
+                        "workspace": self.workspace,
+                        "schema_version": self._CTRL_SCHEMA_VERSION,
+                        "max_gen": max_gen,
+                    },
+                )
+                logger.warning(
+                    f"[{self.workspace}] failure-generation counter behind "
+                    f"persisted rows ({counter} < {max_gen}); recalibrated"
+                )
 
     async def finalize(self):
         if self.db is not None:
@@ -5058,6 +5330,13 @@ class PGDocStatusStorage(DocStatusStorage):
         the canonical ``file_path`` column. The caller is responsible for
         passing an already-canonical basename; storage performs an exact match
         only.
+
+        ``file_path`` is one-to-many (duplicate-attempt ``dup-*`` rows keep the
+        same canonical basename); this returns the single PRIMARY
+        (``metadata.is_duplicate != true``) row — callers doing identity checks
+        / dedup want the document, never a duplicate marker. When only
+        duplicate markers remain (primary deleted) the basename is free again
+        and this returns ``None``.
         """
         if not basename:
             return None
@@ -5065,9 +5344,15 @@ class PGDocStatusStorage(DocStatusStorage):
         if basename == "unknown_source":
             return None
 
+        # COALESCE((metadata->>'is_duplicate')::boolean, false) excludes
+        # duplicate-marker rows; NULL/absent metadata keys coalesce to false
+        # (primary). metadata is JSONB, so ->> yields 'true'/'false' text that
+        # casts cleanly; a non-boolean value raises and propagates (fail
+        # closed) rather than silently matching.
         sql = (
             "SELECT * FROM LIGHTRAG_DOC_STATUS "
             "WHERE workspace=$1 AND file_path = $2 "
+            "AND COALESCE((metadata->>'is_duplicate')::boolean, false) = false "
             "ORDER BY created_at ASC, id ASC LIMIT 1"
         )
         params = [self.workspace, basename]
@@ -5164,6 +5449,494 @@ class PGDocStatusStorage(DocStatusStorage):
             content_hash=row.get("content_hash"),
         )
         return str(row["id"]), doc
+
+    async def get_doc_by_file_basename_strict(
+        self, basename: str
+    ) -> tuple[str, dict[str, Any]] | None:
+        """Fail-closed basename lookup (see base contract).
+
+        The aligned legacy query already satisfies the strict contract: every
+        asyncpg transport/server error propagates out of ``db.query`` (nothing
+        in this class swallows it), so ``None`` here IS a positively confirmed
+        absence of a PRIMARY (non-duplicate) row.
+        """
+        return await self.get_doc_by_file_basename(basename)
+
+    async def get_by_id_strict(self, id: str) -> Union[dict[str, Any], None]:
+        """Strict point read: complete-or-raise (base contract).
+
+        ``db.query`` propagates every transport/server error, so a ``None``
+        from the aligned legacy read is a confirmed absence.
+        """
+        return await self.get_by_id(id)
+
+    # ------------------------------------------------------------------
+    # Memory-bounding scheduling API (Phase 1)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _decode_cursor(opaque: str) -> tuple[datetime.datetime, str]:
+        """Decode an opaque page cursor into (created_at, id).
+
+        The opaque form is ``json.dumps([created_at_iso, id])`` produced by
+        ``_encode_cursor``. The ISO string round-trips exactly through
+        ``datetime.fromisoformat`` (microseconds preserved) and is normalized
+        back to the naive-UTC form the TIMESTAMP column stores, so the
+        parameterized row-value comparison resumes at exactly the last
+        consumed key. A malformed cursor raises
+        :class:`~lightrag.exceptions.StorageControlPlaneError`.
+        """
+        try:
+            decoded = json.loads(opaque)
+            created_iso, doc_id = decoded
+            if not isinstance(created_iso, str) or not isinstance(doc_id, str):
+                raise ValueError("cursor fields must be strings")
+            created = datetime.datetime.fromisoformat(created_iso)
+        except (ValueError, TypeError) as e:
+            raise StorageControlPlaneError(
+                f"Malformed scheduling cursor for PGDocStatusStorage: {e}"
+            ) from e
+        if created.tzinfo is not None:
+            created = created.astimezone(timezone.utc).replace(tzinfo=None)
+        return created, doc_id
+
+    def _encode_cursor(self, row: dict[str, Any]) -> str:
+        """Encode the keyset key of a returned DB row as an opaque cursor."""
+        created = row.get("created_at")
+        if not isinstance(created, datetime.datetime):
+            # Only reachable when an entire page consists of rows whose
+            # created_at is NULL (corrupt writes — the column defaults to
+            # CURRENT_TIMESTAMP). Such rows have no stable sort key, so a
+            # cursor cannot be built over them: fail closed instead of
+            # skipping or re-reading in place.
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] scheduling row {row.get('id')!r} has no "
+                "usable created_at sort key; cannot advance the page cursor"
+            )
+        return json.dumps(
+            [self._format_datetime_with_timezone(created), str(row["id"])]
+        )
+
+    def _pg_scheduling_record_from_row(
+        self, row: dict[str, Any], *, strict: bool
+    ) -> DocSchedulingRecord | None:
+        """Project one DB row; strict raises on unusable rows, relaxed returns
+        None (the row was still returned by the scan and stays consumed)."""
+        doc_id = str(row.get("id") or "")
+        try:
+            if not doc_id:
+                raise KeyError("id")
+            status = DocStatus(str(row["status"]))
+            created_raw = row["created_at"]
+            if not isinstance(created_raw, datetime.datetime):
+                raise TypeError("created_at must be a timestamp")
+            updated_raw = row.get("updated_at") or created_raw
+            if not isinstance(updated_raw, datetime.datetime):
+                raise TypeError("updated_at must be a timestamp")
+            metadata = row.get("metadata")
+            if isinstance(metadata, str):
+                try:
+                    metadata = json.loads(metadata)
+                except json.JSONDecodeError:
+                    metadata = {}
+            if not isinstance(metadata, dict):
+                metadata = {}
+            return DocSchedulingRecord(
+                id=doc_id,
+                status=status,
+                created_at=self._format_datetime_with_timezone(created_raw),
+                updated_at=self._format_datetime_with_timezone(updated_raw),
+                file_path=row.get("file_path") or "no-file-path",
+                track_id=row.get("track_id"),
+                has_custom_chunk_journal=isinstance(
+                    metadata.get(CUSTOM_CHUNK_PATCH_METADATA_KEY), dict
+                ),
+            )
+        except (KeyError, TypeError, ValueError) as e:
+            logger.error(
+                f"[{self.workspace}] Unusable scheduling row "
+                f"{doc_id or '<unknown>'}: {e}"
+            )
+            if strict:
+                raise
+            return None
+
+    async def get_docs_by_statuses_page(
+        self,
+        statuses: list[DocStatus],
+        *,
+        limit: int,
+        position: CursorPosition = CURSOR_START,
+        max_failure_generation: int | None = None,
+        strict: bool = False,
+    ) -> DocStatusPage:
+        """Bounded keyset page over LIGHTRAG_DOC_STATUS.
+
+        A single combined keyset across all requested statuses is correct on
+        PG: ``ORDER BY created_at ASC, id ASC`` plus the composite row-value
+        comparison ``(created_at, id) > ($cur, $id)`` yields the global
+        (created_at, id) order natively — no k-way merge needed. The
+        ``idx_lightrag_doc_status_ws_status_created_id`` (workspace, status,
+        created_at, id) index backs the scan: for a single status it is a pure
+        index range scan resuming at the row-value comparison; for multiple
+        statuses the planner combines per-status index ranges under the LIMIT
+        (top-N bounded — page memory stays O(limit), never a full-table
+        materialization).
+
+        Consumed-position contract (SQL-side filtering makes it trivial):
+        every predicate — workspace, status membership AND the
+        ``max_failure_generation`` cohort predicate — is part of the DB scan
+        itself, so the database skips non-matching rows and keeps scanning
+        until LIMIT rows are collected or the keyset range ends. The rows
+        returned by the query therefore ARE the consumed frontier:
+
+        * ``next_position`` = key of the LAST RETURNED row, and
+        * ``returned < limit`` proves the (unfiltered) keyset range is
+          exhausted — the scan only stops early when the range ends, so a
+          short page can never hide rows that were merely filtered out
+          (unlike client-side filtering, where a fully-filtered page must
+          still advance without terminating).
+
+        ``max_failure_generation`` filters only FAILED rows:
+        ``status != 'failed' OR COALESCE(failure_generation, 0) <= cutoff``
+        (missing/legacy == logical 0). ``strict=True``: any DB error or
+        row-conversion failure raises without returning partial docs or a
+        cursor (single round-trip — there is no partial-page surface). In
+        relaxed mode an unusable row is skipped from the projection but stays
+        consumed (it was returned by the scan). Rows with a NULL created_at
+        (corrupt writes) sort last (NULLS LAST), raise under strict, and are
+        skipped under relaxed; a full page of them fails closed in
+        ``_encode_cursor``.
+        """
+        if limit <= 0:
+            raise ValueError(f"page limit must be positive, got {limit}")
+        if not statuses or position is CURSOR_END:
+            return DocStatusPage(docs={}, next_position=CURSOR_END)
+
+        params: list[Any] = [self.workspace, [s.value for s in statuses]]
+        sql = (
+            "SELECT id, status, created_at, updated_at, file_path, track_id, "
+            "metadata, failure_generation "
+            "FROM LIGHTRAG_DOC_STATUS WHERE workspace=$1 AND status = ANY($2)"
+        )
+        if isinstance(position, CursorAfter):
+            cur_created, cur_id = self._decode_cursor(position.opaque)
+            params.append(cur_created)
+            params.append(cur_id)
+            sql += (
+                f" AND (created_at, id) > (${len(params) - 1}::timestamp, "
+                f"${len(params)})"
+            )
+        if max_failure_generation is not None:
+            params.append(DocStatus.FAILED.value)
+            sql += f" AND (status != ${len(params)}"
+            params.append(int(max_failure_generation))
+            sql += f" OR COALESCE(failure_generation, 0) <= ${len(params)})"
+        params.append(limit)
+        sql += f" ORDER BY created_at ASC, id ASC LIMIT ${len(params)}"
+
+        # Any asyncpg error propagates out of db.query — strict pages never
+        # commit a new cursor on failure.
+        rows = await self.db.query(sql, params, multirows=True) or []
+
+        docs: dict[str, DocSchedulingRecord] = {}
+        for row in rows:
+            record = self._pg_scheduling_record_from_row(row, strict=strict)
+            if record is None:
+                continue  # relaxed skip is still consumed (see docstring)
+            docs[record.id] = record
+
+        if len(rows) < limit:
+            next_position: CursorPosition = CURSOR_END
+        else:
+            next_position = CursorAfter(self._encode_cursor(rows[-1]))
+        return DocStatusPage(docs=docs, next_position=next_position)
+
+    async def count_docs_by_statuses(
+        self, statuses: list[DocStatus], *, strict: bool = True
+    ) -> int:
+        """Fail-closed status count: an accurate number or an exception.
+
+        Unlike ``get_status_counts`` implementations that swallow errors,
+        every DB failure propagates — admission control treats an error as
+        "refuse", never as "capacity available".
+        """
+        if not statuses:
+            return 0
+        sql = (
+            'SELECT COUNT(*) AS "count" FROM LIGHTRAG_DOC_STATUS '
+            "WHERE workspace=$1 AND status = ANY($2)"
+        )
+        row = await self.db.query(sql, [self.workspace, [s.value for s in statuses]])
+        if row is None or row.get("count") is None:
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] COUNT query returned no row for "
+                "count_docs_by_statuses; refusing to report a count"
+            )
+        return int(row["count"])
+
+    def _prepare_doc_status_field_value(self, column: str, value: Any) -> Any:
+        """Serialize one field for a targeted UPDATE/INSERT, matching the
+        batch upsert's handling of JSONB and TIMESTAMP columns."""
+        if column in _DOC_STATUS_JSON_COLUMNS:
+            return value if isinstance(value, str) else json.dumps(value)
+        if column in _DOC_STATUS_DATETIME_COLUMNS:
+            return _parse_doc_status_datetime(
+                value, f"[{self.workspace}] doc status {column}"
+            )
+        return value
+
+    async def update_doc_status_fields(
+        self,
+        doc_id: str,
+        fields: dict[str, Any],
+        *,
+        missing_ok: bool = False,
+    ) -> None:
+        """Targeted single-row UPDATE of the given fields only.
+
+        ``created_at`` is refused (immutable keyset sort key); unknown field
+        names are refused too — column names are interpolated into SQL and
+        must come from the whitelist. 0 rows updated raises
+        :class:`~lightrag.exceptions.StorageRecordNotFoundError` unless
+        ``missing_ok=True``.
+        """
+        if "created_at" in fields:
+            raise ValueError(
+                "created_at is an immutable scheduling sort key and cannot "
+                "be changed via update_doc_status_fields"
+            )
+        unknown = set(fields) - _DOC_STATUS_UPDATABLE_COLUMNS
+        if unknown:
+            raise ValueError(
+                f"update_doc_status_fields received unknown doc_status "
+                f"column(s): {sorted(unknown)}"
+            )
+        if not fields:
+            # Nothing to write; still honour the existence contract.
+            row = await self.db.query(
+                "SELECT id FROM LIGHTRAG_DOC_STATUS WHERE workspace=$1 AND id=$2",
+                [self.workspace, doc_id],
+            )
+            if row is None and not missing_ok:
+                raise StorageRecordNotFoundError(doc_id)
+            return
+
+        params: list[Any] = [self.workspace, doc_id]
+        set_clauses: list[str] = []
+        for column, value in fields.items():
+            params.append(self._prepare_doc_status_field_value(column, value))
+            set_clauses.append(f"{column} = ${len(params)}")
+        sql = (
+            "UPDATE LIGHTRAG_DOC_STATUS SET "
+            + ", ".join(set_clauses)
+            + " WHERE workspace=$1 AND id=$2 RETURNING id"
+        )
+        row = await self.db.query(sql, params)
+        if row is None:
+            if missing_ok:
+                return
+            raise StorageRecordNotFoundError(doc_id)
+
+    async def get_failure_generation_mode(self) -> FailureGenerationMode:
+        """Read the per-workspace activation marker (fail-closed).
+
+        A DB error propagates (never degrades to LEGACY — that would reopen
+        the full-snapshot manual path). A missing row after init, an unknown
+        schema_version or an unparsable mode value all read as MIGRATING.
+        """
+        row = await self.db.query(
+            "SELECT schema_version, mode FROM LIGHTRAG_DOC_SCHEDULING_CTRL "
+            "WHERE workspace=$1",
+            [self.workspace],
+        )
+        if not row:
+            return FailureGenerationMode.MIGRATING
+        if row.get("schema_version") != self._CTRL_SCHEMA_VERSION:
+            return FailureGenerationMode.MIGRATING
+        try:
+            return FailureGenerationMode(str(row.get("mode")))
+        except ValueError:
+            return FailureGenerationMode.MIGRATING
+
+    async def reserve_failure_generation(self) -> int:
+        """Atomically reserve the next failure generation.
+
+        Counter row ``UPDATE ... RETURNING`` — deliberately NOT a sequence:
+        ``nextval`` does not participate in transaction rollback and can be
+        observed before the status commit, reopening the reserve/publish
+        boundary window (explicit review ruling). A missing or
+        version-mismatched ctrl row raises a control-plane error instead of
+        degrading. Crash after commit leaves a permanent hole — allowed;
+        reuse is not.
+        """
+        row = await self.db.query(
+            "UPDATE LIGHTRAG_DOC_SCHEDULING_CTRL "
+            "SET failure_generation_counter = failure_generation_counter + 1, "
+            "update_time = CURRENT_TIMESTAMP "
+            "WHERE workspace=$1 AND schema_version=$2 "
+            "RETURNING failure_generation_counter",
+            [self.workspace, self._CTRL_SCHEMA_VERSION],
+        )
+        if row is None:
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] failure-generation marker missing or "
+                f"version-mismatched for {self.namespace}; refusing (never "
+                "degrades to LEGACY full-snapshot behaviour)"
+            )
+        return int(row["failure_generation_counter"])
+
+    async def mark_doc_failed(self, doc_id: str, fields: dict[str, Any]) -> int | None:
+        """FAILED transition funnel: reserve + publish in ONE transaction.
+
+        The counter ``UPDATE ... RETURNING`` and the row CAS run in the same
+        transaction, so reserve-and-publish is atomic (boundary window → 0):
+        a rolled-back transaction reserves nothing, a committed one published
+        the FAILED row with its generation. Idempotent per attempt: an
+        already-FAILED row (read ``FOR UPDATE``) whose ``failure_attempt_id``
+        equals the current attempt keeps its generation without touching the
+        counter. A caller-supplied ``created_at`` is IGNORED for existing
+        rows (immutable sort key: it is simply never in the SET list); a
+        missing row is conditionally created (enqueue/parse errors can fail
+        before the PENDING row landed) with the caller's ``created_at``.
+        ``_run_with_retry`` may re-run the whole closure after a transient
+        error; the re-read idempotency check absorbs a commit whose response
+        was lost.
+        """
+        unknown = set(fields) - _DOC_STATUS_UPDATABLE_COLUMNS - {"created_at"}
+        if unknown:
+            raise ValueError(
+                f"mark_doc_failed received unknown doc_status column(s): "
+                f"{sorted(unknown)}"
+            )
+        workspace = self.workspace
+        ctrl_schema_version = self._CTRL_SCHEMA_VERSION
+
+        async def _mark_failed(connection: asyncpg.Connection) -> int:
+            async with connection.transaction():
+                row = await connection.fetchrow(
+                    "SELECT status, processing_attempt_id, failure_attempt_id, "
+                    "failure_generation "
+                    "FROM LIGHTRAG_DOC_STATUS WHERE workspace=$1 AND id=$2 "
+                    "FOR UPDATE",
+                    workspace,
+                    doc_id,
+                )
+                if row is not None:
+                    current_attempt = row["processing_attempt_id"] or fields.get(
+                        "processing_attempt_id"
+                    )
+                else:
+                    current_attempt = fields.get("processing_attempt_id")
+
+                if (
+                    row is not None
+                    and row["status"] == DocStatus.FAILED.value
+                    and current_attempt
+                    and row["failure_attempt_id"] == current_attempt
+                ):
+                    # Same attempt already published its failure: idempotent
+                    # return of the existing generation, no counter touch.
+                    return int(row["failure_generation"] or 0)
+
+                gen_row = await connection.fetchrow(
+                    "UPDATE LIGHTRAG_DOC_SCHEDULING_CTRL "
+                    "SET failure_generation_counter = "
+                    "failure_generation_counter + 1, "
+                    "update_time = CURRENT_TIMESTAMP "
+                    "WHERE workspace=$1 AND schema_version=$2 "
+                    "RETURNING failure_generation_counter",
+                    workspace,
+                    ctrl_schema_version,
+                )
+                if gen_row is None:
+                    raise StorageControlPlaneError(
+                        f"[{workspace}] failure-generation marker missing or "
+                        "version-mismatched; refusing FAILED transition"
+                    )
+                generation = int(gen_row["failure_generation_counter"])
+
+                if row is not None:
+                    update_fields = {
+                        k: v for k, v in fields.items() if k != "created_at"
+                    }
+                    update_fields["status"] = DocStatus.FAILED.value
+                    update_fields["failure_generation"] = generation
+                    if current_attempt:
+                        update_fields["failure_attempt_id"] = current_attempt
+                        update_fields.setdefault(
+                            "processing_attempt_id",
+                            row["processing_attempt_id"] or current_attempt,
+                        )
+                    params: list[Any] = [workspace, doc_id]
+                    set_clauses: list[str] = []
+                    for column, value in update_fields.items():
+                        params.append(
+                            self._prepare_doc_status_field_value(column, value)
+                        )
+                        set_clauses.append(f"{column} = ${len(params)}")
+                    # created_at is never in the SET list: immutable sort key.
+                    await connection.execute(
+                        "UPDATE LIGHTRAG_DOC_STATUS SET "
+                        + ", ".join(set_clauses)
+                        + " WHERE workspace=$1 AND id=$2",
+                        *params,
+                    )
+                else:
+                    insert_fields = dict(fields)
+                    insert_fields["status"] = DocStatus.FAILED.value
+                    insert_fields["failure_generation"] = generation
+                    if current_attempt:
+                        insert_fields["failure_attempt_id"] = current_attempt
+                        insert_fields.setdefault(
+                            "processing_attempt_id", current_attempt
+                        )
+                    insert_fields.setdefault("chunks_list", [])
+                    columns = ["workspace", "id"]
+                    values: list[Any] = [workspace, doc_id]
+                    for column, value in insert_fields.items():
+                        columns.append(column)
+                        values.append(
+                            self._prepare_doc_status_field_value(column, value)
+                        )
+                    placeholders = ", ".join(f"${i}" for i in range(1, len(values) + 1))
+                    # FOR UPDATE on a missing row does not block a concurrent
+                    # insert; ON CONFLICT publishes our failure over the racing
+                    # row while preserving its created_at (immutable).
+                    conflict_sets = ", ".join(
+                        f"{c} = EXCLUDED.{c}"
+                        for c in insert_fields
+                        if c != "created_at"
+                    )
+                    await connection.execute(
+                        f"INSERT INTO LIGHTRAG_DOC_STATUS ({', '.join(columns)}) "
+                        f"VALUES ({placeholders}) "
+                        f"ON CONFLICT (id, workspace) DO UPDATE SET {conflict_sets}",
+                        *values,
+                    )
+                return generation
+
+        return await self.db._run_with_retry(_mark_failed)
+
+    async def ensure_processing_attempt_id(self, doc_id: str) -> str:
+        """Atomic mint-or-reuse of the row's attempt id (single-statement CAS).
+
+        ``COALESCE(processing_attempt_id, $new)`` keeps a persisted id and
+        only writes the freshly minted one when the column is NULL, so an
+        interrupted call retried after a lost response reuses the persisted
+        id instead of minting a second one.
+        """
+        minted = uuid.uuid4().hex
+        row = await self.db.query(
+            "UPDATE LIGHTRAG_DOC_STATUS "
+            "SET processing_attempt_id = COALESCE(processing_attempt_id, $3) "
+            "WHERE workspace=$1 AND id=$2 "
+            "RETURNING processing_attempt_id",
+            [self.workspace, doc_id, minted],
+        )
+        if row is None:
+            raise StorageRecordNotFoundError(doc_id)
+        return str(row["processing_attempt_id"])
 
     async def get_status_counts(self) -> dict[str, int]:
         """Get counts of documents in each status"""
@@ -8091,6 +8864,12 @@ TABLES = {
 	               -- 64-char SHA-256 hex; future algos (SHA-512, base64) do
 	               -- not require a schema change.
 	               content_hash TEXT NULL,
+	               -- Memory-bounding scheduling fields (Phase 1). NOT NULL
+	               -- DEFAULT 0 keeps legacy/never-failed rows at logical
+	               -- generation 0 (first manual cutoff covers all history).
+	               failure_generation BIGINT NOT NULL DEFAULT 0,
+	               processing_attempt_id TEXT NULL,
+	               failure_attempt_id TEXT NULL,
 	               created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 	               updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 	               CONSTRAINT LIGHTRAG_DOC_STATUS_PK PRIMARY KEY (workspace, id)

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -5475,11 +5475,13 @@ class PGDocStatusStorage(DocStatusStorage):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _decode_cursor(opaque: str) -> tuple[datetime.datetime, str]:
+    def _decode_cursor(opaque: str) -> tuple[datetime.datetime | None, str]:
         """Decode an opaque page cursor into (created_at, id).
 
-        The opaque form is ``json.dumps([created_at_iso, id])`` produced by
-        ``_encode_cursor``. The ISO string round-trips exactly through
+        The opaque form is ``json.dumps([created_at_iso | None, id])``
+        produced by ``_encode_cursor``. A ``None`` first element marks the
+        NULL-created_at bucket (corrupt rows, sorted FIRST — see the page
+        docstring); a string round-trips exactly through
         ``datetime.fromisoformat`` (microseconds preserved) and is normalized
         back to the naive-UTC form the TIMESTAMP column stores, so the
         parameterized row-value comparison resumes at exactly the last
@@ -5489,8 +5491,12 @@ class PGDocStatusStorage(DocStatusStorage):
         try:
             decoded = json.loads(opaque)
             created_iso, doc_id = decoded
-            if not isinstance(created_iso, str) or not isinstance(doc_id, str):
-                raise ValueError("cursor fields must be strings")
+            if not isinstance(doc_id, str):
+                raise ValueError("cursor id must be a string")
+            if created_iso is None:
+                return None, doc_id
+            if not isinstance(created_iso, str):
+                raise ValueError("cursor created_at must be a string or null")
             created = datetime.datetime.fromisoformat(created_iso)
         except (ValueError, TypeError) as e:
             raise StorageControlPlaneError(
@@ -5501,18 +5507,16 @@ class PGDocStatusStorage(DocStatusStorage):
         return created, doc_id
 
     def _encode_cursor(self, row: dict[str, Any]) -> str:
-        """Encode the keyset key of a returned DB row as an opaque cursor."""
+        """Encode the keyset key of a returned DB row as an opaque cursor.
+
+        Rows with a NULL created_at (corrupt writes — the column defaults to
+        CURRENT_TIMESTAMP) sort FIRST and encode as ``[null, id]`` so the
+        sweep traverses past them instead of losing them behind a row-value
+        comparison that NULL can never satisfy (matching the JSON/Redis
+        backends, which sort a missing created_at first as "")."""
         created = row.get("created_at")
         if not isinstance(created, datetime.datetime):
-            # Only reachable when an entire page consists of rows whose
-            # created_at is NULL (corrupt writes — the column defaults to
-            # CURRENT_TIMESTAMP). Such rows have no stable sort key, so a
-            # cursor cannot be built over them: fail closed instead of
-            # skipping or re-reading in place.
-            raise StorageControlPlaneError(
-                f"[{self.workspace}] scheduling row {row.get('id')!r} has no "
-                "usable created_at sort key; cannot advance the page cursor"
-            )
+            return json.dumps([None, str(row["id"])])
         return json.dumps(
             [self._format_datetime_with_timezone(created), str(row["id"])]
         )
@@ -5603,10 +5607,16 @@ class PGDocStatusStorage(DocStatusStorage):
         row-conversion failure raises without returning partial docs or a
         cursor (single round-trip — there is no partial-page surface). In
         relaxed mode an unusable row is skipped from the projection but stays
-        consumed (it was returned by the scan). Rows with a NULL created_at
-        (corrupt writes) sort last (NULLS LAST), raise under strict, and are
-        skipped under relaxed; a full page of them fails closed in
-        ``_encode_cursor``.
+        consumed (it was returned by the scan).
+
+        NULL created_at (corrupt writes): such rows sort FIRST
+        (``NULLS FIRST``, mirroring JSON/Redis where a missing created_at
+        sorts first as "") and the keyset comparison is bucket-aware — a
+        plain ``(created_at, id) > ($c, $i)`` row-value comparison evaluates
+        to NULL for them, which would silently starve them out of every page
+        after the first, violating the strict complete-or-raise promise.
+        They therefore stay reachable: raised under strict, skipped (but
+        consumed) under relaxed.
         """
         if limit <= 0:
             raise ValueError(f"page limit must be positive, got {limit}")
@@ -5621,19 +5631,31 @@ class PGDocStatusStorage(DocStatusStorage):
         )
         if isinstance(position, CursorAfter):
             cur_created, cur_id = self._decode_cursor(position.opaque)
-            params.append(cur_created)
-            params.append(cur_id)
-            sql += (
-                f" AND (created_at, id) > (${len(params) - 1}::timestamp, "
-                f"${len(params)})"
-            )
+            if cur_created is None:
+                # Cursor inside the NULL bucket (sorted first): continue
+                # through the remaining NULL rows by id, then everything
+                # with a real timestamp.
+                params.append(cur_id)
+                sql += (
+                    f" AND ((created_at IS NULL AND id > ${len(params)}) "
+                    "OR created_at IS NOT NULL)"
+                )
+            else:
+                # Past the NULL bucket: only real-timestamp rows can follow.
+                params.append(cur_created)
+                params.append(cur_id)
+                sql += (
+                    " AND created_at IS NOT NULL AND "
+                    f"(created_at, id) > (${len(params) - 1}::timestamp, "
+                    f"${len(params)})"
+                )
         if max_failure_generation is not None:
             params.append(DocStatus.FAILED.value)
             sql += f" AND (status != ${len(params)}"
             params.append(int(max_failure_generation))
             sql += f" OR COALESCE(failure_generation, 0) <= ${len(params)})"
         params.append(limit)
-        sql += f" ORDER BY created_at ASC, id ASC LIMIT ${len(params)}"
+        sql += f" ORDER BY created_at ASC NULLS FIRST, id ASC LIMIT ${len(params)}"
 
         # Any asyncpg error propagates out of db.query — strict pages never
         # commit a new cursor on failure.

--- a/lightrag/kg/redis_impl.py
+++ b/lightrag/kg/redis_impl.py
@@ -1,7 +1,9 @@
 import os
 import logging
 import asyncio
-from typing import Any, final, Union
+import time
+import uuid
+from typing import Any, ClassVar, final, Union
 from dataclasses import dataclass
 import pipmaster as pm
 import configparser
@@ -13,7 +15,12 @@ if not pm.is_installed("redis"):
 
 # aioredis is a depricated library, replaced with redis
 from redis.asyncio import Redis, ConnectionPool  # type: ignore
-from redis.exceptions import RedisError, ConnectionError, TimeoutError  # type: ignore
+from redis.exceptions import (  # type: ignore
+    RedisError,
+    ConnectionError,
+    TimeoutError,
+    WatchError,
+)
 from lightrag.utils import (
     logger,
     get_pinyin_sort_key,
@@ -22,10 +29,23 @@ from lightrag.utils import (
 )
 
 from lightrag.base import (
+    CURSOR_END,
+    CURSOR_START,
+    CursorAfter,
+    CursorPosition,
     BaseKVStorage,
+    DocSchedulingRecord,
+    DocStatusPage,
     DocStatusStorage,
     DocStatus,
     DocProcessingStatus,
+    FailureGenerationMode,
+)
+from lightrag.constants import CUSTOM_CHUNK_PATCH_METADATA_KEY
+from lightrag.exceptions import (
+    StorageControlPlaneError,
+    StorageMigrationInProgressError,
+    StorageRecordNotFoundError,
 )
 from ..kg.shared_storage import get_data_init_lock
 import json
@@ -193,6 +213,8 @@ class RedisConnectionManager:
 @final
 @dataclass
 class RedisKVStorage(BaseKVStorage):
+    supports_strict_point_reads: ClassVar[bool] = True
+
     def __post_init__(self):
         validate_workspace(self.workspace)
         # Check for REDIS_WORKSPACE environment variable first (higher priority)
@@ -379,6 +401,12 @@ class RedisKVStorage(BaseKVStorage):
                 logger.error(f"[{self.workspace}] JSON decode error for id {id}: {e}")
                 raise
 
+    async def get_by_id_strict(self, id: str) -> dict[str, Any] | None:
+        """Strict point read (base contract): ``get_by_id`` already
+        propagates every transport/decode failure (no swallow-and-None
+        path), so a ``None`` from a healthy GET is a confirmed absence."""
+        return await self.get_by_id(id)
+
     @redis_retry
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
         async with self._get_redis_connection() as redis:
@@ -420,7 +448,6 @@ class RedisKVStorage(BaseKVStorage):
         if not data:
             return
 
-        import time
 
         current_time = int(time.time())  # Get current Unix timestamp
 
@@ -619,7 +646,53 @@ class RedisKVStorage(BaseKVStorage):
 @final
 @dataclass
 class RedisDocStatusStorage(DocStatusStorage):
-    """Redis implementation of document status storage"""
+    """Redis implementation of document status storage.
+
+    Memory-bounding scheduling sidecar (Phase 1)
+    --------------------------------------------
+    Alongside the primary ``{final_namespace}:{doc_id}`` JSON records this
+    class maintains, ATOMICALLY with every write (``WATCH``→``MULTI/EXEC``
+    with conflict retry), a scheduling sidecar under the
+    ``{final_namespace}__sched:`` prefix — deliberately NOT matched by the
+    ``{final_namespace}:*`` patterns the legacy SCAN readers and ``drop``
+    use, so sidecar keys never leak into full-scan reads:
+
+    * ``…__sched:status:{status}`` — one ZSET per status, score 0,
+      member ``"{created_at}|{doc_id}"``; ISO-8601 strings make
+      lexicographic member order the ``(created_at, id)`` keyset order, so
+      ``ZRANGEBYLEX`` pages the sweep and ``ZCARD`` gives O(1) counts.
+    * ``…__sched:basename:{canonical}`` — canonical basename → PRIMARY
+      doc_id (rows with ``metadata.is_duplicate != true`` and a real
+      file_path only). ``file_path`` is one-to-many across rows (duplicate
+      markers keep the canonical name) so ONLY the primary row is indexed;
+      maintenance is an eligibility state machine keyed on the (old, new)
+      row values — a primary that turns into a content-duplicate in place
+      deletes its own mapping (CAS: only if it still points to itself).
+    * ``…__sched:ctrl`` — HASH {schema_version, mode,
+      failure_generation_counter}. Counter and rows live in the same Redis
+      persistence unit, so restore rolls them back together — no per-init
+      recalibration is needed (unlike the JSON sidecar file); calibration
+      happens once at migration.
+
+    Existing deployments lack the sidecar: ``initialize`` runs a one-time
+    streaming migration (SCAN in bounded batches → ZADD/SET, then publishes
+    the ctrl marker LAST) guarded by a short-lease migration lock; ctrl
+    presence with a foreign schema_version reads as MIGRATING — never
+    LEGACY. NOTE: the migration lock only prevents duplicate migrations
+    among new workers; isolating OLD writers is a deployment prerequisite
+    (coordinated stop-write upgrade), not something this class can enforce.
+    """
+
+    supports_bounded_scheduling_pages: ClassVar[bool] = True
+    supports_failure_generation: ClassVar[bool] = True
+    supports_strict_doc_identity_lookup: ClassVar[bool] = True
+    supports_strict_point_reads: ClassVar[bool] = True
+
+    _CTRL_SCHEMA_VERSION: ClassVar[str] = "1"
+    # Bounded retry budget for WATCH/MULTI conflict loops. High contention
+    # on a single doc key is not expected (per-doc writes are serialized by
+    # the pipeline); the cap turns a pathological livelock into an error.
+    _WATCH_RETRY_LIMIT: ClassVar[int] = 50
 
     def __post_init__(self):
         validate_workspace(self.workspace)
@@ -692,7 +765,11 @@ class RedisDocStatusStorage(DocStatusStorage):
                     logger.info(
                         f"[{self.workspace}] Connected to Redis for doc status namespace {self.namespace}"
                     )
-                    self._initialized = True
+                # One-time scheduling sidecar bootstrap (no-op once the ctrl
+                # marker exists) — must complete before serving: the paged
+                # sweep, ZCARD counts and basename index all depend on it.
+                await self._migrate_scheduling_sidecar()
+                self._initialized = True
             except Exception as e:
                 logger.error(
                     f"[{self.workspace}] Failed to connect to Redis for doc status: {e}"
@@ -1011,8 +1088,163 @@ class RedisDocStatusStorage(DocStatusStorage):
             return True
 
     @redis_retry
+    # ------------------------------------------------------------------
+    # Scheduling sidecar helpers (Phase 1) — see class docstring.
+    # ------------------------------------------------------------------
+
+    @property
+    def _sched_prefix(self) -> str:
+        return f"{self.final_namespace}__sched"
+
+    def _zset_key(self, status_value: str) -> str:
+        return f"{self._sched_prefix}:status:{status_value}"
+
+    def _basename_key(self, basename: str) -> str:
+        return f"{self._sched_prefix}:basename:{basename}"
+
+    @property
+    def _ctrl_key(self) -> str:
+        return f"{self._sched_prefix}:ctrl"
+
+    @staticmethod
+    def _zset_member(row: dict[str, Any], doc_id: str) -> str:
+        """``"{created_at}|{doc_id}"`` — ISO-8601 lexicographic order makes
+        member order the (created_at, id) keyset order. A missing/non-str
+        created_at sorts deterministically first as ""; '|' cannot occur in
+        ISO timestamps so the split is unambiguous."""
+        created = row.get("created_at")
+        return f"{created if isinstance(created, str) else ''}|{doc_id}"
+
+    @staticmethod
+    def _split_member(member: str) -> tuple[str, str]:
+        created, _, doc_id = member.partition("|")
+        return created, doc_id
+
+    @staticmethod
+    def _is_duplicate_row(row: Any) -> bool:
+        if not isinstance(row, dict):
+            return False
+        metadata = row.get("metadata")
+        return bool(isinstance(metadata, dict) and metadata.get("is_duplicate"))
+
+    @classmethod
+    def _basename_of(cls, row: Any) -> str | None:
+        """Canonical basename this row would claim in the primary index,
+        or None when the row is index-ineligible (duplicate marker /
+        placeholder file_path)."""
+        if not isinstance(row, dict) or cls._is_duplicate_row(row):
+            return None
+        file_path = row.get("file_path")
+        if not isinstance(file_path, str) or not file_path:
+            return None
+        if file_path in ("unknown_source", "no-file-path"):
+            return None
+        return file_path
+
+    def _queue_index_ops(
+        self,
+        pipe,
+        doc_id: str,
+        old_row: dict[str, Any] | None,
+        new_row: dict[str, Any] | None,
+        *,
+        old_basename_owner: str | None,
+    ) -> None:
+        """Queue sidecar maintenance into an open MULTI for one doc write.
+
+        Status ZSET: remove the old member, add the new one (created_at is
+        immutable for existing rows, but removing by the OLD row's member is
+        still the correct general form). Basename index: the eligibility
+        state machine on (old, new) — the caller supplies the CURRENT index
+        owner (read under WATCH) so deletes are CAS-like: only a mapping
+        that points to this doc is ever touched.
+        """
+        if old_row is not None:
+            old_status = str(old_row.get("status") or "")
+            if old_status:
+                pipe.zrem(
+                    self._zset_key(old_status), self._zset_member(old_row, doc_id)
+                )
+        if new_row is not None:
+            new_status = str(new_row.get("status") or "")
+            if new_status:
+                pipe.zadd(
+                    self._zset_key(new_status),
+                    {self._zset_member(new_row, doc_id): 0},
+                )
+
+        old_basename = self._basename_of(old_row)
+        new_basename = self._basename_of(new_row)
+        if old_basename == new_basename:
+            if new_basename is not None:
+                # eligible → eligible, same name: assert ownership
+                # (idempotent repair of a missing mapping).
+                pipe.set(self._basename_key(new_basename), doc_id)
+            return
+        if old_basename is not None and old_basename_owner == doc_id:
+            # eligible → ineligible (e.g. a primary rewritten in place as a
+            # post-parse content duplicate) or file_path moved: release only
+            # a mapping that still points to us.
+            pipe.delete(self._basename_key(old_basename))
+        if new_basename is not None:
+            # ineligible → eligible, or file_path moved: claim the new name.
+            pipe.set(self._basename_key(new_basename), doc_id)
+
+    async def _atomic_doc_write(
+        self,
+        redis,
+        doc_id: str,
+        mutate,
+    ) -> dict[str, Any] | None:
+        """WATCH→MULTI/EXEC skeleton for one doc: read the old row and the
+        current basename-index owners under WATCH, let ``mutate(old_row)``
+        produce the new row (or ``None`` to abort without writing), then
+        commit row + sidecar in one transaction; retry on conflict.
+
+        Returns the committed new row (or None when aborted).
+        """
+        main_key = f"{self.final_namespace}:{doc_id}"
+        for _ in range(self._WATCH_RETRY_LIMIT):
+            async with redis.pipeline(transaction=True) as pipe:
+                try:
+                    await pipe.watch(main_key)
+                    old_raw = await pipe.get(main_key)
+                    old_row = json.loads(old_raw) if old_raw else None
+                    new_row = mutate(old_row)
+                    if new_row is None:
+                        await pipe.unwatch()
+                        return None
+                    old_basename = self._basename_of(old_row)
+                    old_owner = None
+                    if old_basename is not None:
+                        basename_key = self._basename_key(old_basename)
+                        await pipe.watch(basename_key)
+                        old_owner = await pipe.get(basename_key)
+                    pipe.multi()
+                    pipe.set(main_key, json.dumps(new_row))
+                    self._queue_index_ops(
+                        pipe,
+                        doc_id,
+                        old_row,
+                        new_row,
+                        old_basename_owner=old_owner,
+                    )
+                    await pipe.execute()
+                    return new_row
+                except WatchError:
+                    continue
+        raise StorageControlPlaneError(
+            f"[{self.workspace}] doc_status write for {doc_id} exceeded the "
+            f"WATCH retry budget ({self._WATCH_RETRY_LIMIT})"
+        )
+
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
-        """Insert or update document status data"""
+        """Insert or update document status data.
+
+        Each record commits atomically with its scheduling sidecar (status
+        ZSET member + basename primary index) via a per-doc WATCH/MULTI
+        transaction — a few extra RPCs per doc, bounded by the enqueue
+        batch cap; correctness of the sidecar is the priority."""
         if not data:
             return
 
@@ -1020,21 +1252,15 @@ class RedisDocStatusStorage(DocStatusStorage):
             f"[{self.workspace}] Inserting {len(data)} records to {self.namespace}"
         )
         async with self._get_redis_connection() as redis:
-            try:
-                # Ensure chunks_list field exists for new documents
-                for i, (doc_id, doc_data) in enumerate(data.items(), start=1):
-                    if "chunks_list" not in doc_data:
-                        doc_data["chunks_list"] = []
-                    await _cooperative_yield(i)
+            for i, (doc_id, doc_data) in enumerate(data.items(), start=1):
+                if "chunks_list" not in doc_data:
+                    doc_data["chunks_list"] = []
 
-                pipe = redis.pipeline()
-                for i, (k, v) in enumerate(data.items(), start=1):
-                    pipe.set(f"{self.final_namespace}:{k}", json.dumps(v))
-                    await _cooperative_yield(i)
-                await pipe.execute()
-            except json.JSONDecodeError as e:
-                logger.error(f"[{self.workspace}] JSON decode error during upsert: {e}")
-                raise
+                def _replace(_old, _new=doc_data):
+                    return _new
+
+                await self._atomic_doc_write(redis, doc_id, _replace)
+                await _cooperative_yield(i)
 
     @redis_retry
     async def get_by_id(self, id: str) -> Union[dict[str, Any], None]:
@@ -1047,17 +1273,54 @@ class RedisDocStatusStorage(DocStatusStorage):
                 raise
 
     async def delete(self, doc_ids: list[str]) -> None:
-        """Delete specific records from storage by their IDs"""
+        """Delete records atomically with their scheduling sidecar entries.
+
+        Per-doc WATCH/MULTI: remove the primary key, its status-ZSET member
+        and — only when the basename index still points to THIS doc — the
+        basename mapping (deleting a duplicate marker or a non-owning row
+        must not strip another row's mapping)."""
         if not doc_ids:
             return
 
+        deleted_count = 0
         async with self._get_redis_connection() as redis:
-            pipe = redis.pipeline()
             for doc_id in doc_ids:
-                pipe.delete(f"{self.final_namespace}:{doc_id}")
-
-            results = await pipe.execute()
-            deleted_count = sum(results)
+                main_key = f"{self.final_namespace}:{doc_id}"
+                for _ in range(self._WATCH_RETRY_LIMIT):
+                    async with redis.pipeline(transaction=True) as pipe:
+                        try:
+                            await pipe.watch(main_key)
+                            old_raw = await pipe.get(main_key)
+                            if not old_raw:
+                                await pipe.unwatch()
+                                break
+                            old_row = json.loads(old_raw)
+                            old_basename = self._basename_of(old_row)
+                            old_owner = None
+                            if old_basename is not None:
+                                basename_key = self._basename_key(old_basename)
+                                await pipe.watch(basename_key)
+                                old_owner = await pipe.get(basename_key)
+                            pipe.multi()
+                            pipe.delete(main_key)
+                            old_status = str(old_row.get("status") or "")
+                            if old_status:
+                                pipe.zrem(
+                                    self._zset_key(old_status),
+                                    self._zset_member(old_row, doc_id),
+                                )
+                            if old_basename is not None and old_owner == doc_id:
+                                pipe.delete(self._basename_key(old_basename))
+                            await pipe.execute()
+                            deleted_count += 1
+                            break
+                        except WatchError:
+                            continue
+                else:
+                    raise StorageControlPlaneError(
+                        f"[{self.workspace}] doc_status delete for {doc_id} "
+                        f"exceeded the WATCH retry budget"
+                    )
             logger.info(
                 f"[{self.workspace}] Deleted {deleted_count} of {len(doc_ids)} doc status entries from {self.namespace}"
             )
@@ -1250,56 +1513,62 @@ class RedisDocStatusStorage(DocStatusStorage):
                 logger.error(f"[{self.workspace}] Error in get_doc_by_file_path: {e}")
                 return None
 
-    async def get_doc_by_file_basename(
+    async def _basename_lookup(
         self, basename: str
     ) -> Union[tuple[str, dict[str, Any]], None]:
-        """Find an existing record whose canonical basename matches.
+        """Primary-row basename lookup via the sidecar index (O(1)).
 
-        The caller is responsible for passing an already-canonical basename.
-        Stored ``file_path`` values are canonicalized by the business layer, so
-        this lookup intentionally performs an exact match only.
+        The index only ever holds PRIMARY rows (``is_duplicate != true``),
+        maintained atomically with every write — so a hit is the document,
+        never a duplicate marker, and covers custom-ID rows that a
+        deterministic ``md5(canonical)`` key lookup would miss. A mapping
+        whose primary row is gone is a broken invariant: raise (the strict
+        caller must not treat it as confirmed absence).
         """
         if not basename:
             return None
         if basename == "unknown_source":
             return None
-
         async with self._get_redis_connection() as redis:
-            try:
-                cursor = 0
-                while True:
-                    cursor, keys = await redis.scan(
-                        cursor, match=f"{self.final_namespace}:*", count=1000
-                    )
-                    if keys:
-                        pipe = redis.pipeline()
-                        for key in keys:
-                            pipe.get(key)
-                        values = await pipe.execute()
-
-                        for key, value in zip(keys, values):
-                            if not value:
-                                continue
-                            try:
-                                doc_data = json.loads(value)
-                            except json.JSONDecodeError as e:
-                                logger.error(
-                                    f"[{self.workspace}] JSON decode error in get_doc_by_file_basename: {e}"
-                                )
-                                continue
-                            if doc_data.get("file_path") == basename:
-                                doc_id = key.split(":", 1)[1]
-                                return doc_id, doc_data
-
-                    if cursor == 0:
-                        break
-
+            doc_id = await redis.get(self._basename_key(basename))
+            if not doc_id:
                 return None
-            except Exception as e:
-                logger.error(
-                    f"[{self.workspace}] Error in get_doc_by_file_basename: {e}"
+            raw = await redis.get(f"{self.final_namespace}:{doc_id}")
+            if not raw:
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] basename index points at missing doc "
+                    f"{doc_id} for '{basename}' — sidecar invariant broken"
                 )
-                return None
+            return doc_id, json.loads(raw)
+
+    async def get_doc_by_file_basename(
+        self, basename: str
+    ) -> Union[tuple[str, dict[str, Any]], None]:
+        """Find the PRIMARY record whose canonical basename matches.
+
+        The caller is responsible for passing an already-canonical basename.
+        Stored ``file_path`` values are canonicalized by the business layer, so
+        this lookup intentionally performs an exact match only. Duplicate
+        marker rows (``metadata.is_duplicate``) are never returned — see the
+        class docstring's basename-index contract.
+
+        Legacy error semantics preserved: failures log and return ``None``
+        (best-effort miss). Identity-critical callers use
+        :meth:`get_doc_by_file_basename_strict` instead.
+        """
+        try:
+            return await self._basename_lookup(basename)
+        except Exception as e:
+            logger.error(f"[{self.workspace}] Error in get_doc_by_file_basename: {e}")
+            return None
+
+    async def get_doc_by_file_basename_strict(
+        self, basename: str
+    ) -> Union[tuple[str, dict[str, Any]], None]:
+        """Fail-closed variant: ``None`` only after a healthy index miss;
+        transport errors and broken index invariants propagate (base
+        contract — a swallowed failure would mint duplicate rows)."""
+        return await self._basename_lookup(basename)
 
     async def get_doc_by_content_hash(
         self, content_hash: str
@@ -1345,27 +1614,495 @@ class RedisDocStatusStorage(DocStatusStorage):
                 )
                 return None
 
-    async def drop(self) -> dict[str, str]:
-        """Drop all document status data from storage and clean up resources"""
-        try:
-            async with self._get_redis_connection() as redis:
-                # Use SCAN to find all keys with the namespace prefix
-                pattern = f"{self.final_namespace}:*"
-                cursor = 0
-                deleted_count = 0
+    # ------------------------------------------------------------------
+    # Memory-bounding scheduling API (Phase 1)
+    # ------------------------------------------------------------------
 
+    async def get_by_id_strict(self, id: str) -> Union[dict[str, Any], None]:
+        """Strict point read: ``get_by_id`` already propagates transport and
+        decode failures, so a ``None`` is a confirmed absence."""
+        return await self.get_by_id(id)
+
+    @staticmethod
+    def _encode_cursor(positions: dict[str, str]) -> str:
+        return json.dumps(positions, ensure_ascii=False, sort_keys=True)
+
+    @staticmethod
+    def _decode_cursor(opaque: str) -> dict[str, str]:
+        try:
+            decoded = json.loads(opaque)
+            if not isinstance(decoded, dict) or not all(
+                isinstance(k, str) and isinstance(v, str) for k, v in decoded.items()
+            ):
+                raise ValueError("cursor must map status -> last member")
+        except (ValueError, TypeError) as e:
+            raise StorageControlPlaneError(
+                f"Malformed scheduling cursor for RedisDocStatusStorage: {e}"
+            ) from e
+        return decoded
+
+    def _scheduling_record_from_row(
+        self, doc_id: str, row: dict[str, Any], *, strict: bool
+    ) -> DocSchedulingRecord | None:
+        try:
+            status = DocStatus(str(row["status"]))
+            created_at = row["created_at"]
+            updated_at = row.get("updated_at", created_at)
+            if not isinstance(created_at, str) or not isinstance(updated_at, str):
+                raise TypeError("created_at/updated_at must be strings")
+            metadata = row.get("metadata")
+            return DocSchedulingRecord(
+                id=doc_id,
+                status=status,
+                created_at=created_at,
+                updated_at=updated_at,
+                file_path=row.get("file_path") or "no-file-path",
+                track_id=row.get("track_id"),
+                has_custom_chunk_journal=isinstance(metadata, dict)
+                and isinstance(metadata.get(CUSTOM_CHUNK_PATCH_METADATA_KEY), dict),
+            )
+        except (KeyError, TypeError, ValueError) as e:
+            logger.error(f"[{self.workspace}] Unusable scheduling row {doc_id}: {e}")
+            if strict:
+                raise
+            return None
+
+    async def get_docs_by_statuses_page(
+        self,
+        statuses: list[DocStatus],
+        *,
+        limit: int,
+        position: CursorPosition = CURSOR_START,
+        max_failure_generation: int | None = None,
+        strict: bool = False,
+    ) -> DocStatusPage:
+        """Bounded k-way merge over the per-status ZSETs.
+
+        Each status stream is read with ``ZRANGEBYLEX (last_member +`` —
+        lexicographic member order IS the (created_at, id) keyset order.
+        The composite cursor records each status's own last CONSUMED member:
+        a candidate merged into the page window is consumed (returned,
+        dropped by the generation predicate, or skipped as unusable in
+        relaxed mode) and advances its stream; a prefetched head that did
+        not fit stays unconsumed and is re-read next page. A stream is
+        exhausted when its prefetch came back short AND fully consumed;
+        the sweep ends when every stream is exhausted.
+        """
+        if limit <= 0:
+            raise ValueError(f"page limit must be positive, got {limit}")
+        if not statuses or position is CURSOR_END:
+            return DocStatusPage(docs={}, next_position=CURSOR_END)
+        if isinstance(position, CursorAfter):
+            positions = self._decode_cursor(position.opaque)
+        else:
+            positions = {}
+        status_values = [s.value for s in statuses]
+        failed_value = DocStatus.FAILED.value
+
+        async with self._get_redis_connection() as redis:
+            # Prefetch up to `limit` members per stream, strictly after each
+            # stream's own consumed position.
+            pipe = redis.pipeline()
+            for value in status_values:
+                last = positions.get(value)
+                lex_min = f"({last}" if last else "-"
+                pipe.zrangebylex(self._zset_key(value), lex_min, "+", 0, limit)
+            prefetched: list[list[str]] = await pipe.execute()
+
+            streams: dict[str, list[str]] = dict(zip(status_values, prefetched))
+            short_streams = {
+                value for value, members in streams.items() if len(members) < limit
+            }
+
+            # Merge candidates globally by member (== (created_at, id) key),
+            # keep the first `limit` as this page's consumption window.
+            merged: list[tuple[str, str]] = []  # (member, status_value)
+            for value, members in streams.items():
+                merged.extend((member, value) for member in members)
+            merged.sort(key=lambda t: t[0])
+            window = merged[:limit]
+
+            # Hydrate the window's primary rows in one pipeline.
+            doc_ids = [self._split_member(member)[1] for member, _ in window]
+            rows: list[str | None] = []
+            if doc_ids:
+                pipe = redis.pipeline()
+                for doc_id in doc_ids:
+                    pipe.get(f"{self.final_namespace}:{doc_id}")
+                rows = await pipe.execute()
+
+        docs: dict[str, DocSchedulingRecord] = {}
+        consumed_counts: dict[str, int] = {value: 0 for value in status_values}
+        new_positions = dict(positions)
+        for (member, value), raw in zip(window, rows):
+            _, doc_id = self._split_member(member)
+            consumed_counts[value] += 1
+            new_positions[value] = member
+            if raw is None:
+                message = (
+                    f"[{self.workspace}] status ZSET member {member!r} has no "
+                    f"primary row — sidecar invariant broken"
+                )
+                if strict:
+                    raise StorageControlPlaneError(message)
+                logger.error(message)
+                continue  # consumed; the stale member self-heals on rewrite
+            row = json.loads(raw)
+            if max_failure_generation is not None and value == failed_value:
+                try:
+                    generation = int(row.get("failure_generation") or 0)
+                except (TypeError, ValueError):
+                    generation = 0
+                if generation > max_failure_generation:
+                    continue  # consumed by the cohort predicate
+            record = self._scheduling_record_from_row(doc_id, row, strict=strict)
+            if record is None:
+                continue  # relaxed skip is still consumed
+            docs[doc_id] = record
+
+        exhausted = all(
+            value in short_streams and consumed_counts[value] == len(streams[value])
+            for value in status_values
+        )
+        if exhausted:
+            return DocStatusPage(docs=docs, next_position=CURSOR_END)
+        return DocStatusPage(
+            docs=docs,
+            next_position=CursorAfter(self._encode_cursor(new_positions)),
+        )
+
+    async def count_docs_by_statuses(
+        self, statuses: list[DocStatus], *, strict: bool = True
+    ) -> int:
+        """O(1) fail-closed count: sum of per-status ZCARDs (errors
+        propagate — admission control must never read a failure as zero)."""
+        if not statuses:
+            return 0
+        async with self._get_redis_connection() as redis:
+            pipe = redis.pipeline()
+            for status in statuses:
+                pipe.zcard(self._zset_key(status.value))
+            cards = await pipe.execute()
+        return int(sum(cards))
+
+    async def update_doc_status_fields(
+        self,
+        doc_id: str,
+        fields: dict[str, Any],
+        *,
+        missing_ok: bool = False,
+    ) -> None:
+        """Targeted field update, atomic with the sidecar (WATCH/MULTI)."""
+        if "created_at" in fields:
+            raise ValueError(
+                "created_at is an immutable scheduling sort key and cannot "
+                "be changed via update_doc_status_fields"
+            )
+        missing = False
+
+        def _merge(old_row):
+            nonlocal missing
+            if old_row is None:
+                missing = True
+                return None
+            return {**old_row, **fields}
+
+        async with self._get_redis_connection() as redis:
+            await self._atomic_doc_write(redis, doc_id, _merge)
+        if missing and not missing_ok:
+            raise StorageRecordNotFoundError(doc_id)
+
+    # ------------------------------------------------------------------
+    # failure_generation write side (Phase 1)
+    # ------------------------------------------------------------------
+
+    async def get_failure_generation_mode(self) -> FailureGenerationMode:
+        """Read the per-workspace marker; transport errors propagate and a
+        missing/foreign marker reads MIGRATING — never LEGACY."""
+        async with self._get_redis_connection() as redis:
+            ctrl = await redis.hgetall(self._ctrl_key)
+        if not ctrl:
+            return FailureGenerationMode.MIGRATING
+        if ctrl.get("schema_version") != self._CTRL_SCHEMA_VERSION:
+            return FailureGenerationMode.MIGRATING
+        try:
+            return FailureGenerationMode(str(ctrl.get("mode")))
+        except ValueError:
+            return FailureGenerationMode.MIGRATING
+
+    async def reserve_failure_generation(self) -> int:
+        """Atomic counter reservation (WATCH on the ctrl hash so the marker
+        validation and the increment commit together)."""
+        async with self._get_redis_connection() as redis:
+            for _ in range(self._WATCH_RETRY_LIMIT):
+                async with redis.pipeline(transaction=True) as pipe:
+                    try:
+                        await pipe.watch(self._ctrl_key)
+                        ctrl = await pipe.hgetall(self._ctrl_key)
+                        self._validate_ctrl(ctrl)
+                        counter = int(ctrl.get("failure_generation_counter") or 0) + 1
+                        pipe.multi()
+                        pipe.hset(self._ctrl_key, "failure_generation_counter", counter)
+                        await pipe.execute()
+                        return counter
+                    except WatchError:
+                        continue
+        raise StorageControlPlaneError(
+            f"[{self.workspace}] failure-generation reservation exceeded the "
+            f"WATCH retry budget"
+        )
+
+    def _validate_ctrl(self, ctrl: dict[str, str]) -> None:
+        if not ctrl or ctrl.get("schema_version") != self._CTRL_SCHEMA_VERSION:
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] failure-generation marker missing or "
+                f"version-mismatched for {self.namespace}; refusing (never "
+                "degrades to LEGACY full-snapshot behaviour)"
+            )
+
+    async def mark_doc_failed(self, doc_id: str, fields: dict[str, Any]) -> int | None:
+        """FAILED transition funnel: reserve + publish in ONE transaction.
+
+        WATCHes the doc key AND the ctrl hash, reads the counter, then
+        commits ``counter+1`` and the FAILED row together — a concurrent
+        reservation bumps the ctrl hash and retries this transaction, so the
+        reserve→publish window is zero. Idempotent per attempt; existing
+        created_at preserved; missing rows conditionally created.
+        """
+        main_key = f"{self.final_namespace}:{doc_id}"
+        async with self._get_redis_connection() as redis:
+            for _ in range(self._WATCH_RETRY_LIMIT):
+                async with redis.pipeline(transaction=True) as pipe:
+                    try:
+                        await pipe.watch(main_key, self._ctrl_key)
+                        old_raw = await pipe.get(main_key)
+                        old_row = json.loads(old_raw) if old_raw else None
+                        if isinstance(old_row, dict):
+                            current_attempt = old_row.get(
+                                "processing_attempt_id"
+                            ) or fields.get("processing_attempt_id")
+                        else:
+                            current_attempt = fields.get("processing_attempt_id")
+                        if (
+                            isinstance(old_row, dict)
+                            and str(old_row.get("status")) == DocStatus.FAILED.value
+                            and current_attempt
+                            and old_row.get("failure_attempt_id") == current_attempt
+                        ):
+                            await pipe.unwatch()
+                            try:
+                                return int(old_row.get("failure_generation") or 0)
+                            except (TypeError, ValueError):
+                                return 0
+                        ctrl = await pipe.hgetall(self._ctrl_key)
+                        self._validate_ctrl(ctrl)
+                        generation = (
+                            int(ctrl.get("failure_generation_counter") or 0) + 1
+                        )
+                        new_row = (
+                            {**old_row, **fields}
+                            if isinstance(old_row, dict)
+                            else dict(fields)
+                        )
+                        if isinstance(old_row, dict) and "created_at" in old_row:
+                            new_row["created_at"] = old_row["created_at"]
+                        new_row["status"] = DocStatus.FAILED.value
+                        new_row["failure_generation"] = generation
+                        if current_attempt:
+                            new_row["failure_attempt_id"] = current_attempt
+                            new_row.setdefault("processing_attempt_id", current_attempt)
+                        if "chunks_list" not in new_row:
+                            new_row["chunks_list"] = []
+                        old_basename = self._basename_of(old_row)
+                        old_owner = None
+                        if old_basename is not None:
+                            basename_key = self._basename_key(old_basename)
+                            await pipe.watch(basename_key)
+                            old_owner = await pipe.get(basename_key)
+                        pipe.multi()
+                        pipe.hset(
+                            self._ctrl_key, "failure_generation_counter", generation
+                        )
+                        pipe.set(main_key, json.dumps(new_row))
+                        self._queue_index_ops(
+                            pipe,
+                            doc_id,
+                            old_row,
+                            new_row,
+                            old_basename_owner=old_owner,
+                        )
+                        await pipe.execute()
+                        return generation
+                    except WatchError:
+                        continue
+        raise StorageControlPlaneError(
+            f"[{self.workspace}] mark_doc_failed for {doc_id} exceeded the "
+            f"WATCH retry budget"
+        )
+
+    async def ensure_processing_attempt_id(self, doc_id: str) -> str:
+        """Atomic mint-or-reuse of the row's attempt id (WATCH/MULTI)."""
+        result: dict[str, str | None] = {"attempt": None}
+
+        def _ensure(old_row):
+            if old_row is None:
+                return None
+            attempt = old_row.get("processing_attempt_id")
+            if attempt:
+                result["attempt"] = str(attempt)
+                return None  # nothing to write
+            result["attempt"] = uuid.uuid4().hex
+            return {**old_row, "processing_attempt_id": result["attempt"]}
+
+        async with self._get_redis_connection() as redis:
+            await self._atomic_doc_write(redis, doc_id, _ensure)
+        if result["attempt"] is None:
+            raise StorageRecordNotFoundError(doc_id)
+        return result["attempt"]
+
+    # ------------------------------------------------------------------
+    # Sidecar migration (Phase 1)
+    # ------------------------------------------------------------------
+
+    async def _migrate_scheduling_sidecar(self) -> None:
+        """One-time streaming sidecar build for pre-existing deployments.
+
+        SCAN the primary rows in bounded batches, populate the status ZSETs
+        and the basename primary index, calibrate the counter to
+        ``max(persisted failure_generation)``, then publish the ctrl marker
+        LAST (atomic ENFORCED activation). A short-lease migration lock
+        prevents duplicate migrations among concurrently starting workers;
+        losers wait (bounded) for the marker. Old writers are NOT isolated
+        by this lock — the coordinated stop-write upgrade is a deployment
+        prerequisite (class docstring).
+        """
+        lock_key = f"{self._sched_prefix}:migrate_lock"
+        async with self._get_redis_connection() as redis:
+            ctrl = await redis.hgetall(self._ctrl_key)
+            if ctrl:
+                return  # marker present (any version): nothing to bootstrap
+            got_lock = await redis.set(lock_key, "1", nx=True, ex=300)
+            if not got_lock:
+                # Another worker is migrating: wait (bounded) for the marker.
+                for _ in range(60):
+                    await asyncio.sleep(1)
+                    if await redis.hgetall(self._ctrl_key):
+                        return
+                raise StorageMigrationInProgressError(
+                    f"[{self.workspace}] scheduling sidecar migration by "
+                    f"another worker did not complete in time"
+                )
+            try:
+                # Clear any half-built sidecar from a crashed prior attempt
+                # (marker absent ⇒ nothing published yet, rebuild is safe).
+                for pattern in (
+                    f"{self._sched_prefix}:status:*",
+                    f"{self._sched_prefix}:basename:*",
+                ):
+                    cursor = 0
+                    while True:
+                        cursor, keys = await redis.scan(
+                            cursor, match=pattern, count=1000
+                        )
+                        if keys:
+                            await redis.delete(*keys)
+                        if cursor == 0:
+                            break
+
+                max_generation = 0
+                migrated = 0
+                cursor = 0
                 while True:
-                    cursor, keys = await redis.scan(cursor, match=pattern, count=1000)
+                    cursor, keys = await redis.scan(
+                        cursor, match=f"{self.final_namespace}:*", count=1000
+                    )
                     if keys:
-                        # Delete keys in batches
                         pipe = redis.pipeline()
                         for key in keys:
-                            pipe.delete(key)
-                        results = await pipe.execute()
-                        deleted_count += sum(results)
-
+                            pipe.get(key)
+                        values = await pipe.execute()
+                        write_pipe = redis.pipeline()
+                        for key, raw in zip(keys, values):
+                            if not raw:
+                                continue
+                            try:
+                                row = json.loads(raw)
+                            except json.JSONDecodeError:
+                                logger.error(
+                                    f"[{self.workspace}] skipping undecodable "
+                                    f"row {key} during sidecar migration"
+                                )
+                                continue
+                            if not isinstance(row, dict):
+                                continue
+                            doc_id = key.split(":", 1)[1]
+                            status = str(row.get("status") or "")
+                            if status:
+                                write_pipe.zadd(
+                                    self._zset_key(status),
+                                    {self._zset_member(row, doc_id): 0},
+                                )
+                            basename = self._basename_of(row)
+                            if basename is not None:
+                                write_pipe.set(self._basename_key(basename), doc_id)
+                            try:
+                                generation = int(row.get("failure_generation") or 0)
+                            except (TypeError, ValueError):
+                                generation = 0
+                            max_generation = max(max_generation, generation)
+                            migrated += 1
+                        await write_pipe.execute()
                     if cursor == 0:
                         break
+
+                # Publish the marker LAST: readers treat its absence as
+                # MIGRATING, so a crash before this line re-runs cleanly.
+                await redis.hset(
+                    self._ctrl_key,
+                    mapping={
+                        "schema_version": self._CTRL_SCHEMA_VERSION,
+                        "mode": FailureGenerationMode.ENFORCED.value,
+                        "failure_generation_counter": max_generation,
+                    },
+                )
+                logger.info(
+                    f"[{self.workspace}] scheduling sidecar migrated "
+                    f"({migrated} rows, counter={max_generation}) for "
+                    f"{self.namespace}"
+                )
+            finally:
+                await redis.delete(lock_key)
+
+    async def drop(self) -> dict[str, str]:
+        """Drop all document status data from storage and clean up resources.
+
+        Also clears the scheduling sidecar's status ZSETs and basename index
+        (they mirror the dropped rows). The ctrl hash is KEPT: the
+        failure-generation counter must stay monotonic across a workspace
+        clear (holes are allowed, reuse is not)."""
+        try:
+            async with self._get_redis_connection() as redis:
+                deleted_count = 0
+                for pattern in (
+                    f"{self.final_namespace}:*",
+                    f"{self._sched_prefix}:status:*",
+                    f"{self._sched_prefix}:basename:*",
+                ):
+                    cursor = 0
+                    while True:
+                        cursor, keys = await redis.scan(
+                            cursor, match=pattern, count=1000
+                        )
+                        if keys:
+                            # Delete keys in batches
+                            pipe = redis.pipeline()
+                            for key in keys:
+                                pipe.delete(key)
+                            results = await pipe.execute()
+                            deleted_count += sum(results)
+
+                        if cursor == 0:
+                            break
 
                 logger.info(
                     f"[{self.workspace}] Dropped {deleted_count} doc status keys from {self.namespace}"

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -2199,7 +2199,17 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         elif status == DocStatus.PROCESSED:
             payload["error_msg"] = ""
 
-        await self.doc_status.upsert({doc_key: payload})
+        if status == DocStatus.FAILED:
+            # Phase 1: FAILED custom-chunk journal rows go through the single
+            # mark_doc_failed funnel too — they are FAILED rows a manual sweep
+            # will encounter, so they must carry a failure generation instead
+            # of leaking generation-0 into every cohort. The backend preserves
+            # an existing row's created_at.
+            failed_fields = dict(payload)
+            failed_fields.pop("status", None)
+            await self.doc_status.mark_doc_failed(doc_key, failed_fields)
+        else:
+            await self.doc_status.upsert({doc_key: payload})
         return payload
 
     async def _union_doc_recovery_anchors(

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -931,9 +931,16 @@ class _PipelineMixin:
                         },
                     }
 
-                # Store duplicate records in doc_status
+                # Store duplicate records in doc_status through the FAILED
+                # funnel (Phase 1): duplicate-attempt markers are FAILED rows
+                # too and must carry a failure generation — a plain upsert
+                # would mint generation-0 rows that fall into every manual
+                # cohort forever. mark_doc_failed conditionally creates the
+                # missing dup-* rows.
+                for dup_record_id, dup_fields in duplicate_docs.items():
+                    dup_fields.pop("status", None)
+                    await self.doc_status.mark_doc_failed(dup_record_id, dup_fields)
                 if duplicate_docs:
-                    await self.doc_status.upsert(duplicate_docs)
                     logger.info(
                         f"Created {len(duplicate_docs)} duplicate document records with track_id: {track_id}"
                     )
@@ -1162,11 +1169,14 @@ class _PipelineMixin:
                 },
             }
 
-        # Store error documents in doc_status
+        # Store error documents through the FAILED funnel (Phase 1): these
+        # rows fail before any PENDING row landed, which is exactly the
+        # conditional-create branch of mark_doc_failed — and they must carry
+        # a failure generation like every other FAILED row.
         if error_docs:
-            await self.doc_status.upsert(error_docs)
-            # Log each error for debugging
             for doc_id, error_doc in error_docs.items():
+                error_doc.pop("status", None)
+                await self.doc_status.mark_doc_failed(doc_id, error_doc)
                 logger.error(
                     f"File processing error: - ID: {doc_id} {error_doc['file_path']}"
                 )
@@ -2079,6 +2089,18 @@ class _PipelineMixin:
                 # also raises; that escape is caught by the finally below (workers
                 # are cleanly cancelled) and the batch aborts as a whole.
                 try:
+                    # Attempt-identity bootstrap (Phase 1, §attempt lifecycle):
+                    # persist a processing_attempt_id BEFORE any step that can
+                    # fail, so mark_doc_failed can stamp failure_attempt_id and
+                    # collapse concurrent/retried failure writes of the same
+                    # attempt idempotently. Idempotent itself: an interrupted
+                    # attempt recovered by a later run reuses the persisted id.
+                    # Mirror it onto the in-memory snapshot: downstream
+                    # transitions rebuild the row FROM status_doc and would
+                    # otherwise strip the freshly persisted id.
+                    status_doc.processing_attempt_id = (
+                        await self.doc_status.ensure_processing_attempt_id(doc_id)
+                    )
                     content_data = await self.full_docs.get_by_id(doc_id) or {}
                 except Exception as e:
                     await self._finalize_doc_failure(
@@ -3857,8 +3879,25 @@ class _PipelineMixin:
                 status_doc, extra=metadata_extra
             ),
         }
+        # Attempt identity survives every transition (Phase 1): these upserts
+        # replace the whole row, so without the carry-over each PARSING/
+        # PROCESSING hop would strip the processing_attempt_id minted at the
+        # batch entry and mark_doc_failed could no longer stamp the failing
+        # attempt. Conditional: never overwrite a persisted id with None.
+        if status_doc.processing_attempt_id:
+            payload["processing_attempt_id"] = status_doc.processing_attempt_id
         if extra_fields:
             payload.update(extra_fields)
+        if status == DocStatus.FAILED:
+            # Phase 1 (memory bounding): every FAILED transition goes through
+            # the single mark_doc_failed funnel so it acquires a failure
+            # generation + attempt CAS — a plain upsert here would mint
+            # generation-0 "new" failures that leak into every manual cohort.
+            # Backends ignore the caller-supplied created_at for existing
+            # rows (immutable sort key), so passing it stays safe.
+            payload.pop("status", None)
+            await self.doc_status.mark_doc_failed(doc_id, payload)
+            return
         await self.doc_status.upsert({doc_id: payload})
 
     async def _raise_if_cancelled(
@@ -4168,33 +4207,36 @@ class _PipelineMixin:
             f"Original doc_id: {original_doc_id}, Status: {original_status}"
         )
 
-        await self.doc_status.upsert(
+        # Phase 1: this in-place primary→duplicate rewrite goes through the
+        # FAILED funnel — it acquires a failure generation and, on backends
+        # with a materialized basename index, atomically releases the row's
+        # own primary mapping (eligible → ineligible transition). The
+        # backend preserves the existing row's created_at.
+        await self.doc_status.mark_doc_failed(
+            doc_id,
             {
-                doc_id: {
-                    "status": DocStatus.FAILED,
-                    "content_summary": (
-                        f"[DUPLICATE:content_hash] Original document: {original_doc_id}"
-                    ),
-                    "content_length": content_length,
-                    "chunks_count": 0,
-                    "chunks_list": [],
-                    "created_at": status_doc.created_at,
-                    "updated_at": now,
-                    "file_path": file_path,
-                    "track_id": status_doc.track_id,
-                    "content_hash": content_hash,
-                    "error_msg": message,
-                    "metadata": doc_status_transition_metadata(
-                        status_doc,
-                        extra={
-                            "is_duplicate": True,
-                            "duplicate_kind": "content_hash",
-                            "original_doc_id": original_doc_id,
-                            "original_track_id": original_track_id,
-                        },
-                    ),
-                }
-            }
+                "content_summary": (
+                    f"[DUPLICATE:content_hash] Original document: {original_doc_id}"
+                ),
+                "content_length": content_length,
+                "chunks_count": 0,
+                "chunks_list": [],
+                "created_at": status_doc.created_at,
+                "updated_at": now,
+                "file_path": file_path,
+                "track_id": status_doc.track_id,
+                "content_hash": content_hash,
+                "error_msg": message,
+                "metadata": doc_status_transition_metadata(
+                    status_doc,
+                    extra={
+                        "is_duplicate": True,
+                        "duplicate_kind": "content_hash",
+                        "original_doc_id": original_doc_id,
+                        "original_track_id": original_track_id,
+                    },
+                ),
+            },
         )
         try:
             await self.full_docs.delete([doc_id])

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -20,6 +20,7 @@ from urllib.parse import quote, unquote, urlsplit
 
 from lightrag.base import DocProcessingStatus, DocStatus, DocStatusStorage
 from lightrag.constants import (
+    CUSTOM_CHUNK_PATCH_METADATA_KEY,
     FILE_EXTRACTION_SUMMARY_PREFIX,
     FULL_DOCS_FORMAT_LIGHTRAG,
     LIGHTRAG_DOC_CONTENT_PREFIX,
@@ -264,12 +265,8 @@ def resolve_doc_status_parse_engine(
     )
 
 
-# Reserved doc_status.metadata key holding the custom-chunk patch journal
-# (issue #3400 Phase 3). While present, the document has an in-flight or
-# failed ainsert_custom_chunks operation: the pipeline must NOT process the
-# row as ordinary ingestion, resets must NOT strip it, and deletion must
-# include its staged chunk IDs.
-CUSTOM_CHUNK_PATCH_METADATA_KEY = "custom_chunk_patch"
+# CUSTOM_CHUNK_PATCH_METADATA_KEY moved to lightrag.constants (imported
+# above) so base.py can share it without an import cycle.
 
 # Public, persistent audit trail for structurally successful but semantically
 # degraded KG recovery. The WebUI uses this key to distinguish a processed

--- a/tests/kg/json_impl/test_json_scheduling_pages.py
+++ b/tests/kg/json_impl/test_json_scheduling_pages.py
@@ -1,0 +1,358 @@
+"""JsonDocStatusStorage Phase 1 scheduling contract tests.
+
+Covers: stable ``(created_at, id)`` keyset order with id tie-break, the
+consumed-position advance (a fully generation-filtered page advances the
+cursor instead of terminating or re-reading), CURSOR_END termination,
+lightweight projection, strict count, targeted field updates, the
+failure-generation write side (reserve-before-publish holes, per-attempt
+idempotency, counter calibration on restore), mode-marker semantics
+(missing/mismatched marker reads MIGRATING — never LEGACY), and the
+primary-row basename contract (duplicate markers invisible).
+"""
+
+import json
+
+import pytest
+
+from lightrag.base import (
+    CURSOR_END,
+    CursorAfter,
+    DocStatus,
+    FailureGenerationMode,
+)
+from lightrag.exceptions import (
+    StorageControlPlaneError,
+    StorageRecordNotFoundError,
+)
+from lightrag.kg.json_doc_status_impl import JsonDocStatusStorage
+from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
+from lightrag.utils import load_json, write_json
+
+pytestmark = pytest.mark.offline
+
+
+class _DummyEmbeddingFunc:
+    embedding_dim = 1
+    max_token_size = 1
+
+    async def __call__(self, texts, **kwargs):
+        return [[0.0] for _ in texts]
+
+
+@pytest.fixture(autouse=True)
+def setup_shared_data():
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
+def _doc(
+    status: str,
+    file_path: str = "a.pdf",
+    created_at: str = "2026-01-01T00:00:00+00:00",
+    **extra,
+) -> dict:
+    row = {
+        "content_summary": "s",
+        "content_length": 10,
+        "file_path": file_path,
+        "status": status,
+        "created_at": created_at,
+        "updated_at": created_at,
+        "metadata": {},
+        "error_msg": None,
+        "chunks_list": [],
+    }
+    row.update(extra)
+    return row
+
+
+async def _storage(tmp_path, rows: dict | None = None) -> JsonDocStatusStorage:
+    storage = JsonDocStatusStorage(
+        namespace="doc_status",
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=_DummyEmbeddingFunc(),
+        workspace="test",
+    )
+    await storage.initialize()
+    if rows:
+        async with storage._storage_lock:
+            storage._data.update(rows)
+    return storage
+
+
+async def _sweep_ids(storage, statuses, *, limit, max_failure_generation=None):
+    """Drive a full sweep, returning ids in consumption order + page count."""
+    ids: list[str] = []
+    pages = 0
+    position = None
+    from lightrag.base import CURSOR_START
+
+    position = CURSOR_START
+    while True:
+        page = await storage.get_docs_by_statuses_page(
+            statuses,
+            limit=limit,
+            position=position,
+            max_failure_generation=max_failure_generation,
+            strict=True,
+        )
+        pages += 1
+        ids.extend(page.docs.keys())
+        if page.next_position is CURSOR_END:
+            return ids, pages
+        position = page.next_position
+        assert isinstance(position, CursorAfter)
+        assert pages < 100, "sweep failed to terminate"
+
+
+@pytest.mark.asyncio
+async def test_page_order_created_at_then_id_tiebreak(tmp_path):
+    storage = await _storage(
+        tmp_path,
+        {
+            "doc-b": _doc("pending", created_at="2026-01-02T00:00:00+00:00"),
+            "doc-a": _doc("pending", created_at="2026-01-02T00:00:00+00:00"),
+            "doc-c": _doc("pending", created_at="2026-01-01T00:00:00+00:00"),
+        },
+    )
+    ids, pages = await _sweep_ids(storage, [DocStatus.PENDING], limit=1)
+    # Oldest created_at first; same-timestamp rows tie-break by id ASC.
+    assert ids == ["doc-c", "doc-a", "doc-b"]
+    assert pages >= 3
+
+
+@pytest.mark.asyncio
+async def test_fully_filtered_page_advances_without_false_end(tmp_path):
+    """Rows dropped by the generation predicate are CONSUMED: the cursor
+    advances past a fully-filtered page and still reaches the eligible row
+    behind it — and never re-reads the filtered rows."""
+    rows = {
+        f"doc-{i:02d}": _doc(
+            "failed",
+            created_at=f"2026-01-01T00:00:0{i % 10}+00:00",
+            failure_generation=100,
+        )
+        for i in range(4)
+    }
+    rows["doc-99"] = _doc(
+        "failed", created_at="2026-01-05T00:00:00+00:00", failure_generation=1
+    )
+    storage = await _storage(tmp_path, rows)
+    ids, pages = await _sweep_ids(
+        storage, [DocStatus.FAILED], limit=2, max_failure_generation=5
+    )
+    assert ids == ["doc-99"]
+    assert pages >= 3  # filtered pages advanced instead of terminating
+
+
+@pytest.mark.asyncio
+async def test_page_projection_is_lightweight_and_mixed_status(tmp_path):
+    storage = await _storage(
+        tmp_path,
+        {
+            "doc-1": _doc(
+                "pending", chunks_list=["c"] * 500, created_at="2026-01-01T00:00:00"
+            ),
+            "doc-2": _doc("processing", created_at="2026-01-02T00:00:00"),
+            "doc-3": _doc("processed", created_at="2026-01-03T00:00:00"),
+        },
+    )
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING, DocStatus.PROCESSING], limit=10, strict=True
+    )
+    assert set(page.docs) == {"doc-1", "doc-2"}
+    assert page.next_position is CURSOR_END
+    record = page.docs["doc-1"]
+    assert not hasattr(record, "chunks_list")
+    assert record.status is DocStatus.PENDING
+    assert record.has_custom_chunk_journal is False
+
+
+@pytest.mark.asyncio
+async def test_count_docs_by_statuses_strict(tmp_path):
+    storage = await _storage(
+        tmp_path,
+        {
+            "doc-1": _doc("pending"),
+            "doc-2": _doc("pending"),
+            "doc-3": _doc("failed"),
+        },
+    )
+    assert await storage.count_docs_by_statuses([DocStatus.PENDING]) == 2
+    assert (
+        await storage.count_docs_by_statuses([DocStatus.PENDING, DocStatus.FAILED]) == 3
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_doc_status_fields_targeted(tmp_path):
+    storage = await _storage(tmp_path, {"doc-1": _doc("failed")})
+    await storage.update_doc_status_fields("doc-1", {"status": "pending"})
+    row = await storage.get_by_id("doc-1")
+    assert row["status"] == "pending"
+    assert row["file_path"] == "a.pdf"  # untouched fields preserved
+    with pytest.raises(ValueError, match="created_at"):
+        await storage.update_doc_status_fields("doc-1", {"created_at": "2030-01-01"})
+    with pytest.raises(StorageRecordNotFoundError):
+        await storage.update_doc_status_fields("missing", {"status": "pending"})
+
+
+@pytest.mark.asyncio
+async def test_mode_enforced_after_init_and_migrating_on_marker_loss(tmp_path):
+    storage = await _storage(tmp_path)
+    assert await storage.get_failure_generation_mode() is FailureGenerationMode.ENFORCED
+    # A lost/corrupt marker on an initialized workspace reads MIGRATING —
+    # never LEGACY (which would reopen the full-snapshot path).
+    write_json({"schema_version": 999, "mode": "enforced"}, storage._ctrl_file_name)
+    assert (
+        await storage.get_failure_generation_mode() is FailureGenerationMode.MIGRATING
+    )
+    import os
+
+    os.unlink(storage._ctrl_file_name)
+    assert (
+        await storage.get_failure_generation_mode() is FailureGenerationMode.MIGRATING
+    )
+    with pytest.raises(StorageControlPlaneError):
+        await storage.reserve_failure_generation()
+
+
+@pytest.mark.asyncio
+async def test_reserve_holes_never_reused_and_persisted(tmp_path):
+    storage = await _storage(tmp_path)
+    g1 = await storage.reserve_failure_generation()
+    g2 = await storage.reserve_failure_generation()
+    assert g2 == g1 + 1
+    # A reservation whose FAILED write never happened stays a hole: the next
+    # reservation continues past it (and survives the persisted counter).
+    ctrl = load_json(storage._ctrl_file_name)
+    assert ctrl["failure_generation_counter"] == g2
+
+
+@pytest.mark.asyncio
+async def test_mark_doc_failed_assigns_generation_and_is_attempt_idempotent(
+    tmp_path,
+):
+    storage = await _storage(
+        tmp_path,
+        {
+            "doc-1": _doc(
+                "processing",
+                created_at="2026-01-01T00:00:00+00:00",
+                processing_attempt_id="attempt-1",
+            )
+        },
+    )
+    g1 = await storage.mark_doc_failed(
+        "doc-1",
+        {"error_msg": "boom", "created_at": "2030-12-31T00:00:00+00:00"},
+    )
+    row = await storage.get_by_id("doc-1")
+    assert row["status"] == "failed"
+    assert row["failure_generation"] == g1 and g1 >= 1
+    assert row["failure_attempt_id"] == "attempt-1"
+    # Immutable sort key: the caller-supplied created_at was ignored.
+    assert row["created_at"] == "2026-01-01T00:00:00+00:00"
+
+    # Same attempt failing again (idempotent retry of the failure write):
+    # the generation must NOT advance.
+    g_again = await storage.mark_doc_failed("doc-1", {"error_msg": "boom2"})
+    assert g_again == g1
+    assert (await storage.get_by_id("doc-1"))["failure_generation"] == g1
+
+    # A NEW attempt failing later gets a fresh, larger generation.
+    await storage.update_doc_status_fields(
+        "doc-1", {"status": "processing", "processing_attempt_id": "attempt-2"}
+    )
+    g2 = await storage.mark_doc_failed("doc-1", {"error_msg": "boom3"})
+    assert g2 > g1
+
+    # Missing row: conditional create (pre-PENDING enqueue errors).
+    g3 = await storage.mark_doc_failed(
+        "ghost",
+        {
+            "error_msg": "early",
+            "created_at": "2026-02-01T00:00:00+00:00",
+            "processing_attempt_id": "attempt-x",
+            "content_summary": "s",
+            "content_length": 0,
+            "file_path": "g.pdf",
+            "updated_at": "2026-02-01T00:00:00+00:00",
+        },
+    )
+    ghost = await storage.get_by_id("ghost")
+    assert ghost["status"] == "failed" and ghost["failure_generation"] == g3 > g2
+
+
+@pytest.mark.asyncio
+async def test_counter_recalibrates_on_restore(tmp_path):
+    """Restore-from-backup: rows carry generations ahead of the ctrl counter
+    → init recalibrates to max(counter, max persisted), keeping reservations
+    monotonic."""
+    storage = await _storage(tmp_path)
+    # upsert flushes the row to disk immediately (doc-status recovery anchor).
+    await storage.upsert({"doc-1": _doc("failed", failure_generation=41)})
+    # Simulate the restored, stale ctrl file.
+    write_json(
+        {
+            "schema_version": JsonDocStatusStorage._CTRL_SCHEMA_VERSION,
+            "mode": "enforced",
+            "failure_generation_counter": 3,
+        },
+        storage._ctrl_file_name,
+    )
+
+    finalize_share_data()
+    initialize_share_data()
+    restored = await _storage(tmp_path)
+    assert await restored.reserve_failure_generation() == 42
+
+
+@pytest.mark.asyncio
+async def test_ensure_processing_attempt_id_atomic(tmp_path):
+    storage = await _storage(tmp_path, {"doc-1": _doc("pending")})
+    first = await storage.ensure_processing_attempt_id("doc-1")
+    assert first and (await storage.ensure_processing_attempt_id("doc-1")) == first
+    with pytest.raises(StorageRecordNotFoundError):
+        await storage.ensure_processing_attempt_id("missing")
+
+
+@pytest.mark.asyncio
+async def test_basename_lookup_returns_primary_only(tmp_path):
+    dup = _doc("failed", file_path="a.pdf")
+    dup["metadata"] = {"is_duplicate": True, "duplicate_kind": "filename"}
+    storage = await _storage(
+        tmp_path,
+        {
+            "dup-1": dup,
+            "doc-primary": _doc("pending", file_path="a.pdf"),
+        },
+    )
+    match = await storage.get_doc_by_file_basename("a.pdf")
+    assert match is not None and match[0] == "doc-primary"
+    strict_match = await storage.get_doc_by_file_basename_strict("a.pdf")
+    assert strict_match is not None and strict_match[0] == "doc-primary"
+
+    # Only the duplicate marker left → the basename is free again.
+    await storage.delete(["doc-primary"])
+    assert await storage.get_doc_by_file_basename("a.pdf") is None
+    assert await storage.get_doc_by_file_basename_strict("a.pdf") is None
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_strict_confirmed_absence(tmp_path):
+    storage = await _storage(tmp_path, {"doc-1": _doc("pending")})
+    assert (await storage.get_by_id_strict("doc-1"))["status"] == "pending"
+    assert await storage.get_by_id_strict("missing") is None
+
+
+@pytest.mark.asyncio
+async def test_malformed_cursor_raises_control_plane_error(tmp_path):
+    storage = await _storage(tmp_path, {"doc-1": _doc("pending")})
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.PENDING],
+            limit=1,
+            position=CursorAfter(json.dumps({"not": "a-pair"})),
+        )

--- a/tests/kg/mongo_impl/test_mongo_scheduling_pages.py
+++ b/tests/kg/mongo_impl/test_mongo_scheduling_pages.py
@@ -251,6 +251,42 @@ async def test_page_relaxed_skip_is_still_consumed_strict_raises():
         )
 
 
+async def test_missing_created_at_encodes_null_bucket_cursor():
+    """A doc whose created_at field is entirely ABSENT keys as (None, _id):
+    encoding it as "" would break the resume filter — {"created_at": ""}
+    matches neither a missing field nor a null value, so a second corrupt
+    doc past a page boundary would silently fall out of the sweep."""
+    from lightrag.kg.mongo_impl import MongoDocStatusStorage
+
+    assert MongoDocStatusStorage._doc_cursor_key({"_id": "doc-x"}) == (None, "doc-x")
+    assert MongoDocStatusStorage._doc_cursor_key(
+        {"_id": "doc-y", "created_at": None}
+    ) == (None, "doc-y")
+
+
+async def test_null_bucket_cursor_resumes_with_missing_matching_predicate():
+    """Cursor inside the missing/null bucket: the resume filter must use
+    {"created_at": None} (matches BOTH missing and null per Mongo $eq:null
+    semantics) plus the $ne:None arm for every later bucket."""
+    data = _FakeCollection(find_docs=[])
+    storage = _storage(data=data)
+
+    await storage.get_docs_by_statuses_page(
+        [DocStatus.FAILED],
+        limit=2,
+        position=CursorAfter(json.dumps([None, "doc-null-1"])),
+    )
+
+    query = data.find_queries[0]
+    (keyset_or,) = query["$and"]
+    assert keyset_or == {
+        "$or": [
+            {"created_at": None, "_id": {"$gt": "doc-null-1"}},
+            {"created_at": {"$ne": None}},
+        ]
+    }
+
+
 async def test_page_malformed_cursor_raises_control_plane_error():
     storage = _storage()
 

--- a/tests/kg/mongo_impl/test_mongo_scheduling_pages.py
+++ b/tests/kg/mongo_impl/test_mongo_scheduling_pages.py
@@ -1,0 +1,544 @@
+"""Offline tests for the Mongo Phase 1 scheduling surface.
+
+Covers the bounded keyset page API (query/sort/limit shape, generation
+predicate, consumed-position cursor advance, malformed-cursor rejection),
+the failure-generation control plane (mode mapping, atomic reservation,
+mark_doc_failed idempotency/CAS shape) and the strict basename/point-read
+alignment. The pymongo collection is driven through minimal in-process
+fakes — no live services.
+"""
+
+import json
+
+import pytest
+
+pytest.importorskip(
+    "pymongo",
+    reason="pymongo is required for Mongo storage tests",
+)
+
+from pymongo.errors import PyMongoError
+
+from lightrag.base import (
+    CURSOR_END,
+    CURSOR_START,
+    CursorAfter,
+    DocStatus,
+    FailureGenerationMode,
+)
+from lightrag.exceptions import StorageControlPlaneError, StorageRecordNotFoundError
+from lightrag.kg.mongo_impl import MongoDocStatusStorage
+
+pytestmark = pytest.mark.offline
+
+_ROW_1 = {
+    "_id": "doc-1",
+    "status": "pending",
+    "created_at": "2026-01-01T00:00:00+00:00",
+    "updated_at": "2026-01-01T00:00:00+00:00",
+    "file_path": "a.txt",
+}
+_ROW_2 = {
+    "_id": "doc-2",
+    "status": "failed",
+    "created_at": "2026-01-02T00:00:00+00:00",
+    "updated_at": "2026-01-02T00:00:00+00:00",
+    "file_path": "b.txt",
+}
+
+
+class _UpdateResult:
+    def __init__(self, matched_count=0, modified_count=0, upserted_id=None):
+        self.matched_count = matched_count
+        self.modified_count = modified_count
+        self.upserted_id = upserted_id
+
+
+class _FakeFindCursor:
+    """Records the find(...).sort(...).limit(...).to_list(...) chain."""
+
+    def __init__(self, docs, error=None):
+        self._docs = list(docs)
+        self._error = error
+        self.sort_spec = None
+        self.limit_value = None
+        self.to_list_length = None
+
+    def sort(self, spec):
+        self.sort_spec = spec
+        return self
+
+    def limit(self, n):
+        self.limit_value = n
+        return self
+
+    async def to_list(self, length=None):
+        self.to_list_length = length
+        if self._error is not None:
+            raise self._error
+        return self._docs
+
+
+class _FakeCollection:
+    """Minimal AsyncCollection stand-in recording every call."""
+
+    def __init__(
+        self,
+        find_docs=(),
+        find_error=None,
+        find_one_result=None,
+        find_one_error=None,
+        update_result=None,
+        find_one_and_update_result=None,
+        find_one_and_update_error=None,
+    ):
+        self._find_docs = find_docs
+        self._find_error = find_error
+        self.find_one_result = find_one_result
+        self.find_one_error = find_one_error
+        self.update_result = update_result or _UpdateResult()
+        self.find_one_and_update_result = find_one_and_update_result
+        self.find_one_and_update_error = find_one_and_update_error
+
+        self.find_queries = []
+        self.find_cursors = []
+        self.find_one_calls = []
+        self.update_one_calls = []
+        self.find_one_and_update_calls = []
+        self.count_documents_calls = []
+
+    def find(self, query, projection=None):
+        self.find_queries.append(query)
+        cursor = _FakeFindCursor(self._find_docs, error=self._find_error)
+        self.find_cursors.append(cursor)
+        return cursor
+
+    async def find_one(self, query, projection=None):
+        self.find_one_calls.append((query, projection))
+        if self.find_one_error is not None:
+            raise self.find_one_error
+        return self.find_one_result
+
+    async def update_one(self, filter, update, upsert=False):
+        self.update_one_calls.append((filter, update, upsert))
+        return self.update_result
+
+    async def find_one_and_update(self, filter, update, upsert=False, **kwargs):
+        self.find_one_and_update_calls.append((filter, update, upsert, kwargs))
+        if self.find_one_and_update_error is not None:
+            raise self.find_one_and_update_error
+        return self.find_one_and_update_result
+
+    async def count_documents(self, query, **kwargs):
+        self.count_documents_calls.append(query)
+        return 42
+
+
+def _storage(data=None, ctrl=None) -> MongoDocStatusStorage:
+    storage = MongoDocStatusStorage.__new__(MongoDocStatusStorage)
+    storage.workspace = "t"
+    storage.namespace = "doc_status"
+    storage._collection_name = "t_doc_status"
+    storage._data = data if data is not None else _FakeCollection()
+    storage._ctrl = ctrl if ctrl is not None else _FakeCollection()
+    return storage
+
+
+# ---------------------------------------------------------------------------
+# get_docs_by_statuses_page: query shape / sort / limit / cursor advance
+# ---------------------------------------------------------------------------
+
+
+async def test_page_start_query_shape_and_cursor_end():
+    data = _FakeCollection(find_docs=[_ROW_1, _ROW_2])
+    storage = _storage(data=data)
+
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.FAILED, DocStatus.PENDING], limit=5, position=CURSOR_START
+    )
+
+    # Query: status $in only — no keyset resume, no generation predicate.
+    assert data.find_queries == [{"status": {"$in": ["failed", "pending"]}}]
+    cursor = data.find_cursors[0]
+    assert cursor.sort_spec == [("created_at", 1), ("_id", 1)]
+    assert cursor.limit_value == 5
+    assert cursor.to_list_length == 5
+
+    assert set(page.docs) == {"doc-1", "doc-2"}
+    # returned (2) < limit (5) proves exhaustion.
+    assert page.next_position is CURSOR_END
+
+
+async def test_page_keyset_and_generation_predicates():
+    data = _FakeCollection(find_docs=[])
+    storage = _storage(data=data)
+    opaque = json.dumps(["2026-01-01T00:00:00+00:00", "doc-1"])
+
+    await storage.get_docs_by_statuses_page(
+        [DocStatus.FAILED],
+        limit=2,
+        position=CursorAfter(opaque),
+        max_failure_generation=7,
+    )
+
+    query = data.find_queries[0]
+    assert query["status"] == {"$in": ["failed"]}
+    keyset_or, generation_or = query["$and"]
+    assert keyset_or == {
+        "$or": [
+            {"created_at": {"$gt": "2026-01-01T00:00:00+00:00"}},
+            {"created_at": "2026-01-01T00:00:00+00:00", "_id": {"$gt": "doc-1"}},
+        ]
+    }
+    # Generation predicate constrains ONLY failed rows; a missing field is
+    # logical 0 and therefore always eligible.
+    assert generation_or == {
+        "$or": [
+            {"status": {"$ne": "failed"}},
+            {"failure_generation": {"$lte": 7}},
+            {"failure_generation": {"$exists": False}},
+        ]
+    }
+
+
+async def test_page_no_generation_predicate_without_cutoff():
+    data = _FakeCollection(find_docs=[])
+    storage = _storage(data=data)
+
+    await storage.get_docs_by_statuses_page([DocStatus.FAILED], limit=2)
+
+    assert "$and" not in data.find_queries[0]
+
+
+async def test_page_full_page_advances_to_last_returned_key():
+    data = _FakeCollection(find_docs=[_ROW_1, _ROW_2])
+    storage = _storage(data=data)
+
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.FAILED, DocStatus.PENDING], limit=2
+    )
+
+    assert isinstance(page.next_position, CursorAfter)
+    assert json.loads(page.next_position.opaque) == [
+        "2026-01-02T00:00:00+00:00",
+        "doc-2",
+    ]
+
+
+async def test_page_relaxed_skip_is_still_consumed_strict_raises():
+    bad_row = {
+        # Missing "status": unconvertible, but query-returned hence consumed.
+        "_id": "doc-bad",
+        "created_at": "2026-01-03T00:00:00+00:00",
+    }
+    data = _FakeCollection(find_docs=[_ROW_1, bad_row])
+    storage = _storage(data=data)
+
+    page = await storage.get_docs_by_statuses_page([DocStatus.PENDING], limit=2)
+
+    # Relaxed: skipped from the page, but the cursor advances past the RAW
+    # last returned doc — never re-read, never falsely terminal.
+    assert set(page.docs) == {"doc-1"}
+    assert isinstance(page.next_position, CursorAfter)
+    assert json.loads(page.next_position.opaque) == [
+        "2026-01-03T00:00:00+00:00",
+        "doc-bad",
+    ]
+
+    with pytest.raises(KeyError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.PENDING], limit=2, strict=True
+        )
+
+
+async def test_page_malformed_cursor_raises_control_plane_error():
+    storage = _storage()
+
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.FAILED], limit=2, position=CursorAfter("not-json")
+        )
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.FAILED],
+            limit=2,
+            position=CursorAfter(json.dumps(["2026-01-01", 3])),
+        )
+
+
+async def test_page_transport_error_propagates():
+    data = _FakeCollection(find_error=PyMongoError("boom"))
+    storage = _storage(data=data)
+
+    with pytest.raises(PyMongoError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.FAILED], limit=2, strict=True
+        )
+
+
+async def test_page_invalid_limit_and_terminal_position():
+    storage = _storage()
+
+    with pytest.raises(ValueError):
+        await storage.get_docs_by_statuses_page([DocStatus.FAILED], limit=0)
+
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.FAILED], limit=2, position=CURSOR_END
+    )
+    assert page.docs == {} and page.next_position is CURSOR_END
+    assert storage._data.find_queries == []  # no query issued
+
+
+# ---------------------------------------------------------------------------
+# count_docs_by_statuses
+# ---------------------------------------------------------------------------
+
+
+async def test_count_docs_by_statuses_counts_server_side():
+    data = _FakeCollection()
+    storage = _storage(data=data)
+
+    count = await storage.count_docs_by_statuses(
+        [DocStatus.PENDING, DocStatus.PROCESSING]
+    )
+
+    assert count == 42
+    assert data.count_documents_calls == [
+        {"status": {"$in": ["pending", "processing"]}}
+    ]
+    assert await storage.count_docs_by_statuses([]) == 0
+
+
+# ---------------------------------------------------------------------------
+# update_doc_status_fields
+# ---------------------------------------------------------------------------
+
+
+async def test_update_fields_rejects_created_at_without_db_call():
+    data = _FakeCollection()
+    storage = _storage(data=data)
+
+    with pytest.raises(ValueError):
+        await storage.update_doc_status_fields("doc-1", {"created_at": "x"})
+    assert data.update_one_calls == []
+
+
+async def test_update_fields_missing_row_raises_unless_missing_ok():
+    data = _FakeCollection(update_result=_UpdateResult(matched_count=0))
+    storage = _storage(data=data)
+
+    with pytest.raises(StorageRecordNotFoundError):
+        await storage.update_doc_status_fields("doc-x", {"status": "pending"})
+
+    await storage.update_doc_status_fields(
+        "doc-x", {"status": "pending"}, missing_ok=True
+    )
+
+    data.update_result = _UpdateResult(matched_count=1)
+    await storage.update_doc_status_fields("doc-1", {"status": "pending"})
+    assert data.update_one_calls[-1] == (
+        {"_id": "doc-1"},
+        {"$set": {"status": "pending"}},
+        False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# mark_doc_failed
+# ---------------------------------------------------------------------------
+
+
+async def test_mark_doc_failed_idempotent_same_attempt_no_reserve():
+    existing = {
+        "_id": "doc-1",
+        "status": "failed",
+        "processing_attempt_id": "att-1",
+        "failure_attempt_id": "att-1",
+        "failure_generation": 5,
+    }
+    data = _FakeCollection(find_one_result=existing)
+    ctrl = _FakeCollection()
+    storage = _storage(data=data, ctrl=ctrl)
+
+    generation = await storage.mark_doc_failed("doc-1", {"error_msg": "boom"})
+
+    assert generation == 5
+    assert ctrl.find_one_and_update_calls == []  # no $inc reserved
+    assert data.find_one_and_update_calls == []  # no publish issued
+
+
+async def test_mark_doc_failed_reserves_and_publishes_conditionally():
+    data = _FakeCollection(find_one_result=None)
+    ctrl = _FakeCollection(
+        find_one_and_update_result={
+            "schema_version": 1,
+            "mode": "enforced",
+            "failure_generation_counter": 9,
+        }
+    )
+    storage = _storage(data=data, ctrl=ctrl)
+
+    generation = await storage.mark_doc_failed(
+        "doc-new",
+        {
+            "processing_attempt_id": "att-2",
+            "created_at": "2026-01-05T00:00:00+00:00",
+            "error_msg": "boom",
+        },
+    )
+
+    assert generation == 9
+    # Reservation is an atomic $inc on the version-guarded ctrl doc.
+    ctrl_filter, ctrl_update, _, _ = ctrl.find_one_and_update_calls[0]
+    assert ctrl_filter == {"_id": "scheduling_ctrl", "schema_version": 1}
+    assert ctrl_update == {"$inc": {"failure_generation_counter": 1}}
+
+    publish_filter, publish_update, upsert, _ = data.find_one_and_update_calls[0]
+    assert upsert is True
+    # CAS guard against a concurrent FAILED publish of the same attempt.
+    assert publish_filter == {
+        "_id": "doc-new",
+        "$nor": [{"status": "failed", "failure_attempt_id": "att-2"}],
+    }
+    set_fields = publish_update["$set"]
+    assert set_fields["status"] == "failed"
+    assert set_fields["failure_generation"] == 9
+    assert set_fields["failure_attempt_id"] == "att-2"
+    assert "created_at" not in set_fields  # immutable for existing rows
+    # created_at lands only via $setOnInsert (conditional create path).
+    assert publish_update["$setOnInsert"]["created_at"] == ("2026-01-05T00:00:00+00:00")
+    assert publish_update["$setOnInsert"]["chunks_list"] == []
+
+
+# ---------------------------------------------------------------------------
+# failure-generation mode + reservation
+# ---------------------------------------------------------------------------
+
+
+async def test_mode_mapping_never_degrades_to_legacy():
+    storage = _storage(ctrl=_FakeCollection(find_one_result=None))
+    assert await storage.get_failure_generation_mode() == (
+        FailureGenerationMode.MIGRATING
+    )
+
+    storage = _storage(
+        ctrl=_FakeCollection(find_one_result={"schema_version": 99, "mode": "enforced"})
+    )
+    assert await storage.get_failure_generation_mode() == (
+        FailureGenerationMode.MIGRATING
+    )
+
+    storage = _storage(
+        ctrl=_FakeCollection(find_one_result={"schema_version": 1, "mode": "weird"})
+    )
+    assert await storage.get_failure_generation_mode() == (
+        FailureGenerationMode.MIGRATING
+    )
+
+    storage = _storage(
+        ctrl=_FakeCollection(find_one_result={"schema_version": 1, "mode": "enforced"})
+    )
+    assert await storage.get_failure_generation_mode() == (
+        FailureGenerationMode.ENFORCED
+    )
+
+
+async def test_mode_transport_error_propagates():
+    storage = _storage(ctrl=_FakeCollection(find_one_error=PyMongoError("down")))
+    with pytest.raises(PyMongoError):
+        await storage.get_failure_generation_mode()
+
+
+async def test_reserve_missing_or_corrupt_ctrl_raises_control_plane_error():
+    # find_one_and_update returning None == ctrl missing or version mismatch.
+    storage = _storage(ctrl=_FakeCollection(find_one_and_update_result=None))
+    with pytest.raises(StorageControlPlaneError):
+        await storage.reserve_failure_generation()
+
+    storage = _storage(
+        ctrl=_FakeCollection(
+            find_one_and_update_result={
+                "schema_version": 1,
+                "failure_generation_counter": "corrupt",
+            }
+        )
+    )
+    with pytest.raises(StorageControlPlaneError):
+        await storage.reserve_failure_generation()
+
+    storage = _storage(
+        ctrl=_FakeCollection(
+            find_one_and_update_result={
+                "schema_version": 1,
+                "failure_generation_counter": 4,
+            }
+        )
+    )
+    assert await storage.reserve_failure_generation() == 4
+
+
+# ---------------------------------------------------------------------------
+# ensure_processing_attempt_id
+# ---------------------------------------------------------------------------
+
+
+async def test_ensure_attempt_id_mints_when_conditional_write_matches():
+    data = _FakeCollection(update_result=_UpdateResult(matched_count=1))
+    storage = _storage(data=data)
+
+    attempt = await storage.ensure_processing_attempt_id("doc-1")
+
+    conditional_filter, update, _ = data.update_one_calls[0]
+    assert conditional_filter["_id"] == "doc-1"
+    assert conditional_filter["$or"] == [
+        {"processing_attempt_id": {"$exists": False}},
+        {"processing_attempt_id": {"$in": [None, ""]}},
+    ]
+    assert update == {"$set": {"processing_attempt_id": attempt}}
+
+
+async def test_ensure_attempt_id_reuses_existing_and_raises_on_missing():
+    data = _FakeCollection(
+        update_result=_UpdateResult(matched_count=0),
+        find_one_result={"_id": "doc-1", "processing_attempt_id": "att-old"},
+    )
+    storage = _storage(data=data)
+    assert await storage.ensure_processing_attempt_id("doc-1") == "att-old"
+
+    data = _FakeCollection(
+        update_result=_UpdateResult(matched_count=0), find_one_result=None
+    )
+    storage = _storage(data=data)
+    with pytest.raises(StorageRecordNotFoundError):
+        await storage.ensure_processing_attempt_id("doc-missing")
+
+
+# ---------------------------------------------------------------------------
+# basename lookup: primary-only filter, strict vs legacy error semantics
+# ---------------------------------------------------------------------------
+
+
+async def test_basename_filter_excludes_duplicates():
+    data = _FakeCollection(find_one_result={"_id": "doc-1", "file_path": "a.txt"})
+    storage = _storage(data=data)
+
+    result = await storage.get_doc_by_file_basename_strict("a.txt")
+
+    assert result == ("doc-1", {"_id": "doc-1", "file_path": "a.txt"})
+    query, _ = data.find_one_calls[0]
+    assert query == {"file_path": "a.txt", "metadata.is_duplicate": {"$ne": True}}
+
+    # Legacy method issues the identical primary-only query.
+    await storage.get_doc_by_file_basename("a.txt")
+    assert data.find_one_calls[1][0] == query
+
+
+async def test_basename_strict_propagates_legacy_swallows():
+    data = _FakeCollection(find_one_error=PyMongoError("down"))
+    storage = _storage(data=data)
+
+    with pytest.raises(PyMongoError):
+        await storage.get_doc_by_file_basename_strict("a.txt")
+
+    # Legacy compat path: same failure reads as a best-effort miss.
+    assert await storage.get_doc_by_file_basename("a.txt") is None

--- a/tests/kg/mongo_impl/test_mongo_storage.py
+++ b/tests/kg/mongo_impl/test_mongo_storage.py
@@ -581,7 +581,11 @@ class TestMongoDocStatusLookup:
         doc_id, doc = result
         assert doc_id == "doc-1"
         assert doc["file_path"] == "report.pdf"
-        storage._data.find_one.assert_awaited_once_with({"file_path": "report.pdf"})
+        # Contract alignment (Phase 1): the lookup returns the PRIMARY row
+        # only, so the query excludes duplicate-attempt markers.
+        storage._data.find_one.assert_awaited_once_with(
+            {"file_path": "report.pdf", "metadata.is_duplicate": {"$ne": True}}
+        )
 
     @pytest.mark.asyncio
     async def test_get_doc_by_file_basename_empty_returns_none_without_query(self):

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -241,6 +241,24 @@ def _mget_by_ids_side_effect(node_sources: dict[str, dict]):
     return _side_effect
 
 
+@pytest.fixture(autouse=True)
+def _skip_scheduling_bootstrap():
+    """Isolate these legacy-behaviour tests from the Phase 1 ctrl bootstrap
+    that ``initialize()`` now runs (it has dedicated coverage in
+    test_os_scheduling_pages.py); the mocked clients here predate it."""
+    with (
+        patch.object(
+            OpenSearchDocStatusStorage,
+            "_create_ctrl_index_if_not_exists",
+            AsyncMock(),
+        ),
+        patch.object(
+            OpenSearchDocStatusStorage, "_bootstrap_scheduling_ctrl", AsyncMock()
+        ),
+    ):
+        yield
+
+
 @pytest.fixture
 def mock_client():
     """Fully-mocked AsyncOpenSearch client fixture."""
@@ -1809,7 +1827,14 @@ class TestDocStatusStorage:
             body = mock_client.search.call_args.kwargs.get(
                 "body"
             ) or mock_client.search.call_args[1].get("body", {})
-            assert body["query"] == {"term": {"file_path": "report.pdf"}}
+            # Primary-row contract (Phase 1): the term query is wrapped in a
+            # bool filter that excludes duplicate-marker rows.
+            assert body["query"] == {
+                "bool": {
+                    "filter": [{"term": {"file_path": "report.pdf"}}],
+                    "must_not": [{"term": {"metadata.is_duplicate": True}}],
+                }
+            }
 
     @pytest.mark.asyncio
     async def test_get_doc_by_file_basename_empty_short_circuits(
@@ -1925,11 +1950,16 @@ class TestDocStatusStorage:
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()
-            mock_client.indices.put_mapping.assert_awaited_once()
-            kwargs = mock_client.indices.put_mapping.call_args.kwargs
-            assert kwargs["body"] == {
-                "properties": {"content_hash": {"type": "keyword"}}
-            }
+            # Two mapping patches now: the legacy content_hash ensure plus the
+            # Phase 1 scheduling fields (failure_generation & attempt ids).
+            payloads = [
+                c.kwargs.get("body") or (c.args[1] if len(c.args) > 1 else {})
+                for c in mock_client.indices.put_mapping.await_args_list
+            ]
+            assert any("content_hash" in p.get("properties", {}) for p in payloads)
+            assert any(
+                "failure_generation" in p.get("properties", {}) for p in payloads
+            )
 
     @pytest.mark.asyncio
     async def test_ensure_content_hash_mapping_skipped_when_present(
@@ -1953,7 +1983,16 @@ class TestDocStatusStorage:
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()
-            mock_client.indices.put_mapping.assert_not_awaited()
+            # content_hash must NOT be re-patched; the Phase 1 scheduling
+            # fields (absent from this mapping) still get their own patch.
+            payloads = [
+                c.kwargs.get("body") or (c.args[1] if len(c.args) > 1 else {})
+                for c in mock_client.indices.put_mapping.await_args_list
+            ]
+            assert not any("content_hash" in p.get("properties", {}) for p in payloads)
+            assert any(
+                "failure_generation" in p.get("properties", {}) for p in payloads
+            )
 
     @pytest.mark.asyncio
     async def test_prepare_doc_status_data(self, global_config, embed_func):

--- a/tests/kg/opensearch_impl/test_opensearch_strict_reads.py
+++ b/tests/kg/opensearch_impl/test_opensearch_strict_reads.py
@@ -95,6 +95,24 @@ class _EmbedFunc:
         raise AssertionError("doc-status/kv reads must not embed")
 
 
+@pytest.fixture(autouse=True)
+def _skip_scheduling_bootstrap():
+    """Isolate these legacy-behaviour tests from the Phase 1 ctrl bootstrap
+    that ``initialize()`` now runs (it has dedicated coverage in
+    test_os_scheduling_pages.py); the mocked clients here predate it."""
+    with (
+        patch.object(
+            OpenSearchDocStatusStorage,
+            "_create_ctrl_index_if_not_exists",
+            AsyncMock(),
+        ),
+        patch.object(
+            OpenSearchDocStatusStorage, "_bootstrap_scheduling_ctrl", AsyncMock()
+        ),
+    ):
+        yield
+
+
 def _make_client() -> AsyncMock:
     client = AsyncMock(spec=AsyncOpenSearch)
     client.indices = AsyncMock()

--- a/tests/kg/opensearch_impl/test_os_scheduling_pages.py
+++ b/tests/kg/opensearch_impl/test_os_scheduling_pages.py
@@ -1,0 +1,1054 @@
+"""OpenSearch Phase-1 scheduling contracts (memory-bounding plan).
+
+Offline coverage for the OpenSearch slice of the bounded-scheduling API:
+
+* ``get_docs_by_statuses_page`` — native ``search_after`` keyset pages
+  sorted ``(created_at ASC, __mirrored_id ASC)``, live-view (no PIT),
+  server-side generation-cohort predicate whose ``must_not exists`` arm
+  keeps legacy docs (no ``failure_generation`` field) eligible, cursor =
+  the last HIT's sort values verbatim, ``hits < limit`` == CURSOR_END.
+* ``count_docs_by_statuses`` — fail-closed ``_count``.
+* ``update_doc_status_fields`` — immutable ``created_at`` + 404 mapping.
+* failure-generation control plane — independent ctrl index, realtime GET
+  + ``if_seq_no/if_primary_term`` CAS with bounded 409 retries, mode
+  marker that NEVER degrades to LEGACY on read failure.
+* ``mark_doc_failed`` — per-attempt idempotency (no counter touch) and
+  CAS retry on conflict (reserved generations become holes, never reused).
+* strict point/identity reads — three-state ``get_by_id_strict`` on both
+  the KV and doc-status classes, and ``get_doc_by_file_basename_strict``
+  raising where the legacy lookup swallows.
+"""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from opensearchpy import AsyncOpenSearch
+from opensearchpy.exceptions import ConflictError, NotFoundError, TransportError
+
+from lightrag.base import (
+    CURSOR_END,
+    CursorAfter,
+    DocStatus,
+    FailureGenerationMode,
+)
+from lightrag.exceptions import (
+    StorageControlPlaneError,
+    StorageRecordNotFoundError,
+)
+from lightrag.kg.opensearch_impl import (
+    ClientManager,
+    OpenSearchDocStatusStorage,
+    OpenSearchKVStorage,
+)
+
+pytestmark = pytest.mark.offline
+
+
+class _mock_lock:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+
+def _missing_index_error() -> NotFoundError:
+    return NotFoundError(404, "index_not_found_exception", "no such index")
+
+
+def _doc_missing_error() -> NotFoundError:
+    # A document-level 404 (GET/update on an existing index): the error body
+    # never mentions index_not_found_exception.
+    return NotFoundError(404, "document_missing_exception", "no such document")
+
+
+def _transient_error() -> TransportError:
+    return TransportError(503, "search_phase_execution_exception", "shard failure")
+
+
+def _conflict_error() -> ConflictError:
+    return ConflictError(409, "version_conflict_engine_exception", "seq_no mismatch")
+
+
+@pytest.fixture(autouse=True)
+def patch_data_init_lock():
+    with patch(
+        "lightrag.kg.opensearch_impl.get_data_init_lock", side_effect=_mock_lock
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def patch_namespace_lock():
+    cache: dict[tuple[str, str | None], asyncio.Lock] = {}
+
+    def factory(namespace, workspace=None, enable_logging=False):
+        key = (namespace, workspace or "")
+        lock = cache.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            cache[key] = lock
+        return lock
+
+    with patch("lightrag.kg.opensearch_impl.get_namespace_lock", side_effect=factory):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def patch_shard_doc_supported():
+    with patch("lightrag.kg.opensearch_impl._shard_doc_supported", True):
+        yield
+
+
+@pytest.fixture
+def global_config():
+    return {
+        "embedding_batch_num": 10,
+        "max_graph_nodes": 1000,
+        "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+    }
+
+
+class _EmbedFunc:
+    embedding_dim = 8
+    max_token_size = 512
+    model_name = "mock-embed"
+
+    async def __call__(self, texts, **kwargs):
+        raise AssertionError("doc-status/kv scheduling paths must not embed")
+
+
+def _ctrl_response(
+    counter: int = 0,
+    mode: str = "enforced",
+    schema_version: int = 1,
+    seq_no: int = 0,
+    primary_term: int = 1,
+) -> dict:
+    return {
+        "_id": "scheduling_ctrl",
+        "found": True,
+        "_seq_no": seq_no,
+        "_primary_term": primary_term,
+        "_source": {
+            "schema_version": schema_version,
+            "mode": mode,
+            "failure_generation_counter": counter,
+        },
+    }
+
+
+def _make_client() -> AsyncMock:
+    client = AsyncMock(spec=AsyncOpenSearch)
+    client.indices = AsyncMock()
+    client.indices.exists = AsyncMock(return_value=True)
+    client.indices.create = AsyncMock()
+    client.indices.get_mapping = AsyncMock(return_value={})
+    client.indices.put_mapping = AsyncMock()
+    # Ctrl bootstrap during initialize(): valid marker, counter already
+    # calibrated (max aggregation answers "no persisted generations").
+    client.get = AsyncMock(return_value=_ctrl_response())
+    client.index = AsyncMock(return_value={})
+    client.update = AsyncMock(return_value={})
+    client.count = AsyncMock(return_value={"count": 0})
+    client.search = AsyncMock(
+        return_value={
+            "hits": {"hits": []},
+            "aggregations": {"max_failure_generation": {"value": None}},
+        }
+    )
+    return client
+
+
+def _status_source(doc_id: str, status: str = "pending", **extra) -> dict:
+    source = {
+        "__mirrored_id": doc_id,
+        "content_summary": f"summary-{doc_id}",
+        "content_length": 10,
+        "file_path": f"{doc_id}.txt",
+        "status": status,
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    source.update(extra)
+    return source
+
+
+def _hit(doc_id: str, source: dict, sort: list | None = None) -> dict:
+    return {"_id": doc_id, "_source": source, "sort": sort or [1767225600000, doc_id]}
+
+
+def _page(hits: list[dict]) -> dict:
+    return {"hits": {"hits": hits}}
+
+
+async def _make_doc_status(global_config, client) -> OpenSearchDocStatusStorage:
+    with patch.object(ClientManager, "get_client", return_value=client):
+        storage = OpenSearchDocStatusStorage(
+            namespace="doc_status",
+            global_config=global_config,
+            embedding_func=_EmbedFunc(),
+            workspace="schedws",
+        )
+        await storage.initialize()
+    return storage
+
+
+async def _make_kv(global_config, client) -> OpenSearchKVStorage:
+    with patch.object(ClientManager, "get_client", return_value=client):
+        storage = OpenSearchKVStorage(
+            namespace="full_docs",
+            global_config=global_config,
+            embedding_func=_EmbedFunc(),
+            workspace="schedws",
+        )
+        await storage.initialize()
+    return storage
+
+
+# ---------------------------------------------------------------------------
+# Capability flags
+# ---------------------------------------------------------------------------
+
+
+def test_capability_flags():
+    assert OpenSearchDocStatusStorage.supports_bounded_scheduling_pages is True
+    assert OpenSearchDocStatusStorage.supports_failure_generation is True
+    assert OpenSearchDocStatusStorage.supports_strict_doc_identity_lookup is True
+    assert OpenSearchDocStatusStorage.supports_strict_point_reads is True
+    assert OpenSearchKVStorage.supports_strict_point_reads is True
+
+
+# ---------------------------------------------------------------------------
+# get_docs_by_statuses_page: body construction
+# ---------------------------------------------------------------------------
+
+
+async def test_page_body_sort_size_and_no_generation_predicate(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(return_value=_page([]))
+
+    await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING, DocStatus.FAILED], limit=25, strict=True
+    )
+
+    kwargs = client.search.call_args.kwargs
+    assert kwargs["index"] == storage._index_name
+    body = kwargs["body"]
+    assert body["sort"] == [
+        {"created_at": {"order": "asc"}},
+        {"__mirrored_id": {"order": "asc"}},
+    ]
+    assert body["size"] == 25
+    assert "search_after" not in body
+    assert body["query"] == {"terms": {"status": ["failed", "pending"]}}
+    # No cutoff → no generation predicate anywhere in the body.
+    assert "failure_generation" not in json.dumps(body)
+
+
+async def test_page_generation_predicate_includes_must_not_exists(global_config):
+    """Legacy docs lack the failure_generation field entirely — the cohort
+    query MUST carry the must_not-exists arm (mapping alone does not make
+    missing read as 0), or every legacy FAILED row silently drops out of the
+    first manual cohort."""
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(return_value=_page([]))
+
+    await storage.get_docs_by_statuses_page(
+        [DocStatus.FAILED, DocStatus.PENDING],
+        limit=10,
+        max_failure_generation=7,
+        strict=True,
+    )
+
+    body = client.search.call_args.kwargs["body"]
+    filters = body["query"]["bool"]["filter"]
+    assert filters[0] == {"terms": {"status": ["failed", "pending"]}}
+    predicate = filters[1]["bool"]
+    assert predicate["minimum_should_match"] == 1
+    should = predicate["should"]
+    # Non-FAILED rows are unaffected by the cohort cutoff.
+    assert {"bool": {"must_not": {"term": {"status": "failed"}}}} in should
+    # Migrated FAILED rows: generation <= cutoff.
+    assert {"range": {"failure_generation": {"lte": 7}}} in should
+    # Legacy FAILED rows WITHOUT the field stay eligible (logical 0).
+    assert {"bool": {"must_not": {"exists": {"field": "failure_generation"}}}} in should
+    assert len(should) == 3
+
+
+async def test_page_search_after_passthrough(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(return_value=_page([]))
+
+    opaque = json.dumps([1767225600000, "doc-9"])
+    await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=5, position=CursorAfter(opaque), strict=True
+    )
+
+    body = client.search.call_args.kwargs["body"]
+    assert body["search_after"] == [1767225600000, "doc-9"]
+
+
+# ---------------------------------------------------------------------------
+# get_docs_by_statuses_page: cursor advance / termination
+# ---------------------------------------------------------------------------
+
+
+async def test_page_full_page_returns_cursor_after_last_hit_sort(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    hits = [
+        _hit("d1", _status_source("d1"), sort=[100, "d1"]),
+        _hit("d2", _status_source("d2"), sort=[200, "d2"]),
+    ]
+    client.search = AsyncMock(return_value=_page(hits))
+
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=2, strict=True
+    )
+
+    assert set(page.docs) == {"d1", "d2"}
+    assert isinstance(page.next_position, CursorAfter)
+    # The cursor is the LAST HIT's sort values verbatim — the natural
+    # consumed frontier for a server-side-filtered search_after sweep.
+    assert page.next_position.opaque == json.dumps([200, "d2"])
+    record = page.docs["d1"]
+    assert record.status is DocStatus.PENDING
+    assert record.created_at == "2026-01-01T00:00:00+00:00"
+    assert record.file_path == "d1.txt"
+    assert record.has_custom_chunk_journal is False
+
+
+async def test_page_short_page_terminates(global_config):
+    """Server-side filtering means returned < size proves exhaustion."""
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(return_value=_page([_hit("d1", _status_source("d1"))]))
+
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=2, strict=True
+    )
+    assert set(page.docs) == {"d1"}
+    assert page.next_position is CURSOR_END
+
+
+async def test_page_empty_page_terminates_and_end_position_short_circuits(
+    global_config,
+):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(return_value=_page([]))
+
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=2, strict=True
+    )
+    assert page.docs == {}
+    assert page.next_position is CURSOR_END
+
+    client.search.reset_mock()
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=2, position=CURSOR_END, strict=True
+    )
+    assert page.docs == {}
+    assert page.next_position is CURSOR_END
+    client.search.assert_not_awaited()
+
+
+async def test_page_invalid_limit_raises(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    with pytest.raises(ValueError):
+        await storage.get_docs_by_statuses_page([DocStatus.PENDING], limit=0)
+
+
+# ---------------------------------------------------------------------------
+# get_docs_by_statuses_page: malformed cursor / strict failure semantics
+# ---------------------------------------------------------------------------
+
+
+async def test_page_malformed_cursor_raises_before_any_rpc(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(return_value=_page([]))
+
+    for bad_opaque in ("not-json", '{"a": 1}', "[1]", '["a", "b", "c"]'):
+        with pytest.raises(StorageControlPlaneError):
+            await storage.get_docs_by_statuses_page(
+                [DocStatus.PENDING],
+                limit=5,
+                position=CursorAfter(bad_opaque),
+                strict=True,
+            )
+    client.search.assert_not_awaited()
+
+
+async def test_page_strict_raises_on_transport_error(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(side_effect=_transient_error())
+    with pytest.raises(TransportError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.PENDING], limit=5, strict=True
+        )
+
+
+async def test_page_strict_raises_when_index_not_ready(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    storage._index_ready = False
+    client.search = AsyncMock(return_value=_page([]))
+
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.PENDING], limit=5, strict=True
+        )
+    client.search.assert_not_awaited()
+
+    # Relaxed mode keeps the best-effort empty-terminal behavior.
+    page = await storage.get_docs_by_statuses_page([DocStatus.PENDING], limit=5)
+    assert page.docs == {}
+    assert page.next_position is CURSOR_END
+
+
+async def test_page_missing_index_is_legitimately_empty(global_config):
+    """Mirrors the existing get_docs_by_statuses strict decision: a live
+    index_not_found is a legitimately empty (complete) sweep."""
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(side_effect=_missing_index_error())
+
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=5, strict=True
+    )
+    assert page.docs == {}
+    assert page.next_position is CURSOR_END
+    assert storage._index_ready is False
+
+
+async def test_page_relaxed_skips_bad_row_strict_raises(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    good = _hit("good", _status_source("good"), sort=[100, "good"])
+    bad_source = _status_source("bad")
+    del bad_source["created_at"]  # unusable scheduling row
+    bad = _hit("bad", bad_source, sort=[200, "bad"])
+
+    client.search = AsyncMock(return_value=_page([good, bad]))
+    with pytest.raises((KeyError, TypeError)):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.PENDING], limit=2, strict=True
+        )
+
+    client.search = AsyncMock(return_value=_page([good, bad]))
+    page = await storage.get_docs_by_statuses_page([DocStatus.PENDING], limit=2)
+    assert set(page.docs) == {"good"}
+    # The skipped row is still CONSUMED: the cursor is the last hit's sort,
+    # so the sweep never re-reads (or worse, loops on) the bad record.
+    assert isinstance(page.next_position, CursorAfter)
+    assert page.next_position.opaque == json.dumps([200, "bad"])
+
+
+# ---------------------------------------------------------------------------
+# count_docs_by_statuses
+# ---------------------------------------------------------------------------
+
+
+async def test_count_uses_count_api_with_status_terms(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.count = AsyncMock(return_value={"count": 42})
+
+    assert (
+        await storage.count_docs_by_statuses([DocStatus.PENDING, DocStatus.FAILED])
+        == 42
+    )
+    kwargs = client.count.call_args.kwargs
+    assert kwargs["index"] == storage._index_name
+    assert kwargs["body"] == {"query": {"terms": {"status": ["failed", "pending"]}}}
+
+    assert await storage.count_docs_by_statuses([]) == 0
+
+
+async def test_count_fails_closed(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+
+    client.count = AsyncMock(side_effect=_transient_error())
+    with pytest.raises(TransportError):
+        await storage.count_docs_by_statuses([DocStatus.PENDING])
+
+    client.count = AsyncMock(return_value={"count": "not-a-number"})
+    with pytest.raises(StorageControlPlaneError):
+        await storage.count_docs_by_statuses([DocStatus.PENDING])
+
+    storage._index_ready = False
+    with pytest.raises(StorageControlPlaneError):
+        await storage.count_docs_by_statuses([DocStatus.PENDING])
+
+
+async def test_count_missing_index_is_zero(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.count = AsyncMock(side_effect=_missing_index_error())
+    assert await storage.count_docs_by_statuses([DocStatus.PENDING]) == 0
+    assert storage._index_ready is False
+
+
+# ---------------------------------------------------------------------------
+# update_doc_status_fields
+# ---------------------------------------------------------------------------
+
+
+async def test_update_fields_rejects_created_at(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    with pytest.raises(ValueError, match="created_at"):
+        await storage.update_doc_status_fields(
+            "doc-1", {"created_at": "2026-02-02T00:00:00+00:00"}
+        )
+    client.update.assert_not_awaited()
+
+
+async def test_update_fields_partial_doc_merge(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    await storage.update_doc_status_fields("doc-1", {"status": "processing"})
+    kwargs = client.update.call_args.kwargs
+    assert kwargs["index"] == storage._index_name
+    assert kwargs["id"] == "doc-1"
+    assert kwargs["body"] == {"doc": {"status": "processing"}}
+    assert kwargs["refresh"] == "wait_for"
+
+
+async def test_update_fields_missing_record(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.update = AsyncMock(side_effect=_doc_missing_error())
+    with pytest.raises(StorageRecordNotFoundError):
+        await storage.update_doc_status_fields("ghost", {"status": "failed"})
+    # missing_ok downgrades the 404 to a no-op.
+    await storage.update_doc_status_fields(
+        "ghost", {"status": "failed"}, missing_ok=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_failure_generation_mode
+# ---------------------------------------------------------------------------
+
+
+async def test_mode_missing_marker_is_migrating(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.get = AsyncMock(side_effect=_doc_missing_error())
+    assert (
+        await storage.get_failure_generation_mode() is FailureGenerationMode.MIGRATING
+    )
+
+
+async def test_mode_bad_schema_or_mode_is_migrating(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+
+    client.get = AsyncMock(return_value=_ctrl_response(schema_version=99))
+    assert (
+        await storage.get_failure_generation_mode() is FailureGenerationMode.MIGRATING
+    )
+
+    client.get = AsyncMock(return_value=_ctrl_response(mode="bogus"))
+    assert (
+        await storage.get_failure_generation_mode() is FailureGenerationMode.MIGRATING
+    )
+
+
+async def test_mode_valid_values_map_through(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+
+    client.get = AsyncMock(return_value=_ctrl_response(mode="enforced"))
+    assert await storage.get_failure_generation_mode() is FailureGenerationMode.ENFORCED
+    kwargs = client.get.call_args.kwargs
+    assert kwargs["index"] == storage._ctrl_index_name
+
+    client.get = AsyncMock(return_value=_ctrl_response(mode="legacy"))
+    assert await storage.get_failure_generation_mode() is FailureGenerationMode.LEGACY
+
+
+async def test_mode_transport_error_raises_never_degrades(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.get = AsyncMock(side_effect=_transient_error())
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_failure_generation_mode()
+
+
+# ---------------------------------------------------------------------------
+# reserve_failure_generation
+# ---------------------------------------------------------------------------
+
+
+async def test_reserve_cas_increments_counter(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.get = AsyncMock(
+        return_value=_ctrl_response(counter=5, seq_no=3, primary_term=2)
+    )
+    client.index = AsyncMock(return_value={})
+
+    assert await storage.reserve_failure_generation() == 6
+
+    kwargs = client.index.call_args.kwargs
+    assert kwargs["index"] == storage._ctrl_index_name
+    assert kwargs["body"]["failure_generation_counter"] == 6
+    assert kwargs["if_seq_no"] == 3
+    assert kwargs["if_primary_term"] == 2
+
+
+async def test_reserve_retries_on_conflict(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.get = AsyncMock(
+        side_effect=[
+            _ctrl_response(counter=5, seq_no=3),
+            _ctrl_response(counter=6, seq_no=4),
+        ]
+    )
+    client.index = AsyncMock(side_effect=[_conflict_error(), {}])
+
+    # Lost the first CAS race to a concurrent reservation; the retry re-reads
+    # the fresh counter and lands 7.
+    assert await storage.reserve_failure_generation() == 7
+    assert client.index.await_count == 2
+
+
+async def test_reserve_missing_or_invalid_marker_raises(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+
+    client.get = AsyncMock(side_effect=_doc_missing_error())
+    with pytest.raises(StorageControlPlaneError):
+        await storage.reserve_failure_generation()
+
+    client.get = AsyncMock(return_value=_ctrl_response(schema_version=99))
+    with pytest.raises(StorageControlPlaneError):
+        await storage.reserve_failure_generation()
+
+
+# ---------------------------------------------------------------------------
+# mark_doc_failed
+# ---------------------------------------------------------------------------
+
+
+def _existing_row(**extra) -> dict:
+    row = {
+        "__mirrored_id": "doc-1",
+        "content_summary": "s",
+        "content_length": 1,
+        "file_path": "doc-1.txt",
+        "status": "processing",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+        "processing_attempt_id": "att-1",
+    }
+    row.update(extra)
+    return row
+
+
+async def test_mark_doc_failed_same_attempt_is_idempotent(global_config):
+    """Already-FAILED with the same attempt returns the existing generation
+    and never touches the counter (no reserve, no publish)."""
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.get = AsyncMock(
+        return_value={
+            "_id": "doc-1",
+            "found": True,
+            "_seq_no": 7,
+            "_primary_term": 1,
+            "_source": _existing_row(
+                status="failed", failure_attempt_id="att-1", failure_generation=4
+            ),
+        }
+    )
+    client.index = AsyncMock(return_value={})
+
+    generation = await storage.mark_doc_failed(
+        "doc-1", {"processing_attempt_id": "att-1", "error_msg": "boom"}
+    )
+    assert generation == 4
+    client.index.assert_not_awaited()
+
+
+async def test_mark_doc_failed_cas_retry_on_conflict(global_config):
+    """A 409 on the FAILED publish re-GETs, re-checks idempotency and
+    retries; the first reserved generation becomes a permanent hole."""
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+
+    ctrl_state = {"counter": 0, "seq": 0}
+    doc_writes: list[dict] = []
+    doc_write_kwargs: list[dict] = []
+
+    async def _route_get(index=None, id=None, **kw):
+        if index == storage._ctrl_index_name:
+            return _ctrl_response(
+                counter=ctrl_state["counter"], seq_no=ctrl_state["seq"]
+            )
+        return {
+            "_id": id,
+            "found": True,
+            "_seq_no": 7,
+            "_primary_term": 1,
+            "_source": _existing_row(),
+        }
+
+    async def _route_index(index=None, id=None, body=None, **kw):
+        if index == storage._ctrl_index_name:
+            ctrl_state["counter"] = body["failure_generation_counter"]
+            ctrl_state["seq"] += 1
+            return {}
+        doc_writes.append(body)
+        doc_write_kwargs.append(kw)
+        if len(doc_writes) == 1:
+            raise _conflict_error()
+        return {}
+
+    client.get = AsyncMock(side_effect=_route_get)
+    client.index = AsyncMock(side_effect=_route_index)
+
+    generation = await storage.mark_doc_failed(
+        "doc-1",
+        {
+            "processing_attempt_id": "att-1",
+            "error_msg": "boom",
+            # Caller-supplied created_at must be IGNORED for existing rows.
+            "created_at": "2030-12-31T00:00:00+00:00",
+        },
+    )
+
+    # First reservation (1) was published into the conflicted write and is a
+    # hole; the retry reserved and published 2.
+    assert generation == 2
+    assert ctrl_state["counter"] == 2
+    assert len(doc_writes) == 2
+    final = doc_writes[-1]
+    assert final["status"] == "failed"
+    assert final["failure_generation"] == 2
+    assert final["failure_attempt_id"] == "att-1"
+    assert final["created_at"] == "2026-01-01T00:00:00+00:00"
+    assert doc_write_kwargs[-1]["if_seq_no"] == 7
+    assert doc_write_kwargs[-1]["if_primary_term"] == 1
+    assert doc_write_kwargs[-1]["refresh"] == "wait_for"
+
+
+async def test_mark_doc_failed_missing_row_conditional_create(global_config):
+    """Parse/enqueue errors can fail before the PENDING row landed: the
+    FAILED record is created with op_type=create so a concurrent create can
+    never be clobbered."""
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+
+    async def _route_get(index=None, id=None, **kw):
+        if index == storage._ctrl_index_name:
+            return _ctrl_response(counter=0, seq_no=0)
+        raise _doc_missing_error()
+
+    create_kwargs: list[dict] = []
+
+    async def _route_index(index=None, id=None, body=None, **kw):
+        if index == storage._ctrl_index_name:
+            return {}
+        create_kwargs.append({"body": body, **kw})
+        return {}
+
+    client.get = AsyncMock(side_effect=_route_get)
+    client.index = AsyncMock(side_effect=_route_index)
+
+    generation = await storage.mark_doc_failed(
+        "doc-new",
+        {
+            "processing_attempt_id": "att-9",
+            "error_msg": "parse exploded",
+            "created_at": "2026-03-01T00:00:00+00:00",
+        },
+    )
+    assert generation == 1
+    assert len(create_kwargs) == 1
+    assert create_kwargs[0]["op_type"] == "create"
+    body = create_kwargs[0]["body"]
+    assert body["status"] == "failed"
+    assert body["failure_generation"] == 1
+    assert body["failure_attempt_id"] == "att-9"
+    assert body["__mirrored_id"] == "doc-new"
+    assert body["chunks_list"] == []
+
+
+# ---------------------------------------------------------------------------
+# ensure_processing_attempt_id
+# ---------------------------------------------------------------------------
+
+
+async def test_ensure_attempt_id_reuses_persisted(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.get = AsyncMock(
+        return_value={
+            "_id": "doc-1",
+            "found": True,
+            "_seq_no": 1,
+            "_primary_term": 1,
+            "_source": _existing_row(processing_attempt_id="att-keep"),
+        }
+    )
+    assert await storage.ensure_processing_attempt_id("doc-1") == "att-keep"
+    client.update.assert_not_awaited()
+
+
+async def test_ensure_attempt_id_mints_with_cas(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    row = _existing_row()
+    row.pop("processing_attempt_id")
+    client.get = AsyncMock(
+        return_value={
+            "_id": "doc-1",
+            "found": True,
+            "_seq_no": 5,
+            "_primary_term": 2,
+            "_source": row,
+        }
+    )
+    minted = await storage.ensure_processing_attempt_id("doc-1")
+    assert isinstance(minted, str) and len(minted) == 32
+    kwargs = client.update.call_args.kwargs
+    assert kwargs["body"] == {"doc": {"processing_attempt_id": minted}}
+    assert kwargs["if_seq_no"] == 5
+    assert kwargs["if_primary_term"] == 2
+
+
+async def test_ensure_attempt_id_conflict_reuses_winner(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    bare = _existing_row()
+    bare.pop("processing_attempt_id")
+    client.get = AsyncMock(
+        side_effect=[
+            {
+                "_id": "doc-1",
+                "found": True,
+                "_seq_no": 5,
+                "_primary_term": 2,
+                "_source": bare,
+            },
+            {
+                "_id": "doc-1",
+                "found": True,
+                "_seq_no": 6,
+                "_primary_term": 2,
+                "_source": _existing_row(processing_attempt_id="att-winner"),
+            },
+        ]
+    )
+    client.update = AsyncMock(side_effect=_conflict_error())
+    assert await storage.ensure_processing_attempt_id("doc-1") == "att-winner"
+
+
+async def test_ensure_attempt_id_missing_record(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.get = AsyncMock(side_effect=_doc_missing_error())
+    with pytest.raises(StorageRecordNotFoundError):
+        await storage.ensure_processing_attempt_id("ghost")
+
+
+# ---------------------------------------------------------------------------
+# KV get_by_id_strict: three-state contract
+# ---------------------------------------------------------------------------
+
+
+async def test_kv_strict_pending_delete_is_confirmed_absent(global_config):
+    client = _make_client()
+    storage = await _make_kv(global_config, client)
+    client.mget = AsyncMock()
+    await storage.upsert({"doc-1": {"content": "x"}})
+    await storage.delete(["doc-1"])
+    assert await storage.get_by_id_strict("doc-1") is None
+    client.mget.assert_not_awaited()
+
+
+async def test_kv_strict_pending_upsert_is_present(global_config):
+    client = _make_client()
+    storage = await _make_kv(global_config, client)
+    client.mget = AsyncMock()
+    await storage.upsert({"doc-1": {"content": "x"}})
+    doc = await storage.get_by_id_strict("doc-1")
+    assert doc["content"] == "x"
+    assert doc["_id"] == "doc-1"
+    client.mget.assert_not_awaited()
+
+
+async def test_kv_strict_index_not_ready_raises(global_config):
+    client = _make_client()
+    storage = await _make_kv(global_config, client)
+    storage._index_ready = False
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_by_id_strict("doc-1")
+    # The relaxed read keeps its best-effort miss behavior.
+    assert await storage.get_by_id("doc-1") is None
+
+
+async def test_kv_strict_transport_error_raises(global_config):
+    client = _make_client()
+    storage = await _make_kv(global_config, client)
+    client.mget = AsyncMock(side_effect=_transient_error())
+    with pytest.raises(TransportError):
+        await storage.get_by_id_strict("doc-1")
+
+
+async def test_kv_strict_missing_index_raises(global_config):
+    """get_by_id reads a missing index as a miss; the strict variant cannot
+    positively confirm absence there and must raise."""
+    client = _make_client()
+    storage = await _make_kv(global_config, client)
+    client.mget = AsyncMock(side_effect=_missing_index_error())
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_by_id_strict("doc-1")
+    assert storage._index_ready is False
+
+
+async def test_kv_strict_healthy_miss_is_none(global_config):
+    client = _make_client()
+    storage = await _make_kv(global_config, client)
+    client.mget = AsyncMock(return_value={"docs": [{"_id": "doc-1", "found": False}]})
+    assert await storage.get_by_id_strict("doc-1") is None
+
+
+# ---------------------------------------------------------------------------
+# Doc-status get_by_id_strict
+# ---------------------------------------------------------------------------
+
+
+async def test_doc_status_strict_point_read_three_state(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+
+    client.mget = AsyncMock(return_value={"docs": [{"_id": "doc-1", "found": False}]})
+    assert await storage.get_by_id_strict("doc-1") is None
+
+    client.mget = AsyncMock(side_effect=_transient_error())
+    with pytest.raises(TransportError):
+        await storage.get_by_id_strict("doc-1")
+    # The relaxed read swallows the same error as a miss.
+    client.mget = AsyncMock(side_effect=_transient_error())
+    assert await storage.get_by_id("doc-1") is None
+
+    client.mget = AsyncMock(side_effect=_missing_index_error())
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_by_id_strict("doc-1")
+
+    storage._index_ready = False
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_by_id_strict("doc-1")
+
+
+# ---------------------------------------------------------------------------
+# Basename lookups: primary-only + strict variant
+# ---------------------------------------------------------------------------
+
+
+async def test_basename_queries_exclude_duplicate_rows(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(return_value=_page([]))
+
+    assert await storage.get_doc_by_file_basename("report.pdf") is None
+    body = client.search.call_args.kwargs["body"]
+    assert body["query"]["bool"]["filter"] == [{"term": {"file_path": "report.pdf"}}]
+    assert body["query"]["bool"]["must_not"] == [
+        {"term": {"metadata.is_duplicate": True}}
+    ]
+
+    client.search.reset_mock()
+    assert await storage.get_doc_by_file_basename_strict("report.pdf") is None
+    strict_body = client.search.call_args.kwargs["body"]
+    assert strict_body == body
+
+
+async def test_basename_strict_raises_where_legacy_swallows(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+
+    client.search = AsyncMock(side_effect=_transient_error())
+    assert await storage.get_doc_by_file_basename("report.pdf") is None
+
+    client.search = AsyncMock(side_effect=_transient_error())
+    with pytest.raises(TransportError):
+        await storage.get_doc_by_file_basename_strict("report.pdf")
+
+    client.search = AsyncMock(side_effect=_missing_index_error())
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_doc_by_file_basename_strict("report.pdf")
+
+    storage._index_ready = False
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_doc_by_file_basename_strict("report.pdf")
+
+    # Sentinel basenames are confirmed-absent without any lookup.
+    assert await storage.get_doc_by_file_basename_strict("") is None
+    assert await storage.get_doc_by_file_basename_strict("unknown_source") is None
+
+
+async def test_basename_strict_returns_primary_hit(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    source = _status_source("doc-1", status="processed")
+    client.search = AsyncMock(return_value=_page([_hit("doc-1", source)]))
+    result = await storage.get_doc_by_file_basename_strict("doc-1.txt")
+    assert result == ("doc-1", source)
+
+
+# ---------------------------------------------------------------------------
+# Ctrl bootstrap at initialize()
+# ---------------------------------------------------------------------------
+
+
+async def test_bootstrap_seeds_marker_from_max_aggregation(global_config):
+    client = _make_client()
+    client.get = AsyncMock(side_effect=_doc_missing_error())
+    client.search = AsyncMock(
+        return_value={"aggregations": {"max_failure_generation": {"value": 9.0}}}
+    )
+    storage = await _make_doc_status(global_config, client)
+
+    ctrl_creates = [
+        call.kwargs
+        for call in client.index.await_args_list
+        if call.kwargs.get("index") == storage._ctrl_index_name
+    ]
+    assert len(ctrl_creates) == 1
+    assert ctrl_creates[0]["op_type"] == "create"
+    assert ctrl_creates[0]["body"] == {
+        "schema_version": 1,
+        "mode": "enforced",
+        "failure_generation_counter": 9,
+    }
+
+
+async def test_bootstrap_recalibrates_counter_behind_persisted_rows(global_config):
+    client = _make_client()
+    client.get = AsyncMock(return_value=_ctrl_response(counter=3, seq_no=11))
+    client.search = AsyncMock(
+        return_value={"aggregations": {"max_failure_generation": {"value": 9.0}}}
+    )
+    storage = await _make_doc_status(global_config, client)
+
+    kwargs = client.index.call_args.kwargs
+    assert kwargs["index"] == storage._ctrl_index_name
+    assert kwargs["body"]["failure_generation_counter"] == 9
+    assert kwargs["if_seq_no"] == 11

--- a/tests/kg/postgres_impl/test_pg_scheduling_pages.py
+++ b/tests/kg/postgres_impl/test_pg_scheduling_pages.py
@@ -193,10 +193,68 @@ async def test_malformed_cursor_raises_control_plane_error(opaque):
         )
 
 
-async def test_encode_cursor_null_created_at_fails_closed():
+async def test_null_created_at_encodes_null_bucket_cursor():
+    """NULL created_at rows (corrupt writes) sort FIRST and stay reachable:
+    the cursor encodes [null, id] instead of failing closed — a row-value
+    comparison would otherwise starve them out of every later page."""
     storage = _storage()
-    with pytest.raises(StorageControlPlaneError):
-        storage._encode_cursor(_page_row(created_at=None))
+    opaque = storage._encode_cursor(_page_row(doc_id="doc-n", created_at=None))
+    assert json.loads(opaque) == [None, "doc-n"]
+    assert storage._decode_cursor(opaque) == (None, "doc-n")
+
+
+async def test_null_bucket_cursor_resumes_through_null_rows():
+    """Cursor inside the NULL bucket: remaining NULL rows continue by id,
+    then all real-timestamp rows — nothing is silently excluded."""
+    db = _FakeDB(results=[[]])
+    storage = _storage(db)
+    await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING],
+        limit=10,
+        position=CursorAfter(json.dumps([None, "doc-n"])),
+        strict=True,
+    )
+    sql, params, _ = db.calls[0]
+    assert "(created_at IS NULL AND id > $3) OR created_at IS NOT NULL" in sql
+    assert "ORDER BY created_at ASC NULLS FIRST, id ASC" in sql
+    assert params[2] == "doc-n"
+
+
+async def test_string_cursor_excludes_consumed_null_bucket():
+    db = _FakeDB(results=[[]])
+    storage = _storage(db)
+    await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING],
+        limit=10,
+        position=CursorAfter(json.dumps(["2026-01-01T00:00:00", "doc-1"])),
+        strict=True,
+    )
+    sql, _, _ = db.calls[0]
+    assert "created_at IS NOT NULL AND (created_at, id) >" in sql
+    assert "NULLS FIRST" in sql
+
+
+async def test_null_created_at_row_reachable_across_page_boundary():
+    """Fix-proof for the starvation bug: a NULL created_at row that fills a
+    page still yields a cursor that reaches the NEXT rows (bucket-aware
+    keyset), instead of a NULL-poisoned row-value comparison."""
+    null_row = _page_row(doc_id="doc-null", created_at=None)
+    real_row = _page_row(doc_id="doc-real")
+    db = _FakeDB(results=[[null_row], [real_row], []])
+    storage = _storage(db)
+    page1 = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=1, strict=False
+    )
+    # The corrupt row is consumed (skipped from the projection in relaxed
+    # mode) and the cursor advances into the NULL bucket.
+    assert page1.docs == {}
+    assert isinstance(page1.next_position, CursorAfter)
+    page2 = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=1, position=page1.next_position, strict=False
+    )
+    assert set(page2.docs) == {"doc-real"}
+    sql2, _, _ = db.calls[1]
+    assert "created_at IS NULL AND id >" in sql2
 
 
 # ---------------------------------------------------------------------------
@@ -215,7 +273,7 @@ async def test_page_sql_keyset_shape_without_cursor_or_cutoff():
 
     sql, params, multirows = db.calls[0]
     assert multirows is True
-    assert "ORDER BY created_at ASC, id ASC" in sql
+    assert "ORDER BY created_at ASC NULLS FIRST, id ASC" in sql
     assert "status = ANY($2)" in sql
     assert "(created_at, id) >" not in sql
     # Generation predicate must appear ONLY when a cutoff is given.
@@ -237,7 +295,7 @@ async def test_page_sql_with_cursor_and_generation_cutoff():
     sql, params, _ = db.calls[0]
     assert "(created_at, id) > ($3::timestamp, $4)" in sql
     assert "(status != $5 OR COALESCE(failure_generation, 0) <= $6)" in sql
-    assert "ORDER BY created_at ASC, id ASC LIMIT $7" in sql
+    assert "ORDER BY created_at ASC NULLS FIRST, id ASC LIMIT $7" in sql
     assert params[2] == _TS  # decoded back to the naive-UTC stored form
     assert params[3] == "doc-1"
     assert params[4] == DocStatus.FAILED.value

--- a/tests/kg/postgres_impl/test_pg_scheduling_pages.py
+++ b/tests/kg/postgres_impl/test_pg_scheduling_pages.py
@@ -1,0 +1,585 @@
+"""PGDocStatusStorage memory-bounding scheduling API (Phase 1) — offline.
+
+Covers the PG slice of the cursor-page contract against a mocked ``self.db``
+(same ``__new__`` + fake-db pattern as
+tests/kg/test_doc_status_strict_parse_branches.py — no live PostgreSQL):
+
+* cursor encode/decode round-trip + malformed cursor fails closed;
+* keyset page SQL shape (ORDER BY, row-value comparison, generation
+  predicate only when a cutoff is given) and CURSOR_END/CursorAfter
+  termination semantics;
+* update_doc_status_fields immutable created_at + missing-row contract;
+* mark_doc_failed idempotency / one-transaction reserve+publish / immutable
+  created_at / conditional create;
+* failure-generation mode mapping (missing row / bad schema_version / value
+  parse / DB error propagation);
+* basename lookup excludes duplicate-marker rows;
+* strict point reads + capability flags.
+"""
+
+import datetime
+import json
+
+import pytest
+
+from lightrag.base import (
+    CURSOR_END,
+    CURSOR_START,
+    CursorAfter,
+    DocStatus,
+    FailureGenerationMode,
+)
+from lightrag.exceptions import (
+    StorageControlPlaneError,
+    StorageRecordNotFoundError,
+)
+from lightrag.kg.postgres_impl import PGDocStatusStorage, PGKVStorage
+
+pytestmark = pytest.mark.offline
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeDB:
+    """Records query/execute calls; serves queued results (or raises them)."""
+
+    def __init__(self, results=None):
+        self.results = list(results or [])
+        self.calls: list[tuple[str, list, bool]] = []
+        self.execute_calls: list[tuple[str, dict | None]] = []
+
+    async def query(self, sql, params=None, multirows=False, **kwargs):
+        self.calls.append((sql, params, multirows))
+        if self.results:
+            result = self.results.pop(0)
+        else:
+            result = [] if multirows else None
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    async def execute(self, sql, data=None, **kwargs):
+        self.execute_calls.append((sql, data))
+
+
+class _ExplodingDB:
+    """Any DB touch is a test failure (used to prove pre-DB validation)."""
+
+    async def query(self, *args, **kwargs):  # pragma: no cover - guard
+        raise AssertionError("db.query must not be called")
+
+    async def execute(self, *args, **kwargs):  # pragma: no cover - guard
+        raise AssertionError("db.execute must not be called")
+
+
+class _FakeTransaction:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeConnection:
+    """Minimal asyncpg connection for the mark_doc_failed transaction."""
+
+    def __init__(self, status_row=None, next_generation=5):
+        self.status_row = status_row
+        self.next_generation = next_generation
+        self.fetchrow_calls: list[tuple[str, tuple]] = []
+        self.execute_calls: list[tuple[str, tuple]] = []
+
+    def transaction(self):
+        return _FakeTransaction()
+
+    async def fetchrow(self, sql, *args):
+        self.fetchrow_calls.append((sql, args))
+        if "FROM LIGHTRAG_DOC_STATUS" in sql:
+            return self.status_row
+        if "LIGHTRAG_DOC_SCHEDULING_CTRL" in sql:
+            return {"failure_generation_counter": self.next_generation}
+        raise AssertionError(f"unexpected fetchrow: {sql}")
+
+    async def execute(self, sql, *args):
+        self.execute_calls.append((sql, args))
+        return "UPDATE 1"
+
+    def counter_updates(self):
+        return [
+            c for c in self.fetchrow_calls if "LIGHTRAG_DOC_SCHEDULING_CTRL" in c[0]
+        ]
+
+
+class _FakeDBWithConnection:
+    def __init__(self, connection):
+        self.connection = connection
+
+    async def _run_with_retry(self, operation, **kwargs):
+        return await operation(self.connection)
+
+
+def _storage(db=None) -> PGDocStatusStorage:
+    storage = PGDocStatusStorage.__new__(PGDocStatusStorage)
+    storage.workspace = "ws"
+    storage.namespace = "doc_status"
+    storage.db = db if db is not None else _FakeDB()
+    return storage
+
+
+_TS = datetime.datetime(2026, 1, 2, 3, 4, 5, 123456)
+
+
+def _page_row(doc_id="doc-1", created_at=_TS, **overrides):
+    row = {
+        "id": doc_id,
+        "status": "pending",
+        "created_at": created_at,
+        "updated_at": created_at,
+        "file_path": f"{doc_id}.pdf",
+        "track_id": None,
+        "metadata": "{}",
+        "failure_generation": 0,
+    }
+    row.update(overrides)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Cursor encode/decode
+# ---------------------------------------------------------------------------
+
+
+async def test_cursor_round_trip_preserves_exact_key():
+    storage = _storage()
+    opaque = storage._encode_cursor(_page_row())
+    created, doc_id = storage._decode_cursor(opaque)
+    # Naive-UTC datetime as stored in the TIMESTAMP column, microseconds kept.
+    assert created == _TS
+    assert created.tzinfo is None
+    assert doc_id == "doc-1"
+
+
+async def test_decode_cursor_normalizes_timezone_aware_iso():
+    storage = _storage()
+    aware = "2026-01-02T04:04:05.123456+01:00"
+    created, _ = storage._decode_cursor(json.dumps([aware, "doc-1"]))
+    assert created == _TS
+    assert created.tzinfo is None
+
+
+@pytest.mark.parametrize(
+    "opaque",
+    [
+        "not json",
+        '["only-one"]',
+        '["2026-01-01T00:00:00+00:00", 5]',
+        '[123, "doc-1"]',
+        '["not-a-date", "doc-1"]',
+        '["2026-01-01T00:00:00", "a", "extra"]',
+        "{}",
+    ],
+)
+async def test_malformed_cursor_raises_control_plane_error(opaque):
+    storage = _storage(_ExplodingDB())
+    with pytest.raises(StorageControlPlaneError):
+        storage._decode_cursor(opaque)
+    # And through the page API: rejected before any DB round-trip.
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.PENDING], limit=10, position=CursorAfter(opaque), strict=True
+        )
+
+
+async def test_encode_cursor_null_created_at_fails_closed():
+    storage = _storage()
+    with pytest.raises(StorageControlPlaneError):
+        storage._encode_cursor(_page_row(created_at=None))
+
+
+# ---------------------------------------------------------------------------
+# Page SQL shape + termination
+# ---------------------------------------------------------------------------
+
+
+async def test_page_sql_keyset_shape_without_cursor_or_cutoff():
+    db = _FakeDB(results=[[]])
+    storage = _storage(db)
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING, DocStatus.FAILED], limit=10, strict=True
+    )
+    assert page.docs == {}
+    assert page.next_position is CURSOR_END
+
+    sql, params, multirows = db.calls[0]
+    assert multirows is True
+    assert "ORDER BY created_at ASC, id ASC" in sql
+    assert "status = ANY($2)" in sql
+    assert "(created_at, id) >" not in sql
+    # Generation predicate must appear ONLY when a cutoff is given.
+    assert "COALESCE(failure_generation, 0)" not in sql
+    assert params == ["ws", ["pending", "failed"], 10]
+
+
+async def test_page_sql_with_cursor_and_generation_cutoff():
+    db = _FakeDB(results=[[]])
+    storage = _storage(db)
+    opaque = storage._encode_cursor(_page_row())
+    await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING, DocStatus.FAILED],
+        limit=10,
+        position=CursorAfter(opaque),
+        max_failure_generation=7,
+        strict=True,
+    )
+    sql, params, _ = db.calls[0]
+    assert "(created_at, id) > ($3::timestamp, $4)" in sql
+    assert "(status != $5 OR COALESCE(failure_generation, 0) <= $6)" in sql
+    assert "ORDER BY created_at ASC, id ASC LIMIT $7" in sql
+    assert params[2] == _TS  # decoded back to the naive-UTC stored form
+    assert params[3] == "doc-1"
+    assert params[4] == DocStatus.FAILED.value
+    assert params[5] == 7
+    assert params[6] == 10
+
+
+async def test_page_full_returns_cursor_after_last_returned_row():
+    rows = [_page_row("doc-1"), _page_row("doc-2", created_at=_TS.replace(hour=9))]
+    db = _FakeDB(results=[rows])
+    storage = _storage(db)
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=2, strict=True
+    )
+    assert set(page.docs) == {"doc-1", "doc-2"}
+    assert isinstance(page.next_position, CursorAfter)
+    created, doc_id = storage._decode_cursor(page.next_position.opaque)
+    assert (created, doc_id) == (_TS.replace(hour=9), "doc-2")
+    # Projection sanity: lightweight record, ISO timestamps with tz info.
+    record = page.docs["doc-1"]
+    assert record.status is DocStatus.PENDING
+    assert record.created_at == "2026-01-02T03:04:05.123456+00:00"
+    assert record.file_path == "doc-1.pdf"
+    assert record.has_custom_chunk_journal is False
+
+
+async def test_page_short_read_terminates_with_cursor_end():
+    db = _FakeDB(results=[[_page_row("doc-1")]])
+    storage = _storage(db)
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=2, strict=True
+    )
+    assert set(page.docs) == {"doc-1"}
+    assert page.next_position is CURSOR_END
+
+
+async def test_page_relaxed_skips_unusable_row_but_row_stays_consumed():
+    bad = _page_row("doc-bad", created_at=None)
+    good = _page_row("doc-good", created_at=_TS.replace(hour=9))
+    db = _FakeDB(results=[[bad, good]])
+    storage = _storage(db)
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=2, strict=False
+    )
+    assert set(page.docs) == {"doc-good"}
+    # Cursor still advances past the whole SQL-returned frontier.
+    assert isinstance(page.next_position, CursorAfter)
+    _, doc_id = storage._decode_cursor(page.next_position.opaque)
+    assert doc_id == "doc-good"
+
+
+async def test_page_strict_raises_on_unusable_row_without_cursor():
+    bad = _page_row("doc-bad", created_at=None)
+    db = _FakeDB(results=[[bad, _page_row("doc-good")]])
+    storage = _storage(db)
+    with pytest.raises(TypeError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.PENDING], limit=2, strict=True
+        )
+
+
+async def test_page_argument_validation_before_db():
+    storage = _storage(_ExplodingDB())
+    with pytest.raises(ValueError):
+        await storage.get_docs_by_statuses_page([DocStatus.PENDING], limit=0)
+    empty = await storage.get_docs_by_statuses_page([], limit=5)
+    assert empty.docs == {} and empty.next_position is CURSOR_END
+    ended = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=5, position=CURSOR_END
+    )
+    assert ended.docs == {} and ended.next_position is CURSOR_END
+
+
+async def test_page_db_error_propagates():
+    db = _FakeDB(results=[RuntimeError("boom")])
+    storage = _storage(db)
+    with pytest.raises(RuntimeError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.PENDING], limit=5, position=CURSOR_START, strict=True
+        )
+
+
+# ---------------------------------------------------------------------------
+# count_docs_by_statuses
+# ---------------------------------------------------------------------------
+
+
+async def test_count_docs_by_statuses_returns_int_and_fails_closed():
+    db = _FakeDB(results=[{"count": 3}])
+    storage = _storage(db)
+    assert await storage.count_docs_by_statuses([DocStatus.PENDING]) == 3
+    sql, params, _ = db.calls[0]
+    assert "COUNT(*)" in sql and "status = ANY($2)" in sql
+    assert params == ["ws", ["pending"]]
+
+    assert await storage.count_docs_by_statuses([]) == 0
+
+    # queue exhausted → fake returns None → fail-closed control-plane error
+    with pytest.raises(StorageControlPlaneError):
+        await storage.count_docs_by_statuses([DocStatus.PENDING])
+
+
+async def test_count_docs_by_statuses_db_error_propagates():
+    db = _FakeDB(results=[ConnectionError("down")])
+    storage = _storage(db)
+    with pytest.raises(ConnectionError):
+        await storage.count_docs_by_statuses([DocStatus.PENDING])
+
+
+# ---------------------------------------------------------------------------
+# update_doc_status_fields
+# ---------------------------------------------------------------------------
+
+
+async def test_update_fields_rejects_created_at_and_unknown_columns():
+    storage = _storage(_ExplodingDB())
+    with pytest.raises(ValueError, match="created_at"):
+        await storage.update_doc_status_fields("d1", {"created_at": "2026"})
+    with pytest.raises(ValueError, match="unknown"):
+        await storage.update_doc_status_fields("d1", {"evil; DROP": "x"})
+
+
+async def test_update_fields_sql_shape_and_serialization():
+    db = _FakeDB(results=[{"id": "d1"}])
+    storage = _storage(db)
+    await storage.update_doc_status_fields(
+        "d1", {"status": "processing", "metadata": {"k": 1}, "chunks_list": ["c1"]}
+    )
+    sql, params, _ = db.calls[0]
+    assert sql.startswith("UPDATE LIGHTRAG_DOC_STATUS SET ")
+    assert "WHERE workspace=$1 AND id=$2 RETURNING id" in sql
+    assert params[0] == "ws" and params[1] == "d1"
+    assert params[2] == "processing"
+    assert params[3] == json.dumps({"k": 1})  # JSONB serialized like upsert
+    assert params[4] == json.dumps(["c1"])
+
+
+async def test_update_fields_missing_row_contract():
+    storage = _storage(_FakeDB(results=[None, None]))
+    with pytest.raises(StorageRecordNotFoundError):
+        await storage.update_doc_status_fields("ghost", {"status": "failed"})
+    # missing_ok suppresses only the not-found outcome
+    await storage.update_doc_status_fields(
+        "ghost", {"status": "failed"}, missing_ok=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# mark_doc_failed
+# ---------------------------------------------------------------------------
+
+
+async def test_mark_doc_failed_idempotent_same_attempt_keeps_generation():
+    conn = _FakeConnection(
+        status_row={
+            "status": "failed",
+            "processing_attempt_id": "a1",
+            "failure_attempt_id": "a1",
+            "failure_generation": 7,
+        }
+    )
+    storage = _storage(_FakeDBWithConnection(conn))
+    generation = await storage.mark_doc_failed(
+        "d1", {"processing_attempt_id": "a1", "error_msg": "x"}
+    )
+    assert generation == 7
+    assert conn.counter_updates() == []  # no counter touch
+    assert conn.execute_calls == []  # no row rewrite either
+
+
+async def test_mark_doc_failed_existing_row_reserves_and_updates():
+    conn = _FakeConnection(
+        status_row={
+            "status": "processing",
+            "processing_attempt_id": "a1",
+            "failure_attempt_id": None,
+            "failure_generation": 0,
+        },
+        next_generation=9,
+    )
+    storage = _storage(_FakeDBWithConnection(conn))
+    generation = await storage.mark_doc_failed(
+        "d1", {"error_msg": "x", "created_at": "2020-01-01T00:00:00+00:00"}
+    )
+    assert generation == 9
+    assert len(conn.counter_updates()) == 1
+    sql, args = conn.execute_calls[0]
+    assert sql.startswith("UPDATE LIGHTRAG_DOC_STATUS SET ")
+    # Immutable sort key: caller-supplied created_at is IGNORED.
+    assert "created_at" not in sql
+    assert "status = $" in sql and "failure_generation = $" in sql
+    assert "failure_attempt_id = $" in sql
+    assert DocStatus.FAILED.value in args
+    assert 9 in args
+    assert "a1" in args  # failure_attempt_id = the row's persisted attempt
+
+
+async def test_mark_doc_failed_missing_row_conditional_create():
+    conn = _FakeConnection(status_row=None, next_generation=3)
+    storage = _storage(_FakeDBWithConnection(conn))
+    generation = await storage.mark_doc_failed(
+        "d1",
+        {
+            "processing_attempt_id": "a9",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "error_msg": "parse blew up",
+        },
+    )
+    assert generation == 3
+    sql, args = conn.execute_calls[0]
+    assert sql.startswith("INSERT INTO LIGHTRAG_DOC_STATUS")
+    assert "ON CONFLICT (id, workspace) DO UPDATE SET" in sql
+    # created_at IS inserted for a brand-new row ...
+    assert "created_at" in sql.split("ON CONFLICT")[0]
+    # ... but never overwritten when a concurrent insert won the race.
+    assert "created_at = EXCLUDED.created_at" not in sql
+    assert "failure_attempt_id" in sql
+    assert DocStatus.FAILED.value in args
+
+
+async def test_mark_doc_failed_rejects_unknown_columns():
+    storage = _storage(_ExplodingDB())
+    with pytest.raises(ValueError, match="unknown"):
+        await storage.mark_doc_failed("d1", {"nope": 1})
+
+
+# ---------------------------------------------------------------------------
+# failure-generation mode + reservation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("ctrl_row", "expected"),
+    [
+        (None, FailureGenerationMode.MIGRATING),  # missing row after init
+        (
+            {"schema_version": 99, "mode": "enforced"},
+            FailureGenerationMode.MIGRATING,
+        ),  # unknown marker version
+        (
+            {"schema_version": 1, "mode": "enforced"},
+            FailureGenerationMode.ENFORCED,
+        ),
+        (
+            {"schema_version": 1, "mode": "legacy"},
+            FailureGenerationMode.LEGACY,
+        ),
+        (
+            {"schema_version": 1, "mode": "totally-bogus"},
+            FailureGenerationMode.MIGRATING,
+        ),  # unparsable value
+    ],
+)
+async def test_get_failure_generation_mode_mapping(ctrl_row, expected):
+    storage = _storage(_FakeDB(results=[ctrl_row]))
+    assert await storage.get_failure_generation_mode() is expected
+
+
+async def test_get_failure_generation_mode_db_error_propagates():
+    storage = _storage(_FakeDB(results=[ConnectionError("marker read failed")]))
+    with pytest.raises(ConnectionError):
+        await storage.get_failure_generation_mode()  # never degrades to LEGACY
+
+
+async def test_reserve_failure_generation_counter_row_not_sequence():
+    db = _FakeDB(results=[{"failure_generation_counter": 42}])
+    storage = _storage(db)
+    assert await storage.reserve_failure_generation() == 42
+    sql, params, _ = db.calls[0]
+    assert "UPDATE LIGHTRAG_DOC_SCHEDULING_CTRL" in sql
+    assert "RETURNING failure_generation_counter" in sql
+    assert "nextval" not in sql  # review ruling: counter row, never a sequence
+    assert params == ["ws", 1]
+
+
+async def test_reserve_failure_generation_missing_marker_fails_closed():
+    storage = _storage(_FakeDB(results=[None]))
+    with pytest.raises(StorageControlPlaneError):
+        await storage.reserve_failure_generation()
+
+
+# ---------------------------------------------------------------------------
+# ensure_processing_attempt_id
+# ---------------------------------------------------------------------------
+
+
+async def test_ensure_processing_attempt_id_cas_and_missing():
+    db = _FakeDB(results=[{"processing_attempt_id": "persisted"}, None])
+    storage = _storage(db)
+    assert await storage.ensure_processing_attempt_id("d1") == "persisted"
+    sql, params, _ = db.calls[0]
+    assert "COALESCE(processing_attempt_id, $3)" in sql
+    assert "RETURNING processing_attempt_id" in sql
+    assert params[0] == "ws" and params[1] == "d1" and params[2]
+
+    with pytest.raises(StorageRecordNotFoundError):
+        await storage.ensure_processing_attempt_id("ghost")
+
+
+# ---------------------------------------------------------------------------
+# basename lookup: primary-row-only + strict variants
+# ---------------------------------------------------------------------------
+
+
+async def test_basename_query_excludes_duplicate_marker_rows():
+    db = _FakeDB(results=[[]])
+    storage = _storage(db)
+    assert await storage.get_doc_by_file_basename("report.pdf") is None
+    sql, params, _ = db.calls[0]
+    assert "COALESCE((metadata->>'is_duplicate')::boolean, false) = false" in sql
+    assert "ORDER BY created_at ASC, id ASC LIMIT 1" in sql
+    assert params == ["ws", "report.pdf"]
+
+
+async def test_basename_strict_delegates_and_propagates_errors():
+    db = _FakeDB(results=[[]])
+    storage = _storage(db)
+    assert await storage.get_doc_by_file_basename_strict("report.pdf") is None
+    assert "is_duplicate" in db.calls[0][0]
+
+    failing = _storage(_FakeDB(results=[ConnectionError("down")]))
+    with pytest.raises(ConnectionError):
+        await failing.get_doc_by_file_basename_strict("report.pdf")
+
+
+# ---------------------------------------------------------------------------
+# strict point reads + capability flags
+# ---------------------------------------------------------------------------
+
+
+async def test_doc_status_get_by_id_strict_confirmed_absent_or_raise():
+    storage = _storage(_FakeDB(results=[None]))
+    assert await storage.get_by_id_strict("ghost") is None
+
+    failing = _storage(_FakeDB(results=[ConnectionError("down")]))
+    with pytest.raises(ConnectionError):
+        await failing.get_by_id_strict("d1")
+
+
+def test_capability_flags():
+    assert PGDocStatusStorage.supports_bounded_scheduling_pages is True
+    assert PGDocStatusStorage.supports_failure_generation is True
+    assert PGDocStatusStorage.supports_strict_doc_identity_lookup is True
+    assert PGDocStatusStorage.supports_strict_point_reads is True
+    assert PGKVStorage.supports_strict_point_reads is True

--- a/tests/kg/redis_impl/fake_redis.py
+++ b/tests/kg/redis_impl/fake_redis.py
@@ -1,0 +1,279 @@
+"""In-memory stand-in for the ``redis.asyncio`` surface RedisDocStatusStorage
+uses — including the Phase 1 scheduling sidecar surface: WATCH/MULTI
+transactions with real conflict detection (per-key version counters →
+``WatchError``), ZSETs with lexicographic range reads, and hashes.
+
+Shared by the doc-status lookup tests and the scheduling-page tests so the
+fake's semantics stay consistent. Deliberately implements only the subset the
+storage class calls; unknown commands fail loudly.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from redis.exceptions import WatchError
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store: dict[str, str] = {}
+        self.zsets: dict[str, set[str]] = defaultdict(set)
+        self.hashes: dict[str, dict[str, str]] = defaultdict(dict)
+        self.versions: dict[str, int] = defaultdict(int)
+        # Test hook: raise this exception on the next matching command.
+        self.fail_next: dict[str, Exception] = {}
+
+    # -- version bookkeeping (WATCH support) --------------------------------
+    def _bump(self, key: str) -> None:
+        self.versions[key] += 1
+
+    def _maybe_fail(self, command: str) -> None:
+        exc = self.fail_next.pop(command, None)
+        if exc is not None:
+            raise exc
+
+    # -- immediate commands ---------------------------------------------------
+    async def ping(self):
+        return True
+
+    async def get(self, key: str):
+        self._maybe_fail("get")
+        return self.store.get(key)
+
+    async def set(self, key: str, value: str, nx: bool = False, ex: int | None = None):
+        self._maybe_fail("set")
+        if nx and key in self.store:
+            return None
+        self.store[key] = str(value)
+        self._bump(key)
+        return True
+
+    async def delete(self, *keys: str) -> int:
+        count = 0
+        for key in keys:
+            existed = False
+            if key in self.store:
+                self.store.pop(key)
+                existed = True
+            if key in self.zsets:
+                self.zsets.pop(key)
+                existed = True
+            if key in self.hashes:
+                self.hashes.pop(key)
+                existed = True
+            if existed:
+                self._bump(key)
+                count += 1
+        return count
+
+    async def scan(self, cursor: int = 0, match: str = "", count: int = 1000):
+        prefix = match[:-1] if match.endswith("*") else match
+        # Real SCAN iterates keys of every type (strings, zsets, hashes).
+        all_keys = list(self.store) + list(self.zsets) + list(self.hashes)
+        keys = [k for k in dict.fromkeys(all_keys) if k.startswith(prefix)]
+        return 0, keys
+
+    def scan_iter(self, **kwargs):
+        match = kwargs.get("match", "")
+        prefix = match[:-1] if match.endswith("*") else match
+        keys = [k for k in self.store if k.startswith(prefix)]
+
+        async def _aiter():
+            for k in keys:
+                yield k
+
+        return _aiter()
+
+    async def hgetall(self, key: str) -> dict[str, str]:
+        self._maybe_fail("hgetall")
+        return dict(self.hashes.get(key, {}))
+
+    async def hset(self, key: str, field: str | None = None, value=None, mapping=None):
+        self._maybe_fail("hset")
+        if mapping is not None:
+            for f, v in mapping.items():
+                self.hashes[key][f] = str(v)
+        else:
+            self.hashes[key][field] = str(value)
+        self._bump(key)
+        return 1
+
+    async def zcard(self, key: str) -> int:
+        self._maybe_fail("zcard")
+        return len(self.zsets.get(key, ()))
+
+    async def zrangebylex(
+        self, key: str, lex_min: str, lex_max: str, start=0, num=None
+    ):
+        return self._zrangebylex(key, lex_min, lex_max, start, num)
+
+    # -- shared op appliers ---------------------------------------------------
+    def _zrangebylex(self, key, lex_min, lex_max, start=0, num=None):
+        members = sorted(self.zsets.get(key, ()))
+        if lex_min == "-":
+            lo = members
+        elif lex_min.startswith("("):
+            pivot = lex_min[1:]
+            lo = [m for m in members if m > pivot]
+        elif lex_min.startswith("["):
+            pivot = lex_min[1:]
+            lo = [m for m in members if m >= pivot]
+        else:  # pragma: no cover - storage always uses -,( or [
+            raise ValueError(f"bad lex_min {lex_min!r}")
+        if lex_max != "+":  # pragma: no cover - storage always uses +
+            raise ValueError(f"bad lex_max {lex_max!r}")
+        if num is None:
+            return lo[start:]
+        return lo[start : start + num]
+
+    def _apply(self, op: tuple) -> Any:
+        kind = op[0]
+        if kind == "get":
+            return self.store.get(op[1])
+        if kind == "set":
+            self.store[op[1]] = op[2]
+            self._bump(op[1])
+            return True
+        if kind == "delete":
+            existed = op[1] in self.store or op[1] in self.zsets or op[1] in self.hashes
+            self.store.pop(op[1], None)
+            self.zsets.pop(op[1], None)
+            self.hashes.pop(op[1], None)
+            if existed:
+                self._bump(op[1])
+            return 1 if existed else 0
+        if kind == "exists":
+            return 1 if op[1] in self.store else 0
+        if kind == "zadd":
+            key, member_map = op[1], op[2]
+            for member in member_map:
+                self.zsets[key].add(member)
+            self._bump(key)
+            return len(member_map)
+        if kind == "zrem":
+            key, member = op[1], op[2]
+            removed = member in self.zsets.get(key, set())
+            self.zsets.get(key, set()).discard(member)
+            self._bump(key)
+            return 1 if removed else 0
+        if kind == "zcard":
+            return len(self.zsets.get(op[1], ()))
+        if kind == "zrangebylex":
+            return self._zrangebylex(*op[1:])
+        if kind == "hset":
+            key, field, value = op[1], op[2], op[3]
+            self.hashes[key][field] = str(value)
+            self._bump(key)
+            return 1
+        if kind == "hgetall":
+            return dict(self.hashes.get(op[1], {}))
+        raise ValueError(f"FakeRedis: unsupported op {kind}")  # pragma: no cover
+
+    def pipeline(self, transaction: bool = True):
+        return FakePipeline(self)
+
+
+class FakePipeline:
+    """Supports BOTH usage styles the storage class exercises:
+
+    * buffered batch: ``pipe.get(k); ...; await pipe.execute()``
+    * transactional: ``await pipe.watch(k)`` (immediate reads) →
+      ``pipe.multi()`` (queued writes) → ``await pipe.execute()`` with real
+      WATCH conflict detection via per-key version snapshots.
+    """
+
+    def __init__(self, fake: FakeRedis):
+        self._fake = fake
+        self._ops: list[tuple] = []
+        self._watched: dict[str, int] = {}
+        self._immediate = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self._ops.clear()
+        self._watched.clear()
+        return False
+
+    async def watch(self, *keys: str):
+        self._immediate = True
+        for key in keys:
+            self._watched[key] = self._fake.versions[key]
+
+    async def unwatch(self):
+        self._watched.clear()
+        self._immediate = False
+
+    def multi(self):
+        self._immediate = False
+
+    def _command(self, op: tuple):
+        if self._immediate:
+
+            async def _run():
+                self._fake._maybe_fail(op[0])
+                return (
+                    self._fake._apply(op)
+                    if op[0] != "get"
+                    else self._fake.store.get(op[1])
+                )
+
+            return _run()
+        self._ops.append(op)
+        return self
+
+    def get(self, key: str):
+        if self._immediate:
+            # Delegate to the top-level async method so tests can intercept
+            # immediate WATCH-mode reads by patching FakeRedis.get.
+            return self._fake.get(key)
+        self._ops.append(("get", key))
+        return self
+
+    def hgetall(self, key: str):
+        if self._immediate:
+            return self._fake.hgetall(key)
+        self._ops.append(("hgetall", key))
+        return self
+
+    def set(self, key: str, value: str):
+        return self._command(("set", key, value))
+
+    def delete(self, key: str):
+        return self._command(("delete", key))
+
+    def exists(self, key: str):
+        return self._command(("exists", key))
+
+    def zadd(self, key: str, member_map: dict):
+        return self._command(("zadd", key, member_map))
+
+    def zrem(self, key: str, member: str):
+        return self._command(("zrem", key, member))
+
+    def zcard(self, key: str):
+        return self._command(("zcard", key))
+
+    def zrangebylex(self, key: str, lex_min: str, lex_max: str, start=0, num=None):
+        return self._command(("zrangebylex", key, lex_min, lex_max, start, num))
+
+    def hset(self, key: str, field: str, value):
+        return self._command(("hset", key, field, value))
+
+    async def execute(self):
+        self._fake._maybe_fail("execute")
+        for key, version in self._watched.items():
+            if self._fake.versions[key] != version:
+                self._watched.clear()
+                self._ops.clear()
+                raise WatchError(f"watched key changed: {key}")
+        results = []
+        for op in self._ops:
+            self._fake._maybe_fail(op[0])
+            results.append(self._fake._apply(op))
+        self._ops.clear()
+        self._watched.clear()
+        return results

--- a/tests/kg/redis_impl/test_redis_doc_status_lookup.py
+++ b/tests/kg/redis_impl/test_redis_doc_status_lookup.py
@@ -15,6 +15,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from lightrag.base import DocStatus
+
+from .fake_redis import FakeRedis
 from lightrag.namespace import NameSpace
 
 pytestmark = pytest.mark.offline
@@ -44,104 +46,11 @@ def _doc(status: str, file_path: str, content_hash: str | None = None) -> dict:
     return payload
 
 
-class _FakePipeline:
-    """Mimics redis.asyncio pipeline: commands are queued synchronously and
-    executed in batch via ``await execute()``."""
-
-    def __init__(self, store: dict[str, str]):
-        self._store = store
-        self._ops: list[tuple] = []
-
-    def get(self, key: str) -> None:
-        self._ops.append(("get", key))
-
-    def set(self, key: str, value: str) -> None:
-        self._ops.append(("set", key, value))
-
-    def exists(self, key: str) -> None:
-        self._ops.append(("exists", key))
-
-    def delete(self, key: str) -> None:
-        self._ops.append(("delete", key))
-
-    async def execute(self) -> list:
-        results = []
-        for op in self._ops:
-            kind = op[0]
-            if kind == "get":
-                results.append(self._store.get(op[1]))
-            elif kind == "set":
-                self._store[op[1]] = op[2]
-                results.append(True)
-            elif kind == "exists":
-                results.append(1 if op[1] in self._store else 0)
-            elif kind == "delete":
-                existed = op[1] in self._store
-                self._store.pop(op[1], None)
-                results.append(1 if existed else 0)
-        self._ops.clear()
-        return results
-
-
-class _FakeRedis:
-    """Tiny in-memory stand-in for the bits of ``redis.asyncio.Redis`` that
-    ``RedisDocStatusStorage`` actually calls."""
-
-    def __init__(self):
-        self.store: dict[str, str] = {}
-
-    async def ping(self):
-        return True
-
-    async def scan(self, *args, **kwargs):
-        # Signature: scan(cursor, match=..., count=...). args holds the cursor
-        # positional; we ignore it and return single-shot results (cursor=0)
-        # so callers stop looping.
-        _ = args
-        match = kwargs.get("match", "")
-        if match.endswith("*"):
-            prefix = match[:-1]
-            keys = [k for k in self.store if k.startswith(prefix)]
-        else:
-            keys = [k for k in self.store if k == match]
-        return 0, keys
-
-    def scan_iter(self, **kwargs):
-        # Used by is_empty(); returns an async iterator.
-        match = kwargs.get("match", "")
-        prefix = match[:-1] if match.endswith("*") else match
-        keys = [k for k in self.store if k.startswith(prefix)]
-
-        async def _aiter():
-            for k in keys:
-                yield k
-
-        return _aiter()
-
-    def pipeline(self):
-        return _FakePipeline(self.store)
-
-    async def get(self, key: str):
-        return self.store.get(key)
-
-    async def set(self, key: str, value: str):
-        self.store[key] = value
-        return True
-
-    async def delete(self, *keys: str) -> int:
-        count = 0
-        for k in keys:
-            if k in self.store:
-                self.store.pop(k)
-                count += 1
-        return count
-
-
 @pytest.fixture
 def redis_doc_status(monkeypatch):
     """Construct RedisDocStatusStorage with its Redis client replaced by a
     fake in-memory store. No network I/O occurs."""
-    fake = _FakeRedis()
+    fake = FakeRedis()
 
     # Stub out the connection pool factory so __post_init__ does not invoke
     # the real redis-py ConnectionPool.from_url (which is lazy but still
@@ -181,7 +90,11 @@ def _store_raw(storage, doc_id: str, payload: dict) -> None:
 
 
 async def test_get_doc_by_file_basename_returns_tuple_on_hit(redis_doc_status):
-    _store_raw(redis_doc_status, "doc-1", _doc(DocStatus.PROCESSED.value, "report.pdf"))
+    # Written via upsert: the basename primary index (Phase 1 sidecar) is the
+    # lookup's single source of truth and is maintained atomically by writes.
+    await redis_doc_status.upsert(
+        {"doc-1": _doc(DocStatus.PROCESSED.value, "report.pdf")}
+    )
 
     result = await redis_doc_status.get_doc_by_file_basename("report.pdf")
 

--- a/tests/kg/redis_impl/test_redis_scheduling_pages.py
+++ b/tests/kg/redis_impl/test_redis_scheduling_pages.py
@@ -1,0 +1,390 @@
+"""RedisDocStatusStorage Phase 1 scheduling contract tests (offline fake).
+
+Covers: sidecar migration on initialize (streaming build + marker published
+last), per-status ZSET keyset pages with the composite per-status cursor and
+consumed-position advance, O(1) ZCARD counts, atomic WATCH/MULTI writes
+(status transitions move ZSET members; the basename primary index follows
+the eligibility state machine — including the post-parse content-duplicate
+in-place transition), reserve-before-publish with zero window in
+mark_doc_failed, per-attempt idempotency, and fail-closed strict lookups.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from redis.exceptions import RedisError
+
+from lightrag.base import (
+    CURSOR_END,
+    CURSOR_START,
+    CursorAfter,
+    DocStatus,
+    FailureGenerationMode,
+)
+from lightrag.exceptions import (
+    StorageControlPlaneError,
+    StorageRecordNotFoundError,
+)
+from lightrag.namespace import NameSpace
+
+from .fake_redis import FakeRedis
+
+pytestmark = pytest.mark.offline
+
+
+class _DummyEmbeddingFunc:
+    embedding_dim = 1
+    max_token_size = 1
+
+    async def __call__(self, texts, **kwargs):
+        return [[0.0] for _ in texts]
+
+
+def _doc(
+    status: str,
+    file_path: str = "a.pdf",
+    created_at: str = "2026-01-01T00:00:00+00:00",
+    **extra,
+) -> dict:
+    row = {
+        "content_summary": "s",
+        "content_length": 10,
+        "file_path": file_path,
+        "status": status,
+        "created_at": created_at,
+        "updated_at": created_at,
+        "metadata": {},
+        "error_msg": None,
+        "chunks_list": [],
+    }
+    row.update(extra)
+    return row
+
+
+@pytest.fixture
+def storage(monkeypatch):
+    fake = FakeRedis()
+    monkeypatch.setattr(
+        "lightrag.kg.redis_impl.RedisConnectionManager.get_pool",
+        lambda redis_url: MagicMock(name="fake_pool"),
+    )
+    monkeypatch.setattr(
+        "lightrag.kg.redis_impl.Redis", lambda connection_pool=None, **_: fake
+    )
+    from lightrag.kg.redis_impl import RedisDocStatusStorage
+
+    instance = RedisDocStatusStorage(
+        namespace=NameSpace.DOC_STATUS,
+        global_config={},
+        embedding_func=_DummyEmbeddingFunc(),
+        workspace="test",
+    )
+    instance._initialized = True
+    return instance
+
+
+async def _bootstrap(storage):
+    """Publish the ctrl marker the way initialize()'s migration would."""
+    await storage._migrate_scheduling_sidecar()
+
+
+async def _sweep_ids(storage, statuses, *, limit, max_failure_generation=None):
+    ids: list[str] = []
+    pages = 0
+    position = CURSOR_START
+    while True:
+        page = await storage.get_docs_by_statuses_page(
+            statuses,
+            limit=limit,
+            position=position,
+            max_failure_generation=max_failure_generation,
+            strict=True,
+        )
+        pages += 1
+        ids.extend(page.docs.keys())
+        if page.next_position is CURSOR_END:
+            return ids, pages
+        position = page.next_position
+        assert isinstance(position, CursorAfter)
+        assert pages < 100, "sweep failed to terminate"
+
+
+@pytest.mark.asyncio
+async def test_migration_builds_sidecar_and_publishes_marker_last(storage):
+    # Pre-existing deployment: raw rows only, no sidecar.
+    fake = storage._redis
+    fake.store[f"{storage.final_namespace}:doc-1"] = json.dumps(
+        _doc("pending", file_path="a.pdf")
+    )
+    fake.store[f"{storage.final_namespace}:doc-2"] = json.dumps(
+        _doc("failed", file_path="b.pdf", failure_generation=7)
+    )
+    dup = _doc("failed", file_path="a.pdf")
+    dup["metadata"] = {"is_duplicate": True}
+    fake.store[f"{storage.final_namespace}:dup-1"] = json.dumps(dup)
+
+    await _bootstrap(storage)
+
+    assert await storage.get_failure_generation_mode() is FailureGenerationMode.ENFORCED
+    # Counter calibrated to max persisted generation.
+    assert await storage.reserve_failure_generation() == 8
+    # ZSETs populated; duplicate marker rows are NOT in the basename index.
+    assert await storage.count_docs_by_statuses([DocStatus.PENDING]) == 1
+    assert await storage.count_docs_by_statuses([DocStatus.FAILED]) == 2
+    match = await storage.get_doc_by_file_basename_strict("a.pdf")
+    assert match is not None and match[0] == "doc-1"
+    # Re-running the migration is a no-op (marker present).
+    await _bootstrap(storage)
+    assert await storage.count_docs_by_statuses([DocStatus.PENDING]) == 1
+
+
+@pytest.mark.asyncio
+async def test_missing_marker_reads_migrating_never_legacy(storage):
+    assert (
+        await storage.get_failure_generation_mode() is FailureGenerationMode.MIGRATING
+    )
+    with pytest.raises(StorageControlPlaneError):
+        await storage.reserve_failure_generation()
+
+
+@pytest.mark.asyncio
+async def test_page_kway_merge_and_consumed_position(storage):
+    await _bootstrap(storage)
+    await storage.upsert(
+        {
+            "doc-c": _doc("pending", created_at="2026-01-01T00:00:00+00:00"),
+            "doc-a": _doc("failed", created_at="2026-01-02T00:00:00+00:00"),
+            "doc-b": _doc("pending", created_at="2026-01-03T00:00:00+00:00"),
+        }
+    )
+    ids, pages = await _sweep_ids(
+        storage, [DocStatus.PENDING, DocStatus.FAILED], limit=1
+    )
+    # Global (created_at, id) order across BOTH status streams.
+    assert ids == ["doc-c", "doc-a", "doc-b"]
+    assert pages >= 3
+
+
+@pytest.mark.asyncio
+async def test_page_prefetched_head_not_consumed(storage):
+    """With limit=1 and two streams, the losing stream's prefetched head is
+    NOT consumed — it must reappear on the next page (no skips)."""
+    await _bootstrap(storage)
+    await storage.upsert(
+        {
+            "doc-p": _doc("pending", created_at="2026-01-01T00:00:00+00:00"),
+            "doc-f": _doc("failed", created_at="2026-01-01T00:00:00+00:00"),
+        }
+    )
+    page1 = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING, DocStatus.FAILED], limit=1, strict=True
+    )
+    # (same created_at) id tie-break: doc-f < doc-p
+    assert list(page1.docs) == ["doc-f"]
+    page2 = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING, DocStatus.FAILED],
+        limit=1,
+        position=page1.next_position,
+        strict=True,
+    )
+    assert list(page2.docs) == ["doc-p"]
+
+
+@pytest.mark.asyncio
+async def test_generation_filtered_page_advances_without_false_end(storage):
+    await _bootstrap(storage)
+    rows = {
+        f"doc-{i:02d}": _doc(
+            "failed",
+            created_at=f"2026-01-01T00:00:0{i}+00:00",
+            failure_generation=100,
+        )
+        for i in range(4)
+    }
+    rows["doc-99"] = _doc(
+        "failed", created_at="2026-01-05T00:00:00+00:00", failure_generation=1
+    )
+    await storage.upsert(rows)
+    ids, pages = await _sweep_ids(
+        storage, [DocStatus.FAILED], limit=2, max_failure_generation=5
+    )
+    assert ids == ["doc-99"]
+    assert pages >= 3
+
+
+@pytest.mark.asyncio
+async def test_status_transition_moves_zset_membership(storage):
+    await _bootstrap(storage)
+    await storage.upsert({"doc-1": _doc("pending")})
+    await storage.update_doc_status_fields("doc-1", {"status": "processing"})
+    assert await storage.count_docs_by_statuses([DocStatus.PENDING]) == 0
+    assert await storage.count_docs_by_statuses([DocStatus.PROCESSING]) == 1
+    ids, _ = await _sweep_ids(storage, [DocStatus.PROCESSING], limit=10)
+    assert ids == ["doc-1"]
+    with pytest.raises(ValueError, match="created_at"):
+        await storage.update_doc_status_fields("doc-1", {"created_at": "2030-01-01"})
+    with pytest.raises(StorageRecordNotFoundError):
+        await storage.update_doc_status_fields("missing", {"status": "pending"})
+
+
+@pytest.mark.asyncio
+async def test_basename_index_eligibility_state_machine(storage):
+    await _bootstrap(storage)
+    await storage.upsert({"doc-1": _doc("pending", file_path="a.pdf")})
+    assert (await storage.get_doc_by_file_basename_strict("a.pdf"))[0] == "doc-1"
+
+    # eligible → ineligible IN PLACE: the primary row is rewritten as a
+    # post-parse content duplicate — its own mapping must be released.
+    dup_row = _doc("failed", file_path="a.pdf")
+    dup_row["metadata"] = {"is_duplicate": True, "duplicate_kind": "content_hash"}
+    await storage.upsert({"doc-1": dup_row})
+    assert await storage.get_doc_by_file_basename_strict("a.pdf") is None
+
+    # A fresh ingestion may now legitimately claim the basename.
+    await storage.upsert({"doc-2": _doc("pending", file_path="a.pdf")})
+    assert (await storage.get_doc_by_file_basename_strict("a.pdf"))[0] == "doc-2"
+
+    # Deleting a NON-owning row (the duplicate marker) must not strip the
+    # owner's mapping.
+    await storage.delete(["doc-1"])
+    assert (await storage.get_doc_by_file_basename_strict("a.pdf"))[0] == "doc-2"
+
+    # Deleting the owner frees the name.
+    await storage.delete(["doc-2"])
+    assert await storage.get_doc_by_file_basename_strict("a.pdf") is None
+
+
+@pytest.mark.asyncio
+async def test_mark_doc_failed_atomic_reserve_and_attempt_idempotency(storage):
+    await _bootstrap(storage)
+    await storage.upsert(
+        {
+            "doc-1": _doc(
+                "processing",
+                created_at="2026-01-01T00:00:00+00:00",
+                processing_attempt_id="attempt-1",
+            )
+        }
+    )
+    g1 = await storage.mark_doc_failed(
+        "doc-1", {"error_msg": "boom", "created_at": "2030-01-01T00:00:00+00:00"}
+    )
+    row = await storage.get_by_id("doc-1")
+    assert row["status"] == "failed"
+    assert row["failure_generation"] == g1 >= 1
+    assert row["failure_attempt_id"] == "attempt-1"
+    assert row["created_at"] == "2026-01-01T00:00:00+00:00"  # caller's ignored
+    # ZSET membership moved processing → failed atomically.
+    assert await storage.count_docs_by_statuses([DocStatus.PROCESSING]) == 0
+    assert await storage.count_docs_by_statuses([DocStatus.FAILED]) == 1
+
+    # Same attempt again: idempotent, no new generation.
+    assert await storage.mark_doc_failed("doc-1", {"error_msg": "boom2"}) == g1
+
+    # New attempt: fresh, larger generation.
+    await storage.update_doc_status_fields(
+        "doc-1", {"status": "processing", "processing_attempt_id": "attempt-2"}
+    )
+    g2 = await storage.mark_doc_failed("doc-1", {"error_msg": "boom3"})
+    assert g2 > g1
+
+    # Missing row: conditional create.
+    g3 = await storage.mark_doc_failed(
+        "ghost",
+        {
+            **_doc("processing", file_path="g.pdf"),
+            "processing_attempt_id": "attempt-x",
+            "error_msg": "early",
+        },
+    )
+    ghost = await storage.get_by_id("ghost")
+    assert ghost["status"] == "failed" and ghost["failure_generation"] == g3 > g2
+
+
+@pytest.mark.asyncio
+async def test_mark_doc_failed_watch_conflict_retries_without_gap(storage):
+    """A concurrent ctrl bump between read and commit forces a WATCH retry;
+    the final generation reflects the interleaved reservation (no reuse)."""
+    await _bootstrap(storage)
+    await storage.upsert({"doc-1": _doc("processing", processing_attempt_id="a1")})
+    fake = storage._redis
+
+    original = FakeRedis.hgetall
+    bumped = {"done": False}
+
+    async def hgetall_with_interleaving(self, key):
+        result = await original(self, key)
+        if not bumped["done"] and key.endswith(":ctrl"):
+            bumped["done"] = True
+            # Interleave a concurrent reservation AFTER this read: bump the
+            # version so the WATCH transaction conflicts and retries.
+            self.hashes[key]["failure_generation_counter"] = str(
+                int(result.get("failure_generation_counter") or 0) + 1
+            )
+            self._bump(key)
+        return result
+
+    fake.hgetall = hgetall_with_interleaving.__get__(fake)
+    try:
+        generation = await storage.mark_doc_failed("doc-1", {"error_msg": "x"})
+    finally:
+        fake.hgetall = original.__get__(fake)
+    # The interleaved reservation took 1, so ours is 2 — never a duplicate.
+    assert generation == 2
+
+
+@pytest.mark.asyncio
+async def test_count_and_strict_lookup_fail_closed(storage):
+    await _bootstrap(storage)
+    await storage.upsert({"doc-1": _doc("pending")})
+    fake = storage._redis
+
+    fake.fail_next["zcard"] = RedisError("boom")
+    with pytest.raises(RedisError):
+        await storage.count_docs_by_statuses([DocStatus.PENDING])
+
+    fake.fail_next["get"] = RedisError("boom")
+    with pytest.raises(RedisError):
+        await storage.get_doc_by_file_basename_strict("a.pdf")
+    # The legacy method keeps the swallow-and-None behaviour.
+    fake.fail_next["get"] = RedisError("boom")
+    assert await storage.get_doc_by_file_basename("a.pdf") is None
+
+    # Broken invariant (index points at a missing row) raises for strict.
+    fake.store[storage._basename_key("ghost.pdf")] = "doc-ghost"
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_doc_by_file_basename_strict("ghost.pdf")
+
+
+@pytest.mark.asyncio
+async def test_ensure_processing_attempt_id(storage):
+    await _bootstrap(storage)
+    await storage.upsert({"doc-1": _doc("pending")})
+    first = await storage.ensure_processing_attempt_id("doc-1")
+    assert first and (await storage.ensure_processing_attempt_id("doc-1")) == first
+    with pytest.raises(StorageRecordNotFoundError):
+        await storage.ensure_processing_attempt_id("missing")
+
+
+@pytest.mark.asyncio
+async def test_malformed_cursor_raises_control_plane_error(storage):
+    await _bootstrap(storage)
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.PENDING], limit=1, position=CursorAfter("[1,2]")
+        )
+
+
+@pytest.mark.asyncio
+async def test_drop_clears_sidecar_but_keeps_counter(storage):
+    await _bootstrap(storage)
+    await storage.upsert({"doc-1": _doc("pending", file_path="a.pdf")})
+    g1 = await storage.reserve_failure_generation()
+    await storage.drop()
+    assert await storage.count_docs_by_statuses([DocStatus.PENDING]) == 0
+    assert await storage.get_doc_by_file_basename_strict("a.pdf") is None
+    # Counter survives the destructive clear: monotonic, never reused.
+    assert await storage.reserve_failure_generation() == g1 + 1

--- a/tests/kg/test_scheduling_base_defaults.py
+++ b/tests/kg/test_scheduling_base_defaults.py
@@ -1,0 +1,367 @@
+"""Base-default contract tests for the memory-bounding scheduling API (Phase 1).
+
+A minimal, third-party-style ``DocStatusStorage`` subclass (old abstract
+signatures ONLY — no new methods, no capability flags) must keep working:
+
+* instantiable, with every new base method available as a concrete default;
+* ``get_docs_by_statuses_page``: CURSOR_START → one full page ending the
+  sweep; any other position → empty terminal page; ``max_failure_generation``
+  ignored (one-time warning) instead of raising on the missing field;
+* ``count_docs_by_statuses`` raises ``StorageCapabilityError`` (fail-closed);
+* ``update_doc_status_fields`` refuses ``created_at`` and raises
+  ``StorageRecordNotFoundError`` on unknown ids unless ``missing_ok``;
+* ``mark_doc_failed`` default = LEGACY write side (plain FAILED upsert, no
+  generation, caller-supplied ``created_at`` ignored for existing rows,
+  conditional create for missing rows);
+* ``ensure_processing_attempt_id`` mints once and then reuses;
+* strict variants never call legacy methods with new kwargs (no TypeError);
+* ``BaseKVStorage.get_by_id_strict`` base default raises capability error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from lightrag.base import (
+    CURSOR_END,
+    CursorAfter,
+    DocProcessingStatus,
+    DocSchedulingRecord,
+    DocStatus,
+    DocStatusStorage,
+    FailureGenerationMode,
+)
+from lightrag.constants import CUSTOM_CHUNK_PATCH_METADATA_KEY
+from lightrag.exceptions import (
+    StorageCapabilityError,
+    StorageRecordNotFoundError,
+)
+
+pytestmark = pytest.mark.offline
+
+
+@dataclass
+class _MinimalDocStatusStorage(DocStatusStorage):
+    """Third-party-style subclass: implements ONLY the legacy abstract
+    surface, with the legacy signatures. Anything new must come from base
+    defaults."""
+
+    embedding_func: Any = None
+    namespace: str = "test"
+    workspace: str = "test"
+    global_config: dict = field(default_factory=dict)
+    data: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    async def initialize(self):  # pragma: no cover - unused
+        pass
+
+    async def finalize(self):  # pragma: no cover - unused
+        pass
+
+    async def index_done_callback(self) -> None:
+        pass
+
+    async def drop(self) -> dict[str, str]:
+        self.data.clear()
+        return {"status": "success", "message": "dropped"}
+
+    async def get_by_id(self, id: str) -> dict[str, Any] | None:
+        row = self.data.get(id)
+        return dict(row) if row is not None else None
+
+    async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
+        return [dict(self.data[i]) for i in ids if i in self.data]
+
+    async def filter_keys(self, keys: set[str]) -> set[str]:
+        return {k for k in keys if k not in self.data}
+
+    async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
+        for key, value in data.items():
+            self.data[key] = dict(value)
+
+    async def delete(self, ids: list[str]) -> None:
+        for i in ids:
+            self.data.pop(i, None)
+
+    async def is_empty(self) -> bool:
+        return not self.data
+
+    async def get_status_counts(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for row in self.data.values():
+            status = str(row.get("status"))
+            counts[status] = counts.get(status, 0) + 1
+        return counts
+
+    async def get_docs_by_status(
+        self, status: DocStatus
+    ) -> dict[str, DocProcessingStatus]:
+        return await self.get_docs_by_statuses([status])
+
+    async def get_docs_by_statuses(
+        self, statuses: list[DocStatus], strict: bool = False
+    ) -> dict[str, DocProcessingStatus]:
+        wanted = {s.value for s in statuses}
+        out: dict[str, DocProcessingStatus] = {}
+        for doc_id, row in self.data.items():
+            raw_status = row.get("status")
+            value = (
+                raw_status.value
+                if isinstance(raw_status, DocStatus)
+                else str(raw_status)
+            )
+            if value not in wanted:
+                continue
+            out[doc_id] = DocProcessingStatus(
+                content_summary=row.get("content_summary", ""),
+                content_length=row.get("content_length", 0),
+                file_path=row.get("file_path", "unknown_source"),
+                status=DocStatus(value),
+                created_at=row.get("created_at", ""),
+                updated_at=row.get("updated_at", ""),
+                track_id=row.get("track_id"),
+                metadata=row.get("metadata", {}) or {},
+            )
+        return out
+
+    async def get_docs_by_track_id(
+        self, track_id: str
+    ) -> dict[str, DocProcessingStatus]:  # pragma: no cover - unused
+        return {}
+
+    async def get_docs_paginated(
+        self,
+        status_filter=None,
+        status_filters=None,
+        page: int = 1,
+        page_size: int = 50,
+        sort_field: str = "updated_at",
+        sort_direction: str = "desc",
+    ):  # pragma: no cover - unused
+        return [], 0
+
+    async def get_all_status_counts(self) -> dict[str, int]:
+        return await self.get_status_counts()
+
+    async def get_doc_by_file_path(
+        self, file_path: str
+    ) -> dict[str, Any] | None:  # pragma: no cover - unused
+        return None
+
+    async def get_doc_by_file_basename(
+        self, basename: str
+    ) -> tuple[str, dict[str, Any]] | None:
+        # Legacy signature ON PURPOSE: a strict kwarg here must never appear.
+        for doc_id, row in self.data.items():
+            if row.get("file_path") == basename:
+                return doc_id, dict(row)
+        return None
+
+    async def get_doc_by_content_hash(
+        self, content_hash: str
+    ) -> tuple[str, dict[str, Any]] | None:  # pragma: no cover - unused
+        return None
+
+
+def _row(status: DocStatus, created_at: str = "2026-01-01T00:00:00") -> dict:
+    return {
+        "status": status.value,
+        "content_summary": "s",
+        "content_length": 1,
+        "file_path": "a.pdf",
+        "created_at": created_at,
+        "updated_at": created_at,
+        "track_id": "t1",
+        "metadata": {},
+    }
+
+
+def _storage(**rows: dict) -> _MinimalDocStatusStorage:
+    storage = _MinimalDocStatusStorage()
+    storage.data.update(rows)
+    return storage
+
+
+def test_minimal_subclass_instantiates_with_defaults():
+    storage = _storage()
+    assert storage.supports_bounded_scheduling_pages is False
+    assert storage.supports_failure_generation is False
+    assert storage.supports_strict_doc_identity_lookup is False
+    assert storage.supports_strict_point_reads is False
+
+
+def test_page_default_start_is_single_terminal_page():
+    async def _run():
+        storage = _storage(
+            d1=_row(DocStatus.PENDING),
+            d2=_row(DocStatus.FAILED),
+            d3=_row(DocStatus.PROCESSED),
+        )
+        page = await storage.get_docs_by_statuses_page(
+            [DocStatus.PENDING, DocStatus.FAILED], limit=1, strict=True
+        )
+        # limit is ignored by the compat default: everything in one page.
+        assert set(page.docs) == {"d1", "d2"}
+        assert page.next_position is CURSOR_END
+        record = page.docs["d1"]
+        assert isinstance(record, DocSchedulingRecord)
+        assert record.status is DocStatus.PENDING
+        assert record.has_custom_chunk_journal is False
+
+    asyncio.run(_run())
+
+
+def test_page_default_non_start_positions_terminate_empty():
+    async def _run():
+        storage = _storage(d1=_row(DocStatus.PENDING))
+        for position in (CURSOR_END, CursorAfter("opaque")):
+            page = await storage.get_docs_by_statuses_page(
+                [DocStatus.PENDING], limit=10, position=position
+            )
+            assert page.docs == {}
+            assert page.next_position is CURSOR_END
+
+    asyncio.run(_run())
+
+
+def test_page_default_ignores_generation_filter_with_warning(caplog):
+    async def _run():
+        storage = _storage(d1=_row(DocStatus.FAILED))
+        # Rows lack failure_generation entirely — must NOT raise, must NOT
+        # filter (missing == logical 0 keeps legacy rows eligible).
+        page = await storage.get_docs_by_statuses_page(
+            [DocStatus.FAILED], limit=10, max_failure_generation=5
+        )
+        assert set(page.docs) == {"d1"}
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="lightrag"):
+        logger_obj = logging.getLogger("lightrag")
+        old_propagate = logger_obj.propagate
+        logger_obj.propagate = True
+        try:
+            asyncio.run(_run())
+        finally:
+            logger_obj.propagate = old_propagate
+    assert any("max_failure_generation" in r.message for r in caplog.records)
+
+
+def test_page_default_journal_projection():
+    async def _run():
+        row = _row(DocStatus.PENDING)
+        row["metadata"] = {CUSTOM_CHUNK_PATCH_METADATA_KEY: {"op": "x"}}
+        storage = _storage(d1=row)
+        page = await storage.get_docs_by_statuses_page([DocStatus.PENDING], limit=10)
+        assert page.docs["d1"].has_custom_chunk_journal is True
+
+    asyncio.run(_run())
+
+
+def test_count_default_raises_capability_error():
+    async def _run():
+        storage = _storage()
+        with pytest.raises(StorageCapabilityError):
+            await storage.count_docs_by_statuses([DocStatus.PENDING])
+
+    asyncio.run(_run())
+
+
+def test_update_fields_refuses_created_at_and_missing_ids():
+    async def _run():
+        storage = _storage(d1=_row(DocStatus.PENDING))
+        with pytest.raises(ValueError, match="created_at"):
+            await storage.update_doc_status_fields(
+                "d1", {"created_at": "2030-01-01T00:00:00"}
+            )
+        with pytest.raises(StorageRecordNotFoundError):
+            await storage.update_doc_status_fields("missing", {"error_msg": "x"})
+        # missing_ok best-effort path is a no-op.
+        await storage.update_doc_status_fields(
+            "missing", {"error_msg": "x"}, missing_ok=True
+        )
+        await storage.update_doc_status_fields("d1", {"error_msg": "boom"})
+        assert storage.data["d1"]["error_msg"] == "boom"
+        assert storage.data["d1"]["status"] == DocStatus.PENDING.value
+
+    asyncio.run(_run())
+
+
+def test_mark_doc_failed_default_is_legacy_write_side():
+    async def _run():
+        storage = _storage(d1=_row(DocStatus.PENDING, created_at="2026-01-01T00:00:00"))
+        generation = await storage.mark_doc_failed(
+            "d1",
+            {
+                "error_msg": "boom",
+                "updated_at": "2026-02-01T00:00:00",
+                # Caller-supplied created_at MUST be ignored for existing rows.
+                "created_at": "2030-12-31T00:00:00",
+            },
+        )
+        assert generation is None  # LEGACY: no generation
+        row = storage.data["d1"]
+        assert row["status"] == DocStatus.FAILED
+        assert row["error_msg"] == "boom"
+        assert row["created_at"] == "2026-01-01T00:00:00"
+
+        # Missing row: conditional create (enqueue-time errors can fail
+        # before the PENDING row landed).
+        await storage.mark_doc_failed(
+            "ghost", {"error_msg": "early", "created_at": "2026-03-01T00:00:00"}
+        )
+        assert storage.data["ghost"]["status"] == DocStatus.FAILED
+        assert storage.data["ghost"]["created_at"] == "2026-03-01T00:00:00"
+
+    asyncio.run(_run())
+
+
+def test_ensure_processing_attempt_id_mints_once_then_reuses():
+    async def _run():
+        storage = _storage(d1=_row(DocStatus.PENDING))
+        first = await storage.ensure_processing_attempt_id("d1")
+        assert first
+        second = await storage.ensure_processing_attempt_id("d1")
+        assert second == first
+        assert storage.data["d1"]["processing_attempt_id"] == first
+        with pytest.raises(StorageRecordNotFoundError):
+            await storage.ensure_processing_attempt_id("missing")
+
+    asyncio.run(_run())
+
+
+def test_failure_generation_defaults_are_legacy_and_capability_gated():
+    async def _run():
+        storage = _storage()
+        assert (
+            await storage.get_failure_generation_mode() is FailureGenerationMode.LEGACY
+        )
+        with pytest.raises(StorageCapabilityError):
+            await storage.reserve_failure_generation()
+
+    asyncio.run(_run())
+
+
+def test_strict_basename_delegates_without_new_kwargs():
+    async def _run():
+        storage = _storage(d1=_row(DocStatus.PENDING))
+        # The legacy override has the OLD signature — delegation must not
+        # pass any new kwargs (a strict= kwarg would TypeError here).
+        match = await storage.get_doc_by_file_basename_strict("a.pdf")
+        assert match is not None and match[0] == "d1"
+        assert await storage.get_doc_by_file_basename_strict("missing.pdf") is None
+
+    asyncio.run(_run())
+
+
+def test_kv_get_by_id_strict_default_raises_capability_error():
+    async def _run():
+        storage = _storage(d1=_row(DocStatus.PENDING))
+        with pytest.raises(StorageCapabilityError):
+            await storage.get_by_id_strict("d1")
+
+    asyncio.run(_run())

--- a/tests/pipeline/test_document_file_path_normalization.py
+++ b/tests/pipeline/test_document_file_path_normalization.py
@@ -49,9 +49,15 @@ class DummyRAG:
 class CaptureDocStatus:
     def __init__(self):
         self.upserts = []
+        self.failed = []
 
     async def upsert(self, data):
         self.upserts.append(data)
+
+    async def mark_doc_failed(self, doc_id, fields):
+        # Phase 1: error documents land through the FAILED funnel.
+        self.failed.append((doc_id, fields))
+        return 1
 
 
 class DummyPipeline(_PipelineMixin):
@@ -171,7 +177,7 @@ async def test_error_document_enqueue_canonicalizes_file_path_before_upsert():
         track_id="track-1",
     )
 
-    saved = next(iter(rag.doc_status.upserts[0].values()))
+    _, saved = rag.doc_status.failed[0]
     assert saved["file_path"] == "report.pdf"
 
 

--- a/tests/pipeline/test_failed_write_funnel.py
+++ b/tests/pipeline/test_failed_write_funnel.py
@@ -1,0 +1,128 @@
+"""Every FAILED write goes through the ``mark_doc_failed`` funnel (Phase 1).
+
+Fix-proof: before the audit, FAILED rows were written by plain upserts and
+carried no ``failure_generation`` — logical generation 0, leaking into every
+manual cohort forever. After it, every FAILED path (extraction failure via
+``_upsert_doc_status_transition``, enqueue-time error documents, in-batch
+duplicate markers, post-parse content duplicates) assigns a generation and
+stamps the failing attempt.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import uuid4
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG
+from lightrag.base import DocStatus
+from lightrag.utils import EmbeddingFunc, Tokenizer
+
+pytestmark = pytest.mark.offline
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _dummy_embedding(texts: list[str]) -> np.ndarray:
+    return np.ones((len(texts), 8), dtype=float)
+
+
+async def _dummy_llm(*args, **kwargs) -> str:
+    return "ok"
+
+
+def _chunking(tokenizer, content, *args) -> list[dict]:
+    return [{"tokens": 1, "content": f"{content}::chunk1", "chunk_order_index": 0}]
+
+
+async def _failing_extract(chunks, *args, **kwargs):
+    raise RuntimeError("extract fail sentinel")
+
+
+async def _build_rag(tmp_path) -> LightRAG:
+    rag = LightRAG(
+        working_dir=str(tmp_path / "wd"),
+        workspace=f"ffw-{uuid4().hex[:8]}",
+        llm_model_func=_dummy_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8, max_token_size=8192, func=_dummy_embedding
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        chunking_func=_chunking,
+        max_parallel_insert=1,
+    )
+    await rag.initialize_storages()
+    rag._process_extract_entities = _failing_extract
+    return rag
+
+
+def test_extraction_failure_carries_generation_and_attempt(tmp_path):
+    async def _run():
+        rag = await _build_rag(tmp_path)
+        try:
+            await rag.apipeline_enqueue_documents(input="body a", file_paths="a.txt")
+            await rag.apipeline_process_enqueue_documents()
+            match = await rag.doc_status.get_doc_by_file_basename("a.txt")
+            assert match is not None
+            _, row = match
+            assert str(row.get("status")) == DocStatus.FAILED.value
+            assert int(row.get("failure_generation") or 0) >= 1
+            assert row.get("failure_attempt_id")
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_enqueue_error_documents_carry_generation(tmp_path):
+    async def _run():
+        rag = await _build_rag(tmp_path)
+        try:
+            await rag.apipeline_enqueue_error_documents(
+                [
+                    {
+                        "file_path": "broken.pdf",
+                        "error_description": "bad file",
+                        "original_error": "parse failed",
+                    }
+                ],
+                track_id="track-err",
+            )
+            failed = await rag.doc_status.get_docs_by_status(DocStatus.FAILED)
+            assert failed, "error document was not persisted"
+            rows = await rag.doc_status.get_by_ids(list(failed.keys()))
+            assert all(int(r.get("failure_generation") or 0) >= 1 for r in rows)
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_batch_duplicate_markers_carry_generation(tmp_path):
+    async def _run():
+        rag = await _build_rag(tmp_path)
+        try:
+            # Same canonical basename twice in one enqueue: the second entry
+            # becomes a dup-* FAILED marker — through the funnel it must
+            # carry a generation like every other FAILED row.
+            await rag.apipeline_enqueue_documents(
+                input=["body 1", "body 2"],
+                file_paths=["dup.txt", "dup.txt"],
+            )
+            failed = await rag.doc_status.get_docs_by_status(DocStatus.FAILED)
+            dup_ids = [doc_id for doc_id in failed if doc_id.startswith("dup-")]
+            assert dup_ids, "no duplicate marker row was created"
+            rows = await rag.doc_status.get_by_ids(dup_ids)
+            assert all(int(r.get("failure_generation") or 0) >= 1 for r in rows)
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())

--- a/tests/pipeline/test_pipeline_orchestrator_get_by_id_failure.py
+++ b/tests/pipeline/test_pipeline_orchestrator_get_by_id_failure.py
@@ -221,7 +221,11 @@ async def test_full_outage_escape_still_cancels_workers(tmp_path, monkeypatch):
 
         monkeypatch.setattr(rag.full_docs, "get_by_id", dead_get)
         # _finalize_doc_failure's doc_status write also fails -> escape.
+        # Phase 1: FAILED transitions go through mark_doc_failed, so a full
+        # outage must kill that funnel too (upsert stays dead for the
+        # non-FAILED writes).
         monkeypatch.setattr(rag.doc_status, "upsert", dead_upsert)
+        monkeypatch.setattr(rag.doc_status, "mark_doc_failed", dead_upsert)
 
         # apipeline_process_enqueue_documents lets the storage error propagate
         # out (its finally releases busy but does not swallow the exception).


### PR DESCRIPTION
## Summary

Phase 1 of the pipeline memory-bounding plan: the storage layer that every later phase builds on. When `doc_status` holds a very large number of entries, today's scheduler materializes ALL matching rows per sweep; this PR adds the bounded primitives without changing scheduler behavior yet (Phase 2+ wires them in).

### base layer
- **Three-state cursor keyset paging**: `get_docs_by_statuses_page` with `(created_at ASC, id ASC)` MUST-order, `CURSOR_START / CursorAfter(opaque) / CURSOR_END`, a lightweight `DocSchedulingRecord` projection (no `chunks_list`/large metadata), and the **consumed-position advance contract** (filtered/skipped rows advance the cursor; prefetched-but-unreturned heads never skip; a fully filtered page never terminates or re-reads).
- **`failure_generation` write side**: `reserve_failure_generation` (reserve-before-publish; holes allowed, reuse never) + `mark_doc_failed` as the single FAILED funnel (per-attempt idempotent CAS, immutable `created_at`, conditional create) + per-workspace `get_failure_generation_mode` marker (`LEGACY/MIGRATING/DUAL_WRITE_READY/ENFORCED` — marker anomalies read MIGRATING, **never** LEGACY).
- **Fail-closed `count_docs_by_statuses`** and targeted `update_doc_status_fields` (immutable `created_at`, `StorageRecordNotFoundError`).
- **Strict identity lookups as NEW methods + capability flags** (`get_doc_by_file_basename_strict`, KV `get_by_id_strict`) — existing abstractmethod signatures untouched; third-party subclasses keep working via concrete base defaults (page: single-page compat; count/strict point read: `StorageCapabilityError`).
- Capability flags: `supports_bounded_scheduling_pages` / `supports_failure_generation` / `supports_strict_doc_identity_lookup` / `supports_strict_point_reads` (base defaults `False`; all five built-ins declare `True`).

### five built-in backends
- **JSON**: bounded-heap pages; sidecar ctrl file; init migrate-then-publish-ENFORCED + counter recalibration (`max(counter, max persisted)`).
- **Redis**: atomic `__sched` sidecar (per-status ZSETs, **basename → primary-doc index** with an eligibility state machine covering the in-place primary→content-duplicate transition, ctrl hash) maintained by WATCH/MULTI on every write; `mark_doc_failed` commits counter+row in one transaction (zero reserve→publish window); streaming one-time migration; O(1) ZCARD counts; basename lookups drop from O(N) SCAN to O(1).
- **PG**: idempotent DDL (three columns + keyset index + `LIGHTRAG_DOC_SCHEDULING_CTRL` counter row — deliberately not a sequence, `nextval` escapes rollback); single-transaction `mark_doc_failed`; bucket-aware NULLS FIRST keyset.
- **Mongo**: `$or` keyset + `$inc` counter + `$nor` CAS publish; missing/null `created_at` bucket resumes via the `{"created_at": None}` predicate.
- **OpenSearch**: `search_after` live-view pages; cohort predicate includes `must_not exists(failure_generation)` (legacy docs lack the field — mapping alone does not default it); `if_seq_no/if_primary_term` CAS; independent `*_scheduling_ctrl` metadata index; three-state strict point reads.
- Basename lookups on all backends now return the **primary** (non-`is_duplicate`) row only.

### pipeline FAILED-write audit
All five FAILED write sites route through `mark_doc_failed` (transition throat, enqueue error docs, in-batch `dup-*` markers, post-parse content duplicates, FAILED custom-chunk journals), plus attempt-identity bootstrap at the batch entry with cross-transition carry-over.

## Review
- 16-round adversarially reviewed design doc (plan-level), then a storage-backend-reviewer pass on this diff: 2 blocking findings (PG/Mongo corrupt-`created_at` rows starving out of keyset sweeps) fixed with fix-proof tests; workspace isolation, contract preservation, Redis atomicity, mode-marker semantics and counter monotonicity verified clean.

## Tests
- `tests/kg`: 1251 passed (per-backend `test_*_scheduling_pages.py` suites + cross-backend base-default contract tests + upgraded shared FakeRedis with real WATCH conflict detection).
- `tests/pipeline`: 418 passed (incl. new `test_failed_write_funnel.py` fix-proofs).
- Full suite: 4366 passed; the only 4 failures are a pre-existing order-dependent flake in `tests/api/routes/test_query_stream_routes.py` reproducible identically on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)