### PR TITLE
✨ feat(pipeline): bounded AUTO sweep, feeder and rollback via keyset paging (LR2 Phase 2)

### DIFF
--- a/env.example
+++ b/env.example
@@ -677,6 +677,11 @@ MAX_PARALLEL_INSERT=3
 # QUEUE_SIZE_PARSE=20
 # QUEUE_SIZE_ANALYZE=100
 # QUEUE_SIZE_INSERT=4
+### Bounded scheduling page size: the scheduler sweeps the doc_status backlog
+### through keyset pages of this many records so memory grows with page-size +
+### inflight instead of the whole backlog. 0 disables paging (legacy single
+### scan). Default 500.
+# PIPELINE_SCHEDULING_PAGE_SIZE=500
 ### Max concurrency requests for Embedding
 # EMBEDDING_FUNC_MAX_ASYNC=8
 ### Num of chunks send to Embedding in single request (default is 10)

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -34,6 +34,7 @@ from lightrag.constants import (
     DEFAULT_FORCE_LLM_SUMMARY_ON_MERGE,
     DEFAULT_MAX_ASYNC,
     DEFAULT_MAX_PARALLEL_INSERT,
+    DEFAULT_PIPELINE_SCHEDULING_PAGE_SIZE,
     DEFAULT_SUMMARY_MAX_TOKENS,
     DEFAULT_SUMMARY_LENGTH_RECOMMENDED,
     DEFAULT_SUMMARY_CONTEXT_SIZE,
@@ -504,6 +505,11 @@ def parse_args() -> argparse.Namespace:
     # Get MAX_PARALLEL_INSERT from environment
     args.max_parallel_insert = get_env_value(
         "MAX_PARALLEL_INSERT", DEFAULT_MAX_PARALLEL_INSERT, int
+    )
+
+    # Bounded scheduling page size (LR2 Phase 2); 0 disables paging.
+    args.pipeline_scheduling_page_size = get_env_value(
+        "PIPELINE_SCHEDULING_PAGE_SIZE", DEFAULT_PIPELINE_SCHEDULING_PAGE_SIZE, int
     )
 
     # Get MAX_GRAPH_NODES from environment

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -2147,6 +2147,7 @@ def create_app(args):
             rerank_model_max_async=args.rerank_max_async,
             default_rerank_timeout=args.rerank_timeout,
             max_parallel_insert=args.max_parallel_insert,
+            pipeline_scheduling_page_size=args.pipeline_scheduling_page_size,
             max_graph_nodes=args.max_graph_nodes,
             addon_params=addon_params,
             ollama_server_infos=ollama_server_infos,

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -1291,6 +1291,42 @@ class DocStatusStorage(BaseKVStorage, ABC):
         * Results use the lightweight projection (no chunks / full content).
         """
 
+    @abstractmethod
+    async def get_full_docs_by_ids(
+        self,
+        doc_ids: Sequence[str],
+        *,
+        strict: bool = False,
+    ) -> dict[str, DocProcessingStatus]:
+        """Batch hydration of FULL doc_status records by doc id.
+
+        The scheduling page (:meth:`get_docs_by_statuses_page`) yields the
+        lightweight :class:`DocSchedulingRecord` projection — only enough to
+        order, bound and filter a sweep. The scheduler hydrates the survivors
+        of ONE page into full :class:`DocProcessingStatus` rows through this
+        method right before routing them, so memory stays O(page_size) while
+        the consistency validator and the parse/analyze/process workers still
+        see every field they need (``content_summary`` / ``content_length`` /
+        ``chunks_list`` / ``metadata`` / ...).
+
+        Contract (every backend MUST implement it as a true batch read reusing
+        the SAME raw → :class:`DocProcessingStatus` normalisation as
+        :meth:`get_docs_by_statuses`):
+
+        * The returned mapping contains ONLY ids confirmed to exist; an id
+          the backend positively confirms absent (deleted, or its row no
+          longer decodes) may be omitted — a benign race, since a doc that
+          vanished between the page and its hydration is simply no longer
+          routable.
+        * With ``strict=True`` any transport/server/decode error fails the
+          WHOLE call — the implementation must not return a partial mapping
+          (the scheduler cannot distinguish "gone" from "unread" on a
+          partial, and a silently short page would strand the missing docs in
+          PENDING). All scheduling/control-plane callers pass ``strict=True``.
+        * Results are FULL :class:`DocProcessingStatus`, NOT the lightweight
+          projection.
+        """
+
     async def count_docs_by_statuses(
         self, statuses: list[DocStatus], *, strict: bool = True
     ) -> int:

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -471,3 +471,9 @@ DEFAULT_OLLAMA_MODEL_TAG = "latest"
 DEFAULT_OLLAMA_MODEL_SIZE = 7365960935
 DEFAULT_OLLAMA_CREATED_AT = "2024-01-15T00:00:00Z"
 DEFAULT_OLLAMA_DIGEST = "sha256:lightrag"
+
+# Upper bound on the doc-id samples surfaced by the custom-chunk rollback
+# report. The rollback sweep is paged, so it must not accumulate one entry per
+# journaled document just to describe what it did — counts are exact, the id
+# lists are a bounded sample (see arollback_failed_custom_chunk_patches).
+ROLLBACK_REPORT_SAMPLE_CAP = 32

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -358,6 +358,14 @@ DEFAULT_QUEUE_SIZE_PARSE = 20
 DEFAULT_QUEUE_SIZE_ANALYZE = 100
 DEFAULT_QUEUE_SIZE_INSERT = 4
 
+# Memory-bounding scheduling page size (LR2 Phase 2). The scheduler pages the
+# doc_status backlog through bounded keyset pages of this many records instead
+# of materializing every PENDING/orphan row at once, so RSS grows with
+# page-size + inflight rather than with the whole backlog. ``0`` disables
+# paging (one page holds the whole result set — byte-for-byte the legacy
+# single-scan behaviour).
+DEFAULT_PIPELINE_SCHEDULING_PAGE_SIZE = 500
+
 # LLM / embedding call priority levels.  Lower values run first
 # (asyncio.PriorityQueue semantics); priority only orders calls *within* a
 # single role queue (extract / keyword / query / vlm).  These name the values

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -220,15 +220,7 @@ class JsonDocStatusStorage(DocStatusStorage):
                     # fields below, instead of crashing every relaxed caller.
                     if v["status"] not in status_values:
                         continue
-                    data = v.copy()
-                    data.pop("content", None)
-                    if not data.get("file_path"):
-                        data["file_path"] = "no-file-path"
-                    if "metadata" not in data:
-                        data["metadata"] = {}
-                    if "error_msg" not in data:
-                        data["error_msg"] = None
-                    result[k] = DocProcessingStatus(**data)
+                    result[k] = self._doc_processing_status_from_row(v)
                 except (KeyError, TypeError) as e:
                     logger.error(
                         f"[{self.workspace}] Missing required field for document {k}: {e}"
@@ -664,7 +656,18 @@ class JsonDocStatusStorage(DocStatusStorage):
         """Project one raw row; strict raises on unusable rows, relaxed
         returns None (the caller still counts the row as consumed)."""
         try:
-            status = DocStatus(str(row["status"]))
+            # doc_status holds ``status`` as EITHER a DocStatus member (the
+            # in-memory pipeline path) or its raw string value (JSON-reloaded).
+            # ``DocStatus(str(member))`` would break on a member (str(enum) is
+            # "DocStatus.PENDING", not "pending"), so normalise enum-tolerantly
+            # — same as get_docs_by_statuses' membership test and the base
+            # _scheduling_record_from_raw helper.
+            raw_status = row["status"]
+            status = (
+                raw_status
+                if isinstance(raw_status, DocStatus)
+                else DocStatus(raw_status)
+            )
             created_at = row["created_at"]
             updated_at = row.get("updated_at", created_at)
             if not isinstance(created_at, str) or not isinstance(updated_at, str):
@@ -685,6 +688,23 @@ class JsonDocStatusStorage(DocStatusStorage):
             if strict:
                 raise
             return None
+
+    @staticmethod
+    def _doc_processing_status_from_row(row: dict[str, Any]) -> DocProcessingStatus:
+        """Normalise a raw doc_status row into a FULL DocProcessingStatus.
+
+        Single source of the raw → status construction shared by
+        ``get_docs_by_statuses`` and the ``get_full_docs_by_ids`` hydration
+        path. Raises ``KeyError``/``TypeError`` on a malformed row; the caller
+        decides strict (raise) vs relaxed (skip).
+        """
+        data = dict(row)
+        data.pop("content", None)  # deprecated inline content, never a status field
+        if not data.get("file_path"):
+            data["file_path"] = "no-file-path"
+        data.setdefault("metadata", {})
+        data.setdefault("error_msg", None)
+        return DocProcessingStatus(**data)
 
     async def get_docs_by_statuses_page(
         self,
@@ -731,7 +751,10 @@ class JsonDocStatusStorage(DocStatusStorage):
                     if strict:
                         raise TypeError(f"doc_status record {doc_id} is not a mapping")
                     continue
-                if str(row.get("status")) not in status_values:
+                # Membership (NOT str()) so a DocStatus member matches by its
+                # str-enum value — str(member) is "DocStatus.PENDING", which
+                # would wrongly exclude the in-memory pipeline's enum status.
+                if row.get("status") not in status_values:
                     continue
                 key = self._row_sort_key(doc_id, row)
                 if last_key is not None and key <= last_key:
@@ -770,7 +793,9 @@ class JsonDocStatusStorage(DocStatusStorage):
                             f"doc_status record {doc_id} has no readable status"
                         )
                     continue
-                if str(row.get("status")) in status_values:
+                # Membership (NOT str()) so an enum status member matches by
+                # its str-enum value (see get_docs_by_statuses_page).
+                if row.get("status") in status_values:
                     count += 1
         return count
 
@@ -831,6 +856,39 @@ class JsonDocStatusStorage(DocStatusStorage):
                 record = self._scheduling_record_from_row(doc_id, row, strict=strict)
                 if record is not None:
                     result[doc_id] = record
+        return result
+
+    async def get_full_docs_by_ids(
+        self,
+        doc_ids: Sequence[str],
+        *,
+        strict: bool = False,
+    ) -> dict[str, DocProcessingStatus]:
+        """Batch hydration to full DocProcessingStatus (see base contract).
+
+        In-memory dict lookup: a missing id is a confirmed absence and is
+        omitted. ``strict=True`` raises on a malformed record (mirrors
+        ``get_docs_by_statuses(strict=True)``); uninitialized storage always
+        raises.
+        """
+        if self._storage_lock is None:
+            raise StorageNotInitializedError("JsonDocStatusStorage")
+        result: dict[str, DocProcessingStatus] = {}
+        async with self._storage_lock:
+            for doc_id in doc_ids:
+                row = self._data.get(doc_id)
+                if row is None:
+                    continue  # confirmed absent
+                try:
+                    result[doc_id] = self._doc_processing_status_from_row(row)
+                except (KeyError, TypeError) as e:
+                    logger.error(
+                        f"[{self.workspace}] Unusable doc_status row hydrating "
+                        f"{doc_id}: {e}"
+                    )
+                    if strict:
+                        raise
+                    continue
         return result
 
     # ------------------------------------------------------------------

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -615,6 +615,21 @@ class MongoDocStatusStorage(DocStatusStorage):
                 data.pop("error", None)
         return data
 
+    def _mongo_doc_processing_status_from_doc(
+        self, doc: dict[str, Any]
+    ) -> DocProcessingStatus:
+        """Normalise a raw Mongo document into a FULL DocProcessingStatus.
+
+        Single source of the raw -> status construction shared by
+        ``get_docs_by_statuses`` and the ``get_full_docs_by_ids`` hydration
+        path. Raises ``KeyError``/``TypeError`` on a malformed document
+        (``TypeError`` is what ``DocProcessingStatus(**data)`` raises on
+        missing required fields); the caller decides strict (raise) vs relaxed
+        (skip).
+        """
+        data = self._prepare_doc_status_data(doc)
+        return DocProcessingStatus(**data)
+
     def __init__(self, namespace, global_config, embedding_func, workspace=None):
         super().__init__(
             namespace=namespace,
@@ -762,8 +777,7 @@ class MongoDocStatusStorage(DocStatusStorage):
         result = {}
         for doc in docs:
             try:
-                data = self._prepare_doc_status_data(doc)
-                result[doc["_id"]] = DocProcessingStatus(**data)
+                result[doc["_id"]] = self._mongo_doc_processing_status_from_doc(doc)
             except (KeyError, TypeError) as e:
                 # TypeError is what DocProcessingStatus(**data) actually raises
                 # on missing required fields — without it here, the relaxed
@@ -1403,6 +1417,41 @@ class MongoDocStatusStorage(DocStatusStorage):
             if record is None:
                 continue
             result[record.id] = record
+        return result
+
+    async def get_full_docs_by_ids(
+        self,
+        doc_ids: Sequence[str],
+        *,
+        strict: bool = False,
+    ) -> dict[str, DocProcessingStatus]:
+        """Batch hydration to full DocProcessingStatus (see base contract).
+
+        One indexed ``find({"_id": {"$in": ids}})`` — the server answers
+        definitively or raises, so any id absent from the result set is a
+        CONFIRMED absence and is omitted. Reuses the SAME raw ->
+        DocProcessingStatus normalisation as ``get_docs_by_statuses``.
+        ``strict=True`` raises on any returned document that cannot be
+        converted, failing the WHOLE call rather than returning a partial
+        mapping.
+        """
+        ids = list(doc_ids)
+        if not ids:
+            return {}
+        cursor = self._data.find({"_id": {"$in": ids}})
+        raw_docs = await cursor.to_list(length=None)
+        result: dict[str, DocProcessingStatus] = {}
+        for doc in raw_docs:
+            try:
+                result[doc["_id"]] = self._mongo_doc_processing_status_from_doc(doc)
+            except (KeyError, TypeError) as e:
+                logger.error(
+                    f"[{self.workspace}] Unusable doc_status document hydrating "
+                    f"{doc.get('_id')}: {e}"
+                )
+                if strict:
+                    raise
+                continue
         return result
 
     # ------------------------------------------------------------------

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -1457,6 +1457,20 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                 data.pop("error", None)
         return data
 
+    def _os_doc_processing_status_from_source(
+        self, source: dict[str, Any]
+    ) -> DocProcessingStatus:
+        """Normalize a raw OpenSearch ``_source`` into a FULL DocProcessingStatus.
+
+        Single source of the ``_source`` -> :class:`DocProcessingStatus`
+        construction shared by :meth:`get_docs_by_statuses` (via
+        :meth:`_search_all_docs`) and the :meth:`get_full_docs_by_ids`
+        hydration path. Raises ``KeyError``/``TypeError`` on a malformed
+        source; the caller decides strict (raise) vs relaxed (skip).
+        """
+        data = self._prepare_doc_status_data(source)
+        return DocProcessingStatus(**data)
+
     async def initialize(self):
         """Initialize client connection and create the doc-status index."""
         async with get_data_init_lock():
@@ -1926,8 +1940,11 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                         break
                     for hit in hits:
                         try:
-                            data = self._prepare_doc_status_data(hit["_source"])
-                            result[hit["_id"]] = DocProcessingStatus(**data)
+                            result[hit["_id"]] = (
+                                self._os_doc_processing_status_from_source(
+                                    hit["_source"]
+                                )
+                            )
                         except (KeyError, TypeError) as e:
                             logger.error(
                                 f"[{self.workspace}] Error parsing doc {hit['_id']}: {e}"
@@ -2590,6 +2607,74 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
             record = self._scheduling_record_from_hit(interpreted, strict=strict)
             if record is not None:
                 result[requested_id] = record
+        return result
+
+    async def get_full_docs_by_ids(
+        self,
+        doc_ids: Sequence[str],
+        *,
+        strict: bool = False,
+    ) -> dict[str, DocProcessingStatus]:
+        """Batch hydration to FULL DocProcessingStatus via a single mget.
+
+        Mirrors :meth:`get_docs_by_ids` (same ``mget`` by id, same
+        ``_interpret_mget_item`` absent-vs-error discipline) but fetches the
+        COMPLETE ``_source`` -- no ``_source_includes`` projection -- and
+        normalises each hit through
+        :meth:`_os_doc_processing_status_from_source`, so callers see every
+        field (``content_summary`` / ``content_length`` / ``chunks_list`` /
+        ``metadata`` / ...). A confirmed-absent id (``found=false``) is
+        omitted; with ``strict=True`` an unusable present row or any
+        transport/index error fails the WHOLE call rather than returning a
+        partial map (see base contract).
+        """
+        result: dict[str, DocProcessingStatus] = {}
+        ids = list(doc_ids)
+        if not ids:
+            return result
+        if not self._index_ready:
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] doc status index '{self._index_name}' is "
+                f"not ready; cannot confirm absence for a strict batch read"
+            )
+        try:
+            response = await self.client.mget(
+                index=self._index_name,
+                body={"ids": ids},
+            )
+        except OpenSearchException as e:
+            if _is_missing_index_error(e):
+                self._mark_index_missing()
+                raise StorageControlPlaneError(
+                    f"[{self.workspace}] doc status index '{self._index_name}' "
+                    f"unexpectedly missing; cannot confirm absence for a strict "
+                    f"batch read"
+                ) from e
+            logger.error(f"[{self.workspace}] Error batch-reading doc statuses: {e}")
+            raise
+        docs = response.get("docs")
+        if not isinstance(docs, list) or len(docs) != len(ids):
+            raise RuntimeError(
+                f"[{self.workspace}] OpenSearch mget returned "
+                f"{len(docs) if isinstance(docs, list) else 'no'} items "
+                f"for {len(ids)} requested ids"
+            )
+        for requested_id, item in zip(ids, docs):
+            interpreted = _interpret_mget_item(item, requested_id)
+            if interpreted is None:
+                continue  # confirmed absent
+            try:
+                result[requested_id] = self._os_doc_processing_status_from_source(
+                    interpreted["_source"]
+                )
+            except (KeyError, TypeError) as e:
+                logger.error(
+                    f"[{self.workspace}] Unusable doc_status row hydrating "
+                    f"{requested_id}: {e}"
+                )
+                if strict:
+                    raise
+                continue
         return result
 
     # ------------------------------------------------------------------

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -5655,6 +5655,45 @@ class PGDocStatusStorage(DocStatusStorage):
             result[record.id] = record
         return result
 
+    async def get_full_docs_by_ids(
+        self,
+        doc_ids: Sequence[str],
+        *,
+        strict: bool = False,
+    ) -> dict[str, DocProcessingStatus]:
+        """Batch hydration of FULL DocProcessingStatus records (see base contract).
+
+        One indexed round-trip (``SELECT * ... WHERE workspace=$1 AND id =
+        ANY($2)``) mirroring :meth:`get_docs_by_ids`, but reusing the SAME raw
+        -> :class:`DocProcessingStatus` normalisation as
+        :meth:`get_docs_by_statuses` so every full field (content_summary /
+        content_length / chunks_list / metadata / ...) is populated. A missing
+        id is positively confirmed absent (simply not in the result set) and
+        omitted. ``strict=True`` fails the WHOLE call — any asyncpg error
+        propagates out of ``db.query`` and any row that cannot be converted
+        raises — rather than returning a partial mapping the scheduler would
+        mistake for stale ids.
+        """
+        ids = [str(d) for d in doc_ids]
+        if not ids:
+            return {}
+        sql = "SELECT * FROM LIGHTRAG_DOC_STATUS WHERE workspace=$1 AND id = ANY($2)"
+        rows = await self.db.query(sql, [self.workspace, ids], multirows=True) or []
+        result: dict[str, DocProcessingStatus] = {}
+        for element in rows:
+            try:
+                result[element["id"]] = self._pg_doc_processing_status_from_row(element)
+            except (KeyError, TypeError) as e:
+                doc_id_hint = element.get("id", "<unknown>") if element else "<unknown>"
+                logger.error(
+                    f"[{self.workspace}] Skipping document '{doc_id_hint}' — "
+                    f"required field missing or wrong type while parsing DB row: {e!r}"
+                )
+                if strict:
+                    raise
+                continue
+        return result
+
     # ------------------------------------------------------------------
     # Source-conflict listing and explicit CAS repair
     # ------------------------------------------------------------------
@@ -5906,6 +5945,50 @@ class PGDocStatusStorage(DocStatusStorage):
 
         return docs_by_status
 
+    def _pg_doc_processing_status_from_row(
+        self, element: dict[str, Any]
+    ) -> DocProcessingStatus:
+        """Normalise a raw doc_status DB row into a FULL DocProcessingStatus.
+
+        Single source of the raw -> status construction shared by
+        ``get_docs_by_statuses`` and the ``get_full_docs_by_ids`` hydration
+        path (chunks_list / metadata JSON decode, timezone-normalised
+        timestamps, file_path fallback). Raises ``KeyError``/``TypeError`` on a
+        malformed row; the caller decides strict (raise) vs relaxed (skip).
+        """
+        chunks_list = element.get("chunks_list", [])
+        if isinstance(chunks_list, str):
+            try:
+                chunks_list = json.loads(chunks_list)
+            except json.JSONDecodeError:
+                chunks_list = []
+
+        metadata = element.get("metadata", {})
+        if isinstance(metadata, str):
+            try:
+                metadata = json.loads(metadata)
+            except json.JSONDecodeError:
+                metadata = {}
+        if not isinstance(metadata, dict):
+            metadata = {}
+
+        file_path = element.get("file_path") or "no-file-path"
+
+        return DocProcessingStatus(
+            content_summary=element["content_summary"],
+            content_length=element["content_length"],
+            status=element["status"],
+            created_at=self._format_datetime_with_timezone(element["created_at"]),
+            updated_at=self._format_datetime_with_timezone(element["updated_at"]),
+            chunks_count=element["chunks_count"],
+            file_path=file_path,
+            chunks_list=chunks_list,
+            metadata=metadata,
+            error_msg=element.get("error_msg"),
+            track_id=element.get("track_id"),
+            content_hash=element.get("content_hash"),
+        )
+
     async def get_docs_by_statuses(
         self, statuses: list[DocStatus], strict: bool = False
     ) -> dict[str, DocProcessingStatus]:
@@ -5932,42 +6015,7 @@ class PGDocStatusStorage(DocStatusStorage):
         docs: dict[str, DocProcessingStatus] = {}
         for element in result or []:
             try:
-                chunks_list = element.get("chunks_list", [])
-                if isinstance(chunks_list, str):
-                    try:
-                        chunks_list = json.loads(chunks_list)
-                    except json.JSONDecodeError:
-                        chunks_list = []
-
-                metadata = element.get("metadata", {})
-                if isinstance(metadata, str):
-                    try:
-                        metadata = json.loads(metadata)
-                    except json.JSONDecodeError:
-                        metadata = {}
-                if not isinstance(metadata, dict):
-                    metadata = {}
-
-                file_path = element.get("file_path") or "no-file-path"
-
-                docs[element["id"]] = DocProcessingStatus(
-                    content_summary=element["content_summary"],
-                    content_length=element["content_length"],
-                    status=element["status"],
-                    created_at=self._format_datetime_with_timezone(
-                        element["created_at"]
-                    ),
-                    updated_at=self._format_datetime_with_timezone(
-                        element["updated_at"]
-                    ),
-                    chunks_count=element["chunks_count"],
-                    file_path=file_path,
-                    chunks_list=chunks_list,
-                    metadata=metadata,
-                    error_msg=element.get("error_msg"),
-                    track_id=element.get("track_id"),
-                    content_hash=element.get("content_hash"),
-                )
+                docs[element["id"]] = self._pg_doc_processing_status_from_row(element)
             except (KeyError, TypeError) as e:
                 doc_id_hint = element.get("id", "<unknown>") if element else "<unknown>"
                 logger.error(

--- a/lightrag/kg/redis_impl.py
+++ b/lightrag/kg/redis_impl.py
@@ -1034,6 +1034,28 @@ class RedisDocStatusStorage(DocStatusStorage):
         """Get all documents with a specific status"""
         return await self.get_docs_by_statuses([status])
 
+    @staticmethod
+    def _redis_doc_processing_status_from_data(
+        data: dict[str, Any],
+    ) -> DocProcessingStatus:
+        """Normalise a decoded doc_status row into a FULL DocProcessingStatus.
+
+        Single source of the decoded-JSON -> status construction shared by
+        ``get_docs_by_statuses`` and the ``get_full_docs_by_ids`` hydration
+        path. Raises ``KeyError``/``TypeError`` on a malformed row (``TypeError``
+        is what ``DocProcessingStatus(**data)`` raises on missing required
+        fields); the caller decides strict (raise) vs relaxed (skip).
+        """
+        data = data.copy()
+        data.pop("content", None)
+        if "file_path" not in data:
+            data["file_path"] = "no-file-path"
+        if "metadata" not in data:
+            data["metadata"] = {}
+        if "error_msg" not in data:
+            data["error_msg"] = None
+        return DocProcessingStatus(**data)
+
     async def get_docs_by_statuses(
         self, statuses: list[DocStatus], strict: bool = False
     ) -> dict[str, DocProcessingStatus]:
@@ -1073,15 +1095,11 @@ class RedisDocStatusStorage(DocStatusStorage):
                                 if doc_data.get("status") not in status_values:
                                     continue
                                 doc_id = key.split(":", 1)[1]
-                                data = doc_data.copy()
-                                data.pop("content", None)
-                                if "file_path" not in data:
-                                    data["file_path"] = "no-file-path"
-                                if "metadata" not in data:
-                                    data["metadata"] = {}
-                                if "error_msg" not in data:
-                                    data["error_msg"] = None
-                                result[doc_id] = DocProcessingStatus(**data)
+                                result[doc_id] = (
+                                    self._redis_doc_processing_status_from_data(
+                                        doc_data
+                                    )
+                                )
                             except (json.JSONDecodeError, KeyError, TypeError) as e:
                                 # TypeError is what DocProcessingStatus(**data)
                                 # actually raises on missing required fields —
@@ -1986,6 +2004,47 @@ class RedisDocStatusStorage(DocStatusStorage):
             record = self._scheduling_record_from_row(doc_id, row, strict=strict)
             if record is not None:
                 result[doc_id] = record
+        return result
+
+    async def get_full_docs_by_ids(
+        self,
+        doc_ids: Sequence[str],
+        *,
+        strict: bool = False,
+    ) -> dict[str, DocProcessingStatus]:
+        """Batch hydration to FULL DocProcessingStatus by doc id (see base).
+
+        A single pipelined ``GET`` per id straight off the primary rows (same
+        by-id read mechanism as ``get_docs_by_ids``): a ``None`` is a confirmed
+        absence and is omitted. The pipeline is all-or-nothing at transport, so
+        any server/transport error fails the WHOLE call — the scheduler never
+        receives a partial mapping. ``strict=True`` additionally raises on an
+        undecodable/unconvertible row; ``strict=False`` logs and skips it.
+        Results are FULL records reusing the same raw -> DocProcessingStatus
+        normalisation as ``get_docs_by_statuses``."""
+        if not doc_ids:
+            return {}
+        ids = list(doc_ids)
+        async with self._get_redis_connection() as redis:
+            pipe = redis.pipeline()
+            for doc_id in ids:
+                pipe.get(f"{self.final_namespace}:{doc_id}")
+            raws = await pipe.execute()
+        result: dict[str, DocProcessingStatus] = {}
+        for doc_id, raw in zip(ids, raws):
+            if raw is None:
+                continue  # confirmed absent
+            try:
+                data = json.loads(raw)
+                result[doc_id] = self._redis_doc_processing_status_from_data(data)
+            except (json.JSONDecodeError, KeyError, TypeError) as e:
+                logger.error(
+                    f"[{self.workspace}] Unusable doc_status row hydrating "
+                    f"{doc_id} in get_full_docs_by_ids: {e}"
+                )
+                if strict:
+                    raise
+                continue
         return result
 
     # ------------------------------------------------------------------

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -51,6 +51,7 @@ from lightrag.constants import (
     DEFAULT_MAX_ENTITY_TOKENS,
     DEFAULT_MAX_RELATION_TOKENS,
     DEFAULT_MAX_TOTAL_TOKENS,
+    ROLLBACK_REPORT_SAMPLE_CAP,
     DEFAULT_SUMMARY_PRIORITY,
     DEFAULT_COSINE_THRESHOLD,
     DEFAULT_RELATED_CHUNK_NUMBER,
@@ -2275,7 +2276,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         *,
         pipeline_status: dict | None = None,
         pipeline_status_lock: Any | None = None,
-    ) -> dict[str, list[str]]:
+    ) -> dict[str, Any]:
         """Roll back every failed/stale custom-chunk operation (issue #3400 P4).
 
         The administrative escape hatch invoked at the start of
@@ -2306,7 +2307,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         scan retries it. Absent objects are idempotent no-ops, but success is
         never reported merely because something was already missing.
 
-        Returns ``{"rolled_back": [...], "failed": [...]}`` doc-id lists.
+        Returns ``{"rolled_back_count": int, "failed_count": int,
+        "rolled_back_sample": [...], "failed_sample": [...]}``. Counts are
+        exact; the id lists are bounded to ``ROLLBACK_REPORT_SAMPLE_CAP``,
+        because a report that grows one entry per journaled document would
+        reintroduce the O(N) accumulation this sweep exists to remove.
         """
         if pipeline_status is None or pipeline_status_lock is None:
             pipeline_status = await get_namespace_data(
@@ -2316,17 +2321,83 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 "pipeline_status", workspace=self.workspace
             )
 
+        rolled_back_count = 0
+        failed_count = 0
+        rolled_back_sample: list[str] = []
+        failed_sample: list[str] = []
+        doc_lock_namespace = (
+            f"{self.workspace}:DocPatch" if self.workspace else "DocPatch"
+        )
+
+        async def _roll_back_batch(doc_ids: list[str]) -> None:
+            """Roll back one page's journaled docs, accumulating only counts."""
+            nonlocal rolled_back_count, failed_count
+            for doc_id in doc_ids:
+                async with get_storage_keyed_lock(
+                    [doc_id], namespace=doc_lock_namespace, enable_logging=False
+                ):
+                    # Re-read under the lock: the SDK may have resumed (and
+                    # committed) the operation between discovery and here.
+                    row = await self.doc_status.get_by_id(doc_id)
+                    journal = doc_status_custom_chunk_patch(row)
+                    if journal is None:
+                        continue
+                    try:
+                        await self._rollback_one_custom_chunk_patch(
+                            doc_id,
+                            row,
+                            journal,
+                            pipeline_status=pipeline_status,
+                            pipeline_status_lock=pipeline_status_lock,
+                        )
+                        rolled_back_count += 1
+                        if len(rolled_back_sample) < ROLLBACK_REPORT_SAMPLE_CAP:
+                            rolled_back_sample.append(doc_id)
+                        log_message = (
+                            f"[rollback] Rolled back custom-chunk operation "
+                            f"{journal.get('operation_id')} on {doc_id} "
+                            f"(mode: {journal.get('mode', 'patch')})"
+                        )
+                        logger.info(log_message)
+                        async with pipeline_status_lock:
+                            pipeline_status["latest_message"] = log_message
+                            pipeline_status["history_messages"].append(log_message)
+                    except Exception as rollback_error:
+                        # Journal and FAILED status remain; the next scan retries.
+                        failed_count += 1
+                        if len(failed_sample) < ROLLBACK_REPORT_SAMPLE_CAP:
+                            failed_sample.append(doc_id)
+                        log_message = (
+                            f"[rollback] Failed to roll back custom-chunk "
+                            f"operation on {doc_id}: {rollback_error}"
+                        )
+                        logger.error(log_message)
+                        async with pipeline_status_lock:
+                            pipeline_status["latest_message"] = log_message
+                            pipeline_status["history_messages"].append(log_message)
+
         # Scheduling-control-plane discovery, memory-bounded (LR2 Phase 2):
         # page the FAILED/PROCESSING keyset instead of materializing every such
-        # row, collecting journaled ids straight from the lightweight page's
-        # has_custom_chunk_journal flag (no per-row hydration — journaled docs
-        # are rare, so only the small id list accumulates). strict so a
-        # mid-pagination or per-record backend failure raises instead of
-        # returning a partial candidate set (which would roll back some
-        # journaled docs, silently miss the rest, and report the scan done);
-        # the scan-time caller catches the raise and keeps the journal/FAILED
-        # rows for the next scan — abort-and-retry beats partial recovery.
-        journaled_ids: list[str] = []
+        # row, taking journaled ids straight from the lightweight page's
+        # has_custom_chunk_journal flag (no per-row hydration).
+        #
+        # Each page is rolled back BEFORE the next is fetched, so nothing
+        # proportional to the journaled-document count is ever held — collecting
+        # every id first would have kept the sweep O(N) on the assumption that
+        # journaled docs are rare, which is a workload guess, not a bound.
+        # Interleaving is safe against the live-view keyset: the sort key
+        # ``(created_at, id)`` is immutable (``update_doc_status_fields``
+        # refuses ``created_at``), and a rollback only ever leaves the
+        # FAILED/PROCESSING set — it flips a row to PROCESSED or deletes it, and
+        # never creates one — so it can only touch rows the sweep has already
+        # consumed and passed.
+        #
+        # strict so a mid-pagination or per-record backend failure raises rather
+        # than silently ending the sweep early and reporting the scan done. Docs
+        # rolled back before that raise stay rolled back: each one is an
+        # independent, idempotent unit committed under its own lock, and its
+        # journal is gone, so the next scan simply skips it and picks up the
+        # rest.
         page_size = getattr(self, "pipeline_scheduling_page_size", 0)
         if page_size > 0:
             position: CursorPosition = CURSOR_START
@@ -2337,10 +2408,12 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     position=position,
                     strict=True,
                 )
-                journaled_ids.extend(
-                    doc_id
-                    for doc_id, record in page.docs.items()
-                    if record.has_custom_chunk_journal
+                await _roll_back_batch(
+                    [
+                        doc_id
+                        for doc_id, record in page.docs.items()
+                        if record.has_custom_chunk_journal
+                    ]
                 )
                 if page.next_position is CURSOR_END:
                     break
@@ -2350,61 +2423,20 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             candidates = await self.doc_status.get_docs_by_statuses(
                 [DocStatus.FAILED, DocStatus.PROCESSING], strict=True
             )
-            journaled_ids = [
-                doc_id
-                for doc_id, status_doc in candidates.items()
-                if doc_status_custom_chunk_patch(status_doc) is not None
-            ]
+            await _roll_back_batch(
+                [
+                    doc_id
+                    for doc_id, status_doc in candidates.items()
+                    if doc_status_custom_chunk_patch(status_doc) is not None
+                ]
+            )
 
-        rolled_back: list[str] = []
-        failed: list[str] = []
-        if not journaled_ids:
-            return {"rolled_back": rolled_back, "failed": failed}
-
-        doc_lock_namespace = (
-            f"{self.workspace}:DocPatch" if self.workspace else "DocPatch"
-        )
-        for doc_id in journaled_ids:
-            async with get_storage_keyed_lock(
-                [doc_id], namespace=doc_lock_namespace, enable_logging=False
-            ):
-                # Re-read under the lock: the SDK may have resumed (and
-                # committed) the operation between discovery and here.
-                row = await self.doc_status.get_by_id(doc_id)
-                journal = doc_status_custom_chunk_patch(row)
-                if journal is None:
-                    continue
-                try:
-                    await self._rollback_one_custom_chunk_patch(
-                        doc_id,
-                        row,
-                        journal,
-                        pipeline_status=pipeline_status,
-                        pipeline_status_lock=pipeline_status_lock,
-                    )
-                    rolled_back.append(doc_id)
-                    log_message = (
-                        f"[rollback] Rolled back custom-chunk operation "
-                        f"{journal.get('operation_id')} on {doc_id} "
-                        f"(mode: {journal.get('mode', 'patch')})"
-                    )
-                    logger.info(log_message)
-                    async with pipeline_status_lock:
-                        pipeline_status["latest_message"] = log_message
-                        pipeline_status["history_messages"].append(log_message)
-                except Exception as rollback_error:
-                    # Journal and FAILED status remain; the next scan retries.
-                    failed.append(doc_id)
-                    log_message = (
-                        f"[rollback] Failed to roll back custom-chunk "
-                        f"operation on {doc_id}: {rollback_error}"
-                    )
-                    logger.error(log_message)
-                    async with pipeline_status_lock:
-                        pipeline_status["latest_message"] = log_message
-                        pipeline_status["history_messages"].append(log_message)
-
-        return {"rolled_back": rolled_back, "failed": failed}
+        return {
+            "rolled_back_count": rolled_back_count,
+            "failed_count": failed_count,
+            "rolled_back_sample": rolled_back_sample,
+            "failed_sample": failed_sample,
+        }
 
     async def _rollback_one_custom_chunk_patch(
         self,

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -79,6 +79,7 @@ from lightrag.constants import (
     DEFAULT_QUEUE_SIZE_PARSE,
     DEFAULT_QUEUE_SIZE_ANALYZE,
     DEFAULT_QUEUE_SIZE_INSERT,
+    DEFAULT_PIPELINE_SCHEDULING_PAGE_SIZE,
     DEFAULT_FILE_PATH_MORE_PLACEHOLDER,
 )
 from lightrag.utils import get_env_value
@@ -102,9 +103,12 @@ from lightrag.kg.shared_storage import (
 )
 
 from lightrag.base import (
+    CURSOR_END,
+    CURSOR_START,
     BaseGraphStorage,
     BaseKVStorage,
     BaseVectorStorage,
+    CursorPosition,
     DocProcessingStatus,
     DocStatus,
     DocStatusStorage,
@@ -680,6 +684,22 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         default=get_env_value("QUEUE_SIZE_INSERT", DEFAULT_QUEUE_SIZE_INSERT, int)
     )
 
+    pipeline_scheduling_page_size: int = field(
+        default=get_env_value(
+            "PIPELINE_SCHEDULING_PAGE_SIZE",
+            DEFAULT_PIPELINE_SCHEDULING_PAGE_SIZE,
+            int,
+        )
+    )
+    """Bounded scheduling page size (LR2 Phase 2).
+
+    The scheduler sweeps the doc_status backlog through keyset pages of this
+    many records so memory stays O(page_size + inflight) instead of O(backlog).
+    ``0`` disables paging: one page holds the whole result set, exactly
+    reproducing the legacy single-scan behaviour. Negative values are rejected
+    at initialization.
+    """
+
     max_graph_nodes: int = field(
         default=get_env_value("MAX_GRAPH_NODES", DEFAULT_MAX_GRAPH_NODES, int)
     )
@@ -994,6 +1014,14 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         self._replace_addon_params(addon_params, mark_dirty=False)
         self._apply_chunk_size_overlay()
         self._refresh_addon_params_cache()
+
+        # Bounded scheduling page size: 0 disables paging (single-scan legacy
+        # behaviour); a negative value is a misconfiguration, fail fast.
+        if self.pipeline_scheduling_page_size < 0:
+            raise ValueError(
+                "PIPELINE_SCHEDULING_PAGE_SIZE must be >= 0 (0 disables "
+                f"paging); got {self.pipeline_scheduling_page_size}"
+            )
 
         # Handle deprecated parameters
         if self.log_level is not None:
@@ -2288,20 +2316,45 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 "pipeline_status", workspace=self.workspace
             )
 
-        # Scheduling-control-plane discovery: strict so a mid-pagination or
-        # per-record backend failure raises instead of returning a partial
-        # candidate set (which would roll back some journaled docs, silently
-        # miss the rest, and report the scan done). The scan-time caller
-        # catches the raise and keeps the journal/FAILED rows for the next
-        # scan — abort-and-retry beats partial administrative recovery.
-        candidates = await self.doc_status.get_docs_by_statuses(
-            [DocStatus.FAILED, DocStatus.PROCESSING], strict=True
-        )
-        journaled_ids = [
-            doc_id
-            for doc_id, status_doc in candidates.items()
-            if doc_status_custom_chunk_patch(status_doc) is not None
-        ]
+        # Scheduling-control-plane discovery, memory-bounded (LR2 Phase 2):
+        # page the FAILED/PROCESSING keyset instead of materializing every such
+        # row, collecting journaled ids straight from the lightweight page's
+        # has_custom_chunk_journal flag (no per-row hydration — journaled docs
+        # are rare, so only the small id list accumulates). strict so a
+        # mid-pagination or per-record backend failure raises instead of
+        # returning a partial candidate set (which would roll back some
+        # journaled docs, silently miss the rest, and report the scan done);
+        # the scan-time caller catches the raise and keeps the journal/FAILED
+        # rows for the next scan — abort-and-retry beats partial recovery.
+        journaled_ids: list[str] = []
+        page_size = getattr(self, "pipeline_scheduling_page_size", 0)
+        if page_size > 0:
+            position: CursorPosition = CURSOR_START
+            while True:
+                page = await self.doc_status.get_docs_by_statuses_page(
+                    [DocStatus.FAILED, DocStatus.PROCESSING],
+                    limit=page_size,
+                    position=position,
+                    strict=True,
+                )
+                journaled_ids.extend(
+                    doc_id
+                    for doc_id, record in page.docs.items()
+                    if record.has_custom_chunk_journal
+                )
+                if page.next_position is CURSOR_END:
+                    break
+                position = page.next_position
+        else:
+            # Paging disabled (PIPELINE_SCHEDULING_PAGE_SIZE=0): legacy scan.
+            candidates = await self.doc_status.get_docs_by_statuses(
+                [DocStatus.FAILED, DocStatus.PROCESSING], strict=True
+            )
+            journaled_ids = [
+                doc_id
+                for doc_id, status_doc in candidates.items()
+                if doc_status_custom_chunk_patch(status_doc) is not None
+            ]
 
         rolled_back: list[str] = []
         failed: list[str] = []

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -29,7 +29,13 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-from lightrag.base import DocProcessingStatus, DocStatus
+from lightrag.base import (
+    CURSOR_END,
+    CURSOR_START,
+    CursorPosition,
+    DocProcessingStatus,
+    DocStatus,
+)
 from lightrag.constants import (
     FULL_DOCS_FORMAT_LIGHTRAG,
     FULL_DOCS_FORMAT_PENDING_PARSE,
@@ -165,6 +171,12 @@ class PipelineNextStep(Enum):
     # refetch drains a bounded chunk and lets the strict scan decide: live
     # docs come back as the next batch, provably-stale messages are dropped.
     CONTINUE_DOCUMENT = "continue_document"
+    # The in-progress bounded AUTO sweep has more pages (its keyset cursor is
+    # not yet CURSOR_END).  No wake-up signal is consumed: the run simply
+    # fetches the next page of the SAME sweep before honouring quiescence
+    # signals, so a huge PENDING backlog drains page-by-page while cancellation
+    # and manual retry still preempt at every page boundary (LR2 Phase 2 §6.3).
+    CONTINUE_SWEEP_PAGE = "continue_sweep_page"
     # Cancellation pending: the run must stop WITHOUT consuming any wake-up
     # signal — the ingress is fully retained for the next explicit trigger.
     CANCELLED = "cancelled"
@@ -1325,11 +1337,19 @@ class _PipelineMixin:
             # peeked and stays sticky on its own.)
             uncommitted_wakeup = absorbed_auto_rescan
 
-            to_process_docs: dict[
-                str, DocProcessingStatus
-            ] = await self.doc_status.get_docs_by_statuses(
-                list(initial_statuses), strict=True
-            )
+            # Bounded scheduling sweep (LR2 Phase 2): the initial scan is now
+            # the first PAGE of a keyset sweep. ``sweep_statuses`` /
+            # ``sweep_cursor`` are threaded through every quiescence decision so
+            # the run drains the KNOWN backlog page-by-page (CONTINUE_SWEEP_PAGE)
+            # before honouring auto-rescan/document signals. A manual sweep and
+            # PIPELINE_SCHEDULING_PAGE_SIZE=0 both collapse to a single
+            # CURSOR_END page (legacy single-scan; see _next_scheduling_page).
+            sweep_statuses = initial_statuses
+            to_process_docs: dict[str, DocProcessingStatus]
+            (
+                to_process_docs,
+                sweep_cursor,
+            ) = await self._next_scheduling_page(sweep_statuses, CURSOR_START)
 
             # The scan is complete: an empty result means the signal was fully
             # SERVED, not lost — release ownership.  A non-empty result keeps
@@ -1353,7 +1373,7 @@ class _PipelineMixin:
                 # that gap is not stranded in PENDING.
                 logger.info("No documents to process")
                 decision = await self._decide_pipeline_next_step(
-                    pipeline_status, pipeline_status_lock, ingress
+                    pipeline_status, pipeline_status_lock, ingress, sweep_cursor
                 )
                 if decision.step is PipelineNextStep.RELEASED:
                     # No pending work: slot released silently, finally is a no-op.
@@ -1364,10 +1384,15 @@ class _PipelineMixin:
                     # the finally resets the cancellation state (surfacing the
                     # internal halt when applicable) and releases the slot.
                     return
-                # A wake-up signal was pending: re-fetch per the decision and
-                # fall through into the loop to process it.
-                to_process_docs, pending_manual_ack = await self._refetch_for_decision(
-                    decision, ingress
+                # A wake-up signal (or an unfinished sweep) was pending: re-fetch
+                # per the decision and fall through into the loop to process it.
+                (
+                    to_process_docs,
+                    sweep_statuses,
+                    sweep_cursor,
+                    pending_manual_ack,
+                ) = await self._refetch_for_decision(
+                    decision, sweep_statuses, sweep_cursor, ingress
                 )
                 uncommitted_wakeup = decision.step in (
                     PipelineNextStep.CONTINUE_AUTO,
@@ -1431,7 +1456,7 @@ class _PipelineMixin:
                     pipeline_status["latest_message"] = log_message
                     pipeline_status["history_messages"].append(log_message)
                     decision = await self._decide_pipeline_next_step(
-                        pipeline_status, pipeline_status_lock, ingress
+                        pipeline_status, pipeline_status_lock, ingress, sweep_cursor
                     )
                     if decision.step is PipelineNextStep.RELEASED:
                         busy_released_in_loop = True
@@ -1442,8 +1467,12 @@ class _PipelineMixin:
                         continue  # loop-top handler does the cancel bookkeeping
                     (
                         to_process_docs,
+                        sweep_statuses,
+                        sweep_cursor,
                         pending_manual_ack,
-                    ) = await self._refetch_for_decision(decision, ingress)
+                    ) = await self._refetch_for_decision(
+                        decision, sweep_statuses, sweep_cursor, ingress
+                    )
                     uncommitted_wakeup = decision.step in (
                         PipelineNextStep.CONTINUE_AUTO,
                         PipelineNextStep.CONTINUE_DOCUMENT,
@@ -1478,7 +1507,7 @@ class _PipelineMixin:
                     pipeline_status["latest_message"] = log_message
                     pipeline_status["history_messages"].append(log_message)
                     decision = await self._decide_pipeline_next_step(
-                        pipeline_status, pipeline_status_lock, ingress
+                        pipeline_status, pipeline_status_lock, ingress, sweep_cursor
                     )
                     if decision.step is PipelineNextStep.RELEASED:
                         busy_released_in_loop = True
@@ -1489,8 +1518,12 @@ class _PipelineMixin:
                         continue  # loop-top handler does the cancel bookkeeping
                     (
                         to_process_docs,
+                        sweep_statuses,
+                        sweep_cursor,
                         pending_manual_ack,
-                    ) = await self._refetch_for_decision(decision, ingress)
+                    ) = await self._refetch_for_decision(
+                        decision, sweep_statuses, sweep_cursor, ingress
+                    )
                     uncommitted_wakeup = decision.step in (
                         PipelineNextStep.CONTINUE_AUTO,
                         PipelineNextStep.CONTINUE_DOCUMENT,
@@ -1528,7 +1561,7 @@ class _PipelineMixin:
                 # WHOLE run — no new epoch — with the ingress fully retained
                 # for the next explicit trigger.
                 decision = await self._decide_pipeline_next_step(
-                    pipeline_status, pipeline_status_lock, ingress
+                    pipeline_status, pipeline_status_lock, ingress, sweep_cursor
                 )
                 if decision.step is PipelineNextStep.RELEASED:
                     busy_released_in_loop = True
@@ -1547,9 +1580,15 @@ class _PipelineMixin:
                 pipeline_status["latest_message"] = log_message
                 pipeline_status["history_messages"].append(log_message)
 
-                # Check for pending documents again, per the decision's tuple
-                to_process_docs, pending_manual_ack = await self._refetch_for_decision(
-                    decision, ingress
+                # Fetch the next batch: the next page of the current sweep
+                # (CONTINUE_SWEEP_PAGE) or a fresh sweep per the decision's tuple.
+                (
+                    to_process_docs,
+                    sweep_statuses,
+                    sweep_cursor,
+                    pending_manual_ack,
+                ) = await self._refetch_for_decision(
+                    decision, sweep_statuses, sweep_cursor, ingress
                 )
                 uncommitted_wakeup = decision.step in (
                     PipelineNextStep.CONTINUE_AUTO,
@@ -1840,6 +1879,27 @@ class _PipelineMixin:
             return True
         return False
 
+    def _feeder_epoch_full(self, ctx: "_BatchRunContext") -> bool:
+        """True when this epoch has admitted ``PIPELINE_SCHEDULING_PAGE_SIZE``
+        documents (``inflight`` + ``routing``) — the single-epoch bound of
+        LR2 §6.4.
+
+        ``inflight_doc_ids`` grows monotonically within a batch (it is the
+        dedup set of everything routed into this epoch, never shrunk on
+        completion), so this counts total admissions this epoch, not live
+        concurrency. Once the count reaches the page size the feeder stops
+        admitting and the remaining mailbox / doc_status work continues in the
+        NEXT epoch (a fresh page via CONTINUE_SWEEP_PAGE, or a CONTINUE_DOCUMENT
+        refetch). Disabled when paging is off (``page_size <= 0``) — the feeder
+        then admits freely, exactly as before Phase 2. Read without the lock: a
+        single-threaded ``len`` is a consistent snapshot and this is a soft
+        backpressure gate, not a hard invariant.
+        """
+        page_size = getattr(self, "pipeline_scheduling_page_size", 0)
+        if page_size <= 0:
+            return False
+        return len(ctx.inflight_doc_ids) + len(ctx.routing_doc_ids) >= page_size
+
     async def _pipeline_feeder(self, ctx: "_BatchRunContext", ingress) -> None:
         """Route documents that arrive DURING a batch into its parse queues so
         they process without waiting for the batch barrier.
@@ -1894,11 +1954,27 @@ class _PipelineMixin:
                     # PENDING docs.
                     if self._feeder_should_yield(ctx, ingress, check_auto=True):
                         return
+                    # Single-epoch bound (LR2 §6.4): once this batch holds
+                    # PIPELINE_SCHEDULING_PAGE_SIZE docs the feeder stops
+                    # admitting; the rest continues in the next epoch (a fresh
+                    # page, or a CONTINUE_DOCUMENT refetch of the mailbox).
+                    if self._feeder_epoch_full(ctx):
+                        return
                     batch = await self._feeder_next_batch(ingress)
-                    if any(msg.doc_id for msg in batch):
-                        pending = await self.doc_status.get_docs_by_statuses(
-                            [DocStatus.PENDING], strict=True
+                    drained_ids = [msg.doc_id for msg in batch if msg.doc_id]
+                    if drained_ids:
+                        # Bounded to THIS drain's ids (not the whole PENDING
+                        # set): hydrate full status, keep only rows still
+                        # PENDING. A drained doc now processed/failed/deleted is
+                        # simply absent, and _route_one drops it as stale.
+                        hydrated = await self.doc_status.get_full_docs_by_ids(
+                            drained_ids, strict=True
                         )
+                        pending = {
+                            doc_id: doc
+                            for doc_id, doc in hydrated.items()
+                            if getattr(doc, "status", None) == DocStatus.PENDING
+                        }
                         for reached, msg in enumerate(batch):
                             # Honor an in-flight cancel/manual WITHIN one doc
                             # (auto-rescan is coarser — checked per drain above).
@@ -1906,6 +1982,11 @@ class _PipelineMixin:
                                 ctx, ingress, check_auto=False
                             ):
                                 deferred.extend(batch[reached:])  # unprocessed tail
+                                return
+                            # Re-check the epoch bound mid-drain: earlier
+                            # admissions in THIS loop may have reached the cap.
+                            if self._feeder_epoch_full(ctx):
+                                deferred.extend(batch[reached:])
                                 return
                             if not await self._route_one(ctx, msg, pending):
                                 deferred.append(msg)  # SKIP — survives to teardown
@@ -2371,11 +2452,77 @@ class _PipelineMixin:
 
         return to_process_docs
 
+    async def _next_scheduling_page(
+        self,
+        statuses,
+        position: CursorPosition,
+    ) -> tuple[dict[str, DocProcessingStatus], CursorPosition]:
+        """Fetch ONE bounded scheduling page and hydrate it to full status.
+
+        Returns ``(to_process_docs, next_position)`` — the full
+        :class:`DocProcessingStatus` map for the page, plus the cursor to pass
+        back for the next page (``next_position is CURSOR_END`` ends the
+        sweep). Memory stays O(page_size): the lightweight keyset page only
+        carries ids/status, and the survivors are hydrated to full rows via
+        ``get_full_docs_by_ids`` right before routing.
+
+        Two paths collapse to the LEGACY single-scan (one page terminating at
+        ``CURSOR_END``), so ``PIPELINE_SCHEDULING_PAGE_SIZE=0`` and every manual
+        retry sweep behave byte-for-byte as before Phase 2:
+
+        * ``page_size <= 0`` — paging disabled by configuration;
+        * ``DocStatus.FAILED in statuses`` — a MANUAL retry sweep. The manual
+          ACK contract requires every FAILED→PENDING reset to persist *before*
+          the request is ACKed; a multi-page manual sweep would ACK after the
+          first page while later pages still hold un-reset FAILED rows. Manual
+          backlog is bounded by the FAILED count today and bounded properly by
+          Phase 3's exclusive reset, so manual stays single-scan here.
+
+        The strict page + strict hydration are a complete-or-raise pair: any
+        backend error propagates so the caller neither advances the cursor nor
+        silently drops docs (they stay PENDING for the next sweep).
+        """
+        page_size = getattr(self, "pipeline_scheduling_page_size", 0)
+        paged = page_size > 0 and DocStatus.FAILED not in statuses
+        if not paged:
+            docs = await self.doc_status.get_docs_by_statuses(
+                list(statuses), strict=True
+            )
+            return docs, CURSOR_END
+
+        page = await self.doc_status.get_docs_by_statuses_page(
+            list(statuses),
+            limit=page_size,
+            position=position,
+            strict=True,
+        )
+        if not page.docs:
+            # A fully-filtered page is not termination — the cursor still
+            # advances (or is CURSOR_END); return the empty map and let the
+            # caller loop on next_position.
+            return {}, page.next_position
+
+        hydrated = await self.doc_status.get_full_docs_by_ids(
+            list(page.docs.keys()), strict=True
+        )
+        # Keep only rows still in the requested statuses (matches the legacy
+        # get_docs_by_statuses view): a row raced out of the set between the
+        # page and its hydration is no longer routable. str-enum equality lets
+        # a raw string or a DocStatus member both match.
+        status_values = {s.value for s in statuses}
+        to_process_docs = {
+            doc_id: doc
+            for doc_id, doc in hydrated.items()
+            if getattr(doc, "status", None) in status_values
+        }
+        return to_process_docs, page.next_position
+
     async def _decide_pipeline_next_step(
         self,
         pipeline_status: dict,
         pipeline_status_lock,
         ingress,
+        sweep_cursor: CursorPosition = CURSOR_END,
     ) -> PipelineNextDecision:
         """Atomic quiescence decision: continue for a pending wake-up signal
         or release ``busy`` in the same critical section.
@@ -2439,6 +2586,14 @@ class _PipelineMixin:
                     PipelineNextStep.CONTINUE_MANUAL,
                     manual_request_id=manual_msg.request_id,
                 )
+            # The in-progress bounded sweep has more pages: finish draining the
+            # KNOWN backlog before consuming any quiescence signal. Preempted
+            # by cancellation and manual retry above (LR2 §6.3 "无 manual 时继续
+            # cursor"); consumes nothing, so auto-rescan/document stay pending
+            # for when the cursor reaches CURSOR_END. Collapses to a no-op when
+            # paging is off (cursor is CURSOR_END after a single-scan page).
+            if sweep_cursor is not CURSOR_END:
+                return PipelineNextDecision(PipelineNextStep.CONTINUE_SWEEP_PAGE)
             if ingress.consume_auto_rescan():
                 return PipelineNextDecision(PipelineNextStep.CONTINUE_AUTO)
             if ingress.counts().get("documents"):
@@ -2449,53 +2604,82 @@ class _PipelineMixin:
     async def _refetch_for_decision(
         self,
         decision: PipelineNextDecision,
+        sweep_statuses,
+        sweep_cursor: CursorPosition,
         ingress,
-    ) -> tuple[dict[str, DocProcessingStatus], str | None]:
-        """Strict doc_status refetch for a CONTINUE_* decision.
+    ) -> tuple[dict[str, DocProcessingStatus], tuple, CursorPosition, str | None]:
+        """Fetch the next batch for a CONTINUE_* decision (bounded, Phase 2).
 
-        Selects the status tuple by decision kind — manual continuations are
-        the only path that may pull FAILED documents back in — and restores
-        the consumed wake-up signal on failure: a CONTINUE_AUTO whose strict
-        query raises re-arms the auto-rescan flag before propagating (the
-        signal was already consumed in the decision), while a manual request
-        was only peeked and stays sticky on its own.
+        Returns ``(docs, next_statuses, next_cursor, pending_manual_ack)``:
 
-        CONTINUE_DOCUMENT resolves resident document messages with the same
-        drain→verify protocol the feeder uses, at the supervisor's quiescence
-        point: a bounded destructive drain FIRST, then the strict scan.  The
-        order is the correctness anchor — every drained message's doc that is
-        still live (its PENDING row persisted before its publish, which
-        preceded the drain) is necessarily in the scan result and comes back
-        as the next batch, so a drained message never needs re-publishing;
-        one absent from the scan is PROVABLY stale (terminal/FAILED/deleted —
-        FAILED is manual-only by ruling) and is compacted, which is what
-        keeps a stale notification from holding ``busy`` forever (the
-        has_work-only exit would otherwise livelock on it).  Messages
-        published after the drain stay in the mailbox for the next decision.
-        Crash/failure safety mirrors the feeder's drain: a strict-scan
-        failure re-publishes the drained messages and arms auto-rescan as a
-        backstop before propagating; a SIGKILL — or a Manager response lost
-        AFTER the server executed the drain (at-most-once RPC) — loses only
-        messages whose PENDING rows the next run's initial scan recovers.
+        * ``docs`` — the hydrated full-status map for the batch to process;
+        * ``next_statuses`` / ``next_cursor`` — the sweep state the caller
+          threads back into the next ``_decide``/refetch (``next_cursor is
+          CURSOR_END`` means this sweep is exhausted, so the next quiescence
+          decision falls through to auto-rescan/document/release);
+        * ``pending_manual_ack`` — the request id the caller must ACK once the
+          FAILED→PENDING resets persist (post-validation), or immediately on a
+          legitimately-empty complete result.
 
-        Returns ``(docs, pending_manual_ack)`` where ``pending_manual_ack``
-        is the request id the caller must ACK once the FAILED→PENDING resets
-        persist (post-validation), or immediately on a legitimately-empty
-        complete result.
+        The four continuations:
+
+        * **CONTINUE_SWEEP_PAGE** — advance the SAME sweep to its next page via
+          :meth:`_next_scheduling_page`. Consumes no signal; a page-fetch
+          failure does NOT advance the cursor and arms auto-rescan so the
+          remaining backlog is recovered (LR2 §6.3).
+        * **CONTINUE_MANUAL** — start a fresh MANUAL sweep from ``CURSOR_START``
+          (single-scan: FAILED is in the tuple, so ``_next_scheduling_page``
+          returns one CURSOR_END page — the manual ACK contract needs every
+          reset persisted before ACK).
+        * **CONTINUE_AUTO** — start a fresh bounded AUTO sweep from
+          ``CURSOR_START``. The signal was consumed in the decision, so a
+          first-page failure re-arms auto-rescan before propagating.
+        * **CONTINUE_DOCUMENT** — bounded destructive drain of resident
+          document messages FIRST, then a fresh bounded AUTO sweep from
+          ``CURSOR_START``. Drain-before-scan is the correctness anchor: every
+          drained message's doc that is still live (its PENDING row persisted
+          before its publish, which preceded the drain) is a PENDING row the
+          multi-page sweep necessarily reaches, so a drained message never
+          needs re-publishing; a provably-stale one (terminal/deleted; FAILED
+          is manual-only by ruling) is compacted, which keeps a stale
+          notification from holding ``busy`` forever. A sweep-start failure
+          re-publishes the drained messages and arms auto-rescan as a backstop
+          before propagating; a SIGKILL — or a Manager response lost AFTER the
+          drain executed (at-most-once RPC) — loses only messages whose PENDING
+          rows the next run's initial scan recovers.
         """
-        if decision.step is PipelineNextStep.CONTINUE_MANUAL:
+        step = decision.step
+
+        # (A) Continue the current bounded sweep — same statuses, next page.
+        if step is PipelineNextStep.CONTINUE_SWEEP_PAGE:
+            try:
+                docs, next_cursor = await self._next_scheduling_page(
+                    sweep_statuses, sweep_cursor
+                )
+            except BaseException:
+                try:
+                    ingress.request_auto_rescan()
+                except BaseException as compensation_error:
+                    logger.warning(
+                        "[pipeline] failed to arm auto-rescan after a paged "
+                        "sweep refetch failure; the remaining backlog is "
+                        f"recovered by the NEXT explicit trigger: {compensation_error}"
+                    )
+                raise
+            return docs, sweep_statuses, next_cursor, None
+
+        # (B) Start a FRESH sweep from CURSOR_START. CONTINUE_DOCUMENT drains
+        # the mailbox first (bounded); a deeper backlog re-triggers on the next
+        # decision.
+        drained: list[PipelineIngressMessage] = []
+        if step is PipelineNextStep.CONTINUE_MANUAL:
             statuses = _MANUAL_RETRY_DOC_STATUSES
         else:
             statuses = _AUTO_RESUME_DOC_STATUSES
-        drained: list[PipelineIngressMessage] = []
-        if decision.step is PipelineNextStep.CONTINUE_DOCUMENT:
-            # Drain BEFORE the scan (see docstring proof). Bounded: a deeper
-            # backlog re-triggers CONTINUE_DOCUMENT on the next decision.
+        if step is PipelineNextStep.CONTINUE_DOCUMENT:
             drained = ingress.drain_documents(limit=_FEEDER_DRAIN_LIMIT)
         try:
-            docs = await self.doc_status.get_docs_by_statuses(
-                list(statuses), strict=True
-            )
+            docs, next_cursor = await self._next_scheduling_page(statuses, CURSOR_START)
         except BaseException:
             # Compensations must not raise over the original error (multiproc
             # mailbox calls are RPCs; BaseException here so even an interrupt
@@ -2503,7 +2687,7 @@ class _PipelineMixin:
             # lost signal are still PENDING rows, recovered by the next run's
             # initial scan.
             try:
-                if decision.step is PipelineNextStep.CONTINUE_AUTO:
+                if step is PipelineNextStep.CONTINUE_AUTO:
                     ingress.request_auto_rescan()
                 elif drained:
                     self._republish_documents(ingress, drained, source="quiescence")
@@ -2520,7 +2704,7 @@ class _PipelineMixin:
                     f"not automatically: {compensation_error}"
                 )
             raise
-        return docs, decision.manual_request_id
+        return docs, statuses, next_cursor, decision.manual_request_id
 
     @staticmethod
     def _format_job_name(

--- a/tests/kg/json_impl/test_json_scheduling_pages.py
+++ b/tests/kg/json_impl/test_json_scheduling_pages.py
@@ -216,6 +216,48 @@ async def test_get_docs_by_ids_batch_present_and_missing(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_get_full_docs_by_ids_hydrates_full_status(tmp_path):
+    storage = await _storage(
+        tmp_path,
+        {
+            "doc-1": _doc(
+                "pending",
+                content_summary="hello",
+                content_length=42,
+                chunks_list=["c1", "c2"],
+                track_id="t9",
+            ),
+            "doc-2": _doc("failed"),
+        },
+    )
+    result = await storage.get_full_docs_by_ids(
+        ["doc-1", "doc-2", "ghost"], strict=True
+    )
+    assert set(result) == {"doc-1", "doc-2"}  # missing omitted, confirmed absent
+    # FULL projection (unlike get_docs_by_ids): every heavy field is present.
+    doc1 = result["doc-1"]
+    assert doc1.content_summary == "hello"
+    assert doc1.content_length == 42
+    assert doc1.chunks_list == ["c1", "c2"]
+    assert doc1.track_id == "t9"
+    # Full status mirrors get_docs_by_statuses: status stays the raw str value
+    # (a str-enum member equals its value), NOT converted to the DocStatus obj.
+    assert result["doc-2"].status == DocStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_get_full_docs_by_ids_strict_raises_on_malformed(tmp_path):
+    storage = await _storage(tmp_path, {"doc-1": _doc("pending")})
+    async with storage._storage_lock:
+        storage._data["bad"] = {"status": "pending"}  # missing required fields
+    with pytest.raises((KeyError, TypeError)):
+        await storage.get_full_docs_by_ids(["doc-1", "bad"], strict=True)
+    # relaxed: the malformed row is skipped, the good one still hydrates.
+    relaxed = await storage.get_full_docs_by_ids(["doc-1", "bad"], strict=False)
+    assert set(relaxed) == {"doc-1"}
+
+
+@pytest.mark.asyncio
 async def test_resolve_doc_source_absent_and_unique(tmp_path):
     storage = await _storage(
         tmp_path, {"doc-primary": _doc("pending", file_path="a.pdf")}

--- a/tests/kg/mongo_impl/test_mongo_scheduling_pages.py
+++ b/tests/kg/mongo_impl/test_mongo_scheduling_pages.py
@@ -472,6 +472,87 @@ async def test_get_docs_by_ids_relaxed_skips_bad_row_strict_raises():
 
 
 # ---------------------------------------------------------------------------
+# get_full_docs_by_ids: FULL DocProcessingStatus hydration
+# ---------------------------------------------------------------------------
+
+_FULL_ROW_1 = {
+    "_id": "d1",
+    "status": "pending",
+    "created_at": "2026-01-01T00:00:00+00:00",
+    "updated_at": "2026-01-01T00:00:00+00:00",
+    "file_path": "a.txt",
+    "content_summary": "summary of a",
+    "content_length": 123,
+    "chunks_list": ["chunk-1", "chunk-2"],
+    "metadata": {"k": "v"},
+}
+_FULL_ROW_2 = {
+    "_id": "d2",
+    "status": "failed",
+    "created_at": "2026-01-02T00:00:00+00:00",
+    "updated_at": "2026-01-02T00:00:00+00:00",
+    "file_path": "b.txt",
+    "content_summary": "summary of b",
+    "content_length": 456,
+    "chunks_list": ["chunk-3"],
+    "metadata": {},
+    "error_msg": "boom",
+}
+
+
+async def test_get_full_docs_by_ids_present_omits_missing_full_projection():
+    data = _FakeCollection(find_docs=[_FULL_ROW_1, _FULL_ROW_2])
+    storage = _storage(data=data)
+
+    result = await storage.get_full_docs_by_ids(["d1", "d2", "ghost"], strict=True)
+
+    # One indexed $in query; the missing id is positively absent (omitted).
+    assert data.find_queries == [{"_id": {"$in": ["d1", "d2", "ghost"]}}]
+    assert set(result) == {"d1", "d2"}
+    # FULL projection: fields excluded from DocSchedulingRecord are populated.
+    assert result["d1"].content_summary == "summary of a"
+    assert result["d1"].content_length == 123
+    assert result["d1"].chunks_list == ["chunk-1", "chunk-2"]
+    assert result["d1"].metadata == {"k": "v"}
+    # DocProcessingStatus keeps status as the raw str value (str-enum): ==, not is.
+    assert result["d2"].status == DocStatus.FAILED
+
+
+async def test_get_full_docs_by_ids_empty_input_issues_no_query():
+    data = _FakeCollection()
+    storage = _storage(data=data)
+
+    assert await storage.get_full_docs_by_ids([]) == {}
+    assert data.find_queries == []
+
+
+async def test_get_full_docs_by_ids_strict_raises_on_transport_error():
+    data = _FakeCollection(find_error=PyMongoError("down"))
+    storage = _storage(data=data)
+
+    with pytest.raises(PyMongoError):
+        await storage.get_full_docs_by_ids(["d1"], strict=True)
+
+
+async def test_get_full_docs_by_ids_relaxed_skips_bad_doc_strict_raises():
+    bad = {  # missing required content_summary/content_length -> unconvertible
+        "_id": "d-bad",
+        "status": "pending",
+        "created_at": "2026-01-03T00:00:00+00:00",
+        "updated_at": "2026-01-03T00:00:00+00:00",
+        "file_path": "c.txt",
+    }
+    data = _FakeCollection(find_docs=[_FULL_ROW_1, bad])
+    storage = _storage(data=data)
+
+    relaxed = await storage.get_full_docs_by_ids(["d1", "d-bad"])
+    assert set(relaxed) == {"d1"}  # bad doc dropped, present id kept
+
+    with pytest.raises(TypeError):
+        await storage.get_full_docs_by_ids(["d1", "d-bad"], strict=True)
+
+
+# ---------------------------------------------------------------------------
 # resolve_doc_source_strict: conflict-aware typed resolution
 # ---------------------------------------------------------------------------
 

--- a/tests/kg/opensearch_impl/test_os_scheduling_pages.py
+++ b/tests/kg/opensearch_impl/test_os_scheduling_pages.py
@@ -678,6 +678,97 @@ async def test_get_docs_by_ids_missing_index_raises(global_config):
 
 
 # ---------------------------------------------------------------------------
+# get_full_docs_by_ids: FULL-record batch hydration
+# ---------------------------------------------------------------------------
+
+
+async def test_get_full_docs_by_ids_present_and_missing_full_projection(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    d1_source = _status_source(
+        "d1", status="failed", chunks_list=["c1", "c2"], error="boom"
+    )
+    d2_source = _status_source("d2", status="processed", chunks_list=["c3"])
+    client.mget = AsyncMock(
+        return_value={
+            "docs": [
+                {"_id": "d1", "found": True, "_source": d1_source},
+                {"_id": "d2", "found": True, "_source": d2_source},
+                {"_id": "ghost", "found": False},
+            ]
+        }
+    )
+
+    result = await storage.get_full_docs_by_ids(["d1", "d2", "ghost"], strict=True)
+
+    # found=False is CONFIRMED absent -> omitted.
+    assert set(result) == {"d1", "d2"}
+    # FULL DocProcessingStatus leaves status as the raw str value (== not is).
+    assert result["d1"].status == DocStatus.FAILED
+    # FULL projection: fields the lightweight scheduling record never carries.
+    assert result["d1"].content_summary == "summary-d1"
+    assert result["d1"].content_length == 10
+    assert result["d1"].chunks_list == ["c1", "c2"]
+    assert result["d1"].error_msg == "boom"  # legacy `error` -> error_msg
+    assert result["d2"].chunks_list == ["c3"]
+    # Full fetch: no _source_includes projection is applied (unlike get_docs_by_ids).
+    kwargs = client.mget.call_args.kwargs
+    assert kwargs["body"] == {"ids": ["d1", "d2", "ghost"]}
+    assert "_source_includes" not in kwargs
+
+
+async def test_get_full_docs_by_ids_empty_short_circuits(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.mget = AsyncMock()
+    assert await storage.get_full_docs_by_ids([]) == {}
+    client.mget.assert_not_awaited()
+
+
+async def test_get_full_docs_by_ids_strict_raises_on_transport_error(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    client.mget = AsyncMock(side_effect=_transient_error())
+    with pytest.raises(TransportError):
+        await storage.get_full_docs_by_ids(["d1"], strict=True)
+
+
+async def test_get_full_docs_by_ids_strict_raises_relaxed_skips_bad_row(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    good_source = _status_source("d1", status="processed")
+    bad_source = _status_source("d2")
+    del bad_source["created_at"]  # DocProcessingStatus(**data) -> TypeError
+
+    docs = {
+        "docs": [
+            {"_id": "d1", "found": True, "_source": good_source},
+            {"_id": "d2", "found": True, "_source": bad_source},
+        ]
+    }
+    client.mget = AsyncMock(return_value=docs)
+    # strict: the WHOLE call fails rather than return a partial map.
+    with pytest.raises((KeyError, TypeError)):
+        await storage.get_full_docs_by_ids(["d1", "d2"], strict=True)
+
+    client.mget = AsyncMock(return_value=docs)
+    # relaxed: skip the unusable row, keep the good one.
+    result = await storage.get_full_docs_by_ids(["d1", "d2"])
+    assert set(result) == {"d1"}
+    assert result["d1"].content_summary == "summary-d1"
+
+
+async def test_get_full_docs_by_ids_index_not_ready_raises(global_config):
+    client = _make_client()
+    storage = await _make_doc_status(global_config, client)
+    storage._index_ready = False
+    client.mget = AsyncMock()
+    with pytest.raises(StorageControlPlaneError):
+        await storage.get_full_docs_by_ids(["d1"])
+    client.mget.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
 # resolve_doc_source_strict: conflict-aware source resolution
 # ---------------------------------------------------------------------------
 

--- a/tests/kg/postgres_impl/test_pg_scheduling_pages.py
+++ b/tests/kg/postgres_impl/test_pg_scheduling_pages.py
@@ -481,6 +481,77 @@ async def test_get_docs_by_ids_strict_raises_on_unusable_row():
 
 
 # ---------------------------------------------------------------------------
+# get_full_docs_by_ids (strict batch hydration to FULL DocProcessingStatus)
+# ---------------------------------------------------------------------------
+
+
+def _full_row(doc_id="d1", **overrides):
+    """A FULL doc_status row (superset of the scheduling projection)."""
+    row = _page_row(doc_id)
+    row.update(
+        {
+            "content_summary": f"summary of {doc_id}",
+            "content_length": 4242,
+            "chunks_count": 3,
+            "chunks_list": json.dumps([f"{doc_id}-c1", f"{doc_id}-c2"]),
+            "content_hash": "hash-of-" + doc_id,
+            "error_msg": None,
+        }
+    )
+    row.update(overrides)
+    return row
+
+
+async def test_get_full_docs_by_ids_present_and_missing():
+    rows = [_full_row("d1"), _full_row("d2", status="failed")]
+    db = _FakeDB(results=[rows])
+    storage = _storage(db)
+    result = await storage.get_full_docs_by_ids(["d1", "d2", "ghost"], strict=True)
+    assert set(result) == {"d1", "d2"}  # ghost omitted (confirmed absent)
+    # status is the raw enum-str value, so compare by == (not is)
+    assert result["d2"].status == DocStatus.FAILED
+    # FULL projection: fields absent from the lightweight scheduling record
+    assert result["d1"].content_summary == "summary of d1"
+    assert result["d1"].content_length == 4242
+    assert result["d1"].chunks_list == ["d1-c1", "d1-c2"]
+    sql, params, multirows = db.calls[0]
+    assert "SELECT *" in sql
+    assert "id = ANY($2)" in sql
+    assert multirows is True
+    assert params == ["ws", ["d1", "d2", "ghost"]]
+
+
+async def test_get_full_docs_by_ids_empty_short_circuits():
+    storage = _storage(_ExplodingDB())
+    assert await storage.get_full_docs_by_ids([]) == {}
+
+
+async def test_get_full_docs_by_ids_strict_db_error_propagates():
+    db = _FakeDB(results=[ConnectionError("down")])
+    storage = _storage(db)
+    with pytest.raises(ConnectionError):
+        await storage.get_full_docs_by_ids(["d1"], strict=True)
+
+
+async def test_get_full_docs_by_ids_relaxed_skips_malformed_row():
+    bad = _full_row("d-bad")
+    del bad["content_summary"]  # required field -> KeyError in the row projection
+    db = _FakeDB(results=[[_full_row("d1"), bad]])
+    storage = _storage(db)
+    result = await storage.get_full_docs_by_ids(["d1", "d-bad"], strict=False)
+    assert set(result) == {"d1"}  # malformed row skipped, good one kept
+
+
+async def test_get_full_docs_by_ids_strict_raises_on_malformed_row():
+    bad = _full_row("d-bad")
+    del bad["content_summary"]
+    db = _FakeDB(results=[[bad]])
+    storage = _storage(db)
+    with pytest.raises(KeyError):
+        await storage.get_full_docs_by_ids(["d-bad"], strict=True)
+
+
+# ---------------------------------------------------------------------------
 # resolve_doc_source_strict (conflict-aware source resolution)
 # ---------------------------------------------------------------------------
 

--- a/tests/kg/redis_impl/test_redis_scheduling_pages.py
+++ b/tests/kg/redis_impl/test_redis_scheduling_pages.py
@@ -456,6 +456,48 @@ async def test_conflict_listing_is_bounded_and_resumable(storage, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_get_full_docs_by_ids_present_and_missing(storage):
+    await _bootstrap(storage)
+    await storage.upsert({"doc-1": _doc("pending"), "doc-2": _doc("failed")})
+    result = await storage.get_full_docs_by_ids(
+        ["doc-1", "doc-2", "ghost"], strict=True
+    )
+    # Missing id omitted (confirmed absent); present ids hydrated.
+    assert set(result) == {"doc-1", "doc-2"}
+    # status is the raw str value (DocStatus is a str-enum) -> use ==.
+    assert result["doc-2"].status == DocStatus.FAILED
+    # FULL projection: fields the lightweight scheduling record omits.
+    assert result["doc-1"].content_summary == "s"
+    assert result["doc-1"].content_length == 10
+    assert result["doc-1"].chunks_list == []
+
+
+@pytest.mark.asyncio
+async def test_get_full_docs_by_ids_strict_transport_error_raises(storage):
+    await _bootstrap(storage)
+    await storage.upsert({"doc-1": _doc("pending")})
+    fake = storage._redis
+    # Transport failure at the batched pipeline read fails the WHOLE call —
+    # never a partial mapping.
+    fake.fail_next["execute"] = RedisError("boom")
+    with pytest.raises(RedisError):
+        await storage.get_full_docs_by_ids(["doc-1"], strict=True)
+
+
+@pytest.mark.asyncio
+async def test_get_full_docs_by_ids_relaxed_skips_undecodable_row(storage):
+    await _bootstrap(storage)
+    await storage.upsert({"doc-1": _doc("pending")})
+    fake = storage._redis
+    # An undecodable primary row: relaxed mode logs + skips it, returning the
+    # good ones.
+    fake.store[f"{storage.final_namespace}:bad"] = "not-json{"
+    result = await storage.get_full_docs_by_ids(["doc-1", "bad"], strict=False)
+    assert set(result) == {"doc-1"}
+    assert result["doc-1"].content_summary == "s"
+
+
+@pytest.mark.asyncio
 async def test_list_and_repair_source_conflict(storage):
     await _bootstrap(storage)
     await storage.upsert(

--- a/tests/kg/test_scheduling_base_defaults.py
+++ b/tests/kg/test_scheduling_base_defaults.py
@@ -152,6 +152,11 @@ class _MinimalDocStatusStorage(DocStatusStorage):
     ) -> dict[str, DocSchedulingRecord]:  # pragma: no cover - trivial
         return {}
 
+    async def get_full_docs_by_ids(
+        self, doc_ids: Sequence[str], *, strict: bool = False
+    ) -> dict[str, DocProcessingStatus]:  # pragma: no cover - trivial
+        return {}
+
     async def resolve_doc_source_strict(
         self, canonical_source_key: str
     ) -> SourceResolution:  # pragma: no cover - trivial
@@ -185,6 +190,7 @@ def test_scheduling_methods_are_mandatory_abstractmethods():
     for name in (
         "get_docs_by_statuses_page",
         "get_docs_by_ids",
+        "get_full_docs_by_ids",
         "resolve_doc_source_strict",
     ):
         assert name in DocStatusStorage.__abstractmethods__, name

--- a/tests/pipeline/test_bounded_scheduling.py
+++ b/tests/pipeline/test_bounded_scheduling.py
@@ -1,0 +1,286 @@
+"""Bounded scheduling acceptance tests (LR2 Phase 2).
+
+The scheduler sweeps the doc_status backlog through keyset pages of
+``PIPELINE_SCHEDULING_PAGE_SIZE`` records (hydrated per page via
+``get_full_docs_by_ids``) instead of materializing every PENDING/orphan row
+at once, so memory grows with page-size + inflight, not with the backlog.
+
+These cover the §12-Phase2 acceptance list:
+
+* a huge PENDING backlog drains page-by-page (cursor advances, every doc is
+  processed — the tail is never starved);
+* a page-query failure does NOT advance the cursor and re-arms auto-rescan,
+  so the remaining backlog is recovered by the next run;
+* ``PIPELINE_SCHEDULING_PAGE_SIZE=0`` collapses to the legacy single scan;
+* a manual retry sweep (FAILED included) stays single-scan even with paging
+  on, preserving the ACK-after-all-resets contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import uuid4
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG
+from lightrag.base import CURSOR_END, CURSOR_START, DocStatus
+from lightrag.kg.shared_storage import get_pipeline_ingress
+from lightrag.pipeline import (
+    _AUTO_RESUME_DOC_STATUSES,
+    _MANUAL_RETRY_DOC_STATUSES,
+)
+from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
+
+pytestmark = pytest.mark.offline
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _dummy_embedding(texts: list[str]) -> np.ndarray:
+    return np.ones((len(texts), 8), dtype=float)
+
+
+async def _dummy_llm(*args, **kwargs) -> str:
+    return "ok"
+
+
+def _chunking(
+    tokenizer,
+    content,
+    split_by_character,
+    split_by_character_only,
+    chunk_overlap_token_size,
+    chunk_token_size,
+) -> list[dict]:
+    return [{"tokens": 1, "content": f"{content}::chunk1", "chunk_order_index": 0}]
+
+
+class _Extract:
+    def __init__(self, fail: bool = False):
+        self.fail = fail
+
+    async def __call__(self, chunks, *args, **kwargs):
+        if self.fail:
+            raise RuntimeError("extract fail sentinel")
+        return [({}, {}) for _ in chunks]
+
+
+async def _build_rag(tmp_path, *, page_size: int) -> LightRAG:
+    rag = LightRAG(
+        working_dir=str(tmp_path / "wd"),
+        workspace=f"bs-{uuid4().hex[:8]}",
+        llm_model_func=_dummy_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8, max_token_size=8192, func=_dummy_embedding
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        chunking_func=_chunking,
+        max_parallel_insert=1,
+        pipeline_scheduling_page_size=page_size,
+    )
+    await rag.initialize_storages()
+    rag._process_extract_entities = _Extract()
+    return rag
+
+
+async def _status_of(rag: LightRAG, doc_id: str) -> str:
+    row = await rag.doc_status.get_by_id(doc_id)
+    raw = (row or {}).get("status")
+    return raw.value if isinstance(raw, DocStatus) else str(raw or "<missing>")
+
+
+async def _enqueue_n(rag: LightRAG, n: int) -> list[str]:
+    ids = []
+    for i in range(n):
+        name = f"doc{i}.txt"
+        await rag.apipeline_enqueue_documents(input=f"body {i}", file_paths=name)
+        ids.append(compute_mdhash_id(name, prefix="doc-"))
+    return ids
+
+
+def _count_page_calls(rag):
+    """Wrap the two scheduling reads, returning (counters, restore)."""
+    counts = {"page": 0, "scan": 0}
+    orig_page = rag.doc_status.get_docs_by_statuses_page
+    orig_scan = rag.doc_status.get_docs_by_statuses
+
+    async def counting_page(statuses, *, limit, position=CURSOR_START, strict=False):
+        counts["page"] += 1
+        return await orig_page(statuses, limit=limit, position=position, strict=strict)
+
+    async def counting_scan(statuses, strict=False):
+        counts["scan"] += 1
+        return await orig_scan(statuses, strict=strict)
+
+    rag.doc_status.get_docs_by_statuses_page = counting_page
+    rag.doc_status.get_docs_by_statuses = counting_scan
+    return counts
+
+
+def test_bounded_sweep_processes_all_docs_across_pages(tmp_path):
+    """A backlog larger than one page drains page-by-page: the cursor advances
+    (>1 page fetched) and EVERY doc reaches PROCESSED — the tail behind the
+    first pages is never starved."""
+
+    async def _run():
+        rag = await _build_rag(tmp_path, page_size=2)
+        try:
+            ids = await _enqueue_n(rag, 5)
+            counts = _count_page_calls(rag)
+
+            await rag.apipeline_process_enqueue_documents()
+
+            for doc_id in ids:
+                assert await _status_of(rag, doc_id) == DocStatus.PROCESSED.value
+            # 5 docs / page_size 2 → the SCHEDULING sweep needed multiple pages,
+            # proving it did NOT materialize the whole backlog at once. (Note:
+            # get_docs_by_statuses may still be called by the per-doc
+            # content-hash dedup fallback in utils_pipeline — a separate,
+            # pre-existing scan outside Phase 2's scheduling scope — so we
+            # assert on the page count, the scheduling-path evidence.)
+            assert counts["page"] >= 3, counts
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_page_size_zero_uses_legacy_single_scan(tmp_path):
+    """PIPELINE_SCHEDULING_PAGE_SIZE=0 disables paging: one get_docs_by_statuses
+    scan, no page fetch — byte-for-byte the pre-Phase-2 behaviour."""
+
+    async def _run():
+        rag = await _build_rag(tmp_path, page_size=0)
+        try:
+            ids = await _enqueue_n(rag, 3)
+            counts = _count_page_calls(rag)
+
+            await rag.apipeline_process_enqueue_documents()
+
+            for doc_id in ids:
+                assert await _status_of(rag, doc_id) == DocStatus.PROCESSED.value
+            assert counts["page"] == 0, "paging off → page API never called"
+            assert counts["scan"] >= 1, "legacy single scan drove the sweep"
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_sweep_page_failure_rearms_auto_and_recovers(tmp_path):
+    """A page-query failure mid-sweep must NOT advance the cursor and must
+    re-arm auto-rescan; the un-swept docs stay PENDING and a clean re-run
+    finishes every one (no doc stranded, none double-processed)."""
+
+    async def _run():
+        rag = await _build_rag(tmp_path, page_size=1)
+        try:
+            ids = await _enqueue_n(rag, 3)
+            ingress = await get_pipeline_ingress(rag.workspace)
+            ingress.consume_auto_rescan()  # clear enqueue-era noise
+
+            orig_page = rag.doc_status.get_docs_by_statuses_page
+            calls = {"n": 0}
+
+            async def flaky_page(
+                statuses, *, limit, position=CURSOR_START, strict=False
+            ):
+                calls["n"] += 1
+                if calls["n"] == 2:  # fail the 2nd page (a CONTINUE_SWEEP_PAGE)
+                    raise ConnectionError("backend page failure")
+                return await orig_page(
+                    statuses, limit=limit, position=position, strict=strict
+                )
+
+            rag.doc_status.get_docs_by_statuses_page = flaky_page
+
+            with pytest.raises(ConnectionError, match="backend page failure"):
+                await rag.apipeline_process_enqueue_documents()
+
+            # The failure re-armed auto-rescan (remaining backlog recovery).
+            assert ingress.counts()["auto_rescan_pending"] is True
+            # At least one doc is still PENDING (not stranded terminal/lost).
+            statuses = [await _status_of(rag, d) for d in ids]
+            assert DocStatus.PENDING.value in statuses, statuses
+
+            # Clean re-run drains everything.
+            rag.doc_status.get_docs_by_statuses_page = orig_page
+            await rag.apipeline_process_enqueue_documents()
+            for doc_id in ids:
+                assert await _status_of(rag, doc_id) == DocStatus.PROCESSED.value
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_next_scheduling_page_manual_stays_single_scan(tmp_path):
+    """A manual retry sweep (FAILED in the tuple) is NEVER paged even with
+    paging on — the manual ACK contract needs all FAILED→PENDING resets to
+    persist before the ACK, which a multi-page sweep would break. It returns
+    one CURSOR_END page via the legacy scan."""
+
+    async def _run():
+        rag = await _build_rag(tmp_path, page_size=2)
+        try:
+            await _enqueue_n(rag, 3)
+            counts = _count_page_calls(rag)
+
+            docs, cursor = await rag._next_scheduling_page(
+                _MANUAL_RETRY_DOC_STATUSES, CURSOR_START
+            )
+            assert cursor is CURSOR_END  # single page, sweep exhausted
+            assert counts["scan"] == 1 and counts["page"] == 0
+            assert len(docs) == 3
+
+            # An AUTO sweep with the same page_size DOES page.
+            counts["scan"] = counts["page"] = 0
+            _docs, auto_cursor = await rag._next_scheduling_page(
+                _AUTO_RESUME_DOC_STATUSES, CURSOR_START
+            )
+            assert counts["page"] == 1 and counts["scan"] == 0
+            assert auto_cursor is not CURSOR_END  # 3 docs > page_size 2
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_feeder_epoch_full_gate(tmp_path):
+    """The single-epoch bound: _feeder_epoch_full is True once inflight +
+    routing reaches the page size, and always False when paging is off."""
+
+    async def _run():
+        rag = await _build_rag(tmp_path, page_size=2)
+        try:
+            from lightrag.pipeline import _BatchRunContext
+
+            ctx = _BatchRunContext(
+                pipeline_status={},
+                pipeline_status_lock=asyncio.Lock(),
+                semaphore=asyncio.Semaphore(1),
+                total_files=0,
+                parse_queues={},
+                parser_specs={},
+                q_analyze=asyncio.Queue(),
+                q_process=asyncio.Queue(),
+                pipeline_cancel_event=None,
+            )
+            assert rag._feeder_epoch_full(ctx) is False  # empty
+            ctx.inflight_doc_ids.update({"a", "b"})
+            assert rag._feeder_epoch_full(ctx) is True  # at cap (>= page_size 2)
+
+            rag.pipeline_scheduling_page_size = 0  # paging off → never full
+            assert rag._feeder_epoch_full(ctx) is False
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())

--- a/tests/pipeline/test_custom_chunk_rollback.py
+++ b/tests/pipeline/test_custom_chunk_rollback.py
@@ -145,7 +145,12 @@ async def test_rollback_restores_exact_pre_patch_state(tmp_path, monkeypatch):
         staged_id = _chunk_id("doc-1", "bob is there")
 
         result = await rag.arollback_failed_custom_chunk_patches()
-        assert result == {"rolled_back": ["doc-1"], "failed": []}
+        assert result == {
+            "rolled_back_count": 1,
+            "failed_count": 0,
+            "rolled_back_sample": ["doc-1"],
+            "failed_sample": [],
+        }
 
         row = await rag.doc_status.get_by_id("doc-1")
         assert _status_text(row) == DocStatus.PROCESSED.value
@@ -179,7 +184,12 @@ async def test_missing_cache_rolls_back_with_structural_warning(tmp_path, monkey
             await rag.ainsert_custom_chunks("base", ["alice patch"], doc_id="doc-1")
 
         result = await rag.arollback_failed_custom_chunk_patches()
-        assert result == {"rolled_back": ["doc-1"], "failed": []}
+        assert result == {
+            "rolled_back_count": 1,
+            "failed_count": 0,
+            "rolled_back_sample": ["doc-1"],
+            "failed_sample": [],
+        }
 
         row = await rag.doc_status.get_by_id("doc-1")
         assert _status_text(row) == DocStatus.PROCESSED.value
@@ -243,7 +253,12 @@ async def test_warning_persistence_failure_keeps_journal_and_retry_converges(
         monkeypatch.setattr(rag.doc_status, "upsert", fail_warning_upsert_once)
 
         result = await rag.arollback_failed_custom_chunk_patches()
-        assert result == {"rolled_back": [], "failed": ["doc-1"]}
+        assert result == {
+            "rolled_back_count": 0,
+            "failed_count": 1,
+            "rolled_back_sample": [],
+            "failed_sample": ["doc-1"],
+        }
         row = await rag.doc_status.get_by_id("doc-1")
         assert _status_text(row) == DocStatus.FAILED.value
         assert _journal(row) is not None
@@ -252,7 +267,12 @@ async def test_warning_persistence_failure_keeps_journal_and_retry_converges(
         # already be gone. A journal retry must still rebuild its candidates,
         # persist the warning, and clear the journal idempotently.
         result = await rag.arollback_failed_custom_chunk_patches()
-        assert result == {"rolled_back": ["doc-1"], "failed": []}
+        assert result == {
+            "rolled_back_count": 1,
+            "failed_count": 0,
+            "rolled_back_sample": ["doc-1"],
+            "failed_sample": [],
+        }
         row = await rag.doc_status.get_by_id("doc-1")
         assert _status_text(row) == DocStatus.PROCESSED.value
         assert _journal(row) is None
@@ -271,7 +291,12 @@ async def test_rollback_of_failed_create_removes_document(tmp_path, monkeypatch)
             await rag.ainsert_custom_chunks("fresh", ["alice is here"], doc_id="doc-9")
 
         result = await rag.arollback_failed_custom_chunk_patches()
-        assert result == {"rolled_back": ["doc-9"], "failed": []}
+        assert result == {
+            "rolled_back_count": 1,
+            "failed_count": 0,
+            "rolled_back_sample": ["doc-9"],
+            "failed_sample": [],
+        }
 
         assert await rag.doc_status.get_by_id("doc-9") is None
         assert await rag.full_docs.get_by_id("doc-9") is None
@@ -313,7 +338,12 @@ async def test_create_rollback_warning_is_attached_to_surviving_owner(
             )
 
         result = await rag.arollback_failed_custom_chunk_patches()
-        assert result == {"rolled_back": ["doc-9"], "failed": []}
+        assert result == {
+            "rolled_back_count": 1,
+            "failed_count": 0,
+            "rolled_back_sample": ["doc-9"],
+            "failed_sample": [],
+        }
         assert await rag.doc_status.get_by_id("doc-9") is None
 
         owner_row = await rag.doc_status.get_by_id("doc-1")
@@ -400,14 +430,24 @@ async def test_failed_rollback_keeps_journal_and_retries(tmp_path, monkeypatch):
         monkeypatch.setattr(rag, "_purge_kg_contributions", purge_boom)
 
         result = await rag.arollback_failed_custom_chunk_patches()
-        assert result == {"rolled_back": [], "failed": ["doc-1"]}
+        assert result == {
+            "rolled_back_count": 0,
+            "failed_count": 1,
+            "rolled_back_sample": [],
+            "failed_sample": ["doc-1"],
+        }
         row = await rag.doc_status.get_by_id("doc-1")
         assert _status_text(row) == DocStatus.FAILED.value
         assert _journal(row) is not None, "journal must survive a failed rollback"
 
         # The next scan's rollback succeeds.
         result = await rag.arollback_failed_custom_chunk_patches()
-        assert result == {"rolled_back": ["doc-1"], "failed": []}
+        assert result == {
+            "rolled_back_count": 1,
+            "failed_count": 0,
+            "rolled_back_sample": ["doc-1"],
+            "failed_sample": [],
+        }
         row = await rag.doc_status.get_by_id("doc-1")
         assert _status_text(row) == DocStatus.PROCESSED.value
         assert _journal(row) is None
@@ -422,7 +462,12 @@ async def test_rollback_noop_without_journaled_documents(tmp_path, monkeypatch):
         _fake_extraction(rag, monkeypatch)
         await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
         result = await rag.arollback_failed_custom_chunk_patches()
-        assert result == {"rolled_back": [], "failed": []}
+        assert result == {
+            "rolled_back_count": 0,
+            "failed_count": 0,
+            "rolled_back_sample": [],
+            "failed_sample": [],
+        }
     finally:
         await rag.finalize_storages()
 
@@ -441,7 +486,12 @@ async def test_sdk_resume_still_possible_before_scan_rolls_back(tmp_path, monkey
         assert _status_text(row) == DocStatus.PROCESSED.value
 
         result = await rag.arollback_failed_custom_chunk_patches()
-        assert result == {"rolled_back": [], "failed": []}
+        assert result == {
+            "rolled_back_count": 0,
+            "failed_count": 0,
+            "rolled_back_sample": [],
+            "failed_sample": [],
+        }
         anchors = await rag.full_entities.get_by_id("doc-1")
         assert anchors["entity_names"] == ["ALICE", "BOB"]
     finally:
@@ -475,5 +525,88 @@ async def test_rollback_candidate_discovery_uses_strict(tmp_path, monkeypatch):
             await rag.arollback_failed_custom_chunk_patches()
 
         assert seen_strict == [True]  # discovery used strict, not relaxed
+    finally:
+        await rag.finalize_storages()
+
+
+async def _seed_journaled_docs(rag, monkeypatch, doc_ids: list[str]) -> None:
+    """Leave a failed (journaled) custom-chunk patch on each doc id."""
+    _fake_extraction(rag, monkeypatch)
+    for doc_id in doc_ids:
+        await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id=doc_id)
+        await _fail_one_merge(monkeypatch)
+        with pytest.raises(RuntimeError, match="merge boom"):
+            await rag.ainsert_custom_chunks("base", ["bob is there"], doc_id=doc_id)
+
+
+@pytest.mark.asyncio
+async def test_rollback_interleaves_with_paging(tmp_path, monkeypatch):
+    """Fix-proof: the sweep paged its discovery but still collected EVERY
+    journaled id before rolling anything back, so peak memory stayed
+    proportional to the journaled-document count. Each page must now be rolled
+    back before the next one is fetched.
+
+    Shape-independent: measured by when rollbacks happen relative to the page
+    fetches, not by the report the call returns.
+    """
+    rag = await _build_rag(tmp_path)
+    try:
+        doc_ids = ["doc-a", "doc-b", "doc-c"]
+        await _seed_journaled_docs(rag, monkeypatch, doc_ids)
+        rag.pipeline_scheduling_page_size = 1
+
+        done = {"n": 0}
+        original_rollback_one = rag._rollback_one_custom_chunk_patch
+        original_page = rag.doc_status.get_docs_by_statuses_page
+        # Rollbacks completed at the moment each page was requested.
+        progress_at_fetch: list[int] = []
+
+        async def counting_rollback_one(*args, **kwargs):
+            result = await original_rollback_one(*args, **kwargs)
+            done["n"] += 1
+            return result
+
+        async def observing_page(*args, **kwargs):
+            progress_at_fetch.append(done["n"])
+            return await original_page(*args, **kwargs)
+
+        monkeypatch.setattr(
+            rag, "_rollback_one_custom_chunk_patch", counting_rollback_one
+        )
+        monkeypatch.setattr(rag.doc_status, "get_docs_by_statuses_page", observing_page)
+
+        result = await rag.arollback_failed_custom_chunk_patches()
+
+        assert result["rolled_back_count"] == len(doc_ids)
+        assert result["failed_count"] == 0
+        # More than one page was needed (limit=1 over 3 journaled docs).
+        assert len(progress_at_fetch) > 1
+        # Collect-all-first would leave every fetch at 0 rollbacks done.
+        assert progress_at_fetch[-1] > 0, (
+            "no rollback had completed by the last page fetch — discovery is "
+            "still collecting every journaled id before doing any work"
+        )
+        assert progress_at_fetch == sorted(progress_at_fetch)
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_rollback_report_samples_are_capped(tmp_path, monkeypatch):
+    """Counts stay exact while the id lists stop growing at the cap, so the
+    report cannot reintroduce an O(journaled-docs) accumulation."""
+    rag = await _build_rag(tmp_path)
+    try:
+        monkeypatch.setattr(lightrag_module, "ROLLBACK_REPORT_SAMPLE_CAP", 2)
+        doc_ids = ["doc-a", "doc-b", "doc-c"]
+        await _seed_journaled_docs(rag, monkeypatch, doc_ids)
+
+        result = await rag.arollback_failed_custom_chunk_patches()
+
+        assert result["rolled_back_count"] == 3
+        assert len(result["rolled_back_sample"]) == 2
+        assert set(result["rolled_back_sample"]) <= set(doc_ids)
+        assert result["failed_count"] == 0
+        assert result["failed_sample"] == []
     finally:
         await rag.finalize_storages()

--- a/tests/pipeline/test_custom_chunk_rollback.py
+++ b/tests/pipeline/test_custom_chunk_rollback.py
@@ -457,6 +457,10 @@ async def test_rollback_candidate_discovery_uses_strict(tmp_path, monkeypatch):
     the raise and keeps the journal/FAILED rows for the next scan."""
     rag = await _build_rag(tmp_path)
     try:
+        # Legacy single-scan discovery path so the failure lands on
+        # get_docs_by_statuses; the paged path (page_size>0) is likewise strict
+        # (it passes strict=True to get_docs_by_statuses_page).
+        rag.pipeline_scheduling_page_size = 0
         seen_strict: list[bool] = []
 
         async def _raising_query(statuses, strict=False):

--- a/tests/pipeline/test_fault_injection_matrix.py
+++ b/tests/pipeline/test_fault_injection_matrix.py
@@ -297,7 +297,12 @@ async def test_custom_chunk_failure_then_restart_rollback_converges(
     rag2 = await _build_rag(tmp_path, workspace)
     try:
         result = await rag2.arollback_failed_custom_chunk_patches()
-        assert result == {"rolled_back": ["doc-1"], "failed": []}
+        assert result == {
+            "rolled_back_count": 1,
+            "failed_count": 0,
+            "rolled_back_sample": ["doc-1"],
+            "failed_sample": [],
+        }
 
         row = await rag2.doc_status.get_by_id("doc-1")
         assert _status_text(row) == DocStatus.PROCESSED.value

--- a/tests/pipeline/test_pipeline_failed_retry_semantics.py
+++ b/tests/pipeline/test_pipeline_failed_retry_semantics.py
@@ -247,11 +247,21 @@ def test_auto_rescan_rearmed_when_strict_refetch_fails(tmp_path):
     re-arm it before propagating (sole-consumer compensation rule)."""
 
     async def _run():
-        from lightrag.pipeline import PipelineNextDecision, PipelineNextStep
+        from lightrag.base import CURSOR_START
+        from lightrag.pipeline import (
+            PipelineNextDecision,
+            PipelineNextStep,
+            _AUTO_RESUME_DOC_STATUSES,
+            _MANUAL_RETRY_DOC_STATUSES,
+        )
 
         extract = _CountingExtract()
         rag = await _build_rag(tmp_path, f"frs-{uuid4().hex[:8]}", extract)
         try:
+            # Force the legacy single-scan path so the failure lands on
+            # get_docs_by_statuses; the compensation code under test is shared
+            # with the paged path (both raise through _next_scheduling_page).
+            rag.pipeline_scheduling_page_size = 0
             ingress = await get_pipeline_ingress(rag.workspace)
 
             async def boom(statuses, strict=False):
@@ -260,7 +270,9 @@ def test_auto_rescan_rearmed_when_strict_refetch_fails(tmp_path):
             rag.doc_status.get_docs_by_statuses = boom
             decision = PipelineNextDecision(PipelineNextStep.CONTINUE_AUTO)
             with pytest.raises(RuntimeError, match="refetch boom"):
-                await rag._refetch_for_decision(decision, ingress)
+                await rag._refetch_for_decision(
+                    decision, _AUTO_RESUME_DOC_STATUSES, CURSOR_START, ingress
+                )
             assert ingress.consume_auto_rescan() is True  # re-armed
 
             # A manual continuation stays sticky on its own — no re-arm.
@@ -269,6 +281,8 @@ def test_auto_rescan_rearmed_when_strict_refetch_fails(tmp_path):
                     PipelineNextDecision(
                         PipelineNextStep.CONTINUE_MANUAL, manual_request_id="r1"
                     ),
+                    _MANUAL_RETRY_DOC_STATUSES,
+                    CURSOR_START,
                     ingress,
                 )
             assert ingress.consume_auto_rescan() is False

--- a/tests/pipeline/test_pipeline_ingress_exit.py
+++ b/tests/pipeline/test_pipeline_ingress_exit.py
@@ -26,7 +26,12 @@ from lightrag.kg.shared_storage import (
     get_namespace_lock,
     get_pipeline_ingress,
 )
-from lightrag.pipeline import PipelineNextDecision, PipelineNextStep
+from lightrag.base import CURSOR_END, CURSOR_START
+from lightrag.pipeline import (
+    PipelineNextDecision,
+    PipelineNextStep,
+    _AUTO_RESUME_DOC_STATUSES,
+)
 from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
 from lightrag.utils_pipeline import CUSTOM_CHUNK_PATCH_METADATA_KEY
 
@@ -225,6 +230,9 @@ async def test_refetch_document_failure_republishes_and_arms_auto(tmp_path):
     otherwise the drained notifications die with the exception."""
     rag = await _build_rag(tmp_path, _MarkerExtract())
     try:
+        # Legacy single-scan path so the failure lands on get_docs_by_statuses;
+        # the drain→scan compensation under test is shared with the paged path.
+        rag.pipeline_scheduling_page_size = 0
         ingress = await get_pipeline_ingress(rag.workspace)
         ingress.consume_auto_rescan()
         ingress.put_document(_doc_msg("doc-a"))
@@ -237,7 +245,9 @@ async def test_refetch_document_failure_republishes_and_arms_auto(tmp_path):
 
         decision = PipelineNextDecision(PipelineNextStep.CONTINUE_DOCUMENT)
         with pytest.raises(ConnectionError):
-            await rag._refetch_for_decision(decision, ingress)
+            await rag._refetch_for_decision(
+                decision, _AUTO_RESUME_DOC_STATUSES, CURSOR_START, ingress
+            )
 
         republished = {m.doc_id for m in ingress.drain_documents()}
         assert republished == {"doc-a", "doc-b"}
@@ -308,6 +318,7 @@ async def test_refetch_compensation_failure_does_not_mask_original_error(tmp_pat
     outage, but their docs are PENDING rows recovered by the next trigger."""
     rag = await _build_rag(tmp_path, _MarkerExtract())
     try:
+        rag.pipeline_scheduling_page_size = 0  # legacy single-scan path
         ingress = await get_pipeline_ingress(rag.workspace)
         ingress.put_document(_doc_msg("doc-a"))
 
@@ -326,7 +337,9 @@ async def test_refetch_compensation_failure_does_not_mask_original_error(tmp_pat
 
         decision = PipelineNextDecision(PipelineNextStep.CONTINUE_DOCUMENT)
         with pytest.raises(ConnectionError, match="original strict-scan failure"):
-            await rag._refetch_for_decision(decision, ingress)
+            await rag._refetch_for_decision(
+                decision, _AUTO_RESUME_DOC_STATUSES, CURSOR_START, ingress
+            )
     finally:
         await rag.finalize_storages()
 
@@ -401,8 +414,8 @@ async def test_cancel_after_auto_decision_restores_consumed_signal(tmp_path):
         orig_decide = rag._decide_pipeline_next_step
         cancelled_after = []
 
-        async def decide_then_cancel(ps, ps_lock, ing):
-            decision = await orig_decide(ps, ps_lock, ing)
+        async def decide_then_cancel(ps, ps_lock, ing, sweep_cursor=CURSOR_END):
+            decision = await orig_decide(ps, ps_lock, ing, sweep_cursor)
             if decision.step is PipelineNextStep.CONTINUE_AUTO and not cancelled_after:
                 cancelled_after.append(True)
                 # Lands in the exact window: decision consumed the flag, the
@@ -459,8 +472,8 @@ async def test_cancel_after_document_decision_restores_consumed_signal(tmp_path)
         orig_decide = rag._decide_pipeline_next_step
         cancelled_after = []
 
-        async def decide_then_cancel(ps, ps_lock, ing):
-            decision = await orig_decide(ps, ps_lock, ing)
+        async def decide_then_cancel(ps, ps_lock, ing, sweep_cursor=CURSOR_END):
+            decision = await orig_decide(ps, ps_lock, ing, sweep_cursor)
             if (
                 decision.step is PipelineNextStep.CONTINUE_DOCUMENT
                 and not cancelled_after
@@ -495,6 +508,10 @@ async def test_initial_scan_cancellation_restores_absorbed_auto_signal(tmp_path)
     intact for the next explicit trigger."""
     rag = await _build_rag(tmp_path, _MarkerExtract())
     try:
+        # Legacy single-scan entry path so the cancel lands on the mocked
+        # get_docs_by_statuses; the entry's absorb-then-cancel compensation
+        # (the finally re-arming on uncommitted_wakeup) is path-independent.
+        rag.pipeline_scheduling_page_size = 0
         status, _lock = await _pipeline_ns(rag)
         ingress = await get_pipeline_ingress(rag.workspace)
         ingress.request_auto_rescan()


### PR DESCRIPTION
Puts the scheduler on the paged API from #P1, so the pipeline's working set stops tracking the backlog.

**The sweep.** The initial/recovery AUTO scan was a single query that materialized every `PENDING`/orphan row; it is now a keyset page loop. The supervisor threads `(sweep_statuses, sweep_cursor)` through every quiescence decision and gains a `CONTINUE_SWEEP_PAGE` step, ordered **below** cancellation and manual retry but **above** auto-rescan and mailbox signals: finish draining the backlog you already know about before consuming a new hint.

**Hydration is per page.** The page yields the light projection; `get_full_docs_by_ids(ids, strict=True)` (new, `@abstractmethod`, implemented on all five backends over a shared normalization helper) hydrates just the ids about to be routed. Peak memory is O(page + inflight) rather than O(backlog).

**The feeder** reads exactly the drained ids instead of re-querying all `PENDING`, with a per-epoch inflight/routing cap. **Custom-chunk rollback** pages as well, using the projection's `has_custom_chunk_journal` flag to find candidates without reading journals it does not need.

`PIPELINE_SCHEDULING_PAGE_SIZE` defaults to 500; `0` collapses to one page holding everything — byte-for-byte the old single-scan behaviour, so the change is opt-out.

**Ruling: the manual sweep is not paged here.** Manual retry owes an ACK only after *all* resets land, and paging it would either break that or need a partial-progress notion. It gets its own exclusive phase in #P3 instead.

Also fixes a bug #P1 missed: the JSON backend keeps `DocStatus` **enum** objects in memory, so `str(enum)` produced `"DocStatus.PENDING"` and broke paging, counting and the projection. DB backends serialize to strings and were unaffected — the kind of divergence the shared contract suite in #P7 exists to prevent.

---

**Stack** (merge bottom-up; each PR is green on its own and targets the one below):
`main` ← **#3482** P0 test rig ← **#3483** P1 storage pages ← **#3484** P2 bounded sweep ← **#3485** P2.5 dedup ← **#3486** P3 manual retry ← **#3481** P4 `/scan` ← **#3487** P5 admission ← **#3488** P6 observability ← **#3489** P7 verification

Design: LR2 *pipeline memory bounding*. When merging, retarget the child PR **before** deleting a merged branch — GitHub closes the child otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
