### PR TITLE
✨ feat(storage): bounded scheduling contract — keyset pages, strict reads, typed source resolution (LR2 Phase 1)

### DIFF
--- a/env.example
+++ b/env.example
@@ -1187,6 +1187,13 @@ REDIS_SOCKET_TIMEOUT=30
 REDIS_CONNECT_TIMEOUT=10
 REDIS_MAX_CONNECTIONS=100
 REDIS_RETRY_ATTEMPTS=3
+### LightRAG keeps doc_status / full_docs / the scheduling index in Redis as a
+### system of record, and none of those keys carry a TTL. Startup therefore
+### REFUSES an instance with maxmemory>0 plus an `allkeys-*` maxmemory-policy,
+### because eviction there drops documents and scheduling state silently and
+### undetectably. Use `noeviction` (or a `volatile-*` policy), or give LightRAG
+### its own instance/db. Set this to true only to accept that data loss.
+# REDIS_ALLOW_EVICTION_POLICY=false
 ### DB specific workspace should not be set, keep for compatible only
 # REDIS_WORKSPACE=forced_workspace_name
 

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -1403,16 +1403,32 @@ class DocStatusStorage(BaseKVStorage, ABC):
         ``primary_doc_id`` to keep. Contract for capable backends:
 
         * ``dry_run=True`` (default) makes no mutation and returns the bounded
-          summary plus the deterministic ``fingerprint`` / ``candidate_count``
-          computed under a workspace + canonical-source-key write lock.
-        * On commit, the current candidate set is re-read strictly under that
-          lock; a mismatch with ``expected_candidate_count`` /
+          summary plus the deterministic ``fingerprint`` / ``candidate_count``.
+        * On commit, the current candidate set is re-read strictly and a
+          mismatch with ``expected_candidate_count`` /
           ``expected_candidate_fingerprint`` fails as a CAS conflict rather
           than overwriting a concurrent change.
         * The other candidates are marked ``metadata.is_duplicate=true`` with
-          ``original_doc_id=primary_doc_id`` in bounded pages; content is never
-          deleted. After a successful commit the strict resolver returns
-          ``SourceUnique(primary_doc_id)``.
+          ``original_doc_id=primary_doc_id``; content is never deleted.
+
+        **What this method does NOT serialize.** The storage layer holds no
+        canonical-source-key lock, and no backend here can take one that also
+        excludes an INSERT: a re-read plus CAS detects changes to the candidate
+        rows it saw, but a brand-new primary for the same key is a phantom that
+        neither a ``SELECT … FOR UPDATE`` (PostgreSQL), a snapshot transaction
+        (MongoDB) nor a non-transactional re-scan (Redis, OpenSearch) can block.
+        Serializing repair against enqueue is therefore the CALLER's job, via a
+        ``get_storage_keyed_lock`` on the canonical source key held across both
+        the resolve→enqueue decision and the dry-run→commit pair. That lock
+        spans one deployment (its worker processes included), not several
+        deployments sharing a database.
+
+        ``committed=True`` accordingly means "the demotions named in this result
+        were committed" — NOT "this source key is now conflict-free". A primary
+        inserted mid-repair simply leaves the resolver in
+        :class:`SourceConflict`, which is fail-closed (scan refuses to classify,
+        nothing destructive follows) and which a fresh dry-run + commit
+        resolves; repair is idempotent, so re-running is always safe.
 
         The base default raises
         :class:`~lightrag.exceptions.StorageCapabilityError`.

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -7,7 +7,9 @@ from dotenv import load_dotenv
 from dataclasses import dataclass, field
 from typing import (
     Any,
+    ClassVar,
     Literal,
+    Sequence,
     TypedDict,
     TypeVar,
     Optional,
@@ -17,7 +19,12 @@ from typing import (
 )
 from .utils import EmbeddingFunc, get_env_value
 from .types import KnowledgeGraph
+from .exceptions import (
+    StorageCapabilityError,
+    StorageRecordNotFoundError,
+)
 from .constants import (
+    CUSTOM_CHUNK_PATCH_METADATA_KEY,
     DEFAULT_TOP_K,
     DEFAULT_CHUNK_TOP_K,
     DEFAULT_MAX_ENTITY_TOKENS,
@@ -383,9 +390,47 @@ class BaseVectorStorage(StorageNameSpace, ABC):
 class BaseKVStorage(StorageNameSpace, ABC):
     embedding_func: EmbeddingFunc
 
+    supports_strict_point_reads: ClassVar[bool] = False
+    """Class-level capability flag: the backend implements
+    :meth:`get_by_id_strict` with complete-or-raise semantics.
+
+    Unlike the doc_status scheduling API (mandatory ``@abstractmethod`` — see
+    :class:`DocStatusStorage`), strict point reads are an OPTIONAL KV
+    capability: ``BaseKVStorage`` serves many namespaces (``full_docs``,
+    ``text_chunks``, ``llm_response_cache``, ...) and only the ``full_docs``
+    stale-stub decision needs it. A backend that does not provide it degrades
+    to the conservative path (keep the FAILED stub, never delete on an
+    unconfirmed miss). Callers MUST gate on this flag before calling
+    :meth:`get_by_id_strict`.
+    """
+
     @abstractmethod
     async def get_by_id(self, id: str) -> dict[str, Any] | None:
         """Get value by id"""
+
+    async def get_by_id_strict(self, id: str) -> dict[str, Any] | None:
+        """Point read with complete-or-raise semantics.
+
+        Contract (implemented by backends that declare
+        ``supports_strict_point_reads = True``):
+
+        * ``None`` means **confirmed absent** — the backend positively
+          determined that no record with this id exists.
+        * Any transport/server error, an index/collection that is not ready,
+          or a state where absence cannot be positively confirmed (e.g. an
+          OpenSearch index that is unexpectedly missing after a restore)
+          MUST raise instead of returning ``None``.
+
+        This differs from :meth:`get_by_id`, whose implementations may treat
+        failures as a best-effort miss. The base default raises
+        :class:`~lightrag.exceptions.StorageCapabilityError`; callers must gate
+        on :attr:`supports_strict_point_reads` before calling.
+        """
+        raise StorageCapabilityError(
+            f"{type(self).__name__} does not support strict point reads "
+            "(supports_strict_point_reads=False); the caller must fall back "
+            "to a non-destructive path instead of trusting a miss."
+        )
 
     @abstractmethod
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
@@ -864,9 +909,161 @@ class DocProcessingStatus:
                 self.status = DocStatus.PREPROCESSED
 
 
+class CursorPosition:
+    """Sealed three-state cursor for stable keyset sweeps.
+
+    Exactly three shapes exist: the :data:`CURSOR_START` singleton, the
+    :data:`CURSOR_END` singleton, and :class:`CursorAfter` (an opaque,
+    backend-defined continuation token). ``page.next_position is CURSOR_END``
+    is the ONLY termination signal — an empty ``docs`` dict is not (a page
+    may be fully filtered yet not exhausted).
+    """
+
+    __slots__ = ()
+
+
+class _CursorSentinel(CursorPosition):
+    __slots__ = ("_name",)
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return self._name
+
+
+CURSOR_START = _CursorSentinel("CURSOR_START")
+"""Begin a sweep from the smallest ``(created_at, id)`` key."""
+
+CURSOR_END = _CursorSentinel("CURSOR_END")
+"""The sweep is exhausted; no further page exists."""
+
+
+@dataclass(frozen=True)
+class CursorAfter(CursorPosition):
+    """Opaque continuation token: resume strictly after the last CONSUMED
+    underlying record (see the consumed-position contract on
+    :meth:`DocStatusStorage.get_docs_by_statuses_page`)."""
+
+    opaque: str
+
+
+@dataclass(frozen=True)
+class DocSchedulingRecord:
+    """Lightweight scheduling projection of a doc_status row.
+
+    Deliberately excludes ``chunks_list``, large ``metadata`` blobs and full
+    error text so a page of records stays O(page_size × small constant) —
+    the pipeline hydrates full records per-document only when it actually
+    routes one.
+    """
+
+    id: str
+    status: DocStatus
+    created_at: str
+    updated_at: str
+    file_path: str | None
+    track_id: str | None
+    has_custom_chunk_journal: bool
+    """True when doc_status.metadata carries the custom-chunk patch journal —
+    such rows belong to scan/custom-chunk recovery, not ordinary routing."""
+
+
+@dataclass(frozen=True)
+class DocStatusPage:
+    """One page of a stable keyset sweep.
+
+    ``next_position is CURSOR_END`` terminates the sweep; any other value
+    (including with an empty ``docs``) means "call again".
+    """
+
+    docs: dict[str, DocSchedulingRecord]
+    next_position: CursorPosition
+
+
+@dataclass(frozen=True)
+class SourceAbsent:
+    """No primary candidate exists for the canonical source key."""
+
+
+@dataclass(frozen=True)
+class SourceUnique:
+    """Exactly one primary (non-duplicate) candidate for the canonical source
+    key; ``doc_id`` is the identity every subsequent operation must use."""
+
+    doc_id: str
+    doc: DocSchedulingRecord
+
+
+@dataclass(frozen=True)
+class SourceConflict:
+    """Two or more primary candidates share the canonical source key.
+
+    Scan must not enqueue, delete, or archive — the job surfaces a repair
+    request instead. ``candidate_count`` is ``None`` when the backend only
+    proved "at least two" (via two samples) without a cheap exact count.
+    ``sample_doc_ids`` uses a fixed upper bound — never materialize the whole
+    conflicting set into memory.
+    """
+
+    candidate_count: int | None
+    sample_doc_ids: tuple[str, ...]
+
+
+# doc_id is the sole identity for records and downstream processing; the
+# canonical source key (a physical basename) only locates candidate rows and
+# is NOT assumed globally unique (custom-id inserts, legacy ids and historical
+# basename collisions can all share one basename).
+SourceResolution = SourceAbsent | SourceUnique | SourceConflict
+
+
+@dataclass(frozen=True)
+class SourceConflictSummary:
+    """One conflicting canonical source key with a bounded candidate sample."""
+
+    canonical_source_key: str
+    candidate_count: int | None
+    sample_doc_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SourceConflictPage:
+    """One page of the source-conflict listing (bounded projection)."""
+
+    conflicts: tuple[SourceConflictSummary, ...]
+    next_position: CursorPosition
+
+
+@dataclass(frozen=True)
+class SourceConflictRepairResult:
+    """Outcome of a source-conflict repair, dry-run or committed.
+
+    ``fingerprint`` is a deterministic digest over the candidate doc IDs in
+    stable sort order — the CAS token an operator echoes back on commit so a
+    concurrent change to the candidate set fails the repair instead of being
+    silently overwritten. ``demoted_sample_doc_ids`` is a bounded sample of
+    the rows that would be (dry-run) or were (commit) marked
+    ``metadata.is_duplicate=true``; content is never deleted.
+    """
+
+    canonical_source_key: str
+    primary_doc_id: str
+    candidate_count: int
+    fingerprint: str
+    demoted_sample_doc_ids: tuple[str, ...]
+    committed: bool
+
+
 @dataclass
 class DocStatusStorage(BaseKVStorage, ABC):
-    """Base class for document status storage"""
+    """Base class for document status storage.
+
+    All backends are first-party and MUST implement the bounded scheduling +
+    strict-read API (``get_docs_by_statuses_page`` / ``get_docs_by_ids`` /
+    ``resolve_doc_source_strict``) — these are ``@abstractmethod`` so a backend
+    missing any of them cannot instantiate. There is no degraded fallback and
+    no capability flag: instantiability IS the capability guarantee.
+    """
 
     @staticmethod
     def resolve_status_filter_values(
@@ -997,6 +1194,233 @@ class DocStatusStorage(BaseKVStorage, ABC):
         Returns:
             (doc_id, doc_data) when a matching record exists, otherwise None.
         """
+
+    # ------------------------------------------------------------------
+    # Memory-bounding scheduling API (Phase 1). The paging / batch / source
+    # methods are ``@abstractmethod`` — every (first-party) backend MUST
+    # implement them with bounded / fail-closed behaviour; there is no
+    # degraded base fallback. ``count`` / ``update`` / conflict-repair keep a
+    # concrete base default.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _scheduling_record_from_raw(
+        doc_id: str, raw: dict[str, Any]
+    ) -> DocSchedulingRecord:
+        """Project a raw doc_status dict into the lightweight scheduling record.
+
+        Used by base-default paths that only have the persisted dict (e.g. the
+        legacy-delegating source resolver). ``status`` may already be a
+        :class:`DocStatus` or its string value.
+        """
+        status_val = raw.get("status")
+        status = (
+            status_val if isinstance(status_val, DocStatus) else DocStatus(status_val)
+        )
+        metadata = raw.get("metadata") if isinstance(raw.get("metadata"), dict) else {}
+        return DocSchedulingRecord(
+            id=doc_id,
+            status=status,
+            created_at=raw.get("created_at") or "",
+            updated_at=raw.get("updated_at") or "",
+            file_path=raw.get("file_path"),
+            track_id=raw.get("track_id"),
+            has_custom_chunk_journal=isinstance(
+                metadata.get(CUSTOM_CHUNK_PATCH_METADATA_KEY), dict
+            ),
+        )
+
+    @abstractmethod
+    async def get_docs_by_statuses_page(
+        self,
+        statuses: list[DocStatus],
+        *,
+        limit: int,
+        position: CursorPosition = CURSOR_START,
+        strict: bool = False,
+    ) -> DocStatusPage:
+        """Read one page of a stable keyset sweep over the given statuses.
+
+        Contract (every backend MUST implement this as a true bounded sweep):
+
+        * **Sort (MUST)**: ``(created_at ASC, id ASC)`` keyset order across
+          ALL requested statuses combined (per-status keysets merged with a
+          bounded k-way merge where the backend cannot sort natively).
+          Live-view: the sweep observes concurrent writes; no snapshot
+          isolation is claimed. Termination is ``next_position is
+          CURSOR_END`` — never an empty ``docs``.
+        * **Immutable sort key**: ``created_at`` is written once at record
+          creation and preserved by every later transition
+          (``update_doc_status_fields`` refuses it) so a record can never move
+          underneath a sweep. A missing/NULL ``created_at`` sorts FIRST (an
+          empty-string / NULL bucket) and stays reachable across page
+          boundaries via bucket-aware resume — it must never become
+          permanently unreachable behind a real-timestamp cursor.
+        * **Consumed-position advance**: ``next_position`` advances past the
+          last CONSUMED underlying record — records returned to the caller
+          plus records read and dropped by filtering are consumed; a record
+          prefetched for merging but NOT returned because the page filled is
+          NOT consumed (or must be encoded into the opaque cursor and returned
+          first on the next page). A fully-filtered page therefore advances
+          the cursor without terminating, never re-reads in place, and never
+          skips a prefetched head. With multiple statuses the opaque cursor
+          tracks each status stream's own consumed position.
+        * ``strict=True``: the page is complete or the call raises — on an
+          internal partial failure the implementation must raise WITHOUT
+          returning partial docs or a new cursor. All scheduling/control-plane
+          callers pass ``strict=True`` explicitly.
+        """
+
+    @abstractmethod
+    async def get_docs_by_ids(
+        self,
+        doc_ids: Sequence[str],
+        *,
+        strict: bool = False,
+    ) -> dict[str, DocSchedulingRecord]:
+        """Batch strict read of scheduling records by doc id.
+
+        Contract (every backend MUST implement it as a true batch strict read):
+
+        * The returned mapping contains ONLY ids confirmed to exist; a missing
+          id may be omitted, but the backend must have positively confirmed
+          its absence.
+        * With ``strict=True`` any transport/server/chunking error fails the
+          WHOLE call — the implementation must not return a partial mapping
+          and let the feeder treat un-returned ids as stale.
+        * Results use the lightweight projection (no chunks / full content).
+        """
+
+    async def count_docs_by_statuses(
+        self, statuses: list[DocStatus], *, strict: bool = True
+    ) -> int:
+        """Count documents in the given statuses, fail-closed.
+
+        Unlike ``get_status_counts()`` implementations that swallow errors and
+        report zeros, this method MUST either return an accurate count or
+        raise — admission control treats an error as "refuse", never as
+        "capacity available". The base implementation raises
+        :class:`~lightrag.exceptions.StorageCapabilityError`; deployments that
+        enable ``MAX_PENDING_DOCUMENTS`` validate support at initialization.
+        """
+        raise StorageCapabilityError(
+            f"{type(self).__name__} does not implement strict "
+            "count_docs_by_statuses; admission control cannot run on this "
+            "backend."
+        )
+
+    async def update_doc_status_fields(
+        self,
+        doc_id: str,
+        fields: dict[str, Any],
+        *,
+        missing_ok: bool = False,
+    ) -> None:
+        """Update only the given fields of one doc_status record.
+
+        Contract:
+
+        * Fields not present in ``fields`` are left untouched — this is the
+          targeted alternative to read-modify-write upserts that would drag a
+          huge ``chunks_list`` through memory.
+        * Implementations MUST atomically maintain every secondary index
+          affected by the updated fields (e.g. Redis per-status ZSETs and the
+          source multimap) in the same transaction as the write.
+        * ``created_at`` is an immutable sort key: passing it raises
+          ``ValueError`` (see the keyset-sweep contract).
+        * Unknown ``doc_id`` raises
+          :class:`~lightrag.exceptions.StorageRecordNotFoundError` unless
+          ``missing_ok=True`` (best-effort callers only).
+
+        The base default performs a read-modify-write via ``get_by_id`` +
+        ``upsert`` — correct but not memory-optimal; built-in backends
+        override with native partial updates.
+        """
+        if "created_at" in fields:
+            raise ValueError(
+                "created_at is an immutable scheduling sort key and cannot "
+                "be changed via update_doc_status_fields"
+            )
+        existing = await self.get_by_id(doc_id)
+        if existing is None:
+            if missing_ok:
+                return
+            raise StorageRecordNotFoundError(doc_id)
+        merged = {**existing, **fields}
+        merged.pop("_id", None)
+        await self.upsert({doc_id: merged})
+
+    @abstractmethod
+    async def resolve_doc_source_strict(
+        self, canonical_source_key: str
+    ) -> SourceResolution:
+        """Resolve a canonical source key to a typed source resolution.
+
+        Contract (every backend MUST implement it fail-closed and
+        conflict-aware):
+
+        * Only rows with ``metadata.is_duplicate != true`` are primary
+          candidates.
+        * 0 candidates → :class:`SourceAbsent`; 1 → :class:`SourceUnique`;
+          ≥2 → :class:`SourceConflict` (found by locating just two candidates,
+          never materializing the whole conflicting set).
+        * Query failure, a not-ready index, or an ambiguous state raises a
+          control-plane error instead of returning ``SourceAbsent`` — scan and
+          enqueue treat Absent as "confirmed new", so a swallowed failure would
+          mint duplicate rows.
+        """
+
+    async def list_source_conflicts_page(
+        self,
+        *,
+        limit: int,
+        position: CursorPosition = CURSOR_START,
+    ) -> SourceConflictPage:
+        """List canonical source keys with more than one primary candidate.
+
+        Operator/admin tooling for the explicit repair flow (see
+        :meth:`repair_source_conflict`). The base default raises
+        :class:`~lightrag.exceptions.StorageCapabilityError`; only backends
+        with a real strict resolver can enumerate conflicts.
+        """
+        raise StorageCapabilityError(
+            f"{type(self).__name__} does not implement "
+            "list_source_conflicts_page (no strict source resolution)."
+        )
+
+    async def repair_source_conflict(
+        self,
+        canonical_source_key: str,
+        *,
+        primary_doc_id: str,
+        expected_candidate_count: int,
+        expected_candidate_fingerprint: str,
+        dry_run: bool = True,
+    ) -> SourceConflictRepairResult:
+        """Resolve a historical multi-primary conflict, CAS-guarded.
+
+        The system never picks a winner automatically; the operator names the
+        ``primary_doc_id`` to keep. Contract for capable backends:
+
+        * ``dry_run=True`` (default) makes no mutation and returns the bounded
+          summary plus the deterministic ``fingerprint`` / ``candidate_count``
+          computed under a workspace + canonical-source-key write lock.
+        * On commit, the current candidate set is re-read strictly under that
+          lock; a mismatch with ``expected_candidate_count`` /
+          ``expected_candidate_fingerprint`` fails as a CAS conflict rather
+          than overwriting a concurrent change.
+        * The other candidates are marked ``metadata.is_duplicate=true`` with
+          ``original_doc_id=primary_doc_id`` in bounded pages; content is never
+          deleted. After a successful commit the strict resolver returns
+          ``SourceUnique(primary_doc_id)``.
+
+        The base default raises
+        :class:`~lightrag.exceptions.StorageCapabilityError`.
+        """
+        raise StorageCapabilityError(
+            f"{type(self).__name__} does not implement repair_source_conflict "
+            "(no strict source resolution)."
+        )
 
 
 class StoragesStatus(str, Enum):

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -272,6 +272,13 @@ PARSER_ENGINE_NATIVE = "native"
 PARSER_ENGINE_MINERU = "mineru"
 PARSER_ENGINE_DOCLING = "docling"
 PARSED_DIR_NAME = "__parsed__"  # Dir for parsed files (renamed from __enqueued__)
+# Reserved doc_status.metadata key holding the custom-chunk patch journal
+# (issue #3400 Phase 3). While present, the document has an in-flight or
+# failed ainsert_custom_chunks operation: the pipeline must NOT process the
+# row as ordinary ingestion, resets must NOT strip it, and deletion must
+# include its staged chunk IDs. Lives here (not utils_pipeline) so that
+# base.py can derive the scheduling projection without an import cycle.
+CUSTOM_CHUNK_PATCH_METADATA_KEY = "custom_chunk_patch"
 # Prefix marking a doc_status content_summary as GENERATED from a file
 # extraction error (enqueue-time error documents and parse-stage FAILED
 # upserts). Doubles as the match sentinel that lets a later failure replace

--- a/lightrag/exceptions.py
+++ b/lightrag/exceptions.py
@@ -77,6 +77,36 @@ class StorageNotInitializedError(RuntimeError):
         )
 
 
+class StorageCapabilityError(RuntimeError):
+    """Raised when a storage backend lacks a capability the caller requires.
+
+    Callers that depend on a hard guarantee (strict counting, strict point
+    reads, strict source resolution, ...) must fail closed on this error —
+    never silently substitute a weaker code path.
+    """
+
+
+class StorageControlPlaneError(RuntimeError):
+    """A storage control-plane read failed (e.g. an index that must exist is
+    unexpectedly absent, or a not-yet-ready index during rebuild/recovery).
+
+    Distinct from a data-plane miss: the caller cannot know the true state and
+    MUST fail closed (retry with backoff / surface 503 / keep sticky work
+    unacknowledged). Degrading to a full-materialization or destructive
+    fallback on this error is forbidden — that is exactly the OOM/corruption
+    window the control plane exists to fence off.
+    """
+
+
+class StorageRecordNotFoundError(KeyError):
+    """A targeted doc_status field update referenced a non-existent record.
+
+    Raised by ``update_doc_status_fields(..., missing_ok=False)`` — the
+    default — so callers cannot silently patch a record that a concurrent
+    delete already removed.
+    """
+
+
 class PipelineNotInitializedError(KeyError):
     """Raised when pipeline status is accessed before initialization."""
 

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -1,12 +1,29 @@
 from dataclasses import dataclass
+import hashlib
+import heapq
+import json
 import os
-from typing import Any, Union, final
+from typing import Any, ClassVar, Sequence, Union, final
 
 from lightrag.base import (
+    CURSOR_END,
+    CURSOR_START,
+    CursorAfter,
+    CursorPosition,
     DocProcessingStatus,
+    DocSchedulingRecord,
     DocStatus,
+    DocStatusPage,
     DocStatusStorage,
+    SourceAbsent,
+    SourceConflict,
+    SourceConflictPage,
+    SourceConflictRepairResult,
+    SourceConflictSummary,
+    SourceResolution,
+    SourceUnique,
 )
+from lightrag.constants import CUSTOM_CHUNK_PATCH_METADATA_KEY
 from lightrag.file_atomic import reap_orphan_tmp_files
 from lightrag.utils import (
     _cooperative_yield,
@@ -16,7 +33,11 @@ from lightrag.utils import (
     write_json,
     get_pinyin_sort_key,
 )
-from lightrag.exceptions import StorageNotInitializedError
+from lightrag.exceptions import (
+    StorageControlPlaneError,
+    StorageNotInitializedError,
+    StorageRecordNotFoundError,
+)
 from .shared_storage import (
     get_namespace_data,
     get_namespace_lock,
@@ -73,7 +94,21 @@ class JsonDocStatusStorage(DocStatusStorage):
         * ``drop`` — destructive, **not** serialized; the caller must
           hold the pipeline ``busy`` reservation (the
           ``/documents/clear`` endpoint does this).
+
+    Memory-bounding capability boundary (Phase 1): the paged scheduling
+    API below is a true keyset sweep (bounded page memory via a bounded
+    heap), but this backend inherently keeps the WHOLE store resident in
+    shared memory and rewrites the whole file on flush — that residency
+    is an independent, documented limitation, not something the page API
+    can fix. Deployments with very large doc counts should use a server
+    backend (Redis/PG/...).
     """
+
+    supports_strict_point_reads: ClassVar[bool] = True
+
+    # Bounded upper limit on the sample of conflicting doc IDs surfaced by the
+    # source-conflict listing/repair APIs — never materialize the whole set.
+    _CONFLICT_SAMPLE_CAP: ClassVar[int] = 32
 
     def __post_init__(self):
         # Reject path traversal before using workspace in a file path
@@ -489,14 +524,30 @@ class JsonDocStatusStorage(DocStatusStorage):
 
         return None
 
+    @staticmethod
+    def _is_duplicate_row(row: Any) -> bool:
+        """True for duplicate-attempt marker rows (``dup-*`` records and
+        post-parse content duplicates): ``metadata.is_duplicate == true``."""
+        if not isinstance(row, dict):
+            return False
+        metadata = row.get("metadata")
+        return bool(isinstance(metadata, dict) and metadata.get("is_duplicate"))
+
     async def get_doc_by_file_basename(
         self, basename: str
     ) -> Union[tuple[str, dict[str, Any]], None]:
-        """Find an existing record whose canonical basename matches.
+        """Find the PRIMARY record whose canonical basename matches.
 
         The caller is responsible for passing an already-canonical basename.
         Stored ``file_path`` values are canonicalized by the business layer, so
         this lookup intentionally performs an exact match only.
+
+        ``file_path`` is one-to-many (duplicate-attempt ``dup-*`` rows keep the
+        same canonical basename); this returns the single primary
+        (``metadata.is_duplicate != true``) row — callers doing identity
+        checks / dedup want the document, never a duplicate marker. When only
+        duplicate markers remain (primary deleted) the basename is free again
+        and this returns ``None``.
         """
         if not basename:
             return None
@@ -507,9 +558,61 @@ class JsonDocStatusStorage(DocStatusStorage):
             return None
         async with self._storage_lock:
             for doc_id, doc_data in self._data.items():
-                if doc_data.get("file_path") == basename:
+                if doc_data.get("file_path") == basename and not self._is_duplicate_row(
+                    doc_data
+                ):
                     return doc_id, doc_data
         return None
+
+    async def resolve_doc_source_strict(
+        self, canonical_source_key: str
+    ) -> SourceResolution:
+        """Typed source resolution (see base contract).
+
+        Collects up to two PRIMARY (``metadata.is_duplicate != true``) rows for
+        the canonical basename and maps 0/1/≥2 → Absent/Unique/Conflict. The
+        in-memory scan has no transport failure surface, so a returned
+        ``SourceAbsent`` IS confirmed absence (uninitialized storage raises).
+        """
+        if self._storage_lock is None:
+            raise StorageNotInitializedError("JsonDocStatusStorage")
+        if not canonical_source_key or canonical_source_key == "unknown_source":
+            return SourceAbsent()
+        candidates: list[tuple[str, dict[str, Any]]] = []
+        async with self._storage_lock:
+            for doc_id, row in self._data.items():
+                if not isinstance(row, dict):
+                    continue
+                if row.get("file_path") == canonical_source_key and not (
+                    self._is_duplicate_row(row)
+                ):
+                    candidates.append((doc_id, dict(row)))
+                    if len(candidates) >= 2:
+                        break
+        if not candidates:
+            return SourceAbsent()
+        if len(candidates) == 1:
+            doc_id, row = candidates[0]
+            return SourceUnique(
+                doc_id=doc_id,
+                doc=self._scheduling_record_from_raw(doc_id, row),
+            )
+        return SourceConflict(
+            candidate_count=None,
+            sample_doc_ids=tuple(sorted(doc_id for doc_id, _ in candidates)),
+        )
+
+    async def get_by_id_strict(self, id: str) -> Union[dict[str, Any], None]:
+        """Strict point read: complete-or-raise (base contract).
+
+        In-memory shared dict — a miss is a confirmed absence; the only
+        failure surface is uninitialized storage, which raises.
+        """
+        if self._storage_lock is None:
+            raise StorageNotInitializedError("JsonDocStatusStorage")
+        async with self._storage_lock:
+            row = self._data.get(id)
+        return row.copy() if isinstance(row, dict) else row
 
     async def get_doc_by_content_hash(
         self, content_hash: str
@@ -525,6 +628,358 @@ class JsonDocStatusStorage(DocStatusStorage):
                 if doc_data.get("content_hash") == content_hash:
                     return doc_id, doc_data
         return None
+
+    # ------------------------------------------------------------------
+    # Memory-bounding scheduling API (Phase 1)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _row_sort_key(doc_id: str, row: dict[str, Any]) -> tuple[str, str]:
+        """(created_at, id) keyset key. A missing/non-string created_at sorts
+        deterministically first as "" — such legacy rows are consumed (and
+        skipped/raised per strictness) without ever moving mid-sweep."""
+        created = row.get("created_at")
+        return (created if isinstance(created, str) else "", doc_id)
+
+    @staticmethod
+    def _encode_cursor(key: tuple[str, str]) -> str:
+        return json.dumps(list(key), ensure_ascii=False)
+
+    @staticmethod
+    def _decode_cursor(opaque: str) -> tuple[str, str]:
+        try:
+            decoded = json.loads(opaque)
+            created, doc_id = decoded
+            if not isinstance(created, str) or not isinstance(doc_id, str):
+                raise ValueError("cursor fields must be strings")
+        except (ValueError, TypeError) as e:
+            raise StorageControlPlaneError(
+                f"Malformed scheduling cursor for JsonDocStatusStorage: {e}"
+            ) from e
+        return (created, doc_id)
+
+    def _scheduling_record_from_row(
+        self, doc_id: str, row: dict[str, Any], *, strict: bool
+    ) -> DocSchedulingRecord | None:
+        """Project one raw row; strict raises on unusable rows, relaxed
+        returns None (the caller still counts the row as consumed)."""
+        try:
+            status = DocStatus(str(row["status"]))
+            created_at = row["created_at"]
+            updated_at = row.get("updated_at", created_at)
+            if not isinstance(created_at, str) or not isinstance(updated_at, str):
+                raise TypeError("created_at/updated_at must be strings")
+            metadata = row.get("metadata")
+            return DocSchedulingRecord(
+                id=doc_id,
+                status=status,
+                created_at=created_at,
+                updated_at=updated_at,
+                file_path=row.get("file_path") or "no-file-path",
+                track_id=row.get("track_id"),
+                has_custom_chunk_journal=isinstance(metadata, dict)
+                and isinstance(metadata.get(CUSTOM_CHUNK_PATCH_METADATA_KEY), dict),
+            )
+        except (KeyError, TypeError, ValueError) as e:
+            logger.error(f"[{self.workspace}] Unusable scheduling row {doc_id}: {e}")
+            if strict:
+                raise
+            return None
+
+    async def get_docs_by_statuses_page(
+        self,
+        statuses: list[DocStatus],
+        *,
+        limit: int,
+        position: CursorPosition = CURSOR_START,
+        strict: bool = False,
+    ) -> DocStatusPage:
+        """Bounded keyset page over the in-memory store.
+
+        Selection uses a bounded heap (``heapq.nsmallest``) so page memory is
+        O(limit) even though each page re-scans the resident dict — the
+        O(total) residency itself is this backend's documented boundary.
+
+        Consumed-position contract: every selected candidate is consumed —
+        returned or skipped as unusable in relaxed mode — so the cursor
+        advances past filtered pages instead of re-reading them; fewer
+        candidates than ``limit`` proves exhaustion (CURSOR_END).
+
+        Strict failure surface (backend divergence, by design): because this
+        backend candidate-selects by scanning the WHOLE resident dict, a
+        ``strict=True`` page raises on a malformed (non-mapping) record even
+        when that record's status is NOT part of the requested sweep —
+        server-side backends (PG/Mongo/OpenSearch/Redis) never see
+        out-of-scope rows and would not fail on the same corruption. An
+        operator whose JSON-backed sweep fails closed should inspect the
+        whole store, not just the swept statuses.
+        """
+        if self._storage_lock is None:
+            raise StorageNotInitializedError("JsonDocStatusStorage")
+        if limit <= 0:
+            raise ValueError(f"page limit must be positive, got {limit}")
+        if not statuses or position is CURSOR_END:
+            return DocStatusPage(docs={}, next_position=CURSOR_END)
+        last_key: tuple[str, str] | None = None
+        if isinstance(position, CursorAfter):
+            last_key = self._decode_cursor(position.opaque)
+        status_values = {s.value for s in statuses}
+
+        def _candidates():
+            for doc_id, row in self._data.items():
+                if not isinstance(row, dict):
+                    if strict:
+                        raise TypeError(f"doc_status record {doc_id} is not a mapping")
+                    continue
+                if str(row.get("status")) not in status_values:
+                    continue
+                key = self._row_sort_key(doc_id, row)
+                if last_key is not None and key <= last_key:
+                    continue
+                yield key, doc_id, row
+
+        async with self._storage_lock:
+            selected = heapq.nsmallest(limit, _candidates(), key=lambda t: t[0])
+            docs: dict[str, DocSchedulingRecord] = {}
+            for key, doc_id, row in selected:
+                record = self._scheduling_record_from_row(doc_id, row, strict=strict)
+                if record is None:
+                    continue  # relaxed skip is still consumed
+                docs[doc_id] = record
+        if len(selected) < limit:
+            next_position: CursorPosition = CURSOR_END
+        else:
+            next_position = CursorAfter(self._encode_cursor(selected[-1][0]))
+        return DocStatusPage(docs=docs, next_position=next_position)
+
+    async def count_docs_by_statuses(
+        self, statuses: list[DocStatus], *, strict: bool = True
+    ) -> int:
+        """Fail-closed status count (full scan — documented JSON boundary)."""
+        if self._storage_lock is None:
+            raise StorageNotInitializedError("JsonDocStatusStorage")
+        if not statuses:
+            return 0
+        status_values = {s.value for s in statuses}
+        count = 0
+        async with self._storage_lock:
+            for doc_id, row in self._data.items():
+                if not isinstance(row, dict) or "status" not in row:
+                    if strict:
+                        raise TypeError(
+                            f"doc_status record {doc_id} has no readable status"
+                        )
+                    continue
+                if str(row.get("status")) in status_values:
+                    count += 1
+        return count
+
+    async def update_doc_status_fields(
+        self,
+        doc_id: str,
+        fields: dict[str, Any],
+        *,
+        missing_ok: bool = False,
+    ) -> None:
+        """Targeted field update with an immediate flush (doc-status is the
+        pipeline's recovery anchor — same rationale as ``upsert``)."""
+        if "created_at" in fields:
+            raise ValueError(
+                "created_at is an immutable scheduling sort key and cannot "
+                "be changed via update_doc_status_fields"
+            )
+        if self._storage_lock is None:
+            raise StorageNotInitializedError("JsonDocStatusStorage")
+        async with self._storage_lock:
+            row = self._data.get(doc_id)
+            if row is None:
+                if missing_ok:
+                    return
+                raise StorageRecordNotFoundError(doc_id)
+            self._data[doc_id] = {**row, **fields}
+            await set_all_update_flags(self.namespace, workspace=self.workspace)
+        await self.index_done_callback()
+
+    # ------------------------------------------------------------------
+    # Strict batch read
+    # ------------------------------------------------------------------
+
+    async def get_docs_by_ids(
+        self,
+        doc_ids: Sequence[str],
+        *,
+        strict: bool = False,
+    ) -> dict[str, DocSchedulingRecord]:
+        """Batch strict read (see base contract).
+
+        In-memory dict lookup: a missing id is a confirmed absence and is
+        omitted. ``strict=True`` raises on a malformed (non-mapping) record;
+        uninitialized storage always raises.
+        """
+        if self._storage_lock is None:
+            raise StorageNotInitializedError("JsonDocStatusStorage")
+        result: dict[str, DocSchedulingRecord] = {}
+        async with self._storage_lock:
+            for doc_id in doc_ids:
+                row = self._data.get(doc_id)
+                if row is None:
+                    continue  # confirmed absent
+                if not isinstance(row, dict):
+                    if strict:
+                        raise TypeError(f"doc_status record {doc_id} is not a mapping")
+                    continue
+                record = self._scheduling_record_from_row(doc_id, row, strict=strict)
+                if record is not None:
+                    result[doc_id] = record
+        return result
+
+    # ------------------------------------------------------------------
+    # Source-conflict listing and explicit CAS repair
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _conflict_fingerprint(sorted_doc_ids: list[str]) -> str:
+        """Deterministic digest over candidate doc IDs in stable sort order."""
+        digest = hashlib.sha256()
+        for doc_id in sorted_doc_ids:
+            digest.update(doc_id.encode("utf-8"))
+            digest.update(b"\x00")
+        return digest.hexdigest()
+
+    def _primary_candidates_locked(self, canonical_source_key: str) -> list[str]:
+        """Sorted primary (non-duplicate) doc IDs for a canonical key. The
+        caller holds ``_storage_lock``."""
+        return sorted(
+            doc_id
+            for doc_id, row in self._data.items()
+            if isinstance(row, dict)
+            and row.get("file_path") == canonical_source_key
+            and not self._is_duplicate_row(row)
+        )
+
+    @staticmethod
+    def _decode_conflict_cursor(opaque: str) -> str:
+        try:
+            key = json.loads(opaque)
+            if not isinstance(key, str):
+                raise ValueError("conflict cursor must be a string")
+        except (ValueError, TypeError) as e:
+            raise StorageControlPlaneError(
+                f"Malformed source-conflict cursor for JsonDocStatusStorage: {e}"
+            ) from e
+        return key
+
+    async def list_source_conflicts_page(
+        self,
+        *,
+        limit: int,
+        position: CursorPosition = CURSOR_START,
+    ) -> SourceConflictPage:
+        """Page canonical source keys with >1 primary candidate (see base)."""
+        if self._storage_lock is None:
+            raise StorageNotInitializedError("JsonDocStatusStorage")
+        if limit <= 0:
+            raise ValueError(f"page limit must be positive, got {limit}")
+        if position is CURSOR_END:
+            return SourceConflictPage(conflicts=(), next_position=CURSOR_END)
+        last_key: str | None = None
+        if isinstance(position, CursorAfter):
+            last_key = self._decode_conflict_cursor(position.opaque)
+        async with self._storage_lock:
+            groups: dict[str, list[str]] = {}
+            for doc_id, row in self._data.items():
+                if not isinstance(row, dict):
+                    continue
+                file_path = row.get("file_path")
+                if not isinstance(file_path, str) or file_path in (
+                    "",
+                    "unknown_source",
+                    "no-file-path",
+                ):
+                    continue
+                if self._is_duplicate_row(row):
+                    continue
+                groups.setdefault(file_path, []).append(doc_id)
+        conflict_keys = sorted(k for k, v in groups.items() if len(v) >= 2)
+        page_keys = [k for k in conflict_keys if last_key is None or k > last_key][
+            :limit
+        ]
+        conflicts = tuple(
+            SourceConflictSummary(
+                canonical_source_key=k,
+                candidate_count=len(groups[k]),
+                sample_doc_ids=tuple(sorted(groups[k])[: self._CONFLICT_SAMPLE_CAP]),
+            )
+            for k in page_keys
+        )
+        if len(page_keys) < limit:
+            next_position: CursorPosition = CURSOR_END
+        else:
+            next_position = CursorAfter(json.dumps(page_keys[-1], ensure_ascii=False))
+        return SourceConflictPage(conflicts=conflicts, next_position=next_position)
+
+    async def repair_source_conflict(
+        self,
+        canonical_source_key: str,
+        *,
+        primary_doc_id: str,
+        expected_candidate_count: int,
+        expected_candidate_fingerprint: str,
+        dry_run: bool = True,
+    ) -> SourceConflictRepairResult:
+        """Demote all-but-one primary to duplicate, CAS-guarded (see base).
+
+        The single storage lock makes the re-read + CAS + demotion atomic:
+        dry-run reports the current count/fingerprint; commit refuses when
+        they no longer match the operator-echoed expectation.
+        """
+        if self._storage_lock is None:
+            raise StorageNotInitializedError("JsonDocStatusStorage")
+        async with self._storage_lock:
+            candidates = self._primary_candidates_locked(canonical_source_key)
+            count = len(candidates)
+            fingerprint = self._conflict_fingerprint(candidates)
+            if primary_doc_id not in candidates:
+                raise ValueError(
+                    f"primary_doc_id {primary_doc_id!r} is not a current primary "
+                    f"candidate for {canonical_source_key!r}"
+                )
+            demoted = [d for d in candidates if d != primary_doc_id]
+            if dry_run:
+                return SourceConflictRepairResult(
+                    canonical_source_key=canonical_source_key,
+                    primary_doc_id=primary_doc_id,
+                    candidate_count=count,
+                    fingerprint=fingerprint,
+                    demoted_sample_doc_ids=tuple(demoted[: self._CONFLICT_SAMPLE_CAP]),
+                    committed=False,
+                )
+            if (
+                count != expected_candidate_count
+                or fingerprint != expected_candidate_fingerprint
+            ):
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] source-conflict repair CAS failed for "
+                    f"{canonical_source_key!r}: candidate set changed "
+                    f"(count {count} vs {expected_candidate_count})"
+                )
+            for doc_id in demoted:
+                row = dict(self._data[doc_id])
+                metadata = dict(row.get("metadata") or {})
+                metadata["is_duplicate"] = True
+                metadata["original_doc_id"] = primary_doc_id
+                row["metadata"] = metadata
+                self._data[doc_id] = row
+            await set_all_update_flags(self.namespace, workspace=self.workspace)
+        await self.index_done_callback()
+        return SourceConflictRepairResult(
+            canonical_source_key=canonical_source_key,
+            primary_doc_id=primary_doc_id,
+            candidate_count=count,
+            fingerprint=fingerprint,
+            demoted_sample_doc_ids=tuple(demoted[: self._CONFLICT_SAMPLE_CAP]),
+            committed=True,
+        )
 
     async def drop(self) -> dict[str, str]:
         """Clear shared memory and immediately persist the empty state.

--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -1,6 +1,6 @@
 import os
 from dataclasses import dataclass
-from typing import Any, final
+from typing import Any, ClassVar, final
 
 from lightrag.base import (
     BaseKVStorage,
@@ -131,6 +131,8 @@ class JsonKVStorage(BaseKVStorage):
           but consumers should still respect the pipeline gate to avoid
           interleaving with batched ingest work.
     """
+
+    supports_strict_point_reads: ClassVar[bool] = True
 
     def __post_init__(self):
         # Reject path traversal before using workspace in a file path
@@ -264,6 +266,14 @@ class JsonKVStorage(BaseKVStorage):
                 # Ensure _id field contains the clean ID
                 result["_id"] = id
             return result
+
+    async def get_by_id_strict(self, id: str) -> dict[str, Any] | None:
+        """Strict point read (base contract): the in-memory shared dict has
+        no transport failure surface — a miss is a confirmed absence, and an
+        uninitialized storage raises instead of returning one."""
+        if self._storage_lock is None:
+            raise StorageNotInitializedError("JsonKVStorage")
+        return await self.get_by_id(id)
 
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
         async with self._storage_lock:

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -1443,6 +1443,29 @@ class MongoDocStatusStorage(DocStatusStorage):
         rows = await cursor.to_list(length=None)
         return sorted(str(r.get("_id")) for r in rows)
 
+    async def _primary_candidate_sample(
+        self, canonical_source_key: str
+    ) -> tuple[str, ...]:
+        """The lexicographically first ``_CONFLICT_SAMPLE_CAP`` primary ids.
+
+        Server-side bounded: ``sort(_id) + limit(cap)`` projecting only ``_id``,
+        so a key with a pathological number of primaries still ships a fixed
+        sample (unlike an aggregation ``$push`` of every id).
+        """
+        cursor = (
+            self._data.find(
+                {
+                    "file_path": canonical_source_key,
+                    "metadata.is_duplicate": {"$ne": True},
+                },
+                {"_id": 1},
+            )
+            .sort([("_id", 1)])
+            .limit(self._CONFLICT_SAMPLE_CAP)
+        )
+        rows = await cursor.to_list(length=self._CONFLICT_SAMPLE_CAP)
+        return tuple(str(r.get("_id")) for r in rows)
+
     async def list_source_conflicts_page(
         self,
         *,
@@ -1454,9 +1477,18 @@ class MongoDocStatusStorage(DocStatusStorage):
         A server-side aggregation groups PRIMARY (``metadata.is_duplicate !=
         true``) rows by ``file_path``, keeps groups with candidate count ≥ 2,
         resumes strictly after the cursor's canonical key (``$gt``) and sorts
-        by canonical key so the keyset is stable. ``candidate_count`` is the
-        exact group size; the surfaced sample is bounded to
-        ``_CONFLICT_SAMPLE_CAP``.
+        by canonical key so the keyset is stable.
+
+        The accumulator is COUNT-ONLY: ``$push``-ing the ids would build one
+        array per distinct ``file_path`` in the workspace — every group, not
+        just the conflicting ones, since ``candidate_count >= 2`` can only be
+        applied AFTER ``$group`` — so peak aggregation memory would scale with
+        the document count instead of the number of source keys. Samples are
+        instead fetched per SURFACED key (at most ``limit`` bounded queries),
+        so nothing unbounded crosses the wire either. Detecting "keys with more
+        than one primary" inherently groups the whole collection, so the group
+        set itself still scales with the number of distinct source keys (as it
+        does on PostgreSQL) — ``allowDiskUse`` covers that.
         """
         if limit <= 0:
             raise ValueError(f"page limit must be positive, got {limit}")
@@ -1475,13 +1507,7 @@ class MongoDocStatusStorage(DocStatusStorage):
 
         pipeline = [
             {"$match": match},
-            {
-                "$group": {
-                    "_id": "$file_path",
-                    "candidate_count": {"$sum": 1},
-                    "sample_doc_ids": {"$push": "$_id"},
-                }
-            },
+            {"$group": {"_id": "$file_path", "candidate_count": {"$sum": 1}}},
             {"$match": {"candidate_count": {"$gte": 2}}},
             {"$sort": {"_id": 1}},
             {"$limit": limit},
@@ -1489,18 +1515,17 @@ class MongoDocStatusStorage(DocStatusStorage):
         cursor = await self._data.aggregate(pipeline, allowDiskUse=True)
         groups = await cursor.to_list(length=limit)
 
-        conflicts = tuple(
-            SourceConflictSummary(
-                canonical_source_key=str(g["_id"]),
-                candidate_count=int(g["candidate_count"]),
-                sample_doc_ids=tuple(
-                    sorted(str(d) for d in g["sample_doc_ids"])[
-                        : self._CONFLICT_SAMPLE_CAP
-                    ]
-                ),
+        summaries: list[SourceConflictSummary] = []
+        for group in groups:
+            canonical = str(group["_id"])
+            summaries.append(
+                SourceConflictSummary(
+                    canonical_source_key=canonical,
+                    candidate_count=int(group["candidate_count"]),
+                    sample_doc_ids=await self._primary_candidate_sample(canonical),
+                )
             )
-            for g in groups
-        )
+        conflicts = tuple(summaries)
         if len(groups) < limit:
             next_position: CursorPosition = CURSOR_END
         else:
@@ -1530,6 +1555,12 @@ class MongoDocStatusStorage(DocStatusStorage):
         ``original_doc_id=primary_doc_id`` in the same transaction (content is
         never deleted). ``primary_doc_id`` absent from the current candidate
         set raises ``ValueError``.
+
+        The transaction gives snapshot isolation, not predicate locking: a new
+        primary INSERTed for the same canonical key mid-repair is a phantom the
+        snapshot never sees and no write conflict reports. See the base contract
+        for what ``committed`` does and does not claim, and for the caller-side
+        keyed lock that serializes repair against enqueue.
         """
         if dry_run:
             candidates = await self._primary_candidates(canonical_source_key)

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -2,20 +2,34 @@ import os
 import re
 import json
 import time
+import hashlib
 from dataclasses import dataclass, field
 import numpy as np
 import configparser
 import asyncio
 
-from typing import Any, Union, final
+from typing import Any, ClassVar, Sequence, Union, final
 
 from ..base import (
+    CURSOR_END,
+    CURSOR_START,
     BaseGraphStorage,
     BaseKVStorage,
     BaseVectorStorage,
+    CursorAfter,
+    CursorPosition,
     DocProcessingStatus,
+    DocSchedulingRecord,
     DocStatus,
+    DocStatusPage,
     DocStatusStorage,
+    SourceAbsent,
+    SourceConflict,
+    SourceConflictPage,
+    SourceConflictRepairResult,
+    SourceConflictSummary,
+    SourceResolution,
+    SourceUnique,
 )
 from ..utils import (
     logger,
@@ -25,7 +39,15 @@ from ..utils import (
     validate_workspace,
 )
 from ..types import KnowledgeGraph, KnowledgeGraphNode, KnowledgeGraphEdge
-from ..constants import GRAPH_FIELD_SEP, DEFAULT_QUERY_PRIORITY
+from ..constants import (
+    CUSTOM_CHUNK_PATCH_METADATA_KEY,
+    GRAPH_FIELD_SEP,
+    DEFAULT_QUERY_PRIORITY,
+)
+from ..exceptions import (
+    StorageControlPlaneError,
+    StorageRecordNotFoundError,
+)
 from .._version import __version__
 from ..kg.shared_storage import get_data_init_lock, get_namespace_lock
 
@@ -327,6 +349,8 @@ class MongoKVStorage(BaseKVStorage):
     db: AsyncDatabase = field(default=None)
     _data: AsyncCollection = field(default=None)
 
+    supports_strict_point_reads: ClassVar[bool] = True
+
     def __init__(self, namespace, global_config, embedding_func, workspace=None):
         super().__init__(
             namespace=namespace,
@@ -401,6 +425,15 @@ class MongoKVStorage(BaseKVStorage):
             doc.setdefault("create_time", 0)
             doc.setdefault("update_time", 0)
         return doc
+
+    async def get_by_id_strict(self, id: str) -> dict[str, Any] | None:
+        """Strict point read: complete-or-raise (base contract).
+
+        ``find_one`` either answers definitively or raises a ``PyMongoError``
+        — nothing is swallowed on this path, so a ``None`` IS a confirmed
+        absence (the FAILED-stub deletion path may act on it).
+        """
+        return await self.get_by_id(id)
 
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
         cursor = self._data.find({"_id": {"$in": ids}})
@@ -552,6 +585,12 @@ class MongoDocStatusStorage(DocStatusStorage):
     db: AsyncDatabase = field(default=None)
     _data: AsyncCollection = field(default=None)
 
+    supports_strict_point_reads: ClassVar[bool] = True
+
+    # Bounded upper limit on the sample of conflicting doc IDs surfaced by the
+    # source-conflict listing/repair APIs — never materialize the whole set.
+    _CONFLICT_SAMPLE_CAP: ClassVar[int] = 32
+
     def _prepare_doc_status_data(self, doc: dict[str, Any]) -> dict[str, Any]:
         """Normalize and migrate a raw Mongo document to DocProcessingStatus-compatible dict."""
         # Make a copy of the data to avoid modifying the original
@@ -641,6 +680,15 @@ class MongoDocStatusStorage(DocStatusStorage):
             self._data = None
 
     async def get_by_id(self, id: str) -> Union[dict[str, Any], None]:
+        return await self._data.find_one({"_id": id})
+
+    async def get_by_id_strict(self, id: str) -> Union[dict[str, Any], None]:
+        """Strict point read: complete-or-raise (base contract).
+
+        ``find_one`` either answers definitively or raises a ``PyMongoError``
+        — nothing is swallowed on this path, so a ``None`` IS a confirmed
+        absence.
+        """
         return await self._data.find_one({"_id": id})
 
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
@@ -843,6 +891,14 @@ class MongoDocStatusStorage(DocStatusStorage):
                         "content_hash": {"$exists": True, "$type": "string", "$gt": ""}
                     },
                 },
+                # Keyset sweep index for the bounded scheduling page API:
+                # matches the MUST sort of get_docs_by_statuses_page
+                # ((created_at ASC, _id ASC) within each status branch of a
+                # status $in — the server merges the per-status keysets).
+                {
+                    "name": f"{workspace_prefix}status_created_at_id_asc",
+                    "keys": [("status", 1), ("created_at", 1), ("_id", 1)],
+                },
             ]
 
             # 2. Handle legacy index cleanup: only drop old indexes that exist in THIS collection
@@ -1038,20 +1094,26 @@ class MongoDocStatusStorage(DocStatusStorage):
     async def get_doc_by_file_basename(
         self, basename: str
     ) -> Union[tuple[str, dict[str, Any]], None]:
-        """Mongo-native override of basename-based document lookup.
+        """Mongo-native override of basename-based document lookup (legacy).
 
         The caller is responsible for passing an already-canonical basename;
         stored ``file_path`` values are canonicalized by the business layer, so
         this lookup performs an exact match only and relies on the file_path
         index created by ``create_and_migrate_indexes_if_not_exists``.
-        """
-        if not basename:
-            return None
-        if basename == "unknown_source":
-            return None
 
+        Returns the PRIMARY (``metadata.is_duplicate != true``) row only —
+        duplicate-attempt ``dup-*`` markers keep the same canonical basename
+        and must never satisfy an identity lookup. Legacy error semantics:
+        query failures are logged and read as a best-effort miss (``None``);
+        callers that need "None == confirmed absent" or conflict detection must
+        use :meth:`resolve_doc_source_strict`.
+        """
+        if not basename or basename == "unknown_source":
+            return None
         try:
-            doc = await self._data.find_one({"file_path": basename})
+            doc = await self._data.find_one(
+                {"file_path": basename, "metadata.is_duplicate": {"$ne": True}}
+            )
         except PyMongoError as e:
             logger.error(f"[{self.workspace}] Error in get_doc_by_file_basename: {e}")
             return None
@@ -1061,6 +1123,42 @@ class MongoDocStatusStorage(DocStatusStorage):
         if doc_id is None:
             return None
         return str(doc_id), doc
+
+    async def resolve_doc_source_strict(
+        self, canonical_source_key: str
+    ) -> SourceResolution:
+        """Typed, conflict-aware source resolution (see base contract).
+
+        Locates up to two PRIMARY (``metadata.is_duplicate != true``) rows via
+        an indexed ``find(...).limit(2)`` and maps 0/1/≥2 →
+        Absent/Unique/Conflict. Transport/query errors PROPAGATE (a swallowed
+        failure would read as :class:`SourceAbsent`, and scan/enqueue treat
+        Absent as "confirmed new", minting duplicate primaries). The ≥2 branch
+        runs one cheap indexed ``count_documents`` for the exact candidate
+        count surfaced in the conflict.
+        """
+        if not canonical_source_key or canonical_source_key == "unknown_source":
+            return SourceAbsent()
+
+        query = {
+            "file_path": canonical_source_key,
+            "metadata.is_duplicate": {"$ne": True},
+        }
+        cursor = self._data.find(query).limit(2)
+        rows = await cursor.to_list(length=2)
+        if not rows:
+            return SourceAbsent()
+        if len(rows) == 1:
+            doc = rows[0]
+            return SourceUnique(
+                doc_id=str(doc.get("_id")),
+                doc=self._scheduling_record_from_doc(doc, strict=True),
+            )
+        candidate_count = await self._data.count_documents(query)
+        return SourceConflict(
+            candidate_count=candidate_count,
+            sample_doc_ids=tuple(sorted(str(d.get("_id")) for d in rows)),
+        )
 
     async def get_doc_by_content_hash(
         self, content_hash: str
@@ -1086,6 +1184,413 @@ class MongoDocStatusStorage(DocStatusStorage):
         if doc_id is None:
             return None
         return str(doc_id), doc
+
+    # ------------------------------------------------------------------
+    # Memory-bounding scheduling API (Phase 1)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _encode_cursor(created_at: str | None, doc_id: str) -> str:
+        return json.dumps([created_at, doc_id], ensure_ascii=False)
+
+    @staticmethod
+    def _decode_cursor(opaque: str) -> tuple[str | None, str]:
+        try:
+            decoded = json.loads(opaque)
+            created, doc_id = decoded
+            if not isinstance(doc_id, str):
+                raise ValueError("cursor id must be a string")
+            if created is not None and not isinstance(created, str):
+                raise ValueError("cursor created_at must be a string or null")
+        except (ValueError, TypeError) as e:
+            raise StorageControlPlaneError(
+                f"Malformed scheduling cursor for MongoDocStatusStorage: {e}"
+            ) from e
+        return created, doc_id
+
+    @staticmethod
+    def _doc_cursor_key(doc: dict[str, Any]) -> tuple[str | None, str]:
+        """(created_at, _id) keyset key of a RAW query-returned doc.
+
+        A missing/null/non-string created_at encodes as ``None`` — the
+        missing/null bucket, which BSON sorts BEFORE every string. Encoding
+        it as ``""`` would break the resume filter: ``{"created_at": ""}``
+        matches neither a missing field nor a null value, so a second corrupt
+        row past the page boundary would silently fall out of the sweep. The
+        ``None`` marker resumes with the ``{"created_at": None}`` predicate,
+        which Mongo defines to match BOTH missing and null."""
+        created = doc.get("created_at")
+        return (created if isinstance(created, str) else None, str(doc.get("_id")))
+
+    def _scheduling_record_from_doc(
+        self, doc: dict[str, Any], *, strict: bool
+    ) -> DocSchedulingRecord | None:
+        """Project one raw Mongo doc; strict raises on unusable docs, relaxed
+        returns None (the caller still counts the doc as consumed)."""
+        doc_id = str(doc.get("_id"))
+        try:
+            status = DocStatus(str(doc["status"]))
+            created_at = doc["created_at"]
+            updated_at = doc.get("updated_at", created_at)
+            if not isinstance(created_at, str) or not isinstance(updated_at, str):
+                raise TypeError("created_at/updated_at must be strings")
+            metadata = doc.get("metadata")
+            return DocSchedulingRecord(
+                id=doc_id,
+                status=status,
+                created_at=created_at,
+                updated_at=updated_at,
+                file_path=doc.get("file_path") or "no-file-path",
+                track_id=doc.get("track_id"),
+                has_custom_chunk_journal=isinstance(metadata, dict)
+                and isinstance(metadata.get(CUSTOM_CHUNK_PATCH_METADATA_KEY), dict),
+            )
+        except (KeyError, TypeError, ValueError) as e:
+            logger.error(f"[{self.workspace}] Unusable scheduling row {doc_id}: {e}")
+            if strict:
+                raise
+            return None
+
+    async def get_docs_by_statuses_page(
+        self,
+        statuses: list[DocStatus],
+        *,
+        limit: int,
+        position: CursorPosition = CURSOR_START,
+        strict: bool = False,
+    ) -> DocStatusPage:
+        """Bounded keyset page: one indexed ``find`` with ``sort`` + ``limit``.
+
+        ``created_at`` is stored as an ISO-8601 string, so the keyset
+        comparison stays string-typed end to end (cursor ↔ query ↔ sort).
+
+        Consumed-position contract: every predicate (status, keyset resume) is
+        evaluated SERVER-side, so the
+        set of query-returned docs IS the set of consumed records — the
+        frontier is the last RETURNED doc's ``(created_at, _id)`` key, and
+        fewer returned docs than ``limit`` proves the sweep is exhausted
+        (CURSOR_END). A relaxed-mode conversion skip drops the doc from the
+        page but the doc was still returned by the query, hence consumed:
+        the cursor advances past it (never re-read, never terminal-by-skip).
+
+        Transport/query errors always propagate (never swallowed into a
+        partial page); ``strict=True`` additionally raises on any returned
+        doc that cannot be projected to :class:`DocSchedulingRecord`.
+        """
+        if limit <= 0:
+            raise ValueError(f"page limit must be positive, got {limit}")
+        if not statuses or position is CURSOR_END:
+            return DocStatusPage(docs={}, next_position=CURSOR_END)
+
+        query: dict[str, Any] = {"status": {"$in": sorted({s.value for s in statuses})}}
+        and_clauses: list[dict[str, Any]] = []
+        if isinstance(position, CursorAfter):
+            created, doc_id = self._decode_cursor(position.opaque)
+            if created is None:
+                # Cursor inside the missing/null bucket (sorted first by
+                # BSON): continue through its remaining docs by _id —
+                # {"created_at": None} matches BOTH missing and null — then
+                # every doc with a real (non-null, existing) value.
+                and_clauses.append(
+                    {
+                        "$or": [
+                            {"created_at": None, "_id": {"$gt": doc_id}},
+                            {"created_at": {"$ne": None}},
+                        ]
+                    }
+                )
+            else:
+                # Past the missing/null bucket: string-typed $gt/$eq never
+                # match missing or null fields, which is correct — that
+                # bucket was already consumed before this cursor.
+                and_clauses.append(
+                    {
+                        "$or": [
+                            {"created_at": {"$gt": created}},
+                            {"created_at": created, "_id": {"$gt": doc_id}},
+                        ]
+                    }
+                )
+        if and_clauses:
+            query["$and"] = and_clauses
+
+        cursor = (
+            self._data.find(query).sort([("created_at", 1), ("_id", 1)]).limit(limit)
+        )
+        raw_docs = await cursor.to_list(length=limit)
+
+        docs: dict[str, DocSchedulingRecord] = {}
+        for doc in raw_docs:
+            record = self._scheduling_record_from_doc(doc, strict=strict)
+            if record is None:
+                continue  # relaxed skip: query-returned, hence still consumed
+            docs[record.id] = record
+
+        if len(raw_docs) < limit:
+            return DocStatusPage(docs=docs, next_position=CURSOR_END)
+        last_created, last_id = self._doc_cursor_key(raw_docs[-1])
+        return DocStatusPage(
+            docs=docs,
+            next_position=CursorAfter(self._encode_cursor(last_created, last_id)),
+        )
+
+    async def count_docs_by_statuses(
+        self, statuses: list[DocStatus], *, strict: bool = True
+    ) -> int:
+        """Fail-closed status count: accurate ``count_documents`` or raise
+        (errors propagate — admission control treats an error as "refuse")."""
+        if not statuses:
+            return 0
+        return await self._data.count_documents(
+            {"status": {"$in": sorted({s.value for s in statuses})}}
+        )
+
+    async def update_doc_status_fields(
+        self,
+        doc_id: str,
+        fields: dict[str, Any],
+        *,
+        missing_ok: bool = False,
+    ) -> None:
+        """Targeted ``$set`` of the given fields only (no read-modify-write,
+        so a huge ``chunks_list`` never travels through memory)."""
+        if "created_at" in fields:
+            raise ValueError(
+                "created_at is an immutable scheduling sort key and cannot "
+                "be changed via update_doc_status_fields"
+            )
+        if not fields:
+            # Mongo rejects an empty $set document; still honour the
+            # existence contract for a no-op update.
+            if missing_ok:
+                return
+            if await self._data.find_one({"_id": doc_id}, {"_id": 1}) is None:
+                raise StorageRecordNotFoundError(doc_id)
+            return
+        result = await self._data.update_one({"_id": doc_id}, {"$set": fields})
+        if result.matched_count == 0:
+            if missing_ok:
+                return
+            raise StorageRecordNotFoundError(doc_id)
+
+    # ------------------------------------------------------------------
+    # Strict batch read
+    # ------------------------------------------------------------------
+
+    async def get_docs_by_ids(
+        self,
+        doc_ids: Sequence[str],
+        *,
+        strict: bool = False,
+    ) -> dict[str, DocSchedulingRecord]:
+        """Batch strict read (see base contract).
+
+        One indexed ``find({"_id": {"$in": ids}})`` — the server answers
+        definitively or raises, so any id absent from the result set is a
+        CONFIRMED absence (never a swallowed failure). ``strict=True`` raises
+        on any returned doc that cannot be projected to
+        :class:`DocSchedulingRecord`, failing the WHOLE call rather than
+        returning a partial mapping.
+        """
+        ids = list(doc_ids)
+        if not ids:
+            return {}
+        cursor = self._data.find({"_id": {"$in": ids}})
+        raw_docs = await cursor.to_list(length=None)
+        result: dict[str, DocSchedulingRecord] = {}
+        for doc in raw_docs:
+            record = self._scheduling_record_from_doc(doc, strict=strict)
+            if record is None:
+                continue
+            result[record.id] = record
+        return result
+
+    # ------------------------------------------------------------------
+    # Source-conflict listing and explicit CAS repair
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _conflict_fingerprint(sorted_doc_ids: list[str]) -> str:
+        """Deterministic digest over candidate doc IDs in stable sort order."""
+        digest = hashlib.sha256()
+        for doc_id in sorted_doc_ids:
+            digest.update(doc_id.encode("utf-8"))
+            digest.update(b"\x00")
+        return digest.hexdigest()
+
+    @staticmethod
+    def _decode_conflict_cursor(opaque: str) -> str:
+        try:
+            key = json.loads(opaque)
+            if not isinstance(key, str):
+                raise ValueError("conflict cursor must be a string")
+        except (ValueError, TypeError) as e:
+            raise StorageControlPlaneError(
+                f"Malformed source-conflict cursor for MongoDocStatusStorage: {e}"
+            ) from e
+        return key
+
+    async def _primary_candidates(
+        self, canonical_source_key: str, *, session: Any = None
+    ) -> list[str]:
+        """Sorted primary (``metadata.is_duplicate != true``) doc IDs for a
+        canonical key, projecting only ``_id`` (optionally in a session)."""
+        cursor = self._data.find(
+            {"file_path": canonical_source_key, "metadata.is_duplicate": {"$ne": True}},
+            {"_id": 1},
+            session=session,
+        )
+        rows = await cursor.to_list(length=None)
+        return sorted(str(r.get("_id")) for r in rows)
+
+    async def list_source_conflicts_page(
+        self,
+        *,
+        limit: int,
+        position: CursorPosition = CURSOR_START,
+    ) -> SourceConflictPage:
+        """Page canonical source keys with >1 primary candidate (see base).
+
+        A server-side aggregation groups PRIMARY (``metadata.is_duplicate !=
+        true``) rows by ``file_path``, keeps groups with candidate count ≥ 2,
+        resumes strictly after the cursor's canonical key (``$gt``) and sorts
+        by canonical key so the keyset is stable. ``candidate_count`` is the
+        exact group size; the surfaced sample is bounded to
+        ``_CONFLICT_SAMPLE_CAP``.
+        """
+        if limit <= 0:
+            raise ValueError(f"page limit must be positive, got {limit}")
+        if position is CURSOR_END:
+            return SourceConflictPage(conflicts=(), next_position=CURSOR_END)
+
+        match: dict[str, Any] = {
+            "file_path": {
+                "$type": "string",
+                "$nin": ["", "unknown_source", "no-file-path"],
+            },
+            "metadata.is_duplicate": {"$ne": True},
+        }
+        if isinstance(position, CursorAfter):
+            match["file_path"]["$gt"] = self._decode_conflict_cursor(position.opaque)
+
+        pipeline = [
+            {"$match": match},
+            {
+                "$group": {
+                    "_id": "$file_path",
+                    "candidate_count": {"$sum": 1},
+                    "sample_doc_ids": {"$push": "$_id"},
+                }
+            },
+            {"$match": {"candidate_count": {"$gte": 2}}},
+            {"$sort": {"_id": 1}},
+            {"$limit": limit},
+        ]
+        cursor = await self._data.aggregate(pipeline, allowDiskUse=True)
+        groups = await cursor.to_list(length=limit)
+
+        conflicts = tuple(
+            SourceConflictSummary(
+                canonical_source_key=str(g["_id"]),
+                candidate_count=int(g["candidate_count"]),
+                sample_doc_ids=tuple(
+                    sorted(str(d) for d in g["sample_doc_ids"])[
+                        : self._CONFLICT_SAMPLE_CAP
+                    ]
+                ),
+            )
+            for g in groups
+        )
+        if len(groups) < limit:
+            next_position: CursorPosition = CURSOR_END
+        else:
+            next_position = CursorAfter(
+                json.dumps(str(groups[-1]["_id"]), ensure_ascii=False)
+            )
+        return SourceConflictPage(conflicts=conflicts, next_position=next_position)
+
+    async def repair_source_conflict(
+        self,
+        canonical_source_key: str,
+        *,
+        primary_doc_id: str,
+        expected_candidate_count: int,
+        expected_candidate_fingerprint: str,
+        dry_run: bool = True,
+    ) -> SourceConflictRepairResult:
+        """Demote all-but-one primary to duplicate, CAS-guarded (see base).
+
+        A dry run reads the current candidate set and returns the
+        count/fingerprint the operator must echo back. A commit re-reads the
+        candidates INSIDE a Mongo transaction; if the count/fingerprint no
+        longer match the echoed expectation it raises
+        ``StorageControlPlaneError`` (CAS — never overwrites a concurrent
+        change) and the transaction aborts. Otherwise every losing candidate
+        is marked ``metadata.is_duplicate=true`` +
+        ``original_doc_id=primary_doc_id`` in the same transaction (content is
+        never deleted). ``primary_doc_id`` absent from the current candidate
+        set raises ``ValueError``.
+        """
+        if dry_run:
+            candidates = await self._primary_candidates(canonical_source_key)
+            count = len(candidates)
+            fingerprint = self._conflict_fingerprint(candidates)
+            if primary_doc_id not in candidates:
+                raise ValueError(
+                    f"primary_doc_id {primary_doc_id!r} is not a current primary "
+                    f"candidate for {canonical_source_key!r}"
+                )
+            demoted = [d for d in candidates if d != primary_doc_id]
+            return SourceConflictRepairResult(
+                canonical_source_key=canonical_source_key,
+                primary_doc_id=primary_doc_id,
+                candidate_count=count,
+                fingerprint=fingerprint,
+                demoted_sample_doc_ids=tuple(demoted[: self._CONFLICT_SAMPLE_CAP]),
+                committed=False,
+            )
+
+        async with self.db.client.start_session() as session:
+            async with await session.start_transaction():
+                candidates = await self._primary_candidates(
+                    canonical_source_key, session=session
+                )
+                count = len(candidates)
+                fingerprint = self._conflict_fingerprint(candidates)
+                if primary_doc_id not in candidates:
+                    raise ValueError(
+                        f"primary_doc_id {primary_doc_id!r} is not a current "
+                        f"primary candidate for {canonical_source_key!r}"
+                    )
+                if (
+                    count != expected_candidate_count
+                    or fingerprint != expected_candidate_fingerprint
+                ):
+                    raise StorageControlPlaneError(
+                        f"[{self.workspace}] source-conflict repair CAS failed for "
+                        f"{canonical_source_key!r}: candidate set changed "
+                        f"(count {count} vs {expected_candidate_count})"
+                    )
+                demoted = [d for d in candidates if d != primary_doc_id]
+                if demoted:
+                    await self._data.update_many(
+                        {"_id": {"$in": demoted}},
+                        {
+                            "$set": {
+                                "metadata.is_duplicate": True,
+                                "metadata.original_doc_id": primary_doc_id,
+                            }
+                        },
+                        session=session,
+                    )
+        return SourceConflictRepairResult(
+            canonical_source_key=canonical_source_key,
+            primary_doc_id=primary_doc_id,
+            candidate_count=count,
+            fingerprint=fingerprint,
+            demoted_sample_doc_ids=tuple(demoted[: self._CONFLICT_SAMPLE_CAP]),
+            committed=True,
+        )
 
 
 @final

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -1380,9 +1380,12 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
     ``search_after`` keyset pages sorted ``(created_at ASC, __mirrored_id
     ASC)`` — ``_id`` is not sortable in OpenSearch, so ``__mirrored_id``
     (a keyword copy of the doc id that every write path mirrors) is the
-    page-sort tiebreaker. A missing/NULL ``created_at`` sorts FIRST
-    (``"missing": "_first"``) so legacy rows stay reachable across page
-    boundaries, aligning with the other backends' NULLS-FIRST keyset.
+    page-sort tiebreaker, and startup guarantees every doc carries a VALUE
+    for it on every cluster version (no PIT here means no ``_shard_doc``
+    fallback — see ``_ensure_scheduling_tiebreaker_ready``). A missing/NULL
+    ``created_at`` sorts FIRST (``"missing": "_first"``) so legacy rows stay
+    reachable across page boundaries, aligning with the other backends'
+    NULLS-FIRST keyset.
     Conflict-aware strict source resolution, strict batch reads and the
     operator source-conflict repair flow round out the contract.
     """
@@ -1406,10 +1409,10 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
 
     # ``__mirrored_id`` is a keyword copy of the doc id mirrored by every
     # write path: ``_id`` is not sortable, so this is the page-sort
-    # tiebreaker. Included in the ensured mapping so legacy indexes
-    # (pre-mirrored-id, only tolerated on OpenSearch >= 3.3.0) gain the
-    # keyword mapping for new writes; their OLD docs still lack the field
-    # VALUE and sort behind everything with an unresolved tie until rewritten.
+    # tiebreaker. Included in the ensured mapping so legacy indexes gain the
+    # keyword mapping for new writes; their OLD docs are backfilled from
+    # ``_id`` at startup by ``_ensure_scheduling_tiebreaker_ready`` (a missing
+    # VALUE means NO tiebreaker, which silently skips docs — see there).
     _SCHEDULING_FIELD_MAPPINGS: ClassVar[dict[str, dict[str, str]]] = {
         "__mirrored_id": {"type": "keyword"},
     }
@@ -1508,9 +1511,17 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                     f"[{self.workspace}] Created doc status index: {self._index_name}"
                 )
             else:
-                await _verify_mirrored_id_mapping(self.client, self._index_name)
                 await self._ensure_content_hash_mapping()
-                await self._ensure_scheduling_fields_mapping()
+                added = await self._ensure_scheduling_fields_mapping()
+                if "__mirrored_id" in added:
+                    # Supersedes the version-gated mapping-only check used by
+                    # the KV store: this index needs __mirrored_id VALUES on
+                    # every cluster version (its scheduling page has no PIT),
+                    # and a mapping present with values missing is exactly the
+                    # silent skip we must prevent. Only a pre-existing index
+                    # that LACKED the mapping can hold such docs, so the audit
+                    # costs nothing on an already-migrated index.
+                    await self._ensure_scheduling_tiebreaker_ready()
         except RequestError as e:
             if "resource_already_exists_exception" not in str(e):
                 raise
@@ -1550,22 +1561,26 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                 f"{self._index_name}: {e}"
             )
 
-    async def _ensure_scheduling_fields_mapping(self) -> None:
+    async def _ensure_scheduling_fields_mapping(self) -> set[str]:
         """Ensure the ``__mirrored_id`` keyword mapping on a pre-existing index.
 
         Same idempotent put_mapping pattern as ``_ensure_content_hash_mapping``
         (new fields only — existing indexes need nothing else for new docs).
-        ``__mirrored_id`` is the page-sort tiebreaker; legacy docs predating it
-        still lack the field VALUE (they sort behind everything until
-        rewritten). A put failure is logged rather than raised — ``dynamic:
-        true`` maps the field on first write with the same type, and the
-        strict page sort fails loudly (never silently misorders) if
-        ``__mirrored_id`` stays unsortable.
+        The mapping alone is NOT sufficient: legacy docs predating the field
+        still lack the VALUE, which
+        :meth:`_ensure_scheduling_tiebreaker_ready` repairs. A put failure is
+        logged rather than raised here — the readiness check that follows is
+        the one that fails startup.
+
+        Returns the field names that were absent, which is the precise "this
+        index predates the field" signal the value audit keys off (an index
+        that already maps ``__mirrored_id`` was written by code that mirrors
+        the id on every write, so its docs all carry a value).
         """
         try:
             mapping = await self.client.indices.get_mapping(index=self._index_name)
         except OpenSearchException:
-            return
+            return set()
         props = (
             mapping.get(self._index_name, {}).get("mappings", {}).get("properties", {})
         )
@@ -1575,7 +1590,7 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
             if name not in props
         }
         if not missing:
-            return
+            return set()
         try:
             await self.client.indices.put_mapping(
                 index=self._index_name,
@@ -1590,6 +1605,82 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                 f"[{self.workspace}] Failed to add scheduling field mappings to "
                 f"{self._index_name}: {e}"
             )
+        return set(missing)
+
+    async def _count_docs_missing_mirrored_id(self) -> int:
+        """Count docs with no ``__mirrored_id`` VALUE (not just no mapping)."""
+        response = await self.client.count(
+            index=self._index_name,
+            body={
+                "query": {"bool": {"must_not": {"exists": {"field": "__mirrored_id"}}}}
+            },
+        )
+        count = response.get("count")
+        if not isinstance(count, int):
+            raise RuntimeError(
+                f"OpenSearch _count returned a malformed response while auditing "
+                f"'__mirrored_id' coverage on '{self._index_name}': {response!r}"
+            )
+        return count
+
+    async def _ensure_scheduling_tiebreaker_ready(self) -> None:
+        """Guarantee every doc carries a ``__mirrored_id`` VALUE, or fail startup.
+
+        The scheduling page (:meth:`get_docs_by_statuses_page`) is a PLAIN
+        ``search_after`` keyset with NO point-in-time, so ``_shard_doc`` — the
+        implicit tiebreaker that makes PIT pagination safe on OpenSearch >=
+        3.3.0 — is not available to it. ``__mirrored_id`` is therefore the ONLY
+        tiebreaker, on every cluster version, and a doc missing its VALUE has no
+        tiebreaker at all: ``search_after`` excludes sort values EQUAL to the
+        cursor, so once a page boundary lands on such a doc, every other doc
+        sharing its ``created_at`` (common for bulk ingest, which stamps the
+        same millisecond) is silently SKIPPED and never scheduled.
+
+        Restore-then-serve (never serve a broken invariant): add the mapping,
+        backfill the missing values server-side with one bounded
+        ``_update_by_query``, then VERIFY coverage and raise if anything
+        remains. Verifying the outcome rather than trusting the script also
+        means a cluster that refuses ``ctx._id`` fails loudly instead of
+        leaving a silently lossy sweep. Idempotent and cheap in steady state:
+        indexes written by current code match zero docs, so this costs one
+        ``_count``.
+        """
+        missing = await self._count_docs_missing_mirrored_id()
+        if missing == 0:
+            return
+        logger.warning(
+            f"[{self.workspace}] {missing} doc(s) in '{self._index_name}' predate "
+            f"the '__mirrored_id' page-sort tiebreaker; backfilling from _id "
+            f"before serving scheduling pages"
+        )
+        await self.client.update_by_query(
+            index=self._index_name,
+            body={
+                "query": {"bool": {"must_not": {"exists": {"field": "__mirrored_id"}}}},
+                "script": {
+                    "source": "ctx._source.__mirrored_id = ctx._id",
+                    "lang": "painless",
+                },
+                # Concurrent writers may bump versions mid-backfill; those docs
+                # already carry the field, so proceeding is correct and the
+                # verification below is what actually decides.
+                "conflicts": "proceed",
+            },
+            refresh=True,
+        )
+        remaining = await self._count_docs_missing_mirrored_id()
+        if remaining:
+            raise RuntimeError(
+                f"Index '{self._index_name}' still has {remaining} doc(s) without a "
+                f"'__mirrored_id' value after the backfill. Bounded scheduling "
+                f"pages cannot be served safely: documents sharing a 'created_at' "
+                f"would be silently skipped by the sweep. Reindex the data, then "
+                f"restart."
+            )
+        logger.info(
+            f"[{self.workspace}] Backfilled '__mirrored_id' for {missing} legacy "
+            f"doc(s) in '{self._index_name}'"
+        )
 
     async def finalize(self):
         """Release the OpenSearch client connection."""
@@ -2287,13 +2378,17 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
         values are the natural consumed frontier (they cover hits skipped as
         unusable in relaxed mode, too).
 
-        Strict/failure semantics: ``_index_ready=False`` raises under
-        ``strict`` (the index was dropped/lost — cannot confirm the sweep is
-        complete); a live missing-index error mirrors the existing
-        ``get_docs_by_statuses`` strict decision (legitimately empty →
-        empty terminal page); transport errors raise WITHOUT returning
-        partial docs or a new cursor; ``strict`` additionally turns
-        unusable-row skips into raises.
+        Strict/failure semantics: a lost index — whether already known
+        (``_index_ready=False``) or discovered live (``index_not_found``) —
+        raises under ``strict``; both mean the same thing (the index is gone,
+        so the sweep cannot be confirmed complete) and must not differ merely
+        by which call noticed first. An empty terminal page would be read as
+        "no work left", stranding every document. A legitimate ``drop()``
+        already clears ``_index_ready``, so reaching the live branch means the
+        index vanished from under us. Relaxed mode keeps the best-effort empty
+        terminal page. Transport errors raise WITHOUT returning partial docs or
+        a new cursor; ``strict`` additionally turns unusable-row skips into
+        raises.
         """
         if limit <= 0:
             raise ValueError(f"page limit must be positive, got {limit}")
@@ -2324,6 +2419,12 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
         except OpenSearchException as e:
             if _is_missing_index_error(e):
                 self._mark_index_missing()
+                if strict:
+                    raise StorageControlPlaneError(
+                        f"[{self.workspace}] doc status index "
+                        f"'{self._index_name}' vanished mid-sweep; cannot "
+                        f"serve a complete scheduling page"
+                    ) from e
                 return DocStatusPage(docs={}, next_position=CURSOR_END)
             # Complete-or-raise in BOTH modes: a partial page + advanced
             # cursor would silently strand the missed documents.
@@ -2348,11 +2449,14 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
     ) -> int:
         """Fail-closed status count via the ``_count`` API (base contract).
 
-        Always accurate-or-raise regardless of ``strict`` — admission
-        control must never read an error as "capacity available".
-        ``_index_ready=False`` raises; a live missing-index error mirrors
-        the existing strict ``get_docs_by_statuses`` decision (legitimately
-        empty → 0).
+        Always accurate-or-raise regardless of ``strict`` — admission control
+        must never read an error as "capacity available". A lost index raises
+        whether it was already known (``_index_ready=False``) or discovered
+        live (``index_not_found``): returning ``0`` for the live case would
+        make the FIRST call after an external drop report full capacity and
+        only later calls fail closed. A legitimate ``drop()`` already clears
+        ``_index_ready``, so the live branch means the index vanished from
+        under us.
         """
         if not statuses:
             return 0
@@ -2367,7 +2471,10 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
         except OpenSearchException as e:
             if _is_missing_index_error(e):
                 self._mark_index_missing()
-                return 0
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] doc status index '{self._index_name}' "
+                    f"vanished; cannot produce an accurate status count"
+                ) from e
             logger.error(f"[{self.workspace}] Error counting doc statuses: {e}")
             raise
         count = response.get("count")

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -9,23 +9,42 @@ Requirements:
     - OpenSearch 3.x or higher with k-NN plugin enabled
 """
 
+import hashlib
+import json
 import os
 import re
 import ssl as ssl_module
 import time
 import asyncio
 from dataclasses import dataclass, field
-from typing import Any, AsyncIterator, Union, final
+from typing import Any, AsyncIterator, ClassVar, Sequence, Union, final
 import numpy as np
 import configparser
 
 from ..base import (
+    CURSOR_END,
+    CURSOR_START,
     BaseGraphStorage,
     BaseKVStorage,
     BaseVectorStorage,
+    CursorAfter,
+    CursorPosition,
     DocProcessingStatus,
+    DocSchedulingRecord,
     DocStatus,
+    DocStatusPage,
     DocStatusStorage,
+    SourceAbsent,
+    SourceConflict,
+    SourceConflictPage,
+    SourceConflictRepairResult,
+    SourceConflictSummary,
+    SourceResolution,
+    SourceUnique,
+)
+from ..exceptions import (
+    StorageControlPlaneError,
+    StorageRecordNotFoundError,
 )
 from ..utils import (
     logger,
@@ -35,7 +54,11 @@ from ..utils import (
     validate_workspace,
 )
 from ..types import KnowledgeGraph, KnowledgeGraphNode, KnowledgeGraphEdge
-from ..constants import GRAPH_FIELD_SEP, DEFAULT_QUERY_PRIORITY
+from ..constants import (
+    CUSTOM_CHUNK_PATCH_METADATA_KEY,
+    GRAPH_FIELD_SEP,
+    DEFAULT_QUERY_PRIORITY,
+)
 from ..kg.shared_storage import get_data_init_lock, get_namespace_lock
 
 import pipmaster as pm
@@ -658,6 +681,8 @@ async def _verify_mirrored_id_mapping(client: AsyncOpenSearch, index_name: str) 
 class OpenSearchKVStorage(BaseKVStorage):
     """Key-Value storage using OpenSearch. Uses dynamic mapping to support varied schemas."""
 
+    supports_strict_point_reads: ClassVar[bool] = True
+
     client: AsyncOpenSearch = field(default=None)
     _index_name: str = field(default="", init=False)
     _index_ready: bool = field(default=False, init=False)
@@ -901,6 +926,60 @@ class OpenSearchKVStorage(BaseKVStorage):
             # would delete a live doc_status row on a transient failure.
             logger.error(f"[{self.workspace}] Error getting document {id}: {e}")
             raise
+
+    async def get_by_id_strict(self, id: str) -> dict[str, Any] | None:
+        """Point read with complete-or-raise semantics (base contract).
+
+        Three-state contract on top of the pending buffer:
+
+        * pending delete (tombstone) → ``None`` — the delete is already
+          decided, so absence after flush is a certainty;
+        * pending upsert → the buffered doc (present);
+        * ``_index_ready=False`` → raise ``StorageControlPlaneError``: the
+          index was dropped or previously observed missing, so this class
+          CANNOT positively confirm absence (unlike ``get_by_id``, which
+          reads that state as a best-effort miss);
+        * a live ``index_not_found`` error → raise as well — after
+          ``initialize()`` the index always exists, so it vanishing mid-read
+          (restore/concurrent drop) is indistinguishable from data loss and
+          must not be presented as "confirmed absent";
+        * healthy mget with ``found=False`` → ``None`` (confirmed absent);
+        * any other transport/server or item-level error → raise.
+        """
+        async with self._flush_lock:
+            if id in self._pending_kv_deletes:
+                return None
+            pending = self._pending_upserts.get(id)
+            if pending is not None:
+                return self._materialize_pending_kv_doc(id, pending)
+            if not self._index_ready:
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] {self.namespace} index "
+                    f"'{self._index_name}' is not ready; cannot confirm "
+                    f"absence of '{id}' (strict point read)"
+                )
+        try:
+            response = await _mget_optional_doc(self.client, self._index_name, id)
+        except OpenSearchException as e:
+            if _is_missing_index_error(e):
+                self._mark_index_missing()
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] {self.namespace} index "
+                    f"'{self._index_name}' unexpectedly missing; cannot "
+                    f"confirm absence of '{id}' (strict point read)"
+                ) from e
+            logger.error(
+                f"[{self.workspace}] Error strictly getting document {id}: {e}"
+            )
+            raise
+        if response is None:
+            return None
+        doc = response["_source"]
+        doc.pop("__mirrored_id", None)
+        doc["_id"] = response["_id"]
+        doc.setdefault("create_time", 0)
+        doc.setdefault("update_time", 0)
+        return doc
 
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
         """Get multiple documents by IDs (read-your-writes), preserving order.
@@ -1295,7 +1374,45 @@ class OpenSearchKVStorage(BaseKVStorage):
 @final
 @dataclass
 class OpenSearchDocStatusStorage(DocStatusStorage):
-    """Document status storage using OpenSearch."""
+    """Document status storage using OpenSearch.
+
+    Memory-bounding scheduling API (Phase 1): implements native
+    ``search_after`` keyset pages sorted ``(created_at ASC, __mirrored_id
+    ASC)`` — ``_id`` is not sortable in OpenSearch, so ``__mirrored_id``
+    (a keyword copy of the doc id that every write path mirrors) is the
+    page-sort tiebreaker. A missing/NULL ``created_at`` sorts FIRST
+    (``"missing": "_first"``) so legacy rows stay reachable across page
+    boundaries, aligning with the other backends' NULLS-FIRST keyset.
+    Conflict-aware strict source resolution, strict batch reads and the
+    operator source-conflict repair flow round out the contract.
+    """
+
+    supports_strict_point_reads: ClassVar[bool] = True
+
+    # Bounded upper limit on the sample of conflicting doc IDs surfaced by the
+    # source-conflict listing/repair APIs — never materialize the whole set.
+    _CONFLICT_SAMPLE_CAP: ClassVar[int] = 32
+
+    # Fields the lightweight scheduling projection needs from ``_source`` —
+    # never ``chunks_list`` (see ``get_docs_by_ids``).
+    _SCHEDULING_SOURCE_FIELDS: ClassVar[list[str]] = [
+        "status",
+        "created_at",
+        "updated_at",
+        "file_path",
+        "track_id",
+        "metadata",
+    ]
+
+    # ``__mirrored_id`` is a keyword copy of the doc id mirrored by every
+    # write path: ``_id`` is not sortable, so this is the page-sort
+    # tiebreaker. Included in the ensured mapping so legacy indexes
+    # (pre-mirrored-id, only tolerated on OpenSearch >= 3.3.0) gain the
+    # keyword mapping for new writes; their OLD docs still lack the field
+    # VALUE and sort behind everything with an unresolved tie until rewritten.
+    _SCHEDULING_FIELD_MAPPINGS: ClassVar[dict[str, dict[str, str]]] = {
+        "__mirrored_id": {"type": "keyword"},
+    }
 
     client: AsyncOpenSearch = field(default=None)
     _index_name: str = field(default="", init=False)
@@ -1338,7 +1455,7 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
         return data
 
     async def initialize(self):
-        """Initialize client connection and create doc status index."""
+        """Initialize client connection and create the doc-status index."""
         async with get_data_init_lock():
             if self.client is None:
                 self.client = await ClientManager.get_client()
@@ -1393,6 +1510,7 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
             else:
                 await _verify_mirrored_id_mapping(self.client, self._index_name)
                 await self._ensure_content_hash_mapping()
+                await self._ensure_scheduling_fields_mapping()
         except RequestError as e:
             if "resource_already_exists_exception" not in str(e):
                 raise
@@ -1432,6 +1550,47 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                 f"{self._index_name}: {e}"
             )
 
+    async def _ensure_scheduling_fields_mapping(self) -> None:
+        """Ensure the ``__mirrored_id`` keyword mapping on a pre-existing index.
+
+        Same idempotent put_mapping pattern as ``_ensure_content_hash_mapping``
+        (new fields only — existing indexes need nothing else for new docs).
+        ``__mirrored_id`` is the page-sort tiebreaker; legacy docs predating it
+        still lack the field VALUE (they sort behind everything until
+        rewritten). A put failure is logged rather than raised — ``dynamic:
+        true`` maps the field on first write with the same type, and the
+        strict page sort fails loudly (never silently misorders) if
+        ``__mirrored_id`` stays unsortable.
+        """
+        try:
+            mapping = await self.client.indices.get_mapping(index=self._index_name)
+        except OpenSearchException:
+            return
+        props = (
+            mapping.get(self._index_name, {}).get("mappings", {}).get("properties", {})
+        )
+        missing = {
+            name: spec
+            for name, spec in self._SCHEDULING_FIELD_MAPPINGS.items()
+            if name not in props
+        }
+        if not missing:
+            return
+        try:
+            await self.client.indices.put_mapping(
+                index=self._index_name,
+                body={"properties": missing},
+            )
+            logger.info(
+                f"[{self.workspace}] Added scheduling field mappings "
+                f"{sorted(missing)} to {self._index_name}"
+            )
+        except OpenSearchException as e:
+            logger.warning(
+                f"[{self.workspace}] Failed to add scheduling field mappings to "
+                f"{self._index_name}: {e}"
+            )
+
     async def finalize(self):
         """Release the OpenSearch client connection."""
         if self.client is not None:
@@ -1455,6 +1614,41 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                 return None
             logger.error(f"[{self.workspace}] Error getting doc status {id}: {e}")
             return None
+
+    async def get_by_id_strict(self, id: str) -> Union[dict[str, Any], None]:
+        """Point read with complete-or-raise semantics (base contract).
+
+        Unlike ``get_by_id`` (best-effort: errors and a not-ready index read
+        as a miss), ``None`` here is only returned on a healthy mget miss —
+        ``_index_ready=False``, a live missing-index error and any transport
+        or item-level error RAISE because absence cannot be positively
+        confirmed in those states.
+        """
+        if not self._index_ready:
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] doc status index '{self._index_name}' is "
+                f"not ready; cannot confirm absence of '{id}' (strict point "
+                f"read)"
+            )
+        try:
+            response = await _mget_optional_doc(self.client, self._index_name, id)
+        except OpenSearchException as e:
+            if _is_missing_index_error(e):
+                self._mark_index_missing()
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] doc status index '{self._index_name}' "
+                    f"unexpectedly missing; cannot confirm absence of '{id}' "
+                    f"(strict point read)"
+                ) from e
+            logger.error(
+                f"[{self.workspace}] Error strictly getting doc status {id}: {e}"
+            )
+            raise
+        if response is None:
+            return None
+        doc = response["_source"]
+        doc["_id"] = response["_id"]
+        return doc
 
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
         """Get multiple document status records by IDs."""
@@ -1840,15 +2034,38 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
             logger.error(f"[{self.workspace}] Error getting doc by file_path: {e}")
             return None
 
+    @staticmethod
+    def _primary_basename_query(basename: str) -> dict[str, Any]:
+        """Exact basename match restricted to the PRIMARY row.
+
+        ``file_path`` is one-to-many (duplicate-attempt ``dup-*`` rows keep
+        the same canonical basename); ``metadata.is_duplicate == true`` rows
+        are excluded so identity checks / dedup always see the document,
+        never a duplicate marker. Legacy rows without the field are not
+        excluded (``must_not term`` matches nothing on a missing field).
+        """
+        return {
+            "query": {
+                "bool": {
+                    "filter": [{"term": {"file_path": basename}}],
+                    "must_not": [{"term": {"metadata.is_duplicate": True}}],
+                }
+            },
+            "size": 1,
+        }
+
     async def get_doc_by_file_basename(
         self, basename: str
     ) -> Union[tuple[str, dict[str, Any]], None]:
-        """Find an existing record whose canonical basename matches.
+        """Find the PRIMARY record whose canonical basename matches.
 
         The caller is responsible for passing an already-canonical basename;
         stored ``file_path`` values are canonicalized by the business layer, so
         this lookup performs an exact term query against the file_path keyword
-        field.
+        field, restricted to the primary (``metadata.is_duplicate != true``)
+        row. Legacy best-effort semantics: errors are swallowed and read as a
+        miss — dedup/identity callers that need fail-closed, conflict-aware
+        confirmation use :meth:`resolve_doc_source_strict`.
         """
         if not basename:
             return None
@@ -1857,7 +2074,7 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
         if not self._index_ready:
             return None
         try:
-            body = {"query": {"term": {"file_path": basename}}, "size": 1}
+            body = self._primary_basename_query(basename)
             response = await self.client.search(index=self._index_name, body=body)
             hits = response["hits"]["hits"]
             if not hits:
@@ -1871,6 +2088,84 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                 return None
             logger.error(f"[{self.workspace}] Error getting doc by file_basename: {e}")
             return None
+
+    async def resolve_doc_source_strict(
+        self, canonical_source_key: str
+    ) -> SourceResolution:
+        """Typed, conflict-aware source resolution (base contract).
+
+        Queries PRIMARY (``metadata.is_duplicate != true``) rows for the
+        canonical basename with ``size: 2`` to distinguish
+        Absent/Unique/Conflict without materializing the whole set; a
+        ``SourceConflict`` then runs the cheap ``_count`` API for the exact
+        candidate count. ``_index_ready=False`` and a live missing-index
+        error raise ``StorageControlPlaneError`` (never ``SourceAbsent``) —
+        scan/enqueue treat Absent as "confirmed new", so a swallowed failure
+        would mint duplicate rows. Other transport errors propagate.
+        """
+        if not canonical_source_key or canonical_source_key == "unknown_source":
+            return SourceAbsent()
+        if not self._index_ready:
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] doc status index '{self._index_name}' is "
+                f"not ready; cannot resolve source '{canonical_source_key}' "
+                f"(strict source resolution)"
+            )
+        query = self._primary_basename_query(canonical_source_key)["query"]
+        body = {
+            "query": query,
+            "sort": [{"__mirrored_id": {"order": "asc"}}],
+            "size": 2,
+        }
+        try:
+            response = await self.client.search(index=self._index_name, body=body)
+        except OpenSearchException as e:
+            if _is_missing_index_error(e):
+                self._mark_index_missing()
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] doc status index '{self._index_name}' "
+                    f"unexpectedly missing; cannot resolve source "
+                    f"'{canonical_source_key}' (strict source resolution)"
+                ) from e
+            logger.error(
+                f"[{self.workspace}] Error resolving doc source "
+                f"'{canonical_source_key}': {e}"
+            )
+            raise
+        hits = response["hits"]["hits"]
+        if not hits:
+            return SourceAbsent()
+        if len(hits) == 1:
+            hit = hits[0]
+            return SourceUnique(
+                doc_id=hit["_id"],
+                doc=self._scheduling_record_from_hit(hit, strict=True),
+            )
+        # >=2 primary candidates: exact count via the cheap _count API.
+        try:
+            count_resp = await self.client.count(
+                index=self._index_name, body={"query": query}
+            )
+        except OpenSearchException as e:
+            if _is_missing_index_error(e):
+                self._mark_index_missing()
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] doc status index '{self._index_name}' "
+                    f"unexpectedly missing while counting source conflict "
+                    f"'{canonical_source_key}' (strict source resolution)"
+                ) from e
+            logger.error(
+                f"[{self.workspace}] Error counting source conflict "
+                f"'{canonical_source_key}': {e}"
+            )
+            raise
+        count = count_resp.get("count")
+        candidate_count = count if isinstance(count, int) else None
+        sample_doc_ids = tuple(sorted(hit["_id"] for hit in hits[:2]))
+        return SourceConflict(
+            candidate_count=candidate_count,
+            sample_doc_ids=sample_doc_ids,
+        )
 
     async def get_doc_by_content_hash(
         self, content_hash: str
@@ -1901,6 +2196,581 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                 return None
             logger.error(f"[{self.workspace}] Error getting doc by content_hash: {e}")
             return None
+
+    # ------------------------------------------------------------------
+    # Memory-bounding scheduling API (Phase 1)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _decode_page_cursor(opaque: str) -> list[Any]:
+        """Decode an opaque page cursor back into ``search_after`` values.
+
+        The cursor is ``json.dumps(hits[-1]["sort"])`` — the last hit's sort
+        values verbatim, i.e. ``[created_at sort value, __mirrored_id]``.
+        Anything that does not decode to that two-element list is a corrupt
+        continuation token: raise a control-plane error instead of silently
+        restarting (or worse, mis-positioning) the sweep.
+        """
+        try:
+            decoded = json.loads(opaque)
+        except (TypeError, ValueError) as e:
+            raise StorageControlPlaneError(
+                f"Malformed scheduling cursor for OpenSearchDocStatusStorage: {e}"
+            ) from e
+        if not isinstance(decoded, list) or len(decoded) != 2:
+            raise StorageControlPlaneError(
+                "Malformed scheduling cursor for OpenSearchDocStatusStorage: "
+                f"expected a 2-element sort-values list, got {decoded!r}"
+            )
+        return decoded
+
+    @staticmethod
+    def _build_scheduling_page_query(status_values: list[str]) -> dict[str, Any]:
+        """Server-side page query: a status terms filter over the sweep set."""
+        return {"terms": {"status": sorted(status_values)}}
+
+    def _scheduling_record_from_hit(
+        self, hit: dict[str, Any], *, strict: bool
+    ) -> DocSchedulingRecord | None:
+        """Project one search hit; strict raises on unusable rows, relaxed
+        returns None (the row still counts as consumed — the cursor is the
+        last HIT's sort values, so skipped hits never re-appear)."""
+        doc_id = hit.get("_id")
+        source = hit.get("_source")
+        try:
+            if not isinstance(doc_id, str) or not isinstance(source, dict):
+                raise TypeError("malformed search hit")
+            status = DocStatus(str(source["status"]))
+            created_at = source["created_at"]
+            updated_at = source.get("updated_at", created_at)
+            if not isinstance(created_at, str) or not isinstance(updated_at, str):
+                raise TypeError("created_at/updated_at must be strings")
+            metadata = source.get("metadata")
+            return DocSchedulingRecord(
+                id=doc_id,
+                status=status,
+                created_at=created_at,
+                updated_at=updated_at,
+                file_path=source.get("file_path") or "no-file-path",
+                track_id=source.get("track_id"),
+                has_custom_chunk_journal=isinstance(metadata, dict)
+                and isinstance(metadata.get(CUSTOM_CHUNK_PATCH_METADATA_KEY), dict),
+            )
+        except (KeyError, TypeError, ValueError) as e:
+            logger.error(f"[{self.workspace}] Unusable scheduling row {doc_id}: {e}")
+            if strict:
+                raise
+            return None
+
+    async def get_docs_by_statuses_page(
+        self,
+        statuses: list[DocStatus],
+        *,
+        limit: int,
+        position: CursorPosition = CURSOR_START,
+        strict: bool = False,
+    ) -> DocStatusPage:
+        """Bounded keyset page via native ``search_after`` (base contract).
+
+        Sort is ``(created_at ASC, __mirrored_id ASC)`` — ``_id`` is not
+        sortable in OpenSearch, so the id is tie-broken on the keyword field
+        every write path mirrors it into. The ``created_at`` sort carries
+        ``"missing": "_first"`` so rows lacking the field sort FIRST (an
+        empty bucket) and stay reachable across page boundaries — aligning
+        with the other backends' NULLS-FIRST keyset rather than OpenSearch's
+        ``_last`` default. Plain ``search_after`` (NO point-in-time): the
+        contract is live-view across requests, not a snapshot. Filtering (a
+        status terms clause) is fully server-side, so every hit is consumed
+        by construction and ``returned < limit`` proves exhaustion
+        (CURSOR_END); a full page continues with
+        ``CursorAfter(json.dumps(hits[-1]["sort"]))`` — the last hit's sort
+        values are the natural consumed frontier (they cover hits skipped as
+        unusable in relaxed mode, too).
+
+        Strict/failure semantics: ``_index_ready=False`` raises under
+        ``strict`` (the index was dropped/lost — cannot confirm the sweep is
+        complete); a live missing-index error mirrors the existing
+        ``get_docs_by_statuses`` strict decision (legitimately empty →
+        empty terminal page); transport errors raise WITHOUT returning
+        partial docs or a new cursor; ``strict`` additionally turns
+        unusable-row skips into raises.
+        """
+        if limit <= 0:
+            raise ValueError(f"page limit must be positive, got {limit}")
+        if not statuses or position is CURSOR_END:
+            return DocStatusPage(docs={}, next_position=CURSOR_END)
+        if not self._index_ready:
+            if strict:
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] doc status index '{self._index_name}' "
+                    f"is not ready; cannot serve a complete scheduling page"
+                )
+            return DocStatusPage(docs={}, next_position=CURSOR_END)
+        search_after: list[Any] | None = None
+        if isinstance(position, CursorAfter):
+            search_after = self._decode_page_cursor(position.opaque)
+        body: dict[str, Any] = {
+            "query": self._build_scheduling_page_query([s.value for s in statuses]),
+            "sort": [
+                {"created_at": {"order": "asc", "missing": "_first"}},
+                {"__mirrored_id": {"order": "asc"}},
+            ],
+            "size": limit,
+        }
+        if search_after is not None:
+            body["search_after"] = search_after
+        try:
+            response = await self.client.search(index=self._index_name, body=body)
+        except OpenSearchException as e:
+            if _is_missing_index_error(e):
+                self._mark_index_missing()
+                return DocStatusPage(docs={}, next_position=CURSOR_END)
+            # Complete-or-raise in BOTH modes: a partial page + advanced
+            # cursor would silently strand the missed documents.
+            logger.error(f"[{self.workspace}] Scheduling page query failed: {e}")
+            raise
+        hits = response["hits"]["hits"]
+        docs: dict[str, DocSchedulingRecord] = {}
+        for hit in hits:
+            record = self._scheduling_record_from_hit(hit, strict=strict)
+            if record is None:
+                continue  # relaxed skip is still consumed (see cursor note)
+            docs[record.id] = record
+        if len(hits) < limit:
+            return DocStatusPage(docs=docs, next_position=CURSOR_END)
+        return DocStatusPage(
+            docs=docs,
+            next_position=CursorAfter(json.dumps(hits[-1]["sort"])),
+        )
+
+    async def count_docs_by_statuses(
+        self, statuses: list[DocStatus], *, strict: bool = True
+    ) -> int:
+        """Fail-closed status count via the ``_count`` API (base contract).
+
+        Always accurate-or-raise regardless of ``strict`` — admission
+        control must never read an error as "capacity available".
+        ``_index_ready=False`` raises; a live missing-index error mirrors
+        the existing strict ``get_docs_by_statuses`` decision (legitimately
+        empty → 0).
+        """
+        if not statuses:
+            return 0
+        if not self._index_ready:
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] doc status index '{self._index_name}' is "
+                f"not ready; cannot produce an accurate status count"
+            )
+        body = {"query": {"terms": {"status": sorted({s.value for s in statuses})}}}
+        try:
+            response = await self.client.count(index=self._index_name, body=body)
+        except OpenSearchException as e:
+            if _is_missing_index_error(e):
+                self._mark_index_missing()
+                return 0
+            logger.error(f"[{self.workspace}] Error counting doc statuses: {e}")
+            raise
+        count = response.get("count")
+        if not isinstance(count, int):
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] OpenSearch _count returned a malformed "
+                f"response for {self.namespace}: {response!r}"
+            )
+        return count
+
+    async def update_doc_status_fields(
+        self,
+        doc_id: str,
+        fields: dict[str, Any],
+        *,
+        missing_ok: bool = False,
+    ) -> None:
+        """Targeted partial update via the ``_update`` doc-merge API.
+
+        No read-modify-write: untouched fields (including a huge
+        ``chunks_list``) never travel through memory. ``refresh="wait_for"``
+        matches the visibility of the bulk upsert path (search-based readers
+        may query immediately after). This class keeps no pending buffer for
+        doc-status writes, so the update is immediately authoritative.
+        """
+        if "created_at" in fields:
+            raise ValueError(
+                "created_at is an immutable scheduling sort key and cannot "
+                "be changed via update_doc_status_fields"
+            )
+        await self._ensure_index_ready()
+        try:
+            await self.client.update(
+                index=self._index_name,
+                id=doc_id,
+                body={"doc": fields},
+                refresh="wait_for",
+            )
+        except NotFoundError as e:
+            if _is_missing_index_error(e):
+                self._mark_index_missing()
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] doc status index '{self._index_name}' "
+                    f"unexpectedly missing while updating '{doc_id}'"
+                ) from e
+            if missing_ok:
+                return
+            raise StorageRecordNotFoundError(doc_id) from e
+        except OpenSearchException as e:
+            logger.error(
+                f"[{self.workspace}] Error updating doc status fields for {doc_id}: {e}"
+            )
+            raise
+
+    # ------------------------------------------------------------------
+    # Strict batch read
+    # ------------------------------------------------------------------
+
+    async def get_docs_by_ids(
+        self,
+        doc_ids: Sequence[str],
+        *,
+        strict: bool = False,
+    ) -> dict[str, DocSchedulingRecord]:
+        """Batch strict read via a single mget (base contract).
+
+        Lightweight projection (``_source_includes`` limits the fetch to the
+        scheduling fields — never ``chunks_list``). A missing id is a
+        CONFIRMED absence (``found=false``) and is omitted; an item-level
+        mget error is NEVER read as absent (``_interpret_mget_item`` raises).
+        With ``strict=True`` an unusable present row also raises; a not-ready
+        index and a live missing-index error raise ``StorageControlPlaneError``
+        in both modes (absence cannot be confirmed there), and other transport
+        errors propagate — the whole call fails rather than returning a
+        partial map the feeder would treat as "the rest went stale".
+        """
+        result: dict[str, DocSchedulingRecord] = {}
+        ids = list(doc_ids)
+        if not ids:
+            return result
+        if not self._index_ready:
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] doc status index '{self._index_name}' is "
+                f"not ready; cannot confirm absence for a strict batch read"
+            )
+        try:
+            response = await self.client.mget(
+                index=self._index_name,
+                body={"ids": ids},
+                _source_includes=self._SCHEDULING_SOURCE_FIELDS,
+            )
+        except OpenSearchException as e:
+            if _is_missing_index_error(e):
+                self._mark_index_missing()
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] doc status index '{self._index_name}' "
+                    f"unexpectedly missing; cannot confirm absence for a strict "
+                    f"batch read"
+                ) from e
+            logger.error(f"[{self.workspace}] Error batch-reading doc statuses: {e}")
+            raise
+        docs = response.get("docs")
+        if not isinstance(docs, list) or len(docs) != len(ids):
+            raise RuntimeError(
+                f"[{self.workspace}] OpenSearch mget returned "
+                f"{len(docs) if isinstance(docs, list) else 'no'} items "
+                f"for {len(ids)} requested ids"
+            )
+        for requested_id, item in zip(ids, docs):
+            interpreted = _interpret_mget_item(item, requested_id)
+            if interpreted is None:
+                continue  # confirmed absent
+            record = self._scheduling_record_from_hit(interpreted, strict=strict)
+            if record is not None:
+                result[requested_id] = record
+        return result
+
+    # ------------------------------------------------------------------
+    # Source-conflict listing and explicit CAS repair
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _conflict_fingerprint(sorted_doc_ids: list[str]) -> str:
+        """Deterministic digest over candidate doc IDs in stable sort order."""
+        digest = hashlib.sha256()
+        for doc_id in sorted_doc_ids:
+            digest.update(doc_id.encode("utf-8"))
+            digest.update(b"\x00")
+        return digest.hexdigest()
+
+    @staticmethod
+    def _conflict_scan_query() -> dict[str, Any]:
+        """Restrict conflict scans to PRIMARY rows with a real canonical basename.
+
+        Excludes duplicate markers (``metadata.is_duplicate == true``), the
+        sentinel basenames the business layer never treats as identity, and
+        rows without a ``file_path`` at all (mirrors the JSON reference).
+        """
+        return {
+            "bool": {
+                "filter": [{"exists": {"field": "file_path"}}],
+                "must_not": [
+                    {"term": {"metadata.is_duplicate": True}},
+                    {"terms": {"file_path": ["", "unknown_source", "no-file-path"]}},
+                ],
+            }
+        }
+
+    @staticmethod
+    def _decode_conflict_cursor(opaque: str) -> dict[str, Any]:
+        """Decode a source-conflict page cursor into a composite ``after`` key.
+
+        The cursor is ``json.dumps(after_key)`` — the composite aggregation's
+        ``after_key`` object verbatim. Anything that does not decode to a JSON
+        object is a corrupt continuation token: raise a control-plane error
+        instead of silently restarting the sweep.
+        """
+        try:
+            after = json.loads(opaque)
+            if not isinstance(after, dict):
+                raise ValueError("conflict cursor must be a composite after-key object")
+        except (TypeError, ValueError) as e:
+            raise StorageControlPlaneError(
+                f"Malformed source-conflict cursor for OpenSearchDocStatusStorage: {e}"
+            ) from e
+        return after
+
+    async def _primary_candidate_ids_sorted(
+        self, canonical_source_key: str
+    ) -> list[str]:
+        """All PRIMARY doc IDs for a canonical basename, sorted (ids only).
+
+        Paginates ``search_after`` (``_source=False``) so the full candidate
+        set is collected without materializing any row bodies — historical
+        conflicts are small, but the scan is bounded per page regardless. A
+        live missing-index error raises a control-plane error (the caller
+        already verified ``_index_ready``).
+        """
+        query = self._primary_basename_query(canonical_source_key)["query"]
+        ids: list[str] = []
+        search_after: list[Any] | None = None
+        batch = 1000
+        while True:
+            body: dict[str, Any] = {
+                "query": query,
+                "sort": [{"__mirrored_id": {"order": "asc"}}],
+                "size": batch,
+                "_source": False,
+            }
+            if search_after is not None:
+                body["search_after"] = search_after
+            try:
+                response = await self.client.search(index=self._index_name, body=body)
+            except OpenSearchException as e:
+                if _is_missing_index_error(e):
+                    self._mark_index_missing()
+                    raise StorageControlPlaneError(
+                        f"[{self.workspace}] doc status index "
+                        f"'{self._index_name}' unexpectedly missing while "
+                        f"scanning primary candidates for "
+                        f"'{canonical_source_key}'"
+                    ) from e
+                logger.error(
+                    f"[{self.workspace}] Error scanning primary candidates for "
+                    f"'{canonical_source_key}': {e}"
+                )
+                raise
+            hits = response["hits"]["hits"]
+            if not hits:
+                break
+            for hit in hits:
+                hit_id = hit.get("_id")
+                if isinstance(hit_id, str):
+                    ids.append(hit_id)
+            if len(hits) < batch:
+                break
+            search_after = hits[-1]["sort"]
+        return sorted(ids)
+
+    async def list_source_conflicts_page(
+        self,
+        *,
+        limit: int,
+        position: CursorPosition = CURSOR_START,
+    ) -> SourceConflictPage:
+        """Page canonical source keys with >1 PRIMARY candidate (base contract).
+
+        A ``composite`` aggregation over ``file_path`` (query restricted to
+        primaries and real basenames) pages the key space deterministically
+        via its ``after_key``; a ``top_hits`` sub-agg yields a bounded doc-id
+        sample per bucket. Single-primary buckets are dropped client-side, so
+        a page may carry fewer than ``limit`` conflicts (or none) while more
+        composite buckets remain — the sweep terminates only on ``CURSOR_END``
+        (the composite returned fewer buckets than requested). ``_index_ready
+        =False`` and a live missing-index error raise a control-plane error.
+        """
+        if limit <= 0:
+            raise ValueError(f"page limit must be positive, got {limit}")
+        if position is CURSOR_END:
+            return SourceConflictPage(conflicts=(), next_position=CURSOR_END)
+        if not self._index_ready:
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] doc status index '{self._index_name}' is "
+                f"not ready; cannot list source conflicts"
+            )
+        after: dict[str, Any] | None = None
+        if isinstance(position, CursorAfter):
+            after = self._decode_conflict_cursor(position.opaque)
+        composite: dict[str, Any] = {
+            "size": limit,
+            "sources": [
+                {"file_path": {"terms": {"field": "file_path", "order": "asc"}}}
+            ],
+        }
+        if after is not None:
+            composite["after"] = after
+        body = {
+            "size": 0,
+            "query": self._conflict_scan_query(),
+            "aggs": {
+                "conflicts": {
+                    "composite": composite,
+                    "aggs": {
+                        "sample_ids": {
+                            "top_hits": {
+                                "size": self._CONFLICT_SAMPLE_CAP,
+                                "_source": False,
+                                "sort": [{"__mirrored_id": {"order": "asc"}}],
+                            }
+                        }
+                    },
+                }
+            },
+        }
+        try:
+            response = await self.client.search(index=self._index_name, body=body)
+        except OpenSearchException as e:
+            if _is_missing_index_error(e):
+                self._mark_index_missing()
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] doc status index '{self._index_name}' "
+                    f"unexpectedly missing while listing source conflicts"
+                ) from e
+            logger.error(f"[{self.workspace}] Error listing source conflicts: {e}")
+            raise
+        agg = response.get("aggregations", {}).get("conflicts", {})
+        buckets = agg.get("buckets", [])
+        conflicts_list: list[SourceConflictSummary] = []
+        for bucket in buckets:
+            count = bucket.get("doc_count", 0)
+            if not isinstance(count, int) or count < 2:
+                continue
+            key = bucket.get("key", {}).get("file_path")
+            if not isinstance(key, str):
+                continue
+            sample_hits = bucket.get("sample_ids", {}).get("hits", {}).get("hits", [])
+            sample_doc_ids = tuple(
+                sorted(h["_id"] for h in sample_hits if isinstance(h.get("_id"), str))[
+                    : self._CONFLICT_SAMPLE_CAP
+                ]
+            )
+            conflicts_list.append(
+                SourceConflictSummary(
+                    canonical_source_key=key,
+                    candidate_count=count,
+                    sample_doc_ids=sample_doc_ids,
+                )
+            )
+        conflicts = tuple(conflicts_list)
+        after_key = agg.get("after_key")
+        if len(buckets) < limit or not isinstance(after_key, dict):
+            return SourceConflictPage(conflicts=conflicts, next_position=CURSOR_END)
+        return SourceConflictPage(
+            conflicts=conflicts,
+            next_position=CursorAfter(json.dumps(after_key)),
+        )
+
+    async def repair_source_conflict(
+        self,
+        canonical_source_key: str,
+        *,
+        primary_doc_id: str,
+        expected_candidate_count: int,
+        expected_candidate_fingerprint: str,
+        dry_run: bool = True,
+    ) -> SourceConflictRepairResult:
+        """Demote all-but-one primary to duplicate, CAS-guarded (base contract).
+
+        OpenSearch has no multi-doc transaction, so the CAS is a
+        recompute-and-compare: the current primary candidate set is re-scanned
+        (live view) and its count/fingerprint must equal the operator-echoed
+        ``expected_*`` before any demotion runs, otherwise a
+        ``StorageControlPlaneError`` is raised rather than overwriting a
+        concurrent change. Demotions are ``_update`` doc-merges (deep-merging
+        ``metadata.is_duplicate=true`` + ``original_doc_id`` so other metadata
+        keys survive) with ``refresh="wait_for"``; content is never deleted.
+        The residual window between the re-scan and the demote writes is the
+        documented non-transactional boundary of this backend.
+        """
+        if not self._index_ready:
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] doc status index '{self._index_name}' is "
+                f"not ready; cannot repair source conflict "
+                f"'{canonical_source_key}'"
+            )
+        candidates = await self._primary_candidate_ids_sorted(canonical_source_key)
+        count = len(candidates)
+        fingerprint = self._conflict_fingerprint(candidates)
+        if primary_doc_id not in candidates:
+            raise ValueError(
+                f"primary_doc_id {primary_doc_id!r} is not a current primary "
+                f"candidate for {canonical_source_key!r}"
+            )
+        demoted = [d for d in candidates if d != primary_doc_id]
+        if dry_run:
+            return SourceConflictRepairResult(
+                canonical_source_key=canonical_source_key,
+                primary_doc_id=primary_doc_id,
+                candidate_count=count,
+                fingerprint=fingerprint,
+                demoted_sample_doc_ids=tuple(demoted[: self._CONFLICT_SAMPLE_CAP]),
+                committed=False,
+            )
+        if (
+            count != expected_candidate_count
+            or fingerprint != expected_candidate_fingerprint
+        ):
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] source-conflict repair CAS failed for "
+                f"{canonical_source_key!r}: candidate set changed "
+                f"(count {count} vs {expected_candidate_count})"
+            )
+        for doc_id in demoted:
+            try:
+                await self.client.update(
+                    index=self._index_name,
+                    id=doc_id,
+                    body={
+                        "doc": {
+                            "metadata": {
+                                "is_duplicate": True,
+                                "original_doc_id": primary_doc_id,
+                            }
+                        }
+                    },
+                    refresh="wait_for",
+                )
+            except NotFoundError as e:
+                if _is_missing_index_error(e):
+                    self._mark_index_missing()
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] source-conflict repair for "
+                    f"{canonical_source_key!r}: candidate '{doc_id}' vanished "
+                    f"mid-repair"
+                ) from e
+        return SourceConflictRepairResult(
+            canonical_source_key=canonical_source_key,
+            primary_doc_id=primary_doc_id,
+            candidate_count=count,
+            fingerprint=fingerprint,
+            demoted_sample_doc_ids=tuple(demoted[: self._CONFLICT_SAMPLE_CAP]),
+            committed=True,
+        )
 
     async def index_done_callback(self) -> None:
         """Refresh index to make recently indexed documents searchable."""

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -5759,7 +5759,12 @@ class PGDocStatusStorage(DocStatusStorage):
 
         The candidate set is re-read ``FOR UPDATE`` inside ONE transaction, so
         the count/fingerprint recomputation, the CAS check and the demotions
-        are atomic. dry-run reports the current count/fingerprint without
+        are atomic with respect to the rows it SAW. ``FOR UPDATE`` takes no
+        predicate lock, so it cannot block a new primary being INSERTED for the
+        same canonical key mid-repair — see the base contract for what
+        ``committed`` does and does not claim, and for the caller-side keyed
+        lock that serializes repair against enqueue. dry-run reports the
+        current count/fingerprint without
         mutating; commit refuses (:class:`StorageControlPlaneError`) when they
         no longer match the operator-echoed expectation. Losing candidates get
         ``metadata.is_duplicate=true`` + ``original_doc_id=primary_doc_id`` in

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -7,7 +7,7 @@ import re
 import datetime
 from datetime import timezone
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Callable, TypeVar, Union, final
+from typing import Any, Awaitable, Callable, ClassVar, Sequence, TypeVar, Union, final
 import numpy as np
 import configparser
 import ssl
@@ -27,15 +27,32 @@ from tenacity import (
 )
 
 from ..base import (
+    CURSOR_END,
+    CURSOR_START,
     BaseGraphStorage,
     BaseKVStorage,
     BaseVectorStorage,
+    CursorAfter,
+    CursorPosition,
     DocProcessingStatus,
+    DocSchedulingRecord,
     DocStatus,
+    DocStatusPage,
     DocStatusStorage,
+    SourceAbsent,
+    SourceConflict,
+    SourceConflictPage,
+    SourceConflictRepairResult,
+    SourceConflictSummary,
+    SourceResolution,
+    SourceUnique,
 )
-from ..constants import DEFAULT_QUERY_PRIORITY
-from ..exceptions import DataMigrationError
+from ..constants import CUSTOM_CHUNK_PATCH_METADATA_KEY, DEFAULT_QUERY_PRIORITY
+from ..exceptions import (
+    DataMigrationError,
+    StorageControlPlaneError,
+    StorageRecordNotFoundError,
+)
 from ..namespace import NameSpace, is_namespace
 from ..utils import (
     logger,
@@ -1566,6 +1583,39 @@ class PostgreSQLDB:
                 f"Failed to create partial content_hash index on LIGHTRAG_DOC_STATUS: {e}"
             )
 
+    async def _migrate_doc_status_add_scheduling_fields(self):
+        """Create the keyset-sweep index backing the memory-bounding scheduling
+        page API (Phase 1).
+
+        The (workspace, status, created_at, id) index matches the page query's
+        WHERE workspace/status equality prefix and its ORDER BY created_at ASC,
+        id ASC keyset tail, so a page read is an index scan resuming at the
+        row-value comparison — never a full-table sort. Guarded and idempotent —
+        retried on every startup until present.
+        """
+        indexes = [
+            (
+                "idx_lightrag_doc_status_ws_status_created_id",
+                "CREATE INDEX IF NOT EXISTS idx_lightrag_doc_status_ws_status_created_id "
+                "ON LIGHTRAG_DOC_STATUS (workspace, status, created_at, id)",
+            ),
+        ]
+        for index_name, create_sql in indexes:
+            try:
+                check_index_sql = """
+                SELECT indexname FROM pg_indexes
+                WHERE tablename = 'lightrag_doc_status'
+                  AND indexname = $1
+                """
+                index_info = await self.query(check_index_sql, [index_name])
+                if not index_info:
+                    logger.info(f"Creating index {index_name} on LIGHTRAG_DOC_STATUS")
+                    await self.execute(create_sql)
+            except Exception as e:
+                logger.error(
+                    f"Failed to create index {index_name} on LIGHTRAG_DOC_STATUS: {e}"
+                )
+
     async def _migrate_text_chunks_add_heading_sidecar(self):
         """Add heading and sidecar JSONB columns to LIGHTRAG_DOC_CHUNKS if missing."""
         columns_to_add = [
@@ -1943,6 +1993,15 @@ class PostgreSQLDB:
         except Exception as e:
             logger.error(
                 f"PostgreSQL, Failed to migrate LIGHTRAG_DOC_CHUNKS heading/sidecar fields: {e}"
+            )
+
+        # Migrate LIGHTRAG_DOC_STATUS to add the keyset-sweep index backing the
+        # memory-bounding scheduling page API (Phase 1)
+        try:
+            await self._migrate_doc_status_add_scheduling_fields()
+        except Exception as e:
+            logger.error(
+                f"PostgreSQL, Failed to migrate LIGHTRAG_DOC_STATUS scheduling fields: {e}"
             )
 
     async def _migrate_create_full_entities_relations_tables(self):
@@ -2544,6 +2603,8 @@ class ClientManager:
 class PGKVStorage(BaseKVStorage):
     db: PostgreSQLDB = field(default=None)
 
+    supports_strict_point_reads: ClassVar[bool] = True
+
     def __post_init__(self):
         validate_workspace(self.workspace)
         self._max_batch_size = 200  # DB batch size, independent of embedding batch size
@@ -2723,6 +2784,16 @@ class PGKVStorage(BaseKVStorage):
             response["update_time"] = create_time if update_time == 0 else update_time
 
         return response if response else None
+
+    async def get_by_id_strict(self, id: str) -> dict[str, Any] | None:
+        """Strict point read: complete-or-raise (base contract).
+
+        ``db.query`` propagates every asyncpg transport/server error (nothing
+        in this class swallows it), so a ``None`` from the legacy read is a
+        positively confirmed absence — safe for callers that take destructive
+        action on a miss.
+        """
+        return await self.get_by_id(id)
 
     # Query by id
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
@@ -4823,10 +4894,42 @@ def _parse_doc_status_datetime(
         return None
 
 
+# Columns that the targeted-update path (update_doc_status_fields) may write.
+# Column names are interpolated into SQL, so they MUST come from this whitelist
+# — unknown keys raise instead of being quoted. created_at is deliberately
+# absent: it is the immutable keyset sort key (update_doc_status_fields refuses
+# it).
+_DOC_STATUS_UPDATABLE_COLUMNS = frozenset(
+    {
+        "content_summary",
+        "content_length",
+        "chunks_count",
+        "status",
+        "file_path",
+        "chunks_list",
+        "track_id",
+        "metadata",
+        "error_msg",
+        "content_hash",
+        "updated_at",
+    }
+)
+# JSONB columns serialized exactly like the batch upsert does (json.dumps).
+_DOC_STATUS_JSON_COLUMNS = frozenset({"chunks_list", "metadata"})
+# TIMESTAMP columns converted via _parse_doc_status_datetime like the upsert.
+_DOC_STATUS_DATETIME_COLUMNS = frozenset({"updated_at", "created_at"})
+
+
 @final
 @dataclass
 class PGDocStatusStorage(DocStatusStorage):
     db: PostgreSQLDB = field(default=None)
+
+    supports_strict_point_reads: ClassVar[bool] = True
+
+    # Bounded upper limit on the sample of conflicting doc IDs surfaced by the
+    # source-conflict listing/repair APIs — never materialize the whole set.
+    _CONFLICT_SAMPLE_CAP: ClassVar[int] = 32
 
     def __post_init__(self):
         validate_workspace(self.workspace)
@@ -5058,6 +5161,13 @@ class PGDocStatusStorage(DocStatusStorage):
         the canonical ``file_path`` column. The caller is responsible for
         passing an already-canonical basename; storage performs an exact match
         only.
+
+        ``file_path`` is one-to-many (duplicate-attempt ``dup-*`` rows keep the
+        same canonical basename); this returns the single PRIMARY
+        (``metadata.is_duplicate != true``) row — callers doing identity checks
+        / dedup want the document, never a duplicate marker. When only
+        duplicate markers remain (primary deleted) the basename is free again
+        and this returns ``None``.
         """
         if not basename:
             return None
@@ -5065,9 +5175,15 @@ class PGDocStatusStorage(DocStatusStorage):
         if basename == "unknown_source":
             return None
 
+        # COALESCE((metadata->>'is_duplicate')::boolean, false) excludes
+        # duplicate-marker rows; NULL/absent metadata keys coalesce to false
+        # (primary). metadata is JSONB, so ->> yields 'true'/'false' text that
+        # casts cleanly; a non-boolean value raises and propagates (fail
+        # closed) rather than silently matching.
         sql = (
             "SELECT * FROM LIGHTRAG_DOC_STATUS "
             "WHERE workspace=$1 AND file_path = $2 "
+            "AND COALESCE((metadata->>'is_duplicate')::boolean, false) = false "
             "ORDER BY created_at ASC, id ASC LIMIT 1"
         )
         params = [self.workspace, basename]
@@ -5164,6 +5280,558 @@ class PGDocStatusStorage(DocStatusStorage):
             content_hash=row.get("content_hash"),
         )
         return str(row["id"]), doc
+
+    # SQL predicate isolating PRIMARY (non-duplicate) rows. metadata is JSONB,
+    # so ->> yields 'true'/'false' text that casts cleanly; a NULL/absent key
+    # coalesces to false (primary), and a non-boolean value raises and
+    # propagates (fail closed) rather than silently matching.
+    _PRIMARY_PREDICATE = "COALESCE((metadata->>'is_duplicate')::boolean, false) = false"
+
+    async def resolve_doc_source_strict(
+        self, canonical_source_key: str
+    ) -> SourceResolution:
+        """Typed, conflict-aware source resolution (see base contract).
+
+        Fetches up to two PRIMARY rows for the canonical basename and maps
+        0/1/≥2 → Absent/Unique/Conflict. When two are found the exact count is
+        an indexed ``COUNT(*)`` on the same predicate. Every asyncpg
+        transport/server error propagates out of ``db.query`` (nothing here
+        swallows it), so a returned ``SourceAbsent`` IS a confirmed absence.
+        """
+        if not canonical_source_key or canonical_source_key == "unknown_source":
+            return SourceAbsent()
+
+        sql = (
+            "SELECT id, status, created_at, updated_at, file_path, track_id, "
+            "metadata FROM LIGHTRAG_DOC_STATUS "
+            "WHERE workspace=$1 AND file_path=$2 "
+            f"AND {self._PRIMARY_PREDICATE} "
+            "ORDER BY created_at ASC, id ASC LIMIT 2"
+        )
+        rows = await self.db.query(sql, [self.workspace, canonical_source_key], True)
+        if not rows:
+            return SourceAbsent()
+        if len(rows) == 1:
+            row = rows[0]
+            return SourceUnique(
+                doc_id=str(row["id"]),
+                doc=self._pg_scheduling_record_from_row(row, strict=True),
+            )
+        # ≥2 primary candidates: exact count is cheap on the indexed predicate.
+        count_row = await self.db.query(
+            "SELECT COUNT(*) AS c FROM LIGHTRAG_DOC_STATUS "
+            "WHERE workspace=$1 AND file_path=$2 "
+            f"AND {self._PRIMARY_PREDICATE}",
+            [self.workspace, canonical_source_key],
+        )
+        candidate_count = int(count_row["c"]) if count_row else None
+        return SourceConflict(
+            candidate_count=candidate_count,
+            sample_doc_ids=tuple(sorted(str(r["id"]) for r in rows)),
+        )
+
+    async def get_by_id_strict(self, id: str) -> Union[dict[str, Any], None]:
+        """Strict point read: complete-or-raise (base contract).
+
+        ``db.query`` propagates every transport/server error, so a ``None``
+        from the aligned legacy read is a confirmed absence.
+        """
+        return await self.get_by_id(id)
+
+    # ------------------------------------------------------------------
+    # Memory-bounding scheduling API (Phase 1)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _decode_cursor(opaque: str) -> tuple[datetime.datetime | None, str]:
+        """Decode an opaque page cursor into (created_at, id).
+
+        The opaque form is ``json.dumps([created_at_iso | None, id])``
+        produced by ``_encode_cursor``. A ``None`` first element marks the
+        NULL-created_at bucket (corrupt rows, sorted FIRST — see the page
+        docstring); a string round-trips exactly through
+        ``datetime.fromisoformat`` (microseconds preserved) and is normalized
+        back to the naive-UTC form the TIMESTAMP column stores, so the
+        parameterized row-value comparison resumes at exactly the last
+        consumed key. A malformed cursor raises
+        :class:`~lightrag.exceptions.StorageControlPlaneError`.
+        """
+        try:
+            decoded = json.loads(opaque)
+            created_iso, doc_id = decoded
+            if not isinstance(doc_id, str):
+                raise ValueError("cursor id must be a string")
+            if created_iso is None:
+                return None, doc_id
+            if not isinstance(created_iso, str):
+                raise ValueError("cursor created_at must be a string or null")
+            created = datetime.datetime.fromisoformat(created_iso)
+        except (ValueError, TypeError) as e:
+            raise StorageControlPlaneError(
+                f"Malformed scheduling cursor for PGDocStatusStorage: {e}"
+            ) from e
+        if created.tzinfo is not None:
+            created = created.astimezone(timezone.utc).replace(tzinfo=None)
+        return created, doc_id
+
+    def _encode_cursor(self, row: dict[str, Any]) -> str:
+        """Encode the keyset key of a returned DB row as an opaque cursor.
+
+        Rows with a NULL created_at (corrupt writes — the column defaults to
+        CURRENT_TIMESTAMP) sort FIRST and encode as ``[null, id]`` so the
+        sweep traverses past them instead of losing them behind a row-value
+        comparison that NULL can never satisfy (matching the JSON/Redis
+        backends, which sort a missing created_at first as "")."""
+        created = row.get("created_at")
+        if not isinstance(created, datetime.datetime):
+            return json.dumps([None, str(row["id"])])
+        return json.dumps(
+            [self._format_datetime_with_timezone(created), str(row["id"])]
+        )
+
+    def _pg_scheduling_record_from_row(
+        self, row: dict[str, Any], *, strict: bool
+    ) -> DocSchedulingRecord | None:
+        """Project one DB row; strict raises on unusable rows, relaxed returns
+        None (the row was still returned by the scan and stays consumed)."""
+        doc_id = str(row.get("id") or "")
+        try:
+            if not doc_id:
+                raise KeyError("id")
+            status = DocStatus(str(row["status"]))
+            created_raw = row["created_at"]
+            if not isinstance(created_raw, datetime.datetime):
+                raise TypeError("created_at must be a timestamp")
+            updated_raw = row.get("updated_at") or created_raw
+            if not isinstance(updated_raw, datetime.datetime):
+                raise TypeError("updated_at must be a timestamp")
+            metadata = row.get("metadata")
+            if isinstance(metadata, str):
+                try:
+                    metadata = json.loads(metadata)
+                except json.JSONDecodeError:
+                    metadata = {}
+            if not isinstance(metadata, dict):
+                metadata = {}
+            return DocSchedulingRecord(
+                id=doc_id,
+                status=status,
+                created_at=self._format_datetime_with_timezone(created_raw),
+                updated_at=self._format_datetime_with_timezone(updated_raw),
+                file_path=row.get("file_path") or "no-file-path",
+                track_id=row.get("track_id"),
+                has_custom_chunk_journal=isinstance(
+                    metadata.get(CUSTOM_CHUNK_PATCH_METADATA_KEY), dict
+                ),
+            )
+        except (KeyError, TypeError, ValueError) as e:
+            logger.error(
+                f"[{self.workspace}] Unusable scheduling row "
+                f"{doc_id or '<unknown>'}: {e}"
+            )
+            if strict:
+                raise
+            return None
+
+    async def get_docs_by_statuses_page(
+        self,
+        statuses: list[DocStatus],
+        *,
+        limit: int,
+        position: CursorPosition = CURSOR_START,
+        strict: bool = False,
+    ) -> DocStatusPage:
+        """Bounded keyset page over LIGHTRAG_DOC_STATUS.
+
+        A single combined keyset across all requested statuses is correct on
+        PG: ``ORDER BY created_at ASC, id ASC`` plus the composite row-value
+        comparison ``(created_at, id) > ($cur, $id)`` yields the global
+        (created_at, id) order natively — no k-way merge needed. The
+        ``idx_lightrag_doc_status_ws_status_created_id`` (workspace, status,
+        created_at, id) index backs the scan: for a single status it is a pure
+        index range scan resuming at the row-value comparison; for multiple
+        statuses the planner combines per-status index ranges under the LIMIT
+        (top-N bounded — page memory stays O(limit), never a full-table
+        materialization).
+
+        Consumed-position contract (SQL-side filtering makes it trivial):
+        every predicate — workspace and status membership — is part of the DB
+        scan itself, so the database skips non-matching rows and keeps scanning
+        until LIMIT rows are collected or the keyset range ends. The rows
+        returned by the query therefore ARE the consumed frontier:
+
+        * ``next_position`` = key of the LAST RETURNED row, and
+        * ``returned < limit`` proves the (unfiltered) keyset range is
+          exhausted — the scan only stops early when the range ends, so a
+          short page can never hide rows that were merely filtered out
+          (unlike client-side filtering, where a fully-filtered page must
+          still advance without terminating).
+
+        ``strict=True``: any DB error or row-conversion failure raises without
+        returning partial docs or a cursor (single round-trip — there is no
+        partial-page surface). In relaxed mode an unusable row is skipped from
+        the projection but stays consumed (it was returned by the scan).
+
+        NULL created_at (corrupt writes): such rows sort FIRST
+        (``NULLS FIRST``, mirroring JSON/Redis where a missing created_at
+        sorts first as "") and the keyset comparison is bucket-aware — a
+        plain ``(created_at, id) > ($c, $i)`` row-value comparison evaluates
+        to NULL for them, which would silently starve them out of every page
+        after the first, violating the strict complete-or-raise promise.
+        They therefore stay reachable: raised under strict, skipped (but
+        consumed) under relaxed.
+        """
+        if limit <= 0:
+            raise ValueError(f"page limit must be positive, got {limit}")
+        if not statuses or position is CURSOR_END:
+            return DocStatusPage(docs={}, next_position=CURSOR_END)
+
+        params: list[Any] = [self.workspace, [s.value for s in statuses]]
+        sql = (
+            "SELECT id, status, created_at, updated_at, file_path, track_id, "
+            "metadata "
+            "FROM LIGHTRAG_DOC_STATUS WHERE workspace=$1 AND status = ANY($2)"
+        )
+        if isinstance(position, CursorAfter):
+            cur_created, cur_id = self._decode_cursor(position.opaque)
+            if cur_created is None:
+                # Cursor inside the NULL bucket (sorted first): continue
+                # through the remaining NULL rows by id, then everything
+                # with a real timestamp.
+                params.append(cur_id)
+                sql += (
+                    f" AND ((created_at IS NULL AND id > ${len(params)}) "
+                    "OR created_at IS NOT NULL)"
+                )
+            else:
+                # Past the NULL bucket: only real-timestamp rows can follow.
+                params.append(cur_created)
+                params.append(cur_id)
+                sql += (
+                    " AND created_at IS NOT NULL AND "
+                    f"(created_at, id) > (${len(params) - 1}::timestamp, "
+                    f"${len(params)})"
+                )
+        params.append(limit)
+        sql += f" ORDER BY created_at ASC NULLS FIRST, id ASC LIMIT ${len(params)}"
+
+        # Any asyncpg error propagates out of db.query — strict pages never
+        # commit a new cursor on failure.
+        rows = await self.db.query(sql, params, multirows=True) or []
+
+        docs: dict[str, DocSchedulingRecord] = {}
+        for row in rows:
+            record = self._pg_scheduling_record_from_row(row, strict=strict)
+            if record is None:
+                continue  # relaxed skip is still consumed (see docstring)
+            docs[record.id] = record
+
+        if len(rows) < limit:
+            next_position: CursorPosition = CURSOR_END
+        else:
+            next_position = CursorAfter(self._encode_cursor(rows[-1]))
+        return DocStatusPage(docs=docs, next_position=next_position)
+
+    async def count_docs_by_statuses(
+        self, statuses: list[DocStatus], *, strict: bool = True
+    ) -> int:
+        """Fail-closed status count: an accurate number or an exception.
+
+        Unlike ``get_status_counts`` implementations that swallow errors,
+        every DB failure propagates — admission control treats an error as
+        "refuse", never as "capacity available".
+        """
+        if not statuses:
+            return 0
+        sql = (
+            'SELECT COUNT(*) AS "count" FROM LIGHTRAG_DOC_STATUS '
+            "WHERE workspace=$1 AND status = ANY($2)"
+        )
+        row = await self.db.query(sql, [self.workspace, [s.value for s in statuses]])
+        if row is None or row.get("count") is None:
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] COUNT query returned no row for "
+                "count_docs_by_statuses; refusing to report a count"
+            )
+        return int(row["count"])
+
+    def _prepare_doc_status_field_value(self, column: str, value: Any) -> Any:
+        """Serialize one field for a targeted UPDATE/INSERT, matching the
+        batch upsert's handling of JSONB and TIMESTAMP columns."""
+        if column in _DOC_STATUS_JSON_COLUMNS:
+            return value if isinstance(value, str) else json.dumps(value)
+        if column in _DOC_STATUS_DATETIME_COLUMNS:
+            return _parse_doc_status_datetime(
+                value, f"[{self.workspace}] doc status {column}"
+            )
+        return value
+
+    async def update_doc_status_fields(
+        self,
+        doc_id: str,
+        fields: dict[str, Any],
+        *,
+        missing_ok: bool = False,
+    ) -> None:
+        """Targeted single-row UPDATE of the given fields only.
+
+        ``created_at`` is refused (immutable keyset sort key); unknown field
+        names are refused too — column names are interpolated into SQL and
+        must come from the whitelist. 0 rows updated raises
+        :class:`~lightrag.exceptions.StorageRecordNotFoundError` unless
+        ``missing_ok=True``.
+        """
+        if "created_at" in fields:
+            raise ValueError(
+                "created_at is an immutable scheduling sort key and cannot "
+                "be changed via update_doc_status_fields"
+            )
+        unknown = set(fields) - _DOC_STATUS_UPDATABLE_COLUMNS
+        if unknown:
+            raise ValueError(
+                f"update_doc_status_fields received unknown doc_status "
+                f"column(s): {sorted(unknown)}"
+            )
+        if not fields:
+            # Nothing to write; still honour the existence contract.
+            row = await self.db.query(
+                "SELECT id FROM LIGHTRAG_DOC_STATUS WHERE workspace=$1 AND id=$2",
+                [self.workspace, doc_id],
+            )
+            if row is None and not missing_ok:
+                raise StorageRecordNotFoundError(doc_id)
+            return
+
+        params: list[Any] = [self.workspace, doc_id]
+        set_clauses: list[str] = []
+        for column, value in fields.items():
+            params.append(self._prepare_doc_status_field_value(column, value))
+            set_clauses.append(f"{column} = ${len(params)}")
+        sql = (
+            "UPDATE LIGHTRAG_DOC_STATUS SET "
+            + ", ".join(set_clauses)
+            + " WHERE workspace=$1 AND id=$2 RETURNING id"
+        )
+        row = await self.db.query(sql, params)
+        if row is None:
+            if missing_ok:
+                return
+            raise StorageRecordNotFoundError(doc_id)
+
+    # ------------------------------------------------------------------
+    # Strict batch read
+    # ------------------------------------------------------------------
+
+    async def get_docs_by_ids(
+        self,
+        doc_ids: Sequence[str],
+        *,
+        strict: bool = False,
+    ) -> dict[str, DocSchedulingRecord]:
+        """Batch strict read of scheduling records (see base contract).
+
+        One indexed round-trip (``WHERE workspace=$1 AND id = ANY($2)``): a
+        missing id is positively confirmed absent (simply not in the result
+        set) and omitted. ``strict=True`` fails the WHOLE call — any asyncpg
+        error propagates out of ``db.query`` and any returned row that cannot
+        be projected raises — rather than returning a partial mapping the
+        feeder would mistake for stale ids. Results use the lightweight
+        projection (no chunks / full content).
+        """
+        ids = [str(d) for d in doc_ids]
+        if not ids:
+            return {}
+        sql = (
+            "SELECT id, status, created_at, updated_at, file_path, track_id, "
+            "metadata FROM LIGHTRAG_DOC_STATUS "
+            "WHERE workspace=$1 AND id = ANY($2)"
+        )
+        rows = await self.db.query(sql, [self.workspace, ids], multirows=True) or []
+        result: dict[str, DocSchedulingRecord] = {}
+        for row in rows:
+            record = self._pg_scheduling_record_from_row(row, strict=strict)
+            if record is None:
+                continue  # relaxed skip of an unusable row (still consumed)
+            result[record.id] = record
+        return result
+
+    # ------------------------------------------------------------------
+    # Source-conflict listing and explicit CAS repair
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _conflict_fingerprint(sorted_doc_ids: list[str]) -> str:
+        """Deterministic digest over candidate doc IDs in stable sort order."""
+        digest = hashlib.sha256()
+        for doc_id in sorted_doc_ids:
+            digest.update(doc_id.encode("utf-8"))
+            digest.update(b"\x00")
+        return digest.hexdigest()
+
+    @staticmethod
+    def _decode_conflict_cursor(opaque: str) -> str:
+        try:
+            key = json.loads(opaque)
+            if not isinstance(key, str):
+                raise ValueError("conflict cursor must be a string")
+        except (ValueError, TypeError) as e:
+            raise StorageControlPlaneError(
+                f"Malformed source-conflict cursor for PGDocStatusStorage: {e}"
+            ) from e
+        return key
+
+    async def list_source_conflicts_page(
+        self,
+        *,
+        limit: int,
+        position: CursorPosition = CURSOR_START,
+    ) -> SourceConflictPage:
+        """Page canonical source keys with >1 primary candidate (see base).
+
+        ``GROUP BY file_path HAVING COUNT(*) >= 2`` over PRIMARY rows only,
+        keyset-ordered by the canonical key so pages are stable and bounded.
+        Each key's bounded sample is fetched with its own ``ORDER BY id LIMIT
+        _CONFLICT_SAMPLE_CAP`` query, so no group ever materializes its whole
+        candidate set.
+        """
+        if limit <= 0:
+            raise ValueError(f"page limit must be positive, got {limit}")
+        if position is CURSOR_END:
+            return SourceConflictPage(conflicts=(), next_position=CURSOR_END)
+        params: list[Any] = [self.workspace]
+        sql = (
+            "SELECT file_path, COUNT(*) AS c FROM LIGHTRAG_DOC_STATUS "
+            f"WHERE workspace=$1 AND {self._PRIMARY_PREDICATE} "
+            "AND file_path IS NOT NULL "
+            "AND file_path NOT IN ('', 'unknown_source', 'no-file-path')"
+        )
+        if isinstance(position, CursorAfter):
+            params.append(self._decode_conflict_cursor(position.opaque))
+            sql += f" AND file_path > ${len(params)}"
+        params.append(limit)
+        sql += (
+            " GROUP BY file_path HAVING COUNT(*) >= 2 "
+            f"ORDER BY file_path ASC LIMIT ${len(params)}"
+        )
+        rows = await self.db.query(sql, params, multirows=True) or []
+
+        conflicts: list[SourceConflictSummary] = []
+        for row in rows:
+            key = row["file_path"]
+            sample = (
+                await self.db.query(
+                    "SELECT id FROM LIGHTRAG_DOC_STATUS "
+                    f"WHERE workspace=$1 AND file_path=$2 AND {self._PRIMARY_PREDICATE} "
+                    "ORDER BY id ASC LIMIT $3",
+                    [self.workspace, key, self._CONFLICT_SAMPLE_CAP],
+                    multirows=True,
+                )
+                or []
+            )
+            conflicts.append(
+                SourceConflictSummary(
+                    canonical_source_key=key,
+                    candidate_count=int(row["c"]),
+                    sample_doc_ids=tuple(str(r["id"]) for r in sample),
+                )
+            )
+
+        if len(rows) < limit:
+            next_position: CursorPosition = CURSOR_END
+        else:
+            next_position = CursorAfter(
+                json.dumps(rows[-1]["file_path"], ensure_ascii=False)
+            )
+        return SourceConflictPage(
+            conflicts=tuple(conflicts), next_position=next_position
+        )
+
+    async def repair_source_conflict(
+        self,
+        canonical_source_key: str,
+        *,
+        primary_doc_id: str,
+        expected_candidate_count: int,
+        expected_candidate_fingerprint: str,
+        dry_run: bool = True,
+    ) -> SourceConflictRepairResult:
+        """Demote all-but-one primary to duplicate, CAS-guarded (see base).
+
+        The candidate set is re-read ``FOR UPDATE`` inside ONE transaction, so
+        the count/fingerprint recomputation, the CAS check and the demotions
+        are atomic. dry-run reports the current count/fingerprint without
+        mutating; commit refuses (:class:`StorageControlPlaneError`) when they
+        no longer match the operator-echoed expectation. Losing candidates get
+        ``metadata.is_duplicate=true`` + ``original_doc_id=primary_doc_id`` in
+        the same transaction; content is never deleted. ``primary_doc_id`` not
+        in the current candidate set raises ``ValueError``.
+        """
+        workspace = self.workspace
+        predicate = self._PRIMARY_PREDICATE
+        sample_cap = self._CONFLICT_SAMPLE_CAP
+
+        async def _repair(
+            connection: asyncpg.Connection,
+        ) -> SourceConflictRepairResult:
+            async with connection.transaction():
+                rows = await connection.fetch(
+                    "SELECT id FROM LIGHTRAG_DOC_STATUS "
+                    f"WHERE workspace=$1 AND file_path=$2 AND {predicate} "
+                    "ORDER BY id ASC FOR UPDATE",
+                    workspace,
+                    canonical_source_key,
+                )
+                candidates = sorted(str(r["id"]) for r in rows)
+                count = len(candidates)
+                fingerprint = self._conflict_fingerprint(candidates)
+                if primary_doc_id not in candidates:
+                    raise ValueError(
+                        f"primary_doc_id {primary_doc_id!r} is not a current "
+                        f"primary candidate for {canonical_source_key!r}"
+                    )
+                demoted = [d for d in candidates if d != primary_doc_id]
+                if dry_run:
+                    return SourceConflictRepairResult(
+                        canonical_source_key=canonical_source_key,
+                        primary_doc_id=primary_doc_id,
+                        candidate_count=count,
+                        fingerprint=fingerprint,
+                        demoted_sample_doc_ids=tuple(demoted[:sample_cap]),
+                        committed=False,
+                    )
+                if (
+                    count != expected_candidate_count
+                    or fingerprint != expected_candidate_fingerprint
+                ):
+                    raise StorageControlPlaneError(
+                        f"[{workspace}] source-conflict repair CAS failed for "
+                        f"{canonical_source_key!r}: candidate set changed "
+                        f"(count {count} vs {expected_candidate_count})"
+                    )
+                if demoted:
+                    # jsonb_set both keys, coalescing a NULL/missing metadata
+                    # to '{}' first; the derived is_duplicate exclusion updates
+                    # in the same transaction as the row rewrite.
+                    await connection.execute(
+                        "UPDATE LIGHTRAG_DOC_STATUS SET metadata = jsonb_set("
+                        "jsonb_set(COALESCE(metadata, '{}'::jsonb), "
+                        "'{is_duplicate}', 'true'::jsonb, true), "
+                        "'{original_doc_id}', to_jsonb($3::text), true) "
+                        "WHERE workspace=$1 AND id = ANY($2)",
+                        workspace,
+                        demoted,
+                        primary_doc_id,
+                    )
+                return SourceConflictRepairResult(
+                    canonical_source_key=canonical_source_key,
+                    primary_doc_id=primary_doc_id,
+                    candidate_count=count,
+                    fingerprint=fingerprint,
+                    demoted_sample_doc_ids=tuple(demoted[:sample_cap]),
+                    committed=True,
+                )
+
+        return await self.db._run_with_retry(_repair)
 
     async def get_status_counts(self) -> dict[str, int]:
         """Get counts of documents in each status"""

--- a/lightrag/kg/redis_impl.py
+++ b/lightrag/kg/redis_impl.py
@@ -85,6 +85,80 @@ redis_retry = retry(
     before_sleep=before_sleep_log(logger, logging.WARNING),
 )
 
+# One eviction-policy check per Redis URL per process: the answer is a server
+# property, not a per-storage one, and both storage classes share the pool.
+_eviction_checked: set[str] = set()
+
+
+async def _ensure_no_eviction_policy(redis, redis_url: str, workspace: str) -> None:
+    """Refuse to use an evicting Redis as a system of record.
+
+    ``doc_status`` rows, ``full_docs`` entries and the derived scheduling sidecar
+    (status ZSETs + basename SETs) are all plain keys with NO TTL. Under an
+    ``allkeys-*`` maxmemory policy Redis may evict any of them, and that loss is
+    silent AND undetectable: an evicted status ZSET drops every document in that
+    status out of the sweep, an evicted primary row loses the document outright,
+    and the sidecar's structural probe only asks whether ANY status key exists —
+    so a partially evicted index looks perfectly healthy and gets no rebuild.
+    There is no cheap invariant that would catch it either (verifying the sidecar
+    against the rows is an O(total_docs) scan), which is exactly why this is a
+    startup precondition rather than a runtime repair.
+
+    Safe configurations, allowed silently:
+
+    * ``maxmemory=0`` — no limit, so nothing is ever evicted;
+    * ``volatile-*`` / ``noeviction`` — only keys carrying a TTL can be evicted
+      and none of ours do (just the short-lived rebuild lease), so a full
+      instance fails writes LOUDLY instead of quietly dropping data.
+
+    Managed Redis frequently blocks ``CONFIG GET``. An unreadable config warns
+    rather than fails: refusing to start over a policy we cannot even observe
+    would break working deployments. ``REDIS_ALLOW_EVICTION_POLICY=true`` is the
+    explicit override for an operator who accepts the data loss.
+    """
+    if redis_url in _eviction_checked:
+        return
+    try:
+        settings = await redis.config_get("maxmemory*")
+    except Exception as config_error:
+        # Unknown command, NOPERM, or a proxy that does not implement CONFIG.
+        _eviction_checked.add(redis_url)
+        logger.warning(
+            f"[{workspace}] Could not read the Redis maxmemory policy "
+            f"({config_error}); cannot verify that this instance will not EVICT "
+            f"doc_status/full_docs keys. Ensure maxmemory-policy is 'noeviction' "
+            f"or a 'volatile-*' policy — an 'allkeys-*' policy silently drops "
+            f"documents and scheduling state."
+        )
+        return
+    _eviction_checked.add(redis_url)
+    policy = str((settings or {}).get("maxmemory-policy") or "").strip().lower()
+    raw_maxmemory = str((settings or {}).get("maxmemory") or "0").strip()
+    try:
+        maxmemory = int(raw_maxmemory)
+    except ValueError:
+        maxmemory = 0
+    if maxmemory <= 0 or not policy.startswith("allkeys"):
+        return
+    if os.getenv("REDIS_ALLOW_EVICTION_POLICY", "false").strip().lower() == "true":
+        logger.warning(
+            f"[{workspace}] Redis is configured to EVICT (maxmemory-policy="
+            f"'{policy}', maxmemory={maxmemory}) and REDIS_ALLOW_EVICTION_POLICY "
+            f"is set: doc_status rows, full_docs entries and the scheduling "
+            f"sidecar may be dropped silently, losing documents."
+        )
+        return
+    raise StorageControlPlaneError(
+        f"[{workspace}] Redis at {redis_url} is configured as an evicting cache "
+        f"(maxmemory-policy='{policy}', maxmemory={maxmemory}), but LightRAG "
+        f"stores doc_status, full_docs and the derived scheduling index there as "
+        f"a system of record — none of those keys carry a TTL, so an "
+        f"'allkeys-*' policy can drop documents and scheduling state with no "
+        f"error and no way to detect it. Set maxmemory-policy to 'noeviction' "
+        f"(or a 'volatile-*' policy), give LightRAG its own Redis instance/db, "
+        f"or set REDIS_ALLOW_EVICTION_POLICY=true to accept the data loss."
+    )
+
 
 class RedisConnectionManager:
     """Shared Redis connection pool manager to avoid creating multiple pools for the same Redis URI"""
@@ -287,6 +361,9 @@ class RedisKVStorage(BaseKVStorage):
             try:
                 async with self._get_redis_connection() as redis:
                     await redis.ping()
+                    await _ensure_no_eviction_policy(
+                        redis, self._redis_url, self.workspace
+                    )
                     logger.info(
                         f"[{self.workspace}] Connected to Redis for namespace {self.namespace}"
                     )
@@ -776,6 +853,9 @@ class RedisDocStatusStorage(DocStatusStorage):
             try:
                 async with self._get_redis_connection() as redis:
                     await redis.ping()
+                    await _ensure_no_eviction_policy(
+                        redis, self._redis_url, self.workspace
+                    )
                     logger.info(
                         f"[{self.workspace}] Connected to Redis for doc status namespace {self.namespace}"
                     )
@@ -2135,7 +2215,18 @@ class RedisDocStatusStorage(DocStatusStorage):
         write, so leave it untouched (never clobber a live index); if none
         exists but primary rows do, it is a fresh pre-existing deployment or a
         recovery and must be rebuilt. A short-lease backend lock elects one
-        rebuilding worker; losers wait (bounded) for the index to appear."""
+        rebuilding worker; losers wait (bounded) for the index to appear.
+
+        Deliberate limitation: "any status key exists" cannot detect a PARTIAL
+        index (some status keys or members gone), so a partial loss is NOT
+        repaired here — it looks healthy. Verifying the index against the rows
+        would be an O(total_docs) scan on every startup, and a persisted
+        counter would be the second source of truth this design exists to
+        avoid. Partial loss is therefore prevented at its only real cause
+        instead: ``_ensure_no_eviction_policy`` refuses at startup to run on a
+        Redis configured to evict TTL-less keys. An operator who suspects a
+        damaged index deletes the ``…__sched:*`` keys and restarts, which takes
+        the branch below."""
         status_pattern = f"{self._sched_prefix}:status:*"
         primary_pattern = f"{self.final_namespace}:*"
         lock_key = f"{self._sched_prefix}:rebuild_lock"

--- a/lightrag/kg/redis_impl.py
+++ b/lightrag/kg/redis_impl.py
@@ -699,6 +699,10 @@ class RedisDocStatusStorage(DocStatusStorage):
     # Bounded upper limit on the sample of conflicting doc IDs surfaced by the
     # source-conflict listing/repair APIs — never materialize the whole set.
     _CONFLICT_SAMPLE_CAP: ClassVar[int] = 32
+    # SCAN batch for the conflict listing: the unit of work a page never
+    # abandons half-examined, so it also caps how far a page may overshoot
+    # ``limit`` (see list_source_conflicts_page).
+    _CONFLICT_SCAN_BATCH: ClassVar[int] = 64
     # Bounded retry budget for WATCH/MULTI conflict loops. High contention
     # on a single doc key is not expected (per-doc writes are serialized by
     # the pipeline); the cap turns a pathological livelock into an error.
@@ -1918,16 +1922,24 @@ class RedisDocStatusStorage(DocStatusStorage):
         return digest.hexdigest()
 
     @staticmethod
-    def _decode_conflict_cursor(opaque: str) -> str:
+    def _decode_conflict_cursor(opaque: str) -> int:
+        """Decode the opaque conflict cursor: a raw Redis ``SCAN`` cursor.
+
+        Redis cannot enumerate the source keyspace in key order without
+        materializing (and sorting) all of it, so the conflict listing pages on
+        the SCAN cursor itself — stateless, resumable and bounded. See
+        :meth:`list_source_conflicts_page` for the duplicate-visit caveat this
+        inherits from SCAN.
+        """
         try:
-            key = json.loads(opaque)
-            if not isinstance(key, str):
-                raise ValueError("conflict cursor must be a string")
+            cursor = json.loads(opaque)
+            if isinstance(cursor, bool) or not isinstance(cursor, int) or cursor < 0:
+                raise ValueError("conflict cursor must be a non-negative SCAN cursor")
         except (ValueError, TypeError) as e:
             raise StorageControlPlaneError(
                 f"Malformed source-conflict cursor for RedisDocStatusStorage: {e}"
             ) from e
-        return key
+        return cursor
 
     async def list_source_conflicts_page(
         self,
@@ -1937,54 +1949,74 @@ class RedisDocStatusStorage(DocStatusStorage):
     ) -> SourceConflictPage:
         """Page canonical source keys with >1 validated primary candidate.
 
-        SCANs the source-set keyspace, uses a cheap ``SCARD >= 2`` prefilter,
-        then validates each candidate set exactly (hydrating members, self-
-        healing stale ones) so a set inflated only by stale members is not
-        reported as a conflict. Operator tooling — bounded per output page."""
+        Streams the source-set keyspace one bounded ``SCAN`` batch at a time,
+        pipelines a cheap ``SCARD >= 2`` prefilter over the batch, then
+        validates only the surviving keys exactly (hydrating members, self-
+        healing stale ones) so a set inflated purely by stale members is not
+        reported as a conflict. Stops as soon as ``limit`` conflicts are in
+        hand.
+
+        Bounded in memory (one SCAN batch + the page, never the whole canonical
+        keyspace) and in round-trips per page (one pipelined SCARD per batch,
+        one validation per surviving key — not one per canonical key in the
+        workspace). Paging rides the raw SCAN cursor because Redis cannot
+        enumerate the keyspace in key order without materializing all of it.
+
+        Two consequences of that, both acceptable for operator tooling and
+        neither able to hide a conflict: the page is not ordered by canonical
+        key, and SCAN may revisit a key, so the same conflict can appear on two
+        pages (repair is idempotent and CAS-guarded, and each conflict needs a
+        human decision anyway). ``conflicts`` may overshoot ``limit`` by up to
+        one SCAN batch, because a batch is never abandoned half-examined —
+        doing so would advance the cursor past keys nobody looked at.
+        """
         self._require_sidecar_ready()
         if limit <= 0:
             raise ValueError(f"page limit must be positive, got {limit}")
         if position is CURSOR_END:
             return SourceConflictPage(conflicts=(), next_position=CURSOR_END)
-        last_key: str | None = None
+        cursor = 0
         if isinstance(position, CursorAfter):
-            last_key = self._decode_conflict_cursor(position.opaque)
+            cursor = self._decode_conflict_cursor(position.opaque)
         prefix = f"{self._sched_prefix}:basename:"
+        conflicts: list[SourceConflictSummary] = []
         async with self._get_redis_connection() as redis:
-            canonicals: set[str] = set()
-            cursor = 0
             while True:
-                cursor, keys = await redis.scan(cursor, match=f"{prefix}*", count=1000)
-                for key in keys:
-                    canonicals.add(key[len(prefix) :])
-                if cursor == 0:
+                cursor, keys = await redis.scan(
+                    cursor,
+                    match=f"{prefix}*",
+                    count=self._CONFLICT_SCAN_BATCH,
+                )
+                if keys:
+                    card_pipe = redis.pipeline()
+                    for key in keys:
+                        card_pipe.scard(key)
+                    cards = await card_pipe.execute()
+                    for key, card in zip(keys, cards):
+                        if not card or card < 2:
+                            continue
+                        canonical = key[len(prefix) :]
+                        ids = await self._valid_primary_ids(redis, canonical)
+                        if len(ids) >= 2:
+                            conflicts.append(
+                                SourceConflictSummary(
+                                    canonical_source_key=canonical,
+                                    candidate_count=len(ids),
+                                    sample_doc_ids=tuple(
+                                        ids[: self._CONFLICT_SAMPLE_CAP]
+                                    ),
+                                )
+                            )
+                # cursor == 0 means the iteration completed: nothing is left to
+                # resume from, so the page is terminal even if it filled up.
+                if cursor == 0 or len(conflicts) >= limit:
                     break
-            conflicts_all: list[tuple[str, list[str]]] = []
-            for canonical in sorted(canonicals):
-                card = await redis.scard(self._basename_key(canonical))
-                if card < 2:
-                    continue
-                ids = await self._valid_primary_ids(redis, canonical)
-                if len(ids) >= 2:
-                    conflicts_all.append((canonical, ids))
-        page = [
-            (canonical, ids)
-            for canonical, ids in conflicts_all
-            if last_key is None or canonical > last_key
-        ][:limit]
-        conflicts = tuple(
-            SourceConflictSummary(
-                canonical_source_key=canonical,
-                candidate_count=len(ids),
-                sample_doc_ids=tuple(ids[: self._CONFLICT_SAMPLE_CAP]),
-            )
-            for canonical, ids in page
+        next_position: CursorPosition = (
+            CURSOR_END if cursor == 0 else CursorAfter(json.dumps(cursor))
         )
-        if len(page) < limit:
-            next_position: CursorPosition = CURSOR_END
-        else:
-            next_position = CursorAfter(json.dumps(page[-1][0], ensure_ascii=False))
-        return SourceConflictPage(conflicts=conflicts, next_position=next_position)
+        return SourceConflictPage(
+            conflicts=tuple(conflicts), next_position=next_position
+        )
 
     async def repair_source_conflict(
         self,
@@ -2145,7 +2177,9 @@ class RedisDocStatusStorage(DocStatusStorage):
         temp key into its official name — runs inside one ``MULTI/EXEC`` so a
         reader never observes a partial switch; a crash before the switch
         leaves the old official index untouched and the temp keyspace safe to
-        discard on the next attempt."""
+        discard on the next attempt. See ``_publish_rebuilt_index`` for why the
+        switch also has to guard against concurrent WRITERS, not just readers.
+        """
         temp_prefix = f"{self._sched_prefix}_rebuild"
         # Clear any leftover temp keyspace from a crashed prior attempt.
         await self._delete_by_patterns(
@@ -2153,6 +2187,7 @@ class RedisDocStatusStorage(DocStatusStorage):
         )
 
         rebuilt = 0
+        statuses_seen: set[str] = set()
         cursor = 0
         while True:
             cursor, keys = await redis.scan(
@@ -2180,6 +2215,7 @@ class RedisDocStatusStorage(DocStatusStorage):
                     doc_id = key.split(":", 1)[1]
                     status = str(row.get("status") or "")
                     if status:
+                        statuses_seen.add(status)
                         write_pipe.zadd(
                             f"{temp_prefix}:status:{status}",
                             {self._zset_member(row, doc_id): 0},
@@ -2192,25 +2228,75 @@ class RedisDocStatusStorage(DocStatusStorage):
             if cursor == 0:
                 break
 
-        # Atomic switch: drop stale official keys, rename temp keys into place.
-        official_keys = await self._scan_keys(
-            redis,
-            [f"{self._sched_prefix}:status:*", f"{self._sched_prefix}:basename:*"],
-        )
-        temp_keys = await self._scan_keys(
-            redis, [f"{temp_prefix}:status:*", f"{temp_prefix}:basename:*"]
-        )
-        async with redis.pipeline(transaction=True) as pipe:
-            pipe.multi()
-            for key in official_keys:
-                pipe.delete(key)
-            for temp_key in temp_keys:
-                official = self._sched_prefix + temp_key[len(temp_prefix) :]
-                pipe.rename(temp_key, official)
-            await pipe.execute()
+        await self._publish_rebuilt_index(redis, temp_prefix, statuses_seen)
         logger.info(
             f"[{self.workspace}] scheduling sidecar rebuilt "
             f"({rebuilt} rows) for {self.namespace}"
+        )
+
+    async def _publish_rebuilt_index(
+        self, redis, temp_prefix: str, statuses_seen: set[str]
+    ) -> None:
+        """Switch the temp keyspace into place, refusing to clobber live writes.
+
+        The switch DELETEs the official keys and RENAMEs the temp ones over
+        them, so it must not run while another worker is writing: a write that
+        lands after its row was scanned has already maintained the OFFICIAL
+        index correctly (``_queue_index_ops`` commits row + sidecar in one
+        transaction), and publishing our older snapshot on top would silently
+        revert it — the doc would sit in the wrong status ZSET, so the sweep
+        either re-runs it or never sees it.
+
+        The rebuild only starts when NO official status key exists (probed, then
+        re-checked under the election lock), so any status key present now was
+        created by a concurrent writer. That is detected two ways: a WATCH on
+        every status-ZSET key name — the enum values plus whatever the scan
+        actually saw, and a write always touches one of them — makes ``EXEC``
+        fail if a write lands in the commit window, and a re-probe under that
+        WATCH catches one that landed earlier during the scan. Either way we
+        refuse: publishing would lose writes, and publishing a snapshot we know
+        is stale is worse than failing loudly. Basename leftovers may legitimately
+        survive a partial eviction, so they are deleted as before.
+        """
+        status_pattern = f"{self._sched_prefix}:status:*"
+        watch_keys = sorted(
+            {self._zset_key(s) for s in statuses_seen}
+            | {self._zset_key(s.value) for s in DocStatus}
+        )
+        for _ in range(self._WATCH_RETRY_LIMIT):
+            async with redis.pipeline(transaction=True) as pipe:
+                try:
+                    await pipe.watch(*watch_keys)
+                    if await self._any_key(pipe, status_pattern):
+                        await pipe.unwatch()
+                        raise StorageControlPlaneError(
+                            f"[{self.workspace}] another writer maintained the "
+                            f"scheduling sidecar for {self.namespace} while it was "
+                            f"being rebuilt; refusing to publish a stale snapshot "
+                            f"over live writes. Retry with writers quiesced."
+                        )
+                    official_keys = await self._scan_keys(pipe, [status_pattern])
+                    official_keys += await self._scan_keys(
+                        pipe, [f"{self._sched_prefix}:basename:*"]
+                    )
+                    temp_keys = await self._scan_keys(
+                        pipe,
+                        [f"{temp_prefix}:status:*", f"{temp_prefix}:basename:*"],
+                    )
+                    pipe.multi()
+                    for key in official_keys:
+                        pipe.delete(key)
+                    for temp_key in temp_keys:
+                        official = self._sched_prefix + temp_key[len(temp_prefix) :]
+                        pipe.rename(temp_key, official)
+                    await pipe.execute()
+                    return
+                except WatchError:
+                    continue
+        raise StorageControlPlaneError(
+            f"[{self.workspace}] scheduling sidecar publish for {self.namespace} "
+            f"exceeded the WATCH retry budget ({self._WATCH_RETRY_LIMIT}); a "
+            f"concurrent writer keeps racing the switch"
         )
 
     async def drop(self) -> dict[str, str]:

--- a/lightrag/kg/redis_impl.py
+++ b/lightrag/kg/redis_impl.py
@@ -1,7 +1,9 @@
 import os
 import logging
 import asyncio
-from typing import Any, final, Union
+import time
+import hashlib
+from typing import Any, ClassVar, final, Sequence, Union
 from dataclasses import dataclass
 import pipmaster as pm
 import configparser
@@ -13,7 +15,12 @@ if not pm.is_installed("redis"):
 
 # aioredis is a depricated library, replaced with redis
 from redis.asyncio import Redis, ConnectionPool  # type: ignore
-from redis.exceptions import RedisError, ConnectionError, TimeoutError  # type: ignore
+from redis.exceptions import (  # type: ignore
+    RedisError,
+    ConnectionError,
+    TimeoutError,
+    WatchError,
+)
 from lightrag.utils import (
     logger,
     get_pinyin_sort_key,
@@ -22,10 +29,28 @@ from lightrag.utils import (
 )
 
 from lightrag.base import (
+    CURSOR_END,
+    CURSOR_START,
+    CursorAfter,
+    CursorPosition,
     BaseKVStorage,
+    DocSchedulingRecord,
+    DocStatusPage,
     DocStatusStorage,
     DocStatus,
     DocProcessingStatus,
+    SourceAbsent,
+    SourceConflict,
+    SourceConflictPage,
+    SourceConflictRepairResult,
+    SourceConflictSummary,
+    SourceResolution,
+    SourceUnique,
+)
+from lightrag.constants import CUSTOM_CHUNK_PATCH_METADATA_KEY
+from lightrag.exceptions import (
+    StorageControlPlaneError,
+    StorageRecordNotFoundError,
 )
 from ..kg.shared_storage import get_data_init_lock
 import json
@@ -193,6 +218,8 @@ class RedisConnectionManager:
 @final
 @dataclass
 class RedisKVStorage(BaseKVStorage):
+    supports_strict_point_reads: ClassVar[bool] = True
+
     def __post_init__(self):
         validate_workspace(self.workspace)
         # Check for REDIS_WORKSPACE environment variable first (higher priority)
@@ -379,6 +406,12 @@ class RedisKVStorage(BaseKVStorage):
                 logger.error(f"[{self.workspace}] JSON decode error for id {id}: {e}")
                 raise
 
+    async def get_by_id_strict(self, id: str) -> dict[str, Any] | None:
+        """Strict point read (base contract): ``get_by_id`` already
+        propagates every transport/decode failure (no swallow-and-None
+        path), so a ``None`` from a healthy GET is a confirmed absence."""
+        return await self.get_by_id(id)
+
     @redis_retry
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
         async with self._get_redis_connection() as redis:
@@ -419,8 +452,6 @@ class RedisKVStorage(BaseKVStorage):
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
         if not data:
             return
-
-        import time
 
         current_time = int(time.time())  # Get current Unix timestamp
 
@@ -619,7 +650,59 @@ class RedisKVStorage(BaseKVStorage):
 @final
 @dataclass
 class RedisDocStatusStorage(DocStatusStorage):
-    """Redis implementation of document status storage"""
+    """Redis implementation of document status storage.
+
+    Memory-bounding scheduling sidecar (Phase 1)
+    --------------------------------------------
+    Alongside the primary ``{final_namespace}:{doc_id}`` JSON records this
+    class maintains, ATOMICALLY with every write (``WATCH``→``MULTI/EXEC``
+    with conflict retry), a scheduling sidecar under the
+    ``{final_namespace}__sched:`` prefix — deliberately NOT matched by the
+    ``{final_namespace}:*`` patterns the legacy SCAN readers and ``drop``
+    use, so sidecar keys never leak into full-scan reads:
+
+    * ``…__sched:status:{status}`` — one ZSET per status, score 0,
+      member ``"{created_at}|{doc_id}"``; ISO-8601 strings make
+      lexicographic member order the ``(created_at, id)`` keyset order, so
+      ``ZRANGEBYLEX`` pages the sweep and ``ZCARD`` gives O(1) counts.
+    * ``…__sched:basename:{canonical}`` — canonical basename → SET of
+      eligible PRIMARY doc IDs (rows with ``metadata.is_duplicate != true``
+      and a real file_path). ``file_path`` is NOT assumed globally unique
+      (custom-id inserts, legacy ids and historical basename collisions can
+      all share one basename), so the index is a multimap: each write does a
+      member-level ``SADD``/``SREM`` of its OWN doc_id keyed on the (old,
+      new) eligibility of that row — never a single-value CAS. A primary
+      rewritten in place as a content-duplicate removes only itself; a
+      genuine collision leaves ≥2 members and is surfaced by the typed
+      resolver as a ``SourceConflict``.
+
+    The sidecar is a DERIVED structure, not a migration source of truth and
+    NOT gated by any persistent semantic marker. ``initialize`` rebuilds it
+    from the actual doc_status rows when it is absent (fresh bootstrap of a
+    pre-existing deployment, or recovery after the backend was replaced /
+    the derived keys were lost): a short-lease backend lock elects one
+    worker to stream the primary rows into a TEMPORARY keyspace
+    (``…__sched_rebuild:*``) and then atomically switch it into place
+    (per-key ``DELETE`` of the stale official keys + ``RENAME`` of the temp
+    keys inside a single ``MULTI/EXEC``). A crash before the switch leaves
+    the old official index untouched (still serving) and the unpublished
+    temp keyspace safe to discard on the next attempt. Once present, the
+    index is kept consistent by every write and never rebuilt, so a running
+    system's restarts do not clobber a live index. NOTE: an online rebuild
+    over a workspace under concurrent write traffic still requires a
+    maintenance freeze (deployment prerequisite) — the lock only serializes
+    rebuilding workers, it does not isolate unrelated live writers.
+    """
+
+    supports_strict_point_reads: ClassVar[bool] = True
+
+    # Bounded upper limit on the sample of conflicting doc IDs surfaced by the
+    # source-conflict listing/repair APIs — never materialize the whole set.
+    _CONFLICT_SAMPLE_CAP: ClassVar[int] = 32
+    # Bounded retry budget for WATCH/MULTI conflict loops. High contention
+    # on a single doc key is not expected (per-doc writes are serialized by
+    # the pipeline); the cap turns a pathological livelock into an error.
+    _WATCH_RETRY_LIMIT: ClassVar[int] = 50
 
     def __post_init__(self):
         validate_workspace(self.workspace)
@@ -692,7 +775,12 @@ class RedisDocStatusStorage(DocStatusStorage):
                     logger.info(
                         f"[{self.workspace}] Connected to Redis for doc status namespace {self.namespace}"
                     )
-                    self._initialized = True
+                # Rebuild the derived scheduling sidecar from the actual
+                # doc_status rows when it is absent (no persistent marker) —
+                # must complete before serving: the paged sweep, ZCARD counts
+                # and the basename source index all depend on it.
+                await self._rebuild_scheduling_sidecar()
+                self._initialized = True
             except Exception as e:
                 logger.error(
                     f"[{self.workspace}] Failed to connect to Redis for doc status: {e}"
@@ -1010,9 +1098,162 @@ class RedisDocStatusStorage(DocStatusStorage):
             logger.error(f"[{self.workspace}] Error checking if storage is empty: {e}")
             return True
 
-    @redis_retry
+    # ------------------------------------------------------------------
+    # Scheduling sidecar helpers (Phase 1) — see class docstring.
+    # ------------------------------------------------------------------
+
+    @property
+    def _sched_prefix(self) -> str:
+        return f"{self.final_namespace}__sched"
+
+    def _zset_key(self, status_value: str) -> str:
+        return f"{self._sched_prefix}:status:{status_value}"
+
+    def _basename_key(self, basename: str) -> str:
+        return f"{self._sched_prefix}:basename:{basename}"
+
+    def _require_sidecar_ready(self) -> None:
+        """Guard for strict page/count/resolver reads: refuse to serve while
+        the derived index is not yet published, so a not-ready index is never
+        misread as "empty" (which scan/enqueue would treat as confirmed-new
+        and mint duplicates)."""
+        if not self._initialized:
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] scheduling sidecar not ready for "
+                f"{self.namespace}; refusing to read a rebuilding / "
+                "uninitialized index as empty"
+            )
+
+    @staticmethod
+    def _zset_member(row: dict[str, Any], doc_id: str) -> str:
+        """``"{created_at}|{doc_id}"`` — ISO-8601 lexicographic order makes
+        member order the (created_at, id) keyset order. A missing/non-str
+        created_at sorts deterministically first as ""; '|' cannot occur in
+        ISO timestamps so the split is unambiguous."""
+        created = row.get("created_at")
+        return f"{created if isinstance(created, str) else ''}|{doc_id}"
+
+    @staticmethod
+    def _split_member(member: str) -> tuple[str, str]:
+        created, _, doc_id = member.partition("|")
+        return created, doc_id
+
+    @staticmethod
+    def _is_duplicate_row(row: Any) -> bool:
+        if not isinstance(row, dict):
+            return False
+        metadata = row.get("metadata")
+        return bool(isinstance(metadata, dict) and metadata.get("is_duplicate"))
+
+    @classmethod
+    def _basename_of(cls, row: Any) -> str | None:
+        """Canonical basename this row would claim in the primary index,
+        or None when the row is index-ineligible (duplicate marker /
+        placeholder file_path)."""
+        if not isinstance(row, dict) or cls._is_duplicate_row(row):
+            return None
+        file_path = row.get("file_path")
+        if not isinstance(file_path, str) or not file_path:
+            return None
+        if file_path in ("unknown_source", "no-file-path"):
+            return None
+        return file_path
+
+    def _queue_index_ops(
+        self,
+        pipe,
+        doc_id: str,
+        old_row: dict[str, Any] | None,
+        new_row: dict[str, Any] | None,
+    ) -> None:
+        """Queue sidecar maintenance into an open MULTI for one doc write.
+
+        Status ZSET: remove the old member, add the new one (created_at is
+        immutable for existing rows, but removing by the OLD row's member is
+        still the correct general form). Basename source multimap: the
+        eligibility state machine on (old, new) is applied at MEMBER level —
+        this doc only ever ``SADD``s / ``SREM``s its OWN doc_id, so it never
+        touches another doc's membership and needs no single-value CAS. This
+        makes the whole write atomic under a WATCH on the doc key alone.
+        """
+        if old_row is not None:
+            old_status = str(old_row.get("status") or "")
+            if old_status:
+                pipe.zrem(
+                    self._zset_key(old_status), self._zset_member(old_row, doc_id)
+                )
+        if new_row is not None:
+            new_status = str(new_row.get("status") or "")
+            if new_status:
+                pipe.zadd(
+                    self._zset_key(new_status),
+                    {self._zset_member(new_row, doc_id): 0},
+                )
+
+        old_basename = self._basename_of(old_row)
+        new_basename = self._basename_of(new_row)
+        if old_basename == new_basename:
+            if new_basename is not None:
+                # eligible → eligible, same name: assert own membership
+                # (idempotent repair of a missing member).
+                pipe.sadd(self._basename_key(new_basename), doc_id)
+            return
+        if old_basename is not None:
+            # eligible → ineligible (e.g. a primary rewritten in place as a
+            # post-parse content duplicate) or file_path moved: drop only our
+            # own membership from the old source set.
+            pipe.srem(self._basename_key(old_basename), doc_id)
+        if new_basename is not None:
+            # ineligible → eligible, or file_path moved: join the new source set.
+            pipe.sadd(self._basename_key(new_basename), doc_id)
+
+    async def _atomic_doc_write(
+        self,
+        redis,
+        doc_id: str,
+        mutate,
+    ) -> dict[str, Any] | None:
+        """WATCH→MULTI/EXEC skeleton for one doc: read the old row under a
+        WATCH on the doc key alone, let ``mutate(old_row)`` produce the new
+        row (or ``None`` to abort without writing), then commit row + sidecar
+        in one transaction; retry on conflict.
+
+        The basename source multimap needs no WATCH: ``_queue_index_ops`` only
+        SADD/SREMs this doc's OWN membership, which commutes with concurrent
+        writes to other docs sharing the same source set.
+
+        Returns the committed new row (or None when aborted).
+        """
+        main_key = f"{self.final_namespace}:{doc_id}"
+        for _ in range(self._WATCH_RETRY_LIMIT):
+            async with redis.pipeline(transaction=True) as pipe:
+                try:
+                    await pipe.watch(main_key)
+                    old_raw = await pipe.get(main_key)
+                    old_row = json.loads(old_raw) if old_raw else None
+                    new_row = mutate(old_row)
+                    if new_row is None:
+                        await pipe.unwatch()
+                        return None
+                    pipe.multi()
+                    pipe.set(main_key, json.dumps(new_row))
+                    self._queue_index_ops(pipe, doc_id, old_row, new_row)
+                    await pipe.execute()
+                    return new_row
+                except WatchError:
+                    continue
+        raise StorageControlPlaneError(
+            f"[{self.workspace}] doc_status write for {doc_id} exceeded the "
+            f"WATCH retry budget ({self._WATCH_RETRY_LIMIT})"
+        )
+
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
-        """Insert or update document status data"""
+        """Insert or update document status data.
+
+        Each record commits atomically with its scheduling sidecar (status
+        ZSET member + basename primary index) via a per-doc WATCH/MULTI
+        transaction — a few extra RPCs per doc, bounded by the enqueue
+        batch cap; correctness of the sidecar is the priority."""
         if not data:
             return
 
@@ -1020,21 +1261,15 @@ class RedisDocStatusStorage(DocStatusStorage):
             f"[{self.workspace}] Inserting {len(data)} records to {self.namespace}"
         )
         async with self._get_redis_connection() as redis:
-            try:
-                # Ensure chunks_list field exists for new documents
-                for i, (doc_id, doc_data) in enumerate(data.items(), start=1):
-                    if "chunks_list" not in doc_data:
-                        doc_data["chunks_list"] = []
-                    await _cooperative_yield(i)
+            for i, (doc_id, doc_data) in enumerate(data.items(), start=1):
+                if "chunks_list" not in doc_data:
+                    doc_data["chunks_list"] = []
 
-                pipe = redis.pipeline()
-                for i, (k, v) in enumerate(data.items(), start=1):
-                    pipe.set(f"{self.final_namespace}:{k}", json.dumps(v))
-                    await _cooperative_yield(i)
-                await pipe.execute()
-            except json.JSONDecodeError as e:
-                logger.error(f"[{self.workspace}] JSON decode error during upsert: {e}")
-                raise
+                def _replace(_old, _new=doc_data):
+                    return _new
+
+                await self._atomic_doc_write(redis, doc_id, _replace)
+                await _cooperative_yield(i)
 
     @redis_retry
     async def get_by_id(self, id: str) -> Union[dict[str, Any], None]:
@@ -1047,17 +1282,49 @@ class RedisDocStatusStorage(DocStatusStorage):
                 raise
 
     async def delete(self, doc_ids: list[str]) -> None:
-        """Delete specific records from storage by their IDs"""
+        """Delete records atomically with their scheduling sidecar entries.
+
+        Per-doc WATCH/MULTI on the doc key: remove the primary key, its
+        status-ZSET member and — member-level — this doc's own entry from its
+        source set (``SREM`` never strips another doc's membership, so
+        deleting a duplicate marker or a non-owning row is safe)."""
         if not doc_ids:
             return
 
+        deleted_count = 0
         async with self._get_redis_connection() as redis:
-            pipe = redis.pipeline()
             for doc_id in doc_ids:
-                pipe.delete(f"{self.final_namespace}:{doc_id}")
-
-            results = await pipe.execute()
-            deleted_count = sum(results)
+                main_key = f"{self.final_namespace}:{doc_id}"
+                for _ in range(self._WATCH_RETRY_LIMIT):
+                    async with redis.pipeline(transaction=True) as pipe:
+                        try:
+                            await pipe.watch(main_key)
+                            old_raw = await pipe.get(main_key)
+                            if not old_raw:
+                                await pipe.unwatch()
+                                break
+                            old_row = json.loads(old_raw)
+                            old_basename = self._basename_of(old_row)
+                            pipe.multi()
+                            pipe.delete(main_key)
+                            old_status = str(old_row.get("status") or "")
+                            if old_status:
+                                pipe.zrem(
+                                    self._zset_key(old_status),
+                                    self._zset_member(old_row, doc_id),
+                                )
+                            if old_basename is not None:
+                                pipe.srem(self._basename_key(old_basename), doc_id)
+                            await pipe.execute()
+                            deleted_count += 1
+                            break
+                        except WatchError:
+                            continue
+                else:
+                    raise StorageControlPlaneError(
+                        f"[{self.workspace}] doc_status delete for {doc_id} "
+                        f"exceeded the WATCH retry budget"
+                    )
             logger.info(
                 f"[{self.workspace}] Deleted {deleted_count} of {len(doc_ids)} doc status entries from {self.namespace}"
             )
@@ -1250,56 +1517,109 @@ class RedisDocStatusStorage(DocStatusStorage):
                 logger.error(f"[{self.workspace}] Error in get_doc_by_file_path: {e}")
                 return None
 
+    async def _scan_source_candidates(
+        self, redis, canonical: str, *, limit: int | None
+    ) -> list[tuple[str, dict[str, Any]]]:
+        """Incrementally SSCAN the source multimap for ``canonical`` and return
+        up to ``limit`` validated PRIMARY candidates (all when ``limit`` is
+        ``None``), each as ``(doc_id, raw_row)``.
+
+        Every member is hydrated from its primary key and re-validated as a
+        current primary (``_basename_of(row) == canonical``); a member whose
+        row is gone or no longer eligible is stale and self-healed with a
+        member-level ``SREM``. Transport / decode errors propagate — a strict
+        caller must never read a failure as absence. Reading incrementally
+        (not ``SMEMBERS``) with an early ``limit`` lets the resolver decide
+        Conflict after two valid candidates without materializing a large set.
+        """
+        set_key = self._basename_key(canonical)
+        candidates: list[tuple[str, dict[str, Any]]] = []
+        cursor = 0
+        while True:
+            cursor, members = await redis.sscan(set_key, cursor, count=256)
+            for doc_id in members:
+                raw = await redis.get(f"{self.final_namespace}:{doc_id}")
+                if not raw:
+                    # stale member: primary row gone — self-heal.
+                    await redis.srem(set_key, doc_id)
+                    continue
+                row = json.loads(raw)
+                if self._basename_of(row) != canonical:
+                    # no longer an eligible primary for this key (demoted to
+                    # duplicate / file_path moved): self-heal.
+                    await redis.srem(set_key, doc_id)
+                    continue
+                candidates.append((doc_id, row))
+                if limit is not None and len(candidates) >= limit:
+                    return candidates
+            if cursor == 0:
+                break
+        return candidates
+
+    async def _valid_primary_ids(self, redis, canonical: str) -> list[str]:
+        """Full sorted list of validated primary doc IDs for ``canonical``,
+        self-healing stale members. Used by the operator conflict listing /
+        repair (one source key at a time, bounded by that key's cardinality)."""
+        candidates = await self._scan_source_candidates(redis, canonical, limit=None)
+        return sorted({doc_id for doc_id, _ in candidates})
+
     async def get_doc_by_file_basename(
         self, basename: str
     ) -> Union[tuple[str, dict[str, Any]], None]:
-        """Find an existing record whose canonical basename matches.
+        """Legacy best-effort primary-row lookup by canonical basename.
 
-        The caller is responsible for passing an already-canonical basename.
-        Stored ``file_path`` values are canonicalized by the business layer, so
-        this lookup intentionally performs an exact match only.
-        """
-        if not basename:
+        The caller passes an already-canonical basename; stored ``file_path``
+        values are canonicalized by the business layer, so this is an exact
+        match. Duplicate marker rows are never returned. ``file_path`` is not
+        globally unique, so on a historical collision this returns SOME primary
+        (first validated member) — identity-critical callers must use
+        :meth:`resolve_doc_source_strict` to detect the conflict instead.
+
+        Legacy error semantics preserved: failures log and return ``None``
+        (best-effort miss)."""
+        if not basename or basename == "unknown_source":
             return None
-        if basename == "unknown_source":
-            return None
-
-        async with self._get_redis_connection() as redis:
-            try:
-                cursor = 0
-                while True:
-                    cursor, keys = await redis.scan(
-                        cursor, match=f"{self.final_namespace}:*", count=1000
-                    )
-                    if keys:
-                        pipe = redis.pipeline()
-                        for key in keys:
-                            pipe.get(key)
-                        values = await pipe.execute()
-
-                        for key, value in zip(keys, values):
-                            if not value:
-                                continue
-                            try:
-                                doc_data = json.loads(value)
-                            except json.JSONDecodeError as e:
-                                logger.error(
-                                    f"[{self.workspace}] JSON decode error in get_doc_by_file_basename: {e}"
-                                )
-                                continue
-                            if doc_data.get("file_path") == basename:
-                                doc_id = key.split(":", 1)[1]
-                                return doc_id, doc_data
-
-                    if cursor == 0:
-                        break
-
-                return None
-            except Exception as e:
-                logger.error(
-                    f"[{self.workspace}] Error in get_doc_by_file_basename: {e}"
+        try:
+            async with self._get_redis_connection() as redis:
+                candidates = await self._scan_source_candidates(
+                    redis, basename, limit=1
                 )
-                return None
+            return candidates[0] if candidates else None
+        except Exception as e:
+            logger.error(f"[{self.workspace}] Error in get_doc_by_file_basename: {e}")
+            return None
+
+    async def resolve_doc_source_strict(
+        self, canonical_source_key: str
+    ) -> SourceResolution:
+        """Typed, conflict-aware source resolution (see base contract).
+
+        Reads the source multimap incrementally, stopping once two valid
+        primary candidates are found: 0 → :class:`SourceAbsent`, 1 →
+        :class:`SourceUnique`, ≥2 → :class:`SourceConflict`. Transport errors,
+        broken invariants and a not-ready index all raise a control-plane
+        error rather than returning ``SourceAbsent`` (which scan/enqueue would
+        treat as confirmed-new). ``candidate_count`` is ``None`` — the resolver
+        only proves "at least two" without enumerating the whole set."""
+        self._require_sidecar_ready()
+        if not canonical_source_key or canonical_source_key == "unknown_source":
+            return SourceAbsent()
+        async with self._get_redis_connection() as redis:
+            candidates = await self._scan_source_candidates(
+                redis, canonical_source_key, limit=2
+            )
+        if not candidates:
+            return SourceAbsent()
+        if len(candidates) == 1:
+            doc_id, row = candidates[0]
+            return SourceUnique(
+                doc_id=doc_id,
+                doc=self._scheduling_record_from_row(doc_id, row, strict=True),
+            )
+        return SourceConflict(
+            candidate_count=None,
+            sample_doc_ids=tuple(sorted(doc_id for doc_id, _ in candidates)),
+        )
 
     async def get_doc_by_content_hash(
         self, content_hash: str
@@ -1345,27 +1665,586 @@ class RedisDocStatusStorage(DocStatusStorage):
                 )
                 return None
 
+    # ------------------------------------------------------------------
+    # Memory-bounding scheduling API (Phase 1)
+    # ------------------------------------------------------------------
+
+    async def get_by_id_strict(self, id: str) -> Union[dict[str, Any], None]:
+        """Strict point read: ``get_by_id`` already propagates transport and
+        decode failures, so a ``None`` is a confirmed absence."""
+        return await self.get_by_id(id)
+
+    @staticmethod
+    def _encode_cursor(positions: dict[str, str]) -> str:
+        return json.dumps(positions, ensure_ascii=False, sort_keys=True)
+
+    @staticmethod
+    def _decode_cursor(opaque: str) -> dict[str, str]:
+        try:
+            decoded = json.loads(opaque)
+            if not isinstance(decoded, dict) or not all(
+                isinstance(k, str) and isinstance(v, str) for k, v in decoded.items()
+            ):
+                raise ValueError("cursor must map status -> last member")
+        except (ValueError, TypeError) as e:
+            raise StorageControlPlaneError(
+                f"Malformed scheduling cursor for RedisDocStatusStorage: {e}"
+            ) from e
+        return decoded
+
+    def _scheduling_record_from_row(
+        self, doc_id: str, row: dict[str, Any], *, strict: bool
+    ) -> DocSchedulingRecord | None:
+        try:
+            status = DocStatus(str(row["status"]))
+            created_at = row["created_at"]
+            updated_at = row.get("updated_at", created_at)
+            if not isinstance(created_at, str) or not isinstance(updated_at, str):
+                raise TypeError("created_at/updated_at must be strings")
+            metadata = row.get("metadata")
+            return DocSchedulingRecord(
+                id=doc_id,
+                status=status,
+                created_at=created_at,
+                updated_at=updated_at,
+                file_path=row.get("file_path") or "no-file-path",
+                track_id=row.get("track_id"),
+                has_custom_chunk_journal=isinstance(metadata, dict)
+                and isinstance(metadata.get(CUSTOM_CHUNK_PATCH_METADATA_KEY), dict),
+            )
+        except (KeyError, TypeError, ValueError) as e:
+            logger.error(f"[{self.workspace}] Unusable scheduling row {doc_id}: {e}")
+            if strict:
+                raise
+            return None
+
+    async def get_docs_by_statuses_page(
+        self,
+        statuses: list[DocStatus],
+        *,
+        limit: int,
+        position: CursorPosition = CURSOR_START,
+        strict: bool = False,
+    ) -> DocStatusPage:
+        """Bounded k-way merge over the per-status ZSETs.
+
+        Each status stream is read with ``ZRANGEBYLEX (last_member +`` —
+        lexicographic member order IS the (created_at, id) keyset order.
+        The composite cursor records each status's own last CONSUMED member:
+        a candidate merged into the page window is consumed (returned, or
+        skipped as unusable in relaxed mode) and advances its stream; a
+        prefetched head that did not fit stays unconsumed and is re-read next
+        page. A stream is exhausted when its prefetch came back short AND
+        fully consumed; the sweep ends when every stream is exhausted.
+        """
+        self._require_sidecar_ready()
+        if limit <= 0:
+            raise ValueError(f"page limit must be positive, got {limit}")
+        if not statuses or position is CURSOR_END:
+            return DocStatusPage(docs={}, next_position=CURSOR_END)
+        if isinstance(position, CursorAfter):
+            positions = self._decode_cursor(position.opaque)
+        else:
+            positions = {}
+        status_values = [s.value for s in statuses]
+
+        async with self._get_redis_connection() as redis:
+            # Prefetch up to `limit` members per stream, strictly after each
+            # stream's own consumed position.
+            pipe = redis.pipeline()
+            for value in status_values:
+                last = positions.get(value)
+                lex_min = f"({last}" if last else "-"
+                pipe.zrangebylex(self._zset_key(value), lex_min, "+", 0, limit)
+            prefetched: list[list[str]] = await pipe.execute()
+
+            streams: dict[str, list[str]] = dict(zip(status_values, prefetched))
+            short_streams = {
+                value for value, members in streams.items() if len(members) < limit
+            }
+
+            # Merge candidates globally by member (== (created_at, id) key),
+            # keep the first `limit` as this page's consumption window.
+            merged: list[tuple[str, str]] = []  # (member, status_value)
+            for value, members in streams.items():
+                merged.extend((member, value) for member in members)
+            merged.sort(key=lambda t: t[0])
+            window = merged[:limit]
+
+            # Hydrate the window's primary rows in one pipeline.
+            doc_ids = [self._split_member(member)[1] for member, _ in window]
+            rows: list[str | None] = []
+            if doc_ids:
+                pipe = redis.pipeline()
+                for doc_id in doc_ids:
+                    pipe.get(f"{self.final_namespace}:{doc_id}")
+                rows = await pipe.execute()
+
+        docs: dict[str, DocSchedulingRecord] = {}
+        consumed_counts: dict[str, int] = {value: 0 for value in status_values}
+        new_positions = dict(positions)
+        for (member, value), raw in zip(window, rows):
+            _, doc_id = self._split_member(member)
+            consumed_counts[value] += 1
+            new_positions[value] = member
+            if raw is None:
+                message = (
+                    f"[{self.workspace}] status ZSET member {member!r} has no "
+                    f"primary row — sidecar invariant broken"
+                )
+                if strict:
+                    raise StorageControlPlaneError(message)
+                logger.error(message)
+                continue  # consumed; the stale member self-heals on rewrite
+            row = json.loads(raw)
+            record = self._scheduling_record_from_row(doc_id, row, strict=strict)
+            if record is None:
+                continue  # relaxed skip is still consumed
+            docs[doc_id] = record
+
+        exhausted = all(
+            value in short_streams and consumed_counts[value] == len(streams[value])
+            for value in status_values
+        )
+        if exhausted:
+            return DocStatusPage(docs=docs, next_position=CURSOR_END)
+        return DocStatusPage(
+            docs=docs,
+            next_position=CursorAfter(self._encode_cursor(new_positions)),
+        )
+
+    async def count_docs_by_statuses(
+        self, statuses: list[DocStatus], *, strict: bool = True
+    ) -> int:
+        """O(1) fail-closed count: sum of per-status ZCARDs (errors
+        propagate — admission control must never read a failure as zero)."""
+        self._require_sidecar_ready()
+        if not statuses:
+            return 0
+        async with self._get_redis_connection() as redis:
+            pipe = redis.pipeline()
+            for status in statuses:
+                pipe.zcard(self._zset_key(status.value))
+            cards = await pipe.execute()
+        return int(sum(cards))
+
+    async def update_doc_status_fields(
+        self,
+        doc_id: str,
+        fields: dict[str, Any],
+        *,
+        missing_ok: bool = False,
+    ) -> None:
+        """Targeted field update, atomic with the sidecar (WATCH/MULTI)."""
+        if "created_at" in fields:
+            raise ValueError(
+                "created_at is an immutable scheduling sort key and cannot "
+                "be changed via update_doc_status_fields"
+            )
+        missing = False
+
+        def _merge(old_row):
+            nonlocal missing
+            if old_row is None:
+                missing = True
+                return None
+            return {**old_row, **fields}
+
+        async with self._get_redis_connection() as redis:
+            await self._atomic_doc_write(redis, doc_id, _merge)
+        if missing and not missing_ok:
+            raise StorageRecordNotFoundError(doc_id)
+
+    # ------------------------------------------------------------------
+    # Strict batch read
+    # ------------------------------------------------------------------
+
+    async def get_docs_by_ids(
+        self,
+        doc_ids: Sequence[str],
+        *,
+        strict: bool = False,
+    ) -> dict[str, DocSchedulingRecord]:
+        """Batch strict read of scheduling records by doc id (see base).
+
+        A single pipelined ``GET`` per id straight off the primary rows (the
+        source of truth, no sidecar dependency): a ``None`` is a confirmed
+        absence and is omitted. The pipeline is all-or-nothing at transport,
+        so any server/transport error fails the WHOLE call — the feeder never
+        receives a partial mapping. ``strict=True`` additionally raises on a
+        malformed row; results use the lightweight projection."""
+        if not doc_ids:
+            return {}
+        ids = list(doc_ids)
+        async with self._get_redis_connection() as redis:
+            pipe = redis.pipeline()
+            for doc_id in ids:
+                pipe.get(f"{self.final_namespace}:{doc_id}")
+            raws = await pipe.execute()
+        result: dict[str, DocSchedulingRecord] = {}
+        for doc_id, raw in zip(ids, raws):
+            if raw is None:
+                continue  # confirmed absent
+            try:
+                row = json.loads(raw)
+            except json.JSONDecodeError:
+                logger.error(
+                    f"[{self.workspace}] undecodable row for {doc_id} in "
+                    f"get_docs_by_ids"
+                )
+                if strict:
+                    raise
+                continue
+            if not isinstance(row, dict):
+                if strict:
+                    raise TypeError(f"doc_status record {doc_id} is not a mapping")
+                continue
+            record = self._scheduling_record_from_row(doc_id, row, strict=strict)
+            if record is not None:
+                result[doc_id] = record
+        return result
+
+    # ------------------------------------------------------------------
+    # Source-conflict listing and explicit CAS repair
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _conflict_fingerprint(sorted_doc_ids: list[str]) -> str:
+        """Deterministic digest over candidate doc IDs in stable sort order."""
+        digest = hashlib.sha256()
+        for doc_id in sorted_doc_ids:
+            digest.update(doc_id.encode("utf-8"))
+            digest.update(b"\x00")
+        return digest.hexdigest()
+
+    @staticmethod
+    def _decode_conflict_cursor(opaque: str) -> str:
+        try:
+            key = json.loads(opaque)
+            if not isinstance(key, str):
+                raise ValueError("conflict cursor must be a string")
+        except (ValueError, TypeError) as e:
+            raise StorageControlPlaneError(
+                f"Malformed source-conflict cursor for RedisDocStatusStorage: {e}"
+            ) from e
+        return key
+
+    async def list_source_conflicts_page(
+        self,
+        *,
+        limit: int,
+        position: CursorPosition = CURSOR_START,
+    ) -> SourceConflictPage:
+        """Page canonical source keys with >1 validated primary candidate.
+
+        SCANs the source-set keyspace, uses a cheap ``SCARD >= 2`` prefilter,
+        then validates each candidate set exactly (hydrating members, self-
+        healing stale ones) so a set inflated only by stale members is not
+        reported as a conflict. Operator tooling — bounded per output page."""
+        self._require_sidecar_ready()
+        if limit <= 0:
+            raise ValueError(f"page limit must be positive, got {limit}")
+        if position is CURSOR_END:
+            return SourceConflictPage(conflicts=(), next_position=CURSOR_END)
+        last_key: str | None = None
+        if isinstance(position, CursorAfter):
+            last_key = self._decode_conflict_cursor(position.opaque)
+        prefix = f"{self._sched_prefix}:basename:"
+        async with self._get_redis_connection() as redis:
+            canonicals: set[str] = set()
+            cursor = 0
+            while True:
+                cursor, keys = await redis.scan(cursor, match=f"{prefix}*", count=1000)
+                for key in keys:
+                    canonicals.add(key[len(prefix) :])
+                if cursor == 0:
+                    break
+            conflicts_all: list[tuple[str, list[str]]] = []
+            for canonical in sorted(canonicals):
+                card = await redis.scard(self._basename_key(canonical))
+                if card < 2:
+                    continue
+                ids = await self._valid_primary_ids(redis, canonical)
+                if len(ids) >= 2:
+                    conflicts_all.append((canonical, ids))
+        page = [
+            (canonical, ids)
+            for canonical, ids in conflicts_all
+            if last_key is None or canonical > last_key
+        ][:limit]
+        conflicts = tuple(
+            SourceConflictSummary(
+                canonical_source_key=canonical,
+                candidate_count=len(ids),
+                sample_doc_ids=tuple(ids[: self._CONFLICT_SAMPLE_CAP]),
+            )
+            for canonical, ids in page
+        )
+        if len(page) < limit:
+            next_position: CursorPosition = CURSOR_END
+        else:
+            next_position = CursorAfter(json.dumps(page[-1][0], ensure_ascii=False))
+        return SourceConflictPage(conflicts=conflicts, next_position=next_position)
+
+    async def repair_source_conflict(
+        self,
+        canonical_source_key: str,
+        *,
+        primary_doc_id: str,
+        expected_candidate_count: int,
+        expected_candidate_fingerprint: str,
+        dry_run: bool = True,
+    ) -> SourceConflictRepairResult:
+        """Demote all-but-one primary to duplicate, CAS-guarded (see base).
+
+        Recomputes the validated candidate set (self-healing stale members)
+        and its deterministic fingerprint; dry-run reports without mutating.
+        On commit, a mismatch with the operator-echoed ``expected_*`` fails as
+        a CAS conflict rather than overwriting a concurrent change; otherwise
+        each losing candidate is demoted via :meth:`_atomic_doc_write`, so its
+        ``metadata.is_duplicate``/``original_doc_id`` write and its source-set
+        + status-ZSET maintenance commit in one per-doc transaction. A new
+        primary racing in mid-repair simply leaves the resolver in Conflict,
+        so a re-run (fresh dry-run) continues without any repair marker."""
+        self._require_sidecar_ready()
+        async with self._get_redis_connection() as redis:
+            candidates = await self._valid_primary_ids(redis, canonical_source_key)
+            count = len(candidates)
+            fingerprint = self._conflict_fingerprint(candidates)
+            if primary_doc_id not in candidates:
+                raise ValueError(
+                    f"primary_doc_id {primary_doc_id!r} is not a current primary "
+                    f"candidate for {canonical_source_key!r}"
+                )
+            demoted = [d for d in candidates if d != primary_doc_id]
+            if dry_run:
+                return SourceConflictRepairResult(
+                    canonical_source_key=canonical_source_key,
+                    primary_doc_id=primary_doc_id,
+                    candidate_count=count,
+                    fingerprint=fingerprint,
+                    demoted_sample_doc_ids=tuple(demoted[: self._CONFLICT_SAMPLE_CAP]),
+                    committed=False,
+                )
+            if (
+                count != expected_candidate_count
+                or fingerprint != expected_candidate_fingerprint
+            ):
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] source-conflict repair CAS failed for "
+                    f"{canonical_source_key!r}: candidate set changed "
+                    f"(count {count} vs {expected_candidate_count})"
+                )
+
+            def _demote(old_row, _primary=primary_doc_id):
+                if old_row is None:
+                    return None
+                row = dict(old_row)
+                metadata = dict(row.get("metadata") or {})
+                metadata["is_duplicate"] = True
+                metadata["original_doc_id"] = _primary
+                row["metadata"] = metadata
+                return row
+
+            for doc_id in demoted:
+                await self._atomic_doc_write(redis, doc_id, _demote)
+        return SourceConflictRepairResult(
+            canonical_source_key=canonical_source_key,
+            primary_doc_id=primary_doc_id,
+            candidate_count=count,
+            fingerprint=fingerprint,
+            demoted_sample_doc_ids=tuple(demoted[: self._CONFLICT_SAMPLE_CAP]),
+            committed=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Derived sidecar rebuild (Phase 1)
+    # ------------------------------------------------------------------
+
+    async def _scan_keys(self, redis, patterns: Sequence[str]) -> list[str]:
+        """SCAN every ``pattern`` and collect the matching keys."""
+        found: list[str] = []
+        for pattern in patterns:
+            cursor = 0
+            while True:
+                cursor, keys = await redis.scan(cursor, match=pattern, count=1000)
+                found.extend(keys)
+                if cursor == 0:
+                    break
+        return found
+
+    async def _delete_by_patterns(self, redis, patterns: Sequence[str]) -> None:
+        """Delete every key matching any of ``patterns`` in bounded batches."""
+        for pattern in patterns:
+            cursor = 0
+            while True:
+                cursor, keys = await redis.scan(cursor, match=pattern, count=1000)
+                if keys:
+                    await redis.delete(*keys)
+                if cursor == 0:
+                    break
+
+    async def _any_key(self, redis, pattern: str) -> bool:
+        """True if any key matches ``pattern`` (bounded SCAN)."""
+        cursor = 0
+        while True:
+            cursor, keys = await redis.scan(cursor, match=pattern, count=100)
+            if keys:
+                return True
+            if cursor == 0:
+                return False
+
+    async def _rebuild_scheduling_sidecar(self) -> None:
+        """Rebuild the derived scheduling index from the actual doc_status rows
+        when it is absent — no persistent semantic marker gates this.
+
+        Structural check (not a marker): if any ``…__sched:status:*`` key
+        exists the index is already built and is kept consistent by every
+        write, so leave it untouched (never clobber a live index); if none
+        exists but primary rows do, it is a fresh pre-existing deployment or a
+        recovery and must be rebuilt. A short-lease backend lock elects one
+        rebuilding worker; losers wait (bounded) for the index to appear."""
+        status_pattern = f"{self._sched_prefix}:status:*"
+        primary_pattern = f"{self.final_namespace}:*"
+        lock_key = f"{self._sched_prefix}:rebuild_lock"
+        async with self._get_redis_connection() as redis:
+            if await self._any_key(redis, status_pattern):
+                return  # already built + maintained live
+            if not await self._any_key(redis, primary_pattern):
+                return  # nothing to build (empty / freshly dropped workspace)
+            got_lock = await redis.set(lock_key, "1", nx=True, ex=300)
+            if not got_lock:
+                # Another worker is rebuilding: wait (bounded) for the switch.
+                for _ in range(60):
+                    await asyncio.sleep(1)
+                    if await self._any_key(redis, status_pattern):
+                        return
+                    if not await self._any_key(redis, primary_pattern):
+                        return  # workspace emptied while we waited
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] scheduling sidecar rebuild by another "
+                    f"worker did not complete in time"
+                )
+            try:
+                # Re-check under the lock: another worker may have finished
+                # between our probe and acquiring the lock.
+                if await self._any_key(redis, status_pattern):
+                    return
+                await self._do_rebuild(redis)
+            finally:
+                await redis.delete(lock_key)
+
+    async def _do_rebuild(self, redis) -> None:
+        """Stream the primary rows into a temporary keyspace, then atomically
+        switch it into place.
+
+        The temp keyspace (``…__sched_rebuild:*``) is disjoint from both the
+        official ``…__sched:*`` patterns and the primary ``{ns}:*`` pattern, so
+        neither the SCAN of primary rows nor the official index touches it. The
+        switch — DELETE of every stale official key followed by RENAME of every
+        temp key into its official name — runs inside one ``MULTI/EXEC`` so a
+        reader never observes a partial switch; a crash before the switch
+        leaves the old official index untouched and the temp keyspace safe to
+        discard on the next attempt."""
+        temp_prefix = f"{self._sched_prefix}_rebuild"
+        # Clear any leftover temp keyspace from a crashed prior attempt.
+        await self._delete_by_patterns(
+            redis, [f"{temp_prefix}:status:*", f"{temp_prefix}:basename:*"]
+        )
+
+        rebuilt = 0
+        cursor = 0
+        while True:
+            cursor, keys = await redis.scan(
+                cursor, match=f"{self.final_namespace}:*", count=1000
+            )
+            if keys:
+                pipe = redis.pipeline()
+                for key in keys:
+                    pipe.get(key)
+                values = await pipe.execute()
+                write_pipe = redis.pipeline()
+                for key, raw in zip(keys, values):
+                    if not raw:
+                        continue
+                    try:
+                        row = json.loads(raw)
+                    except json.JSONDecodeError:
+                        logger.error(
+                            f"[{self.workspace}] skipping undecodable row {key} "
+                            f"during sidecar rebuild"
+                        )
+                        continue
+                    if not isinstance(row, dict):
+                        continue
+                    doc_id = key.split(":", 1)[1]
+                    status = str(row.get("status") or "")
+                    if status:
+                        write_pipe.zadd(
+                            f"{temp_prefix}:status:{status}",
+                            {self._zset_member(row, doc_id): 0},
+                        )
+                    basename = self._basename_of(row)
+                    if basename is not None:
+                        write_pipe.sadd(f"{temp_prefix}:basename:{basename}", doc_id)
+                    rebuilt += 1
+                await write_pipe.execute()
+            if cursor == 0:
+                break
+
+        # Atomic switch: drop stale official keys, rename temp keys into place.
+        official_keys = await self._scan_keys(
+            redis,
+            [f"{self._sched_prefix}:status:*", f"{self._sched_prefix}:basename:*"],
+        )
+        temp_keys = await self._scan_keys(
+            redis, [f"{temp_prefix}:status:*", f"{temp_prefix}:basename:*"]
+        )
+        async with redis.pipeline(transaction=True) as pipe:
+            pipe.multi()
+            for key in official_keys:
+                pipe.delete(key)
+            for temp_key in temp_keys:
+                official = self._sched_prefix + temp_key[len(temp_prefix) :]
+                pipe.rename(temp_key, official)
+            await pipe.execute()
+        logger.info(
+            f"[{self.workspace}] scheduling sidecar rebuilt "
+            f"({rebuilt} rows) for {self.namespace}"
+        )
+
     async def drop(self) -> dict[str, str]:
-        """Drop all document status data from storage and clean up resources"""
+        """Drop all document status data from storage and clean up resources.
+
+        Also clears the derived scheduling sidecar — status ZSETs, source
+        multimap sets, and any leftover rebuild temp keyspace — since they
+        mirror the dropped rows. Nothing persists across the clear: the index
+        is purely derived and would be rebuilt from the (now empty) rows."""
         try:
             async with self._get_redis_connection() as redis:
-                # Use SCAN to find all keys with the namespace prefix
-                pattern = f"{self.final_namespace}:*"
-                cursor = 0
                 deleted_count = 0
+                for pattern in (
+                    f"{self.final_namespace}:*",
+                    f"{self._sched_prefix}:status:*",
+                    f"{self._sched_prefix}:basename:*",
+                    f"{self._sched_prefix}_rebuild:status:*",
+                    f"{self._sched_prefix}_rebuild:basename:*",
+                ):
+                    cursor = 0
+                    while True:
+                        cursor, keys = await redis.scan(
+                            cursor, match=pattern, count=1000
+                        )
+                        if keys:
+                            # Delete keys in batches
+                            pipe = redis.pipeline()
+                            for key in keys:
+                                pipe.delete(key)
+                            results = await pipe.execute()
+                            deleted_count += sum(results)
 
-                while True:
-                    cursor, keys = await redis.scan(cursor, match=pattern, count=1000)
-                    if keys:
-                        # Delete keys in batches
-                        pipe = redis.pipeline()
-                        for key in keys:
-                            pipe.delete(key)
-                        results = await pipe.execute()
-                        deleted_count += sum(results)
-
-                    if cursor == 0:
-                        break
+                        if cursor == 0:
+                            break
 
                 logger.info(
                     f"[{self.workspace}] Dropped {deleted_count} doc status keys from {self.namespace}"

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -20,6 +20,7 @@ from urllib.parse import quote, unquote, urlsplit
 
 from lightrag.base import DocProcessingStatus, DocStatus, DocStatusStorage
 from lightrag.constants import (
+    CUSTOM_CHUNK_PATCH_METADATA_KEY,
     FILE_EXTRACTION_SUMMARY_PREFIX,
     FULL_DOCS_FORMAT_LIGHTRAG,
     LIGHTRAG_DOC_CONTENT_PREFIX,
@@ -263,13 +264,6 @@ def resolve_doc_status_parse_engine(
         else PARSER_ENGINE_LEGACY
     )
 
-
-# Reserved doc_status.metadata key holding the custom-chunk patch journal
-# (issue #3400 Phase 3). While present, the document has an in-flight or
-# failed ainsert_custom_chunks operation: the pipeline must NOT process the
-# row as ordinary ingestion, resets must NOT strip it, and deletion must
-# include its staged chunk IDs.
-CUSTOM_CHUNK_PATCH_METADATA_KEY = "custom_chunk_patch"
 
 # Public, persistent audit trail for structurally successful but semantically
 # degraded KG recovery. The WebUI uses this key to distinguish a processed

--- a/tests/kg/json_impl/test_json_scheduling_pages.py
+++ b/tests/kg/json_impl/test_json_scheduling_pages.py
@@ -1,0 +1,348 @@
+"""JsonDocStatusStorage Phase 1 scheduling contract tests (LR2 redesign).
+
+Covers: stable ``(created_at, id)`` keyset order with id tie-break, a
+fully-filtered page advancing the cursor without a false End, CURSOR_END
+termination, lightweight projection, strict count, targeted field updates
+(created_at immutable), strict batch reads, typed source resolution
+(Absent/Unique/Conflict), the explicit CAS source-conflict repair, and the
+primary-row basename contract (duplicate markers invisible). No
+failure-generation machinery remains.
+"""
+
+import json
+
+import pytest
+
+from lightrag.base import (
+    CURSOR_END,
+    CURSOR_START,
+    CursorAfter,
+    DocStatus,
+    SourceAbsent,
+    SourceConflict,
+    SourceUnique,
+)
+from lightrag.exceptions import (
+    StorageControlPlaneError,
+    StorageRecordNotFoundError,
+)
+from lightrag.kg.json_doc_status_impl import JsonDocStatusStorage
+from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
+
+pytestmark = pytest.mark.offline
+
+
+class _DummyEmbeddingFunc:
+    embedding_dim = 1
+    max_token_size = 1
+
+    async def __call__(self, texts, **kwargs):
+        return [[0.0] for _ in texts]
+
+
+@pytest.fixture(autouse=True)
+def setup_shared_data():
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
+def _doc(
+    status: str,
+    file_path: str = "a.pdf",
+    created_at: str = "2026-01-01T00:00:00+00:00",
+    **extra,
+) -> dict:
+    row = {
+        "content_summary": "s",
+        "content_length": 10,
+        "file_path": file_path,
+        "status": status,
+        "created_at": created_at,
+        "updated_at": created_at,
+        "metadata": {},
+        "error_msg": None,
+        "chunks_list": [],
+    }
+    row.update(extra)
+    return row
+
+
+async def _storage(tmp_path, rows: dict | None = None) -> JsonDocStatusStorage:
+    storage = JsonDocStatusStorage(
+        namespace="doc_status",
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=_DummyEmbeddingFunc(),
+        workspace="test",
+    )
+    await storage.initialize()
+    if rows:
+        async with storage._storage_lock:
+            storage._data.update(rows)
+    return storage
+
+
+async def _sweep_ids(storage, statuses, *, limit):
+    """Drive a full sweep, returning ids in consumption order + page count."""
+    ids: list[str] = []
+    pages = 0
+    position = CURSOR_START
+    while True:
+        page = await storage.get_docs_by_statuses_page(
+            statuses,
+            limit=limit,
+            position=position,
+            strict=True,
+        )
+        pages += 1
+        ids.extend(page.docs.keys())
+        if page.next_position is CURSOR_END:
+            return ids, pages
+        position = page.next_position
+        assert isinstance(position, CursorAfter)
+        assert pages < 100, "sweep failed to terminate"
+
+
+@pytest.mark.asyncio
+async def test_page_order_created_at_then_id_tiebreak(tmp_path):
+    storage = await _storage(
+        tmp_path,
+        {
+            "doc-b": _doc("pending", created_at="2026-01-02T00:00:00+00:00"),
+            "doc-a": _doc("pending", created_at="2026-01-02T00:00:00+00:00"),
+            "doc-c": _doc("pending", created_at="2026-01-01T00:00:00+00:00"),
+        },
+    )
+    ids, pages = await _sweep_ids(storage, [DocStatus.PENDING], limit=1)
+    # Oldest created_at first; same-timestamp rows tie-break by id ASC.
+    assert ids == ["doc-c", "doc-a", "doc-b"]
+    assert pages >= 3
+
+
+@pytest.mark.asyncio
+async def test_missing_created_at_sorts_first_and_stays_reachable(tmp_path):
+    """A missing/empty created_at row sorts into the "" bucket first and must
+    stay reachable across a limit=1 sweep (never stranded behind a cursor)."""
+    rows = {
+        "doc-real": _doc("pending", created_at="2026-01-01T00:00:00+00:00"),
+        "doc-null": _doc("pending", created_at=""),
+    }
+    storage = await _storage(tmp_path, rows)
+    ids, _ = await _sweep_ids(storage, [DocStatus.PENDING], limit=1)
+    assert ids == ["doc-null", "doc-real"]
+
+
+@pytest.mark.asyncio
+async def test_multi_status_kway_merge_no_gaps_or_repeats(tmp_path):
+    rows = {
+        f"doc-{i:02d}": _doc(
+            "pending" if i % 2 == 0 else "failed",
+            created_at=f"2026-01-{(i % 9) + 1:02d}T00:00:00+00:00",
+        )
+        for i in range(9)
+    }
+    storage = await _storage(tmp_path, rows)
+    ids, _ = await _sweep_ids(storage, [DocStatus.PENDING, DocStatus.FAILED], limit=2)
+    assert sorted(ids) == sorted(rows)  # no gaps
+    assert len(ids) == len(set(ids))  # no repeats
+
+
+@pytest.mark.asyncio
+async def test_page_projection_is_lightweight_and_mixed_status(tmp_path):
+    storage = await _storage(
+        tmp_path,
+        {
+            "doc-1": _doc(
+                "pending", chunks_list=["c"] * 500, created_at="2026-01-01T00:00:00"
+            ),
+            "doc-2": _doc("processing", created_at="2026-01-02T00:00:00"),
+            "doc-3": _doc("processed", created_at="2026-01-03T00:00:00"),
+        },
+    )
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING, DocStatus.PROCESSING], limit=10, strict=True
+    )
+    assert set(page.docs) == {"doc-1", "doc-2"}
+    assert page.next_position is CURSOR_END
+    record = page.docs["doc-1"]
+    assert not hasattr(record, "chunks_list")
+    assert record.status is DocStatus.PENDING
+    assert record.has_custom_chunk_journal is False
+
+
+@pytest.mark.asyncio
+async def test_count_docs_by_statuses_strict(tmp_path):
+    storage = await _storage(
+        tmp_path,
+        {
+            "doc-1": _doc("pending"),
+            "doc-2": _doc("pending"),
+            "doc-3": _doc("failed"),
+        },
+    )
+    assert await storage.count_docs_by_statuses([DocStatus.PENDING]) == 2
+    assert (
+        await storage.count_docs_by_statuses([DocStatus.PENDING, DocStatus.FAILED]) == 3
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_doc_status_fields_targeted(tmp_path):
+    storage = await _storage(tmp_path, {"doc-1": _doc("failed")})
+    await storage.update_doc_status_fields("doc-1", {"status": "pending"})
+    row = await storage.get_by_id("doc-1")
+    assert row["status"] == "pending"
+    assert row["file_path"] == "a.pdf"  # untouched fields preserved
+    with pytest.raises(ValueError, match="created_at"):
+        await storage.update_doc_status_fields("doc-1", {"created_at": "2030-01-01"})
+    with pytest.raises(StorageRecordNotFoundError):
+        await storage.update_doc_status_fields("missing", {"status": "pending"})
+    # missing_ok swallows the unknown id.
+    await storage.update_doc_status_fields(
+        "missing", {"status": "pending"}, missing_ok=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_docs_by_ids_batch_present_and_missing(tmp_path):
+    storage = await _storage(
+        tmp_path,
+        {"doc-1": _doc("pending"), "doc-2": _doc("failed")},
+    )
+    result = await storage.get_docs_by_ids(["doc-1", "doc-2", "ghost"], strict=True)
+    assert set(result) == {"doc-1", "doc-2"}  # missing omitted, confirmed absent
+    assert result["doc-2"].status is DocStatus.FAILED
+    assert not hasattr(result["doc-1"], "chunks_list")
+
+
+@pytest.mark.asyncio
+async def test_resolve_doc_source_absent_and_unique(tmp_path):
+    storage = await _storage(
+        tmp_path, {"doc-primary": _doc("pending", file_path="a.pdf")}
+    )
+    assert isinstance(
+        await storage.resolve_doc_source_strict("missing.pdf"), SourceAbsent
+    )
+    resolved = await storage.resolve_doc_source_strict("a.pdf")
+    assert isinstance(resolved, SourceUnique)
+    assert resolved.doc_id == "doc-primary"
+    assert resolved.doc.file_path == "a.pdf"
+
+
+@pytest.mark.asyncio
+async def test_resolve_doc_source_ignores_duplicate_markers(tmp_path):
+    dup = _doc("failed", file_path="a.pdf")
+    dup["metadata"] = {"is_duplicate": True}
+    storage = await _storage(
+        tmp_path,
+        {"dup-1": dup, "doc-primary": _doc("pending", file_path="a.pdf")},
+    )
+    resolved = await storage.resolve_doc_source_strict("a.pdf")
+    assert isinstance(resolved, SourceUnique) and resolved.doc_id == "doc-primary"
+
+
+@pytest.mark.asyncio
+async def test_resolve_doc_source_conflict(tmp_path):
+    storage = await _storage(
+        tmp_path,
+        {
+            "doc-1": _doc("pending", file_path="a.pdf"),
+            "doc-2": _doc("failed", file_path="a.pdf"),
+        },
+    )
+    resolved = await storage.resolve_doc_source_strict("a.pdf")
+    assert isinstance(resolved, SourceConflict)
+    assert set(resolved.sample_doc_ids) == {"doc-1", "doc-2"}
+
+
+@pytest.mark.asyncio
+async def test_list_and_repair_source_conflict(tmp_path):
+    storage = await _storage(
+        tmp_path,
+        {
+            "doc-1": _doc("pending", file_path="a.pdf"),
+            "doc-2": _doc("failed", file_path="a.pdf"),
+            "doc-3": _doc("pending", file_path="a.pdf"),
+            "solo": _doc("pending", file_path="b.pdf"),
+        },
+    )
+    page = await storage.list_source_conflicts_page(limit=10)
+    assert len(page.conflicts) == 1
+    conflict = page.conflicts[0]
+    assert conflict.canonical_source_key == "a.pdf"
+    assert conflict.candidate_count == 3
+
+    # dry-run reports without mutating.
+    dry = await storage.repair_source_conflict(
+        "a.pdf",
+        primary_doc_id="doc-2",
+        expected_candidate_count=0,
+        expected_candidate_fingerprint="ignored-in-dry-run",
+    )
+    assert dry.committed is False
+    assert dry.candidate_count == 3
+    still = await storage.resolve_doc_source_strict("a.pdf")
+    assert isinstance(still, SourceConflict)
+
+    # stale expectation → CAS failure.
+    with pytest.raises(StorageControlPlaneError):
+        await storage.repair_source_conflict(
+            "a.pdf",
+            primary_doc_id="doc-2",
+            expected_candidate_count=99,
+            expected_candidate_fingerprint=dry.fingerprint,
+            dry_run=False,
+        )
+
+    # correct expectation → commit; resolver returns the chosen primary.
+    result = await storage.repair_source_conflict(
+        "a.pdf",
+        primary_doc_id="doc-2",
+        expected_candidate_count=dry.candidate_count,
+        expected_candidate_fingerprint=dry.fingerprint,
+        dry_run=False,
+    )
+    assert result.committed is True
+    resolved = await storage.resolve_doc_source_strict("a.pdf")
+    assert isinstance(resolved, SourceUnique) and resolved.doc_id == "doc-2"
+    # losers demoted to duplicates, content intact.
+    for loser in ("doc-1", "doc-3"):
+        row = await storage.get_by_id(loser)
+        assert row["metadata"]["is_duplicate"] is True
+        assert row["metadata"]["original_doc_id"] == "doc-2"
+
+
+@pytest.mark.asyncio
+async def test_basename_lookup_returns_primary_only(tmp_path):
+    dup = _doc("failed", file_path="a.pdf")
+    dup["metadata"] = {"is_duplicate": True, "duplicate_kind": "filename"}
+    storage = await _storage(
+        tmp_path,
+        {
+            "dup-1": dup,
+            "doc-primary": _doc("pending", file_path="a.pdf"),
+        },
+    )
+    match = await storage.get_doc_by_file_basename("a.pdf")
+    assert match is not None and match[0] == "doc-primary"
+    # Only the duplicate marker left → the basename is free again.
+    await storage.delete(["doc-primary"])
+    assert await storage.get_doc_by_file_basename("a.pdf") is None
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_strict_confirmed_absence(tmp_path):
+    storage = await _storage(tmp_path, {"doc-1": _doc("pending")})
+    assert (await storage.get_by_id_strict("doc-1"))["status"] == "pending"
+    assert await storage.get_by_id_strict("missing") is None
+
+
+@pytest.mark.asyncio
+async def test_malformed_cursor_raises_control_plane_error(tmp_path):
+    storage = await _storage(tmp_path, {"doc-1": _doc("pending")})
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.PENDING],
+            limit=1,
+            position=CursorAfter(json.dumps({"not": "a-pair"})),
+        )

--- a/tests/kg/mongo_impl/test_mongo_scheduling_pages.py
+++ b/tests/kg/mongo_impl/test_mongo_scheduling_pages.py
@@ -132,7 +132,10 @@ class _FakeCollection:
 
     def find(self, query, projection=None, session=None):
         self.find_queries.append(query)
-        cursor = _FakeFindCursor(self._find_docs, error=self._find_error)
+        # find_docs may be a callable so a test can route per query (the
+        # conflict listing fetches a bounded sample per surfaced source key).
+        docs = self._find_docs(query) if callable(self._find_docs) else self._find_docs
+        cursor = _FakeFindCursor(docs, error=self._find_error)
         self.find_cursors.append(cursor)
         return cursor
 
@@ -553,15 +556,17 @@ async def test_legacy_basename_swallows_transport_error():
 
 
 async def test_list_conflicts_maps_groups_and_terminates():
+    # The aggregation is COUNT-ONLY: $push-ing every id would allocate an array
+    # per distinct file_path in the collection, conflicting or not.
     groups = [
-        {
-            "_id": "a.txt",
-            "candidate_count": 3,
-            "sample_doc_ids": ["doc-3", "doc-1", "doc-2"],
-        },
-        {"_id": "b.txt", "candidate_count": 2, "sample_doc_ids": ["doc-9", "doc-8"]},
+        {"_id": "a.txt", "candidate_count": 3},
+        {"_id": "b.txt", "candidate_count": 2},
     ]
-    data = _FakeCollection(agg_docs=groups)
+    samples = {
+        "a.txt": [{"_id": "doc-1"}, {"_id": "doc-2"}, {"_id": "doc-3"}],
+        "b.txt": [{"_id": "doc-8"}, {"_id": "doc-9"}],
+    }
+    data = _FakeCollection(agg_docs=groups, find_docs=lambda q: samples[q["file_path"]])
     storage = _storage(data=data)
 
     page = await storage.list_source_conflicts_page(limit=5)
@@ -576,7 +581,10 @@ async def test_list_conflicts_maps_groups_and_terminates():
             "metadata.is_duplicate": {"$ne": True},
         }
     }
-    assert pipeline[1]["$group"]["_id"] == "$file_path"
+    assert pipeline[1]["$group"] == {
+        "_id": "$file_path",
+        "candidate_count": {"$sum": 1},
+    }
     assert pipeline[2] == {"$match": {"candidate_count": {"$gte": 2}}}
     assert pipeline[3] == {"$sort": {"_id": 1}}
     assert pipeline[4] == {"$limit": 5}
@@ -585,14 +593,21 @@ async def test_list_conflicts_maps_groups_and_terminates():
     assert page.conflicts[0].candidate_count == 3
     assert page.conflicts[0].sample_doc_ids == ("doc-1", "doc-2", "doc-3")  # sorted
     assert page.conflicts[1].sample_doc_ids == ("doc-8", "doc-9")
+    # One bounded sample query per SURFACED key — server-side sorted + capped,
+    # so a key with a pathological primary count still ships a fixed sample.
+    assert [q["file_path"] for q in data.find_queries] == ["a.txt", "b.txt"]
+    for cursor in data.find_cursors:
+        assert cursor.sort_spec == [("_id", 1)]
+        assert cursor.limit_value == storage._CONFLICT_SAMPLE_CAP
+        assert cursor.to_list_length == storage._CONFLICT_SAMPLE_CAP
     # returned (2) < limit (5) proves exhaustion.
     assert page.next_position is CURSOR_END
 
 
 async def test_list_conflicts_full_page_advances_cursor():
     groups = [
-        {"_id": "a.txt", "candidate_count": 2, "sample_doc_ids": ["doc-1", "doc-2"]},
-        {"_id": "b.txt", "candidate_count": 2, "sample_doc_ids": ["doc-3", "doc-4"]},
+        {"_id": "a.txt", "candidate_count": 2},
+        {"_id": "b.txt", "candidate_count": 2},
     ]
     data = _FakeCollection(agg_docs=groups)
     storage = _storage(data=data)

--- a/tests/kg/mongo_impl/test_mongo_scheduling_pages.py
+++ b/tests/kg/mongo_impl/test_mongo_scheduling_pages.py
@@ -1,0 +1,707 @@
+"""Offline tests for the Mongo Phase 1 scheduling surface.
+
+Covers the bounded keyset page API (query/sort/limit shape, consumed-position
+cursor advance, null-bucket resume, malformed-cursor rejection), the strict
+batch read (:meth:`get_docs_by_ids`), the conflict-aware source resolver
+(:meth:`resolve_doc_source_strict`), and the source-conflict listing / explicit
+CAS repair. The pymongo collection is driven through minimal in-process fakes —
+no live services.
+"""
+
+import json
+
+import pytest
+
+pytest.importorskip(
+    "pymongo",
+    reason="pymongo is required for Mongo storage tests",
+)
+
+from pymongo.errors import PyMongoError
+
+from lightrag.base import (
+    CURSOR_END,
+    CURSOR_START,
+    CursorAfter,
+    DocStatus,
+    SourceAbsent,
+    SourceConflict,
+    SourceUnique,
+)
+from lightrag.exceptions import StorageControlPlaneError, StorageRecordNotFoundError
+from lightrag.kg.mongo_impl import MongoDocStatusStorage
+
+pytestmark = pytest.mark.offline
+
+_ROW_1 = {
+    "_id": "doc-1",
+    "status": "pending",
+    "created_at": "2026-01-01T00:00:00+00:00",
+    "updated_at": "2026-01-01T00:00:00+00:00",
+    "file_path": "a.txt",
+}
+_ROW_2 = {
+    "_id": "doc-2",
+    "status": "failed",
+    "created_at": "2026-01-02T00:00:00+00:00",
+    "updated_at": "2026-01-02T00:00:00+00:00",
+    "file_path": "b.txt",
+}
+
+
+class _UpdateResult:
+    def __init__(self, matched_count=0, modified_count=0, upserted_id=None):
+        self.matched_count = matched_count
+        self.modified_count = modified_count
+        self.upserted_id = upserted_id
+
+
+class _FakeFindCursor:
+    """Records the find(...).sort(...).limit(...).to_list(...) chain."""
+
+    def __init__(self, docs, error=None):
+        self._docs = list(docs)
+        self._error = error
+        self.sort_spec = None
+        self.limit_value = None
+        self.to_list_length = None
+
+    def sort(self, spec):
+        self.sort_spec = spec
+        return self
+
+    def limit(self, n):
+        self.limit_value = n
+        return self
+
+    async def to_list(self, length=None):
+        self.to_list_length = length
+        if self._error is not None:
+            raise self._error
+        return self._docs
+
+
+class _FakeAggCursor:
+    """Records the aggregate(...).to_list(...) chain."""
+
+    def __init__(self, docs, error=None):
+        self._docs = list(docs)
+        self._error = error
+        self.to_list_length = None
+
+    async def to_list(self, length=None):
+        self.to_list_length = length
+        if self._error is not None:
+            raise self._error
+        return self._docs
+
+
+class _FakeCollection:
+    """Minimal AsyncCollection stand-in recording every call."""
+
+    def __init__(
+        self,
+        find_docs=(),
+        find_error=None,
+        find_one_result=None,
+        find_one_error=None,
+        update_result=None,
+        update_many_result=None,
+        count_value=42,
+        agg_docs=(),
+        agg_error=None,
+    ):
+        self._find_docs = find_docs
+        self._find_error = find_error
+        self.find_one_result = find_one_result
+        self.find_one_error = find_one_error
+        self.update_result = update_result or _UpdateResult()
+        self.update_many_result = update_many_result or _UpdateResult()
+        self._count_value = count_value
+        self._agg_docs = agg_docs
+        self._agg_error = agg_error
+
+        self.find_queries = []
+        self.find_cursors = []
+        self.find_one_calls = []
+        self.update_one_calls = []
+        self.update_many_calls = []
+        self.count_documents_calls = []
+        self.aggregate_calls = []
+        self.agg_cursors = []
+
+    def find(self, query, projection=None, session=None):
+        self.find_queries.append(query)
+        cursor = _FakeFindCursor(self._find_docs, error=self._find_error)
+        self.find_cursors.append(cursor)
+        return cursor
+
+    async def find_one(self, query, projection=None):
+        self.find_one_calls.append((query, projection))
+        if self.find_one_error is not None:
+            raise self.find_one_error
+        return self.find_one_result
+
+    async def update_one(self, filter, update, upsert=False):
+        self.update_one_calls.append((filter, update, upsert))
+        return self.update_result
+
+    async def update_many(self, filter, update, session=None):
+        self.update_many_calls.append((filter, update, session))
+        return self.update_many_result
+
+    async def count_documents(self, query, **kwargs):
+        self.count_documents_calls.append(query)
+        return self._count_value
+
+    async def aggregate(self, pipeline, **kwargs):
+        self.aggregate_calls.append((pipeline, kwargs))
+        cursor = _FakeAggCursor(self._agg_docs, error=self._agg_error)
+        self.agg_cursors.append(cursor)
+        return cursor
+
+
+class _FakeTxn:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    def __init__(self):
+        self.started = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def start_transaction(self):
+        self.started = True
+        return _FakeTxn()
+
+
+class _FakeClient:
+    def __init__(self, session):
+        self._session = session
+
+    def start_session(self):
+        return self._session
+
+
+class _FakeDb:
+    def __init__(self, client):
+        self.client = client
+
+
+def _storage(data=None, db=None) -> MongoDocStatusStorage:
+    storage = MongoDocStatusStorage.__new__(MongoDocStatusStorage)
+    storage.workspace = "t"
+    storage.namespace = "doc_status"
+    storage._collection_name = "t_doc_status"
+    storage._data = data if data is not None else _FakeCollection()
+    storage.db = db
+    return storage
+
+
+# ---------------------------------------------------------------------------
+# get_docs_by_statuses_page: query shape / sort / limit / cursor advance
+# ---------------------------------------------------------------------------
+
+
+async def test_page_start_query_shape_and_cursor_end():
+    data = _FakeCollection(find_docs=[_ROW_1, _ROW_2])
+    storage = _storage(data=data)
+
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.FAILED, DocStatus.PENDING], limit=5, position=CURSOR_START
+    )
+
+    # Query: status $in only — no keyset resume clause on a fresh sweep.
+    assert data.find_queries == [{"status": {"$in": ["failed", "pending"]}}]
+    cursor = data.find_cursors[0]
+    assert cursor.sort_spec == [("created_at", 1), ("_id", 1)]
+    assert cursor.limit_value == 5
+    assert cursor.to_list_length == 5
+
+    assert set(page.docs) == {"doc-1", "doc-2"}
+    # returned (2) < limit (5) proves exhaustion.
+    assert page.next_position is CURSOR_END
+
+
+async def test_page_keyset_predicate():
+    data = _FakeCollection(find_docs=[])
+    storage = _storage(data=data)
+    opaque = json.dumps(["2026-01-01T00:00:00+00:00", "doc-1"])
+
+    await storage.get_docs_by_statuses_page(
+        [DocStatus.FAILED],
+        limit=2,
+        position=CursorAfter(opaque),
+    )
+
+    query = data.find_queries[0]
+    assert query["status"] == {"$in": ["failed"]}
+    # Only the keyset resume clause — no generation cohort predicate.
+    (keyset_or,) = query["$and"]
+    assert keyset_or == {
+        "$or": [
+            {"created_at": {"$gt": "2026-01-01T00:00:00+00:00"}},
+            {"created_at": "2026-01-01T00:00:00+00:00", "_id": {"$gt": "doc-1"}},
+        ]
+    }
+
+
+async def test_page_no_and_clause_on_fresh_sweep():
+    data = _FakeCollection(find_docs=[])
+    storage = _storage(data=data)
+
+    await storage.get_docs_by_statuses_page([DocStatus.FAILED], limit=2)
+
+    assert "$and" not in data.find_queries[0]
+
+
+async def test_page_full_page_advances_to_last_returned_key():
+    data = _FakeCollection(find_docs=[_ROW_1, _ROW_2])
+    storage = _storage(data=data)
+
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.FAILED, DocStatus.PENDING], limit=2
+    )
+
+    assert isinstance(page.next_position, CursorAfter)
+    assert json.loads(page.next_position.opaque) == [
+        "2026-01-02T00:00:00+00:00",
+        "doc-2",
+    ]
+
+
+async def test_page_relaxed_skip_is_still_consumed_strict_raises():
+    bad_row = {
+        # Missing "status": unconvertible, but query-returned hence consumed.
+        "_id": "doc-bad",
+        "created_at": "2026-01-03T00:00:00+00:00",
+    }
+    data = _FakeCollection(find_docs=[_ROW_1, bad_row])
+    storage = _storage(data=data)
+
+    page = await storage.get_docs_by_statuses_page([DocStatus.PENDING], limit=2)
+
+    # Relaxed: skipped from the page, but the cursor advances past the RAW
+    # last returned doc — never re-read, never falsely terminal.
+    assert set(page.docs) == {"doc-1"}
+    assert isinstance(page.next_position, CursorAfter)
+    assert json.loads(page.next_position.opaque) == [
+        "2026-01-03T00:00:00+00:00",
+        "doc-bad",
+    ]
+
+    with pytest.raises(KeyError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.PENDING], limit=2, strict=True
+        )
+
+
+async def test_missing_created_at_encodes_null_bucket_cursor():
+    """A doc whose created_at field is entirely ABSENT keys as (None, _id):
+    encoding it as "" would break the resume filter — {"created_at": ""}
+    matches neither a missing field nor a null value, so a second corrupt
+    doc past a page boundary would silently fall out of the sweep."""
+    assert MongoDocStatusStorage._doc_cursor_key({"_id": "doc-x"}) == (None, "doc-x")
+    assert MongoDocStatusStorage._doc_cursor_key(
+        {"_id": "doc-y", "created_at": None}
+    ) == (None, "doc-y")
+
+
+async def test_null_bucket_cursor_resumes_with_missing_matching_predicate():
+    """Cursor inside the missing/null bucket: the resume filter must use
+    {"created_at": None} (matches BOTH missing and null per Mongo $eq:null
+    semantics) plus the $ne:None arm for every later bucket."""
+    data = _FakeCollection(find_docs=[])
+    storage = _storage(data=data)
+
+    await storage.get_docs_by_statuses_page(
+        [DocStatus.FAILED],
+        limit=2,
+        position=CursorAfter(json.dumps([None, "doc-null-1"])),
+    )
+
+    query = data.find_queries[0]
+    (keyset_or,) = query["$and"]
+    assert keyset_or == {
+        "$or": [
+            {"created_at": None, "_id": {"$gt": "doc-null-1"}},
+            {"created_at": {"$ne": None}},
+        ]
+    }
+
+
+async def test_page_malformed_cursor_raises_control_plane_error():
+    storage = _storage()
+
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.FAILED], limit=2, position=CursorAfter("not-json")
+        )
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.FAILED],
+            limit=2,
+            position=CursorAfter(json.dumps(["2026-01-01", 3])),
+        )
+
+
+async def test_page_transport_error_propagates():
+    data = _FakeCollection(find_error=PyMongoError("boom"))
+    storage = _storage(data=data)
+
+    with pytest.raises(PyMongoError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.FAILED], limit=2, strict=True
+        )
+
+
+async def test_page_invalid_limit_and_terminal_position():
+    storage = _storage()
+
+    with pytest.raises(ValueError):
+        await storage.get_docs_by_statuses_page([DocStatus.FAILED], limit=0)
+
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.FAILED], limit=2, position=CURSOR_END
+    )
+    assert page.docs == {} and page.next_position is CURSOR_END
+    assert storage._data.find_queries == []  # no query issued
+
+
+# ---------------------------------------------------------------------------
+# count_docs_by_statuses
+# ---------------------------------------------------------------------------
+
+
+async def test_count_docs_by_statuses_counts_server_side():
+    data = _FakeCollection()
+    storage = _storage(data=data)
+
+    count = await storage.count_docs_by_statuses(
+        [DocStatus.PENDING, DocStatus.PROCESSING]
+    )
+
+    assert count == 42
+    assert data.count_documents_calls == [
+        {"status": {"$in": ["pending", "processing"]}}
+    ]
+    assert await storage.count_docs_by_statuses([]) == 0
+
+
+# ---------------------------------------------------------------------------
+# update_doc_status_fields
+# ---------------------------------------------------------------------------
+
+
+async def test_update_fields_rejects_created_at_without_db_call():
+    data = _FakeCollection()
+    storage = _storage(data=data)
+
+    with pytest.raises(ValueError):
+        await storage.update_doc_status_fields("doc-1", {"created_at": "x"})
+    assert data.update_one_calls == []
+
+
+async def test_update_fields_missing_row_raises_unless_missing_ok():
+    data = _FakeCollection(update_result=_UpdateResult(matched_count=0))
+    storage = _storage(data=data)
+
+    with pytest.raises(StorageRecordNotFoundError):
+        await storage.update_doc_status_fields("doc-x", {"status": "pending"})
+
+    await storage.update_doc_status_fields(
+        "doc-x", {"status": "pending"}, missing_ok=True
+    )
+
+    data.update_result = _UpdateResult(matched_count=1)
+    await storage.update_doc_status_fields("doc-1", {"status": "pending"})
+    assert data.update_one_calls[-1] == (
+        {"_id": "doc-1"},
+        {"$set": {"status": "pending"}},
+        False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_docs_by_ids: strict batch read
+# ---------------------------------------------------------------------------
+
+
+async def test_get_docs_by_ids_returns_present_omits_missing():
+    data = _FakeCollection(find_docs=[_ROW_1, _ROW_2])
+    storage = _storage(data=data)
+
+    result = await storage.get_docs_by_ids(["doc-1", "doc-2", "doc-missing"])
+
+    # One indexed $in query; missing id positively absent from the result set.
+    assert data.find_queries == [{"_id": {"$in": ["doc-1", "doc-2", "doc-missing"]}}]
+    assert set(result) == {"doc-1", "doc-2"}
+    assert result["doc-1"].status is DocStatus.PENDING
+
+
+async def test_get_docs_by_ids_empty_input_issues_no_query():
+    data = _FakeCollection()
+    storage = _storage(data=data)
+
+    assert await storage.get_docs_by_ids([]) == {}
+    assert data.find_queries == []
+
+
+async def test_get_docs_by_ids_relaxed_skips_bad_row_strict_raises():
+    bad = {"_id": "doc-bad", "created_at": "2026-01-03T00:00:00+00:00"}  # no status
+    data = _FakeCollection(find_docs=[_ROW_1, bad])
+    storage = _storage(data=data)
+
+    relaxed = await storage.get_docs_by_ids(["doc-1", "doc-bad"])
+    assert set(relaxed) == {"doc-1"}  # bad row dropped, present ids kept
+
+    with pytest.raises(KeyError):
+        await storage.get_docs_by_ids(["doc-1", "doc-bad"], strict=True)
+
+
+# ---------------------------------------------------------------------------
+# resolve_doc_source_strict: conflict-aware typed resolution
+# ---------------------------------------------------------------------------
+
+_PRIMARY_QUERY = {"file_path": "a.txt", "metadata.is_duplicate": {"$ne": True}}
+
+
+async def test_resolve_source_absent_for_empty_and_sentinels():
+    data = _FakeCollection(find_docs=[])
+    storage = _storage(data=data)
+
+    assert isinstance(await storage.resolve_doc_source_strict("a.txt"), SourceAbsent)
+    # Sentinels short-circuit without touching the collection.
+    assert isinstance(await storage.resolve_doc_source_strict(""), SourceAbsent)
+    assert isinstance(
+        await storage.resolve_doc_source_strict("unknown_source"), SourceAbsent
+    )
+    assert data.find_queries == [_PRIMARY_QUERY]
+
+
+async def test_resolve_source_unique():
+    data = _FakeCollection(find_docs=[_ROW_1])
+    storage = _storage(data=data)
+
+    resolution = await storage.resolve_doc_source_strict("a.txt")
+
+    assert isinstance(resolution, SourceUnique)
+    assert resolution.doc_id == "doc-1"
+    assert resolution.doc.id == "doc-1"
+    assert resolution.doc.status is DocStatus.PENDING
+    # limit(2) is what proves uniqueness cheaply.
+    assert data.find_cursors[0].limit_value == 2
+    assert data.count_documents_calls == []  # no exact count needed for unique
+
+
+async def test_resolve_source_conflict_reports_exact_count_and_sample():
+    data = _FakeCollection(find_docs=[_ROW_2, _ROW_1], count_value=7)
+    storage = _storage(data=data)
+
+    resolution = await storage.resolve_doc_source_strict("a.txt")
+
+    assert isinstance(resolution, SourceConflict)
+    assert resolution.candidate_count == 7  # exact count via count_documents
+    assert resolution.sample_doc_ids == ("doc-1", "doc-2")  # sorted sample
+    assert data.count_documents_calls == [_PRIMARY_QUERY]
+
+
+async def test_resolve_transport_error_propagates():
+    data = _FakeCollection(find_error=PyMongoError("down"))
+    storage = _storage(data=data)
+
+    with pytest.raises(PyMongoError):
+        await storage.resolve_doc_source_strict("a.txt")
+
+
+# ---------------------------------------------------------------------------
+# legacy get_doc_by_file_basename: primary-only query, best-effort errors
+# ---------------------------------------------------------------------------
+
+
+async def test_legacy_basename_primary_only_query():
+    data = _FakeCollection(find_one_result={"_id": "doc-1", "file_path": "a.txt"})
+    storage = _storage(data=data)
+
+    result = await storage.get_doc_by_file_basename("a.txt")
+
+    assert result == ("doc-1", {"_id": "doc-1", "file_path": "a.txt"})
+    query, _ = data.find_one_calls[0]
+    assert query == _PRIMARY_QUERY
+
+
+async def test_legacy_basename_swallows_transport_error():
+    data = _FakeCollection(find_one_error=PyMongoError("down"))
+    storage = _storage(data=data)
+
+    # Legacy compat path: a transport failure reads as a best-effort miss.
+    assert await storage.get_doc_by_file_basename("a.txt") is None
+
+
+# ---------------------------------------------------------------------------
+# list_source_conflicts_page
+# ---------------------------------------------------------------------------
+
+
+async def test_list_conflicts_maps_groups_and_terminates():
+    groups = [
+        {
+            "_id": "a.txt",
+            "candidate_count": 3,
+            "sample_doc_ids": ["doc-3", "doc-1", "doc-2"],
+        },
+        {"_id": "b.txt", "candidate_count": 2, "sample_doc_ids": ["doc-9", "doc-8"]},
+    ]
+    data = _FakeCollection(agg_docs=groups)
+    storage = _storage(data=data)
+
+    page = await storage.list_source_conflicts_page(limit=5)
+
+    pipeline = data.aggregate_calls[0][0]
+    assert pipeline[0] == {
+        "$match": {
+            "file_path": {
+                "$type": "string",
+                "$nin": ["", "unknown_source", "no-file-path"],
+            },
+            "metadata.is_duplicate": {"$ne": True},
+        }
+    }
+    assert pipeline[1]["$group"]["_id"] == "$file_path"
+    assert pipeline[2] == {"$match": {"candidate_count": {"$gte": 2}}}
+    assert pipeline[3] == {"$sort": {"_id": 1}}
+    assert pipeline[4] == {"$limit": 5}
+
+    assert [c.canonical_source_key for c in page.conflicts] == ["a.txt", "b.txt"]
+    assert page.conflicts[0].candidate_count == 3
+    assert page.conflicts[0].sample_doc_ids == ("doc-1", "doc-2", "doc-3")  # sorted
+    assert page.conflicts[1].sample_doc_ids == ("doc-8", "doc-9")
+    # returned (2) < limit (5) proves exhaustion.
+    assert page.next_position is CURSOR_END
+
+
+async def test_list_conflicts_full_page_advances_cursor():
+    groups = [
+        {"_id": "a.txt", "candidate_count": 2, "sample_doc_ids": ["doc-1", "doc-2"]},
+        {"_id": "b.txt", "candidate_count": 2, "sample_doc_ids": ["doc-3", "doc-4"]},
+    ]
+    data = _FakeCollection(agg_docs=groups)
+    storage = _storage(data=data)
+
+    page = await storage.list_source_conflicts_page(
+        limit=2, position=CursorAfter(json.dumps("0.txt"))
+    )
+
+    # Cursor resumes strictly after the last canonical key.
+    match = data.aggregate_calls[0][0][0]["$match"]
+    assert match["file_path"]["$gt"] == "0.txt"
+    # full page (2 == limit) → resume after the last group.
+    assert isinstance(page.next_position, CursorAfter)
+    assert json.loads(page.next_position.opaque) == "b.txt"
+
+
+async def test_list_conflicts_terminal_and_invalid_limit():
+    storage = _storage()
+
+    with pytest.raises(ValueError):
+        await storage.list_source_conflicts_page(limit=0)
+
+    page = await storage.list_source_conflicts_page(limit=2, position=CURSOR_END)
+    assert page.conflicts == () and page.next_position is CURSOR_END
+    assert storage._data.aggregate_calls == []
+
+
+# ---------------------------------------------------------------------------
+# repair_source_conflict: dry-run + CAS commit
+# ---------------------------------------------------------------------------
+
+_CANDIDATES = [{"_id": "doc-1"}, {"_id": "doc-2"}, {"_id": "doc-3"}]
+_FINGERPRINT = MongoDocStatusStorage._conflict_fingerprint(["doc-1", "doc-2", "doc-3"])
+
+
+async def test_repair_dry_run_reports_fingerprint_without_mutation():
+    data = _FakeCollection(find_docs=_CANDIDATES)
+    storage = _storage(data=data)
+
+    result = await storage.repair_source_conflict(
+        "a.txt",
+        primary_doc_id="doc-1",
+        expected_candidate_count=0,
+        expected_candidate_fingerprint="",
+        dry_run=True,
+    )
+
+    assert result.committed is False
+    assert result.candidate_count == 3
+    assert result.fingerprint == _FINGERPRINT
+    assert result.demoted_sample_doc_ids == ("doc-2", "doc-3")
+    assert data.update_many_calls == []  # dry run never mutates
+
+
+async def test_repair_commit_cas_success_demotes_losers_in_txn():
+    data = _FakeCollection(
+        find_docs=_CANDIDATES, update_many_result=_UpdateResult(modified_count=2)
+    )
+    session = _FakeSession()
+    storage = _storage(data=data, db=_FakeDb(_FakeClient(session)))
+
+    result = await storage.repair_source_conflict(
+        "a.txt",
+        primary_doc_id="doc-1",
+        expected_candidate_count=3,
+        expected_candidate_fingerprint=_FINGERPRINT,
+        dry_run=False,
+    )
+
+    assert result.committed is True
+    assert result.demoted_sample_doc_ids == ("doc-2", "doc-3")
+    assert session.started is True  # ran inside a transaction
+
+    filt, update, sess = data.update_many_calls[0]
+    assert filt == {"_id": {"$in": ["doc-2", "doc-3"]}}
+    assert update == {
+        "$set": {
+            "metadata.is_duplicate": True,
+            "metadata.original_doc_id": "doc-1",
+        }
+    }
+    assert sess is session  # demotion runs in the same session/txn
+
+
+async def test_repair_commit_cas_mismatch_raises_without_mutation():
+    data = _FakeCollection(find_docs=_CANDIDATES)
+    session = _FakeSession()
+    storage = _storage(data=data, db=_FakeDb(_FakeClient(session)))
+
+    with pytest.raises(StorageControlPlaneError):
+        await storage.repair_source_conflict(
+            "a.txt",
+            primary_doc_id="doc-1",
+            expected_candidate_count=2,  # stale count
+            expected_candidate_fingerprint="stale",
+            dry_run=False,
+        )
+    assert data.update_many_calls == []  # CAS refused the overwrite
+
+
+async def test_repair_primary_not_in_candidates_raises_value_error():
+    data = _FakeCollection(find_docs=[{"_id": "doc-2"}, {"_id": "doc-3"}])
+    storage = _storage(data=data)
+
+    with pytest.raises(ValueError):
+        await storage.repair_source_conflict(
+            "a.txt",
+            primary_doc_id="doc-1",
+            expected_candidate_count=0,
+            expected_candidate_fingerprint="",
+            dry_run=True,
+        )

--- a/tests/kg/mongo_impl/test_mongo_storage.py
+++ b/tests/kg/mongo_impl/test_mongo_storage.py
@@ -581,7 +581,11 @@ class TestMongoDocStatusLookup:
         doc_id, doc = result
         assert doc_id == "doc-1"
         assert doc["file_path"] == "report.pdf"
-        storage._data.find_one.assert_awaited_once_with({"file_path": "report.pdf"})
+        # Primary-only lookup: duplicate markers (metadata.is_duplicate=true)
+        # are excluded so filename dedup never matches a dup-* row.
+        storage._data.find_one.assert_awaited_once_with(
+            {"file_path": "report.pdf", "metadata.is_duplicate": {"$ne": True}}
+        )
 
     @pytest.mark.asyncio
     async def test_get_doc_by_file_basename_empty_returns_none_without_query(self):

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -1809,7 +1809,14 @@ class TestDocStatusStorage:
             body = mock_client.search.call_args.kwargs.get(
                 "body"
             ) or mock_client.search.call_args[1].get("body", {})
-            assert body["query"] == {"term": {"file_path": "report.pdf"}}
+            # Primary-only lookup: duplicate markers are excluded via must_not
+            # so filename dedup never matches a dup-* row.
+            assert body["query"] == {
+                "bool": {
+                    "filter": [{"term": {"file_path": "report.pdf"}}],
+                    "must_not": [{"term": {"metadata.is_duplicate": True}}],
+                }
+            }
 
     @pytest.mark.asyncio
     async def test_get_doc_by_file_basename_empty_short_circuits(

--- a/tests/kg/opensearch_impl/test_opensearch_strict_reads.py
+++ b/tests/kg/opensearch_impl/test_opensearch_strict_reads.py
@@ -95,12 +95,18 @@ class _EmbedFunc:
         raise AssertionError("doc-status/kv reads must not embed")
 
 
+def _migrated_mapping(index: str, **_kwargs) -> dict:
+    """Mapping of an index that already carries the __mirrored_id tiebreaker, so
+    startup runs no legacy value backfill (see _ensure_scheduling_fields_mapping)."""
+    return {index: {"mappings": {"properties": {"__mirrored_id": {"type": "keyword"}}}}}
+
+
 def _make_client() -> AsyncMock:
     client = AsyncMock(spec=AsyncOpenSearch)
     client.indices = AsyncMock()
     client.indices.exists = AsyncMock(return_value=True)
     client.indices.create = AsyncMock()
-    client.indices.get_mapping = AsyncMock(return_value={})
+    client.indices.get_mapping = AsyncMock(side_effect=_migrated_mapping)
     client.create_pit = AsyncMock(return_value={"pit_id": "pit-1"})
     client.delete_pit = AsyncMock()
     return client

--- a/tests/kg/opensearch_impl/test_os_scheduling_pages.py
+++ b/tests/kg/opensearch_impl/test_os_scheduling_pages.py
@@ -120,18 +120,34 @@ class _EmbedFunc:
         raise AssertionError("doc-status/kv scheduling paths must not embed")
 
 
+def _migrated_mapping(index: str, **_kwargs) -> dict:
+    """Mapping of an index that already carries the __mirrored_id tiebreaker, so
+    startup runs no legacy value backfill (see _ensure_scheduling_fields_mapping)."""
+    return {index: {"mappings": {"properties": {"__mirrored_id": {"type": "keyword"}}}}}
+
+
+def _make_legacy_client() -> AsyncMock:
+    """Client for an index predating __mirrored_id: no mapping, so no values."""
+    client = _make_client()
+    client.indices.get_mapping = AsyncMock(return_value={})
+    return client
+
+
 def _make_client() -> AsyncMock:
     client = AsyncMock(spec=AsyncOpenSearch)
     client.indices = AsyncMock()
     client.indices.exists = AsyncMock(return_value=True)
     client.indices.create = AsyncMock()
-    client.indices.get_mapping = AsyncMock(return_value={})
+    client.indices.get_mapping = AsyncMock(side_effect=_migrated_mapping)
     client.indices.put_mapping = AsyncMock()
     client.get = AsyncMock(return_value={})
     client.index = AsyncMock(return_value={})
     client.update = AsyncMock(return_value={})
     client.count = AsyncMock(return_value={"count": 0})
     client.search = AsyncMock(return_value={"hits": {"hits": []}})
+    # query_params wraps the client methods in a SYNC wrapper, so spec'd
+    # children default to MagicMock — async ones must be set explicitly.
+    client.update_by_query = AsyncMock(return_value={"updated": 0, "failures": []})
     return client
 
 
@@ -343,6 +359,68 @@ async def test_page_malformed_cursor_raises_before_any_rpc(global_config):
     client.search.assert_not_awaited()
 
 
+# ---------------------------------------------------------------------------
+# __mirrored_id tiebreaker readiness (startup)
+# ---------------------------------------------------------------------------
+
+
+def _missing_mirrored_id_query() -> dict:
+    return {"bool": {"must_not": {"exists": {"field": "__mirrored_id"}}}}
+
+
+async def test_startup_skips_audit_on_an_already_migrated_index(global_config):
+    """An index that already maps __mirrored_id was written by code that mirrors
+    the id on every write, so it needs neither the audit nor its _count."""
+    client = _make_client()
+    await _make_doc_status(global_config, client)
+    client.update_by_query.assert_not_awaited()
+    client.count.assert_not_awaited()
+
+
+async def test_startup_skips_backfill_when_coverage_is_complete(global_config):
+    client = _make_legacy_client()
+    client.count = AsyncMock(return_value={"count": 0})
+    await _make_doc_status(global_config, client)
+    client.update_by_query.assert_not_awaited()
+
+
+async def test_startup_backfills_legacy_docs_missing_mirrored_id(global_config):
+    """Fix-proof: a legacy index whose docs carry NO __mirrored_id value used to
+    be accepted silently on OpenSearch >= 3.3.0 (the mapping-only check is
+    skipped there), leaving the no-PIT scheduling page with no tiebreaker — so
+    docs sharing a created_at were dropped from the sweep. Startup must now
+    repair the values before serving."""
+    client = _make_legacy_client()
+    # 3 legacy docs before the backfill, full coverage after it.
+    client.count = AsyncMock(side_effect=[{"count": 3}, {"count": 0}])
+    await _make_doc_status(global_config, client)
+
+    client.update_by_query.assert_awaited_once()
+    kwargs = client.update_by_query.call_args.kwargs
+    body = kwargs["body"]
+    assert body["query"] == _missing_mirrored_id_query()
+    assert body["script"]["source"] == "ctx._source.__mirrored_id = ctx._id"
+    assert body["conflicts"] == "proceed"
+    assert kwargs["refresh"] is True
+
+
+async def test_startup_raises_when_mirrored_id_backfill_leaves_gaps(global_config):
+    """The outcome is VERIFIED, not assumed: a cluster that refuses the script
+    (or races new legacy writes in) must fail startup loudly rather than serve a
+    sweep that silently skips documents."""
+    client = _make_legacy_client()
+    client.count = AsyncMock(side_effect=[{"count": 3}, {"count": 2}])
+    with pytest.raises(RuntimeError, match="__mirrored_id"):
+        await _make_doc_status(global_config, client)
+
+
+async def test_startup_raises_on_malformed_mirrored_id_audit(global_config):
+    client = _make_legacy_client()
+    client.count = AsyncMock(return_value={"count": None})
+    with pytest.raises(RuntimeError, match="malformed"):
+        await _make_doc_status(global_config, client)
+
+
 async def test_page_strict_raises_on_transport_error(global_config):
     client = _make_client()
     storage = await _make_doc_status(global_config, client)
@@ -371,16 +449,32 @@ async def test_page_strict_raises_when_index_not_ready(global_config):
     assert page.next_position is CURSOR_END
 
 
-async def test_page_missing_index_is_legitimately_empty(global_config):
-    """Mirrors the existing get_docs_by_statuses strict decision: a live
-    index_not_found is a legitimately empty (complete) sweep."""
+async def test_page_strict_raises_when_index_vanishes_mid_sweep(global_config):
+    """A live index_not_found is a lost index, NOT a completed sweep.
+
+    Fail-proof for the fail-open bug: strict paging used to return an empty
+    terminal page here, which the sweep reads as "no work left" — stranding
+    every document. It must raise, exactly like the already-known
+    ``_index_ready=False`` case, and must not differ by which call noticed.
+    """
     client = _make_client()
     storage = await _make_doc_status(global_config, client)
     client.search = AsyncMock(side_effect=_missing_index_error())
 
-    page = await storage.get_docs_by_statuses_page(
-        [DocStatus.PENDING], limit=5, strict=True
-    )
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.PENDING], limit=5, strict=True
+        )
+    assert storage._index_ready is False
+
+
+async def test_page_relaxed_missing_index_stays_best_effort(global_config):
+    """Relaxed mode keeps the best-effort empty terminal page."""
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(side_effect=_missing_index_error())
+
+    page = await storage.get_docs_by_statuses_page([DocStatus.PENDING], limit=5)
     assert page.docs == {}
     assert page.next_position is CURSOR_END
     assert storage._index_ready is False
@@ -447,11 +541,15 @@ async def test_count_fails_closed(global_config):
         await storage.count_docs_by_statuses([DocStatus.PENDING])
 
 
-async def test_count_missing_index_is_zero(global_config):
+async def test_count_missing_index_raises_not_zero(global_config):
+    """Fail-proof for the fail-open bug: a live index_not_found used to return
+    0, so the FIRST admission check after an external drop reported full
+    capacity (only later ones, seeing _index_ready=False, failed closed)."""
     client = _make_client()
     storage = await _make_doc_status(global_config, client)
     client.count = AsyncMock(side_effect=_missing_index_error())
-    assert await storage.count_docs_by_statuses([DocStatus.PENDING]) == 0
+    with pytest.raises(StorageControlPlaneError):
+        await storage.count_docs_by_statuses([DocStatus.PENDING])
     assert storage._index_ready is False
 
 

--- a/tests/kg/opensearch_impl/test_os_scheduling_pages.py
+++ b/tests/kg/opensearch_impl/test_os_scheduling_pages.py
@@ -1,0 +1,966 @@
+"""OpenSearch Phase-1 scheduling contracts (memory-bounding plan).
+
+Offline coverage for the OpenSearch slice of the bounded-scheduling API:
+
+* ``get_docs_by_statuses_page`` — native ``search_after`` keyset pages
+  sorted ``(created_at ASC, __mirrored_id ASC)`` with ``created_at``
+  ``missing=_first`` (legacy rows sort FIRST and stay reachable), live-view
+  (no PIT), a plain status terms filter, cursor = the last HIT's sort values
+  verbatim, ``hits < limit`` == CURSOR_END.
+* ``count_docs_by_statuses`` — fail-closed ``_count``.
+* ``update_doc_status_fields`` — immutable ``created_at`` + 404 mapping.
+* ``get_docs_by_ids`` — strict batch mget, lightweight projection, confirmed
+  absence vs never-absent item errors.
+* ``resolve_doc_source_strict`` — conflict-aware Absent/Unique/Conflict with
+  a cheap exact ``_count``; fail-closed where the legacy lookup swallows.
+* ``list_source_conflicts_page`` / ``repair_source_conflict`` — operator
+  conflict flow with a recompute-and-compare CAS.
+* strict point reads — three-state ``get_by_id_strict`` on both the KV and
+  doc-status classes.
+"""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from opensearchpy import AsyncOpenSearch
+from opensearchpy.exceptions import NotFoundError, TransportError
+
+from lightrag.base import (
+    CURSOR_END,
+    CursorAfter,
+    DocStatus,
+    SourceAbsent,
+    SourceConflict,
+    SourceConflictSummary,
+    SourceUnique,
+)
+from lightrag.exceptions import (
+    StorageControlPlaneError,
+    StorageRecordNotFoundError,
+)
+from lightrag.kg.opensearch_impl import (
+    ClientManager,
+    OpenSearchDocStatusStorage,
+    OpenSearchKVStorage,
+)
+
+pytestmark = pytest.mark.offline
+
+
+class _mock_lock:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+
+def _missing_index_error() -> NotFoundError:
+    return NotFoundError(404, "index_not_found_exception", "no such index")
+
+
+def _doc_missing_error() -> NotFoundError:
+    # A document-level 404 (GET/update on an existing index): the error body
+    # never mentions index_not_found_exception.
+    return NotFoundError(404, "document_missing_exception", "no such document")
+
+
+def _transient_error() -> TransportError:
+    return TransportError(503, "search_phase_execution_exception", "shard failure")
+
+
+@pytest.fixture(autouse=True)
+def patch_data_init_lock():
+    with patch(
+        "lightrag.kg.opensearch_impl.get_data_init_lock", side_effect=_mock_lock
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def patch_namespace_lock():
+    cache: dict[tuple[str, str | None], asyncio.Lock] = {}
+
+    def factory(namespace, workspace=None, enable_logging=False):
+        key = (namespace, workspace or "")
+        lock = cache.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            cache[key] = lock
+        return lock
+
+    with patch("lightrag.kg.opensearch_impl.get_namespace_lock", side_effect=factory):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def patch_shard_doc_supported():
+    with patch("lightrag.kg.opensearch_impl._shard_doc_supported", True):
+        yield
+
+
+@pytest.fixture
+def global_config():
+    return {
+        "embedding_batch_num": 10,
+        "max_graph_nodes": 1000,
+        "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+    }
+
+
+class _EmbedFunc:
+    embedding_dim = 8
+    max_token_size = 512
+    model_name = "mock-embed"
+
+    async def __call__(self, texts, **kwargs):
+        raise AssertionError("doc-status/kv scheduling paths must not embed")
+
+
+def _make_client() -> AsyncMock:
+    client = AsyncMock(spec=AsyncOpenSearch)
+    client.indices = AsyncMock()
+    client.indices.exists = AsyncMock(return_value=True)
+    client.indices.create = AsyncMock()
+    client.indices.get_mapping = AsyncMock(return_value={})
+    client.indices.put_mapping = AsyncMock()
+    client.get = AsyncMock(return_value={})
+    client.index = AsyncMock(return_value={})
+    client.update = AsyncMock(return_value={})
+    client.count = AsyncMock(return_value={"count": 0})
+    client.search = AsyncMock(return_value={"hits": {"hits": []}})
+    return client
+
+
+def _status_source(doc_id: str, status: str = "pending", **extra) -> dict:
+    source = {
+        "__mirrored_id": doc_id,
+        "content_summary": f"summary-{doc_id}",
+        "content_length": 10,
+        "file_path": f"{doc_id}.txt",
+        "status": status,
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    source.update(extra)
+    return source
+
+
+def _hit(doc_id: str, source: dict, sort: list | None = None) -> dict:
+    return {"_id": doc_id, "_source": source, "sort": sort or [1767225600000, doc_id]}
+
+
+def _page(hits: list[dict]) -> dict:
+    return {"hits": {"hits": hits}}
+
+
+async def _make_doc_status(global_config, client) -> OpenSearchDocStatusStorage:
+    with patch.object(ClientManager, "get_client", return_value=client):
+        storage = OpenSearchDocStatusStorage(
+            namespace="doc_status",
+            global_config=global_config,
+            embedding_func=_EmbedFunc(),
+            workspace="schedws",
+        )
+        await storage.initialize()
+    return storage
+
+
+async def _make_kv(global_config, client) -> OpenSearchKVStorage:
+    with patch.object(ClientManager, "get_client", return_value=client):
+        storage = OpenSearchKVStorage(
+            namespace="full_docs",
+            global_config=global_config,
+            embedding_func=_EmbedFunc(),
+            workspace="schedws",
+        )
+        await storage.initialize()
+    return storage
+
+
+# ---------------------------------------------------------------------------
+# Capability flags
+# ---------------------------------------------------------------------------
+
+
+def test_scheduling_api_is_mandatory_no_flags():
+    # The doc_status scheduling flags were removed: the paging/batch/resolver
+    # API is @abstractmethod, so an instantiable backend implements it by
+    # definition. get_by_id_strict stays an optional KV capability flag.
+    for name in (
+        "supports_bounded_scheduling_pages",
+        "supports_strict_doc_status_batch_reads",
+        "supports_strict_doc_source_resolution",
+        "supports_failure_generation",
+    ):
+        assert not hasattr(OpenSearchDocStatusStorage, name)
+        assert not hasattr(OpenSearchKVStorage, name)
+    # strict point reads remain a declared capability.
+    assert OpenSearchDocStatusStorage.supports_strict_point_reads is True
+    assert OpenSearchKVStorage.supports_strict_point_reads is True
+    # Fully concrete → no abstract methods left → instantiable.
+    assert not OpenSearchDocStatusStorage.__abstractmethods__
+    assert not OpenSearchKVStorage.__abstractmethods__
+
+
+# ---------------------------------------------------------------------------
+# get_docs_by_statuses_page: body construction
+# ---------------------------------------------------------------------------
+
+
+async def test_page_body_sort_size_and_status_terms(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(return_value=_page([]))
+
+    await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING, DocStatus.FAILED], limit=25, strict=True
+    )
+
+    kwargs = client.search.call_args.kwargs
+    assert kwargs["index"] == storage._index_name
+    body = kwargs["body"]
+    # created_at sorts missing rows FIRST (NULLS-FIRST parity with the other
+    # backends), tie-broken on the mirrored keyword id.
+    assert body["sort"] == [
+        {"created_at": {"order": "asc", "missing": "_first"}},
+        {"__mirrored_id": {"order": "asc"}},
+    ]
+    assert body["size"] == 25
+    assert "search_after" not in body
+    assert body["query"] == {"terms": {"status": ["failed", "pending"]}}
+    # No failure-generation predicate exists anywhere in the query anymore.
+    assert "failure_generation" not in json.dumps(body)
+
+
+async def test_page_search_after_passthrough(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(return_value=_page([]))
+
+    opaque = json.dumps([1767225600000, "doc-9"])
+    await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=5, position=CursorAfter(opaque), strict=True
+    )
+
+    body = client.search.call_args.kwargs["body"]
+    assert body["search_after"] == [1767225600000, "doc-9"]
+
+
+# ---------------------------------------------------------------------------
+# get_docs_by_statuses_page: cursor advance / termination
+# ---------------------------------------------------------------------------
+
+
+async def test_page_full_page_returns_cursor_after_last_hit_sort(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    hits = [
+        _hit("d1", _status_source("d1"), sort=[100, "d1"]),
+        _hit("d2", _status_source("d2"), sort=[200, "d2"]),
+    ]
+    client.search = AsyncMock(return_value=_page(hits))
+
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=2, strict=True
+    )
+
+    assert set(page.docs) == {"d1", "d2"}
+    assert isinstance(page.next_position, CursorAfter)
+    # The cursor is the LAST HIT's sort values verbatim — the natural
+    # consumed frontier for a server-side-filtered search_after sweep.
+    assert page.next_position.opaque == json.dumps([200, "d2"])
+    record = page.docs["d1"]
+    assert record.status is DocStatus.PENDING
+    assert record.created_at == "2026-01-01T00:00:00+00:00"
+    assert record.file_path == "d1.txt"
+    assert record.has_custom_chunk_journal is False
+
+
+async def test_page_short_page_terminates(global_config):
+    """Server-side filtering means returned < size proves exhaustion."""
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(return_value=_page([_hit("d1", _status_source("d1"))]))
+
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=2, strict=True
+    )
+    assert set(page.docs) == {"d1"}
+    assert page.next_position is CURSOR_END
+
+
+async def test_page_empty_page_terminates_and_end_position_short_circuits(
+    global_config,
+):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(return_value=_page([]))
+
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=2, strict=True
+    )
+    assert page.docs == {}
+    assert page.next_position is CURSOR_END
+
+    client.search.reset_mock()
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=2, position=CURSOR_END, strict=True
+    )
+    assert page.docs == {}
+    assert page.next_position is CURSOR_END
+    client.search.assert_not_awaited()
+
+
+async def test_page_invalid_limit_raises(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    with pytest.raises(ValueError):
+        await storage.get_docs_by_statuses_page([DocStatus.PENDING], limit=0)
+
+
+# ---------------------------------------------------------------------------
+# get_docs_by_statuses_page: malformed cursor / strict failure semantics
+# ---------------------------------------------------------------------------
+
+
+async def test_page_malformed_cursor_raises_before_any_rpc(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(return_value=_page([]))
+
+    for bad_opaque in ("not-json", '{"a": 1}', "[1]", '["a", "b", "c"]'):
+        with pytest.raises(StorageControlPlaneError):
+            await storage.get_docs_by_statuses_page(
+                [DocStatus.PENDING],
+                limit=5,
+                position=CursorAfter(bad_opaque),
+                strict=True,
+            )
+    client.search.assert_not_awaited()
+
+
+async def test_page_strict_raises_on_transport_error(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(side_effect=_transient_error())
+    with pytest.raises(TransportError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.PENDING], limit=5, strict=True
+        )
+
+
+async def test_page_strict_raises_when_index_not_ready(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    storage._index_ready = False
+    client.search = AsyncMock(return_value=_page([]))
+
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.PENDING], limit=5, strict=True
+        )
+    client.search.assert_not_awaited()
+
+    # Relaxed mode keeps the best-effort empty-terminal behavior.
+    page = await storage.get_docs_by_statuses_page([DocStatus.PENDING], limit=5)
+    assert page.docs == {}
+    assert page.next_position is CURSOR_END
+
+
+async def test_page_missing_index_is_legitimately_empty(global_config):
+    """Mirrors the existing get_docs_by_statuses strict decision: a live
+    index_not_found is a legitimately empty (complete) sweep."""
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(side_effect=_missing_index_error())
+
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=5, strict=True
+    )
+    assert page.docs == {}
+    assert page.next_position is CURSOR_END
+    assert storage._index_ready is False
+
+
+async def test_page_relaxed_skips_bad_row_strict_raises(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    good = _hit("good", _status_source("good"), sort=[100, "good"])
+    bad_source = _status_source("bad")
+    del bad_source["created_at"]  # unusable scheduling row
+    bad = _hit("bad", bad_source, sort=[200, "bad"])
+
+    client.search = AsyncMock(return_value=_page([good, bad]))
+    with pytest.raises((KeyError, TypeError)):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.PENDING], limit=2, strict=True
+        )
+
+    client.search = AsyncMock(return_value=_page([good, bad]))
+    page = await storage.get_docs_by_statuses_page([DocStatus.PENDING], limit=2)
+    assert set(page.docs) == {"good"}
+    # The skipped row is still CONSUMED: the cursor is the last hit's sort,
+    # so the sweep never re-reads (or worse, loops on) the bad record.
+    assert isinstance(page.next_position, CursorAfter)
+    assert page.next_position.opaque == json.dumps([200, "bad"])
+
+
+# ---------------------------------------------------------------------------
+# count_docs_by_statuses
+# ---------------------------------------------------------------------------
+
+
+async def test_count_uses_count_api_with_status_terms(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.count = AsyncMock(return_value={"count": 42})
+
+    assert (
+        await storage.count_docs_by_statuses([DocStatus.PENDING, DocStatus.FAILED])
+        == 42
+    )
+    kwargs = client.count.call_args.kwargs
+    assert kwargs["index"] == storage._index_name
+    assert kwargs["body"] == {"query": {"terms": {"status": ["failed", "pending"]}}}
+
+    assert await storage.count_docs_by_statuses([]) == 0
+
+
+async def test_count_fails_closed(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+
+    client.count = AsyncMock(side_effect=_transient_error())
+    with pytest.raises(TransportError):
+        await storage.count_docs_by_statuses([DocStatus.PENDING])
+
+    client.count = AsyncMock(return_value={"count": "not-a-number"})
+    with pytest.raises(StorageControlPlaneError):
+        await storage.count_docs_by_statuses([DocStatus.PENDING])
+
+    storage._index_ready = False
+    with pytest.raises(StorageControlPlaneError):
+        await storage.count_docs_by_statuses([DocStatus.PENDING])
+
+
+async def test_count_missing_index_is_zero(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.count = AsyncMock(side_effect=_missing_index_error())
+    assert await storage.count_docs_by_statuses([DocStatus.PENDING]) == 0
+    assert storage._index_ready is False
+
+
+# ---------------------------------------------------------------------------
+# update_doc_status_fields
+# ---------------------------------------------------------------------------
+
+
+async def test_update_fields_rejects_created_at(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    with pytest.raises(ValueError, match="created_at"):
+        await storage.update_doc_status_fields(
+            "doc-1", {"created_at": "2026-02-02T00:00:00+00:00"}
+        )
+    client.update.assert_not_awaited()
+
+
+async def test_update_fields_partial_doc_merge(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    await storage.update_doc_status_fields("doc-1", {"status": "processing"})
+    kwargs = client.update.call_args.kwargs
+    assert kwargs["index"] == storage._index_name
+    assert kwargs["id"] == "doc-1"
+    assert kwargs["body"] == {"doc": {"status": "processing"}}
+    assert kwargs["refresh"] == "wait_for"
+
+
+async def test_update_fields_missing_record(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.update = AsyncMock(side_effect=_doc_missing_error())
+    with pytest.raises(StorageRecordNotFoundError):
+        await storage.update_doc_status_fields("ghost", {"status": "failed"})
+    # missing_ok downgrades the 404 to a no-op.
+    await storage.update_doc_status_fields(
+        "ghost", {"status": "failed"}, missing_ok=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_docs_by_ids: strict batch read
+# ---------------------------------------------------------------------------
+
+
+async def test_get_docs_by_ids_present_and_confirmed_absent(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.mget = AsyncMock(
+        return_value={
+            "docs": [
+                {"_id": "d1", "found": True, "_source": _status_source("d1")},
+                {"_id": "d2", "found": False},
+            ]
+        }
+    )
+    result = await storage.get_docs_by_ids(["d1", "d2"])
+    assert set(result) == {"d1"}  # found=False is CONFIRMED absent → omitted
+    assert result["d1"].status is DocStatus.PENDING
+    assert result["d1"].file_path == "d1.txt"
+    # Lightweight projection: never fetch chunks_list.
+    kwargs = client.mget.call_args.kwargs
+    assert kwargs["body"] == {"ids": ["d1", "d2"]}
+    assert (
+        kwargs["_source_includes"]
+        == OpenSearchDocStatusStorage._SCHEDULING_SOURCE_FIELDS
+    )
+
+
+async def test_get_docs_by_ids_empty_short_circuits(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.mget = AsyncMock()
+    assert await storage.get_docs_by_ids([]) == {}
+    client.mget.assert_not_awaited()
+
+
+async def test_get_docs_by_ids_item_level_error_never_absent(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.mget = AsyncMock(
+        return_value={
+            "docs": [{"_id": "d1", "error": {"type": "shard"}, "status": 503}]
+        }
+    )
+    with pytest.raises(RuntimeError, match="item error"):
+        await storage.get_docs_by_ids(["d1"])
+
+
+async def test_get_docs_by_ids_strict_raises_relaxed_skips_bad_row(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    bad_source = _status_source("d1")
+    del bad_source["created_at"]
+
+    client.mget = AsyncMock(
+        return_value={"docs": [{"_id": "d1", "found": True, "_source": bad_source}]}
+    )
+    with pytest.raises((KeyError, TypeError)):
+        await storage.get_docs_by_ids(["d1"], strict=True)
+
+    client.mget = AsyncMock(
+        return_value={"docs": [{"_id": "d1", "found": True, "_source": bad_source}]}
+    )
+    assert await storage.get_docs_by_ids(["d1"]) == {}
+
+
+async def test_get_docs_by_ids_index_not_ready_raises(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    storage._index_ready = False
+    client.mget = AsyncMock()
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_docs_by_ids(["d1"])
+    client.mget.assert_not_awaited()
+
+
+async def test_get_docs_by_ids_missing_index_raises(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.mget = AsyncMock(side_effect=_missing_index_error())
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_docs_by_ids(["d1"])
+    assert storage._index_ready is False
+
+
+# ---------------------------------------------------------------------------
+# resolve_doc_source_strict: conflict-aware source resolution
+# ---------------------------------------------------------------------------
+
+
+async def test_resolve_source_absent_on_zero_hits(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(return_value=_page([]))
+
+    assert isinstance(
+        await storage.resolve_doc_source_strict("report.pdf"), SourceAbsent
+    )
+    body = client.search.call_args.kwargs["body"]
+    assert body["size"] == 2
+    assert body["sort"] == [{"__mirrored_id": {"order": "asc"}}]
+    assert body["query"]["bool"]["filter"] == [{"term": {"file_path": "report.pdf"}}]
+    assert body["query"]["bool"]["must_not"] == [
+        {"term": {"metadata.is_duplicate": True}}
+    ]
+
+
+async def test_resolve_source_unique(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    source = _status_source("doc-1", status="processed", file_path="report.pdf")
+    client.search = AsyncMock(return_value=_page([_hit("doc-1", source)]))
+
+    result = await storage.resolve_doc_source_strict("report.pdf")
+    assert isinstance(result, SourceUnique)
+    assert result.doc_id == "doc-1"
+    assert result.doc.status is DocStatus.PROCESSED
+    assert result.doc.file_path == "report.pdf"
+    # A single hit needs no _count follow-up.
+    client.count.assert_not_awaited()
+
+
+async def test_resolve_source_conflict_uses_exact_count(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    hits = [
+        _hit("doc-b", _status_source("doc-b", file_path="report.pdf")),
+        _hit("doc-a", _status_source("doc-a", file_path="report.pdf")),
+    ]
+    client.search = AsyncMock(return_value=_page(hits))
+    client.count = AsyncMock(return_value={"count": 5})
+
+    result = await storage.resolve_doc_source_strict("report.pdf")
+    assert isinstance(result, SourceConflict)
+    assert result.candidate_count == 5
+    assert result.sample_doc_ids == ("doc-a", "doc-b")  # sorted sample of two
+    # The exact count reuses the same primary-only query.
+    count_body = client.count.call_args.kwargs["body"]
+    assert count_body["query"] == storage._primary_basename_query("report.pdf")["query"]
+
+
+async def test_resolve_source_sentinels_are_absent_without_lookup(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(return_value=_page([]))
+    assert isinstance(await storage.resolve_doc_source_strict(""), SourceAbsent)
+    assert isinstance(
+        await storage.resolve_doc_source_strict("unknown_source"), SourceAbsent
+    )
+    client.search.assert_not_awaited()
+
+
+async def test_resolve_source_fail_closed(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+
+    client.search = AsyncMock(side_effect=_transient_error())
+    with pytest.raises(TransportError):
+        await storage.resolve_doc_source_strict("report.pdf")
+
+    client.search = AsyncMock(side_effect=_missing_index_error())
+    with pytest.raises(StorageControlPlaneError):
+        await storage.resolve_doc_source_strict("report.pdf")
+    assert storage._index_ready is False
+
+    storage._index_ready = False
+    with pytest.raises(StorageControlPlaneError):
+        await storage.resolve_doc_source_strict("report.pdf")
+
+
+# ---------------------------------------------------------------------------
+# list_source_conflicts_page
+# ---------------------------------------------------------------------------
+
+
+def _composite_response(buckets: list[dict], after_key: dict | None) -> dict:
+    agg: dict = {"buckets": buckets}
+    if after_key is not None:
+        agg["after_key"] = after_key
+    return {"aggregations": {"conflicts": agg}}
+
+
+def _bucket(file_path: str, doc_count: int, sample_ids: list[str]) -> dict:
+    return {
+        "key": {"file_path": file_path},
+        "doc_count": doc_count,
+        "sample_ids": {"hits": {"hits": [{"_id": i} for i in sample_ids]}},
+    }
+
+
+async def test_list_conflicts_filters_single_primary_and_continues(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    buckets = [
+        _bucket("a.pdf", 3, ["a3", "a1", "a2"]),
+        _bucket("b.pdf", 1, ["b1"]),  # single primary → not a conflict
+    ]
+    client.search = AsyncMock(
+        return_value=_composite_response(buckets, after_key={"file_path": "b.pdf"})
+    )
+
+    page = await storage.list_source_conflicts_page(limit=2)
+    assert page.conflicts == (
+        SourceConflictSummary(
+            canonical_source_key="a.pdf",
+            candidate_count=3,
+            sample_doc_ids=("a1", "a2", "a3"),
+        ),
+    )
+    # Full composite page (len == limit) with an after_key → keep sweeping.
+    assert isinstance(page.next_position, CursorAfter)
+    assert page.next_position.opaque == json.dumps({"file_path": "b.pdf"})
+
+    # The scan restricts to primaries and real basenames.
+    body = client.search.call_args.kwargs["body"]
+    assert body["query"] == storage._conflict_scan_query()
+    assert body["aggs"]["conflicts"]["composite"]["size"] == 2
+
+
+async def test_list_conflicts_short_page_terminates(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(
+        return_value=_composite_response(
+            [_bucket("a.pdf", 2, ["a1", "a2"])], after_key={"file_path": "a.pdf"}
+        )
+    )
+    page = await storage.list_source_conflicts_page(limit=5)
+    assert len(page.conflicts) == 1
+    # Fewer buckets than the limit proves the composite is exhausted.
+    assert page.next_position is CURSOR_END
+
+
+async def test_list_conflicts_end_position_short_circuits(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock()
+    page = await storage.list_source_conflicts_page(limit=5, position=CURSOR_END)
+    assert page.conflicts == ()
+    assert page.next_position is CURSOR_END
+    client.search.assert_not_awaited()
+
+
+async def test_list_conflicts_cursor_passthrough_and_bad_cursor(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(return_value=_composite_response([], after_key=None))
+
+    await storage.list_source_conflicts_page(
+        limit=3, position=CursorAfter(json.dumps({"file_path": "a.pdf"}))
+    )
+    composite = client.search.call_args.kwargs["body"]["aggs"]["conflicts"]["composite"]
+    assert composite["after"] == {"file_path": "a.pdf"}
+
+    with pytest.raises(StorageControlPlaneError):
+        await storage.list_source_conflicts_page(
+            limit=3, position=CursorAfter("[1, 2]")
+        )
+
+
+# ---------------------------------------------------------------------------
+# repair_source_conflict
+# ---------------------------------------------------------------------------
+
+
+def _candidate_scan_page(doc_ids: list[str]) -> dict:
+    return {"hits": {"hits": [{"_id": d, "sort": [d]} for d in doc_ids]}}
+
+
+async def test_repair_dry_run_reports_count_and_fingerprint(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(return_value=_candidate_scan_page(["d3", "d1", "d2"]))
+
+    result = await storage.repair_source_conflict(
+        "report.pdf",
+        primary_doc_id="d1",
+        expected_candidate_count=0,
+        expected_candidate_fingerprint="ignored-on-dry-run",
+        dry_run=True,
+    )
+    assert result.committed is False
+    assert result.candidate_count == 3
+    assert result.fingerprint == storage._conflict_fingerprint(["d1", "d2", "d3"])
+    assert result.demoted_sample_doc_ids == ("d2", "d3")
+    client.update.assert_not_awaited()
+
+
+async def test_repair_commit_demotes_losers_with_cas(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(return_value=_candidate_scan_page(["d1", "d2", "d3"]))
+    fingerprint = storage._conflict_fingerprint(["d1", "d2", "d3"])
+
+    result = await storage.repair_source_conflict(
+        "report.pdf",
+        primary_doc_id="d1",
+        expected_candidate_count=3,
+        expected_candidate_fingerprint=fingerprint,
+        dry_run=False,
+    )
+    assert result.committed is True
+    assert result.candidate_count == 3
+    demoted = {c.kwargs["id"] for c in client.update.await_args_list}
+    assert demoted == {"d2", "d3"}
+    for call in client.update.await_args_list:
+        assert call.kwargs["body"] == {
+            "doc": {"metadata": {"is_duplicate": True, "original_doc_id": "d1"}}
+        }
+        assert call.kwargs["refresh"] == "wait_for"
+
+
+async def test_repair_commit_cas_mismatch_raises(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(return_value=_candidate_scan_page(["d1", "d2", "d3"]))
+
+    with pytest.raises(StorageControlPlaneError):
+        await storage.repair_source_conflict(
+            "report.pdf",
+            primary_doc_id="d1",
+            expected_candidate_count=2,  # stale expectation
+            expected_candidate_fingerprint="stale",
+            dry_run=False,
+        )
+    client.update.assert_not_awaited()
+
+
+async def test_repair_primary_not_a_candidate_raises(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(return_value=_candidate_scan_page(["d1", "d2"]))
+
+    with pytest.raises(ValueError, match="not a current primary"):
+        await storage.repair_source_conflict(
+            "report.pdf",
+            primary_doc_id="zzz",
+            expected_candidate_count=2,
+            expected_candidate_fingerprint="whatever",
+            dry_run=True,
+        )
+
+
+async def test_repair_index_not_ready_raises(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    storage._index_ready = False
+    with pytest.raises(StorageControlPlaneError):
+        await storage.repair_source_conflict(
+            "report.pdf",
+            primary_doc_id="d1",
+            expected_candidate_count=2,
+            expected_candidate_fingerprint="x",
+            dry_run=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# KV get_by_id_strict: three-state contract
+# ---------------------------------------------------------------------------
+
+
+async def test_kv_strict_pending_delete_is_confirmed_absent(global_config):
+    client = _make_client()
+    storage = await _make_kv(global_config, client)
+    client.mget = AsyncMock()
+    await storage.upsert({"doc-1": {"content": "x"}})
+    await storage.delete(["doc-1"])
+    assert await storage.get_by_id_strict("doc-1") is None
+    client.mget.assert_not_awaited()
+
+
+async def test_kv_strict_pending_upsert_is_present(global_config):
+    client = _make_client()
+    storage = await _make_kv(global_config, client)
+    client.mget = AsyncMock()
+    await storage.upsert({"doc-1": {"content": "x"}})
+    doc = await storage.get_by_id_strict("doc-1")
+    assert doc["content"] == "x"
+    assert doc["_id"] == "doc-1"
+    client.mget.assert_not_awaited()
+
+
+async def test_kv_strict_index_not_ready_raises(global_config):
+    client = _make_client()
+    storage = await _make_kv(global_config, client)
+    storage._index_ready = False
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_by_id_strict("doc-1")
+    # The relaxed read keeps its best-effort miss behavior.
+    assert await storage.get_by_id("doc-1") is None
+
+
+async def test_kv_strict_transport_error_raises(global_config):
+    client = _make_client()
+    storage = await _make_kv(global_config, client)
+    client.mget = AsyncMock(side_effect=_transient_error())
+    with pytest.raises(TransportError):
+        await storage.get_by_id_strict("doc-1")
+
+
+async def test_kv_strict_missing_index_raises(global_config):
+    """get_by_id reads a missing index as a miss; the strict variant cannot
+    positively confirm absence there and must raise."""
+    client = _make_client()
+    storage = await _make_kv(global_config, client)
+    client.mget = AsyncMock(side_effect=_missing_index_error())
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_by_id_strict("doc-1")
+    assert storage._index_ready is False
+
+
+async def test_kv_strict_healthy_miss_is_none(global_config):
+    client = _make_client()
+    storage = await _make_kv(global_config, client)
+    client.mget = AsyncMock(return_value={"docs": [{"_id": "doc-1", "found": False}]})
+    assert await storage.get_by_id_strict("doc-1") is None
+
+
+# ---------------------------------------------------------------------------
+# Doc-status get_by_id_strict
+# ---------------------------------------------------------------------------
+
+
+async def test_doc_status_strict_point_read_three_state(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+
+    client.mget = AsyncMock(return_value={"docs": [{"_id": "doc-1", "found": False}]})
+    assert await storage.get_by_id_strict("doc-1") is None
+
+    client.mget = AsyncMock(side_effect=_transient_error())
+    with pytest.raises(TransportError):
+        await storage.get_by_id_strict("doc-1")
+    # The relaxed read swallows the same error as a miss.
+    client.mget = AsyncMock(side_effect=_transient_error())
+    assert await storage.get_by_id("doc-1") is None
+
+    client.mget = AsyncMock(side_effect=_missing_index_error())
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_by_id_strict("doc-1")
+
+    storage._index_ready = False
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_by_id_strict("doc-1")
+
+
+# ---------------------------------------------------------------------------
+# Legacy basename lookup: primary-only best-effort (unchanged)
+# ---------------------------------------------------------------------------
+
+
+async def test_legacy_basename_query_excludes_duplicate_rows(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(return_value=_page([]))
+
+    assert await storage.get_doc_by_file_basename("report.pdf") is None
+    body = client.search.call_args.kwargs["body"]
+    assert body["query"]["bool"]["filter"] == [{"term": {"file_path": "report.pdf"}}]
+    assert body["query"]["bool"]["must_not"] == [
+        {"term": {"metadata.is_duplicate": True}}
+    ]
+
+
+async def test_legacy_basename_swallows_errors(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.search = AsyncMock(side_effect=_transient_error())
+    assert await storage.get_doc_by_file_basename("report.pdf") is None

--- a/tests/kg/postgres_impl/test_pg_scheduling_pages.py
+++ b/tests/kg/postgres_impl/test_pg_scheduling_pages.py
@@ -1,0 +1,733 @@
+"""PGDocStatusStorage memory-bounding scheduling API (Phase 1) — offline.
+
+Covers the PG slice of the cursor-page / strict-read contract against a mocked
+``self.db`` (same ``__new__`` + fake-db pattern as
+tests/kg/test_doc_status_strict_parse_branches.py — no live PostgreSQL):
+
+* cursor encode/decode round-trip + malformed cursor fails closed;
+* keyset page SQL shape (ORDER BY, row-value comparison) and
+  CURSOR_END/CursorAfter termination semantics;
+* count_docs_by_statuses fail-closed;
+* update_doc_status_fields immutable created_at + missing-row contract;
+* get_docs_by_ids strict batch (present/missing/error/unusable);
+* resolve_doc_source_strict Absent/Unique/Conflict (conflict-aware, exact
+  count on the indexed predicate);
+* list_source_conflicts_page SQL shape + bounded per-key sample + keyset
+  termination;
+* repair_source_conflict dry-run / CAS mismatch / commit-demotes-losers /
+  bad-primary;
+* legacy basename lookup excludes duplicate-marker rows;
+* strict point reads + capability flags.
+"""
+
+import datetime
+import json
+
+import pytest
+
+from lightrag.base import (
+    CURSOR_END,
+    CURSOR_START,
+    CursorAfter,
+    DocStatus,
+    SourceAbsent,
+    SourceConflict,
+    SourceUnique,
+)
+from lightrag.exceptions import (
+    StorageControlPlaneError,
+    StorageRecordNotFoundError,
+)
+from lightrag.kg.postgres_impl import PGDocStatusStorage, PGKVStorage
+
+pytestmark = pytest.mark.offline
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeDB:
+    """Records query/execute calls; serves queued results (or raises them)."""
+
+    def __init__(self, results=None):
+        self.results = list(results or [])
+        self.calls: list[tuple[str, list, bool]] = []
+        self.execute_calls: list[tuple[str, dict | None]] = []
+
+    async def query(self, sql, params=None, multirows=False, **kwargs):
+        self.calls.append((sql, params, multirows))
+        if self.results:
+            result = self.results.pop(0)
+        else:
+            result = [] if multirows else None
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    async def execute(self, sql, data=None, **kwargs):
+        self.execute_calls.append((sql, data))
+
+
+class _ExplodingDB:
+    """Any DB touch is a test failure (used to prove pre-DB validation)."""
+
+    async def query(self, *args, **kwargs):  # pragma: no cover - guard
+        raise AssertionError("db.query must not be called")
+
+    async def execute(self, *args, **kwargs):  # pragma: no cover - guard
+        raise AssertionError("db.execute must not be called")
+
+    async def _run_with_retry(self, *args, **kwargs):  # pragma: no cover - guard
+        raise AssertionError("db._run_with_retry must not be called")
+
+
+class _FakeTransaction:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeRepairConnection:
+    """asyncpg-connection stub for the repair_source_conflict transaction.
+
+    ``fetch`` returns the queued candidate rows (the FOR UPDATE re-read);
+    ``execute`` records the demotion UPDATE so tests can assert its shape.
+    """
+
+    def __init__(self, candidate_ids):
+        self._candidate_ids = list(candidate_ids)
+        self.fetch_calls: list[tuple[str, tuple]] = []
+        self.execute_calls: list[tuple[str, tuple]] = []
+
+    def transaction(self):
+        return _FakeTransaction()
+
+    async def fetch(self, sql, *args):
+        self.fetch_calls.append((sql, args))
+        return [{"id": cid} for cid in self._candidate_ids]
+
+    async def execute(self, sql, *args):
+        self.execute_calls.append((sql, args))
+        return "UPDATE"
+
+
+class _FakeDBWithConnection:
+    def __init__(self, connection):
+        self.connection = connection
+
+    async def _run_with_retry(self, operation, **kwargs):
+        return await operation(self.connection)
+
+
+def _storage(db=None) -> PGDocStatusStorage:
+    storage = PGDocStatusStorage.__new__(PGDocStatusStorage)
+    storage.workspace = "ws"
+    storage.namespace = "doc_status"
+    storage.db = db if db is not None else _FakeDB()
+    return storage
+
+
+_TS = datetime.datetime(2026, 1, 2, 3, 4, 5, 123456)
+
+
+def _page_row(doc_id="doc-1", created_at=_TS, **overrides):
+    row = {
+        "id": doc_id,
+        "status": "pending",
+        "created_at": created_at,
+        "updated_at": created_at,
+        "file_path": f"{doc_id}.pdf",
+        "track_id": None,
+        "metadata": "{}",
+    }
+    row.update(overrides)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Cursor encode/decode
+# ---------------------------------------------------------------------------
+
+
+async def test_cursor_round_trip_preserves_exact_key():
+    storage = _storage()
+    opaque = storage._encode_cursor(_page_row())
+    created, doc_id = storage._decode_cursor(opaque)
+    # Naive-UTC datetime as stored in the TIMESTAMP column, microseconds kept.
+    assert created == _TS
+    assert created.tzinfo is None
+    assert doc_id == "doc-1"
+
+
+async def test_decode_cursor_normalizes_timezone_aware_iso():
+    storage = _storage()
+    aware = "2026-01-02T04:04:05.123456+01:00"
+    created, _ = storage._decode_cursor(json.dumps([aware, "doc-1"]))
+    assert created == _TS
+    assert created.tzinfo is None
+
+
+@pytest.mark.parametrize(
+    "opaque",
+    [
+        "not json",
+        '["only-one"]',
+        '["2026-01-01T00:00:00+00:00", 5]',
+        '[123, "doc-1"]',
+        '["not-a-date", "doc-1"]',
+        '["2026-01-01T00:00:00", "a", "extra"]',
+        "{}",
+    ],
+)
+async def test_malformed_cursor_raises_control_plane_error(opaque):
+    storage = _storage(_ExplodingDB())
+    with pytest.raises(StorageControlPlaneError):
+        storage._decode_cursor(opaque)
+    # And through the page API: rejected before any DB round-trip.
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.PENDING], limit=10, position=CursorAfter(opaque), strict=True
+        )
+
+
+async def test_null_created_at_encodes_null_bucket_cursor():
+    """NULL created_at rows (corrupt writes) sort FIRST and stay reachable:
+    the cursor encodes [null, id] instead of failing closed — a row-value
+    comparison would otherwise starve them out of every later page."""
+    storage = _storage()
+    opaque = storage._encode_cursor(_page_row(doc_id="doc-n", created_at=None))
+    assert json.loads(opaque) == [None, "doc-n"]
+    assert storage._decode_cursor(opaque) == (None, "doc-n")
+
+
+async def test_null_bucket_cursor_resumes_through_null_rows():
+    """Cursor inside the NULL bucket: remaining NULL rows continue by id,
+    then all real-timestamp rows — nothing is silently excluded."""
+    db = _FakeDB(results=[[]])
+    storage = _storage(db)
+    await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING],
+        limit=10,
+        position=CursorAfter(json.dumps([None, "doc-n"])),
+        strict=True,
+    )
+    sql, params, _ = db.calls[0]
+    assert "(created_at IS NULL AND id > $3) OR created_at IS NOT NULL" in sql
+    assert "ORDER BY created_at ASC NULLS FIRST, id ASC" in sql
+    assert params[2] == "doc-n"
+
+
+async def test_string_cursor_excludes_consumed_null_bucket():
+    db = _FakeDB(results=[[]])
+    storage = _storage(db)
+    await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING],
+        limit=10,
+        position=CursorAfter(json.dumps(["2026-01-01T00:00:00", "doc-1"])),
+        strict=True,
+    )
+    sql, _, _ = db.calls[0]
+    assert "created_at IS NOT NULL AND (created_at, id) >" in sql
+    assert "NULLS FIRST" in sql
+
+
+async def test_null_created_at_row_reachable_across_page_boundary():
+    """Fix-proof for the starvation bug: a NULL created_at row that fills a
+    page still yields a cursor that reaches the NEXT rows (bucket-aware
+    keyset), instead of a NULL-poisoned row-value comparison."""
+    null_row = _page_row(doc_id="doc-null", created_at=None)
+    real_row = _page_row(doc_id="doc-real")
+    db = _FakeDB(results=[[null_row], [real_row], []])
+    storage = _storage(db)
+    page1 = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=1, strict=False
+    )
+    # The corrupt row is consumed (skipped from the projection in relaxed
+    # mode) and the cursor advances into the NULL bucket.
+    assert page1.docs == {}
+    assert isinstance(page1.next_position, CursorAfter)
+    page2 = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=1, position=page1.next_position, strict=False
+    )
+    assert set(page2.docs) == {"doc-real"}
+    sql2, _, _ = db.calls[1]
+    assert "created_at IS NULL AND id >" in sql2
+
+
+# ---------------------------------------------------------------------------
+# Page SQL shape + termination
+# ---------------------------------------------------------------------------
+
+
+async def test_page_sql_keyset_shape_without_cursor():
+    db = _FakeDB(results=[[]])
+    storage = _storage(db)
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING, DocStatus.FAILED], limit=10, strict=True
+    )
+    assert page.docs == {}
+    assert page.next_position is CURSOR_END
+
+    sql, params, multirows = db.calls[0]
+    assert multirows is True
+    assert "ORDER BY created_at ASC NULLS FIRST, id ASC" in sql
+    assert "status = ANY($2)" in sql
+    assert "(created_at, id) >" not in sql
+    # The removed failure-generation cohort predicate must never reappear.
+    assert "failure_generation" not in sql
+    assert params == ["ws", ["pending", "failed"], 10]
+
+
+async def test_page_sql_with_cursor():
+    db = _FakeDB(results=[[]])
+    storage = _storage(db)
+    opaque = storage._encode_cursor(_page_row())
+    await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING, DocStatus.FAILED],
+        limit=10,
+        position=CursorAfter(opaque),
+        strict=True,
+    )
+    sql, params, _ = db.calls[0]
+    assert "(created_at, id) > ($3::timestamp, $4)" in sql
+    assert "ORDER BY created_at ASC NULLS FIRST, id ASC LIMIT $5" in sql
+    assert "failure_generation" not in sql
+    assert params[2] == _TS  # decoded back to the naive-UTC stored form
+    assert params[3] == "doc-1"
+    assert params[4] == 10
+
+
+async def test_page_full_returns_cursor_after_last_returned_row():
+    rows = [_page_row("doc-1"), _page_row("doc-2", created_at=_TS.replace(hour=9))]
+    db = _FakeDB(results=[rows])
+    storage = _storage(db)
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=2, strict=True
+    )
+    assert set(page.docs) == {"doc-1", "doc-2"}
+    assert isinstance(page.next_position, CursorAfter)
+    created, doc_id = storage._decode_cursor(page.next_position.opaque)
+    assert (created, doc_id) == (_TS.replace(hour=9), "doc-2")
+    # Projection sanity: lightweight record, ISO timestamps with tz info.
+    record = page.docs["doc-1"]
+    assert record.status is DocStatus.PENDING
+    assert record.created_at == "2026-01-02T03:04:05.123456+00:00"
+    assert record.file_path == "doc-1.pdf"
+    assert record.has_custom_chunk_journal is False
+
+
+async def test_page_short_read_terminates_with_cursor_end():
+    db = _FakeDB(results=[[_page_row("doc-1")]])
+    storage = _storage(db)
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=2, strict=True
+    )
+    assert set(page.docs) == {"doc-1"}
+    assert page.next_position is CURSOR_END
+
+
+async def test_page_relaxed_skips_unusable_row_but_row_stays_consumed():
+    bad = _page_row("doc-bad", created_at=None)
+    good = _page_row("doc-good", created_at=_TS.replace(hour=9))
+    db = _FakeDB(results=[[bad, good]])
+    storage = _storage(db)
+    page = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=2, strict=False
+    )
+    assert set(page.docs) == {"doc-good"}
+    # Cursor still advances past the whole SQL-returned frontier.
+    assert isinstance(page.next_position, CursorAfter)
+    _, doc_id = storage._decode_cursor(page.next_position.opaque)
+    assert doc_id == "doc-good"
+
+
+async def test_page_strict_raises_on_unusable_row_without_cursor():
+    bad = _page_row("doc-bad", created_at=None)
+    db = _FakeDB(results=[[bad, _page_row("doc-good")]])
+    storage = _storage(db)
+    with pytest.raises(TypeError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.PENDING], limit=2, strict=True
+        )
+
+
+async def test_page_argument_validation_before_db():
+    storage = _storage(_ExplodingDB())
+    with pytest.raises(ValueError):
+        await storage.get_docs_by_statuses_page([DocStatus.PENDING], limit=0)
+    empty = await storage.get_docs_by_statuses_page([], limit=5)
+    assert empty.docs == {} and empty.next_position is CURSOR_END
+    ended = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=5, position=CURSOR_END
+    )
+    assert ended.docs == {} and ended.next_position is CURSOR_END
+
+
+async def test_page_db_error_propagates():
+    db = _FakeDB(results=[RuntimeError("boom")])
+    storage = _storage(db)
+    with pytest.raises(RuntimeError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.PENDING], limit=5, position=CURSOR_START, strict=True
+        )
+
+
+# ---------------------------------------------------------------------------
+# count_docs_by_statuses
+# ---------------------------------------------------------------------------
+
+
+async def test_count_docs_by_statuses_returns_int_and_fails_closed():
+    db = _FakeDB(results=[{"count": 3}])
+    storage = _storage(db)
+    assert await storage.count_docs_by_statuses([DocStatus.PENDING]) == 3
+    sql, params, _ = db.calls[0]
+    assert "COUNT(*)" in sql and "status = ANY($2)" in sql
+    assert params == ["ws", ["pending"]]
+
+    assert await storage.count_docs_by_statuses([]) == 0
+
+    # queue exhausted → fake returns None → fail-closed control-plane error
+    with pytest.raises(StorageControlPlaneError):
+        await storage.count_docs_by_statuses([DocStatus.PENDING])
+
+
+async def test_count_docs_by_statuses_db_error_propagates():
+    db = _FakeDB(results=[ConnectionError("down")])
+    storage = _storage(db)
+    with pytest.raises(ConnectionError):
+        await storage.count_docs_by_statuses([DocStatus.PENDING])
+
+
+# ---------------------------------------------------------------------------
+# update_doc_status_fields
+# ---------------------------------------------------------------------------
+
+
+async def test_update_fields_rejects_created_at_and_unknown_columns():
+    storage = _storage(_ExplodingDB())
+    with pytest.raises(ValueError, match="created_at"):
+        await storage.update_doc_status_fields("d1", {"created_at": "2026"})
+    with pytest.raises(ValueError, match="unknown"):
+        await storage.update_doc_status_fields("d1", {"evil; DROP": "x"})
+
+
+async def test_update_fields_sql_shape_and_serialization():
+    db = _FakeDB(results=[{"id": "d1"}])
+    storage = _storage(db)
+    await storage.update_doc_status_fields(
+        "d1", {"status": "processing", "metadata": {"k": 1}, "chunks_list": ["c1"]}
+    )
+    sql, params, _ = db.calls[0]
+    assert sql.startswith("UPDATE LIGHTRAG_DOC_STATUS SET ")
+    assert "WHERE workspace=$1 AND id=$2 RETURNING id" in sql
+    assert params[0] == "ws" and params[1] == "d1"
+    assert params[2] == "processing"
+    assert params[3] == json.dumps({"k": 1})  # JSONB serialized like upsert
+    assert params[4] == json.dumps(["c1"])
+
+
+async def test_update_fields_missing_row_contract():
+    storage = _storage(_FakeDB(results=[None, None]))
+    with pytest.raises(StorageRecordNotFoundError):
+        await storage.update_doc_status_fields("ghost", {"status": "failed"})
+    # missing_ok suppresses only the not-found outcome
+    await storage.update_doc_status_fields(
+        "ghost", {"status": "failed"}, missing_ok=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_docs_by_ids (strict batch read)
+# ---------------------------------------------------------------------------
+
+
+async def test_get_docs_by_ids_present_and_missing():
+    rows = [_page_row("doc-1"), _page_row("doc-2", status="failed")]
+    db = _FakeDB(results=[rows])
+    storage = _storage(db)
+    result = await storage.get_docs_by_ids(["doc-1", "doc-2", "ghost"], strict=True)
+    assert set(result) == {"doc-1", "doc-2"}  # ghost omitted (confirmed absent)
+    assert result["doc-2"].status is DocStatus.FAILED
+    assert not hasattr(result["doc-1"], "chunks_list")  # lightweight projection
+    sql, params, multirows = db.calls[0]
+    assert "id = ANY($2)" in sql
+    assert multirows is True
+    assert params == ["ws", ["doc-1", "doc-2", "ghost"]]
+
+
+async def test_get_docs_by_ids_empty_short_circuits():
+    storage = _storage(_ExplodingDB())
+    assert await storage.get_docs_by_ids([]) == {}
+
+
+async def test_get_docs_by_ids_strict_db_error_propagates():
+    db = _FakeDB(results=[ConnectionError("down")])
+    storage = _storage(db)
+    with pytest.raises(ConnectionError):
+        await storage.get_docs_by_ids(["doc-1"], strict=True)
+
+
+async def test_get_docs_by_ids_strict_raises_on_unusable_row():
+    bad = _page_row("doc-bad", created_at=None)
+    db = _FakeDB(results=[[bad]])
+    storage = _storage(db)
+    with pytest.raises(TypeError):
+        await storage.get_docs_by_ids(["doc-bad"], strict=True)
+
+
+# ---------------------------------------------------------------------------
+# resolve_doc_source_strict (conflict-aware source resolution)
+# ---------------------------------------------------------------------------
+
+
+async def test_resolve_doc_source_short_circuits_sentinel_keys():
+    storage = _storage(_ExplodingDB())
+    assert isinstance(await storage.resolve_doc_source_strict(""), SourceAbsent)
+    assert isinstance(
+        await storage.resolve_doc_source_strict("unknown_source"), SourceAbsent
+    )
+
+
+async def test_resolve_doc_source_absent():
+    db = _FakeDB(results=[[]])
+    storage = _storage(db)
+    assert isinstance(
+        await storage.resolve_doc_source_strict("missing.pdf"), SourceAbsent
+    )
+    sql, params, multirows = db.calls[0]
+    assert "COALESCE((metadata->>'is_duplicate')::boolean, false) = false" in sql
+    assert "LIMIT 2" in sql
+    assert multirows is True
+    assert params == ["ws", "missing.pdf"]
+
+
+async def test_resolve_doc_source_unique():
+    db = _FakeDB(results=[[_page_row("doc-primary", file_path="a.pdf")]])
+    storage = _storage(db)
+    resolved = await storage.resolve_doc_source_strict("a.pdf")
+    assert isinstance(resolved, SourceUnique)
+    assert resolved.doc_id == "doc-primary"
+    assert resolved.doc.file_path == "a.pdf"
+
+
+async def test_resolve_doc_source_conflict_uses_exact_count():
+    rows = [
+        _page_row("doc-1", file_path="a.pdf"),
+        _page_row("doc-2", file_path="a.pdf"),
+    ]
+    db = _FakeDB(results=[rows, {"c": 5}])
+    storage = _storage(db)
+    resolved = await storage.resolve_doc_source_strict("a.pdf")
+    assert isinstance(resolved, SourceConflict)
+    assert resolved.candidate_count == 5  # exact COUNT(*), not the two-row sample
+    assert set(resolved.sample_doc_ids) == {"doc-1", "doc-2"}
+    # second query is the exact COUNT(*) on the same primary predicate
+    count_sql, count_params, _ = db.calls[1]
+    assert "COUNT(*)" in count_sql
+    assert "is_duplicate" in count_sql
+    assert count_params == ["ws", "a.pdf"]
+
+
+async def test_resolve_doc_source_db_error_propagates():
+    db = _FakeDB(results=[ConnectionError("down")])
+    storage = _storage(db)
+    with pytest.raises(ConnectionError):
+        await storage.resolve_doc_source_strict("a.pdf")  # never degrades to Absent
+
+
+# ---------------------------------------------------------------------------
+# list_source_conflicts_page
+# ---------------------------------------------------------------------------
+
+
+async def test_list_source_conflicts_page_sql_and_projection():
+    group_rows = [{"file_path": "a.pdf", "c": 3}]
+    sample_rows = [{"id": "doc-1"}, {"id": "doc-2"}, {"id": "doc-3"}]
+    db = _FakeDB(results=[group_rows, sample_rows])
+    storage = _storage(db)
+    page = await storage.list_source_conflicts_page(limit=10)
+    assert len(page.conflicts) == 1
+    conflict = page.conflicts[0]
+    assert conflict.canonical_source_key == "a.pdf"
+    assert conflict.candidate_count == 3
+    assert set(conflict.sample_doc_ids) == {"doc-1", "doc-2", "doc-3"}
+    assert page.next_position is CURSOR_END  # short read (< limit)
+
+    group_sql, group_params, _ = db.calls[0]
+    assert "GROUP BY file_path HAVING COUNT(*) >= 2" in group_sql
+    assert "COALESCE((metadata->>'is_duplicate')::boolean, false) = false" in group_sql
+    assert "NOT IN ('', 'unknown_source', 'no-file-path')" in group_sql
+    assert group_params == ["ws", 10]
+    sample_sql, sample_params, _ = db.calls[1]
+    assert "ORDER BY id ASC LIMIT $3" in sample_sql
+    assert sample_params == ["ws", "a.pdf", PGDocStatusStorage._CONFLICT_SAMPLE_CAP]
+
+
+async def test_list_source_conflicts_page_full_returns_cursor():
+    group_rows = [{"file_path": "a.pdf", "c": 2}]
+    sample_rows = [{"id": "doc-1"}, {"id": "doc-2"}]
+    db = _FakeDB(results=[group_rows, sample_rows])
+    storage = _storage(db)
+    page = await storage.list_source_conflicts_page(limit=1)  # full page
+    assert isinstance(page.next_position, CursorAfter)
+    assert storage._decode_conflict_cursor(page.next_position.opaque) == "a.pdf"
+
+
+async def test_list_source_conflicts_page_cursor_predicate():
+    db = _FakeDB(results=[[]])
+    storage = _storage(db)
+    await storage.list_source_conflicts_page(
+        limit=10, position=CursorAfter(json.dumps("a.pdf"))
+    )
+    sql, params, _ = db.calls[0]
+    assert "file_path > $2" in sql
+    assert params == ["ws", "a.pdf", 10]
+
+
+async def test_list_source_conflicts_page_argument_validation():
+    storage = _storage(_ExplodingDB())
+    with pytest.raises(ValueError):
+        await storage.list_source_conflicts_page(limit=0)
+    ended = await storage.list_source_conflicts_page(limit=5, position=CURSOR_END)
+    assert ended.conflicts == () and ended.next_position is CURSOR_END
+
+
+async def test_malformed_conflict_cursor_raises():
+    storage = _storage(_ExplodingDB())
+    with pytest.raises(StorageControlPlaneError):
+        storage._decode_conflict_cursor("not json")
+    # Non-string decoded value is also rejected, before any DB round-trip.
+    with pytest.raises(StorageControlPlaneError):
+        await storage.list_source_conflicts_page(limit=10, position=CursorAfter("123"))
+
+
+# ---------------------------------------------------------------------------
+# repair_source_conflict (explicit CAS repair)
+# ---------------------------------------------------------------------------
+
+
+async def test_repair_source_conflict_dry_run_reports_without_mutation():
+    conn = _FakeRepairConnection(["doc-1", "doc-2", "doc-3"])
+    storage = _storage(_FakeDBWithConnection(conn))
+    result = await storage.repair_source_conflict(
+        "a.pdf",
+        primary_doc_id="doc-2",
+        expected_candidate_count=0,  # ignored in dry-run
+        expected_candidate_fingerprint="ignored",
+    )
+    assert result.committed is False
+    assert result.candidate_count == 3
+    assert set(result.demoted_sample_doc_ids) == {"doc-1", "doc-3"}
+    # Candidate set re-read FOR UPDATE, no mutation issued.
+    assert conn.fetch_calls and "FOR UPDATE" in conn.fetch_calls[0][0]
+    assert conn.execute_calls == []
+
+
+async def test_repair_source_conflict_cas_mismatch_refuses():
+    conn = _FakeRepairConnection(["doc-1", "doc-2", "doc-3"])
+    storage = _storage(_FakeDBWithConnection(conn))
+    with pytest.raises(StorageControlPlaneError):
+        await storage.repair_source_conflict(
+            "a.pdf",
+            primary_doc_id="doc-2",
+            expected_candidate_count=99,  # stale
+            expected_candidate_fingerprint="whatever",
+            dry_run=False,
+        )
+    assert conn.execute_calls == []  # CAS fails before any mutation
+
+
+async def test_repair_source_conflict_commit_demotes_losers():
+    # dry-run first to obtain the matching CAS fingerprint.
+    dry_conn = _FakeRepairConnection(["doc-1", "doc-2", "doc-3"])
+    dry = await _storage(_FakeDBWithConnection(dry_conn)).repair_source_conflict(
+        "a.pdf",
+        primary_doc_id="doc-2",
+        expected_candidate_count=0,
+        expected_candidate_fingerprint="ignored",
+    )
+
+    conn = _FakeRepairConnection(["doc-1", "doc-2", "doc-3"])
+    storage = _storage(_FakeDBWithConnection(conn))
+    result = await storage.repair_source_conflict(
+        "a.pdf",
+        primary_doc_id="doc-2",
+        expected_candidate_count=dry.candidate_count,
+        expected_candidate_fingerprint=dry.fingerprint,
+        dry_run=False,
+    )
+    assert result.committed is True
+    assert result.candidate_count == 3
+    # One demotion UPDATE marking the losers is_duplicate + original_doc_id.
+    assert len(conn.execute_calls) == 1
+    sql, args = conn.execute_calls[0]
+    assert "is_duplicate" in sql and "original_doc_id" in sql
+    assert args[0] == "ws"
+    assert set(args[1]) == {"doc-1", "doc-3"}  # all-but-primary demoted
+    assert args[2] == "doc-2"  # original_doc_id = chosen primary
+
+
+async def test_repair_source_conflict_primary_not_in_candidates_raises():
+    conn = _FakeRepairConnection(["doc-1", "doc-2"])
+    storage = _storage(_FakeDBWithConnection(conn))
+    with pytest.raises(ValueError):
+        await storage.repair_source_conflict(
+            "a.pdf",
+            primary_doc_id="ghost",
+            expected_candidate_count=2,
+            expected_candidate_fingerprint="x",
+        )
+
+
+# ---------------------------------------------------------------------------
+# legacy basename lookup: primary-row-only
+# ---------------------------------------------------------------------------
+
+
+async def test_basename_query_excludes_duplicate_marker_rows():
+    db = _FakeDB(results=[[]])
+    storage = _storage(db)
+    assert await storage.get_doc_by_file_basename("report.pdf") is None
+    sql, params, _ = db.calls[0]
+    assert "COALESCE((metadata->>'is_duplicate')::boolean, false) = false" in sql
+    assert "ORDER BY created_at ASC, id ASC LIMIT 1" in sql
+    assert params == ["ws", "report.pdf"]
+
+
+# ---------------------------------------------------------------------------
+# strict point reads + capability flags
+# ---------------------------------------------------------------------------
+
+
+async def test_doc_status_get_by_id_strict_confirmed_absent_or_raise():
+    storage = _storage(_FakeDB(results=[None]))
+    assert await storage.get_by_id_strict("ghost") is None
+
+    failing = _storage(_FakeDB(results=[ConnectionError("down")]))
+    with pytest.raises(ConnectionError):
+        await failing.get_by_id_strict("d1")
+
+
+def test_scheduling_api_is_mandatory_no_flags():
+    # The doc_status scheduling flags were removed: the paging/batch/resolver
+    # API is @abstractmethod, so an instantiable backend implements it by
+    # definition. get_by_id_strict stays an optional KV capability flag.
+    for name in (
+        "supports_bounded_scheduling_pages",
+        "supports_strict_doc_status_batch_reads",
+        "supports_strict_doc_source_resolution",
+        "supports_failure_generation",
+    ):
+        assert not hasattr(PGDocStatusStorage, name)
+        assert not hasattr(PGKVStorage, name)
+    # strict point reads remain a declared capability.
+    assert PGDocStatusStorage.supports_strict_point_reads is True
+    assert PGKVStorage.supports_strict_point_reads is True
+    # Fully concrete → no abstract methods left → instantiable.
+    assert not PGDocStatusStorage.__abstractmethods__
+    assert not PGKVStorage.__abstractmethods__

--- a/tests/kg/redis_impl/fake_redis.py
+++ b/tests/kg/redis_impl/fake_redis.py
@@ -75,13 +75,26 @@ class FakeRedis:
         return count
 
     async def scan(self, cursor: int = 0, match: str = "", count: int = 1000):
+        """Batched cursor semantics over a stable sorted snapshot.
+
+        Real SCAN iterates keys of every type (strings, zsets, sets, hashes) and
+        returns them ``count`` at a time with a resumable cursor; callers must
+        loop until the cursor comes back 0. Honouring ``count`` here (rather than
+        returning everything at once) is what makes the paged, bounded readers
+        exercisable — sorting keeps it deterministic and skip-free.
+        """
+        self._maybe_fail("scan")
         prefix = match[:-1] if match.endswith("*") else match
-        # Real SCAN iterates keys of every type (strings, zsets, sets, hashes).
         all_keys = (
             list(self.store) + list(self.zsets) + list(self.sets) + list(self.hashes)
         )
-        keys = [k for k in dict.fromkeys(all_keys) if k.startswith(prefix)]
-        return 0, keys
+        keys = sorted(k for k in dict.fromkeys(all_keys) if k.startswith(prefix))
+        start = int(cursor)
+        batch = keys[start : start + count]
+        next_cursor = start + count
+        if next_cursor >= len(keys):
+            next_cursor = 0
+        return next_cursor, batch
 
     # -- set commands ---------------------------------------------------------
     async def sadd(self, key: str, *members: str) -> int:
@@ -324,6 +337,16 @@ class FakePipeline:
             return self._fake.hgetall(key)
         self._ops.append(("hgetall", key))
         return self
+
+    def scan(self, cursor: int = 0, match: str = "", count: int = 1000):
+        """Immediate-mode only, mirroring redis-py: while WATCHing (and before
+        MULTI) commands execute right away and return real values, which is how
+        the sidecar publish re-probes the official keyspace under its WATCH."""
+        if not self._immediate:
+            raise AssertionError(
+                "FakeRedis: SCAN is only supported in immediate WATCH mode"
+            )
+        return self._fake.scan(cursor, match=match, count=count)
 
     def set(self, key: str, value: str):
         return self._command(("set", key, value))

--- a/tests/kg/redis_impl/fake_redis.py
+++ b/tests/kg/redis_impl/fake_redis.py
@@ -1,0 +1,377 @@
+"""In-memory stand-in for the ``redis.asyncio`` surface RedisDocStatusStorage
+uses — including the Phase 1 scheduling sidecar surface: WATCH/MULTI
+transactions with real conflict detection (per-key version counters →
+``WatchError``), ZSETs with lexicographic range reads, source multimap SETs
+(``SADD``/``SREM``/``SCARD`` plus batched-cursor ``SSCAN``), ``RENAME`` for the
+atomic rebuild switch, and hashes.
+
+Shared by the doc-status lookup tests and the scheduling-page tests so the
+fake's semantics stay consistent. Deliberately implements only the subset the
+storage class calls; unknown commands fail loudly.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from redis.exceptions import WatchError
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store: dict[str, str] = {}
+        self.zsets: dict[str, set[str]] = defaultdict(set)
+        self.sets: dict[str, set[str]] = defaultdict(set)
+        self.hashes: dict[str, dict[str, str]] = defaultdict(dict)
+        self.versions: dict[str, int] = defaultdict(int)
+        # Test hook: raise this exception on the next matching command.
+        self.fail_next: dict[str, Exception] = {}
+
+    # -- version bookkeeping (WATCH support) --------------------------------
+    def _bump(self, key: str) -> None:
+        self.versions[key] += 1
+
+    def _maybe_fail(self, command: str) -> None:
+        exc = self.fail_next.pop(command, None)
+        if exc is not None:
+            raise exc
+
+    # -- immediate commands ---------------------------------------------------
+    async def ping(self):
+        return True
+
+    async def get(self, key: str):
+        self._maybe_fail("get")
+        return self.store.get(key)
+
+    async def set(self, key: str, value: str, nx: bool = False, ex: int | None = None):
+        self._maybe_fail("set")
+        if nx and key in self.store:
+            return None
+        self.store[key] = str(value)
+        self._bump(key)
+        return True
+
+    async def delete(self, *keys: str) -> int:
+        count = 0
+        for key in keys:
+            existed = False
+            if key in self.store:
+                self.store.pop(key)
+                existed = True
+            if key in self.zsets:
+                self.zsets.pop(key)
+                existed = True
+            if key in self.sets:
+                self.sets.pop(key)
+                existed = True
+            if key in self.hashes:
+                self.hashes.pop(key)
+                existed = True
+            if existed:
+                self._bump(key)
+                count += 1
+        return count
+
+    async def scan(self, cursor: int = 0, match: str = "", count: int = 1000):
+        prefix = match[:-1] if match.endswith("*") else match
+        # Real SCAN iterates keys of every type (strings, zsets, sets, hashes).
+        all_keys = (
+            list(self.store) + list(self.zsets) + list(self.sets) + list(self.hashes)
+        )
+        keys = [k for k in dict.fromkeys(all_keys) if k.startswith(prefix)]
+        return 0, keys
+
+    # -- set commands ---------------------------------------------------------
+    async def sadd(self, key: str, *members: str) -> int:
+        self._maybe_fail("sadd")
+        added = 0
+        for member in members:
+            if member not in self.sets[key]:
+                self.sets[key].add(member)
+                added += 1
+        self._bump(key)
+        return added
+
+    async def srem(self, key: str, *members: str) -> int:
+        self._maybe_fail("srem")
+        removed = 0
+        for member in members:
+            if member in self.sets.get(key, set()):
+                self.sets[key].discard(member)
+                removed += 1
+        # An emptied set is deleted, mirroring real Redis.
+        if key in self.sets and not self.sets[key]:
+            self.sets.pop(key)
+        self._bump(key)
+        return removed
+
+    async def scard(self, key: str) -> int:
+        self._maybe_fail("scard")
+        return len(self.sets.get(key, ()))
+
+    async def sscan(self, key: str, cursor: int = 0, count: int = 10):
+        """Real batched cursor semantics over a stable sorted snapshot so the
+        resolver's "stop after two valid candidates" path is exercisable."""
+        self._maybe_fail("sscan")
+        members = sorted(self.sets.get(key, ()))
+        start = int(cursor)
+        batch = members[start : start + count]
+        next_cursor = start + count
+        if next_cursor >= len(members):
+            next_cursor = 0
+        return next_cursor, batch
+
+    def scan_iter(self, **kwargs):
+        match = kwargs.get("match", "")
+        prefix = match[:-1] if match.endswith("*") else match
+        keys = [k for k in self.store if k.startswith(prefix)]
+
+        async def _aiter():
+            for k in keys:
+                yield k
+
+        return _aiter()
+
+    async def hgetall(self, key: str) -> dict[str, str]:
+        self._maybe_fail("hgetall")
+        return dict(self.hashes.get(key, {}))
+
+    async def hset(self, key: str, field: str | None = None, value=None, mapping=None):
+        self._maybe_fail("hset")
+        if mapping is not None:
+            for f, v in mapping.items():
+                self.hashes[key][f] = str(v)
+        else:
+            self.hashes[key][field] = str(value)
+        self._bump(key)
+        return 1
+
+    async def zcard(self, key: str) -> int:
+        self._maybe_fail("zcard")
+        return len(self.zsets.get(key, ()))
+
+    async def zrangebylex(
+        self, key: str, lex_min: str, lex_max: str, start=0, num=None
+    ):
+        return self._zrangebylex(key, lex_min, lex_max, start, num)
+
+    # -- shared op appliers ---------------------------------------------------
+    def _zrangebylex(self, key, lex_min, lex_max, start=0, num=None):
+        members = sorted(self.zsets.get(key, ()))
+        if lex_min == "-":
+            lo = members
+        elif lex_min.startswith("("):
+            pivot = lex_min[1:]
+            lo = [m for m in members if m > pivot]
+        elif lex_min.startswith("["):
+            pivot = lex_min[1:]
+            lo = [m for m in members if m >= pivot]
+        else:  # pragma: no cover - storage always uses -,( or [
+            raise ValueError(f"bad lex_min {lex_min!r}")
+        if lex_max != "+":  # pragma: no cover - storage always uses +
+            raise ValueError(f"bad lex_max {lex_max!r}")
+        if num is None:
+            return lo[start:]
+        return lo[start : start + num]
+
+    def _apply(self, op: tuple) -> Any:
+        kind = op[0]
+        if kind == "get":
+            return self.store.get(op[1])
+        if kind == "set":
+            self.store[op[1]] = op[2]
+            self._bump(op[1])
+            return True
+        if kind == "delete":
+            existed = (
+                op[1] in self.store
+                or op[1] in self.zsets
+                or op[1] in self.sets
+                or op[1] in self.hashes
+            )
+            self.store.pop(op[1], None)
+            self.zsets.pop(op[1], None)
+            self.sets.pop(op[1], None)
+            self.hashes.pop(op[1], None)
+            if existed:
+                self._bump(op[1])
+            return 1 if existed else 0
+        if kind == "rename":
+            src, dst = op[1], op[2]
+            if src in self.store:
+                self.store[dst] = self.store.pop(src)
+            if src in self.zsets:
+                self.zsets[dst] = self.zsets.pop(src)
+            if src in self.sets:
+                self.sets[dst] = self.sets.pop(src)
+            if src in self.hashes:
+                self.hashes[dst] = self.hashes.pop(src)
+            self._bump(src)
+            self._bump(dst)
+            return True
+        if kind == "exists":
+            return 1 if op[1] in self.store else 0
+        if kind == "zadd":
+            key, member_map = op[1], op[2]
+            for member in member_map:
+                self.zsets[key].add(member)
+            self._bump(key)
+            return len(member_map)
+        if kind == "zrem":
+            key, member = op[1], op[2]
+            removed = member in self.zsets.get(key, set())
+            self.zsets.get(key, set()).discard(member)
+            self._bump(key)
+            return 1 if removed else 0
+        if kind == "zcard":
+            return len(self.zsets.get(op[1], ()))
+        if kind == "zrangebylex":
+            return self._zrangebylex(*op[1:])
+        if kind == "sadd":
+            key, members = op[1], op[2]
+            added = 0
+            for member in members:
+                if member not in self.sets[key]:
+                    self.sets[key].add(member)
+                    added += 1
+            self._bump(key)
+            return added
+        if kind == "srem":
+            key, member = op[1], op[2]
+            removed = member in self.sets.get(key, set())
+            self.sets.get(key, set()).discard(member)
+            if key in self.sets and not self.sets[key]:
+                self.sets.pop(key)
+            self._bump(key)
+            return 1 if removed else 0
+        if kind == "scard":
+            return len(self.sets.get(op[1], ()))
+        if kind == "hset":
+            key, field, value = op[1], op[2], op[3]
+            self.hashes[key][field] = str(value)
+            self._bump(key)
+            return 1
+        if kind == "hgetall":
+            return dict(self.hashes.get(op[1], {}))
+        raise ValueError(f"FakeRedis: unsupported op {kind}")  # pragma: no cover
+
+    def pipeline(self, transaction: bool = True):
+        return FakePipeline(self)
+
+
+class FakePipeline:
+    """Supports BOTH usage styles the storage class exercises:
+
+    * buffered batch: ``pipe.get(k); ...; await pipe.execute()``
+    * transactional: ``await pipe.watch(k)`` (immediate reads) →
+      ``pipe.multi()`` (queued writes) → ``await pipe.execute()`` with real
+      WATCH conflict detection via per-key version snapshots.
+    """
+
+    def __init__(self, fake: FakeRedis):
+        self._fake = fake
+        self._ops: list[tuple] = []
+        self._watched: dict[str, int] = {}
+        self._immediate = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self._ops.clear()
+        self._watched.clear()
+        return False
+
+    async def watch(self, *keys: str):
+        self._immediate = True
+        for key in keys:
+            self._watched[key] = self._fake.versions[key]
+
+    async def unwatch(self):
+        self._watched.clear()
+        self._immediate = False
+
+    def multi(self):
+        self._immediate = False
+
+    def _command(self, op: tuple):
+        if self._immediate:
+
+            async def _run():
+                self._fake._maybe_fail(op[0])
+                return (
+                    self._fake._apply(op)
+                    if op[0] != "get"
+                    else self._fake.store.get(op[1])
+                )
+
+            return _run()
+        self._ops.append(op)
+        return self
+
+    def get(self, key: str):
+        if self._immediate:
+            # Delegate to the top-level async method so tests can intercept
+            # immediate WATCH-mode reads by patching FakeRedis.get.
+            return self._fake.get(key)
+        self._ops.append(("get", key))
+        return self
+
+    def hgetall(self, key: str):
+        if self._immediate:
+            return self._fake.hgetall(key)
+        self._ops.append(("hgetall", key))
+        return self
+
+    def set(self, key: str, value: str):
+        return self._command(("set", key, value))
+
+    def delete(self, key: str):
+        return self._command(("delete", key))
+
+    def exists(self, key: str):
+        return self._command(("exists", key))
+
+    def zadd(self, key: str, member_map: dict):
+        return self._command(("zadd", key, member_map))
+
+    def zrem(self, key: str, member: str):
+        return self._command(("zrem", key, member))
+
+    def zcard(self, key: str):
+        return self._command(("zcard", key))
+
+    def zrangebylex(self, key: str, lex_min: str, lex_max: str, start=0, num=None):
+        return self._command(("zrangebylex", key, lex_min, lex_max, start, num))
+
+    def sadd(self, key: str, *members: str):
+        return self._command(("sadd", key, members))
+
+    def srem(self, key: str, member: str):
+        return self._command(("srem", key, member))
+
+    def scard(self, key: str):
+        return self._command(("scard", key))
+
+    def rename(self, src: str, dst: str):
+        return self._command(("rename", src, dst))
+
+    def hset(self, key: str, field: str, value):
+        return self._command(("hset", key, field, value))
+
+    async def execute(self):
+        self._fake._maybe_fail("execute")
+        for key, version in self._watched.items():
+            if self._fake.versions[key] != version:
+                self._watched.clear()
+                self._ops.clear()
+                raise WatchError(f"watched key changed: {key}")
+        results = []
+        for op in self._ops:
+            self._fake._maybe_fail(op[0])
+            results.append(self._fake._apply(op))
+        self._ops.clear()
+        self._watched.clear()
+        return results

--- a/tests/kg/redis_impl/fake_redis.py
+++ b/tests/kg/redis_impl/fake_redis.py
@@ -27,6 +27,11 @@ class FakeRedis:
         self.versions: dict[str, int] = defaultdict(int)
         # Test hook: raise this exception on the next matching command.
         self.fail_next: dict[str, Exception] = {}
+        # CONFIG GET response; the default is an eviction-safe server.
+        self.config_values: dict[str, str] = {
+            "maxmemory": "0",
+            "maxmemory-policy": "noeviction",
+        }
 
     # -- version bookkeeping (WATCH support) --------------------------------
     def _bump(self, key: str) -> None:
@@ -40,6 +45,16 @@ class FakeRedis:
     # -- immediate commands ---------------------------------------------------
     async def ping(self):
         return True
+
+    async def config_get(self, pattern: str = "*"):
+        """Default to a NON-evicting server so initialize() proceeds.
+
+        Tests that need the eviction guard to fire override ``config_values``
+        (or set ``fail_next["config_get"]`` to simulate a server that blocks
+        CONFIG, as managed Redis often does).
+        """
+        self._maybe_fail("config_get")
+        return dict(self.config_values)
 
     async def get(self, key: str):
         self._maybe_fail("get")

--- a/tests/kg/redis_impl/test_redis_doc_status_lookup.py
+++ b/tests/kg/redis_impl/test_redis_doc_status_lookup.py
@@ -15,6 +15,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from lightrag.base import DocStatus
+
+from .fake_redis import FakeRedis
 from lightrag.namespace import NameSpace
 
 pytestmark = pytest.mark.offline
@@ -44,104 +46,11 @@ def _doc(status: str, file_path: str, content_hash: str | None = None) -> dict:
     return payload
 
 
-class _FakePipeline:
-    """Mimics redis.asyncio pipeline: commands are queued synchronously and
-    executed in batch via ``await execute()``."""
-
-    def __init__(self, store: dict[str, str]):
-        self._store = store
-        self._ops: list[tuple] = []
-
-    def get(self, key: str) -> None:
-        self._ops.append(("get", key))
-
-    def set(self, key: str, value: str) -> None:
-        self._ops.append(("set", key, value))
-
-    def exists(self, key: str) -> None:
-        self._ops.append(("exists", key))
-
-    def delete(self, key: str) -> None:
-        self._ops.append(("delete", key))
-
-    async def execute(self) -> list:
-        results = []
-        for op in self._ops:
-            kind = op[0]
-            if kind == "get":
-                results.append(self._store.get(op[1]))
-            elif kind == "set":
-                self._store[op[1]] = op[2]
-                results.append(True)
-            elif kind == "exists":
-                results.append(1 if op[1] in self._store else 0)
-            elif kind == "delete":
-                existed = op[1] in self._store
-                self._store.pop(op[1], None)
-                results.append(1 if existed else 0)
-        self._ops.clear()
-        return results
-
-
-class _FakeRedis:
-    """Tiny in-memory stand-in for the bits of ``redis.asyncio.Redis`` that
-    ``RedisDocStatusStorage`` actually calls."""
-
-    def __init__(self):
-        self.store: dict[str, str] = {}
-
-    async def ping(self):
-        return True
-
-    async def scan(self, *args, **kwargs):
-        # Signature: scan(cursor, match=..., count=...). args holds the cursor
-        # positional; we ignore it and return single-shot results (cursor=0)
-        # so callers stop looping.
-        _ = args
-        match = kwargs.get("match", "")
-        if match.endswith("*"):
-            prefix = match[:-1]
-            keys = [k for k in self.store if k.startswith(prefix)]
-        else:
-            keys = [k for k in self.store if k == match]
-        return 0, keys
-
-    def scan_iter(self, **kwargs):
-        # Used by is_empty(); returns an async iterator.
-        match = kwargs.get("match", "")
-        prefix = match[:-1] if match.endswith("*") else match
-        keys = [k for k in self.store if k.startswith(prefix)]
-
-        async def _aiter():
-            for k in keys:
-                yield k
-
-        return _aiter()
-
-    def pipeline(self):
-        return _FakePipeline(self.store)
-
-    async def get(self, key: str):
-        return self.store.get(key)
-
-    async def set(self, key: str, value: str):
-        self.store[key] = value
-        return True
-
-    async def delete(self, *keys: str) -> int:
-        count = 0
-        for k in keys:
-            if k in self.store:
-                self.store.pop(k)
-                count += 1
-        return count
-
-
 @pytest.fixture
 def redis_doc_status(monkeypatch):
     """Construct RedisDocStatusStorage with its Redis client replaced by a
     fake in-memory store. No network I/O occurs."""
-    fake = _FakeRedis()
+    fake = FakeRedis()
 
     # Stub out the connection pool factory so __post_init__ does not invoke
     # the real redis-py ConnectionPool.from_url (which is lazy but still
@@ -181,7 +90,11 @@ def _store_raw(storage, doc_id: str, payload: dict) -> None:
 
 
 async def test_get_doc_by_file_basename_returns_tuple_on_hit(redis_doc_status):
-    _store_raw(redis_doc_status, "doc-1", _doc(DocStatus.PROCESSED.value, "report.pdf"))
+    # Written via upsert: the basename primary index (Phase 1 sidecar) is the
+    # lookup's single source of truth and is maintained atomically by writes.
+    await redis_doc_status.upsert(
+        {"doc-1": _doc(DocStatus.PROCESSED.value, "report.pdf")}
+    )
 
     result = await redis_doc_status.get_doc_by_file_basename("report.pdf")
 

--- a/tests/kg/redis_impl/test_redis_eviction_guard.py
+++ b/tests/kg/redis_impl/test_redis_eviction_guard.py
@@ -1,0 +1,195 @@
+"""Redis eviction-policy startup guard.
+
+``doc_status`` rows, ``full_docs`` entries and the derived scheduling sidecar are
+all TTL-less keys holding a system of record. Under an ``allkeys-*`` maxmemory
+policy Redis may evict any of them, and the loss is both silent and undetectable
+— the sidecar's structural probe only asks whether ANY status key exists, so a
+partially evicted index looks healthy and never gets rebuilt. The only place this
+can be caught is startup, which is what these tests pin.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from redis.exceptions import ResponseError
+
+from lightrag.exceptions import StorageControlPlaneError
+from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
+from lightrag.namespace import NameSpace
+
+from .fake_redis import FakeRedis
+
+pytestmark = pytest.mark.offline
+
+
+class _DummyEmbeddingFunc:
+    embedding_dim = 1
+    max_token_size = 1
+
+    async def __call__(self, texts, **kwargs):
+        return [[0.0] for _ in texts]
+
+
+@pytest.fixture(autouse=True)
+def _shared():
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
+@pytest.fixture(autouse=True)
+def _reset_eviction_cache():
+    """The guard checks once per Redis URL per process; isolate that state.
+
+    Tolerant of the cache not existing so a missing guard fails these tests on
+    BEHAVIOUR (initialize succeeding when it must refuse) rather than on a
+    fixture error.
+    """
+    from lightrag.kg import redis_impl
+
+    cache = getattr(redis_impl, "_eviction_checked", None)
+    if cache is not None:
+        cache.clear()
+    yield
+    if cache is not None:
+        cache.clear()
+
+
+@pytest.fixture
+def fake(monkeypatch):
+    instance = FakeRedis()
+    monkeypatch.setattr(
+        "lightrag.kg.redis_impl.RedisConnectionManager.get_pool",
+        lambda redis_url: MagicMock(name="fake_pool"),
+    )
+    monkeypatch.setattr(
+        "lightrag.kg.redis_impl.Redis", lambda connection_pool=None, **_: instance
+    )
+    return instance
+
+
+def _doc_status_storage(workspace: str = "evict-ws"):
+    from lightrag.kg.redis_impl import RedisDocStatusStorage
+
+    return RedisDocStatusStorage(
+        namespace=NameSpace.DOC_STATUS,
+        global_config={},
+        embedding_func=_DummyEmbeddingFunc(),
+        workspace=workspace,
+    )
+
+
+def _kv_storage(workspace: str = "evict-ws"):
+    from lightrag.kg.redis_impl import RedisKVStorage
+
+    return RedisKVStorage(
+        namespace=NameSpace.KV_STORE_FULL_DOCS,
+        global_config={},
+        embedding_func=_DummyEmbeddingFunc(),
+        workspace=workspace,
+    )
+
+
+@pytest.mark.asyncio
+async def test_noeviction_server_initializes(fake):
+    storage = _doc_status_storage()
+    await storage.initialize()
+    assert storage._initialized is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("policy", ["allkeys-lru", "allkeys-lfu", "allkeys-random"])
+async def test_allkeys_policy_with_a_memory_cap_refuses_to_start(fake, policy):
+    """Every allkeys-* policy can evict a TTL-less key, so all of them refuse."""
+    fake.config_values = {"maxmemory": "1073741824", "maxmemory-policy": policy}
+    storage = _doc_status_storage()
+    with pytest.raises(StorageControlPlaneError, match="evicting cache"):
+        await storage.initialize()
+    assert storage._initialized is False
+
+
+@pytest.mark.asyncio
+async def test_full_docs_kv_is_guarded_too(fake):
+    """full_docs is a system of record as much as doc_status is."""
+    fake.config_values = {"maxmemory": "1073741824", "maxmemory-policy": "allkeys-lru"}
+    storage = _kv_storage()
+    with pytest.raises(StorageControlPlaneError, match="evicting cache"):
+        await storage.initialize()
+
+
+@pytest.mark.asyncio
+async def test_allkeys_policy_without_a_memory_cap_is_safe(fake):
+    """maxmemory=0 means no limit, so the policy never fires."""
+    fake.config_values = {"maxmemory": "0", "maxmemory-policy": "allkeys-lru"}
+    storage = _doc_status_storage()
+    await storage.initialize()
+    assert storage._initialized is True
+
+
+@pytest.mark.asyncio
+async def test_volatile_policy_is_safe(fake):
+    """volatile-* only evicts keys with a TTL; none of ours carry one, so a full
+    instance fails writes loudly instead of dropping data."""
+    fake.config_values = {"maxmemory": "1073741824", "maxmemory-policy": "volatile-lru"}
+    storage = _doc_status_storage()
+    await storage.initialize()
+    assert storage._initialized is True
+
+
+@pytest.mark.asyncio
+async def test_unreadable_config_warns_but_starts(fake, caplog):
+    """Managed Redis often blocks CONFIG GET. Refusing to start over a policy we
+    cannot observe would break working deployments, so this warns instead."""
+    import logging
+
+    from lightrag.utils import logger
+
+    fake.fail_next["config_get"] = ResponseError("unknown command 'CONFIG'")
+    storage = _doc_status_storage()
+    logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger=logger.name):
+            await storage.initialize()
+    finally:
+        logger.propagate = False
+    assert storage._initialized is True
+    assert "Could not read the Redis maxmemory policy" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_explicit_override_downgrades_to_a_warning(fake, monkeypatch, caplog):
+    import logging
+
+    from lightrag.utils import logger
+
+    monkeypatch.setenv("REDIS_ALLOW_EVICTION_POLICY", "true")
+    fake.config_values = {"maxmemory": "1073741824", "maxmemory-policy": "allkeys-lru"}
+    storage = _doc_status_storage()
+    logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger=logger.name):
+            await storage.initialize()
+    finally:
+        logger.propagate = False
+    assert storage._initialized is True
+    assert "configured to EVICT" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_policy_is_checked_once_per_url(fake):
+    """The policy is a server property shared by every storage on the pool, so a
+    second storage on the same URL must not re-issue CONFIG GET."""
+    calls = {"n": 0}
+    real_config_get = fake.config_get
+
+    async def counting_config_get(pattern="*"):
+        calls["n"] += 1
+        return await real_config_get(pattern)
+
+    fake.config_get = counting_config_get
+
+    await _doc_status_storage().initialize()
+    await _kv_storage().initialize()
+    assert calls["n"] == 1

--- a/tests/kg/redis_impl/test_redis_scheduling_pages.py
+++ b/tests/kg/redis_impl/test_redis_scheduling_pages.py
@@ -1,0 +1,466 @@
+"""RedisDocStatusStorage Phase 1 scheduling contract tests (offline fake).
+
+Covers: derived-sidecar rebuild on initialize (streaming build into a temp
+keyspace + atomic switch), per-status ZSET keyset pages with the composite
+per-status cursor and consumed-position advance, O(1) ZCARD counts, atomic
+WATCH/MULTI writes (status transitions move ZSET members; the source multimap
+follows the member-level eligibility state machine — including the post-parse
+content-duplicate in-place transition), the typed conflict-aware source
+resolver (Absent/Unique/Conflict with stale self-heal and early stop), the
+strict batch read, the operator conflict listing + CAS repair, and fail-closed
+strict lookups.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from redis.exceptions import RedisError
+
+from lightrag.base import (
+    CURSOR_END,
+    CURSOR_START,
+    CursorAfter,
+    DocStatus,
+    SourceAbsent,
+    SourceConflict,
+    SourceUnique,
+)
+from lightrag.exceptions import (
+    StorageControlPlaneError,
+    StorageRecordNotFoundError,
+)
+from lightrag.namespace import NameSpace
+
+from .fake_redis import FakeRedis
+
+pytestmark = pytest.mark.offline
+
+
+class _DummyEmbeddingFunc:
+    embedding_dim = 1
+    max_token_size = 1
+
+    async def __call__(self, texts, **kwargs):
+        return [[0.0] for _ in texts]
+
+
+def _doc(
+    status: str,
+    file_path: str = "a.pdf",
+    created_at: str = "2026-01-01T00:00:00+00:00",
+    **extra,
+) -> dict:
+    row = {
+        "content_summary": "s",
+        "content_length": 10,
+        "file_path": file_path,
+        "status": status,
+        "created_at": created_at,
+        "updated_at": created_at,
+        "metadata": {},
+        "error_msg": None,
+        "chunks_list": [],
+    }
+    row.update(extra)
+    return row
+
+
+def _dup(status: str, file_path: str = "a.pdf", **extra) -> dict:
+    row = _doc(status, file_path=file_path, **extra)
+    row["metadata"] = {"is_duplicate": True}
+    return row
+
+
+@pytest.fixture
+def storage(monkeypatch):
+    fake = FakeRedis()
+    monkeypatch.setattr(
+        "lightrag.kg.redis_impl.RedisConnectionManager.get_pool",
+        lambda redis_url: MagicMock(name="fake_pool"),
+    )
+    monkeypatch.setattr(
+        "lightrag.kg.redis_impl.Redis", lambda connection_pool=None, **_: fake
+    )
+    from lightrag.kg.redis_impl import RedisDocStatusStorage
+
+    instance = RedisDocStatusStorage(
+        namespace=NameSpace.DOC_STATUS,
+        global_config={},
+        embedding_func=_DummyEmbeddingFunc(),
+        workspace="test",
+    )
+    instance._initialized = True
+    return instance
+
+
+async def _bootstrap(storage):
+    """Run the derived-sidecar rebuild the way initialize() would."""
+    await storage._rebuild_scheduling_sidecar()
+
+
+async def _sweep_ids(storage, statuses, *, limit):
+    ids: list[str] = []
+    pages = 0
+    position = CURSOR_START
+    while True:
+        page = await storage.get_docs_by_statuses_page(
+            statuses,
+            limit=limit,
+            position=position,
+            strict=True,
+        )
+        pages += 1
+        ids.extend(page.docs.keys())
+        if page.next_position is CURSOR_END:
+            return ids, pages
+        position = page.next_position
+        assert isinstance(position, CursorAfter)
+        assert pages < 100, "sweep failed to terminate"
+
+
+@pytest.mark.asyncio
+async def test_rebuild_builds_sidecar_from_primary_rows(storage):
+    # Pre-existing deployment: raw rows only, no derived sidecar.
+    fake = storage._redis
+    fake.store[f"{storage.final_namespace}:doc-1"] = json.dumps(
+        _doc("pending", file_path="a.pdf")
+    )
+    fake.store[f"{storage.final_namespace}:doc-2"] = json.dumps(
+        _doc("failed", file_path="b.pdf")
+    )
+    fake.store[f"{storage.final_namespace}:dup-1"] = json.dumps(
+        _dup("failed", file_path="a.pdf")
+    )
+
+    await _bootstrap(storage)
+
+    # Status ZSETs populated from the actual rows.
+    assert await storage.count_docs_by_statuses([DocStatus.PENDING]) == 1
+    assert await storage.count_docs_by_statuses([DocStatus.FAILED]) == 2
+    # Source multimap built; duplicate marker rows are NOT indexed.
+    resolved = await storage.resolve_doc_source_strict("a.pdf")
+    assert isinstance(resolved, SourceUnique) and resolved.doc_id == "doc-1"
+    # No leftover rebuild temp keyspace after the atomic switch.
+    assert not any(
+        k.startswith(f"{storage._sched_prefix}_rebuild:") for k in fake.zsets
+    )
+    assert not any(k.startswith(f"{storage._sched_prefix}_rebuild:") for k in fake.sets)
+    # Re-running the rebuild is a no-op (index already present).
+    await _bootstrap(storage)
+    assert await storage.count_docs_by_statuses([DocStatus.PENDING]) == 1
+
+
+@pytest.mark.asyncio
+async def test_sidecar_not_ready_raises_never_empty(storage):
+    # Simulate a not-yet-initialized instance: strict reads must refuse rather
+    # than read the empty index as confirmed absence.
+    storage._initialized = False
+    with pytest.raises(StorageControlPlaneError):
+        await storage.count_docs_by_statuses([DocStatus.PENDING])
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_docs_by_statuses_page([DocStatus.PENDING], limit=1)
+    with pytest.raises(StorageControlPlaneError):
+        await storage.resolve_doc_source_strict("a.pdf")
+
+
+@pytest.mark.asyncio
+async def test_page_kway_merge_and_consumed_position(storage):
+    await _bootstrap(storage)
+    await storage.upsert(
+        {
+            "doc-c": _doc("pending", created_at="2026-01-01T00:00:00+00:00"),
+            "doc-a": _doc("failed", created_at="2026-01-02T00:00:00+00:00"),
+            "doc-b": _doc("pending", created_at="2026-01-03T00:00:00+00:00"),
+        }
+    )
+    ids, pages = await _sweep_ids(
+        storage, [DocStatus.PENDING, DocStatus.FAILED], limit=1
+    )
+    # Global (created_at, id) order across BOTH status streams.
+    assert ids == ["doc-c", "doc-a", "doc-b"]
+    assert pages >= 3
+
+
+@pytest.mark.asyncio
+async def test_page_prefetched_head_not_consumed(storage):
+    """With limit=1 and two streams, the losing stream's prefetched head is
+    NOT consumed — it must reappear on the next page (no skips)."""
+    await _bootstrap(storage)
+    await storage.upsert(
+        {
+            "doc-p": _doc("pending", created_at="2026-01-01T00:00:00+00:00"),
+            "doc-f": _doc("failed", created_at="2026-01-01T00:00:00+00:00"),
+        }
+    )
+    page1 = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING, DocStatus.FAILED], limit=1, strict=True
+    )
+    # (same created_at) id tie-break: doc-f < doc-p
+    assert list(page1.docs) == ["doc-f"]
+    page2 = await storage.get_docs_by_statuses_page(
+        [DocStatus.PENDING, DocStatus.FAILED],
+        limit=1,
+        position=page1.next_position,
+        strict=True,
+    )
+    assert list(page2.docs) == ["doc-p"]
+
+
+@pytest.mark.asyncio
+async def test_status_transition_moves_zset_membership(storage):
+    await _bootstrap(storage)
+    await storage.upsert({"doc-1": _doc("pending")})
+    await storage.update_doc_status_fields("doc-1", {"status": "processing"})
+    assert await storage.count_docs_by_statuses([DocStatus.PENDING]) == 0
+    assert await storage.count_docs_by_statuses([DocStatus.PROCESSING]) == 1
+    ids, _ = await _sweep_ids(storage, [DocStatus.PROCESSING], limit=10)
+    assert ids == ["doc-1"]
+    with pytest.raises(ValueError, match="created_at"):
+        await storage.update_doc_status_fields("doc-1", {"created_at": "2030-01-01"})
+    with pytest.raises(StorageRecordNotFoundError):
+        await storage.update_doc_status_fields("missing", {"status": "pending"})
+
+
+@pytest.mark.asyncio
+async def test_atomic_write_retries_on_watch_conflict(storage):
+    """A concurrent bump of the doc key between the WATCH read and EXEC forces
+    a retry; the write still lands and the sidecar stays consistent."""
+    await _bootstrap(storage)
+    await storage.upsert({"doc-1": _doc("pending")})
+    fake = storage._redis
+    main_key = f"{storage.final_namespace}:doc-1"
+
+    original = FakeRedis.get
+    tripped = {"done": False}
+
+    async def get_with_interleaving(self, key):
+        result = await original(self, key)
+        if not tripped["done"] and key == main_key:
+            tripped["done"] = True
+            # Interleave a concurrent write AFTER the WATCH snapshot read.
+            self._bump(key)
+        return result
+
+    fake.get = get_with_interleaving.__get__(fake)
+    try:
+        await storage.update_doc_status_fields("doc-1", {"status": "processing"})
+    finally:
+        fake.get = original.__get__(fake)
+    assert tripped["done"] is True
+    assert (await storage.get_by_id("doc-1"))["status"] == "processing"
+    assert await storage.count_docs_by_statuses([DocStatus.PROCESSING]) == 1
+    assert await storage.count_docs_by_statuses([DocStatus.PENDING]) == 0
+
+
+@pytest.mark.asyncio
+async def test_atomic_write_transport_failure_propagates(storage):
+    """A transport failure at EXEC propagates (not swallowed as WatchError);
+    the transaction commits nothing."""
+    await _bootstrap(storage)
+    await storage.upsert({"doc-1": _doc("pending")})
+    fake = storage._redis
+    fake.fail_next["execute"] = RedisError("boom")
+    with pytest.raises(RedisError):
+        await storage.update_doc_status_fields("doc-1", {"status": "processing"})
+    assert (await storage.get_by_id("doc-1"))["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_source_multimap_eligibility_state_machine(storage):
+    await _bootstrap(storage)
+    await storage.upsert({"doc-1": _doc("pending", file_path="a.pdf")})
+    resolved = await storage.resolve_doc_source_strict("a.pdf")
+    assert isinstance(resolved, SourceUnique) and resolved.doc_id == "doc-1"
+
+    # eligible → ineligible IN PLACE: the primary row is rewritten as a
+    # post-parse content duplicate — its own membership must be released.
+    await storage.upsert(
+        {"doc-1": _dup("failed", file_path="a.pdf", duplicate_kind="content_hash")}
+    )
+    assert isinstance(await storage.resolve_doc_source_strict("a.pdf"), SourceAbsent)
+
+    # A fresh ingestion may now legitimately claim the basename.
+    await storage.upsert({"doc-2": _doc("pending", file_path="a.pdf")})
+    resolved = await storage.resolve_doc_source_strict("a.pdf")
+    assert isinstance(resolved, SourceUnique) and resolved.doc_id == "doc-2"
+
+    # Deleting a NON-owning row (the duplicate marker) must not strip the
+    # surviving primary's membership.
+    await storage.delete(["doc-1"])
+    resolved = await storage.resolve_doc_source_strict("a.pdf")
+    assert isinstance(resolved, SourceUnique) and resolved.doc_id == "doc-2"
+
+    # Deleting the primary frees the name.
+    await storage.delete(["doc-2"])
+    assert isinstance(await storage.resolve_doc_source_strict("a.pdf"), SourceAbsent)
+
+
+@pytest.mark.asyncio
+async def test_resolve_source_conflict(storage):
+    await _bootstrap(storage)
+    await storage.upsert(
+        {
+            "doc-1": _doc("pending", file_path="a.pdf"),
+            "doc-2": _doc("failed", file_path="a.pdf"),
+        }
+    )
+    resolved = await storage.resolve_doc_source_strict("a.pdf")
+    assert isinstance(resolved, SourceConflict)
+    assert resolved.candidate_count is None  # only proved "at least two"
+    assert set(resolved.sample_doc_ids) == {"doc-1", "doc-2"}
+
+
+@pytest.mark.asyncio
+async def test_resolve_source_stale_member_self_heals(storage):
+    await _bootstrap(storage)
+    await storage.upsert({"doc-1": _doc("pending", file_path="a.pdf")})
+    # Inject a stale member whose primary row does not exist.
+    fake = storage._redis
+    set_key = storage._basename_key("a.pdf")
+    fake.sets[set_key].add("gone")
+
+    resolved = await storage.resolve_doc_source_strict("a.pdf")
+    assert isinstance(resolved, SourceUnique) and resolved.doc_id == "doc-1"
+    # The stale member was self-healed out of the set.
+    assert "gone" not in fake.sets.get(set_key, set())
+
+
+@pytest.mark.asyncio
+async def test_resolve_source_stops_after_two_valid_candidates(storage):
+    await _bootstrap(storage)
+    await storage.upsert(
+        {
+            "doc-a": _doc("pending", file_path="a.pdf"),
+            "doc-b": _doc("failed", file_path="a.pdf"),
+        }
+    )
+    fake = storage._redis
+    set_key = storage._basename_key("a.pdf")
+    # A third (stale) member that sorts LAST: if the resolver stopped after two
+    # valid candidates it is never examined, so it is not self-healed.
+    fake.sets[set_key].add("zzz-stale")
+
+    resolved = await storage.resolve_doc_source_strict("a.pdf")
+    assert isinstance(resolved, SourceConflict)
+    assert set(resolved.sample_doc_ids) == {"doc-a", "doc-b"}
+    assert "zzz-stale" in fake.sets.get(set_key, set())
+
+
+@pytest.mark.asyncio
+async def test_get_docs_by_ids_present_and_missing(storage):
+    await _bootstrap(storage)
+    await storage.upsert({"doc-1": _doc("pending"), "doc-2": _doc("failed")})
+    result = await storage.get_docs_by_ids(["doc-1", "doc-2", "ghost"], strict=True)
+    assert set(result) == {"doc-1", "doc-2"}  # missing omitted, confirmed absent
+    assert result["doc-2"].status is DocStatus.FAILED
+    assert not hasattr(result["doc-1"], "chunks_list")
+
+
+@pytest.mark.asyncio
+async def test_list_and_repair_source_conflict(storage):
+    await _bootstrap(storage)
+    await storage.upsert(
+        {
+            "doc-1": _doc("pending", file_path="a.pdf"),
+            "doc-2": _doc("failed", file_path="a.pdf"),
+            "doc-3": _doc("pending", file_path="a.pdf"),
+            "solo": _doc("pending", file_path="b.pdf"),
+        }
+    )
+    page = await storage.list_source_conflicts_page(limit=10)
+    assert len(page.conflicts) == 1
+    conflict = page.conflicts[0]
+    assert conflict.canonical_source_key == "a.pdf"
+    assert conflict.candidate_count == 3
+    assert set(conflict.sample_doc_ids) == {"doc-1", "doc-2", "doc-3"}
+
+    # dry-run reports without mutating.
+    dry = await storage.repair_source_conflict(
+        "a.pdf",
+        primary_doc_id="doc-2",
+        expected_candidate_count=0,
+        expected_candidate_fingerprint="ignored-in-dry-run",
+    )
+    assert dry.committed is False
+    assert dry.candidate_count == 3
+    assert isinstance(await storage.resolve_doc_source_strict("a.pdf"), SourceConflict)
+
+    # primary_doc_id must be a current candidate.
+    with pytest.raises(ValueError):
+        await storage.repair_source_conflict(
+            "a.pdf",
+            primary_doc_id="not-a-candidate",
+            expected_candidate_count=dry.candidate_count,
+            expected_candidate_fingerprint=dry.fingerprint,
+            dry_run=False,
+        )
+
+    # stale expectation → CAS failure.
+    with pytest.raises(StorageControlPlaneError):
+        await storage.repair_source_conflict(
+            "a.pdf",
+            primary_doc_id="doc-2",
+            expected_candidate_count=99,
+            expected_candidate_fingerprint=dry.fingerprint,
+            dry_run=False,
+        )
+
+    # correct expectation → commit; resolver returns the chosen primary.
+    result = await storage.repair_source_conflict(
+        "a.pdf",
+        primary_doc_id="doc-2",
+        expected_candidate_count=dry.candidate_count,
+        expected_candidate_fingerprint=dry.fingerprint,
+        dry_run=False,
+    )
+    assert result.committed is True
+    resolved = await storage.resolve_doc_source_strict("a.pdf")
+    assert isinstance(resolved, SourceUnique) and resolved.doc_id == "doc-2"
+    # losers demoted to duplicates, content intact.
+    for loser in ("doc-1", "doc-3"):
+        row = await storage.get_by_id(loser)
+        assert row["metadata"]["is_duplicate"] is True
+        assert row["metadata"]["original_doc_id"] == "doc-2"
+    # no more conflicts.
+    page = await storage.list_source_conflicts_page(limit=10)
+    assert page.conflicts == ()
+
+
+@pytest.mark.asyncio
+async def test_count_and_strict_lookup_fail_closed(storage):
+    await _bootstrap(storage)
+    await storage.upsert({"doc-1": _doc("pending")})
+    fake = storage._redis
+
+    fake.fail_next["zcard"] = RedisError("boom")
+    with pytest.raises(RedisError):
+        await storage.count_docs_by_statuses([DocStatus.PENDING])
+
+    # The typed resolver propagates transport errors (never a false Absent).
+    fake.fail_next["sscan"] = RedisError("boom")
+    with pytest.raises(RedisError):
+        await storage.resolve_doc_source_strict("a.pdf")
+    # The legacy method keeps the swallow-and-None behaviour.
+    fake.fail_next["sscan"] = RedisError("boom")
+    assert await storage.get_doc_by_file_basename("a.pdf") is None
+
+
+@pytest.mark.asyncio
+async def test_malformed_cursor_raises_control_plane_error(storage):
+    await _bootstrap(storage)
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_docs_by_statuses_page(
+            [DocStatus.PENDING], limit=1, position=CursorAfter("[1,2]")
+        )
+
+
+@pytest.mark.asyncio
+async def test_drop_clears_rows_and_sidecar(storage):
+    await _bootstrap(storage)
+    await storage.upsert({"doc-1": _doc("pending", file_path="a.pdf")})
+    await storage.drop()
+    assert await storage.count_docs_by_statuses([DocStatus.PENDING]) == 0
+    assert isinstance(await storage.resolve_doc_source_strict("a.pdf"), SourceAbsent)

--- a/tests/kg/redis_impl/test_redis_scheduling_pages.py
+++ b/tests/kg/redis_impl/test_redis_scheduling_pages.py
@@ -154,6 +154,52 @@ async def test_rebuild_builds_sidecar_from_primary_rows(storage):
 
 
 @pytest.mark.asyncio
+async def test_publish_refuses_to_clobber_a_concurrent_writer(storage, monkeypatch):
+    """Fix-proof: the switch used to DELETE the official keys and RENAME the
+    snapshot over them unconditionally, so a write that landed after its row was
+    scanned (it had already maintained the OFFICIAL index in the same
+    transaction) was silently reverted — leaving the doc in the wrong status ZSET
+    and out of the sweep. The publish must now refuse instead of losing it."""
+    fake = storage._redis
+    fake.store[f"{storage.final_namespace}:doc-1"] = json.dumps(
+        _doc("pending", file_path="a.pdf")
+    )
+
+    # Land the racing write through the SCAN the rebuild itself drives, so this
+    # test exercises whatever publish logic exists rather than asserting a
+    # particular helper is present. The primary keyspace is scanned twice: once
+    # by the pre-lock "are there rows to build from" probe, then by the snapshot
+    # loop — the write has to land during the second one, after the snapshot has
+    # already captured its slot.
+    primary_pattern = f"{storage.final_namespace}:*"
+    real_scan = fake.scan
+    primary_scans = {"n": 0}
+
+    async def scan_with_racing_write(
+        cursor: int = 0, match: str = "", count: int = 1000
+    ):
+        result = await real_scan(cursor, match=match, count=count)
+        if match == primary_pattern:
+            primary_scans["n"] += 1
+            if primary_scans["n"] == 2:
+                # Another worker enqueues doc-new: its write commits the row and
+                # the OFFICIAL sidecar entry in one transaction.
+                await storage.upsert({"doc-new": _doc("pending", file_path="c.pdf")})
+        return result
+
+    monkeypatch.setattr(fake, "scan", scan_with_racing_write)
+
+    # Old behaviour: no exception — the snapshot was published over the live
+    # index. New behaviour: refuse, because the write cannot be preserved.
+    with pytest.raises(StorageControlPlaneError, match="stale snapshot"):
+        await storage._rebuild_scheduling_sidecar()
+
+    # Either way, the concurrent write must still be in the official index.
+    pending_members = fake.zsets[f"{storage._sched_prefix}:status:pending"]
+    assert any("doc-new" in member for member in pending_members)
+
+
+@pytest.mark.asyncio
 async def test_sidecar_not_ready_raises_never_empty(storage):
     # Simulate a not-yet-initialized instance: strict reads must refuse rather
     # than read the empty index as confirmed absence.
@@ -357,6 +403,56 @@ async def test_get_docs_by_ids_present_and_missing(storage):
     assert set(result) == {"doc-1", "doc-2"}  # missing omitted, confirmed absent
     assert result["doc-2"].status is DocStatus.FAILED
     assert not hasattr(result["doc-1"], "chunks_list")
+
+
+@pytest.mark.asyncio
+async def test_conflict_listing_is_bounded_and_resumable(storage, monkeypatch):
+    """Fix-proof: the listing used to materialize EVERY canonical key, validate
+    every one with card>=2 across the whole workspace, build the complete
+    conflict list and only then slice to `limit` — redoing all of it per page.
+    It must now stop early and validate only what it actually surfaces."""
+    await _bootstrap(storage)
+    rows = {}
+    # 40 non-conflicting sources plus 4 conflicting ones.
+    for i in range(40):
+        rows[f"solo-{i:03d}"] = _doc("pending", file_path=f"solo-{i:03d}.pdf")
+    for i in range(4):
+        rows[f"conf-{i}-a"] = _doc("pending", file_path=f"dup-{i}.pdf")
+        rows[f"conf-{i}-b"] = _doc("failed", file_path=f"dup-{i}.pdf")
+    await storage.upsert(rows)
+
+    validated: list[str] = []
+    real_valid = storage._valid_primary_ids
+
+    async def counting_valid_primary_ids(redis, canonical):
+        validated.append(canonical)
+        return await real_valid(redis, canonical)
+
+    monkeypatch.setattr(storage, "_valid_primary_ids", counting_valid_primary_ids)
+
+    # Force a small batch so "stop once limit is reached" is reachable.
+    monkeypatch.setattr(type(storage), "_CONFLICT_SCAN_BATCH", 8)
+
+    page = await storage.list_source_conflicts_page(limit=1)
+    assert len(page.conflicts) >= 1
+    assert isinstance(page.next_position, CursorAfter)
+    # Bounded work: it stopped instead of validating all 44 source keys. Only
+    # keys surviving the SCARD>=2 prefilter are ever validated.
+    assert len(validated) <= 8
+    assert all(name.startswith("dup-") for name in validated)
+
+    # Resuming from the cursor keeps making progress and terminates.
+    seen = {c.canonical_source_key for c in page.conflicts}
+    position = page.next_position
+    for _ in range(20):
+        nxt = await storage.list_source_conflicts_page(limit=1, position=position)
+        seen.update(c.canonical_source_key for c in nxt.conflicts)
+        if nxt.next_position is CURSOR_END:
+            break
+        position = nxt.next_position
+    else:
+        raise AssertionError("conflict paging failed to terminate")
+    assert seen == {f"dup-{i}.pdf" for i in range(4)}
 
 
 @pytest.mark.asyncio

--- a/tests/kg/test_scheduling_base_defaults.py
+++ b/tests/kg/test_scheduling_base_defaults.py
@@ -1,0 +1,278 @@
+"""Base-contract tests for the memory-bounding scheduling API (Phase 1).
+
+doc_status backends are all first-party: the bounded-paging / strict-batch /
+strict-point / source-resolution methods are ``@abstractmethod``, so a subclass
+missing any of them cannot instantiate (instantiability IS the capability
+guarantee — there are no capability flags and no degraded fallback).
+
+The methods that DO keep a concrete base default are still exercised here via a
+minimal subclass that implements the abstract surface:
+
+* ``count_docs_by_statuses`` raises ``StorageCapabilityError`` (fail-closed);
+* ``update_doc_status_fields`` refuses ``created_at`` and raises
+  ``StorageRecordNotFoundError`` on unknown ids unless ``missing_ok``;
+* ``list_source_conflicts_page`` / ``repair_source_conflict`` raise capability
+  errors until a backend overrides them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from abc import abstractmethod
+from dataclasses import dataclass, field, fields
+from typing import Any, Sequence
+
+import pytest
+
+from lightrag.base import (
+    CURSOR_END,
+    CursorPosition,
+    DocProcessingStatus,
+    DocSchedulingRecord,
+    DocStatus,
+    DocStatusPage,
+    DocStatusStorage,
+    SourceAbsent,
+    SourceResolution,
+)
+from lightrag.exceptions import (
+    StorageCapabilityError,
+    StorageRecordNotFoundError,
+)
+
+pytestmark = pytest.mark.offline
+
+
+@dataclass
+class _MinimalDocStatusStorage(DocStatusStorage):
+    """First-party-style subclass implementing the full abstract surface
+    (legacy methods + the mandatory scheduling methods) trivially, so the
+    concrete base defaults (count/update/list/repair) can be exercised."""
+
+    embedding_func: Any = None
+    namespace: str = "test"
+    workspace: str = "test"
+    global_config: dict = field(default_factory=dict)
+    data: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    async def initialize(self):  # pragma: no cover - unused
+        pass
+
+    async def finalize(self):  # pragma: no cover - unused
+        pass
+
+    async def index_done_callback(self) -> None:
+        pass
+
+    async def drop(self) -> dict[str, str]:
+        self.data.clear()
+        return {"status": "success", "message": "dropped"}
+
+    async def get_by_id(self, id: str) -> dict[str, Any] | None:
+        row = self.data.get(id)
+        return dict(row) if row is not None else None
+
+    # NOTE: get_by_id_strict is intentionally NOT implemented — it is an
+    # optional KV capability (supports_strict_point_reads defaults False), so
+    # the inherited base default (raise) applies.
+
+    async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
+        return [dict(self.data[i]) for i in ids if i in self.data]
+
+    async def filter_keys(self, keys: set[str]) -> set[str]:
+        return {k for k in keys if k not in self.data}
+
+    async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
+        for key, value in data.items():
+            self.data[key] = dict(value)
+
+    async def delete(self, ids: list[str]) -> None:
+        for i in ids:
+            self.data.pop(i, None)
+
+    async def is_empty(self) -> bool:
+        return not self.data
+
+    async def get_status_counts(self) -> dict[str, int]:  # pragma: no cover
+        return {}
+
+    async def get_docs_by_status(
+        self, status: DocStatus
+    ) -> dict[str, DocProcessingStatus]:  # pragma: no cover - unused
+        return {}
+
+    async def get_docs_by_statuses(
+        self, statuses: list[DocStatus], strict: bool = False
+    ) -> dict[str, DocProcessingStatus]:  # pragma: no cover - unused
+        return {}
+
+    async def get_docs_by_track_id(
+        self, track_id: str
+    ) -> dict[str, DocProcessingStatus]:  # pragma: no cover - unused
+        return {}
+
+    async def get_docs_paginated(
+        self,
+        status_filter=None,
+        status_filters=None,
+        page: int = 1,
+        page_size: int = 50,
+        sort_field: str = "updated_at",
+        sort_direction: str = "desc",
+    ):  # pragma: no cover - unused
+        return [], 0
+
+    async def get_all_status_counts(self) -> dict[str, int]:  # pragma: no cover
+        return {}
+
+    async def get_doc_by_file_path(
+        self, file_path: str
+    ) -> dict[str, Any] | None:  # pragma: no cover - unused
+        return None
+
+    async def get_doc_by_file_basename(
+        self, basename: str
+    ) -> tuple[str, dict[str, Any]] | None:  # pragma: no cover - unused
+        return None
+
+    async def get_doc_by_content_hash(
+        self, content_hash: str
+    ) -> tuple[str, dict[str, Any]] | None:  # pragma: no cover - unused
+        return None
+
+    # Mandatory scheduling surface — trivial concrete impls so the class is
+    # instantiable (behaviour is covered by the per-backend test suites).
+    async def get_docs_by_statuses_page(
+        self, statuses, *, limit, position=None, strict=False
+    ) -> DocStatusPage:  # pragma: no cover - trivial
+        return DocStatusPage(docs={}, next_position=CURSOR_END)
+
+    async def get_docs_by_ids(
+        self, doc_ids: Sequence[str], *, strict: bool = False
+    ) -> dict[str, DocSchedulingRecord]:  # pragma: no cover - trivial
+        return {}
+
+    async def resolve_doc_source_strict(
+        self, canonical_source_key: str
+    ) -> SourceResolution:  # pragma: no cover - trivial
+        return SourceAbsent()
+
+
+def _row(status: DocStatus, created_at: str = "2026-01-01T00:00:00") -> dict:
+    return {
+        "status": status.value,
+        "content_summary": "s",
+        "content_length": 1,
+        "file_path": "a.pdf",
+        "created_at": created_at,
+        "updated_at": created_at,
+        "track_id": "t1",
+        "metadata": {},
+    }
+
+
+def _storage(**rows: dict) -> _MinimalDocStatusStorage:
+    storage = _MinimalDocStatusStorage()
+    storage.data.update(rows)
+    return storage
+
+
+def test_scheduling_methods_are_mandatory_abstractmethods():
+    # The doc_status scheduling surface is abstract, so a backend cannot
+    # instantiate without implementing every one. get_by_id_strict is NOT here
+    # — it is an optional KV capability gated by supports_strict_point_reads.
+    assert "get_by_id_strict" not in DocStatusStorage.__abstractmethods__
+    for name in (
+        "get_docs_by_statuses_page",
+        "get_docs_by_ids",
+        "resolve_doc_source_strict",
+    ):
+        assert name in DocStatusStorage.__abstractmethods__, name
+
+
+def test_get_by_id_strict_is_optional_capability():
+    async def _run():
+        storage = _storage(d1=_row(DocStatus.PENDING))
+        # Not implemented + capability defaults False → conservative raise
+        # (a caller must gate on the flag and fall back to a safe path).
+        assert storage.supports_strict_point_reads is False
+        with pytest.raises(StorageCapabilityError):
+            await storage.get_by_id_strict("d1")
+
+    asyncio.run(_run())
+
+
+def test_subclass_missing_an_abstract_cannot_instantiate():
+    # Re-declaring a mandatory method as abstract makes ABCMeta recompute a
+    # non-empty __abstractmethods__ → instantiation raises TypeError (there is
+    # no silent degraded fallback to fall back to).
+    class _Incomplete(_MinimalDocStatusStorage):
+        @abstractmethod
+        async def resolve_doc_source_strict(
+            self, canonical_source_key: str
+        ) -> SourceResolution: ...
+
+    assert "resolve_doc_source_strict" in _Incomplete.__abstractmethods__
+    with pytest.raises(TypeError):
+        _Incomplete()
+
+
+def test_minimal_subclass_instantiates():
+    storage = _MinimalDocStatusStorage()
+    assert isinstance(storage, DocStatusStorage)
+
+
+def test_scheduling_record_projection_is_lightweight():
+    projected = {f.name for f in fields(DocSchedulingRecord)}
+    assert "chunks_list" not in projected
+    assert "error_msg" not in projected
+    assert "content_length" not in projected
+
+
+def test_count_default_raises_capability_error():
+    async def _run():
+        storage = _storage(d1=_row(DocStatus.PENDING))
+        with pytest.raises(StorageCapabilityError):
+            await storage.count_docs_by_statuses([DocStatus.PENDING])
+
+    asyncio.run(_run())
+
+
+def test_update_fields_refuses_created_at_and_missing_ids():
+    async def _run():
+        storage = _storage(d1=_row(DocStatus.PENDING))
+        with pytest.raises(ValueError):
+            await storage.update_doc_status_fields(
+                "d1", {"created_at": "2027-01-01T00:00:00"}
+            )
+        with pytest.raises(StorageRecordNotFoundError):
+            await storage.update_doc_status_fields("missing", {"status": "failed"})
+        await storage.update_doc_status_fields(
+            "missing", {"status": "failed"}, missing_ok=True
+        )
+        await storage.update_doc_status_fields("d1", {"track_id": "t2"})
+        assert storage.data["d1"]["track_id"] == "t2"
+        assert storage.data["d1"]["created_at"] == "2026-01-01T00:00:00"
+
+    asyncio.run(_run())
+
+
+def test_source_conflict_methods_raise_capability_error():
+    async def _run():
+        storage = _storage(d1=_row(DocStatus.PENDING))
+        with pytest.raises(StorageCapabilityError):
+            await storage.list_source_conflicts_page(limit=10)
+        with pytest.raises(StorageCapabilityError):
+            await storage.repair_source_conflict(
+                "a.pdf",
+                primary_doc_id="d1",
+                expected_candidate_count=2,
+                expected_candidate_fingerprint="deadbeef",
+            )
+
+    asyncio.run(_run())
+
+
+def test_cursor_position_type_available():
+    # Sanity: the sealed cursor type is importable for type checks.
+    assert issubclass(type(CURSOR_END), CursorPosition)


### PR DESCRIPTION
Gives `doc_status` a bounded scheduling read API. Nothing consumes it yet — the scheduler moves onto it in the next PR — so this is additive and behaviour-neutral by itself.

**The contract.** A three-state cursor (`CURSOR_START` / opaque `CursorAfter` / `CURSOR_END`), keyset pages ordered by an immutable `(created_at, id)`, and a lightweight `DocSchedulingRecord` projection that deliberately omits `chunks_list`, large `metadata` and full error text so a page stays O(page_size × small constant). `next_position is CURSOR_END` is the **only** termination signal: an empty page is not the end, because a page may be fully filtered yet not exhausted.

**Strict means complete-or-raise.** `get_docs_by_statuses_page`, `get_docs_by_ids` and `get_by_id_strict` under `strict=True` either return a complete answer or raise. This closes a class of bug where a transport error read as "the document is gone" and the pipeline treated live rows as stale.

**Typed source resolution.** `resolve_doc_source_strict` returns `SourceAbsent | SourceUnique | SourceConflict`. A basename is **not** assumed globally unique — custom-id inserts, legacy ids and historical collisions can share one — so a duplicate surfaces as a typed conflict with a bounded candidate sample instead of being silently resolved by `LIMIT 1`.

**Deliberate ruling: no capability flag for the scheduling methods.** All `doc_status` backends are first-party, so the three scheduling methods are `@abstractmethod`. A backend that lacks them cannot be instantiated — instantiability *is* the guarantee, which is stronger than a flag that can be false at runtime. Only `get_by_id_strict` keeps an opt-in (`supports_strict_point_reads`), because `BaseKVStorage` is a wider surface.

**Five backends.** JSON, PostgreSQL, MongoDB, OpenSearch and Redis. Redis needs derived state to page at all, so it builds a per-status ZSET and a `file_path → doc_id` **multimap** (a plain key could not represent a collision), maintained in the same transaction as the row, rebuilt from the actual rows when absent and never gated by a marker. `mark_doc_failed` goes through a funnel that preserves `created_at`.

Also removes the `failure_generation` contract entirely: scheduling correctness must not depend on a counter whose lifecycle is separate from `doc_status`.

---

**Stack** (merge bottom-up; each PR is green on its own and targets the one below):
`main` ← **#3482** P0 test rig ← **#3483** P1 storage pages ← **#3484** P2 bounded sweep ← **#3485** P2.5 dedup ← **#3486** P3 manual retry ← **#3481** P4 `/scan` ← **#3487** P5 admission ← **#3488** P6 observability ← **#3489** P7 verification

Design: LR2 *pipeline memory bounding*. When merging, retarget the child PR **before** deleting a merged branch — GitHub closes the child otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
