### PR TITLE
✅ test: heal module identity and derive the Bedrock args rig from the real parser (LR2 P0)

### DIFF
--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,47 @@
+"""Shared isolation for the API test package.
+
+``lightrag.api.config`` / ``auth`` / ``utils_api`` compute module-level state at
+IMPORT time (``auth_handler.accounts``, ``whitelist_patterns``,
+``auth_configured``) and the router modules capture
+``get_combined_auth_dependency`` by value — so its closure reads whatever module
+object was live when the router was imported, for the rest of the session.
+
+Several tests here deliberately re-import those modules under a mocked config to
+exercise a different auth profile. That leaves a DIFFERENT object in
+``sys.modules`` than the one the routers actually read, and the next test that
+tries to open up auth by patching ``sys.modules["lightrag.api.utils_api"]``
+patches a module nobody consults: with ``AUTH_ACCOUNTS`` set in a developer
+``.env``, the stale ``auth_configured=True`` then answers its requests with 401
+(seen as order-dependent failures in ``tests/api/routes/test_query_stream_routes.py``).
+"""
+
+import sys
+
+import pytest
+
+_API_MODULE_PREFIX = "lightrag.api"
+
+
+@pytest.fixture(autouse=True)
+def _restore_lightrag_api_module_identity():
+    """Restore ``lightrag.api.*`` entries a test replaced or removed.
+
+    Only REPLACEMENTS and REMOVALS are healed (identity comparison): a module
+    imported for the first time during a test is left in place, so this never
+    creates a fresh duplicate of its own. Parent-package attributes are re-pointed
+    too, because the re-import helpers ``delattr`` them to dodge the shadowing.
+    """
+    saved = {
+        name: module
+        for name, module in sys.modules.items()
+        if name == _API_MODULE_PREFIX or name.startswith(_API_MODULE_PREFIX + ".")
+    }
+    yield
+    for name, module in saved.items():
+        if sys.modules.get(name) is module:
+            continue
+        sys.modules[name] = module
+        parent_name, _, child = name.rpartition(".")
+        parent = sys.modules.get(parent_name)
+        if parent is not None and child and getattr(parent, child, None) is not module:
+            setattr(parent, child, module)

--- a/tests/llm/bedrock_impl/test_bedrock_llm.py
+++ b/tests/llm/bedrock_impl/test_bedrock_llm.py
@@ -647,8 +647,26 @@ class _FakeOllamaAPI:
         self.router = APIRouter()
 
 
-def _make_args(tmp_path) -> SimpleNamespace:
-    return SimpleNamespace(
+def _make_args(tmp_path):
+    """Server args for the ``create_app`` tests below.
+
+    Derived from the REAL parser and then overridden, NOT hand-rolled: every
+    server-consumed config knob added later (LR2 Phase 2's
+    ``pipeline_scheduling_page_size`` broke all seven ``create_app`` tests here
+    with an ``AttributeError``) exists automatically. ``sys.argv`` is pinned so
+    the parse never sees pytest's own arguments, and the auth/env-sensitive
+    fields stay pinned below so a developer ``.env`` cannot reach the app.
+    """
+    original_argv = sys.argv[:]
+    sys.argv = ["lightrag-server"]
+    try:
+        from lightrag.api.config import parse_args
+
+        args = parse_args()
+    finally:
+        sys.argv = original_argv
+
+    overrides = dict(
         host="127.0.0.1",
         port=9621,
         log_level="INFO",
@@ -729,6 +747,9 @@ def _make_args(tmp_path) -> SimpleNamespace:
         rerank_max_async=4,
         rerank_timeout=30,
     )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
 
 
 @pytest.mark.offline


### PR DESCRIPTION
Two test-rig fixes that stand on their own and unblock the phases above by making the suite honest about module identity and server args. Both are test-only.

**`lightrag.api` module identity.** The auth and config tests `pop` and re-import `lightrag.api.*`, but the router captured `get_combined_auth_dependency` **by value** at import time and kept reading the old object. Four `test_query_stream_routes` cases then answered 401 whenever a `.env` with `AUTH_ACCOUNTS` was present — a failure that depends on collection order, so it reproduces in a full run and vanishes when the file is run alone. `tests/api/conftest.py` now heals the identity between tests.

**Bedrock server-args rig.** `_make_args` hand-built a ~90-field namespace, so it broke every time the real parser gained a field. Derived from the actual parser instead: it cannot drift again. (LR2 adds five such fields above this PR, which is what surfaced it.)

Both failures exist on `main` today — the first reproduces as `pytest tests/api`.

---

**Stack** (merge bottom-up; each PR is green on its own and targets the one below):
`main` ← **#3482** P0 test rig ← **#3483** P1 storage pages ← **#3484** P2 bounded sweep ← **#3485** P2.5 dedup ← **#3486** P3 manual retry ← **#3481** P4 `/scan` ← **#3487** P5 admission ← **#3488** P6 observability ← **#3489** P7 verification

Design: LR2 *pipeline memory bounding*. When merging, retarget the child PR **before** deleting a merged branch — GitHub closes the child otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
