### PR TITLE
✨ feat(observability): bound the manual channel, the metrics registry and the status history (LR2 Phase 6)

### DIFF
--- a/docs/LightRAG-API-Server-zh.md
+++ b/docs/LightRAG-API-Server-zh.md
@@ -25,6 +25,26 @@ LIGHTRAG_PARSER=*:legacy-F
 - 修改 chunker 配置（`CHUNK_*`）会影响服务器重启后入队的文档。若希望旧文档的 `chunk_options` 快照也采用新配置，请重新处理这些文档。
 - 启用多模态选项（`i/t/e`）需要已有解析 sidecar，并设置 `VLM_PROCESS_ENABLE=true`。已有文档可通过重新处理在可用 sidecar 上补跑 VLM 分析；但切换解析引擎仍需要删除并重新上传。
 
+## 升级到有界管线调度
+
+引入 `PIPELINE_SCHEDULING_PAGE_SIZE`、`MAX_PENDING_DOCUMENTS` 和 `MAX_UNACKED_MANUAL_RETRIES`（见 `env.example`）的这个版本，同时改变了各 writer 通过共享状态协调时使用的**并发协议**。这是一次性的原地升级，不写任何 marker、也不写协议版本号，因此存储层无法替你识别出残留的旧 writer。所以这是一条运维要求：
+
+> **在对同一存储、同一 workspace 启动新版本之前，必须先停掉所有旧 writer。** 滚动重启时只要还留着一个旧 worker——或者一个共用同一 Redis/PostgreSQL workspace 的旧实例——就是故障场景，而不只是升级得慢一点。
+
+旧 writer 无法遵守的三件事：
+
+- **manual retry 冻结。** `/documents/reprocess_failed` 不再就地重置 `FAILED` 行。它发布一个 intent、冻结入口、等待管线转为空闲，然后在没有任何 worker 运行的前提下分页把 `FAILED`→`PENDING` 改写回去。旧 writer 不读冻结标志，于是会继续往这个被重置逻辑视为独占的窗口里入队。
+- **调度排序键。** `created_at` 现在是不可变的 `(created_at, id)` keyset 游标，以 UTC ISO-8601 时间戳写入。旧 writer 用其它格式打上的时间戳与之排序不一致，keyset 分页因此可能跳过或重复文档。
+- **派生索引。** 在 Redis 上，status 集合与 source multimap 与文档主记录在同一个事务中维护。旧 writer 只更新主记录，会把索引留成陈旧状态——此后 strict 分页与 strict 活跃计数会静默漏掉这个文档。
+
+推荐顺序：
+
+1. 停止接收新文档，等待管线跑完。在已鉴权的 `/health` 上，没有任何在途工作时 `scheduling.drain_waiting_on_workers` 为 `false`、`scheduling.drain_pending_enqueues` 为 `0`。
+2. 停掉共用该存储与 workspace 的**全部** worker 和实例。
+3. 启动新版本。
+
+不需要做数据迁移。启动后的第一轮 sweep 是一次 strict 全量 sweep，因此旧 writer 留在半途的文档——例如卡在 `PARSING`/`ANALYZING`/`PROCESSING` 但背后已没有 worker 的行——会被自动捡起并重新处理。如果确实无法排空（必须放弃一次运行），基于同样的原因，中途停止也是安全的；不安全的是事后又把旧版本启动回来。
+
 ## 入门指南
 
 ### 安装

