### PR TITLE
✨ feat(pipeline): manual retry as freeze → drain → exclusive reset, with no generation marker (LR2 Phase 3)

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -1292,7 +1292,7 @@ async def _reserve_enqueue_slot(rag: LightRAG, token: str) -> bool:
     scan transitions to driving the processing pipeline like any
     other enqueuer, and uploads can land alongside it.
 
-    Two states block new uploads/inserts:
+    Three states block new uploads/inserts:
 
     - ``scanning_exclusive``: scan task is in its CLASSIFICATION
       phase — reading doc_status to classify files (PROCESSED →
@@ -1305,6 +1305,11 @@ async def _reserve_enqueue_slot(rag: LightRAG, token: str) -> bool:
       accepted in this window would write to a storage that is being
       torn down and silently lose the document after the client saw
       success.
+    - ``manual_freeze_requested``: a manual retry (``/reprocess_failed``
+      or ``/scan``) has frozen new ingress while it drains the pipeline
+      to idle and exclusively resets FAILED→PENDING (LR2 §6.1/§7.2).
+      An enqueue reserved BEFORE the freeze is allowed to finish; only
+      new reservations are refused, for the bounded freeze window.
 
     ``pending_enqueues`` is incremented so the scan endpoint can refuse
     while bg tasks are mid-enqueue.  The counter does NOT gate
@@ -1322,8 +1327,9 @@ async def _reserve_enqueue_slot(rag: LightRAG, token: str) -> bool:
 
     Raises:
         HTTPException(409): when
-            ``pipeline_status['scanning_exclusive']`` or
-            ``pipeline_status['destructive_busy']`` is set.
+            ``pipeline_status['scanning_exclusive']``,
+            ``pipeline_status['destructive_busy']`` or
+            ``pipeline_status['manual_freeze_requested']`` is set.
     """
     from lightrag.exceptions import PipelineNotInitializedError
     from lightrag.kg.shared_storage import (
@@ -1356,6 +1362,11 @@ async def _reserve_enqueue_slot(rag: LightRAG, token: str) -> bool:
                 "destructive_busy",
                 "Pipeline is clearing or deleting documents. Wait for the running "
                 "job to finish before submitting new work.",
+            ),
+            (
+                "manual_freeze_requested",
+                "A retry of failed documents is draining the pipeline. Wait for it "
+                "to finish before submitting new work.",
             ),
         ),
     )

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -2136,6 +2136,23 @@ def reconcile_dead_pipeline_reservations(
     return updates
 
 
+async def reap_dead_reservations_locked(
+    pipeline_status: Dict[str, Any],
+    pipeline_status_lock,
+) -> None:
+    """Reap confirmed-dead reservation tokens under ``pipeline_status_lock``.
+
+    A liveness escape hatch for a caller that is NOT taking a reservation (so it
+    cannot use the acquire helpers, which reconcile as a side effect) but must
+    not stall on a phantom count — specifically the manual DRAIN_TO_IDLE wait,
+    where the freeze blocks the uploads whose acquire would otherwise reap a
+    worker SIGKILLed mid-enqueue. No-op off Linux multi-worker
+    (:func:`_reservation_recovery_enabled`). Keeps
+    ``reconcile_dead_pipeline_reservations`` shared-storage-private."""
+    async with pipeline_status_lock:
+        reconcile_dead_pipeline_reservations(pipeline_status)
+
+
 class PipelineReservationConflict(str, Enum):
     """Structured reason why a pipeline reservation was refused."""
 

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -126,6 +126,15 @@ KEY_SEP = "\x1f"
 _CONCURRENCY_LEASE_NAMESPACE = "concurrency_leases"
 _QUEUE_STATS_NAMESPACE = "queue_stats"
 
+# Manual retry protocol phases (LR2 §6.1). Stored as PLAIN STRINGS in
+# ``pipeline_status["manual_phase"]`` — never enum members — so a Manager
+# ``DictProxy`` round-trip and any ``str(...)`` interpolation stay byte-stable
+# (cf. the Phase 2 enum-status bug where ``str(DocStatus.PENDING)`` yielded
+# "DocStatus.PENDING").
+MANUAL_PHASE_IDLE = "idle"
+MANUAL_PHASE_DRAIN_TO_IDLE = "drain_to_idle"
+MANUAL_PHASE_EXCLUSIVE_RESET = "exclusive_reset"
+
 # Heartbeat / staleness parameters (module-level so tests can monkeypatch).
 _heartbeat_ttl: float = DEFAULT_GLOBAL_SLOT_HEARTBEAT_TTL
 _suspect_grace: float = DEFAULT_GLOBAL_SLOT_SUSPECT_GRACE
@@ -1637,6 +1646,29 @@ async def initialize_pipeline_status(workspace: str | None = None):
                 "busy_owner": None,
                 "scanning_owner": None,
                 "pending_enqueue_tokens": {},
+                # ---- manual retry coordination (LR2 §6.1) ----
+                # Runtime-only state for the freeze → DRAIN_TO_IDLE →
+                # EXCLUSIVE_RESET manual-retry protocol.  NEVER written to
+                # doc_status and NEVER surviving a Manager/whole-process restart
+                # (a restart resets them to idle; recovery is driven only by the
+                # persistent doc_status: PENDING resumes via AUTO, FAILED waits
+                # for the next explicit manual request).
+                #
+                # ``manual_freeze_requested`` rejects NEW enqueue reservations
+                # (upload/text/SDK direct enqueue) but lets already-reserved
+                # requests finish; ``manual_resetting`` marks the exclusive
+                # FAILED→PENDING phase (no worker runs); ``manual_phase`` is one
+                # of MANUAL_PHASE_{IDLE,DRAIN_TO_IDLE,EXCLUSIVE_RESET}.  The
+                # freeze/reset flags and ``manual_owner`` are ALWAYS written in
+                # a single atomic update: there is never a True flag with no
+                # owner (LR2 §6.1).  ``manual_owner`` is the busy processing run
+                # that holds the freeze — {request_id, owner_token, pid,
+                # process_start_id} — so a dead busy owner clears the manual
+                # state too (see _dead_reservation_updates).
+                "manual_freeze_requested": False,
+                "manual_resetting": False,
+                "manual_phase": MANUAL_PHASE_IDLE,
+                "manual_owner": None,
             }
         )
 
@@ -1897,6 +1929,14 @@ _INTERNAL_PIPELINE_STATUS_FIELDS = (
     "operation_record",
     "recovery_required",
     "scan_deferred_processing",
+    # ``manual_owner`` carries a pid / process_start_id / owner token — internal
+    # coordination identity, never surfaced on /pipeline_status. The
+    # manual_freeze_requested / manual_resetting / manual_phase booleans+string
+    # are also hidden here in Phase 3; Phase 6 adds a curated observability view.
+    "manual_owner",
+    "manual_freeze_requested",
+    "manual_resetting",
+    "manual_phase",
 )
 
 # Owner ``kind`` values whose work is safely RE-RUNNABLE after a dead-owner
@@ -1973,6 +2013,22 @@ def _dead_reservation_updates(
     updates: Dict[str, Any] = {owner_key: None}
     for flag in flags:
         updates[flag] = False
+    # The manual-retry freeze/reset is driven BY the busy processing run
+    # (manual_owner shares its pid/process_start_id). A dead busy owner cannot
+    # legitimately still hold a freeze, so clear the whole manual state in the
+    # SAME atomic update — never leave a True freeze flag with no live owner
+    # (LR2 §6.1). The sticky manual request itself survives in the ingress
+    # mailbox and is re-run from scratch (idempotent drain→reset) by the next
+    # owner. ``processing`` is re-runnable, so busy is simply cleared here.
+    if owner_key == "busy_owner":
+        updates.update(
+            {
+                "manual_freeze_requested": False,
+                "manual_resetting": False,
+                "manual_phase": MANUAL_PHASE_IDLE,
+                "manual_owner": None,
+            }
+        )
     if rec.get("kind") not in _RERUNNABLE_RESERVATION_KINDS:
         updates["recovery_required"] = {
             "kind": rec.get("kind"),
@@ -2071,6 +2127,11 @@ class PipelineReservationConflict(str, Enum):
     PENDING_ENQUEUE = "pending_enqueue"
     DESTRUCTIVE = "destructive"
     RECOVERY_REQUIRED = "recovery_required"
+    # A manual retry has frozen new enqueues while it drains the pipeline to
+    # idle and exclusively resets FAILED→PENDING (LR2 §6.1/§7.2). Maps to HTTP
+    # 409 like every non-recovery conflict — the freeze is a bounded window,
+    # not a fenced workspace.
+    MANUAL_FREEZE = "manual_freeze"
 
 
 @dataclass(frozen=True)
@@ -2102,6 +2163,7 @@ def _conflict_for_status_flag(flag_key: str) -> PipelineReservationConflict:
             "scanning_exclusive": PipelineReservationConflict.SCANNING,
             "pending_enqueues": PipelineReservationConflict.PENDING_ENQUEUE,
             "destructive_busy": PipelineReservationConflict.DESTRUCTIVE,
+            "manual_freeze_requested": PipelineReservationConflict.MANUAL_FREEZE,
         }[flag_key]
     except KeyError:
         # Fail-fast on an unmapped reject_when flag: a silent BUSY fallback would

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -1996,6 +1996,23 @@ def make_owner_record(token: str, kind: str) -> Dict[str, Any]:
     }
 
 
+def make_manual_owner_record(request_id: str, token: str) -> Dict[str, Any]:
+    """Build the manual-retry freeze owner record (LR2 §6.1):
+    ``{request_id, owner_token, pid, process_start_id}``.
+
+    The freeze/drain/reset is driven BY the busy processing run, so the process
+    identity reuses :func:`make_owner_record` (same pid / process_start_id as the
+    busy owner) — a dead busy owner is therefore a dead manual owner. Kept in the
+    shared coordination layer so process identity is only ever captured here."""
+    owner = make_owner_record(token, "manual")
+    return {
+        "request_id": request_id,
+        "owner_token": owner["token"],
+        "pid": owner["pid"],
+        "process_start_id": owner["process_start_id"],
+    }
+
+
 def _dead_reservation_updates(
     pipeline_status: Mapping[str, Any],
     owner_key: str,

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -61,6 +61,7 @@ from lightrag.kg.shared_storage import (
     get_namespace_lock,
     get_pipeline_ingress,
     make_manual_owner_record,
+    reap_dead_reservations_locked,
     run_to_completion,
     with_reservation_lock,
 )
@@ -130,25 +131,19 @@ from lightrag.utils_pipeline import (
 
 
 # Document statuses the pipeline resumes AUTOMATICALLY — the initial snapshot
-# of every run and every quiescence refetch.  PROCESSING/PARSING/ANALYZING are
-# dead-process orphans (an interrupted run left them mid-flight) and must
-# self-heal; FAILED is deliberately absent: a document that genuinely failed
-# is retried only through an explicit human request (see
-# ``_MANUAL_RETRY_DOC_STATUSES``), never as a side effect of an unrelated
-# upload or rescan.
+# of every run and every quiescence refetch, AND the only statuses any
+# ``_next_scheduling_page`` sweep ever carries.  PROCESSING/PARSING/ANALYZING
+# are dead-process orphans (an interrupted run left them mid-flight) and must
+# self-heal; FAILED is deliberately absent: a document that genuinely failed is
+# retried only through an explicit manual request, whose EXCLUSIVE_RESET phase
+# pages FAILED→PENDING via ``_next_failed_page`` with no worker running (LR2
+# §7.3) — never as a side effect of an unrelated upload or rescan.
 _AUTO_RESUME_DOC_STATUSES = (
     DocStatus.PENDING,
     DocStatus.PROCESSING,
     DocStatus.PARSING,
     DocStatus.ANALYZING,
 )
-
-# Superset used exactly once per manual retry request (``/documents/scan`` /
-# ``/documents/reprocess_failed``): the sticky ingress request is the only
-# path that may pull FAILED documents back into the pipeline, and it is ACKed
-# after their reset-to-PENDING persists — so a doc that fails AGAIN inside
-# that run stays FAILED until the next explicit human request (no retry loop).
-_MANUAL_RETRY_DOC_STATUSES = (*_AUTO_RESUME_DOC_STATUSES, DocStatus.FAILED)
 
 # Multiprocess feeder poll interval: the Manager-backed ingress has no async
 # ``get_document``, so the feeder blocks a worker thread in
@@ -2534,6 +2529,10 @@ class _PipelineMixin:
             if not content_data:  # Fails consistency check; handled above
                 continue
             status = getattr(status_doc, "status", None)
+            # FAILED is DEFENSIVE here: post-Phase-3 the AUTO sweep that feeds
+            # this validator never carries FAILED (those are reset only by the
+            # manual EXCLUSIVE_RESET), so this branch handles orphan
+            # PROCESSING/PARSING/ANALYZING in practice.
             is_interrupted = status in (
                 DocStatus.PROCESSING,
                 DocStatus.FAILED,
@@ -2570,8 +2569,8 @@ class _PipelineMixin:
 
             async with pipeline_status_lock:
                 reset_message = (
-                    f"Reset {reset_count} documents from "
-                    "PARSING/ANALYZING/PROCESSING/FAILED to PENDING status"
+                    f"Reset {reset_count} interrupted document(s) from "
+                    "PARSING/ANALYZING/PROCESSING to PENDING status"
                     + (
                         f"; normalized {normalized_count} PENDING document(s) "
                         "with stale metadata"
@@ -2845,25 +2844,18 @@ class _PipelineMixin:
         carries ids/status, and the survivors are hydrated to full rows via
         ``get_full_docs_by_ids`` right before routing.
 
-        Two paths collapse to the LEGACY single-scan (one page terminating at
-        ``CURSOR_END``), so ``PIPELINE_SCHEDULING_PAGE_SIZE=0`` and every manual
-        retry sweep behave byte-for-byte as before Phase 2:
-
-        * ``page_size <= 0`` — paging disabled by configuration;
-        * ``DocStatus.FAILED in statuses`` — a MANUAL retry sweep. The manual
-          ACK contract requires every FAILED→PENDING reset to persist *before*
-          the request is ACKed; a multi-page manual sweep would ACK after the
-          first page while later pages still hold un-reset FAILED rows. Manual
-          backlog is bounded by the FAILED count today and bounded properly by
-          Phase 3's exclusive reset, so manual stays single-scan here.
+        ``PIPELINE_SCHEDULING_PAGE_SIZE=0`` collapses to the LEGACY single-scan
+        (one page terminating at ``CURSOR_END``), behaving byte-for-byte as
+        before Phase 2. Every caller passes ``_AUTO_RESUME_DOC_STATUSES`` (no
+        FAILED — those are reset only by the manual EXCLUSIVE_RESET's own
+        ``_next_failed_page``), so this sweep is always a plain AUTO drain.
 
         The strict page + strict hydration are a complete-or-raise pair: any
         backend error propagates so the caller neither advances the cursor nor
         silently drops docs (they stay PENDING for the next sweep).
         """
         page_size = getattr(self, "pipeline_scheduling_page_size", 0)
-        paged = page_size > 0 and DocStatus.FAILED not in statuses
-        if not paged:
+        if page_size <= 0:
             docs = await self.doc_status.get_docs_by_statuses(
                 list(statuses), strict=True
             )
@@ -2972,7 +2964,11 @@ class _PipelineMixin:
                 if pipeline_status.get("pending_enqueues", 0) > 0:
                     # Enqueues reserved BEFORE the freeze must finish (their
                     # PENDING docs join this cohort) before the reset can start
-                    # with no failed producer (LR2 §7.2 step 5 / §7.3).
+                    # with no failed producer (LR2 §7.2 step 5 / §7.3). The
+                    # CONTINUE_DRAIN_WAIT refetch reaps confirmed-dead tokens
+                    # before it waits, so a worker SIGKILLed mid-reserve (Linux
+                    # multi-worker) cannot leave a phantom count that wedges this
+                    # drain (the freeze blocks the uploads that would reap it).
                     return PipelineNextDecision(PipelineNextStep.CONTINUE_DRAIN_WAIT)
                 return PipelineNextDecision(PipelineNextStep.BEGIN_EXCLUSIVE_RESET)
             manual_msg = ingress.peek_next_manual_retry()
@@ -3067,9 +3063,15 @@ class _PipelineMixin:
             return docs, sweep_statuses, next_cursor
 
         # (A2) Manual drain: hold the freeze while the pre-freeze in-flight
-        # enqueues finish. Bounded async sleep (not a busy-loop); the next
-        # decision drains any doc they publish, then re-checks pending_enqueues.
+        # enqueues finish. Reap confirmed-dead reservation tokens FIRST — a
+        # worker SIGKILLed mid-reserve (Linux multi-worker) would otherwise leave
+        # a phantom pending_enqueues count that wedges this drain forever, since
+        # the freeze blocks the uploads whose acquire would normally reap it
+        # (no-op off Linux-multiworker). Then a bounded async sleep (not a
+        # busy-loop); the next decision drains any doc they publish, then
+        # re-checks pending_enqueues.
         if step is PipelineNextStep.CONTINUE_DRAIN_WAIT:
+            await reap_dead_reservations_locked(pipeline_status, pipeline_status_lock)
             await asyncio.sleep(_MANUAL_DRAIN_POLL_SECONDS)
             return {}, sweep_statuses, sweep_cursor
 

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -50,6 +50,9 @@ from lightrag.exceptions import (
     IndexFlushError,
 )
 from lightrag.kg.shared_storage import (
+    MANUAL_PHASE_DRAIN_TO_IDLE,
+    MANUAL_PHASE_EXCLUSIVE_RESET,
+    MANUAL_PHASE_IDLE,
     PipelineReservationConflict,
     _reservation_owner_token,
     acquire_processing_reservation,
@@ -57,7 +60,9 @@ from lightrag.kg.shared_storage import (
     get_namespace_data,
     get_namespace_lock,
     get_pipeline_ingress,
+    make_owner_record,
     run_to_completion,
+    with_reservation_lock,
 )
 from lightrag.kg.pipeline_ingress import PipelineIngressMessage
 from lightrag.operate import merge_nodes_and_edges
@@ -159,6 +164,12 @@ _FEEDER_POLL_SECONDS = 0.5
 # one admission, not a whole drain.
 _FEEDER_DRAIN_LIMIT = 256
 
+# Manual DRAIN_TO_IDLE poll: how long to sleep between re-checks while waiting
+# for pre-freeze in-flight enqueue reservations (pending_enqueues > 0) to
+# finish (LR2 §7.2 step 5). Bounded by the background enqueue's own duration —
+# the freeze admits no NEW reservations, so the count only decreases.
+_MANUAL_DRAIN_POLL_SECONDS = 0.2
+
 
 class PipelineNextStep(Enum):
     """Outcome of the atomic quiescence decision (see
@@ -166,7 +177,20 @@ class PipelineNextStep(Enum):
 
     RELEASED = "released"
     CONTINUE_AUTO = "continue_auto"
+    # A sticky manual retry is pending and the pipeline is IDLE: BEGIN the
+    # manual protocol (LR2 §6.1/§7.2) — freeze new ingress, then drain the AUTO
+    # backlog to idle.  No FAILED is swept here; FAILED is reset only in the
+    # exclusive phase below.  The request stays sticky (ACKed after the reset).
     CONTINUE_MANUAL = "continue_manual"
+    # Manual drain reached AUTO-empty but pre-freeze in-flight enqueue
+    # reservations (pending_enqueues > 0) have not finished.  Bounded-wait for
+    # them so their PENDING docs join this drain cohort before the reset
+    # (LR2 §7.2 step 5 / §7.3 pending_enqueues=0 precondition).
+    CONTINUE_DRAIN_WAIT = "continue_drain_wait"
+    # Manual drain reached strict idle (no AUTO, no in-flight, no mailbox):
+    # enter EXCLUSIVE_RESET — page FAILED→PENDING with NO worker running, then
+    # ACK the request and resume normal processing (LR2 §7.3).
+    BEGIN_EXCLUSIVE_RESET = "begin_exclusive_reset"
     # Document messages still resident in the mailbox at quiescence (e.g. an
     # enqueue that landed after the batch's feeder stopped, or a stale
     # notification for a doc that has since reached a terminal state).  The
@@ -1372,22 +1396,25 @@ class _PipelineMixin:
                 return
 
             # Run-start peek protocol: the ingress mailbox is the ONLY source
-            # of manual retry intent (processing carries no manual params).
-            # The earliest sticky request — if any — selects the manual status
-            # tuple for the initial scan and is ACKed only after its
-            # FAILED→PENDING resets persist (in the loop, post-validation, or
-            # right below on a legitimately-empty complete result).  With no
-            # manual request pending, this run IS the rescan: absorb the
-            # auto-rescan dirty flag so quiescence doesn't re-trigger for work
-            # this very scan already picks up.
-            pending_manual_ack: str | None = None
+            # of manual retry intent (processing carries no manual params). The
+            # earliest sticky request — if any — BEGINS the manual drain right
+            # here: set the freeze + owner (owner-checked, tied to this run's
+            # busy token) BEFORE any AUTO work, so no new ingress enters during
+            # the drain (LR2 §7.2). The request stays sticky and is ACKed only
+            # after the exclusive FAILED→PENDING reset persists (in
+            # BEGIN_EXCLUSIVE_RESET). FAILED is never swept inline — the initial
+            # scan drains the AUTO backlog only. With no manual request pending,
+            # this run IS the rescan: absorb the auto-rescan dirty flag so
+            # quiescence doesn't re-trigger for work this very scan already
+            # picks up.
+            initial_statuses = _AUTO_RESUME_DOC_STATUSES
             manual_msg = ingress.peek_next_manual_retry()
             if manual_msg is not None:
-                initial_statuses = _MANUAL_RETRY_DOC_STATUSES
-                pending_manual_ack = manual_msg.request_id
+                await self._begin_manual_drain(
+                    manual_msg.request_id, token, pipeline_status, pipeline_status_lock
+                )
                 absorbed_auto_rescan = False
             else:
-                initial_statuses = _AUTO_RESUME_DOC_STATUSES
                 absorbed_auto_rescan = ingress.consume_auto_rescan()
             # Own the absorbed signal from the INSTANT of consumption (see the
             # definition above the try): if the strict scan below raises —
@@ -1421,17 +1448,15 @@ class _PipelineMixin:
             uncommitted_wakeup = absorbed_auto_rescan and bool(to_process_docs)
 
             if not to_process_docs:
-                # Empty queue — a complete strict result, so a pending manual
-                # request is satisfied (nothing to retry) and can be ACKed.
-                if pending_manual_ack is not None:
-                    ingress.ack_manual_retry(pending_manual_ack)
-                    pending_manual_ack = None
-                # Release the slot we just took WITHOUT the "pipeline stopped"
-                # bookkeeping — a run that did no work should record nothing —
-                # but through the atomic quiescence decision that also consumes
-                # a wake-up signal (manual/auto/document) set by a
-                # concurrent publisher AFTER our read, so a doc that landed in
-                # that gap is not stranded in PENDING.
+                # Empty AUTO scan. Release the slot we just took WITHOUT the
+                # "pipeline stopped" bookkeeping — a run that did no work should
+                # record nothing — but through the atomic quiescence decision
+                # that also consumes a wake-up signal (manual/auto/document) set
+                # by a concurrent publisher AFTER our read, so a doc that landed
+                # in that gap is not stranded in PENDING. A pending manual is
+                # served here too: the decision returns BEGIN_EXCLUSIVE_RESET
+                # (phase already DRAIN_TO_IDLE), whose refetch runs the reset and
+                # ACKs — never RELEASED while a manual is being served.
                 logger.info("No documents to process")
                 decision = await self._decide_pipeline_next_step(
                     pipeline_status, pipeline_status_lock, ingress, sweep_cursor
@@ -1445,15 +1470,21 @@ class _PipelineMixin:
                     # the finally resets the cancellation state (surfacing the
                     # internal halt when applicable) and releases the slot.
                     return
-                # A wake-up signal (or an unfinished sweep) was pending: re-fetch
-                # per the decision and fall through into the loop to process it.
+                # A wake-up signal (or an unfinished sweep / manual reset) was
+                # pending: re-fetch per the decision and fall through into the
+                # loop to process it.
                 (
                     to_process_docs,
                     sweep_statuses,
                     sweep_cursor,
-                    pending_manual_ack,
                 ) = await self._refetch_for_decision(
-                    decision, sweep_statuses, sweep_cursor, ingress
+                    decision,
+                    sweep_statuses,
+                    sweep_cursor,
+                    ingress,
+                    token=token,
+                    pipeline_status=pipeline_status,
+                    pipeline_status_lock=pipeline_status_lock,
                 )
                 uncommitted_wakeup = decision.step in (
                     PipelineNextStep.CONTINUE_AUTO,
@@ -1507,11 +1538,6 @@ class _PipelineMixin:
                         return
 
                 if not to_process_docs:
-                    # The strict fetch that produced this empty view was
-                    # complete, so a manual request served by it is satisfied.
-                    if pending_manual_ack is not None:
-                        ingress.ack_manual_retry(pending_manual_ack)
-                        pending_manual_ack = None
                     log_message = "All enqueued documents have been processed"
                     logger.info(log_message)
                     pipeline_status["latest_message"] = log_message
@@ -1530,9 +1556,14 @@ class _PipelineMixin:
                         to_process_docs,
                         sweep_statuses,
                         sweep_cursor,
-                        pending_manual_ack,
                     ) = await self._refetch_for_decision(
-                        decision, sweep_statuses, sweep_cursor, ingress
+                        decision,
+                        sweep_statuses,
+                        sweep_cursor,
+                        ingress,
+                        token=token,
+                        pipeline_status=pipeline_status,
+                        pipeline_status_lock=pipeline_status_lock,
                     )
                     uncommitted_wakeup = decision.step in (
                         PipelineNextStep.CONTINUE_AUTO,
@@ -1540,25 +1571,19 @@ class _PipelineMixin:
                     ) and bool(to_process_docs)
                     continue
 
-                # Validate document data consistency and fix any issues
+                # Validate document data consistency and fix any issues. The
+                # AUTO sweep never carries FAILED (manual resets happen in the
+                # exclusive phase), so the validator only normalises interrupted
+                # orphans / stale PENDING here — it no longer ACKs a manual
+                # request.
                 to_process_docs = await self._validate_and_fix_document_consistency(
                     to_process_docs, pipeline_status, pipeline_status_lock
                 )
-                # The validator has taken the docs over (its FAILED→PENDING
-                # resets are persisted): the consumed signal is committed, and
-                # from here the batch/feeder teardown and the PENDING rows own
-                # recovery — a later cancel must NOT re-arm.
+                # The validator has taken the docs over (its resets are
+                # persisted): the consumed signal is committed, and from here
+                # the batch/feeder teardown and the PENDING rows own recovery —
+                # a later cancel must NOT re-arm.
                 uncommitted_wakeup = False
-
-                # ACK point for a manual retry request: the validation above
-                # persisted every FAILED→PENDING reset, and no worker has
-                # started yet — a crash after this line leaves the documents
-                # PENDING (recovered automatically), a crash before it leaves
-                # the request sticky (re-executed by the next run).  Validation
-                # raising skips this, so the request is never lost.
-                if pending_manual_ack is not None:
-                    ingress.ack_manual_retry(pending_manual_ack)
-                    pending_manual_ack = None
 
                 if not to_process_docs:
                     log_message = (
@@ -1581,9 +1606,14 @@ class _PipelineMixin:
                         to_process_docs,
                         sweep_statuses,
                         sweep_cursor,
-                        pending_manual_ack,
                     ) = await self._refetch_for_decision(
-                        decision, sweep_statuses, sweep_cursor, ingress
+                        decision,
+                        sweep_statuses,
+                        sweep_cursor,
+                        ingress,
+                        token=token,
+                        pipeline_status=pipeline_status,
+                        pipeline_status_lock=pipeline_status_lock,
                     )
                     uncommitted_wakeup = decision.step in (
                         PipelineNextStep.CONTINUE_AUTO,
@@ -1642,14 +1672,20 @@ class _PipelineMixin:
                 pipeline_status["history_messages"].append(log_message)
 
                 # Fetch the next batch: the next page of the current sweep
-                # (CONTINUE_SWEEP_PAGE) or a fresh sweep per the decision's tuple.
+                # (CONTINUE_SWEEP_PAGE), a manual reset/drain (CONTINUE_MANUAL /
+                # BEGIN_EXCLUSIVE_RESET) or a fresh sweep per the decision.
                 (
                     to_process_docs,
                     sweep_statuses,
                     sweep_cursor,
-                    pending_manual_ack,
                 ) = await self._refetch_for_decision(
-                    decision, sweep_statuses, sweep_cursor, ingress
+                    decision,
+                    sweep_statuses,
+                    sweep_cursor,
+                    ingress,
+                    token=token,
+                    pipeline_status=pipeline_status,
+                    pipeline_status_lock=pipeline_status_lock,
                 )
                 uncommitted_wakeup = decision.step in (
                     PipelineNextStep.CONTINUE_AUTO,
@@ -1701,7 +1737,24 @@ class _PipelineMixin:
                     # Release ``busy`` only if the loop did not already release it
                     # under the atomic exit check AND we still own the slot.
                     if not busy_released_in_loop and current_owner == token:
-                        updates.update({"busy": False, "busy_owner": None})
+                        # Clear the manual freeze in the SAME atomic update: an
+                        # abnormal exit (exception / cancel) mid drain-or-reset
+                        # must never leave a live-but-gone owner's freeze wedging
+                        # uploads forever (LR2 §6.1). The sticky manual request
+                        # survives in the mailbox and is re-run from Start by the
+                        # next owner (idempotent). A clean PROCESS-phase exit
+                        # already cleared it via _end_manual_drain, so this is a
+                        # no-op there.
+                        updates.update(
+                            {
+                                "busy": False,
+                                "busy_owner": None,
+                                "manual_freeze_requested": False,
+                                "manual_resetting": False,
+                                "manual_phase": MANUAL_PHASE_IDLE,
+                                "manual_owner": None,
+                            }
+                        )
                         current_owner = None  # slot is now free
                         released_here = True
 
@@ -2309,6 +2362,46 @@ class _PipelineMixin:
         if internal_abort:
             await self._discard_pending_index_ops()
 
+    def _build_pending_reset_update(
+        self,
+        status_doc: DocProcessingStatus,
+        content_data: dict | None,
+    ) -> tuple[dict, str, dict]:
+        """Build the doc_status upsert that returns one interrupted/FAILED doc
+        to a clean PENDING state, preserving the immutable ``created_at``.
+
+        Shared by the batch consistency validator and the manual EXCLUSIVE_RESET
+        (LR2 §7.3) so both scrub stale per-attempt metadata identically. Returns
+        ``(update_dict, resolved_file_path, reset_metadata)`` — the latter two so
+        the caller can also mirror them onto the in-memory ``status_doc`` when it
+        carries the doc forward into workers (the reset path does not).
+        """
+        preserved_chunks_list, preserved_chunks_count = chunk_fields_from_status_doc(
+            status_doc
+        )
+        resolved_file_path = resolve_doc_file_path(
+            status_doc=status_doc,
+            content_data=content_data,
+        )
+        # Directives-only metadata: drop per-attempt timing/result fields, keep
+        # process_options / source_file (legacy source_file_name tolerant).
+        reset_metadata = doc_status_reset_metadata(status_doc)
+        update = {
+            "status": DocStatus.PENDING,
+            "content_summary": status_doc.content_summary,
+            "content_length": status_doc.content_length,
+            "chunks_count": preserved_chunks_count,
+            "chunks_list": preserved_chunks_list,
+            "created_at": status_doc.created_at,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+            "file_path": resolved_file_path,
+            "track_id": getattr(status_doc, "track_id", ""),
+            "content_hash": getattr(status_doc, "content_hash", None),
+            "error_msg": "",
+            "metadata": reset_metadata,
+        }
+        return update, resolved_file_path, reset_metadata
+
     async def _validate_and_fix_document_consistency(
         self,
         to_process_docs: dict[str, DocProcessingStatus],
@@ -2457,31 +2550,10 @@ class _PipelineMixin:
             if not (is_interrupted or needs_pending_normalize):
                 continue
 
-            preserved_chunks_list, preserved_chunks_count = (
-                chunk_fields_from_status_doc(status_doc)
+            reset_update, resolved_file_path, reset_metadata = (
+                self._build_pending_reset_update(status_doc, content_data)
             )
-            resolved_file_path = resolve_doc_file_path(
-                status_doc=status_doc,
-                content_data=content_data,
-            )
-            # Directives-only metadata: drop per-attempt timing/result fields,
-            # keep process_options / source_file (legacy source_file_name
-            # tolerant).
-            reset_metadata = doc_status_reset_metadata(status_doc)
-            docs_to_reset[doc_id] = {
-                "status": DocStatus.PENDING,
-                "content_summary": status_doc.content_summary,
-                "content_length": status_doc.content_length,
-                "chunks_count": preserved_chunks_count,
-                "chunks_list": preserved_chunks_list,
-                "created_at": status_doc.created_at,
-                "updated_at": datetime.now(timezone.utc).isoformat(),
-                "file_path": resolved_file_path,
-                "track_id": getattr(status_doc, "track_id", ""),
-                "content_hash": getattr(status_doc, "content_hash", None),
-                "error_msg": "",
-                "metadata": reset_metadata,
-            }
+            docs_to_reset[doc_id] = reset_update
 
             # Mirror onto the in-memory status_doc so workers carry it forward.
             status_doc.status = DocStatus.PENDING
@@ -2512,6 +2584,265 @@ class _PipelineMixin:
                 pipeline_status["history_messages"].append(reset_message)
 
         return to_process_docs
+
+    # ============================================================
+    # Manual retry protocol: freeze → DRAIN_TO_IDLE → EXCLUSIVE_RESET
+    # (LR2 §6.1/§7). The busy processing run drives all three phases; the
+    # freeze/phase/owner state is owner-checked against THIS run's busy token,
+    # so a dead owner's reaper reclaim (which shares the busy pid) clears the
+    # whole manual state and the sticky request is re-run from scratch.
+    # ============================================================
+
+    def _manual_owner_record(self, request_id: str, token: str) -> dict:
+        """Build the ``manual_owner`` record — the busy run that holds the
+        freeze, identified by ``{request_id, owner_token, pid, process_start_id}``
+        (LR2 §6.1). Reuses the reservation owner record for the process identity
+        so liveness matches the busy owner's."""
+        owner = make_owner_record(token, "manual")
+        return {
+            "request_id": request_id,
+            "owner_token": owner["token"],
+            "pid": owner["pid"],
+            "process_start_id": owner["process_start_id"],
+        }
+
+    async def _begin_manual_drain(
+        self,
+        request_id: str,
+        token: str,
+        pipeline_status: dict,
+        pipeline_status_lock,
+    ) -> bool:
+        """Enter DRAIN_TO_IDLE for a manual retry (owner-checked, atomic).
+
+        Sets ``manual_freeze_requested=True`` (rejects new enqueue reservations),
+        ``manual_phase=DRAIN_TO_IDLE`` and ``manual_owner`` in ONE update, only
+        while we still own ``busy`` — never a True freeze flag with no owner
+        (LR2 §6.1). Returns False if we no longer own the slot."""
+        owner = self._manual_owner_record(request_id, token)
+
+        def _apply(status):
+            status.update(
+                {
+                    "manual_freeze_requested": True,
+                    "manual_resetting": False,
+                    "manual_phase": MANUAL_PHASE_DRAIN_TO_IDLE,
+                    "manual_owner": owner,
+                }
+            )
+            return True
+
+        return bool(
+            await with_reservation_lock(
+                pipeline_status,
+                pipeline_status_lock,
+                owner_key="busy_owner",
+                token=token,
+                action=_apply,
+            )
+        )
+
+    async def _end_manual_drain(
+        self,
+        token: str,
+        pipeline_status: dict,
+        pipeline_status_lock,
+    ) -> None:
+        """Clear the manual freeze/reset state back to idle (owner-checked).
+
+        Called after the ACK at the PROCESS transition, and defensively in the
+        run's finally: a live-but-exiting owner must never leave a freeze that
+        wedges uploads forever. Owner-checked so a handed-off/new owner's state
+        is never clobbered; the sticky request (if not yet ACKed) survives in
+        the mailbox and is re-run."""
+
+        def _apply(status):
+            status.update(
+                {
+                    "manual_freeze_requested": False,
+                    "manual_resetting": False,
+                    "manual_phase": MANUAL_PHASE_IDLE,
+                    "manual_owner": None,
+                }
+            )
+            return True
+
+        await with_reservation_lock(
+            pipeline_status,
+            pipeline_status_lock,
+            owner_key="busy_owner",
+            token=token,
+            action=_apply,
+        )
+
+    async def _still_freeze_owner(
+        self,
+        token: str,
+        pipeline_status: dict,
+        pipeline_status_lock,
+    ) -> bool:
+        """True iff THIS run still owns ``busy`` (and therefore the freeze).
+
+        The manual protocol runs single-threaded in the busy owner's task, so
+        the owner can only change via the dead-process reaper — impossible while
+        this task is alive. This check is defense-in-depth (LR2 §7.7 item 8):
+        every FAILED reset page verifies ownership before it writes."""
+
+        async def _run() -> bool:
+            async with pipeline_status_lock:
+                return _reservation_owner_token(pipeline_status.get("busy_owner")) == (
+                    token
+                )
+
+        return await run_to_completion(_run)
+
+    async def _next_failed_page(
+        self, position: CursorPosition
+    ) -> tuple[dict[str, DocProcessingStatus], CursorPosition]:
+        """Fetch ONE bounded page of FAILED docs, hydrated to full status.
+
+        The manual EXCLUSIVE_RESET pages FAILED so a huge backlog (LR2 §13.2
+        case 1: 10,000 FAILED) never materialises at once. ``page_size <= 0``
+        collapses to the legacy single strict scan (paging disabled). Ordering
+        is the immutable ``(created_at, id)`` keyset. A strict page/hydration
+        error propagates so the caller neither advances the cursor nor drops a
+        FAILED row (it stays FAILED for the next run)."""
+        page_size = getattr(self, "pipeline_scheduling_page_size", 0)
+        if page_size <= 0:
+            docs = await self.doc_status.get_docs_by_statuses(
+                [DocStatus.FAILED], strict=True
+            )
+            return docs, CURSOR_END
+
+        page = await self.doc_status.get_docs_by_statuses_page(
+            [DocStatus.FAILED],
+            limit=page_size,
+            position=position,
+            strict=True,
+        )
+        if not page.docs:
+            return {}, page.next_position
+        hydrated = await self.doc_status.get_full_docs_by_ids(
+            list(page.docs.keys()), strict=True
+        )
+        # Keep only rows still FAILED (a row raced out between page and
+        # hydration is no longer this reset's concern). str-enum equality lets
+        # a raw string or a DocStatus member both match.
+        failed = {
+            doc_id: doc
+            for doc_id, doc in hydrated.items()
+            if getattr(doc, "status", None) in {DocStatus.FAILED.value}
+        }
+        return failed, page.next_position
+
+    async def _reset_failed_page(
+        self,
+        docs: dict[str, DocProcessingStatus],
+        token: str,
+        pipeline_status: dict,
+        pipeline_status_lock,
+    ) -> int:
+        """Reset one page of FAILED docs to PENDING (LR2 §7.3 per-FAILED rules).
+
+        * journaled custom-chunk patch → skipped (an in-flight SDK operation
+          owns it; a reset would strip its recovery anchor);
+        * FAILED without ``full_docs`` content → skipped, left FAILED (an
+          unprocessable stub; a reset would immediately re-fail — matches the
+          batch validator's "preserve failed for manual review");
+        * otherwise → reset to PENDING preserving the immutable ``created_at``.
+
+        The page upsert is owner-checked: ownership is verified immediately
+        before the write, so a reaper reclaim (dead process) aborts the reset
+        instead of a stale task writing doc_status. Returns the reset count.
+        Raises on a storage read/write error so the caller keeps the request
+        sticky and does not advance the cursor."""
+        docs_to_reset: dict[str, dict] = {}
+        for doc_id, status_doc in docs.items():
+            if doc_status_custom_chunk_patch(status_doc) is not None:
+                continue
+            content_data = await self.full_docs.get_by_id(doc_id)
+            if not content_data:
+                continue
+            update, _, _ = self._build_pending_reset_update(status_doc, content_data)
+            docs_to_reset[doc_id] = update
+        if not docs_to_reset:
+            return 0
+        # Owner-checked page write (LR2 §7.7 item 8): confirm we still hold the
+        # freeze before persisting, so a dead-owner reclaim cannot be overwritten
+        # by this stale task.
+        if not await self._still_freeze_owner(
+            token, pipeline_status, pipeline_status_lock
+        ):
+            raise RuntimeError(
+                "manual reset lost freeze ownership before a FAILED→PENDING page "
+                "write; aborting so a new owner re-runs the reset from Start"
+            )
+        await self.doc_status.upsert(docs_to_reset)
+        return len(docs_to_reset)
+
+    async def _run_exclusive_failed_reset(
+        self,
+        request_id: str,
+        token: str,
+        pipeline_status: dict,
+        pipeline_status_lock,
+    ) -> bool:
+        """Phase two (LR2 §7.3): page FAILED→PENDING with NO worker running.
+
+        Precondition (guaranteed by the caller): DRAIN_TO_IDLE reached strict
+        idle — pending_enqueues/inflight/routing are 0 and no AUTO record
+        remains — so this reset runs without any failed producer. Transitions
+        ``manual_phase`` to EXCLUSIVE_RESET (``manual_resetting=True``,
+        owner-checked), then pages FAILED from Start to End, resetting each page.
+
+        Returns True when the reset reached End (caller ACKs); False if it lost
+        ownership. A storage error propagates: the request stays sticky, the
+        cursor does not advance, and the next run re-runs the reset from Start
+        (already-reset rows are PENDING and no longer appear on a FAILED page,
+        so no double reset — LR2 §7.3 "为什么不需要 generation/checkpoint")."""
+
+        def _enter(status):
+            status.update(
+                {
+                    "manual_resetting": True,
+                    "manual_phase": MANUAL_PHASE_EXCLUSIVE_RESET,
+                }
+            )
+            return True
+
+        if not await with_reservation_lock(
+            pipeline_status,
+            pipeline_status_lock,
+            owner_key="busy_owner",
+            token=token,
+            action=_enter,
+        ):
+            return False
+
+        total_reset = 0
+        cursor: CursorPosition = CURSOR_START
+        while True:
+            if not await self._still_freeze_owner(
+                token, pipeline_status, pipeline_status_lock
+            ):
+                return False
+            docs, cursor = await self._next_failed_page(cursor)
+            if docs:
+                total_reset += await self._reset_failed_page(
+                    docs, token, pipeline_status, pipeline_status_lock
+                )
+            if cursor is CURSOR_END:
+                break
+
+        reset_message = (
+            f"Manual retry {request_id[:8]}: reset {total_reset} FAILED "
+            "document(s) to PENDING (exclusive phase, no worker running)"
+        )
+        logger.info(reset_message)
+        async with pipeline_status_lock:
+            pipeline_status["latest_message"] = reset_message
+            pipeline_status["history_messages"].append(reset_message)
+        return True
 
     async def _next_scheduling_page(
         self,
@@ -2594,39 +2925,35 @@ class _PipelineMixin:
         critical section that would release ``busy``, so the loop refetches
         instead of stranding the new work.
 
-        Signal priority and semantics — the lock covers only this decision
-        (mailbox calls are single in-memory/Manager RPCs; storage queries
-        happen strictly outside, in :meth:`_refetch_for_decision`):
+        Fixed priority (LR2 §6.2): cancellation → advancement of the CURRENT
+        manual drain/reset → earliest (new) manual request → auto-rescan →
+        document mailbox → release. The lock covers only this decision (mailbox
+        calls are single in-memory/Manager RPCs; storage queries happen strictly
+        outside, in :meth:`_refetch_for_decision`).
 
-        0. **Cancellation** (consumes NOTHING): checked first, INSIDE this
-           critical section — the cancel endpoint sets the flag under the same
-           lock, so a cancel can never land between its own check and a
-           consuming step below.  The run stops with the ingress fully
-           retained; the caller routes an internal-error abort to the finally
-           (which surfaces the halt message) and a user cancel to the loop-top
-           handler (its "Pipeline cancelled" bookkeeping).
-        1. **Manual retry** (peeked, NOT consumed): earliest sticky request,
-           at most one per quiescence cycle; ACKed only after its
-           FAILED→PENDING resets persist, so crashing anywhere in between
-           re-executes it instead of losing it.
-        2. **Auto rescan** (consumed atomically): the supervisor is the sole
-           consumer of the dirty flag; a failed follow-up query re-arms it in
-           :meth:`_refetch_for_decision` — without consumption here,
-           ``has_work()`` would stay true forever and ``busy`` could never
-           release.
-        3. **Document channel non-empty** (peeked via ``counts``, NOT drained):
-           a message published after this batch's feeder stopped, or a stale
-           notification for a doc that has since reached a terminal state.
-           The run stays busy and the CONTINUE_DOCUMENT refetch resolves it —
-           live docs become the next batch, provably-stale messages are
-           compacted (see :meth:`_refetch_for_decision`).  Without this check
-           a doc published into a quiescing run with no other signal would
-           strand in PENDING until an unrelated trigger.
-        4. Nothing pending — ``has_work()`` is false: release the slot
-           together with its owner token so a later owner-checked release
-           (the finally, or a fresh acquirer) sees the slot as free and
-           unowned — RELEASED, caller breaks and skips clearing ``busy`` in
-           its finally block.
+        The decision is ``manual_phase``-aware (read from ``pipeline_status``
+        under this same lock):
+
+        * **DRAIN_TO_IDLE** — this run already holds the freeze and is draining
+          for a manual retry. Advancing THAT drain is top priority after cancel:
+          finish the AUTO sweep pages, consume auto-rescan / document backlog,
+          then wait for pre-freeze in-flight enqueues (CONTINUE_DRAIN_WAIT), and
+          once strictly idle enter the exclusive reset (BEGIN_EXCLUSIVE_RESET).
+          A second manual is NOT peeked here — it waits FIFO until this one ACKs
+          and the phase returns to IDLE (LR2 §7.5).
+        * **IDLE** — normal quiescence:
+          0. **Cancellation** (consumes NOTHING): the cancel endpoint sets the
+             flag under this same lock, so a cancel never lands between its
+             check and a consuming step below.
+          1. **Manual retry** (peeked, NOT consumed): earliest sticky request;
+             BEGINS a drain (CONTINUE_MANUAL sets the freeze). It preempts an
+             in-progress AUTO sweep (the drain re-scans AUTO from Start, so no
+             doc is lost). Stays sticky, ACKed only after the exclusive reset.
+          2. **Sweep page** — the in-progress bounded AUTO sweep has more pages.
+          3. **Auto rescan** (consumed atomically): sole consumer of the dirty
+             flag; re-armed on a failed follow-up query in the refetch.
+          4. **Document channel non-empty** (peeked, NOT drained).
+          5. Nothing pending: release the slot with its owner token — RELEASED.
 
         Boundary (documented, not solved here): this closes every
         published-but-missed handoff, but an enqueue that crashes BETWEEN its
@@ -2641,6 +2968,26 @@ class _PipelineMixin:
                     internal_error=pipeline_status.get("cancellation_reason")
                     == "internal_error",
                 )
+            if (
+                pipeline_status.get("manual_phase", MANUAL_PHASE_IDLE)
+                == MANUAL_PHASE_DRAIN_TO_IDLE
+            ):
+                # Advance the manual drain we already own (freeze is set). Drain
+                # every remaining page / signal, wait out pre-freeze in-flight
+                # enqueues, then run the exclusive reset. Do NOT peek a new
+                # manual — a second request waits FIFO (LR2 §7.5).
+                if sweep_cursor is not CURSOR_END:
+                    return PipelineNextDecision(PipelineNextStep.CONTINUE_SWEEP_PAGE)
+                if ingress.consume_auto_rescan():
+                    return PipelineNextDecision(PipelineNextStep.CONTINUE_AUTO)
+                if ingress.counts().get("documents"):
+                    return PipelineNextDecision(PipelineNextStep.CONTINUE_DOCUMENT)
+                if pipeline_status.get("pending_enqueues", 0) > 0:
+                    # Enqueues reserved BEFORE the freeze must finish (their
+                    # PENDING docs join this cohort) before the reset can start
+                    # with no failed producer (LR2 §7.2 step 5 / §7.3).
+                    return PipelineNextDecision(PipelineNextStep.CONTINUE_DRAIN_WAIT)
+                return PipelineNextDecision(PipelineNextStep.BEGIN_EXCLUSIVE_RESET)
             manual_msg = ingress.peek_next_manual_retry()
             if manual_msg is not None:
                 return PipelineNextDecision(
@@ -2668,30 +3015,37 @@ class _PipelineMixin:
         sweep_statuses,
         sweep_cursor: CursorPosition,
         ingress,
-    ) -> tuple[dict[str, DocProcessingStatus], tuple, CursorPosition, str | None]:
-        """Fetch the next batch for a CONTINUE_* decision (bounded, Phase 2).
+        *,
+        token: str,
+        pipeline_status: dict,
+        pipeline_status_lock,
+    ) -> tuple[dict[str, DocProcessingStatus], tuple, CursorPosition]:
+        """Fetch the next batch for a CONTINUE_*/BEGIN_* decision (bounded).
 
-        Returns ``(docs, next_statuses, next_cursor, pending_manual_ack)``:
+        Returns ``(docs, next_statuses, next_cursor)`` — the hydrated
+        full-status map to process plus the sweep state the caller threads into
+        the next ``_decide``/refetch (``next_cursor is CURSOR_END`` ends the
+        sweep). All manual ACKing is internal to BEGIN_EXCLUSIVE_RESET, so no
+        ACK id is returned.
 
-        * ``docs`` — the hydrated full-status map for the batch to process;
-        * ``next_statuses`` / ``next_cursor`` — the sweep state the caller
-          threads back into the next ``_decide``/refetch (``next_cursor is
-          CURSOR_END`` means this sweep is exhausted, so the next quiescence
-          decision falls through to auto-rescan/document/release);
-        * ``pending_manual_ack`` — the request id the caller must ACK once the
-          FAILED→PENDING resets persist (post-validation), or immediately on a
-          legitimately-empty complete result.
+        The continuations:
 
-        The four continuations:
-
-        * **CONTINUE_SWEEP_PAGE** — advance the SAME sweep to its next page via
-          :meth:`_next_scheduling_page`. Consumes no signal; a page-fetch
-          failure does NOT advance the cursor and arms auto-rescan so the
-          remaining backlog is recovered (LR2 §6.3).
-        * **CONTINUE_MANUAL** — start a fresh MANUAL sweep from ``CURSOR_START``
-          (single-scan: FAILED is in the tuple, so ``_next_scheduling_page``
-          returns one CURSOR_END page — the manual ACK contract needs every
-          reset persisted before ACK).
+        * **CONTINUE_SWEEP_PAGE** — advance the SAME sweep to its next page. A
+          page-fetch failure does NOT advance the cursor and arms auto-rescan so
+          the remaining backlog is recovered (LR2 §6.3).
+        * **CONTINUE_MANUAL** — BEGIN a manual drain (LR2 §7.2): set the freeze +
+          owner (owner-checked, tied to this run's busy token), phase →
+          DRAIN_TO_IDLE, then start a fresh AUTO sweep from ``CURSOR_START`` (the
+          drain processes the AUTO backlog; FAILED is reset only in the exclusive
+          phase). The manual request stays sticky — ACKed after the reset.
+        * **CONTINUE_DRAIN_WAIT** — bounded async sleep waiting for pre-freeze
+          in-flight enqueues to finish, then re-decide (empty batch).
+        * **BEGIN_EXCLUSIVE_RESET** — the drain reached strict idle. Do a FINAL
+          strict AUTO confirmation sweep (a doc a since-finished in-flight
+          enqueue added after the previous sweep passed); if non-empty, process
+          it and stay in the drain. If empty, run the exclusive FAILED→PENDING
+          reset (no worker), ACK the request, clear the freeze (→ PROCESS), then
+          fetch a fresh AUTO sweep so the just-reset PENDING docs get processed.
         * **CONTINUE_AUTO** — start a fresh bounded AUTO sweep from
           ``CURSOR_START``. The signal was consumed in the decision, so a
           first-page failure re-arms auto-rescan before propagating.
@@ -2701,13 +3055,9 @@ class _PipelineMixin:
           drained message's doc that is still live (its PENDING row persisted
           before its publish, which preceded the drain) is a PENDING row the
           multi-page sweep necessarily reaches, so a drained message never
-          needs re-publishing; a provably-stale one (terminal/deleted; FAILED
-          is manual-only by ruling) is compacted, which keeps a stale
-          notification from holding ``busy`` forever. A sweep-start failure
-          re-publishes the drained messages and arms auto-rescan as a backstop
-          before propagating; a SIGKILL — or a Manager response lost AFTER the
-          drain executed (at-most-once RPC) — loses only messages whose PENDING
-          rows the next run's initial scan recovers.
+          needs re-publishing; a provably-stale one (terminal/deleted) is
+          compacted. A sweep-start failure re-publishes the drained messages
+          and arms auto-rescan before propagating.
         """
         step = decision.step
 
@@ -2727,26 +3077,50 @@ class _PipelineMixin:
                         f"recovered by the NEXT explicit trigger: {compensation_error}"
                     )
                 raise
-            return docs, sweep_statuses, next_cursor, None
+            return docs, sweep_statuses, next_cursor
 
-        # (B) Start a FRESH sweep from CURSOR_START. CONTINUE_DOCUMENT drains
-        # the mailbox first (bounded); a deeper backlog re-triggers on the next
-        # decision.
+        # (A2) Manual drain: hold the freeze while the pre-freeze in-flight
+        # enqueues finish. Bounded async sleep (not a busy-loop); the next
+        # decision drains any doc they publish, then re-checks pending_enqueues.
+        if step is PipelineNextStep.CONTINUE_DRAIN_WAIT:
+            await asyncio.sleep(_MANUAL_DRAIN_POLL_SECONDS)
+            return {}, sweep_statuses, sweep_cursor
+
+        # (A3) The manual drain reached strict idle — run the exclusive reset.
+        if step is PipelineNextStep.BEGIN_EXCLUSIVE_RESET:
+            return await self._refetch_begin_exclusive_reset(
+                ingress,
+                token=token,
+                pipeline_status=pipeline_status,
+                pipeline_status_lock=pipeline_status_lock,
+            )
+
+        # (B) Start a FRESH sweep from CURSOR_START. CONTINUE_MANUAL begins the
+        # freeze first; CONTINUE_DOCUMENT drains the mailbox first (bounded).
         drained: list[PipelineIngressMessage] = []
         if step is PipelineNextStep.CONTINUE_MANUAL:
-            statuses = _MANUAL_RETRY_DOC_STATUSES
-        else:
-            statuses = _AUTO_RESUME_DOC_STATUSES
+            # Set the freeze + owner BEFORE draining so no new ingress enters
+            # (owner-checked; a lost slot winds the run down via an empty batch).
+            if not await self._begin_manual_drain(
+                decision.manual_request_id,
+                token,
+                pipeline_status,
+                pipeline_status_lock,
+            ):
+                return {}, _AUTO_RESUME_DOC_STATUSES, CURSOR_END
         if step is PipelineNextStep.CONTINUE_DOCUMENT:
             drained = ingress.drain_documents(limit=_FEEDER_DRAIN_LIMIT)
         try:
-            docs, next_cursor = await self._next_scheduling_page(statuses, CURSOR_START)
+            docs, next_cursor = await self._next_scheduling_page(
+                _AUTO_RESUME_DOC_STATUSES, CURSOR_START
+            )
         except BaseException:
             # Compensations must not raise over the original error (multiproc
             # mailbox calls are RPCs; BaseException here so even an interrupt
             # in a compensation call cannot displace it): the docs behind a
             # lost signal are still PENDING rows, recovered by the next run's
-            # initial scan.
+            # initial scan. A manual request stays sticky on its own (the freeze
+            # is cleared by the run's finally), so it needs no re-arm.
             try:
                 if step is PipelineNextStep.CONTINUE_AUTO:
                     ingress.request_auto_rescan()
@@ -2765,7 +3139,55 @@ class _PipelineMixin:
                     f"not automatically: {compensation_error}"
                 )
             raise
-        return docs, statuses, next_cursor, decision.manual_request_id
+        return docs, _AUTO_RESUME_DOC_STATUSES, next_cursor
+
+    async def _refetch_begin_exclusive_reset(
+        self,
+        ingress,
+        *,
+        token: str,
+        pipeline_status: dict,
+        pipeline_status_lock,
+    ) -> tuple[dict[str, DocProcessingStatus], tuple, CursorPosition]:
+        """BEGIN_EXCLUSIVE_RESET handler (LR2 §7.2 step 7-8 → §7.3 → §7.4).
+
+        A final strict AUTO sweep confirms the drain is complete; if it finds a
+        doc (an in-flight enqueue added it after the previous sweep passed), the
+        run processes it and stays in DRAIN_TO_IDLE. Otherwise the exclusive
+        FAILED→PENDING reset runs (no worker), the request is ACKed, the freeze
+        is cleared (→ PROCESS), and a fresh AUTO sweep returns the just-reset
+        PENDING docs for normal processing."""
+        # (1) Final strict confirmation that AUTO is drained.
+        docs, next_cursor = await self._next_scheduling_page(
+            _AUTO_RESUME_DOC_STATUSES, CURSOR_START
+        )
+        if docs:
+            return docs, _AUTO_RESUME_DOC_STATUSES, next_cursor
+
+        # (2) Read the request id off the freeze owner, then run the reset. A
+        # missing owner means a concurrent reaper cleared the freeze (dead
+        # process) — wind the run down via an empty PROCESS sweep.
+        async with pipeline_status_lock:
+            manual_owner = pipeline_status.get("manual_owner")
+        request_id = (manual_owner or {}).get("request_id")
+        if request_id is None:
+            return {}, _AUTO_RESUME_DOC_STATUSES, CURSOR_END
+
+        if await self._run_exclusive_failed_reset(
+            request_id, token, pipeline_status, pipeline_status_lock
+        ):
+            # ACK only after every FAILED→PENDING reset persisted (LR2 §7.3
+            # completion point): a crash before this re-runs the reset; a crash
+            # after is recovered by the now-persistent PENDING rows.
+            ingress.ack_manual_retry(request_id)
+            await self._end_manual_drain(token, pipeline_status, pipeline_status_lock)
+
+        # (3) PROCESS: the reset PENDING docs (and any admitted since the freeze
+        # cleared) are picked up by a fresh AUTO sweep.
+        docs, next_cursor = await self._next_scheduling_page(
+            _AUTO_RESUME_DOC_STATUSES, CURSOR_START
+        )
+        return docs, _AUTO_RESUME_DOC_STATUSES, next_cursor
 
     @staticmethod
     def _format_job_name(

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -373,6 +373,14 @@ class _BatchRunContext:
     #    set.
     inflight_doc_ids: set = field(default_factory=set)
     routing_doc_ids: set = field(default_factory=set)
+    # Reservation token of the run that owns ``busy`` for this batch (LR2 §7.7
+    # items 3/4/7). Every worker status write verifies it is still the current
+    # ``busy_owner`` before touching doc_status, so a run whose ownership was
+    # reclaimed (dead-process reaper, Manager generation change) discards its
+    # late results instead of writing a final status over the new owner's work.
+    # ``None`` disables the check and exists only for call paths that construct
+    # a context outside a reservation (tests).
+    run_owner_token: str | None = None
 
 
 class _PipelineMixin:
@@ -1633,6 +1641,7 @@ class _PipelineMixin:
                     pipeline_status=pipeline_status,
                     pipeline_status_lock=pipeline_status_lock,
                     ingress=ingress,
+                    token=token,
                 )
 
                 # Atomic exit handoff: if a wake-up signal arrived during this
@@ -2126,6 +2135,7 @@ class _PipelineMixin:
         pipeline_status: dict,
         pipeline_status_lock,
         ingress,
+        token: str | None = None,
     ) -> None:
         """Run one batch of pending documents through the parse → analyze →
         process queues.
@@ -2162,6 +2172,7 @@ class _PipelineMixin:
             # Pre-register the whole initial batch as inflight BEFORE the feeder
             # starts, so a document message that echoes an initial-batch doc is
             # deduplicated the moment the feeder runs.
+            run_owner_token=token,
             inflight_doc_ids=set(to_process_docs.keys()),
         )
 
@@ -2272,6 +2283,7 @@ class _PipelineMixin:
                     content_data = await self.full_docs.get_by_id(doc_id) or {}
                 except Exception as e:
                     await self._finalize_doc_failure(
+                        ctx=ctx,
                         doc_id=doc_id,
                         status_doc=status_doc,
                         file_path=file_path,
@@ -2661,6 +2673,26 @@ class _PipelineMixin:
             action=_apply,
         )
 
+    async def _still_run_owner(self, ctx: "_BatchRunContext") -> bool:
+        """True iff this batch run still owns ``busy`` (LR2 §7.7 items 3/4/7).
+
+        Guards every worker status write. ``run_owner_token is None`` means the
+        context was built outside a reservation (tests) and skips the check.
+
+        This is an in-memory owner check, deliberately NOT an expiring lease:
+        LR2 §7.7 keeps stale writers out by never revoking a live owner, and
+        notes that forcing takeover from a process that is alive but unreachable
+        would require a storage-verifiable fencing token, which the no-new-field
+        design does not have. So this rejects writes from a run whose ownership
+        was reclaimed after its process was CONFIRMED dead (or after a Manager
+        generation change) — it is not a partition-safe fence.
+        """
+        if ctx.run_owner_token is None:
+            return True
+        return await self._still_freeze_owner(
+            ctx.run_owner_token, ctx.pipeline_status, ctx.pipeline_status_lock
+        )
+
     async def _still_freeze_owner(
         self,
         token: str,
@@ -2737,20 +2769,49 @@ class _PipelineMixin:
           batch validator's "preserve failed for manual review");
         * otherwise → reset to PENDING preserving the immutable ``created_at``.
 
+        The ``full_docs`` probe is STRICT where the backend supports it: a plain
+        ``get_by_id`` may report a transport failure (or, on OpenSearch, an index
+        that is merely not ready) as a best-effort ``None``, which this loop
+        would read as "unprocessable stub" and skip. Every doc would then be
+        skipped, the sweep would still page to End, and the manual retry would be
+        ACKed having reset nothing — the user's "retry my failed documents"
+        silently doing nothing. A strict read raises instead, so the caller keeps
+        the request sticky and does not advance the cursor. Backends without the
+        capability keep the conservative skip but are COUNTED, so the operator
+        sees the reset was not complete instead of inferring success from silence.
+
         The page upsert is owner-checked: ownership is verified immediately
         before the write, so a reaper reclaim (dead process) aborts the reset
         instead of a stale task writing doc_status. Returns the reset count.
         Raises on a storage read/write error so the caller keeps the request
         sticky and does not advance the cursor."""
         docs_to_reset: dict[str, dict] = {}
+        unconfirmed = 0
+        strict_reads = getattr(self.full_docs, "supports_strict_point_reads", False)
         for doc_id, status_doc in docs.items():
             if doc_status_custom_chunk_patch(status_doc) is not None:
                 continue
-            content_data = await self.full_docs.get_by_id(doc_id)
+            if strict_reads:
+                content_data = await self.full_docs.get_by_id_strict(doc_id)
+            else:
+                content_data = await self.full_docs.get_by_id(doc_id)
+                if not content_data:
+                    unconfirmed += 1
             if not content_data:
                 continue
             update, _, _ = self._build_pending_reset_update(status_doc, content_data)
             docs_to_reset[doc_id] = update
+        if unconfirmed:
+            warning = (
+                f"Manual retry: {unconfirmed} FAILED document(s) left untouched — "
+                f"{type(self.full_docs).__name__} cannot confirm whether their "
+                f"content is really absent (no strict point reads), so a storage "
+                f"failure is indistinguishable from an unprocessable stub"
+            )
+            logger.warning(warning)
+            async with pipeline_status_lock:
+                pipeline_status["latest_message"] = warning
+                pipeline_status["history_messages"].append(warning)
         if not docs_to_reset:
             return 0
         # Owner-checked page write (LR2 §7.7 item 8): confirm we still hold the
@@ -3232,6 +3293,7 @@ class _PipelineMixin:
                     ctx.pipeline_status, ctx.pipeline_status_lock
                 ):
                     await self._mark_doc_cancelled_in_stage(
+                        ctx=ctx,
                         doc_id=doc_id_w,
                         status_doc=status_doc_w,
                         file_path=file_path_w,
@@ -3271,6 +3333,7 @@ class _PipelineMixin:
                 # point), so they are not carried into this PARSING upsert.
                 status_doc_w.metadata["parse_start_time"] = int(time.time())
                 await self._upsert_doc_status_transition(
+                    ctx=ctx,
                     doc_id=doc_id_w,
                     status=DocStatus.PARSING,
                     status_doc=status_doc_w,
@@ -3375,6 +3438,7 @@ class _PipelineMixin:
                     ctx.pipeline_status, ctx.pipeline_status_lock
                 ):
                     await self._mark_doc_cancelled_in_stage(
+                        ctx=ctx,
                         doc_id=doc_id_w,
                         status_doc=status_doc_w,
                         file_path=file_path_w,
@@ -3477,6 +3541,7 @@ class _PipelineMixin:
                     content_data=content_data_w,
                     pipeline_status=ctx.pipeline_status,
                     pipeline_status_lock=ctx.pipeline_status_lock,
+                    ctx=ctx,
                 ):
                     continue
 
@@ -3498,6 +3563,7 @@ class _PipelineMixin:
                 # ANALYZING transition via carry-over. content_hash is already
                 # refreshed and duplicates are filtered out by this point.
                 await self._upsert_doc_status_transition(
+                    ctx=ctx,
                     doc_id=doc_id_w,
                     status=DocStatus.PARSING,
                     status_doc=status_doc_w,
@@ -3528,6 +3594,7 @@ class _PipelineMixin:
                 # event. Parser-executor shutdown is intentionally a distinct
                 # exception and remains a generic parse failure for audit.
                 await self._mark_doc_cancelled_in_stage(
+                    ctx=ctx,
                     doc_id=doc_id_w,
                     status_doc=status_doc_w,
                     file_path=getattr(status_doc_w, "file_path", "unknown_source"),
@@ -3548,6 +3615,7 @@ class _PipelineMixin:
                 )
                 try:
                     await self._upsert_doc_status_transition(
+                        ctx=ctx,
                         doc_id=doc_id_w,
                         status=DocStatus.FAILED,
                         status_doc=status_doc_w,
@@ -3587,6 +3655,7 @@ class _PipelineMixin:
                     ctx.pipeline_status, ctx.pipeline_status_lock
                 ):
                     await self._mark_doc_cancelled_in_stage(
+                        ctx=ctx,
                         doc_id=doc_id_w,
                         status_doc=status_doc_w,
                         file_path=file_path_w,
@@ -3607,6 +3676,7 @@ class _PipelineMixin:
                     status_doc_w.metadata = {}
                 status_doc_w.metadata["analyzing_start_time"] = int(time.time())
                 await self._upsert_doc_status_transition(
+                    ctx=ctx,
                     doc_id=doc_id_w,
                     status=DocStatus.ANALYZING,
                     status_doc=status_doc_w,
@@ -3651,6 +3721,7 @@ class _PipelineMixin:
                 # the extra upsert; PROCESSING will be their next doc_status write.
                 if analyze_outcome_recorded:
                     await self._upsert_doc_status_transition(
+                        ctx=ctx,
                         doc_id=doc_id_w,
                         status=DocStatus.ANALYZING,
                         status_doc=status_doc_w,
@@ -3663,6 +3734,7 @@ class _PipelineMixin:
                 # Route through the friendly message path so error_msg and
                 # history_messages match the boundary-check branch.
                 await self._mark_doc_cancelled_in_stage(
+                    ctx=ctx,
                     doc_id=doc_id_w,
                     status_doc=status_doc_w,
                     file_path=getattr(status_doc_w, "file_path", "unknown_source"),
@@ -3679,6 +3751,7 @@ class _PipelineMixin:
                 logger.error(f"Analyze worker failed: {e}")
                 try:
                     await self._upsert_doc_status_transition(
+                        ctx=ctx,
                         doc_id=doc_id_w,
                         status=DocStatus.FAILED,
                         status_doc=status_doc_w,
@@ -4192,6 +4265,7 @@ class _PipelineMixin:
                 # Stage 1: persist doc_status PROCESSING + chunks in parallel.
                 doc_status_task = asyncio.create_task(
                     self._upsert_doc_status_transition(
+                        ctx=ctx,
                         doc_id=doc_id,
                         status=DocStatus.PROCESSING,
                         status_doc=status_doc,
@@ -4244,6 +4318,7 @@ class _PipelineMixin:
                     [entity_relation_task] if entity_relation_task else []
                 )
                 await self._finalize_doc_failure(
+                    ctx=ctx,
                     doc_id=doc_id,
                     status_doc=status_doc,
                     file_path=file_path,
@@ -4322,6 +4397,7 @@ class _PipelineMixin:
 
                     process_end_time = int(time.time())
                     await self._upsert_doc_status_transition(
+                        ctx=ctx,
                         doc_id=doc_id,
                         status=DocStatus.PROCESSED,
                         status_doc=status_doc,
@@ -4372,6 +4448,7 @@ class _PipelineMixin:
                             f"Aborting pipeline batch due to storage flush error: {e}"
                         )
                     await self._finalize_doc_failure(
+                        ctx=ctx,
                         doc_id=doc_id,
                         status_doc=status_doc,
                         file_path=file_path,
@@ -4489,6 +4566,7 @@ class _PipelineMixin:
         status_doc: DocProcessingStatus,
         file_path: str,
         *,
+        ctx: "_BatchRunContext",
         extra_fields: dict[str, Any] | None = None,
         metadata_extra: dict[str, Any] | None = None,
     ) -> None:
@@ -4499,7 +4577,25 @@ class _PipelineMixin:
         ``chunks_count`` / ``chunks_list`` / ``error_msg``; ``metadata_extra``
         is forwarded to ``doc_status_transition_metadata`` so carry-over
         fields (e.g. ``process_options``) survive every state change.
+
+        Owner-checked (LR2 §7.7 items 3/4/7): every worker status write verifies
+        its run still owns ``busy`` immediately before writing, and a run whose
+        ownership was reclaimed DISCARDS the result with a warning instead of
+        writing. Without this, a storage/LLM response arriving late in a run that
+        was already declared dead could stamp a final status over the new owner's
+        work — including re-FAILING a document the manual exclusive reset had just
+        moved to PENDING, which would ACK the retry with the document still
+        failed. ``ctx`` is required so a new call site has to state which run the
+        write belongs to.
         """
+        if not await self._still_run_owner(ctx):
+            logger.warning(
+                f"[stale-writer] Discarded {getattr(status, 'value', status)} "
+                f"status write for {doc_id} ({file_path}): this run no longer "
+                f"owns the pipeline (ownership was reclaimed), so the result is "
+                f"late and must not overwrite the current owner's state"
+            )
+            return
         payload: dict[str, Any] = {
             "status": status,
             "content_summary": status_doc.content_summary,
@@ -4598,6 +4694,7 @@ class _PipelineMixin:
         status_doc: DocProcessingStatus,
         file_path: str,
         stage_label: str,
+        ctx: "_BatchRunContext",
         pipeline_status: dict,
         pipeline_status_lock,
     ) -> None:
@@ -4625,6 +4722,7 @@ class _PipelineMixin:
         )
         try:
             await self._upsert_doc_status_transition(
+                ctx=ctx,
                 doc_id=doc_id,
                 status=DocStatus.FAILED,
                 status_doc=status_doc,
@@ -4647,6 +4745,7 @@ class _PipelineMixin:
         failed_chunks_snapshot: tuple[list[str], int],
         pending_tasks: list[asyncio.Task],
         metadata_extra: dict[str, Any],
+        ctx: "_BatchRunContext",
         pipeline_status: dict,
         pipeline_status_lock,
     ) -> None:
@@ -4714,6 +4813,7 @@ class _PipelineMixin:
 
         failed_chunks_list, failed_chunks_count = failed_chunks_snapshot
         await self._upsert_doc_status_transition(
+            ctx=ctx,
             doc_id=doc_id,
             status=DocStatus.FAILED,
             status_doc=status_doc,
@@ -4804,8 +4904,14 @@ class _PipelineMixin:
         content_data: dict[str, Any] | None = None,
         pipeline_status: dict | None = None,
         pipeline_status_lock: asyncio.Lock | None = None,
+        ctx: "_BatchRunContext | None" = None,
     ) -> bool:
-        """Mark post-parse content duplicates and stop further processing."""
+        """Mark post-parse content duplicates and stop further processing.
+
+        Owner-checked like every other worker status write (LR2 §7.7 items 3/4):
+        this one does not go through ``_upsert_doc_status_transition``, so it
+        verifies ownership itself before the FAILED-duplicate upsert.
+        """
         if not content_hash:
             return False
 
@@ -4813,6 +4919,13 @@ class _PipelineMixin:
             self.doc_status, content_hash, doc_id
         )
         if not match:
