### PR TITLE
fix(retrieval): improve diagnostics for missing chunk vectors

### DIFF
--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4531,16 +4531,19 @@ async def pick_by_vector_similarity(
             f"Vector similarity chunk selection: {len(chunk_vectors)} chunk vectors Retrieved"
         )
 
-        if not chunk_vectors or len(chunk_vectors) != len(all_chunk_ids):
-            if not chunk_vectors:
-                logger.warning(
-                    "Vector similarity chunk selection: no vectors retrieved from chunks_vdb"
-                )
-            else:
-                logger.warning(
-                    f"Vector similarity chunk selection: found {len(chunk_vectors)} but expecting {len(all_chunk_ids)}"
-                )
+        if not chunk_vectors:
+            logger.warning(
+                "Vector similarity chunk selection: no vectors retrieved from chunks_vdb"
+            )
             return []
+
+        if len(chunk_vectors) != len(all_chunk_ids):
+            # Some candidate chunks have no stored vector (e.g. after deletions
+            # or a partial re-embed). Rank the ones we do have rather than
+            # discarding the whole selection; the loop below skips the missing.
+            logger.debug(
+                f"Vector similarity chunk selection: found {len(chunk_vectors)} of {len(all_chunk_ids)}; ranking the available chunks"
+            )
 
         # Calculate cosine similarities
         similarities = []

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4538,12 +4538,28 @@ async def pick_by_vector_similarity(
             return []
 
         if len(chunk_vectors) != len(all_chunk_ids):
-            # Some candidate chunks have no stored vector (e.g. after deletions
-            # or a partial re-embed). Rank the ones we do have rather than
-            # discarding the whole selection; the loop below skips the missing.
-            logger.debug(
-                f"Vector similarity chunk selection: found {len(chunk_vectors)} of {len(all_chunk_ids)}; ranking the available chunks"
+            # A referenced chunk with no stored vector signals an inconsistency
+            # between the graph/text stores and the vector store. Keep the
+            # existing safety behavior: abort vector ranking so callers can fall
+            # back to the WEIGHT method, but make the mismatch easier to observe
+            # and repair by logging counts and a bounded sample of missing IDs.
+            expected = len(all_chunk_ids)
+            retrieved = len(chunk_vectors)
+            missing_ids = [
+                chunk_id for chunk_id in all_chunk_ids if chunk_id not in chunk_vectors
+            ]
+            sample = missing_ids[:5]
+            logger.warning(
+                "Vector similarity chunk selection: data inconsistency detected "
+                "(expected %s, retrieved %s, missing %s). Falling back to WEIGHT method. "
+                "Missing chunk IDs (sample): %s. "
+                "Vector/text storages may be out of sync; consider re-embedding or repairing.",
+                expected,
+                retrieved,
+                expected - retrieved,
+                sample,
             )
+            return []
 
         # Calculate cosine similarities
         similarities = []

--- a/tests/utils/test_pick_by_vector_similarity.py
+++ b/tests/utils/test_pick_by_vector_similarity.py
@@ -1,0 +1,66 @@
+"""Regression tests for :func:`lightrag.utils.pick_by_vector_similarity`.
+
+A single candidate chunk missing its stored vector (common after deletions or
+partial re-embeds) must not discard the ranking of every other candidate.
+"""
+
+import numpy as np
+import pytest
+
+from lightrag.utils import pick_by_vector_similarity
+
+pytestmark = pytest.mark.offline
+
+
+class _StubChunksVDB:
+    """Minimal vector store exposing only get_vectors_by_ids."""
+
+    def __init__(self, vectors):
+        self._vectors = vectors
+
+    async def get_vectors_by_ids(self, ids):
+        # Mimic a real backend: only return entries that actually exist.
+        return {cid: self._vectors[cid] for cid in ids if cid in self._vectors}
+
+
+async def test_partial_missing_vectors_still_ranks_available_chunks():
+    query_embedding = np.array([1.0, 0.0, 0.0])
+    entity_info = [{"sorted_chunks": ["c0", "c1", "c2"]}]
+    # c2 has no stored vector; c0 is the closest match to the query.
+    vdb = _StubChunksVDB(
+        {
+            "c0": np.array([1.0, 0.0, 0.0]),
+            "c1": np.array([0.9, 0.1, 0.0]),
+        }
+    )
+
+    selected = await pick_by_vector_similarity(
+        query="q",
+        text_chunks_storage=None,
+        chunks_vdb=vdb,
+        num_of_chunks=5,
+        entity_info=entity_info,
+        embedding_func=None,
+        query_embedding=query_embedding,
+    )
+
+    # Before the fix this returned [] because one of three chunks lacked a
+    # vector, silently disabling the default VECTOR pick method for the query.
+    assert selected == ["c0", "c1"]
+
+
+async def test_no_vectors_at_all_returns_empty():
+    entity_info = [{"sorted_chunks": ["c0", "c1"]}]
+    vdb = _StubChunksVDB({})
+
+    selected = await pick_by_vector_similarity(
+        query="q",
+        text_chunks_storage=None,
+        chunks_vdb=vdb,
+        num_of_chunks=5,
+        entity_info=entity_info,
+        embedding_func=None,
+        query_embedding=np.array([1.0, 0.0, 0.0]),
+    )
+
+    assert selected == []

--- a/tests/utils/test_pick_by_vector_similarity.py
+++ b/tests/utils/test_pick_by_vector_similarity.py
@@ -6,11 +6,12 @@ WEIGHT retrieval method, while emitting a diagnostic warning that includes
 counts and a sample of missing chunk IDs.
 """
 
-import logging
+from unittest.mock import patch
 
 import numpy as np
 import pytest
 
+from lightrag.utils import logger as utils_logger
 from lightrag.utils import pick_by_vector_similarity
 
 pytestmark = pytest.mark.offline
@@ -27,7 +28,7 @@ class _StubChunksVDB:
         return {cid: self._vectors[cid] for cid in ids if cid in self._vectors}
 
 
-async def test_partial_missing_vectors_falls_back_and_warns(caplog):
+async def test_partial_missing_vectors_falls_back_and_warns():
     query_embedding = np.array([1.0, 0.0, 0.0])
     entity_info = [{"sorted_chunks": ["c0", "c1", "c2"]}]
     # c2 has no stored vector; the function should not rank the partial set.
@@ -38,7 +39,7 @@ async def test_partial_missing_vectors_falls_back_and_warns(caplog):
         }
     )
 
-    with caplog.at_level(logging.WARNING):
+    with patch.object(utils_logger, "warning") as mock_warning:
         selected = await pick_by_vector_similarity(
             query="q",
             text_chunks_storage=None,
@@ -51,21 +52,21 @@ async def test_partial_missing_vectors_falls_back_and_warns(caplog):
 
     assert selected == []
 
-    warning_record = next(
-        (r for r in caplog.records if "data inconsistency detected" in r.message), None
-    )
-    assert warning_record is not None, "Expected a data-inconsistency warning"
-    assert "expected 3" in warning_record.message
-    assert "retrieved 2" in warning_record.message
-    assert "missing 1" in warning_record.message
-    assert "'c2'" in warning_record.message
+    # The lightrag logger has propagate=False, so inspect the logger call directly.
+    assert mock_warning.call_count == 1
+    fmt, expected, retrieved, missing, sample = mock_warning.call_args.args
+    assert "data inconsistency detected" in fmt
+    assert expected == 3
+    assert retrieved == 2
+    assert missing == 1
+    assert "c2" in str(sample)
 
 
-async def test_no_vectors_at_all_returns_empty(caplog):
+async def test_no_vectors_at_all_returns_empty():
     entity_info = [{"sorted_chunks": ["c0", "c1"]}]
     vdb = _StubChunksVDB({})
 
-    with caplog.at_level(logging.WARNING):
+    with patch.object(utils_logger, "warning") as mock_warning:
         selected = await pick_by_vector_similarity(
             query="q",
             text_chunks_storage=None,
@@ -78,7 +79,8 @@ async def test_no_vectors_at_all_returns_empty(caplog):
 
     assert selected == []
     assert any(
-        "no vectors retrieved from chunks_vdb" in r.message for r in caplog.records
+        "no vectors retrieved from chunks_vdb" in call.args[0]
+        for call in mock_warning.call_args_list
     )
 
 

--- a/tests/utils/test_pick_by_vector_similarity.py
+++ b/tests/utils/test_pick_by_vector_similarity.py
@@ -1,8 +1,12 @@
 """Regression tests for :func:`lightrag.utils.pick_by_vector_similarity`.
 
-A single candidate chunk missing its stored vector (common after deletions or
-partial re-embeds) must not discard the ranking of every other candidate.
+Missing stored vectors for candidate chunks are treated as a data
+inconsistency. The function returns an empty list so callers fall back to the
+WEIGHT retrieval method, while emitting a diagnostic warning that includes
+counts and a sample of missing chunk IDs.
 """
+
+import logging
 
 import numpy as np
 import pytest
@@ -23,14 +27,69 @@ class _StubChunksVDB:
         return {cid: self._vectors[cid] for cid in ids if cid in self._vectors}
 
 
-async def test_partial_missing_vectors_still_ranks_available_chunks():
+async def test_partial_missing_vectors_falls_back_and_warns(caplog):
     query_embedding = np.array([1.0, 0.0, 0.0])
     entity_info = [{"sorted_chunks": ["c0", "c1", "c2"]}]
-    # c2 has no stored vector; c0 is the closest match to the query.
+    # c2 has no stored vector; the function should not rank the partial set.
     vdb = _StubChunksVDB(
         {
             "c0": np.array([1.0, 0.0, 0.0]),
             "c1": np.array([0.9, 0.1, 0.0]),
+        }
+    )
+
+    with caplog.at_level(logging.WARNING):
+        selected = await pick_by_vector_similarity(
+            query="q",
+            text_chunks_storage=None,
+            chunks_vdb=vdb,
+            num_of_chunks=5,
+            entity_info=entity_info,
+            embedding_func=None,
+            query_embedding=query_embedding,
+        )
+
+    assert selected == []
+
+    warning_record = next(
+        (r for r in caplog.records if "data inconsistency detected" in r.message), None
+    )
+    assert warning_record is not None, "Expected a data-inconsistency warning"
+    assert "expected 3" in warning_record.message
+    assert "retrieved 2" in warning_record.message
+    assert "missing 1" in warning_record.message
+    assert "'c2'" in warning_record.message
+
+
+async def test_no_vectors_at_all_returns_empty(caplog):
+    entity_info = [{"sorted_chunks": ["c0", "c1"]}]
+    vdb = _StubChunksVDB({})
+
+    with caplog.at_level(logging.WARNING):
+        selected = await pick_by_vector_similarity(
+            query="q",
+            text_chunks_storage=None,
+            chunks_vdb=vdb,
+            num_of_chunks=5,
+            entity_info=entity_info,
+            embedding_func=None,
+            query_embedding=np.array([1.0, 0.0, 0.0]),
+        )
+
+    assert selected == []
+    assert any(
+        "no vectors retrieved from chunks_vdb" in r.message for r in caplog.records
+    )
+
+
+async def test_all_vectors_present_ranks_normally():
+    query_embedding = np.array([1.0, 0.0, 0.0])
+    entity_info = [{"sorted_chunks": ["c0", "c1", "c2"]}]
+    vdb = _StubChunksVDB(
+        {
+            "c0": np.array([1.0, 0.0, 0.0]),
+            "c1": np.array([0.9, 0.1, 0.0]),
+            "c2": np.array([0.0, 1.0, 0.0]),
         }
     )
 
@@ -44,23 +103,4 @@ async def test_partial_missing_vectors_still_ranks_available_chunks():
         query_embedding=query_embedding,
     )
 
-    # Before the fix this returned [] because one of three chunks lacked a
-    # vector, silently disabling the default VECTOR pick method for the query.
-    assert selected == ["c0", "c1"]
-
-
-async def test_no_vectors_at_all_returns_empty():
-    entity_info = [{"sorted_chunks": ["c0", "c1"]}]
-    vdb = _StubChunksVDB({})
-
-    selected = await pick_by_vector_similarity(
-        query="q",
-        text_chunks_storage=None,
-        chunks_vdb=vdb,
-        num_of_chunks=5,
-        entity_info=entity_info,
-        embedding_func=None,
-        query_embedding=np.array([1.0, 0.0, 0.0]),
-    )
-
-    assert selected == []
+    assert selected == ["c0", "c1", "c2"]


### PR DESCRIPTION
## Summary

Preserve the existing all-or-nothing vector selection behavior when candidate chunks are missing stored vectors, while making the underlying data inconsistency easier to diagnose.

## Motivation

A chunk that is still referenced by an entity or relation is expected to have a corresponding entry in `chunks_vdb`. Missing vectors indicate that the graph/text stores and vector store are out of sync.

Ranking only the available vectors can exclude text-bearing candidates from retrieval and underfill the requested chunk count. Returning an empty result keeps the existing caller behavior: entity and relation retrieval fall back to the `WEIGHT` method, so all valid candidates remain eligible for selection.

## What's Changed

- Keep the completeness check in `pick_by_vector_similarity` and return `[]` when the retrieved vector count does not match the candidate count.
- Emit a warning with expected, retrieved, and missing counts.
- Include a bounded sample of up to five missing chunk IDs to support operational diagnosis and repair.
- Keep the no-vectors warning and the normal similarity-ranking path unchanged.
- Add offline regression tests for partial vector loss, complete vector loss, and the all-vectors-present ranking path.
- Patch `logger.warning` directly in tests because the LightRAG logger uses `propagate=False`.

## Behavior

- All candidate vectors present: rank chunks by vector similarity.
- Some or all candidate vectors missing: return `[]`; the current callers fall back to `WEIGHT`.
- Partial vector results are not treated as a supported best-effort retrieval mode.

## Verification

- Linting and Formatting: passed
- Offline Tests (Python 3.12): passed
- Offline Tests (Python 3.14): passed