--- a/docs/LightRAG-API-Server-zh.md
+++ b/docs/LightRAG-API-Server-zh.md
@@ -474,8 +474,9 @@ server {
    - Nginx 首先验证 `Content-Length` 头
    - LightRAG 在上传过程中执行流式验证
    - 在两层设置适当的限制可确保更好的错误消息和安全性
-6. **服务端入库限制**（两者默认关闭，见 `env.example`）：
+6. **服务端入库限制**（默认全部关闭，见 `env.example`）：
    - `MAX_REQUEST_BODY_BYTES` 限制 `/documents/upload`、`/text`、`/texts` 的**原始请求体**字节数，在 ASGI 流式接收过程中累加。与 `MAX_UPLOAD_SIZE`（multipart 解析后限制单个文件）不同，它也能拦住谎报或不报 `Content-Length` 的请求体，在整个 body 读完之前就返回 **413**。
+   - `MAX_TEXTS_PER_REQUEST` 限制单个 `/documents/texts` 请求可携带的文本数量，在任何逐条存储查询之前就返回 **413**。它限制的是单个请求的扇出，因此与下面的容量上限不同，**不是**"稍后重试"类条件：超限的批次无论等多久都不会被接受，必须拆分。
    - `MAX_PENDING_DOCUMENTS` 限制可同时处于活跃状态（`PENDING`/`PARSING`/`ANALYZING`/`PROCESSING`）或被在飞请求预留的文档数。超容量时返回 **429**,带 `Retry-After` 头,detail 里给出当前数量、本次请求数量与容量——且**在 body 传输之前**就拒绝。`/documents/scan` 与人工重试按设计突破该上限;它们产生的文档会让普通上传排队等待。
 
 ### 离线部署

--- a/docs/LightRAG-API-Server.md
+++ b/docs/LightRAG-API-Server.md
@@ -25,6 +25,26 @@ LIGHTRAG_PARSER=*:legacy-F
 - Changing chunker settings (`CHUNK_*`) affects documents enqueued after the server restarts. Reprocess older documents if you want their stored `chunk_options` snapshot to match the new settings.
 - Enabling multimodal options (`i/t/e`) requires parsed sidecars plus `VLM_PROCESS_ENABLE=true`. Existing documents can be reprocessed to run VLM analysis on available sidecars; switching extraction engines still requires delete + re-upload.
 
+## Upgrading to bounded pipeline scheduling
+
+The release that introduces `PIPELINE_SCHEDULING_PAGE_SIZE`, `MAX_PENDING_DOCUMENTS` and `MAX_UNACKED_MANUAL_RETRIES` (see `env.example`) also changes the **concurrency protocol** writers use to coordinate through shared state. It is a one-time, in-place upgrade that writes no marker and no protocol version, so the storage cannot detect a stale writer for you. The requirement is therefore operational:
+
+> **Stop every old writer before starting a new one against the same storage and workspace.** A rolling restart that leaves one old worker — or one old instance sharing the same Redis/PostgreSQL workspace — running is the failure case, not a slower upgrade.
+
+Three things an old writer cannot honour:
+
+- **The manual retry freeze.** `/documents/reprocess_failed` no longer resets `FAILED` rows inline. It publishes an intent, freezes ingestion, waits for the pipeline to go idle, and only then rewrites `FAILED`→`PENDING` page by page with no worker running. An old writer does not read the freeze flag, so it keeps enqueueing into a window the reset assumes is exclusive.
+- **The scheduling sort key.** `created_at` is now the immutable `(created_at, id)` keyset cursor, written as a UTC ISO-8601 timestamp. Rows an old writer stamps in another format sort inconsistently against it, and a keyset page can then skip or repeat documents.
+- **Derived indexes.** On Redis the status set and the source multimap are maintained in the same transaction as the document row. An old writer updates the row only, leaving the index stale — after which strict paging and the strict active count silently omit that document.
+
+Recommended sequence:
+
+1. Stop accepting new documents and let the pipeline finish. On the authenticated `/health`, `scheduling.drain_waiting_on_workers` is `false` and `scheduling.drain_pending_enqueues` is `0` when nothing is in flight.
+2. Stop **all** workers and instances that share the storage and workspace.
+3. Start the new version.
+
+No data migration is required. The first sweep after startup is a strict full sweep, so a document an old writer left mid-flight — a row stuck in `PARSING`/`ANALYZING`/`PROCESSING` with no worker behind it — is picked up and reprocessed on its own. If a run genuinely cannot be drained, stopping mid-run is still safe for the same reason; what is not safe is starting the old version again afterwards.
+
 ## Getting Started
 
 ### Installation

--- a/docs/LightRAG-API-Server.md
+++ b/docs/LightRAG-API-Server.md
@@ -474,12 +474,17 @@ server {
    - Nginx validates the `Content-Length` header first
    - LightRAG performs streaming validation during upload
    - Setting appropriate limits at both layers ensures better error messages and security
-6. **Server-side ingestion limits** (both off by default, see `env.example`):
+6. **Server-side ingestion limits** (all off by default, see `env.example`):
    - `MAX_REQUEST_BODY_BYTES` bounds the raw body of `/documents/upload`, `/text`
      and `/texts`, counted as it streams through ASGI. Unlike `MAX_UPLOAD_SIZE`
      (which bounds one uploaded file after multipart parsing), it also stops a
      body that understates or omits its `Content-Length`, answering **413**
      before the whole body is read.
+   - `MAX_TEXTS_PER_REQUEST` bounds how many texts one `/documents/texts` request
+     may carry, answering **413** before any per-text storage lookup. It bounds
+     the fan-out of a single request, so — unlike the capacity limit below — it is
+     not a "retry later" condition: an oversized batch never fits and must be
+     split.
    - `MAX_PENDING_DOCUMENTS` bounds how many documents may be active
      (`PENDING`/`PARSING`/`ANALYZING`/`PROCESSING`) or reserved by an in-flight
      request. Over capacity the server answers **429** with a `Retry-After`

--- a/env.example
+++ b/env.example
@@ -699,6 +699,12 @@ MAX_PARALLEL_INSERT=3
 ### Content-Length is still cut off with 413). Independent of MAX_UPLOAD_SIZE,
 ### which bounds one uploaded FILE after multipart parsing. 0 disables (default).
 # MAX_REQUEST_BODY_BYTES=0
+### Ceiling on how many texts ONE /documents/texts request may carry, refused
+### with 413 before any per-text storage lookup. Bounds the fan-out of a single
+### request, unlike MAX_PENDING_DOCUMENTS which bounds the whole backlog and says
+### "retry later" — no amount of waiting makes an oversized batch fit.
+### 0 disables (default).
+# MAX_TEXTS_PER_REQUEST=0
 ### Per-workspace ceiling on manual retry requests (/documents/reprocess_failed,
 ### /documents/scan) that have been published but not yet acknowledged by their
 ### exclusive FAILED->PENDING reset. The channel is sticky, so an over-capacity

--- a/env.example
+++ b/env.example
@@ -699,6 +699,11 @@ MAX_PARALLEL_INSERT=3
 ### Content-Length is still cut off with 413). Independent of MAX_UPLOAD_SIZE,
 ### which bounds one uploaded FILE after multipart parsing. 0 disables (default).
 # MAX_REQUEST_BODY_BYTES=0
+### Per-workspace ceiling on manual retry requests (/documents/reprocess_failed,
+### /documents/scan) that have been published but not yet acknowledged by their
+### exclusive FAILED->PENDING reset. The channel is sticky, so an over-capacity
+### publish is refused with 429 rather than dropped. Default 64.
+# MAX_UNACKED_MANUAL_RETRIES=64
 ### Max concurrency requests for Embedding
 # EMBEDDING_FUNC_MAX_ASYNC=8
 ### Num of chunks send to Embedding in single request (default is 10)

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -37,6 +37,7 @@ from lightrag.constants import (
     DEFAULT_PIPELINE_SCHEDULING_PAGE_SIZE,
     DEFAULT_MAX_PENDING_DOCUMENTS,
     DEFAULT_MAX_REQUEST_BODY_BYTES,
+    DEFAULT_MAX_TEXTS_PER_REQUEST,
     DEFAULT_SCAN_ENQUEUE_BATCH_SIZE,
     DEFAULT_SUMMARY_MAX_TOKENS,
     DEFAULT_SUMMARY_LENGTH_RECOMMENDED,
@@ -200,11 +201,11 @@ def validate_scan_batch_configuration(args: argparse.Namespace) -> None:
 
 
 def validate_admission_configuration(args: argparse.Namespace) -> None:
-    """Reject a negative admission capacity (LR2 §9.1/§11).
+    """Reject negative values for the three ingestion ceilings (LR2 §9.1/§11).
 
-    ``0`` legitimately disables admission control, but a negative capacity would
-    refuse every upload — never what an operator meant, and a failure mode that
-    only shows up on the first request.
+    ``0`` legitimately disables each of them, but a negative value would refuse
+    every request — never what an operator meant, and a failure mode that only
+    shows up on the first request.
     """
     if not hasattr(args, "max_pending_documents"):
         # Partial namespace from a programmatic caller — see
@@ -226,6 +227,17 @@ def validate_admission_configuration(args: argparse.Namespace) -> None:
             raise ValueError(
                 "MAX_REQUEST_BODY_BYTES must be an integer >= 0 (0 disables the "
                 f"body limit); got {body_limit!r}"
+            )
+    if hasattr(args, "max_texts_per_request"):
+        texts_limit = args.max_texts_per_request
+        if (
+            not isinstance(texts_limit, int)
+            or isinstance(texts_limit, bool)
+            or texts_limit < 0
+        ):
+            raise ValueError(
+                "MAX_TEXTS_PER_REQUEST must be an integer >= 0 (0 disables the "
+                f"per-request text limit); got {texts_limit!r}"
             )
 
 
@@ -587,6 +599,11 @@ def parse_args() -> argparse.Namespace:
     # Raw request-body ceiling for the ingestion endpoints (LR2 §9.4); 0 disables.
     args.max_request_body_bytes = get_env_value(
         "MAX_REQUEST_BODY_BYTES", DEFAULT_MAX_REQUEST_BODY_BYTES, int
+    )
+
+    # Document fan-out ceiling for one /documents/texts request (LR2 §11); 0 disables.
+    args.max_texts_per_request = get_env_value(
+        "MAX_TEXTS_PER_REQUEST", DEFAULT_MAX_TEXTS_PER_REQUEST, int
     )
 
     # Get MAX_GRAPH_NODES from environment

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -17,6 +17,7 @@ import logging
 import logging.config
 import sys
 import textwrap
+import time
 import uuid
 import uvicorn
 import pipmaster as pm
@@ -75,7 +76,9 @@ from lightrag.kg.shared_storage import (
     cleanup_keyed_lock,
     drain_reserved_background_tasks,
     finalize_share_data,
+    get_pipeline_ingress,
 )
+from lightrag.utils_pipeline import describe_doc_status_capabilities
 from fastapi.security import OAuth2PasswordRequestForm
 from lightrag.api.auth import auth_handler
 from lightrag.api.login_rate_limit import LoginRateLimiter
@@ -1203,6 +1206,64 @@ def check_frontend_build():
         # If check fails, log warning but don't affect startup
         logger.warning(f"Failed to check frontend source freshness: {e}")
         return (True, False)  # Assume assets exist and up-to-date on error
+
+
+def _build_capability_status(rag) -> dict:
+    """Strict-capability report, or ``{}`` when it cannot be determined.
+
+    /health is a liveness probe first: one unavailable diagnostic must never turn
+    it into a 500.
+    """
+    doc_status = getattr(rag, "doc_status", None)
+    if doc_status is None:
+        return {}
+    try:
+        return describe_doc_status_capabilities(doc_status)
+    except Exception as capability_error:  # pragma: no cover - defensive
+        logger.debug(f"Capability probe unavailable for /health: {capability_error}")
+        return {}
+
+
+def _build_scheduling_status(pipeline_snapshot: dict, ingress_counts: dict) -> dict:
+    """Curated scheduling/observability view for /health (LR2 Phase 6 items 2/4).
+
+    Answers the questions an operator actually has during a manual retry or a
+    scan: which phase the manual channel is in, which request holds the freeze
+    and since when, what the drain is still waiting for, and how full the sticky
+    channel is. The manual owner's ``owner_token`` is omitted on purpose — it
+    authorizes releasing a reservation, so publishing it would turn a status page
+    into a control surface.
+    """
+    owner = pipeline_snapshot.get("manual_owner") or {}
+    freeze_started = pipeline_snapshot.get("manual_freeze_started_at")
+    freeze_seconds = None
+    if isinstance(freeze_started, (int, float)) and freeze_started > 0:
+        # Wall clock, because the freeze may be held by another process; a
+        # negative value (clock stepped back) is reported as 0 rather than as a
+        # nonsensical duration.
+        freeze_seconds = max(0.0, round(time.time() - float(freeze_started), 3))
+    pending_enqueues = int(pipeline_snapshot.get("pending_enqueues", 0) or 0)
+    return {
+        "manual_phase": pipeline_snapshot.get("manual_phase") or "idle",
+        "manual_freeze_requested": bool(
+            pipeline_snapshot.get("manual_freeze_requested", False)
+        ),
+        "manual_resetting": bool(pipeline_snapshot.get("manual_resetting", False)),
+        "manual_freeze_seconds": freeze_seconds,
+        "manual_owner_request_id": (
+            owner.get("request_id") if isinstance(owner, dict) else None
+        ),
+        "manual_owner_pid": owner.get("pid") if isinstance(owner, dict) else None,
+        # What a DRAIN_TO_IDLE is still waiting for: reservations whose rows are
+        # not written yet, plus whether a processing run still holds busy.
+        "drain_pending_enqueues": pending_enqueues,
+        "drain_waiting_on_workers": bool(pipeline_snapshot.get("busy", False)),
+        "manual_retries_queued": ingress_counts.get("manual_retries"),
+        "manual_retries_capacity": ingress_counts.get("manual_retries_capacity"),
+        "document_notifications_queued": ingress_counts.get("documents"),
+        "document_notification_overflows": ingress_counts.get("document_overflows"),
+        "auto_rescan_pending": ingress_counts.get("auto_rescan_pending"),
+    }
 
 
 def create_app(args):
@@ -2492,6 +2553,17 @@ def create_app(args):
                 or pipeline_pending_enqueues > 0
             )
 
+            # Ingress channel depths (bounded counters only — never the
+            # messages). Best-effort: a mailbox that is not bootstrapped yet must
+            # not turn a liveness probe into a 500.
+            ingress_counts: dict[str, Any] = {}
+            try:
+                ingress_counts = dict(
+                    (await get_pipeline_ingress(workspace)).counts() or {}
+                )
+            except Exception as ingress_error:
+                logger.debug(f"Ingress counts unavailable for /health: {ingress_error}")
+
             if not auth_configured:
                 auth_mode = "disabled"
             else:
@@ -2586,6 +2658,16 @@ def create_app(args):
                     "pipeline_scanning": pipeline_scanning,
                     "pipeline_destructive_busy": pipeline_destructive_busy,
                     "pipeline_pending_enqueues": pipeline_pending_enqueues,
+                    # Curated scheduling view (LR2 Phase 6 items 2 & 4). The raw
+                    # manual_* fields stay hidden from /pipeline_status — they are
+                    # coordination internals — but an operator watching a freeze
+                    # needs to see WHICH request holds it, for how long, and what
+                    # the drain is still waiting for. The owner token is
+                    # deliberately omitted: it is a capability, not a status.
+                    "scheduling": _build_scheduling_status(
+                        pipeline_snapshot, ingress_counts
+                    ),
+                    "capabilities": _build_capability_status(rag),
                     "keyed_locks": keyed_lock_info,
                     "llm_queue_status": await rag.get_llm_queue_status(
                         include_base=True

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -78,6 +78,7 @@ from lightrag.kg.shared_storage import (
     finalize_share_data,
     get_pipeline_ingress,
 )
+from lightrag import pipeline_metrics
 from lightrag.utils_pipeline import describe_doc_status_capabilities
 from fastapi.security import OAuth2PasswordRequestForm
 from lightrag.api.auth import auth_handler
@@ -2668,6 +2669,10 @@ def create_app(args):
                         pipeline_snapshot, ingress_counts
                     ),
                     "capabilities": _build_capability_status(rag),
+                    # Per-worker counters/durations for the paths the bounded
+                    # rework introduced (LR2 Phase 6 item 3); see
+                    # lightrag/pipeline_metrics.py for the boundary.
+                    "scheduling_metrics": pipeline_metrics.snapshot(),
                     "keyed_locks": keyed_lock_info,
                     "llm_queue_status": await rag.get_llm_queue_status(
                         include_base=True

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -87,6 +87,7 @@ from lightrag.utils import (
     generate_track_id,
     move_file_to_parsed_dir,
 )
+from lightrag.kg.shared_storage import append_pipeline_history
 from lightrag.utils_pipeline import count_active_documents, read_source_file_basename
 from lightrag.api.admission import adopt_admission_ticket
 from lightrag.api.utils_api import get_combined_auth_dependency
@@ -2110,7 +2111,7 @@ async def record_scan_warning(rag: LightRAG, message: str) -> None:
         )
         async with pipeline_status_lock:
             pipeline_status["latest_message"] = message
-            pipeline_status["history_messages"].append(message)
+            append_pipeline_history(pipeline_status, message)
     except Exception:
         pass
 
@@ -3550,8 +3551,8 @@ async def background_delete_documents(
                 "Starting document deletion process"
             ]
             if delete_llm_cache:
-                pipeline_status["history_messages"].append(
-                    "LLM cache cleanup requested for this deletion job"
+                append_pipeline_history(
+                    pipeline_status, "LLM cache cleanup requested for this deletion job"
                 )
 
         # Loop through each document ID and delete them one by one
@@ -3562,7 +3563,7 @@ async def background_delete_documents(
                     cancel_msg = f"Deletion cancelled by user at document {i}/{total_docs}. {len(successful_deletions)} deleted, {total_docs - i + 1} remaining."
                     logger.info(cancel_msg)
                     pipeline_status["latest_message"] = cancel_msg
-                    pipeline_status["history_messages"].append(cancel_msg)
+                    append_pipeline_history(pipeline_status, cancel_msg)
                     # Add remaining documents to failed list with cancellation reason
                     failed_deletions.extend(
                         doc_ids[i - 1 :]
@@ -3572,7 +3573,7 @@ async def background_delete_documents(
                 start_msg = f"Deleting document {i}/{total_docs}: {doc_id}"
                 logger.info(start_msg)
                 pipeline_status.update({"cur_batch": i, "latest_message": start_msg})
-                pipeline_status["history_messages"].append(start_msg)
+                append_pipeline_history(pipeline_status, start_msg)
 
             file_path = "#"
             try:
@@ -3589,7 +3590,7 @@ async def background_delete_documents(
                     )
                     logger.info(success_msg)
                     async with pipeline_status_lock:
-                        pipeline_status["history_messages"].append(success_msg)
+                        append_pipeline_history(pipeline_status, success_msg)
 
                     # Handle file deletion if requested and source information is available
                     if (
@@ -3610,8 +3611,8 @@ async def background_delete_documents(
                                     pipeline_status["latest_message"] = (
                                         file_delete_error
                                     )
-                                    pipeline_status["history_messages"].append(
-                                        file_delete_error
+                                    append_pipeline_history(
+                                        pipeline_status, file_delete_error
                                     )
 
                             if deleted_files:
@@ -3622,8 +3623,8 @@ async def background_delete_documents(
                                 logger.info(file_delete_msg)
                                 async with pipeline_status_lock:
                                     pipeline_status["latest_message"] = file_delete_msg
-                                    pipeline_status["history_messages"].append(
-                                        file_delete_msg
+                                    append_pipeline_history(
+                                        pipeline_status, file_delete_msg
                                     )
                             else:
                                 file_error_msg = (
@@ -3633,8 +3634,8 @@ async def background_delete_documents(
                                 logger.warning(file_error_msg)
                                 async with pipeline_status_lock:
                                     pipeline_status["latest_message"] = file_error_msg
-                                    pipeline_status["history_messages"].append(
-                                        file_error_msg
+                                    append_pipeline_history(
+                                        pipeline_status, file_error_msg
                                     )
 
                         except Exception as file_error:
@@ -3642,9 +3643,7 @@ async def background_delete_documents(
                             logger.error(file_error_msg)
                             async with pipeline_status_lock:
                                 pipeline_status["latest_message"] = file_error_msg
-                                pipeline_status["history_messages"].append(
-                                    file_error_msg
-                                )
+                                append_pipeline_history(pipeline_status, file_error_msg)
                     elif delete_file:
                         no_file_msg = (
                             f"File deletion skipped, missing file path: {doc_id}"
@@ -3652,14 +3651,14 @@ async def background_delete_documents(
                         logger.warning(no_file_msg)
                         async with pipeline_status_lock:
                             pipeline_status["latest_message"] = no_file_msg
-                            pipeline_status["history_messages"].append(no_file_msg)
+                            append_pipeline_history(pipeline_status, no_file_msg)
                 else:
                     failed_deletions.append(doc_id)
                     error_msg = f"Failed to delete {i}/{total_docs}: {doc_id}[{file_path}] - {result.message}"
                     logger.error(error_msg)
                     async with pipeline_status_lock:
                         pipeline_status["latest_message"] = error_msg
-                        pipeline_status["history_messages"].append(error_msg)
+                        append_pipeline_history(pipeline_status, error_msg)
 
             except Exception as e:
                 failed_deletions.append(doc_id)
@@ -3668,7 +3667,7 @@ async def background_delete_documents(
                 logger.error(traceback.format_exc())
                 async with pipeline_status_lock:
                     pipeline_status["latest_message"] = error_msg
-                    pipeline_status["history_messages"].append(error_msg)
+                    append_pipeline_history(pipeline_status, error_msg)
 
     except Exception as e:
         error_msg = f"Critical error during batch deletion: {str(e)}"
@@ -3676,7 +3675,7 @@ async def background_delete_documents(
         logger.error(traceback.format_exc())
         if pipeline_status is not None and pipeline_status_lock is not None:
             async with pipeline_status_lock:
-                pipeline_status["history_messages"].append(error_msg)
+                append_pipeline_history(pipeline_status, error_msg)
     finally:
         # Final summary + release the destructive slot, owner-checked +
         # cancellation-resistant so a cancel here cannot wedge the slot or
@@ -3713,7 +3712,7 @@ async def background_delete_documents(
                     "latest_message": completion_msg,
                 }
             )
-            status["history_messages"].append(completion_msg)
+            append_pipeline_history(status, completion_msg)
             # Probe the mailbox INSIDE the same critical section that releases
             # the slot: a processing request refused while we held busy armed
             # the auto-rescan flag under this very lock, so it is either seen
@@ -5056,8 +5055,8 @@ def create_document_routes(
                 )
                 # Cleaning history_messages without breaking it as a shared list object
                 del pipeline_status["history_messages"][:]
-                pipeline_status["history_messages"].append(
-                    "Starting document clearing process"
+                append_pipeline_history(
+                    pipeline_status, "Starting document clearing process"
                 )
 
             # We own busy+destructive: every document the mailbox refers to is
@@ -5122,10 +5121,9 @@ def create_document_routes(
             ]
 
             # Log storage drop start
-            if "history_messages" in pipeline_status:
-                pipeline_status["history_messages"].append(
-                    "Starting to drop storage components"
-                )
+            append_pipeline_history(
+                pipeline_status, "Starting to drop storage components"
+            )
 
             for storage in storages:
                 if storage is not None:
@@ -5167,29 +5165,28 @@ def create_document_routes(
                     storage_success_count += 1
 
             # Log storage drop results
-            if "history_messages" in pipeline_status:
-                if storage_error_count > 0:
-                    pipeline_status["history_messages"].append(
-                        f"Dropped {storage_success_count} storage components with {storage_error_count} errors"
-                    )
-                else:
-                    pipeline_status["history_messages"].append(
-                        f"Successfully dropped all {storage_success_count} storage components"
-                    )
+            if storage_error_count > 0:
+                append_pipeline_history(
+                    pipeline_status,
+                    f"Dropped {storage_success_count} storage components with {storage_error_count} errors",
+                )
+            else:
+                append_pipeline_history(
+                    pipeline_status,
+                    f"Successfully dropped all {storage_success_count} storage components",
+                )
 
             # If all storage operations failed, return error status and don't proceed with file deletion
             if storage_success_count == 0 and storage_error_count > 0:
                 error_message = "All storage drop operations failed. Aborting document clearing process."
                 logger.error(error_message)
-                if "history_messages" in pipeline_status:
-                    pipeline_status["history_messages"].append(error_message)
+                append_pipeline_history(pipeline_status, error_message)
                 return ClearDocumentsResponse(status="fail", message=error_message)
 
             # Log file deletion start
-            if "history_messages" in pipeline_status:
-                pipeline_status["history_messages"].append(
-                    "Starting to delete files in input directory"
-                )
+            append_pipeline_history(
+                pipeline_status, "Starting to delete files in input directory"
+            )
 
             # Delete only files in the current directory, preserve files in subdirectories
             deleted_files_count = 0
@@ -5205,16 +5202,16 @@ def create_document_routes(
                         file_errors_count += 1
 
             # Log file deletion results
-            if "history_messages" in pipeline_status:
-                if file_errors_count > 0:
-                    pipeline_status["history_messages"].append(
-                        f"Deleted {deleted_files_count} files with {file_errors_count} errors"
-                    )
-                    errors.append(f"Failed to delete {file_errors_count} files")
-                else:
-                    pipeline_status["history_messages"].append(
-                        f"Successfully deleted {deleted_files_count} files"
-                    )
+            if file_errors_count > 0:
+                append_pipeline_history(
+                    pipeline_status,
+                    f"Deleted {deleted_files_count} files with {file_errors_count} errors",
+                )
+                errors.append(f"Failed to delete {file_errors_count} files")
+            else:
+                append_pipeline_history(
+                    pipeline_status, f"Successfully deleted {deleted_files_count} files"
+                )
 
             # Prepare final result message
             final_message = ""
@@ -5226,8 +5223,7 @@ def create_document_routes(
                 status = "success"
 
             # Log final result
-            if "history_messages" in pipeline_status:
-                pipeline_status["history_messages"].append(final_message)
+            append_pipeline_history(pipeline_status, final_message)
 
             # Return response based on results
             return ClearDocumentsResponse(status=status, message=final_message)
@@ -5235,8 +5231,7 @@ def create_document_routes(
             error_msg = f"Error clearing documents: {str(e)}"
             logger.error(error_msg)
             logger.error(traceback.format_exc())
-            if "history_messages" in pipeline_status:
-                pipeline_status["history_messages"].append(error_msg)
+            append_pipeline_history(pipeline_status, error_msg)
             raise internal_server_error(e)
         finally:
             # Reset busy + destructive_busy after completion so the next
@@ -5256,8 +5251,7 @@ def create_document_routes(
                         "latest_message": completion_msg,
                     }
                 )
-                if "history_messages" in status:
-                    status["history_messages"].append(completion_msg)
+                append_pipeline_history(status, completion_msg)
 
             await with_reservation_lock(
                 pipeline_status,
@@ -6244,7 +6238,7 @@ def create_document_routes(
                         "latest_message": cancel_msg,
                     }
                 )
-                pipeline_status["history_messages"].append(cancel_msg)
+                append_pipeline_history(pipeline_status, cancel_msg)
 
             return CancelPipelineResponse(
                 status="cancellation_requested",

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -2951,6 +2951,34 @@ def _scan_enqueue_batch_size() -> int:
     return configured
 
 
+def _enforce_texts_per_request(count: int) -> None:
+    """Refuse an oversized ``/documents/texts`` batch with 413 (LR2 §11).
+
+    Read per request (not captured at import) so a config reload applies, and
+    checked BEFORE the endpoint's per-text existence reads — those are one
+    storage round-trip each, so a 100k-text batch would otherwise do 100k of them
+    on its way to being refused.
+
+    413 rather than 429: ``MAX_PENDING_DOCUMENTS`` says "the pipeline is full,
+    come back later", but a request that carries more documents than one request
+    may carry will never fit, however long the client waits. A non-positive or
+    non-integer setting disables the check — ``initialize_config`` already
+    rejects a negative one, and refusing every batch because a knob is malformed
+    would be worse than not enforcing it.
+    """
+    limit = getattr(global_args, "max_texts_per_request", None)
+    if not isinstance(limit, int) or isinstance(limit, bool) or limit <= 0:
+        return
+    if count > limit:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"Too many texts in one request: {count} (maximum {limit}). "
+                "Split the batch into smaller requests."
+            ),
+        )
+
+
 # Upper bound on one source-conflict listing page. The projection is bounded
 # per key (count + fixed sample), so this only caps the response size.
 _SOURCE_CONFLICT_PAGE_MAX = 200
@@ -4846,14 +4874,19 @@ def create_document_routes(
 
         Raises:
             HTTPException: 400 invalid file_sources, 409 same-name
-                conflict or scan/destructive job in flight, 500 other
-                errors.
+                conflict or scan/destructive job in flight, 413 more texts
+                than ``MAX_TEXTS_PER_REQUEST`` allows, 500 other errors.
         """
         from lightrag.kg.shared_storage import start_reserved_background_task
 
         enqueue_token, admission_adopted = _adopt_or_new_enqueue_token(http_request)
         handed_off = False
         try:
+            # Before anything that costs a storage round-trip or a reservation:
+            # a batch over the per-request ceiling is refused on its shape alone,
+            # independent of pipeline state.
+            _enforce_texts_per_request(len(request.texts))
+
             # Reject batch text insertion while a scan is in progress AND
             # reserve a pending-enqueue slot — see /upload for the rationale.
             if not admission_adopted:

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -3826,8 +3826,13 @@ def create_document_routes(
                 collision, 503 when the job store is unavailable.
         """
         from lightrag.exceptions import PipelineNotInitializedError
-        from lightrag.kg.pipeline_ingress import PipelineIngressMessage
+        from lightrag.kg.pipeline_ingress import (
+            ManualRetryPublishResult,
+            PipelineIngressMessage,
+        )
         from lightrag.kg.shared_storage import (
+            ManualIntentRefusal,
+            ManualIntentRefused,
             PipelineReservationConflict,
             acquire_reservation,
             get_namespace_data,
@@ -4039,7 +4044,7 @@ def create_document_routes(
                 # cancellation landing in the lock release already counts as
                 # committed on both sides.
                 async with pipeline_status_lock:
-                    ingress.request_manual_retry(
+                    publish = ingress.request_manual_retry(
                         manual_request_id,
                         PipelineIngressMessage(
                             kind="rescan",
@@ -4047,6 +4052,20 @@ def create_document_routes(
                             request_id=manual_request_id,
                         ),
                     )
+                    if publish is not ManualRetryPublishResult.ACCEPTED:
+                        # Nothing was published, so nothing is owned: refuse the
+                        # commit instead of starting a scan whose FAILED reset
+                        # would never be acknowledged (LR2 §10.1). The endpoint's
+                        # compensation chain releases the scanning reservation and
+                        # cancels the job record because ``handed_off`` stays
+                        # False.
+                        return ManualIntentRefusal(
+                            "Could not queue this scan's retry intent "
+                            f"({publish.value}); no scan was started.",
+                            capacity_exceeded=(
+                                publish is ManualRetryPublishResult.CAPACITY_EXCEEDED
+                            ),
+                        )
                     state["committed"] = True
                     takeover["committed"] = True
                 return None
@@ -4074,6 +4093,19 @@ def create_document_routes(
                 status="scanning_started",
                 message="Scanning process has been initiated in the background",
                 track_id=track_id,
+            )
+        except ManualIntentRefused as refusal:
+            # The commit refused BEFORE publishing, so nothing is owned and the
+            # finally below undoes the reservation and the job record. Capacity is
+            # the one refusal worth retrying unchanged.
+            raise HTTPException(
+                status_code=429 if refusal.capacity_exceeded else 503,
+                detail=str(refusal),
+                headers=(
+                    {"Retry-After": str(_ADMISSION_RETRY_AFTER_SECONDS)}
+                    if refusal.capacity_exceeded
+                    else None
+                ),
             )
         finally:
             # Release the scanning slot if we reserved it but a cancellation
@@ -6066,7 +6098,17 @@ def create_document_routes(
                 "point. Documents retain their original track_id.",
             )
         except ManualIntentRefused as refusal:
-            raise HTTPException(status_code=503, detail=str(refusal))
+            # 429 only for a full manual channel (retry later works); every other
+            # refusal — fence held, id already finalized — is 503 (LR2 §10.1).
+            raise HTTPException(
+                status_code=429 if refusal.capacity_exceeded else 503,
+                detail=str(refusal),
+                headers=(
+                    {"Retry-After": str(_ADMISSION_RETRY_AFTER_SECONDS)}
+                    if refusal.capacity_exceeded
+                    else None
+                ),
+            )
         except Exception as e:
             logger.error(f"Error initiating reprocessing of failed documents: {str(e)}")
             logger.error(traceback.format_exc())

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -382,6 +382,15 @@ DEFAULT_SCAN_ENQUEUE_BATCH_SIZE = 100
 # cap; the active rows they create make ordinary uploads wait.
 DEFAULT_MAX_PENDING_DOCUMENTS = 0
 
+# Ceiling on how many documents ONE ``/documents/texts`` request may carry
+# (LR2 §11). ``0`` disables it. Distinct from ``MAX_PENDING_DOCUMENTS``, which
+# bounds the pipeline's total backlog and answers 429 (retry later): this bounds
+# the fan-out of a single request, which no amount of waiting fixes, so it
+# answers 413. It has to be checked before the endpoint's per-text existence
+# reads — those are one storage round-trip each, so an oversized batch would
+# otherwise do all of them before being refused.
+DEFAULT_MAX_TEXTS_PER_REQUEST = 0
+
 # Hard ceiling on the raw request body an ingestion endpoint may receive, counted
 # as it streams through the ASGI ``receive`` channel (LR2 §9.4). ``0`` disables
 # it. Distinct from ``MAX_UPLOAD_SIZE``, which bounds one uploaded FILE after

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -397,6 +397,23 @@ DEFAULT_MAX_REQUEST_BODY_BYTES = 0
 # 429; an already-finalized id is a client error, not backpressure.
 DEFAULT_MAX_UNACKED_MANUAL_RETRIES = 64
 
+# Fixed capacity of the human-facing pipeline status history (LR2 §10.3). Every
+# write funnels through ``append_pipeline_history``, which drops the oldest lines
+# past this many, making the log a ring instead of an append-only list whose only
+# bound used to be "the extraction loop happens to trim it" — a deletion job, a
+# scan or a manual reset logs plenty without ever reaching that trim.
+# Deliberately not an env knob: §11 does not list one, the API response already
+# caps what it shows at the newest 1000 lines, and a status log is not a place a
+# deployment should have to size.
+PIPELINE_HISTORY_MAX_MESSAGES = 5000
+
+# Per-message UTF-8 byte ceiling for the same log. Capacity alone does not bound
+# memory: one call site appends a whole ``traceback.format_exc()``, and any
+# message interpolating a file list or an exception string is unbounded, so
+# N messages × unbounded size is still unbounded. Counted in BYTES rather than
+# characters because that is what is being bounded (CJK is 3 bytes/char).
+PIPELINE_HISTORY_MESSAGE_MAX_BYTES = 4096
+
 # LLM / embedding call priority levels.  Lower values run first
 # (asyncio.PriorityQueue semantics); priority only orders calls *within* a
 # single role queue (extract / keyword / query / vlm).  These name the values

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -389,6 +389,14 @@ DEFAULT_MAX_PENDING_DOCUMENTS = 0
 # body that lies about (or omits) Content-Length is still cut off.
 DEFAULT_MAX_REQUEST_BODY_BYTES = 0
 
+# Per-workspace ceiling on manual retry requests that have been published but
+# not yet ACKed (LR2 §10.1). The channel is sticky — a request survives until an
+# exclusive reset acknowledges it — so an operator hammering /reprocess_failed
+# would otherwise grow it without bound. Over the ceiling the publish is refused
+# with CAPACITY_EXCEEDED, which is the ONLY manual-publish refusal that maps to
+# 429; an already-finalized id is a client error, not backpressure.
+DEFAULT_MAX_UNACKED_MANUAL_RETRIES = 64
+
 # LLM / embedding call priority levels.  Lower values run first
 # (asyncio.PriorityQueue semantics); priority only orders calls *within* a
 # single role queue (extract / keyword / query / vlm).  These name the values

--- a/lightrag/kg/pipeline_ingress.py
+++ b/lightrag/kg/pipeline_ingress.py
@@ -43,9 +43,9 @@ SIGKILLed at any point can neither strand a lock nor split-brain the
 workspace.  :class:`ManagerPipelineIngress` is the thin per-workspace client
 view binding a namespace to the hub proxy.
 
-This module is dependency-free on purpose: :mod:`lightrag.kg.shared_storage`
-imports it to register the hub on the LightRAG ``SyncManager`` subclass and to
-build the per-process registry.
+This module deliberately does NOT import :mod:`lightrag.kg.shared_storage` —
+that module imports it, to register the hub on the LightRAG ``SyncManager``
+subclass and to build the per-process registry (only leaf imports here).
 """
 
 from __future__ import annotations
@@ -55,7 +55,11 @@ import threading
 from collections import OrderedDict, deque
 from dataclasses import dataclass
 from multiprocessing.managers import BaseProxy
+from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Protocol, runtime_checkable
+
+from lightrag.constants import DEFAULT_MAX_UNACKED_MANUAL_RETRIES
+from lightrag.utils import get_env_value
 
 # Terminal states for manual retry request ids.
 MANUAL_RETRY_ACKED = "acked"
@@ -76,6 +80,14 @@ TERMINAL_MANUAL_REQUEST_IDS_CAPACITY = 4096
 # lives in the Manager server process, so the bound also protects a shared
 # resource from one stalled workspace's feeder.
 DOCUMENT_CHANNEL_CAPACITY = 4096
+
+# Bound of the sticky manual-retry channel per workspace (LR2 §10.1). Unlike the
+# document channel, overflow here CANNOT be dropped and recovered later: a manual
+# retry is an explicit human intent with an ACK contract, so the publish is
+# refused instead and the caller is told to retry.
+MANUAL_CHANNEL_CAPACITY = get_env_value(
+    "MAX_UNACKED_MANUAL_RETRIES", DEFAULT_MAX_UNACKED_MANUAL_RETRIES, int
+)
 
 # Hard ceiling for one mailbox wait RPC.  A Manager server runs each client
 # connection on its own thread; a client SIGKILLed while a wait_for_* call is
@@ -102,6 +114,29 @@ class PipelineIngressMessage:
     doc_id: str | None = None
     retry_failed: bool = False
     request_id: str | None = None
+
+
+class ManualRetryPublishResult(str, Enum):
+    """Outcome of publishing a manual retry request (LR2 §10.1).
+
+    Three distinct answers, because they need three distinct HTTP statuses and
+    only one of them is a retry-later condition:
+
+    * ``ACCEPTED`` — queued (or already queued: re-publishing a still-pending id
+      is idempotent and keeps its FIFO position);
+    * ``ALREADY_TERMINAL`` — the id was ACKed or cancelled by a clear. A client
+      error: the caller must mint a new id, retrying this one never works.
+    * ``CAPACITY_EXCEEDED`` — the workspace is at
+      ``MAX_UNACKED_MANUAL_RETRIES``. The ONLY publish refusal that means
+      "later, not never", and the only one mapped to 429.
+
+    A str-Enum so the value survives a Manager round-trip and reads plainly in
+    logs; compare against the members, never against ``str(member)``.
+    """
+
+    ACCEPTED = "accepted"
+    ALREADY_TERMINAL = "already_terminal"
+    CAPACITY_EXCEEDED = "capacity_exceeded"
 
 
 class _BoundedTerminalIds:
@@ -223,9 +258,14 @@ class PipelineIngressMailbox:
     entries.
     """
 
-    def __init__(self, document_capacity: int = DOCUMENT_CHANNEL_CAPACITY) -> None:
+    def __init__(
+        self,
+        document_capacity: int = DOCUMENT_CHANNEL_CAPACITY,
+        manual_capacity: int = MANUAL_CHANNEL_CAPACITY,
+    ) -> None:
         self._cond = threading.Condition()
         self._document_capacity = max(1, int(document_capacity))
+        self._manual_capacity = max(1, int(manual_capacity))
         self._documents: deque[PipelineIngressMessage] = deque()
         self._document_overflows = 0
         self._auto_rescan_pending = False
@@ -276,22 +316,27 @@ class PipelineIngressMailbox:
 
     def request_manual_retry(
         self, request_id: str, msg: PipelineIngressMessage
-    ) -> bool:
-        """Sticky-register a manual retry request; False iff refused.
+    ) -> ManualRetryPublishResult:
+        """Sticky-register a manual retry request (LR2 §10.1).
 
-        Refusal happens only for ids already in the terminal set (ACKED or
-        CANCELLED_BY_CLEAR) — the bounded-window replay guard.  Re-requesting
-        an id that is still pending is an idempotent no-op (True) and does not
-        change its FIFO position.
+        ``ALREADY_TERMINAL`` for an id already ACKed or cancelled by a clear —
+        the bounded-window replay guard. ``CAPACITY_EXCEEDED`` when the workspace
+        already holds ``MAX_UNACKED_MANUAL_RETRIES`` un-ACKed requests; the
+        channel is sticky, so it cannot drop the oldest to make room the way the
+        document channel does. Re-requesting an id that is still pending is
+        idempotent (``ACCEPTED``), keeps its FIFO position, and is NOT subject to
+        the ceiling — it adds nothing.
         """
         _validate_manual_request(request_id, msg)
         with self._cond:
             if request_id in self._terminal_ids:
-                return False
+                return ManualRetryPublishResult.ALREADY_TERMINAL
             if request_id not in self._manual_retries:
+                if len(self._manual_retries) >= self._manual_capacity:
+                    return ManualRetryPublishResult.CAPACITY_EXCEEDED
                 self._manual_retries[request_id] = msg
                 self._cond.notify_all()
-            return True
+            return ManualRetryPublishResult.ACCEPTED
 
     # -- consuming ------------------------------------------------------
 
@@ -368,6 +413,7 @@ class PipelineIngressMailbox:
                 "document_overflows": self._document_overflows,
                 "auto_rescan_pending": self._auto_rescan_pending,
                 "manual_retries": len(self._manual_retries),
+                "manual_retries_capacity": self._manual_capacity,
                 "terminal_manual_request_ids": len(self._terminal_ids),
             }
 
@@ -667,9 +713,14 @@ class AsyncioPipelineIngress:
     initial scan recover the document backlog.
     """
 
-    def __init__(self, document_capacity: int = DOCUMENT_CHANNEL_CAPACITY) -> None:
+    def __init__(
+        self,
+        document_capacity: int = DOCUMENT_CHANNEL_CAPACITY,
+        manual_capacity: int = MANUAL_CHANNEL_CAPACITY,
+    ) -> None:
         self.owning_loop = asyncio.get_running_loop()
         self._document_capacity = max(1, int(document_capacity))
+        self._manual_capacity = max(1, int(manual_capacity))
         self.document_messages: asyncio.Queue[PipelineIngressMessage] = asyncio.Queue()
         self._document_overflows = 0
         self._auto_rescan_pending = False
@@ -731,14 +782,17 @@ class AsyncioPipelineIngress:
 
     def request_manual_retry(
         self, request_id: str, msg: PipelineIngressMessage
-    ) -> bool:
+    ) -> ManualRetryPublishResult:
+        """See :meth:`PipelineIngressMailbox.request_manual_retry`."""
         _validate_manual_request(request_id, msg)
         if request_id in self._terminal_ids:
-            return False
+            return ManualRetryPublishResult.ALREADY_TERMINAL
         if request_id not in self._manual_retries:
+            if len(self._manual_retries) >= self._manual_capacity:
+                return ManualRetryPublishResult.CAPACITY_EXCEEDED
             self._manual_retries[request_id] = msg
             self.work_event.set()
-        return True
+        return ManualRetryPublishResult.ACCEPTED
 
     # -- consuming ------------------------------------------------------
 
@@ -812,6 +866,7 @@ class AsyncioPipelineIngress:
             "document_overflows": self._document_overflows,
             "auto_rescan_pending": self._auto_rescan_pending,
             "manual_retries": len(self._manual_retries),
+            "manual_retries_capacity": self._manual_capacity,
             "terminal_manual_request_ids": len(self._terminal_ids),
         }
 

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -34,6 +34,7 @@ from lightrag.constants import (
     DEFAULT_GLOBAL_SLOT_WAITER_STALE_TTL,
     DEFAULT_QUEUE_STATS_STALE_TTL,
 )
+from lightrag import pipeline_metrics
 from lightrag.exceptions import (
     PipelineBackpressureError,
     PipelineNotInitializedError,
@@ -2266,6 +2267,10 @@ def _recovery_required_result(
 
 
 def _conflict_for_status_flag(flag_key: str) -> PipelineReservationConflict:
+    if flag_key == "manual_freeze_requested":
+        # One chokepoint for every ingress path (enqueue reservation, last-line
+        # guard, scan fence), so the count cannot drift between them.
+        pipeline_metrics.increment(pipeline_metrics.FREEZE_REJECTS)
     try:
         return {
             "busy": PipelineReservationConflict.BUSY,
@@ -2689,6 +2694,7 @@ async def acquire_processing_reservation(
             # (busy=False — this acquire would have succeeded instead).
             _commit_pipeline_reservation_updates(pipeline_status, recovery_updates)
             pipeline_ingress.request_auto_rescan()
+            pipeline_metrics.increment(pipeline_metrics.AUTO_RESCAN_REARMS)
             return PipelineReservationResult(
                 acquired=False,
                 conflict=PipelineReservationConflict.BUSY,

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -33,6 +33,8 @@ from lightrag.constants import (
     DEFAULT_GLOBAL_SLOT_SUSPECT_GRACE,
     DEFAULT_GLOBAL_SLOT_WAITER_STALE_TTL,
     DEFAULT_QUEUE_STATS_STALE_TTL,
+    PIPELINE_HISTORY_MAX_MESSAGES,
+    PIPELINE_HISTORY_MESSAGE_MAX_BYTES,
 )
 from lightrag import pipeline_metrics
 from lightrag.exceptions import (
@@ -1876,6 +1878,125 @@ _UNRESOLVED = object()
 """
 
 
+# ---------------------------------------------------------------------------
+# Bounded pipeline status history (LR2 §10.3)
+# ---------------------------------------------------------------------------
+#
+# Every history write in the repo funnels through ``append_pipeline_history``
+# (or :class:`PipelineStatusLogger`, which shares the helpers below). Two bounds
+# are enforced together because either alone is insufficient: a message count
+# without a size cap still lets one ``traceback.format_exc()`` line dominate the
+# log, and a size cap without a count is unbounded by definition.
+
+# How many appends may pass before the capacity check is taken. The check itself
+# is a ``len()`` — one Manager RPC in multiprocess mode — and the hot extraction
+# path logs thousands of lines per document, so checking every time would add
+# 50% to the per-line RPC budget that PipelineStatusLogger exists to hold at 2.
+# Amortizing it makes the real bound ``capacity + interval × concurrently
+# written histories`` (2.5% overshoot per writer), which is still a fixed bound.
+_HISTORY_TRIM_CHECK_INTERVAL = 128
+
+# Process-local, deliberately not synchronized: this is a heuristic for *when* to
+# check, never a correctness input. A racing double-check just runs the trim
+# twice, and the trim is idempotent (it always leaves the newest `capacity`).
+_history_appends_since_trim = 0
+
+
+def clamp_pipeline_history_message(message: Any) -> Any:
+    """Cut one history line to ``PIPELINE_HISTORY_MESSAGE_MAX_BYTES`` UTF-8 bytes.
+
+    Truncation keeps the HEAD plus a marker naming the original size: status
+    lines put the identifying part first (stage, counter, doc id, file path), and
+    an operator who sees "48213 bytes" knows to look in the server log for the
+    full text — which every one of these call sites has already written there.
+
+    Never raises (part of the status-write contract): an unexpected object is
+    returned untouched rather than failing the operation being logged.
+    """
+    try:
+        if not isinstance(message, str):
+            message = str(message)
+        raw = message.encode("utf-8")
+        if len(raw) <= PIPELINE_HISTORY_MESSAGE_MAX_BYTES:
+            return message
+        marker = f"…[truncated, {len(raw)} bytes]"
+        budget = max(
+            0, PIPELINE_HISTORY_MESSAGE_MAX_BYTES - len(marker.encode("utf-8"))
+        )
+        # Slice the BYTES and drop the partial trailing character (the whole
+        # point of errors="ignore" here); slicing characters instead would
+        # overshoot the byte budget by up to 3x on CJK text.
+        return raw[:budget].decode("utf-8", errors="ignore") + marker
+    except Exception as exc:
+        _debug_log_failure("history message clamp skipped", exc)
+        return message
+
+
+def _maybe_trim_pipeline_history(history, appended: int = 1) -> None:
+    """Enforce the ring capacity on an already-resolved history handle.
+
+    ``appended`` counts MESSAGES, not calls: a group write advances the counter by
+    its own length, so the overshoot stays ``interval`` regardless of how large a
+    group a call site passes.
+
+    Lock-free on purpose. The trim is a read-modify-write, but its only possible
+    race outcome is running twice, and ``del history[:overflow]`` never removes a
+    message newer than the retained window — so no reader can observe anything a
+    single-threaded trim would not also have produced. Coordination state still
+    requires ``pipeline_status_lock``; this is status log housekeeping.
+    """
+    global _history_appends_since_trim
+    _history_appends_since_trim += appended
+    if _history_appends_since_trim < _HISTORY_TRIM_CHECK_INTERVAL:
+        return
+    _history_appends_since_trim = 0
+    try:
+        overflow = len(history) - PIPELINE_HISTORY_MAX_MESSAGES
+        if overflow > 0:
+            # In place, and by slice: `history` is the shared Manager ListProxy
+            # that every worker appends to and PipelineStatusLogger caches, so
+            # rebinding it would orphan both. One `del` is one server-side RPC;
+            # popping in a loop would be `overflow` of them.
+            del history[:overflow]
+    except Exception as exc:
+        _debug_log_failure("history trim skipped", exc)
+
+
+def append_pipeline_history(pipeline_status, *messages) -> None:
+    """The single funnel for pipeline status history writes (LR2 §10.3).
+
+    Replaces the raw ``history_messages`` append at every call site — a repo-wide
+    test fails if one is re-introduced, because a single unfunnelled writer is an
+    unbounded leak that nothing else would notice.
+
+    Deliberately does NOT touch ``latest_message``: the call sites that set it do
+    so alongside other coordination fields in one ``update()``, and folding that
+    in would turn a mechanical, reviewable substitution into a behaviour change.
+
+    Same never-raise contract as :class:`PipelineStatusLogger`, for the same
+    reason — the call sites are shaped ``except ...: log(...); raise`` and a
+    raising status write would mask the real exception. A missing/None
+    ``history_messages`` is skipped rather than raising KeyError.
+    """
+    if pipeline_status is None or not messages:
+        return
+    try:
+        history = pipeline_status.get("history_messages")
+    except Exception as exc:
+        _debug_log_failure("history fetch skipped", exc)
+        return
+    if history is None:
+        return
+    try:
+        # One `extend` per group: N appends would be N RPCs, and a group written
+        # by one call site belongs together in the log.
+        history.extend([clamp_pipeline_history_message(m) for m in messages])
+    except Exception as exc:
+        _debug_log_failure("history append skipped", exc)
+        return
+    _maybe_trim_pipeline_history(history, len(messages))
+
+
 class PipelineStatusLogger:
     """Operation-scoped, lock-free pipeline status logger with a cached history list.
 
@@ -1900,13 +2021,15 @@ class PipelineStatusLogger:
       reset IN PLACE (``del h[:]`` / ``h[:] = [...]``) and never replaced with
       a new list object; a replacement would leave this logger appending to
       the orphaned list for the rest of the operation.
-    - History *trimming* is deliberately not offered here: the ``len`` check
-      plus delete is a read-modify-write and must stay inside
-      ``async with pipeline_status_lock`` (see the processing loop).
+    - Shares the LR2 §10.3 bounds with :func:`append_pipeline_history`: each
+      message is clamped by :func:`clamp_pipeline_history_message` and the ring
+      capacity is enforced by :func:`_maybe_trim_pipeline_history`. This is the
+      hot path (thousands of lines per document), which is exactly why the
+      capacity check there is amortized rather than taken per line.
 
     Why lock-free is safe: this is for pure status logging ONLY, never for
     coordination state (``busy`` / ``cancellation_*`` /
-    reservation owner tokens / ``cur_batch`` / the history trim), which stays
+    reservation owner tokens / ``cur_batch``), which stays
     in ``async with pipeline_status_lock`` read-modify-write blocks. Each of
     ``dict.__setitem__`` and ``list.extend`` is a single indivisible operation
     on the backing dict/list under the Manager server's CPython GIL (for plain
@@ -1945,6 +2068,10 @@ class PipelineStatusLogger:
         the whole group to history with one ``extend``."""
         if self._pipeline_status is None or not messages:
             return
+        # Clamp once, up front: `latest_message` is a single slot but it is read
+        # back on every status poll, so an unclamped 48 KB line would be shipped
+        # to the UI for as long as it stays the latest.
+        messages = tuple(clamp_pipeline_history_message(m) for m in messages)
         try:
             self._pipeline_status["latest_message"] = messages[-1]
         except Exception as exc:
@@ -1968,6 +2095,8 @@ class PipelineStatusLogger:
             # Do NOT retry these messages: the extend may have half-committed.
             self._history = _UNRESOLVED
             _debug_log_failure("history append skipped", exc)
+            return
+        _maybe_trim_pipeline_history(history, len(messages))
 
 
 # ============================================================================

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -11,7 +11,17 @@ import logging
 from dataclasses import dataclass
 from enum import Enum
 from contextvars import ContextVar
-from typing import Any, Dict, List, Mapping, Optional, Union, TypeVar, Generic
+from typing import (
+    Any,
+    Dict,
+    Generic,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    TypeVar,
+    Union,
+)
 
 try:
     import psutil
@@ -31,6 +41,7 @@ from lightrag.exceptions import (
 from lightrag.kg.pipeline_ingress import (
     AsyncioPipelineIngress,
     ManagerPipelineIngress,
+    ManualRetryPublishResult,
     PipelineIngressHub,
     PipelineIngressMessage,
     _PipelineIngressHubProxy,
@@ -2992,14 +3003,32 @@ async def start_reserved_background_task(
     raise RuntimeError("reserved background task failed to start")
 
 
+class ManualIntentRefusal(NamedTuple):
+    """A refusal a ``commit`` implementation can return instead of a bare string.
+
+    ``capacity_exceeded`` is the one distinction the HTTP layer must not lose:
+    the manual channel being full is a "later" (429 + Retry-After), while every
+    other refusal — fence held, id already finalized — is a "not like this"
+    (503 / client error). See LR2 §10.1.
+    """
+
+    message: str
+    capacity_exceeded: bool = False
+
+
 class ManualIntentRefused(Exception):
     """A manual-intent commit was refused by the pipeline fence.
 
     Raised by :func:`start_committed_background_task` when ``commit`` returned
     a refusal: the fence rejected the request BEFORE the sticky message was
     published, so no side effect exists and the endpoint can surface the
-    message (e.g. as a 503) without any cleanup.
+    message (e.g. as a 503) without any cleanup. ``capacity_exceeded`` marks the
+    one refusal that is worth retrying unchanged (429).
     """
+
+    def __init__(self, message: str, *, capacity_exceeded: bool = False) -> None:
+        super().__init__(message)
+        self.capacity_exceeded = capacity_exceeded
 
 
 async def commit_manual_retry_request(
@@ -3047,14 +3076,25 @@ async def commit_manual_retry_request(
                 "it finishes."
             )
         _commit_pipeline_reservation_updates(pipeline_status, recovery_updates)
-        if not ingress.request_manual_retry(request_id, message):
+        publish = ingress.request_manual_retry(request_id, message)
+        if publish is ManualRetryPublishResult.ALREADY_TERMINAL:
             # The id is already terminal (ACKED / CANCELLED_BY_CLEAR): nothing
             # was published and nothing is owned. Unreachable for the current
             # callers (they mint a fresh uuid per request) but a future caller
             # reusing ids must get a refusal, not a phantom commit.
-            return (
+            return ManualIntentRefusal(
                 f"manual retry request id {request_id!r} was already "
                 "finalized; mint a new request id"
+            )
+        if publish is ManualRetryPublishResult.CAPACITY_EXCEEDED:
+            # Sticky channel full (LR2 §10.1): un-ACKed requests are waiting for
+            # exclusive resets that have not run yet. Retrying later works, so
+            # this is the one publish refusal the API answers with 429.
+            return ManualIntentRefusal(
+                "Too many manual retry requests are still waiting to be "
+                "served for this workspace. Retry once the queued requests "
+                "have been processed.",
+                capacity_exceeded=True,
             )
         state["committed"] = True
         return None
@@ -3162,7 +3202,12 @@ async def start_committed_background_task(
     if join_cancel is not None:
         raise join_cancel
     if state["refusal"] is not None:
-        raise ManualIntentRefused(state["refusal"])
+        refusal = state["refusal"]
+        if isinstance(refusal, ManualIntentRefusal):
+            raise ManualIntentRefused(
+                refusal.message, capacity_exceeded=refusal.capacity_exceeded
+            )
+        raise ManualIntentRefused(str(refusal))
     raise RuntimeError("committed background task failed to start")
 
 

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -1703,6 +1703,7 @@ async def initialize_pipeline_status(workspace: str | None = None):
                 # process_start_id} — so a dead busy owner clears the manual
                 # state too (see _dead_reservation_updates).
                 "manual_freeze_requested": False,
+                "manual_freeze_started_at": None,
                 "manual_resetting": False,
                 "manual_phase": MANUAL_PHASE_IDLE,
                 "manual_owner": None,
@@ -2008,6 +2009,7 @@ _INTERNAL_PIPELINE_STATUS_FIELDS = (
     # are also hidden here in Phase 3; Phase 6 adds a curated observability view.
     "manual_owner",
     "manual_freeze_requested",
+    "manual_freeze_started_at",
     "manual_resetting",
     "manual_phase",
 )
@@ -2114,6 +2116,7 @@ def _dead_reservation_updates(
         updates.update(
             {
                 "manual_freeze_requested": False,
+                "manual_freeze_started_at": None,
                 "manual_resetting": False,
                 "manual_phase": MANUAL_PHASE_IDLE,
                 "manual_owner": None,

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -94,6 +94,7 @@ from lightrag.kg import (
 from lightrag.kg.shared_storage import (
     PipelineReservationConflict,
     acquire_reservation,
+    append_pipeline_history,
     check_pipeline_status_mutation,
     get_namespace_data,
     get_default_workspace,
@@ -2390,7 +2391,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         logger.info(log_message)
                         async with pipeline_status_lock:
                             pipeline_status["latest_message"] = log_message
-                            pipeline_status["history_messages"].append(log_message)
+                            append_pipeline_history(pipeline_status, log_message)
                     except Exception as rollback_error:
                         # Journal and FAILED status remain; the next scan retries.
                         failed_count += 1
@@ -2403,7 +2404,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         logger.error(log_message)
                         async with pipeline_status_lock:
                             pipeline_status["latest_message"] = log_message
-                            pipeline_status["history_messages"].append(log_message)
+                            append_pipeline_history(pipeline_status, log_message)
 
         # Scheduling-control-plane discovery, memory-bounded (LR2 Phase 2):
         # page the FAILED/PROCESSING keyset instead of materializing every such
@@ -2698,7 +2699,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         logger.warning(log_message)
         async with pipeline_status_lock:
             pipeline_status["latest_message"] = log_message
-            pipeline_status["history_messages"].append(log_message)
+            append_pipeline_history(pipeline_status, log_message)
 
         return updated_rows
 
@@ -2795,7 +2796,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             if pipeline_status is not None and pipeline_status_lock is not None:
                 async with pipeline_status_lock:
                     pipeline_status["latest_message"] = error_msg
-                    pipeline_status["history_messages"].append(error_msg)
+                    append_pipeline_history(pipeline_status, error_msg)
             raise e
 
     def _index_storages(self) -> list:
@@ -2965,7 +2966,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         if pipeline_status is not None and pipeline_status_lock is not None:
             async with pipeline_status_lock:
                 pipeline_status["latest_message"] = log_message
-                pipeline_status["history_messages"].append(log_message)
+                append_pipeline_history(pipeline_status, log_message)
 
     async def _insert_done_with_cleanup(self) -> None:
         """``_insert_done`` for UPSERT-oriented direct (non-pipeline) callers,
@@ -4160,7 +4161,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 )
                 logger.info(log_message)
                 pipeline_status["latest_message"] = log_message
-                pipeline_status["history_messages"].append(log_message)
+                append_pipeline_history(pipeline_status, log_message)
 
             for edge_data in affected_edges:
                 src = edge_data.get("source")
@@ -4225,7 +4226,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 )
                 logger.info(log_message)
                 pipeline_status["latest_message"] = log_message
-                pipeline_status["history_messages"].append(log_message)
+                append_pipeline_history(pipeline_status, log_message)
 
             # Update entity/relation chunk-tracking with the remaining sources.
             current_time = int(time.time())
@@ -4289,7 +4290,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     )
                     logger.info(log_message)
                     pipeline_status["latest_message"] = log_message
-                    pipeline_status["history_messages"].append(log_message)
+                    append_pipeline_history(pipeline_status, log_message)
             except Exception as e:
                 logger.error(
                     f"[purge] Failed to delete relationships for {doc_id}: {e}"
@@ -4352,7 +4353,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     )
                     logger.info(log_message)
                     pipeline_status["latest_message"] = log_message
-                    pipeline_status["history_messages"].append(log_message)
+                    append_pipeline_history(pipeline_status, log_message)
             except Exception as e:
                 logger.error(f"[purge] Failed to delete entities for {doc_id}: {e}")
                 raise Exception(f"Failed to delete entities: {e}") from e
@@ -4415,7 +4416,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 )
                 logger.info(log_message)
                 pipeline_status["latest_message"] = log_message
-                pipeline_status["history_messages"].append(log_message)
+                append_pipeline_history(pipeline_status, log_message)
         except Exception as e:
             logger.error(f"[purge] Failed to delete chunks for {doc_id}: {e}")
             raise Exception(f"Failed to delete document chunks: {e}") from e
@@ -4576,7 +4577,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 log_message = f"Starting deletion process for document {doc_id}"
                 logger.info(log_message)
                 pipeline_status["latest_message"] = log_message
-                pipeline_status["history_messages"].append(log_message)
+                append_pipeline_history(pipeline_status, log_message)
 
             # 1. Get the document status and related data
             doc_status_data = await self.doc_status.get_by_id(doc_id)
@@ -4628,7 +4629,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 # Update pipeline status for monitoring
                 async with pipeline_status_lock:
                     pipeline_status["latest_message"] = warning_msg
-                    pipeline_status["history_messages"].append(warning_msg)
+                    append_pipeline_history(pipeline_status, warning_msg)
 
             # 2. Get chunk IDs from document status
             metadata = doc_status_data.get("metadata", {})
@@ -4695,7 +4696,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         logger.error(no_cache_msg)
                         async with pipeline_status_lock:
                             pipeline_status["latest_message"] = no_cache_msg
-                            pipeline_status["history_messages"].append(no_cache_msg)
+                            append_pipeline_history(pipeline_status, no_cache_msg)
                         raise Exception(no_cache_msg)
                     try:
                         deletion_stage = "delete_llm_cache"
@@ -4737,7 +4738,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     )
                     logger.info(log_message)
                     pipeline_status["latest_message"] = log_message
-                    pipeline_status["history_messages"].append(log_message)
+                    append_pipeline_history(pipeline_status, log_message)
 
                 deletion_fully_completed = True
                 return DeletionResult(
@@ -4975,7 +4976,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     log_message = f"Found {len(entities_to_rebuild)} affected entities"
                     logger.info(log_message)
                     pipeline_status["latest_message"] = log_message
-                    pipeline_status["history_messages"].append(log_message)
+                    append_pipeline_history(pipeline_status, log_message)
 
                 # Process relationships
                 for edge_data in affected_edges:
@@ -5052,7 +5053,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     )
                     logger.info(log_message)
                     pipeline_status["latest_message"] = log_message
-                    pipeline_status["history_messages"].append(log_message)
+                    append_pipeline_history(pipeline_status, log_message)
 
                 current_time = int(time.time())
                 deletion_stage = "update_chunk_tracking"
@@ -5106,7 +5107,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         )
                         logger.info(log_message)
                         pipeline_status["latest_message"] = log_message
-                        pipeline_status["history_messages"].append(log_message)
+                        append_pipeline_history(pipeline_status, log_message)
 
                 except Exception as e:
                     logger.error(f"Failed to delete chunks: {e}")
@@ -5144,7 +5145,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         log_message = f"Successfully deleted {len(relationships_to_delete)} relations"
                         logger.info(log_message)
                         pipeline_status["latest_message"] = log_message
-                        pipeline_status["history_messages"].append(log_message)
+                        append_pipeline_history(pipeline_status, log_message)
 
                 except Exception as e:
                     logger.error(f"Failed to delete relationships: {e}")
@@ -5241,7 +5242,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         )
                         logger.info(log_message)
                         pipeline_status["latest_message"] = log_message
-                        pipeline_status["history_messages"].append(log_message)
+                        append_pipeline_history(pipeline_status, log_message)
 
                 except Exception as e:
                     logger.error(f"Failed to delete entities: {e}")
@@ -5292,7 +5293,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     logger.error(log_message)
                     async with pipeline_status_lock:
                         pipeline_status["latest_message"] = log_message
-                        pipeline_status["history_messages"].append(log_message)
+                        append_pipeline_history(pipeline_status, log_message)
                     raise Exception(log_message)
                 try:
                     deletion_stage = "delete_llm_cache"
@@ -5312,7 +5313,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     logger.info(cache_log_message)
                     async with pipeline_status_lock:
                         pipeline_status["latest_message"] = cache_log_message
-                        pipeline_status["history_messages"].append(cache_log_message)
+                        append_pipeline_history(pipeline_status, cache_log_message)
                     log_message = cache_log_message
                 except Exception as cache_delete_error:
                     log_message = (
@@ -5323,7 +5324,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     logger.error(traceback.format_exc())
                     async with pipeline_status_lock:
                         pipeline_status["latest_message"] = log_message
-                        pipeline_status["history_messages"].append(log_message)
+                        append_pipeline_history(pipeline_status, log_message)
                     raise Exception(log_message) from cache_delete_error
 
             # 10. Delete from full_entities and full_relations storage
@@ -5448,7 +5449,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                             "or enqueued document is not silently deferred: "
                             f"{probe_error}"
                         )
-                status["history_messages"].append(completion_msg)
+                append_pipeline_history(status, completion_msg)
                 logger.info(completion_msg)
                 if ingress_has_work:
                     status.update(updates)

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -88,7 +88,11 @@ from lightrag.constants import (
     DEFAULT_ENTITY_NAME_MAX_LENGTH,
     DEFAULT_ENTITY_NAME_MAX_BYTES,
 )
-from lightrag.kg.shared_storage import PipelineStatusLogger, get_storage_keyed_lock
+from lightrag.kg.shared_storage import (
+    PipelineStatusLogger,
+    append_pipeline_history,
+    get_storage_keyed_lock,
+)
 import time
 from dotenv import load_dotenv
 
@@ -1055,7 +1059,7 @@ async def rebuild_knowledge_from_chunks(
     if pipeline_status is not None and pipeline_status_lock is not None:
         async with pipeline_status_lock:
             pipeline_status["latest_message"] = status_message
-            pipeline_status["history_messages"].append(status_message)
+            append_pipeline_history(pipeline_status, status_message)
 
     # Get cached extraction results for these chunks using storage
     # cached_results： chunk_id -> [list of (extraction_result, create_time) from LLM cache sorted by create_time of the first extraction_result]
@@ -1077,7 +1081,7 @@ async def rebuild_knowledge_from_chunks(
         if pipeline_status is not None and pipeline_status_lock is not None:
             async with pipeline_status_lock:
                 pipeline_status["latest_message"] = status_message
-                pipeline_status["history_messages"].append(status_message)
+                append_pipeline_history(pipeline_status, status_message)
 
     if not cached_results:
         status_message = "No cached extraction results found"
@@ -1085,7 +1089,7 @@ async def rebuild_knowledge_from_chunks(
         if pipeline_status is not None and pipeline_status_lock is not None:
             async with pipeline_status_lock:
                 pipeline_status["latest_message"] = status_message
-                pipeline_status["history_messages"].append(status_message)
+                append_pipeline_history(pipeline_status, status_message)
         if rebuild_policy == "best_effort":
             return report
 
@@ -1270,7 +1274,7 @@ async def rebuild_knowledge_from_chunks(
     if pipeline_status is not None and pipeline_status_lock is not None:
         async with pipeline_status_lock:
             pipeline_status["latest_message"] = status_message
-            pipeline_status["history_messages"].append(status_message)
+            append_pipeline_history(pipeline_status, status_message)
 
     # Execute all tasks in parallel with semaphore control; on any failure
     # every sibling is cancelled and drained before the first exception
@@ -1286,7 +1290,7 @@ async def rebuild_knowledge_from_chunks(
     if pipeline_status is not None and pipeline_status_lock is not None:
         async with pipeline_status_lock:
             pipeline_status["latest_message"] = status_message
-            pipeline_status["history_messages"].append(status_message)
+            append_pipeline_history(pipeline_status, status_message)
 
     if report.has_warnings:
         logger.warning(
@@ -3300,7 +3304,7 @@ async def merge_nodes_and_edges(
     logger.info(log_message)
     async with pipeline_status_lock:
         pipeline_status["latest_message"] = log_message
-        pipeline_status["history_messages"].append(log_message)
+        append_pipeline_history(pipeline_status, log_message)
 
     # ===== Phase 0: write-ahead recovery indexes (issue #3400) =====
     # Persist the candidate superset BEFORE any graph/vector/tracking
@@ -3320,7 +3324,7 @@ async def merge_nodes_and_edges(
         logger.info(log_message)
         async with pipeline_status_lock:
             pipeline_status["latest_message"] = log_message
-            pipeline_status["history_messages"].append(log_message)
+            append_pipeline_history(pipeline_status, log_message)
 
         await full_entities_storage.upsert(
             {
@@ -3361,7 +3365,7 @@ async def merge_nodes_and_edges(
     logger.info(log_message)
     async with pipeline_status_lock:
         pipeline_status["latest_message"] = log_message
-        pipeline_status["history_messages"].append(log_message)
+        append_pipeline_history(pipeline_status, log_message)
 
     async def _locked_process_entity_name(entity_name, entities):
         async with semaphore:
@@ -3407,7 +3411,7 @@ async def merge_nodes_and_edges(
                         ):
                             async with pipeline_status_lock:
                                 pipeline_status["latest_message"] = error_msg
-                                pipeline_status["history_messages"].append(error_msg)
+                                append_pipeline_history(pipeline_status, error_msg)
                     except Exception as status_error:
                         logger.error(
                             f"Failed to update pipeline status: {status_error}"
@@ -3441,7 +3445,7 @@ async def merge_nodes_and_edges(
     logger.info(log_message)
     async with pipeline_status_lock:
         pipeline_status["latest_message"] = log_message
-        pipeline_status["history_messages"].append(log_message)
+        append_pipeline_history(pipeline_status, log_message)
 
     async def _locked_process_edges(edge_key, edges):
         async with semaphore:
@@ -3500,7 +3504,7 @@ async def merge_nodes_and_edges(
                         ):
                             async with pipeline_status_lock:
                                 pipeline_status["latest_message"] = error_msg
-                                pipeline_status["history_messages"].append(error_msg)
+                                append_pipeline_history(pipeline_status, error_msg)
                     except Exception as status_error:
                         logger.error(
                             f"Failed to update pipeline status: {status_error}"
@@ -3553,7 +3557,7 @@ async def merge_nodes_and_edges(
     logger.info(log_message)
     async with pipeline_status_lock:
         pipeline_status["latest_message"] = log_message
-        pipeline_status["history_messages"].append(log_message)
+        append_pipeline_history(pipeline_status, log_message)
 
 
 async def extract_entities(

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -67,6 +67,7 @@ from lightrag.kg.shared_storage import (
     run_to_completion,
     with_reservation_lock,
 )
+from lightrag import pipeline_metrics
 from lightrag.kg.pipeline_ingress import PipelineIngressMessage
 from lightrag.operate import merge_nodes_and_edges
 from lightrag.parser.base import ParseContext
@@ -287,6 +288,18 @@ def _call_source_file_resolver(
             parser_engine=parser_engine,
         )
     return resolver(source_file or file_path)
+
+
+def _rearm_auto_rescan(ingress: Any) -> None:
+    """Set the auto-rescan dirty flag and count the re-arm (LR2 Phase 6 item 3).
+
+    Every re-arm costs a later strict sweep, so the rate explains sweep load that
+    no upload accounts for. Counted here rather than inside the ingress because in
+    multiprocess mode the mailbox lives in the Manager process, where a counter
+    would be invisible to the worker answering /health.
+    """
+    ingress.request_auto_rescan()
+    pipeline_metrics.increment(pipeline_metrics.AUTO_RESCAN_REARMS)
 
 
 def _normalize_scheduling_timestamp(value: Any) -> str:
@@ -1357,7 +1370,7 @@ class _PipelineMixin:
                         # the enqueue re-raises the storage error either way.
                         if not pipeline_status.get("busy"):
                             process_after_status_error = True
-                        ingress.request_auto_rescan()
+                        _rearm_auto_rescan(ingress)
                 except Exception as wake_error:
                     logger.error(
                         "Failed to wake document processing after enqueue "
@@ -1423,7 +1436,7 @@ class _PipelineMixin:
                 )
             except Exception as publish_error:
                 try:
-                    ingress.request_auto_rescan()
+                    _rearm_auto_rescan(ingress)
                     logger.warning(
                         "Ingress document notification failed after a "
                         "successful enqueue; armed the auto-rescan flag "
@@ -1966,7 +1979,7 @@ class _PipelineMixin:
                     # degrades to next-explicit-trigger recovery.
                     if uncommitted_wakeup and ingress is not None:
                         try:
-                            ingress.request_auto_rescan()
+                            _rearm_auto_rescan(ingress)
                         except Exception as restore_error:
                             logger.error(
                                 "[pipeline] failed to restore the consumed "
@@ -2355,7 +2368,7 @@ class _PipelineMixin:
                                 # Arm the recovery signal so the skip is picked up
                                 # by the supervisor's next rescan even if this
                                 # feeder never otherwise reaches a boundary.
-                                ingress.request_auto_rescan()
+                                _rearm_auto_rescan(ingress)
                     reached = len(batch)  # every message reached a decision
                 except asyncio.CancelledError:
                     deferred.extend(batch[reached:])  # unprocessed tail → finally
@@ -3095,6 +3108,14 @@ class _PipelineMixin:
         so no double reset — LR2 §7.3 "为什么不需要 generation/checkpoint")."""
 
         def _enter(status):
+            # The freeze timestamp is wall clock because the freeze may have been
+            # taken by another process; this is the DRAIN_TO_IDLE window — the one
+            # an operator feels, since uploads are refused throughout it.
+            froze_at = status.get("manual_freeze_started_at")
+            if isinstance(froze_at, (int, float)) and froze_at > 0:
+                pipeline_metrics.observe(
+                    pipeline_metrics.MANUAL_DRAIN_SECONDS, time.time() - float(froze_at)
+                )
             status.update(
                 {
                     "manual_resetting": True,
@@ -3113,6 +3134,8 @@ class _PipelineMixin:
             return False
 
         total_reset = 0
+        pages = 0
+        reset_started = time.monotonic()
         cursor: CursorPosition = CURSOR_START
         while True:
             if not await self._still_freeze_owner(
@@ -3120,12 +3143,21 @@ class _PipelineMixin:
             ):
                 return False
             docs, cursor = await self._next_failed_page(cursor)
+            pages += 1
             if docs:
                 total_reset += await self._reset_failed_page(
                     docs, token, pipeline_status, pipeline_status_lock
                 )
             if cursor is CURSOR_END:
                 break
+
+        # The reset runs with no worker, so its duration is exactly how long the
+        # pipeline was held idle on purpose (LR2 Phase 6 item 3).
+        pipeline_metrics.observe(
+            pipeline_metrics.MANUAL_RESET_SECONDS, time.monotonic() - reset_started
+        )
+        pipeline_metrics.increment(pipeline_metrics.MANUAL_RESET_PAGES, pages)
+        pipeline_metrics.increment(pipeline_metrics.MANUAL_RESET_DOCS, total_reset)
 
         reset_message = (
             f"Manual retry {request_id[:8]}: reset {total_reset} FAILED "
@@ -3333,11 +3365,18 @@ class _PipelineMixin:
             )
             return docs, CURSOR_END
 
+        page_started = time.monotonic()
         page = await self.doc_status.get_docs_by_statuses_page(
             list(statuses),
             limit=page_size,
             position=position,
             strict=True,
+        )
+        # Timed around the keyset query alone (not the hydration below): a slow
+        # page here means the backend's (created_at, id) index, and that is the
+        # one thing the bounded sweep cannot work around.
+        pipeline_metrics.observe(
+            pipeline_metrics.SCHEDULING_PAGE_SECONDS, time.monotonic() - page_started
         )
         if not page.docs:
             # A fully-filtered page is not termination — the cursor still
@@ -3524,7 +3563,7 @@ class _PipelineMixin:
                 )
             except BaseException:
                 try:
-                    ingress.request_auto_rescan()
+                    _rearm_auto_rescan(ingress)
                 except BaseException as compensation_error:
                     logger.warning(
                         "[pipeline] failed to arm auto-rescan after a paged "
@@ -3584,12 +3623,12 @@ class _PipelineMixin:
             # is cleared by the run's finally), so it needs no re-arm.
             try:
                 if step is PipelineNextStep.CONTINUE_AUTO:
-                    ingress.request_auto_rescan()
+                    _rearm_auto_rescan(ingress)
                 elif drained:
                     self._republish_documents(ingress, drained, source="quiescence")
                     # Backstop for re-publishes swallowed above: the strict
                     # rescan behind the flag recovers those PENDING docs.
-                    ingress.request_auto_rescan()
+                    _rearm_auto_rescan(ingress)
             except BaseException as compensation_error:
                 logger.warning(
                     "[pipeline] failed to restore the consumed wake-up signal "

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1997,6 +1997,7 @@ class _PipelineMixin:
                                 "busy": False,
                                 "busy_owner": None,
                                 "manual_freeze_requested": False,
+                                "manual_freeze_started_at": None,
                                 "manual_resetting": False,
                                 "manual_phase": MANUAL_PHASE_IDLE,
                                 "manual_owner": None,
@@ -2866,6 +2867,7 @@ class _PipelineMixin:
             status.update(
                 {
                     "manual_freeze_requested": True,
+                    "manual_freeze_started_at": time.time(),
                     "manual_resetting": False,
                     "manual_phase": MANUAL_PHASE_DRAIN_TO_IDLE,
                     "manual_owner": owner,
@@ -2901,6 +2903,7 @@ class _PipelineMixin:
             status.update(
                 {
                     "manual_freeze_requested": False,
+                    "manual_freeze_started_at": None,
                     "manual_resetting": False,
                     "manual_phase": MANUAL_PHASE_IDLE,
                     "manual_owner": None,
@@ -3281,6 +3284,7 @@ class _PipelineMixin:
                                 "busy": False,
                                 "busy_owner": None,
                                 "manual_freeze_requested": False,
+                                "manual_freeze_started_at": None,
                                 "manual_resetting": False,
                                 "manual_phase": MANUAL_PHASE_IDLE,
                                 "manual_owner": None,

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -58,6 +58,7 @@ from lightrag.kg.shared_storage import (
     PipelineReservationConflict,
     _reservation_owner_token,
     acquire_processing_reservation,
+    append_pipeline_history,
     check_pipeline_status_mutation,
     get_namespace_data,
     get_namespace_lock,
@@ -1783,7 +1784,7 @@ class _PipelineMixin:
                                 "latest_message": log_message,
                             }
                         )
-                        status_snapshot["history_messages"].append(log_message)
+                        append_pipeline_history(status_snapshot, log_message)
 
                         # A signal consumed by the immediately-preceding
                         # decision (or the entry absorb) that no batch took
@@ -1800,7 +1801,7 @@ class _PipelineMixin:
                     log_message = "All enqueued documents have been processed"
                     logger.info(log_message)
                     pipeline_status["latest_message"] = log_message
-                    pipeline_status["history_messages"].append(log_message)
+                    append_pipeline_history(pipeline_status, log_message)
                     decision = await self._decide_pipeline_next_step(
                         pipeline_status, pipeline_status_lock, ingress, sweep_cursor
                     )
@@ -1850,7 +1851,7 @@ class _PipelineMixin:
                     )
                     logger.info(log_message)
                     pipeline_status["latest_message"] = log_message
-                    pipeline_status["history_messages"].append(log_message)
+                    append_pipeline_history(pipeline_status, log_message)
                     decision = await self._decide_pipeline_next_step(
                         pipeline_status, pipeline_status_lock, ingress, sweep_cursor
                     )
@@ -1890,7 +1891,7 @@ class _PipelineMixin:
                         "latest_message": log_message,
                     }
                 )
-                pipeline_status["history_messages"].append(log_message)
+                append_pipeline_history(pipeline_status, log_message)
 
                 await self._run_pipeline_batch(
                     to_process_docs,
@@ -1929,7 +1930,7 @@ class _PipelineMixin:
                 log_message = "Processing additional documents due to pending request"
                 logger.info(log_message)
                 pipeline_status["latest_message"] = log_message
-                pipeline_status["history_messages"].append(log_message)
+                append_pipeline_history(pipeline_status, log_message)
 
                 # Fetch the next batch: the next page of the current sweep
                 # (CONTINUE_SWEEP_PAGE), a manual reset/drain (CONTINUE_MANUAL /
@@ -2061,9 +2062,9 @@ class _PipelineMixin:
                         }
                     )
                     status.update(updates)
-                    status_snapshot["history_messages"].append(stopped_message)
+                    append_pipeline_history(status_snapshot, stopped_message)
                     if internal_halt is not None:
-                        status_snapshot["history_messages"].append(internal_halt)
+                        append_pipeline_history(status_snapshot, internal_halt)
 
             await run_to_completion(_finalize)
 
@@ -2695,7 +2696,7 @@ class _PipelineMixin:
                 )
                 logger.info(skip_message)
                 pipeline_status["latest_message"] = skip_message
-                pipeline_status["history_messages"].append(skip_message)
+                append_pipeline_history(pipeline_status, skip_message)
 
         inconsistent_docs = []
         failed_docs_to_preserve = []
@@ -2721,7 +2722,7 @@ class _PipelineMixin:
                 preserve_message = f"Preserving {len(failed_docs_to_preserve)} failed document entries for manual review"
                 logger.info(preserve_message)
                 pipeline_status["latest_message"] = preserve_message
-                pipeline_status["history_messages"].append(preserve_message)
+                append_pipeline_history(pipeline_status, preserve_message)
 
             # Remove failed documents from processing list but keep them in doc_status
             for doc_id in failed_docs_to_preserve:
@@ -2735,7 +2736,7 @@ class _PipelineMixin:
                 )
                 logger.info(summary_message)
                 pipeline_status["latest_message"] = summary_message
-                pipeline_status["history_messages"].append(summary_message)
+                append_pipeline_history(pipeline_status, summary_message)
 
             successful_deletions = 0
             for doc_id in inconsistent_docs:
@@ -2754,7 +2755,7 @@ class _PipelineMixin:
                         )
                         logger.info(log_message)
                         pipeline_status["latest_message"] = log_message
-                        pipeline_status["history_messages"].append(log_message)
+                        append_pipeline_history(pipeline_status, log_message)
 
                     # Remove from processing list
                     to_process_docs.pop(doc_id, None)
@@ -2765,7 +2766,7 @@ class _PipelineMixin:
                         error_message = f"Failed to delete entry: {doc_id} - {str(e)}"
                         logger.error(error_message)
                         pipeline_status["latest_message"] = error_message
-                        pipeline_status["history_messages"].append(error_message)
+                        append_pipeline_history(pipeline_status, error_message)
 
         # Final summary log
         # async with pipeline_status_lock:
@@ -2849,7 +2850,7 @@ class _PipelineMixin:
                 )
                 logger.info(reset_message)
                 pipeline_status["latest_message"] = reset_message
-                pipeline_status["history_messages"].append(reset_message)
+                append_pipeline_history(pipeline_status, reset_message)
 
         return to_process_docs
 
@@ -3166,7 +3167,7 @@ class _PipelineMixin:
         logger.info(reset_message)
         async with pipeline_status_lock:
             pipeline_status["latest_message"] = reset_message
-            pipeline_status["history_messages"].append(reset_message)
+            append_pipeline_history(pipeline_status, reset_message)
         return True
 
     async def _confirm_scan_drain_idle(
@@ -3793,7 +3794,7 @@ class _PipelineMixin:
                     log_message = f"Parsing ({engine}): {doc_id_w}"
                     logger.info(log_message)
                     ctx.pipeline_status["latest_message"] = log_message
-                    ctx.pipeline_status["history_messages"].append(log_message)
+                    append_pipeline_history(ctx.pipeline_status, log_message)
                 # Resolve the actual parser per-doc from the batch snapshot
                 # (snapshot-consistent: a mid-batch register_parser cannot be
                 # picked up here). ``engine`` is only the queue-group/pool id.
@@ -4331,18 +4332,14 @@ class _PipelineMixin:
                             "latest_message": processing_message,
                         }
                     )
-                    ctx.pipeline_status["history_messages"].append(extraction_message)
-                    ctx.pipeline_status["history_messages"].append(processing_message)
-
-                    # Prevent memory growth: keep only latest 5000 messages
-                    # when exceeding 10000.  Trim in place so Manager.list-
-                    # backed shared state remains appendable and visible
-                    # across processes.
-                    if len(ctx.pipeline_status["history_messages"]) > 10000:
-                        logger.info(
-                            f"Trimming pipeline history from {len(ctx.pipeline_status['history_messages'])} to 5000 messages"
-                        )
-                        del ctx.pipeline_status["history_messages"][:-5000]
+                    # One call: the pair belongs together in the log, and the
+                    # ring capacity that used to be enforced right here now
+                    # lives in the funnel — this loop was never the only writer
+                    # (deletes, scans and manual resets log plenty without ever
+                    # reaching it), so trimming here bounded nothing.
+                    append_pipeline_history(
+                        ctx.pipeline_status, extraction_message, processing_message
+                    )
 
                 # The parsed body is no longer carried through q_analyze /
                 # q_process (it would pin large documents in memory). Re-read it
@@ -4871,7 +4868,7 @@ class _PipelineMixin:
                         )
                         logger.info(log_message)
                         ctx.pipeline_status["latest_message"] = log_message
-                        ctx.pipeline_status["history_messages"].append(log_message)
+                        append_pipeline_history(ctx.pipeline_status, log_message)
 
                 except Exception as e:
                     # A storage flush failure (raised by _insert_done) is not
@@ -4968,7 +4965,7 @@ class _PipelineMixin:
             logger.warning(log_message)
             async with pipeline_status_lock:
                 pipeline_status["latest_message"] = log_message
-                pipeline_status["history_messages"].append(log_message)
+                append_pipeline_history(pipeline_status, log_message)
 
         # Order-preserving dedup; keep a list so it satisfies the storage delete
         # contract (``delete(ids: list[str])``) when passed down to purge.
@@ -4992,7 +4989,7 @@ class _PipelineMixin:
         logger.info(log_message)
         async with pipeline_status_lock:
             pipeline_status["latest_message"] = log_message
-            pipeline_status["history_messages"].append(log_message)
+            append_pipeline_history(pipeline_status, log_message)
         await self._purge_doc_chunks_and_kg(
             doc_id,
             stored_chunk_ids,
@@ -5165,7 +5162,7 @@ class _PipelineMixin:
         logger.warning(error_msg)
         async with pipeline_status_lock:
             pipeline_status["latest_message"] = error_msg
-            pipeline_status["history_messages"].append(error_msg)
+            append_pipeline_history(pipeline_status, error_msg)
         await self._persist_llm_response_cache_best_effort(
             stage_label=f"{stage_label} cancellation",
             doc_id=doc_id,
@@ -5232,7 +5229,7 @@ class _PipelineMixin:
             logger.warning(error_msg)
             async with pipeline_status_lock:
                 pipeline_status["latest_message"] = error_msg
-                pipeline_status["history_messages"].append(error_msg)
+                append_pipeline_history(pipeline_status, error_msg)
         else:
             doc_error_msg = str(error)
             logger.error(traceback.format_exc())
@@ -5249,8 +5246,8 @@ class _PipelineMixin:
             logger.error(error_msg)
             async with pipeline_status_lock:
                 pipeline_status["latest_message"] = error_msg
-                pipeline_status["history_messages"].append(traceback.format_exc())
-                pipeline_status["history_messages"].append(error_msg)
+                append_pipeline_history(pipeline_status, traceback.format_exc())
+                append_pipeline_history(pipeline_status, error_msg)
 
         for task in pending_tasks:
             if task and not task.done():
@@ -5433,7 +5430,7 @@ class _PipelineMixin:
         if pipeline_status is not None and pipeline_status_lock is not None:
             async with pipeline_status_lock:
                 pipeline_status["latest_message"] = warning
-                pipeline_status["history_messages"].append(warning)
+                append_pipeline_history(pipeline_status, warning)
         return True
 
     def _resolve_source_file_for_parser(
@@ -6344,7 +6341,7 @@ class _PipelineMixin:
                     if pipeline_status is not None and pipeline_status_lock is not None:
                         async with pipeline_status_lock:
                             pipeline_status["latest_message"] = log_message
-                            pipeline_status["history_messages"].append(log_message)
+                            append_pipeline_history(pipeline_status, log_message)
                     raise
                 result_obj = result[0] if isinstance(result, tuple) else {}
                 is_success = (
@@ -6357,7 +6354,7 @@ class _PipelineMixin:
                     if pipeline_status is not None and pipeline_status_lock is not None:
                         async with pipeline_status_lock:
                             pipeline_status["latest_message"] = log_message
-                            pipeline_status["history_messages"].append(log_message)
+                            append_pipeline_history(pipeline_status, log_message)
                 else:
                     logger.debug(f"Analyzing  {kind}/{item_id}: skipped")
                 return result
@@ -6409,7 +6406,7 @@ class _PipelineMixin:
                         log_message = f"Analyzing multimodal: {doc_id}"
                         logger.info(log_message)
                         pipeline_status["latest_message"] = log_message
-                        pipeline_status["history_messages"].append(log_message)
+                        append_pipeline_history(pipeline_status, log_message)
                     start_logged = True
 
                 # Pre-schedule cancellation check: if the user cancelled

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -3071,7 +3071,7 @@ class _PipelineMixin:
             logger.warning(warning)
             async with pipeline_status_lock:
                 pipeline_status["latest_message"] = warning
-                pipeline_status["history_messages"].append(warning)
+                append_pipeline_history(pipeline_status, warning)
         if not docs_to_reset:
             return 0
         # Owner-checked page write (LR2 §7.7 item 8): confirm we still hold the

--- a/lightrag/pipeline_metrics.py
+++ b/lightrag/pipeline_metrics.py
@@ -1,0 +1,153 @@
+"""Bounded in-process metrics for the scheduling paths (LR2 Phase 6, item 3).
+
+The bounded-memory rework moved several decisions off the happy path — a paged
+sweep, a strict active count per admission, a drain-then-reset freeze — and each
+one can be slow or noisy without anything visible going wrong. These counters and
+duration summaries are the only way to tell "the sweep is paging" from "the sweep
+is thrashing", or "a freeze is normal" from "a freeze is stuck".
+
+Design constraints that shaped this module:
+
+* **Fixed key set.** Every metric name is declared below. An unknown name is
+  logged once and dropped rather than inserted — a metrics registry that grows
+  with cardinality is exactly the unbounded structure this whole plan exists to
+  remove.
+* **O(1) per metric.** Durations keep count / total / max / last, not samples.
+  There are no percentiles: a ring of samples would be a per-metric bound to
+  pick, defend and test, and the questions above are answered by max plus mean.
+* **In-process, per worker.** Incrementing a shared (Manager-hosted) counter
+  would add an RPC to paths taken thousands of times per sweep, which is the cost
+  the scheduling rework was built to avoid. Under gunicorn with N workers
+  ``/health`` therefore reports the numbers of the worker that answered — the
+  same documented boundary as the login rate limiter and the keyed-lock table.
+  The pipeline supervisor is single-owner (whoever holds ``busy``), so its
+  measurements are not spread across workers in the first place.
+* **Never fatal.** A metrics failure must not fail the operation it measures;
+  every entry point swallows its own errors.
+
+Deliberately NOT duplicated here: scan classification counts, source-conflict
+sightings and abandoned scan jobs. Those already have a bounded, per-job surface
+in the scan job record (``GET /documents/scan/status/{track_id}``) — counting
+them twice would invite the two numbers to disagree.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Dict
+
+from lightrag.utils import logger
+
+# --- counters -------------------------------------------------------------
+# Ingress refused because a manual retry froze new work (LR2 §6.1/§7.2). A
+# handful during a reset is normal; a steadily climbing number means clients are
+# retrying into a freeze that is not ending.
+FREEZE_REJECTS = "freeze_rejects"
+# Auto-rescan dirty flag re-armed: a processing request that could not name doc
+# ids (busy-refused, partial commit, recovery). Each one costs a later strict
+# sweep, so a high rate explains sweep load that no upload seems to account for.
+AUTO_RESCAN_REARMS = "auto_rescan_rearms"
+# Documents moved FAILED→PENDING by an exclusive reset, and the pages it took.
+MANUAL_RESET_DOCS = "manual_reset_docs"
+MANUAL_RESET_PAGES = "manual_reset_pages"
+
+_COUNTERS: tuple[str, ...] = (
+    FREEZE_REJECTS,
+    AUTO_RESCAN_REARMS,
+    MANUAL_RESET_DOCS,
+    MANUAL_RESET_PAGES,
+)
+
+# --- duration summaries ---------------------------------------------------
+# One keyset page of the doc_status sweep (query + projection).
+SCHEDULING_PAGE_SECONDS = "scheduling_page_seconds"
+# One strict active-document count, taken per admission decision.
+ACTIVE_COUNT_SECONDS = "active_count_seconds"
+# DRAIN_TO_IDLE: from freezing ingress to confirmed quiescence. This is the
+# window during which uploads are refused, so it is the one an operator feels.
+MANUAL_DRAIN_SECONDS = "manual_drain_seconds"
+# EXCLUSIVE_RESET: the paged FAILED→PENDING rewrite, with no worker running.
+MANUAL_RESET_SECONDS = "manual_reset_seconds"
+
+_DURATIONS: tuple[str, ...] = (
+    SCHEDULING_PAGE_SECONDS,
+    ACTIVE_COUNT_SECONDS,
+    MANUAL_DRAIN_SECONDS,
+    MANUAL_RESET_SECONDS,
+)
+
+_lock = threading.Lock()
+_counters: Dict[str, int] = {name: 0 for name in _COUNTERS}
+_durations: Dict[str, Dict[str, float]] = {
+    name: {"count": 0, "total_seconds": 0.0, "max_seconds": 0.0, "last_seconds": 0.0}
+    for name in _DURATIONS
+}
+
+
+def increment(name: str, amount: int = 1) -> None:
+    """Add to a declared counter; unknown names are dropped, never inserted."""
+    try:
+        if name not in _counters:
+            logger.warning(f"Ignoring unknown pipeline metric counter {name!r}")
+            return
+        if amount <= 0:
+            return
+        with _lock:
+            _counters[name] += amount
+    except Exception as metric_error:  # pragma: no cover - defensive
+        logger.debug(f"pipeline metric {name!r} not recorded: {metric_error}")
+
+
+def observe(name: str, seconds: float) -> None:
+    """Record one duration sample into a declared summary."""
+    try:
+        if name not in _durations:
+            logger.warning(f"Ignoring unknown pipeline metric duration {name!r}")
+            return
+        value = max(0.0, float(seconds))
+        with _lock:
+            summary = _durations[name]
+            summary["count"] += 1
+            summary["total_seconds"] += value
+            summary["last_seconds"] = value
+            if value > summary["max_seconds"]:
+                summary["max_seconds"] = value
+    except Exception as metric_error:  # pragma: no cover - defensive
+        logger.debug(f"pipeline metric {name!r} not recorded: {metric_error}")
+
+
+def snapshot() -> Dict[str, Any]:
+    """Current values, rounded for display. Bounded by the declared key set."""
+    with _lock:
+        counters = dict(_counters)
+        durations = {
+            name: {
+                "count": int(summary["count"]),
+                "total_seconds": round(summary["total_seconds"], 4),
+                "max_seconds": round(summary["max_seconds"], 4),
+                "last_seconds": round(summary["last_seconds"], 4),
+                "mean_seconds": (
+                    round(summary["total_seconds"] / summary["count"], 4)
+                    if summary["count"]
+                    else 0.0
+                ),
+            }
+            for name, summary in _durations.items()
+        }
+    return {"counters": counters, "durations": durations}
+
+
+def reset() -> None:
+    """Zero everything (tests only; there is no runtime reset endpoint)."""
+    with _lock:
+        for name in _counters:
+            _counters[name] = 0
+        for summary in _durations.values():
+            summary.update(
+                {
+                    "count": 0,
+                    "total_seconds": 0.0,
+                    "max_seconds": 0.0,
+                    "last_seconds": 0.0,
+                }
+            )

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -549,6 +549,48 @@ ADMISSION_ACTIVE_STATUSES: tuple[DocStatus, ...] = (
 )
 
 
+def _overrides_base(doc_status: Any, method_name: str) -> bool:
+    """Whether this backend replaced ``DocStatusStorage``'s fail-closed default."""
+    base = getattr(DocStatusStorage, method_name, None)
+    implementation = getattr(type(doc_status), method_name, None)
+    return implementation is not None and implementation is not base
+
+
+def describe_doc_status_capabilities(doc_status: Any) -> dict[str, bool]:
+    """Report which strict capabilities this doc_status backend actually has.
+
+    The scheduling contract fails CLOSED on a missing capability: admission
+    refuses with 503, a stale FAILED stub is kept instead of deleted, source
+    conflicts cannot be listed. Each of those is a silent, confusing degradation
+    from the outside — an operator staring at 503s needs to be told that the
+    configured backend simply cannot count, not to go hunting for a database
+    problem (LR2 Phase 6 item 2).
+
+    Probes the class rather than calling anything: /health must stay cheap and
+    side-effect free.
+    """
+    return {
+        # Bounded keyset paging + typed source resolution are @abstractmethod on
+        # DocStatusStorage, so a first-party backend always has them; a
+        # third-party subclass that stubs them out shows up here as False.
+        "scheduling_pages": _overrides_base(doc_status, "get_docs_by_statuses_page"),
+        "typed_source_resolution": _overrides_base(
+            doc_status, "resolve_doc_source_strict"
+        ),
+        # Base defaults raise StorageCapabilityError — these three are the ones a
+        # deployment can genuinely lack.
+        "strict_active_count": _overrides_base(doc_status, "count_docs_by_statuses"),
+        "source_conflict_listing": _overrides_base(
+            doc_status, "list_source_conflicts_page"
+        ),
+        "source_conflict_repair": _overrides_base(doc_status, "repair_source_conflict"),
+        # Class-level opt-in: gates the STALE_STUB deletion during a scan.
+        "strict_point_reads": bool(
+            getattr(type(doc_status), "supports_strict_point_reads", False)
+        ),
+    }
+
+
 async def count_active_documents(doc_status: DocStatusStorage) -> int:
     """Strictly count the documents that occupy admission capacity.
 

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -34,6 +34,7 @@ from lightrag.constants import (
     PARSER_ENGINE_LEGACY,
     PARSER_ENGINE_NATIVE,
 )
+from lightrag import pipeline_metrics
 from lightrag.parser.routing import canonicalize_parser_hinted_basename
 from lightrag.utils import (
     compute_mdhash_id,
@@ -603,9 +604,17 @@ async def count_active_documents(doc_status: DocStatusStorage) -> int:
     on failure, and this helper does not soften that — a caller that cannot
     learn the count must refuse the request (503), never assume there is room.
     """
-    return await doc_status.count_docs_by_statuses(
-        list(ADMISSION_ACTIVE_STATUSES), strict=True
-    )
+    started = time.monotonic()
+    try:
+        return await doc_status.count_docs_by_statuses(
+            list(ADMISSION_ACTIVE_STATUSES), strict=True
+        )
+    finally:
+        # Recorded even on failure: a count that times out is exactly the case an
+        # operator needs to see when uploads start answering 503.
+        pipeline_metrics.observe(
+            pipeline_metrics.ACTIVE_COUNT_SECONDS, time.monotonic() - started
+        )
 
 
 # Sidecar item ids embed ``doc_hash`` (= doc_id without the ``doc-`` prefix),

--- a/tests/api/config/test_api_config_admission.py
+++ b/tests/api/config/test_api_config_admission.py
@@ -12,7 +12,10 @@ from lightrag.api.config import (
     parse_args,
     validate_admission_configuration,
 )
-from lightrag.constants import DEFAULT_MAX_PENDING_DOCUMENTS
+from lightrag.constants import (
+    DEFAULT_MAX_PENDING_DOCUMENTS,
+    DEFAULT_MAX_TEXTS_PER_REQUEST,
+)
 
 pytestmark = pytest.mark.offline
 
@@ -104,5 +107,37 @@ def test_negative_body_limit_fails_fast(monkeypatch):
 
 def test_body_limit_absent_from_a_partial_namespace_is_fine():
     """Validated independently of the capacity: a namespace carrying only one of
-    the two knobs must still pass."""
+    the knobs must still pass."""
     validate_admission_configuration(Namespace(max_pending_documents=5))
+
+
+# --------------------------------------------------------------------------- #
+# MAX_TEXTS_PER_REQUEST (LR2 §11)
+# --------------------------------------------------------------------------- #
+
+
+def _parse_texts_limit(monkeypatch, value: str | None):
+    monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+    if value is None:
+        monkeypatch.delenv("MAX_TEXTS_PER_REQUEST", raising=False)
+    else:
+        monkeypatch.setenv("MAX_TEXTS_PER_REQUEST", value)
+    return parse_args()
+
+
+def test_texts_limit_disabled_by_default(monkeypatch):
+    args = _parse_texts_limit(monkeypatch, None)
+    assert args.max_texts_per_request == DEFAULT_MAX_TEXTS_PER_REQUEST == 0
+    validate_admission_configuration(args)
+
+
+def test_texts_limit_env_value_is_honoured(monkeypatch):
+    args = _parse_texts_limit(monkeypatch, "50")
+    assert args.max_texts_per_request == 50
+    validate_admission_configuration(args)
+
+
+def test_negative_texts_limit_fails_fast(monkeypatch):
+    args = _parse_texts_limit(monkeypatch, "-1")
+    with pytest.raises(ValueError, match="MAX_TEXTS_PER_REQUEST"):
+        validate_admission_configuration(args)

--- a/tests/api/routes/test_clear_documents_ingress.py
+++ b/tests/api/routes/test_clear_documents_ingress.py
@@ -18,7 +18,10 @@ sys.argv = [sys.argv[0]]
 _document_routes = importlib.import_module("lightrag.api.routers.document_routes")
 sys.argv = _original_argv
 
-from lightrag.kg.pipeline_ingress import PipelineIngressMessage  # noqa: E402
+from lightrag.kg.pipeline_ingress import (  # noqa: E402
+    ManualRetryPublishResult,
+    PipelineIngressMessage,
+)
 from lightrag.kg.scan_job_store import ScanJobStatus  # noqa: E402
 from lightrag.kg.shared_storage import get_pipeline_ingress  # noqa: E402
 
@@ -76,7 +79,10 @@ async def test_clear_documents_clears_ingress_and_refuses_replay(tmp_path):
     manual_msg = PipelineIngressMessage(
         kind="rescan", retry_failed=True, request_id="req-cleared"
     )
-    assert ingress.request_manual_retry("req-cleared", manual_msg) is True
+    assert (
+        ingress.request_manual_retry("req-cleared", manual_msg)
+        is ManualRetryPublishResult.ACCEPTED
+    )
 
     rag = _ClearRag(workspace)
     router = create_document_routes(rag, DocumentManager(str(tmp_path)))
@@ -97,7 +103,10 @@ async def test_clear_documents_clears_ingress_and_refuses_replay(tmp_path):
 
     # CANCELLED_BY_CLEAR is terminal: a delayed replay of the same id must be
     # refused instead of re-entering the now-empty workspace.
-    assert ingress.request_manual_retry("req-cleared", manual_msg) is False
+    assert (
+        ingress.request_manual_retry("req-cleared", manual_msg)
+        is ManualRetryPublishResult.ALREADY_TERMINAL
+    )
     assert ingress.snapshot_manual_retries() == []
 
     pipeline_status = await shared_storage.get_namespace_data(

--- a/tests/api/routes/test_scan_manual_retry.py
+++ b/tests/api/routes/test_scan_manual_retry.py
@@ -26,7 +26,10 @@ sys.argv = _original_argv
 
 from lightrag import LightRAG  # noqa: E402
 from lightrag.base import DocStatus  # noqa: E402
-from lightrag.kg.pipeline_ingress import PipelineIngressMessage  # noqa: E402
+from lightrag.kg.pipeline_ingress import (  # noqa: E402
+    ManualRetryPublishResult,
+    PipelineIngressMessage,
+)
 from lightrag.kg.shared_storage import (  # noqa: E402
     MANUAL_PHASE_IDLE,
     acquire_reservation,
@@ -486,6 +489,51 @@ def test_scan_endpoint_refused_while_earlier_manual_request_queued(tmp_path):
             assert [m.request_id for m in ingress.snapshot_manual_retries()] == [
                 request_id
             ]  # untouched: the earlier request keeps its place
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_scan_refuses_when_the_manual_channel_is_full(tmp_path, monkeypatch):
+    """LR2 §10.1: a scan whose retry intent cannot be published must not start —
+    its exclusive FAILED reset would never be acknowledged. Capacity is the one
+    publish refusal worth retrying unchanged (429), and the reservation plus the
+    job record are compensated because nothing was handed off."""
+
+    async def _run():
+        extract = _FlippableExtract()
+        rag = await _build_rag(tmp_path, extract)
+        try:
+            await initialize_pipeline_status(workspace=rag.workspace)
+            ingress = await get_pipeline_ingress(rag.workspace)
+            monkeypatch.setattr(
+                ingress,
+                "request_manual_retry",
+                lambda *args, **kwargs: ManualRetryPublishResult.CAPACITY_EXCEEDED,
+            )
+
+            doc_manager = DocumentManager(str(tmp_path / "inputs"))
+            router = _document_routes.create_document_routes(rag, doc_manager)
+            scan_endpoint = [
+                route.endpoint
+                for route in router.routes
+                if getattr(route, "name", "") == "scan_for_new_documents"
+            ][-1]
+
+            with pytest.raises(_document_routes.HTTPException) as excinfo:
+                await scan_endpoint(set())
+
+            assert excinfo.value.status_code == 429
+            assert excinfo.value.headers["Retry-After"]
+
+            # Nothing owned: the scan reservation was released again.
+            pipeline_status = await get_namespace_data(
+                "pipeline_status", workspace=rag.workspace
+            )
+            assert pipeline_status["scanning"] is False
+            assert pipeline_status["scanning_exclusive"] is False
+            assert pipeline_status["busy"] is False
         finally:
             await rag.finalize_storages()
 

--- a/tests/api/routes/test_texts_per_request_limit.py
+++ b/tests/api/routes/test_texts_per_request_limit.py
@@ -1,0 +1,137 @@
+"""``MAX_TEXTS_PER_REQUEST``: the per-request document fan-out ceiling (LR2 §11).
+
+Distinct from the other two ingestion limits, and the tests below pin what makes
+it distinct:
+
+* **413, not 429.** ``MAX_PENDING_DOCUMENTS`` means "the pipeline is full, retry
+  later"; a batch carrying more documents than one request may carry will never
+  fit, so telling the client to wait would be a lie.
+* **Checked before any per-text work.** The endpoint does one storage lookup per
+  ``file_source`` to detect same-name conflicts, so a refusal placed after that
+  loop would let a 100k-text batch do 100k round-trips on its way to being
+  rejected — which is the cost the limit exists to prevent, not merely the row
+  count it caps.
+* **A malformed knob disables the check.** Refusing every batch because a value
+  is unparseable is worse than not enforcing it; ``initialize_config`` is where a
+  bad value is supposed to stop the server.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+_original_argv = sys.argv[:]
+sys.argv = [sys.argv[0]]
+_dr = importlib.import_module("lightrag.api.routers.document_routes")
+sys.argv = _original_argv
+
+pytestmark = pytest.mark.offline
+
+_HEADERS = {"X-API-Key": "test-key"}
+
+
+class _Rag:
+    workspace = "texts-limit-test"
+    addon_params: dict = {}
+    doc_status = SimpleNamespace()
+
+
+def _make_client(monkeypatch, limit):
+    """A client whose reservation and indexing are no-ops, and whose per-text
+    existence lookup is counted so the ordering claim is testable."""
+    calls = {"lookups": 0, "reservations": 0, "indexed": 0}
+
+    async def _lookup(_doc_status, _file_source):
+        calls["lookups"] += 1
+        return None
+
+    async def _reserve(*_args, **_kwargs):
+        calls["reservations"] += 1
+        return True
+
+    async def _release(*_args, **_kwargs):
+        return None
+
+    async def _index(*_args, **_kwargs):
+        calls["indexed"] += 1
+
+    monkeypatch.setattr(_dr, "get_existing_doc_by_file_path_candidates", _lookup)
+    monkeypatch.setattr(_dr, "_reserve_enqueue_slot", _reserve)
+    monkeypatch.setattr(_dr, "_release_enqueue_slot", _release)
+    monkeypatch.setattr(_dr, "pipeline_index_texts", _index)
+    monkeypatch.setattr(_dr.global_args, "max_texts_per_request", limit, raising=False)
+
+    app = FastAPI()
+    app.state.background_tasks = set()
+    app.include_router(
+        _dr.create_document_routes(_Rag(), SimpleNamespace(), api_key="test-key")
+    )
+    return TestClient(app), calls
+
+
+def _post(client, count):
+    return client.post(
+        "/documents/texts",
+        headers=_HEADERS,
+        json={
+            "texts": [f"text {i}" for i in range(count)],
+            "file_sources": [f"doc-{i}.md" for i in range(count)],
+        },
+    )
+
+
+def test_an_oversized_batch_is_refused_with_413_before_any_storage_lookup(monkeypatch):
+    client, calls = _make_client(monkeypatch, 2)
+
+    resp = _post(client, 3)
+
+    assert resp.status_code == 413
+    detail = resp.json()["detail"]
+    assert "3" in detail and "2" in detail  # the actual count and the limit
+    # The point of the limit: no per-text round-trip, no reservation, no task.
+    assert calls == {"lookups": 0, "reservations": 0, "indexed": 0}
+
+
+def test_a_batch_exactly_at_the_limit_is_accepted(monkeypatch):
+    """The bound is a maximum, not a strict upper bound."""
+    client, calls = _make_client(monkeypatch, 2)
+
+    resp = _post(client, 2)
+
+    assert resp.status_code == 200
+    assert calls["lookups"] == 2
+
+
+def test_zero_disables_the_check(monkeypatch):
+    client, calls = _make_client(monkeypatch, 0)
+
+    resp = _post(client, 200)
+
+    assert resp.status_code == 200
+    assert calls["lookups"] == 200
+
+
+@pytest.mark.parametrize(
+    "bad", [-1, "50", None, True], ids=["neg", "str", "none", "bool"]
+)
+def test_a_malformed_limit_disables_the_check_instead_of_refusing_everything(
+    monkeypatch, bad
+):
+    client, _calls = _make_client(monkeypatch, bad)
+
+    assert _post(client, 5).status_code == 200
+
+
+def test_the_limit_is_read_per_request_not_captured_at_import(monkeypatch):
+    """An operator raising the ceiling must not need a restart."""
+    client, _calls = _make_client(monkeypatch, 1)
+    assert _post(client, 4).status_code == 413
+
+    monkeypatch.setattr(_dr.global_args, "max_texts_per_request", 10, raising=False)
+    assert _post(client, 4).status_code == 200

--- a/tests/api/test_health_scheduling_view.py
+++ b/tests/api/test_health_scheduling_view.py
@@ -1,0 +1,150 @@
+"""The curated scheduling / capability view on /health (LR2 Phase 6, items 2 & 4).
+
+The raw ``manual_*`` fields stay hidden from ``/documents/pipeline_status`` — they
+are coordination internals — but an operator watching a manual retry needs to see
+which request holds the freeze, for how long, and what the drain is still waiting
+for. And when a doc_status backend lacks a strict capability the whole scheduling
+contract fails closed (admission 503s, stale stubs are kept, conflicts cannot be
+listed), which from the outside looks like a database problem unless health says
+otherwise.
+
+Two invariants get their own tests: the owner TOKEN is never published (it
+authorizes releasing a reservation — a status page must not become a control
+surface), and a bootstrapped-but-idle pipeline reports plain zeros rather than
+nulls that a dashboard would have to special-case.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import time
+
+import pytest
+
+_original_argv = sys.argv[:]
+sys.argv = [sys.argv[0]]
+_server = importlib.import_module("lightrag.api.lightrag_server")
+_utils_pipeline = importlib.import_module("lightrag.utils_pipeline")
+sys.argv = _original_argv
+
+from lightrag.base import DocStatusStorage  # noqa: E402
+from lightrag.kg.json_doc_status_impl import JsonDocStatusStorage  # noqa: E402
+
+pytestmark = pytest.mark.offline
+
+
+def _idle_snapshot() -> dict:
+    return {
+        "busy": False,
+        "pending_enqueues": 0,
+        "manual_phase": "idle",
+        "manual_freeze_requested": False,
+        "manual_resetting": False,
+        "manual_freeze_started_at": None,
+        "manual_owner": None,
+    }
+
+
+def test_idle_pipeline_reports_zeros_not_nulls():
+    view = _server._build_scheduling_status(
+        _idle_snapshot(), {"manual_retries": 0, "manual_retries_capacity": 64}
+    )
+
+    assert view["manual_phase"] == "idle"
+    assert view["manual_freeze_requested"] is False
+    assert view["manual_freeze_seconds"] is None  # nothing is frozen
+    assert view["drain_pending_enqueues"] == 0
+    assert view["drain_waiting_on_workers"] is False
+    assert view["manual_retries_queued"] == 0
+    assert view["manual_retries_capacity"] == 64
+
+
+def test_freeze_is_reported_with_its_holder_and_age():
+    snapshot = _idle_snapshot()
+    snapshot.update(
+        {
+            "manual_phase": "exclusive_reset",
+            "manual_freeze_requested": True,
+            "manual_resetting": True,
+            "manual_freeze_started_at": time.time() - 9,
+            "manual_owner": {"request_id": "req-42", "pid": 4242},
+            "pending_enqueues": 2,
+            "busy": True,
+        }
+    )
+
+    view = _server._build_scheduling_status(snapshot, {})
+
+    assert view["manual_phase"] == "exclusive_reset"
+    assert view["manual_resetting"] is True
+    assert 8.0 <= view["manual_freeze_seconds"] <= 15.0
+    assert view["manual_owner_request_id"] == "req-42"
+    assert view["manual_owner_pid"] == 4242
+    # What the drain is still waiting for.
+    assert view["drain_pending_enqueues"] == 2
+    assert view["drain_waiting_on_workers"] is True
+
+
+def test_owner_token_is_never_published():
+    """The token authorizes releasing another process's reservation."""
+    snapshot = _idle_snapshot()
+    snapshot["manual_owner"] = {
+        "request_id": "req-1",
+        "pid": 7,
+        "owner_token": "capability-do-not-leak",
+        "process_start_id": "abc",
+    }
+
+    view = _server._build_scheduling_status(snapshot, {})
+
+    assert "capability-do-not-leak" not in str(view)
+    assert not any("token" in key for key in view)
+
+
+def test_clock_stepping_backwards_never_reports_a_negative_age():
+    snapshot = _idle_snapshot()
+    snapshot["manual_freeze_started_at"] = time.time() + 60  # future timestamp
+
+    view = _server._build_scheduling_status(snapshot, {})
+
+    assert view["manual_freeze_seconds"] == 0.0
+
+
+def test_a_first_party_backend_reports_every_capability():
+    capabilities = _utils_pipeline.describe_doc_status_capabilities(
+        JsonDocStatusStorage.__new__(JsonDocStatusStorage)
+    )
+
+    assert all(capabilities.values()), capabilities
+
+
+def test_a_backend_on_the_fail_closed_defaults_reports_the_gaps():
+    """A third-party doc_status that only implements the abstract methods keeps
+    the base's fail-closed defaults; health has to say so, otherwise an operator
+    sees only 503s with no explanation."""
+
+    class _MinimalDocStatus(DocStatusStorage):
+        supports_strict_point_reads = False
+
+        async def get_docs_by_statuses_page(self, *args, **kwargs): ...
+        async def get_docs_by_ids(self, *args, **kwargs): ...
+        async def resolve_doc_source_strict(self, *args, **kwargs): ...
+        async def get_full_docs_by_ids(self, *args, **kwargs): ...
+
+    # The probe only reads the class, so the remaining (unrelated) abstract
+    # methods are irrelevant here — clear the ABC guard instead of stubbing 17
+    # data-plane methods that this test does not exercise.
+    _MinimalDocStatus.__abstractmethods__ = frozenset()
+
+    capabilities = _utils_pipeline.describe_doc_status_capabilities(
+        _MinimalDocStatus.__new__(_MinimalDocStatus)
+    )
+
+    assert capabilities["scheduling_pages"] is True
+    assert capabilities["typed_source_resolution"] is True
+    # The three that a deployment can genuinely lack, plus the point-read opt-in.
+    assert capabilities["strict_active_count"] is False
+    assert capabilities["source_conflict_listing"] is False
+    assert capabilities["source_conflict_repair"] is False
+    assert capabilities["strict_point_reads"] is False

--- a/tests/kg/test_bounded_pipeline_history.py
+++ b/tests/kg/test_bounded_pipeline_history.py
@@ -1,0 +1,238 @@
+"""The bounded pipeline status history funnel (LR2 §10.3).
+
+Before this, the only bound on ``pipeline_status["history_messages"]`` was a
+hard-coded 10000→5000 trim sitting *inside the document extraction loop*. Two
+holes followed from that, and both are pinned here as fix-proof:
+
+  - a writer that never reaches that loop was unbounded. Deletions, ``/scan``,
+    manual resets and ``clear_documents`` all log per item and none of them runs
+    the extraction loop, so their history grew for the lifetime of the process;
+  - no message had a size cap, so N messages × unbounded size is still
+    unbounded — one call site appends a whole ``traceback.format_exc()``, and any
+    message interpolating an exception string or a file list can be arbitrarily
+    large. A count alone bounds nothing.
+
+The repo-wide guard test matters as much as the numeric ones: the bound is only
+real if every write goes through the funnel, so a re-introduced raw
+``["history_messages"].append(...)`` is a regression even though nothing fails.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from lightrag.constants import (
+    PIPELINE_HISTORY_MAX_MESSAGES,
+    PIPELINE_HISTORY_MESSAGE_MAX_BYTES,
+)
+from lightrag.kg import shared_storage
+from lightrag.kg.shared_storage import (
+    PipelineStatusLogger,
+    append_pipeline_history,
+    clamp_pipeline_history_message,
+)
+
+pytestmark = pytest.mark.offline
+
+_INTERVAL = shared_storage._HISTORY_TRIM_CHECK_INTERVAL
+
+
+@pytest.fixture(autouse=True)
+def _reset_trim_counter():
+    """The capacity check is amortized through a process-local counter; a test
+    must not inherit another test's position in that cycle."""
+    shared_storage._history_appends_since_trim = 0
+    yield
+    shared_storage._history_appends_since_trim = 0
+
+
+# ---------------------------------------------------------------------------
+# Fix-proof: the ring capacity, enforced for every writer.
+# ---------------------------------------------------------------------------
+
+
+def test_a_writer_that_never_reaches_the_extraction_loop_is_still_bounded():
+    """Shaped like a deletion / clear job: it only logs, it never processes a
+    document, so the old in-loop trim never ran for it."""
+    history = []
+    status = {"history_messages": history}
+
+    total = PIPELINE_HISTORY_MAX_MESSAGES + 3 * _INTERVAL
+    for i in range(total):
+        append_pipeline_history(status, f"deleting document {i}")
+
+    assert len(history) <= PIPELINE_HISTORY_MAX_MESSAGES + _INTERVAL
+    # A ring, not a head-truncation: the newest line survives, the oldest is gone.
+    assert history[-1] == f"deleting document {total - 1}"
+    assert "deleting document 0" not in history
+
+
+def test_a_group_write_advances_the_bound_by_its_own_length():
+    """The counter counts messages, not calls — otherwise a call site passing a
+    group of N would multiply the overshoot by N."""
+    history = []
+    status = {"history_messages": history}
+
+    group = 8
+    for i in range(0, PIPELINE_HISTORY_MAX_MESSAGES + 3 * _INTERVAL, group):
+        append_pipeline_history(status, *[f"msg {i}.{k}" for k in range(group)])
+
+    assert len(history) <= PIPELINE_HISTORY_MAX_MESSAGES + _INTERVAL
+
+
+def test_trimming_never_rebinds_the_shared_list_object():
+    """``history_messages`` is a Manager ListProxy that every worker appends to
+    and that PipelineStatusLogger caches; replacing it would orphan both."""
+    history = []
+    status = {"history_messages": history}
+
+    for i in range(PIPELINE_HISTORY_MAX_MESSAGES + 2 * _INTERVAL):
+        append_pipeline_history(status, f"line {i}")
+
+    assert status["history_messages"] is history
+
+
+# ---------------------------------------------------------------------------
+# Fix-proof: the per-message byte cap.
+# ---------------------------------------------------------------------------
+
+
+def test_a_traceback_sized_message_is_capped():
+    history = []
+    traceback_text = "Traceback (most recent call last):\n" + (
+        '  File "lightrag/pipeline.py", line 1, in _process\n    raise RuntimeError\n'
+        * 400
+    )
+    assert len(traceback_text.encode()) > 5 * PIPELINE_HISTORY_MESSAGE_MAX_BYTES
+
+    append_pipeline_history({"history_messages": history}, traceback_text)
+
+    stored = history[0]
+    assert len(stored.encode("utf-8")) <= PIPELINE_HISTORY_MESSAGE_MAX_BYTES
+    # The head identifies what happened; the marker names the size that was cut
+    # so an operator knows to go to the server log for the rest.
+    assert stored.startswith("Traceback (most recent call last):")
+    assert f"[truncated, {len(traceback_text.encode())} bytes]" in stored
+
+
+def test_a_cjk_message_is_cut_on_a_byte_boundary():
+    """Counting characters would overshoot the byte budget by 3x on CJK, and
+    slicing bytes carelessly would leave a mojibake half-character."""
+    message = "文档解析失败：" + "中" * 5000
+
+    stored = clamp_pipeline_history_message(message)
+
+    assert len(stored.encode("utf-8")) <= PIPELINE_HISTORY_MESSAGE_MAX_BYTES
+    assert stored.startswith("文档解析失败：")
+    assert "�" not in stored  # no split character
+
+
+def test_a_message_at_the_cap_is_stored_verbatim():
+    message = "x" * PIPELINE_HISTORY_MESSAGE_MAX_BYTES
+
+    assert clamp_pipeline_history_message(message) == message
+    assert "truncated" not in clamp_pipeline_history_message("short line")
+
+
+# ---------------------------------------------------------------------------
+# Fix-proof: the funnel is the only writer.
+# ---------------------------------------------------------------------------
+
+
+def test_no_raw_history_append_survives_in_the_package():
+    """A single missed call site is an unbounded leak that no test would notice."""
+    package = Path(shared_storage.__file__).resolve().parents[1]
+    raw_append = re.compile(r'\["history_messages"\]\s*\.\s*append\(')
+
+    offenders = []
+    for path in sorted(package.rglob("*.py")):
+        for lineno, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            if raw_append.search(line) and not line.lstrip().startswith("#"):
+                offenders.append(f"{path.relative_to(package)}:{lineno}")
+
+    assert offenders == [], (
+        "route these through append_pipeline_history (LR2 §10.3): "
+        + ", ".join(offenders)
+    )
+
+
+# ---------------------------------------------------------------------------
+# The never-raise contract (call sites are `except ...: log(...); raise`).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "status",
+    [None, {}, {"history_messages": None}],
+    ids=["none-status", "missing-key", "late-initialized-key"],
+)
+def test_a_missing_history_is_skipped_not_raised(status):
+    append_pipeline_history(status, "message")
+
+
+def test_a_failing_extend_is_swallowed():
+    class _DeadProxy(list):
+        def extend(self, _iterable):
+            raise ConnectionRefusedError("manager is gone")
+
+    append_pipeline_history({"history_messages": _DeadProxy()}, "message")
+
+
+def test_a_failing_len_does_not_fail_the_append():
+    """The capacity check is best effort; losing it must not lose the message."""
+
+    class _UnmeasurableProxy(list):
+        def __len__(self):
+            raise BrokenPipeError("manager is gone")
+
+    history = _UnmeasurableProxy()
+    shared_storage._history_appends_since_trim = _INTERVAL - 1
+
+    append_pipeline_history({"history_messages": history}, "message")
+
+    assert list.__len__(history) == 1
+
+
+def test_a_non_string_message_is_coerced_not_dropped():
+    history = []
+
+    append_pipeline_history({"history_messages": history}, RuntimeError("boom"), 42)
+
+    assert history == ["boom", "42"]
+
+
+# ---------------------------------------------------------------------------
+# PipelineStatusLogger shares the same bounds (it is the hot path).
+# ---------------------------------------------------------------------------
+
+
+def test_the_lock_free_logger_clamps_and_trims_too():
+    history = []
+    status = {"history_messages": history}
+    logger = PipelineStatusLogger(status)
+
+    for i in range(PIPELINE_HISTORY_MAX_MESSAGES + 2 * _INTERVAL):
+        logger.log(f"entity {i}")
+    logger.log("失败" * 5000)
+
+    assert len(history) <= PIPELINE_HISTORY_MAX_MESSAGES + _INTERVAL
+    assert status["history_messages"] is history
+    assert len(history[-1].encode("utf-8")) <= PIPELINE_HISTORY_MESSAGE_MAX_BYTES
+
+
+def test_latest_message_is_clamped_as_well():
+    """A single slot, but it is re-serialized on every status poll, so an
+    unclamped line is shipped to the UI for as long as it stays the latest."""
+    status = {"history_messages": []}
+
+    PipelineStatusLogger(status).log("x" * (4 * PIPELINE_HISTORY_MESSAGE_MAX_BYTES))
+
+    assert (
+        len(status["latest_message"].encode("utf-8"))
+        <= PIPELINE_HISTORY_MESSAGE_MAX_BYTES
+    )

--- a/tests/kg/test_committed_background_task.py
+++ b/tests/kg/test_committed_background_task.py
@@ -12,7 +12,10 @@ import asyncio
 
 import pytest
 
-from lightrag.kg.pipeline_ingress import PipelineIngressMessage
+from lightrag.kg.pipeline_ingress import (
+    AsyncioPipelineIngress,
+    PipelineIngressMessage,
+)
 from lightrag.kg.shared_storage import (
     ManualIntentRefused,
     commit_manual_retry_request,
@@ -255,7 +258,10 @@ async def test_commit_manual_retry_refuses_terminal_id_without_commit(share_data
     refusal = await commit_manual_retry_request(
         _base_status(), asyncio.Lock(), ingress, "req-done", state
     )
-    assert refusal is not None and "already" in refusal
+    assert refusal is not None and "already" in refusal.message
+    # An already-finalized id is a client error, not backpressure: retrying it
+    # can never succeed, so it must NOT be flagged as a capacity refusal (429).
+    assert refusal.capacity_exceeded is False
     assert state["committed"] is False
     assert not ingress.has_work()
 
@@ -270,3 +276,27 @@ async def test_commit_manual_retry_is_idempotent_for_pending_id(share_data):
     )
     assert refusal is None
     assert len(ingress.snapshot_manual_retries()) == 1
+
+
+async def test_commit_manual_retry_reports_capacity_as_retryable():
+    """A full manual channel is the one publish refusal that means "later": it
+    must reach the API as capacity_exceeded so the endpoint answers 429 instead
+    of 503 (LR2 §10.1)."""
+    ingress = AsyncioPipelineIngress(manual_capacity=1)
+    ingress.request_manual_retry(
+        "req-first",
+        PipelineIngressMessage(
+            kind="rescan", retry_failed=True, request_id="req-first"
+        ),
+    )
+
+    state = {"committed": False}
+    refusal = await commit_manual_retry_request(
+        _base_status(), asyncio.Lock(), ingress, "req-second", state
+    )
+
+    assert refusal is not None
+    assert refusal.capacity_exceeded is True
+    assert state["committed"] is False
+    # The queued request is untouched; only the new one was refused.
+    assert [m.request_id for m in ingress.snapshot_manual_retries()] == ["req-first"]

--- a/tests/kg/test_pipeline_ingress.py
+++ b/tests/kg/test_pipeline_ingress.py
@@ -22,6 +22,7 @@ import pytest
 
 import lightrag.kg.shared_storage as shared_storage
 from lightrag.kg.pipeline_ingress import (
+    ManualRetryPublishResult,
     MANUAL_RETRY_ACKED,
     MANUAL_RETRY_CANCELLED_BY_CLEAR,
     MAX_MAILBOX_WAIT_SECONDS,
@@ -136,7 +137,10 @@ def test_closed_loop_migration_preserves_all_state():
             # Control state survives.
             assert ingress.peek_next_manual_retry().request_id == "r1"
             assert ingress.consume_auto_rescan() is True
-            assert ingress.request_manual_retry("r0", _manual("r0")) is False
+            assert (
+                ingress.request_manual_retry("r0", _manual("r0"))
+                is ManualRetryPublishResult.ALREADY_TERMINAL
+            )
             # New-loop primitives are live: publish + await again.
             ingress.put_document(_doc("d2"))
             assert (await ingress.get_document()).doc_id == "d2"
@@ -276,9 +280,15 @@ async def test_manual_retry_fifo_ack_and_terminal_replay_guard(
 ):
     ingress = await get_pipeline_ingress("wsA")
     for rid in ("r1", "r2", "r3"):
-        assert ingress.request_manual_retry(rid, _manual(rid)) is True
+        assert (
+            ingress.request_manual_retry(rid, _manual(rid))
+            is ManualRetryPublishResult.ACCEPTED
+        )
     # Re-requesting a pending id is a no-op and keeps its FIFO position.
-    assert ingress.request_manual_retry("r2", _manual("r2")) is True
+    assert (
+        ingress.request_manual_retry("r2", _manual("r2"))
+        is ManualRetryPublishResult.ACCEPTED
+    )
     assert [m.request_id for m in ingress.snapshot_manual_retries()] == [
         "r1",
         "r2",
@@ -292,7 +302,10 @@ async def test_manual_retry_fifo_ack_and_terminal_replay_guard(
     assert ingress.peek_next_manual_retry().request_id == "r2"
 
     # Terminal id refuses replay.
-    assert ingress.request_manual_retry("r1", _manual("r1")) is False
+    assert (
+        ingress.request_manual_retry("r1", _manual("r1"))
+        is ManualRetryPublishResult.ALREADY_TERMINAL
+    )
     assert ingress.counts()["manual_retries"] == 2
 
 
@@ -305,9 +318,15 @@ async def test_clear_tombstones_pending_manual_ids(single_process_share_data):
     ingress.clear()
     assert not ingress.has_work()
     # The un-ACKed id was tombstoned: a delayed replay must not re-enter.
-    assert ingress.request_manual_retry("r1", _manual("r1")) is False
+    assert (
+        ingress.request_manual_retry("r1", _manual("r1"))
+        is ManualRetryPublishResult.ALREADY_TERMINAL
+    )
     # Fresh ids keep working; the terminal set survived the clear.
-    assert ingress.request_manual_retry("r2", _manual("r2")) is True
+    assert (
+        ingress.request_manual_retry("r2", _manual("r2"))
+        is ManualRetryPublishResult.ACCEPTED
+    )
     assert ingress.counts()["terminal_manual_request_ids"] == 1
 
 
@@ -494,7 +513,10 @@ async def test_multiprocess_cross_process_publish_and_sticky_survival(
 
     # ACK + bounded-window replay guard, across namespace views.
     assert ingress.ack_manual_retry("req-child") is True
-    assert ingress.request_manual_retry("req-child", _manual("req-child")) is False
+    assert (
+        ingress.request_manual_retry("req-child", _manual("req-child"))
+        is ManualRetryPublishResult.ALREADY_TERMINAL
+    )
 
     # Same-workspace resolution from this process reaches the same mailbox.
     again = await get_pipeline_ingress("wsM")
@@ -549,7 +571,10 @@ async def test_multiprocess_wait_isolation_and_cancelled_waiter_steals_nothing(
 
     # clear() tombstones the pending manual id server-side as well.
     ingress.clear()
-    assert ingress.request_manual_retry("r1", _manual("r1")) is False
+    assert (
+        ingress.request_manual_retry("r1", _manual("r1"))
+        is ManualRetryPublishResult.ALREADY_TERMINAL
+    )
     assert not ingress.has_work()
 
 
@@ -567,3 +592,84 @@ async def test_multiprocess_finalize_keeps_server_side_state(
     again = await get_pipeline_ingress("wsM")
     assert again is not ingress  # new local view ...
     assert again.peek_next_manual_retry().request_id == "r-sticky"  # ... same state
+
+
+# --------------------------------------------------------------------------- #
+# manual channel capacity (LR2 §10.1)
+# --------------------------------------------------------------------------- #
+
+
+def test_manual_channel_capacity_refuses_instead_of_dropping():
+    """The sticky channel cannot drop its oldest entry to make room: every
+    un-ACKed request is a human intent with an ACK contract. So the publish is
+    refused with CAPACITY_EXCEEDED — the one refusal that means "later", which is
+    why it is the only one the API maps to 429."""
+    mailbox = PipelineIngressMailbox(manual_capacity=2)
+
+    assert (
+        mailbox.request_manual_retry("r1", _manual("r1"))
+        is ManualRetryPublishResult.ACCEPTED
+    )
+    assert (
+        mailbox.request_manual_retry("r2", _manual("r2"))
+        is ManualRetryPublishResult.ACCEPTED
+    )
+    assert (
+        mailbox.request_manual_retry("r3", _manual("r3"))
+        is ManualRetryPublishResult.CAPACITY_EXCEEDED
+    )
+    # The two accepted requests are untouched and still in FIFO order.
+    assert [m.request_id for m in mailbox.snapshot_manual_retries()] == ["r1", "r2"]
+
+
+def test_republishing_a_pending_id_is_not_charged_against_capacity():
+    """Idempotent re-request adds nothing, so it must not be refused at a full
+    channel — otherwise a retrying client could never confirm its own request."""
+    mailbox = PipelineIngressMailbox(manual_capacity=1)
+    assert (
+        mailbox.request_manual_retry("r1", _manual("r1"))
+        is ManualRetryPublishResult.ACCEPTED
+    )
+
+    assert (
+        mailbox.request_manual_retry("r1", _manual("r1"))
+        is ManualRetryPublishResult.ACCEPTED
+    )
+    assert len(mailbox.snapshot_manual_retries()) == 1
+
+
+def test_acking_frees_manual_capacity():
+    mailbox = PipelineIngressMailbox(manual_capacity=1)
+    mailbox.request_manual_retry("r1", _manual("r1"))
+    assert (
+        mailbox.request_manual_retry("r2", _manual("r2"))
+        is ManualRetryPublishResult.CAPACITY_EXCEEDED
+    )
+
+    assert mailbox.ack_manual_retry("r1") is True
+
+    assert (
+        mailbox.request_manual_retry("r2", _manual("r2"))
+        is ManualRetryPublishResult.ACCEPTED
+    )
+
+
+def test_terminal_check_precedes_the_capacity_check():
+    """A finalized id must report ALREADY_TERMINAL even at a full channel: the
+    caller has to mint a new id, and telling it to "retry later" would be a lie."""
+    mailbox = PipelineIngressMailbox(manual_capacity=1)
+    mailbox.request_manual_retry("done", _manual("done"))
+    assert mailbox.ack_manual_retry("done") is True
+    mailbox.request_manual_retry("filler", _manual("filler"))
+
+    assert (
+        mailbox.request_manual_retry("done", _manual("done"))
+        is ManualRetryPublishResult.ALREADY_TERMINAL
+    )
+
+
+def test_counts_expose_the_manual_capacity():
+    mailbox = PipelineIngressMailbox(manual_capacity=7)
+    counts = mailbox.counts()
+    assert counts["manual_retries"] == 0
+    assert counts["manual_retries_capacity"] == 7

--- a/tests/pipeline/test_pipeline_failed_retry_semantics.py
+++ b/tests/pipeline/test_pipeline_failed_retry_semantics.py
@@ -16,7 +16,10 @@ import pytest
 
 from lightrag import LightRAG
 from lightrag.base import DocStatus
-from lightrag.kg.pipeline_ingress import PipelineIngressMessage
+from lightrag.kg.pipeline_ingress import (
+    ManualRetryPublishResult,
+    PipelineIngressMessage,
+)
 from lightrag.kg.shared_storage import get_pipeline_ingress
 from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
 
@@ -148,7 +151,7 @@ def test_manual_retry_processes_failed_and_acks(tmp_path):
                         kind="rescan", retry_failed=True, request_id=request_id
                     ),
                 )
-                is False
+                is ManualRetryPublishResult.ALREADY_TERMINAL
             )
 
             # A second, DIFFERENT request is a fresh attempt (no doc is

--- a/tests/pipeline/test_pipeline_metrics.py
+++ b/tests/pipeline/test_pipeline_metrics.py
@@ -1,0 +1,123 @@
+"""Bounded scheduling metrics (LR2 Phase 6, item 3).
+
+The registry itself has to be boring and unbreakable: a metric must never fail
+the operation it measures, and the key set must not grow — a registry whose
+cardinality follows traffic is the same unbounded structure the whole plan exists
+to remove.
+
+The instrumented paths are pinned where the measurement is load-bearing: the
+strict active count records even when it FAILS (a count that times out is exactly
+what an operator needs to see when uploads start answering 503), and the manual
+freeze reject counter sits at the single conflict-mapping chokepoint so the number
+cannot drift between the ingress paths that share it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from lightrag import pipeline_metrics
+from lightrag.base import DocStatus
+from lightrag.exceptions import StorageControlPlaneError
+from lightrag.kg.shared_storage import _conflict_for_status_flag
+from lightrag.utils_pipeline import count_active_documents
+
+pytestmark = pytest.mark.offline
+
+
+@pytest.fixture(autouse=True)
+def _clean_metrics():
+    pipeline_metrics.reset()
+    yield
+    pipeline_metrics.reset()
+
+
+def test_counters_and_durations_start_at_zero():
+    snapshot = pipeline_metrics.snapshot()
+
+    assert snapshot["counters"][pipeline_metrics.FREEZE_REJECTS] == 0
+    summary = snapshot["durations"][pipeline_metrics.ACTIVE_COUNT_SECONDS]
+    assert summary == {
+        "count": 0,
+        "total_seconds": 0.0,
+        "max_seconds": 0.0,
+        "last_seconds": 0.0,
+        "mean_seconds": 0.0,
+    }
+
+
+def test_duration_summary_tracks_count_max_and_mean():
+    pipeline_metrics.observe(pipeline_metrics.SCHEDULING_PAGE_SECONDS, 0.1)
+    pipeline_metrics.observe(pipeline_metrics.SCHEDULING_PAGE_SECONDS, 0.3)
+
+    summary = pipeline_metrics.snapshot()["durations"][
+        pipeline_metrics.SCHEDULING_PAGE_SECONDS
+    ]
+    assert summary["count"] == 2
+    assert summary["max_seconds"] == 0.3
+    assert summary["last_seconds"] == 0.3
+    assert summary["mean_seconds"] == 0.2
+
+
+def test_unknown_names_are_dropped_not_inserted():
+    """No key may enter the registry at runtime."""
+    pipeline_metrics.increment("not_a_declared_counter")
+    pipeline_metrics.observe("not_a_declared_duration", 1.0)
+
+    snapshot = pipeline_metrics.snapshot()
+    assert "not_a_declared_counter" not in snapshot["counters"]
+    assert "not_a_declared_duration" not in snapshot["durations"]
+
+
+def test_negative_and_zero_samples_cannot_corrupt_a_summary():
+    pipeline_metrics.increment(pipeline_metrics.FREEZE_REJECTS, 0)
+    pipeline_metrics.increment(pipeline_metrics.FREEZE_REJECTS, -5)
+    pipeline_metrics.observe(pipeline_metrics.MANUAL_DRAIN_SECONDS, -2.0)
+
+    snapshot = pipeline_metrics.snapshot()
+    assert snapshot["counters"][pipeline_metrics.FREEZE_REJECTS] == 0
+    drain = snapshot["durations"][pipeline_metrics.MANUAL_DRAIN_SECONDS]
+    assert drain["count"] == 1 and drain["max_seconds"] == 0.0
+
+
+def test_freeze_rejection_is_counted_at_the_shared_chokepoint():
+    before = pipeline_metrics.snapshot()["counters"][pipeline_metrics.FREEZE_REJECTS]
+
+    _conflict_for_status_flag("manual_freeze_requested")
+    _conflict_for_status_flag("destructive_busy")  # a different fence: not counted
+
+    after = pipeline_metrics.snapshot()["counters"][pipeline_metrics.FREEZE_REJECTS]
+    assert after == before + 1
+
+
+def test_active_count_latency_is_recorded_even_when_the_count_fails():
+    class _CountingDocStatus:
+        def __init__(self, error=None):
+            self.error = error
+
+        async def count_docs_by_statuses(self, statuses, *, strict=True):
+            assert set(statuses) == {
+                DocStatus.PENDING,
+                DocStatus.PARSING,
+                DocStatus.ANALYZING,
+                DocStatus.PROCESSING,
+            }
+            if self.error:
+                raise self.error
+            return 3
+
+    async def _run():
+        assert await count_active_documents(_CountingDocStatus()) == 3
+        with pytest.raises(StorageControlPlaneError):
+            await count_active_documents(
+                _CountingDocStatus(StorageControlPlaneError("index down"))
+            )
+
+    asyncio.run(_run())
+
+    summary = pipeline_metrics.snapshot()["durations"][
+        pipeline_metrics.ACTIVE_COUNT_SECONDS
+    ]
+    assert summary["count"] == 2  # the failure is measured too


### PR DESCRIPTION
Bounds the last unbounded structures and makes the new phases observable.

**Sticky manual-retry channel** (`MAX_UNACKED_MANUAL_RETRIES`, 64). A request survives until an exclusive reset acknowledges it, so an operator hammering `/reprocess_failed` grew the channel without limit. `request_manual_retry` now returns `ACCEPTED | ALREADY_TERMINAL | CAPACITY_EXCEEDED`, and **only capacity maps to 429** — an already-finalized id is a client error, not backpressure. Terminal is checked before capacity, and re-publishing a pending id is `ACCEPTED` and uncharged.

The bool → enum change required inspecting every call site, because `str`-Enum members are **always truthy**: an `if refusal:` would have silently inverted. That inspection found a **real production bug** — `/scan`'s commit ignored the publish result, so a refused publish still started a scan whose exclusive reset had nothing to ACK.

**Curated `/health` view.** The raw `manual_*` fields stay off `/documents/pipeline_status` (coordination internals), but an operator watching a retry needs the phase, who holds the freeze, for how long, and what the drain is still waiting for. The owner **token is never published** — it authorizes releasing another process's reservation, and a status page must not become a control surface. `/health` also reports which strict capabilities the configured backend actually has: each gap fails closed, which from outside looks like a broken database rather than a backend that never could.

**Bounded metrics registry.** Fixed key set — an unknown name is logged and dropped, because a registry whose cardinality follows traffic is the same unbounded structure this whole design removes. O(1) per metric (count/total/max/last, no sample ring, no percentiles), in-process per worker (incrementing a Manager-hosted counter would add an RPC to a path taken thousands of times per sweep), and never fatal. Records page latency, strict-count latency (**including failures** — that is exactly what an operator needs when uploads start answering 503), drain and reset durations, reset pages/docs, freeze rejections and auto-rescan re-arms.

**One funnel for the status history.** The only bound was a hard-coded 10000→5000 trim sitting *inside the document extraction loop*, which left two holes: a writer that never reaches that loop was unbounded (deletes, scans, manual resets and `clear_documents` all log per item), and no message had a size cap — one call site appends a whole `traceback.format_exc()`, so N × unbounded is still unbounded. All 89 raw appends now go through `append_pipeline_history`: 4096-byte clamp (cut on a **byte** boundary, since CJK is 3 bytes/char) and a 5000-message ring. The capacity check is amortized over 128 messages because it is a `len()` — one Manager RPC — on the hottest logging path. A repo-wide test fails if a raw append reappears; the bound is only real if every writer goes through the funnel.

Dropping the eight `if "history_messages" in pipeline_status:` guards also fixed a latent bug: `clear_documents` had `errors.append(...)` inside one of them, so the response's error list depended on whether the history key existed.

**`MAX_TEXTS_PER_REQUEST`** bounds one `/documents/texts` request's fan-out, answering **413** rather than 429 — an oversized batch never fits, however long the client waits — and checked before the per-`file_source` existence lookups, which are one round-trip each.

Also documents the one-time concurrency-protocol upgrade: the freeze flag, the immutable sort key and the Redis derived indexes cannot be honoured by an old writer, and **no marker or version is written**, so old writers must be fully stopped rather than rolling-restarted.

---

**Stack** (merge bottom-up; each PR is green on its own and targets the one below):
`main` ← **#3482** P0 test rig ← **#3483** P1 storage pages ← **#3484** P2 bounded sweep ← **#3485** P2.5 dedup ← **#3486** P3 manual retry ← **#3481** P4 `/scan` ← **#3487** P5 admission ← **#3488** P6 observability ← **#3489** P7 verification

Design: LR2 *pipeline memory bounding*. When merging, retarget the child PR **before** deleting a merged branch — GitHub closes the child otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