+            return False
+
+        if ctx is not None and not await self._still_run_owner(ctx):
+            logger.warning(
+                f"[stale-writer] Discarded duplicate marking for {doc_id} "
+                f"({file_path}): this run no longer owns the pipeline"
+            )
             return False
 
         original_doc_id, original_doc = match

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -455,7 +455,7 @@ class _PipelineMixin:
         # doc_status, so a consistency check never sees a ghost row, and
         # (b) the running loop observes the ingress mailbox mid-batch and
         # at every batch boundary, so work that arrives while busy is
-        # picked up without a new run.  Two states still block enqueue:
+        # picked up without a new run.  Three states still block enqueue:
         #   * ``scanning_exclusive`` — scan task is in its CLASSIFICATION
         #     phase, reading doc_status to classify files and possibly
         #     deleting stale stubs.  Concurrent enqueue would race
@@ -463,6 +463,10 @@ class _PipelineMixin:
         #     lifts this guard for the scan task's own enqueues.
         #     ``scanning`` alone (the processing phase) does NOT block,
         #     identical to the upload-during-busy case.
+        #   * ``manual_freeze_requested`` — a manual retry has frozen new
+        #     ingress while it drains the pipeline to idle and exclusively
+        #     resets FAILED→PENDING (LR2 §6.1/§7.2).  Also lifted by
+        #     ``from_scan=True`` (the scan owns the manual operation).
         #   * ``destructive_busy`` — clear / delete is dropping storages
         #     or removing input files; a concurrent write would be
         #     silently clobbered.
@@ -479,6 +483,17 @@ class _PipelineMixin:
                     "scanning_exclusive",
                     "Cannot enqueue while scan is classifying files; wait for the "
                     "classification phase to finish before retrying.",
+                )
+            )
+            # A manual retry (LR2 §6.1/§7.2) froze new ingress while it drains
+            # the pipeline and exclusively resets FAILED→PENDING. Lifted for
+            # ``from_scan=True`` exactly like scanning_exclusive: the scan is the
+            # manual operation's own driver, so its enqueues must not self-block.
+            reject_when.append(
+                (
+                    "manual_freeze_requested",
+                    "Cannot enqueue while a manual retry is draining the pipeline; "
+                    "wait for it to finish before retrying.",
                 )
             )
         reject_when.append(

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -60,7 +60,7 @@ from lightrag.kg.shared_storage import (
     get_namespace_data,
     get_namespace_lock,
     get_pipeline_ingress,
-    make_owner_record,
+    make_manual_owner_record,
     run_to_completion,
     with_reservation_lock,
 )
@@ -2593,19 +2593,6 @@ class _PipelineMixin:
     # whole manual state and the sticky request is re-run from scratch.
     # ============================================================
 
-    def _manual_owner_record(self, request_id: str, token: str) -> dict:
-        """Build the ``manual_owner`` record — the busy run that holds the
-        freeze, identified by ``{request_id, owner_token, pid, process_start_id}``
-        (LR2 §6.1). Reuses the reservation owner record for the process identity
-        so liveness matches the busy owner's."""
-        owner = make_owner_record(token, "manual")
-        return {
-            "request_id": request_id,
-            "owner_token": owner["token"],
-            "pid": owner["pid"],
-            "process_start_id": owner["process_start_id"],
-        }
-
     async def _begin_manual_drain(
         self,
         request_id: str,
@@ -2619,7 +2606,7 @@ class _PipelineMixin:
         ``manual_phase=DRAIN_TO_IDLE`` and ``manual_owner`` in ONE update, only
         while we still own ``busy`` — never a True freeze flag with no owner
         (LR2 §6.1). Returns False if we no longer own the slot."""
-        owner = self._manual_owner_record(request_id, token)
+        owner = make_manual_owner_record(request_id, token)
 
         def _apply(status):
             status.update(

--- a/tests/api/routes/test_document_routes_docx_archive.py
+++ b/tests/api/routes/test_document_routes_docx_archive.py
@@ -1150,6 +1150,45 @@ async def test_upload_returns_409_when_scanning_classification(tmp_path, monkeyp
     assert not (tmp_path / "while_scanning.docx").exists()
 
 
+async def test_upload_returns_409_when_manual_freeze(tmp_path, monkeypatch):
+    """LR2 Phase 3: while a manual retry has frozen new ingress
+    (``manual_freeze_requested=True``) to drain the pipeline and reset FAILED,
+    a new upload must refuse with 409 (MANUAL_FREEZE) — not silently land in a
+    window that violates the reset's "no failed producer" precondition."""
+    import importlib
+
+    monkeypatch.setattr(
+        _document_routes, "global_args", SimpleNamespace(max_upload_size=None)
+    )
+    doc_manager = DocumentManager(str(tmp_path))
+    rag = _DuplicateUploadRag({})
+
+    shared_storage = importlib.import_module("lightrag.kg.shared_storage")
+    await shared_storage.initialize_pipeline_status(workspace=rag.workspace)
+    pipeline_status = await shared_storage.get_namespace_data(
+        "pipeline_status", workspace=rag.workspace
+    )
+    pipeline_status["busy"] = True
+    pipeline_status["manual_freeze_requested"] = True
+
+    router = create_document_routes(rag, doc_manager)
+    upload_endpoint = [
+        route.endpoint
+        for route in router.routes
+        if getattr(route, "name", "") == "upload_to_input_dir"
+    ][-1]
+    upload_file = _document_routes.UploadFile(
+        filename="while_freezing.docx",
+        file=BytesIO(b"docx bytes"),
+    )
+
+    with pytest.raises(_document_routes.HTTPException) as excinfo:
+        await upload_endpoint(set(), upload_file)
+    assert excinfo.value.status_code == 409
+    assert "retry of failed documents" in excinfo.value.detail.lower()
+    assert not (tmp_path / "while_freezing.docx").exists()
+
+
 async def test_upload_succeeds_during_scan_processing_phase(tmp_path, monkeypatch):
     """User-reported scenario: while pipeline is doing scan-driven
     processing (``scanning=True`` but ``scanning_exclusive=False``),

--- a/tests/kg/test_reservation_dead_process_recovery.py
+++ b/tests/kg/test_reservation_dead_process_recovery.py
@@ -177,6 +177,23 @@ def test_reconcile_is_noop_when_disabled():
     assert status["busy_owner"] is not None
 
 
+async def test_reap_dead_reservations_locked_drops_dead_token(recovery_enabled):
+    # LR2 Phase 3 liveness: the manual DRAIN_TO_IDLE wait reaps a dead
+    # enqueue token itself (the freeze blocks the uploads that would otherwise
+    # reap it), so the drain can reach the exclusive reset instead of polling
+    # forever on a phantom pending_enqueues count.
+    status = {
+        "pending_enqueues": 2,
+        "pending_enqueue_tokens": {
+            "live": {"pid": os.getpid(), "process_start_id": None},
+            "dead": {"pid": _dead_pid(), "process_start_id": "gone"},
+        },
+    }
+    await shared_storage.reap_dead_reservations_locked(status, asyncio.Lock())
+    assert set(status["pending_enqueue_tokens"]) == {"live"}
+    assert status["pending_enqueues"] == 1
+
+
 def test_pipeline_recovery_blocked_message():
     status = {
         "recovery_required": {

--- a/tests/kg/test_reservation_dead_process_recovery.py
+++ b/tests/kg/test_reservation_dead_process_recovery.py
@@ -83,6 +83,27 @@ def test_reconcile_reclaims_dead_processing_owner(recovery_enabled):
     assert "recovery_required" not in status  # re-runnable, not fenced
 
 
+def test_reconcile_clears_manual_state_with_dead_busy_owner(recovery_enabled):
+    # LR2 Phase 3 §6.1: the manual-retry freeze is driven BY the busy processing
+    # run, so a dead busy owner must clear the whole manual state in the same
+    # atomic reclaim — never a True freeze flag with no live owner. The sticky
+    # request survives in the mailbox and is re-run by the next owner.
+    status = {
+        "busy": True,
+        "busy_owner": _dead_owner("processing"),
+        "manual_freeze_requested": True,
+        "manual_resetting": True,
+        "manual_phase": shared_storage.MANUAL_PHASE_EXCLUSIVE_RESET,
+        "manual_owner": {"request_id": "r1", "token": "t", "pid": 999999},
+    }
+    reconcile_dead_pipeline_reservations(status)
+    assert status["busy"] is False and status["busy_owner"] is None
+    assert status["manual_freeze_requested"] is False
+    assert status["manual_resetting"] is False
+    assert status["manual_phase"] == shared_storage.MANUAL_PHASE_IDLE
+    assert status["manual_owner"] is None
+
+
 def test_reconcile_reclaims_dead_scan_owner(recovery_enabled):
     status = {
         "scanning": True,
@@ -178,8 +199,30 @@ def test_internal_fields_constant_covers_recovery_state():
         "pending_enqueue_tokens",
         "operation_record",
         "recovery_required",
+        # Phase 3 manual coordination — hidden from the public /pipeline_status
+        # response (manual_owner carries pid/token identity).
+        "manual_owner",
+        "manual_freeze_requested",
+        "manual_resetting",
+        "manual_phase",
     ):
         assert field in _INTERNAL_PIPELINE_STATUS_FIELDS
+
+
+async def test_initialize_pipeline_status_seeds_manual_state_at_idle(tmp_path):
+    # Phase 3: the manual-retry runtime state exists at init, defaulted to a
+    # clean idle (no freeze, no owner) so a fresh workspace never appears frozen.
+    ws = "manual-init-ws"
+    initialize_share_data()
+    try:
+        await initialize_pipeline_status(workspace=ws)
+        ps = await get_namespace_data("pipeline_status", workspace=ws)
+        assert ps["manual_freeze_requested"] is False
+        assert ps["manual_resetting"] is False
+        assert ps["manual_phase"] == shared_storage.MANUAL_PHASE_IDLE
+        assert ps["manual_owner"] is None
+    finally:
+        finalize_share_data()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/kg/test_reservation_primitives.py
+++ b/tests/kg/test_reservation_primitives.py
@@ -150,6 +150,45 @@ async def test_enqueue_acquire_combines_recovery_and_reservation_update(monkeypa
 
 
 @pytest.mark.offline
+async def test_enqueue_acquire_rejects_under_manual_freeze():
+    # LR2 Phase 3 §6.1/§7.2: a manual retry freeze rejects NEW enqueue
+    # reservations with the dedicated MANUAL_FREEZE conflict (HTTP 409).
+    ps = {
+        "busy": False,
+        "busy_owner": None,
+        "scanning_owner": None,
+        "destructive_busy": False,
+        "manual_freeze_requested": True,
+        "pending_enqueue_tokens": {},
+        "pending_enqueues": 0,
+    }
+
+    result = await acquire_enqueue_reservation(
+        ps,
+        asyncio.Lock(),
+        token="new",
+        reject_when=(
+            ("destructive_busy", "destructive"),
+            ("manual_freeze_requested", "manual retry draining"),
+        ),
+    )
+
+    assert result.acquired is False
+    assert result.conflict is shared_storage.PipelineReservationConflict.MANUAL_FREEZE
+    assert result.message == "manual retry draining"
+    # No slot taken while frozen.
+    assert ps["pending_enqueue_tokens"] == {} and ps["pending_enqueues"] == 0
+
+
+@pytest.mark.offline
+def test_manual_freeze_flag_maps_to_manual_freeze_conflict():
+    assert (
+        shared_storage._conflict_for_status_flag("manual_freeze_requested")
+        is shared_storage.PipelineReservationConflict.MANUAL_FREEZE
+    )
+
+
+@pytest.mark.offline
 async def test_single_owner_acquire_always_honors_recovery_fence(monkeypatch):
     monkeypatch.setattr(shared_storage, "_reservation_recovery_enabled", lambda: True)
     monkeypatch.setattr(shared_storage, "_process_alive", lambda *_: False)

--- a/tests/pipeline/test_bounded_scheduling.py
+++ b/tests/pipeline/test_bounded_scheduling.py
@@ -11,9 +11,10 @@ These cover the §12-Phase2 acceptance list:
   processed — the tail is never starved);
 * a page-query failure does NOT advance the cursor and re-arms auto-rescan,
   so the remaining backlog is recovered by the next run;
-* ``PIPELINE_SCHEDULING_PAGE_SIZE=0`` collapses to the legacy single scan;
-* a manual retry sweep (FAILED included) stays single-scan even with paging
-  on, preserving the ACK-after-all-resets contract.
+* ``PIPELINE_SCHEDULING_PAGE_SIZE=0`` collapses to the legacy single scan.
+
+(The AUTO sweep never carries FAILED post-Phase-3; the manual FAILED reset is
+paged separately by ``_next_failed_page`` — see ``test_manual_exclusive_reset``.)
 """
 
 from __future__ import annotations
@@ -25,12 +26,8 @@ import numpy as np
 import pytest
 
 from lightrag import LightRAG
-from lightrag.base import CURSOR_END, CURSOR_START, DocStatus
+from lightrag.base import CURSOR_START, DocStatus
 from lightrag.kg.shared_storage import get_pipeline_ingress
-from lightrag.pipeline import (
-    _AUTO_RESUME_DOC_STATUSES,
-    _MANUAL_RETRY_DOC_STATUSES,
-)
 from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
 
 pytestmark = pytest.mark.offline
@@ -216,38 +213,6 @@ def test_sweep_page_failure_rearms_auto_and_recovers(tmp_path):
             await rag.apipeline_process_enqueue_documents()
             for doc_id in ids:
                 assert await _status_of(rag, doc_id) == DocStatus.PROCESSED.value
-        finally:
-            await rag.finalize_storages()
-
-    asyncio.run(_run())
-
-
-def test_next_scheduling_page_manual_stays_single_scan(tmp_path):
-    """A manual retry sweep (FAILED in the tuple) is NEVER paged even with
-    paging on — the manual ACK contract needs all FAILED→PENDING resets to
-    persist before the ACK, which a multi-page sweep would break. It returns
-    one CURSOR_END page via the legacy scan."""
-
-    async def _run():
-        rag = await _build_rag(tmp_path, page_size=2)
-        try:
-            await _enqueue_n(rag, 3)
-            counts = _count_page_calls(rag)
-
-            docs, cursor = await rag._next_scheduling_page(
-                _MANUAL_RETRY_DOC_STATUSES, CURSOR_START
-            )
-            assert cursor is CURSOR_END  # single page, sweep exhausted
-            assert counts["scan"] == 1 and counts["page"] == 0
-            assert len(docs) == 3
-
-            # An AUTO sweep with the same page_size DOES page.
-            counts["scan"] = counts["page"] = 0
-            _docs, auto_cursor = await rag._next_scheduling_page(
-                _AUTO_RESUME_DOC_STATUSES, CURSOR_START
-            )
-            assert counts["page"] == 1 and counts["scan"] == 0
-            assert auto_cursor is not CURSOR_END  # 3 docs > page_size 2
         finally:
             await rag.finalize_storages()
 

--- a/tests/pipeline/test_manual_exclusive_reset.py
+++ b/tests/pipeline/test_manual_exclusive_reset.py
@@ -1,0 +1,257 @@
+"""Manual retry EXCLUSIVE_RESET protocol (LR2 Phase 3).
+
+A manual retry no longer sweeps FAILED inline with workers. Instead it freezes
+new ingress, drains the AUTO backlog to idle, then — with NO worker running —
+pages FAILED→PENDING (preserving created_at), ACKs, clears the freeze and
+processes the reset docs. These tests pin the Phase-3-specific observables that
+the shared failed-retry semantics suite does not: the reset is PAGED (bounded),
+the freeze rejects new enqueue reservations while draining, created_at is
+preserved, and a FAILED stub without content is left FAILED.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import uuid4
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG
+from lightrag.base import CURSOR_START, DocStatus
+from lightrag.kg.shared_storage import (
+    MANUAL_PHASE_DRAIN_TO_IDLE,
+    PipelineReservationConflict,
+    acquire_enqueue_reservation,
+    get_namespace_data,
+    get_namespace_lock,
+    make_owner_record,
+)
+from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
+
+from .conftest import request_failed_retry
+
+pytestmark = pytest.mark.offline
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _dummy_embedding(texts: list[str]) -> np.ndarray:
+    return np.ones((len(texts), 8), dtype=float)
+
+
+async def _dummy_llm(*args, **kwargs) -> str:
+    return "ok"
+
+
+def _chunking(tokenizer, content, *a, **k) -> list[dict]:
+    return [{"tokens": 1, "content": f"{content}::chunk1", "chunk_order_index": 0}]
+
+
+class _CountingExtract:
+    def __init__(self, fail: bool = False):
+        self.fail = fail
+        self.calls = 0
+
+    async def __call__(self, chunks, *args, **kwargs):
+        self.calls += 1
+        if self.fail:
+            raise RuntimeError("extract fail sentinel")
+        return [({}, {}) for _ in chunks]
+
+
+async def _build_rag(tmp_path, extract: _CountingExtract) -> LightRAG:
+    rag = LightRAG(
+        working_dir=str(tmp_path / "wd"),
+        workspace=f"mxr-{uuid4().hex[:8]}",
+        llm_model_func=_dummy_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8, max_token_size=8192, func=_dummy_embedding
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        chunking_func=_chunking,
+        max_parallel_insert=1,
+    )
+    await rag.initialize_storages()
+    rag._process_extract_entities = extract
+    return rag
+
+
+async def _status_of(rag: LightRAG, doc_id: str) -> str:
+    row = await rag.doc_status.get_by_id(doc_id)
+    raw = (row or {}).get("status")
+    return raw.value if isinstance(raw, DocStatus) else str(raw or "<missing>")
+
+
+async def _make_failed(rag: LightRAG, name: str, extract: _CountingExtract) -> str:
+    extract.fail = True
+    await rag.apipeline_enqueue_documents(input=f"body of {name}", file_paths=name)
+    await rag.apipeline_process_enqueue_documents()
+    doc_id = compute_mdhash_id(name, prefix="doc-")
+    assert await _status_of(rag, doc_id) == DocStatus.FAILED.value
+    return doc_id
+
+
+def test_exclusive_reset_pages_failed_backlog(tmp_path):
+    """With paging on and a small page, the exclusive reset pages the FAILED
+    backlog (never one giant scan) and every FAILED doc is reset+reprocessed."""
+
+    async def _run():
+        extract = _CountingExtract()
+        rag = await _build_rag(tmp_path, extract)
+        try:
+            rag.pipeline_scheduling_page_size = 2
+            ids = [await _make_failed(rag, f"f{i}.txt", extract) for i in range(5)]
+
+            page_calls = {"failed": 0}
+            original_page = rag.doc_status.get_docs_by_statuses_page
+
+            async def counting_page(statuses, *, limit, position, strict=False):
+                if list(statuses) == [DocStatus.FAILED]:
+                    page_calls["failed"] += 1
+                return await original_page(
+                    statuses, limit=limit, position=position, strict=strict
+                )
+
+            rag.doc_status.get_docs_by_statuses_page = counting_page
+
+            extract.fail = False
+            await request_failed_retry(rag)
+            await rag.apipeline_process_enqueue_documents()
+
+            # Every FAILED doc was reset and reprocessed.
+            for doc_id in ids:
+                assert await _status_of(rag, doc_id) == DocStatus.PROCESSED.value
+            # Paged: 5 docs / page 2 → at least 3 FAILED page fetches (2+2+1),
+            # i.e. never a single unbounded scan.
+            assert page_calls["failed"] >= 3
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_exclusive_reset_preserves_created_at(tmp_path):
+    """FAILED→PENDING reset preserves the immutable created_at (LR2 §4.4/§7.3)."""
+
+    async def _run():
+        extract = _CountingExtract()
+        rag = await _build_rag(tmp_path, extract)
+        try:
+            doc_id = await _make_failed(rag, "keep.txt", extract)
+            created_before = (await rag.doc_status.get_by_id(doc_id))["created_at"]
+
+            extract.fail = False
+            await request_failed_retry(rag)
+            await rag.apipeline_process_enqueue_documents()
+
+            row = await rag.doc_status.get_by_id(doc_id)
+            assert row["status"] in (DocStatus.PROCESSED, DocStatus.PROCESSED.value)
+            assert row["created_at"] == created_before
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_exclusive_reset_leaves_stub_without_content_failed(tmp_path):
+    """A FAILED doc whose full_docs content is gone is unprocessable: the
+    exclusive reset must leave it FAILED (matches the validator's preserve),
+    never reset it into an immediate re-fail loop."""
+
+    async def _run():
+        extract = _CountingExtract()
+        rag = await _build_rag(tmp_path, extract)
+        try:
+            doc_id = await _make_failed(rag, "stub.txt", extract)
+            # Simulate a content-less stub: drop the full_docs row.
+            await rag.full_docs.delete([doc_id])
+
+            extract.fail = False
+            await request_failed_retry(rag)
+            await rag.apipeline_process_enqueue_documents()
+
+            # Left FAILED — never reset to PENDING (which would immediately
+            # re-fail on the missing content).
+            assert await _status_of(rag, doc_id) == DocStatus.FAILED.value
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_begin_manual_drain_freezes_new_enqueue_reservation(tmp_path):
+    """While a manual drain holds the freeze, a NEW enqueue reservation is
+    rejected with MANUAL_FREEZE (→ 409); clearing the freeze re-admits it."""
+
+    async def _run():
+        extract = _CountingExtract()
+        rag = await _build_rag(tmp_path, extract)
+        try:
+            status = await get_namespace_data(
+                "pipeline_status", workspace=rag.workspace
+            )
+            lock = get_namespace_lock("pipeline_status", workspace=rag.workspace)
+            token = "busy-tok"
+            status.update(
+                {"busy": True, "busy_owner": make_owner_record(token, "processing")}
+            )
+
+            assert await rag._begin_manual_drain("req-1", token, status, lock) is True
+            assert status["manual_freeze_requested"] is True
+            assert status["manual_phase"] == MANUAL_PHASE_DRAIN_TO_IDLE
+            assert status["manual_owner"]["request_id"] == "req-1"
+            assert status["manual_owner"]["owner_token"] == token
+
+            reject_when = (("manual_freeze_requested", "manual retry draining"),)
+            blocked = await acquire_enqueue_reservation(
+                status, lock, token="up-1", reject_when=reject_when
+            )
+            assert blocked.acquired is False
+            assert blocked.conflict is PipelineReservationConflict.MANUAL_FREEZE
+
+            # Clearing the freeze re-admits enqueues.
+            await rag._end_manual_drain(token, status, lock)
+            assert status["manual_freeze_requested"] is False
+            assert status["manual_owner"] is None
+            admitted = await acquire_enqueue_reservation(
+                status, lock, token="up-2", reject_when=reject_when
+            )
+            assert admitted.acquired is True
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_next_failed_page_single_scan_when_paging_off(tmp_path):
+    """page_size<=0 collapses the FAILED reset to one strict scan ending at
+    CURSOR_END (legacy path); paging on returns a keyset cursor."""
+
+    async def _run():
+        extract = _CountingExtract()
+        rag = await _build_rag(tmp_path, extract)
+        try:
+            await _make_failed(rag, "a.txt", extract)
+            await _make_failed(rag, "b.txt", extract)
+
+            rag.pipeline_scheduling_page_size = 0
+            docs, cursor = await rag._next_failed_page(CURSOR_START)
+            assert set(docs) and cursor is not None
+            from lightrag.base import CURSOR_END
+
+            assert cursor is CURSOR_END
+            assert all(
+                d.status in (DocStatus.FAILED, DocStatus.FAILED.value)
+                for d in docs.values()
+            )
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())

--- a/tests/pipeline/test_manual_exclusive_reset.py
+++ b/tests/pipeline/test_manual_exclusive_reset.py
@@ -230,6 +230,90 @@ def test_begin_manual_drain_freezes_new_enqueue_reservation(tmp_path):
     asyncio.run(_run())
 
 
+def test_exclusive_reset_returns_false_when_not_owner(tmp_path):
+    """LR2 §7.7 item 8 / §13.2 case 11: the exclusive reset is owner-checked. If
+    the busy owner changed (a dead-owner reaper reclaim handed the slot to a new
+    owner), a stale run's reset must not run — it returns False and touches
+    nothing, leaving every FAILED row intact for the real owner to reset."""
+
+    async def _run():
+        extract = _CountingExtract()
+        rag = await _build_rag(tmp_path, extract)
+        try:
+            doc_id = await _make_failed(rag, "a.txt", extract)
+            status = await get_namespace_data(
+                "pipeline_status", workspace=rag.workspace
+            )
+            lock = get_namespace_lock("pipeline_status", workspace=rag.workspace)
+            # The slot is owned by a DIFFERENT token than the stale run's.
+            status.update(
+                {"busy": True, "busy_owner": make_owner_record("owner-B", "processing")}
+            )
+
+            wrote = {"called": False}
+            orig_upsert = rag.doc_status.upsert
+
+            async def spy_upsert(data):
+                wrote["called"] = True
+                return await orig_upsert(data)
+
+            rag.doc_status.upsert = spy_upsert
+
+            ok = await rag._run_exclusive_failed_reset(
+                "req-stale", "owner-A", status, lock
+            )
+            assert ok is False
+            assert wrote["called"] is False  # no page write by the stale run
+            # phase never advanced to EXCLUSIVE_RESET (the enter transition was
+            # owner-checked and refused).
+            assert status["manual_resetting"] is False
+            assert await _status_of(rag, doc_id) == DocStatus.FAILED.value
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_reset_page_rejects_write_when_owner_changed(tmp_path):
+    """_reset_failed_page raises (discards the late write) rather than persist a
+    FAILED→PENDING page once the freeze owner no longer matches — so a reaper
+    reclaim mid-reset can never be overwritten by the stale task."""
+
+    async def _run():
+        extract = _CountingExtract()
+        rag = await _build_rag(tmp_path, extract)
+        try:
+            await _make_failed(rag, "a.txt", extract)
+            status = await get_namespace_data(
+                "pipeline_status", workspace=rag.workspace
+            )
+            lock = get_namespace_lock("pipeline_status", workspace=rag.workspace)
+            status.update(
+                {"busy": True, "busy_owner": make_owner_record("owner-B", "processing")}
+            )
+
+            docs, _ = await rag._next_failed_page(CURSOR_START)
+            assert docs  # a real FAILED page to attempt
+
+            wrote = {"called": False}
+            orig_upsert = rag.doc_status.upsert
+
+            async def spy_upsert(data):
+                wrote["called"] = True
+                return await orig_upsert(data)
+
+            rag.doc_status.upsert = spy_upsert
+
+            # token "owner-A" != current owner "owner-B" → reject before write.
+            with pytest.raises(RuntimeError, match="lost freeze ownership"):
+                await rag._reset_failed_page(docs, "owner-A", status, lock)
+            assert wrote["called"] is False
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
 def test_next_failed_page_single_scan_when_paging_off(tmp_path):
     """page_size<=0 collapses the FAILED reset to one strict scan ending at
     CURSOR_END (legacy path); paging on returns a keyset cursor."""

--- a/tests/pipeline/test_manual_exclusive_reset.py
+++ b/tests/pipeline/test_manual_exclusive_reset.py
@@ -462,3 +462,173 @@ def test_next_failed_page_single_scan_when_paging_off(tmp_path):
             await rag.finalize_storages()
 
     asyncio.run(_run())
+
+
+def test_reset_page_propagates_a_strict_full_docs_failure(tmp_path):
+    """Fix-proof: the content probe used the NON-strict ``get_by_id``, whose
+    implementations may report a transport failure (or, on OpenSearch, an index
+    that is merely not ready) as a best-effort ``None``. This loop read that as
+    "unprocessable stub" and skipped the doc, so a storage failure could skip
+    EVERY doc, still page to End, and ACK the manual retry having reset nothing.
+    The strict read must propagate instead."""
+
+    async def _run():
+        extract = _CountingExtract()
+        rag = await _build_rag(tmp_path, extract)
+        try:
+            await _make_failed(rag, "a.txt", extract)
+            status = await get_namespace_data(
+                "pipeline_status", workspace=rag.workspace
+            )
+            lock = get_namespace_lock("pipeline_status", workspace=rag.workspace)
+            docs, _ = await rag._next_failed_page(CURSOR_START)
+            assert docs
+
+            assert rag.full_docs.supports_strict_point_reads is True
+
+            async def _boom(doc_id):
+                raise RuntimeError("full_docs transport failure")
+
+            rag.full_docs.get_by_id_strict = _boom
+            # A non-strict read that softens the same failure to None would make
+            # this a silent skip; the strict path must surface it.
+            rag.full_docs.get_by_id = _boom
+
+            wrote = {"called": False}
+            orig_upsert = rag.doc_status.upsert
+
+            async def spy_upsert(data):
+                wrote["called"] = True
+                return await orig_upsert(data)
+
+            rag.doc_status.upsert = spy_upsert
+
+            with pytest.raises(RuntimeError, match="full_docs transport failure"):
+                await rag._reset_failed_page(docs, "tok", status, lock)
+            assert wrote["called"] is False
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_reset_page_counts_unconfirmed_misses_without_strict_reads(tmp_path):
+    """A backend that cannot confirm absence keeps the conservative skip, but the
+    skipped docs are surfaced so the operator does not read silence as success."""
+
+    async def _run():
+        extract = _CountingExtract()
+        rag = await _build_rag(tmp_path, extract)
+        try:
+            await _make_failed(rag, "a.txt", extract)
+            status = await get_namespace_data(
+                "pipeline_status", workspace=rag.workspace
+            )
+            status["history_messages"] = []
+            lock = get_namespace_lock("pipeline_status", workspace=rag.workspace)
+            docs, _ = await rag._next_failed_page(CURSOR_START)
+            assert docs
+
+            # Pretend the backend lacks strict point reads and misses the row.
+            type(rag.full_docs).supports_strict_point_reads = False
+            try:
+
+                async def _miss(doc_id):
+                    return None
+
+                rag.full_docs.get_by_id = _miss
+                reset = await rag._reset_failed_page(docs, "tok", status, lock)
+            finally:
+                type(rag.full_docs).supports_strict_point_reads = True
+
+            assert reset == 0
+            assert any(
+                "cannot confirm whether their content is really absent" in m
+                for m in status["history_messages"]
+            ), status["history_messages"]
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_worker_status_write_is_discarded_when_ownership_was_reclaimed(tmp_path):
+    """LR2 §7.7 items 3/4/7: a run whose ownership was reclaimed must DISCARD its
+    late status write, not stamp a final status over the new owner's work.
+
+    Fix-proof: the worker write path did a plain ``doc_status.upsert`` with no
+    owner check, so a late result from a run declared dead could re-FAIL a
+    document the manual exclusive reset had just moved to PENDING — ACKing the
+    retry with the document still failed.
+    """
+
+    async def _run():
+        from lightrag.pipeline import _BatchRunContext
+        from lightrag.parser.registry import parser_specs_snapshot
+
+        extract = _CountingExtract()
+        rag = await _build_rag(tmp_path, extract)
+        try:
+            doc_id = await _make_failed(rag, "a.txt", extract)
+            status = await get_namespace_data(
+                "pipeline_status", workspace=rag.workspace
+            )
+            lock = get_namespace_lock("pipeline_status", workspace=rag.workspace)
+            status["history_messages"] = []
+            # Ownership now belongs to owner-B; our run still holds owner-A.
+            status.update(
+                {"busy": True, "busy_owner": make_owner_record("owner-B", "processing")}
+            )
+
+            ctx = _BatchRunContext(
+                pipeline_status=status,
+                pipeline_status_lock=lock,
+                semaphore=asyncio.Semaphore(1),
+                total_files=1,
+                parse_queues={"native": asyncio.Queue()},
+                parser_specs=parser_specs_snapshot(),
+                q_analyze=asyncio.Queue(),
+                q_process=asyncio.Queue(),
+                run_owner_token="owner-A",
+            )
+
+            rows = await rag.doc_status.get_by_id(doc_id)
+            status_doc = (await rag._next_failed_page(CURSOR_START))[0][doc_id]
+            before = rows.get("status")
+
+            wrote = {"called": False}
+            orig_upsert = rag.doc_status.upsert
+
+            async def spy_upsert(data):
+                wrote["called"] = True
+                return await orig_upsert(data)
+
+            rag.doc_status.upsert = spy_upsert
+
+            await rag._upsert_doc_status_transition(
+                doc_id=doc_id,
+                status=DocStatus.PROCESSED,
+                status_doc=status_doc,
+                file_path="a.txt",
+                ctx=ctx,
+            )
+
+            # Nothing written, and the row is untouched.
+            assert wrote["called"] is False
+            after = (await rag.doc_status.get_by_id(doc_id)).get("status")
+            assert after == before
+
+            # The current owner's write still goes through.
+            ctx.run_owner_token = "owner-B"
+            await rag._upsert_doc_status_transition(
+                doc_id=doc_id,
+                status=DocStatus.PROCESSED,
+                status_doc=status_doc,
+                file_path="a.txt",
+                ctx=ctx,
+            )
+            assert wrote["called"] is True
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())

--- a/tests/pipeline/test_manual_exclusive_reset.py
+++ b/tests/pipeline/test_manual_exclusive_reset.py
@@ -25,6 +25,7 @@ from lightrag.kg.shared_storage import (
     acquire_enqueue_reservation,
     get_namespace_data,
     get_namespace_lock,
+    get_pipeline_ingress,
     make_owner_record,
 )
 from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
@@ -96,6 +97,128 @@ async def _make_failed(rag: LightRAG, name: str, extract: _CountingExtract) -> s
     doc_id = compute_mdhash_id(name, prefix="doc-")
     assert await _status_of(rag, doc_id) == DocStatus.FAILED.value
     return doc_id
+
+
+def test_manual_drains_auto_backlog_before_reset(tmp_path):
+    """LR2 §13.2 case 5: a manual retry arriving with an AUTO backlog freezes
+    new ingress, drains the AUTO (PENDING) backlog to idle FIRST, then resets
+    FAILED→PENDING and processes those too — all in one run."""
+
+    async def _run():
+        extract = _CountingExtract()
+        rag = await _build_rag(tmp_path, extract)
+        try:
+            # A pre-existing FAILED doc (the manual retry target).
+            failed_id = await _make_failed(rag, "old.txt", extract)
+            # An AUTO-backlog PENDING doc enqueued but not yet processed.
+            extract.fail = False
+            await rag.apipeline_enqueue_documents(
+                input="fresh body", file_paths="new.txt"
+            )
+            pending_id = compute_mdhash_id("new.txt", prefix="doc-")
+            assert await _status_of(rag, pending_id) == DocStatus.PENDING.value
+
+            await request_failed_retry(rag)
+            await rag.apipeline_process_enqueue_documents()
+
+            # AUTO backlog drained AND the FAILED doc reset+reprocessed.
+            assert await _status_of(rag, pending_id) == DocStatus.PROCESSED.value
+            assert await _status_of(rag, failed_id) == DocStatus.PROCESSED.value
+            ingress = await get_pipeline_ingress(rag.workspace)
+            assert ingress.snapshot_manual_retries() == []  # ACKed
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_refail_during_process_stays_failed(tmp_path):
+    """LR2 §7.4 / §13.2 case 3: a doc the manual reset returns to PENDING that
+    FAILS AGAIN during the PROCESS phase stays FAILED — the SAME request never
+    resets it a second time (no retry loop)."""
+
+    async def _run():
+        extract = _CountingExtract()
+        rag = await _build_rag(tmp_path, extract)
+        try:
+            failed_id = await _make_failed(rag, "a.txt", extract)
+            calls_after_failure = extract.calls
+
+            # Extraction still fails: the reset returns it to PENDING, it is
+            # processed once, fails again → FAILED, and is NOT reset again by
+            # the SAME request (no loop).
+            await request_failed_retry(rag)
+            await rag.apipeline_process_enqueue_documents()
+
+            assert await _status_of(rag, failed_id) == DocStatus.FAILED.value
+            # Exactly ONE extra attempt for this request (no retry loop).
+            assert extract.calls == calls_after_failure + 1
+            # A second run with no new signal must not retry again.
+            await rag.apipeline_process_enqueue_documents()
+            assert extract.calls == calls_after_failure + 1
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_reset_idempotent_across_mid_reset_failure(tmp_path):
+    """LR2 §13.2 case 2 / §7.3 "为什么不需要 generation": a reset that fails on a
+    later FAILED page leaves the already-reset rows PENDING; the next run
+    re-runs the reset from Start and does NOT re-reset them (they are no longer
+    on a FAILED page). Every doc is processed exactly once."""
+
+    async def _run():
+        extract = _CountingExtract()
+        rag = await _build_rag(tmp_path, extract)
+        try:
+            rag.pipeline_scheduling_page_size = 1  # one FAILED per page
+            id_a = await _make_failed(rag, "a.txt", extract)
+            id_b = await _make_failed(rag, "b.txt", extract)
+            calls_after_setup = extract.calls
+
+            # Fail the SECOND FAILED page fetch of the reset (first page resets
+            # one doc, second raises → run aborts, request stays sticky).
+            original_page = rag.doc_status.get_docs_by_statuses_page
+            state = {"failed_pages": 0, "armed": True}
+
+            async def flaky(statuses, *, limit, position, strict=False):
+                if list(statuses) == [DocStatus.FAILED]:
+                    state["failed_pages"] += 1
+                    if state["failed_pages"] == 2 and state["armed"]:
+                        state["armed"] = False
+                        raise RuntimeError("mid-reset page boom")
+                return await original_page(
+                    statuses, limit=limit, position=position, strict=strict
+                )
+
+            rag.doc_status.get_docs_by_statuses_page = flaky
+
+            extract.fail = False
+            await request_failed_retry(rag)
+            with pytest.raises(RuntimeError, match="mid-reset page boom"):
+                await rag.apipeline_process_enqueue_documents()
+
+            ingress = await get_pipeline_ingress(rag.workspace)
+            assert ingress.snapshot_manual_retries()  # still sticky, not ACKed
+            # Freeze cleared on the aborted exit (no wedge).
+            status = await get_namespace_data(
+                "pipeline_status", workspace=rag.workspace
+            )
+            assert status["manual_freeze_requested"] is False
+
+            # Next run completes: both docs processed exactly once, no double reset.
+            await rag.apipeline_process_enqueue_documents()
+            assert await _status_of(rag, id_a) == DocStatus.PROCESSED.value
+            assert await _status_of(rag, id_b) == DocStatus.PROCESSED.value
+            # Exactly two extra attempts (a + b, once each) — the already-reset
+            # a.txt is not reset/processed a second time.
+            assert extract.calls == calls_after_setup + 2
+            assert ingress.snapshot_manual_retries() == []  # ACKed
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
 
 
 def test_exclusive_reset_pages_failed_backlog(tmp_path):

--- a/tests/pipeline/test_pipeline_failed_retry_semantics.py
+++ b/tests/pipeline/test_pipeline_failed_retry_semantics.py
@@ -209,6 +209,11 @@ def test_strict_scan_failure_keeps_request_sticky(tmp_path):
         extract = _CountingExtract()
         rag = await _build_rag(tmp_path, f"frs-{uuid4().hex[:8]}", extract)
         try:
+            # Legacy single-scan path (LR2 Phase 3): the manual protocol's AUTO
+            # drain and exclusive FAILED reset both route through
+            # get_docs_by_statuses when paging is off, so the injected failure
+            # lands on the very first strict scan of the run.
+            rag.pipeline_scheduling_page_size = 0
             failed_id = await _make_failed_doc(rag, "a.txt", extract)
             ingress = await get_pipeline_ingress(rag.workspace)
             request_id = await request_failed_retry(rag)
@@ -252,7 +257,12 @@ def test_auto_rescan_rearmed_when_strict_refetch_fails(tmp_path):
             PipelineNextDecision,
             PipelineNextStep,
             _AUTO_RESUME_DOC_STATUSES,
-            _MANUAL_RETRY_DOC_STATUSES,
+        )
+
+        from lightrag.kg.shared_storage import (
+            get_namespace_data,
+            get_namespace_lock,
+            make_owner_record,
         )
 
         extract = _CountingExtract()
@@ -263,6 +273,16 @@ def test_auto_rescan_rearmed_when_strict_refetch_fails(tmp_path):
             # with the paged path (both raise through _next_scheduling_page).
             rag.pipeline_scheduling_page_size = 0
             ingress = await get_pipeline_ingress(rag.workspace)
+            status = await get_namespace_data(
+                "pipeline_status", workspace=rag.workspace
+            )
+            lock = get_namespace_lock("pipeline_status", workspace=rag.workspace)
+            # This run owns busy — the manual drain/reset is owner-checked
+            # against this token.
+            token = "owner-tok"
+            status.update(
+                {"busy": True, "busy_owner": make_owner_record(token, "processing")}
+            )
 
             async def boom(statuses, strict=False):
                 raise RuntimeError("refetch boom")
@@ -271,21 +291,34 @@ def test_auto_rescan_rearmed_when_strict_refetch_fails(tmp_path):
             decision = PipelineNextDecision(PipelineNextStep.CONTINUE_AUTO)
             with pytest.raises(RuntimeError, match="refetch boom"):
                 await rag._refetch_for_decision(
-                    decision, _AUTO_RESUME_DOC_STATUSES, CURSOR_START, ingress
+                    decision,
+                    _AUTO_RESUME_DOC_STATUSES,
+                    CURSOR_START,
+                    ingress,
+                    token=token,
+                    pipeline_status=status,
+                    pipeline_status_lock=lock,
                 )
             assert ingress.consume_auto_rescan() is True  # re-armed
 
-            # A manual continuation stays sticky on its own — no re-arm.
+            # A manual continuation (LR2 Phase 3): CONTINUE_MANUAL begins the
+            # drain (freeze set), then the AUTO drain scan fails. The manual
+            # stays sticky on its own — no auto-rescan re-arm.
             with pytest.raises(RuntimeError, match="refetch boom"):
                 await rag._refetch_for_decision(
                     PipelineNextDecision(
                         PipelineNextStep.CONTINUE_MANUAL, manual_request_id="r1"
                     ),
-                    _MANUAL_RETRY_DOC_STATUSES,
+                    _AUTO_RESUME_DOC_STATUSES,
                     CURSOR_START,
                     ingress,
+                    token=token,
+                    pipeline_status=status,
+                    pipeline_status_lock=lock,
                 )
             assert ingress.consume_auto_rescan() is False
+            # The freeze was set by begin-drain and must be visible.
+            assert status["manual_freeze_requested"] is True
         finally:
             await rag.finalize_storages()
 

--- a/tests/pipeline/test_pipeline_ingress_exit.py
+++ b/tests/pipeline/test_pipeline_ingress_exit.py
@@ -243,10 +243,17 @@ async def test_refetch_document_failure_republishes_and_arms_auto(tmp_path):
 
         rag.doc_status.get_docs_by_statuses = dead_scan
 
+        status, lock = await _pipeline_ns(rag)
         decision = PipelineNextDecision(PipelineNextStep.CONTINUE_DOCUMENT)
         with pytest.raises(ConnectionError):
             await rag._refetch_for_decision(
-                decision, _AUTO_RESUME_DOC_STATUSES, CURSOR_START, ingress
+                decision,
+                _AUTO_RESUME_DOC_STATUSES,
+                CURSOR_START,
+                ingress,
+                token="tok",
+                pipeline_status=status,
+                pipeline_status_lock=lock,
             )
 
         republished = {m.doc_id for m in ingress.drain_documents()}
@@ -335,10 +342,17 @@ async def test_refetch_compensation_failure_does_not_mask_original_error(tmp_pat
         ingress.put_document = dead_put
         ingress.request_auto_rescan = dead_arm
 
+        status, lock = await _pipeline_ns(rag)
         decision = PipelineNextDecision(PipelineNextStep.CONTINUE_DOCUMENT)
         with pytest.raises(ConnectionError, match="original strict-scan failure"):
             await rag._refetch_for_decision(
-                decision, _AUTO_RESUME_DOC_STATUSES, CURSOR_START, ingress
+                decision,
+                _AUTO_RESUME_DOC_STATUSES,
+                CURSOR_START,
+                ingress,
+                token="tok",
+                pipeline_status=status,
+                pipeline_status_lock=lock,
             )
     finally:
         await rag.finalize_storages()

--- a/tests/pipeline/test_pipeline_internal_abort.py
+++ b/tests/pipeline/test_pipeline_internal_abort.py
@@ -418,6 +418,19 @@ async def test_finalize_doc_failure_labels_internal_error_in_doc_status(tmp_path
         pipeline_status["cancellation_reason"] = "internal_error"
         pipeline_status["cancellation_detail"] = "RedisKVStorage[full_docs]: boom"
 
+        # run_owner_token stays None: this unit test drives the helper outside a
+        # reservation, so the owner check is a no-op (see _still_run_owner).
+        ctx = _BatchRunContext(
+            pipeline_status=pipeline_status,
+            pipeline_status_lock=pipeline_status_lock,
+            semaphore=asyncio.Semaphore(1),
+            total_files=10,
+            parse_queues={"native": asyncio.Queue()},
+            parser_specs=parser_specs_snapshot(),
+            q_analyze=asyncio.Queue(),
+            q_process=asyncio.Queue(),
+        )
+
         await rag._finalize_doc_failure(
             doc_id=doc_id,
             status_doc=status_doc,
@@ -429,6 +442,7 @@ async def test_finalize_doc_failure_labels_internal_error_in_doc_status(tmp_path
             failed_chunks_snapshot=([], 0),
             pending_tasks=[],
             metadata_extra={},
+            ctx=ctx,
             pipeline_status=pipeline_status,
             pipeline_status_lock=pipeline_status_lock,
         )
@@ -463,8 +477,19 @@ async def test_finalize_doc_failure_keeps_user_cancel_label(tmp_path):
         pipeline_status["history_messages"] = []
         pipeline_status["cancellation_reason"] = None
         pipeline_status["cancellation_detail"] = None
+        ctx = _BatchRunContext(
+            pipeline_status=pipeline_status,
+            pipeline_status_lock=pipeline_status_lock,
+            semaphore=asyncio.Semaphore(1),
+            total_files=10,
+            parse_queues={"native": asyncio.Queue()},
+            parser_specs=parser_specs_snapshot(),
+            q_analyze=asyncio.Queue(),
+            q_process=asyncio.Queue(),
+        )
 
         await rag._finalize_doc_failure(
+            ctx=ctx,
             doc_id=doc_id,
             status_doc=status_doc,
             file_path=f"{doc_id}.txt",


### PR DESCRIPTION
Replaces manual retry's correctness basis. **No new storage field, table or marker** — this is the point of the design.

Before: `/documents/reprocess_failed` reset `FAILED` rows inline, in the same batch as `PENDING`, while workers were running. Whether a document was eligible depended on timing, and the earlier proposal fixed that with a `failure_generation` counter plus migration markers — a **second source of truth** that drifts on crash, backend swap or recovery.

Instead, the phase itself supplies the guarantee: **freeze new enqueues → DRAIN_TO_IDLE → EXCLUSIVE_RESET → ACK → PROCESS**. If no failure producer is running when the reset starts, "which rows are eligible" needs no bookkeeping — it is whatever is `FAILED` right then.

**State** (all hidden behind `_INTERNAL_PIPELINE_STATUS_FIELDS`, never on the API): `manual_freeze_requested`, `manual_resetting`, `manual_phase` (a plain string — `str(enum)` has bitten this repo before), and `manual_owner`. `PipelineReservationConflict.MANUAL_FREEZE` maps to 409 through the existing branch. `/documents/scan` is exempt from the freeze, matching `scanning_exclusive`: it is the operation *driving* the reset.

**Decisions are phase-aware.** During DRAIN_TO_IDLE the supervisor drains remaining pages and signals first, waits out pre-freeze in-flight enqueues with a bounded sleep (the freeze can only shrink that set), and enters the reset once a strict count confirms idle. A second request waits FIFO and drains to idle on its own.

**Crash and cancellation.** The owner/reaper/process-identity machinery already existed (the ingress-mailbox work, #3458→#3467); this wires manual state into it. The `busy` release clears manual state in the *same* atomic update, so an exception or cancellation cannot leave ingestion frozen with no owner. The reaper clears dead manual state atomically for the same reason. Every late write re-checks ownership before landing.

Adversarial review covered freeze-wedge, ACK-before-persist, double reset, non-terminating drain, FIFO inversion, torn reads and cancellation. One real liveness bug came out of it: if a worker was `SIGKILL`ed mid-reserve, its dead token kept `pending_enqueues > 0` forever and the freeze blocked the very uploads that would have reaped it — so the drain-wait now reaps confirmed-dead tokens before waiting.

Endpoints need no change: `commit_manual_retry_request` deliberately does not refuse during a freeze, because requests are served FIFO.

---

**Stack** (merge bottom-up; each PR is green on its own and targets the one below):
`main` ← **#3482** P0 test rig ← **#3483** P1 storage pages ← **#3484** P2 bounded sweep ← **#3485** P2.5 dedup ← **#3486** P3 manual retry ← **#3481** P4 `/scan` ← **#3487** P5 admission ← **#3488** P6 observability ← **#3489** P7 verification

Design: LR2 *pipeline memory bounding*. When merging, retarget the child PR **before** deleting a merged branch — GitHub closes the child otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
